### PR TITLE
Fix VisualShader code overwrites and save failures

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -426,7 +426,7 @@ void ShaderEditor::ensure_select_current() {
 
 void ShaderEditor::edit(const Ref<Shader> &p_shader) {
 
-	if (p_shader.is_null())
+	if (p_shader.is_null() || !p_shader->is_text_shader())
 		return;
 
 	shader = p_shader;
@@ -606,7 +606,7 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 bool ShaderEditorPlugin::handles(Object *p_object) const {
 
 	Shader *shader = Object::cast_to<Shader>(p_object);
-	return shader != NULL;
+	return shader != NULL && shader->is_text_shader();
 }
 
 void ShaderEditorPlugin::make_visible(bool p_visible) {

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -126,6 +126,11 @@ void Shader::get_default_texture_param_list(List<StringName> *r_textures) const 
 		r_textures->push_back(E->key());
 	}
 }
+
+bool Shader::is_text_shader() const {
+	return true;
+}
+
 bool Shader::has_param(const StringName &p_param) const {
 
 	return params_cache.has(p_param);
@@ -235,8 +240,10 @@ Error ResourceFormatSaverShader::save(const String &p_path, const RES &p_resourc
 
 void ResourceFormatSaverShader::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
 
-	if (Object::cast_to<Shader>(*p_resource)) {
-		p_extensions->push_back("shader");
+	if (const Shader *shader = Object::cast_to<Shader>(*p_resource)) {
+		if (shader->is_text_shader()) {
+			p_extensions->push_back("shader");
+		}
 	}
 }
 bool ResourceFormatSaverShader::recognize(const RES &p_resource) const {

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -79,6 +79,8 @@ public:
 	Ref<Texture> get_default_texture_param(const StringName &p_param) const;
 	void get_default_texture_param_list(List<StringName> *r_textures) const;
 
+	virtual bool is_text_shader() const;
+
 	_FORCE_INLINE_ StringName remap_param(const StringName &p_param) const {
 		if (params_cache_dirty)
 			get_param_list(NULL);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -414,6 +414,10 @@ Shader::Mode VisualShader::get_mode() const {
 	return shader_mode;
 }
 
+bool VisualShader::is_text_shader() const {
+	return false;
+}
+
 String VisualShader::generate_preview_shader(Type p_type, int p_node, int p_port, Vector<DefaultTextureParam> &default_tex_params) const {
 
 	Ref<VisualShaderNode> node = get_node(p_type, p_node);

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -141,6 +141,8 @@ public:
 	void set_mode(Mode p_mode);
 	virtual Mode get_mode() const;
 
+	virtual bool is_text_shader() const;
+
 	void set_graph_offset(const Vector2 &p_offset);
 	Vector2 get_graph_offset() const;
 


### PR DESCRIPTION
This mainly fixes an issue where any changes made to a VisualShader seem to stop taking effect when the shader is saved unless the editor is restarted.

Specifically, this prevents VisualShaders from being opened or handled by the (text) shader editor, which currently opens alongside the VisualShader editor.  This is problematic for two reasons:

First, the source code isn't supposed to be editable.

Second, because the shader is open in the shader editor, saving the resource will cause it to update the shader code when saving, clobbering the VisualShader code with the code in the shader editor, usually causing it to revert back to whatever it was when it was loaded, and save the wrong code to the file.

Also uses the added text shader flag to remove "shader" from the recognized extension list of non-text shaders.  The "shader" extension doesn't work with visual shaders in the first place, and because it's currently the default, "New Resource..." --> "VisualShader" --> "Save" fails with an uninformative error.  Removing it makes it default to "tres" instead, which works.