### PR TITLE
Fix and refactor core/list.h

### DIFF
--- a/core/list.h
+++ b/core/list.h
@@ -58,83 +58,62 @@ public:
 		_Data *data;
 
 	public:
-		/**
-		 * Get NEXT Element iterator, for constant lists.
-		 */
+		// Get NEXT Element iterator, for constant lists.
 		_FORCE_INLINE_ const Element *next() const {
-
 			return next_ptr;
 		};
-		/**
-		 * Get NEXT Element iterator,
-		 */
+
+		// Get NEXT Element iterator.
 		_FORCE_INLINE_ Element *next() {
-
 			return next_ptr;
 		};
 
-		/**
-		 * Get PREV Element iterator, for constant lists.
-		 */
+		// Get PREV Element iterator, for constant lists.
 		_FORCE_INLINE_ const Element *prev() const {
-
 			return prev_ptr;
 		};
-		/**
-		 * Get PREV Element iterator,
-		 */
+
+		// Get PREV Element iterator,
 		_FORCE_INLINE_ Element *prev() {
-
 			return prev_ptr;
 		};
 
-		/**
-		 * * operator, for using as *iterator, when iterators are defined on stack.
-		 */
+		// Operator *, for using as *iterator, when iterators are defined on stack, for constant lists.
 		_FORCE_INLINE_ const T &operator*() const {
 			return value;
 		};
-		/**
-		 * operator->, for using as iterator->, when iterators are defined on stack, for constant lists.
-		 */
-		_FORCE_INLINE_ const T *operator->() const {
 
+		// Operator->, for using as iterator->, when iterators are defined on stack, for constant lists.
+		_FORCE_INLINE_ const T *operator->() const {
 			return &value;
 		};
-		/**
-		 * * operator, for using as *iterator, when iterators are defined on stack,
-		 */
+
+		// Operator *, for using as *iterator, when iterators are defined on stack.
 		_FORCE_INLINE_ T &operator*() {
 			return value;
 		};
-		/**
-		 * operator->, for using as iterator->, when iterators are defined on stack, for constant lists.
-		 */
+
+		// Operator->, for using as iterator->, when iterators are defined on stack.
 		_FORCE_INLINE_ T *operator->() {
 			return &value;
 		};
 
-		/**
-		 * get the value stored in this element.
-		 */
+		// Get the value stored in this element.
 		_FORCE_INLINE_ T &get() {
 			return value;
 		};
-		/**
-		 * get the value stored in this element, for constant lists
-		 */
+
+		// Get the value stored in this element, for constant lists.
 		_FORCE_INLINE_ const T &get() const {
 			return value;
 		};
-		/**
-		 * set the value stored in this element.
-		 */
+
+		// Set the value stored in this element.
 		_FORCE_INLINE_ void set(const T &p_value) {
 			value = (T &)p_value;
 		};
 
 		void erase() {
-
 			data->erase(this);
 		}
 
@@ -153,22 +132,20 @@ private:
 		int size_cache;
 
 		bool erase(const Element *p_I) {
-
 			ERR_FAIL_COND_V(!p_I, false);
 			ERR_FAIL_COND_V(p_I->data != this, false);
 
-			if (first == p_I) {
-				first = p_I->next_ptr;
-			};
-
-			if (last == p_I)
-				last = p_I->prev_ptr;
-
-			if (p_I->prev_ptr)
+			if (p_I->prev_ptr) {
 				p_I->prev_ptr->next_ptr = p_I->next_ptr;
+			} else { // p_I == first
+				first = p_I->next_ptr;
+			}
 
-			if (p_I->next_ptr)
+			if (p_I->next_ptr) {
 				p_I->next_ptr->prev_ptr = p_I->prev_ptr;
+			} else { // p_I == last
+				last = p_I->prev_ptr;
+			}
 
 			memdelete_allocator<Element, A>(const_cast<Element *>(p_I));
 			size_cache--;
@@ -180,44 +157,29 @@ private:
 	_Data *_data;
 
 public:
-	/**
-	* return a const iterator to the beginning of the list.
-	*/
+	// Return a const iterator to the beginning of the list.
 	_FORCE_INLINE_ const Element *front() const {
-
 		return _data ? _data->first : 0;
 	};
 
-	/**
-	* return an iterator to the beginning of the list.
-	*/
+	// Return an iterator to the beginning of the list.
 	_FORCE_INLINE_ Element *front() {
 		return _data ? _data->first : 0;
 	};
 
-	/**
- 	* return a const iterator to the last member of the list.
-	*/
+	// Return a const iterator to the last member of the list.
 	_FORCE_INLINE_ const Element *back() const {
-
 		return _data ? _data->last : 0;
 	};
 
-	/**
- 	* return an iterator to the last member of the list.
-	*/
+	// Return an iterator to the last member of the list.
 	_FORCE_INLINE_ Element *back() {
-
 		return _data ? _data->last : 0;
 	};
 
-	/**
-	 * store a new element at the end of the list
-	 */
+	// Store a new element at the end of the list.
 	Element *push_back(const T &value) {
-
 		if (!_data) {
-
 			_data = memnew_allocator(_Data, A);
 			_data->first = NULL;
 			_data->last = NULL;
@@ -226,39 +188,29 @@ public:
 
 		Element *n = memnew_allocator(Element, A);
 		n->value = (T &)value;
-
 		n->prev_ptr = _data->last;
 		n->next_ptr = 0;
 		n->data = _data;
 
-		if (_data->last) {
-
+		if (_data->last)
 			_data->last->next_ptr = n;
-		}
 
 		_data->last = n;
-
 		if (!_data->first)
 			_data->first = n;
 
 		_data->size_cache++;
-
 		return n;
 	};
 
 	void pop_back() {
-
 		if (_data && _data->last)
 			erase(_data->last);
 	}
 
-	/**
-	 * store a new element at the beginning of the list
-	 */
+	// Store a new element at the beginning of the list.
 	Element *push_front(const T &value) {
-
 		if (!_data) {
-
 			_data = memnew_allocator(_Data, A);
 			_data->first = NULL;
 			_data->last = NULL;
@@ -267,27 +219,22 @@ public:
 
 		Element *n = memnew_allocator(Element, A);
 		n->value = (T &)value;
-		n->prev_ptr = 0;
+		n->prev_ptr = NULL;
 		n->next_ptr = _data->first;
 		n->data = _data;
 
-		if (_data->first) {
-
+		if (_data->first)
 			_data->first->prev_ptr = n;
-		}
 
 		_data->first = n;
-
 		if (!_data->last)
 			_data->last = n;
 
 		_data->size_cache++;
-
 		return n;
 	};
 
 	void pop_front() {
-
 		if (_data && _data->first)
 			erase(_data->first);
 	}
@@ -295,9 +242,8 @@ public:
 	Element *insert_after(Element *p_element, const T &p_value) {
 		CRASH_COND(p_element && (!_data || p_element->data != _data));
 
-		if (!p_element) {
+		if (!p_element)
 			return push_back(p_value);
-		}
 
 		Element *n = memnew_allocator(Element, A);
 		n->value = (T &)p_value;
@@ -314,16 +260,14 @@ public:
 		p_element->next_ptr = n;
 
 		_data->size_cache++;
-
 		return n;
 	}
 
 	Element *insert_before(Element *p_element, const T &p_value) {
 		CRASH_COND(p_element && (!_data || p_element->data != _data));
 
-		if (!p_element) {
+		if (!p_element)
 			return push_back(p_value);
-		}
 
 		Element *n = memnew_allocator(Element, A);
 		n->value = (T &)p_value;
@@ -340,16 +284,12 @@ public:
 		p_element->prev_ptr = n;
 
 		_data->size_cache++;
-
 		return n;
 	}
 
-	/**
-	 * find an element in the list,
-	 */
+	// Find an element in the list.
 	template <class T_v>
 	Element *find(const T_v &p_val) {
-
 		Element *it = front();
 		while (it) {
 			if (it->value == p_val) return it;
@@ -359,11 +299,9 @@ public:
 		return NULL;
 	};
 
-	/**
-	 * erase an element in the list, by iterator pointing to it. Return true if it was found/erased.
-	 */
+	// Erase an element in the list, by iterator pointing to it.
+	// Return true if it was found/erased.
 	bool erase(const Element *p_I) {
-
 		if (_data) {
 			bool ret = _data->erase(p_I);
 
@@ -378,89 +316,88 @@ public:
 		return false;
 	};
 
-	/**
-	 * erase the first element in the list, that contains value
-	 */
+	// Erase the first element in the list that contains value.
 	bool erase(const T &value) {
-
 		Element *I = find(value);
 		return erase(I);
 	};
 
-	/**
-	 * return whether the list is empty
-	 */
+	// Return whether the list is empty
 	_FORCE_INLINE_ bool empty() const {
-
 		return (!_data || !_data->size_cache);
 	}
 
-	/**
-	 * clear the list
-	 */
+	// Clear the list
 	void clear() {
-
 		while (front()) {
 			erase(front());
 		};
 	};
 
 	_FORCE_INLINE_ int size() const {
-
 		return _data ? _data->size_cache : 0;
 	}
 
 	void swap(Element *p_A, Element *p_B) {
-
 		ERR_FAIL_COND(!p_A || !p_B);
 		ERR_FAIL_COND(p_A->data != _data);
 		ERR_FAIL_COND(p_B->data != _data);
 
+		if (p_A == p_B)
+			return;
+
 		Element *A_prev = p_A->prev_ptr;
 		Element *A_next = p_A->next_ptr;
 
-		p_A->next_ptr = p_B->next_ptr;
 		p_A->prev_ptr = p_B->prev_ptr;
+		p_A->next_ptr = p_B->next_ptr;
 
-		p_B->next_ptr = A_next;
 		p_B->prev_ptr = A_prev;
+		p_B->next_ptr = A_next;
 
-		if (p_A->prev_ptr)
+		if (p_A->prev_ptr) {
 			p_A->prev_ptr->next_ptr = p_A;
-		if (p_A->next_ptr)
+		} else { // p_A is first
+			_data->first = p_A;
+		}
+		if (p_A->next_ptr) {
 			p_A->next_ptr->prev_ptr = p_A;
+		} else { // p_A is last
+			_data->last = p_A;
+		}
 
-		if (p_B->prev_ptr)
+		if (p_B->prev_ptr) {
 			p_B->prev_ptr->next_ptr = p_B;
-		if (p_B->next_ptr)
+		} else { // p_B is first
+			_data->first = p_B;
+		}
+		if (p_B->next_ptr) {
 			p_B->next_ptr->prev_ptr = p_B;
+		} else { // p_B is last
+			_data->last = p_B;
+		}
 	}
-	/**
-	 * copy the list
-	 */
-	void operator=(const List &p_list) {
 
+	// Copy the list
+	void operator=(const List &p_list) {
 		clear();
+
 		const Element *it = p_list.front();
 		while (it) {
-
 			push_back(it->get());
 			it = it->next();
 		}
 	}
 
 	T &operator[](int p_index) {
-
 		CRASH_BAD_INDEX(p_index, size());
 
 		Element *I = front();
 		int c = 0;
 		while (I) {
-
-			if (c == p_index) {
-
+			if (c == p_index)
 				return I->get();
-			}
+
 			I = I->next();
 			c++;
 		}
@@ -469,17 +406,14 @@ public:
 	}
 
 	const T &operator[](int p_index) const {
-
 		CRASH_BAD_INDEX(p_index, size());
 
 		const Element *I = front();
 		int c = 0;
 		while (I) {
-
-			if (c == p_index) {
-
+			if (c == p_index)
 				return I->get();
-			}
+
 			I = I->next();
 			c++;
 		}
@@ -488,20 +422,16 @@ public:
 	}
 
 	void move_to_back(Element *p_I) {
-
 		ERR_FAIL_COND(p_I->data != _data);
-		if (!p_I->next_ptr)
-			return;
-
-		if (_data->first == p_I) {
-			_data->first = p_I->next_ptr;
-		};
 
 		if (_data->last == p_I)
-			_data->last = p_I->prev_ptr;
+			return; // Already last
 
-		if (p_I->prev_ptr)
+		if (p_I->prev_ptr) {
 			p_I->prev_ptr->next_ptr = p_I->next_ptr;
+		} else { // p_I is first
+			_data->first = p_I->next_ptr;
+		}
 
 		p_I->next_ptr->prev_ptr = p_I->prev_ptr;
 
@@ -512,35 +442,36 @@ public:
 	}
 
 	void invert() {
+		int len = size();
+		Element *current = front();
+		Element *next = current->next_ptr;
 
-		int s = size() / 2;
-		Element *F = front();
-		Element *B = back();
-		for (int i = 0; i < s; i++) {
+		for (int i = 0; i < len; i++) {
+			// Swap current element, prev and next ptrs
+			SWAP(current->prev_ptr, current->next_ptr);
 
-			SWAP(F->value, B->value);
-			F = F->next();
-			B = B->prev();
+			// Set up to flip next element ptrs in next iteration
+			current = next;
+			next = current->next_ptr;
 		}
+
+		// Flip data ptrs
+		SWAP(_data->first, _data->last);
 	}
 
 	void move_to_front(Element *p_I) {
-
 		ERR_FAIL_COND(p_I->data != _data);
-		if (!p_I->prev_ptr)
-			return;
 
-		if (_data->first == p_I) {
-			_data->first = p_I->next_ptr;
-		};
-
-		if (_data->last == p_I)
-			_data->last = p_I->prev_ptr;
+		if (_data->first == p_I)
+			return; // Already first
 
 		p_I->prev_ptr->next_ptr = p_I->next_ptr;
 
-		if (p_I->next_ptr)
+		if (p_I->next_ptr) {
 			p_I->next_ptr->prev_ptr = p_I->prev_ptr;
+		} else { // p_I is last
+			_data->last = p_I->prev_ptr;
+		}
 
 		_data->first->prev_ptr = p_I;
 		p_I->next_ptr = _data->first;
@@ -549,7 +480,7 @@ public:
 	}
 
 	void move_before(Element *value, Element *where) {
-
+		// Remove value from list
 		if (value->prev_ptr) {
 			value->prev_ptr->next_ptr = value->next_ptr;
 		} else {
@@ -561,100 +492,96 @@ public:
 			_data->last = value->prev_ptr;
 		}
 
+		// Add value back into list
 		value->next_ptr = where;
-		if (!where) {
+		if (!where) { // value is moved to last
 			value->prev_ptr = _data->last;
+
+			if (value->prev_ptr)
+				value->prev_ptr->next_ptr = value;
+			else
+				_data->first = value;
+
 			_data->last = value;
 			return;
 		};
 
 		value->prev_ptr = where->prev_ptr;
+		where->prev_ptr = value;
 
-		if (where->prev_ptr) {
-			where->prev_ptr->next_ptr = value;
+		if (value->prev_ptr) {
+			value->prev_ptr->next_ptr = value;
 		} else {
 			_data->first = value;
 		};
-
-		where->prev_ptr = value;
 	};
 
-	/**
-	 * simple insertion sort
-	 */
-
+	// Simple insertion sort
 	void sort() {
-
 		sort_custom<Comparator<T> >();
 	}
 
 	template <class C>
 	void sort_custom_inplace() {
-
 		if (size() < 2)
 			return;
 
-		Element *from = front();
-		Element *current = from;
-		Element *to = from;
+		Element *current = front();
+		Element *next = current->next_ptr;
+
+		// Disconnect first element to and use it to begin sorted list
+		current->prev_ptr = NULL;
+		current->next_ptr = NULL;
+		// _data->first should already equal current
+		_data->last = current;
+
+		current = next;
 
 		while (current) {
+			next = current->next_ptr;
 
-			Element *next = current->next_ptr;
-
-			//disconnect
-			current->next_ptr = NULL;
-
-			if (from != current) {
-
-				current->prev_ptr = NULL;
-				current->next_ptr = from;
-
-				Element *find = from;
-				C less;
-				while (find && less(find->value, current->value)) {
-
-					current->prev_ptr = find;
-					current->next_ptr = find->next_ptr;
-					find = find->next_ptr;
-				}
-
-				if (current->prev_ptr)
-					current->prev_ptr->next_ptr = current;
-				else
-					from = current;
-
-				if (current->next_ptr)
-					current->next_ptr->prev_ptr = current;
-				else
-					to = current;
-			} else {
-
-				current->prev_ptr = NULL;
-				current->next_ptr = NULL;
+			// Find element bigger than current, within the sorted elements
+			Element *find = _data->first;
+			C less;
+			while (find && less(find->value, current->value)) {
+				find = find->next_ptr;
 			}
 
+			// Place current element into sorted list
+			if (find) {
+				current->next_ptr = find;
+				current->prev_ptr = find->prev_ptr;
+				current->next_ptr->prev_ptr = current;
+			} else { // current element is placed at end of sorted list
+				current->next_ptr = NULL;
+				current->prev_ptr = _data->last;
+				_data->last = current;
+			}
+
+			if (current->prev_ptr) {
+				current->prev_ptr->next_ptr = current;
+			} else {
+				_data->first = current;
+			}
+
+			// Setup for next iteration
 			current = next;
 		}
-		_data->first = from;
-		_data->last = to;
 	}
 
 	template <class C>
 	struct AuxiliaryComparator {
-
 		C compare;
-		_FORCE_INLINE_ bool operator()(const Element *a, const Element *b) const {
 
+		_FORCE_INLINE_ bool operator()(const Element *a, const Element *b) const {
 			return compare(a->value, b->value);
 		}
 	};
 
 	template <class C>
 	void sort_custom() {
-
-		//this version uses auxiliary memory for speed.
-		//if you don't want to use auxiliary memory, use the in_place version
+		// This version uses auxiliary memory for speed.
+		// If you don't want to use auxiliary memory, use sort_custom_inplace()
 
 		int s = size();
 		if (s < 2)
@@ -664,7 +591,6 @@ public:
 
 		int idx = 0;
 		for (Element *E = front(); E; E = E->next_ptr) {
-
 			aux_buffer[idx] = E;
 			idx++;
 		}
@@ -681,7 +607,6 @@ public:
 		aux_buffer[s - 1]->next_ptr = NULL;
 
 		for (int i = 1; i < s - 1; i++) {
-
 			aux_buffer[i]->prev_ptr = aux_buffer[i - 1];
 			aux_buffer[i]->next_ptr = aux_buffer[i + 1];
 		}
@@ -693,15 +618,12 @@ public:
 		return (void *)_data;
 	}
 
-	/**
-	 * copy constructor for the list
-	 */
+	// Copy constructor for the list
 	List(const List &p_list) {
-
 		_data = NULL;
+
 		const Element *it = p_list.front();
 		while (it) {
-
 			push_back(it->get());
 			it = it->next();
 		}
@@ -710,14 +632,15 @@ public:
 	List() {
 		_data = NULL;
 	};
+
 	~List() {
 		clear();
-		if (_data) {
 
+		if (_data) {
 			ERR_FAIL_COND(_data->size_cache);
 			memdelete_allocator<_Data, A>(_data);
 		}
 	};
 };
 
-#endif
+#endif // GLOBALS_LIST_H


### PR DESCRIPTION
- Fixed `swap(Element *p_A, Element *p_B)` so `_data->first` and `_data->last` are accounted for.
- Updated `invert()` to a more performant version.
- Updated `sort_custom_inplace()` to be more readable and performant.

**Refactoring:**
- Simplified code
- Simplified comments
- Adjusted spacing