### PR TITLE
Fix scene tab text drawing if font size is non-standart

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -152,7 +152,7 @@ void EditorNode::_update_scene_tabs() {
 
 		int current = editor_data.get_edited_scene();
 		bool unsaved = (i == current) ? saved_version != editor_data.get_undo_redo().get_version() : editor_data.get_scene_version(i) != 0;
-		scene_tabs->add_tab(editor_data.get_scene_title(i) + (unsaved ? "(*)" : ""), icon);
+		scene_tabs->add_tab(editor_data.get_scene_title(i) + (unsaved ? "(*) " : " "), icon);
 
 		if (show_rb && editor_data.get_scene_root_script(i).is_valid()) {
 			scene_tabs->set_tab_right_button(i, script_icon);


### PR DESCRIPTION
I accidentaly found this bug. For example if you have few scenes

![image](https://user-images.githubusercontent.com/3036176/44510735-220bdd00-a6be-11e8-81d9-cacd79d0e742.png)

Now change Main Font Size from 14 to 15 - bam

![image](https://user-images.githubusercontent.com/3036176/44510882-8b8beb80-a6be-11e8-9003-d794a367a97d.png)

I've fixed it just by adding extra space