### PR TITLE
Fix warnings on virtual methods [-Woverloaded-virtual] [-Wdelete-non-…

### DIFF
--- a/core/engine.h
+++ b/core/engine.h
@@ -125,6 +125,7 @@ public:
 	String get_license_text() const;
 
 	Engine();
+	virtual ~Engine() {}
 };
 
 #endif // ENGINE_H

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -40,7 +40,7 @@
 #define CONTRIBUTE2_URL "https://github.com/godotengine/godot-docs"
 #define REQUEST_URL "https://github.com/godotengine/godot-docs/issues/new"
 
-void EditorHelpSearch::popup() {
+void EditorHelpSearch::popup_dialog() {
 
 	popup_centered(Size2(700, 600) * EDSCALE);
 	if (search_box->get_text() != "") {
@@ -50,15 +50,16 @@ void EditorHelpSearch::popup() {
 	search_box->grab_focus();
 }
 
-void EditorHelpSearch::popup(const String &p_term) {
+void EditorHelpSearch::popup_dialog(const String &p_term) {
 
 	popup_centered(Size2(700, 600) * EDSCALE);
 	if (p_term != "") {
 		search_box->set_text(p_term);
 		search_box->select_all();
 		_update_search();
-	} else
+	} else {
 		search_box->clear();
+	}
 	search_box->grab_focus();
 }
 
@@ -362,7 +363,7 @@ void EditorHelpIndex::select_class(const String &p_class) {
 	class_list->ensure_cursor_is_visible();
 }
 
-void EditorHelpIndex::popup() {
+void EditorHelpIndex::popup_dialog() {
 
 	popup_centered(Size2(500, 600) * EDSCALE);
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -92,8 +92,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void popup();
-	void popup(const String &p_term);
+	void popup_dialog();
+	void popup_dialog(const String &p_term);
 
 	EditorHelpSearch();
 };
@@ -120,7 +120,7 @@ protected:
 public:
 	void select_class(const String &p_class);
 
-	void popup();
+	void popup_dialog();
 
 	EditorHelpIndex();
 };

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1738,13 +1738,13 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case FILE_QUICK_OPEN_SCENE: {
 
-			quick_open->popup("PackedScene", true);
+			quick_open->popup_dialog("PackedScene", true);
 			quick_open->set_title(TTR("Quick Open Scene..."));
 
 		} break;
 		case FILE_QUICK_OPEN_SCRIPT: {
 
-			quick_open->popup("Script", true);
+			quick_open->popup_dialog("Script", true);
 			quick_open->set_title(TTR("Quick Open Script..."));
 
 		} break;
@@ -2002,7 +2002,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case RUN_PLAY_CUSTOM_SCENE: {
 			if (run_custom_filename.empty() || editor_run.get_status() == EditorRun::STATUS_STOP) {
 				_menu_option_confirm(RUN_STOP, true);
-				quick_run->popup("PackedScene", true);
+				quick_run->popup_dialog("PackedScene", true);
 				quick_run->set_title(TTR("Quick Run Scene..."));
 				play_custom_scene_button->set_pressed(false);
 			} else {

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -782,12 +782,13 @@ bool CurvePreviewGenerator::handles(const String &p_type) const {
 	return p_type == "Curve";
 }
 
-Ref<Texture> CurvePreviewGenerator::generate(const Ref<Resource> &p_from) {
+Ref<Texture> CurvePreviewGenerator::generate(const Ref<Resource> &p_from, const Size2 p_size) const {
 
 	Ref<Curve> curve_ref = p_from;
 	ERR_FAIL_COND_V(curve_ref.is_null(), Ref<Texture>());
 	Curve &curve = **curve_ref;
 
+	// FIXME: Should be ported to use p_size as done in b2633a97
 	int thumbnail_size = EditorSettings::get_singleton()->get("filesystem/file_dialog/thumbnail_size");
 	thumbnail_size *= EDSCALE;
 	Ref<Image> img_ref;

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -131,14 +131,14 @@ class CurveEditorPlugin : public EditorPlugin {
 public:
 	CurveEditorPlugin(EditorNode *p_node);
 
-	String get_name() const { return "Curve"; }
+	virtual String get_name() const { return "Curve"; }
 };
 
 class CurvePreviewGenerator : public EditorResourcePreviewGenerator {
 	GDCLASS(CurvePreviewGenerator, EditorResourcePreviewGenerator)
 public:
-	bool handles(const String &p_type) const;
-	Ref<Texture> generate(const Ref<Resource> &p_from);
+	virtual bool handles(const String &p_type) const;
+	virtual Ref<Texture> generate(const Ref<Resource> &p_from, const Size2 p_size) const;
 };
 
 #endif // CURVE_EDITOR_PLUGIN_H

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -96,7 +96,7 @@ public:
 		}
 	}
 
-	RES get_cached_resource(const String &p_path) {
+	virtual RES get_cached_resource(const String &p_path) {
 
 		Map<String, Cache>::Element *E = cached.find(p_path);
 		if (!E) {
@@ -134,9 +134,11 @@ public:
 		max_cache_size = 128;
 		max_time_cache = 5 * 60 * 1000; //minutes, five
 	}
+
+	virtual ~EditorScriptCodeCompletionCache() {}
 };
 
-void ScriptEditorQuickOpen::popup(const Vector<String> &p_functions, bool p_dontclear) {
+void ScriptEditorQuickOpen::popup_dialog(const Vector<String> &p_functions, bool p_dontclear) {
 
 	popup_centered_ratio(0.6);
 	if (p_dontclear)
@@ -968,11 +970,11 @@ void ScriptEditor::_menu_option(int p_option) {
 		} break;
 		case SEARCH_HELP: {
 
-			help_search_dialog->popup();
+			help_search_dialog->popup_dialog();
 		} break;
 		case SEARCH_CLASSES: {
 
-			help_index->popup();
+			help_index->popup_dialog();
 		} break;
 		case SEARCH_WEBSITE: {
 
@@ -1204,7 +1206,7 @@ void ScriptEditor::_menu_option(int p_option) {
 
 				case SEARCH_CLASSES: {
 
-					help_index->popup();
+					help_index->popup_dialog();
 					help_index->call_deferred("select_class", help->get_class());
 				} break;
 				case HELP_SEARCH_FIND: {
@@ -2727,11 +2729,11 @@ void ScriptEditor::set_live_auto_reload_running_scripts(bool p_enabled) {
 }
 
 void ScriptEditor::_help_index(String p_text) {
-	help_index->popup();
+	help_index->popup_dialog();
 }
 
 void ScriptEditor::_help_search(String p_text) {
-	help_search_dialog->popup(p_text);
+	help_search_dialog->popup_dialog(p_text);
 }
 
 void ScriptEditor::_open_script_request(const String &p_path) {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -67,7 +67,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void popup(const Vector<String> &p_functions, bool p_dontclear = false);
+	void popup_dialog(const Vector<String> &p_functions, bool p_dontclear = false);
 	ScriptEditorQuickOpen();
 };
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -940,7 +940,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		} break;
 		case SEARCH_LOCATE_FUNCTION: {
 
-			quick_open->popup(get_functions());
+			quick_open->popup_dialog(get_functions());
 			quick_open->set_title(TTR("Go to Function"));
 		} break;
 		case SEARCH_GOTO_LINE: {

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -32,7 +32,7 @@
 
 #include "core/os/keyboard.h"
 
-void EditorQuickOpen::popup(const StringName &p_base, bool p_enable_multi, bool p_add_dirs, bool p_dontclear) {
+void EditorQuickOpen::popup_dialog(const StringName &p_base, bool p_enable_multi, bool p_add_dirs, bool p_dontclear) {
 
 	add_directories = p_add_dirs;
 	popup_centered_ratio(0.6);

--- a/editor/quick_open.h
+++ b/editor/quick_open.h
@@ -66,7 +66,7 @@ public:
 	String get_selected() const;
 	Vector<String> get_selected_files() const;
 
-	void popup(const StringName &p_base, bool p_enable_multi = false, bool p_add_dirs = false, bool p_dontclear = false);
+	void popup_dialog(const StringName &p_base, bool p_enable_multi = false, bool p_add_dirs = false, bool p_dontclear = false);
 	EditorQuickOpen();
 };
 

--- a/main/tests/test_io.cpp
+++ b/main/tests/test_io.cpp
@@ -50,7 +50,7 @@ class TestMainLoop : public MainLoop {
 	bool quit;
 
 public:
-	virtual void input_event(const InputEvent &p_event) {
+	virtual void input_event(const Ref<InputEvent> &p_event) {
 	}
 	virtual bool idle(float p_time) {
 		return false;

--- a/platform/haiku/context_gl_haiku.h
+++ b/platform/haiku/context_gl_haiku.h
@@ -46,9 +46,6 @@ private:
 	bool use_vsync;
 
 public:
-	ContextGL_Haiku(HaikuDirectWindow *p_window);
-	~ContextGL_Haiku();
-
 	virtual Error initialize();
 	virtual void release_current();
 	virtual void make_current();
@@ -58,6 +55,9 @@ public:
 
 	virtual void set_use_vsync(bool p_use);
 	virtual bool is_using_vsync() const;
+
+	ContextGL_Haiku(HaikuDirectWindow *p_window);
+	virtual ~ContextGL_Haiku();
 };
 
 #endif

--- a/platform/uwp/gl_context_egl.h
+++ b/platform/uwp/gl_context_egl.h
@@ -71,8 +71,8 @@ public:
 	virtual int get_window_height();
 	virtual void swap_buffers();
 
-	void set_use_vsync(bool use) { vsync = use; }
-	bool is_using_vsync() const { return vsync; }
+	virtual void set_use_vsync(bool use) { vsync = use; }
+	virtual bool is_using_vsync() const { return vsync; }
 
 	virtual Error initialize();
 	void reset();
@@ -80,7 +80,7 @@ public:
 	void cleanup();
 
 	ContextEGL(CoreWindow ^ p_window, Driver p_driver);
-	~ContextEGL();
+	virtual ~ContextEGL();
 };
 
 #endif

--- a/platform/windows/context_gl_win.h
+++ b/platform/windows/context_gl_win.h
@@ -69,7 +69,7 @@ public:
 	virtual bool is_using_vsync() const;
 
 	ContextGL_Win(HWND hwnd, bool p_opengl_3_context);
-	~ContextGL_Win();
+	virtual ~ContextGL_Win();
 };
 
 #endif

--- a/platform/x11/context_gl_x11.h
+++ b/platform/x11/context_gl_x11.h
@@ -79,7 +79,7 @@ public:
 	virtual bool is_using_vsync() const;
 
 	ContextGL_X11(::Display *p_x11_display, ::Window &p_x11_window, const OS::VideoMode &p_default_video_mode, ContextType p_context_type);
-	~ContextGL_X11();
+	virtual ~ContextGL_X11();
 };
 
 #endif

--- a/scene/2d/visibility_notifier_2d.h
+++ b/scene/2d/visibility_notifier_2d.h
@@ -43,7 +43,7 @@ class VisibilityNotifier2D : public Node2D {
 	Rect2 rect;
 
 protected:
-	friend class SpatialIndexer2D;
+	friend struct SpatialIndexer2D;
 
 	void _enter_viewport(Viewport *p_viewport);
 	void _exit_viewport(Viewport *p_viewport);

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -389,6 +389,8 @@ public:
 		virtual bool _set(const StringName &p_name, const Variant &p_value, RID j = RID());
 		virtual bool _get(const StringName &p_name, Variant &r_ret) const;
 		virtual void _get_property_list(List<PropertyInfo> *p_list) const;
+
+		virtual ~JointData() {}
 	};
 
 	struct PinJointData : public JointData {

--- a/scene/3d/visibility_notifier.h
+++ b/scene/3d/visibility_notifier.h
@@ -48,7 +48,7 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
-	friend class SpatialIndexer;
+	friend struct SpatialIndexer;
 
 	void _enter_camera(Camera *p_camera);
 	void _exit_camera(Camera *p_camera);

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -44,7 +44,7 @@ void AudioEffectRecordInstance::process(const AudioFrame *p_src_frames, AudioFra
 	}
 }
 
-bool AudioEffectRecordInstance::process_silence() {
+bool AudioEffectRecordInstance::process_silence() const {
 	return true;
 }
 

--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -66,7 +66,7 @@ class AudioEffectRecordInstance : public AudioEffectInstance {
 public:
 	void init();
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count);
-	virtual bool process_silence();
+	virtual bool process_silence() const;
 
 	AudioEffectRecordInstance() :
 			thread_active(false) {}

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -544,7 +544,7 @@ public:
 	bool free(RID p_rid);
 
 	VisualServerScene();
-	~VisualServerScene();
+	virtual ~VisualServerScene();
 };
 
 #endif // VISUALSERVERSCENE_H

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -194,6 +194,7 @@ public:
 	bool free(RID p_rid);
 
 	VisualServerViewport();
+	virtual ~VisualServerViewport() {}
 };
 
 #endif // VISUALSERVERVIEWPORT_H


### PR DESCRIPTION
…virtual-dtor]

Fixes the following Clang 7 warnings:
```
editor/editor_help.h:123:7: warning: 'EditorHelpIndex::popup' hides overloaded virtual function [-Woverloaded-virtual]
editor/editor_help.h:95:7: warning: 'EditorHelpSearch::popup' hides overloaded virtual function [-Woverloaded-virtual]
editor/editor_help.h:96:7: warning: 'EditorHelpSearch::popup' hides overloaded virtual function [-Woverloaded-virtual]
editor/plugins/curve_editor_plugin.h:141:15: warning: 'CurvePreviewGenerator::generate' hides overloaded virtual function [-Woverloaded-virtual]
editor/plugins/script_editor_plugin.h:70:7: warning: 'ScriptEditorQuickOpen::popup' hides overloaded virtual function [-Woverloaded-virtual]
editor/quick_open.h:69:7: warning: 'EditorQuickOpen::popup' hides overloaded virtual function [-Woverloaded-virtual]
main/tests/test_io.cpp:53:15: warning: 'TestIO::TestMainLoop::input_event' hides overloaded virtual function [-Woverloaded-virtual]
modules/opensimplex/noise_texture.h:87:10: warning: 'NoiseTexture::get_size' hides overloaded virtual function [-Woverloaded-virtual]
servers/audio/effects/audio_effect_record.h:69:15: warning: 'AudioEffectRecordInstance::process_silence' hides overloaded virtual function [-Woverloaded-virtual]

core/os/memory.h:119:2: warning: destructor called on non-final 'ContextGL_X11' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
core/os/memory.h:119:2: warning: destructor called on non-final 'EditorScriptCodeCompletionCache' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
core/os/memory.h:119:2: warning: destructor called on non-final 'Engine' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
core/os/memory.h:119:2: warning: destructor called on non-final 'PhysicalBone::JointData' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
core/os/memory.h:119:2: warning: destructor called on non-final 'VisualServerScene' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
core/os/memory.h:119:2: warning: destructor called on non-final 'VisualServerViewport' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
```