### PR TITLE
[macOS] Fixed a problem sdk path could not be detected

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -6,7 +6,7 @@ import glob
 import string
 import datetime
 import subprocess
-from compat import iteritems, isbasestring
+from compat import iteritems, isbasestring, decode_utf8
 
 
 def add_source_files(self, sources, filetype, lib_env=None, shared=False):
@@ -645,7 +645,7 @@ def detect_darwin_sdk_path(platform, env):
 
     if not env[var_name]:
         try:
-            sdk_path = subprocess.check_output(['xcrun', '--sdk', sdk_name, '--show-sdk-path']).strip()
+            sdk_path = decode_utf8(subprocess.check_output(['xcrun', '--sdk', sdk_name, '--show-sdk-path']).strip())
             if sdk_path:
                 env[var_name] = sdk_path
         except (subprocess.CalledProcessError, OSError) as e:


### PR DESCRIPTION
Hi

I failed the master build(8348aca118311b82f632781b19230471fae56d4a) in my environment.
It appears to be caused by subprocess.check_output() returning a byte string in [here](https://github.com/godotengine/godot/blob/master/methods.py#L648).
This problem was solved by decoding to Unicode string.

Build Command
```
$ scons platform=osx tools=yes target=debug
```

My Environment
```
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.14.1
BuildVersion:	18B75

$ xcodebuild -version
Xcode 10.1
Build version 10B61

$ python --version
Python 3.6.6 :: Anaconda custom (64-bit)

$ scons --version
SCons by Steven Knight et al.:
	script: v3.0.1.74b2c53bc42290e911b334a6b44f187da698a668, 2017/11/14 13:16:53, by bdbaddog on hpmicrodog
	engine: v3.0.1.74b2c53bc42290e911b334a6b44f187da698a668, 2017/11/14 13:16:53, by bdbaddog on hpmicrodog
	engine path: ['/usr/local/Cellar/scons/3.0.1/libexec/scons-local/SCons']
Copyright (c) 2001 - 2017 The SCons Foundation
```