### PR TITLE
Backport CanvasLayer fixes

### DIFF
--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -17,7 +17,8 @@
 			<return type="World2D">
 			</return>
 			<description>
-				Return the [World2D] used by this layer.
+				Returns the own [code]World2D[/code] used by this layer if [code]own_world[/code] is set or [code]null[/code] otherwise.
+				This method is deprecated (the future builtin behavior will be [code]CanvasLayer[/code]s not having their own [code]World2D[/code] ever).
 			</description>
 		</method>
 	</methods>
@@ -30,6 +31,11 @@
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset">
 			The layer's base offset.
+		</member>
+		<member name="own_world" type="bool" setter="set_use_own_world" getter="is_using_own_world">
+			Whether this layer uses its own [code]World2D[/code]; i.e. if this layer has a separate physics space.
+			Default value: [code]true[/code]
+			This property is deprecated (the future builtin behavior will be as if it was [code]false[/code]).
 		</member>
 		<member name="rotation" type="float" setter="set_rotation" getter="get_rotation">
 			The layer's rotation in radians.

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -3485,6 +3485,19 @@
 				Sets the renderlayer for a viewport's canvas.
 			</description>
 		</method>
+		<method name="viewport_set_canvas_sublayer">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="canvas" type="RID">
+			</argument>
+			<argument index="2" name="sublayer" type="int">
+			</argument>
+			<description>
+				Sets the stacking order of the canvas among those in the same layer.
+			</description>
+		</method>
 		<method name="viewport_set_canvas_transform">
 			<return type="void">
 			</return>

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -396,6 +396,9 @@ void CanvasItem::_enter_canvas() {
 			if (canvas_layer) {
 				break;
 			}
+			if (Object::cast_to<Viewport>(n)) {
+				break;
+			}
 			n = n->get_parent();
 		}
 

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -345,23 +345,12 @@ void CanvasItem::_update_callback() {
 
 Transform2D CanvasItem::get_global_transform_with_canvas() const {
 
-	const CanvasItem *ci = this;
-	Transform2D xform;
-	const CanvasItem *last_valid = NULL;
-
-	while (ci) {
-
-		last_valid = ci;
-		xform = ci->get_transform() * xform;
-		ci = ci->get_parent_item();
-	}
-
-	if (last_valid->canvas_layer)
-		return last_valid->canvas_layer->get_transform() * xform;
+	if (canvas_layer)
+		return canvas_layer->get_transform() * get_global_transform();
 	else if (is_inside_tree())
-		return get_viewport()->get_canvas_transform() * xform;
-
-	return xform;
+		return get_viewport()->get_canvas_transform() * get_global_transform();
+	else
+		return get_global_transform();
 }
 
 Transform2D CanvasItem::get_global_transform() const {

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -846,6 +846,10 @@ Ref<World2D> CanvasItem::get_world_2d() const {
 
 	ERR_FAIL_COND_V(!is_inside_tree(), Ref<World2D>());
 
+	if (canvas_layer && canvas_layer->is_using_own_world()) {
+		return canvas_layer->get_world_2d();
+	}
+
 	CanvasItem *tl = get_toplevel();
 
 	if (tl->get_viewport()) {

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -401,7 +401,7 @@ void CanvasItem::_enter_canvas() {
 
 		RID canvas;
 		if (canvas_layer)
-			canvas = canvas_layer->get_world_2d()->get_canvas();
+			canvas = canvas_layer->get_canvas();
 		else
 			canvas = get_viewport()->find_world_2d()->get_canvas();
 
@@ -827,7 +827,7 @@ RID CanvasItem::get_canvas() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), RID());
 
 	if (canvas_layer)
-		return canvas_layer->get_world_2d()->get_canvas();
+		return canvas_layer->get_canvas();
 	else
 		return get_viewport()->find_world_2d()->get_canvas();
 }
@@ -848,9 +848,7 @@ Ref<World2D> CanvasItem::get_world_2d() const {
 
 	CanvasItem *tl = get_toplevel();
 
-	if (tl->canvas_layer) {
-		return tl->canvas_layer->get_world_2d();
-	} else if (tl->get_viewport()) {
+	if (tl->get_viewport()) {
 		return tl->get_viewport()->find_world_2d();
 	} else {
 		return Ref<World2D>();

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -835,6 +835,15 @@ RID CanvasItem::get_canvas() const {
 		return get_viewport()->find_world_2d()->get_canvas();
 }
 
+ObjectID CanvasItem::get_canvas_layer_instance_id() const {
+
+	if (canvas_layer) {
+		return canvas_layer->get_instance_id();
+	} else {
+		return 0;
+	}
+}
+
 CanvasItem *CanvasItem::get_toplevel() const {
 
 	CanvasItem *ci = const_cast<CanvasItem *>(this);

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -314,6 +314,7 @@ public:
 	Rect2 get_viewport_rect() const;
 	RID get_viewport_rid() const;
 	RID get_canvas() const;
+	ObjectID get_canvas_layer_instance_id() const;
 	Ref<World2D> get_world_2d() const;
 
 	virtual void set_material(const Ref<Material> &p_material);

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -54,6 +54,14 @@ void CollisionObject2D::_notification(int p_what) {
 			//get space
 		}
 
+		case NOTIFICATION_ENTER_CANVAS: {
+
+			if (area)
+				Physics2DServer::get_singleton()->area_attach_canvas_instance_id(rid, get_canvas_layer_instance_id());
+			else
+				Physics2DServer::get_singleton()->body_attach_canvas_instance_id(rid, get_canvas_layer_instance_id());
+		}
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 
 			_update_pickable();
@@ -74,6 +82,14 @@ void CollisionObject2D::_notification(int p_what) {
 				Physics2DServer::get_singleton()->body_set_space(rid, RID());
 
 		} break;
+
+		case NOTIFICATION_EXIT_CANVAS: {
+
+			if (area)
+				Physics2DServer::get_singleton()->area_attach_canvas_instance_id(rid, 0);
+			else
+				Physics2DServer::get_singleton()->body_attach_canvas_instance_id(rid, 0);
+		}
 	}
 }
 

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -72,7 +72,7 @@ void ParallaxLayer::_update_mirroring() {
 	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
 	if (pb) {
 
-		RID c = pb->get_world_2d()->get_canvas();
+		RID c = pb->get_canvas();
 		RID ci = get_canvas_item();
 		Point2 mirrorScale = mirroring * get_scale();
 		VisualServer::get_singleton()->canvas_set_item_mirroring(c, ci, mirrorScale);

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -35,8 +35,10 @@
 void CanvasLayer::set_layer(int p_xform) {
 
 	layer = p_xform;
-	if (viewport.is_valid())
+	if (viewport.is_valid()) {
 		VisualServer::get_singleton()->viewport_set_canvas_layer(viewport, canvas, layer);
+		VisualServer::get_singleton()->viewport_set_canvas_sublayer(viewport, canvas, get_position_in_parent());
+	}
 }
 
 int CanvasLayer::get_layer() const {
@@ -184,6 +186,11 @@ void CanvasLayer::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 
 			_detach_from_viewport();
+		} break;
+		case NOTIFICATION_MOVED_IN_PARENT: {
+
+			if (is_inside_tree())
+				VisualServer::get_singleton()->viewport_set_canvas_sublayer(viewport, canvas, get_position_in_parent());
 		} break;
 	}
 }

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -81,6 +81,8 @@ void CanvasLayer::_attach_to_viewport() {
 		vp = Node::get_viewport();
 	}
 	ERR_FAIL_COND(!vp);
+
+	vp->_canvas_layer_add(this);
 	viewport = vp->get_viewport_rid();
 
 	VisualServer::get_singleton()->viewport_attach_canvas(viewport, canvas);
@@ -89,6 +91,15 @@ void CanvasLayer::_attach_to_viewport() {
 }
 
 void CanvasLayer::_detach_from_viewport() {
+
+	if (custom_viewport && ObjectDB::get_instance(custom_viewport_id)) {
+		vp = custom_viewport;
+	} else {
+		vp = Node::get_viewport();
+	}
+	ERR_FAIL_COND(!vp);
+
+	vp->_canvas_layer_remove(this);
 
 	VisualServer::get_singleton()->viewport_remove_canvas(viewport, canvas);
 	viewport = RID();

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "canvas_layer.h"
+#include "engine.h"
 #include "viewport.h"
 
 void CanvasLayer::set_layer(int p_xform) {
@@ -70,6 +71,27 @@ void CanvasLayer::_update_locrotscale() {
 	rot = transform.get_rotation();
 	scale = transform.get_scale();
 	locrotscale_dirty = false;
+}
+
+void CanvasLayer::_attach_to_viewport() {
+
+	if (custom_viewport && ObjectDB::get_instance(custom_viewport_id)) {
+		vp = custom_viewport;
+	} else {
+		vp = Node::get_viewport();
+	}
+	ERR_FAIL_COND(!vp);
+	viewport = vp->get_viewport_rid();
+
+	VisualServer::get_singleton()->viewport_attach_canvas(viewport, canvas);
+	VisualServer::get_singleton()->viewport_set_canvas_layer(viewport, canvas, layer);
+	VisualServer::get_singleton()->viewport_set_canvas_transform(viewport, canvas, transform);
+}
+
+void CanvasLayer::_detach_from_viewport() {
+
+	VisualServer::get_singleton()->viewport_remove_canvas(viewport, canvas);
+	viewport = RID();
 }
 
 void CanvasLayer::set_offset(const Vector2 &p_offset) {
@@ -133,31 +155,24 @@ Vector2 CanvasLayer::get_scale() const {
 	return scale;
 }
 
+Ref<World2D> CanvasLayer::get_world_2d() const {
+
+	WARN_PRINT("This method is deprecated and will be removed in 3.1.");
+
+	return own_world;
+}
+
 void CanvasLayer::_notification(int p_what) {
 
 	switch (p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
-			if (custom_viewport && ObjectDB::get_instance(custom_viewport_id)) {
-
-				vp = custom_viewport;
-			} else {
-				vp = Node::get_viewport();
-			}
-			ERR_FAIL_COND(!vp);
-			viewport = vp->get_viewport_rid();
-
-			VisualServer::get_singleton()->viewport_attach_canvas(viewport, canvas);
-			VisualServer::get_singleton()->viewport_set_canvas_layer(viewport, canvas, layer);
-			VisualServer::get_singleton()->viewport_set_canvas_transform(viewport, canvas, transform);
-
+			_attach_to_viewport();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 
-			VisualServer::get_singleton()->viewport_remove_canvas(viewport, canvas);
-			viewport = RID();
-
+			_detach_from_viewport();
 		} break;
 	}
 }
@@ -179,8 +194,7 @@ RID CanvasLayer::get_viewport() const {
 void CanvasLayer::set_custom_viewport(Node *p_viewport) {
 	ERR_FAIL_NULL(p_viewport);
 	if (is_inside_tree()) {
-		VisualServer::get_singleton()->viewport_remove_canvas(viewport, canvas);
-		viewport = RID();
+		_detach_from_viewport();
 	}
 
 	custom_viewport = Object::cast_to<Viewport>(p_viewport);
@@ -192,23 +206,48 @@ void CanvasLayer::set_custom_viewport(Node *p_viewport) {
 	}
 
 	if (is_inside_tree()) {
-
-		if (custom_viewport)
-			vp = custom_viewport;
-		else
-			vp = Node::get_viewport();
-
-		viewport = vp->get_viewport_rid();
-
-		VisualServer::get_singleton()->viewport_attach_canvas(viewport, canvas);
-		VisualServer::get_singleton()->viewport_set_canvas_layer(viewport, canvas, layer);
-		VisualServer::get_singleton()->viewport_set_canvas_transform(viewport, canvas, transform);
+		_attach_to_viewport();
 	}
 }
 
 Node *CanvasLayer::get_custom_viewport() const {
 
 	return custom_viewport;
+}
+
+void CanvasLayer::set_use_own_world(bool p_enable) {
+
+	WARN_PRINT("own_world is deprecated and will be removed in 3.1.");
+
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
+		// Technically, it should be possible by propagating enter/exit world notifications
+		// and having 2D physics objects handling them, but it's probably not worth
+		ERR_EXPLAIN("Own world flag can only be changed while the CanvasLayer is not in the tree.");
+		ERR_FAIL();
+	}
+
+	if (p_enable == own_world.is_valid())
+		return;
+
+	if (p_enable) {
+		own_world = Ref<World2D>(memnew(World2D));
+		if (!Engine::get_singleton()->is_editor_hint()) {
+			// Use canvas from the World2D
+			VS::get_singleton()->free(canvas);
+			canvas = own_world->get_canvas();
+		}
+	} else {
+		own_world = Ref<World2D>();
+		if (!Engine::get_singleton()->is_editor_hint()) {
+			// Create new canvas
+			canvas = VS::get_singleton()->canvas_create();
+		}
+	}
+}
+
+bool CanvasLayer::is_using_own_world() const {
+
+	return own_world.is_valid();
 }
 
 void CanvasLayer::reset_sort_index() {
@@ -224,6 +263,7 @@ RID CanvasLayer::get_canvas() const {
 
 	return canvas;
 }
+
 void CanvasLayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_layer", "layer"), &CanvasLayer::set_layer);
@@ -247,8 +287,12 @@ void CanvasLayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_custom_viewport", "viewport"), &CanvasLayer::set_custom_viewport);
 	ClassDB::bind_method(D_METHOD("get_custom_viewport"), &CanvasLayer::get_custom_viewport);
 
+	ClassDB::bind_method(D_METHOD("get_world_2d"), &CanvasLayer::get_world_2d);
 	ClassDB::bind_method(D_METHOD("get_canvas"), &CanvasLayer::get_canvas);
 	//ClassDB::bind_method(D_METHOD("get_viewport"),&CanvasLayer::get_viewport);
+
+	ClassDB::bind_method(D_METHOD("set_use_own_world", "enable"), &CanvasLayer::set_use_own_world);
+	ClassDB::bind_method(D_METHOD("is_using_own_world"), &CanvasLayer::is_using_own_world);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layer", PROPERTY_HINT_RANGE, "-128,128,1"), "set_layer", "get_layer");
 	//ADD_PROPERTY( PropertyInfo(Variant::MATRIX32,"transform",PROPERTY_HINT_RANGE),"set_transform","get_transform") ;
@@ -258,6 +302,7 @@ void CanvasLayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "scale"), "set_scale", "get_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform"), "set_transform", "get_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "custom_viewport", PROPERTY_HINT_RESOURCE_TYPE, "Viewport", 0), "set_custom_viewport", "get_custom_viewport");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "own_world"), "set_use_own_world", "is_using_own_world");
 }
 
 CanvasLayer::CanvasLayer() {
@@ -267,7 +312,14 @@ CanvasLayer::CanvasLayer() {
 	rot = 0;
 	locrotscale_dirty = false;
 	layer = 1;
-	canvas = VS::get_singleton()->canvas_create();
+	own_world = Ref<World2D>(memnew(World2D));
+	// Since own world flag cannot be changed while in tree, unconditionally use own canvas in the editor
+	if (Engine::get_singleton()->is_editor_hint()) {
+		canvas = VS::get_singleton()->canvas_create();
+	} else {
+		canvas = own_world->get_canvas();
+	}
+
 	custom_viewport = NULL;
 	custom_viewport_id = 0;
 	sort_index = 0;
@@ -275,5 +327,6 @@ CanvasLayer::CanvasLayer() {
 
 CanvasLayer::~CanvasLayer() {
 
-	VS::get_singleton()->free(canvas);
+	if (own_world.is_null() || Engine::get_singleton()->is_editor_hint())
+		VS::get_singleton()->free(canvas);
 }

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -45,7 +45,7 @@ class CanvasLayer : public Node {
 	real_t rot;
 	int layer;
 	Transform2D transform;
-	Ref<World2D> canvas;
+	RID canvas;
 
 	ObjectID custom_viewport_id; // to check validity
 	Viewport *custom_viewport;
@@ -81,8 +81,6 @@ public:
 	void set_scale(const Size2 &p_scale);
 	Size2 get_scale() const;
 
-	Ref<World2D> get_world_2d() const;
-
 	Size2 get_viewport_size() const;
 
 	RID get_viewport() const;
@@ -93,7 +91,10 @@ public:
 	void reset_sort_index();
 	int get_sort_index();
 
+	RID get_canvas() const;
+
 	CanvasLayer();
+	~CanvasLayer();
 };
 
 #endif // CANVAS_LAYER_H

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -45,6 +45,7 @@ class CanvasLayer : public Node {
 	real_t rot;
 	int layer;
 	Transform2D transform;
+	Ref<World2D> own_world;
 	RID canvas;
 
 	ObjectID custom_viewport_id; // to check validity
@@ -57,6 +58,9 @@ class CanvasLayer : public Node {
 
 	void _update_xform();
 	void _update_locrotscale();
+
+	void _attach_to_viewport();
+	void _detach_from_viewport();
 
 protected:
 	void _notification(int p_what);
@@ -88,9 +92,13 @@ public:
 	void set_custom_viewport(Node *p_viewport);
 	Node *get_custom_viewport() const;
 
+	void set_use_own_world(bool p_enable);
+	bool is_using_own_world() const;
+
 	void reset_sort_index();
 	int get_sort_index();
 
+	Ref<World2D> get_world_2d() const;
 	RID get_canvas() const;
 
 	CanvasLayer();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -42,6 +42,7 @@
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/panel.h"
+#include "scene/main/canvas_layer.h"
 #include "scene/main/timer.h"
 #include "scene/resources/mesh.h"
 #include "scene/scene_string_names.h"
@@ -435,24 +436,39 @@ void Viewport::_notification(int p_what) {
 
 						uint64_t frame = get_tree()->get_frame();
 
-						Vector2 point = get_canvas_transform().affine_inverse().xform(pos);
 						Physics2DDirectSpaceState::ShapeResult res[64];
-						int rc = ss2d->intersect_point(point, res, 64, Set<RID>(), 0xFFFFFFFF, true);
-						for (int i = 0; i < rc; i++) {
+						for (Set<CanvasLayer *>::Element *E = canvas_layers.front(); E; E = E->next()) {
+							Transform2D canvas_transform;
+							ObjectID canvas_layer_id;
+							if (E->get()) {
+								// A descendant CanvasLayer
+								canvas_transform = E->get()->get_transform();
+								canvas_layer_id = E->get()->get_instance_id();
+							} else {
+								// This Viewport's builtin canvas
+								canvas_transform = get_canvas_transform();
+								canvas_layer_id = 0;
+							}
 
-							if (res[i].collider_id && res[i].collider) {
-								CollisionObject2D *co = Object::cast_to<CollisionObject2D>(res[i].collider);
-								if (co) {
+							Vector2 point = canvas_transform.affine_inverse().xform(pos);
 
-									Map<ObjectID, uint64_t>::Element *E = physics_2d_mouseover.find(res[i].collider_id);
-									if (!E) {
-										E = physics_2d_mouseover.insert(res[i].collider_id, frame);
-										co->_mouse_enter();
-									} else {
-										E->get() = frame;
+							int rc = ss2d->intersect_point_on_canvas(point, canvas_layer_id, res, 64, Set<RID>(), 0xFFFFFFFF, true);
+							for (int i = 0; i < rc; i++) {
+
+								if (res[i].collider_id && res[i].collider) {
+									CollisionObject2D *co = Object::cast_to<CollisionObject2D>(res[i].collider);
+									if (co) {
+
+										Map<ObjectID, uint64_t>::Element *E = physics_2d_mouseover.find(res[i].collider_id);
+										if (!E) {
+											E = physics_2d_mouseover.insert(res[i].collider_id, frame);
+											co->_mouse_enter();
+										} else {
+											E->get() = frame;
+										}
+
+										co->_input_event(this, ev, res[i].shape);
 									}
-
-									co->_input_event(this, ev, res[i].shape);
 								}
 							}
 						}
@@ -865,6 +881,16 @@ void Viewport::_camera_make_next_current(Camera *p_exclude) {
 	}
 }
 #endif
+
+void Viewport::_canvas_layer_add(CanvasLayer *p_canvas_layer) {
+
+	canvas_layers.insert(p_canvas_layer);
+}
+
+void Viewport::_canvas_layer_remove(CanvasLayer *p_canvas_layer) {
+
+	canvas_layers.erase(p_canvas_layer);
+}
 
 void Viewport::set_transparent_background(bool p_enable) {
 
@@ -2751,6 +2777,7 @@ Viewport::Viewport() {
 	parent = NULL;
 	listener = NULL;
 	camera = NULL;
+	canvas_layers.insert(NULL); // This eases picking code (interpreted as the canvas of the Viewport)
 	arvr = false;
 	size_override = false;
 	size_override_stretch = false;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -45,6 +45,7 @@ class Camera2D;
 class Listener;
 class Control;
 class CanvasItem;
+class CanvasLayer;
 class Panel;
 class Label;
 class Timer;
@@ -162,6 +163,7 @@ private:
 
 	Camera *camera;
 	Set<Camera *> cameras;
+	Set<CanvasLayer *> canvas_layers;
 
 	RID viewport;
 	RID current_canvas;
@@ -344,6 +346,10 @@ private:
 	bool _camera_add(Camera *p_camera); //true if first
 	void _camera_remove(Camera *p_camera);
 	void _camera_make_next_current(Camera *p_exclude);
+
+	friend class CanvasLayer;
+	void _canvas_layer_add(CanvasLayer *p_canvas_layer);
+	void _canvas_layer_remove(CanvasLayer *p_canvas_layer);
 
 protected:
 	void _notification(int p_what);

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -350,12 +350,12 @@ void World2D::_update() {
 	indexer->_update();
 }
 
-RID World2D::get_canvas() {
+RID World2D::get_canvas() const {
 
 	return canvas;
 }
 
-RID World2D::get_space() {
+RID World2D::get_space() const {
 
 	return space;
 }

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -64,8 +64,8 @@ protected:
 	void _update();
 
 public:
-	RID get_canvas();
-	RID get_space();
+	RID get_canvas() const;
+	RID get_space() const;
 
 	Physics2DDirectSpaceState *get_direct_space_state();
 

--- a/servers/physics_2d/collision_object_2d_sw.cpp
+++ b/servers/physics_2d/collision_object_2d_sw.cpp
@@ -216,6 +216,7 @@ CollisionObject2DSW::CollisionObject2DSW(Type p_type) {
 	type = p_type;
 	space = NULL;
 	instance_id = 0;
+	canvas_instance_id = 0;
 	collision_mask = 1;
 	collision_layer = 1;
 	pickable = true;

--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -49,6 +49,7 @@ private:
 	Type type;
 	RID self;
 	ObjectID instance_id;
+	ObjectID canvas_instance_id;
 	bool pickable;
 
 	struct Shape {
@@ -101,6 +102,9 @@ public:
 
 	_FORCE_INLINE_ void set_instance_id(const ObjectID &p_instance_id) { instance_id = p_instance_id; }
 	_FORCE_INLINE_ ObjectID get_instance_id() const { return instance_id; }
+
+	_FORCE_INLINE_ void set_canvas_instance_id(const ObjectID &p_canvas_instance_id) { canvas_instance_id = p_canvas_instance_id; }
+	_FORCE_INLINE_ ObjectID get_canvas_instance_id() const { return canvas_instance_id; }
 
 	void _shape_changed();
 

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -468,6 +468,27 @@ ObjectID Physics2DServerSW::area_get_object_instance_id(RID p_area) const {
 	return area->get_instance_id();
 }
 
+void Physics2DServerSW::area_attach_canvas_instance_id(RID p_area, ObjectID p_ID) {
+
+	if (space_owner.owns(p_area)) {
+		Space2DSW *space = space_owner.get(p_area);
+		p_area = space->get_default_area()->get_self();
+	}
+	Area2DSW *area = area_owner.get(p_area);
+	ERR_FAIL_COND(!area);
+	area->set_canvas_instance_id(p_ID);
+}
+ObjectID Physics2DServerSW::area_get_canvas_instance_id(RID p_area) const {
+
+	if (space_owner.owns(p_area)) {
+		Space2DSW *space = space_owner.get(p_area);
+		p_area = space->get_default_area()->get_self();
+	}
+	Area2DSW *area = area_owner.get(p_area);
+	ERR_FAIL_COND_V(!area, 0);
+	return area->get_canvas_instance_id();
+}
+
 void Physics2DServerSW::area_set_param(RID p_area, AreaParameter p_param, const Variant &p_value) {
 
 	if (space_owner.owns(p_area)) {
@@ -741,6 +762,22 @@ uint32_t Physics2DServerSW::body_get_object_instance_id(RID p_body) const {
 	ERR_FAIL_COND_V(!body, 0);
 
 	return body->get_instance_id();
+};
+
+void Physics2DServerSW::body_attach_canvas_instance_id(RID p_body, uint32_t p_ID) {
+
+	Body2DSW *body = body_owner.get(p_body);
+	ERR_FAIL_COND(!body);
+
+	body->set_canvas_instance_id(p_ID);
+};
+
+uint32_t Physics2DServerSW::body_get_canvas_instance_id(RID p_body) const {
+
+	Body2DSW *body = body_owner.get(p_body);
+	ERR_FAIL_COND_V(!body, 0);
+
+	return body->get_canvas_instance_id();
 };
 
 void Physics2DServerSW::body_set_collision_layer(RID p_body, uint32_t p_layer) {

--- a/servers/physics_2d/physics_2d_server_sw.h
+++ b/servers/physics_2d/physics_2d_server_sw.h
@@ -144,6 +144,9 @@ public:
 	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_ID);
 	virtual ObjectID area_get_object_instance_id(RID p_area) const;
 
+	virtual void area_attach_canvas_instance_id(RID p_area, ObjectID p_ID);
+	virtual ObjectID area_get_canvas_instance_id(RID p_area) const;
+
 	virtual void area_set_param(RID p_area, AreaParameter p_param, const Variant &p_value);
 	virtual void area_set_transform(RID p_area, const Transform2D &p_transform);
 
@@ -187,6 +190,9 @@ public:
 
 	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_ID);
 	virtual uint32_t body_get_object_instance_id(RID p_body) const;
+
+	virtual void body_attach_canvas_instance_id(RID p_body, uint32_t p_ID);
+	virtual uint32_t body_get_canvas_instance_id(RID p_body) const;
 
 	virtual void body_set_continuous_collision_detection_mode(RID p_body, CCDMode p_mode);
 	virtual CCDMode body_get_continuous_collision_detection_mode(RID p_body) const;

--- a/servers/physics_2d/physics_2d_server_wrap_mt.h
+++ b/servers/physics_2d/physics_2d_server_wrap_mt.h
@@ -154,6 +154,9 @@ public:
 	FUNC2(area_attach_object_instance_id, RID, ObjectID);
 	FUNC1RC(ObjectID, area_get_object_instance_id, RID);
 
+	FUNC2(area_attach_canvas_instance_id, RID, ObjectID);
+	FUNC1RC(ObjectID, area_get_canvas_instance_id, RID);
+
 	FUNC3(area_set_param, RID, AreaParameter, const Variant &);
 	FUNC2(area_set_transform, RID, const Transform2D &);
 
@@ -198,6 +201,9 @@ public:
 
 	FUNC2(body_attach_object_instance_id, RID, uint32_t);
 	FUNC1RC(uint32_t, body_get_object_instance_id, RID);
+
+	FUNC2(body_attach_canvas_instance_id, RID, uint32_t);
+	FUNC1RC(uint32_t, body_get_canvas_instance_id, RID);
 
 	FUNC2(body_set_continuous_collision_detection_mode, RID, CCDMode);
 	FUNC1RC(CCDMode, body_get_continuous_collision_detection_mode, RID);

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -38,7 +38,7 @@ _FORCE_INLINE_ static bool _can_collide_with(CollisionObject2DSW *p_object, uint
 	return p_object->get_collision_layer() & p_collision_mask;
 }
 
-int Physics2DDirectSpaceStateSW::intersect_point(const Vector2 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_pick_point) {
+int Physics2DDirectSpaceStateSW::_intersect_point_impl(const Vector2 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_pick_point, bool p_filter_by_canvas, ObjectID p_canvas_instance_id) {
 
 	if (p_result_max <= 0)
 		return 0;
@@ -64,6 +64,9 @@ int Physics2DDirectSpaceStateSW::intersect_point(const Vector2 &p_point, ShapeRe
 		if (p_pick_point && !col_obj->is_pickable())
 			continue;
 
+		if (p_filter_by_canvas && col_obj->get_canvas_instance_id() != p_canvas_instance_id)
+			continue;
+
 		int shape_idx = space->intersection_query_subindex_results[i];
 
 		Shape2DSW *shape = col_obj->get_shape(shape_idx);
@@ -87,6 +90,16 @@ int Physics2DDirectSpaceStateSW::intersect_point(const Vector2 &p_point, ShapeRe
 	}
 
 	return cc;
+}
+
+int Physics2DDirectSpaceStateSW::intersect_point(const Vector2 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_pick_point) {
+
+	return _intersect_point_impl(p_point, r_results, p_result_max, p_exclude, p_collision_mask, p_pick_point);
+}
+
+int Physics2DDirectSpaceStateSW::intersect_point_on_canvas(const Vector2 &p_point, ObjectID p_canvas_instance_id, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_pick_point) {
+
+	return _intersect_point_impl(p_point, r_results, p_result_max, p_exclude, p_collision_mask, p_pick_point, true, p_canvas_instance_id);
 }
 
 bool Physics2DDirectSpaceStateSW::intersect_ray(const Vector2 &p_from, const Vector2 &p_to, RayResult &r_result, const Set<RID> &p_exclude, uint32_t p_collision_mask) {

--- a/servers/physics_2d/space_2d_sw.h
+++ b/servers/physics_2d/space_2d_sw.h
@@ -45,10 +45,13 @@ class Physics2DDirectSpaceStateSW : public Physics2DDirectSpaceState {
 
 	GDCLASS(Physics2DDirectSpaceStateSW, Physics2DDirectSpaceState);
 
+	int _intersect_point_impl(const Vector2 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_pick_point, bool p_filter_by_canvas = false, ObjectID p_canvas_instance_id = 0);
+
 public:
 	Space2DSW *space;
 
 	virtual int intersect_point(const Vector2 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_pick_point = false);
+	virtual int intersect_point_on_canvas(const Vector2 &p_point, ObjectID p_canvas_instance_id, ShapeResult * r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_layer = 0xFFFFFFFF, bool p_pick_point = false);
 	virtual bool intersect_ray(const Vector2 &p_from, const Vector2 &p_to, RayResult &r_result, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF);
 	virtual int intersect_shape(const RID &p_shape, const Transform2D &p_xform, const Vector2 &p_motion, real_t p_margin, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF);
 	virtual bool cast_motion(const RID &p_shape, const Transform2D &p_xform, const Vector2 &p_motion, real_t p_margin, real_t &p_closest_safe, real_t &p_closest_unsafe, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF);

--- a/servers/physics_2d_server.cpp
+++ b/servers/physics_2d_server.cpp
@@ -289,7 +289,7 @@ Array Physics2DDirectSpaceState::_cast_motion(const Ref<Physics2DShapeQueryParam
 	return ret;
 }
 
-Array Physics2DDirectSpaceState::_intersect_point(const Vector2 &p_point, int p_max_results, const Vector<RID> &p_exclude, uint32_t p_layers) {
+Array Physics2DDirectSpaceState::_intersect_point_impl(const Vector2 &p_point, int p_max_results, const Vector<RID> &p_exclude, uint32_t p_layers, bool p_filter_by_canvas, ObjectID p_canvas_instance_id) {
 
 	Set<RID> exclude;
 	for (int i = 0; i < p_exclude.size(); i++)
@@ -298,7 +298,12 @@ Array Physics2DDirectSpaceState::_intersect_point(const Vector2 &p_point, int p_
 	Vector<ShapeResult> ret;
 	ret.resize(p_max_results);
 
-	int rc = intersect_point(p_point, ret.ptrw(), ret.size(), exclude, p_layers);
+	int rc;
+	if (p_filter_by_canvas)
+		rc = intersect_point(p_point, ret.ptrw(), ret.size(), exclude, p_layers);
+	else
+		rc = intersect_point_on_canvas(p_point, p_canvas_instance_id, ret.ptrw(), ret.size(), exclude, p_layers);
+
 	if (rc == 0)
 		return Array();
 
@@ -315,6 +320,16 @@ Array Physics2DDirectSpaceState::_intersect_point(const Vector2 &p_point, int p_
 		r[i] = d;
 	}
 	return r;
+}
+
+Array Physics2DDirectSpaceState::_intersect_point(const Vector2 &p_point, int p_max_results, const Vector<RID> &p_exclude, uint32_t p_layers) {
+
+	return _intersect_point_impl(p_point, p_max_results, p_exclude, p_layers);
+}
+
+Array Physics2DDirectSpaceState::_intersect_point_on_canvas(const Vector2 &p_point, ObjectID p_canvas_intance_id, int p_max_results, const Vector<RID> &p_exclude, uint32_t p_layers) {
+
+	return _intersect_point_impl(p_point, p_max_results, p_exclude, p_layers, true, p_canvas_intance_id);
 }
 
 Array Physics2DDirectSpaceState::_collide_shape(const Ref<Physics2DShapeQueryParameters> &p_shape_query, int p_max_results) {
@@ -357,6 +372,7 @@ Physics2DDirectSpaceState::Physics2DDirectSpaceState() {
 void Physics2DDirectSpaceState::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("intersect_point", "point", "max_results", "exclude", "collision_layer"), &Physics2DDirectSpaceState::_intersect_point, DEFVAL(32), DEFVAL(Array()), DEFVAL(0x7FFFFFFF));
+	ClassDB::bind_method(D_METHOD("intersect_point_on_canvas", "point", "canvas_instance_id", "max_results", "exclude", "collision_layer"), &Physics2DDirectSpaceState::_intersect_point_on_canvas, DEFVAL(32), DEFVAL(Array()), DEFVAL(0x7FFFFFFF));
 	ClassDB::bind_method(D_METHOD("intersect_ray", "from", "to", "exclude", "collision_layer"), &Physics2DDirectSpaceState::_intersect_ray, DEFVAL(Array()), DEFVAL(0x7FFFFFFF));
 	ClassDB::bind_method(D_METHOD("intersect_shape", "shape", "max_results"), &Physics2DDirectSpaceState::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "shape"), &Physics2DDirectSpaceState::_cast_motion);
@@ -538,6 +554,9 @@ void Physics2DServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("area_attach_object_instance_id", "area", "id"), &Physics2DServer::area_attach_object_instance_id);
 	ClassDB::bind_method(D_METHOD("area_get_object_instance_id", "area"), &Physics2DServer::area_get_object_instance_id);
 
+	ClassDB::bind_method(D_METHOD("area_attach_canvas_instance_id", "area", "id"), &Physics2DServer::area_attach_canvas_instance_id);
+	ClassDB::bind_method(D_METHOD("area_get_canvas_instance_id", "area"), &Physics2DServer::area_get_canvas_instance_id);
+
 	ClassDB::bind_method(D_METHOD("area_set_monitor_callback", "area", "receiver", "method"), &Physics2DServer::area_set_monitor_callback);
 
 	ClassDB::bind_method(D_METHOD("body_create"), &Physics2DServer::body_create);
@@ -566,6 +585,9 @@ void Physics2DServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("body_attach_object_instance_id", "body", "id"), &Physics2DServer::body_attach_object_instance_id);
 	ClassDB::bind_method(D_METHOD("body_get_object_instance_id", "body"), &Physics2DServer::body_get_object_instance_id);
+
+	ClassDB::bind_method(D_METHOD("body_attach_canvas_instance_id", "body", "id"), &Physics2DServer::body_attach_canvas_instance_id);
+	ClassDB::bind_method(D_METHOD("body_get_canvas_instance_id", "body"), &Physics2DServer::body_get_canvas_instance_id);
 
 	ClassDB::bind_method(D_METHOD("body_set_continuous_collision_detection_mode", "body", "mode"), &Physics2DServer::body_set_continuous_collision_detection_mode);
 	ClassDB::bind_method(D_METHOD("body_get_continuous_collision_detection_mode", "body"), &Physics2DServer::body_get_continuous_collision_detection_mode);

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -132,7 +132,10 @@ class Physics2DDirectSpaceState : public Object {
 
 	Dictionary _intersect_ray(const Vector2 &p_from, const Vector2 &p_to, const Vector<RID> &p_exclude = Vector<RID>(), uint32_t p_layers = 0);
 
+	Array _intersect_point_impl(const Vector2 &p_point, int p_max_results, const Vector<RID> &p_exclude, uint32_t p_layers, bool p_filter_by_canvas = false, ObjectID p_canvas_instance_id = 0);
+
 	Array _intersect_point(const Vector2 &p_point, int p_max_results = 32, const Vector<RID> &p_exclude = Vector<RID>(), uint32_t p_layers = 0);
+	Array _intersect_point_on_canvas(const Vector2 &p_point, ObjectID p_canvas_intance_id, int p_max_results = 32, const Vector<RID> &p_exclude = Vector<RID>(), uint32_t p_layers = 0);
 	Array _intersect_shape(const Ref<Physics2DShapeQueryParameters> &p_shape_query, int p_max_results = 32);
 	Array _cast_motion(const Ref<Physics2DShapeQueryParameters> &p_shape_query);
 	Array _collide_shape(const Ref<Physics2DShapeQueryParameters> &p_shape_query, int p_max_results = 32);
@@ -165,6 +168,7 @@ public:
 	};
 
 	virtual int intersect_point(const Vector2 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_layer = 0xFFFFFFFF, bool p_pick_point = false) = 0;
+	virtual int intersect_point_on_canvas(const Vector2 &p_point, ObjectID p_canvas_instance_id, ShapeResult * r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_layer = 0xFFFFFFFF, bool p_pick_point = false) = 0;
 
 	virtual int intersect_shape(const RID &p_shape, const Transform2D &p_xform, const Vector2 &p_motion, float p_margin, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_layer = 0xFFFFFFFF) = 0;
 
@@ -332,6 +336,9 @@ public:
 	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_ID) = 0;
 	virtual ObjectID area_get_object_instance_id(RID p_area) const = 0;
 
+	virtual void area_attach_canvas_instance_id(RID p_area, ObjectID p_ID) = 0;
+	virtual ObjectID area_get_canvas_instance_id(RID p_area) const = 0;
+
 	virtual void area_set_param(RID p_area, AreaParameter p_param, const Variant &p_value) = 0;
 	virtual void area_set_transform(RID p_area, const Transform2D &p_transform) = 0;
 
@@ -385,6 +392,9 @@ public:
 
 	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_ID) = 0;
 	virtual uint32_t body_get_object_instance_id(RID p_body) const = 0;
+
+	virtual void body_attach_canvas_instance_id(RID p_body, uint32_t p_ID) = 0;
+	virtual uint32_t body_get_canvas_instance_id(RID p_body) const = 0;
 
 	enum CCDMode {
 		CCD_MODE_DISABLED,

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -461,6 +461,7 @@ public:
 
 	BIND2(viewport_set_global_canvas_transform, RID, const Transform2D &)
 	BIND3(viewport_set_canvas_layer, RID, RID, int)
+	BIND3(viewport_set_canvas_sublayer, RID, RID, int)
 	BIND2(viewport_set_shadow_atlas_size, RID, int)
 	BIND3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	BIND2(viewport_set_msaa, RID, ViewportMSAA)

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -138,7 +138,7 @@ void VisualServerViewport::_draw_viewport(Viewport *p_viewport, ARVRInterface::E
 			}
 
 			//print_line("lights: "+itos(light_count));
-			canvas_map[Viewport::CanvasKey(E->key(), E->get().layer)] = &E->get();
+			canvas_map[Viewport::CanvasKey(E->key(), E->get().layer, E->get().sublayer)] = &E->get();
 		}
 
 		if (lights_with_shadow) {
@@ -177,7 +177,7 @@ void VisualServerViewport::_draw_viewport(Viewport *p_viewport, ARVRInterface::E
 
 		VSG::rasterizer->restore_render_target();
 
-		if (scenario_draw_canvas_bg && canvas_map.front() && canvas_map.front()->key().layer > scenario_canvas_max_layer) {
+		if (scenario_draw_canvas_bg && canvas_map.front() && canvas_map.front()->key().get_layer() > scenario_canvas_max_layer) {
 
 			if (can_draw_3d) {
 				VSG::scene->render_camera(p_viewport->camera, p_viewport->scenario, p_viewport->size, p_viewport->shadow_atlas);
@@ -209,7 +209,7 @@ void VisualServerViewport::_draw_viewport(Viewport *p_viewport, ARVRInterface::E
 			VSG::canvas->render_canvas(canvas, xform, canvas_lights, lights_with_mask, clip_rect);
 			i++;
 
-			if (scenario_draw_canvas_bg && E->key().layer >= scenario_canvas_max_layer) {
+			if (scenario_draw_canvas_bg && E->key().get_layer() >= scenario_canvas_max_layer) {
 
 				if (can_draw_3d) {
 					VSG::scene->render_camera(p_viewport->camera, p_viewport->scenario, p_viewport->size, p_viewport->shadow_atlas);
@@ -479,6 +479,7 @@ void VisualServerViewport::viewport_attach_canvas(RID p_viewport, RID p_canvas) 
 	canvas->viewports.insert(p_viewport);
 	viewport->canvas_map[p_canvas] = Viewport::CanvasData();
 	viewport->canvas_map[p_canvas].layer = 0;
+	viewport->canvas_map[p_canvas].sublayer = 0;
 	viewport->canvas_map[p_canvas].canvas = canvas;
 }
 
@@ -524,6 +525,14 @@ void VisualServerViewport::viewport_set_canvas_layer(RID p_viewport, RID p_canva
 
 	ERR_FAIL_COND(!viewport->canvas_map.has(p_canvas));
 	viewport->canvas_map[p_canvas].layer = p_layer;
+}
+void VisualServerViewport::viewport_set_canvas_sublayer(RID p_viewport, RID p_canvas, int p_sublayer) {
+
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+
+	ERR_FAIL_COND(!viewport->canvas_map.has(p_canvas));
+	viewport->canvas_map[p_canvas].sublayer = p_sublayer;
 }
 
 void VisualServerViewport::viewport_set_shadow_atlas_size(RID p_viewport, int p_size) {

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -77,17 +77,18 @@ public:
 
 		struct CanvasKey {
 
-			int layer;
+			int64_t stacking;
 			RID canvas;
 			bool operator<(const CanvasKey &p_canvas) const {
-				if (layer == p_canvas.layer) return canvas < p_canvas.canvas;
-				return layer < p_canvas.layer;
+				if (stacking == p_canvas.stacking) return canvas < p_canvas.canvas;
+				return stacking < p_canvas.stacking;
 			}
-			CanvasKey() { layer = 0; }
-			CanvasKey(const RID &p_canvas, int p_layer) {
+			CanvasKey() { stacking = 0; }
+			CanvasKey(const RID &p_canvas, int p_layer, int p_sublayer) {
 				canvas = p_canvas;
-				layer = p_layer;
+				stacking = ((int64_t)p_layer << 32) + p_sublayer;
 			}
+			int get_layer() const { return stacking >> 32; }
 		};
 
 		struct CanvasData {
@@ -95,6 +96,7 @@ public:
 			CanvasBase *canvas;
 			Transform2D transform;
 			int layer;
+			int sublayer;
 		};
 
 		Transform2D global_transform;
@@ -174,6 +176,7 @@ public:
 
 	void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform);
 	void viewport_set_canvas_layer(RID p_viewport, RID p_canvas, int p_layer);
+	void viewport_set_canvas_sublayer(RID p_viewport, RID p_canvas, int p_sublayer);
 
 	void viewport_set_shadow_atlas_size(RID p_viewport, int p_size);
 	void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -388,6 +388,7 @@ public:
 
 	FUNC2(viewport_set_global_canvas_transform, RID, const Transform2D &)
 	FUNC3(viewport_set_canvas_layer, RID, RID, int)
+	FUNC3(viewport_set_canvas_sublayer, RID, RID, int)
 	FUNC2(viewport_set_shadow_atlas_size, RID, int)
 	FUNC3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	FUNC2(viewport_set_msaa, RID, ViewportMSAA)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1745,6 +1745,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_transparent_background", "viewport", "enabled"), &VisualServer::viewport_set_transparent_background);
 	ClassDB::bind_method(D_METHOD("viewport_set_global_canvas_transform", "viewport", "transform"), &VisualServer::viewport_set_global_canvas_transform);
 	ClassDB::bind_method(D_METHOD("viewport_set_canvas_layer", "viewport", "canvas", "layer"), &VisualServer::viewport_set_canvas_layer);
+	ClassDB::bind_method(D_METHOD("viewport_set_canvas_sublayer", "viewport", "canvas", "sublayer"), &VisualServer::viewport_set_canvas_sublayer);
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_size", "viewport", "size"), &VisualServer::viewport_set_shadow_atlas_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_quadrant_subdivision", "viewport", "quadrant", "subdivision"), &VisualServer::viewport_set_shadow_atlas_quadrant_subdivision);
 	ClassDB::bind_method(D_METHOD("viewport_set_msaa", "viewport", "msaa"), &VisualServer::viewport_set_msaa);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -601,6 +601,7 @@ public:
 
 	virtual void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform) = 0;
 	virtual void viewport_set_canvas_layer(RID p_viewport, RID p_canvas, int p_layer) = 0;
+	virtual void viewport_set_canvas_sublayer(RID p_viewport, RID p_canvas, int p_sublayer) = 0;
 
 	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size) = 0;
 	virtual void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv) = 0;


### PR DESCRIPTION
This is a pack of backports from 3.1 also fixing & enhancing `CanvasLayer` **in a compatible way**.

**UPDATE: No longer [tentative], all _master_'s counterparts merged!**

**EDIT:** Rewritten commits summary after updates in the PR. Again, to add commit 6. Once more.

- Commit 1 is the good one from #21245, adding an optimization (the other commit from that PR was reverted in master because it was implementing a wrong approach; see commit 5).
- Commit 2 is a cherry-pick of 9e7cee2ceb1a963c1da2c21013adf7d616412d3c, which removes the own `World2D` that `CanvasLayer`s had (therefore, fixing  #17524, #17523 and #18005). This was not backwards compatible.
- Commit 3 is from #21173, letting `CanvasLayer`s have their own `World2D` (as always in 3.0), but adding a flag to use the default one. That is, this takes the best from the previous cherry-pick but keeps the former behavior as the default to restore compatibility. It warns about its deprecation because 3.1 has the unbroken behavior (not own world).
- Commit 4: just a cherry-pick of a bug fix.
- Commit 5: cherry-picks (with conflicts solved) the only commit from #21386 (**~~still not merged into master~~**), which implements the right approach to the issue about picking inside `CanvasLayer`s.
- Commit 6: adaptation of #23411 & #23734 (a fix the former required) to 3.0 in a back-compat way.

This code is donated by an anonymous contributor.