### PR TITLE
Fix key icon overlapping revert icon

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -128,18 +128,22 @@ void EditorProperty::_notification(int p_what) {
 
 				bottom_rect = Rect2(m, rect.size.height + get_constant("vseparation", "Tree"), size.width - m, bottom_editor->get_combined_minimum_size().height);
 			}
-		}
 
-		if (keying) {
-			Ref<Texture> key;
+			if (keying) {
+				Ref<Texture> key;
 
-			if (use_keying_next()) {
-				key = get_icon("KeyNext", "EditorIcons");
-			} else {
-				key = get_icon("Key", "EditorIcons");
+				if (use_keying_next()) {
+					key = get_icon("KeyNext", "EditorIcons");
+				} else {
+					key = get_icon("Key", "EditorIcons");
+				}
+
+				rect.size.x -= key->get_width() + get_constant("hseparator", "Tree");
+
+				if (no_children) {
+					text_size -= key->get_width() + 4 * EDSCALE;
+				}
 			}
-
-			rect.size.x -= key->get_width() + get_constant("hseparator", "Tree");
 		}
 
 		//set children


### PR DESCRIPTION
before:
![captura de tela de 2018-11-30 14-01-58](https://user-images.githubusercontent.com/1387165/49300116-8c47d100-f4a8-11e8-82e1-37a842147292.png)

after:
![captura de tela de 2018-11-30 13-56-03](https://user-images.githubusercontent.com/1387165/49300055-6fab9900-f4a8-11e8-9a9a-3f36f594ebd0.png)
