### PR TITLE
Add new log functions for C#.

### DIFF
--- a/modules/mono/glue/Managed/Files/GD.cs
+++ b/modules/mono/glue/Managed/Files/GD.cs
@@ -70,6 +70,16 @@ namespace Godot
             return ResourceLoader.Load<T>(path);
         }
 
+        public static void LogError(string message)
+        {
+            godot_icall_GD_logerror(message);
+        }
+
+        public static void LogWarning(string message)
+        {
+            godot_icall_GD_logwarning(message);
+        }
+
         public static void Print(params object[] what)
         {
             godot_icall_GD_print(what);
@@ -238,5 +248,11 @@ namespace Godot
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static string godot_icall_GD_var2str(object var);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static void godot_icall_GD_logerror(string type);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static void godot_icall_GD_logwarning(string type);
     }
 }

--- a/modules/mono/glue/gd_glue.cpp
+++ b/modules/mono/glue/gd_glue.cpp
@@ -157,6 +157,14 @@ bool godot_icall_GD_type_exists(MonoString *p_type) {
 	return ClassDB::class_exists(GDMonoMarshal::mono_string_to_godot(p_type));
 }
 
+void godot_icall_GD_logerror(MonoString *p_str) {
+	ERR_PRINTS(GDMonoMarshal::mono_string_to_godot(p_str));
+}
+
+void godot_icall_GD_logwarning(MonoString *p_str) {
+	WARN_PRINTS(GDMonoMarshal::mono_string_to_godot(p_str));
+}
+
 MonoArray *godot_icall_GD_var2bytes(MonoObject *p_var) {
 	Variant var = GDMonoMarshal::mono_object_to_variant(p_var);
 
@@ -186,6 +194,8 @@ void godot_register_gd_icalls() {
 	mono_add_internal_call("Godot.GD::godot_icall_GD_convert", (void *)godot_icall_GD_convert);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_hash", (void *)godot_icall_GD_hash);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_instance_from_id", (void *)godot_icall_GD_instance_from_id);
+	mono_add_internal_call("Godot.GD::godot_icall_GD_logerror", (void *)godot_icall_GD_logerror);
+	mono_add_internal_call("Godot.GD::godot_icall_GD_logwarning", (void *)godot_icall_GD_logwarning);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_print", (void *)godot_icall_GD_print);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_printerr", (void *)godot_icall_GD_printerr);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_printraw", (void *)godot_icall_GD_printraw);


### PR DESCRIPTION
At the moment, the only way for a C# script to create an error that shows up in the Debugger pane is to throw an exception. This has some problems and limitations:

* There is no way to create multiple errors within one function
* There is no way to create a warning
* There is no practical way to create an error, then resume execution, even if the error is recoverable

(okay you can technically store an exception, along with stack trace, then throw it right before you return execution to godot, but . . . eugh)

This adds a pair of functions that let you insert errors and warnings directly. Example:

```cs
    public override void _Ready()
    {
        Library.Config.InfoHandler = str => GD.Print(str);
        Library.Config.WarningHandler = str => GD.LogWarning(str);
        Library.Config.ErrorHandler = str => GD.LogError(str);
        
        // Spool up library, record any errors via callbacks
        Library.Init();

        GD.LogWarning("++?????++ Out of Cheese Error. Redo From Start.");
    }
```

![image](https://user-images.githubusercontent.com/160754/47544099-3c1e9300-d89a-11e8-82ce-6abbcfa57f96.png)

Note that this picks up full stack traces automatically due to how the C# interconnection works.

Some various notes/issues/concerns:

* The functions take simple strings due to how easy text formatting now is in C#.
* This is currently provided for C# only. I've got maybe-functional interfaces for GDScript and visual scripting, but I don't use either of those so I don't feel entirely competent designing how it should work. Still, I'm happy to provide those and beat them into shape if the general idea is accepted.
* The function names are LogError/LogWarning. This was chosen because PrintErr was already taken and because I wanted to implement something so I could keep working. They could probably be improved.
* There's now a bizarre profusion of print functions; the list is now Print(), PrintStack(), PrintErr(), PrintRaw(), PrintS(), PrintT(), LogWarning(), and LogError(), some printing to console and some printing to standard error. My gut feeling is that this could do with a lot of cleanup; I hate to say "you should do it how Unity does it", but Unity really did get the debug output system right. These functions are (intentionally) one step closer to that.

There are probably improvements that can be made to this; feel free to ask.

I've posted this on both IRC and Discord and gotten no feedback, so now it's going here :)