### PR TITLE
Do not call _update_actions when only changing deadzone

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -213,10 +213,8 @@ void ProjectSettingsEditor::_action_edited() {
 
 		undo_redo->create_action(TTR("Change Action deadzone"));
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, new_action);
-		undo_redo->add_do_method(this, "_update_actions");
 		undo_redo->add_do_method(this, "_settings_changed");
 		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_action);
-		undo_redo->add_undo_method(this, "_update_actions");
 		undo_redo->add_undo_method(this, "_settings_changed");
 		undo_redo->commit_action();
 	}


### PR DESCRIPTION
Because changing the deadzone with a click happens during
_propagate_mouse_event the tree is always blocked leading to a crash. We
don't actually need to update actions here anyway.

This fixes #20184