### PR TITLE
Make inspector select the correct resource after making them unique

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -104,6 +104,7 @@ void InspectorDock::_menu_option(int p_option) {
 								res = duplicates[res];
 
 								current->set(E->get().name, res);
+								editor->get_inspector()->update_property(E->get().name);
 							}
 						}
 					}


### PR DESCRIPTION
Make inspector select the correct resource after making them unique.

This fixes #20684