### PR TITLE
Move Penner easing equations to thirdparty/misc

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -278,6 +278,11 @@ Comment: curl
 Copyright: 1998-2012, Daniel Stenberg et al.
 License: curl
 
+Files: ./thirdparty/misc/easing_equations.cpp
+Comment: Robert Penner's Easing Functions
+Copyright: 2001, Robert Penner
+License: BSD-3-clause
+
 Files: ./thirdparty/misc/fastlz.c
  ./thirdparty/misc/fastlz.h
 Comment: FastLZ

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -7,6 +7,8 @@ env.scene_sources = []
 # Thirdparty code
 thirdparty_dir = "#thirdparty/misc/"
 thirdparty_sources = [
+	# C++ sources
+	"easing_equations.cpp",
 	# C sources
 	"mikktspace.c",
 ]

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -375,6 +375,10 @@ Collection of single-file libraries used in Godot components.
 
 ### scene
 
+- `easing_equations.cpp`
+  * Upstream: http://robertpenner.com/easing/ via https://github.com/jesusgollonet/ofpennereasing (modified to fit Godot types)
+  * Version: git (af72c14, 2008) + Godot types and style changes
+  * License: BSD-3-Clause
 - `mikktspace.{c,h}`
   * Upstream: https://wiki.blender.org/index.php/Dev:Shading/Tangent_Space_Normal_Maps
   * Version: 1.0

--- a/thirdparty/misc/easing_equations.cpp
+++ b/thirdparty/misc/easing_equations.cpp
@@ -1,40 +1,10 @@
-/*************************************************************************/
-/*  tween_interpolaters.cpp                                              */
-/*************************************************************************/
-/*                       This file is part of:                           */
-/*                           GODOT ENGINE                                */
-/*                      https://godotengine.org                          */
-/*************************************************************************/
-/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
-/*                                                                       */
-/* Permission is hereby granted, free of charge, to any person obtaining */
-/* a copy of this software and associated documentation files (the       */
-/* "Software"), to deal in the Software without restriction, including   */
-/* without limitation the rights to use, copy, modify, merge, publish,   */
-/* distribute, sublicense, and/or sell copies of the Software, and to    */
-/* permit persons to whom the Software is furnished to do so, subject to */
-/* the following conditions:                                             */
-/*                                                                       */
-/* The above copyright notice and this permission notice shall be        */
-/* included in all copies or substantial portions of the Software.       */
-/*                                                                       */
-/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
-/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
-/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
-/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
-/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
-/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
-/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
-/*************************************************************************/
-
 /**
  *  Adapted from Penner Easing equations' C++ port.
  *  Source: https://github.com/jesusgollonet/ofpennereasing
  *  License: BSD-3-clause
  */
 
-#include "tween.h"
+#include "scene/animation/tween.h"
 
 const real_t pi = 3.1415926535898;
 


### PR DESCRIPTION
It was Godot-ified and integrated into Tween originally (#628) without mention that it was thirdparty code, but it's actually derived from https://github.com/jesusgollonet/ofpennereasing.

It's also very bad quality code and should be replaced by a better, properly-maintained library of easing equations.

Closes #21600 and supersedes #21608 (thirdparty code, we don't change it).