### PR TITLE
Fix FileDialog doesn't display directory content until refresh

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -43,6 +43,10 @@ void Popup::_notification(int p_what) {
 			popped_up = false;
 			notification(NOTIFICATION_POPUP_HIDE);
 			emit_signal("popup_hide");
+		} else if (!popped_up && is_visible_in_tree()) {
+			popped_up = true;
+			_post_popup();
+			notification(NOTIFICATION_POST_POPUP);
 		}
 
 		update_configuration_warning();


### PR DESCRIPTION
__post_popup()_ was never called.
Fixes #20809.
