### PR TITLE
Removed error message arriving whenever csv file changed

### DIFF
--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -353,7 +353,8 @@ Vector<String> FileAccess::get_csv_line(const String &p_delim) const {
 	String l;
 	int qc = 0;
 	do {
-		ERR_FAIL_COND_V(eof_reached(), Vector<String>());
+		if (eof_reached())
+			break;
 
 		l += get_line() + "\n";
 		qc = 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3036176/50050003-a0730b80-0101-11e9-9f90-575829170d41.png)

This error arriving each time you change localization file(csv) outside of editor, I think its incorrect(and very irritating) and should be removed.