### PR TITLE
Hide header and footer in AssetLib when not necessary

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -962,6 +962,9 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 
+	if (p_page_count < 2)
+		return hbc;
+
 	//do the mario
 	int from = p_page - 5;
 	if (from < 0)


### PR DESCRIPTION
Reduces visual clutter by hiding pages navigator header and footer in AssetLib if no results are
found or when results fit on one page one page.

Fix for issue #23036