### PR TITLE
Added add_triangles method to SurfaceTool

### DIFF
--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -190,10 +190,10 @@ void SurfaceTool::add_smooth_group(bool p_smooth) {
 	}
 }
 
-void SurfaceTool::add_triangle_fan(const Vector<Vector3> &p_vertexes, const Vector<Vector2> &p_uvs, const Vector<Color> &p_colors, const Vector<Vector2> &p_uv2s, const Vector<Vector3> &p_normals, const Vector<Plane> &p_tangents) {
+void SurfaceTool::add_triangle_fan(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<Color> &p_colors, const Vector<Vector2> &p_uv2s, const Vector<Vector3> &p_normals, const Vector<Plane> &p_tangents) {
 	ERR_FAIL_COND(!begun);
 	ERR_FAIL_COND(primitive != Mesh::PRIMITIVE_TRIANGLES);
-	ERR_FAIL_COND(p_vertexes.size() < 3);
+	ERR_FAIL_COND(p_vertices.size() < 3);
 
 #define ADD_POINT(n)                    \
 	{                                   \
@@ -207,11 +207,24 @@ void SurfaceTool::add_triangle_fan(const Vector<Vector3> &p_vertexes, const Vect
 			add_normal(p_normals[n]);   \
 		if (p_tangents.size() > n)      \
 			add_tangent(p_tangents[n]); \
-		add_vertex(p_vertexes[n]);      \
+		add_vertex(p_vertices[n]);      \
 	}
 
-	for (int i = 0; i < p_vertexes.size() - 2; i++) {
+	for (int i = 0; i < p_vertices.size() - 2; i++) {
 		ADD_POINT(0);
+		ADD_POINT(i + 1);
+		ADD_POINT(i + 2);
+	}
+}
+
+void SurfaceTool::add_triangles(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<Color> &p_colors, const Vector<Vector2> &p_uv2s, const Vector<Vector3> &p_normals, const Vector<Plane> &p_tangents) {
+	ERR_FAIL_COND(!begun);
+	ERR_FAIL_COND(primitive != Mesh::PRIMITIVE_TRIANGLES);
+	ERR_FAIL_COND(p_vertices.size() < 3);
+	ERR_FAIL_COND(p_vertices.size() % 3 != 0);
+
+	for (int i = 0; i < p_vertices.size() - 2; i += 3) {
+		ADD_POINT(i);
 		ADD_POINT(i + 1);
 		ADD_POINT(i + 2);
 	}
@@ -976,7 +989,8 @@ void SurfaceTool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_weights", "weights"), &SurfaceTool::add_weights);
 	ClassDB::bind_method(D_METHOD("add_smooth_group", "smooth"), &SurfaceTool::add_smooth_group);
 
-	ClassDB::bind_method(D_METHOD("add_triangle_fan", "vertexes", "uvs", "colors", "uv2s", "normals", "tangents"), &SurfaceTool::add_triangle_fan, DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Color>()), DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Vector3>()), DEFVAL(Vector<Plane>()));
+	ClassDB::bind_method(D_METHOD("add_triangle_fan", "vertices", "uvs", "colors", "uv2s", "normals", "tangents"), &SurfaceTool::add_triangle_fan, DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Color>()), DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Vector3>()), DEFVAL(Vector<Plane>()));
+	ClassDB::bind_method(D_METHOD("add_triangles", "vertices", "uvs", "colors", "uv2s", "normals", "tangents"), &SurfaceTool::add_triangles, DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Color>()), DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Vector3>()), DEFVAL(Vector<Plane>()));
 
 	ClassDB::bind_method(D_METHOD("add_index", "index"), &SurfaceTool::add_index);
 

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -111,6 +111,7 @@ public:
 	void add_smooth_group(bool p_smooth);
 
 	void add_triangle_fan(const Vector<Vector3> &p_vertexes, const Vector<Vector2> &p_uvs = Vector<Vector2>(), const Vector<Color> &p_colors = Vector<Color>(), const Vector<Vector2> &p_uv2s = Vector<Vector2>(), const Vector<Vector3> &p_normals = Vector<Vector3>(), const Vector<Plane> &p_tangents = Vector<Plane>());
+	void add_triangles(const Vector<Vector3> &p_vertexes, const Vector<Vector2> &p_uvs = Vector<Vector2>(), const Vector<Color> &p_colors = Vector<Color>(), const Vector<Vector2> &p_uv2s = Vector<Vector2>(), const Vector<Vector3> &p_normals = Vector<Vector3>(), const Vector<Plane> &p_tangents = Vector<Plane>());
 
 	void add_index(int p_index);
 


### PR DESCRIPTION
The `add_triangles` method works the same as the current `add_triangle_fan` method. It runs through user provided arrays of vertices and vertex attributes and adds them to the SurfaceTools' vertex array. 

The motivation for this PR is that when creating meshes in code it is often easier to pass in an array of vertices rather than to create a loop and add each vertex individually. Users may have arrays generated from methods, or read from disk that they want to pass in without creating a big loop in the middle of the code. As we already have `add_triangle_fan`, in the future it would be beneficial to also add an `add_triangle_strip` function and the like. Functions like this facilitate the process of using the SurfaceTool, without adding any significant overhead. 

Also note for documentation later on. This method requires that the user has already called `begin`, that the primitive type is set to `triangles`, the size of the array must be at least 3, and the array must be divisible by 3.

edit: updated PR to also fix typo of vertices being spelt "vertexes" throughout the class.