### PR TITLE
Fix z-fighting on origin grid lines in spatial editor

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4468,6 +4468,7 @@ void SpatialEditor::_init_indicators() {
 
 		VisualServer::get_singleton()->instance_geometry_set_cast_shadows_setting(origin_instance, VS::SHADOW_CASTING_SETTING_OFF);
 
+		origin_enabled = true;
 		grid_enabled = true;
 		last_grid_snap = 1;
 	}


### PR DESCRIPTION
PR #20246 caused the original bug, which #21129 fixed when manually toggling/untoggling the display of origin grid lines, but it lacked the initial value that works for the default state.

Fixes #21264.