### PR TITLE
Fix bad res file include in VS project

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -7,6 +7,7 @@ from platform_methods import run_in_subprocess
 import platform_windows_builders
 
 common_win = [
+    "godot_win.cpp",
     "context_gl_win.cpp",
     "crash_handler_win.cpp",
     "os_windows.cpp",
@@ -17,17 +18,17 @@ common_win = [
     "windows_terminal_logger.cpp"
 ]
 
-restarget = "godot_res" + env["OBJSUFFIX"]
+res_file = 'godot_res.rc'
 
-obj = env.RES(restarget, 'godot_res.rc')
+res_target = "godot_res" + env["OBJSUFFIX"]
 
-common_win.append(obj)
+res_obj = env.RES(res_target, res_file)
 
-prog = env.add_program('#bin/godot', ['godot_win.cpp'] + common_win, PROGSUFFIX=env["PROGSUFFIX"])
+prog = env.add_program('#bin/godot', common_win + res_obj, PROGSUFFIX=env["PROGSUFFIX"])
 
 # Microsoft Visual Studio Project Generation
 if env['vsproj']:
-    env.vs_srcs = env.vs_srcs + ["platform/windows/godot_win.cpp"]
+    env.vs_srcs = env.vs_srcs + ["platform/windows/" + res_file]
     for x in common_win:
         env.vs_srcs = env.vs_srcs + ["platform/windows/" + str(x)]
 


### PR DESCRIPTION
Building with `vsproj=yes` creates a bad file reference in the VS project to `['godot_res.windows.opt.tools.64.obj']` (exact file depends on target)

![image](https://user-images.githubusercontent.com/1137273/44942964-3b321f00-ad8b-11e8-9963-155a159aa310.png)

This changes it to put the `godot_res.rc` file in the VS project instead.