### PR TITLE
Change EditorLineEditFileChooser to use the "Folder" icon

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1699,6 +1699,12 @@ EditorFileDialog::~EditorFileDialog() {
 	memdelete(dir_access);
 }
 
+void EditorLineEditFileChooser::_notification(int p_what) {
+
+	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED)
+		button->set_icon(get_icon("Folder", "EditorIcons"));
+}
+
 void EditorLineEditFileChooser::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_browse"), &EditorLineEditFileChooser::_browse);
@@ -1725,7 +1731,6 @@ EditorLineEditFileChooser::EditorLineEditFileChooser() {
 	add_child(line_edit);
 	line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	button = memnew(Button);
-	button->set_text(" .. ");
 	add_child(button);
 	button->connect("pressed", this, "_browse");
 	dialog = memnew(EditorFileDialog);

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -254,6 +254,7 @@ class EditorLineEditFileChooser : public HBoxContainer {
 	void _browse();
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Considering that this is only used in the Autoload section of the Project Settings, I was surprised that it was a class of its own.

But anyways, I think it shows its purpose better having a folder icon, instead of ".." on the button:
![screenshot at 2018-12-13 19-36-54](https://user-images.githubusercontent.com/30739239/49969474-85957100-ff20-11e8-9cb0-590684f5a88b.png)