### PR TITLE
Scene tabs closing and thumbnail errors, issue 22890

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3892,7 +3892,9 @@ void EditorNode::_scene_tab_hover(int p_tab) {
 		tab_preview_panel->hide();
 	} else {
 		String path = editor_data.get_scene_path(p_tab);
-		EditorResourcePreview::get_singleton()->queue_resource_preview(path, this, "_thumbnail_done", p_tab);
+		if (path != String()) {
+			EditorResourcePreview::get_singleton()->queue_resource_preview(path, this, "_thumbnail_done", p_tab);
+		}
 	}
 }
 

--- a/scene/gui/tabs.h
+++ b/scene/gui/tabs.h
@@ -97,6 +97,8 @@ private:
 
 	int get_tab_width(int p_idx) const;
 	void _ensure_no_over_offset();
+
+	void _update_hover();
 	void _update_cache();
 
 protected:


### PR DESCRIPTION
Fixed `Tabs` node not updating its hovered status when new tabs are added or removed. 
Fixed the editor attempting to create thumbnails for unsaved scenes.

closes #22890