### PR TITLE
Fix warnings in Android platform

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -583,6 +583,7 @@
 			</argument>
 			<description>
 				Plays native video from the specified path, at the given volume and with audio and subtitle tracks.
+				Note: This method is only implemented on Android and iOS, and the current Android implementation does not support the [code]volume[/code], [code]audio_track[/code] and [code]subtitle_track[/code] options.
 			</description>
 		</method>
 		<method name="native_video_stop">

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -391,7 +391,7 @@ size_t DirAccessUnix::get_space_left() {
 
 	return vfs.f_bfree * vfs.f_bsize;
 #else
-#warning THIS IS BROKEN
+	// FIXME: Implement this.
 	return 0;
 #endif
 };

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -398,7 +398,6 @@ void MobileVRInterface::commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_t
 	ERR_FAIL_COND(p_screen_rect == Rect2());
 
 	Rect2 dest = p_screen_rect;
-	float aspect_ratio = 0.5 * p_screen_rect.size.x / p_screen_rect.size.y;
 	Vector2 eye_center;
 
 	// we output half a screen

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -18,12 +18,15 @@ android_files = [
     'dir_access_jandroid.cpp',
     'thread_jandroid.cpp',
     'audio_driver_jandroid.cpp',
-    'ifaddrs_android.cpp',
-    'android_native_app_glue.c',
     'java_glue.cpp',
-    'cpu-features.c',
     'java_class_wrapper.cpp',
 #    'power_android.cpp'
+]
+
+thirdparty_files = [
+    'ifaddrs_android.cpp',
+    'android_native_app_glue.c',
+    'cpu-features.c',
 ]
 
 env_android = env.Clone()
@@ -33,6 +36,11 @@ if env['target'] == "profile":
 android_objects = []
 for x in android_files:
     android_objects.append(env_android.SharedObject(x))
+
+env_thirdparty = env_android.Clone()
+env_thirdparty.disable_warnings()
+for x in thirdparty_files:
+    android_objects.append(env_thirdparty.SharedObject(x))
 
 prog = None
 

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -38,12 +38,7 @@
 /* Structure for passing information to callback function */
 
 void AudioDriverOpenSL::_buffer_callback(
-		SLAndroidSimpleBufferQueueItf queueItf
-		/*   SLuint32 eventFlags,
-    const void * pBuffer,
-    SLuint32 bufferSize,
-    SLuint32 dataUsed*/
-) {
+		SLAndroidSimpleBufferQueueItf queueItf) {
 
 	bool mix = true;
 
@@ -85,7 +80,6 @@ void AudioDriverOpenSL::_buffer_callbacks(
 
 	AudioDriverOpenSL *ad = (AudioDriverOpenSL *)pContext;
 
-	//ad->_buffer_callback(queueItf,eventFlags,pBuffer,bufferSize,dataUsed);
 	ad->_buffer_callback(queueItf);
 }
 
@@ -98,12 +92,9 @@ const char *AudioDriverOpenSL::get_name() const {
 
 Error AudioDriverOpenSL::init() {
 
-	SLresult
-			res;
+	SLresult res;
 	SLEngineOption EngineOption[] = {
-		(SLuint32)SL_ENGINEOPTION_THREADSAFE,
-		(SLuint32)SL_BOOLEAN_TRUE
-
+		{ (SLuint32)SL_ENGINEOPTION_THREADSAFE, (SLuint32)SL_BOOLEAN_TRUE }
 	};
 	res = slCreateEngine(&sl, 1, EngineOption, 0, NULL, NULL);
 	if (res != SL_RESULT_SUCCESS) {
@@ -126,8 +117,6 @@ void AudioDriverOpenSL::start() {
 	mutex = Mutex::create();
 	active = false;
 
-	SLint32 numOutputs = 0;
-	SLuint32 deviceID = 0;
 	SLresult res;
 
 	buffer_size = 1024;

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -70,19 +70,10 @@ class AudioDriverOpenSL : public AudioDriver {
 	static AudioDriverOpenSL *s_ad;
 
 	void _buffer_callback(
-			SLAndroidSimpleBufferQueueItf queueItf
-			/*   SLuint32 eventFlags,
-	    const void * pBuffer,
-	    SLuint32 bufferSize,
-	    SLuint32 dataUsed*/
-	);
+			SLAndroidSimpleBufferQueueItf queueItf);
 
 	static void _buffer_callbacks(
 			SLAndroidSimpleBufferQueueItf queueItf,
-			/*SLuint32 eventFlags,
-	    const void * pBuffer,
-	    SLuint32 bufferSize,
-	    SLuint32 dataUsed,*/
 			void *pContext);
 
 public:

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -589,8 +589,6 @@ TST tst;
 
 static bool initialized = false;
 static int step = 0;
-static bool resized = false;
-static bool resized_reload = false;
 static Size2 new_size;
 static Vector3 accelerometer;
 static Vector3 gravity;
@@ -792,7 +790,6 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *en
 		_getClipboard = env->GetMethodID(cls, "getClipboard", "()Ljava/lang/String;");
 		_setClipboard = env->GetMethodID(cls, "setClipboard", "(Ljava/lang/String;)V");
 
-		jclass clsio = env->FindClass("org/godotengine/godot/Godot");
 		if (cls) {
 			jclass c = env->GetObjectClass(gob);
 			_openURI = env->GetMethodID(c, "openURI", "(Ljava/lang/String;)I");
@@ -886,8 +883,6 @@ static void _initialize_java_modules() {
 				ERR_EXPLAIN("Couldn't find proper initialize function 'public static Godot.SingletonBase Class::initialize(Activity p_activity)' initializer for singleton class: " + m);
 				ERR_CONTINUE(!initialize);
 			}
-			jobject obj = env->CallStaticObjectMethod(singletonClass, initialize, _godot_instance);
-			jobject gob = env->NewGlobalRef(obj);
 		}
 	}
 }
@@ -931,13 +926,6 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, j
 
 	if (os_android)
 		os_android->set_display_size(Size2(width, height));
-
-	/*input_mutex->lock();
-	resized=true;
-	if (reload)
-		resized_reload=true;
-	new_size=Size2(width,height);
-	input_mutex->unlock();*/
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_newcontext(JNIEnv *env, jobject obj, bool p_32_bits) {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -677,13 +677,14 @@ String OS_Android::get_unique_id() const {
 	return OS::get_unique_id();
 }
 
-Error OS_Android::native_video_play(String p_path, float p_volume) {
+Error OS_Android::native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track) {
+	// FIXME: Add support for volume, audio and subtitle tracks
 	if (video_play_func)
 		video_play_func(p_path);
 	return OK;
 }
 
-bool OS_Android::native_video_is_playing() {
+bool OS_Android::native_video_is_playing() const {
 	if (video_is_playing_func)
 		return video_is_playing_func();
 	return false;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -237,8 +237,8 @@ public:
 	void process_event(Ref<InputEvent> p_event);
 	void init_video_mode(int p_video_width, int p_video_height);
 
-	virtual Error native_video_play(String p_path, float p_volume);
-	virtual bool native_video_is_playing();
+	virtual Error native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track);
+	virtual bool native_video_is_playing() const;
 	virtual void native_video_pause();
 	virtual void native_video_stop();
 


### PR DESCRIPTION
Fixes the following Clang 7 warnings:
```
platform/android/os_android.h:240:16: warning: 'OS_Android::native_video_play' hides overloaded virtual function [-Woverloaded-virtual]
platform/android/os_android.h:241:15: warning: 'OS_Android::native_video_is_playing' hides overloaded virtual function [-Woverloaded-virtual]

platform/android/audio_driver_opensl.cpp:104:3: warning: suggest braces around initialization of subobject [-Wmissing-braces]

platform/android/audio_driver_opensl.cpp:129:10: warning: unused variable 'numOutputs' [-Wunused-variable]
platform/android/audio_driver_opensl.cpp:130:11: warning: unused variable 'deviceID' [-Wunused-variable]
platform/android/java_glue.cpp:795:10: warning: unused variable 'clsio' [-Wunused-variable]
platform/android/java_glue.cpp:890:12: warning: unused variable 'gob' [-Wunused-variable]
platform/android/java_glue.cpp:592:13: warning: unused variable 'resized' [-Wunused-variable]
platform/android/java_glue.cpp:593:13: warning: unused variable 'resized_reload' [-Wunused-variable]

modules/mobile_vr/mobile_vr_interface.cpp:401:8: warning: unused variable 'aspect_ratio' [-Wunused-variable]

drivers/unix/dir_access_unix.cpp:394:2: warning: THIS IS BROKEN [-W#warnings]
```