### PR TITLE
Use monotonic clock for get_ticks_usec

### DIFF
--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -42,8 +42,6 @@
 
 class OS_Unix : public OS {
 
-	uint64_t ticks_start;
-
 protected:
 	// UNIX only handles the core functions.
 	// inheriting platforms under unix (eg. X11) should handle the rest


### PR DESCRIPTION
Fix `get_ticks_usec`/`get_ticks_msec` on Unix systems.

Use `clock_get_time` on Unix. (`CLOCK_MONOTONIC_RAW` on Linux, `CLOCK_MONOTONIC` on other systems).
Use `mach_absolute_time` where `__APPLE__` is defined (should be OSX and iPhone).
Windows is unaffected, but should also be unaffected by the issue itself because it uses `QueryPerformanceCounter`.

It compiles for Mac, but I need someone to test it, because I don't have a Mac (cross compiles fine, but need to check if it actually works as expected... it should!),

Some references:
https://hg.libsdl.org/SDL/file/b504b29c3831/src/timer/unix/SDL_systimer.c
https://github.com/ThomasHabets/monotonic_clock

Closes #19393 
*Bugsquad edit:* Fixes #22041.

EDIT: How to test? Run your game, and let it print delta time in frames. Send your system clock back in time of few hours.
The `delta` time should be unaffected (instead of starting to be negative like it does without this patch)