### PR TITLE
Add erase and brush_transfer method in Image Class

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2014,6 +2014,99 @@ void Image::blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, co
 	msk->unlock();
 }
 
+void Image::brush_transfer(const Ref<Image> &p_src, const Ref<Image> &p_brush, const Point2 &p_dest) {
+	ERR_FAIL_COND(p_src.is_null());
+	ERR_FAIL_COND(p_brush.is_null());
+	int dsize = data.size();
+	int srcdsize = p_src->data.size();
+	int brushdsize = p_brush->data.size();
+	ERR_FAIL_COND(dsize == 0);
+	ERR_FAIL_COND(srcdsize == 0);
+	ERR_FAIL_COND(brushdsize == 0);
+	ERR_FAIL_COND(p_src->width != p_brush->width);
+	ERR_FAIL_COND(p_src->height != p_brush->height);
+	ERR_FAIL_COND(format != p_src->format);
+
+	Rect2i act_rect = Rect2i(-p_src->width, -p_src->height, width + p_src->width, height + p_src->height);
+	if (!act_rect.has_point(p_dest))
+		return;
+
+	Rect2i dest_rect = Rect2i(0, 0, width, height).clip(Rect2i(p_dest, p_src->get_size()));
+
+	for (int i = 0; i < dest_rect.size.y; i++) {
+
+		for (int j = 0; j < dest_rect.size.x; j++) {
+
+			int src_x = MAX(-p_dest.x, 0) + j;
+			int src_y = MAX(-p_dest.y, 0) + i;
+
+			int dst_x = dest_rect.position.x + j;
+			int dst_y = dest_rect.position.y + i;
+
+			lock();
+			Ref<Image> brush = p_brush;
+			Ref<Image> src = p_src;
+			brush->lock();
+			src->lock();
+
+			Color br = brush->get_pixel(src_x, src_y);
+			Color sc = src->get_pixel(src_x, src_y);
+			Color dc = get_pixel(dst_x, dst_y);
+
+			float a = (double)(1.0 - (1.0 - sc.a * br.a) * (1.0 - dc.a));
+			dc.r = (double)((sc.a * br.a * sc.r + (1.0 - sc.a * br.a) * dc.a * dc.r) / a);
+			dc.g = (double)((sc.a * br.a * sc.g + (1.0 - sc.a * br.a) * dc.a * dc.g) / a);
+			dc.b = (double)((sc.a * br.a * sc.b + (1.0 - sc.a * br.a) * dc.a * dc.b) / a);
+			dc.a = a;
+
+			set_pixel(dst_x, dst_y, dc);
+
+			brush->unlock();
+			src->unlock();
+			unlock();
+		}
+	}
+}
+
+void Image::erase(const Ref<Image> &p_brush, const Point2 &p_dest) {
+	ERR_FAIL_COND(p_brush.is_null());
+	int dsize = data.size();
+	int brushdsize = p_brush->data.size();
+	ERR_FAIL_COND(dsize == 0);
+	ERR_FAIL_COND(brushdsize == 0);
+
+	Rect2i act_rect = Rect2i(-p_brush->width, -p_brush->height, width + p_brush->width, height + p_brush->height);
+	if (!act_rect.has_point(p_dest))
+		return;
+
+	Rect2i dest_rect = Rect2i(0, 0, width, height).clip(Rect2i(p_dest, p_brush->get_size()));
+
+	for (int i = 0; i < dest_rect.size.y; i++) {
+
+		for (int j = 0; j < dest_rect.size.x; j++) {
+
+			int src_x = MAX(-p_dest.x, 0) + j;
+			int src_y = MAX(-p_dest.y, 0) + i;
+
+			int dst_x = dest_rect.position.x + j;
+			int dst_y = dest_rect.position.y + i;
+
+			lock();
+			Ref<Image> brush = p_brush;
+			brush->lock();
+
+			Color br = brush->get_pixel(src_x, src_y);
+			Color dc = get_pixel(dst_x, dst_y);
+			dc.a = dc.a * (1.0 - br.a);
+
+			set_pixel(dst_x, dst_y, dc);
+
+			brush->unlock();
+			unlock();
+		}
+	}
+}
+
 void Image::blend_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Point2 &p_dest) {
 
 	ERR_FAIL_COND(p_src.is_null());
@@ -2594,6 +2687,8 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("blit_rect", "src", "src_rect", "dst"), &Image::blit_rect);
 	ClassDB::bind_method(D_METHOD("blit_rect_mask", "src", "mask", "src_rect", "dst"), &Image::blit_rect_mask);
+	ClassDB::bind_method(D_METHOD("brush_transfer", "src", "brush", "dst"), &Image::brush_transfer);
+	ClassDB::bind_method(D_METHOD("erase", "brush", "dst"), &Image::erase);
 	ClassDB::bind_method(D_METHOD("blend_rect", "src", "src_rect", "dst"), &Image::blend_rect);
 	ClassDB::bind_method(D_METHOD("blend_rect_mask", "src", "mask", "src_rect", "dst"), &Image::blend_rect_mask);
 	ClassDB::bind_method(D_METHOD("fill", "color"), &Image::fill);

--- a/core/image.h
+++ b/core/image.h
@@ -309,6 +309,8 @@ public:
 
 	void blit_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Point2 &p_dest);
 	void blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest);
+	void brush_transfer(const Ref<Image> &p_src, const Ref<Image> &p_brush, const Point2 &p_dest);
+	void erase(const Ref<Image> &p_brush, const Point2 &p_dest);
 	void blend_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Point2 &p_dest);
 	void blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest);
 	void fill(const Color &c);


### PR DESCRIPTION
erase method:
![2](https://user-images.githubusercontent.com/10054853/47263825-fb421980-d53b-11e8-9b90-6929daad310f.gif)
brush_transfer method(and this fixs #22999):
![1](https://user-images.githubusercontent.com/10054853/47263826-fc734680-d53b-11e8-9dad-f704d32811ac.gif)
