### PR TITLE
Particles2D: fix editing Visibility Rect from new inspector

### DIFF
--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -58,8 +58,6 @@ void Particles2DEditorPlugin::make_visible(bool p_visible) {
 
 void Particles2DEditorPlugin::_file_selected(const String &p_file) {
 
-	print_line("file: " + p_file);
-
 	source_emission_file = p_file;
 	emission_mask->popup_centered_minsize();
 }
@@ -73,7 +71,7 @@ void Particles2DEditorPlugin::_menu_callback(int p_idx) {
 				generate_seconds->set_value(1.0);
 			else
 				generate_seconds->set_value(trunc(gen_time) + 1.0);
-			generate_aabb->popup_centered_minsize();
+			generate_visibility_rect->popup_centered_minsize();
 		} break;
 		case MENU_LOAD_EMISSION_MASK: {
 
@@ -93,7 +91,7 @@ void Particles2DEditorPlugin::_generate_visibility_rect() {
 
 	float running = 0.0;
 
-	EditorProgress ep("gen_aabb", TTR("Generating AABB"), int(time));
+	EditorProgress ep("gen_vrect", TTR("Generating Visibility Rect"), int(time));
 
 	bool was_emitting = particles->is_emitting();
 	if (!was_emitting) {
@@ -376,19 +374,19 @@ Particles2DEditorPlugin::Particles2DEditorPlugin(EditorNode *p_node) {
 	epoints->set_value(512);
 	file->get_vbox()->add_margin_child(TTR("Generated Point Count:"), epoints);
 
-	generate_aabb = memnew(ConfirmationDialog);
-	generate_aabb->set_title(TTR("Generate Visibility Rect"));
+	generate_visibility_rect = memnew(ConfirmationDialog);
+	generate_visibility_rect->set_title(TTR("Generate Visibility Rect"));
 	VBoxContainer *genvb = memnew(VBoxContainer);
-	generate_aabb->add_child(genvb);
+	generate_visibility_rect->add_child(genvb);
 	generate_seconds = memnew(SpinBox);
 	genvb->add_margin_child(TTR("Generation Time (sec):"), generate_seconds);
 	generate_seconds->set_min(0.1);
 	generate_seconds->set_max(25);
 	generate_seconds->set_value(2);
 
-	toolbar->add_child(generate_aabb);
+	toolbar->add_child(generate_visibility_rect);
 
-	generate_aabb->connect("confirmed", this, "_generate_visibility_rect");
+	generate_visibility_rect->connect("confirmed", this, "_generate_visibility_rect");
 
 	emission_mask = memnew(ConfirmationDialog);
 	emission_mask->set_title(TTR("Generate Visibility Rect"));

--- a/editor/plugins/particles_2d_editor_plugin.h
+++ b/editor/plugins/particles_2d_editor_plugin.h
@@ -66,7 +66,7 @@ class Particles2DEditorPlugin : public EditorPlugin {
 
 	SpinBox *epoints;
 
-	ConfirmationDialog *generate_aabb;
+	ConfirmationDialog *generate_visibility_rect;
 	SpinBox *generate_seconds;
 
 	ConfirmationDialog *emission_mask;

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -74,14 +74,14 @@ void Particles2D::set_randomness_ratio(float p_ratio) {
 	randomness_ratio = p_ratio;
 	VS::get_singleton()->particles_set_randomness_ratio(particles, randomness_ratio);
 }
-void Particles2D::set_visibility_rect(const Rect2 &p_aabb) {
+void Particles2D::set_visibility_rect(const Rect2 &p_visibility_rect) {
 
-	visibility_rect = p_aabb;
+	visibility_rect = p_visibility_rect;
 	AABB aabb;
-	aabb.position.x = p_aabb.position.x;
-	aabb.position.y = p_aabb.position.y;
-	aabb.size.x = p_aabb.size.x;
-	aabb.size.y = p_aabb.size.y;
+	aabb.position.x = p_visibility_rect.position.x;
+	aabb.position.y = p_visibility_rect.position.y;
+	aabb.size.x = p_visibility_rect.size.x;
+	aabb.size.y = p_visibility_rect.size.y;
 
 	VS::get_singleton()->particles_set_custom_aabb(particles, aabb);
 
@@ -326,7 +326,7 @@ void Particles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pre_process_time", "secs"), &Particles2D::set_pre_process_time);
 	ClassDB::bind_method(D_METHOD("set_explosiveness_ratio", "ratio"), &Particles2D::set_explosiveness_ratio);
 	ClassDB::bind_method(D_METHOD("set_randomness_ratio", "ratio"), &Particles2D::set_randomness_ratio);
-	ClassDB::bind_method(D_METHOD("set_visibility_rect", "aabb"), &Particles2D::set_visibility_rect);
+	ClassDB::bind_method(D_METHOD("set_visibility_rect", "visibility_rect"), &Particles2D::set_visibility_rect);
 	ClassDB::bind_method(D_METHOD("set_use_local_coordinates", "enable"), &Particles2D::set_use_local_coordinates);
 	ClassDB::bind_method(D_METHOD("set_fixed_fps", "fps"), &Particles2D::set_fixed_fps);
 	ClassDB::bind_method(D_METHOD("set_fractional_delta", "enable"), &Particles2D::set_fractional_delta);
@@ -378,7 +378,7 @@ void Particles2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_fps", PROPERTY_HINT_RANGE, "0,1000,1"), "set_fixed_fps", "get_fixed_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fract_delta"), "set_fractional_delta", "get_fractional_delta");
 	ADD_GROUP("Drawing", "");
-	ADD_PROPERTY(PropertyInfo(Variant::AABB, "visibility_rect"), "set_visibility_rect", "get_visibility_rect");
+	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "visibility_rect"), "set_visibility_rect", "get_visibility_rect");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "local_coords"), "set_use_local_coordinates", "get_use_local_coordinates");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "draw_order", PROPERTY_HINT_ENUM, "Index,Lifetime"), "set_draw_order", "get_draw_order");
 	ADD_GROUP("Process Material", "process_");

--- a/scene/2d/particles_2d.h
+++ b/scene/2d/particles_2d.h
@@ -84,7 +84,7 @@ public:
 	void set_pre_process_time(float p_time);
 	void set_explosiveness_ratio(float p_ratio);
 	void set_randomness_ratio(float p_ratio);
-	void set_visibility_rect(const Rect2 &p_aabb);
+	void set_visibility_rect(const Rect2 &p_visibility_rect);
 	void set_use_local_coordinates(bool p_enable);
 	void set_process_material(const Ref<Material> &p_material);
 	void set_speed_scale(float p_scale);


### PR DESCRIPTION
fix editing Visibility Rect from new inspector 
and renamed generate_aabb to generate_visibility_rect to prevent future confusions

fixes #21066