### PR TITLE
Prevent "Property not found: ..." warning when creating/importing a project

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -946,16 +946,18 @@ void EditorData::script_class_save_icon_paths() {
 void EditorData::script_class_load_icon_paths() {
 	script_class_clear_icon_paths();
 
-	Dictionary d = ProjectSettings::get_singleton()->get("_global_script_class_icons");
-	List<Variant> keys;
-	d.get_key_list(&keys);
+	if (ProjectSettings::get_singleton()->has_setting("_global_script_class_icons")) {
+		Dictionary d = ProjectSettings::get_singleton()->get("_global_script_class_icons");
+		List<Variant> keys;
+		d.get_key_list(&keys);
 
-	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-		String name = E->get().operator String();
-		_script_class_icon_paths[name] = d[name];
+		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
+			String name = E->get().operator String();
+			_script_class_icon_paths[name] = d[name];
 
-		String path = ScriptServer::get_global_class_path(name);
-		script_class_set_name(path, name);
+			String path = ScriptServer::get_global_class_path(name);
+			script_class_set_name(path, name);
+		}
 	}
 }
 


### PR DESCRIPTION
When creating a new project or importing an pre-3.1 project the engine tried to load the `_global_script_class_icon` project settings, which does not exist at that moment, which in turn caused a warning to be emitted.

This change mirrors how the _global_script_classes array is loaded in [`core/script_language.cpp:108`](https://github.com/godotengine/godot/blob/master/core/script_language.cpp#L108) to prevent the warning from being generated by checking if the property exists when loading.

Fixes #23332