### PR TITLE
Fixed !is_inside_tree() errors in file dialog

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -582,7 +582,8 @@ void FileDialog::set_current_file(const String &p_file) {
 	int lp = p_file.find_last(".");
 	if (lp != -1) {
 		file->select(0, lp);
-		file->grab_focus();
+		if (file->is_inside_tree())
+			file->grab_focus();
 	}
 }
 void FileDialog::set_current_path(const String &p_path) {


### PR DESCRIPTION
Fixed !is_inside_tree() errors appearing when current_file has a . in it.

This fixes #18631