### PR TITLE
Refactor core/color.h and core/color.cpp

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -36,7 +36,6 @@
 #include "core/print_string.h"
 
 uint32_t Color::to_argb32() const {
-
 	uint32_t c = (uint8_t)Math::round(a * 255);
 	c <<= 8;
 	c |= (uint8_t)Math::round(r * 255);
@@ -49,7 +48,6 @@ uint32_t Color::to_argb32() const {
 }
 
 uint32_t Color::to_abgr32() const {
-
 	uint32_t c = (uint8_t)Math::round(a * 255);
 	c <<= 8;
 	c |= (uint8_t)Math::round(b * 255);
@@ -62,7 +60,6 @@ uint32_t Color::to_abgr32() const {
 }
 
 uint32_t Color::to_rgba32() const {
-
 	uint32_t c = (uint8_t)Math::round(r * 255);
 	c <<= 8;
 	c |= (uint8_t)Math::round(g * 255);
@@ -75,7 +72,6 @@ uint32_t Color::to_rgba32() const {
 }
 
 uint64_t Color::to_abgr64() const {
-
 	uint64_t c = (uint16_t)Math::round(a * 65535);
 	c <<= 16;
 	c |= (uint16_t)Math::round(b * 65535);
@@ -88,7 +84,6 @@ uint64_t Color::to_abgr64() const {
 }
 
 uint64_t Color::to_argb64() const {
-
 	uint64_t c = (uint16_t)Math::round(a * 65535);
 	c <<= 16;
 	c |= (uint16_t)Math::round(r * 65535);
@@ -101,7 +96,6 @@ uint64_t Color::to_argb64() const {
 }
 
 uint64_t Color::to_rgba64() const {
-
 	uint64_t c = (uint16_t)Math::round(r * 65535);
 	c <<= 16;
 	c |= (uint16_t)Math::round(g * 65535);
@@ -114,121 +108,114 @@ uint64_t Color::to_rgba64() const {
 }
 
 float Color::get_h() const {
-
 	float min = MIN(r, g);
 	min = MIN(min, b);
 	float max = MAX(r, g);
 	max = MAX(max, b);
 
 	float delta = max - min;
-
 	if (delta == 0)
 		return 0;
 
 	float h;
-	if (r == max)
-		h = (g - b) / delta; // between yellow & magenta
-	else if (g == max)
-		h = 2 + (b - r) / delta; // between cyan & yellow
-	else
-		h = 4 + (r - g) / delta; // between magenta & cyan
+	if (r == max) {
+		h = (g - b) / delta; // between magenta & yellow
+		if (h < 0)
+			h += 6;
+	} else if (g == max) {
+		h = 2 + (b - r) / delta; // between yellow & cyan
+	} else {
+		h = 4 + (r - g) / delta; // between cyan & magenta
+	}
 
 	h /= 6.0;
-	if (h < 0)
-		h += 1.0;
-
 	return h;
 }
 
 float Color::get_s() const {
+	float max = MAX(r, g);
+	max = MAX(max, b);
+	if (max == 0)
+		return 0;
 
 	float min = MIN(r, g);
 	min = MIN(min, b);
-	float max = MAX(r, g);
-	max = MAX(max, b);
 
-	float delta = max - min;
-
-	return (max != 0) ? (delta / max) : 0;
+	return (max - min) / max;
 }
 
 float Color::get_v() const {
-
 	float max = MAX(r, g);
 	max = MAX(max, b);
 	return max;
 }
 
 void Color::set_hsv(float p_h, float p_s, float p_v, float p_alpha) {
-
-	int i;
-	float f, p, q, t;
 	a = p_alpha;
-
-	if (p_s == 0) {
-		// acp_hromatic (grey)
+	if (p_s == 0 || p_v == 0) {
 		r = g = b = p_v;
 		return;
 	}
 
+	float min = p_v * (1 - p_s);
+
 	p_h *= 6.0;
 	p_h = Math::fmod(p_h, 6);
-	i = Math::floor(p_h);
+	int i = Math::floor(p_h);
+	float f = p_h - i;
+	if (i % 2 == 0) {
+		f = 1 - f;
+	}
 
-	f = p_h - i;
-	p = p_v * (1 - p_s);
-	q = p_v * (1 - p_s * f);
-	t = p_v * (1 - p_s * (1 - f));
+	float mid = p_v * (1 - p_s * f);
 
 	switch (i) {
-		case 0: // Red is the dominant color
+		case 0: // Red dominant, Blue weakest
 			r = p_v;
-			g = t;
-			b = p;
+			g = mid;
+			b = min;
 			break;
-		case 1: // Green is the dominant color
-			r = q;
+		case 1: // Green dominant, Blue weakest
+			r = mid;
 			g = p_v;
-			b = p;
+			b = min;
 			break;
-		case 2:
-			r = p;
+		case 2: // Green dominant, Red weakest
+			r = min;
 			g = p_v;
-			b = t;
+			b = mid;
 			break;
-		case 3: // Blue is the dominant color
-			r = p;
-			g = q;
+		case 3: // Blue dominant, Red weakest
+			r = min;
+			g = mid;
 			b = p_v;
 			break;
-		case 4:
-			r = t;
-			g = p;
+		case 4: // Blue dominant, Green weakest
+			r = mid;
+			g = min;
 			b = p_v;
 			break;
-		default: // (5) Red is the dominant color
+		default: // Red dominant, Green weakest
 			r = p_v;
-			g = p;
-			b = q;
+			g = min;
+			b = mid;
 			break;
 	}
 }
 
 void Color::invert() {
-
 	r = 1.0 - r;
 	g = 1.0 - g;
 	b = 1.0 - b;
 }
-void Color::contrast() {
 
+void Color::contrast() {
 	r = Math::fmod(r + 0.5, 1.0);
 	g = Math::fmod(g + 0.5, 1.0);
 	b = Math::fmod(b + 0.5, 1.0);
 }
 
 Color Color::hex(uint32_t p_hex) {
-
 	float a = (p_hex & 0xFF) / 255.0;
 	p_hex >>= 8;
 	float b = (p_hex & 0xFF) / 255.0;
@@ -241,7 +228,6 @@ Color Color::hex(uint32_t p_hex) {
 }
 
 Color Color::hex64(uint64_t p_hex) {
-
 	float a = (p_hex & 0xFFFF) / 65535.0;
 	p_hex >>= 16;
 	float b = (p_hex & 0xFFFF) / 65535.0;
@@ -254,7 +240,6 @@ Color Color::hex64(uint64_t p_hex) {
 }
 
 Color Color::from_rgbe9995(uint32_t p_rgbe) {
-
 	float r = p_rgbe & 0x1ff;
 	float g = (p_rgbe >> 9) & 0x1ff;
 	float b = (p_rgbe >> 18) & 0x1ff;
@@ -268,150 +253,90 @@ Color Color::from_rgbe9995(uint32_t p_rgbe) {
 	return Color(rd, gd, bd, 1.0f);
 }
 
-static float _parse_col(const String &p_str, int p_ofs) {
+// Take a hex string of type ARGB and convert it to an uint32_t stored in out
+// Returns a bool that indicates whether conversion was successful
+static bool _parse_hex(const String &p_color, uint32_t &out) {
+	String col_str = p_color;
+	int len = col_str.length();
+	if (len == 0)
+		return false;
 
-	int ig = 0;
-
-	for (int i = 0; i < 2; i++) {
-
-		int c = p_str[i + p_ofs];
-		int v = 0;
-
-		if (c >= '0' && c <= '9') {
-			v = c - '0';
-		} else if (c >= 'a' && c <= 'f') {
-			v = c - 'a';
-			v += 10;
-		} else if (c >= 'A' && c <= 'F') {
-			v = c - 'A';
-			v += 10;
-		} else {
-			return -1;
-		}
-
-		if (i == 0)
-			ig += v * 16;
-		else
-			ig += v;
+	// Reformat color string
+	if (col_str[0] == '#') {
+		len--;
+		col_str = col_str.substr(1, len);
 	}
 
-	return ig;
+	if (len == 3 || len == 4) {
+		String full_hex = "";
+		for (int i = 0; i < len; i++) {
+			full_hex += col_str[i] + col_str[i];
+		}
+		len *= 2;
+		col_str = full_hex;
+	}
+
+	// Check validity
+	if (len != 8 && len != 6)
+		return false;
+
+	// Convert to int
+	out = 255;
+	out <<= 8;
+	for (int i = 0; i < len; i++) {
+		int c = col_str[i];
+
+		if (c >= '0' && c <= '9') {
+			out |= c - '0';
+		} else if (c >= 'a' && c <= 'f') {
+			out |= 10 + c - 'a';
+		} else if (c >= 'A' && c <= 'F') {
+			out |= 10 + c - 'A';
+		} else {
+			return false;
+		}
+
+		if (i != len - 1)
+			out <<= 4;
+	}
+
+	return true;
 }
 
 Color Color::inverted() const {
-
 	Color c = *this;
 	c.invert();
 	return c;
 }
 
 Color Color::contrasted() const {
-
 	Color c = *this;
 	c.contrast();
 	return c;
 }
 
 Color Color::html(const String &p_color) {
-
-	String color = p_color;
-	if (color.length() == 0)
-		return Color();
-	if (color[0] == '#')
-		color = color.substr(1, color.length() - 1);
-	if (color.length() == 3 || color.length() == 4) {
-		String exp_color;
-		for (int i = 0; i < color.length(); i++) {
-			exp_color += color[i];
-			exp_color += color[i];
-		}
-		color = exp_color;
-	}
-
-	bool alpha = false;
-
-	if (color.length() == 8) {
-		alpha = true;
-	} else if (color.length() == 6) {
-		alpha = false;
-	} else {
+	uint32_t col_int;
+	bool hex_valid = _parse_hex(p_color, col_int);
+	if (!hex_valid) {
 		ERR_EXPLAIN("Invalid Color Code: " + p_color);
 		ERR_FAIL_V(Color());
 	}
 
-	int a = 255;
-	if (alpha) {
-		a = _parse_col(color, 0);
-		if (a < 0) {
-			ERR_EXPLAIN("Invalid Color Code: " + p_color);
-			ERR_FAIL_V(Color());
-		}
-	}
+	// Rearrange the bits of the int to convert ARGB to RGBA for hex()
+	uint32_t temp = col_int >> 24;
+	col_int <<= 8;
+	col_int |= temp;
 
-	int from = alpha ? 2 : 0;
-
-	int r = _parse_col(color, from + 0);
-	if (r < 0) {
-		ERR_EXPLAIN("Invalid Color Code: " + p_color);
-		ERR_FAIL_V(Color());
-	}
-	int g = _parse_col(color, from + 2);
-	if (g < 0) {
-		ERR_EXPLAIN("Invalid Color Code: " + p_color);
-		ERR_FAIL_V(Color());
-	}
-	int b = _parse_col(color, from + 4);
-	if (b < 0) {
-		ERR_EXPLAIN("Invalid Color Code: " + p_color);
-		ERR_FAIL_V(Color());
-	}
-
-	return Color(r / 255.0, g / 255.0, b / 255.0, a / 255.0);
+	return hex(col_int);
 }
 
 bool Color::html_is_valid(const String &p_color) {
-
-	String color = p_color;
-
-	if (color.length() == 0)
+	uint32_t dummy;
+	if (_parse_hex(p_color, dummy))
+		return true;
+	else
 		return false;
-	if (color[0] == '#')
-		color = color.substr(1, color.length() - 1);
-
-	bool alpha = false;
-
-	if (color.length() == 8) {
-		alpha = true;
-	} else if (color.length() == 6) {
-		alpha = false;
-	} else {
-		return false;
-	}
-
-	int a = 255;
-	if (alpha) {
-		a = _parse_col(color, 0);
-		if (a < 0) {
-			return false;
-		}
-	}
-
-	int from = alpha ? 2 : 0;
-
-	int r = _parse_col(color, from + 0);
-	if (r < 0) {
-		return false;
-	}
-	int g = _parse_col(color, from + 2);
-	if (g < 0) {
-		return false;
-	}
-	int b = _parse_col(color, from + 4);
-	if (b < 0) {
-		return false;
-	}
-
-	return true;
 }
 
 Color Color::named(const String &p_name) {
@@ -435,107 +360,54 @@ Color Color::named(const String &p_name) {
 }
 
 String _to_hex(float p_val) {
-
 	int v = Math::round(p_val * 255);
 	v = CLAMP(v, 0, 255);
-	String ret;
 
+	CharType c[3] = { 0, 0, 0 };
 	for (int i = 0; i < 2; i++) {
-
-		CharType c[2] = { 0, 0 };
 		int lv = v & 0xF;
 		if (lv < 10)
-			c[0] = '0' + lv;
+			c[i] = '0' + lv;
 		else
-			c[0] = 'a' + lv - 10;
+			c[i] = 'a' + lv - 10;
 
 		v >>= 4;
-		String cs = (const CharType *)c;
-		ret = cs + ret;
 	}
 
-	return ret;
+	String cs = (const CharType *)c;
+	return cs;
 }
 
 String Color::to_html(bool p_alpha) const {
-
 	String txt;
+	if (p_alpha)
+		txt += _to_hex(a);
 	txt += _to_hex(r);
 	txt += _to_hex(g);
 	txt += _to_hex(b);
-	if (p_alpha)
-		txt = _to_hex(a) + txt;
+
 	return txt;
 }
 
 Color Color::from_hsv(float p_h, float p_s, float p_v, float p_a) const {
+	Color ret = Color();
+	ret.set_hsv(p_h, p_s, p_v, p_a);
 
-	p_h = Math::fmod(p_h * 360.0f, 360.0f);
-	if (p_h < 0.0)
-		p_h += 360.0f;
-
-	const float h_ = p_h / 60.0f;
-	const float c = p_v * p_s;
-	const float x = c * (1.0f - Math::abs(Math::fmod(h_, 2.0f) - 1.0f));
-	float r, g, b;
-
-	switch ((int)h_) {
-		case 0: {
-			r = c;
-			g = x;
-			b = 0;
-		} break;
-		case 1: {
-			r = x;
-			g = c;
-			b = 0;
-		} break;
-		case 2: {
-			r = 0;
-			g = c;
-			b = x;
-		} break;
-		case 3: {
-			r = 0;
-			g = x;
-			b = c;
-		} break;
-		case 4: {
-			r = x;
-			g = 0;
-			b = c;
-		} break;
-		case 5: {
-			r = c;
-			g = 0;
-			b = x;
-		} break;
-		default: {
-			r = 0;
-			g = 0;
-			b = 0;
-		} break;
-	}
-
-	const float m = p_v - c;
-	return Color(m + r, m + g, m + b, p_a);
+	return ret;
 }
 
 // FIXME: Remove once Godot 3.1 has been released
 float Color::gray() const {
-
 	ERR_EXPLAIN("Color.gray() is deprecated and will be removed in a future version. Use Color.get_v() for a better grayscale approximation.");
 	WARN_DEPRECATED
 	return (r + g + b) / 3.0;
 }
 
 Color::operator String() const {
-
 	return rtos(r) + ", " + rtos(g) + ", " + rtos(b) + ", " + rtos(a);
 }
 
 Color Color::operator+(const Color &p_color) const {
-
 	return Color(
 			r + p_color.r,
 			g + p_color.g,
@@ -544,15 +416,13 @@ Color Color::operator+(const Color &p_color) const {
 }
 
 void Color::operator+=(const Color &p_color) {
-
-	r = r + p_color.r;
-	g = g + p_color.g;
-	b = b + p_color.b;
-	a = a + p_color.a;
+	r += p_color.r;
+	g += p_color.g;
+	b += p_color.b;
+	a += p_color.a;
 }
 
 Color Color::operator-(const Color &p_color) const {
-
 	return Color(
 			r - p_color.r,
 			g - p_color.g,
@@ -561,15 +431,13 @@ Color Color::operator-(const Color &p_color) const {
 }
 
 void Color::operator-=(const Color &p_color) {
-
-	r = r - p_color.r;
-	g = g - p_color.g;
-	b = b - p_color.b;
-	a = a - p_color.a;
+	r -= p_color.r;
+	g -= p_color.g;
+	b -= p_color.b;
+	a -= p_color.a;
 }
 
 Color Color::operator*(const Color &p_color) const {
-
 	return Color(
 			r * p_color.r,
 			g * p_color.g,
@@ -578,7 +446,6 @@ Color Color::operator*(const Color &p_color) const {
 }
 
 Color Color::operator*(const real_t &rvalue) const {
-
 	return Color(
 			r * rvalue,
 			g * rvalue,
@@ -587,23 +454,20 @@ Color Color::operator*(const real_t &rvalue) const {
 }
 
 void Color::operator*=(const Color &p_color) {
-
-	r = r * p_color.r;
-	g = g * p_color.g;
-	b = b * p_color.b;
-	a = a * p_color.a;
+	r *= p_color.r;
+	g *= p_color.g;
+	b *= p_color.b;
+	a *= p_color.a;
 }
 
 void Color::operator*=(const real_t &rvalue) {
-
-	r = r * rvalue;
-	g = g * rvalue;
-	b = b * rvalue;
-	a = a * rvalue;
+	r *= rvalue;
+	g *= rvalue;
+	b *= rvalue;
+	a *= rvalue;
 }
 
 Color Color::operator/(const Color &p_color) const {
-
 	return Color(
 			r / p_color.r,
 			g / p_color.g,
@@ -612,6 +476,8 @@ Color Color::operator/(const Color &p_color) const {
 }
 
 Color Color::operator/(const real_t &rvalue) const {
+	if (rvalue == 0)
+		return Color(1.0, 1.0, 1.0, 1.0);
 
 	return Color(
 			r / rvalue,
@@ -621,30 +487,27 @@ Color Color::operator/(const real_t &rvalue) const {
 }
 
 void Color::operator/=(const Color &p_color) {
-
-	r = r / p_color.r;
-	g = g / p_color.g;
-	b = b / p_color.b;
-	a = a / p_color.a;
+	r /= p_color.r;
+	g /= p_color.g;
+	b /= p_color.b;
+	a /= p_color.a;
 }
 
 void Color::operator/=(const real_t &rvalue) {
-
 	if (rvalue == 0) {
 		r = 1.0;
 		g = 1.0;
 		b = 1.0;
 		a = 1.0;
 	} else {
-		r = r / rvalue;
-		g = g / rvalue;
-		b = b / rvalue;
-		a = a / rvalue;
+		r /= rvalue;
+		g /= rvalue;
+		b /= rvalue;
+		a /= rvalue;
 	}
 };
 
 Color Color::operator-() const {
-
 	return Color(
 			1.0 - r,
 			1.0 - g,


### PR DESCRIPTION
**core/color.h:**
- Simplifying the code
- Move implementation of `operator <` inside the class

**core/color.cpp:**
- Simplifying code (Spacing, removing unnecessary variables)
- Subtle performance changes (Using bit shift operators, moving if clauses)
- Rewrite `set_hsv` to be easier to understand, through variable renaming and comment changes
- Use `set_hsv` in `from_hsv` as both sets of code are mathematically equivalent, chose `set_hsv` implementation as it is likely more performant. Although `from_hsv`'s implementation is documented better online.

**Update:**
- Changed `_parse_col` to `_parse_hex`.
- Reduce duplicate code by moving similar code in `html` and `html_is_valid` to `_parse_hex`
- Added comments to `_parse_hex` to provide a better description of its functionality.