### PR TITLE
Fix a mistake in itemlist multi_select signal

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -502,7 +502,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 					bool selected = !items[j].selected;
 					select(j, false);
 					if (selected)
-						emit_signal("multi_selected", i, true);
+						emit_signal("multi_selected", j, true);
 				}
 
 				if (mb->get_button_index() == BUTTON_RIGHT) {


### PR DESCRIPTION
When an itemlist has the multiple selection activated and you select several files with shift, the multi_selected signal is now sent with different ID for each modified selection.