### PR TITLE
Add GDScript optional prefix filter for enum exports.

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4342,15 +4342,21 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 							// Enumeration
 							bool is_flags = false;
 
-							if (tokenizer->get_token() == GDScriptTokenizer::TK_COMMA) {
-								tokenizer->advance();
-
-								if (tokenizer->get_token() == GDScriptTokenizer::TK_IDENTIFIER && tokenizer->get_token_identifier() == "FLAGS") {
-									is_flags = true;
+							String prefix_filter = "";
+							for (int i = 0; i < 2; i++) {
+								if (tokenizer->get_token() == GDScriptTokenizer::TK_COMMA) {
 									tokenizer->advance();
-								} else {
-									current_export = PropertyInfo();
-									_set_error("Expected 'FLAGS' after comma.");
+
+									if (tokenizer->get_token() == GDScriptTokenizer::TK_IDENTIFIER && tokenizer->get_token_identifier() == "FLAGS") {
+										is_flags = true;
+										tokenizer->advance();
+									} else if (tokenizer->get_token() == GDScriptTokenizer::TK_CONSTANT && tokenizer->get_token_constant().get_type() == Variant::STRING) {
+										prefix_filter = tokenizer->get_token_constant();
+										tokenizer->advance();
+									} else {
+										current_export = PropertyInfo();
+										_set_error("Expected 'FLAGS' or string-constant prefix filter after comma.");
+									}
 								}
 							}
 
@@ -4370,10 +4376,12 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 									else
 										first = false;
 
-									current_export.hint_string += E->get().operator String().camelcase_to_underscore(true).capitalize().xml_escape();
+									String s = E->get();
+									current_export.hint_string += (s.substr(prefix_filter.length(), s.length())).camelcase_to_underscore(true).capitalize().xml_escape();
+
 									if (!is_flags) {
-										current_export.hint_string += ":";
-										current_export.hint_string += enum_values[E->get()].operator String().xml_escape();
+
+										current_export.hint_string += ":" + enum_values[s].operator String().xml_escape();
 									}
 								}
 							}


### PR DESCRIPTION
Closes #20988's use-case and (removes the need for) #21014.

(Edit: Also closes #22122 now)

A simple change that will let users optionally define a string constant to filter out of their Inspector's generated enum fields' textual representation.

    enum Elements {
        ELEM_NONE,
        ELEM_FIRE,
        ELEM_ICE
    }
    export(Elements, "ELEM_") var element = ELEM_FIRE
    # or...
    export(Elements, FLAGS, "ELEM_") var element_combo = ELEM_FIRE | ELEM_ICE

The above code would now display the options as (with the additional edit)...

    None
    Fire
    Ice

rather than...

    Elem None:0
    Elem Fire:1
    Elem Ice:2

The implementation allows the ordering of the FLAGS flag and the string constant to be flexible.