### PR TITLE
OptionButton fix remove and select

### DIFF
--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -40,6 +40,7 @@ class OptionButton : public Button {
 
 	PopupMenu *popup;
 	int current;
+	bool allow_duplicates;
 
 	void _focused(int p_which);
 	void _selected(int p_which);
@@ -57,14 +58,17 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_id = -1);
-	void add_item(const String &p_label, int p_id = -1);
+	bool add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_id = -1);
+	bool add_item(const String &p_label, int p_id = -1);
 
 	void set_item_text(int p_idx, const String &p_text);
 	void set_item_icon(int p_idx, const Ref<Texture> &p_icon);
 	void set_item_id(int p_idx, int p_id);
 	void set_item_metadata(int p_idx, const Variant &p_metadata);
 	void set_item_disabled(int p_idx, bool p_disabled);
+
+	void set_allow_duplicates(bool p_allow);
+	bool get_allow_duplicates() const;
 
 	String get_item_text(int p_idx) const;
 	Ref<Texture> get_item_icon(int p_idx) const;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1381,6 +1381,13 @@ void PopupMenu::clear_autohide_areas() {
 	autohide_areas.clear();
 }
 
+void PopupMenu::sort_items_by_id() {
+	items.sort_custom<PopupMenu::SortItems>();
+	for (int i = 0; i < items.size(); i++) {
+		items.write[i].id = i;
+	}
+}
+
 void PopupMenu::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &PopupMenu::_gui_input);
@@ -1444,6 +1451,7 @@ void PopupMenu::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_separator", "label"), &PopupMenu::add_separator, DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("clear"), &PopupMenu::clear);
+	ClassDB::bind_method(D_METHOD("sort_items_by_id"), &PopupMenu::sort_items_by_id);
 
 	ClassDB::bind_method(D_METHOD("_set_items"), &PopupMenu::_set_items);
 	ClassDB::bind_method(D_METHOD("_get_items"), &PopupMenu::_get_items);

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -77,6 +77,12 @@ class PopupMenu : public Popup {
 		}
 	};
 
+	struct SortItems {
+		bool operator()(Item p_a, Item p_b) const {
+			return p_a.id < p_b.id;
+		}
+	};
+
 	Timer *submenu_timer;
 	List<Rect2> autohide_areas;
 	Vector<Item> items;
@@ -186,7 +192,7 @@ public:
 	void add_separator(const String &p_text = String());
 
 	void clear();
-
+	void sort_items_by_id();
 	void set_parent_rect(const Rect2 &p_rect);
 
 	virtual String get_tooltip(const Point2 &p_pos) const;


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/6558

Added a few features since these are always needed.
- Make sure there is always something selected
  - Always Select next on remove_item
  - Always Select first on add_item if current is -1
- Make sure no duplicate names are allowed (it is optional and disabled by default)
- Deselect all now works with `select(-1)`

Insert at id was not working, solved it by converting -1 to size() and added a sort by item.ID in PopupMenu. It updates item.ID on each sort. Adding an item at < `current` will increase `current` by one silently.

Example
```
func _ready():
	$OptionButton.add_item("0")
	$OptionButton.add_item("1")
	$OptionButton.add_item("2")
	$OptionButton.add_item("3")
	
	$OptionButton.add_item("0.0",0) # Moves 0 to index 1 and updates current from 0 to 1
```

Test 
```
extends Control

var option_button
var label_index

func _ready():
		
	var hb_label = HBoxContainer.new()
	var label = Label.new()
	label.text = "Selected: "
	label_index = Label.new()
	
	hb_label.add_child(label)
	hb_label.add_child(label_index)
	
	var vb = VBoxContainer.new()
	var hb = HBoxContainer.new()
	hb.set("custom_constants/separation", 20)
	
	var add = Button.new()
	var add_custom = Button.new()
	var delete = Button.new()
	var clear = Button.new()
	var select_nothing = Button.new()
	option_button = OptionButton.new()
	#option_button.set_allow_duplicates(false)
	option_button.connect("item_selected",self,"_on_OptionButton_item_selected")
	add()
	add()
	add()
	add()
	add()
	
	add.text = "Add"
	add_custom.text = "Add Custom"
	delete.text = "Delete"
	clear.text = "Clear"
	select_nothing.text = "Select Nothing"
	add.connect("pressed", self, "add")
	add_custom.connect("pressed", self, "add_custom")
	delete.connect("pressed", self, "delete")
	clear.connect("pressed", self, "clear")
	select_nothing.connect("pressed", self, "select_nothing")
	
	hb.add_child(add)
	hb.add_child(add_custom)
	hb.add_child(delete)
	hb.add_child(clear)
	hb.add_child(select_nothing)
	
	vb.add_child(hb)
	vb.add_child(hb_label)
	vb.add_child(option_button)
	
	add_child(vb)


func add():
	if !option_button.add_item("Element "+str(option_button.get_item_count())):
		print("Already in use: " + str(option_button.get_item_count()))
	
func add_custom():
	if !option_button.add_item("Custom Element "+str(option_button.get_item_count()), 0): # Try 0,1,2
		print("Already in use: " + str(option_button.get_item_count()))

func delete():
	option_button.remove_item(option_button.get_selected())
	
func clear():
	option_button.clear()

func select_nothing():
	option_button.select(-1)

func _process(delta):
	label_index.text = str(option_button.get_selected())
	
func _on_OptionButton_item_selected(ID):
	print("Event: " + str(ID))

```