### PR TITLE
Documented some RigidBody and PhysicsDirectBodyState methods

### DIFF
--- a/doc/classes/PhysicsDirectBodyState.xml
+++ b/doc/classes/PhysicsDirectBodyState.xml
@@ -15,6 +15,8 @@
 			<argument index="0" name="force" type="Vector3">
 			</argument>
 			<description>
+				Adds a constant directional force without affecting rotation.
+				This is equivalent to [code]add_force(force, Vector3(0,0,0))[/code].
 			</description>
 		</method>
 		<method name="add_force">
@@ -25,6 +27,7 @@
 			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<description>
+				Adds a constant force (i.e. acceleration).
 			</description>
 		</method>
 		<method name="add_torque">
@@ -33,6 +36,7 @@
 			<argument index="0" name="torque" type="Vector3">
 			</argument>
 			<description>
+				Adds a constant rotational force (i.e. a motor) without affecting position.
 			</description>
 		</method>
 		<method name="apply_central_impulse">
@@ -41,6 +45,8 @@
 			<argument index="0" name="j" type="Vector3">
 			</argument>
 			<description>
+				Applies a single directional impulse without affecting rotation.
+				This is equivalent to ``apply_impulse(Vector3(0,0,0), impulse)``.
 			</description>
 		</method>
 		<method name="apply_impulse">
@@ -51,6 +57,7 @@
 			<argument index="1" name="j" type="Vector3">
 			</argument>
 			<description>
+				Apply a positioned impulse (which will be affected by the body mass and shape). This is the equivalent of hitting a billiard ball with a cue: a force that is applied once, and only once. Both the impulse and the position are in global coordinates, and the position is relative to the object's origin.
 			</description>
 		</method>
 		<method name="apply_torque_impulse">
@@ -59,6 +66,7 @@
 			<argument index="0" name="j" type="Vector3">
 			</argument>
 			<description>
+				Apply a torque impulse (which will be affected by the body mass and shape). This will rotate the body around the passed in vector.
 			</description>
 		</method>
 		<method name="get_contact_collider" qualifiers="const">

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -30,6 +30,8 @@
 			<argument index="0" name="force" type="Vector3">
 			</argument>
 			<description>
+				Adds a constant directional force without affecting rotation.
+				This is equivalent to [code]add_force(force, Vector3(0,0,0))[/code].
 			</description>
 		</method>
 		<method name="add_force">
@@ -40,6 +42,7 @@
 			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<description>
+				Adds a constant force (i.e. acceleration).
 			</description>
 		</method>
 		<method name="add_torque">
@@ -48,6 +51,7 @@
 			<argument index="0" name="torque" type="Vector3">
 			</argument>
 			<description>
+				Adds a constant rotational force (i.e. a motor) without affecting position.
 			</description>
 		</method>
 		<method name="apply_central_impulse">
@@ -56,6 +60,8 @@
 			<argument index="0" name="impulse" type="Vector3">
 			</argument>
 			<description>
+				Applies a single directional impulse without affecting rotation.
+				This is equivalent to ``apply_impulse(Vector3(0,0,0), impulse)``.
 			</description>
 		</method>
 		<method name="apply_impulse">


### PR DESCRIPTION
As stated in [this issue](https://github.com/godotengine/godot-docs/issues/1696) in the godot-docs repo, a lot of the methods in ``RigidBody`` didn't have descriptions. I have added some basic descriptions to the ``add_force`` and ``apply_impulse`` methods. I have also mirrored these descriptions to the ``PhysicsDirectBodyState`` methods of the same name, since they share the same functionality.