### PR TITLE
Improve/fix resource broken dependencies management

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -557,8 +557,9 @@ DependencyRemoveDialog::DependencyRemoveDialog() {
 
 //////////////
 
-void DependencyErrorDialog::show(const String &p_for_file, const Vector<String> &report) {
+void DependencyErrorDialog::show(Mode p_mode, const String &p_for_file, const Vector<String> &report) {
 
+	mode = p_mode;
 	for_file = p_for_file;
 	set_title(TTR("Error loading:") + " " + p_for_file.get_file());
 	files->clear();
@@ -584,7 +585,14 @@ void DependencyErrorDialog::show(const String &p_for_file, const Vector<String> 
 
 void DependencyErrorDialog::ok_pressed() {
 
-	EditorNode::get_singleton()->load_scene(for_file, true);
+	switch (mode) {
+		case MODE_SCENE:
+			EditorNode::get_singleton()->load_scene(for_file, true);
+			break;
+		case MODE_RESOURCE:
+			EditorNode::get_singleton()->load_resource(for_file, true);
+			break;
+	}
 }
 
 void DependencyErrorDialog::custom_action(const String &) {
@@ -599,7 +607,7 @@ DependencyErrorDialog::DependencyErrorDialog() {
 
 	files = memnew(Tree);
 	files->set_hide_root(true);
-	vb->add_margin_child(TTR("Scene failed to load due to missing dependencies:"), files, true);
+	vb->add_margin_child(TTR("Load failed due to missing dependencies:"), files, true);
 	files->set_v_size_flags(SIZE_EXPAND_FILL);
 	files->set_custom_minimum_size(Size2(1, 200));
 	get_ok()->set_text(TTR("Open Anyway"));

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -134,7 +134,15 @@ public:
 class DependencyErrorDialog : public ConfirmationDialog {
 	GDCLASS(DependencyErrorDialog, ConfirmationDialog);
 
+public:
+	enum Mode {
+		MODE_SCENE,
+		MODE_RESOURCE,
+	};
+
+private:
 	String for_file;
+	Mode mode;
 	Button *fdep;
 	Label *text;
 	Tree *files;
@@ -142,7 +150,7 @@ class DependencyErrorDialog : public ConfirmationDialog {
 	void custom_action(const String &);
 
 public:
-	void show(const String &p_for_file, const Vector<String> &report);
+	void show(Mode p_mode, const String &p_for_file, const Vector<String> &report);
 	DependencyErrorDialog();
 };
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -574,13 +574,29 @@ void EditorNode::_editor_select_prev() {
 	_editor_select(editor);
 }
 
-Error EditorNode::load_resource(const String &p_scene) {
+Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_deps) {
 
-	RES res = ResourceLoader::load(p_scene);
+	dependency_errors.clear();
+
+	Error err;
+	RES res = ResourceLoader::load(p_resource, "", false, &err);
 	ERR_FAIL_COND_V(!res.is_valid(), ERR_CANT_OPEN);
 
-	inspector_dock->edit_resource(res);
+	if (!p_ignore_broken_deps && dependency_errors.has(p_resource)) {
 
+		//current_option = -1;
+		Vector<String> errors;
+		for (Set<String>::Element *E = dependency_errors[p_resource].front(); E; E = E->next()) {
+
+			errors.push_back(E->get());
+		}
+		dependency_error->show(DependencyErrorDialog::MODE_RESOURCE, p_resource, errors);
+		dependency_errors.erase(p_resource);
+
+		return ERR_FILE_MISSING_DEPENDENCIES;
+	}
+
+	inspector_dock->edit_resource(res);
 	return OK;
 }
 
@@ -2845,7 +2861,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 			errors.push_back(E->get());
 		}
-		dependency_error->show(lpath, errors);
+		dependency_error->show(DependencyErrorDialog::MODE_SCENE, lpath, errors);
 		opening_prev = false;
 
 		if (prev != -1) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -688,7 +688,7 @@ public:
 	void fix_dependencies(const String &p_for_file);
 	void clear_scene() { _cleanup_scene(); }
 	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_clear_errors = true, bool p_force_open_imported = false);
-	Error load_resource(const String &p_scene);
+	Error load_resource(const String &p_resource, bool p_ignore_broken_deps = false);
 
 	bool is_scene_open(const String &p_path);
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2111,13 +2111,24 @@ void TileSetEditor::update_texture_list() {
 
 	List<int> ids;
 	tileset->get_tile_list(&ids);
+	Vector<int> ids_to_remove;
 	for (List<int>::Element *E = ids.front(); E; E = E->next()) {
+		// Clear tiles referencing gone textures (user has been already given the chance to fix broken deps)
+		if (!tileset->tile_get_texture(E->get()).is_valid()) {
+			ids_to_remove.push_back(E->get());
+			ERR_CONTINUE(!tileset->tile_get_texture(E->get()).is_valid());
+		}
+
 		if (!texture_map.has(tileset->tile_get_texture(E->get())->get_rid())) {
 			texture_list->add_item(tileset->tile_get_texture(E->get())->get_path().get_file());
 			texture_map.insert(tileset->tile_get_texture(E->get())->get_rid(), tileset->tile_get_texture(E->get()));
 			texture_list->set_item_metadata(texture_list->get_item_count() - 1, tileset->tile_get_texture(E->get())->get_rid());
 		}
 	}
+	for (int i = 0; i < ids_to_remove.size(); i++) {
+		tileset->remove_tile(ids_to_remove[i]);
+	}
+
 	if (texture_list->get_item_count() > 0 && selected_texture.is_valid()) {
 		texture_list->select(texture_list->find_metadata(selected_texture->get_rid()));
 		if (texture_list->get_selected_items().size() > 0)


### PR DESCRIPTION
The first commit enables the mighty dependency fixing flow for resources.

The second one lets the `TileSetEditor` remove tiles pointing to textures that were not loaded.
(This causes data loss only if the user rejects fixing the dependencies and saves the already purged `TileSet`.)

Fixes #23300.