### PR TITLE
fix Android/HTML5 custom templates option does not work

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1333,12 +1333,28 @@ public:
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {
 
+		String err;
 		r_missing_templates = find_export_template("android_debug.apk") == String() || find_export_template("android_release.apk") == String();
+
+		if (p_preset->get("custom_package/debug") != "") {
+			if (FileAccess::exists(p_preset->get("custom_package/debug"))) {
+				r_missing_templates = false;
+			} else {
+				err += "Custom debug package not found.\n";
+			}
+		}
+
+		if (p_preset->get("custom_package/release") != "") {
+			if (FileAccess::exists(p_preset->get("custom_package/release"))) {
+				r_missing_templates = false;
+			} else {
+				err += "Custom release package not found.\n";
+			}
+		}
 
 		bool valid = !r_missing_templates;
 
 		String adb = EditorSettings::get_singleton()->get("export/android/adb");
-		String err;
 
 		if (!FileAccess::exists(adb)) {
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -140,14 +140,35 @@ Ref<Texture> EditorExportPlatformJavaScript::get_logo() const {
 
 bool EditorExportPlatformJavaScript::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {
 
-	r_missing_templates = false;
+	bool valid = false;
+	String err;
 
-	if (find_export_template(EXPORT_TEMPLATE_WEBASSEMBLY_RELEASE) == String())
-		r_missing_templates = true;
-	else if (find_export_template(EXPORT_TEMPLATE_WEBASSEMBLY_DEBUG) == String())
-		r_missing_templates = true;
+	if (find_export_template(EXPORT_TEMPLATE_WEBASSEMBLY_RELEASE) != "")
+		valid = true;
+	else if (find_export_template(EXPORT_TEMPLATE_WEBASSEMBLY_DEBUG) != "")
+		valid = true;
 
-	return !r_missing_templates;
+	if (p_preset->get("custom_template/debug") != "") {
+		if (FileAccess::exists(p_preset->get("custom_template/debug"))) {
+			valid = true;
+		} else {
+			err += "Custom debug template not found.\n";
+		}
+	}
+
+	if (p_preset->get("custom_template/release") != "") {
+		if (FileAccess::exists(p_preset->get("custom_template/release"))) {
+			valid = true;
+		} else {
+			err += "Custom release template not found.\n";
+		}
+	}
+
+	if (!err.empty())
+		r_error = err;
+
+	r_missing_templates = !valid;
+	return valid;
 }
 
 String EditorExportPlatformJavaScript::get_binary_extension(const Ref<EditorExportPreset> &p_preset) const {


### PR DESCRIPTION
Fixes #17661, allowing to export projects for android and html even if the default export templates are missing, as long as you provide custom ones.