### PR TITLE
Fix error icon color for light themes

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -173,7 +173,7 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 	const Color error_color = p_theme->get_color("error_color", "Editor");
 	const Color success_color = p_theme->get_color("success_color", "Editor");
 	const Color warning_color = p_theme->get_color("warning_color", "Editor");
-	dark_icon_color_dictionary[Color::html("#ff5d5d")] = error_color;
+	dark_icon_color_dictionary[Color::html("#ff0000")] = error_color;
 	dark_icon_color_dictionary[Color::html("#45ff8b")] = success_color;
 	dark_icon_color_dictionary[Color::html("#dbab09")] = warning_color;
 


### PR DESCRIPTION
I found that error icon is black for light theme, so I adjusted its color a bit to make it trully red

before

![image](https://user-images.githubusercontent.com/3036176/44250952-3ef86a00-a1ff-11e8-8d95-6641d548376c.png)

after

![image](https://user-images.githubusercontent.com/3036176/44250927-2720e600-a1ff-11e8-962b-d77e514ad723.png)
