### PR TITLE
Reset caret blink when Ctrl+moving the cursor

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2195,9 +2195,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			k->set_shift(false);
 		}
 
-		if (!k->get_command()) {
-			_reset_caret_blink_timer();
-		}
+		_reset_caret_blink_timer();
 
 		// save here for insert mode, just in case it is cleared in the following section
 		bool had_selection = selection.active;


### PR DESCRIPTION
There was a hardcoded exception to never reset caret blinking if Ctrl
(`command`) was pressed. This broke on Ctrl+arrows,
Ctrl+Home/End/PgUp/PgDn, Ctrl+C, Ctrl+V, Ctrl+Backspace and Ctrl+Delete.

Resetting blink only for those Ctrl operations that actually touch the
cursor somehow would clutter the code a lot, so I removed the check
entirely. That means we now also reset blinking on unrelated operations
like Ctrl+O, but that seems pretty harmless. I actually like the
additional bit of feedback even in that case (most of these will
immediately defocus the editor anyway, so you never see it).

Fixes #18100