### PR TITLE
Fix clone line undo history and extra new line, issue 21811

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1060,7 +1060,7 @@ void CodeTextEditor::delete_lines() {
 	text_editor->end_complex_operation();
 }
 
-void CodeTextEditor::code_lines_down() {
+void CodeTextEditor::clone_lines_down() {
 	int from_line = text_editor->cursor_get_line();
 	int to_line = text_editor->cursor_get_line();
 	int column = text_editor->cursor_get_column();
@@ -1072,20 +1072,19 @@ void CodeTextEditor::code_lines_down() {
 	}
 	int next_line = to_line + 1;
 
-	if (to_line >= text_editor->get_line_count() - 1) {
-		text_editor->set_line(to_line, text_editor->get_line(to_line) + "\n");
-	}
-
+	bool caret_at_start = text_editor->cursor_get_line() == from_line;
 	text_editor->begin_complex_operation();
 	for (int i = from_line; i <= to_line; i++) {
-
 		text_editor->unfold_line(i);
-		if (i >= text_editor->get_line_count() - 1) {
-			text_editor->set_line(i, text_editor->get_line(i) + "\n");
-		}
-		String line_clone = text_editor->get_line(i);
-		text_editor->insert_at(line_clone, next_line);
+		text_editor->set_line(next_line - 1, text_editor->get_line(next_line - 1) + "\n");
+		text_editor->set_line(next_line, text_editor->get_line(i));
 		next_line++;
+	}
+
+	if (caret_at_start) {
+		text_editor->cursor_set_line(to_line + 1);
+	} else {
+		text_editor->cursor_set_line(next_line - 1);
 	}
 
 	text_editor->cursor_set_column(column);

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -203,7 +203,7 @@ public:
 	void move_lines_up();
 	void move_lines_down();
 	void delete_lines();
-	void code_lines_down();
+	void clone_lines_down();
 
 	void goto_line(int p_line);
 	void goto_line_selection(int p_line, int p_begin, int p_end);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -773,7 +773,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		} break;
 		case EDIT_CLONE_DOWN: {
 
-			code_editor->code_lines_down();
+			code_editor->clone_lines_down();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -263,7 +263,7 @@ void ShaderEditor::_menu_option(int p_option) {
 			shader_editor->delete_lines();
 		} break;
 		case EDIT_CLONE_DOWN: {
-			shader_editor->code_lines_down();
+			shader_editor->clone_lines_down();
 		} break;
 		case EDIT_TOGGLE_COMMENT: {
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -360,7 +360,7 @@ void TextEditor::_edit_option(int p_op) {
 		} break;
 		case EDIT_CLONE_DOWN: {
 
-			code_editor->code_lines_down();
+			code_editor->clone_lines_down();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
 


### PR DESCRIPTION
Fixes the additional new line when cloning and the undo history for the last line.

Also fixed a typo in the function name.

closes #21811