### PR TITLE
Change the orientation of generated NavigationMeshes so they face up

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5746,7 +5746,7 @@ SpatialEditorPlugin::SpatialEditorPlugin(EditorNode *p_node) {
 SpatialEditorPlugin::~SpatialEditorPlugin() {
 }
 
-void EditorSpatialGizmoPlugin::create_material(const String &p_name, const Color &p_color, bool p_billboard, bool p_on_top, bool p_use_vertex_color) {
+void EditorSpatialGizmoPlugin::create_material(const String &p_name, const Color &p_color, bool p_billboard, bool p_on_top, bool p_use_vertex_color, SpatialMaterial::CullMode p_cull_mode) {
 
 	Color instanced_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/instanced", Color(0.7, 0.7, 0.7, 0.6));
 
@@ -5768,6 +5768,7 @@ void EditorSpatialGizmoPlugin::create_material(const String &p_name, const Color
 		material->set_flag(SpatialMaterial::FLAG_UNSHADED, true);
 		material->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, true);
 		material->set_render_priority(SpatialMaterial::RENDER_PRIORITY_MIN + 1);
+		material->set_cull_mode(p_cull_mode);
 
 		if (p_use_vertex_color) {
 			material->set_flag(SpatialMaterial::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -768,7 +768,7 @@ protected:
 	virtual Ref<EditorSpatialGizmo> create_gizmo(Spatial *p_spatial);
 
 public:
-	void create_material(const String &p_name, const Color &p_color, bool p_billboard = false, bool p_on_top = false, bool p_use_vertex_color = false);
+	void create_material(const String &p_name, const Color &p_color, bool p_billboard = false, bool p_on_top = false, bool p_use_vertex_color = false, SpatialMaterial::CullMode p_cull_mode = SpatialMaterial::CULL_BACK);
 	void create_icon_material(const String &p_name, const Ref<Texture> &p_texture, bool p_on_top = false, const Color &p_albedo = Color(1, 1, 1, 1));
 	void create_handle_material(const String &p_name, bool p_billboard = false);
 	void add_material(const String &p_name, Ref<SpatialMaterial> p_material);

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -3539,10 +3539,10 @@ void CollisionPolygonSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 ////
 
 NavigationMeshSpatialGizmoPlugin::NavigationMeshSpatialGizmoPlugin() {
-	create_material("navigation_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_edge", Color(0.5, 1, 1)));
-	create_material("navigation_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_edge_disabled", Color(0.7, 0.7, 0.7)));
-	create_material("navigation_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_solid", Color(0.5, 1, 1, 0.4)));
-	create_material("navigation_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_solid_disabled", Color(0.7, 0.7, 0.7, 0.4)));
+	create_material("navigation_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_edge", Color(0.5, 1, 1)), false, false, false, SpatialMaterial::CULL_DISABLED);
+	create_material("navigation_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_edge_disabled", Color(0.7, 0.7, 0.7)), false, false, false, SpatialMaterial::CULL_DISABLED);
+	create_material("navigation_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_solid", Color(0.5, 1, 1, 0.4)), false, false, false, SpatialMaterial::CULL_DISABLED);
+	create_material("navigation_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_solid_disabled", Color(0.7, 0.7, 0.7, 0.4)), false, false, false, SpatialMaterial::CULL_DISABLED);
 }
 
 bool NavigationMeshSpatialGizmoPlugin::has_gizmo(Spatial *p_spatial) {

--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -126,9 +126,10 @@ void NavigationMeshGenerator::_convert_detail_mesh_to_native_navigation_mesh(con
 		for (unsigned int j = 0; j < ntris; j++) {
 			Vector<int> nav_indices;
 			nav_indices.resize(3);
+			// CCW to CW
 			nav_indices.write[0] = ((int)(bverts + tris[j * 4 + 0]));
-			nav_indices.write[1] = ((int)(bverts + tris[j * 4 + 1]));
-			nav_indices.write[2] = ((int)(bverts + tris[j * 4 + 2]));
+			nav_indices.write[1] = ((int)(bverts + tris[j * 4 + 2]));
+			nav_indices.write[2] = ((int)(bverts + tris[j * 4 + 1]));
 			p_nav_mesh->add_polygon(nav_indices);
 		}
 	}

--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -126,10 +126,9 @@ void NavigationMeshGenerator::_convert_detail_mesh_to_native_navigation_mesh(con
 		for (unsigned int j = 0; j < ntris; j++) {
 			Vector<int> nav_indices;
 			nav_indices.resize(3);
-			// CCW to CW
 			nav_indices.write[0] = ((int)(bverts + tris[j * 4 + 0]));
-			nav_indices.write[1] = ((int)(bverts + tris[j * 4 + 2]));
-			nav_indices.write[2] = ((int)(bverts + tris[j * 4 + 1]));
+			nav_indices.write[1] = ((int)(bverts + tris[j * 4 + 1]));
+			nav_indices.write[2] = ((int)(bverts + tris[j * 4 + 2]));
 			p_nav_mesh->add_polygon(nav_indices);
 		}
 	}


### PR DESCRIPTION
Now the faces of a navigation mesh point towards the specified "up" vector.

Fixes #23817 

This should not (and from my testing, doesn't) affect the path-finding behavior of a navmesh, only its appearance in the editor, but feel free to double-check.

I think (and I only looked at this for like an hour so I'm no expert) this bug was because the ReCast library orients the faces of meshes counter-clockwise, while Godot orients them clockwise.  This was taken into account when inputting meshes to ReCast, but apparently forgotten about when getting the generated navmesh.