### PR TITLE
Removed undeclared and unused variable, which caused a compile error

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -191,7 +191,6 @@ void GDMono::initialize() {
 			String hint_config_dir = path_join(locations[i], "etc");
 
 			if (FileAccess::exists(hint_mscorlib_path) && DirAccess::exists(hint_config_dir)) {
-				need_set_mono_dirs = false;
 				assembly_rootdir = hint_assembly_rootdir;
 				config_dir = hint_config_dir;
 				break;


### PR DESCRIPTION
This variable is never mentioned before or after this line, but it causes the compiler to fail on macOS, when compiling with Mono support.