### PR TITLE
Fix VisualScriptVariableSet #21840 you can't use a variable in the Ve…

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -1799,23 +1799,11 @@ void CustomPropertyEditor::_focus_enter() {
 }
 
 void CustomPropertyEditor::_focus_exit() {
-	switch (type) {
-		case Variant::REAL:
-		case Variant::STRING:
-		case Variant::VECTOR2:
-		case Variant::RECT2:
-		case Variant::VECTOR3:
-		case Variant::PLANE:
-		case Variant::QUAT:
-		case Variant::AABB:
-		case Variant::TRANSFORM2D:
-		case Variant::BASIS:
-		case Variant::TRANSFORM: {
-			for (int i = 0; i < MAX_VALUE_EDITORS; ++i) {
-				value_editor[i]->select(0, 0);
-			}
-		} break;
-		default: {}
+	for (int i = 0; i < MAX_VALUE_EDITORS; i++) {
+		if (value_editor[i]->has_focus()) {
+			_modified(value_editor[i]->get_text());
+			break;
+		}
 	}
 }
 


### PR DESCRIPTION
…ctor3 constructor using VisualScript.

Reproduction steps: Make a VisualScript script with a variable and use this variable in a Vector3 constructor, then print the result. It will return null.

Preserves the current workflow of clicking outside to avoid editing, but requires enter to be pressed to confirm changes.