### PR TITLE
Use more subtle indentation guides in the script editor

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -765,6 +765,7 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_indent_using_spaces(EditorSettings::get_singleton()->get("text_editor/indent/type"));
 	text_editor->set_indent_size(EditorSettings::get_singleton()->get("text_editor/indent/size"));
 	text_editor->set_auto_indent(EditorSettings::get_singleton()->get("text_editor/indent/auto_indent"));
+	text_editor->set_draw_indent_guides(EditorSettings::get_singleton()->get("text_editor/indent/draw_indent_guides"));
 	text_editor->set_draw_tabs(EditorSettings::get_singleton()->get("text_editor/indent/draw_tabs"));
 	text_editor->set_show_line_numbers(EditorSettings::get_singleton()->get("text_editor/line_numbers/show_line_numbers"));
 	text_editor->set_line_numbers_zero_padded(EditorSettings::get_singleton()->get("text_editor/line_numbers/line_numbers_zero_padded"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -373,6 +373,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["text_editor/indent/size"] = PropertyInfo(Variant::INT, "text_editor/indent/size", PROPERTY_HINT_RANGE, "1, 64, 1"); // size of 0 crashes.
 	_initial_set("text_editor/indent/auto_indent", true);
 	_initial_set("text_editor/indent/convert_indent_on_save", false);
+	_initial_set("text_editor/indent/draw_indent_guides", true);
 	_initial_set("text_editor/indent/draw_tabs", true);
 
 	_initial_set("text_editor/line_numbers/show_line_numbers", true);
@@ -586,8 +587,8 @@ void EditorSettings::_load_default_text_editor_theme() {
 	_initial_set("text_editor/highlighting/engine_type_color", Color::html("83d3ff"));
 	_initial_set("text_editor/highlighting/comment_color", Color::html("676767"));
 	_initial_set("text_editor/highlighting/string_color", Color::html("ef6ebe"));
-	_initial_set("text_editor/highlighting/background_color", dark_theme ? Color::html("3b000000") : Color::html("#323b4f"));
-	_initial_set("text_editor/highlighting/completion_background_color", Color::html("2C2A32"));
+	_initial_set("text_editor/highlighting/background_color", dark_theme ? Color::html("3b000000") : Color::html("323b4f"));
+	_initial_set("text_editor/highlighting/completion_background_color", Color::html("2c2a32"));
 	_initial_set("text_editor/highlighting/completion_selected_color", Color::html("434244"));
 	_initial_set("text_editor/highlighting/completion_existing_color", Color::html("21dfdfdf"));
 	_initial_set("text_editor/highlighting/completion_scroll_color", Color::html("ffffff"));
@@ -597,13 +598,14 @@ void EditorSettings::_load_default_text_editor_theme() {
 	_initial_set("text_editor/highlighting/safe_line_number_color", Color::html("99aac8aa"));
 	_initial_set("text_editor/highlighting/caret_color", Color::html("aaaaaa"));
 	_initial_set("text_editor/highlighting/caret_background_color", Color::html("000000"));
+	_initial_set("text_editor/highlighting/indent_guide_color", Color::html("50808080"));
 	_initial_set("text_editor/highlighting/text_selected_color", Color::html("000000"));
 	_initial_set("text_editor/highlighting/selection_color", Color::html("6ca9c2"));
 	_initial_set("text_editor/highlighting/brace_mismatch_color", Color(1, 0.2, 0.2));
 	_initial_set("text_editor/highlighting/current_line_color", Color(0.3, 0.5, 0.8, 0.15));
 	_initial_set("text_editor/highlighting/line_length_guideline_color", Color(0.3, 0.5, 0.8, 0.1));
 	_initial_set("text_editor/highlighting/word_highlighted_color", Color(0.8, 0.9, 0.9, 0.15));
-	_initial_set("text_editor/highlighting/number_color", Color::html("EB9532"));
+	_initial_set("text_editor/highlighting/number_color", Color::html("eb9532"));
 	_initial_set("text_editor/highlighting/function_color", Color::html("66a2ce"));
 	_initial_set("text_editor/highlighting/member_variable_color", Color::html("e64e59"));
 	_initial_set("text_editor/highlighting/mark_color", Color(1.0, 0.4, 0.4, 0.4));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1089,6 +1089,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color safe_line_number_color = dim_color * Color(1, 1.2, 1, 1.5);
 	const Color caret_color = mono_color;
 	const Color caret_background_color = mono_color.inverted();
+	const Color indent_guide_color = alpha2;
 	const Color text_selected_color = dark_color_3;
 	const Color selection_color = alpha2;
 	const Color brace_mismatch_color = error_color;
@@ -1124,6 +1125,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		setting->set_initial_value("text_editor/highlighting/safe_line_number_color", safe_line_number_color, true);
 		setting->set_initial_value("text_editor/highlighting/caret_color", caret_color, true);
 		setting->set_initial_value("text_editor/highlighting/caret_background_color", caret_background_color, true);
+		setting->set_initial_value("text_editor/highlighting/indent_guide_color", indent_guide_color, true);
 		setting->set_initial_value("text_editor/highlighting/text_selected_color", text_selected_color, true);
 		setting->set_initial_value("text_editor/highlighting/selection_color", selection_color, true);
 		setting->set_initial_value("text_editor/highlighting/brace_mismatch_color", brace_mismatch_color, true);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -132,6 +132,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	Color safe_line_number_color = EDITOR_GET("text_editor/highlighting/safe_line_number_color");
 	Color caret_color = EDITOR_GET("text_editor/highlighting/caret_color");
 	Color caret_background_color = EDITOR_GET("text_editor/highlighting/caret_background_color");
+	Color indent_guide_color = EDITOR_GET("text_editor/highlighting/indent_guide_color");
 	Color text_selected_color = EDITOR_GET("text_editor/highlighting/text_selected_color");
 	Color selection_color = EDITOR_GET("text_editor/highlighting/selection_color");
 	Color brace_mismatch_color = EDITOR_GET("text_editor/highlighting/brace_mismatch_color");
@@ -164,6 +165,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	text_edit->add_color_override("safe_line_number_color", safe_line_number_color);
 	text_edit->add_color_override("caret_color", caret_color);
 	text_edit->add_color_override("caret_background_color", caret_background_color);
+	text_edit->add_color_override("indent_guide_color", indent_guide_color);
 	text_edit->add_color_override("font_selected_color", text_selected_color);
 	text_edit->add_color_override("selection_color", selection_color);
 	text_edit->add_color_override("brace_mismatch_color", brace_mismatch_color);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -71,6 +71,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	Color line_number_color = EDITOR_GET("text_editor/highlighting/line_number_color");
 	Color caret_color = EDITOR_GET("text_editor/highlighting/caret_color");
 	Color caret_background_color = EDITOR_GET("text_editor/highlighting/caret_background_color");
+	Color indent_guide_color = EDITOR_GET("text_editor/highlighting/indent_guide_color");
 	Color text_selected_color = EDITOR_GET("text_editor/highlighting/text_selected_color");
 	Color selection_color = EDITOR_GET("text_editor/highlighting/selection_color");
 	Color brace_mismatch_color = EDITOR_GET("text_editor/highlighting/brace_mismatch_color");
@@ -102,6 +103,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	get_text_edit()->add_color_override("line_number_color", line_number_color);
 	get_text_edit()->add_color_override("caret_color", caret_color);
 	get_text_edit()->add_color_override("caret_background_color", caret_background_color);
+	get_text_edit()->add_color_override("indent_guide_color", indent_guide_color);
 	get_text_edit()->add_color_override("font_selected_color", text_selected_color);
 	get_text_edit()->add_color_override("selection_color", selection_color);
 	get_text_edit()->add_color_override("brace_mismatch_color", brace_mismatch_color);
@@ -389,6 +391,7 @@ void ShaderEditor::_editor_settings_changed() {
 	shader_editor->get_text_edit()->set_indent_size(EditorSettings::get_singleton()->get("text_editor/indent/size"));
 	shader_editor->get_text_edit()->set_indent_using_spaces(EditorSettings::get_singleton()->get("text_editor/indent/type"));
 	shader_editor->get_text_edit()->set_auto_indent(EditorSettings::get_singleton()->get("text_editor/indent/auto_indent"));
+	shader_editor->get_text_edit()->set_draw_indent_guides(EditorSettings::get_singleton()->get("text_editor/indent/draw_indent_guides"));
 	shader_editor->get_text_edit()->set_draw_tabs(EditorSettings::get_singleton()->get("text_editor/indent/draw_tabs"));
 	shader_editor->get_text_edit()->set_show_line_numbers(EditorSettings::get_singleton()->get("text_editor/line_numbers/show_line_numbers"));
 	shader_editor->get_text_edit()->set_syntax_coloring(EditorSettings::get_singleton()->get("text_editor/highlighting/syntax_highlighting"));

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -81,6 +81,7 @@ void TextEditor::_load_theme_settings() {
 	Color line_number_color = EDITOR_GET("text_editor/highlighting/line_number_color");
 	Color caret_color = EDITOR_GET("text_editor/highlighting/caret_color");
 	Color caret_background_color = EDITOR_GET("text_editor/highlighting/caret_background_color");
+	Color indent_guide_color = EDITOR_GET("text_editor/highlighting/indent_guide_color");
 	Color text_selected_color = EDITOR_GET("text_editor/highlighting/text_selected_color");
 	Color selection_color = EDITOR_GET("text_editor/highlighting/selection_color");
 	Color brace_mismatch_color = EDITOR_GET("text_editor/highlighting/brace_mismatch_color");
@@ -112,6 +113,7 @@ void TextEditor::_load_theme_settings() {
 	text_edit->add_color_override("line_number_color", line_number_color);
 	text_edit->add_color_override("caret_color", caret_color);
 	text_edit->add_color_override("caret_background_color", caret_background_color);
+	text_edit->add_color_override("indent_guide_color", indent_guide_color);
 	text_edit->add_color_override("font_selected_color", text_selected_color);
 	text_edit->add_color_override("selection_color", selection_color);
 	text_edit->add_color_override("brace_mismatch_color", brace_mismatch_color);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -39,6 +39,7 @@
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_scale.h"
+#include "editor_settings.h"
 #endif
 
 #define TAB_PIXELS
@@ -923,6 +924,26 @@ void TextEdit::_notification(int p_what) {
 						}
 					}
 
+					int indent_level = get_indent_level(i);
+					if (draw_indent_guides && indent_level > 0) {
+#ifdef TOOLS_ENABLED
+						int indent_size = EditorSettings::get_singleton()->get("text_editor/indent/size");
+						float line_width = Math::round(EDSCALE);
+#else
+						int indent_size = 4;
+						float line_width = 1.0;
+#endif
+						int guides = 1 + (indent_level - 1) / indent_size;
+
+						for (int guide = 0; guide < guides; guide++) {
+							draw_line(
+									Point2(guide * indent_size * cache.font->get_char_size(' ').width + char_margin, ofs_y),
+									Point2(guide * indent_size * cache.font->get_char_size(' ').width + char_margin, ofs_y + get_row_height()),
+									cache.indent_guide_color,
+									line_width);
+						}
+					}
+
 					if (line_wrap_index == 0) {
 						// only do these if we are on the first wrapped part of a line
 
@@ -1179,9 +1200,14 @@ void TextEdit::_notification(int p_what) {
 							if (underlined) {
 								draw_rect(Rect2(char_ofs + char_margin + ofs_x, yofs + ascent + 2, w, 1), in_selection && override_selected_font_color ? cache.font_selected_color : color);
 							}
-						} else if (draw_tabs && str[j] == '\t') {
+						} else if (draw_tabs && (j > get_indent_level(i) || !draw_indent_guides) && str[j] == '\t') {
+							// If indent guides are enabled, only draw trailing or alignment tabs
+							// Otherwise, draw all tabs (including those used for indentation)
 							int yofs = (get_row_height() - cache.tab_icon->get_height()) / 2;
-							cache.tab_icon->draw(ci, Point2(char_ofs + char_margin + ofs_x, ofs_y + yofs), in_selection && override_selected_font_color ? cache.font_selected_color : color);
+							cache.tab_icon->draw(
+									ci,
+									Point2(char_ofs + char_margin + ofs_x, ofs_y + yofs),
+									in_selection && override_selected_font_color ? cache.font_selected_color : color);
 						}
 
 						char_ofs += char_w;
@@ -4324,6 +4350,7 @@ void TextEdit::_update_caches() {
 	cache.font = get_font("font");
 	cache.caret_color = get_color("caret_color");
 	cache.caret_background_color = get_color("caret_background_color");
+	cache.indent_guide_color = get_color("indent_guide_color");
 	cache.line_number_color = get_color("line_number_color");
 	cache.safe_line_number_color = get_color("safe_line_number_color");
 	cache.font_color = get_color("font_color");
@@ -5428,6 +5455,16 @@ void TextEdit::set_indent_size(const int p_size) {
 int TextEdit::get_indent_size() {
 
 	return indent_size;
+}
+
+void TextEdit::set_draw_indent_guides(bool p_draw) {
+
+	draw_indent_guides = p_draw;
+}
+
+bool TextEdit::is_drawing_indent_guides() const {
+
+	return draw_indent_guides;
 }
 
 void TextEdit::set_draw_tabs(bool p_draw) {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -167,6 +167,7 @@ private:
 		Color completion_font_color;
 		Color caret_color;
 		Color caret_background_color;
+		Color indent_guide_color;
 		Color line_number_color;
 		Color safe_line_number_color;
 		Color font_color;
@@ -277,6 +278,7 @@ private:
 	int wrap_right_offset;
 
 	bool setting_row;
+	bool draw_indent_guides;
 	bool draw_tabs;
 	bool override_selected_font_color;
 	bool cursor_changed_dirty;
@@ -591,6 +593,8 @@ public:
 	bool is_indent_using_spaces() const;
 	void set_indent_size(const int p_size);
 	int get_indent_size();
+	void set_draw_indent_guides(bool p_draw);
+	bool is_drawing_indent_guides() const;
 	void set_draw_tabs(bool p_draw);
 	bool is_drawing_tabs() const;
 	void set_override_selected_font_color(bool p_override_selected_font_color);


### PR DESCRIPTION
This uses simple lines instead of an icon to represent indentation, resulting in a less cluttered look especially with heavily-indented code.

The line thickness is scaled with the editor scale, so it becomes wider on hiDPI displays. The color of indent guides can also be changed in the Editor Settings as part of the syntax theme.

## Preview

**Default editor theme, adaptive syntax theme:**

![indent_guide_default_adaptive](https://user-images.githubusercontent.com/180032/43681044-0af49d06-9849-11e8-889c-05565cf7d8b7.png)

**Default editor theme, default syntax theme:**

![indent_guide_default_default](https://user-images.githubusercontent.com/180032/43681045-0b170ab2-9849-11e8-8f33-a3934ce21847.png)

**Light editor theme, adaptive syntax theme:**

![indent_guide_light_adaptive](https://user-images.githubusercontent.com/180032/43681046-0b534c20-9849-11e8-8e09-abd6dde28d67.png)
