### PR TITLE
Use select instead of WSAPoll on Windows.

### DIFF
--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -400,6 +400,7 @@ Error NetSocketPosix::poll(PollType p_type, int p_timeout) const {
 	int ret = ::poll(&pfd, 1, p_timeout);
 
 	ERR_FAIL_COND_V(ret < 0, FAILED);
+	ERR_FAIL_COND_V(pfd.revents & POLLERR, FAILED);
 
 	if (ret == 0)
 		return ERR_BUSY;


### PR DESCRIPTION
Closes #22319

WSAPoll is broken by design.
It was announced as the new way to introduce compatibility to posix
sockets, their implementation was broken, and they decided not to fix it.

You can read the full story here:
https://daniel.haxx.se/blog/2012/10/10/wsapoll-is-broken/

The second one-line commit is to try and maintain the same behaviour on Linux with what I'm doing with select on Windows.
It should be an improvement to what we have now. I left it in a separate commit so if anything bad happens that commit can be blamed :wink: 