### PR TITLE
Fixed scancode with modifiers matching in InputEventKey

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -304,7 +304,7 @@ bool InputEventKey::action_match(const Ref<InputEvent> &p_event, bool *p_pressed
 	uint32_t code = get_scancode_with_modifiers();
 	uint32_t event_code = key->get_scancode_with_modifiers();
 
-	bool match = get_scancode() == key->get_scancode() && (!key->is_pressed() || (code & event_code) == code);
+	bool match = code == event_code && (!key->is_pressed() || (code & event_code) == code);
 	if (match) {
 		if (p_pressed != NULL)
 			*p_pressed = key->is_pressed();


### PR DESCRIPTION
I have a problem when implementing  multiple keys for one action. If you set the first key with any modifier(for example CTRL), and than second key without CTRL, the second key will be ignored because it will be identical to first. This will resolve it

Update: so let me rephrase it -

I want to apply two keys to one action - one with modifier the other without. I do it using `InputMap.action_add_event` method. This method using the match comparsion, and currently not allow adding input keys with identical scancode even if modifiers are different, I think its bug and should be fixed. Without this change, I need to create separate action which I do not want cuz its overkill.