### PR TITLE
Fix spam when dragging in the editor

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -769,7 +769,7 @@ void Control::force_drag(const Variant &p_data, Control *p_control) {
 void Control::set_drag_preview(Control *p_control) {
 
 	ERR_FAIL_COND(!is_inside_tree());
-	ERR_FAIL_COND(get_viewport()->gui_is_dragging());
+	ERR_FAIL_COND(!get_viewport()->gui_is_dragging());
 	get_viewport()->_gui_set_drag_preview(this, p_control);
 }
 


### PR DESCRIPTION
I believe this error macro had its condition swapped. Please let me know if the code was correct.

Found here:

https://github.com/capnm/godot/issues/1

*Bugsquad edit:* Fixes #21493.