### PR TITLE
[DOCS] more detailed example for usage of PackedScene

### DIFF
--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -6,10 +6,27 @@
 	<description>
 		A simplified interface to a scene file. Provides access to operations and checks that can be performed on the scene resource itself.
 		Can be used to save a node to a file. When saving, the node as well as all the node it owns get saved (see [code]owner[/code] property on [Node]). Note that the node doesn't need to own itself.
-		Example of saving a node:
+
+		[b]Example of saving a node with different owners[/b]
+
+		The following example creates 3 objects: [code]Node2D[/code] ([code]node[/code]), [code]RigidBody2D[/code] ([code]rigid[/code]) and [code]CollisionObject2D[/code] ([code]collision[/code]). [code]collision[/code] is a child of [code]rigid[/code] which is a child of [code]node[/code]. Only [code]rigid[/code] is owned by [code]node[/code] and [code]pack[/code] will therefore only save those two nodes, but not [code]collision[/code].
+
 		[codeblock]
+		# create the objects
+		var node = Node2D.new()
+		var rigid = RigidBody2D.new()
+		var collision = CollisionShape2D.new()
+
+		# create the object hierachy
+		rigid.add_child(collision)
+		node.add_child(rigid)
+
+		# change owner of rigid, but not of collision
+		rigid.set_owner(node)
+
 		var scene = PackedScene.new()
-		var result = scene.pack(child)
+		# only node and rigid are now packed
+		var result = scene.pack(node)
 		if result == OK:
 		    ResourceSaver.save("res://path/name.scn", scene) # or user://...
 		[/codeblock]


### PR DESCRIPTION
Attempt to make the usage of `packedScene` clearer. Users might assume that children are automatically packed, e.g. https://github.com/godotengine/godot/issues/20954