### PR TITLE
Check for mono binary when finding version

### DIFF
--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -282,7 +282,14 @@ def pkgconfig_try_find_mono_version():
 def mono_root_try_find_mono_version(mono_root):
     from compat import decode_utf8
 
-    output = subprocess.check_output([os.path.join(mono_root, 'bin', 'mono'), '--version'])
+    mono_bin = os.path.join(mono_root, 'bin')
+    if os.path.isfile(os.path.join(mono_bin, 'mono')):
+        mono_binary = os.path.join(mono_bin, 'mono')
+    elif os.path.isfile(os.path.join(mono_bin, 'mono.exe')):
+        mono_binary = os.path.join(mono_bin, 'mono.exe')
+    else:
+        return None
+    output = subprocess.check_output([mono_binary, '--version'])
     first_line = decode_utf8(output.splitlines()[0])
     try:
         return LooseVersion(first_line.split()[len('Mono JIT compiler version'.split())])


### PR DESCRIPTION
This checks that the mono binary actually exists and optionally uses the `mono.exe` file directly.

With this change, cross-compiling Godot for Windows with enabled Mono support can use a Windows mono.exe for finding the version. Thus the Windows templates can be compiled on Linux using Windows Mono if wine is configured for running .exe files.

Doesn't directly fix issue 22104 (not referencing it to make sure that GitHub doesn't auto-close), but makes it easier to compile.