### PR TITLE
Changes to the TileSet and TextureRegion editors

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -603,7 +603,6 @@ void TextureRegionEditor::_notification(int p_what) {
 			zoom_out->set_icon(get_icon("ZoomLess", "EditorIcons"));
 			zoom_reset->set_icon(get_icon("ZoomReset", "EditorIcons"));
 			zoom_in->set_icon(get_icon("ZoomMore", "EditorIcons"));
-			icon_zoom->set_texture(get_icon("Zoom", "EditorIcons"));
 		} break;
 	}
 }
@@ -865,7 +864,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	hb_grid->add_child(sb_step_y);
 
 	hb_grid->add_child(memnew(VSeparator));
-	hb_grid->add_child(memnew(Label(TTR("Separation:"))));
+	hb_grid->add_child(memnew(Label(TTR("Sep.:"))));
 
 	sb_sep_x = memnew(SpinBox);
 	sb_sep_x->set_min(0);
@@ -897,10 +896,6 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	Control *separator = memnew(Control);
 	separator->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hb_tools->add_child(separator);
-
-	icon_zoom = memnew(TextureRect);
-	icon_zoom->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	hb_tools->add_child(icon_zoom);
 
 	zoom_out = memnew(ToolButton);
 	zoom_out->connect("pressed", this, "_zoom_out");
@@ -940,16 +935,15 @@ bool TextureRegionEditorPlugin::handles(Object *p_object) const {
 void TextureRegionEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		texture_region_button->show();
-		if (region_editor->is_stylebox() || region_editor->is_atlas_texture() || region_editor->is_ninepatch() || (region_editor->get_sprite() && region_editor->get_sprite()->is_region())) {
+		if (region_editor->is_stylebox() || region_editor->is_atlas_texture() || region_editor->is_ninepatch() || (region_editor->get_sprite() && region_editor->get_sprite()->is_region()) || texture_region_button->is_pressed()) {
 			editor->make_bottom_panel_item_visible(region_editor);
-		} else {
-			if (texture_region_button->is_pressed())
-				region_editor->show();
 		}
 	} else {
+		if (region_editor->is_visible_in_tree()) {
+			editor->hide_bottom_panel();
+		}
 		texture_region_button->hide();
 		region_editor->edit(NULL);
-		region_editor->hide();
 	}
 }
 
@@ -1001,10 +995,9 @@ TextureRegionEditorPlugin::TextureRegionEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	region_editor = memnew(TextureRegionEditor(p_node));
 
-	texture_region_button = p_node->add_bottom_panel_item(TTR("TextureRegion"), region_editor);
-	texture_region_button->set_tooltip(TTR("Texture Region Editor"));
-
 	region_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	region_editor->hide();
+
+	texture_region_button = p_node->add_bottom_panel_item(TTR("TextureRegion"), region_editor);
 	texture_region_button->hide();
 }

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -56,7 +56,6 @@ class TextureRegionEditor : public Control {
 
 	friend class TextureRegionEditorPlugin;
 	MenuButton *snap_mode_button;
-	TextureRect *icon_zoom;
 	ToolButton *zoom_in;
 	ToolButton *zoom_reset;
 	ToolButton *zoom_out;

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -307,6 +307,11 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 		tool_workspacemode[i]->connect("pressed", this, "_on_workspace_mode_changed", p);
 		tool_hb->add_child(tool_workspacemode[i]);
 	}
+	Control *spacer = memnew(Control);
+	spacer->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	tool_hb->add_child(spacer);
+	tool_hb->move_child(spacer, (int)WORKSPACE_CREATE_SINGLE);
+
 	tool_workspacemode[WORKSPACE_EDIT]->set_pressed(true);
 	workspace_mode = WORKSPACE_EDIT;
 
@@ -314,9 +319,6 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	main_vb->add_child(memnew(HSeparator));
 
 	tool_hb = memnew(HBoxContainer);
-	Control *spacer = memnew(Control);
-	spacer->set_custom_minimum_size(Size2(30, 0));
-	tool_hb->add_child(spacer);
 
 	g = Ref<ButtonGroup>(memnew(ButtonGroup));
 	String label[EDITMODE_MAX] = { "Region", "Collision", "Occlusion", "Navigation", "Bitmask", "Priority", "Icon" };
@@ -335,7 +337,8 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	edit_mode = EDITMODE_COLLISION;
 
 	main_vb->add_child(tool_hb);
-	main_vb->add_child(memnew(HSeparator));
+	separator_editmode = memnew(HSeparator);
+	main_vb->add_child(separator_editmode);
 
 	toolbar = memnew(HBoxContainer);
 	Ref<ButtonGroup> tg(memnew(ButtonGroup));
@@ -369,13 +372,17 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	toolbar->add_child(tools[SHAPE_NEW_POLYGON]);
 	tools[SHAPE_NEW_POLYGON]->set_toggle_mode(true);
 	tools[SHAPE_NEW_POLYGON]->set_button_group(tg);
-	toolbar->add_child(memnew(VSeparator));
+
+	separator_delete = memnew(VSeparator);
+	toolbar->add_child(separator_delete);
 	tools[SHAPE_DELETE] = memnew(ToolButton);
 	p = Vector<Variant>();
 	p.push_back((int)SHAPE_DELETE);
 	tools[SHAPE_DELETE]->connect("pressed", this, "_on_tool_clicked", p);
 	toolbar->add_child(tools[SHAPE_DELETE]);
-	toolbar->add_child(memnew(VSeparator));
+
+	separator_grid = memnew(VSeparator);
+	toolbar->add_child(separator_grid);
 	tools[SHAPE_KEEP_INSIDE_TILE] = memnew(ToolButton);
 	tools[SHAPE_KEEP_INSIDE_TILE]->set_toggle_mode(true);
 	tools[SHAPE_KEEP_INSIDE_TILE]->set_pressed(true);
@@ -588,10 +595,16 @@ void TileSetEditor::_on_edit_mode_changed(int p_edit_mode) {
 			tools[BITMASK_PASTE]->hide();
 			tools[BITMASK_CLEAR]->hide();
 			tools[SHAPE_NEW_POLYGON]->hide();
-			if (workspace_mode == WORKSPACE_EDIT)
+
+			if (workspace_mode == WORKSPACE_EDIT) {
+				separator_delete->show();
 				tools[SHAPE_DELETE]->show();
-			else
+			} else {
+				separator_delete->hide();
 				tools[SHAPE_DELETE]->hide();
+			}
+
+			separator_grid->show();
 			tools[SHAPE_KEEP_INSIDE_TILE]->hide();
 			tools[TOOL_GRID_SNAP]->show();
 
@@ -605,7 +618,11 @@ void TileSetEditor::_on_edit_mode_changed(int p_edit_mode) {
 			tools[BITMASK_PASTE]->show();
 			tools[BITMASK_CLEAR]->show();
 			tools[SHAPE_NEW_POLYGON]->hide();
+
+			separator_delete->hide();
 			tools[SHAPE_DELETE]->hide();
+
+			separator_grid->hide();
 			tools[SHAPE_KEEP_INSIDE_TILE]->hide();
 			tools[TOOL_GRID_SNAP]->hide();
 
@@ -621,7 +638,11 @@ void TileSetEditor::_on_edit_mode_changed(int p_edit_mode) {
 			tools[BITMASK_PASTE]->hide();
 			tools[BITMASK_CLEAR]->hide();
 			tools[SHAPE_NEW_POLYGON]->show();
+
+			separator_delete->show();
 			tools[SHAPE_DELETE]->show();
+
+			separator_grid->show();
 			tools[SHAPE_KEEP_INSIDE_TILE]->show();
 			tools[TOOL_GRID_SNAP]->show();
 
@@ -635,9 +656,14 @@ void TileSetEditor::_on_edit_mode_changed(int p_edit_mode) {
 			tools[BITMASK_PASTE]->hide();
 			tools[BITMASK_CLEAR]->hide();
 			tools[SHAPE_NEW_POLYGON]->hide();
+
+			separator_delete->hide();
 			tools[SHAPE_DELETE]->hide();
+
+			separator_grid->show();
 			tools[SHAPE_KEEP_INSIDE_TILE]->hide();
 			tools[TOOL_GRID_SNAP]->show();
+
 			if (edit_mode == EDITMODE_ICON) {
 				tools[TOOL_SELECT]->set_tooltip(TTR("Select sub-tile to use as icon, this will be also used on invalid autotile bindings.\nClick on another Tile to edit it."));
 				spin_priority->hide();
@@ -661,6 +687,7 @@ void TileSetEditor::_on_workspace_mode_changed(int p_workspace_mode) {
 		tool_editmode[EDITMODE_REGION]->show();
 		tool_editmode[EDITMODE_REGION]->set_pressed(true);
 		_on_edit_mode_changed(EDITMODE_REGION);
+		separator_editmode->show();
 	}
 }
 
@@ -2076,6 +2103,7 @@ void TileSetEditor::update_workspace_tile_mode() {
 		tool_editmode[EDITMODE_REGION]->show();
 		tool_editmode[EDITMODE_REGION]->set_pressed(true);
 		_on_edit_mode_changed(EDITMODE_REGION);
+		separator_editmode->show();
 		return;
 	}
 
@@ -2086,12 +2114,16 @@ void TileSetEditor::update_workspace_tile_mode() {
 		for (int i = 0; i < ZOOM_OUT; i++) {
 			tools[i]->hide();
 		}
+		separator_editmode->hide();
+		separator_delete->hide();
+		separator_grid->hide();
 		return;
 	}
 
 	for (int i = 0; i < EDITMODE_MAX; i++) {
 		tool_editmode[i]->show();
 	}
+	separator_editmode->show();
 
 	if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::SINGLE_TILE) {
 		if (tool_editmode[EDITMODE_ICON]->is_pressed() || tool_editmode[EDITMODE_PRIORITY]->is_pressed() || tool_editmode[EDITMODE_BITMASK]->is_pressed()) {
@@ -2336,12 +2368,10 @@ bool TileSetEditorPlugin::handles(Object *p_node) const {
 void TileSetEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		tileset_editor_button->show();
-		if (tileset_editor_button->is_pressed()) {
-			tileset_editor->show();
-		}
+		editor->make_bottom_panel_item_visible(tileset_editor);
 		get_tree()->connect("idle_frame", tileset_editor, "_on_workspace_process");
 	} else {
-		tileset_editor->hide();
+		editor->hide_bottom_panel();
 		tileset_editor_button->hide();
 		get_tree()->disconnect("idle_frame", tileset_editor, "_on_workspace_process");
 	}

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -40,12 +40,12 @@
 #define WORKSPACE_MARGIN Vector2(10, 10)
 class TilesetEditorContext;
 
-class TileSetEditor : public Panel {
+class TileSetEditor : public Control {
 
 	friend class TileSetEditorPlugin;
 	friend class TilesetEditorContext;
 
-	GDCLASS(TileSetEditor, Panel)
+	GDCLASS(TileSetEditor, Control)
 
 	enum TextureToolButtons {
 		TOOL_TILESET_ADD_TEXTURE,
@@ -131,8 +131,11 @@ class TileSetEditor : public Panel {
 	Control *workspace;
 	Button *tool_workspacemode[WORKSPACE_MODE_MAX];
 	Button *tool_editmode[EDITMODE_MAX];
+	HSeparator *separator_editmode;
 	HBoxContainer *toolbar;
 	ToolButton *tools[TOOL_MAX];
+	VSeparator *separator_delete;
+	VSeparator *separator_grid;
 	SpinBox *spin_priority;
 	WorkspaceMode workspace_mode;
 	EditMode edit_mode;


### PR DESCRIPTION
## General
- Fixed TileSet/TextureRegion editors not closing the bottom panel correctly when hiding. Fixes #20698.

## TileSet
- Made it open automatically when editing a TileSet resource.
- Hide separators together with the icons.
- Made the editor extend from a control to blend better with the bottom panel, like the other editors.
- Spaced the "New Tile" section to the right.
- Removed spacing from the toolbar section (I really don't see the point of it).

### Before:
![screenshot at 2018-08-14 13-57-45](https://user-images.githubusercontent.com/30739239/44106994-707630b0-9fcc-11e8-8576-f5a63bf135ed.png)

### After:
![screenshot at 2018-08-14 14-00-24](https://user-images.githubusercontent.com/30739239/44107003-73e4add0-9fcc-11e8-8cef-f1a3bfe81a8d.png)

## TextureRegion
- Adjusted the toolbar to fit better in smaller screens.

### Before:
![screenshot at 2018-08-14 13-57-13](https://user-images.githubusercontent.com/30739239/44106963-60ef34fc-9fcc-11e8-93bd-993498eef5bd.png)

### After:
![screenshot at 2018-08-14 13-59-58](https://user-images.githubusercontent.com/30739239/44106973-64f7add6-9fcc-11e8-9833-b57aad9920e5.png)