### PR TITLE
fixed PrismMesh size property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,5 +310,8 @@ platform/windows/godot_res.res
 /.vs
 /.vscode
 
+# Visual Studio Code workspace file
+*.code-workspace
+
 # Scons progress indicator
 .scons_node_count

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -1282,7 +1282,7 @@ void PrismMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_subdivide_depth"), &PrismMesh::get_subdivide_depth);
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "left_to_right", PROPERTY_HINT_RANGE, "-2.0,2.0,0.1"), "set_left_to_right", "get_left_to_right");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), "set_size", "get_size");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdivide_width", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), "set_subdivide_width", "get_subdivide_width");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdivide_height", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), "set_subdivide_height", "get_subdivide_height");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdivide_depth", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), "set_subdivide_depth", "get_subdivide_depth");


### PR DESCRIPTION
This pull request is to fix an issue I found today on prism not being able to resize (and having only X and Y showing on the inspector).
This PR restore, I think the original functionality.
![imagen](https://user-images.githubusercontent.com/21297356/47862563-6bb22b80-ddc3-11e8-8aec-04cdfed619fb.png)

You can check against the latest build, if you create a mesh and add a prism primitive, you can't resize it.

I have also added another line to the already huge .gitignore file, I hope you don't mind. Wi work with VS Code.

This is my first pull request, I hope I did it right.