### PR TITLE
Add expand/collapse all buttons for the "Errors" tab

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -405,8 +405,8 @@ void InspectorDock::update(Object *p_object) {
 	PopupMenu *p = object_menu->get_popup();
 
 	p->clear();
-	p->add_shortcut(ED_SHORTCUT("property_editor/expand_all", TTR("Expand all properties")), EXPAND_ALL);
-	p->add_shortcut(ED_SHORTCUT("property_editor/collapse_all", TTR("Collapse all properties")), COLLAPSE_ALL);
+	p->add_shortcut(ED_SHORTCUT("property_editor/expand_all", TTR("Expand All Properties")), EXPAND_ALL);
+	p->add_shortcut(ED_SHORTCUT("property_editor/collapse_all", TTR("Collapse All Properties")), COLLAPSE_ALL);
 	p->add_separator();
 	if (is_resource) {
 		p->add_item(TTR("Save"), RESOURCE_SAVE);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1717,6 +1717,32 @@ void ScriptEditorDebugger::_error_selected() {
 	emit_signal("goto_script_line", s, int(meta[1]) - 1);
 }
 
+void ScriptEditorDebugger::_expand_errors_list() {
+
+	TreeItem *root = error_tree->get_root();
+	if (!root)
+		return;
+
+	TreeItem *item = root->get_children();
+	while (item) {
+		item->set_collapsed(false);
+		item = item->get_next();
+	}
+}
+
+void ScriptEditorDebugger::_collapse_errors_list() {
+
+	TreeItem *root = error_tree->get_root();
+	if (!root)
+		return;
+
+	TreeItem *item = root->get_children();
+	while (item) {
+		item->set_collapsed(true);
+		item = item->get_next();
+	}
+}
+
 void ScriptEditorDebugger::set_hide_on_stop(bool p_hide) {
 
 	hide_on_stop = p_hide;
@@ -1861,6 +1887,8 @@ void ScriptEditorDebugger::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_error_selected"), &ScriptEditorDebugger::_error_selected);
 	ClassDB::bind_method(D_METHOD("_error_activated"), &ScriptEditorDebugger::_error_activated);
+	ClassDB::bind_method(D_METHOD("_expand_errors_list"), &ScriptEditorDebugger::_expand_errors_list);
+	ClassDB::bind_method(D_METHOD("_collapse_errors_list"), &ScriptEditorDebugger::_collapse_errors_list);
 	ClassDB::bind_method(D_METHOD("_profiler_activate"), &ScriptEditorDebugger::_profiler_activate);
 	ClassDB::bind_method(D_METHOD("_profiler_seeked"), &ScriptEditorDebugger::_profiler_seeked);
 	ClassDB::bind_method(D_METHOD("_clear_errors_list"), &ScriptEditorDebugger::_clear_errors_list);
@@ -1999,8 +2027,31 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	}
 
 	{ //errors
+		VBoxContainer *errvb = memnew(VBoxContainer);
+		errvb->set_name(TTR("Errors"));
+
 		HBoxContainer *errhb = memnew(HBoxContainer);
-		errhb->set_name(TTR("Errors"));
+		errvb->add_child(errhb);
+
+		Button *expand_all = memnew(Button);
+		expand_all->set_text(TTR("Expand All"));
+		expand_all->connect("pressed", this, "_expand_errors_list");
+		errhb->add_child(expand_all);
+
+		Button *collapse_all = memnew(Button);
+		collapse_all->set_text(TTR("Collapse All"));
+		collapse_all->connect("pressed", this, "_collapse_errors_list");
+		errhb->add_child(collapse_all);
+
+		Control *space = memnew(Control);
+		space->set_h_size_flags(SIZE_EXPAND_FILL);
+		errhb->add_child(space);
+
+		clearbutton = memnew(Button);
+		clearbutton->set_text(TTR("Clear"));
+		clearbutton->set_h_size_flags(0);
+		clearbutton->connect("pressed", this, "_clear_errors_list");
+		errhb->add_child(clearbutton);
 
 		error_tree = memnew(Tree);
 		error_tree->set_columns(2);
@@ -2012,22 +2063,16 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 		error_tree->set_select_mode(Tree::SELECT_ROW);
 		error_tree->set_hide_root(true);
-		error_tree->set_h_size_flags(SIZE_EXPAND_FILL);
+		error_tree->set_v_size_flags(SIZE_EXPAND_FILL);
 		error_tree->set_allow_rmb_select(true);
 		error_tree->connect("item_rmb_selected", this, "_error_tree_item_rmb_selected");
-		errhb->add_child(error_tree);
+		errvb->add_child(error_tree);
 
 		item_menu = memnew(PopupMenu);
 		item_menu->connect("id_pressed", this, "_item_menu_id_pressed");
 		error_tree->add_child(item_menu);
 
-		clearbutton = memnew(Button);
-		clearbutton->set_text(TTR("Clear"));
-		clearbutton->set_v_size_flags(0);
-		clearbutton->connect("pressed", this, "_clear_errors_list");
-		errhb->add_child(clearbutton);
-
-		tabs->add_child(errhb);
+		tabs->add_child(errvb);
 	}
 
 	{ // remote scene tree

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -181,6 +181,9 @@ class ScriptEditorDebugger : public Control {
 	void _error_activated();
 	void _error_selected();
 
+	void _expand_errors_list();
+	void _collapse_errors_list();
+
 	void _profiler_activate(bool p_enable);
 	void _profiler_seeked();
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -76,7 +76,7 @@ public:
 		SIZE_EXPAND = 2,
 		SIZE_EXPAND_FILL = SIZE_EXPAND | SIZE_FILL,
 		SIZE_SHRINK_CENTER = 4, //ignored by expand or fill
-		SIZE_SHRINK_END = 8, //ignored by expand or fil
+		SIZE_SHRINK_END = 8, //ignored by expand or fill
 
 	};
 


### PR DESCRIPTION
As suggested [here](https://github.com/godotengine/godot/pull/21884#issuecomment-420636956). Also made the menu horizontal, looks far better in my opinion.
![screenshot at 2018-09-12 23-56-28](https://user-images.githubusercontent.com/30739239/45464946-4705d580-b6e9-11e8-92ff-77d166eafecd.png)

Took the time to capitalize some strings in the Inspector Dock as well.