### PR TITLE
SCons: Remove avoidable defines from main env's CPPPATH

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -157,7 +157,6 @@ opts.Add(BoolVariable('deprecated', "Enable deprecated features", True))
 opts.Add(BoolVariable('gdscript', "Enable GDScript support", True))
 opts.Add(BoolVariable('minizip', "Enable ZIP archive support using minizip", True))
 opts.Add(BoolVariable('xaudio2', "Enable the XAudio2 audio driver", False))
-opts.Add(BoolVariable('xml', "Enable XML format support for resources", True))
 
 # Advanced options
 opts.Add(BoolVariable('disable_3d', "Disable 3D nodes for a smaller executable", False))
@@ -228,14 +227,14 @@ Help(opts.GenerateHelpText(env_base))  # generate help
 
 # add default include paths
 
-env_base.Append(CPPPATH=['#editor', '#drivers', '#'])
+env_base.Append(CPPPATH=['#editor', '#'])
 
 # configure ENV for platform
 env_base.platform_exporters = platform_exporters
 env_base.platform_apis = platform_apis
 
 if (env_base['target'] == 'debug'):
-    env_base.Append(CPPDEFINES=['DEBUG_MEMORY_ALLOC', 'SCI_NAMESPACE'])
+    env_base.Append(CPPDEFINES=['DEBUG_MEMORY_ALLOC'])
 
 if (env_base['no_editor_splash']):
     env_base.Append(CPPDEFINES=['NO_EDITOR_SPLASH'])
@@ -444,8 +443,6 @@ if selected_platform in platform_list:
             env.Append(CPPDEFINES=['ADVANCED_GUI_DISABLED'])
     if env['minizip']:
         env.Append(CPPDEFINES=['MINIZIP_ENABLED'])
-    if env['xml']:
-        env.Append(CPPDEFINES=['XML_ENABLED'])
 
     if not env['verbose']:
         methods.no_verbose(sys, env)

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -32,7 +32,7 @@
 
 #include "core/os/os.h"
 #include "core/project_settings.h"
-#include "gl_context/context_gl.h"
+#include "drivers/gl_context/context_gl.h"
 
 #define _EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB 0x8242
 #define _EXT_DEBUG_NEXT_LOGGED_MESSAGE_LENGTH_ARB 0x8243

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -32,7 +32,7 @@
 
 #include "core/os/os.h"
 #include "core/project_settings.h"
-#include "gl_context/context_gl.h"
+#include "drivers/gl_context/context_gl.h"
 
 RasterizerStorage *RasterizerGLES3::get_storage() {
 

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -27,6 +27,8 @@ if env['builtin_libpng']:
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_png.Append(CPPPATH=[thirdparty_dir])
+    # Needed for drivers includes and in platform/javascript
+    env.Append(CPPPATH=[thirdparty_dir])
 
     # Currently .ASM filter_neon.S does not compile on NT.
     import os

--- a/drivers/register_driver_types.cpp
+++ b/drivers/register_driver_types.cpp
@@ -31,11 +31,11 @@
 #include "register_driver_types.h"
 
 #include "core/math/geometry.h"
-#include "png/image_loader_png.h"
-#include "png/resource_saver_png.h"
+#include "drivers/png/image_loader_png.h"
+#include "drivers/png/resource_saver_png.h"
 
 #ifdef TOOLS_ENABLED
-#include "convex_decomp/b2d_decompose.h"
+#include "drivers/convex_decomp/b2d_decompose.h"
 #endif
 
 #ifdef TOOLS_ENABLED

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -79,7 +79,9 @@ if env['tools']:
     env.CommandNoCache('#editor/builtin_fonts.gen.h', flist, run_in_subprocess(editor_builders.make_fonts_header))
 
     env.add_source_files(env.editor_sources, "*.cpp")
-    env.add_source_files(env.editor_sources, ["#thirdparty/misc/clipper.cpp"])
+    env_thirdparty = env.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.editor_sources, ["#thirdparty/misc/clipper.cpp"])
 
     SConscript('collada/SCsub')
     SConscript('doc/SCsub')

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
 Import('env')
+Import('env_modules')
+
 from compat import isbasestring
 
-# Not building in a separate env as scene needs it
+env_freetype = env_modules.Clone()
 
 # Thirdparty source files
 if env['builtin_freetype']:
@@ -54,28 +56,33 @@ if env['builtin_freetype']:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
+    if env['platform'] == 'uwp':
+        # Include header for UWP to fix build issues
+        env_freetype.Append(CCFLAGS=['/FI', '"modules/freetype/uwpdef.h"'])
+
     sfnt = thirdparty_dir + 'src/sfnt/sfnt.c'
-
-    if 'platform' in env:
-        if env['platform'] == 'uwp':
-            # Include header for UWP to fix build issues
-            env.Append(CCFLAGS=['/FI', '"modules/freetype/uwpdef.h"'])
-        elif env['platform'] == 'javascript':
-            # Forcibly undefine this macro so SIMD is not used in this file,
-            # since currently unsupported in WASM
-            sfnt = env.Object(sfnt, CPPFLAGS=['-U__OPTIMIZE__'])
-
+    if env['platform'] == 'javascript':
+        # Forcibly undefine this macro so SIMD is not used in this file,
+        # since currently unsupported in WASM
+        sfnt = env_freetype.Object(sfnt, CPPFLAGS=['-U__OPTIMIZE__'])
     thirdparty_sources += [sfnt]
 
-    env.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "/include"])
+    env_freetype.Append(CPPPATH=[thirdparty_dir + "/include"])
+    # Also needed in main env for scene/
+    env.Append(CPPPATH=[thirdparty_dir + "/include"])
 
-    # also requires libpng headers
+    env_freetype.Append(CCFLAGS=['-DFT2_BUILD_LIBRARY', '-DFT_CONFIG_OPTION_USE_PNG'])
+    if (env['target'] != 'release'):
+        env_freetype.Append(CCFLAGS=['-DZLIB_DEBUG'])
+
+    # Also requires libpng headers
     if env['builtin_libpng']:
-        env.Append(CPPPATH=["#thirdparty/libpng"])
+        env_freetype.Append(CPPPATH=["#thirdparty/libpng"])
 
-    # FIXME: Find a way to build this in a separate env nevertheless
-    # so that we can disable warnings on thirdparty code
-    lib = env.add_library("freetype_builtin", thirdparty_sources)
+    env_thirdparty = env_freetype.Clone()
+    env_thirdparty.disable_warnings()
+    lib = env_thirdparty.add_library("freetype_builtin", thirdparty_sources)
+
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
     # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
@@ -88,12 +95,8 @@ if env['builtin_freetype']:
             break
     if not inserted:
         env.Append(LIBS=[lib])
-    env.Append(CCFLAGS=['-DFT2_BUILD_LIBRARY'])
-    if (env['target'] != 'release'):
-        env.Append(CCFLAGS=['-DZLIB_DEBUG'])
 
 # Godot source files
-env.add_source_files(env.modules_sources, "*.cpp")
-env.Append(CCFLAGS=['-DFREETYPE_ENABLED', '-DFT_CONFIG_OPTION_USE_PNG'])
-
-Export('env')
+env_freetype.add_source_files(env.modules_sources, "*.cpp")
+# Used in scene/, needs to be in main env
+env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
 Import('env')
+Import('env_modules')
+
+env_svg = env_modules.Clone()
 
 # Thirdparty source files
 thirdparty_dir = "#thirdparty/nanosvg/"
@@ -9,12 +12,15 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
+env_svg.Append(CPPPATH=[thirdparty_dir])
+# FIXME: Needed in editor/editor_themes.cpp for now, but ideally there
+# shouldn't be a dependency on modules/ and its own 3rd party deps.
 env.Append(CPPPATH=[thirdparty_dir])
 env.Append(CCFLAGS=["-DSVG_ENABLED"])
 
-env_thirdparty = env.Clone()
+env_thirdparty = env_svg.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot's own source files
-env.add_source_files(env.modules_sources, "*.cpp")
+env_svg.add_source_files(env.modules_sources, "*.cpp")

--- a/platform/haiku/detect.py
+++ b/platform/haiku/detect.py
@@ -148,7 +148,7 @@ def configure(env):
     ## Flags
 
     env.Append(CPPPATH=['#platform/haiku'])
-    env.Append(CPPFLAGS=['-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES_ENABLED', '-DGLES_OVER_GL'])
+    env.Append(CPPFLAGS=['-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES_ENABLED'])
     env.Append(CPPFLAGS=['-DMEDIA_KIT_ENABLED'])
     # env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
     env.Append(CPPFLAGS=['-DPTHREAD_NO_RENAME'])  # TODO: enable when we have pthread_setname_np

--- a/platform/haiku/platform_config.h
+++ b/platform/haiku/platform_config.h
@@ -33,5 +33,5 @@
 // for ifaddrs.h needed in drivers/unix/ip_unix.cpp
 #define _BSD_SOURCE 1
 
-#define GLES3_INCLUDE_H "glad/glad.h"
-#define GLES2_INCLUDE_H "glad/glad.h"
+#define GLES3_INCLUDE_H "thirdparty/glad/glad/glad.h"
+#define GLES2_INCLUDE_H "thirdparty/glad/glad/glad.h"

--- a/platform/osx/platform_config.h
+++ b/platform/osx/platform_config.h
@@ -30,6 +30,6 @@
 
 #include <alloca.h>
 
-#define GLES3_INCLUDE_H "glad/glad.h"
-#define GLES2_INCLUDE_H "glad/glad.h"
+#define GLES3_INCLUDE_H "thirdparty/glad/glad/glad.h"
+#define GLES2_INCLUDE_H "thirdparty/glad/glad/glad.h"
 #define PTHREAD_RENAME_SELF

--- a/platform/windows/platform_config.h
+++ b/platform/windows/platform_config.h
@@ -32,5 +32,5 @@
 //#else
 //#include <alloca.h>
 //#endif
-#define GLES3_INCLUDE_H "glad/glad.h"
-#define GLES2_INCLUDE_H "glad/glad.h"
+#define GLES3_INCLUDE_H "thirdparty/glad/glad/glad.h"
+#define GLES2_INCLUDE_H "thirdparty/glad/glad/glad.h"

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -250,7 +250,8 @@ def configure(env):
     if (os.system("pkg-config --exists alsa") == 0): # 0 means found
         print("Enabling ALSA")
         env.Append(CPPFLAGS=["-DALSA_ENABLED", "-DALSAMIDI_ENABLED"])
-        env.ParseConfig('pkg-config alsa --cflags --libs')
+	# Don't parse --cflags, we don't need to add /usr/include/alsa to include path
+        env.ParseConfig('pkg-config alsa --libs')
     else:
         print("ALSA libraries not found, disabling driver")
 
@@ -278,7 +279,7 @@ def configure(env):
         env.ParseConfig('pkg-config zlib --cflags --libs')
 
     env.Append(CPPPATH=['#platform/x11'])
-    env.Append(CPPFLAGS=['-DX11_ENABLED', '-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES_ENABLED', '-DGLES_OVER_GL'])
+    env.Append(CPPFLAGS=['-DX11_ENABLED', '-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES_ENABLED'])
     env.Append(LIBS=['GL', 'pthread'])
 
     if (platform.system() == "Linux"):

--- a/platform/x11/platform_config.h
+++ b/platform/x11/platform_config.h
@@ -36,5 +36,5 @@
 #define PTHREAD_BSD_SET_NAME
 #endif
 
-#define GLES3_INCLUDE_H "glad/glad.h"
-#define GLES2_INCLUDE_H "glad/glad.h"
+#define GLES3_INCLUDE_H "thirdparty/glad/glad/glad.h"
+#define GLES2_INCLUDE_H "thirdparty/glad/glad/glad.h"


### PR DESCRIPTION
Also finally move freetype to its own env and disable warnings for it.
Still needs some work to fix the awkward situation of the freetype and
svg modules used in scene/ and editor/ respectively.