### PR TITLE
Better MultiplayerAPI error messages.

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -38,20 +38,23 @@ _FORCE_INLINE_ bool _should_call_local(MultiplayerAPI::RPCMode mode, bool is_mas
 	switch (mode) {
 
 		case MultiplayerAPI::RPC_MODE_DISABLED: {
-			//do nothing
+			// Do nothing.
 		} break;
 		case MultiplayerAPI::RPC_MODE_REMOTE: {
-			//do nothing also, no need to call local
+			// Do nothing also. Remote cannot produce a local call.
 		} break;
+		case MultiplayerAPI::RPC_MODE_MASTERSYNC: {
+			if (is_master)
+				r_skip_rpc = true; // I am the master, so skip remote call.
+		} // Do not break, fall over to other sync.
 		case MultiplayerAPI::RPC_MODE_REMOTESYNC:
-		case MultiplayerAPI::RPC_MODE_MASTERSYNC:
 		case MultiplayerAPI::RPC_MODE_PUPPETSYNC: {
-			//call it, sync always results in call
+			// Call it, sync always results in a local call.
 			return true;
 		} break;
 		case MultiplayerAPI::RPC_MODE_MASTER: {
 			if (is_master)
-				r_skip_rpc = true; //no other master so..
+				r_skip_rpc = true; // I am the master, so skip remote call.
 			return is_master;
 		} break;
 		case MultiplayerAPI::RPC_MODE_PUPPET: {

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -94,7 +94,7 @@ void MultiplayerAPI::poll() {
 
 	network_peer->poll();
 
-	if (!network_peer.is_valid()) //it's possible that polling might have resulted in a disconnection, so check here
+	if (!network_peer.is_valid()) // It's possible that polling might have resulted in a disconnection, so check here.
 		return;
 
 	while (network_peer->get_available_packet_count()) {
@@ -113,7 +113,7 @@ void MultiplayerAPI::poll() {
 		rpc_sender_id = 0;
 
 		if (!network_peer.is_valid()) {
-			break; //it's also possible that a packet or RPC caused a disconnection, so also check here
+			break; // It's also possible that a packet or RPC caused a disconnection, so also check here.
 		}
 	}
 }
@@ -160,7 +160,9 @@ Ref<NetworkedMultiplayerPeer> MultiplayerAPI::get_network_peer() const {
 
 void MultiplayerAPI::_process_packet(int p_from, const uint8_t *p_packet, int p_packet_len) {
 
+	ERR_EXPLAIN("Multiplayer root node was not initialized. If you are using custom multiplayer, remember to set the root node via MultiplayerAPI.set_root_node before using it");
 	ERR_FAIL_COND(root_node == NULL);
+	ERR_EXPLAIN("Invalid packet received. Size too small.");
 	ERR_FAIL_COND(p_packet_len < 1);
 
 	uint8_t packet_type = p_packet[0];
@@ -180,13 +182,15 @@ void MultiplayerAPI::_process_packet(int p_from, const uint8_t *p_packet, int p_
 		case NETWORK_COMMAND_REMOTE_CALL:
 		case NETWORK_COMMAND_REMOTE_SET: {
 
+			ERR_EXPLAIN("Invalid packet received. Size too small.");
 			ERR_FAIL_COND(p_packet_len < 6);
 
 			Node *node = _process_get_node(p_from, p_packet, p_packet_len);
 
+			ERR_EXPLAIN("Invalid packet received. Requested node was not found.");
 			ERR_FAIL_COND(node == NULL);
 
-			//detect cstring end
+			// Detect cstring end.
 			int len_end = 5;
 			for (; len_end < p_packet_len; len_end++) {
 				if (p_packet[len_end] == 0) {
@@ -194,6 +198,7 @@ void MultiplayerAPI::_process_packet(int p_from, const uint8_t *p_packet, int p_
 				}
 			}
 
+			ERR_EXPLAIN("Invalid packet received. Size too small.");
 			ERR_FAIL_COND(len_end >= p_packet_len);
 
 			StringName name = String::utf8((const char *)&p_packet[5]);
@@ -222,9 +227,11 @@ Node *MultiplayerAPI::_process_get_node(int p_from, const uint8_t *p_packet, int
 	Node *node = NULL;
 
 	if (target & 0x80000000) {
-		//use full path (not cached yet)
+		// Use full path (not cached yet).
 
 		int ofs = target & 0x7FFFFFFF;
+
+		ERR_EXPLAIN("Invalid packet received. Size smaller than declared.");
 		ERR_FAIL_COND_V(ofs >= p_packet_len, NULL);
 
 		String paths;
@@ -237,17 +244,19 @@ Node *MultiplayerAPI::_process_get_node(int p_from, const uint8_t *p_packet, int
 		if (!node)
 			ERR_PRINTS("Failed to get path from RPC: " + String(np));
 	} else {
-		//use cached path
+		// Use cached path.
 		int id = target;
 
 		Map<int, PathGetCache>::Element *E = path_get_cache.find(p_from);
+		ERR_EXPLAIN("Invalid packet received. Requests invalid peer cache.");
 		ERR_FAIL_COND_V(!E, NULL);
 
 		Map<int, PathGetCache::NodeInfo>::Element *F = E->get().nodes.find(id);
+		ERR_EXPLAIN("Invalid packet received. Unabled to find requested cached node.");
 		ERR_FAIL_COND_V(!F, NULL);
 
 		PathGetCache::NodeInfo *ni = &F->get();
-		//do proper caching later
+		// Do proper caching later.
 
 		node = root_node->get_node(ni->path);
 		if (!node)
@@ -258,9 +267,10 @@ Node *MultiplayerAPI::_process_get_node(int p_from, const uint8_t *p_packet, int
 
 void MultiplayerAPI::_process_rpc(Node *p_node, const StringName &p_name, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset) {
 
+	ERR_EXPLAIN("Invalid packet received. Size too small.");
 	ERR_FAIL_COND(p_offset >= p_packet_len);
 
-	// Check that remote can call the RPC on this node
+	// Check that remote can call the RPC on this node.
 	RPCMode rpc_mode = RPC_MODE_DISABLED;
 	const Map<StringName, RPCMode>::Element *E = p_node->get_node_rpc_mode(p_name);
 	if (E) {
@@ -268,6 +278,8 @@ void MultiplayerAPI::_process_rpc(Node *p_node, const StringName &p_name, int p_
 	} else if (p_node->get_script_instance()) {
 		rpc_mode = p_node->get_script_instance()->get_rpc_mode(p_name);
 	}
+
+	ERR_EXPLAIN("RPC '" + String(p_name) + "' is not allowed from: " + itos(p_from) + ". Mode is " + itos((int)rpc_mode) + ", master is " + itos(p_node->get_network_master()) + ".");
 	ERR_FAIL_COND(!_can_call_mode(p_node, rpc_mode, p_from));
 
 	int argc = p_packet[p_offset];
@@ -280,11 +292,14 @@ void MultiplayerAPI::_process_rpc(Node *p_node, const StringName &p_name, int p_
 
 	for (int i = 0; i < argc; i++) {
 
+		ERR_EXPLAIN("Invalid packet received. Size too small.");
 		ERR_FAIL_COND(p_offset >= p_packet_len);
+
 		int vlen;
 		Error err = decode_variant(args.write[i], &p_packet[p_offset], p_packet_len - p_offset, &vlen);
+		ERR_EXPLAIN("Invalid packet received. Unable to decode RPC argument.");
 		ERR_FAIL_COND(err != OK);
-		//args[i]=p_packet[3+i];
+
 		argp.write[i] = &args[i];
 		p_offset += vlen;
 	}
@@ -301,9 +316,10 @@ void MultiplayerAPI::_process_rpc(Node *p_node, const StringName &p_name, int p_
 
 void MultiplayerAPI::_process_rset(Node *p_node, const StringName &p_name, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset) {
 
+	ERR_EXPLAIN("Invalid packet received. Size too small.");
 	ERR_FAIL_COND(p_offset >= p_packet_len);
 
-	// Check that remote can call the RSET on this node
+	// Check that remote can call the RSET on this node.
 	RPCMode rset_mode = RPC_MODE_DISABLED;
 	const Map<StringName, RPCMode>::Element *E = p_node->get_node_rset_mode(p_name);
 	if (E) {
@@ -311,10 +327,15 @@ void MultiplayerAPI::_process_rset(Node *p_node, const StringName &p_name, int p
 	} else if (p_node->get_script_instance()) {
 		rset_mode = p_node->get_script_instance()->get_rset_mode(p_name);
 	}
+
+	ERR_EXPLAIN("RSET '" + String(p_name) + "' is not allowed from: " + itos(p_from) + ". Mode is " + itos((int)rset_mode) + ", master is " + itos(p_node->get_network_master()) + ".");
 	ERR_FAIL_COND(!_can_call_mode(p_node, rset_mode, p_from));
 
 	Variant value;
-	decode_variant(value, &p_packet[p_offset], p_packet_len - p_offset);
+	Error err = decode_variant(value, &p_packet[p_offset], p_packet_len - p_offset);
+
+	ERR_EXPLAIN("Invalid packet received. Unable to decode RSET value.");
+	ERR_FAIL_COND(err != OK);
 
 	bool valid;
 
@@ -327,6 +348,7 @@ void MultiplayerAPI::_process_rset(Node *p_node, const StringName &p_name, int p
 
 void MultiplayerAPI::_process_simplify_path(int p_from, const uint8_t *p_packet, int p_packet_len) {
 
+	ERR_EXPLAIN("Invalid packet received. Size too small.");
 	ERR_FAIL_COND(p_packet_len < 5);
 	int id = decode_uint32(&p_packet[1]);
 
@@ -345,9 +367,7 @@ void MultiplayerAPI::_process_simplify_path(int p_from, const uint8_t *p_packet,
 
 	path_get_cache[p_from].nodes[id] = ni;
 
-	//send ack
-
-	//encode path
+	// Encode path to send ack.
 	CharString pname = String(path).utf8();
 	int len = encode_cstring(pname.get_data(), NULL);
 
@@ -364,6 +384,7 @@ void MultiplayerAPI::_process_simplify_path(int p_from, const uint8_t *p_packet,
 
 void MultiplayerAPI::_process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len) {
 
+	ERR_EXPLAIN("Invalid packet received. Size too small.");
 	ERR_FAIL_COND(p_packet_len < 2);
 
 	String paths;
@@ -372,31 +393,33 @@ void MultiplayerAPI::_process_confirm_path(int p_from, const uint8_t *p_packet, 
 	NodePath path = paths;
 
 	PathSentCache *psc = path_send_cache.getptr(path);
+	ERR_EXPLAIN("Invalid packet received. Tries to confirm a path which was not found in cache.");
 	ERR_FAIL_COND(!psc);
 
 	Map<int, bool>::Element *E = psc->confirmed_peers.find(p_from);
+	ERR_EXPLAIN("Invalid packet received. Source peer was not found in cache for the given path.");
 	ERR_FAIL_COND(!E);
 	E->get() = true;
 }
 
 bool MultiplayerAPI::_send_confirm_path(NodePath p_path, PathSentCache *psc, int p_target) {
 	bool has_all_peers = true;
-	List<int> peers_to_add; //if one is missing, take note to add it
+	List<int> peers_to_add; // If one is missing, take note to add it.
 
 	for (Set<int>::Element *E = connected_peers.front(); E; E = E->next()) {
 
 		if (p_target < 0 && E->get() == -p_target)
-			continue; //continue, excluded
+			continue; // Continue, excluded.
 
 		if (p_target > 0 && E->get() != p_target)
-			continue; //continue, not for this peer
+			continue; // Continue, not for this peer.
 
 		Map<int, bool>::Element *F = psc->confirmed_peers.find(E->get());
 
 		if (!F || F->get() == false) {
-			//path was not cached, or was cached but is unconfirmed
+			// Path was not cached, or was cached but is unconfirmed.
 			if (!F) {
-				//not cached at all, take note
+				// Not cached at all, take note.
 				peers_to_add.push_back(E->get());
 			}
 
@@ -404,11 +427,11 @@ bool MultiplayerAPI::_send_confirm_path(NodePath p_path, PathSentCache *psc, int
 		}
 	}
 
-	//those that need to be added, send a message for this
+	// Those that need to be added, send a message for this.
 
 	for (List<int>::Element *E = peers_to_add.front(); E; E = E->next()) {
 
-		//encode function name
+		// Encode function name.
 		CharString pname = String(p_path).utf8();
 		int len = encode_cstring(pname.get_data(), NULL);
 
@@ -419,11 +442,11 @@ bool MultiplayerAPI::_send_confirm_path(NodePath p_path, PathSentCache *psc, int
 		encode_uint32(psc->id, &packet.write[1]);
 		encode_cstring(pname.get_data(), &packet.write[5]);
 
-		network_peer->set_target_peer(E->get()); //to all of you
+		network_peer->set_target_peer(E->get()); // To all of you.
 		network_peer->set_transfer_mode(NetworkedMultiplayerPeer::TRANSFER_MODE_RELIABLE);
 		network_peer->put_packet(packet.ptr(), packet.size());
 
-		psc->confirmed_peers.insert(E->get(), false); //insert into confirmed, but as false since it was not confirmed
+		psc->confirmed_peers.insert(E->get(), false); // Insert into confirmed, but as false since it was not confirmed.
 	}
 
 	return has_all_peers;
@@ -462,35 +485,36 @@ void MultiplayerAPI::_send_rpc(Node *p_from, int p_to, bool p_unreliable, bool p
 	}
 
 	NodePath from_path = (root_node->get_path()).rel_path_to(p_from->get_path());
+	ERR_EXPLAIN("Unable to send RPC. Relative path is empty. THIS IS LIKELY A BUG IN THE ENGINE!");
 	ERR_FAIL_COND(from_path.is_empty());
 
-	//see if the path is cached
+	// See if the path is cached.
 	PathSentCache *psc = path_send_cache.getptr(from_path);
 	if (!psc) {
-		//path is not cached, create
+		// Path is not cached, create.
 		path_send_cache[from_path] = PathSentCache();
 		psc = path_send_cache.getptr(from_path);
 		psc->id = last_send_cache_id++;
 	}
 
-	//create base packet, lots of hardcode because it must be tight
+	// Create base packet, lots of hardcode because it must be tight.
 
 	int ofs = 0;
 
 #define MAKE_ROOM(m_amount) \
 	if (packet_cache.size() < m_amount) packet_cache.resize(m_amount);
 
-	//encode type
+	// Encode type.
 	MAKE_ROOM(1);
 	packet_cache.write[0] = p_set ? NETWORK_COMMAND_REMOTE_SET : NETWORK_COMMAND_REMOTE_CALL;
 	ofs += 1;
 
-	//encode ID
+	// Encode ID.
 	MAKE_ROOM(ofs + 4);
 	encode_uint32(psc->id, &(packet_cache.write[ofs]));
 	ofs += 4;
 
-	//encode function name
+	// Encode function name.
 	CharString name = String(p_name).utf8();
 	int len = encode_cstring(name.get_data(), NULL);
 	MAKE_ROOM(ofs + len);
@@ -498,20 +522,22 @@ void MultiplayerAPI::_send_rpc(Node *p_from, int p_to, bool p_unreliable, bool p
 	ofs += len;
 
 	if (p_set) {
-		//set argument
+		// Set argument.
 		Error err = encode_variant(*p_arg[0], NULL, len);
+		ERR_EXPLAIN("Unable to encode RSET value. THIS IS LIKELY A BUG IN THE ENGINE!");
 		ERR_FAIL_COND(err != OK);
 		MAKE_ROOM(ofs + len);
 		encode_variant(*p_arg[0], &(packet_cache.write[ofs]), len);
 		ofs += len;
 
 	} else {
-		//call arguments
+		// Call arguments.
 		MAKE_ROOM(ofs + 1);
 		packet_cache.write[ofs] = p_argcount;
 		ofs += 1;
 		for (int i = 0; i < p_argcount; i++) {
 			Error err = encode_variant(*p_arg[i], NULL, len);
+			ERR_EXPLAIN("Unable to encode RPC argument. THIS IS LIKELY A BUG IN THE ENGINE!");
 			ERR_FAIL_COND(err != OK);
 			MAKE_ROOM(ofs + len);
 			encode_variant(*p_arg[i], &(packet_cache.write[ofs]), len);
@@ -519,21 +545,21 @@ void MultiplayerAPI::_send_rpc(Node *p_from, int p_to, bool p_unreliable, bool p
 		}
 	}
 
-	//see if all peers have cached path (is so, call can be fast)
+	// See if all peers have cached path (is so, call can be fast).
 	bool has_all_peers = _send_confirm_path(from_path, psc, p_to);
 
-	//take chance and set transfer mode, since all send methods will use it
+	// Take chance and set transfer mode, since all send methods will use it.
 	network_peer->set_transfer_mode(p_unreliable ? NetworkedMultiplayerPeer::TRANSFER_MODE_UNRELIABLE : NetworkedMultiplayerPeer::TRANSFER_MODE_RELIABLE);
 
 	if (has_all_peers) {
 
-		//they all have verified paths, so send fast
-		network_peer->set_target_peer(p_to); //to all of you
-		network_peer->put_packet(packet_cache.ptr(), ofs); //a message with love
+		// They all have verified paths, so send fast.
+		network_peer->set_target_peer(p_to); // To all of you.
+		network_peer->put_packet(packet_cache.ptr(), ofs); // A message with love.
 	} else {
-		//not all verified path, so send one by one
+		// Not all verified path, so send one by one.
 
-		//apend path at the end, since we will need it for some packets
+		// Append path at the end, since we will need it for some packets.
 		CharString pname = String(from_path).utf8();
 		int path_len = encode_cstring(pname.get_data(), NULL);
 		MAKE_ROOM(ofs + path_len);
@@ -542,23 +568,23 @@ void MultiplayerAPI::_send_rpc(Node *p_from, int p_to, bool p_unreliable, bool p
 		for (Set<int>::Element *E = connected_peers.front(); E; E = E->next()) {
 
 			if (p_to < 0 && E->get() == -p_to)
-				continue; //continue, excluded
+				continue; // Continue, excluded.
 
 			if (p_to > 0 && E->get() != p_to)
-				continue; //continue, not for this peer
+				continue; // Continue, not for this peer.
 
 			Map<int, bool>::Element *F = psc->confirmed_peers.find(E->get());
-			ERR_CONTINUE(!F); //should never happen
+			ERR_CONTINUE(!F); // Should never happen.
 
-			network_peer->set_target_peer(E->get()); //to this one specifically
+			network_peer->set_target_peer(E->get()); // To this one specifically.
 
 			if (F->get() == true) {
-				//this one confirmed path, so use id
+				// This one confirmed path, so use id.
 				encode_uint32(psc->id, &(packet_cache.write[1]));
 				network_peer->put_packet(packet_cache.ptr(), ofs);
 			} else {
-				//this one did not confirm path yet, so use entire path (sorry!)
-				encode_uint32(0x80000000 | ofs, &(packet_cache.write[1])); //offset to path and flag
+				// This one did not confirm path yet, so use entire path (sorry!).
+				encode_uint32(0x80000000 | ofs, &(packet_cache.write[1])); // Offset to path and flag.
 				network_peer->put_packet(packet_cache.ptr(), ofs + path_len);
 			}
 		}
@@ -573,7 +599,7 @@ void MultiplayerAPI::_add_peer(int p_id) {
 
 void MultiplayerAPI::_del_peer(int p_id) {
 	connected_peers.erase(p_id);
-	path_get_cache.erase(p_id); //I no longer need your cache, sorry
+	path_get_cache.erase(p_id); // I no longer need your cache, sorry.
 	emit_signal("network_peer_disconnected", p_id);
 }
 
@@ -594,8 +620,12 @@ void MultiplayerAPI::_server_disconnected() {
 
 void MultiplayerAPI::rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const StringName &p_method, const Variant **p_arg, int p_argcount) {
 
-	ERR_FAIL_COND(!p_node->is_inside_tree());
+	ERR_EXPLAIN("Trying to call an RPC while no network peer is active.");
 	ERR_FAIL_COND(!network_peer.is_valid());
+	ERR_EXPLAIN("Trying to call an RPC on a node which is not inside SceneTree.");
+	ERR_FAIL_COND(!p_node->is_inside_tree());
+	ERR_EXPLAIN("Trying to call an RPC via a network peer which is not connected.");
+	ERR_FAIL_COND(network_peer->get_connection_status() != NetworkedMultiplayerPeer::CONNECTION_CONNECTED);
 
 	int node_id = network_peer->get_unique_id();
 	bool skip_rpc = false;
@@ -604,7 +634,7 @@ void MultiplayerAPI::rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const 
 	bool is_master = p_node->is_network_master();
 
 	if (p_peer_id == 0 || p_peer_id == node_id || (p_peer_id < 0 && p_peer_id != -node_id)) {
-		//check that send mode can use local call
+		// Check that send mode can use local call.
 
 		const Map<StringName, RPCMode>::Element *E = p_node->get_node_rpc_mode(p_method);
 		if (E) {
@@ -612,9 +642,9 @@ void MultiplayerAPI::rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const 
 		}
 
 		if (call_local_native) {
-			// done below
+			// Done below.
 		} else if (p_node->get_script_instance()) {
-			//attempt with script
+			// Attempt with script.
 			RPCMode rpc_mode = p_node->get_script_instance()->get_rpc_mode(p_method);
 			call_local_script = _should_call_local(rpc_mode, is_master, skip_rpc);
 		}
@@ -650,15 +680,19 @@ void MultiplayerAPI::rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const 
 
 void MultiplayerAPI::rsetp(Node *p_node, int p_peer_id, bool p_unreliable, const StringName &p_property, const Variant &p_value) {
 
-	ERR_FAIL_COND(!p_node->is_inside_tree());
+	ERR_EXPLAIN("Trying to RSET while no network peer is active.");
 	ERR_FAIL_COND(!network_peer.is_valid());
+	ERR_EXPLAIN("Trying to RSET on a node which is not inside SceneTree.");
+	ERR_FAIL_COND(!p_node->is_inside_tree());
+	ERR_EXPLAIN("Trying to send an RSET via a network peer which is not connected.");
+	ERR_FAIL_COND(network_peer->get_connection_status() != NetworkedMultiplayerPeer::CONNECTION_CONNECTED);
 
 	int node_id = network_peer->get_unique_id();
 	bool is_master = p_node->is_network_master();
 	bool skip_rset = false;
 
 	if (p_peer_id == 0 || p_peer_id == node_id || (p_peer_id < 0 && p_peer_id != -node_id)) {
-		//check that send mode can use local call
+		// Check that send mode can use local call.
 
 		bool set_local = false;
 
@@ -678,7 +712,7 @@ void MultiplayerAPI::rsetp(Node *p_node, int p_peer_id, bool p_unreliable, const
 				return;
 			}
 		} else if (p_node->get_script_instance()) {
-			//attempt with script
+			// Attempt with script.
 			RPCMode rpc_mode = p_node->get_script_instance()->get_rset_mode(p_property);
 
 			set_local = _should_call_local(rpc_mode, is_master, skip_rset);
@@ -706,8 +740,11 @@ void MultiplayerAPI::rsetp(Node *p_node, int p_peer_id, bool p_unreliable, const
 
 Error MultiplayerAPI::send_bytes(PoolVector<uint8_t> p_data, int p_to, NetworkedMultiplayerPeer::TransferMode p_mode) {
 
+	ERR_EXPLAIN("Trying to send an empty raw packet.");
 	ERR_FAIL_COND_V(p_data.size() < 1, ERR_INVALID_DATA);
+	ERR_EXPLAIN("Trying to send a raw packet while no network peer is active.");
 	ERR_FAIL_COND_V(!network_peer.is_valid(), ERR_UNCONFIGURED);
+	ERR_EXPLAIN("Trying to send a raw packet via a network peer which is not connected.");
 	ERR_FAIL_COND_V(network_peer->get_connection_status() != NetworkedMultiplayerPeer::CONNECTION_CONNECTED, ERR_UNCONFIGURED);
 
 	MAKE_ROOM(p_data.size() + 1);
@@ -723,6 +760,7 @@ Error MultiplayerAPI::send_bytes(PoolVector<uint8_t> p_data, int p_to, Networked
 
 void MultiplayerAPI::_process_raw(int p_from, const uint8_t *p_packet, int p_packet_len) {
 
+	ERR_EXPLAIN("Invalid packet received. Size too small.");
 	ERR_FAIL_COND(p_packet_len < 2);
 
 	PoolVector<uint8_t> out;
@@ -737,30 +775,36 @@ void MultiplayerAPI::_process_raw(int p_from, const uint8_t *p_packet, int p_pac
 
 int MultiplayerAPI::get_network_unique_id() const {
 
+	ERR_EXPLAIN("No network peer is assigned. Unable to get unique network ID.");
 	ERR_FAIL_COND_V(!network_peer.is_valid(), 0);
 	return network_peer->get_unique_id();
 }
 
 bool MultiplayerAPI::is_network_server() const {
 
+	// XXX Maybe fail silently? Maybe should actually return true to make development of both local and online multiplayer easier?
+	ERR_EXPLAIN("No network peer is assigned. I can't be a server.");
 	ERR_FAIL_COND_V(!network_peer.is_valid(), false);
 	return network_peer->is_server();
 }
 
 void MultiplayerAPI::set_refuse_new_network_connections(bool p_refuse) {
 
+	ERR_EXPLAIN("No network peer is assigned. Unable to set 'refuse_new_connections'.");
 	ERR_FAIL_COND(!network_peer.is_valid());
 	network_peer->set_refuse_new_connections(p_refuse);
 }
 
 bool MultiplayerAPI::is_refusing_new_network_connections() const {
 
+	ERR_EXPLAIN("No network peer is assigned. Unable to get 'refuse_new_connections'.");
 	ERR_FAIL_COND_V(!network_peer.is_valid(), false);
 	return network_peer->is_refusing_new_connections();
 }
 
 Vector<int> MultiplayerAPI::get_network_connected_peers() const {
 
+	ERR_EXPLAIN("No network peer is assigned. Assume no peers are connected.");
 	ERR_FAIL_COND_V(!network_peer.is_valid(), Vector<int>());
 
 	Vector<int> ret;
@@ -805,9 +849,9 @@ void MultiplayerAPI::_bind_methods() {
 	BIND_ENUM_CONSTANT(RPC_MODE_REMOTE);
 	BIND_ENUM_CONSTANT(RPC_MODE_MASTER);
 	BIND_ENUM_CONSTANT(RPC_MODE_PUPPET);
-	BIND_ENUM_CONSTANT(RPC_MODE_SLAVE); // deprecated
+	BIND_ENUM_CONSTANT(RPC_MODE_SLAVE); // Deprecated.
 	BIND_ENUM_CONSTANT(RPC_MODE_REMOTESYNC);
-	BIND_ENUM_CONSTANT(RPC_MODE_SYNC); // deprecated
+	BIND_ENUM_CONSTANT(RPC_MODE_SYNC); // Deprecated.
 	BIND_ENUM_CONSTANT(RPC_MODE_MASTERSYNC);
 	BIND_ENUM_CONSTANT(RPC_MODE_PUPPETSYNC);
 }


### PR DESCRIPTION
Possibly closes #22318 . @mhilbrunner ?

Also add a small optimization when calling a `mastersync` RPC/RSET from the master itself (will now skip the remote call, as there can only be one master).