### PR TITLE
Fixed Animation Keyframe inspector not displaying after moving key.

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4086,6 +4086,8 @@ void AnimationTrackEditor::_move_selection_commit() {
 	for (int i = 0; i < track_edits.size(); i++) {
 		track_edits[i]->update();
 	}
+
+	_update_key_edit();
 }
 void AnimationTrackEditor::_move_selection_cancel() {
 


### PR DESCRIPTION
Fixed Animation Keyframe inspector not displaying after moving key.

Fixes #22650