### PR TITLE
General fixup of the "Find in Files" dialog

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "find_in_files.h"
+
 #include "core/os/dir_access.h"
 #include "core/os/os.h"
 #include "editor_node.h"
@@ -89,8 +90,6 @@ static bool find_next(const String &line, String pattern, int from, bool match_c
 //--------------------------------------------------------------------------------
 FindInFiles::FindInFiles() {
 	_root_prefix = ROOT_PREFIX;
-	_extension_filter.insert("gd");
-	_extension_filter.insert("cs");
 	_searching = false;
 	_whole_words = true;
 	_match_case = true;
@@ -301,8 +300,7 @@ const char *FindInFilesDialog::SIGNAL_REPLACE_REQUESTED = "replace_requested";
 
 FindInFilesDialog::FindInFilesDialog() {
 
-	set_custom_minimum_size(Size2(400, 190) * EDSCALE);
-	set_resizable(true);
+	set_custom_minimum_size(Size2(500 * EDSCALE, 0));
 	set_title(TTR("Find in Files"));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
@@ -317,7 +315,7 @@ FindInFilesDialog::FindInFilesDialog() {
 	vbc->add_child(gc);
 
 	Label *find_label = memnew(Label);
-	find_label->set_text(TTR("Find: "));
+	find_label->set_text(TTR("Find:"));
 	gc->add_child(find_label);
 
 	_search_text_line_edit = memnew(LineEdit);
@@ -326,10 +324,7 @@ FindInFilesDialog::FindInFilesDialog() {
 	_search_text_line_edit->connect("text_entered", this, "_on_search_text_entered");
 	gc->add_child(_search_text_line_edit);
 
-	{
-		Control *placeholder = memnew(Control);
-		gc->add_child(placeholder);
-	}
+	gc->add_child(memnew(Control)); // Space to mantain the grid aligned.
 
 	{
 		HBoxContainer *hbc = memnew(HBoxContainer);
@@ -346,7 +341,7 @@ FindInFilesDialog::FindInFilesDialog() {
 	}
 
 	Label *folder_label = memnew(Label);
-	folder_label->set_text(TTR("Folder: "));
+	folder_label->set_text(TTR("Folder:"));
 	gc->add_child(folder_label);
 
 	{
@@ -374,7 +369,7 @@ FindInFilesDialog::FindInFilesDialog() {
 	}
 
 	Label *filter_label = memnew(Label);
-	filter_label->set_text(TTR("Filter: "));
+	filter_label->set_text(TTR("Filters:"));
 	gc->add_child(filter_label);
 
 	{
@@ -382,7 +377,8 @@ FindInFilesDialog::FindInFilesDialog() {
 
 		Vector<String> exts;
 		exts.push_back("gd");
-		exts.push_back("cs");
+		if (Engine::get_singleton()->has_singleton("GodotSharp"))
+			exts.push_back("cs");
 
 		for (int i = 0; i < exts.size(); ++i) {
 			CheckBox *cb = memnew(CheckBox);
@@ -395,39 +391,14 @@ FindInFilesDialog::FindInFilesDialog() {
 		gc->add_child(hbc);
 	}
 
-	{
-		Control *placeholder = memnew(Control);
-		placeholder->set_custom_minimum_size(Size2(0, EDSCALE * 16));
-		vbc->add_child(placeholder);
-	}
+	_find_button = add_button(TTR("Find..."), false, "find");
+	_find_button->set_disabled(true);
 
-	{
-		HBoxContainer *hbc = memnew(HBoxContainer);
-		hbc->set_alignment(HBoxContainer::ALIGN_CENTER);
+	_replace_button = add_button(TTR("Replace..."), false, "replace");
+	_replace_button->set_disabled(true);
 
-		_find_button = add_button(TTR("Find..."), false, "find");
-		_find_button->set_disabled(true);
-
-		{
-			Control *placeholder = memnew(Control);
-			placeholder->set_custom_minimum_size(Size2(EDSCALE * 16, 0));
-			hbc->add_child(placeholder);
-		}
-
-		_replace_button = add_button(TTR("Replace..."), false, "replace");
-		_replace_button->set_disabled(true);
-
-		{
-			Control *placeholder = memnew(Control);
-			placeholder->set_custom_minimum_size(Size2(EDSCALE * 16, 0));
-			hbc->add_child(placeholder);
-		}
-
-		Button *cancel_button = get_ok();
-		cancel_button->set_text(TTR("Cancel"));
-
-		vbc->add_child(hbc);
-	}
+	Button *cancel_button = get_ok();
+	cancel_button->set_text(TTR("Cancel"));
 }
 
 void FindInFilesDialog::set_search_text(String text) {


### PR DESCRIPTION
- Removed the filter setting in the `FindInFiles` constructor, as it is overwritten by the `ScriptEditorPlugin`.
- Made the "cs" filter only appear if using a Mono version of Godot. Done by checking if the `GodotSharp` singleton exists [**Needs testing**. If someone who uses C# could check if the filter appears for you, that would be great.].
- Removed lots of `Control` nodes that didn't seem to do anything.
- Made the dialog not resizable, as it looks weird with the empty space in the bottom. Made the minimum size slightly bigger to compensate.