### PR TITLE
Lower minimum margin for collision shapes

### DIFF
--- a/scene/resources/shape.cpp
+++ b/scene/resources/shape.cpp
@@ -101,7 +101,7 @@ void Shape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &Shape::set_margin);
 	ClassDB::bind_method(D_METHOD("get_margin"), &Shape::get_margin);
 
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "margin", PROPERTY_HINT_RANGE, "0.04,10,0.001"), "set_margin", "get_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "margin", PROPERTY_HINT_RANGE, "0.001,10,0.001"), "set_margin", "get_margin");
 }
 
 Shape::Shape() :


### PR DESCRIPTION
This is a very small change, the problem I'm having in VR is that 1 unit by default measures 1 meter. That means a minimum collision margin of 0.04 is a collision margin of 4 cm. That's a bit big when working at that scale.

I've changed the minimum to 0.005 seeing precision was already set to 0.001. 