### PR TITLE
Renaming SimplexNoise refs to OpenSimplexNoise

### DIFF
--- a/modules/opensimplex/SCsub
+++ b/modules/opensimplex/SCsub
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 
 Import('env')
-env.add_source_files(env.modules_sources, ["register_types.cpp", "simplex_noise.cpp", "noise_texture.cpp", "#thirdparty/misc/open-simplex-noise.c"])
+env.add_source_files(env.modules_sources, ["register_types.cpp", "open_simplex_noise.cpp", "noise_texture.cpp", "#thirdparty/misc/open-simplex-noise.c"])

--- a/modules/opensimplex/doc_classes/NoiseTexture.xml
+++ b/modules/opensimplex/doc_classes/NoiseTexture.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NoiseTexture" inherits="Texture" category="Core" version="3.1">
 	<brief_description>
-		[SimplexNoise] filled texture.
+		[OpenSimplexNoise] filled texture.
 	</brief_description>
 	<description>
-		Uses a [SimplexNoise] to fill the texture data. You can specify the texture size but keep in mind that larger textures will take longer to generate and seamless noise only works with square sized textures.
+		Uses an [OpenSimplexNoise] to fill the texture data. You can specify the texture size but keep in mind that larger textures will take longer to generate and seamless noise only works with square sized textures.
 		NoiseTexture can also generate normalmap textures.
 	</description>
 	<tutorials>
@@ -35,8 +35,8 @@
 		<member name="as_normalmap" type="bool" setter="set_as_normalmap" getter="is_normalmap">
 			If true, the resulting texture contains a normal map created from the original noise interpreted as a bump map.
 		</member>
-		<member name="noise" type="SimplexNoise" setter="set_noise" getter="get_noise">
-			The [SimplexNoise] instance used to generate the noise.
+		<member name="noise" type="OpenSimplexNoise" setter="set_noise" getter="get_noise">
+			The [OpenSimplexNoise] instance used to generate the noise.
 		</member>
 		<member name="seamless" type="bool" setter="set_seamless" getter="get_seamless">
 			Whether the texture can be tiled without visible seams or not. Seamless textures take longer to generate.

--- a/modules/opensimplex/doc_classes/OpenSimplexNoise.xml
+++ b/modules/opensimplex/doc_classes/OpenSimplexNoise.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SimplexNoise" inherits="Resource" category="Core" version="3.1">
+<class name="OpenSimplexNoise" inherits="Resource" category="Core" version="3.1">
 	<brief_description>
 		Noise generator based on Open Simplex.
 	</brief_description>
 	<description>
-		This resource allows you to configure and sample a fractal noise space. Here is a brief usage example that configures a SimplexNoise and gets samples at various positions and dimensions:
+		This resource allows you to configure and sample a fractal noise space. Here is a brief usage example that configures an OpenSimplexNoise and gets samples at various positions and dimensions:
 		[codeblock]
-		var noise = SimplexNoise.new()
+		var noise = OpenSimplexNoise.new()
 
 		# Configure
 		noise.seed = randi()
@@ -109,7 +109,7 @@
 			Difference in period between [member octaves].
 		</member>
 		<member name="octaves" type="int" setter="set_octaves" getter="get_octaves">
-			Number of Simplex noise layers that are sampled to get the fractal noise.
+			Number of OpenSimplex noise layers that are sampled to get the fractal noise.
 		</member>
 		<member name="period" type="float" setter="set_period" getter="get_period">
 			Period of the base octave. A lower period results in a higher-frequency noise (more value changes across the same distance).

--- a/modules/opensimplex/noise_texture.cpp
+++ b/modules/opensimplex/noise_texture.cpp
@@ -43,7 +43,7 @@ NoiseTexture::NoiseTexture() {
 	as_normalmap = false;
 	flags = FLAGS_DEFAULT;
 
-	noise = Ref<SimplexNoise>();
+	noise = Ref<OpenSimplexNoise>();
 
 	texture = VS::get_singleton()->texture_create();
 
@@ -76,7 +76,7 @@ void NoiseTexture::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "seamless"), "set_seamless", "get_seamless");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "as_normalmap"), "set_as_normalmap", "is_normalmap");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "noise", PROPERTY_HINT_RESOURCE_TYPE, "SimplexNoise"), "set_noise", "get_noise");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "noise", PROPERTY_HINT_RESOURCE_TYPE, "OpenSimplexNoise"), "set_noise", "get_noise");
 }
 
 void NoiseTexture::_set_texture_data(const Ref<Image> &p_image) {
@@ -159,7 +159,7 @@ void NoiseTexture::_update_texture() {
 	}
 }
 
-void NoiseTexture::set_noise(Ref<SimplexNoise> p_noise) {
+void NoiseTexture::set_noise(Ref<OpenSimplexNoise> p_noise) {
 	if (p_noise == noise)
 		return;
 	if (noise.is_valid()) {
@@ -172,7 +172,7 @@ void NoiseTexture::set_noise(Ref<SimplexNoise> p_noise) {
 	_queue_update();
 }
 
-Ref<SimplexNoise> NoiseTexture::get_noise() {
+Ref<OpenSimplexNoise> NoiseTexture::get_noise() {
 	return noise;
 }
 

--- a/modules/opensimplex/noise_texture.h
+++ b/modules/opensimplex/noise_texture.h
@@ -31,7 +31,7 @@
 #ifndef NOISE_TEXTURE_H
 #define NOISE_TEXTURE_H
 
-#include "simplex_noise.h"
+#include "open_simplex_noise.h"
 
 #include "core/image.h"
 #include "core/reference.h"
@@ -54,7 +54,7 @@ private:
 	RID texture;
 	uint32_t flags;
 
-	Ref<SimplexNoise> noise;
+	Ref<OpenSimplexNoise> noise;
 	Vector2i size;
 	bool seamless;
 	bool as_normalmap;
@@ -71,8 +71,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_noise(Ref<SimplexNoise> p_noise);
-	Ref<SimplexNoise> get_noise();
+	void set_noise(Ref<OpenSimplexNoise> p_noise);
+	Ref<OpenSimplexNoise> get_noise();
 
 	void set_width(int p_width);
 	void set_height(int p_hieght);

--- a/modules/opensimplex/open_simplex_noise.cpp
+++ b/modules/opensimplex/open_simplex_noise.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  simplex_noise.cpp                                                    */
+/*  open_simplex_noise.cpp                                               */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "simplex_noise.h"
+#include "open_simplex_noise.h"
 
 #include "core/core_string_names.h"
 
-SimplexNoise::SimplexNoise() {
+OpenSimplexNoise::OpenSimplexNoise() {
 
 	seed = 0;
 	persistence = 0.5;
@@ -43,16 +43,16 @@ SimplexNoise::SimplexNoise() {
 	_init_seeds();
 }
 
-SimplexNoise::~SimplexNoise() {
+OpenSimplexNoise::~OpenSimplexNoise() {
 }
 
-void SimplexNoise::_init_seeds() {
+void OpenSimplexNoise::_init_seeds() {
 	for (int i = 0; i < 6; ++i) {
 		open_simplex_noise(seed + i * 2, &(contexts[i]));
 	}
 }
 
-void SimplexNoise::set_seed(int p_seed) {
+void OpenSimplexNoise::set_seed(int p_seed) {
 
 	if (seed == p_seed)
 		return;
@@ -64,36 +64,36 @@ void SimplexNoise::set_seed(int p_seed) {
 	emit_changed();
 }
 
-int SimplexNoise::get_seed() {
+int OpenSimplexNoise::get_seed() {
 
 	return seed;
 }
 
-void SimplexNoise::set_octaves(int p_octaves) {
+void OpenSimplexNoise::set_octaves(int p_octaves) {
 	if (p_octaves == octaves) return;
 	octaves = CLAMP(p_octaves, 1, 6);
 	emit_changed();
 }
 
-void SimplexNoise::set_period(float p_period) {
+void OpenSimplexNoise::set_period(float p_period) {
 	if (p_period == period) return;
 	period = p_period;
 	emit_changed();
 }
 
-void SimplexNoise::set_persistence(float p_persistence) {
+void OpenSimplexNoise::set_persistence(float p_persistence) {
 	if (p_persistence == persistence) return;
 	persistence = p_persistence;
 	emit_changed();
 }
 
-void SimplexNoise::set_lacunarity(float p_lacunarity) {
+void OpenSimplexNoise::set_lacunarity(float p_lacunarity) {
 	if (p_lacunarity == lacunarity) return;
 	lacunarity = p_lacunarity;
 	emit_changed();
 }
 
-Ref<Image> SimplexNoise::get_image(int p_width, int p_height) {
+Ref<Image> OpenSimplexNoise::get_image(int p_width, int p_height) {
 
 	PoolVector<uint8_t> data;
 	data.resize(p_width * p_height * 4);
@@ -116,7 +116,7 @@ Ref<Image> SimplexNoise::get_image(int p_width, int p_height) {
 	return image;
 }
 
-Ref<Image> SimplexNoise::get_seamless_image(int p_size) {
+Ref<Image> OpenSimplexNoise::get_seamless_image(int p_size) {
 
 	PoolVector<uint8_t> data;
 	data.resize(p_size * p_size * 4);
@@ -153,32 +153,32 @@ Ref<Image> SimplexNoise::get_seamless_image(int p_size) {
 	return image;
 }
 
-void SimplexNoise::_bind_methods() {
+void OpenSimplexNoise::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("get_seed"), &SimplexNoise::get_seed);
-	ClassDB::bind_method(D_METHOD("set_seed", "seed"), &SimplexNoise::set_seed);
+	ClassDB::bind_method(D_METHOD("get_seed"), &OpenSimplexNoise::get_seed);
+	ClassDB::bind_method(D_METHOD("set_seed", "seed"), &OpenSimplexNoise::set_seed);
 
-	ClassDB::bind_method(D_METHOD("set_octaves", "octave_count"), &SimplexNoise::set_octaves);
-	ClassDB::bind_method(D_METHOD("get_octaves"), &SimplexNoise::get_octaves);
+	ClassDB::bind_method(D_METHOD("set_octaves", "octave_count"), &OpenSimplexNoise::set_octaves);
+	ClassDB::bind_method(D_METHOD("get_octaves"), &OpenSimplexNoise::get_octaves);
 
-	ClassDB::bind_method(D_METHOD("set_period", "period"), &SimplexNoise::set_period);
-	ClassDB::bind_method(D_METHOD("get_period"), &SimplexNoise::get_period);
+	ClassDB::bind_method(D_METHOD("set_period", "period"), &OpenSimplexNoise::set_period);
+	ClassDB::bind_method(D_METHOD("get_period"), &OpenSimplexNoise::get_period);
 
-	ClassDB::bind_method(D_METHOD("set_persistence", "persistence"), &SimplexNoise::set_persistence);
-	ClassDB::bind_method(D_METHOD("get_persistence"), &SimplexNoise::get_persistence);
+	ClassDB::bind_method(D_METHOD("set_persistence", "persistence"), &OpenSimplexNoise::set_persistence);
+	ClassDB::bind_method(D_METHOD("get_persistence"), &OpenSimplexNoise::get_persistence);
 
-	ClassDB::bind_method(D_METHOD("set_lacunarity", "lacunarity"), &SimplexNoise::set_lacunarity);
-	ClassDB::bind_method(D_METHOD("get_lacunarity"), &SimplexNoise::get_lacunarity);
+	ClassDB::bind_method(D_METHOD("set_lacunarity", "lacunarity"), &OpenSimplexNoise::set_lacunarity);
+	ClassDB::bind_method(D_METHOD("get_lacunarity"), &OpenSimplexNoise::get_lacunarity);
 
-	ClassDB::bind_method(D_METHOD("get_image", "width", "height"), &SimplexNoise::get_image);
-	ClassDB::bind_method(D_METHOD("get_seamless_image", "size"), &SimplexNoise::get_seamless_image);
+	ClassDB::bind_method(D_METHOD("get_image", "width", "height"), &OpenSimplexNoise::get_image);
+	ClassDB::bind_method(D_METHOD("get_seamless_image", "size"), &OpenSimplexNoise::get_seamless_image);
 
-	ClassDB::bind_method(D_METHOD("get_noise_2d", "x", "y"), &SimplexNoise::get_noise_2d);
-	ClassDB::bind_method(D_METHOD("get_noise_3d", "x", "y", "z"), &SimplexNoise::get_noise_3d);
-	ClassDB::bind_method(D_METHOD("get_noise_4d", "x", "y", "z", "w"), &SimplexNoise::get_noise_4d);
+	ClassDB::bind_method(D_METHOD("get_noise_2d", "x", "y"), &OpenSimplexNoise::get_noise_2d);
+	ClassDB::bind_method(D_METHOD("get_noise_3d", "x", "y", "z"), &OpenSimplexNoise::get_noise_3d);
+	ClassDB::bind_method(D_METHOD("get_noise_4d", "x", "y", "z", "w"), &OpenSimplexNoise::get_noise_4d);
 
-	ClassDB::bind_method(D_METHOD("get_noise_2dv", "pos"), &SimplexNoise::get_noise_2dv);
-	ClassDB::bind_method(D_METHOD("get_noise_3dv", "pos"), &SimplexNoise::get_noise_3dv);
+	ClassDB::bind_method(D_METHOD("get_noise_2dv", "pos"), &OpenSimplexNoise::get_noise_2dv);
+	ClassDB::bind_method(D_METHOD("get_noise_3dv", "pos"), &OpenSimplexNoise::get_noise_3dv);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "seed"), "set_seed", "get_seed");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "octaves", PROPERTY_HINT_RANGE, "1,6,1"), "set_octaves", "get_octaves");
@@ -187,7 +187,7 @@ void SimplexNoise::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lacunarity", PROPERTY_HINT_RANGE, "0.1,4.0,0.01"), "set_lacunarity", "get_lacunarity");
 }
 
-float SimplexNoise::get_noise_2d(float x, float y) {
+float OpenSimplexNoise::get_noise_2d(float x, float y) {
 
 	x /= period;
 	y /= period;
@@ -208,7 +208,7 @@ float SimplexNoise::get_noise_2d(float x, float y) {
 	return sum / max;
 }
 
-float SimplexNoise::get_noise_3d(float x, float y, float z) {
+float OpenSimplexNoise::get_noise_3d(float x, float y, float z) {
 
 	x /= period;
 	y /= period;
@@ -231,7 +231,7 @@ float SimplexNoise::get_noise_3d(float x, float y, float z) {
 	return sum / max;
 }
 
-float SimplexNoise::get_noise_4d(float x, float y, float z, float w) {
+float OpenSimplexNoise::get_noise_4d(float x, float y, float z, float w) {
 
 	x /= period;
 	y /= period;

--- a/modules/opensimplex/open_simplex_noise.h
+++ b/modules/opensimplex/open_simplex_noise.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  simplex_noise.h                                                      */
+/*  open_simplex_noise.h                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SIMPLEX_NOISE_H
-#define SIMPLEX_NOISE_H
+#ifndef OPEN_SIMPLEX_NOISE_H
+#define OPEN_SIMPLEX_NOISE_H
 
 #include "core/image.h"
 #include "core/reference.h"
@@ -37,9 +37,9 @@
 
 #include "thirdparty/misc/open-simplex-noise.h"
 
-class SimplexNoise : public Resource {
-	GDCLASS(SimplexNoise, Resource)
-	OBJ_SAVE_TYPE(SimplexNoise);
+class OpenSimplexNoise : public Resource {
+	GDCLASS(OpenSimplexNoise, Resource)
+	OBJ_SAVE_TYPE(OpenSimplexNoise);
 
 	osn_context contexts[6];
 
@@ -50,8 +50,8 @@ class SimplexNoise : public Resource {
 	float lacunarity; // Controls period change across octaves. 2 is usually a good value to address all detail levels.
 
 public:
-	SimplexNoise();
-	~SimplexNoise();
+	OpenSimplexNoise();
+	~OpenSimplexNoise();
 
 	void _init_seeds();
 
@@ -90,4 +90,4 @@ protected:
 	static void _bind_methods();
 };
 
-#endif // OPENSIMPLEX_NOISE_H
+#endif // OPEN_SIMPLEX_NOISE_H

--- a/modules/opensimplex/register_types.cpp
+++ b/modules/opensimplex/register_types.cpp
@@ -30,11 +30,11 @@
 
 #include "register_types.h"
 #include "noise_texture.h"
-#include "simplex_noise.h"
+#include "open_simplex_noise.h"
 
 void register_opensimplex_types() {
 
-	ClassDB::register_class<SimplexNoise>();
+	ClassDB::register_class<OpenSimplexNoise>();
 	ClassDB::register_class<NoiseTexture>();
 }
 


### PR DESCRIPTION
Sorry for this useless pr but I think it will prevent headaches in the future if simplex noise is implemented too.

The three arguments against I see in #21569 are:
- It's a long name to write.
- Users are more familiar with simplex noise and don't care.
- It can later be replaced internally with simplex noise.

But,
I don't think it's a long name to write, you just write it once anyway
The name is self explainable, it just adds an open to prefix. Users should care, because it's a different algorithm.
It can't be replaced internally with simplex noise later because it will return different values. Also it doesn't have to be replaced, it can be added.

 @Megalomaniak and @Xrayez if you have any objections to that.
@JFonS 

the code example in the anouncement should be changed too https://godotengine.org/article/simplex-noise-lands-godot-31, along with the change from persistance to persistence