### PR TITLE
Clarify Size() method

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -300,7 +300,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of elements in the array.
+				Return the amount of non-NULL elements in the array.
 			</description>
 		</method>
 		<method name="sort">


### PR DESCRIPTION
Clarify that Array.size() only counts non-NULL elements within an array