### PR TITLE
Save last export path when exporting

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -144,6 +144,17 @@ String EditorExportPreset::get_include_filter() const {
 	return include_filter;
 }
 
+void EditorExportPreset::set_export_path(const String &p_path) {
+
+	export_path = p_path;
+	EditorExport::singleton->save_presets();
+}
+
+String EditorExportPreset::get_export_path() const {
+
+	return export_path;
+}
+
 void EditorExportPreset::set_exclude_filter(const String &p_exclude) {
 
 	exclude_filter = p_exclude;
@@ -213,6 +224,7 @@ String EditorExportPreset::get_custom_features() const {
 
 EditorExportPreset::EditorExportPreset() {
 
+	export_path = "";
 	export_filter = EXPORT_ALL_RESOURCES;
 	runnable = false;
 }
@@ -1034,6 +1046,7 @@ void EditorExport::_save() {
 		}
 		config->set_value(section, "include_filter", preset->get_include_filter());
 		config->set_value(section, "exclude_filter", preset->get_exclude_filter());
+		config->set_value(section, "export_path", preset->get_export_path());
 		config->set_value(section, "patch_list", preset->get_patches());
 
 		String option_section = "preset." + itos(i) + ".options";
@@ -1189,6 +1202,7 @@ void EditorExport::load_config() {
 
 		preset->set_include_filter(config->get_value(section, "include_filter"));
 		preset->set_exclude_filter(config->get_value(section, "exclude_filter"));
+		preset->set_export_path(config->get_value(section, "export_path", ""));
 
 		Vector<String> patch_list = config->get_value(section, "patch_list");
 

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -57,6 +57,7 @@ private:
 	ExportFilter export_filter;
 	String include_filter;
 	String exclude_filter;
+	String export_path;
 
 	String exporter;
 	Set<String> selected_files;
@@ -113,6 +114,9 @@ public:
 
 	void set_custom_features(const String &p_custom_features);
 	String get_custom_features() const;
+
+	void set_export_path(const String &p_path);
+	String get_export_path() const;
 
 	const List<PropertyInfo> &get_properties() const { return properties; }
 

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -745,12 +745,16 @@ void ProjectExportDialog::_export_project() {
 	export_project->set_access(FileDialog::ACCESS_FILESYSTEM);
 	export_project->clear_filters();
 
-	String extension = platform->get_binary_extension(current);
-	if (extension != String()) {
-		export_project->add_filter("*." + extension + " ; " + platform->get_name() + " Export");
-		export_project->set_current_file(default_filename + "." + extension);
+	if (current->get_export_path() != "") {
+		export_project->set_current_path(current->get_export_path());
 	} else {
-		export_project->set_current_file(default_filename);
+		String extension = platform->get_binary_extension(current);
+		if (extension != String()) {
+			export_project->add_filter("*." + extension + " ; " + platform->get_name() + " Export");
+			export_project->set_current_file(default_filename + "." + extension);
+		} else {
+			export_project->set_current_file(default_filename);
+		}
 	}
 
 	// Ensure that signal is connected if previous attempt left it disconnected with _validate_export_path
@@ -772,6 +776,7 @@ void ProjectExportDialog::_export_project_to_path(const String &p_path) {
 	ERR_FAIL_COND(current.is_null());
 	Ref<EditorExportPlatform> platform = current->get_platform();
 	ERR_FAIL_COND(platform.is_null());
+	current->set_export_path(p_path);
 
 	Error err = platform->export_project(current, export_debug->is_pressed(), p_path, 0);
 	if (err != OK) {


### PR DESCRIPTION
With this PR the last used export path is saved so that next time you run godot and export the project the last path is already selected.