### PR TITLE
Fixes to mouse mode confined and captured

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -742,12 +742,15 @@ void OS_X11::set_mouse_mode(MouseMode p_mode) {
 			ERR_PRINT("NO GRAB");
 		}
 
-		center.x = current_videomode.width / 2;
-		center.y = current_videomode.height / 2;
-		XWarpPointer(x11_display, None, x11_window,
-				0, 0, 0, 0, (int)center.x, (int)center.y);
+		if (mouse_mode == MOUSE_MODE_CAPTURED) {
+			center.x = current_videomode.width / 2;
+			center.y = current_videomode.height / 2;
 
-		input->set_mouse_position(center);
+			XWarpPointer(x11_display, None, x11_window,
+					0, 0, 0, 0, (int)center.x, (int)center.y);
+
+			input->set_mouse_position(center);
+		}
 	} else {
 		do_mouse_warp = false;
 	}
@@ -2043,6 +2046,10 @@ void OS_X11::process_xevents() {
 				}
 
 				Point2i rel = pos - last_mouse_pos;
+
+				if (mouse_mode == MOUSE_MODE_CAPTURED) {
+					pos = Point2i(current_videomode.width / 2, current_videomode.height / 2);
+				}
 
 				Ref<InputEventMouseMotion> mm;
 				mm.instance();


### PR DESCRIPTION
CONFINED and CAPTURED will work on Linux in the same way as Windows.

When mouse mode is CAPTURED, the cursor (global/green dot) will be forced to center.

Fix #21744.
Fix #21751. The "cursor" doesn't leaves our planet anymore.

Screencast from Linux (using mouse):
![peek 05-09-2018 11-33](https://user-images.githubusercontent.com/1387165/45100912-bcc5dc00-b100-11e8-9c1f-02fb1a7125a0.gif)
(using pen in absolute mode)
![peek 05-09-2018 11-52](https://user-images.githubusercontent.com/1387165/45101609-4629de00-b102-11e8-868a-540755d9aa47.gif)


## Considerations:
On Windows, pen and touch doesn't work in captured mode. Issue opened #21779.

# Update
Also fix free camera for Linux. The camera stop when the "cursor" leaves the viewport.
Tested with 53070437514e448c87f6cb31cf5b27a3839dbfa1, 3.0.6 and 3.1 alpha:
![peek 06-09-2018 13-22](https://user-images.githubusercontent.com/1387165/45171189-18af6400-b1d8-11e8-8d8f-ba928547dca2.gif)
After this PR:
![peek 06-09-2018 13-23](https://user-images.githubusercontent.com/1387165/45171190-19e09100-b1d8-11e8-9dd7-f75864d3e036.gif)

