### PR TITLE
Fix video toggle UX issue

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5446,13 +5446,6 @@ EditorNode::EditorNode() {
 	video_driver_current = 0;
 	for (int i = 0; i < video_drivers.get_slice_count(","); i++) {
 		String driver = video_drivers.get_slice(",", i);
-		Ref<Texture> icon = get_class_icon(driver, "");
-		if (icon.is_valid()) {
-			video_driver->add_icon_item(icon, "");
-		} else {
-			video_driver->add_item(driver);
-		}
-
 		video_driver->add_item(driver);
 		video_driver->set_item_metadata(i, driver);
 


### PR DESCRIPTION
It was still functional but showing duplicate entries and thus
"GLES2" for both GLES2 and GLES3 choices.

Fixes #22089.