### PR TITLE
Add mention of common user error in Func_Ref

### DIFF
--- a/doc/classes/FuncRef.xml
+++ b/doc/classes/FuncRef.xml
@@ -17,6 +17,7 @@
 			</return>
 			<description>
 				Calls the referenced function previously set by [method set_function] or [method @GDScript.funcref].
+				The error "Nonexistent function 'call_func' in base 'Func_Ref'" is most often the result of a misspelled function string.  The call_func method is dynamically bound to the Func_Ref class at runtime, and only if set_function() is given a valid function name.  If set_function() is given an invalid string, the call_func method will not be available.
 			</description>
 		</method>
 		<method name="set_function">


### PR DESCRIPTION
When using Func_Ref, the most likely error would be misspelling the name of the target function.  If this happens, the user is told that the "call_func" method doesn't exist within the "Func_Ref" class.  The first likely place to look for information is the Func_Ref documentation, so I propose adding a line to the documentation of the "call_func" method explaining that the error most likely refers to a misspelling in the user's code rather than a bug in the engine.

The error message seems to be a result of how the "call_func" method is bound at runtime.  So, while changing the error message would be more immediately useful to the user, it might involve changing more code than is warranted by what is really a fairly minor problem.