### PR TITLE
Cleanup some unused controls in the editor's top bar

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5187,12 +5187,6 @@ EditorNode::EditorNode() {
 	top_region->add_child(left_menu_hb);
 	menu_hb->add_child(top_region);
 
-	{
-		Control *sp = memnew(Control);
-		sp->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
-		menu_hb->add_child(sp);
-	}
-
 	file_menu = memnew(MenuButton);
 	file_menu->set_flat(false);
 	file_menu->set_text(TTR("Scene"));
@@ -5409,12 +5403,8 @@ EditorNode::EditorNode() {
 	p->add_separator();
 	p->add_icon_item(gui_base->get_icon("Godot", "EditorIcons"), TTR("About"), HELP_ABOUT);
 
-	play_cc = memnew(CenterContainer);
-	play_cc->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
-	menu_hb->add_child(play_cc);
-
 	play_button_panel = memnew(PanelContainer);
-	play_cc->add_child(play_button_panel);
+	menu_hb->add_child(play_button_panel);
 
 	HBoxContainer *play_hb = memnew(HBoxContainer);
 	play_button_panel->add_child(play_hb);
@@ -5460,11 +5450,6 @@ EditorNode::EditorNode() {
 
 	run_native = memnew(EditorRunNative);
 	play_hb->add_child(run_native);
-	native_play_button = memnew(MenuButton);
-	native_play_button->set_text("NTV");
-	menu_hb->add_child(native_play_button);
-	native_play_button->hide();
-	native_play_button->get_popup()->connect("id_pressed", this, "_run_in_device");
 	run_native->connect("native_run", this, "_menu_option", varray(RUN_PLAY_NATIVE));
 
 	play_scene_button = memnew(ToolButton);
@@ -5493,6 +5478,9 @@ EditorNode::EditorNode() {
 	play_custom_scene_button->set_shortcut(ED_SHORTCUT("editor/play_custom_scene", TTR("Play Custom Scene"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_F5));
 #endif
 
+	HBoxContainer *right_menu_hb = memnew(HBoxContainer);
+	menu_hb->add_child(right_menu_hb);
+
 	// Toggle for video driver
 	video_driver = memnew(OptionButton);
 	video_driver->set_flat(true);
@@ -5500,7 +5488,7 @@ EditorNode::EditorNode() {
 	video_driver->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	video_driver->connect("item_selected", this, "_video_driver_selected");
 	video_driver->add_font_override("font", gui_base->get_font("bold", "EditorFonts"));
-	menu_hb->add_child(video_driver);
+	right_menu_hb->add_child(video_driver);
 
 	String video_drivers = ProjectSettings::get_singleton()->get_custom_property_info()["rendering/quality/driver/driver_name"].hint_string;
 	String current_video_driver = OS::get_singleton()->get_video_driver_name(OS::get_singleton()->get_current_video_driver());
@@ -5525,9 +5513,6 @@ EditorNode::EditorNode() {
 	gui_base->add_child(video_restart_dialog);
 
 	progress_hb = memnew(BackgroundProgress);
-
-	HBoxContainer *right_menu_hb = memnew(HBoxContainer);
-	menu_hb->add_child(right_menu_hb);
 
 	layout_dialog = memnew(EditorNameDialog);
 	gui_base->add_child(layout_dialog);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -243,7 +243,6 @@ private:
 	Control *vp_base;
 	PaneDrag *pd;
 
-	CenterContainer *play_cc;
 	HBoxContainer *menu_hb;
 	Control *viewport;
 	MenuButton *file_menu;
@@ -255,7 +254,6 @@ private:
 	ToolButton *export_button;
 	ToolButton *prev_scene;
 	ToolButton *play_button;
-	MenuButton *native_play_button;
 	ToolButton *pause_button;
 	ToolButton *stop_button;
 	ToolButton *run_settings_button;


### PR DESCRIPTION
Seems to have fixed #15714.

I would also like to thank and recommend @Zylann's new [Editor Debugger](https://godotengine.org/asset-library/asset/295) plugin, which is a really neat tool for devs who like to tinker with the editor itself.

Also, @akien-mga, while doing this, I found a hidden `native_play_button` `MenuButton`, that has no logic to show it at any moment. Is this working as intended?