### PR TITLE
HTML5: use console.warn instead of Module.printErr

### DIFF
--- a/platform/javascript/http_request.js
+++ b/platform/javascript/http_request.js
@@ -82,7 +82,7 @@ var GodotHTTPRequest = {
 
 	godot_xhr_send_string: function(xhrId, strPtr) {
 		if (!strPtr) {
-			Module.printErr("Failed to send string per XHR: null pointer");
+			console.warn("Failed to send string per XHR: null pointer");
 			return;
 		}
 		GodotHTTPRequest.requests[xhrId].send(UTF8ToString(strPtr));
@@ -90,11 +90,11 @@ var GodotHTTPRequest = {
 
 	godot_xhr_send_data: function(xhrId, ptr, len) {
 		if (!ptr) {
-			Module.printErr("Failed to send data per XHR: null pointer");
+			console.warn("Failed to send data per XHR: null pointer");
 			return;
 		}
 		if (len < 0) {
-			Module.printErr("Failed to send data per XHR: buffer length less than 0");
+			console.warn("Failed to send data per XHR: buffer length less than 0");
 			return;
 		}
 		GodotHTTPRequest.requests[xhrId].send(HEAPU8.subarray(ptr, ptr + len));

--- a/platform/javascript/javascript_eval.cpp
+++ b/platform/javascript/javascript_eval.cpp
@@ -69,7 +69,7 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 				eval_ret = eval(UTF8ToString(CODE));
 			}
 		} catch (e) {
-			Module.printErr(e);
+			console.warn(e);
 			eval_ret = null;
 		}
 
@@ -97,7 +97,7 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 					if (array_ptr!==0) {
 						_free(array_ptr)
 					}
-					Module.printErr(e);
+					console.warn(e);
 					// fall through
 				}
 				break;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -788,7 +788,7 @@ bool OS_JavaScript::main_loop_iterate() {
 			/* clang-format off */
 			EM_ASM(
 				FS.syncfs(function(err) {
-					if (err) { Module.printErr('Failed to save IDB file system: ' + err.message); }
+					if (err) { console.warn('Failed to save IDB file system: ' + err.message); }
 				});
 			);
 			/* clang-format on */


### PR DESCRIPTION
Emscripten no longer exports `Module.printErr()` by default, and instead `err()` should be used in code seen by the optimizer (and `printErr` exported if accessed from outside the module); however, as Godot only runs on the Web (and not in node.js or elsewhere), using `console.warn()` directly is good enough, and will work in all versions of emscripten.

I verified building `scons platform=javascript tools=no target=release` succeeds with this change - are there any tests I should run?