### PR TITLE
Fix ExportDialog layout out of boundary when select a template.

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -298,6 +298,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	custom_features->set_text(current->get_custom_features());
 	_update_feature_list();
 	_update_export_all();
+	minimum_size_changed();
 
 	updating = false;
 }
@@ -1173,6 +1174,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_pck_zip->connect("file_selected", this, "_export_pck_zip_selected");
 
 	export_error = memnew(Label);
+	export_error->set_autowrap(true);
 	main_vb->add_child(export_error);
 	export_error->hide();
 	export_error->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));


### PR DESCRIPTION
This fixed issue #24202 