### PR TITLE
[2.1] Backport add GZIP compression support

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -31,6 +31,7 @@
 
 #include "core/globals.h"
 #include "geometry.h"
+#include "io/file_access_compressed.h"
 #include "io/file_access_encrypted.h"
 #include "io/marshalls.h"
 #include "os/keyboard.h"
@@ -1827,6 +1828,10 @@ void _File::_bind_methods() {
 	BIND_CONSTANT(WRITE);
 	BIND_CONSTANT(READ_WRITE);
 	BIND_CONSTANT(WRITE_READ);
+
+	BIND_CONSTANT(COMPRESSION_FASTLZ);
+	BIND_CONSTANT(COMPRESSION_DEFLATE);
+	BIND_CONSTANT(COMPRESSION_GZIP);
 }
 
 _File::_File() {

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -30,6 +30,7 @@
 #ifndef CORE_BIND_H
 #define CORE_BIND_H
 
+#include "io/compression.h"
 #include "io/resource_loader.h"
 #include "io/resource_saver.h"
 #include "os/dir_access.h"
@@ -381,6 +382,12 @@ public:
 		WRITE = 2,
 		READ_WRITE = 3,
 		WRITE_READ = 7,
+	};
+
+	enum CompressionMode {
+		COMPRESSION_FASTLZ = Compression::MODE_FASTLZ,
+		COMPRESSION_DEFLATE = Compression::MODE_DEFLATE,
+		COMPRESSION_GZIP = Compression::MODE_GZIP
 	};
 
 	Error open_encrypted(const String &p_path, int p_mode_flags, const Vector<uint8_t> &p_key);

--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -51,13 +51,16 @@ int Compression::compress(uint8_t *p_dst, const uint8_t *p_src, int p_src_size, 
 			}
 
 		} break;
-		case MODE_DEFLATE: {
+		case MODE_DEFLATE:
+		case MODE_GZIP: {
+
+			int window_bits = p_mode == MODE_DEFLATE ? 15 : 15 + 16;
 
 			z_stream strm;
 			strm.zalloc = zipio_alloc;
 			strm.zfree = zipio_free;
 			strm.opaque = Z_NULL;
-			int err = deflateInit(&strm, Z_DEFAULT_COMPRESSION);
+			int err = deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, window_bits, 8, Z_DEFAULT_STRATEGY);
 			if (err != Z_OK)
 				return -1;
 
@@ -88,13 +91,16 @@ int Compression::get_max_compressed_buffer_size(int p_src_size, Mode p_mode) {
 			return ss;
 
 		} break;
-		case MODE_DEFLATE: {
+		case MODE_DEFLATE:
+		case MODE_GZIP: {
+
+			int window_bits = p_mode == MODE_DEFLATE ? 15 : 15 + 16;
 
 			z_stream strm;
 			strm.zalloc = zipio_alloc;
 			strm.zfree = zipio_free;
 			strm.opaque = Z_NULL;
-			int err = deflateInit(&strm, Z_DEFAULT_COMPRESSION);
+			int err = deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, window_bits, 8, Z_DEFAULT_STRATEGY);
 			if (err != Z_OK)
 				return -1;
 			int aout = deflateBound(&strm, p_src_size);
@@ -122,7 +128,10 @@ int Compression::decompress(uint8_t *p_dst, int p_dst_max_size, const uint8_t *p
 			}
 			return ret_size;
 		} break;
-		case MODE_DEFLATE: {
+		case MODE_DEFLATE:
+		case MODE_GZIP: {
+
+			int window_bits = p_mode == MODE_DEFLATE ? 15 : 15 + 16;
 
 			z_stream strm;
 			strm.zalloc = zipio_alloc;
@@ -130,7 +139,7 @@ int Compression::decompress(uint8_t *p_dst, int p_dst_max_size, const uint8_t *p
 			strm.opaque = Z_NULL;
 			strm.avail_in = 0;
 			strm.next_in = Z_NULL;
-			int err = inflateInit(&strm);
+			int err = inflateInit2(&strm, window_bits);
 			ERR_FAIL_COND_V(err != Z_OK, -1);
 
 			strm.avail_in = p_src_size;

--- a/core/io/compression.h
+++ b/core/io/compression.h
@@ -36,7 +36,8 @@ class Compression {
 public:
 	enum Mode {
 		MODE_FASTLZ,
-		MODE_DEFLATE
+		MODE_DEFLATE,
+		MODE_GZIP
 	};
 
 	static int compress(uint8_t *p_dst, const uint8_t *p_src, int p_src_size, Mode p_mode = MODE_FASTLZ);

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -31529,6 +31529,26 @@
 				Append an [RawArray] at the end of this array.
 			</description>
 		</method>
+		<method name="compress">
+			<return type="RawArray">
+			</return>
+			<argument index="0" name="compression_mode" type="int" default="0">
+			</argument>
+			<description>
+				Returns a new [code]RawArray[/code] with the data compressed. Set the compression mode using one of [File]'s COMPRESS_* constants.
+			</description>
+		</method>
+		<method name="decompress">
+			<return type="RawArray">
+			</return>
+			<argument index="0" name="buffer_size" type="int">
+			</argument>
+			<argument index="1" name="compression_mode" type="int" default="0">
+			</argument>
+			<description>
+				Returns a new [code]RawArray[/code] with the data decompressed. Set buffer_size to the size of the uncompressed data. Set the compression mode using one of [File]'s COMPRESS_* constants.
+			</description>
+		</method>
 		<method name="get_string_from_ascii">
 			<return type="String">
 			</return>


### PR DESCRIPTION
Backport GZIP compression support for Godot 2.1.5