### PR TITLE
Improve dragging behavior of editor_spin_slider

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -63,6 +63,7 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 
 				grabbing_spinner_attempt = true;
 				grabbing_spinner_dist_cache = 0;
+				pre_grab_value = get_value();
 				grabbing_spinner = false;
 				grabbing_spinner_mouse_pos = Input::get_singleton()->get_mouse_position();
 			}
@@ -107,10 +108,10 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 					if (ABS(grabbing_spinner_dist_cache) > 6) {
 						set_value(get_value() + SGN(grabbing_spinner_dist_cache));
 						grabbing_spinner_dist_cache = 0;
+						pre_grab_value = get_value();
 					}
 				} else {
-					set_value(get_value() + get_step() * grabbing_spinner_dist_cache * 10);
-					grabbing_spinner_dist_cache = 0;
+					set_value(pre_grab_value + get_step() * grabbing_spinner_dist_cache * 10);
 				}
 			}
 		} else if (updown_offset != -1) {
@@ -434,6 +435,7 @@ EditorSpinSlider::EditorSpinSlider() {
 	grabbing_spinner_attempt = false;
 	grabbing_spinner = false;
 	grabbing_spinner_dist_cache = 0;
+	pre_grab_value = 0;
 	set_focus_mode(FOCUS_ALL);
 	updown_offset = -1;
 	hover_updown = false;

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -59,6 +59,7 @@ class EditorSpinSlider : public Range {
 	bool read_only;
 	float grabbing_spinner_dist_cache;
 	Vector2 grabbing_spinner_mouse_pos;
+	double pre_grab_value;
 
 	LineEdit *value_input;
 	bool value_input_just_closed;


### PR DESCRIPTION
Fixes issues with changing the size or position of a Rect and other whole number values that are stored as floating point numbers and controlled by an editor_spin_slider without an updown.

The position and size of a Rect are stored as a Vector2, but they only accept whole number values. So when the position or size is set via dragging the value box, the bounds are recalculated and rounded down. Since the previous version would reset the drag distance after every ui update, small mouse movements would be unable to increase the value of the position or size, regardless of how far it was moved and small movements to the left would decrease the value.

 Fixes #23011