### PR TITLE
Construct Transform from Transform2D bug

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1662,7 +1662,17 @@ Variant::operator Transform() const {
 		return Transform(*_data._basis, Vector3());
 	else if (type == QUAT)
 		return Transform(Basis(*reinterpret_cast<const Quat *>(_data._mem)), Vector3());
-	else
+	else if (type == TRANSFORM2D) {
+		const Transform2D &t = *_data._transform2d;
+		Transform m;
+		m.basis.elements[0][0] = t.elements[0][0];
+		m.basis.elements[1][0] = t.elements[0][1];
+		m.basis.elements[0][1] = t.elements[1][0];
+		m.basis.elements[1][1] = t.elements[1][1];
+		m.origin[0] = t.elements[2][0];
+		m.origin[1] = t.elements[2][1];
+		return m;
+	} else
 		return Transform();
 }
 


### PR DESCRIPTION
Fixes bug where a Transform could not be constructed from Transform2D. Addresses issue found in PR #23976.

@reduz This should be good to go now, I ensured that it matched the conversion from Transform to Transform2D below. Thank you for catching the mistake in my last PR.