### PR TITLE
Delete duplicate functions at OS_Unix and OS_OSX

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -204,8 +204,6 @@ public:
 	virtual VideoMode get_video_mode(int p_screen = 0) const;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen = 0) const;
 
-	virtual String get_executable_path() const;
-
 	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
 
 	virtual void move_window_to_foreground();

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -2318,24 +2318,6 @@ bool OS_OSX::get_borderless_window() {
 	return [window_object styleMask] == NSWindowStyleMaskBorderless;
 }
 
-String OS_OSX::get_executable_path() const {
-
-	int ret;
-	pid_t pid;
-	char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
-
-	pid = getpid();
-	ret = proc_pidpath(pid, pathbuf, sizeof(pathbuf));
-	if (ret <= 0) {
-		return OS::get_executable_path();
-	} else {
-		String path;
-		path.parse_utf8(pathbuf);
-
-		return path;
-	}
-}
-
 // Returns string representation of keys, if they are printable.
 //
 static NSString *createStringForKeys(const CGKeyCode *keyCode, int length) {


### PR DESCRIPTION
In mac, OS_Unix::get_executable_path() and OS_OSX::get_executable_path() returns same path.

Two functions seem to be doing the same thing.
https://github.com/godotengine/godot/blob/master/drivers/unix/os_unix.cpp#L517-L531
https://github.com/godotengine/godot/blob/master/platform/osx/os_osx.mm#L2321-L2337

So, I deleted duplicate code.

The following is the performance test result
```
NSDate *start1 = [NSDate date];

for (int i = 0; i < 1000000; ++i) {
	OS_OSX::get_executable_path();
}

NSDate *end1 = [NSDate date];
NSTimeInterval executionTime1 = [end1 timeIntervalSinceDate:start1];

NSDate *start2 = [NSDate date];

for (int i = 0; i < 1000000; ++i) {
	OS_Unix::get_executable_path();
}

NSDate *end2 = [NSDate date];
NSTimeInterval executionTime2 = [end2 timeIntervalSinceDate:start2];

NSLog(@"OS_OSX::get_executable_path() = %f sec", executionTime1);
NSLog(@"OS_Unix::get_executable_path() = %f sec", executionTime2);


2018-10-21 16:03:33.626 GodotPythonTest[2954:1985375] OS_OSX::get_executable_path() = 6.030224 sec
2018-10-21 16:03:33.626 GodotPythonTest[2954:1985375] OS_Unix::get_executable_path() = 0.427494 sec
```