### PR TITLE
[macOS] Change runtime OS version checks to allow build with MacOS 10.9 SDK

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -76,6 +76,13 @@
 #define NSWindowStyleMaskBorderless NSBorderlessWindowMask
 #endif
 
+#ifndef NSAppKitVersionNumber10_12
+#define NSAppKitVersionNumber10_12 1504
+#endif
+#ifndef NSAppKitVersionNumber10_14
+#define NSAppKitVersionNumber10_14 1671
+#endif
+
 static void get_key_modifier_state(unsigned int p_osx_state, Ref<InputEventWithModifiers> state) {
 
 	state->set_shift((p_osx_state & NSEventModifierFlagShift));
@@ -1237,7 +1244,7 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	ERR_FAIL_COND_V(window_object == nil, ERR_UNAVAILABLE);
 
 	window_view = [[GodotContentView alloc] init];
-	if (@available(macOS 10.14, *)) {
+	if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14) {
 		[window_view setWantsLayer:TRUE];
 	}
 
@@ -1472,7 +1479,7 @@ public:
 
 		switch (p_type) {
 			case ERR_WARNING:
-				if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12) {
+				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
 					os_log_info(OS_LOG_DEFAULT,
 							"WARNING: %{public}s: %{public}s\nAt: %{public}s:%i.",
 							p_function, err_details, p_file, p_line);
@@ -1482,7 +1489,7 @@ public:
 				logf_error("\E[0;33m   At: %s:%i.\E[0m\n", p_file, p_line);
 				break;
 			case ERR_SCRIPT:
-				if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12) {
+				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
 					os_log_error(OS_LOG_DEFAULT,
 							"SCRIPT ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
 							p_function, err_details, p_file, p_line);
@@ -1492,7 +1499,7 @@ public:
 				logf_error("\E[0;35m   At: %s:%i.\E[0m\n", p_file, p_line);
 				break;
 			case ERR_SHADER:
-				if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12) {
+				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
 					os_log_error(OS_LOG_DEFAULT,
 							"SHADER ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
 							p_function, err_details, p_file, p_line);
@@ -1503,7 +1510,7 @@ public:
 				break;
 			case ERR_ERROR:
 			default:
-				if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12) {
+				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
 					os_log_error(OS_LOG_DEFAULT,
 							"ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
 							p_function, err_details, p_file, p_line);
@@ -2174,11 +2181,7 @@ void OS_OSX::set_window_size(const Size2 p_size) {
 		if (menuBarHeight != 0.f) {
 			size.y += menuBarHeight;
 		} else {
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
 			if (floor(NSAppKitVersionNumber) < NSAppKitVersionNumber10_12) {
-#else
-			{
-#endif
 				size.y += [[NSStatusBar systemStatusBar] thickness];
 			}
 		}


### PR DESCRIPTION
Change runtime OS version checks to use hardcoded constants instead of `@available` (Xcode 9+ only) and `NSAppKitVersionNumber10_12` (macOS 10.13+ SDK only)

Now it's possible to build Godot using MacOSX 10.9 SDK from Xcode 6.2 (6C131e), and clang 5.0.2 from MacPorts on MacOS 10.9.5 (13F1911).

Tested using following command:
```
scons -j8 p=osx tools=yes target=debug macports_clang=5.0 CPPFLAGS=" -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk " LINKFLAGS=" -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk "
```

Should fix `undeclared identifier` error on 10.12 (#21339) and OSXCross build (https://github.com/godotengine/godot/commit/4aa441591c23cc192e6c2589bb5d2f8bb420b9df#commitcomment-31344257)