### PR TITLE
Made changing editor_lock/display_folded in code update their value in editor

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1077,6 +1077,8 @@ void Object::set_meta(const String &p_name, const Variant &p_value) {
 	};
 
 	metadata[p_name] = p_value;
+
+	_change_notify("__meta__");
 }
 
 Variant Object::get_meta(const String &p_name) const {

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -165,6 +165,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		part_of_subscene = p_node != get_scene_node() && get_scene_node()->get_scene_inherited_state().is_valid() && get_scene_node()->get_scene_inherited_state()->find_node_by_path(get_scene_node()->get_path_to(p_node)) >= 0;
 	}
 
+	p_node->add_change_receptor(this);
+
 	TreeItem *item = tree->create_item(p_parent);
 
 	item->set_text(0, p_node->get_name());
@@ -425,6 +427,8 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 		if (p_node->is_connected("visibility_changed", this, "_node_visibility_changed"))
 			p_node->disconnect("visibility_changed", this, "_node_visibility_changed");
 	}
+
+	p_node->remove_change_receptor(this);
 
 	if (p_node == selected) {
 		selected = NULL;
@@ -964,6 +968,14 @@ void SceneTreeEditor::_warning_changed(Node *p_for_node) {
 
 	//should use a timer
 	update_timer->start();
+}
+
+void SceneTreeEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+	if (p_prop == StringName("__meta__") && p_changed->is_class("CanvasItem"))
+		call_deferred("_update_tree");
+
+	if (p_prop == StringName("display_folded"))
+		call_deferred("_update_tree");
 }
 
 void SceneTreeEditor::_editor_settings_changed() {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -124,6 +124,8 @@ class SceneTreeEditor : public Control {
 
 	void _warning_changed(Node *p_for_node);
 
+	void _changed_callback(Object *p_changed, const char *p_prop);
+
 	void _editor_settings_changed();
 
 	Timer *update_timer;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2586,6 +2586,8 @@ bool Node::is_owned_by_parent() const {
 
 void Node::set_display_folded(bool p_folded) {
 	data.display_folded = p_folded;
+
+	_change_notify("display_folded");
 }
 
 bool Node::is_displayed_folded() const {


### PR DESCRIPTION
Previously if you changed display_folded in code this wouldn't be reflected in the editor until reload, same was true for changing editor_lock.

Fixes #21406