### PR TITLE
Fix ResourceLoader::exists() false negative and readd deprecated has()

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -112,6 +112,13 @@ PoolStringArray _ResourceLoader::get_dependencies(const String &p_path) {
 	return ret;
 };
 
+#ifndef DISABLE_DEPRECATED
+bool _ResourceLoader::has(const String &p_path) {
+	WARN_PRINTS("ResourceLoader.has() is deprecated, please replace it with the equivalent has_cached() or the new exists().");
+	return has_cached(p_path);
+}
+#endif // DISABLE_DEPRECATED
+
 bool _ResourceLoader::has_cached(const String &p_path) {
 
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
@@ -131,6 +138,9 @@ void _ResourceLoader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_dependencies", "path"), &_ResourceLoader::get_dependencies);
 	ClassDB::bind_method(D_METHOD("has_cached", "path"), &_ResourceLoader::has_cached);
 	ClassDB::bind_method(D_METHOD("exists", "path", "type_hint"), &_ResourceLoader::exists, DEFVAL(""));
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("has", "path"), &_ResourceLoader::has);
+#endif // DISABLE_DEPRECATED
 }
 
 _ResourceLoader::_ResourceLoader() {

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -55,6 +55,9 @@ public:
 	PoolVector<String> get_recognized_extensions_for_type(const String &p_type);
 	void set_abort_on_missing_resources(bool p_abort);
 	PoolStringArray get_dependencies(const String &p_path);
+#ifndef DISABLE_DEPRECATED
+	bool has(const String &p_path);
+#endif // DISABLE_DEPRECATED
 	bool has_cached(const String &p_path);
 	bool exists(const String &p_path, const String &p_type_hint = "");
 

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -126,6 +126,7 @@ Ref<ResourceInteractiveLoader> ResourceFormatLoader::load_interactive(const Stri
 bool ResourceFormatLoader::exists(const String &p_path) const {
 	return FileAccess::exists(p_path); //by default just check file
 }
+
 RES ResourceFormatLoader::load(const String &p_path, const String &p_original_path, Error *r_error) {
 
 	String path = p_path;
@@ -252,7 +253,7 @@ bool ResourceLoader::exists(const String &p_path, const String &p_type_hint) {
 
 	if (ResourceCache::has(local_path)) {
 
-		return false; //if cached, it probably exists i guess
+		return true; // If cached, it probably exists
 	}
 
 	bool xl_remapped = false;


### PR DESCRIPTION
Fixes typo as reported in https://github.com/godotengine/godot/commit/852378109fa701101c851c789cc5306298d2a636#r30041881 and prevents compatibility breakage by readding `ResourceLoader.has` bindings with a deprecation warning.

CC @reduz 