### PR TITLE
Change PhysicsMaterial extension to phymat

### DIFF
--- a/scene/resources/physics_material.h
+++ b/scene/resources/physics_material.h
@@ -37,7 +37,7 @@ class PhysicsMaterial : public Resource {
 
 	GDCLASS(PhysicsMaterial, Resource);
 	OBJ_SAVE_TYPE(PhysicsMaterial);
-	RES_BASE_EXTENSION("PhyMat");
+	RES_BASE_EXTENSION("phymat");
 
 	real_t friction;
 	bool rough;


### PR DESCRIPTION
All other binary extensions are lowercase.

```
$ rg RES_BASE_EXTENSION
scene/resources/mesh.h
157:    RES_BASE_EXTENSION("mesh");

scene/resources/packed_scene.h
200:    RES_BASE_EXTENSION("scn");

scene/resources/theme.h
47:     RES_BASE_EXTENSION("theme");

scene/resources/font.h
111:    RES_BASE_EXTENSION("font");

scene/resources/texture.h
90:     RES_BASE_EXTENSION("tex");
238:    RES_BASE_EXTENSION("atlastex");
281:    RES_BASE_EXTENSION("largetex");
328:    RES_BASE_EXTENSION("cubemap");
491:    RES_BASE_EXTENSION("curvetex")

scene/resources/shader_graph.h
42:     RES_BASE_EXTENSION("vshader");

scene/resources/multimesh.h
40:     RES_BASE_EXTENSION("multimesh");

core/resource.h
45:#define RES_BASE_EXTENSION(m_ext)                                                                                   \
56:     RES_BASE_EXTENSION("res");

scene/resources/physics_material.h
40:     RES_BASE_EXTENSION("PhyMat");

scene/resources/mesh_library.h
43:     RES_BASE_EXTENSION("meshlib");

scene/resources/style_box.h
43:     RES_BASE_EXTENSION("stylebox");

scene/resources/world.h
45:     RES_BASE_EXTENSION("world");

scene/resources/animation.h
41:     RES_BASE_EXTENSION("anim");

scene/resources/shape.h
41:     RES_BASE_EXTENSION("shape");

scene/resources/material.h
47:     RES_BASE_EXTENSION("material")

scene/resources/room.h
46:     RES_BASE_EXTENSION("room");

core/translation.h
40:     RES_BASE_EXTENSION("translation");

scene/resources/audio_stream_sample.h
85:     RES_BASE_EXTENSION("sample")

modules/stb_vorbis/audio_stream_ogg_vorbis.h
82:     RES_BASE_EXTENSION("oggstr");

modules/visual_script/visual_script.h
171:    RES_BASE_EXTENSION("vs");
```