### PR TITLE
Fix C# API assembly build errors in generics

### DIFF
--- a/modules/mono/glue/Managed/Files/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/Managed/Files/Extensions/NodeExtensions.cs
@@ -4,7 +4,7 @@ namespace Godot
     {
         public T GetNode<T>(NodePath path) where T : class
         {
-            return (T)GetNode(path);
+            return (T)(object)GetNode(path);
         }
 
         public T GetNodeOrNull<T>(NodePath path) where T : class
@@ -14,7 +14,7 @@ namespace Godot
 
         public T GetChild<T>(int idx) where T : class
         {
-            return (T)GetChild(idx);
+            return (T)(object)GetChild(idx);
         }
 
         public T GetChildOrNull<T>(int idx) where T : class
@@ -24,7 +24,7 @@ namespace Godot
 
         public T GetOwner<T>() where T : class
         {
-            return (T)GetOwner();
+            return (T)(object)GetOwner();
         }
 
         public T GetOwnerOrNull<T>() where T : class
@@ -34,7 +34,7 @@ namespace Godot
 
         public T GetParent<T>() where T : class
         {
-            return (T)GetParent();
+            return (T)(object)GetParent();
         }
 
         public T GetParentOrNull<T>() where T : class

--- a/modules/mono/glue/Managed/Files/Extensions/ResourceLoaderExtensions.cs
+++ b/modules/mono/glue/Managed/Files/Extensions/ResourceLoaderExtensions.cs
@@ -2,9 +2,9 @@ namespace Godot
 {
     public static partial class ResourceLoader
     {
-        public static T Load<T>(string path) where T : Godot.Resource
+        public static T Load<T>(string path) where T : class
         {
-            return (T) Load(path);
+            return (T)(object)Load(path);
         }
     }
 }

--- a/modules/mono/glue/Managed/Files/GD.cs
+++ b/modules/mono/glue/Managed/Files/GD.cs
@@ -67,7 +67,7 @@ namespace Godot
 
         public static T Load<T>(string path) where T : class
         {
-            return (T) ResourceLoader.Load(path);
+            return ResourceLoader.Load<T>(path);
         }
 
         public static void Print(params object[] what)


### PR DESCRIPTION
*Bugsquad edit:* This fixes a regression from #22760.

Sorry, I should have made sure it compiled before approving.

Casting to `object` before casting to `T` fixes the constraint limitation. It outputs the same IL for my test build:

``` IL
  .method public hidebysig instance !!T  GetNode<(Godot.Node) T>(class Godot.NodePath path) cil managed
  {
    // Code size       13 (0xd)
    .maxstack  8
    IL_0000:  ldarg.0
    IL_0001:  ldarg.1
    IL_0002:  call       instance class Godot.Node Godot.Node::GetNode(class Godot.NodePath)
    IL_0007:  unbox.any  !!T
    IL_000c:  ret
  } // end of method Node::GetNode
```

``` IL
  .method public hidebysig instance !!T  GetNode<class T>(class Godot.NodePath path) cil managed
  {
    // Code size       13 (0xd)
    .maxstack  8
    IL_0000:  ldarg.0
    IL_0001:  ldarg.1
    IL_0002:  call       instance class Godot.Node Godot.Node::GetNode(class Godot.NodePath)
    IL_0007:  unbox.any  !!T
    IL_000c:  ret
  } // end of method Node::GetNode
```

Closes #22765
