### PR TITLE
Enable toggle behaviour for buttons that trigger popups

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -786,6 +786,7 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	grid->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(grid);
 	button = memnew(Button);
+	button->set_toggle_mode(true);
 	button->set_text("..");
 	button->connect("pressed", this, "_button_pressed");
 	hb->add_child(button);
@@ -794,7 +795,9 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	add_child(layers);
 	layers->set_hide_on_checkable_item_selection(false);
 	layers->connect("id_pressed", this, "_menu_pressed");
+	layers->connect("popup_hide", button, "set_pressed", varray(false));
 }
+
 ///////////////////// INT /////////////////////////
 
 void EditorPropertyInteger::_value_changed(double val) {
@@ -2492,6 +2495,7 @@ void EditorPropertyResource::_resource_selected() {
 	RES res = get_edited_object()->get(get_edited_property());
 
 	if (res.is_null()) {
+		edit->set_pressed(true);
 		_update_menu();
 		return;
 	}
@@ -2709,7 +2713,9 @@ EditorPropertyResource::EditorPropertyResource() {
 	add_child(menu);
 	edit = memnew(Button);
 	edit->set_flat(true);
+	edit->set_toggle_mode(true);
 	menu->connect("id_pressed", this, "_menu_option");
+	menu->connect("popup_hide", edit, "set_pressed", varray(false));
 	edit->connect("pressed", this, "_update_menu");
 	hbc->add_child(edit);
 	edit->connect("gui_input", this, "_button_input");

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -802,6 +802,7 @@ ThemeEditor::ThemeEditor() {
 	type_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	type_hbc->add_child(type_edit);
 	type_menu = memnew(MenuButton);
+	type_menu->set_flat(false);
 	type_menu->set_text("..");
 	type_hbc->add_child(type_menu);
 
@@ -819,6 +820,7 @@ ThemeEditor::ThemeEditor() {
 	name_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	name_hbc->add_child(name_edit);
 	name_menu = memnew(MenuButton);
+	type_menu->set_flat(false);
 	name_menu->set_text("..");
 	name_hbc->add_child(name_menu);
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -813,6 +813,8 @@ void ColorPickerButton::_update_picker() {
 		add_child(popup);
 		picker->connect("color_changed", this, "_color_changed");
 		popup->connect("modal_closed", this, "_modal_closed");
+		popup->connect("about_to_show", this, "set_pressed", varray(true));
+		popup->connect("popup_hide", this, "set_pressed", varray(false));
 		picker->set_pick_color(color);
 		picker->set_edit_alpha(edit_alpha);
 	}
@@ -843,4 +845,6 @@ ColorPickerButton::ColorPickerButton() {
 	picker = NULL;
 	popup = NULL;
 	edit_alpha = true;
+
+	set_toggle_mode(true);
 }

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -116,15 +116,19 @@ MenuButton::MenuButton() {
 
 	switch_on_hover = false;
 	set_flat(true);
+	set_toggle_mode(true);
 	set_disable_shortcuts(false);
 	set_enabled_focus_mode(FOCUS_NONE);
+	set_process_unhandled_key_input(true);
+	set_action_mode(ACTION_MODE_BUTTON_PRESS);
+
 	popup = memnew(PopupMenu);
 	popup->hide();
 	add_child(popup);
 	popup->set_as_toplevel(true);
 	popup->set_pass_on_modal_close_click(false);
-	set_process_unhandled_key_input(true);
-	set_action_mode(ACTION_MODE_BUTTON_PRESS);
+	popup->connect("about_to_show", this, "set_pressed", varray(true)); // For when switching from another MenuButton.
+	popup->connect("popup_hide", this, "set_pressed", varray(false));
 }
 
 MenuButton::~MenuButton() {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -333,6 +333,7 @@ void OptionButton::_bind_methods() {
 OptionButton::OptionButton() {
 
 	current = -1;
+	set_toggle_mode(true);
 	set_text_align(ALIGN_LEFT);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 
@@ -343,6 +344,7 @@ OptionButton::OptionButton() {
 	popup->set_pass_on_modal_close_click(false);
 	popup->connect("id_pressed", this, "_selected");
 	popup->connect("id_focused", this, "_focused");
+	popup->connect("popup_hide", this, "set_pressed", varray(false));
 }
 
 OptionButton::~OptionButton() {


### PR DESCRIPTION
So they actually highlight when their popups are open:
![peek 2018-09-21 02-42](https://user-images.githubusercontent.com/30739239/45862668-2ec93280-bd49-11e8-81e6-792403b04c9b.gif)