### PR TITLE
[Test] Run CI builds from scratch with warnings=all

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,6 @@ os: Visual Studio 2015
 environment:
   HOME: "%HOMEDRIVE%%HOMEPATH%"
   PYTHON: C:\Python27
-  SCONS_CACHE_ROOT: "%HOME%\\scons_cache"
   SCONS_CACHE_LIMIT: 1024
   matrix:
     - VS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
@@ -11,9 +10,6 @@ environment:
       TOOLS: yes
       TARGET: release_debug
       ARCH: amd64
-
-cache:
-  - "%SCONS_CACHE_ROOT%"
 
 install:
   - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
@@ -26,7 +22,6 @@ before_build:
   - python --version
   - scons --version
   - cl.exe
-  - SET "SCONS_CACHE=%SCONS_CACHE_ROOT%\master"
 
 build_script:
 - scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% debug_symbols=no verbose=yes progress=no gdnative_wrapper=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,9 @@ sudo: false
 
 env:
   global:
-    - SCONS_CACHE=$HOME/.scons_cache
     - SCONS_CACHE_LIMIT=1024
     - OPTIONS="debug_symbols=no verbose=yes progress=no gdnative_wrapper=yes"
     - secure: "uch9QszCgsl1qVbuzY41P7S2hWL2IiNFV4SbAYRCdi0oJ9MIu+pVyrQdpf3+jG4rH6j4Rffl+sN17Zz4dIDDioFL1JwqyCqyCyswR8uACC0Rr8gr4Mi3+HIRbv+2s2P4cIQq41JM8FJe84k9jLEMGCGh69w+ibCWoWs74CokYVA="
-
-cache:
-  directories:
-    - $SCONS_CACHE
 
 matrix:
   include:

--- a/SConstruct
+++ b/SConstruct
@@ -164,7 +164,7 @@ opts.Add(BoolVariable('disable_advanced_gui', "Disable advanced 3D GUI nodes and
 opts.Add('extra_suffix', "Custom extra suffix added to the base filename of all generated binary files", '')
 opts.Add(BoolVariable('verbose', "Enable verbose output for the compilation", False))
 opts.Add(BoolVariable('vsproj', "Generate a Visual Studio solution", False))
-opts.Add(EnumVariable('warnings', "Set the level of warnings emitted during compilation", 'no', ('extra', 'all', 'moderate', 'no')))
+opts.Add(EnumVariable('warnings', "Set the level of warnings emitted during compilation", 'all', ('extra', 'all', 'moderate', 'no')))
 opts.Add(BoolVariable('progress', "Show a progress indicator during compilation", True))
 opts.Add(BoolVariable('dev', "If yes, alias for verbose=yes warnings=all", False))
 opts.Add(EnumVariable('macports_clang', "Build using Clang from MacPorts", 'no', ('no', '5.0', 'devel')))
@@ -318,15 +318,12 @@ if selected_platform in platform_list:
     # must happen after the flags, so when flags are used by configure, stuff happens (ie, ssl on x11)
     detect.configure(env)
 
-    if (env["warnings"] == 'yes'):
-        print("WARNING: warnings=yes is deprecated; assuming warnings=all")
-
     if env.msvc:
         # Truncations, narrowing conversions, signed/unsigned comparisons...
         disable_nonessential_warnings = ['/wd4267', '/wd4244', '/wd4305', '/wd4018', '/wd4800']
         if (env["warnings"] == 'extra'):
             env.Append(CCFLAGS=['/Wall']) # Implies /W4
-        elif (env["warnings"] == 'all' or env["warnings"] == 'yes'):
+        elif (env["warnings"] == 'all'):
             env.Append(CCFLAGS=['/W3'] + disable_nonessential_warnings)
         elif (env["warnings"] == 'moderate'):
             env.Append(CCFLAGS=['/W2'] + disable_nonessential_warnings)
@@ -338,7 +335,7 @@ if selected_platform in platform_list:
         disable_nonessential_warnings = ['-Wno-sign-compare']
         if (env["warnings"] == 'extra'):
             env.Append(CCFLAGS=['-Wall', '-Wextra'])
-        elif (env["warnings"] == 'all' or env["warnings"] == 'yes'):
+        elif (env["warnings"] == 'all'):
             env.Append(CCFLAGS=['-Wall'] + disable_nonessential_warnings)
         elif (env["warnings"] == 'moderate'):
             env.Append(CCFLAGS=['-Wall', '-Wno-unused'] + disable_nonessential_warnings)

--- a/methods.py
+++ b/methods.py
@@ -22,6 +22,10 @@ def add_source_files(self, sources, filetype, lib_env=None, shared=False):
 def disable_warnings(self):
     # 'self' is the environment
     if self.msvc:
+        # We have to remove existing warning level defines before appending /w,
+        # otherwise we get: "warning D9025 : overriding '/W3' with '/w'"
+        warn_flags = ['/Wall', '/W4', '/W3', '/W2', '/W1', '/WX']
+        self['CCFLAGS'] = [x for x in self['CCFLAGS'] if not x in warn_flags]
         self.Append(CCFLAGS=['/w'])
     else:
         self.Append(CCFLAGS=['-w'])


### PR DESCRIPTION
**DO NOT MERGE!**

This is #22620 with an added temporary commit to disable the cache in Travis and AppVeyor and thus get a full view of current compilation warnings after the many fixes of the past week.