### PR TITLE
Fixes the support of the 'keep on reimport' flag - Issue #20878.

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -972,7 +972,7 @@ void ResourceImporterScene::_make_external_resources(Node *p_node, const String 
 					} else {
 
 						ResourceSaver::save(ext_name, mat, ResourceSaver::FLAG_CHANGE_PATH);
-						p_materials[mat] = ResourceLoader::load(ext_name);
+						p_materials[mat] = ResourceLoader::load(ext_name, "", true); // disable loading from the cache.
 					}
 				}
 
@@ -1018,13 +1018,13 @@ void ResourceImporterScene::_make_external_resources(Node *p_node, const String 
 
 									String ext_name = p_base_path.plus_file(_make_extname(mat->get_name()) + ".material");
 									;
-									if (FileAccess::exists(ext_name)) {
+									if (p_keep_materials && FileAccess::exists(ext_name)) {
 										//if exists, use it
 										p_materials[mat] = ResourceLoader::load(ext_name);
 									} else {
 
 										ResourceSaver::save(ext_name, mat, ResourceSaver::FLAG_CHANGE_PATH);
-										p_materials[mat] = ResourceLoader::load(ext_name);
+										p_materials[mat] = ResourceLoader::load(ext_name, "", true); // disable loading from the cache.
 									}
 								}
 


### PR DESCRIPTION
This fixes the support for disabling 'Keep on reimport' for materials.
This fix has two components:
1. check the flag when deciding whether to load existing materials from file or save the imported ones.
2. after saving the import materials, don't reload them from the cache - if you do, you'll get a stale resource.

*Bugsquad edit:* Fixes #20878.