### PR TITLE
Fixed issues with audio input on some Macs

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -43,6 +43,7 @@
 class AudioDriverCoreAudio : public AudioDriver {
 
 	AudioComponentInstance audio_unit;
+	AudioComponentInstance input_unit;
 
 	bool active;
 	Mutex *mutex;
@@ -82,6 +83,9 @@ class AudioDriverCoreAudio : public AudioDriver {
 			const AudioTimeStamp *inTimeStamp,
 			UInt32 inBusNumber, UInt32 inNumberFrames,
 			AudioBufferList *ioData);
+
+	Error capture_init();
+	void capture_finish();
 
 public:
 	const char *get_name() const {


### PR DESCRIPTION
I've recently found that the current CoreAudio input code wasn't usually working on Macs. This PR fixes the problem by splitting the use of the AudioUnits.