### PR TITLE
Fixed an access after free in ShaderLanguage::_reduce_expression.

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3437,8 +3437,9 @@ ShaderLanguage::Node *ShaderLanguage::_reduce_expression(BlockNode *p_block, Sha
 					}
 				}
 			} else {
+				ConstantNode::Value value = values[0];
 				for (int i = 1; i < cardinality; i++) {
-					values.push_back(values[0]);
+					values.push_back(value);
 				}
 			}
 		} else if (values.size() != cardinality) {


### PR DESCRIPTION
Passing an element reference of a vector to a push_back call to
that same vector can cause an access after free. This is because push_back
will resize the vector, reallocating if necessary, leaving the reference
referring to the freed memory.
Removed an instance of this usage here.