### PR TITLE
Do not attempt to set_instance_base_type on non-existent object

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2036,7 +2036,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 			ERR_BREAK(!obj);
 			Resource *resp = Object::cast_to<Resource>(obj);
 			ERR_BREAK(!resp);
-			if (get_edited_object() && base_type != String() && base_type == "Script") {
+			if (get_edited_object() && base_type != String() && base_type == "Script" && !res.is_null()) {
 				//make visual script the right type
 				res->call("set_instance_base_type", get_edited_object()->get_class());
 			}


### PR DESCRIPTION
When creating a resource in the editor and attaching a script
get_edited_object()->get(get_edited_property)) returns a null reference.
After which we try to call it. This seems to only happen when the
resource in question hasn't been saved yet.

In this case we we just not call set_instance_base_type.

This fixes #19289

Note: editing the new script triggers #20501. This seems to be an
unrelated issue.