### PR TITLE
Fixed error spam when selecting root in remote tree

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -502,8 +502,12 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				String str = var;
 				var = str.substr(4, str.length());
 
-				if (str.begins_with("PATH"))
-					var = ResourceLoader::load(var);
+				if (str.begins_with("PATH")) {
+					if (String(var).empty())
+						var = RES();
+					else
+						var = ResourceLoader::load(var);
+				}
 			}
 
 			debugObj->prop_values[pinfo.name] = var;


### PR DESCRIPTION
Fixed error spam when selecting root in remote tree.

This fixes #22376.

This also prevents the spam in #22377 but does not solve the root cause of that problem.