### PR TITLE
[macOS] Fix .app bundle crash and blank initial window

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -328,14 +328,14 @@ static Vector2 get_mouse_pos(NSPoint locationInWindow, CGFloat backingScaleFacto
 	//_GodotPlatformSetCursorMode(window, window->cursorMode);
 	[OS_OSX::singleton->context update];
 
-	get_mouse_pos(
-			[OS_OSX::singleton->window_object mouseLocationOutsideOfEventStream],
-			[OS_OSX::singleton->window_view backingScaleFactor]);
-	if (OS_OSX::singleton->input)
+	if (OS_OSX::singleton->get_main_loop()) {
+		get_mouse_pos(
+				[OS_OSX::singleton->window_object mouseLocationOutsideOfEventStream],
+				[OS_OSX::singleton->window_view backingScaleFactor]);
 		OS_OSX::singleton->input->set_mouse_position(Point2(mouse_x, mouse_y));
 
-	if (OS_OSX::singleton->get_main_loop())
 		OS_OSX::singleton->get_main_loop()->notification(MainLoop::NOTIFICATION_WM_FOCUS_IN);
+	}
 }
 
 - (void)windowDidResignKey:(NSNotification *)notification {

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -365,6 +365,8 @@ static Vector2 get_mouse_pos(NSPoint locationInWindow, CGFloat backingScaleFacto
 	bool imeMode;
 }
 - (void)cancelComposition;
+- (BOOL)wantsUpdateLayer;
+- (void)updateLayer;
 @end
 
 @implementation GodotContentView
@@ -373,6 +375,14 @@ static Vector2 get_mouse_pos(NSPoint locationInWindow, CGFloat backingScaleFacto
 	if (self == [GodotContentView class]) {
 		// nothing left to do here at the moment..
 	}
+}
+
+- (BOOL)wantsUpdateLayer {
+	return YES;
+}
+
+- (void)updateLayer {
+	[OS_OSX::singleton->context update];
 }
 
 - (id)init {


### PR DESCRIPTION
Fixes .app bundle crash (regression from #23244).

Add additional context updates (SDL fix linked in #23100 comment), main window content should always update correctly, splash screen is NOT fully fixed.

Fixes #23307, fixes #23496, related #22689