### PR TITLE
Hide shading options in SpatialMaterial when 'FLAG_UNSHADED' is set.

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1313,7 +1313,7 @@ void SpatialMaterial::set_flag(Flags p_flag, bool p_enabled) {
 		return;
 
 	flags[p_flag] = p_enabled;
-	if (p_flag == FLAG_USE_ALPHA_SCISSOR) {
+	if (p_flag == FLAG_USE_ALPHA_SCISSOR || p_flag == FLAG_UNSHADED) {
 		_change_notify();
 	}
 	_queue_shader_change();
@@ -1406,6 +1406,48 @@ void SpatialMaterial::_validate_property(PropertyInfo &property) const {
 
 	if ((property.name == "depth_min_layers" || property.name == "depth_max_layers") && !deep_parallax) {
 		property.usage = 0;
+	}
+
+	if (flags[FLAG_UNSHADED]) {
+		if (property.name.begins_with("anisotropy")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("ao")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("clearcoat")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("emission")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("metallic")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("normal")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("rim")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("roughness")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("subsurf_scatter")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("transmission")) {
+			property.usage = 0;
+		}
 	}
 }
 


### PR DESCRIPTION
This is to implement #10480.

The "refraction" property is not hidden, as it affects the shadow cast by an object, even when it is unshaded.

*Bugsquad edit:* Fixes #10480.