### PR TITLE
Error running Expression.execute after parse error

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -2120,6 +2120,10 @@ Error Expression::parse(const String &p_expression, const Vector<String> &p_inpu
 }
 
 Variant Expression::execute(Array p_inputs, Object *p_base, bool p_show_error) {
+	if (error_set) {
+		ERR_EXPLAIN("There was previously a parse error: " + error_str);
+		ERR_FAIL_V(Variant());
+	}
 
 	execution_error = false;
 	Variant output;


### PR DESCRIPTION
There happens a segmentation fault when you use Expression.parse() and you don't check for errors and then run Expression.execute(). So we check if there was a parse error in the execute method now.
```
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x37140) [0x7f72c6d68140] (??:0)
[2] Expression::_execute(Array const&, Object*, Expression::ENode*, Variant&, String&) (??:0)
[3] Expression::execute(Array, Object*, bool) (??:0)
[4] MethodBind3R<Variant, Array, Object*, bool>::call(Object*, Variant const**, int, Variant::CallError&) (??:0)
[5] Object::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[6] Variant::call_ptr(StringName const&, Variant const**, int, Variant*, Variant::CallError&) (??:0)
[7] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Variant::CallError&, GDScriptFunction::CallState*) (??:0)
[8] GDScriptInstance::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[9] Object::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[10] Object::emit_signal(StringName const&, Variant const**, int) (??:0)
[11] Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (??:0)
[12] LineEdit::_gui_input(Ref<InputEvent>) (??:0)
[13] MethodBind1<Ref<InputEvent> >::call(Object*, Variant const**, int, Variant::CallError&) (??:0)
[14] Object::call_multilevel(StringName const&, Variant const**, int) (??:0)
[15] Object::call_multilevel(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (??:0)
[16] Viewport::_gui_input_event(Ref<InputEvent>) (??:0)
[17] Viewport::input(Ref<InputEvent> const&) (??:0)
[18] Viewport::_vp_input(Ref<InputEvent> const&) (??:0)
[19] MethodBind1<Ref<InputEvent> const&>::call(Object*, Variant const**, int, Variant::CallError&) (??:0)
[20] Object::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[21] Object::call(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (??:0)
[22] SceneTree::call_group_flags(unsigned int, StringName const&, StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (??:0)
[23] SceneTree::input_event(Ref<InputEvent> const&) (??:0)
[24] InputDefault::_parse_input_event_impl(Ref<InputEvent> const&, bool) (??:0)
[25] InputDefault::parse_input_event(Ref<InputEvent> const&) (??:0)
[26] OS_X11::handle_key_event(XKeyEvent*, bool) (??:0)
[27] OS_X11::process_xevents() (??:0)
[28] OS_X11::run() (??:0)
```
I guess Expression.parse() and Expression.execute() shouldn't be exposed to gdscript and have a method like Expression.run() that combine them but that's another conversation.