### PR TITLE
Discard button pressing flags on disable

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -315,6 +315,14 @@ void BaseButton::set_disabled(bool p_disabled) {
 		return;
 
 	status.disabled = p_disabled;
+	if (p_disabled) {
+		if (!toggle_mode) {
+			status.pressed = false;
+		}
+		status.press_attempt = false;
+		status.pressing_inside = false;
+		status.pressing_button = 0;
+	}
 	update();
 	_change_notify("disabled");
 }


### PR DESCRIPTION
Is it a bug?
1) Click the button and hold
2) Disable it (for example I bind this action on keyboard)
3) Release the mouse and move it outside the button
4) Enable the button
5) It's still pressed, but shouldn't

*Bugsquad edit:* Fixes #12217.