### PR TITLE
Fix missing texture image check

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -567,7 +567,7 @@ Ref<Image> RasterizerStorageGLES2::texture_get_data(RID p_texture, int p_layer) 
 	ERR_FAIL_COND_V(!texture->active, Ref<Image>());
 	ERR_FAIL_COND_V(texture->data_size == 0 && !texture->render_target, Ref<Image>());
 
-	if (!texture->images[p_layer].is_null()) {
+	if (texture->images.size() > p_layer && !texture->images[p_layer].is_null()) {
 		return texture->images[p_layer];
 	}
 #ifdef GLES_OVER_GL


### PR DESCRIPTION
Missing size() check causes crash at:

````
	godot.windows.tools.32.exe!CowData<Ref<Image> >::get(int p_index) Line 146	C++
 	godot.windows.tools.32.exe!Vector<Ref<Image> >::operator[](int p_index) Line 88	C++
 	godot.windows.tools.32.exe!RasterizerStorageGLES2::texture_get_data(RID p_texture, int p_layer) Line 570	C++
 	godot.windows.tools.32.exe!VisualServerRaster::texture_get_data(RID arg1, int arg2) Line 154	C++
 	godot.windows.tools.32.exe!VisualServerWrapMT::texture_get_data(RID p1, int p2) Line 88	C++
 	godot.windows.tools.32.exe!ViewportTexture::get_data() Line 128	C++
 	godot.windows.tools.32.exe!EditorNode::_save_scene_with_preview(String p_file, int p_idx) Line 935	C++
````