### PR TITLE
Fix GLES2 automatic texture lookup in canvas

### DIFF
--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -148,7 +148,10 @@ void main() {
 
 	vec4 color = color_interp;
 
+#if !defined(COLOR_USED)
+	//default behavior, texture by color
 	color *= texture2D(color_texture, uv_interp);
+#endif
 
 #ifdef SCREEN_UV_USED
 	vec2 screen_uv = gl_FragCoord.xy * screen_pixel_size;


### PR DESCRIPTION
After this change the color will only be fetched if the shader code doesn't use it explicitly, to match the GLES3 behaviour.

Fixes #23179.