### PR TITLE
Allows user to click on error line in status bar to jump into error.

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1130,6 +1130,19 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 void CodeTextEditor::set_error(const String &p_error) {
 
 	error->set_text(p_error);
+	error->set_tooltip(p_error);
+	error->set_visible(p_error != "");
+}
+
+void CodeTextEditor::set_error_pos(int p_line, int p_column) {
+	error_line = p_line;
+	error_column = p_column;
+}
+
+void CodeTextEditor::_error_pressed() {
+	text_editor->cursor_set_line(error_line);
+	text_editor->cursor_set_column(error_column);
+	text_editor->center_viewport_to_cursor();
 }
 
 void CodeTextEditor::_update_font() {
@@ -1191,6 +1204,7 @@ void CodeTextEditor::_bind_methods() {
 	ClassDB::bind_method("_code_complete_timer_timeout", &CodeTextEditor::_code_complete_timer_timeout);
 	ClassDB::bind_method("_complete_request", &CodeTextEditor::_complete_request);
 	ClassDB::bind_method("_font_resize_timeout", &CodeTextEditor::_font_resize_timeout);
+	ClassDB::bind_method("_error_pressed", &CodeTextEditor::_error_pressed);
 
 	ADD_SIGNAL(MethodInfo("validate_script"));
 	ADD_SIGNAL(MethodInfo("load_theme_settings"));
@@ -1239,13 +1253,22 @@ CodeTextEditor::CodeTextEditor() {
 
 	code_complete_timer->set_wait_time(EDITOR_DEF("text_editor/completion/code_complete_delay", .3f));
 
-	error = memnew(Label);
-	status_bar->add_child(error);
-	error->set_autowrap(true);
-	error->set_valign(Label::VALIGN_CENTER);
+	error_line = 0;
+	error_column = 0;
+
+	Control *error_box = memnew(Control);
+	status_bar->add_child(error_box);
+	error_box->set_v_size_flags(SIZE_EXPAND_FILL);
+	error_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	error_box->set_clip_contents(true);
+
+	error = memnew(LinkButton);
+	error_box->add_child(error);
+	error->set_anchors_and_margins_preset(Control::PRESET_CENTER_LEFT);
+	error->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
 	error->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
 	error->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
-	error->set_h_size_flags(SIZE_EXPAND_FILL); //required for it to display, given now it's clipping contents, do not touch
+	error->connect("pressed", this, "_error_pressed");
 	find_replace_bar->connect("error", error, "set_text");
 
 	status_bar->add_child(memnew(Label)); //to keep the height if the other labels are not visible

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -36,6 +36,7 @@
 #include "scene/gui/check_button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
+#include "scene/gui/link_button.h"
 #include "scene/gui/text_edit.h"
 #include "scene/gui/tool_button.h"
 #include "scene/main/timer.h"
@@ -157,7 +158,9 @@ class CodeTextEditor : public VBoxContainer {
 	int font_resize_val;
 	real_t font_size;
 
-	Label *error;
+	LinkButton *error;
+	int error_line;
+	int error_column;
 
 	void _on_settings_change();
 
@@ -171,6 +174,7 @@ class CodeTextEditor : public VBoxContainer {
 	void _zoom_out();
 	void _zoom_changed();
 	void _reset_zoom();
+	void _error_pressed();
 
 	CodeTextEditorCodeCompleteFunc code_complete_func;
 	void *code_complete_ud;
@@ -213,6 +217,7 @@ public:
 
 	void update_editor_settings();
 	void set_error(const String &p_error);
+	void set_error_pos(int p_line, int p_column);
 	void update_line_and_column() { _line_col_changed(); }
 	TextEdit *get_text_edit() { return text_editor; }
 	FindReplaceBar *get_find_replace_bar() { return find_replace_bar; }

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -443,6 +443,7 @@ void ScriptTextEditor::_validate_script() {
 	if (!script->get_language()->validate(text, line, col, errortxt, script->get_path(), &fnc, &warnings, &safe_lines)) {
 		String error_text = "error(" + itos(line) + "," + itos(col) + "): " + errortxt;
 		code_editor->set_error(error_text);
+		code_editor->set_error_pos(line - 1, col - 1);
 	} else {
 		code_editor->set_error("");
 		line = -1;

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -193,6 +193,7 @@ void ShaderTextEditor::_validate_script() {
 	if (err != OK) {
 		String error_text = "error(" + itos(sl.get_error_line()) + "): " + sl.get_error_text();
 		set_error(error_text);
+		set_error_pos(sl.get_error_line() - 1, 0);
 		for (int i = 0; i < get_text_edit()->get_line_count(); i++)
 			get_text_edit()->set_line_as_marked(i, false);
 		get_text_edit()->set_line_as_marked(sl.get_error_line() - 1, true);


### PR DESCRIPTION
Its a bit of useful functionality, it makes the error line in the script editor(and shader editor too) clickable and allow user to quickly jump into error. 

![image](https://user-images.githubusercontent.com/3036176/48837079-6aa66580-ed95-11e8-9533-f28faccd321b.png)

I changed line type to LinkButton <s>and the only downside about this approach is if this is long error line, the editor will try to expand itself(instead of clip or autowrap). Leave a suggestions of how to fix it..</s>