### PR TITLE
fix tile set editor crash when drawing polygon shapes

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -958,7 +958,7 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 	Ref<InputEventMouseMotion> mm = p_ie;
 
 	if (mb.is_valid()) {
-		if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+		if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT && !creating_shape) {
 			if (!current_tile_region.has_point(mb->get_position())) {
 				List<int> *tiles = new List<int>();
 				tileset->get_tile_list(tiles);


### PR DESCRIPTION
Fixes #21545, fixes #22905
i have reviewed the code draw_polygon_shapes , the crash happened because current_tile has changed when click on another tile, and then tileset->tile_get_shapes get wrong ShapeData .
So I think one solution is : when the workspace is on drawing a shape , In _on_workspace_input shoudn't change the current tile .