### PR TITLE
Fix HTML5 gamepad input

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -565,8 +565,11 @@ void OS_JavaScript::process_joypads() {
 	int joypad_count = emscripten_get_num_gamepads();
 	for (int joypad = 0; joypad < joypad_count; joypad++) {
 		EmscriptenGamepadEvent state;
-		emscripten_get_gamepad_status(joypad, &state);
-		if (state.connected) {
+		EMSCRIPTEN_RESULT query_result = emscripten_get_gamepad_status(joypad, &state);
+		// Chromium reserves gamepads slots, so NO_DATA is an expected result.
+		ERR_CONTINUE(query_result != EMSCRIPTEN_RESULT_SUCCESS &&
+					 query_result != EMSCRIPTEN_RESULT_NO_DATA);
+		if (query_result == EMSCRIPTEN_RESULT_SUCCESS && state.connected) {
 
 			int button_count = MIN(state.numButtons, 18);
 			int axis_count = MIN(state.numAxes, 8);


### PR DESCRIPTION
`state` remains uninitialized if `emscripten_get_gamepad_status()` doesn't return `EMSCRIPTEN_RESULT_SUCCESS`. Since Chromium reserves gamepad slots, `EMSCRIPTEN_RESULT_NO_DATA` is an expected return value.
Fixes #16262