### PR TITLE
Android / Gradle: Change order of Gradle repos

### DIFF
--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -14,9 +14,9 @@ apply plugin: 'com.android.application'
 
 allprojects {
     repositories {
-    	jcenter()
 	mavenCentral()
 	google()
+	jcenter()
 	$$GRADLE_REPOSITORY_URLS$$
     }
 }


### PR DESCRIPTION
* Move jcenter behind mavenCentral and google gradle repos to fix build problems

## Why?

In my team's Godot/Android project, we use a Firebase module to connect with a Realtime Database.
The `config.py` of the module looks like this:

```python
def can_build(env, platform):
	return platform == "android"

def configure(env):
	if (env['platform'] == 'android'):
		env.android_add_java_dir("android")
		env.android_add_res_dir("android/res")
		env.android_add_gradle_classpath('com.google.gms:google-services:4.1.0')
		env.android_add_dependency("compile 'com.google.firebase:firebase-core:16.0.4'")
		env.android_add_dependency("compile 'com.google.firebase:firebase-database:16.0.3'")
		env.android_add_dependency("compile 'com.google.firebase:firebase-auth:16.0.4'")
		env.android_add_gradle_plugin("com.google.gms.google-services")
``` 

(There is also a `google-services.json` file which is added manually to `platform/android/java`.)

Some time last week, our gradle build stopped working with the following error message:

```gradle
FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all files for configuration ':debugCompileClasspath'.
> Could not find firebase-iid-interop.aar (com.google.firebase:firebase-iid-interop:16.0.0).
  Searched in the following locations:
      https://jcenter.bintray.com/com/google/firebase/firebase-iid-interop/16.0.0/firebase-iid-interop-16.0.0.aar
> Could not find play-services-basement.aar (com.google.android.gms:play-services-basement:15.0.1).
  Searched in the following locations:
      https://jcenter.bintray.com/com/google/android/gms/play-services-basement/15.0.1/play-services-basement-15.0.1.aar
```

Other people seem to have had this problem before, with earlier versions of the libraries: https://stackoverflow.com/questions/50563407/could-not-find-play-services-basement-aar

There is also this Google issue: https://issuetracker.google.com/issues/80362794

I'm not sure what happened last week that made our build fail (as we did not recently upgrade anything), but the suggested solution here: https://stackoverflow.com/a/51213879 of putting jCenter behing mavenCentral and google works for our build.