### PR TITLE
Restore ClearScript btn w/ ExtendScript RMB link

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -358,15 +358,12 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					ScriptLanguage *l = ScriptServer::get_language(i);
 					if (l->get_type() == existing->get_class()) {
 						String name = l->get_global_class_name(existing->get_path());
-						if (ScriptServer::is_global_class(name)) {
-							if (EDITOR_GET("interface/editors/derive_script_globals_by_name").operator bool()) {
-								inherits = editor->get_editor_data().script_class_get_base(name);
-							} else if (l->can_inherit_from_file()) {
-								inherits = "\"" + existing->get_path() + "\"";
-							}
-						} else {
+						if (ScriptServer::is_global_class(name) && EDITOR_GET("interface/editors/derive_script_globals_by_name").operator bool()) {
+							inherits = name;
+						} else if (l->can_inherit_from_file()) {
 							inherits = "\"" + existing->get_path() + "\"";
 						}
+						break;
 					}
 				}
 			}
@@ -1503,6 +1500,7 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 	editor_data->get_undo_redo().commit_action();
 
 	editor->push_item(p_script.operator->());
+	_update_script_button();
 }
 
 void SceneTreeDock::_toggle_editable_children() {
@@ -1618,17 +1616,17 @@ void SceneTreeDock::_delete_confirm() {
 
 void SceneTreeDock::_update_script_button() {
 	if (EditorNode::get_singleton()->get_editor_selection()->get_selection().size() == 1) {
-		button_create_script->show();
 		Node *n = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list()[0];
 		if (n->get_script().is_null()) {
-			button_create_script->set_icon(get_icon("ScriptCreate", "EditorIcons"));
-			button_create_script->set_tooltip(TTR("Attach a new or existing script for the selected node."));
+			button_create_script->show();
+			button_clear_script->hide();
 		} else {
-			button_create_script->set_icon(get_icon("ScriptExtend", "EditorIcons"));
-			button_create_script->set_tooltip(TTR("Extend the selected node's script with a new or existing script."));
+			button_create_script->hide();
+			button_clear_script->show();
 		}
 	} else {
-		button_create_script->hide();
+		button_create_script->show();
+		button_clear_script->hide();
 	}
 }
 
@@ -2076,6 +2074,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	menu->add_icon_shortcut(get_icon("ScriptCreate", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/attach_script"), TOOL_ATTACH_SCRIPT);
 	if (selection.size() > 1 || existing_script.is_valid()) {
 		menu->add_icon_shortcut(get_icon("ScriptRemove", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/clear_script"), TOOL_CLEAR_SCRIPT);
+		menu->add_icon_shortcut(get_icon("ScriptExtend", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/extend_script"), TOOL_ATTACH_SCRIPT);
 	}
 
 	menu->add_separator();
@@ -2339,6 +2338,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	ED_SHORTCUT("scene_tree/instance_scene", TTR("Instance Child Scene"));
 	ED_SHORTCUT("scene_tree/change_node_type", TTR("Change Type"));
 	ED_SHORTCUT("scene_tree/attach_script", TTR("Attach Script"));
+	ED_SHORTCUT("scene_tree/extend_script", TTR("Extend Script"));
 	ED_SHORTCUT("scene_tree/clear_script", TTR("Clear Script"));
 	ED_SHORTCUT("scene_tree/move_up", TTR("Move Up"), KEY_MASK_CMD | KEY_UP);
 	ED_SHORTCUT("scene_tree/move_down", TTR("Move Down"), KEY_MASK_CMD | KEY_DOWN);
@@ -2374,6 +2374,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	tb = memnew(ToolButton);
 	tb->connect("pressed", this, "_tool_selected", make_binds(TOOL_ATTACH_SCRIPT, false));
+	tb->set_tooltip(TTR("Attach a new or existing script for the selected node."));
 	tb->set_shortcut(ED_GET_SHORTCUT("scene_tree/attach_script"));
 	filter_hbc->add_child(tb);
 	tb->hide();


### PR DESCRIPTION
Closes #20590.

Changes:

1. Since quite a few people seem to want the old functionality back, and because it will be jarring for old users who haven't yet messed around in 3.1, I'm restoring the old "Clear Script" button and just adding an "Extend Script" option in the right-mouse-button menu.

2. I also noticed that the extension code wasn't properly filling in a script class's name (was filling in the script class's inherited name rather than the name of the currently attached script you want to extend). It now also checks that the language can inherit from a file regardless of whether it's a script class or not (which is the right way to handle it).

3. The scene dock's script button will now update correctly when creating a script on an unscripted node. Previously, after creating the script, the dock would still display the "CreateScript" button. You would have to click off the node in the scene dock and then click back onto it in order for the icon to update itself to show the "ClearScript" button.
    - Curiously, you can't actually *click* the button until you've clicked off/on the node anyway. It would seem that until you do, the scene dock just doesn't open the ScriptCreateDialog at all (unresponsive). The above change is more of an easier-on-the-eyes change so that the visuals reflect the changed data more consistently.