### PR TITLE
Patch zstd to build for UWP ARM

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -523,3 +523,5 @@ Files extracted from upstream source:
 
 - lib/{common/,compress/,decompress/,zstd.h}
 - LICENSE
+
+- Applied the patch in `thirdparty/zstd/1314.diff` (PR 1314 upstream, already merged). Needed to build on UWP ARM. Can be removed when a new version is released with the patch.

--- a/thirdparty/zstd/1314.diff
+++ b/thirdparty/zstd/1314.diff
@@ -1,0 +1,13 @@
+diff --git a/common/cpu.h b/common/cpu.h
+index 88e0ebf44..eeb428ad5 100644
+--- a/common/cpu.h
++++ b/common/cpu.h
+@@ -36,7 +36,7 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
+     U32 f1d = 0;
+     U32 f7b = 0;
+     U32 f7c = 0;
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+     int reg[4];
+     __cpuid((int*)reg, 0);
+     {

--- a/thirdparty/zstd/common/cpu.h
+++ b/thirdparty/zstd/common/cpu.h
@@ -36,7 +36,7 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
     U32 f1d = 0;
     U32 f7b = 0;
     U32 f7c = 0;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
     int reg[4];
     __cpuid((int*)reg, 0);
     {


### PR DESCRIPTION
Patch comes from upstream and can be removed when it makes to stable
release.

Fix #21579