### PR TITLE
Fix put_var encoding some 32bits ints as 64bits.

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -807,7 +807,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 
 		case Variant::INT: {
 			int64_t val = p_variant;
-			if (val > 0x7FFFFFFF || val < -0x80000000) {
+			if (val > (int64_t)INT_MAX || val < (int64_t)INT_MIN) {
 				flags |= ENCODE_FLAG_64;
 			}
 		} break;
@@ -850,7 +850,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 		case Variant::INT: {
 
 			int64_t val = p_variant;
-			if (val > 0x7FFFFFFF || val < -0x80000000) {
+			if (flags & ENCODE_FLAG_64) {
 				//64 bits
 				if (buf) {
 					encode_uint64(val, buf);
@@ -869,7 +869,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 
 			double d = p_variant;
 			float f = d;
-			if (double(f) != d) {
+			if (flags & ENCODE_FLAG_64) {
 				if (buf) {
 					encode_double(p_variant.operator double(), buf);
 				}


### PR DESCRIPTION
Fix wrong comparison (+ explicit cast).
Use flags later on in the same function (should save us some cycles :wink:  )

Closes #15383