### PR TITLE
Fix regular macOS build by passing -isysroot to compiler so correct system headers are found

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -613,3 +613,27 @@ def CommandNoCache(env, target, sources, command, **args):
     result = env.Command(target, sources, command, **args)
     env.NoCache(result)
     return result
+
+def detect_darwin_sdk_path(platform, env):
+    sdk_name = ''
+    if platform == 'osx':
+        sdk_name = 'macosx'
+        var_name = 'MACOS_SDK_PATH'
+    elif platform == 'iphone':
+        sdk_name = 'iphoneos'
+        var_name = 'IPHONESDK'
+    elif platform == 'iphonesimulator':
+        sdk_name = 'iphonesimulator'
+        var_name = 'IPHONESDK'
+    else:
+        raise Exception("Invalid platform argument passed to detect_darwin_sdk_path")
+
+    if not env[var_name]:
+        try:
+            sdk_path = subprocess.check_output(['xcrun', '--sdk', sdk_name, '--show-sdk-path']).strip()
+            if sdk_path:
+                env[var_name] = sdk_path
+        except (subprocess.CalledProcessError, OSError) as e:
+            print("Failed to find SDK path while running xcrun --sdk {} --show-sdk-path.".format(sdk_name))
+            raise
+

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from methods import detect_darwin_sdk_path
 
 
 def is_active():
@@ -23,6 +24,7 @@ def get_opts():
 
     return [
         ('osxcross_sdk', 'OSXCross SDK version', 'darwin14'),
+        ('MACOS_SDK_PATH', 'Path to the macOS SDK', ''),
         EnumVariable('debug_symbols', 'Add debugging symbols to release builds', 'yes', ('yes', 'no', 'full')),
         BoolVariable('separate_debug_symbols', 'Create a separate file containing debugging symbols', False),
     ]
@@ -83,6 +85,10 @@ def configure(env):
             env['RANLIB'] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ranlib"
             env['AS'] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-as"
             env.Append(CCFLAGS=['-D__MACPORTS__']) #hack to fix libvpx MM256_BROADCASTSI128_SI256 define
+
+        detect_darwin_sdk_path('osx', env)
+        env.Append(CPPFLAGS=['-isysroot', '$MACOS_SDK_PATH'])
+        env.Append(LINKFLAGS=['-isysroot', '$MACOS_SDK_PATH'])
 
     else: # osxcross build
         root = os.environ.get("OSXCROSS_ROOT", 0)


### PR DESCRIPTION
Hi.

I tried building master branch of Godot, and failed due to a compilation issue.
Here is the invocation and error message:

```
$ scons platform=osx target=release_debug verbose=true

Initial build] clang -o platform/osx/os_osx.osx.opt.tools.64.o -c -g1 -O2 -DDEBUG_ENABLED -arch x86_64 -w -Werror=return-type -DZSTD_STATIC_LINKING_ONLY -DFT2_BUILD_LIBRARY -DZLIB_DEBUG -DFREETYPE_ENABLED -DFT_CONFIG_OPTION_USE_PNG -DSVG_ENABLED -DOSX_ENABLED -DUNIX_ENABLED -DGLES_ENABLED -DAPPLE_STYLE_KEYS -DCOREAUDIO_ENABLED -DCOREMIDI_ENABLED -mmacosx-version-min=10.9 -DGLAD_ENABLED -DGLES_OVER_GL -DPTRCALL_ENABLED -DTOOLS_ENABLED -DGDSCRIPT_ENABLED -DMINIZIP_ENABLED -DXML_ENABLED -Icore -Icore/math -Ieditor -Idrivers -I. -Iplatform/osx -Ithirdparty/zstd -Ithirdparty/zstd/common -Ithirdparty/zlib -Ithirdparty/glad -Ithirdparty/freetype -Ithirdparty/freetype/include -Ithirdparty/libpng -Ithirdparty/nanosvg platform/osx/os_osx.mm

platform/osx/os_osx.mm:1421:41: error: use of undeclared identifier 'NSAppKitVersionNumber10_12'; did you mean 'NSAppKitVersionNumber'?
                                if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12) {
                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                    NSAppKitVersionNumber
/System/Library/Frameworks/AppKit.framework/Headers/NSApplication.h:26:28: note: 'NSAppKitVersionNumber' declared here
APPKIT_EXTERN const double NSAppKitVersionNumber;
```

This is on macOS 10.12.6, XCode Version 9.2 (9C40b)

It seems that the headers found in Appkit.framework under /System/Library/Frameworks/ are not up-to-date with respect with what is present in the SDK that comes with Xcode.

My pull request fixes that by passing -isysroot to point to the Xcode SDK.
This allows me to build successfully on my machine.
Thought it might make sense to fix it upstream as well.