### PR TITLE
Uncommenting a selection was not updating the selection.

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -373,6 +373,7 @@ private:
 	void _update_selection_mode_word();
 	void _update_selection_mode_line();
 
+	void _uncomment_line(int p_line);
 	void _scroll_up(real_t p_delta);
 	void _scroll_down(real_t p_delta);
 


### PR DESCRIPTION
Also adds uncomment lines(ctrl+u) where # is not in first place

closes https://github.com/godotengine/godot/issues/15840 and part of https://github.com/godotengine/godot/issues/21310

Test with 
ctrl+u and ctrl+k

![peek 2018-08-27 02-49](https://user-images.githubusercontent.com/4741886/44635305-0fd2bd00-a9a4-11e8-8cab-e85a9a1f53de.gif)
 
Test
```
          #Test
#	s #Test
```