### PR TITLE
Add conda environment as dependency manager

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -1,0 +1,9 @@
+name: godot-dev
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - clangdev=6.0.0=default_0
+  - python=3.6
+  - scons=3.0.1=py36_1
+


### PR DESCRIPTION
This file allows new contributors to just run
`conda env update` and then activate the environment
in order to have Godot dependencies setup.

Fixes #23363