### PR TITLE
[WIP|Discussion] Better socket polling (+ StreamPeer refactor)

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -376,6 +376,18 @@ Error HTTPClient::poll() {
 		} break;
 		case STATUS_CONNECTED: {
 			// Connection established, requests can now be made
+			if (ssl) {
+				StreamPeerSSL *tmp = static_cast<StreamPeerSSL *>(connection.ptr());
+				tmp->poll();
+				if (tmp->get_status() != StreamPeerSSL::STATUS_CONNECTED) {
+					status = STATUS_CONNECTION_ERROR;
+					return ERR_CONNECTION_ERROR;
+				}
+			} else if (static_cast<StreamPeerTCP *>(connection.ptr())->get_status() != StreamPeerTCP::STATUS_CONNECTED) {
+				status = STATUS_CONNECTION_ERROR;
+				return ERR_CONNECTION_ERROR;
+			}
+
 			return OK;
 		} break;
 		case STATUS_REQUESTING: {

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -371,7 +371,9 @@ void StreamPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_data", "bytes"), &StreamPeer::_get_data);
 	ClassDB::bind_method(D_METHOD("get_partial_data", "bytes"), &StreamPeer::_get_partial_data);
 
+	ClassDB::bind_method(D_METHOD("poll"), &StreamPeer::poll);
 	ClassDB::bind_method(D_METHOD("get_available_bytes"), &StreamPeer::get_available_bytes);
+	ClassDB::bind_method(D_METHOD("get_status"), &StreamPeer::get_status);
 
 	ClassDB::bind_method(D_METHOD("set_big_endian", "enable"), &StreamPeer::set_big_endian);
 	ClassDB::bind_method(D_METHOD("is_big_endian_enabled"), &StreamPeer::is_big_endian_enabled);
@@ -404,6 +406,11 @@ void StreamPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_var"), &StreamPeer::get_var);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "big_endian"), "set_big_endian", "is_big_endian_enabled");
+
+	BIND_ENUM_CONSTANT(STATUS_CLOSED);
+	BIND_ENUM_CONSTANT(STATUS_CONNECTING);
+	BIND_ENUM_CONSTANT(STATUS_CONNECTED);
+	BIND_ENUM_CONSTANT(STATUS_ERROR);
 }
 ////////////////////////////////
 
@@ -477,6 +484,11 @@ Error StreamPeerBuffer::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_
 int StreamPeerBuffer::get_available_bytes() const {
 
 	return data.size() - pointer;
+}
+
+StreamPeer::Status StreamPeerBuffer::get_status() {
+
+	return data.size() > 0 ? STATUS_CONNECTED : STATUS_CLOSED;
 }
 
 void StreamPeerBuffer::seek(int p_pos) {

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -50,13 +50,23 @@ protected:
 	bool big_endian;
 
 public:
+	enum Status {
+
+		STATUS_CLOSED,
+		STATUS_CONNECTING,
+		STATUS_CONNECTED,
+		STATUS_ERROR,
+	};
+
 	virtual Error put_data(const uint8_t *p_data, int p_bytes) = 0; ///< put a whole chunk of data, blocking until it sent
 	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) = 0; ///< put as much data as possible, without blocking.
 
 	virtual Error get_data(uint8_t *p_buffer, int p_bytes) = 0; ///< read p_bytes of data, if p_bytes > available, it will block
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) = 0; ///< read as much data as p_bytes into buffer, if less was read, return in r_received
 
+	virtual Status get_status() = 0; // Return the Status of this stream.
 	virtual int get_available_bytes() const = 0;
+	virtual Error poll() { return OK; } // Poll the stream looking for change in status and available bytes.
 
 	void set_big_endian(bool p_enable);
 	bool is_big_endian_enabled() const;
@@ -108,6 +118,7 @@ public:
 	Error get_data(uint8_t *p_buffer, int p_bytes);
 	Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 
+	virtual Status get_status();
 	virtual int get_available_bytes() const;
 
 	void seek(int p_pos);
@@ -124,5 +135,7 @@ public:
 
 	StreamPeerBuffer();
 };
+
+VARIANT_ENUM_CAST(StreamPeer::Status);
 
 #endif // STREAM_PEER_H

--- a/core/io/stream_peer_ssl.cpp
+++ b/core/io/stream_peer_ssl.cpp
@@ -117,20 +117,13 @@ PoolByteArray StreamPeerSSL::get_project_cert_array() {
 
 void StreamPeerSSL::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("poll"), &StreamPeerSSL::poll);
 	ClassDB::bind_method(D_METHOD("accept_stream", "base"), &StreamPeerSSL::accept_stream);
 	ClassDB::bind_method(D_METHOD("connect_to_stream", "stream", "validate_certs", "for_hostname"), &StreamPeerSSL::connect_to_stream, DEFVAL(false), DEFVAL(String()));
-	ClassDB::bind_method(D_METHOD("get_status"), &StreamPeerSSL::get_status);
 	ClassDB::bind_method(D_METHOD("disconnect_from_stream"), &StreamPeerSSL::disconnect_from_stream);
 	ClassDB::bind_method(D_METHOD("set_blocking_handshake_enabled", "enabled"), &StreamPeerSSL::set_blocking_handshake_enabled);
 	ClassDB::bind_method(D_METHOD("is_blocking_handshake_enabled"), &StreamPeerSSL::is_blocking_handshake_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "blocking_handshake"), "set_blocking_handshake_enabled", "is_blocking_handshake_enabled");
-
-	BIND_ENUM_CONSTANT(STATUS_DISCONNECTED);
-	BIND_ENUM_CONSTANT(STATUS_CONNECTED);
-	BIND_ENUM_CONSTANT(STATUS_ERROR);
-	BIND_ENUM_CONSTANT(STATUS_ERROR_HOSTNAME_MISMATCH);
 }
 
 StreamPeerSSL::StreamPeerSSL() {

--- a/core/io/stream_peer_ssl.h
+++ b/core/io/stream_peer_ssl.h
@@ -49,21 +49,11 @@ protected:
 	bool blocking_handshake;
 
 public:
-	enum Status {
-		STATUS_DISCONNECTED,
-		STATUS_HANDSHAKING,
-		STATUS_CONNECTED,
-		STATUS_ERROR,
-		STATUS_ERROR_HOSTNAME_MISMATCH
-	};
-
 	void set_blocking_handshake_enabled(bool p_enabled);
 	bool is_blocking_handshake_enabled() const;
 
-	virtual void poll() = 0;
 	virtual Error accept_stream(Ref<StreamPeer> p_base) = 0;
 	virtual Error connect_to_stream(Ref<StreamPeer> p_base, bool p_validate_certs = false, const String &p_for_hostname = String()) = 0;
-	virtual Status get_status() const = 0;
 
 	virtual void disconnect_from_stream() = 0;
 
@@ -77,7 +67,5 @@ public:
 
 	StreamPeerSSL();
 };
-
-VARIANT_ENUM_CAST(StreamPeerSSL::Status);
 
 #endif // STREAM_PEER_SSL_H

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -249,6 +249,21 @@ StreamPeerTCP::Status StreamPeerTCP::get_status() {
 
 	if (status == STATUS_CONNECTING) {
 		_poll_connection();
+	} else if (status == STATUS_CONNECTED) {
+		Error err;
+		err = _sock->poll(NetSocket::POLL_TYPE_IN, 0);
+		if (err == OK) {
+			// FIN received
+			if (_sock->get_available_bytes() == 0)
+				disconnect_from_host();
+		}
+		// Also poll write
+		err = _sock->poll(NetSocket::POLL_TYPE_IN_OUT, 0);
+		if (err != OK && err != ERR_BUSY) {
+			// Got an error
+			disconnect_from_host();
+			status = STATUS_ERROR;
+		}
 	}
 
 	return status;

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -41,15 +41,6 @@ class StreamPeerTCP : public StreamPeer {
 	GDCLASS(StreamPeerTCP, StreamPeer);
 	OBJ_CATEGORY("Networking");
 
-public:
-	enum Status {
-
-		STATUS_NONE,
-		STATUS_CONNECTING,
-		STATUS_CONNECTED,
-		STATUS_ERROR,
-	};
-
 protected:
 	Ref<NetSocket> _sock;
 	Status status;
@@ -57,7 +48,6 @@ protected:
 	uint16_t peer_port;
 
 	Error _connect(const String &p_address, int p_port);
-	Error _poll_connection();
 	Error write(const uint8_t *p_data, int p_bytes, int &r_sent, bool p_block);
 	Error read(uint8_t *p_buffer, int p_bytes, int &r_received, bool p_block);
 
@@ -72,21 +62,20 @@ public:
 	uint16_t get_connected_port() const;
 	void disconnect_from_host();
 
-	int get_available_bytes() const;
-	Status get_status();
-
 	void set_no_delay(bool p_enabled);
 
-	// Read/Write from StreamPeer
+	// StreamPeer
 	Error put_data(const uint8_t *p_data, int p_bytes);
 	Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent);
 	Error get_data(uint8_t *p_buffer, int p_bytes);
 	Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 
+	Error poll();
+	Status get_status();
+	int get_available_bytes() const;
+
 	StreamPeerTCP();
 	~StreamPeerTCP();
 };
-
-VARIANT_ENUM_CAST(StreamPeerTCP::Status);
 
 #endif

--- a/modules/gdnative/include/net/godot_net.h
+++ b/modules/gdnative/include/net/godot_net.h
@@ -55,7 +55,9 @@ typedef struct {
 	godot_error (*put_data)(void *user, const uint8_t *p_data, int p_bytes);
 	godot_error (*put_partial_data)(void *user, const uint8_t *p_data, int p_bytes, int &r_sent);
 
+	godot_error (*poll)(void *user);
 	int (*get_available_bytes)(const void *user);
+	godot_int (*get_status)(void *user);
 
 	void *next; /* For extension? */
 } godot_net_stream_peer;

--- a/modules/gdnative/net/stream_peer_gdnative.cpp
+++ b/modules/gdnative/net/stream_peer_gdnative.cpp
@@ -44,6 +44,14 @@ void StreamPeerGDNative::set_native_stream_peer(godot_net_stream_peer *p_interfa
 void StreamPeerGDNative::_bind_methods() {
 }
 
+StreamPeer::Status StreamPeerGDNative::get_status() {
+	return (Status)(interface->get_status(interface->data));
+}
+
+Error StreamPeerGDNative::poll() {
+	return (Error)(interface->poll(interface->data));
+}
+
 Error StreamPeerGDNative::put_data(const uint8_t *p_data, int p_bytes) {
 	ERR_FAIL_COND_V(interface == NULL, ERR_UNCONFIGURED);
 	return (Error)(interface->put_data(interface->data, p_data, p_bytes));

--- a/modules/gdnative/net/stream_peer_gdnative.h
+++ b/modules/gdnative/net/stream_peer_gdnative.h
@@ -55,7 +55,9 @@ public:
 	Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent);
 	Error get_data(uint8_t *p_buffer, int p_bytes);
 	Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
+	Error poll();
 	int get_available_bytes() const;
+	Status get_status();
 };
 
 #endif // STREAM_PEER_GDNATIVE_H

--- a/modules/mbedtls/stream_peer_mbed_tls.cpp
+++ b/modules/mbedtls/stream_peer_mbed_tls.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "stream_peer_mbed_tls.h"
+#include "core/io/stream_peer_tcp.h"
 #include "core/os/file_access.h"
 #include "mbedtls/platform_util.h"
 
@@ -259,6 +260,12 @@ void StreamPeerMbedTLS::poll() {
 	if (ret < 0 && ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
 		_print_error(ret);
 		disconnect_from_stream();
+		return;
+	}
+
+	if (static_cast<StreamPeerTCP *>(base.ptr())->get_status() != STATUS_CONNECTED) {
+		disconnect_from_stream();
+		return;
 	}
 }
 

--- a/modules/mbedtls/stream_peer_mbed_tls.h
+++ b/modules/mbedtls/stream_peer_mbed_tls.h
@@ -70,10 +70,8 @@ protected:
 	Error _do_handshake();
 
 public:
-	virtual void poll();
 	virtual Error accept_stream(Ref<StreamPeer> p_base);
 	virtual Error connect_to_stream(Ref<StreamPeer> p_base, bool p_validate_certs = false, const String &p_for_hostname = String());
-	virtual Status get_status() const;
 
 	virtual void disconnect_from_stream();
 
@@ -84,6 +82,8 @@ public:
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 
 	virtual int get_available_bytes() const;
+	virtual Status get_status();
+	virtual Error poll();
 
 	static void initialize_ssl();
 	static void finalize_ssl();


### PR DESCRIPTION
This is a fix for #4157 - Detect server clean close in TCP/SSL (the SSL part need some extra work to implement proper client close notify which is now detected as an error instead of a clean close, but still detected).
The first commit is the uglier version (no refactoring), just get the thing done.

Discussion
---
The second commit tries to do that better, but also changes the API a bit, and admittedly over-generalize.
The idea is that most StreamPeers do have a status and need to be polled to update it.
Polling can be, sometimes, an expensive operation. For this reason, instead of "polling when you ask the status" it would make sense to move to a more expressive approach where you can decide when to poll, and `get_status` will not poll the connection (like it use to do in TCP).
Also, in the effort of diminishing duplicate status enums, and make them more consistent, I tried to have a simpler generalized StreamStatus (CLOSED-CONNECTING/OPENING-CONNECTED/OPENED/ERROR). Additional, stream-specific status could be added to the specific stream (e.g `StreamPeerSSL.get_ssl_error()` to get the SSL-specific error when `get_status` return `ERROR`).

Being honest, I'm not yet fully convinced this is the right approach, so feedback is very welcome.

Compatibility Notes
--
This is in no state to be merged yet. If we decide this is the approach we want to go to, here are some notes on how to make script transition smoother.
- We could rename `get_status` to `get_stream_status`, deprecating the first, but maintaining its behaviour of polling before returning the status (in TCP).
- We should provide logically compatible enums for the old statuses in TCP and SSL
  - SSL_HOSTNAME_MISMATCH error will probably have to be equated to generic ERROR, so we should provide release notes accordingly.