### PR TITLE
[DOC] Update and expand SurfaceTool doc

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -14,6 +14,7 @@
 		[/codeblock]
 		The [code]SurfaceTool[/code] now contains one vertex of a triangle which has a UV coordinate and a specified [Color]. If another vertex were added without calls to [method add_uv] or [method add_color] then the last values would be used.
 		It is very important that vertex attributes are passed [b]before[/b] the call to [method add_vertex], failure to do this will result in an error when committing the vertex information to a mesh.
+		Additionally, the attributes used before the first vertex is added determine the format of the mesh. For example if you only add UVs to the first vertex, you cannot add color to any of the subsequent vertices.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -26,7 +27,7 @@
 			<argument index="0" name="bones" type="PoolIntArray">
 			</argument>
 			<description>
-				Add an array of bones for the next Vertex to use.
+				Add an array of bones for the next Vertex to use. Array must contain 4 integers.
 			</description>
 		</method>
 		<method name="add_color">
@@ -99,6 +100,7 @@
 			</argument>
 			<description>
 				Insert a triangle fan made of array data into [Mesh] being constructed.
+				Requires primitive type be set to [code]PRIMITIVE_TRIANGLES[/code].
 			</description>
 		</method>
 		<method name="add_uv">
@@ -134,7 +136,7 @@
 			<argument index="0" name="weights" type="PoolRealArray">
 			</argument>
 			<description>
-				Specify weight value for next Vertex to use.
+				Specify weight values for next Vertex to use. Array must contain 4 values.
 			</description>
 		</method>
 		<method name="append_from">
@@ -147,6 +149,7 @@
 			<argument index="2" name="transform" type="Transform">
 			</argument>
 			<description>
+				Append vertices from a given [Mesh] surface onto the current vertex array with specified [Transform]. 
 			</description>
 		</method>
 		<method name="begin">
@@ -184,6 +187,7 @@
 			<argument index="1" name="surface" type="int">
 			</argument>
 			<description>
+				Creates a vertex array from an existing [Mesh]. 
 			</description>
 		</method>
 		<method name="deindex">
@@ -201,12 +205,15 @@
 			<description>
 				Generates normals from Vertices so you do not have to do it manually.
 				Setting "flip" [code]true[/code] inverts resulting normals.
+				Requires primitive type to be set to [code]PRIMITIVE_TRIANGLES[/code].
 			</description>
 		</method>
 		<method name="generate_tangents">
 			<return type="void">
 			</return>
 			<description>
+				Generates a tangent vector for each vertex.
+				Requires that each vertex have UVs and normals set already.
 			</description>
 		</method>
 		<method name="index">


### PR DESCRIPTION
I just filled in some information and clarified others.

Partially address issue #16208 

I left the method description add_to_format blank as I think this method should be removed in a future PR. If it is used during the construction of a primitive it can easily cause a crash. All it does is update the variable `format` which is used to keep track of which arrays have been added. Allowing a user to update format without the corresponding arrays will lead other functions to try to access those arrays even though they dont exist.