### PR TITLE
Fix a typo in a TTR() call

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1227,7 +1227,7 @@ void EditorNode::_dialog_action(String p_file) {
 			Error err = ResourceSaver::save(p_file, tileset);
 			if (err) {
 
-				show_accept(TRR("Error saving TileSet!"), TTR("OK"));
+				show_accept(TTR("Error saving TileSet!"), TTR("OK"));
 				return;
 			}
 		} break;


### PR DESCRIPTION
This fixes a build regression introduced by https://github.com/godotengine/godot/commit/51da08856aa25491397ad1274c1af139cb1bc68b.