### PR TITLE
Update Light properties in the inspector when dragging their gizmos

### DIFF
--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -48,6 +48,13 @@ void Light::set_param(Param p_param, float p_value) {
 
 	if (p_param == PARAM_SPOT_ANGLE || p_param == PARAM_RANGE) {
 		update_gizmo();
+
+		if (p_param == PARAM_SPOT_ANGLE) {
+			_change_notify("spot_angle");
+		} else if (p_param == PARAM_RANGE) {
+			_change_notify("omni_range");
+			_change_notify("spot_range");
+		}
 	}
 }
 


### PR DESCRIPTION
This is similar to https://github.com/godotengine/godot/commit/39e8aca1b77c6cba8f7fa22cc277441e5e86cd16, but for OmniLight and SpotLight.