### PR TITLE
Expose "meta" to the Inspector

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -638,9 +638,12 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 #endif
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));
 	}
-	if (!metadata.empty()) {
-		p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-	}
+
+#ifdef TOOLS_ENABLED
+	p_list->push_back(PropertyInfo(Variant::NIL, "Metadata", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
+#endif
+	p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT));
+
 	if (script_instance && !p_reversed) {
 		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
 		script_instance->get_property_list(p_list);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -47,7 +47,7 @@ public:
 	bool setting;
 	bool hidden;
 
-	bool _hide_script_from_inspector() {
+	bool _hide_object_properties_from_inspector() {
 		return true;
 	}
 
@@ -55,7 +55,7 @@ public:
 
 		ClassDB::bind_method("_update_obj", &AnimationTrackKeyEdit::_update_obj);
 		ClassDB::bind_method("_key_ofs_changed", &AnimationTrackKeyEdit::_key_ofs_changed);
-		ClassDB::bind_method("_hide_script_from_inspector", &AnimationTrackKeyEdit::_hide_script_from_inspector);
+		ClassDB::bind_method("_hide_object_properties_from_inspector", &AnimationTrackKeyEdit::_hide_object_properties_from_inspector);
 		ClassDB::bind_method("get_root_path", &AnimationTrackKeyEdit::get_root_path);
 	}
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1483,7 +1483,7 @@ void EditorInspector::update_tree() {
 		if (p.usage & PROPERTY_USAGE_HIGH_END_GFX && VS::get_singleton()->is_low_end())
 			continue; //do not show this property in low end gfx
 
-		if (p.name == "script" && (hide_script || bool(object->call("_hide_script_from_inspector")))) {
+		if ((hide_object_properties || bool(object->call("_hide_object_properties_from_inspector"))) && (p.name == "script" || p.name == "__meta__")) {
 			continue;
 		}
 
@@ -1810,8 +1810,8 @@ void EditorInspector::set_use_doc_hints(bool p_enable) {
 	use_doc_hints = p_enable;
 	update_tree();
 }
-void EditorInspector::set_hide_script(bool p_hide) {
-	hide_script = p_hide;
+void EditorInspector::set_hide_object_properties(bool p_hide) {
+	hide_object_properties = p_hide;
 	update_tree();
 }
 void EditorInspector::set_use_filter(bool p_use) {
@@ -2240,7 +2240,7 @@ EditorInspector::EditorInspector() {
 	set_enable_v_scroll(true);
 
 	show_categories = false;
-	hide_script = true;
+	hide_object_properties = true;
 	use_doc_hints = false;
 	capitalize_paths = true;
 	use_filter = false;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -269,7 +269,7 @@ class EditorInspector : public ScrollContainer {
 
 	LineEdit *search_box;
 	bool show_categories;
-	bool hide_script;
+	bool hide_object_properties;
 	bool use_doc_hints;
 	bool capitalize_paths;
 	bool use_filter;
@@ -353,7 +353,7 @@ public:
 
 	void set_show_categories(bool p_show);
 	void set_use_doc_hints(bool p_enable);
-	void set_hide_script(bool p_hide);
+	void set_hide_object_properties(bool p_hide);
 
 	void set_use_filter(bool p_use);
 	void register_text_enter(Node *p_line_edit);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -586,7 +586,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	inspector->set_show_categories(true);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector->set_use_doc_hints(true);
-	inspector->set_hide_script(false);
+	inspector->set_hide_object_properties(false);
 	inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));
 	inspector->set_use_folding(!bool(EDITOR_GET("interface/inspector/disable_folding")));
 	inspector->register_text_enter(search);

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2476,7 +2476,7 @@ void TilesetEditorContext::_get_property_list(List<PropertyInfo> *p_list) const 
 
 void TilesetEditorContext::_bind_methods() {
 
-	ClassDB::bind_method("_hide_script_from_inspector", &TilesetEditorContext::_hide_script_from_inspector);
+	ClassDB::bind_method("_hide_object_properties_from_inspector", &TilesetEditorContext::_hide_object_properties_from_inspector);
 }
 
 TilesetEditorContext::TilesetEditorContext(TileSetEditor *p_tileset_editor) {

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -216,7 +216,7 @@ class TilesetEditorContext : public Object {
 	bool snap_options_visible;
 
 public:
-	bool _hide_script_from_inspector() { return true; }
+	bool _hide_object_properties_from_inspector() { return true; }
 	void set_tileset(const Ref<TileSet> &p_tileset);
 
 private:


### PR DESCRIPTION
And by "WIP" I mean "I really could use some help on this".

The `metadata` dictionary is part of the `Object` class, and exposing stuff from there to the inspector wasn't as easy as I thought it would be.

Initially, it looks fine, it's accessible just below the "Script" subcategory, except that unlike "Script", it also appears in literally all inspectors across the editor.

(It will, hopefully) Closes #5433.

**EDIT**: Done, see below.