### PR TITLE
Add print_verbose to print to stdout only in verbose mode

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -204,8 +204,7 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p
 
 	if (!p_no_cache && ResourceCache::has(local_path)) {
 
-		if (OS::get_singleton()->is_stdout_verbose())
-			print_line("load resource: " + local_path + " (cached)");
+		print_verbose("Loading resource: " + local_path + " (cached)");
 		if (r_error)
 			*r_error = OK;
 		return RES(ResourceCache::get(local_path));
@@ -216,9 +215,7 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p
 
 	ERR_FAIL_COND_V(path == "", RES());
 
-	if (OS::get_singleton()->is_stdout_verbose())
-		print_line("load resource: " + path);
-
+	print_verbose("Loading resource: " + path);
 	RES res = _load(path, local_path, p_type_hint, p_no_cache, r_error);
 
 	if (res.is_null()) {
@@ -286,9 +283,7 @@ Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String &p_
 
 	if (!p_no_cache && ResourceCache::has(local_path)) {
 
-		if (OS::get_singleton()->is_stdout_verbose())
-			print_line("load resource: " + local_path + " (cached)");
-
+		print_verbose("Loading resource: " + local_path + " (cached)");
 		Ref<Resource> res_cached = ResourceCache::get(local_path);
 		Ref<ResourceInteractiveLoaderDefault> ril = Ref<ResourceInteractiveLoaderDefault>(memnew(ResourceInteractiveLoaderDefault));
 
@@ -298,14 +293,10 @@ Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String &p_
 
 	bool xl_remapped = false;
 	String path = _path_remap(local_path, &xl_remapped);
-
 	ERR_FAIL_COND_V(path == "", Ref<ResourceInteractiveLoader>());
-
-	if (OS::get_singleton()->is_stdout_verbose())
-		print_line("load resource: ");
+	print_verbose("Loading resource: " + path);
 
 	bool found = false;
-
 	for (int i = 0; i < loader_count; i++) {
 
 		if (!loader[i]->recognize_path(path, p_type_hint))

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -2080,10 +2080,10 @@ void ObjectDB::cleanup() {
 
 				String node_name;
 				if (instances[*K]->is_class("Node"))
-					node_name = " - Node Name: " + String(instances[*K]->call("get_name"));
+					node_name = " - Node name: " + String(instances[*K]->call("get_name"));
 				if (instances[*K]->is_class("Resource"))
-					node_name = " - Resource Name: " + String(instances[*K]->call("get_name")) + " Path: " + String(instances[*K]->call("get_path"));
-				print_line("Leaked Instance: " + String(instances[*K]->get_class()) + ":" + itos(*K) + node_name);
+					node_name = " - Resource name: " + String(instances[*K]->call("get_name")) + " Path: " + String(instances[*K]->call("get_path"));
+				print_line("Leaked instance: " + String(instances[*K]->get_class()) + ":" + itos(*K) + node_name);
 			}
 		}
 	}

--- a/core/print_string.cpp
+++ b/core/print_string.cpp
@@ -107,3 +107,10 @@ void print_error(String p_string) {
 
 	_global_unlock();
 }
+
+void print_verbose(String p_string) {
+
+	if (OS::get_singleton()->is_stdout_verbose()) {
+		print_line(p_string);
+	}
+}

--- a/core/print_string.h
+++ b/core/print_string.h
@@ -58,5 +58,6 @@ extern bool _print_line_enabled;
 extern bool _print_error_enabled;
 extern void print_line(String p_string);
 extern void print_error(String p_string);
+extern void print_verbose(String p_string);
 
 #endif

--- a/core/string_db.cpp
+++ b/core/string_db.cpp
@@ -73,7 +73,6 @@ void StringName::cleanup() {
 			_Data *d = _table[i];
 			lost_strings++;
 			if (OS::get_singleton()->is_stdout_verbose()) {
-
 				if (d->cname) {
 					print_line("Orphan StringName: " + String(d->cname));
 				} else {
@@ -85,8 +84,8 @@ void StringName::cleanup() {
 			memdelete(d);
 		}
 	}
-	if (OS::get_singleton()->is_stdout_verbose() && lost_strings) {
-		print_line("StringName: " + itos(lost_strings) + " unclaimed string names at exit.");
+	if (lost_strings) {
+		print_verbose("StringName: " + itos(lost_strings) + " unclaimed string names at exit.");
 	}
 	lock->unlock();
 

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -116,9 +116,7 @@ Error AudioDriverALSA::init_device() {
 	status = snd_pcm_hw_params_set_period_size_near(pcm_handle, hwparams, &period_size, NULL);
 	CHECK_FAIL(status < 0);
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("audio buffer frames: " + itos(period_size) + " calculated latency: " + itos(period_size * 1000 / mix_rate) + "ms");
-	}
+	print_verbose("Audio buffer frames: " + itos(period_size) + " calculated latency: " + itos(period_size * 1000 / mix_rate) + "ms");
 
 	status = snd_pcm_hw_params_set_periods_near(pcm_handle, hwparams, &periods, NULL);
 	CHECK_FAIL(status < 0);

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -178,10 +178,8 @@ Error AudioDriverCoreAudio::init() {
 	input_position = 0;
 	input_size = 0;
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("CoreAudio: detected " + itos(channels) + " channels");
-		print_line("CoreAudio: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
-	}
+	print_verbose("CoreAudio: detected " + itos(channels) + " channels");
+	print_verbose("CoreAudio: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	AURenderCallbackStruct callback;
 	zeromem(&callback, sizeof(AURenderCallbackStruct));

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -138,9 +138,7 @@ RasterizerScene *RasterizerGLES2::get_scene() {
 
 void RasterizerGLES2::initialize() {
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("Using GLES2 video driver");
-	}
+	print_verbose("Using GLES2 video driver");
 
 #ifdef GLAD_ENABLED
 	if (!gladLoadGL()) {

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -33,7 +33,9 @@
 #include "gl_context/context_gl.h"
 #include "os/os.h"
 #include "project_settings.h"
+
 #include <string.h>
+
 RasterizerStorage *RasterizerGLES3::get_storage() {
 
 	return storage;
@@ -136,9 +138,7 @@ typedef void (*DebugMessageCallbackARB)(DEBUGPROCARB callback, const void *userP
 
 void RasterizerGLES3::initialize() {
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("Using GLES3 video driver");
-	}
+	print_verbose("Using GLES3 video driver");
 
 #ifdef GLAD_ENABLED
 	if (!gladLoadGL()) {

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -183,10 +183,8 @@ Error AudioDriverPulseAudio::init_device() {
 	buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
 	pa_buffer_size = buffer_frames * pa_map.channels;
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("PulseAudio: detected " + itos(pa_map.channels) + " channels");
-		print_line("PulseAudio: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
-	}
+	print_verbose("PulseAudio: detected " + itos(pa_map.channels) + " channels");
+	print_verbose("PulseAudio: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	pa_sample_spec spec;
 	spec.format = PA_SAMPLE_S16LE;
@@ -614,9 +612,7 @@ Error AudioDriverPulseAudio::capture_init_device() {
 			break;
 	}
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
-	}
+	print_verbose("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
 
 	pa_sample_spec spec;
 

--- a/drivers/rtaudio/audio_driver_rtaudio.cpp
+++ b/drivers/rtaudio/audio_driver_rtaudio.cpp
@@ -112,10 +112,7 @@ Error AudioDriverRtAudio::init() {
 
 	int latency = GLOBAL_DEF("audio/output_latency", DEFAULT_OUTPUT_LATENCY);
 	unsigned int buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
-
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
-	}
+	print_verbose("Audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	short int tries = 2;
 

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -106,7 +106,6 @@ Error FileAccessUnix::_open(const String &p_path, int p_mode_flags) {
 	if (is_backup_save_enabled() && (p_mode_flags & WRITE) && !(p_mode_flags & READ)) {
 		save_path = path;
 		path = path + ".tmp";
-		//print_line("saving instead to "+path);
 	}
 
 	f = fopen(path.utf8().get_data(), mode_string);
@@ -134,9 +133,6 @@ void FileAccessUnix::close() {
 	}
 
 	if (save_path != "") {
-
-		//unlink(save_path.utf8().get_data());
-		//print_line("renaming...");
 		int rename_error = rename((save_path + ".tmp").utf8().get_data(), save_path.utf8().get_data());
 
 		if (rename_error && close_fail_notify) {
@@ -291,8 +287,7 @@ uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 	if (!err) {
 		return flags.st_mtime;
 	} else {
-		print_line("ERROR IN: " + p_file);
-
+		ERR_EXPLAIN("Failed to get modified time for: " + p_file);
 		ERR_FAIL_V(0);
 	};
 }

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -321,10 +321,8 @@ Error AudioDriverWASAPI::init_render_device(bool reinit) {
 	input_position = 0;
 	input_size = 0;
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("WASAPI: detected " + itos(channels) + " channels");
-		print_line("WASAPI: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
-	}
+	print_verbose("WASAPI: detected " + itos(channels) + " channels");
+	print_verbose("WASAPI: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	return OK;
 }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -853,10 +853,7 @@ void EditorSettings::create() {
 		singleton->data_dir = data_dir;
 		singleton->cache_dir = cache_dir;
 
-		if (OS::get_singleton()->is_stdout_verbose()) {
-
-			print_line("EditorSettings: Load OK!");
-		}
+		print_verbose("EditorSettings: Load OK!");
 
 		singleton->setup_language();
 		singleton->setup_network();
@@ -968,8 +965,8 @@ void EditorSettings::save() {
 
 	if (err != OK) {
 		ERR_PRINTS("Error saving editor settings to " + singleton->config_file_path);
-	} else if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("EditorSettings Save OK!");
+	} else {
+		print_verbose("EditorSettings: Save OK!");
 	}
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1214,10 +1214,8 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	ClassDB::set_current_api(ClassDB::API_NONE); //no more api is registered at this point
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("CORE API HASH: " + itos(ClassDB::get_api_hash(ClassDB::API_CORE)));
-		print_line("EDITOR API HASH: " + itos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
-	}
+	print_verbose("CORE API HASH: " + itos(ClassDB::get_api_hash(ClassDB::API_CORE)));
+	print_verbose("EDITOR API HASH: " + itos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
 	MAIN_PRINT("Main: Done");
 
 	return OK;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2118,11 +2118,7 @@ Error CSharpScript::reload(bool p_keep_state) {
 
 		if (script_class) {
 #ifdef DEBUG_ENABLED
-			if (OS::get_singleton()->is_stdout_verbose()) {
-				OS::get_singleton()->print(String("Found class " + script_class->get_namespace() + "." +
-												  script_class->get_name() + " for script " + get_path() + "\n")
-												   .utf8());
-			}
+			print_verbose("Found class " + script_class->get_namespace() + "." + script_class->get_name() + " for script " + get_path());
 #endif
 
 			tool = script_class->has_attribute(CACHED_CLASS(ToolAttribute));

--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -97,8 +97,7 @@ MonoString *godot_icall_BuildInstance_get_MSBuildPath() {
 				return GDMonoMarshal::mono_string_from_godot(msbuild_tools_path + "MSBuild.exe");
 			}
 
-			if (OS::get_singleton()->is_stdout_verbose())
-				OS::get_singleton()->print("Cannot find executable for '" PROP_NAME_MSBUILD_VS "'. Trying with '" PROP_NAME_MSBUILD_MONO "'...\n");
+			print_verbose("Cannot find executable for '" PROP_NAME_MSBUILD_VS "'. Trying with '" PROP_NAME_MSBUILD_MONO "'...");
 		} // FALL THROUGH
 		case GodotSharpBuilds::MSBUILD_MONO: {
 			String msbuild_path = GDMono::get_singleton()->get_mono_reg_info().bin_dir.plus_file("msbuild.bat");
@@ -556,8 +555,9 @@ void GodotSharpBuilds::BuildProcess::start(bool p_blocking) {
 		exited = true;
 		exit_code = klass->get_field("exitCode")->get_int_value(mono_object);
 
-		if (exit_code != 0 && OS::get_singleton()->is_stdout_verbose())
-			OS::get_singleton()->print(String("MSBuild finished with exit code " + itos(exit_code) + "\n").utf8());
+		if (exit_code != 0) {
+			print_verbose("MSBuild finished with exit code " + itos(exit_code));
+		}
 
 		build_tab->on_build_exit(exit_code == 0 ? MonoBuildTab::RESULT_SUCCESS : MonoBuildTab::RESULT_ERROR);
 	} else {

--- a/modules/mono/mono_gd/gd_mono_log.cpp
+++ b/modules/mono/mono_gd/gd_mono_log.cpp
@@ -152,8 +152,7 @@ void GDMonoLog::initialize() {
 	log_level_id = log_level_get_id(log_level);
 
 	if (log_file) {
-		if (OS::get_singleton()->is_stdout_verbose())
-			OS::get_singleton()->print(String("Mono: Logfile is " + log_file_path + "\n").utf8());
+		print_verbose("Mono: Logfile is " + log_file_path);
 		mono_trace_set_log_handler(gdmono_MonoLogCallback, this);
 	} else {
 		OS::get_singleton()->printerr("Mono: No log file, using default log handler\n");

--- a/platform/android/audio_driver_jandroid.cpp
+++ b/platform/android/audio_driver_jandroid.cpp
@@ -82,9 +82,7 @@ Error AudioDriverAndroid::init() {
 
 	int latency = GLOBAL_DEF_RST("audio/output_latency", 25);
 	unsigned int buffer_size = next_power_of_2(latency * mix_rate / 1000);
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("audio buffer size: " + itos(buffer_size));
-	}
+	print_verbose("Audio buffer size: " + itos(buffer_size));
 
 	audioBuffer = env->CallObjectMethod(io, _init_audio, mix_rate, buffer_size);
 

--- a/platform/windows/joypad.cpp
+++ b/platform/windows/joypad.cpp
@@ -540,9 +540,7 @@ void JoypadWindows::load_xinput() {
 	}
 
 	if (!xinput_dll) {
-		if (OS::get_singleton()->is_stdout_verbose()) {
-			print_line("Could not find XInput, using DirectInput only");
-		}
+		print_verbose("Could not find XInput, using DirectInput only");
 		return;
 	}
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -170,13 +170,13 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 #ifdef TOUCH_ENABLED
 	if (!XQueryExtension(x11_display, "XInputExtension", &touch.opcode, &event_base, &error_base)) {
-		fprintf(stderr, "XInput extension not available");
+		print_verbose("XInput extension not available, touch support disabled.");
 	} else {
 		// 2.2 is the first release with multitouch
 		int xi_major = 2;
 		int xi_minor = 2;
 		if (XIQueryVersion(x11_display, &xi_major, &xi_minor) != Success) {
-			fprintf(stderr, "XInput 2.2 not available (server supports %d.%d)\n", xi_major, xi_minor);
+			print_verbose(vformat("XInput 2.2 not available (server supports %d.%d), touch support disabled.", xi_major, xi_minor));
 			touch.opcode = 0;
 		} else {
 			int dev_count;
@@ -198,14 +198,14 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 				}
 				if (direct_touch) {
 					touch.devices.push_back(dev->deviceid);
-					fprintf(stderr, "Using touch device: %s\n", dev->name);
+					print_verbose("XInput: Using touch device: " + String(dev->name));
 				}
 			}
 
 			XIFreeDeviceInfo(info);
 
-			if (is_stdout_verbose() && !touch.devices.size()) {
-				fprintf(stderr, "No touch devices found\n");
+			if (!touch.devices.size()) {
+				print_verbose("XInput: No touch devices found.");
 			}
 		}
 	}
@@ -266,7 +266,6 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	*/
 
 // maybe contextgl wants to be in charge of creating the window
-//print_line("def videomode "+itos(current_videomode.width)+","+itos(current_videomode.height));
 #if defined(OPENGL_ENABLED)
 
 	ContextGL_X11::ContextType opengl_api_type = ContextGL_X11::GLES_3_0_COMPATIBLE;
@@ -427,9 +426,7 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	cursor_theme = XcursorGetTheme(x11_display);
 
 	if (!cursor_theme) {
-		if (is_stdout_verbose()) {
-			print_line("XcursorGetTheme could not get cursor theme");
-		}
+		print_verbose("XcursorGetTheme could not get cursor theme");
 		cursor_theme = "default";
 	}
 
@@ -442,7 +439,6 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	current_cursor = CURSOR_ARROW;
 
 	if (cursor_theme) {
-		//print_line("cursor theme: "+String(cursor_theme));
 		for (int i = 0; i < CURSOR_MAX; i++) {
 
 			static const char *cursor_file[] = {
@@ -468,10 +464,8 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 			img[i] = XcursorLibraryLoadImage(cursor_file[i], cursor_theme, cursor_size);
 			if (img[i]) {
 				cursors[i] = XcursorImageLoadCursor(x11_display, img[i]);
-				//print_line("found cursor: "+String(cursor_file[i])+" id "+itos(cursors[i]));
 			} else {
-				if (OS::is_stdout_verbose())
-					print_line("failed cursor: " + String(cursor_file[i]));
+				print_verbose("Failed loading custom cursor: " + String(cursor_file[i]));
 			}
 		}
 	}
@@ -1516,7 +1510,6 @@ void OS_X11::handle_key_event(XKeyEvent *p_event, bool p_echo) {
 	// KeyMappingX11 also translates keysym to unicode.
 	// It does a binary search on a table to translate
 	// most properly.
-	//print_line("keysym_unicode: "+rtos(keysym_unicode));
 	unsigned int unicode = keysym_unicode > 0 ? KeyMappingX11::get_unicode_from_keysym(keysym_unicode) : 0;
 
 	/* Phase 4, determine if event must be filtered */


### PR DESCRIPTION
Equivalent of the cumbersome:
```
if (OS::get_singleton()->is_stdout_verbose())
	print_line(msg);
```

It still doesn't handle #7095 in a satisfactory way, IMO we need to refactor the way we do logging in the first place (and add more relevant info messages as different verbosity levels). But it's an improvement over the current hack :)