### PR TITLE
get/set parameters in AnimationTree for gdscript

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1483,6 +1483,13 @@ void AnimationTree::_get_property_list(List<PropertyInfo> *p_list) const {
 
 void AnimationTree::set_parameter(const StringName &p_name, const Variant &p_value) {
 
+	if (properties_dirty) {
+		_update_properties();
+	}
+
+	ERR_EXPLAIN("Parameter not found: " + p_name);
+	ERR_FAIL_COND(!property_map.has(p_name));
+
 	_set(p_name, p_value);
 }
 
@@ -1492,11 +1499,10 @@ Variant AnimationTree::get_parameter(const StringName &p_name) const {
 		const_cast<AnimationTree *>(this)->_update_properties();
 	}
 
-	if (property_map.has(p_name)) {
-		return property_map[p_name];
-	}
+	ERR_EXPLAIN("Parameter not found: " + p_name);
+	ERR_FAIL_COND_V(!property_map.has(p_name), Variant());
 
-	return Variant();
+	return property_map[p_name];
 }
 
 void AnimationTree::rename_parameter(const String &p_base, const String &p_new_base) {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1481,6 +1481,24 @@ void AnimationTree::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
+void AnimationTree::set_parameter(const StringName &p_name, const Variant &p_value) {
+
+	_set(p_name, p_value);
+}
+
+Variant AnimationTree::get_parameter(const StringName &p_name) const {
+
+	if (properties_dirty) {
+		const_cast<AnimationTree *>(this)->_update_properties();
+	}
+
+	if (property_map.has(p_name)) {
+		return property_map[p_name];
+	}
+
+	return Variant();
+}
+
 void AnimationTree::rename_parameter(const String &p_base, const String &p_new_base) {
 
 	//rename values first
@@ -1534,6 +1552,9 @@ void AnimationTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_tree_changed"), &AnimationTree::_tree_changed);
 	ClassDB::bind_method(D_METHOD("_update_properties"), &AnimationTree::_update_properties);
+
+	ClassDB::bind_method(D_METHOD("set_parameter", "name", "value"), &AnimationTree::set_parameter);
+	ClassDB::bind_method(D_METHOD("get_parameter", "name"), &AnimationTree::get_parameter);
 
 	ClassDB::bind_method(D_METHOD("rename_parameter", "old_name", "new_name"), &AnimationTree::rename_parameter);
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -332,6 +332,9 @@ public:
 	float get_connection_activity(const StringName &p_path, int p_connection) const;
 	void advance(float p_time);
 
+	void set_parameter(const StringName &p_name, const Variant &p_value);
+	Variant get_parameter(const StringName &p_name) const;
+
 	void rename_parameter(const String &p_base, const String &p_new_base);
 
 	uint64_t get_last_process_pass() const;


### PR DESCRIPTION
This change allows scripts to interact with an AnimationTree by getting and setting parameters for animation nodes within the tree.

New functions for gdscript in AnimationTree:
- get_parameter ( String name ) const
- set_parameter ( String name, Variant value )

Usage with Transition node:
<img src="https://user-images.githubusercontent.com/1075032/50048835-f29e3780-00d5-11e9-8988-166bf06c6810.png" width="400"/>
<img src="https://user-images.githubusercontent.com/1075032/50048844-1e212200-00d6-11e9-8823-37501ad807a3.png" width="200"/>
```
var animation_tree = get_node("./AnimationTree")

var param_name = "parameters/actions/current";

# print current value
var param_value = animation_tree.get_parameter(param_name)
print("get_parameter: ", param_value)

# change animation to run
animation_tree.set_parameter(param_name, 1)

# change animation to idle
animation_tree.set_parameter(param_name, 0)
```