### PR TITLE
Add a property to control DynamicFont anti-aliasing

### DIFF
--- a/doc/classes/DynamicFontData.xml
+++ b/doc/classes/DynamicFontData.xml
@@ -13,6 +13,9 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="antialiased" type="bool" setter="set_antialiased" getter="is_antialiased">
+			Controls whether the font should be rendered with anti-aliasing.
+		</member>
 		<member name="font_path" type="String" setter="set_font_path" getter="get_font_path">
 			The path to the vector font file.
 		</member>

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -93,12 +93,14 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	/* Custom font */
 
+	bool font_antialiased = (bool)EditorSettings::get_singleton()->get("interface/editor/main_font_antialiased");
 	DynamicFontData::Hinting font_hinting = (DynamicFontData::Hinting)(int)EditorSettings::get_singleton()->get("interface/editor/main_font_hinting");
 
 	String custom_font_path = EditorSettings::get_singleton()->get("interface/editor/main_font");
 	Ref<DynamicFontData> CustomFont;
 	if (custom_font_path.length() > 0 && dir->file_exists(custom_font_path)) {
 		CustomFont.instance();
+		CustomFont->set_antialiased(font_antialiased);
 		CustomFont->set_hinting(font_hinting);
 		CustomFont->set_font_path(custom_font_path);
 		CustomFont->set_force_autohinter(true); //just looks better..i think?
@@ -112,6 +114,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	Ref<DynamicFontData> CustomFontBold;
 	if (custom_font_path_bold.length() > 0 && dir->file_exists(custom_font_path_bold)) {
 		CustomFontBold.instance();
+		CustomFontBold->set_antialiased(font_antialiased);
 		CustomFontBold->set_hinting(font_hinting);
 		CustomFontBold->set_font_path(custom_font_path_bold);
 		CustomFontBold->set_force_autohinter(true); //just looks better..i think?
@@ -122,10 +125,12 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	/* Custom source code font */
 
 	String custom_font_path_source = EditorSettings::get_singleton()->get("interface/editor/code_font");
+	bool font_source_antialiased = (bool)EditorSettings::get_singleton()->get("interface/editor/code_font_antialiased");
 	DynamicFontData::Hinting font_source_hinting = (DynamicFontData::Hinting)(int)EditorSettings::get_singleton()->get("interface/editor/code_font_hinting");
 	Ref<DynamicFontData> CustomFontSource;
 	if (custom_font_path_source.length() > 0 && dir->file_exists(custom_font_path_source)) {
 		CustomFontSource.instance();
+		CustomFontSource->set_antialiased(font_source_antialiased);
 		CustomFontSource->set_hinting(font_source_hinting);
 		CustomFontSource->set_font_path(custom_font_path_source);
 	} else {
@@ -138,48 +143,56 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	Ref<DynamicFontData> DefaultFont;
 	DefaultFont.instance();
+	DefaultFont->set_antialiased(font_antialiased);
 	DefaultFont->set_hinting(font_hinting);
 	DefaultFont->set_font_ptr(_font_NotoSansUI_Regular, _font_NotoSansUI_Regular_size);
 	DefaultFont->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> DefaultFontBold;
 	DefaultFontBold.instance();
-	DefaultFont->set_hinting(font_hinting);
+	DefaultFontBold->set_antialiased(font_antialiased);
+	DefaultFontBold->set_hinting(font_hinting);
 	DefaultFontBold->set_font_ptr(_font_NotoSansUI_Bold, _font_NotoSansUI_Bold_size);
 	DefaultFontBold->set_force_autohinter(true); // just looks better..i think?
 
 	Ref<DynamicFontData> FontFallback;
 	FontFallback.instance();
+	FontFallback->set_antialiased(font_antialiased);
 	FontFallback->set_hinting(font_hinting);
 	FontFallback->set_font_ptr(_font_DroidSansFallback, _font_DroidSansFallback_size);
 	FontFallback->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontJapanese;
 	FontJapanese.instance();
+	FontJapanese->set_antialiased(font_antialiased);
 	FontJapanese->set_hinting(font_hinting);
 	FontJapanese->set_font_ptr(_font_DroidSansJapanese, _font_DroidSansJapanese_size);
 	FontJapanese->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontArabic;
 	FontArabic.instance();
+	FontArabic->set_antialiased(font_antialiased);
 	FontArabic->set_hinting(font_hinting);
 	FontArabic->set_font_ptr(_font_NotoNaskhArabicUI_Regular, _font_NotoNaskhArabicUI_Regular_size);
 	FontArabic->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontHebrew;
 	FontHebrew.instance();
+	FontHebrew->set_antialiased(font_antialiased);
 	FontHebrew->set_hinting(font_hinting);
 	FontHebrew->set_font_ptr(_font_NotoSansHebrew_Regular, _font_NotoSansHebrew_Regular_size);
 	FontHebrew->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontThai;
 	FontThai.instance();
+	FontThai->set_antialiased(font_antialiased);
 	FontThai->set_hinting(font_hinting);
 	FontThai->set_font_ptr(_font_NotoSansThaiUI_Regular, _font_NotoSansThaiUI_Regular_size);
 	FontThai->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontHindi;
 	FontHindi.instance();
+	FontHindi->set_antialiased(font_antialiased);
 	FontHindi->set_hinting(font_hinting);
 	FontHindi->set_font_ptr(_font_NotoSansDevanagariUI_Regular, _font_NotoSansDevanagariUI_Regular_size);
 	FontHindi->set_force_autohinter(true); //just looks better..i think?
@@ -188,6 +201,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	Ref<DynamicFontData> dfmono;
 	dfmono.instance();
+	dfmono->set_antialiased(font_source_antialiased);
 	dfmono->set_hinting(font_source_hinting);
 	dfmono->set_font_ptr(_font_Hack_Regular, _font_Hack_Regular_size);
 	//dfd->set_force_autohinter(true); //just looks better..i think?

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -300,6 +300,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/editor/main_font_size"] = PropertyInfo(Variant::INT, "interface/editor/main_font_size", PROPERTY_HINT_RANGE, "10,40,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/code_font_size", 14);
 	hints["interface/editor/code_font_size"] = PropertyInfo(Variant::INT, "interface/editor/code_font_size", PROPERTY_HINT_RANGE, "8,96,1", PROPERTY_USAGE_DEFAULT);
+	_initial_set("interface/editor/main_font_antialiased", true);
+	_initial_set("interface/editor/code_font_antialiased", true);
 	_initial_set("interface/editor/main_font_hinting", 2);
 	hints["interface/editor/main_font_hinting"] = PropertyInfo(Variant::INT, "interface/editor/main_font_hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/editor/code_font_hinting", 2);

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -82,11 +82,14 @@ void DynamicFontData::set_force_autohinter(bool p_force) {
 }
 
 void DynamicFontData::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_antialiased", "antialiased"), &DynamicFontData::set_antialiased);
+	ClassDB::bind_method(D_METHOD("is_antialiased"), &DynamicFontData::is_antialiased);
 	ClassDB::bind_method(D_METHOD("set_font_path", "path"), &DynamicFontData::set_font_path);
 	ClassDB::bind_method(D_METHOD("get_font_path"), &DynamicFontData::get_font_path);
 	ClassDB::bind_method(D_METHOD("set_hinting", "mode"), &DynamicFontData::set_hinting);
 	ClassDB::bind_method(D_METHOD("get_hinting"), &DynamicFontData::get_hinting);
 
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "antialiased"), "set_antialiased", "is_antialiased");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), "set_hinting", "get_hinting");
 
 	BIND_ENUM_CONSTANT(HINTING_NONE);
@@ -98,6 +101,7 @@ void DynamicFontData::_bind_methods() {
 
 DynamicFontData::DynamicFontData() {
 
+	antialiased = true;
 	force_autohinter = false;
 	hinting = DynamicFontData::HINTING_NORMAL;
 	font_mem = NULL;
@@ -632,7 +636,7 @@ void DynamicFontAtSize::_update_char(CharType p_char) {
 	if (id.outline_size > 0) {
 		character = _make_outline_char(p_char);
 	} else {
-		error = FT_Render_Glyph(face->glyph, FT_RENDER_MODE_NORMAL);
+		error = FT_Render_Glyph(face->glyph, font->antialiased ? FT_RENDER_MODE_NORMAL : FT_RENDER_MODE_MONO);
 		if (!error)
 			character = _bitmap_to_character(slot->bitmap, slot->bitmap_top, slot->bitmap_left, slot->advance.x / 64.0);
 	}
@@ -783,6 +787,18 @@ void DynamicFont::set_use_filter(bool p_enable) {
 	cache_id.filter = p_enable;
 	outline_cache_id.filter = p_enable;
 	_reload_cache();
+}
+
+bool DynamicFontData::is_antialiased() const {
+
+	return antialiased;
+}
+
+void DynamicFontData::set_antialiased(bool p_antialiased) {
+
+	if (antialiased == p_antialiased)
+		return;
+	antialiased = p_antialiased;
 }
 
 DynamicFontData::Hinting DynamicFontData::get_hinting() const {

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -71,12 +71,15 @@ public:
 		HINTING_NORMAL
 	};
 
+	bool is_antialiased() const;
+	void set_antialiased(bool p_antialiased);
 	Hinting get_hinting() const;
 	void set_hinting(Hinting p_hinting);
 
 private:
 	const uint8_t *font_mem;
 	int font_mem_size;
+	bool antialiased;
 	bool force_autohinter;
 	Hinting hinting;
 


### PR DESCRIPTION
- Editor font anti-aliasing can now be disabled in the Editor Settings.
- DynamicFonts used in projects can now have their anti-aliasing disabled in their DynamicFontData child. Changes will be visible upon reloading the scene in the editor.

Reimplementation of #17292, thanks @ivodopiviz for the initial work :smiley:

This also fixes a typo that made the default bold font ignore the hinting setting.

**Preview:**

![dynamicfont_antialias](https://user-images.githubusercontent.com/180032/48306101-1cdc6280-e536-11e8-94bd-a4c81c71e9cd.png)