### PR TITLE
Fix possible audio input buffer issues

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -145,9 +145,6 @@ Error AudioDriverCoreAudio::init() {
 	unsigned int buffer_size = buffer_frames * channels;
 	samples_in.resize(buffer_size);
 	input_buf.resize(buffer_size);
-	input_buffer.resize(buffer_size * 8);
-	input_position = 0;
-	input_size = 0;
 
 	print_verbose("CoreAudio: detected " + itos(channels) + " channels");
 	print_verbose("CoreAudio: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
@@ -486,6 +483,8 @@ void AudioDriverCoreAudio::capture_finish() {
 }
 
 Error AudioDriverCoreAudio::capture_start() {
+
+	input_buffer_init(buffer_frames);
 
 	OSStatus result = AudioOutputUnitStart(input_unit);
 	if (result != noErr) {

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -613,20 +613,18 @@ Error AudioDriverPulseAudio::capture_init_device() {
 			break;
 	}
 
-	print_verbose("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
-
 	pa_sample_spec spec;
 
 	spec.format = PA_SAMPLE_S16LE;
 	spec.channels = pa_rec_map.channels;
 	spec.rate = mix_rate;
 
-	int latency = 30;
-	input_buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
-	int buffer_size = input_buffer_frames * spec.channels;
+	int input_latency = 30;
+	int input_buffer_frames = closest_power_of_2(input_latency * mix_rate / 1000);
+	int input_buffer_size = input_buffer_frames * spec.channels;
 
 	pa_buffer_attr attr;
-	attr.fragsize = buffer_size * sizeof(int16_t);
+	attr.fragsize = input_buffer_size * sizeof(int16_t);
 
 	pa_rec_str = pa_stream_new(pa_ctx, "Record", &spec, &pa_rec_map);
 	if (pa_rec_str == NULL) {
@@ -642,9 +640,10 @@ Error AudioDriverPulseAudio::capture_init_device() {
 		ERR_FAIL_V(ERR_CANT_OPEN);
 	}
 
-	input_buffer.resize(input_buffer_frames * 8);
-	input_position = 0;
-	input_size = 0;
+	input_buffer_init(input_buffer_frames);
+
+	print_verbose("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
+	print_verbose("PulseAudio: input buffer frames: " + itos(input_buffer_frames) + " calculated latency: " + itos(input_buffer_frames * 1000 / mix_rate) + "ms");
 
 	return OK;
 }
@@ -760,7 +759,6 @@ AudioDriverPulseAudio::AudioDriverPulseAudio() {
 
 	mix_rate = 0;
 	buffer_frames = 0;
-	input_buffer_frames = 0;
 	pa_buffer_size = 0;
 	channels = 0;
 	pa_ready = 0;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -64,7 +64,6 @@ class AudioDriverPulseAudio : public AudioDriver {
 
 	unsigned int mix_rate;
 	unsigned int buffer_frames;
-	unsigned int input_buffer_frames;
 	unsigned int pa_buffer_size;
 	int channels;
 	int pa_ready;

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -336,10 +336,7 @@ Error AudioDriverWASAPI::init_capture_device(bool reinit) {
 	HRESULT hr = audio_input.audio_client->GetBufferSize(&max_frames);
 	ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
 
-	// Set the buffer size
-	input_buffer.resize(max_frames * CAPTURE_BUFFER_CHANNELS);
-	input_position = 0;
-	input_size = 0;
+	input_buffer_init(max_frames);
 
 	return OK;
 }

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -122,8 +122,6 @@ class AudioStreamPlaybackMicrophone : public AudioStreamPlaybackResampled {
 	GDCLASS(AudioStreamPlaybackMicrophone, AudioStreamPlayback)
 	friend class AudioStreamMicrophone;
 
-	static const int MICROPHONE_PLAYBACK_DELAY = 256;
-
 	bool active;
 	unsigned int input_ofs;
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -80,6 +80,14 @@ double AudioDriver::get_mix_time() const {
 	return total;
 }
 
+void AudioDriver::input_buffer_init(int driver_buffer_frames) {
+
+	const int input_buffer_channels = 2;
+	input_buffer.resize(driver_buffer_frames * input_buffer_channels * 4);
+	input_position = 0;
+	input_size = 0;
+}
+
 void AudioDriver::input_buffer_write(int32_t sample) {
 
 	input_buffer.write[input_position++] = sample;

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -59,6 +59,7 @@ protected:
 
 	void audio_server_process(int p_frames, int32_t *p_buffer, bool p_update_mix_time = true);
 	void update_mix_time(int p_frames);
+	void input_buffer_init(int driver_buffer_frames);
 	void input_buffer_write(int32_t sample);
 
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
This fixes buffer underruns that I've been detecting on the audio input code.
The playback delay is now adjusted based on the mix_rate instead of being a hardcoded value. Since the greater the mix_rate the greater the buffers are.
The input buffer size is now calculated with a generic function so that it's large enough to avoid buffer underruns on all drivers.

Project I've been using for testing: [MicRecord.zip](https://github.com/godotengine/godot/files/2498280/MicRecord.zip)
