### PR TITLE
Clarification about Input.get_accelerometer() usage

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -46,6 +46,7 @@
 			</return>
 			<description>
 				If the device has an accelerometer, this will return the acceleration. Otherwise, it returns an empty [Vector3].
+				Note this method returns an empty [Vector3] when running from the editor even when your device has an accelerometer. You must export your project to a supported device to read values from the accelerometer.
 			</description>
 		</method>
 		<method name="get_action_strength" qualifiers="const">


### PR DESCRIPTION
At present you can't currently get anything from the accelerometer if you run your project from the editor.  If you export the project to a device where this function is implemented, you do get readings.

The documentation doesn't currently reflect this, and causes confusion.  This change will point people in the right direction if they want to get started right away.

I've created [issue 21924](https://github.com/godotengine/godot/issues/21924) to request the editor be extended to provide readings from the accelerometer.