### PR TITLE
Fix C# parsing the full name of base types

### DIFF
--- a/modules/mono/editor/csharp_project.cpp
+++ b/modules/mono/editor/csharp_project.cpp
@@ -167,6 +167,7 @@ Error generate_scripts_metadata(const String &p_project_path, const String &p_ou
 		ScriptClassParser scp;
 		Error err = scp.parse_file(project_file);
 		if (err != OK) {
+			ERR_PRINTS("Parse error: " + scp.get_error());
 			ERR_EXPLAIN("Failed to determine namespace and class for script: " + project_file);
 			ERR_FAIL_V(err);
 		}

--- a/modules/mono/editor/script_class_parser.h
+++ b/modules/mono/editor/script_class_parser.h
@@ -52,13 +52,18 @@ private:
 		TK_OP_LESS,
 		TK_OP_GREATER,
 		TK_EOF,
-		TK_ERROR
+		TK_ERROR,
+		TK_MAX
 	};
+
+	static const char *token_names[TK_MAX];
+	static String get_token_name(Token p_token);
 
 	Token get_token();
 
-	Error _skip_type_parameters();
+	Error _skip_generic_type_params();
 
+	Error _parse_type_full_name(String &r_full_name);
 	Error _parse_class_base(Vector<String> &r_base);
 	Error _parse_namespace_name(String &r_name, int &r_curly_stack);
 


### PR DESCRIPTION
Previously it would fail if the type name included its namespace.