### PR TITLE
General fixes for the new unified help search

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -315,12 +315,12 @@
 			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
-				Emitted when an item is selected with right mouse button.
+				Emitted when an item is selected with the right mouse button.
 			</description>
 		</signal>
 		<signal name="item_selected">
 			<description>
-				Emitted when an item is selected with right mouse button.
+				Emitted when an item is selected.
 			</description>
 		</signal>
 		<signal name="multi_selected">


### PR DESCRIPTION
- Fixed editor crash when trying to open a doc when none is selected.
- Fixed error spam when typing in the search box (turns out the `get_parent_class_nocheck()` was a necessary change).
- Fixed a misinformation on the `Tree` doc that made this PR take a little more time than it should've.