### PR TITLE
Fix libwebsockets 32-bits UWP builds.

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -208,8 +208,8 @@ def configure_msvc(env, manual_msvc_config):
                                    'RTAUDIO_ENABLED', 'WASAPI_ENABLED',
                                    'WINMIDI_ENABLED', 'TYPED_METHOD_BIND',
                                    'WIN32', 'MSVC',
-                                   {'WINVER' : '$target_win_version',
-                                    '_WIN32_WINNT': '$target_win_version'}])
+                                   'WINVER=$target_win_version',
+                                   '_WIN32_WINNT=$target_win_version'])
     env.AppendUnique(CPPDEFINES=['NOMINMAX']) # disable bogus min/max WinDef.h macros
     if env["bits"] == "64":
         env.AppendUnique(CPPDEFINES=['_WIN64'])

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -266,6 +266,8 @@ File extracted from upstream source:
 - Also copy `win32helpers/` from `win32port/` inside `thirdparty/libwebsockets`
 - A small fix has been added in `libwebsockets/libwebsockets.h` to `#include <sys/socket.h>` for the BSD family.
   This change has been PRed upstream, and should be merged before the next update. Remember to check and remove this line.
+- Another fix has been added to allow building for 32-bits UWP, replacing `GetFileSize[Ex]` and `CreateFileW` with supported functions.
+  There is a diff for this change in `thirdparty/libwebsockets/uwp_fixes.diff`
 
 Important: `lws_config.h` and `lws_config_private.h` contains custom
 Godot build configurations, check them out when updating.

--- a/thirdparty/libwebsockets/plat/lws-plat-win.c
+++ b/thirdparty/libwebsockets/plat/lws-plat-win.c
@@ -635,9 +635,20 @@ _lws_plat_file_open(const struct lws_plat_file_ops *fops, const char *filename,
 	HANDLE ret;
 	WCHAR buf[MAX_PATH];
 	lws_fop_fd_t fop_fd;
-	LARGE_INTEGER llFileSize = {0};
+	FILE_STANDARD_INFO fInfo = {0};
 
 	MultiByteToWideChar(CP_UTF8, 0, filename, -1, buf, ARRAY_SIZE(buf));
+
+#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602 // Windows 8 (minimum when UWP_ENABLED, but can be used in Windows builds)
+	CREATEFILE2_EXTENDED_PARAMETERS extParams = {0};
+	extParams.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
+
+	if (((*flags) & 7) == _O_RDONLY) {
+		ret = CreateFile2(buf, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, &extParams);
+	} else {
+		ret = CreateFile2(buf, GENERIC_WRITE, 0, CREATE_ALWAYS, &extParams);
+	}
+#else
 	if (((*flags) & 7) == _O_RDONLY) {
 		ret = CreateFileW(buf, GENERIC_READ, FILE_SHARE_READ,
 			  NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -645,6 +656,7 @@ _lws_plat_file_open(const struct lws_plat_file_ops *fops, const char *filename,
 		ret = CreateFileW(buf, GENERIC_WRITE, 0, NULL,
 			  CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 	}
+#endif
 
 	if (ret == LWS_INVALID_FILE)
 		goto bail;
@@ -657,9 +669,9 @@ _lws_plat_file_open(const struct lws_plat_file_ops *fops, const char *filename,
 	fop_fd->fd = ret;
 	fop_fd->filesystem_priv = NULL; /* we don't use it */
 	fop_fd->flags = *flags;
-	fop_fd->len = GetFileSize(ret, NULL);
-	if(GetFileSizeEx(ret, &llFileSize))
-		fop_fd->len = llFileSize.QuadPart;
+	fop_fd->len = 0;
+	if(GetFileInformationByHandleEx(ret, FileStandardInfo, &fInfo, sizeof(fInfo)))
+		fop_fd->len = fInfo.EndOfFile.QuadPart;
 
 	fop_fd->pos = 0;
 

--- a/thirdparty/libwebsockets/uwp_fixes.diff
+++ b/thirdparty/libwebsockets/uwp_fixes.diff
@@ -1,0 +1,47 @@
+diff --git a/thirdparty/libwebsockets/plat/lws-plat-win.c b/thirdparty/libwebsockets/plat/lws-plat-win.c
+index 948db6289..511e29739 100644
+--- a/thirdparty/libwebsockets/plat/lws-plat-win.c
++++ b/thirdparty/libwebsockets/plat/lws-plat-win.c
+@@ -635,9 +635,20 @@ _lws_plat_file_open(const struct lws_plat_file_ops *fops, const char *filename,
+ 	HANDLE ret;
+ 	WCHAR buf[MAX_PATH];
+ 	lws_fop_fd_t fop_fd;
+-	LARGE_INTEGER llFileSize = {0};
++	FILE_STANDARD_INFO fInfo = {0};
+ 
+ 	MultiByteToWideChar(CP_UTF8, 0, filename, -1, buf, ARRAY_SIZE(buf));
++
++#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602 // Windows 8 (minimum when UWP_ENABLED, but can be used in Windows builds)
++	CREATEFILE2_EXTENDED_PARAMETERS extParams = {0};
++	extParams.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
++
++	if (((*flags) & 7) == _O_RDONLY) {
++		ret = CreateFile2(buf, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, &extParams);
++	} else {
++		ret = CreateFile2(buf, GENERIC_WRITE, 0, CREATE_ALWAYS, &extParams);
++	}
++#else
+ 	if (((*flags) & 7) == _O_RDONLY) {
+ 		ret = CreateFileW(buf, GENERIC_READ, FILE_SHARE_READ,
+ 			  NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+@@ -645,6 +656,7 @@ _lws_plat_file_open(const struct lws_plat_file_ops *fops, const char *filename,
+ 		ret = CreateFileW(buf, GENERIC_WRITE, 0, NULL,
+ 			  CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+ 	}
++#endif
+ 
+ 	if (ret == LWS_INVALID_FILE)
+ 		goto bail;
+@@ -657,9 +669,9 @@ _lws_plat_file_open(const struct lws_plat_file_ops *fops, const char *filename,
+ 	fop_fd->fd = ret;
+ 	fop_fd->filesystem_priv = NULL; /* we don't use it */
+ 	fop_fd->flags = *flags;
+-	fop_fd->len = GetFileSize(ret, NULL);
+-	if(GetFileSizeEx(ret, &llFileSize))
+-		fop_fd->len = llFileSize.QuadPart;
++	fop_fd->len = 0;
++	if(GetFileInformationByHandleEx(ret, FileStandardInfo, &fInfo, sizeof(fInfo)))
++		fop_fd->len = fInfo.EndOfFile.QuadPart;
+ 
+ 	fop_fd->pos = 0;
+ 


### PR DESCRIPTION
If Minimum Windows Version is Win8 (minimum for UWP), use `CreateFile2` instead of `CreateFileW`.

Always use `GetFileInformationByHandleEx` instead of `GetFileSize[Ex]`.

Closes #21548 .
Initial work on #20672 (UPNP missing).