### PR TITLE
Add argument to UndoRedo's "clear_history()" to not increase the version

### DIFF
--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -325,7 +325,7 @@ bool UndoRedo::undo() {
 	return true;
 }
 
-void UndoRedo::clear_history() {
+void UndoRedo::clear_history(bool p_increase_version) {
 
 	ERR_FAIL_COND(action_level > 0);
 	_discard_redo();
@@ -333,7 +333,8 @@ void UndoRedo::clear_history() {
 	while (actions.size())
 		_pop_history_tail();
 
-	version++;
+	if (p_increase_version)
+		version++;
 }
 
 String UndoRedo::get_current_action_name() const {
@@ -493,7 +494,7 @@ void UndoRedo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_undo_property", "object", "property", "value"), &UndoRedo::add_undo_property);
 	ClassDB::bind_method(D_METHOD("add_do_reference", "object"), &UndoRedo::add_do_reference);
 	ClassDB::bind_method(D_METHOD("add_undo_reference", "object"), &UndoRedo::add_undo_reference);
-	ClassDB::bind_method(D_METHOD("clear_history"), &UndoRedo::clear_history);
+	ClassDB::bind_method(D_METHOD("clear_history", "increase_version"), &UndoRedo::clear_history, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_current_action_name"), &UndoRedo::get_current_action_name);
 	ClassDB::bind_method(D_METHOD("get_version"), &UndoRedo::get_version);
 	ClassDB::bind_method(D_METHOD("redo"), &UndoRedo::redo);

--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -112,7 +112,7 @@ public:
 	bool redo();
 	bool undo();
 	String get_current_action_name() const;
-	void clear_history();
+	void clear_history(bool p_increase_version = true);
 
 	uint64_t get_version() const;
 

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -102,8 +102,11 @@
 		<method name="clear_history">
 			<return type="void">
 			</return>
+			<argument index="0" name="increase_version" type="bool" default="true">
+			</argument>
 			<description>
 				Clear the undo/redo history and associated references.
+				Passing [code]false[/code] to [code]increase_version[/code] will prevent the version number to be increased from this.
 			</description>
 		</method>
 		<method name="commit_action">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2003,7 +2003,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			if (err != OK)
 				ERR_PRINT("Failed to load scene");
 			editor_data.move_edited_scene_to_index(cur_idx);
-			get_undo_redo()->clear_history();
+			get_undo_redo()->clear_history(false);
 			scene_tabs->set_current_tab(cur_idx);
 
 		} break;
@@ -2613,7 +2613,7 @@ void EditorNode::_remove_edited_scene() {
 	}
 	_scene_tab_changed(new_index);
 	editor_data.remove_scene(old_index);
-	editor_data.get_undo_redo().clear_history();
+	editor_data.get_undo_redo().clear_history(false);
 	_update_title();
 	_update_scene_tabs();
 }


### PR DESCRIPTION
Fixes #23791.

@reduz, could you see if used it in the right location inside the `EditorNode` file?