### PR TITLE
Fix has_method

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2604,7 +2604,7 @@ Error _ClassDB::set_property(Object *p_object, const StringName &p_property, con
 	return OK;
 }
 
-bool _ClassDB::has_method(StringName p_class, StringName p_method, bool p_no_inheritance) const {
+bool _ClassDB::class_has_method(StringName p_class, StringName p_method, bool p_no_inheritance) const {
 
 	return ClassDB::has_method(p_class, p_method, p_no_inheritance);
 }
@@ -2685,7 +2685,7 @@ void _ClassDB::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("class_get_property", "object", "property"), &_ClassDB::get_property);
 	ClassDB::bind_method(D_METHOD("class_set_property", "object", "property", "value"), &_ClassDB::set_property);
 
-	ClassDB::bind_method(D_METHOD("class_has_method", "class", "method", "no_inheritance"), &_ClassDB::has_method, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("class_has_method", "class", "method", "no_inheritance"), &_ClassDB::class_has_method, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("class_get_method_list", "class", "no_inheritance"), &_ClassDB::get_method_list, DEFVAL(false));
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -656,7 +656,7 @@ public:
 	Variant get_property(Object *p_object, const StringName &p_property) const;
 	Error set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const;
 
-	bool has_method(StringName p_class, StringName p_method, bool p_no_inheritance = false) const;
+	bool class_has_method(StringName p_class, StringName p_method, bool p_no_inheritance = false) const;
 
 	Array get_method_list(StringName p_class, bool p_no_inheritance = false) const;
 

--- a/core/object.h
+++ b/core/object.h
@@ -649,7 +649,7 @@ public:
 
 	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false) const;
 
-	bool has_method(const StringName &p_method) const;
+	virtual bool has_method(const StringName &p_method) const;
 	void get_method_list(List<MethodInfo> *p_list) const;
 	Variant callv(const StringName &p_method, const Array &p_args);
 	virtual Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error);

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -48,6 +48,24 @@ void Script::_notification(int p_what) {
 	}
 }
 
+bool Script::has_method(const StringName &p_method) const {
+
+	if (Object::has_method(p_method)) {
+		return true;
+	}
+
+	if (defines_method(p_method)) {
+		return true;
+	}
+
+	Ref<Script> parent = get_base_script();
+	if (parent.is_valid() && parent->has_method(p_method)) {
+		return true;
+	}
+
+	return false;
+}
+
 void Script::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("can_instance"), &Script::can_instance);

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -124,7 +124,8 @@ public:
 	virtual void set_source_code(const String &p_code) = 0;
 	virtual Error reload(bool p_keep_state = false) = 0;
 
-	virtual bool has_method(const StringName &p_method) const = 0;
+	virtual bool has_method(const StringName &p_method) const;
+	virtual bool defines_method(const StringName &p_method) const = 0;
 	virtual MethodInfo get_method_info(const StringName &p_method) const = 0;
 
 	virtual bool is_tool() const = 0;

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -265,7 +265,7 @@ Error NativeScript::reload(bool p_keep_state) {
 	return FAILED;
 }
 
-bool NativeScript::has_method(const StringName &p_method) const {
+bool NativeScript::defines_method(const StringName &p_method) const {
 	NativeScriptDesc *script_data = get_script_desc();
 
 	while (script_data) {

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -156,7 +156,7 @@ public:
 	virtual void set_source_code(const String &p_code);
 	virtual Error reload(bool p_keep_state = false);
 
-	virtual bool has_method(const StringName &p_method) const;
+	virtual bool defines_method(const StringName &p_method) const;
 	virtual MethodInfo get_method_info(const StringName &p_method) const;
 
 	virtual bool is_tool() const;

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -286,7 +286,7 @@ void PluginScript::get_script_property_list(List<PropertyInfo> *r_properties) co
 	}
 }
 
-bool PluginScript::has_method(const StringName &p_method) const {
+bool PluginScript::defines_method(const StringName &p_method) const {
 	ASSERT_SCRIPT_VALID_V(false);
 	return _methods_info.has(p_method);
 }

--- a/modules/gdnative/pluginscript/pluginscript_script.h
+++ b/modules/gdnative/pluginscript/pluginscript_script.h
@@ -95,7 +95,7 @@ public:
 	// TODO: load_source_code only allow utf-8 file, should handle bytecode as well ?
 	virtual Error load_source_code(const String &p_path);
 
-	virtual bool has_method(const StringName &p_method) const;
+	virtual bool defines_method(const StringName &p_method) const;
 	virtual MethodInfo get_method_info(const StringName &p_method) const;
 
 	bool has_property(const StringName &p_method) const;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -268,7 +268,7 @@ void GDScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-bool GDScript::has_method(const StringName &p_method) const {
+bool GDScript::defines_method(const StringName &p_method) const {
 
 	return member_functions.has(p_method);
 }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -190,7 +190,7 @@ public:
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const;
 
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const;
-	virtual bool has_method(const StringName &p_method) const;
+	virtual bool defines_method(const StringName &p_method) const;
 	virtual MethodInfo get_method_info(const StringName &p_method) const;
 
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1235,7 +1235,7 @@ static bool _guess_identifier_type(const GDScriptCompletionContext &p_context, c
 			switch (base_type.kind) {
 				case GDScriptParser::DataType::GDSCRIPT: {
 					Ref<GDScript> gds = base_type.script_type;
-					if (gds.is_valid() && gds->has_method(p_context.function->name)) {
+					if (gds.is_valid() && gds->defines_method(p_context.function->name)) {
 						GDScriptFunction *func = gds->get_member_functions()[p_context.function->name];
 						if (func) {
 							for (int i = 0; i < func->get_argument_count(); i++) {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2393,7 +2393,7 @@ void CSharpScript::set_source_code(const String &p_code) {
 #endif
 }
 
-bool CSharpScript::has_method(const StringName &p_method) const {
+bool CSharpScript::defines_method(const StringName &p_method) const {
 
 	if (!script_class)
 		return false;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -162,7 +162,7 @@ public:
 	virtual ScriptLanguage *get_language() const;
 
 	/* TODO */ virtual void get_script_method_list(List<MethodInfo> *p_list) const {}
-	bool has_method(const StringName &p_method) const;
+	bool defines_method(const StringName &p_method) const;
 	/* TODO */ MethodInfo get_method_info(const StringName &p_method) const { return MethodInfo(); }
 
 	virtual int get_member_line(const StringName &p_member) const;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1038,7 +1038,7 @@ void VisualScript::get_script_method_list(List<MethodInfo> *p_list) const {
 	}
 }
 
-bool VisualScript::has_method(const StringName &p_method) const {
+bool VisualScript::defines_method(const StringName &p_method) const {
 
 	return functions.has(p_method);
 }

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -349,7 +349,7 @@ public:
 	virtual bool get_property_default_value(const StringName &p_property, Variant &r_value) const;
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const;
 
-	virtual bool has_method(const StringName &p_method) const;
+	virtual bool defines_method(const StringName &p_method) const;
 	virtual MethodInfo get_method_info(const StringName &p_method) const;
 
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -422,7 +422,7 @@ void VisualScriptFunctionCall::_update_method_cache() {
 				use_default_args++;
 			}
 		}
-	} else if (script.is_valid() && script->has_method(function)) {
+	} else if (script.is_valid() && script->defines_method(function)) {
 
 		method_cache = script->get_method_info(function);
 		use_default_args = method_cache.default_arguments.size();

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2686,7 +2686,7 @@ int VisualScriptSubCall::get_input_value_port_count() const {
 
 	Ref<Script> script = get_script();
 
-	if (script.is_valid() && script->has_method(VisualScriptLanguage::singleton->_subcall)) {
+	if (script.is_valid() && script->defines_method(VisualScriptLanguage::singleton->_subcall)) {
 
 		MethodInfo mi = script->get_method_info(VisualScriptLanguage::singleton->_subcall);
 		return mi.arguments.size();
@@ -2707,7 +2707,7 @@ String VisualScriptSubCall::get_output_sequence_port_text(int p_port) const {
 PropertyInfo VisualScriptSubCall::get_input_value_port_info(int p_idx) const {
 
 	Ref<Script> script = get_script();
-	if (script.is_valid() && script->has_method(VisualScriptLanguage::singleton->_subcall)) {
+	if (script.is_valid() && script->defines_method(VisualScriptLanguage::singleton->_subcall)) {
 
 		MethodInfo mi = script->get_method_info(VisualScriptLanguage::singleton->_subcall);
 		return mi.arguments[p_idx];
@@ -2719,7 +2719,7 @@ PropertyInfo VisualScriptSubCall::get_input_value_port_info(int p_idx) const {
 PropertyInfo VisualScriptSubCall::get_output_value_port_info(int p_idx) const {
 
 	Ref<Script> script = get_script();
-	if (script.is_valid() && script->has_method(VisualScriptLanguage::singleton->_subcall)) {
+	if (script.is_valid() && script->defines_method(VisualScriptLanguage::singleton->_subcall)) {
 		MethodInfo mi = script->get_method_info(VisualScriptLanguage::singleton->_subcall);
 		return mi.return_val;
 	}
@@ -2775,7 +2775,7 @@ VisualScriptNodeInstance *VisualScriptSubCall::instance(VisualScriptInstance *p_
 	VisualScriptNodeInstanceSubCall *instance = memnew(VisualScriptNodeInstanceSubCall);
 	instance->instance = p_instance;
 	Ref<Script> script = get_script();
-	if (script.is_valid() && script->has_method(VisualScriptLanguage::singleton->_subcall)) {
+	if (script.is_valid() && script->defines_method(VisualScriptLanguage::singleton->_subcall)) {
 		instance->valid = true;
 		instance->input_args = get_input_value_port_count();
 	} else {


### PR DESCRIPTION
Closes #22838

- Renamed Script::has_method to Script::defines_method
- Object::has_method gets overridden by new Script::has_method if called on a Script.