### PR TITLE
Prevent "cannot use a string pattern on a bytes-like object"

### DIFF
--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -265,11 +265,13 @@ def pkgconfig_try_find_mono_root(mono_lib_names, sharedlib_ext):
 
 
 def pkgconfig_try_find_mono_version():
+    from compat import decode_utf8
+
     lines = subprocess.check_output(['pkg-config', 'monosgen-2', '--modversion']).splitlines()
     greater_version = None
     for line in lines:
         try:
-            version = LooseVersion(line)
+            version = LooseVersion(decode_utf8(line))
             if greater_version is None or version > greater_version:
                 greater_version = version
         except ValueError:


### PR DESCRIPTION
Fixes #21207