### PR TITLE
Don't try to update the visual shader graph if it doesn't exist yet

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -119,6 +119,9 @@ void VisualShaderEditor::_update_graph() {
 	if (updating)
 		return;
 
+	if (visual_shader.is_null())
+		return;
+
 	graph->set_scroll_ofs(visual_shader->get_graph_offset() * EDSCALE);
 
 	VisualShader::Type type = VisualShader::Type(edit_type->get_selected());


### PR DESCRIPTION
When setting shader mode on a visual shader that was just created in the
editor we try to _update_graph(). However, the graph does not yet exist
in the visualshadereditor. This gets populated in
VisualShaderEditor::edit() which hasn't been called yet.

This PR simply changes the logic to not try to update the non-existent
graph.

This fixes #20322