### PR TITLE
Refactor core/pool_vector

### DIFF
--- a/core/pool_vector.cpp
+++ b/core/pool_vector.cpp
@@ -51,12 +51,10 @@ void MemoryPool::setup(uint32_t p_max_allocs) {
 	alloc_count = p_max_allocs;
 	allocs_used = 0;
 
+	free_list = &allocs[0];
 	for (uint32_t i = 0; i < alloc_count - 1; i++) {
-
 		allocs[i].free_list = &allocs[i + 1];
 	}
-
-	free_list = &allocs[0];
 
 	alloc_mutex = Mutex::create();
 }


### PR DESCRIPTION
Refactor core/dvector.h and core/dvector.cpp

**pool_vector.cpp:**

- Small rearrangement to make order more logical.

**pool_vector.h:**

- Renaming vaiables
- Updating comments
- Reformat code
- Comments on lines 492-497: Is based on the assumption that resize probably shouldn't be trying to resize to a negative size.
- Deletion of lines 608-617: Is based on the assumption that `sizeof(T)` cannot be `0`. `new_size = sizeof(T) * p_size`. So `new_size == 0` only when `p_size == 0` and that is handled earlier in the function.