### PR TITLE
Allow to specify a custom strength when calling Input.action_press(),…

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -86,7 +86,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &Input::set_mouse_mode);
 	ClassDB::bind_method(D_METHOD("get_mouse_mode"), &Input::get_mouse_mode);
 	ClassDB::bind_method(D_METHOD("warp_mouse_position", "to"), &Input::warp_mouse_position);
-	ClassDB::bind_method(D_METHOD("action_press", "action"), &Input::action_press);
+	ClassDB::bind_method(D_METHOD("action_press", "action", "strength"), &Input::action_press);
 	ClassDB::bind_method(D_METHOD("action_release", "action"), &Input::action_release);
 	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Input::set_default_cursor_shape, DEFVAL(CURSOR_ARROW));
 	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image", "shape", "hotspot"), &Input::set_custom_mouse_cursor, DEFVAL(CURSOR_ARROW), DEFVAL(Vector2()));

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -113,7 +113,7 @@ public:
 	virtual Vector3 get_magnetometer() const = 0;
 	virtual Vector3 get_gyroscope() const = 0;
 
-	virtual void action_press(const StringName &p_action) = 0;
+	virtual void action_press(const StringName &p_action, float p_strength = 1.f) = 0;
 	virtual void action_release(const StringName &p_action) = 0;
 
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -17,8 +17,10 @@
 			</return>
 			<argument index="0" name="action" type="String">
 			</argument>
+			<argument index="1" name="strength" type="float" default="1.0f">
+			</argument>
 			<description>
-				This will simulate pressing the specified action.
+				This will simulate pressing the specified action. The strength can be used for non-boolean actions.
 			</description>
 		</method>
 		<method name="action_release">

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -556,14 +556,14 @@ Point2i InputDefault::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_moti
 void InputDefault::iteration(float p_step) {
 }
 
-void InputDefault::action_press(const StringName &p_action) {
+void InputDefault::action_press(const StringName &p_action, float p_strength) {
 
 	Action action;
 
 	action.physics_frame = Engine::get_singleton()->get_physics_frames();
 	action.idle_frame = Engine::get_singleton()->get_idle_frames();
 	action.pressed = true;
-	action.strength = 0.f;
+	action.strength = p_strength;
 
 	action_state[p_action] = action;
 }

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -227,7 +227,7 @@ public:
 	void set_main_loop(MainLoop *p_main_loop);
 	void set_mouse_position(const Point2 &p_posf);
 
-	void action_press(const StringName &p_action);
+	void action_press(const StringName &p_action, float p_strength = 1.f);
 	void action_release(const StringName &p_action);
 
 	void iteration(float p_step);


### PR DESCRIPTION
Use case: mobile virtual gamepad.
I want to have an analog input like "player_up" from a virtual gamepad.

Allow to specify a custom strength when calling Input.action_press(), this allows virtual axis, mainly for mobile.