### PR TITLE
Added find_parent method to node class

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -266,6 +266,15 @@
 				Returns the parent node of the current node, or an empty [code]Node[/code] if the node lacks a parent.
 			</description>
 		</method>
+		<method name="find_parent" qualifiers="const">
+			<return type="Node">
+			</return>
+			<argument index="0" name="mask" type="String">
+			</argument>
+			<description>
+				Finds the first parent of the current node whose name matches [code]mask[/code] as in [method String.match] (i.e. case sensitive, but '*' matches zero or more characters and '?' matches any single character except '.'). Note that it does not match against the full path, just against individual node names.
+			</description>
+		</method>
 		<method name="get_path" qualifiers="const">
 			<return type="NodePath">
 			</return>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1348,6 +1348,19 @@ Node *Node::get_parent() const {
 	return data.parent;
 }
 
+Node *Node::find_parent(const String &p_mask) const {
+
+	Node *p = data.parent;
+	while (p) {
+
+		if (p->data.name.operator String().match(p_mask))
+			return p;
+		p = p->data.parent;
+	}
+
+	return NULL;
+}
+
 bool Node::is_a_parent_of(const Node *p_node) const {
 
 	ERR_FAIL_NULL_V(p_node, false);
@@ -2617,6 +2630,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_node", "path"), &Node::get_node);
 	ClassDB::bind_method(D_METHOD("get_parent"), &Node::get_parent);
 	ClassDB::bind_method(D_METHOD("find_node", "mask", "recursive", "owned"), &Node::find_node, DEFVAL(true), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("find_parent", "mask"), &Node::find_parent);
 	ClassDB::bind_method(D_METHOD("has_node_and_resource", "path"), &Node::has_node_and_resource);
 	ClassDB::bind_method(D_METHOD("get_node_and_resource", "path"), &Node::_get_node_and_resource);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -257,6 +257,8 @@ public:
 	Node *get_node_and_resource(const NodePath &p_path, RES &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property = true) const;
 
 	Node *get_parent() const;
+	Node *find_parent(const String &p_mask) const;
+
 	_FORCE_INLINE_ SceneTree *get_tree() const {
 		ERR_FAIL_COND_V(!data.tree, NULL);
 		return data.tree;


### PR DESCRIPTION
Added helper node method `find_parent` which traverses up the scene tree from the current node and returns the first parent matching given name, similar to find_node. 