### PR TITLE
Clarify which direction RemoteTransform[2D] work

### DIFF
--- a/doc/classes/RemoteTransform.xml
+++ b/doc/classes/RemoteTransform.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RemoteTransform" inherits="Spatial" category="Core" version="3.1">
 	<brief_description>
-		RemoteTransform leads the [Transform] of another [Spatial] derived Node in the scene.
+		RemoteTransform pushes its own [Transform] to another [Spatial] derived Node in the scene.
 	</brief_description>
 	<description>
-		RemoteTransform leads the [Transform] of another [Spatial] derived Node (called the remote node) in the scene.
-		It can be set to track another Node's position, rotation and/or scale. It can update using either global or local coordinates.
+		RemoteTransform pushes its own [Transform] to another [Spatial] derived Node (called the remote node) in the scene.
+		It can be set to update another Node's position, rotation and/or scale. It can use either global or local coordinates.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -18,13 +18,13 @@
 			The [NodePath] to the remote node, relative to the RemoteTransform's position in the scene.
 		</member>
 		<member name="update_position" type="bool" setter="set_update_position" getter="get_update_position">
-			If [code]true[/code] the remote node's position is tracked. Default value: [code]true[/code].
+			If [code]true[/code] the remote node's position is updated. Default value: [code]true[/code].
 		</member>
 		<member name="update_rotation" type="bool" setter="set_update_rotation" getter="get_update_rotation">
-			If [code]true[/code] the remote node's rotation is tracked. Default value: [code]true[/code].
+			If [code]true[/code] the remote node's rotation is updated. Default value: [code]true[/code].
 		</member>
 		<member name="update_scale" type="bool" setter="set_update_scale" getter="get_update_scale">
-			If [code]true[/code] the remote node's scale is tracked. Default value: [code]true[/code].
+			If [code]true[/code] the remote node's scale is updated. Default value: [code]true[/code].
 		</member>
 		<member name="use_global_coordinates" type="bool" setter="set_use_global_coordinates" getter="get_use_global_coordinates">
 			If [code]true[/code] global coordinates are used. If [code]false[/code] local coordinates are used. Default value: [code]true[/code].

--- a/doc/classes/RemoteTransform2D.xml
+++ b/doc/classes/RemoteTransform2D.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RemoteTransform2D" inherits="Node2D" category="Core" version="3.1">
 	<brief_description>
-		RemoteTransform2D leads the [Transform2D] of another [CanvasItem] derived Node in the scene.
+		RemoteTransform2D pushes its own [Transform2D] to another [CanvasItem] derived Node in the scene.
 	</brief_description>
 	<description>
-		RemoteTransform2D leads the [Transform2D] of another [CanvasItem] derived Node (called the remote node) in the scene.
-		It can be set to track another Node's position, rotation and/or scale. It can update using either global or local coordinates.
+		RemoteTransform2D pushes its own [Transform2D] to another [CanvasItem] derived Node (called the remote node) in the scene.
+		It can be set to update another Node's position, rotation and/or scale. It can use either global or local coordinates.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -18,13 +18,13 @@
 			The [NodePath] to the remote node, relative to the RemoteTransform2D's position in the scene.
 		</member>
 		<member name="update_position" type="bool" setter="set_update_position" getter="get_update_position">
-			If [code]true[/code] the remote node's position is tracked. Default value: [code]true[/code].
+			If [code]true[/code] the remote node's position is updated. Default value: [code]true[/code].
 		</member>
 		<member name="update_rotation" type="bool" setter="set_update_rotation" getter="get_update_rotation">
-			If [code]true[/code] the remote node's rotation is tracked. Default value: [code]true[/code].
+			If [code]true[/code] the remote node's rotation is updated. Default value: [code]true[/code].
 		</member>
 		<member name="update_scale" type="bool" setter="set_update_scale" getter="get_update_scale">
-			If [code]true[/code] the remote node's scale is tracked. Default value: [code]true[/code].
+			If [code]true[/code] the remote node's scale is updated. Default value: [code]true[/code].
 		</member>
 		<member name="use_global_coordinates" type="bool" setter="set_use_global_coordinates" getter="get_use_global_coordinates">
 			If [code]true[/code] global coordinates are used. If [code]false[/code] local coordinates are used. Default value: [code]true[/code].


### PR DESCRIPTION
Hopefully this language makes it more clear that it's the remote node that gets its transform updated.