### PR TITLE
Fixed overriding autoloads causing duplicate autoloads.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1499,6 +1499,13 @@ bool Main::start() {
 				for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 
 					String s = E->get().name;
+					//ignore feature overrides
+					int dot = s.find(".");
+					if (dot >= 0) {
+						Vector<String> ss = s.split(".");
+						if (ProjectSettings::get_singleton()->has_setting(ss[0]))
+							continue;
+					}
 					if (!s.begins_with("autoload/"))
 						continue;
 					String name = s.get_slicec('/', 1);
@@ -1520,6 +1527,13 @@ bool Main::start() {
 				for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 
 					String s = E->get().name;
+					//ignore feature overrides
+					int dot = s.find(".");
+					if (dot >= 0) {
+						Vector<String> ss = s.split(".");
+						if (ProjectSettings::get_singleton()->has_setting(ss[0]))
+							continue;
+					}
 					if (!s.begins_with("autoload/"))
 						continue;
 					String name = s.get_slicec('/', 1);


### PR DESCRIPTION
Trying to use feature overrides on AutoLoads resulted in duplicate autoloads with the same script but different names.
This pull request fixes that by ignoring AutoLoads with a dot in their name if there exists another AutoLoad with the same base name.

Usage:
MyAutoLoad			:	my_script.gdns
MyAutoLoad.web		:	my_dummy_script.gd
MyAutoLoad.windows	:	my_cs_script.cs

On web : MyAutoLoad -> my_dummy_script.gd
On Windows: MyAutoLoad -> my_cs_script.cs
On everything else: MyAutoLoad -> my_script.gdns