### PR TITLE
Avoids error messages when importing zero scale transforms in the COLLADA importer

### DIFF
--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1655,7 +1655,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 				}
 			}
 
-			Quat q = xform.basis.get_rotation_quat();
+			Quat q = Math::is_equal_approx(xform.basis.determinant(), 0) ? Quat() : xform.basis.get_rotation_quat();
 			Vector3 s = xform.basis.get_scale();
 			Vector3 l = xform.origin;
 
@@ -1705,7 +1705,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 
 			xform = sk->get_bone_rest(nm.bone).affine_inverse() * xform;
 
-			Quat q = xform.basis.get_rotation_quat();
+			Quat q = Math::is_equal_approx(xform.basis.determinant(), 0) ? Quat() : xform.basis.get_rotation_quat();
 			Vector3 s = xform.basis.get_scale();
 			Vector3 l = xform.origin;
 


### PR DESCRIPTION
Avoids spamming the user when the COLLADA importer detects a singular basis during the animation import. Fixes #22848.