### PR TITLE
remove defunct set custom camera

### DIFF
--- a/editor/plugins/camera_editor_plugin.cpp
+++ b/editor/plugins/camera_editor_plugin.cpp
@@ -33,30 +33,17 @@
 #include "spatial_editor_plugin.h"
 
 void CameraEditor::_notification(int p_what) {
-
-	switch (p_what) {
-
-		/*		case NOTIFICATION_PROCESS: {
-
-			if (preview->is_pressed() && node)
-				node->call("make_current");
-
-		} break;*/
-	}
 }
+
 void CameraEditor::_node_removed(Node *p_node) {
 
 	if (p_node == node) {
 		node = NULL;
-		SpatialEditor::get_singleton()->set_custom_camera(NULL);
 		hide();
 	}
 }
 
 void CameraEditor::_pressed() {
-
-	Node *sn = (node && preview->is_pressed()) ? node : NULL;
-	SpatialEditor::get_singleton()->set_custom_camera(sn);
 }
 
 void CameraEditor::_bind_methods() {
@@ -70,13 +57,6 @@ void CameraEditor::edit(Node *p_camera) {
 
 	if (!node) {
 		preview->set_pressed(false);
-		SpatialEditor::get_singleton()->set_custom_camera(NULL);
-	} else {
-
-		if (preview->is_pressed())
-			SpatialEditor::get_singleton()->set_custom_camera(p_camera);
-		else
-			SpatialEditor::get_singleton()->set_custom_camera(NULL);
 	}
 }
 
@@ -99,7 +79,6 @@ CameraEditor::CameraEditor() {
 void CameraEditorPlugin::edit(Object *p_object) {
 
 	SpatialEditor::get_singleton()->set_can_preview(Object::cast_to<Camera>(p_object));
-	//camera_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool CameraEditorPlugin::handles(Object *p_object) const {
@@ -117,21 +96,7 @@ void CameraEditorPlugin::make_visible(bool p_visible) {
 }
 
 CameraEditorPlugin::CameraEditorPlugin(EditorNode *p_node) {
-
 	editor = p_node;
-	/*	camera_editor = memnew( CameraEditor );
-	editor->get_viewport()->add_child(camera_editor);
-
-	camera_editor->set_anchor(MARGIN_LEFT,Control::ANCHOR_END);
-	camera_editor->set_anchor(MARGIN_RIGHT,Control::ANCHOR_END);
-	camera_editor->set_margin(MARGIN_LEFT,60);
-	camera_editor->set_margin(MARGIN_RIGHT,0);
-	camera_editor->set_margin(MARGIN_TOP,0);
-	camera_editor->set_margin(MARGIN_BOTTOM,10);
-
-
-	camera_editor->hide();
-*/
 }
 
 CameraEditorPlugin::~CameraEditorPlugin() {

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5263,7 +5263,6 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	undo_redo = p_editor->get_undo_redo();
 	VBoxContainer *vbc = this;
 
-	custom_camera = NULL;
 	singleton = this;
 	editor = p_editor;
 	editor_selection = editor->get_editor_selection();

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -620,8 +620,6 @@ private:
 
 	void _toggle_maximize_view(Object *p_viewport);
 
-	Node *custom_camera;
-
 	Object *_get_editor_data(Object *p_what);
 
 	Ref<Environment> viewport_environment;
@@ -680,7 +678,6 @@ public:
 	void update_all_gizmos();
 	void snap_selected_nodes_to_floor();
 	void select_gizmo_highlight_axis(int p_axis);
-	void set_custom_camera(Node *p_camera) { custom_camera = p_camera; }
 
 	void set_undo_redo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; }
 	Dictionary get_state() const;


### PR DESCRIPTION
Working on other editor plugin stuff and was confused why the set_custom_camera in the camera editor plugin wasn't doing anything. Then realized it wasn't needed anymore and is defunct. I also took the liberty to clean out some of the comments.

prrof that it still works after. I don't think the cinematic camera preview would be affected in any way but I haven't used it before so I wouldn't know.
![custom_camera](https://user-images.githubusercontent.com/3332598/44938198-6432bf80-ad4b-11e8-8a55-1c3bf51b89a0.gif)
