### PR TITLE
Improved support for custom image loaders

### DIFF
--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -60,7 +60,7 @@ Error ImageLoader::load_image(String p_file, Ref<Image> p_image, FileAccess *p_c
 
 	String extension = p_file.get_extension();
 
-	for (int i = 0; i < loader_count; i++) {
+	for (int i = 0; i < loader.size(); i++) {
 
 		if (!loader[i]->recognize(extension))
 			continue;
@@ -83,30 +83,45 @@ Error ImageLoader::load_image(String p_file, Ref<Image> p_image, FileAccess *p_c
 
 void ImageLoader::get_recognized_extensions(List<String> *p_extensions) {
 
-	for (int i = 0; i < loader_count; i++) {
+	for (int i = 0; i < loader.size(); i++) {
 
 		loader[i]->get_recognized_extensions(p_extensions);
 	}
 }
 
-bool ImageLoader::recognize(const String &p_extension) {
+ImageFormatLoader *ImageLoader::recognize(const String &p_extension) {
 
-	for (int i = 0; i < loader_count; i++) {
+	for (int i = 0; i < loader.size(); i++) {
 
 		if (loader[i]->recognize(p_extension))
-			return true;
+			return loader[i];
 	}
 
-	return false;
+	return NULL;
 }
 
-ImageFormatLoader *ImageLoader::loader[MAX_LOADERS];
-int ImageLoader::loader_count = 0;
+Vector<ImageFormatLoader *> ImageLoader::loader;
 
 void ImageLoader::add_image_format_loader(ImageFormatLoader *p_loader) {
 
-	ERR_FAIL_COND(loader_count >= MAX_LOADERS);
-	loader[loader_count++] = p_loader;
+	loader.push_back(p_loader);
+}
+
+void ImageLoader::remove_image_format_loader(ImageFormatLoader *p_loader) {
+
+	loader.erase(p_loader);
+}
+
+const Vector<ImageFormatLoader *> &ImageLoader::get_image_format_loaders() {
+
+	return loader;
+}
+
+void ImageLoader::cleanup() {
+
+	while (loader.size()) {
+		remove_image_format_loader(loader[0]);
+	}
 }
 
 /////////////////
@@ -137,7 +152,7 @@ RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_origin
 
 	int idx = -1;
 
-	for (int i = 0; i < ImageLoader::loader_count; i++) {
+	for (int i = 0; i < ImageLoader::loader.size(); i++) {
 		if (ImageLoader::loader[i]->recognize(extension)) {
 			idx = i;
 			break;

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -70,20 +70,21 @@ public:
 
 class ImageLoader {
 
-	enum {
-		MAX_LOADERS = 32
-	};
+	static Vector<ImageFormatLoader *> loader;
 	friend class ResourceFormatLoaderImage;
-	static ImageFormatLoader *loader[MAX_LOADERS];
-	static int loader_count;
 
 protected:
 public:
 	static Error load_image(String p_file, Ref<Image> p_image, FileAccess *p_custom = NULL, bool p_force_linear = false, float p_scale = 1.0);
 	static void get_recognized_extensions(List<String> *p_extensions);
-	static bool recognize(const String &p_extension);
+	static ImageFormatLoader *recognize(const String &p_extension);
 
 	static void add_image_format_loader(ImageFormatLoader *p_loader);
+	static void remove_image_format_loader(ImageFormatLoader *p_loader);
+
+	static const Vector<ImageFormatLoader *> &get_image_format_loaders();
+
+	static void cleanup();
 };
 
 class ResourceFormatLoaderImage : public ResourceFormatLoader {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1992,6 +1992,8 @@ void Main::cleanup() {
 		memdelete(arvr_server);
 	}
 
+	ImageLoader::cleanup();
+
 	unregister_driver_types();
 	unregister_module_types();
 	unregister_platform_apis();


### PR DESCRIPTION
The fixup for #19374 which I messed up but have cleaned up here.

Removed image loader limit. Support to add/remove/find/list image loaders. Resolves both #19322 and #19037

@reduz can you check this now. Ta