### PR TITLE
Fixing *.TSCN extension filter not present when loading Resource exports in editor

### DIFF
--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -1242,7 +1242,7 @@ void ResourceFormatLoaderText::get_recognized_extensions_for_type(const String &
 		return;
 	}
 
-	if (p_type == "PackedScene")
+	if (p_type == "PackedScene" || p_type == "Resource")
 		p_extensions->push_back("tscn");
 	else
 		p_extensions->push_back("tres");


### PR DESCRIPTION
After reading the comments section and after being able to recreate the bug, *.TSCN extension filter is now present when loading Resource exports in editor.

*Bugsquad edit:* Fixes #7278