### PR TITLE
Fixed int interpolation issue, closes #22763

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -3542,7 +3542,10 @@ void Variant::interpolate(const Variant &a, const Variant &b, float c, Variant &
 		case INT: {
 			int64_t va = a._data._int;
 			int64_t vb = b._data._int;
-			r_dst = int((1.0 - c) * va + vb * c);
+			if (va != vb)
+				r_dst = int((1.0 - c) * va + vb * c);
+			else //avoid int casting issues
+				r_dst = a;
 		}
 			return;
 		case REAL: {


### PR DESCRIPTION
When interpolating between two equal int values a and b, floating point calculation imprecision can result in different values depending on the interpolation factor. For a=3, b=3 the result will be < 3, sometimes >= 3, with the result being either 2 or 3 due to the int cast:
ERROR: interpolate: interpolate va=3 vb=3 c=0.363636 r_dst=3
   At: core/variant_op.cpp:3546.
ERROR: interpolate: interpolate va=3 vb=3 c=0.454545 r_dst=2
   At: core/variant_op.cpp:3546.

Edit: uses @CptPotato solution now