### PR TITLE
Add Spatial/CanvasItem export property "inherits_transform"

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -1075,6 +1075,9 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("make_canvas_position_local", "screen_point"), &CanvasItem::make_canvas_position_local);
 	ClassDB::bind_method(D_METHOD("make_input_local", "event"), &CanvasItem::make_input_local);
 
+	ClassDB::bind_method(D_METHOD("set_inherits_transform", "enable"), &CanvasItem::set_inherits_transform);
+	ClassDB::bind_method(D_METHOD("get_inherits_transform"), &CanvasItem::get_inherits_transform);
+
 	BIND_VMETHOD(MethodInfo("_draw"));
 
 	ADD_GROUP("Visibility", "");
@@ -1088,8 +1091,9 @@ void CanvasItem::_bind_methods() {
 	ADD_GROUP("Material", "");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,CanvasItemMaterial"), "set_material", "get_material");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "use_parent_material"), "set_use_parent_material", "get_use_parent_material");
+	ADD_GROUP("Context", "");
+	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL, "inherits_transform"), "set_inherits_transform", "get_inherits_transform");
 	//exporting these things doesn't really make much sense i think
-	// ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toplevel", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_as_toplevel", "is_set_as_toplevel");
 	// ADD_PROPERTY(PropertyInfo(Variant::BOOL,"transform/notify"),"set_transform_notify","is_transform_notify_enabled");
 
 	ADD_SIGNAL(MethodInfo("draw"));

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -205,6 +205,9 @@ protected:
 
 	void item_rect_changed(bool p_size_changed = true);
 
+	void set_inherits_transform(bool p_inherits_transform) { set_as_toplevel(!p_inherits_transform); }
+	bool get_inherits_transform() const { return !is_set_as_toplevel(); }
+
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -787,6 +787,9 @@ void Spatial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Spatial::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Spatial::to_global);
 
+	ClassDB::bind_method(D_METHOD("set_inherits_transform", "enable"), &Spatial::set_inherits_transform);
+	ClassDB::bind_method(D_METHOD("get_inherits_transform"), &Spatial::get_inherits_transform);
+
 	BIND_CONSTANT(NOTIFICATION_TRANSFORM_CHANGED);
 	BIND_CONSTANT(NOTIFICATION_ENTER_WORLD);
 	BIND_CONSTANT(NOTIFICATION_EXIT_WORLD);
@@ -804,6 +807,8 @@ void Spatial::_bind_methods() {
 	ADD_GROUP("Visibility", "");
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "gizmo", PROPERTY_HINT_RESOURCE_TYPE, "SpatialGizmo", 0), "set_gizmo", "get_gizmo");
+	ADD_GROUP("Context", "");
+	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL, "inherits_transform"), "set_inherits_transform", "get_inherits_transform");
 
 	ADD_SIGNAL(MethodInfo("visibility_changed"));
 }

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -114,6 +114,9 @@ protected:
 
 	_FORCE_INLINE_ void _update_local_transform() const;
 
+	void set_inherits_transform(bool p_inherits_transform) { set_as_toplevel(!p_inherits_transform); }
+	bool get_inherits_transform() const { return !is_set_as_toplevel(); }
+
 	void _notification(int p_what);
 	static void _bind_methods();
 


### PR DESCRIPTION
The toplevel stuff is the flag that determines whether the Spatial should orient itself independently of its parent (so it doesn't "inherit" the parent's transform). I was thinking it should go in the Transform or Matrix area, but those seem to be dedicated exclusively to the vector values. It'd be much more convenient if we could just set this boolean from the Inspector rather than using a script or hacking it with a Node in between the two Spatials.

If anyone has suggestions for a different GROUP name or a different place to put this, let me know.
Let me know what you think.