### PR TITLE
fixed the tilemap drawing to follow the mouse and the viewport changes

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -1396,8 +1396,7 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 		return;
 
 	Transform2D cell_xf = node->get_cell_transform();
-
-	Transform2D xform = p_overlay->get_canvas_transform() * node->get_global_transform();
+	Transform2D xform = CanvasItemEditor::get_singleton()->get_canvas_transform() * node->get_global_transform();
 	Transform2D xform_inv = xform.affine_inverse();
 
 	Size2 screen_size = p_overlay->get_size();


### PR DESCRIPTION
the forward_canvas_draw_over_viewport function used the wrong xform and thus its map_to_world is not the inverse of the mouse interactor world_to_map, making the tiles draw from 0,0 of the screen instead of 0,0 of the tile map (which is in a different place)

_Bugsquad edit: fixes #22349_ 