### PR TITLE
Fix UWP build.

### DIFF
--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -59,6 +59,8 @@ if env['builtin_freetype']:
     if env['platform'] == 'uwp':
         # Include header for UWP to fix build issues
         env_freetype.Append(CCFLAGS=['/FI', '"modules/freetype/uwpdef.h"'])
+        # Globally too, as freetype is used in scene (see bottom)
+        env.Append(CCFLAGS=['/FI', '"modules/freetype/uwpdef.h"'])
 
     sfnt = thirdparty_dir + 'src/sfnt/sfnt.c'
     if env['platform'] == 'javascript':

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -47,6 +47,7 @@
 #include "platform/windows/windows_terminal_logger.h"
 #include "servers/audio_server.h"
 #include "servers/visual/visual_server_raster.h"
+#include "servers/visual/visual_server_wrap_mt.h"
 #include "thread_uwp.h"
 
 #include <ppltasks.h>


### PR DESCRIPTION
Add missing os_uwp.cpp include for VisualServerWrapMT.
Add global env forced include to fix freetype in UWP.