### PR TITLE
Settings: Sort text editor themes alphabetically

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1216,18 +1216,25 @@ bool EditorSettings::is_dark_theme() {
 
 void EditorSettings::list_text_editor_themes() {
 	String themes = "Adaptive,Default,Custom";
+
 	DirAccess *d = DirAccess::open(get_text_editor_themes_dir());
 	if (d) {
+		List<String> custom_themes;
 		d->list_dir_begin();
 		String file = d->get_next();
 		while (file != String()) {
 			if (file.get_extension() == "tet" && file.get_basename().to_lower() != "default" && file.get_basename().to_lower() != "adaptive" && file.get_basename().to_lower() != "custom") {
-				themes += "," + file.get_basename();
+				custom_themes.push_back(file.get_basename());
 			}
 			file = d->get_next();
 		}
 		d->list_dir_end();
 		memdelete(d);
+
+		custom_themes.sort();
+		for (List<String>::Element *E = custom_themes.front(); E; E = E->next()) {
+			themes += "," + E->get();
+		}
 	}
 	add_property_hint(PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, themes));
 }


### PR DESCRIPTION
Previously it would look like this ([from reddit](https://www.reddit.com/r/godot/comments/9hv2oz/new_base16_template_for_godot_use_dozens_of/e6etw8h)): https://i.imgur.com/ZUm7Rp0.png

Now looks like this:
![screenshot_20180922_100429](https://user-images.githubusercontent.com/4701338/45915076-e5fba180-be4e-11e8-8b83-32b3a2dd8982.png)

It's still unusable when you have so many entries that it overflows the popup, but that's an unrelated issue.
