### PR TITLE
Added warning when setting autoplay of AnimationPlayer that's inside the tree.

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1415,6 +1415,8 @@ StringName AnimationPlayer::find_animation(const Ref<Animation> &p_animation) co
 }
 
 void AnimationPlayer::set_autoplay(const String &p_name) {
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint())
+		WARN_PRINT("Setting autoplay after the node has been added to the scene has no effect.");
 
 	autoplay = p_name;
 }


### PR DESCRIPTION
Added warning when setting autoplay of AnimationPlayer that's inside the tree.

`Setting autoplay after the node has been added to the scene has no effect.`

This should resolve #22525