### PR TITLE
Call minimum_size_changed() in PopupMenu::remove_item()

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1099,6 +1099,7 @@ void PopupMenu::remove_item(int p_idx) {
 
 	items.remove(p_idx);
 	update();
+	minimum_size_changed();
 }
 
 void PopupMenu::add_separator(const String &p_text) {


### PR DESCRIPTION
When removing an item from a PopupMenu we need to update the control's
size cache otherwise the size of the PopupMenu itself lags behind by 1
item size. Meaning the PopupMenu will remain too large.