### PR TITLE
Fix EditorSettings saving on draw calls

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1378,7 +1378,6 @@ void EditorFileSystem::update_script_classes() {
 
 	ScriptServer::save_global_classes();
 	EditorNode::get_editor_data().script_class_save_icon_paths();
-	emit_signal("script_classes_updated");
 }
 
 void EditorFileSystem::_queue_update_script_classes() {
@@ -1721,7 +1720,6 @@ void EditorFileSystem::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("filesystem_changed"));
 	ADD_SIGNAL(MethodInfo("sources_changed", PropertyInfo(Variant::BOOL, "exist")));
 	ADD_SIGNAL(MethodInfo("resources_reimported", PropertyInfo(Variant::POOL_STRING_ARRAY, "resources")));
-	ADD_SIGNAL(MethodInfo("script_classes_updated"));
 }
 
 void EditorFileSystem::_update_extensions() {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2401,7 +2401,6 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	add_child(create_dialog);
 	create_dialog->connect("create", this, "_create");
 	create_dialog->connect("favorites_updated", this, "_update_create_root_dialog");
-	EditorFileSystem::get_singleton()->connect("script_classes_updated", create_dialog, "_save_and_update_favorite_list");
 
 	rename_dialog = memnew(RenameDialog(scene_tree, &editor_data->get_undo_redo()));
 	add_child(rename_dialog);


### PR DESCRIPTION
Closes #22097.

This, combined with #22234 should ensure that everything in the CreateDialog is working fine regardless of whether it is receiving the signal.

I am a little confused though as to why `EditorFileSystem::update_script_classes` is being called every draw call though. Someone who's more familiar with how the file caching system works will need to determine whether that's really necessary (since presumably it should only need to be called any time a script file has actually been modified).