### PR TITLE
Restrict Autoloads from having keywords as their names

### DIFF
--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -84,6 +84,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 	void _autoload_edited();
 	void _autoload_button_pressed(Object *p_item, int p_column, int p_button);
 	void _autoload_activated();
+	void _autoload_text_entered(String) { _autoload_add(); }
 	void _autoload_open(const String &fpath);
 	void _autoload_file_callback(const String &p_path);
 	Node *_create_autoload(const String &p_path);
@@ -98,7 +99,7 @@ protected:
 
 public:
 	void update_autoload();
-	void autoload_add(const String &p_name, const String &p_path);
+	bool autoload_add(const String &p_name, const String &p_path);
 	void autoload_remove(const String &p_name);
 
 	EditorAutoloadSettings();


### PR DESCRIPTION
A re-take on #22107, fixes #17494.

A comment in the original PR suggests using `ScriptServer::is_scripting_enabled()`, but as it always returns `false`, this condition is not used.

Some small enhancements where also added:
- Passing an invalid name now only clears the name field, avoiding having to choose the path again.
- Pressing `Enter` while having the name field focused now counts as having pressed "Add".
---
While doing this, I also made an interesting discovery: Classes registered which names start with "_" (such as `_Engine`, `_OS`, etc), even though they can be identified without the underscore while scripting, searching for it in the `ClassDB` will result in nothing without it.

This explains why you can name Autoloads which such classes, and also why they don't inherent the `Object` icon in the new Editor Help dialog.

Now here's the question: Should we make those two places also check the class names with "_" when searching the database, or should something be done in the `ClassDB` itself?

**UPDATE**: The above can be fixed by either #26990 or #26922.