### PR TITLE
Avoids error messages when importing zero scale transforms in the COLLADA importer

### DIFF
--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1655,8 +1655,8 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 				}
 			}
 
-			Quat q = xform.basis.get_rotation_quat();
 			Vector3 s = xform.basis.get_scale();
+			Quat q = Math::is_equal_approx(s.length_squared(), 0) ? Quat() : xform.basis.get_rotation_quat();
 			Vector3 l = xform.origin;
 
 			animation->transform_track_insert_key(track, snapshots[i], l, q, s);
@@ -1705,8 +1705,8 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 
 			xform = sk->get_bone_rest(nm.bone).affine_inverse() * xform;
 
-			Quat q = xform.basis.get_rotation_quat();
 			Vector3 s = xform.basis.get_scale();
+			Quat q = Math::is_equal_approx(s.length_squared(), 0) ? Quat() : xform.basis.get_rotation_quat();
 			Vector3 l = xform.origin;
 
 			animation->transform_track_insert_key(track, 0, l, q, s);


### PR DESCRIPTION
Avoids spamming the user when the COLLADA importer detects the zero scale vector during the animation import. Fixes https://github.com/godotengine/godot/issues/22848.

