### PR TITLE
Backport canvas layer fixes

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -412,7 +412,7 @@ void CanvasItem::_enter_canvas() {
 
 		RID canvas;
 		if (canvas_layer)
-			canvas = canvas_layer->get_world_2d()->get_canvas();
+			canvas = canvas_layer->get_canvas();
 		else
 			canvas = get_viewport()->find_world_2d()->get_canvas();
 
@@ -838,7 +838,7 @@ RID CanvasItem::get_canvas() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), RID());
 
 	if (canvas_layer)
-		return canvas_layer->get_world_2d()->get_canvas();
+		return canvas_layer->get_canvas();
 	else
 		return get_viewport()->find_world_2d()->get_canvas();
 }
@@ -859,9 +859,7 @@ Ref<World2D> CanvasItem::get_world_2d() const {
 
 	CanvasItem *tl = get_toplevel();
 
-	if (tl->canvas_layer) {
-		return tl->canvas_layer->get_world_2d();
-	} else if (tl->get_viewport()) {
+	if (tl->get_viewport()) {
 		return tl->get_viewport()->find_world_2d();
 	} else {
 		return Ref<World2D>();

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -72,7 +72,7 @@ void ParallaxLayer::_update_mirroring() {
 	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
 	if (pb) {
 
-		RID c = pb->get_world_2d()->get_canvas();
+		RID c = pb->get_canvas();
 		RID ci = get_canvas_item();
 		Point2 mirrorScale = mirroring * get_scale();
 		VisualServer::get_singleton()->canvas_set_item_mirroring(c, ci, mirrorScale);

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -133,6 +133,12 @@ Vector2 CanvasLayer::get_scale() const {
 	return scale;
 }
 
+Ref<World2D> CanvasLayer::get_world_2d() const {
+
+	ERR_EXPLAIN("CanvasLayers no longer have their own World2D. Returning an empty one.");
+	ERR_FAIL_V(Ref<World2D>());
+}
+
 void CanvasLayer::_notification(int p_what) {
 
 	switch (p_what) {
@@ -247,6 +253,7 @@ void CanvasLayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_custom_viewport", "viewport"), &CanvasLayer::set_custom_viewport);
 	ClassDB::bind_method(D_METHOD("get_custom_viewport"), &CanvasLayer::get_custom_viewport);
 
+	ClassDB::bind_method(D_METHOD("get_world_2d"), &CanvasLayer::get_world_2d);
 	ClassDB::bind_method(D_METHOD("get_canvas"), &CanvasLayer::get_canvas);
 	//ClassDB::bind_method(D_METHOD("get_viewport"),&CanvasLayer::get_viewport);
 

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -45,7 +45,7 @@ class CanvasLayer : public Node {
 	real_t rot;
 	int layer;
 	Transform2D transform;
-	Ref<World2D> canvas;
+	RID canvas;
 
 	ObjectID custom_viewport_id; // to check validity
 	Viewport *custom_viewport;
@@ -81,8 +81,6 @@ public:
 	void set_scale(const Size2 &p_scale);
 	Size2 get_scale() const;
 
-	Ref<World2D> get_world_2d() const;
-
 	Size2 get_viewport_size() const;
 
 	RID get_viewport() const;
@@ -93,7 +91,10 @@ public:
 	void reset_sort_index();
 	int get_sort_index();
 
+	RID get_canvas() const;
+
 	CanvasLayer();
+	~CanvasLayer();
 };
 
 #endif // CANVAS_LAYER_H

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -81,6 +81,8 @@ public:
 	void set_scale(const Size2 &p_scale);
 	Size2 get_scale() const;
 
+	Ref<World2D> get_world_2d() const;
+
 	Size2 get_viewport_size() const;
 
 	RID get_viewport() const;


### PR DESCRIPTION
This PR backports these:
- A general fix for `CanvasLayer` by @reduz. That one fixes some issues ocurring on 3.0 as well. I've tagged this PR as compat-breaking because people may have been relying on the former, incorrect behavior.
- The only commit from #21112, which alleviates the compatibility breakage at the API level.

@akien-mga , I've removed the cherry-pick label you added to #17523.

This code is donated by an anonymous party,