### PR TITLE
Enable squish decompression in runtime builds

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -7673,7 +7673,7 @@ void RasterizerStorageGLES3::initialize() {
 	config.etc2_supported = true;
 	config.hdr_supported = false;
 	config.s3tc_supported = config.extensions.has("GL_EXT_texture_compression_dxt1") || config.extensions.has("GL_EXT_texture_compression_s3tc") || config.extensions.has("WEBGL_compressed_texture_s3tc");
-	config.rgtc_supported = config.extensions.has("GL_EXT_texture_compression_rgtc") || config.extensions.has("GL_ARB_texture_compression_rgtc");
+	config.rgtc_supported = config.extensions.has("GL_EXT_texture_compression_rgtc") || config.extensions.has("GL_ARB_texture_compression_rgtc") || config.extensions.has("EXT_texture_compression_rgtc");
 #endif
 
 	config.pvrtc_supported = config.extensions.has("GL_IMG_texture_compression_pvrtc");

--- a/modules/squish/config.py
+++ b/modules/squish/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env['tools']
+    return True
 
 def configure(env):
     pass

--- a/modules/squish/image_compress_squish.cpp
+++ b/modules/squish/image_compress_squish.cpp
@@ -30,8 +30,6 @@
 
 #include "image_compress_squish.h"
 
-#include "core/print_string.h"
-
 #include <squish.h>
 
 void image_decompress_squish(Image *p_image) {
@@ -76,6 +74,7 @@ void image_decompress_squish(Image *p_image) {
 	p_image->create(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
 }
 
+#ifdef TOOLS_ENABLED
 void image_compress_squish(Image *p_image, float p_lossy_quality, Image::CompressSource p_source) {
 
 	if (p_image->get_format() >= Image::FORMAT_DXT1)
@@ -204,3 +203,4 @@ void image_compress_squish(Image *p_image, float p_lossy_quality, Image::Compres
 		p_image->create(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
 	}
 }
+#endif

--- a/modules/squish/image_compress_squish.h
+++ b/modules/squish/image_compress_squish.h
@@ -33,7 +33,9 @@
 
 #include "core/image.h"
 
+#ifdef TOOLS_ENABLED
 void image_compress_squish(Image *p_image, float p_lossy_quality, Image::CompressSource p_source);
+#endif
 void image_decompress_squish(Image *p_image);
 
 #endif // IMAGE_COMPRESS_SQUISH_H

--- a/modules/squish/register_types.cpp
+++ b/modules/squish/register_types.cpp
@@ -29,17 +29,14 @@
 /*************************************************************************/
 
 #include "register_types.h"
-
-#ifdef TOOLS_ENABLED
-
 #include "image_compress_squish.h"
 
 void register_squish_types() {
 
+#ifdef TOOLS_ENABLED
 	Image::set_compress_bc_func(image_compress_squish);
+#endif
 	Image::_image_decompress_bc = image_decompress_squish;
 }
 
 void unregister_squish_types() {}
-
-#endif

--- a/modules/squish/register_types.h
+++ b/modules/squish/register_types.h
@@ -28,7 +28,5 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef TOOLS_ENABLED
 void register_squish_types();
 void unregister_squish_types();
-#endif


### PR DESCRIPTION
Build squish decompression in no-tools builds. Allows decompressing RGTC when the relevant extension isn't available. Also add a check for the new WebGL extension for WebGL 2.
Fix #15983