### PR TITLE
Prevent overwriting open scenes when saving

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1174,6 +1174,16 @@ void EditorNode::_dialog_action(String p_file) {
 			int scene_idx = (current_option == FILE_SAVE_SCENE || current_option == FILE_SAVE_AS_SCENE) ? -1 : tab_closing;
 
 			if (file->get_mode() == EditorFileDialog::MODE_SAVE_FILE) {
+				bool same_open_scene = false;
+				for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
+					if (editor_data.get_scene_path(i) == p_file && i != scene_idx)
+						same_open_scene = true;
+				}
+
+				if (same_open_scene) {
+					show_warning(TTR("Can't overwrite scene that is still open!"));
+					return;
+				}
 
 				_save_default_environment();
 				_save_scene_with_preview(p_file, scene_idx);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1816,6 +1816,13 @@ void SceneTreeDock::_new_scene_from(String p_file) {
 		return;
 	}
 
+	if (EditorNode::get_singleton()->is_scene_open(p_file)) {
+		accept->get_ok()->set_text(TTR("OK"));
+		accept->set_text(TTR("Can't overwrite scene that is still open!"));
+		accept->popup_centered_minsize();
+		return;
+	}
+
 	Node *base = selection.front()->get();
 
 	Map<Node *, Node *> reown;


### PR DESCRIPTION
Prevent overwriting open scenes when saving, this fixes #17628