### PR TITLE
Fix some compile warnings for Windows from Linux

### DIFF
--- a/drivers/rtaudio/audio_driver_rtaudio.cpp
+++ b/drivers/rtaudio/audio_driver_rtaudio.cpp
@@ -114,11 +114,12 @@ Error AudioDriverRtAudio::init() {
 	unsigned int buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
 	print_verbose("Audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
-	short int tries = 2;
+	short int tries = 4;
 
-	while (tries >= 0) {
+	while (tries > 0) {
 		switch (speaker_mode) {
 			case SPEAKER_MODE_STEREO: parameters.nChannels = 2; break;
+			case SPEAKER_SURROUND_31: parameters.nChannels = 4; break;
 			case SPEAKER_SURROUND_51: parameters.nChannels = 6; break;
 			case SPEAKER_SURROUND_71: parameters.nChannels = 8; break;
 		};
@@ -133,7 +134,9 @@ Error AudioDriverRtAudio::init() {
 			ERR_PRINT("Unable to open audio, retrying with fewer channels...");
 
 			switch (speaker_mode) {
-				case SPEAKER_SURROUND_51: speaker_mode = SPEAKER_MODE_STEREO; break;
+				case SPEAKER_MODE_STEREO: break; // Required to silence unhandled enum value warning.
+				case SPEAKER_SURROUND_31: speaker_mode = SPEAKER_MODE_STEREO; break;
+				case SPEAKER_SURROUND_51: speaker_mode = SPEAKER_SURROUND_31; break;
 				case SPEAKER_SURROUND_71: speaker_mode = SPEAKER_SURROUND_51; break;
 			}
 

--- a/platform/windows/context_gl_win.cpp
+++ b/platform/windows/context_gl_win.cpp
@@ -92,9 +92,9 @@ Error ContextGL_Win::initialize() {
 				PFD_SUPPORT_OPENGL | // Format Must Support OpenGL
 				PFD_DOUBLEBUFFER,
 		(BYTE)PFD_TYPE_RGBA,
-		OS::get_singleton()->is_layered_allowed() ? (BYTE)32 : (BYTE)24,
+		(BYTE)(OS::get_singleton()->is_layered_allowed() ? 32 : 24),
 		(BYTE)0, (BYTE)0, (BYTE)0, (BYTE)0, (BYTE)0, (BYTE)0, // Color Bits Ignored
-		OS::get_singleton()->is_layered_allowed() ? (BYTE)8 : (BYTE)0, // Alpha Buffer
+		(BYTE)(OS::get_singleton()->is_layered_allowed() ? 8 : 0), // Alpha Buffer
 		(BYTE)0, // Shift Bit Ignored
 		(BYTE)0, // No Accumulation Buffer
 		(BYTE)0, (BYTE)0, (BYTE)0, (BYTE)0, // Accumulation Bits Ignored

--- a/platform/windows/joypad.cpp
+++ b/platform/windows/joypad.cpp
@@ -172,7 +172,7 @@ bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE *instance) {
 
 	joy->di_joy->SetDataFormat(&c_dfDIJoystick2);
 	joy->di_joy->SetCooperativeLevel(*hWnd, DISCL_FOREGROUND);
-	joy->di_joy->EnumObjects(objectsCallback, this, NULL);
+	joy->di_joy->EnumObjects(objectsCallback, this, 0);
 	joy->joy_axis.sort();
 
 	joy->guid = instance->guidInstance;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -629,10 +629,8 @@ Rect2 Viewport::get_visible_rect() const {
 	Rect2 r;
 
 	if (size == Size2()) {
-
-		r = Rect2(Point2(), Size2(OS::get_singleton()->get_window_size().width, OS::get_singleton()->get_window_size().height));
+		r = Rect2(Point2(), OS::get_singleton()->get_window_size());
 	} else {
-
 		r = Rect2(Point2(), size);
 	}
 


### PR DESCRIPTION
At least some of the ones I got when I compiled it using Mingw64 POSIX on Xubuntu 18.04. It seems to compile and run fine on both Windows and Linux.

I did experience two other warnings which I was not knowledgeable enough to fix:

```
[ ] Compiling ==> drivers/wasapi/audio_driver_wasapi.cpp
drivers/wasapi/audio_driver_wasapi.cpp: In member function 'virtual ULONG CMMNotificationClient::Release()':
drivers/wasapi/audio_driver_wasapi.cpp:93:11: warning: deleting object of polymorphic class type 'CMMNotificationClient' which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
    delete this;
           ^~~~

[ ] Compiling ==> core/ustring.cpp
core/ustring.cpp: In member function 'String String::http_escape() const':
core/ustring.cpp:3275:34: warning: unknown conversion type character 'h' in format [-Wformat=]
    snprintf(h_Val, 3, "%hhX", ord);
                                  ^
core/ustring.cpp:3275:34: warning: too many arguments for format [-Wformat-extra-args]
```