### PR TITLE
Minor mono-related cleanup.

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2245,7 +2245,7 @@ Ref<CSharpScript> CSharpScript::create_for_managed_type(GDMonoClass *p_class) {
 
 	script->name = p_class->get_name();
 	script->script_class = p_class;
-	script->native = GDMonoUtils::get_class_native_base(script->script_class);
+	script->native = script->script_class->get_native_base();
 
 	CRASH_COND(script->native == NULL);
 
@@ -2262,7 +2262,7 @@ Ref<CSharpScript> CSharpScript::create_for_managed_type(GDMonoClass *p_class) {
 	if (script->script_class != script->native) {
 		GDMonoClass *native_top = script->native;
 		while (native_top) {
-			native_top->fetch_methods_with_godot_api_checks(script->native);
+			native_top->fetch_methods_with_godot_api_checks();
 
 			if (native_top == CACHED_CLASS(GodotObject))
 				break;
@@ -2272,12 +2272,12 @@ Ref<CSharpScript> CSharpScript::create_for_managed_type(GDMonoClass *p_class) {
 	}
 #endif
 
-	script->script_class->fetch_methods_with_godot_api_checks(script->native);
+	script->script_class->fetch_methods_with_godot_api_checks();
 
 	// Need to fetch method from base classes as well
 	GDMonoClass *top = script->script_class;
 	while (top && top != script->native) {
-		top->fetch_methods_with_godot_api_checks(script->native);
+		top->fetch_methods_with_godot_api_checks();
 		top = top->get_parent_class();
 	}
 
@@ -2553,7 +2553,7 @@ Error CSharpScript::reload(bool p_keep_state) {
 
 			tool = script_class->has_attribute(CACHED_CLASS(ToolAttribute));
 
-			native = GDMonoUtils::get_class_native_base(script_class);
+			native = script_class->get_native_base();
 
 			CRASH_COND(native == NULL);
 
@@ -2570,7 +2570,7 @@ Error CSharpScript::reload(bool p_keep_state) {
 			if (script_class != native) {
 				GDMonoClass *native_top = native;
 				while (native_top) {
-					native_top->fetch_methods_with_godot_api_checks(native);
+					native_top->fetch_methods_with_godot_api_checks();
 
 					if (native_top == CACHED_CLASS(GodotObject))
 						break;
@@ -2580,12 +2580,12 @@ Error CSharpScript::reload(bool p_keep_state) {
 			}
 #endif
 
-			script_class->fetch_methods_with_godot_api_checks(native);
+			script_class->fetch_methods_with_godot_api_checks();
 
 			// Need to fetch method from base classes as well
 			GDMonoClass *top = script_class;
 			while (top && top != native) {
-				top->fetch_methods_with_godot_api_checks(native);
+				top->fetch_methods_with_godot_api_checks();
 				top = top->get_parent_class();
 			}
 

--- a/modules/mono/mono_gd/gd_mono_class.cpp
+++ b/modules/mono/mono_gd/gd_mono_class.cpp
@@ -68,11 +68,28 @@ GDMonoClass *GDMonoClass::get_parent_class() {
 
 	if (assembly) {
 		MonoClass *parent_mono_class = mono_class_get_parent(mono_class);
-
 		if (parent_mono_class) {
 			return GDMono::get_singleton()->get_class(parent_mono_class);
 		}
 	}
+
+	return NULL;
+}
+
+GDMonoClass *GDMonoClass::get_native_base() {
+
+	GDMonoClass *klass = this;
+
+	do {
+		const GDMonoAssembly *assembly = klass->get_assembly();
+		if (assembly == GDMono::get_singleton()->get_core_api_assembly())
+			return klass;
+
+#ifdef TOOLS_ENABLED
+		if (assembly == GDMono::get_singleton()->get_editor_api_assembly())
+			return klass;
+#endif
+	} while ((klass = klass->get_parent_class()) != NULL);
 
 	return NULL;
 }
@@ -139,7 +156,7 @@ void GDMonoClass::fetch_attributes() {
 	attrs_fetched = true;
 }
 
-void GDMonoClass::fetch_methods_with_godot_api_checks(GDMonoClass *p_native_base) {
+void GDMonoClass::fetch_methods_with_godot_api_checks() {
 
 	CRASH_COND(!CACHED_CLASS(GodotObject)->is_assignable_from(this));
 
@@ -169,24 +186,25 @@ void GDMonoClass::fetch_methods_with_godot_api_checks(GDMonoClass *p_native_base
 		// For debug builds, we also fetched from native base classes as well before if this is not a native base class.
 		// This allows us to warn the user here if he is using snake_case by mistake.
 
-		if (p_native_base != this) {
+		{
+			GDMonoClass *native_top = get_native_base();
+			if (native_top != this) {
+				while (native_top) {
+					GDMonoMethod *m = native_top->get_method(name, method->get_parameters_count());
 
-			GDMonoClass *native_top = p_native_base;
-			while (native_top) {
-				GDMonoMethod *m = native_top->get_method(name, method->get_parameters_count());
+					if (m && m->get_name() != name) {
+						// found
+						String fullname = m->get_ret_type_full_name() + " " + name + "(" + m->get_signature_desc(true) + ")";
+						WARN_PRINTS("Method `" + fullname + "` should be `" + m->get_full_name_no_class() +
+									"`. In class `" + namespace_name + "." + class_name + "`.");
+						break;
+					}
 
-				if (m && m->get_name() != name) {
-					// found
-					String fullname = m->get_ret_type_full_name() + " " + name + "(" + m->get_signature_desc(true) + ")";
-					WARN_PRINTS("Method `" + fullname + "` should be `" + m->get_full_name_no_class() +
-								"`. In class `" + namespace_name + "." + class_name + "`.");
-					break;
+					if (native_top == CACHED_CLASS(GodotObject))
+						break;
+
+					native_top = native_top->get_parent_class();
 				}
-
-				if (native_top == CACHED_CLASS(GodotObject))
-					break;
-
-				native_top = native_top->get_parent_class();
 			}
 		}
 #endif
@@ -198,7 +216,7 @@ void GDMonoClass::fetch_methods_with_godot_api_checks(GDMonoClass *p_native_base
 
 		// Virtual method of Godot Object derived type, let's try to find GodotMethod attribute
 
-		GDMonoClass *top = p_native_base;
+		GDMonoClass *top = get_native_base();
 
 		while (top) {
 			GDMonoMethod *base_method = top->get_method(name, method->get_parameters_count());

--- a/modules/mono/mono_gd/gd_mono_class.h
+++ b/modules/mono/mono_gd/gd_mono_class.h
@@ -118,6 +118,7 @@ public:
 	_FORCE_INLINE_ const GDMonoAssembly *get_assembly() const { return assembly; }
 
 	GDMonoClass *get_parent_class();
+	GDMonoClass *get_native_base();
 
 #ifdef TOOLS_ENABLED
 	Vector<MonoClassField *> get_enum_fields();
@@ -130,7 +131,7 @@ public:
 	MonoObject *get_attribute(GDMonoClass *p_attr_class);
 
 	void fetch_attributes();
-	void fetch_methods_with_godot_api_checks(GDMonoClass *p_native_base);
+	void fetch_methods_with_godot_api_checks();
 
 	GDMonoMethod *get_method(const StringName &p_name, int p_params_count = 0);
 	GDMonoMethod *get_method(MonoMethod *p_raw_method);

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -372,19 +372,9 @@ GDMonoClass *type_get_proxy_class(const StringName &p_type) {
 }
 
 GDMonoClass *get_class_native_base(GDMonoClass *p_class) {
-	GDMonoClass *klass = p_class;
+	WARN_DEPRECATED;
 
-	do {
-		const GDMonoAssembly *assembly = klass->get_assembly();
-		if (assembly == GDMono::get_singleton()->get_core_api_assembly())
-			return klass;
-#ifdef TOOLS_ENABLED
-		if (assembly == GDMono::get_singleton()->get_editor_api_assembly())
-			return klass;
-#endif
-	} while ((klass = klass->get_parent_class()) != NULL);
-
-	return NULL;
+	return p_class->get_native_base();
 }
 
 MonoObject *create_managed_for_godot_object(GDMonoClass *p_class, const StringName &p_native, Object *p_object) {


### PR DESCRIPTION
I originally made these changes as part of another pull request, then ended up abandoning the rest of the pull request because it wasn't the right approach for what I was doing. But I think these changes are still valuable.

This is a small cleanup pass to move get_class_native_base() into being a member of GDMonoClass. As an added bonus, this also makes it easy to remove the redundant parameter from fetch_methods_with_godot_api_checks().

get_class_native_base() is left in place, but prints a deprecation warning before simply calling GDMonoClass::get_native_base().