### PR TITLE
[WIP] Adding new access methods to GDNative-Android

### DIFF
--- a/modules/gdnative/android/android_gdn.cpp
+++ b/modules/gdnative/android/android_gdn.cpp
@@ -34,10 +34,9 @@
 // These entry points are only for the android platform and are simple stubs in all others.
 
 #ifdef __ANDROID__
+#include "platform/android/java_godot_wrapper.h"
+#include "platform/android/os_android.h"
 #include "platform/android/thread_jandroid.h"
-#else
-#define JNIEnv void
-#define jobject void *
 #endif
 
 #ifdef __cplusplus
@@ -54,15 +53,19 @@ JNIEnv *GDAPI godot_android_get_env() {
 
 jobject GDAPI godot_android_get_activity() {
 #ifdef __ANDROID__
-	JNIEnv *env = ThreadAndroid::get_env();
+	OS_Android *os_android = (OS_Android *)OS::get_singleton();
 
-	jclass activityThread = env->FindClass("android/app/ActivityThread");
-	jmethodID currentActivityThread = env->GetStaticMethodID(activityThread, "currentActivityThread", "()Landroid/app/ActivityThread;");
-	jobject at = env->CallStaticObjectMethod(activityThread, currentActivityThread);
-	jmethodID getApplication = env->GetMethodID(activityThread, "getApplication", "()Landroid/app/Application;");
-	jobject context = env->CallObjectMethod(at, getApplication);
+	return os_android->get_godot_java()->get_activity();
+#else
+	return NULL;
+#endif
+}
 
-	return env->NewGlobalRef(context);
+jobject GDAPI godot_android_get_surface() {
+#ifdef __ANDROID__
+	OS_Android *os_android = (OS_Android *)OS::get_singleton();
+
+	return os_android->get_godot_java()->get_surface();
 #else
 	return NULL;
 #endif

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -6269,7 +6269,7 @@
       "type": "ANDROID",
       "version": {
         "major": 1,
-        "minor": 0
+        "minor": 1
       },
       "next": null,
       "api": [
@@ -6281,6 +6281,12 @@
         },
         {
           "name": "godot_android_get_activity",
+          "return_type": "jobject",
+          "arguments": [
+          ]
+        },
+        {
+          "name": "godot_android_get_surface",
           "return_type": "jobject",
           "arguments": [
           ]

--- a/modules/gdnative/include/android/godot_android.h
+++ b/modules/gdnative/include/android/godot_android.h
@@ -46,6 +46,7 @@ extern "C" {
 
 JNIEnv *GDAPI godot_android_get_env();
 jobject GDAPI godot_android_get_activity();
+jobject GDAPI godot_android_get_surface();
 
 #ifdef __cplusplus
 }

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -64,6 +64,7 @@ import android.util.Log;
 import android.view.Display;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
@@ -399,6 +400,10 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 			e.printStackTrace();
 			return new String[0];
 		}
+	}
+
+	public Surface get_surface() {
+		return mView.getHolder().getSurface();
 	}
 
 	String expansion_pack_path;

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -59,6 +59,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance) {
 	_get_clipboard = p_env->GetMethodID(cls, "getClipboard", "()Ljava/lang/String;");
 	_set_clipboard = p_env->GetMethodID(cls, "setClipboard", "(Ljava/lang/String;)V");
 	_request_permission = p_env->GetMethodID(cls, "requestPermission", "(Ljava/lang/String;)Z");
+	_get_surface = p_env->GetMethodID(cls, "get_surface", "()Landroid/view/Surface");
 }
 
 GodotJavaWrapper::~GodotJavaWrapper() {
@@ -181,5 +182,14 @@ bool GodotJavaWrapper::request_permission(const String &p_name) {
 		return env->CallBooleanMethod(godot_instance, _request_permission, jStrName);
 	} else {
 		return false;
+	}
+}
+
+jobject GodotJavaWrapper::get_surface() {
+	if (_get_surface) {
+		JNIEnv *env = ThreadAndroid::get_env();
+		return env->CallObjectMethod(godot_instance, _get_surface);
+	} else {
+		return NULL;
 	}
 }

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -54,6 +54,7 @@ private:
 	jmethodID _get_clipboard = 0;
 	jmethodID _set_clipboard = 0;
 	jmethodID _request_permission = 0;
+	jmethodID _get_surface = 0;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance);
@@ -76,6 +77,7 @@ public:
 	bool has_set_clipboard();
 	void set_clipboard(const String &p_text);
 	bool request_permission(const String &p_name);
+	jobject get_surface();
 };
 
 #endif /* !JAVA_GODOT_WRAPPER_H */


### PR DESCRIPTION
This fixes the get activity method and adds a get surface method to our GDNative Android bindings. These are needed to make Oculus Go/Quest work.

More may be needed and until we test this with the Oculus SDK we'll keep this as WIP :)