### PR TITLE
Fix CSGBox size

### DIFF
--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -139,9 +139,9 @@ void CSGShapeSpatialGizmoPlugin::set_handle(EditorSpatialGizmo *p_gizmo, int p_i
 			d = 0.001;
 
 		switch (p_idx) {
-			case 0: s->set_width(d); break;
-			case 1: s->set_height(d); break;
-			case 2: s->set_depth(d); break;
+			case 0: s->set_width(d * 2); break;
+			case 1: s->set_height(d * 2); break;
+			case 2: s->set_depth(d * 2); break;
 		}
 	}
 
@@ -329,9 +329,9 @@ void CSGShapeSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 		CSGBox *s = Object::cast_to<CSGBox>(cs);
 
 		Vector<Vector3> handles;
-		handles.push_back(Vector3(s->get_width(), 0, 0));
-		handles.push_back(Vector3(0, s->get_height(), 0));
-		handles.push_back(Vector3(0, 0, s->get_depth()));
+		handles.push_back(Vector3(s->get_width() * 0.5, 0, 0));
+		handles.push_back(Vector3(0, s->get_height() * 0.5, 0));
+		handles.push_back(Vector3(0, 0, s->get_depth() * 0.5));
 		p_gizmo->add_handles(handles, handles_material);
 	}
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -917,7 +917,7 @@ CSGBrush *CSGBox::_build_brush() {
 
 		int face = 0;
 
-		Vector3 vertex_mul(width, height, depth);
+		Vector3 vertex_mul(width * 0.5, height * 0.5, depth * 0.5);
 
 		{
 
@@ -1051,9 +1051,9 @@ Ref<Material> CSGBox::get_material() const {
 
 CSGBox::CSGBox() {
 	// defaults
-	width = 1.0;
-	height = 1.0;
-	depth = 1.0;
+	width = 2.0;
+	height = 2.0;
+	depth = 2.0;
 }
 
 ///////////////


### PR DESCRIPTION
This is based on the erroneously closed #19913.
CSGBox is currently twice the size it should be. A box of size 1x1x1 is actually 2x2x2 units large. This pull request fixes this bug for CSGBox. All other CSG objects appear to respect the parameters and create the object properly.