### PR TITLE
Fixed issue #11893 (SpinBox capturing mouse)

### DIFF
--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -54,10 +54,10 @@ class SpinBox : public Range {
 
 	struct Drag {
 		float base_val;
+		bool allowed;
 		bool enabled;
-		Vector2 from;
-		Vector2 mouse_pos;
 		Vector2 capture_pos;
+		float diff_y;
 	} drag;
 
 	void _line_edit_focus_exit();


### PR DESCRIPTION
To prevent the SpinBox from capturing mouse, added a "drag.allowed"
variable that is set to true only when clicking inside the control.
Entering the control with the left mouse button pressed will not
trigger drag anymore.

Also modified the value update code when dragging so it does not
modify the base_val (to take advantage of the non-linear function
used to calculate the new value).

Only tested this under Windows.

*Bugsquad edit:* Fixes #11893