### PR TITLE
Set default CanvasItemEditor zoom shortcut to KEY_EQUAL

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4390,7 +4390,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	zoom_plus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_plus);
 	zoom_plus->connect("pressed", this, "_button_zoom_plus");
-	zoom_plus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_plus", TTR("Zoom in"), KEY_MASK_CMD | KEY_PLUS));
+	zoom_plus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_plus", TTR("Zoom in"), KEY_MASK_CMD | KEY_EQUAL)); // Usually direct access key for PLUS
 	zoom_plus->set_focus_mode(FOCUS_NONE);
 
 	updating_scroll = false;


### PR DESCRIPTION
At least on en_US QWERTY (and various QWERTY-derived variants)
and fr_FR AZERTY, "+" is an indirect key obtained by pressing
"Shift" + "=", so using "=" in the binding makes it easier to
access.

It doesn't work this way on other layouts like de_DE QWERTZ though,
but since 'script_editor/zoom_in' also uses KEY_EQUAL, setting
the same for consistency.

Fixes #22067.