### PR TITLE
Make sort_custom take anything, not just Object. Fix #22888.

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1701,7 +1701,7 @@ void register_variant_methods() {
 	ADDFUNC0RNC(ARRAY, NIL, Array, pop_back, varray());
 	ADDFUNC0RNC(ARRAY, NIL, Array, pop_front, varray());
 	ADDFUNC0NC(ARRAY, NIL, Array, sort, varray());
-	ADDFUNC2NC(ARRAY, NIL, Array, sort_custom, OBJECT, "obj", STRING, "func", varray());
+	ADDFUNC2NC(ARRAY, NIL, Array, sort_custom, NIL, "obj", STRING, "func", varray());
 	ADDFUNC0NC(ARRAY, NIL, Array, shuffle, varray());
 	ADDFUNC2R(ARRAY, INT, Array, bsearch, NIL, "value", BOOL, "before", varray(true));
 	ADDFUNC4R(ARRAY, INT, Array, bsearch_custom, NIL, "value", OBJECT, "obj", STRING, "func", BOOL, "before", varray(true));

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -309,7 +309,7 @@
 			</description>
 		</method>
 		<method name="sort_custom">
-			<argument index="0" name="obj" type="Object">
+			<argument index="0" name="obj" type="Variant">
 			</argument>
 			<argument index="1" name="func" type="String">
 			</argument>


### PR DESCRIPTION
This should fix #22888, in a possibly temporary way, some type hinting of a parameter of type class might need to be introduced in the future.