### PR TITLE
Readd CanvasLayer::get_world_2d as deprecated

### DIFF
--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -133,6 +133,12 @@ Vector2 CanvasLayer::get_scale() const {
 	return scale;
 }
 
+Ref<World2D> CanvasLayer::get_world_2d() const {
+
+	ERR_EXPLAIN("CanvasLayers no longer have their own World2D. Returning an empty one.");
+	ERR_FAIL_V(Ref<World2D>());
+}
+
 void CanvasLayer::_notification(int p_what) {
 
 	switch (p_what) {
@@ -247,6 +253,7 @@ void CanvasLayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_custom_viewport", "viewport"), &CanvasLayer::set_custom_viewport);
 	ClassDB::bind_method(D_METHOD("get_custom_viewport"), &CanvasLayer::get_custom_viewport);
 
+	ClassDB::bind_method(D_METHOD("get_world_2d"), &CanvasLayer::get_world_2d);
 	ClassDB::bind_method(D_METHOD("get_canvas"), &CanvasLayer::get_canvas);
 	//ClassDB::bind_method(D_METHOD("get_viewport"),&CanvasLayer::get_viewport);
 

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -81,6 +81,8 @@ public:
 	void set_scale(const Size2 &p_scale);
 	Size2 get_scale() const;
 
+	Ref<World2D> get_world_2d() const;
+
 	Size2 get_viewport_size() const;
 
 	RID get_viewport() const;


### PR DESCRIPTION
introduced on 9e7cee2ceb1a963c1da2c21013adf7d616412d3c

~~No need to cherry-pick. A dedicated PR for 3.0 will contain the original fix + this compat keeper (edit: #21114 ).~~

This code is donated by an anonymous party,