### PR TITLE
Implement OS::set_icon in HTML5 platform

### DIFF
--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -135,6 +135,7 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 	virtual void set_window_title(const String &p_title);
+	virtual void set_icon(const Ref<Image> &p_icon);
 	String get_executable_path() const;
 	virtual Error shell_open(String p_uri);
 	virtual String get_name();


### PR DESCRIPTION
Implement `OS.set_icon` by displaying the image as favicon. This is automatically called on start-up with the project icon.

Fix #13083