### PR TITLE
Add new "push_*()" functions to GDScript

### DIFF
--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -106,6 +106,8 @@ const char *GDScriptFunctions::get_func_name(Function p_func) {
 		"printerr",
 		"printraw",
 		"print_debug",
+		"push_error",
+		"push_warning",
 		"var2str",
 		"str2var",
 		"var2bytes",
@@ -707,11 +709,38 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 
 			ScriptLanguage *script = GDScriptLanguage::get_singleton();
 			if (script->debug_get_stack_level_count() > 0) {
-				str += "\n\t";
-				str += "At: " + script->debug_get_stack_level_source(0) + ":" + itos(script->debug_get_stack_level_line(0)); // + " in function '" + script->debug_get_stack_level_function(0) + "'";
+				str += "\n   At: " + script->debug_get_stack_level_source(0) + ":" + itos(script->debug_get_stack_level_line(0)) + ":" + script->debug_get_stack_level_function(0) + "()";
 			}
 
 			print_line(str);
+			r_ret = Variant();
+		} break;
+		case PUSH_ERROR: {
+			VALIDATE_ARG_COUNT(1);
+			if (p_args[0]->get_type() != Variant::STRING) {
+				r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				r_error.argument = 0;
+				r_error.expected = Variant::STRING;
+				r_ret = Variant();
+				break;
+			}
+
+			String message = *p_args[0];
+			ERR_PRINTS(message);
+			r_ret = Variant();
+		} break;
+		case PUSH_WARNING: {
+			VALIDATE_ARG_COUNT(1);
+			if (p_args[0]->get_type() != Variant::STRING) {
+				r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				r_error.argument = 0;
+				r_error.expected = Variant::STRING;
+				r_ret = Variant();
+				break;
+			}
+
+			String message = *p_args[0];
+			WARN_PRINTS(message);
 			r_ret = Variant();
 		} break;
 		case VAR_TO_STR: {
@@ -1754,11 +1783,25 @@ MethodInfo GDScriptFunctions::get_info(Function p_func) {
 			return mi;
 
 		} break;
+		case PUSH_ERROR: {
+
+			MethodInfo mi(Variant::NIL, "push_error", PropertyInfo(Variant::STRING, "message"));
+			mi.return_val.type = Variant::NIL;
+			return mi;
+
+		} break;
+		case PUSH_WARNING: {
+
+			MethodInfo mi(Variant::NIL, "push_warning", PropertyInfo(Variant::STRING, "message"));
+			mi.return_val.type = Variant::NIL;
+			return mi;
+
+		} break;
 		case VAR_TO_STR: {
+
 			MethodInfo mi("var2str", PropertyInfo(Variant::NIL, "var", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT));
 			mi.return_val.type = Variant::STRING;
 			return mi;
-
 		} break;
 		case STR_TO_VAR: {
 
@@ -1768,10 +1811,10 @@ MethodInfo GDScriptFunctions::get_info(Function p_func) {
 			return mi;
 		} break;
 		case VAR_TO_BYTES: {
+
 			MethodInfo mi("var2bytes", PropertyInfo(Variant::NIL, "var", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT));
 			mi.return_val.type = Variant::POOL_BYTE_ARRAY;
 			return mi;
-
 		} break;
 		case BYTES_TO_VAR: {
 

--- a/modules/gdscript/gdscript_functions.h
+++ b/modules/gdscript/gdscript_functions.h
@@ -97,6 +97,8 @@ public:
 		TEXT_PRINTERR,
 		TEXT_PRINTRAW,
 		TEXT_PRINT_DEBUG,
+		PUSH_ERROR,
+		PUSH_WARNING,
 		VAR_TO_STR,
 		STR_TO_VAR,
 		VAR_TO_BYTES,
@@ -117,7 +119,6 @@ public:
 		LEN,
 		IS_INSTANCE_VALID,
 		FUNC_MAX
-
 	};
 
 	static const char *get_func_name(Function p_func);

--- a/modules/mono/glue/Managed/Files/GD.cs
+++ b/modules/mono/glue/Managed/Files/GD.cs
@@ -70,14 +70,14 @@ namespace Godot
             return ResourceLoader.Load<T>(path);
         }
 
-        public static void LogError(string message)
+        public static void PushError(string message)
         {
-            godot_icall_GD_logerror(message);
+            godot_icall_GD_pusherror(message);
         }
 
-        public static void LogWarning(string message)
+        public static void PushWarning(string message)
         {
-            godot_icall_GD_logwarning(message);
+            godot_icall_GD_pushwarning(message);
         }
 
         public static void Print(params object[] what)
@@ -250,9 +250,9 @@ namespace Godot
         internal extern static string godot_icall_GD_var2str(object var);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_logerror(string type);
+        internal extern static void godot_icall_GD_pusherror(string type);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_logwarning(string type);
+        internal extern static void godot_icall_GD_pushwarning(string type);
     }
 }

--- a/modules/mono/glue/gd_glue.cpp
+++ b/modules/mono/glue/gd_glue.cpp
@@ -157,11 +157,11 @@ bool godot_icall_GD_type_exists(MonoString *p_type) {
 	return ClassDB::class_exists(GDMonoMarshal::mono_string_to_godot(p_type));
 }
 
-void godot_icall_GD_logerror(MonoString *p_str) {
+void godot_icall_GD_pusherror(MonoString *p_str) {
 	ERR_PRINTS(GDMonoMarshal::mono_string_to_godot(p_str));
 }
 
-void godot_icall_GD_logwarning(MonoString *p_str) {
+void godot_icall_GD_pushwarning(MonoString *p_str) {
 	WARN_PRINTS(GDMonoMarshal::mono_string_to_godot(p_str));
 }
 
@@ -194,8 +194,8 @@ void godot_register_gd_icalls() {
 	mono_add_internal_call("Godot.GD::godot_icall_GD_convert", (void *)godot_icall_GD_convert);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_hash", (void *)godot_icall_GD_hash);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_instance_from_id", (void *)godot_icall_GD_instance_from_id);
-	mono_add_internal_call("Godot.GD::godot_icall_GD_logerror", (void *)godot_icall_GD_logerror);
-	mono_add_internal_call("Godot.GD::godot_icall_GD_logwarning", (void *)godot_icall_GD_logwarning);
+	mono_add_internal_call("Godot.GD::godot_icall_GD_pusherror", (void *)godot_icall_GD_pusherror);
+	mono_add_internal_call("Godot.GD::godot_icall_GD_pushwarning", (void *)godot_icall_GD_pushwarning);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_print", (void *)godot_icall_GD_print);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_printerr", (void *)godot_icall_GD_printerr);
 	mono_add_internal_call("Godot.GD::godot_icall_GD_printraw", (void *)godot_icall_GD_printraw);


### PR DESCRIPTION
- Added to GDScript the new log functions from #23345.
- Made some small changes to `print_debugger()`, mainly making it show the function name as well.

I really think these should be named something like `debug_error()` and `debug_warn()` (most `print*()` functions should be renamed to be honest), but I'm sticking with the original names from that PR for now.