### PR TITLE
Fix AudioEffectRecord not working without thread support

### DIFF
--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -62,14 +62,18 @@ class AudioEffectRecordInstance : public AudioEffectInstance {
 	void _io_store_buffer();
 	static void _thread_callback(void *_instance);
 	void _init_recording();
+	void _update_buffer();
+	static void _update(void *userdata);
 
 public:
 	void init();
+	void finish();
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count);
 	virtual bool process_silence() const;
 
 	AudioEffectRecordInstance() :
 			thread_active(false) {}
+	~AudioEffectRecordInstance();
 };
 
 class AudioEffectRecord : public AudioEffect {

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1004,6 +1004,11 @@ void AudioServer::update() {
 	AudioDriver::get_singleton()->reset_profiling_time();
 	prof_time = 0;
 #endif
+
+	for (Set<CallbackItem>::Element *E = update_callbacks.front(); E; E = E->next()) {
+
+		E->get().callback(E->get().userdata);
+	}
 }
 
 void AudioServer::load_default_bus_layout() {
@@ -1126,6 +1131,25 @@ void AudioServer::remove_callback(AudioCallback p_callback, void *p_userdata) {
 	ci.callback = p_callback;
 	ci.userdata = p_userdata;
 	callbacks.erase(ci);
+	unlock();
+}
+
+void AudioServer::add_update_callback(AudioCallback p_callback, void *p_userdata) {
+	lock();
+	CallbackItem ci;
+	ci.callback = p_callback;
+	ci.userdata = p_userdata;
+	update_callbacks.insert(ci);
+	unlock();
+}
+
+void AudioServer::remove_update_callback(AudioCallback p_callback, void *p_userdata) {
+
+	lock();
+	CallbackItem ci;
+	ci.callback = p_callback;
+	ci.userdata = p_userdata;
+	update_callbacks.erase(ci);
 	unlock();
 }
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -262,6 +262,7 @@ private:
 	};
 
 	Set<CallbackItem> callbacks;
+	Set<CallbackItem> update_callbacks;
 
 	friend class AudioDriver;
 	void _driver_process(int p_frames, int32_t *p_buffer);
@@ -356,6 +357,9 @@ public:
 
 	void add_callback(AudioCallback p_callback, void *p_userdata);
 	void remove_callback(AudioCallback p_callback, void *p_userdata);
+
+	void add_update_callback(AudioCallback p_callback, void *p_userdata);
+	void remove_update_callback(AudioCallback p_callback, void *p_userdata);
 
 	void set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout);
 	Ref<AudioBusLayout> generate_bus_layout() const;


### PR DESCRIPTION
This allows the AudioEffectRecord to work even without thread support on the platform. Currently on the javascript platform this effect doesn't works, this PR fixes this problem.