### PR TITLE
Mono: Editor and export template dependencies and fixes

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -244,16 +244,13 @@ def mono_build_solution(source, target, env):
 
     copyfile(os.path.join(src_dir, asm_file), os.path.join(dst_dir, asm_file))
 
-output_dir = Dir('#bin').abspath
-assemblies_output_dir = Dir(env['mono_assemblies_output_dir']).abspath
+if env['tools']:
+    output_dir = Dir('#bin').abspath
+    editor_tools_dir = os.path.join(output_dir, 'GodotSharp', 'Tools')
 
-mono_sln_builder = Builder(action=mono_build_solution)
-env_mono.Append(BUILDERS={'MonoBuildSolution': mono_sln_builder})
-env_mono.MonoBuildSolution(
-    os.path.join(assemblies_output_dir, 'GodotSharpTools.dll'),
-    'editor/GodotSharpTools/GodotSharpTools.sln'
-)
-
-if os.path.normpath(output_dir) != os.path.normpath(assemblies_output_dir):
-    rel_assemblies_output_dir = os.path.relpath(assemblies_output_dir, output_dir)
-    env_mono.Append(CPPDEFINES={'GD_MONO_EDITOR_ASSEMBLIES_DIR': rel_assemblies_output_dir})
+    mono_sln_builder = Builder(action=mono_build_solution)
+    env_mono.Append(BUILDERS={'MonoBuildSolution': mono_sln_builder})
+    env_mono.MonoBuildSolution(
+        os.path.join(editor_tools_dir, 'GodotSharpTools.dll'),
+        'editor/GodotSharpTools/GodotSharpTools.sln'
+    )

--- a/modules/mono/editor/GodotSharpTools/Editor/GodotSharpExport.cs
+++ b/modules/mono/editor/GodotSharpTools/Editor/GodotSharpExport.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace GodotSharpTools.Editor
+{
+    public static class GodotSharpExport
+    {
+        public static void _ExportBegin(string[] features, bool debug, string path, int flags)
+        {
+            var featureSet = new HashSet<string>(features);
+
+            if (PlatformHasTemplateDir(featureSet))
+            {
+                string templateDirName = "data.mono";
+
+                if (featureSet.Contains("Windows"))
+                {
+                    templateDirName += ".windows";
+                    templateDirName += featureSet.Contains("64") ? ".64" : ".32";
+                }
+                else if (featureSet.Contains("X11"))
+                {
+                    templateDirName += ".x11";
+                    templateDirName += featureSet.Contains("64") ? ".64" : ".32";
+                }
+                else
+                {
+                    throw new NotSupportedException("Target platform not supported");
+                }
+
+                templateDirName += debug ? ".debug" : ".release";
+
+                string templateDirPath = Path.Combine(GetTemplatesDir(), templateDirName);
+
+                if (!Directory.Exists(templateDirPath))
+                    throw new FileNotFoundException("Data template directory not found");
+
+                string outputDir = new FileInfo(path).Directory.FullName;
+
+                string outputDataDir = Path.Combine(outputDir, GetDataDirName());
+
+                Directory.Delete(outputDataDir, recursive: true); // Clean first
+                Directory.CreateDirectory(outputDataDir);
+                
+                foreach (string dir in Directory.GetDirectories(templateDirPath, "*", SearchOption.AllDirectories))
+                {
+                    Directory.CreateDirectory(Path.Combine(outputDataDir, dir.Substring(templateDirPath.Length + 1)));
+                }
+
+                foreach (string file in Directory.GetFiles(templateDirPath, "*", SearchOption.AllDirectories))
+                {
+                    File.Copy(file, Path.Combine(outputDataDir, file.Substring(templateDirPath.Length + 1)));
+                }
+            }
+        }
+
+        public static bool PlatformHasTemplateDir(HashSet<string> featureSet)
+        {
+            // OSX export templates are contained in a zip, so we place
+            // our custom template inside it and let Godot do the rest.
+            return !featureSet.Contains("OSX");
+        }
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        extern static string GetTemplatesDir();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        extern static string GetDataDirName();
+    }
+}

--- a/modules/mono/editor/GodotSharpTools/GodotSharpTools.csproj
+++ b/modules/mono/editor/GodotSharpTools/GodotSharpTools.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Project\ProjectUtils.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\OS.cs" />
+    <Compile Include="Editor\GodotSharpExport.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/modules/mono/editor/csharp_project.cpp
+++ b/modules/mono/editor/csharp_project.cpp
@@ -51,7 +51,7 @@ String generate_core_api_project(const String &p_dir, const Vector<String> &p_fi
 	MonoObject *ret = klass->get_method("GenCoreApiProject", 2)->invoke(NULL, args, &exc);
 
 	if (exc) {
-		GDMonoUtils::debug_unhandled_exception(exc);
+		GDMonoUtils::debug_print_unhandled_exception(exc);
 		ERR_FAIL_V(String());
 	}
 
@@ -72,7 +72,7 @@ String generate_editor_api_project(const String &p_dir, const String &p_core_dll
 	MonoObject *ret = klass->get_method("GenEditorApiProject", 3)->invoke(NULL, args, &exc);
 
 	if (exc) {
-		GDMonoUtils::debug_unhandled_exception(exc);
+		GDMonoUtils::debug_print_unhandled_exception(exc);
 		ERR_FAIL_V(String());
 	}
 
@@ -93,7 +93,7 @@ String generate_game_project(const String &p_dir, const String &p_name, const Ve
 	MonoObject *ret = klass->get_method("GenGameProject", 3)->invoke(NULL, args, &exc);
 
 	if (exc) {
-		GDMonoUtils::debug_unhandled_exception(exc);
+		GDMonoUtils::debug_print_unhandled_exception(exc);
 		ERR_FAIL_V(String());
 	}
 
@@ -114,7 +114,7 @@ void add_item(const String &p_project_path, const String &p_item_type, const Str
 	klass->get_method("AddItemToProjectChecked", 3)->invoke(NULL, args, &exc);
 
 	if (exc) {
-		GDMonoUtils::debug_unhandled_exception(exc);
+		GDMonoUtils::debug_print_unhandled_exception(exc);
 		ERR_FAIL();
 	}
 }

--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -197,6 +197,7 @@ void GodotSharpEditor::register_internal_calls() {
 	mono_add_internal_call("GodotSharpTools.Utils.OS::GetPlatformName", (void *)godot_icall_Utils_OS_GetPlatformName);
 
 	GodotSharpBuilds::register_internal_calls();
+	GodotSharpExport::register_internal_calls();
 }
 
 void GodotSharpEditor::show_error_dialog(const String &p_message, const String &p_title) {

--- a/modules/mono/editor/godotsharp_export.cpp
+++ b/modules/mono/editor/godotsharp_export.cpp
@@ -30,12 +30,37 @@
 
 #include "godotsharp_export.h"
 
+#include "core/version.h"
+
 #include "../csharp_script.h"
 #include "../godotsharp_defs.h"
 #include "../godotsharp_dirs.h"
+#include "../mono_gd/gd_mono_class.h"
+#include "../mono_gd/gd_mono_marshal.h"
 #include "godotsharp_builds.h"
 
-void GodotSharpExport::_export_file(const String &p_path, const String &p_type, const Set<String> &p_features) {
+static MonoString *godot_icall_GodotSharpExport_GetTemplatesDir() {
+	String current_version = VERSION_FULL_CONFIG;
+	String templates_dir = EditorSettings::get_singleton()->get_templates_dir().plus_file(current_version);
+	return GDMonoMarshal::mono_string_from_godot(ProjectSettings::get_singleton()->globalize_path(templates_dir));
+}
+
+static MonoString *godot_icall_GodotSharpExport_GetDataDirName() {
+	String appname = ProjectSettings::get_singleton()->get("application/config/name");
+	String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
+	return GDMonoMarshal::mono_string_from_godot("data_" + appname_safe);
+}
+
+void GodotSharpExport::register_internal_calls() {
+	static bool registered = false;
+	ERR_FAIL_COND(registered);
+	registered = true;
+
+	mono_add_internal_call("GodotSharpTools.Editor.GodotSharpExport::GetTemplatesDir", (void *)godot_icall_GodotSharpExport_GetTemplatesDir);
+	mono_add_internal_call("GodotSharpTools.Editor.GodotSharpExport::GetDataDirName", (void *)godot_icall_GodotSharpExport_GetDataDirName);
+}
+
+void GodotSharpExport::_export_file(const String &p_path, const String &p_type, const Set<String> &) {
 
 	if (p_type != CSharpLanguage::get_singleton()->get_type())
 		return;
@@ -56,58 +81,77 @@ void GodotSharpExport::_export_begin(const Set<String> &p_features, bool p_debug
 	// TODO right now there is no way to stop the export process with an error
 
 	ERR_FAIL_COND(!GDMono::get_singleton()->is_runtime_initialized());
-	ERR_FAIL_NULL(GDMono::get_singleton()->get_tools_domain());
+	ERR_FAIL_NULL(TOOLS_DOMAIN);
+	ERR_FAIL_NULL(GDMono::get_singleton()->get_editor_tools_assembly());
 
 	String build_config = p_debug ? "Debug" : "Release";
 
 	ERR_FAIL_COND(!GodotSharpBuilds::build_project_blocking(build_config));
 
-	// Add API assemblies
+	// Add dependency assemblies
 
-	String core_api_dll_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(API_ASSEMBLY_NAME ".dll");
-	ERR_FAIL_COND(!_add_assembly(core_api_dll_path, core_api_dll_path));
-
-	String editor_api_dll_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(EDITOR_API_ASSEMBLY_NAME ".dll");
-	ERR_FAIL_COND(!_add_assembly(editor_api_dll_path, editor_api_dll_path));
-
-	// Add project assembly
+	Map<String, String> dependencies;
 
 	String project_dll_name = ProjectSettings::get_singleton()->get("application/config/name");
 	if (project_dll_name.empty()) {
 		project_dll_name = "UnnamedProject";
 	}
 
-	String project_dll_src_path = GodotSharpDirs::get_res_temp_assemblies_base_dir().plus_file(build_config).plus_file(project_dll_name + ".dll");
-	String project_dll_dst_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(project_dll_name + ".dll");
-	ERR_FAIL_COND(!_add_assembly(project_dll_src_path, project_dll_dst_path));
+	String project_dll_src_dir = GodotSharpDirs::get_res_temp_assemblies_base_dir().plus_file(build_config);
+	String project_dll_src_path = project_dll_src_dir.plus_file(project_dll_name + ".dll");
+	dependencies.insert(project_dll_name, project_dll_src_path);
 
-	// Add dependencies
+	{
+		MonoDomain *export_domain = GDMonoUtils::create_domain("GodotEngine.ProjectExportDomain");
+		ERR_FAIL_NULL(export_domain);
+		_GDMONO_SCOPE_EXIT_DOMAIN_UNLOAD_(export_domain);
 
-	MonoDomain *prev_domain = mono_domain_get();
-	MonoDomain *export_domain = GDMonoUtils::create_domain("GodotEngine.ProjectExportDomain");
+		_GDMONO_SCOPE_DOMAIN_(export_domain);
 
-	ERR_FAIL_COND(!export_domain);
-	ERR_FAIL_COND(!mono_domain_set(export_domain, false));
+		GDMonoAssembly *scripts_assembly = NULL;
+		bool load_success = GDMono::get_singleton()->load_assembly_from(project_dll_name,
+				project_dll_src_dir, &scripts_assembly, /* refonly: */ true);
 
-	Map<String, String> dependencies;
-	dependencies.insert("mscorlib", GDMono::get_singleton()->get_corlib_assembly()->get_path());
+		ERR_EXPLAIN("Cannot load refonly assembly: " + project_dll_name);
+		ERR_FAIL_COND(!load_success);
 
-	GDMonoAssembly *scripts_assembly = GDMonoAssembly::load_from(project_dll_name, project_dll_src_path, /* refonly: */ true);
-
-	ERR_EXPLAIN("Cannot load refonly assembly: " + project_dll_name);
-	ERR_FAIL_COND(!scripts_assembly);
-
-	Error depend_error = _get_assembly_dependencies(scripts_assembly, dependencies);
-
-	GDMono::get_singleton()->finalize_and_unload_domain(export_domain);
-	mono_domain_set(prev_domain, false);
-
-	ERR_FAIL_COND(depend_error != OK);
+		Vector<String> search_dirs;
+		GDMonoAssembly::fill_search_dirs(search_dirs);
+		Error depend_error = _get_assembly_dependencies(scripts_assembly, search_dirs, dependencies);
+		ERR_FAIL_COND(depend_error != OK);
+	}
 
 	for (Map<String, String>::Element *E = dependencies.front(); E; E = E->next()) {
 		String depend_src_path = E->value();
 		String depend_dst_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(depend_src_path.get_file());
 		ERR_FAIL_COND(!_add_assembly(depend_src_path, depend_dst_path));
+	}
+
+	// Mono specific export template extras (data dir)
+
+	GDMonoClass *export_class = GDMono::get_singleton()->get_editor_tools_assembly()->get_class("GodotSharpTools.Editor", "GodotSharpExport");
+	ERR_FAIL_NULL(export_class);
+	GDMonoMethod *export_begin_method = export_class->get_method("_ExportBegin", 4);
+	ERR_FAIL_NULL(export_begin_method);
+
+	MonoArray *features = mono_array_new(mono_domain_get(), CACHED_CLASS_RAW(String), p_features.size());
+	int i = 0;
+	for (const Set<String>::Element *E = p_features.front(); E; E = E->next()) {
+		MonoString *boxed = GDMonoMarshal::mono_string_from_godot(E->get());
+		mono_array_set(features, MonoString *, i, boxed);
+		i++;
+	}
+
+	MonoBoolean debug = p_debug;
+	MonoString *path = GDMonoMarshal::mono_string_from_godot(p_path);
+	uint32_t flags = p_flags;
+	void *args[4] = { features, &debug, path, &flags };
+	MonoException *exc = NULL;
+	export_begin_method->invoke_raw(NULL, args, &exc);
+
+	if (exc) {
+		GDMonoUtils::debug_print_unhandled_exception(exc);
+		ERR_FAIL();
 	}
 }
 
@@ -125,7 +169,7 @@ bool GodotSharpExport::_add_assembly(const String &p_src_path, const String &p_d
 	return true;
 }
 
-Error GodotSharpExport::_get_assembly_dependencies(GDMonoAssembly *p_assembly, Map<String, String> &r_dependencies) {
+Error GodotSharpExport::_get_assembly_dependencies(GDMonoAssembly *p_assembly, const Vector<String> &p_search_dirs, Map<String, String> &r_dependencies) {
 
 	MonoImage *image = p_assembly->get_image();
 
@@ -134,18 +178,48 @@ Error GodotSharpExport::_get_assembly_dependencies(GDMonoAssembly *p_assembly, M
 		mono_assembly_get_assemblyref(image, i, ref_aname);
 		String ref_name = mono_assembly_name_get_name(ref_aname);
 
-		if (ref_name == "mscorlib" || r_dependencies.find(ref_name))
+		if (r_dependencies.find(ref_name))
 			continue;
 
 		GDMonoAssembly *ref_assembly = NULL;
-		if (!GDMono::get_singleton()->load_assembly(ref_name, ref_aname, &ref_assembly, /* refonly: */ true)) {
-			ERR_EXPLAIN("Cannot load refonly assembly: " + ref_name);
+		String path;
+		bool has_extension = ref_name.ends_with(".dll") || ref_name.ends_with(".exe");
+
+		for (int i = 0; i < p_search_dirs.size(); i++) {
+			const String &search_dir = p_search_dirs[i];
+
+			if (has_extension) {
+				path = search_dir.plus_file(ref_name);
+				if (FileAccess::exists(path)) {
+					GDMono::get_singleton()->load_assembly_from(ref_name.get_basename(), search_dir, ref_aname, &ref_assembly, true);
+					if (ref_assembly != NULL)
+						break;
+				}
+			} else {
+				path = search_dir.plus_file(ref_name + ".dll");
+				if (FileAccess::exists(path)) {
+					GDMono::get_singleton()->load_assembly_from(ref_name, search_dir, ref_aname, &ref_assembly, true);
+					if (ref_assembly != NULL)
+						break;
+				}
+
+				path = search_dir.plus_file(ref_name + ".exe");
+				if (FileAccess::exists(path)) {
+					GDMono::get_singleton()->load_assembly_from(ref_name, search_dir, ref_aname, &ref_assembly, true);
+					if (ref_assembly != NULL)
+						break;
+				}
+			}
+		}
+
+		if (!ref_assembly) {
+			ERR_EXPLAIN("Cannot load assembly (refonly): " + ref_name);
 			ERR_FAIL_V(ERR_CANT_RESOLVE);
 		}
 
 		r_dependencies.insert(ref_name, ref_assembly->get_path());
 
-		Error err = _get_assembly_dependencies(ref_assembly, r_dependencies);
+		Error err = _get_assembly_dependencies(ref_assembly, p_search_dirs, r_dependencies);
 		if (err != OK)
 			return err;
 	}

--- a/modules/mono/editor/godotsharp_export.h
+++ b/modules/mono/editor/godotsharp_export.h
@@ -43,13 +43,15 @@ class GodotSharpExport : public EditorExportPlugin {
 
 	bool _add_assembly(const String &p_src_path, const String &p_dst_path);
 
-	Error _get_assembly_dependencies(GDMonoAssembly *p_assembly, Map<String, String> &r_dependencies);
+	Error _get_assembly_dependencies(GDMonoAssembly *p_assembly, const Vector<String> &p_search_dirs, Map<String, String> &r_dependencies);
 
 protected:
 	virtual void _export_file(const String &p_path, const String &p_type, const Set<String> &p_features);
 	virtual void _export_begin(const Set<String> &p_features, bool p_debug, const String &p_path, int p_flags);
 
 public:
+	static void register_internal_calls();
+
 	GodotSharpExport();
 	~GodotSharpExport();
 };

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -30,11 +30,11 @@
 
 #include "godotsharp_dirs.h"
 
+#include "core/os/dir_access.h"
 #include "core/os/os.h"
+#include "core/project_settings.h"
 
 #ifdef TOOLS_ENABLED
-#include "core/os/dir_access.h"
-#include "core/project_settings.h"
 #include "core/version.h"
 #include "editor/editor_settings.h"
 #endif
@@ -95,9 +95,17 @@ public:
 #ifdef TOOLS_ENABLED
 	String mono_solutions_dir;
 	String build_logs_dir;
+
 	String sln_filepath;
 	String csproj_filepath;
+
+	String data_mono_bin_dir;
+	String data_editor_tools_dir;
+	String data_editor_prebuilt_api_dir;
 #endif
+
+	String data_mono_etc_dir;
+	String data_mono_lib_dir;
 
 private:
 	_GodotSharpDirs() {
@@ -123,10 +131,60 @@ private:
 			name = "UnnamedProject";
 		}
 
-		String base_path = String("res://") + name;
+		String base_path = ProjectSettings::get_singleton()->globalize_path("res://");
 
-		sln_filepath = ProjectSettings::get_singleton()->globalize_path(base_path + ".sln");
-		csproj_filepath = ProjectSettings::get_singleton()->globalize_path(base_path + ".csproj");
+		sln_filepath = base_path.plus_file(name + ".sln");
+		csproj_filepath = base_path.plus_file(name + ".csproj");
+#endif
+
+		String exe_dir = OS::get_singleton()->get_executable_path().get_base_dir();
+
+#ifdef TOOLS_ENABLED
+
+		String data_dir_root = exe_dir.plus_file("GodotSharp");
+		data_editor_tools_dir = data_dir_root.plus_file("Tools");
+		data_editor_prebuilt_api_dir = data_dir_root.plus_file("Api");
+
+		String data_mono_root_dir = data_dir_root.plus_file("Mono");
+		data_mono_bin_dir = data_mono_root_dir.plus_file("bin");
+		data_mono_etc_dir = data_mono_root_dir.plus_file("etc");
+		data_mono_lib_dir = data_mono_root_dir.plus_file("lib");
+
+#ifdef OSX_ENABLED
+		if (!DirAccess::exists(data_editor_tools_dir)) {
+			data_editor_tools_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Tools");
+		}
+
+		if (!DirAccess::exists(data_editor_prebuilt_api_dir)) {
+			data_editor_prebuilt_api_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Api");
+		}
+
+		if (!DirAccess::exists(data_mono_root_dir)) {
+			data_mono_bin_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Mono/bin");
+			data_mono_etc_dir = exe_dir.plus_file("../Resources/GodotSharp/Mono/etc");
+			data_mono_lib_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Mono/lib");
+		}
+#endif
+
+#else
+
+		String appname = OS::get_singleton()->get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/name"));
+		String data_dir_root = exe_dir.plus_file("data_" + appname);
+		if (!DirAccess::exists(data_dir_root)) {
+			data_dir_root = exe_dir.plus_file("data_Godot");
+		}
+
+		String data_mono_root_dir = data_dir_root.plus_file("Mono");
+		data_mono_etc_dir = data_mono_root_dir.plus_file("etc");
+		data_mono_lib_dir = data_mono_root_dir.plus_file("lib");
+
+#ifdef OSX_ENABLED
+		if (!DirAccess::exists(data_mono_root_dir)) {
+			data_mono_etc_dir = exe_dir.plus_file("../Resources/GodotSharp/Mono/etc");
+			data_mono_lib_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Mono/lib");
+		}
+#endif
+
 #endif
 	}
 
@@ -192,5 +250,26 @@ String get_project_sln_path() {
 String get_project_csproj_path() {
 	return _GodotSharpDirs::get_singleton().csproj_filepath;
 }
+
+String get_data_mono_bin_dir() {
+	return _GodotSharpDirs::get_singleton().data_mono_bin_dir;
+}
+
+String get_data_editor_tools_dir() {
+	return _GodotSharpDirs::get_singleton().data_editor_tools_dir;
+}
+
+String get_data_editor_prebuilt_api_dir() {
+	return _GodotSharpDirs::get_singleton().data_editor_prebuilt_api_dir;
+}
 #endif
+
+String get_data_mono_etc_dir() {
+	return _GodotSharpDirs::get_singleton().data_mono_etc_dir;
+}
+
+String get_data_mono_lib_dir() {
+	return _GodotSharpDirs::get_singleton().data_mono_lib_dir;
+}
+
 } // namespace GodotSharpDirs

--- a/modules/mono/godotsharp_dirs.h
+++ b/modules/mono/godotsharp_dirs.h
@@ -49,11 +49,18 @@ String get_mono_logs_dir();
 #ifdef TOOLS_ENABLED
 String get_mono_solutions_dir();
 String get_build_logs_dir();
-String get_custom_project_settings_dir();
-#endif
 
 String get_project_sln_path();
 String get_project_csproj_path();
+
+String get_data_mono_bin_dir();
+String get_data_editor_tools_dir();
+String get_data_editor_prebuilt_api_dir();
+#endif
+
+String get_data_mono_etc_dir();
+String get_data_mono_lib_dir();
+
 } // namespace GodotSharpDirs
 
 #endif // GODOTSHARP_DIRS_H

--- a/modules/mono/mono_gd/gd_mono_assembly.h
+++ b/modules/mono/mono_gd/gd_mono_assembly.h
@@ -102,6 +102,7 @@ class GDMonoAssembly {
 	static MonoAssembly *_preload_hook(MonoAssemblyName *aname, char **assemblies_path, void *user_data, bool refonly);
 
 	static GDMonoAssembly *_load_assembly_from(const String &p_name, const String &p_path, bool p_refonly);
+	static GDMonoAssembly *_load_assembly_search(const String &p_name, const Vector<String> &p_search_dirs, bool p_refonly);
 	static void _wrap_mono_assembly(MonoAssembly *assembly);
 
 	friend class GDMono;
@@ -125,7 +126,7 @@ public:
 
 	GDMonoClass *get_object_derived_class(const StringName &p_class);
 
-	static GDMonoAssembly *load_from(const String &p_name, const String &p_path, bool p_refonly);
+	static void fill_search_dirs(Vector<String> &r_search_dirs, const String &p_custom_config = String());
 
 	GDMonoAssembly(const String &p_name, const String &p_path = String());
 	~GDMonoAssembly();


### PR DESCRIPTION
- Bundle editor dependencies:
    - 'GodotSharp': Root data directory for the editor
        - 'Tools': Editor dependencies. Only GodotSharpTools.dll for now.
        - 'Api': Prebuilt GodotSharp and GodotSharpEditor API assemblies.
        - 'Mono': Mono files to bundle with the editor.
            - 'bin': (Optional, not used for now) Mono bin directory.
            - 'etc': Mono configuration files.
            - 'lib': Mono dependency shared libraries.
            - 'lib/mono/4.5': Framework assemblies.
    - Added build option to copy the required files from the mono installation to 'GodotSharp/Mono'. Enable with 'copy_mono_root=yes'. Disabled by default.

- Export template dependencies:
    - 'data_AppName'/'data_Godot':
        - 'Mono': Mono files to bundle with the game.
            - 'etc': Mono configuration files.
            - 'lib': Mono dependency shared libraries.
    - The data directory is generated when compiling and must be bundled with the export templates. In the case of OSX, the data directory must be placed inside the 'osx.zip' export template.
    - In OSX, alternative location for directories (needed for app bundles) are:
        - 'data_AppName/Mono/etc' --> '../Resources/GodotSharp/Mono/etc'
        - 'data_AppName/Mono/lib' --> '../Frameworks/GodotSharp/Mono/lib'

- The editor can bundle prebuilt API assemblies. Closes #21734.
    - Generate them with a tools build by running: `godot --generate-cs-core-api <GodotSharp_OutputDir> --generate-cs-editor-api <GodotSharpEditor_OutputDir> <GodotSharp_OutputDir>/bin/Release/GodotSharp.dll` (This command will be simplified in the future and both projects will be in the same solution)
    - Build the solutions and copy the output files to '#bin/GodotSharp/Api'.
- Fixed API assembly being added twice during the export process.