### PR TITLE
Allow empty divisors in String.split() and String.rsplit()

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -738,7 +738,15 @@ Vector<String> String::split(const String &p_splitter, bool p_allow_empty, int p
 
 	while (true) {
 
-		int end = find(p_splitter, from);
+		int end;
+
+		if (p_splitter == "") {
+			// Split on every byte if the divisor is empty
+			end = from + 1;
+		} else {
+			end = find(p_splitter, from);
+		}
+
 		if (end < 0)
 			end = len;
 		if (p_allow_empty || (end > from)) {
@@ -782,7 +790,14 @@ Vector<String> String::rsplit(const String &p_splitter, bool p_allow_empty, int 
 			break;
 		}
 
-		int left_edge = rfind(p_splitter, remaining_len - p_splitter.length());
+		int left_edge;
+
+		if (p_splitter == "") {
+			// Split on every byte if the divisor is empty
+			left_edge = remaining_len - p_splitter.length() - 1;
+		} else {
+			left_edge = rfind(p_splitter, remaining_len - p_splitter.length());
+		}
 
 		if (left_edge < 0) {
 			// no more splitters, we're done

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -653,9 +653,10 @@
 			<argument index="2" name="maxsplit" type="int" default="0">
 			</argument>
 			<description>
-				Splits the string by a [code]divisor[/code] string and returns an array of the substrings, starting from right.
+				Splits the string by a [code]divisor[/code] string and returns an array of the substrings, starting from the right.
 				[b]Example:[/b] "One,Two,Three" will return ["One","Two","Three"] if split by ",".
-				If [code]maxsplit[/code] is specified, then it is number of splits to do, default is 0 which splits all the items.
+				If [code]divisor[/code] is an empty string, then the string is split on every byte.
+				If [code]maxsplit[/code] is given, at most [code]maxsplit[/code] number of splits occur, and the remainder of the string is returned as the first element of the list (thus, the list will have at most [code]maxsplit[/code] + 1 elements).
 			</description>
 		</method>
 		<method name="rstrip">
@@ -701,7 +702,8 @@
 			<description>
 				Splits the string by a divisor string and returns an array of the substrings.
 				[b]Example:[/b] "One,Two,Three" will return ["One","Two","Three"] if split by ",".
-				If [code]maxsplit[/code] is given, at most maxsplit number of splits occur, and the remainder of the string is returned as the final element of the list (thus, the list will have at most maxsplit+1 elements)
+				If [code]divisor[/code] is an empty string, then the string is split on every byte.
+				If [code]maxsplit[/code] is given, at most [code]maxsplit[/code] number of splits occur, and the remainder of the string is returned as the last element of the list (thus, the list will have at most [code]maxsplit[/code] + 1 elements).
 			</description>
 		</method>
 		<method name="split_floats">


### PR DESCRIPTION
If an empty string is passed as a divisor to either of those functions, then the string will be splitted on every byte.

This is similar to `String.split("")` in JavaScript, for instance.