### PR TITLE
Scale the project manager window size with the editor scale

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1757,6 +1757,8 @@ ProjectManager::ProjectManager() {
 				editor_set_scale(custom_display_scale);
 			} break;
 		}
+
+		OS::get_singleton()->set_window_size(OS::get_singleton()->get_window_size() * MAX(1, EDSCALE));
 	}
 
 	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
@@ -1825,7 +1827,7 @@ ProjectManager::ProjectManager() {
 	project_filter = memnew(ProjectListFilter);
 	search_box->add_child(project_filter);
 	project_filter->connect("filter_changed", this, "_load_recent_projects");
-	project_filter->set_custom_minimum_size(Size2(250, 10));
+	project_filter->set_custom_minimum_size(Size2(280, 10) * EDSCALE);
 	search_tree_vb->add_child(search_box);
 
 	PanelContainer *pc = memnew(PanelContainer);


### PR DESCRIPTION
This also makes the project search field slightly larger.

Note that the window will be resized once the engine initialization is done; therefore, the window will be smaller while the splash screen is being displayed. Please let me know if this can be improved :slightly_smiling_face:

Editor scales below 100% will not affect the project manager window size.

This closes #8543.