### PR TITLE
Change global timestamp behavior earlier

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3135,6 +3135,9 @@ bool EditorNode::is_scene_in_use(const String &p_path) {
 
 void EditorNode::register_editor_types() {
 
+	ResourceLoader::set_timestamp_on_load(true);
+	ResourceSaver::set_timestamp_on_save(true);
+
 	ClassDB::register_class<EditorPlugin>();
 	ClassDB::register_class<EditorImportPlugin>();
 	ClassDB::register_class<EditorScript>();
@@ -4825,9 +4828,6 @@ EditorNode::EditorNode() {
 	EditorFileDialog::set_default_display_mode((EditorFileDialog::DisplayMode)EditorSettings::get_singleton()->get("filesystem/file_dialog/display_mode").operator int());
 	ResourceLoader::set_error_notify_func(this, _load_error_notify);
 	ResourceLoader::set_dependency_error_notify_func(this, _dependency_error_report);
-
-	ResourceLoader::set_timestamp_on_load(true);
-	ResourceSaver::set_timestamp_on_save(true);
 
 	{ //register importers at the beginning, so dialogs are created with the right extensions
 		Ref<ResourceImporterTexture> import_texture;


### PR DESCRIPTION
If you open a project and play it immediately, some files would be saved again on the disk. Effectively, files loaded through the project settings, would not have a correct timestamp associated to it (last modified time still 0), forcing the file to be reloaded and saved again.
Correct behavior is to set the timestamp when loading the file, which is done is EditorNode() constructor. Now, this behavior is enabled earlier to set the timestamp for files loaded through project settings.