### PR TITLE
RichTextLabel: update the cache when the scroll hide.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -765,19 +765,17 @@ void RichTextLabel::_update_scroll() {
 
 		if (exceeds) {
 			scroll_visible = true;
-			main->first_invalid_line = 0;
 			scroll_w = vscroll->get_combined_minimum_size().width;
 			vscroll->show();
 			vscroll->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_END, -scroll_w);
-			_validate_line_caches(main);
-
 		} else {
-
 			scroll_visible = false;
-			vscroll->hide();
 			scroll_w = 0;
-			_validate_line_caches(main);
+			vscroll->hide();
 		}
+
+		main->first_invalid_line = 0; //invalidate ALL
+		_validate_line_caches(main);
 	}
 }
 
@@ -1616,7 +1614,6 @@ void RichTextLabel::clear() {
 	main->lines.clear();
 	main->lines.resize(1);
 	main->first_invalid_line = 0;
-	scroll_w = 0;
 	update();
 	selection.click = NULL;
 	selection.active = false;


### PR DESCRIPTION
This a proper fix for #23933, i hope 8), revert 970dc91(caused issue: when after long text with scrollbar, set a new long text, scroll offset will be ignored.)
No need to clear the scroll offset, it's cleared in _update_scroll(), but cache not updated.
Updated test project:
[godot_3_rich_text.zip](https://github.com/godotengine/godot/files/2636406/godot_3_rich_text.zip)
