### PR TITLE
Disable graceful close feature by default

### DIFF
--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -188,6 +188,9 @@ void ScriptDebuggerRemote::debug(ScriptLanguage *p_script, bool p_can_continue) 
 
 		_get_output();
 
+		if (!tcp_client->is_connected_to_host())
+			break;
+
 		if (packet_peer_stream->get_available_packet_count() > 0) {
 
 			Variant var;

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -32,6 +32,9 @@
 
 #include "editor_settings.h"
 #include "project_settings.h"
+#include "script_editor_debugger.h"
+
+#include "plugins/script_editor_plugin.h"
 
 EditorRun::Status EditorRun::get_status() const {
 
@@ -196,7 +199,9 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 void EditorRun::stop() {
 
 	if (status != STATUS_STOP && pid != 0) {
-		const int max_wait_msec = GLOBAL_DEF("editor/stop_max_wait_msec", 10000);
+		ScriptEditor::get_singleton()->get_debugger()->stop();
+
+		const int max_wait_msec = GLOBAL_DEF("editor/stop_max_wait_msec", -1);
 		OS::get_singleton()->kill(pid, max_wait_msec);
 	}
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -190,20 +190,32 @@ BOOL WINAPI HandlerRoutine(_In_ DWORD dwCtrlType) {
 	}
 }
 
+struct _CloseData {
+	DWORD pid;
+	UINT msg;
+};
+
 BOOL CALLBACK _CloseWindowsEnum(HWND hWnd, LPARAM lParam) {
 	DWORD dwID;
 
 	GetWindowThreadProcessId(hWnd, &dwID);
 
-	if (dwID == (DWORD)lParam) {
-		PostMessage(hWnd, WM_CLOSE, 0, 0);
+	const _CloseData const *cd = reinterpret_cast<_CloseData *>(lParam);
+
+	if (dwID == cd->pid) {
+		PostMessage(hWnd, cd->msg, 0, 0);
 	}
 
 	return TRUE;
 }
 
-bool _close_gracefully(const PROCESS_INFORMATION &pi, const DWORD dwStopWaitMsec) {
-	if (!EnumWindows(_CloseWindowsEnum, pi.dwProcessId))
+bool _close_gracefully(const PROCESS_INFORMATION &pi, const UINT msg, const DWORD dwStopWaitMsec) {
+	_CloseData cd;
+
+	cd.msg = msg;
+	cd.pid = pi.dwProcessId;
+
+	if (!EnumWindows(_CloseWindowsEnum, reinterpret_cast<LPARAM>(&cd)))
 		return false;
 
 	if (WaitForSingleObject(pi.hProcess, dwStopWaitMsec) != WAIT_OBJECT_0)
@@ -262,6 +274,10 @@ void OS_Windows::initialize_core() {
 	IP_Unix::make_default();
 
 	cursor_shape = CURSOR_ARROW;
+
+#ifdef TOOLS_ENABLED
+	close_now_msg = RegisterWindowMessage("GodotCloseNow");
+#endif
 }
 
 bool OS_Windows::can_draw() const {
@@ -959,6 +975,20 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 		} break;
 
 		default: {
+
+#ifdef TOOLS_ENABLED
+			if (uMsg == close_now_msg) {
+				if (!main_loop)
+					break;
+
+				SceneTree *scene_tree = Object::cast_to<SceneTree>(main_loop);
+				if (!scene_tree)
+					break;
+
+				scene_tree->quit();
+				return 0;
+			}
+#endif
 
 			if (user_proc) {
 
@@ -2445,8 +2475,15 @@ Error OS_Windows::kill(const ProcessID &p_pid, const int p_max_wait_msec) {
 	process_map->erase(p_pid);
 
 	Error result;
+	bool closed;
 
-	if (p_max_wait_msec != -1 && _close_gracefully(pi, p_max_wait_msec)) {
+#ifdef TOOLS_ENABLED
+	closed = p_max_wait_msec != -1 && _close_gracefully(pi, close_now_msg, p_max_wait_msec);
+#else
+	closed = false;
+#endif
+
+	if (closed) {
 		result = OK;
 	} else {
 		const int ret = TerminateProcess(pi.hProcess, 0);

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -149,6 +149,9 @@ class OS_Windows : public OS {
 #ifdef WINMIDI_ENABLED
 	MIDIDriverWinMidi driver_midi;
 #endif
+#ifdef TOOLS_ENABLED
+	UINT close_now_msg;
+#endif
 
 	CrashHandler crash_handler;
 


### PR DESCRIPTION
This disables the graceful process close feature (introduced with ca1c851dbdc14701695d9589225b44d5681606f0) by default.

Fixes #21324 and keeps the feature so it can be used in case a project loads DLLs that need to cleanup their global state before the process terminates.