### PR TITLE
GLES2: Set clear color based on env background mode when rendering scene and fix viewport transparent bg flag

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2587,9 +2587,30 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 	glClearDepth(1.0f);
 	glEnable(GL_DEPTH_TEST);
 
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	// clear color
 
-	storage->frame.clear_request = false;
+	Color clear_color(0, 0, 0, 0);
+
+	if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {
+		clear_color = Color(0, 0, 0, 0);
+		storage->frame.clear_request = false;
+	} else if (!env || env->bg_mode == VS::ENV_BG_CLEAR_COLOR || env->bg_mode == VS::ENV_BG_SKY) {
+		if (storage->frame.clear_request) {
+			clear_color = storage->frame.clear_request_color.to_linear();
+			storage->frame.clear_request = false;
+		}
+	} else if (env->bg_mode == VS::ENV_BG_CANVAS || env->bg_mode == VS::ENV_BG_COLOR || env->bg_mode == VS::ENV_BG_COLOR_SKY) {
+		clear_color = env->bg_color.to_linear();
+		storage->frame.clear_request = false;
+	} else {
+		storage->frame.clear_request = false;
+	}
+
+	if (!env || env->bg_mode != VS::ENV_BG_KEEP) {
+		glClearColor(clear_color.r, clear_color.g, clear_color.b, clear_color.a);
+	}
+
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	glVertexAttrib4f(VS::ARRAY_COLOR, 1, 1, 1, 1);
 


### PR DESCRIPTION
This PR will fix viewport `transparent bg` flag and environment custom color background mode on gles2 renderer.

fixes #23978