### PR TITLE
Refactor core/cowdata.h

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -55,10 +55,9 @@ class CowData {
 private:
 	mutable T *_ptr;
 
-	// internal helpers
+	// Internal Helpers
 
 	_FORCE_INLINE_ uint32_t *_get_refcount() const {
-
 		if (!_ptr)
 			return NULL;
 
@@ -66,22 +65,13 @@ private:
 	}
 
 	_FORCE_INLINE_ uint32_t *_get_size() const {
-
 		if (!_ptr)
 			return NULL;
 
 		return reinterpret_cast<uint32_t *>(_ptr) - 1;
 	}
 
-	_FORCE_INLINE_ T *_get_data() const {
-
-		if (!_ptr)
-			return NULL;
-		return reinterpret_cast<T *>(_ptr);
-	}
-
 	_FORCE_INLINE_ size_t _get_alloc_size(size_t p_elements) const {
-		//return nearest_power_of_2_templated(p_elements*sizeof(T)+sizeof(SafeRefCount)+sizeof(int));
 		return next_power_of_2(p_elements * sizeof(T));
 	}
 
@@ -98,13 +88,13 @@ private:
 		return true;
 #else
 		// Speed is more important than correctness here, do the operations unchecked
-		// and hope the best
+		// and hope for the best
 		*out = _get_alloc_size(p_elements);
 		return true;
 #endif
 	}
 
-	void _unref(void *p_data);
+	void _unref();
 	void _ref(const CowData *p_from);
 	void _ref(const CowData &p_from);
 	void _copy_on_write();
@@ -114,15 +104,15 @@ public:
 
 	_FORCE_INLINE_ T *ptrw() {
 		_copy_on_write();
-		return (T *)_get_data();
+		return _ptr;
 	}
 
 	_FORCE_INLINE_ const T *ptr() const {
-		return _get_data();
+		return _ptr;
 	}
 
 	_FORCE_INLINE_ int size() const {
-		uint32_t *size = (uint32_t *)_get_size();
+		uint32_t *size = _get_size();
 		if (size)
 			return *size;
 		else
@@ -133,49 +123,45 @@ public:
 	_FORCE_INLINE_ bool empty() const { return _ptr == 0; }
 
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) {
-
 		CRASH_BAD_INDEX(p_index, size());
 		_copy_on_write();
-		_get_data()[p_index] = p_elem;
+		_ptr[p_index] = p_elem;
 	}
 
 	_FORCE_INLINE_ T &get_m(int p_index) {
-
 		CRASH_BAD_INDEX(p_index, size());
 		_copy_on_write();
-		return _get_data()[p_index];
+		return _ptr[p_index];
 	}
 
 	_FORCE_INLINE_ const T &get(int p_index) const {
-
 		CRASH_BAD_INDEX(p_index, size());
-
-		return _get_data()[p_index];
+		return _ptr[p_index];
 	}
 
 	Error resize(int p_size);
 
 	_FORCE_INLINE_ void remove(int p_index) {
-
 		ERR_FAIL_INDEX(p_index, size());
-		T *p = ptrw();
-		int len = size();
-		for (int i = p_index; i < len - 1; i++) {
 
+		T *p = ptrw();
+		int len_new = size() - 1;
+		for (int i = p_index; i < len_new; i++) {
 			p[i] = p[i + 1];
 		};
 
-		resize(len - 1);
+		resize(len_new);
 	};
 
 	Error insert(int p_pos, const T &p_val) {
-
 		ERR_FAIL_INDEX_V(p_pos, size() + 1, ERR_INVALID_PARAMETER);
-		resize(size() + 1);
-		for (int i = (size() - 1); i > p_pos; i--)
-			set(i, get(i - 1));
-		set(p_pos, p_val);
 
+		resize(size() + 1);
+		for (int i = (size() - 1); i > p_pos; i--) {
+			set(i, get(i - 1));
+		};
+
+		set(p_pos, p_val);
 		return OK;
 	};
 
@@ -187,29 +173,26 @@ public:
 };
 
 template <class T>
-void CowData<T>::_unref(void *p_data) {
+void CowData<T>::_unref() {
 
-	if (!p_data)
+	if (!_ptr)
 		return;
 
 	uint32_t *refc = _get_refcount();
-
 	if (atomic_decrement(refc) > 0)
 		return; // still in use
+
 	// clean up
-
 	if (!__has_trivial_destructor(T)) {
-		uint32_t *count = _get_size();
-		T *data = (T *)(count + 1);
-
-		for (uint32_t i = 0; i < *count; ++i) {
+		uint32_t count = *_get_size();
+		for (uint32_t i = 0; i < count; ++i) {
 			// call destructors
-			data[i].~T();
+			_ptr[i].~T();
 		}
 	}
 
 	// free mem
-	Memory::free_static((uint8_t *)p_data, true);
+	Memory::free_static(_ptr, true);
 }
 
 template <class T>
@@ -219,36 +202,32 @@ void CowData<T>::_copy_on_write() {
 		return;
 
 	uint32_t *refc = _get_refcount();
-
 	if (unlikely(*refc > 1)) {
 		/* in use by more than me */
 		uint32_t current_size = *_get_size();
+		uint32_t *mem = (uint32_t *)Memory::alloc_static(_get_alloc_size(current_size), true);
 
-		uint32_t *mem_new = (uint32_t *)Memory::alloc_static(_get_alloc_size(current_size), true);
-
-		*(mem_new - 2) = 1; //refcount
-		*(mem_new - 1) = current_size; //size
-
-		T *_data = (T *)(mem_new);
+		*(mem - 2) = 1; //refcount
+		*(mem - 1) = current_size; //size
+		T *data = (T *)mem;
 
 		// initialize new elements
 		if (__has_trivial_copy(T)) {
-			memcpy(mem_new, _ptr, current_size * sizeof(T));
+			memcpy(mem, _ptr, current_size * sizeof(T));
 
 		} else {
 			for (uint32_t i = 0; i < current_size; i++) {
-				memnew_placement(&_data[i], T(_get_data()[i]));
+				memnew_placement((data + i), T(_ptr[i]));
 			}
 		}
 
-		_unref(_ptr);
-		_ptr = _data;
+		_unref();
+		_ptr = data;
 	}
 }
 
 template <class T>
 Error CowData<T>::resize(int p_size) {
-
 	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
 
 	if (p_size == size())
@@ -256,63 +235,56 @@ Error CowData<T>::resize(int p_size) {
 
 	if (p_size == 0) {
 		// wants to clean up
-		_unref(_ptr);
+		_unref();
 		_ptr = NULL;
 		return OK;
 	}
 
-	// possibly changing size, copy on write
+	// Changing size, make unique
 	_copy_on_write();
 
 	size_t alloc_size;
 	ERR_FAIL_COND_V(!_get_alloc_size_checked(p_size, &alloc_size), ERR_OUT_OF_MEMORY);
 
 	if (p_size > size()) {
-
 		if (size() == 0) {
 			// alloc from scratch
 			uint32_t *ptr = (uint32_t *)Memory::alloc_static(alloc_size, true);
 			ERR_FAIL_COND_V(!ptr, ERR_OUT_OF_MEMORY);
-			*(ptr - 1) = 0; //size, currently none
-			*(ptr - 2) = 1; //refcount
-
+			*(ptr - 1) = 0; // Size is currently 0
+			*(ptr - 2) = 1; // Refcount
 			_ptr = (T *)ptr;
 
 		} else {
-			void *_ptrnew = (T *)Memory::realloc_static(_ptr, alloc_size, true);
-			ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
-			_ptr = (T *)(_ptrnew);
+			T *ptr = (T *)Memory::realloc_static(_ptr, alloc_size, true);
+			ERR_FAIL_COND_V(!ptr, ERR_OUT_OF_MEMORY);
+			_ptr = ptr;
 		}
 
 		// construct the newly created elements
-
 		if (!__has_trivial_constructor(T)) {
-			T *elems = _get_data();
-
 			for (int i = *_get_size(); i < p_size; i++) {
-				memnew_placement(&elems[i], T);
+				memnew_placement((_ptr + i), T);
 			}
 		}
 
-		*_get_size() = p_size;
-
-	} else if (p_size < size()) {
+	} else { // p_size < size()
 
 		if (!__has_trivial_destructor(T)) {
 			// deinitialize no longer needed elements
 			for (uint32_t i = p_size; i < *_get_size(); i++) {
-				T *t = &_get_data()[i];
+				T *t = (_ptr + i);
 				t->~T();
 			}
 		}
 
-		void *_ptrnew = (T *)Memory::realloc_static(_ptr, alloc_size, true);
-		ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
+		T *ptr = (T *)Memory::realloc_static(_ptr, alloc_size, true);
+		ERR_FAIL_COND_V(!ptr, ERR_OUT_OF_MEMORY);
 
-		_ptr = (T *)(_ptrnew);
-
-		*_get_size() = p_size;
+		_ptr = ptr;
 	}
+
+	*_get_size() = p_size;
 
 	return OK;
 }
@@ -321,14 +293,14 @@ template <class T>
 int CowData<T>::find(const T &p_val, int p_from) const {
 	int ret = -1;
 
-	if (p_from < 0 || size() == 0) {
+	if (p_from < 0)
 		return ret;
-	}
 
-	for (int i = p_from; i < size(); i++) {
+	int current_size = size();
+	for (int i = p_from; i < current_size; i++) {
 		if (get(i) == p_val) {
 			ret = i;
-			break;
+			return ret;
 		}
 	}
 
@@ -342,15 +314,14 @@ void CowData<T>::_ref(const CowData *p_from) {
 
 template <class T>
 void CowData<T>::_ref(const CowData &p_from) {
-
 	if (_ptr == p_from._ptr)
 		return; // self assign, do nothing.
 
-	_unref(_ptr);
+	_unref();
 	_ptr = NULL;
 
 	if (!p_from._ptr)
-		return; //nothing to do
+		return; // Nothing to do
 
 	if (atomic_conditional_increment(p_from._get_refcount()) > 0) { // could reference
 		_ptr = p_from._ptr;
@@ -359,14 +330,12 @@ void CowData<T>::_ref(const CowData &p_from) {
 
 template <class T>
 CowData<T>::CowData() {
-
 	_ptr = NULL;
 }
 
 template <class T>
 CowData<T>::~CowData() {
-
-	_unref(_ptr);
+	_unref();
 }
 
-#endif /* COW_H_ */
+#endif // COWDATA_H_


### PR DESCRIPTION
- Remove excess casting
- Removed parameter `p_data` from `unref(void *p_data)`, as it was just passing `_ptr` as `p_data`.
- Renamed variables
- Updated comments
