### PR TITLE
Remove unused variable in ScriptEditorDebugger

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -467,7 +467,6 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		String type = p_data[1];
 		Array properties = p_data[2];
 
-		bool is_new_object = false;
 		if (remote_objects.has(id)) {
 			debugObj = remote_objects[id];
 		} else {
@@ -475,7 +474,6 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			debugObj->remote_object_id = id;
 			debugObj->type_name = type;
 			remote_objects[id] = debugObj;
-			is_new_object = true;
 			debugObj->connect("value_edited", this, "_scene_tree_property_value_edited");
 		}
 


### PR DESCRIPTION
Leftover from reduz's last commit (d16ce4a8edb26fb4730c51405662479f7ebf6617).

*Bugsquad edit:* Fixes #23660.