### PR TITLE
Tween: Always remove the desired InterpolateData when finished

### DIFF
--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -100,6 +100,7 @@ private:
 		real_t delay;
 		int args;
 		Variant arg[5];
+		int uid;
 	};
 
 	String autoplay;
@@ -107,6 +108,7 @@ private:
 	bool repeat;
 	float speed_scale;
 	mutable int pending_update;
+	int uid;
 
 	List<InterpolateData> interpolates;
 
@@ -131,7 +133,8 @@ private:
 	bool _apply_tween_value(InterpolateData &p_data, Variant &value);
 
 	void _tween_process(float p_delta);
-	void _remove(Object *p_object, StringName p_key, bool first_only);
+	void _remove_by_uid(int uid);
+	void _push_interpolate_data(InterpolateData &p_data);
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);


### PR DESCRIPTION
Hi,
This is intended to fix #21030.
After many tries, I ended up adding a unique identifier in the InterpolateData struct in order to be sure which ones are removed.
Feel free to comment this PR, especially the implementation of `Tween::_push_interpolate_data`!