### PR TITLE
ColorPicker: extend access to presets from gds

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -20,6 +20,22 @@
 				Adds the given color to a list of color presets. The presets are displayed in the color picker and the user will be able to select them. Note: the presets list is only for [i]this[/i] color picker.
 			</description>
 		</method>
+		<method name="erase_preset">
+			<return type="void">
+			</return>
+			<argument index="0" name="color" type="Color">
+			</argument>
+			<description>
+				Remove the given color from the list of color presets of this color picker.
+			</description>
+		</method>
+		<method name="get_presets">
+			<return type="PoolColorArray">
+			</return>
+			<description>
+				Return the list of colors in the presets of the color picker.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="color" type="Color" setter="set_pick_color" getter="get_pick_color">
@@ -41,6 +57,24 @@
 			</argument>
 			<description>
 				Emitted when the color is changed.
+			</description>
+		</signal>
+	</signals>
+	<signals>
+		<signal name="preset_added">
+			<argument index="0" name="color" type="Color">
+			</argument>
+			<description>
+				Emitted when a preset is added.
+			</description>
+		</signal>
+	</signals>
+	<signals>
+		<signal name="preset_removed">
+			<argument index="0" name="color" type="Color">
+			</argument>
+			<description>
+				Emitted when a preset is removed.
 			</description>
 		</signal>
 	</signals>

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -222,6 +222,24 @@ void ColorPicker::add_preset(const Color &p_color) {
 		bt_add_preset->hide();
 }
 
+void ColorPicker::erase_preset(const Color &p_color) {
+
+	if (presets.find(p_color)) {
+		presets.erase(presets.find(p_color));
+		preset->update();
+	}
+}
+
+PoolColorArray ColorPicker::get_presets() const {
+
+	PoolColorArray arr;
+	arr.resize(presets.size());
+	for (int i = 0; i < presets.size(); i++) {
+		arr.set(i, presets[i]);
+	}
+	return arr;
+}
+
 void ColorPicker::set_raw_mode(bool p_enabled) {
 
 	if (raw_mode_enabled == p_enabled)
@@ -415,7 +433,9 @@ void ColorPicker::_preset_input(const Ref<InputEvent> &p_event) {
 			set_pick_color(presets[index]);
 		} else if (bev->is_pressed() && bev->get_button_index() == BUTTON_RIGHT) {
 			int index = bev->get_position().x / (preset->get_size().x / presets.size());
-			presets.erase(presets[index]);
+			Color clicked_preset = presets[index];
+			presets.erase(clicked_preset);
+			emit_signal("preset_removed", clicked_preset);
 			preset->update();
 			bt_add_preset->show();
 		}
@@ -470,6 +490,7 @@ void ColorPicker::_screen_input(const Ref<InputEvent> &p_event) {
 
 void ColorPicker::_add_preset_pressed() {
 	add_preset(color);
+	emit_signal("preset_added", color);
 }
 
 void ColorPicker::_screen_pick_pressed() {
@@ -522,6 +543,8 @@ void ColorPicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_edit_alpha", "show"), &ColorPicker::set_edit_alpha);
 	ClassDB::bind_method(D_METHOD("is_editing_alpha"), &ColorPicker::is_editing_alpha);
 	ClassDB::bind_method(D_METHOD("add_preset", "color"), &ColorPicker::add_preset);
+	ClassDB::bind_method(D_METHOD("erase_preset", "color"), &ColorPicker::erase_preset);
+	ClassDB::bind_method(D_METHOD("get_presets"), &ColorPicker::get_presets);
 	ClassDB::bind_method(D_METHOD("_value_changed"), &ColorPicker::_value_changed);
 	ClassDB::bind_method(D_METHOD("_html_entered"), &ColorPicker::_html_entered);
 	ClassDB::bind_method(D_METHOD("_text_type_toggled"), &ColorPicker::_text_type_toggled);
@@ -544,6 +567,8 @@ void ColorPicker::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deferred_mode"), "set_deferred_mode", "is_deferred_mode");
 
 	ADD_SIGNAL(MethodInfo("color_changed", PropertyInfo(Variant::COLOR, "color")));
+	ADD_SIGNAL(MethodInfo("preset_added", PropertyInfo(Variant::COLOR, "color")));
+	ADD_SIGNAL(MethodInfo("preset_removed", PropertyInfo(Variant::COLOR, "color")));
 }
 
 ColorPicker::ColorPicker() :

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -105,6 +105,9 @@ public:
 	Color get_pick_color() const;
 
 	void add_preset(const Color &p_color);
+	void erase_preset(const Color &p_color);
+	PoolColorArray get_presets() const;
+
 	void set_raw_mode(bool p_enabled);
 	bool is_raw_mode() const;
 


### PR DESCRIPTION
this fixes https://github.com/godotengine/godot/issues/22411

new methods:
- void erase_preset(const Color &p_color);
- Array get_presets() const;

new signals:
- "preset_added"
- "preset_removed"