### PR TITLE
Fix small visual bug in filesystem dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -353,7 +353,7 @@ void FileSystemDock::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			if (tree->is_visible_in_tree()) {
+			if (is_visible_in_tree()) {
 				_update_display_mode(true);
 			}
 		} break;


### PR DESCRIPTION
Fix for a small bug. when theme changed it didnt change theme elements when Toggle split mode is disabled, now it will..