### PR TITLE
make skeleton3d check inside tree when updating with global transform

### DIFF
--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -257,7 +257,11 @@ void Skeleton::_notification(int p_what) {
 				rest_global_inverse_dirty = false;
 			}
 
-			Transform global_transform = get_global_transform();
+			Transform global_transform;
+			// added in case the skeleton has exited the tree while an animation was still running
+			// and the message was still passed through. In other words, the skeleton may still have an
+			// animation running on a node while it is instanced but not within the tree.
+			if (is_inside_tree()) global_transform = get_global_transform();
 			Transform global_transform_inverse = global_transform.affine_inverse();
 
 			for (int i = 0; i < len; i++) {


### PR DESCRIPTION
Without fix: I have a sort of LOD logic where I switch two different nodes. A 3d mesh node with skeleton vs an imposter sprite node, based on camera distance logic.

I noticed the skeleton was logging warnings. I do try to stop the animations of the 3d mesh node instsance when it's removed as a child, but I'm guessing the message queue is firing a NOTIFICATION_UPDATE_SKELETON after the node was removed as a child (i.e. it only happens in the frame right after the child is removed, and it doesn't happen everytime). 

![godot2](https://user-images.githubusercontent.com/3332598/44317336-bea05780-a3fe-11e8-93ac-3104b1cebd63.gif)

After fix:
![godot1](https://user-images.githubusercontent.com/3332598/44317342-c5c76580-a3fe-11e8-8012-ff5cbeca160d.gif)



"why not just change visiblity of the nodes?" <- I get severe fps performance hit with all the full 3d mesh node.