### PR TITLE
Fix emitting ScrollContainer scroll_started and scroll_ended signals

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -122,8 +122,8 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 		}
 
-		if (!OS::get_singleton()->has_touchscreen_ui_hint())
-			return;
+		/*if (!OS::get_singleton()->has_touchscreen_ui_hint())
+			return;*/
 
 		if (mb->get_button_index() != BUTTON_LEFT)
 			return;
@@ -139,7 +139,7 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				drag_accum = Vector2();
 				last_drag_accum = Vector2();
 				drag_from = Vector2(h_scroll->get_value(), v_scroll->get_value());
-				drag_touching = OS::get_singleton()->has_touchscreen_ui_hint();
+				drag_touching = true;
 				drag_touching_deaccel = false;
 				beyond_deadzone = false;
 				time_since_motion = 0;
@@ -537,6 +537,8 @@ ScrollContainer::ScrollContainer() {
 
 	h_scroll->connect("value_changed", this, "_scroll_moved");
 	v_scroll->connect("value_changed", this, "_scroll_moved");
+	h_scroll->connect("gui_input", this, "_gui_input");
+	v_scroll->connect("gui_input", this, "_gui_input");
 
 	drag_speed = Vector2();
 	drag_touching = false;


### PR DESCRIPTION
Would like to hear feedback. It works now, but i am not sure about the drag_touching parts.

problem was that _gui_input did not get called if the scrollbars are used. On top of that touch by mouse emulation has to be active to even come to the signal part.

*Bugsquad edit:* Fixes #22936.