### PR TITLE
Print error(instead crash) when set invalid pitch scale for AudioStreamPlayer2D/3D

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -296,6 +296,7 @@ float AudioStreamPlayer2D::get_volume_db() const {
 }
 
 void AudioStreamPlayer2D::set_pitch_scale(float p_pitch_scale) {
+	ERR_FAIL_COND(p_pitch_scale <= 0.0);
 	pitch_scale = p_pitch_scale;
 }
 float AudioStreamPlayer2D::get_pitch_scale() const {

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -626,6 +626,7 @@ float AudioStreamPlayer3D::get_max_db() const {
 }
 
 void AudioStreamPlayer3D::set_pitch_scale(float p_pitch_scale) {
+	ERR_FAIL_COND(p_pitch_scale <= 0.0);
 	pitch_scale = p_pitch_scale;
 }
 float AudioStreamPlayer3D::get_pitch_scale() const {

--- a/scene/audio/audio_player.cpp
+++ b/scene/audio/audio_player.cpp
@@ -192,6 +192,7 @@ float AudioStreamPlayer::get_volume_db() const {
 }
 
 void AudioStreamPlayer::set_pitch_scale(float p_pitch_scale) {
+	ERR_FAIL_COND(p_pitch_scale <= 0.0);
 	pitch_scale = p_pitch_scale;
 }
 float AudioStreamPlayer::get_pitch_scale() const {

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -305,9 +305,9 @@ Ref<AudioEffectInstance> AudioEffectPitchShift::instance() {
 	return ins;
 }
 
-void AudioEffectPitchShift::set_pitch_scale(float p_adjust) {
-
-	pitch_scale = p_adjust;
+void AudioEffectPitchShift::set_pitch_scale(float p_pitch_scale) {
+	ERR_FAIL_COND(p_pitch_scale <= 0.0);
+	pitch_scale = p_pitch_scale;
 }
 
 float AudioEffectPitchShift::get_pitch_scale() const {

--- a/servers/audio/effects/audio_effect_pitch_shift.h
+++ b/servers/audio/effects/audio_effect_pitch_shift.h
@@ -100,7 +100,7 @@ protected:
 public:
 	Ref<AudioEffectInstance> instance();
 
-	void set_pitch_scale(float p_adjust);
+	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
 
 	AudioEffectPitchShift();


### PR DESCRIPTION
Because @TiagoJoseMagalhaes does not have activity for a long period, and his PR is a bit not correct, I suggest my own fix for #20459 (also closes #20658). Without this fix setting pitch scale to value less than 0.01 cause editor crash. Now user will get an error message instead.

 I suppose clamping is not desired behavior in this case, other properties is follow that rule. Its better to be an error message, and user will clamp to it himself.