### PR TITLE
22586: Dragging file icon on to another file causes "Error Moving" in FileSystem dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1953,7 +1953,7 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 		}
 
 		String ltarget = files->get_item_metadata(pos);
-		target = ltarget.ends_with("/") ? ltarget : path;
+		target = ltarget.ends_with("/") ? ltarget : path.get_base_dir();
 		return;
 	}
 


### PR DESCRIPTION
Fix for https://github.com/godotengine/godot/issues/22586

Make drag and drop consistent for both FileSystem views