### PR TITLE
Fix "This control can't grab focus." warning spam

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5586,7 +5586,6 @@ void SpatialEditorPlugin::make_visible(bool p_visible) {
 
 		spatial_editor->show();
 		spatial_editor->set_process(true);
-		spatial_editor->grab_focus();
 
 	} else {
 


### PR DESCRIPTION
No need to grab focus on spatial editor - it does not have any visible effect but cause the warning to arrive

Currently it has spawned in every new project