### PR TITLE
Add reroute node to Visual Shader Graph

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -71,6 +71,9 @@ class VisualShaderEditor : public VBoxContainer {
 
 	void _update_graph();
 
+	void _connect_reroute(const VisualShader::Type p_type, const int p_from_node, const int p_from_port, const int p_to_node, const int p_to_port);
+	void _disconnect_reroute(const VisualShader::Type p_type, const int p_from_node, const int p_from_port, const int p_to_node, const int p_to_port);
+
 	struct AddOption {
 		String name;
 		String category;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -509,6 +509,7 @@ void register_scene_types() {
 	ClassDB::register_class<VisualShaderNodeTransformUniform>();
 	ClassDB::register_class<VisualShaderNodeTextureUniform>();
 	ClassDB::register_class<VisualShaderNodeCubeMapUniform>();
+	ClassDB::register_class<VisualShaderNodeReroute>();
 
 	ClassDB::register_class<ShaderMaterial>();
 	ClassDB::register_virtual_class<CanvasItem>();

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -176,6 +176,7 @@ public:
 		PORT_TYPE_SCALAR,
 		PORT_TYPE_VECTOR,
 		PORT_TYPE_TRANSFORM,
+		PORT_TYPE_REROUTE
 	};
 
 	virtual String get_caption() const = 0;
@@ -311,6 +312,78 @@ public:
 	String get_uniform_name() const;
 
 	VisualShaderNodeUniform();
+};
+
+///////////////////////////////////////
+
+class VisualShaderNodeReroute : public VisualShaderNode {
+	GDCLASS(VisualShaderNodeReroute, VisualShaderNode)
+
+	Vector<int> out_nodes;
+	Vector<int> out_ports;
+	int in_node;
+
+	int in_node_begin;
+	int in_port_begin;
+
+	PortType port_type;
+	bool has_output;
+
+	void _update_out_connection(const Ref<VisualShader> &p_visual_shader, const VisualShader::Type, const int p_exclude_node);
+
+	void _update_port_type_output(const Ref<VisualShader> &p_visual_shader, const VisualShader::Type p_type, const int p_exclude_node);
+	void _update_port_type_output_reverse(const Ref<VisualShader> &p_visual_shader, const VisualShader::Type p_type);
+
+	PortType _get_connected_output_type(const Ref<VisualShader> &p_visual_shader, const VisualShader::Type p_type, const int p_exclude_node);
+
+	void _set_output_nodes(const Array &p_array);
+	Array _get_output_nodes() const;
+
+	void _set_output_ports(const Array &p_array);
+	Array _get_output_ports() const;
+
+	void _set_input_node(const int p_node);
+	int _get_input_node() const;
+
+	void _set_input_node_begin(const int p_node);
+	int _get_input_node_begin() const;
+
+	void _set_input_port_begin(const int p_port);
+	int _get_input_port_begin() const;
+
+	void _set_port_type(const int p_port_type);
+	int _get_port_type() const;
+
+	void _set_has_output(const int p_has_output);
+	bool _get_has_output() const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual String get_caption() const;
+
+	virtual int get_input_port_count() const;
+	virtual PortType get_input_port_type(int p_port) const;
+	virtual String get_input_port_name(int p_port) const;
+
+	virtual int get_output_port_count() const;
+	virtual PortType get_output_port_type(int p_port) const;
+	virtual String get_output_port_name(int p_port) const;
+
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
+
+	void add_out_connection(const Ref<VisualShader> &p_visual_shader, const VisualShader::Type p_type, const int p_node, const int p_port);
+	void remove_out_connection(const Ref<VisualShader> &p_visual_shader, const VisualShader::Type p_type, const int p_node);
+	bool has_out_connection() const;
+
+	void set_in_connection(const Ref<VisualShader> &p_visual_shader, const VisualShader::Type p_type, const int p_node, const int p_port);
+
+	bool get_connected_input_connection(int &p_node, int &p_port) const;
+
+	void clear();
+
+	VisualShaderNodeReroute();
 };
 
 #endif // VISUAL_SHADER_H


### PR DESCRIPTION
Added a reroute node to the visual shader graph, related to #11001

Currently the node still has separate ports for input and output. If requested will look into it, to make it one port.

![reroute_node](https://user-images.githubusercontent.com/10676051/46636662-38c89f00-cb59-11e8-933a-fcefe49fae91.png)
