### PR TITLE
Add error and configuration warning for scale with zero component

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -167,15 +167,21 @@ void Node2D::set_rotation_degrees(float p_degrees) {
 
 void Node2D::set_scale(const Size2 &p_scale) {
 
+#ifdef DEBUG_ENABLED
+	if (p_scale.x == 0 || p_scale.y == 0) {
+		ERR_PRINT("Spatial scale was set with one or more zero components, this may cause bugs.");
+	}
+#endif
+
 	if (_xform_dirty)
 		((Node2D *)this)->_update_xform_values();
+
 	_scale = p_scale;
-	if (_scale.x == 0)
-		_scale.x = CMP_EPSILON;
-	if (_scale.y == 0)
-		_scale.y = CMP_EPSILON;
+
 	_update_transform();
 	_change_notify("scale");
+
+	update_configuration_warning();
 }
 
 Point2 Node2D::get_position() const {
@@ -393,6 +399,16 @@ Point2 Node2D::to_local(Point2 p_global) const {
 Point2 Node2D::to_global(Point2 p_local) const {
 
 	return get_global_transform().xform(p_local);
+}
+
+String Node2D::get_configuration_warning() const {
+
+	Vector2 abs_scale = get_scale().abs();
+	if (abs_scale.x < CMP_EPSILON || abs_scale.y < CMP_EPSILON) {
+		return TTR("A Node2D node cannot have a scale with a zero component.");
+	}
+
+	return String();
 }
 
 void Node2D::_bind_methods() {

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -117,6 +117,8 @@ public:
 
 	Transform2D get_transform() const;
 
+	virtual String get_configuration_warning() const;
+
 	Node2D();
 };
 

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -105,7 +105,6 @@ class Spatial : public Node {
 	void _update_gizmo();
 	void _notify_dirty();
 	void _propagate_transform_changed(Spatial *p_origin);
-
 	void _propagate_visibility_changed();
 
 protected:
@@ -203,6 +202,8 @@ public:
 	bool is_visible_in_tree() const;
 
 	void force_update_transform();
+
+	virtual String get_configuration_warning() const;
 
 	Spatial();
 	~Spatial();


### PR DESCRIPTION
Also removes the workaround for zero scale in Node2D.

Doesn't handle the case where a zero scale component would be set via the transform, but at least the most obvious case is covered.

Fixes #20251.