### PR TITLE
[Mono] Quat - add some missing constructors and methods

### DIFF
--- a/core/math/quat.cpp
+++ b/core/math/quat.cpp
@@ -134,7 +134,7 @@ Quat Quat::normalized() const {
 }
 
 bool Quat::is_normalized() const {
-	return Math::is_equal_approx(length(), 1.0);
+	return Math::is_equal_approx(length_squared(), 1.0);
 }
 
 Quat Quat::inverse() const {

--- a/modules/mono/glue/cs_files/Basis.cs
+++ b/modules/mono/glue/cs_files/Basis.cs
@@ -426,7 +426,7 @@ namespace Godot
 
         public Basis(Quat quat)
         {
-            real_t s = 2.0f / quat.LengthSquared();
+            real_t s = 2.0f / quat.LengthSquared;
 
             real_t xs = quat.x * s;
             real_t ys = quat.y * s;


### PR DESCRIPTION
~~change public fields `x`, `y`, `z`, `w` to auto-properties `X`, `Y`, `Z`, `W`~~
change functions `Length()` and `LengthSquared()` to properties of the same name  
change `Identity` property from using a backing field to having a direct initialiser  

new ~~property~~ function `IsNormalized()`  
new functions `GetEuler()`, `SetAxisAngle(Vector3 axis, real_t angle)` and `SetEuler(Vector3 eulerYXZ)`  
new constructors `Quat(Basis basis)`, `Quat(Vector3 eulerYXZ)`  
