### PR TITLE
Add display/window/screen_id configuration

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -704,6 +704,17 @@ void OS::close_midi_inputs() {
 		MIDIDriver::get_singleton()->close();
 }
 
+int OS::_get_initial_screen_id() {
+	int screen_id = GLOBAL_DEF("display/window/screen_id", -1);
+	if (screen_id == -1) {
+		screen_id = get_current_screen();
+	} else if (screen_id >= get_screen_count()) {
+		screen_id = 0;
+	}
+
+	return screen_id;
+}
+
 OS::OS() {
 	void *volatile stack_bottom;
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -146,6 +146,8 @@ protected:
 	void _ensure_user_data_dir();
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
 
+	int _get_initial_screen_id();
+
 public:
 	typedef int64_t ProcessID;
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -329,6 +329,9 @@
 		</member>
 		<member name="display/window/per_pixel_transparency_splash" type="bool" setter="" getter="">
 		</member>
+		<member name="display/window/screen_id" type="int" setter="" getter="">
+			Set the screen number, defaults to -1. If configured, use the 'No Management' option on 'run/window_placement/rect', otherwise the editor overrides this value.
+		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="">
 			Force the window to be always on top.
 		</member>

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -148,6 +148,9 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 			args.push_back(itos(pos.x) + "," + itos(pos.y));
 			args.push_back("--fullscreen");
 		} break;
+		case 5: { // no management
+
+		} break;
 	}
 
 	if (p_breakpoints.size()) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -497,7 +497,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/poly_editor/show_previous_outline", true);
 
 	_initial_set("run/window_placement/rect", 1);
-	hints["run/window_placement/rect"] = PropertyInfo(Variant::INT, "run/window_placement/rect", PROPERTY_HINT_ENUM, "Top Left,Centered,Custom Position,Force Maximized,Force Fullscreen");
+	hints["run/window_placement/rect"] = PropertyInfo(Variant::INT, "run/window_placement/rect", PROPERTY_HINT_ENUM, "Top Left,Centered,Custom Position,Force Maximized,Force Fullscreen,No Management");
 	String screen_hints = "Same as Editor,Previous Monitor,Next Monitor";
 	for (int i = 0; i < OS::get_singleton()->get_screen_count(); i++) {
 		screen_hints += ",Monitor " + itos(i + 1);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -892,6 +892,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_width", PropertyInfo(Variant::INT, "display/window/size/test_width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
 	GLOBAL_DEF("display/window/size/test_height", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_height", PropertyInfo(Variant::INT, "display/window/size/test_height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/screen_id", -1);
 
 	if (use_custom_res) {
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1235,11 +1235,16 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 		styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | (p_desired.resizable ? NSWindowStyleMaskResizable : 0);
 	}
 
+	int screen_id = _get_initial_screen_id();
+	Size2 screen_size = get_screen_size(screen_id);
+	NSScreen *screen = [[NSScreen screens] objectAtIndex:screen_id];
+
 	window_object = [[GodotWindow alloc]
-			initWithContentRect:NSMakeRect(0, 0, p_desired.width, p_desired.height)
+			initWithContentRect:NSMakeRect((screen_size.x - p_desired.width) / 2, (screen_size.y - p_desired.height) / 2, p_desired.width, p_desired.height)
 					  styleMask:styleMask
 						backing:NSBackingStoreBuffered
-						  defer:NO];
+						  defer:NO
+						 screen:screen];
 
 	ERR_FAIL_COND_V(window_object == nil, ERR_UNAVAILABLE);
 
@@ -1251,7 +1256,6 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	float displayScale = 1.0;
 	if (is_hidpi_allowed()) {
 		// note that mainScreen is not screen #0 but the one with the keyboard focus.
-		NSScreen *screen = [NSScreen mainScreen];
 		if ([screen respondsToSelector:@selector(backingScaleFactor)]) {
 			displayScale = fmax(displayScale, [screen backingScaleFactor]);
 		}
@@ -1270,7 +1274,6 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	[window_object setContentView:window_view];
 	[window_object setDelegate:window_delegate];
 	[window_object setAcceptsMouseMovedEvents:YES];
-	[window_object center];
 
 	[window_object setRestorable:NO];
 
@@ -2640,6 +2643,7 @@ OS_OSX::OS_OSX() {
 	im_callback = NULL;
 	im_target = NULL;
 	layered_window = false;
+	window_object = 0;
 	autoreleasePool = [[NSAutoreleasePool alloc] init];
 
 	eventSource = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1099,6 +1099,9 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 	video_mode = p_desired;
 	//printf("**************** desired %s, mode %s\n", p_desired.fullscreen?"true":"false", video_mode.fullscreen?"true":"false");
 	RECT WindowRect;
+	int screen_id = _get_initial_screen_id();
+	Point2 screen_pos = get_screen_position(screen_id);
+	Size2 screen_size = get_screen_size(screen_id);
 
 	WindowRect.left = 0;
 	WindowRect.right = video_mode.width;
@@ -1141,35 +1144,9 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 	pre_fs_valid = true;
 	if (video_mode.fullscreen) {
 
-		/* this returns DPI unaware size, commenting
-		DEVMODE current;
-		memset(&current, 0, sizeof(current));
-		EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &current);
+		WindowRect.right = screen_size.x;
+		WindowRect.bottom = screen_size.y;
 
-		WindowRect.right = current.dmPelsWidth;
-		WindowRect.bottom = current.dmPelsHeight;
-
-		*/
-
-		EnumSizeData data = { 0, 0, Size2() };
-		EnumDisplayMonitors(NULL, NULL, _MonitorEnumProcSize, (LPARAM)&data);
-
-		WindowRect.right = data.size.width;
-		WindowRect.bottom = data.size.height;
-
-		/*  DEVMODE dmScreenSettings;
-		memset(&dmScreenSettings,0,sizeof(dmScreenSettings));
-		dmScreenSettings.dmSize=sizeof(dmScreenSettings);
-		dmScreenSettings.dmPelsWidth	= video_mode.width;
-		dmScreenSettings.dmPelsHeight	= video_mode.height;
-		dmScreenSettings.dmBitsPerPel	= current.dmBitsPerPel;
-		dmScreenSettings.dmFields=DM_BITSPERPEL|DM_PELSWIDTH|DM_PELSHEIGHT;
-
-		LONG err = ChangeDisplaySettings(&dmScreenSettings,CDS_FULLSCREEN);
-		if (err!=DISP_CHANGE_SUCCESSFUL) {
-
-			video_mode.fullscreen=false;
-		}*/
 		pre_fs_valid = false;
 	}
 
@@ -1233,8 +1210,8 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 				dwExStyle,
 				L"Engine", L"",
 				dwStyle | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
-				(GetSystemMetrics(SM_CXSCREEN) - WindowRect.right) / 2,
-				(GetSystemMetrics(SM_CYSCREEN) - WindowRect.bottom) / 2,
+				screen_pos.x + (screen_size.x - WindowRect.right) / 2,
+				screen_pos.y + (screen_size.y - WindowRect.bottom) / 2,
 				WindowRect.right - WindowRect.left,
 				WindowRect.bottom - WindowRect.top,
 				NULL, NULL, hInstance, NULL);

--- a/platform/x11/context_gl_x11.h
+++ b/platform/x11/context_gl_x11.h
@@ -60,6 +60,7 @@ private:
 	//::Colormap x11_colormap;
 	::Display *x11_display;
 	::Window &x11_window;
+	int screen_id;
 	bool double_buffer;
 	bool direct_render;
 	int glx_minor, glx_major;
@@ -78,7 +79,7 @@ public:
 	virtual void set_use_vsync(bool p_use);
 	virtual bool is_using_vsync() const;
 
-	ContextGL_X11(::Display *p_x11_display, ::Window &p_x11_window, const OS::VideoMode &p_default_video_mode, ContextType p_context_type);
+	ContextGL_X11(::Display *p_x11_display, ::Window &p_x11_window, const OS::VideoMode &p_default_video_mode, ContextType p_context_type, int p_screen_id);
 	virtual ~ContextGL_X11();
 };
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -278,12 +278,13 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 		opengl_api_type = ContextGL_X11::GLES_2_0_COMPATIBLE;
 	}
 
+	int screen_id = _get_initial_screen_id();
 	bool editor = Engine::get_singleton()->is_editor_hint();
 	bool gl_initialization_error = false;
 
 	context_gl = NULL;
 	while (!context_gl) {
-		context_gl = memnew(ContextGL_X11(x11_display, x11_window, current_videomode, opengl_api_type));
+		context_gl = memnew(ContextGL_X11(x11_display, x11_window, current_videomode, opengl_api_type, screen_id));
 
 		if (context_gl->initialize() != OK) {
 			memdelete(context_gl);
@@ -929,6 +930,10 @@ int OS_X11::get_screen_count() const {
 }
 
 int OS_X11::get_current_screen() const {
+	if (!x11_window) {
+		return XDefaultScreen(x11_display);
+	}
+
 	int x, y;
 	Window child;
 	XTranslateCoordinates(x11_display, x11_window, DefaultRootWindow(x11_display), 0, 0, &x, &y, &child);


### PR DESCRIPTION
This new configuration option can be used to start a project on a specific screen.

In combination with #23799 it is now easy to start projects at the last screen used, saving the screen_id with something like:
```
	var cf = ConfigFile.new()
	cf.set_value("display", "window/screen_id", OS.get_current_screen())
	cf.save("user://override_ps.dat")

```

Note 1: This also adds a `No management` option to `run/window_placement/rect` so that the editor does no management with the window position. Otherwise the `display/window/size/screen_id` is overridden by the editor (if the project is run inside the editor).

Note 2: By default now Windows, OS X and Linux create the window centered. Previously only Windows and OS X centered the window when it was being created.