### PR TITLE
Added ranged integer generation function to RNG class

### DIFF
--- a/core/math/random_number_generator.cpp
+++ b/core/math/random_number_generator.cpp
@@ -40,6 +40,7 @@ void RandomNumberGenerator::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("randi"), &RandomNumberGenerator::randi);
 	ClassDB::bind_method(D_METHOD("randf"), &RandomNumberGenerator::randf);
-	ClassDB::bind_method(D_METHOD("rand_range", "from", "to"), &RandomNumberGenerator::rand_range);
+	ClassDB::bind_method(D_METHOD("randf_range", "from", "to"), &RandomNumberGenerator::randf_range);
+	ClassDB::bind_method(D_METHOD("randi_range", "from", "to"), &RandomNumberGenerator::randi_range);
 	ClassDB::bind_method(D_METHOD("randomize"), &RandomNumberGenerator::randomize);
 }

--- a/core/math/random_number_generator.h
+++ b/core/math/random_number_generator.h
@@ -53,7 +53,12 @@ public:
 
 	_FORCE_INLINE_ real_t randf() { return randbase.randf(); }
 
-	_FORCE_INLINE_ real_t rand_range(real_t from, real_t to) { return randbase.random(from, to); }
+	_FORCE_INLINE_ real_t randf_range(real_t from, real_t to) { return randbase.random(from, to); }
+
+	_FORCE_INLINE_ int randi_range(int from, int to) {
+		unsigned int ret = randbase.rand();
+		return ret % (to - from + 1) + from;
+	}
 
 	RandomNumberGenerator();
 };

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -10,7 +10,7 @@
 	<demos>
 	</demos>
 	<methods>
-		<method name="rand_range">
+		<method name="randf_range">
 			<return type="float">
 			</return>
 			<argument index="0" name="from" type="float">
@@ -19,6 +19,17 @@
 			</argument>
 			<description>
 				Generates pseudo-random float between [code]from[/code] and [code]to[/code].
+			</description>
+		</method>
+		<method name="randi_range">
+			<return type="int">
+			</return>
+			<argument index="0" name="from" type="int">
+			</argument>
+			<argument index="1" name="to" type="int">
+			</argument>
+			<description>
+				Generates pseudo-random 32-bit signed integer between [code]from[/code] and [code]to[/code](inclusive).
 			</description>
 		</method>
 		<method name="randf">
@@ -32,7 +43,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Generates pseudo-random 32-bit integer between '0' and '4294967295'.
+				Generates pseudo-random 32-bit unsigned integer between '0' and '4294967295'.
 			</description>
 		</method>
 		<method name="randomize">


### PR DESCRIPTION
Its an often-requested feature, so I've decided to add it into RandomNumberGeneration class..
I did not add it to global space, to prevent engine bloating
eg
`rng.randi_range(0, 1) - generates 0 or 1`