### PR TITLE
Fixed calling start() after remove_all() on tween not working

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -673,6 +673,10 @@ float Tween::get_speed_scale() const {
 }
 
 bool Tween::start() {
+	if (pending_update != 0) {
+		call_deferred("start");
+		return true;
+	}
 
 	set_active(true);
 	return true;


### PR DESCRIPTION
Fixed calling start() immediately after remove_all() on tween not working

Fixes #19901