### PR TITLE
Rename ScrollBar's drag_slave to drag_node

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -29,12 +29,13 @@
 /*************************************************************************/
 
 #include "rich_text_label.h"
+
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "scene/scene_string_names.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/editor_node.h"
+#include "editor/editor_scale.h"
 #endif
 
 RichTextLabel::Item *RichTextLabel::_get_next_item(Item *p_item, bool p_free) {
@@ -2295,7 +2296,7 @@ RichTextLabel::RichTextLabel() {
 
 	vscroll = memnew(VScrollBar);
 	add_child(vscroll);
-	vscroll->set_drag_slave(String(".."));
+	vscroll->set_drag_node(String(".."));
 	vscroll->set_step(1);
 	vscroll->set_anchor_and_margin(MARGIN_TOP, ANCHOR_BEGIN, 0);
 	vscroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, 0);

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -300,24 +300,24 @@ void ScrollBar::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		if (has_node(drag_slave_path)) {
-			Node *n = get_node(drag_slave_path);
-			drag_slave = Object::cast_to<Control>(n);
+		if (has_node(drag_node_path)) {
+			Node *n = get_node(drag_node_path);
+			drag_node = Object::cast_to<Control>(n);
 		}
 
-		if (drag_slave) {
-			drag_slave->connect("gui_input", this, "_drag_slave_input");
-			drag_slave->connect("tree_exiting", this, "_drag_slave_exit", varray(), CONNECT_ONESHOT);
+		if (drag_node) {
+			drag_node->connect("gui_input", this, "_drag_node_input");
+			drag_node->connect("tree_exiting", this, "_drag_node_exit", varray(), CONNECT_ONESHOT);
 		}
 	}
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
-		if (drag_slave) {
-			drag_slave->disconnect("gui_input", this, "_drag_slave_input");
-			drag_slave->disconnect("tree_exiting", this, "_drag_slave_exit");
+		if (drag_node) {
+			drag_node->disconnect("gui_input", this, "_drag_node_input");
+			drag_node->disconnect("tree_exiting", this, "_drag_node_exit");
 		}
 
-		drag_slave = NULL;
+		drag_node = NULL;
 	}
 
 	if (p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
@@ -337,12 +337,13 @@ void ScrollBar::_notification(int p_what) {
 				scrolling = false;
 				set_physics_process_internal(false);
 			}
-		} else if (drag_slave_touching) {
 
-			if (drag_slave_touching_deaccel) {
+		} else if (drag_node_touching) {
+
+			if (drag_node_touching_deaccel) {
 
 				Vector2 pos = Vector2(orientation == HORIZONTAL ? get_value() : 0, orientation == VERTICAL ? get_value() : 0);
-				pos += drag_slave_speed * get_physics_process_delta_time();
+				pos += drag_node_speed * get_physics_process_delta_time();
 
 				bool turnoff = false;
 
@@ -360,15 +361,15 @@ void ScrollBar::_notification(int p_what) {
 
 					set_value(pos.x);
 
-					float sgn_x = drag_slave_speed.x < 0 ? -1 : 1;
-					float val_x = Math::abs(drag_slave_speed.x);
+					float sgn_x = drag_node_speed.x < 0 ? -1 : 1;
+					float val_x = Math::abs(drag_node_speed.x);
 					val_x -= 1000 * get_physics_process_delta_time();
 
 					if (val_x < 0) {
 						turnoff = true;
 					}
 
-					drag_slave_speed.x = sgn_x * val_x;
+					drag_node_speed.x = sgn_x * val_x;
 
 				} else {
 
@@ -384,29 +385,29 @@ void ScrollBar::_notification(int p_what) {
 
 					set_value(pos.y);
 
-					float sgn_y = drag_slave_speed.y < 0 ? -1 : 1;
-					float val_y = Math::abs(drag_slave_speed.y);
+					float sgn_y = drag_node_speed.y < 0 ? -1 : 1;
+					float val_y = Math::abs(drag_node_speed.y);
 					val_y -= 1000 * get_physics_process_delta_time();
 
 					if (val_y < 0) {
 						turnoff = true;
 					}
-					drag_slave_speed.y = sgn_y * val_y;
+					drag_node_speed.y = sgn_y * val_y;
 				}
 
 				if (turnoff) {
 					set_physics_process_internal(false);
-					drag_slave_touching = false;
-					drag_slave_touching_deaccel = false;
+					drag_node_touching = false;
+					drag_node_touching_deaccel = false;
 				}
 
 			} else {
 
 				if (time_since_motion == 0 || time_since_motion > 0.1) {
 
-					Vector2 diff = drag_slave_accum - last_drag_slave_accum;
-					last_drag_slave_accum = drag_slave_accum;
-					drag_slave_speed = diff / get_physics_process_delta_time();
+					Vector2 diff = drag_node_accum - last_drag_node_accum;
+					last_drag_node_accum = drag_node_accum;
+					drag_node_speed = diff / get_physics_process_delta_time();
 				}
 
 				time_since_motion += get_physics_process_delta_time();
@@ -544,15 +545,15 @@ float ScrollBar::get_custom_step() const {
 	return custom_step;
 }
 
-void ScrollBar::_drag_slave_exit() {
+void ScrollBar::_drag_node_exit() {
 
-	if (drag_slave) {
-		drag_slave->disconnect("gui_input", this, "_drag_slave_input");
+	if (drag_node) {
+		drag_node->disconnect("gui_input", this, "_drag_node_input");
 	}
-	drag_slave = NULL;
+	drag_node = NULL;
 }
 
-void ScrollBar::_drag_slave_input(const Ref<InputEvent> &p_input) {
+void ScrollBar::_drag_node_input(const Ref<InputEvent> &p_input) {
 
 	Ref<InputEventMouseButton> mb = p_input;
 
@@ -563,43 +564,30 @@ void ScrollBar::_drag_slave_input(const Ref<InputEvent> &p_input) {
 
 		if (mb->is_pressed()) {
 
-			if (drag_slave_touching) {
-				set_physics_process_internal(false);
-				drag_slave_touching_deaccel = false;
-				drag_slave_touching = false;
-				drag_slave_speed = Vector2();
-				drag_slave_accum = Vector2();
-				last_drag_slave_accum = Vector2();
-				drag_slave_from = Vector2();
-			}
+			drag_node_speed = Vector2();
+			drag_node_accum = Vector2();
+			last_drag_node_accum = Vector2();
+			drag_node_from = Vector2(orientation == HORIZONTAL ? get_value() : 0, orientation == VERTICAL ? get_value() : 0);
 
-			if (true) {
-				drag_slave_speed = Vector2();
-				drag_slave_accum = Vector2();
-				last_drag_slave_accum = Vector2();
-				//drag_slave_from=Vector2(h_scroll->get_val(),v_scroll->get_val());
-				drag_slave_from = Vector2(orientation == HORIZONTAL ? get_value() : 0, orientation == VERTICAL ? get_value() : 0);
+			drag_node_touching = OS::get_singleton()->has_touchscreen_ui_hint();
+			drag_node_touching_deaccel = false;
+			time_since_motion = 0;
 
-				drag_slave_touching = OS::get_singleton()->has_touchscreen_ui_hint();
-				drag_slave_touching_deaccel = false;
+			if (drag_node_touching) {
+				set_physics_process_internal(true);
 				time_since_motion = 0;
-				if (drag_slave_touching) {
-					set_physics_process_internal(true);
-					time_since_motion = 0;
-				}
 			}
 
 		} else {
 
-			if (drag_slave_touching) {
+			if (drag_node_touching) {
 
-				if (drag_slave_speed == Vector2()) {
-					drag_slave_touching_deaccel = false;
-					drag_slave_touching = false;
+				if (drag_node_speed == Vector2()) {
+					drag_node_touching_deaccel = false;
+					drag_node_touching = false;
 					set_physics_process_internal(false);
 				} else {
-
-					drag_slave_touching_deaccel = true;
+					drag_node_touching_deaccel = true;
 				}
 			}
 		}
@@ -609,60 +597,54 @@ void ScrollBar::_drag_slave_input(const Ref<InputEvent> &p_input) {
 
 	if (mm.is_valid()) {
 
-		if (drag_slave_touching && !drag_slave_touching_deaccel) {
+		if (drag_node_touching && !drag_node_touching_deaccel) {
 
 			Vector2 motion = Vector2(mm->get_relative().x, mm->get_relative().y);
 
-			drag_slave_accum -= motion;
-			Vector2 diff = drag_slave_from + drag_slave_accum;
+			drag_node_accum -= motion;
+			Vector2 diff = drag_node_from + drag_node_accum;
 
 			if (orientation == HORIZONTAL)
 				set_value(diff.x);
-			/*
-			else
-				drag_slave_accum.x=0;
-			*/
+
 			if (orientation == VERTICAL)
 				set_value(diff.y);
-			/*
-			else
-				drag_slave_accum.y=0;
-			*/
+
 			time_since_motion = 0;
 		}
 	}
 }
 
-void ScrollBar::set_drag_slave(const NodePath &p_path) {
+void ScrollBar::set_drag_node(const NodePath &p_path) {
 
 	if (is_inside_tree()) {
 
-		if (drag_slave) {
-			drag_slave->disconnect("gui_input", this, "_drag_slave_input");
-			drag_slave->disconnect("tree_exiting", this, "_drag_slave_exit");
+		if (drag_node) {
+			drag_node->disconnect("gui_input", this, "_drag_node_input");
+			drag_node->disconnect("tree_exiting", this, "_drag_node_exit");
 		}
 	}
 
-	drag_slave = NULL;
-	drag_slave_path = p_path;
+	drag_node = NULL;
+	drag_node_path = p_path;
 
 	if (is_inside_tree()) {
 
 		if (has_node(p_path)) {
 			Node *n = get_node(p_path);
-			drag_slave = Object::cast_to<Control>(n);
+			drag_node = Object::cast_to<Control>(n);
 		}
 
-		if (drag_slave) {
-			drag_slave->connect("gui_input", this, "_drag_slave_input");
-			drag_slave->connect("tree_exiting", this, "_drag_slave_exit", varray(), CONNECT_ONESHOT);
+		if (drag_node) {
+			drag_node->connect("gui_input", this, "_drag_node_input");
+			drag_node->connect("tree_exiting", this, "_drag_node_exit", varray(), CONNECT_ONESHOT);
 		}
 	}
 }
 
-NodePath ScrollBar::get_drag_slave() const {
+NodePath ScrollBar::get_drag_node() const {
 
-	return drag_slave_path;
+	return drag_node_path;
 }
 
 void ScrollBar::set_smooth_scroll_enabled(bool p_enable) {
@@ -678,8 +660,8 @@ void ScrollBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_gui_input"), &ScrollBar::_gui_input);
 	ClassDB::bind_method(D_METHOD("set_custom_step", "step"), &ScrollBar::set_custom_step);
 	ClassDB::bind_method(D_METHOD("get_custom_step"), &ScrollBar::get_custom_step);
-	ClassDB::bind_method(D_METHOD("_drag_slave_input"), &ScrollBar::_drag_slave_input);
-	ClassDB::bind_method(D_METHOD("_drag_slave_exit"), &ScrollBar::_drag_slave_exit);
+	ClassDB::bind_method(D_METHOD("_drag_node_input"), &ScrollBar::_drag_node_input);
+	ClassDB::bind_method(D_METHOD("_drag_node_exit"), &ScrollBar::_drag_node_exit);
 
 	ADD_SIGNAL(MethodInfo("scrolling"));
 
@@ -691,13 +673,13 @@ ScrollBar::ScrollBar(Orientation p_orientation) {
 	orientation = p_orientation;
 	highlight = HIGHLIGHT_NONE;
 	custom_step = -1;
-	drag_slave = NULL;
+	drag_node = NULL;
 
 	drag.active = false;
 
-	drag_slave_speed = Vector2();
-	drag_slave_touching = false;
-	drag_slave_touching_deaccel = false;
+	drag_node_speed = Vector2();
+	drag_node_touching = false;
+	drag_node_touching_deaccel = false;
 
 	scrolling = false;
 	target_scroll = 0;

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -36,6 +36,7 @@
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
+
 class ScrollBar : public Range {
 
 	GDCLASS(ScrollBar, Range);
@@ -71,25 +72,25 @@ class ScrollBar : public Range {
 
 	static void set_can_focus_by_default(bool p_can_focus);
 
-	Node *drag_slave;
-	NodePath drag_slave_path;
+	Node *drag_node;
+	NodePath drag_node_path;
 
-	Vector2 drag_slave_speed;
-	Vector2 drag_slave_accum;
-	Vector2 drag_slave_from;
-	Vector2 last_drag_slave_accum;
-	float last_drag_slave_time;
+	Vector2 drag_node_speed;
+	Vector2 drag_node_accum;
+	Vector2 drag_node_from;
+	Vector2 last_drag_node_accum;
+	float last_drag_node_time;
 	float time_since_motion;
-	bool drag_slave_touching;
-	bool drag_slave_touching_deaccel;
+	bool drag_node_touching;
+	bool drag_node_touching_deaccel;
 	bool click_handled;
 
 	bool scrolling;
 	double target_scroll;
 	bool smooth_scroll_enabled;
 
-	void _drag_slave_exit();
-	void _drag_slave_input(const Ref<InputEvent> &p_input);
+	void _drag_node_exit();
+	void _drag_node_input(const Ref<InputEvent> &p_input);
 
 	void _gui_input(Ref<InputEvent> p_event);
 
@@ -102,8 +103,8 @@ public:
 	void set_custom_step(float p_custom_step);
 	float get_custom_step() const;
 
-	void set_drag_slave(const NodePath &p_path);
-	NodePath get_drag_slave() const;
+	void set_drag_node(const NodePath &p_path);
+	NodePath get_drag_node() const;
 
 	void set_smooth_scroll_enabled(bool p_enable);
 	bool is_smooth_scroll_enabled() const;


### PR DESCRIPTION
While reviewing #22087 I found another use of the term `slave` in the code base, so I changed it too for consistency as it doesn't particularly convey a very important meaning.

I'm not even sure the feature itself does anything, it seems related to touch devices so I could not test it easily. I did not add compatibility methods with deprecation warnings as the only method bound to scripting languages was with a leading underscore, i.e. meant for internal use and not for use in scripts.