### PR TITLE
Fix uninitialized mipmap levels

### DIFF
--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -247,8 +247,8 @@ void image_compress_cvtt(Image *p_image, float p_lossy_quality, Image::CompressS
 		}
 
 		dst_ofs += (MAX(4, bw) * MAX(4, bh)) >> shift;
-		w >>= 1;
-		h >>= 1;
+		w = MAX(w / 2, 1);
+		h = MAX(h / 2, 1);
 	}
 
 	if (num_job_threads > 0) {

--- a/modules/squish/image_compress_squish.cpp
+++ b/modules/squish/image_compress_squish.cpp
@@ -193,8 +193,8 @@ void image_compress_squish(Image *p_image, float p_lossy_quality, Image::Compres
 			int src_ofs = p_image->get_mipmap_offset(i);
 			squish::CompressImage(&rb[src_ofs], w, h, &wb[dst_ofs], squish_comp);
 			dst_ofs += (MAX(4, bw) * MAX(4, bh)) >> shift;
-			w >>= 1;
-			h >>= 1;
+			w = MAX(w / 2, 1);
+			h = MAX(h / 2, 1);
 		}
 
 		rb = PoolVector<uint8_t>::Read();


### PR DESCRIPTION
Fix #21391 and some related problems with low mipmap levels not being initialized.

`generate_mipmaps` always fails to generate the last mipmap, `_generate_po2_mipmap` fails to generate mipmaps of rectangular textures where one of the input dimensions is 1px, and the Squish compressor would fail in the same rectangular texture situation due to the input dimension being reduced to zero.