### PR TITLE
Cleanup the editor history from remote nodes after the scene stopped.

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1272,7 +1272,7 @@ void ScriptEditorDebugger::stop() {
 	breaked = false;
 
 	server->stop();
-
+	_clear_remote_objects();
 	ppeer->set_stream_peer(Ref<StreamPeer>());
 
 	if (connection.is_valid()) {


### PR DESCRIPTION
Fixed #22624