### PR TITLE
[2.1] Enable autoload in editor

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -187,6 +187,8 @@ public:
 	virtual Error complete_code(const String &p_code, const String &p_base_path, Object *p_owner, List<String> *r_options, String &r_call_hint) { return ERR_UNAVAILABLE; }
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const = 0;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) = 0;
+	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) {}
+	virtual void remove_named_global_constant(const StringName &p_name) {}
 
 	/* MULTITHREAD FUNCTIONS */
 

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -50,10 +50,20 @@ class EditorAutoloadSettings : public VBoxContainer {
 
 	struct AutoLoadInfo {
 		String name;
+		String path;
+		bool is_singleton;
+		bool in_editor;
 		int order;
+		Node *node;
 
 		bool operator==(const AutoLoadInfo &p_info) {
 			return order == p_info.order;
+		}
+
+		AutoLoadInfo() {
+			is_singleton = false;
+			in_editor = false;
+			node = NULL;
 		}
 	};
 
@@ -74,6 +84,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 	void _autoload_edited();
 	void _autoload_button_pressed(Object *p_item, int p_column, int p_button);
 	void _autoload_file_callback(const String &p_path);
+	Node *_create_autoload(const String &p_path);
 
 	void _autoload_activated();
 
@@ -91,6 +102,7 @@ public:
 	void update_autoload();
 
 	EditorAutoloadSettings();
+	~EditorAutoloadSettings();
 };
 
 #endif

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5109,6 +5109,10 @@ void EditorNode::_export_godot3_path(const String &p_path) {
 
 EditorNode::EditorNode() {
 
+	PhysicsServer::get_singleton()->set_active(false); // no physics by default if editor
+	Physics2DServer::get_singleton()->set_active(false); // no physics by default if editor
+	ScriptServer::set_scripting_enabled(false); // no scripting by default if editor
+
 	EditorHelp::generate_doc(); //before any editor classes are crated
 	SceneState::set_disable_placeholders(true);
 	editor_initialize_certificates(); //for asset sharing
@@ -6287,10 +6291,6 @@ EditorNode::EditorNode() {
 	//	force_top_viewport(true);
 	_edit_current();
 	current = NULL;
-
-	PhysicsServer::get_singleton()->set_active(false); // no physics by default if editor
-	Physics2DServer::get_singleton()->set_active(false); // no physics by default if editor
-	ScriptServer::set_scripting_enabled(false); // no scripting by default if editor
 
 	Globals::get_singleton()->set("debug/indicators_enabled", true);
 	Globals::get_singleton()->set("render/room_cull_enabled", false);

--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -237,6 +237,17 @@ int GDCompiler::_parse_expression(CodeGen &codegen, const GDParser::Node *p_expr
 				return idx | (GDFunction::ADDR_TYPE_GLOBAL << GDFunction::ADDR_BITS); //argument (stack root)
 			}
 
+#ifdef TOOLS_ENABLED
+			if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(identifier)) {
+				int idx = codegen.named_globals.find(identifier);
+				if (idx == -1) {
+					idx = codegen.named_globals.size();
+					codegen.named_globals.push_back(identifier);
+				}
+				return idx | (GDFunction::ADDR_TYPE_NAMED_GLOBAL << GDFunction::ADDR_BITS);
+			}
+#endif
+
 			//not found, error
 
 			_set_error("Identifier not found: " + String(identifier), p_expression);
@@ -1354,6 +1365,18 @@ Error GDCompiler::_parse_function(GDScript *p_script, const GDParser::ClassNode 
 		gdfunc->_global_names_ptr = NULL;
 		gdfunc->_global_names_count = 0;
 	}
+
+#ifdef TOOLS_ENABLED
+	// Named globals
+	if (codegen.named_globals.size()) {
+		gdfunc->named_globals.resize(codegen.named_globals.size());
+		gdfunc->_named_globals_ptr = gdfunc->named_globals.ptr();
+		for (int i = 0; i < codegen.named_globals.size(); i++) {
+			gdfunc->named_globals[i] = codegen.named_globals[i];
+		}
+		gdfunc->_named_globals_count = gdfunc->named_globals.size();
+	}
+#endif
 
 	if (codegen.opcodes.size()) {
 

--- a/modules/gdscript/gd_compiler.h
+++ b/modules/gdscript/gd_compiler.h
@@ -93,6 +93,9 @@ class GDCompiler {
 		//int get_identifier_pos(const StringName& p_dentifier) const;
 		HashMap<Variant, int, VariantHasher, VariantComparator> constant_map;
 		Map<StringName, int> name_map;
+#ifdef TOOLS_ENABLED
+		Vector<StringName> named_globals;
+#endif
 
 		int get_name_map_pos(const StringName &p_identifier) {
 			int ret;

--- a/modules/gdscript/gd_function.cpp
+++ b/modules/gdscript/gd_function.cpp
@@ -68,6 +68,20 @@ Variant *GDFunction::_get_variant(int p_address, GDInstance *p_instance, GDScrip
 
 			return &GDScriptLanguage::get_singleton()->get_global_array()[address];
 		} break;
+#ifdef TOOLS_ENABLED
+		case ADDR_TYPE_NAMED_GLOBAL: {
+#ifdef DEBUG_ENABLED
+			ERR_FAIL_INDEX_V(address, _named_globals_count, NULL);
+#endif
+			StringName id = _named_globals_ptr[address];
+			if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(id)) {
+				return (Variant *)&GDScriptLanguage::get_singleton()->get_named_globals_map()[id];
+			} else {
+				r_error = "Autoload singleton '" + String(id) + "' has been removed.";
+				return NULL;
+			}
+		} break;
+#endif
 		case ADDR_TYPE_NIL: {
 			return &nil;
 		} break;

--- a/modules/gdscript/gd_function.h
+++ b/modules/gdscript/gd_function.h
@@ -59,7 +59,8 @@ public:
 		ADDR_TYPE_STACK = 5,
 		ADDR_TYPE_STACK_VARIABLE = 6,
 		ADDR_TYPE_GLOBAL = 7,
-		ADDR_TYPE_NIL = 8
+		ADDR_TYPE_NAMED_GLOBAL = 8,
+		ADDR_TYPE_NIL = 9
 	};
 
 	struct StackDebug {
@@ -80,6 +81,10 @@ private:
 	int _constant_count;
 	const StringName *_global_names_ptr;
 	int _global_names_count;
+#ifdef TOOLS_ENABLED
+	const StringName *_named_globals_ptr;
+	int _named_globals_count;
+#endif
 	const int *_default_arg_ptr;
 	int _default_arg_count;
 	const int *_code_ptr;
@@ -94,6 +99,9 @@ private:
 	StringName name;
 	Vector<Variant> constants;
 	Vector<StringName> global_names;
+#ifdef TOOLS_ENABLED
+	Vector<StringName> named_globals;
+#endif
 	Vector<int> default_arguments;
 	Vector<int> code;
 

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -1255,6 +1255,14 @@ void GDScriptLanguage::add_global_constant(const StringName &p_variable, const V
 	_add_global(p_variable, p_value);
 }
 
+void GDScriptLanguage::add_named_global_constant(const StringName &p_name, const Variant &p_value) {
+	named_globals[p_name] = p_value;
+}
+void GDScriptLanguage::remove_named_global_constant(const StringName &p_name) {
+	ERR_FAIL_COND(!named_globals.has(p_name));
+	named_globals.erase(p_name);
+}
+
 void GDScriptLanguage::init() {
 
 	//populate global constants

--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -235,6 +235,7 @@ class GDScriptLanguage : public ScriptLanguage {
 	Variant *_global_array;
 	Vector<Variant> global_array;
 	Map<StringName, int> globals;
+	Map<StringName, Variant> named_globals;
 
 	struct CallLevel {
 
@@ -338,7 +339,8 @@ public:
 
 	_FORCE_INLINE_ int get_global_array_size() const { return global_array.size(); }
 	_FORCE_INLINE_ Variant *get_global_array() { return _global_array; }
-	_FORCE_INLINE_ const Map<StringName, int> &get_global_map() { return globals; }
+	_FORCE_INLINE_ const Map<StringName, int> &get_global_map() const { return globals; }
+	_FORCE_INLINE_ const Map<StringName, Variant> &get_named_globals_map() const { return named_globals; }
 
 	_FORCE_INLINE_ static GDScriptLanguage *get_singleton() { return singleton; }
 
@@ -366,6 +368,8 @@ public:
 	virtual Error complete_code(const String &p_code, const String &p_base_path, Object *p_owner, List<String> *r_options, String &r_call_hint);
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value);
+	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value);
+	virtual void remove_named_global_constant(const StringName &p_name);
 
 	/* DEBUGGER FUNCTIONS */
 


### PR DESCRIPTION
- Tool scripts will be executed and can be accessed by plugins.
- Other script languages can implement add/remove_named_global_constant
to make use of this functionality.
Thanks @vnen for the great work.
(cherry picked from commits decf178 and 55b4b30 and ed3776c)