### PR TITLE
18534: File Dialog's returned path does not account for suffix filter correctly

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -915,7 +915,14 @@ void EditorFileDialog::clear_filters() {
 }
 void EditorFileDialog::add_filter(const String &p_filter) {
 
-	filters.push_back(p_filter);
+	if (p_filter.begins_with("*.")) {
+		filters.push_back(p_filter);
+	} else if (p_filter.begins_with(".")) {
+		filters.push_back("*" + p_filter);
+	} else {
+		filters.push_back("*." + p_filter);
+	}
+
 	update_filters();
 	invalidate();
 }

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -555,7 +555,14 @@ void FileDialog::clear_filters() {
 }
 void FileDialog::add_filter(const String &p_filter) {
 
-	filters.push_back(p_filter);
+	if (p_filter.begins_with("*.")) {
+		filters.push_back(p_filter);
+	} else if (p_filter.begins_with(".")) {
+		filters.push_back("*" + p_filter);
+	} else {
+		filters.push_back("*." + p_filter);
+	}
+
 	update_filters();
 	invalidate();
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/18534.

The reported issue maybe considered a misuse of the function `add_filters` for the FileDialog. Added a fix anyway