### PR TITLE
Change the default variable Visual Script constructor to use EditorInspector and etc

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -321,7 +321,7 @@ protected:
 		p_list->push_back(PropertyInfo(Variant::INT, "type", PROPERTY_HINT_ENUM, argt));
 		p_list->push_back(PropertyInfo(script->get_variable_info(var).type, "value", script->get_variable_info(var).hint, script->get_variable_info(var).hint_string, PROPERTY_USAGE_DEFAULT));
 		// Update this when PropertyHint changes
-		p_list->push_back(PropertyInfo(Variant::INT, "hint", PROPERTY_HINT_ENUM, "None,Range,ExpRange,Enum,ExpEasing,Length,SpriteFrame,KeyAccel,Flags,Layers2dRender,Layers2dPhysics,Layer3dRender,Layer3dPhysics,File,Dir,GlobalFile,GlobalDir,ResourceType,MultilineText,ColorNoAlpha,ImageCompressLossy,ImageCompressLossLess,ObjectId,String,NodePathToEditedNode,MethodOfVariantType,MethodOfBaseType,MethodOfInstance,MethodOfScript,PropertyOfVariantType,PropertyOfBaseType,PropertyOfInstance,PropertyOfScript,ObjectTooBig"));
+		p_list->push_back(PropertyInfo(Variant::INT, "hint", PROPERTY_HINT_ENUM, "None,Range,ExpRange,Enum,ExpEasing,Length,SpriteFrame,KeyAccel,Flags,Layers2dRender,Layers2dPhysics,Layer3dRender,Layer3dPhysics,File,Dir,GlobalFile,GlobalDir,ResourceType,MultilineText,PlaceholderText,ColorNoAlpha,ImageCompressLossy,ImageCompressLossLess,ObjectId,String,NodePathToEditedNode,MethodOfVariantType,MethodOfBaseType,MethodOfInstance,MethodOfScript,PropertyOfVariantType,PropertyOfBaseType,PropertyOfInstance,PropertyOfScript,ObjectTooBig,NodePathValidTypes"));
 		p_list->push_back(PropertyInfo(Variant::STRING, "hint_string"));
 		p_list->push_back(PropertyInfo(Variant::BOOL, "export"));
 	}
@@ -3615,8 +3615,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	edit_signal_dialog->set_title(TTR("Edit Signal Arguments:"));
 
 	signal_editor = memnew(VisualScriptEditorSignalEdit);
-	edit_signal_edit = memnew(PropertyEditor);
-	edit_signal_edit->hide_top_label();
+	edit_signal_edit = memnew(EditorInspector);
 	edit_signal_dialog->add_child(edit_signal_edit);
 
 	edit_signal_edit->edit(signal_editor);
@@ -3627,8 +3626,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	edit_variable_dialog->set_title(TTR("Edit Variable:"));
 
 	variable_editor = memnew(VisualScriptEditorVariableEdit);
-	edit_variable_edit = memnew(PropertyEditor);
-	edit_variable_edit->hide_top_label();
+	edit_variable_edit = memnew(EditorInspector);
 	edit_variable_dialog->add_child(edit_variable_edit);
 
 	edit_variable_edit->edit(variable_editor);

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -93,7 +93,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 	VisualScriptEditorSignalEdit *signal_editor;
 
 	AcceptDialog *edit_signal_dialog;
-	PropertyEditor *edit_signal_edit;
+	EditorInspector *edit_signal_edit;
 
 	VisualScriptPropertySelector *method_select;
 	VisualScriptPropertySelector *new_connect_node_select;
@@ -102,7 +102,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 	VisualScriptEditorVariableEdit *variable_editor;
 
 	AcceptDialog *edit_variable_dialog;
-	PropertyEditor *edit_variable_edit;
+	EditorInspector *edit_variable_edit;
 
 	CustomPropertyEditor *default_value_edit;
 


### PR DESCRIPTION
For #18024.

Updated property hints and used EditorInspector instead of PropertyEditor.

The bug is that PropertyEditor was not updated to the code, so this patch uses the EditorInspector.

Don't know if it's ok to make the switch or I should actually fix PropertyEditor.

![screenshot from 2018-09-08 02-54-25](https://user-images.githubusercontent.com/32321/45252873-852e7e00-b312-11e8-9112-fd65a34da1ac.png)

![screenshot from 2018-09-08 02-55-14](https://user-images.githubusercontent.com/32321/45252887-a0998900-b312-11e8-979a-e39caa9853ba.png)

![screenshot from 2018-09-08 02-55-53](https://user-images.githubusercontent.com/32321/45252893-b8710d00-b312-11e8-9a17-40264aeacdd0.png)
