### PR TITLE
Fixed argument names having wrong order for atan2

### DIFF
--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1458,7 +1458,7 @@ MethodInfo GDScriptFunctions::get_info(Function p_func) {
 			return mi;
 		} break;
 		case MATH_ATAN2: {
-			MethodInfo mi("atan2", PropertyInfo(Variant::REAL, "x"), PropertyInfo(Variant::REAL, "y"));
+			MethodInfo mi("atan2", PropertyInfo(Variant::REAL, "y"), PropertyInfo(Variant::REAL, "x"));
 			mi.return_val.type = Variant::REAL;
 			return mi;
 		} break;

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -260,7 +260,12 @@ PropertyInfo VisualScriptBuiltinFunc::get_input_value_port_info(int p_idx) const
 		case MATH_SQRT: {
 			return PropertyInfo(Variant::REAL, "s");
 		} break;
-		case MATH_ATAN2:
+		case MATH_ATAN2: {
+			if (p_idx == 0)
+				return PropertyInfo(Variant::REAL, "y");
+			else
+				return PropertyInfo(Variant::REAL, "x");
+		} break;
 		case MATH_FMOD:
 		case MATH_FPOSMOD: {
 			if (p_idx == 0)


### PR DESCRIPTION
The arguments of atan2() should be y,x instead of x,y This was just wrong since the internal atan2 already had y,x as parameters, so if you followed the autocomplete your result would just be wrong.