### PR TITLE
Add sorting to the project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -866,16 +866,22 @@ struct ProjectItem {
 	uint64_t last_modified;
 	bool favorite;
 	bool grayed;
+	bool ordered_latest_modification;
 	ProjectItem() {}
-	ProjectItem(const String &p_project, const String &p_path, const String &p_conf, uint64_t p_last_modified, bool p_favorite = false, bool p_grayed = false) {
+	ProjectItem(const String &p_project, const String &p_path, const String &p_conf, uint64_t p_last_modified, bool p_favorite = false, bool p_grayed = false, const bool p_ordered_latest_modification = true) {
 		project = p_project;
 		path = p_path;
 		conf = p_conf;
 		last_modified = p_last_modified;
 		favorite = p_favorite;
 		grayed = p_grayed;
+		ordered_latest_modification = p_ordered_latest_modification;
 	}
-	_FORCE_INLINE_ bool operator<(const ProjectItem &l) const { return last_modified > l.last_modified; }
+	_FORCE_INLINE_ bool operator<(const ProjectItem &l) const {
+		if (ordered_latest_modification)
+			return last_modified > l.last_modified;
+		return project < l.project;
+	}
 	_FORCE_INLINE_ bool operator==(const ProjectItem &l) const { return project == l.project; }
 };
 
@@ -1156,6 +1162,13 @@ void ProjectManager::_load_recent_projects() {
 
 	Color font_color = gui_base->get_color("font_color", "Tree");
 
+	bool set_ordered_latest_modification;
+	ProjectListFilter::FilterOption filter_order_option = project_order_filter->get_filter_option();
+	if (filter_order_option == ProjectListFilter::FILTER_NAME)
+		set_ordered_latest_modification = false;
+	else
+		set_ordered_latest_modification = true;
+
 	List<ProjectItem> projects;
 	List<ProjectItem> favorite_projects;
 
@@ -1188,13 +1201,12 @@ void ProjectManager::_load_recent_projects() {
 			grayed = true;
 		}
 
-		ProjectItem item(project, path, conf, last_modified, favorite, grayed);
+		ProjectItem item(project, path, conf, last_modified, favorite, grayed, set_ordered_latest_modification);
 		if (favorite)
 			favorite_projects.push_back(item);
 		else
 			projects.push_back(item);
 	}
-
 	projects.sort();
 	favorite_projects.sort();
 
@@ -1818,16 +1830,41 @@ ProjectManager::ProjectManager() {
 	tabs->add_child(tree_hb);
 
 	VBoxContainer *search_tree_vb = memnew(VBoxContainer);
-	search_tree_vb->set_h_size_flags(SIZE_EXPAND_FILL);
 	tree_hb->add_child(search_tree_vb);
+	search_tree_vb->set_h_size_flags(SIZE_EXPAND_FILL);
 
-	HBoxContainer *search_box = memnew(HBoxContainer);
-	search_box->add_spacer(true);
+	HBoxContainer *sort_filters = memnew(HBoxContainer);
+	Label *sort_label = memnew(Label);
+	sort_label->set_text(TTR("Sort:"));
+	sort_filters->add_child(sort_label);
+	Vector<String> vec1;
+	vec1.push_back("Name");
+	vec1.push_back("Last Modified");
+	project_order_filter = memnew(ProjectListFilter);
+	project_order_filter->_setup_filters(vec1);
+	project_order_filter->set_filter_size(150);
+	sort_filters->add_child(project_order_filter);
+	project_order_filter->connect("filter_changed", this, "_load_recent_projects");
+	project_order_filter->set_custom_minimum_size(Size2(180, 10) * EDSCALE);
+
+	sort_filters->add_spacer(true);
+	Label *search_label = memnew(Label);
+	search_label->set_text(TTR("  Search:"));
+	sort_filters->add_child(search_label);
+
+	HBoxContainer *search_filters = memnew(HBoxContainer);
+	Vector<String> vec2;
+	vec2.push_back("Name");
+	vec2.push_back("Path");
 	project_filter = memnew(ProjectListFilter);
-	search_box->add_child(project_filter);
+	project_filter->_setup_filters(vec2);
+	project_filter->add_search_box();
+	search_filters->add_child(project_filter);
 	project_filter->connect("filter_changed", this, "_load_recent_projects");
 	project_filter->set_custom_minimum_size(Size2(280, 10) * EDSCALE);
-	search_tree_vb->add_child(search_box);
+	sort_filters->add_child(search_filters);
+
+	search_tree_vb->add_child(sort_filters);
 
 	PanelContainer *pc = memnew(PanelContainer);
 	pc->add_style_override("panel", gui_base->get_stylebox("bg", "Tree"));
@@ -2017,11 +2054,11 @@ ProjectManager::~ProjectManager() {
 		EditorSettings::destroy();
 }
 
-void ProjectListFilter::_setup_filters() {
+void ProjectListFilter::_setup_filters(Vector<String> options) {
 
 	filter_option->clear();
-	filter_option->add_item(TTR("Name"));
-	filter_option->add_item(TTR("Path"));
+	for (int i = 0; i < options.size(); i++)
+		filter_option->add_item(TTR(options[i]));
 }
 
 void ProjectListFilter::_search_text_changed(const String &p_newtext) {
@@ -2046,7 +2083,7 @@ void ProjectListFilter::_filter_option_selected(int p_idx) {
 
 void ProjectListFilter::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
+	if (p_what == NOTIFICATION_ENTER_TREE && has_search_box) {
 		search_box->set_right_icon(get_icon("Search", "EditorIcons"));
 		search_box->set_clear_button_enabled(true);
 	}
@@ -2060,20 +2097,27 @@ void ProjectListFilter::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("filter_changed"));
 }
 
+void ProjectListFilter::add_search_box() {
+	search_box = memnew(LineEdit);
+	search_box->connect("text_changed", this, "_search_text_changed");
+	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	add_child(search_box);
+	has_search_box = true;
+}
+
+void ProjectListFilter::set_filter_size(int h_size) {
+	filter_option->set_custom_minimum_size(Size2(h_size * EDSCALE, 10 * EDSCALE));
+}
+
 ProjectListFilter::ProjectListFilter() {
 
 	_current_filter = FILTER_NAME;
 
 	filter_option = memnew(OptionButton);
-	filter_option->set_custom_minimum_size(Size2(80 * EDSCALE, 10 * EDSCALE));
+	set_filter_size(80);
 	filter_option->set_clip_text(true);
 	filter_option->connect("item_selected", this, "_filter_option_selected");
 	add_child(filter_option);
 
-	_setup_filters();
-
-	search_box = memnew(LineEdit);
-	search_box->connect("text_changed", this, "_search_text_changed");
-	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	add_child(search_box);
+	has_search_box = false;
 }

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -54,6 +54,7 @@ class ProjectManager : public Control {
 	EditorAssetLibrary *asset_library;
 
 	ProjectListFilter *project_filter;
+	ProjectListFilter *project_order_filter;
 
 	ConfirmationDialog *language_restart_ask;
 	ConfirmationDialog *erase_ask;
@@ -130,6 +131,7 @@ private:
 
 	OptionButton *filter_option;
 	LineEdit *search_box;
+	bool has_search_box;
 
 	enum FilterOption {
 		FILTER_NAME,
@@ -138,7 +140,6 @@ private:
 	FilterOption _current_filter;
 
 	void _search_text_changed(const String &p_newtext);
-	void _setup_filters();
 	void _filter_option_selected(int p_idx);
 
 protected:
@@ -146,6 +147,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	void _setup_filters(Vector<String> options);
+	void add_search_box();
+	void set_filter_size(int h_size);
 	String get_search_term();
 	FilterOption get_filter_option();
 	ProjectListFilter();


### PR DESCRIPTION
We added to option to order the projects in the Project Manager in alphabetic order, here's how it looks:

![byname](https://user-images.githubusercontent.com/36671963/48958158-45f8ec00-ef55-11e8-9899-8499c53dfe58.jpg)

This solves issue [#8794](https://github.com/godotengine/godot/issues/8794)