### PR TITLE
Rename Plane constants, add to Mono

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1920,9 +1920,9 @@ void register_variant_methods() {
 	transform_x.set(1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0);
 	_VariantCall::add_variant_constant(Variant::TRANSFORM, "FLIP_Z", transform_z);
 
-	_VariantCall::add_variant_constant(Variant::PLANE, "X", Plane(Vector3(1, 0, 0), 0));
-	_VariantCall::add_variant_constant(Variant::PLANE, "Y", Plane(Vector3(0, 1, 0), 0));
-	_VariantCall::add_variant_constant(Variant::PLANE, "Z", Plane(Vector3(0, 0, 1), 0));
+	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_YZ", Plane(Vector3(1, 0, 0), 0));
+	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XZ", Plane(Vector3(0, 1, 0), 0));
+	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XY", Plane(Vector3(0, 0, 1), 0));
 
 	_VariantCall::add_variant_constant(Variant::QUAT, "IDENTITY", Quat(0, 0, 0, 1));
 

--- a/modules/mono/glue/cs_files/Plane.cs
+++ b/modules/mono/glue/cs_files/Plane.cs
@@ -145,6 +145,15 @@ namespace Godot
             return point - _normal * DistanceTo(point);
         }
         
+        // Constants
+        private static readonly Plane _planeYZ = new Plane(1, 0, 0, 0);
+        private static readonly Plane _planeXZ = new Plane(0, 1, 0, 0);
+        private static readonly Plane _planeXY = new Plane(0, 0, 1, 0);
+
+        public static Plane PlaneYZ { get { return _planeYZ; } }
+        public static Plane PlaneXZ { get { return _planeXZ; } }
+        public static Plane PlaneXY { get { return _planeXY; } }
+        
         // Constructors 
         public Plane(real_t a, real_t b, real_t c, real_t d)
         {


### PR DESCRIPTION
Rename Plane constants to `PLANE_YZ`, `PLANE_XZ`, and `PLANE_XY`, and add C# constants  `PlaneYZ` etc. For discussion on other constants, see https://github.com/godotengine/godot/pull/21248