### PR TITLE
Moved the ResourceFormatLoaderText to a solid singleton pattern

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1446,7 +1446,7 @@ void EditorSceneImporterESCN::get_extensions(List<String> *r_extensions) const {
 Node *EditorSceneImporterESCN::import_scene(const String &p_path, uint32_t p_flags, int p_bake_fps, List<String> *r_missing_deps, Error *r_err) {
 
 	Error error;
-	Ref<PackedScene> ps = ResourceFormatLoaderText::singleton->load(p_path, p_path, &error);
+	Ref<PackedScene> ps = ResourceFormatLoaderText::get_singleton()->load(p_path, p_path, &error);
 	ERR_FAIL_COND_V(!ps.is_valid(), NULL);
 
 	Node *scene = ps->instance();

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1711,7 +1711,7 @@ void NativeReloadNode::_notification(int p_what) {
 }
 
 RES ResourceFormatLoaderNativeScript::load(const String &p_path, const String &p_original_path, Error *r_error) {
-	return ResourceFormatLoaderText::singleton->load(p_path, p_original_path, r_error);
+	return ResourceFormatLoaderText::get_singleton()->load(p_path, p_original_path, r_error);
 }
 
 void ResourceFormatLoaderNativeScript::get_recognized_extensions(List<String> *p_extensions) const {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -248,7 +248,7 @@ void register_scene_types() {
 	resource_saver_text = memnew(ResourceFormatSaverText);
 	ResourceSaver::add_resource_format_saver(resource_saver_text, true);
 
-	resource_loader_text = memnew(ResourceFormatLoaderText);
+	resource_loader_text = ResourceFormatLoaderText::get_singleton();
 	ResourceLoader::add_resource_format_loader(resource_loader_text, true);
 
 	resource_saver_shader = memnew(ResourceFormatSaverShader);

--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -1333,6 +1333,13 @@ Error ResourceFormatLoaderText::convert_file_to_binary(const String &p_src_path,
 	return ria->save_as_binary(f, p_dst_path);
 }
 
+ResourceFormatLoaderText *ResourceFormatLoaderText::get_singleton() {
+	if (ResourceFormatLoaderText::singleton == NULL) {
+		ResourceFormatLoaderText::singleton = memnew(ResourceFormatLoaderText);
+	}
+	return ResourceFormatLoaderText::singleton;
+}
+
 /*****************************************************************************************************/
 /*****************************************************************************************************/
 /*****************************************************************************************************/

--- a/scene/resources/scene_format_text.h
+++ b/scene/resources/scene_format_text.h
@@ -129,8 +129,10 @@ public:
 
 class ResourceFormatLoaderText : public ResourceFormatLoader {
 
-public:
+	ResourceFormatLoaderText() {}
 	static ResourceFormatLoaderText *singleton;
+
+public:
 	virtual Ref<ResourceInteractiveLoader> load_interactive(const String &p_path, const String &p_original_path = "", Error *r_error = NULL);
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
@@ -140,8 +142,7 @@ public:
 	virtual Error rename_dependencies(const String &p_path, const Map<String, String> &p_map);
 
 	static Error convert_file_to_binary(const String &p_src_path, const String &p_dst_path);
-
-	ResourceFormatLoaderText() { singleton = this; }
+	static ResourceFormatLoaderText *get_singleton();
 };
 
 class ResourceFormatSaverTextInstance {


### PR DESCRIPTION
The misuse of the ResourceFormatLoaderText in GDNative caused issues on my project for quite some time.
(Segfaults when importing escn files, forcing everyone that partecipates in the project to open godot 3 - 10 times when pulling the updated project)
 
As mentioned in #23223, might be worth to make the code more robust.

When editing scene/register_scene_types.cpp,  i noticed that there are many other loaders.
Not sure if it makes sense to do the same for all of them.