### PR TITLE
Clear cache after reimporting an ArrayMesh

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1375,6 +1375,7 @@ void ArrayMesh::reload_from_file() {
 	VisualServer::get_singleton()->mesh_clear(mesh);
 	surfaces.clear();
 	clear_blend_shapes();
+	clear_cache();
 
 	Resource::reload_from_file();
 


### PR DESCRIPTION
Mesh cache was not being cleared after reimporting an ArrayMesh, causing issues like #18014.