### PR TITLE
Do not make a function that returns Variant::NIL a void function. Fix #22791

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -6709,9 +6709,15 @@ GDScriptParser::DataType GDScriptParser::_reduce_function_call_type(const Operat
 					}
 				}
 
+				bool rets = false;
 				return_type.has_type = true;
 				return_type.kind = DataType::BUILTIN;
-				return_type.builtin_type = Variant::get_method_return_type(base_type.builtin_type, callee_name);
+				return_type.builtin_type = Variant::get_method_return_type(base_type.builtin_type, callee_name, &rets);
+				// If the method returns, but it might return any type, (Variant::NIL), pretend we don't know the type.
+				// At least make sure we know that it returns
+				if (rets && return_type.builtin_type == Variant::NIL) {
+					return_type.has_type = false;
+				}
 				break;
 			}
 


### PR DESCRIPTION
A problem with how built-ins are defined is that when they can return any Variant/anything, their return type is specified as `Variant::NIL`, this confuses the parser and it then thinks of said functions as void functions, see #22791.

This PR keeps track of when a built-in returns but returns `Variant::NIL` and then forgets about the fact that it returns `Variant::NIL`, and thus doesn't consider it a void function, which it is not.

Not sure if this concrete fix will not break other things, but something like this is necessary for methods like `Array.front()` and so.