### PR TITLE
AnimatedSprite: Fixed signal animation_finished

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -398,11 +398,11 @@ void AnimatedSprite::_notification(int p_what) {
 							emit_signal(SceneStringNames::get_singleton()->animation_finished);
 							frame = 0;
 						} else {
-							if (!is_over) {
-								emit_signal(SceneStringNames::get_singleton()->animation_finished);
-								is_over = true;
-							}
 							frame = fc - 1;
+							if (!is_over) {
+								is_over = true;
+								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+							}
 						}
 					} else {
 						frame++;


### PR DESCRIPTION
The signal animation_finished is now fired after all values have been changed so changes to the animation can be done inside animation_finished without generating unexpected behavior.

Fixes: https://github.com/godotengine/godot/issues/23928