### PR TITLE
Fix blend tree editor updating invalid blend tree node graph

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -846,8 +846,6 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 
 	if (p_node.is_valid()) {
 		blend_tree = p_node;
-	} else {
-		blend_tree.unref();
 	}
 
 	if (blend_tree.is_null()) {


### PR DESCRIPTION
Editing unreferenced blend tree caused SIGSEGV when updating node graph.

Not sure if hacky but I tried to pin down the issue with my shiny debugger :)

Fixes #22037