### PR TITLE
Allow the server platform to build on linux again.

### DIFF
--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -19,7 +19,7 @@ def get_program_suffix():
 
 def can_build():
 
-    if (os.name != "posix" or sys.platform != "darwin"):
+    if (os.name != "posix"):
         return False
 
     return True


### PR DESCRIPTION
Fixed a logic error in platform/server/detect.py that prevented building
the server platform on linux.