### PR TITLE
Fixes docs displaying error if xml has parentheses after brackets

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -280,7 +280,7 @@ def rstize_text(text, cclass):
                 escape_post = True
 
         # Properly escape things like `[Node]s`
-        if escape_post and post_text and post_text[0].isalnum():  # not punctuation, escape
+        if escape_post and post_text and (post_text[0].isalnum() or post_text[0] == "("):  # not punctuation, escape
             post_text = '\ ' + post_text
 
         next_brac_pos = post_text.find('[', 0)


### PR DESCRIPTION
Prevents deformatting of the HTML pages when the original class XML has parenthesis after brackets.

Godot documentation is written in XML files, parsed into RST files by makerst and then turned into HTML files in godot-docs (the godot documentation repository).

By enabling makerst to escape for parenthesis as well, the RST files are generated correctly, making it so that the display in HTML is correct when parenthesis are after brackets.

Fixes Issue godotengine#15009. 