### PR TITLE
Fix multi-statement macro call not being covered.

### DIFF
--- a/modules/bullet/bullet_utilities.h
+++ b/modules/bullet/bullet_utilities.h
@@ -39,7 +39,8 @@
 	new cl
 
 #define bulletdelete(cl) \
-	delete cl;           \
-	cl = NULL;
-
+	{                    \
+		delete cl;       \
+		cl = NULL;       \
+	}
 #endif

--- a/modules/bullet/collision_object_bullet.cpp
+++ b/modules/bullet/collision_object_bullet.cpp
@@ -310,9 +310,10 @@ void RigidCollisionObjectBullet::shape_changed(int p_shape_index) {
 
 void RigidCollisionObjectBullet::reload_shapes() {
 
-	if (mainShape && mainShape->isCompound())
+	if (mainShape && mainShape->isCompound()) {
 		// Destroy compound
 		bulletdelete(mainShape);
+	}
 
 	mainShape = NULL;
 


### PR DESCRIPTION
`gcc` gives the following warning on compilation:

```
In file included from modules/bullet/constraint_bullet.h:34,
                 from modules/bullet/joint_bullet.h:34,
                 from modules/bullet/bullet_physics_server.h:36,
                 from modules/bullet/collision_object_bullet.cpp:34:
modules/bullet/collision_object_bullet.cpp: In member function 'virtual void RigidCollisionObjectBullet::reload_shapes()':
modules/bullet/bullet_utilities.h:42:2: warning: macro expands to multiple statements [-Wmultistatement-macros]
  delete cl;           \
  ^~~~~~
modules/bullet/collision_object_bullet.cpp:315:3: note: in expansion of macro 'bulletdelete'
   bulletdelete(mainShape);
   ^~~~~~~~~~~~
modules/bullet/collision_object_bullet.cpp:313:2: note: some parts of macro expansion are not guarded by this 'if' clause
  if (mainShape && mainShape->isCompound())
  ^~
```
, this PR fixes this misplaced macro call.
