### PR TITLE
Fixed the problem with vector3 constructor

### DIFF
--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -48,20 +48,22 @@ bool VisualScriptNode::is_breakpoint() const {
 void VisualScriptNode::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_POSTINITIALIZE) {
+		_update_input_ports();
+	}
+}
 
-		int dvc = get_input_value_port_count();
-		for (int i = 0; i < dvc; i++) {
-			Variant::Type expected = get_input_value_port_info(i).type;
-			Variant::CallError ce;
-			default_input_values.push_back(Variant::construct(expected, NULL, 0, ce, false));
-		}
+void VisualScriptNode::_update_input_ports() {
+	default_input_values.resize(MAX(default_input_values.size(), get_input_value_port_count())); //let it grow as big as possible, we don't want to lose values on resize
+	int port_count = get_input_value_port_count();
+	for (int i = 0; i < port_count; i++) {
+		Variant::Type expected = get_input_value_port_info(i).type;
+		Variant::CallError ce;
+		set_default_input_value(i, Variant::construct(expected, NULL, 0, ce, false));
 	}
 }
 
 void VisualScriptNode::ports_changed_notify() {
-
-	default_input_values.resize(MAX(default_input_values.size(), get_input_value_port_count())); //let it grow as big as possible, we don't want to lose values on resize
-
+	_update_input_ports();
 	emit_signal("ports_changed");
 }
 

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -52,6 +52,7 @@ class VisualScriptNode : public Resource {
 	Array _get_default_input_values() const;
 
 	void validate_input_default_values();
+	void _update_input_ports();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Whenever there's a port change that may change the inputs, the default inputs will be recalculated.

Moving the update port loop into its own function.

Replacement of #22542 since there has been no movement on the issue.

@akien-mga 