### PR TITLE
GLES2: Implement pixel snap 2D option

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1185,7 +1185,6 @@ void RasterizerCanvasGLES2::initialize() {
 			_EIDX(1, 1), _EIDX(1, 2), _EIDX(2, 2),
 			_EIDX(2, 2), _EIDX(2, 1), _EIDX(1, 1)
 		};
-		;
 #undef _EIDX
 
 		glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(elems), elems, GL_STATIC_DRAW);
@@ -1200,6 +1199,8 @@ void RasterizerCanvasGLES2::initialize() {
 	state.canvas_shader.bind();
 
 	state.lens_shader.init();
+
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_PIXEL_SNAP, GLOBAL_DEF("rendering/quality/2d/use_pixel_snap", false));
 }
 
 void RasterizerCanvasGLES2::finalize() {

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -96,6 +96,10 @@ VERTEX_SHADER_CODE
 
 	color_interp = color;
 
+#ifdef USE_PIXEL_SNAP
+	outvec.xy = floor(outvec + 0.5).xy;
+#endif
+
 	gl_Position = projection_matrix * outvec;
 }
 

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -182,7 +182,6 @@ VERTEX_SHADER_CODE
 	color_interp = color;
 
 #ifdef USE_PIXEL_SNAP
-
 	outvec.xy = floor(outvec + 0.5).xy;
 #endif
 


### PR DESCRIPTION
Implemented as in the GLES3 backend.

Tested on Jetpaca, works fine.