### PR TITLE
Fix control lost focus on multi touch

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -858,11 +858,11 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 				public void run() {
 					switch (action) {
 						case MotionEvent.ACTION_DOWN: {
-							GodotLib.touch(0, 0, evcount, arr);
+							GodotLib.touch(0, pointer_idx, evcount, arr);
 							//System.out.printf("action down at: %f,%f\n", event.getX(),event.getY());
 						} break;
 						case MotionEvent.ACTION_MOVE: {
-							GodotLib.touch(1, 0, evcount, arr);
+							GodotLib.touch(1, pointer_idx, evcount, arr);
 							/*
 							for(int i=0;i<event.getPointerCount();i++) {
 								System.out.printf("%d - moved to: %f,%f\n",i, event.getX(i),event.getY(i));
@@ -879,7 +879,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 						} break;
 						case MotionEvent.ACTION_CANCEL:
 						case MotionEvent.ACTION_UP: {
-							GodotLib.touch(2, 0, evcount, arr);
+							GodotLib.touch(2, pointer_idx, evcount, arr);
 							/*
 							for(int i=0;i<event.getPointerCount();i++) {
 								System.out.printf("%d - up! %f,%f\n",i, event.getX(i),event.getY(i));

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -251,6 +251,7 @@ private:
 		bool key_event_accepted;
 		Control *mouse_focus;
 		Control *mouse_click_grabber;
+		Vector<Control *> touch_focus;
 		int mouse_focus_button;
 		Control *key_focus;
 		Control *mouse_over;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/16761

Allows focusing multiple control elements on multi-touch screen devices. Also sets valid pointer's index 
 on release event when the pointers are released in reverse order.

Tested on 3.0 and 3.1, works on my KIW-L21, Android 6.0

Example project provided [_gui_input.zip](https://github.com/godotengine/godot/files/2503143/_gui_input.zip)

EDIT: I've made this PR because i'm working on a customized version of Godot 3.0 for my game and i've fixed this issue as well, maybe you can use it too.