### PR TITLE
Properly initialize Winsock on startup

### DIFF
--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -67,6 +67,7 @@ protected:
 
 public:
 	static void make_default();
+	static void cleanup();
 
 	virtual Error open(Type p_sock_type, IP::Type &ip_type);
 	virtual void close();

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -139,6 +139,8 @@ void OS_Unix::initialize_core() {
 }
 
 void OS_Unix::finalize_core() {
+
+	NetSocketPosix::cleanup();
 }
 
 void OS_Unix::alert(const String &p_alert, const String &p_title) {

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -406,6 +406,8 @@ void OSUWP::finalize() {
 }
 
 void OSUWP::finalize_core() {
+
+	NetSocketPosix::cleanup();
 }
 
 void OSUWP::alert(const String &p_alert, const String &p_title) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1512,6 +1512,7 @@ void OS_Windows::finalize_core() {
 	timeEndPeriod(1);
 
 	memdelete(process_map);
+	NetSocketPosix::cleanup();
 }
 
 void OS_Windows::alert(const String &p_alert, const String &p_title) {


### PR DESCRIPTION
Winsock was broken after #21692 due to missing initialization.

Also fix a typo in `_get_last_error` which caused Winsock connect to fail.