### PR TITLE
GDNative: Fixes a library path problem after exporting app for OSX

### DIFF
--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -306,6 +306,13 @@ bool GDNative::initialize() {
 #elif defined(UWP_ENABLED)
 	// On UWP we use a relative path from the app
 	String path = lib_path.replace("res://", "");
+#elif defined(OSX_ENABLED)
+	// On OSX the exported libraries are located under the Frameworks directory.
+	// So we need to replace the library path.
+	String path = ProjectSettings::get_singleton()->globalize_path(lib_path);
+	if (!FileAccess::exists(path)) {
+		path = OS::get_singleton()->get_executable_path().get_base_dir().plus_file("../Frameworks").plus_file(lib_path.get_file());
+	}
 #else
 	String path = ProjectSettings::get_singleton()->globalize_path(lib_path);
 #endif


### PR DESCRIPTION
Hi

I have a problem with GDNative on OSX after exporting.

After exporting the OSX application, the GDNative library will be placed under Frameworks directory.

When I launch this exported application, the library path of the project is loaded, but since this path does not exist, it will be replaced within OS_OSX::open_dynamic_library().
https://github.com/godotengine/godot/blob/master/platform/osx/os_osx.mm#L1534-L1537

Finally, the library path is assigned to active_library_path, but it is not correct because it is replaced within OS_OSX::open_dynamic_library().
https://github.com/godotengine/godot/blob/master/modules/gdnative/gdnative.cpp#L367

So I think it is necessary to replace the library path before OS_OSX::open_dynamic_library().

Thanks