### PR TITLE
Use BufferSubData instead of MapBufferRange in non-ES platforms

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -43,6 +43,12 @@
 #include "shaders/cubemap_filter.glsl.gen.h"
 #include "shaders/particles.glsl.gen.h"
 
+// WebGL 2.0 has no MapBufferRange/UnmapBuffer, but offers a non-ES style BufferSubData API instead.
+#ifdef __EMSCRIPTEN__
+void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data);
+void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const GLvoid *data);
+#endif
+
 class RasterizerCanvasGLES3;
 class RasterizerSceneGLES3;
 


### PR DESCRIPTION
Emscripten changed default settings to fail on undefined references (#23005), including `glMapBufferRange` and `glUnmapBuffer`, which aren't available in WebGL.
Rather than change the setting, this patch replaces usage of those functions in HTML5 builds with WebGL 2 functions that mirror the non-ES `glBufferSubData` interface.

In cases where using `glGetBufferSubData` avoids a copy over buffer mapping, it's now used in non-ES platforms as well.