### PR TITLE
Editor: Skip loading main scene if restore_scenes_on_load is used

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3592,6 +3592,7 @@ void EditorNode::_load_docks() {
 
 	_load_docks_from_config(config, "docks");
 	_load_open_scenes_from_config(config, "EditorNode");
+
 	editor_data.set_plugin_window_layout(config);
 }
 
@@ -3784,6 +3785,23 @@ void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout, const S
 	}
 
 	restoring_scenes = false;
+}
+
+bool EditorNode::has_scenes_in_session() {
+	if (!bool(EDITOR_GET("interface/scene_tabs/restore_scenes_on_load"))) {
+		return false;
+	}
+	Ref<ConfigFile> config;
+	config.instance();
+	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	if (err != OK) {
+		return false;
+	}
+	if (!config->has_section("EditorNode") || !config->has_section_key("EditorNode", "open_scenes")) {
+		return false;
+	}
+	Array scenes = config->get_value("EditorNode", "open_scenes");
+	return !scenes.empty();
 }
 
 void EditorNode::_update_layouts_menu() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -777,6 +777,7 @@ public:
 	void edit_current() { _edit_current(); };
 
 	void update_keying() const { inspector_dock->update_keying(); };
+	bool has_scenes_in_session();
 
 	EditorNode();
 	~EditorNode();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1681,9 +1681,11 @@ bool Main::start() {
 #ifdef TOOLS_ENABLED
 			if (editor) {
 
-				Error serr = editor_node->load_scene(local_game_path);
-				if (serr != OK)
-					ERR_PRINT("Failed to load scene");
+				if (game_path != GLOBAL_GET("application/run/main_scene") || !editor_node->has_scenes_in_session()) {
+					Error serr = editor_node->load_scene(local_game_path);
+					if (serr != OK)
+						ERR_PRINT("Failed to load scene");
+				}
 				OS::get_singleton()->set_context(OS::CONTEXT_EDITOR);
 			}
 #endif


### PR DESCRIPTION
*Hi, this is my first non-cherry-pick PR for Godot and I'm still slowly learning C++.*

I use the option `interface/scene_tabs/restore_scenes_on_load` since its first appearance (3.0-stable) but this feature has an annoying behavior. I'm always expecting that only the scenes in "session" will be opened but the main scene (`application/run/main_scene`) is also opened (and it's opened in a deferred manner).

This PR is intended to ignore the main_scene if there is at least one scene to be restored.
The command `godot -e <any-scene>` still works with the restored scenes.

About the code, I really don't know if this is the best approach. I added a `main_scene` variable to `EditorNode` and it's loading the main_scene only if `_load_open_scenes_from_config()` does not load anything.

Thanks in advance :) 