### PR TITLE
Fix icon issue for the resource list popup #22320.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3202,7 +3202,7 @@ Ref<Texture> EditorNode::get_class_icon(const String &p_class, const String &p_f
 		}
 	}
 
-	if (p_fallback.length())
+	if (p_fallback.length() && gui_base->has_icon(p_fallback, "EditorIcons"))
 		return gui_base->get_icon(p_fallback, "EditorIcons");
 
 	return NULL;


### PR DESCRIPTION
When a resource item doesn´t define a icon it should not use the theme default icon, the default theme icon is an error msg.

_Bugsquad edit : fixes #22320_