### PR TITLE
Allow editing the resource of an EditorResourceProperty by doubleclicking it

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1896,6 +1896,26 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 
 ////////////// RESOURCE //////////////////////
 
+class EditorPropertyResourceAssignButton : public Button {
+	GDCLASS(EditorPropertyResourceAssignButton, Button)
+public:
+	bool doubleclicked;
+
+	virtual void _gui_input(Ref<InputEvent> p_event) {
+		Ref<InputEventMouseButton> b = p_event;
+
+		if (b.is_valid() && b->is_pressed() && b->get_button_index() == BUTTON_LEFT) {
+			doubleclicked = b->is_doubleclick();
+		}
+
+		Button::_gui_input(p_event);
+	}
+
+	EditorPropertyResourceAssignButton() {
+		doubleclicked = false;
+	}
+};
+
 void EditorPropertyResource::_file_selected(const String &p_path) {
 
 	RES res = ResourceLoader::load(p_path);
@@ -2379,6 +2399,12 @@ void EditorPropertyResource::_resource_selected() {
 
 	if (use_sub_inspector) {
 
+		if (assign->doubleclicked) {
+			get_edited_object()->editor_set_section_unfold(get_edited_property(), false);
+			emit_signal("resource_selected", get_edited_property(), res);
+			return;
+		}
+
 		get_edited_object()->editor_set_section_unfold(get_edited_property(), assign->is_pressed());
 		update_property();
 	} else {
@@ -2567,7 +2593,7 @@ EditorPropertyResource::EditorPropertyResource() {
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	add_child(hbc);
-	assign = memnew(Button);
+	assign = memnew(EditorPropertyResourceAssignButton);
 	assign->set_flat(true);
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -513,6 +513,8 @@ public:
 	EditorPropertyNodePath();
 };
 
+class EditorPropertyResourceAssignButton;
+
 class EditorPropertyResource : public EditorProperty {
 	GDCLASS(EditorPropertyResource, EditorProperty)
 
@@ -531,7 +533,7 @@ class EditorPropertyResource : public EditorProperty {
 
 	};
 
-	Button *assign;
+	EditorPropertyResourceAssignButton *assign;
 	TextureRect *preview;
 	Button *edit;
 	PopupMenu *menu;


### PR DESCRIPTION

This allows to edit the resource of an EditorPropertyResource by double clicking it in the inspector.

In my specific case, I (could have) found this useful some months ago, while setting up some modular level pieces, in some workflows that involved SavingAs a base scene multiple times (no scene inheritance), and each time having to modify and SaveAs some subresource (to disk, no builtin)
The kinda slow part was accessing the subresource's SaveAs option
To be honest this was some time ago, I don't recall clearly, because since then the development has been all about code

Now, I know the Edit popup option exists but doing (click)->(aim edit button)->(click) instead of (click)(click) is quite different when repeated multiple times

Went with doubleclick instead of middleclick or control+click since this feels more uniform with other parts of the UI (Signal connection dock, filesystem, etc)
