### PR TITLE
Mono: Fix crash on NodePath/RID disposal during Godot shutdown

### DIFF
--- a/modules/mono/glue/nodepath_glue.cpp
+++ b/modules/mono/glue/nodepath_glue.cpp
@@ -40,7 +40,7 @@ NodePath *godot_icall_NodePath_Ctor(MonoString *p_path) {
 
 void godot_icall_NodePath_Dtor(NodePath *p_ptr) {
 	ERR_FAIL_NULL(p_ptr);
-	_GodotSharp::get_singleton()->queue_dispose(p_ptr);
+	memdelete(p_ptr);
 }
 
 MonoString *godot_icall_NodePath_operator_String(NodePath *p_np) {

--- a/modules/mono/glue/rid_glue.cpp
+++ b/modules/mono/glue/rid_glue.cpp
@@ -45,7 +45,7 @@ RID *godot_icall_RID_Ctor(Object *p_from) {
 
 void godot_icall_RID_Dtor(RID *p_ptr) {
 	ERR_FAIL_NULL(p_ptr);
-	_GodotSharp::get_singleton()->queue_dispose(p_ptr);
+	memdelete(p_ptr);
 }
 
 uint32_t godot_icall_RID_get_id(RID *p_ptr) {

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -172,6 +172,8 @@ public:
 
 	_FORCE_INLINE_ bool is_runtime_initialized() const { return runtime_initialized && !mono_runtime_is_shutting_down() /* stays true after shutdown finished */; }
 
+	_FORCE_INLINE_ bool is_finalizing_scripts_domain() { return finalizing_scripts_domain; }
+
 	_FORCE_INLINE_ MonoDomain *get_scripts_domain() { return scripts_domain; }
 #ifdef TOOLS_ENABLED
 	_FORCE_INLINE_ MonoDomain *get_tools_domain() { return tools_domain; }
@@ -260,8 +262,6 @@ class _GodotSharp : public Object {
 
 	friend class GDMono;
 
-	void _dispose_callback();
-
 	bool _is_domain_finalizing_for_unload(int32_t p_domain_id);
 
 	List<NodePath *> np_delete_queue;
@@ -294,9 +294,6 @@ public:
 
 	bool is_runtime_shutting_down();
 	bool is_runtime_initialized();
-
-	void queue_dispose(NodePath *p_node_path);
-	void queue_dispose(RID *p_rid);
 
 	_GodotSharp();
 	~_GodotSharp();


### PR DESCRIPTION
Fixes #22781

This was the same bug fixed by #16073, but I changed the finalization check recently and it doesn't seem to work. At least on Mono, AppDomain.IsFinalizingForUnload doesn't return true during domain finalization, only during domain unloading.

I ended up realizing it's pointless to have a queue now that it's not used for Object anymore, so ended up removing it entirely.

I still think we should not delete MessageQueue before ScriptServer finalization. Some script could call `call_deferred` after that.


