### PR TITLE
Windows raw input fixes

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -697,7 +697,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			last_button_state = mb->get_button_mask();
 			mb->set_position(Vector2(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
 
-			if (mouse_mode == MOUSE_MODE_CAPTURED) {
+			if (mouse_mode == MOUSE_MODE_CAPTURED && !use_raw_input) {
 
 				mb->set_position(Vector2(old_x, old_y));
 			}

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -458,7 +458,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 					*/
 				}
 
-				if (window_has_focus && main_loop)
+				if (window_has_focus && main_loop && mm->get_relative() != Vector2())
 					input->parse_input_event(mm);
 			}
 			delete[] lpb;


### PR DESCRIPTION
First commit removes extra mouse movement events when clicking in MOUSE_MODE_CAPTURED.
Second commit fixes #22366.