### PR TITLE
Fix crash when setting Material's next pass to itself

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -34,6 +34,8 @@
 
 void Material::set_next_pass(const Ref<Material> &p_pass) {
 
+	ERR_FAIL_COND(p_pass == this);
+
 	if (next_pass == p_pass)
 		return;
 


### PR DESCRIPTION
Fix #19672