### PR TITLE
Added rpc_node_notfound signal to SceneTree and MultiplayerAPI

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -241,8 +241,10 @@ Node *MultiplayerAPI::_process_get_node(int p_from, const uint8_t *p_packet, int
 
 		node = root_node->get_node(np);
 
-		if (!node)
+		if (!node) {
+			emit_signal("rpc_node_notfound", String(np));
 			ERR_PRINTS("Failed to get path from RPC: " + String(np));
+		}
 	} else {
 		// Use cached path.
 		int id = target;
@@ -259,8 +261,10 @@ Node *MultiplayerAPI::_process_get_node(int p_from, const uint8_t *p_packet, int
 		// Do proper caching later.
 
 		node = root_node->get_node(ni->path);
-		if (!node)
+		if (!node) {
+			emit_signal("rpc_node_notfound", String(ni->path));
 			ERR_PRINTS("Failed to get cached path from RPC: " + String(ni->path));
+		}
 	}
 	return node;
 }
@@ -844,6 +848,7 @@ void MultiplayerAPI::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("connected_to_server"));
 	ADD_SIGNAL(MethodInfo("connection_failed"));
 	ADD_SIGNAL(MethodInfo("server_disconnected"));
+	ADD_SIGNAL(MethodInfo("rpc_node_notfound", PropertyInfo(Variant::STRING, "node_name")));
 
 	BIND_ENUM_CONSTANT(RPC_MODE_DISABLED);
 	BIND_ENUM_CONSTANT(RPC_MODE_REMOTE);

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -135,6 +135,13 @@
 				Emitted whenever this MultiplayerAPI's [member network_peer] disconnects from server. Only emitted on clients.
 			</description>
 		</signal>
+		<signal name="rpc_node_notfound">
+			<argument index="0" name="node_path" type="String">
+			</argument>
+			<description>
+				Emitted whenever a RPC or RSET call is made to a node that does not exist on the client.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="RPC_MODE_DISABLED" value="0" enum="RPCMode">

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -332,6 +332,13 @@
 				Emitted whenever this SceneTree's [member network_peer] disconnects from a peer. Clients get notified when other clients disconnect from the same server.
 			</description>
 		</signal>
+		<signal name="rpc_node_notfound">
+			<argument index="0" name="node_path" type="String">
+			</argument>
+			<description>
+				Emitted whenever a RPC or RSET call is made to a node that does not exist on the client.
+			</description>
+		</signal>
 		<signal name="node_added">
 			<argument index="0" name="node" type="Node">
 			</argument>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1699,6 +1699,10 @@ void SceneTree::_server_disconnected() {
 	emit_signal("server_disconnected");
 }
 
+void SceneTree::_rpc_node_notfound(String np) {
+	emit_signal("rpc_node_notfound", np);
+}
+
 Ref<MultiplayerAPI> SceneTree::get_multiplayer() const {
 	return multiplayer;
 }
@@ -1720,6 +1724,7 @@ void SceneTree::set_multiplayer(Ref<MultiplayerAPI> p_multiplayer) {
 		multiplayer->disconnect("connected_to_server", this, "_connected_to_server");
 		multiplayer->disconnect("connection_failed", this, "_connection_failed");
 		multiplayer->disconnect("server_disconnected", this, "_server_disconnected");
+		multiplayer->disconnect("rpc_node_notfound", this, "_rpc_node_notfound");
 	}
 
 	multiplayer = p_multiplayer;
@@ -1730,6 +1735,7 @@ void SceneTree::set_multiplayer(Ref<MultiplayerAPI> p_multiplayer) {
 	multiplayer->connect("connected_to_server", this, "_connected_to_server");
 	multiplayer->connect("connection_failed", this, "_connection_failed");
 	multiplayer->connect("server_disconnected", this, "_server_disconnected");
+	multiplayer->connect("rpc_node_notfound", this, "_rpc_node_notfound");
 }
 
 void SceneTree::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_network_peer) {
@@ -1857,6 +1863,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_connected_to_server"), &SceneTree::_connected_to_server);
 	ClassDB::bind_method(D_METHOD("_connection_failed"), &SceneTree::_connection_failed);
 	ClassDB::bind_method(D_METHOD("_server_disconnected"), &SceneTree::_server_disconnected);
+	ClassDB::bind_method(D_METHOD("_rpc_node_notfound"), &SceneTree::_rpc_node_notfound);
 
 	ClassDB::bind_method(D_METHOD("set_use_font_oversampling", "enable"), &SceneTree::set_use_font_oversampling);
 	ClassDB::bind_method(D_METHOD("is_using_font_oversampling"), &SceneTree::is_using_font_oversampling);
@@ -1888,6 +1895,7 @@ void SceneTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("connected_to_server"));
 	ADD_SIGNAL(MethodInfo("connection_failed"));
 	ADD_SIGNAL(MethodInfo("server_disconnected"));
+	ADD_SIGNAL(MethodInfo("rpc_node_notfound", PropertyInfo(Variant::STRING, "node_path")));
 
 	BIND_ENUM_CONSTANT(GROUP_CALL_DEFAULT);
 	BIND_ENUM_CONSTANT(GROUP_CALL_REVERSE);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -195,6 +195,8 @@ private:
 	void _connection_failed();
 	void _server_disconnected();
 
+	void _rpc_node_notfound(String np);
+
 	static SceneTree *singleton;
 	friend class Node;
 


### PR DESCRIPTION
# rpc_node_notfound signal

## Affected classes

* MultiplayerAPI
* SceneTree

## Objective

I have added an rpc_node_notfound signal in SceneTree to make the multiplayer system more usable in real-life use cases.  The main issue I keep facing is a Node Tree Desync between server and client, where the client will keep throwing Node Not Found exceptions when a node on the server uses an RPC.  This is a typical problem for me with movement synchronization.  I had found myself implementing multiplayer on a NetworkController node instead of on the game nodes themselves to avoid this issue.

## The solution

I have added an rpc_node_notfound signal on the SceneTree which is emitted whenever the client receives an RPC for a node that it does not have.  This allows you to connect the signal to a function that does an RPC to request missing nodes from the server.

## Note

Please be gentle, this is my first PR to this project :) Let me know if I have overstepped somehow or if this PR is undesirable or if I can improve my PR somehow to be more in line with the project.