### PR TITLE
Make sure API assemblies are up to date at startup

### DIFF
--- a/modules/mono/editor/godotsharp_editor.h
+++ b/modules/mono/editor/godotsharp_editor.h
@@ -56,6 +56,8 @@ class GodotSharpEditor : public Node {
 #endif
 
 	bool _create_project_solution();
+	void _make_api_solutions_if_needed();
+	void _make_api_solutions_if_needed_impl();
 
 	void _remove_create_sln_menu_option();
 	void _show_about_dialog();


### PR DESCRIPTION
- If there is a solution and C# project at startup, make sure API assemblies are up to date.
- Fix prebuilt assemblies only being used when building the game project, and not in other instances.
