### PR TITLE
Set the default DynamicFont size to 16

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -1036,6 +1036,7 @@ SelfList<DynamicFont>::List DynamicFont::dynamic_fonts;
 DynamicFont::DynamicFont() :
 		font_list(this) {
 
+	set_size(16);
 	spacing_top = 0;
 	spacing_bottom = 0;
 	spacing_char = 0;


### PR DESCRIPTION
This makes it possible to view newly-created DynamicFonts once a font has been assigned to them, without having to change their size by hand after creating them.

**Note:** I don't know if that's the proper way to set the font size from the constructor, but it seems to work well without causing side-effects in existing projects.

**Preview:**

![dynamicfont_default_size](https://user-images.githubusercontent.com/180032/44303646-66a61a00-a346-11e8-88ed-851221e72587.png)
