### PR TITLE
Reverts warning fix on release builds that caused segfault in release build

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -673,7 +673,6 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			OPCODE(OPCODE_SET_MEMBER) {
 
 				CHECK_SPACE(3);
-#ifdef DEBUG_ENABLED
 				int indexname = _code_ptr[ip + 1];
 				GD_ERR_BREAK(indexname < 0 || indexname >= _global_names_count);
 				const StringName *index = &_global_names_ptr[indexname];
@@ -681,6 +680,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				bool valid;
 				bool ok = ClassDB::set_property(p_instance->owner, *index, *src, &valid);
+#ifdef DEBUG_ENABLED
 				if (!ok) {
 					err_text = "Internal error setting property: " + String(*index);
 					OPCODE_BREAK;
@@ -696,13 +696,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			OPCODE(OPCODE_GET_MEMBER) {
 
 				CHECK_SPACE(3);
-#ifdef DEBUG_ENABLED
 				int indexname = _code_ptr[ip + 1];
 				GD_ERR_BREAK(indexname < 0 || indexname >= _global_names_count);
 				const StringName *index = &_global_names_ptr[indexname];
 				GET_VARIANT_PTR(dst, 2);
-
 				bool ok = ClassDB::get_property(p_instance->owner, *index, *dst);
+
+#ifdef DEBUG_ENABLED
 				if (!ok) {
 					err_text = "Internal error getting property: " + String(*index);
 					OPCODE_BREAK;
@@ -749,13 +749,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			OPCODE(OPCODE_ASSIGN_TYPED_BUILTIN) {
 
 				CHECK_SPACE(4);
+				Variant::Type var_type = (Variant::Type)_code_ptr[ip + 1];
 				GET_VARIANT_PTR(dst, 2);
 				GET_VARIANT_PTR(src, 3);
 
-#ifdef DEBUG_ENABLED
-				Variant::Type var_type = (Variant::Type)_code_ptr[ip + 1];
 				GD_ERR_BREAK(var_type < 0 || var_type >= Variant::VARIANT_MAX);
 
+#ifdef DEBUG_ENABLED
 				if (src->get_type() != var_type) {
 					if (Variant::can_convert_strict(src->get_type(), var_type)) {
 						Variant::CallError ce;


### PR DESCRIPTION
This reverts specific change in 95131e6 that caused #22794

All of the harmless fixes of 95131e6 are reapplied in this PR. Changes in `gdscript_function.cpp` were bisected down to specific section of the file that introduced the problem.