### PR TITLE
Reset reason text when no longer connected

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1240,6 +1240,9 @@ void ScriptEditorDebugger::stop() {
 	if (connection.is_valid()) {
 		EditorNode::get_log()->add_message("** Debug Process Stopped **");
 		connection.unref();
+
+		reason->set_text("");
+		reason->set_tooltip("");
 	}
 
 	pending_in_queue = 0;


### PR DESCRIPTION
Resets the "Child Process Connected" when the child process is no longer
connected.

![image](https://user-images.githubusercontent.com/447143/44360634-b6f2b880-a4bb-11e8-940a-8b3b96244043.png)

becomes this (after the process is disconnected):

![image](https://user-images.githubusercontent.com/447143/44360684-e0134900-a4bb-11e8-8f95-474bf4ec9ab9.png)