### PR TITLE
Improve SimplexNoise documentation and fix typos

### DIFF
--- a/modules/opensimplex/doc_classes/SimplexNoise.xml
+++ b/modules/opensimplex/doc_classes/SimplexNoise.xml
@@ -15,12 +15,12 @@
 		noise.octaves = 4
 		noise.period = 20.0
 		noise.persistance = 0.8
-		
-		#Sample
+
+		# Sample
 		print("Values:")
-		print(noise.get_noise_2d(1.0,1.0))
-		print(noise.get_noise_3d(0.5,3.0,15.0))
-		print(noise.get_noise_3d(0.5,1.9,4.7,0.0))
+		print(noise.get_noise_2d(1.0, 1.0))
+		print(noise.get_noise_3d(0.5, 3.0, 15.0))
+		print(noise.get_noise_3d(0.5, 1.9, 4.7, 0.0))
 		[/codeblock]
 	</description>
 	<tutorials>
@@ -47,7 +47,7 @@
 			<argument index="1" name="y" type="float">
 			</argument>
 			<description>
-				2D noise value [-1,1] at position [code]x[/code],[code]y[/code].
+				Returns the 2D noise value [-1,1] at the given position.
 			</description>
 		</method>
 		<method name="get_noise_2dv">
@@ -56,7 +56,7 @@
 			<argument index="0" name="pos" type="Vector2">
 			</argument>
 			<description>
-				2D noise value [-1,1] at position [code]pos.x[/code],[code]pos.y[/code].
+				Returns the 2D noise value [-1,1] at the given position.
 			</description>
 		</method>
 		<method name="get_noise_3d">
@@ -69,7 +69,7 @@
 			<argument index="2" name="z" type="float">
 			</argument>
 			<description>
-				3D noise value [-1,1] at position [code]x[/code],[code]y[/code],[code]z[/code].
+				Returns the 3D noise value [-1,1] at the given position.
 			</description>
 		</method>
 		<method name="get_noise_3dv">
@@ -78,7 +78,7 @@
 			<argument index="0" name="pos" type="Vector3">
 			</argument>
 			<description>
-				3D noise value [-1,1] at position [code]pos.x[/code],[code]pos.y[/code],[code]pos.z[/code].
+				Returns the 3D noise value [-1,1] at the given position.
 			</description>
 		</method>
 		<method name="get_noise_4d">
@@ -93,7 +93,7 @@
 			<argument index="3" name="w" type="float">
 			</argument>
 			<description>
-				4D noise value [-1,1] at position [code]x[/code],[code]y[/code],[code]z[/code],[code]w[/code].
+				Returns the 4D noise value [-1,1] at the given position.
 			</description>
 		</method>
 		<method name="get_seamless_image">
@@ -102,8 +102,8 @@
 			<argument index="0" name="size" type="int">
 			</argument>
 			<description>
-				Generate a tileable noise image, based on the current noise parameters. 
-				Generated seamless images are always square ([code]size[/code]x[code]size[/code]).
+				Generate a tileable noise image, based on the current noise parameters.
+				Generated seamless images are always square ([code]size[/code] x [code]size[/code]).
 			</description>
 		</method>
 	</methods>
@@ -112,14 +112,14 @@
 			Difference in period between [member octaves].
 		</member>
 		<member name="octaves" type="int" setter="set_octaves" getter="get_octaves">
-			Number of Simplex Noise layers that are sampled to get the fractal noise.
+			Number of Simplex noise layers that are sampled to get the fractal noise.
 		</member>
 		<member name="period" type="float" setter="set_period" getter="get_period">
-			Period of the base octave. 
-			A lower period results in a higher frequancy noise (more value changes across the same distance).
+			Period of the base octave.
+			A lower period results in a higher-frequency noise (more value changes across the same distance).
 		</member>
 		<member name="persistance" type="float" setter="set_persistance" getter="get_persistance">
-			Contribuiton factor of the different octaves. 
+			Contribution factor of the different octaves.
 			A [code]persistance[/code] value of 1 means all the octaves have the same contribution, a value of 0.5 means each octave contributes half as much as the previous one.
 		</member>
 		<member name="seed" type="int" setter="set_seed" getter="get_seed">


### PR DESCRIPTION
Spaces were added after code blocks to ensure correct rendering on the online class reference.