### PR TITLE
Enter key behaviour in several the pop-up windows on the opening GUI

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -95,6 +95,7 @@ private:
 	String zip_title;
 	AcceptDialog *dialog_error;
 	String fav_dir;
+	bool popup_window_active = false;
 
 	String created_folder_path;
 
@@ -462,7 +463,6 @@ private:
 
 					mode = MODE_INSTALL;
 					ok_pressed();
-
 					return;
 				}
 
@@ -631,6 +631,8 @@ private:
 
 		if (install_status_rect->get_texture() == get_icon("StatusError", "EditorIcons"))
 			msg->show();
+
+		set_popup_window_active(false);
 	}
 
 	void _notification(int p_what) {
@@ -655,6 +657,10 @@ protected:
 	}
 
 public:
+
+	bool get_popup_window_active() { return popup_window_active; }
+	void set_popup_window_active(bool value) { popup_window_active = value; }
+
 	void set_zip_path(const String &p_path) {
 		zip_path = p_path;
 	}
@@ -672,6 +678,7 @@ public:
 	}
 
 	void show_dialog() {
+		popup_window_active = true;
 
 		if (mode == MODE_RENAME) {
 
@@ -996,8 +1003,8 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 		switch (k->get_scancode()) {
 
 			case KEY_ENTER: {
-
-				_open_project();
+				if(!npdialog->get_popup_window_active())
+					_open_project();
 			} break;
 			case KEY_DELETE: {
 
@@ -1540,6 +1547,7 @@ void ProjectManager::_scan_projects() {
 void ProjectManager::_new_project() {
 
 	npdialog->set_mode(ProjectDialog::MODE_NEW);
+
 	npdialog->show_dialog();
 }
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -95,7 +95,7 @@ private:
 	String zip_title;
 	AcceptDialog *dialog_error;
 	String fav_dir;
-	bool popup_window_active = false;
+	bool popup_window_active;
 
 	String created_folder_path;
 
@@ -657,7 +657,6 @@ protected:
 	}
 
 public:
-
 	bool get_popup_window_active() { return popup_window_active; }
 	void set_popup_window_active(bool value) { popup_window_active = value; }
 
@@ -863,6 +862,8 @@ public:
 
 		dialog_error = memnew(AcceptDialog);
 		add_child(dialog_error);
+
+		set_popup_window_active(false);
 	}
 };
 
@@ -1003,7 +1004,7 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 		switch (k->get_scancode()) {
 
 			case KEY_ENTER: {
-				if(!npdialog->get_popup_window_active())
+				if (!npdialog->get_popup_window_active())
 					_open_project();
 			} break;
 			case KEY_DELETE: {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -95,6 +95,7 @@ private:
 	String zip_title;
 	AcceptDialog *dialog_error;
 	String fav_dir;
+	bool popup_window_active = false;
 
 	String created_folder_path;
 
@@ -317,7 +318,7 @@ private:
 
 		String p = p_path;
 		if (mode == MODE_IMPORT) {
-			if (p.ends_with("project.godot")) {
+			if (p.ends_with("projnpdialog->ect.godot")) {
 				p = p.get_base_dir();
 				install_path_container->hide();
 				get_ok()->set_disabled(false);
@@ -462,7 +463,6 @@ private:
 
 					mode = MODE_INSTALL;
 					ok_pressed();
-
 					return;
 				}
 
@@ -631,6 +631,8 @@ private:
 
 		if (install_status_rect->get_texture() == get_icon("StatusError", "EditorIcons"))
 			msg->show();
+
+		set_popup_window_active(false);
 	}
 
 	void _notification(int p_what) {
@@ -655,6 +657,10 @@ protected:
 	}
 
 public:
+
+	bool get_popup_window_active() { return popup_window_active; }
+	void set_popup_window_active(bool value) { popup_window_active = value; }
+
 	void set_zip_path(const String &p_path) {
 		zip_path = p_path;
 	}
@@ -672,6 +678,7 @@ public:
 	}
 
 	void show_dialog() {
+		popup_window_active = true;
 
 		if (mode == MODE_RENAME) {
 
@@ -996,8 +1003,8 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 		switch (k->get_scancode()) {
 
 			case KEY_ENTER: {
-
-				_open_project();
+				if(!npdialog->get_popup_window_active())
+					_open_project();
 			} break;
 			case KEY_DELETE: {
 
@@ -1540,6 +1547,7 @@ void ProjectManager::_scan_projects() {
 void ProjectManager::_new_project() {
 
 	npdialog->set_mode(ProjectDialog::MODE_NEW);
+
 	npdialog->show_dialog();
 }
 


### PR DESCRIPTION
## PR Description

#17620 Should be solved

This PR adds a new variable to the class **Project Manager**, that solves the weird behaviour the enter key had in some pop-up windows of the opening GUI, one of them being the **Import** one. This type of behaviour was also found in the other pop-up windows such as **New Project** or **Scan**.

When a popup window appears from clicking any of the buttons on the right side of the window, the enter key no longer interacts with the main window while those are active, it only interacts with the popup window itself (as it should happen in my opinion).

Before, if the user had highlighted one of the listed projects and the clicked one of those buttons, if the enter key was pressed while the "okay" button of the specific pop-up window (In the **Import** window, the button is "Import&Edit", for example) was not valid.

Now, in those situations, nothing happens, and the pop-up windows remain open and waiting for the user interaction.

## Changes

To fix the issue, we simply added a boolean variable called *popup_window_active* (with the respective getter and setter), that would allow the program to know when a pop-up window was active or not. The variable is initialized with __false__,and is set to true while a pop-up window is active in the __show_dialog()__ function.

`bool popup_window_active = false;`

On the project_manager.cpp file, the ___unhandled_input()__ function will verify the value of the __popup_window_active__ variable, and will only do anything else if the variable is true.

``` c
		switch (k->get_scancode()) {

			case KEY_ENTER: {
				if(!npdialog->get_popup_window_active())
					_open_project();
			} break;
```

## To Do

Update documentation related to the changed classes.