### PR TITLE
Remove circle/diamond String constants

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1925,18 +1925,6 @@ void register_variant_methods() {
 	_VariantCall::add_variant_constant(Variant::PLANE, "Z", Plane(Vector3(0, 0, 1), 0));
 
 	_VariantCall::add_variant_constant(Variant::QUAT, "IDENTITY", Quat(0, 0, 0, 1));
-
-	CharType black_circle[2] = { 0x25CF, 0 };
-	_VariantCall::add_variant_constant(Variant::STRING, "BLACK_CIRCLE", String(black_circle));
-	CharType white_circle[2] = { 0x25CB, 0 };
-	_VariantCall::add_variant_constant(Variant::STRING, "WHITE_CIRCLE", String(white_circle));
-	CharType black_diamond[2] = { 0x25C6, 0 };
-	_VariantCall::add_variant_constant(Variant::STRING, "BLACK_DIAMOND", String(black_diamond));
-	CharType white_diamond[2] = { 0x25C7, 0 };
-	_VariantCall::add_variant_constant(Variant::STRING, "WHITE_DIAMOND", String(white_diamond));
-
-	_VariantCall::add_variant_constant(Variant::NODE_PATH, "CURRENT", String("."));
-	_VariantCall::add_variant_constant(Variant::NODE_PATH, "PARENT", String(".."));
 }
 
 void unregister_variant_methods() {


### PR DESCRIPTION
They were introduced in #14704 but need more discussion IMO, they don't strike me as core features that would have to be registered in Variant directly.

What was approved in #14704 was mostly the way the new built-in constants were implemented, but the actual list of constants was not thoroughly reviewed. I'm not against adding constants to String but those 4 seem quite arbitrary to me, and set a precedent for "please add a constant for \<insert favourite Unicode emoji here\>" feature requests.