### PR TITLE
Add a configuration warning to [Oriented]PathFollow

### DIFF
--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -43,6 +43,16 @@ void Path::_curve_changed() {
 	if (is_inside_tree()) {
 		emit_signal("curve_changed");
 	}
+
+	// update the configuration warnings of all children of type OrientedPathFollows
+	if (is_inside_tree()) {
+		for (int i = 0; i < get_child_count(); i++) {
+			OrientedPathFollow *child = Object::cast_to<OrientedPathFollow>(get_child(i));
+			if (child) {
+				child->update_configuration_warning();
+			}
+		}
+	}
 }
 
 void Path::set_curve(const Ref<Curve3D> &p_curve) {
@@ -205,6 +215,18 @@ void PathFollow::_validate_property(PropertyInfo &property) const {
 
 		property.hint_string = "0," + rtos(max) + ",0.01";
 	}
+}
+
+String PathFollow::get_configuration_warning() const {
+
+	if (!is_visible_in_tree() || !is_inside_tree())
+		return String();
+
+	if (!Object::cast_to<Path>(get_parent())) {
+		return TTR("PathFollow only works when set as a child of a Path node.");
+	}
+
+	return String();
 }
 
 void PathFollow::_bind_methods() {
@@ -442,6 +464,23 @@ void OrientedPathFollow::_validate_property(PropertyInfo &property) const {
 
 		property.hint_string = "0," + rtos(max) + ",0.01";
 	}
+}
+
+String OrientedPathFollow::get_configuration_warning() const {
+
+	if (!is_visible_in_tree() || !is_inside_tree())
+		return String();
+
+	if (!Object::cast_to<Path>(get_parent())) {
+		return TTR("OrientedPathFollow only works when set as a child of a Path node.");
+	} else {
+		Path *path = Object::cast_to<Path>(get_parent());
+		if (path->get_curve().is_valid() && !path->get_curve()->is_up_vector_enabled()) {
+			return TTR("OrientedPathFollow requires up vectors enabled in its parent Path.");
+		}
+	}
+
+	return String();
 }
 
 void OrientedPathFollow::_bind_methods() {

--- a/scene/3d/path.h
+++ b/scene/3d/path.h
@@ -106,6 +106,8 @@ public:
 	void set_cubic_interpolation(bool p_enable);
 	bool get_cubic_interpolation() const;
 
+	String get_configuration_warning() const;
+
 	PathFollow();
 };
 
@@ -150,6 +152,8 @@ public:
 
 	void set_cubic_interpolation(bool p_enable);
 	bool get_cubic_interpolation() const;
+
+	String get_configuration_warning() const;
 
 	OrientedPathFollow();
 };


### PR DESCRIPTION
Fixed: ~~Limitations: Warning about up normals does not update yet when changing `up_vectors_enabled` in the parent's curve.~~