### PR TITLE
Get surface material count in MeshInstance for scripts

### DIFF
--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -253,6 +253,11 @@ void MeshInstance::_notification(int p_what) {
 	}
 }
 
+int MeshInstance::get_surface_material_count() const {
+
+	return materials.size();
+}
+
 void MeshInstance::set_surface_material(int p_surface, const Ref<Material> &p_material) {
 
 	ERR_FAIL_INDEX(p_surface, materials.size());
@@ -359,6 +364,7 @@ void MeshInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skeleton_path", "skeleton_path"), &MeshInstance::set_skeleton_path);
 	ClassDB::bind_method(D_METHOD("get_skeleton_path"), &MeshInstance::get_skeleton_path);
 
+	ClassDB::bind_method(D_METHOD("get_surface_material_count"), &MeshInstance::get_surface_material_count);
 	ClassDB::bind_method(D_METHOD("set_surface_material", "surface", "material"), &MeshInstance::set_surface_material);
 	ClassDB::bind_method(D_METHOD("get_surface_material", "surface"), &MeshInstance::get_surface_material);
 

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -76,6 +76,7 @@ public:
 	void set_skeleton_path(const NodePath &p_skeleton);
 	NodePath get_skeleton_path();
 
+	int get_surface_material_count() const;
 	void set_surface_material(int p_surface, const Ref<Material> &p_material);
 	Ref<Material> get_surface_material(int p_surface) const;
 


### PR DESCRIPTION
Mesh instance has an interface for scripts to get/set surface materials by index, but there's currently no way to access the number of surface materials.

It can be useful for scripts to access all materials from any mesh, for example in order to set shader parameters on all of them.