### PR TITLE
Implementing get_shape_source for both Collision Objects.

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -203,6 +203,19 @@ Object *CollisionObject2D::shape_owner_get_owner(uint32_t p_owner) const {
 	return shapes[p_owner].owner;
 }
 
+String CollisionObject2D::get_shape_source(uint32_t p_owner) const {
+
+	ERR_FAIL_COND_V(!shapes.has(p_owner), "");
+
+	Node *n = Object::cast_to<Node>(shapes[p_owner].owner);
+
+	if (n == NULL) {
+		return "";
+	}
+
+	return n->get_name();
+}
+
 void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape) {
 
 	ERR_FAIL_COND(!shapes.has(p_owner));
@@ -370,6 +383,7 @@ void CollisionObject2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shape_owner_set_transform", "owner_id", "transform"), &CollisionObject2D::shape_owner_set_transform);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_transform", "owner_id"), &CollisionObject2D::shape_owner_get_transform);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_owner", "owner_id"), &CollisionObject2D::shape_owner_get_owner);
+	ClassDB::bind_method(D_METHOD("get_shape_source", "owner_id"), &CollisionObject2D::get_shape_source);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_disabled", "owner_id", "disabled"), &CollisionObject2D::shape_owner_set_disabled);
 	ClassDB::bind_method(D_METHOD("is_shape_owner_disabled", "owner_id"), &CollisionObject2D::is_shape_owner_disabled);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_one_way_collision", "owner_id", "enable"), &CollisionObject2D::shape_owner_set_one_way_collision);

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -91,6 +91,7 @@ public:
 	void shape_owner_set_transform(uint32_t p_owner, const Transform2D &p_transform);
 	Transform2D shape_owner_get_transform(uint32_t p_owner) const;
 	Object *shape_owner_get_owner(uint32_t p_owner) const;
+	String get_shape_source(uint32_t p_owner) const;
 
 	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
 	bool is_shape_owner_disabled(uint32_t p_owner) const;

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -136,6 +136,7 @@ void CollisionObject::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shape_owner_set_transform", "owner_id", "transform"), &CollisionObject::shape_owner_set_transform);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_transform", "owner_id"), &CollisionObject::shape_owner_get_transform);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_owner", "owner_id"), &CollisionObject::shape_owner_get_owner);
+	ClassDB::bind_method(D_METHOD("get_shape_source", "owner_id"), &CollisionObject::get_shape_source);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_disabled", "owner_id", "disabled"), &CollisionObject::shape_owner_set_disabled);
 	ClassDB::bind_method(D_METHOD("is_shape_owner_disabled", "owner_id"), &CollisionObject::is_shape_owner_disabled);
 	ClassDB::bind_method(D_METHOD("shape_owner_add_shape", "owner_id", "shape"), &CollisionObject::shape_owner_add_shape);
@@ -247,6 +248,19 @@ Object *CollisionObject::shape_owner_get_owner(uint32_t p_owner) const {
 	ERR_FAIL_COND_V(!shapes.has(p_owner), NULL);
 
 	return shapes[p_owner].owner;
+}
+
+String CollisionObject::get_shape_source(uint32_t p_owner) const {
+
+	ERR_FAIL_COND_V(!shapes.has(p_owner), "");
+
+	Node *n = Object::cast_to<Node>(shapes[p_owner].owner);
+
+	if (n == NULL) {
+		return "";
+	}
+
+	return n->get_name();
 }
 
 void CollisionObject::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape> &p_shape) {

--- a/scene/3d/collision_object.h
+++ b/scene/3d/collision_object.h
@@ -88,6 +88,7 @@ public:
 	void shape_owner_set_transform(uint32_t p_owner, const Transform &p_transform);
 	Transform shape_owner_get_transform(uint32_t p_owner) const;
 	Object *shape_owner_get_owner(uint32_t p_owner) const;
+	String get_shape_source(uint32_t p_owner) const;
 
 	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
 	bool is_shape_owner_disabled(uint32_t p_owner) const;


### PR DESCRIPTION
Is this what's been requested for issue #2089 ? Also is this still requested? And couldn't it already be accessed via shape_owner_get_owner(i).name?

Please feel free to decline this if I misunderstood horribly (like I feel I might, because this seems too simple to have been on hold for 3 years), it just seemed better to discuss it over the code than the issue.