### PR TITLE
Tweak editor status colors (success, warning, error)

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -351,18 +351,18 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_color("mono_color", "Editor", mono_color);
 
-	Color success_color = accent_color.linear_interpolate(Color(0.2, 1, 0.2), 0.6) * 1.2;
-	Color warning_color = accent_color.linear_interpolate(Color(1, 1, 0), 0.7) * 1.0;
-	Color error_color = accent_color.linear_interpolate(Color(1, 0, 0), 0.8) * 1.7;
+	Color success_color = Color(0.45, 0.95, 0.5);
+	Color warning_color = Color(1, 0.87, 0.4);
+	Color error_color = Color(1, 0.47, 0.42);
 	Color property_color = font_color.linear_interpolate(Color(0.5, 0.5, 0.5), 0.5);
 
 	if (!dark_theme) {
-		// yellow on white themes is a P.I.T.A.
-		warning_color = accent_color.linear_interpolate(Color(0.9, 0.7, 0), 0.9);
-		warning_color = warning_color.linear_interpolate(mono_color, 0.2);
-		success_color = success_color.linear_interpolate(mono_color, 0.2);
-		error_color = error_color.linear_interpolate(mono_color, 0.2);
+		// Darken some colors to be readable on a light background
+		success_color = success_color.linear_interpolate(mono_color, 0.35);
+		warning_color = warning_color.linear_interpolate(mono_color, 0.35);
+		error_color = error_color.linear_interpolate(mono_color, 0.25);
 	}
+
 	theme->set_color("success_color", "Editor", success_color);
 	theme->set_color("warning_color", "Editor", warning_color);
 	theme->set_color("error_color", "Editor", error_color);


### PR DESCRIPTION
Some of the previous colors were "overbright" in the sense that some of their components were above 1, causing font anti-aliasing to look bad.

These new colors should be easier on the eyes while fitting better with the rest of the editor's color palette.

**Preview:**

### Errors

![color_godot2_1 25x_error](https://user-images.githubusercontent.com/180032/50045569-5b18f480-0095-11e9-9a47-ecf191c8794f.png)
![color_default_1 5x_error](https://user-images.githubusercontent.com/180032/50045567-5b18f480-0095-11e9-813a-f2c514738cd3.png)
![color_grey_2x_error](https://user-images.githubusercontent.com/180032/50045570-5b18f480-0095-11e9-8032-06f71ee228bc.png)
![color_light_1x_error](https://user-images.githubusercontent.com/180032/50045573-5bb18b00-0095-11e9-9ac7-73d6fc0bb360.png)

### Successes

![color_default_1 5x_success](https://user-images.githubusercontent.com/180032/50045568-5b18f480-0095-11e9-81fc-3c4d828c2896.png)
![color_grey_2x_success](https://user-images.githubusercontent.com/180032/50045571-5bb18b00-0095-11e9-9e2c-0c7a3ef83595.png)
![color_light_1x_success](https://user-images.githubusercontent.com/180032/50045574-5bb18b00-0095-11e9-90ac-b04217d7edb4.png)

### Warnings

![color_grey_2x_warning](https://user-images.githubusercontent.com/180032/50045572-5bb18b00-0095-11e9-9dfd-e8ff2d6e17fb.png)

