### PR TITLE
Delay initializing lens distortion shader so GLES2 doesn't crash

### DIFF
--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -58,7 +58,7 @@ private:
 	float eye_height;
 	uint64_t last_ticks;
 
-	LensDistortedShaderGLES3 lens_shader;
+	LensDistortedShaderGLES3 *lens_shader;
 	GLuint half_screen_quad;
 	GLuint half_screen_array;
 


### PR DESCRIPTION
This delays initializing the lens distortion shader for mobile vr until the mobile vr interface is initialized. As a result it is not crashing on initializing a GLES3 shader when running in GLES2 (#20734)

We need to add a GLES2 version of the lens distortion shader and maybe even move it into the drivers. But for now I at least wanted to fix the crash for people who don't use this at all.

*Bugsquad edit:* Fixes #20734.