### PR TITLE
Add option to convert from height map to depth map

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -198,6 +198,7 @@ void ResourceImporterTexture::get_import_options(List<ImportOption> *r_options, 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/fix_alpha_border"), p_preset != PRESET_3D ? true : false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/premult_alpha"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/HDR_as_SRGB"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/invert_color"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "stream"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "size_limit", PROPERTY_HINT_RANGE, "0,4096,1"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "detect_3d"), p_preset == PRESET_DETECT));
@@ -354,6 +355,7 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 	int srgb = p_options["flags/srgb"];
 	bool fix_alpha_border = p_options["process/fix_alpha_border"];
 	bool premult_alpha = p_options["process/premult_alpha"];
+	bool invert_color = p_options["process/invert_color"];
 	bool stream = p_options["stream"];
 	int size_limit = p_options["size_limit"];
 	bool force_rgbe = int(p_options["compress/hdr_mode"]) == 1;
@@ -407,6 +409,19 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 
 	if (premult_alpha) {
 		image->premultiply_alpha();
+	}
+
+	if (invert_color) {
+		int height = image->get_height();
+		int width = image->get_width();
+
+		image->lock();
+		for (int i = 0; i < height; i++) {
+			for (int j = 0; j < width; j++) {
+				image->set_pixel(i, j, image->get_pixel(i, j).inverted());
+			}
+		}
+		image->unlock();
 	}
 
 	bool detect_3d = p_options["detect_3d"];


### PR DESCRIPTION
This is very inconvenient because external tools that generate height maps create an image like this:
![fixed_texture_bricks_depth](https://user-images.githubusercontent.com/1387165/43975384-c2482a68-9cb3-11e8-96d8-30b70b1df2b0.jpg)
[click here to see others references from google](https://www.google.com/search?client=firefox-b-ab&biw=1920&bih=951&tbm=isch&sa=1&ei=O85tW4CYAsihwAS5ypXQCA&q=brick+height+map&oq=brick+height+map&gs_l=img.3..0i7i30k1.18001.19514.0.19754.6.6.0.0.0.0.297.456.0j1j1.2.0....0...1c..64.img..5.1.297....0.MkYtC5e475c#imgrc=_)
but godot only accept like this:
![texture_bricks_depth](https://user-images.githubusercontent.com/1387165/43975386-c376a0b8-9cb3-11e8-9401-bc9243ba4f01.jpg)
*Image above is from godot material test (https://github.com/godotengine/godot-demo-projects/blob/master/3d/material_testers/texture_bricks_depth.jpg)*

Then I always need to invert the colors with image editor and this is tedious.

Update:
Added "Invert Color".
![captura de tela de 2018-08-17 13-25-37](https://user-images.githubusercontent.com/1387165/44277665-cc4cb600-a221-11e8-8443-b67f5c936715.png)

