### PR TITLE
Fixes disconnect error for new physics material in rigid and static body

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -235,7 +235,9 @@ real_t StaticBody::get_bounce() const {
 
 void StaticBody::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics")) {
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		}
 	}
 
 	physics_material_override = p_physics_material_override;
@@ -665,7 +667,9 @@ real_t RigidBody::get_bounce() const {
 
 void RigidBody::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics")) {
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		}
 	}
 
 	physics_material_override = p_physics_material_override;


### PR DESCRIPTION
Partial fix for #20434.
The disconnect signal error seems to have been caused by attempting to disconnect before having connected the signal (happened only at instantiation).
Still does not fix the Warnings

@AndreaCatania, As you are currently assigned to this issue (and know more about the physics material part) you should probably check it to see if it is solved in a correct way. It may be more prudent to connect the signal on instantiation and leave these checks out.