### PR TITLE
TileMap: Fix floor precision in world_to_map on tile borders

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1445,6 +1445,11 @@ Vector2 TileMap::world_to_map(const Vector2 &p_pos) const {
 		default: {}
 	}
 
+	// Account for precision errors on the border (GH-23250).
+	// 0.00005 is 5*CMP_EPSILON, results would start being unpredictible if
+	// cell size is > 15,000, but we can hardly have more precision anyway with
+	// floating point.
+	ret += Vector2(0.00005, 0.00005);
 	return ret.floor();
 }
 


### PR DESCRIPTION
Fixes #23250, supersedes #23315.

There might be better ways to avoid this precision error in the first place, see discussion in https://github.com/godotengine/godot/issues/23250#issuecomment-435161641 - but in the meantime this should do the trick too.