### PR TITLE
Add method get_collision_exceptions to PhysicsBody2D

### DIFF
--- a/doc/classes/PhysicsBody.xml
+++ b/doc/classes/PhysicsBody.xml
@@ -21,6 +21,13 @@
 				Adds a body to the list of bodies that this body can't collide with.
 			</description>
 		</method>
+		<method name="get_collision_exceptions">
+			<return type="Array">
+			</return>
+			<description>
+				Returns an array of nodes that were added as collision exceptions for this body.
+			</description>
+		</method>
 		<method name="get_collision_layer_bit" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -21,6 +21,13 @@
 				Adds a body to the list of bodies that this body can't collide with.
 			</description>
 		</method>
+		<method name="get_collision_exceptions">
+			<return type="Array">
+			</return>
+			<description>
+				Returns an array of nodes that were added as collision exceptions for this body.
+			</description>
+		</method>
 		<method name="get_collision_layer_bit" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/doc/classes/SoftBody.xml
+++ b/doc/classes/SoftBody.xml
@@ -20,6 +20,13 @@
 				Adds a body to the list of bodies that this body can't collide with.
 			</description>
 		</method>
+		<method name="get_collision_exceptions">
+			<return type="Array">
+			</return>
+			<description>
+				Returns an array of nodes that were added as collision exceptions for this body.
+			</description>
+		</method>
 		<method name="get_collision_layer_bit" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -67,6 +67,7 @@ public:
 	void set_collision_layer_bit(int p_bit, bool p_value);
 	bool get_collision_layer_bit(int p_bit) const;
 
+	Array get_collision_exceptions();
 	void add_collision_exception_with(Node *p_node); //must be physicsbody
 	void remove_collision_exception_with(Node *p_node);
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -32,7 +32,10 @@
 
 #include "core/core_string_names.h"
 #include "core/engine.h"
+#include "core/list.h"
 #include "core/method_bind_ext.gen.inc"
+#include "core/object.h"
+#include "core/rid.h"
 #include "scene/scene_string_names.h"
 
 #ifdef TOOLS_ENABLED
@@ -106,6 +109,20 @@ void PhysicsBody::set_collision_layer_bit(int p_bit, bool p_value) {
 bool PhysicsBody::get_collision_layer_bit(int p_bit) const {
 
 	return get_collision_layer() & (1 << p_bit);
+}
+
+Array PhysicsBody::get_collision_exceptions() {
+	List<RID> exceptions;
+	PhysicsServer::get_singleton()->body_get_collision_exceptions(get_rid(), &exceptions);
+	Array ret;
+	for (List<RID>::Element *E = exceptions.front(); E; E = E->next()) {
+		RID body = E->get();
+		ObjectID instance_id = PhysicsServer::get_singleton()->body_get_object_instance_id(body);
+		Object *obj = ObjectDB::get_instance(instance_id);
+		PhysicsBody *physics_body = Object::cast_to<PhysicsBody>(obj);
+		ret.append(physics_body);
+	}
+	return ret;
 }
 
 void PhysicsBody::add_collision_exception_with(Node *p_node) {
@@ -289,6 +306,7 @@ void StaticBody::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_reload_physics_characteristics"), &StaticBody::_reload_physics_characteristics);
 
+	ClassDB::bind_method(D_METHOD("get_collision_exceptions"), &PhysicsBody::get_collision_exceptions);
 	ClassDB::bind_method(D_METHOD("add_collision_exception_with", "body"), &PhysicsBody::add_collision_exception_with);
 	ClassDB::bind_method(D_METHOD("remove_collision_exception_with", "body"), &PhysicsBody::remove_collision_exception_with);
 

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -69,6 +69,7 @@ public:
 	void set_collision_mask_bit(int p_bit, bool p_value);
 	bool get_collision_mask_bit(int p_bit) const;
 
+	Array get_collision_exceptions();
 	void add_collision_exception_with(Node *p_node); //must be physicsbody
 	void remove_collision_exception_with(Node *p_node);
 

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -29,8 +29,12 @@
 /*************************************************************************/
 
 #include "soft_body.h"
+#include "core/list.h"
+#include "core/object.h"
 #include "core/os/os.h"
+#include "core/rid.h"
 #include "scene/3d/collision_object.h"
+#include "scene/3d/physics_body.h"
 #include "scene/3d/skeleton.h"
 #include "servers/physics_server.h"
 
@@ -335,6 +339,7 @@ void SoftBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_parent_collision_ignore", "parent_collision_ignore"), &SoftBody::set_parent_collision_ignore);
 	ClassDB::bind_method(D_METHOD("get_parent_collision_ignore"), &SoftBody::get_parent_collision_ignore);
 
+	ClassDB::bind_method(D_METHOD("get_collision_exceptions"), &SoftBody::get_collision_exceptions);
 	ClassDB::bind_method(D_METHOD("add_collision_exception_with", "body"), &SoftBody::add_collision_exception_with);
 	ClassDB::bind_method(D_METHOD("remove_collision_exception_with", "body"), &SoftBody::remove_collision_exception_with);
 
@@ -545,6 +550,20 @@ void SoftBody::set_pinned_points_indices(PoolVector<SoftBody::PinnedPoint> p_pin
 
 PoolVector<SoftBody::PinnedPoint> SoftBody::get_pinned_points_indices() {
 	return pinned_points;
+}
+
+Array SoftBody::get_collision_exceptions() {
+	List<RID> exceptions;
+	PhysicsServer::get_singleton()->soft_body_get_collision_exceptions(physics_rid, &exceptions);
+	Array ret;
+	for (List<RID>::Element *E = exceptions.front(); E; E = E->next()) {
+		RID body = E->get();
+		ObjectID instance_id = PhysicsServer::get_singleton()->body_get_object_instance_id(body);
+		Object *obj = ObjectDB::get_instance(instance_id);
+		PhysicsBody *physics_body = Object::cast_to<PhysicsBody>(obj);
+		ret.append(physics_body);
+	}
+	return ret;
 }
 
 void SoftBody::add_collision_exception_with(Node *p_node) {

--- a/scene/3d/soft_body.h
+++ b/scene/3d/soft_body.h
@@ -166,6 +166,7 @@ public:
 	void set_drag_coefficient(real_t p_drag_coefficient);
 	real_t get_drag_coefficient();
 
+	Array get_collision_exceptions();
 	void add_collision_exception_with(Node *p_node);
 	void remove_collision_exception_with(Node *p_node);
 


### PR DESCRIPTION
This method returns a list of nodes included in
collision exceptions.

Fixes #23235, cheers!