### PR TITLE
Moved dirty material lists from static to lifetime controlled by main.

### DIFF
--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -109,7 +109,7 @@ private:
 	}
 
 	static Mutex *material_mutex;
-	static SelfList<CanvasItemMaterial>::List dirty_materials;
+	static SelfList<CanvasItemMaterial>::List *dirty_materials;
 	SelfList<CanvasItemMaterial> element;
 
 	void _update_shader();

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -360,7 +360,7 @@ private:
 	};
 
 	static Mutex *material_mutex;
-	static SelfList<SpatialMaterial>::List dirty_materials;
+	static SelfList<SpatialMaterial>::List *dirty_materials;
 	static ShaderNames *shader_names;
 
 	SelfList<SpatialMaterial> element;

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -31,7 +31,7 @@
 #include "particles_material.h"
 
 Mutex *ParticlesMaterial::material_mutex = NULL;
-SelfList<ParticlesMaterial>::List ParticlesMaterial::dirty_materials;
+SelfList<ParticlesMaterial>::List *ParticlesMaterial::dirty_materials = NULL;
 Map<ParticlesMaterial::MaterialKey, ParticlesMaterial::ShaderData> ParticlesMaterial::shader_map;
 ParticlesMaterial::ShaderNames *ParticlesMaterial::shader_names = NULL;
 
@@ -40,6 +40,8 @@ void ParticlesMaterial::init_shaders() {
 #ifndef NO_THREADS
 	material_mutex = Mutex::create();
 #endif
+
+	dirty_materials = memnew(SelfList<ParticlesMaterial>::List);
 
 	shader_names = memnew(ShaderNames);
 
@@ -106,12 +108,15 @@ void ParticlesMaterial::finish_shaders() {
 	memdelete(material_mutex);
 #endif
 
+	memdelete(dirty_materials);
+	dirty_materials = NULL;
+
 	memdelete(shader_names);
 }
 
 void ParticlesMaterial::_update_shader() {
 
-	dirty_materials.remove(&element);
+	dirty_materials->remove(&element);
 
 	MaterialKey mk = _compute_key();
 	if (mk.key == current_key.key)
@@ -584,9 +589,9 @@ void ParticlesMaterial::flush_changes() {
 	if (material_mutex)
 		material_mutex->lock();
 
-	while (dirty_materials.first()) {
+	while (dirty_materials->first()) {
 
-		dirty_materials.first()->self()->_update_shader();
+		dirty_materials->first()->self()->_update_shader();
 	}
 
 	if (material_mutex)
@@ -599,7 +604,7 @@ void ParticlesMaterial::_queue_shader_change() {
 		material_mutex->lock();
 
 	if (!element.in_list()) {
-		dirty_materials.add(&element);
+		dirty_materials->add(&element);
 	}
 
 	if (material_mutex)

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -126,7 +126,7 @@ private:
 	}
 
 	static Mutex *material_mutex;
-	static SelfList<ParticlesMaterial>::List dirty_materials;
+	static SelfList<ParticlesMaterial>::List *dirty_materials;
 
 	struct ShaderNames {
 		StringName spread;


### PR DESCRIPTION
As with 7d82bed4f4cac8f5227d935c0496290e24eb48c8,
The list is now destroyed before the OS object, so can print errors if
there are unfreed materials.