### PR TITLE
Made changing transform impossible for children of Containers.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -469,6 +469,8 @@ private:
 	void _update_bone_list();
 	void _tree_changed(Node *);
 
+	bool _can_drag_nodes(List<CanvasItem *> nodes);
+
 	friend class CanvasItemEditorPlugin;
 
 protected:


### PR DESCRIPTION
Made changing transform impossible for children of Containers and added a warning stating:
`Cannot change transform of children of Containers.`

Fixes #20750 and all issues referenced in it.