### PR TITLE
Make "Perspective" button look like a actual clickable button

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -192,7 +192,7 @@ private:
 	EditorSelection *editor_selection;
 	UndoRedo *undo_redo;
 
-	Button *preview_camera;
+	CheckBox *preview_camera;
 	ViewportContainer *viewport_container;
 
 	MenuButton *view_menu;
@@ -211,6 +211,7 @@ private:
 	Label *info_label;
 	Label *fps_label;
 	Label *cinema_label;
+	Label *locked_label;
 
 	struct _RayResult {
 


### PR DESCRIPTION
Currently as it is, the "Perspective" button looks exactly like the rest of info boxes in the Spatial Editor, so I changed to to look like an actual clickable button to avoid confusion.

I also moved the "Camera" button below it, as it makes more sense for the buttons to be on the same corner.