### PR TITLE
Fix inspector color when theme changed

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2139,6 +2139,13 @@ void EditorInspector::_notification(int p_what) {
 	}
 
 	if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
+
+		if (use_sub_inspector_bg) {
+			add_style_override("bg", get_stylebox("sub_inspector_bg", "Editor"));
+		} else if (is_inside_tree()) {
+			add_style_override("bg", get_stylebox("bg", "Tree"));
+		}
+
 		update_tree();
 	}
 }

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -328,6 +328,21 @@ Container *InspectorDock::get_addon_area() {
 	return this;
 }
 
+void InspectorDock::_notification(int p_what) {
+	switch (p_what) {
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			set_theme(editor->get_gui_base()->get_theme());
+			resource_new_button->set_icon(get_icon("New", "EditorIcons"));
+			resource_load_button->set_icon(get_icon("Load", "EditorIcons"));
+			backward_button->set_icon(get_icon("Back", "EditorIcons"));
+			forward_button->set_icon(get_icon("Forward", "EditorIcons"));
+			history_menu->set_icon(get_icon("History", "EditorIcons"));
+			object_menu->set_icon(get_icon("Tools", "EditorIcons"));
+			warning->set_icon(get_icon("NodeWarning", "EditorIcons"));
+		} break;
+	}
+}
+
 void InspectorDock::_bind_methods() {
 	ClassDB::bind_method("_menu_option", &InspectorDock::_menu_option);
 

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -118,6 +118,7 @@ class InspectorDock : public VBoxContainer {
 
 protected:
 	static void _bind_methods();
+	void _notification(int p_what);
 
 public:
 	void go_back();


### PR DESCRIPTION
"light" version of #22716 PR, does not change the theme settings, just fix #19190. I made this separate cuz I think #22716 is too radical to be implemented right now.