### PR TITLE
Always initialize VariantCall return_type.

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -155,9 +155,7 @@ struct _VariantCall {
 		funcdata.default_args = p_defaultarg;
 		funcdata._const = p_const;
 		funcdata.returns = p_has_return;
-#ifdef DEBUG_ENABLED
 		funcdata.return_type = p_return;
-#endif
 
 		if (p_argtype1.name) {
 			funcdata.arg_types.push_back(p_argtype1.type);


### PR DESCRIPTION
The return_type is used by the GDScript parser (and possibly other scripting languages), so it MUST be initialized at least.
It could be initialized to Variant::NIL in release, but I see no reason for not setting the actual value.
See similar issue #16649
Fixes #22292