### PR TITLE
Some work on double-precision support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -119,6 +119,7 @@ opts.Add(BoolVariable("tools", "Build the tools (a.k.a. the Godot editor)", True
 opts.Add(EnumVariable("target", "Compilation target", "debug", ("debug", "release_debug", "release")))
 opts.Add("arch", "Platform-dependent architecture (arm/arm64/x86/x64/mips/...)", "")
 opts.Add(EnumVariable("bits", "Target platform bits", "default", ("default", "32", "64")))
+opts.Add(EnumVariable("float", "Floating-point precision", "default", ("default", "32", "64")))
 opts.Add(EnumVariable("optimize", "Optimization type", "speed", ("speed", "size", "none")))
 opts.Add(BoolVariable("production", "Set defaults to build Godot for use in production", False))
 opts.Add(BoolVariable("use_lto", "Use link-time optimization", False))
@@ -326,6 +327,9 @@ if env_base["no_editor_splash"]:
 
 if not env_base["deprecated"]:
     env_base.Append(CPPDEFINES=["DISABLE_DEPRECATED"])
+
+if env_base["float"] == "64":
+    env_base.Append(CPPDEFINES=["REAL_T_IS_DOUBLE"])
 
 if selected_platform in platform_list:
     tmppath = "./platform/" + selected_platform
@@ -563,6 +567,9 @@ if selected_platform in platform_list:
         suffix = "." + detect.get_program_suffix()
     else:
         suffix = "." + selected_platform
+
+    if env_base["float"] == "64":
+        suffix += ".double"
 
     if env["target"] == "release":
         if env["tools"]:

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1414,7 +1414,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 	//animation->set_loop(true);
 	//create animation tracks
 
-	Vector<float> base_snapshots;
+	Vector<real_t> base_snapshots;
 
 	float f = 0;
 	float snapshot_interval = 1.0 / bake_fps; //should be customizable somewhere...
@@ -1466,7 +1466,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 		animation->track_set_path(track, path);
 		animation->track_set_imported(track, true); //helps merging later
 
-		Vector<float> snapshots = base_snapshots;
+		Vector<real_t> snapshots = base_snapshots;
 
 		if (nm.anim_tracks.size() == 1) {
 			//use snapshot keys from anim track instead, because this was most likely exported baked

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -92,7 +92,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	PopupMenu *animations_menu;
 	Vector<String> animations_to_add;
 	float add_point_pos;
-	Vector<float> points;
+	Vector<real_t> points;
 
 	bool dragging_selected_attempt;
 	bool dragging_selected;

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -56,7 +56,7 @@ public:
 	Transform2D pre_drag_xform;
 	Rect2 pre_drag_rect;
 
-	List<float> pre_drag_bones_length;
+	List<real_t> pre_drag_bones_length;
 	List<Dictionary> pre_drag_bones_undo_state;
 
 	Dictionary undo_state;

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -386,7 +386,7 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	Vector<Vector3> vertices;
 	Vector<Vector3> normals;
 	Vector<Vector2> uvs;
-	Vector<float> tangents;
+	Vector<real_t> tangents;
 	Basis tt = Basis(Vector3(0, 1, 0), Math_PI * 0.5);
 
 	for (int i = 1; i <= lats; i++) {
@@ -635,7 +635,7 @@ Ref<Texture2D> EditorAudioStreamPreviewPlugin::generate(const RES &p_from, const
 	Ref<AudioStreamPlayback> playback = stream->instance_playback();
 	ERR_FAIL_COND_V(playback.is_null(), Ref<Texture2D>());
 
-	float len_s = stream->get_length();
+	real_t len_s = stream->get_length();
 	if (len_s == 0) {
 		len_s = 60; //one minute audio if no length specified
 	}
@@ -649,8 +649,8 @@ Ref<Texture2D> EditorAudioStreamPreviewPlugin::generate(const RES &p_from, const
 	playback->stop();
 
 	for (int i = 0; i < w; i++) {
-		float max = -1000;
-		float min = 1000;
+		real_t max = -1000;
+		real_t min = 1000;
 		int from = uint64_t(i) * frame_length / w;
 		int to = (uint64_t(i) + 1) * frame_length / w;
 		to = MIN(to, frame_length);

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -63,7 +63,7 @@ class EditorNode3DGizmo : public Node3DGizmo {
 	Vector<Vector3> secondary_handles;
 	Vector<int> secondary_handle_ids;
 
-	float selectable_icon_size;
+	real_t selectable_icon_size;
 	bool billboard_handle;
 
 	bool valid;

--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -12,6 +12,8 @@ thirdparty_obj = []
 if env["builtin_bullet"]:
     # Build only version 2 for now (as of 2.89)
     # Sync file list with relevant upstream CMakeLists.txt for each folder.
+    if env["float"] == "64":
+        env.Append(CPPDEFINES=["BT_USE_DOUBLE_PRECISION=1"])
     thirdparty_dir = "#thirdparty/bullet/"
 
     bullet2_src = [

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -83,14 +83,14 @@ private:
 		Vector<Vector3> vertices;
 		Vector<Vector3> normals;
 		Vector<Vector2> uvs;
-		Vector<float> tans;
+		Vector<real_t> tans;
 		Ref<Material> material;
 		int last_added = 0;
 
 		Vector3 *verticesw = nullptr;
 		Vector3 *normalsw = nullptr;
 		Vector2 *uvsw = nullptr;
-		float *tansw = nullptr;
+		real_t *tansw = nullptr;
 	};
 
 	//mikktspace callbacks

--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -433,7 +433,7 @@ void FBXMeshData::sanitize_vertex_weights(const ImportState &state) {
 
 		{
 			// Sort
-			real_t *weights_ptr = vm->weights.ptrw();
+			float *weights_ptr = vm->weights.ptrw();
 			int *bones_ptr = vm->bones.ptrw();
 			for (int i = 0; i < vm->weights.size(); i += 1) {
 				for (int x = i + 1; x < vm->weights.size(); x += 1) {
@@ -449,7 +449,7 @@ void FBXMeshData::sanitize_vertex_weights(const ImportState &state) {
 			// Resize
 			vm->weights.resize(max_vertex_influence_count);
 			vm->bones.resize(max_vertex_influence_count);
-			real_t *weights_ptr = vm->weights.ptrw();
+			float *weights_ptr = vm->weights.ptrw();
 			int *bones_ptr = vm->bones.ptrw();
 			for (int i = initial_size; i < max_vertex_influence_count; i += 1) {
 				weights_ptr[i] = 0.0;

--- a/modules/fbx/data/fbx_mesh_data.h
+++ b/modules/fbx/data/fbx_mesh_data.h
@@ -64,7 +64,7 @@ struct SurfaceData {
 };
 
 struct VertexWeightMapping {
-	Vector<real_t> weights;
+	Vector<float> weights;
 	Vector<int> bones;
 	// This extra vector is used because the bone id is computed in a second step.
 	// TODO Get rid of this extra step is a good idea.

--- a/modules/vhacd/register_types.cpp
+++ b/modules/vhacd/register_types.cpp
@@ -33,7 +33,7 @@
 #include "thirdparty/vhacd/public/VHACD.h"
 
 static Vector<Vector<Face3>> convex_decompose(const Vector<Face3> &p_faces, int p_max_convex_hulls = -1) {
-	Vector<float> vertices;
+	Vector<real_t> vertices;
 	vertices.resize(p_faces.size() * 9);
 	Vector<uint32_t> indices;
 	indices.resize(p_faces.size() * 3);

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -874,7 +874,7 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->interpolate(tv);
 		}
 
-		real_t hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
+		real_t hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
 		real_t hue_rot_c = Math::cos(hue_rot_angle);
 		real_t hue_rot_s = Math::sin(hue_rot_angle);
 

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -83,7 +83,7 @@ private:
 	struct Particle {
 		Transform2D transform;
 		Color color;
-		float custom[4] = {};
+		real_t custom[4] = {};
 		real_t rotation = 0.0;
 		Vector2 velocity;
 		bool active = false;

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -231,11 +231,11 @@ double GPUParticles2D::get_pre_process_time() const {
 	return pre_process_time;
 }
 
-float GPUParticles2D::get_explosiveness_ratio() const {
+real_t GPUParticles2D::get_explosiveness_ratio() const {
 	return explosiveness_ratio;
 }
 
-float GPUParticles2D::get_randomness_ratio() const {
+real_t GPUParticles2D::get_randomness_ratio() const {
 	return randomness_ratio;
 }
 

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -109,16 +109,16 @@ public:
 	double get_lifetime() const;
 	bool get_one_shot() const;
 	double get_pre_process_time() const;
-	float get_explosiveness_ratio() const;
-	float get_randomness_ratio() const;
+	real_t get_explosiveness_ratio() const;
+	real_t get_randomness_ratio() const;
 	Rect2 get_visibility_rect() const;
 	bool get_use_local_coordinates() const;
 	Ref<Material> get_process_material() const;
 	double get_speed_scale() const;
 
-	float get_collision_base_size() const;
+	real_t get_collision_base_size() const;
 	bool is_trail_enabled() const;
-	float get_trail_length() const;
+	real_t get_trail_length() const;
 	int get_trail_sections() const;
 	int get_trail_section_subdivisions() const;
 

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -455,7 +455,7 @@ void NavigationRegion2D::_notification(int p_what) {
 				// Draw the region
 				Transform2D xform = get_global_transform();
 				const NavigationServer2D *ns = NavigationServer2D::get_singleton();
-				float radius = ns->map_get_edge_connection_margin(get_world_2d()->get_navigation_map()) / 2.0;
+				real_t radius = ns->map_get_edge_connection_margin(get_world_2d()->get_navigation_map()) / 2.0;
 				for (int i = 0; i < ns->region_get_connections_count(region); i++) {
 					// Two main points
 					Vector2 a = ns->region_get_connection_pathway_start(region, i);
@@ -465,7 +465,7 @@ void NavigationRegion2D::_notification(int p_what) {
 					draw_line(a, b, doors_color);
 
 					// Draw a circle to illustrate the margins.
-					float angle = (b - a).angle();
+					real_t angle = (b - a).angle();
 					draw_arc(a, radius, angle + Math_PI / 2.0, angle - Math_PI / 2.0 + Math_TAU, 10, doors_color);
 					draw_arc(b, radius, angle - Math_PI / 2.0, angle + Math_PI / 2.0, 10, doors_color);
 				}

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -212,17 +212,17 @@ void RayCast2D::_update_raycast_state() {
 void RayCast2D::_draw_debug_shape() {
 	Color draw_col = collided ? Color(1.0, 0.01, 0) : get_tree()->get_debug_collisions_color();
 	if (!enabled) {
-		float g = draw_col.get_v();
+		const float g = draw_col.get_v();
 		draw_col.r = g;
 		draw_col.g = g;
 		draw_col.b = g;
 	}
 
 	// Draw an arrow indicating where the RayCast is pointing to
-	const float max_arrow_size = 6;
-	const float line_width = 1.4;
+	const real_t max_arrow_size = 6;
+	const real_t line_width = 1.4;
 	bool no_line = target_position.length() < line_width;
-	float arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
+	real_t arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 	if (no_line) {
 		arrow_size = target_position.length();

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -45,7 +45,7 @@ bool Bone2D::_set(const StringName &p_path, const Variant &p_value) {
 	} else if (path.begins_with("length")) {
 		set_length(p_value);
 	} else if (path.begins_with("bone_angle")) {
-		set_bone_angle(Math::deg2rad(float(p_value)));
+		set_bone_angle(Math::deg2rad(real_t(p_value)));
 	} else if (path.begins_with("default_length")) {
 		set_length(p_value);
 	}
@@ -330,7 +330,7 @@ bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p
 		rel = (p_other_bone->get_global_transform().get_origin() - get_global_transform().get_origin());
 		rel = rel.rotated(-get_global_rotation()); // Undo Bone2D node's rotation so its drawn correctly regardless of the node's rotation
 	} else {
-		float angle_to_use = get_rotation() + bone_angle;
+		real_t angle_to_use = get_rotation() + bone_angle;
 		rel = Vector2(cos(angle_to_use), sin(angle_to_use)) * (length * MIN(get_global_scale().x, get_global_scale().y));
 		rel = rel.rotated(-get_rotation()); // Undo Bone2D node's rotation so its drawn correctly regardless of the node's rotation
 	}
@@ -414,12 +414,12 @@ void Bone2D::apply_rest() {
 	set_transform(rest);
 }
 
-void Bone2D::set_default_length(float p_length) {
+void Bone2D::set_default_length(real_t p_length) {
 	WARN_DEPRECATED_MSG("set_default_length is deprecated. Please use set_length instead!");
 	set_length(p_length);
 }
 
-float Bone2D::get_default_length() const {
+real_t Bone2D::get_default_length() const {
 	WARN_DEPRECATED_MSG("get_default_length is deprecated. Please use get_length instead!");
 	return get_length();
 }
@@ -485,7 +485,7 @@ bool Bone2D::get_autocalculate_length_and_angle() const {
 	return autocalculate_length_and_angle;
 }
 
-void Bone2D::set_length(float p_length) {
+void Bone2D::set_length(real_t p_length) {
 	length = p_length;
 
 #ifdef TOOLS_ENABLED
@@ -493,11 +493,11 @@ void Bone2D::set_length(float p_length) {
 #endif // TOOLS_ENABLED
 }
 
-float Bone2D::get_length() const {
+real_t Bone2D::get_length() const {
 	return length;
 }
 
-void Bone2D::set_bone_angle(float p_angle) {
+void Bone2D::set_bone_angle(real_t p_angle) {
 	bone_angle = p_angle;
 
 #ifdef TOOLS_ENABLED
@@ -505,7 +505,7 @@ void Bone2D::set_bone_angle(float p_angle) {
 #endif // TOOLS_ENABLED
 }
 
-float Bone2D::get_bone_angle() const {
+real_t Bone2D::get_bone_angle() const {
 	return bone_angle;
 }
 
@@ -690,7 +690,7 @@ RID Skeleton2D::get_skeleton() const {
 	return skeleton;
 }
 
-void Skeleton2D::set_bone_local_pose_override(int p_bone_idx, Transform2D p_override, float p_amount, bool p_persistent) {
+void Skeleton2D::set_bone_local_pose_override(int p_bone_idx, Transform2D p_override, real_t p_amount, bool p_persistent) {
 	ERR_FAIL_INDEX_MSG(p_bone_idx, bones.size(), "Bone index is out of range!");
 	bones.write[p_bone_idx].local_pose_override = p_override;
 	bones.write[p_bone_idx].local_pose_override_amount = p_amount;
@@ -728,7 +728,7 @@ Ref<SkeletonModificationStack2D> Skeleton2D::get_modification_stack() const {
 	return modification_stack;
 }
 
-void Skeleton2D::execute_modifications(float p_delta, int p_execution_mode) {
+void Skeleton2D::execute_modifications(real_t p_delta, int p_execution_mode) {
 	if (!modification_stack.is_valid()) {
 		return;
 	}

--- a/scene/2d/skeleton_2d.h
+++ b/scene/2d/skeleton_2d.h
@@ -49,8 +49,8 @@ class Bone2D : public Node2D {
 	Transform2D rest;
 
 	bool autocalculate_length_and_angle = true;
-	float length = 16;
-	float bone_angle = 0;
+	real_t length = 16;
+	real_t bone_angle = 0;
 
 	int skeleton_index = -1;
 
@@ -85,10 +85,10 @@ public:
 
 	void set_autocalculate_length_and_angle(bool p_autocalculate);
 	bool get_autocalculate_length_and_angle() const;
-	void set_length(float p_length);
-	float get_length() const;
-	void set_bone_angle(float p_angle);
-	float get_bone_angle() const;
+	void set_length(real_t p_length);
+	real_t get_length() const;
+	void set_bone_angle(real_t p_angle);
+	real_t get_bone_angle() const;
 
 	int get_index_in_skeleton() const;
 
@@ -122,7 +122,7 @@ class Skeleton2D : public Node2D {
 
 		//Transform2D local_pose_cache;
 		Transform2D local_pose_override;
-		float local_pose_override_amount = 0;
+		real_t local_pose_override_amount = 0;
 		bool local_pose_override_persistent = false;
 	};
 
@@ -153,12 +153,12 @@ public:
 
 	RID get_skeleton() const;
 
-	void set_bone_local_pose_override(int p_bone_idx, Transform2D p_override, float p_amount, bool p_persistent = true);
+	void set_bone_local_pose_override(int p_bone_idx, Transform2D p_override, real_t p_amount, bool p_persistent = true);
 	Transform2D get_bone_local_pose_override(int p_bone_idx);
 
 	Ref<SkeletonModificationStack2D> get_modification_stack() const;
 	void set_modification_stack(Ref<SkeletonModificationStack2D> p_stack);
-	void execute_modifications(float p_delta, int p_execution_mode);
+	void execute_modifications(real_t p_delta, int p_execution_mode);
 
 	Skeleton2D();
 	~Skeleton2D();

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -942,7 +942,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->interpolate(tv);
 		}
 
-		real_t hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
+		real_t hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
 		real_t hue_rot_c = Math::cos(hue_rot_angle);
 		real_t hue_rot_s = Math::sin(hue_rot_angle);
 
@@ -1097,7 +1097,7 @@ void CPUParticles3D::_update_particle_data_buffer() {
 			ptr[10] = t.basis.elements[2][2];
 			ptr[11] = t.origin.z;
 		} else {
-			memset(ptr, 0, sizeof(float) * 12);
+			memset(ptr, 0, sizeof(Transform3D));
 		}
 
 		Color c = r[idx].color;

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -86,7 +86,7 @@ private:
 	struct Particle {
 		Transform3D transform;
 		Color color;
-		float custom[4] = {};
+		real_t custom[4] = {};
 		Vector3 velocity;
 		bool active = false;
 		real_t angle_rand = 0.0;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -780,7 +780,7 @@ void AnimationPlayer::_animation_process_data(PlaybackData &cd, double p_delta, 
 	double delta = p_delta * speed_scale * cd.speed_scale;
 	double next_pos = cd.pos + delta;
 
-	float len = cd.from->animation->get_length();
+	real_t len = cd.from->animation->get_length();
 	bool loop = cd.from->animation->has_loop();
 
 	if (!loop) {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -85,7 +85,7 @@ void AnimationNode::get_child_nodes(List<ChildNode> *r_child_nodes) {
 	}
 }
 
-void AnimationNode::blend_animation(const StringName &p_animation, float p_time, float p_delta, bool p_seeked, float p_blend) {
+void AnimationNode::blend_animation(const StringName &p_animation, real_t p_time, real_t p_delta, bool p_seeked, real_t p_blend) {
 	ERR_FAIL_COND(!state);
 	ERR_FAIL_COND(!state->player->has_animation(p_animation));
 
@@ -115,13 +115,13 @@ void AnimationNode::blend_animation(const StringName &p_animation, float p_time,
 	state->animation_states.push_back(anim_state);
 }
 
-float AnimationNode::_pre_process(const StringName &p_base_path, AnimationNode *p_parent, State *p_state, float p_time, bool p_seek, const Vector<StringName> &p_connections) {
+real_t AnimationNode::_pre_process(const StringName &p_base_path, AnimationNode *p_parent, State *p_state, real_t p_time, bool p_seek, const Vector<StringName> &p_connections) {
 	base_path = p_base_path;
 	parent = p_parent;
 	connections = p_connections;
 	state = p_state;
 
-	float t = process(p_time, p_seek);
+	real_t t = process(p_time, p_seek);
 
 	state = nullptr;
 	parent = nullptr;
@@ -140,7 +140,7 @@ void AnimationNode::make_invalid(const String &p_reason) {
 	state->invalid_reasons += String::utf8("•  ") + p_reason;
 }
 
-float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter, bool p_optimize) {
+real_t AnimationNode::blend_input(int p_input, real_t p_time, bool p_seek, real_t p_blend, FilterAction p_filter, bool p_optimize) {
 	ERR_FAIL_INDEX_V(p_input, inputs.size(), 0);
 	ERR_FAIL_COND_V(!state, 0);
 
@@ -158,8 +158,8 @@ float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p
 	Ref<AnimationNode> node = blend_tree->get_node(node_name);
 
 	//inputs.write[p_input].last_pass = state->last_pass;
-	float activity = 0.0;
-	float ret = _blend_node(node_name, blend_tree->get_node_connection_array(node_name), nullptr, node, p_time, p_seek, p_blend, p_filter, p_optimize, &activity);
+	real_t activity = 0.0;
+	real_t ret = _blend_node(node_name, blend_tree->get_node_connection_array(node_name), nullptr, node, p_time, p_seek, p_blend, p_filter, p_optimize, &activity);
 
 	Vector<AnimationTree::Activity> *activity_ptr = state->tree->input_activity_map.getptr(base_path);
 
@@ -170,11 +170,11 @@ float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p
 	return ret;
 }
 
-float AnimationNode::blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter, bool p_optimize) {
+real_t AnimationNode::blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, real_t p_time, bool p_seek, real_t p_blend, FilterAction p_filter, bool p_optimize) {
 	return _blend_node(p_sub_path, Vector<StringName>(), this, p_node, p_time, p_seek, p_blend, p_filter, p_optimize);
 }
 
-float AnimationNode::_blend_node(const StringName &p_subpath, const Vector<StringName> &p_connections, AnimationNode *p_new_parent, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter, bool p_optimize, float *r_max) {
+real_t AnimationNode::_blend_node(const StringName &p_subpath, const Vector<StringName> &p_connections, AnimationNode *p_new_parent, Ref<AnimationNode> p_node, real_t p_time, bool p_seek, real_t p_blend, FilterAction p_filter, bool p_optimize, real_t *r_max) {
 	ERR_FAIL_COND_V(!p_node.is_valid(), 0);
 	ERR_FAIL_COND_V(!state, 0);
 
@@ -184,8 +184,8 @@ float AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Strin
 		p_node->blends.resize(blend_count);
 	}
 
-	float *blendw = p_node->blends.ptrw();
-	const float *blendr = blends.ptr();
+	real_t *blendw = p_node->blends.ptrw();
+	const real_t *blendr = blends.ptr();
 
 	bool any_valid = false;
 
@@ -718,7 +718,7 @@ void AnimationTree::_clear_caches() {
 	cache_valid = false;
 }
 
-void AnimationTree::_process_graph(float p_delta) {
+void AnimationTree::_process_graph(real_t p_delta) {
 	_update_properties(); //if properties need updating, update them
 
 	//check all tracks, see if they need modification
@@ -790,7 +790,7 @@ void AnimationTree::_process_graph(float p_delta) {
 		// root source blends
 
 		root->blends.resize(state.track_count);
-		float *src_blendsw = root->blends.ptrw();
+		real_t *src_blendsw = root->blends.ptrw();
 		for (int i = 0; i < state.track_count; i++) {
 			src_blendsw[i] = 1.0; //by default all go to 1 for the root input
 		}
@@ -820,7 +820,7 @@ void AnimationTree::_process_graph(float p_delta) {
 			Ref<Animation> a = as.animation;
 			double time = as.time;
 			double delta = as.delta;
-			float weight = as.blend;
+			real_t weight = as.blend;
 			bool seeked = as.seeked;
 
 			for (int i = 0; i < a->get_track_count(); i++) {
@@ -840,7 +840,7 @@ void AnimationTree::_process_graph(float p_delta) {
 
 				ERR_CONTINUE(blend_idx < 0 || blend_idx >= state.track_count);
 
-				float blend = (*as.track_blends)[blend_idx] * weight;
+				real_t blend = (*as.track_blends)[blend_idx] * weight;
 
 				if (blend < CMP_EPSILON) {
 					continue; //nothing to blend
@@ -860,7 +860,7 @@ void AnimationTree::_process_graph(float p_delta) {
 								t->scale = Vector3(1, 1, 1);
 							}
 
-							float prev_time = time - delta;
+							real_t prev_time = time - delta;
 							if (prev_time < 0) {
 								if (!a->has_loop()) {
 									prev_time = 0;
@@ -928,7 +928,7 @@ void AnimationTree::_process_graph(float p_delta) {
 								t->rot = rot;
 								t->rot_blend_accum = blend;
 							} else {
-								float rot_total = t->rot_blend_accum + blend;
+								real_t rot_total = t->rot_blend_accum + blend;
 								t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
 								t->rot_blend_accum = rot_total;
 							}
@@ -1003,7 +1003,7 @@ void AnimationTree::_process_graph(float p_delta) {
 					case Animation::TYPE_BEZIER: {
 						TrackCacheBezier *t = static_cast<TrackCacheBezier *>(track);
 
-						float bezier = a->bezier_track_interpolate(i, time);
+						real_t bezier = a->bezier_track_interpolate(i, time);
 
 						if (t->process_pass != process_pass) {
 							t->value = bezier;
@@ -1029,10 +1029,10 @@ void AnimationTree::_process_graph(float p_delta) {
 								t->playing = false;
 								playing_caches.erase(t);
 							} else {
-								float start_ofs = a->audio_track_get_key_start_offset(i, idx);
+								real_t start_ofs = a->audio_track_get_key_start_offset(i, idx);
 								start_ofs += time - a->track_get_key_time(i, idx);
-								float end_ofs = a->audio_track_get_key_end_offset(i, idx);
-								float len = stream->get_length();
+								real_t end_ofs = a->audio_track_get_key_end_offset(i, idx);
+								real_t len = stream->get_length();
 
 								if (start_ofs > len - end_ofs) {
 									t->object->call("stop");
@@ -1068,9 +1068,9 @@ void AnimationTree::_process_graph(float p_delta) {
 									t->playing = false;
 									playing_caches.erase(t);
 								} else {
-									float start_ofs = a->audio_track_get_key_start_offset(i, idx);
-									float end_ofs = a->audio_track_get_key_end_offset(i, idx);
-									float len = stream->get_length();
+									real_t start_ofs = a->audio_track_get_key_start_offset(i, idx);
+									real_t end_ofs = a->audio_track_get_key_end_offset(i, idx);
+									real_t len = stream->get_length();
 
 									t->object->call("set_stream", stream);
 									t->object->call("play", start_ofs);
@@ -1093,7 +1093,7 @@ void AnimationTree::_process_graph(float p_delta) {
 								if (!loop && time < t->start) {
 									stop = true;
 								} else if (t->len > 0) {
-									float len = t->start > time ? (a->get_length() - t->start) + time : time - t->start;
+									real_t len = t->start > time ? (a->get_length() - t->start) + time : time - t->start;
 
 									if (len > t->len) {
 										stop = true;
@@ -1109,7 +1109,7 @@ void AnimationTree::_process_graph(float p_delta) {
 							}
 						}
 
-						float db = Math::linear2db(MAX(blend, 0.00001));
+						real_t db = Math::linear2db(MAX(blend, 0.00001));
 						if (t->object->has_method("set_unit_db")) {
 							t->object->call("set_unit_db", db);
 						} else {
@@ -1141,7 +1141,7 @@ void AnimationTree::_process_graph(float p_delta) {
 
 							Ref<Animation> anim = player2->get_animation(anim_name);
 
-							float at_anim_pos;
+							real_t at_anim_pos;
 
 							if (anim->has_loop()) {
 								at_anim_pos = Math::fposmod(time - pos, (double)anim->get_length()); //seek to loop
@@ -1238,7 +1238,7 @@ void AnimationTree::_process_graph(float p_delta) {
 	}
 }
 
-void AnimationTree::advance(float p_time) {
+void AnimationTree::advance(real_t p_time) {
 	_process_graph(p_time);
 }
 
@@ -1443,7 +1443,7 @@ void AnimationTree::rename_parameter(const String &p_base, const String &p_new_b
 	_update_properties();
 }
 
-float AnimationTree::get_connection_activity(const StringName &p_path, int p_connection) const {
+real_t AnimationTree::get_connection_activity(const StringName &p_path, int p_connection) const {
 	if (!input_activity_map_get.has(p_path)) {
 		return 0;
 	}

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -57,7 +57,7 @@ public:
 
 	Vector<Input> inputs;
 
-	float process_input(int p_input, float p_time, bool p_seek, float p_blend);
+	real_t process_input(int p_input, real_t p_time, bool p_seek, real_t p_blend);
 
 	friend class AnimationTree;
 
@@ -65,8 +65,8 @@ public:
 		Ref<Animation> animation;
 		double time = 0.0;
 		double delta = 0.0;
-		const Vector<float> *track_blends = nullptr;
-		float blend = 0.0;
+		const Vector<real_t> *track_blends = nullptr;
+		real_t blend = 0.0;
 		bool seeked = false;
 	};
 
@@ -81,10 +81,10 @@ public:
 		uint64_t last_pass = 0;
 	};
 
-	Vector<float> blends;
+	Vector<real_t> blends;
 	State *state = nullptr;
 
-	float _pre_process(const StringName &p_base_path, AnimationNode *p_parent, State *p_state, float p_time, bool p_seek, const Vector<StringName> &p_connections);
+	real_t _pre_process(const StringName &p_base_path, AnimationNode *p_parent, State *p_state, real_t p_time, bool p_seek, const Vector<StringName> &p_connections);
 	void _pre_update_animations(HashMap<NodePath, int> *track_map);
 
 	//all this is temporary
@@ -98,12 +98,12 @@ public:
 	Array _get_filters() const;
 	void _set_filters(const Array &p_filters);
 	friend class AnimationNodeBlendTree;
-	float _blend_node(const StringName &p_subpath, const Vector<StringName> &p_connections, AnimationNode *p_new_parent, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, float *r_max = nullptr);
+	real_t _blend_node(const StringName &p_subpath, const Vector<StringName> &p_connections, AnimationNode *p_new_parent, Ref<AnimationNode> p_node, real_t p_time, bool p_seek, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, real_t *r_max = nullptr);
 
 protected:
-	void blend_animation(const StringName &p_animation, float p_time, float p_delta, bool p_seeked, float p_blend);
-	float blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
-	float blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
+	void blend_animation(const StringName &p_animation, real_t p_time, real_t p_delta, bool p_seeked, real_t p_blend);
+	real_t blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, real_t p_time, bool p_seek, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
+	real_t blend_input(int p_input, real_t p_time, bool p_seek, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
 	void make_invalid(const String &p_reason);
 
 	static void _bind_methods();
@@ -191,7 +191,7 @@ private:
 		int bone_idx = -1;
 		Vector3 loc;
 		Quaternion rot;
-		float rot_blend_accum = 0.0;
+		real_t rot_blend_accum = 0.0;
 		Vector3 scale;
 
 		TrackCacheTransform() {
@@ -210,7 +210,7 @@ private:
 	};
 
 	struct TrackCacheBezier : public TrackCache {
-		float value = 0.0;
+		real_t value = 0.0;
 		Vector<StringName> subpath;
 		TrackCacheBezier() {
 			type = Animation::TYPE_BEZIER;
@@ -219,8 +219,8 @@ private:
 
 	struct TrackCacheAudio : public TrackCache {
 		bool playing = false;
-		float start = 0.0;
-		float len = 0.0;
+		real_t start = 0.0;
+		real_t len = 0.0;
 
 		TrackCacheAudio() {
 			type = Animation::TYPE_AUDIO;
@@ -251,7 +251,7 @@ private:
 
 	void _clear_caches();
 	bool _update_caches(AnimationPlayer *player);
-	void _process_graph(float p_delta);
+	void _process_graph(real_t p_delta);
 
 	uint64_t setup_pass = 1;
 	uint64_t process_pass = 1;
@@ -271,7 +271,7 @@ private:
 
 	struct Activity {
 		uint64_t last_pass = 0;
-		float activity = 0.0;
+		real_t activity = 0.0;
 	};
 
 	HashMap<StringName, Vector<Activity>> input_activity_map;
@@ -312,8 +312,8 @@ public:
 
 	Transform3D get_root_motion_transform() const;
 
-	float get_connection_activity(const StringName &p_path, int p_connection) const;
-	void advance(float p_time);
+	real_t get_connection_activity(const StringName &p_path, int p_connection) const;
+	void advance(real_t p_time);
 
 	void rename_parameter(const String &p_base, const String &p_new_base);
 

--- a/scene/animation/root_motion_view.h
+++ b/scene/animation/root_motion_view.h
@@ -39,8 +39,8 @@ class RootMotionView : public VisualInstance3D {
 public:
 	Ref<ImmediateMesh> immediate;
 	NodePath path;
-	float cell_size = 1.0;
-	float radius = 10.0;
+	real_t cell_size = 1.0;
+	real_t radius = 10.0;
 	bool use_in_game = false;
 	Color color = Color(0.5, 0.5, 1.0);
 	bool first = true;

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -415,7 +415,7 @@ void GradientEdit::_color_changed(const Color &p_color) {
 	emit_signal(SNAME("ramp_changed"));
 }
 
-void GradientEdit::set_ramp(const Vector<float> &p_offsets, const Vector<Color> &p_colors) {
+void GradientEdit::set_ramp(const Vector<real_t> &p_offsets, const Vector<Color> &p_colors) {
 	ERR_FAIL_COND(p_offsets.size() != p_colors.size());
 	points.clear();
 	for (int i = 0; i < p_offsets.size(); i++) {
@@ -429,8 +429,8 @@ void GradientEdit::set_ramp(const Vector<float> &p_offsets, const Vector<Color> 
 	update();
 }
 
-Vector<float> GradientEdit::get_offsets() const {
-	Vector<float> ret;
+Vector<real_t> GradientEdit::get_offsets() const {
+	Vector<real_t> ret;
 	for (int i = 0; i < points.size(); i++) {
 		ret.push_back(points[i].offset);
 	}

--- a/scene/gui/gradient_edit.h
+++ b/scene/gui/gradient_edit.h
@@ -57,8 +57,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_ramp(const Vector<float> &p_offsets, const Vector<Color> &p_colors);
-	Vector<float> get_offsets() const;
+	void set_ramp(const Vector<real_t> &p_offsets, const Vector<Color> &p_colors);
+	Vector<real_t> get_offsets() const;
 	Vector<Color> get_colors() const;
 	void set_points(Vector<Gradient::Point> &p_points);
 	Vector<Gradient::Point> &get_points();

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -77,17 +77,17 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (what == "keys" || what == "key_values") {
 			if (track_get_type(track) == TYPE_TRANSFORM3D) {
 				TransformTrack *tt = static_cast<TransformTrack *>(tracks[track]);
-				Vector<float> values = p_value;
+				Vector<real_t> values = p_value;
 				int vcount = values.size();
-				ERR_FAIL_COND_V(vcount % 12, false); // should be multiple of 11
+				ERR_FAIL_COND_V(vcount % 12, false); // should be multiple of 12
 
-				const float *r = values.ptr();
+				const real_t *r = values.ptr();
 
 				tt->transforms.resize(vcount / 12);
 
 				for (int i = 0; i < (vcount / 12); i++) {
 					TKey<TransformKey> &tk = tt->transforms.write[i];
-					const float *ofs = &r[i * 12];
+					const real_t *ofs = &r[i * 12];
 					tk.time = ofs[0];
 					tk.transition = ofs[1];
 
@@ -125,7 +125,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 					vt->update_mode = UpdateMode(um);
 				}
 
-				Vector<float> times = d["times"];
+				Vector<real_t> times = d["times"];
 				Array values = d["values"];
 
 				ERR_FAIL_COND_V(times.size() != values.size(), false);
@@ -133,7 +133,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				if (times.size()) {
 					int valcount = times.size();
 
-					const float *rt = times.ptr();
+					const real_t *rt = times.ptr();
 
 					vt->values.resize(valcount);
 
@@ -143,10 +143,10 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 					}
 
 					if (d.has("transitions")) {
-						Vector<float> transitions = d["transitions"];
+						Vector<real_t> transitions = d["transitions"];
 						ERR_FAIL_COND_V(transitions.size() != valcount, false);
 
-						const float *rtr = transitions.ptr();
+						const real_t *rtr = transitions.ptr();
 
 						for (int i = 0; i < valcount; i++) {
 							vt->values.write[i].transition = rtr[i];
@@ -165,7 +165,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				ERR_FAIL_COND_V(!d.has("times"), false);
 				ERR_FAIL_COND_V(!d.has("values"), false);
 
-				Vector<float> times = d["times"];
+				Vector<real_t> times = d["times"];
 				Array values = d["values"];
 
 				ERR_FAIL_COND_V(times.size() != values.size(), false);
@@ -173,17 +173,17 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				if (times.size()) {
 					int valcount = times.size();
 
-					const float *rt = times.ptr();
+					const real_t *rt = times.ptr();
 
 					for (int i = 0; i < valcount; i++) {
 						track_insert_key(track, rt[i], values[i]);
 					}
 
 					if (d.has("transitions")) {
-						Vector<float> transitions = d["transitions"];
+						Vector<real_t> transitions = d["transitions"];
 						ERR_FAIL_COND_V(transitions.size() != valcount, false);
 
-						const float *rtr = transitions.ptr();
+						const real_t *rtr = transitions.ptr();
 
 						for (int i = 0; i < valcount; i++) {
 							track_set_key_transition(track, i, rtr[i]);
@@ -196,16 +196,16 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				ERR_FAIL_COND_V(!d.has("times"), false);
 				ERR_FAIL_COND_V(!d.has("points"), false);
 
-				Vector<float> times = d["times"];
-				PackedFloat32Array values = d["points"];
+				Vector<real_t> times = d["times"];
+				Vector<real_t> values = d["points"];
 
 				ERR_FAIL_COND_V(times.size() * 5 != values.size(), false);
 
 				if (times.size()) {
 					int valcount = times.size();
 
-					const float *rt = times.ptr();
-					const float *rv = values.ptr();
+					const real_t *rt = times.ptr();
+					const real_t *rv = values.ptr();
 
 					bt->values.resize(valcount);
 
@@ -227,7 +227,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				ERR_FAIL_COND_V(!d.has("times"), false);
 				ERR_FAIL_COND_V(!d.has("clips"), false);
 
-				Vector<float> times = d["times"];
+				Vector<real_t> times = d["times"];
 				Array clips = d["clips"];
 
 				ERR_FAIL_COND_V(clips.size() != times.size(), false);
@@ -235,7 +235,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				if (times.size()) {
 					int valcount = times.size();
 
-					const float *rt = times.ptr();
+					const real_t *rt = times.ptr();
 
 					ad->values.clear();
 
@@ -268,7 +268,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				ERR_FAIL_COND_V(!d.has("times"), false);
 				ERR_FAIL_COND_V(!d.has("clips"), false);
 
-				Vector<float> times = d["times"];
+				Vector<real_t> times = d["times"];
 				Vector<String> clips = d["clips"];
 
 				ERR_FAIL_COND_V(clips.size() != times.size(), false);
@@ -276,7 +276,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				if (times.size()) {
 					int valcount = times.size();
 
-					const float *rt = times.ptr();
+					const real_t *rt = times.ptr();
 					const String *rc = clips.ptr();
 
 					an->values.resize(valcount);
@@ -352,9 +352,9 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 			r_ret = track_is_enabled(track);
 		} else if (what == "keys") {
 			if (track_get_type(track) == TYPE_TRANSFORM3D) {
-				Vector<float> keys;
+				Vector<real_t> keys;
 				int kk = track_get_key_count(track);
-				keys.resize(kk * 12);
+				keys.resize(kk * sizeof(Transform3D));
 
 				real_t *w = keys.ptrw();
 
@@ -389,8 +389,8 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 
 				Dictionary d;
 
-				Vector<float> key_times;
-				Vector<float> key_transitions;
+				Vector<real_t> key_times;
+				Vector<real_t> key_transitions;
 				Array key_values;
 
 				int kk = vt->values.size();
@@ -399,8 +399,8 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 				key_transitions.resize(kk);
 				key_values.resize(kk);
 
-				float *wti = key_times.ptrw();
-				float *wtr = key_transitions.ptrw();
+				real_t *wti = key_times.ptrw();
+				real_t *wtr = key_transitions.ptrw();
 
 				int idx = 0;
 
@@ -427,8 +427,8 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 			} else if (track_get_type(track) == TYPE_METHOD) {
 				Dictionary d;
 
-				Vector<float> key_times;
-				Vector<float> key_transitions;
+				Vector<real_t> key_times;
+				Vector<real_t> key_transitions;
 				Array key_values;
 
 				int kk = track_get_key_count(track);
@@ -437,8 +437,8 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 				key_transitions.resize(kk);
 				key_values.resize(kk);
 
-				float *wti = key_times.ptrw();
-				float *wtr = key_transitions.ptrw();
+				real_t *wti = key_times.ptrw();
+				real_t *wtr = key_transitions.ptrw();
 
 				int idx = 0;
 				for (int i = 0; i < track_get_key_count(track); i++) {
@@ -463,16 +463,16 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 
 				Dictionary d;
 
-				Vector<float> key_times;
-				Vector<float> key_points;
+				Vector<real_t> key_times;
+				Vector<real_t> key_points;
 
 				int kk = bt->values.size();
 
 				key_times.resize(kk);
 				key_points.resize(kk * 5);
 
-				float *wti = key_times.ptrw();
-				float *wpo = key_points.ptrw();
+				real_t *wti = key_times.ptrw();
+				real_t *wpo = key_points.ptrw();
 
 				int idx = 0;
 
@@ -499,14 +499,14 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 
 				Dictionary d;
 
-				Vector<float> key_times;
+				Vector<real_t> key_times;
 				Array clips;
 
 				int kk = ad->values.size();
 
 				key_times.resize(kk);
 
-				float *wti = key_times.ptrw();
+				real_t *wti = key_times.ptrw();
 
 				int idx = 0;
 
@@ -533,7 +533,7 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 
 				Dictionary d;
 
-				Vector<float> key_times;
+				Vector<real_t> key_times;
 				Vector<String> clips;
 
 				int kk = an->values.size();
@@ -541,7 +541,7 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 				key_times.resize(kk);
 				clips.resize(kk);
 
-				float *wti = key_times.ptrw();
+				real_t *wti = key_times.ptrw();
 				String *wcl = clips.ptrw();
 
 				const TKey<StringName> *vls = an->values.ptr();
@@ -946,7 +946,7 @@ int Animation::track_find_key(int p_track, double p_time, bool p_exact) const {
 	return -1;
 }
 
-void Animation::track_insert_key(int p_track, double p_time, const Variant &p_key, float p_transition) {
+void Animation::track_insert_key(int p_track, double p_time, const Variant &p_key, real_t p_transition) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 
@@ -1260,7 +1260,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 	ERR_FAIL();
 }
 
-float Animation::track_get_key_transition(int p_track, int p_key_idx) const {
+real_t Animation::track_get_key_transition(int p_track, int p_key_idx) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
@@ -1379,7 +1379,7 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 	emit_changed();
 }
 
-void Animation::track_set_key_transition(int p_track, int p_key_idx, float p_transition) {
+void Animation::track_set_key_transition(int p_track, int p_key_idx, real_t p_transition) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 
@@ -1449,7 +1449,7 @@ int Animation::_find(const Vector<K> &p_keys, double p_time) const {
 	return middle;
 }
 
-Animation::TransformKey Animation::_interpolate(const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, float p_c) const {
+Animation::TransformKey Animation::_interpolate(const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, real_t p_c) const {
 	TransformKey ret;
 	ret.loc = _interpolate(p_a.loc, p_b.loc, p_c);
 	ret.rot = _interpolate(p_a.rot, p_b.rot, p_c);
@@ -1458,25 +1458,25 @@ Animation::TransformKey Animation::_interpolate(const Animation::TransformKey &p
 	return ret;
 }
 
-Vector3 Animation::_interpolate(const Vector3 &p_a, const Vector3 &p_b, float p_c) const {
+Vector3 Animation::_interpolate(const Vector3 &p_a, const Vector3 &p_b, real_t p_c) const {
 	return p_a.lerp(p_b, p_c);
 }
 
-Quaternion Animation::_interpolate(const Quaternion &p_a, const Quaternion &p_b, float p_c) const {
+Quaternion Animation::_interpolate(const Quaternion &p_a, const Quaternion &p_b, real_t p_c) const {
 	return p_a.slerp(p_b, p_c);
 }
 
-Variant Animation::_interpolate(const Variant &p_a, const Variant &p_b, float p_c) const {
+Variant Animation::_interpolate(const Variant &p_a, const Variant &p_b, real_t p_c) const {
 	Variant dst;
 	Variant::interpolate(p_a, p_b, p_c, dst);
 	return dst;
 }
 
-float Animation::_interpolate(const float &p_a, const float &p_b, float p_c) const {
+real_t Animation::_interpolate(const real_t &p_a, const real_t &p_b, real_t p_c) const {
 	return p_a * (1.0 - p_c) + p_b * p_c;
 }
 
-Animation::TransformKey Animation::_cubic_interpolate(const Animation::TransformKey &p_pre_a, const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, const Animation::TransformKey &p_post_b, float p_c) const {
+Animation::TransformKey Animation::_cubic_interpolate(const Animation::TransformKey &p_pre_a, const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, const Animation::TransformKey &p_post_b, real_t p_c) const {
 	Animation::TransformKey tk;
 
 	tk.loc = p_a.loc.cubic_interpolate(p_b.loc, p_pre_a.loc, p_post_b.loc, p_c);
@@ -1486,15 +1486,15 @@ Animation::TransformKey Animation::_cubic_interpolate(const Animation::Transform
 	return tk;
 }
 
-Vector3 Animation::_cubic_interpolate(const Vector3 &p_pre_a, const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_post_b, float p_c) const {
+Vector3 Animation::_cubic_interpolate(const Vector3 &p_pre_a, const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_post_b, real_t p_c) const {
 	return p_a.cubic_interpolate(p_b, p_pre_a, p_post_b, p_c);
 }
 
-Quaternion Animation::_cubic_interpolate(const Quaternion &p_pre_a, const Quaternion &p_a, const Quaternion &p_b, const Quaternion &p_post_b, float p_c) const {
+Quaternion Animation::_cubic_interpolate(const Quaternion &p_pre_a, const Quaternion &p_a, const Quaternion &p_b, const Quaternion &p_post_b, real_t p_c) const {
 	return p_a.cubic_slerp(p_b, p_pre_a, p_post_b, p_c);
 }
 
-Variant Animation::_cubic_interpolate(const Variant &p_pre_a, const Variant &p_a, const Variant &p_b, const Variant &p_post_b, float p_c) const {
+Variant Animation::_cubic_interpolate(const Variant &p_pre_a, const Variant &p_a, const Variant &p_b, const Variant &p_post_b, real_t p_c) const {
 	Variant::Type type_a = p_a.get_type();
 	Variant::Type type_b = p_b.get_type();
 	Variant::Type type_pa = p_pre_a.get_type();
@@ -1515,9 +1515,9 @@ Variant Animation::_cubic_interpolate(const Variant &p_pre_a, const Variant &p_a
 		real_t p2 = p_b;
 		real_t p3 = p_post_b;
 
-		float t = p_c;
-		float t2 = t * t;
-		float t3 = t2 * t;
+		real_t t = p_c;
+		real_t t2 = t * t;
+		real_t t3 = t2 * t;
 
 		return 0.5f * ((p1 * 2.0f) +
 							  (-p0 + p2) * t +
@@ -1579,7 +1579,7 @@ Variant Animation::_cubic_interpolate(const Variant &p_pre_a, const Variant &p_a
 	}
 }
 
-float Animation::_cubic_interpolate(const float &p_pre_a, const float &p_a, const float &p_b, const float &p_post_b, float p_c) const {
+real_t Animation::_cubic_interpolate(const real_t &p_pre_a, const real_t &p_a, const real_t &p_b, const real_t &p_post_b, real_t p_c) const {
 	return _interpolate(p_a, p_b, p_c);
 }
 
@@ -1608,7 +1608,7 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, Interpol
 
 	bool result = true;
 	int next = 0;
-	float c = 0.0;
+	real_t c = 0.0;
 	// prepare for all cases of interpolation
 
 	if (loop && p_loop_wrap) {
@@ -1616,8 +1616,8 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, Interpol
 		if (idx >= 0) {
 			if ((idx + 1) < len) {
 				next = idx + 1;
-				float delta = p_keys[next].time - p_keys[idx].time;
-				float from = p_time - p_keys[idx].time;
+				real_t delta = p_keys[next].time - p_keys[idx].time;
+				real_t from = p_time - p_keys[idx].time;
 
 				if (Math::is_zero_approx(delta)) {
 					c = 0;
@@ -1627,8 +1627,8 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, Interpol
 
 			} else {
 				next = 0;
-				float delta = (length - p_keys[idx].time) + p_keys[next].time;
-				float from = p_time - p_keys[idx].time;
+				real_t delta = (length - p_keys[idx].time) + p_keys[next].time;
+				real_t from = p_time - p_keys[idx].time;
 
 				if (Math::is_zero_approx(delta)) {
 					c = 0;
@@ -1641,12 +1641,12 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, Interpol
 			// on loop, behind first key
 			idx = len - 1;
 			next = 0;
-			float endtime = (length - p_keys[idx].time);
+			real_t endtime = (length - p_keys[idx].time);
 			if (endtime < 0) { // may be keys past the end
 				endtime = 0;
 			}
-			float delta = endtime + p_keys[next].time;
-			float from = endtime + p_time;
+			real_t delta = endtime + p_keys[next].time;
+			real_t from = endtime + p_time;
 
 			if (Math::is_zero_approx(delta)) {
 				c = 0;
@@ -1660,8 +1660,8 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, Interpol
 		if (idx >= 0) {
 			if ((idx + 1) < len) {
 				next = idx + 1;
-				float delta = p_keys[next].time - p_keys[idx].time;
-				float from = p_time - p_keys[idx].time;
+				real_t delta = p_keys[next].time - p_keys[idx].time;
+				real_t from = p_time - p_keys[idx].time;
 
 				if (Math::is_zero_approx(delta)) {
 					c = 0;
@@ -1690,7 +1690,7 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, Interpol
 		return T();
 	}
 
-	float tr = p_keys[idx].transition;
+	real_t tr = p_keys[idx].transition;
 
 	if (tr == 0 || idx == next) {
 		// don't interpolate if not needed
@@ -2128,7 +2128,7 @@ StringName Animation::method_track_get_name(int p_track, int p_key_idx) const {
 	return pm->methods[p_key_idx].method;
 }
 
-int Animation::bezier_track_insert_key(int p_track, double p_time, float p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle) {
+int Animation::bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BEZIER, -1);
@@ -2154,7 +2154,7 @@ int Animation::bezier_track_insert_key(int p_track, double p_time, float p_value
 	return key;
 }
 
-void Animation::bezier_track_set_key_value(int p_track, int p_index, float p_value) {
+void Animation::bezier_track_set_key_value(int p_track, int p_index, real_t p_value) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_BEZIER);
@@ -2199,7 +2199,7 @@ void Animation::bezier_track_set_key_out_handle(int p_track, int p_index, const 
 	emit_changed();
 }
 
-float Animation::bezier_track_get_key_value(int p_track, int p_index) const {
+real_t Animation::bezier_track_get_key_value(int p_track, int p_index) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BEZIER, 0);
@@ -2246,7 +2246,7 @@ static _FORCE_INLINE_ Vector2 _bezier_interp(real_t t, const Vector2 &start, con
 	return start * omt3 + control_1 * omt2 * t * 3.0 + control_2 * omt * t2 * 3.0 + end * t3;
 }
 
-float Animation::bezier_track_interpolate(int p_track, double p_time) const {
+real_t Animation::bezier_track_interpolate(int p_track, double p_time) const {
 	//this uses a different interpolation scheme
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
 	Track *track = tracks[p_track];
@@ -2312,7 +2312,7 @@ float Animation::bezier_track_interpolate(int p_track, double p_time) const {
 	return low_pos.lerp(high_pos, c).y;
 }
 
-int Animation::audio_track_insert_key(int p_track, double p_time, const RES &p_stream, float p_start_offset, float p_end_offset) {
+int Animation::audio_track_insert_key(int p_track, double p_time, const RES &p_stream, real_t p_start_offset, real_t p_end_offset) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, -1);
@@ -2352,7 +2352,7 @@ void Animation::audio_track_set_key_stream(int p_track, int p_key, const RES &p_
 	emit_changed();
 }
 
-void Animation::audio_track_set_key_start_offset(int p_track, int p_key, float p_offset) {
+void Animation::audio_track_set_key_start_offset(int p_track, int p_key, real_t p_offset) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_AUDIO);
@@ -2370,7 +2370,7 @@ void Animation::audio_track_set_key_start_offset(int p_track, int p_key, float p
 	emit_changed();
 }
 
-void Animation::audio_track_set_key_end_offset(int p_track, int p_key, float p_offset) {
+void Animation::audio_track_set_key_end_offset(int p_track, int p_key, real_t p_offset) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_AUDIO);
@@ -2400,7 +2400,7 @@ RES Animation::audio_track_get_key_stream(int p_track, int p_key) const {
 	return at->values[p_key].value.stream;
 }
 
-float Animation::audio_track_get_key_start_offset(int p_track, int p_key) const {
+real_t Animation::audio_track_get_key_start_offset(int p_track, int p_key) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
 	const Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, 0);
@@ -2412,7 +2412,7 @@ float Animation::audio_track_get_key_start_offset(int p_track, int p_key) const 
 	return at->values[p_key].value.start_offset;
 }
 
-float Animation::audio_track_get_key_end_offset(int p_track, int p_key) const {
+real_t Animation::audio_track_get_key_end_offset(int p_track, int p_key) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
 	const Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, 0);
@@ -2470,7 +2470,7 @@ StringName Animation::animation_track_get_key_animation(int p_track, int p_key) 
 	return at->values[p_key].value;
 }
 
-void Animation::set_length(float p_length) {
+void Animation::set_length(real_t p_length) {
 	if (p_length < ANIM_MIN_LENGTH) {
 		p_length = ANIM_MIN_LENGTH;
 	}
@@ -2478,7 +2478,7 @@ void Animation::set_length(float p_length) {
 	emit_changed();
 }
 
-float Animation::get_length() const {
+real_t Animation::get_length() const {
 	return length;
 }
 
@@ -2558,12 +2558,12 @@ void Animation::track_swap(int p_track, int p_with_track) {
 	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
 
-void Animation::set_step(float p_step) {
+void Animation::set_step(real_t p_step) {
 	step = p_step;
 	emit_changed();
 }
 
-float Animation::get_step() const {
+real_t Animation::get_step() const {
 	return step;
 }
 
@@ -2708,7 +2708,7 @@ void Animation::clear() {
 	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
 
-bool Animation::_transform_track_optimize_key(const TKey<TransformKey> &t0, const TKey<TransformKey> &t1, const TKey<TransformKey> &t2, float p_alowed_linear_err, float p_alowed_angular_err, float p_max_optimizable_angle, const Vector3 &p_norm) {
+bool Animation::_transform_track_optimize_key(const TKey<TransformKey> &t0, const TKey<TransformKey> &t1, const TKey<TransformKey> &t2, real_t p_alowed_linear_err, real_t p_alowed_angular_err, real_t p_max_optimizable_angle, const Vector3 &p_norm) {
 	real_t c = (t1.time - t0.time) / (t2.time - t0.time);
 	real_t t[3] = { -1, -1, -1 };
 
@@ -2875,7 +2875,7 @@ bool Animation::_transform_track_optimize_key(const TKey<TransformKey> &t0, cons
 	return erase;
 }
 
-void Animation::_transform_track_optimize(int p_idx, float p_allowed_linear_err, float p_allowed_angular_err, float p_max_optimizable_angle) {
+void Animation::_transform_track_optimize(int p_idx, real_t p_allowed_linear_err, real_t p_allowed_angular_err, real_t p_max_optimizable_angle) {
 	ERR_FAIL_INDEX(p_idx, tracks.size());
 	ERR_FAIL_COND(tracks[p_idx]->type != TYPE_TRANSFORM3D);
 	TransformTrack *tt = static_cast<TransformTrack *>(tracks[p_idx]);
@@ -2915,7 +2915,7 @@ void Animation::_transform_track_optimize(int p_idx, float p_allowed_linear_err,
 	}
 }
 
-void Animation::optimize(float p_allowed_linear_err, float p_allowed_angular_err, float p_max_optimizable_angle) {
+void Animation::optimize(real_t p_allowed_linear_err, real_t p_allowed_angular_err, real_t p_max_optimizable_angle) {
 	for (int i = 0; i < tracks.size(); i++) {
 		if (tracks[i]->type == TYPE_TRANSFORM3D) {
 			_transform_track_optimize(i, p_allowed_linear_err, p_allowed_angular_err, p_max_optimizable_angle);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -76,8 +76,8 @@ private:
 	};
 
 	struct Key {
-		float transition = 1.0;
-		float time = 0.0; // time in secs
+		real_t transition = 1.0;
+		double time = 0.0; // time in secs
 	};
 
 	// transform key holds either Vector3 or Quaternion
@@ -129,7 +129,7 @@ private:
 	struct BezierKey {
 		Vector2 in_handle; //relative (x always <0)
 		Vector2 out_handle; //relative (x always >0)
-		float value = 0.0;
+		real_t value = 0.0;
 	};
 
 	struct BezierTrack : public Track {
@@ -144,8 +144,8 @@ private:
 
 	struct AudioKey {
 		RES stream;
-		float start_offset = 0.0; //offset from start
-		float end_offset = 0.0; //offset from end, if 0 then full length or infinite
+		real_t start_offset = 0.0; //offset from start
+		real_t end_offset = 0.0; //offset from end, if 0 then full length or infinite
 		AudioKey() {
 		}
 	};
@@ -183,18 +183,18 @@ private:
 	template <class K>
 	inline int _find(const Vector<K> &p_keys, double p_time) const;
 
-	_FORCE_INLINE_ Animation::TransformKey _interpolate(const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, float p_c) const;
+	_FORCE_INLINE_ Animation::TransformKey _interpolate(const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, real_t p_c) const;
 
-	_FORCE_INLINE_ Vector3 _interpolate(const Vector3 &p_a, const Vector3 &p_b, float p_c) const;
-	_FORCE_INLINE_ Quaternion _interpolate(const Quaternion &p_a, const Quaternion &p_b, float p_c) const;
-	_FORCE_INLINE_ Variant _interpolate(const Variant &p_a, const Variant &p_b, float p_c) const;
-	_FORCE_INLINE_ float _interpolate(const float &p_a, const float &p_b, float p_c) const;
+	_FORCE_INLINE_ Vector3 _interpolate(const Vector3 &p_a, const Vector3 &p_b, real_t p_c) const;
+	_FORCE_INLINE_ Quaternion _interpolate(const Quaternion &p_a, const Quaternion &p_b, real_t p_c) const;
+	_FORCE_INLINE_ Variant _interpolate(const Variant &p_a, const Variant &p_b, real_t p_c) const;
+	_FORCE_INLINE_ real_t _interpolate(const real_t &p_a, const real_t &p_b, real_t p_c) const;
 
-	_FORCE_INLINE_ Animation::TransformKey _cubic_interpolate(const Animation::TransformKey &p_pre_a, const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, const Animation::TransformKey &p_post_b, float p_c) const;
-	_FORCE_INLINE_ Vector3 _cubic_interpolate(const Vector3 &p_pre_a, const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_post_b, float p_c) const;
-	_FORCE_INLINE_ Quaternion _cubic_interpolate(const Quaternion &p_pre_a, const Quaternion &p_a, const Quaternion &p_b, const Quaternion &p_post_b, float p_c) const;
-	_FORCE_INLINE_ Variant _cubic_interpolate(const Variant &p_pre_a, const Variant &p_a, const Variant &p_b, const Variant &p_post_b, float p_c) const;
-	_FORCE_INLINE_ float _cubic_interpolate(const float &p_pre_a, const float &p_a, const float &p_b, const float &p_post_b, float p_c) const;
+	_FORCE_INLINE_ Animation::TransformKey _cubic_interpolate(const Animation::TransformKey &p_pre_a, const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, const Animation::TransformKey &p_post_b, real_t p_c) const;
+	_FORCE_INLINE_ Vector3 _cubic_interpolate(const Vector3 &p_pre_a, const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_post_b, real_t p_c) const;
+	_FORCE_INLINE_ Quaternion _cubic_interpolate(const Quaternion &p_pre_a, const Quaternion &p_a, const Quaternion &p_b, const Quaternion &p_post_b, real_t p_c) const;
+	_FORCE_INLINE_ Variant _cubic_interpolate(const Variant &p_pre_a, const Variant &p_a, const Variant &p_b, const Variant &p_post_b, real_t p_c) const;
+	_FORCE_INLINE_ real_t _cubic_interpolate(const real_t &p_pre_a, const real_t &p_a, const real_t &p_b, const real_t &p_post_b, real_t p_c) const;
 
 	template <class T>
 	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const;
@@ -206,7 +206,7 @@ private:
 	_FORCE_INLINE_ void _method_track_get_key_indices_in_range(const MethodTrack *mt, double from_time, double to_time, List<int> *p_indices) const;
 
 	double length = 1.0;
-	float step = 0.1;
+	real_t step = 0.1;
 	bool loop = false;
 
 	// bind helpers
@@ -244,8 +244,8 @@ private:
 		return idxr;
 	}
 
-	bool _transform_track_optimize_key(const TKey<TransformKey> &t0, const TKey<TransformKey> &t1, const TKey<TransformKey> &t2, float p_alowed_linear_err, float p_alowed_angular_err, float p_max_optimizable_angle, const Vector3 &p_norm);
-	void _transform_track_optimize(int p_idx, float p_allowed_linear_err = 0.05, float p_allowed_angular_err = 0.01, float p_max_optimizable_angle = Math_PI * 0.125);
+	bool _transform_track_optimize_key(const TKey<TransformKey> &t0, const TKey<TransformKey> &t1, const TKey<TransformKey> &t2, real_t p_alowed_linear_err, real_t p_alowed_angular_err, real_t p_max_optimizable_angle, const Vector3 &p_norm);
+	void _transform_track_optimize(int p_idx, real_t p_allowed_linear_err = 0.05, real_t p_allowed_angular_err = 0.01, real_t p_max_optimizable_angle = Math_PI * 0.125);
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -279,8 +279,8 @@ public:
 	void track_set_enabled(int p_track, bool p_enabled);
 	bool track_is_enabled(int p_track) const;
 
-	void track_insert_key(int p_track, double p_time, const Variant &p_key, float p_transition = 1);
-	void track_set_key_transition(int p_track, int p_key_idx, float p_transition);
+	void track_insert_key(int p_track, double p_time, const Variant &p_key, real_t p_transition = 1);
+	void track_set_key_transition(int p_track, int p_key_idx, real_t p_transition);
 	void track_set_key_value(int p_track, int p_key_idx, const Variant &p_value);
 	void track_set_key_time(int p_track, int p_key_idx, double p_time);
 	int track_find_key(int p_track, double p_time, bool p_exact = false) const;
@@ -289,30 +289,30 @@ public:
 	int track_get_key_count(int p_track) const;
 	Variant track_get_key_value(int p_track, int p_key_idx) const;
 	double track_get_key_time(int p_track, int p_key_idx) const;
-	float track_get_key_transition(int p_track, int p_key_idx) const;
+	real_t track_get_key_transition(int p_track, int p_key_idx) const;
 
 	int transform_track_insert_key(int p_track, double p_time, const Vector3 &p_loc, const Quaternion &p_rot = Quaternion(), const Vector3 &p_scale = Vector3());
 	Error transform_track_get_key(int p_track, int p_key, Vector3 *r_loc, Quaternion *r_rot, Vector3 *r_scale) const;
 	void track_set_interpolation_type(int p_track, InterpolationType p_interp);
 	InterpolationType track_get_interpolation_type(int p_track) const;
 
-	int bezier_track_insert_key(int p_track, double p_time, float p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle);
-	void bezier_track_set_key_value(int p_track, int p_index, float p_value);
+	int bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle);
+	void bezier_track_set_key_value(int p_track, int p_index, real_t p_value);
 	void bezier_track_set_key_in_handle(int p_track, int p_index, const Vector2 &p_handle);
 	void bezier_track_set_key_out_handle(int p_track, int p_index, const Vector2 &p_handle);
-	float bezier_track_get_key_value(int p_track, int p_index) const;
+	real_t bezier_track_get_key_value(int p_track, int p_index) const;
 	Vector2 bezier_track_get_key_in_handle(int p_track, int p_index) const;
 	Vector2 bezier_track_get_key_out_handle(int p_track, int p_index) const;
 
-	float bezier_track_interpolate(int p_track, double p_time) const;
+	real_t bezier_track_interpolate(int p_track, double p_time) const;
 
-	int audio_track_insert_key(int p_track, double p_time, const RES &p_stream, float p_start_offset = 0, float p_end_offset = 0);
+	int audio_track_insert_key(int p_track, double p_time, const RES &p_stream, real_t p_start_offset = 0, real_t p_end_offset = 0);
 	void audio_track_set_key_stream(int p_track, int p_key, const RES &p_stream);
-	void audio_track_set_key_start_offset(int p_track, int p_key, float p_offset);
-	void audio_track_set_key_end_offset(int p_track, int p_key, float p_offset);
+	void audio_track_set_key_start_offset(int p_track, int p_key, real_t p_offset);
+	void audio_track_set_key_end_offset(int p_track, int p_key, real_t p_offset);
 	RES audio_track_get_key_stream(int p_track, int p_key) const;
-	float audio_track_get_key_start_offset(int p_track, int p_key) const;
-	float audio_track_get_key_end_offset(int p_track, int p_key) const;
+	real_t audio_track_get_key_start_offset(int p_track, int p_key) const;
+	real_t audio_track_get_key_end_offset(int p_track, int p_key) const;
 
 	int animation_track_insert_key(int p_track, double p_time, const StringName &p_animation);
 	void animation_track_set_key_animation(int p_track, int p_key, const StringName &p_animation);
@@ -336,18 +336,18 @@ public:
 
 	void track_get_key_indices_in_range(int p_track, double p_time, double p_delta, List<int> *p_indices) const;
 
-	void set_length(float p_length);
-	float get_length() const;
+	void set_length(real_t p_length);
+	real_t get_length() const;
 
 	void set_loop(bool p_enabled);
 	bool has_loop() const;
 
-	void set_step(float p_step);
-	float get_step() const;
+	void set_step(real_t p_step);
+	real_t get_step() const;
 
 	void clear();
 
-	void optimize(float p_allowed_linear_err = 0.05, float p_allowed_angular_err = 0.01, float p_max_optimizable_angle = Math_PI * 0.125);
+	void optimize(real_t p_allowed_linear_err = 0.05, real_t p_allowed_angular_err = 0.01, real_t p_max_optimizable_angle = Math_PI * 0.125);
 
 	Animation();
 	~Animation();

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1366,7 +1366,7 @@ float Curve3D::interpolate_baked_tilt(float p_offset) const {
 		frac /= bake_interval;
 	}
 
-	return Math::lerp(r[idx], r[idx + 1], frac);
+	return Math::lerp(r[idx], r[idx + 1], (real_t)frac);
 }
 
 Vector3 Curve3D::interpolate_baked_up_vector(float p_offset, bool p_apply_tilt) const {
@@ -1424,7 +1424,7 @@ PackedVector3Array Curve3D::get_baked_points() const {
 	return baked_point_cache;
 }
 
-PackedFloat32Array Curve3D::get_baked_tilts() const {
+Vector<real_t> Curve3D::get_baked_tilts() const {
 	if (baked_cache_dirty) {
 		_bake();
 	}
@@ -1545,7 +1545,7 @@ Dictionary Curve3D::_get_data() const {
 	PackedVector3Array d;
 	d.resize(points.size() * 3);
 	Vector3 *w = d.ptrw();
-	PackedFloat32Array t;
+	Vector<real_t> t;
 	t.resize(points.size());
 	real_t *wt = t.ptrw();
 
@@ -1571,7 +1571,7 @@ void Curve3D::_set_data(const Dictionary &p_data) {
 	ERR_FAIL_COND(pc % 3 != 0);
 	points.resize(pc / 3);
 	const Vector3 *r = rp.ptr();
-	PackedFloat32Array rtl = p_data["tilts"];
+	Vector<real_t> rtl = p_data["tilts"];
 	const real_t *rt = rtl.ptr();
 
 	for (int i = 0; i < points.size(); i++) {

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -222,7 +222,7 @@ class Curve3D : public Resource {
 
 	mutable bool baked_cache_dirty = false;
 	mutable PackedVector3Array baked_point_cache;
-	mutable PackedFloat32Array baked_tilt_cache;
+	mutable Vector<real_t> baked_tilt_cache;
 	mutable PackedVector3Array baked_up_vector_cache;
 	mutable float baked_max_ofs = 0.0;
 
@@ -265,7 +265,7 @@ public:
 	float interpolate_baked_tilt(float p_offset) const;
 	Vector3 interpolate_baked_up_vector(float p_offset, bool p_apply_tilt = false) const;
 	PackedVector3Array get_baked_points() const; //useful for going through
-	PackedFloat32Array get_baked_tilts() const; //useful for going through
+	Vector<real_t> get_baked_tilts() const; //useful for going through
 	PackedVector3Array get_baked_up_vectors() const;
 	Vector3 get_closest_point(const Vector3 &p_to_point) const;
 	float get_closest_offset(const Vector3 &p_to_point) const;

--- a/scene/resources/height_map_shape_3d.cpp
+++ b/scene/resources/height_map_shape_3d.cpp
@@ -41,7 +41,7 @@ Vector<Vector3> HeightMapShape3D::get_debug_mesh_lines() const {
 		Vector2 size(map_width - 1, map_depth - 1);
 		Vector2 start = size * -0.5;
 
-		const float *r = map_data.ptr();
+		const real_t *r = map_data.ptr();
 
 		// reserve some memory for our points..
 		points.resize(((map_width - 1) * map_depth * 2) + (map_width * (map_depth - 1) * 2) + ((map_width - 1) * (map_depth - 1) * 2));
@@ -105,7 +105,7 @@ void HeightMapShape3D::set_map_width(int p_new) {
 		int new_size = map_width * map_depth;
 		map_data.resize(map_width * map_depth);
 
-		float *w = map_data.ptrw();
+		real_t *w = map_data.ptrw();
 		while (was_size < new_size) {
 			w[was_size++] = 0.0;
 		}
@@ -129,7 +129,7 @@ void HeightMapShape3D::set_map_depth(int p_new) {
 		int new_size = map_width * map_depth;
 		map_data.resize(new_size);
 
-		float *w = map_data.ptrw();
+		real_t *w = map_data.ptrw();
 		while (was_size < new_size) {
 			w[was_size++] = 0.0;
 		}
@@ -143,7 +143,7 @@ int HeightMapShape3D::get_map_depth() const {
 	return map_depth;
 }
 
-void HeightMapShape3D::set_map_data(PackedFloat32Array p_new) {
+void HeightMapShape3D::set_map_data(Vector<real_t> p_new) {
 	int size = (map_width * map_depth);
 	if (p_new.size() != size) {
 		// fail
@@ -151,10 +151,10 @@ void HeightMapShape3D::set_map_data(PackedFloat32Array p_new) {
 	}
 
 	// copy
-	float *w = map_data.ptrw();
-	const float *r = p_new.ptr();
+	real_t *w = map_data.ptrw();
+	const real_t *r = p_new.ptr();
 	for (int i = 0; i < size; i++) {
-		float val = r[i];
+		real_t val = r[i];
 		w[i] = val;
 		if (i == 0) {
 			min_height = val;
@@ -174,7 +174,7 @@ void HeightMapShape3D::set_map_data(PackedFloat32Array p_new) {
 	notify_change_to_owners();
 }
 
-PackedFloat32Array HeightMapShape3D::get_map_data() const {
+Vector<real_t> HeightMapShape3D::get_map_data() const {
 	return map_data;
 }
 
@@ -194,7 +194,7 @@ void HeightMapShape3D::_bind_methods() {
 HeightMapShape3D::HeightMapShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_HEIGHTMAP)) {
 	map_data.resize(map_width * map_depth);
-	float *w = map_data.ptrw();
+	real_t *w = map_data.ptrw();
 	w[0] = 0.0;
 	w[1] = 0.0;
 	w[2] = 0.0;

--- a/scene/resources/height_map_shape_3d.h
+++ b/scene/resources/height_map_shape_3d.h
@@ -38,7 +38,7 @@ class HeightMapShape3D : public Shape3D {
 
 	int map_width = 2;
 	int map_depth = 2;
-	PackedFloat32Array map_data;
+	Vector<real_t> map_data;
 	real_t min_height = 0.0;
 	real_t max_height = 0.0;
 
@@ -51,8 +51,8 @@ public:
 	int get_map_width() const;
 	void set_map_depth(int p_new);
 	int get_map_depth() const;
-	void set_map_data(PackedFloat32Array p_new);
-	PackedFloat32Array get_map_data() const;
+	void set_map_data(Vector<real_t> p_new);
+	Vector<real_t> get_map_data() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;

--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -107,9 +107,9 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 		bo = arrays[Mesh::ARRAY_BONES].operator Vector<int>().ptr();
 	}
 
-	const real_t *we = nullptr;
+	const float *we = nullptr;
 	if (arrays[Mesh::ARRAY_WEIGHTS].get_type() != Variant::NIL) {
-		we = arrays[Mesh::ARRAY_WEIGHTS].operator Vector<real_t>().ptr();
+		we = arrays[Mesh::ARRAY_WEIGHTS].operator Vector<float>().ptr();
 	}
 
 	vertices.resize(vcount);

--- a/scene/resources/polygon_path_finder.cpp
+++ b/scene/resources/polygon_path_finder.cpp
@@ -417,9 +417,9 @@ void PolygonPathFinder::_set_data(const Dictionary &p_data) {
 	}
 
 	if (p_data.has("penalties")) {
-		Vector<float> penalties = p_data["penalties"];
+		Vector<real_t> penalties = p_data["penalties"];
 		if (penalties.size() == pc) {
-			const float *pr2 = penalties.ptr();
+			const real_t *pr2 = penalties.ptr();
 			for (int i = 0; i < pc; i++) {
 				points.write[i].penalty = pr2[i];
 			}
@@ -445,11 +445,11 @@ Dictionary PolygonPathFinder::_get_data() const {
 	p.resize(MAX(0, points.size() - 2));
 	connections.resize(MAX(0, points.size() - 2));
 	ind.resize(edges.size() * 2);
-	Vector<float> penalties;
+	Vector<real_t> penalties;
 	penalties.resize(MAX(0, points.size() - 2));
 	{
 		Vector2 *wp = p.ptrw();
-		float *pw = penalties.ptrw();
+		real_t *pw = penalties.ptrw();
 
 		for (int i = 0; i < points.size() - 2; i++) {
 			wp[i] = points[i].pos;

--- a/servers/physics_3d/shape_3d_sw.cpp
+++ b/servers/physics_3d/shape_3d_sw.cpp
@@ -1635,7 +1635,7 @@ ConcavePolygonShape3DSW::ConcavePolygonShape3DSW() {
 
 /* HEIGHT MAP SHAPE */
 
-Vector<float> HeightMapShape3DSW::get_heights() const {
+Vector<real_t> HeightMapShape3DSW::get_heights() const {
 	return heights;
 }
 
@@ -1932,7 +1932,7 @@ Vector3 HeightMapShape3DSW::get_moment_of_inertia(real_t p_mass) const {
 			(p_mass / 3.0) * (extents.x * extents.x + extents.y * extents.y));
 }
 
-void HeightMapShape3DSW::_setup(const Vector<float> &p_heights, int p_width, int p_depth, real_t p_min_height, real_t p_max_height) {
+void HeightMapShape3DSW::_setup(const Vector<real_t> &p_heights, int p_width, int p_depth, real_t p_min_height, real_t p_max_height) {
 	heights = p_heights;
 	width = p_width;
 	depth = p_depth;
@@ -1966,8 +1966,12 @@ void HeightMapShape3DSW::set_data(const Variant &p_data) {
 	ERR_FAIL_COND(depth <= 0.0);
 
 	Variant heights_variant = d["heights"];
-	Vector<float> heights_buffer;
+	Vector<real_t> heights_buffer;
+#ifdef REAL_T_IS_DOUBLE
+	if (heights_variant.get_type() == Variant::PACKED_FLOAT64_ARRAY) {
+#else
 	if (heights_variant.get_type() == Variant::PACKED_FLOAT32_ARRAY) {
+#endif
 		// Ready-to-use heights can be passed.
 		heights_buffer = heights_variant;
 	} else if (heights_variant.get_type() == Variant::OBJECT) {
@@ -1980,13 +1984,17 @@ void HeightMapShape3DSW::set_data(const Variant &p_data) {
 		PackedByteArray im_data = image->get_data();
 		heights_buffer.resize(image->get_width() * image->get_height());
 
-		float *w = heights_buffer.ptrw();
-		float *rp = (float *)im_data.ptr();
+		real_t *w = heights_buffer.ptrw();
+		real_t *rp = (real_t *)im_data.ptr();
 		for (int i = 0; i < heights_buffer.size(); ++i) {
 			w[i] = rp[i];
 		}
 	} else {
+#ifdef REAL_T_IS_DOUBLE
+		ERR_FAIL_MSG("Expected PackedFloat64Array or float Image.");
+#else
 		ERR_FAIL_MSG("Expected PackedFloat32Array or float Image.");
+#endif
 	}
 
 	// Compute min and max heights or use precomputed values.

--- a/servers/physics_3d/shape_3d_sw.h
+++ b/servers/physics_3d/shape_3d_sw.h
@@ -389,12 +389,12 @@ public:
 };
 
 struct HeightMapShape3DSW : public ConcaveShape3DSW {
-	Vector<float> heights;
+	Vector<real_t> heights;
 	int width = 0;
 	int depth = 0;
 	Vector3 local_origin;
 
-	_FORCE_INLINE_ float _get_height(int p_x, int p_z) const {
+	_FORCE_INLINE_ real_t _get_height(int p_x, int p_z) const {
 		return heights[(p_z * width) + p_x];
 	}
 
@@ -406,10 +406,10 @@ struct HeightMapShape3DSW : public ConcaveShape3DSW {
 
 	void _get_cell(const Vector3 &p_point, int &r_x, int &r_y, int &r_z) const;
 
-	void _setup(const Vector<float> &p_heights, int p_width, int p_depth, real_t p_min_height, real_t p_max_height);
+	void _setup(const Vector<real_t> &p_heights, int p_width, int p_depth, real_t p_min_height, real_t p_max_height);
 
 public:
-	Vector<float> get_heights() const;
+	Vector<real_t> get_heights() const;
 	int get_width() const;
 	int get_depth() const;
 

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1866,7 +1866,7 @@ void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance)
 		//rotate it
 		Basis rot = lightmap->transform.basis.orthonormalized();
 		for (int i = 0; i < 3; i++) {
-			float csh[9];
+			real_t csh[9];
 			for (int j = 0; j < 9; j++) {
 				csh[j] = sh[j][i];
 			}
@@ -1878,7 +1878,7 @@ void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance)
 
 		Vector3 inner_pos = ((lm_pos - bounds.position) / bounds.size) * 2.0 - Vector3(1.0, 1.0, 1.0);
 
-		float blend = MAX(inner_pos.x, MAX(inner_pos.y, inner_pos.z));
+		real_t blend = MAX(inner_pos.x, MAX(inner_pos.y, inner_pos.z));
 		//make blend more rounded
 		blend = Math::lerp(inner_pos.length(), blend, blend);
 		blend *= blend;

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -60,7 +60,7 @@ public:
 
 		void update_mips();
 
-		_FORCE_INLINE_ bool is_occluded(const float p_bounds[6], const Vector3 &p_cam_position, const Transform3D &p_cam_inv_transform, const CameraMatrix &p_cam_projection, float p_near) const {
+		_FORCE_INLINE_ bool is_occluded(const real_t p_bounds[6], const Vector3 &p_cam_position, const Transform3D &p_cam_inv_transform, const CameraMatrix &p_cam_projection, real_t p_near) const {
 			if (is_empty()) {
 				return false;
 			}

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -242,7 +242,7 @@ RID RenderingServer::_make_test_cube() {
 	return test_cube;
 }
 
-RID RenderingServer::make_sphere_mesh(int p_lats, int p_lons, float p_radius) {
+RID RenderingServer::make_sphere_mesh(int p_lats, int p_lons, real_t p_radius) {
 	Vector<Vector3> vertices;
 	Vector<Vector3> normals;
 	const double lat_step = Math_TAU / p_lats;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1457,7 +1457,7 @@ public:
 
 	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) = 0;
 
-	virtual RID make_sphere_mesh(int p_lats, int p_lons, float p_radius);
+	virtual RID make_sphere_mesh(int p_lats, int p_lons, real_t p_radius);
 
 	virtual void mesh_add_surface_from_mesh_data(RID p_mesh, const Geometry3D::MeshData &p_mesh_data);
 	virtual void mesh_add_surface_from_planes(RID p_mesh, const Vector<Plane> &p_planes);

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -589,13 +589,13 @@ MainLoop *test() {
 	{
 		Vector3 v(1, 2, 3);
 		v.normalize();
-		float a = 0.3;
+		real_t a = 0.3;
 
 		Basis m(v, a);
 
 		Vector3 v2(7, 3, 1);
 		v2.normalize();
-		float a2 = 0.8;
+		real_t a2 = 0.8;
 
 		Basis m2(v2, a2);
 


### PR DESCRIPTION
Please see this proposal for the eventual goals this PR is a part of: https://github.com/godotengine/godot-proposals/issues/892

This PR does a lot of work on double-precision support. I have previously split this PR up into smaller ones that are easier to review/merge and now those have been merged. It's small enough now that I don't think splitting this further would help much, the majority of the code that can be reviewed/merged separately has been reviewed/merged. Note that the rest of this PR changes things like arrays/vectors which are a bit more tricky so keep that in mind when reviewing.

In its current state things are mostly working except for a binding issue with integer vector multiplication/division that causes this PR to not compile. I previously had #44441 included in this PR's list of commits but now I've removed it so that this can be merged, and then the integer vector multiplication/division issue can be solved separately.