### PR TITLE
Fixed empty item slipping into Search Classes dialog

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -752,6 +752,8 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 }
 
 void EditorHelp::_update_doc() {
+	if (!doc->class_list.has(edited_class))
+		return;
 
 	scroll_locked = true;
 


### PR DESCRIPTION
Fixed empty item slipping into Search Classes dialog.

Phew tracking this down was weird.

Fixes #21640