### PR TITLE
Ensure mouse is visible on destroying editor_spin_slider

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -461,3 +461,8 @@ EditorSpinSlider::EditorSpinSlider() {
 	read_only = false;
 	use_custom_label_color = false;
 }
+EditorSpinSlider::~EditorSpinSlider() {
+	if (grabbing_spinner) {
+		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+	}
+}

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -103,6 +103,7 @@ public:
 
 	virtual Size2 get_minimum_size() const;
 	EditorSpinSlider();
+	~EditorSpinSlider();
 };
 
 #endif // EDITOR_SPIN_SLIDER_H


### PR DESCRIPTION
This is a partial fix to a bug where the mouse becomes invisible when dragging to change the size of a DynamicFont. The behavior is still undesirable since changing the font size by one will move the mouse to the center of the window and the selection loses focus. There are likely other bugs caused by the same underlying issue. The issue is that when the size of DynamicFont is changed, the settings fields are destroyed and recreated. If the mouse is still hidden, it currently remains hidden regardless of user input.

For a demonstration, see #22581.

Using a destructor to solve this is likely the wrong approach, so I welcome input.