### PR TITLE
Fix build error: inconsistent use of tabs and spaces in indentation

### DIFF
--- a/modules/thekla_unwrap/SCsub
+++ b/modules/thekla_unwrap/SCsub
@@ -58,12 +58,12 @@ if env['builtin_thekla_atlas']:
 
     # upstream uses c++11
     if (not env.msvc):
-         env_thekla_unwrap.Append(CXXFLAGS="-std=c++11")
+        env_thekla_unwrap.Append(CXXFLAGS="-std=c++11")
 
     if env["platform"] == 'x11':
         # if not specifically one of the *BSD, then use LINUX as default
         if platform.system() == "FreeBSD":
-		    env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])
+            env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])
         elif platform.system() == "OpenBSD":
             env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_OPENBSD", "-DPOSH_COMPILER_GCC"])
         else:

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -19,12 +19,12 @@ if env['builtin_xatlas']:
 
     # upstream uses c++11
     if (not env.msvc):
-         env_xatlas_unwrap.Append(CXXFLAGS="-std=c++11")
+        env_xatlas_unwrap.Append(CXXFLAGS="-std=c++11")
 
     if env["platform"] == 'x11':
         # if not specifically one of the *BSD, then use LINUX as default
         if platform.system() == "FreeBSD":
-		    env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])
+            env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])
         elif platform.system() == "OpenBSD":
             env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_OPENBSD", "-DPOSH_COMPILER_GCC"])
         else:


### PR DESCRIPTION
Fixes this build error that happens at least on Windows.

```
File "C:\godot\modules\thekla_unwrap\SCsub", line 66

    env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])

                                                                               ^

TabError: inconsistent use of tabs and spaces in indentation

File "C:\godot\modules\xatlas_unwrap\SCsub", line 27

    env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])

                                                                               ^

TabError: inconsistent use of tabs and spaces in indentation```