### PR TITLE
added undo to "Change Node Type"

### DIFF
--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -551,6 +551,10 @@ bool ScriptDebuggerRemote::_parse_live_edit(const Array &p_command) {
 
 		live_edit_funcs->tree_reparent_node_func(live_edit_funcs->udata, p_command[1], p_command[2], p_command[3], p_command[4]);
 
+	} else if (cmdstr == "live_replace_node") {
+
+		live_edit_funcs->tree_replace_node_func(live_edit_funcs->udata, p_command[1], p_command[2], p_command[3]);
+
 	} else {
 
 		return false;

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -406,6 +406,7 @@ public:
 		void (*tree_restore_node_func)(void *, ObjectID p_id, const NodePath &p_at, int p_at_pos);
 		void (*tree_duplicate_node_func)(void *, const NodePath &p_at, const String &p_new_name);
 		void (*tree_reparent_node_func)(void *, const NodePath &p_at, const NodePath &p_new_place, const String &p_new_name, int p_at_pos);
+		void (*tree_replace_node_func)(void *, const NodePath &p_parent, const String &p_type, const String &p_name);
 	};
 
 	_FORCE_INLINE_ static ScriptDebugger *get_singleton() { return singleton; }

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1645,6 +1645,18 @@ void ScriptEditorDebugger::live_debug_reparent_node(const NodePath &p_at, const 
 	}
 }
 
+void ScriptEditorDebugger::live_debug_replace_node(const NodePath &p_parent, const String &p_type, const String &p_name) {
+
+	if (live_debug && connection.is_valid()) {
+		Array msg;
+		msg.push_back("live_replace_node");
+		msg.push_back(p_parent);
+		msg.push_back(p_type);
+		msg.push_back(p_name);
+		ppeer->put_var(msg);
+	}
+}
+
 void ScriptEditorDebugger::set_breakpoint(const String &p_path, int p_line, bool p_enabled) {
 
 	if (connection.is_valid()) {
@@ -1855,6 +1867,7 @@ void ScriptEditorDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("live_debug_restore_node"), &ScriptEditorDebugger::live_debug_restore_node);
 	ClassDB::bind_method(D_METHOD("live_debug_duplicate_node"), &ScriptEditorDebugger::live_debug_duplicate_node);
 	ClassDB::bind_method(D_METHOD("live_debug_reparent_node"), &ScriptEditorDebugger::live_debug_reparent_node);
+	ClassDB::bind_method(D_METHOD("live_debug_replace_node"), &ScriptEditorDebugger::live_debug_replace_node);
 	ClassDB::bind_method(D_METHOD("_scene_tree_property_select_object"), &ScriptEditorDebugger::_scene_tree_property_select_object);
 	ClassDB::bind_method(D_METHOD("_scene_tree_property_value_edited"), &ScriptEditorDebugger::_scene_tree_property_value_edited);
 

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -225,6 +225,7 @@ public:
 	void live_debug_restore_node(ObjectID p_id, const NodePath &p_at, int p_at_pos);
 	void live_debug_duplicate_node(const NodePath &p_at, const String &p_new_name);
 	void live_debug_reparent_node(const NodePath &p_at, const NodePath &p_new_place, const String &p_new_name, int p_at_pos);
+	void live_debug_replace_node(const NodePath &p_parent, const String &p_type, const String &p_name);
 
 	void set_breakpoint(const String &p_path, int p_line, bool p_enabled);
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -251,6 +251,7 @@ private:
 	void _live_edit_restore_node_func(ObjectID p_id, const NodePath &p_at, int p_at_pos);
 	void _live_edit_duplicate_node_func(const NodePath &p_at, const String &p_new_name);
 	void _live_edit_reparent_node_func(const NodePath &p_at, const NodePath &p_new_place, const String &p_new_name, int p_at_pos);
+	void _live_edit_replace_node_func(const NodePath &p_parent, const String &p_type, const String &p_name);
 
 	static void _live_edit_node_path_funcs(void *self, const NodePath &p_path, int p_id) { reinterpret_cast<SceneTree *>(self)->_live_edit_node_path_func(p_path, p_id); }
 	static void _live_edit_res_path_funcs(void *self, const String &p_path, int p_id) { reinterpret_cast<SceneTree *>(self)->_live_edit_res_path_func(p_path, p_id); }
@@ -270,7 +271,7 @@ private:
 	static void _live_edit_restore_node_funcs(void *self, ObjectID p_id, const NodePath &p_at, int p_at_pos) { reinterpret_cast<SceneTree *>(self)->_live_edit_restore_node_func(p_id, p_at, p_at_pos); }
 	static void _live_edit_duplicate_node_funcs(void *self, const NodePath &p_at, const String &p_new_name) { reinterpret_cast<SceneTree *>(self)->_live_edit_duplicate_node_func(p_at, p_new_name); }
 	static void _live_edit_reparent_node_funcs(void *self, const NodePath &p_at, const NodePath &p_new_place, const String &p_new_name, int p_at_pos) { reinterpret_cast<SceneTree *>(self)->_live_edit_reparent_node_func(p_at, p_new_place, p_new_name, p_at_pos); }
-
+	static void _live_edit_replace_node_funcs(void *self, const NodePath &p_parent, const String &p_type, const String &p_name) { reinterpret_cast<SceneTree *>(self)->_live_edit_replace_node_func(p_parent, p_type, p_name); }
 #endif
 
 	enum {


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/15936

![peek 2018-08-24 13-44](https://user-images.githubusercontent.com/4741886/44583047-fc590380-a7a3-11e8-8703-4e5e10b4c88f.gif)

<details>
  <summary> EDIT: Can't reproduce anymore</summary>
Need to double check something

```
ERROR: get_node: Node not found: /root/EditorNode/@@5/@@6/@@14/@@16/@@20/@@24/@@25/@@26/@@42/@@43/@@52/@@53/@@5414/@@5281/@@5282/@@5283/@@5284/@@5285/Control/Control3
   At: scene/main/node.cpp:1304.
ERROR: get_meta: Condition ' !metadata.has(p_name) ' is true. returned: Variant()
   At: core/object.cpp:1084.
test: Null
```
Restarting the Editor lead to a missing Node Icon.

</details>


--
Added Live debug and noticed that "Make Scene Root" and "Rename Node" have no live_debug