### PR TITLE
Fix GCC 8 warnings about potentially unitialized variables

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -780,9 +780,9 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
 	// Setup mipmap-aware scaling
 	Image dst2;
-	int mip1;
-	int mip2;
-	float mip1_weight;
+	int mip1 = 0;
+	int mip2 = 0;
+	float mip1_weight = 0;
 	if (mipmap_aware) {
 		float avg_scale = ((float)p_width / width + (float)p_height / height) * 0.5f;
 		if (avg_scale >= 1.0f) {

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -91,11 +91,15 @@ void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 	if (prepad) {
 		// Clang 5 wrongly complains about 's' being unused,
 		// while it's used to modify 'mem'.
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
+#endif // __clang__
 		uint64_t *s = (uint64_t *)mem;
 		*s = p_bytes;
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif // __clang__
 
 		uint8_t *s8 = (uint8_t *)mem;
 

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -50,7 +50,7 @@ float AudioStreamPreview::get_max(float p_time, float p_time_next) const {
 		time_to = time_from + 1;
 	}
 
-	uint8_t vmax;
+	uint8_t vmax = 0;
 
 	for (int i = time_from; i < time_to; i++) {
 
@@ -77,7 +77,7 @@ float AudioStreamPreview::get_min(float p_time, float p_time_next) const {
 		time_to = time_from + 1;
 	}
 
-	uint8_t vmin;
+	uint8_t vmin = 0;
 
 	for (int i = time_from; i < time_to; i++) {
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -251,7 +251,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	Color preset_accent_color;
 	Color preset_base_color;
-	float preset_contrast;
+	float preset_contrast = 0;
 
 	// Please, use alphabet order if you've added new theme here(After "Default" and "Custom")
 

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -434,7 +434,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 
 		if (blend_space->get_snap().x > 0) {
 
-			int prev_idx;
+			int prev_idx = 0;
 			for (int i = 0; i < s.x; i++) {
 
 				float v = blend_space->get_min_space().x + i * (blend_space->get_max_space().x - blend_space->get_min_space().x) / s.x;
@@ -450,7 +450,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 
 		if (blend_space->get_snap().y > 0) {
 
-			int prev_idx;
+			int prev_idx = 0;
 			for (int i = 0; i < s.y; i++) {
 
 				float v = blend_space->get_max_space().y - i * (blend_space->get_max_space().y - blend_space->get_min_space().y) / s.y;

--- a/main/tests/test_oa_hash_map.cpp
+++ b/main/tests/test_oa_hash_map.cpp
@@ -48,7 +48,7 @@ MainLoop *test() {
 		map.set(1337, 21);
 		map.set(42, 11880);
 
-		int value;
+		int value = 0;
 		map.lookup(42, value);
 
 		OS::get_singleton()->print("capacity  %d\n", map.get_capacity());

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -750,7 +750,7 @@ void CSGBrushOperation::_add_poly_outline(const BuildPoly &p_poly, int p_from_po
 
 		t2d.affine_invert();
 
-		float max_angle;
+		float max_angle = 0;
 		int next_point_angle = -1;
 
 		for (int i = 0; i < vertex_process[to_point].size(); i++) {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1573,7 +1573,7 @@ CSGBrush *CSGPolygon::_build_brush() {
 	}
 	CSGBrush *brush = memnew(CSGBrush);
 
-	int face_count;
+	int face_count = 0;
 
 	switch (mode) {
 		case MODE_DEPTH: face_count = triangles.size() * 2 / 3 + (final_polygon.size()) * 2; break;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -304,7 +304,7 @@ void TileMap::update_dirty_quadrants() {
 		}
 		q.occluder_instances.clear();
 		Ref<ShaderMaterial> prev_material;
-		int prev_z_index;
+		int prev_z_index = 0;
 		RID prev_canvas_item;
 		RID prev_debug_canvas_item;
 

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -1589,8 +1589,8 @@ Vector3 VoxelLightBaker::_compute_pixel_light_at_pos(const Vector3 &p_pos, const
 
 	const Vector3 *cone_dirs;
 	const float *cone_weights;
-	int cone_dir_count;
-	float cone_aperture;
+	int cone_dir_count = 0;
+	float cone_aperture = 0;
 
 	switch (bake_quality) {
 		case BAKE_QUALITY_LOW: {

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -468,7 +468,7 @@ float AnimationNodeBlendSpace2D::process(float p_time, bool p_seek) {
 	}
 
 	first = true;
-	float mind;
+	float mind = 0;
 	for (int i = 0; i < blend_points_used; i++) {
 
 		bool found = false;


### PR DESCRIPTION
Fixes the following GCC 8 warnings:
```
core/image.cpp:730:44: warning: 'mip1_weight' may be used uninitialized in this function [-Wmaybe-uninitialized]
core/image.cpp:293:20: warning: 'mip2' may be used uninitialized in this function [-Wmaybe-uninitialized]
core/image.cpp:293:20: warning: 'mip1' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/audio_stream_preview.cpp:58:19: warning: 'vmax' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/audio_stream_preview.cpp:85:19: warning: 'vmin' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/editor_themes.cpp:306:53: warning: 'preset_contrast' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/plugins/animation_blend_space_2d_editor.cpp:459:27: warning: 'prev_idx' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/plugins/animation_blend_space_2d_editor.cpp:443:27: warning: 'prev_idx' may be used uninitialized in this function [-Wmaybe-uninitialized]
main/tests/test_oa_hash_map.cpp:57:29: warning: 'value' may be used uninitialized in this function [-Wmaybe-uninitialized]
modules/csg/csg.cpp:764:40: warning: 'max_angle' may be used uninitialized in this function [-Wmaybe-uninitialized]
modules/csg/csg_shape.cpp:1945:3: warning: 'face_count' may be used uninitialized in this function [-Wmaybe-uninitialized]
scene/3d/voxel_light_baker.cpp:1593:8: warning: 'cone_aperture' may be used uninitialized in this function [-Wmaybe-uninitialized]
scene/3d/voxel_light_baker.cpp:1592:6: warning: 'cone_dir_count' may be used uninitialized in this function [-Wmaybe-uninitialized]
scene/animation/animation_blend_space_2d.cpp:471:8: warning: 'mind' may be used uninitialized in this function [-Wmaybe-uninitialized]

core/os/memory.cpp:94: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
core/os/memory.cpp:95: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
core/os/memory.cpp:98: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
```