### PR TITLE
Draw Button's "focus" style as an overlay to other styles

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -140,8 +140,8 @@ void Button::_notification(int p_what) {
 
 		if (has_focus()) {
 
-			Ref<StyleBox> style = get_stylebox("focus");
-			style->draw(ci, Rect2(Point2(), size));
+			Ref<StyleBox> hover_style = get_stylebox("focus");
+			hover_style->draw(ci, Rect2(Point2(), size));
 		}
 
 		Ref<Font> font = get_font("font");


### PR DESCRIPTION
Focus styles in existing projects should be tweaked to make the base style (normal/hover/pressed) visible.

This closes #4575.

[Demo project](https://github.com/godotengine/godot/files/2489253/test_focus.zip)
