### PR TITLE
Use filename instead of the class name for drag & drop Mesh Instance.

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -3238,7 +3238,7 @@ bool SpatialEditorViewport::_create_instance(Node *parent, String &path, const P
 		if (mesh != NULL) {
 			MeshInstance *mesh_instance = memnew(MeshInstance);
 			mesh_instance->set_mesh(mesh);
-			mesh_instance->set_name(mesh->get_name());
+			mesh_instance->set_name(path.get_file().get_basename());
 			instanced_scene = mesh_instance;
 		} else {
 			if (!scene.is_valid()) { // invalid scene


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/24061

Before:
![before](https://user-images.githubusercontent.com/43449832/49249590-41d14080-f425-11e8-9b25-76844036c40f.png)
After:
![after](https://user-images.githubusercontent.com/43449832/49249589-4138aa00-f425-11e8-85f4-2ba113c9d512.png)

