### PR TITLE
Added 'reparent_child' Function to Node Class.

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -350,6 +350,18 @@ bool Node2D::is_z_relative() const {
 	return z_relative;
 }
 
+void Node2D::reparent_child(Node *p_child, bool preserve_global_transform, bool p_legible_unique_name) {
+	CanvasItem *ci_child = dynamic_cast<CanvasItem *>(p_child);
+	Node2D *twod_child = dynamic_cast<Node2D *>(p_child);
+	if (preserve_global_transform && ci_child && twod_child) {
+		Transform2D global_transform = ci_child->get_global_transform();
+		Node::reparent_child(p_child, preserve_global_transform, p_legible_unique_name);
+		twod_child->set_global_transform(global_transform);
+	} else {
+		Node::reparent_child(p_child, preserve_global_transform, p_legible_unique_name);
+	}
+}
+
 int Node2D::get_z_index() const {
 
 	return z_index;

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -111,6 +111,7 @@ public:
 	void set_z_as_relative(bool p_enabled);
 	bool is_z_relative() const;
 
+	void reparent_child(Node *p_child, bool preserve_global_transform = false, bool p_legible_unique_name = false);
 	Transform2D get_relative_transform_to_parent(const Node *p_parent) const;
 
 	Transform2D get_transform() const;

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -731,6 +731,17 @@ void Spatial::force_update_transform() {
 	notification(NOTIFICATION_TRANSFORM_CHANGED);
 }
 
+void Spatial::reparent_child(Node *p_child, bool preserve_global_transform, bool p_legible_unique_name) {
+	Spatial *sp_child = dynamic_cast<Spatial *>(p_child);
+	if (preserve_global_transform && sp_child) {
+		Transform global_transform = sp_child->get_global_transform();
+		Node::reparent_child(p_child, preserve_global_transform, p_legible_unique_name);
+		sp_child->set_global_transform(global_transform);
+	} else {
+		Node::reparent_child(p_child, preserve_global_transform, p_legible_unique_name);
+	}
+}
+
 void Spatial::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_transform", "local"), &Spatial::set_transform);

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -203,6 +203,7 @@ public:
 	bool is_visible_in_tree() const;
 
 	void force_update_transform();
+	void reparent_child(Node *p_child, bool preserve_global_location = false, bool p_legible_unique_name = false);
 
 	Spatial();
 	~Spatial();

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1237,6 +1237,28 @@ void Node::remove_child(Node *p_child) {
 	}
 }
 
+void Node::adopt_child(Node *p_child, bool p_legible_unique_name) {
+
+	if (p_child == this) {
+		ERR_EXPLAIN("Can't add '" + p_child->get_name() + "' as a child to itself.")
+		ERR_FAIL_COND(p_child == this); // adding to itself!
+	}
+
+	if (data.blocked > 0) {
+		ERR_EXPLAIN("Parent node is busy setting up children, adopt_node() failed.");
+		ERR_FAIL_COND(data.blocked > 0);
+	}
+
+	Node *parent = p_child->get_parent();
+	if (parent) {
+		parent->remove_child(p_child);
+	}
+
+	/* Validate name */
+	_validate_child_name(p_child, p_legible_unique_name);
+	_add_child_nocheck(p_child, p_child->data.name);
+}
+
 int Node::get_child_count() const {
 
 	return data.children.size();
@@ -2653,6 +2675,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Node::set_name);
 	ClassDB::bind_method(D_METHOD("get_name"), &Node::get_name);
 	ClassDB::bind_method(D_METHOD("add_child", "node", "legible_unique_name"), &Node::add_child, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("adopt_child", "node", "legible_unique_name"), &Node::adopt_child, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_child", "node"), &Node::remove_child);
 	ClassDB::bind_method(D_METHOD("get_child_count"), &Node::get_child_count);
 	ClassDB::bind_method(D_METHOD("get_children"), &Node::_get_children);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -248,6 +248,8 @@ public:
 	void add_child_below_node(Node *p_node, Node *p_child, bool p_legible_unique_name = false);
 	void remove_child(Node *p_child);
 
+	void adopt_child(Node *p_child, bool p_legible_unique_name = false);
+
 	int get_child_count() const;
 	Node *get_child(int p_index) const;
 	bool has_node(const NodePath &p_path) const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -248,7 +248,7 @@ public:
 	void add_child_below_node(Node *p_node, Node *p_child, bool p_legible_unique_name = false);
 	void remove_child(Node *p_child);
 
-	void adopt_child(Node *p_child, bool p_legible_unique_name = false);
+	virtual void reparent_child(Node *p_child, bool preserve_global_transform = false, bool p_legible_unique_name = false);
 
 	int get_child_count() const;
 	Node *get_child(int p_index) const;


### PR DESCRIPTION
This is a proposal for an `reparent_child` method addition to the Node class. This function provides a shorthand method for adding a child that may already have a parent node. This has helped me with reducing code repetition in cases where I want to move a child quickly to another node. An example of what would be done before this patch:

```
func set_up_player_camera_prepatch(player):
	var socket = player.get_node("./CameraSocket")
	var p = camera.get_parent()
	p.remove_child(camera)
	socket.add_child(camera)
	camera.translation = Vector3.ZERO
	camera.rotation = Quat.IDENTITY.get_euler()
```
Becomes the following code after patch:

```
func set_up_player_camera(player):
	var socket = player.get_node("./CameraSocket")
	socket.reparent_child(camera)
	camera.translation = Vector3.ZERO
	camera.rotation = Quat.IDENTITY.get_euler()
```

While the difference may be minor, I believe that it helps create more concise code that allows scripting files to be more concise when passing nodes to other parts of a tree. I believe that the `reparent_child` terminology also makes it clear that this node will become the new parent regardless of the presence of a parent node on a given child. 

## Preservation of Global Transform
For children that have compatible transforms, you can use this method to preserve your global transform using an optional boolean argument.

```
func set_up_player_camera(player):
	var socket = player.get_node("./CameraSocket")
	socket.reparent_child(camera, true)
```
