### PR TITLE
Fix crash in Tree when moving using Joypad

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2183,6 +2183,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 	Ref<InputEventKey> k = p_event;
 
+	bool is_command = k.is_valid() && k->get_command();
 	if (p_event->is_action("ui_right") && p_event->is_pressed()) {
 
 		if (!cursor_can_exit_tree) accept_event();
@@ -2219,13 +2220,13 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 			_go_left();
 		}
 
-	} else if (p_event->is_action("ui_up") && p_event->is_pressed() && !k->get_command()) {
+	} else if (p_event->is_action("ui_up") && p_event->is_pressed() && !is_command) {
 
 		if (!cursor_can_exit_tree) accept_event();
 
 		_go_up();
 
-	} else if (p_event->is_action("ui_down") && p_event->is_pressed() && !k->get_command()) {
+	} else if (p_event->is_action("ui_down") && p_event->is_pressed() && !is_command) {
 
 		if (!cursor_can_exit_tree) accept_event();
 


### PR DESCRIPTION
Closes #22816

`k` might be invalid after cast to `InputEventKey`, so calling k->get_command() on a `InputEventJoypadButton` crashes the engine.