### PR TITLE
Fixed non-monitorable areas triggering overlap (reopened)

### DIFF
--- a/servers/physics_2d/area_pair_2d_sw.cpp
+++ b/servers/physics_2d/area_pair_2d_sw.cpp
@@ -147,10 +147,10 @@ Area2Pair2DSW::~Area2Pair2DSW() {
 
 	if (colliding) {
 
-		if (area_b->has_area_monitor_callback() && area_a->is_monitorable())
+		if (area_b->has_area_monitor_callback())
 			area_b->remove_area_from_query(area_a, shape_a, shape_b);
 
-		if (area_a->has_area_monitor_callback() && area_b->is_monitorable())
+		if (area_a->has_area_monitor_callback())
 			area_a->remove_area_from_query(area_b, shape_b, shape_a);
 	}
 


### PR DESCRIPTION
Non-monitorable areas are never removed from the monitor query of other areas. This makes areas that turn not
monitorable while overlapping with other areas get stuck in the other areas' monitor query and trigger false
overlaps.

This is a  fix for issue #9148.