### PR TITLE
Simplified boolean logic in GLES2/3 rasterizers

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1602,7 +1602,7 @@ void RasterizerStorageGLES2::_update_material(Material *p_material) {
 		if (p_material->shader && p_material->shader->mode == VS::SHADER_SPATIAL) {
 
 			if (p_material->shader->spatial.blend_mode == Shader::Spatial::BLEND_MODE_MIX &&
-					(!p_material->shader->spatial.uses_alpha || (p_material->shader->spatial.uses_alpha && p_material->shader->spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS))) {
+					(!p_material->shader->spatial.uses_alpha || p_material->shader->spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS)) {
 				can_cast_shadow = true;
 			}
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2830,7 +2830,7 @@ void RasterizerStorageGLES3::_update_material(Material *material) {
 		if (material->shader && material->shader->mode == VS::SHADER_SPATIAL) {
 
 			if (material->shader->spatial.blend_mode == Shader::Spatial::BLEND_MODE_MIX &&
-					(!material->shader->spatial.uses_alpha || (material->shader->spatial.uses_alpha && material->shader->spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS))) {
+					(!material->shader->spatial.uses_alpha || material->shader->spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS)) {
 				can_cast_shadow = true;
 			}
 


### PR DESCRIPTION
These were found with `cppcheck`:

```
[drivers/gles2/rasterizer_storage_gles2.cpp:1605]: (style) Redundant condition: p_material->shader->spatial.uses_alpha. '!A || (A && B)' is equivalent to '!A || B'
[drivers/gles3/rasterizer_storage_gles3.cpp:2833]: (style) Redundant condition: material->shader->spatial.uses_alpha. '!A || (A && B)' is equivalent to '!A || B'
```