### PR TITLE
Hide numeric value for constants in EditorPropertyEnum

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -477,33 +477,16 @@ EditorPropertyCheck::EditorPropertyCheck() {
 
 void EditorPropertyEnum::_option_selected(int p_which) {
 
-	String text = options->get_item_text(p_which);
-	Vector<String> text_split = text.split(":");
-	if (text_split.size() == 1) {
-		emit_signal("property_changed", get_edited_property(), p_which);
-		return;
-	}
-	String name = text_split[1];
-	emit_signal("property_changed", get_edited_property(), name.to_int());
+	int val = options->get_item_metadata(p_which);
+	emit_signal("property_changed", get_edited_property(), val);
 }
 
 void EditorPropertyEnum::update_property() {
 
 	int which = get_edited_object()->get(get_edited_property());
-	if (which == 0) {
-		options->select(which);
-		return;
-	}
 
 	for (int i = 0; i < options->get_item_count(); i++) {
-		String text = options->get_item_text(i);
-		Vector<String> text_split = text.split(":");
-		if (text_split.size() == 1) {
-			options->select(which);
-			return;
-		}
-		String name = text_split[1];
-		if (itos(which) == name) {
+		if (which == (int)options->get_item_metadata(i)) {
 			options->select(i);
 			return;
 		}
@@ -511,8 +494,15 @@ void EditorPropertyEnum::update_property() {
 }
 
 void EditorPropertyEnum::setup(const Vector<String> &p_options) {
+
+	int current_val = 0;
 	for (int i = 0; i < p_options.size(); i++) {
-		options->add_item(p_options[i], i);
+		Vector<String> text_split = p_options[i].split(":");
+		if (text_split.size() != 1)
+			current_val = text_split[1].to_int();
+		options->add_item(text_split[0]);
+		options->set_item_metadata(i, current_val);
+		current_val += 1;
 	}
 }
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -132,7 +132,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 				emit_signal("variant_changed");
 			} else if (hint == PROPERTY_HINT_ENUM) {
 
-				v = p_which;
+				v = menu->get_item_metadata(p_which);
 				emit_signal("variant_changed");
 			}
 		} break;
@@ -427,12 +427,14 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			} else if (hint == PROPERTY_HINT_ENUM) {
 
 				Vector<String> options = hint_text.split(",");
+				int current_val = 0;
 				for (int i = 0; i < options.size(); i++) {
-					if (options[i].find(":") != -1) {
-						menu->add_item(options[i].get_slicec(':', 0), options[i].get_slicec(':', 1).to_int());
-					} else {
-						menu->add_item(options[i], i);
-					}
+					Vector<String> text_split = options[i].split(":");
+					if (text_split.size() != 1)
+						current_val = text_split[1].to_int();
+					menu->add_item(text_split[0]);
+					menu->set_item_metadata(i, current_val);
+					current_val += 1;
 				}
 				menu->set_position(get_position());
 				menu->popup();


### PR DESCRIPTION
Closes #22122

This change was not necessary for CustomPropertyEditor, since it already hides the numeric value. However, I changed it as well as EditorPropertyEnum to calculate values correctly when only some constants have an explicit value:

``` C++
hint_string = "A,B:3,C,D:2,E,F"

enum {
    A,
    B = 3,
    C,
    D = 2,
    E,
    F
}

// Before. The constants without an explicit value had the constant index as the value itself:
enum {
    A = 0, // Index: 0 (applied)
    B = 3, // Index: 1
    C = 2, // Index: 2 (applied)
    D = 2, // Index: 3
    E = 4, // Index: 4 (applied)
    F = 5  // Index: 5 (applied)
}

// After. The constants without an explicit value had the value of the previous constant incremented by one:
enum {
    A = 0, // Begins at 0
    B = 3, // Explicit
    C = 4, // B + 1
    D = 2, // Explicit
    E = 3, // D + 1
    F = 4  // E + 1
}
```

This is how it works at least in C#, C++ and GDScript.

Also fixes #23022 (see https://github.com/godotengine/godot/pull/22885#discussion_r225332726)
