### PR TITLE
fix branch on uninit in spatial_editor_plugin

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4418,6 +4418,8 @@ void SpatialEditor::_menu_item_pressed(int p_option) {
 void SpatialEditor::_init_indicators() {
 
 	{
+		origin_enabled = true;
+		grid_enabled = true;
 
 		indicator_mat.instance();
 		indicator_mat->set_flag(SpatialMaterial::FLAG_UNSHADED, true);
@@ -4458,10 +4460,6 @@ void SpatialEditor::_init_indicators() {
 		VS::get_singleton()->instance_set_layer_mask(origin_instance, 1 << SpatialEditorViewport::GIZMO_GRID_LAYER);
 
 		VisualServer::get_singleton()->instance_geometry_set_cast_shadows_setting(origin_instance, VS::SHADOW_CASTING_SETTING_OFF);
-
-		origin_enabled = true;
-		grid_enabled = true;
-		last_grid_snap = 1;
 	}
 
 	{

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -510,7 +510,6 @@ private:
 	RID grid[3];
 	RID grid_instance[3];
 	bool grid_visible[3]; //currently visible
-	float last_grid_snap;
 	bool grid_enable[3]; //should be always visible if true
 	bool grid_enabled;
 


### PR DESCRIPTION
Moved the initialisation of origin_enabled up a bit, to be inited before
it's accessed in _init_grid. A step towards cleaner valgrind output and
removes an opportunity for a random occurance of the origin/grid
z-fighting issue.

Also removed unused variable last_grid_snap to avoid later confusion.