### PR TITLE
Delay emitting pressed signals in PopupMenu

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1071,22 +1071,26 @@ void PopupMenu::activate_item(int p_item) {
 		pop = Object::cast_to<PopupMenu>(next);
 	}
 
-	emit_signal("id_pressed", id);
-	emit_signal("index_pressed", p_item);
-
 	// Hides popup by default; unless otherwise specified
 	// by using set_hide_on_item_selection and set_hide_on_checkable_item_selection
 
+	bool need_hide = true;
+
 	if (items[p_item].checkable_type) {
 		if (!hide_on_checkable_item_selection)
-			return;
+			need_hide = false;
 	} else if (0 < items[p_item].max_states) {
 		if (!hide_on_multistate_item_selection)
-			return;
+			need_hide = false;
 	} else if (!hide_on_item_selection)
-		return;
+		need_hide = false;
 
-	hide();
+	emit_signal("id_pressed", id);
+	emit_signal("index_pressed", p_item);
+
+	if (need_hide) {
+		hide();
+	}
 }
 
 void PopupMenu::remove_item(int p_idx) {


### PR DESCRIPTION
When processing items we may actually delete the item we're processing
in the callback for the signal. To avoid this, call the signal after
we're done processing the items. But before hiding the popupmenu itself.

Thanks to @reduz for writing the whole solution.

This fixes #19842