### PR TITLE
Crash when trying to add a wrong file format as a texture to the tileset editor #22930

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -569,12 +569,16 @@ void TileSetEditor::_on_textures_added(const PoolStringArray &p_paths) {
 	int invalid_count = 0;
 	for (int i = 0; i < p_paths.size(); i++) {
 		Ref<Texture> t = Ref<Texture>(ResourceLoader::load(p_paths[i]));
-		if (texture_map.has(t->get_rid())) {
-			invalid_count++;
+		if (t != NULL) {
+			if (texture_map.has(t->get_rid())) {
+				invalid_count++;
+			} else {
+				texture_list->add_item(t->get_path().get_file());
+				texture_map.insert(t->get_rid(), t);
+				texture_list->set_item_metadata(texture_list->get_item_count() - 1, t->get_rid());
+			}
 		} else {
-			texture_list->add_item(t->get_path().get_file());
-			texture_map.insert(t->get_rid(), t);
-			texture_list->set_item_metadata(texture_list->get_item_count() - 1, t->get_rid());
+			invalid_count++;
 		}
 	}
 	update_texture_list_icon();


### PR DESCRIPTION


Fixes the crash if an wrong file was added as texture.