### PR TITLE
Properly setup EditorProperties in arrays and dictionaries

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -336,16 +336,16 @@ void EditorPropertyArray::update_property() {
 
 				} break;
 				case Variant::INT: {
-					EditorPropertyInteger *ed = memnew(EditorPropertyInteger);
-					ed->setup(-100000, 100000, true, true);
-					prop = ed;
+					EditorPropertyInteger *editor = memnew(EditorPropertyInteger);
+					editor->setup(-100000, 100000, true, true);
+					prop = editor;
 
 				} break;
 				case Variant::REAL: {
 
-					EditorPropertyFloat *ed = memnew(EditorPropertyFloat);
-					ed->setup(-100000, 100000, 0.001, true, false, true, true);
-					prop = ed;
+					EditorPropertyFloat *editor = memnew(EditorPropertyFloat);
+					editor->setup(-100000, 100000, 0.001, true, false, true, true);
+					prop = editor;
 				} break;
 				case Variant::STRING: {
 
@@ -357,63 +357,63 @@ void EditorPropertyArray::update_property() {
 
 				case Variant::VECTOR2: {
 
-					EditorPropertyVector2 *ed = memnew(EditorPropertyVector2);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyVector2 *editor = memnew(EditorPropertyVector2);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::RECT2: {
 
-					EditorPropertyRect2 *ed = memnew(EditorPropertyRect2);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyRect2 *editor = memnew(EditorPropertyRect2);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::VECTOR3: {
 
-					EditorPropertyVector3 *ed = memnew(EditorPropertyVector3);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyVector3 *editor = memnew(EditorPropertyVector3);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::TRANSFORM2D: {
 
-					EditorPropertyTransform2D *ed = memnew(EditorPropertyTransform2D);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::PLANE: {
 
-					EditorPropertyPlane *ed = memnew(EditorPropertyPlane);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyPlane *editor = memnew(EditorPropertyPlane);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::QUAT: {
 
-					EditorPropertyQuat *ed = memnew(EditorPropertyQuat);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyQuat *editor = memnew(EditorPropertyQuat);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::AABB: {
 
-					EditorPropertyAABB *ed = memnew(EditorPropertyAABB);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyAABB *editor = memnew(EditorPropertyAABB);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::BASIS: {
-					EditorPropertyBasis *ed = memnew(EditorPropertyBasis);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyBasis *editor = memnew(EditorPropertyBasis);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::TRANSFORM: {
-					EditorPropertyTransform *ed = memnew(EditorPropertyTransform);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyTransform *editor = memnew(EditorPropertyTransform);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 
@@ -431,8 +431,9 @@ void EditorPropertyArray::update_property() {
 
 				} break;
 				case Variant::OBJECT: {
-
-					prop = memnew(EditorPropertyResource);
+					EditorPropertyResource *editor = memnew(EditorPropertyResource);
+					editor->setup("Resource");
+					prop = editor;
 
 				} break;
 				case Variant::DICTIONARY: {
@@ -798,16 +799,16 @@ void EditorPropertyDictionary::update_property() {
 
 				} break;
 				case Variant::INT: {
-					EditorPropertyInteger *ed = memnew(EditorPropertyInteger);
-					ed->setup(-100000, 100000, true, true);
-					prop = ed;
+					EditorPropertyInteger *editor = memnew(EditorPropertyInteger);
+					editor->setup(-100000, 100000, true, true);
+					prop = editor;
 
 				} break;
 				case Variant::REAL: {
 
-					EditorPropertyFloat *ed = memnew(EditorPropertyFloat);
-					ed->setup(-100000, 100000, 0.001, true, false, true, true);
-					prop = ed;
+					EditorPropertyFloat *editor = memnew(EditorPropertyFloat);
+					editor->setup(-100000, 100000, 0.001, true, false, true, true);
+					prop = editor;
 				} break;
 				case Variant::STRING: {
 
@@ -815,67 +816,66 @@ void EditorPropertyDictionary::update_property() {
 
 				} break;
 
-					// math types
-
+				// math types
 				case Variant::VECTOR2: {
 
-					EditorPropertyVector2 *ed = memnew(EditorPropertyVector2);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyVector2 *editor = memnew(EditorPropertyVector2);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::RECT2: {
 
-					EditorPropertyRect2 *ed = memnew(EditorPropertyRect2);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyRect2 *editor = memnew(EditorPropertyRect2);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::VECTOR3: {
 
-					EditorPropertyVector3 *ed = memnew(EditorPropertyVector3);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyVector3 *editor = memnew(EditorPropertyVector3);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::TRANSFORM2D: {
 
-					EditorPropertyTransform2D *ed = memnew(EditorPropertyTransform2D);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::PLANE: {
 
-					EditorPropertyPlane *ed = memnew(EditorPropertyPlane);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyPlane *editor = memnew(EditorPropertyPlane);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::QUAT: {
 
-					EditorPropertyQuat *ed = memnew(EditorPropertyQuat);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyQuat *editor = memnew(EditorPropertyQuat);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::AABB: {
 
-					EditorPropertyAABB *ed = memnew(EditorPropertyAABB);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyAABB *editor = memnew(EditorPropertyAABB);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::BASIS: {
-					EditorPropertyBasis *ed = memnew(EditorPropertyBasis);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyBasis *editor = memnew(EditorPropertyBasis);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 				case Variant::TRANSFORM: {
-					EditorPropertyTransform *ed = memnew(EditorPropertyTransform);
-					ed->setup(-100000, 100000, 0.001, true);
-					prop = ed;
+					EditorPropertyTransform *editor = memnew(EditorPropertyTransform);
+					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
 
 				} break;
 
@@ -893,8 +893,9 @@ void EditorPropertyDictionary::update_property() {
 
 				} break;
 				case Variant::OBJECT: {
-
-					prop = memnew(EditorPropertyResource);
+					EditorPropertyResource *editor = memnew(EditorPropertyResource);
+					editor->setup("Resource");
+					prop = editor;
 
 				} break;
 				case Variant::DICTIONARY: {
@@ -902,39 +903,53 @@ void EditorPropertyDictionary::update_property() {
 
 				} break;
 				case Variant::ARRAY: {
-
-					prop = memnew(EditorPropertyArray);
-
+					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					editor->setup(Variant::ARRAY);
+					prop = editor;
 				} break;
 
 				// arrays
 				case Variant::POOL_BYTE_ARRAY: {
-					prop = memnew(EditorPropertyArray);
 
+					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					editor->setup(Variant::POOL_BYTE_ARRAY);
+					prop = editor;
 				} break;
 				case Variant::POOL_INT_ARRAY: {
-					prop = memnew(EditorPropertyArray);
 
+					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					editor->setup(Variant::POOL_INT_ARRAY);
+					prop = editor;
 				} break;
 				case Variant::POOL_REAL_ARRAY: {
 
-					prop = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					editor->setup(Variant::POOL_REAL_ARRAY);
+					prop = editor;
 				} break;
 				case Variant::POOL_STRING_ARRAY: {
 
-					prop = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					editor->setup(Variant::POOL_STRING_ARRAY);
+					prop = editor;
 				} break;
 				case Variant::POOL_VECTOR2_ARRAY: {
 
-					prop = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					editor->setup(Variant::POOL_VECTOR2_ARRAY);
+					prop = editor;
 				} break;
 				case Variant::POOL_VECTOR3_ARRAY: {
-					prop = memnew(EditorPropertyArray);
 
+					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					editor->setup(Variant::POOL_VECTOR3_ARRAY);
+					prop = editor;
 				} break;
 				case Variant::POOL_COLOR_ARRAY: {
-					prop = memnew(EditorPropertyArray);
 
+					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					editor->setup(Variant::POOL_COLOR_ARRAY);
+					prop = editor;
 				} break;
 				default: {}
 			}


### PR DESCRIPTION
Now arrays will correctly identify their type (e. g. `IntArray(size 0)` instead of just `(size 0)`) when editing arrays/dictionary elements in the inspector.

Also, made possible to pick any resource in those as well, instead of just being able to load one from the filesystem.