### PR TITLE
 Expose methods for colliding body count 

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -478,6 +478,16 @@ Array Area2D::get_overlapping_areas() const {
 	return ret;
 }
 
+int Area2D::get_overlapping_body_count() const {
+
+	return body_map.size();
+}
+
+int Area2D::get_overlapping_area_count() const {
+
+	return area_map.size();
+}
+
 bool Area2D::overlaps_area(Node *p_area) const {
 
 	ERR_FAIL_NULL_V(p_area, false);
@@ -641,6 +651,8 @@ void Area2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_overlapping_bodies"), &Area2D::get_overlapping_bodies);
 	ClassDB::bind_method(D_METHOD("get_overlapping_areas"), &Area2D::get_overlapping_areas);
+	ClassDB::bind_method(D_METHOD("get_overlapping_body_count"), &Area2D::get_overlapping_body_count);
+	ClassDB::bind_method(D_METHOD("get_overlapping_area_count"), &Area2D::get_overlapping_area_count);
 
 	ClassDB::bind_method(D_METHOD("overlaps_body", "body"), &Area2D::overlaps_body);
 	ClassDB::bind_method(D_METHOD("overlaps_area", "area"), &Area2D::overlaps_area);

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -181,6 +181,9 @@ public:
 	Array get_overlapping_bodies() const; //function for script
 	Array get_overlapping_areas() const; //function for script
 
+	int get_overlapping_body_count() const;
+	int get_overlapping_area_count() const;
+
 	bool overlaps_area(Node *p_area) const;
 	bool overlaps_body(Node *p_body) const;
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -898,6 +898,13 @@ Array RigidBody2D::get_colliding_bodies() const {
 	return ret;
 }
 
+int RigidBody2D::get_colliding_body_count() const {
+
+	ERR_FAIL_COND_V(!contact_monitor, 0);
+
+	return contact_monitor->body_map.size();
+}
+
 void RigidBody2D::set_contact_monitor(bool p_enabled) {
 
 	if (p_enabled == is_contact_monitor_enabled())
@@ -1053,6 +1060,7 @@ void RigidBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_body_exit_tree"), &RigidBody2D::_body_exit_tree);
 
 	ClassDB::bind_method(D_METHOD("get_colliding_bodies"), &RigidBody2D::get_colliding_bodies);
+	ClassDB::bind_method(D_METHOD("get_colliding_body_count"), &RigidBody2D::get_colliding_body_count);
 
 	BIND_VMETHOD(MethodInfo("_integrate_forces", PropertyInfo(Variant::OBJECT, "state", PROPERTY_HINT_RESOURCE_TYPE, "Physics2DDirectBodyState")));
 

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -273,6 +273,8 @@ public:
 
 	Array get_colliding_bodies() const; //function for script
 
+	int get_colliding_body_count() const;
+
 	virtual String get_configuration_warning() const;
 
 	RigidBody2D();

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -435,6 +435,11 @@ Array Area::get_overlapping_bodies() const {
 	return ret;
 }
 
+int Area::get_overlapping_body_count() const {
+
+	return body_map.size();
+}
+
 void Area::set_monitorable(bool p_enable) {
 
 	if (locked || PhysicsServer::get_singleton()->is_flushing_queries()) {
@@ -471,6 +476,11 @@ Array Area::get_overlapping_areas() const {
 	}
 
 	return ret;
+}
+
+int Area::get_overlapping_area_count() const {
+
+	return area_map.size();
 }
 
 bool Area::overlaps_area(Node *p_area) const {
@@ -674,6 +684,8 @@ void Area::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_overlapping_bodies"), &Area::get_overlapping_bodies);
 	ClassDB::bind_method(D_METHOD("get_overlapping_areas"), &Area::get_overlapping_areas);
+	ClassDB::bind_method(D_METHOD("get_overlapping_body_count"), &Area::get_overlapping_body_count);
+	ClassDB::bind_method(D_METHOD("get_overlapping_area_count"), &Area::get_overlapping_area_count);
 
 	ClassDB::bind_method(D_METHOD("overlaps_body", "body"), &Area::overlaps_body);
 	ClassDB::bind_method(D_METHOD("overlaps_area", "area"), &Area::overlaps_area);

--- a/scene/3d/area.h
+++ b/scene/3d/area.h
@@ -187,6 +187,9 @@ public:
 	Array get_overlapping_bodies() const;
 	Array get_overlapping_areas() const; //function for script
 
+	int get_overlapping_body_count() const;
+	int get_overlapping_area_count() const;
+
 	bool overlaps_area(Node *p_area) const;
 	bool overlaps_body(Node *p_body) const;
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -926,6 +926,13 @@ Array RigidBody::get_colliding_bodies() const {
 	return ret;
 }
 
+int RigidBody::get_colliding_body_count() const {
+
+	ERR_FAIL_COND_V(!contact_monitor, 0);
+
+	return contact_monitor->body_map.size();
+}
+
 String RigidBody::get_configuration_warning() const {
 
 	Transform t = get_transform();
@@ -1017,6 +1024,7 @@ void RigidBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_axis_lock", "axis"), &RigidBody::get_axis_lock);
 
 	ClassDB::bind_method(D_METHOD("get_colliding_bodies"), &RigidBody::get_colliding_bodies);
+	ClassDB::bind_method(D_METHOD("get_colliding_body_count"), &RigidBody::get_colliding_body_count);
 
 	BIND_VMETHOD(MethodInfo("_integrate_forces", PropertyInfo(Variant::OBJECT, "state", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsDirectBodyState")));
 

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -255,6 +255,8 @@ public:
 
 	Array get_colliding_bodies() const;
 
+	int get_colliding_body_count() const;
+
 	void add_central_force(const Vector3 &p_force);
 	void add_force(const Vector3 &p_force, const Vector3 &p_pos);
 	void add_torque(const Vector3 &p_torque);


### PR DESCRIPTION
Like `get_overlapping_bodies().size()` but slightly faster.

New methods:
```
Area.get_overlapping_area_count()
Area.get_overlapping_body_count()
Area2D.get_overlapping_area_count()
Area2D.get_overlapping_body_count()
RigidBody.get_colliding_body_count()
RigidBody2D.get_colliding_body_count()
```