### PR TITLE
Highlight multiline strings as strings instead of comments

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -46,12 +46,12 @@
 void GDScriptLanguage::get_comment_delimiters(List<String> *p_delimiters) const {
 
 	p_delimiters->push_back("#");
-	p_delimiters->push_back("\"\"\" \"\"\"");
 }
 void GDScriptLanguage::get_string_delimiters(List<String> *p_delimiters) const {
 
 	p_delimiters->push_back("\" \"");
 	p_delimiters->push_back("' '");
+	p_delimiters->push_back("\"\"\" \"\"\"");
 }
 Ref<Script> GDScriptLanguage::get_template(const String &p_class_name, const String &p_base_class_name) const {
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Since multiline comments are not officially supported in GDScript, it is more common to see multiline strings being used as strings rather than as comments (which are actually standalone expressions here).

This closes #21142.