### PR TITLE
Update autoload references when moving files.

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -185,6 +185,7 @@ void EditorAutoloadSettings::_autoload_edited() {
 		if (path.begins_with("*"))
 			path = path.substr(1, path.length());
 
+		// Singleton autoloads are represented with a leading "*" in their path.
 		if (checked)
 			path = "*" + path;
 
@@ -651,6 +652,7 @@ void EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	undo_redo->create_action(TTR("Add AutoLoad"));
+	// Singleton autoloads are represented with a leading "*" in their path.
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, "*" + path);
 
 	if (ProjectSettings::get_singleton()->has_setting(name)) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1172,6 +1172,23 @@ void FileSystemDock::_update_project_settings_after_move(const Map<String, Strin
 			}
 		};
 	}
+
+	// Also search for the file in autoload, as they are stored differently from normal files.
+	List<PropertyInfo> property_list;
+	ProjectSettings::get_singleton()->get_property_list(&property_list);
+	for (const List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
+		if (E->get().name.begins_with("autoload/")) {
+			// If the autoload resource paths has a leading "*", it indicates that it is a Singleton,
+			// so we have to handle both cases when updating.
+			String autoload = GLOBAL_GET(E->get().name);
+			String autoload_singleton = autoload.substr(1, autoload.length());
+			if (p_renames.has(autoload)) {
+				ProjectSettings::get_singleton()->set_setting(E->get().name, p_renames[autoload]);
+			} else if (autoload.begins_with("*") && p_renames.has(autoload_singleton)) {
+				ProjectSettings::get_singleton()->set_setting(E->get().name, "*" + p_renames[autoload_singleton]);
+			}
+		}
+	}
 	ProjectSettings::get_singleton()->save();
 }
 


### PR DESCRIPTION
Prior to this, file references in autoload were not updated when a
script was moved or renamed. This adds extra logic to update the
autoload references when updating project settings.

Fixes #22995.