### PR TITLE
Add call_recursive method to TreeItem

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -536,6 +536,15 @@
 				Sets the given column's tooltip text.
 			</description>
 		</method>
+		<method name="call_recursive" qualifiers="vararg">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="method" type="String">
+			</argument>
+			<description>
+				Calls the [code]method[/code] on the actual TreeItem and its children recursively. Pass parameters as a comma separated list.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="collapsed" type="bool" setter="set_collapsed" getter="is_collapsed">

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -698,6 +698,43 @@ bool TreeItem::is_folding_disabled() const {
 	return disable_folding;
 }
 
+Variant TreeItem::_call_recursive_bind(const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
+
+	if (p_argcount < 1) {
+		r_error.error = Variant::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.argument = 0;
+		return Variant();
+	}
+
+	if (p_args[0]->get_type() != Variant::STRING) {
+		r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
+		r_error.argument = 0;
+		r_error.expected = Variant::STRING;
+		return Variant();
+	}
+
+	StringName method = *p_args[0];
+
+	call_recursive(method, &p_args[1], p_argcount - 1, r_error);
+	return Variant();
+}
+
+void recursive_call_aux(TreeItem *p_item, const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
+	if (!p_item) {
+		return;
+	}
+	p_item->call(p_method, p_args, p_argcount, r_error);
+	TreeItem *c = p_item->get_children();
+	while (c) {
+		recursive_call_aux(c, p_method, p_args, p_argcount, r_error);
+		c = c->get_next();
+	}
+}
+
+void TreeItem::call_recursive(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
+	recursive_call_aux(this, p_method, p_args, p_argcount, r_error);
+}
+
 void TreeItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_cell_mode", "column", "mode"), &TreeItem::set_cell_mode);
@@ -783,6 +820,14 @@ void TreeItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_disable_folding", "disable"), &TreeItem::set_disable_folding);
 	ClassDB::bind_method(D_METHOD("is_folding_disabled"), &TreeItem::is_folding_disabled);
+
+	{
+		MethodInfo mi;
+		mi.name = "call_recursive";
+		mi.arguments.push_back(PropertyInfo(Variant::STRING, "method"));
+
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_recursive", &TreeItem::_call_recursive_bind, mi);
+	}
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collapsed"), "set_collapsed", "is_collapsed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_folding"), "set_disable_folding", "is_folding_disabled");

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -177,6 +177,8 @@ protected:
 		remove_child(Object::cast_to<TreeItem>(p_child));
 	}
 
+	Variant _call_recursive_bind(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
+
 public:
 	/* cell mode */
 	void set_cell_mode(int p_column, TreeCellMode p_mode);
@@ -282,6 +284,8 @@ public:
 
 	void set_disable_folding(bool p_disable);
 	bool is_folding_disabled() const;
+
+	void call_recursive(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 
 	~TreeItem();
 };


### PR DESCRIPTION
Implementation of call_recursive("method", args...) as mentioned [here](https://github.com/godotengine/godot/pull/22728#issuecomment-427442206).

What to do with the return? vararg methods require a Variant as a return parameter, should this use it somehow or always return an empty variant?
if it returns an empty variant should the docs say something about it? I added `<return type="Variant">` in TreeItem.xml