### PR TITLE
Some fixes to mouse's cursor and shape

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -293,7 +293,7 @@
 			<argument index="2" name="hotspot" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<description>
-				Set a custom mouse cursor image, which is only visible inside the game window. The hotspot can also be specified. Passing [code]null[/code] to the image parameter resets to the system cursor. See enum [code]CURSOR_*[/code] for the list of shapes.
+				Sets a custom mouse cursor image, which is only visible inside the game window. The hotspot can also be specified. Passing [code]null[/code] to the image parameter resets to the system cursor. See enum [code]CURSOR_*[/code] for the list of shapes.
 				[code]image[/code]'s size must be lower than 256x256.
 				[code]hotspot[/code] must be within [code]image[/code]'s size.
 			</description>
@@ -304,6 +304,8 @@
 			<argument index="0" name="shape" type="int" enum="Input.CursorShape" default="0">
 			</argument>
 			<description>
+				Sets the default cursor shape to be used in the viewport instead of [code]CURSOR_ARROW[/code].
+				Note that if you want to change the default cursor shape for [Control]'s nodes, use [member Control.mouse_default_cursor_shape] instead.
 			</description>
 		</method>
 		<method name="set_mouse_mode">

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1662,7 +1662,7 @@ void OS_OSX::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 		[cursors[p_shape] release];
 		cursors[p_shape] = cursor;
 
-		if (p_shape == CURSOR_ARROW) {
+		if (p_shape == cursor_shape) {
 			[cursor set];
 		}
 
@@ -1671,8 +1671,10 @@ void OS_OSX::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 	} else {
 		// Reset to default system cursor
 		cursors[p_shape] = NULL;
+
+		CursorShape c = cursor_shape;
 		cursor_shape = CURSOR_MAX;
-		set_cursor_shape(p_shape);
+		set_cursor_shape(c);
 	}
 }
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2311,7 +2311,7 @@ void OS_Windows::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shap
 
 		cursors[p_shape] = CreateIconIndirect(&iconinfo);
 
-		if (p_shape == CURSOR_ARROW) {
+		if (p_shape == cursor_shape) {
 			SetCursor(cursors[p_shape]);
 		}
 
@@ -2328,8 +2328,10 @@ void OS_Windows::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shap
 	} else {
 		// Reset to default system cursor
 		cursors[p_shape] = NULL;
+
+		CursorShape c = cursor_shape;
 		cursor_shape = CURSOR_MAX;
-		set_cursor_shape(p_shape);
+		set_cursor_shape(c);
 	}
 }
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2606,7 +2606,7 @@ void OS_X11::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 		// Save it for a further usage
 		cursors[p_shape] = XcursorImageLoadCursor(x11_display, cursor_image);
 
-		if (p_shape == CURSOR_ARROW) {
+		if (p_shape == current_cursor) {
 			XDefineCursor(x11_display, x11_window, cursors[p_shape]);
 		}
 
@@ -2618,8 +2618,9 @@ void OS_X11::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 			cursors[p_shape] = XcursorImageLoadCursor(x11_display, img[p_shape]);
 		}
 
+		CursorShape c = current_cursor;
 		current_cursor = CURSOR_MAX;
-		set_cursor_shape(p_shape);
+		set_cursor_shape(c);
 	}
 }
 


### PR DESCRIPTION
Fix #21958. (Like I said in the class ref., `set_default_cursor_shape` only affects viewport, `Control`s must use `Control::mouse_default_cursor_shape`)

Fix `set_custom_mouse_cursor` changing to incorrect cursor shape;
[Docs] Add class ref for Input::set_default_cursor_shape