### PR TITLE
Expose _validate_property to GDscript

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -986,7 +986,7 @@ void ClassDB::get_property_list(StringName p_class, List<PropertyInfo> *p_list, 
 
 			if (p_validator) {
 				PropertyInfo pi = E->get();
-				p_validator->_validate_property(pi);
+				p_validator->_validate_property_script(pi);
 				p_list->push_back(pi);
 			} else {
 				p_list->push_back(E->get());

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -592,7 +592,7 @@ Variant Object::get_indexed(const Vector<StringName> &p_names, bool *r_valid) co
 	return current_value;
 }
 
-void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) const {
+void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed, bool p_validate) const {
 
 	if (script_instance && p_reversed) {
 		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
@@ -614,9 +614,24 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
 		script_instance->get_property_list(p_list);
 	}
+
+	if (p_validate) {
+		for (List<PropertyInfo>::Element *E = p_list->front(); E; E = E->next()) {
+			_validate_property_script(E->get());
+		}
+	}
 }
 
 void Object::_validate_property(PropertyInfo &property) const {
+}
+
+void Object::_validate_property_script(PropertyInfo &property) const
+{
+	_validate_property(property);
+
+	if (script_instance) {
+		script_instance->validate_property(property);
+	}
 }
 
 void Object::get_method_list(List<MethodInfo> *p_list) const {

--- a/core/object.h
+++ b/core/object.h
@@ -544,6 +544,7 @@ protected:
 
 	friend class ClassDB;
 	virtual void _validate_property(PropertyInfo &property) const;
+	void _validate_property_script(PropertyInfo &property) const;
 
 public: //should be protected, but bug in clang++
 	static void initialize_class();
@@ -636,7 +637,7 @@ public:
 	void set_indexed(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid = NULL);
 	Variant get_indexed(const Vector<StringName> &p_names, bool *r_valid = NULL) const;
 
-	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false) const;
+	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false, bool p_validate = false) const;
 
 	bool has_method(const StringName &p_method) const;
 	void get_method_list(List<MethodInfo> *p_list) const;

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -133,6 +133,7 @@ public:
 	virtual bool get(const StringName &p_name, Variant &r_ret) const = 0;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const = 0;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = NULL) const = 0;
+	virtual void validate_property(PropertyInfo &p_property) const = 0;
 
 	virtual Object *get_owner() { return NULL; }
 	virtual void get_property_state(List<Pair<StringName, Variant> > &state);
@@ -306,6 +307,7 @@ public:
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = NULL) const;
+	virtual void validate_property(PropertyInfo &p_property) const {};
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const {}
 	virtual bool has_method(const StringName &p_method) const { return false; }

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -2762,7 +2762,7 @@ void PropertyEditor::update_tree() {
 	tree->set_hide_root(true);
 
 	List<PropertyInfo> plist;
-	obj->get_property_list(&plist, true);
+	obj->get_property_list(&plist, true, true);
 
 	bool draw_red = false;
 

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -609,6 +609,11 @@ Variant::Type NativeScriptInstance::get_property_type(const StringName &p_name, 
 	return Variant::NIL;
 }
 
+void NativeScriptInstance::validate_property(PropertyInfo &p_property) const
+{
+
+}
+
 void NativeScriptInstance::get_method_list(List<MethodInfo> *p_list) const {
 	script->get_method_list(p_list);
 }

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -176,6 +176,7 @@ public:
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid) const;
+	virtual void validate_property(PropertyInfo &p_property) const;
 	virtual void get_method_list(List<MethodInfo> *p_list) const;
 	virtual bool has_method(const StringName &p_method) const;
 	virtual Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error);

--- a/modules/gdnative/pluginscript/pluginscript_instance.h
+++ b/modules/gdnative/pluginscript/pluginscript_instance.h
@@ -55,6 +55,7 @@ public:
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = NULL) const;
+	virtual void validate_property(PropertyInfo &p_property) const {};
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const;
 	virtual bool has_method(const StringName &p_method) const;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -229,6 +229,7 @@ public:
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = NULL) const;
+	virtual void validate_property(PropertyInfo &p_property) const;
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const;
 	virtual bool has_method(const StringName &p_method) const;
@@ -363,6 +364,7 @@ public:
 		StringName _set;
 		StringName _get;
 		StringName _get_property_list;
+		StringName _validate_property;
 		StringName _script_source;
 
 	} strings;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -200,6 +200,7 @@ public:
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid) const;
+	virtual void validate_property(PropertyInfo &p_property) const {}
 
 	/* TODO */ virtual void get_method_list(List<MethodInfo> *p_list) const {}
 	virtual bool has_method(const StringName &p_method) const;

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -400,6 +400,7 @@ public:
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = NULL) const;
+	virtual void validate_property(PropertyInfo &p_property) const {};
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const;
 	virtual bool has_method(const StringName &p_method) const;


### PR DESCRIPTION
[Godot 3.0]

Expose `_validate_property` to GDscript, so that exported variables can be hidden whit user's custom logic.