### PR TITLE
Warning dialog is now shown if trying to set Node name to empty string

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -665,6 +665,13 @@ void SceneTreeEditor::_renamed() {
 	Node *n = get_node(np);
 	ERR_FAIL_COND(!n);
 
+	// Empty node names are not allowed, so resets it to previous text and show warning
+	if (which->get_text(0).strip_edges().empty()) {
+		which->set_text(0, n->get_name());
+		EditorNode::get_singleton()->show_warning(TTR("No name provided"));
+		return;
+	}
+
 	String new_name = which->get_text(0);
 	if (!Node::_validate_node_name(new_name)) {
 


### PR DESCRIPTION
If the user tried to change a Node name to an empty string in the Scene Tree Editor an error would be returned to console, now a warning dialog is shown with a clear message.

Fixes #23376 and fixes #23378.