### PR TITLE
Add a warning when changing project settings version

### DIFF
--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -97,7 +97,7 @@ protected:
 
 	static ProjectSettings *singleton;
 
-	Error _load_settings_text(const String p_path);
+	Error _load_settings_text(const String p_path, int *p_retrieve_version = NULL);
 	Error _load_settings_binary(const String p_path);
 	Error _load_settings_text_or_binary(const String p_text_path, const String p_bin_path);
 
@@ -106,7 +106,7 @@ protected:
 
 	Error _save_custom_bnd(const String &p_file);
 
-	void _convert_to_last_version();
+	void _convert_to_last_version(int p_from_version);
 
 	bool _load_resource_pack(const String &p_pack);
 
@@ -138,6 +138,9 @@ public:
 	void set_builtin_order(const String &p_name);
 
 	Error setup(const String &p_path, const String &p_main_pack, bool p_upwards = false);
+
+	bool is_settings_text_up_to_date();
+	bool is_settings_text_up_to_date_custom(const String &p_path);
 
 	Error save_custom(const String &p_path = "", const CustomMap &p_custom = CustomMap(), const Vector<String> &p_custom_features = Vector<String>(), bool p_merge_with_current = true);
 	Error save();

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -60,6 +60,7 @@ class ProjectManager : public Control {
 	ConfirmationDialog *multi_open_ask;
 	ConfirmationDialog *multi_run_ask;
 	ConfirmationDialog *multi_scan_ask;
+	ConfirmationDialog *ask_update_settings;
 	AcceptDialog *run_error_diag;
 	AcceptDialog *dialog_error;
 	ProjectDialog *npdialog;
@@ -83,8 +84,8 @@ class ProjectManager : public Control {
 	void _scan_projects();
 	void _run_project();
 	void _run_project_confirm();
-	void _open_project();
-	void _open_project_confirm();
+	void _open_selected_projects();
+	void _open_selected_projects_ask();
 	void _show_project(const String &p_path);
 	void _import_project();
 	void _new_project();
@@ -96,6 +97,12 @@ class ProjectManager : public Control {
 	void _restart_confirm();
 	void _exit_dialog();
 	void _scan_begin(const String &p_base);
+
+	struct {
+		ProjectSettings *project_settings;
+		String path;
+	} confirm_update_settings_args;
+	void _confirm_update_settings();
 
 	void _load_recent_projects();
 	void _on_project_created(const String &dir);


### PR DESCRIPTION
Closes #20626
![2018-09-26-181329_789x180_scrot](https://user-images.githubusercontent.com/6093119/46093541-e29e4800-c1b7-11e8-855e-d52360df6fc6.png)

Note that the warning is only displayed when the project is loaded from the project manager. Outside the project manager, `main.cpp` transparently loads the project settings from the different possibilities (text, binary, network, etc...). Adding the support for a warning would have needed a bunch of workarounds for a really corner-case situation.