### PR TITLE
Add own world flag to CanvasLayer

### DIFF
--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -20,6 +20,13 @@
 				Returns the RID of the canvas used by this layer.
 			</description>
 		</method>
+		<method name="get_world_2d" qualifiers="const">
+			<return type="World2D">
+			</return>
+			<description>
+				Returns the own [code]World2D[/code] used by this layer if [code]own_world[/code] is set or [code]null[/code] otherwise.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="custom_viewport" type="Node" setter="set_custom_viewport" getter="get_custom_viewport">
@@ -30,6 +37,9 @@
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset">
 			The layer's base offset.
+		</member>
+		<member name="own_world" type="bool" setter="set_use_own_world" getter="is_using_own_world">
+			Whether this layer uses its own [code]World2D[/code]; i.e. if this layer has a separate physics space.
 		</member>
 		<member name="rotation" type="float" setter="set_rotation" getter="get_rotation">
 			The layer's rotation in radians.

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -886,6 +886,10 @@ Ref<World2D> CanvasItem::get_world_2d() const {
 
 	ERR_FAIL_COND_V(!is_inside_tree(), Ref<World2D>());
 
+	if (canvas_layer && canvas_layer->is_using_own_world()) {
+		return canvas_layer->get_world_2d();
+	}
+
 	CanvasItem *tl = get_toplevel();
 
 	if (tl->get_viewport()) {

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -45,6 +45,7 @@ class CanvasLayer : public Node {
 	real_t rot;
 	int layer;
 	Transform2D transform;
+	Ref<World2D> own_world;
 	RID canvas;
 
 	ObjectID custom_viewport_id; // to check validity
@@ -57,6 +58,9 @@ class CanvasLayer : public Node {
 
 	void _update_xform();
 	void _update_locrotscale();
+
+	void _attach_to_viewport();
+	void _detach_from_viewport();
 
 protected:
 	void _notification(int p_what);
@@ -88,9 +92,13 @@ public:
 	void set_custom_viewport(Node *p_viewport);
 	Node *get_custom_viewport() const;
 
+	void set_use_own_world(bool p_enable);
+	bool is_using_own_world() const;
+
 	void reset_sort_index();
 	int get_sort_index();
 
+	Ref<World2D> get_world_2d() const;
 	RID get_canvas() const;
 
 	CanvasLayer();

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -350,12 +350,12 @@ void World2D::_update() {
 	indexer->_update();
 }
 
-RID World2D::get_canvas() {
+RID World2D::get_canvas() const {
 
 	return canvas;
 }
 
-RID World2D::get_space() {
+RID World2D::get_space() const {
 
 	return space;
 }

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -64,8 +64,8 @@ protected:
 	void _update();
 
 public:
-	RID get_canvas();
-	RID get_space();
+	RID get_canvas() const;
+	RID get_space() const;
 
 	Physics2DDirectSpaceState *get_direct_space_state();
 


### PR DESCRIPTION
It all began with 9e7cee2ceb1a963c1da2c21013adf7d616412d3c, by which `CanvasLayer`s stopped having their own `World2D`.

Although that change was good, it broke compatibility with 3.0.

This PR keeps the spirit of that change by keeping the `CanvasLayer`'s ability to manage its own canvas `RID`, but adds a boolean property (`own_world`) that switches it to the "classic" behavior of having its own `World2D`. That way, a `World2D` object is only created if needed, while creating no more than a canvas if it's to share the physics space of its `Viewport`.

To be clearer, from the user standpoint:
- **`own_world = true` (default, to keep 3.0 behavior)**
2D physics objects descendant of the `CanvasLayer` will live in a separate space and they will be not pickable and won't interact with objects in other `CanvasLayer`s.
- **`own_world = false` (new desired behavior)**
The `CanvasLayer` won't have its own space, so physics descendants will be pickable and will interact with all objects in the same viewport.

In future Godot versions where compatibility can be safely broken the default state can be `false` or even the flag removed altogether keeping the behavior of the `own_world = false` case.

**EDIT:** No cherry-pick needed, a separate PR for 3.0 will contain this.

This code is donated by an anonymous party.