### PR TITLE
Init `ignore_camera_zoom` property in parallax background constructor

### DIFF
--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -206,7 +206,9 @@ void ParallaxBackground::_bind_methods() {
 
 ParallaxBackground::ParallaxBackground() {
 
-	base_scale = Vector2(1, 1);
 	scale = 1.0;
 	set_layer(-1); //behind all by default
+
+	base_scale = Vector2(1, 1);
+	ignore_camera_zoom = false;
 }


### PR DESCRIPTION
The default value for `ignore_camera_zoom` property was initialized by garbage value,
leading to camera's zoom to be ignored even if unset in editor most of the time.

Fixes #23031.

Fixes one of the issues in #16800.

Related PR #2330.