### PR TITLE
TextEdit: prevent the copy of an empty string

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4547,9 +4547,13 @@ void TextEdit::cut() {
 void TextEdit::copy() {
 
 	if (!selection.active) {
-		String clipboard = _base_get_text(cursor.line, 0, cursor.line, text[cursor.line].length());
-		OS::get_singleton()->set_clipboard(clipboard);
-		cut_copy_line = clipboard;
+
+		if (text[cursor.line].length() != 0) {
+
+			String clipboard = _base_get_text(cursor.line, 0, cursor.line, text[cursor.line].length());
+			OS::get_singleton()->set_clipboard(clipboard);
+			cut_copy_line = clipboard;
+		}
 	} else {
 		String clipboard = _base_get_text(selection.from_line, selection.from_column, selection.to_line, selection.to_column);
 		OS::get_singleton()->set_clipboard(clipboard);


### PR DESCRIPTION
With this change the clipboard isn't deleted after you hit Ctrl+C on an empty line.
Note:
RichTextLabel checks for empty strings before the copy to clipboard:
https://github.com/godotengine/godot/blob/4cf5bb027678717263476e676cd23f881eef1ca1/scene/gui/rich_text_label.cpp#L2074