### PR TITLE
Remove "Doc Path" setting

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -531,7 +531,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	_initial_set("docks/property_editor/texture_preview_width", 48);
 	_initial_set("docks/property_editor/auto_refresh_interval", 0.3);
-	_initial_set("text_editor/help/doc_path", "");
 	_initial_set("text_editor/help/show_help_index", true);
 
 	_initial_set("filesystem/import/ask_save_before_reimport", false);


### PR DESCRIPTION
Unless I missed something, this setting is not used anywhere.

Fully closes #15510.