### PR TITLE
fix class reference markup for KinematicBody2D

### DIFF
--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -116,7 +116,7 @@
 			</argument>
 			<description>
 				Moves the body while keeping it attached to slopes. Similar to [method move_and_slide].
-				As long as the [code]snap[/code] vector is in contact with the ground, the body will remain attached to the surface. This means you must disable snap in order to jump, for example. You can do this by setting[code]snap[/code] to[code](0, 0)[/code] or by using [method move_and_slide] instead.
+				As long as the [code]snap[/code] vector is in contact with the ground, the body will remain attached to the surface. This means you must disable snap in order to jump, for example. You can do this by setting [code]snap[/code] to [code](0, 0)[/code] or by using [method move_and_slide] instead.
 			</description>
 		</method>
 		<method name="test_move">


### PR DESCRIPTION
![bug image](https://user-images.githubusercontent.com/31960676/47033882-eaf8fb80-d143-11e8-97aa-a0f133463837.png)

added spaces between markup and words preceding it to fix this

continuation from https://github.com/godotengine/godot-docs/pull/1855