### PR TITLE
Fallback to "en" when invalid locale is requested

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -938,11 +938,14 @@ void TranslationServer::set_locale(const String &p_locale) {
 
 	if (!is_locale_valid(univ_locale)) {
 		String trimmed_locale = get_trimmed_locale(univ_locale);
+		print_verbose(vformat("Unsupported locale '%s', falling back to '%s'.", p_locale, trimmed_locale));
 
-		ERR_EXPLAIN("Invalid locale: " + trimmed_locale);
-		ERR_FAIL_COND(!is_locale_valid(trimmed_locale));
-
-		locale = trimmed_locale;
+		if (!is_locale_valid(trimmed_locale)) {
+			ERR_PRINTS(vformat("Unsupported locale '%s', falling back to 'en'.", trimmed_locale));
+			locale = "en";
+		} else {
+			locale = trimmed_locale;
+		}
 	} else {
 		locale = univ_locale;
 	}


### PR DESCRIPTION
Close #22365 (it will still show an error but now it's more explicit and won't impact the actual use since it defaults to "en").