### PR TITLE
Fix to projects with period names (at least on MacOS)

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -269,6 +269,7 @@ public:
 	virtual String get_name() = 0;
 	virtual List<String> get_cmdline_args() const { return _cmdline; }
 	virtual String get_model_name() const;
+	virtual String get_executable_extension() const { return "."; }	// may be too specific or not specific enough for some platforms
 
 	virtual MainLoop *get_main_loop() const = 0;
 

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -324,8 +324,9 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bo
 	if (exec_path != "") {
 		bool found = false;
 
-		// get our filename without our path (note, using exec_path.get_file before get_basename anymore because not all file systems have dots in their file names!)
-		String filebase_name = exec_path.get_file().get_basename();
+		// We want to get the filename without the extension (no .exe on Windows or .app on Mac) without
+		// breaking the executables that don't have file extensions but do have periods in their names
+		String filebase_name = exec_path.get_file().get_basename(OS::get_singleton()->get_executable_extension());
 
 		// try to open at the location of executable
 		String datapack_name = exec_path.get_base_dir().plus_file(filebase_name) + ".pck";

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3887,8 +3887,11 @@ String String::percent_decode() const {
 }
 
 String String::get_basename() const {
+	return get_basename(".");
+}
 
-	int pos = find_last(".");
+String String::get_basename(const String &file_extension) const {
+	int pos = to_lower().find_last(file_extension.to_lower());
 	if (pos < 0 || pos < MAX(find_last("/"), find_last("\\")))
 		return *this;
 

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -232,6 +232,7 @@ public:
 	String rstrip(const String &p_chars) const;
 	String get_extension() const;
 	String get_basename() const;
+	String get_basename(const String &file_extension) const;
 	String plus_file(const String &p_file) const;
 	CharType ord_at(int p_idx) const;
 

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -156,6 +156,7 @@ public:
 	void wm_minimized(bool p_minimized);
 
 	virtual String get_name();
+	virtual String get_executable_extension() const;
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1436,6 +1436,11 @@ String OS_OSX::get_name() {
 	return "OSX";
 }
 
+String OS_OSX::get_executable_extension() const {
+
+	return ".app";
+}
+
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
 class OSXTerminalLogger : public StdLogger {
 public:

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2064,6 +2064,11 @@ String OS_Windows::get_name() {
 	return "Windows";
 }
 
+String OS_Windows::get_executable_extension() const {
+
+	return ".exe";
+}
+
 OS::Date OS_Windows::get_date(bool utc) const {
 
 	SYSTEMTIME systemtime;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -245,6 +245,7 @@ public:
 	virtual MainLoop *get_main_loop() const;
 
 	virtual String get_name();
+	virtual String get_executable_extension() const;
 
 	virtual Date get_date(bool utc) const;
 	virtual Time get_time(bool utc) const;


### PR DESCRIPTION
This PR fixes issue #15188. 
My C++ is a little rusty, and I'm really new to Godot (I named my first project tic.tac.toe and  fell down a rabbit hole trying to figure out why it didn't work). So if there's any recommendations for better ways to fix this, please let me know! I'm not sure how binary and pck naming works on other platforms, so if the same bug with periods in names exists on Linux or mobile I haven't done anything to fix it there (but it'd be pretty straightforward)