### PR TITLE
Fix Find in Files font size on hiDPI displays

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -31,6 +31,7 @@
 #include "find_in_files.h"
 #include "core/os/dir_access.h"
 #include "core/os/os.h"
+#include "editor_node.h"
 #include "editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -300,7 +301,7 @@ const char *FindInFilesDialog::SIGNAL_REPLACE_REQUESTED = "replace_requested";
 
 FindInFilesDialog::FindInFilesDialog() {
 
-	set_custom_minimum_size(Size2(400, 190));
+	set_custom_minimum_size(Size2(400, 190) * EDSCALE);
 	set_resizable(true);
 	set_title(TTR("Find in Files"));
 
@@ -334,12 +335,12 @@ FindInFilesDialog::FindInFilesDialog() {
 		HBoxContainer *hbc = memnew(HBoxContainer);
 
 		_whole_words_checkbox = memnew(CheckBox);
-		_whole_words_checkbox->set_text(TTR("Whole words"));
+		_whole_words_checkbox->set_text(TTR("Whole Words"));
 		_whole_words_checkbox->set_pressed(true);
 		hbc->add_child(_whole_words_checkbox);
 
 		_match_case_checkbox = memnew(CheckBox);
-		_match_case_checkbox->set_text(TTR("Match case"));
+		_match_case_checkbox->set_text(TTR("Match Case"));
 		_match_case_checkbox->set_pressed(true);
 		hbc->add_child(_match_case_checkbox);
 
@@ -548,7 +549,7 @@ FindInFilesPanel::FindInFilesPanel() {
 		hbc->add_child(find_label);
 
 		_search_text_label = memnew(Label);
-		_search_text_label->add_font_override("font", get_font("source", "EditorFonts"));
+		_search_text_label->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("source", "EditorFonts"));
 		hbc->add_child(_search_text_label);
 
 		_progress_bar = memnew(ProgressBar);
@@ -569,7 +570,7 @@ FindInFilesPanel::FindInFilesPanel() {
 	}
 
 	_results_display = memnew(Tree);
-	_results_display->add_font_override("font", get_font("source", "EditorFonts"));
+	_results_display->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("source", "EditorFonts"));
 	_results_display->set_v_size_flags(SIZE_EXPAND_FILL);
 	_results_display->connect("item_selected", this, "_on_result_selected");
 	_results_display->connect("item_edited", this, "_on_item_edited");
@@ -702,7 +703,7 @@ void FindInFilesPanel::_on_result_found(String fpath, int line_number, int begin
 	r.begin = begin;
 	r.end = end;
 	r.draw_begin = (item_text_width - raw_text_width) + font->get_string_size(text.left(r.begin)).x;
-	r.draw_width = font->get_string_size(text.substr(r.begin, r.end - r.begin + 1)).x;
+	r.draw_width = font->get_string_size(text.substr(r.begin, r.end - r.begin)).x;
 	_result_items[item] = r;
 
 	if (_with_replace) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3173,9 +3173,9 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	find_in_files_dialog->connect(FindInFilesDialog::SIGNAL_REPLACE_REQUESTED, this, "_start_find_in_files", varray(true));
 	add_child(find_in_files_dialog);
 	find_in_files = memnew(FindInFilesPanel);
-	find_in_files_button = editor->add_bottom_panel_item(TTR("Search results"), find_in_files);
+	find_in_files_button = editor->add_bottom_panel_item(TTR("Search Results"), find_in_files);
 	find_in_files_button->set_tooltip(TTR("Search in files"));
-	find_in_files->set_custom_minimum_size(Size2(0, 200));
+	find_in_files->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	find_in_files->connect(FindInFilesPanel::SIGNAL_RESULT_SELECTED, this, "_on_find_in_files_result_selected");
 	find_in_files->connect(FindInFilesPanel::SIGNAL_FILES_MODIFIED, this, "_on_find_in_files_modified_files");
 	find_in_files->hide();


### PR DESCRIPTION
This also tweaks the casing of a few strings to match the rest of the editor.

This closes #22692.

**Preview:**

![find_in_files_hidpi](https://user-images.githubusercontent.com/180032/46438487-4697b200-c75e-11e8-94df-8003eaafd500.png)
