### PR TITLE
Bind Curve::get_point_count

### DIFF
--- a/doc/classes/Curve.xml
+++ b/doc/classes/Curve.xml
@@ -49,6 +49,13 @@
 				Removes all points from the curve.
 			</description>
 		</method>
+		<method name="get_point_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the number of points describing the curve.
+			</description>
+		</method>
 		<method name="get_point_left_mode" qualifiers="const">
 			<return type="int" enum="Curve.TangentMode">
 			</return>

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -491,6 +491,7 @@ void Curve::ensure_default_setup(float p_min, float p_max) {
 
 void Curve::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("get_point_count"), &Curve::get_point_count);
 	ClassDB::bind_method(D_METHOD("add_point", "position", "left_tangent", "right_tangent", "left_mode", "right_mode"), &Curve::add_point, DEFVAL(0), DEFVAL(0), DEFVAL(TANGENT_FREE), DEFVAL(TANGENT_FREE));
 	ClassDB::bind_method(D_METHOD("remove_point", "index"), &Curve::remove_point);
 	ClassDB::bind_method(D_METHOD("clear_points"), &Curve::clear_points);


### PR DESCRIPTION
`get_point_count` is exposed for Curve2D and Curve3D but was not available in Curve for some reason.