### PR TITLE
Make `_sort_list_on_update` true before opening files, fixes 14400

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1793,8 +1793,8 @@ void ScriptEditor::_update_script_names() {
 				new_cur_tab = i;
 			}
 		}
-		tab_container->call_deferred("set_current_tab", new_prev_tab);
-		tab_container->call_deferred("set_current_tab", new_cur_tab);
+		tab_container->set_current_tab(new_prev_tab);
+		tab_container->set_current_tab(new_cur_tab);
 		_sort_list_on_update = false;
 	}
 
@@ -2017,6 +2017,7 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 		_go_to_tab(tab_container->get_tab_count() - 1);
 	}
 
+	_sort_list_on_update = true;
 	_update_script_names();
 	_save_layout();
 	se->connect("name_changed", this, "_update_script_names");
@@ -2591,6 +2592,7 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 	eh->go_to_class(p_class, 0);
 	eh->connect("go_to_help", this, "_help_class_goto");
 	_add_recent_script(p_class);
+	_sort_list_on_update = true;
 	_update_script_names();
 	_save_layout();
 }
@@ -2620,6 +2622,7 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	eh->go_to_help(p_desc);
 	eh->connect("go_to_help", this, "_help_class_goto");
 	_add_recent_script(eh->get_class());
+	_sort_list_on_update = true;
 	_update_script_names();
 	_save_layout();
 }


### PR DESCRIPTION
Looks like this issue was due to `_sort_list_on_update` not being set back to true before `_update_script_names()` is called in the appropriate functions. I have also changed the deferred calls to immediate, which keeps the indices relevant.

closes #14400


_Apologies for edits, mis-hit enter key while opening PR._