### PR TITLE
Do not record year of build

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -43,7 +43,7 @@ def update_version(module_version_string=""):
     f.write("#define VERSION_STATUS \"" + str(version.status) + "\"\n")
     f.write("#define VERSION_BUILD \"" + str(build_name) + "\"\n")
     f.write("#define VERSION_MODULE_CONFIG \"" + str(version.module_config) + module_version_string + "\"\n")
-    f.write("#define VERSION_YEAR " + str(datetime.datetime.now().year) + "\n")
+    f.write("#define VERSION_YEAR " + str(2018) + "\n")
     f.close()
 
     # NOTE: It is safe to generate this file here, since this is still executed serially


### PR DESCRIPTION
This value becomes part of get_version_info output,
but if it is changing every year without any other change,
it cannot be a useful indicator of anything.

Using a constant value, makes the package build reproducible.
See https://reproducible-builds.org/ for why this is good.

https://stackoverflow.com/questions/2390230/do-copyright-dates-need-to-be-updated also suggests, that copyright years do not have to be updated because expiry is counted from death of author, not from date of creation.