### PR TITLE
Fix update 2D view on selections in scene tree

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -521,8 +521,10 @@ void SceneTreeEditor::_selected_changed() {
 void SceneTreeEditor::_deselect_items() {
 
 	// Clear currently elected items in scene tree dock.
-	if (editor_selection)
+	if (editor_selection) {
 		editor_selection->clear();
+		emit_signal("node_changed");
+	}
 }
 
 void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_selected) {
@@ -546,6 +548,7 @@ void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_
 	} else {
 		editor_selection->remove_node(n);
 	}
+	emit_signal("node_changed");
 }
 
 void SceneTreeEditor::_notification(int p_what) {


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/5885

![peek 2018-08-23 14-06](https://user-images.githubusercontent.com/4741886/44525306-d9b1e680-a6e0-11e8-9c0e-8056007b0549.gif)

![peek 2018-08-23 14-07](https://user-images.githubusercontent.com/4741886/44525311-df0f3100-a6e0-11e8-951d-07766301ff9c.gif)
