### PR TITLE
log to console if falling back to dummy audio driver

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -185,8 +185,12 @@ void AudioDriverManager::initialize(int p_driver) {
 
 		if (drivers[i]->init() == OK) {
 			drivers[i]->set_singleton();
-			return;
+			break;
 		}
+	}
+
+	if (driver_count > 1 && AudioDriver::get_singleton()->get_name() == "Dummy") {
+		WARN_PRINT("All audio drivers failed, falling back to the dummy driver.");
 	}
 }
 


### PR DESCRIPTION
Since dummy audio driver now seems to serve as fallback, I think it should be visible when other audio drivers fail. This diff logs it with `print_line()`; main alternative would be `alert()` but that seemed too intrusive for my taste.