### PR TITLE
Fixes drag and drog of image files on scaled nodes

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -608,7 +608,7 @@ class CanvasItemEditorViewport : public Control {
 
 	EditorNode *editor;
 	EditorData *editor_data;
-	CanvasItemEditor *canvas;
+	CanvasItemEditor *canvas_item_editor;
 	Node2D *preview_node;
 	AcceptDialog *accept;
 	WindowDialog *selector;
@@ -642,7 +642,7 @@ public:
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data);
 
-	CanvasItemEditorViewport(EditorNode *p_node, CanvasItemEditor *p_canvas);
+	CanvasItemEditorViewport(EditorNode *p_node, CanvasItemEditor *p_canvas_item_editor);
 	~CanvasItemEditorViewport();
 };
 


### PR DESCRIPTION
Fixes #23373

I also renamed the "canvas" variable to "canvas_item_editor" as it could have lead to confusion.
I also removed a functionality that did "center" specific dropped types (Polygon2D, TouchScreenButton, TextureRect, NinePatchRect), because it was hard to reimplement without dirty workarounds, and I am not sure this is really needed. The drag preview could be updated though, depending on the default type. 