### PR TITLE
[WIP] emit_changed on resource/value changes in Theme

### DIFF
--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -48,11 +48,6 @@ class Theme : public Resource {
 
 	static Ref<Theme> default_theme;
 
-	//keep a reference count to font, so each time the font changes, we emit theme changed too
-	Map<Ref<Font>, int> font_refcount;
-
-	void _ref_font(Ref<Font> p_sc);
-	void _unref_font(Ref<Font> p_sc);
 	void _emit_theme_changed();
 
 	HashMap<StringName, HashMap<StringName, Ref<Texture> > > icon_map;


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/6145 (WIP).

The color is updated in Preview, 2D and runtime with Sync Changes.
![peek 2018-08-20 23-35](https://user-images.githubusercontent.com/4741886/44400475-9114f480-a54b-11e8-99d7-530428e57967.gif)



When I change the size of a font or some stylebox setting I get only Preview and 2D updates. Any Idea why?
It seems this issue is Inspector related, unfolding and edit is not updating the remote tree like `open edit` (edit resource).
![peek 2018-08-21 14-15](https://user-images.githubusercontent.com/4741886/44408611-00491380-a561-11e8-991d-4bbd000382ba.gif)



