### PR TITLE
Server platform builds (dummy) mobile_vr module.

### DIFF
--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -297,6 +297,7 @@ bool MobileVRInterface::initialize() {
 		mag_current_min = Vector3(0, 0, 0);
 		mag_current_max = Vector3(0, 0, 0);
 
+#if !defined(SERVER_ENABLED)
 		// build our shader
 		if (lens_shader == NULL) {
 			///@TODO need to switch between GLES2 and GLES3 version, Reduz suggested moving this into our drivers and making this a core shader
@@ -337,6 +338,7 @@ bool MobileVRInterface::initialize() {
 			glBindVertexArray(0);
 			glBindBuffer(GL_ARRAY_BUFFER, 0); //unbind
 		}
+#endif
 
 		// reset our orientation
 		orientation = Basis();
@@ -360,6 +362,7 @@ void MobileVRInterface::uninitialize() {
 			arvr_server->clear_primary_interface_if(this);
 		}
 
+#if !defined(SERVER_ENABLED)
 		// cleanup our shader and buffers
 		if (lens_shader != NULL) {
 			glDeleteVertexArrays(1, &half_screen_array);
@@ -368,6 +371,7 @@ void MobileVRInterface::uninitialize() {
 			delete lens_shader;
 			lens_shader = NULL;
 		}
+#endif
 
 		initialized = false;
 	};
@@ -470,6 +474,7 @@ void MobileVRInterface::commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_t
 	// get our render target
 	RID eye_texture = VSG::storage->render_target_get_texture(p_render_target);
 	uint32_t texid = VS::get_singleton()->texture_get_texid(eye_texture);
+#if !defined(SERVER_ENABLED)
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, texid);
 
@@ -484,6 +489,7 @@ void MobileVRInterface::commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_t
 	glBindVertexArray(half_screen_array);
 	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 	glBindVertexArray(0);
+#endif
 };
 
 void MobileVRInterface::process() {

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -34,7 +34,9 @@
 #include "servers/arvr/arvr_interface.h"
 #include "servers/arvr/arvr_positional_tracker.h"
 
+#if !defined(SERVER_ENABLED)
 #include "shaders/lens_distorted.glsl.gen.h"
+#endif
 
 /**
 	@author Bastiaan Olij <mux213@gmail.com>
@@ -58,9 +60,13 @@ private:
 	float eye_height;
 	uint64_t last_ticks;
 
+#if !defined(SERVER_ENABLED)
 	LensDistortedShaderGLES3 *lens_shader;
 	GLuint half_screen_quad;
 	GLuint half_screen_array;
+#else
+	void *lens_shader;
+#endif
 
 	real_t intraocular_dist;
 	real_t display_width;

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -29,9 +29,7 @@ def get_opts():
 
 def get_flags():
 
-    return [
-            ("module_mobile_vr_enabled", False),
-    ]
+    return []
 
 
 def configure(env):


### PR DESCRIPTION
Protect GL functions in mobile_vr with ifdefs.

As mentioned by @neikeq in https://github.com/godotengine/godot/pull/16653#discussion_r219901324 not building the `mobile_vr` causes issues with `C#`.
I think the exported game GDScript byte-code might be different because of the different numbers of bounded classes/methods.

I'm not sure this is the best way to do it. I don't like too much having ifdefs in the code.

@BastiaanOlij maybe we could move the functions that use GL into a separate file? So we could just ifdef that file and mock it. (should be just 3, initialize (shader), uninitialize (shader), commit_for_eye (GL part) )