### PR TITLE
Add "Resume" action

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -232,6 +232,12 @@ void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
 			_editor_select_next();
 		} else if (ED_IS_SHORTCUT("editor/editor_prev", p_event)) {
 			_editor_select_prev();
+		} else if (ED_IS_SHORTCUT("editor/resume", p_event)) {
+			if (editor_run.get_status() == EditorRun::STATUS_PLAY) {
+				emit_signal("resumed");
+			} else {
+				_run(false, "");
+			}
 		}
 
 		if (k->get_scancode() == KEY_ESCAPE) {
@@ -4580,6 +4586,7 @@ void EditorNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("play_pressed"));
 	ADD_SIGNAL(MethodInfo("pause_pressed"));
 	ADD_SIGNAL(MethodInfo("stop_pressed"));
+	ADD_SIGNAL(MethodInfo("resumed"));
 	ADD_SIGNAL(MethodInfo("request_help_search"));
 	ADD_SIGNAL(MethodInfo("request_help_index"));
 	ADD_SIGNAL(MethodInfo("script_add_function_request", PropertyInfo(Variant::OBJECT, "obj"), PropertyInfo(Variant::STRING, "function"), PropertyInfo(Variant::POOL_STRING_ARRAY, "args")));
@@ -5791,6 +5798,7 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT("editor/editor_assetlib", TTR("Open Asset Library"));
 	ED_SHORTCUT("editor/editor_next", TTR("Open the next Editor"));
 	ED_SHORTCUT("editor/editor_prev", TTR("Open the previous Editor"));
+	ED_SHORTCUT("editor/resume", TTR("Resume"));
 }
 
 EditorNode::~EditorNode() {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1294,6 +1294,7 @@ void ScriptEditor::_notification(int p_what) {
 			editor->connect("stop_pressed", this, "_editor_stop");
 			editor->connect("script_add_function_request", this, "_add_callback");
 			editor->connect("resource_saved", this, "_res_saved_callback");
+			editor->connect("resumed", this, "_editor_resume");
 			script_list->connect("item_selected", this, "_script_selected");
 
 			members_overview->connect("item_selected", this, "_members_overview_selected");
@@ -1333,6 +1334,7 @@ void ScriptEditor::_notification(int p_what) {
 			editor->disconnect("play_pressed", this, "_editor_play");
 			editor->disconnect("pause_pressed", this, "_editor_pause");
 			editor->disconnect("stop_pressed", this, "_editor_stop");
+			editor->disconnect("resumed", this, "_editor_resume");
 		} break;
 
 		case MainLoop::NOTIFICATION_WM_FOCUS_IN: {
@@ -2103,6 +2105,7 @@ void ScriptEditor::_editor_play() {
 
 void ScriptEditor::_editor_pause() {
 }
+
 void ScriptEditor::_editor_stop() {
 
 	debugger->stop();
@@ -2120,6 +2123,13 @@ void ScriptEditor::_editor_stop() {
 		}
 
 		se->set_debugger_active(false);
+	}
+}
+
+void ScriptEditor::_editor_resume() {
+
+	if (debugger) {
+		debugger->debug_continue();
 	}
 }
 
@@ -2844,6 +2854,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_editor_play", &ScriptEditor::_editor_play);
 	ClassDB::bind_method("_editor_pause", &ScriptEditor::_editor_pause);
 	ClassDB::bind_method("_editor_stop", &ScriptEditor::_editor_stop);
+	ClassDB::bind_method("_editor_resume", &ScriptEditor::_editor_resume);
 	ClassDB::bind_method("_add_callback", &ScriptEditor::_add_callback);
 	ClassDB::bind_method("_reload_scripts", &ScriptEditor::_reload_scripts);
 	ClassDB::bind_method("_resave_scripts", &ScriptEditor::_resave_scripts);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -303,6 +303,7 @@ class ScriptEditor : public PanelContainer {
 	void _editor_play();
 	void _editor_pause();
 	void _editor_stop();
+	void _editor_resume();
 
 	int edit_pass;
 


### PR DESCRIPTION
Adds a "Resume" action, which allows for a more VS-like workflow, where one keybind launches the game if it's not running and continues the debugger if it is.

This isn't currently possible because the "Play" actions are the only actions that will start the game, they restart the game if it's already running, and they take priority over "Continue."