### PR TITLE
Revert "Fix selection of spatial nodes after selecting a non-spatial one."

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1558,8 +1558,6 @@ void EditorNode::_edit_current() {
 
 				editor_plugin_screen->edit(current_obj);
 			}
-		} else {
-			editor_plugin_screen->edit(current_obj);
 		}
 
 		Vector<EditorPlugin *> sub_plugins = editor_data.get_subeditors(current_obj);


### PR DESCRIPTION
Reverts #21831, fixes #21960 and reopens #13849.