### PR TITLE
Added hover_pressed style to CheckBox and CheckButton

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -360,7 +360,9 @@ BaseButton::DrawMode BaseButton::get_draw_mode() const {
 		return DRAW_DISABLED;
 	};
 
-	if (status.press_attempt == false && status.hovering && !status.pressed) {
+	if (status.press_attempt == false && status.hovering) {
+		if (status.pressed)
+			return DRAW_HOVER_PRESSED;
 
 		return DRAW_HOVER;
 	} else {
@@ -536,6 +538,7 @@ void BaseButton::_bind_methods() {
 	BIND_ENUM_CONSTANT(DRAW_PRESSED);
 	BIND_ENUM_CONSTANT(DRAW_HOVER);
 	BIND_ENUM_CONSTANT(DRAW_DISABLED);
+	BIND_ENUM_CONSTANT(DRAW_HOVER_PRESSED);
 
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_PRESS);
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_RELEASE);

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -85,6 +85,7 @@ public:
 		DRAW_PRESSED,
 		DRAW_HOVER,
 		DRAW_DISABLED,
+		DRAW_HOVER_PRESSED,
 	};
 
 	DrawMode get_draw_mode() const;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -88,6 +88,21 @@ void Button::_notification(int p_what) {
 				if (has_color("icon_color_normal"))
 					color_icon = get_color("icon_color_normal");
 			} break;
+			case DRAW_HOVER_PRESSED: {
+				if (has_stylebox("hover_pressed") && has_stylebox_override("hover_pressed")) {
+					style = get_stylebox("hover_pressed");
+					if (!flat)
+						style->draw(ci, Rect2(Point2(0, 0), size));
+					if (has_color("font_color_hover_pressed"))
+						color = get_color("font_color_hover_pressed");
+					else
+						color = get_color("font_color");
+					if (has_color("icon_color_hover_pressed"))
+						color_icon = get_color("icon_color_hover_pressed");
+
+					break;
+				}
+			}
 			case DRAW_PRESSED: {
 
 				style = get_stylebox("pressed");

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -364,6 +364,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("pressed", "CheckBox", cbx_empty);
 	theme->set_stylebox("disabled", "CheckBox", cbx_empty);
 	theme->set_stylebox("hover", "CheckBox", cbx_empty);
+	theme->set_stylebox("hover_pressed", "CheckBox", cbx_empty);
 	theme->set_stylebox("focus", "CheckBox", cbx_focus);
 
 	theme->set_icon("checked", "CheckBox", make_icon(checked_png));
@@ -376,6 +377,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color", "CheckBox", control_font_color);
 	theme->set_color("font_color_pressed", "CheckBox", control_font_color_pressed);
 	theme->set_color("font_color_hover", "CheckBox", control_font_color_hover);
+	theme->set_color("font_color_hover_pressed", "CheckBox", control_font_color_pressed);
 	theme->set_color("font_color_disabled", "CheckBox", control_font_color_disabled);
 
 	theme->set_constant("hseparation", "CheckBox", 4 * scale);
@@ -393,6 +395,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("pressed", "CheckButton", cb_empty);
 	theme->set_stylebox("disabled", "CheckButton", cb_empty);
 	theme->set_stylebox("hover", "CheckButton", cb_empty);
+	theme->set_stylebox("hover_pressed", "CheckButton", cb_empty);
 	theme->set_stylebox("focus", "CheckButton", focus);
 
 	theme->set_icon("on", "CheckButton", make_icon(toggle_on_png));
@@ -403,6 +406,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color", "CheckButton", control_font_color);
 	theme->set_color("font_color_pressed", "CheckButton", control_font_color_pressed);
 	theme->set_color("font_color_hover", "CheckButton", control_font_color_hover);
+	theme->set_color("font_color_hover_pressed", "CheckButton", control_font_color_pressed);
 	theme->set_color("font_color_disabled", "CheckButton", control_font_color_disabled);
 
 	theme->set_constant("hseparation", "CheckButton", 4 * scale);


### PR DESCRIPTION
Added hover_pressed style to CheckBox and CheckButton.
If no style is defined for this styleit will default to the pressed style.

This fixes #19429