### PR TITLE
[Mono] Various style changes and naming standardization

### DIFF
--- a/modules/mono/glue/cs_files/AABB.cs
+++ b/modules/mono/glue/cs_files/AABB.cs
@@ -51,24 +51,24 @@ namespace Godot
                    src_max.z > dst_max.z;
         }
 
-        public AABB Expand(Vector3 to_point)
+        public AABB Expand(Vector3 point)
         {
             Vector3 begin = _position;
             Vector3 end = _position + _size;
 
-            if (to_point.x < begin.x)
-                begin.x = to_point.x;
-            if (to_point.y < begin.y)
-                begin.y = to_point.y;
-            if (to_point.z < begin.z)
-                begin.z = to_point.z;
+            if (point.x < begin.x)
+                begin.x = point.x;
+            if (point.y < begin.y)
+                begin.y = point.y;
+            if (point.z < begin.z)
+                begin.z = point.z;
 
-            if (to_point.x > end.x)
-                end.x = to_point.x;
-            if (to_point.y > end.y)
-                end.y = to_point.y;
-            if (to_point.z > end.z)
-                end.z = to_point.z;
+            if (point.x > end.x)
+                end.x = point.x;
+            if (point.y > end.y)
+                end.y = point.y;
+            if (point.z > end.z)
+                end.z = point.z;
 
             return new AABB(begin, end - begin);
         }
@@ -347,29 +347,29 @@ namespace Godot
 
             for (int i = 0; i < 3; i++)
             {
-                real_t seg_from = from[i];
-                real_t seg_to = to[i];
-                real_t box_begin = _position[i];
-                real_t box_end = box_begin + _size[i];
+                real_t segFrom = from[i];
+                real_t segTo = to[i];
+                real_t boxBegin = _position[i];
+                real_t boxEnd = boxBegin + _size[i];
                 real_t cmin, cmax;
 
-                if (seg_from < seg_to)
+                if (segFrom < segTo)
                 {
-                    if (seg_from > box_end || seg_to < box_begin)
+                    if (segFrom > boxEnd || segTo < boxBegin)
                         return false;
 
-                    real_t length = seg_to - seg_from;
-                    cmin = seg_from < box_begin ? (box_begin - seg_from) / length : 0f;
-                    cmax = seg_to > box_end ? (box_end - seg_from) / length : 1f;
+                    real_t length = segTo - segFrom;
+                    cmin = segFrom < boxBegin ? (boxBegin - segFrom) / length : 0f;
+                    cmax = segTo > boxEnd ? (boxEnd - segFrom) / length : 1f;
                 }
                 else
                 {
-                    if (seg_to > box_end || seg_from < box_begin)
+                    if (segTo > boxEnd || segFrom < boxBegin)
                         return false;
 
-                    real_t length = seg_to - seg_from;
-                    cmin = seg_from > box_end ? (box_end - seg_from) / length : 0f;
-                    cmax = seg_to < box_begin ? (box_begin - seg_from) / length : 1f;
+                    real_t length = segTo - segFrom;
+                    cmin = segFrom > boxEnd ? (boxEnd - segFrom) / length : 0f;
+                    cmax = segTo < boxBegin ? (boxBegin - segFrom) / length : 1f;
                 }
 
                 if (cmin > min)
@@ -388,21 +388,21 @@ namespace Godot
 
         public AABB Merge(AABB with)
         {
-            Vector3 beg_1 = _position;
-            Vector3 beg_2 = with._position;
-            var end_1 = new Vector3(_size.x, _size.y, _size.z) + beg_1;
-            var end_2 = new Vector3(with._size.x, with._size.y, with._size.z) + beg_2;
+            Vector3 beg1 = _position;
+            Vector3 beg2 = with._position;
+            var end1 = new Vector3(_size.x, _size.y, _size.z) + beg1;
+            var end2 = new Vector3(with._size.x, with._size.y, with._size.z) + beg2;
 
             var min = new Vector3(
-                              beg_1.x < beg_2.x ? beg_1.x : beg_2.x,
-                              beg_1.y < beg_2.y ? beg_1.y : beg_2.y,
-                              beg_1.z < beg_2.z ? beg_1.z : beg_2.z
+                              beg1.x < beg2.x ? beg1.x : beg2.x,
+                              beg1.y < beg2.y ? beg1.y : beg2.y,
+                              beg1.z < beg2.z ? beg1.z : beg2.z
                           );
 
             var max = new Vector3(
-                              end_1.x > end_2.x ? end_1.x : end_2.x,
-                              end_1.y > end_2.y ? end_1.y : end_2.y,
-                              end_1.z > end_2.z ? end_1.z : end_2.z
+                              end1.x > end2.x ? end1.x : end2.x,
+                              end1.y > end2.y ? end1.y : end2.y,
+                              end1.z > end2.z ? end1.z : end2.z
                           );
 
             return new AABB(min, max - min);

--- a/modules/mono/glue/cs_files/Basis.cs
+++ b/modules/mono/glue/cs_files/Basis.cs
@@ -378,51 +378,51 @@ namespace Godot
             );
         }
 
-		public Quat Quat() {
-			real_t trace = _x[0] + _y[1] + _z[2];
+        public Quat Quat() {
+            real_t trace = _x[0] + _y[1] + _z[2];
 
-			if (trace > 0.0f) {
-				real_t s = Mathf.Sqrt(trace + 1.0f) * 2f;
-				real_t inv_s = 1f / s;
-				return new Quat(
-					(_z[1] - _y[2]) * inv_s,
-					(_x[2] - _z[0]) * inv_s,
-					(_y[0] - _x[1]) * inv_s,
-					s * 0.25f
-				);
-			}
+            if (trace > 0.0f) {
+                real_t s = Mathf.Sqrt(trace + 1.0f) * 2f;
+                real_t inv_s = 1f / s;
+                return new Quat(
+                    (_z[1] - _y[2]) * inv_s,
+                    (_x[2] - _z[0]) * inv_s,
+                    (_y[0] - _x[1]) * inv_s,
+                    s * 0.25f
+                );
+            }
 
-		    if (_x[0] > _y[1] && _x[0] > _z[2]) {
-		        real_t s = Mathf.Sqrt(_x[0] - _y[1] - _z[2] + 1.0f) * 2f;
-		        real_t inv_s = 1f / s;
-		        return new Quat(
-		            s * 0.25f,
-		            (_x[1] + _y[0]) * inv_s,
-		            (_x[2] + _z[0]) * inv_s,
-		            (_z[1] - _y[2]) * inv_s
-		        );
-		    }
+            if (_x[0] > _y[1] && _x[0] > _z[2]) {
+                real_t s = Mathf.Sqrt(_x[0] - _y[1] - _z[2] + 1.0f) * 2f;
+                real_t inv_s = 1f / s;
+                return new Quat(
+                    s * 0.25f,
+                    (_x[1] + _y[0]) * inv_s,
+                    (_x[2] + _z[0]) * inv_s,
+                    (_z[1] - _y[2]) * inv_s
+                );
+            }
 
-		    if (_y[1] > _z[2]) {
-		        real_t s = Mathf.Sqrt(-_x[0] + _y[1] - _z[2] + 1.0f) * 2f;
-		        real_t inv_s = 1f / s;
-		        return new Quat(
-		            (_x[1] + _y[0]) * inv_s,
-		            s * 0.25f,
-		            (_y[2] + _z[1]) * inv_s,
-		            (_x[2] - _z[0]) * inv_s
-		        );
-		    } else {
-		        real_t s = Mathf.Sqrt(-_x[0] - _y[1] + _z[2] + 1.0f) * 2f;
-		        real_t inv_s = 1f / s;
-		        return new Quat(
-		            (_x[2] + _z[0]) * inv_s,
-		            (_y[2] + _z[1]) * inv_s,
-		            s * 0.25f,
-		            (_y[0] - _x[1]) * inv_s
-		        );
-		    }
-		}
+            if (_y[1] > _z[2]) {
+                real_t s = Mathf.Sqrt(-_x[0] + _y[1] - _z[2] + 1.0f) * 2f;
+                real_t inv_s = 1f / s;
+                return new Quat(
+                    (_x[1] + _y[0]) * inv_s,
+                    s * 0.25f,
+                    (_y[2] + _z[1]) * inv_s,
+                    (_x[2] - _z[0]) * inv_s
+                );
+            } else {
+                real_t s = Mathf.Sqrt(-_x[0] - _y[1] + _z[2] + 1.0f) * 2f;
+                real_t inv_s = 1f / s;
+                return new Quat(
+                    (_x[2] + _z[0]) * inv_s,
+                    (_y[2] + _z[1]) * inv_s,
+                    s * 0.25f,
+                    (_y[0] - _x[1]) * inv_s
+                );
+            }
+        }
 
         public Basis(Quat quat)
         {

--- a/modules/mono/glue/cs_files/Color.cs
+++ b/modules/mono/glue/cs_files/Color.cs
@@ -370,12 +370,12 @@ namespace Godot
         {
             var txt = string.Empty;
 
-            txt += _to_hex(r);
-            txt += _to_hex(g);
-            txt += _to_hex(b);
+            txt += ToHex32(r);
+            txt += ToHex32(g);
+            txt += ToHex32(b);
 
             if (include_alpha)
-                txt = _to_hex(a) + txt;
+                txt = ToHex32(a) + txt;
 
             return txt;
         }
@@ -411,7 +411,7 @@ namespace Godot
             r = (rgba & 0xFFFF) / 65535.0f;
         }
 
-        private static int _parse_col(string str, int ofs)
+        private static int ParseCol8(string str, int ofs)
         {
             int ig = 0;
 
@@ -448,7 +448,7 @@ namespace Godot
             return ig;
         }
 
-        private String _to_hex(float val)
+        private String ToHex32(float val)
         {
             int v = Mathf.RoundToInt(Mathf.Clamp(val * 255, 0, 255));
 
@@ -490,17 +490,17 @@ namespace Godot
 
             if (alpha)
             {
-                if (_parse_col(color, 0) < 0)
+                if (ParseCol8(color, 0) < 0)
                     return false;
             }
 
             int from = alpha ? 2 : 0;
 
-            if (_parse_col(color, from + 0) < 0)
+            if (ParseCol8(color, from + 0) < 0)
                 return false;
-            if (_parse_col(color, from + 2) < 0)
+            if (ParseCol8(color, from + 2) < 0)
                 return false;
-            if (_parse_col(color, from + 4) < 0)
+            if (ParseCol8(color, from + 4) < 0)
                 return false;
 
             return true;
@@ -542,7 +542,7 @@ namespace Godot
 
             if (alpha)
             {
-                a = _parse_col(rgba, 0) / 255f;
+                a = ParseCol8(rgba, 0) / 255f;
 
                 if (a < 0)
                     throw new ArgumentOutOfRangeException("Invalid color code. Alpha part is not valid hexadecimal: " + rgba);
@@ -554,17 +554,17 @@ namespace Godot
 
             int from = alpha ? 2 : 0;
 
-            r = _parse_col(rgba, from + 0) / 255f;
+            r = ParseCol8(rgba, from + 0) / 255f;
 
             if (r < 0)
                 throw new ArgumentOutOfRangeException("Invalid color code. Red part is not valid hexadecimal: " + rgba);
 
-            g = _parse_col(rgba, from + 2) / 255f;
+            g = ParseCol8(rgba, from + 2) / 255f;
 
             if (g < 0)
                 throw new ArgumentOutOfRangeException("Invalid color code. Green part is not valid hexadecimal: " + rgba);
 
-            b = _parse_col(rgba, from + 4) / 255f;
+            b = ParseCol8(rgba, from + 4) / 255f;
 
             if (b < 0)
                 throw new ArgumentOutOfRangeException("Invalid color code. Blue part is not valid hexadecimal: " + rgba);

--- a/modules/mono/glue/cs_files/GodotSynchronizationContext.cs
+++ b/modules/mono/glue/cs_files/GodotSynchronizationContext.cs
@@ -4,22 +4,22 @@ using System.Threading;
 
 namespace Godot
 {
-	public class GodotSynchronizationContext : SynchronizationContext
-	{
-		private readonly BlockingCollection<KeyValuePair<SendOrPostCallback, object>> queue = new BlockingCollection<KeyValuePair<SendOrPostCallback, object>>();
+    public class GodotSynchronizationContext : SynchronizationContext
+    {
+        private readonly BlockingCollection<KeyValuePair<SendOrPostCallback, object>> queue = new BlockingCollection<KeyValuePair<SendOrPostCallback, object>>();
 
-		public override void Post(SendOrPostCallback d, object state)
-		{
-			queue.Add(new KeyValuePair<SendOrPostCallback, object>(d, state));
-		}
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            queue.Add(new KeyValuePair<SendOrPostCallback, object>(d, state));
+        }
 
-		public void ExecutePendingContinuations()
-		{
-			KeyValuePair<SendOrPostCallback, object> workItem;
-			while (queue.TryTake(out workItem))
-			{
-				workItem.Key(workItem.Value);
-			}
-		}
-	}
+        public void ExecutePendingContinuations()
+        {
+            KeyValuePair<SendOrPostCallback, object> workItem;
+            while (queue.TryTake(out workItem))
+            {
+                workItem.Key(workItem.Value);
+            }
+        }
+    }
 }

--- a/modules/mono/glue/cs_files/GodotTaskScheduler.cs
+++ b/modules/mono/glue/cs_files/GodotTaskScheduler.cs
@@ -6,89 +6,89 @@ using System.Threading.Tasks;
 
 namespace Godot
 {
-	public class GodotTaskScheduler : TaskScheduler
-	{
-		private GodotSynchronizationContext Context { get; set; }
-		private readonly LinkedList<Task> _tasks = new LinkedList<Task>();
+    public class GodotTaskScheduler : TaskScheduler
+    {
+        private GodotSynchronizationContext Context { get; set; }
+        private readonly LinkedList<Task> _tasks = new LinkedList<Task>();
 
-		public GodotTaskScheduler()
-		{
-			Context = new GodotSynchronizationContext();
-			SynchronizationContext.SetSynchronizationContext(Context);
-		}
+        public GodotTaskScheduler()
+        {
+            Context = new GodotSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(Context);
+        }
 
-		protected sealed override void QueueTask(Task task)
-		{
-			lock (_tasks)
-			{
-				_tasks.AddLast(task);
-			}
-		}
+        protected sealed override void QueueTask(Task task)
+        {
+            lock (_tasks)
+            {
+                _tasks.AddLast(task);
+            }
+        }
 
-		protected sealed override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
-		{
-			if (SynchronizationContext.Current != Context)
-			{
-				return false;
-			}
+        protected sealed override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            if (SynchronizationContext.Current != Context)
+            {
+                return false;
+            }
 
-			if (taskWasPreviouslyQueued)
-			{
-				TryDequeue(task);
-			}
+            if (taskWasPreviouslyQueued)
+            {
+                TryDequeue(task);
+            }
 
-			return TryExecuteTask(task);
-		}
+            return TryExecuteTask(task);
+        }
 
-		protected sealed override bool TryDequeue(Task task)
-		{
-			lock (_tasks)
-			{
-				return _tasks.Remove(task);
-			}
-		}
+        protected sealed override bool TryDequeue(Task task)
+        {
+            lock (_tasks)
+            {
+                return _tasks.Remove(task);
+            }
+        }
 
-		protected sealed override IEnumerable<Task> GetScheduledTasks()
-		{
-			lock (_tasks)
-			{
-				return _tasks.ToArray();
-			}
-		}
+        protected sealed override IEnumerable<Task> GetScheduledTasks()
+        {
+            lock (_tasks)
+            {
+                return _tasks.ToArray();
+            }
+        }
 
-		public void Activate()
-		{
-			ExecuteQueuedTasks();
-			Context.ExecutePendingContinuations();
-		}
+        public void Activate()
+        {
+            ExecuteQueuedTasks();
+            Context.ExecutePendingContinuations();
+        }
 
-		private void ExecuteQueuedTasks()
-		{
-			while (true)
-			{
-				Task task;
+        private void ExecuteQueuedTasks()
+        {
+            while (true)
+            {
+                Task task;
 
-				lock (_tasks)
-				{
-					if (_tasks.Any())
-					{
-						task = _tasks.First.Value;
-						_tasks.RemoveFirst();
-					}
-					else
-					{
-						break;
-					}
-				}
+                lock (_tasks)
+                {
+                    if (_tasks.Any())
+                    {
+                        task = _tasks.First.Value;
+                        _tasks.RemoveFirst();
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
 
-				if (task != null)
-				{
-					if (!TryExecuteTask(task))
-					{
-						throw new InvalidOperationException();
-					}
-				}
-			}
-		}
-	}
+                if (task != null)
+                {
+                    if (!TryExecuteTask(task))
+                    {
+                        throw new InvalidOperationException();
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
There were lots of inconsistencies and [style violations](https://godot.readthedocs.io/en/latest/getting_started/scripting/c_sharp/c_sharp_style_guide.html) in the code. I've went through and changed these. Most are internal changes, but here's a list of user-facing & breaking changes:

* `GetSlicec` renamed to `GetSliceCharacter`
* `Md5Text` renamed to `MD5Text`
* `Md5Buffer` renamed to `MD5Buffer`
* `JsonEscape` renamed to `JSONEscape`
* `IsValidIpAddress` renamed to `IsValidIPAddress`
* `Basename` renamed to `BaseName`
* `Match` and `Matchn` combined into `Match`
* `NocasecmpTo` and `CasecmpTo` combined into `CompareTo`
* `IsSubsequenceOf` and `IsSubsequenceOfI` combined into `IsSubsequenceOf`

(All these are in `StringExtensions.cs`) See https://github.com/godotengine/godot/issues/17212

For the record, I prefer tabs, but it's important to be consistent.