### PR TITLE
Add Pause property to particles

### DIFF
--- a/doc/classes/CPUParticles.xml
+++ b/doc/classes/CPUParticles.xml
@@ -79,6 +79,9 @@
 		</member>
 		<member name="emitting" type="bool" setter="set_emitting" getter="is_emitting">
 		</member>
+		<member name="pause" type="bool" setter="set_pause" getter="is_paused">
+			If [code]true[/code] particles are paused (no more movements). Default value: [code]false[/code].
+		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio">
 		</member>
 		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps">

--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -51,6 +51,9 @@
 		<member name="emitting" type="bool" setter="set_emitting" getter="is_emitting">
 			If [code]true[/code] particles are being emitted. Default value: [code]true[/code].
 		</member>
+		<member name="pause" type="bool" setter="set_pause" getter="is_paused">
+			If [code]true[/code] particles are paused (no more movements). Default value: [code]false[/code].
+		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio">
 			Time ratio between each emission. If [code]0[/code] particles are emitted continuously. If [code]1[/code] all particles are emitted simultaneously. Default value: [code]0[/code].
 		</member>

--- a/doc/classes/Particles2D.xml
+++ b/doc/classes/Particles2D.xml
@@ -35,6 +35,9 @@
 		<member name="emitting" type="bool" setter="set_emitting" getter="is_emitting">
 			If [code]true[/code] particles are being emitted. Default value: [code]true[/code].
 		</member>
+		<member name="pause" type="bool" setter="set_pause" getter="is_paused">
+			If [code]true[/code] particles are paused (no more movements). Default value: [code]false[/code].
+		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio">
 			How rapidly particles in an emission cycle are emitted. If greater than [code]0[/code], there will be a gap in emissions before the next cycle begins. Default value: [code]0[/code].
 		</member>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -660,6 +660,7 @@ public:
 	RID particles_create() { return RID(); }
 
 	void particles_set_emitting(RID p_particles, bool p_emitting) {}
+	void particles_set_pause(RID p_particles, bool p_pause) {}
 	void particles_set_amount(RID p_particles, int p_amount) {}
 	void particles_set_lifetime(RID p_particles, float p_lifetime) {}
 	void particles_set_one_shot(RID p_particles, bool p_one_shot) {}
@@ -686,6 +687,7 @@ public:
 	void particles_set_emission_transform(RID p_particles, const Transform &p_transform) {}
 
 	bool particles_get_emitting(RID p_particles) { return false; }
+	bool particles_get_pause(RID p_pause) { return false; }
 	int particles_get_draw_passes(RID p_particles) const { return 0; }
 	RID particles_get_draw_pass_mesh(RID p_particles, int p_pass) const { return RID(); }
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -3502,7 +3502,14 @@ RID RasterizerStorageGLES2::particles_create() {
 void RasterizerStorageGLES2::particles_set_emitting(RID p_particles, bool p_emitting) {
 }
 
+void RasterizerStorageGLES2::particles_set_pause(RID p_particles, bool p_pause) {
+}
+
 bool RasterizerStorageGLES2::particles_get_emitting(RID p_particles) {
+	return false;
+}
+
+bool RasterizerStorageGLES2::particles_get_pause(RID p_particles) {
 	return false;
 }
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1036,7 +1036,9 @@ public:
 	virtual RID particles_create();
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting);
+	virtual void particles_set_pause(RID p_particles, bool p_pause);
 	virtual bool particles_get_emitting(RID p_particles);
+	virtual bool particles_get_pause(RID p_particles);
 
 	virtual void particles_set_amount(RID p_particles, int p_amount);
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5749,6 +5749,20 @@ bool RasterizerStorageGLES3::particles_get_emitting(RID p_particles) {
 	return particles->emitting;
 }
 
+void RasterizerStorageGLES3::particles_set_pause(RID p_particles, bool p_pause) {
+
+	Particles *particles = particles_owner.getornull(p_particles);
+	ERR_FAIL_COND(!particles);
+	particles->pause = p_pause;
+}
+
+bool RasterizerStorageGLES3::particles_get_pause(RID p_particles) {
+	Particles *particles = particles_owner.getornull(p_particles);
+	ERR_FAIL_COND_V(!particles, false);
+
+	return particles->pause;
+}
+
 void RasterizerStorageGLES3::particles_set_amount(RID p_particles, int p_amount) {
 
 	Particles *particles = particles_owner.getornull(p_particles);
@@ -6116,6 +6130,11 @@ void RasterizerStorageGLES3::update_particles() {
 		//use transform feedback to process particles
 
 		Particles *particles = particle_update_list.first()->self();
+
+		if (particles->pause) {
+			particle_update_list.remove(particle_update_list.first());
+			continue;
+		}
 
 		if (particles->restart_request) {
 			particles->emitting = true; //restart from zero

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1131,6 +1131,7 @@ public:
 		bool inactive;
 		float inactive_time;
 		bool emitting;
+		bool pause;
 		bool one_shot;
 		int amount;
 		float lifetime;
@@ -1230,6 +1231,8 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting);
 	virtual bool particles_get_emitting(RID p_particles);
+	virtual void particles_set_pause(RID p_particles, bool p_emitting);
+	virtual bool particles_get_pause(RID p_particles);
 	virtual void particles_set_amount(RID p_particles, int p_amount);
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime);
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot);

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -39,6 +39,11 @@ void Particles2D::set_emitting(bool p_emitting) {
 	VS::get_singleton()->particles_set_emitting(particles, p_emitting);
 }
 
+void Particles2D::set_pause(bool p_pause) {
+
+	VS::get_singleton()->particles_set_pause(particles, p_pause);
+}
+
 void Particles2D::set_amount(int p_amount) {
 
 	ERR_FAIL_COND(p_amount < 1);
@@ -135,6 +140,10 @@ void Particles2D::set_speed_scale(float p_scale) {
 bool Particles2D::is_emitting() const {
 
 	return VS::get_singleton()->particles_get_emitting(particles);
+}
+bool Particles2D::is_paused() const {
+
+	return VS::get_singleton()->particles_get_pause(particles);
 }
 int Particles2D::get_amount() const {
 
@@ -320,6 +329,7 @@ void Particles2D::_notification(int p_what) {
 void Particles2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &Particles2D::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_pause", "pause"), &Particles2D::set_pause);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &Particles2D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &Particles2D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "secs"), &Particles2D::set_one_shot);
@@ -334,6 +344,7 @@ void Particles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &Particles2D::set_speed_scale);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &Particles2D::is_emitting);
+	ClassDB::bind_method(D_METHOD("is_paused"), &Particles2D::is_paused);
 	ClassDB::bind_method(D_METHOD("get_amount"), &Particles2D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &Particles2D::get_lifetime);
 	ClassDB::bind_method(D_METHOD("get_one_shot"), &Particles2D::get_one_shot);
@@ -367,6 +378,7 @@ void Particles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart"), &Particles2D::restart);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pause"), "set_pause", "is_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_EXP_RANGE, "1,1000000,1"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lifetime", PROPERTY_HINT_RANGE, "0.01,600.0,0.01,or_greater"), "set_lifetime", "get_lifetime");

--- a/scene/2d/particles_2d.h
+++ b/scene/2d/particles_2d.h
@@ -78,6 +78,7 @@ protected:
 
 public:
 	void set_emitting(bool p_emitting);
+	void set_pause(bool p_pause);
 	void set_amount(int p_amount);
 	void set_lifetime(float p_lifetime);
 	void set_one_shot(bool p_enable);
@@ -90,6 +91,7 @@ public:
 	void set_speed_scale(float p_scale);
 
 	bool is_emitting() const;
+	bool is_paused() const;
 	int get_amount() const;
 	float get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/3d/cpu_particles.h
+++ b/scene/3d/cpu_particles.h
@@ -55,6 +55,7 @@ public:
 
 private:
 	bool emitting;
+	bool pause;
 
 	struct Particle {
 		Transform transform;
@@ -159,6 +160,7 @@ public:
 	PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;
 
 	void set_emitting(bool p_emitting);
+	void set_pause(bool p_pause);
 	void set_amount(int p_amount);
 	void set_lifetime(float p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -170,6 +172,7 @@ public:
 	void set_speed_scale(float p_scale);
 
 	bool is_emitting() const;
+	bool is_paused() const;
 	int get_amount() const;
 	float get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -46,6 +46,11 @@ void Particles::set_emitting(bool p_emitting) {
 	VS::get_singleton()->particles_set_emitting(particles, p_emitting);
 }
 
+void Particles::set_pause(bool p_pause) {
+
+	VS::get_singleton()->particles_set_pause(particles, p_pause);
+}
+
 void Particles::set_amount(int p_amount) {
 
 	ERR_FAIL_COND(p_amount < 1);
@@ -114,6 +119,10 @@ void Particles::set_speed_scale(float p_scale) {
 bool Particles::is_emitting() const {
 
 	return VS::get_singleton()->particles_get_emitting(particles);
+}
+bool Particles::is_paused() const {
+
+	return VS::get_singleton()->particles_get_pause(particles);
 }
 int Particles::get_amount() const {
 
@@ -283,6 +292,7 @@ void Particles::_notification(int p_what) {
 void Particles::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &Particles::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_pause", "pause"), &Particles::set_pause);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &Particles::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &Particles::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &Particles::set_one_shot);
@@ -297,6 +307,7 @@ void Particles::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &Particles::set_speed_scale);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &Particles::is_emitting);
+	ClassDB::bind_method(D_METHOD("is_paused"), &Particles::is_paused);
 	ClassDB::bind_method(D_METHOD("get_amount"), &Particles::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &Particles::get_lifetime);
 	ClassDB::bind_method(D_METHOD("get_one_shot"), &Particles::get_one_shot);
@@ -324,6 +335,7 @@ void Particles::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("capture_aabb"), &Particles::capture_aabb);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pause"), "set_pause", "is_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_EXP_RANGE, "1,1000000,1"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lifetime", PROPERTY_HINT_EXP_RANGE, "0.01,600.0,0.01"), "set_lifetime", "get_lifetime");
@@ -359,6 +371,7 @@ Particles::Particles() {
 	particles = VS::get_singleton()->particles_create();
 	set_base(particles);
 	set_emitting(true);
+	set_pause(false);
 	set_one_shot(false);
 	set_amount(8);
 	set_lifetime(1);

--- a/scene/3d/particles.h
+++ b/scene/3d/particles.h
@@ -86,6 +86,7 @@ public:
 	PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;
 
 	void set_emitting(bool p_emitting);
+	void set_pause(bool p_pause);
 	void set_amount(int p_amount);
 	void set_lifetime(float p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -98,6 +99,7 @@ public:
 	void set_speed_scale(float p_scale);
 
 	bool is_emitting() const;
+	bool is_paused() const;
 	int get_amount() const;
 	float get_lifetime() const;
 	bool get_one_shot() const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -503,6 +503,8 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) = 0;
 	virtual bool particles_get_emitting(RID p_particles) = 0;
+	virtual void particles_set_pause(RID p_particles, bool p_pause) = 0;
+	virtual bool particles_get_pause(RID p_particles) = 0;
 
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -398,6 +398,8 @@ public:
 
 	BIND2(particles_set_emitting, RID, bool)
 	BIND1R(bool, particles_get_emitting, RID)
+	BIND2(particles_set_pause, RID, bool)
+	BIND1R(bool, particles_get_pause, RID)
 	BIND2(particles_set_amount, RID, int)
 	BIND2(particles_set_lifetime, RID, float)
 	BIND2(particles_set_one_shot, RID, bool)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -329,7 +329,9 @@ public:
 	FUNCRID(particles)
 
 	FUNC2(particles_set_emitting, RID, bool)
+	FUNC2(particles_set_pause, RID, bool)
 	FUNC1R(bool, particles_get_emitting, RID)
+	FUNC1R(bool, particles_get_pause, RID)
 	FUNC2(particles_set_amount, RID, int)
 	FUNC2(particles_set_lifetime, RID, float)
 	FUNC2(particles_set_one_shot, RID, bool)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1840,6 +1840,8 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("particles_create"), &VisualServer::particles_create);
 	ClassDB::bind_method(D_METHOD("particles_set_emitting", "particles", "emitting"), &VisualServer::particles_set_emitting);
 	ClassDB::bind_method(D_METHOD("particles_get_emitting", "particles"), &VisualServer::particles_get_emitting);
+	ClassDB::bind_method(D_METHOD("particles_set_pause", "particles", "pause"), &VisualServer::particles_set_pause);
+	ClassDB::bind_method(D_METHOD("particles_get_pause", "particles"), &VisualServer::particles_get_pause);
 	ClassDB::bind_method(D_METHOD("particles_set_amount", "particles", "amount"), &VisualServer::particles_set_amount);
 	ClassDB::bind_method(D_METHOD("particles_set_lifetime", "particles", "lifetime"), &VisualServer::particles_set_lifetime);
 	ClassDB::bind_method(D_METHOD("particles_set_one_shot", "particles", "one_shot"), &VisualServer::particles_set_one_shot);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -547,6 +547,8 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) = 0;
 	virtual bool particles_get_emitting(RID p_particles) = 0;
+	virtual void particles_set_pause(RID p_particles, bool p_pause) = 0;
+	virtual bool particles_get_pause(RID p_particles) = 0;
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) = 0;


### PR DESCRIPTION
Hi,
This is just some fun I had with Particles3D, and thought it might be of use for some people.
It adds a "Pause" checkbox under "Emitting" in the particles properties. If activated, the particles is 'paused', it stops moving. When deactivated, the particles... well, restarts (obviously 😁 )
As for all other properties, "pause" can also be used in scripts.

I made it for Particles3D and 2D, and I also added it to CPUParticles, it works but I'm not sure if I did it right (I simply copied the "set_emitting" function and renamed it to suit my needs, but as CPUParticles are WIP it might not be a good thing). In fact I added it to CPUParticles mainly to have a good compilation 😆 

I also added a getter ("is_paused"), but I don't have a usecase for it... it's there if needed.

Here is a small project I used to test this. It contains 3 CPUParticles and 1 Particles3D emitting in front of a wall, and a moving omnilight is used to cast shadows onto the wall.
When run, you can use SpaceBar to show/hide a small GUI, and in this GUI there is a checkbutton to pause/unpause the particles. When the GUI is hidden, you can move in the scene using mouse + arrows.
[test_Particles3D.zip](https://github.com/godotengine/godot/files/2300509/test_Particles3D.zip)

To test the Particles2D, I just used the 2D Particles Demo.
