### PR TITLE
Track screen drag speed

### DIFF
--- a/main/input_default.h
+++ b/main/input_default.h
@@ -117,6 +117,7 @@ class InputDefault : public Input {
 	};
 
 	SpeedTrack mouse_speed_track;
+	Map<int, SpeedTrack> touch_speed_track;
 	Map<int, Joypad> joy_names;
 	int fallback_mapping;
 


### PR DESCRIPTION
Following the universal input handling effort, this works the same for every platform, as long as the touch move event coming from it contains the relative movement.

The same tracking algorithm used to track the mouse speed is used here, but tracking separately each touch index.

Fixes #3623.