### PR TITLE
Fix bucket fill behaviour when multiple tiles selected

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -532,12 +532,6 @@ PoolVector<Vector2> TileMapEditor::_bucket_fill(const Point2i &p_start, bool era
 		return PoolVector<Vector2>();
 	}
 
-	for (int i = ids.size() - 1; i >= 0; i--) {
-		if (ids[i] == prev_id) {
-			return PoolVector<Vector2>();
-		}
-	}
-
 	Rect2i r = node->get_used_rect();
 
 	int area = r.get_area();


### PR DESCRIPTION
The code I removed was preventing users from using bucket fill starting on a tile that has the same id as one of the tiles selected in the side panel, like in this situation:
![godot windows tools 32_2018-08-07_12-37-20](https://user-images.githubusercontent.com/1990835/43771216-c1187296-9a3e-11e8-90a0-45b498e4fafe.png)