### PR TITLE
Changes the default skybox to avoid the blue shade

### DIFF
--- a/scene/resources/sky_box.cpp
+++ b/scene/resources/sky_box.cpp
@@ -532,14 +532,14 @@ ProceduralSky::ProceduralSky() {
 	texture = VS::get_singleton()->texture_create();
 
 	update_queued = false;
-	sky_top_color = Color::hex(0x0c74f9ff);
-	sky_horizon_color = Color::hex(0x8ed2e8ff);
-	sky_curve = 0.25;
+	sky_top_color = Color::hex(0xa5d6f1ff);
+	sky_horizon_color = Color::hex(0xd6eafaff);
+	sky_curve = 0.09;
 	sky_energy = 1;
 
-	ground_bottom_color = Color::hex(0x1a2530ff);
-	ground_horizon_color = Color::hex(0x7bc9f3ff);
-	ground_curve = 0.01;
+	ground_bottom_color = Color::hex(0x282f36ff);
+	ground_horizon_color = Color::hex(0x6c655fff);
+	ground_curve = 0.02;
 	ground_energy = 1;
 
 	sun_color = Color(1, 1, 1);


### PR DESCRIPTION
Old:
![old](https://user-images.githubusercontent.com/6093119/43778620-770b9bd4-9a56-11e8-9012-8e8b758b1ae5.png)
New:
![new](https://user-images.githubusercontent.com/6093119/43778627-7ba7170e-9a56-11e8-9adf-30f6efa193e1.png)

The blue shade is still a little bit present but is a lot more subtle.

Closes #18226