### PR TITLE
Add option for automatic project updating.

### DIFF
--- a/modules/mono/editor/csharp_project.cpp
+++ b/modules/mono/editor/csharp_project.cpp
@@ -106,6 +106,9 @@ String generate_game_project(const String &p_dir, const String &p_name, const Ve
 
 void add_item(const String &p_project_path, const String &p_item_type, const String &p_include) {
 
+	if (!GLOBAL_DEF("mono/project/auto_update_project", true))
+		return;
+
 	_GDMONO_SCOPE_DOMAIN_(TOOLS_DOMAIN)
 
 	GDMonoClass *klass = GDMono::get_singleton()->get_editor_tools_assembly()->get_class("GodotSharpTools.Project", "ProjectUtils");


### PR DESCRIPTION
I've got my project set up so I don't have to manually add files, it just scoops up all the appropriate files for me. This works great except Godot keeps modifying my .csproj on its own. I originally turned this off in my own branch, but given that it's working exactly how I want I figured I'd turn it into an option and send it upstream.

I've got it as a project setting instead of an editor setting because I find it hard to imagine a situation where one person would want it and another wouldn't; either it Just Does The Right Thing in all cases, or it will instantly corrupt your .csproj when it triggers. So it's a project setting.