### PR TITLE
Make color picker control cannot change alpha value through text when edit alpha option is turned off.

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -156,10 +156,18 @@ void ColorPicker::_value_changed(double) {
 
 void ColorPicker::_html_entered(const String &p_html) {
 
+	String tmp_html = p_html;
+
 	if (updating)
 		return;
 
-	color = Color::html(p_html);
+	if (!edit_alpha)
+	{
+		if (tmp_html.size() > 6)
+			tmp_html = tmp_html.right(2);
+	}
+
+	color = Color::html(tmp_html);
 
 	if (!is_inside_tree())
 		return;


### PR DESCRIPTION
When edit alpha is turned off, if input text contains alpha, which means its size would be more than 6 digits, clear first 2 digits for alpha value.

Fixes #22721