### PR TITLE
Tree: add expand_all and collapse_all methods

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -218,6 +218,20 @@
 				If [code]true[/code] column titles are visible.
 			</description>
 		</method>
+		<method name="expand_all">
+			<return type="void">
+			</return>
+			<description>
+				Expand all the children recursively.
+			</description>
+		</method>
+		<method name="collapse_all">
+			<return type="void">
+			</return>
+			<description>
+				Collapse all the children recursively.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="allow_reselect" type="bool" setter="set_allow_reselect" getter="get_allow_reselect">

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3102,6 +3102,32 @@ bool Tree::is_anything_selected() {
 	return (selected_item != NULL);
 }
 
+void recursive_collapsed(TreeItem *p_item, bool p_collapsed) {
+
+	if (!p_item) {
+		return;
+	}
+
+	p_item->set_collapsed(p_collapsed);
+	TreeItem *c = p_item->get_children();
+
+	while (c) {
+
+		recursive_collapsed(c, p_collapsed);
+		c = c->get_next();
+	}
+}
+
+void Tree::expand_all() {
+
+	recursive_collapsed(root, false);
+}
+
+void Tree::collapse_all() {
+
+	recursive_collapsed(root, true);
+}
+
 void Tree::clear() {
 
 	if (blocked > 0) {
@@ -3764,6 +3790,9 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pressed_button"), &Tree::get_pressed_button);
 	ClassDB::bind_method(D_METHOD("set_select_mode", "mode"), &Tree::set_select_mode);
 	ClassDB::bind_method(D_METHOD("get_select_mode"), &Tree::get_select_mode);
+
+	ClassDB::bind_method(D_METHOD("expand_all"), &Tree::expand_all);
+	ClassDB::bind_method(D_METHOD("collapse_all"), &Tree::collapse_all);
 
 	ClassDB::bind_method(D_METHOD("set_columns", "amount"), &Tree::set_columns);
 	ClassDB::bind_method(D_METHOD("get_columns"), &Tree::get_columns);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -553,6 +553,9 @@ public:
 	void deselect_all();
 	bool is_anything_selected();
 
+	void expand_all();
+	void collapse_all();
+
 	void set_columns(int p_columns);
 	int get_columns() const;
 


### PR DESCRIPTION
Qt provides the methods expandAll() and collapseAll() for [QTreeView](https://doc.qt.io/qt-5/qtreeview.html#public-slots).
It is an useful feature and it would be nice to have it in Godot :)

Here it is in action:
![ezgif-5-ae28a54943f0](https://user-images.githubusercontent.com/14951430/46542243-38f93e00-c8be-11e8-831d-560e72b757c8.gif)
