### PR TITLE
Fix Script -> Script Class not in CreateDialog

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -857,11 +857,16 @@ bool EditorData::script_class_is_parent(const String &p_class, const String &p_i
 	if (!ScriptServer::is_global_class(p_class))
 		return false;
 	String base = script_class_get_base(p_class);
+	Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(p_class), "Script");
+	Ref<Script> base_script = script->get_base_script();
+
 	while (p_inherits != base) {
 		if (ClassDB::class_exists(base)) {
 			return ClassDB::is_parent_class(base, p_inherits);
 		} else if (ScriptServer::is_global_class(base)) {
 			base = script_class_get_base(base);
+		} else if (base_script.is_valid()) {
+			return ClassDB::is_parent_class(base_script->get_instance_base_type(), p_inherits);
 		} else {
 			return false;
 		}


### PR DESCRIPTION
Related to #21461. (Previously would have completed it, had it not been changed)

(Edit: Looks like that PR deals specifically with a cyclic reference error showing up. My bad. This PR is about making sure that script classes which extend a non-class script still show up in the CreateDialog properly.)

This is more of a bandaid until #22181 can be merged for 3.2. The ClassType object is a lot better for this since it can carry the potential type name AND potential resource path within a single object that knows how to fetch the "base" typename regardless of what it's actually looking at.

The below implementation will allow script classes deriving a script to be interpreted as extensions of that script's engine type, but it WON'T support going from a script class to a script to another script class and allowing the 2nd script class to register that it is extending the first one. That sort of complexity is beyond the scope of this PR's solution.