### PR TITLE
Remove redundant "== true" and "== false" code

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2487,7 +2487,7 @@ _Thread::~_Thread() {
 	if (active) {
 		ERR_EXPLAIN("Reference to a Thread object object was lost while the thread is still running...");
 	}
-	ERR_FAIL_COND(active == true);
+	ERR_FAIL_COND(active);
 }
 /////////////////////////////////////
 

--- a/core/dictionary.cpp
+++ b/core/dictionary.cpp
@@ -145,6 +145,11 @@ bool Dictionary::operator==(const Dictionary &p_dictionary) const {
 	return _p == p_dictionary._p;
 }
 
+bool Dictionary::operator!=(const Dictionary &p_dictionary) const {
+
+	return _p != p_dictionary._p;
+}
+
 void Dictionary::_ref(const Dictionary &p_from) const {
 
 	//make a copy first (thread safe)

--- a/core/dictionary.h
+++ b/core/dictionary.h
@@ -69,6 +69,7 @@ public:
 	bool erase(const Variant &p_key);
 
 	bool operator==(const Dictionary &p_dictionary) const;
+	bool operator!=(const Dictionary &p_dictionary) const;
 
 	uint32_t hash() const;
 	void operator=(const Dictionary &p_dictionary);

--- a/core/dvector.h
+++ b/core/dvector.h
@@ -149,7 +149,7 @@ class PoolVector {
 			}
 		}
 
-		if (old_alloc->refcount.unref() == true) {
+		if (old_alloc->refcount.unref()) {
 			//this should never happen but..
 
 #ifdef DEBUG_ENABLED

--- a/core/dvector.h
+++ b/core/dvector.h
@@ -209,7 +209,7 @@ class PoolVector {
 		if (!alloc)
 			return;
 
-		if (alloc->refcount.unref() == false) {
+		if (!alloc->refcount.unref()) {
 			alloc = NULL;
 			return;
 		}

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -416,7 +416,7 @@ bool MultiplayerAPI::_send_confirm_path(NodePath p_path, PathSentCache *psc, int
 
 		Map<int, bool>::Element *F = psc->confirmed_peers.find(E->get());
 
-		if (!F || F->get() == false) {
+		if (!F || !F->get()) {
 			// Path was not cached, or was cached but is unconfirmed.
 			if (!F) {
 				// Not cached at all, take note.

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -578,7 +578,7 @@ void MultiplayerAPI::_send_rpc(Node *p_from, int p_to, bool p_unreliable, bool p
 
 			network_peer->set_target_peer(E->get()); // To this one specifically.
 
-			if (F->get() == true) {
+			if (F->get()) {
 				// This one confirmed path, so use id.
 				encode_uint32(psc->id, &(packet_cache.write[1]));
 				network_peer->put_packet(packet_cache.ptr(), ofs);

--- a/core/math/matrix3.cpp
+++ b/core/math/matrix3.cpp
@@ -299,14 +299,14 @@ Vector3 Basis::rotref_posscale_decomposition(Basis &rotref) const {
 	ERR_FAIL_COND_V(determinant() == 0, Vector3());
 
 	Basis m = transposed() * (*this);
-	ERR_FAIL_COND_V(m.is_diagonal() == false, Vector3());
+	ERR_FAIL_COND_V(!m.is_diagonal(), Vector3());
 #endif
 	Vector3 scale = get_scale();
 	Basis inv_scale = Basis().scaled(scale.inverse()); // this will also absorb the sign of scale
 	rotref = (*this) * inv_scale;
 
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(rotref.is_orthogonal() == false, Vector3());
+	ERR_FAIL_COND_V(!rotref.is_orthogonal(), Vector3());
 #endif
 	return scale.abs();
 }
@@ -430,7 +430,7 @@ Vector3 Basis::get_euler_xyz() const {
 
 	Vector3 euler;
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_rotation() == false, euler);
+	ERR_FAIL_COND_V(!is_rotation(), euler);
 #endif
 	real_t sy = elements[0][2];
 	if (sy < 1.0) {
@@ -497,7 +497,7 @@ Vector3 Basis::get_euler_yxz() const {
 
 	Vector3 euler;
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_rotation() == false, euler);
+	ERR_FAIL_COND_V(!is_rotation(), euler);
 #endif
 	real_t m12 = elements[1][2];
 
@@ -556,7 +556,7 @@ bool Basis::is_equal_approx(const Basis &a, const Basis &b) const {
 
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
-			if (Math::is_equal_approx(a.elements[i][j], b.elements[i][j]) == false)
+			if (!Math::is_equal_approx(a.elements[i][j], b.elements[i][j]))
 				return false;
 		}
 	}
@@ -600,7 +600,7 @@ Basis::operator String() const {
 
 Quat Basis::get_quat() const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_rotation() == false, Quat());
+	ERR_FAIL_COND_V(!is_rotation(), Quat());
 #endif
 	real_t trace = elements[0][0] + elements[1][1] + elements[2][2];
 	real_t temp[4];
@@ -697,7 +697,7 @@ void Basis::set_orthogonal_index(int p_index) {
 
 void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND(is_rotation() == false);
+	ERR_FAIL_COND(!is_rotation());
 #endif
 	real_t angle, x, y, z; // variables for result
 	real_t epsilon = 0.01; // margin to allow for rounding errors
@@ -785,7 +785,7 @@ void Basis::set_quat(const Quat &p_quat) {
 void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_phi) {
 // Rotation matrix from axis and angle, see https://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_angle
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND(p_axis.is_normalized() == false);
+	ERR_FAIL_COND(!p_axis.is_normalized());
 #endif
 	Vector3 axis_sq(p_axis.x * p_axis.x, p_axis.y * p_axis.y, p_axis.z * p_axis.z);
 
@@ -837,8 +837,8 @@ void Basis::set_diagonal(const Vector3 p_diag) {
 Basis Basis::slerp(const Basis &target, const real_t &t) const {
 // TODO: implement this directly without using quaternions to make it more efficient
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_rotation() == false, Basis());
-	ERR_FAIL_COND_V(target.is_rotation() == false, Basis());
+	ERR_FAIL_COND_V(!is_rotation(), Basis());
+	ERR_FAIL_COND_V(!target.is_rotation(), Basis());
 #endif
 
 	Quat from(*this);

--- a/core/math/quat.cpp
+++ b/core/math/quat.cpp
@@ -100,7 +100,7 @@ void Quat::set_euler_yxz(const Vector3 &p_euler) {
 // This implementation uses YXZ convention (Z is the first rotation).
 Vector3 Quat::get_euler_yxz() const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_normalized() == false, Vector3(0, 0, 0));
+	ERR_FAIL_COND_V(!is_normalized(), Vector3(0, 0, 0));
 #endif
 	Basis m(*this);
 	return m.get_euler_yxz();
@@ -140,15 +140,15 @@ bool Quat::is_normalized() const {
 
 Quat Quat::inverse() const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_normalized() == false, Quat());
+	ERR_FAIL_COND_V(!is_normalized(), Quat());
 #endif
 	return Quat(-x, -y, -z, w);
 }
 
 Quat Quat::slerp(const Quat &q, const real_t &t) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_normalized() == false, Quat());
-	ERR_FAIL_COND_V(q.is_normalized() == false, Quat());
+	ERR_FAIL_COND_V(!is_normalized(), Quat());
+	ERR_FAIL_COND_V(!q.is_normalized(), Quat());
 #endif
 	Quat to1;
 	real_t omega, cosom, sinom, scale0, scale1;
@@ -194,8 +194,8 @@ Quat Quat::slerp(const Quat &q, const real_t &t) const {
 
 Quat Quat::slerpni(const Quat &q, const real_t &t) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_normalized() == false, Quat());
-	ERR_FAIL_COND_V(q.is_normalized() == false, Quat());
+	ERR_FAIL_COND_V(!is_normalized(), Quat());
+	ERR_FAIL_COND_V(!q.is_normalized(), Quat());
 #endif
 	const Quat &from = *this;
 
@@ -216,8 +216,8 @@ Quat Quat::slerpni(const Quat &q, const real_t &t) const {
 
 Quat Quat::cubic_slerp(const Quat &q, const Quat &prep, const Quat &postq, const real_t &t) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_normalized() == false, Quat());
-	ERR_FAIL_COND_V(q.is_normalized() == false, Quat());
+	ERR_FAIL_COND_V(!is_normalized(), Quat());
+	ERR_FAIL_COND_V(!q.is_normalized(), Quat());
 #endif
 	//the only way to do slerp :|
 	real_t t2 = (1.0 - t) * t * 2;
@@ -233,7 +233,7 @@ Quat::operator String() const {
 
 void Quat::set_axis_angle(const Vector3 &axis, const real_t &angle) {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND(axis.is_normalized() == false);
+	ERR_FAIL_COND(!axis.is_normalized());
 #endif
 	real_t d = axis.length();
 	if (d == 0)

--- a/core/math/quat.h
+++ b/core/math/quat.h
@@ -87,7 +87,7 @@ public:
 
 	_FORCE_INLINE_ Vector3 xform(const Vector3 &v) const {
 #ifdef MATH_CHECKS
-		ERR_FAIL_COND_V(is_normalized() == false, v);
+		ERR_FAIL_COND_V(!is_normalized(), v);
 #endif
 		Vector3 u(x, y, z);
 		Vector3 uv = u.cross(v);

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -167,7 +167,7 @@ Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, c
 // slide returns the component of the vector along the given plane, specified by its normal vector.
 Vector2 Vector2::slide(const Vector2 &p_normal) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(p_normal.is_normalized() == false, Vector2());
+	ERR_FAIL_COND_V(!p_normal.is_normalized(), Vector2());
 #endif
 	return *this - p_normal * this->dot(p_normal);
 }
@@ -178,7 +178,7 @@ Vector2 Vector2::bounce(const Vector2 &p_normal) const {
 
 Vector2 Vector2::reflect(const Vector2 &p_normal) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(p_normal.is_normalized() == false, Vector2());
+	ERR_FAIL_COND_V(!p_normal.is_normalized(), Vector2());
 #endif
 	return 2.0 * p_normal * this->dot(p_normal) - *this;
 }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -230,7 +230,7 @@ Vector2 Vector2::linear_interpolate(const Vector2 &p_b, real_t p_t) const {
 
 Vector2 Vector2::slerp(const Vector2 &p_b, real_t p_t) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_normalized() == false, Vector2());
+	ERR_FAIL_COND_V(!is_normalized(), Vector2());
 #endif
 	real_t theta = angle_to(p_b);
 	return rotated(theta * p_t);

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -218,7 +218,7 @@ Vector3 Vector3::linear_interpolate(const Vector3 &p_b, real_t p_t) const {
 
 Vector3 Vector3::slerp(const Vector3 &p_b, real_t p_t) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(is_normalized() == false, Vector3());
+	ERR_FAIL_COND_V(!is_normalized(), Vector3());
 #endif
 
 	real_t theta = angle_to(p_b);
@@ -430,7 +430,7 @@ void Vector3::zero() {
 // slide returns the component of the vector along the given plane, specified by its normal vector.
 Vector3 Vector3::slide(const Vector3 &p_normal) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(p_normal.is_normalized() == false, Vector3());
+	ERR_FAIL_COND_V(!p_normal.is_normalized(), Vector3());
 #endif
 	return *this - p_normal * this->dot(p_normal);
 }
@@ -441,7 +441,7 @@ Vector3 Vector3::bounce(const Vector3 &p_normal) const {
 
 Vector3 Vector3::reflect(const Vector3 &p_normal) const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(p_normal.is_normalized() == false, Vector3());
+	ERR_FAIL_COND_V(!p_normal.is_normalized(), Vector3());
 #endif
 	return 2.0 * p_normal * this->dot(p_normal) - *this;
 }

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -858,7 +858,7 @@ bool Variant::is_one() const {
 		// atomic types
 		case BOOL: {
 
-			return _data._bool == true;
+			return _data._bool;
 		} break;
 		case INT: {
 

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -521,7 +521,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 				const Dictionary *arr_a = reinterpret_cast<const Dictionary *>(p_a._data._mem);
 				const Dictionary *arr_b = reinterpret_cast<const Dictionary *>(p_b._data._mem);
 
-				_RETURN((*arr_a == *arr_b) == false);
+				_RETURN(*arr_a != *arr_b);
 			}
 
 			CASE_TYPE(math, OP_NOT_EQUAL, ARRAY) {

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6841,7 +6841,7 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, level);
 			glDisable(GL_SCISSOR_TEST);
 			glColorMask(1, 1, 1, 1);
-			if (rt->buffers.active == false) {
+			if (!rt->buffers.active) {
 				glDepthMask(GL_TRUE);
 			}
 

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -796,14 +796,13 @@ Error AudioDriverWASAPI::capture_start() {
 		return err;
 	}
 
-	if (audio_input.active == false) {
-		audio_input.audio_client->Start();
-		audio_input.active = true;
-
-		return OK;
+	if (audio_input.active) {
+		return FAILED;
 	}
 
-	return FAILED;
+	audio_input.audio_client->Start();
+	audio_input.active = true;
+	return OK;
 }
 
 Error AudioDriverWASAPI::capture_stop() {

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -808,7 +808,7 @@ Error AudioDriverWASAPI::capture_start() {
 
 Error AudioDriverWASAPI::capture_stop() {
 
-	if (audio_input.active == true) {
+	if (audio_input.active) {
 		audio_input.audio_client->Stop();
 		audio_input.active = false;
 

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -501,7 +501,7 @@ void EditorFileDialog::_items_clear_selection() {
 		case MODE_OPEN_FILE:
 		case MODE_OPEN_FILES:
 			get_ok()->set_text(TTR("Open"));
-			get_ok()->set_disabled(item_list->is_anything_selected() == false);
+			get_ok()->set_disabled(!item_list->is_anything_selected());
 			break;
 
 		case MODE_OPEN_DIR:

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3889,7 +3889,7 @@ void EditorNode::_scene_tab_closed(int p_tab) {
 }
 
 void EditorNode::_scene_tab_hover(int p_tab) {
-	if (bool(EDITOR_GET("interface/scene_tabs/show_thumbnail_on_hover")) == false) {
+	if (!bool(EDITOR_GET("interface/scene_tabs/show_thumbnail_on_hover"))) {
 		return;
 	}
 	int current_tab = scene_tabs->get_current_tab();

--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -257,7 +257,7 @@ void EditorProfiler::_update_plot() {
 
 					//get
 					const Metric &m = frame_metrics[idx];
-					if (m.valid == false)
+					if (!m.valid)
 						continue; //skip because invalid
 
 					float value = 0;

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1793,22 +1793,22 @@ template <>
 struct EditorSceneImporterGLTFInterpolate<Quat> {
 
 	Quat lerp(const Quat &a, const Quat &b, float c) const {
-		ERR_FAIL_COND_V(a.is_normalized() == false, Quat());
-		ERR_FAIL_COND_V(b.is_normalized() == false, Quat());
+		ERR_FAIL_COND_V(!a.is_normalized(), Quat());
+		ERR_FAIL_COND_V(!b.is_normalized(), Quat());
 
 		return a.slerp(b, c).normalized();
 	}
 
 	Quat catmull_rom(const Quat &p0, const Quat &p1, const Quat &p2, const Quat &p3, float c) {
-		ERR_FAIL_COND_V(p1.is_normalized() == false, Quat());
-		ERR_FAIL_COND_V(p2.is_normalized() == false, Quat());
+		ERR_FAIL_COND_V(!p1.is_normalized(), Quat());
+		ERR_FAIL_COND_V(!p2.is_normalized(), Quat());
 
 		return p1.slerp(p2, c).normalized();
 	}
 
 	Quat bezier(Quat start, Quat control_1, Quat control_2, Quat end, float t) {
-		ERR_FAIL_COND_V(start.is_normalized() == false, Quat());
-		ERR_FAIL_COND_V(end.is_normalized() == false, Quat());
+		ERR_FAIL_COND_V(!start.is_normalized(), Quat());
+		ERR_FAIL_COND_V(!end.is_normalized(), Quat());
 
 		return start.slerp(end, t).normalized();
 	}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5113,7 +5113,7 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 						   type == "AtlasTexture" ||
 						   type == "LargeTexture") {
 					Ref<Texture> texture = Ref<Texture>(Object::cast_to<Texture>(*res));
-					if (texture.is_valid() == false) {
+					if (!texture.is_valid()) {
 						continue;
 					}
 				} else {

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2124,7 +2124,7 @@ void SpatialEditorViewport::_notification(int p_what) {
 		_update_freelook(delta);
 
 		Node *scene_root = editor->get_scene_tree_dock()->get_editor_data()->get_edited_scene_root();
-		if (previewing_cinema == true && scene_root != NULL) {
+		if (previewing_cinema && scene_root != NULL) {
 			Camera *cam = scene_root->get_viewport()->get_camera();
 			if (cam != NULL && cam != previewing) {
 				//then switch the viewport's camera to the scene's viewport camera

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -638,10 +638,10 @@ bool ProjectExportDialog::_fill_tree(EditorFileSystemDirectory *p_dir, TreeItem 
 	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
 
 		TreeItem *subdir = include_files->create_item(p_item);
-		if (_fill_tree(p_dir->get_subdir(i), subdir, current, p_only_scenes) == false) {
-			memdelete(subdir);
-		} else {
+		if (_fill_tree(p_dir->get_subdir(i), subdir, current, p_only_scenes)) {
 			used = true;
+		} else {
+			memdelete(subdir);
 		}
 	}
 

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -805,7 +805,7 @@ void CSGBrushOperation::_merge_poly(MeshMerge &mesh, int p_face_idx, const Build
 
 	//process points that were not processed
 	for (int i = 0; i < edge_process.size(); i++) {
-		if (edge_process[i] == true)
+		if (edge_process[i])
 			continue; //already processed
 
 		int intersect_poly = -1;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -679,7 +679,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 
 			if (tokenizer->get_token() == GDScriptTokenizer::TK_BUILT_IN_TYPE) {
 				Variant::Type ct = tokenizer->get_token_type();
-				if (p_parsing_constant == false) {
+				if (!p_parsing_constant) {
 					if (ct == Variant::ARRAY) {
 						if (tokenizer->get_token(2) == GDScriptTokenizer::TK_PARENTHESIS_CLOSE) {
 							ArrayNode *arr = alloc_node<ArrayNode>();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1194,7 +1194,7 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 
 			MonoObject *ret = method->invoke(mono_object, args);
 
-			if (ret && GDMonoMarshal::unbox<MonoBoolean>(ret) == true)
+			if (ret && GDMonoMarshal::unbox<MonoBoolean>(ret))
 				return true;
 
 			break;
@@ -1459,7 +1459,7 @@ MonoObject *CSharpInstance::_internal_new_managed() {
 void CSharpInstance::mono_object_disposed(MonoObject *p_obj) {
 
 #ifdef DEBUG_ENABLED
-	CRASH_COND(base_ref == true);
+	CRASH_COND(base_ref);
 	CRASH_COND(gchandle.is_null());
 #endif
 	CSharpLanguage::get_singleton()->release_script_gchandle(p_obj, gchandle);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1468,7 +1468,7 @@ void CSharpInstance::mono_object_disposed(MonoObject *p_obj) {
 void CSharpInstance::mono_object_disposed_baseref(MonoObject *p_obj, bool p_is_finalizer, bool &r_owner_deleted) {
 
 #ifdef DEBUG_ENABLED
-	CRASH_COND(base_ref == false);
+	CRASH_COND(!base_ref);
 	CRASH_COND(gchandle.is_null());
 #endif
 	if (_unreference_owner_unsafe()) {

--- a/modules/mono/editor/mono_bottom_panel.cpp
+++ b/modules/mono/editor/mono_bottom_panel.cpp
@@ -63,7 +63,7 @@ void MonoBottomPanel::_update_build_tabs_list() {
 				item_tooltip += "Running";
 			}
 
-			if (!tab->build_exited || !tab->build_result == MonoBuildTab::RESULT_SUCCESS) {
+			if (!tab->build_exited || tab->build_result == MonoBuildTab::RESULT_ERROR) {
 				item_tooltip += "\nErrors: " + itos(tab->error_count);
 			}
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2816,7 +2816,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 
 void VisualScriptEditor::connect_seq(Ref<VisualScriptNode> vnode_old, Ref<VisualScriptNode> vnode_new, int new_id) {
 	VisualScriptOperator *vnode_operator = Object::cast_to<VisualScriptOperator>(vnode_new.ptr());
-	if (vnode_operator != NULL && vnode_operator->has_input_sequence_port() == false) {
+	if (vnode_operator != NULL && !vnode_operator->has_input_sequence_port()) {
 		return;
 	}
 	VisualScriptConstructor *vnode_constructor = Object::cast_to<VisualScriptConstructor>(vnode_new.ptr());
@@ -2826,7 +2826,7 @@ void VisualScriptEditor::connect_seq(Ref<VisualScriptNode> vnode_old, Ref<Visual
 	if (vnode_old->get_output_sequence_port_count() <= 0) {
 		return;
 	}
-	if (vnode_new->has_input_sequence_port() == false) {
+	if (!vnode_new->has_input_sequence_port()) {
 		return;
 	}
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2639,7 +2639,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		}
 		undo_redo->create_action(TTR("Add Node"));
 		undo_redo->add_do_method(script.ptr(), "add_node", edited_func, new_id, vnode_new, ofs);
-		if (vnode_old.is_valid() && p_connecting == true) {
+		if (vnode_old.is_valid() && p_connecting) {
 			connect_seq(vnode_old, vnode_new, new_id);
 			connect_data(vnode_old, vnode_new, new_id);
 		}
@@ -2806,7 +2806,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		}
 	}
 	Ref<VisualScriptNode> vnode_old = script->get_node(edited_func, port_action_node);
-	if (vnode_old.is_valid() && p_connecting == true) {
+	if (vnode_old.is_valid() && p_connecting) {
 		connect_seq(vnode_old, vnode, port_action_new_node);
 		connect_data(vnode_old, vnode, port_action_new_node);
 	}

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -853,7 +853,7 @@ public:
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Variant::CallError &r_error, String &r_error_str) {
 
-		if (instance->get_variable(variable, p_outputs[0]) == false) {
+		if (!instance->get_variable(variable, p_outputs[0])) {
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 			r_error_str = RTR("VariableGet not found in script: ") + "'" + String(variable) + "'";
 			return false;
@@ -975,7 +975,7 @@ public:
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Variant::CallError &r_error, String &r_error_str) {
 
-		if (instance->set_variable(variable, *p_inputs[0]) == false) {
+		if (!instance->set_variable(variable, *p_inputs[0])) {
 
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 			r_error_str = RTR("VariableSet not found in script: ") + "'" + String(variable) + "'";

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -149,7 +149,7 @@ void VisualScriptPropertySelector::_update_search() {
 			Control::get_icon("PoolColorArray", "EditorIcons")
 		};
 
-		if (!seq_connect && visual_script_generic == false) {
+		if (!seq_connect && !visual_script_generic) {
 			get_visual_node_names("flow_control/type_cast", Set<String>(), found, root, search_box);
 			get_visual_node_names("functions/built_in/print", Set<String>(), found, root, search_box);
 			get_visual_node_names("functions/by_type/" + Variant::get_type_name(type), Set<String>(), found, root, search_box);
@@ -228,7 +228,7 @@ void VisualScriptPropertySelector::_update_search() {
 		}
 	}
 
-	if (seq_connect && visual_script_generic == false) {
+	if (seq_connect && !visual_script_generic) {
 		String text = search_box->get_text();
 		create_visualscript_item(String("VisualScriptCondition"), root, text, String("Condition"));
 		create_visualscript_item(String("VisualScriptSwitch"), root, text, String("Switch"));

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -228,7 +228,7 @@ void VisualScriptPropertySelector::_update_search() {
 		}
 	}
 
-	if (seq_connect == true && visual_script_generic == false) {
+	if (seq_connect && visual_script_generic == false) {
 		String text = search_box->get_text();
 		create_visualscript_item(String("VisualScriptCondition"), root, text, String("Condition"));
 		create_visualscript_item(String("VisualScriptSwitch"), root, text, String("Switch"));
@@ -392,7 +392,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 				break;
 			}
 		}
-		if (is_filter == true) {
+		if (is_filter) {
 			continue;
 		}
 

--- a/platform/android/godot_android.cpp
+++ b/platform/android/godot_android.cpp
@@ -408,7 +408,7 @@ static void engine_draw_frame(struct engine *engine) {
 	// Just fill the screen with a color.
 	//glClearColor(0,1,0,1);
 	//glClear(GL_COLOR_BUFFER_BIT);
-	if (engine->os && engine->os->main_loop_iterate() == true) {
+	if (engine->os && engine->os->main_loop_iterate()) {
 
 		engine->requested_quit = true;
 		return; //should exit instead

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -974,7 +974,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, job
 
 	os_android->process_gyroscope(gyroscope);
 
-	if (os_android->main_loop_iterate() == true) {
+	if (os_android->main_loop_iterate()) {
 
 		jclass cls = env->FindClass("org/godotengine/godot/Godot");
 		jmethodID _finish = env->GetMethodID(cls, "forceQuit", "()V");

--- a/platform/haiku/haiku_direct_window.cpp
+++ b/platform/haiku/haiku_direct_window.cpp
@@ -86,7 +86,7 @@ void HaikuDirectWindow::DirectConnected(direct_buffer_info *info) {
 void HaikuDirectWindow::MessageReceived(BMessage *message) {
 	switch (message->what) {
 		case REDRAW_MSG:
-			if (Main::iteration() == true) {
+			if (Main::iteration()) {
 				view->EnableDirectMode(false);
 				Quit();
 			}

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -221,7 +221,7 @@ void OS_Server::run() {
 
 	while (!force_quit) {
 
-		if (Main::iteration() == true)
+		if (Main::iteration())
 			break;
 	};
 

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -864,7 +864,7 @@ void OSUWP::run() {
 		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 		if (managed_object->alert_close_handle) continue;
 		process_events(); // get rid of pending events
-		if (Main::iteration() == true)
+		if (Main::iteration())
 			break;
 	};
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1744,7 +1744,7 @@ void OS_Windows::set_window_size(const Size2 p_size) {
 	RECT rect;
 	GetWindowRect(hWnd, &rect);
 
-	if (video_mode.borderless_window == false) {
+	if (!video_mode.borderless_window) {
 		RECT crect;
 		GetClientRect(hWnd, &crect);
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2737,7 +2737,7 @@ void OS_Windows::run() {
 	while (!force_quit) {
 
 		process_events(); // get rid of pending events
-		if (Main::iteration() == true)
+		if (Main::iteration())
 			break;
 	};
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1096,7 +1096,7 @@ void OS_X11::set_window_size(const Size2 p_size) {
 	int old_h = xwa.height;
 
 	// If window resizable is disabled we need to update the attributes first
-	if (is_window_resizable() == false) {
+	if (!is_window_resizable()) {
 		XSizeHints *xsh;
 		xsh = XAllocSizeHints();
 		xsh->flags = PMinSize | PMaxSize;
@@ -1688,7 +1688,7 @@ void OS_X11::handle_key_event(XKeyEvent *p_event, bool p_echo) {
 		}
 	} else {
 		//ignore
-		if (last_is_pressed == false) {
+		if (!last_is_pressed) {
 			return;
 		}
 	}

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2814,7 +2814,7 @@ void OS_X11::run() {
 #ifdef JOYDEV_ENABLED
 		joypad->process_joypads();
 #endif
-		if (Main::iteration() == true)
+		if (Main::iteration())
 			break;
 	};
 

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -368,7 +368,7 @@ BaseButton::DrawMode BaseButton::get_draw_mode() const {
 		return DRAW_DISABLED;
 	};
 
-	if (status.press_attempt == false && status.hovering) {
+	if (!status.press_attempt && status.hovering) {
 		if (status.pressed)
 			return DRAW_HOVER_PRESSED;
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1079,7 +1079,7 @@ bool Control::has_constant_override(const StringName &p_name) const {
 bool Control::has_icon(const StringName &p_name, const StringName &p_type) const {
 
 	if (p_type == StringName() || p_type == "") {
-		if (has_icon_override(p_name) == true)
+		if (has_icon_override(p_name))
 			return true;
 	}
 
@@ -1113,7 +1113,7 @@ bool Control::has_icon(const StringName &p_name, const StringName &p_type) const
 bool Control::has_shader(const StringName &p_name, const StringName &p_type) const {
 
 	if (p_type == StringName() || p_type == "") {
-		if (has_shader_override(p_name) == true)
+		if (has_shader_override(p_name))
 			return true;
 	}
 
@@ -1146,7 +1146,7 @@ bool Control::has_shader(const StringName &p_name, const StringName &p_type) con
 bool Control::has_stylebox(const StringName &p_name, const StringName &p_type) const {
 
 	if (p_type == StringName() || p_type == "") {
-		if (has_stylebox_override(p_name) == true)
+		if (has_stylebox_override(p_name))
 			return true;
 	}
 
@@ -1179,7 +1179,7 @@ bool Control::has_stylebox(const StringName &p_name, const StringName &p_type) c
 bool Control::has_font(const StringName &p_name, const StringName &p_type) const {
 
 	if (p_type == StringName() || p_type == "") {
-		if (has_font_override(p_name) == true)
+		if (has_font_override(p_name))
 			return true;
 	}
 
@@ -1213,7 +1213,7 @@ bool Control::has_font(const StringName &p_name, const StringName &p_type) const
 bool Control::has_color(const StringName &p_name, const StringName &p_type) const {
 
 	if (p_type == StringName() || p_type == "") {
-		if (has_color_override(p_name) == true)
+		if (has_color_override(p_name))
 			return true;
 	}
 
@@ -1247,7 +1247,7 @@ bool Control::has_color(const StringName &p_name, const StringName &p_type) cons
 bool Control::has_constant(const StringName &p_name, const StringName &p_type) const {
 
 	if (p_type == StringName() || p_type == "") {
-		if (has_constant_override(p_name) == true)
+		if (has_constant_override(p_name))
 			return true;
 	}
 

--- a/servers/physics/joints/generic_6dof_joint_sw.cpp
+++ b/servers/physics/joints/generic_6dof_joint_sw.cpp
@@ -83,7 +83,7 @@ int G6DOFRotationalLimitMotorSW::testLimitValue(real_t test_value) {
 real_t G6DOFRotationalLimitMotorSW::solveAngularLimits(
 		real_t timeStep, Vector3 &axis, real_t jacDiagABInv,
 		BodySW *body0, BodySW *body1) {
-	if (needApplyTorques() == false) return 0.0f;
+	if (!needApplyTorques()) return 0.0f;
 
 	real_t target_velocity = m_targetVelocity;
 	real_t maxMotorForce = m_maxMotorForce;

--- a/servers/physics/joints/generic_6dof_joint_sw.h
+++ b/servers/physics/joints/generic_6dof_joint_sw.h
@@ -118,14 +118,12 @@ public:
 
 	//! Is limited
 	bool isLimited() {
-		if (m_loLimit >= m_hiLimit) return false;
-		return true;
+		return (m_loLimit < m_hiLimit);
 	}
 
 	//! Need apply correction
 	bool needApplyTorques() {
-		if (m_currentLimit == 0 && m_enableMotor == false) return false;
-		return true;
+		return (m_enableMotor || m_currentLimit != 0);
 	}
 
 	//! calculates  error

--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -138,7 +138,7 @@ void BodyPair2DSW::_validate_contacts() {
 		Contact &c = contacts[i];
 
 		bool erase = false;
-		if (c.reused == false) {
+		if (!c.reused) {
 			//was left behind in previous frame
 			erase = true;
 		} else {

--- a/servers/physics_2d/step_2d_sw.cpp
+++ b/servers/physics_2d/step_2d_sw.cpp
@@ -222,7 +222,7 @@ void Step2DSW::step(Space2DSW *p_space, real_t p_delta, int p_iterations) {
 		Constraint2DSW *prev_ci = NULL;
 		while (ci) {
 
-			if (_setup_island(ci, p_delta) == true) {
+			if (_setup_island(ci, p_delta)) {
 
 				//removed the root from the island graph because it is not to be processed
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -2831,7 +2831,7 @@ void VisualServerScene::_bake_gi_probe(Instance *p_gi_probe) {
 		RID rid = E->key();
 		const InstanceGIProbeData::LightCache &lc = E->get();
 
-		if ((!probe_data->dynamic.light_cache_changes.has(rid) || !(probe_data->dynamic.light_cache_changes[rid] == lc)) && lc.visible) {
+		if ((!probe_data->dynamic.light_cache_changes.has(rid) || probe_data->dynamic.light_cache_changes[rid] != lc) && lc.visible) {
 			//erase light data
 
 			_bake_gi_probe_light(header, cells, local_data, leaves, leaf_count, lc, -1);
@@ -2844,7 +2844,7 @@ void VisualServerScene::_bake_gi_probe(Instance *p_gi_probe) {
 		RID rid = E->key();
 		const InstanceGIProbeData::LightCache &lc = E->get();
 
-		if ((!probe_data->dynamic.light_cache.has(rid) || !(probe_data->dynamic.light_cache[rid] == lc)) && lc.visible) {
+		if ((!probe_data->dynamic.light_cache.has(rid) || probe_data->dynamic.light_cache[rid] != lc) && lc.visible) {
 			//add light data
 
 			_bake_gi_probe_light(header, cells, local_data, leaves, leaf_count, lc, 1);
@@ -3061,7 +3061,7 @@ bool VisualServerScene::_check_gi_probe(Instance *p_gi_probe) {
 		lc.transform = probe_data->dynamic.light_to_cell_xform * E->get()->transform;
 		lc.visible = E->get()->visible;
 
-		if (!probe_data->dynamic.light_cache.has(E->get()->self) || !(probe_data->dynamic.light_cache[E->get()->self] == lc)) {
+		if (!probe_data->dynamic.light_cache.has(E->get()->self) || probe_data->dynamic.light_cache[E->get()->self] != lc) {
 			all_equal = false;
 		}
 
@@ -3081,7 +3081,7 @@ bool VisualServerScene::_check_gi_probe(Instance *p_gi_probe) {
 		lc.transform = probe_data->dynamic.light_to_cell_xform * E->get()->transform;
 		lc.visible = E->get()->visible;
 
-		if (!probe_data->dynamic.light_cache.has(E->get()->self) || !(probe_data->dynamic.light_cache[E->get()->self] == lc)) {
+		if (!probe_data->dynamic.light_cache.has(E->get()->self) || probe_data->dynamic.light_cache[E->get()->self] != lc) {
 			all_equal = false;
 		}
 
@@ -3164,7 +3164,7 @@ void VisualServerScene::render_probes() {
 			force_lighting = true;
 		}
 
-		if (probe->invalid == false && probe->dynamic.enabled) {
+		if (!probe->invalid && probe->dynamic.enabled) {
 
 			switch (probe->dynamic.updating_stage) {
 				case GI_UPDATE_STAGE_CHECK: {

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -355,6 +355,11 @@ public:
 						visible == p_cache.visible);
 			}
 
+			bool operator!=(const LightCache &p_cache) {
+
+				return !operator==(p_cache);
+			}
+
 			LightCache() {
 
 				type = VS::LIGHT_DIRECTIONAL;


### PR DESCRIPTION
If it can be compared to a boolean, it can be evaluated as one in-place. Some of the code in the `== false` commit has been re-organized to be more readable (avoid double negatives etc).

I also added `!=` for Dictionary and InstanceGIProbeData.

Reviewing the code [here](https://github.com/godotengine/godot/pull/22634) got me thinking about this.

It seems to work fine, but worth looking over for sure.