### PR TITLE
Added render_mode `world_vertex_coords` in canvas

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -54,6 +54,8 @@ void RasterizerCanvasGLES2::_set_uniforms() {
 
 	state.canvas_shader.set_uniform(CanvasShaderGLES2::PROJECTION_MATRIX, state.uniforms.projection_matrix);
 	state.canvas_shader.set_uniform(CanvasShaderGLES2::MODELVIEW_MATRIX, state.uniforms.modelview_matrix);
+	state.canvas_shader.set_uniform(CanvasShaderGLES2::WORLD_MATRIX, state.uniforms.world_matrix);
+	state.canvas_shader.set_uniform(CanvasShaderGLES2::INV_WORLD_MATRIX, state.uniforms.inv_world_matrix);
 	state.canvas_shader.set_uniform(CanvasShaderGLES2::EXTRA_MATRIX, state.uniforms.extra_matrix);
 
 	state.canvas_shader.set_uniform(CanvasShaderGLES2::FINAL_MODULATE, state.uniforms.final_modulate);
@@ -178,6 +180,8 @@ void RasterizerCanvasGLES2::canvas_begin() {
 	state.uniforms.final_modulate = Color(1, 1, 1, 1);
 
 	state.uniforms.modelview_matrix = Transform2D();
+	state.uniforms.world_matrix = Transform2D();
+	state.uniforms.inv_world_matrix = Transform2D();
 	state.uniforms.extra_matrix = Transform2D();
 
 	_set_uniforms();
@@ -1579,6 +1583,8 @@ void RasterizerCanvasGLES2::canvas_render_items(Item *p_item_list, int p_z, cons
 		state.uniforms.final_modulate = unshaded ? ci->final_modulate : Color(ci->final_modulate.r * p_modulate.r, ci->final_modulate.g * p_modulate.g, ci->final_modulate.b * p_modulate.b, ci->final_modulate.a * p_modulate.a);
 
 		state.uniforms.modelview_matrix = ci->final_transform;
+		state.uniforms.world_matrix = p_base_transform.affine_inverse() * ci->final_transform;
+		state.uniforms.inv_world_matrix = state.uniforms.world_matrix.affine_inverse();
 		state.uniforms.extra_matrix = Transform2D();
 
 		_set_uniforms();

--- a/drivers/gles2/rasterizer_canvas_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_gles2.h
@@ -51,6 +51,8 @@ public:
 		Transform projection_matrix;
 
 		Transform2D modelview_matrix;
+		Transform2D world_matrix;
+		Transform2D inv_world_matrix;
 		Transform2D extra_matrix;
 
 		Color final_modulate;

--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -884,6 +884,8 @@ ShaderCompilerGLES2::ShaderCompilerGLES2() {
 	actions[VS::SHADER_CANVAS_ITEM].renames["POINT_SIZE"] = "gl_PointSize";
 
 	actions[VS::SHADER_CANVAS_ITEM].renames["WORLD_MATRIX"] = "modelview_matrix";
+	actions[VS::SHADER_CANVAS_ITEM].renames["GLOBAL_MATRIX"] = "world_matrix";
+	actions[VS::SHADER_CANVAS_ITEM].renames["INV_GLOBAL_MATRIX"] = "inv_world_matrix";
 	actions[VS::SHADER_CANVAS_ITEM].renames["PROJECTION_MATRIX"] = "projection_matrix";
 	actions[VS::SHADER_CANVAS_ITEM].renames["EXTRA_MATRIX"] = "extra_matrix";
 	actions[VS::SHADER_CANVAS_ITEM].renames["TIME"] = "time";
@@ -918,6 +920,7 @@ ShaderCompilerGLES2::ShaderCompilerGLES2() {
 	actions[VS::SHADER_CANVAS_ITEM].usage_defines["NORMALMAP"] = "#define NORMALMAP_USED\n";
 	actions[VS::SHADER_CANVAS_ITEM].usage_defines["LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 	actions[VS::SHADER_CANVAS_ITEM].render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
+	actions[VS::SHADER_CANVAS_ITEM].render_mode_defines["world_vertex_coords"] = "#define VERTEX_WORLD_COORDS_USED\n";
 
 	/** SPATIAL SHADER **/
 

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -16,6 +16,8 @@ uniform highp mat4 projection_matrix;
 #include "stdlib.glsl"
 
 uniform highp mat4 modelview_matrix;
+uniform highp mat4 world_matrix;
+uniform highp mat4 inv_world_matrix;
 uniform highp mat4 extra_matrix;
 attribute highp vec2 vertex; // attrib:0
 attribute vec4 color_attrib; // attrib:3
@@ -149,6 +151,12 @@ void main() {
 	uv = uv_attrib;
 #endif
 
+#if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
+	outvec = world_matrix * extra_matrix_instance * outvec;
+#endif
+
+#define extra_matrix extra_matrix_instance
+
 	{
 		vec2 src_vtx = outvec.xy;
 		/* clang-format off */
@@ -158,10 +166,17 @@ VERTEX_SHADER_CODE
 		/* clang-format on */
 	}
 
-#if !defined(SKIP_TRANSFORM_USED)
-	outvec = extra_matrix_instance * outvec;
+#if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
+	outvec = inv_world_matrix * outvec;
 	outvec = modelview_matrix * outvec;
 #endif
+
+#if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
+	outvec = extra_matrix * outvec;
+	outvec = modelview_matrix * outvec;
+#endif
+
+#undef extra_matrix
 
 	color_interp = color;
 

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -87,6 +87,8 @@ public:
 		Color canvas_item_modulate;
 		Transform2D extra_matrix;
 		Transform2D final_transform;
+		Transform2D world_transform;
+		Transform2D inv_world_transform;
 		bool using_skeleton;
 		Transform2D skeleton_transform;
 		Transform2D skeleton_transform_inverse;

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -885,6 +885,8 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 	actions[VS::SHADER_CANVAS_ITEM].renames["POINT_SIZE"] = "gl_PointSize";
 
 	actions[VS::SHADER_CANVAS_ITEM].renames["WORLD_MATRIX"] = "modelview_matrix";
+	actions[VS::SHADER_CANVAS_ITEM].renames["GLOBAL_MATRIX"] = "world_matrix";
+	actions[VS::SHADER_CANVAS_ITEM].renames["INV_GLOBAL_MATRIX"] = "inv_world_matrix";
 	actions[VS::SHADER_CANVAS_ITEM].renames["PROJECTION_MATRIX"] = "projection_matrix";
 	actions[VS::SHADER_CANVAS_ITEM].renames["EXTRA_MATRIX"] = "extra_matrix";
 	actions[VS::SHADER_CANVAS_ITEM].renames["TIME"] = "time";
@@ -919,6 +921,7 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 	actions[VS::SHADER_CANVAS_ITEM].usage_defines["NORMALMAP"] = "#define NORMALMAP_USED\n";
 	actions[VS::SHADER_CANVAS_ITEM].usage_defines["LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 	actions[VS::SHADER_CANVAS_ITEM].render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
+	actions[VS::SHADER_CANVAS_ITEM].render_mode_defines["world_vertex_coords"] = "#define VERTEX_WORLD_COORDS_USED\n";
 
 	/** SPATIAL SHADER **/
 

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -45,6 +45,8 @@ layout(std140) uniform CanvasItemData { //ubo:0
 
 uniform highp mat4 modelview_matrix;
 uniform highp mat4 extra_matrix;
+uniform highp mat4 world_matrix;
+uniform highp mat4 inv_world_matrix;
 
 out highp vec2 uv_interp;
 out mediump vec4 color_interp;
@@ -148,6 +150,10 @@ void main() {
 	outvec.xy /= color_texpixel_size;
 #endif
 
+#if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
+	outvec = world_matrix * extra_matrix_instance * outvec;
+#endif
+
 #define extra_matrix extra_matrix_instance
 
 	//for compatibility with the fragment shader we need to use uv here
@@ -167,7 +173,12 @@ VERTEX_SHADER_CODE
 	pixel_size_interp = abs(dst_rect.zw) * vertex;
 #endif
 
-#if !defined(SKIP_TRANSFORM_USED)
+#if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
+	outvec = inv_world_matrix * outvec;
+	outvec = modelview_matrix * outvec;
+#endif
+
+#if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 	outvec = extra_matrix * outvec;
 	outvec = modelview_matrix * outvec;
 #endif

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -202,6 +202,8 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["POINT_SIZE"] = ShaderLanguage::TYPE_FLOAT;
 
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["WORLD_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["GLOBAL_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["INV_GLOBAL_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["PROJECTION_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["EXTRA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
@@ -245,6 +247,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["light"].can_discard = true;
 
 	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("skip_vertex_transform");
+	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("world_vertex_coords");
 
 	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("blend_mix");
 	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("blend_add");


### PR DESCRIPTION
This PR brings the render mode `world_vertex_coords` to canvas item shaders. It also provides access to two new uniform matrices for converting to and from world coordinates named  `GLOBAL_MATRIX` and `INV_GLOBAL_MATRIX` respectively. I would prefer to name them `WORLD_MATRIX` (which is what it is internally) and `INV_WORLD_MATRIX`, however, for some reason the modelview transform is accessed using `WORLD_MATRIX` (which is incredibly confusing for users). 

The behaviour is the same as in spatial shaders. It presents `VERTEX` to the user in world coordinates, and then transforms it into view and NDC coordinates after the user written code is run.

Many users have asked for access to this render mode and it directly addresses issue #19800. With the current system there is no way to acquire world position in the shader without passing in the global transform as a mat4 (which is currently broken, but fixed with #23976) or passing in the global position, scale, rotation and calculating the position manually (which is needlessly complicated/difficult). 

*Bugsquad edit:* Fixes #19800.