### PR TITLE
Better buffering for WebSocket

### DIFF
--- a/core/ring_buffer.h
+++ b/core/ring_buffer.h
@@ -135,6 +135,12 @@ public:
 		return p_n;
 	};
 
+	inline int decrease_write(int p_n) {
+		p_n = MIN(p_n, data_left());
+		inc(write_pos, size_mask + 1 - p_n);
+		return p_n;
+	}
+
 	Error write(const T &p_v) {
 		ERR_FAIL_COND_V(space_left() < 1, FAILED);
 		data.write[inc(write_pos, 1)] = p_v;

--- a/modules/websocket/emws_client.h
+++ b/modules/websocket/emws_client.h
@@ -41,6 +41,8 @@ class EMWSClient : public WebSocketClient {
 	GDCIIMPL(EMWSClient, WebSocketClient);
 
 private:
+	int _in_buf_size;
+	int _in_pkt_size;
 	int _js_id;
 
 public:
@@ -52,6 +54,7 @@ public:
 	IP_Address get_connected_host() const;
 	uint16_t get_connected_port() const;
 	virtual ConnectionStatus get_connection_status() const;
+	int get_max_packet_size() const;
 	virtual void poll();
 	EMWSClient();
 	~EMWSClient();

--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -32,11 +32,11 @@
 #include "emws_peer.h"
 #include "core/io/ip.h"
 
-void EMWSPeer::set_sock(int p_sock) {
+void EMWSPeer::set_sock(int p_sock, unsigned int p_in_buf_size, unsigned int p_in_pkt_size) {
 
 	peer_sock = p_sock;
-	in_buffer.clear();
-	queue_count = 0;
+	_in_buffer.resize(p_in_pkt_size, p_in_buf_size);
+	_packet_buffer.resize((1 << p_in_buf_size));
 }
 
 void EMWSPeer::set_write_mode(WriteMode p_mode) {
@@ -47,18 +47,10 @@ EMWSPeer::WriteMode EMWSPeer::get_write_mode() const {
 	return write_mode;
 }
 
-void EMWSPeer::read_msg(uint8_t *p_data, uint32_t p_size, bool p_is_string) {
-
-	if (in_buffer.space_left() < p_size + 5) {
-		ERR_EXPLAIN("Buffer full! Dropping data");
-		ERR_FAIL();
-	}
+Error EMWSPeer::read_msg(uint8_t *p_data, uint32_t p_size, bool p_is_string) {
 
 	uint8_t is_string = p_is_string ? 1 : 0;
-	in_buffer.write((uint8_t *)&p_size, 4);
-	in_buffer.write((uint8_t *)&is_string, 1);
-	in_buffer.write(p_data, p_size);
-	queue_count++;
+	return _in_buffer.write_packet(p_data, p_size, &is_string);
 }
 
 Error EMWSPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
@@ -89,40 +81,28 @@ Error EMWSPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 
 Error EMWSPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 
-	if (queue_count == 0)
+	if (_in_buffer.packets_left() == 0)
 		return ERR_UNAVAILABLE;
 
-	uint32_t to_read = 0;
-	uint32_t left = 0;
-	uint8_t is_string = 0;
-	r_buffer_size = 0;
+	PoolVector<uint8_t>::Write rw = _packet_buffer.write();
+	int read = 0;
+	Error err = _in_buffer.read_packet(rw.ptr(), _packet_buffer.size(), &_is_string, read);
+	ERR_FAIL_COND_V(err != OK, err);
 
-	in_buffer.read((uint8_t *)&to_read, 4);
-	--queue_count;
-	left = in_buffer.data_left();
-
-	if (left < to_read + 1) {
-		in_buffer.advance_read(left);
-		return FAILED;
-	}
-
-	in_buffer.read(&is_string, 1);
-	_was_string = is_string == 1;
-	in_buffer.read(packet_buffer, to_read);
-	*r_buffer = packet_buffer;
-	r_buffer_size = to_read;
+	*r_buffer = rw.ptr();
+	r_buffer_size = read;
 
 	return OK;
 };
 
 int EMWSPeer::get_available_packet_count() const {
 
-	return queue_count;
+	return _in_buffer.packets_left();
 };
 
 bool EMWSPeer::was_string_packet() const {
 
-	return _was_string;
+	return _is_string;
 };
 
 bool EMWSPeer::is_connected_to_host() const {
@@ -143,9 +123,9 @@ void EMWSPeer::close(int p_code, String p_reason) {
 		}, peer_sock, p_code, p_reason.utf8().get_data());
 		/* clang-format on */
 	}
+	_is_string = 0;
+	_in_buffer.clear();
 	peer_sock = -1;
-	queue_count = 0;
-	in_buffer.clear();
 };
 
 IP_Address EMWSPeer::get_connected_host() const {
@@ -162,15 +142,12 @@ uint16_t EMWSPeer::get_connected_port() const {
 
 EMWSPeer::EMWSPeer() {
 	peer_sock = -1;
-	queue_count = 0;
-	_was_string = false;
-	in_buffer.resize(16);
 	write_mode = WRITE_MODE_BINARY;
+	close();
 };
 
 EMWSPeer::~EMWSPeer() {
 
-	in_buffer.resize(0);
 	close();
 };
 

--- a/modules/websocket/emws_server.cpp
+++ b/modules/websocket/emws_server.cpp
@@ -74,6 +74,10 @@ void EMWSServer::disconnect_peer(int p_peer_id, int p_code, String p_reason) {
 void EMWSServer::poll() {
 }
 
+int EMWSServer::get_max_packet_size() const {
+	return 0;
+}
+
 EMWSServer::EMWSServer() {
 }
 

--- a/modules/websocket/emws_server.h
+++ b/modules/websocket/emws_server.h
@@ -49,6 +49,7 @@ public:
 	IP_Address get_peer_address(int p_peer_id) const;
 	int get_peer_port(int p_peer_id) const;
 	void disconnect_peer(int p_peer_id, int p_code = 1000, String p_reason = "");
+	int get_max_packet_size() const;
 	virtual void poll();
 	virtual PoolVector<String> get_protocols() const;
 

--- a/modules/websocket/lws_client.cpp
+++ b/modules/websocket/lws_client.cpp
@@ -32,6 +32,7 @@
 #include "lws_client.h"
 #include "core/io/ip.h"
 #include "core/io/stream_peer_ssl.h"
+#include "core/project_settings.h"
 #include "tls/mbedtls/wrapper/include/openssl/ssl.h"
 
 Error LWSClient::connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocols) {
@@ -104,6 +105,10 @@ Error LWSClient::connect_to_host(String p_host, String p_path, uint16_t p_port, 
 	return OK;
 };
 
+int LWSClient::get_max_packet_size() const {
+	return (1 << _out_buf_size) - PROTO_SIZE;
+}
+
 void LWSClient::poll() {
 
 	_lws_poll();
@@ -124,7 +129,7 @@ int LWSClient::_handle_cb(struct lws *wsi, enum lws_callback_reasons reason, voi
 		} break;
 
 		case LWS_CALLBACK_CLIENT_ESTABLISHED:
-			peer->set_wsi(wsi);
+			peer->set_wsi(wsi, _in_buf_size, _in_pkt_size, _out_buf_size, _out_pkt_size);
 			peer_data->peer_id = 0;
 			peer_data->force_close = false;
 			peer_data->clean_close = false;
@@ -207,6 +212,11 @@ uint16_t LWSClient::get_connected_port() const {
 };
 
 LWSClient::LWSClient() {
+	_in_buf_size = nearest_shift((int)GLOBAL_GET(WSC_IN_BUF) - 1) + 10;
+	_in_pkt_size = nearest_shift((int)GLOBAL_GET(WSC_IN_PKT) - 1);
+	_out_buf_size = nearest_shift((int)GLOBAL_GET(WSC_OUT_BUF) - 1) + 10;
+	_out_pkt_size = nearest_shift((int)GLOBAL_GET(WSC_OUT_PKT) - 1);
+
 	context = NULL;
 	_lws_ref = NULL;
 	_peer = Ref<LWSPeer>(memnew(LWSPeer));

--- a/modules/websocket/lws_client.h
+++ b/modules/websocket/lws_client.h
@@ -43,8 +43,15 @@ class LWSClient : public WebSocketClient {
 
 	LWS_HELPER(LWSClient);
 
+private:
+	int _in_buf_size;
+	int _in_pkt_size;
+	int _out_buf_size;
+	int _out_pkt_size;
+
 public:
 	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocol = PoolVector<String>());
+	int get_max_packet_size() const;
 	Ref<WebSocketPeer> get_peer(int p_peer_id) const;
 	void disconnect_from_host(int p_code = 1000, String p_reason = "");
 	IP_Address get_connected_host() const;

--- a/modules/websocket/lws_server.h
+++ b/modules/websocket/lws_server.h
@@ -45,11 +45,16 @@ class LWSServer : public WebSocketServer {
 
 private:
 	Map<int, Ref<LWSPeer> > peer_map;
+	int _in_buf_size;
+	int _in_pkt_size;
+	int _out_buf_size;
+	int _out_pkt_size;
 
 public:
 	Error listen(int p_port, PoolVector<String> p_protocols = PoolVector<String>(), bool gd_mp_api = false);
 	void stop();
 	bool is_listening() const;
+	int get_max_packet_size() const;
 	bool has_peer(int p_id) const;
 	Ref<WebSocketPeer> get_peer(int p_id) const;
 	IP_Address get_peer_address(int p_peer_id) const;

--- a/modules/websocket/packet_buffer.h
+++ b/modules/websocket/packet_buffer.h
@@ -1,0 +1,122 @@
+/*************************************************************************/
+/*  packet_buffer.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PACKET_BUFFER_H
+#define PACKET_BUFFER_H
+
+#include "core/os/copymem.h"
+#include "core/ring_buffer.h"
+
+template <class T>
+class PacketBuffer {
+
+private:
+	typedef struct {
+		uint32_t size;
+		T info;
+	} _Packet;
+
+	RingBuffer<_Packet> _packets;
+	RingBuffer<uint8_t> _payload;
+
+public:
+	Error write_packet(const uint8_t *p_payload, uint32_t p_size, const T *p_info) {
+#ifdef TOOLS_ENABLED
+		// Verbose buffer warnings
+		if (p_payload && _payload.space_left() < p_size) {
+			ERR_PRINT("Buffer payload full! Dropping data.");
+			ERR_FAIL_V(ERR_OUT_OF_MEMORY);
+		}
+		if (p_info && _packets.space_left() < 1) {
+			ERR_PRINT("Too many packets in queue! Dropping data.");
+			ERR_FAIL_V(ERR_OUT_OF_MEMORY);
+		}
+#else
+		ERR_FAIL_COND_V(p_payload && _payload.space_left() < p_size, ERR_OUT_OF_MEMORY);
+		ERR_FAIL_COND_V(p_info && _packets.space_left() < 1, ERR_OUT_OF_MEMORY);
+#endif
+
+		// If p_info is NULL, only the payload is written
+		if (p_info) {
+			_Packet p;
+			p.size = p_size;
+			copymem(&p.info, p_info, sizeof(T));
+			_packets.write(p);
+		}
+
+		// If p_payload is NULL, only the packet information is written.
+		if (p_payload) {
+			_payload.write((const uint8_t *)p_payload, p_size);
+		}
+
+		return OK;
+	}
+
+	Error read_packet(uint8_t *r_payload, int p_bytes, T *r_info, int &r_read) {
+		ERR_FAIL_COND_V(_packets.data_left() < 1, ERR_UNAVAILABLE);
+		_Packet p;
+		_packets.read(&p, 1);
+		ERR_FAIL_COND_V(_payload.data_left() < p.size, ERR_BUG);
+		ERR_FAIL_COND_V(p_bytes < p.size, ERR_OUT_OF_MEMORY);
+
+		r_read = p.size;
+		copymem(r_info, &p.info, sizeof(T));
+		_payload.read(r_payload, p.size);
+		return OK;
+	}
+
+	void discard_payload(int p_size) {
+		_packets.decrease_write(p_size);
+	}
+
+	void resize(int p_pkt_shift, int p_buf_shift) {
+		_packets.resize(p_pkt_shift);
+		_payload.resize(p_buf_shift);
+	}
+
+	int packets_left() const {
+		return _packets.data_left();
+	}
+
+	void clear() {
+		_payload.resize(0);
+		_packets.resize(0);
+	}
+
+	PacketBuffer() {
+		clear();
+	}
+
+	~PacketBuffer() {
+		clear();
+	}
+};
+
+#endif // PACKET_BUFFER_H

--- a/modules/websocket/register_types.cpp
+++ b/modules/websocket/register_types.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "register_types.h"
 #include "core/error_macros.h"
+#include "core/project_settings.h"
 #ifdef JAVASCRIPT_ENABLED
 #include "emscripten.h"
 #include "emws_client.h"
@@ -41,6 +42,22 @@
 #endif
 
 void register_websocket_types() {
+#define _SET_HINT(NAME, _VAL_, _MAX_) \
+	GLOBAL_DEF(NAME, _VAL_);          \
+	ProjectSettings::get_singleton()->set_custom_property_info(NAME, PropertyInfo(Variant::INT, NAME, PROPERTY_HINT_RANGE, "2," #_MAX_ ",1,or_greater"));
+
+	// Client buffers project settings
+	_SET_HINT(WSC_IN_BUF, 64, 4096);
+	_SET_HINT(WSC_IN_PKT, 1024, 16384);
+	_SET_HINT(WSC_OUT_BUF, 64, 4096);
+	_SET_HINT(WSC_OUT_PKT, 1024, 16384);
+
+	// Server buffers project settings
+	_SET_HINT(WSS_IN_BUF, 64, 4096);
+	_SET_HINT(WSS_IN_PKT, 1024, 16384);
+	_SET_HINT(WSS_OUT_BUF, 64, 4096);
+	_SET_HINT(WSS_OUT_PKT, 1024, 16384);
+
 #ifdef JAVASCRIPT_ENABLED
 	EM_ASM({
 		var IDHandler = {};

--- a/modules/websocket/websocket_macros.h
+++ b/modules/websocket/websocket_macros.h
@@ -30,6 +30,16 @@
 #ifndef WEBSOCKETMACTOS_H
 #define WEBSOCKETMACTOS_H
 
+#define WSC_IN_BUF "network/limits/websocket_client/max_in_buffer_kb"
+#define WSC_IN_PKT "network/limits/websocket_client/max_in_packets"
+#define WSC_OUT_BUF "network/limits/websocket_client/max_out_buffer_kb"
+#define WSC_OUT_PKT "network/limits/websocket_client/max_out_packets"
+
+#define WSS_IN_BUF "network/limits/websocket_server/max_in_buffer_kb"
+#define WSS_IN_PKT "network/limits/websocket_server/max_in_packets"
+#define WSS_OUT_BUF "network/limits/websocket_server/max_out_buffer_kb"
+#define WSS_OUT_PKT "network/limits/websocket_server/max_out_packets"
+
 /* clang-format off */
 #define GDCICLASS(CNAME) \
 public:\

--- a/modules/websocket/websocket_multiplayer.cpp
+++ b/modules/websocket/websocket_multiplayer.cpp
@@ -100,13 +100,6 @@ int WebSocketMultiplayerPeer::get_available_packet_count() const {
 	return _incoming_packets.size();
 }
 
-int WebSocketMultiplayerPeer::get_max_packet_size() const {
-
-	ERR_FAIL_COND_V(!_is_multiplayer, ERR_UNCONFIGURED);
-
-	return MAX_PACKET_SIZE;
-}
-
 Error WebSocketMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 
 	r_buffer_size = 0;

--- a/modules/websocket/websocket_multiplayer.h
+++ b/modules/websocket/websocket_multiplayer.h
@@ -51,9 +51,7 @@ protected:
 		SYS_DEL = 2,
 		SYS_ID = 3,
 
-		PROTO_SIZE = 9,
-		SYS_PACKET_SIZE = 13,
-		MAX_PACKET_SIZE = 65536 - 14 // 5 websocket, 9 multiplayer
+		PROTO_SIZE = 9
 	};
 
 	struct Packet {
@@ -93,7 +91,7 @@ public:
 
 	/* PacketPeer */
 	virtual int get_available_packet_count() const;
-	virtual int get_max_packet_size() const;
+	virtual int get_max_packet_size() const = 0;
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size);
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size);
 

--- a/modules/websocket/websocket_peer.h
+++ b/modules/websocket/websocket_peer.h
@@ -32,7 +32,6 @@
 
 #include "core/error_list.h"
 #include "core/io/packet_peer.h"
-#include "core/ring_buffer.h"
 #include "websocket_macros.h"
 
 class WebSocketPeer : public PacketPeer {


### PR DESCRIPTION
After a lots of thoughts, I still can't help myself thinking changing PacketPeerUDP and adding PacketBuffer to core was too excessive, so unless more things come up that needs it, it will stay in the websocket module instead.

In this PR:
- Added `RingBuffer::decrease_write` to allow "discarding" the latest written bytes.
- Add new `PacketBuffer` class, in websocket module, to simplify buffer handling (originally, this was moved to `core/` and `PacketPeerUDP` used it too, but maybe that's a matter for another PR if this proves to be the right decision).
- Add ProjectSettings options to define input and output buffer sizes, and packets limits for WebSocketClient and WebSocketServer (note, `WebSocketClient` output buffer is unused in HTML5, and fully depend on the browser implementation, which is usually up to 2gb).
  Defaults: `packets = 1024` `buffer = 64 KiB`. Server buffers are intended *per peer*.

![buffers2](https://user-images.githubusercontent.com/1687918/48377630-a3c44300-e6ce-11e8-853b-09b28f631695.png)


Fixes #22496
