### PR TITLE
Fall back to GLES2 if GLES3 is not working

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -658,6 +658,9 @@
 		</member>
 		<member name="rendering/quality/driver/driver_name" type="String" setter="" getter="">
 		</member>
+		<member name="rendering/quality/driver/driver_fallback" type="String" setter="" getter="">
+			Whether to allow falling back to other graphics drivers if the preferred driver is not available. Best means use the best working driver (this is the default). Never means never fall back to another driver even if it does not work. This means the project will not run if the preferred driver does not function.
+		</member>
 		<member name="rendering/quality/filters/anisotropic_filter_level" type="int" setter="" getter="">
 			Maximum Anisotropic filter level used for textures when anisotropy enabled.
 		</member>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -789,6 +789,10 @@ public:
 	void end_frame(bool p_swap_buffers) {}
 	void finalize() {}
 
+	static Error is_viable() {
+		return OK;
+	}
+
 	static Rasterizer *_create_current() {
 		return memnew(RasterizerDummy);
 	}

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -136,26 +136,21 @@ RasterizerScene *RasterizerGLES2::get_scene() {
 	return scene;
 }
 
-void RasterizerGLES2::initialize() {
-
-	print_verbose("Using GLES2 video driver");
+Error RasterizerGLES2::is_viable() {
 
 #ifdef GLAD_ENABLED
 	if (!gladLoadGL()) {
 		ERR_PRINT("Error initializing GLAD");
+		return ERR_UNAVAILABLE;
 	}
 
 // GLVersion seems to be used for both GL and GL ES, so we need different version checks for them
 #ifdef OPENGL_ENABLED // OpenGL 2.1 Profile required
-	if (GLVersion.major < 2) {
-#else // OpenGL ES 3.0
+	if (GLVersion.major < 2 || (GLVersion.major == 2 && GLVersion.minor < 1)) {
+#else // OpenGL ES 2.0
 	if (GLVersion.major < 2) {
 #endif
-		ERR_PRINT("Your system's graphic drivers seem not to support OpenGL 2.1 / OpenGL ES 2.0, sorry :(\n"
-				  "Try a drivers update, buy a new GPU or try software rendering on Linux; Godot will now crash with a segmentation fault.");
-		OS::get_singleton()->alert("Your system's graphic drivers seem not to support OpenGL 2.1 / OpenGL ES 2.0, sorry :(\n"
-								   "Godot Engine will self-destruct as soon as you acknowledge this error message.",
-				"Fatal error: Insufficient OpenGL / GLES driver support");
+		return ERR_UNAVAILABLE;
 	}
 
 #ifdef GLES_OVER_GL
@@ -181,14 +176,21 @@ void RasterizerGLES2::initialize() {
 			glGetFramebufferAttachmentParameteriv = glGetFramebufferAttachmentParameterivEXT;
 			glGenerateMipmap = glGenerateMipmapEXT;
 		} else {
-			ERR_PRINT("Your system's graphic drivers seem not to support GL_ARB(EXT)_framebuffer_object OpenGL extension, sorry :(\n"
-					  "Try a drivers update, buy a new GPU or try software rendering on Linux; Godot will now crash with a segmentation fault.");
-			OS::get_singleton()->alert("Your system's graphic drivers seem not to support GL_ARB(EXT)_framebuffer_object OpenGL extension, sorry :(\n"
-									   "Godot Engine will self-destruct as soon as you acknowledge this error message.",
-					"Fatal error: Insufficient OpenGL / GLES driver support");
+			return ERR_UNAVAILABLE;
 		}
 	}
 #endif
+
+#endif // GLAD_ENABLED
+
+	return OK;
+}
+
+void RasterizerGLES2::initialize() {
+
+	print_verbose("Using GLES2 video driver");
+
+#ifdef GLAD_ENABLED
 	if (true || OS::get_singleton()->is_stdout_verbose()) {
 		if (GLAD_GL_ARB_debug_output) {
 			glEnable(_EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
@@ -198,7 +200,6 @@ void RasterizerGLES2::initialize() {
 			print_line("OpenGL debugging not supported!");
 		}
 	}
-
 #endif // GLAD_ENABLED
 
 	// For debugging

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -61,9 +61,10 @@ public:
 	virtual void end_frame(bool p_swap_buffers);
 	virtual void finalize();
 
+	static Error is_viable();
 	static void make_current();
-
 	static void register_config();
+
 	RasterizerGLES2();
 	~RasterizerGLES2();
 };

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -62,9 +62,10 @@ public:
 	virtual void end_frame(bool p_swap_buffers);
 	virtual void finalize();
 
+	static Error is_viable();
 	static void make_current();
-
 	static void register_config();
+
 	RasterizerGLES3();
 	~RasterizerGLES3();
 };

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -830,6 +830,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		video_driver = GLOBAL_GET("rendering/quality/driver/driver_name");
 	}
 
+	GLOBAL_DEF("rendering/quality/driver/driver_fallback", "Best");
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/driver/driver_fallback", PropertyInfo(Variant::STRING, "rendering/quality/driver/driver_fallback", PROPERTY_HINT_ENUM, "Best,Never"));
+
 	GLOBAL_DEF("display/window/size/width", 1024);
 	GLOBAL_DEF("display/window/size/height", 600);
 	GLOBAL_DEF("display/window/size/resizable", true);
@@ -1040,6 +1043,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	if (err != OK) {
 		return err;
 	}
+
 	if (init_use_custom_pos) {
 		OS::get_singleton()->set_window_position(init_custom_pos);
 	}

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -99,8 +99,11 @@ int OSIPhone::get_current_video_driver() const {
 
 Error OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {
 
-	video_driver_index = p_video_driver; //this may be misleading
+	video_driver_index = VIDEO_DRIVER_GLES3;
 
+	if (RasterizerGLES3::is_viable() != OK) {
+		return ERR_UNAVAILABLE;
+	}
 	RasterizerGLES3::register_config();
 	RasterizerGLES3::make_current();
 

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -652,23 +652,57 @@ Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, 
 	attributes.alpha = false;
 	attributes.antialias = false;
 	ERR_FAIL_INDEX_V(p_video_driver, VIDEO_DRIVER_MAX, ERR_INVALID_PARAMETER);
-	switch (p_video_driver) {
-		case VIDEO_DRIVER_GLES3:
-			attributes.majorVersion = 2;
-			RasterizerGLES3::register_config();
-			RasterizerGLES3::make_current();
-			break;
-		case VIDEO_DRIVER_GLES2:
-			attributes.majorVersion = 1;
-			RasterizerGLES2::register_config();
-			RasterizerGLES2::make_current();
-			break;
+
+	bool gles3 = true;
+	if (p_video_driver == VIDEO_DRIVER_GLES2) {
+		gles3 = false;
+	}
+
+	bool gl_initialization_error = false;
+
+	while (true) {
+		if (gles3) {
+			if (RasterizerGLES3::is_viable() == OK) {
+				attributes.majorVersion = 2;
+				RasterizerGLES3::register_config();
+				RasterizerGLES3::make_current();
+				break;
+			} else {
+				if (GLOBAL_GET("rendering/quality/driver/driver_fallback") == "Best") {
+					p_video_driver = VIDEO_DRIVER_GLES2;
+					gles3 = false;
+					continue;
+				} else {
+					gl_initialization_error = true;
+					break;
+				}
+			}
+		} else {
+			if (RasterizerGLES2::is_viable() == OK) {
+				attributes.majorVersion = 1;
+				RasterizerGLES2::register_config();
+				RasterizerGLES2::make_current();
+				break;
+			} else {
+				gl_initialization_error = true;
+				break;
+			}
+		}
+	}
+
+	EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context(NULL, &attributes);
+	if (emscripten_webgl_make_context_current(ctx) != EMSCRIPTEN_RESULT_SUCCESS) {
+		gl_initialization_error = true;
+	}
+
+	if (gl_initialization_error) {
+		OS::get_singleton()->alert("Your browser does not support any of the supported WebGL versions.\n"
+								   "Please update your browser version.",
+				"Unable to initialize Video driver");
+		return ERR_UNAVAILABLE;
 	}
 
 	video_driver_index = p_video_driver;
-	EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context(NULL, &attributes);
-	ERR_EXPLAIN("WebGL " + itos(attributes.majorVersion) + ".0 not available");
-	ERR_FAIL_COND_V(emscripten_webgl_make_context_current(ctx) != EMSCRIPTEN_RESULT_SUCCESS, ERR_UNAVAILABLE);
 
 	video_mode = p_desired;
 	// Can't fulfil fullscreen request during start-up due to browser security.

--- a/platform/windows/context_gl_win.cpp
+++ b/platform/windows/context_gl_win.cpp
@@ -108,28 +108,24 @@ Error ContextGL_Win::initialize() {
 
 	hDC = GetDC(hWnd);
 	if (!hDC) {
-		MessageBox(NULL, "Can't Create A GL Device Context.", "ERROR", MB_OK | MB_ICONEXCLAMATION);
 		return ERR_CANT_CREATE; // Return FALSE
 	}
 
 	pixel_format = ChoosePixelFormat(hDC, &pfd);
 	if (!pixel_format) // Did Windows Find A Matching Pixel Format?
 	{
-		MessageBox(NULL, "Can't Find A Suitable pixel_format.", "ERROR", MB_OK | MB_ICONEXCLAMATION);
 		return ERR_CANT_CREATE; // Return FALSE
 	}
 
 	BOOL ret = SetPixelFormat(hDC, pixel_format, &pfd);
 	if (!ret) // Are We Able To Set The Pixel Format?
 	{
-		MessageBox(NULL, "Can't Set The pixel_format.", "ERROR", MB_OK | MB_ICONEXCLAMATION);
 		return ERR_CANT_CREATE; // Return FALSE
 	}
 
 	hRC = wglCreateContext(hDC);
 	if (!hRC) // Are We Able To Get A Rendering Context?
 	{
-		MessageBox(NULL, "Can't Create A Temporary GL Rendering Context.", "ERROR", MB_OK | MB_ICONEXCLAMATION);
 		return ERR_CANT_CREATE; // Return FALSE
 	}
 
@@ -151,7 +147,6 @@ Error ContextGL_Win::initialize() {
 
 		if (wglCreateContextAttribsARB == NULL) //OpenGL 3.0 is not supported
 		{
-			MessageBox(NULL, "Cannot get Proc Address for CreateContextAttribs", "ERROR", MB_OK | MB_ICONEXCLAMATION);
 			wglDeleteContext(hRC);
 			return ERR_CANT_CREATE;
 		}
@@ -159,7 +154,6 @@ Error ContextGL_Win::initialize() {
 		HGLRC new_hRC = wglCreateContextAttribsARB(hDC, 0, attribs);
 		if (!new_hRC) {
 			wglDeleteContext(hRC);
-			MessageBox(NULL, "Can't Create An OpenGL 3.3 Rendering Context.", "ERROR", MB_OK | MB_ICONEXCLAMATION);
 			return ERR_CANT_CREATE; // Return false
 		}
 		wglMakeCurrent(hDC, NULL);
@@ -168,7 +162,6 @@ Error ContextGL_Win::initialize() {
 
 		if (!wglMakeCurrent(hDC, hRC)) // Try To Activate The Rendering Context
 		{
-			MessageBox(NULL, "Can't Activate The GL 3.3 Rendering Context.", "ERROR", MB_OK | MB_ICONEXCLAMATION);
 			return ERR_CANT_CREATE; // Return FALSE
 		}
 	}

--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -116,8 +116,13 @@ Error ContextGL_X11::initialize() {
 	};
 
 	int fbcount;
-	GLXFBConfig fbconfig;
+	GLXFBConfig fbconfig = 0;
 	XVisualInfo *vi = NULL;
+
+	XSetWindowAttributes swa;
+	swa.event_mask = StructureNotifyMask;
+	swa.border_pixel = 0;
+	unsigned long valuemask = CWBorderPixel | CWColormap | CWEventMask;
 
 	if (OS::get_singleton()->is_layered_allowed()) {
 		GLXFBConfig *fbc = glXChooseFBConfig(x11_display, DefaultScreen(x11_display), visual_attribs_layered, &fbcount);
@@ -142,16 +147,10 @@ Error ContextGL_X11::initialize() {
 		}
 		ERR_FAIL_COND_V(!fbconfig, ERR_UNCONFIGURED);
 
-		XSetWindowAttributes swa;
-
-		swa.colormap = XCreateColormap(x11_display, RootWindow(x11_display, vi->screen), vi->visual, AllocNone);
-		swa.border_pixel = 0;
 		swa.background_pixmap = None;
 		swa.background_pixel = 0;
 		swa.border_pixmap = None;
-		swa.event_mask = StructureNotifyMask;
-
-		x11_window = XCreateWindow(x11_display, RootWindow(x11_display, vi->screen), 0, 0, OS::get_singleton()->get_video_mode().width, OS::get_singleton()->get_video_mode().height, 0, vi->depth, InputOutput, vi->visual, CWBorderPixel | CWColormap | CWEventMask | CWBackPixel, &swa);
+		valuemask |= CWBackPixel;
 
 	} else {
 		GLXFBConfig *fbc = glXChooseFBConfig(x11_display, DefaultScreen(x11_display), visual_attribs, &fbcount);
@@ -160,42 +159,21 @@ Error ContextGL_X11::initialize() {
 		vi = glXGetVisualFromFBConfig(x11_display, fbc[0]);
 
 		fbconfig = fbc[0];
-
-		XSetWindowAttributes swa;
-
-		swa.colormap = XCreateColormap(x11_display, RootWindow(x11_display, vi->screen), vi->visual, AllocNone);
-		swa.border_pixel = 0;
-		swa.event_mask = StructureNotifyMask;
-
-		x11_window = XCreateWindow(x11_display, RootWindow(x11_display, vi->screen), 0, 0, OS::get_singleton()->get_video_mode().width, OS::get_singleton()->get_video_mode().height, 0, vi->depth, InputOutput, vi->visual, CWBorderPixel | CWColormap | CWEventMask, &swa);
 	}
 
-	ERR_FAIL_COND_V(!x11_window, ERR_UNCONFIGURED);
-	set_class_hint(x11_display, x11_window);
-	XMapWindow(x11_display, x11_window);
-
-	int (*oldHandler)(Display *, XErrorEvent *) =
-			XSetErrorHandler(&ctxErrorHandler);
+	int (*oldHandler)(Display *, XErrorEvent *) = XSetErrorHandler(&ctxErrorHandler);
 
 	switch (context_type) {
-		case GLES_2_0_COMPATIBLE:
 		case OLDSTYLE: {
+
 			p->glx_context = glXCreateContext(x11_display, vi, 0, GL_TRUE);
-		} break;
-		/*
-		case ContextType::GLES_2_0_COMPATIBLE: {
-
-			static int context_attribs[] = {
-				GLX_CONTEXT_MAJOR_VERSION_ARB, 3,
-				GLX_CONTEXT_MINOR_VERSION_ARB, 0,
-				None
-			};
-
-			p->glx_context = glXCreateContextAttribsARB(x11_display, fbconfig, NULL, true, context_attribs);
-			ERR_EXPLAIN("Could not obtain an OpenGL 3.0 context!");
 			ERR_FAIL_COND_V(!p->glx_context, ERR_UNCONFIGURED);
 		} break;
-		*/
+		case GLES_2_0_COMPATIBLE: {
+
+			p->glx_context = glXCreateNewContext(x11_display, fbconfig, GLX_RGBA_TYPE, 0, true);
+			ERR_FAIL_COND_V(!p->glx_context, ERR_UNCONFIGURED);
+		} break;
 		case GLES_3_0_COMPATIBLE: {
 
 			static int context_attribs[] = {
@@ -207,23 +185,21 @@ Error ContextGL_X11::initialize() {
 			};
 
 			p->glx_context = glXCreateContextAttribsARB(x11_display, fbconfig, NULL, true, context_attribs);
-			ERR_EXPLAIN("Could not obtain an OpenGL 3.3 context!");
 			ERR_FAIL_COND_V(ctxErrorOccurred || !p->glx_context, ERR_UNCONFIGURED);
 		} break;
 	}
+
+	swa.colormap = XCreateColormap(x11_display, RootWindow(x11_display, vi->screen), vi->visual, AllocNone);
+	x11_window = XCreateWindow(x11_display, RootWindow(x11_display, vi->screen), 0, 0, OS::get_singleton()->get_video_mode().width, OS::get_singleton()->get_video_mode().height, 0, vi->depth, InputOutput, vi->visual, valuemask, &swa);
+
+	ERR_FAIL_COND_V(!x11_window, ERR_UNCONFIGURED);
+	set_class_hint(x11_display, x11_window);
+	XMapWindow(x11_display, x11_window);
 
 	XSync(x11_display, False);
 	XSetErrorHandler(oldHandler);
 
 	glXMakeCurrent(x11_display, x11_window, p->glx_context);
-
-	/*
-	glWrapperInit(wrapper_get_proc_address);
-	glFlush();
-
-	glXSwapBuffers(x11_display,x11_window);
-*/
-	//glXMakeCurrent(x11_display, None, NULL);
 
 	XFree(vi);
 
@@ -297,7 +273,6 @@ ContextGL_X11::ContextGL_X11(::Display *p_x11_display, ::Window &p_x11_window, c
 ContextGL_X11::~ContextGL_X11() {
 	release_current();
 	glXDestroyContext(x11_display, p->glx_context);
-
 	memdelete(p);
 }
 


### PR DESCRIPTION
This adds a static is_viable() method to all rasterizers which has to be
called before initializing the rasterizer. This allows us to check what
rasterizer to use in OS::initialize together with the GL context
initialization.

This commit also adds a new project setting
"rendering/quality/driver/driver_fallback" which allows the creator of a
project to specify whether or not fallback to GLES2 is allowed. This
setting is ignored for the editor so the editor will always open even if
the project itself cannot run. This will hopefully reduce confusion for
users downloading projects from the internet.

We also no longer crash when GLES3 is not functioning on a platform.

This fixes #15324