### PR TITLE
fix bug #20255 on CSGMesh

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -521,6 +521,11 @@ CSGBrush *CSGMesh::_build_brush() {
 
 		Array arrays = mesh->surface_get_arrays(i);
 
+		if (arrays.size() == 0) {
+			_make_dirty();
+			ERR_FAIL_COND_V(arrays.size() == 0, NULL);
+		}
+
 		PoolVector<Vector3> avertices = arrays[Mesh::ARRAY_VERTEX];
 		if (avertices.size() == 0)
 			continue;


### PR DESCRIPTION
The problem was that a call to mesh->surface_get_arrays(i) was made before a call to RasterizerStorageGLES3::mesh_add_surface was executed from visual server queue. This resulted in an empty array and a crash. I added a fail condition that call _make_dirty() and return NULL.

*Bugsquad edit:* Fixes #20255.