### PR TITLE
Emit pressed events after processing items

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1049,10 +1049,8 @@ void PopupMenu::activate_item(int p_item) {
 	ERR_FAIL_INDEX(p_item, items.size());
 	ERR_FAIL_COND(items[p_item].separator);
 	int id = items[p_item].ID >= 0 ? items[p_item].ID : p_item;
-	emit_signal("id_pressed", id);
-	emit_signal("index_pressed", p_item);
 
-	//hide all parent PopupMenue's
+	//hide all parent PopupMenus
 	Node *next = get_parent();
 	PopupMenu *pop = Object::cast_to<PopupMenu>(next);
 	while (pop) {
@@ -1086,6 +1084,9 @@ void PopupMenu::activate_item(int p_item) {
 		return;
 
 	hide();
+
+	emit_signal("id_pressed", id);
+	emit_signal("index_pressed", p_item);
 }
 
 void PopupMenu::remove_item(int p_idx) {


### PR DESCRIPTION
When processing items we may actually delete the item we're processing
in the callback for the signal. To avoid this, call the signal after
we're done processing the items.

This fixes #19842