### PR TITLE
Fix some OSX and iOS Clang warnings

### DIFF
--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -89,8 +89,13 @@ void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 	atomic_increment(&alloc_count);
 
 	if (prepad) {
+		// Clang 5 wrongly complains about 's' being unused,
+		// while it's used to modify 'mem'.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
 		uint64_t *s = (uint64_t *)mem;
 		*s = p_bytes;
+#pragma clang diagnostic pop
 
 		uint8_t *s8 = (uint8_t *)mem;
 

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -74,6 +74,7 @@
 #include <EGL/eglext.h>
 #endif
 
+#ifndef IPHONE_ENABLED
 static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
 
 	if (type == _EXT_DEBUG_TYPE_OTHER_ARB)
@@ -120,6 +121,7 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 
 	ERR_PRINTS(output);
 }
+#endif // IPHONE_ENABLED
 
 typedef void (*DEBUGPROCARB)(GLenum source,
 		GLenum type,

--- a/drivers/unix/thread_posix.cpp
+++ b/drivers/unix/thread_posix.cpp
@@ -103,8 +103,6 @@ void ThreadPosix::wait_to_finish_func_posix(Thread *p_thread) {
 
 Error ThreadPosix::set_name_func_posix(const String &p_name) {
 
-	pthread_t running_thread = pthread_self();
-
 #ifdef PTHREAD_NO_RENAME
 	return ERR_UNAVAILABLE;
 
@@ -117,6 +115,7 @@ Error ThreadPosix::set_name_func_posix(const String &p_name) {
 
 #else
 
+	pthread_t running_thread = pthread_self();
 #ifdef PTHREAD_BSD_SET_NAME
 	pthread_set_name_np(running_thread, p_name.utf8().get_data());
 	int err = 0; // Open/FreeBSD ignore errors in this function

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -368,11 +368,14 @@ inline NativeScriptDesc *NativeScript::get_script_desc() const {
 
 class NativeReloadNode : public Node {
 	GDCLASS(NativeReloadNode, Node)
-	bool unloaded = false;
+	bool unloaded;
 
 public:
 	static void _bind_methods();
 	void _notification(int p_what);
+
+	NativeReloadNode() :
+			unloaded(false) {}
 };
 
 class ResourceFormatLoaderNativeScript : public ResourceFormatLoader {

--- a/platform/iphone/gl_view.mm
+++ b/platform/iphone/gl_view.mm
@@ -53,7 +53,6 @@ static GLView *_instance = NULL;
 
 static bool video_found_error = false;
 static bool video_playing = false;
-static float video_previous_volume = 0.0f;
 static CMTime video_current_time;
 
 void _show_keyboard(String);
@@ -246,16 +245,6 @@ static int remove_touch(UITouch *p_touch) {
 			++remaining;
 	};
 	return remaining;
-};
-
-static int get_first_id(UITouch *p_touch) {
-
-	for (int i = 0; i < max_touches; i++) {
-
-		if (touches[i] != NULL)
-			return i;
-	};
-	return -1;
 };
 
 static void clear_touches() {
@@ -751,7 +740,6 @@ static void clear_touches() {
 		[_instance.moviePlayerController stop];
 		[_instance.moviePlayerController.view removeFromSuperview];
 
-	//[[MPMusicPlayerController applicationMusicPlayer] setVolume: video_previous_volume];
 	video_playing = false;
 }
 */

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -76,11 +76,6 @@
 #define NSWindowStyleMaskBorderless NSBorderlessWindowMask
 #endif
 
-static NSRect convertRectToBacking(NSRect contentRect) {
-
-	return [OS_OSX::singleton->window_view convertRectToBacking:contentRect];
-}
-
 static void get_key_modifier_state(unsigned int p_osx_state, Ref<InputEventWithModifiers> state) {
 
 	state->set_shift((p_osx_state & NSEventModifierFlagShift));
@@ -271,7 +266,7 @@ static Vector2 get_mouse_pos(NSEvent *event) {
 		float newDisplayScale = OS_OSX::singleton->is_hidpi_allowed() ? newBackingScaleFactor : 1.0;
 
 		const NSRect contentRect = [OS_OSX::singleton->window_view frame];
-		const NSRect fbRect = contentRect; //convertRectToBacking(contentRect);
+		const NSRect fbRect = contentRect;
 
 		OS_OSX::singleton->window_size.width = fbRect.size.width * newDisplayScale;
 		OS_OSX::singleton->window_size.height = fbRect.size.height * newDisplayScale;
@@ -292,7 +287,7 @@ static Vector2 get_mouse_pos(NSEvent *event) {
 	[OS_OSX::singleton->context update];
 
 	const NSRect contentRect = [OS_OSX::singleton->window_view frame];
-	const NSRect fbRect = contentRect; //convertRectToBacking(contentRect);
+	const NSRect fbRect = contentRect;
 
 	float displayScale = OS_OSX::singleton->_display_scale();
 	OS_OSX::singleton->window_size.width = fbRect.size.width * displayScale;


### PR DESCRIPTION
Fixes the following XCode 9.4.1 warnings:
```
core/os/memory.cpp:175:13: warning: unused variable 's' [-Wunused-variable]
drivers/coremidi/core_midi.cpp:68:14: warning: comparison between NULL and non-pointer ('MIDIEndpointRef' (aka 'unsigned int') and NULL) [-Wnull-arithmetic]
drivers/gles2/rasterizer_gles2.cpp:77:24: warning: unused function '_gl_debug_print' [-Wunused-function,34]
drivers/unix/thread_posix.cpp:106:12: warning: unused variable 'running_thread' [-Wunused-variable,34]
modules/gdnative/nativescript/nativescript.h:371:16: warning: in-class initialization of non-static data member is a C++11 extension [-Wc++11-extensions]
platform/iphone/gl_view.mm:56:14: warning: unused variable 'video_previous_volume' [-Wunused-variable,34]
platform/iphone/gl_view.mm:251:12: warning: unused function 'get_first_id' [-Wunused-function,34]
platform/osx/os_osx.mm:79:15: warning: unused function 'convertRectToBacking' [-Wunused-function]
```

*Edit:* Removed mention of `platform/iphone/main.m:45:15: warning: unused variable 'app' [-Wunused-variable,34]`, didn't fix it eventually.