### PR TITLE
Fix warnings in HTML5 build outside platform files

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -46,7 +46,7 @@ class Math {
 public:
 	Math() {} // useless to instance
 
-	static const uint64_t RANDOM_MAX = 4294967295;
+	static const uint64_t RANDOM_MAX = 0xFFFFFFFF;
 
 	static _ALWAYS_INLINE_ double sin(double p_x) { return ::sin(p_x); }
 	static _ALWAYS_INLINE_ float sin(float p_x) { return ::sinf(p_x); }

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -42,11 +42,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #ifndef NO_FCNTL
-#ifdef __HAIKU__
 #include <fcntl.h>
-#else
-#include <sys/fcntl.h>
-#endif
 #else
 #include <sys/ioctl.h>
 #endif


### PR DESCRIPTION
Using a non-decimal syntax allows the integer literal for `RANDOM_MAX` to be of unsigned type.