### PR TITLE
Remove error raised by curve2d when there is no point in the curve

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -761,8 +761,7 @@ Vector2 Curve2D::interpolate_baked(float p_offset, bool p_cubic) const {
 	//validate//
 	int pc = baked_point_cache.size();
 	if (pc == 0) {
-		ERR_EXPLAIN("No points in Curve2D");
-		ERR_FAIL_COND_V(pc == 0, Vector2());
+		return Vector2();
 	}
 
 	if (pc == 1)


### PR DESCRIPTION
removing the error of "no points in curve2d" as mentioned in this error request https://github.com/godotengine/godot/issues/22338 i just removed the error and defaulted to the fault case of returning 0,0 but i don't know if it solves the error in a satisfactory way.