### PR TITLE
Fix get_8 returning 0 for last byte of compressed files

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -293,7 +293,6 @@ uint8_t FileAccessCompressed::get_8() const {
 		} else {
 			read_block--;
 			at_end = true;
-			ret = 0;
 		}
 	}
 


### PR DESCRIPTION
Fix #21991.  FileAccessCompressed::get_8 was returning 0 on the last byte of the file.