### PR TITLE
Fix re-opening of TextFiles when its already being edited.

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1937,7 +1937,7 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 		if (!se)
 			continue;
 
-		if (se->get_edited_resource() == p_resource) {
+		if ((script != NULL && se->get_edited_resource() == p_resource) || se->get_edited_resource()->get_path() == p_resource->get_path()) {
 
 			if (should_open) {
 				if (tab_container->get_current_tab() != i) {


### PR DESCRIPTION
As `TextFiles` don't go through `ResourceLoader` it was allowing the same file to be opened twice. Now if its not a script we compare the resource's path to make sure that's not been opened before.