### PR TITLE
Avoid forceful variable names with race

### DIFF
--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -90,7 +90,7 @@
 	</methods>
 	<members>
 		<member name="network_peer" type="NetworkedMultiplayerPeer" setter="set_network_peer" getter="get_network_peer">
-			The peer object to handle the RPC system (effectively enabling networking when set). Depending on the peer itself, the MultiplayerAPI will become a network server (check with [method is_network_server]) and will set root node's network mode to master (see NETWORK_MODE_* constants in [Node]), or it will become a regular peer with root node set to puppet. All child nodes are set to inherit the network mode by default. Handling of networking-related events (connection, disconnection, new clients) is done by connecting to MultiplayerAPI's signals.
+			The peer object to handle the RPC system (effectively enabling networking when set). Depending on the peer itself, the MultiplayerAPI will become a network server (check with [method is_network_server]) and will set root node's network mode to main (see NETWORK_MODE_* constants in [Node]), or it will become a regular peer with root node set to puppet. All child nodes are set to inherit the network mode by default. Handling of networking-related events (connection, disconnection, new clients) is done by connecting to MultiplayerAPI's signals.
 		</member>
 		<member name="refuse_new_network_connections" type="bool" setter="set_refuse_new_network_connections" getter="is_refusing_new_network_connections">
 			If [code]true[/code] the MultiplayerAPI's [member network_peer] refuses new incoming connections.
@@ -141,13 +141,13 @@
 			Used with [method Node.rpc_config] or [method Node.rset_config] to disable a method or property for all RPC calls, making it unavailable. Default for all methods.
 		</constant>
 		<constant name="RPC_MODE_REMOTE" value="1" enum="RPCMode">
-			Used with [method Node.rpc_config] or [method Node.rset_config] to set a method to be called or a property to be changed only on the remote end, not locally. Analogous to the [code]remote[/code] keyword. Calls and property changes are accepted from all remote peers, no matter if they are node's master or puppets.
+			Used with [method Node.rpc_config] or [method Node.rset_config] to set a method to be called or a property to be changed only on the remote end, not locally. Analogous to the [code]remote[/code] keyword. Calls and property changes are accepted from all remote peers, no matter if they are node puppets.
 		</constant>
 		<constant name="RPC_MODE_MASTER" value="2" enum="RPCMode">
-			Used with [method Node.rpc_config] or [method Node.rset_config] to set a method to be called or a property to be changed only on the network master for this node. Analogous to the [code]master[/code] keyword. Only accepts calls or property changes from the node's network puppets, see [method Node.set_network_master].
+			Used with [method Node.rpc_config] or [method Node.rset_config] to set a method to be called or a property to be changed only on the network main for this node. Analogous to the [code]main[/code] keyword. Only accepts calls or property changes from the node's network puppets, see [method Node.set_network_master].
 		</constant>
 		<constant name="RPC_MODE_PUPPET" value="3" enum="RPCMode">
-			Used with [method Node.rpc_config] or [method Node.rset_config] to set a method to be called or a property to be changed only on puppets for this node. Analogous to the [code]puppet[/code] keyword. Only accepts calls or property changes from the node's network master, see [method Node.set_network_master].
+			Used with [method Node.rpc_config] or [method Node.rset_config] to set a method to be called or a property to be changed only on puppets for this node. Analogous to the [code]puppet[/code] keyword. Only accepts calls or property changes from the node's network main, see [method Node.set_network_master].
 		</constant>
 		<constant name="RPC_MODE_SLAVE" value="3" enum="RPCMode">
 			Deprecated. Use [code]RPC_MODE_PUPPET[/code] instead. Analogous to the [code]slave[/code] keyword.

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1264,10 +1264,10 @@ void AnimationPlayerEditor::_onion_skinning_menu(int p_option) {
 			menu->set_item_checked(idx, onion.differences_only);
 		} break;
 
-		case ONION_SKINNING_FORCE_WHITE_MODULATE: {
+		case ONION_SKINNING_is_white_MODULATE: {
 
-			onion.force_white_modulate = !onion.force_white_modulate;
-			menu->set_item_checked(idx, onion.force_white_modulate);
+			onion.is_white_modulate = !onion.is_white_modulate;
+			menu->set_item_checked(idx, onion.is_white_modulate);
 		} break;
 
 		case ONION_SKINNING_INCLUDE_GIZMOS: {
@@ -1460,12 +1460,12 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 	int step_off_a = onion.past ? -onion.steps : 0;
 	int step_off_b = onion.future ? onion.steps : 0;
 	int cidx = 0;
-	onion.capture.material->set_shader_param("dir_color", onion.force_white_modulate ? Color(1, 1, 1) : Color(EDITOR_GET("editors/animation/onion_layers_past_color")));
+	onion.capture.material->set_shader_param("dir_color", onion.is_white_modulate ? Color(1, 1, 1) : Color(EDITOR_GET("editors/animation/onion_layers_past_color")));
 	for (int step_off = step_off_a; step_off <= step_off_b; step_off++) {
 
 		if (step_off == 0) {
 			// Skip present step and switch to the color of future
-			if (!onion.force_white_modulate)
+			if (!onion.is_white_modulate)
 				onion.capture.material->set_shader_param("dir_color", EDITOR_GET("editors/animation/onion_layers_future_color"));
 			continue;
 		}
@@ -1722,7 +1722,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	onion_skinning->get_popup()->add_radio_check_item(TTR("3 steps"), ONION_SKINNING_3_STEPS);
 	onion_skinning->get_popup()->add_separator();
 	onion_skinning->get_popup()->add_check_item(TTR("Differences Only"), ONION_SKINNING_DIFFERENCES_ONLY);
-	onion_skinning->get_popup()->add_check_item(TTR("Force White Modulate"), ONION_SKINNING_FORCE_WHITE_MODULATE);
+	onion_skinning->get_popup()->add_check_item(TTR("Force White Modulate"), ONION_SKINNING_is_white_MODULATE);
 	onion_skinning->get_popup()->add_check_item(TTR("Include Gizmos (3D)"), ONION_SKINNING_INCLUDE_GIZMOS);
 	hb->add_child(onion_skinning);
 
@@ -1813,7 +1813,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	onion.future = false;
 	onion.steps = 1;
 	onion.differences_only = false;
-	onion.force_white_modulate = false;
+	onion.is_white_modulate = false;
 	onion.include_gizmos = false;
 
 	onion.last_frame = 0;


### PR DESCRIPTION
Modified some `onion.force_white` properties to `onion.is_white`. I don't see much need to "force" a variable/property name to be white. Better naming convention would be `is_white` instead. More expressive and less opressive.

Also changed some master to main wording in the `MultiplayerAPI.xml` docs as well. 

Let me know if I missed anything!

