### PR TITLE
Remove "save folding for:" message when saving

### DIFF
--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -112,7 +112,6 @@ void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path
 	String path = EditorSettings::get_singleton()->get_project_settings_dir();
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
 	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
-	print_line("save folding for: " + file);
 	config->save(file);
 }
 void EditorFolding::load_scene_folding(Node *p_scene, const String &p_path) {


### PR DESCRIPTION
It's unnecessary and just pollutes the Output.