### PR TITLE
Update Comments in core/typedefs.h

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -33,9 +33,7 @@
 
 #include <stddef.h>
 
-/**
- * Basic definitions and simple functions to be used everywhere.
- */
+// Basic definitions and simple functions to be used everywhere.
 
 #include "platform_config.h"
 
@@ -44,7 +42,7 @@
 #define _MKSTR(m_x) _STR(m_x)
 #endif
 
-//should always inline no matter what
+// Should always inline no matter what
 #ifndef _ALWAYS_INLINE_
 
 #if defined(__GNUC__) && (__GNUC__ >= 4)
@@ -59,7 +57,7 @@
 
 #endif
 
-//should always inline, except in some cases because it makes debugging harder
+// Should always inline, except in some cases because it makes debugging harder
 #ifndef _FORCE_INLINE_
 
 #ifdef DISABLE_FORCED_INLINE
@@ -70,7 +68,7 @@
 
 #endif
 
-//custom, gcc-safe offsetof, because gcc complains a lot.
+// Custom, gcc-safe offsetof, because gcc complains a lot.
 template <class T>
 T *_nullptr() {
 	T *t = NULL;
@@ -79,18 +77,13 @@ T *_nullptr() {
 
 #define OFFSET_OF(st, m) \
 	((size_t)((char *)&(_nullptr<st>()->m) - (char *)0))
-/**
- * Some platforms (devices) don't define NULL
- */
 
+// Some platforms (devices) don't define NULL
 #ifndef NULL
 #define NULL 0
 #endif
 
-/**
- * Windows badly defines a lot of stuff we'll never use. Undefine it.
- */
-
+// Windows badly defines a lot of stuff we'll never use. Undefine it.
 #ifdef _WIN32
 #undef min // override standard definition
 #undef max // override standard definition
@@ -110,43 +103,41 @@ T *_nullptr() {
 #include "core/error_list.h"
 #include "core/error_macros.h"
 
-/** Generic ABS function, for math uses please use Math::abs */
-
+// Generic Math functions (useful when speed is of high importance, else use Math::abs etc.)
 #ifndef ABS
-#define ABS(m_v) (((m_v) < 0) ? (-(m_v)) : (m_v))
+#define ABS(m_v) ((m_v < 0) ? (-m_v) : m_v)
 #endif
 
 #define ABSDIFF(x, y) (((x) < (y)) ? ((y) - (x)) : ((x) - (y)))
 
 #ifndef SGN
-#define SGN(m_v) (((m_v) < 0) ? (-1.0) : (+1.0))
+#define SGN(m_v) ((m_v < 0) ? -1.0 : +1.0)
 #endif
 
 #ifndef MIN
-#define MIN(m_a, m_b) (((m_a) < (m_b)) ? (m_a) : (m_b))
+#define MIN(m_a, m_b) ((m_a < m_b) ? m_a : m_b)
 #endif
 
 #ifndef MAX
-#define MAX(m_a, m_b) (((m_a) > (m_b)) ? (m_a) : (m_b))
+#define MAX(m_a, m_b) ((m_a > m_b) ? m_a : m_b)
 #endif
 
 #ifndef CLAMP
-#define CLAMP(m_a, m_min, m_max) (((m_a) < (m_min)) ? (m_min) : (((m_a) > (m_max)) ? m_max : m_a))
+#define CLAMP(m_a, m_min, m_max) ((m_a < m_min) ? m_min : ((m_a > m_max) ? m_max : m_a))
 #endif
 
-/** Generic swap template */
+// Generic swap template
 #ifndef SWAP
 
 #define SWAP(m_x, m_y) __swap_tmpl((m_x), (m_y))
 template <class T>
 inline void __swap_tmpl(T &x, T &y) {
-
 	T aux = x;
 	x = y;
 	y = aux;
 }
 
-#endif //swap
+#endif // SWAP
 
 /* clang-format off */
 #define HEX2CHR(m_hex) \
@@ -155,8 +146,7 @@ inline void __swap_tmpl(T &x, T &y) {
 	((m_hex >= 'a' && m_hex <= 'f') ? (10 + m_hex - 'a') : 0)))
 /* clang-format on */
 
-// Macro to check whether we are compiled by clang
-// and we have a specific builtin
+// Macro to check whether we are compiled by clang and we have a specific builtin
 #if defined(__llvm__) && defined(__has_builtin)
 #define _llvm_has_builtin(x) __has_builtin(x)
 #else
@@ -171,10 +161,8 @@ inline void __swap_tmpl(T &x, T &y) {
 #define _add_overflow __builtin_add_overflow
 #endif
 
-/** Function to find the next power of 2 to an integer */
-
+// Function to find the power of 2 greater than or equal to an int
 static _FORCE_INLINE_ unsigned int next_power_of_2(unsigned int x) {
-
 	--x;
 	x |= x >> 1;
 	x |= x >> 2;
@@ -185,34 +173,52 @@ static _FORCE_INLINE_ unsigned int next_power_of_2(unsigned int x) {
 	return ++x;
 }
 
+// Function to find the power of 2 less than or equal to an int
 static _FORCE_INLINE_ unsigned int previous_power_of_2(unsigned int x) {
-
 	x |= x >> 1;
 	x |= x >> 2;
 	x |= x >> 4;
 	x |= x >> 8;
 	x |= x >> 16;
+
 	return x - (x >> 1);
 }
 
+// Find the power of 2 closest to an integer, rounding up at midpoint
 static _FORCE_INLINE_ unsigned int closest_power_of_2(unsigned int x) {
-
 	unsigned int nx = next_power_of_2(x);
 	unsigned int px = previous_power_of_2(x);
 	return (nx - x) > (x - px) ? px : nx;
 }
 
-// We need this definition inside the function below.
-static inline int get_shift_from_power_of_2(unsigned int p_pixel);
+// Get a shift value of a power of 2
+static inline int get_shift_from_power_of_2(unsigned int p_pixel) {
+	// return a GL_TEXTURE_SIZE_ENUM
+
+	for (int i = 0; i < 32; i++) {
+		if (p_pixel & (unsigned int)(1 << i))
+			return i;
+	}
+
+	return -1;
+}
+
+// Get the shift value of the power of 2 greater than an int
+static inline unsigned int nearest_shift(unsigned int p_number) {
+	for (int i = 30; i >= 0; i--) {
+		if (p_number & (unsigned int)(1 << i))
+			return i + 1;
+	}
+
+	return 0;
+}
 
 template <class T>
 static _FORCE_INLINE_ T nearest_power_of_2_templated(T x) {
-
 	--x;
 
-	// The number of operations on x is the base two logarithm
-	// of the p_number of bits in the type. Add three to account
-	// for sizeof(T) being in bytes.
+	// The number of operations on x is the base two logarithm of the number of bits in the type.
+	// Add three to convert sizeof(T), which is in bytes, to bits.
 	size_t num = get_shift_from_power_of_2(sizeof(T)) + 3;
 
 	// If the compiler is smart, it unrolls this loop
@@ -223,33 +229,7 @@ static _FORCE_INLINE_ T nearest_power_of_2_templated(T x) {
 	return ++x;
 }
 
-/** Function to find the nearest (bigger) power of 2 to an integer */
-
-static inline unsigned int nearest_shift(unsigned int p_number) {
-
-	for (int i = 30; i >= 0; i--) {
-
-		if (p_number & (1 << i))
-			return i + 1;
-	}
-
-	return 0;
-}
-
-/** get a shift value from a power of 2 */
-static inline int get_shift_from_power_of_2(unsigned int p_pixel) {
-	// return a GL_TEXTURE_SIZE_ENUM
-
-	for (unsigned int i = 0; i < 32; i++) {
-
-		if (p_pixel == (unsigned int)(1 << i))
-			return i;
-	}
-
-	return -1;
-}
-
-/** Swap 16 bits value for endianness */
+// Swap 16 bits value for endianness
 #if defined(__GNUC__) || _llvm_has_builtin(__builtin_bswap16)
 #define BSWAP16(x) __builtin_bswap16(x)
 #else
@@ -258,7 +238,7 @@ static inline uint16_t BSWAP16(uint16_t x) {
 }
 #endif
 
-/** Swap 32 bits value for endianness */
+// Swap 32 bits value for endianness
 #if defined(__GNUC__) || _llvm_has_builtin(__builtin_bswap32)
 #define BSWAP32(x) __builtin_bswap32(x)
 #else
@@ -267,26 +247,20 @@ static inline uint32_t BSWAP32(uint32_t x) {
 }
 #endif
 
-/** Swap 64 bits value for endianness */
+// Swap 64 bits value for endianness
 #if defined(__GNUC__) || _llvm_has_builtin(__builtin_bswap64)
 #define BSWAP64(x) __builtin_bswap64(x)
 #else
 static inline uint64_t BSWAP64(uint64_t x) {
-	x = (x & 0x00000000FFFFFFFF) << 32 | (x & 0xFFFFFFFF00000000) >> 32;
+	x = (x << 32) | (x >> 32);
 	x = (x & 0x0000FFFF0000FFFF) << 16 | (x & 0xFFFF0000FFFF0000) >> 16;
 	x = (x & 0x00FF00FF00FF00FF) << 8 | (x & 0xFF00FF00FF00FF00) >> 8;
 	return x;
 }
 #endif
 
-/** When compiling with RTTI, we can add an "extra"
- * layer of safeness in many operations, so dynamic_cast
- * is used besides casting by enum.
- */
-
 template <class T>
 struct Comparator {
-
 	_ALWAYS_INLINE_ bool operator()(const T &p_a, const T &p_b) const { return (p_a < p_b); }
 };
 
@@ -294,13 +268,14 @@ void _global_lock();
 void _global_unlock();
 
 struct _GlobalLock {
-
 	_GlobalLock() { _global_lock(); }
 	~_GlobalLock() { _global_unlock(); }
 };
 
 #define GLOBAL_LOCK_FUNCTION _GlobalLock _global_lock_;
 
+// When compiling with RTTI, we can add an "extra" layer of safeness in many operations,
+// so dynamic_cast is used besides casting by enum.
 #ifdef NO_SAFE_CAST
 #define SAFE_CAST static_cast
 #else


### PR DESCRIPTION
Increased readability by:
- Updating comment blocks
- Maintaining consistency (See function `BSWAP64`)

Update:
- Removed excess bracketing in the math functions.
- Moved some functions around to remove the extra `get_shift_from_power_of_2` declaration.