### PR TITLE
FileAccess::store_csv_line() don't added unnecessary double quotes.

### DIFF
--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -534,7 +534,7 @@ void FileAccess::store_csv_line(const Vector<String> &p_values, const String &p_
 	for (int i = 0; i < size; ++i) {
 		String value = p_values[i];
 
-		if (value.find("\"") != -1 || value.find(p_delim) != -1 || value.find("\n")) {
+		if (value.find("\"") != -1 || value.find(p_delim) != -1 || value.find("\n") != -1) {
 			value = "\"" + value.replace("\"", "\"\"") + "\"";
 		}
 		if (i < size - 1) {


### PR DESCRIPTION
Fixed #23900.