### PR TITLE
Clears application/run/main_scene from project.godot if the file is deleted in editor. 

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -495,10 +495,6 @@ void DependencyRemoveDialog::ok_pressed() {
 			Resource *res = ResourceCache::get(files_to_delete[i]);
 			res->set_path("");
 		}
-      // If the file we are deleting is the main scene, clear the info for the main scene in project.godot.
-      if (files_to_delete[i] == ProjectSettings::get_singleton()->get("application/run/main_scene")) {
-         ProjectSettings::get_singleton()->set("application/run/main_scene", "");
-      }
 		String path = OS::get_singleton()->get_resource_dir() + files_to_delete[i].replace_first("res://", "/");
 		print_verbose("Moving to trash: " + path);
 		Error err = OS::get_singleton()->move_to_trash(path);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -495,10 +495,12 @@ void DependencyRemoveDialog::ok_pressed() {
 			Resource *res = ResourceCache::get(files_to_delete[i]);
 			res->set_path("");
 		}
-      // If the file we are deleting is the main scene, clear the info for the main scene in project.godot.
-      if (files_to_delete[i] == ProjectSettings::get_singleton()->get("application/run/main_scene")) {
-         ProjectSettings::get_singleton()->set("application/run/main_scene", "");
-      }
+
+		// If the file we are deleting is the main scene, clear the info for the main scene in project.godot.
+		if (files_to_delete[i] == ProjectSettings::get_singleton()->get("application/run/main_scene")) {
+			ProjectSettings::get_singleton()->set("application/run/main_scene", "");
+		}
+
 		String path = OS::get_singleton()->get_resource_dir() + files_to_delete[i].replace_first("res://", "/");
 		print_verbose("Moving to trash: " + path);
 		Error err = OS::get_singleton()->move_to_trash(path);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -495,6 +495,10 @@ void DependencyRemoveDialog::ok_pressed() {
 			Resource *res = ResourceCache::get(files_to_delete[i]);
 			res->set_path("");
 		}
+      // If the file we are deleting is the main scene, clear the info for the main scene in project.godot.
+      if (files_to_delete[i] == ProjectSettings::get_singleton()->get("application/run/main_scene")) {
+         ProjectSettings::get_singleton()->set("application/run/main_scene", "");
+      }
 		String path = OS::get_singleton()->get_resource_dir() + files_to_delete[i].replace_first("res://", "/");
 		print_verbose("Moving to trash: " + path);
 		Error err = OS::get_singleton()->move_to_trash(path);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -152,6 +152,7 @@ void EditorNode::_update_scene_tabs() {
 	}
 
 	scene_tabs->set_current_tab(editor_data.get_edited_scene());
+	scene_tabs->ensure_tab_visible(editor_data.get_edited_scene());
 
 	if (scene_tabs->get_offset_buttons_visible()) {
 		// move add button to fixed position on the tabbar


### PR DESCRIPTION
Note: This pull request is virtually identical to #23413 I simply fixed my formatting mistake.

Fixes a bug relating to the main scene.

Currently, if the main scene is deleted through the editor, nothing is changed in the project.godot file to indicate this. Therefore the next time the project is loaded, it will try to open a file that has been deleted.

This change fixes the problem by checking if the file to be deleted is the main scene, and if so clearing "application/run/main_scene" from the project.godot file.

Fixes issue #22473