### PR TITLE
Add small thumbnails to the FileSystem file list

### DIFF
--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -188,7 +188,7 @@ private:
 	void _file_list_gui_input(Ref<InputEvent> p_event);
 	void _tree_gui_input(Ref<InputEvent> p_event);
 
-	void _update_files(bool p_keep_selection);
+	void _update_file_list(bool p_keep_selection);
 	void _update_file_list_display_mode_button();
 	void _change_file_display();
 	void _fs_changed();


### PR DESCRIPTION
Closes #22303 
![2018-09-28-132757_284x643_scrot](https://user-images.githubusercontent.com/6093119/46205799-5492a080-c322-11e8-8f31-a51a10817741.png)

I also renamed `_update_files(...)` to `_update_file_list(...)` for consistency.