### PR TITLE
Add some curly braces to make dictionary printing less ambiguous

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1460,7 +1460,7 @@ Variant::operator String() const {
 
 			const Dictionary &d = *reinterpret_cast<const Dictionary *>(_data._mem);
 			//const String *K=NULL;
-			String str;
+			String str("{");
 			List<Variant> keys;
 			d.get_key_list(&keys);
 
@@ -1479,8 +1479,9 @@ Variant::operator String() const {
 			for (int i = 0; i < pairs.size(); i++) {
 				if (i > 0)
 					str += ", ";
-				str += "(" + pairs[i].key + ":" + pairs[i].value + ")";
+				str += pairs[i].key + ":" + pairs[i].value;
 			}
+			str += "}";
 
 			return str;
 		} break;


### PR DESCRIPTION
Made in response to #20638 

In summary, with this change the following code...
```
print([{"a": 1, "b": 2, "c": 3}])
print([{"a": 1, "b": 2}, {"c": 3}])
print([{"a": 1}, {"b": 2}, {"c": 3}])
```

...instead of...
```
[(a:1), (b:2), (c:3)]
[(a:1), (b:2), (c:3)]
[(a:1), (b:2), (c:3)]
```

...will output:
```
[{a:1, b:2, c:3}]
[{a:1, b:2}, {c:3}]
[{a:1}, {b:2}, {c:3}]
```

The change adds curly braces that denote beginning and end of dictionary, so there's less ambiguity. Also, I removed round brackets, due to them being mixed with curlies and looking pretty bad in the result. They weren't necessary anyways, as everything is prettily separated by commas.