### PR TITLE
Fix compiler warnings in HTML5 platform

### DIFF
--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -237,7 +237,7 @@ Error HTTPClient::poll() {
 		case STATUS_CONNECTION_ERROR:
 			return ERR_CONNECTION_ERROR;
 
-		case STATUS_REQUESTING:
+		case STATUS_REQUESTING: {
 
 #ifdef DEBUG_ENABLED
 			if (!has_polled) {
@@ -281,6 +281,10 @@ Error HTTPClient::poll() {
 			godot_xhr_get_response(xhr_id, write.ptr(), polled_response.size());
 			write = PoolByteArray::Write();
 			break;
+		}
+
+		default:
+			ERR_FAIL_V(ERR_BUG);
 	}
 	return OK;
 }

--- a/platform/javascript/javascript_eval.cpp
+++ b/platform/javascript/javascript_eval.cpp
@@ -140,8 +140,9 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 		case Variant::POOL_BYTE_ARRAY:
 			arr_write = PoolByteArray::Write();
 			return arr;
+		default:
+			return Variant();
 	}
-	return Variant();
 }
 
 #endif // JAVASCRIPT_EVAL_ENABLED

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -121,14 +121,14 @@ void OS_JavaScript::set_window_size(const Size2 p_size) {
 			emscripten_exit_soft_fullscreen();
 			window_maximized = false;
 		}
-		emscripten_set_canvas_size(p_size.x, p_size.y);
+		emscripten_set_canvas_element_size(NULL, p_size.x, p_size.y);
 	}
 }
 
 Size2 OS_JavaScript::get_window_size() const {
 
-	int canvas[3];
-	emscripten_get_canvas_size(canvas, canvas + 1, canvas + 2);
+	int canvas[2];
+	emscripten_get_canvas_element_size(NULL, canvas, canvas + 1);
 	return Size2(canvas[0], canvas[1]);
 }
 
@@ -378,15 +378,13 @@ static void set_css_cursor(const char *p_cursor) {
 	/* clang-format on */
 }
 
-static const char *get_css_cursor() {
+static bool is_css_cursor_hidden() {
 
-	char cursor[16];
 	/* clang-format off */
-	EM_ASM_INT({
-		stringToUTF8(Module.canvas.style.cursor ? Module.canvas.style.cursor : 'auto', $0, 16);
-	}, cursor);
+	return EM_ASM_INT({
+		return Module.canvas.style.cursor === 'none';
+	});
 	/* clang-format on */
-	return cursor;
 }
 
 void OS_JavaScript::set_cursor_shape(CursorShape p_shape) {
@@ -430,7 +428,7 @@ void OS_JavaScript::set_mouse_mode(OS::MouseMode p_mode) {
 
 OS::MouseMode OS_JavaScript::get_mouse_mode() const {
 
-	if (String::utf8(get_css_cursor()) == "none")
+	if (is_css_cursor_hidden())
 		return MOUSE_MODE_HIDDEN;
 
 	EmscriptenPointerlockChangeEvent ev;
@@ -835,13 +833,13 @@ bool OS_JavaScript::main_loop_iterate() {
 			strategy.canvasResizedCallback = NULL;
 			emscripten_enter_soft_fullscreen(NULL, &strategy);
 		} else {
-			emscripten_set_canvas_size(windowed_size.width, windowed_size.height);
+			emscripten_set_canvas_element_size(NULL, windowed_size.width, windowed_size.height);
 		}
 		just_exited_fullscreen = false;
 	}
 
-	int canvas[3];
-	emscripten_get_canvas_size(canvas, canvas + 1, canvas + 2);
+	int canvas[2];
+	emscripten_get_canvas_element_size(NULL, canvas, canvas + 1);
 	video_mode.width = canvas[0];
 	video_mode.height = canvas[1];
 	if (!window_maximized && !video_mode.fullscreen && !just_exited_fullscreen && !entering_fullscreen) {


### PR DESCRIPTION
Fix warnings that fastcomp clang 6.0.1 reports with `-Wall` in files in `platform/javascript`.