### PR TITLE
Fix ScriptCreateDialog passing script w/ no filename

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -443,6 +443,12 @@ void ScriptCreateDialog::_path_changed(const String &p_path) {
 		return;
 	}
 
+	if (p.get_file().get_basename() == "") {
+		_msg_path_valid(false, TTR("Filename is empty"));
+		_update_dialog();
+		return;
+	}
+
 	/* All checks passed */
 
 	is_path_valid = true;


### PR DESCRIPTION
Fixes #13965, but there's another bug in that one that needs investigating, so it can't be closed yet.