### PR TITLE
Fixed inspector not going back to single-node when deselecting an item.

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1587,6 +1587,10 @@ void SceneTreeDock::_selection_changed() {
 	if (selection_size > 1) {
 		//automatically turn on multi-edit
 		_tool_selected(TOOL_MULTI_EDIT);
+	} else if (selection_size == 1) {
+		editor->push_item(EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list()[0]);
+	} else {
+		editor->push_item(NULL);
 	}
 	_update_script_button();
 }


### PR DESCRIPTION
Fixed inspector not going back to single-node when deselecting an item.

Fixes #22479