### PR TITLE
[WIP] Adding sensor delay setting for android

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1185,6 +1185,10 @@ ProjectSettings::ProjectSettings() {
 	Compression::gzip_level = GLOBAL_DEF("compression/formats/gzip/compression_level", Z_DEFAULT_COMPRESSION);
 	custom_prop_info["compression/formats/gzip/compression_level"] = PropertyInfo(Variant::INT, "compression/formats/gzip/compression_level", PROPERTY_HINT_RANGE, "-1,9,1");
 
+	// this is only for android but needs a place, setting sensor precision
+	GLOBAL_DEF("input_devices/sensors/sensor_delay", "Game");
+	set_custom_property_info("input_devices/sensors/sensor_delay", PropertyInfo(Variant::STRING, "input_devices/sensors/sensor_delay", PROPERTY_HINT_ENUM, "Fastest,Game,Normal,UI"));
+
 	using_datapack = false;
 }
 

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -119,6 +119,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 	private boolean use_debug_opengl = false;
 	private boolean mStatePaused;
 	private int mState;
+	private int sensor_delay = SensorManager.SENSOR_DELAY_GAME;
 
 	static private Intent mCurrentIntent;
 
@@ -407,15 +408,27 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		GodotLib.io = io;
 		mSensorManager = (SensorManager)getSystemService(Context.SENSOR_SERVICE);
 		mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
-		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
 		mGravity = mSensorManager.getDefaultSensor(Sensor.TYPE_GRAVITY);
-		mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME);
 		mMagnetometer = mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
-		mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME);
 		mGyroscope = mSensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE);
-		mSensorManager.registerListener(this, mGyroscope, SensorManager.SENSOR_DELAY_GAME);
 
 		GodotLib.initialize(this, io.needsReloadHooks(), getAssets(), use_apk_expansion);
+
+		String sensor_delay_string = GodotLib.getGlobal("input_devices/sensors/sensor_delay");
+		if (sensor_delay_string.equals("Fastest")) {
+			sensor_delay = SensorManager.SENSOR_DELAY_FASTEST;
+		} else if (sensor_delay_string.equals("Game")) {
+			sensor_delay = SensorManager.SENSOR_DELAY_GAME;
+		} else if (sensor_delay_string.equals("Normal")) {
+			sensor_delay = SensorManager.SENSOR_DELAY_NORMAL;
+		} else if (sensor_delay_string.equals("UI")) {
+			sensor_delay = SensorManager.SENSOR_DELAY_UI;
+		}
+
+		mSensorManager.registerListener(this, mAccelerometer, sensor_delay);
+		mSensorManager.registerListener(this, mGravity, sensor_delay);
+		mSensorManager.registerListener(this, mMagnetometer, sensor_delay);
+		mSensorManager.registerListener(this, mGyroscope, sensor_delay);
 
 		result_callback = null;
 
@@ -641,10 +654,11 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 				GodotLib.focusin();
 			}
 		});
-		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
-		mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME);
-		mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME);
-		mSensorManager.registerListener(this, mGyroscope, SensorManager.SENSOR_DELAY_GAME);
+
+		mSensorManager.registerListener(this, mAccelerometer, sensor_delay);
+		mSensorManager.registerListener(this, mGravity, sensor_delay);
+		mSensorManager.registerListener(this, mMagnetometer, sensor_delay);
+		mSensorManager.registerListener(this, mGyroscope, sensor_delay);
 
 		if (use_immersive && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) { // check if the application runs on an android 4.4+
 			Window window = getWindow();


### PR DESCRIPTION
Adding a new project setting to be used on Android with which you can set the sensor update frequency. This defaults to the setting "Game" which is good for games (whats in a name), it is a faster update frequency then normal but still retains some accuracy taking out jitter from the accelerometer, gyrometer and magnetometer readings.

For VR however this update frequency is not high enough resulting in a lot of jitter and you need to use the "Fastest" option.

The new setting allows you to set all 4 presets available in Android. The higher/faster the update frequency, the more noise there will be in the readings but the more up to date your reading is.

Fixes #19645