### PR TITLE
Fix not to show configuration warning on every node has script

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2555,7 +2555,7 @@ void Node::clear_internal_tree_resource_paths() {
 
 String Node::get_configuration_warning() const {
 
-	if (get_script_instance()) {
+	if (get_script_instance() && get_script_instance()->has_method("_get_configuration_warning")) {
 		return get_script_instance()->call("_get_configuration_warning");
 	}
 	return String();


### PR DESCRIPTION
it came from ef5095720b56e72d99b8ca2773e2a5fa24f7097d

This PR fix not to show the warning on every node has a script.
![screenshot_20180815_213348](https://user-images.githubusercontent.com/8281454/44148490-8c04db4e-a0d3-11e8-833d-3a8f0ed6c10d.png)
