### PR TITLE
Use `ResourceLoader::exists` to check for default audio bus layout

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1017,7 +1017,7 @@ void AudioServer::update() {
 
 void AudioServer::load_default_bus_layout() {
 
-	if (FileAccess::exists("res://default_bus_layout.tres")) {
+	if (ResourceLoader::exists("res://default_bus_layout.tres")) {
 		Ref<AudioBusLayout> default_layout = ResourceLoader::load("res://default_bus_layout.tres");
 		if (default_layout.is_valid()) {
 			set_bus_layout(default_layout);


### PR DESCRIPTION
Use `ResourceLoader::exists` to check for the default audio bus layout so it is also found when "Convert Text Resources To Binary On Export" is enabled.

Fixes #15771.