### PR TITLE
Fix occasional crash when downloading assets from the Asset Library

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -421,7 +421,16 @@ void EditorAssetLibraryItemDownload::_notification(int p_what) {
 		int cstatus = download->get_http_client_status();
 
 		if (cstatus == HTTPClient::STATUS_BODY) {
-			status->set_text(vformat(TTR("Downloading (%s / %s)..."), String::humanize_size(download->get_downloaded_bytes()), String::humanize_size(download->get_body_size())));
+			if (download->get_body_size() > 0) {
+				status->set_text(
+						vformat(
+								TTR("Downloading (%s / %s)..."),
+								String::humanize_size(download->get_downloaded_bytes()),
+								String::humanize_size(download->get_body_size())));
+			} else {
+				// Total file size is unknown, so it cannot be displayed
+				status->set_text(TTR("Downloading..."));
+			}
 		}
 
 		if (cstatus != prev_status) {


### PR DESCRIPTION
This is caused by GitHub not publishing a Content-Length header in all cases (it only does so if the file was requested recently), which in turn made `String.humanize_size()` try to humanize a size of -1 byte (as returned by HTTPRequest when no Content-Length is contained in the response). This crashed the editor due to a division by zero.

For some reason, HTTPRequest always returns 0 bytes downloaded if the body size isn't known (even though the download is successful). Therefore, I also hid the number of downloaded bytes if the total file size is unknown. This may hint at a bug in HTTPRequest, which should be fixed separately.

This closes #21200.