### PR TITLE
Expose ButtonGroup's "get_buttons()" to GDScript

### DIFF
--- a/doc/classes/ButtonGroup.xml
+++ b/doc/classes/ButtonGroup.xml
@@ -12,11 +12,18 @@
 	<demos>
 	</demos>
 	<methods>
+		<method name="get_buttons">
+			<return type="Array">
+			</return>
+			<description>
+				Returns an [Array] of [Button]s who have this as their [code]ButtonGroup[/code] (see [member BaseButton.group]).
+			</description>
+		</method>
 		<method name="get_pressed_button">
 			<return type="BaseButton">
 			</return>
 			<description>
-				Return the pressed button.
+				Returns the current pressed button.
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -595,6 +595,16 @@ void ButtonGroup::get_buttons(List<BaseButton *> *r_buttons) {
 	}
 }
 
+Array ButtonGroup::_get_buttons() {
+
+	Array btns;
+	for (Set<BaseButton *>::Element *E = buttons.front(); E; E = E->next()) {
+		btns.push_back(E->get());
+	}
+
+	return btns;
+}
+
 BaseButton *ButtonGroup::get_pressed_button() {
 
 	for (Set<BaseButton *>::Element *E = buttons.front(); E; E = E->next()) {
@@ -608,6 +618,7 @@ BaseButton *ButtonGroup::get_pressed_button() {
 void ButtonGroup::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_pressed_button"), &ButtonGroup::get_pressed_button);
+	ClassDB::bind_method(D_METHOD("get_buttons"), &ButtonGroup::_get_buttons);
 }
 
 ButtonGroup::ButtonGroup() {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -143,6 +143,7 @@ protected:
 public:
 	BaseButton *get_pressed_button();
 	void get_buttons(List<BaseButton *> *r_buttons);
+	Array _get_buttons();
 	ButtonGroup();
 };
 


### PR DESCRIPTION
Well, technically. The default function wouldn't be able to work in GDScript, so another had to be made to get the job done.

@akien-mga  I know we're in feature freeze, but I **really** need this to be exposed for what I'm doing (and is surprising that such function was not exposed already).