### PR TITLE
Feature/moving folder to existing folder with same  name causing error #22850

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1017,7 +1017,23 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 
 	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	print_verbose("Moving " + old_path + " -> " + new_path);
-	Error err = da->rename(old_path, new_path);
+	Error err;
+	if (p_item.is_file) {
+		err = da->rename(old_path, new_path);
+	}
+	else {
+		if (da->copy_dir(old_path, new_path) == OK) {
+			for (int i = 0; i < file_changed_paths.size(); ++i) {
+				err = da->remove(file_changed_paths[i]);
+				if (err == FAILED) {
+					break;
+				}
+			}
+			if (err == OK) {
+				err = da->remove(old_path);
+			}
+		}
+	}
 	if (err == OK) {
 		//Move/Rename any corresponding import settings too
 		if (p_item.is_file && FileAccess::exists(old_path + ".import")) {


### PR DESCRIPTION
If a directory is moved instead of renaming it it will copy the directory to the new path.
If it copied all the files successfully it deletes all files in the old directory and then removes the original directory

*Bugsquad edit:* Fixes #22850.