### PR TITLE
SCons: Build thirdparty code in own env, disable warnings

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -123,6 +123,7 @@ env_base.__class__.add_shared_library = methods.add_shared_library
 env_base.__class__.add_library = methods.add_library
 env_base.__class__.add_program = methods.add_program
 env_base.__class__.CommandNoCache = methods.CommandNoCache
+env_base.__class__.disable_warnings = methods.disable_warnings
 
 env_base["x86_libtheora_opt_gcc"] = False
 env_base["x86_libtheora_opt_vc"] = False

--- a/core/SCsub
+++ b/core/SCsub
@@ -56,6 +56,7 @@ with open("script_encryption_key.gen.cpp", "w") as f:
 
 # Add required thirdparty code.
 env_thirdparty = env.Clone()
+env_thirdparty.disable_warnings()
 
 # Misc thirdparty code: header paths are hardcoded, we don't need to append
 # to the include path (saves a few chars on the compiler invocation for touchy MSVC...)

--- a/drivers/alsa/SCsub
+++ b/drivers/alsa/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-Export('env')

--- a/drivers/alsamidi/SCsub
+++ b/drivers/alsamidi/SCsub
@@ -4,5 +4,3 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-Export('env')

--- a/drivers/convex_decomp/SCsub
+++ b/drivers/convex_decomp/SCsub
@@ -11,6 +11,7 @@ thirdparty_sources = [
 	"b2Triangle.cpp",
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-env.add_source_files(env.drivers_sources, thirdparty_sources)
 
-Export('env')
+env_thirdparty = env.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.drivers_sources, thirdparty_sources)

--- a/drivers/coreaudio/SCsub
+++ b/drivers/coreaudio/SCsub
@@ -4,5 +4,3 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-Export('env')

--- a/drivers/coremidi/SCsub
+++ b/drivers/coremidi/SCsub
@@ -4,5 +4,3 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-Export('env')

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -10,13 +10,14 @@ if (env["platform"] in ["haiku", "osx", "windows", "x11"]):
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env.add_source_files(env.drivers_sources, thirdparty_sources)
     env.Append(CPPPATH=[thirdparty_dir])
 
     env.Append(CPPFLAGS=['-DGLAD_ENABLED'])
     env.Append(CPPFLAGS=['-DGLES_OVER_GL'])
 
+    env_thirdparty = env.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.drivers_sources, thirdparty_sources)
+
 # Godot source files
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-Export('env')

--- a/drivers/gles2/SCsub
+++ b/drivers/gles2/SCsub
@@ -2,6 +2,6 @@
 
 Import('env')
 
-env.add_source_files(env.drivers_sources,"*.cpp")
+env.add_source_files(env.drivers_sources, "*.cpp")
 
 SConscript("shaders/SCsub")

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -26,14 +26,22 @@ if env['builtin_libpng']:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_png.add_source_files(env.drivers_sources, thirdparty_sources)
     env_png.Append(CPPPATH=[thirdparty_dir])
 
     # Currently .ASM filter_neon.S does not compile on NT.
     import os
-    if ("neon_enabled" in env and env["neon_enabled"]) and os.name != "nt":
+    use_neon = "neon_enabled" in env and env["neon_enabled"] and os.name != "nt"
+    if use_neon:
         env_png.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=2"])
-        env_neon = env_png.Clone()
+    else:
+        env_png.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=0"])
+
+    env_thirdparty = env_png.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.drivers_sources, thirdparty_sources)
+
+    if use_neon:
+        env_neon = env_thirdparty.Clone()
         if "S_compiler" in env:
             env_neon['CC'] = env['S_compiler']
         neon_sources = []
@@ -41,8 +49,6 @@ if env['builtin_libpng']:
         neon_sources.append(env_neon.Object(thirdparty_dir + "/arm/filter_neon_intrinsics.c"))
         neon_sources.append(env_neon.Object(thirdparty_dir + "/arm/filter_neon.S"))
         env.drivers_sources += neon_sources
-    else:
-        env_png.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=0"])
 
 # Godot source files
 env_png.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/pulseaudio/SCsub
+++ b/drivers/pulseaudio/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-Export('env')

--- a/drivers/rtaudio/SCsub
+++ b/drivers/rtaudio/SCsub
@@ -11,8 +11,11 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env.add_source_files(env.drivers_sources, thirdparty_sources)
 env.Append(CPPPATH=[thirdparty_dir])
+
+env_thirdparty = env.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.drivers_sources, thirdparty_sources)
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -5,5 +5,3 @@ Import('env')
 env.add_source_files(env.drivers_sources, "*.cpp")
 
 env["check_c_headers"] = [ [ "mntent.h", "HAVE_MNTENT" ] ]
-
-Export('env')

--- a/drivers/wasapi/SCsub
+++ b/drivers/wasapi/SCsub
@@ -4,5 +4,3 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-Export('env')

--- a/drivers/windows/SCsub
+++ b/drivers/windows/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-Export('env')

--- a/drivers/winmidi/SCsub
+++ b/drivers/winmidi/SCsub
@@ -4,5 +4,3 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-Export('env')

--- a/drivers/xaudio2/SCsub
+++ b/drivers/xaudio2/SCsub
@@ -5,5 +5,3 @@ Import('env')
 env.add_source_files(env.drivers_sources, "*.cpp")
 env.Append(CXXFLAGS=['-DXAUDIO2_ENABLED'])
 env.Append(LINKFLAGS=['xaudio2_8.lib'])
-
-Export('env')

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 Import('env')
+
 env.editor_sources = []
 
 import os
@@ -89,5 +90,3 @@ if env['tools']:
 
     lib = env.add_library("editor", env.editor_sources)
     env.Prepend(LIBS=[lib])
-
-    Export('env')

--- a/editor/collada/SCsub
+++ b/editor/collada/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.editor_sources, "*.cpp")
-
-Export('env')

--- a/editor/doc/SCsub
+++ b/editor/doc/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.editor_sources, "*.cpp")
-
-Export('env')

--- a/editor/fileserver/SCsub
+++ b/editor/fileserver/SCsub
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 
 Import('env')
-Export('env')
+
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 Import('env')
+
 from platform_methods import run_in_subprocess
 import editor_icons_builders
-
 
 make_editor_icons_builder = Builder(action=run_in_subprocess(editor_icons_builders.make_editor_icons_action),
                                     suffix='.h',
@@ -11,5 +11,3 @@ make_editor_icons_builder = Builder(action=run_in_subprocess(editor_icons_builde
 
 env['BUILDERS']['MakeEditorIconsBuilder'] = make_editor_icons_builder
 env.Alias('editor_icons', [env.MakeEditorIconsBuilder('#editor/editor_icons.gen.h', Glob("*.svg"))])
-
-Export('env')

--- a/editor/import/SCsub
+++ b/editor/import/SCsub
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 
 Import('env')
-Export('env')
+
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/plugins/SCsub
+++ b/editor/plugins/SCsub
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 
 Import('env')
-Export('env')
+
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/main/SCsub
+++ b/main/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 Import('env')
+
 from platform_methods import run_in_subprocess
 import main_builders
 
@@ -14,8 +15,6 @@ env.Depends("#main/default_controller_mappings.gen.cpp", controller_databases)
 env.CommandNoCache("#main/default_controller_mappings.gen.cpp", controller_databases, run_in_subprocess(main_builders.make_default_controller_mappings))
 
 env.main_sources.append("#main/default_controller_mappings.gen.cpp")
-
-Export('env')
 
 env.Depends("#main/splash.gen.h", "#main/splash.png")
 env.CommandNoCache("#main/splash.gen.h", "#main/splash.png", run_in_subprocess(main_builders.make_splash))

--- a/main/tests/SCsub
+++ b/main/tests/SCsub
@@ -5,9 +5,5 @@ Import('env')
 env.tests_sources = []
 env.add_source_files(env.tests_sources, "*.cpp")
 
-Export('env')
-
-# SConscript('math/SCsub');
-
 lib = env.add_library("tests", env.tests_sources)
 env.Prepend(LIBS=[lib])

--- a/methods.py
+++ b/methods.py
@@ -19,6 +19,14 @@ def add_source_files(self, sources, filetype, lib_env=None, shared=False):
         sources.append(self.Object(path))
 
 
+def disable_warnings(self):
+    # 'self' is the environment
+    if self.msvc:
+        self.Append(CCFLAGS=['/w'])
+    else:
+        self.Append(CCFLAGS=['-w'])
+
+
 def add_module_version_string(self,s):
     self.module_version_string += "." + s
 

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -9,7 +9,6 @@ Export('env_modules')
 env.modules_sources = [
     "register_module_types.gen.cpp",
 ]
-Export('env')
 
 for x in env.module_list:
     if (x in env.disabled_modules):
@@ -20,7 +19,6 @@ for x in env.module_list:
 if env.split_modules:
     env.split_lib("modules", env_lib = env_modules)
 else:
-
     lib = env_modules.add_library("modules", env.modules_sources)
 
     env.Prepend(LIBS=[lib])

--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -186,8 +186,12 @@ if env['builtin_bullet']:
 
     thirdparty_sources = [thirdparty_dir + file for file in bullet2_src]
 
-    env_bullet.add_source_files(env.modules_sources, thirdparty_sources)
     env_bullet.Append(CPPPATH=[thirdparty_dir])
+
+    env_thirdparty = env_bullet.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+
 
 # Godot source files
 env_bullet.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/cvtt/SCsub
+++ b/modules/cvtt/SCsub
@@ -14,8 +14,11 @@ if env['builtin_squish']:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_cvtt.add_source_files(env.modules_sources, thirdparty_sources)
     env_cvtt.Append(CPPPATH=[thirdparty_dir])
+
+    env_thirdparty = env_cvtt.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_cvtt.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -21,8 +21,11 @@ if env['builtin_enet']:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_enet.add_source_files(env.modules_sources, thirdparty_sources)
     env_enet.Append(CPPPATH=[thirdparty_dir])
     env_enet.Append(CPPFLAGS=["-DGODOT_ENET"])
+
+    env_thirdparty = env_enet.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 env_enet.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/etc/SCsub
+++ b/modules/etc/SCsub
@@ -27,16 +27,20 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_etc.add_source_files(env.modules_sources, thirdparty_sources)
 env_etc.Append(CPPPATH=[thirdparty_dir])
 
-# Godot source files
-env_etc.add_source_files(env.modules_sources, "*.cpp")
-
 # upstream uses c++11
-if (not env_etc.msvc):
+if not env.msvc:
 	env_etc.Append(CCFLAGS="-std=c++11")
-# -ffast-math seems to be incompatible with ec2comp on recent versions of
+
+# -ffast-math seems to be incompatible with etc2comp on recent versions of
 # GCC and Clang
 if '-ffast-math' in env_etc['CCFLAGS']:
 	env_etc['CCFLAGS'].remove('-ffast-math')
+
+env_thirdparty = env_etc.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+
+# Godot source files
+env_etc.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -73,6 +73,8 @@ if env['builtin_freetype']:
     if env['builtin_libpng']:
         env.Append(CPPPATH=["#thirdparty/libpng"])
 
+    # FIXME: Find a way to build this in a separate env nevertheless
+    # so that we can disable warnings on thirdparty code
     lib = env.add_library("freetype_builtin", thirdparty_sources)
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -1,35 +1,38 @@
 #!/usr/bin/env python
 
 Import('env')
+Import('env_modules')
 
-gdn_env = env.Clone()
-gdn_env.add_source_files(env.modules_sources, "gdnative.cpp")
-gdn_env.add_source_files(env.modules_sources, "register_types.cpp")
-gdn_env.add_source_files(env.modules_sources, "android/*.cpp")
-gdn_env.add_source_files(env.modules_sources, "gdnative/*.cpp")
-gdn_env.add_source_files(env.modules_sources, "nativescript/*.cpp")
-gdn_env.add_source_files(env.modules_sources, "gdnative_library_singleton_editor.cpp")
-gdn_env.add_source_files(env.modules_sources, "gdnative_library_editor_plugin.cpp")
+env_gdnative = env_modules.Clone()
+env_gdnative.add_source_files(env.modules_sources, "gdnative.cpp")
+env_gdnative.add_source_files(env.modules_sources, "register_types.cpp")
+env_gdnative.add_source_files(env.modules_sources, "android/*.cpp")
+env_gdnative.add_source_files(env.modules_sources, "gdnative/*.cpp")
+env_gdnative.add_source_files(env.modules_sources, "nativescript/*.cpp")
+env_gdnative.add_source_files(env.modules_sources, "gdnative_library_singleton_editor.cpp")
+env_gdnative.add_source_files(env.modules_sources, "gdnative_library_editor_plugin.cpp")
 
-gdn_env.Append(CPPPATH=['#modules/gdnative/include/'])
+env_gdnative.Append(CPPPATH=['#modules/gdnative/include/'])
+
+Export('env_gdnative')
 
 SConscript("net/SCsub")
 SConscript("arvr/SCsub")
 SConscript("pluginscript/SCsub")
 
+
 from platform_methods import run_in_subprocess
 import gdnative_builders
 
-
-_, gensource = gdn_env.CommandNoCache(['include/gdnative_api_struct.gen.h', 'gdnative_api_struct.gen.cpp'],
+_, gensource = env_gdnative.CommandNoCache(['include/gdnative_api_struct.gen.h', 'gdnative_api_struct.gen.cpp'],
                                'gdnative_api.json', run_in_subprocess(gdnative_builders.build_gdnative_api_struct))
-gdn_env.add_source_files(env.modules_sources, [gensource])
+env_gdnative.add_source_files(env.modules_sources, [gensource])
 
 env.use_ptrcall = True
 
 
 if ARGUMENTS.get('gdnative_wrapper', False):
-    gensource, = gdn_env.CommandNoCache('gdnative_wrapper_code.gen.cpp', 'gdnative_api.json', run_in_subprocess(gdnative_builders.build_gdnative_wrapper_code))
+    gensource, = env_gdnative.CommandNoCache('gdnative_wrapper_code.gen.cpp', 'gdnative_api.json', run_in_subprocess(gdnative_builders.build_gdnative_wrapper_code))
 
     gd_wrapper_env = env.Clone()
     gd_wrapper_env.Append(CPPPATH=['#modules/gdnative/include/'])

--- a/modules/gdnative/arvr/SCsub
+++ b/modules/gdnative/arvr/SCsub
@@ -1,13 +1,6 @@
 #!/usr/bin/env python
 
-import os
-import methods
-
 Import('env')
-Import('env_modules')
+Import('env_gdnative')
 
-env_arvr_gdnative = env_modules.Clone()
-
-env_arvr_gdnative.Append(CPPPATH=['#modules/gdnative/include/'])
-env_arvr_gdnative.add_source_files(env.modules_sources, '*.cpp')
-
+env_gdnative.add_source_files(env.modules_sources, '*.cpp')

--- a/modules/gdnative/nativescript/SCsub
+++ b/modules/gdnative/nativescript/SCsub
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
 
 Import('env')
+Import('env_gdnative')
 
-mod_env = env.Clone()
-mod_env.add_source_files(env.modules_sources, "*.cpp")
-mod_env.Append(CPPFLAGS=['-DGDAPI_BUILT_IN'])
+env_gdnative.add_source_files(env.modules_sources, '*.cpp')
+env_gdnative.Append(CPPFLAGS=['-DGDAPI_BUILT_IN'])
 
 if "platform" in env and env["platform"] in ["x11", "iphone"]:
     env.Append(LINKFLAGS=["-rdynamic"])
-
-Export('mod_env')

--- a/modules/gdnative/net/SCsub
+++ b/modules/gdnative/net/SCsub
@@ -1,12 +1,7 @@
 #!/usr/bin/env python
 
-import os
-import methods
-
 Import('env')
-Import('env_modules')
+Import('env_gdnative')
 
-env_net_gdnative = env_modules.Clone()
+env_gdnative.add_source_files(env.modules_sources, '*.cpp')
 
-env_net_gdnative.Append(CPPPATH=['#modules/gdnative/include/'])
-env_net_gdnative.add_source_files(env.modules_sources, '*.cpp')

--- a/modules/gdnative/pluginscript/SCsub
+++ b/modules/gdnative/pluginscript/SCsub
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
 Import('env')
-Import('env_modules')
+Import('env_gdnative')
 
-env_pluginscript = env_modules.Clone()
-
-env_pluginscript.Append(CPPPATH=['#modules/gdnative/include/'])
-env_pluginscript.add_source_files(env.modules_sources, '*.cpp')
+env_gdnative.add_source_files(env.modules_sources, '*.cpp')

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -9,5 +9,3 @@ env_gdscript.add_source_files(env.modules_sources, "*.cpp")
 
 if env['tools']:
 	env_gdscript.add_source_files(env.modules_sources, "./editor/*.cpp")
-
-Export('env')

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -6,5 +6,3 @@ Import('env_modules')
 env_gridmap = env_modules.Clone()
 
 env_gridmap.add_source_files(env.modules_sources, "*.cpp")
-
-Export('env')

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -13,8 +13,11 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_jpg.add_source_files(env.modules_sources, thirdparty_sources)
 env_jpg.Append(CPPPATH=[thirdparty_dir])
+
+env_thirdparty = env_jpg.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot's own source files
 env_jpg.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -91,8 +91,12 @@ if env['builtin_mbedtls']:
 
     thirdparty_dir = "#thirdparty/mbedtls/library/"
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-    env_mbed_tls.add_source_files(env.modules_sources, thirdparty_sources)
+
     env_mbed_tls.Prepend(CPPPATH=["#thirdparty/mbedtls/include/"])
+
+    env_thirdparty = env_mbed_tls.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Module sources
 env_mbed_tls.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/mobile_vr/SCsub
+++ b/modules/mobile_vr/SCsub
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-import os
-import methods
-
 Import('env')
 Import('env_modules')
 

--- a/modules/mobile_vr/shaders/SCsub
+++ b/modules/mobile_vr/shaders/SCsub
@@ -4,4 +4,3 @@ Import('env')
 
 if 'GLES3_GLSL' in env['BUILDERS']:
     env.GLES3_GLSL('lens_distorted.glsl');
-

--- a/modules/ogg/SCsub
+++ b/modules/ogg/SCsub
@@ -14,8 +14,11 @@ if env['builtin_libogg']:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_ogg.add_source_files(env.modules_sources, thirdparty_sources)
     env_ogg.Append(CPPPATH=[thirdparty_dir])
+
+    env_thirdparty = env_ogg.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_ogg.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/opensimplex/SCsub
+++ b/modules/opensimplex/SCsub
@@ -1,4 +1,22 @@
 #!/usr/bin/env python
 
 Import('env')
-env.add_source_files(env.modules_sources, ["register_types.cpp", "open_simplex_noise.cpp", "noise_texture.cpp", "#thirdparty/misc/open-simplex-noise.c"])
+Import('env_modules')
+
+env_opensimplex = env_modules.Clone()
+
+# Thirdparty source files
+thirdparty_dir = "#thirdparty/misc/"
+thirdparty_sources = [
+    "open-simplex-noise.c",
+]
+thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
+
+env_opensimplex.Append(CPPPATH=[thirdparty_dir])
+
+env_thirdparty = env_opensimplex.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+
+# Godot's own source files
+env_opensimplex.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -3,7 +3,6 @@
 Import('env')
 Import('env_modules')
 
-
 stub = True
 
 env_opus = env_modules.Clone()
@@ -198,7 +197,10 @@ if env['builtin_opus']:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources + opus_sources_silk]
 
-    env_opus.add_source_files(env.modules_sources, thirdparty_sources)
+    # also requires libogg
+    if env['builtin_libogg']:
+        env_opus.Append(CPPPATH=["#thirdparty/libogg"])
+
     env_opus.Append(CFLAGS=["-DHAVE_CONFIG_H"])
 
     thirdparty_include_paths = [
@@ -211,9 +213,9 @@ if env['builtin_opus']:
     ]
     env_opus.Append(CPPPATH=[thirdparty_dir + "/" + dir for dir in thirdparty_include_paths])
 
-    # also requires libogg
-    if env['builtin_libogg']:
-        env_opus.Append(CPPPATH=["#thirdparty/libogg"])
+    env_thirdparty = env_opus.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 if not stub:
     # Module files

--- a/modules/pvr/SCsub
+++ b/modules/pvr/SCsub
@@ -17,8 +17,11 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_pvr.add_source_files(env.modules_sources, thirdparty_sources)
 env_pvr.Append(CPPPATH=[thirdparty_dir])
+
+env_thirdparty = env_pvr.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_pvr.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/recast/SCsub
+++ b/modules/recast/SCsub
@@ -23,10 +23,11 @@ if env['builtin_recast']:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_recast.add_source_files(env.modules_sources, thirdparty_sources)
     env_recast.Append(CPPPATH=[thirdparty_dir + "/Include"])
+
+    env_thirdparty = env_recast.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_recast.add_source_files(env.modules_sources, "*.cpp")
-
-Export('env')

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -4,15 +4,16 @@ Import('env')
 Import('env_modules')
 
 env_regex = env_modules.Clone()
-env_regex.Append(CPPFLAGS=["-DPCRE2_CODE_UNIT_WIDTH=0"])
-env_regex.add_source_files(env.modules_sources, "*.cpp")
 
 if env['builtin_pcre2']:
     jit_blacklist = ['javascript', 'uwp']
+
     thirdparty_dir = '#thirdparty/pcre2/src/'
     thirdparty_flags = ['-DPCRE2_STATIC', '-DHAVE_CONFIG_H']
+
     if 'platform' in env and env['platform'] not in jit_blacklist:
         thirdparty_flags.append('-DSUPPORT_JIT')
+
     thirdparty_sources = [
         "pcre2_auto_possess.c",
         "pcre2_chartables.c",
@@ -42,15 +43,21 @@ if env['builtin_pcre2']:
         "pcre2_valid_utf.c",
         "pcre2_xclass.c",
     ]
+
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
+
     env_regex.Append(CPPPATH=[thirdparty_dir])
     env_regex.Append(CPPFLAGS=thirdparty_flags)
+
     def pcre2_builtin(width):
-        env_pcre2 = env_modules.Clone()
+        env_pcre2 = env_regex.Clone()
+        env_pcre2.disable_warnings()
         env_pcre2["OBJSUFFIX"] = "_" + width + env_pcre2["OBJSUFFIX"]
-        env_pcre2.Append(CPPPATH=[thirdparty_dir])
         env_pcre2.add_source_files(env.modules_sources, thirdparty_sources)
-        env_pcre2.Append(CPPFLAGS=thirdparty_flags)
         env_pcre2.Append(CPPFLAGS=["-DPCRE2_CODE_UNIT_WIDTH=" + width])
+
     pcre2_builtin("16")
     pcre2_builtin("32")
+
+env_regex.Append(CPPFLAGS=["-DPCRE2_CODE_UNIT_WIDTH=0"])
+env_regex.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/squish/SCsub
+++ b/modules/squish/SCsub
@@ -22,8 +22,11 @@ if env['builtin_squish']:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_squish.add_source_files(env.modules_sources, thirdparty_sources)
     env_squish.Append(CPPPATH=[thirdparty_dir])
+
+    env_thirdparty = env_squish.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_squish.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -9,11 +9,12 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env.add_source_files(env.modules_sources, thirdparty_sources)
 env.Append(CPPPATH=[thirdparty_dir])
 env.Append(CCFLAGS=["-DSVG_ENABLED"])
 
+env_thirdparty = env.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+
 # Godot's own source files
 env.add_source_files(env.modules_sources, "*.cpp")
-
-Export('env')

--- a/modules/thekla_unwrap/SCsub
+++ b/modules/thekla_unwrap/SCsub
@@ -54,17 +54,16 @@ if env['builtin_thekla_atlas']:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_thekla_unwrap.add_source_files(env.modules_sources, thirdparty_sources)
-    env_thekla_unwrap.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "/poshlib", thirdparty_dir + "/nvcore", thirdparty_dir + "/nvmesh"])
+    env_thekla_unwrap.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "poshlib", thirdparty_dir + "nvcore", thirdparty_dir + "nvmesh"])
 
     # upstream uses c++11
-    if (not env_thekla_unwrap.msvc):
-        env_thekla_unwrap.Append(CXXFLAGS="-std=c++11")
+    if (not env.msvc):
+         env_thekla_unwrap.Append(CXXFLAGS="-std=c++11")
 
     if env["platform"] == 'x11':
         # if not specifically one of the *BSD, then use LINUX as default
         if platform.system() == "FreeBSD":
-            env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])
+		    env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])
         elif platform.system() == "OpenBSD":
             env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_OPENBSD", "-DPOSH_COMPILER_GCC"])
         else:
@@ -77,6 +76,10 @@ if env['builtin_thekla_atlas']:
         else:
             env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_MINGW", "-DNV_CC_GNUC", "-DPOSH_COMPILER_GCC", "-U__STRICT_ANSI__"])
             env.Append(LIBS=["dbghelp"])
+
+    env_thirdparty = env_thekla_unwrap.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_thekla_unwrap.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -70,7 +70,6 @@ if env['builtin_libtheora']:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_theora.add_source_files(env.modules_sources, thirdparty_sources)
     env_theora.Append(CPPPATH=[thirdparty_dir])
 
     # also requires libogg and libvorbis
@@ -78,6 +77,10 @@ if env['builtin_libtheora']:
         env_theora.Append(CPPPATH=["#thirdparty/libogg"])
     if env['builtin_libvorbis']:
         env_theora.Append(CPPPATH=["#thirdparty/libvorbis"])
+
+    env_thirdparty = env_theora.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_theora.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/tinyexr/SCsub
+++ b/modules/tinyexr/SCsub
@@ -13,8 +13,11 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_tinyexr.add_source_files(env.modules_sources, thirdparty_sources)
 env_tinyexr.Append(CPPPATH=[thirdparty_dir])
+
+env_thirdparty = env_tinyexr.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot's own source files
 env_tinyexr.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -25,8 +25,12 @@ if env['builtin_miniupnpc']:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_upnp.add_source_files(env.modules_sources, thirdparty_sources)
     env_upnp.Append(CPPPATH=[thirdparty_dir])
     env_upnp.Append(CPPFLAGS=["-DMINIUPNP_STATICLIB"])
 
+    env_thirdparty = env_upnp.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+
+# Godot source files
 env_upnp.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/visual_script/SCsub
+++ b/modules/visual_script/SCsub
@@ -6,5 +6,3 @@ Import('env_modules')
 env_vs = env_modules.Clone()
 
 env_vs.add_source_files(env.modules_sources, "*.cpp")
-
-Export('env')

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -40,12 +40,15 @@ if env['builtin_libvorbis']:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_vorbis.add_source_files(env.modules_sources, thirdparty_sources)
     env_vorbis.Append(CPPPATH=[thirdparty_dir])
 
     # also requires libogg
     if env['builtin_libogg']:
         env_vorbis.Append(CPPPATH=["#thirdparty/libogg"])
+
+    env_thirdparty = env_vorbis.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 if not stub:
     # Module files

--- a/modules/webm/SCsub
+++ b/modules/webm/SCsub
@@ -6,17 +6,16 @@ Import('env_modules')
 env_webm = env_modules.Clone()
 
 # Thirdparty source files
-thirdparty_libsimplewebm_dir = "#thirdparty/libsimplewebm/"
-thirdparty_libsimplewebm_sources = [
+thirdparty_dir = "#thirdparty/libsimplewebm/"
+thirdparty_sources = [
     "libwebm/mkvparser/mkvparser.cc",
     "OpusVorbisDecoder.cpp",
     "VPXDecoder.cpp",
     "WebMDemuxer.cpp",
 ]
-thirdparty_libsimplewebm_sources = [thirdparty_libsimplewebm_dir + file for file in thirdparty_libsimplewebm_sources]
+thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_webm.add_source_files(env.modules_sources, thirdparty_libsimplewebm_sources)
-env_webm.Append(CPPPATH=[thirdparty_libsimplewebm_dir, thirdparty_libsimplewebm_dir + "libwebm/"])
+env_webm.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "libwebm/"])
 
 # upstream uses c++11
 if (not env_webm.msvc):
@@ -31,8 +30,12 @@ if env['builtin_opus']:
     env_webm.Append(CPPPATH=["#thirdparty/opus"])
 
 if env['builtin_libvpx']:
-    Export('env_webm')
+    env_webm.Append(CPPPATH=["#thirdparty/libvpx"])
     SConscript("libvpx/SCsub")
+
+env_thirdparty = env_webm.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_webm.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+Import('env')
+Import('env_modules')
+
+# Thirdparty sources
+
 libvpx_dir = "#thirdparty/libvpx/"
 
 libvpx_sources = [
@@ -249,12 +254,8 @@ libvpx_sources_arm_neon_armasm_ms = [libvpx_dir + file for file in libvpx_source
 libvpx_sources_arm_neon_gas_apple = [libvpx_dir + file for file in libvpx_sources_arm_neon_gas_apple]
 
 
-Import('env')
-Import('env_webm')
-
-env_webm.Append(CPPPATH=[libvpx_dir])
-
-env_libvpx = env.Clone()
+env_libvpx = env_modules.Clone()
+env_libvpx.disable_warnings()
 env_libvpx.Append(CPPPATH=[libvpx_dir])
 
 webm_multithread = env["platform"] != 'javascript'

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -127,8 +127,11 @@ if env['builtin_libwebp']:
     ]
     thirdparty_sources = [thirdparty_dir + "src/" + file for file in thirdparty_sources]
 
-    env_webp.add_source_files(env.modules_sources, thirdparty_sources)
     env_webp.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "src/"])
+
+    env_thirdparty = env_webp.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_webp.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -7,7 +7,7 @@ Import('env_modules')
 
 env_lws = env_modules.Clone()
 
-if env['builtin_libwebsockets']:
+if env['builtin_libwebsockets'] and not env["platform"] == "javascript": # already builtin for javascript
     thirdparty_dir = "#thirdparty/libwebsockets/"
     helper_dir = "win32helpers/"
     thirdparty_sources = [
@@ -61,34 +61,33 @@ if env['builtin_libwebsockets']:
         "tls/mbedtls/mbedtls-server.c"
     ]
 
-    if env_lws["platform"] == "android": # Builtin getifaddrs
+    if env["platform"] == "android": # Builtin getifaddrs
         thirdparty_sources += ["misc/getifaddrs.c"]
 
-    if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp": # Winsock
+    if env["platform"] == "windows" or env["platform"] == "uwp": # Winsock
         thirdparty_sources += ["plat/lws-plat-win.c", helper_dir + "getopt.c", helper_dir + "getopt_long.c", helper_dir + "gettimeofday.c"]
     else: # Unix socket
         thirdparty_sources += ["plat/lws-plat-unix.c"]
 
-
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    if env_lws["platform"] == "javascript": # No need to add third party libraries at all
-        pass
-    else:
-        env_lws.add_source_files(env.modules_sources, thirdparty_sources)
-        env_lws.Append(CPPPATH=[thirdparty_dir])
+    env_lws.Append(CPPPATH=[thirdparty_dir])
 
-        wrapper_includes = ["#thirdparty/libwebsockets/tls/mbedtls/wrapper/include/" + inc for inc in ["internal", "openssl", "platform", ""]]
-        env_lws.Prepend(CPPPATH=wrapper_includes)
+    if env['builtin_mbedtls']:
+        mbedtls_includes = "#thirdparty/mbedtls/include"
+        env_lws.Prepend(CPPPATH=[mbedtls_includes])
 
-        if env['builtin_mbedtls']:
-            mbedtls_includes = "#thirdparty/mbedtls/include"
-            env_lws.Prepend(CPPPATH=[mbedtls_includes])
+    wrapper_includes = ["#thirdparty/libwebsockets/tls/mbedtls/wrapper/include/" + inc for inc in ["internal", "openssl", "platform", ""]]
+    env_lws.Prepend(CPPPATH=wrapper_includes)
 
-        if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp":
-            env_lws.Append(CPPPATH=[thirdparty_dir + helper_dir])
+    if env["platform"] == "windows" or env["platform"] == "uwp":
+        env_lws.Append(CPPPATH=[thirdparty_dir + helper_dir])
 
-        if env_lws["platform"] == "uwp":
-            env_lws.Append(CCFLAGS=["/DLWS_MINGW_SUPPORT"])
+    if env["platform"] == "uwp":
+        env_lws.Append(CCFLAGS=["/DLWS_MINGW_SUPPORT"])
+
+    env_thirdparty = env_lws.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 env_lws.add_source_files(env.modules_sources, "*.cpp")

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -29,5 +29,3 @@ platform_sources.append('register_platform_apis.gen.cpp')
 
 lib = env.add_library('platform', platform_sources)
 env.Prepend(LIBS=lib)
-
-Export('env')

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
+Import('env')
+
 import shutil
 from compat import open_utf8
 from distutils.version import LooseVersion
 from detect import get_ndk_version
-
-Import('env')
 
 android_files = [
 
@@ -25,10 +25,6 @@ android_files = [
     'java_class_wrapper.cpp',
 #    'power_android.cpp'
 ]
-
-# env.Depends('#core/math/vector3.h', 'vector3_psp.h')
-
-#obj = env.SharedObject('godot_android.cpp')
 
 env_android = env.Clone()
 if env['target'] == "profile":

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-import os
 
 Import('env')
+
+import os
 
 iphone_lib = [
     'godot_iphone.cpp',

--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-import os
 Import('env')
 
+import os
 from platform_methods import run_in_subprocess
 import platform_osx_builders
 

--- a/platform/server/SCsub
+++ b/platform/server/SCsub
@@ -2,11 +2,9 @@
 
 Import('env')
 
-
 common_server = [\
     "os_server.cpp",\
     "#platform/x11/crash_handler_x11.cpp",
     "#platform/x11/power_x11.cpp",
 ]
-
 prog = env.add_program('#bin/godot_server', ['godot_server.cpp'] + common_server)

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-import os
 Import('env')
 
+import os
 from platform_methods import run_in_subprocess
 import platform_windows_builders
 
@@ -19,9 +19,7 @@ common_win = [
 ]
 
 res_file = 'godot_res.rc'
-
 res_target = "godot_res" + env["OBJSUFFIX"]
-
 res_obj = env.RES(res_target, res_file)
 
 prog = env.add_program('#bin/godot', common_win + res_obj, PROGSUFFIX=env["PROGSUFFIX"])

--- a/platform/x11/SCsub
+++ b/platform/x11/SCsub
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-import os
 Import('env')
 
+import os
 from platform_methods import run_in_subprocess
 import platform_x11_builders
 

--- a/scene/2d/SCsub
+++ b/scene/2d/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
-
-Export('env')

--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -2,9 +2,7 @@
 
 Import('env')
 
-
 if env['disable_3d']:
-
     env.scene_sources.append("3d/spatial.cpp")
     env.scene_sources.append("3d/skeleton.cpp")
     env.scene_sources.append("3d/particles.cpp")
@@ -12,5 +10,3 @@ if env['disable_3d']:
     env.scene_sources.append("3d/scenario_fx.cpp")
 else:
     env.add_source_files(env.scene_sources, "*.cpp")
-
-Export('env')

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -4,7 +4,6 @@ Import('env')
 
 env.scene_sources = []
 
-
 # Thirdparty code
 thirdparty_dir = "#thirdparty/misc/"
 thirdparty_sources = [
@@ -12,8 +11,10 @@ thirdparty_sources = [
 	"mikktspace.c",
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-env.add_source_files(env.scene_sources, thirdparty_sources)
 
+env_thirdparty = env.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.scene_sources, thirdparty_sources)
 
 # Godot's own sources
 env.add_source_files(env.scene_sources, "*.cpp")
@@ -32,5 +33,3 @@ SConscript('resources/SCsub')
 # Build it all as a library
 lib = env.add_library("scene", env.scene_sources)
 env.Prepend(LIBS=[lib])
-
-Export('env')

--- a/scene/animation/SCsub
+++ b/scene/animation/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
-
-Export('env')

--- a/scene/audio/SCsub
+++ b/scene/audio/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
-
-Export('env')

--- a/scene/gui/SCsub
+++ b/scene/gui/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
-
-Export('env')

--- a/scene/main/SCsub
+++ b/scene/main/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
-
-Export('env')

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -4,6 +4,4 @@ Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
 
-Export('env')
-
 SConscript("default_theme/SCsub")

--- a/scene/resources/default_theme/SCsub
+++ b/scene/resources/default_theme/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
-
-Export('env')

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -5,8 +5,6 @@ Import('env')
 env.servers_sources = []
 env.add_source_files(env.servers_sources, "*.cpp")
 
-Export('env')
-
 SConscript('arvr/SCsub')
 SConscript('physics/SCsub')
 SConscript('physics_2d/SCsub')

--- a/servers/arvr/SCsub
+++ b/servers/arvr/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
-
-Export('env')

--- a/servers/audio/SCsub
+++ b/servers/audio/SCsub
@@ -4,6 +4,4 @@ Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
 
-Export('env')
-
 SConscript("effects/SCsub")

--- a/servers/audio/effects/SCsub
+++ b/servers/audio/effects/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
-
-Export('env')

--- a/servers/physics/SCsub
+++ b/servers/physics/SCsub
@@ -4,6 +4,4 @@ Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
 
-Export('env')
-
 SConscript("joints/SCsub")

--- a/servers/physics/joints/SCsub
+++ b/servers/physics/joints/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
-
-Export('env')

--- a/servers/visual/SCsub
+++ b/servers/visual/SCsub
@@ -3,5 +3,3 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
-
-Export('env')


### PR DESCRIPTION
Also remove unnecessary `Export('env')` in other SCsubs,
Export should only be used when exporting *new* objects.