### PR TITLE
Minor nit-picky tweaks in spatial_editor_plugin.cpp

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -531,12 +531,12 @@ void SpatialEditorViewport::_select_region() {
 
 void SpatialEditorViewport::_update_name() {
 
-	String ortho = orthogonal ? TTR("Orthogonal") : TTR("Perspective");
+	String view_mode = orthogonal ? TTR("Orthogonal") : TTR("Perspective");
 
 	if (name != "")
-		view_menu->set_text("[ " + name + " " + ortho + " ]");
+		view_menu->set_text("[ " + name + " " + view_mode + " ]");
 	else
-		view_menu->set_text("[ " + ortho + " ]");
+		view_menu->set_text("[ " + view_mode + " ]");
 
 	view_menu->set_size(Vector2(0, 0)); // resets the button size
 }
@@ -1912,7 +1912,7 @@ void SpatialEditorViewport::_nav_orbit(Ref<InputEventWithModifiers> p_event, con
 void SpatialEditorViewport::_nav_look(Ref<InputEventWithModifiers> p_event, const Vector2 &p_relative) {
 
 	// Freelook only works properly in perspective.
-	// It technically works too in ortho, but it's awful for a user due to fov being near zero
+	// It could technically work in ortho, but it's terrible for a user due to FOV being a fixed width.
 	if (!orthogonal) {
 		real_t degrees_per_pixel = EditorSettings::get_singleton()->get("editors/3d/navigation_feel/orbit_sensitivity");
 		real_t radians_per_pixel = Math::deg2rad(degrees_per_pixel);


### PR DESCRIPTION
* Orthogonal cameras don't have an FOV that's "near zero". Or zero, or any number of degrees. It's not a measurement of degrees, it's just a fixed width. This comment is more accurate. Also, "terrible" is a better word than "awful" here.

* While I'm editing this file, the "String ortho" variable name could be more intuitive, so I've changed it to "view_mode".

Minor nit-picky changes, I know, but I found it so I may as well improve it.

It's not vital or anything but you may as well put it on the 3.1 milestone.