### PR TITLE
Better error message for malformed plugins

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2551,6 +2551,12 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled)
 		return;
 	}
 
+	//errors in the script cause the base_type to be ""
+	if (String(script->get_instance_base_type()) == "") {
+		show_warning(vformat(TTR("Unable to load addon script from path: '%s' There seems to be an error in the code, please check the syntax."), path));
+		return;
+	}
+
 	//could check inheritance..
 	if (String(script->get_instance_base_type()) != "EditorPlugin") {
 		show_warning(vformat(TTR("Unable to load addon script from path: '%s' Base type is not EditorPlugin."), path));


### PR DESCRIPTION
Errors in the plugin script results (typos, syntax errors, etc.) result in the following error message:

`Base type is not EditorPlugin`

which might confusing for users. One could assume that this error is a result of a mistake/error in the `extends EditorPlugin` statement although the error is caused by something different.
With this PR different error messages are presented to the user.

Here are some examples of users getting this error message:
https://github.com/godotengine/godot/issues/9286#issuecomment-372023199
https://github.com/godotengine/godot/issues/20661
