### PR TITLE
Fixed visibility toggle with node selection

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -73,7 +73,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		undo_redo->create_action(TTR("Toggle Visible"));
 		_toggle_visible(n);
 		List<Node *> selection = editor_selection->get_selected_node_list();
-		if (selection.size() > 1) {
+		if (selection.size() > 1 && selection.find(n) != NULL) {
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 				Node *nv = E->get();
 				ERR_FAIL_COND(!nv);


### PR DESCRIPTION
before this PR toggling visibility of not selected nodes would toggle
the visibility of the whole selection.
This PR changes this behaviour, so if visibility is toggled on a node
that it is not selected, the visibility toggle will happen only on this
node.
No changes to the behaviour of when one of the selected nodes has
visibility toggled: they still toggle all together

Fixes #20960