### PR TITLE
Try closing gracefully before terminating process

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -254,7 +254,7 @@ public:
 
 	virtual String get_executable_path() const;
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking, ProcessID *r_child_id = NULL, String *r_pipe = NULL, int *r_exitcode = NULL, bool read_stderr = false) = 0;
-	virtual Error kill(const ProcessID &p_pid) = 0;
+	virtual Error kill(const ProcessID &p_pid, const int p_max_wait_msec = -1) = 0;
 	virtual int get_process_id() const;
 
 	virtual Error shell_open(String p_uri);

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -329,7 +329,7 @@ Error OS_Unix::execute(const String &p_path, const List<String> &p_arguments, bo
 	return OK;
 }
 
-Error OS_Unix::kill(const ProcessID &p_pid) {
+Error OS_Unix::kill(const ProcessID &p_pid, const int p_max_wait_msec) {
 
 	int ret = ::kill(p_pid, SIGKILL);
 	if (!ret) {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -91,7 +91,7 @@ public:
 	virtual uint64_t get_ticks_usec() const;
 
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking, ProcessID *r_child_id = NULL, String *r_pipe = NULL, int *r_exitcode = NULL, bool read_stderr = false);
-	virtual Error kill(const ProcessID &p_pid);
+	virtual Error kill(const ProcessID &p_pid, const int p_max_wait_msec = -1);
 	virtual int get_process_id() const;
 
 	virtual bool has_environment(const String &p_var) const;

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -181,8 +181,8 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 void EditorRun::stop() {
 
 	if (status != STATUS_STOP && pid != 0) {
-
-		OS::get_singleton()->kill(pid);
+		const int max_wait_msec = GLOBAL_DEF("editor/stop_max_wait_msec", 10000);
+		OS::get_singleton()->kill(pid, max_wait_msec);
 	}
 
 	status = STATUS_STOP;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -258,7 +258,7 @@ public:
 	virtual uint64_t get_ticks_usec() const;
 
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking, ProcessID *r_child_id = NULL, String *r_pipe = NULL, int *r_exitcode = NULL, bool read_stderr = false);
-	virtual Error kill(const ProcessID &p_pid);
+	virtual Error kill(const ProcessID &p_pid, const int p_stop_max_wait_msec = -1);
 	virtual int get_process_id() const;
 
 	virtual bool has_environment(const String &p_var) const;


### PR DESCRIPTION
Use a Microsoft recommended way of process termination for the project
process run from the editor. This allows loaded DLLs to receive and handle
DLL_PROCESS_DETACH notification and cleanup any global state before the
process actually exits.