### PR TITLE
Style: Enable clang-format on GLSL shaders

### DIFF
--- a/drivers/gles2/shaders/blend_shape.glsl
+++ b/drivers/gles2/shaders/blend_shape.glsl
@@ -1,3 +1,4 @@
+/* clang-format off */
 [vertex]
 
 /*
@@ -23,6 +24,7 @@ ARRAY_INDEX=8,
 /* INPUT ATTRIBS */
 
 layout(location = 0) in highp VFORMAT vertex_attrib;
+/* clang-format on */
 layout(location = 1) in vec3 normal_attrib;
 
 #ifdef ENABLE_TANGENT
@@ -183,8 +185,10 @@ void main() {
 	gl_Position = vec4(0.0);
 }
 
+/* clang-format off */
 [fragment]
 
 void main() {
 
 }
+/* clang-format on */

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -1,3 +1,4 @@
+/* clang-format off */
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
@@ -9,6 +10,7 @@ precision mediump int;
 #endif
 
 uniform highp mat4 projection_matrix;
+/* clang-format on */
 uniform highp mat4 modelview_matrix;
 uniform highp mat4 extra_matrix;
 attribute highp vec2 vertex; // attrib:0
@@ -29,7 +31,11 @@ uniform vec4 src_rect;
 
 uniform highp float time;
 
+/* clang-format off */
+
 VERTEX_SHADER_GLOBALS
+
+/* clang-format on */
 
 vec2 select(vec2 a, vec2 b, bvec2 c) {
 	vec2 ret;
@@ -74,17 +80,21 @@ void main() {
 
 #endif
 
-{
-	vec2 src_vtx = outvec.xy;
+	{
+		vec2 src_vtx = outvec.xy;
+		/* clang-format off */
+
 VERTEX_SHADER_CODE
 
-}
+		/* clang-format on */
+	}
 
 	color_interp = color;
 
 	gl_Position = projection_matrix * modelview_matrix * outvec;
 }
 
+/* clang-format off */
 [fragment]
 
 #ifdef USE_GLES_OVER_GL
@@ -96,6 +106,7 @@ precision mediump int;
 #endif
 
 uniform sampler2D color_texture; // texunit:-1
+/* clang-format on */
 uniform highp vec2 color_texpixel_size;
 uniform mediump sampler2D normal_texture; // texunit:-2
 
@@ -118,7 +129,11 @@ uniform vec2 screen_pixel_size;
 
 #endif
 
+/* clang-format off */
+
 FRAGMENT_SHADER_GLOBALS
+
+/* clang-format on */
 
 void main() {
 
@@ -129,11 +144,13 @@ void main() {
 #ifdef SCREEN_UV_USED
 	vec2 screen_uv = gl_FragCoord.xy * screen_pixel_size;
 #endif
-{
+	{
+		/* clang-format off */
 
 FRAGMENT_SHADER_CODE
 
-}
+		/* clang-format on */
+	}
 
 	color *= final_modulate;
 

--- a/drivers/gles2/shaders/canvas_shadow.glsl
+++ b/drivers/gles2/shaders/canvas_shadow.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 uniform highp mat4 projection_matrix;
+/* clang-format on */
 uniform highp mat4 light_matrix;
 uniform highp mat4 world_matrix;
 uniform highp float distance_norm;
@@ -15,9 +17,11 @@ void main() {
 	position_interp = gl_Position;
 }
 
+/* clang-format off */
 [fragment]
 
 in highp vec4 position_interp;
+/* clang-format on */
 
 #ifdef USE_RGBA_SHADOWS
 

--- a/drivers/gles2/shaders/copy.glsl
+++ b/drivers/gles2/shaders/copy.glsl
@@ -1,3 +1,4 @@
+/* clang-format off */
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
@@ -9,6 +10,7 @@ precision mediump int;
 #endif
 
 attribute highp vec4 vertex_attrib; // attrib:0
+/* clang-format on */
 
 #if defined(USE_CUBEMAP) || defined(USE_PANORAMA)
 attribute vec3 cube_in; // attrib:4
@@ -46,6 +48,7 @@ void main() {
 #endif
 }
 
+/* clang-format off */
 [fragment]
 
 #define M_PI 3.14159265359
@@ -63,6 +66,7 @@ varying vec3 cube_interp;
 #else
 varying vec2 uv_interp;
 #endif
+/* clang-format on */
 
 #ifdef USE_CUBEMAP
 uniform samplerCube source_cube; // texunit:0

--- a/drivers/gles2/shaders/cube_to_dp.glsl
+++ b/drivers/gles2/shaders/cube_to_dp.glsl
@@ -1,3 +1,4 @@
+/* clang-format off */
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
@@ -9,6 +10,7 @@ precision mediump int;
 #endif
 
 attribute highp vec4 vertex_attrib; // attrib:0
+/* clang-format on */
 attribute vec2 uv_in; // attrib:4
 
 varying vec2 uv_interp;
@@ -19,6 +21,7 @@ void main() {
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 #ifdef USE_GLES_OVER_GL
@@ -30,6 +33,7 @@ precision mediump int;
 #endif
 
 uniform highp samplerCube source_cube; //texunit:0
+/* clang-format on */
 varying vec2 uv_interp;
 
 uniform bool z_flip;

--- a/drivers/gles2/shaders/cubemap_filter.glsl
+++ b/drivers/gles2/shaders/cubemap_filter.glsl
@@ -1,3 +1,4 @@
+/* clang-format off */
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
@@ -9,6 +10,7 @@ precision mediump int;
 #endif
 
 attribute highp vec2 vertex; // attrib:0
+/* clang-format on */
 attribute highp vec2 uv; // attrib:4
 
 varying highp vec2 uv_interp;
@@ -19,6 +21,7 @@ void main() {
 	gl_Position = vec4(vertex, 0, 1);
 }
 
+/* clang-format off */
 [fragment]
 
 #extension GL_ARB_shader_texture_lod : enable
@@ -41,6 +44,7 @@ uniform sampler2D source_panorama; //texunit:0
 #else
 uniform samplerCube source_cube; //texunit:0
 #endif
+/* clang-format on */
 
 uniform int face_id;
 uniform float roughness;

--- a/drivers/gles2/shaders/effect_blur.glsl
+++ b/drivers/gles2/shaders/effect_blur.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -22,6 +24,7 @@ void main() {
 #endif
 }
 
+/* clang-format off */
 [fragment]
 
 #if !defined(GLES_OVER_GL)
@@ -29,6 +32,7 @@ precision mediump float;
 #endif
 
 in vec2 uv_interp;
+/* clang-format on */
 uniform sampler2D source_color; //texunit:0
 
 #ifdef SSAO_MERGE

--- a/drivers/gles2/shaders/exposure.glsl
+++ b/drivers/gles2/shaders/exposure.glsl
@@ -1,15 +1,19 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 
 void main() {
 
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 uniform highp sampler2D source_exposure; //texunit:0
+/* clang-format on */
 
 #ifdef EXPOSURE_BEGIN
 

--- a/drivers/gles2/shaders/particles.glsl
+++ b/drivers/gles2/shaders/particles.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 color;
+/* clang-format on */
 layout(location = 1) in highp vec4 velocity_active;
 layout(location = 2) in highp vec4 custom;
 layout(location = 3) in highp vec4 xform_1;
@@ -45,15 +47,21 @@ out highp vec4 out_xform_3; //tfb:
 
 #if defined(USE_MATERIAL)
 
+/* clang-format off */
 layout(std140) uniform UniformData { //ubo:0
 
 MATERIAL_UNIFORMS
 
 };
+/* clang-format on */
 
 #endif
 
+/* clang-format off */
+
 VERTEX_SHADER_GLOBALS
+
+/* clang-format on */
 
 uint hash(uint x) {
 
@@ -165,9 +173,11 @@ void main() {
 		//execute shader
 
 		{
+			/* clang-format off */
 
 VERTEX_SHADER_CODE
 
+			/* clang-format on */
 		}
 
 #if !defined(DISABLE_FORCE)
@@ -223,6 +233,7 @@ VERTEX_SHADER_CODE
 #endif //PARTICLES_COPY
 }
 
+/* clang-format off */
 [fragment]
 
 //any code here is never executed, stuff is filled just so it works
@@ -240,12 +251,16 @@ MATERIAL_UNIFORMS
 FRAGMENT_SHADER_GLOBALS
 
 void main() {
-
 	{
+
 LIGHT_SHADER_CODE
+
 	}
 
 	{
+
 FRAGMENT_SHADER_CODE
+
 	}
 }
+/* clang-format on */

--- a/drivers/gles2/shaders/resolve.glsl
+++ b/drivers/gles2/shaders/resolve.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -11,6 +13,7 @@ void main() {
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 #if !defined(GLES_OVER_GL)
@@ -18,6 +21,7 @@ precision mediump float;
 #endif
 
 in vec2 uv_interp;
+/* clang-format on */
 uniform sampler2D source_specular; //texunit:0
 uniform sampler2D source_ssr; //texunit:1
 

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1,3 +1,4 @@
+/* clang-format off */
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
@@ -15,6 +16,7 @@ precision mediump int;
 //
 
 attribute highp vec4 vertex_attrib; // attrib:0
+/* clang-format on */
 attribute vec3 normal_attrib; // attrib:1
 
 #if defined(ENABLE_TANGENT_INTERP) || defined(ENABLE_NORMALMAP)
@@ -108,7 +110,11 @@ varying vec2 uv_interp;
 varying vec2 uv2_interp;
 #endif
 
+/* clang-format off */
+
 VERTEX_SHADER_GLOBALS
+
+/* clang-format on */
 
 void main() {
 
@@ -206,11 +212,13 @@ void main() {
 
 #define world_transform world_matrix
 
-{
+	{
+		/* clang-format off */
 
 VERTEX_SHADER_CODE
 
-}
+		/* clang-format on */
+	}
 
 	vec4 outvec = vertex;
 
@@ -254,6 +262,7 @@ VERTEX_SHADER_CODE
 	gl_Position = projection_matrix * vec4(vertex_interp, 1.0);
 }
 
+/* clang-format off */
 [fragment]
 #extension GL_ARB_shader_texture_lod : enable
 
@@ -279,6 +288,7 @@ precision mediump int;
 //
 
 uniform mat4 camera_matrix;
+/* clang-format on */
 uniform mat4 camera_inverse_matrix;
 uniform mat4 projection_matrix;
 uniform mat4 projection_inverse_matrix;
@@ -390,7 +400,11 @@ vec3 metallic_to_specular_color(float metallic, float specular, vec3 albedo) {
 	return mix(vec3(dielectric), albedo, metallic); // TODO: reference?
 }
 
+/* clang-format off */
+
 FRAGMENT_SHADER_GLOBALS
+
+/* clang-format on */
 
 #ifdef LIGHT_PASS
 void light_compute(
@@ -504,11 +518,13 @@ void main() {
 	vec2 screen_uv = gl_FragCoord.xy * screen_pixel_size;
 #endif
 
-{
+	{
+		/* clang-format off */
 
 FRAGMENT_SHADER_CODE
 
-}
+		/* clang-format on */
+	}
 
 #if defined(ENABLE_NORMALMAP)
 	normalmap.xy = normalmap.xy * 2.0 - 1.0;

--- a/drivers/gles2/shaders/screen_space_reflection.glsl
+++ b/drivers/gles2/shaders/screen_space_reflection.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -13,9 +15,11 @@ void main() {
 	pos_interp.xy = gl_Position.xy;
 }
 
+/* clang-format off */
 [fragment]
 
 in vec2 uv_interp;
+/* clang-format on */
 in vec2 pos_interp;
 
 uniform sampler2D source_diffuse; //texunit:0

--- a/drivers/gles2/shaders/ssao.glsl
+++ b/drivers/gles2/shaders/ssao.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 
 void main() {
 
@@ -8,6 +10,7 @@ void main() {
 	gl_Position.z = 1.0;
 }
 
+/* clang-format off */
 [fragment]
 
 #define TWO_PI 6.283185307179586476925286766559
@@ -53,6 +56,7 @@ const int ROTATIONS[] = int[](
 		29, 21, 19, 27, 31, 29, 21, 18, 17, 29,
 		31, 31, 23, 18, 25, 26, 25, 23, 19, 34,
 		19, 27, 21, 25, 39, 29, 17, 21, 27);
+/* clang-format on */
 
 //#define NUM_SPIRAL_TURNS (7)
 const int NUM_SPIRAL_TURNS = ROTATIONS[NUM_SAMPLES - 1];

--- a/drivers/gles2/shaders/ssao_blur.glsl
+++ b/drivers/gles2/shaders/ssao_blur.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 
 void main() {
 
@@ -8,9 +10,11 @@ void main() {
 	gl_Position.z = 1.0;
 }
 
+/* clang-format off */
 [fragment]
 
 uniform sampler2D source_ssao; //texunit:0
+/* clang-format on */
 uniform sampler2D source_depth; //texunit:1
 uniform sampler2D source_normal; //texunit:3
 
@@ -43,7 +47,7 @@ const float gaussian[R + 1] =
 		//float[](0.356642, 0.239400, 0.072410, 0.009869);
 		//float[](0.398943, 0.241971, 0.053991, 0.004432, 0.000134);  // stddev = 1.0
 		float[](0.153170, 0.144893, 0.122649, 0.092902, 0.062970); // stddev = 2.0
-		//float[](0.111220, 0.107798, 0.098151, 0.083953, 0.067458, 0.050920, 0.036108); // stddev = 3.0
+//float[](0.111220, 0.107798, 0.098151, 0.083953, 0.067458, 0.050920, 0.036108); // stddev = 3.0
 
 /** (1, 0) or (0, 1)*/
 uniform ivec2 axis;

--- a/drivers/gles2/shaders/ssao_minify.glsl
+++ b/drivers/gles2/shaders/ssao_minify.glsl
@@ -1,12 +1,15 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 
 void main() {
 
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 #ifdef MINIFY_START
@@ -14,6 +17,7 @@ void main() {
 #define SDEPTH_TYPE highp sampler2D
 uniform float camera_z_far;
 uniform float camera_z_near;
+/* clang-format on */
 
 #else
 

--- a/drivers/gles2/shaders/subsurf_scattering.glsl
+++ b/drivers/gles2/shaders/subsurf_scattering.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -11,6 +13,7 @@ void main() {
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 //#define QUALIFIER uniform // some guy on the interweb says it may be faster with this
@@ -18,6 +21,7 @@ void main() {
 
 #ifdef USE_25_SAMPLES
 const int kernel_size = 25;
+/* clang-format on */
 QUALIFIER vec2 kernel[25] = vec2[](
 		vec2(0.530605, 0.0),
 		vec2(0.000973794, -3.0),

--- a/drivers/gles2/shaders/tonemap.glsl
+++ b/drivers/gles2/shaders/tonemap.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -14,6 +16,7 @@ void main() {
 #endif
 }
 
+/* clang-format off */
 [fragment]
 
 #if !defined(GLES_OVER_GL)
@@ -21,6 +24,7 @@ precision mediump float;
 #endif
 
 in vec2 uv_interp;
+/* clang-format on */
 
 uniform highp sampler2D source; //texunit:0
 
@@ -115,7 +119,7 @@ vec4 texture2D_bicubic(sampler2D tex, vec2 uv, int p_lod) {
 	vec2 p3 = (vec2(iuv.x + h1x, iuv.y + h1y) - 0.5) * pixel_size;
 
 	return (g0(fuv.y) * (g0x * textureLod(tex, p0, lod) + g1x * textureLod(tex, p1, lod))) +
-			(g1(fuv.y) * (g0x * textureLod(tex, p2, lod) + g1x * textureLod(tex, p3, lod)));
+		   (g1(fuv.y) * (g0x * textureLod(tex, p2, lod) + g1x * textureLod(tex, p3, lod)));
 }
 
 #define GLOW_TEXTURE_SAMPLE(m_tex, m_uv, m_lod) texture2D_bicubic(m_tex, m_uv, m_lod)

--- a/drivers/gles3/shaders/blend_shape.glsl
+++ b/drivers/gles3/shaders/blend_shape.glsl
@@ -1,3 +1,4 @@
+/* clang-format off */
 [vertex]
 
 /*
@@ -23,6 +24,7 @@ ARRAY_INDEX=8,
 /* INPUT ATTRIBS */
 
 layout(location = 0) in highp VFORMAT vertex_attrib;
+/* clang-format on */
 layout(location = 1) in vec3 normal_attrib;
 
 #ifdef ENABLE_TANGENT
@@ -183,8 +185,10 @@ void main() {
 	gl_Position = vec4(0.0);
 }
 
+/* clang-format off */
 [fragment]
 
 void main() {
 
 }
+/* clang-format on */

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec2 vertex;
+/* clang-format on */
 layout(location = 3) in vec4 color_attrib;
 
 #ifdef USE_SKELETON
@@ -97,15 +99,21 @@ uniform int v_frames;
 
 #if defined(USE_MATERIAL)
 
+/* clang-format off */
 layout(std140) uniform UniformData { //ubo:2
 
 MATERIAL_UNIFORMS
 
 };
+/* clang-format on */
 
 #endif
 
+/* clang-format off */
+
 VERTEX_SHADER_GLOBALS
+
+/* clang-format on */
 
 void main() {
 
@@ -151,11 +159,13 @@ void main() {
 
 #define extra_matrix extra_matrix2
 
-{
+	{
+		/* clang-format off */
 
 VERTEX_SHADER_CODE
 
-}
+		/* clang-format on */
+	}
 
 #ifdef USE_NINEPATCH
 
@@ -188,29 +198,29 @@ VERTEX_SHADER_CODE
 		highp mat2x4 m;
 		m = mat2x4(
 					texelFetch(skeleton_texture, tex_ofs, 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0))
-				* bone_weights.x;
+					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0)) *
+			bone_weights.x;
 
 		tex_ofs = ivec2(bone_indicesi.y % 256, (bone_indicesi.y / 256) * 2);
 
 		m += mat2x4(
-					texelFetch(skeleton_texture, tex_ofs, 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0))
-				* bone_weights.y;
+					 texelFetch(skeleton_texture, tex_ofs, 0),
+					 texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0)) *
+			 bone_weights.y;
 
 		tex_ofs = ivec2(bone_indicesi.z % 256, (bone_indicesi.z / 256) * 2);
 
 		m += mat2x4(
-					texelFetch(skeleton_texture, tex_ofs, 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0))
-				* bone_weights.z;
+					 texelFetch(skeleton_texture, tex_ofs, 0),
+					 texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0)) *
+			 bone_weights.z;
 
 		tex_ofs = ivec2(bone_indicesi.w % 256, (bone_indicesi.w / 256) * 2);
 
 		m += mat2x4(
-					texelFetch(skeleton_texture, tex_ofs, 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0))
-				* bone_weights.w;
+					 texelFetch(skeleton_texture, tex_ofs, 0),
+					 texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0)) *
+			 bone_weights.w;
 
 		mat4 bone_matrix = skeleton_transform * transpose(mat4(m[0], m[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))) * skeleton_transform_inverse;
 
@@ -246,9 +256,11 @@ VERTEX_SHADER_CODE
 #endif
 }
 
+/* clang-format off */
 [fragment]
 
 uniform mediump sampler2D color_texture; // texunit:0
+/* clang-format on */
 uniform highp vec2 color_texpixel_size;
 uniform mediump sampler2D normal_texture; // texunit:1
 
@@ -313,15 +325,21 @@ layout(location = 0) out mediump vec4 frag_color;
 
 #if defined(USE_MATERIAL)
 
+/* clang-format off */
 layout(std140) uniform UniformData {
 
 MATERIAL_UNIFORMS
 
 };
+/* clang-format on */
 
 #endif
 
+/* clang-format off */
+
 FRAGMENT_SHADER_GLOBALS
+
+/* clang-format on */
 
 void light_compute(
 		inout vec4 light,
@@ -339,7 +357,11 @@ void light_compute(
 
 #if defined(USE_LIGHT_SHADER_CODE)
 
+	/* clang-format off */
+
 LIGHT_SHADER_CODE
+
+	/* clang-format on */
 
 #endif
 }
@@ -472,7 +494,11 @@ void main() {
 		vec3 normal_map = vec3(0.0, 0.0, 1.0);
 #endif
 
+		/* clang-format off */
+
 FRAGMENT_SHADER_CODE
+
+		/* clang-format on */
 
 #if defined(NORMALMAP_USED)
 		normal = mix(vec3(0.0, 0.0, 1.0), normal_map * vec3(2.0, -2.0, 1.0) - vec3(1.0, -1.0, 0.0), normal_depth);

--- a/drivers/gles3/shaders/canvas_shadow.glsl
+++ b/drivers/gles3/shaders/canvas_shadow.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 uniform highp mat4 projection_matrix;
+/* clang-format on */
 uniform highp mat4 light_matrix;
 uniform highp mat4 world_matrix;
 uniform highp float distance_norm;
@@ -15,9 +17,11 @@ void main() {
 	position_interp = gl_Position;
 }
 
+/* clang-format off */
 [fragment]
 
 in highp vec4 position_interp;
+/* clang-format on */
 
 #ifdef USE_RGBA_SHADOWS
 layout(location = 0) out lowp vec4 distance_buf;

--- a/drivers/gles3/shaders/copy.glsl
+++ b/drivers/gles3/shaders/copy.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 #if defined(USE_CUBEMAP) || defined(USE_PANORAMA)
 layout(location = 4) in vec3 cube_in;
 #else
@@ -45,6 +47,7 @@ void main() {
 #endif
 }
 
+/* clang-format off */
 [fragment]
 
 #define M_PI 3.14159265359
@@ -58,6 +61,7 @@ in vec3 cube_interp;
 #else
 in vec2 uv_interp;
 #endif
+/* clang-format on */
 
 #ifdef USE_ASYM_PANO
 uniform highp mat4 pano_transform;

--- a/drivers/gles3/shaders/cube_to_dp.glsl
+++ b/drivers/gles3/shaders/cube_to_dp.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -11,9 +13,11 @@ void main() {
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 uniform highp samplerCube source_cube; //texunit:0
+/* clang-format on */
 in vec2 uv_interp;
 
 uniform bool z_flip;

--- a/drivers/gles3/shaders/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/cubemap_filter.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec2 vertex;
+/* clang-format on */
 
 layout(location = 4) in highp vec2 uv;
 
@@ -12,9 +14,11 @@ void main() {
 	gl_Position = vec4(vertex, 0, 1);
 }
 
+/* clang-format off */
 [fragment]
 
 precision highp float;
+/* clang-format on */
 precision highp int;
 
 #ifdef USE_SOURCE_PANORAMA

--- a/drivers/gles3/shaders/effect_blur.glsl
+++ b/drivers/gles3/shaders/effect_blur.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -22,11 +24,13 @@ void main() {
 #endif
 }
 
+/* clang-format off */
 [fragment]
 
 #if !defined(GLES_OVER_GL)
 precision mediump float;
 #endif
+/* clang-format on */
 
 in vec2 uv_interp;
 uniform sampler2D source_color; //texunit:0

--- a/drivers/gles3/shaders/exposure.glsl
+++ b/drivers/gles3/shaders/exposure.glsl
@@ -1,15 +1,19 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 
 void main() {
 
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 uniform highp sampler2D source_exposure; //texunit:0
+/* clang-format on */
 
 #ifdef EXPOSURE_BEGIN
 

--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 color;
+/* clang-format on */
 layout(location = 1) in highp vec4 velocity_active;
 layout(location = 2) in highp vec4 custom;
 layout(location = 3) in highp vec4 xform_1;
@@ -45,15 +47,21 @@ out highp vec4 out_xform_3; //tfb:
 
 #if defined(USE_MATERIAL)
 
+/* clang-format off */
 layout(std140) uniform UniformData { //ubo:0
 
 MATERIAL_UNIFORMS
 
 };
+/* clang-format on */
 
 #endif
 
+/* clang-format off */
+
 VERTEX_SHADER_GLOBALS
+
+/* clang-format on */
 
 uint hash(uint x) {
 
@@ -165,7 +173,11 @@ void main() {
 		//execute shader
 
 		{
+			/* clang-format off */
+
 VERTEX_SHADER_CODE
+
+			/* clang-format on */
 		}
 
 #if !defined(DISABLE_FORCE)
@@ -221,6 +233,7 @@ VERTEX_SHADER_CODE
 #endif //PARTICLES_COPY
 }
 
+/* clang-format off */
 [fragment]
 
 // any code here is never executed, stuff is filled just so it works
@@ -240,10 +253,15 @@ FRAGMENT_SHADER_GLOBALS
 void main() {
 
 	{
+
 LIGHT_SHADER_CODE
+
 	}
 
 	{
+
 FRAGMENT_SHADER_CODE
+
 	}
 }
+/* clang-format on */

--- a/drivers/gles3/shaders/resolve.glsl
+++ b/drivers/gles3/shaders/resolve.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -11,11 +13,13 @@ void main() {
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 #if !defined(GLES_OVER_GL)
 precision mediump float;
 #endif
+/* clang-format on */
 
 in vec2 uv_interp;
 uniform sampler2D source_specular; // texunit:0

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1,3 +1,4 @@
+/* clang-format off */
 [vertex]
 
 #define M_PI 3.14159265359
@@ -21,6 +22,7 @@ ARRAY_INDEX=8,
 /* INPUT ATTRIBS */
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 1) in vec3 normal_attrib;
 #if defined(ENABLE_TANGENT_INTERP) || defined(ENABLE_NORMALMAP) || defined(LIGHT_USE_ANISOTROPY)
 layout(location = 2) in vec4 tangent_attrib;
@@ -226,15 +228,21 @@ out vec3 binormal_interp;
 
 #if defined(USE_MATERIAL)
 
+/* clang-format off */
 layout(std140) uniform UniformData { // ubo:1
 
 MATERIAL_UNIFORMS
 
 };
+/* clang-format on */
 
 #endif
 
+/* clang-format off */
+
 VERTEX_SHADER_GLOBALS
+
+/* clang-format on */
 
 #ifdef RENDER_DEPTH_DUAL_PARABOLOID
 
@@ -340,32 +348,32 @@ void main() {
 		m = mat3x4(
 					texelFetch(skeleton_texture, tex_ofs, 0),
 					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 2), 0))
-			* bone_weights.x;
+					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 2), 0)) *
+			bone_weights.x;
 
 		tex_ofs = ivec2(bone_indicesi.y % 256, (bone_indicesi.y / 256) * 3);
 
 		m += mat3x4(
-					texelFetch(skeleton_texture, tex_ofs, 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 2), 0))
-			* bone_weights.y;
+					 texelFetch(skeleton_texture, tex_ofs, 0),
+					 texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0),
+					 texelFetch(skeleton_texture, tex_ofs + ivec2(0, 2), 0)) *
+			 bone_weights.y;
 
 		tex_ofs = ivec2(bone_indicesi.z % 256, (bone_indicesi.z / 256) * 3);
 
 		m += mat3x4(
-					texelFetch(skeleton_texture, tex_ofs, 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 2), 0))
-			* bone_weights.z;
+					 texelFetch(skeleton_texture, tex_ofs, 0),
+					 texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0),
+					 texelFetch(skeleton_texture, tex_ofs + ivec2(0, 2), 0)) *
+			 bone_weights.z;
 
 		tex_ofs = ivec2(bone_indicesi.w % 256, (bone_indicesi.w / 256) * 3);
 
 		m += mat3x4(
-					texelFetch(skeleton_texture, tex_ofs, 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0),
-					texelFetch(skeleton_texture, tex_ofs + ivec2(0, 2), 0))
-			* bone_weights.w;
+					 texelFetch(skeleton_texture, tex_ofs, 0),
+					 texelFetch(skeleton_texture, tex_ofs + ivec2(0, 1), 0),
+					 texelFetch(skeleton_texture, tex_ofs + ivec2(0, 2), 0)) *
+			 bone_weights.w;
 
 		mat4 bone_matrix = transpose(mat4(m[0], m[1], m[2], vec4(0.0, 0.0, 0.0, 1.0)));
 
@@ -374,11 +382,13 @@ void main() {
 #endif
 
 	mat4 modelview = camera_inverse_matrix * world_matrix;
-{
+	{
+		/* clang-format off */
 
 VERTEX_SHADER_CODE
 
-}
+		/* clang-format on */
+	}
 
 // using local coordinates (default)
 #if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
@@ -501,6 +511,7 @@ VERTEX_SHADER_CODE
 #endif // USE_VERTEX_LIGHTING
 }
 
+/* clang-format off */
 [fragment]
 
 /* texture unit usage, N is max_texture_unity-N
@@ -519,6 +530,7 @@ VERTEX_SHADER_CODE
 */
 
 uniform highp mat4 world_transform;
+/* clang-format on */
 
 #define M_PI 3.14159265359
 
@@ -552,7 +564,6 @@ layout(std140) uniform Radiance { // ubo:2
 
 	mat4 radiance_inverse_xform;
 	float radiance_ambient_contribution;
-
 };
 
 #define RADIANCE_MAX_LOD 5.0
@@ -608,15 +619,21 @@ vec3 textureDualParaboloid(sampler2D p_tex, vec3 p_vec, float p_roughness) {
 
 #if defined(USE_MATERIAL)
 
+/* clang-format off */
 layout(std140) uniform UniformData {
 
 MATERIAL_UNIFORMS
 
 };
+/* clang-format on */
 
 #endif
 
+/* clang-format off */
+
 FRAGMENT_SHADER_GLOBALS
+
+/* clang-format on */
 
 layout(std140) uniform SceneData {
 
@@ -663,7 +680,7 @@ layout(std140) uniform SceneData {
 	highp float fog_height_curve;
 };
 
-//directional light data
+	//directional light data
 
 #ifdef USE_LIGHT_DIRECTIONAL
 
@@ -701,7 +718,6 @@ struct LightData {
 	mediump vec4 light_clamp;
 	mediump vec4 shadow_color_contact;
 	highp mat4 shadow_matrix;
-
 };
 
 layout(std140) uniform OmniLightData { // ubo:4
@@ -916,7 +932,11 @@ void light_compute(vec3 N, vec3 L, vec3 V, vec3 B, vec3 T, vec3 light_color, vec
 	vec3 light = L;
 	vec3 view = V;
 
+	/* clang-format off */
+
 LIGHT_SHADER_CODE
+
+	/* clang-format on */
 
 #else
 	float NdotL = dot(N, L);
@@ -1599,11 +1619,13 @@ void main() {
 	float sss_strength = 0.0;
 #endif
 
-{
+	{
+		/* clang-format off */
 
 FRAGMENT_SHADER_CODE
 
-}
+		/* clang-format on */
+	}
 
 #if defined(ALPHA_SCISSOR_USED)
 	if (alpha < alpha_scissor) {

--- a/drivers/gles3/shaders/screen_space_reflection.glsl
+++ b/drivers/gles3/shaders/screen_space_reflection.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -13,9 +15,11 @@ void main() {
 	pos_interp.xy = gl_Position.xy;
 }
 
+/* clang-format off */
 [fragment]
 
 in vec2 uv_interp;
+/* clang-format on */
 in vec2 pos_interp;
 
 uniform sampler2D source_diffuse; //texunit:0

--- a/drivers/gles3/shaders/ssao.glsl
+++ b/drivers/gles3/shaders/ssao.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 
 void main() {
 
@@ -8,6 +10,7 @@ void main() {
 	gl_Position.z = 1.0;
 }
 
+/* clang-format off */
 [fragment]
 
 #define TWO_PI 6.283185307179586476925286766559
@@ -46,8 +49,8 @@ const int ROTATIONS[] = int[](
 		13, 17, 11, 17, 19, 18, 25, 18, 19, 19,
 		29, 21, 19, 27, 31, 29, 21, 18, 17, 29,
 		31, 31, 23, 18, 25, 26, 25, 23, 19, 34,
-		19, 27, 21, 25, 39, 29, 17, 21, 27
-);
+		19, 27, 21, 25, 39, 29, 17, 21, 27);
+/* clang-format on */
 
 //#define NUM_SPIRAL_TURNS (7)
 const int NUM_SPIRAL_TURNS = ROTATIONS[NUM_SAMPLES - 1];

--- a/drivers/gles3/shaders/ssao_blur.glsl
+++ b/drivers/gles3/shaders/ssao_blur.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 
 void main() {
 
@@ -8,9 +10,11 @@ void main() {
 	gl_Position.z = 1.0;
 }
 
+/* clang-format off */
 [fragment]
 
 uniform sampler2D source_ssao; //texunit:0
+/* clang-format on */
 uniform sampler2D source_depth; //texunit:1
 uniform sampler2D source_normal; //texunit:3
 
@@ -36,16 +40,14 @@ uniform int filter_scale;
 /** Filter radius in pixels. This will be multiplied by SCALE. */
 #define R (4)
 
-
 //////////////////////////////////////////////////////////////////////////////////////////////
-
 
 // Gaussian coefficients
 const float gaussian[R + 1] =
-//	float[](0.356642, 0.239400, 0.072410, 0.009869);
-//	float[](0.398943, 0.241971, 0.053991, 0.004432, 0.000134);  // stddev = 1.0
-	float[](0.153170, 0.144893, 0.122649, 0.092902, 0.062970);  // stddev = 2.0
-//	float[](0.111220, 0.107798, 0.098151, 0.083953, 0.067458, 0.050920, 0.036108); // stddev = 3.0
+		//float[](0.356642, 0.239400, 0.072410, 0.009869);
+		//float[](0.398943, 0.241971, 0.053991, 0.004432, 0.000134);  // stddev = 1.0
+		float[](0.153170, 0.144893, 0.122649, 0.092902, 0.062970); // stddev = 2.0
+//float[](0.111220, 0.107798, 0.098151, 0.083953, 0.067458, 0.050920, 0.036108); // stddev = 3.0
 
 /** (1, 0) or (0, 1) */
 uniform ivec2 axis;

--- a/drivers/gles3/shaders/ssao_minify.glsl
+++ b/drivers/gles3/shaders/ssao_minify.glsl
@@ -1,18 +1,22 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 
 void main() {
 
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 #ifdef MINIFY_START
 
 #define SDEPTH_TYPE highp sampler2D
 uniform float camera_z_far;
+/* clang-format on */
 uniform float camera_z_near;
 
 #else

--- a/drivers/gles3/shaders/subsurf_scattering.glsl
+++ b/drivers/gles3/shaders/subsurf_scattering.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -11,6 +13,7 @@ void main() {
 	gl_Position = vertex_attrib;
 }
 
+/* clang-format off */
 [fragment]
 
 //#define QUALIFIER uniform // some guy on the interweb says it may be faster with this
@@ -18,7 +21,8 @@ void main() {
 
 #ifdef USE_25_SAMPLES
 const int kernel_size = 25;
-QUALIFIER vec2 kernel[25] = vec2[] (
+/* clang-format on */
+QUALIFIER vec2 kernel[25] = vec2[](
 		vec2(0.530605, 0.0),
 		vec2(0.000973794, -3.0),
 		vec2(0.00333804, -2.52083),
@@ -43,8 +47,7 @@ QUALIFIER vec2 kernel[25] = vec2[] (
 		vec2(0.00700976, 1.6875),
 		vec2(0.00500364, 2.08333),
 		vec2(0.00333804, 2.52083),
-		vec2(0.000973794, 3.0)
-);
+		vec2(0.000973794, 3.0));
 #endif //USE_25_SAMPLES
 
 #ifdef USE_17_SAMPLES
@@ -66,10 +69,8 @@ QUALIFIER vec2 kernel[17] = vec2[](
 		vec2(0.0216301, 0.78125),
 		vec2(0.0144609, 1.125),
 		vec2(0.0100386, 1.53125),
-		vec2(0.00317394, 2.0)
-);
+		vec2(0.00317394, 2.0));
 #endif //USE_17_SAMPLES
-
 
 #ifdef USE_11_SAMPLES
 const int kernel_size = 11;
@@ -84,8 +85,7 @@ QUALIFIER vec2 kernel[11] = vec2[](
 		vec2(0.0821904, 0.32),
 		vec2(0.03639, 0.72),
 		vec2(0.0192831, 1.28),
-		vec2(0.00471691, 2.0)
-);
+		vec2(0.00471691, 2.0));
 #endif //USE_11_SAMPLES
 
 uniform float max_radius;

--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -1,6 +1,8 @@
+/* clang-format off */
 [vertex]
 
 layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
 layout(location = 4) in vec2 uv_in;
 
 out vec2 uv_interp;
@@ -15,11 +17,13 @@ void main() {
 #endif
 }
 
+/* clang-format off */
 [fragment]
 
 #if !defined(GLES_OVER_GL)
 precision mediump float;
 #endif
+/* clang-format on */
 
 in vec2 uv_interp;
 
@@ -110,10 +114,8 @@ vec4 texture2D_bicubic(sampler2D tex, vec2 uv, int p_lod) {
 	vec2 p2 = (vec2(iuv.x + h0x, iuv.y + h1y) - vec2(0.5f)) * pixel_size;
 	vec2 p3 = (vec2(iuv.x + h1x, iuv.y + h1y) - vec2(0.5f)) * pixel_size;
 
-	return g0(fuv.y) * (g0x * textureLod(tex, p0, lod) +
-			g1x * textureLod(tex, p1, lod)) +
-			g1(fuv.y) * (g0x * textureLod(tex, p2, lod) +
-			g1x * textureLod(tex, p3, lod));
+	return (g0(fuv.y) * (g0x * textureLod(tex, p0, lod) + g1x * textureLod(tex, p1, lod))) +
+		   (g1(fuv.y) * (g0x * textureLod(tex, p2, lod) + g1x * textureLod(tex, p3, lod)));
 }
 
 #define GLOW_TEXTURE_SAMPLE(m_tex, m_uv, m_lod) texture2D_bicubic(m_tex, m_uv, m_lod)

--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -31,7 +31,7 @@ PARSE_EXTS=true
 
 # File types to parse. Only effective when PARSE_EXTS is true.
 # FILE_EXTS=".c .h .cpp .hpp"
-FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .m .mm .inc *.java"
+FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .m .mm .inc *.java *.glsl"
 
 # Use pygmentize instead of cat to parse diff with highlighting.
 # Install it with `pip install pygments` (Linux) or `easy_install Pygments` (Mac)

--- a/misc/travis/clang-format.sh
+++ b/misc/travis/clang-format.sh
@@ -11,7 +11,7 @@ else
     RANGE=HEAD
 fi
 
-FILES=$(git diff-tree --no-commit-id --name-only -r $RANGE | grep -v thirdparty/ | grep -E "\.(c|h|cpp|hpp|cc|hh|cxx|m|mm|inc|java)$")
+FILES=$(git diff-tree --no-commit-id --name-only -r $RANGE | grep -v thirdparty/ | grep -E "\.(c|h|cpp|hpp|cc|hh|cxx|m|mm|inc|java|glsl)$")
 echo "Checking files:\n$FILES"
 
 # create a random filename to store our generated patch

--- a/modules/mobile_vr/shaders/lens_distorted.glsl
+++ b/modules/mobile_vr/shaders/lens_distorted.glsl
@@ -1,7 +1,9 @@
+/* clang-format off */
 [vertex]
 
-layout(location=0) in highp vec4 vertex_attrib;
-layout(location=4) in vec2 uv_in;
+layout(location = 0) in highp vec4 vertex_attrib;
+/* clang-format on */
+layout(location = 4) in vec2 uv_in;
 
 uniform float offset_x;
 
@@ -9,13 +11,15 @@ out vec2 uv_interp;
 
 void main() {
 
-  uv_interp = uv_in;
-  gl_Position = vec4(vertex_attrib.x + offset_x, vertex_attrib.y, 0.0, 1.0);
+	uv_interp = uv_in;
+	gl_Position = vec4(vertex_attrib.x + offset_x, vertex_attrib.y, 0.0, 1.0);
 }
 
+/* clang-format off */
 [fragment]
 
 uniform sampler2D source; //texunit:0
+/* clang-format on */
 
 uniform vec2 eye_center;
 uniform float k1;
@@ -28,32 +32,31 @@ in vec2 uv_interp;
 layout(location = 0) out vec4 frag_color;
 
 void main() {
-  vec2 coords = uv_interp;
-  vec2 offset = coords - eye_center;
+	vec2 coords = uv_interp;
+	vec2 offset = coords - eye_center;
 
-  // take aspect ratio into account
-  offset.y /= aspect_ratio;
+	// take aspect ratio into account
+	offset.y /= aspect_ratio;
 
-  // distort 
-  vec2 offset_sq = offset * offset;
-  float radius_sq = offset_sq.x + offset_sq.y;
-  float radius_s4 = radius_sq * radius_sq;
-  float distortion_scale = 1.0 + (k1 * radius_sq) + (k2 * radius_s4);
-  offset *= distortion_scale;
+	// distort
+	vec2 offset_sq = offset * offset;
+	float radius_sq = offset_sq.x + offset_sq.y;
+	float radius_s4 = radius_sq * radius_sq;
+	float distortion_scale = 1.0 + (k1 * radius_sq) + (k2 * radius_s4);
+	offset *= distortion_scale;
 
-  // reapply aspect ratio
-  offset.y *= aspect_ratio;
+	// reapply aspect ratio
+	offset.y *= aspect_ratio;
 
-  // add our eye center back in
-  coords = offset + eye_center;
-  coords /= upscale;
+	// add our eye center back in
+	coords = offset + eye_center;
+	coords /= upscale;
 
-  // and check our color
-  if (coords.x < -1.0 || coords.y < -1.0 || coords.x > 1.0 || coords.y > 1.0) {
-    frag_color = vec4(0.0, 0.0, 0.0, 1.0);
-  } else {
-    coords = (coords + vec2(1.0)) / vec2(2.0);
-    frag_color = textureLod(source, coords, 0.0);
-  }
+	// and check our color
+	if (coords.x < -1.0 || coords.y < -1.0 || coords.x > 1.0 || coords.y > 1.0) {
+		frag_color = vec4(0.0, 0.0, 0.0, 1.0);
+	} else {
+		coords = (coords + vec2(1.0)) / vec2(2.0);
+		frag_color = textureLod(source, coords, 0.0);
+	}
 }
-


### PR DESCRIPTION
As of clang-format 6.0.1, putting the `/* clang-format off */` hint
around our "invalid" `[vertex]` and `[shader]` statements isn't enough
to prevent a bogus indent of the next comments and first valid statement,
so we need to enclose that first valid statement in the unformatted chunk.

**Note to devs:** Please update your git pre-commit hook for clang-format accordingly to include `.glsl` files.