### PR TITLE
Show in File Manager Clarification

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -558,7 +558,9 @@ void EditorFileDialog::_item_list_item_rmb_selected(int p_item, const Vector2 &p
 	}
 	if (single_item_selected) {
 		item_menu->add_separator();
-		item_menu->add_icon_item(get_icon("Filesystem", "EditorIcons"), TTR("Show In File Manager"), ITEM_MENU_SHOW_IN_EXPLORER);
+		Dictionary item_meta = item_list->get_item_metadata(p_item);
+		String item_text = item_meta["dir"] ? TTR("Open In File Manager") : TTR("Show In File Manager");
+		item_menu->add_icon_item(get_icon("Filesystem", "EditorIcons"), item_text, ITEM_MENU_SHOW_IN_EXPLORER);
 	}
 
 	if (item_menu->get_item_count() > 0) {
@@ -582,7 +584,7 @@ void EditorFileDialog::_item_list_rmb_clicked(const Vector2 &p_pos) {
 	}
 	item_menu->add_icon_item(get_icon("Reload", "EditorIcons"), TTR("Refresh"), ITEM_MENU_REFRESH, KEY_F5);
 	item_menu->add_separator();
-	item_menu->add_icon_item(get_icon("Filesystem", "EditorIcons"), TTR("Show In File Manager"), ITEM_MENU_SHOW_IN_EXPLORER);
+	item_menu->add_icon_item(get_icon("Filesystem", "EditorIcons"), TTR("Open In File Manager"), ITEM_MENU_SHOW_IN_EXPLORER);
 
 	item_menu->set_position(item_list->get_global_position() + p_pos);
 	item_menu->popup();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1448,7 +1448,7 @@ void FileSystemDock::_dir_rmb_pressed(const Vector2 &p_pos) {
 		}
 		folder_options->add_separator();
 		folder_options->add_item(TTR("New Folder..."), FOLDER_NEW_FOLDER);
-		folder_options->add_item(TTR("Show In File Manager"), FOLDER_SHOW_IN_EXPLORER);
+		folder_options->add_item(TTR("Open In File Manager"), FOLDER_SHOW_IN_EXPLORER);
 	}
 	folder_options->set_position(tree->get_global_position() + p_pos);
 	folder_options->popup();
@@ -1757,7 +1757,10 @@ void FileSystemDock::_files_list_rmb_select(int p_item, const Vector2 &p_pos) {
 	file_options->add_item(TTR("New Folder..."), FILE_NEW_FOLDER);
 	file_options->add_item(TTR("New Script..."), FILE_NEW_SCRIPT);
 	file_options->add_item(TTR("New Resource..."), FILE_NEW_RESOURCE);
-	file_options->add_item(TTR("Show In File Manager"), FILE_SHOW_IN_EXPLORER);
+
+	String fpath = files->get_item_metadata(p_item);
+	String item_text = fpath.ends_with("/") ? TTR("Open In File Manager") : TTR("Show In File Manager");
+	file_options->add_item(item_text, FILE_SHOW_IN_EXPLORER);
 
 	file_options->set_position(files->get_global_position() + p_pos);
 	file_options->popup();


### PR DESCRIPTION
Changed the context menu 'Show in File Manager' action description to better reflect actual behavior. Fixes #20897 

PS. I'm not sure if I need to do something to add a new translatable string or if it's picked up automatically by the translation system.