### PR TITLE
Fix "blocked > 0" error when selecting an item in the Search Help dialog

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -130,7 +130,7 @@ void EditorHelpSearch::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_POPUP_HIDE: {
 
-			results_tree->clear();
+			results_tree->call_deferred("clear"); // Wait for the Tree's mouse event propagation.
 			get_ok()->set_disabled(true);
 			EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "search_help", get_rect());
 		} break;


### PR DESCRIPTION
Fixes #24254.

Also sorry @RayKoopa, apparently I am now the official maintainer of this instead of you. :stuck_out_tongue_winking_eye: