### PR TITLE
Improvements on the gizmo disabling menu and icon selection bugfix

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -560,10 +560,10 @@ private:
 		MENU_VIEW_USE_4_VIEWPORTS,
 		MENU_VIEW_ORIGIN,
 		MENU_VIEW_GRID,
+		MENU_VIEW_GIZMOS_3D_ICONS,
 		MENU_VIEW_CAMERA_SETTINGS,
 		MENU_LOCK_SELECTED,
 		MENU_UNLOCK_SELECTED,
-		MENU_VISIBILITY_SKELETON,
 		MENU_SNAP_TO_FLOOR
 	};
 
@@ -571,7 +571,7 @@ private:
 	Button *tool_option_button[TOOL_OPT_MAX];
 
 	MenuButton *transform_menu;
-	MenuButton *gizmos_menu;
+	PopupMenu *gizmos_menu;
 	MenuButton *view_menu;
 
 	ToolButton *lock_button;
@@ -675,8 +675,6 @@ public:
 	Ref<ArrayMesh> get_scale_gizmo(int idx) const { return scale_gizmo[idx]; }
 	Ref<ArrayMesh> get_scale_plane_gizmo(int idx) const { return scale_plane_gizmo[idx]; }
 
-	int get_skeleton_visibility_state() const;
-
 	void update_transform_gizmo();
 	void update_all_gizmos();
 	void snap_selected_nodes_to_floor();
@@ -751,7 +749,13 @@ class EditorSpatialGizmoPlugin : public Resource {
 
 	GDCLASS(EditorSpatialGizmoPlugin, Resource);
 
-	bool hidden;
+public:
+	static const int ON_TOP = 0;
+	static const int VISIBLE = 1;
+	static const int HIDDEN = 2;
+
+private:
+	int current_state;
 	List<EditorSpatialGizmo *> current_gizmos;
 	HashMap<String, Vector<Ref<SpatialMaterial> > > materials;
 
@@ -779,7 +783,7 @@ public:
 	virtual bool is_gizmo_handle_highlighted(const EditorSpatialGizmo *p_gizmo, int idx) const { return false; }
 
 	Ref<EditorSpatialGizmo> get_gizmo(Spatial *p_spatial);
-	void set_hidden(bool p_hidden);
+	void set_state(int p_state);
 	void unregister_gizmo(EditorSpatialGizmo *p_gizmo);
 
 	EditorSpatialGizmoPlugin();

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -48,7 +48,7 @@
 // It's so ugly it will eat them alive
 
 // The previous comment is kept only for historical reasons.
-// No children will be harmed by the visioning of this file... hopefully.
+// No children will be harmed by the viewing of this file... hopefully.
 
 #define HANDLE_HALF_SIZE 9.5
 
@@ -531,6 +531,8 @@ bool EditorSpatialGizmo::intersect_ray(Camera *p_camera, const Point2 &p_point, 
 		rect.set_position(center - rect.get_size() / 2.0);
 
 		if (rect.has_point(p_point)) {
+			r_pos = t.origin;
+			r_normal = -p_camera->project_ray_normal(p_point);
 			return true;
 		}
 
@@ -1472,34 +1474,6 @@ void SkeletonSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 	p_gizmo->clear();
 
 	Ref<Material> material = get_material("skeleton_material", p_gizmo);
-	SpatialMaterial *sm = Object::cast_to<SpatialMaterial>(material.ptr());
-
-	{ // Reset
-		Color c(sm->get_albedo());
-		c.a = 1;
-		sm->set_albedo(c);
-	}
-	if (sm) {
-		switch (SpatialEditor::get_singleton()->get_skeleton_visibility_state()) {
-			case 0: {
-				// Hidden
-				Color c(sm->get_albedo());
-				c.a = 0;
-				sm->set_albedo(c);
-				sm->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, true);
-			} break;
-			case 1:
-				// Visible
-				sm->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, false);
-				sm->set_render_priority(SpatialMaterial::RENDER_PRIORITY_MIN);
-				sm->set_flag(SpatialMaterial::FLAG_DISABLE_DEPTH_TEST, false);
-				break;
-			case 2:
-				// x-ray
-				sm->set_on_top_of_alpha();
-				break;
-		}
-	}
 
 	Ref<SurfaceTool> surface_tool(memnew(SurfaceTool));
 


### PR DESCRIPTION
Gizmos can now be hidden, visible (as they were before) or "on top". Being "on top" makes the gizmo render on top of everything when the node is selected and it's set as the default state.

Changing the render mode of gizmos can be done through the view menu.

I also fixed a small bug caused by not setting the hit point in intersect_ray for gizmo icons.