### PR TITLE
Use `env["arch"]` instead of `platform.machine()` in scons build scripts

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -6,6 +6,7 @@ import string
 import os
 import os.path
 import glob
+import platform
 import sys
 import methods
 import gles_builders
@@ -294,6 +295,9 @@ if selected_platform in platform_list:
 
     if env["extra_suffix"] != '':
         env.extra_suffix += '.' + env["extra_suffix"]
+
+    if env["arch"] == "":
+        env["arch"] = platform.machine()
 
     CCFLAGS = env.get('CCFLAGS', '')
     env['CCFLAGS'] = ''

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -269,8 +269,7 @@ if env["platform"] == 'uwp':
     else:
         webm_cpu_x86 = True
 else:
-    import platform
-    is_x11_or_server_arm = ((env["platform"] == 'x11' or env["platform"] == 'server') and (platform.machine().startswith('arm') or platform.machine().startswith('aarch')))
+    is_x11_or_server_arm = ((env["platform"] == 'x11' or env["platform"] == 'server') and (env["arch"].startswith('arm') or env["arch"].startswith('aarch')))
     is_ios_x86 = (env["platform"] == 'iphone' and env["ios_sim"])
     is_android_x86 = (env["platform"] == 'android' and env["android_arch"] == 'x86')
     if is_android_x86:

--- a/platform/haiku/detect.py
+++ b/platform/haiku/detect.py
@@ -125,7 +125,7 @@ def configure(env):
 
     if env['builtin_libtheora']:
         list_of_x86 = ['x86_64', 'x86', 'i386', 'i586']
-        if any(platform.machine() in s for s in list_of_x86):
+        if any(env["arch"] in s for s in list_of_x86):
             env["x86_libtheora_opt_gcc"] = True
 
     if not env['builtin_libwebsockets']:

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -208,7 +208,7 @@ def configure(env):
         env.ParseConfig('pkg-config theora theoradec --cflags --libs')
     else:
         list_of_x86 = ['x86_64', 'x86', 'i386', 'i586']
-        if any(platform.machine() in s for s in list_of_x86):
+        if any(env["arch"] in s for s in list_of_x86):
             env["x86_libtheora_opt_gcc"] = True
 
     if not env['builtin_libvpx']:


### PR DESCRIPTION
Fixes #23506