### PR TITLE
Fixed custom nodes not working with favorites and recently used

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -587,7 +587,7 @@ void CreateDialog::_history_selected() {
 	if (!item)
 		return;
 
-	search_box->set_text(item->get_text(0));
+	search_box->set_text(item->get_text(0).get_slicec(' ', 0));
 	_update_search();
 }
 
@@ -597,7 +597,7 @@ void CreateDialog::_favorite_selected() {
 	if (!item)
 		return;
 
-	search_box->set_text(item->get_text(0));
+	search_box->set_text(item->get_text(0).get_slicec(' ', 0));
 	_update_search();
 }
 


### PR DESCRIPTION
This happened due to the script in brackets being included in the search bar on selection which meant the custom node couldn't be found.