### PR TITLE
Moving lens distortion shader into drivers and adding GLES2 support

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -788,6 +788,7 @@ public:
 	void restore_render_target() {}
 	void clear_render_target(const Color &p_color) {}
 	void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0) {}
+	void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) {}
 	void end_frame(bool p_swap_buffers) {}
 	void finalize() {}
 

--- a/drivers/gles2/rasterizer_canvas_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_gles2.h
@@ -34,6 +34,7 @@
 #include "servers/visual/rasterizer.h"
 
 #include "shaders/canvas.glsl.gen.h"
+#include "shaders/lens_distorted.glsl.gen.h"
 
 // #include "shaders/canvas_shadow.glsl.gen.h"
 
@@ -70,6 +71,7 @@ public:
 		bool canvas_texscreen_used;
 		CanvasShaderGLES2 canvas_shader;
 		// CanvasShadowShaderGLES3 canvas_shadow_shader;
+		LensDistortedShaderGLES2 lens_shader;
 
 		bool using_texture_rect;
 		bool using_ninepatch;
@@ -117,6 +119,7 @@ public:
 
 	void _bind_quad_buffer();
 	void draw_generic_textured_rect(const Rect2 &p_rect, const Rect2 &p_src);
+	void draw_lens_distortion_rect(const Rect2 &p_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample);
 
 	void initialize();
 	void finalize();

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -380,6 +380,26 @@ void RasterizerGLES2::blit_render_target_to_screen(RID p_render_target, const Re
 	canvas->canvas_end();
 }
 
+void RasterizerGLES2::output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) {
+	ERR_FAIL_COND(storage->frame.current_rt);
+
+	RasterizerStorageGLES2::RenderTarget *rt = storage->render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	glDisable(GL_BLEND);
+
+	// render to our framebuffer
+	glBindFramebuffer(GL_FRAMEBUFFER, RasterizerStorageGLES2::system_fbo);
+
+	// output our texture
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, rt->color);
+
+	canvas->draw_lens_distortion_rect(p_screen_rect, p_k1, p_k2, p_eye_center, p_oversample);
+
+	glBindTexture(GL_TEXTURE_2D, 0);
+}
+
 void RasterizerGLES2::end_frame(bool p_swap_buffers) {
 
 	if (OS::get_singleton()->is_layered_allowed()) {

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -59,6 +59,7 @@ public:
 	virtual void restore_render_target();
 	virtual void clear_render_target(const Color &p_color);
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0);
+	virtual void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample);
 	virtual void end_frame(bool p_swap_buffers);
 	virtual void finalize();
 

--- a/drivers/gles2/shaders/SCsub
+++ b/drivers/gles2/shaders/SCsub
@@ -20,3 +20,4 @@ if 'GLES2_GLSL' in env['BUILDERS']:
 #    env.GLES2_GLSL('exposure.glsl');
 #    env.GLES2_GLSL('tonemap.glsl');
 #    env.GLES2_GLSL('particles.glsl');
+    env.GLES2_GLSL('lens_distorted.glsl');

--- a/drivers/gles2/shaders/lens_distorted.glsl
+++ b/drivers/gles2/shaders/lens_distorted.glsl
@@ -1,0 +1,62 @@
+/* clang-format off */
+[vertex]
+
+attribute highp vec2 vertex; // attrib:0
+/* clang-format on */
+
+uniform vec2 offset;
+uniform vec2 scale;
+
+varying vec2 uv_interp;
+
+void main() {
+
+	uv_interp = vertex.xy * 2.0 - 1.0;
+
+	vec2 v = vertex.xy * scale + offset;
+	gl_Position = vec4(v, 0.0, 1.0);
+}
+
+/* clang-format off */
+[fragment]
+
+uniform sampler2D source; //texunit:0
+/* clang-format on */
+
+uniform vec2 eye_center;
+uniform float k1;
+uniform float k2;
+uniform float upscale;
+uniform float aspect_ratio;
+
+varying vec2 uv_interp;
+
+void main() {
+	vec2 coords = uv_interp;
+	vec2 offset = coords - eye_center;
+
+	// take aspect ratio into account
+	offset.y /= aspect_ratio;
+
+	// distort
+	vec2 offset_sq = offset * offset;
+	float radius_sq = offset_sq.x + offset_sq.y;
+	float radius_s4 = radius_sq * radius_sq;
+	float distortion_scale = 1.0 + (k1 * radius_sq) + (k2 * radius_s4);
+	offset *= distortion_scale;
+
+	// reapply aspect ratio
+	offset.y *= aspect_ratio;
+
+	// add our eye center back in
+	coords = offset + eye_center;
+	coords /= upscale;
+
+	// and check our color
+	if (coords.x < -1.0 || coords.y < -1.0 || coords.x > 1.0 || coords.y > 1.0) {
+		gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+	} else {
+		coords = (coords + vec2(1.0)) / vec2(2.0);
+		gl_FragColor = texture2D(source, coords);
+	}
+}

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -35,6 +35,7 @@
 #include "servers/visual/rasterizer.h"
 
 #include "shaders/canvas_shadow.glsl.gen.h"
+#include "shaders/lens_distorted.glsl.gen.h"
 
 class RasterizerSceneGLES3;
 
@@ -72,6 +73,7 @@ public:
 		bool canvas_texscreen_used;
 		CanvasShaderGLES3 canvas_shader;
 		CanvasShadowShaderGLES3 canvas_shadow_shader;
+		LensDistortedShaderGLES3 lens_shader;
 
 		bool using_texture_rect;
 		bool using_ninepatch;
@@ -141,6 +143,7 @@ public:
 	virtual void reset_canvas();
 
 	void draw_generic_textured_rect(const Rect2 &p_rect, const Rect2 &p_src);
+	void draw_lens_distortion_rect(const Rect2 &p_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample);
 
 	void initialize();
 	void finalize();

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -359,6 +359,26 @@ void RasterizerGLES3::blit_render_target_to_screen(RID p_render_target, const Re
 #endif
 }
 
+void RasterizerGLES3::output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) {
+	ERR_FAIL_COND(storage->frame.current_rt);
+
+	RasterizerStorageGLES3::RenderTarget *rt = storage->render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	glDisable(GL_BLEND);
+
+	// render to our framebuffer
+	glBindFramebuffer(GL_FRAMEBUFFER, RasterizerStorageGLES3::system_fbo);
+
+	// output our texture
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, rt->color);
+
+	canvas->draw_lens_distortion_rect(p_screen_rect, p_k1, p_k2, p_eye_center, p_oversample);
+
+	glBindTexture(GL_TEXTURE_2D, 0);
+}
+
 void RasterizerGLES3::end_frame(bool p_swap_buffers) {
 
 	if (OS::get_singleton()->is_layered_allowed()) {

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -59,6 +59,7 @@ public:
 	virtual void restore_render_target();
 	virtual void clear_render_target(const Color &p_color);
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0);
+	virtual void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample);
 	virtual void end_frame(bool p_swap_buffers);
 	virtual void finalize();
 

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -20,3 +20,4 @@ if 'GLES3_GLSL' in env['BUILDERS']:
     env.GLES3_GLSL('exposure.glsl');
     env.GLES3_GLSL('tonemap.glsl');
     env.GLES3_GLSL('particles.glsl');
+    env.GLES3_GLSL('lens_distorted.glsl');

--- a/drivers/gles3/shaders/lens_distorted.glsl
+++ b/drivers/gles3/shaders/lens_distorted.glsl
@@ -3,16 +3,18 @@
 
 layout(location = 0) in highp vec4 vertex_attrib;
 /* clang-format on */
-layout(location = 4) in vec2 uv_in;
 
-uniform float offset_x;
+uniform vec2 offset;
+uniform vec2 scale;
 
 out vec2 uv_interp;
 
 void main() {
 
-	uv_interp = uv_in;
-	gl_Position = vec4(vertex_attrib.x + offset_x, vertex_attrib.y, 0.0, 1.0);
+	uv_interp = vertex_attrib.xy * 2.0 - 1.0;
+
+	vec2 v = vertex_attrib.xy * scale + offset;
+	gl_Position = vec4(v, 0.0, 1.0);
 }
 
 /* clang-format off */

--- a/modules/mobile_vr/SCsub
+++ b/modules/mobile_vr/SCsub
@@ -6,5 +6,3 @@ Import('env_modules')
 env_mobile_vr = env_modules.Clone()
 
 env_mobile_vr.add_source_files(env.modules_sources, '*.cpp')
-
-SConscript("shaders/SCsub")

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -34,10 +34,6 @@
 #include "servers/arvr/arvr_interface.h"
 #include "servers/arvr/arvr_positional_tracker.h"
 
-#if !defined(SERVER_ENABLED)
-#include "shaders/lens_distorted.glsl.gen.h"
-#endif
-
 /**
 	@author Bastiaan Olij <mux213@gmail.com>
 
@@ -59,14 +55,6 @@ private:
 	Basis orientation;
 	float eye_height;
 	uint64_t last_ticks;
-
-#if !defined(SERVER_ENABLED)
-	LensDistortedShaderGLES3 *lens_shader;
-	GLuint half_screen_quad;
-	GLuint half_screen_array;
-#else
-	void *lens_shader;
-#endif
 
 	real_t intraocular_dist;
 	real_t display_width;

--- a/modules/mobile_vr/shaders/SCsub
+++ b/modules/mobile_vr/shaders/SCsub
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-Import('env')
-
-if 'GLES3_GLSL' in env['BUILDERS']:
-    env.GLES3_GLSL('lens_distorted.glsl');

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1104,6 +1104,7 @@ public:
 	virtual void restore_render_target() = 0;
 	virtual void clear_render_target(const Color &p_color) = 0;
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0) = 0;
+	virtual void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) = 0;
 	virtual void end_frame(bool p_swap_buffers) = 0;
 	virtual void finalize() = 0;
 


### PR DESCRIPTION
Moving the lens distortion shader out of the mobile_vr module and into the GLES2 and GLES3 drivers. 
