### PR TITLE
AtlasTexture fixes, part 2.

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -431,7 +431,7 @@ void Sprite3D::_draw() {
 
 	};
 
-	Vector2 src_tsize = Vector2(texture->get_width(), texture->get_height());
+	Vector2 src_tsize = tsize;
 
 	// Properly setup UVs for impostor textures (AtlasTexture).
 	Ref<AtlasTexture> atlas_tex = texture;
@@ -441,10 +441,10 @@ void Sprite3D::_draw() {
 	}
 
 	Vector2 uvs[4] = {
-		final_src_rect.position / tsize,
-		(final_src_rect.position + Vector2(final_src_rect.size.x, 0)) / tsize,
-		(final_src_rect.position + final_src_rect.size) / tsize,
-		(final_src_rect.position + Vector2(0, final_src_rect.size.y)) / tsize,
+		final_src_rect.position / src_tsize,
+		(final_src_rect.position + Vector2(final_src_rect.size.x, 0)) / src_tsize,
+		(final_src_rect.position + final_src_rect.size) / src_tsize,
+		(final_src_rect.position + Vector2(0, final_src_rect.size.y)) / src_tsize,
 	};
 
 	if (is_flipped_h()) {
@@ -731,7 +731,7 @@ void AnimatedSprite3D::_draw() {
 
 	};
 
-	Vector2 src_tsize = Vector2(texture->get_width(), texture->get_height());
+	Vector2 src_tsize = tsize;
 
 	// Properly setup UVs for impostor textures (AtlasTexture).
 	Ref<AtlasTexture> atlas_tex = texture;
@@ -741,10 +741,10 @@ void AnimatedSprite3D::_draw() {
 	}
 
 	Vector2 uvs[4] = {
-		final_src_rect.position / tsize,
-		(final_src_rect.position + Vector2(final_src_rect.size.x, 0)) / tsize,
-		(final_src_rect.position + final_src_rect.size) / tsize,
-		(final_src_rect.position + Vector2(0, final_src_rect.size.y)) / tsize,
+		final_src_rect.position / src_tsize,
+		(final_src_rect.position + Vector2(final_src_rect.size.x, 0)) / src_tsize,
+		(final_src_rect.position + final_src_rect.size) / src_tsize,
+		(final_src_rect.position + Vector2(0, final_src_rect.size.y)) / src_tsize,
 	};
 
 	if (is_flipped_h()) {


### PR DESCRIPTION
It turns out I forgot to actually use the AtlasTexture's fixed coordinates when drawing the sprite. Continuation of #18691.