### PR TITLE
DocData: Fix return type listed as "var" instead of "Variant"

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -84,14 +84,14 @@
 			</description>
 		</method>
 		<method name="append">
-			<argument index="0" name="value" type="var">
+			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
 				Append an element at the end of the array (alias of [method push_back]).
 			</description>
 		</method>
 		<method name="back">
-			<return type="var">
+			<return type="Variant">
 			</return>
 			<description>
 				Returns the last element of the array if the array is not empty (size&gt;0).
@@ -100,7 +100,7 @@
 		<method name="bsearch">
 			<return type="int">
 			</return>
-			<argument index="0" name="value" type="var">
+			<argument index="0" name="value" type="Variant">
 			</argument>
 			<argument index="1" name="before" type="bool" default="True">
 			</argument>
@@ -111,7 +111,7 @@
 		<method name="bsearch_custom">
 			<return type="int">
 			</return>
-			<argument index="0" name="value" type="var">
+			<argument index="0" name="value" type="Variant">
 			</argument>
 			<argument index="1" name="obj" type="Object">
 			</argument>
@@ -131,7 +131,7 @@
 		<method name="count">
 			<return type="int">
 			</return>
-			<argument index="0" name="value" type="var">
+			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
 				Return the amount of times an element is in the array.
@@ -155,7 +155,7 @@
 			</description>
 		</method>
 		<method name="erase">
-			<argument index="0" name="value" type="var">
+			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
 				Remove the first occurrence of a value from the array.
@@ -164,7 +164,7 @@
 		<method name="find">
 			<return type="int">
 			</return>
-			<argument index="0" name="what" type="var">
+			<argument index="0" name="what" type="Variant">
 			</argument>
 			<argument index="1" name="from" type="int" default="0">
 			</argument>
@@ -175,14 +175,14 @@
 		<method name="find_last">
 			<return type="int">
 			</return>
-			<argument index="0" name="value" type="var">
+			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
 				Searches the array in reverse order for a value and returns its index or -1 if not found.
 			</description>
 		</method>
 		<method name="front">
-			<return type="var">
+			<return type="Variant">
 			</return>
 			<description>
 				Returns the first element of the array if the array is not empty (size&gt;0).
@@ -191,7 +191,7 @@
 		<method name="has">
 			<return type="bool">
 			</return>
-			<argument index="0" name="value" type="var">
+			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
 				Return true if the array contains given value.
@@ -213,7 +213,7 @@
 		<method name="insert">
 			<argument index="0" name="position" type="int">
 			</argument>
-			<argument index="1" name="value" type="var">
+			<argument index="1" name="value" type="Variant">
 			</argument>
 			<description>
 				Insert a new element at a given position in the array. The position must be valid, or at the end of the array ([code]pos == size()[/code]).
@@ -225,42 +225,42 @@
 			</description>
 		</method>
 		<method name="max">
-			<return type="var">
+			<return type="Variant">
 			</return>
 			<description>
 				Return maximum value contained in the array if all elements are of comparable types. If the elements can't be compared, [code]null[/code] is returned.
 			</description>
 		</method>
 		<method name="min">
-			<return type="var">
+			<return type="Variant">
 			</return>
 			<description>
 				Return minimum value contained in the array if all elements are of comparable types. If the elements can't be compared, [code]null[/code] is returned.
 			</description>
 		</method>
 		<method name="pop_back">
-			<return type="var">
+			<return type="Variant">
 			</return>
 			<description>
 				Remove the last element of the array.
 			</description>
 		</method>
 		<method name="pop_front">
-			<return type="var">
+			<return type="Variant">
 			</return>
 			<description>
 				Remove the first element of the array.
 			</description>
 		</method>
 		<method name="push_back">
-			<argument index="0" name="value" type="var">
+			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
 				Append an element at the end of the array.
 			</description>
 		</method>
 		<method name="push_front">
-			<argument index="0" name="value" type="var">
+			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
 				Add an element at the beginning of the array.
@@ -283,7 +283,7 @@
 		<method name="rfind">
 			<return type="int">
 			</return>
-			<argument index="0" name="what" type="var">
+			<argument index="0" name="what" type="Variant">
 			</argument>
 			<argument index="1" name="from" type="int" default="-1">
 			</argument>

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -35,7 +35,7 @@
 		<method name="erase">
 			<return type="bool">
 			</return>
-			<argument index="0" name="key" type="var">
+			<argument index="0" name="key" type="Variant">
 			</argument>
 			<description>
 				Erase a dictionary key/value pair by key.
@@ -44,7 +44,7 @@
 		<method name="has">
 			<return type="bool">
 			</return>
-			<argument index="0" name="key" type="var">
+			<argument index="0" name="key" type="Variant">
 			</argument>
 			<description>
 				Return true if the dictionary has a given key.

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -339,7 +339,7 @@
 		<method name="format">
 			<return type="String">
 			</return>
-			<argument index="0" name="values" type="var">
+			<argument index="0" name="values" type="Variant">
 			</argument>
 			<argument index="1" name="placeholder" type="String" default="{_}">
 			</argument>

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -44,12 +44,30 @@
 			<description>
 			</description>
 		</method>
+		<method name="autotile_get_size" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="autotile_set_bitmask_mode">
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
 			<argument index="1" name="mode" type="int" enum="TileSet.BitmaskMode">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="autotile_set_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="size" type="Vector2">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -141,18 +141,18 @@
 			</description>
 		</method>
 		<method name="xform">
-			<return type="var">
+			<return type="Variant">
 			</return>
-			<argument index="0" name="v" type="var">
+			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
 				Transforms the given [Vector3], [Plane], or [AABB] by this transform.
 			</description>
 		</method>
 		<method name="xform_inv">
-			<return type="var">
+			<return type="Variant">
 			</return>
-			<argument index="0" name="v" type="var">
+			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
 				Inverse-transforms the given [Vector3], [Plane], or [AABB] by this transform.

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -143,18 +143,18 @@
 			</description>
 		</method>
 		<method name="xform">
-			<return type="var">
+			<return type="Variant">
 			</return>
-			<argument index="0" name="v" type="var">
+			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
 				Transforms the given [Vector2] or [Rect2] by this transform.
 			</description>
 		</method>
 		<method name="xform_inv">
-			<return type="var">
+			<return type="Variant">
 			</return>
-			<argument index="0" name="v" type="var">
+			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
 				Inverse-transforms the given [Vector2] or [Rect2] by this transform.

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -505,7 +505,7 @@ void DocData::generate(bool p_basic_types) {
 				ad.name = arginfo.name;
 
 				if (arginfo.type == Variant::NIL)
-					ad.type = "var";
+					ad.type = "Variant";
 				else
 					ad.type = Variant::get_type_name(arginfo.type);
 
@@ -518,7 +518,7 @@ void DocData::generate(bool p_basic_types) {
 
 			if (mi.return_val.type == Variant::NIL) {
 				if (mi.return_val.name != "")
-					method.return_type = "var";
+					method.return_type = "Variant";
 			} else {
 				method.return_type = Variant::get_type_name(mi.return_val.type);
 			}

--- a/editor/doc/doc_dump.cpp
+++ b/editor/doc/doc_dump.cpp
@@ -142,7 +142,7 @@ void DocDump::dump(const String &p_file) {
 					if (arginfo.hint == PROPERTY_HINT_RESOURCE_TYPE)
 						type_name = arginfo.hint_string;
 					else if (arginfo.type == Variant::NIL)
-						type_name = "var";
+						type_name = "Variant";
 					else
 						type_name = Variant::get_type_name(arginfo.type);
 


### PR DESCRIPTION
IIRC `Variant` was always represented as `var` in the docs initially, but we fixed most cases a while ago and those three might have gotten through the cracks.