### PR TITLE
Fix warnings about non-static data member initializers in nativescript

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1016,6 +1016,16 @@ NativeScriptLanguage::NativeScriptLanguage() {
 #ifdef DEBUG_ENABLED
 	profiling = false;
 #endif
+
+	_init_call_type = "nativescript_init";
+	_init_call_name = "nativescript_init";
+	_terminate_call_name = "nativescript_terminate";
+	_noarg_call_type = "nativescript_no_arg";
+	_frame_call_name = "nativescript_frame";
+#ifndef NO_THREADS
+	_thread_enter_call_name = "nativescript_thread_enter";
+	_thread_exit_call_name = "nativescript_thread_exit";
+#endif
 }
 
 NativeScriptLanguage::~NativeScriptLanguage() {

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -277,18 +277,14 @@ public:
 
 	Map<String, Set<NativeScript *> > library_script_users;
 
-	const StringName _init_call_type = "nativescript_init";
-	const StringName _init_call_name = "nativescript_init";
-
-	const StringName _terminate_call_name = "nativescript_terminate";
-
-	const StringName _noarg_call_type = "nativescript_no_arg";
-
-	const StringName _frame_call_name = "nativescript_frame";
-
+	StringName _init_call_type;
+	StringName _init_call_name;
+	StringName _terminate_call_name;
+	StringName _noarg_call_type;
+	StringName _frame_call_name;
 #ifndef NO_THREADS
-	const StringName _thread_enter_call_name = "nativescript_thread_enter";
-	const StringName _thread_exit_call_name = "nativescript_thread_exit";
+	StringName _thread_enter_call_name;
+	StringName _thread_exit_call_name;
 #endif
 
 	NativeScriptLanguage();


### PR DESCRIPTION
Fixes the following GCC/Clang warnings:
```
modules/gdnative/nativescript/nativescript.h:280:37: warning: non-static data member initializers only available with -std=c++11 or -std=gnu++11
modules/gdnative/nativescript/nativescript.h:281:37: warning: non-static data member initializers only available with -std=c++11 or -std=gnu++11
modules/gdnative/nativescript/nativescript.h:283:42: warning: non-static data member initializers only available with -std=c++11 or -std=gnu++11
modules/gdnative/nativescript/nativescript.h:285:38: warning: non-static data member initializers only available with -std=c++11 or -std=gnu++11
modules/gdnative/nativescript/nativescript.h:287:38: warning: non-static data member initializers only available with -std=c++11 or -std=gnu++11
modules/gdnative/nativescript/nativescript.h:290:45: warning: non-static data member initializers only available with -std=c++11 or -std=gnu++11
modules/gdnative/nativescript/nativescript.h:291:44: warning: non-static data member initializers only available with -std=c++11 or -std=gnu++11
```

---

Currently building from scratch locally and it seems to work fine, but I have yet to actually test the engine once built (last attempt at fixing this warning caused a segfault on start). *Edit:* Works fine.