### PR TITLE
Fix #17843 describing inability to generate vs projects without being…

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -578,6 +578,9 @@ def generate_vs_project(env, num_jobs):
         release_targets = ['bin\\godot.windows.opt.32.exe'] + ['bin\\godot.windows.opt.64.exe']
         release_debug_targets = ['bin\\godot.windows.opt.tools.32.exe'] + ['bin\\godot.windows.opt.tools.64.exe']
         targets = debug_targets + release_targets + release_debug_targets
+        if not env.get('MSVS'):
+            env['MSVS']['PROJECTSUFFIX'] = '.vcxproj'    
+            env['MSVS']['SOLUTIONSUFFIX'] = '.sln'
         env.MSVSProject(
             target=['#godot' + env['MSVSPROJECTSUFFIX']],
             incs=env.vs_incs,


### PR DESCRIPTION
Fix #17843 's inability to generate vs projects without being in a MSVC command prompt by guessing variables.

The vcxproj extension has been in MSVC 2012.
The sln extension has been in MSVC 2012.

