### PR TITLE
Fix text files constantly asking for reload as no last modified time

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -123,6 +123,7 @@ public:
 	static int get_import_order(const String &p_path);
 
 	static void set_timestamp_on_load(bool p_timestamp) { timestamp_on_load = p_timestamp; }
+	static bool get_timestamp_on_load() { return timestamp_on_load; }
 
 	static void notify_load_error(const String &p_err) {
 		if (err_notify) err_notify(err_notify_ud, p_err);

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -76,6 +76,8 @@ public:
 	static void add_resource_format_saver(ResourceFormatSaver *p_format_saver, bool p_at_front = false);
 
 	static void set_timestamp_on_save(bool p_timestamp) { timestamp_on_save = p_timestamp; }
+	static bool get_timestamp_on_save() { return timestamp_on_save; }
+
 	static void set_save_callback(ResourceSavedCallback p_callback);
 };
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1815,6 +1815,10 @@ Ref<TextFile> ScriptEditor::_load_text_file(const String &p_path, Error *r_error
 	text_file->set_file_path(local_path);
 	text_file->set_path(local_path, true);
 
+	if (ResourceLoader::get_timestamp_on_load()) {
+		text_file->set_last_modified_time(FileAccess::get_modified_time(path));
+	}
+
 	if (r_error) {
 		*r_error = OK;
 	}
@@ -1843,6 +1847,10 @@ Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_p
 	}
 	file->close();
 	memdelete(file);
+
+	if (ResourceSaver::get_timestamp_on_save()) {
+		p_text_file->set_last_modified_time(FileAccess::get_modified_time(p_path));
+	}
 
 	_res_saved_callback(sqscr);
 	return OK;


### PR DESCRIPTION
Text files were constantly asking to be reloaded as the last modified time was never being set. As a result it though that the file had been changed on disk.