### PR TITLE
Project wide groups implementation

### DIFF
--- a/editor/editor_group_settings.cpp
+++ b/editor/editor_group_settings.cpp
@@ -1,0 +1,555 @@
+/*************************************************************************/
+/*  editor_group_settings.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor_group_settings.h"
+
+#include "core/global_constants.h"
+#include "core/project_settings.h"
+#include "editor_node.h"
+#include "scene/main/viewport.h"
+#include "scene/resources/packed_scene.h"
+
+void EditorGroupSettings::_notification(int p_what) {
+
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+			update_tree();
+			break;
+	}
+}
+
+bool EditorGroupSettings::_group_exists(const String &p_name) {
+	return names.find(p_name) != -1;
+}
+
+bool EditorGroupSettings::_group_name_is_valid(const String &p_name, String *r_error) {
+
+	if (!p_name.is_valid_identifier()) {
+		if (r_error)
+			*r_error = TTR("Invalid name.") + "\n" + TTR("Valid characters:") + " a-z, A-Z, 0-9 or _";
+
+		return false;
+	}
+
+	if (ClassDB::class_exists(p_name)) {
+		if (r_error)
+			*r_error = TTR("Invalid name. Must not collide with an existing engine class name.");
+
+		return false;
+	}
+
+	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+		if (Variant::get_type_name(Variant::Type(i)) == p_name) {
+			if (r_error)
+				*r_error = TTR("Invalid name. Must not collide with an existing built-in type name.");
+
+			return false;
+		}
+	}
+
+	for (int i = 0; i < GlobalConstants::get_global_constant_count(); i++) {
+		if (GlobalConstants::get_global_constant_name(i) == p_name) {
+			if (r_error)
+				*r_error = TTR("Invalid name. Must not collide with an existing global constant name.");
+
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void EditorGroupSettings::_item_edited() {
+
+	if (updating_group)
+		return;
+
+	TreeItem *ti = tree->get_edited();
+
+	String name = ti->get_text(0);
+	int column = tree->get_edited_column();
+
+	UndoRedo *undo_redo = EditorNode::get_undo_redo();
+
+	if (column == 0) {
+		String old_name = selected_group;
+
+		if (name == old_name)
+			return;
+
+		String error;
+		if (!_group_name_is_valid(name, &error)) {
+			ti->set_text(0, old_name);
+			EditorNode::get_singleton()->show_warning(error);
+			return;
+		}
+
+		if (names.find(name) >= 0) {
+			ti->set_text(0, old_name);
+			EditorNode::get_singleton()->show_warning(vformat(TTR("Group '%s' already exists!"), name));
+			return;
+		}
+
+		updating_group = true;
+
+		undo_redo->create_action(TTR("Rename Group"));
+
+		undo_redo->add_do_method(this, "_rename_group", old_name, name);
+		undo_redo->add_undo_method(this, "_rename_group", name, old_name);
+
+		undo_redo->add_do_method(this, "_rename_references", old_name, name);
+		undo_redo->add_undo_method(this, "_rename_references", name, old_name);
+
+		undo_redo->add_do_method(this, "call_deferred", "update_tree");
+		undo_redo->add_undo_method(this, "call_deferred", "update_tree");
+
+		undo_redo->add_do_method(this, "emit_signal", group_changed);
+		undo_redo->add_undo_method(this, "emit_signal", group_changed);
+
+		undo_redo->add_do_method(this, "_save_groups");
+		undo_redo->add_undo_method(this, "_save_groups");
+
+		undo_redo->commit_action();
+
+		selected_group = name;
+	} else if (column == 1) {
+		updating_group = true;
+
+		String description = ti->get_text(1);
+		String old_description = group_cache[name].description;
+
+		undo_redo->create_action(TTR("Change Group Description"));
+
+		undo_redo->add_do_method(this, "_set_description", name, description);
+		undo_redo->add_undo_method(this, "_set_description", name, old_description);
+
+		undo_redo->add_do_method(this, "call_deferred", "update_tree");
+		undo_redo->add_undo_method(this, "call_deferred", "update_tree");
+
+		undo_redo->add_do_method(this, "emit_signal", group_changed);
+		undo_redo->add_undo_method(this, "emit_signal", group_changed);
+
+		undo_redo->add_do_method(this, "_save_groups");
+		undo_redo->add_undo_method(this, "_save_groups");
+
+		undo_redo->commit_action();
+	}
+
+	updating_group = false;
+}
+
+void EditorGroupSettings::_item_selected() {
+
+	TreeItem *ti = tree->get_selected();
+	if (!ti)
+		return;
+
+	selected_group = ti->get_text(0);
+}
+
+void EditorGroupSettings::_item_activated() {
+
+	TreeItem *ti = tree->get_selected();
+	if (!ti)
+		return;
+}
+
+void EditorGroupSettings::_item_button_pressed(Object *p_item, int p_column, int p_button) {
+
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
+
+	selected_group = ti->get_text(0);
+
+	remove_confirmation->popup_centered_minsize();
+}
+
+void EditorGroupSettings::_create_button_pressed() {
+
+	String name = create_group_name->get_text();
+
+	String error;
+	if (!_group_name_is_valid(name, &error)) {
+		EditorNode::get_singleton()->show_warning(error);
+		return;
+	}
+
+	if (names.find(name) >= 0) {
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Group '%s' already exists!"), name));
+		return;
+	}
+
+	String description = create_group_description->get_text();
+
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
+
+	undo_redo->create_action(TTR("Add Group"));
+
+	undo_redo->add_do_method(this, "_create_group", name, description);
+	undo_redo->add_undo_method(this, "_delete_group", name);
+
+	undo_redo->add_do_method(this, "call_deferred", "update_tree");
+	undo_redo->add_undo_method(this, "call_deferred", "update_tree");
+
+	undo_redo->add_do_method(this, "emit_signal", group_changed);
+	undo_redo->add_undo_method(this, "emit_signal", group_changed);
+
+	undo_redo->add_do_method(this, "_save_groups");
+	undo_redo->add_undo_method(this, "_save_groups");
+
+	undo_redo->commit_action();
+
+	create_group_name->set_text("");
+	create_group_description->set_text("");
+}
+
+void EditorGroupSettings::_remove_references(const String &p_name) {
+
+	Set<String> scenes;
+	_get_all_scenes(EditorFileSystem::get_singleton()->get_filesystem(), scenes);
+	for (Set<String>::Element *E = scenes.front(); E; E = E->next()) {
+
+		Ref<PackedScene> data = ResourceLoader::load(E->get());
+		if (data->get_state()->remove_group_references(StringName(p_name))) {
+			ResourceSaver::save(E->get(), data);
+		}
+	}
+
+	// Update opened scenes
+	Node *es = EditorNode::get_singleton()->get_edited_scene();
+	if (es != NULL) {
+		_remove_node_references(es, p_name);
+		EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->update_tree();
+	}
+}
+
+void EditorGroupSettings::_rename_references(const String &p_old_name, const String &p_new_name) {
+
+	Set<String> scenes;
+	_get_all_scenes(EditorFileSystem::get_singleton()->get_filesystem(), scenes);
+	for (Set<String>::Element *E = scenes.front(); E; E = E->next()) {
+
+		Ref<PackedScene> data = ResourceLoader::load(E->get());
+		if (data->get_state()->rename_group_references(StringName(p_old_name), StringName(p_new_name))) {
+			ResourceSaver::save(E->get(), data);
+		}
+	}
+
+	// Update opened scenes
+	Node *es = EditorNode::get_singleton()->get_edited_scene();
+	if (es != NULL) {
+		_rename_node_references(es, p_old_name, p_new_name);
+		EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->update_tree();
+	}
+}
+
+void EditorGroupSettings::_remove_node_references(Node *p_node, const String &p_name) {
+
+	if (p_node->is_in_group(p_name)) {
+		p_node->remove_from_group(p_name);
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_remove_node_references(p_node->get_child(i), p_name);
+	}
+}
+
+void EditorGroupSettings::_rename_node_references(Node *p_node, const String &p_old_name, const String &p_new_name) {
+
+	if (p_node->is_in_group(p_old_name)) {
+		p_node->remove_from_group(p_old_name);
+		p_node->add_to_group(p_new_name, true);
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_rename_node_references(p_node->get_child(i), p_old_name, p_new_name);
+	}
+}
+
+void EditorGroupSettings::_get_all_scenes(EditorFileSystemDirectory *p_dir, Set<String> &r_list) {
+
+	for (int i = 0; i < p_dir->get_file_count(); i++) {
+		if (p_dir->get_file_type(i) == "PackedScene")
+			r_list.insert(p_dir->get_file_path(i));
+	}
+
+	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
+		_get_all_scenes(p_dir->get_subdir(i), r_list);
+	}
+}
+
+void EditorGroupSettings::_confirm_delete() {
+
+	String name = selected_group;
+	String description = group_cache[name].description;
+
+	UndoRedo *undo_redo = EditorNode::get_undo_redo();
+
+	undo_redo->create_action(TTR("Remove Group"));
+
+	undo_redo->add_do_method(this, "_delete_group", name);
+	undo_redo->add_undo_method(this, "_create_group", name, description);
+
+	undo_redo->add_do_method(this, "_remove_references", name);
+
+	undo_redo->add_do_method(this, "update_tree");
+	undo_redo->add_undo_method(this, "update_tree");
+
+	undo_redo->add_do_method(this, "emit_signal", group_changed);
+	undo_redo->add_undo_method(this, "emit_signal", group_changed);
+
+	undo_redo->add_do_method(this, "_save_groups");
+	undo_redo->add_undo_method(this, "_save_groups");
+
+	undo_redo->commit_action();
+}
+
+void EditorGroupSettings::_create_group(const String &p_name, const String &p_description) {
+
+	GroupInfo gi;
+
+	gi.name = p_name;
+	gi.description = p_description;
+
+	group_cache[p_name] = gi;
+
+	names.push_back(p_name);
+	names.sort_custom<StringComparator>();
+}
+
+void EditorGroupSettings::_delete_group(const String &p_name) {
+
+	names.erase(p_name);
+	group_cache.erase(p_name);
+}
+
+void EditorGroupSettings::_rename_group(const String &p_old_name, const String &p_new_name) {
+
+	GroupInfo gi = group_cache[p_old_name];
+	gi.name = p_new_name;
+
+	group_cache.erase(p_old_name);
+	group_cache[p_new_name] = gi;
+
+	names.erase(p_old_name);
+	names.push_back(p_new_name);
+	names.sort_custom<StringComparator>();
+}
+
+void EditorGroupSettings::_set_description(const String &p_name, const String &p_description) {
+
+	GroupInfo gi = group_cache[p_name];
+	gi.description = p_description;
+}
+
+void EditorGroupSettings::_init_groups() {
+	group_cache.clear();
+	if (ProjectSettings::get_singleton()->has_setting("_global_groups")) {
+		Array groups = ProjectSettings::get_singleton()->get("_global_groups");
+
+		for (int i = 0; i < groups.size(); i++) {
+			Dictionary g = groups[i];
+
+			_create_group(g["name"], g["description"]);
+		}
+	}
+}
+
+void EditorGroupSettings::_save_groups() {
+	Array g_array;
+	for (int i = 0; i < names.size(); i++) {
+		GroupInfo gi = group_cache[names[i]];
+		Dictionary d;
+		d["name"] = gi.name;
+		d["description"] = gi.description;
+		g_array.push_back(d);
+	}
+
+	ProjectSettings::get_singleton()->set("_global_groups", g_array);
+	ProjectSettings::get_singleton()->save();
+}
+
+void EditorGroupSettings::update_tree() {
+
+	if (updating_group)
+		return;
+
+	updating_group = true;
+
+	tree->clear();
+	TreeItem *root = tree->create_item();
+
+	for (int i = 0; i < names.size(); i++) {
+
+		String name = names[i];
+
+		GroupInfo gi = group_cache[names[i]];
+
+		TreeItem *item = tree->create_item(root);
+		item->set_text(0, gi.name);
+		item->set_editable(0, true);
+
+		item->set_text(1, gi.description);
+		item->set_editable(1, true);
+		item->add_button(2, get_icon("Remove", "EditorIcons"), BUTTON_DELETE);
+		item->set_selectable(2, false);
+	}
+
+	updating_group = false;
+}
+
+void EditorGroupSettings::create_group(const String &p_name, const String &p_description) {
+
+	if (_group_exists(p_name))
+		return;
+
+	_create_group(p_name, p_description);
+	_save_groups();
+	update_tree();
+}
+
+void EditorGroupSettings::delete_group(const String &p_name) {
+
+	if (!_group_exists(p_name))
+		return;
+
+	_delete_group(p_name);
+	_remove_references(p_name);
+	_save_groups();
+	update_tree();
+}
+
+void EditorGroupSettings::get_groups(List<String> *current_groups) {
+
+	for (int i = 0; i < names.size(); i++) {
+		current_groups->push_back(names[i]);
+	}
+}
+
+void EditorGroupSettings::_bind_methods() {
+
+	ClassDB::bind_method("_item_edited", &EditorGroupSettings::_item_edited);
+	ClassDB::bind_method("_item_selected", &EditorGroupSettings::_item_selected);
+	ClassDB::bind_method("_item_activated", &EditorGroupSettings::_item_activated);
+	ClassDB::bind_method("_item_button_pressed", &EditorGroupSettings::_item_button_pressed);
+
+	ClassDB::bind_method("_create_button_pressed", &EditorGroupSettings::_create_button_pressed);
+
+	ClassDB::bind_method("_create_group", &EditorGroupSettings::_create_group);
+	ClassDB::bind_method("_delete_group", &EditorGroupSettings::_delete_group);
+	ClassDB::bind_method("_rename_group", &EditorGroupSettings::_rename_group);
+	ClassDB::bind_method("_set_description", &EditorGroupSettings::_set_description);
+
+	ClassDB::bind_method("_remove_references", &EditorGroupSettings::_remove_references);
+	ClassDB::bind_method("_rename_references", &EditorGroupSettings::_rename_references);
+
+	ClassDB::bind_method("_confirm_delete", &EditorGroupSettings::_confirm_delete);
+
+	ClassDB::bind_method("_init_groups", &EditorGroupSettings::_init_groups);
+	ClassDB::bind_method("_save_groups", &EditorGroupSettings::_save_groups);
+
+	ClassDB::bind_method("create_group", &EditorGroupSettings::create_group);
+	ClassDB::bind_method("delete_group", &EditorGroupSettings::delete_group);
+	ClassDB::bind_method("update_tree", &EditorGroupSettings::update_tree);
+
+	ADD_SIGNAL(MethodInfo("group_changed"));
+}
+
+EditorGroupSettings::EditorGroupSettings() {
+
+	_init_groups();
+
+	group_changed = "group_changed";
+
+	updating_group = false;
+	selected_group = "";
+
+	remove_confirmation = memnew(ConfirmationDialog);
+	remove_confirmation->set_title(TTR("Delete confirmation"));
+	remove_confirmation->set_text(TTR("Deleting a group will also remove its references. This action is undoable."));
+	remove_confirmation->get_ok()->set_text(TTR("Delete"));
+	remove_confirmation->connect("confirmed", this, "_confirm_delete");
+	add_child(remove_confirmation);
+
+	HBoxContainer *hbc = memnew(HBoxContainer);
+	add_child(hbc);
+
+	Label *l = memnew(Label);
+	l->set_text(TTR("Group Name:"));
+	hbc->add_child(l);
+
+	create_group_name = memnew(LineEdit);
+	create_group_name->set_h_size_flags(SIZE_EXPAND_FILL);
+	hbc->add_child(create_group_name);
+
+	l = memnew(Label);
+	l->set_text(TTR("Group Description:"));
+	hbc->add_child(l);
+
+	create_group_description = memnew(LineEdit);
+	create_group_description->set_h_size_flags(SIZE_EXPAND_FILL);
+	hbc->add_child(create_group_description);
+
+	Button *create_group = memnew(Button);
+	create_group->set_text(TTR("Create"));
+	create_group->connect("pressed", this, "_create_button_pressed");
+	hbc->add_child(create_group);
+
+	tree = memnew(Tree);
+	tree->set_hide_root(true);
+	tree->set_select_mode(Tree::SELECT_MULTI);
+	tree->set_allow_reselect(true);
+
+	tree->set_drag_forwarding(this);
+
+	tree->set_columns(3);
+	tree->set_column_titles_visible(true);
+
+	tree->set_column_title(0, TTR("Name"));
+	tree->set_column_expand(0, true);
+	tree->set_column_min_width(0, 100);
+
+	tree->set_column_title(1, TTR("Description"));
+	tree->set_column_expand(1, true);
+	tree->set_column_min_width(1, 100);
+
+	tree->set_column_expand(2, false);
+	tree->set_column_min_width(2, 1 * 40 * EDSCALE);
+
+	tree->connect("item_edited", this, "_item_edited");
+	tree->connect("cell_selected", this, "_item_selected");
+	tree->connect("item_activated", this, "_item_activated");
+	tree->connect("button_pressed", this, "_item_button_pressed");
+	tree->set_v_size_flags(SIZE_EXPAND_FILL);
+
+	add_child(tree, true);
+}
+
+EditorGroupSettings::~EditorGroupSettings() {
+}

--- a/editor/editor_group_settings.h
+++ b/editor/editor_group_settings.h
@@ -1,0 +1,132 @@
+/*************************************************************************/
+/*  editor_group_settings.h                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef EDITOR_GROUP_SETTINGS_H
+#define EDITOR_GROUP_SETTINGS_H
+
+#include "core/ordered_hash_map.h"
+#include "core/os/file_access.h"
+#include "core/ustring.h"
+#include "scene/gui/tree.h"
+
+#include "editor_file_dialog.h"
+#include "editor_file_system.h"
+
+class EditorGroupSettings : public VBoxContainer {
+
+	GDCLASS(EditorGroupSettings, VBoxContainer);
+
+	enum {
+		BUTTON_MOVE_UP,
+		BUTTON_MOVE_DOWN,
+		BUTTON_DELETE
+	};
+
+	String group_changed;
+
+	struct GroupInfo {
+		String name;
+		String description;
+		int order;
+
+		bool operator==(const GroupInfo &p_info) {
+			return order == p_info.order;
+		}
+
+		GroupInfo() {
+		}
+	};
+
+	struct StringComparator {
+
+		bool operator()(const String &g_a, const String &g_b) const {
+
+			return is_str_less(g_a.ptr(), g_b.ptr());
+		}
+	};
+
+	Vector<String> names;
+	HashMap<String, GroupInfo> group_cache;
+
+	bool updating_group;
+	String selected_group;
+
+	Tree *tree;
+	LineEdit *create_group_name;
+	LineEdit *create_group_description;
+
+	ConfirmationDialog *remove_confirmation;
+
+	bool _group_exists(const String &p_name);
+	bool _group_name_is_valid(const String &p_name, String *r_error = NULL);
+
+	void _item_edited();
+	void _item_selected();
+	void _item_activated();
+	void _item_button_pressed(Object *p_item, int p_column, int p_button);
+
+	void _create_button_pressed();
+	void _confirm_delete();
+
+	void _remove_node_references(Node *p_node, const String &p_name);
+	void _rename_node_references(Node *p_node, const String &p_old_name, const String &p_new_name);
+
+	void _get_node(const String &p_name);
+	void _get_all_scenes(EditorFileSystemDirectory *p_dir, Set<String> &r_list);
+
+	void _create_group(const String &p_name, const String &p_description);
+	void _delete_group(const String &p_name);
+	void _rename_group(const String &p_old_name, const String &p_new_name);
+	void _set_description(const String &p_name, const String &p_description);
+
+	void _remove_references(const String &p_name);
+	void _rename_references(const String &p_old_name, const String &p_new_name);
+
+	void _init_groups();
+	void _save_groups();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void update_tree();
+
+	void create_group(const String &p_name, const String &p_description);
+	void delete_group(const String &p_name);
+	void rename_group(const String &p_old_name, const String &p_new_name);
+
+	void get_groups(List<String> *current_groups);
+
+	EditorGroupSettings();
+	~EditorGroupSettings();
+};
+
+#endif

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -298,6 +298,16 @@ void EditorPlugin::remove_custom_type(const String &p_type) {
 	EditorNode::get_editor_data().remove_custom_type(p_type);
 }
 
+void EditorPlugin::create_group(const String &p_name, const String &d_description) {
+
+	ProjectSettingsEditor::get_singleton()->get_group_settings()->create_group(p_name, d_description);
+}
+
+void EditorPlugin::delete_group(const String &p_name) {
+
+	ProjectSettingsEditor::get_singleton()->get_group_settings()->delete_group(p_name);
+}
+
 void EditorPlugin::add_autoload_singleton(const String &p_name, const String &p_path) {
 	EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_add(p_name, p_path);
 }
@@ -757,6 +767,9 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_tool_menu_item", "name"), &EditorPlugin::remove_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("add_custom_type", "type", "base", "script", "icon"), &EditorPlugin::add_custom_type);
 	ClassDB::bind_method(D_METHOD("remove_custom_type", "type"), &EditorPlugin::remove_custom_type);
+
+	ClassDB::bind_method(D_METHOD("create_group", "name", "description"), &EditorPlugin::create_group);
+	ClassDB::bind_method(D_METHOD("delete_group", "name"), &EditorPlugin::delete_group);
 
 	ClassDB::bind_method(D_METHOD("add_autoload_singleton", "name", "path"), &EditorPlugin::add_autoload_singleton);
 	ClassDB::bind_method(D_METHOD("remove_autoload_singleton", "name"), &EditorPlugin::remove_autoload_singleton);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -120,6 +120,9 @@ protected:
 	static void _bind_methods();
 	UndoRedo &get_undo_redo() { return *undo_redo; }
 
+	void create_group(const String &p_name, const String &d_description);
+	void delete_group(const String &p_name);
+
 	void add_custom_type(const String &p_type, const String &p_base, const Ref<Script> &p_script, const Ref<Texture> &p_icon);
 	void remove_custom_type(const String &p_type);
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -29,436 +29,20 @@
 /*************************************************************************/
 
 #include "groups_editor.h"
+
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
 #include "editor/scene_tree_editor.h"
-#include "editor_node.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
 #include "scene/resources/packed_scene.h"
 
-void GroupDialog::ok_pressed() {
-}
-
-void GroupDialog::_cancel_pressed() {
-}
-
-void GroupDialog::_group_selected() {
-	nodes_to_add->clear();
-	add_node_root = nodes_to_add->create_item();
-
-	nodes_to_remove->clear();
-	remove_node_root = nodes_to_remove->create_item();
-
-	if (!groups->is_anything_selected()) {
-		return;
-	}
-
-	selected_group = groups->get_selected()->get_text(0);
-	_load_nodes(scene_tree->get_edited_scene_root());
-}
-
-void GroupDialog::_load_nodes(Node *p_current) {
-	String item_name = p_current->get_name();
-	if (p_current != scene_tree->get_edited_scene_root()) {
-		item_name = String(p_current->get_parent()->get_name()) + "/" + String(item_name);
-	}
-
-	bool keep = true;
-	Node *root = scene_tree->get_edited_scene_root();
-	Node *owner = p_current->get_owner();
-	if (owner != root && p_current != root && !owner && !root->is_editable_instance(owner)) {
-		keep = false;
-	}
-
-	TreeItem *node;
-	NodePath path = scene_tree->get_edited_scene_root()->get_path_to(p_current);
-	if (keep && p_current->is_in_group(selected_group)) {
-		if (remove_filter->get_text().is_subsequence_ofi(String(p_current->get_name()))) {
-			node = nodes_to_remove->create_item(remove_node_root);
-			keep = true;
-		} else {
-			keep = false;
-		}
-	} else if (keep && add_filter->get_text().is_subsequence_ofi(String(p_current->get_name()))) {
-		node = nodes_to_add->create_item(add_node_root);
-		keep = true;
-	} else {
-		keep = false;
-	}
-
-	if (keep) {
-		node->set_text(0, item_name);
-		node->set_metadata(0, path);
-		node->set_tooltip(0, path);
-
-		Ref<Texture> icon = EditorNode::get_singleton()->get_object_icon(p_current, "Node");
-		node->set_icon(0, icon);
-
-		if (!_can_edit(p_current, selected_group)) {
-			node->set_selectable(0, false);
-			node->set_custom_color(0, get_color("disabled_font_color", "Editor"));
-		}
-	}
-
-	for (int i = 0; i < p_current->get_child_count(); i++) {
-		_load_nodes(p_current->get_child(i));
-	}
-}
-
-bool GroupDialog::_can_edit(Node *p_node, String p_group) {
-	Node *n = p_node;
-	bool can_edit = true;
-	while (n) {
-		Ref<SceneState> ss = (n == EditorNode::get_singleton()->get_edited_scene()) ? n->get_scene_inherited_state() : n->get_scene_instance_state();
-		if (ss.is_valid()) {
-			int path = ss->find_node_by_path(n->get_path_to(p_node));
-			if (path != -1) {
-				if (ss->is_node_in_group(path, p_group)) {
-					can_edit = false;
-				}
-			}
-		}
-		n = n->get_owner();
-	}
-	return can_edit;
-}
-
-void GroupDialog::_add_pressed() {
-	TreeItem *selected = nodes_to_add->get_selected();
-
-	if (!selected) {
-		return;
-	}
-
-	while (selected) {
-		Node *node = scene_tree->get_edited_scene_root()->get_node(selected->get_metadata(0));
-		node->add_to_group(selected_group, true);
-
-		selected = nodes_to_add->get_next_selected(selected);
-	}
-
-	_group_selected();
-	EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->update_tree();
-}
-
-void GroupDialog::_removed_pressed() {
-	TreeItem *selected = nodes_to_remove->get_selected();
-
-	if (!selected) {
-		return;
-	}
-
-	while (selected) {
-		Node *node = scene_tree->get_edited_scene_root()->get_node(selected->get_metadata(0));
-		node->remove_from_group(selected_group);
-
-		selected = nodes_to_add->get_next_selected(selected);
-	}
-
-	_group_selected();
-	EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->update_tree();
-}
-
-void GroupDialog::_remove_filter_changed(const String &p_filter) {
-	_group_selected();
-}
-
-void GroupDialog::_add_filter_changed(const String &p_filter) {
-	_group_selected();
-}
-
-void GroupDialog::_add_group_pressed() {
-	_add_group(add_group_text->get_text());
-	add_group_text->clear();
-}
-
-void GroupDialog::_group_renamed() {
-	TreeItem *renamed_group = groups->get_edited();
-	if (!renamed_group) {
-		return;
-	}
-
-	String name = renamed_group->get_text(0).strip_edges();
-	for (TreeItem *E = groups_root->get_children(); E; E = E->get_next()) {
-		if (E != renamed_group && E->get_text(0) == name) {
-			renamed_group->set_text(0, selected_group);
-			error->set_text(TTR("Group name already exists."));
-			error->popup_centered();
-			return;
-		}
-	}
-
-	if (name == "") {
-		renamed_group->set_text(0, selected_group);
-		error->set_text(TTR("Invalid group name."));
-		error->popup_centered();
-		return;
-	}
-
-	List<Node *> nodes;
-	scene_tree->get_nodes_in_group(selected_group, &nodes);
-	bool removed_all = true;
-	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
-		Node *node = E->get();
-		if (_can_edit(node, selected_group)) {
-			node->remove_from_group(selected_group);
-			node->add_to_group(name, true);
-		} else {
-			removed_all = false;
-		}
-	}
-
-	if (!removed_all) {
-		_add_group(selected_group);
-	}
-
-	selected_group = renamed_group->get_text(0);
-	_group_selected();
-}
-
-void GroupDialog::_add_group(String p_name) {
-
-	String name = p_name.strip_edges();
-	if (name == "" || groups->search_item_text(name)) {
-		return;
-	}
-
-	TreeItem *new_group = groups->create_item(groups_root);
-	new_group->set_text(0, name);
-	new_group->add_button(0, get_icon("Remove", "EditorIcons"), 0);
-	new_group->set_editable(0, true);
-}
-
-void GroupDialog::_load_groups(Node *p_current) {
-	List<Node::GroupInfo> gi;
-	p_current->get_groups(&gi);
-
-	for (List<Node::GroupInfo>::Element *E = gi.front(); E; E = E->next()) {
-		if (!E->get().persistent) {
-			continue;
-		}
-		_add_group(E->get().name);
-	}
-
-	for (int i = 0; i < p_current->get_child_count(); i++) {
-		_load_groups(p_current->get_child(i));
-	}
-}
-
-void GroupDialog::_delete_group_pressed(Object *p_item, int p_column, int p_id) {
-	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
-	if (!ti)
-		return;
-
-	String name = ti->get_text(0);
-
-	List<Node *> nodes;
-	scene_tree->get_nodes_in_group(name, &nodes);
-	bool removed_all = true;
-	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
-		if (_can_edit(E->get(), name)) {
-			E->get()->remove_from_group(name);
-		} else {
-			removed_all = false;
-		}
-	}
-
-	if (removed_all) {
-		if (selected_group == name) {
-			add_filter->clear();
-			remove_filter->clear();
-			nodes_to_remove->clear();
-			nodes_to_add->clear();
-			groups->deselect_all();
-			selected_group = "";
-		}
-		groups_root->remove_child(ti);
-	}
-	EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->update_tree();
-}
-
-void GroupDialog::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			add_button->set_icon(get_icon("Forward", "EditorIcons"));
-			remove_button->set_icon(get_icon("Back", "EditorIcons"));
-
-			add_filter->set_right_icon(get_icon("Search", "EditorIcons"));
-			add_filter->set_clear_button_enabled(true);
-			remove_filter->set_right_icon(get_icon("Search", "EditorIcons"));
-			remove_filter->set_clear_button_enabled(true);
-		} break;
-	}
-}
-
-void GroupDialog::edit() {
-
-	popup_centered(Size2(600, 400));
-
-	groups->clear();
-	groups_root = groups->create_item();
-
-	nodes_to_add->clear();
-	nodes_to_remove->clear();
-
-	add_group_text->clear();
-	add_filter->clear();
-	remove_filter->clear();
-
-	_load_groups(scene_tree->get_edited_scene_root());
-}
-
-void GroupDialog::_bind_methods() {
-	ClassDB::bind_method("_cancel", &GroupDialog::_cancel_pressed);
-
-	ClassDB::bind_method("_add_pressed", &GroupDialog::_add_pressed);
-	ClassDB::bind_method("_removed_pressed", &GroupDialog::_removed_pressed);
-	ClassDB::bind_method("_delete_group_pressed", &GroupDialog::_delete_group_pressed);
-
-	ClassDB::bind_method("_group_selected", &GroupDialog::_group_selected);
-	ClassDB::bind_method("_add_group_pressed", &GroupDialog::_add_group_pressed);
-
-	ClassDB::bind_method("_add_filter_changed", &GroupDialog::_add_filter_changed);
-	ClassDB::bind_method("_remove_filter_changed", &GroupDialog::_remove_filter_changed);
-
-	ClassDB::bind_method("_group_renamed", &GroupDialog::_group_renamed);
-}
-
-GroupDialog::GroupDialog() {
-
-	scene_tree = SceneTree::get_singleton();
-
-	VBoxContainer *vbc = memnew(VBoxContainer);
-	add_child(vbc);
-
-	HBoxContainer *hbc = memnew(HBoxContainer);
-	vbc->add_child(hbc);
-	hbc->set_v_size_flags(SIZE_EXPAND_FILL);
-
-	VBoxContainer *vbc_left = memnew(VBoxContainer);
-	hbc->add_child(vbc_left);
-	vbc_left->set_h_size_flags(SIZE_EXPAND_FILL);
-
-	Label *group_title = memnew(Label);
-	group_title->set_text(TTR("Groups"));
-	vbc_left->add_child(group_title);
-
-	groups = memnew(Tree);
-	vbc_left->add_child(groups);
-	groups->set_hide_root(true);
-	groups->set_v_size_flags(SIZE_EXPAND_FILL);
-	groups->set_select_mode(Tree::SELECT_SINGLE);
-	groups->set_allow_reselect(true);
-	groups->set_allow_rmb_select(true);
-	groups->connect("item_selected", this, "_group_selected");
-	groups->connect("button_pressed", this, "_delete_group_pressed");
-	groups->connect("item_edited", this, "_group_renamed");
-
-	HBoxContainer *chbc = memnew(HBoxContainer);
-	vbc_left->add_child(chbc);
-	chbc->set_h_size_flags(SIZE_EXPAND_FILL);
-
-	add_group_text = memnew(LineEdit);
-	chbc->add_child(add_group_text);
-	add_group_text->set_h_size_flags(SIZE_EXPAND_FILL);
-
-	Button *add_group_button = memnew(Button);
-	add_group_button->set_text("Add");
-	chbc->add_child(add_group_button);
-	add_group_button->connect("pressed", this, "_add_group_pressed");
-
-	VBoxContainer *vbc_add = memnew(VBoxContainer);
-	hbc->add_child(vbc_add);
-	vbc_add->set_h_size_flags(SIZE_EXPAND_FILL);
-
-	Label *out_of_group_title = memnew(Label);
-	out_of_group_title->set_text(TTR("Nodes not in Group"));
-	vbc_add->add_child(out_of_group_title);
-
-	nodes_to_add = memnew(Tree);
-	vbc_add->add_child(nodes_to_add);
-	nodes_to_add->set_hide_root(true);
-	nodes_to_add->set_hide_folding(true);
-	nodes_to_add->set_v_size_flags(SIZE_EXPAND_FILL);
-	nodes_to_add->set_select_mode(Tree::SELECT_MULTI);
-	nodes_to_add->connect("item_selected", this, "_nodes_to_add_selected");
-
-	HBoxContainer *add_filter_hbc = memnew(HBoxContainer);
-	add_filter_hbc->add_constant_override("separate", 0);
-	vbc_add->add_child(add_filter_hbc);
-
-	add_filter = memnew(LineEdit);
-	add_filter->set_h_size_flags(SIZE_EXPAND_FILL);
-	add_filter->set_placeholder(TTR("Filter nodes"));
-	add_filter_hbc->add_child(add_filter);
-	add_filter->connect("text_changed", this, "_add_filter_changed");
-
-	VBoxContainer *vbc_buttons = memnew(VBoxContainer);
-	hbc->add_child(vbc_buttons);
-	vbc_buttons->set_h_size_flags(SIZE_SHRINK_CENTER);
-	vbc_buttons->set_v_size_flags(SIZE_SHRINK_CENTER);
-
-	add_button = memnew(ToolButton);
-	add_button->set_text(TTR("Add"));
-	add_button->connect("pressed", this, "_add_pressed");
-
-	vbc_buttons->add_child(add_button);
-	vbc_buttons->add_spacer();
-	vbc_buttons->add_spacer();
-	vbc_buttons->add_spacer();
-
-	remove_button = memnew(ToolButton);
-	remove_button->set_text(TTR("Remove"));
-	remove_button->connect("pressed", this, "_removed_pressed");
-
-	vbc_buttons->add_child(remove_button);
-
-	VBoxContainer *vbc_remove = memnew(VBoxContainer);
-	hbc->add_child(vbc_remove);
-	vbc_remove->set_h_size_flags(SIZE_EXPAND_FILL);
-
-	Label *in_group_title = memnew(Label);
-	in_group_title->set_text(TTR("Nodes in Group"));
-	vbc_remove->add_child(in_group_title);
-
-	nodes_to_remove = memnew(Tree);
-	vbc_remove->add_child(nodes_to_remove);
-	nodes_to_remove->set_v_size_flags(SIZE_EXPAND_FILL);
-	nodes_to_remove->set_hide_root(true);
-	nodes_to_remove->set_hide_folding(true);
-	nodes_to_remove->set_select_mode(Tree::SELECT_MULTI);
-	nodes_to_remove->connect("item_selected", this, "_node_to_remove_selected");
-
-	HBoxContainer *remove_filter_hbc = memnew(HBoxContainer);
-	remove_filter_hbc->add_constant_override("separate", 0);
-	vbc_remove->add_child(remove_filter_hbc);
-
-	remove_filter = memnew(LineEdit);
-	remove_filter->set_h_size_flags(SIZE_EXPAND_FILL);
-	remove_filter->set_placeholder(TTR("Filter nodes"));
-	remove_filter_hbc->add_child(remove_filter);
-	remove_filter->connect("text_changed", this, "_remove_filter_changed");
-
-	set_title("Group Editor");
-	get_cancel()->hide();
-	set_as_toplevel(true);
-	set_resizable(true);
-
-	error = memnew(ConfirmationDialog);
-	add_child(error);
-	error->get_ok()->set_text(TTR("Close"));
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-void GroupsEditor::_add_group(const String &p_group) {
+void GroupsEditor::_add_to_group(const String &p_group) {
 
 	if (!node)
 		return;
 
-	String name = group_name->get_text();
-	if (name.strip_edges() == "")
-		return;
-
+	String name = p_group;
 	if (node->is_in_group(name))
 		return;
 
@@ -468,24 +52,18 @@ void GroupsEditor::_add_group(const String &p_group) {
 	undo_redo->add_do_method(this, "update_tree");
 	undo_redo->add_undo_method(node, "remove_from_group", name);
 	undo_redo->add_undo_method(this, "update_tree");
+
 	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); //to force redraw of scene tree
 	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); //to force redraw of scene tree
 
 	undo_redo->commit_action();
-
-	group_name->clear();
 }
 
-void GroupsEditor::_remove_group(Object *p_item, int p_column, int p_id) {
+void GroupsEditor::_remove_from_group(const String &p_group) {
 
 	if (!node)
 		return;
-
-	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
-	if (!ti)
-		return;
-
-	String name = ti->get_text(0);
+	String name = p_group;
 
 	undo_redo->create_action(TTR("Remove from Group"));
 
@@ -493,66 +71,80 @@ void GroupsEditor::_remove_group(Object *p_item, int p_column, int p_id) {
 	undo_redo->add_do_method(this, "update_tree");
 	undo_redo->add_undo_method(node, "add_to_group", name, true);
 	undo_redo->add_undo_method(this, "update_tree");
+
 	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); //to force redraw of scene tree
 	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); //to force redraw of scene tree
 
 	undo_redo->commit_action();
 }
 
-struct _GroupInfoComparator {
+void GroupsEditor::_group_toggled() {
+	if (updating_group)
+		return;
 
-	bool operator()(const Node::GroupInfo &p_a, const Node::GroupInfo &p_b) const {
-		return p_a.name.operator String() < p_b.name.operator String();
+	TreeItem *ti = tree->get_edited();
+	int column = tree->get_edited_column();
+
+	if (column == 0) {
+		updating_group = true;
+
+		bool checked = ti->is_checked(0);
+		String group_name = ti->get_text(0);
+
+		if (checked) {
+			_add_to_group(group_name);
+		} else {
+			_remove_from_group(group_name);
+		}
 	}
-};
+
+	updating_group = false;
+}
+
+void GroupsEditor::_manage_groups() {
+	EditorNode::get_singleton()->get_project_settings()->set_groups_page();
+	EditorNode::get_singleton()->get_project_settings()->popup_project_settings();
+}
 
 void GroupsEditor::update_tree() {
-
-	tree->clear();
 
 	if (!node)
 		return;
 
-	List<Node::GroupInfo> groups;
-	node->get_groups(&groups);
-	groups.sort_custom<_GroupInfoComparator>();
+	if (updating_group)
+		return;
+
+	updating_group = true;
+
+	tree->clear();
+
+	List<Node::GroupInfo> current_groups;
+	node->get_groups(&current_groups);
+
+	List<String> current_groups_names;
+	for (List<GroupInfo>::Element *E = current_groups.front(); E; E = E->next()) {
+
+		Node::GroupInfo gi = E->get();
+		current_groups_names.push_back(gi.name);
+	}
 
 	TreeItem *root = tree->create_item();
 
-	for (List<GroupInfo>::Element *E = groups.front(); E; E = E->next()) {
+	List<String> group_names;
+	ProjectSettingsEditor::get_singleton()->get_group_settings()->get_groups(&group_names);
 
-		Node::GroupInfo gi = E->get();
-		if (!gi.persistent)
-			continue;
+	for (List<String>::Element *E = group_names.front(); E; E = E->next()) {
 
-		Node *n = node;
-		bool can_be_deleted = true;
-
-		while (n) {
-
-			Ref<SceneState> ss = (n == EditorNode::get_singleton()->get_edited_scene()) ? n->get_scene_inherited_state() : n->get_scene_instance_state();
-
-			if (ss.is_valid()) {
-
-				int path = ss->find_node_by_path(n->get_path_to(node));
-				if (path != -1) {
-					if (ss->is_node_in_group(path, gi.name)) {
-						can_be_deleted = false;
-					}
-				}
-			}
-
-			n = n->get_owner();
-		}
+		String name = E->get();
 
 		TreeItem *item = tree->create_item(root);
-		item->set_text(0, gi.name);
-		if (can_be_deleted) {
-			item->add_button(0, get_icon("Remove", "EditorIcons"), 0);
-		} else {
-			item->set_selectable(0, false);
-		}
+		item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+		item->set_editable(0, true);
+		item->set_checked(0, current_groups_names.find(name) != NULL);
+		item->set_text(0, name);
 	}
+
+	updating_group = false;
 }
 
 void GroupsEditor::set_current(Node *p_node) {
@@ -561,59 +153,35 @@ void GroupsEditor::set_current(Node *p_node) {
 	update_tree();
 }
 
-void GroupsEditor::_show_group_dialog() {
-	group_dialog->edit();
-}
-
-void GroupsEditor::_group_dialog_closed() {
-	update_tree();
-}
-
 void GroupsEditor::_bind_methods() {
 
-	ClassDB::bind_method("_add_group", &GroupsEditor::_add_group);
-	ClassDB::bind_method("_remove_group", &GroupsEditor::_remove_group);
-	ClassDB::bind_method("update_tree", &GroupsEditor::update_tree);
+	ClassDB::bind_method("_add_to_group", &GroupsEditor::_add_to_group);
+	ClassDB::bind_method("_remove_from_group", &GroupsEditor::_remove_from_group);
 
-	ClassDB::bind_method("_show_group_dialog", &GroupsEditor::_show_group_dialog);
-	ClassDB::bind_method("_group_dialog_closed", &GroupsEditor::_group_dialog_closed);
+	ClassDB::bind_method("update_tree", &GroupsEditor::update_tree);
 }
 
 GroupsEditor::GroupsEditor() {
 
 	node = NULL;
-
-	VBoxContainer *vbc = this;
-
-	group_dialog = memnew(GroupDialog);
-	group_dialog->set_as_toplevel(true);
-	add_child(group_dialog);
-	group_dialog->connect("popup_hide", this, "_group_dialog_closed");
+	updating_group = false;
 
 	Button *group_dialog_button = memnew(Button);
 	group_dialog_button->set_text(TTR("Manage Groups"));
-	vbc->add_child(group_dialog_button);
-	group_dialog_button->connect("pressed", this, "_show_group_dialog");
+	add_child(group_dialog_button);
+	group_dialog_button->connect("pressed", this, "_manage_groups");
 
-	HBoxContainer *hbc = memnew(HBoxContainer);
-	vbc->add_child(hbc);
-
-	group_name = memnew(LineEdit);
-	group_name->set_h_size_flags(SIZE_EXPAND_FILL);
-	hbc->add_child(group_name);
-	group_name->connect("text_entered", this, "_add_group");
-
-	add = memnew(Button);
-	add->set_text(TTR("Add"));
-	hbc->add_child(add);
-	add->connect("pressed", this, "_add_group", varray(String()));
+	add_constant_override("separation", 3 * EDSCALE);
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
+	tree->set_column_titles_visible(false);
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
-	vbc->add_child(tree);
-	tree->connect("button_pressed", this, "_remove_group");
-	add_constant_override("separation", 3 * EDSCALE);
+
+	tree->connect("item_edited", this, "_group_toggled");
+	add_child(tree);
+
+	ProjectSettingsEditor::get_singleton()->get_group_settings()->connect("group_changed", this, "update_tree");
 }
 
 GroupsEditor::~GroupsEditor() {

--- a/editor/groups_editor.h
+++ b/editor/groups_editor.h
@@ -45,84 +45,23 @@
 @author Juan Linietsky <reduzio@gmail.com>
 */
 
-class GroupDialog : public ConfirmationDialog {
-
-	GDCLASS(GroupDialog, ConfirmationDialog);
-
-	ConfirmationDialog *error;
-
-	SceneTree *scene_tree;
-	TreeItem *groups_root;
-
-	LineEdit *add_group_text;
-
-	Tree *groups;
-
-	Tree *nodes_to_add;
-	TreeItem *add_node_root;
-	LineEdit *add_filter;
-
-	Tree *nodes_to_remove;
-	TreeItem *remove_node_root;
-	LineEdit *remove_filter;
-
-	ToolButton *add_button;
-	ToolButton *remove_button;
-
-	String selected_group;
-
-	void ok_pressed();
-	void _cancel_pressed();
-	void _group_selected();
-
-	void _remove_filter_changed(const String &p_filter);
-	void _add_filter_changed(const String &p_filter);
-
-	void _add_pressed();
-	void _removed_pressed();
-	void _add_group_pressed();
-
-	void _group_renamed();
-
-	void _add_group(String p_name);
-	void _delete_group_pressed(Object *p_item, int p_column, int p_id);
-
-	bool _can_edit(Node *p_node, String p_group);
-
-	void _load_groups(Node *p_current);
-	void _load_nodes(Node *p_current);
-
-protected:
-	void _notification(int p_what);
-	static void _bind_methods();
-
-public:
-	void edit();
-
-	GroupDialog();
-};
-
 class GroupsEditor : public VBoxContainer {
 
 	GDCLASS(GroupsEditor, VBoxContainer);
 
+	bool updating_group;
+
 	Node *node;
-
-	GroupDialog *group_dialog;
-
-	LineEdit *group_name;
-	Button *add;
 	Tree *tree;
-
 	UndoRedo *undo_redo;
 
 	void update_tree();
-	void _add_group(const String &p_group = "");
-	void _remove_group(Object *p_item, int p_column, int p_id);
-	void _close();
 
-	void _show_group_dialog();
-	void _group_dialog_closed();
+	void _add_to_group(const String &p_group);
+	void _remove_from_group(const String &p_group);
+
+	void _manage_groups();
+	void _group_toggled();
 
 protected:
 	static void _bind_methods();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -294,7 +294,8 @@ void ProjectSettingsEditor::_device_input_add() {
 			ie = jb;
 
 		} break;
-		default: {}
+		default: {
+		}
 	}
 
 	if (idx < 0 || idx >= events.size()) {
@@ -519,7 +520,8 @@ void ProjectSettingsEditor::_add_item(int p_item, Ref<InputEvent> p_exiting_even
 			}
 
 		} break;
-		default: {}
+		default: {
+		}
 	}
 }
 
@@ -1600,6 +1602,11 @@ void ProjectSettingsEditor::set_plugins_page() {
 	tab_container->set_current_tab(plugin_settings->get_index());
 }
 
+void ProjectSettingsEditor::set_groups_page() {
+
+	tab_container->set_current_tab(group_settings->get_index());
+}
+
 TabContainer *ProjectSettingsEditor::get_tabs() {
 
 	return tab_container;
@@ -2018,6 +2025,11 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	autoload_settings->set_name(TTR("AutoLoad"));
 	tab_container->add_child(autoload_settings);
 	autoload_settings->connect("autoload_changed", this, "_settings_changed");
+
+	group_settings = memnew(EditorGroupSettings);
+	group_settings->set_name(TTR("Groups"));
+	tab_container->add_child(group_settings);
+	group_settings->connect("group_changed", this, "_settings_changed");
 
 	plugin_settings = memnew(EditorPluginSettings);
 	plugin_settings->set_name(TTR("Plugins"));

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -34,6 +34,7 @@
 #include "core/undo_redo.h"
 #include "editor/editor_autoload_settings.h"
 #include "editor/editor_data.h"
+#include "editor/editor_group_settings.h"
 #include "editor/editor_plugin_settings.h"
 #include "editor/editor_sectioned_inspector.h"
 #include "scene/gui/dialogs.h"
@@ -109,51 +110,82 @@ class ProjectSettingsEditor : public AcceptDialog {
 
 	EditorAutoloadSettings *autoload_settings;
 
+	EditorGroupSettings *group_settings;
+
 	EditorPluginSettings *plugin_settings;
 
 	void _item_selected(const String &);
+
 	void _item_adds(String);
+
 	void _item_add();
+
 	void _item_del();
+
 	void _update_actions();
+
 	void _save();
+
 	void _add_item(int p_item, Ref<InputEvent> p_exiting_event = NULL);
+
 	void _edit_item(Ref<InputEvent> p_exiting_event);
 
 	void _action_check(String p_action);
+
 	void _action_adds(String);
+
 	void _action_add();
+
 	void _device_input_add();
 
 	void _item_checked(const String &p_item, bool p_check);
+
 	void _action_selected();
+
 	void _action_edited();
+
 	void _action_activated();
+
 	void _action_button_pressed(Object *p_obj, int p_column, int p_id);
+
 	void _wait_for_key(const Ref<InputEvent> &p_event);
+
 	void _press_a_key_confirm();
+
 	void _show_last_added(const Ref<InputEvent> &p_event, const String &p_name);
 
 	void _settings_prop_edited(const String &p_name);
+
 	void _settings_changed();
 
 	void _copy_to_platform(int p_which);
 
 	void _translation_file_open();
+
 	void _translation_add(const String &p_path);
+
 	void _translation_delete(Object *p_item, int p_column, int p_button);
+
 	void _update_translations();
 
 	void _translation_res_file_open();
+
 	void _translation_res_add(const String &p_path);
+
 	void _translation_res_delete(Object *p_item, int p_column, int p_button);
+
 	void _translation_res_select();
+
 	void _translation_res_option_file_open();
+
 	void _translation_res_option_add(const String &p_path);
+
 	void _translation_res_option_changed();
+
 	void _translation_res_option_delete(Object *p_item, int p_column, int p_button);
 
 	void _translation_filter_option_changed();
+
 	void _translation_filter_mode_changed(int p_mode);
 
 	void _toggle_search_bar(bool p_pressed);
@@ -170,25 +202,37 @@ class ProjectSettingsEditor : public AcceptDialog {
 	ToolButton *restart_close_button;
 
 	void _editor_restart_request();
+
 	void _editor_restart();
+
 	void _editor_restart_close();
 
 protected:
 	void _notification(int p_what);
+
 	static void _bind_methods();
 
 	int _get_current_device();
+
 	void _set_current_device(int i_device);
+
 	String _get_device_string(int i_device);
 
 public:
 	void add_translation(const String &p_translation);
+
 	static ProjectSettingsEditor *get_singleton() { return singleton; }
+
 	void popup_project_settings();
+
 	void set_plugins_page();
+
+	void set_groups_page();
+
 	void update_plugins();
 
 	EditorAutoloadSettings *get_autoload_settings() { return autoload_settings; }
+	EditorGroupSettings *get_group_settings() { return group_settings; }
 
 	TabContainer *get_tabs();
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2615,7 +2615,26 @@ void Node::get_argument_options(const StringName &p_function, int p_idx, List<St
 	if ((pf == "has_node" || pf == "get_node") && p_idx == 0) {
 
 		_add_nodes_to_options(this, this, r_options);
+	} else if ((pf == "add_to_group" || pf == "remove_from_group" || pf == "is_in_group") && p_idx == 0) {
+
+		List<PropertyInfo> props;
+		ProjectSettings::get_singleton()->get_property_list(&props);
+		for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
+
+			const PropertyInfo &pi = E->get();
+
+			if (!pi.name.begins_with("groups/"))
+				continue;
+
+			String name = pi.name.get_slice("/", 1);
+
+			if (name.empty())
+				continue;
+
+			r_options->push_back(name);
+		}
 	}
+
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1611,6 +1611,36 @@ void SceneState::add_editable_instance(const NodePath &p_path) {
 	editable_instances.push_back(p_path);
 }
 
+bool SceneState::remove_group_references(const StringName &p_name) {
+
+	bool edited = false;
+	for (int node_idx = 0; node_idx < get_node_count(); node_idx++) {
+		for (int group_idx = 0; group_idx < nodes[node_idx].groups.size(); group_idx++) {
+			if (names[nodes[node_idx].groups[group_idx]] == p_name) {
+				nodes.write[node_idx].groups.remove(group_idx);
+				edited = true;
+				break;
+			}
+		}
+	}
+	return edited;
+}
+
+bool SceneState::rename_group_references(const StringName &p_old_name, const StringName &p_new_name) {
+
+	bool edited = false;
+	for (int node_idx = 0; node_idx < get_node_count(); node_idx++) {
+		for (int group_idx = 0; group_idx < nodes[node_idx].groups.size(); group_idx++) {
+			if (names[nodes[node_idx].groups[group_idx]] == p_old_name) {
+				names.set(nodes[node_idx].groups[group_idx], p_new_name);
+				edited = true;
+				break;
+			}
+		}
+	}
+	return edited;
+}
+
 PoolVector<String> SceneState::_get_node_groups(int p_idx) const {
 
 	Vector<StringName> groups = get_node_groups(p_idx);

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -186,6 +186,9 @@ public:
 	void add_connection(int p_from, int p_to, int p_signal, int p_method, int p_flags, const Vector<int> &p_binds);
 	void add_editable_instance(const NodePath &p_path);
 
+	bool remove_group_references(const StringName &p_name);
+	bool rename_group_references(const StringName &p_old_name, const StringName &p_new_name);
+
 	virtual void set_last_modified_time(uint64_t p_time) { last_modified_time = p_time; }
 	uint64_t get_last_modified_time() const { return last_modified_time; }
 


### PR DESCRIPTION
This PR implements global groups as requested by #5744 taking into consideration #18861 and #20416.

The system ended up to look like the mockups in #20416

In the project settings under "Groups" it is possible to:
- create groups (name and description)
- delete groups (this will also remove references to that group in every node in every scene)
- rename groups (this will change the name and fix group references on every node in every scene)
- edit groups description
- groups are auto ordered alphabetically
- You have a confirm notification upon deleting a group

<img width="892" alt="captura de ecra 2018-12-14 as 11 28 28" src="https://user-images.githubusercontent.com/10358443/50001020-6d126e80-ff93-11e8-860a-af64c3af84b5.png">

<img width="639" alt="captura de ecra 2018-12-15 as 19 18 53" src="https://user-images.githubusercontent.com/10358443/50046644-67ee1600-009e-11e9-8b66-50cdcb0c473c.png">

In node groups editor dock it is possible to:
- add node to existent group (checkbox)
- remove node from group (checkbox)
- call the group manager (opens the project settings "Groups" tab)

<img width="373" alt="captura de ecra 2018-12-10 as 15 15 15" src="https://user-images.githubusercontent.com/10358443/49743411-8c0eb900-fc92-11e8-9ce6-e0cfd497fc00.png">

In code editor you get:
- autocompletion for "add_to_group", "remove_from_group" and "is_in_group"

In the plugin editor it is now possible to:
- add groups (create_group(name, description));
- remove groups (delete_group(name));

<img width="477" alt="captura de ecra 2018-12-15 as 19 18 06" src="https://user-images.githubusercontent.com/10358443/50046642-573da000-009e-11e9-87f4-29c60caf9521.png">

NEW addition: groups are now saved as an array of dictionaries to allow for adding new groups related features in the future.