### PR TITLE
Fix richtextlabel meta links shouldn't open when swiping to scroll

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -776,6 +776,7 @@ void RichTextLabel::_update_scroll() {
 			_validate_line_caches(main);
 		}
 	}
+	scroll_updated = true;
 }
 
 void RichTextLabel::_notification(int p_what) {
@@ -928,6 +929,7 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 			if (true) {
 
 				if (b->is_pressed() && !b->is_doubleclick()) {
+					scroll_updated = false;
 					int line = 0;
 					Item *item = NULL;
 
@@ -936,12 +938,7 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 
 					if (item) {
 
-						Variant meta;
-						if (!outside && _find_meta(item, &meta)) {
-							//meta clicked
-
-							emit_signal("meta_clicked", meta);
-						} else if (selection.enabled) {
+						if (selection.enabled) {
 
 							selection.click = item;
 							selection.click_char = line;
@@ -990,6 +987,24 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 				} else if (!b->is_pressed()) {
 
 					selection.click = NULL;
+
+					if (!b->is_doubleclick() && !scroll_updated) {
+						int line = 0;
+						Item *item = NULL;
+
+						bool outside;
+						_find_click(main, b->get_position(), &item, &line, &outside);
+
+						if (item) {
+
+							Variant meta;
+							if (!outside && _find_meta(item, &meta)) {
+								//meta clicked
+
+								emit_signal("meta_clicked", meta);
+							}
+						}
+					}
 				}
 			}
 		}
@@ -2323,6 +2338,7 @@ RichTextLabel::RichTextLabel() {
 	updating_scroll = false;
 	scroll_active = true;
 	scroll_w = 0;
+	scroll_updated = false;
 
 	vscroll = memnew(VScrollBar);
 	add_child(vscroll);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -225,6 +225,7 @@ private:
 	bool scroll_following;
 	bool scroll_active;
 	int scroll_w;
+	bool scroll_updated;
 	bool updating_scroll;
 	int current_idx;
 	int visible_line_count;


### PR DESCRIPTION
It is changed to perform 'emit_signal ("meta_clicked")' when the mouse is up and not scrolled.
Fix #7620