### PR TITLE
Update mouse enter/exit on TouchEvent

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2002,6 +2002,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			Control *over = _gui_find_control(pos);
 			if (over) {
 
+				over->notification(Control::NOTIFICATION_MOUSE_ENTER);
+				gui.mouse_over = over;
+
 				if (!gui.modal_stack.empty()) {
 
 					Control *top = gui.modal_stack.back()->get();
@@ -2024,9 +2027,15 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				get_tree()->set_input_as_handled();
 				return;
 			}
-		} else if (gui.mouse_focus) {
+		} else {
 
-			if (gui.mouse_focus->can_process()) {
+			if (gui.mouse_over) {
+				gui.mouse_over->notification(Control::NOTIFICATION_MOUSE_EXIT);
+				_gui_cancel_tooltip();
+				gui.mouse_over = NULL;
+			}
+
+			if (gui.mouse_focus && gui.mouse_focus->can_process()) {
 
 				touch_event = touch_event->xformed_by(Transform2D()); //make a copy
 				touch_event->set_position(gui.focus_inv_xform.xform(pos));


### PR DESCRIPTION
It was only updated on Drag/Motion this PR updates the state on TouchEvents closes https://github.com/godotengine/godot/issues/1212
Tested on Android.

The red area should turn green on touch. It stays red without this change.

[New Game Project55.zip](https://github.com/godotengine/godot/files/2332613/New.Game.Project55.zip)
