### PR TITLE
Check all selected items on OPEN_MANY/OPEN_FILES in FileDialog, also …

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -284,7 +284,13 @@ bool FileDialog::_is_open_should_be_disabled() {
 	if (mode == MODE_OPEN_ANY || mode == MODE_SAVE_FILE)
 		return false;
 
-	TreeItem *ti = tree->get_selected();
+	TreeItem *ti = tree->get_next_selected(tree->get_root());
+	while (ti) {
+		TreeItem *prev_ti = ti;
+		ti = tree->get_next_selected(tree->get_root());
+		if (ti == prev_ti)
+			break;
+	}
 	// We have something that we can't select?
 	if (!ti)
 		return mode != MODE_OPEN_DIR; // In "Open folder" mode, having nothing selected picks the current folder.
@@ -326,6 +332,10 @@ void FileDialog::deselect_items() {
 				break;
 		}
 	}
+}
+
+void FileDialog::_tree_multi_selected(Object *p_object, int p_cell, bool p_selected) {
+	_tree_selected();
 }
 
 void FileDialog::_tree_selected() {
@@ -753,6 +763,7 @@ void FileDialog::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_unhandled_input"), &FileDialog::_unhandled_input);
 
+	ClassDB::bind_method(D_METHOD("_tree_multi_selected"), &FileDialog::_tree_multi_selected);
 	ClassDB::bind_method(D_METHOD("_tree_selected"), &FileDialog::_tree_selected);
 	ClassDB::bind_method(D_METHOD("_tree_item_activated"), &FileDialog::_tree_item_activated);
 	ClassDB::bind_method(D_METHOD("_dir_entered"), &FileDialog::_dir_entered);
@@ -793,7 +804,7 @@ void FileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("invalidate"), &FileDialog::invalidate);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mode_overrides_title"), "set_mode_overrides_title", "is_mode_overriding_title");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Open one,Open many,Open folder,Open any,Save"), "set_mode", "get_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Open File,Open Files,Open Folder,Open Any,Save"), "set_mode", "get_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "access", PROPERTY_HINT_ENUM, "Resources,User data,File system"), "set_access", "get_access");
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_STRING_ARRAY, "filters"), "set_filters", "get_filters");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_hidden_files"), "set_show_hidden_files", "is_showing_hidden_files");
@@ -889,6 +900,7 @@ FileDialog::FileDialog() {
 	_update_drives();
 
 	connect("confirmed", this, "_action_pressed");
+	tree->connect("multi_selected", this, "_tree_multi_selected", varray(), CONNECT_DEFERRED);
 	tree->connect("cell_selected", this, "_tree_selected", varray(), CONNECT_DEFERRED);
 	tree->connect("item_activated", this, "_tree_item_activated", varray());
 	tree->connect("nothing_selected", this, "deselect_items");

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -104,6 +104,7 @@ private:
 	void update_file_list();
 	void update_filters();
 
+	void _tree_multi_selected(Object *p_object, int p_cell, bool p_selected);
 	void _tree_selected();
 
 	void _select_drive(int p_idx);


### PR DESCRIPTION
…changed confusing naming.

closes https://github.com/godotengine/godot/issues/20073

EDIT:
Any reason why "cell_selected" is used instead of "item_selected"?
Alternative: Remove "cell_selected" and use "multi_selected" only.
