### PR TITLE
Support higher-quality S3TC compression modes

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1685,7 +1685,7 @@ Error Image::compress(CompressMode p_mode, CompressSource p_source, float p_loss
 		case COMPRESS_S3TC: {
 
 			ERR_FAIL_COND_V(!_image_compress_bc_func, ERR_UNAVAILABLE);
-			_image_compress_bc_func(this, p_source);
+			_image_compress_bc_func(this, p_lossy_quality, p_source);
 		} break;
 		case COMPRESS_PVRTC2: {
 
@@ -2048,7 +2048,7 @@ ImageMemLoadFunc Image::_png_mem_loader_func = NULL;
 ImageMemLoadFunc Image::_jpg_mem_loader_func = NULL;
 ImageMemLoadFunc Image::_webp_mem_loader_func = NULL;
 
-void (*Image::_image_compress_bc_func)(Image *, Image::CompressSource) = NULL;
+void (*Image::_image_compress_bc_func)(Image *, float, Image::CompressSource) = NULL;
 void (*Image::_image_compress_bptc_func)(Image *, float, Image::CompressSource) = NULL;
 void (*Image::_image_compress_pvrtc2_func)(Image *) = NULL;
 void (*Image::_image_compress_pvrtc4_func)(Image *) = NULL;
@@ -2569,7 +2569,7 @@ void Image::_bind_methods() {
 	BIND_ENUM_CONSTANT(COMPRESS_SOURCE_NORMAL);
 }
 
-void Image::set_compress_bc_func(void (*p_compress_func)(Image *, CompressSource)) {
+void Image::set_compress_bc_func(void (*p_compress_func)(Image *, float, CompressSource)) {
 
 	_image_compress_bc_func = p_compress_func;
 }

--- a/core/image.h
+++ b/core/image.h
@@ -126,7 +126,7 @@ public:
 	static ImageMemLoadFunc _jpg_mem_loader_func;
 	static ImageMemLoadFunc _webp_mem_loader_func;
 
-	static void (*_image_compress_bc_func)(Image *, CompressSource p_source);
+	static void (*_image_compress_bc_func)(Image *, float, CompressSource p_source);
 	static void (*_image_compress_bptc_func)(Image *, float p_lossy_quality, CompressSource p_source);
 	static void (*_image_compress_pvrtc2_func)(Image *);
 	static void (*_image_compress_pvrtc4_func)(Image *);
@@ -316,7 +316,7 @@ public:
 	Rect2 get_used_rect() const;
 	Ref<Image> get_rect(const Rect2 &p_area) const;
 
-	static void set_compress_bc_func(void (*p_compress_func)(Image *, CompressSource));
+	static void set_compress_bc_func(void (*p_compress_func)(Image *, float, CompressSource));
 	static void set_compress_bptc_func(void (*p_compress_func)(Image *, float, CompressSource));
 	static String get_format_name(Format p_format);
 

--- a/modules/squish/image_compress_squish.cpp
+++ b/modules/squish/image_compress_squish.cpp
@@ -75,7 +75,7 @@ void image_decompress_squish(Image *p_image) {
 	p_image->create(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
 }
 
-void image_compress_squish(Image *p_image, Image::CompressSource p_source) {
+void image_compress_squish(Image *p_image, float p_lossy_quality, Image::CompressSource p_source) {
 
 	if (p_image->get_format() >= Image::FORMAT_DXT1)
 		return; //do not compress, already compressed
@@ -86,6 +86,12 @@ void image_compress_squish(Image *p_image, Image::CompressSource p_source) {
 	if (p_image->get_format() <= Image::FORMAT_RGBA8) {
 
 		int squish_comp = squish::kColourRangeFit;
+
+		if (p_lossy_quality > 0.85)
+			squish_comp = squish::kColourIterativeClusterFit;
+		else if (p_lossy_quality > 0.75)
+			squish_comp = squish::kColourClusterFit;
+
 		Image::Format target_format = Image::FORMAT_RGBA8;
 
 		Image::DetectChannels dc = p_image->get_detected_channels();

--- a/modules/squish/image_compress_squish.h
+++ b/modules/squish/image_compress_squish.h
@@ -33,7 +33,7 @@
 
 #include "image.h"
 
-void image_compress_squish(Image *p_image, Image::CompressSource p_source);
+void image_compress_squish(Image *p_image, float p_lossy_quality, Image::CompressSource p_source);
 void image_decompress_squish(Image *p_image);
 
 #endif // IMAGE_COMPRESS_SQUISH_H


### PR DESCRIPTION
Switches Squish compression mode to cluster fit at >0.75 and iterative cluster fit at >0.85 lossy quality.  Both get substantially better quality than range fit.