### PR TITLE
fix enum cast warnings on clang

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -42,7 +42,7 @@ Input *Input::get_singleton() {
 }
 
 void Input::set_mouse_mode(MouseMode p_mode) {
-	ERR_FAIL_INDEX(p_mode, 4);
+	ERR_FAIL_INDEX((int)p_mode, 4);
 	OS::get_singleton()->set_mouse_mode((OS::MouseMode)p_mode);
 }
 

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -422,14 +422,14 @@ void Camera2D::clear_current() {
 
 void Camera2D::set_limit(Margin p_margin, int p_limit) {
 
-	ERR_FAIL_INDEX(p_margin, 4);
+	ERR_FAIL_INDEX((int)p_margin, 4);
 	limit[p_margin] = p_limit;
 	update();
 }
 
 int Camera2D::get_limit(Margin p_margin) const {
 
-	ERR_FAIL_INDEX_V(p_margin, 4, 0);
+	ERR_FAIL_INDEX_V((int)p_margin, 4, 0);
 	return limit[p_margin];
 }
 
@@ -446,14 +446,14 @@ bool Camera2D::is_limit_smoothing_enabled() const {
 
 void Camera2D::set_drag_margin(Margin p_margin, float p_drag_margin) {
 
-	ERR_FAIL_INDEX(p_margin, 4);
+	ERR_FAIL_INDEX((int)p_margin, 4);
 	drag_margin[p_margin] = p_drag_margin;
 	update();
 }
 
 float Camera2D::get_drag_margin(Margin p_margin) const {
 
-	ERR_FAIL_INDEX_V(p_margin, 4, 0);
+	ERR_FAIL_INDEX_V((int)p_margin, 4, 0);
 	return drag_margin[p_margin];
 }
 

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -247,7 +247,7 @@ Vector<Point2> CollisionPolygon2D::get_polygon() const {
 
 void CollisionPolygon2D::set_build_mode(BuildMode p_mode) {
 
-	ERR_FAIL_INDEX(p_mode, 2);
+	ERR_FAIL_INDEX((int)p_mode, 2);
 	build_mode = p_mode;
 	if (parent) {
 		_build_polygon();

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -814,7 +814,7 @@ AudioStreamPlayer3D::AttenuationModel AudioStreamPlayer3D::get_attenuation_model
 
 void AudioStreamPlayer3D::set_out_of_range_mode(OutOfRangeMode p_mode) {
 
-	ERR_FAIL_INDEX(p_mode, 2);
+	ERR_FAIL_INDEX((int)p_mode, 2);
 	out_of_range_mode = p_mode;
 }
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2235,13 +2235,13 @@ String Control::_get_tooltip() const {
 
 void Control::set_focus_neighbour(Margin p_margin, const NodePath &p_neighbour) {
 
-	ERR_FAIL_INDEX(p_margin, 4);
+	ERR_FAIL_INDEX((int)p_margin, 4);
 	data.focus_neighbour[p_margin] = p_neighbour;
 }
 
 NodePath Control::get_focus_neighbour(Margin p_margin) const {
 
-	ERR_FAIL_INDEX_V(p_margin, 4, NodePath());
+	ERR_FAIL_INDEX_V((int)p_margin, 4, NodePath());
 	return data.focus_neighbour[p_margin];
 }
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -511,7 +511,7 @@ void Label::regenerate_word_cache() {
 
 void Label::set_align(Align p_align) {
 
-	ERR_FAIL_INDEX(p_align, 4);
+	ERR_FAIL_INDEX((int)p_align, 4);
 	align = p_align;
 	update();
 }
@@ -523,7 +523,7 @@ Label::Align Label::get_align() const {
 
 void Label::set_valign(VAlign p_align) {
 
-	ERR_FAIL_INDEX(p_align, 4);
+	ERR_FAIL_INDEX((int)p_align, 4);
 	valign = p_align;
 	update();
 }

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -527,7 +527,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 void LineEdit::set_align(Align p_align) {
 
-	ERR_FAIL_INDEX(p_align, 4);
+	ERR_FAIL_INDEX((int)p_align, 4);
 	align = p_align;
 	update();
 }

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -110,7 +110,7 @@ Ref<Texture> NinePatchRect::get_texture() const {
 
 void NinePatchRect::set_patch_margin(Margin p_margin, int p_size) {
 
-	ERR_FAIL_INDEX(p_margin, 4);
+	ERR_FAIL_INDEX((int)p_margin, 4);
 	margin[p_margin] = p_size;
 	update();
 	minimum_size_changed();
@@ -132,7 +132,7 @@ void NinePatchRect::set_patch_margin(Margin p_margin, int p_size) {
 
 int NinePatchRect::get_patch_margin(Margin p_margin) const {
 
-	ERR_FAIL_INDEX_V(p_margin, 4, 0);
+	ERR_FAIL_INDEX_V((int)p_margin, 4, 0);
 	return margin[p_margin];
 }
 

--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -59,14 +59,14 @@ Ref<Texture> TextureProgress::get_over_texture() const {
 }
 
 void TextureProgress::set_stretch_margin(Margin p_margin, int p_size) {
-	ERR_FAIL_INDEX(p_margin, 4);
+	ERR_FAIL_INDEX((int)p_margin, 4);
 	stretch_margin[p_margin] = p_size;
 	update();
 	minimum_size_changed();
 }
 
 int TextureProgress::get_stretch_margin(Margin p_margin) const {
-	ERR_FAIL_INDEX_V(p_margin, 4, 0);
+	ERR_FAIL_INDEX_V((int)p_margin, 4, 0);
 	return stretch_margin[p_margin];
 }
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1901,7 +1901,7 @@ void Animation::value_track_set_update_mode(int p_track, UpdateMode p_mode) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_VALUE);
-	ERR_FAIL_INDEX(p_mode, 4);
+	ERR_FAIL_INDEX((int)p_mode, 4);
 
 	ValueTrack *vt = static_cast<ValueTrack *>(t);
 	vt->update_mode = p_mode;

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -136,7 +136,7 @@ Ref<Texture> StyleBoxTexture::get_normal_map() const {
 
 void StyleBoxTexture::set_margin_size(Margin p_margin, float p_size) {
 
-	ERR_FAIL_INDEX(p_margin, 4);
+	ERR_FAIL_INDEX((int)p_margin, 4);
 
 	margin[p_margin] = p_size;
 	emit_changed();
@@ -200,7 +200,7 @@ Size2 StyleBoxTexture::get_center_size() const {
 
 void StyleBoxTexture::set_expand_margin_size(Margin p_expand_margin, float p_size) {
 
-	ERR_FAIL_INDEX(p_expand_margin, 4);
+	ERR_FAIL_INDEX((int)p_expand_margin, 4);
 	expand_margin[p_expand_margin] = p_size;
 	emit_changed();
 }
@@ -223,7 +223,7 @@ void StyleBoxTexture::set_expand_margin_size_all(float p_expand_margin_size) {
 
 float StyleBoxTexture::get_expand_margin_size(Margin p_expand_margin) const {
 
-	ERR_FAIL_INDEX_V(p_expand_margin, 4, 0);
+	ERR_FAIL_INDEX_V((int)p_expand_margin, 4, 0);
 	return expand_margin[p_expand_margin];
 }
 


### PR DESCRIPTION
This makes clang compile without any warnings on my machine.