### PR TITLE
Add a subtle background and border to unselected tabs in the editor

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -478,8 +478,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tab_selected->set_bg_color(tab_color);
 
 	Ref<StyleBoxFlat> style_tab_unselected = style_tab_selected->duplicate();
-	style_tab_unselected->set_draw_center(false);
-	style_tab_unselected->set_border_width_all(0);
+	style_tab_unselected->set_bg_color(dark_color_1);
+	style_tab_unselected->set_border_color_all(dark_color_2);
 
 	// Editor background
 	theme->set_stylebox("Background", "EditorStyles", make_flat_stylebox(background_color, default_margin_size, default_margin_size, default_margin_size, default_margin_size));


### PR DESCRIPTION
Some users have complained about unselected tabs being difficult to notice. This adds a subtle background that should make them easier to see.

It's not very noticeable, but I don't think it can be made much lighter without decreasing the contrast between the selected tab and unselected tabs too much.

**Preview:**

![tab_background_1](https://user-images.githubusercontent.com/180032/46260267-0200e200-c4e4-11e8-9b6e-796ec5d6bf81.png)

![tab_background_2](https://user-images.githubusercontent.com/180032/46260268-02997880-c4e4-11e8-987d-fe0923395756.png)

![tab_background_3](https://user-images.githubusercontent.com/180032/46260269-02997880-c4e4-11e8-99f4-ad65d0aafa75.png)

![tab_background_4](https://user-images.githubusercontent.com/180032/46260271-02997880-c4e4-11e8-8051-3e2eebd344bb.png)