### PR TITLE
Scale the Item List Editor window size with the editor scale

### DIFF
--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -296,7 +296,7 @@ void ItemListEditor::_delete_pressed() {
 
 void ItemListEditor::_edit_items() {
 
-	dialog->popup_centered(Vector2(300, 400));
+	dialog->popup_centered(Vector2(300, 400) * EDSCALE);
 }
 
 void ItemListEditor::edit(Node *p_item_list) {


### PR DESCRIPTION
Makes the dialog bigger and more usable on HiDPI screens.

Fixes #21520