### PR TITLE
Fix selection of instanced scenes in 3D

### DIFF
--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -215,8 +215,8 @@ void PathSpatialGizmo::redraw() {
 
 	clear();
 
-	Ref<SpatialMaterial> path_material = gizmo_plugin->get_material("path_material");
-	Ref<SpatialMaterial> path_thin_material = gizmo_plugin->get_material("path_thin_material");
+	Ref<SpatialMaterial> path_material = gizmo_plugin->get_material("path_material", this);
+	Ref<SpatialMaterial> path_thin_material = gizmo_plugin->get_material("path_thin_material", this);
 	Ref<SpatialMaterial> handles_material = gizmo_plugin->get_material("handles");
 
 	Ref<Curve3D> c = path->get_curve();
@@ -641,24 +641,8 @@ String PathSpatialGizmoPlugin::get_name() const {
 PathSpatialGizmoPlugin::PathSpatialGizmoPlugin() {
 
 	Color path_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/path", Color(0.5, 0.5, 1.0, 0.8));
-
-	Ref<SpatialMaterial> path_material = Ref<SpatialMaterial>(memnew(SpatialMaterial));
-	path_color.a = 0.8;
-	path_material->set_albedo(path_color);
-	path_material->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, true);
-	path_material->set_line_width(3);
-	path_material->set_cull_mode(SpatialMaterial::CULL_DISABLED);
-	path_material->set_flag(SpatialMaterial::FLAG_UNSHADED, true);
-
-	Ref<SpatialMaterial> path_thin_material = Ref<SpatialMaterial>(memnew(SpatialMaterial));
+	create_material("path_material", path_color);
 	path_color.a = 0.4;
-	path_thin_material->set_albedo(path_color);
-	path_thin_material->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, true);
-	path_thin_material->set_line_width(1);
-	path_thin_material->set_cull_mode(SpatialMaterial::CULL_DISABLED);
-	path_thin_material->set_flag(SpatialMaterial::FLAG_UNSHADED, true);
-
-	add_material("path_material", path_material);
-	add_material("path_thin_material", path_thin_material);
+	create_material("path_thin_material", path_color);
 	create_handle_material("handles");
 }

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -274,7 +274,7 @@ void SpatialEditorViewport::_select_clicked(bool p_append, bool p_single) {
 	_select(sp, clicked_wants_append, true);
 }
 
-void SpatialEditorViewport::_select(Spatial *p_node, bool p_append, bool p_single) {
+void SpatialEditorViewport::_select(Node *p_node, bool p_append, bool p_single) {
 
 	if (!p_append) {
 		editor_selection->clear();
@@ -340,12 +340,10 @@ ObjectID SpatialEditorViewport::_select_ray(const Point2 &p_pos, bool p_append, 
 			continue;
 
 		if (dist < closest_dist) {
-			//make sure that whathever is selected is editable
-			Node *owner = spat->get_owner();
-			if (owner != edited_scene && !edited_scene->is_editable_instance(owner)) {
-				item = owner;
-			} else {
-				item = Object::cast_to<Node>(spat);
+
+			item = Object::cast_to<Node>(spat);
+			while (item->get_owner() && item->get_owner() != edited_scene && !edited_scene->is_editable_instance(item->get_owner())) {
+				item = item->get_owner();
 			}
 
 			closest = item->get_instance_id();
@@ -496,7 +494,7 @@ void SpatialEditorViewport::_select_region() {
 	}
 
 	Vector<ObjectID> instances = VisualServer::get_singleton()->instances_cull_convex(frustum, get_tree()->get_root()->get_world()->get_scenario());
-	Vector<Spatial *> selected;
+	Vector<Node *> selected;
 
 	Node *edited_scene = get_tree()->get_edited_scene_root();
 
@@ -506,12 +504,12 @@ void SpatialEditorViewport::_select_region() {
 		if (!sp)
 			continue;
 
-		Spatial *root_sp = sp;
-		while (root_sp && root_sp != edited_scene && root_sp->get_owner() != edited_scene && !edited_scene->is_editable_instance(root_sp->get_owner())) {
-			root_sp = Object::cast_to<Spatial>(root_sp->get_owner());
+		Node *item = Object::cast_to<Node>(sp);
+		while (item->get_owner() && item->get_owner() != edited_scene && !edited_scene->is_editable_instance(item->get_owner())) {
+			item = item->get_owner();
 		}
 
-		if (selected.find(root_sp) != -1) continue;
+		if (selected.find(item) != -1) continue;
 
 		Ref<EditorSpatialGizmo> seg = sp->get_gizmo();
 
@@ -519,7 +517,7 @@ void SpatialEditorViewport::_select_region() {
 			continue;
 
 		if (seg->intersect_frustum(camera, frustum)) {
-			selected.push_back(root_sp);
+			selected.push_back(item);
 		}
 	}
 
@@ -3911,8 +3909,9 @@ void _update_all_gizmos(Node *p_node) {
 	}
 }
 
-void SpatialEditor::update_all_gizmos() {
-	_update_all_gizmos(SceneTree::get_singleton()->get_root());
+void SpatialEditor::update_all_gizmos(Node *p_node) {
+	if (!p_node) p_node = SceneTree::get_singleton()->get_root();
+	_update_all_gizmos(p_node);
 }
 
 Object *SpatialEditor::_get_editor_data(Object *p_what) {
@@ -5662,7 +5661,7 @@ SpatialEditorPlugin::~SpatialEditorPlugin() {
 
 void EditorSpatialGizmoPlugin::create_material(const String &p_name, const Color &p_color, bool p_billboard, bool p_on_top, bool p_use_vertex_color) {
 
-	Color instanced_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/instanced", Color(0.7, 0.7, 0.7, 0.5));
+	Color instanced_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/instanced", Color(0.7, 0.7, 0.7, 0.6));
 
 	Vector<Ref<SpatialMaterial> > mats;
 
@@ -5704,7 +5703,7 @@ void EditorSpatialGizmoPlugin::create_material(const String &p_name, const Color
 
 void EditorSpatialGizmoPlugin::create_icon_material(const String &p_name, const Ref<Texture> &p_texture, bool p_on_top, const Color &p_albedo) {
 
-	Color instanced_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/instanced", Color(0.7, 0.7, 0.7, 0.5));
+	Color instanced_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/instanced", Color(0.7, 0.7, 0.7, 0.6));
 
 	Vector<Ref<SpatialMaterial> > icons;
 
@@ -5717,7 +5716,7 @@ void EditorSpatialGizmoPlugin::create_icon_material(const String &p_name, const 
 		Color color = instanced ? instanced_color : p_albedo;
 
 		if (!selected) {
-			color.a *= 0.3;
+			color.a *= 0.85;
 		}
 
 		icon->set_albedo(color);

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -127,9 +127,7 @@ public:
 	virtual void redraw();
 	virtual void free();
 
-	//TODO remove (?)
 	virtual bool is_editable() const;
-	virtual bool can_draw() const;
 
 	void set_hidden(bool p_hidden);
 	void set_plugin(EditorSpatialGizmoPlugin *p_gizmo);
@@ -226,7 +224,7 @@ private:
 	void _compute_edit(const Point2 &p_point);
 	void _clear_selected();
 	void _select_clicked(bool p_append, bool p_single);
-	void _select(Spatial *p_node, bool p_append, bool p_single);
+	void _select(Node *p_node, bool p_append, bool p_single);
 	ObjectID _select_ray(const Point2 &p_pos, bool p_append, bool &r_includes_current, int *r_gizmo_handle = NULL, bool p_alt_select = false);
 	void _find_items_at_pos(const Point2 &p_pos, bool &r_includes_current, Vector<_RayResult> &results, bool p_alt_select = false);
 	Vector3 _get_ray_pos(const Vector2 &p_pos) const;
@@ -677,7 +675,7 @@ public:
 	Ref<ArrayMesh> get_scale_plane_gizmo(int idx) const { return scale_plane_gizmo[idx]; }
 
 	void update_transform_gizmo();
-	void update_all_gizmos();
+	void update_all_gizmos(Node *p_node = NULL);
 	void snap_selected_nodes_to_floor();
 	void select_gizmo_highlight_axis(int p_axis);
 	void set_custom_camera(Node *p_camera) { custom_camera = p_camera; }

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -720,6 +720,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						node->set_scene_instance_load_placeholder(false);
 						menu->set_item_checked(placeholder_item_idx, false);
 					}
+
+					SpatialEditor::get_singleton()->update_all_gizmos(node);
+
 					scene_tree->update_tree();
 				}
 			}

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -52,9 +52,6 @@
 
 #define HANDLE_HALF_SIZE 9.5
 
-bool EditorSpatialGizmo::can_draw() const {
-	return is_editable();
-}
 bool EditorSpatialGizmo::is_editable() const {
 
 	ERR_FAIL_COND_V(!spatial_node, false);

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -185,10 +185,8 @@ void Spatial::_notification(int p_what) {
 
 					if (data.gizmo.is_valid()) {
 						data.gizmo->create();
-						if (data.gizmo->can_draw()) {
-							if (is_visible_in_tree()) {
-								data.gizmo->redraw();
-							}
+						if (is_visible_in_tree()) {
+							data.gizmo->redraw();
 						}
 						data.gizmo->transform();
 					}
@@ -423,10 +421,8 @@ void Spatial::set_gizmo(const Ref<SpatialGizmo> &p_gizmo) {
 	if (data.gizmo.is_valid() && is_inside_world()) {
 
 		data.gizmo->create();
-		if (data.gizmo->can_draw()) {
-			if (is_visible_in_tree()) {
-				data.gizmo->redraw();
-			}
+		if (is_visible_in_tree()) {
+			data.gizmo->redraw();
 		}
 		data.gizmo->transform();
 	}
@@ -452,12 +448,10 @@ void Spatial::_update_gizmo() {
 		return;
 	data.gizmo_dirty = false;
 	if (data.gizmo.is_valid()) {
-		if (data.gizmo->can_draw()) {
-			if (is_visible_in_tree())
-				data.gizmo->redraw();
-			else
-				data.gizmo->clear();
-		}
+		if (is_visible_in_tree())
+			data.gizmo->redraw();
+		else
+			data.gizmo->clear();
 	}
 #endif
 }

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -48,7 +48,6 @@ public:
 	virtual void clear() = 0;
 	virtual void redraw() = 0;
 	virtual void free() = 0;
-	virtual bool can_draw() const = 0;
 
 	SpatialGizmo();
 	virtual ~SpatialGizmo() {}


### PR DESCRIPTION
Selecting an object inside an instanced scene will select the scene's root, unless the scene has "editable children" enabled.

Should close #21649.