### PR TITLE
Add a 2D scale factor property

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -265,8 +265,10 @@
 			</argument>
 			<argument index="3" name="shrink" type="float" default="1">
 			</argument>
+			<argument index="4" name="scale" type="float" default="1">
+			</argument>
 			<description>
-				Configures screen stretching to the given [enum StretchMode], [enum StretchAspect], minimum size and [code]shrink[/code] ratio.
+				Configures screen stretching to the given [enum StretchMode], [enum StretchAspect], minimum size, [code]shrink[/code] and [code]scale[/code].
 			</description>
 		</method>
 	</methods>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1728,6 +1728,7 @@ bool Main::start() {
 			String stretch_aspect = GLOBAL_DEF("display/window/stretch/aspect", "ignore");
 			Size2i stretch_size = Size2(GLOBAL_DEF("display/window/size/width", 0), GLOBAL_DEF("display/window/size/height", 0));
 			real_t stretch_shrink = GLOBAL_DEF("display/window/stretch/shrink", 1.0);
+			real_t stretch_scale = GLOBAL_DEF("display/window/stretch/scale", 1.0);
 
 			SceneTree::StretchMode sml_sm = SceneTree::STRETCH_MODE_DISABLED;
 			if (stretch_mode == "2d")
@@ -1745,7 +1746,7 @@ bool Main::start() {
 			else if (stretch_aspect == "expand")
 				sml_aspect = SceneTree::STRETCH_ASPECT_EXPAND;
 
-			sml->set_screen_stretch(sml_sm, sml_aspect, stretch_size, stretch_shrink);
+			sml->set_screen_stretch(sml_sm, sml_aspect, stretch_size, stretch_shrink, stretch_scale);
 
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
@@ -1784,6 +1785,8 @@ bool Main::start() {
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/aspect", PropertyInfo(Variant::STRING, "display/window/stretch/aspect", PROPERTY_HINT_ENUM, "ignore,keep,keep_width,keep_height,expand"));
 			GLOBAL_DEF("display/window/stretch/shrink", 1.0);
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/shrink", PropertyInfo(Variant::FLOAT, "display/window/stretch/shrink", PROPERTY_HINT_RANGE, "1.0,8.0,0.1"));
+			GLOBAL_DEF("display/window/stretch/scale", 1.0);
+			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/scale", PropertyInfo(Variant::FLOAT, "display/window/stretch/scale", PROPERTY_HINT_RANGE, "0.1,8,0.01,or_greater"));
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
 			GLOBAL_DEF("gui/common/snap_controls_to_pixels", true);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -151,6 +151,7 @@ private:
 	StretchAspect stretch_aspect;
 	Size2i stretch_min;
 	real_t stretch_shrink;
+	real_t stretch_scale;
 
 	void _update_font_oversampling(float p_ratio);
 	void _update_root_rect();
@@ -335,7 +336,7 @@ public:
 	void get_nodes_in_group(const StringName &p_group, List<Node *> *p_list);
 	bool has_group(const StringName &p_identifier) const;
 
-	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 &p_minsize, real_t p_shrink = 1);
+	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 &p_minsize, real_t p_shrink = 1.0, real_t p_scale = 1.0);
 
 	void set_use_font_oversampling(bool p_oversampling);
 	bool is_using_font_oversampling() const;


### PR DESCRIPTION
This can be used to make 2D elements larger or smaller, independently of the current stretch mode.

Only the `disabled` and `2d` stretch modes support this new property.

Note that I removed the property hint for `shrink` as it was causing the Project Settings GUI to recognize it as a string instead of a floating-point value (it seems there's no way to add property hints for floats).

[Demo project](https://github.com/godotengine/godot/files/2321558/2d-scaling-demo.zip)