### PR TITLE
Fix the weird method linking issue when the previous method's description ends with a code block

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -673,7 +673,7 @@ def make_rst_class(node):
     if methods != None and len(list(methods)) > 0:
         f.write(make_heading('Method Descriptions', '-'))
         for m in list(methods):
-            f.write("  .. _class_" + name + "_" + m.attrib['name'] + ":\n\n")
+            f.write(".. _class_" + name + "_" + m.attrib['name'] + ":\n\n")
             make_method(f, name, m, True)
             f.write('\n')
             d = m.find('description')


### PR DESCRIPTION
This fixes an issue with the docs where the method reference labels would be treated as part of a code block, if the previous method's description ends with a code block:
![screen_shot_2018-09-19_at_9 18 41_am 1](https://user-images.githubusercontent.com/1008889/45849725-38c74300-bd01-11e8-86f7-83ef985a5caf.png)

This issue was introduced with https://github.com/godotengine/godot/commit/4e0f415c83c89c0eeabfe420535e182fcab11250#diff-b83879f4092e118d9567dd909e19b638L530.

I recognize this is a bit of a hack, but I couldn't find any other way of resolving the issue short of adding a blank comment to the line just above the reference label. I don't know which would be preferred.