### PR TITLE
Fix X11 running a project with fullscreen setting on and resizable off with multiple screens

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -369,7 +369,7 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	}
 
 	// disable resizable window
-	if (!current_videomode.resizable) {
+	if (!current_videomode.resizable && !current_videomode.fullscreen) {
 		XSizeHints *xsh;
 		xsh = XAllocSizeHints();
 		xsh->flags = PMinSize | PMaxSize;


### PR DESCRIPTION
If you run a project with fullscreen on and resizable off and you're using multiple screens the window bugs and gets mapped with a bigger size than it should.