### PR TITLE
Change viewport type after using create root menu

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -830,6 +830,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)NULL);
 			editor_data->get_undo_redo().commit_action();
 
+			editor->edit_node(new_node);
+
 		} break;
 
 		default: {


### PR DESCRIPTION
Change viewport type (2D/3D) according to the type of node just created from the "Create Root Node" menu.

Right now it can be confusing for new users, since you create a 2D scene and the viewport doesn't change until you select the new root node.