### PR TITLE
Fix mouse mode restoration on Windows

### DIFF
--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -157,6 +157,8 @@ class OS_Windows : public OS {
 
 	void _update_window_style(bool repaint = true);
 
+	void _set_mouse_mode_impl(MouseMode p_mode);
+
 	// functions used by main to initialize/deinitialize the OS
 protected:
 	virtual int get_current_video_driver() const;


### PR DESCRIPTION
Fixes #23494.

Not cherry-pickable for 3.0. I'll submit a dedicated PR.