### PR TITLE
StreamPeer get[_utf8]_string with negative length.

### DIFF
--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -209,6 +209,12 @@ void StreamPeer::put_double(double p_val) {
 	}
 	put_data(buf, 8);
 }
+void StreamPeer::put_string(const String &p_string) {
+
+	CharString cs = p_string.ascii();
+	put_u32(cs.length());
+	put_data((const uint8_t *)cs.get_data(), cs.length());
+}
 void StreamPeer::put_utf8_string(const String &p_string) {
 
 	CharString cs = p_string.utf8();
@@ -325,6 +331,8 @@ double StreamPeer::get_double() {
 }
 String StreamPeer::get_string(int p_bytes) {
 
+	if (p_bytes < 0)
+		p_bytes = get_u32();
 	ERR_FAIL_COND_V(p_bytes < 0, String());
 
 	Vector<char> buf;
@@ -337,6 +345,8 @@ String StreamPeer::get_string(int p_bytes) {
 }
 String StreamPeer::get_utf8_string(int p_bytes) {
 
+	if (p_bytes < 0)
+		p_bytes = get_u32();
 	ERR_FAIL_COND_V(p_bytes < 0, String());
 
 	Vector<uint8_t> buf;
@@ -386,6 +396,7 @@ void StreamPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("put_u64", "value"), &StreamPeer::put_u64);
 	ClassDB::bind_method(D_METHOD("put_float", "value"), &StreamPeer::put_float);
 	ClassDB::bind_method(D_METHOD("put_double", "value"), &StreamPeer::put_double);
+	ClassDB::bind_method(D_METHOD("put_string", "value"), &StreamPeer::put_string);
 	ClassDB::bind_method(D_METHOD("put_utf8_string", "value"), &StreamPeer::put_utf8_string);
 	ClassDB::bind_method(D_METHOD("put_var", "value"), &StreamPeer::put_var);
 
@@ -399,8 +410,8 @@ void StreamPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_u64"), &StreamPeer::get_u64);
 	ClassDB::bind_method(D_METHOD("get_float"), &StreamPeer::get_float);
 	ClassDB::bind_method(D_METHOD("get_double"), &StreamPeer::get_double);
-	ClassDB::bind_method(D_METHOD("get_string", "bytes"), &StreamPeer::get_string);
-	ClassDB::bind_method(D_METHOD("get_utf8_string", "bytes"), &StreamPeer::get_utf8_string);
+	ClassDB::bind_method(D_METHOD("get_string", "bytes"), &StreamPeer::get_string, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("get_utf8_string", "bytes"), &StreamPeer::get_utf8_string, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("get_var"), &StreamPeer::get_var);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "big_endian"), "set_big_endian", "is_big_endian_enabled");

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -71,6 +71,7 @@ public:
 	void put_u64(uint64_t p_val);
 	void put_float(float p_val);
 	void put_double(double p_val);
+	void put_string(const String &p_string);
 	void put_utf8_string(const String &p_string);
 	void put_var(const Variant &p_variant);
 
@@ -84,8 +85,8 @@ public:
 	int64_t get_64();
 	float get_float();
 	double get_double();
-	String get_string(int p_bytes);
-	String get_utf8_string(int p_bytes);
+	String get_string(int p_bytes = -1);
+	String get_utf8_string(int p_bytes = -1);
 	Variant get_var();
 
 	StreamPeer() { big_endian = false; }

--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -81,10 +81,10 @@
 		<method name="get_string">
 			<return type="String">
 			</return>
-			<argument index="0" name="bytes" type="int">
+			<argument index="0" name="bytes" type="int" default="-1">
 			</argument>
 			<description>
-				Get a string with byte-length "bytes" from the stream.
+				Get a string with byte-length [code]bytes[/code] from the stream. If [code]bytes[/code] is negative (default) the length will be read from the stream using the reverse process of [method put_string].
 			</description>
 		</method>
 		<method name="get_u16">
@@ -118,10 +118,10 @@
 		<method name="get_utf8_string">
 			<return type="String">
 			</return>
-			<argument index="0" name="bytes" type="int">
+			<argument index="0" name="bytes" type="int" default="-1">
 			</argument>
 			<description>
-				Get a utf8 string with byte-length "bytes" from the stream (this decodes the string sent as utf8).
+				Get a utf8 string with byte-length [code]bytes[/code] from the stream (this decodes the string sent as utf8). If [code]bytes[/code] is negative (default) the length will be read from the stream using the reverse process of [method put_utf8_string].
 			</description>
 		</method>
 		<method name="get_var">
@@ -203,6 +203,15 @@
 				Send a chunk of data through the connection, if all the data could not be sent at once, only part of it will. This function returns two values, an Error code and an integer, describing how much data was actually sent.
 			</description>
 		</method>
+		<method name="put_string">
+			<return type="void">
+			</return>
+			<argument index="0" name="value" type="String">
+			</argument>
+			<description>
+				Put a zero-terminated ascii string into the stream prepended by a 32 bits unsigned integer representing its size.
+			</description>
+		</method>
 		<method name="put_u16">
 			<return type="void">
 			</return>
@@ -245,7 +254,7 @@
 			<argument index="0" name="value" type="String">
 			</argument>
 			<description>
-				Put a zero-terminated utf8 string into the stream.
+				Put a zero-terminated utf8 string into the stream prepended by a 32 bits unsigned integer representing its size.
 			</description>
 		</method>
 		<method name="put_var">


### PR DESCRIPTION
If the "bytes" parameter of get_string and get_utf8_string is negative,
the length will be read from the stream instead.
The bytes parameter has now a default (-1), allowing to use them
directly as reverses of put_string and put_utf8_string .
`put_string` was not implemented, so I implemented it to allow sending
ASCII strings (which are much smaller than UTF8 ones).

EDIT: `put_string` was not implemented. This PR adds it too, to encode ascii strings (resulting in much smaller payload size)

Tested with:
```gdscript
extends Node

func _ready():
	var buff = StreamPeerBuffer.new()
	buff.put_utf8_string("Test")
	buff.seek(0)
	var l = buff.get_u32()
	print(buff.get_utf8_string(l)) # "Test"
	buff.seek(0)
	print(buff.get_utf8_string()) # "Test" once more :)
```

Closes #12783

Edit:
More test:
```gdscript
extends Node

func _ready():
	var buff = StreamPeerBuffer.new()
	buff.put_utf8_string("T漢字est漢字")
	buff.seek(0)
	var l = buff.get_u32()
	print(buff.get_utf8_string(l)) # T漢字est漢字
	buff.seek(0)
	print(buff.get_utf8_string()) # T漢字est漢字
	print(buff.get_size()) # 20
	buff.seek(buff.get_size())
	print(buff.get_8()) # 0 (correctly null terminated)
	buff.resize(0)
	buff.seek(0)
	buff.put_string("T漢字est漢字")
	buff.seek(0)
	l = buff.get_u32()
	print(buff.get_string(l)) # T"West"W
	buff.seek(0)
	print(buff.get_string()) # T"West"W
	print(buff.get_size()) # 12
	buff.seek(0)
	buff.seek(buff.get_size())
	print(buff.get_8()) # 0 (correctly null terminated)
```