### PR TITLE
Unique id for mac

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -216,6 +216,7 @@ public:
 	virtual Point2 get_screen_position(int p_screen = -1) const;
 	virtual Size2 get_screen_size(int p_screen = -1) const;
 	virtual int get_screen_dpi(int p_screen = -1) const;
+	virtual String get_unique_id() const;
 
 	virtual Point2 get_window_position() const;
 	virtual void set_window_position(const Point2 &p_position);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1991,6 +1991,16 @@ int OS_OSX::get_screen_dpi(int p_screen) const {
 	return 72;
 }
 
+String OS_OSX::get_unique_id() const {
+  char buf[256];
+  io_registry_entry_t ioRegistryRoot = IORegistryEntryFromPath(kIOMasterPortDefault,"IOService:/");
+  CFStringRef uuidCf = (CFStringRef) IORegistryEntryCreateCFProperty(ioRegistryRoot, CFSTR(kIOPlatformUUIDKey), kCFAllocatorDefault, 0);
+  IOObjectRelease(ioRegistryRoot);
+  CFStringGetCString(uuidCf, buf, sizeof(buf), kCFStringEncodingMacRoman);
+  CFRelease(uuidCf);
+  return String::utf8(buf);
+}
+
 Size2 OS_OSX::get_screen_size(int p_screen) const {
 	if (p_screen == -1) {
 		p_screen = get_current_screen();


### PR DESCRIPTION
Potentially a good idea? Currently get_unique_id() returns an empty string for osx.