### PR TITLE
Disable ability to copy or cut text from LineEdit if secret mode is enabled.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -866,15 +866,14 @@ void LineEdit::_notification(int p_what) {
 
 void LineEdit::copy_text() {
 
-	if (selection.enabled) {
-
+	if (selection.enabled && !pass) {
 		OS::get_singleton()->set_clipboard(text.substr(selection.begin, selection.end - selection.begin));
 	}
 }
 
 void LineEdit::cut_text() {
 
-	if (selection.enabled) {
+	if (selection.enabled && !pass) {
 		OS::get_singleton()->set_clipboard(text.substr(selection.begin, selection.end - selection.begin));
 		selection_delete();
 	}


### PR DESCRIPTION
Fix for issue #21352.

Changes LineEdit behavior to ignore copy and cut commands if secret mode is enabled. This matches the behavior found in today's major web browsers. (Tested Firefox, Chrome, and Edge.)