### PR TITLE
Revert "Created a new function named get_element in GridContainer. This funct…"

### DIFF
--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -184,8 +184,6 @@ void GridContainer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_columns", "columns"), &GridContainer::set_columns);
 	ClassDB::bind_method(D_METHOD("get_columns"), &GridContainer::get_columns);
-	ClassDB::bind_method(D_METHOD("get_child_control_at_cell", "row", "column"),
-			&GridContainer::get_child_control_at_cell);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "columns", PROPERTY_HINT_RANGE, "1,1024,1"), "set_columns", "get_columns");
 }
@@ -239,21 +237,6 @@ Size2 GridContainer::get_minimum_size() const {
 	ms.width += hsep * max_col;
 
 	return ms;
-}
-
-Control *GridContainer::get_child_control_at_cell(int row, int column) {
-	Control *c;
-	int grid_index = row * columns + column;
-	for (int i = 0; i < get_child_count(); i++) {
-		c = Object::cast_to<Control>(get_child(i));
-		if (!c || !c->is_visible_in_tree())
-			continue;
-
-		if (grid_index == i) {
-			break;
-		}
-	}
-	return c;
 }
 
 GridContainer::GridContainer() {

--- a/scene/gui/grid_container.h
+++ b/scene/gui/grid_container.h
@@ -47,7 +47,6 @@ public:
 	void set_columns(int p_columns);
 	int get_columns() const;
 	virtual Size2 get_minimum_size() const;
-	Control *get_child_control_at_cell(int row, int column);
 
 	GridContainer();
 };


### PR DESCRIPTION
Reverts godotengine/godot#16977, as mentioned in https://github.com/godotengine/godot/pull/16977#issuecomment-426972105 there are problems in the implementation and we didn't properly assess whether this is actually a meaningful addition (PR review until merge mostly focused on style/git workflow and it even ended up merged with a bad commit log).

As I understand the implementation this method is simply a convoluted way to do `get_child(row * columns + column)`, so it doesn't needed to add as core method - I might be wrong, but if we were to readd it the implementation and use case need to be reviewed more thoroughly.