### PR TITLE
Add more project window placement options

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -68,9 +68,24 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 
 	int screen = EditorSettings::get_singleton()->get("run/window_placement/screen");
 	if (screen == 0) {
+		// Same as editor
 		screen = OS::get_singleton()->get_current_screen();
+	} else if (screen == 1) {
+		// Previous monitor (wrap to the other end if needed)
+		screen = Math::wrapi(
+				OS::get_singleton()->get_current_screen() - 1,
+				0,
+				OS::get_singleton()->get_screen_count());
+	} else if (screen == 2) {
+		// Next monitor (wrap to the other end if needed)
+		screen = Math::wrapi(
+				OS::get_singleton()->get_current_screen() + 1,
+				0,
+				OS::get_singleton()->get_screen_count());
 	} else {
-		screen--;
+		// Fixed monitor ID
+		// There are 3 special options, so decrement the option ID by 3 to get the monitor ID
+		screen -= 3;
 	}
 
 	if (OS::get_singleton()->is_disable_crash_handler()) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -492,7 +492,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	_initial_set("run/window_placement/rect", 1);
 	hints["run/window_placement/rect"] = PropertyInfo(Variant::INT, "run/window_placement/rect", PROPERTY_HINT_ENUM, "Top Left,Centered,Custom Position,Force Maximized,Force Fullscreen");
-	String screen_hints = TTR("Default (Same as Editor)");
+	String screen_hints = "Same as Editor,Previous Monitor,Next Monitor";
 	for (int i = 0; i < OS::get_singleton()->get_screen_count(); i++) {
 		screen_hints += ",Monitor " + itos(i + 1);
 	}


### PR DESCRIPTION
It is now possible to use the monitor on the left or on the right of the editor to display running projects. If either the left or right end is reached, it will wrap around to the last or first monitor (respectively).

It looks like `TTR()` calls are not functional when used in setting hints (I tested it by setting the editor language to French, which translates the string mentioned), so I removed it in the setting hint.

This closes #20283.