### PR TITLE
Increase the source font's line spacing

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -47,7 +47,9 @@ void EditorAbout::_notification(int p_what) {
 			Control *base = EditorNode::get_singleton()->get_gui_base();
 			Ref<Font> font = base->get_font("source", "EditorFonts");
 			_tpl_text->add_font_override("normal_font", font);
+			_tpl_text->add_constant_override("line_separation", 6 * EDSCALE);
 			_license_text->add_font_override("normal_font", font);
+			_license_text->add_constant_override("line_separation", 6 * EDSCALE);
 			_logo->set_texture(base->get_icon("Logo", "EditorIcons"));
 		} break;
 	}

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -357,7 +357,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/theme/color_theme", "Adaptive");
 	hints["text_editor/theme/color_theme"] = PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, "Adaptive,Default,Custom");
 
-	_initial_set("text_editor/theme/line_spacing", 4);
+	_initial_set("text_editor/theme/line_spacing", 6);
 	_initial_set("text_editor/theme/selection_color", Color::html("40808080"));
 
 	_load_default_text_editor_theme();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -179,7 +179,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	text_edit->add_color_override("search_result_border_color", search_result_border_color);
 	text_edit->add_color_override("symbol_color", symbol_color);
 
-	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 4));
+	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 6));
 
 	colors_cache.symbol_color = symbol_color;
 	colors_cache.keyword_color = keyword_color;

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -131,7 +131,7 @@ void TextEditor::_load_theme_settings() {
 	text_edit->add_color_override("search_result_border_color", search_result_border_color);
 	text_edit->add_color_override("symbol_color", symbol_color);
 
-	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 4));
+	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 6));
 
 	colors_cache.font_color = text_color;
 	colors_cache.symbol_color = symbol_color;


### PR DESCRIPTION
This also increases line spacing in license texts in the editor's About dialog.

**Preview:**

![about_dialog](https://user-images.githubusercontent.com/180032/46921327-3e5f3280-cffa-11e8-9905-6f4d2ecfee39.png)

![script_line_spacing](https://user-images.githubusercontent.com/180032/46921326-3c956f00-cffa-11e8-8a73-7ed9a3564774.png)