### PR TITLE
Fix undo redo not showing errors

### DIFF
--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -268,7 +268,24 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
 
 			case Operation::TYPE_METHOD: {
 
-				obj->call(op.name, VARIANT_ARGS_FROM_ARRAY(op.args));
+				Vector<const Variant *> argptrs;
+				argptrs.resize(VARIANT_ARG_MAX);
+				int argc = 0;
+
+				for (int i = 0; i < VARIANT_ARG_MAX; i++) {
+					if (op.args[i].get_type() == Variant::NIL) {
+						break;
+					}
+					argptrs.write[i] = &op.args[i];
+					argc++;
+				}
+				argptrs.resize(argc);
+
+				Variant::CallError ce;
+				obj->call(op.name, (const Variant **)argptrs.ptr(), argc, ce);
+				if (ce.error != Variant::CallError::CALL_OK) {
+					ERR_PRINTS("Error calling method from signal '" + String(op.name) + "': " + Variant::get_call_error_text(obj, op.name, (const Variant **)argptrs.ptr(), argc, ce));
+				}
 #ifdef TOOLS_ENABLED
 				Resource *res = Object::cast_to<Resource>(obj);
 				if (res)


### PR DESCRIPTION
part of https://github.com/godotengine/godot/issues/18744

null args are still not recognized `null == Variant::Nil` ?

So this is not working properly?
https://github.com/godotengine/godot/blob/master/core/undo_redo.cpp#L148