### PR TITLE
Add extra newline after enum members and constants, to ensure they'll…

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -610,8 +610,7 @@ def make_rst_class(node):
                     s += ' = **' + c.attrib['value'] + '**'
                 if c.text.strip() != '':
                     s += ' --- ' + rstize_text(c.text.strip(), name)
-                f.write(s + '\n')
-            f.write('\n')
+                f.write(s + '\n\n')
 
     # Constants
     if len(consts) > 0:
@@ -623,8 +622,7 @@ def make_rst_class(node):
                 s += ' = **' + c.attrib['value'] + '**'
             if c.text.strip() != '':
                 s += ' --- ' + rstize_text(c.text.strip(), name)
-            f.write(s + '\n')
-        f.write('\n')
+            f.write(s + '\n\n')
 
     # Class description
     descr = node.find('description')


### PR DESCRIPTION
… format properly after a multi-line description

This was a quick and easy solution I found to the issue shown, where enum members won't format properly after a multi-line description:
![image](https://user-images.githubusercontent.com/1008889/46375686-0fdc7180-c662-11e8-861e-56e931623b12.png)

For the sake of consistency, I also applied the change to constants, which are basically enum members that aren't grouped into anything.

cc @akien-mga 