### PR TITLE
Support for java.lang.Long values in Android GodotLib.calldeferred calls

### DIFF
--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -268,11 +268,11 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 		return ret;
 	};
 
-	if (name == "java.lang.Integer") {
+	if (name == "java.lang.Integer" || name == "java.lang.Long") {
 
 		jclass nclass = env->FindClass("java/lang/Number");
-		jmethodID intValue = env->GetMethodID(nclass, "intValue", "()I");
-		int ret = env->CallIntMethod(obj, intValue);
+		jmethodID longValue = env->GetMethodID(nclass, "longValue", "()J");
+		jlong ret = env->CallLongMethod(obj, longValue);
 		return ret;
 	};
 


### PR DESCRIPTION
```java.lang.Long``` values are ignored when sent from Android modules via GodotLib.calldeferred().

Example:

	 GodotLib.calldeferred(instance_id, "_my_godot_func", new Object[]{123L});

The java Long values are later ignored when attempting to invoke the ```_my_godot_func``` gdscript func.

Adding possibility to send them with the object array from an Android module with this patch.

Resolves #23845 