### PR TITLE
Manually linking static libraries with MSVC appends Godot's LIBSUFFIX

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -119,6 +119,15 @@ env_base.__class__.add_source_files = methods.add_source_files
 env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
 env_base.__class__.split_lib = methods.split_lib
 
+if(os.name == "nt"):
+    env_base.__class__.append_libs = methods.append_libs_windows
+    env_base.__class__.prepend_libs = methods.prepend_libs_windows
+    env_base.__class__.insert_libs = methods.insert_libs_windows
+else:
+    env_base.__class__.append_libs = methods.append_libs_linux
+    env_base.__class__.prepend_libs = methods.prepend_libs_linux
+    env_base.__class__.insert_libs = methods.insert_libs_linux
+
 env_base.__class__.add_shared_library = methods.add_shared_library
 env_base.__class__.add_library = methods.add_library
 env_base.__class__.add_program = methods.add_program
@@ -430,6 +439,9 @@ if selected_platform in platform_list:
         # On Windows, only static libraries and import libraries can be
         # statically linked - both using .lib extension
         env["LIBSUFFIXES"] += [env["LIBSUFFIX"]]
+        # Disabling prefix and suffix concatenation to library names.
+        # Libraries are added as full paths using append/prepend_libs function.
+        env["_LIBFLAGS"] = '${_concat("", LIBS, "", __env__)}'
     else:
         env["LIBSUFFIXES"] += [env["LIBSUFFIX"], env["SHLIBSUFFIX"]]
     env["LIBSUFFIX"] = suffix + env["LIBSUFFIX"]

--- a/core/SCsub
+++ b/core/SCsub
@@ -180,4 +180,5 @@ SConscript('bind/SCsub')
 
 # Build it all as a library
 lib = env.add_library("core", env.core_sources)
-env.Prepend(LIBS=[lib])
+#env.Prepend(LIBS=[lib])
+env.prepend_libs(lib)

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -52,4 +52,5 @@ if env.split_drivers:
 else:
     env.add_source_files(env.drivers_sources, "*.cpp")
     lib = env.add_library("drivers", env.drivers_sources)
-    env.Prepend(LIBS=[lib])
+    #env.Prepend(LIBS=[lib])
+    env.prepend_libs(lib)

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -91,4 +91,5 @@ if env['tools']:
     SConscript('plugins/SCsub')
 
     lib = env.add_library("editor", env.editor_sources)
-    env.Prepend(LIBS=[lib])
+    #env.Prepend(LIBS=[lib])
+    env.prepend_libs(lib)

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -92,11 +92,11 @@ if env['builtin_freetype']:
     inserted = False
     for idx, linklib in enumerate(env["LIBS"]):
         if isbasestring(linklib): # first system lib such as "X11", otherwise SCons lib object
-            env["LIBS"].insert(idx, lib)
+            env.insert_libs(idx, lib)
             inserted = True
             break
     if not inserted:
-        env.Append(LIBS=[lib])
+        env.append_libs(lib)
 
 # Godot source files
 env_freetype.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/thekla_unwrap/SCsub
+++ b/modules/thekla_unwrap/SCsub
@@ -75,7 +75,8 @@ if env['builtin_thekla_atlas']:
             env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_WIN32", "-DNV_CC_MSVC", "-DPOSH_COMPILER_MSVC" ])
         else:
             env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_MINGW", "-DNV_CC_GNUC", "-DPOSH_COMPILER_GCC", "-U__STRICT_ANSI__"])
-            env.Append(LIBS=["dbghelp"])
+            #env.Append(LIBS=["dbghelp"])
+            env.append_libs("dbghelp")
 
     env_thirdparty = env_thekla_unwrap.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -36,7 +36,8 @@ if env['builtin_xatlas']:
             env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_WIN32", "-DNV_CC_MSVC", "-DPOSH_COMPILER_MSVC" ])
         else:
             env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_MINGW", "-DNV_CC_GNUC", "-DPOSH_COMPILER_GCC", "-U__STRICT_ANSI__"])
-            env.Append(LIBS=["dbghelp"])
+            #env.Append(LIBS=["dbghelp"])
+            env.append_libs("dbghelp")
 
     env_thirdparty = env_xatlas_unwrap.Clone()
     env_thirdparty.disable_warnings()

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -28,4 +28,5 @@ with open_utf8('register_platform_apis.gen.cpp', 'w') as f:
 platform_sources.append('register_platform_apis.gen.cpp')
 
 lib = env.add_library('platform', platform_sources)
-env.Prepend(LIBS=lib)
+#env.Prepend(LIBS=lib)
+env.prepend_libs(lib)

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -13,4 +13,5 @@ SConscript('audio/SCsub')
 
 lib = env.add_library("servers", env.servers_sources)
 
-env.Prepend(LIBS=[lib])
+#env.Prepend(LIBS=[lib])
+env.prepend_libs(lib)


### PR DESCRIPTION
Added functions append_libs() and prepend_libs() that add libraries to the $LIBS environment variable. It deduces and adds full path of each library to the $LIBS.

This solves issue #23687.

Since I'm not very experienced with Python, the code will probably need some clean up. All comments are welcome.