### PR TITLE
Fix Theora/Webm loaders declaring binary extension

### DIFF
--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -163,7 +163,6 @@ public:
 class VideoStreamTheora : public VideoStream {
 
 	GDCLASS(VideoStreamTheora, VideoStream);
-	RES_BASE_EXTENSION("ogv");
 
 	String file;
 	int audio_track;

--- a/modules/webm/video_stream_webm.h
+++ b/modules/webm/video_stream_webm.h
@@ -109,7 +109,6 @@ private:
 class VideoStreamWebm : public VideoStream {
 
 	GDCLASS(VideoStreamWebm, VideoStream);
-	RES_BASE_EXTENSION("webm");
 
 	String file;
 	int audio_track;


### PR DESCRIPTION
RES_BASE_EXTENSION is only to declare our proprietary binary formats
(e.g. "scn", "res", etc.).

Fixes #20395.