### PR TITLE
Add application/config/project_settings_override option to override project settings

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -307,7 +307,7 @@ void ProjectSettings::_convert_to_last_version() {
  *    If a project file is found, load it or fail.
  *    If nothing was found, error out.
  */
-Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bool p_upwards) {
+Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, bool p_upwards) {
 
 	// If looking for files in a network client, use it directly
 
@@ -448,6 +448,18 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bo
 	_convert_to_last_version();
 
 	return OK;
+}
+
+Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bool p_upwards) {
+	Error err = _setup(p_path, p_main_pack, p_upwards);
+	if (err == OK) {
+		String custom_settings = GLOBAL_DEF("application/config/project_settings_override", "");
+		if (custom_settings != "") {
+			_load_settings_text(custom_settings);
+		}
+	}
+
+	return err;
 }
 
 bool ProjectSettings::has_setting(String p_var) const {
@@ -995,6 +1007,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/run/disable_stderr", false);
 	GLOBAL_DEF("application/config/use_custom_user_dir", false);
 	GLOBAL_DEF("application/config/custom_user_dir_name", "");
+	GLOBAL_DEF("application/config/project_settings_override", "");
 
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -112,6 +112,8 @@ protected:
 
 	void _add_property_info_bind(const Dictionary &p_info);
 
+	Error _setup(const String &p_path, const String &p_main_pack, bool p_upwards = false);
+
 protected:
 	static void _bind_methods();
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -184,6 +184,9 @@
 		<member name="application/config/use_custom_user_dir" type="bool" setter="" getter="">
 			Allow the project to save to its own custom user dir (in AppData on windows or ~/.config on unixes). This setting only works for desktop exporters. A name must be set in the "custom_user_dir_name" setting for this to take effect.
 		</member>
+		<member name="application/config/project_settings_override" type="String" setter="" getter="">
+			Specifies a file to override project settings. For example: user://custom_settings.cfg.
+		</member>
 		<member name="application/run/disable_stderr" type="bool" setter="" getter="">
 			Disable printing to stderr on exported build.
 		</member>


### PR DESCRIPTION
With this projects can for example save `user://config.dat` and save some settings there that will load next time the project is run. This helps with some settings like fullscreen, that with this way I can make Godot load the last saved setting, instead of starting always with the default setting of the project.