### PR TITLE
Fix missing texture-download error with OpenGL ES

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -506,8 +506,8 @@ Ref<Image> RasterizerStorageGLES2::texture_get_data(RID p_texture, VS::CubeMapSi
 	return Ref<Image>(img);
 #else
 
-	ERR_EXPLAIN("Sorry, It's not posible to obtain images back in OpenGL ES");
-	return Ref<Image>();
+	ERR_EXPLAIN("Sorry, It's not possible to obtain images back in OpenGL ES");
+	ERR_FAIL_V(Ref<Image>());
 #endif
 }
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -962,7 +962,7 @@ Ref<Image> RasterizerStorageGLES3::texture_get_data(RID p_texture, VS::CubeMapSi
 #else
 
 	ERR_EXPLAIN("Sorry, It's not possible to obtain images back in OpenGL ES");
-	return Ref<Image>();
+	ERR_FAIL_V(Ref<Image>());
 #endif
 }
 


### PR DESCRIPTION
Missing `ERR_FAIL` here.