### PR TITLE
CI: Disable debug_symbols on Travis/AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ environment:
   HOME: "%HOMEDRIVE%%HOMEPATH%"
   PYTHON: C:\Python27
   SCONS_CACHE_ROOT: "%HOME%\\scons_cache"
-  SCONS_CACHE_LIMIT: 512
+  SCONS_CACHE_LIMIT: 1024
   matrix:
     - VS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
       GD_PLATFORM: windows
@@ -29,4 +29,4 @@ before_build:
   - SET "SCONS_CACHE=%SCONS_CACHE_ROOT%\master"
 
 build_script:
-- scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% verbose=yes progress=no gdnative_wrapper=yes
+- scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% debug_symbols=no verbose=yes progress=no gdnative_wrapper=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - SCONS_CACHE=$HOME/.scons_cache
     - SCONS_CACHE_LIMIT=1024
-    - OPTIONS="verbose=yes progress=no gdnative_wrapper=yes"
+    - OPTIONS="debug_symbols=no verbose=yes progress=no gdnative_wrapper=yes"
     - secure: "QLFRizqry/Y5pnEZvDlQz5S3YydQ+600u4rHEzFgUTd0heYeQaETXAQeMzp0ymuG1BkdRAl5YJoLVJgAzjwI9hrvugvoUlh2//SfpqZCHN/Q1fYbtGgNTn01R3VFEpcfYQL93I2EjrxVm0WTM4PwCvMO+hU0aWTRDvCt1Lty0kMR+RMDQOO/woqunoXh5wvFNxTJJkAmuLe0v962DJYOIwJAnqMLR0aFYjmeQJ20bc/2X5oLt+WuJDuf/lGj6WSlD6z/o/kL3YxHoUyw4A/HAZ2IX0IfNHKuay60ESWzl/NlobnePiPwHAE2pdDVu//q16fanb9VeYnBYRFse49TpFRb86Lo+Qz8nKDJqpQEIY0YKNCFqekrubqTM++Lj6QvGpykQZNxUhybmELcEsRG4PS0UMvCpebdnJD46nNB+DtO2Lgb4xXDLQwpq19z1wizq/XDQ5hz61TIIx8+i8TsgdSQKCTeWovd4HcD4CVjAD5XTLGgyRmI/zC2d+lTnKo6W9diLq/bX/Goq2QPeaTPABqv817IaJka2JyugQ7Qal/+gNTjYRRsimRCL9B2tVh+Uh8rWhTFhQL4QbP5P65HF+p8qojUzqtAhPMbZ8mxUtNukUI3liVgPgiMss96sG0nTVglFgkkAkEjIMFnqMSKnTfG812K4jIhp2jCO2Q3NeI="
 
 cache:

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -183,12 +183,6 @@ def configure_msvc(env, manual_msvc_config):
         env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
         env.Append(LINKFLAGS=['/OPT:REF'])
 
-    elif (env["target"] == "debug_release"):
-        env.Append(CCFLAGS=['/Z7', '/Od'])
-        env.Append(LINKFLAGS=['/DEBUG'])
-        env.Append(LINKFLAGS=['/SUBSYSTEM:WINDOWS'])
-        env.Append(LINKFLAGS=['/ENTRY:mainCRTStartup'])
-
     elif (env["target"] == "debug"):
         env.AppendUnique(CCFLAGS=['/Z7', '/Od', '/EHsc'])
         env.AppendUnique(CPPDEFINES = ['DEBUG_ENABLED', 'DEBUG_MEMORY_ENABLED',


### PR DESCRIPTION
Also increase AppVeyor cache size to 1024,
should match what is available for us in the free plan:
https://www.appveyor.com/docs/build-cache/#cache-size-beta