### PR TITLE
Remove WebGL 2 support, default to to GLES2 for UWP

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -817,6 +817,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->set_cmdline(execpath, main_args);
 
 	GLOBAL_DEF("rendering/quality/driver/driver_name", "GLES3");
+	GLOBAL_DEF("rendering/quality/driver/driver_name.UWP", "GLES2");
 	GLOBAL_DEF("rendering/quality/driver/driver_name.web", "GLES2");
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/driver/driver_name", PropertyInfo(Variant::STRING, "rendering/quality/driver/driver_name", PROPERTY_HINT_ENUM, "GLES2,GLES3"));
 	if (video_driver == "") {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -905,9 +905,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (video_driver_idx < 0) {
 
-		//OS::get_singleton()->alert("Invalid Video Driver: " + video_driver);
+		WARN_PRINTS("Invalid Video Driver \"" + video_driver + "\", using default Video Driver");
 		video_driver_idx = 0;
-		//goto error;
 	}
 
 	if (audio_driver == "") { // specified in project.godot

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -817,6 +817,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->set_cmdline(execpath, main_args);
 
 	GLOBAL_DEF("rendering/quality/driver/driver_name", "GLES3");
+	GLOBAL_DEF("rendering/quality/driver/driver_name.web", "GLES2");
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/driver/driver_name", PropertyInfo(Variant::STRING, "rendering/quality/driver/driver_name", PROPERTY_HINT_ENUM, "GLES2,GLES3"));
 	if (video_driver == "") {
 		video_driver = GLOBAL_GET("rendering/quality/driver/driver_name");

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -128,9 +128,6 @@ def configure(env):
     # us since we don't know requirements at compile-time.
     env.Append(LINKFLAGS=['-s', 'ALLOW_MEMORY_GROWTH=1'])
 
-    # This setting just makes WebGL 2 APIs available, it does NOT disable WebGL 1.
-    env.Append(LINKFLAGS=['-s', 'USE_WEBGL2=1'])
-
     env.Append(LINKFLAGS=['-s', 'INVOKE_RUN=0'])
 
     # TODO: Reevaluate usage of this setting now that engine.js manages engine runtime.

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -80,8 +80,6 @@ class OS_JavaScript : public OS_Unix {
 
 	static void file_access_close_callback(const String &p_file, int p_flags);
 
-	int video_driver_index;
-
 protected:
 	virtual int get_current_video_driver() const;
 


### PR DESCRIPTION
The WebGL 2 rasterizer has too many issues for use in production. Considering it'll be removed once the Vulkan rasterizer hits, it's unreasonable to work further on it.

With this patch only the WebGL 1 rasterizer is available for web export. This also saves about half a MB.