### PR TITLE
Show error if required fields are not filled when exporting iOS

### DIFF
--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -982,11 +982,27 @@ bool EditorExportPlatformIOS::can_export(const Ref<EditorExportPreset> &p_preset
 		err += "Custom release package not found.\n";
 	}
 
+	String team_id = p_preset->get("application/app_store_team_id");
+	if (team_id.length() == 0) {
+		err += "App Store Team ID not specified - cannot configure the project.\n";
+	}
+
+	for (unsigned int i = 0; i < (sizeof(icon_infos) / sizeof(icon_infos[0])); ++i) {
+		IconInfo info = icon_infos[i];
+		String icon_path = p_preset->get(info.preset_key);
+		if (icon_path.length() == 0) {
+			if (info.is_required) {
+				err += "Required icon is not specified in the preset.\n";
+			}
+			break;
+		}
+	}
+
 	if (!err.empty())
 		r_error = err;
 
 	r_missing_templates = !valid;
-	return valid;
+	return err.empty();
 }
 
 EditorExportPlatformIOS::EditorExportPlatformIOS() {


### PR DESCRIPTION
Fix #15058

![ios_export](https://user-images.githubusercontent.com/8281454/48923001-00550880-eeee-11e8-936f-3b60dcc7f59a.gif)
