### PR TITLE
Fixed project name line edit focus lost when open project-create dialog.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -745,7 +745,8 @@ public:
 				get_ok()->set_text(TTR("Create & Edit"));
 				name_container->show();
 				install_path_container->hide();
-				project_name->grab_focus();
+                project_name->call_deferred("grab_focus");
+                project_name->call_deferred("select_all");
 
 			} else if (mode == MODE_INSTALL) {
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -745,8 +745,8 @@ public:
 				get_ok()->set_text(TTR("Create & Edit"));
 				name_container->show();
 				install_path_container->hide();
-                project_name->call_deferred("grab_focus");
-                project_name->call_deferred("select_all");
+                		project_name->call_deferred("grab_focus");
+                		project_name->call_deferred("select_all");
 
 			} else if (mode == MODE_INSTALL) {
 


### PR DESCRIPTION
This fixed project name line edit input control focus lost when open dialog to create a new project.