### PR TITLE
[GLES2] enable hardware skeletons

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -913,8 +913,8 @@ void RasterizerSceneGLES2::_setup_material(RasterizerStorageGLES2::Material *p_m
 void RasterizerSceneGLES2::_setup_geometry(RenderList::Element *p_element, RasterizerStorageGLES2::Skeleton *p_skeleton) {
 
 	state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON, p_skeleton != NULL);
-	// state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON_SOFTWARE, !storage->config.float_texture_supported);
-	state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON_SOFTWARE, true);
+	state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON_SOFTWARE, !storage->config.float_texture_supported);
+	// state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON_SOFTWARE, true);
 
 	switch (p_element->instance->base_type) {
 
@@ -951,9 +951,9 @@ void RasterizerSceneGLES2::_setup_geometry(RenderList::Element *p_element, Raste
 		} break;
 	}
 
-	if (false && storage->config.float_texture_supported) {
+	if (storage->config.float_texture_supported) {
 		if (p_skeleton) {
-			glActiveTexture(GL_TEXTURE4);
+			glActiveTexture(GL_TEXTURE0 + storage->config.max_texture_image_units - 1);
 			glBindTexture(GL_TEXTURE_2D, p_skeleton->tex_id);
 		}
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -384,6 +384,10 @@ void RasterizerStorageGLES2::texture_allocate(RID p_texture, int p_width, int p_
 		case VS::TEXTURE_TYPE_3D: {
 			texture->images.resize(p_depth_3d);
 		} break;
+		default: {
+			ERR_PRINT("Unknown texture type!");
+			return;
+		}
 	}
 
 	Image::Format real_format;
@@ -2848,7 +2852,11 @@ void RasterizerStorageGLES2::skeleton_allocate(RID p_skeleton, int p_bones, bool
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, skeleton->tex_id);
 
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, p_bones * 3, 1, 0, GL_RGB, GL_FLOAT, NULL);
+#ifdef GLES_OVER_GL
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, p_bones * 3, 1, 0, GL_RGBA, GL_FLOAT, NULL);
+#else
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, p_bones * 3, 1, 0, GL_RGBA, GL_FLOAT, NULL);
+#endif
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -168,7 +168,7 @@ void main() {
 
 #ifdef USE_SKELETON
 
-	highp mat4 bone_transform = mat4(1.0);
+	highp mat4 bone_transform = mat4(0.0);
 
 #ifdef USE_SKELETON_SOFTWARE
 	// passing the transform as attributes
@@ -189,7 +189,7 @@ void main() {
 			              texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(1, 0)),
 			              texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(2, 0)),
 			              vec4(0.0, 0.0, 0.0, 1.0));
-
+			
 			bone_transform += transpose(b) * bone_weights[i];
 		}
 	}

--- a/drivers/gles2/shaders/stdlib.glsl
+++ b/drivers/gles2/shaders/stdlib.glsl
@@ -38,8 +38,5 @@ highp vec4 texel2DFetch(highp sampler2D tex, ivec2 size, ivec2 coord)
 	float x_coord = float(2 * coord.x + 1) / float(size.x * 2);
 	float y_coord = float(2 * coord.y + 1) / float(size.y * 2);
 
-	x_coord = float(coord.x) / float(size.x);
-	y_coord = float(coord.y) / float(size.y);
-
 	return texture2DLod(tex, vec2(x_coord, y_coord), 0.0);
 }


### PR DESCRIPTION
Until now, skeletal mesh deforms have been computed on CPU, which is quite heavy on performance. This adds support of calculating the deformations on the GPU.

This will not work properly on devices that have floating point texture support but not vertex shader texture unit support. (TODO)