### PR TITLE
Reload text shaders when externally edited, issue 19852

### DIFF
--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -58,6 +58,8 @@ protected:
 public:
 	virtual void _validate_script();
 
+	void reload_text();
+
 	Ref<Shader> get_edited_shader() const;
 	void set_edited_shader(const Ref<Shader> &p_shader);
 	ShaderTextEditor();
@@ -103,6 +105,7 @@ class ShaderEditor : public PanelContainer {
 
 	GotoLineDialog *goto_line_dialog;
 	ConfirmationDialog *erase_tab_confirm;
+	ConfirmationDialog *disk_changed;
 
 	ShaderTextEditor *shader_editor;
 
@@ -111,6 +114,9 @@ class ShaderEditor : public PanelContainer {
 	mutable Ref<Shader> shader;
 
 	void _editor_settings_changed();
+
+	void _check_for_external_edit();
+	void _reload_shader_from_disk();
 
 protected:
 	void _notification(int p_what);
@@ -127,7 +133,7 @@ public:
 	void goto_line_selection(int p_line, int p_begin, int p_end);
 
 	virtual Size2 get_minimum_size() const { return Size2(0, 200); }
-	void save_external_data();
+	void save_external_data(const String &p_str = "");
 
 	ShaderEditor(EditorNode *p_node);
 };


### PR DESCRIPTION
When a `.shader` file is open in the editor and then changed externally, it will reload it when the editor is brought back into focus.

Solves part of #19852 but not fully as the '.shader' has to be open in the editor. 