### PR TITLE
Fix for resource save dialog call

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1408,7 +1408,7 @@ void FileSystemDock::_resource_created() const {
 
 	RES current_res = RES(r);
 
-	editor->save_resource_as(current_res);
+	editor->save_resource_as(current_res, path);
 }
 
 void FileSystemDock::_go_to_file_list() {


### PR DESCRIPTION
to make sure the resource save opens in the current folder when using right click to do it.

This fixes #20690 