### PR TITLE
Fix initialization of visual server in all platforms

### DIFF
--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -39,7 +39,7 @@
 #include "file_access_android.h"
 #include "main/main.h"
 #include "servers/visual/visual_server_raster.h"
-//#include "servers/visual/visual_server_wrap_mt.h"
+#include "servers/visual/visual_server_wrap_mt.h"
 
 #ifdef ANDROID_NATIVE_ACTIVITY
 #include "dir_access_android.h"
@@ -182,11 +182,12 @@ Error OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int
 
 	video_driver_index = p_video_driver;
 
-	visual_server = memnew(VisualServerRaster);
-	/*	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
+	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
 
 		visual_server = memnew(VisualServerWrapMT(visual_server, false));
-	};*/
+	} else {
+		visual_server = memnew(VisualServerRaster);
+	}
 
 	visual_server->init();
 	//	visual_server->cursor_set_visible(false, 0);

--- a/platform/haiku/os_haiku.cpp
+++ b/platform/haiku/os_haiku.cpp
@@ -117,16 +117,15 @@ Error OS_Haiku::initialize(const VideoMode &p_desired, int p_video_driver, int p
 
 #endif
 
-	visual_server = memnew(VisualServerRaster());
+	// FIXME: Reimplement threaded rendering? Or remove?
+	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
+
+		visual_server = memnew(VisualServerWrapMT(visual_server, false));
+	} else {
+		visual_server = memnew(VisualServerRaster);
+	}
 
 	ERR_FAIL_COND_V(!visual_server, ERR_UNAVAILABLE);
-
-	// TODO: enable multithreaded VS
-	/*
-	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
-		visual_server = memnew(VisualServerWrapMT(visual_server, get_render_thread_mode() == RENDER_SEPARATE_THREAD));
-	}
-	*/
 
 	video_driver_index = p_video_driver;
 

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -34,7 +34,7 @@
 
 #include "drivers/gles3/rasterizer_gles3.h"
 #include "servers/visual/visual_server_raster.h"
-//#include "servers/visual/visual_server_wrap_mt.h"
+#include "servers/visual/visual_server_wrap_mt.h"
 
 #include "main/main.h"
 
@@ -107,13 +107,12 @@ Error OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p
 	RasterizerGLES3::register_config();
 	RasterizerGLES3::make_current();
 
-	visual_server = memnew(VisualServerRaster());
-	/*
-		FIXME: Reimplement threaded rendering? Or remove?
+	// FIXME: Reimplement threaded rendering? Or remove?
 	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
 		visual_server = memnew(VisualServerWrapMT(visual_server, false));
-	};
-	*/
+	} else {
+		visual_server = memnew(VisualServerRaster);
+	}
 
 	visual_server->init();
 	//visual_server->cursor_set_visible(false, 0);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1383,10 +1383,11 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	video_driver_index = p_video_driver;
 
-	visual_server = memnew(VisualServerRaster);
 	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
 
 		visual_server = memnew(VisualServerWrapMT(visual_server, get_render_thread_mode() == RENDER_SEPARATE_THREAD));
+	} else {
+		visual_server = memnew(VisualServerRaster);
 	}
 
 	visual_server->init();

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -294,14 +294,13 @@ Error OSUWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 
 	set_video_mode(vm);
 
-	visual_server = memnew(VisualServerRaster);
 	// FIXME: Reimplement threaded rendering? Or remove?
-	/*
 	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
 
-		visual_server = memnew(VisualServerWrapMT(visual_server, get_render_thread_mode() == RENDER_SEPARATE_THREAD));
+		visual_server = memnew(VisualServerWrapMT(visual_server, false));
+	} else {
+		visual_server = memnew(VisualServerRaster);
 	}
-	*/
 
 	visual_server->init();
 	input = memnew(InputDefault);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1332,10 +1332,11 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 	gl_context->set_use_vsync(video_mode.use_vsync);
 #endif
 
-	visual_server = memnew(VisualServerRaster);
 	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
 
 		visual_server = memnew(VisualServerWrapMT(visual_server, get_render_thread_mode() == RENDER_SEPARATE_THREAD));
+	} else {
+		visual_server = memnew(VisualServerRaster);
 	}
 
 	/*

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -342,11 +342,12 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	context_gl->set_use_vsync(current_videomode.use_vsync);
 
 #endif
-	visual_server = memnew(VisualServerRaster);
 
 	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
 
 		visual_server = memnew(VisualServerWrapMT(visual_server, get_render_thread_mode() == RENDER_SEPARATE_THREAD));
+	} else {
+		visual_server = memnew(VisualServerRaster);
 	}
 	if (current_videomode.maximized) {
 		current_videomode.maximized = false;


### PR DESCRIPTION
Avoid leaking an extra instance when using threads. Also fix threaded loading issues on Android and iOS.

Fix #21609.
Likely fix #17086 too.