### PR TITLE
Added PointMesh primitive

### DIFF
--- a/doc/classes/PointMesh.xml
+++ b/doc/classes/PointMesh.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PointMesh" inherits="PrimitiveMesh" category="Core" version="3.2">
+	<brief_description>
+		Mesh with a single Point primitive.
+	</brief_description>
+	<description>
+		The PointMesh is made from a single point. Instead of relying on triangles, points are rendered as a single rectangle on the screen with a constant size. They are intended to be used with Particle systems, but can be used as a cheap way to render constant size billboarded sprites (for example in a point cloud).
+		PointMeshes, must be used with a material that has a point size. Point size can be accessed in a shader with [code]POINT_SIZE[/code], or in a [SpatialMaterial] by setting [member SpatialMaterial.flags_use_point_size] and the variable [member SpatialMaterial.params_point_size].
+		When using PointMeshes, properties that normally alter vertices will be ignored, including billboard mode, grow, and cull face.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/editor/icons/icon_point_mesh.svg
+++ b/editor/icons/icon_point_mesh.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+<g fill="#ffd684" stroke="#000" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" stroke-opacity="0" stroke-width="0">
+<ellipse cx="3.7237" cy="3.0268" rx="2.0114" ry="1.9956"/>
+<ellipse cx="11.717" cy="6.1734" rx="2.0114" ry="1.9956"/>
+<ellipse cx="6.5219" cy="12.477" rx="2.0114" ry="1.9956"/>
+</g>
+</svg>

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -607,6 +607,7 @@ void register_scene_types() {
 	ClassDB::register_class<PrismMesh>();
 	ClassDB::register_class<QuadMesh>();
 	ClassDB::register_class<SphereMesh>();
+	ClassDB::register_class<PointMesh>();
 	ClassDB::register_virtual_class<Material>();
 	ClassDB::register_class<SpatialMaterial>();
 	SceneTree::add_idle_callback(SpatialMaterial::flush_changes);

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -1572,3 +1572,19 @@ SphereMesh::SphereMesh() {
 	rings = 32;
 	is_hemisphere = false;
 }
+
+/**
+  PointMesh
+*/
+
+void PointMesh::_create_mesh_array(Array &p_arr) const {
+	PoolVector<Vector3> faces;
+	faces.resize(1);
+	faces.set(0, Vector3(0.0, 0.0, 0.0));
+
+	p_arr[VS::ARRAY_VERTEX] = faces;
+}
+
+PointMesh::PointMesh() {
+	primitive_type = PRIMITIVE_POINTS;
+}

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -322,4 +322,19 @@ public:
 	SphereMesh();
 };
 
+/**
+	A single point for use in particle systems
+*/
+
+class PointMesh : public PrimitiveMesh {
+
+	GDCLASS(PointMesh, PrimitiveMesh)
+
+protected:
+	virtual void _create_mesh_array(Array &p_arr) const;
+
+public:
+	PointMesh();
+};
+
 #endif


### PR DESCRIPTION
This PR allows you to create a mesh with just a single point. It is useful for creating a simple billboarded quad using a single vertex. This is most beneficial for use in particle systems where you want to have lots of points but dont want to submit four vertices for each point. For simple particle systems it will help to speed them up. Combined with a shadermaterial it should be very versatile with a very low cost.

