### PR TITLE
Project manager: remove projects with delete key

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -999,6 +999,10 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 
 				_open_project();
 			} break;
+			case KEY_DELETE: {
+
+				_erase_project();
+			} break;
 			case KEY_HOME: {
 
 				for (int i = 0; i < scroll_children->get_child_count(); i++) {


### PR DESCRIPTION
Pressing the delete key the editor asks for confirmation to remove the selected projects as it does when you press the `Remove` button.