### PR TITLE
Fix #22591: shader error when shadow enabled

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1630,7 +1630,7 @@ FRAGMENT_SHADER_CODE
 		highp vec4 splane = shadow_coord;
 		float shadow_len = length(splane.xyz);
 
-		splane = normalize(splane.xyz);
+		splane.xyz = normalize(splane.xyz);
 
 		vec4 clamp_rect = light_clamp;
 


### PR DESCRIPTION
shader failed to compile when shadow enabled because of incompatible assignment of vec3 to a vec4.