### PR TITLE
Remove a stray semicolon

### DIFF
--- a/editor/editor_plugin_settings.h
+++ b/editor/editor_plugin_settings.h
@@ -31,7 +31,7 @@
 #ifndef EDITORPLUGINSETTINGS_H
 #define EDITORPLUGINSETTINGS_H
 
-#include "editor/plugin_config_dialog.h";
+#include "editor/plugin_config_dialog.h"
 #include "editor_data.h"
 #include "property_editor.h"
 #include "scene/gui/dialogs.h"


### PR DESCRIPTION
This was causing a lot of compiler warnings for no good reason.