### PR TITLE
Always disable V-Sync in the editor to improve UI responsiveness

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -867,9 +867,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/allow_per_pixel_transparency", false);
 
-	video_mode.use_vsync = GLOBAL_DEF("display/window/vsync/use_vsync", true);
-	OS::get_singleton()->_use_vsync = video_mode.use_vsync;
-
 	video_mode.layered = GLOBAL_DEF("display/window/per_pixel_transparency", false);
 	video_mode.layered_splash = GLOBAL_DEF("display/window/per_pixel_transparency_splash", false);
 
@@ -878,9 +875,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (editor || project_manager) {
 		// The editor and project manager always detect and use hiDPI if needed
+		// VSync is always disabled to increase UI responsiveness,
+		// although the graphics driver may override that
 		OS::get_singleton()->_allow_hidpi = true;
 		OS::get_singleton()->_allow_layered = false;
+		video_mode.use_vsync = false;
+	} else {
+		video_mode.use_vsync = GLOBAL_DEF("display/window/vsync/use_vsync", true);
 	}
+
+	OS::get_singleton()->_use_vsync = video_mode.use_vsync;
 
 	Engine::get_singleton()->_pixel_snap = GLOBAL_DEF("rendering/quality/2d/use_pixel_snap", false);
 	OS::get_singleton()->_keep_screen_on = GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);


### PR DESCRIPTION
The project's V-Sync value is no longer used to control whether the editor should use V-Sync.

Note that the graphics driver may still force V-Sync; in this case, this change will have no effect (it will be enabled as it was before).

If editing a project with V-Sync enabled (which is the default) and your graphics driver doesn't force V-Sync, this should increase responsiveness since there is no longer an inherent 1-frame delay caused by V-Sync.

If the editor has to be continuously redrawn for any reason, the rendering will be capped at 100 FPS if the editor is set to **Update Changes**, which is the default option.