### PR TITLE
When resizing an X11 window wait for the WM to process our request

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1079,6 +1079,16 @@ Size2 OS_X11::get_real_window_size() const {
 }
 
 void OS_X11::set_window_size(const Size2 p_size) {
+
+	if (current_videomode.width == p_size.width && current_videomode.height == p_size.height)
+		return;
+
+	XWindowAttributes xwa;
+	XSync(x11_display, False);
+	XGetWindowAttributes(x11_display, x11_window, &xwa);
+	int old_w = xwa.width;
+	int old_h = xwa.height;
+
 	// If window resizable is disabled we need to update the attributes first
 	if (is_window_resizable() == false) {
 		XSizeHints *xsh;
@@ -1098,6 +1108,16 @@ void OS_X11::set_window_size(const Size2 p_size) {
 	// Update our videomode width and height
 	current_videomode.width = p_size.x;
 	current_videomode.height = p_size.y;
+
+	for (int timeout = 0; timeout < 50; ++timeout) {
+		XSync(x11_display, False);
+		XGetWindowAttributes(x11_display, x11_window, &xwa);
+
+		if (old_w != xwa.width || old_h != xwa.height)
+			break;
+
+		usleep(10000);
+	}
 }
 
 void OS_X11::set_window_fullscreen(bool p_enabled) {


### PR DESCRIPTION
On X11 when we send an XResizeWindow request to the X server it is happy
to say it is done when the request has been handed over to the window
manager. The window manager itself may however take some time to
actually do the resize. Godot expects that a resize request is
immediate. To work around this issue we could implement the whole
_NET_WM_SYNC_REQUEST protocol. However this protocol does not fit very
well with the way we currently process X events and would when
implemented in the current framework still cause a 1 frame delay between
a resize request and the actual resize happening.

This fixes #21720