### PR TITLE
GLES2: Fix shadows shader error for SpotLights

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1307,8 +1307,7 @@ LIGHT_SHADER_CODE
 #define SAMPLE_SHADOW_TEXEL(p_shadow, p_pos, p_depth) step(p_depth, texture2D(p_shadow, p_pos).r)
 #define SAMPLE_SHADOW_TEXEL_PROJ(p_shadow, p_pos) step(p_pos.z, texture2DProj(p_shadow, p_pos).r)
 
-float sample_shadow(
-		highp sampler2D shadow, highp vec4 spos) {
+float sample_shadow(highp sampler2D shadow, highp vec4 spos) {
 
 #ifdef SHADOW_MODE_PCF_13
 
@@ -1923,12 +1922,12 @@ FRAGMENT_SHADER_CODE
 		highp vec4 splane = shadow_coord;
 		splane.xyz /= splane.w;
 
-		float shadow = sample_shadow(light_shadow_atlas, splane.xy, splane.z);
+		float shadow = sample_shadow(light_shadow_atlas, splane);
 		light_att *= shadow;
 	}
 #endif
 
-#endif
+#endif // LIGHT_MODE_SPOT
 
 #ifdef USE_VERTEX_LIGHTING
 	//vertex lighting


### PR DESCRIPTION
Fixes #23268, fixes #22649.

It doesn't actually make shadows work for SpotLights under GLES2 though, in my tests they're not functional and the SpotLight itself seems a bit broken. But it prevents a shader compilation failure and weird rendering bug, so that's good to take anyway. I'll open an issue about non functional SpotLight shadows.