### PR TITLE
Made Debugger's Video Memory tab show correct resource paths.

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -423,6 +423,15 @@ ImageTexture::~ImageTexture() {
 
 //////////////////////////////////////////
 
+void StreamTexture::set_path(const String &p_path, bool p_take_over) {
+
+	if (texture.is_valid()) {
+		VisualServer::get_singleton()->texture_set_path(texture, p_path);
+	}
+
+	Resource::set_path(p_path, p_take_over);
+}
+
 void StreamTexture::_requested_3d(void *p_ud) {
 
 	StreamTexture *st = (StreamTexture *)p_ud;

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -219,6 +219,8 @@ public:
 	int get_height() const;
 	virtual RID get_rid() const;
 
+	virtual void set_path(const String &p_path, bool p_take_over);
+
 	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>()) const;
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>()) const;
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>(), bool p_clip_uv = true) const;


### PR DESCRIPTION
Made Debugger's Video Memory tab show correct resource paths.

The Icons are still missing but that is due to the get_icon(type, "EditorIcons") for type = "Texture" being missing. Adding that icon in EditorIcons would fix it.

This fixes #21163