### PR TITLE
Increase project input map tree column sizes to show all icons

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1843,9 +1843,9 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	input_editor->set_column_title(0, TTR("Action"));
 	input_editor->set_column_title(1, TTR("Deadzone"));
 	input_editor->set_column_expand(1, false);
-	input_editor->set_column_min_width(1, 80);
+	input_editor->set_column_min_width(1, 160);
 	input_editor->set_column_expand(2, false);
-	input_editor->set_column_min_width(2, 50);
+	input_editor->set_column_min_width(2, 100);
 	input_editor->connect("item_edited", this, "_action_edited");
 	input_editor->connect("item_activated", this, "_action_activated");
 	input_editor->connect("cell_selected", this, "_action_selected");


### PR DESCRIPTION
Previously the add / remove key icons would be shown overlapped
with the deadzone control, which means you couldn't really add a new
key, because clicking on the add icon would trigger editing the
deadzone control.

Increase the minimum width of the tree columns, to make sure that
all icons fit.

Before screenshot:
<img width="1277" alt="screen shot 2018-09-03 at 01 00 36" src="https://user-images.githubusercontent.com/252084/44961670-487b1500-af15-11e8-945d-f95e123d5e62.png">

After screenshot:
<img width="1270" alt="screen shot 2018-09-03 at 00 59 46" src="https://user-images.githubusercontent.com/252084/44961672-4e70f600-af15-11e8-8690-7e5ff647e4e9.png">

_Bugsquad edit: fixes #20898_ 
