### PR TITLE
possible fix for issue #24183

### DIFF
--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -61,17 +61,17 @@ void Body2DSW::update_inertias() {
 
 			for (int i = 0; i < get_shape_count(); i++) {
 
-				const Shape2DSW *shape = get_shape(i);
+				if (check_if_shape_is_not_disabled(i)) { //it only adds to inertia if shape is not disabled
+					const Shape2DSW *shape = get_shape(i);
 
-				real_t area = get_shape_aabb(i).get_area();
+					real_t area = get_shape_aabb(i).get_area();
 
-				real_t mass = area * this->mass / total_area;
+					real_t mass = area * this->mass / total_area;
 
-				Transform2D mtx = get_shape_transform(i);
-				Vector2 scale = mtx.get_scale();
-				_inertia += shape->get_moment_of_inertia(mass, scale) + mass * mtx.get_origin().length_squared();
-				//Rect2 ab = get_shape_aabb(i);
-				//_inertia+=mass*ab.size.dot(ab.size)/12.0f;
+					Transform2D mtx = get_shape_transform(i);
+					Vector2 scale = mtx.get_scale();
+					_inertia += shape->get_moment_of_inertia(mass, scale) + mass * mtx.get_origin().length_squared();
+				}
 			}
 
 			if (_inertia != 0)

--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -115,6 +115,11 @@ public:
 	void set_shape_metadata(int p_index, const Variant &p_metadata);
 
 	_FORCE_INLINE_ int get_shape_count() const { return shapes.size(); }
+
+	_FORCE_INLINE_ bool check_if_shape_is_not_disabled(int shape_index) const {
+		CRASH_BAD_INDEX(shape_index, shapes.size());
+		return !shapes[shape_index].disabled;
+	}
 	_FORCE_INLINE_ Shape2DSW *get_shape(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].shape;


### PR DESCRIPTION
Fixed issue where disabled shapes would count for inertia calculations.

Before getting the shape, it checks if that shape is disabled. if it's not, uses that shape to calculate inertia.

https://github.com/godotengine/godot/issues/24183 link to user issue report.