### PR TITLE
Add message when ScriptDebugger connects.

### DIFF
--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -77,18 +77,19 @@ Error ScriptDebuggerRemote::connect_to_host(const String &p_host, uint16_t p_por
 	for (int i = 0; i < tries; i++) {
 
 		if (tcp_client->get_status() == StreamPeerTCP::STATUS_CONNECTED) {
+			print_verbose("Remote Debugger: Connected!");
 			break;
 		} else {
 
 			const int ms = waits[i];
 			OS::get_singleton()->delay_usec(ms * 1000);
-			ERR_PRINTS("Remote Debugger: Connection failed with status: '" + String::num(tcp_client->get_status()) + "', retrying in " + String::num(ms) + " msec.");
+			print_verbose("Remote Debugger: Connection failed with status: '" + String::num(tcp_client->get_status()) + "', retrying in " + String::num(ms) + " msec.");
 		};
 	};
 
 	if (tcp_client->get_status() != StreamPeerTCP::STATUS_CONNECTED) {
 
-		ERR_PRINTS("Remote Debugger: Unable to connect.");
+		ERR_PRINTS("Remote Debugger: Unable to connect. Status: " + String::num(tcp_client->get_status()));
 		return FAILED;
 	};
 


### PR DESCRIPTION
Short diff, long explaination:

This will hopefully clarify whether or not issues are about the dubgger
like the case of the never ending thread about MacOS "Remote debugger
fails", which started as a real issue, and ended up being referenced for
every strange OSX issue where the window was not visible or the engine
crashed without appearing on screen.

Closes #8563 .
Move the discussion about OSX multi screens issue to #13017