### PR TITLE
fixed godotphysics sat dispatch table

### DIFF
--- a/servers/physics/collision_solver_sat.cpp
+++ b/servers/physics/collision_solver_sat.cpp
@@ -560,6 +560,12 @@ static void _collision_sphere_capsule(const ShapeSW *p_a, const Transform &p_tra
 }
 
 template <bool withMargin>
+static void _collision_sphere_cylinder(const ShapeSW *p_a, const Transform &p_transform_a, const ShapeSW *p_b, const Transform &p_transform_b, _CollectorCallback *p_collector, real_t p_margin_a, real_t p_margin_b) {
+
+	return;
+}
+
+template <bool withMargin>
 static void _collision_sphere_convex_polygon(const ShapeSW *p_a, const Transform &p_transform_a, const ShapeSW *p_b, const Transform &p_transform_b, _CollectorCallback *p_collector, real_t p_margin_a, real_t p_margin_b) {
 
 	const SphereShapeSW *sphere_A = static_cast<const SphereShapeSW *>(p_a);
@@ -851,6 +857,12 @@ static void _collision_box_capsule(const ShapeSW *p_a, const Transform &p_transf
 }
 
 template <bool withMargin>
+static void _collision_box_cylinder(const ShapeSW *p_a, const Transform &p_transform_a, const ShapeSW *p_b, const Transform &p_transform_b, _CollectorCallback *p_collector, real_t p_margin_a, real_t p_margin_b) {
+
+	return;
+}
+
+template <bool withMargin>
 static void _collision_box_convex_polygon(const ShapeSW *p_a, const Transform &p_transform_a, const ShapeSW *p_b, const Transform &p_transform_b, _CollectorCallback *p_collector, real_t p_margin_a, real_t p_margin_b) {
 
 	const BoxShapeSW *box_A = static_cast<const BoxShapeSW *>(p_a);
@@ -1127,6 +1139,12 @@ static void _collision_capsule_capsule(const ShapeSW *p_a, const Transform &p_tr
 }
 
 template <bool withMargin>
+static void _collision_capsule_cylinder(const ShapeSW *p_a, const Transform &p_transform_a, const ShapeSW *p_b, const Transform &p_transform_b, _CollectorCallback *p_collector, real_t p_margin_a, real_t p_margin_b) {
+
+	return;
+}
+
+template <bool withMargin>
 static void _collision_capsule_convex_polygon(const ShapeSW *p_a, const Transform &p_transform_a, const ShapeSW *p_b, const Transform &p_transform_b, _CollectorCallback *p_collector, real_t p_margin_a, real_t p_margin_b) {
 
 	const CapsuleShapeSW *capsule_A = static_cast<const CapsuleShapeSW *>(p_a);
@@ -1244,6 +1262,24 @@ static void _collision_capsule_face(const ShapeSW *p_a, const Transform &p_trans
 	}
 
 	separator.generate_contacts();
+}
+
+template <bool withMargin>
+static void _collision_cylinder_cylinder(const ShapeSW *p_a, const Transform &p_transform_a, const ShapeSW *p_b, const Transform &p_transform_b, _CollectorCallback *p_collector, real_t p_margin_a, real_t p_margin_b) {
+
+	return;
+}
+
+template <bool withMargin>
+static void _collision_cylinder_convex_polygon(const ShapeSW *p_a, const Transform &p_transform_a, const ShapeSW *p_b, const Transform &p_transform_b, _CollectorCallback *p_collector, real_t p_margin_a, real_t p_margin_b) {
+
+	return;
+}
+
+template <bool withMargin>
+static void _collision_cylinder_face(const ShapeSW *p_a, const Transform &p_transform_a, const ShapeSW *p_b, const Transform &p_transform_b, _CollectorCallback *p_collector, real_t p_margin_a, real_t p_margin_b) {
+
+	return;
 }
 
 template <bool withMargin>
@@ -1475,23 +1511,33 @@ bool sat_calculate_penetration(const ShapeSW *p_shape_A, const Transform &p_tran
 	ERR_FAIL_COND_V(type_B == PhysicsServer::SHAPE_RAY, false);
 	ERR_FAIL_COND_V(p_shape_B->is_concave(), false);
 
-	static const CollisionFunc collision_table[5][5] = {
+	static const CollisionFunc collision_table[6][6] = {
 		{ _collision_sphere_sphere<false>,
 				_collision_sphere_box<false>,
 				_collision_sphere_capsule<false>,
+				_collision_sphere_cylinder<false>,
 				_collision_sphere_convex_polygon<false>,
 				_collision_sphere_face<false> },
 		{ 0,
 				_collision_box_box<false>,
 				_collision_box_capsule<false>,
+				_collision_box_cylinder<false>,
 				_collision_box_convex_polygon<false>,
 				_collision_box_face<false> },
 		{ 0,
 				0,
 				_collision_capsule_capsule<false>,
+				_collision_capsule_cylinder<false>,
 				_collision_capsule_convex_polygon<false>,
 				_collision_capsule_face<false> },
 		{ 0,
+				0,
+				0,
+				_collision_cylinder_cylinder<false>,
+				_collision_cylinder_convex_polygon<false>,
+				_collision_cylinder_face<false> },
+		{ 0,
+				0,
 				0,
 				0,
 				_collision_convex_polygon_convex_polygon<false>,
@@ -1500,31 +1546,43 @@ bool sat_calculate_penetration(const ShapeSW *p_shape_A, const Transform &p_tran
 				0,
 				0,
 				0,
+				0,
 				0 },
 	};
 
-	static const CollisionFunc collision_table_margin[5][5] = {
+	static const CollisionFunc collision_table_margin[6][6] = {
 		{ _collision_sphere_sphere<true>,
 				_collision_sphere_box<true>,
 				_collision_sphere_capsule<true>,
+				_collision_sphere_cylinder<true>,
 				_collision_sphere_convex_polygon<true>,
 				_collision_sphere_face<true> },
 		{ 0,
 				_collision_box_box<true>,
 				_collision_box_capsule<true>,
+				_collision_box_cylinder<true>,
 				_collision_box_convex_polygon<true>,
 				_collision_box_face<true> },
 		{ 0,
 				0,
 				_collision_capsule_capsule<true>,
+				_collision_capsule_cylinder<true>,
 				_collision_capsule_convex_polygon<true>,
 				_collision_capsule_face<true> },
 		{ 0,
 				0,
 				0,
+				_collision_cylinder_cylinder<true>,
+				_collision_cylinder_convex_polygon<true>,
+				_collision_cylinder_face<true> },
+		{ 0,
+				0,
+				0,
+				0,
 				_collision_convex_polygon_convex_polygon<true>,
 				_collision_convex_polygon_face<true> },
 		{ 0,
+				0,
 				0,
 				0,
 				0,


### PR DESCRIPTION
Should fix #20699 

Tested in an example project with static/rigid bodies with box, sphere, capsule, convex, and trimesh colliders (that all collides) plus a static cylinder (that does not collide, as intented)

To keep the table readable I added all the stubs, but they could be replaced with one _collide_ignore function or 0, (unless it triggers static analysis, dunno)

Maybe I should also add two ERR_FAIL_COND_V(type == PhysicsServer::SHAPE_CYLINDER, false); at the top

To be clear, assigning a CylinderShape to a CollisionShape in GodotPhysics still prints out a warning plus a couple of failed asserts, and said cylinder colliders shows no effects, since unsupported, maybe this should be documented
