### PR TITLE
Deprecate incorrect Color::gray()

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -506,8 +506,11 @@ Color Color::from_hsv(float p_h, float p_s, float p_v, float p_a) {
 	return Color(m + r, m + g, m + b, p_a);
 }
 
+// FIXME: Remove once Godot 3.1 has been released
 float Color::gray() const {
 
+	ERR_EXPLAIN("Color.gray() is deprecated and will be removed in a future version. Use Color.get_v() for a better grayscale approximation.");
+	WARN_DEPRECATED
 	return (r + g + b) / 3.0;
 }
 

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2230,10 +2230,10 @@ void Image::set_pixel(int p_x, int p_y, const Color &p_color) {
 
 	switch (format) {
 		case FORMAT_L8: {
-			ptr[ofs] = uint8_t(CLAMP(p_color.gray() * 255.0, 0, 255));
+			ptr[ofs] = uint8_t(CLAMP(p_color.get_v() * 255.0, 0, 255));
 		} break;
 		case FORMAT_LA8: {
-			ptr[ofs * 2 + 0] = uint8_t(CLAMP(p_color.gray() * 255.0, 0, 255));
+			ptr[ofs * 2 + 0] = uint8_t(CLAMP(p_color.get_v() * 255.0, 0, 255));
 			ptr[ofs * 2 + 1] = uint8_t(CLAMP(p_color.a * 255.0, 0, 255));
 		} break;
 		case FORMAT_R8: {

--- a/modules/mono/glue/cs_files/Color.cs
+++ b/modules/mono/glue/cs_files/Color.cs
@@ -258,11 +258,6 @@ namespace Godot
             return res;
         }
 
-        public float Gray()
-        {
-            return (r + g + b) / 3.0f;
-        }
-
         public Color Inverted()
         {
             return new Color(

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -119,7 +119,7 @@ void CollisionShape2D::_notification(int p_what) {
 
 			Color draw_col = get_tree()->get_debug_collisions_color();
 			if (disabled) {
-				float g = draw_col.gray();
+				float g = draw_col.get_v();
 				draw_col.r = g;
 				draw_col.g = g;
 				draw_col.b = g;


### PR DESCRIPTION
This average is not a proper approximation of a grayscale value,
get_v() is better suited for that.

If we want a real to_grayscale() conversion, it's somewhat more
involved: https://en.wikipedia.org/wiki/Grayscale

Remove the deprecated Gray() from C# bindings as it conflicts
with new named color constants.

Solves https://github.com/godotengine/godot/pull/21248#issuecomment-414630442