### PR TITLE
Fix unnecessary parentheses warnings with GCC 8 [-Wparentheses]

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -318,7 +318,7 @@ protected:                                                                      
 	virtual void _initialize_classv() {                                                                                                 \
 		initialize_class();                                                                                                             \
 	}                                                                                                                                   \
-	_FORCE_INLINE_ bool (Object::*(_get_get() const))(const StringName &p_name, Variant &) const {                                      \
+	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &) const {                                        \
 		return (bool (Object::*)(const StringName &, Variant &) const) & m_class::_get;                                                 \
 	}                                                                                                                                   \
 	virtual bool _getv(const StringName &p_name, Variant &r_ret) const {                                                                \
@@ -328,7 +328,7 @@ protected:                                                                      
 		}                                                                                                                               \
 		return m_inherits::_getv(p_name, r_ret);                                                                                        \
 	}                                                                                                                                   \
-	_FORCE_INLINE_ bool (Object::*(_get_set() const))(const StringName &p_name, const Variant &p_property) {                            \
+	_FORCE_INLINE_ bool (Object::*_get_set() const)(const StringName &p_name, const Variant &p_property) {                              \
 		return (bool (Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                 \
 	}                                                                                                                                   \
 	virtual bool _setv(const StringName &p_name, const Variant &p_property) {                                                           \
@@ -338,7 +338,7 @@ protected:                                                                      
 		}                                                                                                                               \
 		return false;                                                                                                                   \
 	}                                                                                                                                   \
-	_FORCE_INLINE_ void (Object::*(_get_get_property_list() const))(List<PropertyInfo> * p_list) const {                                \
+	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> * p_list) const {                                  \
 		return (void (Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                            \
 	}                                                                                                                                   \
 	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const {                                               \
@@ -357,7 +357,7 @@ protected:                                                                      
 			m_inherits::_get_property_listv(p_list, p_reversed);                                                                        \
 		}                                                                                                                               \
 	}                                                                                                                                   \
-	_FORCE_INLINE_ void (Object::*(_get_notification() const))(int) {                                                                   \
+	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {                                                                     \
 		return (void (Object::*)(int)) & m_class::_notification;                                                                        \
 	}                                                                                                                                   \
 	virtual void _notificationv(int p_notification, bool p_reversed) {                                                                  \
@@ -514,16 +514,16 @@ protected:
 	_FORCE_INLINE_ static void (*_get_bind_methods())() {
 		return &Object::_bind_methods;
 	}
-	_FORCE_INLINE_ bool (Object::*(_get_get() const))(const StringName &p_name, Variant &r_ret) const {
+	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &r_ret) const {
 		return &Object::_get;
 	}
-	_FORCE_INLINE_ bool (Object::*(_get_set() const))(const StringName &p_name, const Variant &p_property) {
+	_FORCE_INLINE_ bool (Object::*_get_set() const)(const StringName &p_name, const Variant &p_property) {
 		return &Object::_set;
 	}
-	_FORCE_INLINE_ void (Object::*(_get_get_property_list() const))(List<PropertyInfo> *p_list) const {
+	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> *p_list) const {
 		return &Object::_get_property_list;
 	}
-	_FORCE_INLINE_ void (Object::*(_get_notification() const))(int) {
+	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {
 		return &Object::_notification;
 	}
 	static void get_valid_parents_static(List<String> *p_parents);


### PR DESCRIPTION
Fixes the following GCC 8 warnings:
```
core/object.h:321:32: warning: unnecessary parentheses in declaration of '_get_get' [-Wparentheses]
core/object.h:331:32: warning: unnecessary parentheses in declaration of '_get_set' [-Wparentheses]
core/object.h:341:32: warning: unnecessary parentheses in declaration of '_get_get_property_list' [-Wparentheses]
core/object.h:360:32: warning: unnecessary parentheses in declaration of '_get_notification' [-Wparentheses]
core/object.h:517:32: warning: unnecessary parentheses in declaration of '_get_get' [-Wparentheses]
core/object.h:520:32: warning: unnecessary parentheses in declaration of '_get_set' [-Wparentheses]
core/object.h:523:32: warning: unnecessary parentheses in declaration of '_get_get_property_list' [-Wparentheses]
core/object.h:526:32: warning: unnecessary parentheses in declaration of '_get_notification' [-Wparentheses]
```