### PR TITLE
Resurrect integrated error display for the Debugger.

### DIFF
--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -88,8 +88,7 @@ class ScriptEditorDebugger : public Control {
 	Set<ObjectID> unfold_cache;
 
 	HSplitContainer *error_split;
-	ItemList *error_list;
-	ItemList *error_stack;
+	Tree *error_tree;
 	Tree *inspect_scene_tree;
 	Button *clearbutton;
 	PopupMenu *item_menu;
@@ -179,8 +178,8 @@ class ScriptEditorDebugger : public Control {
 	void _method_changed(Object *p_base, const StringName &p_name, VARIANT_ARG_DECLARE);
 	void _property_changed(Object *p_base, const StringName &p_property, const Variant &p_value);
 
-	void _error_selected(int p_idx);
-	void _error_stack_selected(int p_idx);
+	void _error_activated();
+	void _error_selected();
 
 	void _profiler_activate(bool p_enable);
 	void _profiler_seeked();
@@ -191,7 +190,7 @@ class ScriptEditorDebugger : public Control {
 	void _clear_remote_objects();
 	void _clear_errors_list();
 
-	void _error_list_item_rmb_selected(int p_item, const Vector2 &p_pos);
+	void _error_tree_item_rmb_selected(const Vector2 &p_pos);
 	void _item_menu_id_pressed(int p_option);
 
 protected:


### PR DESCRIPTION
I have taken a look at how the editor has changed since I originally made this feature(https://github.com/godotengine/godot/pull/15272) and found it simpler to just re-write on top of the changes made since. I was able to integrate the right-click error copy as well. No rebase should be necessary.

I made use of @akien-mga 's suggested changes from the branch indicated. We should finally be able to close #15234 and salvage this.

![image](https://user-images.githubusercontent.com/5884865/45259629-14817300-b39f-11e8-9865-ca9f17cf7831.png)

I would appreciate any feedback. Thank you.

*Edit:* Also fixes #21676