### PR TITLE
Fix advancing based on condition in AnimationNodeStateMachinePlayback

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -390,7 +390,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *sm, 
 				auto_advance = true;
 			}
 
-			if (sm->transitions[i].from == current && sm->transitions[i].transition->has_auto_advance()) {
+			if (sm->transitions[i].from == current && auto_advance) {
 
 				if (sm->transitions[i].transition->get_priority() < priority_best) {
 					auto_advance_to = i;


### PR DESCRIPTION
It looks like with the rewrite to AnimationTree in c7e4527a88b90062e1d5fdea50c1b85cea3c8c6c, that advancing between states via a condition was added. However, the `auto_advance` variable was never used to actually do the advancing.

This fixes that, and states are advanced correctly when the condition is true.