### PR TITLE
Fix hovering on toggled link and texture buttons

### DIFF
--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -75,6 +75,7 @@ void LinkButton::_notification(int p_what) {
 					color = get_color("font_color");
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
 				} break;
+				case DRAW_HOVER_PRESSED:
 				case DRAW_PRESSED: {
 
 					if (has_color("font_color_pressed"))
@@ -91,7 +92,6 @@ void LinkButton::_notification(int p_what) {
 					do_underline = underline_mode != UNDERLINE_MODE_NEVER;
 
 				} break;
-				case DRAW_HOVER_PRESSED: break; // Not used in this class
 				case DRAW_DISABLED: {
 
 					color = get_color("font_color_disabled");

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -128,6 +128,7 @@ void TextureButton::_notification(int p_what) {
 					if (normal.is_valid())
 						texdraw = normal;
 				} break;
+				case DRAW_HOVER_PRESSED:
 				case DRAW_PRESSED: {
 
 					if (pressed.is_null()) {
@@ -150,7 +151,6 @@ void TextureButton::_notification(int p_what) {
 					} else
 						texdraw = hover;
 				} break;
-				case DRAW_HOVER_PRESSED: break; // Not used in this class
 				case DRAW_DISABLED: {
 
 					if (disabled.is_null()) {


### PR DESCRIPTION
It seems that DRAW_HOVER_PRESSED introduced a small bug in the TextureButton class. When one of these buttons is toggled (toggle mode being active) the button disappears when the mouse is over it.

Steps
1. Download this project: [TextureButtonBug.zip](https://github.com/godotengine/godot/files/2452450/TextureButtonBug.zip)
2. Play it.
3. Toggle the button and see how it disappears while the mouse is over it.

I basically copied the code from the DRAW_HOVER case to the DRAW_HOVER_PRESSED one and removed the `if (hover.is_null())` conditional. Let me know if this is the right way to do it!