### PR TITLE
Open search bar on find next/find previous to avoid permanent code highlights

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -311,6 +311,10 @@ bool FindReplaceBar::search_current() {
 
 bool FindReplaceBar::search_prev() {
 
+	if (!is_visible()) {
+		popup_search(true);
+	}
+
 	uint32_t flags = 0;
 	String text = get_search_text();
 
@@ -336,6 +340,10 @@ bool FindReplaceBar::search_prev() {
 }
 
 bool FindReplaceBar::search_next() {
+
+	if (!is_visible()) {
+		popup_search(true);
+	}
 
 	uint32_t flags = 0;
 	String text = get_search_text();
@@ -373,7 +381,7 @@ void FindReplaceBar::_hide_bar() {
 	hide();
 }
 
-void FindReplaceBar::_show_search() {
+void FindReplaceBar::_show_search(bool p_show_only) {
 
 	show();
 	search_text->call_deferred("grab_focus");
@@ -382,19 +390,19 @@ void FindReplaceBar::_show_search() {
 		search_text->set_text(text_edit->get_selection_text());
 	}
 
-	if (!get_search_text().empty()) {
+	if (!get_search_text().empty() && !p_show_only) {
 		search_text->select_all();
 		search_text->set_cursor_position(search_text->get_text().length());
 		search_current();
 	}
 }
 
-void FindReplaceBar::popup_search() {
+void FindReplaceBar::popup_search(bool p_show_only) {
 
 	replace_text->hide();
 	hbc_button_replace->hide();
 	hbc_option_replace->hide();
-	_show_search();
+	_show_search(p_show_only);
 }
 
 void FindReplaceBar::popup_replace() {

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -89,7 +89,7 @@ class FindReplaceBar : public HBoxContainer {
 
 	void _get_search_from(int &r_line, int &r_col);
 
-	void _show_search();
+	void _show_search(bool p_show_only = false);
 	void _hide_bar();
 
 	void _editor_text_changed();
@@ -121,7 +121,7 @@ public:
 
 	void set_text_edit(TextEdit *p_text_edit);
 
-	void popup_search();
+	void popup_search(bool p_show_only = false);
 	void popup_replace();
 
 	bool search_current();


### PR DESCRIPTION
Fixes #20643

I went with the first fix proposed there, which is forcing search bar on find next/find previous commands (so if your search bar is hidden and you press F3, it will appear). With this change, you no longer need to CTRL + F to remove highlights if it happens that you follow steps described in the issue.

At first I just tried to call `popup_search()` on SEARCH_FIND_NEXT/PREV, but instead of only opening the bar, it also searched for next text, resulting in double search. To remedy this, I created `popup_search_simple()` and `_show_search_simple()`, which do just what their "non-simple" equivalents, minus going to next text. `popup_search_simple()` is called just before `search_next()`.

I really wasn't sure how to do this "correctly", so I hope it's alright >.>