### PR TITLE
Fix set_default_cursor_shape interaction with Control nodes

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -598,7 +598,13 @@ Input::CursorShape InputDefault::get_default_cursor_shape() {
 
 void InputDefault::set_default_cursor_shape(CursorShape p_shape) {
 	default_shape = p_shape;
-	OS::get_singleton()->set_cursor_shape((OS::CursorShape)p_shape);
+	// The default shape is set in Viewport::_gui_input_event. To instantly
+	// see the shape in the viewport we need to trigger a mouse motion event.
+	Ref<InputEventMouseMotion> mm;
+	mm.instance();
+	mm->set_position(mouse_pos);
+	mm->set_global_position(mouse_pos);
+	parse_input_event(mm);
 }
 
 void InputDefault::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2524,13 +2524,16 @@ void OS_X11::set_cursor_shape(CursorShape p_shape) {
 
 	ERR_FAIL_INDEX(p_shape, CURSOR_MAX);
 
-	if (p_shape == current_cursor)
+	if (p_shape == current_cursor) {
 		return;
-	if (mouse_mode == MOUSE_MODE_VISIBLE && mouse_mode != MOUSE_MODE_CONFINED) {
-		if (cursors[p_shape] != None)
+	}
+
+	if (mouse_mode == MOUSE_MODE_VISIBLE || mouse_mode == MOUSE_MODE_CONFINED) {
+		if (cursors[p_shape] != None) {
 			XDefineCursor(x11_display, x11_window, cursors[p_shape]);
-		else if (cursors[CURSOR_ARROW] != None)
+		} else if (cursors[CURSOR_ARROW] != None) {
 			XDefineCursor(x11_display, x11_window, cursors[CURSOR_ARROW]);
+		}
 	}
 
 	current_cursor = p_shape;


### PR DESCRIPTION
Do not call `set_cursor_shape` when the cursor is inside the `Control` node.

Make it work for x11 in MOUSE_MODE_CONFINED.

Test demo [v2 - added a custom cursor shape test]
[pr22070-set_default_cursor_shape.zip](https://github.com/godotengine/godot/files/2385518/pr22070-set_default_cursor_shape.zip)

![peek4](https://user-images.githubusercontent.com/4047289/45584327-f0a7bb00-b8d1-11e8-8578-90c9929d57ac.gif)
