### PR TITLE
Fix Members/Help Overview getting their items deselected when a tooltip appears

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1692,7 +1692,6 @@ void ScriptEditor::_update_script_names() {
 	if (restoring_layout)
 		return;
 
-	waiting_update_names = false;
 	Set<Ref<Script> > used;
 	Node *edited = EditorNode::get_singleton()->get_edited_scene();
 	if (edited) {
@@ -1816,8 +1815,12 @@ void ScriptEditor::_update_script_names() {
 		}
 	}
 
-	_update_members_overview();
-	_update_help_overview();
+	if (!waiting_update_names) {
+		_update_members_overview();
+		_update_help_overview();
+	} else {
+		waiting_update_names = false;
+	}
 	_update_members_overview_visibility();
 	_update_help_overview_visibility();
 	_update_script_colors();


### PR DESCRIPTION
I posted the cause in the issue itself, but for the lazy:

> Found the problem, when a tooltip appears, it makes the SceneTree fire the `tree_changed` signal, which with the ScriptEditorPlugin, triggers the `_update_script_names()` function, which then triggers the `_update_members_overview()`/`_update_help_overview()` functions, which **then** clears the ItemLists, deselecting the last selected item.

Fixes #16480.