### PR TITLE
Avoid the infinite loop when loading a scene.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3985,6 +3985,8 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 	if (p_tab == editor_data.get_edited_scene())
 		return; //pointless
 
+	editor_data.set_edited_scene(p_tab);
+
 	uint64_t next_scene_version = editor_data.get_scene_version(p_tab);
 
 	editor_data.get_undo_redo().create_action(TTR("Switch Scene Tab"));


### PR DESCRIPTION
Avoid the infinite loop when loading a scene.

A crash occurs when an open callback is repeated forever.
Simply avoid the loop by setting the tab index before doing the relative actions so it'll be avoided in the next loop.

To reproduce:
1. open a project
2. open a scene which is not the main scene
3. run the game
4. go back to main scene
5. crash on infinite loop

It's probably fixable also by checking why there is an infinite loop in the load_scene() but still setting the tab index as soon as it's decided to switch doesn't seem a bad idea in general.

Here a piece of  a stack dump:

    #38407 0x0000000001c78bdf in EditorNode::_scene_tab_changed (this=0x67dacc0, p_tab=0) at editor/editor_node.cpp:3998
    #38408 0x0000000001c6f163 in EditorNode::load_scene (this=0x67dacc0, p_scene=..., p_ignore_broken_deps=false, p_set_inherited=false, p_clear_errors=true, p_force_open_imported=false)
    at editor/editor_node.cpp:2805
    #38409 0x0000000001c703da in EditorNode::open_request (this=0x67dacc0, p_path=...) at editor/editor_node.cpp:2947
    #38410 0x0000000001d81a37 in FileSystemDock::_select_file (this=0xa17f3b0, p_path=...) at editor/filesystem_dock.cpp:801
    #38411 0x00000000014e09d9 in MethodBind1<String>::call (this=0xa367070, p_object=0xa17f3b0, p_args=0x7fffffe0f960, p_arg_count=1, r_error=...) at ./core/method_bind.gen.inc:729
    #38412 0x00000000031ad06e in Object::call (this=0xa17f3b0, p_method=..., p_args=0x7fffffe0f960, p_argcount=1, r_error=...) at core/object.cpp:945
    #38413 0x00000000031a37db in MessageQueue::_call_function (this=0x4be1120, p_target=0xa17f3b0, p_func=..., p_args=0x7ffff7e9a038, p_argcount=1, p_show_error=false) at core/message_queue.cpp:256
    #38414 0x00000000031a3a49 in MessageQueue::flush (this=0x4be1120) at core/message_queue.cpp:300
    #38415 0x00000000024ade4d in SceneTree::idle (this=0x5f8a210, p_time=8.70000003e-05) at scene/main/scene_tree.cpp:505
    #38416 0x0000000001170f8c in Main::iteration () at main/main.cpp:1856
    #38417 0x0000000001dbb6c8 in ProgressDialog::task_step (this=0x8220450, p_task=..., p_state=..., p_step=0, p_force_redraw=true) at editor/progress_dialog.cpp:218
    #38418 0x0000000001c72acc in EditorNode::progress_task_step (p_task=..., p_state=..., p_step=0, p_force_refresh=true) at editor/editor_node.cpp:3232
    #38419 0x000000000158165f in EditorProgress::step (this=0x7fffffe0fd90, p_state=..., p_step=0, p_force_refresh=true) at ./editor/editor_node.h:803
    #38420 0x0000000001ba8ae5 in EditorData::check_and_update_scene (this=0x67db418, p_idx=0) at editor/editor_data.cpp:637
    #38421 0x0000000001c6e982 in EditorNode::set_current_scene (this=0x67dacc0, p_idx=0) at editor/editor_node.cpp:2742
    #38422 0x00000000011d69dd in MethodBind1<int>::call (this=0xc7591e0, p_object=0x67dacc0, p_args=0x7fffffe100e0, p_arg_count=1, r_error=...) at ./core/method_bind.gen.inc:729
    #38423 0x00000000031ad06e in Object::call (this=0x67dacc0, p_method=..., p_args=0x7fffffe100e0, p_argcount=1, r_error=...) at core/object.cpp:945
    #38424 0x00000000031acb36 in Object::call (this=0x67dacc0, p_name=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...) at core/object.cpp:869
    #38425 0x0000000003213d91 in UndoRedo::_process_operation_list (this=0x67db448, E=0x112235e0) at core/undo_redo.cpp:271
    #38426 0x00000000032140e5 in UndoRedo::redo (this=0x67db448) at core/undo_redo.cpp:310
    #38427 0x0000000003213bca in UndoRedo::commit_action (this=0x67db448) at core/undo_redo.cpp:247
    #38428 0x0000000001c78bdf in EditorNode::_scene_tab_changed (this=0x67dacc0, p_tab=0) at editor/editor_node.cpp:3998
    #38429 0x0000000001c6f163 in EditorNode::load_scene (this=0x67dacc0, p_scene=..., p_ignore_broken_deps=false, p_set_inherited=false, p_clear_errors=true, p_force_open_imported=false)
    at editor/editor_node.cpp:2805
    #38430 0x0000000001c703da in EditorNode::open_request (this=0x67dacc0, p_path=...) at editor/editor_node.cpp:2947

