### PR TITLE
Made NodePath property display path instead of object name if object is not named.

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1870,6 +1870,12 @@ void EditorPropertyNodePath::update_property() {
 	Node *target_node = base_node->get_node(p);
 	ERR_FAIL_COND(!target_node);
 
+	if (String(target_node->get_name()).find("@") != -1) {
+		assign->set_icon(Ref<Texture>());
+		assign->set_text(p);
+		return;
+	}
+
 	assign->set_text(target_node->get_name());
 	assign->set_icon(EditorNode::get_singleton()->get_object_icon(target_node, "Node"));
 }


### PR DESCRIPTION
This is to prevent those ugly and unclear names with the @'s to appear in things like standalone animationplayer nodes.

![ugly_2](https://user-images.githubusercontent.com/7482073/46980478-f82ad180-d0d4-11e8-95af-4cf80785d826.png)
Becomes
![ugly_1](https://user-images.githubusercontent.com/7482073/46980465-f103c380-d0d4-11e8-9fbb-b5269cd40dac.png)