### PR TITLE
Bullet ray picking should ignore objects with input_ray_pickable=false

### DIFF
--- a/modules/bullet/godot_result_callbacks.cpp
+++ b/modules/bullet/godot_result_callbacks.cpp
@@ -51,8 +51,8 @@ bool GodotClosestRayResultCallback::needsCollision(btBroadphaseProxy *proxy0) co
 	if (needs) {
 		btCollisionObject *btObj = static_cast<btCollisionObject *>(proxy0->m_clientObject);
 		CollisionObjectBullet *gObj = static_cast<CollisionObjectBullet *>(btObj->getUserPointer());
-		if (m_pickRay && gObj->is_ray_pickable()) {
-			return true;
+		if (m_pickRay && !gObj->is_ray_pickable()) {
+			return false;
 		} else if (m_exclude->has(gObj->get_self())) {
 			return false;
 		}


### PR DESCRIPTION
This is a fix for https://github.com/godotengine/godot/issues/21194

You can see in the code that if `m_pickRay` is true, `gObj->is_ray_pickable()` is false, and `m_exclude->has(gObj->get_self())` is false then the function will return `true` which is not desired because `gObj->is_ray_pickable()` is false. 

Testing notes:
I recompiled the engine and ran the Picking Problem project posted in the task. All picks performed as expected. 