### PR TITLE
A colon ending a comment line no longer indents the next line

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2331,9 +2331,9 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				// no need to indent if we are going upwards.
 				if (auto_indent && !(k->get_command() && k->get_shift())) {
-					// indent once again if previous line will end with ':' or '{'
+					// indent once again if previous line will end with ':' or '{' and the line is not a comment
 					// (i.e. colon/brace precedes current cursor position)
-					if (cursor.column > 0 && (text[cursor.line][cursor.column - 1] == ':' || text[cursor.line][cursor.column - 1] == '{')) {
+					if (cursor.column > 0 && (text[cursor.line][cursor.column - 1] == ':' || text[cursor.line][cursor.column - 1] == '{') && !is_line_comment(cursor.line)) {
 						if (indent_using_spaces) {
 							ins += space_indent;
 						} else {


### PR DESCRIPTION
_Bugsquad edit :_ Fix https://github.com/godotengine/godot/issues/20055
If the line the cursor is on now is a comment ending with a colon and the user presses enter to go to the next line, an extra indentation is no longer added.
Previous behavior:
```
>    # Some comment:
>    >    New line indented
```

New behavior:
```
>    # Some comment:
>    New line not indented
```
