### PR TITLE
Fixes resources name not showing in the inspector

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2380,7 +2380,7 @@ void EditorPropertyResource::update_property() {
 		if (res->get_name() != String()) {
 			assign->set_text(res->get_name());
 		} else if (res->get_path().is_resource_file()) {
-			assign->set_text(res->get_name());
+			assign->set_text(res->get_path().get_file());
 			assign->set_tooltip(res->get_path());
 		} else {
 			assign->set_text(res->get_class());


### PR DESCRIPTION
Closes #22919 

The shader here is a resource file:
![2018-10-11-111125_486x148_scrot](https://user-images.githubusercontent.com/6093119/46793610-776f7c80-cd46-11e8-84fe-b20da60ac135.png)
