### PR TITLE
Fixed tilemap saving, format FORMAT_2 was not correctly written since…

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1114,6 +1114,8 @@ void TileMap::_set_tile_data(const PoolVector<int> &p_data) {
 		*/
 		set_cell(x, y, v, flip_h, flip_v, transpose, Vector2(coord_x, coord_y));
 	}
+
+	format = FORMAT_2;
 }
 
 PoolVector<int> TileMap::_get_tile_data() const {
@@ -1403,7 +1405,7 @@ bool TileMap::_set(const StringName &p_name, const Variant &p_value) {
 bool TileMap::_get(const StringName &p_name, Variant &r_ret) const {
 
 	if (p_name == "format") {
-		r_ret = FORMAT_2;
+		r_ret = format;
 		return true;
 	} else if (p_name == "tile_data") {
 		r_ret = _get_tile_data();


### PR DESCRIPTION
    Fixed tilemap saving, format FORMAT_2 was not correctly written since it was recognized as default value, hence
    FORMAT_1 was always the case even when the tile_data was written in FORMAT_2.

To reproduce: simply create a new tilemap save it & load it again.