### PR TITLE
Added possibility to reparent a group of tracks of animation player to another node

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -64,7 +64,8 @@ class AnimationPlayerEditor : public VBoxContainer {
 		TOOL_REMOVE_ANIM,
 		TOOL_COPY_ANIM,
 		TOOL_PASTE_ANIM,
-		TOOL_EDIT_RESOURCE
+		TOOL_EDIT_RESOURCE,
+		TOOL_REPARENT_TRACK
 	};
 
 	enum {
@@ -129,6 +130,10 @@ class AnimationPlayerEditor : public VBoxContainer {
 	ConfirmationDialog *error_dialog;
 	bool renaming;
 
+	ConfirmationDialog *reparent_track_dialog;
+	OptionButton *reparent_track_nodepath_ob;
+	LineEdit *reparent_track_le;
+
 	bool updating;
 	bool updating_blends;
 
@@ -188,6 +193,8 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _animation_edit();
 	void _animation_duplicate();
 	void _animation_resource_edit();
+	void _animation_reparent_track();
+	void _animation_reparent_track_confirmed();
 	void _scale_changed(const String &p_scale);
 	void _dialog_action(String p_file);
 	void _seek_frame_changed(const String &p_frame);


### PR DESCRIPTION
With this PR is possible to change the current node path of an animation track to another.

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/8342599/43684785-f08d501c-98a6-11e8-9009-87fe58da6c37.gif)

(Sorry if I've used a broken animation to show it)