### PR TITLE
Fix #21991 Reading from G-Zip Compressed File cuts last letter/digit

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -279,7 +279,6 @@ uint8_t FileAccessCompressed::get_8() const {
 
 	uint8_t ret = read_ptr[read_pos];
 
-	read_pos++;
 	if (read_pos >= read_block_size) {
 		read_block++;
 
@@ -296,6 +295,7 @@ uint8_t FileAccessCompressed::get_8() const {
 			ret = 0;
 		}
 	}
+	read_pos++;
 
 	return ret;
 }


### PR DESCRIPTION
Fixes #21991. Classic bug where the position was increased before executing the code block.

I put increasing the variable at the end of the code block.

First contribution of mine, so if something is not quite right, please let me know and I'll do my best to resolve the issue!