### PR TITLE
Made it possible to define connections that do not fire in the editor

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1221,7 +1221,11 @@ Error Object::emit_signal(const StringName &p_name, const Variant **p_args, int 
 
 		const Connection &c = slot_map.getv(i).conn;
 
+		if (Engine::get_singleton()->is_editor_hint() && c.flags & CONNECT_NOT_IN_EDITOR)
+			continue;
+
 		Object *target;
+
 #ifdef DEBUG_ENABLED
 		target = ObjectDB::get_instance(slot_map.getk(i)._id);
 		ERR_CONTINUE(!target);
@@ -1784,6 +1788,7 @@ void Object::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONNECT_PERSIST);
 	BIND_ENUM_CONSTANT(CONNECT_ONESHOT);
 	BIND_ENUM_CONSTANT(CONNECT_REFERENCE_COUNTED);
+	BIND_ENUM_CONSTANT(CONNECT_NOT_IN_EDITOR);
 }
 
 void Object::call_deferred(const StringName &p_method, VARIANT_ARG_DECLARE) {

--- a/core/object.h
+++ b/core/object.h
@@ -394,6 +394,7 @@ public:
 		CONNECT_PERSIST = 2, // hint for scene to save this connection
 		CONNECT_ONESHOT = 4,
 		CONNECT_REFERENCE_COUNTED = 8,
+		CONNECT_NOT_IN_EDITOR = 16,
 	};
 
 	struct Connection {

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -249,6 +249,11 @@ bool ConnectDialog::get_oneshot() const {
 	return oneshot->is_pressed();
 }
 
+bool ConnectDialog::get_not_in_editor() const {
+
+	return not_in_editor->is_pressed();
+}
+
 /*
 Returns true if ConnectDialog is being used to edit an existing connection.
 */
@@ -380,6 +385,11 @@ ConnectDialog::ConnectDialog() {
 	oneshot->set_text(TTR("Oneshot"));
 	dstm_hb->add_child(oneshot);
 
+	not_in_editor = memnew(CheckButton);
+	not_in_editor->set_pressed(true);
+	not_in_editor->set_text(TTR("Not In Editor"));
+	dstm_hb->add_child(not_in_editor);
+
 	set_as_toplevel(true);
 
 	cdbinds = memnew(ConnectDialogBinds);
@@ -425,7 +435,8 @@ void ConnectionsDock::_make_or_edit_connection() {
 	cToMake.binds = connect_dialog->get_binds();
 	bool defer = connect_dialog->get_deferred();
 	bool oshot = connect_dialog->get_oneshot();
-	cToMake.flags = CONNECT_PERSIST | (defer ? CONNECT_DEFERRED : 0) | (oshot ? CONNECT_ONESHOT : 0);
+	bool no_editor = connect_dialog->get_not_in_editor();
+	cToMake.flags = CONNECT_PERSIST | (defer ? CONNECT_DEFERRED : 0) | (oshot ? CONNECT_ONESHOT : 0) | (no_editor ? CONNECT_NOT_IN_EDITOR : 0);
 
 	bool add_script_function = connect_dialog->get_make_callback();
 	PoolStringArray script_function_args;

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -67,6 +67,7 @@ class ConnectDialog : public ConfirmationDialog {
 	CheckButton *deferred;
 	CheckButton *oneshot;
 	CheckButton *make_callback;
+	CheckButton *not_in_editor;
 
 	void ok_pressed();
 	void _cancel_pressed();
@@ -90,6 +91,7 @@ public:
 	bool get_make_callback() { return make_callback->is_visible() && make_callback->is_pressed(); }
 	bool get_deferred() const;
 	bool get_oneshot() const;
+	bool get_not_in_editor() const;
 	bool is_editing() const;
 
 	void init(Connection c, bool bEdit = false);


### PR DESCRIPTION
Made it possible to define connections that do not fire in the editor, this can be done by adding the CONNECTION_NOT_IN_EDITOR flag. This can also be done with a toggle in the create connection window.

This is to prevent constant `Method not found.` errors in the editor.

Fixes: #13070