### PR TITLE
Parse C# generics and type constraints correctly

### DIFF
--- a/modules/mono/editor/GodotSharpTools/.gitignore
+++ b/modules/mono/editor/GodotSharpTools/.gitignore
@@ -1,0 +1,2 @@
+# nuget packages
+packages

--- a/modules/mono/editor/script_class_parser.h
+++ b/modules/mono/editor/script_class_parser.h
@@ -65,6 +65,7 @@ private:
 
 	Error _parse_type_full_name(String &r_full_name);
 	Error _parse_class_base(Vector<String> &r_base);
+	Error _parse_type_constraints();
 	Error _parse_namespace_name(String &r_name, int &r_curly_stack);
 
 public:


### PR DESCRIPTION
The newly added ScriptClassParser currently fails when it encounters the following code patterns:
1. Multiple generic type variables in a base class
```cs
public class SomeClass : BaseClass<A, B>
```
2. Type constraints
```cs 
public class SomeClass<T> : BaseClass where T : SomeOtherClass, new()
```

This fixes those cases. I also made it so only the first base class declaration is added to the base class list. C# requires the first slot to be the base class, so any other slot must be an interface. I also updated the .gitignore file to ignore the new GodotSharpTools nuget dependency.

Personal opinion: I don't think we should be in the business of parsing C# files. The current implementation is extremely flimsy.  I'm betting there are more corner cases we missed (clearly I already found two). And even if the parser implementation is perfect, we don't want to update it every time the language changes (which is frequently). And if we aren't 100% on the ball people's projects will break.

Mono's c++ interface has functions to get this information. Or we could write it in C# and use reflection. Using either option ensures our code intelligence is in sync with whatever version of mono we are using.

I also have a question: 
The code prior to this change added all interfaces to the base class list. After this change we will add at most one interface to the base class list (if there is no base class and the first inheritance slot is an interface).  Do we want interfaces as base classes in the context of Godot?

If the answer is no (which is my guess), we need to do real type checking to find out if a symbol is an interface or a class. The current parser doesn't detect if something is an interface. And even if it did, what if we inherit from an interface or class that we didn't explicitly define?

pulling in the expert: @neikeq :smile: 