### PR TITLE
Hide "Attach Script" if node has one

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2071,7 +2071,9 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		existing_script = selected->get_script();
 	}
 
-	menu->add_icon_shortcut(get_icon("ScriptCreate", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/attach_script"), TOOL_ATTACH_SCRIPT);
+	if (!existing_script.is_valid()) {
+		menu->add_icon_shortcut(get_icon("ScriptCreate", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/attach_script"), TOOL_ATTACH_SCRIPT);
+	}
 	if (selection.size() > 1 || existing_script.is_valid()) {
 		menu->add_icon_shortcut(get_icon("ScriptRemove", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/clear_script"), TOOL_CLEAR_SCRIPT);
 		menu->add_icon_shortcut(get_icon("ScriptExtend", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/extend_script"), TOOL_ATTACH_SCRIPT);


### PR DESCRIPTION
"Attach Script" acts the same way with "Extend Script" when a node has one.

Current version
![peek 2018-10-29 22-32](https://user-images.githubusercontent.com/8281454/47652960-b452c480-dbca-11e8-92fa-692d7014d252.gif)

with this PR
![peek 2018-10-29 22-30](https://user-images.githubusercontent.com/8281454/47652970-bb79d280-dbca-11e8-8bf8-950a8e31588a.gif)
