### PR TITLE
Add SimplexNoise and NoiseTexture as new resources

### DIFF
--- a/modules/opensimplex/SCsub
+++ b/modules/opensimplex/SCsub
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+Import('env')
+env.add_source_files(env.modules_sources, ["register_types.cpp", "simplex_noise.cpp", "noise_texture.cpp", "#thirdparty/misc/open-simplex-noise.c"])

--- a/modules/opensimplex/config.py
+++ b/modules/opensimplex/config.py
@@ -1,0 +1,14 @@
+def can_build(env, platform):
+	  return True
+
+def configure(env):
+	pass
+
+def get_doc_classes():
+    return [
+        "NoiseTexture",
+        "SimplexNoise"
+    ]
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/opensimplex/doc_classes/NoiseTexture.xml
+++ b/modules/opensimplex/doc_classes/NoiseTexture.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NoiseTexture" inherits="Texture" category="Core" version="3.1">
+	<brief_description>
+		[SimplexNoise] filled texture.
+	</brief_description>
+	<description>
+		Uses a [SimplexNoise] to fill the texture data. You can specify the texture size but keep in mind that larger textures will take longer to generate and seamless noise only works with square sized textures.
+		NoiseTexture can also generate normalmap textures.
+	</description>
+	<tutorials>
+	</tutorials>
+	<demos>
+	</demos>
+	<methods>
+		<method name="set_height">
+			<return type="void">
+			</return>
+			<argument index="0" name="height" type="int">
+			</argument>
+			<description>
+				Set texture height.
+			</description>
+		</method>
+		<method name="set_width">
+			<return type="void">
+			</return>
+			<argument index="0" name="width" type="int">
+			</argument>
+			<description>
+				Set texture width.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="as_normalmap" type="bool" setter="set_as_normalmap" getter="is_normalmap">
+			If true, the resulting texture contains a normal map created from the original noise interpreted as a bump map.
+		</member>
+		<member name="noise" type="SimplexNoise" setter="set_noise" getter="get_noise">
+			The [SimplexNoise] instance used to generate the noise.
+		</member>
+		<member name="seamless" type="bool" setter="set_seamless" getter="get_seamless">
+			Whether the texture can be tiled without visible seams or not. Seamless textures take longer to generate.
+		</member>
+		<member name="size" type="Vector2" setter="set_size" getter="get_size">
+			Size of the generated texture.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/modules/opensimplex/doc_classes/SimplexNoise.xml
+++ b/modules/opensimplex/doc_classes/SimplexNoise.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SimplexNoise" inherits="Resource" category="Core" version="3.1">
+	<brief_description>
+		Noise generator based on Open Simplex.
+	</brief_description>
+	<description>
+		This resource allows you to configure and sample a fractal noise space.
+
+		Here is a brief usage example that configures a SimplexNoise and gets samples at various positions and dimensions:
+		[codeblock]
+		var noise = SimplexNoise.new()
+
+		# Configure
+		noise.seed = randi()
+		noise.octaves = 4
+		noise.period = 20.0
+		noise.persistance = 0.8
+		
+		#Sample
+		print("Values:")
+		print(noise.get_noise_2d(1.0,1.0))
+		print(noise.get_noise_3d(0.5,3.0,15.0))
+		print(noise.get_noise_3d(0.5,1.9,4.7,0.0))
+		[/codeblock]
+
+	</description>
+	<tutorials>
+	</tutorials>
+	<demos>
+	</demos>
+	<methods>
+		<method name="get_image">
+			<return type="Image">
+			</return>
+			<argument index="0" name="width" type="int">
+			</argument>
+			<argument index="1" name="height" type="int">
+			</argument>
+			<description>
+				Generate a noise image with the requested [code]width[/code] and [code]height[/code], based on the current noise parameters.
+			</description>
+		</method>
+		<method name="get_noise_2d">
+			<return type="float">
+			</return>
+			<argument index="0" name="x" type="float">
+			</argument>
+			<argument index="1" name="y" type="float">
+			</argument>
+			<description>
+				2D noise value [-1,1] at position [code]x[/code],[code]y[/code].
+			</description>
+		</method>
+		<method name="get_noise_2dv">
+			<return type="float">
+			</return>
+			<argument index="0" name="pos" type="Vector2">
+			</argument>
+			<description>
+				2D noise value [-1,1] at position [code]pos.x[/code],[code]pos.y[/code].
+			</description>
+		</method>
+		<method name="get_noise_3d">
+			<return type="float">
+			</return>
+			<argument index="0" name="x" type="float">
+			</argument>
+			<argument index="1" name="y" type="float">
+			</argument>
+			<argument index="2" name="z" type="float">
+			</argument>
+			<description>
+				3D noise value [-1,1] at position [code]x[/code],[code]y[/code],[code]z[/code].
+			</description>
+		</method>
+		<method name="get_noise_3dv">
+			<return type="float">
+			</return>
+			<argument index="0" name="pos" type="Vector3">
+			</argument>
+			<description>
+				3D noise value [-1,1] at position [code]pos.x[/code],[code]pos.y[/code],[code]pos.z[/code].
+			</description>
+		</method>
+		<method name="get_noise_4d">
+			<return type="float">
+			</return>
+			<argument index="0" name="x" type="float">
+			</argument>
+			<argument index="1" name="y" type="float">
+			</argument>
+			<argument index="2" name="z" type="float">
+			</argument>
+			<argument index="3" name="w" type="float">
+			</argument>
+			<description>
+				4D noise value [-1,1] at position [code]x[/code],[code]y[/code],[code]z[/code],[code]w[/code].
+			</description>
+		</method>
+		<method name="get_seamless_image">
+			<return type="Image">
+			</return>
+			<argument index="0" name="size" type="int">
+			</argument>
+			<description>
+				Generate a tileable noise image, based on the current noise parameters. 
+				Generated seamless images are always square ([code]size[/code]x[code]size[/code]).
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="lacunarity" type="float" setter="set_lacunarity" getter="get_lacunarity">
+			Difference in period between [member octaves].
+		</member>
+		<member name="octaves" type="int" setter="set_octaves" getter="get_octaves">
+			Number of Simplex Noise layers that are sampled to get the fractal noise.
+		</member>
+		<member name="period" type="float" setter="set_period" getter="get_period">
+			Period of the base octave. 
+			A lower period results in a higher frequancy noise (more value changes across the same distance).
+		</member>
+		<member name="persistance" type="float" setter="set_persistance" getter="get_persistance">
+			Contribuiton factor of the different octaves. 
+			A [code]persistance[/code] value of 1 means all the octaves have the same contribution, a value of 0.5 means each octave contributes half as much as the previous one.
+		</member>
+		<member name="seed" type="int" setter="set_seed" getter="get_seed">
+			Seed used to generate random values, different seeds will generate different noise maps.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/modules/opensimplex/noise_texture.cpp
+++ b/modules/opensimplex/noise_texture.cpp
@@ -1,0 +1,244 @@
+/*************************************************************************/
+/*  noise_texture.cpp                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "noise_texture.h"
+
+#include "core/core_string_names.h"
+
+NoiseTexture::NoiseTexture() {
+	update_queued = false;
+	noise_thread = NULL;
+	regen_queued = false;
+	first_time = true;
+
+	size = Vector2i(512, 512);
+	seamless = false;
+	as_normalmap = false;
+	flags = FLAGS_DEFAULT;
+
+	noise = Ref<SimplexNoise>();
+
+	texture = VS::get_singleton()->texture_create();
+
+	_queue_update();
+}
+
+NoiseTexture::~NoiseTexture() {
+	VS::get_singleton()->free(texture);
+}
+
+void NoiseTexture::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("set_width", "width"), &NoiseTexture::set_width);
+	ClassDB::bind_method(D_METHOD("set_height", "height"), &NoiseTexture::set_height);
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &NoiseTexture::set_size);
+
+	ClassDB::bind_method(D_METHOD("set_noise", "noise"), &NoiseTexture::set_noise);
+	ClassDB::bind_method(D_METHOD("get_noise"), &NoiseTexture::get_noise);
+
+	ClassDB::bind_method(D_METHOD("set_seamless", "seamless"), &NoiseTexture::set_seamless);
+	ClassDB::bind_method(D_METHOD("get_seamless"), &NoiseTexture::get_seamless);
+
+	ClassDB::bind_method(D_METHOD("set_as_normalmap", "as_normalmap"), &NoiseTexture::set_as_normalmap);
+	ClassDB::bind_method(D_METHOD("is_normalmap"), &NoiseTexture::is_normalmap);
+
+	ClassDB::bind_method(D_METHOD("_update_texture"), &NoiseTexture::_update_texture);
+	ClassDB::bind_method(D_METHOD("_generate_texture"), &NoiseTexture::_generate_texture);
+	ClassDB::bind_method(D_METHOD("_thread_done", "image"), &NoiseTexture::_thread_done);
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), "set_size", "get_size");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "seamless"), "set_seamless", "get_seamless");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "as_normalmap"), "set_as_normalmap", "is_normalmap");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "noise", PROPERTY_HINT_RESOURCE_TYPE, "SimplexNoise"), "set_noise", "get_noise");
+}
+
+void NoiseTexture::_set_texture_data(const Ref<Image> &p_image) {
+	data = p_image;
+	if (data.is_valid()) {
+		VS::get_singleton()->texture_allocate(texture, size.x, size.y, 0, Image::FORMAT_RGBA8, VS::TEXTURE_TYPE_2D, flags);
+		VS::get_singleton()->texture_set_data(texture, p_image);
+	}
+	emit_changed();
+}
+
+void NoiseTexture::_thread_done(const Ref<Image> &p_image) {
+
+	_set_texture_data(p_image);
+	Thread::wait_to_finish(noise_thread);
+	memdelete(noise_thread);
+	noise_thread = NULL;
+	if (regen_queued) {
+		noise_thread = Thread::create(_thread_function, this);
+		regen_queued = false;
+	}
+}
+
+void NoiseTexture::_thread_function(void *p_ud) {
+	NoiseTexture *tex = (NoiseTexture *)p_ud;
+	tex->call_deferred("_thread_done", tex->_generate_texture());
+}
+
+void NoiseTexture::_queue_update() {
+
+	if (update_queued)
+		return;
+
+	update_queued = true;
+	call_deferred("_update_texture");
+}
+
+Ref<Image> NoiseTexture::_generate_texture() {
+
+	update_queued = false;
+
+	if (noise.is_null()) return Ref<Image>();
+
+	Ref<Image> image;
+
+	if (seamless) {
+		image = noise->get_seamless_image(size.x);
+	} else {
+		image = noise->get_image(size.x, size.y);
+	}
+
+	if (as_normalmap) {
+		image->bumpmap_to_normalmap();
+	}
+
+	return image;
+}
+
+void NoiseTexture::_update_texture() {
+	bool use_thread = true;
+	if (first_time) {
+		use_thread = false;
+		first_time = false;
+	}
+#ifdef NO_THREADS
+	use_thread = false;
+#endif
+	if (use_thread) {
+
+		if (!noise_thread) {
+			noise_thread = Thread::create(_thread_function, this);
+			regen_queued = false;
+		} else {
+			regen_queued = true;
+		}
+
+	} else {
+		Ref<Image> image = _generate_texture();
+		_set_texture_data(image);
+	}
+}
+
+void NoiseTexture::set_noise(Ref<SimplexNoise> p_noise) {
+	if (p_noise == noise)
+		return;
+	if (noise.is_valid()) {
+		noise->disconnect(CoreStringNames::get_singleton()->changed, this, "_update_texture");
+	}
+	noise = p_noise;
+	if (noise.is_valid()) {
+		noise->connect(CoreStringNames::get_singleton()->changed, this, "_update_texture");
+	}
+	_queue_update();
+}
+
+Ref<SimplexNoise> NoiseTexture::get_noise() {
+	return noise;
+}
+
+void NoiseTexture::set_width(int p_width) {
+	if (p_width == size.x) return;
+	size.x = p_width;
+	_queue_update();
+}
+
+void NoiseTexture::set_height(int p_height) {
+	if (p_height == size.y) return;
+	size.y = p_height;
+	_queue_update();
+}
+
+void NoiseTexture::set_seamless(bool p_seamless) {
+	if (p_seamless == seamless) return;
+	seamless = p_seamless;
+	_queue_update();
+}
+
+bool NoiseTexture::get_seamless() {
+	return seamless;
+}
+
+void NoiseTexture::set_as_normalmap(bool p_as_normalmap) {
+	if (p_as_normalmap == as_normalmap) return;
+	as_normalmap = p_as_normalmap;
+	_queue_update();
+}
+
+bool NoiseTexture::is_normalmap() {
+	return as_normalmap;
+}
+
+void NoiseTexture::set_size(Vector2 p_size) {
+	if (p_size == size) return;
+	size = p_size;
+	_queue_update();
+}
+
+Vector2 NoiseTexture::get_size() {
+
+	return size;
+}
+
+int NoiseTexture::get_width() const {
+
+	return size.x;
+}
+
+int NoiseTexture::get_height() const {
+
+	return size.y;
+}
+
+void NoiseTexture::set_flags(uint32_t p_flags) {
+	flags = p_flags;
+	VS::get_singleton()->texture_set_flags(texture, flags);
+}
+
+uint32_t NoiseTexture::get_flags() const {
+	return flags;
+}
+
+Ref<Image> NoiseTexture::get_data() const {
+
+	return data;
+}

--- a/modules/opensimplex/noise_texture.h
+++ b/modules/opensimplex/noise_texture.h
@@ -1,0 +1,104 @@
+/*************************************************************************/
+/*  noise_texture.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef NOISE_TEXTURE_H
+#define NOISE_TEXTURE_H
+
+#include "simplex_noise.h"
+
+#include "core/image.h"
+#include "core/reference.h"
+#include "editor/editor_node.h"
+#include "editor/editor_plugin.h"
+#include "editor/property_editor.h"
+
+class NoiseTexture : public Texture {
+	GDCLASS(NoiseTexture, Texture)
+
+private:
+	Ref<Image> data;
+
+	Thread *noise_thread;
+
+	bool first_time;
+	bool update_queued;
+	bool regen_queued;
+
+	RID texture;
+	uint32_t flags;
+
+	Ref<SimplexNoise> noise;
+	Vector2i size;
+	bool seamless;
+	bool as_normalmap;
+
+	void _thread_done(const Ref<Image> &p_image);
+	static void _thread_function(void *p_ud);
+
+	void _queue_update();
+	Ref<Image> _generate_texture();
+	void _update_texture();
+	void _set_texture_data(const Ref<Image> &p_image);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_noise(Ref<SimplexNoise> p_noise);
+	Ref<SimplexNoise> get_noise();
+
+	void set_width(int p_width);
+	void set_height(int p_hieght);
+
+	void set_seamless(bool p_seamless);
+	bool get_seamless();
+
+	void set_as_normalmap(bool p_seamless);
+	bool is_normalmap();
+
+	void set_size(Vector2 p_size);
+	Vector2 get_size();
+
+	int get_width() const;
+	int get_height() const;
+
+	virtual void set_flags(uint32_t p_flags);
+	virtual uint32_t get_flags() const;
+
+	virtual RID get_rid() const { return texture; }
+	virtual bool has_alpha() const { return false; }
+
+	virtual Ref<Image> get_data() const;
+
+	NoiseTexture();
+	virtual ~NoiseTexture();
+};
+
+#endif // NOISE_TEXTURE_H

--- a/modules/opensimplex/register_types.cpp
+++ b/modules/opensimplex/register_types.cpp
@@ -1,0 +1,42 @@
+/*************************************************************************/
+/*  register_types.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "register_types.h"
+#include "noise_texture.h"
+#include "simplex_noise.h"
+
+void register_opensimplex_types() {
+
+	ClassDB::register_class<SimplexNoise>();
+	ClassDB::register_class<NoiseTexture>();
+}
+
+void unregister_opensimplex_types() {
+}

--- a/modules/opensimplex/register_types.h
+++ b/modules/opensimplex/register_types.h
@@ -1,0 +1,32 @@
+/*************************************************************************/
+/*  register_types.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+void register_opensimplex_types();
+void unregister_opensimplex_types();

--- a/modules/opensimplex/simplex_noise.cpp
+++ b/modules/opensimplex/simplex_noise.cpp
@@ -1,0 +1,257 @@
+/*************************************************************************/
+/*  simplex_noise.cpp                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "simplex_noise.h"
+
+#include "core/core_string_names.h"
+
+SimplexNoise::SimplexNoise() {
+
+	seed = 0;
+	persistance = 0.5;
+	octaves = 3;
+	period = 64;
+	lacunarity = 2.0;
+
+	_init_seeds();
+}
+
+SimplexNoise::~SimplexNoise() {
+}
+
+void SimplexNoise::_init_seeds() {
+	for (int i = 0; i < 6; ++i) {
+		open_simplex_noise(seed + i * 2, &(contexts[i]));
+	}
+}
+
+void SimplexNoise::set_seed(int p_seed) {
+
+	if (seed == p_seed)
+		return;
+
+	seed = p_seed;
+
+	_init_seeds();
+
+	emit_changed();
+}
+
+int SimplexNoise::get_seed() {
+
+	return seed;
+}
+
+void SimplexNoise::set_octaves(int p_octaves) {
+	if (p_octaves == octaves) return;
+	octaves = CLAMP(p_octaves, 1, 6);
+	emit_changed();
+}
+
+void SimplexNoise::set_period(float p_period) {
+	if (p_period == period) return;
+	period = p_period;
+	emit_changed();
+}
+
+void SimplexNoise::set_persistance(float p_persistance) {
+	if (p_persistance == persistance) return;
+	persistance = p_persistance;
+	emit_changed();
+}
+
+void SimplexNoise::set_lacunarity(float p_lacunarity) {
+	if (p_lacunarity == lacunarity) return;
+	lacunarity = p_lacunarity;
+	emit_changed();
+}
+
+Ref<Image> SimplexNoise::get_image(int p_width, int p_height) {
+
+	PoolVector<uint8_t> data;
+	data.resize(p_width * p_height * 4);
+
+	PoolVector<uint8_t>::Write wd8 = data.write();
+
+	for (int i = 0; i < p_height; i++) {
+		for (int j = 0; j < p_width; j++) {
+			float v = get_noise_2d(i, j);
+			v = v * 0.5 + 0.5; // Normalize [0..1]
+			uint8_t value = uint8_t(CLAMP(v * 255.0, 0, 255));
+			wd8[(i * p_width + j) * 4 + 0] = value;
+			wd8[(i * p_width + j) * 4 + 1] = value;
+			wd8[(i * p_width + j) * 4 + 2] = value;
+			wd8[(i * p_width + j) * 4 + 3] = 255;
+		}
+	}
+
+	Ref<Image> image = memnew(Image(p_width, p_height, false, Image::FORMAT_RGBA8, data));
+	return image;
+}
+
+Ref<Image> SimplexNoise::get_seamless_image(int p_size) {
+
+	PoolVector<uint8_t> data;
+	data.resize(p_size * p_size * 4);
+
+	PoolVector<uint8_t>::Write wd8 = data.write();
+
+	for (int i = 0; i < p_size; i++) {
+		for (int j = 0; j < p_size; j++) {
+
+			float ii = (float)i / (float)p_size;
+			float jj = (float)j / (float)p_size;
+
+			ii *= 2.0 * Math_PI;
+			jj *= 2.0 * Math_PI;
+
+			float radius = p_size / (2.0 * Math_PI);
+
+			float x = radius * Math::sin(jj);
+			float y = radius * Math::cos(jj);
+			float z = radius * Math::sin(ii);
+			float w = radius * Math::cos(ii);
+			float v = get_noise_4d(x, y, z, w);
+
+			v = v * 0.5 + 0.5; // Normalize [0..1]
+			uint8_t value = uint8_t(CLAMP(v * 255.0, 0, 255));
+			wd8[(i * p_size + j) * 4 + 0] = value;
+			wd8[(i * p_size + j) * 4 + 1] = value;
+			wd8[(i * p_size + j) * 4 + 2] = value;
+			wd8[(i * p_size + j) * 4 + 3] = 255;
+		}
+	}
+
+	Ref<Image> image = memnew(Image(p_size, p_size, false, Image::FORMAT_RGBA8, data));
+	return image;
+}
+
+void SimplexNoise::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("get_seed"), &SimplexNoise::get_seed);
+	ClassDB::bind_method(D_METHOD("set_seed", "seed"), &SimplexNoise::set_seed);
+
+	ClassDB::bind_method(D_METHOD("set_octaves", "octave_count"), &SimplexNoise::set_octaves);
+	ClassDB::bind_method(D_METHOD("get_octaves"), &SimplexNoise::get_octaves);
+
+	ClassDB::bind_method(D_METHOD("set_period", "period"), &SimplexNoise::set_period);
+	ClassDB::bind_method(D_METHOD("get_period"), &SimplexNoise::get_period);
+
+	ClassDB::bind_method(D_METHOD("set_persistance", "persistance"), &SimplexNoise::set_persistance);
+	ClassDB::bind_method(D_METHOD("get_persistance"), &SimplexNoise::get_persistance);
+
+	ClassDB::bind_method(D_METHOD("set_lacunarity", "lacunarity"), &SimplexNoise::set_lacunarity);
+	ClassDB::bind_method(D_METHOD("get_lacunarity"), &SimplexNoise::get_lacunarity);
+
+	ClassDB::bind_method(D_METHOD("get_image", "width", "height"), &SimplexNoise::get_image);
+	ClassDB::bind_method(D_METHOD("get_seamless_image", "size"), &SimplexNoise::get_seamless_image);
+
+	ClassDB::bind_method(D_METHOD("get_noise_2d", "x", "y"), &SimplexNoise::get_noise_2d);
+	ClassDB::bind_method(D_METHOD("get_noise_3d", "x", "y", "z"), &SimplexNoise::get_noise_3d);
+	ClassDB::bind_method(D_METHOD("get_noise_4d", "x", "y", "z", "w"), &SimplexNoise::get_noise_4d);
+
+	ClassDB::bind_method(D_METHOD("get_noise_2dv", "pos"), &SimplexNoise::get_noise_2dv);
+	ClassDB::bind_method(D_METHOD("get_noise_3dv", "pos"), &SimplexNoise::get_noise_3dv);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "seed"), "set_seed", "get_seed");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "octaves", PROPERTY_HINT_RANGE, "1,6,1"), "set_octaves", "get_octaves");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "period", PROPERTY_HINT_RANGE, "0.1,256.0,0.1"), "set_period", "get_period");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "persistance", PROPERTY_HINT_RANGE, "0.0,1.0,0.001"), "set_persistance", "get_persistance");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lacunarity", PROPERTY_HINT_RANGE, "0.1,4.0,0.01"), "set_lacunarity", "get_lacunarity");
+}
+
+float SimplexNoise::get_noise_2d(float x, float y) {
+
+	x /= period;
+	y /= period;
+
+	float amp = 1.0;
+	float max = 1.0;
+	float sum = _get_octave_noise_2d(0, x, y);
+
+	unsigned int i = 0;
+	while (++i < octaves) {
+		x *= lacunarity;
+		y *= lacunarity;
+		amp *= persistance;
+		max += amp;
+		sum += _get_octave_noise_2d(i, x, y) * amp;
+	}
+
+	return sum / max;
+}
+
+float SimplexNoise::get_noise_3d(float x, float y, float z) {
+
+	x /= period;
+	y /= period;
+	z /= period;
+
+	float amp = 1.0;
+	float max = 1.0;
+	float sum = _get_octave_noise_3d(0, x, y, z);
+
+	unsigned int i = 0;
+	while (++i < octaves) {
+		x *= lacunarity;
+		y *= lacunarity;
+		z *= lacunarity;
+		amp *= persistance;
+		max += amp;
+		sum += _get_octave_noise_3d(i, x, y, z) * amp;
+	}
+
+	return sum / max;
+}
+
+float SimplexNoise::get_noise_4d(float x, float y, float z, float w) {
+
+	x /= period;
+	y /= period;
+	z /= period;
+	w /= period;
+
+	float amp = 1.0;
+	float max = 1.0;
+	float sum = _get_octave_noise_4d(0, x, y, z, w);
+
+	unsigned int i = 0;
+	while (++i < octaves) {
+		x *= lacunarity;
+		y *= lacunarity;
+		z *= lacunarity;
+		w *= lacunarity;
+		amp *= persistance;
+		max += amp;
+		sum += _get_octave_noise_4d(i, x, y, z, w) * amp;
+	}
+
+	return sum / max;
+}

--- a/modules/opensimplex/simplex_noise.h
+++ b/modules/opensimplex/simplex_noise.h
@@ -1,0 +1,93 @@
+/*************************************************************************/
+/*  simplex_noise.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SIMPLEX_NOISE_H
+#define SIMPLEX_NOISE_H
+
+#include "core/image.h"
+#include "core/reference.h"
+#include "scene/resources/texture.h"
+
+#include "thirdparty/misc/open-simplex-noise.h"
+
+class SimplexNoise : public Resource {
+	GDCLASS(SimplexNoise, Resource)
+	OBJ_SAVE_TYPE(SimplexNoise);
+
+	osn_context contexts[6];
+
+	int seed;
+	float persistance; // Controls details, value in [0,1]. Higher increases grain, lower increases smoothness.
+	int octaves; // Number of noise layers
+	float period; // Distance above which we start to see similarities. The higher, the longer "hills" will be on a terrain.
+	float lacunarity; // Controls period change across octaves. 2 is usually a good value to address all detail levels.
+
+public:
+	SimplexNoise();
+	~SimplexNoise();
+
+	void _init_seeds();
+
+	void set_seed(int seed);
+	int get_seed();
+
+	void set_octaves(int p_octaves);
+	int get_octaves() const { return octaves; }
+
+	void set_period(float p_period);
+	float get_period() const { return period; }
+
+	void set_persistance(float p_persistance);
+	float get_persistance() const { return persistance; }
+
+	void set_lacunarity(float p_lacunarity);
+	float get_lacunarity() const { return lacunarity; }
+
+	Ref<Image> get_image(int p_width, int p_height);
+	Ref<Image> get_seamless_image(int p_size);
+
+	float get_noise_2d(float x, float y);
+	float get_noise_3d(float x, float y, float z);
+	float get_noise_4d(float x, float y, float z, float w);
+
+	_FORCE_INLINE_ float _get_octave_noise_2d(int octave, float x, float y) { return open_simplex_noise2(&(contexts[octave]), x, y); }
+	_FORCE_INLINE_ float _get_octave_noise_3d(int octave, float x, float y, float z) { return open_simplex_noise3(&(contexts[octave]), x, y, z); }
+	_FORCE_INLINE_ float _get_octave_noise_4d(int octave, float x, float y, float z, float w) { return open_simplex_noise4(&(contexts[octave]), x, y, z, w); }
+
+	// Convenience
+
+	_FORCE_INLINE_ float get_noise_2dv(Vector2 v) { return get_noise_2d(v.x, v.y); }
+	_FORCE_INLINE_ float get_noise_3dv(Vector3 v) { return get_noise_3d(v.x, v.y, v.z); }
+
+protected:
+	static void _bind_methods();
+};
+
+#endif // OPENSIMPLEX_NOISE_H

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1633,15 +1633,16 @@ void GradientTexture::_queue_update() {
 	if (update_pending)
 		return;
 
+	update_pending = true;
 	call_deferred("_update");
 }
 
 void GradientTexture::_update() {
 
+	update_pending = false;
+
 	if (gradient.is_null())
 		return;
-
-	update_pending = false;
 
 	PoolVector<uint8_t> data;
 	data.resize(width * 4);

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -356,6 +356,11 @@ Collection of single-file libraries used in Godot components.
   * Upstream: https://github.com/ivanfratric/polypartition (`src/polypartition.cpp`)
   * Version: TBD, class was renamed
   * License: MIT
+- `open-simplex-noise.{c,h}`
+  * Upstream: https://github.com/smcameron/open-simplex-noise-in-c
+  * Version: git (0d555e7, 2015)
+  * License: Unlicense
+
 
 ### modules
 

--- a/thirdparty/misc/open-simplex-noise-LICENSE
+++ b/thirdparty/misc/open-simplex-noise-LICENSE
@@ -1,0 +1,25 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
+

--- a/thirdparty/misc/open-simplex-noise-no-allocate.patch
+++ b/thirdparty/misc/open-simplex-noise-no-allocate.patch
@@ -1,0 +1,133 @@
+diff -u orig/open-simplex-noise.c misc/open-simplex-noise.c
+--- orig/open-simplex-noise.c	2018-09-14 11:11:40.049810000 +0200
++++ misc/open-simplex-noise.c	2018-09-14 11:09:39.726457000 +0200
+@@ -13,6 +13,11 @@
+  *   of any particular randomization library, so results
+  *   will be the same when ported to other languages.
+  */
++
++// -- GODOT start --
++// Modified to work without allocating memory, also removed some unused function. 
++// -- GODOT end --
++
+ #include <math.h>
+ #include <stdlib.h>
+ #include <stdint.h>
+@@ -34,11 +39,12 @@
+ 	
+ #define DEFAULT_SEED (0LL)
+ 
+-struct osn_context {
++// -- GODOT start --
++/*struct osn_context {
+ 	int16_t *perm;
+ 	int16_t *permGradIndex3D;
+-};
+-
++};*/
++// -- GODOT end --
+ #define ARRAYSIZE(x) (sizeof((x)) / sizeof((x)[0]))
+ 
+ /* 
+@@ -126,7 +132,9 @@
+ 	int xi = (int) x;
+ 	return x < xi ? xi - 1 : xi;
+ }
+-	
++
++// -- GODOT start --
++/*
+ static int allocate_perm(struct osn_context *ctx, int nperm, int ngrad)
+ {
+ 	if (ctx->perm)
+@@ -154,18 +162,21 @@
+ 	memcpy(ctx->perm, p, sizeof(*ctx->perm) * nelements);
+ 		
+ 	for (i = 0; i < 256; i++) {
+-		/* Since 3D has 24 gradients, simple bitmask won't work, so precompute modulo array. */
++		// Since 3D has 24 gradients, simple bitmask won't work, so precompute modulo array.
+ 		ctx->permGradIndex3D[i] = (int16_t)((ctx->perm[i] % (ARRAYSIZE(gradients3D) / 3)) * 3);
+ 	}
+ 	return 0;
+ }
++*/
++// -- GODOT end --
+ 
+ /*	
+  * Initializes using a permutation array generated from a 64-bit seed.
+  * Generates a proper permutation (i.e. doesn't merely perform N successive pair
+  * swaps on a base array).  Uses a simple 64-bit LCG.
+  */
+-int open_simplex_noise(int64_t seed, struct osn_context **ctx)
++// -- GODOT start --
++int open_simplex_noise(int64_t seed, struct osn_context *ctx)
+ {
+ 	int rc;
+ 	int16_t source[256];
+@@ -174,20 +185,9 @@
+ 	int16_t *permGradIndex3D;
+ 	int r;
+ 
+-	*ctx = (struct osn_context *) malloc(sizeof(**ctx));
+-	if (!(*ctx))
+-		return -ENOMEM;
+-	(*ctx)->perm = NULL;
+-	(*ctx)->permGradIndex3D = NULL;
+-
+-	rc = allocate_perm(*ctx, 256, 256);
+-	if (rc) {
+-		free(*ctx);
+-		return rc;
+-	}
+-
+-	perm = (*ctx)->perm;
+-	permGradIndex3D = (*ctx)->permGradIndex3D;
++	perm = ctx->perm;
++	permGradIndex3D = ctx->permGradIndex3D;
++// -- GODOT end --
+ 
+ 	for (i = 0; i < 256; i++)
+ 		source[i] = (int16_t) i;
+@@ -206,6 +206,8 @@
+ 	return 0;
+ }
+ 
++// -- GODOT start --
++/*
+ void open_simplex_noise_free(struct osn_context *ctx)
+ {
+ 	if (!ctx)
+@@ -220,6 +222,8 @@
+ 	}
+ 	free(ctx);
+ }
++*/
++// -- GODOT end --
+ 	
+ /* 2D OpenSimplex (Simplectic) Noise. */
+ double open_simplex_noise2(struct osn_context *ctx, double x, double y) 
+diff -u orig/open-simplex-noise.h misc/open-simplex-noise.h
+--- orig/open-simplex-noise.h	2018-09-14 11:11:19.659807000 +0200
++++ misc/open-simplex-noise.h	2018-09-14 11:10:05.006460000 +0200
+@@ -35,11 +35,18 @@
+ 	extern "C" {
+ #endif
+ 
+-struct osn_context;
++// -- GODOT start --
++// Modified to work without allocating memory, also removed some unused function. 
+ 
+-int open_simplex_noise(int64_t seed, struct osn_context **ctx);
++struct osn_context {
++	int16_t perm[256];
++	int16_t permGradIndex3D[256];
++};
++
++int open_simplex_noise(int64_t seed, struct osn_context *ctx);
++//int open_simplex_noise_init_perm(struct osn_context *ctx, int16_t p[], int nelements);
++// -- GODOT end --
+ void open_simplex_noise_free(struct osn_context *ctx);
+-int open_simplex_noise_init_perm(struct osn_context *ctx, int16_t p[], int nelements);
+ double open_simplex_noise2(struct osn_context *ctx, double x, double y);
+ double open_simplex_noise3(struct osn_context *ctx, double x, double y, double z);
+ double open_simplex_noise4(struct osn_context *ctx, double x, double y, double z, double w);

--- a/thirdparty/misc/open-simplex-noise.c
+++ b/thirdparty/misc/open-simplex-noise.c
@@ -1,0 +1,2254 @@
+/*
+ * OpenSimplex (Simplectic) Noise in C.
+ * Ported by Stephen M. Cameron from Kurt Spencer's java implementation
+ * 
+ * v1.1 (October 5, 2014)
+ * - Added 2D and 4D implementations.
+ * - Proper gradient sets for all dimensions, from a
+ *   dimensionally-generalizable scheme with an actual
+ *   rhyme and reason behind it.
+ * - Removed default permutation array in favor of
+ *   default seed.
+ * - Changed seed-based constructor to be independent
+ *   of any particular randomization library, so results
+ *   will be the same when ported to other languages.
+ */
+
+// -- GODOT start --
+// Modified to work without allocating memory, also removed some unused function. 
+// -- GODOT end --
+
+#include <math.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+
+#include "open-simplex-noise.h"
+
+#define STRETCH_CONSTANT_2D (-0.211324865405187)    /* (1 / sqrt(2 + 1) - 1 ) / 2; */
+#define SQUISH_CONSTANT_2D  (0.366025403784439)     /* (sqrt(2 + 1) -1) / 2; */
+#define STRETCH_CONSTANT_3D (-1.0 / 6.0)            /* (1 / sqrt(3 + 1) - 1) / 3; */
+#define SQUISH_CONSTANT_3D  (1.0 / 3.0)             /* (sqrt(3+1)-1)/3; */
+#define STRETCH_CONSTANT_4D (-0.138196601125011)    /* (1 / sqrt(4 + 1) - 1) / 4; */
+#define SQUISH_CONSTANT_4D  (0.309016994374947)     /* (sqrt(4 + 1) - 1) / 4; */
+	
+#define NORM_CONSTANT_2D (47.0)
+#define NORM_CONSTANT_3D (103.0)
+#define NORM_CONSTANT_4D (30.0)
+	
+#define DEFAULT_SEED (0LL)
+
+// -- GODOT start --
+/*struct osn_context {
+	int16_t *perm;
+	int16_t *permGradIndex3D;
+};*/
+// -- GODOT end --
+#define ARRAYSIZE(x) (sizeof((x)) / sizeof((x)[0]))
+
+/* 
+ * Gradients for 2D. They approximate the directions to the
+ * vertices of an octagon from the center.
+ */
+static const int8_t gradients2D[] = {
+	 5,  2,    2,  5,
+	-5,  2,   -2,  5,
+	 5, -2,    2, -5,
+	-5, -2,   -2, -5,
+};
+
+/*	
+ * Gradients for 3D. They approximate the directions to the
+ * vertices of a rhombicuboctahedron from the center, skewed so
+ * that the triangular and square facets can be inscribed inside
+ * circles of the same radius.
+ */
+static const signed char gradients3D[] = {
+	-11,  4,  4,     -4,  11,  4,    -4,  4,  11,
+	 11,  4,  4,      4,  11,  4,     4,  4,  11,
+	-11, -4,  4,     -4, -11,  4,    -4, -4,  11,
+	 11, -4,  4,      4, -11,  4,     4, -4,  11,
+	-11,  4, -4,     -4,  11, -4,    -4,  4, -11,
+	 11,  4, -4,      4,  11, -4,     4,  4, -11,
+	-11, -4, -4,     -4, -11, -4,    -4, -4, -11,
+	 11, -4, -4,      4, -11, -4,     4, -4, -11,
+};
+
+/*	
+ * Gradients for 4D. They approximate the directions to the
+ * vertices of a disprismatotesseractihexadecachoron from the center,
+ * skewed so that the tetrahedral and cubic facets can be inscribed inside
+ * spheres of the same radius.
+ */
+static const signed char gradients4D[] = {
+	 3,  1,  1,  1,      1,  3,  1,  1,      1,  1,  3,  1,      1,  1,  1,  3,
+	-3,  1,  1,  1,     -1,  3,  1,  1,     -1,  1,  3,  1,     -1,  1,  1,  3,
+	 3, -1,  1,  1,      1, -3,  1,  1,      1, -1,  3,  1,      1, -1,  1,  3,
+	-3, -1,  1,  1,     -1, -3,  1,  1,     -1, -1,  3,  1,     -1, -1,  1,  3,
+	 3,  1, -1,  1,      1,  3, -1,  1,      1,  1, -3,  1,      1,  1, -1,  3,
+	-3,  1, -1,  1,     -1,  3, -1,  1,     -1,  1, -3,  1,     -1,  1, -1,  3,
+	 3, -1, -1,  1,      1, -3, -1,  1,      1, -1, -3,  1,      1, -1, -1,  3,
+	-3, -1, -1,  1,     -1, -3, -1,  1,     -1, -1, -3,  1,     -1, -1, -1,  3,
+	 3,  1,  1, -1,      1,  3,  1, -1,      1,  1,  3, -1,      1,  1,  1, -3,
+	-3,  1,  1, -1,     -1,  3,  1, -1,     -1,  1,  3, -1,     -1,  1,  1, -3,
+	 3, -1,  1, -1,      1, -3,  1, -1,      1, -1,  3, -1,      1, -1,  1, -3,
+	-3, -1,  1, -1,     -1, -3,  1, -1,     -1, -1,  3, -1,     -1, -1,  1, -3,
+	 3,  1, -1, -1,      1,  3, -1, -1,      1,  1, -3, -1,      1,  1, -1, -3,
+	-3,  1, -1, -1,     -1,  3, -1, -1,     -1,  1, -3, -1,     -1,  1, -1, -3,
+	 3, -1, -1, -1,      1, -3, -1, -1,      1, -1, -3, -1,      1, -1, -1, -3,
+	-3, -1, -1, -1,     -1, -3, -1, -1,     -1, -1, -3, -1,     -1, -1, -1, -3,
+};
+
+static double extrapolate2(struct osn_context *ctx, int xsb, int ysb, double dx, double dy)
+{
+	int16_t *perm = ctx->perm;	
+	int index = perm[(perm[xsb & 0xFF] + ysb) & 0xFF] & 0x0E;
+	return gradients2D[index] * dx
+		+ gradients2D[index + 1] * dy;
+}
+	
+static double extrapolate3(struct osn_context *ctx, int xsb, int ysb, int zsb, double dx, double dy, double dz)
+{
+	int16_t *perm = ctx->perm;	
+	int16_t *permGradIndex3D = ctx->permGradIndex3D;
+	int index = permGradIndex3D[(perm[(perm[xsb & 0xFF] + ysb) & 0xFF] + zsb) & 0xFF];
+	return gradients3D[index] * dx
+		+ gradients3D[index + 1] * dy
+		+ gradients3D[index + 2] * dz;
+}
+	
+static double extrapolate4(struct osn_context *ctx, int xsb, int ysb, int zsb, int wsb, double dx, double dy, double dz, double dw)
+{
+	int16_t *perm = ctx->perm;
+	int index = perm[(perm[(perm[(perm[xsb & 0xFF] + ysb) & 0xFF] + zsb) & 0xFF] + wsb) & 0xFF] & 0xFC;
+	return gradients4D[index] * dx
+		+ gradients4D[index + 1] * dy
+		+ gradients4D[index + 2] * dz
+		+ gradients4D[index + 3] * dw;
+}
+	
+static INLINE int fastFloor(double x) {
+	int xi = (int) x;
+	return x < xi ? xi - 1 : xi;
+}
+
+// -- GODOT start --
+/*
+static int allocate_perm(struct osn_context *ctx, int nperm, int ngrad)
+{
+	if (ctx->perm)
+		free(ctx->perm);
+	if (ctx->permGradIndex3D)
+		free(ctx->permGradIndex3D);
+	ctx->perm = (int16_t *) malloc(sizeof(*ctx->perm) * nperm); 
+	if (!ctx->perm)
+		return -ENOMEM;
+	ctx->permGradIndex3D = (int16_t *) malloc(sizeof(*ctx->permGradIndex3D) * ngrad);
+	if (!ctx->permGradIndex3D) {
+		free(ctx->perm);
+		return -ENOMEM;
+	}
+	return 0;
+}
+	
+int open_simplex_noise_init_perm(struct osn_context *ctx, int16_t p[], int nelements)
+{
+	int i, rc;
+
+	rc = allocate_perm(ctx, nelements, 256);
+	if (rc)
+		return rc;
+	memcpy(ctx->perm, p, sizeof(*ctx->perm) * nelements);
+		
+	for (i = 0; i < 256; i++) {
+		// Since 3D has 24 gradients, simple bitmask won't work, so precompute modulo array.
+		ctx->permGradIndex3D[i] = (int16_t)((ctx->perm[i] % (ARRAYSIZE(gradients3D) / 3)) * 3);
+	}
+	return 0;
+}
+*/
+// -- GODOT end --
+
+/*	
+ * Initializes using a permutation array generated from a 64-bit seed.
+ * Generates a proper permutation (i.e. doesn't merely perform N successive pair
+ * swaps on a base array).  Uses a simple 64-bit LCG.
+ */
+// -- GODOT start --
+int open_simplex_noise(int64_t seed, struct osn_context *ctx)
+{
+	int rc;
+	int16_t source[256];
+	int i;
+	int16_t *perm;
+	int16_t *permGradIndex3D;
+	int r;
+
+	perm = ctx->perm;
+	permGradIndex3D = ctx->permGradIndex3D;
+// -- GODOT end --
+
+	for (i = 0; i < 256; i++)
+		source[i] = (int16_t) i;
+	seed = seed * 6364136223846793005LL + 1442695040888963407LL;
+	seed = seed * 6364136223846793005LL + 1442695040888963407LL;
+	seed = seed * 6364136223846793005LL + 1442695040888963407LL;
+	for (i = 255; i >= 0; i--) {
+		seed = seed * 6364136223846793005LL + 1442695040888963407LL;
+		r = (int)((seed + 31) % (i + 1));
+		if (r < 0)
+			r += (i + 1);
+		perm[i] = source[r];
+		permGradIndex3D[i] = (short)((perm[i] % (ARRAYSIZE(gradients3D) / 3)) * 3);
+		source[r] = source[i];
+	}
+	return 0;
+}
+
+// -- GODOT start --
+/*
+void open_simplex_noise_free(struct osn_context *ctx)
+{
+	if (!ctx)
+		return;
+	if (ctx->perm) {
+		free(ctx->perm);
+		ctx->perm = NULL;	
+	}
+	if (ctx->permGradIndex3D) {
+		free(ctx->permGradIndex3D);
+		ctx->permGradIndex3D = NULL;
+	}
+	free(ctx);
+}
+*/
+// -- GODOT end --
+	
+/* 2D OpenSimplex (Simplectic) Noise. */
+double open_simplex_noise2(struct osn_context *ctx, double x, double y) 
+{
+	
+	/* Place input coordinates onto grid. */
+	double stretchOffset = (x + y) * STRETCH_CONSTANT_2D;
+	double xs = x + stretchOffset;
+	double ys = y + stretchOffset;
+		
+	/* Floor to get grid coordinates of rhombus (stretched square) super-cell origin. */
+	int xsb = fastFloor(xs);
+	int ysb = fastFloor(ys);
+		
+	/* Skew out to get actual coordinates of rhombus origin. We'll need these later. */
+	double squishOffset = (xsb + ysb) * SQUISH_CONSTANT_2D;
+	double xb = xsb + squishOffset;
+	double yb = ysb + squishOffset;
+		
+	/* Compute grid coordinates relative to rhombus origin. */
+	double xins = xs - xsb;
+	double yins = ys - ysb;
+		
+	/* Sum those together to get a value that determines which region we're in. */
+	double inSum = xins + yins;
+
+	/* Positions relative to origin point. */
+	double dx0 = x - xb;
+	double dy0 = y - yb;
+		
+	/* We'll be defining these inside the next block and using them afterwards. */
+	double dx_ext, dy_ext;
+	int xsv_ext, ysv_ext;
+
+	double dx1;
+	double dy1;
+	double attn1;
+	double dx2;
+	double dy2;
+	double attn2;
+	double zins;
+	double attn0;
+	double attn_ext;
+
+	double value = 0;
+
+	/* Contribution (1,0) */
+	dx1 = dx0 - 1 - SQUISH_CONSTANT_2D;
+	dy1 = dy0 - 0 - SQUISH_CONSTANT_2D;
+	attn1 = 2 - dx1 * dx1 - dy1 * dy1;
+	if (attn1 > 0) {
+		attn1 *= attn1;
+		value += attn1 * attn1 * extrapolate2(ctx, xsb + 1, ysb + 0, dx1, dy1);
+	}
+
+	/* Contribution (0,1) */
+	dx2 = dx0 - 0 - SQUISH_CONSTANT_2D;
+	dy2 = dy0 - 1 - SQUISH_CONSTANT_2D;
+	attn2 = 2 - dx2 * dx2 - dy2 * dy2;
+	if (attn2 > 0) {
+		attn2 *= attn2;
+		value += attn2 * attn2 * extrapolate2(ctx, xsb + 0, ysb + 1, dx2, dy2);
+	}
+		
+	if (inSum <= 1) { /* We're inside the triangle (2-Simplex) at (0,0) */
+		zins = 1 - inSum;
+		if (zins > xins || zins > yins) { /* (0,0) is one of the closest two triangular vertices */
+			if (xins > yins) {
+				xsv_ext = xsb + 1;
+				ysv_ext = ysb - 1;
+				dx_ext = dx0 - 1;
+				dy_ext = dy0 + 1;
+			} else {
+				xsv_ext = xsb - 1;
+				ysv_ext = ysb + 1;
+				dx_ext = dx0 + 1;
+				dy_ext = dy0 - 1;
+			}
+		} else { /* (1,0) and (0,1) are the closest two vertices. */
+			xsv_ext = xsb + 1;
+			ysv_ext = ysb + 1;
+			dx_ext = dx0 - 1 - 2 * SQUISH_CONSTANT_2D;
+			dy_ext = dy0 - 1 - 2 * SQUISH_CONSTANT_2D;
+		}
+	} else { /* We're inside the triangle (2-Simplex) at (1,1) */
+		zins = 2 - inSum;
+		if (zins < xins || zins < yins) { /* (0,0) is one of the closest two triangular vertices */
+			if (xins > yins) {
+				xsv_ext = xsb + 2;
+				ysv_ext = ysb + 0;
+				dx_ext = dx0 - 2 - 2 * SQUISH_CONSTANT_2D;
+				dy_ext = dy0 + 0 - 2 * SQUISH_CONSTANT_2D;
+			} else {
+				xsv_ext = xsb + 0;
+				ysv_ext = ysb + 2;
+				dx_ext = dx0 + 0 - 2 * SQUISH_CONSTANT_2D;
+				dy_ext = dy0 - 2 - 2 * SQUISH_CONSTANT_2D;
+			}
+		} else { /* (1,0) and (0,1) are the closest two vertices. */
+			dx_ext = dx0;
+			dy_ext = dy0;
+			xsv_ext = xsb;
+			ysv_ext = ysb;
+		}
+		xsb += 1;
+		ysb += 1;
+		dx0 = dx0 - 1 - 2 * SQUISH_CONSTANT_2D;
+		dy0 = dy0 - 1 - 2 * SQUISH_CONSTANT_2D;
+	}
+		
+	/* Contribution (0,0) or (1,1) */
+	attn0 = 2 - dx0 * dx0 - dy0 * dy0;
+	if (attn0 > 0) {
+		attn0 *= attn0;
+		value += attn0 * attn0 * extrapolate2(ctx, xsb, ysb, dx0, dy0);
+	}
+	
+	/* Extra Vertex */
+	attn_ext = 2 - dx_ext * dx_ext - dy_ext * dy_ext;
+	if (attn_ext > 0) {
+		attn_ext *= attn_ext;
+		value += attn_ext * attn_ext * extrapolate2(ctx, xsv_ext, ysv_ext, dx_ext, dy_ext);
+	}
+	
+	return value / NORM_CONSTANT_2D;
+}
+	
+/*
+ * 3D OpenSimplex (Simplectic) Noise
+ */
+double open_simplex_noise3(struct osn_context *ctx, double x, double y, double z)
+{
+
+	/* Place input coordinates on simplectic honeycomb. */
+	double stretchOffset = (x + y + z) * STRETCH_CONSTANT_3D;
+	double xs = x + stretchOffset;
+	double ys = y + stretchOffset;
+	double zs = z + stretchOffset;
+	
+	/* Floor to get simplectic honeycomb coordinates of rhombohedron (stretched cube) super-cell origin. */
+	int xsb = fastFloor(xs);
+	int ysb = fastFloor(ys);
+	int zsb = fastFloor(zs);
+	
+	/* Skew out to get actual coordinates of rhombohedron origin. We'll need these later. */
+	double squishOffset = (xsb + ysb + zsb) * SQUISH_CONSTANT_3D;
+	double xb = xsb + squishOffset;
+	double yb = ysb + squishOffset;
+	double zb = zsb + squishOffset;
+	
+	/* Compute simplectic honeycomb coordinates relative to rhombohedral origin. */
+	double xins = xs - xsb;
+	double yins = ys - ysb;
+	double zins = zs - zsb;
+	
+	/* Sum those together to get a value that determines which region we're in. */
+	double inSum = xins + yins + zins;
+
+	/* Positions relative to origin point. */
+	double dx0 = x - xb;
+	double dy0 = y - yb;
+	double dz0 = z - zb;
+	
+	/* We'll be defining these inside the next block and using them afterwards. */
+	double dx_ext0, dy_ext0, dz_ext0;
+	double dx_ext1, dy_ext1, dz_ext1;
+	int xsv_ext0, ysv_ext0, zsv_ext0;
+	int xsv_ext1, ysv_ext1, zsv_ext1;
+
+	double wins;
+	int8_t c, c1, c2;
+	int8_t aPoint, bPoint;
+	double aScore, bScore;
+	int aIsFurtherSide;
+	int bIsFurtherSide;
+	double p1, p2, p3;
+	double score;
+	double attn0, attn1, attn2, attn3, attn4, attn5, attn6;
+	double dx1, dy1, dz1;
+	double dx2, dy2, dz2;
+	double dx3, dy3, dz3;
+	double dx4, dy4, dz4;
+	double dx5, dy5, dz5;
+	double dx6, dy6, dz6;
+	double attn_ext0, attn_ext1;
+	
+	double value = 0;
+	if (inSum <= 1) { /* We're inside the tetrahedron (3-Simplex) at (0,0,0) */
+		
+		/* Determine which two of (0,0,1), (0,1,0), (1,0,0) are closest. */
+		aPoint = 0x01;
+		aScore = xins;
+		bPoint = 0x02;
+		bScore = yins;
+		if (aScore >= bScore && zins > bScore) {
+			bScore = zins;
+			bPoint = 0x04;
+		} else if (aScore < bScore && zins > aScore) {
+			aScore = zins;
+			aPoint = 0x04;
+		}
+		
+		/* Now we determine the two lattice points not part of the tetrahedron that may contribute.
+		   This depends on the closest two tetrahedral vertices, including (0,0,0) */
+		wins = 1 - inSum;
+		if (wins > aScore || wins > bScore) { /* (0,0,0) is one of the closest two tetrahedral vertices. */
+			c = (bScore > aScore ? bPoint : aPoint); /* Our other closest vertex is the closest out of a and b. */
+			
+			if ((c & 0x01) == 0) {
+				xsv_ext0 = xsb - 1;
+				xsv_ext1 = xsb;
+				dx_ext0 = dx0 + 1;
+				dx_ext1 = dx0;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsb + 1;
+				dx_ext0 = dx_ext1 = dx0 - 1;
+			}
+
+			if ((c & 0x02) == 0) {
+				ysv_ext0 = ysv_ext1 = ysb;
+				dy_ext0 = dy_ext1 = dy0;
+				if ((c & 0x01) == 0) {
+					ysv_ext1 -= 1;
+					dy_ext1 += 1;
+				} else {
+					ysv_ext0 -= 1;
+					dy_ext0 += 1;
+				}
+			} else {
+				ysv_ext0 = ysv_ext1 = ysb + 1;
+				dy_ext0 = dy_ext1 = dy0 - 1;
+			}
+
+			if ((c & 0x04) == 0) {
+				zsv_ext0 = zsb;
+				zsv_ext1 = zsb - 1;
+				dz_ext0 = dz0;
+				dz_ext1 = dz0 + 1;
+			} else {
+				zsv_ext0 = zsv_ext1 = zsb + 1;
+				dz_ext0 = dz_ext1 = dz0 - 1;
+			}
+		} else { /* (0,0,0) is not one of the closest two tetrahedral vertices. */
+			c = (int8_t)(aPoint | bPoint); /* Our two extra vertices are determined by the closest two. */
+			
+			if ((c & 0x01) == 0) {
+				xsv_ext0 = xsb;
+				xsv_ext1 = xsb - 1;
+				dx_ext0 = dx0 - 2 * SQUISH_CONSTANT_3D;
+				dx_ext1 = dx0 + 1 - SQUISH_CONSTANT_3D;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsb + 1;
+				dx_ext0 = dx0 - 1 - 2 * SQUISH_CONSTANT_3D;
+				dx_ext1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+			}
+
+			if ((c & 0x02) == 0) {
+				ysv_ext0 = ysb;
+				ysv_ext1 = ysb - 1;
+				dy_ext0 = dy0 - 2 * SQUISH_CONSTANT_3D;
+				dy_ext1 = dy0 + 1 - SQUISH_CONSTANT_3D;
+			} else {
+				ysv_ext0 = ysv_ext1 = ysb + 1;
+				dy_ext0 = dy0 - 1 - 2 * SQUISH_CONSTANT_3D;
+				dy_ext1 = dy0 - 1 - SQUISH_CONSTANT_3D;
+			}
+
+			if ((c & 0x04) == 0) {
+				zsv_ext0 = zsb;
+				zsv_ext1 = zsb - 1;
+				dz_ext0 = dz0 - 2 * SQUISH_CONSTANT_3D;
+				dz_ext1 = dz0 + 1 - SQUISH_CONSTANT_3D;
+			} else {
+				zsv_ext0 = zsv_ext1 = zsb + 1;
+				dz_ext0 = dz0 - 1 - 2 * SQUISH_CONSTANT_3D;
+				dz_ext1 = dz0 - 1 - SQUISH_CONSTANT_3D;
+			}
+		}
+
+		/* Contribution (0,0,0) */
+		attn0 = 2 - dx0 * dx0 - dy0 * dy0 - dz0 * dz0;
+		if (attn0 > 0) {
+			attn0 *= attn0;
+			value += attn0 * attn0 * extrapolate3(ctx, xsb + 0, ysb + 0, zsb + 0, dx0, dy0, dz0);
+		}
+
+		/* Contribution (1,0,0) */
+		dx1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+		dy1 = dy0 - 0 - SQUISH_CONSTANT_3D;
+		dz1 = dz0 - 0 - SQUISH_CONSTANT_3D;
+		attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1;
+		if (attn1 > 0) {
+			attn1 *= attn1;
+			value += attn1 * attn1 * extrapolate3(ctx, xsb + 1, ysb + 0, zsb + 0, dx1, dy1, dz1);
+		}
+
+		/* Contribution (0,1,0) */
+		dx2 = dx0 - 0 - SQUISH_CONSTANT_3D;
+		dy2 = dy0 - 1 - SQUISH_CONSTANT_3D;
+		dz2 = dz1;
+		attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2;
+		if (attn2 > 0) {
+			attn2 *= attn2;
+			value += attn2 * attn2 * extrapolate3(ctx, xsb + 0, ysb + 1, zsb + 0, dx2, dy2, dz2);
+		}
+
+		/* Contribution (0,0,1) */
+		dx3 = dx2;
+		dy3 = dy1;
+		dz3 = dz0 - 1 - SQUISH_CONSTANT_3D;
+		attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3;
+		if (attn3 > 0) {
+			attn3 *= attn3;
+			value += attn3 * attn3 * extrapolate3(ctx, xsb + 0, ysb + 0, zsb + 1, dx3, dy3, dz3);
+		}
+	} else if (inSum >= 2) { /* We're inside the tetrahedron (3-Simplex) at (1,1,1) */
+	
+		/* Determine which two tetrahedral vertices are the closest, out of (1,1,0), (1,0,1), (0,1,1) but not (1,1,1). */
+		aPoint = 0x06;
+		aScore = xins;
+		bPoint = 0x05;
+		bScore = yins;
+		if (aScore <= bScore && zins < bScore) {
+			bScore = zins;
+			bPoint = 0x03;
+		} else if (aScore > bScore && zins < aScore) {
+			aScore = zins;
+			aPoint = 0x03;
+		}
+		
+		/* Now we determine the two lattice points not part of the tetrahedron that may contribute.
+		   This depends on the closest two tetrahedral vertices, including (1,1,1) */
+		wins = 3 - inSum;
+		if (wins < aScore || wins < bScore) { /* (1,1,1) is one of the closest two tetrahedral vertices. */
+			c = (bScore < aScore ? bPoint : aPoint); /* Our other closest vertex is the closest out of a and b. */
+			
+			if ((c & 0x01) != 0) {
+				xsv_ext0 = xsb + 2;
+				xsv_ext1 = xsb + 1;
+				dx_ext0 = dx0 - 2 - 3 * SQUISH_CONSTANT_3D;
+				dx_ext1 = dx0 - 1 - 3 * SQUISH_CONSTANT_3D;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsb;
+				dx_ext0 = dx_ext1 = dx0 - 3 * SQUISH_CONSTANT_3D;
+			}
+
+			if ((c & 0x02) != 0) {
+				ysv_ext0 = ysv_ext1 = ysb + 1;
+				dy_ext0 = dy_ext1 = dy0 - 1 - 3 * SQUISH_CONSTANT_3D;
+				if ((c & 0x01) != 0) {
+					ysv_ext1 += 1;
+					dy_ext1 -= 1;
+				} else {
+					ysv_ext0 += 1;
+					dy_ext0 -= 1;
+				}
+			} else {
+				ysv_ext0 = ysv_ext1 = ysb;
+				dy_ext0 = dy_ext1 = dy0 - 3 * SQUISH_CONSTANT_3D;
+			}
+
+			if ((c & 0x04) != 0) {
+				zsv_ext0 = zsb + 1;
+				zsv_ext1 = zsb + 2;
+				dz_ext0 = dz0 - 1 - 3 * SQUISH_CONSTANT_3D;
+				dz_ext1 = dz0 - 2 - 3 * SQUISH_CONSTANT_3D;
+			} else {
+				zsv_ext0 = zsv_ext1 = zsb;
+				dz_ext0 = dz_ext1 = dz0 - 3 * SQUISH_CONSTANT_3D;
+			}
+		} else { /* (1,1,1) is not one of the closest two tetrahedral vertices. */
+			c = (int8_t)(aPoint & bPoint); /* Our two extra vertices are determined by the closest two. */
+			
+			if ((c & 0x01) != 0) {
+				xsv_ext0 = xsb + 1;
+				xsv_ext1 = xsb + 2;
+				dx_ext0 = dx0 - 1 - SQUISH_CONSTANT_3D;
+				dx_ext1 = dx0 - 2 - 2 * SQUISH_CONSTANT_3D;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsb;
+				dx_ext0 = dx0 - SQUISH_CONSTANT_3D;
+				dx_ext1 = dx0 - 2 * SQUISH_CONSTANT_3D;
+			}
+
+			if ((c & 0x02) != 0) {
+				ysv_ext0 = ysb + 1;
+				ysv_ext1 = ysb + 2;
+				dy_ext0 = dy0 - 1 - SQUISH_CONSTANT_3D;
+				dy_ext1 = dy0 - 2 - 2 * SQUISH_CONSTANT_3D;
+			} else {
+				ysv_ext0 = ysv_ext1 = ysb;
+				dy_ext0 = dy0 - SQUISH_CONSTANT_3D;
+				dy_ext1 = dy0 - 2 * SQUISH_CONSTANT_3D;
+			}
+
+			if ((c & 0x04) != 0) {
+				zsv_ext0 = zsb + 1;
+				zsv_ext1 = zsb + 2;
+				dz_ext0 = dz0 - 1 - SQUISH_CONSTANT_3D;
+				dz_ext1 = dz0 - 2 - 2 * SQUISH_CONSTANT_3D;
+			} else {
+				zsv_ext0 = zsv_ext1 = zsb;
+				dz_ext0 = dz0 - SQUISH_CONSTANT_3D;
+				dz_ext1 = dz0 - 2 * SQUISH_CONSTANT_3D;
+			}
+		}
+		
+		/* Contribution (1,1,0) */
+		dx3 = dx0 - 1 - 2 * SQUISH_CONSTANT_3D;
+		dy3 = dy0 - 1 - 2 * SQUISH_CONSTANT_3D;
+		dz3 = dz0 - 0 - 2 * SQUISH_CONSTANT_3D;
+		attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3;
+		if (attn3 > 0) {
+			attn3 *= attn3;
+			value += attn3 * attn3 * extrapolate3(ctx, xsb + 1, ysb + 1, zsb + 0, dx3, dy3, dz3);
+		}
+
+		/* Contribution (1,0,1) */
+		dx2 = dx3;
+		dy2 = dy0 - 0 - 2 * SQUISH_CONSTANT_3D;
+		dz2 = dz0 - 1 - 2 * SQUISH_CONSTANT_3D;
+		attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2;
+		if (attn2 > 0) {
+			attn2 *= attn2;
+			value += attn2 * attn2 * extrapolate3(ctx, xsb + 1, ysb + 0, zsb + 1, dx2, dy2, dz2);
+		}
+
+		/* Contribution (0,1,1) */
+		dx1 = dx0 - 0 - 2 * SQUISH_CONSTANT_3D;
+		dy1 = dy3;
+		dz1 = dz2;
+		attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1;
+		if (attn1 > 0) {
+			attn1 *= attn1;
+			value += attn1 * attn1 * extrapolate3(ctx, xsb + 0, ysb + 1, zsb + 1, dx1, dy1, dz1);
+		}
+
+		/* Contribution (1,1,1) */
+		dx0 = dx0 - 1 - 3 * SQUISH_CONSTANT_3D;
+		dy0 = dy0 - 1 - 3 * SQUISH_CONSTANT_3D;
+		dz0 = dz0 - 1 - 3 * SQUISH_CONSTANT_3D;
+		attn0 = 2 - dx0 * dx0 - dy0 * dy0 - dz0 * dz0;
+		if (attn0 > 0) {
+			attn0 *= attn0;
+			value += attn0 * attn0 * extrapolate3(ctx, xsb + 1, ysb + 1, zsb + 1, dx0, dy0, dz0);
+		}
+	} else { /* We're inside the octahedron (Rectified 3-Simplex) in between.
+		        Decide between point (0,0,1) and (1,1,0) as closest */
+		p1 = xins + yins;
+		if (p1 > 1) {
+			aScore = p1 - 1;
+			aPoint = 0x03;
+			aIsFurtherSide = 1;
+		} else {
+			aScore = 1 - p1;
+			aPoint = 0x04;
+			aIsFurtherSide = 0;
+		}
+
+		/* Decide between point (0,1,0) and (1,0,1) as closest */
+		p2 = xins + zins;
+		if (p2 > 1) {
+			bScore = p2 - 1;
+			bPoint = 0x05;
+			bIsFurtherSide = 1;
+		} else {
+			bScore = 1 - p2;
+			bPoint = 0x02;
+			bIsFurtherSide = 0;
+		}
+		
+		/* The closest out of the two (1,0,0) and (0,1,1) will replace the furthest out of the two decided above, if closer. */
+		p3 = yins + zins;
+		if (p3 > 1) {
+			score = p3 - 1;
+			if (aScore <= bScore && aScore < score) {
+				aScore = score;
+				aPoint = 0x06;
+				aIsFurtherSide = 1;
+			} else if (aScore > bScore && bScore < score) {
+				bScore = score;
+				bPoint = 0x06;
+				bIsFurtherSide = 1;
+			}
+		} else {
+			score = 1 - p3;
+			if (aScore <= bScore && aScore < score) {
+				aScore = score;
+				aPoint = 0x01;
+				aIsFurtherSide = 0;
+			} else if (aScore > bScore && bScore < score) {
+				bScore = score;
+				bPoint = 0x01;
+				bIsFurtherSide = 0;
+			}
+		}
+		
+		/* Where each of the two closest points are determines how the extra two vertices are calculated. */
+		if (aIsFurtherSide == bIsFurtherSide) {
+			if (aIsFurtherSide) { /* Both closest points on (1,1,1) side */
+
+				/* One of the two extra points is (1,1,1) */
+				dx_ext0 = dx0 - 1 - 3 * SQUISH_CONSTANT_3D;
+				dy_ext0 = dy0 - 1 - 3 * SQUISH_CONSTANT_3D;
+				dz_ext0 = dz0 - 1 - 3 * SQUISH_CONSTANT_3D;
+				xsv_ext0 = xsb + 1;
+				ysv_ext0 = ysb + 1;
+				zsv_ext0 = zsb + 1;
+
+				/* Other extra point is based on the shared axis. */
+				c = (int8_t)(aPoint & bPoint);
+				if ((c & 0x01) != 0) {
+					dx_ext1 = dx0 - 2 - 2 * SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 - 2 * SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 - 2 * SQUISH_CONSTANT_3D;
+					xsv_ext1 = xsb + 2;
+					ysv_ext1 = ysb;
+					zsv_ext1 = zsb;
+				} else if ((c & 0x02) != 0) {
+					dx_ext1 = dx0 - 2 * SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 - 2 - 2 * SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 - 2 * SQUISH_CONSTANT_3D;
+					xsv_ext1 = xsb;
+					ysv_ext1 = ysb + 2;
+					zsv_ext1 = zsb;
+				} else {
+					dx_ext1 = dx0 - 2 * SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 - 2 * SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 - 2 - 2 * SQUISH_CONSTANT_3D;
+					xsv_ext1 = xsb;
+					ysv_ext1 = ysb;
+					zsv_ext1 = zsb + 2;
+				}
+			} else { /* Both closest points on (0,0,0) side */
+
+				/* One of the two extra points is (0,0,0) */
+				dx_ext0 = dx0;
+				dy_ext0 = dy0;
+				dz_ext0 = dz0;
+				xsv_ext0 = xsb;
+				ysv_ext0 = ysb;
+				zsv_ext0 = zsb;
+
+				/* Other extra point is based on the omitted axis. */
+				c = (int8_t)(aPoint | bPoint);
+				if ((c & 0x01) == 0) {
+					dx_ext1 = dx0 + 1 - SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 - 1 - SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 - 1 - SQUISH_CONSTANT_3D;
+					xsv_ext1 = xsb - 1;
+					ysv_ext1 = ysb + 1;
+					zsv_ext1 = zsb + 1;
+				} else if ((c & 0x02) == 0) {
+					dx_ext1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 + 1 - SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 - 1 - SQUISH_CONSTANT_3D;
+					xsv_ext1 = xsb + 1;
+					ysv_ext1 = ysb - 1;
+					zsv_ext1 = zsb + 1;
+				} else {
+					dx_ext1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 - 1 - SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 + 1 - SQUISH_CONSTANT_3D;
+					xsv_ext1 = xsb + 1;
+					ysv_ext1 = ysb + 1;
+					zsv_ext1 = zsb - 1;
+				}
+			}
+		} else { /* One point on (0,0,0) side, one point on (1,1,1) side */
+			if (aIsFurtherSide) {
+				c1 = aPoint;
+				c2 = bPoint;
+			} else {
+				c1 = bPoint;
+				c2 = aPoint;
+			}
+
+			/* One contribution is a permutation of (1,1,-1) */
+			if ((c1 & 0x01) == 0) {
+				dx_ext0 = dx0 + 1 - SQUISH_CONSTANT_3D;
+				dy_ext0 = dy0 - 1 - SQUISH_CONSTANT_3D;
+				dz_ext0 = dz0 - 1 - SQUISH_CONSTANT_3D;
+				xsv_ext0 = xsb - 1;
+				ysv_ext0 = ysb + 1;
+				zsv_ext0 = zsb + 1;
+			} else if ((c1 & 0x02) == 0) {
+				dx_ext0 = dx0 - 1 - SQUISH_CONSTANT_3D;
+				dy_ext0 = dy0 + 1 - SQUISH_CONSTANT_3D;
+				dz_ext0 = dz0 - 1 - SQUISH_CONSTANT_3D;
+				xsv_ext0 = xsb + 1;
+				ysv_ext0 = ysb - 1;
+				zsv_ext0 = zsb + 1;
+			} else {
+				dx_ext0 = dx0 - 1 - SQUISH_CONSTANT_3D;
+				dy_ext0 = dy0 - 1 - SQUISH_CONSTANT_3D;
+				dz_ext0 = dz0 + 1 - SQUISH_CONSTANT_3D;
+				xsv_ext0 = xsb + 1;
+				ysv_ext0 = ysb + 1;
+				zsv_ext0 = zsb - 1;
+			}
+
+			/* One contribution is a permutation of (0,0,2) */
+			dx_ext1 = dx0 - 2 * SQUISH_CONSTANT_3D;
+			dy_ext1 = dy0 - 2 * SQUISH_CONSTANT_3D;
+			dz_ext1 = dz0 - 2 * SQUISH_CONSTANT_3D;
+			xsv_ext1 = xsb;
+			ysv_ext1 = ysb;
+			zsv_ext1 = zsb;
+			if ((c2 & 0x01) != 0) {
+				dx_ext1 -= 2;
+				xsv_ext1 += 2;
+			} else if ((c2 & 0x02) != 0) {
+				dy_ext1 -= 2;
+				ysv_ext1 += 2;
+			} else {
+				dz_ext1 -= 2;
+				zsv_ext1 += 2;
+			}
+		}
+
+		/* Contribution (1,0,0) */
+		dx1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+		dy1 = dy0 - 0 - SQUISH_CONSTANT_3D;
+		dz1 = dz0 - 0 - SQUISH_CONSTANT_3D;
+		attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1;
+		if (attn1 > 0) {
+			attn1 *= attn1;
+			value += attn1 * attn1 * extrapolate3(ctx, xsb + 1, ysb + 0, zsb + 0, dx1, dy1, dz1);
+		}
+
+		/* Contribution (0,1,0) */
+		dx2 = dx0 - 0 - SQUISH_CONSTANT_3D;
+		dy2 = dy0 - 1 - SQUISH_CONSTANT_3D;
+		dz2 = dz1;
+		attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2;
+		if (attn2 > 0) {
+			attn2 *= attn2;
+			value += attn2 * attn2 * extrapolate3(ctx, xsb + 0, ysb + 1, zsb + 0, dx2, dy2, dz2);
+		}
+
+		/* Contribution (0,0,1) */
+		dx3 = dx2;
+		dy3 = dy1;
+		dz3 = dz0 - 1 - SQUISH_CONSTANT_3D;
+		attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3;
+		if (attn3 > 0) {
+			attn3 *= attn3;
+			value += attn3 * attn3 * extrapolate3(ctx, xsb + 0, ysb + 0, zsb + 1, dx3, dy3, dz3);
+		}
+
+		/* Contribution (1,1,0) */
+		dx4 = dx0 - 1 - 2 * SQUISH_CONSTANT_3D;
+		dy4 = dy0 - 1 - 2 * SQUISH_CONSTANT_3D;
+		dz4 = dz0 - 0 - 2 * SQUISH_CONSTANT_3D;
+		attn4 = 2 - dx4 * dx4 - dy4 * dy4 - dz4 * dz4;
+		if (attn4 > 0) {
+			attn4 *= attn4;
+			value += attn4 * attn4 * extrapolate3(ctx, xsb + 1, ysb + 1, zsb + 0, dx4, dy4, dz4);
+		}
+
+		/* Contribution (1,0,1) */
+		dx5 = dx4;
+		dy5 = dy0 - 0 - 2 * SQUISH_CONSTANT_3D;
+		dz5 = dz0 - 1 - 2 * SQUISH_CONSTANT_3D;
+		attn5 = 2 - dx5 * dx5 - dy5 * dy5 - dz5 * dz5;
+		if (attn5 > 0) {
+			attn5 *= attn5;
+			value += attn5 * attn5 * extrapolate3(ctx, xsb + 1, ysb + 0, zsb + 1, dx5, dy5, dz5);
+		}
+
+		/* Contribution (0,1,1) */
+		dx6 = dx0 - 0 - 2 * SQUISH_CONSTANT_3D;
+		dy6 = dy4;
+		dz6 = dz5;
+		attn6 = 2 - dx6 * dx6 - dy6 * dy6 - dz6 * dz6;
+		if (attn6 > 0) {
+			attn6 *= attn6;
+			value += attn6 * attn6 * extrapolate3(ctx, xsb + 0, ysb + 1, zsb + 1, dx6, dy6, dz6);
+		}
+	}
+
+	/* First extra vertex */
+	attn_ext0 = 2 - dx_ext0 * dx_ext0 - dy_ext0 * dy_ext0 - dz_ext0 * dz_ext0;
+	if (attn_ext0 > 0)
+	{
+		attn_ext0 *= attn_ext0;
+		value += attn_ext0 * attn_ext0 * extrapolate3(ctx, xsv_ext0, ysv_ext0, zsv_ext0, dx_ext0, dy_ext0, dz_ext0);
+	}
+
+	/* Second extra vertex */
+	attn_ext1 = 2 - dx_ext1 * dx_ext1 - dy_ext1 * dy_ext1 - dz_ext1 * dz_ext1;
+	if (attn_ext1 > 0)
+	{
+		attn_ext1 *= attn_ext1;
+		value += attn_ext1 * attn_ext1 * extrapolate3(ctx, xsv_ext1, ysv_ext1, zsv_ext1, dx_ext1, dy_ext1, dz_ext1);
+	}
+	
+	return value / NORM_CONSTANT_3D;
+}
+	
+/* 
+ * 4D OpenSimplex (Simplectic) Noise.
+ */
+double open_simplex_noise4(struct osn_context *ctx, double x, double y, double z, double w)
+{
+	double uins;
+	double dx1, dy1, dz1, dw1;
+	double dx2, dy2, dz2, dw2;
+	double dx3, dy3, dz3, dw3;
+	double dx4, dy4, dz4, dw4;
+	double dx5, dy5, dz5, dw5;
+	double dx6, dy6, dz6, dw6;
+	double dx7, dy7, dz7, dw7;
+	double dx8, dy8, dz8, dw8;
+	double dx9, dy9, dz9, dw9;
+	double dx10, dy10, dz10, dw10;
+	double attn0, attn1, attn2, attn3, attn4;
+	double attn5, attn6, attn7, attn8, attn9, attn10;
+	double attn_ext0, attn_ext1, attn_ext2;
+	int8_t c, c1, c2;
+	int8_t aPoint, bPoint;
+	double aScore, bScore;
+	int aIsBiggerSide;
+	int bIsBiggerSide;
+	double p1, p2, p3, p4;
+	double score;
+
+	/* Place input coordinates on simplectic honeycomb. */
+	double stretchOffset = (x + y + z + w) * STRETCH_CONSTANT_4D;
+	double xs = x + stretchOffset;
+	double ys = y + stretchOffset;
+	double zs = z + stretchOffset;
+	double ws = w + stretchOffset;
+	
+	/* Floor to get simplectic honeycomb coordinates of rhombo-hypercube super-cell origin. */
+	int xsb = fastFloor(xs);
+	int ysb = fastFloor(ys);
+	int zsb = fastFloor(zs);
+	int wsb = fastFloor(ws);
+	
+	/* Skew out to get actual coordinates of stretched rhombo-hypercube origin. We'll need these later. */
+	double squishOffset = (xsb + ysb + zsb + wsb) * SQUISH_CONSTANT_4D;
+	double xb = xsb + squishOffset;
+	double yb = ysb + squishOffset;
+	double zb = zsb + squishOffset;
+	double wb = wsb + squishOffset;
+	
+	/* Compute simplectic honeycomb coordinates relative to rhombo-hypercube origin. */
+	double xins = xs - xsb;
+	double yins = ys - ysb;
+	double zins = zs - zsb;
+	double wins = ws - wsb;
+	
+	/* Sum those together to get a value that determines which region we're in. */
+	double inSum = xins + yins + zins + wins;
+
+	/* Positions relative to origin point. */
+	double dx0 = x - xb;
+	double dy0 = y - yb;
+	double dz0 = z - zb;
+	double dw0 = w - wb;
+	
+	/* We'll be defining these inside the next block and using them afterwards. */
+	double dx_ext0, dy_ext0, dz_ext0, dw_ext0;
+	double dx_ext1, dy_ext1, dz_ext1, dw_ext1;
+	double dx_ext2, dy_ext2, dz_ext2, dw_ext2;
+	int xsv_ext0, ysv_ext0, zsv_ext0, wsv_ext0;
+	int xsv_ext1, ysv_ext1, zsv_ext1, wsv_ext1;
+	int xsv_ext2, ysv_ext2, zsv_ext2, wsv_ext2;
+	
+	double value = 0;
+	if (inSum <= 1) { /* We're inside the pentachoron (4-Simplex) at (0,0,0,0) */
+
+		/* Determine which two of (0,0,0,1), (0,0,1,0), (0,1,0,0), (1,0,0,0) are closest. */
+		aPoint = 0x01;
+		aScore = xins;
+		bPoint = 0x02;
+		bScore = yins;
+		if (aScore >= bScore && zins > bScore) {
+			bScore = zins;
+			bPoint = 0x04;
+		} else if (aScore < bScore && zins > aScore) {
+			aScore = zins;
+			aPoint = 0x04;
+		}
+		if (aScore >= bScore && wins > bScore) {
+			bScore = wins;
+			bPoint = 0x08;
+		} else if (aScore < bScore && wins > aScore) {
+			aScore = wins;
+			aPoint = 0x08;
+		}
+		
+		/* Now we determine the three lattice points not part of the pentachoron that may contribute.
+		   This depends on the closest two pentachoron vertices, including (0,0,0,0) */
+		uins = 1 - inSum;
+		if (uins > aScore || uins > bScore) { /* (0,0,0,0) is one of the closest two pentachoron vertices. */
+			c = (bScore > aScore ? bPoint : aPoint); /* Our other closest vertex is the closest out of a and b. */
+			if ((c & 0x01) == 0) {
+				xsv_ext0 = xsb - 1;
+				xsv_ext1 = xsv_ext2 = xsb;
+				dx_ext0 = dx0 + 1;
+				dx_ext1 = dx_ext2 = dx0;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsv_ext2 = xsb + 1;
+				dx_ext0 = dx_ext1 = dx_ext2 = dx0 - 1;
+			}
+
+			if ((c & 0x02) == 0) {
+				ysv_ext0 = ysv_ext1 = ysv_ext2 = ysb;
+				dy_ext0 = dy_ext1 = dy_ext2 = dy0;
+				if ((c & 0x01) == 0x01) {
+					ysv_ext0 -= 1;
+					dy_ext0 += 1;
+				} else {
+					ysv_ext1 -= 1;
+					dy_ext1 += 1;
+				}
+			} else {
+				ysv_ext0 = ysv_ext1 = ysv_ext2 = ysb + 1;
+				dy_ext0 = dy_ext1 = dy_ext2 = dy0 - 1;
+			}
+			
+			if ((c & 0x04) == 0) {
+				zsv_ext0 = zsv_ext1 = zsv_ext2 = zsb;
+				dz_ext0 = dz_ext1 = dz_ext2 = dz0;
+				if ((c & 0x03) != 0) {
+					if ((c & 0x03) == 0x03) {
+						zsv_ext0 -= 1;
+						dz_ext0 += 1;
+					} else {
+						zsv_ext1 -= 1;
+						dz_ext1 += 1;
+					}
+				} else {
+					zsv_ext2 -= 1;
+					dz_ext2 += 1;
+				}
+			} else {
+				zsv_ext0 = zsv_ext1 = zsv_ext2 = zsb + 1;
+				dz_ext0 = dz_ext1 = dz_ext2 = dz0 - 1;
+			}
+			
+			if ((c & 0x08) == 0) {
+				wsv_ext0 = wsv_ext1 = wsb;
+				wsv_ext2 = wsb - 1;
+				dw_ext0 = dw_ext1 = dw0;
+				dw_ext2 = dw0 + 1;
+			} else {
+				wsv_ext0 = wsv_ext1 = wsv_ext2 = wsb + 1;
+				dw_ext0 = dw_ext1 = dw_ext2 = dw0 - 1;
+			}
+		} else { /* (0,0,0,0) is not one of the closest two pentachoron vertices. */
+			c = (int8_t)(aPoint | bPoint); /* Our three extra vertices are determined by the closest two. */
+			
+			if ((c & 0x01) == 0) {
+				xsv_ext0 = xsv_ext2 = xsb;
+				xsv_ext1 = xsb - 1;
+				dx_ext0 = dx0 - 2 * SQUISH_CONSTANT_4D;
+				dx_ext1 = dx0 + 1 - SQUISH_CONSTANT_4D;
+				dx_ext2 = dx0 - SQUISH_CONSTANT_4D;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsv_ext2 = xsb + 1;
+				dx_ext0 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dx_ext1 = dx_ext2 = dx0 - 1 - SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c & 0x02) == 0) {
+				ysv_ext0 = ysv_ext1 = ysv_ext2 = ysb;
+				dy_ext0 = dy0 - 2 * SQUISH_CONSTANT_4D;
+				dy_ext1 = dy_ext2 = dy0 - SQUISH_CONSTANT_4D;
+				if ((c & 0x01) == 0x01) {
+					ysv_ext1 -= 1;
+					dy_ext1 += 1;
+				} else {
+					ysv_ext2 -= 1;
+					dy_ext2 += 1;
+				}
+			} else {
+				ysv_ext0 = ysv_ext1 = ysv_ext2 = ysb + 1;
+				dy_ext0 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dy_ext1 = dy_ext2 = dy0 - 1 - SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c & 0x04) == 0) {
+				zsv_ext0 = zsv_ext1 = zsv_ext2 = zsb;
+				dz_ext0 = dz0 - 2 * SQUISH_CONSTANT_4D;
+				dz_ext1 = dz_ext2 = dz0 - SQUISH_CONSTANT_4D;
+				if ((c & 0x03) == 0x03) {
+					zsv_ext1 -= 1;
+					dz_ext1 += 1;
+				} else {
+					zsv_ext2 -= 1;
+					dz_ext2 += 1;
+				}
+			} else {
+				zsv_ext0 = zsv_ext1 = zsv_ext2 = zsb + 1;
+				dz_ext0 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dz_ext1 = dz_ext2 = dz0 - 1 - SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c & 0x08) == 0) {
+				wsv_ext0 = wsv_ext1 = wsb;
+				wsv_ext2 = wsb - 1;
+				dw_ext0 = dw0 - 2 * SQUISH_CONSTANT_4D;
+				dw_ext1 = dw0 - SQUISH_CONSTANT_4D;
+				dw_ext2 = dw0 + 1 - SQUISH_CONSTANT_4D;
+			} else {
+				wsv_ext0 = wsv_ext1 = wsv_ext2 = wsb + 1;
+				dw_ext0 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dw_ext1 = dw_ext2 = dw0 - 1 - SQUISH_CONSTANT_4D;
+			}
+		}
+
+		/* Contribution (0,0,0,0) */
+		attn0 = 2 - dx0 * dx0 - dy0 * dy0 - dz0 * dz0 - dw0 * dw0;
+		if (attn0 > 0) {
+			attn0 *= attn0;
+			value += attn0 * attn0 * extrapolate4(ctx, xsb + 0, ysb + 0, zsb + 0, wsb + 0, dx0, dy0, dz0, dw0);
+		}
+
+		/* Contribution (1,0,0,0) */
+		dx1 = dx0 - 1 - SQUISH_CONSTANT_4D;
+		dy1 = dy0 - 0 - SQUISH_CONSTANT_4D;
+		dz1 = dz0 - 0 - SQUISH_CONSTANT_4D;
+		dw1 = dw0 - 0 - SQUISH_CONSTANT_4D;
+		attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1 - dw1 * dw1;
+		if (attn1 > 0) {
+			attn1 *= attn1;
+			value += attn1 * attn1 * extrapolate4(ctx, xsb + 1, ysb + 0, zsb + 0, wsb + 0, dx1, dy1, dz1, dw1);
+		}
+
+		/* Contribution (0,1,0,0) */
+		dx2 = dx0 - 0 - SQUISH_CONSTANT_4D;
+		dy2 = dy0 - 1 - SQUISH_CONSTANT_4D;
+		dz2 = dz1;
+		dw2 = dw1;
+		attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2 - dw2 * dw2;
+		if (attn2 > 0) {
+			attn2 *= attn2;
+			value += attn2 * attn2 * extrapolate4(ctx, xsb + 0, ysb + 1, zsb + 0, wsb + 0, dx2, dy2, dz2, dw2);
+		}
+
+		/* Contribution (0,0,1,0) */
+		dx3 = dx2;
+		dy3 = dy1;
+		dz3 = dz0 - 1 - SQUISH_CONSTANT_4D;
+		dw3 = dw1;
+		attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3 - dw3 * dw3;
+		if (attn3 > 0) {
+			attn3 *= attn3;
+			value += attn3 * attn3 * extrapolate4(ctx, xsb + 0, ysb + 0, zsb + 1, wsb + 0, dx3, dy3, dz3, dw3);
+		}
+
+		/* Contribution (0,0,0,1) */
+		dx4 = dx2;
+		dy4 = dy1;
+		dz4 = dz1;
+		dw4 = dw0 - 1 - SQUISH_CONSTANT_4D;
+		attn4 = 2 - dx4 * dx4 - dy4 * dy4 - dz4 * dz4 - dw4 * dw4;
+		if (attn4 > 0) {
+			attn4 *= attn4;
+			value += attn4 * attn4 * extrapolate4(ctx, xsb + 0, ysb + 0, zsb + 0, wsb + 1, dx4, dy4, dz4, dw4);
+		}
+	} else if (inSum >= 3) { /* We're inside the pentachoron (4-Simplex) at (1,1,1,1)
+		Determine which two of (1,1,1,0), (1,1,0,1), (1,0,1,1), (0,1,1,1) are closest. */
+		aPoint = 0x0E;
+		aScore = xins;
+		bPoint = 0x0D;
+		bScore = yins;
+		if (aScore <= bScore && zins < bScore) {
+			bScore = zins;
+			bPoint = 0x0B;
+		} else if (aScore > bScore && zins < aScore) {
+			aScore = zins;
+			aPoint = 0x0B;
+		}
+		if (aScore <= bScore && wins < bScore) {
+			bScore = wins;
+			bPoint = 0x07;
+		} else if (aScore > bScore && wins < aScore) {
+			aScore = wins;
+			aPoint = 0x07;
+		}
+		
+		/* Now we determine the three lattice points not part of the pentachoron that may contribute.
+		   This depends on the closest two pentachoron vertices, including (0,0,0,0) */
+		uins = 4 - inSum;
+		if (uins < aScore || uins < bScore) { /* (1,1,1,1) is one of the closest two pentachoron vertices. */
+			c = (bScore < aScore ? bPoint : aPoint); /* Our other closest vertex is the closest out of a and b. */
+			
+			if ((c & 0x01) != 0) {
+				xsv_ext0 = xsb + 2;
+				xsv_ext1 = xsv_ext2 = xsb + 1;
+				dx_ext0 = dx0 - 2 - 4 * SQUISH_CONSTANT_4D;
+				dx_ext1 = dx_ext2 = dx0 - 1 - 4 * SQUISH_CONSTANT_4D;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsv_ext2 = xsb;
+				dx_ext0 = dx_ext1 = dx_ext2 = dx0 - 4 * SQUISH_CONSTANT_4D;
+			}
+
+			if ((c & 0x02) != 0) {
+				ysv_ext0 = ysv_ext1 = ysv_ext2 = ysb + 1;
+				dy_ext0 = dy_ext1 = dy_ext2 = dy0 - 1 - 4 * SQUISH_CONSTANT_4D;
+				if ((c & 0x01) != 0) {
+					ysv_ext1 += 1;
+					dy_ext1 -= 1;
+				} else {
+					ysv_ext0 += 1;
+					dy_ext0 -= 1;
+				}
+			} else {
+				ysv_ext0 = ysv_ext1 = ysv_ext2 = ysb;
+				dy_ext0 = dy_ext1 = dy_ext2 = dy0 - 4 * SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c & 0x04) != 0) {
+				zsv_ext0 = zsv_ext1 = zsv_ext2 = zsb + 1;
+				dz_ext0 = dz_ext1 = dz_ext2 = dz0 - 1 - 4 * SQUISH_CONSTANT_4D;
+				if ((c & 0x03) != 0x03) {
+					if ((c & 0x03) == 0) {
+						zsv_ext0 += 1;
+						dz_ext0 -= 1;
+					} else {
+						zsv_ext1 += 1;
+						dz_ext1 -= 1;
+					}
+				} else {
+					zsv_ext2 += 1;
+					dz_ext2 -= 1;
+				}
+			} else {
+				zsv_ext0 = zsv_ext1 = zsv_ext2 = zsb;
+				dz_ext0 = dz_ext1 = dz_ext2 = dz0 - 4 * SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c & 0x08) != 0) {
+				wsv_ext0 = wsv_ext1 = wsb + 1;
+				wsv_ext2 = wsb + 2;
+				dw_ext0 = dw_ext1 = dw0 - 1 - 4 * SQUISH_CONSTANT_4D;
+				dw_ext2 = dw0 - 2 - 4 * SQUISH_CONSTANT_4D;
+			} else {
+				wsv_ext0 = wsv_ext1 = wsv_ext2 = wsb;
+				dw_ext0 = dw_ext1 = dw_ext2 = dw0 - 4 * SQUISH_CONSTANT_4D;
+			}
+		} else { /* (1,1,1,1) is not one of the closest two pentachoron vertices. */
+			c = (int8_t)(aPoint & bPoint); /* Our three extra vertices are determined by the closest two. */
+			
+			if ((c & 0x01) != 0) {
+				xsv_ext0 = xsv_ext2 = xsb + 1;
+				xsv_ext1 = xsb + 2;
+				dx_ext0 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dx_ext1 = dx0 - 2 - 3 * SQUISH_CONSTANT_4D;
+				dx_ext2 = dx0 - 1 - 3 * SQUISH_CONSTANT_4D;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsv_ext2 = xsb;
+				dx_ext0 = dx0 - 2 * SQUISH_CONSTANT_4D;
+				dx_ext1 = dx_ext2 = dx0 - 3 * SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c & 0x02) != 0) {
+				ysv_ext0 = ysv_ext1 = ysv_ext2 = ysb + 1;
+				dy_ext0 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dy_ext1 = dy_ext2 = dy0 - 1 - 3 * SQUISH_CONSTANT_4D;
+				if ((c & 0x01) != 0) {
+					ysv_ext2 += 1;
+					dy_ext2 -= 1;
+				} else {
+					ysv_ext1 += 1;
+					dy_ext1 -= 1;
+				}
+			} else {
+				ysv_ext0 = ysv_ext1 = ysv_ext2 = ysb;
+				dy_ext0 = dy0 - 2 * SQUISH_CONSTANT_4D;
+				dy_ext1 = dy_ext2 = dy0 - 3 * SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c & 0x04) != 0) {
+				zsv_ext0 = zsv_ext1 = zsv_ext2 = zsb + 1;
+				dz_ext0 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dz_ext1 = dz_ext2 = dz0 - 1 - 3 * SQUISH_CONSTANT_4D;
+				if ((c & 0x03) != 0) {
+					zsv_ext2 += 1;
+					dz_ext2 -= 1;
+				} else {
+					zsv_ext1 += 1;
+					dz_ext1 -= 1;
+				}
+			} else {
+				zsv_ext0 = zsv_ext1 = zsv_ext2 = zsb;
+				dz_ext0 = dz0 - 2 * SQUISH_CONSTANT_4D;
+				dz_ext1 = dz_ext2 = dz0 - 3 * SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c & 0x08) != 0) {
+				wsv_ext0 = wsv_ext1 = wsb + 1;
+				wsv_ext2 = wsb + 2;
+				dw_ext0 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dw_ext1 = dw0 - 1 - 3 * SQUISH_CONSTANT_4D;
+				dw_ext2 = dw0 - 2 - 3 * SQUISH_CONSTANT_4D;
+			} else {
+				wsv_ext0 = wsv_ext1 = wsv_ext2 = wsb;
+				dw_ext0 = dw0 - 2 * SQUISH_CONSTANT_4D;
+				dw_ext1 = dw_ext2 = dw0 - 3 * SQUISH_CONSTANT_4D;
+			}
+		}
+
+		/* Contribution (1,1,1,0) */
+		dx4 = dx0 - 1 - 3 * SQUISH_CONSTANT_4D;
+		dy4 = dy0 - 1 - 3 * SQUISH_CONSTANT_4D;
+		dz4 = dz0 - 1 - 3 * SQUISH_CONSTANT_4D;
+		dw4 = dw0 - 3 * SQUISH_CONSTANT_4D;
+		attn4 = 2 - dx4 * dx4 - dy4 * dy4 - dz4 * dz4 - dw4 * dw4;
+		if (attn4 > 0) {
+			attn4 *= attn4;
+			value += attn4 * attn4 * extrapolate4(ctx, xsb + 1, ysb + 1, zsb + 1, wsb + 0, dx4, dy4, dz4, dw4);
+		}
+
+		/* Contribution (1,1,0,1) */
+		dx3 = dx4;
+		dy3 = dy4;
+		dz3 = dz0 - 3 * SQUISH_CONSTANT_4D;
+		dw3 = dw0 - 1 - 3 * SQUISH_CONSTANT_4D;
+		attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3 - dw3 * dw3;
+		if (attn3 > 0) {
+			attn3 *= attn3;
+			value += attn3 * attn3 * extrapolate4(ctx, xsb + 1, ysb + 1, zsb + 0, wsb + 1, dx3, dy3, dz3, dw3);
+		}
+
+		/* Contribution (1,0,1,1) */
+		dx2 = dx4;
+		dy2 = dy0 - 3 * SQUISH_CONSTANT_4D;
+		dz2 = dz4;
+		dw2 = dw3;
+		attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2 - dw2 * dw2;
+		if (attn2 > 0) {
+			attn2 *= attn2;
+			value += attn2 * attn2 * extrapolate4(ctx, xsb + 1, ysb + 0, zsb + 1, wsb + 1, dx2, dy2, dz2, dw2);
+		}
+
+		/* Contribution (0,1,1,1) */
+		dx1 = dx0 - 3 * SQUISH_CONSTANT_4D;
+		dz1 = dz4;
+		dy1 = dy4;
+		dw1 = dw3;
+		attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1 - dw1 * dw1;
+		if (attn1 > 0) {
+			attn1 *= attn1;
+			value += attn1 * attn1 * extrapolate4(ctx, xsb + 0, ysb + 1, zsb + 1, wsb + 1, dx1, dy1, dz1, dw1);
+		}
+
+		/* Contribution (1,1,1,1) */
+		dx0 = dx0 - 1 - 4 * SQUISH_CONSTANT_4D;
+		dy0 = dy0 - 1 - 4 * SQUISH_CONSTANT_4D;
+		dz0 = dz0 - 1 - 4 * SQUISH_CONSTANT_4D;
+		dw0 = dw0 - 1 - 4 * SQUISH_CONSTANT_4D;
+		attn0 = 2 - dx0 * dx0 - dy0 * dy0 - dz0 * dz0 - dw0 * dw0;
+		if (attn0 > 0) {
+			attn0 *= attn0;
+			value += attn0 * attn0 * extrapolate4(ctx, xsb + 1, ysb + 1, zsb + 1, wsb + 1, dx0, dy0, dz0, dw0);
+		}
+	} else if (inSum <= 2) { /* We're inside the first dispentachoron (Rectified 4-Simplex) */
+		aIsBiggerSide = 1;
+		bIsBiggerSide = 1;
+		
+		/* Decide between (1,1,0,0) and (0,0,1,1) */
+		if (xins + yins > zins + wins) {
+			aScore = xins + yins;
+			aPoint = 0x03;
+		} else {
+			aScore = zins + wins;
+			aPoint = 0x0C;
+		}
+		
+		/* Decide between (1,0,1,0) and (0,1,0,1) */
+		if (xins + zins > yins + wins) {
+			bScore = xins + zins;
+			bPoint = 0x05;
+		} else {
+			bScore = yins + wins;
+			bPoint = 0x0A;
+		}
+		
+		/* Closer between (1,0,0,1) and (0,1,1,0) will replace the further of a and b, if closer. */
+		if (xins + wins > yins + zins) {
+			score = xins + wins;
+			if (aScore >= bScore && score > bScore) {
+				bScore = score;
+				bPoint = 0x09;
+			} else if (aScore < bScore && score > aScore) {
+				aScore = score;
+				aPoint = 0x09;
+			}
+		} else {
+			score = yins + zins;
+			if (aScore >= bScore && score > bScore) {
+				bScore = score;
+				bPoint = 0x06;
+			} else if (aScore < bScore && score > aScore) {
+				aScore = score;
+				aPoint = 0x06;
+			}
+		}
+		
+		/* Decide if (1,0,0,0) is closer. */
+		p1 = 2 - inSum + xins;
+		if (aScore >= bScore && p1 > bScore) {
+			bScore = p1;
+			bPoint = 0x01;
+			bIsBiggerSide = 0;
+		} else if (aScore < bScore && p1 > aScore) {
+			aScore = p1;
+			aPoint = 0x01;
+			aIsBiggerSide = 0;
+		}
+		
+		/* Decide if (0,1,0,0) is closer. */
+		p2 = 2 - inSum + yins;
+		if (aScore >= bScore && p2 > bScore) {
+			bScore = p2;
+			bPoint = 0x02;
+			bIsBiggerSide = 0;
+		} else if (aScore < bScore && p2 > aScore) {
+			aScore = p2;
+			aPoint = 0x02;
+			aIsBiggerSide = 0;
+		}
+		
+		/* Decide if (0,0,1,0) is closer. */
+		p3 = 2 - inSum + zins;
+		if (aScore >= bScore && p3 > bScore) {
+			bScore = p3;
+			bPoint = 0x04;
+			bIsBiggerSide = 0;
+		} else if (aScore < bScore && p3 > aScore) {
+			aScore = p3;
+			aPoint = 0x04;
+			aIsBiggerSide = 0;
+		}
+		
+		/* Decide if (0,0,0,1) is closer. */
+		p4 = 2 - inSum + wins;
+		if (aScore >= bScore && p4 > bScore) {
+			bScore = p4;
+			bPoint = 0x08;
+			bIsBiggerSide = 0;
+		} else if (aScore < bScore && p4 > aScore) {
+			aScore = p4;
+			aPoint = 0x08;
+			aIsBiggerSide = 0;
+		}
+		
+		/* Where each of the two closest points are determines how the extra three vertices are calculated. */
+		if (aIsBiggerSide == bIsBiggerSide) {
+			if (aIsBiggerSide) { /* Both closest points on the bigger side */
+				c1 = (int8_t)(aPoint | bPoint);
+				c2 = (int8_t)(aPoint & bPoint);
+				if ((c1 & 0x01) == 0) {
+					xsv_ext0 = xsb;
+					xsv_ext1 = xsb - 1;
+					dx_ext0 = dx0 - 3 * SQUISH_CONSTANT_4D;
+					dx_ext1 = dx0 + 1 - 2 * SQUISH_CONSTANT_4D;
+				} else {
+					xsv_ext0 = xsv_ext1 = xsb + 1;
+					dx_ext0 = dx0 - 1 - 3 * SQUISH_CONSTANT_4D;
+					dx_ext1 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				}
+				
+				if ((c1 & 0x02) == 0) {
+					ysv_ext0 = ysb;
+					ysv_ext1 = ysb - 1;
+					dy_ext0 = dy0 - 3 * SQUISH_CONSTANT_4D;
+					dy_ext1 = dy0 + 1 - 2 * SQUISH_CONSTANT_4D;
+				} else {
+					ysv_ext0 = ysv_ext1 = ysb + 1;
+					dy_ext0 = dy0 - 1 - 3 * SQUISH_CONSTANT_4D;
+					dy_ext1 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				}
+				
+				if ((c1 & 0x04) == 0) {
+					zsv_ext0 = zsb;
+					zsv_ext1 = zsb - 1;
+					dz_ext0 = dz0 - 3 * SQUISH_CONSTANT_4D;
+					dz_ext1 = dz0 + 1 - 2 * SQUISH_CONSTANT_4D;
+				} else {
+					zsv_ext0 = zsv_ext1 = zsb + 1;
+					dz_ext0 = dz0 - 1 - 3 * SQUISH_CONSTANT_4D;
+					dz_ext1 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				}
+				
+				if ((c1 & 0x08) == 0) {
+					wsv_ext0 = wsb;
+					wsv_ext1 = wsb - 1;
+					dw_ext0 = dw0 - 3 * SQUISH_CONSTANT_4D;
+					dw_ext1 = dw0 + 1 - 2 * SQUISH_CONSTANT_4D;
+				} else {
+					wsv_ext0 = wsv_ext1 = wsb + 1;
+					dw_ext0 = dw0 - 1 - 3 * SQUISH_CONSTANT_4D;
+					dw_ext1 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				}
+				
+				/* One combination is a permutation of (0,0,0,2) based on c2 */
+				xsv_ext2 = xsb;
+				ysv_ext2 = ysb;
+				zsv_ext2 = zsb;
+				wsv_ext2 = wsb;
+				dx_ext2 = dx0 - 2 * SQUISH_CONSTANT_4D;
+				dy_ext2 = dy0 - 2 * SQUISH_CONSTANT_4D;
+				dz_ext2 = dz0 - 2 * SQUISH_CONSTANT_4D;
+				dw_ext2 = dw0 - 2 * SQUISH_CONSTANT_4D;
+				if ((c2 & 0x01) != 0) {
+					xsv_ext2 += 2;
+					dx_ext2 -= 2;
+				} else if ((c2 & 0x02) != 0) {
+					ysv_ext2 += 2;
+					dy_ext2 -= 2;
+				} else if ((c2 & 0x04) != 0) {
+					zsv_ext2 += 2;
+					dz_ext2 -= 2;
+				} else {
+					wsv_ext2 += 2;
+					dw_ext2 -= 2;
+				}
+				
+			} else { /* Both closest points on the smaller side */
+				/* One of the two extra points is (0,0,0,0) */
+				xsv_ext2 = xsb;
+				ysv_ext2 = ysb;
+				zsv_ext2 = zsb;
+				wsv_ext2 = wsb;
+				dx_ext2 = dx0;
+				dy_ext2 = dy0;
+				dz_ext2 = dz0;
+				dw_ext2 = dw0;
+				
+				/* Other two points are based on the omitted axes. */
+				c = (int8_t)(aPoint | bPoint);
+				
+				if ((c & 0x01) == 0) {
+					xsv_ext0 = xsb - 1;
+					xsv_ext1 = xsb;
+					dx_ext0 = dx0 + 1 - SQUISH_CONSTANT_4D;
+					dx_ext1 = dx0 - SQUISH_CONSTANT_4D;
+				} else {
+					xsv_ext0 = xsv_ext1 = xsb + 1;
+					dx_ext0 = dx_ext1 = dx0 - 1 - SQUISH_CONSTANT_4D;
+				}
+				
+				if ((c & 0x02) == 0) {
+					ysv_ext0 = ysv_ext1 = ysb;
+					dy_ext0 = dy_ext1 = dy0 - SQUISH_CONSTANT_4D;
+					if ((c & 0x01) == 0x01)
+					{
+						ysv_ext0 -= 1;
+						dy_ext0 += 1;
+					} else {
+						ysv_ext1 -= 1;
+						dy_ext1 += 1;
+					}
+				} else {
+					ysv_ext0 = ysv_ext1 = ysb + 1;
+					dy_ext0 = dy_ext1 = dy0 - 1 - SQUISH_CONSTANT_4D;
+				}
+				
+				if ((c & 0x04) == 0) {
+					zsv_ext0 = zsv_ext1 = zsb;
+					dz_ext0 = dz_ext1 = dz0 - SQUISH_CONSTANT_4D;
+					if ((c & 0x03) == 0x03)
+					{
+						zsv_ext0 -= 1;
+						dz_ext0 += 1;
+					} else {
+						zsv_ext1 -= 1;
+						dz_ext1 += 1;
+					}
+				} else {
+					zsv_ext0 = zsv_ext1 = zsb + 1;
+					dz_ext0 = dz_ext1 = dz0 - 1 - SQUISH_CONSTANT_4D;
+				}
+				
+				if ((c & 0x08) == 0)
+				{
+					wsv_ext0 = wsb;
+					wsv_ext1 = wsb - 1;
+					dw_ext0 = dw0 - SQUISH_CONSTANT_4D;
+					dw_ext1 = dw0 + 1 - SQUISH_CONSTANT_4D;
+				} else {
+					wsv_ext0 = wsv_ext1 = wsb + 1;
+					dw_ext0 = dw_ext1 = dw0 - 1 - SQUISH_CONSTANT_4D;
+				}
+				
+			}
+		} else { /* One point on each "side" */
+			if (aIsBiggerSide) {
+				c1 = aPoint;
+				c2 = bPoint;
+			} else {
+				c1 = bPoint;
+				c2 = aPoint;
+			}
+			
+			/* Two contributions are the bigger-sided point with each 0 replaced with -1. */
+			if ((c1 & 0x01) == 0) {
+				xsv_ext0 = xsb - 1;
+				xsv_ext1 = xsb;
+				dx_ext0 = dx0 + 1 - SQUISH_CONSTANT_4D;
+				dx_ext1 = dx0 - SQUISH_CONSTANT_4D;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsb + 1;
+				dx_ext0 = dx_ext1 = dx0 - 1 - SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c1 & 0x02) == 0) {
+				ysv_ext0 = ysv_ext1 = ysb;
+				dy_ext0 = dy_ext1 = dy0 - SQUISH_CONSTANT_4D;
+				if ((c1 & 0x01) == 0x01) {
+					ysv_ext0 -= 1;
+					dy_ext0 += 1;
+				} else {
+					ysv_ext1 -= 1;
+					dy_ext1 += 1;
+				}
+			} else {
+				ysv_ext0 = ysv_ext1 = ysb + 1;
+				dy_ext0 = dy_ext1 = dy0 - 1 - SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c1 & 0x04) == 0) {
+				zsv_ext0 = zsv_ext1 = zsb;
+				dz_ext0 = dz_ext1 = dz0 - SQUISH_CONSTANT_4D;
+				if ((c1 & 0x03) == 0x03) {
+					zsv_ext0 -= 1;
+					dz_ext0 += 1;
+				} else {
+					zsv_ext1 -= 1;
+					dz_ext1 += 1;
+				}
+			} else {
+				zsv_ext0 = zsv_ext1 = zsb + 1;
+				dz_ext0 = dz_ext1 = dz0 - 1 - SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c1 & 0x08) == 0) {
+				wsv_ext0 = wsb;
+				wsv_ext1 = wsb - 1;
+				dw_ext0 = dw0 - SQUISH_CONSTANT_4D;
+				dw_ext1 = dw0 + 1 - SQUISH_CONSTANT_4D;
+			} else {
+				wsv_ext0 = wsv_ext1 = wsb + 1;
+				dw_ext0 = dw_ext1 = dw0 - 1 - SQUISH_CONSTANT_4D;
+			}
+
+			/* One contribution is a permutation of (0,0,0,2) based on the smaller-sided point */
+			xsv_ext2 = xsb;
+			ysv_ext2 = ysb;
+			zsv_ext2 = zsb;
+			wsv_ext2 = wsb;
+			dx_ext2 = dx0 - 2 * SQUISH_CONSTANT_4D;
+			dy_ext2 = dy0 - 2 * SQUISH_CONSTANT_4D;
+			dz_ext2 = dz0 - 2 * SQUISH_CONSTANT_4D;
+			dw_ext2 = dw0 - 2 * SQUISH_CONSTANT_4D;
+			if ((c2 & 0x01) != 0) {
+				xsv_ext2 += 2;
+				dx_ext2 -= 2;
+			} else if ((c2 & 0x02) != 0) {
+				ysv_ext2 += 2;
+				dy_ext2 -= 2;
+			} else if ((c2 & 0x04) != 0) {
+				zsv_ext2 += 2;
+				dz_ext2 -= 2;
+			} else {
+				wsv_ext2 += 2;
+				dw_ext2 -= 2;
+			}
+		}
+		
+		/* Contribution (1,0,0,0) */
+		dx1 = dx0 - 1 - SQUISH_CONSTANT_4D;
+		dy1 = dy0 - 0 - SQUISH_CONSTANT_4D;
+		dz1 = dz0 - 0 - SQUISH_CONSTANT_4D;
+		dw1 = dw0 - 0 - SQUISH_CONSTANT_4D;
+		attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1 - dw1 * dw1;
+		if (attn1 > 0) {
+			attn1 *= attn1;
+			value += attn1 * attn1 * extrapolate4(ctx, xsb + 1, ysb + 0, zsb + 0, wsb + 0, dx1, dy1, dz1, dw1);
+		}
+
+		/* Contribution (0,1,0,0) */
+		dx2 = dx0 - 0 - SQUISH_CONSTANT_4D;
+		dy2 = dy0 - 1 - SQUISH_CONSTANT_4D;
+		dz2 = dz1;
+		dw2 = dw1;
+		attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2 - dw2 * dw2;
+		if (attn2 > 0) {
+			attn2 *= attn2;
+			value += attn2 * attn2 * extrapolate4(ctx, xsb + 0, ysb + 1, zsb + 0, wsb + 0, dx2, dy2, dz2, dw2);
+		}
+
+		/* Contribution (0,0,1,0) */
+		dx3 = dx2;
+		dy3 = dy1;
+		dz3 = dz0 - 1 - SQUISH_CONSTANT_4D;
+		dw3 = dw1;
+		attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3 - dw3 * dw3;
+		if (attn3 > 0) {
+			attn3 *= attn3;
+			value += attn3 * attn3 * extrapolate4(ctx, xsb + 0, ysb + 0, zsb + 1, wsb + 0, dx3, dy3, dz3, dw3);
+		}
+
+		/* Contribution (0,0,0,1) */
+		dx4 = dx2;
+		dy4 = dy1;
+		dz4 = dz1;
+		dw4 = dw0 - 1 - SQUISH_CONSTANT_4D;
+		attn4 = 2 - dx4 * dx4 - dy4 * dy4 - dz4 * dz4 - dw4 * dw4;
+		if (attn4 > 0) {
+			attn4 *= attn4;
+			value += attn4 * attn4 * extrapolate4(ctx, xsb + 0, ysb + 0, zsb + 0, wsb + 1, dx4, dy4, dz4, dw4);
+		}
+		
+		/* Contribution (1,1,0,0) */
+		dx5 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dy5 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dz5 = dz0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dw5 = dw0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		attn5 = 2 - dx5 * dx5 - dy5 * dy5 - dz5 * dz5 - dw5 * dw5;
+		if (attn5 > 0) {
+			attn5 *= attn5;
+			value += attn5 * attn5 * extrapolate4(ctx, xsb + 1, ysb + 1, zsb + 0, wsb + 0, dx5, dy5, dz5, dw5);
+		}
+		
+		/* Contribution (1,0,1,0) */
+		dx6 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dy6 = dy0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dz6 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dw6 = dw0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		attn6 = 2 - dx6 * dx6 - dy6 * dy6 - dz6 * dz6 - dw6 * dw6;
+		if (attn6 > 0) {
+			attn6 *= attn6;
+			value += attn6 * attn6 * extrapolate4(ctx, xsb + 1, ysb + 0, zsb + 1, wsb + 0, dx6, dy6, dz6, dw6);
+		}
+
+		/* Contribution (1,0,0,1) */
+		dx7 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dy7 = dy0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dz7 = dz0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dw7 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		attn7 = 2 - dx7 * dx7 - dy7 * dy7 - dz7 * dz7 - dw7 * dw7;
+		if (attn7 > 0) {
+			attn7 *= attn7;
+			value += attn7 * attn7 * extrapolate4(ctx, xsb + 1, ysb + 0, zsb + 0, wsb + 1, dx7, dy7, dz7, dw7);
+		}
+		
+		/* Contribution (0,1,1,0) */
+		dx8 = dx0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dy8 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dz8 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dw8 = dw0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		attn8 = 2 - dx8 * dx8 - dy8 * dy8 - dz8 * dz8 - dw8 * dw8;
+		if (attn8 > 0) {
+			attn8 *= attn8;
+			value += attn8 * attn8 * extrapolate4(ctx, xsb + 0, ysb + 1, zsb + 1, wsb + 0, dx8, dy8, dz8, dw8);
+		}
+		
+		/* Contribution (0,1,0,1) */
+		dx9 = dx0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dy9 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dz9 = dz0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dw9 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		attn9 = 2 - dx9 * dx9 - dy9 * dy9 - dz9 * dz9 - dw9 * dw9;
+		if (attn9 > 0) {
+			attn9 *= attn9;
+			value += attn9 * attn9 * extrapolate4(ctx, xsb + 0, ysb + 1, zsb + 0, wsb + 1, dx9, dy9, dz9, dw9);
+		}
+		
+		/* Contribution (0,0,1,1) */
+		dx10 = dx0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dy10 = dy0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dz10 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dw10 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		attn10 = 2 - dx10 * dx10 - dy10 * dy10 - dz10 * dz10 - dw10 * dw10;
+		if (attn10 > 0) {
+			attn10 *= attn10;
+			value += attn10 * attn10 * extrapolate4(ctx, xsb + 0, ysb + 0, zsb + 1, wsb + 1, dx10, dy10, dz10, dw10);
+		}
+	} else { /* We're inside the second dispentachoron (Rectified 4-Simplex) */
+		aIsBiggerSide = 1;
+		bIsBiggerSide = 1;
+		
+		/* Decide between (0,0,1,1) and (1,1,0,0) */
+		if (xins + yins < zins + wins) {
+			aScore = xins + yins;
+			aPoint = 0x0C;
+		} else {
+			aScore = zins + wins;
+			aPoint = 0x03;
+		}
+		
+		/* Decide between (0,1,0,1) and (1,0,1,0) */
+		if (xins + zins < yins + wins) {
+			bScore = xins + zins;
+			bPoint = 0x0A;
+		} else {
+			bScore = yins + wins;
+			bPoint = 0x05;
+		}
+		
+		/* Closer between (0,1,1,0) and (1,0,0,1) will replace the further of a and b, if closer. */
+		if (xins + wins < yins + zins) {
+			score = xins + wins;
+			if (aScore <= bScore && score < bScore) {
+				bScore = score;
+				bPoint = 0x06;
+			} else if (aScore > bScore && score < aScore) {
+				aScore = score;
+				aPoint = 0x06;
+			}
+		} else {
+			score = yins + zins;
+			if (aScore <= bScore && score < bScore) {
+				bScore = score;
+				bPoint = 0x09;
+			} else if (aScore > bScore && score < aScore) {
+				aScore = score;
+				aPoint = 0x09;
+			}
+		}
+		
+		/* Decide if (0,1,1,1) is closer. */
+		p1 = 3 - inSum + xins;
+		if (aScore <= bScore && p1 < bScore) {
+			bScore = p1;
+			bPoint = 0x0E;
+			bIsBiggerSide = 0;
+		} else if (aScore > bScore && p1 < aScore) {
+			aScore = p1;
+			aPoint = 0x0E;
+			aIsBiggerSide = 0;
+		}
+		
+		/* Decide if (1,0,1,1) is closer. */
+		p2 = 3 - inSum + yins;
+		if (aScore <= bScore && p2 < bScore) {
+			bScore = p2;
+			bPoint = 0x0D;
+			bIsBiggerSide = 0;
+		} else if (aScore > bScore && p2 < aScore) {
+			aScore = p2;
+			aPoint = 0x0D;
+			aIsBiggerSide = 0;
+		}
+		
+		/* Decide if (1,1,0,1) is closer. */
+		p3 = 3 - inSum + zins;
+		if (aScore <= bScore && p3 < bScore) {
+			bScore = p3;
+			bPoint = 0x0B;
+			bIsBiggerSide = 0;
+		} else if (aScore > bScore && p3 < aScore) {
+			aScore = p3;
+			aPoint = 0x0B;
+			aIsBiggerSide = 0;
+		}
+		
+		/* Decide if (1,1,1,0) is closer. */
+		p4 = 3 - inSum + wins;
+		if (aScore <= bScore && p4 < bScore) {
+			bScore = p4;
+			bPoint = 0x07;
+			bIsBiggerSide = 0;
+		} else if (aScore > bScore && p4 < aScore) {
+			aScore = p4;
+			aPoint = 0x07;
+			aIsBiggerSide = 0;
+		}
+		
+		/* Where each of the two closest points are determines how the extra three vertices are calculated. */
+		if (aIsBiggerSide == bIsBiggerSide) {
+			if (aIsBiggerSide) { /* Both closest points on the bigger side */
+				c1 = (int8_t)(aPoint & bPoint);
+				c2 = (int8_t)(aPoint | bPoint);
+				
+				/* Two contributions are permutations of (0,0,0,1) and (0,0,0,2) based on c1 */
+				xsv_ext0 = xsv_ext1 = xsb;
+				ysv_ext0 = ysv_ext1 = ysb;
+				zsv_ext0 = zsv_ext1 = zsb;
+				wsv_ext0 = wsv_ext1 = wsb;
+				dx_ext0 = dx0 - SQUISH_CONSTANT_4D;
+				dy_ext0 = dy0 - SQUISH_CONSTANT_4D;
+				dz_ext0 = dz0 - SQUISH_CONSTANT_4D;
+				dw_ext0 = dw0 - SQUISH_CONSTANT_4D;
+				dx_ext1 = dx0 - 2 * SQUISH_CONSTANT_4D;
+				dy_ext1 = dy0 - 2 * SQUISH_CONSTANT_4D;
+				dz_ext1 = dz0 - 2 * SQUISH_CONSTANT_4D;
+				dw_ext1 = dw0 - 2 * SQUISH_CONSTANT_4D;
+				if ((c1 & 0x01) != 0) {
+					xsv_ext0 += 1;
+					dx_ext0 -= 1;
+					xsv_ext1 += 2;
+					dx_ext1 -= 2;
+				} else if ((c1 & 0x02) != 0) {
+					ysv_ext0 += 1;
+					dy_ext0 -= 1;
+					ysv_ext1 += 2;
+					dy_ext1 -= 2;
+				} else if ((c1 & 0x04) != 0) {
+					zsv_ext0 += 1;
+					dz_ext0 -= 1;
+					zsv_ext1 += 2;
+					dz_ext1 -= 2;
+				} else {
+					wsv_ext0 += 1;
+					dw_ext0 -= 1;
+					wsv_ext1 += 2;
+					dw_ext1 -= 2;
+				}
+				
+				/* One contribution is a permutation of (1,1,1,-1) based on c2 */
+				xsv_ext2 = xsb + 1;
+				ysv_ext2 = ysb + 1;
+				zsv_ext2 = zsb + 1;
+				wsv_ext2 = wsb + 1;
+				dx_ext2 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dy_ext2 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dz_ext2 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				dw_ext2 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+				if ((c2 & 0x01) == 0) {
+					xsv_ext2 -= 2;
+					dx_ext2 += 2;
+				} else if ((c2 & 0x02) == 0) {
+					ysv_ext2 -= 2;
+					dy_ext2 += 2;
+				} else if ((c2 & 0x04) == 0) {
+					zsv_ext2 -= 2;
+					dz_ext2 += 2;
+				} else {
+					wsv_ext2 -= 2;
+					dw_ext2 += 2;
+				}
+			} else { /* Both closest points on the smaller side */
+				/* One of the two extra points is (1,1,1,1) */
+				xsv_ext2 = xsb + 1;
+				ysv_ext2 = ysb + 1;
+				zsv_ext2 = zsb + 1;
+				wsv_ext2 = wsb + 1;
+				dx_ext2 = dx0 - 1 - 4 * SQUISH_CONSTANT_4D;
+				dy_ext2 = dy0 - 1 - 4 * SQUISH_CONSTANT_4D;
+				dz_ext2 = dz0 - 1 - 4 * SQUISH_CONSTANT_4D;
+				dw_ext2 = dw0 - 1 - 4 * SQUISH_CONSTANT_4D;
+				
+				/* Other two points are based on the shared axes. */
+				c = (int8_t)(aPoint & bPoint);
+				
+				if ((c & 0x01) != 0) {
+					xsv_ext0 = xsb + 2;
+					xsv_ext1 = xsb + 1;
+					dx_ext0 = dx0 - 2 - 3 * SQUISH_CONSTANT_4D;
+					dx_ext1 = dx0 - 1 - 3 * SQUISH_CONSTANT_4D;
+				} else {
+					xsv_ext0 = xsv_ext1 = xsb;
+					dx_ext0 = dx_ext1 = dx0 - 3 * SQUISH_CONSTANT_4D;
+				}
+				
+				if ((c & 0x02) != 0) {
+					ysv_ext0 = ysv_ext1 = ysb + 1;
+					dy_ext0 = dy_ext1 = dy0 - 1 - 3 * SQUISH_CONSTANT_4D;
+					if ((c & 0x01) == 0)
+					{
+						ysv_ext0 += 1;
+						dy_ext0 -= 1;
+					} else {
+						ysv_ext1 += 1;
+						dy_ext1 -= 1;
+					}
+				} else {
+					ysv_ext0 = ysv_ext1 = ysb;
+					dy_ext0 = dy_ext1 = dy0 - 3 * SQUISH_CONSTANT_4D;
+				}
+				
+				if ((c & 0x04) != 0) {
+					zsv_ext0 = zsv_ext1 = zsb + 1;
+					dz_ext0 = dz_ext1 = dz0 - 1 - 3 * SQUISH_CONSTANT_4D;
+					if ((c & 0x03) == 0)
+					{
+						zsv_ext0 += 1;
+						dz_ext0 -= 1;
+					} else {
+						zsv_ext1 += 1;
+						dz_ext1 -= 1;
+					}
+				} else {
+					zsv_ext0 = zsv_ext1 = zsb;
+					dz_ext0 = dz_ext1 = dz0 - 3 * SQUISH_CONSTANT_4D;
+				}
+				
+				if ((c & 0x08) != 0)
+				{
+					wsv_ext0 = wsb + 1;
+					wsv_ext1 = wsb + 2;
+					dw_ext0 = dw0 - 1 - 3 * SQUISH_CONSTANT_4D;
+					dw_ext1 = dw0 - 2 - 3 * SQUISH_CONSTANT_4D;
+				} else {
+					wsv_ext0 = wsv_ext1 = wsb;
+					dw_ext0 = dw_ext1 = dw0 - 3 * SQUISH_CONSTANT_4D;
+				}
+			}
+		} else { /* One point on each "side" */
+			if (aIsBiggerSide) {
+				c1 = aPoint;
+				c2 = bPoint;
+			} else {
+				c1 = bPoint;
+				c2 = aPoint;
+			}
+			
+			/* Two contributions are the bigger-sided point with each 1 replaced with 2. */
+			if ((c1 & 0x01) != 0) {
+				xsv_ext0 = xsb + 2;
+				xsv_ext1 = xsb + 1;
+				dx_ext0 = dx0 - 2 - 3 * SQUISH_CONSTANT_4D;
+				dx_ext1 = dx0 - 1 - 3 * SQUISH_CONSTANT_4D;
+			} else {
+				xsv_ext0 = xsv_ext1 = xsb;
+				dx_ext0 = dx_ext1 = dx0 - 3 * SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c1 & 0x02) != 0) {
+				ysv_ext0 = ysv_ext1 = ysb + 1;
+				dy_ext0 = dy_ext1 = dy0 - 1 - 3 * SQUISH_CONSTANT_4D;
+				if ((c1 & 0x01) == 0) {
+					ysv_ext0 += 1;
+					dy_ext0 -= 1;
+				} else {
+					ysv_ext1 += 1;
+					dy_ext1 -= 1;
+				}
+			} else {
+				ysv_ext0 = ysv_ext1 = ysb;
+				dy_ext0 = dy_ext1 = dy0 - 3 * SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c1 & 0x04) != 0) {
+				zsv_ext0 = zsv_ext1 = zsb + 1;
+				dz_ext0 = dz_ext1 = dz0 - 1 - 3 * SQUISH_CONSTANT_4D;
+				if ((c1 & 0x03) == 0) {
+					zsv_ext0 += 1;
+					dz_ext0 -= 1;
+				} else {
+					zsv_ext1 += 1;
+					dz_ext1 -= 1;
+				}
+			} else {
+				zsv_ext0 = zsv_ext1 = zsb;
+				dz_ext0 = dz_ext1 = dz0 - 3 * SQUISH_CONSTANT_4D;
+			}
+			
+			if ((c1 & 0x08) != 0) {
+				wsv_ext0 = wsb + 1;
+				wsv_ext1 = wsb + 2;
+				dw_ext0 = dw0 - 1 - 3 * SQUISH_CONSTANT_4D;
+				dw_ext1 = dw0 - 2 - 3 * SQUISH_CONSTANT_4D;
+			} else {
+				wsv_ext0 = wsv_ext1 = wsb;
+				dw_ext0 = dw_ext1 = dw0 - 3 * SQUISH_CONSTANT_4D;
+			}
+
+			/* One contribution is a permutation of (1,1,1,-1) based on the smaller-sided point */
+			xsv_ext2 = xsb + 1;
+			ysv_ext2 = ysb + 1;
+			zsv_ext2 = zsb + 1;
+			wsv_ext2 = wsb + 1;
+			dx_ext2 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+			dy_ext2 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+			dz_ext2 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+			dw_ext2 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+			if ((c2 & 0x01) == 0) {
+				xsv_ext2 -= 2;
+				dx_ext2 += 2;
+			} else if ((c2 & 0x02) == 0) {
+				ysv_ext2 -= 2;
+				dy_ext2 += 2;
+			} else if ((c2 & 0x04) == 0) {
+				zsv_ext2 -= 2;
+				dz_ext2 += 2;
+			} else {
+				wsv_ext2 -= 2;
+				dw_ext2 += 2;
+			}
+		}
+		
+		/* Contribution (1,1,1,0) */
+		dx4 = dx0 - 1 - 3 * SQUISH_CONSTANT_4D;
+		dy4 = dy0 - 1 - 3 * SQUISH_CONSTANT_4D;
+		dz4 = dz0 - 1 - 3 * SQUISH_CONSTANT_4D;
+		dw4 = dw0 - 3 * SQUISH_CONSTANT_4D;
+		attn4 = 2 - dx4 * dx4 - dy4 * dy4 - dz4 * dz4 - dw4 * dw4;
+		if (attn4 > 0) {
+			attn4 *= attn4;
+			value += attn4 * attn4 * extrapolate4(ctx, xsb + 1, ysb + 1, zsb + 1, wsb + 0, dx4, dy4, dz4, dw4);
+		}
+
+		/* Contribution (1,1,0,1) */
+		dx3 = dx4;
+		dy3 = dy4;
+		dz3 = dz0 - 3 * SQUISH_CONSTANT_4D;
+		dw3 = dw0 - 1 - 3 * SQUISH_CONSTANT_4D;
+		attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3 - dw3 * dw3;
+		if (attn3 > 0) {
+			attn3 *= attn3;
+			value += attn3 * attn3 * extrapolate4(ctx, xsb + 1, ysb + 1, zsb + 0, wsb + 1, dx3, dy3, dz3, dw3);
+		}
+
+		/* Contribution (1,0,1,1) */
+		dx2 = dx4;
+		dy2 = dy0 - 3 * SQUISH_CONSTANT_4D;
+		dz2 = dz4;
+		dw2 = dw3;
+		attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2 - dw2 * dw2;
+		if (attn2 > 0) {
+			attn2 *= attn2;
+			value += attn2 * attn2 * extrapolate4(ctx, xsb + 1, ysb + 0, zsb + 1, wsb + 1, dx2, dy2, dz2, dw2);
+		}
+
+		/* Contribution (0,1,1,1) */
+		dx1 = dx0 - 3 * SQUISH_CONSTANT_4D;
+		dz1 = dz4;
+		dy1 = dy4;
+		dw1 = dw3;
+		attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1 - dw1 * dw1;
+		if (attn1 > 0) {
+			attn1 *= attn1;
+			value += attn1 * attn1 * extrapolate4(ctx, xsb + 0, ysb + 1, zsb + 1, wsb + 1, dx1, dy1, dz1, dw1);
+		}
+		
+		/* Contribution (1,1,0,0) */
+		dx5 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dy5 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dz5 = dz0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dw5 = dw0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		attn5 = 2 - dx5 * dx5 - dy5 * dy5 - dz5 * dz5 - dw5 * dw5;
+		if (attn5 > 0) {
+			attn5 *= attn5;
+			value += attn5 * attn5 * extrapolate4(ctx, xsb + 1, ysb + 1, zsb + 0, wsb + 0, dx5, dy5, dz5, dw5);
+		}
+		
+		/* Contribution (1,0,1,0) */
+		dx6 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dy6 = dy0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dz6 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dw6 = dw0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		attn6 = 2 - dx6 * dx6 - dy6 * dy6 - dz6 * dz6 - dw6 * dw6;
+		if (attn6 > 0) {
+			attn6 *= attn6;
+			value += attn6 * attn6 * extrapolate4(ctx, xsb + 1, ysb + 0, zsb + 1, wsb + 0, dx6, dy6, dz6, dw6);
+		}
+
+		/* Contribution (1,0,0,1) */
+		dx7 = dx0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dy7 = dy0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dz7 = dz0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dw7 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		attn7 = 2 - dx7 * dx7 - dy7 * dy7 - dz7 * dz7 - dw7 * dw7;
+		if (attn7 > 0) {
+			attn7 *= attn7;
+			value += attn7 * attn7 * extrapolate4(ctx, xsb + 1, ysb + 0, zsb + 0, wsb + 1, dx7, dy7, dz7, dw7);
+		}
+		
+		/* Contribution (0,1,1,0) */
+		dx8 = dx0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dy8 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dz8 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dw8 = dw0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		attn8 = 2 - dx8 * dx8 - dy8 * dy8 - dz8 * dz8 - dw8 * dw8;
+		if (attn8 > 0) {
+			attn8 *= attn8;
+			value += attn8 * attn8 * extrapolate4(ctx, xsb + 0, ysb + 1, zsb + 1, wsb + 0, dx8, dy8, dz8, dw8);
+		}
+		
+		/* Contribution (0,1,0,1) */
+		dx9 = dx0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dy9 = dy0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dz9 = dz0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dw9 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		attn9 = 2 - dx9 * dx9 - dy9 * dy9 - dz9 * dz9 - dw9 * dw9;
+		if (attn9 > 0) {
+			attn9 *= attn9;
+			value += attn9 * attn9 * extrapolate4(ctx, xsb + 0, ysb + 1, zsb + 0, wsb + 1, dx9, dy9, dz9, dw9);
+		}
+		
+		/* Contribution (0,0,1,1) */
+		dx10 = dx0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dy10 = dy0 - 0 - 2 * SQUISH_CONSTANT_4D;
+		dz10 = dz0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		dw10 = dw0 - 1 - 2 * SQUISH_CONSTANT_4D;
+		attn10 = 2 - dx10 * dx10 - dy10 * dy10 - dz10 * dz10 - dw10 * dw10;
+		if (attn10 > 0) {
+			attn10 *= attn10;
+			value += attn10 * attn10 * extrapolate4(ctx, xsb + 0, ysb + 0, zsb + 1, wsb + 1, dx10, dy10, dz10, dw10);
+		}
+	}
+
+	/* First extra vertex */
+	attn_ext0 = 2 - dx_ext0 * dx_ext0 - dy_ext0 * dy_ext0 - dz_ext0 * dz_ext0 - dw_ext0 * dw_ext0;
+	if (attn_ext0 > 0)
+	{
+		attn_ext0 *= attn_ext0;
+		value += attn_ext0 * attn_ext0 * extrapolate4(ctx, xsv_ext0, ysv_ext0, zsv_ext0, wsv_ext0, dx_ext0, dy_ext0, dz_ext0, dw_ext0);
+	}
+
+	/* Second extra vertex */
+	attn_ext1 = 2 - dx_ext1 * dx_ext1 - dy_ext1 * dy_ext1 - dz_ext1 * dz_ext1 - dw_ext1 * dw_ext1;
+	if (attn_ext1 > 0)
+	{
+		attn_ext1 *= attn_ext1;
+		value += attn_ext1 * attn_ext1 * extrapolate4(ctx, xsv_ext1, ysv_ext1, zsv_ext1, wsv_ext1, dx_ext1, dy_ext1, dz_ext1, dw_ext1);
+	}
+
+	/* Third extra vertex */
+	attn_ext2 = 2 - dx_ext2 * dx_ext2 - dy_ext2 * dy_ext2 - dz_ext2 * dz_ext2 - dw_ext2 * dw_ext2;
+	if (attn_ext2 > 0)
+	{
+		attn_ext2 *= attn_ext2;
+		value += attn_ext2 * attn_ext2 * extrapolate4(ctx, xsv_ext2, ysv_ext2, zsv_ext2, wsv_ext2, dx_ext2, dy_ext2, dz_ext2, dw_ext2);
+	}
+
+	return value / NORM_CONSTANT_4D;
+}
+	

--- a/thirdparty/misc/open-simplex-noise.h
+++ b/thirdparty/misc/open-simplex-noise.h
@@ -1,0 +1,58 @@
+#ifndef OPEN_SIMPLEX_NOISE_H__
+#define OPEN_SIMPLEX_NOISE_H__
+
+/*
+ * OpenSimplex (Simplectic) Noise in C.
+ * Ported to C from Kurt Spencer's java implementation by Stephen M. Cameron
+ *
+ * v1.1 (October 6, 2014) 
+ * - Ported to C
+ * 
+ * v1.1 (October 5, 2014)
+ * - Added 2D and 4D implementations.
+ * - Proper gradient sets for all dimensions, from a
+ *   dimensionally-generalizable scheme with an actual
+ *   rhyme and reason behind it.
+ * - Removed default permutation array in favor of
+ *   default seed.
+ * - Changed seed-based constructor to be independent
+ *   of any particular randomization library, so results
+ *   will be the same when ported to other languages.
+ */
+
+#if ((__GNUC_STDC_INLINE__) || (__STDC_VERSION__ >= 199901L))
+	#include <stdint.h>
+	#define INLINE inline
+#elif (defined (_MSC_VER) || defined (__GNUC_GNU_INLINE__))
+	#include <stdint.h>
+	#define INLINE __inline
+#else 
+	/* ANSI C doesn't have inline or stdint.h. */
+	#define INLINE
+#endif
+
+#ifdef __cplusplus
+	extern "C" {
+#endif
+
+// -- GODOT start --
+// Modified to work without allocating memory, also removed some unused function. 
+
+struct osn_context {
+	int16_t perm[256];
+	int16_t permGradIndex3D[256];
+};
+
+int open_simplex_noise(int64_t seed, struct osn_context *ctx);
+//int open_simplex_noise_init_perm(struct osn_context *ctx, int16_t p[], int nelements);
+// -- GODOT end --
+void open_simplex_noise_free(struct osn_context *ctx);
+double open_simplex_noise2(struct osn_context *ctx, double x, double y);
+double open_simplex_noise3(struct osn_context *ctx, double x, double y, double z);
+double open_simplex_noise4(struct osn_context *ctx, double x, double y, double z, double w);
+
+#ifdef __cplusplus
+	}
+#endif
+
+#endif


### PR DESCRIPTION
SimplexNoise can be used to generate parameterized fractal noise based on Open Simplex, intended to be used in GDsrcipt.

NoiseTexture uses SimplexNoise to generate noise textures for using in
shaders/visual effects.

Documentation is missing, I will make a separate PR for that later on.

Edit: added option to use noise as a normalmap,

![noise0](https://user-images.githubusercontent.com/4402304/44797492-a0311d80-abaf-11e8-8816-ef5fd1552124.png)
![noise1](https://user-images.githubusercontent.com/4402304/44797499-a2937780-abaf-11e8-937d-ffcb71a169d7.png)
