### PR TITLE
Fix setting the space of a RigidBody.

### DIFF
--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -255,8 +255,6 @@ public:
 	bool can_add_collision() { return collisionsCount < maxCollisionsDetection; }
 	bool add_collision_object(RigidBodyBullet *p_otherObject, const Vector3 &p_hitWorldLocation, const Vector3 &p_hitLocalLocation, const Vector3 &p_hitNormal, const float &p_appliedImpulse, int p_other_shape_index, int p_local_shape_index);
 
-	void assert_no_constraints();
-
 	void set_activation_state(bool p_active);
 	bool is_active() const;
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -2326,7 +2326,8 @@ void PhysicalBone::set_joint_type(JointType p_joint_type) {
 	if (p_joint_type == get_joint_type())
 		return;
 
-	memdelete(joint_data);
+	if (joint_data)
+		memdelete(joint_data);
 	joint_data = NULL;
 	switch (p_joint_type) {
 		case JOINT_TYPE_PIN:
@@ -2526,7 +2527,8 @@ PhysicalBone::PhysicalBone() :
 }
 
 PhysicalBone::~PhysicalBone() {
-	memdelete(joint_data);
+	if (joint_data)
+		memdelete(joint_data);
 }
 
 void PhysicalBone::update_bone_id() {


### PR DESCRIPTION
Fixes #22823 crash, which SEGVed because it was dereferencing NULL.
Furthermore, should fix the warning, as now the constraints are moved from one space to the other.