### PR TITLE
[Docs] Remove double-spaces from descriptions, plus a couple other tiny fixes

### DIFF
--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -55,7 +55,7 @@
 			<argument index="0" name="s" type="float">
 			</argument>
 			<description>
-				Returns the absolute value of parameter [code]s[/code]  (i.e. unsigned value, works for integer and float).
+				Returns the absolute value of parameter [code]s[/code] (i.e. unsigned value, works for integer and float).
 				[codeblock]
 				# a is 1
 				a = abs(-1)
@@ -373,7 +373,7 @@
 			<description>
 				Returns the floating-point remainder of [code]x/y[/code] that wraps equally in positive and negative.
 				[codeblock]
-				var i = -10;
+				var i = -10
 				while i &lt; 0:
 				    prints(i, fposmod(i, 10))
 				    i += 1

--- a/doc/classes/ARVRController.xml
+++ b/doc/classes/ARVRController.xml
@@ -6,7 +6,7 @@
 	<description>
 		This is a helper spatial node that is linked to the tracking of controllers. It also offers several handy pass throughs to the state of buttons and such on the controllers.
 		Controllers are linked by their id. You can create controller nodes before the controllers are available. Say your game always uses two controllers (one for each hand) you can predefine the controllers with id 1 and 2 and they will become active as soon as the controllers are identified. If you expect additional controllers to be used you should react to the signals and add ARVRController nodes to your scene.
-		The position of the controller node is automatically updated by the ARVR Server. This makes this node ideal to add child  nodes to visualise the controller.
+		The position of the controller node is automatically updated by the ARVR Server. This makes this node ideal to add child nodes to visualise the controller.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -120,7 +120,7 @@
 			<argument index="3" name="before" type="bool" default="True">
 			</argument>
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search and a custom comparison method. Optionally, a before specifier can be passed. If false, the returned index comes after all existing entries of the value in the array.  The custom method receives two arguments (an element from the array and the value searched for) and must return true if the first argument is less than the second, and return false otherwise. Note that calling bsearch on an unsorted array results in unexpected behavior.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search and a custom comparison method. Optionally, a before specifier can be passed. If false, the returned index comes after all existing entries of the value in the array. The custom method receives two arguments (an element from the array and the value searched for) and must return true if the first argument is less than the second, and return false otherwise. Note that calling bsearch on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
 		<method name="clear">
@@ -321,7 +321,7 @@
 				    static func sort(a, b):
 				        if a[0] &lt; b[0]:
 				            return true
-				    return false
+				        return false
 
 				var my_items = [[5, "Potato"], [9, "Rice"], [4, "Tomato"]]
 				my_items.sort_custom(MyCustomSorter, "sort")

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -4,7 +4,7 @@
 		Color in RGBA format with some support for ARGB format.
 	</brief_description>
 	<description>
-		A color is represented as red, green and blue (r,g,b) components. Additionally, "a" represents the alpha component, often used for transparency. Values are in floating point and usually range from 0 to 1.  Some methods (such as set_modulate(color)) may accept values &gt; 1.
+		A color is represented as red, green and blue (r,g,b) components. Additionally, "a" represents the alpha component, often used for transparency. Values are in floating point and usually range from 0 to 1. Some methods (such as set_modulate(color)) may accept values &gt; 1.
 		You can also create a color from standardised color names with Color.ColorN (e.g. Color.green) or [method @GDScript.ColorN].
 	</description>
 	<tutorials>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -229,9 +229,9 @@
 				extends Control
 
 				func get_drag_data(position):
-					var mydata = make_data()
-					set_drag_preview(make_preview(mydata))
-					return mydata
+				    var mydata = make_data()
+				    set_drag_preview(make_preview(mydata))
+				    return mydata
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -111,7 +111,7 @@
 			<argument index="1" name="t" type="float">
 			</argument>
 			<description>
-				Returns the position between the vertex "idx" and the vertex "idx"+1, where "t" controls if the point is the first vertex (t = 0.0), the last vertex (t = 1.0), or in between. Values of "t" outside the range (0.0 &gt;= t  &lt;=1) give strange, but predictable results.
+				Returns the position between the vertex "idx" and the vertex "idx"+1, where "t" controls if the point is the first vertex (t = 0.0), the last vertex (t = 1.0), or in between. Values of "t" outside the range (0.0 &gt;= t &lt;=1) give strange, but predictable results.
 				If "idx" is out of bounds it is truncated to the first or last vertex, and "t" is ignored. If the curve has no points, the function sends an error to the console, and returns (0, 0).
 			</description>
 		</method>

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -135,7 +135,7 @@
 			<argument index="1" name="t" type="float">
 			</argument>
 			<description>
-				Returns the position between the vertex "idx" and the vertex "idx"+1, where "t" controls if the point is the first vertex (t = 0.0), the last vertex (t = 1.0), or in between. Values of "t" outside the range (0.0 &gt;= t  &lt;=1) give strange, but predictable results.
+				Returns the position between the vertex "idx" and the vertex "idx"+1, where "t" controls if the point is the first vertex (t = 0.0), the last vertex (t = 1.0), or in between. Values of "t" outside the range (0.0 &gt;= t &lt;=1) give strange, but predictable results.
 				If "idx" is out of bounds it is truncated to the first or last vertex, and "t" is ignored. If the curve has no points, the function sends an error to the console, and returns (0, 0, 0).
 			</description>
 		</method>

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -41,7 +41,7 @@
 		        return FAILED
 
 		    var mesh = Mesh.new()
-			# Fill the Mesh with data read in 'file', left as exercise to the reader
+		    # Fill the Mesh with data read in 'file', left as exercise to the reader
 
 		    var filename = save_path + "." + get_save_extension()
 		    ResourceSaver.save(filename, mesh)

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -33,7 +33,7 @@
 			<argument index="2" name="selectable" type="bool" default="true">
 			</argument>
 			<description>
-				Adds an item to the item list with specified text.  Specify an icon of null for a list item with no icon.
+				Adds an item to the item list with specified text. Specify an icon of null for a list item with no icon.
 				If selectable is true the list item will be selectable.
 			</description>
 		</method>
@@ -222,7 +222,7 @@
 			</argument>
 			<description>
 				Select the item at the specified index.
-				Note:  This method does not trigger the item selection signal.
+				Note: This method does not trigger the item selection signal.
 			</description>
 		</method>
 		<method name="set_item_custom_bg_color">

--- a/doc/classes/LargeTexture.xml
+++ b/doc/classes/LargeTexture.xml
@@ -74,7 +74,7 @@
 			<argument index="1" name="texture" type="Texture">
 			</argument>
 			<description>
-				Sets the [Texture] of the piece with index "idx" to  "ofs".
+				Sets the [Texture] of the piece with index "idx" to "texture".
 			</description>
 		</method>
 		<method name="set_size">

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -11,7 +11,7 @@
 		var scene = PackedScene.new()
 		var result = scene.pack(child)
 		if result == OK:
-		    ResourceSaver.save("res://path/name.scn", scene) // or user://...
+		    ResourceSaver.save("res://path/name.scn", scene) # or user://...
 		[/codeblock]
 	</description>
 	<tutorials>

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -129,7 +129,7 @@
 			<argument index="1" name="to" type="int">
 			</argument>
 			<description>
-				Returns the slice of the [code]PoolByteArray[/code] between indices (inclusive) as a new [code]PoolByteArray[/code].  Any negative index is considered to be from the end of the array.
+				Returns the slice of the [code]PoolByteArray[/code] between indices (inclusive) as a new [code]PoolByteArray[/code]. Any negative index is considered to be from the end of the array.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RID.xml
+++ b/doc/classes/RID.xml
@@ -4,7 +4,7 @@
 		Handle for a [Resource]'s unique ID.
 	</brief_description>
 	<description>
-		The RID type is used to access the unique integer ID of a resource.  They are opaque, so they do not grant access to the associated resource by themselves. They are used by and with the low-level Server classes such as [VisualServer].
+		The RID type is used to access the unique integer ID of a resource. They are opaque, so they do not grant access to the associated resource by themselves. They are used by and with the low-level Server classes such as [VisualServer].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -44,7 +44,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Updates the collision information for the ray.  Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the ray or its parent has changed state. Note: [code]enabled == true[/code] is not required for this to work.
+				Updates the collision information for the ray. Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the ray or its parent has changed state. Note: [code]enabled == true[/code] is not required for this to work.
 			</description>
 		</method>
 		<method name="get_collider" qualifiers="const">

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -88,7 +88,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Return a list of the bodies colliding with this one. By default, number of max contacts reported is at 0 , see [method set_max_contacts_reported] to increase it.  Note that the result of this test is not immediate after moving objects. For performance, list of collisions is updated once per frame and before the physics step. Consider using signals instead.
+				Return a list of the bodies colliding with this one. By default, number of max contacts reported is at 0 , see [method set_max_contacts_reported] to increase it. Note that the result of this test is not immediate after moving objects. For performance, list of collisions is updated once per frame and before the physics step. Consider using signals instead.
 			</description>
 		</method>
 		<method name="set_axis_velocity">

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -4,7 +4,7 @@
 		A helper node for displaying scrollable elements (e.g. lists).
 	</brief_description>
 	<description>
-		A ScrollContainer node with a [Control] child and scrollbar child ([HScrollbar], [VScrollBar], or both) will only draw the Control within the ScrollContainer area.  Scrollbars will automatically be drawn at the right (for vertical) or bottom (for horizontal) and will enable dragging to move the viewable Control (and its children) within the ScrollContainer.  Scrollbars will also automatically resize the grabber based on the minimum_size of the Control relative to the ScrollContainer.  Works great with a [Panel] control.  You can set EXPAND on children size flags, so they will upscale to ScrollContainer size if ScrollContainer size is bigger (scroll is invisible for chosen dimension).
+		A ScrollContainer node with a [Control] child and scrollbar child ([HScrollbar], [VScrollBar], or both) will only draw the Control within the ScrollContainer area. Scrollbars will automatically be drawn at the right (for vertical) or bottom (for horizontal) and will enable dragging to move the viewable Control (and its children) within the ScrollContainer. Scrollbars will also automatically resize the grabber based on the minimum_size of the Control relative to the ScrollContainer. Works great with a [Panel] control. You can set EXPAND on children size flags, so they will upscale to ScrollContainer size if ScrollContainer size is bigger (scroll is invisible for chosen dimension).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -248,7 +248,7 @@
 			Amount to offset alternating tiles. Uses HALF_OFFSET_* constants. Default value: HALF_OFFSET_DISABLED.
 		</member>
 		<member name="cell_quadrant_size" type="int" setter="set_quadrant_size" getter="get_quadrant_size">
-			The TileMap's quadrant size.  Optimizes drawing by batching, using chunks of this size. Default value: 16.
+			The TileMap's quadrant size. Optimizes drawing by batching, using chunks of this size. Default value: 16.
 		</member>
 		<member name="cell_size" type="Vector2" setter="set_cell_size" getter="get_cell_size">
 			The TileMap's cell size.
@@ -278,7 +278,7 @@
 			The TileMap orientation mode. Uses MODE_* constants. Default value: MODE_SQUARE.
 		</member>
 		<member name="occluder_light_mask" type="int" setter="set_occluder_light_mask" getter="get_occluder_light_mask">
-			The light mask assigned to all light occluders in the TileMap.  The TileSet's light occluders will cast shadows only from Light2D(s) that have the same light mask(s).
+			The light mask assigned to all light occluders in the TileMap. The TileSet's light occluders will cast shadows only from Light2D(s) that have the same light mask(s).
 		</member>
 		<member name="tile_set" type="TileSet" setter="set_tileset" getter="get_tileset">
 			The assigned [TileSet].

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -94,7 +94,7 @@
 			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
-				If [member drop_mode_flags] includes [code]DROP_MODE_INBETWEEN[/code], returns -1 if [code]position[/code] is the upper part of a tree item at that position, 1 for the lower part, and additionally 0 for the middle part if [member drop_mode_flags] includes [code]DROP_MODE_ON_ITEM[/code]. 
+				If [member drop_mode_flags] includes [code]DROP_MODE_INBETWEEN[/code], returns -1 if [code]position[/code] is the upper part of a tree item at that position, 1 for the lower part, and additionally 0 for the middle part if [member drop_mode_flags] includes [code]DROP_MODE_ON_ITEM[/code].
 				Otherwise, returns 0. If there are no tree item at [code]position[/code], returns -100.
 			</description>
 		</method>

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -9,8 +9,8 @@
 		[codeblock]
 		var tween = get_node("Tween")
 		tween.interpolate_property($Node2D, "position",
-                Vector2(0, 0), Vector2(100, 100), 1,
-                Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+		        Vector2(0, 0), Vector2(100, 100), 1,
+		        Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
 		tween.start()
 		[/codeblock]
 		Many methods require a property name, such as "position" above. You can find the correct property name by hovering over the property in the Inspector.
@@ -44,7 +44,7 @@
 			</argument>
 			<description>
 				Follows [code]method[/code] of [code]object[/code] and applies the returned value on [code]target_method[/code] of [code]target[/code], beginning from [code]initial_val[/code] for [code]duration[/code] seconds, [code]delay[/code] later. Methods are called with consecutive values.
-                Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
 			</description>
 		</method>
 		<method name="follow_property">
@@ -70,7 +70,7 @@
 			</argument>
 			<description>
 				Follows [code]property[/code] of [code]object[/code] and applies it on [code]target_property[/code] of [code]target[/code], beginning from [code]initial_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later.
-                Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
 			</description>
 		</method>
 		<method name="get_runtime" qualifiers="const">
@@ -147,7 +147,7 @@
 			</argument>
 			<description>
 				Animates [code]method[/code] of [code]object[/code] from [code]initial_val[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later. Methods are called with consecutive values.
-                Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
 			</description>
 		</method>
 		<method name="interpolate_property">
@@ -171,7 +171,7 @@
 			</argument>
 			<description>
 				Animates [code]property[/code] of [code]object[/code] from [code]initial_val[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later. Setting the initial value to [code]null[/code] uses the current value of the property.
-                Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
 			</description>
 		</method>
 		<method name="is_active" qualifiers="const">
@@ -301,7 +301,7 @@
 			</argument>
 			<description>
 				Animates [code]method[/code] of [code]object[/code] from the value returned by [code]initial_method[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later. Methods are animated by calling them with consecutive values.
-                Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
 			</description>
 		</method>
 		<method name="targeting_property">
@@ -327,7 +327,7 @@
 			</argument>
 			<description>
 				Animates [code]property[/code] of [code]object[/code] from the current value of the [code]initial_val[/code] property of [code]initial[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later.
-                Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
+				Use [enum TransitionType] for [code]trans_type[/code] and [enum EaseType] for [code]ease_type[/code] parameters. These values control the timing and direction of the interpolation. See the class description for more information
 			</description>
 		</method>
 		<method name="tell" qualifiers="const">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -227,7 +227,7 @@
 			<argument index="1" name="t" type="float">
 			</argument>
 			<description>
-				Returns the result of SLERP between this vector and [code]b[/code], by amount [code]t[/code]. [code]t[/code] is in the range of  [code]0.0 - 1.0[/code], representing the amount of interpolation.
+				Returns the result of SLERP between this vector and [code]b[/code], by amount [code]t[/code]. [code]t[/code] is in the range of [code]0.0 - 1.0[/code], representing the amount of interpolation.
 				Both vectors need to be normalized.
 			</description>
 		</method>


### PR DESCRIPTION
This PR changes any spaces that are used as indentation for the descriptions into tabs. Additionally, this also does the same for any code-blocks so as to allow copy-pasting into the engine. Exceptions are made when the spaces in question are used to align something such as a comment with another comment, or more parameters for a function where they would not fit well on a single line.

Additionally, this PR also fixes a small error I noticed in LargeTexture's documentation where a parameter is named wrongly within the description. I figured it's not worth the effort of making an entirely separate PR for that.

Please let me know if I missed anything!