### PR TITLE
Fix scroll bar lock when smooth scroll enabled, issue 23314

### DIFF
--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -330,6 +330,8 @@ void ScrollBar::_notification(int p_what) {
 
 				if (Math::abs(vel) >= dist) {
 					set_value(target_scroll);
+					scrolling = false;
+					set_physics_process_internal(false);
 				} else {
 					set_value(get_value() + vel);
 				}


### PR DESCRIPTION
Fixes the scroll bar locking / jitter when `smooth_scrolling` is enabled.

closes #23314