### PR TITLE
== and != operators for Ref<T> / T*

### DIFF
--- a/core/reference.h
+++ b/core/reference.h
@@ -87,6 +87,13 @@ class Ref {
 
 	//virtual Reference * get_reference() const { return reference; }
 public:
+	_FORCE_INLINE_ bool operator==(const T *p_ptr) const {
+		return reference == p_ptr;
+	}
+	_FORCE_INLINE_ bool operator!=(const T *p_ptr) const {
+		return reference != p_ptr;
+	}
+
 	_FORCE_INLINE_ bool operator<(const Ref<T> &p_r) const {
 
 		return reference < p_r.reference;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -34,7 +34,7 @@
 
 void Material::set_next_pass(const Ref<Material> &p_pass) {
 
-	ERR_FAIL_COND(p_pass.ptr() == this);
+	ERR_FAIL_COND(p_pass == this);
 
 	if (next_pass == p_pass)
 		return;


### PR DESCRIPTION
This is to prevent crashes for code like:

````
void Material::set_next_pass(const Ref<Material> &p_pass) {

	ERR_FAIL_COND(p_pass == this);
````

that's been fixed in 031f763d4fda4e0dbcdf90a170aad3124c50c062