### PR TITLE
Cleaning up some uninitialised variables in GLES2 stuff.

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -1209,6 +1209,8 @@ bool RasterizerSceneGLES2::_setup_material(RasterizerStorageGLES2::Material *p_m
 
 	state.scene_shader.set_uniform(SceneShaderGLES2::SKELETON_TEXTURE_SIZE, p_skeleton_tex_size);
 
+	state.current_main_tex = 0;
+
 	for (int i = 0; i < tc; i++) {
 
 		glActiveTexture(GL_TEXTURE0 + i);
@@ -1239,6 +1241,9 @@ bool RasterizerSceneGLES2::_setup_material(RasterizerStorageGLES2::Material *p_m
 		t = t->get_ptr();
 
 		glBindTexture(t->target, t->tex_id);
+		if (i == 0) {
+			state.current_main_tex = t->tex_id;
+		}
 	}
 	state.scene_shader.use_material((void *)p_material);
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4458,6 +4458,7 @@ void RasterizerStorageGLES2::initialize() {
 		}
 	}
 
+	config.keep_original_textures = false;
 	config.shrink_textures_x2 = false;
 
 	config.float_texture_supported = config.extensions.has("GL_ARB_texture_float") || config.extensions.has("GL_OES_texture_float");
@@ -4605,6 +4606,7 @@ void RasterizerStorageGLES2::initialize() {
 #endif
 
 	config.force_vertex_shading = GLOBAL_GET("rendering/quality/shading/force_vertex_shading");
+	config.use_fast_texture_filter = GLOBAL_GET("rendering/quality/filters/use_nearest_mipmap_filter");
 }
 
 void RasterizerStorageGLES2::finalize() {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -60,20 +60,12 @@ public:
 
 		bool shrink_textures_x2;
 		bool use_fast_texture_filter;
-		// bool use_anisotropic_filter;
-
-		bool hdr_supported;
-
-		bool use_rgba_2d_shadows;
-
-		// float anisotropic_level;
 
 		int max_texture_image_units;
 		int max_texture_size;
 
-		bool generate_wireframes;
-
-		bool use_texture_array_environment;
+		// TODO implement wireframe in GLES2
+		// bool generate_wireframes;
 
 		Set<String> extensions;
 
@@ -83,7 +75,6 @@ public:
 
 		bool keep_original_textures;
 
-		bool no_depth_prepass;
 		bool force_vertex_shading;
 	} config;
 
@@ -272,31 +263,28 @@ public:
 		void *detect_normal_ud;
 
 		Texture() {
-			flags = 0;
-			width = 0;
-			height = 0;
 			alloc_width = 0;
 			alloc_height = 0;
-			format = Image::FORMAT_L8;
-
 			target = 0;
 
-			data_size = 0;
-			total_data_size = 0;
-			ignore_mipmaps = false;
-
-			compressed = false;
-
-			active = false;
-
-			tex_id = 0;
-
 			stored_cube_sides = 0;
-
-			proxy = NULL;
-
+			ignore_mipmaps = false;
 			render_target = NULL;
-
+			flags = width = height = 0;
+			tex_id = 0;
+			data_size = 0;
+			format = Image::FORMAT_L8;
+			active = false;
+			compressed = false;
+			total_data_size = 0;
+			mipmaps = 0;
+			detect_3d = NULL;
+			detect_3d_ud = NULL;
+			detect_srgb = NULL;
+			detect_srgb_ud = NULL;
+			detect_normal = NULL;
+			detect_normal_ud = NULL;
+			proxy = NULL;
 			redraw_if_visible = false;
 		}
 

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -432,7 +432,6 @@ void RasterizerGLES3::make_current() {
 
 void RasterizerGLES3::register_config() {
 
-	GLOBAL_DEF("rendering/quality/filters/use_nearest_mipmap_filter", false);
 	GLOBAL_DEF("rendering/quality/filters/anisotropic_filter_level", 4);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/filters/anisotropic_filter_level", PropertyInfo(Variant::INT, "rendering/quality/filters/anisotropic_filter_level", PROPERTY_HINT_RANGE, "1,16,1"));
 	GLOBAL_DEF("rendering/limits/time/time_rollover_secs", 3600);

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2401,6 +2401,8 @@ VisualServer::VisualServer() {
 
 	GLOBAL_DEF("rendering/quality/depth_prepass/enable", true);
 	GLOBAL_DEF("rendering/quality/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno");
+
+	GLOBAL_DEF("rendering/quality/filters/use_nearest_mipmap_filter", false);
 }
 
 VisualServer::~VisualServer() {


### PR DESCRIPTION
Initialise keep_original_textures and use_fast_texture_filter in storage
config. Removed any other variables from storage config that were both unused
and uninitialised to avoid future confusion (if they're needed it's
easier to spot an uninitialised variable problem in a PR that adds the
variable again rather than just uses it).

Copied storage Texture struct constructor from GLES3 implementation
(except where variables were already initialised with different values).
Gives us sensible tested defaults for previously uninitialised vars.

Added assignments for state.current_main_tex based on same in GLES3.

fixes #23246