### PR TITLE
Add get_animation_name function to animation resource

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -966,6 +966,7 @@ Error AnimationPlayer::add_animation(const StringName &p_name, const Ref<Animati
 		animation_set[p_name] = ad;
 	}
 
+	animation_set[p_name].animation->set_animation_name(p_name);
 	_ref_anim(p_animation);
 	_change_notify();
 	return OK;
@@ -977,6 +978,7 @@ void AnimationPlayer::remove_animation(const StringName &p_name) {
 
 	stop();
 	_unref_anim(animation_set[p_name].animation);
+	animation_set[p_name].animation->set_animation_name("");
 	animation_set.erase(p_name);
 
 	clear_caches();

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2600,6 +2600,14 @@ void Animation::track_swap(int p_track, int p_with_track) {
 	emit_changed();
 }
 
+void Animation::set_animation_name(const StringName &p_name) {
+	animation_name = p_name;
+}
+
+StringName Animation::get_animation_name() {
+	return animation_name;
+}
+
 void Animation::set_step(float p_step) {
 
 	step = p_step;
@@ -2699,6 +2707,8 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("animation_track_insert_key", "track", "time", "animation"), &Animation::animation_track_insert_key);
 	ClassDB::bind_method(D_METHOD("animation_track_set_key_animation", "idx", "key_idx", "animation"), &Animation::animation_track_set_key_animation);
 	ClassDB::bind_method(D_METHOD("animation_track_get_key_animation", "idx", "key_idx"), &Animation::animation_track_get_key_animation);
+
+	ClassDB::bind_method(D_METHOD("get_animation_name"), &Animation::get_animation_name);
 
 	ClassDB::bind_method(D_METHOD("set_length", "time_sec"), &Animation::set_length);
 	ClassDB::bind_method(D_METHOD("get_length"), &Animation::get_length);
@@ -2966,7 +2976,7 @@ void Animation::optimize(float p_allowed_linear_err, float p_allowed_angular_err
 }
 
 Animation::Animation() {
-
+	animation_name = "";
 	step = 0.1;
 	loop = false;
 	length = 1;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -227,6 +227,7 @@ private:
 	_FORCE_INLINE_ void _value_track_get_key_indices_in_range(const ValueTrack *vt, float from_time, float to_time, List<int> *p_indices) const;
 	_FORCE_INLINE_ void _method_track_get_key_indices_in_range(const MethodTrack *mt, float from_time, float to_time, List<int> *p_indices) const;
 
+	String animation_name;
 	float length;
 	float step;
 	bool loop;
@@ -357,6 +358,9 @@ public:
 	void copy_track(int p_track, Ref<Animation> p_to_animation);
 
 	void track_get_key_indices_in_range(int p_track, float p_time, float p_delta, List<int> *p_indices) const;
+
+	void set_animation_name(const StringName &p_name);
+	StringName get_animation_name();
 
 	void set_length(float p_length);
 	float get_length() const;


### PR DESCRIPTION
Add get_animation_name function to animation resource. This adds a way to reference an Animation resource by its name.

This fixes #21946