### PR TITLE
Fix warnings genearted by MSVC.

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -114,7 +114,7 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 		path = path + ".tmp";
 	}
 
-	f = _wfopen(path.c_str(), mode_string);
+	_wfopen_s(&f, path.c_str(), mode_string);
 
 	if (f == NULL) {
 		last_error = ERR_FILE_CANT_OPEN;
@@ -278,7 +278,7 @@ bool FileAccessWindows::file_exists(const String &p_name) {
 	FILE *g;
 	//printf("opening file %s\n", p_fname.c_str());
 	String filename = fix_path(p_name);
-	g = _wfopen(filename.c_str(), L"rb");
+	_wfopen_s(&g, filename.c_str(), L"rb");
 	if (g == NULL) {
 
 		return false;

--- a/editor/plugins/camera_editor_plugin.cpp
+++ b/editor/plugins/camera_editor_plugin.cpp
@@ -36,12 +36,14 @@ void CameraEditor::_notification(int p_what) {
 
 	switch (p_what) {
 
-		/*		case NOTIFICATION_PROCESS: {
-
+		case NOTIFICATION_PROCESS: /*{
 			if (preview->is_pressed() && node)
 				node->call("make_current");
 
 		} break;*/
+		default:
+			// Do nothing
+			break;
 	}
 }
 void CameraEditor::_node_removed(Node *p_node) {

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -3454,7 +3454,7 @@ void CollisionShapeSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 
 		if (points.size() > 3) {
 
-			QuickHull qh;
+			QuickHull qh = {};
 			Vector<Vector3> varr = Variant(points);
 			Geometry::MeshData md;
 			Error err = qh.build(varr, md);

--- a/platform/windows/joypad.cpp
+++ b/platform/windows/joypad.cpp
@@ -163,7 +163,7 @@ bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE *instance) {
 
 	const GUID &guid = instance->guidProduct;
 	char uid[128];
-	sprintf(uid, "%08lx%04hx%04hx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
+	sprintf_s(uid, sizeof(uid), "%08lx%04hx%04hx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
 			__builtin_bswap32(guid.Data1), guid.Data2, guid.Data3,
 			guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3],
 			guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1204,7 +1204,15 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 
 	AdjustWindowRectEx(&WindowRect, dwStyle, FALSE, dwExStyle);
 
-	char *windowid = getenv("GODOT_WINDOWID");
+	char *windowid = NULL;
+
+#ifdef MINGW_ENABLED
+	windowid = getenv("GODOT_WINDOWID");
+#else
+	size_t len = 0;
+	_dupenv_s(&windowid, &len, "GODOT_WINDOWID");
+#endif
+
 	if (windowid) {
 
 // strtoull on mingw
@@ -1213,6 +1221,7 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 #else
 		hWnd = (HWND)_strtoui64(windowid, NULL, 0);
 #endif
+		free(windowid);
 		SetLastError(0);
 		user_proc = (WNDPROC)GetWindowLongPtr(hWnd, GWLP_WNDPROC);
 		SetWindowLongPtr(hWnd, GWLP_WNDPROC, (LONG_PTR)(WNDPROC)::WndProc);
@@ -2546,7 +2555,12 @@ void OS_Windows::set_icon(const Ref<Image> &p_icon) {
 
 bool OS_Windows::has_environment(const String &p_var) const {
 
-	return _wgetenv(p_var.c_str()) != NULL;
+	wchar_t *env_value = NULL;
+	size_t len = 0;
+	_wdupenv_s(&env_value, &len, p_var.c_str());
+	bool res = env_value != NULL;
+	free(env_value);
+	return res;
 };
 
 String OS_Windows::get_environment(const String &p_var) const {
@@ -2926,7 +2940,8 @@ bool OS_Windows::is_disable_crash_handler() const {
 Error OS_Windows::move_to_trash(const String &p_path) {
 	SHFILEOPSTRUCTW sf;
 	WCHAR *from = new WCHAR[p_path.length() + 2];
-	wcscpy(from, p_path.c_str());
+	wcscpy_s(from, (p_path.length() + 2) / sizeof(WCHAR), p_path.c_str());
+
 	from[p_path.length() + 1] = 0;
 
 	sf.hwnd = hWnd;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -448,7 +448,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 
 							//float dist_att_db = -20 * Math::log(dist + 0.00001); //logarithmic attenuation, like in real life
 
-							float center_val[3] = { 0.5, 0.25, 0.16666 };
+							float center_val[3] = { 0.5f, 0.25f, 0.16666f };
 							AudioFrame center_frame(center_val[vol_index_max - 1], center_val[vol_index_max - 1]);
 
 							if (attenuation < 1.0) {

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -1619,7 +1619,7 @@ Vector3 VoxelLightBaker::_compute_pixel_light_at_pos(const Vector3 &p_pos, const
 				Vector3(-0.700629, -0.509037, 0.5),
 				Vector3(0.267617, -0.823639, 0.5)
 			};
-			static const float weights[6] = { 0.25, 0.15, 0.15, 0.15, 0.15, 0.15 };
+			static const float weights[6] = { 0.25f, 0.15f, 0.15f, 0.15f, 0.15f, 0.15f };
 			//
 			cone_dirs = dirs;
 			cone_dir_count = 6;
@@ -1641,7 +1641,7 @@ Vector3 VoxelLightBaker::_compute_pixel_light_at_pos(const Vector3 &p_pos, const
 				Vector3(0.19124006749743122, 0.39355745585016605, 0.8991883926788214),
 				Vector3(0.19124006749743122, -0.39355745585016605, 0.8991883926788214),
 			};
-			static const float weights[10] = { 0.08571, 0.08571, 0.08571, 0.08571, 0.08571, 0.08571, 0.08571, 0.133333, 0.133333, 0.13333 };
+			static const float weights[10] = { 0.08571f, 0.08571f, 0.08571f, 0.08571f, 0.08571f, 0.08571f, 0.08571f, 0.133333f, 0.133333f, 0.13333f };
 			cone_dirs = dirs;
 			cone_dir_count = 10;
 			cone_aperture = 0.404; // tan(angle) 45 degrees
@@ -1875,7 +1875,7 @@ Error VoxelLightBaker::make_lightmap(const Transform &p_xform, Ref<Mesh> &p_mesh
 		if (bake_mode == BAKE_MODE_RAY_TRACE) {
 			//blur
 			//gauss kernel, 7 step sigma 2
-			static const float gauss_kernel[4] = { 0.214607, 0.189879, 0.131514, 0.071303 };
+			static const float gauss_kernel[4] = { 0.214607f, 0.189879f, 0.131514f, 0.071303f };
 			//horizontal pass
 			for (int i = 0; i < height; i++) {
 				for (int j = 0; j < width; j++) {


### PR DESCRIPTION
Address MSDN warnings by using the secured version of the functions
instead of the deprecated version.

Fixes the following warnings:
```
platform\windows\os_windows.cpp(1207): warning C4996: 'getenv': This
function or variable may be unsafe. Consider
using _dupenv_s instead. To disable deprecation, use
_CRT_SECURE_NO_WARNINGS. See online help for details.

platform\windows\os_windows.cpp(2549): warning C4996: '_wgetenv': This
function or variable may be unsafe. Conside
r using _wdupenv_s instead. To disable deprecation, use
_CRT_SECURE_NO_WARNINGS. See online help for details.
'_wgetenv'
platform\windows\os_windows.cpp(2929): warning C4996: 'wcscpy': This
function or variable may be unsafe. Consider
using wcscpy_s instead. To disable deprecation, use
_CRT_SECURE_NO_WARNINGS. See online help for details.
```

Related issue: https://github.com/godotengine/godot/issues/22684