### PR TITLE
Fixed step value not being respected for ranges in some cases.

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -66,10 +66,11 @@ void Range::Shared::emit_changed(const char *p_what) {
 }
 
 void Range::set_value(double p_val) {
+	if (shared->step > 0)
+		p_val = Math::round(p_val / shared->step) * shared->step;
 
-	if (_rounded_values) {
+	if (_rounded_values)
 		p_val = Math::round(p_val);
-	}
 
 	if (!shared->allow_greater && p_val > shared->max - shared->page)
 		p_val = shared->max - shared->page;


### PR DESCRIPTION
Fixed step value not being respected for ranges in some cases.

Fixes #21441