### PR TITLE
Fix out of buffer read when copying from a non-null-terminated string

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -148,7 +148,7 @@ void String::copy_from(const char *p_cstr) {
 	}
 }
 
-void String::copy_from(const CharType *p_cstr, int p_clip_to) {
+void String::copy_from(const CharType *p_cstr, const int p_clip_to) {
 
 	if (!p_cstr) {
 
@@ -158,11 +158,8 @@ void String::copy_from(const CharType *p_cstr, int p_clip_to) {
 
 	int len = 0;
 	const CharType *ptr = p_cstr;
-	while (*(ptr++) != 0)
+	while ((p_clip_to < 0 || len < p_clip_to) && *(ptr++) != 0)
 		len++;
-
-	if (p_clip_to >= 0 && len > p_clip_to)
-		len = p_clip_to;
 
 	if (len == 0) {
 
@@ -177,7 +174,7 @@ void String::copy_from(const CharType *p_cstr, int p_clip_to) {
 // p_char != NULL
 // p_length > 0
 // p_length <= p_char strlen
-void String::copy_from_unchecked(const CharType *p_char, int p_length) {
+void String::copy_from_unchecked(const CharType *p_char, const int p_length) {
 	resize(p_length + 1);
 	set(p_length, 0);
 

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -84,9 +84,9 @@ class String {
 	CowData<CharType> _cowdata;
 
 	void copy_from(const char *p_cstr);
-	void copy_from(const CharType *p_cstr, int p_clip_to = -1);
+	void copy_from(const CharType *p_cstr, const int p_clip_to = -1);
 	void copy_from(const CharType &p_char);
-	void copy_from_unchecked(const CharType *p_char, int p_length);
+	void copy_from_unchecked(const CharType *p_char, const int p_length);
 	bool _base_is_subsequence_of(const String &p_string, bool case_insensitive) const;
 
 public:


### PR DESCRIPTION
A non-null terminated string is passed to the copy_from method on this stack:
````
godot.windows.tools.32.exe!String::copy_from(const wchar_t * p_cstr, const int p_clip_to)
godot.windows.tools.32.exe!String::String(const wchar_t * p_str, int p_clip_to_len)
godot.windows.tools.32.exe!StringBuilder::as_string()
godot.windows.tools.32.exe!ShaderCompilerGLES2::_dump_node_code(ShaderLanguage::Node * p_node, int p_level, ShaderCompilerGLES2::GeneratedCode & r_gen_code, ShaderCompilerGLES2::IdentifierActions & p_actions, const ShaderCompilerGLES2::DefaultIdentifierActions & p_default_actions, bool p_assigning)
godot.windows.tools.32.exe!ShaderCompilerGLES2::_dump_node_code(ShaderLanguage::Node * p_node, int p_level, ShaderCompilerGLES2::GeneratedCode & r_gen_code, ShaderCompilerGLES2::IdentifierActions & p_actions, const ShaderCompilerGLES2::DefaultIdentifierActions & p_default_actions, bool p_assigning)
godot.windows.tools.32.exe!ShaderCompilerGLES2::_dump_node_code(ShaderLanguage::Node * p_node, int p_level, ShaderCompilerGLES2::GeneratedCode & r_gen_code, ShaderCompilerGLES2::IdentifierActions & p_actions, const ShaderCompilerGLES2::DefaultIdentifierActions & p_default_actions, bool p_assigning)
godot.windows.tools.32.exe!ShaderCompilerGLES2::_dump_node_code(ShaderLanguage::Node * p_node, int p_level, ShaderCompilerGLES2::GeneratedCode & r_gen_code, ShaderCompilerGLES2::IdentifierActions & p_actions, const ShaderCompilerGLES2::DefaultIdentifierActions & p_default_actions, bool p_assigning)
godot.windows.tools.32.exe!ShaderCompilerGLES2::_dump_node_code(ShaderLanguage::Node * p_node, int p_level, ShaderCompilerGLES2::GeneratedCode & r_gen_code, ShaderCompilerGLES2::IdentifierActions & p_actions, const ShaderCompilerGLES2::DefaultIdentifierActions & p_default_actions, bool p_assigning)
godot.windows.tools.32.exe!ShaderCompilerGLES2::compile(VisualServer::ShaderMode p_mode, const String & p_code, ShaderCompilerGLES2::IdentifierActions * p_actions, const String & p_path, ShaderCompilerGLES2::GeneratedCode & r_gen_code)
godot.windows.tools.32.exe!RasterizerStorageGLES2::_update_shader(RasterizerStorageGLES2::Shader * p_shader)
godot.windows.tools.32.exe!RasterizerStorageGLES2::update_dirty_shaders()
godot.windows.tools.32.exe!RasterizerStorageGLES2::update_dirty_resources()
godot.windows.tools.32.exe!RasterizerGLES2::begin_frame(double frame_step)
````