### PR TITLE
TileSetEditor: Don't crash when adding invalid files

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -569,6 +569,10 @@ void TileSetEditor::_on_textures_added(const PoolStringArray &p_paths) {
 	int invalid_count = 0;
 	for (int i = 0; i < p_paths.size(); i++) {
 		Ref<Texture> t = Ref<Texture>(ResourceLoader::load(p_paths[i]));
+
+		ERR_EXPLAIN("'" + p_paths[i] + "' is not a valid texture.");
+		ERR_CONTINUE(!t.is_valid());
+
 		if (texture_map.has(t->get_rid())) {
 			invalid_count++;
 		} else {
@@ -577,9 +581,13 @@ void TileSetEditor::_on_textures_added(const PoolStringArray &p_paths) {
 			texture_list->set_item_metadata(texture_list->get_item_count() - 1, t->get_rid());
 		}
 	}
-	update_texture_list_icon();
-	texture_list->select(texture_list->get_item_count() - 1);
-	_on_texture_list_selected(texture_list->get_item_count() - 1);
+
+	if (texture_list->get_item_count() > 0) {
+		update_texture_list_icon();
+		texture_list->select(texture_list->get_item_count() - 1);
+		_on_texture_list_selected(texture_list->get_item_count() - 1);
+	}
+
 	if (invalid_count > 0) {
 		err_dialog->set_text(vformat(TTR("%s file(s) were not added because was already on the list."), String::num(invalid_count, 0)));
 		err_dialog->popup_centered(Size2(300, 60));


### PR DESCRIPTION
Fixes #22930.