### PR TITLE
Fix gles3 shader to actually multiply specular light by rev_amount for fog calculations.

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2053,7 +2053,7 @@ FRAGMENT_SHADER_CODE
 
 		emission = emission * rev_amount + fog_color * fog_amount;
 		ambient_light *= rev_amount;
-		specular_light *rev_amount;
+		specular_light *= rev_amount;
 		diffuse_light *= rev_amount;
 	}
 


### PR DESCRIPTION
This resolves the 'additive' anomaly seen for dark colors of fog mentioned in #12454.

*Bugsquad edit:* Fixes #12454.