### PR TITLE
Add proper strikethrough BBCode to RichTextLabel

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -62,6 +62,7 @@ public:
 		ITEM_FONT,
 		ITEM_COLOR,
 		ITEM_UNDERLINE,
+		ITEM_STRIKETHROUGH,
 		ITEM_ALIGN,
 		ITEM_INDENT,
 		ITEM_LIST,
@@ -162,6 +163,11 @@ private:
 	struct ItemUnderline : public Item {
 
 		ItemUnderline() { type = ITEM_UNDERLINE; }
+	};
+
+	struct ItemStrikethrough : public Item {
+
+		ItemStrikethrough() { type = ITEM_STRIKETHROUGH; }
 	};
 
 	struct ItemMeta : public Item {
@@ -277,6 +283,7 @@ private:
 	Align _find_align(Item *p_item);
 	Color _find_color(Item *p_item, const Color &p_default_color);
 	bool _find_underline(Item *p_item);
+	bool _find_strikethrough(Item *p_item);
 	bool _find_meta(Item *p_item, Variant *r_meta);
 
 	void _update_scroll();
@@ -307,6 +314,7 @@ public:
 	void push_font(const Ref<Font> &p_font);
 	void push_color(const Color &p_color);
 	void push_underline();
+	void push_strikethrough();
 	void push_align(Align p_align);
 	void push_indent(int p_level);
 	void push_list(ListType p_list);


### PR DESCRIPTION
![screenshot at 2018-09-22 18-40-07](https://user-images.githubusercontent.com/30739239/45921983-67772200-be97-11e8-8a34-9dcee7b9411b.png)

On a related note, could someone explain the comments `//use underline/strikethrough` on tags that seem to be completely unrelated (e. g. [img], [url], [center], etc)?