### PR TITLE
Remove auto disabling of the split-view in the FileSystem dock

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -517,7 +517,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	_initial_set("docks/filesystem/display_mode", 0);
 	hints["docks/filesystem/display_mode"] = PropertyInfo(Variant::INT, "docks/filesystem/display_mode", PROPERTY_HINT_ENUM, "Tree only, Split");
-	_initial_set("docks/filesystem/split_mode_minimum_height", 600);
 	_initial_set("docks/filesystem/thumbnail_size", 64);
 	hints["docks/filesystem/thumbnail_size"] = PropertyInfo(Variant::INT, "docks/filesystem/thumbnail_size", PROPERTY_HINT_RANGE, "32,128,16");
 	_initial_set("docks/filesystem/files_display_mode", 0);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -223,11 +223,9 @@ void FileSystemDock::_update_tree(const Vector<String> p_uncollapsed_paths, bool
 }
 
 void FileSystemDock::_update_display_mode() {
-	bool compact_mode = get_size().height < int(EditorSettings::get_singleton()->get("docks/filesystem/split_mode_minimum_height"));
-
 	// Compute the new display mode
 	DisplayMode new_display_mode;
-	if ((display_mode_setting == DISPLAY_MODE_SETTING_TREE_ONLY) || compact_mode) {
+	if (display_mode_setting == DISPLAY_MODE_SETTING_TREE_ONLY) {
 		new_display_mode = file_list_view ? DISPLAY_MODE_FILE_LIST_ONLY : DISPLAY_MODE_TREE_ONLY;
 	} else {
 		new_display_mode = DISPLAY_MODE_SPLIT;


### PR DESCRIPTION
Closes #21499
Closes #22307