### PR TITLE
Sort list of input files

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -23,7 +23,7 @@ platform_exporters = []
 platform_apis = []
 global_defaults = []
 
-for x in glob.glob("platform/*"):
+for x in sorted(glob.glob("platform/*")):
     if (not os.path.isdir(x) or not os.path.exists(x + "/detect.py")):
         continue
     tmppath = "./" + x

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -77,6 +77,7 @@ if env['tools']:
     # Fonts
     flist = glob.glob(path + "/../thirdparty/fonts/*.ttf")
     flist.extend(glob.glob(path + "/../thirdparty/fonts/*.otf"))
+    flist.sort()
     env.Depends('#editor/builtin_fonts.gen.h', flist)
     env.CommandNoCache('#editor/builtin_fonts.gen.h', flist, run_in_subprocess(editor_builders.make_fonts_header))
 

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -76,7 +76,7 @@ if env['tools']:
 
     # Fonts
     flist = glob.glob(path + "/../thirdparty/fonts/*.ttf")
-    flist.append(glob.glob(path + "/../thirdparty/fonts/*.otf"))
+    flist.extend(glob.glob(path + "/../thirdparty/fonts/*.otf"))
     env.Depends('#editor/builtin_fonts.gen.h', flist)
     env.CommandNoCache('#editor/builtin_fonts.gen.h', flist, run_in_subprocess(editor_builders.make_fonts_header))
 

--- a/methods.py
+++ b/methods.py
@@ -13,7 +13,7 @@ def add_source_files(self, sources, filetype, lib_env=None, shared=False):
 
     if isbasestring(filetype):
         dir_path = self.Dir('.').abspath
-        filetype = glob.glob(dir_path + "/" + filetype)
+        filetype = sorted(glob.glob(dir_path + "/" + filetype))
 
     for path in filetype:
         sources.append(self.Object(path))


### PR DESCRIPTION
While working on reproducible builds for openSUSE, I found that
the godot package differed for every build.
These patches fix most issues by sorting lists of input files.

There is also a correctness fix included. Without that, sorting failed, because `str < list` is not a valid python operation.

See individual commit messages for details.