### PR TITLE
Added a class for baking navmeshes in tool scripts

### DIFF
--- a/modules/recast/tool_navigation_mesh_generator.cpp
+++ b/modules/recast/tool_navigation_mesh_generator.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  register_types.cpp                                                   */
+/*  tool_navigation_mesh_generator.cpp                                   */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,14 +28,17 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "register_types.h"
-
-#include "navigation_mesh_editor_plugin.h"
 #include "tool_navigation_mesh_generator.h"
 
-void register_recast_types() {
-	EditorPlugins::add_by_type<NavigationMeshEditorPlugin>();
-	ClassDB::register_class<ToolNavigationMeshGenerator>();
+void ToolNavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node) {
+	NavigationMeshGenerator::bake(p_nav_mesh, p_node);
 }
 
-void unregister_recast_types() {}
+void ToolNavigationMeshGenerator::clear(Ref<NavigationMesh> p_nav_mesh) {
+	NavigationMeshGenerator::clear(p_nav_mesh);
+}
+
+void ToolNavigationMeshGenerator::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("bake", "nav_mesh", "mesh_instance"), &ToolNavigationMeshGenerator::bake);
+	ClassDB::bind_method(D_METHOD("clear", "nav_mesh"), &ToolNavigationMeshGenerator::clear);
+}

--- a/modules/recast/tool_navigation_mesh_generator.h
+++ b/modules/recast/tool_navigation_mesh_generator.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  register_types.cpp                                                   */
+/*  tool_navigation_mesh_generator.h                                     */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,14 +28,20 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "register_types.h"
+#ifndef TOOL_NAVIGATION_MESH_GENERATOR_H
+#define TOOL_NAVIGATION_MESH_GENERATOR_H
 
-#include "navigation_mesh_editor_plugin.h"
-#include "tool_navigation_mesh_generator.h"
+#include "core/reference.h"
+#include "navigation_mesh_generator.h"
 
-void register_recast_types() {
-	EditorPlugins::add_by_type<NavigationMeshEditorPlugin>();
-	ClassDB::register_class<ToolNavigationMeshGenerator>();
-}
+class ToolNavigationMeshGenerator : public Reference {
+	GDCLASS(ToolNavigationMeshGenerator, Reference)
+protected:
+	static void _bind_methods();
 
-void unregister_recast_types() {}
+public:
+	void bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node);
+	void clear(Ref<NavigationMesh> p_nav_mesh);
+};
+
+#endif // TOOL_NAVIGATION_MESH_GENERATOR_H


### PR DESCRIPTION
The RuntimeNavigationMeshGenerator works overall, but the module recast depends on the editor so, if it is compiled with tool=no, it will fail to find the class.

I am not sure how to restructure the module itself :(