### PR TITLE
Fix: String::format Variant to String conversion

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2774,16 +2774,13 @@ String String::format(const Variant &values, String placeholder) const {
 
 				if (value_arr.size() == 2) {
 					Variant v_key = value_arr[0];
-					String key;
-
-					key = v_key.get_construct_string();
+					String key = v_key;
 					if (key.left(1) == "\"" && key.right(key.length() - 1) == "\"") {
 						key = key.substr(1, key.length() - 2);
 					}
 
 					Variant v_val = value_arr[1];
-					String val;
-					val = v_val.get_construct_string();
+					String val = v_val;
 
 					if (val.left(1) == "\"" && val.right(val.length() - 1) == "\"") {
 						val = val.substr(1, val.length() - 2);
@@ -2795,8 +2792,7 @@ String String::format(const Variant &values, String placeholder) const {
 				}
 			} else { //Array structure ["RobotGuy","Logis","rookie"]
 				Variant v_val = values_arr[i];
-				String val;
-				val = v_val.get_construct_string();
+				String val = v_val;
 
 				if (val.left(1) == "\"" && val.right(val.length() - 1) == "\"") {
 					val = val.substr(1, val.length() - 2);
@@ -2815,8 +2811,8 @@ String String::format(const Variant &values, String placeholder) const {
 		d.get_key_list(&keys);
 
 		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-			String key = E->get().get_construct_string();
-			String val = d[E->get()].get_construct_string();
+			String key = E->get();
+			String val = d[E->get()];
 
 			if (key.left(1) == "\"" && key.right(key.length() - 1) == "\"") {
 				key = key.substr(1, key.length() - 2);


### PR DESCRIPTION
Previosly String::format used variant.get_construct_string() to convert the passed Variants to Strings. This however did not match the expected printing behavior of some datatypes: Strings for example turned out escaped.

This fix replaces the call to get_construct_string() with a simple conversion. This makes String::format consistent with "%s" % "sth" and formated Variants turn out like printed as expected.

Closes #23129