### PR TITLE
set step default to 0 #22655

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -323,7 +323,7 @@ Range::Range() {
 	shared->min = 0;
 	shared->max = 100;
 	shared->val = 0;
-	shared->step = 1;
+	shared->step = 0;
 	shared->page = 0;
 	shared->owners.insert(this);
 	shared->exp_ratio = false;


### PR DESCRIPTION
Setting step > 0 will round it to nearest integer breaking backwards compatibility ith previous behaviour.

Default is currently 1, this patch simply sets it to 0.

_Bugsquad edit : closes #22655_