### PR TITLE
Add example to Animation doc

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -5,7 +5,16 @@
 	</brief_description>
 	<description>
 		An Animation resource contains data used to animate everything in the engine. Animations are divided into tracks, and each track must be linked to a node. The state of that node can be changed through time, by adding timed keys (events) to the track.
-		Animations are just data containers, and must be added to odes such as an [AnimationPlayer] or [AnimationTreePlayer] to be played back.
+		[codeblock]
+		# This creates an animation that makes the node "Enemy" move to the right by
+		# 100 pixels in 1 second. 
+		var animation = Animation.new()
+		var track_index = animation.add_track(Animation.TYPE_VALUE)
+		animation.track_set_path(track_index, "Enemy:position.x")
+		animation.track_insert_key(track_index, 0.0, 0)
+		animation.track_insert_key(track_index, 0.5, 100)
+		[/codeblock]
+		Animations are just data containers, and must be added to nodes such as an [AnimationPlayer] or [AnimationTreePlayer] to be played back.
 	</description>
 	<tutorials>
 		<link>http://docs.godotengine.org/en/3.0/tutorials/animation/index.html</link>


### PR DESCRIPTION
Also fixed a typo ("odes" -> "nodes").

Fixes #17313.