### PR TITLE
Added warning when disabling editable_instance

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -121,6 +121,7 @@ class SceneTreeDock : public VBoxContainer {
 	ScriptCreateDialog *script_create_dialog;
 	AcceptDialog *accept;
 	ConfirmationDialog *delete_dialog;
+	ConfirmationDialog *editable_instance_remove_dialog;
 
 	ReparentDialog *reparent_dialog;
 	EditorFileDialog *file;
@@ -168,6 +169,8 @@ class SceneTreeDock : public VBoxContainer {
 	void _script_created(Ref<Script> p_script);
 
 	void _delete_confirm();
+
+	void _toggle_editable_children();
 
 	void _node_prerenamed(Node *p_node, const String &p_new_name);
 


### PR DESCRIPTION
Added warning when disabling editable_instance to prevent data loss. This fixes #17547

The warning is currently this:

![](https://user-images.githubusercontent.com/7482073/45625638-a23f1b80-ba8d-11e8-86ad-775657d2620f.png)