### PR TITLE
Fix warnings on release builds and some MSVC warnings

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -322,13 +322,13 @@ if selected_platform in platform_list:
         print("WARNING: warnings=yes is deprecated; assuming warnings=all")
 
     if env.msvc:
-        disable_nonessential_warnings = ['/wd4267', '/wd4244', '/wd4305', '/wd4800'] # Truncations, narrowing conversions...
+        # Truncations, narrowing conversions, signed/unsigned comparisons...
+        disable_nonessential_warnings = ['/wd4267', '/wd4244', '/wd4305', '/wd4018', '/wd4800']
         if (env["warnings"] == 'extra'):
             env.Append(CCFLAGS=['/Wall']) # Implies /W4
         elif (env["warnings"] == 'all' or env["warnings"] == 'yes'):
             env.Append(CCFLAGS=['/W3'] + disable_nonessential_warnings)
         elif (env["warnings"] == 'moderate'):
-            # C4244 shouldn't be needed here being a level-3 warning, but it is
             env.Append(CCFLAGS=['/W2'] + disable_nonessential_warnings)
         else: # 'no'
             env.Append(CCFLAGS=['/w'])

--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -809,10 +809,10 @@ void ClassDB::add_signal(StringName p_class, const MethodInfo &p_signal) {
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_COND(!type);
 
-	ClassInfo *check = type;
 	StringName sname = p_signal.name;
-#ifdef DEBUG_METHODS_ENABLED
 
+#ifdef DEBUG_METHODS_ENABLED
+	ClassInfo *check = type;
 	while (check) {
 		if (check->signal_map.has(sname)) {
 			ERR_EXPLAIN("Type " + String(p_class) + " already has signal: " + String(sname));

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -307,6 +307,7 @@ void Image::_get_mipmap_offset_and_size(int p_mipmap, int &r_offset, int &r_widt
 	r_width = w;
 	r_height = h;
 }
+
 int Image::get_mipmap_offset(int p_mipmap) const {
 
 	ERR_FAIL_INDEX_V(p_mipmap, get_mipmap_count() + 1, -1);
@@ -498,8 +499,6 @@ void Image::convert(Format p_new_format) {
 	w = PoolVector<uint8_t>::Write();
 
 	bool gen_mipmaps = mipmaps;
-
-	//mipmaps=false;
 
 	_copy_internals_from(new_img);
 
@@ -799,6 +798,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 	if (interpolate_mipmaps) {
 		dst2.create(p_width, p_height, 0, format);
 	}
+
 	bool had_mipmaps = mipmaps;
 	if (interpolate_mipmaps && !had_mipmaps) {
 		generate_mipmaps();
@@ -951,6 +951,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 }
 
 void Image::crop_from_point(int p_x, int p_y, int p_width, int p_height) {
+
 	if (!_can_modify(format)) {
 		ERR_EXPLAIN("Cannot crop in indexed, compressed or custom image formats.");
 		ERR_FAIL();
@@ -996,7 +997,7 @@ void Image::crop_from_point(int p_x, int p_y, int p_width, int p_height) {
 		}
 	}
 
-	if (mipmaps > 0)
+	if (has_mipmaps())
 		dst.generate_mipmaps();
 	_copy_internals_from(dst);
 }
@@ -1013,10 +1014,10 @@ void Image::flip_y() {
 		ERR_FAIL();
 	}
 
-	bool gm = mipmaps;
-
-	if (gm)
+	bool used_mipmaps = has_mipmaps();
+	if (used_mipmaps) {
 		clear_mipmaps();
+	}
 
 	{
 		PoolVector<uint8_t>::Write w = data.write();
@@ -1037,8 +1038,9 @@ void Image::flip_y() {
 		}
 	}
 
-	if (gm)
+	if (used_mipmaps) {
 		generate_mipmaps();
+	}
 }
 
 void Image::flip_x() {
@@ -1048,9 +1050,10 @@ void Image::flip_x() {
 		ERR_FAIL();
 	}
 
-	bool gm = mipmaps;
-	if (gm)
+	bool used_mipmaps = has_mipmaps();
+	if (used_mipmaps) {
 		clear_mipmaps();
+	}
 
 	{
 		PoolVector<uint8_t>::Write w = data.write();
@@ -1071,8 +1074,9 @@ void Image::flip_x() {
 		}
 	}
 
-	if (gm)
+	if (used_mipmaps) {
 		generate_mipmaps();
+	}
 }
 
 int Image::_get_dst_image_size(int p_width, int p_height, Format p_format, int &r_mipmaps, int p_mipmaps) {
@@ -1167,11 +1171,12 @@ void Image::expand_x2_hq2x() {
 
 	ERR_FAIL_COND(!_can_modify(format));
 
-	Format current = format;
-	bool mm = has_mipmaps();
-	if (mm) {
+	bool used_mipmaps = has_mipmaps();
+	if (used_mipmaps) {
 		clear_mipmaps();
 	}
+
+	Format current = format;
 
 	if (current != FORMAT_RGBA8)
 		convert(FORMAT_RGBA8);
@@ -1193,7 +1198,7 @@ void Image::expand_x2_hq2x() {
 	if (current != FORMAT_RGBA8)
 		convert(current);
 
-	if (mipmaps) {
+	if (used_mipmaps) {
 		generate_mipmaps();
 	}
 }

--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -175,7 +175,7 @@ int Compression::decompress(uint8_t *p_dst, int p_dst_max_size, const uint8_t *p
 		} break;
 		case MODE_ZSTD: {
 			ZSTD_DCtx *dctx = ZSTD_createDCtx();
-			if (zstd_long_distance_matching) ZSTD_DCtx_setMaxWindowSize(dctx, 1 << zstd_window_log_size);
+			if (zstd_long_distance_matching) ZSTD_DCtx_setMaxWindowSize(dctx, (size_t)1 << zstd_window_log_size);
 			int ret = ZSTD_decompressDCtx(dctx, p_dst, p_dst_max_size, p_src, p_src_size);
 			ZSTD_freeDCtx(dctx);
 			return ret;

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -169,11 +169,11 @@ bool PackedSourcePCK::try_open_pack(const String &p_path) {
 	uint32_t version = f->get_32();
 	uint32_t ver_major = f->get_32();
 	uint32_t ver_minor = f->get_32();
-	uint32_t ver_rev = f->get_32();
+	f->get_32(); // ver_rev
 
 	ERR_EXPLAIN("Pack version unsupported: " + itos(version));
 	ERR_FAIL_COND_V(version != PACK_VERSION, false);
-	ERR_EXPLAIN("Pack created with a newer version of the engine: " + itos(ver_major) + "." + itos(ver_minor) + "." + itos(ver_rev));
+	ERR_EXPLAIN("Pack created with a newer version of the engine: " + itos(ver_major) + "." + itos(ver_minor));
 	ERR_FAIL_COND_V(ver_major > VERSION_MAJOR || (ver_major == VERSION_MAJOR && ver_minor > VERSION_MINOR), false);
 
 	for (int i = 0; i < 16; i++) {

--- a/core/math/bsp_tree.cpp
+++ b/core/math/bsp_tree.cpp
@@ -165,7 +165,6 @@ int BSP_Tree::get_points_inside(const Vector3 *p_points, int p_point_count) cons
 	int pass_count = 0;
 	const Node *nodesptr = &nodes[0];
 	const Plane *planesptr = &planes[0];
-	int plane_count = planes.size();
 	int node_count = nodes.size();
 
 	if (node_count == 0) // no nodes!
@@ -192,9 +191,9 @@ int BSP_Tree::get_points_inside(const Vector3 *p_points, int p_point_count) cons
 				break;
 			}
 
-			uint16_t plane = nodesptr[idx].plane;
 #ifdef DEBUG_ENABLED
-
+			int plane_count = planes.size();
+			uint16_t plane = nodesptr[idx].plane;
 			ERR_FAIL_INDEX_V(plane, plane_count, false);
 #endif
 

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -227,10 +227,7 @@ static void user_read_data(png_structp png_ptr, png_bytep data, png_size_t p_len
 	PNGReadStatus *rstatus;
 	rstatus = (PNGReadStatus *)png_get_io_ptr(png_ptr);
 
-	png_size_t to_read = p_length;
-	if (rstatus->size >= 0) {
-		to_read = MIN(p_length, rstatus->size - rstatus->offset);
-	}
+	png_size_t to_read = MIN(p_length, rstatus->size - rstatus->offset);
 	memcpy(data, &rstatus->image[rstatus->offset], to_read);
 	rstatus->offset += to_read;
 

--- a/editor/doc/doc_dump.cpp
+++ b/editor/doc/doc_dump.cpp
@@ -223,7 +223,7 @@ void DocDump::dump(const String &p_file) {
 						hint = "Values: ";
 						for (int j = 0; j < arginfo.hint_string.get_slice_count(","); j++) {
 							if (j > 0) hint += ", ";
-							hint += arginfo.hint_string.get_slice(",", j) + "=" + itos(1 << j);
+							hint += arginfo.hint_string.get_slice(",", j) + "=" + itos((uint64_t)1 << j);
 						}
 						break;
 					case PROPERTY_HINT_FILE: hint = "A file:"; break;

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -376,7 +376,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	//Register icons + font
 
 	// the resolution and the icon color (dark_theme bool) has not changed, so we do not regenerate the icons
-	if (p_theme != NULL && fabs(p_theme->get_constant("scale", "Editor") - EDSCALE) < 0.00001 && p_theme->get_constant("dark_theme", "Editor") == dark_theme) {
+	if (p_theme != NULL && fabs(p_theme->get_constant("scale", "Editor") - EDSCALE) < 0.00001 && (bool)p_theme->get_constant("dark_theme", "Editor") == dark_theme) {
 		// register already generated icons
 		for (int i = 0; i < editor_icons_count; i++) {
 			theme->set_icon(editor_icons_names[i], "EditorIcons", p_theme->get_icon(editor_icons_names[i], "EditorIcons"));

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -42,12 +42,9 @@ Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 
 	if (err == OK) {
 		size_t index = 0;
-		size_t width =
-				static_cast<size_t>(p_header.bmp_info_header.bmp_width < 0 ? -p_header.bmp_info_header.bmp_width : p_header.bmp_info_header.bmp_width);
-		size_t height =
-				static_cast<size_t>(p_header.bmp_info_header.bmp_height < 0 ? -p_header.bmp_info_header.bmp_height : p_header.bmp_info_header.bmp_height);
-		size_t bits_per_pixel =
-				static_cast<size_t>(p_header.bmp_info_header.bmp_bit_count);
+		size_t width = (size_t)p_header.bmp_info_header.bmp_width;
+		size_t height = (size_t)p_header.bmp_info_header.bmp_height;
+		size_t bits_per_pixel = (size_t)p_header.bmp_info_header.bmp_bit_count;
 
 		if (p_header.bmp_info_header.bmp_compression != 0) {
 			err = FAILED;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -56,7 +56,9 @@ T *GDScriptParser::alloc_node() {
 	return t;
 }
 
+#ifdef DEBUG_ENABLED
 static String _find_function_name(const GDScriptParser::OperatorNode *p_call);
+#endif // DEBUG_ENABLED
 
 bool GDScriptParser::_end_statement() {
 
@@ -747,7 +749,6 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 			while (!bfn && b) {
 				if (b->variables.has(identifier)) {
 					IdentifierNode *id = alloc_node<IdentifierNode>();
-					LocalVarNode *lv = b->variables[identifier];
 					id->name = identifier;
 					id->declared_block = b;
 					id->line = id_line;
@@ -755,6 +756,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 					bfn = true;
 
 #ifdef DEBUG_ENABLED
+					LocalVarNode *lv = b->variables[identifier];
 					switch (tokenizer->get_token()) {
 						case GDScriptTokenizer::TK_OP_ASSIGN_ADD:
 						case GDScriptTokenizer::TK_OP_ASSIGN_BIT_AND:

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1042,7 +1042,7 @@ void GraphEdit::set_connection_activity(const StringName &p_from, int p_from_por
 
 		if (E->get().from == p_from && E->get().from_port == p_from_port && E->get().to == p_to && E->get().to_port == p_to_port) {
 
-			if (ABS(E->get().activity != p_activity)) {
+			if (ABS(E->get().activity - p_activity) < CMP_EPSILON) {
 				//update only if changed
 				top_layer->update();
 				connections_layer->update();

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2486,6 +2486,7 @@ void Node::_set_tree(SceneTree *p_tree) {
 		tree_changed_b->tree_changed();
 }
 
+#ifdef DEBUG_ENABLED
 static void _Node_debug_sn(Object *p_obj) {
 
 	Node *n = Object::cast_to<Node>(p_obj);
@@ -2507,6 +2508,7 @@ static void _Node_debug_sn(Object *p_obj) {
 		path = String(p->get_name()) + "/" + p->get_path_to(n);
 	print_line(itos(p_obj->get_instance_id()) + " - Stray Node: " + path + " (Type: " + n->get_class() + ")");
 }
+#endif // DEBUG_ENABLED
 
 void Node::_print_stray_nodes() {
 
@@ -2516,7 +2518,6 @@ void Node::_print_stray_nodes() {
 void Node::print_stray_nodes() {
 
 #ifdef DEBUG_ENABLED
-
 	ObjectDB::debug_objects(_Node_debug_sn);
 #endif
 }

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -286,7 +286,7 @@ private:
 		mk.key = 0;
 		for (int i = 0; i < FEATURE_MAX; i++) {
 			if (features[i]) {
-				mk.feature_mask |= (1 << i);
+				mk.feature_mask |= ((uint64_t)1 << i);
 			}
 		}
 		mk.detail_uv = detail_uv;
@@ -295,7 +295,7 @@ private:
 		mk.cull_mode = cull_mode;
 		for (int i = 0; i < FLAG_MAX; i++) {
 			if (flags[i]) {
-				mk.flags |= (1 << i);
+				mk.flags |= ((uint64_t)1 << i);
 			}
 		}
 		mk.detail_blend_mode = detail_blend_mode;


### PR DESCRIPTION
Fixes the following Clang 5 warnings:
```
modules/bmp/image_loader_bmp.cpp:46:60: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
modules/bmp/image_loader_bmp.cpp:48:61: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
drivers/png/image_loader_png.cpp:231:20: warning: comparison of unsigned expression >= 0 is always true [-Wtautological-compare]
scene/gui/graph_edit.cpp:1045:8: warning: comparison of constant 0 with expression of type 'bool' is always false [-Wtautological-constant-out-of-range-compare]

core/class_db.cpp:812:13: warning: unused variable 'check' [-Wunused-variable]
core/io/file_access_pack.cpp:172:11: warning: unused variable 'ver_rev' [-Wunused-variable]
core/math/bsp_tree.cpp:195:13: warning: unused variable 'plane' [-Wunused-variable]
core/math/bsp_tree.cpp:168:6: warning: unused variable 'plane_count' [-Wunused-variable]
modules/gdscript/gdscript_function.cpp:685:10: warning: unused variable 'ok' [-Wunused-variable]
modules/gdscript/gdscript_function.cpp:706:10: warning: unused variable 'ok' [-Wunused-variable]
modules/gdscript/gdscript_function.cpp:755:19: warning: unused variable 'var_type' [-Wunused-variable]
modules/gdscript/gdscript_function.cpp:1306:12: warning: unused variable 'err' [-Wunused-variable]

modules/gdscript/gdscript_function.cpp:158:15: warning: unused function '_get_var_type' [-Wunused-function]
modules/gdscript/gdscript_parser.cpp:750:20: warning: unused variable 'lv' [-Wunused-variable]
modules/gdscript/gdscript_parser.cpp:59:15: warning: unused function '_find_function_name' [-Wunused-function]
scene/main/node.cpp:2489:13: warning: unused function '_Node_debug_sn' [-Wunused-function]
```