### PR TITLE
Fixed scons warning: Ignoring missing 'core/helper/SCsub' after  #22351.

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -117,7 +117,6 @@ SConscript('os/SCsub')
 SConscript('math/SCsub')
 SConscript('io/SCsub')
 SConscript('bind/SCsub')
-SConscript('helper/SCsub')
 
 
 # Build it all as a library


### PR DESCRIPTION
After commit #22351 scons generate warning: Ignoring missing SConscript 'core/helper/SCsub'.