### PR TITLE
Visualscript search fixes

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -586,6 +586,8 @@ String String::camelcase_to_underscore(bool lowercase) const {
 		bool is_upper = cstr[i] >= A && cstr[i] <= Z;
 		bool is_number = cstr[i] >= '0' && cstr[i] <= '9';
 		bool are_next_2_lower = false;
+		bool is_next_lower = false;
+		bool is_next_number = false;
 		bool was_precedent_upper = cstr[i - 1] >= A && cstr[i - 1] <= Z;
 		bool was_precedent_number = cstr[i - 1] >= '0' && cstr[i - 1] <= '9';
 
@@ -593,7 +595,18 @@ String String::camelcase_to_underscore(bool lowercase) const {
 			are_next_2_lower = cstr[i + 1] >= a && cstr[i + 1] <= z && cstr[i + 2] >= a && cstr[i + 2] <= z;
 		}
 
-		bool should_split = ((is_upper && !was_precedent_upper && !was_precedent_number) || (was_precedent_upper && is_upper && are_next_2_lower) || (is_number && !was_precedent_number));
+		if (i + 1 < this->size()) {
+			is_next_lower = cstr[i + 1] >= a && cstr[i + 1] <= z;
+			is_next_number = cstr[i + 1] >= '0' && cstr[i + 1] <= '9';
+		}
+
+		const bool a = is_upper && !was_precedent_upper && !was_precedent_number;
+		const bool b = was_precedent_upper && is_upper && are_next_2_lower;
+		const bool c = is_number && !was_precedent_number;
+		const bool can_break_number_letter = is_number && !was_precedent_number && is_next_lower;
+		const bool can_break_letter_number = !is_number && was_precedent_number && (is_next_lower || is_next_number);
+
+		bool should_split = a || b || c || can_break_number_letter || can_break_letter_number;
 		if (should_split) {
 			new_string += this->substr(start_index, i - start_index) + "_";
 			start_index = i;

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -480,7 +480,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish % frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	//////// INTS
 
@@ -491,7 +491,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 5 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Int left padded with zeroes.
 	format = "fish %05d frog";
@@ -500,7 +500,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 00005 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Int left padded with spaces.
 	format = "fish %5d frog";
@@ -509,7 +509,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish     5 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Int right padded with spaces.
 	format = "fish %-5d frog";
@@ -518,7 +518,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 5     frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Int with sign (positive).
 	format = "fish %+d frog";
@@ -527,7 +527,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish +5 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Negative int.
 	format = "fish %d frog";
@@ -536,7 +536,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish -5 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Hex (lower)
 	format = "fish %x frog";
@@ -545,7 +545,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 2d frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Hex (upper)
 	format = "fish %X frog";
@@ -554,7 +554,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 2D frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Octal
 	format = "fish %o frog";
@@ -563,7 +563,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 143 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	////// REALS
 
@@ -574,7 +574,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 99.990000 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Real left-padded
 	format = "fish %11f frog";
@@ -583,7 +583,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish   99.990000 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Real right-padded
 	format = "fish %-11f frog";
@@ -592,7 +592,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 99.990000   frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Real given int.
 	format = "fish %f frog";
@@ -601,7 +601,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 99.000000 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Real with sign (positive).
 	format = "fish %+f frog";
@@ -610,7 +610,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish +99.990000 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Real with 1 decimals.
 	format = "fish %.1f frog";
@@ -619,7 +619,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 100.0 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Real with 12 decimals.
 	format = "fish %.12f frog";
@@ -628,7 +628,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 99.990000000000 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Real with no decimals.
 	format = "fish %.f frog";
@@ -637,7 +637,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish 100 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	/////// Strings.
 
@@ -648,7 +648,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish cheese frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// String left-padded
 	format = "fish %10s frog";
@@ -657,7 +657,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish     cheese frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// String right-padded
 	format = "fish %-10s frog";
@@ -666,7 +666,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish cheese     frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	///// Characters
 
@@ -677,7 +677,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish A frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Character as int.
 	format = "fish %c frog";
@@ -686,7 +686,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish A frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	///// Dynamic width
 
@@ -698,7 +698,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish     cheese frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Int dynamic width
 	format = "fish %*d frog";
@@ -708,7 +708,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish         99 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Float dynamic width
 	format = "fish %*.*f frog";
@@ -719,7 +719,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == String("fish     99.990 frog") && !error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	///// Errors
 
@@ -730,7 +730,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == "not enough arguments for format string" && error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// More arguments than formats.
 	format = "fish %s frog";
@@ -740,7 +740,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == "not all arguments converted during string formatting" && error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Incomplete format.
 	format = "fish %10";
@@ -749,7 +749,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == "incomplete format" && error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Bad character in format string
 	format = "fish %&f frog";
@@ -758,7 +758,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == "unsupported format character" && error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Too many decimals.
 	format = "fish %2.2.2f frog";
@@ -767,7 +767,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == "too many decimal points in format" && error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// * not a number
 	format = "fish %*f frog";
@@ -777,7 +777,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == "* wants number" && error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Character too long.
 	format = "fish %c frog";
@@ -786,7 +786,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == "%c requires number or single-character string" && error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	// Character bad type.
 	format = "fish %c frog";
@@ -795,7 +795,7 @@ bool test_28() {
 	output = format.sprintf(args, &error);
 	success = (output == "%c requires number or single-character string" && error);
 	OS::get_singleton()->print(output_format, format.c_str(), output.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	return state;
 }
@@ -819,37 +819,127 @@ bool test_29() {
 	String ip4 = "192.168.0.1";
 	bool success = ip4.is_valid_ip_address();
 	OS::get_singleton()->print("Is valid ipv4: %ls, %s\n", ip4.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	ip4 = "192.368.0.1";
 	success = (!ip4.is_valid_ip_address());
 	OS::get_singleton()->print("Is invalid ipv4: %ls, %s\n", ip4.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	String ip6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
 	success = ip6.is_valid_ip_address();
 	OS::get_singleton()->print("Is valid ipv6: %ls, %s\n", ip6.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	ip6 = "2001:0db8:85j3:0000:0000:8a2e:0370:7334";
 	success = (!ip6.is_valid_ip_address());
 	OS::get_singleton()->print("Is invalid ipv6: %ls, %s\n", ip6.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	ip6 = "2001:0db8:85f345:0000:0000:8a2e:0370:7334";
 	success = (!ip6.is_valid_ip_address());
 	OS::get_singleton()->print("Is invalid ipv6: %ls, %s\n", ip6.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	ip6 = "2001:0db8::0:8a2e:370:7334";
 	success = (ip6.is_valid_ip_address());
 	OS::get_singleton()->print("Is valid ipv6: %ls, %s\n", ip6.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
 
 	ip6 = "::ffff:192.168.0.1";
 	success = (ip6.is_valid_ip_address());
 	OS::get_singleton()->print("Is valid ipv6: %ls, %s\n", ip6.c_str(), success ? "OK" : "FAIL");
-	if (!success) state = false;
+	state = state && success;
+
+	return state;
+};
+
+bool test_30() {
+	bool state = true;
+	bool success = true;
+	String input = "bytes2var";
+	String output = "Bytes 2 Var";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "linear2db";
+	output = "Linear 2 Db";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "vector3";
+	output = "Vector 3";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "sha256";
+	output = "Sha 256";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "2db";
+	output = "2 Db";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "PascalCase";
+	output = "Pascal Case";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "PascalPascalCase";
+	output = "Pascal Pascal Case";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "snake_case";
+	output = "Snake Case";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "snake_snake_case";
+	output = "Snake Snake Case";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "sha256sum";
+	output = "Sha 256 Sum";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "cat2dog";
+	output = "Cat 2 Dog";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "function(name)";
+	output = "Function(name)";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls (existing incorrect behavior): %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "snake_case_function(snake_case_arg)";
+	output = "Snake Case Function(snake Case Arg)";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls (existing incorrect behavior): %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
+
+	input = "snake_case_function( snake_case_arg )";
+	output = "Snake Case Function( Snake Case Arg )";
+	success = (input.capitalize() == output);
+	state = state && success;
+	OS::get_singleton()->print("Capitalize %ls: %ls, %s\n", input.c_str(), output.c_str(), success ? "OK" : "FAIL");
 
 	return state;
 };
@@ -887,6 +977,7 @@ TestFunc test_funcs[] = {
 	test_27,
 	test_28,
 	test_29,
+	test_30,
 	0
 
 };

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -3708,18 +3708,18 @@ void register_visual_script_nodes() {
 		for (List<MethodInfo>::Element *E = constructors.front(); E; E = E->next()) {
 
 			if (E->get().arguments.size() > 0) {
-
-				String name = "functions/constructors/" + Variant::get_type_name(Variant::Type(i)) + " ( ";
+				String name = "functions/constructors/" + Variant::get_type_name(Variant::Type(i)) + "(";
 				for (int j = 0; j < E->get().arguments.size(); j++) {
-					if (j > 0)
+					if (j > 0) {
 						name += ", ";
-					if (E->get().arguments.size() == 1)
+					}
+					if (E->get().arguments.size() == 1) {
 						name += Variant::get_type_name(E->get().arguments[j].type);
-					else
+					} else {
 						name += E->get().arguments[j].name;
+					}
 				}
-				name += ") ";
-
+				name += ")";
 				VisualScriptLanguage::singleton->add_register_func(name, create_constructor_node);
 				Pair<Variant::Type, MethodInfo> pair;
 				pair.first = Variant::Type(i);


### PR DESCRIPTION
The Visualscript search has display problems.

* There were spaces unequally inside the function definitions.
* camelcase_to_underscore() should also work for numbers inside of the camel case.
* Removed the builtin concept
* Capitalize descriptions from methods too.
* Match the visual script functions by removing the empty arguments "( )"

(out of date images here were removed)

Before:
![godot windows opt tools 64_2018-09-29_21-38-18](https://user-images.githubusercontent.com/32321/46253408-14b9df00-c430-11e8-81fc-bb8318c65602.png)

After:

![godot windows opt tools 64_2018-09-29_21-52-54](https://user-images.githubusercontent.com/32321/46253500-0c62a380-c432-11e8-9dcb-a457f9cfaed6.png)

