### PR TITLE
Remove unneeded strncpy in lws_client.

### DIFF
--- a/modules/websocket/emws_server.cpp
+++ b/modules/websocket/emws_server.cpp
@@ -71,6 +71,9 @@ int EMWSServer::get_peer_port(int p_peer_id) const {
 void EMWSServer::disconnect_peer(int p_peer_id, int p_code, String p_reason) {
 }
 
+void EMWSServer::poll() {
+}
+
 EMWSServer::EMWSServer() {
 }
 


### PR DESCRIPTION
Pass the String buffer directly, `lws_client_connect_via_info` will copy them for us.

Closes #23236
Fixes #23141

*Edit*: Also add missing definition of `EMWSServer::poll` in ref to #23005