### PR TITLE
Changes the check for a singular matrix to use the scale vector.

### DIFF
--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1655,8 +1655,9 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 				}
 			}
 
-			Quat q = Math::is_equal_approx(xform.basis.determinant(), 0) ? Quat() : xform.basis.get_rotation_quat();
 			Vector3 s = xform.basis.get_scale();
+			bool singular_matrix = Math::is_equal_approx(s.x, 0.0f) || Math::is_equal_approx(s.y, 0.0f) || Math::is_equal_approx(s.z, 0.0f);
+			Quat q = singular_matrix ? Quat() : xform.basis.get_rotation_quat();
 			Vector3 l = xform.origin;
 
 			animation->transform_track_insert_key(track, snapshots[i], l, q, s);
@@ -1705,8 +1706,9 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 
 			xform = sk->get_bone_rest(nm.bone).affine_inverse() * xform;
 
-			Quat q = Math::is_equal_approx(xform.basis.determinant(), 0) ? Quat() : xform.basis.get_rotation_quat();
 			Vector3 s = xform.basis.get_scale();
+			bool singular_matrix = Math::is_equal_approx(s.x, 0.0f) || Math::is_equal_approx(s.y, 0.0f) || Math::is_equal_approx(s.z, 0.0f);
+			Quat q = singular_matrix ? Quat() : xform.basis.get_rotation_quat();
 			Vector3 l = xform.origin;
 
 			animation->transform_track_insert_key(track, 0, l, q, s);


### PR DESCRIPTION
The check for the determinant does not have enough precision when used with a 0.01 uniform scale.
With this PR, I've checked the reporter's data in #18790 and the issue is otherwise fixed.
I've blamed the code and revision 9d41161596167984efdb02639d0857da8979b01b is to credit for fixing #18790.