### PR TITLE
Added system for deprecating methods, properties, signals and constants.

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -30,6 +30,7 @@
 
 #include "class_db.h"
 
+#include "core/deprecation_manager.h"
 #include "core/engine.h"
 #include "core/os/mutex.h"
 #include "core/version.h"
@@ -718,7 +719,7 @@ int ClassDB::get_integer_constant(const StringName &p_class, const StringName &p
 
 		int *constant = type->constant_map.getptr(p_name);
 		if (constant) {
-
+			TEST_CONSTANT_DEPRECATED(type->name, p_name);
 			if (p_success)
 				*p_success = true;
 			return *constant;
@@ -746,8 +747,10 @@ StringName ClassDB::get_integer_constant_enum(const StringName &p_class, const S
 
 			List<StringName> &constants_list = type->enum_map.get(*k);
 			const List<StringName>::Element *found = constants_list.find(p_name);
-			if (found)
+			if (found) {
+				TEST_CONSTANT_DEPRECATED(type->name, p_name);
 				return *k;
+			}
 		}
 
 		if (p_no_inheritance)
@@ -996,6 +999,7 @@ bool ClassDB::set_property(Object *p_object, const StringName &p_property, const
 	while (check) {
 		const PropertySetGet *psg = check->property_setget.getptr(p_property);
 		if (psg) {
+			TEST_PROPERTY_DEPRECATED(check->name, p_property);
 
 			if (!psg->setter) {
 				if (r_valid)
@@ -1042,6 +1046,7 @@ bool ClassDB::get_property(Object *p_object, const StringName &p_property, Varia
 	while (check) {
 		const PropertySetGet *psg = check->property_setget.getptr(p_property);
 		if (psg) {
+			TEST_PROPERTY_DEPRECATED(check->name, p_property);
 			if (!psg->getter)
 				return true; //return true but do nothing
 
@@ -1066,7 +1071,7 @@ bool ClassDB::get_property(Object *p_object, const StringName &p_property, Varia
 
 		const int *c = check->constant_map.getptr(p_property);
 		if (c) {
-
+			TEST_CONSTANT_DEPRECATED(check->name, p_property);
 			r_value = *c;
 			return true;
 		}

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -396,7 +396,6 @@ public:
 #else
 
 #define BIND_VMETHOD(m_method)
-
 #endif
 
 #endif // CLASS_DB_H

--- a/core/deprecation_manager.cpp
+++ b/core/deprecation_manager.cpp
@@ -1,0 +1,87 @@
+#include "deprecation_manager.h"
+#include "core/class_db.h"
+
+#ifdef DEBUG_ENABLED
+
+DeprecationInfo::DeprecationInfo() :
+		warned(false),
+		custom_warning("") {
+}
+
+DeprecationInfo::DeprecationInfo(String p_custom_warning) :
+		warned(false),
+		custom_warning(p_custom_warning) {
+}
+
+HashMap<String, DeprecationManager::ClassInfo> DeprecationManager::classes;
+
+void DeprecationManager::warn_deprecated(const StringName &p_name, const StringName &p_type, const DeprecationInfo &p_info) {
+	String warning = "The " + p_type + " '" + p_name + "' has been deprecated and will be removed in the future.";
+
+	if (!p_info.custom_warning.empty())
+		warning = warning + " " + p_info.custom_warning;
+
+	WARN_PRINTS(warning);
+}
+
+void DeprecationManager::deprecate_method(const StringName &p_class, const StringName &p_method, DeprecationInfo p_info) {
+	classes[p_class].deprecated_methods[p_method] = p_info;
+}
+
+void DeprecationManager::deprecate_constant(const StringName &p_class, const StringName &p_constant, DeprecationInfo p_info) {
+	classes[p_class].deprecated_constants[p_constant] = p_info;
+}
+
+void DeprecationManager::deprecate_signal(const StringName &p_class, const StringName &p_signal, DeprecationInfo p_info) {
+	classes[p_class].deprecated_signals[p_signal] = p_info;
+}
+
+void DeprecationManager::deprecate_property(const StringName &p_class, const StringName &p_property, DeprecationInfo p_info) {
+	classes[p_class].deprecated_properties[p_property] = p_info;
+}
+
+void DeprecationManager::test_method_deprecated(const StringName &p_class, const StringName &p_method_name) {
+	if (classes[p_class].deprecated_methods.has(p_method_name)) {
+		DeprecationInfo *info = &classes[p_class].deprecated_properties[p_method_name];
+
+		if (!info->warned) {
+			warn_deprecated(p_method_name, "method", *info);
+			info->warned = true;
+		}
+	}
+}
+
+void DeprecationManager::test_constant_deprecated(const StringName &p_class, const StringName &p_const) {
+	if (classes[p_class].deprecated_constants.has(p_const)) {
+		DeprecationInfo *info = &classes[p_class].deprecated_constants[p_const];
+
+		if (!info->warned) {
+			warn_deprecated(p_const, "constant", *info);
+			info->warned = true;
+		}
+	}
+}
+
+void DeprecationManager::test_property_deprecated(const StringName &p_class, const StringName &p_property) {
+	if (classes[p_class].deprecated_properties.has(p_property)) {
+		DeprecationInfo *info = &classes[p_class].deprecated_properties[p_property];
+
+		if (!info->warned) {
+			warn_deprecated(p_property, "property", *info);
+			info->warned = true;
+		}
+	}
+}
+
+void DeprecationManager::test_signal_deprecated(const StringName &p_class, const StringName &p_signal) {
+	if (classes[p_class].deprecated_signals.has(p_signal)) {
+		DeprecationInfo *info = &classes[p_class].deprecated_signals[p_signal];
+
+		if (!info->warned) {
+			warn_deprecated(p_signal, "signal", *info);
+			info->warned = true;
+		}
+	}
+}
+
+#endif

--- a/core/deprecation_manager.h
+++ b/core/deprecation_manager.h
@@ -1,0 +1,72 @@
+#include "core/hash_map.h"
+#include "core/ustring.h"
+
+#ifndef DEPRECATION_MANAGER_H
+#define DEPRECATION_MANAGER_H
+
+#ifdef DEBUG_ENABLED
+
+struct DeprecationInfo {
+	bool warned;
+	String custom_warning;
+
+	DeprecationInfo();
+	DeprecationInfo(String p_custom_message);
+};
+
+class DeprecationManager {
+	struct ClassInfo {
+		HashMap<String, DeprecationInfo> deprecated_methods;
+		HashMap<String, DeprecationInfo> deprecated_properties;
+		HashMap<String, DeprecationInfo> deprecated_constants;
+		HashMap<String, DeprecationInfo> deprecated_signals;
+	};
+
+	static HashMap<String, ClassInfo> classes;
+	static HashMap<int, DeprecationInfo> deprecated_methods;
+
+public:
+	static void warn_deprecated(const StringName &p_name, const StringName &p_type, const DeprecationInfo &p_info);
+	static void deprecate_method(const StringName &p_class, const StringName &p_method, DeprecationInfo p_info);
+	static void deprecate_property(const StringName &p_class, const StringName &p_property, DeprecationInfo p_info);
+	static void deprecate_constant(const StringName &p_class, const StringName &p_const, DeprecationInfo p_info);
+	static void deprecate_signal(const StringName &p_class, const StringName &p_signal, DeprecationInfo p_info);
+	static void test_method_deprecated(const StringName &p_class, const StringName &p_method_name);
+	static void test_constant_deprecated(const StringName &p_class, const StringName &p_const);
+	static void test_property_deprecated(const StringName &p_class, const StringName &p_property);
+	static void test_signal_deprecated(const StringName &p_class, const StringName &p_signal);
+};
+
+#define DEPRECATE_METHOD(p_method, p_info) \
+	DeprecationManager::deprecate_method(get_class_static(), p_method, p_info);
+#define DEPRECATE_PROPERTY(p_property, p_info) \
+	DeprecationManager::deprecate_property(get_class_static(), p_property, p_info);
+#define DEPRECATE_SIGNAL(p_signal, p_info) \
+	DeprecationManager::deprecate_signal(get_class_static(), p_signal, p_info);
+#define DEPRECATE_CONSTANT(p_const, p_info) \
+	DeprecationManager::deprecate_constant(get_class_static(), #p_const, p_info);
+
+#define TEST_METHOD_DEPRECATED(p_class_name, p_method_name) \
+	DeprecationManager::test_method_deprecated(p_class_name, p_method_name);
+#define TEST_CONSTANT_DEPRECATED(p_class_name, p_const) \
+	DeprecationManager::test_constant_deprecated(p_class_name, p_const);
+#define TEST_SIGNAL_DEPRECATED(p_class_name, p_signal) \
+	DeprecationManager::test_signal_deprecated(p_class_name, p_signal);
+#define TEST_PROPERTY_DEPRECATED(p_class_name, p_property) \
+	DeprecationManager::test_property_deprecated(p_class_name, p_property);
+
+#else
+
+#define DEPRECATE_METHOD(p_method, p_info)
+#define DEPRECATE_PROPERTY(p_property, p_info)
+#define DEPRECATE_SIGNAL(p_signal, p_info)
+#define DEPRECATE_CONSTANT(p_const, p_info)
+
+#define TEST_METHOD_DEPRECATED(p_class_name, p_method_name)
+#define TEST_CONSTANT_DEPRECATED(p_class_name, p_const)
+#define TEST_SIGNAL_DEPRECATED(p_class_name, p_signal)
+#define TEST_PROPERTY_DEPRECATED(p_class_name, p_property)
+
+#endif
+
+#endif // DEPRECATION_MANAGER_H

--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -31,7 +31,8 @@ public:
 		T *instance=Object::cast_to<T>(p_object);
 		r_error.error=Variant::CallError::CALL_OK;
 #ifdef DEBUG_METHODS_ENABLED
-
+		TEST_METHOD_DEPRECATED(get_instance_class(), get_name());
+		
 		ERR_FAIL_COND_V(!instance,Variant());
 		if (p_arg_count>get_argument_count()) {
 			r_error.error=Variant::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
@@ -121,6 +122,8 @@ public:
 		r_error.error=Variant::CallError::CALL_OK;
 #ifdef DEBUG_METHODS_ENABLED
 
+		TEST_METHOD_DEPRECATED(get_instance_class(), get_name());
+        
 		ERR_FAIL_COND_V(!instance,Variant());
 		if (p_arg_count>get_argument_count()) {
 			r_error.error=Variant::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;

--- a/core/method_bind.h
+++ b/core/method_bind.h
@@ -31,11 +31,11 @@
 #ifndef METHOD_BIND_H
 #define METHOD_BIND_H
 
+#include "core/deprecation_manager.h"
 #include "core/list.h"
 #include "core/method_ptrcall.h"
 #include "core/object.h"
 #include "core/variant.h"
-
 #include <stdio.h>
 
 /**

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1473,6 +1473,17 @@ Error Object::connect(const StringName &p_signal, Object *p_to_object, const Str
 			ERR_EXPLAIN("In Object of type '" + String(get_class()) + "': Attempt to connect nonexistent signal '" + p_signal + "' to method '" + p_to_object->get_class() + "." + p_to_method + "'");
 			ERR_FAIL_COND_V(!signal_is_valid, ERR_INVALID_PARAMETER);
 		}
+
+#ifdef DEBUG_METHODS_ENABLED
+		StringName class_name = get_class_name();
+
+		while (class_name != StringName()) {
+			TEST_SIGNAL_DEPRECATED(class_name, p_signal);
+
+			class_name = ClassDB::get_parent_class_nocheck(class_name);
+		}
+#endif
+
 		signal_map[p_signal] = Signal();
 		s = &signal_map[p_signal];
 	}
@@ -1651,7 +1662,8 @@ void Object::_clear_internal_resource_paths(const Variant &p_var) {
 				_clear_internal_resource_paths(d[E->get()]);
 			}
 		} break;
-		default: {}
+		default: {
+		}
 	}
 }
 


### PR DESCRIPTION
_As requested in #4397, I tried to include most suggestions from there._

### Description
This PR will allow methods, properties, signals and constants to be marked as deprecated and show a warning when they are first used.

They are deprecated by using the following macros in the file where the methods/properties/signals/constants are bound:

`DEPRECATE_PROPERTY("property_name", DeprecationInfo())`
`DEPRECATE_METHOD("method_name", DeprecationInfo())`
`DEPRECATE_SIGNAL("signal_name", DeprecationInfo())`
`DEPRECATE_CONSTANT(CONSTANT_NAME, DeprecationInfo())`

The DeprecationInfo struct can be used to set the warning that is shown.
When left empty the default warning will be shown:

`The method method_name has been deprecated and will be removed in the future.`
`The property property_name has been deprecated and will be removed in the future.`
`The signal signal_name has been deprecated and will be removed in the future.`
`The constant CONSTANT_NAME has been deprecated and will be removed in the future.`

The `.replacement` string of DeprecationInfo can be set to indicate which method/property/signal/constant should be used instead.

The warning will become:

`The method method_name has been deprecated and will be removed in the future. Use replacement_method instead.`

The `.removal_version` string of DeprecationInfo can be set to indicate which version it will be removed entirely, it will replace the vague `in the future` in the warning message. This can be used in conjunction with the `.replacement` string.

If a totally custom warning is needed the `.custom_warning` of DeprecationInfo can be used and that warning will replace the default warning.

This functionality is only present is only present in TOOL builds to maximize performance due to an extra check that occurs when calling methods and such. This was suggested in #4397

### Examples

Some stupid examples

```
ClassDB::bind_method(D_METHOD("print_stray_nodes"), &Node::_print_stray_nodes);
DEPRECATE_METHOD("print_stray_nodes", DeprecationInfo());
```
![dep1](https://user-images.githubusercontent.com/7482073/46924158-e9cfad80-d021-11e8-842c-19847ec6dd59.png)

```
ADD_PROPERTYNZ(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE, "", 0), "set_name", "get_name");

DEPRECATE_PROPERTY("name", DeprecationInfo("better_name"));
```
![dep2](https://user-images.githubusercontent.com/7482073/46924233-c78a5f80-d022-11e8-8afb-597a7e4efd63.png)
```
ADD_SIGNAL(MethodInfo("renamed"));
DEPRECATE_SIGNAL("renamed", DeprecationInfo("better_renamed", "3.2"));
```
![dep3](https://user-images.githubusercontent.com/7482073/46924265-539c8700-d023-11e8-8825-62890055db99.png)

```
BIND_ENUM_CONSTANT(DUPLICATE_SCRIPTS);
DeprecationInfo deprecation_info;
deprecation_info.custom_warning = "This constant is no longer in use and is deprecated. PLS NO USE.";
DEPRECATE_CONSTANT(DUPLICATE, deprecation_info)
```
![dep4](https://user-images.githubusercontent.com/7482073/46924268-5eefb280-d023-11e8-8f75-039b661770b0.png)

### Possible Future Improvements

- Make the deprecated methods/properties/signals/constants be properly marked as such in the documentation. (I would've done this for this PR but I'm totally unfamiliar with the code that generates the documentation, I might look into this later.) 
This seems very doable with the way the deprecation is stored.

- Make it possible to automatically redirect the deprecated method/property/signal/constant to another one (I'm not sure how needed this functionality really is, let me know what you think).



BTW if needed I can go trough all deprecated methods and mark them using this.
