### PR TITLE
Fixed duplicating nodes not attaching script in-game with Sync Scene Changes enabled

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1602,7 +1602,7 @@ void SceneTree::_live_edit_duplicate_node_func(const NodePath &p_at, const Strin
 			continue;
 		Node *n2 = n->get_node(p_at);
 
-		Node *dup = n2->duplicate(true);
+		Node *dup = n2->duplicate(Node::DUPLICATE_SIGNALS | Node::DUPLICATE_GROUPS | Node::DUPLICATE_SCRIPTS);
 
 		if (!dup)
 			continue;


### PR DESCRIPTION
Fixed duplicating nodes not attaching script in-game with Sync Scene Changes enabled.

This fixes #15978