### PR TITLE
Fixes AnimatedSprite2D animation_finished signal triggering too early

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -395,15 +395,17 @@ void AnimatedSprite::_notification(int p_what) {
 					int fc = frames->get_frame_count(animation);
 					if (frame >= fc - 1) {
 						if (frames->get_animation_loop(animation)) {
+							emit_signal(SceneStringNames::get_singleton()->animation_finished);
 							frame = 0;
 						} else {
+							if (!is_over) {
+								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+								is_over = true;
+							}
 							frame = fc - 1;
 						}
 					} else {
 						frame++;
-						if (frame == fc - 1) {
-							emit_signal(SceneStringNames::get_singleton()->animation_finished);
-						}
 					}
 
 					update();
@@ -625,6 +627,7 @@ void AnimatedSprite::_reset_timeout() {
 		return;
 
 	timeout = _get_frame_duration();
+	is_over = false;
 }
 
 void AnimatedSprite::set_animation(const StringName &p_animation) {
@@ -712,4 +715,5 @@ AnimatedSprite::AnimatedSprite() {
 	playing = false;
 	animation = "default";
 	timeout = 0;
+	is_over = false;
 }

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -135,6 +135,7 @@ class AnimatedSprite : public Node2D {
 	bool centered;
 	Point2 offset;
 
+	bool is_over;
 	float timeout;
 
 	bool hflip;


### PR DESCRIPTION
Closes #18250
Triggers the signal at the end of the animation instead of as soon as the last frame should appear.