### PR TITLE
Add TileProperties, generalize EditorPropertyResource

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -609,6 +609,7 @@ void register_scene_types() {
 	ClassDB::register_class<PinJoint2D>();
 	ClassDB::register_class<GrooveJoint2D>();
 	ClassDB::register_class<DampedSpringJoint2D>();
+	ClassDB::register_class<TileProperties>();
 	ClassDB::register_class<TileSet>();
 	ClassDB::register_class<TileMap>();
 	ClassDB::register_class<ParallaxBackground>();

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -34,6 +34,10 @@
 #include "core/engine.h"
 #include "core/math/geometry_2d.h"
 
+void TileProperties::_bind_methods() {}
+
+TileProperties::TileProperties() {}
+
 bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 	String n = p_name;
 	int slash = n.find("/");
@@ -203,6 +207,14 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 		tile_set_navigation_polygon_offset(id, p_value);
 	} else if (what == "z_index") {
 		tile_set_z_index(id, p_value);
+	} else if (what == "properties") {
+		tile_set_properties(id, p_value);
+	} else if (what == "properties_script") {
+		Ref<TileProperties> properties = tile_get_properties(id);
+		if (properties.is_valid()) {
+			Ref<Script> script = p_value;
+			properties->set_script(script.ptr());
+		}
 	} else {
 		return false;
 	}
@@ -318,6 +330,13 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = tile_get_navigation_polygon_offset(id);
 	} else if (what == "z_index") {
 		r_ret = tile_get_z_index(id);
+	} else if (what == "properties") {
+		r_ret = tile_get_properties(id);
+	} else if (what == "properties_script") {
+		RES properties = tile_get_properties(id);
+		if (properties.is_valid()) {
+			r_ret = properties->get_script();
+		}
 	} else {
 		return false;
 	}
@@ -367,6 +386,8 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::FLOAT, pre + "shape_one_way_margin", PROPERTY_HINT_RANGE, "0,128,0.01", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "shapes", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::INT, pre + "z_index", PROPERTY_HINT_RANGE, itos(RS::CANVAS_ITEM_Z_MIN) + "," + itos(RS::CANVAS_ITEM_Z_MAX) + ",1", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "properties", PROPERTY_HINT_RESOURCE_TYPE, "TileProperties"));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "properties_script", PROPERTY_HINT_RESOURCE_TYPE, "Script"));
 	}
 }
 
@@ -374,8 +395,37 @@ void TileSet::create_tile(int p_id) {
 	ERR_FAIL_COND(tile_map.has(p_id));
 	tile_map[p_id] = TileData();
 	tile_map[p_id].autotile_data = AutotileData();
+	if (tile_properties_script.is_valid()) {
+		tile_map[p_id].properties = Ref<TileProperties>(memnew(TileProperties));
+		tile_map[p_id].properties->set_script(tile_properties_script.ptr());
+	}
 	_change_notify("");
 	emit_changed();
+}
+
+void TileSet::set_tile_properties_script(const Ref<Script> &p_script) {
+	if (tile_properties_script == p_script)
+		return;
+	if (tile_properties_script.is_null()) {
+		for (Map<int, TileSet::TileData>::Element *E = tile_map.front(); E; E = E->next()) {
+			Ref<TileProperties> tp = memnew(TileProperties());
+			tp->set_script(p_script.ptr());
+			E->value().properties = tp;
+		}
+	} else {
+		for (Map<int, TileSet::TileData>::Element *E = tile_map.front(); E; E = E->next()) {
+			Ref<TileProperties> p = E->value().properties;
+			ERR_CONTINUE(p.is_valid());
+			Ref<Script> s = p->get_script();
+			if (s != p_script)
+				E->value().properties->set_script(p_script.ptr());
+		}
+	}
+	tile_properties_script = p_script;
+}
+
+Ref<Script> TileSet::get_tile_properties_script() const {
+	return tile_properties_script;
 }
 
 void TileSet::autotile_set_bitmask_mode(int p_id, BitmaskMode p_mode) {
@@ -907,6 +957,17 @@ Vector2 TileSet::tile_get_occluder_offset(int p_id) const {
 	return tile_map[p_id].occluder_offset;
 }
 
+Ref<TileProperties> TileSet::tile_get_properties(int p_id) const {
+	ERR_FAIL_COND_V(!tile_map.has(p_id), 0);
+	return tile_map[p_id].properties;
+}
+
+void TileSet::tile_set_properties(int p_id, const Ref<TileProperties> &p_properties) {
+	ERR_FAIL_COND(!tile_map.has(p_id));
+	tile_map[p_id].properties = p_properties;
+	emit_changed();
+}
+
 void TileSet::tile_set_shapes(int p_id, const Vector<ShapeData> &p_shapes) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].shapes_data = p_shapes;
@@ -1049,6 +1110,14 @@ void TileSet::_decompose_convex_shape(Ref<Shape2D> p_shape) {
 	}
 }
 
+void TileSet::set_meta_properties(Dictionary p_dict) {
+	meta_properties = p_dict;
+}
+
+Dictionary TileSet::get_meta_properties() const {
+	return meta_properties;
+}
+
 void TileSet::get_tile_list(List<int> *p_tiles) const {
 	for (Map<int, TileData>::Element *E = tile_map.front(); E; E = E->next()) {
 		p_tiles->push_back(E->key());
@@ -1164,12 +1233,24 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tile_get_occluder_offset", "id"), &TileSet::tile_get_occluder_offset);
 	ClassDB::bind_method(D_METHOD("tile_set_z_index", "id", "z_index"), &TileSet::tile_set_z_index);
 	ClassDB::bind_method(D_METHOD("tile_get_z_index", "id"), &TileSet::tile_get_z_index);
+	ClassDB::bind_method(D_METHOD("tile_set_properties", "id", "properties"), &TileSet::tile_set_properties);
+	ClassDB::bind_method(D_METHOD("tile_get_properties", "id"), &TileSet::tile_get_properties);
 
 	ClassDB::bind_method(D_METHOD("remove_tile", "id"), &TileSet::remove_tile);
 	ClassDB::bind_method(D_METHOD("clear"), &TileSet::clear);
 	ClassDB::bind_method(D_METHOD("get_last_unused_tile_id"), &TileSet::get_last_unused_tile_id);
 	ClassDB::bind_method(D_METHOD("find_tile_by_name", "name"), &TileSet::find_tile_by_name);
 	ClassDB::bind_method(D_METHOD("get_tiles_ids"), &TileSet::_get_tiles_ids);
+	ClassDB::bind_method(D_METHOD("set_tile_properties_script", "script"), &TileSet::set_tile_properties_script);
+	ClassDB::bind_method(D_METHOD("get_tile_properties_script"), &TileSet::get_tile_properties_script);
+
+	ClassDB::bind_method(D_METHOD("set_meta_properties", "dict"), &TileSet::set_meta_properties);
+	ClassDB::bind_method(D_METHOD("get_meta_properties"), &TileSet::get_meta_properties);
+
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "meta_properties", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "Script"), "set_meta_properties", "get_meta_properties");
+
+	ADD_GROUP("Tiles", "tiles_");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "tiles_default_script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT, "Script"), "set_tile_properties_script", "get_tile_properties_script");
 
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_is_tile_bound", PropertyInfo(Variant::INT, "drawn_id"), PropertyInfo(Variant::INT, "neighbor_id")));
 	BIND_VMETHOD(MethodInfo(Variant::VECTOR2, "_forward_subtile_selection", PropertyInfo(Variant::INT, "autotile_id"), PropertyInfo(Variant::INT, "bitmask"), PropertyInfo(Variant::OBJECT, "tilemap", PROPERTY_HINT_NONE, "TileMap"), PropertyInfo(Variant::VECTOR2, "tile_location")));

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -39,6 +39,24 @@
 #include "scene/resources/shape_2d.h"
 #include "scene/resources/texture.h"
 
+class TileSet;
+
+class TileProperties : public Resource {
+	GDCLASS(TileProperties, Resource);
+
+	friend class TileSet;
+
+private:
+	int id;
+	Ref<TileSet> tileset;
+
+protected:
+	static void _bind_methods();
+
+public:
+	TileProperties();
+};
+
 class TileSet : public Resource {
 	GDCLASS(TileSet, Resource);
 
@@ -120,16 +138,21 @@ private:
 		Color modulate = Color(1, 1, 1);
 		AutotileData autotile_data;
 		int z_index = 0;
+		Ref<TileProperties> properties;
 
 		explicit TileData() {}
 	};
 
 	Map<int, TileData> tile_map;
 
+	Ref<Script> tile_properties_script;
+	Dictionary meta_properties;
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	void _get_tile_property_list(int p_id, List<PropertyInfo> *p_list) const;
 	void _tile_set_shapes(int p_id, const Array &p_shapes);
 	Array _tile_get_shapes(int p_id) const;
 	Array _get_tiles_ids() const;
@@ -139,6 +162,12 @@ protected:
 
 public:
 	void create_tile(int p_id);
+
+	void set_meta_properties(Dictionary p_dict);
+	Dictionary get_meta_properties() const;
+
+	void set_tile_properties_script(const Ref<Script> &p_script);
+	Ref<Script> get_tile_properties_script() const;
 
 	void autotile_set_bitmask_mode(int p_id, BitmaskMode p_mode);
 	BitmaskMode autotile_get_bitmask_mode(int p_id) const;
@@ -235,6 +264,9 @@ public:
 
 	void tile_set_z_index(int p_id, int p_z_index);
 	int tile_get_z_index(int p_id) const;
+
+	void tile_set_properties(int p_id, const Ref<TileProperties> &p_meta);
+	Ref<TileProperties> tile_get_properties(int p_id) const;
 
 	void remove_tile(int p_id);
 


### PR DESCRIPTION
This PR does several things.

1. The TileSet's scripted properties are now displayed in the Inspector. This enables TileMaps to see this information in the new EditorInspector when they expand out the sub-inspector.
2. The TileSet now has a `meta_properties` Dictionary that is exported to the Inspector. It likewise can be edited from a TileMap just by expanding the sub-inspector.
3. When using the new TileSet Editor, the TileSetContextEditor's inspector window will display the scripted properties and the `meta_properties` Dictionary just like in the TileMap. It also displays the script for the TileSet so that it can be assigned a value without having to open a separate Inspector.
4. When a tile is selected, a new property is present at the bottom: TileProperties. This is a new resource type that can be inherited by scripts. If users create a TileProperties object and give it a script (the tile properties script is ALSO exposed to the TileSetContextEditor), then they can easily define custom properties per-tile and share them between tiles by re-using the same resource object.
5. A `tiles_default_script` property has been added to the TileSet class and exposed to the Inspector. If one sets a script to this value, then all created tiles will automatically create an instance of a TileProperties sub-resource and assign that script to it, guaranteeing that all tiles have access to those properties.
6. I also noticed that the EditorPropertyResource class wasn't taking into account script classes when determining what creation options to display, so I added a section that adds them to the potential inheritors.
7. The EditorPropertyResource class was still using the old icon lookup algorithm, so I swapped out all of the logic for just using the new `get_class_icon` method.

This should take care of a great many different Issues:

1. Closes #23305. This exposes a TileSet's scripted properties, and then some.
2. Related to #12634. While it doesn't directly add a Dictionary to each tile, it does provide a Resource which itself can contain a Dictionary. It also adds a Dictionary to the Tileset (which, if keys were combined with strings, could serve as an alternative, i.e. `meta_properties[str(id) + "/property"] = "value"`. I THINK we could close it with this PR.
3. Related to #23714. ^ This Issue is basically identical. Same reasoning.
4. Related to #15583. With this PR, combined with implementing #9180, I think we'd have all of the needs associated with this PR met. As such, I don't really know whether it would still be necessary to implement a "Tile node".

Here are some screenshots from my build, using the below scripts:

    # tileset.gd
    extends TileSet
    export var units_per_tile = 1

    # tile.gd
    extends TileProperties
    export var type = "forest"
    export var movement = 2
    export var defense = 3

TileMap Inspector:
<img width="247" alt="tilemap" src="https://user-images.githubusercontent.com/16217563/48807485-48eca600-ece3-11e8-9d88-767b16656d25.png">

TileSetContextEditor:
<img width="248" alt="tilesetcontexteditor" src="https://user-images.githubusercontent.com/16217563/48807498-4db15a00-ece3-11e8-88bb-7853501ed448.png">

Edit: I have just modified it so that the `meta_properties` value is displayed as "Meta Properties" in the TileSetContextEditor instead of as "Meta" (that was a mistake).