### PR TITLE
Fixes the crash in String::percent_decode() for empty strings

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3298,7 +3298,9 @@ String String::http_unescape() const {
 			res += ord_at(i);
 		}
 	}
-	return String::utf8(res.ascii());
+
+	CharString res2 = res.ascii();
+	return res2.ptr() ? String::utf8(res2.ptr()) : String();
 }
 
 String String::c_unescape() const {
@@ -3892,7 +3894,7 @@ String String::percent_decode() const {
 		pe += c;
 	}
 
-	return String::utf8(pe.ptr());
+	return pe.ptr() ? String::utf8(pe.ptr()) : String();
 }
 
 String String::get_basename() const {


### PR DESCRIPTION
The String::percent_decode() and String::http_unescape() functions do not null-terminate the empty character buffers, so avoid the call to String::utf8() if the character buffer is null.
Fixes #22221.