### PR TITLE
Add warning color to output log

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -54,7 +54,11 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 		self->emit_signal("show_request");
 	*/
 
-	self->add_message(err_str, true);
+	if (p_type == ERR_HANDLER_WARNING) {
+		self->add_message(err_str, MSG_TYPE_WARNING);
+	} else {
+		self->add_message(err_str, MSG_TYPE_ERROR);
+	}
 }
 
 void EditorLog::_notification(int p_what) {
@@ -95,22 +99,32 @@ void EditorLog::clear() {
 	_clear_request();
 }
 
-void EditorLog::add_message(const String &p_msg, bool p_error) {
+void EditorLog::add_message(const String &p_msg, MessageType p_type) {
 
 	log->add_newline();
 
-	if (p_error) {
-		log->push_color(get_color("error_color", "Editor"));
-		Ref<Texture> icon = get_icon("Error", "EditorIcons");
-		log->add_image(icon);
-		log->add_text(" ");
-		tool_button->set_icon(icon);
+	bool restore = p_type != MSG_TYPE_STD;
+	switch (p_type) {
+		case MSG_TYPE_ERROR: {
+			log->push_color(get_color("error_color", "Editor"));
+			Ref<Texture> icon = get_icon("Error", "EditorIcons");
+			log->add_image(icon);
+			log->add_text(" ");
+			tool_button->set_icon(icon);
+		} break;
+		case MSG_TYPE_WARNING: {
+			log->push_color(get_color("warning_color", "Editor"));
+			Ref<Texture> icon = get_icon("Warning", "EditorIcons");
+			log->add_image(icon);
+			log->add_text(" ");
+			tool_button->set_icon(icon);
+		} break;
 	}
 
 	log->add_text(p_msg);
 	//button->set_text(p_msg);
 
-	if (p_error)
+	if (restore)
 		log->pop();
 }
 

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -42,6 +42,7 @@
 #include "scene/gui/panel_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tool_button.h"
+
 class EditorLog : public VBoxContainer {
 
 	GDCLASS(EditorLog, VBoxContainer);
@@ -68,7 +69,13 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void add_message(const String &p_msg, bool p_error = false);
+	enum MessageType {
+		MSG_TYPE_STD,
+		MSG_TYPE_ERROR,
+		MSG_TYPE_WARNING
+	};
+
+	void add_message(const String &p_msg, MessageType p_type = MSG_TYPE_STD);
 	void set_tool_button(ToolButton *p_tool_button);
 	void deinit();
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4566,7 +4566,7 @@ static Node *_resource_get_edited_scene() {
 
 void EditorNode::_print_handler(void *p_this, const String &p_string, bool p_error) {
 	EditorNode *en = (EditorNode *)p_this;
-	en->log->add_message(p_string, p_error);
+	en->log->add_message(p_string, p_error ? EditorLog::MSG_TYPE_ERROR : EditorLog::MSG_TYPE_STD);
 }
 
 EditorNode::EditorNode() {

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -175,7 +175,7 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 	const Color warning_color = p_theme->get_color("warning_color", "Editor");
 	dark_icon_color_dictionary[Color::html("#ff5d5d")] = error_color;
 	dark_icon_color_dictionary[Color::html("#45ff8b")] = success_color;
-	dark_icon_color_dictionary[Color::html("#ffdd65")] = warning_color;
+	dark_icon_color_dictionary[Color::html("#dbab09")] = warning_color;
 
 	List<String> exceptions;
 	exceptions.push_back("EditorPivot");
@@ -365,13 +365,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("mono_color", "Editor", mono_color);
 
 	Color success_color = accent_color.linear_interpolate(Color(0.2, 1, 0.2), 0.6) * 1.2;
-	Color warning_color = accent_color.linear_interpolate(Color(1, 1, 0), 0.7) * 1.2;
+	Color warning_color = accent_color.linear_interpolate(Color(1, 1, 0), 0.7) * 1.0;
 	Color error_color = accent_color.linear_interpolate(Color(1, 0, 0), 0.8) * 1.7;
 	Color property_color = font_color.linear_interpolate(Color(0.5, 0.5, 0.5), 0.5);
 
 	if (!dark_theme) {
 		// yellow on white themes is a P.I.T.A.
-		warning_color = accent_color.linear_interpolate(Color(1, 0.8, 0), 0.9);
+		warning_color = accent_color.linear_interpolate(Color(0.9, 0.7, 0), 0.9);
 		warning_color = warning_color.linear_interpolate(mono_color, 0.2);
 		success_color = success_color.linear_interpolate(mono_color, 0.2);
 		error_color = error_color.linear_interpolate(mono_color, 0.2);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1198,7 +1198,7 @@ void ScriptEditorDebugger::start() {
 
 	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 	if (server->listen(remote_port) != OK) {
-		EditorNode::get_log()->add_message(String("Error listening on port ") + itos(remote_port), true);
+		EditorNode::get_log()->add_message(String("Error listening on port ") + itos(remote_port), EditorLog::MSG_TYPE_ERROR);
 		return;
 	}
 


### PR DESCRIPTION
Because warnings are now real and visible to other, its not a bad idea to give them unique color, which separate them from errors. I changed the existed warning color a bit, simply to make it more visible in light theme. Fix #20973

Dark theme

![image](https://user-images.githubusercontent.com/3036176/44040319-9e88bc7e-9f23-11e8-80f2-c7fd9034be0d.png)

Light theme

![image](https://user-images.githubusercontent.com/3036176/44040262-7d555bb6-9f23-11e8-8da3-cd2675a213c4.png)

