### PR TITLE
Simplify AudioEffectRecord code so that it doesn't needs Threads

### DIFF
--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -47,19 +47,8 @@ class AudioEffectRecordInstance : public AudioEffectInstance {
 	friend class AudioEffectRecord;
 	Ref<AudioEffectRecord> base;
 
-	bool is_recording;
-	Thread *io_thread;
-	bool thread_active;
-
-	Vector<AudioFrame> ring_buffer;
 	Vector<float> recording_data;
 
-	unsigned int ring_buffer_pos;
-	unsigned int ring_buffer_mask;
-	unsigned int ring_buffer_read_pos;
-
-	void _io_thread_process();
-	void _io_store_buffer();
 	static void _thread_callback(void *_instance);
 	void _init_recording();
 
@@ -68,8 +57,7 @@ public:
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count);
 	virtual bool process_silence() const;
 
-	AudioEffectRecordInstance() :
-			thread_active(false) {}
+	AudioEffectRecordInstance() {}
 };
 
 class AudioEffectRecord : public AudioEffect {


### PR DESCRIPTION
This change is most useful on the javascript platform since WebAssembly currently doesn't supports Threads (this effect is currently not working on the javascript platform).