### PR TITLE
Prevent FileDialog from stealing focus when setting current file in editor

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "file_dialog.h"
+
 #include "core/os/keyboard.h"
 #include "core/print_string.h"
 #include "scene/gui/label.h"
@@ -596,7 +597,7 @@ void FileDialog::set_current_file(const String &p_file) {
 	int lp = p_file.find_last(".");
 	if (lp != -1) {
 		file->select(0, lp);
-		if (file->is_inside_tree())
+		if (file->is_inside_tree() && !get_tree()->is_node_being_edited(file))
 			file->grab_focus();
 	}
 }


### PR DESCRIPTION
Should close #23619 

The issue also mentions that you can input "/" characters for the current file property. I suppose it isn't a problem since if the filename is invalid it will throw an error while opening/saving it, but should something be done about that ?