### PR TITLE
Show an alert when a project is not found in release mode

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -729,7 +729,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 		editor = false;
 #else
-		OS::get_singleton()->print("Error: Could not load game path '%s'.\n", project_path.ascii().get_data());
+		String error_msg = "Error: Could not load game data at path '" + project_path + "'. Is the .pck file missing?\n";
+		OS::get_singleton()->print(error_msg.ascii().get_data());
+		OS::get_singleton()->alert(error_msg);
 
 		goto error;
 #endif


### PR DESCRIPTION
Previously, an error message would get printed to the console, but this
is problematic in e.g. Windows where a console is not displayed. In the
case of a missing .pck file, the binary would just silently fail. Now,
it shows an alert.

Fixes #21994.