### PR TITLE
Fixes several resource leaks listed on coverity

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1008,7 +1008,10 @@ RID RasterizerSceneGLES3::light_instance_create(RID p_light) {
 	light_instance->light = p_light;
 	light_instance->light_ptr = storage->light_owner.getornull(p_light);
 
-	ERR_FAIL_COND_V(!light_instance->light_ptr, RID());
+	if (!light_instance->light_ptr) {
+		memdelete(light_instance);
+		ERR_FAIL_COND_V(!light_instance->light_ptr, RID());
+	}
 
 	light_instance->self = light_instance_owner.make_rid(light_instance);
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6998,7 +6998,10 @@ RID RasterizerStorageGLES3::canvas_light_shadow_buffer_create(int p_width) {
 	//printf("errnum: %x\n",status);
 	glBindFramebuffer(GL_FRAMEBUFFER, RasterizerStorageGLES3::system_fbo);
 
-	ERR_FAIL_COND_V(status != GL_FRAMEBUFFER_COMPLETE, RID());
+	if (status != GL_FRAMEBUFFER_COMPLETE) {
+		memdelete(cls);
+		ERR_FAIL_COND_V(status != GL_FRAMEBUFFER_COMPLETE, RID());
+	}
 
 	return canvas_light_shadow_owner.make_rid(cls);
 }

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1322,6 +1322,8 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 
 						int ret = _parse_expression(codegen, op, p_stack_level);
 						if (ret < 0) {
+							memdelete(id);
+							memdelete(op);
 							return ERR_PARSE_ERROR;
 						}
 
@@ -1341,6 +1343,8 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 							// compile the condition
 							int ret = _parse_expression(codegen, branch.compiled_pattern, p_stack_level);
 							if (ret < 0) {
+								memdelete(id);
+								memdelete(op);
 								return ERR_PARSE_ERROR;
 							}
 
@@ -1353,6 +1357,8 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 
 							Error err = _parse_block(codegen, branch.body, p_stack_level, p_break_addr, continue_addr);
 							if (err) {
+								memdelete(id);
+								memdelete(op);
 								return ERR_PARSE_ERROR;
 							}
 
@@ -1363,6 +1369,9 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 						}
 
 						codegen.opcodes.write[break_addr + 1] = codegen.opcodes.size();
+
+						memdelete(id);
+						memdelete(op);
 
 					} break;
 

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -205,6 +205,8 @@ Error RegEx::compile(const String &p_pattern) {
 
 		code = pcre2_compile_16(p, pattern.length(), flags, &err, &offset, cctx);
 
+		pcre2_compile_context_free_16(cctx);
+
 		if (!code) {
 			PCRE2_UCHAR16 buf[256];
 			pcre2_get_error_message_16(err, buf, 256);
@@ -220,6 +222,8 @@ Error RegEx::compile(const String &p_pattern) {
 		PCRE2_SPTR32 p = (PCRE2_SPTR32)pattern.c_str();
 
 		code = pcre2_compile_32(p, pattern.length(), flags, &err, &offset, cctx);
+
+		pcre2_compile_context_free_32(cctx);
 
 		if (!code) {
 			PCRE2_UCHAR32 buf[256];
@@ -285,6 +289,8 @@ Ref<RegExMatch> RegEx::search(const String &p_subject, int p_offset, int p_end) 
 
 		if (res < 0) {
 			pcre2_match_data_free_32(match);
+			pcre2_match_context_free_32(mctx);
+
 			return NULL;
 		}
 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1591,8 +1591,11 @@ public:
 				String apkfname = "main." + itos(version_code) + "." + get_package_name(package_name) + ".obb";
 				String fullpath = p_path.get_base_dir().plus_file(apkfname);
 				err = save_pack(p_preset, fullpath);
+
 				if (err != OK) {
+					unzClose(pkg);
 					EditorNode::add_io_error("Could not write expansion package file: " + apkfname);
+
 					return OK;
 				}
 


### PR DESCRIPTION
Fixes resource leaks in:
- gdscript (CID#269851)
- gdscript compiler  (CID#269423)
- regex  (CID#269571 &  CID#269860)
- android/export  (CID#269470)
- gles3/rasterizer scene (CID#269848)
- gles3/rasterizer storage (CID#269660)