### PR TITLE
Uses skip_vertex_transform in GLES2 canvas shader

### DIFF
--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -89,9 +89,14 @@ VERTEX_SHADER_CODE
 		/* clang-format on */
 	}
 
+#if !defined(SKIP_TRANSFORM_USED)
+	outvec = extra_matrix * outvec;
+	outvec = modelview_matrix * outvec;
+#endif
+
 	color_interp = color;
 
-	gl_Position = projection_matrix * modelview_matrix * outvec;
+	gl_Position = projection_matrix * outvec;
 }
 
 /* clang-format off */


### PR DESCRIPTION
Issue:
render_mode skip_vertex_transform is ignored in GLES2 canvas shader

The snippet was copied from gles3 canvas.glsl

Repro:
- Open attached project, open main.tscn scene
- For each renderer, move the 2d scene view or run the scene
- The label with the shader material "floats" around in gles2

[bug_gles2_canvas_skip_transform.zip](https://github.com/godotengine/godot/files/2431698/bug_gles2_canvas_skip_transform.zip)
