### PR TITLE
No need to link with libandroid_support.a in NDK 17

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -258,9 +258,10 @@ def configure(env):
     if ndk_version != None and LooseVersion(ndk_version) >= LooseVersion("15.0.4075724"):
         if LooseVersion(ndk_version) >= LooseVersion("17.1.4828580"):
             env.Append(LINKFLAGS=['-Wl,--exclude-libs,libgcc.a','-Wl,--exclude-libs,libatomic.a','-nostdlib++'])
+        else:
+            env.Append(LINKFLAGS=[env["ANDROID_NDK_ROOT"] +"/sources/cxx-stl/llvm-libc++/libs/"+arch_subpath+"/libandroid_support.a"])
         env.Append(LINKFLAGS=['-shared', '--sysroot=' + lib_sysroot, '-Wl,--warn-shared-textrel'])
         env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++/libs/"+arch_subpath+"/"])
-        env.Append(LINKFLAGS=[env["ANDROID_NDK_ROOT"] +"/sources/cxx-stl/llvm-libc++/libs/"+arch_subpath+"/libandroid_support.a"])
         env.Append(LINKFLAGS=[env["ANDROID_NDK_ROOT"] +"/sources/cxx-stl/llvm-libc++/libs/"+arch_subpath+"/libc++_shared.so"])
     else:
         env.Append(LINKFLAGS=['-shared', '--sysroot=' + lib_sysroot, '-Wl,--warn-shared-textrel'])


### PR DESCRIPTION
According to https://github.com/bytedeco/javacpp/pull/244 in NDK 17 `libandroid_support.a` library is not needed any more, and for `armv8` arch it is already gone which breaks compilation.