### PR TITLE
Fix border artifacts at the edge of deep parallax.

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -694,6 +694,8 @@ void SpatialMaterial::_update_shader() {
 		}
 
 		code += "\t\tbase_uv=ofs;\n";
+		code += "\t\tif(base_uv.x > 1.0 || base_uv.y > 1.0 || base_uv.x < 0.0 || base_uv.y < 0.0)\n";
+		code += "\t\t\tdiscard;\n";
 		if (features[FEATURE_DETAIL] && detail_uv == DETAIL_UV_2) {
 			code += "\t\tbase_uv2-=ofs;\n";
 		}


### PR DESCRIPTION
Fix #20854.

![captura de tela de 2018-08-09 19-27-12](https://user-images.githubusercontent.com/1387165/43929349-fa5d8dca-9c0a-11e8-8fb0-6308d8b33353.png)
before:
![peek 09-08-2018 20-30](https://user-images.githubusercontent.com/1387165/43931157-8afc5d04-9c13-11e8-8312-7dda686f03e9.gif)

after:
![peek 09-08-2018 20-35](https://user-images.githubusercontent.com/1387165/43931302-2e8d2138-9c14-11e8-8fdc-efb6295ad524.gif)
