### PR TITLE
tilemap_editor: change move and duplicate tools

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -61,8 +61,7 @@ class TileMapEditor : public VBoxContainer {
 		TOOL_SELECTING,
 		TOOL_BUCKET,
 		TOOL_PICKING,
-		TOOL_DUPLICATING,
-		TOOL_MOVING
+		TOOL_PASTING
 	};
 
 	enum Options {
@@ -70,11 +69,11 @@ class TileMapEditor : public VBoxContainer {
 		OPTION_BUCKET,
 		OPTION_PICK_TILE,
 		OPTION_SELECT,
-		OPTION_DUPLICATE,
+		OPTION_COPY,
 		OPTION_ERASE_SELECTION,
 		OPTION_PAINTING,
 		OPTION_FIX_INVALID,
-		OPTION_MOVE
+		OPTION_CUT
 	};
 
 	TileMap *node;
@@ -167,6 +166,7 @@ class TileMapEditor : public VBoxContainer {
 	void _erase_points(const PoolVector<Vector2> p_points);
 
 	void _select(const Point2i &p_from, const Point2i &p_to);
+	void _erase_selection();
 
 	void _draw_cell(int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Transform2D &p_xform);
 	void _draw_fill_preview(int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Transform2D &p_xform);


### PR DESCRIPTION
This is a proposition regarding #21123.  

 _ | Old behaviour | New behaviour
-- | -------------- | ----------------
Duplicate / Copy | ![2018-08-21_21-51-29](https://user-images.githubusercontent.com/437025/44425892-78c5c980-a58d-11e8-8994-f28b0b652a7a.gif) | ![2018-08-21_21-36-25](https://user-images.githubusercontent.com/437025/44425932-9430d480-a58d-11e8-9e97-705c7d9a5cd3.gif)
Move / Cut | ![2018-08-21_21-51-43](https://user-images.githubusercontent.com/437025/44425965-b0cd0c80-a58d-11e8-895b-77f0150255c9.gif) | ![2018-08-21_21-36-45](https://user-images.githubusercontent.com/437025/44425977-c0e4ec00-a58d-11e8-9661-fcb19834badc.gif)

Bests.