### PR TITLE
Added new scaling modes to splash screen

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -196,15 +196,15 @@
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color(0.14, 0.14, 0.14, 1)">
 			Background color for the boot splash.
 		</member>
-		<member name="application/boot_splash/fullsize" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], scale the boot splash image to the full window size (preserving the aspect ratio) when the engine starts. If [code]false[/code], the engine will leave it at the default pixel size.
-		</member>
 		<member name="application/boot_splash/image" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to an image used as the boot splash. If left empty, the default Godot Engine splash will be displayed instead.
 			[b]Note:[/b] Only effective if [member application/boot_splash/show_image] is [code]true[/code].
 		</member>
 		<member name="application/boot_splash/show_image" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], displays the image specified in [member application/boot_splash/image] when the engine starts. If [code]false[/code], only displays the plain color specified in [member application/boot_splash/bg_color].
+		</member>
+		<member name="application/boot_splash/stretch_mode" type="int" setter="" getter="" default="1">
+			Specifies how the splash image will be stretched. See [enum RenderingServer.SplashStretchMode] constants for more information.
 		</member>
 		<member name="application/boot_splash/use_filter" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], applies linear filtering when scaling the image (recommended for high-resolution artwork). If [code]false[/code], uses nearest-neighbor interpolation (recommended for pixel art).

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2657,10 +2657,10 @@
 			<return type="void" />
 			<argument index="0" name="image" type="Image" />
 			<argument index="1" name="color" type="Color" />
-			<argument index="2" name="scale" type="bool" />
+			<argument index="2" name="stretch_mode" type="int" enum="RenderingServer.SplashStretchMode" />
 			<argument index="3" name="use_filter" type="bool" default="true" />
 			<description>
-				Sets a boot image. The color defines the background color. If [code]scale[/code] is [code]true[/code], the image will be scaled to fit the screen size. If [code]use_filter[/code] is [code]true[/code], the image will be scaled with linear interpolation. If [code]use_filter[/code] is [code]false[/code], the image will be scaled with nearest-neighbor interpolation.
+				Sets a boot image. The color defines the background color. The value of [code]stretch_mode[/code] indicates how the image will be stretched (see [enum SplashStretchMode] for possible values). If [code]use_filter[/code] is [code]true[/code], the image will be scaled with linear interpolation. If [code]use_filter[/code] is [code]false[/code], the image will be scaled with nearest-neighbor interpolation.
 			</description>
 		</method>
 		<method name="set_debug_generate_wireframes">
@@ -4503,6 +4503,24 @@
 		<constant name="RENDERING_INFO_BUFFER_MEM_USED" value="4" enum="RenderingInfo">
 		</constant>
 		<constant name="RENDERING_INFO_VIDEO_MEM_USED" value="5" enum="RenderingInfo">
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_DISABLED" value="0" enum="SplashStretchMode">
+			The splash image uses its default pixel size.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_KEEP" value="1" enum="SplashStretchMode">
+			If the window width is greater than its height, the splash image will be stretched to have the same height as the window. Otherwise, the image will be stretched to have the same width as the window. Both cases keep the original image's aspect ratio.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_KEEP_WIDTH" value="2" enum="SplashStretchMode">
+			The splash image is stretched to have the same width as the window. It keeps the image's aspect ratio.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_KEEP_HEIGHT" value="3" enum="SplashStretchMode">
+			The splash image is stretched to have the same height as the window. It keeps the image's aspect ratio.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_COVER" value="4" enum="SplashStretchMode">
+			The splash image covers the window while keeping the aspect ratio.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_EXPAND" value="5" enum="SplashStretchMode">
+			The splash image covers the window without keeping the aspect ratio.
 		</constant>
 		<constant name="FEATURE_SHADERS" value="0" enum="Features">
 			Hardware supports shaders. This enum is currently unused in Godot 3.x.

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -298,54 +298,89 @@ void RasterizerGLES3::blit_render_targets_to_screen(DisplayServer::WindowID p_sc
 	}
 }
 
-void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
-	if (p_image.is_null() || p_image->is_empty())
+void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter) {
+	if (p_image.is_null() || p_image->is_empty()) {
 		return;
+	}
 
-	Size2i win_size = DisplayServer::get_singleton()->screen_get_size();
+	Size2 window_size = DisplayServer::get_singleton()->screen_get_size();
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	glViewport(0, 0, win_size.width, win_size.height);
+	glViewport(0, 0, window_size.width, window_size.height);
 	glDisable(GL_BLEND);
 	glDepthMask(GL_FALSE);
-	if (false) {
-		//	if (OS::get_singleton()->get_window_per_pixel_transparency_enabled()) {
-		glClearColor(0.0, 0.0, 0.0, 0.0);
-	} else {
-		glClearColor(p_color.r, p_color.g, p_color.b, 1.0);
-	}
+	glClearColor(p_color.r, p_color.g, p_color.b, 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
 	canvas.canvas_begin();
 
 	RID texture = storage.texture_create();
+	// FIXME: Handle p_filter.
 	//storage.texture_allocate(texture, p_image->get_width(), p_image->get_height(), 0, p_image->get_format(), VS::TEXTURE_TYPE_2D, p_use_filter ? VS::TEXTURE_FLAG_FILTER : 0);
 	storage._texture_allocate_internal(texture, p_image->get_width(), p_image->get_height(), 0, p_image->get_format(), RenderingDevice::TEXTURE_TYPE_2D);
 	storage.texture_set_data(texture, p_image);
 
+	// Stretch code synced with RendererCompositorRD.
 	Rect2 imgrect(0, 0, p_image->get_width(), p_image->get_height());
 	Rect2 screenrect;
-	if (p_scale) {
-		if (win_size.width > win_size.height) {
-			//scale horizontally
-			screenrect.size.y = win_size.height;
-			screenrect.size.x = imgrect.size.x * win_size.height / imgrect.size.y;
-			screenrect.position.x = (win_size.width - screenrect.size.x) / 2;
+	switch (p_stretch_mode) {
+		case RenderingServer::SPLASH_STRETCH_MODE_DISABLED: {
+			screenrect = imgrect;
+			screenrect.position += ((window_size - screenrect.size) / 2.0).floor();
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_KEEP: {
+			if (window_size.width > window_size.height) {
+				// Scale horizontally.
+				screenrect.size.y = window_size.height;
+				screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
+				screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
+			} else {
+				// Scale vertically.
+				screenrect.size.x = window_size.width;
+				screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
+				screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
+			}
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_WIDTH: {
+			// Scale vertically.
+			screenrect.size.x = window_size.width;
+			screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
+			screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_HEIGHT: {
+			// Scale horizontally.
+			screenrect.size.y = window_size.height;
+			screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
+			screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_COVER: {
+			double window_aspect = (double)window_size.width / window_size.height;
+			double img_aspect = imgrect.size.x / imgrect.size.y;
 
-		} else {
-			//scale vertically
-			screenrect.size.x = win_size.width;
-			screenrect.size.y = imgrect.size.y * win_size.width / imgrect.size.x;
-			screenrect.position.y = (win_size.height - screenrect.size.y) / 2;
-		}
-	} else {
-		screenrect = imgrect;
-		screenrect.position += ((Size2(win_size.width, win_size.height) - screenrect.size) / 2.0).floor();
+			if (window_aspect > img_aspect) {
+				// Scale vertically.
+				screenrect.size.x = window_size.width;
+				screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
+				screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
+			} else {
+				// Scale horizontally.
+				screenrect.size.y = window_size.height;
+				screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
+				screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
+			}
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_EXPAND: {
+			screenrect.size.x = window_size.width;
+			screenrect.size.y = window_size.height;
+		} break;
 	}
+
+	// FIXME: Actually draw the image after binding it, using screenrect for scaling.
 
 	RasterizerStorageGLES3::Texture *t = storage.texture_owner.get_or_null(texture);
 	glActiveTexture(GL_TEXTURE0 + storage.config.max_texture_image_units - 1);
 	glBindTexture(GL_TEXTURE_2D, t->tex_id);
+	//canvas->draw_generic_textured_rect(screenrect, Rect2(0, 0, 1, 1));
 	glBindTexture(GL_TEXTURE_2D, 0);
 	canvas.canvas_end();
 

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -57,7 +57,7 @@ public:
 	RendererCanvasRender *get_canvas() { return &canvas; }
 	RendererSceneRender *get_scene() { return &scene; }
 
-	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
+	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter = true);
 
 	void initialize();
 	void begin_frame(double frame_step);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1728,11 +1728,15 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	if (show_logo) { //boot logo!
 		const bool boot_logo_image = GLOBAL_DEF("application/boot_splash/show_image", true);
 		const String boot_logo_path = String(GLOBAL_DEF("application/boot_splash/image", String())).strip_edges();
-		const bool boot_logo_scale = GLOBAL_DEF("application/boot_splash/fullsize", true);
+		const RenderingServer::SplashStretchMode boot_stretch_mode =
+				(RenderingServer::SplashStretchMode)(int)GLOBAL_DEF("application/boot_splash/stretch_mode", RenderingServer::SPLASH_STRETCH_MODE_KEEP);
 		const bool boot_logo_filter = GLOBAL_DEF("application/boot_splash/use_filter", true);
+
+		ProjectSettings::get_singleton()->set_custom_property_info("application/boot_splash/stretch_mode",
+				PropertyInfo(Variant::INT, "application/boot_splash/stretch_mode",
+						PROPERTY_HINT_ENUM, "Disabled,Keep,Keep Width,Keep Height,Cover,Expand")); // Sync with RenderingServer::SplashStretchMode.
 		ProjectSettings::get_singleton()->set_custom_property_info("application/boot_splash/image",
-				PropertyInfo(Variant::STRING,
-						"application/boot_splash/image",
+				PropertyInfo(Variant::STRING, "application/boot_splash/image",
 						PROPERTY_HINT_FILE, "*.png"));
 
 		Ref<Image> boot_logo;
@@ -1760,9 +1764,8 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		const Color boot_bg_color = GLOBAL_DEF("application/boot_splash/bg_color", boot_splash_bg_color);
 #endif
 		if (boot_logo.is_valid()) {
-			RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color, boot_logo_scale,
-					boot_logo_filter);
-
+			RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color,
+					boot_stretch_mode, boot_logo_filter);
 		} else {
 #ifndef NO_DEFAULT_BOOT_LOGO
 			MAIN_PRINT("Main: Create bootsplash");
@@ -1775,7 +1778,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 			MAIN_PRINT("Main: ClearColor");
 			RenderingServer::get_singleton()->set_default_clear_color(boot_bg_color);
 			MAIN_PRINT("Main: Image");
-			RenderingServer::get_singleton()->set_boot_image(splash, boot_bg_color, false);
+			RenderingServer::get_singleton()->set_boot_image(splash, boot_bg_color, RenderingServer::SPLASH_STRETCH_MODE_DISABLED);
 #endif
 		}
 

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -763,7 +763,7 @@ public:
 	RendererCanvasRender *get_canvas() override { return &canvas; }
 	RendererSceneRender *get_scene() override { return &scene; }
 
-	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) override {}
+	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter = true) override {}
 
 	void initialize() override {}
 	void begin_frame(double frame_step) override {

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -76,7 +76,7 @@ public:
 	virtual RendererCanvasRender *get_canvas() = 0;
 	virtual RendererSceneRender *get_scene() = 0;
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
+	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter = true) = 0;
 
 	virtual void initialize() = 0;
 	virtual void begin_frame(double frame_step) = 0;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -159,7 +159,7 @@ void RendererCompositorRD::finalize() {
 	RD::get_singleton()->free(blit.sampler);
 }
 
-void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
+void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter) {
 	RD::get_singleton()->prepare_screen_for_drawing();
 
 	RID texture = storage->texture_allocate();
@@ -182,22 +182,56 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 
 	Rect2 imgrect(0, 0, p_image->get_width(), p_image->get_height());
 	Rect2 screenrect;
-	if (p_scale) {
-		if (window_size.width > window_size.height) {
-			//scale horizontally
-			screenrect.size.y = window_size.height;
-			screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
-			screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
-
-		} else {
-			//scale vertically
+	switch (p_stretch_mode) {
+		case RenderingServer::SPLASH_STRETCH_MODE_DISABLED: {
+			screenrect = imgrect;
+			screenrect.position += ((window_size - screenrect.size) / 2.0).floor();
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_KEEP: {
+			if (window_size.width > window_size.height) {
+				// Scale horizontally.
+				screenrect.size.y = window_size.height;
+				screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
+				screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
+			} else {
+				// Scale vertically.
+				screenrect.size.x = window_size.width;
+				screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
+				screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
+			}
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_WIDTH: {
+			// Scale vertically.
 			screenrect.size.x = window_size.width;
 			screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
 			screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
-		}
-	} else {
-		screenrect = imgrect;
-		screenrect.position += ((window_size - screenrect.size) / 2.0).floor();
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_HEIGHT: {
+			// Scale horizontally.
+			screenrect.size.y = window_size.height;
+			screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
+			screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_COVER: {
+			double window_aspect = (double)window_size.width / window_size.height;
+			double img_aspect = imgrect.size.x / imgrect.size.y;
+
+			if (window_aspect > img_aspect) {
+				// Scale vertically.
+				screenrect.size.x = window_size.width;
+				screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
+				screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
+			} else {
+				// Scale horizontally.
+				screenrect.size.y = window_size.height;
+				screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
+				screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
+			}
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_EXPAND: {
+			screenrect.size.x = window_size.width;
+			screenrect.size.y = window_size.height;
+		} break;
 	}
 
 	screenrect.position /= window_size;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -90,7 +90,7 @@ public:
 	RendererCanvasRender *get_canvas() { return canvas; }
 	RendererSceneRender *get_scene() { return scene; }
 
-	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter);
+	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter);
 
 	void initialize();
 	void begin_frame(double frame_step);

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -273,9 +273,9 @@ Vector<RenderingServer::FrameProfileArea> RenderingServerDefault::get_frame_prof
 
 /* TESTING */
 
-void RenderingServerDefault::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
+void RenderingServerDefault::set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter) {
 	redraw_request();
-	RSG::rasterizer->set_boot_image(p_image, p_color, p_scale, p_use_filter);
+	RSG::rasterizer->set_boot_image(p_image, p_color, p_stretch_mode, p_use_filter);
 }
 
 void RenderingServerDefault::set_default_clear_color(const Color &p_color) {

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -907,7 +907,7 @@ public:
 
 	virtual double get_frame_setup_time_cpu() const override;
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) override;
+	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter = true) override;
 	virtual void set_default_clear_color(const Color &p_color) override;
 
 	virtual bool has_feature(Features p_feature) const override;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2730,7 +2730,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_test_texture"), &RenderingServer::get_test_texture);
 	ClassDB::bind_method(D_METHOD("get_white_texture"), &RenderingServer::get_white_texture);
 
-	ClassDB::bind_method(D_METHOD("set_boot_image", "image", "color", "scale", "use_filter"), &RenderingServer::set_boot_image, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("set_boot_image", "image", "color", "stretch_mode", "use_filter"), &RenderingServer::set_boot_image, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("set_default_clear_color", "color"), &RenderingServer::set_default_clear_color);
 
 	ClassDB::bind_method(D_METHOD("has_feature", "feature"), &RenderingServer::has_feature);
@@ -2750,6 +2750,13 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(RENDERING_INFO_TEXTURE_MEM_USED);
 	BIND_ENUM_CONSTANT(RENDERING_INFO_BUFFER_MEM_USED);
 	BIND_ENUM_CONSTANT(RENDERING_INFO_VIDEO_MEM_USED);
+
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_DISABLED);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_KEEP);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_KEEP_WIDTH);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_KEEP_HEIGHT);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_COVER);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_EXPAND);
 
 	BIND_ENUM_CONSTANT(FEATURE_SHADERS);
 	BIND_ENUM_CONSTANT(FEATURE_MULTITHREADED);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1510,7 +1510,16 @@ public:
 	virtual void mesh_add_surface_from_mesh_data(RID p_mesh, const Geometry3D::MeshData &p_mesh_data);
 	virtual void mesh_add_surface_from_planes(RID p_mesh, const Vector<Plane> &p_planes);
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
+	enum SplashStretchMode {
+		SPLASH_STRETCH_MODE_DISABLED,
+		SPLASH_STRETCH_MODE_KEEP,
+		SPLASH_STRETCH_MODE_KEEP_WIDTH,
+		SPLASH_STRETCH_MODE_KEEP_HEIGHT,
+		SPLASH_STRETCH_MODE_COVER,
+		SPLASH_STRETCH_MODE_EXPAND,
+	};
+
+	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter = true) = 0;
 	virtual void set_default_clear_color(const Color &p_color) = 0;
 
 	enum Features {
@@ -1624,6 +1633,7 @@ VARIANT_ENUM_CAST(RenderingServer::CanvasLightShadowFilter);
 VARIANT_ENUM_CAST(RenderingServer::CanvasOccluderPolygonCullMode);
 VARIANT_ENUM_CAST(RenderingServer::GlobalVariableType);
 VARIANT_ENUM_CAST(RenderingServer::RenderingInfo);
+VARIANT_ENUM_CAST(RenderingServer::SplashStretchMode);
 VARIANT_ENUM_CAST(RenderingServer::Features);
 VARIANT_ENUM_CAST(RenderingServer::CanvasTextureChannel);
 VARIANT_ENUM_CAST(RenderingServer::BakeChannels);


### PR DESCRIPTION
Originally I opened this PR https://github.com/godotengine/godot/pull/20541 but I deleted my godot repository, so I became unable to edit my own PR. Here's the new one.

I basically added a new property called `stretch_mode` to `Application/Boot Splash/` in the project settings. This property allows 5 values representing different stretch modes: `keep, keep_width, keep_height, cover and expand`.

For compatibility purposes, I kept the already available `fullsize` property. Like before, if `fullsize` is `false` no stretching will be applied and the image is left to its original size. If `fullsize` is `true`, then the selected stretch mode will be applied.

Selecting `keep` and having `fullsize` to `true` will result in the same behavior as having `fullsize` to `true` before this commit. Because of this, I set `keep` as the default value for `stretch_mode`.

I wasn't able to keep compatibility for `VisualServer.set_boot_image()` function. I changed the signature from `void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale)` to `void set_boot_image(const Ref<Image> &p_image, const Color &p_color, SplashStretchMode p_stretch_mode)`, where `SplashStretchMode` is an `enum` I defined in `servers/VisualServer.h`. I don't know if this is a big problem.

Here's how the the new property looks like:
![stretch_mode](https://user-images.githubusercontent.com/8157352/46164206-b2c17400-c28d-11e8-8da0-fbd7c3f6c7da.png)


Here's some pictures to illustrate how each scaling mode works. In each case an icon with size 64x64 is used:

| Stretch Mode | Horizontal (960x540) | Vertical (540x960) |
| ------------- | ------------- | ------------- |
| `fullsize=false`  | ![h_fullsize_off](https://user-images.githubusercontent.com/8157352/43355917-985f0818-9266-11e8-85e0-3e76241e3cc0.png) | ![v_fullsize_off](https://user-images.githubusercontent.com/8157352/43355920-acea9b44-9266-11e8-9eec-0f8483652ede.png) |
| `fullsize=true` and `stretch_mode=keep_width`  | ![h_keep_width](https://user-images.githubusercontent.com/8157352/43355935-dd389bf2-9266-11e8-8f16-69b363d3c5a5.png)  | ![v_fullsize_on](https://user-images.githubusercontent.com/8157352/43355943-f0a2d144-9266-11e8-94c6-131086427154.png)  |
| `fullsize=true` and `stretch_mode=keep_height`  | ![h_fullsize_on](https://user-images.githubusercontent.com/8157352/43355939-ee6ae6be-9266-11e8-9186-2ee769baa5c9.png)  | ![v_keep_height](https://user-images.githubusercontent.com/8157352/43355944-f0d9b8ee-9266-11e8-9fe1-f2c2dfcc3401.png)  |
| `fullsize=true` and `stretch_mode=cover` | ![h_keep_width](https://user-images.githubusercontent.com/8157352/43355935-dd389bf2-9266-11e8-8f16-69b363d3c5a5.png)  | ![v_keep_height](https://user-images.githubusercontent.com/8157352/43355944-f0d9b8ee-9266-11e8-9fe1-f2c2dfcc3401.png)  |
| `fullsize=true` and `stretch_mode=expand`  | ![h_expand](https://user-images.githubusercontent.com/8157352/43355937-ee2b2326-9266-11e8-87c9-83af89423e21.png) | ![v_expand](https://user-images.githubusercontent.com/8157352/43355940-eed1dc7a-9266-11e8-87c9-05c7e358db77.png)  |
| `fullsize=true` and `stretch_mode=keep`  | ![h_fullsize_on](https://user-images.githubusercontent.com/8157352/43355939-ee6ae6be-9266-11e8-9186-2ee769baa5c9.png) | ![v_fullsize_on](https://user-images.githubusercontent.com/8157352/43355943-f0a2d144-9266-11e8-94c6-131086427154.png) |

As I said, `fullsize=true` with `stretch_mode=keep` results in the same behavior as `fullsize=true` before this commit.

This may solve this feature request: https://github.com/godotengine/godot/issues/22075.
*Bugsquad edit:* Fixes #22075.

I don't usually code in C++ and I don't know the project well yet so any improvement suggestion is welcome.