### PR TITLE
added get_camera_method to spatial editor plugin viewport

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -406,6 +406,7 @@ public:
 			AcceptDialog *p_accept);
 
 	Viewport *get_viewport_node() { return viewport; }
+	Camera *get_camera() { return camera; } // return the default camera object.
 
 	SpatialEditorViewport(SpatialEditor *p_spatial_editor, EditorNode *p_editor, int p_index);
 };
@@ -710,7 +711,6 @@ public:
 
 	void register_gizmo_plugin(Ref<EditorSpatialGizmoPlugin> ref);
 
-	Camera *get_camera() { return NULL; }
 	void edit(Spatial *p_spatial);
 	void clear();
 


### PR DESCRIPTION
removed defunct get_camera method. not called anywhere else. 
added get_camera method to the spatial editor viewports. 
was necessary to allow me to reset the spatial editor default 0 viewport after I had been using it to generate my spritesheets.
https://github.com/godotengine/godot/issues/21269