### PR TITLE
Added "shader" filter to "Find in Files"

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -44,8 +44,6 @@
 #include "scene/gui/progress_bar.h"
 #include "scene/gui/tree.h"
 
-#define ROOT_PREFIX "res://"
-
 const char *FindInFiles::SIGNAL_RESULT_FOUND = "result_found";
 const char *FindInFiles::SIGNAL_FINISHED = "finished";
 
@@ -89,7 +87,6 @@ static bool find_next(const String &line, String pattern, int from, bool match_c
 
 //--------------------------------------------------------------------------------
 FindInFiles::FindInFiles() {
-	_root_prefix = ROOT_PREFIX;
 	_searching = false;
 	_whole_words = true;
 	_match_case = true;
@@ -182,7 +179,7 @@ void FindInFiles::_iterate() {
 			_current_dir = _current_dir.plus_file(folder_name);
 
 			PoolStringArray sub_dirs;
-			_scan_dir(_root_prefix + _current_dir, sub_dirs);
+			_scan_dir("res://" + _current_dir, sub_dirs);
 
 			_folders_stack.push_back(sub_dirs);
 
@@ -348,7 +345,7 @@ FindInFilesDialog::FindInFilesDialog() {
 		HBoxContainer *hbc = memnew(HBoxContainer);
 
 		Label *prefix_label = memnew(Label);
-		prefix_label->set_text(ROOT_PREFIX);
+		prefix_label->set_text("res://");
 		hbc->add_child(prefix_label);
 
 		_folder_line_edit = memnew(LineEdit);
@@ -375,10 +372,12 @@ FindInFilesDialog::FindInFilesDialog() {
 	{
 		HBoxContainer *hbc = memnew(HBoxContainer);
 
+		// TODO: Unhardcode this.
 		Vector<String> exts;
 		exts.push_back("gd");
 		if (Engine::get_singleton()->has_singleton("GodotSharp"))
 			exts.push_back("cs");
+		exts.push_back("shader");
 
 		for (int i = 0; i < exts.size(); ++i) {
 			CheckBox *cb = memnew(CheckBox);

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -73,7 +73,6 @@ private:
 	// Config
 	String _pattern;
 	Set<String> _extension_filter;
-	String _root_prefix;
 	String _root_dir;
 	bool _whole_words;
 	bool _match_case;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -40,6 +40,7 @@
 #include "editor/editor_settings.h"
 #include "editor/find_in_files.h"
 #include "editor/node_dock.h"
+#include "editor/plugins/shader_editor_plugin.h"
 #include "editor/script_editor_debugger.h"
 #include "scene/main/viewport.h"
 #include "script_text_editor.h"
@@ -2788,13 +2789,18 @@ void ScriptEditor::_on_find_in_files_requested(String text) {
 void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_number, int begin, int end) {
 
 	RES res = ResourceLoader::load(fpath);
-	edit(res);
+	if (fpath.get_extension() == "shader") {
+		ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));
+		shader_editor->edit(res.ptr());
+		shader_editor->make_visible(true);
+		shader_editor->get_shader_editor()->goto_line_selection(line_number - 1, begin, end);
+	} else {
+		edit(res);
 
-	ScriptEditorBase *seb = _get_current_editor();
-
-	ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(seb);
-	if (ste) {
-		ste->goto_line_selection(line_number - 1, begin, end);
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
+		if (ste) {
+			ste->goto_line_selection(line_number - 1, begin, end);
+		}
 	}
 }
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -349,9 +349,9 @@ void ShaderEditor::_menu_option(int p_option) {
 
 void ShaderEditor::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-	}
-	if (p_what == NOTIFICATION_DRAW) {
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+		if (is_visible_in_tree())
+			shader_editor->get_text_edit()->grab_focus();
 	}
 }
 
@@ -388,7 +388,6 @@ void ShaderEditor::_bind_methods() {
 	ClassDB::bind_method("_menu_option", &ShaderEditor::_menu_option);
 	ClassDB::bind_method("_params_changed", &ShaderEditor::_params_changed);
 	ClassDB::bind_method("apply_shaders", &ShaderEditor::apply_shaders);
-	//ClassDB::bind_method("_close_current_tab",&ShaderEditor::_close_current_tab);
 }
 
 void ShaderEditor::ensure_select_current() {
@@ -402,6 +401,11 @@ void ShaderEditor::ensure_select_current() {
 		Ref<Shader> shader = ste->get_edited_shader();
 		get_scene()->get_root_node()->call("_resource_selected",shader);
 	}*/
+}
+
+void ShaderEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
+
+	shader_editor->goto_line_selection(p_line, p_begin, p_end);
 }
 
 void ShaderEditor::edit(const Ref<Shader> &p_shader) {

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -120,6 +120,8 @@ public:
 	void ensure_select_current();
 	void edit(const Ref<Shader> &p_shader);
 
+	void goto_line_selection(int p_line, int p_begin, int p_end);
+
 	virtual Size2 get_minimum_size() const { return Size2(0, 200); }
 	void save_external_data();
 
@@ -142,6 +144,8 @@ public:
 	virtual bool handles(Object *p_object) const;
 	virtual void make_visible(bool p_visible);
 	virtual void selected_notify();
+
+	ShaderEditor *get_shader_editor() const { return shader_editor; }
 
 	virtual void save_external_data();
 	virtual void apply_changes();


### PR DESCRIPTION
There are times that searching inside shader scripts is desirable. So I don't see why it should't be an option.