### PR TITLE
EditorExportPlugin now calls _export_end() when export ends if scripted

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -546,6 +546,13 @@ void EditorExportPlugin::_export_begin_script(const PoolVector<String> &p_featur
 	}
 }
 
+void EditorExportPlugin::_export_end_script() {
+
+	if (get_script_instance()) {
+		get_script_instance()->call("_export_end");
+	}
+}
+
 void EditorExportPlugin::_export_file(const String &p_path, const String &p_type, const Set<String> &p_features) {
 }
 
@@ -606,6 +613,9 @@ EditorExportPlatform::ExportNotifier::ExportNotifier(EditorExportPlatform &p_pla
 EditorExportPlatform::ExportNotifier::~ExportNotifier() {
 	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	for (int i = 0; i < export_plugins.size(); i++) {
+		if (export_plugins[i]->get_script_instance()) {
+			export_plugins.write[i]->_export_end_script();
+		}
 		export_plugins.write[i]->_export_end();
 	}
 }

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -291,6 +291,7 @@ class EditorExportPlugin : public Reference {
 
 	void _export_file_script(const String &p_path, const String &p_type, const PoolVector<String> &p_features);
 	void _export_begin_script(const PoolVector<String> &p_features, bool p_debug, const String &p_path, int p_flags);
+	void _export_end_script();
 
 protected:
 	void add_file(const String &p_path, const Vector<uint8_t> &p_file, bool p_remap);


### PR DESCRIPTION
This PR adds the possibility to script _export_end() for EditorExportPlugin.

So you can do stuff when an exports ends:
```
tool
extends EditorExportPlugin

var export_features
var export_debug
var export_path
var export_flags

func _export_begin(features, is_debug, path, flags):
	export_features = features
	export_debug = is_debug
	export_path = path
	export_flags = flags

func _export_end():
	print("export end")
	print(export_features)
	print(export_path)
	print(export_debug)
	print(export_flags)

```