### PR TITLE
Improve the C# API projects generation

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2770,7 +2770,8 @@ Error ResourceFormatSaverCSharpScript::save(const String &p_path, const RES &p_r
 					"Compile",
 					ProjectSettings::get_singleton()->globalize_path(p_path));
 		} else {
-			ERR_PRINTS("Cannot add " + p_path + " to the C# project because it could not be created.");
+			ERR_PRINTS("Failed to create C# project");
+			ERR_PRINTS("Cannot add " + p_path + " to the C# project");
 		}
 	}
 #endif

--- a/modules/mono/editor/GodotSharpTools/Project/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotSharpTools/Project/ProjectGenerator.cs
@@ -6,22 +6,24 @@ namespace GodotSharpTools.Project
 {
     public static class ProjectGenerator
     {
+        public const string CoreApiProjectName = "GodotSharp";
+        public const string EditorApiProjectName = "GodotSharpEditor";
         const string CoreApiProjectGuid = "{AEBF0036-DA76-4341-B651-A3F2856AB2FA}";
         const string EditorApiProjectGuid = "{8FBEC238-D944-4074-8548-B3B524305905}";
 
         public static string GenCoreApiProject(string dir, string[] compileItems)
         {
-            string path = Path.Combine(dir, CoreApiProject + ".csproj");
+            string path = Path.Combine(dir, CoreApiProjectName + ".csproj");
 
             ProjectPropertyGroupElement mainGroup;
-            var root = CreateLibraryProject(CoreApiProject, out mainGroup);
+            var root = CreateLibraryProject(CoreApiProjectName, out mainGroup);
 
             mainGroup.AddProperty("DocumentationFile", Path.Combine("$(OutputPath)", "$(AssemblyName).xml"));
             mainGroup.SetProperty("RootNamespace", "Godot");
             mainGroup.SetProperty("ProjectGuid", CoreApiProjectGuid);
 
-            GenAssemblyInfoFile(root, dir, CoreApiProject,
-                                new string[] { "[assembly: InternalsVisibleTo(\"" + EditorApiProject + "\")]" },
+            GenAssemblyInfoFile(root, dir, CoreApiProjectName,
+                                new string[] { "[assembly: InternalsVisibleTo(\"" + EditorApiProjectName + "\")]" },
                                 new string[] { "System.Runtime.CompilerServices" });
 
             foreach (var item in compileItems)
@@ -31,34 +33,33 @@ namespace GodotSharpTools.Project
 
             root.Save(path);
 
-            return root.GetGuid().ToString().ToUpper();
+            return CoreApiProjectGuid;
         }
 
-        public static string GenEditorApiProject(string dir, string coreApiHintPath, string[] compileItems)
+        public static string GenEditorApiProject(string dir, string coreApiProjPath, string[] compileItems)
         {
-            string path = Path.Combine(dir, EditorApiProject + ".csproj");
+            string path = Path.Combine(dir, EditorApiProjectName + ".csproj");
 
             ProjectPropertyGroupElement mainGroup;
-            var root = CreateLibraryProject(EditorApiProject, out mainGroup);
+            var root = CreateLibraryProject(EditorApiProjectName, out mainGroup);
 
             mainGroup.AddProperty("DocumentationFile", Path.Combine("$(OutputPath)", "$(AssemblyName).xml"));
             mainGroup.SetProperty("RootNamespace", "Godot");
             mainGroup.SetProperty("ProjectGuid", EditorApiProjectGuid);
 
-            GenAssemblyInfoFile(root, dir, EditorApiProject);
+            GenAssemblyInfoFile(root, dir, EditorApiProjectName);
 
             foreach (var item in compileItems)
             {
                 root.AddItem("Compile", item.RelativeToPath(dir).Replace("/", "\\"));
             }
 
-            var coreApiRef = root.AddItem("Reference", CoreApiProject);
-            coreApiRef.AddMetadata("HintPath", coreApiHintPath);
+            var coreApiRef = root.AddItem("ProjectReference", coreApiProjPath.Replace("/", "\\"));
             coreApiRef.AddMetadata("Private", "False");
 
             root.Save(path);
 
-            return root.GetGuid().ToString().ToUpper();
+            return EditorApiProjectGuid;
         }
 
         public static string GenGameProject(string dir, string name, string[] compileItems)
@@ -82,13 +83,13 @@ namespace GodotSharpTools.Project
             toolsGroup.AddProperty("WarningLevel", "4");
             toolsGroup.AddProperty("ConsolePause", "false");
 
-            var coreApiRef = root.AddItem("Reference", CoreApiProject);
-            coreApiRef.AddMetadata("HintPath", Path.Combine("$(ProjectDir)", ".mono", "assemblies", CoreApiProject + ".dll"));
+            var coreApiRef = root.AddItem("Reference", CoreApiProjectName);
+            coreApiRef.AddMetadata("HintPath", Path.Combine("$(ProjectDir)", ".mono", "assemblies", CoreApiProjectName + ".dll"));
             coreApiRef.AddMetadata("Private", "False");
 
-            var editorApiRef = root.AddItem("Reference", EditorApiProject);
+            var editorApiRef = root.AddItem("Reference", EditorApiProjectName);
             editorApiRef.Condition = " '$(Configuration)' == 'Tools' ";
-            editorApiRef.AddMetadata("HintPath", Path.Combine("$(ProjectDir)", ".mono", "assemblies", EditorApiProject + ".dll"));
+            editorApiRef.AddMetadata("HintPath", Path.Combine("$(ProjectDir)", ".mono", "assemblies", EditorApiProjectName + ".dll"));
             editorApiRef.AddMetadata("Private", "False");
 
             GenAssemblyInfoFile(root, dir, name);
@@ -186,9 +187,6 @@ namespace GodotSharpTools.Project
                 group.AddItem(groupName, item);
             }
         }
-
-        public const string CoreApiProject = "GodotSharp";
-        public const string EditorApiProject = "GodotSharpEditor";
 
         private const string assemblyInfoTemplate =
 @"using System.Reflection;{0}

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -32,6 +32,7 @@
 #define BINDINGS_GENERATOR_H
 
 #include "core/class_db.h"
+#include "dotnet_solution.h"
 #include "editor/doc/doc_data.h"
 #include "editor/editor_help.h"
 
@@ -556,8 +557,9 @@ class BindingsGenerator {
 	static BindingsGenerator *singleton;
 
 public:
-	Error generate_cs_core_project(const String &p_output_dir, bool p_verbose_output = true);
-	Error generate_cs_editor_project(const String &p_output_dir, const String &p_core_dll_path, bool p_verbose_output = true);
+	Error generate_cs_core_project(const String &p_solution_dir, DotNetSolution &r_solution, bool p_verbose_output = true);
+	Error generate_cs_editor_project(const String &p_solution_dir, DotNetSolution &r_solution, bool p_verbose_output = true);
+	Error generate_cs_api(const String &p_output_dir, bool p_verbose_output = true);
 	Error generate_glue(const String &p_output_dir);
 
 	static uint32_t get_version();

--- a/modules/mono/editor/csharp_project.cpp
+++ b/modules/mono/editor/csharp_project.cpp
@@ -31,6 +31,8 @@
 #include "csharp_project.h"
 
 #include "core/io/json.h"
+#include "core/os/dir_access.h"
+#include "core/os/file_access.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
 
@@ -62,16 +64,16 @@ String generate_core_api_project(const String &p_dir, const Vector<String> &p_fi
 	return ret ? GDMonoMarshal::mono_string_to_godot((MonoString *)ret) : String();
 }
 
-String generate_editor_api_project(const String &p_dir, const String &p_core_dll_path, const Vector<String> &p_files) {
+String generate_editor_api_project(const String &p_dir, const String &p_core_proj_path, const Vector<String> &p_files) {
 
 	_GDMONO_SCOPE_DOMAIN_(TOOLS_DOMAIN)
 
 	GDMonoClass *klass = GDMono::get_singleton()->get_editor_tools_assembly()->get_class("GodotSharpTools.Project", "ProjectGenerator");
 
 	Variant dir = p_dir;
-	Variant core_dll_path = p_core_dll_path;
+	Variant core_proj_path = p_core_proj_path;
 	Variant compile_items = p_files;
-	const Variant *args[3] = { &dir, &core_dll_path, &compile_items };
+	const Variant *args[3] = { &dir, &core_proj_path, &compile_items };
 	MonoException *exc = NULL;
 	MonoObject *ret = klass->get_method("GenEditorApiProject", 3)->invoke(NULL, args, &exc);
 
@@ -126,6 +128,14 @@ void add_item(const String &p_project_path, const String &p_item_type, const Str
 Error generate_scripts_metadata(const String &p_project_path, const String &p_output_path) {
 
 	_GDMONO_SCOPE_DOMAIN_(TOOLS_DOMAIN)
+
+	if (FileAccess::exists(p_output_path)) {
+		DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		Error rm_err = da->remove(p_output_path);
+
+		ERR_EXPLAIN("Failed to remove old scripts metadata file");
+		ERR_FAIL_COND_V(rm_err != OK, rm_err);
+	}
 
 	GDMonoClass *project_utils = GDMono::get_singleton()->get_editor_tools_assembly()->get_class("GodotSharpTools.Project", "ProjectUtils");
 

--- a/modules/mono/editor/dotnet_solution.cpp
+++ b/modules/mono/editor/dotnet_solution.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  net_solution.cpp                                                     */
+/*  dotnet_solution.cpp                                                  */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "net_solution.h"
+#include "dotnet_solution.h"
 
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
@@ -58,27 +58,26 @@
 	"\t\t{%0}.%1|Any CPU.ActiveCfg = %1|Any CPU\n" \
 	"\t\t{%0}.%1|Any CPU.Build.0 = %1|Any CPU"
 
-void NETSolution::add_new_project(const String &p_name, const String &p_guid, const Vector<String> &p_extra_configs) {
-	if (projects.has(p_name))
-		WARN_PRINT("Overriding existing project.");
-
-	ProjectInfo procinfo;
-	procinfo.guid = p_guid;
-
-	procinfo.configs.push_back("Debug");
-	procinfo.configs.push_back("Release");
-
-	for (int i = 0; i < p_extra_configs.size(); i++) {
-		procinfo.configs.push_back(p_extra_configs[i]);
-	}
-
-	projects[p_name] = procinfo;
+void DotNetSolution::add_new_project(const String &p_name, const ProjectInfo &p_project_info) {
+	projects[p_name] = p_project_info;
 }
 
-Error NETSolution::save() {
+bool DotNetSolution::has_project(const String &p_name) const {
+	return projects.find(p_name) != NULL;
+}
+
+const DotNetSolution::ProjectInfo &DotNetSolution::get_project_info(const String &p_name) const {
+	return projects[p_name];
+}
+
+bool DotNetSolution::remove_project(const String &p_name) {
+	return projects.erase(p_name);
+}
+
+Error DotNetSolution::save() {
 	bool dir_exists = DirAccess::exists(path);
 	ERR_EXPLAIN("The directory does not exist.");
-	ERR_FAIL_COND_V(!dir_exists, ERR_FILE_BAD_PATH);
+	ERR_FAIL_COND_V(!dir_exists, ERR_FILE_NOT_FOUND);
 
 	String projs_decl;
 	String sln_platform_cfg;
@@ -86,34 +85,40 @@ Error NETSolution::save() {
 
 	for (Map<String, ProjectInfo>::Element *E = projects.front(); E; E = E->next()) {
 		const String &name = E->key();
-		const ProjectInfo &procinfo = E->value();
+		const ProjectInfo &proj_info = E->value();
 
-		projs_decl += sformat(PROJECT_DECLARATION, name, name + ".csproj", procinfo.guid);
+		bool is_front = E == projects.front();
 
-		for (int i = 0; i < procinfo.configs.size(); i++) {
-			const String &config = procinfo.configs[i];
+		if (!is_front)
+			projs_decl += "\n";
 
-			if (i != 0) {
+		projs_decl += sformat(PROJECT_DECLARATION, name, proj_info.relpath.replace("/", "\\"), proj_info.guid);
+
+		for (int i = 0; i < proj_info.configs.size(); i++) {
+			const String &config = proj_info.configs[i];
+
+			if (i != 0 || !is_front) {
 				sln_platform_cfg += "\n";
 				proj_platform_cfg += "\n";
 			}
 
 			sln_platform_cfg += sformat(SOLUTION_PLATFORMS_CONFIG, config);
-			proj_platform_cfg += sformat(PROJECT_PLATFORMS_CONFIG, procinfo.guid, config);
+			proj_platform_cfg += sformat(PROJECT_PLATFORMS_CONFIG, proj_info.guid, config);
 		}
 	}
 
 	String content = sformat(SOLUTION_TEMPLATE, projs_decl, sln_platform_cfg, proj_platform_cfg);
 
-	FileAccessRef file = FileAccess::open(path_join(path, name + ".sln"), FileAccess::WRITE);
-	ERR_FAIL_COND_V(!file, ERR_FILE_CANT_WRITE);
+	FileAccess *file = FileAccess::open(path_join(path, name + ".sln"), FileAccess::WRITE);
+	ERR_FAIL_NULL_V(file, ERR_FILE_CANT_WRITE);
 	file->store_string(content);
 	file->close();
+	memdelete(file);
 
 	return OK;
 }
 
-bool NETSolution::set_path(const String &p_existing_path) {
+bool DotNetSolution::set_path(const String &p_existing_path) {
 	if (p_existing_path.is_abs_path()) {
 		path = p_existing_path;
 	} else {
@@ -126,6 +131,10 @@ bool NETSolution::set_path(const String &p_existing_path) {
 	return true;
 }
 
-NETSolution::NETSolution(const String &p_name) {
+String DotNetSolution::get_path() {
+	return path;
+}
+
+DotNetSolution::DotNetSolution(const String &p_name) {
 	name = p_name;
 }

--- a/modules/mono/editor/dotnet_solution.h
+++ b/modules/mono/editor/dotnet_solution.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  net_solution.h                                                       */
+/*  dotnet_solution.h                                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -34,23 +34,28 @@
 #include "core/map.h"
 #include "core/ustring.h"
 
-struct NETSolution {
+struct DotNetSolution {
 	String name;
 
-	void add_new_project(const String &p_name, const String &p_guid, const Vector<String> &p_extra_configs = Vector<String>());
+	struct ProjectInfo {
+		String guid;
+		String relpath; // Must be relative to the solution directory
+		Vector<String> configs;
+	};
+
+	void add_new_project(const String &p_name, const ProjectInfo &p_project_info);
+	bool has_project(const String &p_name) const;
+	const ProjectInfo &get_project_info(const String &p_name) const;
+	bool remove_project(const String &p_name);
 
 	Error save();
 
 	bool set_path(const String &p_existing_path);
+	String get_path();
 
-	NETSolution(const String &p_name);
+	DotNetSolution(const String &p_name);
 
 private:
-	struct ProjectInfo {
-		String guid;
-		Vector<String> configs;
-	};
-
 	String path;
 	Map<String, ProjectInfo> projects;
 };

--- a/modules/mono/editor/godotsharp_builds.h
+++ b/modules/mono/editor/godotsharp_builds.h
@@ -84,10 +84,10 @@ public:
 	bool build(const MonoBuildInfo &p_build_info);
 	bool build_async(const MonoBuildInfo &p_build_info, GodotSharpBuild_ExitCallback p_callback = NULL);
 
-	static bool build_api_sln(const String &p_name, const String &p_api_sln_dir, const String &p_config);
+	static bool build_api_sln(const String &p_api_sln_dir, const String &p_config);
 	static bool copy_api_assembly(const String &p_src_dir, const String &p_dst_dir, const String &p_assembly_name, APIAssembly::Type p_api_type);
 
-	static bool make_api_sln(APIAssembly::Type p_api_type);
+	static bool make_api_assembly(APIAssembly::Type p_api_type);
 
 	static bool build_project_blocking(const String &p_config);
 

--- a/modules/mono/godotsharp_defs.h
+++ b/modules/mono/godotsharp_defs.h
@@ -36,7 +36,8 @@
 #define BINDINGS_GLOBAL_SCOPE_CLASS "GD"
 #define BINDINGS_PTR_FIELD "ptr"
 #define BINDINGS_NATIVE_NAME_FIELD "nativeName"
-#define API_ASSEMBLY_NAME "GodotSharp"
+#define API_SOLUTION_NAME "GodotSharp"
+#define CORE_API_ASSEMBLY_NAME "GodotSharp"
 #define EDITOR_API_ASSEMBLY_NAME "GodotSharpEditor"
 #define EDITOR_TOOLS_ASSEMBLY_NAME "GodotSharpTools"
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -496,12 +496,12 @@ bool GDMono::_load_core_api_assembly() {
 	}
 #endif
 
-	String assembly_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(API_ASSEMBLY_NAME ".dll");
+	String assembly_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(CORE_API_ASSEMBLY_NAME ".dll");
 
 	if (!FileAccess::exists(assembly_path))
 		return false;
 
-	bool success = load_assembly_from(API_ASSEMBLY_NAME,
+	bool success = load_assembly_from(CORE_API_ASSEMBLY_NAME,
 			assembly_path,
 			&core_api_assembly);
 
@@ -635,7 +635,7 @@ void GDMono::metadata_set_api_assembly_invalidated(APIAssembly::Type p_api_type,
 
 	String assembly_path = GodotSharpDirs::get_res_assemblies_dir()
 								   .plus_file(p_api_type == APIAssembly::API_CORE ?
-													  API_ASSEMBLY_NAME ".dll" :
+													  CORE_API_ASSEMBLY_NAME ".dll" :
 													  EDITOR_API_ASSEMBLY_NAME ".dll");
 
 	ERR_FAIL_COND(!FileAccess::exists(assembly_path));
@@ -666,7 +666,7 @@ bool GDMono::metadata_is_api_assembly_invalidated(APIAssembly::Type p_api_type) 
 
 	String assembly_path = GodotSharpDirs::get_res_assemblies_dir()
 								   .plus_file(p_api_type == APIAssembly::API_CORE ?
-													  API_ASSEMBLY_NAME ".dll" :
+													  CORE_API_ASSEMBLY_NAME ".dll" :
 													  EDITOR_API_ASSEMBLY_NAME ".dll");
 
 	if (!FileAccess::exists(assembly_path))

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -631,36 +631,36 @@ void set_pending_exception(MonoException *p_exc) {
 _THREAD_LOCAL_(int)
 current_invoke_count = 0;
 
-MonoObject *runtime_invoke(MonoMethod *p_method, void *p_obj, void **p_params, MonoException **p_exc) {
+MonoObject *runtime_invoke(MonoMethod *p_method, void *p_obj, void **p_params, MonoException **r_exc) {
 	GD_MONO_BEGIN_RUNTIME_INVOKE;
-	MonoObject *ret = mono_runtime_invoke(p_method, p_obj, p_params, (MonoObject **)p_exc);
+	MonoObject *ret = mono_runtime_invoke(p_method, p_obj, p_params, (MonoObject **)r_exc);
 	GD_MONO_END_RUNTIME_INVOKE;
 	return ret;
 }
 
-MonoObject *runtime_invoke_array(MonoMethod *p_method, void *p_obj, MonoArray *p_params, MonoException **p_exc) {
+MonoObject *runtime_invoke_array(MonoMethod *p_method, void *p_obj, MonoArray *p_params, MonoException **r_exc) {
 	GD_MONO_BEGIN_RUNTIME_INVOKE;
-	MonoObject *ret = mono_runtime_invoke_array(p_method, p_obj, p_params, (MonoObject **)p_exc);
+	MonoObject *ret = mono_runtime_invoke_array(p_method, p_obj, p_params, (MonoObject **)r_exc);
 	GD_MONO_END_RUNTIME_INVOKE;
 	return ret;
 }
 
-MonoString *object_to_string(MonoObject *p_obj, MonoException **p_exc) {
+MonoString *object_to_string(MonoObject *p_obj, MonoException **r_exc) {
 	GD_MONO_BEGIN_RUNTIME_INVOKE;
-	MonoString *ret = mono_object_to_string(p_obj, (MonoObject **)p_exc);
+	MonoString *ret = mono_object_to_string(p_obj, (MonoObject **)r_exc);
 	GD_MONO_END_RUNTIME_INVOKE;
 	return ret;
 }
 
-void property_set_value(MonoProperty *p_prop, void *p_obj, void **p_params, MonoException **p_exc) {
+void property_set_value(MonoProperty *p_prop, void *p_obj, void **p_params, MonoException **r_exc) {
 	GD_MONO_BEGIN_RUNTIME_INVOKE;
-	mono_property_set_value(p_prop, p_obj, p_params, (MonoObject **)p_exc);
+	mono_property_set_value(p_prop, p_obj, p_params, (MonoObject **)r_exc);
 	GD_MONO_END_RUNTIME_INVOKE;
 }
 
-MonoObject *property_get_value(MonoProperty *p_prop, void *p_obj, void **p_params, MonoException **p_exc) {
+MonoObject *property_get_value(MonoProperty *p_prop, void *p_obj, void **p_params, MonoException **r_exc) {
 	GD_MONO_BEGIN_RUNTIME_INVOKE;
-	MonoObject *ret = mono_property_get_value(p_prop, p_obj, p_params, (MonoObject **)p_exc);
+	MonoObject *ret = mono_property_get_value(p_prop, p_obj, p_params, (MonoObject **)r_exc);
 	GD_MONO_END_RUNTIME_INVOKE;
 	return ret;
 }

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -233,13 +233,13 @@ _FORCE_INLINE_ int &get_runtime_invoke_count_ref() {
 	return current_invoke_count;
 }
 
-MonoObject *runtime_invoke(MonoMethod *p_method, void *p_obj, void **p_params, MonoException **p_exc);
-MonoObject *runtime_invoke_array(MonoMethod *p_method, void *p_obj, MonoArray *p_params, MonoException **p_exc);
+MonoObject *runtime_invoke(MonoMethod *p_method, void *p_obj, void **p_params, MonoException **r_exc);
+MonoObject *runtime_invoke_array(MonoMethod *p_method, void *p_obj, MonoArray *p_params, MonoException **r_exc);
 
-MonoString *object_to_string(MonoObject *p_obj, MonoException **p_exc);
+MonoString *object_to_string(MonoObject *p_obj, MonoException **r_exc);
 
-void property_set_value(MonoProperty *p_prop, void *p_obj, void **p_params, MonoException **p_exc);
-MonoObject *property_get_value(MonoProperty *p_prop, void *p_obj, void **p_params, MonoException **p_exc);
+void property_set_value(MonoProperty *p_prop, void *p_obj, void **p_params, MonoException **r_exc);
+MonoObject *property_get_value(MonoProperty *p_prop, void *p_obj, void **p_params, MonoException **r_exc);
 
 uint64_t unbox_enum_value(MonoObject *p_boxed, MonoType *p_enum_basetype, bool &r_error);
 

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -88,7 +88,7 @@ void fix_path(const String &p_path, String &r_out) {
 bool rel_path_to_abs(const String &p_existing_path, String &r_abs_path) {
 #ifdef WINDOWS_ENABLED
 	CharType ret[_MAX_PATH];
-	if (_wfullpath(ret, p_existing_path.c_str(), _MAX_PATH)) {
+	if (::_wfullpath(ret, p_existing_path.c_str(), _MAX_PATH)) {
 		String abspath = String(ret).replace("\\", "/");
 		int pos = abspath.find(":/");
 		if (pos != -1) {
@@ -99,10 +99,12 @@ bool rel_path_to_abs(const String &p_existing_path, String &r_abs_path) {
 		return true;
 	}
 #else
-	char ret[PATH_MAX];
-	if (realpath(p_existing_path.utf8().get_data(), ret)) {
+	char *resolved_path = ::realpath(p_existing_path.utf8().get_data(), NULL);
+	if (resolved_path) {
 		String retstr;
-		if (!retstr.parse_utf8(ret)) {
+		bool success = !retstr.parse_utf8(resolved_path);
+		::free(resolved_path);
+		if (success) {
 			r_abs_path = retstr;
 			return true;
 		}


### PR DESCRIPTION
- Now there is only one solution that contains both GodotSharp and GodotSharpEditor project. Previously we had one solution for each project
- GodotSharpEditor references GodotShatp with a `ProjectReference`. Previously it was a `Reference` to the assembly
- This also simplifies the command line option to generate this solution: `godot --generate-cs-api <OutputDir>`