### PR TITLE
Fix CanvasLayer trying to re-stack while out of tree

### DIFF
--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -164,7 +164,9 @@ void CanvasLayer::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_MOVED_IN_PARENT: {
 
-			VisualServer::get_singleton()->viewport_set_canvas_stacking(viewport, canvas, layer, get_position_in_parent());
+			if (is_inside_tree())
+				VisualServer::get_singleton()->viewport_set_canvas_stacking(viewport, canvas, layer, get_position_in_parent());
+
 		} break;
 	}
 }


### PR DESCRIPTION
Fixes #23718.

No cherry-pick needed for 3.0. Will be included in #21271.