### PR TITLE
Port ImportDock and ProjectExport to new property editor (2nd try)

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -420,10 +420,9 @@ ImportDock::ImportDock() {
 	preset->get_popup()->connect("index_pressed", this, "_preset_selected");
 	hb->add_child(preset);
 
-	import_opts = memnew(PropertyEditor);
+	import_opts = memnew(EditorInspector);
 	add_child(import_opts);
 	import_opts->set_v_size_flags(SIZE_EXPAND_FILL);
-	import_opts->hide_top_label();
 
 	hb = memnew(HBoxContainer);
 	add_child(hb);

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -31,10 +31,12 @@
 #ifndef IMPORTDOCK_H
 #define IMPORTDOCK_H
 
-#include "editor_file_system.h"
-#include "io/resource_import.h"
-#include "property_editor.h"
+#include "core/io/config_file.h"
+#include "core/io/resource_import.h"
+#include "editor/editor_file_system.h"
+#include "editor/editor_inspector.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/popup_menu.h"
 
@@ -45,7 +47,7 @@ class ImportDock : public VBoxContainer {
 	Label *imported;
 	OptionButton *import_as;
 	MenuButton *preset;
-	PropertyEditor *import_opts;
+	EditorInspector *import_opts;
 
 	List<PropertyInfo> properties;
 	Map<StringName, Variant> property_values;

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "project_export.h"
+
 #include "compressed_translation.h"
 #include "editor_data.h"
 #include "editor_node.h"
@@ -389,7 +390,6 @@ void ProjectExportDialog::_patch_deleted() {
 void ProjectExportDialog::_update_parameters(const String &p_edited_property) {
 
 	_edit_preset(presets->get_current());
-	parameters->update_tree();
 }
 
 void ProjectExportDialog::_runnable_pressed() {
@@ -842,12 +842,10 @@ ProjectExportDialog::ProjectExportDialog() {
 	settings_vb->add_child(sections);
 	sections->set_v_size_flags(SIZE_EXPAND_FILL);
 
-	parameters = memnew(PropertyEditor);
+	parameters = memnew(EditorInspector);
 	sections->add_child(parameters);
 	parameters->set_name(TTR("Options"));
-	parameters->hide_top_label();
 	parameters->set_v_size_flags(SIZE_EXPAND_FILL);
-
 	parameters->connect("property_edited", this, "_update_parameters");
 
 	VBoxContainer *resources_vb = memnew(VBoxContainer);

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -31,25 +31,26 @@
 #ifndef PROJECT_EXPORT_SETTINGS_H
 #define PROJECT_EXPORT_SETTINGS_H
 
+#include "core/os/dir_access.h"
+#include "core/os/thread.h"
+#include "editor/editor_export.h"
 #include "editor/editor_file_dialog.h"
-#include "os/dir_access.h"
-#include "os/thread.h"
+#include "editor/editor_file_system.h"
+#include "editor/editor_inspector.h"
 #include "scene/gui/button.h"
+#include "scene/gui/check_button.h"
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/file_dialog.h"
 #include "scene/gui/label.h"
 #include "scene/gui/link_button.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/rich_text_label.h"
+#include "scene/gui/slider.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/tree.h"
 #include "scene/main/timer.h"
-
-#include "editor/editor_file_system.h"
-#include "editor_export.h"
-#include "property_editor.h"
-#include "scene/gui/slider.h"
 
 class EditorNode;
 
@@ -64,11 +65,8 @@ private:
 	ItemList *presets;
 
 	LineEdit *name;
-	PropertyEditor *parameters;
+	EditorInspector *parameters;
 	CheckButton *runnable;
-
-	//EditorFileDialog *pck_export;
-	//EditorFileDialog *file_export;
 
 	Button *button_export;
 	bool updating;


### PR DESCRIPTION
Thanks to @ibrahn for helping debug the crashes caused in ProjectExportDialog
by the stray `update_tree()` call, no longer needed in the new inspector.

Previous attempt (reverted due to crashes): #21146