### PR TITLE
C#: Replace calls to old of old Basis(Vec3,Vec3,Vec3) constructor

### DIFF
--- a/modules/mono/glue/Managed/Files/Basis.cs
+++ b/modules/mono/glue/Managed/Files/Basis.cs
@@ -13,9 +13,9 @@ namespace Godot
     {
         private static readonly Basis identity = new Basis
         (
-            new Vector3(1f, 0f, 0f),
-            new Vector3(0f, 1f, 0f),
-            new Vector3(0f, 0f, 1f)
+            1f, 0f, 0f,
+            0f, 1f, 0f,
+            0f, 0f, 1f
         );
 
         private static readonly Basis[] orthoBases = {
@@ -159,9 +159,9 @@ namespace Godot
         {
             return new Basis
             (
-                new Vector3(xAxis.x, yAxis.x, zAxis.x),
-                new Vector3(xAxis.y, yAxis.y, zAxis.y),
-                new Vector3(xAxis.z, yAxis.z, zAxis.z)
+                xAxis.x, yAxis.x, zAxis.x,
+                xAxis.y, yAxis.y, zAxis.y,
+                xAxis.z, yAxis.z, zAxis.z
             );
         }
 
@@ -535,12 +535,17 @@ namespace Godot
 
         public Basis(Vector3 xAxis, Vector3 yAxis, Vector3 zAxis)
         {
-            x = xAxis;
-            y = yAxis;
-            z = zAxis;
+            _x = new Vector3(xAxis.x, yAxis.x, zAxis.x);
+            _y = new Vector3(xAxis.y, yAxis.y, zAxis.y);
+            _z = new Vector3(xAxis.z, yAxis.z, zAxis.z);
+            // Same as:
+            // SetAxis(0, xAxis);
+            // SetAxis(1, yAxis);
+            // SetAxis(2, zAxis);
+            // We need to assign the struct fields so we can't do that...
         }
 
-        public Basis(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_t yz, real_t zx, real_t zy, real_t zz)
+        internal Basis(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_t yz, real_t zx, real_t zy, real_t zz)
         {
             _x = new Vector3(xx, xy, xz);
             _y = new Vector3(yx, yy, yz);

--- a/modules/mono/glue/Managed/Files/Transform.cs
+++ b/modules/mono/glue/Managed/Files/Transform.cs
@@ -124,9 +124,9 @@ namespace Godot
 
         // Constants
         private static readonly Transform _identity = new Transform(Basis.Identity, Vector3.Zero);
-        private static readonly Transform _flipX = new Transform(new Basis(new Vector3(-1, 0, 0), new Vector3(0, 1, 0), new Vector3(0, 0, 1)), Vector3.Zero);
-        private static readonly Transform _flipY = new Transform(new Basis(new Vector3(1, 0, 0), new Vector3(0, -1, 0), new Vector3(0, 0, 1)), Vector3.Zero);
-        private static readonly Transform _flipZ = new Transform(new Basis(new Vector3(1, 0, 0), new Vector3(0, 1, 0), new Vector3(0, 0, -1)), Vector3.Zero);
+        private static readonly Transform _flipX = new Transform(new Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1), Vector3.Zero);
+        private static readonly Transform _flipY = new Transform(new Basis(1, 0, 0, 0, -1, 0, 0, 0, 1), Vector3.Zero);
+        private static readonly Transform _flipZ = new Transform(new Basis(1, 0, 0, 0, 1, 0, 0, 0, -1), Vector3.Zero);
 
         public static Transform Identity { get { return _identity; } }
         public static Transform FlipX { get { return _flipX; } }

--- a/modules/mono/glue/Managed/Files/Vector3.cs
+++ b/modules/mono/glue/Managed/Files/Vector3.cs
@@ -204,9 +204,9 @@ namespace Godot
         public Basis Outer(Vector3 b)
         {
             return new Basis(
-                new Vector3(x * b.x, x * b.y, x * b.z),
-                new Vector3(y * b.x, y * b.y, y * b.z),
-                new Vector3(z * b.x, z * b.y, z * b.z)
+                x * b.x, x * b.y, x * b.z,
+                y * b.x, y * b.y, y * b.z,
+                z * b.x, z * b.y, z * b.z
             );
         }
 


### PR DESCRIPTION
Replaced old calls to `Basis(Vec3,Vec3,Vec3)`. Made the Basis constructor that takes 9 reals internal. It would be confusing since it's different from the former. It's also not meant to be exposed to scripts (GDScript does not have it).
