### PR TITLE
Fix keycode problem on OSX

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -934,7 +934,7 @@ static int remapKey(unsigned int key) {
 
 	CFDataRef layoutData = (CFDataRef)TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData);
 	if (!layoutData)
-		return 0;
+		return translateKey(key);
 
 	const UCKeyboardLayout *keyboardLayout = (const UCKeyboardLayout *)CFDataGetBytePtr(layoutData);
 


### PR DESCRIPTION
fix #21558

In my environment,[ this line](https://github.com/godotengine/godot/blob/master/platform/osx/os_osx.mm#L935) always return nil. and key code will be zero.
I think there should return translated key.

My environment

- macOS 10.14.1
- MacBook Pro (Retina, 13-inch, Late 2013)

