### PR TITLE
Fixed ctrl+up/down shortcut no longer working in scene tree

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2239,13 +2239,13 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 			_go_left();
 		}
 
-	} else if (p_event->is_action("ui_up") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_up") && p_event->is_pressed() && !k->get_command()) {
 
 		if (!cursor_can_exit_tree) accept_event();
 
 		_go_up();
 
-	} else if (p_event->is_action("ui_down") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_down") && p_event->is_pressed() && !k->get_command()) {
 
 		if (!cursor_can_exit_tree) accept_event();
 


### PR DESCRIPTION
Fixed ctrl+up/down shortcut no longer working in scene tree.

I'm not super happy with the way this was solved, if someone has a better idea please comment.

This fixes #7736

BTW the problem is related to #18793