### PR TITLE
Fix to ColorPicker behaviour when entering html. Fixing Issue #22714

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -159,7 +159,10 @@ void ColorPicker::_html_entered(const String &p_html) {
 	if (updating)
 		return;
 
+	float last_alpha = color.a;
 	color = Color::html(p_html);
+	if (!is_editing_alpha())
+		color.a = last_alpha;
 
 	if (!is_inside_tree())
 		return;


### PR DESCRIPTION
Fixes #22714
Problem was, that if "edit alpha" was set to false, it was still possible to change the alpha in game by entering it through the html color code.
Now the function checks, if "edit alpha" is false and if so resets the alpha to the original value.