### PR TITLE
Add checks for clean disconnect in HTTP/TCP/SSL.

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -375,6 +375,18 @@ Error HTTPClient::poll() {
 			}
 		} break;
 		case STATUS_CONNECTED: {
+			// Check if we are still connected
+			if (ssl) {
+				Ref<StreamPeerSSL> tmp = connection;
+				tmp->poll();
+				if (tmp->get_status() != StreamPeerSSL::STATUS_CONNECTED) {
+					status = STATUS_CONNECTION_ERROR;
+					return ERR_CONNECTION_ERROR;
+				}
+			} else if (tcp_connection->get_status() != StreamPeerTCP::STATUS_CONNECTED) {
+				status = STATUS_CONNECTION_ERROR;
+				return ERR_CONNECTION_ERROR;
+			}
 			// Connection established, requests can now be made
 			return OK;
 		} break;

--- a/core/io/stream_peer_ssl.cpp
+++ b/core/io/stream_peer_ssl.cpp
@@ -128,6 +128,7 @@ void StreamPeerSSL::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "blocking_handshake"), "set_blocking_handshake_enabled", "is_blocking_handshake_enabled");
 
 	BIND_ENUM_CONSTANT(STATUS_DISCONNECTED);
+	BIND_ENUM_CONSTANT(STATUS_HANDSHAKING);
 	BIND_ENUM_CONSTANT(STATUS_CONNECTED);
 	BIND_ENUM_CONSTANT(STATUS_ERROR);
 	BIND_ENUM_CONSTANT(STATUS_ERROR_HOSTNAME_MISMATCH);


### PR DESCRIPTION
Half-open TCP connection can, of course, only be detected by writing the socket, or waiting for TCP timeout.

This is a (slightly better) version of the first commit in #22191 , without the refactoring part. In accordance with reduz the refactoring will be done after `3.1` so we can break some compat (we will still try to provide compatible but deprecated methods whenever possible to make transition easier).

Fixes #4157
Closes #15369 (as I tried to explain more then once, there is NO WAY of detecting an half-closed/severed TCP connection without writing on it, or waiting for timeout to happen).