### PR TITLE
unhacking some GLES2 code

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -349,7 +349,7 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 				state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_UV_ATTRIBUTE, false);
 				if (state.canvas_shader.bind()) {
 					_set_uniforms();
-					state.canvas_shader.use_material((void *)p_material, 2);
+					state.canvas_shader.use_material((void *)p_material);
 				}
 
 				_bind_canvas_texture(RID(), RID());
@@ -393,7 +393,7 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 				state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_UV_ATTRIBUTE, false);
 				if (state.canvas_shader.bind()) {
 					_set_uniforms();
-					state.canvas_shader.use_material((void *)p_material, 2);
+					state.canvas_shader.use_material((void *)p_material);
 				}
 
 				RasterizerStorageGLES2::Texture *tex = _bind_canvas_texture(r->texture, r->normal_map);
@@ -476,7 +476,7 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 				state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_UV_ATTRIBUTE, true);
 				if (state.canvas_shader.bind()) {
 					_set_uniforms();
-					state.canvas_shader.use_material((void *)p_material, 2);
+					state.canvas_shader.use_material((void *)p_material);
 				}
 
 				glDisableVertexAttribArray(VS::ARRAY_COLOR);
@@ -642,7 +642,7 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				if (state.canvas_shader.bind()) {
 					_set_uniforms();
-					state.canvas_shader.use_material((void *)p_material, 2);
+					state.canvas_shader.use_material((void *)p_material);
 				}
 
 				static const int num_points = 32;
@@ -673,7 +673,7 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				if (state.canvas_shader.bind()) {
 					_set_uniforms();
-					state.canvas_shader.use_material((void *)p_material, 2);
+					state.canvas_shader.use_material((void *)p_material);
 				}
 
 				RasterizerStorageGLES2::Texture *texture = _bind_canvas_texture(polygon->texture, polygon->normal_map);
@@ -694,7 +694,7 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				if (state.canvas_shader.bind()) {
 					_set_uniforms();
-					state.canvas_shader.use_material((void *)p_material, 2);
+					state.canvas_shader.use_material((void *)p_material);
 				}
 
 				_bind_canvas_texture(RID(), RID());
@@ -727,7 +727,7 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				if (state.canvas_shader.bind()) {
 					_set_uniforms();
-					state.canvas_shader.use_material((void *)p_material, 2);
+					state.canvas_shader.use_material((void *)p_material);
 				}
 
 				ERR_CONTINUE(primitive->points.size() < 1);
@@ -926,7 +926,7 @@ void RasterizerCanvasGLES2::canvas_render_items(Item *p_item_list, int p_z, cons
 				state.canvas_shader.set_custom_shader(0);
 				state.canvas_shader.bind();
 			}
-			state.canvas_shader.use_material((void *)material_ptr, 2);
+			state.canvas_shader.use_material((void *)material_ptr);
 
 			shader_cache = shader_ptr;
 

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -545,11 +545,23 @@ public:
 	void _add_geometry_with_material(RasterizerStorageGLES2::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES2::GeometryOwner *p_owner, RasterizerStorageGLES2::Material *p_material, bool p_depth_pass, bool p_shadow_pass);
 
 	void _fill_render_list(InstanceBase **p_cull_result, int p_cull_count, bool p_depth_pass, bool p_shadow_pass);
-	void _render_render_list(RenderList::Element **p_elements, int p_element_count, const RID *p_light_cull_result, int p_light_cull_count, const Transform &p_view_transform, const CameraMatrix &p_projection, RID p_shadow_atlas, Environment *p_env, GLuint p_base_env, float p_shadow_bias, float p_shadow_normal_bias, bool p_reverse_cull, bool p_alpha_pass, bool p_shadow, bool p_directional_add, bool p_directional_shadows);
+	void _render_render_list(RenderList::Element **p_elements, int p_element_count,
+			const RID *p_directional_lights, int p_directional_light_count,
+			const Transform &p_view_transform,
+			const CameraMatrix &p_projection,
+			RID p_shadow_atlas,
+			Environment *p_env,
+			GLuint p_base_env,
+			float p_shadow_bias,
+			float p_shadow_normal_bias,
+			bool p_reverse_cull,
+			bool p_alpha_pass,
+			bool p_shadow,
+			bool p_directional_add);
 
 	void _draw_sky(RasterizerStorageGLES2::Sky *p_sky, const CameraMatrix &p_projection, const Transform &p_transform, bool p_vflip, float p_custom_fov, float p_energy);
 
-	void _setup_material(RasterizerStorageGLES2::Material *p_material, bool p_use_radiance_map, bool p_reverse_cull, bool p_shadow_atlas = false, bool p_skeleton_tex = false, Size2i p_skeleton_tex_size = Size2i(0, 0));
+	void _setup_material(RasterizerStorageGLES2::Material *p_material, bool p_reverse_cull, Size2i p_skeleton_tex_size = Size2i(0, 0));
 	void _setup_geometry(RenderList::Element *p_element, RasterizerStorageGLES2::Skeleton *p_skeleton);
 	void _render_geometry(RenderList::Element *p_element);
 

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -527,8 +527,13 @@ ShaderGLES2::Version *ShaderGLES2::get_current_version() {
 
 	for (int i = 0; i < texunit_pair_count; i++) {
 		GLint loc = glGetUniformLocation(v.id, texunit_pairs[i].name);
-		if (loc >= 0)
-			glUniform1i(loc, texunit_pairs[i].index);
+		if (loc >= 0) {
+			if (texunit_pairs[i].index < 0) {
+				glUniform1i(loc, max_image_units + texunit_pairs[i].index);
+			} else {
+				glUniform1i(loc, texunit_pairs[i].index);
+			}
+		}
 	}
 
 	if (cc) {
@@ -643,6 +648,8 @@ void ShaderGLES2::setup(
 			}
 		}
 	}
+
+	glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_image_units);
 }
 
 void ShaderGLES2::finish() {
@@ -717,7 +724,7 @@ void ShaderGLES2::free_custom_shader(uint32_t p_code_id) {
 	custom_code_map.erase(p_code_id);
 }
 
-void ShaderGLES2::use_material(void *p_material, int p_num_predef_textures) {
+void ShaderGLES2::use_material(void *p_material) {
 	RasterizerStorageGLES2::Material *material = (RasterizerStorageGLES2::Material *)p_material;
 
 	if (!material) {
@@ -906,20 +913,58 @@ void ShaderGLES2::use_material(void *p_material, int p_num_predef_textures) {
 				case ShaderLanguage::TYPE_MAT2: {
 					Transform2D val = V->get();
 
-					// TODO
+					if (value.second.size() < 4) {
+						value.second.resize(4);
+					}
+
+					value.second.write[0].real = val.elements[0][0];
+					value.second.write[1].real = val.elements[0][1];
+					value.second.write[2].real = val.elements[1][0];
+					value.second.write[3].real = val.elements[1][1];
 
 				} break;
 
 				case ShaderLanguage::TYPE_MAT3: {
 					Basis val = V->get();
 
-					// TODO
+					if (value.second.size() < 9) {
+						value.second.resize(9);
+					}
+
+					value.second.write[0].real = val.elements[0][0];
+					value.second.write[1].real = val.elements[0][1];
+					value.second.write[2].real = val.elements[0][2];
+					value.second.write[3].real = val.elements[1][0];
+					value.second.write[4].real = val.elements[1][1];
+					value.second.write[5].real = val.elements[1][2];
+					value.second.write[6].real = val.elements[2][0];
+					value.second.write[7].real = val.elements[2][1];
+					value.second.write[8].real = val.elements[2][2];
 				} break;
 
 				case ShaderLanguage::TYPE_MAT4: {
 					Transform val = V->get();
 
-					// TODO
+					if (value.second.size() < 16) {
+						value.second.resize(16);
+					}
+
+					value.second.write[0].real = val.basis.elements[0][0];
+					value.second.write[0].real = val.basis.elements[0][1];
+					value.second.write[0].real = val.basis.elements[0][2];
+					value.second.write[0].real = 0;
+					value.second.write[0].real = val.basis.elements[1][0];
+					value.second.write[0].real = val.basis.elements[1][1];
+					value.second.write[0].real = val.basis.elements[1][2];
+					value.second.write[0].real = 0;
+					value.second.write[0].real = val.basis.elements[2][0];
+					value.second.write[0].real = val.basis.elements[2][1];
+					value.second.write[0].real = val.basis.elements[2][2];
+					value.second.write[0].real = 0;
+					value.second.write[0].real = val.origin[0];
+					value.second.write[0].real = val.origin[1];
+					value.second.write[0].real = val.origin[2];
+					value.second.write[0].real = 1;
 				} break;
 
 				case ShaderLanguage::TYPE_SAMPLER2D: {
@@ -1034,7 +1079,7 @@ void ShaderGLES2::use_material(void *p_material, int p_num_predef_textures) {
 		Pair<ShaderLanguage::DataType, Vector<ShaderLanguage::ConstantNode::Value> > value;
 		value.first = ShaderLanguage::TYPE_INT;
 		value.second.resize(1);
-		value.second.write[0].sint = p_num_predef_textures + i;
+		value.second.write[0].sint = i;
 
 		// GLint location = get_uniform_location(textures[i].first);
 

--- a/drivers/gles2/shader_gles2.h
+++ b/drivers/gles2/shader_gles2.h
@@ -465,7 +465,7 @@ public:
 
 	// this void* is actually a RasterizerStorageGLES2::Material, but C++ doesn't
 	// like forward declared nested classes.
-	void use_material(void *p_material, int p_num_predef_textures);
+	void use_material(void *p_material);
 
 	uint32_t get_version() const { return new_conditional_version.version; }
 

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -48,7 +48,7 @@ attribute highp vec4 bone_transform_row_2; // attrib:11
 attribute vec4 bone_ids; // attrib:6
 attribute highp vec4 bone_weights; // attrib:7
 
-uniform highp sampler2D bone_transforms; // texunit:4
+uniform highp sampler2D bone_transforms; // texunit:-1
 uniform ivec2 skeleton_texture_size;
 
 #endif
@@ -294,17 +294,17 @@ uniform highp float time;
 uniform vec2 screen_pixel_size;
 #endif
 
-uniform highp sampler2D depth_buffer; //texunit:1
+uniform highp sampler2D depth_buffer; //texunit:-5
 
 #if defined(SCREEN_TEXTURE_USED)
-uniform highp sampler2D screen_texture; //texunit:2
+uniform highp sampler2D screen_texture; //texunit:-6
 #endif
 
 #ifdef USE_RADIANCE_MAP
 
 #define RADIANCE_MAX_LOD 6.0
 
-uniform samplerCube radiance_map; // texunit:0
+uniform samplerCube radiance_map; // texunit:-2
 
 uniform mat4 radiance_inverse_xform;
 
@@ -345,7 +345,7 @@ uniform float light_spot_angle;
 
 
 // shadows
-uniform highp sampler2D light_shadow_atlas; //texunit:3
+uniform highp sampler2D light_shadow_atlas; //texunit:-4
 uniform float light_has_shadow;
 
 uniform mat4 light_shadow_matrix;
@@ -353,7 +353,7 @@ uniform vec4 light_clamp;
 
 // directional shadow
 
-uniform highp sampler2D light_directional_shadow; // texunit:3
+uniform highp sampler2D light_directional_shadow; // texunit:-4
 uniform vec4 light_split_offsets;
 
 uniform mat4 light_shadow_matrix1;
@@ -439,11 +439,10 @@ void light_compute(vec3 N,
 	{
 		// calculate specular reflection
 
-		 vec3 R = normalize(-reflect(L,N));
-		 float cRdotV = max(dot(R, V), 0.0);
-		 float blob_intensity = pow(cRdotV, (1.0 - roughness) * 256.0);
-		 specular_light += light_color * attenuation * blob_intensity * specular_blob_intensity;
-
+		vec3 R = normalize(-reflect(L,N));
+		float cRdotV = max(dot(R, V), 0.0);
+		float blob_intensity = pow(cRdotV, (1.0 - roughness) * 256.0);
+		specular_light += light_color * attenuation * blob_intensity * specular_blob_intensity;
 
 	}
 }
@@ -808,7 +807,6 @@ FRAGMENT_SHADER_CODE
 		              anisotropy,
 		              diffuse_light,
 		              specular_light);
-
 	}
 
 	gl_FragColor = vec4(ambient_light + diffuse_light + specular_light, alpha);


### PR DESCRIPTION
This commit unhacks some parts of the 3D rendering.

Most notably:

 - possibility to use negative texture units
   (no longer weird manual index allocation for user samplers)

 - refactoring of light code, now sorts in a different way,
   should yield better performance

 - fixes a crash while saving (because of "Illegal instruction" execution)
   when using a decent compiler (clang, it's clang. Thanks GCC for not telling me about UB).

(fixes #20792 )