### PR TITLE
Request mic access only when is needed

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -210,6 +210,9 @@
 		</member>
 		<member name="audio/driver" type="String" setter="" getter="">
 		</member>
+		<member name="audio/enable_audio_input" type="bool" setter="" getter="">
+			This option should be enabled if project works with microphone.
+		</member>
 		<member name="audio/mix_rate" type="int" setter="" getter="">
 			Mix rate used for audio. In general, it's better to not touch this and leave it to the host operating system.
 		</member>

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -159,7 +159,10 @@ Error AudioDriverCoreAudio::init() {
 	result = AudioUnitInitialize(audio_unit);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 
-	return capture_init();
+	if (GLOBAL_GET("audio/enable_audio_input")) {
+		return capture_init();
+	}
+	return OK;
 }
 
 OSStatus AudioDriverCoreAudio::output_callback(void *inRefCon,

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -30,6 +30,7 @@
 
 #include "audio_stream.h"
 #include "core/os/os.h"
+#include "core/project_settings.h"
 
 //////////////////////////////
 
@@ -184,6 +185,12 @@ float AudioStreamPlaybackMicrophone::get_stream_sampling_rate() {
 }
 
 void AudioStreamPlaybackMicrophone::start(float p_from_pos) {
+
+	if (!GLOBAL_GET("audio/enable_audio_input")) {
+		WARN_PRINTS("Need to enable Project settings > Audio > Enable Audio Input option to use capturing.");
+		return;
+	}
+
 	input_ofs = 0;
 
 	AudioDriver::get_singleton()->capture_start();

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -172,6 +172,7 @@ int AudioDriverManager::get_driver_count() {
 }
 
 void AudioDriverManager::initialize(int p_driver) {
+	GLOBAL_DEF_RST("audio/enable_audio_input", false);
 	int failed_driver = -1;
 
 	// Check if there is a selected driver


### PR DESCRIPTION
Fix #23682

edit : `Project Settings` > `Audio` > `Enable Audio Input` option is added. default is `false` (disabled)