### PR TITLE
Fix more "may be used initialized" warnings from GCC 7

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -87,7 +87,10 @@ private:
 #if defined(_add_overflow) && defined(_mul_overflow)
 		size_t o;
 		size_t p;
-		if (_mul_overflow(p_elements, sizeof(T), &o)) return false;
+		if (_mul_overflow(p_elements, sizeof(T), &o)) {
+			*out = 0;
+			return false;
+		}
 		*out = next_power_of_2(o);
 		if (_add_overflow(o, static_cast<size_t>(32), &p)) return false; //no longer allocated here
 		return true;

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1471,7 +1471,8 @@ void Image::create(int p_width, int p_height, bool p_use_mipmaps, Format p_forma
 
 void Image::create(const char **p_xpm) {
 
-	int size_width, size_height;
+	int size_width = 0;
+	int size_height = 0;
 	int pixelchars = 0;
 	mipmaps = false;
 	bool has_alpha = false;
@@ -1487,8 +1488,8 @@ void Image::create(const char **p_xpm) {
 	int line = 0;
 
 	HashMap<String, Color> colormap;
-	int colormap_size;
-	uint32_t pixel_size;
+	int colormap_size = 0;
+	uint32_t pixel_size = 0;
 	PoolVector<uint8_t>::Write w;
 
 	while (status != DONE) {

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -202,11 +202,12 @@ bool Face3::intersects_aabb(const AABB &p_aabb) const {
 	{                                                              \
 		real_t aabb_min = p_aabb.position.m_ax;                    \
 		real_t aabb_max = p_aabb.position.m_ax + p_aabb.size.m_ax; \
-		real_t tri_min, tri_max;                                   \
-		for (int i = 0; i < 3; i++) {                              \
-			if (i == 0 || vertex[i].m_ax > tri_max)                \
+		real_t tri_min = vertex[0].m_ax;                           \
+		real_t tri_max = vertex[0].m_ax;                           \
+		for (int i = 1; i < 3; i++) {                              \
+			if (vertex[i].m_ax > tri_max)                          \
 				tri_max = vertex[i].m_ax;                          \
-			if (i == 0 || vertex[i].m_ax < tri_min)                \
+			if (vertex[i].m_ax < tri_min)                          \
 				tri_min = vertex[i].m_ax;                          \
 		}                                                          \
                                                                    \

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -653,7 +653,7 @@ bool RasterizerSceneGLES3::reflection_probe_instance_begin_render(RID p_instance
 
 	int best_free = -1;
 	int best_used = -1;
-	uint64_t best_used_frame;
+	uint64_t best_used_frame = 0;
 
 	for (int i = 0; i < reflection_atlas->reflections.size(); i++) {
 		if (reflection_atlas->reflections[i].owner == RID()) {

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -730,7 +730,7 @@ void RasterizerStorageGLES3::texture_set_data(RID p_texture, const Ref<Image> &p
 		}
 	};
 
-	GLenum blit_target;
+	GLenum blit_target = GL_TEXTURE_2D;
 
 	switch (texture->type) {
 		case VS::TEXTURE_TYPE_2D: {
@@ -948,7 +948,7 @@ void RasterizerStorageGLES3::texture_set_data_partial(RID p_texture, const Ref<I
 	Image::Format real_format;
 	Ref<Image> img = _get_gl_image_and_format(p_sub_img, p_sub_img->get_format(), texture->flags, real_format, format, internal_format, type, compressed, srgb);
 
-	GLenum blit_target;
+	GLenum blit_target = GL_TEXTURE_2D;
 
 	switch (texture->type) {
 		case VS::TEXTURE_TYPE_2D: {

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -128,11 +128,13 @@ private:
 		Vector<GLint> texture_uniform_locations;
 		uint32_t code_version;
 		bool ok;
-		Version() {
-			code_version = 0;
-			ok = false;
-			uniform_location = NULL;
-		}
+		Version() :
+				id(0),
+				vert_id(0),
+				frag_id(0),
+				uniform_location(NULL),
+				code_version(0),
+				ok(false) {}
 	};
 
 	Version *version;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1960,7 +1960,7 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 
 	// doesn't have it, make a new one
 
-	ScriptEditorBase *se;
+	ScriptEditorBase *se = NULL;
 
 	for (int i = script_editor_func_count - 1; i >= 0; i--) {
 		se = script_editor_funcs[i](p_resource);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -797,7 +797,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		case TOOL_CREATE_USER_INTERFACE:
 		case TOOL_CREATE_FAVORITE: {
 
-			Node *new_node;
+			Node *new_node = NULL;
 
 			if (TOOL_CREATE_FAVORITE == p_tool) {
 				String name = selected_favorite_root.get_slicec(' ', 0);

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -4201,21 +4201,16 @@ void JointSpatialGizmoPlugin::CreateGeneric6DOFJointGizmo(
 	float cs = 0.25;
 
 	for (int ax = 0; ax < 3; ax++) {
-		/*r_points.push_back(p_offset.translated(Vector3(+cs,0,0)).origin);
-		r_points.push_back(p_offset.translated(Vector3(-cs,0,0)).origin);
-		r_points.push_back(p_offset.translated(Vector3(0,+cs,0)).origin);
-		r_points.push_back(p_offset.translated(Vector3(0,-cs,0)).origin);
-		r_points.push_back(p_offset.translated(Vector3(0,0,+cs*2)).origin);
-		r_points.push_back(p_offset.translated(Vector3(0,0,-cs*2)).origin); */
+		float ll = 0;
+		float ul = 0;
+		float lll = 0;
+		float lul = 0;
 
-		float ll;
-		float ul;
-		float lll;
-		float lul;
-
-		int a1, a2, a3;
-		bool enable_ang;
-		bool enable_lin;
+		int a1 = 0;
+		int a2 = 0;
+		int a3 = 0;
+		bool enable_ang = false;
+		bool enable_lin = false;
 
 		switch (ax) {
 			case 0:

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -1587,8 +1587,8 @@ Vector3 VoxelLightBaker::_compute_pixel_light_at_pos(const Vector3 &p_pos, const
 	Vector3 bitangent = tangent.cross(p_normal).normalized();
 	Basis normal_xform = Basis(tangent, bitangent, p_normal).transposed();
 
-	const Vector3 *cone_dirs;
-	const float *cone_weights;
+	const Vector3 *cone_dirs = NULL;
+	const float *cone_weights = NULL;
 	int cone_dir_count = 0;
 	float cone_aperture = 0;
 

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -238,21 +238,21 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		if (mm->get_shift()) {
 			float snap_treshhold = 0.03;
 			float smallest_ofs = snap_treshhold;
-			bool founded = false;
-			int nearest_point;
+			bool found = false;
+			int nearest_point = 0;
 			for (int i = 0; i < points.size(); ++i) {
 				if (i != grabbed) {
 					float temp_ofs = ABS(points[i].offset - newofs);
 					if (temp_ofs < smallest_ofs) {
 						smallest_ofs = temp_ofs;
 						nearest_point = i;
-						if (founded)
+						if (found)
 							break;
-						founded = true;
+						found = true;
 					}
 				}
 			}
-			if (founded) {
+			if (found) {
 				if (points[nearest_point].offset < newofs)
 					newofs = points[nearest_point].offset + 0.00001;
 				else

--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -148,9 +148,9 @@ Point2 TextureProgress::unit_val_to_uv(float val) {
 	float angle = (val * Math_TAU) - Math_PI * 0.5;
 	Point2 dir = Vector2(Math::cos(angle), Math::sin(angle));
 	float t1 = 1.0;
-	float cp;
-	float cq;
-	float cr;
+	float cp = 0;
+	float cq = 0;
+	float cr = 0;
 	float edgeLeft = 0.0;
 	float edgeRight = 1.0;
 	float edgeBottom = 0.0;

--- a/servers/physics/shape_sw.cpp
+++ b/servers/physics/shape_sw.cpp
@@ -1047,7 +1047,7 @@ void FaceShapeSW::get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_su
 	/** FIND SUPPORT VERTEX **/
 
 	int vert_support_idx = -1;
-	real_t support_max;
+	real_t support_max = 0;
 
 	for (int i = 0; i < 3; i++) {
 


### PR DESCRIPTION
Fixes the following GCC 7 warnings reported in https://github.com/godotengine/godot/pull/22620#issuecomment-427032446 by @capnm (thanks!):
```
core/cowdata.h:269:47: warning: 'alloc_size' may be used uninitialized in this function [-Wmaybe-uninitialized]
core/error_macros.h:163:26: warning: 'nearest_point' may be used uninitialized in this function [-Wmaybe-uninitialized]
core/image.cpp:1579:5: warning: 'colormap_size' may be used uninitialized in this function [-Wmaybe-uninitialized]
core/image.cpp:1582:12: warning: 'size_height' may be used uninitialized in this function [-Wmaybe-uninitialized]
core/image.cpp:1590:23: warning: 'size_width' may be used uninitialized in this function [-Wmaybe-uninitialized]
core/image.cpp:1599:29: warning: 'pixel_size' may be used uninitialized in this function [-Wmaybe-uninitialized]
core/math/face3.cpp:207:15: warning: 'tri_max' may be used uninitialized in this function [-Wmaybe-uninitialized]
core/math/face3.cpp:209:15: warning: 'tri_min' may be used uninitialized in this function [-Wmaybe-uninitialized]
drivers/gles3/rasterizer_scene_gles3.cpp:665:22: warning: 'best_used_frame' may be used uninitialized in this function [-Wmaybe-uninitialized]
drivers/gles3/rasterizer_storage_gles3.cpp:865:27: warning: 'blit_target' may be used uninitialized in this function [-Wmaybe-uninitialized]
drivers/gles3/rasterizer_storage_gles3.cpp:980:29: warning: 'blit_target' may be used uninitialized in this function [-Wmaybe-uninitialized]
drivers/gles3/shader_gles3.h:122:9: warning: '<anonymous>.ShaderGLES3::Version::frag_id' may be used uninitialized in this function [-Wmaybe-uninitialized]
drivers/gles3/shader_gles3.h:122:9: warning: '<anonymous>.ShaderGLES3::Version::id' may be used uninitialized in this function [-Wmaybe-uninitialized]
drivers/gles3/shader_gles3.h:122:9: warning: '<anonymous>.ShaderGLES3::Version::vert_id' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/plugins/script_editor_plugin.cpp:1980:31: warning: 'se' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/scene_tree_dock.cpp:840:30: warning: 'new_node' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/spatial_editor_gizmos.cpp:4259:9: warning: 'a1' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/spatial_editor_gizmos.cpp:4259:9: warning: 'lll' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/spatial_editor_gizmos.cpp:4259:9: warning: 'lul' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/spatial_editor_gizmos.cpp:4260:9: warning: 'a2' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/spatial_editor_gizmos.cpp:4261:9: warning: 'a3' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/spatial_editor_gizmos.cpp:4265:3: warning: 'enable_lin' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/spatial_editor_gizmos.cpp:4294:3: warning: 'enable_ang' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/spatial_editor_gizmos.cpp:4311:34: warning: 'll' may be used uninitialized in this function [-Wmaybe-uninitialized]
editor/spatial_editor_gizmos.cpp:4311:34: warning: 'ul' may be used uninitialized in this function [-Wmaybe-uninitialized]
scene/3d/voxel_light_baker.cpp:1655:47: warning: 'cone_dirs' may be used uninitialized in this function [-Wmaybe-uninitialized]
scene/3d/voxel_light_baker.cpp:1656:73: warning: 'cone_weights' may be used uninitialized in this function [-Wmaybe-uninitialized]
scene/gui/texture_progress.cpp:181:6: warning: 'cp' may be used uninitialized in this function [-Wmaybe-uninitialized]
scene/gui/texture_progress.cpp:181:6: warning: 'cq' may be used uninitialized in this function [-Wmaybe-uninitialized]
servers/physics/shape_sw.cpp:1056:19: warning: 'support_max' may be used uninitialized in this function [-Wmaybe-uninitialized]
```