### PR TITLE
Fixed hang when segfaulting after OS object destroyed (OSX and X11)

### DIFF
--- a/platform/osx/crash_handler_osx.mm
+++ b/platform/osx/crash_handler_osx.mm
@@ -68,8 +68,9 @@ static uint64_t load_address() {
 }
 
 static void handle_crash(int sig) {
-	if (OS::get_singleton() == NULL)
-		return;
+	if (OS::get_singleton() == NULL) {
+		abort();
+	}
 
 	void *bt_buffer[256];
 	size_t size = backtrace(bt_buffer, 256);
@@ -151,6 +152,7 @@ CrashHandler::CrashHandler() {
 }
 
 CrashHandler::~CrashHandler() {
+	disable();
 }
 
 void CrashHandler::disable() {

--- a/platform/x11/crash_handler_x11.cpp
+++ b/platform/x11/crash_handler_x11.cpp
@@ -45,8 +45,9 @@
 #include <stdlib.h>
 
 static void handle_crash(int sig) {
-	if (OS::get_singleton() == NULL)
-		return;
+	if (OS::get_singleton() == NULL) {
+		abort();
+	}
 
 	void *bt_buffer[256];
 	size_t size = backtrace(bt_buffer, 256);
@@ -119,6 +120,7 @@ CrashHandler::CrashHandler() {
 }
 
 CrashHandler::~CrashHandler() {
+	disable();
 }
 
 void CrashHandler::disable() {


### PR DESCRIPTION
The two POSIX style crash handlers (OSX and X11) now remove their signal
handlers when they are destroyed.
Additonally if they are called while no OS singleton is set, they will
simply abort(). This should not happen now that they remove themselves,
but if a future change seperates OS object and crash handler lifetimes,
this may be easier to report/debug than hanging on SIGSEGV.