### PR TITLE
Properly accept wildcard when binding IPv4 socket.

### DIFF
--- a/core/io/ip_address.cpp
+++ b/core/io/ip_address.cpp
@@ -184,7 +184,7 @@ bool IP_Address::is_ipv4() const {
 }
 
 const uint8_t *IP_Address::get_ipv4() const {
-	ERR_FAIL_COND_V(!is_ipv4(), 0);
+	ERR_FAIL_COND_V(!is_ipv4(), &(field8[12])); // Not the correct IPv4 (it's an IPv6), but we don't want to return a null pointer risking an engine crash.
 	return &(field8[12]);
 }
 

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -110,7 +110,7 @@ size_t NetSocketPosix::_set_addr_storage(struct sockaddr_storage *p_addr, const 
 	} else { // IPv4 socket
 
 		// IPv4 socket with IPv6 address
-		ERR_FAIL_COND_V(!p_ip.is_ipv4(), 0);
+		ERR_FAIL_COND_V(!p_ip.is_wildcard() && !p_ip.is_ipv4(), 0);
 
 		struct sockaddr_in *addr4 = (struct sockaddr_in *)p_addr;
 		addr4->sin_family = AF_INET;
@@ -122,7 +122,6 @@ size_t NetSocketPosix::_set_addr_storage(struct sockaddr_storage *p_addr, const 
 			addr4->sin_addr.s_addr = INADDR_ANY;
 		}
 
-		copymem(&addr4->sin_addr.s_addr, p_ip.get_ipv4(), 4);
 		return sizeof(sockaddr_in);
 	}
 }


### PR DESCRIPTION
Also never return null for is_ipv4 to avoid crashes due to engine bug.
(better to get an error and a broken socket then seeing your game crash).

Fixes #23780 