### PR TITLE
Fix project and editor data paths not being opened correctly on macOS

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2078,7 +2078,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case RUN_PROJECT_DATA_FOLDER: {
 
-			OS::get_singleton()->shell_open(OS::get_singleton()->get_user_data_dir());
+			OS::get_singleton()->shell_open(String("file://") + OS::get_singleton()->get_user_data_dir());
 		} break;
 		case FILE_QUIT:
 		case RUN_PROJECT_MANAGER: {
@@ -2214,11 +2214,11 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case SETTINGS_EDITOR_DATA_FOLDER: {
 
-			OS::get_singleton()->shell_open(EditorSettings::get_singleton()->get_data_dir());
+			OS::get_singleton()->shell_open(String("file://") + EditorSettings::get_singleton()->get_data_dir());
 		} break;
 		case SETTINGS_EDITOR_CONFIG_FOLDER: {
 
-			OS::get_singleton()->shell_open(EditorSettings::get_singleton()->get_settings_dir());
+			OS::get_singleton()->shell_open(String("file://") + EditorSettings::get_singleton()->get_settings_dir());
 		} break;
 		case SETTINGS_MANAGE_EXPORT_TEMPLATES: {
 


### PR DESCRIPTION
This closes #21904. **Testers on macOS are welcome, as I am not currently able to test this.**