### PR TITLE
Fix clear button not clearing plot when stopped

### DIFF
--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -100,6 +100,8 @@ void EditorProfiler::clear() {
 	updating_frame = false;
 	hover_metric = -1;
 	seeking = false;
+
+	_update_plot();
 }
 
 static String _get_percent_txt(float p_value, float p_total) {
@@ -167,7 +169,7 @@ void EditorProfiler::_update_plot() {
 	int w = graph->get_size().width;
 	int h = graph->get_size().height;
 
-	bool reset_texture = false;
+	bool reset_texture = graph_texture.is_null();
 
 	int desired_len = w * h * 4;
 


### PR DESCRIPTION
Fixes the profiler Clear button that did not clear the profiler plot if the profiler was stopped.