### PR TITLE
Added dictionary get function

### DIFF
--- a/core/dictionary.cpp
+++ b/core/dictionary.cpp
@@ -121,6 +121,13 @@ bool Dictionary::empty() const {
 	return !_p->variant_map.size();
 }
 
+Variant Dictionary::get(const Variant &p_key, const Variant &p_default_value) const {
+	if (_p->variant_map.has(p_key)) {
+		return _p->variant_map[p_key];
+	} 
+	return p_default_value;
+}
+
 bool Dictionary::has(const Variant &p_key) const {
 
 	return _p->variant_map.has(p_key);

--- a/core/dictionary.h
+++ b/core/dictionary.h
@@ -63,6 +63,8 @@ public:
 	bool empty() const;
 	void clear();
 
+	Variant get(const Variant &p_key, const Variant &p_default_value) const;
+	
 	bool has(const Variant &p_key) const;
 	bool has_all(const Array &p_keys) const;
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -477,6 +477,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(Dictionary, size);
 	VCALL_LOCALMEM0R(Dictionary, empty);
 	VCALL_LOCALMEM0(Dictionary, clear);
+	VCALL_LOCALMEM2R(Dictionary, get);
 	VCALL_LOCALMEM1R(Dictionary, has);
 	VCALL_LOCALMEM1R(Dictionary, has_all);
 	VCALL_LOCALMEM1(Dictionary, erase);
@@ -1670,6 +1671,7 @@ void register_variant_methods() {
 	ADDFUNC0R(DICTIONARY, INT, Dictionary, size, varray());
 	ADDFUNC0R(DICTIONARY, BOOL, Dictionary, empty, varray());
 	ADDFUNC0NC(DICTIONARY, NIL, Dictionary, clear, varray());
+	ADDFUNC2R(DICTIONARY, NIL, Dictionary, get, NIL, "key", NIL, "default_value", varray(Variant()));
 	ADDFUNC1R(DICTIONARY, BOOL, Dictionary, has, NIL, "key", varray());
 	ADDFUNC1R(DICTIONARY, BOOL, Dictionary, has_all, ARRAY, "keys", varray());
 	ADDFUNC1R(DICTIONARY, BOOL, Dictionary, erase, NIL, "key", varray());

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -41,6 +41,17 @@
 				Erase a dictionary key/value pair by key.
 			</description>
 		</method>
+		<method name="get">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="key" type="Variant">
+			</argument>
+			<argument index="1" name="default_value" type="Variant" default="null">
+			</argument>
+			<description>
+				Returns the value if the dictionary has the given key, otherwise, default_value is returned. If no default 
+			</description>
+		</method>
 		<method name="has">
 			<return type="bool">
 			</return>

--- a/modules/gdnative/gdnative/dictionary.cpp
+++ b/modules/gdnative/gdnative/dictionary.cpp
@@ -70,6 +70,19 @@ void GDAPI godot_dictionary_clear(godot_dictionary *p_self) {
 	self->clear();
 }
 
+godot_variant GDAPI godot_dictionary_get_default(const godot_dictionary *p_self, const godot_variant *p_key, const godot_variant *p_default_value) {
+	const Dictionary *self = (const Dictionary *)p_self;
+	const Variant *key = (const Variant *)p_key;
+
+	if (self->has(*key)) {
+		godot_variant raw_dest;
+		Variant *dest = (Variant *)&raw_dest;
+		memnew_placement(dest, Variant(self->operator[](*key)));
+		return raw_dest;
+	};
+	return *p_default_value;
+}
+
 godot_bool GDAPI godot_dictionary_has(const godot_dictionary *p_self, const godot_variant *p_key) {
 	const Dictionary *self = (const Dictionary *)p_self;
 	const Variant *key = (const Variant *)p_key;

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -3135,6 +3135,15 @@
         ]
       },
       {
+        "name": "godot_dictionary_get_default",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["const godot_dictionary *", "p_self"],
+          ["const godot_variant *", "p_key"],
+          ["const godot_variant *", "p_default_value"]
+        ]
+      },
+      {
         "name": "godot_dictionary_has",
         "return_type": "godot_bool",
         "arguments": [

--- a/modules/gdnative/include/gdnative/dictionary.h
+++ b/modules/gdnative/include/gdnative/dictionary.h
@@ -69,6 +69,8 @@ godot_bool GDAPI godot_dictionary_empty(const godot_dictionary *p_self);
 
 void GDAPI godot_dictionary_clear(godot_dictionary *p_self);
 
+godot_variant GDAPI godot_dictionary_get_default(const godot_dictionary *p_self, const godot_variant *p_key, const godot_variant *p_default_value);
+
 godot_bool GDAPI godot_dictionary_has(const godot_dictionary *p_self, const godot_variant *p_key);
 
 godot_bool GDAPI godot_dictionary_has_all(const godot_dictionary *p_self, const godot_array *p_keys);


### PR DESCRIPTION
Hey guys,

As I do a lot of dayjob programming in Python, I've taken a big liking to the Python dictionary's get function. 
https://pythontips.com/2013/07/29/dictionaries-have-a-get-method/

And I added it to Godot's Dictionary class, as I miss it and use a lot of JSON and dictionaries for my game. I've done this because it makes code a lot more concise.

```python
var variable = default_value
if dictionary.has("key"):
    variable = dictionary["key"]
# becomes
var variable = dictionary.get("key", default_value)
```
Another example is chaining for default values.
```python
var velocity = dictionary.get("properties", {}).get("velocity", GAME_CONSTANTS.DEFAULT_VELOCITY)
```

I've got some questions though. I can't get the documentation to say 'null' instead of 'Null', as the binding of the default values occurs elsewhere. I'd need to change this in the documentation generator, which I assume uses the variant "Null" print also used when printing a null variable. This is the only function in the godot/core/variant_call.cpp file which to my knowledge uses a null default value, and I wonder whether it is discouraged?

I also don't know if this counts as a new feature, it doesn't break any API to my knowledge either. Would be rad to see this in 3.1 :relieved: 

I'm unsure about my GDNative implementation, but I added it regardless. Sorry if I messed up.