### PR TITLE
Fix empty script interface crash on tscn load. #23495

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -765,6 +765,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 }
 
 void VisualScriptEditor::_update_members() {
+	ERR_FAIL_COND(!script.is_valid());
 
 	updating_members = true;
 
@@ -3061,7 +3062,7 @@ void VisualScriptEditor::_notification(int p_what) {
 			}
 		}
 
-		if (is_visible_in_tree()) {
+		if (is_visible_in_tree() && script.is_valid()) {
 			_update_members();
 			_update_graph();
 		}


### PR DESCRIPTION
Add fail conditions to protect the visual script functions and also fix the initiating cause.

@akien-mga Do you prefer if I fix the initiating cause, add the ERR_FAILs or both?

*Bugsquad edit:* Fixes #23495.