### PR TITLE
Fixed initialization of android modules

### DIFF
--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -883,6 +883,8 @@ static void _initialize_java_modules() {
 				ERR_EXPLAIN("Couldn't find proper initialize function 'public static Godot.SingletonBase Class::initialize(Activity p_activity)' initializer for singleton class: " + m);
 				ERR_CONTINUE(!initialize);
 			}
+			jobject obj = env->CallStaticObjectMethod(singletonClass, initialize, _godot_instance);
+			env->NewGlobalRef(obj);
 		}
 	}
 }


### PR DESCRIPTION
Commit d952126caf35fbc58db6976e6cc8be8baba95638 from October 3rd broke the initialization of custom android modules in an attempt to correct compilation warnings. 
This PR fixes that issue