### PR TITLE
Fixed name of deleted node not dissapearing from inspector dock.

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -259,6 +259,8 @@ void InspectorDock::_prepare_history() {
 		}
 		history_menu->get_popup()->add_icon_item(icon, text, i);
 	}
+
+	editor_path->update_path();
 }
 
 void InspectorDock::_select_history(int p_idx) const {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1570,7 +1570,7 @@ void SceneTreeDock::_delete_confirm() {
 	// Fixes the EditorHistory from still offering deleted notes
 	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
 	editor_history->cleanup_history();
-	EditorNode::get_singleton()->call("_prepare_history");
+	EditorNode::get_singleton()->get_inspector_dock()->call("_prepare_history");
 }
 
 void SceneTreeDock::_update_script_button() {


### PR DESCRIPTION
Fixed name of deleted node not dissapearing from inspector dock.

Fixes #7180