### PR TITLE
Fix#23250 rounding error in world_to_map function in tile_map

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -50,7 +50,7 @@ void Transform2D::affine_invert() {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
-	real_t idet = 1.0 / det;
+	real_t idet = (((1.0 / det) * 100000) + 0.5) / 100000;
 
 	SWAP(elements[0][0], elements[1][1]);
 	elements[0] *= Vector2(idet, -idet);


### PR DESCRIPTION
[deprecated]Problem: Returning Vector2D always get round down. Vector2D round off is the solution.

Used this script for testing:
```
extends Node2D
func _ready():	
	var tiles = $TileMap.get_used_cells()
	var count = tiles.size()
	print(count)
	if !tiles.empty():
	   for i in count:
		   var before = tiles[i]
		   var world = $TileMap.map_to_world(tiles[i])	  
		   var after = $TileMap.world_to_map(world)
		   if after != before:
			    print("Test Failed:",before,"!=", after,"World=",world)
		   else:
			    print("Test Succeded:",before,"==",after,"World=",world)
	else:
		print("empty")
```
Edit:
Problem is indeed a rounding error.  The Function affine_inverse in transform_2d.cpp got problems with TileMap-cell_sizes which are one of those numbers:
![codecogseqn](https://user-images.githubusercontent.com/24325735/47611134-72f1d600-da5f-11e8-820f-df05d864604f.gif)
the variable idet doesn't evaluate to the desired number
as example:
```
det= 400
idet = 1.0 / det #idet is about 0.0024999... but should be 0.0025
```
The commit provides some workaround in a way that only some of these digits are considered significant to avoid the representational error.
Bug-Reproduction Project 
from https://github.com/godotengine/godot/issues/23250#issuecomment-433231112
[bug.zip](https://github.com/godotengine/godot/files/2520816/bug.zip)

