### PR TITLE
Fixed DDS loader width/height attribs, fixes #22530

### DIFF
--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -108,8 +108,8 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 	uint32_t magic = f->get_32();
 	uint32_t hsize = f->get_32();
 	uint32_t flags = f->get_32();
-	uint32_t width = f->get_32();
 	uint32_t height = f->get_32();
+	uint32_t width = f->get_32();
 	uint32_t pitch = f->get_32();
 	/* uint32_t depth = */ f->get_32();
 	uint32_t mipmaps = f->get_32();


### PR DESCRIPTION
width and height attributes have to be switched according to the
official DDS header docs:
https://docs.microsoft.com/en-us/windows/desktop/direct3ddds/dds-header