### PR TITLE
Fix default_cursor_shape for TextEdit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4174,7 +4174,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 		}
 	}
 
-	return CURSOR_IBEAM;
+	return get_default_cursor_shape();
 }
 
 void TextEdit::set_text(String p_text) {
@@ -6256,6 +6256,7 @@ TextEdit::TextEdit() {
 	breakpoint_gutter_width = 0;
 	cache.fold_gutter_width = 0;
 	fold_gutter_width = 0;
+	set_default_cursor_shape(CURSOR_IBEAM);
 
 	indent_size = 4;
 	text.set_indent_size(indent_size);


### PR DESCRIPTION
~Also fix #20296. If users change anchor bottom to zero (END) this error will come back again. Maybe we still need this pr #21219 as a fallback (I didn't test it to know if is really a fallback, just guessing) or another solution should be created.~