### PR TITLE
Fix GCC compiler warning in mono module

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2244,8 +2244,8 @@ void BindingsGenerator::_populate_global_constants() {
 			String constant_name = GlobalConstants::get_global_constant_name(i);
 
 			const DocData::ConstantDoc *const_doc = NULL;
-			for (int i = 0; i < global_scope_doc.constants.size(); i++) {
-				const DocData::ConstantDoc &curr_const_doc = global_scope_doc.constants[i];
+			for (int j = 0; j < global_scope_doc.constants.size(); j++) {
+				const DocData::ConstantDoc &curr_const_doc = global_scope_doc.constants[j];
 
 				if (curr_const_doc.name == constant_name) {
 					const_doc = &curr_const_doc;

--- a/modules/mono/editor/mono_bottom_panel.cpp
+++ b/modules/mono/editor/mono_bottom_panel.cpp
@@ -475,14 +475,14 @@ void MonoBuildTab::_bind_methods() {
 }
 
 MonoBuildTab::MonoBuildTab(const MonoBuildInfo &p_build_info, const String &p_logs_dir) :
-		build_info(p_build_info),
-		logs_dir(p_logs_dir),
 		build_exited(false),
 		issues_list(memnew(ItemList)),
 		error_count(0),
 		warning_count(0),
 		errors_visible(true),
-		warnings_visible(true) {
+		warnings_visible(true),
+		logs_dir(p_logs_dir),
+		build_info(p_build_info) {
 	issues_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	issues_list->connect("item_activated", this, "_issue_activated");
 	add_child(issues_list);

--- a/modules/mono/utils/mono_reg_utils.cpp
+++ b/modules/mono/utils/mono_reg_utils.cpp
@@ -228,4 +228,4 @@ cleanup:
 }
 } // namespace MonoRegUtils
 
-#endif WINDOWS_ENABLED
+#endif // WINDOWS_ENABLED

--- a/modules/mono/utils/thread_local.h
+++ b/modules/mono/utils/thread_local.h
@@ -108,17 +108,23 @@ class ThreadLocal {
 		return data;
 	}
 
-public:
-	ThreadLocal() :
-			ThreadLocal(T()) {}
-
-	ThreadLocal(const T &p_init_val) :
-			init_val(p_init_val) {
+	void _initialize(const T &p_init_val) {
+		init_val = p_init_val;
 		storage.alloc(&destr_callback);
 	}
 
-	ThreadLocal(const ThreadLocal &other) :
-			ThreadLocal(*other._tls_get_value()) {}
+public:
+	ThreadLocal() {
+		_initialize(T());
+	}
+
+	ThreadLocal(const T &p_init_val) {
+		_initialize(p_init_val);
+	}
+
+	ThreadLocal(const ThreadLocal &other) {
+		_initialize(*other._tls_get_value());
+	}
 
 	~ThreadLocal() {
 		storage.free();


### PR DESCRIPTION
Fixed the following warnings:

- `thread_local.h`: _'delegating constructors only available with -std=c++11 or -std=gnu++11'_
- `mono_reg_utils.cpp`: _'extra tokens at end of #endif directive'_
- `mono_bottom_panel.cpp`: _'<fieldB> will be initialized after <fieldA> when initialized here'_
- `bindings_generator.cpp`: _'name lookup of 'i' changed (...) matches this 'i' under ISO standard rules (...) matches this 'i' under old rules (...)'_
