### PR TITLE
Fix some undefined behaviour in Bullet module.

### DIFF
--- a/modules/bullet/collision_object_bullet.cpp
+++ b/modules/bullet/collision_object_bullet.cpp
@@ -304,7 +304,11 @@ bool RigidCollisionObjectBullet::is_shape_disabled(int p_index) {
 }
 
 void RigidCollisionObjectBullet::shape_changed(int p_shape_index) {
-	bulletdelete(shapes.write[p_shape_index].bt_shape);
+	ShapeWrapper &shp = shapes.write[p_shape_index];
+	if (shp.bt_shape == mainShape) {
+		mainShape = NULL;
+	}
+	bulletdelete(shp.bt_shape);
 	reload_shapes();
 }
 
@@ -366,5 +370,8 @@ void RigidCollisionObjectBullet::body_scale_changed() {
 void RigidCollisionObjectBullet::internal_shape_destroy(int p_index, bool p_permanentlyFromThisBody) {
 	ShapeWrapper &shp = shapes.write[p_index];
 	shp.shape->remove_owner(this, p_permanentlyFromThisBody);
+	if (shp.bt_shape == mainShape) {
+		mainShape = NULL;
+	}
 	bulletdelete(shp.bt_shape);
 }

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -797,7 +797,10 @@ void RigidBodyBullet::reload_shapes() {
 	const btScalar mass = invMass == 0 ? 0 : 1 / invMass;
 
 	if (mainShape) {
-		btVector3 inertia;
+		// inertia initialised zero here because some of bullet's collision
+		// shapes incorrectly do not set the vector in calculateLocalIntertia.
+		// Arbitrary zero is preferable to undefined behaviour.
+		btVector3 inertia(0, 0, 0);
 		mainShape->calculateLocalInertia(mass, inertia);
 		btBody->setMassProps(mass, inertia);
 	}


### PR DESCRIPTION
Nulling mainShape when it's deleted to avoid double free.
Initialising vector in inertia calculation to work around bug in bullet.

fixes #21863