### PR TITLE
ExportDialog: Validate path before allowing export

### DIFF
--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -136,6 +136,7 @@ private:
 	void _export_pck_zip();
 	void _export_pck_zip_selected(const String &p_path);
 
+	void _validate_export_path(const String &p_path);
 	void _export_project();
 	void _export_project_to_path(const String &p_path);
 


### PR DESCRIPTION
Otherwise one could quite easily end up with the exported game
being hidden files named ".x86_64" and ".pck" for example.

Also improved the default filename logic a bit to also include
extension, and never fallback to an empty string.

Also fixed being able to click "Export project" without selecting
a preset.

----

I've been annoyed by this UX issue several times, and I'm fairly confident there must be one or more issues about it in the tracker, but couldn't find them...