### PR TITLE
Fix handling of normals that approach 1

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -526,7 +526,7 @@ FRAGMENT_SHADER_CODE
 
 #if defined(ENABLE_NORMALMAP)
 	normalmap.xy = normalmap.xy * 2.0 - 1.0;
-	normalmap.z = sqrt(1.0 - dot(normalmap.xy, normalmap.xy));
+	normalmap.z = sqrt(max(0.0, 1.0 - dot(normalmap.xy, normalmap.xy)));
 
 	// normal = normalize(mix(normal_interp, tangent * normalmap.x + binormal * normalmap.y + normal * normalmap.z, normaldepth)) * side;
 	normal = normalmap;

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1700,7 +1700,7 @@ FRAGMENT_SHADER_CODE
 #if defined(ENABLE_NORMALMAP)
 
 	normalmap.xy=normalmap.xy*2.0-1.0;
-	normalmap.z=sqrt(1.0-dot(normalmap.xy,normalmap.xy)); //always ignore Z, as it can be RG packed, Z may be pos/neg, etc.
+	normalmap.z=sqrt(max(0.0, 1.0-dot(normalmap.xy,normalmap.xy))); //always ignore Z, as it can be RG packed, Z may be pos/neg, etc.
 
 	normal = normalize( mix(normal_interp,tangent * normalmap.x + binormal * normalmap.y + normal * normalmap.z,normaldepth) ) * side;
 


### PR DESCRIPTION
Fixes #19994 
This PR fixes the handling of normals that approach 1, as outlined in #19994 , by preventing that a negative value gets passed to sqrt().
@supagu I implemented your fix as a PR for both GLES2 and GLES3.

This is my first contribution to Godot, so any input is welcome.