### PR TITLE
Enable --no-heap-copy flag for HTML5 builds

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -128,6 +128,10 @@ def configure(env):
     # us since we don't know requirements at compile-time.
     env.Append(LINKFLAGS=['-s', 'ALLOW_MEMORY_GROWTH=1'])
 
+    # Since we use both memory growth and MEMFS preloading,
+    # this avoids unecessary copying on start-up.
+    env.Append(LINKFLAGS=['--no-heap-copy'])
+
     # This setting just makes WebGL 2 APIs available, it does NOT disable WebGL 1.
     env.Append(LINKFLAGS=['-s', 'USE_WEBGL2=1'])
 


### PR DESCRIPTION
Optimization for HTML5 start-up. Emscripten has recently started emitting a runtime warning about this.