### PR TITLE
Don't crash on storing an empty pascal case string

### DIFF
--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -500,6 +500,11 @@ void FileAccess::store_string(const String &p_string) {
 
 void FileAccess::store_pascal_string(const String &p_string) {
 
+	if (p_string.length() == 0) {
+		store_32(0);
+		return;
+	}
+
 	CharString cs = p_string.utf8();
 	store_32(cs.length());
 	store_buffer((uint8_t *)&cs[0], cs.length());


### PR DESCRIPTION
This behavior mirrors the behavior of storing a regular string. I've
tested this with Godot 3.0.0-stable and the crash exists there also. I
do not believe that previously Strings behaved differently so I'm going
to assume the bug is actually with storing pascal type strings and not
with the String class itself.

This fixes #21242