### PR TITLE
Fix error spam from loading script class icons

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -158,12 +158,15 @@ Ref<Texture> CreateDialog::_get_editor_icon(const String &p_type) const {
 	}
 
 	if (ScriptServer::is_global_class(p_type)) {
-		RES icon = ResourceLoader::load(EditorNode::get_editor_data().script_class_get_icon_path(p_type));
-		if (icon.is_valid())
-			return icon;
-		icon = get_icon(ScriptServer::get_global_class_base(p_type), "EditorIcons");
-		if (icon.is_valid())
-			return icon;
+		String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(p_type);
+		RES icon;
+		if (FileAccess::exists(icon_path)) {
+			icon = ResourceLoader::load(icon_path);
+		}
+		if (!icon.is_valid()) {
+			icon = get_icon(ScriptServer::get_global_class_base(p_type), "EditorIcons");
+		}
+		return icon;
 	}
 
 	const Map<String, Vector<EditorData::CustomType> > &p_map = EditorNode::get_editor_data().get_custom_types();

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1877,7 +1877,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 			}
 		}
 		if (r_icon_path) {
-			if (c->icon_path.is_abs_path())
+			if (c->icon_path.empty() || c->icon_path.is_abs_path())
 				*r_icon_path = c->icon_path;
 			else if (c->icon_path.is_rel_path())
 				*r_icon_path = p_path.get_base_dir().plus_file(c->icon_path).simplify_path();


### PR DESCRIPTION
As mentioned in #21021, this PR fixes an issue with script classes reporting errors loading icons whenever the CreateDialog::add_type method fires.

The problem was that the GDScript handler wasn't properly serializing an empty string in cases where there was no icon path defined, instead serializing "res://" due to the simplify_path() call in the is_rel_path() control flow logic. When that string was then deserialized and loaded, you'd get "cannot load resource 'res://'" errors.