### PR TITLE
Construct Transform from Transform2D 

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1662,7 +1662,17 @@ Variant::operator Transform() const {
 		return Transform(*_data._basis, Vector3());
 	else if (type == QUAT)
 		return Transform(Basis(*reinterpret_cast<const Quat *>(_data._mem)), Vector3());
-	else
+	else if (type == TRANSFORM2D) {
+		const Transform2D &t = *_data._transform2d;
+		Transform m;
+		m.basis.elements[0][0] = t.elements[0][0];
+		m.basis.elements[1][0] = t.elements[1][0];
+		m.basis.elements[0][1] = t.elements[0][1];
+		m.basis.elements[1][1] = t.elements[1][1];
+		m.origin[0] = t.elements[2][0];
+		m.origin[1] = t.elements[2][1];
+		return m;
+	} else
 		return Transform();
 }
 


### PR DESCRIPTION
According to the [docs](http://docs.godotengine.org/en/latest/classes/class_transform.html#class-transform) for Transform, you are supposed to be able to construct a Transform using a Transform2D. However, I noticed that when you do so, all you get is an identity transform. 

This was also creating a serious bug when using as a shader uniform. I'm not sure why, becuase Transform2Ds should be passed in as uniforms no problem, but for some reason they are getting converted to Transforms before being passed into the shader, as a result, if you tried to pass a Transform2D into a shader all you would get is an identity matrix in the shader. Because of the nature of shaders, this bug was *very* difficult to diagnose.