### PR TITLE
Find in Files improvements

### DIFF
--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -131,7 +131,8 @@ private:
 };
 
 class Button;
-class ItemList;
+class Tree;
+class TreeItem;
 class ProgressBar;
 
 // Display search results
@@ -159,22 +160,37 @@ private:
 	void _on_result_found(String fpath, int line_number, int begin, int end, String text);
 	void _on_finished();
 	void _on_cancel_button_clicked();
-	void _on_result_selected(int i);
+	void _on_result_selected();
+	void _on_item_edited();
 	void _on_replace_text_changed(String text);
 	void _on_replace_all_clicked();
 
-	void apply_replaces_in_file(String fpath, PoolIntArray locations, String text);
+	struct Result {
+		int line_number;
+		int begin;
+		int end;
+		float draw_begin;
+		float draw_width;
+	};
 
+	void apply_replaces_in_file(String fpath, const Vector<Result> &locations, String new_text);
 	void update_replace_buttons();
 	String get_replace_text();
+
+	void draw_result_text(Object *item_obj, Rect2 rect);
+
 	void set_progress_visible(bool visible);
+	void clear();
 
 	FindInFiles *_finder;
 	Label *_search_text_label;
-	ItemList *_results_display;
+	Tree *_results_display;
 	Label *_status_label;
 	Button *_cancel_button;
 	ProgressBar *_progress_bar;
+	Map<String, TreeItem *> _file_items;
+	Map<TreeItem *, Result> _result_items;
+	bool _with_replace;
 
 	HBoxContainer *_replace_container;
 	LineEdit *_replace_line_edit;


### PR DESCRIPTION
- Search results are now grouped by file using a Tree control
- You can opt out occurences when using replace mode
- Double-check search results in case files have been tampered with, so occurrences don't get badly replaced
- Fixed replace bug when an occurrence is found twice in one line
- Matches are highlighted within the results

Some annoying things:
- Open scripts used to update after a replace operation, but currently they don't, even though Find in Files emits a signal to force the script editor to update.
- I used `_results_display->add_font_override("font", get_font("source", "EditorFonts"));` to use a monospace font in the search results, but it didn't have any effect
- I would like to put the checkboxes on the left for better UX given the length of the panel, but I didn't find an option to do so (however I'm experimenting the use of `CELL_MODE_CHECK` with an extra column)

![image](https://user-images.githubusercontent.com/1311555/44304024-97874e80-a348-11e8-85f4-8108192ed274.png)

