### PR TITLE
Refactor editor icon retrieval

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -30,6 +30,8 @@
 
 #include "animation_bezier_editor.h"
 
+#include "editor/editor_node.h"
+
 float AnimationBezierTrackEdit::_bezier_h_to_pixel(float p_h) {
 	float h = p_h;
 	h = (h - v_scroll) / v_zoom;
@@ -288,12 +290,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			int h = font->get_height();
 
 			if (node) {
-				Ref<Texture> icon;
-				if (has_icon(node->get_class(), "EditorIcons")) {
-					icon = get_icon(node->get_class(), "EditorIcons");
-				} else {
-					icon = get_icon("Node", "EditorIcons");
-				}
+				Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(node, "Node");
 
 				h = MAX(h, icon->get_height());
 

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -60,7 +60,7 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode) {
 
 				TreeItem *ti = recent->create_item(root);
 				ti->set_text(0, l);
-				ti->set_icon(0, _get_editor_icon(l));
+				ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(l, base_type));
 			}
 		}
 
@@ -151,41 +151,6 @@ void CreateDialog::_sbox_input(const Ref<InputEvent> &p_ie) {
 	}
 }
 
-Ref<Texture> CreateDialog::_get_editor_icon(const String &p_type) const {
-
-	if (has_icon(p_type, "EditorIcons")) {
-		return get_icon(p_type, "EditorIcons");
-	}
-
-	if (ScriptServer::is_global_class(p_type)) {
-		String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(p_type);
-		RES icon;
-		if (FileAccess::exists(icon_path)) {
-			icon = ResourceLoader::load(icon_path);
-		}
-		if (!icon.is_valid()) {
-			icon = get_icon(ScriptServer::get_global_class_base(p_type), "EditorIcons");
-		}
-		return icon;
-	}
-
-	const Map<String, Vector<EditorData::CustomType> > &p_map = EditorNode::get_editor_data().get_custom_types();
-	for (const Map<String, Vector<EditorData::CustomType> >::Element *E = p_map.front(); E; E = E->next()) {
-		const Vector<EditorData::CustomType> &ct = E->value();
-		for (int i = 0; i < ct.size(); ++i) {
-			if (ct[i].name == p_type) {
-				if (ct[i].icon.is_valid()) {
-					return ct[i].icon;
-				} else {
-					return get_icon("Object", "EditorIcons");
-				}
-			}
-		}
-	}
-
-	return get_icon("Object", "EditorIcons");
-}
-
 void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p_types, TreeItem *p_root, TreeItem **to_select) {
 
 	if (p_types.has(p_type))
@@ -246,7 +211,10 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 		to_select_type = to_select_type.split(" ")[0];
 		bool current_item_is_preferred;
 		if (cpp_type) {
-			current_item_is_preferred = ClassDB::is_parent_class(p_type, preferred_search_result_type) && !ClassDB::is_parent_class(to_select_type, preferred_search_result_type) && search_box->get_text() != to_select_type;
+			String cpp_to_select_type = to_select_type;
+			if (ScriptServer::is_global_class(to_select_type))
+				cpp_to_select_type = ScriptServer::get_global_class_base(to_select_type);
+			current_item_is_preferred = ClassDB::is_parent_class(p_type, preferred_search_result_type) && !ClassDB::is_parent_class(cpp_to_select_type, preferred_search_result_type);
 		} else {
 			current_item_is_preferred = ed.script_class_is_parent(p_type, preferred_search_result_type) && !ed.script_class_is_parent(to_select_type, preferred_search_result_type) && search_box->get_text() != to_select_type;
 		}
@@ -274,7 +242,7 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 	const String &description = EditorHelp::get_doc_data()->class_list[p_type].brief_description;
 	item->set_tooltip(0, description);
 
-	item->set_icon(0, _get_editor_icon(p_type));
+	item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, base_type));
 
 	p_types[p_type] = item;
 }
@@ -578,7 +546,7 @@ void CreateDialog::_update_favorite_list() {
 			continue;
 		TreeItem *ti = favorites->create_item(root);
 		ti->set_text(0, l);
-		ti->set_icon(0, _get_editor_icon(l));
+		ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(l, base_type));
 	}
 	emit_signal("favorites_updated");
 }

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -198,12 +198,7 @@ void DependencyEditor::_update_list() {
 		}
 		String name = path.get_file();
 
-		Ref<Texture> icon;
-		if (has_icon(type, "EditorIcons")) {
-			icon = get_icon(type, "EditorIcons");
-		} else {
-			icon = get_icon("Object", "EditorIcons");
-		}
+		Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(type);
 		item->set_text(0, name);
 		item->set_icon(0, icon);
 		item->set_metadata(0, type);
@@ -346,13 +341,7 @@ void DependencyEditorOwners::_fill_owners(EditorFileSystemDirectory *efsd) {
 		if (!found)
 			continue;
 
-		Ref<Texture> icon;
-		String type = efsd->get_file_type(i);
-		if (!has_icon(type, "EditorIcons")) {
-			icon = get_icon("Object", "EditorIcons");
-		} else {
-			icon = get_icon(type, "EditorIcons");
-		}
+		Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(efsd->get_file_type(i));
 
 		owners->add_item(efsd->get_file_path(i), icon);
 	}
@@ -460,7 +449,7 @@ void DependencyRemoveDialog::_build_removed_dependency_tree(const Vector<Removed
 		}
 
 		//List this file under this dependency
-		Ref<Texture> icon = has_icon(rd.file_type, "EditorIcons") ? get_icon(rd.file_type, "EditorIcons") : get_icon("Object", "EditorIcons");
+		Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(rd.file_type);
 		TreeItem *file_item = owners->create_item(tree_items[rd.dependency]);
 		file_item->set_text(0, rd.file);
 		file_item->set_icon(0, icon);
@@ -579,12 +568,7 @@ void DependencyErrorDialog::show(const String &p_for_file, const Vector<String> 
 		if (report[i].get_slice_count("::") > 0)
 			type = report[i].get_slice("::", 1);
 
-		Ref<Texture> icon;
-		if (!has_icon(type, "EditorIcons")) {
-			icon = get_icon("Object", "EditorIcons");
-		} else {
-			icon = get_icon(type, "EditorIcons");
-		}
+		Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(type);
 
 		TreeItem *ti = files->create_item(root);
 		ti->set_text(0, dep);
@@ -687,12 +671,7 @@ bool OrphanResourcesDialog::_fill_owners(EditorFileSystemDirectory *efsd, HashMa
 
 				String type = efsd->get_file_type(i);
 
-				Ref<Texture> icon;
-				if (has_icon(type, "EditorIcons")) {
-					icon = get_icon(type, "EditorIcons");
-				} else {
-					icon = get_icon("Object", "EditorIcons");
-				}
+				Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(type);
 				ti->set_icon(0, icon);
 				int ds = efsd->get_file_deps(i).size();
 				ti->set_text(1, itos(ds));

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -765,10 +765,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 		if (!ClassDB::can_instance(E->get()))
 			continue;
 
-		Ref<Texture> icon;
-		if (has_icon(E->get(), "EditorIcons")) {
-			icon = get_icon(E->get(), "EditorIcons");
-		}
+		Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(E->get());
 		String name = E->get().operator String().replace("AudioEffect", "");
 		effect_options->add_item(name);
 		effect_options->set_item_metadata(effect_options->get_item_count() - 1, E->get());

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -869,7 +869,7 @@ bool EditorData::script_class_is_parent(const String &p_class, const String &p_i
 	return true;
 }
 
-StringName EditorData::script_class_get_base(const String &p_class) {
+StringName EditorData::script_class_get_base(const String &p_class) const {
 
 	if (!ScriptServer::is_global_class(p_class))
 		return StringName();
@@ -895,15 +895,38 @@ Object *EditorData::script_class_instance(const String &p_class) {
 			RES script = ResourceLoader::load(ScriptServer::get_global_class_path(p_class));
 			if (script.is_valid())
 				obj->set_script(script.get_ref_ptr());
-
-			RES icon = ResourceLoader::load(script_class_get_icon_path(p_class));
-			if (icon.is_valid())
-				obj->set_meta("_editor_icon", icon);
-
 			return obj;
 		}
 	}
 	return NULL;
+}
+
+void EditorData::script_class_set_icon_path(const String &p_class, const String &p_icon_path) {
+	_script_class_icon_paths[p_class] = p_icon_path;
+}
+
+String EditorData::script_class_get_icon_path(const String &p_class) const {
+	if (!ScriptServer::is_global_class(p_class))
+		return String();
+
+	String current = p_class;
+	String ret = _script_class_icon_paths[current];
+	while (ret.empty()) {
+		current = script_class_get_base(current);
+		if (!ScriptServer::is_global_class(current))
+			return String();
+		ret = _script_class_icon_paths.has(current) ? _script_class_icon_paths[current] : String();
+	}
+
+	return ret;
+}
+
+StringName EditorData::script_class_get_name(const String &p_path) const {
+	return _script_class_file_to_path.has(p_path) ? _script_class_file_to_path[p_path] : StringName();
+}
+
+void EditorData::script_class_set_name(const String &p_path, const StringName &p_class) {
+	_script_class_file_to_path[p_path] = p_class;
 }
 
 void EditorData::script_class_save_icon_paths() {
@@ -912,7 +935,8 @@ void EditorData::script_class_save_icon_paths() {
 
 	Dictionary d;
 	for (List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-		d[E->get()] = _script_class_icon_paths[E->get()];
+		if (ScriptServer::is_global_class(E->get()))
+			d[E->get()] = _script_class_icon_paths[E->get()];
 	}
 
 	ProjectSettings::get_singleton()->set("_global_script_class_icons", d);
@@ -927,8 +951,11 @@ void EditorData::script_class_load_icon_paths() {
 	d.get_key_list(&keys);
 
 	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-		String key = E->get().operator String();
-		_script_class_icon_paths[key] = d[key];
+		String name = E->get().operator String();
+		_script_class_icon_paths[name] = d[name];
+
+		String path = ScriptServer::get_global_class_path(name);
+		script_class_set_name(path, name);
 	}
 }
 

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -147,6 +147,7 @@ private:
 	bool _find_updated_instances(Node *p_root, Node *p_node, Set<String> &checked_paths);
 
 	HashMap<StringName, String> _script_class_icon_paths;
+	HashMap<String, StringName> _script_class_file_to_path;
 
 public:
 	EditorPlugin *get_editor(Object *p_object);
@@ -214,10 +215,14 @@ public:
 	void notify_resource_saved(const Ref<Resource> &p_resource);
 
 	bool script_class_is_parent(const String &p_class, const String &p_inherits);
-	StringName script_class_get_base(const String &p_class);
+	StringName script_class_get_base(const String &p_class) const;
 	Object *script_class_instance(const String &p_class);
-	String script_class_get_icon_path(const String &p_class) const { return _script_class_icon_paths.has(p_class) ? _script_class_icon_paths[p_class] : String(); }
-	void script_class_set_icon_path(const String &p_class, const String &p_icon_path) { _script_class_icon_paths[p_class] = p_icon_path; }
+
+	StringName script_class_get_name(const String &p_path) const;
+	void script_class_set_name(const String &p_path, const StringName &p_class);
+
+	String script_class_get_icon_path(const String &p_class) const;
+	void script_class_set_icon_path(const String &p_class, const String &p_icon_path);
 	void script_class_clear_icon_paths() { _script_class_icon_paths.clear(); }
 	void script_class_save_icon_paths();
 	void script_class_load_icon_paths();

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1358,6 +1358,7 @@ void EditorFileSystem::_scan_script_classes(EditorFileSystemDirectory *p_dir) {
 		}
 		ScriptServer::add_global_class(files[i]->script_class_name, files[i]->script_class_extends, lang, p_dir->get_file_path(i));
 		EditorNode::get_editor_data().script_class_set_icon_path(files[i]->script_class_name, files[i]->script_class_icon_path);
+		EditorNode::get_editor_data().script_class_set_name(files[i]->file, files[i]->script_class_name);
 	}
 	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
 		_scan_script_classes(p_dir->get_subdir(i));

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -88,10 +88,8 @@ void EditorHelpSearch::IncrementalSearch::phase1(Map<String, DocData::ClassDoc>:
 		TreeItem *item = search_options->create_item(root);
 		item->set_metadata(0, "class_name:" + E->key());
 		item->set_text(0, E->key() + " (Class)");
-		if (search->has_icon(E->key(), "EditorIcons"))
-			item->set_icon(0, search->get_icon(E->key(), "EditorIcons"));
-		else
-			item->set_icon(0, def_icon);
+		Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(E->key(), "Node");
+		item->set_icon(0, icon);
 	}
 }
 
@@ -99,11 +97,7 @@ void EditorHelpSearch::IncrementalSearch::phase2(Map<String, DocData::ClassDoc>:
 
 	DocData::ClassDoc &c = E->get();
 
-	Ref<Texture> cicon;
-	if (search->has_icon(E->key(), "EditorIcons"))
-		cicon = search->get_icon(E->key(), "EditorIcons");
-	else
-		cicon = def_icon;
+	Ref<Texture> cicon = EditorNode::get_singleton()->get_class_icon(E->key(), "Node");
 
 	for (int i = 0; i < c.methods.size(); i++) {
 		if ((term.begins_with(".") && c.methods[i].name.begins_with(term.right(1))) || (term.ends_with("(") && c.methods[i].name.ends_with(term.left(term.length() - 1).strip_edges())) || (term.begins_with(".") && term.ends_with("(") && c.methods[i].name == term.substr(1, term.length() - 2).strip_edges()) || c.methods[i].name.findn(term) != -1) {
@@ -343,10 +337,8 @@ void EditorHelpIndex::add_type(const String &p_type, HashMap<String, TreeItem *>
 	item->set_tooltip(0, EditorHelp::get_doc_data()->class_list[p_type].brief_description);
 	item->set_text(0, p_type);
 
-	if (has_icon(p_type, "EditorIcons")) {
-
-		item->set_icon(0, get_icon(p_type, "EditorIcons"));
-	}
+	Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(p_type);
+	item->set_icon(0, icon);
 
 	p_types[p_type] = item;
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1423,10 +1423,7 @@ void EditorInspector::update_tree() {
 			category_vbox = NULL; //reset
 
 			String type = p.name;
-			if (has_icon(type, "EditorIcons"))
-				category->icon = get_icon(type, "EditorIcons");
-			else
-				category->icon = get_icon("Object", "EditorIcons");
+			category->icon = EditorNode::get_singleton()->get_class_icon(type, "Object");
 			category->label = type;
 
 			category->bg_color = get_color("prop_category", "Editor");

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -706,6 +706,8 @@ public:
 	void stop_child_process();
 
 	Ref<Theme> get_editor_theme() const { return theme; }
+	Ref<Texture> get_object_icon(const Object *p_object, const String &p_fallback = "Object") const;
+	Ref<Texture> get_class_icon(const String &p_class, const String &p_fallback = "Object") const;
 
 	void show_accept(const String &p_text, const String &p_title);
 	void show_warning(const String &p_text, const String &p_title = "Warning!");

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -54,12 +54,7 @@ void EditorPath::_add_children_to_popup(Object *p_obj, int p_depth) {
 		if (!obj)
 			continue;
 
-		Ref<Texture> icon;
-
-		if (has_icon(obj->get_class(), "EditorIcons"))
-			icon = get_icon(obj->get_class(), "EditorIcons");
-		else
-			icon = get_icon("Object", "EditorIcons");
+		Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(obj);
 
 		int index = popup->get_item_count();
 		popup->add_icon_item(icon, E->get().name.capitalize(), objects.size());
@@ -122,12 +117,7 @@ void EditorPath::_notification(int p_what) {
 
 				String type = obj->get_class();
 
-				Ref<Texture> icon;
-
-				if (has_icon(obj->get_class(), "EditorIcons"))
-					icon = get_icon(obj->get_class(), "EditorIcons");
-				else
-					icon = get_icon("Object", "EditorIcons");
+				Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(obj);
 
 				icon->draw(ci, Point2i(ofs, (size.height - icon->get_height()) / 2));
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -846,18 +846,11 @@ void EditorPropertyObjectID::update_property() {
 	if (type == "")
 		type = "Object";
 
-	String icon_type = type;
-	if (has_icon(icon_type, "EditorIcons")) {
-		type = icon_type;
-	} else {
-		type = "Object";
-	}
-
 	ObjectID id = get_edited_object()->get(get_edited_property());
 	if (id != 0) {
 		edit->set_text(type + " ID: " + itos(id));
 		edit->set_disabled(false);
-		edit->set_icon(get_icon(icon_type, "EditorIcons"));
+		edit->set_icon(EditorNode::get_singleton()->get_class_icon(type));
 	} else {
 		edit->set_text(TTR("[Empty]"));
 		edit->set_disabled(true);
@@ -1858,14 +1851,7 @@ void EditorPropertyNodePath::update_property() {
 	ERR_FAIL_COND(!target_node);
 
 	assign->set_text(target_node->get_name());
-
-	Ref<Texture> icon;
-	if (has_icon(target_node->get_class(), "EditorIcons"))
-		icon = get_icon(target_node->get_class(), "EditorIcons");
-	else
-		icon = get_icon("Node", "EditorIcons");
-
-	assign->set_icon(icon);
+	assign->set_icon(EditorNode::get_singleton()->get_object_icon(target_node, "Node"));
 }
 
 void EditorPropertyNodePath::setup(const NodePath &p_base_hint, Vector<StringName> p_valid_types) {
@@ -2363,13 +2349,7 @@ void EditorPropertyResource::update_property() {
 		assign->set_text(TTR("[empty]"));
 	} else {
 
-		Ref<Texture> icon;
-		if (has_icon(res->get_class(), "EditorIcons"))
-			icon = get_icon(res->get_class(), "EditorIcons");
-		else
-			icon = get_icon("Node", "EditorIcons");
-
-		assign->set_icon(icon);
+		assign->set_icon(EditorNode::get_singleton()->get_object_icon(res.operator->(), "Node"));
 
 		if (res->get_name() != String()) {
 			assign->set_text(res->get_name());

--- a/editor/editor_sub_scene.cpp
+++ b/editor/editor_sub_scene.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_sub_scene.h"
 
+#include "editor/editor_node.h"
 #include "scene/gui/margin_container.h"
 #include "scene/resources/packed_scene.h"
 
@@ -84,9 +85,7 @@ void EditorSubScene::_fill_tree(Node *p_node, TreeItem *p_parent) {
 	it->set_text(0, p_node->get_name());
 	it->set_editable(0, false);
 	it->set_selectable(0, true);
-	if (has_icon(p_node->get_class(), "EditorIcons")) {
-		it->set_icon(0, get_icon(p_node->get_class(), "EditorIcons"));
-	}
+	it->set_icon(0, EditorNode::get_singleton()->get_object_icon(p_node, "Node"));
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -90,12 +90,7 @@ void GroupDialog::_load_nodes(Node *p_current) {
 		node->set_metadata(0, path);
 		node->set_tooltip(0, path);
 
-		Ref<Texture> icon;
-		if (p_current->has_meta("_editor_icon")) {
-			icon = p_current->get_meta("_editor_icon");
-		} else {
-			icon = get_icon((has_icon(p_current->get_class(), "EditorIcons") ? p_current->get_class() : String("Object")), "EditorIcons");
-		}
+		Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(p_current, "Node");
 		node->set_icon(0, icon);
 
 		if (!_can_edit(p_current, selected_group)) {

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -231,11 +231,10 @@ void InspectorDock::_prepare_history() {
 
 		already.insert(id);
 
-		Ref<Texture> icon = get_icon("Object", "EditorIcons");
-		if (has_icon(obj->get_class(), "EditorIcons"))
-			icon = get_icon(obj->get_class(), "EditorIcons");
-		else
+		Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(obj, "");
+		if (icon.is_null()) {
 			icon = base_icon;
+		}
 
 		String text;
 		if (Object::cast_to<Resource>(obj)) {

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -542,11 +542,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 
 				if (base->has_node(accum)) {
 					Node *node = base->get_node(accum);
-					if (has_icon(node->get_class(), "EditorIcons")) {
-						ti->set_icon(0, get_icon(node->get_class(), "EditorIcons"));
-					} else {
-						ti->set_icon(0, get_icon("Node", "EditorIcons"));
-					}
+					ti->set_icon(0, EditorNode::get_singleton()->get_object_icon(node, "Node"));
 				}
 
 			} else {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1905,11 +1905,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 				for (int i = 0; i < selection_results.size(); i++) {
 					CanvasItem *item = selection_results[i].item;
 
-					Ref<Texture> icon;
-					if (item->has_meta("_editor_icon"))
-						icon = item->get_meta("_editor_icon");
-					else
-						icon = get_icon(has_icon(item->get_class(), "EditorIcons") ? item->get_class() : String("Object"), "EditorIcons");
+					Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(item, "Node");
 					String node_path = "/" + root_name + "/" + root_path.rel_path_to(item->get_path());
 
 					selection_menu->add_item(item->get_name());
@@ -2046,10 +2042,7 @@ bool CanvasItemEditor::_gui_input_hover(const Ref<InputEvent> &p_event) {
 
 			_HoverResult hover_result;
 			hover_result.position = canvas_item->get_global_transform_with_canvas().get_origin();
-			if (has_icon(canvas_item->get_class(), "EditorIcons"))
-				hover_result.icon = get_icon(canvas_item->get_class(), "EditorIcons");
-			else
-				hover_result.icon = get_icon("Object", "EditorIcons");
+			hover_result.icon = EditorNode::get_singleton()->get_object_icon(canvas_item);
 			hover_result.name = canvas_item->get_name();
 
 			hovering_results_tmp.push_back(hover_result);

--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -317,10 +317,7 @@ void ItemListEditor::edit(Node *p_item_list) {
 			item_plugins[i]->set_object(p_item_list);
 			property_editor->edit(item_plugins[i]);
 
-			if (has_icon(item_list->get_class(), "EditorIcons"))
-				toolbar_button->set_icon(get_icon(item_list->get_class(), "EditorIcons"));
-			else
-				toolbar_button->set_icon(Ref<Texture>());
+			toolbar_button->set_icon(EditorNode::get_singleton()->get_object_icon(item_list, ""));
 
 			selected_idx = i;
 			return;

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -238,8 +238,7 @@ void ResourcePreloaderEditor::_update_library() {
 		ti->set_text(2, type);
 		ti->set_selectable(2, false);
 
-		if (has_icon(type, "EditorIcons"))
-			ti->set_icon(2, get_icon(type, "EditorIcons"));
+		ti->set_icon(2, EditorNode::get_singleton()->get_class_icon(type, ""));
 	}
 
 	//player->add_resource("default",resource);

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -109,11 +109,7 @@ void EditorPropertyRootMotion::_node_assign() {
 
 				if (base->has_node(accum)) {
 					Node *node = base->get_node(accum);
-					if (has_icon(node->get_class(), "EditorIcons")) {
-						ti->set_icon(0, get_icon(node->get_class(), "EditorIcons"));
-					} else {
-						ti->set_icon(0, get_icon("Node", "EditorIcons"));
-					}
+					ti->set_icon(0, EditorNode::get_singleton()->get_object_icon(node, "Node"));
 				}
 
 			} else {
@@ -235,14 +231,7 @@ void EditorPropertyRootMotion::update_property() {
 	ERR_FAIL_COND(!target_node);
 
 	assign->set_text(target_node->get_name());
-
-	Ref<Texture> icon;
-	if (has_icon(target_node->get_class(), "EditorIcons"))
-		icon = get_icon(target_node->get_class(), "EditorIcons");
-	else
-		icon = get_icon("Node", "EditorIcons");
-
-	assign->set_icon(icon);
+	assign->set_icon(EditorNode::get_singleton()->get_object_icon(target_node, "Node"));
 }
 
 void EditorPropertyRootMotion::setup(const NodePath &p_base_hint) {

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -847,11 +847,7 @@ void SpatialEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 
 			Spatial *spat = selection_results[i].item;
 
-			Ref<Texture> icon;
-			if (spat->has_meta("_editor_icon"))
-				icon = spat->get_meta("_editor_icon");
-			else
-				icon = get_icon(has_icon(spat->get_class(), "EditorIcons") ? spat->get_class() : String("Object"), "EditorIcons");
+			Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(spat, "Node");
 
 			String node_path = "/" + root_name + "/" + root_path.rel_path_to(spat->get_path());
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -30,6 +30,8 @@
 
 #include "text_editor.h"
 
+#include "editor_node.h"
+
 void TextEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
 	highlighters[p_highlighter->get_name()] = p_highlighter;
 	highlighter_menu->add_radio_check_item(p_highlighter->get_name());
@@ -158,10 +160,7 @@ String TextEditor::get_name() {
 
 Ref<Texture> TextEditor::get_icon() {
 
-	if (get_parent_control() && get_parent_control()->has_icon(text_file->get_class(), "EditorIcons")) {
-		return get_parent_control()->get_icon(text_file->get_class(), "EditorIcons");
-	}
-	return Ref<Texture>();
+	return EditorNode::get_singleton()->get_object_icon(text_file.operator->(), "");
 }
 
 RES TextEditor::get_edited_resource() const {

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -655,16 +655,9 @@ bool ProjectExportDialog::_fill_tree(EditorFileSystemDirectory *p_dir, TreeItem 
 		file->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 		file->set_text(0, p_dir->get_file(i));
 
-		Ref<Texture> tex;
-		if (has_icon(type, editor_icons)) {
-			tex = get_icon(type, editor_icons);
-		} else {
-			tex = get_icon("Object", editor_icons);
-		}
-
 		String path = p_dir->get_file_path(i);
 
-		file->set_icon(0, tex);
+		file->set_icon(0, EditorNode::get_singleton()->get_class_icon(type));
 		file->set_editable(0, true);
 		file->set_checked(0, current->has_export_file(path));
 		file->set_metadata(0, path);

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -31,6 +31,7 @@
 #include "property_selector.h"
 
 #include "core/os/keyboard.h"
+#include "editor/editor_node.h"
 #include "editor_scale.h"
 
 void PropertySelector::_text_changed(const String &p_newtext) {
@@ -161,10 +162,8 @@ void PropertySelector::_update_search() {
 				Ref<Texture> icon;
 				if (E->get().name == "Script Variables") {
 					icon = get_icon("Script", "EditorIcons");
-				} else if (has_icon(E->get().name, "EditorIcons")) {
-					icon = get_icon(E->get().name, "EditorIcons");
 				} else {
-					icon = get_icon("Object", "EditorIcons");
+					icon = EditorNode::get_singleton()->get_class_icon(E->get().name);
 				}
 				category->set_icon(0, icon);
 				continue;
@@ -241,10 +240,8 @@ void PropertySelector::_update_search() {
 				if (E->get().name == "*Script Methods") {
 					icon = get_icon("Script", "EditorIcons");
 					script_methods = true;
-				} else if (has_icon(rep, "EditorIcons")) {
-					icon = get_icon(rep, "EditorIcons");
 				} else {
-					icon = get_icon("Object", "EditorIcons");
+					icon = EditorNode::get_singleton()->get_class_icon(rep);
 				}
 				category->set_icon(0, icon);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -399,11 +399,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					const RefPtr empty;
 					editor_data->get_undo_redo().add_do_method(E->get(), "set_script", empty);
 					editor_data->get_undo_redo().add_undo_method(E->get(), "set_script", existing);
-
-					if (E->get()->has_meta("_editor_icon")) {
-						editor_data->get_undo_redo().add_do_method(E->get(), "set_meta", "_editor_icon", get_icon(E->get()->get_class(), "EditorIcons"));
-						editor_data->get_undo_redo().add_undo_method(E->get(), "set_meta", "_editor_icon", E->get()->get_meta("_editor_icon"));
-					}
 				}
 			}
 
@@ -1501,19 +1496,6 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 		Ref<Script> existing = E->get()->get_script();
 		editor_data->get_undo_redo().add_do_method(E->get(), "set_script", p_script.get_ref_ptr());
 		editor_data->get_undo_redo().add_undo_method(E->get(), "set_script", existing);
-
-		String icon_path;
-		String name = p_script->get_language()->get_global_class_name(p_script->get_path(), NULL, &icon_path);
-		if (ScriptServer::is_global_class(name)) {
-			RES icon = ResourceLoader::load(icon_path);
-			editor_data->get_undo_redo().add_do_method(E->get(), "set_meta", "_editor_icon", icon);
-			String existing_name = existing.is_valid() ? existing->get_language()->get_global_class_name(existing->get_path()) : String();
-			if (existing.is_null() || !ScriptServer::is_global_class(existing_name)) {
-				editor_data->get_undo_redo().add_undo_method(E->get(), "set_meta", "_editor_icon", get_icon(E->get()->get_class(), "EditorIcons"));
-			} else {
-				editor_data->get_undo_redo().add_undo_method(E->get(), "set_meta", "_editor_icon", editor_data->script_class_get_icon_path(existing_name));
-			}
-		}
 	}
 
 	editor_data->get_undo_redo().commit_action();
@@ -2029,12 +2011,7 @@ void SceneTreeDock::_add_children_to_popup(Object *p_obj, int p_depth) {
 		if (!obj)
 			continue;
 
-		Ref<Texture> icon;
-
-		if (has_icon(obj->get_class(), "EditorIcons"))
-			icon = get_icon(obj->get_class(), "EditorIcons");
-		else
-			icon = get_icon("Object", "EditorIcons");
+		Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(obj);
 
 		if (menu->get_item_count() == 0) {
 			menu->add_submenu_item(TTR("Sub-Resources"), "Sub-Resources");
@@ -2264,7 +2241,7 @@ void SceneTreeDock::_update_create_root_dialog() {
 					String name = l.get_slicec(' ', 0);
 					if (ScriptServer::is_global_class(name))
 						name = ScriptServer::get_global_class_base(name);
-					button->set_icon(get_icon(name, "EditorIcons"));
+					button->set_icon(EditorNode::get_singleton()->get_class_icon(name));
 					button->connect("pressed", this, "_favorite_root_selected", make_binds(l));
 				}
 			}

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -186,11 +186,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			item->set_collapsed(true);
 	}
 
-	Ref<Texture> icon;
-	if (p_node->has_meta("_editor_icon"))
-		icon = p_node->get_meta("_editor_icon");
-	else
-		icon = get_icon((has_icon(p_node->get_class(), "EditorIcons") ? p_node->get_class() : String("Object")), "EditorIcons");
+	Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(p_node, "Node");
 	item->set_icon(0, icon);
 	item->set_metadata(0, p_node->get_path());
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -428,8 +428,9 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			ObjectID id = ObjectID(p_data[i + 3]);
 
 			it->set_text(0, p_data[i + 1]);
-			if (has_icon(p_data[i + 2], "EditorIcons"))
-				it->set_icon(0, get_icon(p_data[i + 2], "EditorIcons"));
+			Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(p_data[i + 2], "");
+			if (icon.is_valid())
+				it->set_icon(0, icon);
 			it->set_metadata(0, id);
 
 			if (id == inspected_object_id) {

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -31,6 +31,7 @@
 #include "visual_script_property_selector.h"
 
 #include "core/os/keyboard.h"
+#include "editor/editor_node.h"
 #include "editor_scale.h"
 #include "modules/visual_script/visual_script.h"
 #include "modules/visual_script/visual_script_builtin_funcs.h"
@@ -176,10 +177,8 @@ void VisualScriptPropertySelector::_update_search() {
 				Ref<Texture> icon;
 				if (E->get().name == "Script Variables") {
 					icon = get_icon("Script", "EditorIcons");
-				} else if (has_icon(E->get().name, "EditorIcons")) {
-					icon = get_icon(E->get().name, "EditorIcons");
 				} else {
-					icon = get_icon("Object", "EditorIcons");
+					icon = EditorNode::get_singleton()->get_class_icon(E->get().name);
 				}
 				category->set_icon(0, icon);
 				continue;
@@ -289,10 +288,8 @@ void VisualScriptPropertySelector::_update_search() {
 			if (E->get().name == "*Script Methods") {
 				icon = get_icon("Script", "EditorIcons");
 				script_methods = true;
-			} else if (has_icon(rep, "EditorIcons")) {
-				icon = get_icon(rep, "EditorIcons");
 			} else {
-				icon = get_icon("Object", "EditorIcons");
+				icon = EditorNode::get_singleton()->get_class_icon(rep);
 			}
 			category->set_icon(0, icon);
 


### PR DESCRIPTION
It looks like this has a ton of different changes, but the vast majority of this is just about centralizing copy-pasta code all over the Godot Editor into a centralized location that does the same processing in every case (rather than bits and pieces that the copy-pasta had induced at various locations).

Fixes #21615 and circumvents any previous "fixes" surrounding "_editor_icon" metadata.

1. Create `EditorData::script_class_get_name(p_path)` so that a path alone can fetch us the name, and from there, the icon path. Start caching these values during `EditorFileSystem::_scan_script_classes(...)`.
2. Create `EditorData::get_object_icon(obj, ...)` and `EditorData::get_object_icon_name(name, ...)` to fetch the appropriate editor icon depending on whether an object pointer or a String/StringName is available. Edit: we changed `get_object_icon_name` to `get_class_icon`.
3. Fix a script class icon bug in create_dialog.cpp regarding the `current_item_is_preferred` in the `cpp_type` case (prevents a possible `ClassDB::is_parent_class()` ERR_FAIL_COND_V trigger).
3. Replace all "_editor_icon" metadata fetches with the above functions. Allow editor nodes to check the live data directly rather than using the third-party "_editor_icon" metadata that was desynchronizing and causing all sorts of random bugs in different places.
    - group_editor.cpp
    - canvas_item_editor_plugin.cpp
    - spatial_editor_plugin.cpp
    - scene_tree_dock.cpp
    - scene_tree_editor.cpp
4. I then noticed that the same methods could be used to refactor and centralize the vast majority of `get_icon(...)` calls in the editor classes, so I started to evaluate all of those files and determine if their usage could be converted into an EditorData call without compromising their logical functionality. I believe I've done that, but I'm sure people will want to investigate it further.