### PR TITLE
Fixing create spatial root button

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -836,6 +836,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			editor_data->get_undo_redo().commit_action();
 
 			editor->edit_node(new_node);
+			editor_selection->clear();
+			editor_selection->add_node(new_node);
 
 		} break;
 


### PR DESCRIPTION
Simple fix to add the new_node to the selection.
Closes #22677 

I am still curious why the Control based Nodes were working fine, if you guys have any ideas please do tell.