### PR TITLE
Fix custom cursor hotspot

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -293,6 +293,8 @@
 			</argument>
 			<description>
 				Set a custom mouse cursor image, which is only visible inside the game window. The hotspot can also be specified. Passing [code]null[/code] to the image parameter resets to the system cursor. See enum [code]CURSOR_*[/code] for the list of shapes.
+				[code]image[/code]'s size must be lower than 256x256.
+				[code]hotspot[/code] must be within [code]image[/code]'s size.
 			</description>
 		</method>
 		<method name="set_default_cursor_shape">

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1605,6 +1605,7 @@ void OS_OSX::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 
 		ERR_FAIL_COND(!texture.is_valid());
 		ERR_FAIL_COND(texture_size.width > 256 || texture_size.height > 256);
+		ERR_FAIL_COND(p_hotspot.x > texture_size.width || p_hotspot.y > texture_size.height);
 
 		image = texture->get_data();
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2253,6 +2253,7 @@ void OS_Windows::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shap
 
 		ERR_FAIL_COND(!texture.is_valid());
 		ERR_FAIL_COND(texture_size.width > 256 || texture_size.height > 256);
+		ERR_FAIL_COND(p_hotspot.x > texture_size.width || p_hotspot.y > texture_size.height);
 
 		image = texture->get_data();
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2535,6 +2535,7 @@ void OS_X11::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 
 		ERR_FAIL_COND(!texture.is_valid());
 		ERR_FAIL_COND(texture_size.width > 256 || texture_size.height > 256);
+		ERR_FAIL_COND(p_hotspot.x > texture_size.width || p_hotspot.y > texture_size.height);
 
 		image = texture->get_data();
 


### PR DESCRIPTION
Cursor hotspot must be inside image on Linux. Adding validation for all
platforms for consistency.

Fix #21721.