### PR TITLE
Add comments to javascript wrapper parts.

### DIFF
--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -1,3 +1,6 @@
+		// The following is concatenated with generated code, and acts as the end
+		// of a wrapper for said code. See pre.js for the other part of the
+		// wrapper.
 		exposedLibs['PATH'] = PATH;
 		exposedLibs['FS'] = FS;
 		return Module;

--- a/platform/javascript/pre.js
+++ b/platform/javascript/pre.js
@@ -1,2 +1,5 @@
 var Engine = {
 	RuntimeEnvironment: function(Module, exposedLibs) {
+		// The above is concatenated with generated code, and acts as the start of
+		// a wrapper for said code. See engine.js for the other part of the
+		// wrapper.


### PR DESCRIPTION
The code in pre.js and engine.js is a bit confusing to see in isolation,
since the files aren't valid JS files by themselves. This just adds some
explanatory text to both files.

Fixes #22937.
*Bugsquad edit: Closes #23146, Closes #23147*