### PR TITLE
[DOCS] Added section that coordinates can be accessed via indexes

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -259,10 +259,10 @@
 	</methods>
 	<members>
 		<member name="x" type="float" setter="" getter="">
-			The vector's x component.
+			The vector's x component. Also accessible by using the index position [code][0][/code].
 		</member>
 		<member name="y" type="float" setter="" getter="">
-			The vector's y component.
+			The vector's y component. Also accessible by using the index position [code][1][/code].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -260,13 +260,13 @@
 	</methods>
 	<members>
 		<member name="x" type="float" setter="" getter="">
-			The vector's x component.
+			The vector's x component. Also accessible by using the index position [code][0][/code].
 		</member>
 		<member name="y" type="float" setter="" getter="">
-			The vector's y component.
+			The vector's y component. Also accessible by using the index position [code][1][/code].
 		</member>
 		<member name="z" type="float" setter="" getter="">
-			The vector's z component.
+			The vector's z component. Also accessible by using the index position [code][2][/code].
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Coulnd't find any documentation that vector coordinates can be accessed like arrays. Don't know what's the best place to add it, I think it should be part of the documentation since it makes writing code much easier. 