### PR TITLE
Removed unused code

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3098,40 +3098,6 @@ void RasterizerSceneGLES3::_copy_screen(bool p_invalidate_color, bool p_invalida
 	glBindVertexArray(0);
 }
 
-void RasterizerSceneGLES3::_copy_to_front_buffer(Environment *env) {
-
-	//copy to front buffer
-	glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo);
-
-	glDepthMask(GL_FALSE);
-	glDisable(GL_DEPTH_TEST);
-	glDisable(GL_CULL_FACE);
-	glDisable(GL_BLEND);
-	glDepthFunc(GL_LEQUAL);
-	glColorMask(1, 1, 1, 1);
-
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->buffers.diffuse);
-
-	storage->shaders.copy.set_conditional(CopyShaderGLES3::DISABLE_ALPHA, true);
-
-	if (!env) {
-		//no environment, simply convert from linear to srgb
-		storage->shaders.copy.set_conditional(CopyShaderGLES3::LINEAR_TO_SRGB, true);
-	} else {
-		/* FIXME: Why are both statements equal? */
-		storage->shaders.copy.set_conditional(CopyShaderGLES3::LINEAR_TO_SRGB, true);
-	}
-
-	storage->shaders.copy.bind();
-
-	_copy_screen();
-
-	//turn off everything used
-	storage->shaders.copy.set_conditional(CopyShaderGLES3::LINEAR_TO_SRGB, false);
-	storage->shaders.copy.set_conditional(CopyShaderGLES3::DISABLE_ALPHA, false);
-}
-
 void RasterizerSceneGLES3::_copy_texture_to_front_buffer(GLuint p_texture) {
 
 	//copy to front buffer

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -837,7 +837,6 @@ public:
 	void _setup_reflections(RID *p_reflection_probe_cull_result, int p_reflection_probe_cull_count, const Transform &p_camera_inverse_transform, const CameraMatrix &p_camera_projection, RID p_reflection_atlas, Environment *p_env);
 
 	void _copy_screen(bool p_invalidate_color = false, bool p_invalidate_depth = false);
-	void _copy_to_front_buffer(Environment *env);
 	void _copy_texture_to_front_buffer(GLuint p_texture); //used for debug
 
 	void _fill_render_list(InstanceBase **p_cull_result, int p_cull_count, bool p_depth_pass, bool p_shadow_pass);


### PR DESCRIPTION
Fixes #15667

From what I can tell, everything the warnings point to is unused code.

The last warning that still shows up is:
```
[modules/visual_script/visual_script.cpp:1718] -> [modules/visual_script/visual_script.cpp:1716]: (style, inconclusive) Found duplicate branches for 'if' and 'else'.
```

But can be ignored since `VSDEBUG` is simply nothing:
https://github.com/godotengine/godot/blob/1093c0ff51b980634dffdd9618eaa53061da6419/modules/visual_script/visual_script.cpp#L1441

Which makes the following if-else an obvious duplicate branch that probably gets optimized out by the compiler anyway:
https://github.com/godotengine/godot/blob/1093c0ff51b980634dffdd9618eaa53061da6419/modules/visual_script/visual_script.cpp#L1716-L1720