### PR TITLE
GLES2 implemented VIEWPORT_SIZE builtin for spatial shader

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2017,6 +2017,8 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 
 	ShadowAtlas *shadow_atlas = shadow_atlas_owner.getornull(p_shadow_atlas);
 
+	Vector2 viewport_size = state.viewport_size;
+
 	Vector2 screen_pixel_size = state.screen_pixel_size;
 
 	bool use_radiance_map = false;
@@ -2335,6 +2337,8 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 
 			state.scene_shader.set_uniform(SceneShaderGLES2::TIME, storage->frame.time[0]);
 
+			state.scene_shader.set_uniform(SceneShaderGLES2::VIEWPORT_SIZE, viewport_size);
+
 			state.scene_shader.set_uniform(SceneShaderGLES2::SCREEN_PIXEL_SIZE, screen_pixel_size);
 		}
 
@@ -2506,8 +2510,6 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 		}
 
 		current_fb = probe->fbo[p_reflection_probe_pass];
-		state.screen_pixel_size.x = 1.0 / probe->probe_ptr->resolution;
-		state.screen_pixel_size.y = 1.0 / probe->probe_ptr->resolution;
 
 		viewport_width = probe->probe_ptr->resolution;
 		viewport_height = probe->probe_ptr->resolution;
@@ -2518,11 +2520,16 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 		state.render_no_shadows = false;
 		current_fb = storage->frame.current_rt->fbo;
 		env = environment_owner.getornull(p_environment);
-		state.screen_pixel_size.x = 1.0 / storage->frame.current_rt->width;
-		state.screen_pixel_size.y = 1.0 / storage->frame.current_rt->height;
+
 		viewport_width = storage->frame.current_rt->width;
 		viewport_height = storage->frame.current_rt->height;
 	}
+
+	state.viewport_size.x = viewport_width;
+	state.viewport_size.y = viewport_height;
+	state.screen_pixel_size.x = 1.0 / viewport_width;
+	state.screen_pixel_size.y = 1.0 / viewport_height;
+
 	//push back the directional lights
 
 	if (p_light_cull_count) {

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -211,6 +211,8 @@ public:
 
 		bool render_no_shadows;
 
+		Vector2 viewport_size;
+
 		Vector2 screen_pixel_size;
 	} state;
 

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -84,6 +84,8 @@ uniform highp mat4 world_transform;
 
 uniform highp float time;
 
+uniform highp vec2 viewport_size;
+
 #ifdef RENDER_DEPTH
 uniform float light_bias;
 uniform float light_normal_bias;
@@ -676,6 +678,8 @@ uniform highp mat4 projection_inverse_matrix;
 uniform highp mat4 world_transform;
 
 uniform highp float time;
+
+uniform highp vec2 viewport_size;
 
 #if defined(SCREEN_UV_USED)
 uniform vec2 screen_pixel_size;


### PR DESCRIPTION
attempt to fix #23931

Don't know if its correct, im just using viewport_width and viewport_height but in the gles3 code the viewport_size is assigned with (commented line)
```
p_cam_projection.get_viewport_size(state.viewport_size.x, state.viewport_size.y);
```