### PR TITLE
No longer save all scripts automatically when closing the editor.

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3270,8 +3270,8 @@ void ScriptEditorPlugin::selected_notify() {
 }
 
 void ScriptEditorPlugin::save_external_data() {
-
-	script_editor->save_all_scripts();
+	if (EDITOR_GET("interface/editor/save_each_scene_on_quit"))
+		script_editor->save_all_scripts();
 }
 
 void ScriptEditorPlugin::apply_changes() {


### PR DESCRIPTION
This fixes #18010.