### PR TITLE
Improvements to AnimationNodeStateMachine

### DIFF
--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -39,12 +39,6 @@
 				Adds a transition between the given nodes.
 			</description>
 		</method>
-		<method name="get_end_node" qualifiers="const">
-			<return type="String" />
-			<description>
-				Returns the graph's end node.
-			</description>
-		</method>
 		<method name="get_graph_offset" qualifiers="const">
 			<return type="Vector2" />
 			<description>
@@ -70,12 +64,6 @@
 			<argument index="0" name="name" type="StringName" />
 			<description>
 				Returns the given node's coordinates. Used for display in the editor.
-			</description>
-		</method>
-		<method name="get_start_node" qualifiers="const">
-			<return type="String" />
-			<description>
-				Returns the graph's end node.
 			</description>
 		</method>
 		<method name="get_transition" qualifiers="const">
@@ -157,13 +145,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_end_node">
-			<return type="void" />
-			<argument index="0" name="name" type="StringName" />
-			<description>
-				Sets the given node as the graph end point.
-			</description>
-		</method>
 		<method name="set_graph_offset">
 			<return type="void" />
 			<argument index="0" name="offset" type="Vector2" />
@@ -177,13 +158,6 @@
 			<argument index="1" name="position" type="Vector2" />
 			<description>
 				Sets the node's coordinates. Used for display in the editor.
-			</description>
-		</method>
-		<method name="set_start_node">
-			<return type="void" />
-			<argument index="0" name="name" type="StringName" />
-			<description>
-				Sets the given node as the graph start point.
 			</description>
 		</method>
 	</methods>

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -42,6 +42,8 @@
 #include "scene/animation/animation_player.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
+#include "scene/gui/tree.h"
+#include "scene/main/viewport.h"
 #include "scene/main/window.h"
 
 bool AnimationNodeStateMachineEditor::can_edit(const Ref<AnimationNode> &p_node) {
@@ -55,7 +57,10 @@ void AnimationNodeStateMachineEditor::edit(const Ref<AnimationNode> &p_node) {
 	if (state_machine.is_valid()) {
 		selected_transition_from = StringName();
 		selected_transition_to = StringName();
+		selected_transition_index = -1;
+		selected_multi_transition = TransitionLine();
 		selected_node = StringName();
+		selected_nodes.clear();
 		_update_mode();
 		_update_graph();
 	}
@@ -69,71 +74,39 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 	Ref<InputEventKey> k = p_event;
 	if (tool_select->is_pressed() && k.is_valid() && k->is_pressed() && k->get_keycode() == Key::KEY_DELETE && !k->is_echo()) {
-		if (selected_node != StringName() || selected_transition_to != StringName() || selected_transition_from != StringName()) {
+		if (selected_node != StringName() || !selected_nodes.is_empty() || selected_transition_to != StringName() || selected_transition_from != StringName()) {
 			_erase_selected();
 			accept_event();
 		}
 	}
 
-	Ref<InputEventMouseButton> mb = p_event;
-
-	//Add new node
-	if (mb.is_valid() && mb->is_pressed() && ((tool_select->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) || (tool_create->is_pressed() && mb->get_button_index() == MouseButton::LEFT))) {
-		menu->clear();
-		animations_menu->clear();
-		animations_to_add.clear();
-		List<StringName> classes;
-		classes.sort_custom<StringName::AlphCompare>();
-
-		ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
-		menu->add_submenu_item(TTR("Add Animation"), "animations");
-
-		AnimationTree *gp = AnimationTreeEditor::get_singleton()->get_tree();
-		ERR_FAIL_COND(!gp);
-		if (gp && gp->has_node(gp->get_animation_player())) {
-			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(gp->get_node(gp->get_animation_player()));
-			if (ap) {
-				List<StringName> names;
-				ap->get_animation_list(&names);
-				for (const StringName &E : names) {
-					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E);
-					animations_to_add.push_back(E);
-				}
-			}
-		}
-
-		for (const StringName &E : classes) {
-			String name = String(E).replace_first("AnimationNode", "");
-			if (name == "Animation") {
-				continue; // nope
-			}
-			int idx = menu->get_item_count();
-			menu->add_item(vformat(TTR("Add %s"), name), idx);
-			menu->set_item_metadata(idx, E);
-		}
-		Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
-
-		if (clipb.is_valid()) {
-			menu->add_separator();
-			menu->add_item(TTR("Paste"), MENU_PASTE);
-		}
-		menu->add_separator();
-		menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
-
-		menu->set_position(state_machine_draw->get_screen_position() + mb->get_position());
-		menu->reset_size();
-		menu->popup();
-		add_node_pos = mb->get_position() / EDSCALE + state_machine->get_graph_offset();
+	// Group selected nodes on a state machine
+	if (tool_select->is_pressed() && k.is_valid() && k->is_pressed() && k->is_ctrl_pressed() && !k->is_shift_pressed() && k->get_keycode() == Key::G && !k->is_echo()) {
+		_group_selected_nodes();
 	}
 
-	// select node or push a field inside
-	if (mb.is_valid() && !mb->is_shift_pressed() && mb->is_pressed() && tool_select->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+	// Ungroup state machine
+	if (tool_select->is_pressed() && k.is_valid() && k->is_pressed() && k->is_ctrl_pressed() && k->is_shift_pressed() && k->get_keycode() == Key::G && !k->is_echo()) {
+		_ungroup_selected_nodes();
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+
+	// Add new node
+	if (mb.is_valid() && mb->is_pressed() && !box_selecting && !connecting && ((tool_select->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) || (tool_create->is_pressed() && mb->get_button_index() == MouseButton::LEFT))) {
+		connecting_from = StringName();
+		_open_menu(mb->get_position());
+	}
+
+	// Select node or push a field inside
+	if (mb.is_valid() && !mb->is_shift_pressed() && !mb->is_ctrl_pressed() && mb->is_pressed() && tool_select->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 		selected_transition_from = StringName();
 		selected_transition_to = StringName();
+		selected_transition_index = -1;
+		selected_multi_transition = TransitionLine();
 		selected_node = StringName();
 
 		for (int i = node_rects.size() - 1; i >= 0; i--) { //inverse to draw order
-
 			if (node_rects[i].play.has_point(mb->get_position())) { //edit name
 				if (play_mode->get_selected() == 1 || !playback->is_playing()) {
 					//start
@@ -146,8 +119,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				return;
 			}
 
-			if (node_rects[i].name.has_point(mb->get_position())) { //edit name
-
+			if (node_rects[i].name.has_point(mb->get_position()) && state_machine->can_edit_node(node_rects[i].node_name)) { // edit name
 				Ref<StyleBox> line_sb = get_theme_stylebox(SNAME("normal"), SNAME("LineEdit"));
 
 				Rect2 edit_rect = node_rects[i].name;
@@ -172,6 +144,12 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 			if (node_rects[i].node.has_point(mb->get_position())) { //select node since nothing else was selected
 				selected_node = node_rects[i].node_name;
+
+				if (!selected_nodes.has(selected_node)) {
+					selected_nodes.clear();
+				}
+
+				selected_nodes.insert(selected_node);
 
 				Ref<AnimationNode> anode = state_machine->get_node(selected_node);
 				EditorNode::get_singleton()->push_item(anode.ptr(), "", true);
@@ -209,23 +187,53 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		if (closest >= 0) {
 			selected_transition_from = transition_lines[closest].from_node;
 			selected_transition_to = transition_lines[closest].to_node;
+			selected_transition_index = closest;
 
 			Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(closest);
 			EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
+
+			if (!transition_lines[closest].multi_transitions.is_empty()) {
+				selected_transition_index = -1;
+				selected_multi_transition = transition_lines[closest];
+
+				Ref<EditorAnimationMultiTransitionEdit> multi;
+				multi.instantiate();
+				multi->add_transition(selected_transition_from, selected_transition_to, tr);
+
+				for (int i = 0; i < transition_lines[closest].multi_transitions.size(); i++) {
+					int index = transition_lines[closest].multi_transitions[i].transition_index;
+
+					Ref<AnimationNodeStateMachineTransition> transition = state_machine->get_transition(index);
+					StringName from = transition_lines[closest].multi_transitions[i].from_node;
+					StringName to = transition_lines[closest].multi_transitions[i].to_node;
+
+					multi->add_transition(from, to, transition);
+				}
+				EditorNode::get_singleton()->push_item(multi.ptr(), "", true);
+			}
 		}
 
 		state_machine_draw->update();
 		_update_mode();
 	}
 
-	//end moving node
+	// End moving node
 	if (mb.is_valid() && dragging_selected_attempt && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed()) {
 		if (dragging_selected) {
 			Ref<AnimationNode> an = state_machine->get_node(selected_node);
 			updating = true;
+
 			undo_redo->create_action(TTR("Move Node"));
-			undo_redo->add_do_method(state_machine.ptr(), "set_node_position", selected_node, state_machine->get_node_position(selected_node) + drag_ofs / EDSCALE);
-			undo_redo->add_undo_method(state_machine.ptr(), "set_node_position", selected_node, state_machine->get_node_position(selected_node));
+
+			for (int i = 0; i < node_rects.size(); i++) {
+				if (!selected_nodes.has(node_rects[i].node_name)) {
+					continue;
+				}
+
+				undo_redo->add_do_method(state_machine.ptr(), "set_node_position", node_rects[i].node_name, state_machine->get_node_position(node_rects[i].node_name) + drag_ofs / EDSCALE);
+				undo_redo->add_undo_method(state_machine.ptr(), "set_node_position", node_rects[i].node_name, state_machine->get_node_position(node_rects[i].node_name));
+			}
+
 			undo_redo->add_do_method(this, "_update_graph");
 			undo_redo->add_undo_method(this, "_update_graph");
 			undo_redo->commit_action();
@@ -239,7 +247,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		state_machine_draw->update();
 	}
 
-	//connect nodes
+	// Connect nodes
 	if (mb.is_valid() && ((tool_select->is_pressed() && mb->is_shift_pressed()) || tool_connect->is_pressed()) && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
 		for (int i = node_rects.size() - 1; i >= 0; i--) { //inverse to draw order
 			if (node_rects[i].node.has_point(mb->get_position())) { //select node since nothing else was selected
@@ -252,47 +260,63 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		}
 	}
 
-	//end connecting nodes
+	// End connecting nodes
 	if (mb.is_valid() && connecting && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed()) {
 		if (connecting_to_node != StringName()) {
-			if (state_machine->has_transition(connecting_from, connecting_to_node)) {
+			Ref<AnimationNode> node = state_machine->get_node(connecting_to_node);
+			Ref<AnimationNodeStateMachine> anodesm = node;
+			Ref<AnimationNodeEndState> end_node = node;
+
+			if (state_machine->has_transition(connecting_from, connecting_to_node) && state_machine->can_edit_node(connecting_to_node) && !anodesm.is_valid()) {
 				EditorNode::get_singleton()->show_warning(TTR("Transition exists!"));
-
+				connecting = false;
 			} else {
-				Ref<AnimationNodeStateMachineTransition> tr;
-				tr.instantiate();
-				tr->set_switch_mode(AnimationNodeStateMachineTransition::SwitchMode(transition_mode->get_selected()));
-
-				updating = true;
-				undo_redo->create_action(TTR("Add Transition"));
-				undo_redo->add_do_method(state_machine.ptr(), "add_transition", connecting_from, connecting_to_node, tr);
-				undo_redo->add_undo_method(state_machine.ptr(), "remove_transition", connecting_from, connecting_to_node);
-				undo_redo->add_do_method(this, "_update_graph");
-				undo_redo->add_undo_method(this, "_update_graph");
-				undo_redo->commit_action();
-				updating = false;
-
-				selected_transition_from = connecting_from;
-				selected_transition_to = connecting_to_node;
-
-				EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
-				_update_mode();
+				if (anodesm.is_valid() || end_node.is_valid()) {
+					_open_connect_menu(mb->get_position());
+				} else {
+					_add_transition();
+				}
 			}
+		} else {
+			_open_menu(mb->get_position());
 		}
 		connecting_to_node = StringName();
-		connecting = false;
 		state_machine_draw->update();
+	}
+
+	// Start box selecting
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && tool_select->is_pressed()) {
+		box_selecting = true;
+		box_selecting_from = box_selecting_to = state_machine_draw->get_local_mouse_position();
+		box_selecting_rect = Rect2(MIN(box_selecting_from.x, box_selecting_to.x),
+				MIN(box_selecting_from.y, box_selecting_to.y),
+				ABS(box_selecting_from.x - box_selecting_to.x),
+				ABS(box_selecting_from.y - box_selecting_to.y));
+
+		if (mb->is_ctrl_pressed() || mb->is_shift_pressed()) {
+			previous_selected = selected_nodes;
+		} else {
+			selected_nodes.clear();
+			previous_selected.clear();
+		}
+	}
+
+	// End box selecting
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed() && box_selecting) {
+		box_selecting = false;
+		state_machine_draw->update();
+		_update_mode();
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
 
-	//pan window
+	// Pan window
 	if (mm.is_valid() && (mm->get_button_mask() & MouseButton::MASK_MIDDLE) != MouseButton::NONE) {
 		h_scroll->set_value(h_scroll->get_value() - mm->get_relative().x);
 		v_scroll->set_value(v_scroll->get_value() - mm->get_relative().y);
 	}
 
-	//move mouse while connecting
+	// Move mouse while connecting
 	if (mm.is_valid() && connecting) {
 		connecting_to = mm->get_position();
 		connecting_to_node = StringName();
@@ -306,7 +330,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		}
 	}
 
-	//move mouse while moving a node
+	// Move mouse while moving a node
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
 		drag_ofs = mm->get_position() - drag_from;
@@ -353,6 +377,11 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		int new_over_node_what = -1;
 		if (tool_select->is_pressed()) {
 			for (int i = node_rects.size() - 1; i >= 0; i--) { // Inverse to draw order.
+
+				if (!state_machine->can_edit_node(node_rects[i].node_name)) {
+					continue; // start/end node can't be edited
+				}
+
 				if (node_rects[i].node.has_point(mm->get_position())) {
 					new_over_node = node_rects[i].node_name;
 					if (node_rects[i].play.has_point(mm->get_position())) {
@@ -369,6 +398,43 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			over_node = new_over_node;
 			over_node_what = new_over_node_what;
 			state_machine_draw->update();
+		}
+
+		// set tooltip for transition
+		if (tool_select->is_pressed()) {
+			int closest = -1;
+			float closest_d = 1e20;
+			for (int i = 0; i < transition_lines.size(); i++) {
+				Vector2 s[2] = {
+					transition_lines[i].from,
+					transition_lines[i].to
+				};
+				Vector2 cpoint = Geometry2D::get_closest_point_to_segment(mm->get_position(), s);
+				float d = cpoint.distance_to(mm->get_position());
+				if (d > transition_lines[i].width) {
+					continue;
+				}
+
+				if (d < closest_d) {
+					closest = i;
+					closest_d = d;
+				}
+			}
+
+			if (closest >= 0) {
+				String from = String(transition_lines[closest].from_node);
+				String to = String(transition_lines[closest].to_node);
+				String tooltip = from + " -> " + to;
+
+				for (int i = 0; i < transition_lines[closest].multi_transitions.size(); i++) {
+					from = String(transition_lines[closest].multi_transitions[i].from_node);
+					to = String(transition_lines[closest].multi_transitions[i].to_node);
+					tooltip += "\n" + from + " -> " + to;
+				}
+				state_machine_draw->set_tooltip(tooltip);
+			} else {
+				state_machine_draw->set_tooltip("");
+			}
 		}
 	}
 
@@ -394,6 +460,458 @@ Control::CursorShape AnimationNodeStateMachineEditor::get_cursor_shape(const Poi
 		}
 	}
 	return cursor_shape;
+}
+
+void AnimationNodeStateMachineEditor::_group_selected_nodes() {
+	if (!selected_nodes.is_empty()) {
+		if (selected_nodes.size() == 1 && (selected_nodes.front()->get() == state_machine->start_node || selected_nodes.front()->get() == state_machine->end_node))
+			return;
+
+		Ref<AnimationNodeStateMachine> group_sm = memnew(AnimationNodeStateMachine);
+		Vector2 group_position;
+
+		Vector<NodeUR> nodes_ur;
+		Vector<TransitionUR> transitions_ur;
+
+		int base = 1;
+		String base_name = group_sm->get_caption();
+		String group_name = base_name;
+
+		while (state_machine->has_node(group_name) && !selected_nodes.has(group_name)) {
+			base++;
+			group_name = base_name + " " + itos(base);
+		}
+
+		updating = true;
+		undo_redo->create_action("Group");
+
+		// Move selected nodes to the new state machine
+		for (const StringName &E : selected_nodes) {
+			if (!state_machine->can_edit_node(E)) {
+				continue;
+			}
+
+			Ref<AnimationNode> node = state_machine->get_node(E);
+			Vector2 node_position = state_machine->get_node_position(E);
+			group_position += node_position;
+
+			NodeUR new_node;
+			new_node.name = E;
+			new_node.node = node;
+			new_node.position = node_position;
+
+			nodes_ur.push_back(new_node);
+		}
+
+		// Add the transitions to the new state machine
+		for (int i = 0; i < state_machine->get_transition_count(); i++) {
+			String from = state_machine->get_transition_from(i);
+			String to = state_machine->get_transition_to(i);
+
+			String local_from = from.get_slicec('/', 0);
+			String local_to = to.get_slicec('/', 0);
+
+			String old_from = from;
+			String old_to = to;
+
+			bool from_selected = false;
+			bool to_selected = false;
+
+			if (selected_nodes.has(local_from) && local_from != state_machine->start_node) {
+				from_selected = true;
+			}
+			if (selected_nodes.has(local_to) && local_to != state_machine->end_node) {
+				to_selected = true;
+			}
+			if (!from_selected && !to_selected) {
+				continue;
+			}
+
+			Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(i);
+
+			if (!from_selected) {
+				from = "../" + old_from;
+			}
+			if (!to_selected) {
+				to = "../" + old_to;
+			}
+
+			TransitionUR new_tr;
+			new_tr.new_from = from;
+			new_tr.new_to = to;
+			new_tr.old_from = old_from;
+			new_tr.old_to = old_to;
+			new_tr.transition = tr;
+
+			transitions_ur.push_back(new_tr);
+		}
+
+		for (int i = 0; i < nodes_ur.size(); i++) {
+			undo_redo->add_do_method(state_machine.ptr(), "remove_node", nodes_ur[i].name);
+			undo_redo->add_undo_method(group_sm.ptr(), "remove_node", nodes_ur[i].name);
+		}
+
+		undo_redo->add_do_method(state_machine.ptr(), "add_node", group_name, group_sm, group_position / nodes_ur.size());
+		undo_redo->add_undo_method(state_machine.ptr(), "remove_node", group_name);
+
+		for (int i = 0; i < nodes_ur.size(); i++) {
+			undo_redo->add_do_method(group_sm.ptr(), "add_node", nodes_ur[i].name, nodes_ur[i].node, nodes_ur[i].position);
+			undo_redo->add_undo_method(state_machine.ptr(), "add_node", nodes_ur[i].name, nodes_ur[i].node, nodes_ur[i].position);
+		}
+
+		for (int i = 0; i < transitions_ur.size(); i++) {
+			undo_redo->add_do_method(group_sm.ptr(), "add_transition", transitions_ur[i].new_from, transitions_ur[i].new_to, transitions_ur[i].transition);
+			undo_redo->add_undo_method(state_machine.ptr(), "add_transition", transitions_ur[i].old_from, transitions_ur[i].old_to, transitions_ur[i].transition);
+		}
+
+		undo_redo->add_do_method(this, "_update_graph");
+		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->commit_action();
+		updating = false;
+
+		selected_nodes.clear();
+		selected_nodes.insert(group_name);
+		state_machine_draw->update();
+		accept_event();
+		_update_mode();
+	}
+}
+
+void AnimationNodeStateMachineEditor::_ungroup_selected_nodes() {
+	bool find = false;
+	Set<StringName> new_selected_nodes;
+
+	for (const StringName &E : selected_nodes) {
+		Ref<AnimationNodeStateMachine> group_sm = state_machine->get_node(E);
+
+		if (group_sm.is_valid()) {
+			find = true;
+
+			Vector2 group_position = state_machine->get_node_position(E);
+			StringName group_name = E;
+
+			List<AnimationNode::ChildNode> nodes;
+			group_sm->get_child_nodes(&nodes);
+
+			Vector<NodeUR> nodes_ur;
+			Vector<TransitionUR> transitions_ur;
+
+			updating = true;
+			undo_redo->create_action("Ungroup");
+
+			// Move all child nodes to current state machine
+			for (int i = 0; i < nodes.size(); i++) {
+				if (!group_sm->can_edit_node(nodes[i].name)) {
+					continue;
+				}
+
+				Vector2 node_position = group_sm->get_node_position(nodes[i].name);
+
+				NodeUR new_node;
+				new_node.name = nodes[i].name;
+				new_node.position = node_position;
+				new_node.node = nodes[i].node;
+
+				nodes_ur.push_back(new_node);
+			}
+
+			for (int i = 0; i < group_sm->get_transition_count(); i++) {
+				String from = group_sm->get_transition_from(i);
+				String to = group_sm->get_transition_to(i);
+				Ref<AnimationNodeStateMachineTransition> tr = group_sm->get_transition(i);
+
+				TransitionUR new_tr;
+				new_tr.new_from = from.replace_first("../", "");
+				new_tr.new_to = to.replace_first("../", "");
+				new_tr.old_from = from;
+				new_tr.old_to = to;
+				new_tr.transition = tr;
+
+				transitions_ur.push_back(new_tr);
+			}
+
+			for (int i = 0; i < nodes_ur.size(); i++) {
+				undo_redo->add_do_method(group_sm.ptr(), "remove_node", nodes_ur[i].name);
+				undo_redo->add_undo_method(state_machine.ptr(), "remove_node", nodes_ur[i].name);
+			}
+
+			undo_redo->add_do_method(state_machine.ptr(), "remove_node", group_name);
+			undo_redo->add_undo_method(state_machine.ptr(), "add_node", group_name, group_sm, group_position);
+
+			for (int i = 0; i < nodes_ur.size(); i++) {
+				new_selected_nodes.insert(nodes_ur[i].name);
+				undo_redo->add_do_method(state_machine.ptr(), "add_node", nodes_ur[i].name, nodes_ur[i].node, nodes_ur[i].position);
+				undo_redo->add_undo_method(group_sm.ptr(), "add_node", nodes_ur[i].name, nodes_ur[i].node, nodes_ur[i].position);
+			}
+
+			for (int i = 0; i < transitions_ur.size(); i++) {
+				if (transitions_ur[i].old_from != state_machine->start_node && transitions_ur[i].old_to != state_machine->end_node) {
+					undo_redo->add_do_method(state_machine.ptr(), "add_transition", transitions_ur[i].new_from, transitions_ur[i].new_to, transitions_ur[i].transition);
+				}
+
+				undo_redo->add_undo_method(group_sm.ptr(), "add_transition", transitions_ur[i].old_from, transitions_ur[i].old_to, transitions_ur[i].transition);
+			}
+
+			for (int i = 0; i < state_machine->get_transition_count(); i++) {
+				String from = state_machine->get_transition_from(i);
+				String to = state_machine->get_transition_to(i);
+				Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(i);
+
+				if (from == group_name || to == group_name) {
+					undo_redo->add_undo_method(state_machine.ptr(), "add_transition", from, to, tr);
+				}
+			}
+
+			undo_redo->add_do_method(this, "_update_graph");
+			undo_redo->add_undo_method(this, "_update_graph");
+			undo_redo->commit_action();
+			updating = false;
+		}
+	}
+
+	if (find) {
+		selected_nodes = new_selected_nodes;
+		selected_node = StringName();
+		state_machine_draw->update();
+		accept_event();
+		_update_mode();
+	}
+}
+
+void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
+	menu->clear();
+	animations_menu->clear();
+	animations_to_add.clear();
+	List<StringName> classes;
+	classes.sort_custom<StringName::AlphCompare>();
+
+	ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
+	menu->add_submenu_item(TTR("Add Animation"), "animations");
+
+	AnimationTree *gp = AnimationTreeEditor::get_singleton()->get_tree();
+	ERR_FAIL_COND(!gp);
+	if (gp && gp->has_node(gp->get_animation_player())) {
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(gp->get_node(gp->get_animation_player()));
+		if (ap) {
+			List<StringName> names;
+			ap->get_animation_list(&names);
+			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+				animations_menu->add_icon_item(get_theme_icon("Animation", "EditorIcons"), E->get());
+				animations_to_add.push_back(E->get());
+			}
+		}
+	}
+
+	for (List<StringName>::Element *E = classes.front(); E; E = E->next()) {
+		String name = String(E->get()).replace_first("AnimationNode", "");
+		if (name == "Animation" || name == "StartState" || name == "EndState") {
+			continue; // nope
+		}
+		int idx = menu->get_item_count();
+		menu->add_item(vformat(TTR("Add %s"), name), idx);
+		menu->set_item_metadata(idx, E->get());
+	}
+	Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
+
+	if (clipb.is_valid()) {
+		menu->add_separator();
+		menu->add_item(TTR("Paste"), MENU_PASTE);
+	}
+	menu->add_separator();
+	menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
+
+	menu->set_position(state_machine_draw->get_screen_transform().xform(p_position));
+	menu->popup();
+	add_node_pos = p_position / EDSCALE + state_machine->get_graph_offset();
+}
+
+void AnimationNodeStateMachineEditor::_open_connect_menu(const Vector2 &p_position) {
+	ERR_FAIL_COND(connecting_to_node == StringName());
+
+	Ref<AnimationNode> node = state_machine->get_node(connecting_to_node);
+	Ref<AnimationNodeStateMachine> anodesm = node;
+	Ref<AnimationNodeEndState> end_node = node;
+	ERR_FAIL_COND(!anodesm.is_valid() && !end_node.is_valid());
+
+	connect_menu->clear();
+	state_machine_menu->clear();
+	end_menu->clear();
+	nodes_to_connect.clear();
+
+	for (int i = connect_menu->get_child_count() - 1; i >= 0; i--) {
+		Node *child = connect_menu->get_child(i);
+
+		if (child->is_class("PopupMenu")) {
+			connect_menu->remove_child(child);
+		}
+	}
+
+	connect_menu->reset_size();
+	state_machine_menu->reset_size();
+	end_menu->reset_size();
+
+	if (anodesm.is_valid()) {
+		_create_submenu(connect_menu, anodesm, connecting_to_node, connecting_to_node);
+	} else {
+		Ref<AnimationNodeStateMachine> prev = state_machine;
+		_create_submenu(connect_menu, prev, connecting_to_node, connecting_to_node, true);
+	}
+
+	connect_menu->add_submenu_item(TTR("To") + " Animation", connecting_to_node);
+
+	if (state_machine_menu->get_item_count() > 0 || !end_node.is_valid()) {
+		connect_menu->add_submenu_item(TTR("To") + " StateMachine", "state_machines");
+		connect_menu->add_child(state_machine_menu);
+	}
+
+	if (end_node.is_valid()) {
+		connect_menu->add_submenu_item(TTR("To") + " End", "end_nodes");
+		connect_menu->add_child(end_menu);
+	} else {
+		state_machine_menu->add_item(connecting_to_node, nodes_to_connect.size());
+	}
+
+	nodes_to_connect.push_back(connecting_to_node);
+
+	if (nodes_to_connect.size() == 1) {
+		_add_transition();
+		return;
+	}
+
+	connect_menu->set_position(state_machine_draw->get_screen_transform().xform(p_position));
+	connect_menu->popup();
+}
+
+bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path, bool from_root, Vector<Ref<AnimationNodeStateMachine>> p_parents) {
+	String prev_path;
+	Vector<Ref<AnimationNodeStateMachine>> parents = p_parents;
+
+	if (from_root) {
+		Ref<AnimationNodeStateMachine> prev = p_nodesm->get_prev_state_machine();
+
+		while (prev.is_valid()) {
+			parents.push_back(prev);
+			p_nodesm = prev;
+			prev_path += "../";
+			prev = prev->get_prev_state_machine();
+		}
+		prev_path.remove_at(prev_path.size() - 1);
+	}
+
+	List<StringName> nodes;
+	p_nodesm->get_node_list(&nodes);
+
+	PopupMenu *nodes_menu = memnew(PopupMenu);
+	nodes_menu->set_name(p_name);
+	nodes_menu->connect("id_pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_connect_to));
+	p_menu->add_child(nodes_menu);
+
+	bool node_added = false;
+	for (const StringName &E : nodes) {
+		if (p_nodesm->can_edit_node(E)) {
+			Ref<AnimationNodeStateMachine> ansm = p_nodesm->get_node(E);
+
+			String path;
+			if (from_root) {
+				path = prev_path + "/" + E;
+			} else {
+				path = String(p_path) + "/" + E;
+			}
+
+			if (ansm == state_machine) {
+				end_menu->add_item(E, nodes_to_connect.size());
+				nodes_to_connect.push_back(state_machine->end_node);
+				continue;
+			}
+
+			if (ansm.is_valid()) {
+				bool found = false;
+
+				for (int i = 0; i < parents.size(); i++) {
+					if (parents[i] == ansm) {
+						path = path.replace_first("/../" + E, "");
+						found = true;
+						break;
+					}
+				}
+
+				if (!found) {
+					state_machine_menu->add_item(E, nodes_to_connect.size());
+					nodes_to_connect.push_back(path);
+				} else {
+					end_menu->add_item(E, nodes_to_connect.size());
+					nodes_to_connect.push_back(path + "/" + state_machine->end_node);
+				}
+
+				if (_create_submenu(nodes_menu, ansm, E, path, false, parents)) {
+					nodes_menu->add_submenu_item(E, E);
+					node_added = true;
+				}
+			} else {
+				nodes_menu->add_item(E, nodes_to_connect.size());
+				nodes_to_connect.push_back(path);
+				node_added = true;
+			}
+		}
+	}
+
+	return node_added;
+}
+
+void AnimationNodeStateMachineEditor::_stop_connecting() {
+	connecting = false;
+	state_machine_draw->update();
+}
+
+void AnimationNodeStateMachineEditor::_delete_selected() {
+	TreeItem *item = delete_tree->get_next_selected(nullptr);
+	while (item) {
+		if (!updating) {
+			updating = true;
+			selected_multi_transition = TransitionLine();
+			undo_redo->create_action("Transition(s) Removed");
+		}
+
+		Vector<String> path = item->get_text(0).split(" -> ");
+
+		selected_transition_from = path[0];
+		selected_transition_to = path[1];
+		_erase_selected(true);
+
+		item = delete_tree->get_next_selected(item);
+	}
+
+	if (updating) {
+		undo_redo->commit_action();
+		updating = false;
+	}
+}
+
+void AnimationNodeStateMachineEditor::_delete_all() {
+	Vector<TransitionLine> multi_transitions = selected_multi_transition.multi_transitions;
+	selected_multi_transition = TransitionLine();
+
+	updating = true;
+	undo_redo->create_action("Transition(s) Removed");
+	_erase_selected(true);
+	for (int i = 0; i < multi_transitions.size(); i++) {
+		selected_transition_from = multi_transitions[i].from_node;
+		selected_transition_to = multi_transitions[i].to_node;
+		_erase_selected(true);
+	}
+	undo_redo->commit_action();
+	updating = false;
+
+	delete_window->hide();
+}
+
+void AnimationNodeStateMachineEditor::_delete_tree_draw() {
+	TreeItem *item = delete_tree->get_next_selected(nullptr);
+	while (item) {
+		delete_window->get_cancel_button()->set_disabled(false);
+		return;
+	}
+	delete_window->get_cancel_button()->set_disabled(true);
 }
 
 void AnimationNodeStateMachineEditor::_file_opened(const String &p_file) {
@@ -456,6 +974,8 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
 	undo_redo->add_do_method(this, "_update_graph");
 	undo_redo->add_undo_method(this, "_update_graph");
+	connecting_to_node = name;
+	_add_transition(true);
 	undo_redo->commit_action();
 	updating = false;
 
@@ -482,13 +1002,58 @@ void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
 	undo_redo->add_do_method(this, "_update_graph");
 	undo_redo->add_undo_method(this, "_update_graph");
+	connecting_to_node = name;
+	_add_transition(true);
 	undo_redo->commit_action();
 	updating = false;
 
 	state_machine_draw->update();
 }
 
-void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, bool p_auto_advance) {
+void AnimationNodeStateMachineEditor::_connect_to(int p_index) {
+	connecting_to_node = nodes_to_connect[p_index];
+	_add_transition();
+}
+
+void AnimationNodeStateMachineEditor::_add_transition(const bool p_nested_action) {
+	if (connecting_from != StringName() && connecting_to_node != StringName()) {
+		if (state_machine->has_transition(connecting_from, connecting_to_node)) {
+			EditorNode::get_singleton()->show_warning("Transition exists!");
+			connecting = false;
+			return;
+		}
+
+		Ref<AnimationNodeStateMachineTransition> tr;
+		tr.instantiate();
+		tr->set_switch_mode(AnimationNodeStateMachineTransition::SwitchMode(transition_mode->get_selected()));
+
+		if (!p_nested_action) {
+			updating = true;
+		}
+
+		undo_redo->create_action(TTR("Add Transition"));
+		undo_redo->add_do_method(state_machine.ptr(), "add_transition", connecting_from, connecting_to_node, tr);
+		undo_redo->add_undo_method(state_machine.ptr(), "remove_transition", connecting_from, connecting_to_node);
+		undo_redo->add_do_method(this, "_update_graph");
+		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->commit_action();
+
+		if (!p_nested_action) {
+			updating = false;
+		}
+
+		selected_transition_from = connecting_from;
+		selected_transition_to = connecting_to_node;
+		selected_transition_index = transition_lines.size();
+
+		EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
+		_update_mode();
+	}
+
+	connecting = false;
+}
+
+void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, bool p_auto_advance, bool p_multi_transitions) {
 	Color linecolor = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	Color icon_color(1, 1, 1);
 	Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
@@ -516,6 +1081,7 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 		linecolor = accent;
 		linecolor.set_hsv(1.0, linecolor.get_s(), linecolor.get_v());
 	}
+
 	state_machine_draw->draw_line(p_from, p_to, linecolor, 2);
 
 	Ref<Texture2D> icon = icons[p_mode + (p_auto_advance ? 3 : 0)];
@@ -526,7 +1092,13 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 	xf.elements[2] = (p_from + p_to) * 0.5 - xf.elements[1] * icon->get_height() * 0.5 - xf.elements[0] * icon->get_height() * 0.5;
 
 	state_machine_draw->draw_set_transform_matrix(xf);
-	state_machine_draw->draw_texture(icon, Vector2(), icon_color);
+	if (p_multi_transitions) {
+		state_machine_draw->draw_texture(icons[0], Vector2(-icon->get_width(), 0), icon_color);
+		state_machine_draw->draw_texture(icons[0], Vector2(), icon_color);
+		state_machine_draw->draw_texture(icons[0], Vector2(icon->get_width(), 0), icon_color);
+	} else {
+		state_machine_draw->draw_texture(icon, Vector2(), icon_color);
+	}
 	state_machine_draw->draw_set_transform_matrix(Transform2D());
 }
 
@@ -557,19 +1129,26 @@ void AnimationNodeStateMachineEditor::_clip_dst_line_to_rect(const Vector2 &p_fr
 void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	Ref<AnimationNodeStateMachinePlayback> playback = AnimationTreeEditor::get_singleton()->get_tree()->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
 
-	Ref<StyleBox> style = get_theme_stylebox(SNAME("state_machine_frame"), SNAME("GraphNode"));
-	Ref<StyleBox> style_selected = get_theme_stylebox(SNAME("state_machine_selected_frame"), SNAME("GraphNode"));
+	Ref<StyleBoxFlat> style = get_theme_stylebox(SNAME("state_machine_frame"), SNAME("GraphNode"));
+	Ref<StyleBoxFlat> style_selected = get_theme_stylebox(SNAME("state_machine_selected_frame"), SNAME("GraphNode"));
 
 	Ref<Font> font = get_theme_font(SNAME("title_font"), SNAME("GraphNode"));
 	int font_size = get_theme_font_size(SNAME("title_font_size"), SNAME("GraphNode"));
 	Color font_color = get_theme_color(SNAME("title_color"), SNAME("GraphNode"));
 	Ref<Texture2D> play = get_theme_icon(SNAME("Play"), SNAME("EditorIcons"));
-	Ref<Texture2D> auto_play = get_theme_icon(SNAME("AutoPlay"), SNAME("EditorIcons"));
 	Ref<Texture2D> edit = get_theme_icon(SNAME("Edit"), SNAME("EditorIcons"));
 	Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 	Color linecolor = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	linecolor.a *= 0.3;
 	Ref<StyleBox> playing_overlay = get_theme_stylebox(SNAME("position"), SNAME("GraphNode"));
+
+	Ref<StyleBoxFlat> start_overlay = style->duplicate();
+	start_overlay->set_border_width_all(1 * EDSCALE);
+	start_overlay->set_border_color(Color::html("#80f6cf"));
+
+	Ref<StyleBoxFlat> end_overlay = style->duplicate();
+	end_overlay->set_border_width_all(1 * EDSCALE);
+	end_overlay->set_border_color(Color::html("#f26661"));
 
 	bool playing = false;
 	StringName current;
@@ -612,22 +1191,25 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		Ref<AnimationNode> anode = state_machine->get_node(E);
 		String name = E;
 		bool needs_editor = EditorNode::get_singleton()->item_has_editor(anode.ptr());
-		Ref<StyleBox> sb = E == selected_node ? style_selected : style;
+		Ref<StyleBox> sb = selected_nodes.has(E) ? style_selected : style;
 
 		Size2 s = sb->get_minimum_size();
 		int strsize = font->get_string_size(name, font_size).width;
 		s.width += strsize;
 		s.height += MAX(font->get_height(font_size), play->get_height());
 		s.width += sep + play->get_width();
+
 		if (needs_editor) {
 			s.width += sep + edit->get_width();
 		}
 
 		Vector2 offset;
 		offset += state_machine->get_node_position(E) * EDSCALE;
-		if (selected_node == E && dragging_selected) {
+
+		if (selected_nodes.has(E) && dragging_selected) {
 			offset += drag_ofs;
 		}
+
 		offset -= s / 2;
 		offset = offset.floor();
 
@@ -666,7 +1248,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 			}
 		}
 
-		_connection_draw(from, to, AnimationNodeStateMachineTransition::SwitchMode(transition_mode->get_selected()), true, false, false, false);
+		_connection_draw(from, to, AnimationNodeStateMachineTransition::SwitchMode(transition_mode->get_selected()), true, false, false, false, false);
 	}
 
 	Ref<Texture2D> tr_reference_icon = get_theme_icon(SNAME("TransitionImmediateBig"), SNAME("EditorIcons"));
@@ -675,13 +1257,18 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	//draw transition lines
 	for (int i = 0; i < state_machine->get_transition_count(); i++) {
 		TransitionLine tl;
+		tl.transition_index = i;
 		tl.from_node = state_machine->get_transition_from(i);
-		Vector2 ofs_from = (dragging_selected && tl.from_node == selected_node) ? drag_ofs : Vector2();
-		tl.from = (state_machine->get_node_position(tl.from_node) * EDSCALE) + ofs_from - state_machine->get_graph_offset() * EDSCALE;
+		StringName local_from = String(tl.from_node).get_slicec('/', 0);
+		local_from = local_from == ".." ? state_machine->start_node : local_from;
+		Vector2 ofs_from = (dragging_selected && selected_nodes.has(local_from)) ? drag_ofs : Vector2();
+		tl.from = (state_machine->get_node_position(local_from) * EDSCALE) + ofs_from - state_machine->get_graph_offset() * EDSCALE;
 
 		tl.to_node = state_machine->get_transition_to(i);
-		Vector2 ofs_to = (dragging_selected && tl.to_node == selected_node) ? drag_ofs : Vector2();
-		tl.to = (state_machine->get_node_position(tl.to_node) * EDSCALE) + ofs_to - state_machine->get_graph_offset() * EDSCALE;
+		StringName local_to = String(tl.to_node).get_slicec('/', 0);
+		local_to = local_to == ".." ? state_machine->end_node : local_to;
+		Vector2 ofs_to = (dragging_selected && selected_nodes.has(local_to)) ? drag_ofs : Vector2();
+		tl.to = (state_machine->get_node_position(local_to) * EDSCALE) + ofs_to - state_machine->get_graph_offset() * EDSCALE;
 
 		Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(i);
 		tl.disabled = tr->is_disabled();
@@ -690,52 +1277,70 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		tl.advance_condition_state = false;
 		tl.mode = tr->get_switch_mode();
 		tl.width = tr_bidi_offset;
+		tl.travel = false;
+		tl.hidden = false;
 
-		if (state_machine->has_transition(tl.to_node, tl.from_node)) { //offset if same exists
+		if (state_machine->has_local_transition(local_to, local_from)) { //offset if same exists
 			Vector2 offset = -(tl.from - tl.to).normalized().orthogonal() * tr_bidi_offset;
 			tl.from += offset;
 			tl.to += offset;
 		}
 
 		for (int j = 0; j < node_rects.size(); j++) {
-			if (node_rects[j].node_name == tl.from_node) {
+			if (node_rects[j].node_name == local_from) {
 				_clip_src_line_to_rect(tl.from, tl.to, node_rects[j].node);
 			}
-			if (node_rects[j].node_name == tl.to_node) {
+			if (node_rects[j].node_name == local_to) {
 				_clip_dst_line_to_rect(tl.from, tl.to, node_rects[j].node);
 			}
 		}
 
-		bool selected = selected_transition_from == tl.from_node && selected_transition_to == tl.to_node;
+		tl.selected = selected_transition_from == tl.from_node && selected_transition_to == tl.to_node;
 
-		bool travel = false;
-
-		if (blend_from == tl.from_node && current == tl.to_node) {
-			travel = true;
+		if (blend_from == local_from && current == local_to) {
+			tl.travel = true;
 		}
 
 		if (travel_path.size()) {
-			if (current == tl.from_node && travel_path[0] == tl.to_node) {
-				travel = true;
+			if (current == local_from && travel_path[0] == local_to) {
+				tl.travel = true;
 			} else {
 				for (int j = 0; j < travel_path.size() - 1; j++) {
-					if (travel_path[j] == tl.from_node && travel_path[j + 1] == tl.to_node) {
-						travel = true;
+					if (travel_path[j] == local_from && travel_path[j + 1] == local_to) {
+						tl.travel = true;
 						break;
 					}
 				}
 			}
 		}
 
-		bool auto_advance = tl.auto_advance;
 		StringName fullpath = AnimationTreeEditor::get_singleton()->get_base_path() + String(tl.advance_condition_name);
 		if (tl.advance_condition_name != StringName() && bool(AnimationTreeEditor::get_singleton()->get_tree()->get(fullpath))) {
 			tl.advance_condition_state = true;
-			auto_advance = true;
+			tl.auto_advance = true;
 		}
-		_connection_draw(tl.from, tl.to, tl.mode, !tl.disabled, selected, travel, auto_advance);
 
+		// check if already have this local transition
+		for (int j = 0; j < transition_lines.size(); j++) {
+			StringName from = String(transition_lines[j].from_node).get_slicec('/', 0);
+			StringName to = String(transition_lines[j].to_node).get_slicec('/', 0);
+			from = from == ".." ? state_machine->start_node : from;
+			to = to == ".." ? state_machine->end_node : to;
+
+			if (from == local_from && to == local_to) {
+				tl.hidden = true;
+				transition_lines.write[j].disabled = transition_lines[j].disabled && tl.disabled;
+				transition_lines.write[j].multi_transitions.push_back(tl);
+			}
+		}
 		transition_lines.push_back(tl);
+	}
+
+	for (int i = 0; i < transition_lines.size(); i++) {
+		TransitionLine tl = transition_lines[i];
+		if (!tl.hidden) {
+			_connection_draw(tl.from, tl.to, tl.mode, !tl.disabled, tl.selected, tl.travel, tl.auto_advance, !tl.multi_transitions.is_empty());
+		}
 	}
 
 	//draw actual nodes
@@ -743,9 +1348,8 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		String name = node_rects[i].node_name;
 		Ref<AnimationNode> anode = state_machine->get_node(name);
 		bool needs_editor = AnimationTreeEditor::get_singleton()->can_edit(anode);
-		Ref<StyleBox> sb = name == selected_node ? style_selected : style;
+		Ref<StyleBox> sb = selected_nodes.has(name) ? style_selected : style;
 		int strsize = font->get_string_size(name, font_size).width;
-
 		NodeRect &nr = node_rects.write[i];
 
 		Vector2 offset = nr.node.position;
@@ -756,18 +1360,16 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		//now scroll it to draw
 		state_machine_draw->draw_style_box(sb, nr.node);
 
+		if (state_machine->start_node == name) {
+			state_machine_draw->draw_style_box(sb == style_selected ? style_selected : start_overlay, nr.node);
+		}
+
+		if (state_machine->end_node == name) {
+			state_machine_draw->draw_style_box(sb == style_selected ? style_selected : end_overlay, nr.node);
+		}
+
 		if (playing && (blend_from == name || current == name || travel_path.has(name))) {
 			state_machine_draw->draw_style_box(playing_overlay, nr.node);
-		}
-
-		bool onstart = state_machine->get_start_node() == name;
-		if (onstart) {
-			state_machine_draw->draw_string(font, offset + Vector2(0, -font->get_height(font_size) - 3 * EDSCALE + font->get_ascent(font_size)), TTR("Start"), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_color);
-		}
-
-		if (state_machine->get_end_node() == name) {
-			int endofs = nr.node.size.x - font->get_string_size(TTR("End"), font_size).x;
-			state_machine_draw->draw_string(font, offset + Vector2(endofs, -font->get_height(font_size) - 3 * EDSCALE + font->get_ascent(font_size)), TTR("End"), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_color);
 		}
 
 		offset.x += sb->get_offset().x;
@@ -775,13 +1377,14 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		nr.play.position = offset + Vector2(0, (h - play->get_height()) / 2).floor();
 		nr.play.size = play->get_size();
 
-		Ref<Texture2D> play_tex = onstart ? auto_play : play;
+		Ref<Texture2D> play_tex = play;
 
 		if (over_node == name && over_node_what == 0) {
 			state_machine_draw->draw_texture(play_tex, nr.play.position, accent);
 		} else {
 			state_machine_draw->draw_texture(play_tex, nr.play.position);
 		}
+
 		offset.x += sep + play->get_width();
 
 		nr.name.position = offset + Vector2(0, (h - font->get_height(font_size)) / 2).floor();
@@ -801,6 +1404,11 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 			}
 			offset.x += sep + edit->get_width();
 		}
+	}
+
+	//draw box select
+	if (box_selecting) {
+		state_machine_draw->draw_rect(box_selecting_rect, Color(0.7, 0.7, 1.0, 0.3));
 	}
 
 	scroll_range.position -= state_machine_draw->get_size();
@@ -826,6 +1434,10 @@ void AnimationNodeStateMachineEditor::_state_machine_pos_draw() {
 	Ref<AnimationNodeStateMachinePlayback> playback = AnimationTreeEditor::get_singleton()->get_tree()->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
 
 	if (!playback.is_valid() || !playback->is_playing()) {
+		return;
+	}
+
+	if (playback->get_current_node() == state_machine->start_node || playback->get_current_node() == state_machine->end_node) {
 		return;
 	}
 
@@ -902,8 +1514,8 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 			transition_mode->add_icon_item(get_theme_icon(SNAME("TransitionEnd"), SNAME("EditorIcons")), TTR("At End"));
 
 			tool_erase->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
-			tool_autoplay->set_icon(get_theme_icon(SNAME("AutoPlay"), SNAME("EditorIcons")));
-			tool_end->set_icon(get_theme_icon(SNAME("AutoEnd"), SNAME("EditorIcons")));
+			tool_group->set_icon(get_theme_icon(SNAME("Group"), SNAME("EditorIcons")));
+			tool_ungroup->set_icon(get_theme_icon(SNAME("Ungroup"), SNAME("EditorIcons")));
 
 			play_mode->clear();
 			play_mode->add_icon_item(get_theme_icon(SNAME("PlayTravel"), SNAME("EditorIcons")), TTR("Travel"));
@@ -1109,94 +1721,121 @@ void AnimationNodeStateMachineEditor::_scroll_changed(double) {
 	state_machine_draw->update();
 }
 
-void AnimationNodeStateMachineEditor::_erase_selected() {
-	if (selected_node != StringName() && state_machine->has_node(selected_node)) {
-		updating = true;
+void AnimationNodeStateMachineEditor::_erase_selected(const bool p_nested_action) {
+	if (!selected_nodes.is_empty()) {
+		if (!p_nested_action) {
+			updating = true;
+		}
 		undo_redo->create_action(TTR("Node Removed"));
-		undo_redo->add_do_method(state_machine.ptr(), "remove_node", selected_node);
-		undo_redo->add_undo_method(state_machine.ptr(), "add_node", selected_node, state_machine->get_node(selected_node), state_machine->get_node_position(selected_node));
-		for (int i = 0; i < state_machine->get_transition_count(); i++) {
-			String from = state_machine->get_transition_from(i);
-			String to = state_machine->get_transition_to(i);
-			if (from == selected_node || to == selected_node) {
-				undo_redo->add_undo_method(state_machine.ptr(), "add_transition", from, to, state_machine->get_transition(i));
+
+		for (int i = 0; i < node_rects.size(); i++) {
+			if (node_rects[i].node_name == state_machine->start_node || node_rects[i].node_name == state_machine->end_node) {
+				continue;
+			}
+
+			if (!selected_nodes.has(node_rects[i].node_name)) {
+				continue;
+			}
+
+			undo_redo->add_do_method(state_machine.ptr(), "remove_node", node_rects[i].node_name);
+			undo_redo->add_undo_method(state_machine.ptr(), "add_node", node_rects[i].node_name,
+					state_machine->get_node(node_rects[i].node_name),
+					state_machine->get_node_position(node_rects[i].node_name));
+
+			for (int j = 0; j < state_machine->get_transition_count(); j++) {
+				String from = state_machine->get_transition_from(j);
+				String to = state_machine->get_transition_to(j);
+				String local_from = from.get_slicec('/', 0);
+				String local_to = to.get_slicec('/', 0);
+
+				if (local_from == node_rects[i].node_name || local_to == node_rects[i].node_name) {
+					undo_redo->add_undo_method(state_machine.ptr(), "add_transition", from, to, state_machine->get_transition(j));
+				}
 			}
 		}
-		if (String(state_machine->get_start_node()) == selected_node) {
-			undo_redo->add_undo_method(state_machine.ptr(), "set_start_node", selected_node);
-		}
+
 		undo_redo->add_do_method(this, "_update_graph");
 		undo_redo->add_undo_method(this, "_update_graph");
 		undo_redo->commit_action();
-		updating = false;
-		selected_node = StringName();
+
+		if (!p_nested_action) {
+			updating = false;
+		}
+
+		selected_nodes.clear();
+	}
+
+	if (!selected_multi_transition.multi_transitions.is_empty()) {
+		delete_tree->clear();
+
+		TreeItem *root = delete_tree->create_item();
+
+		TreeItem *item = delete_tree->create_item(root);
+		item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+		item->set_text(0, String(selected_transition_from) + " -> " + selected_transition_to);
+		item->set_editable(0, true);
+
+		for (int i = 0; i < selected_multi_transition.multi_transitions.size(); i++) {
+			String from = selected_multi_transition.multi_transitions[i].from_node;
+			String to = selected_multi_transition.multi_transitions[i].to_node;
+
+			item = delete_tree->create_item(root);
+			item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+			item->set_text(0, from + " -> " + to);
+			item->set_editable(0, true);
+		}
+
+		delete_window->popup_centered(Vector2(400, 200));
+		return;
 	}
 
 	if (selected_transition_to != StringName() && selected_transition_from != StringName() && state_machine->has_transition(selected_transition_from, selected_transition_to)) {
 		Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(state_machine->find_transition(selected_transition_from, selected_transition_to));
-		updating = true;
+		if (!p_nested_action) {
+			updating = true;
+		}
 		undo_redo->create_action(TTR("Transition Removed"));
 		undo_redo->add_do_method(state_machine.ptr(), "remove_transition", selected_transition_from, selected_transition_to);
 		undo_redo->add_undo_method(state_machine.ptr(), "add_transition", selected_transition_from, selected_transition_to, tr);
 		undo_redo->add_do_method(this, "_update_graph");
 		undo_redo->add_undo_method(this, "_update_graph");
 		undo_redo->commit_action();
-		updating = false;
+		if (!p_nested_action) {
+			updating = false;
+		}
 		selected_transition_from = StringName();
 		selected_transition_to = StringName();
+		selected_transition_index = -1;
+		selected_multi_transition = TransitionLine();
 	}
 
 	state_machine_draw->update();
 }
 
-void AnimationNodeStateMachineEditor::_autoplay_selected() {
-	if (selected_node != StringName() && state_machine->has_node(selected_node)) {
-		StringName new_start_node;
-		if (state_machine->get_start_node() == selected_node) { //toggle it
-			new_start_node = StringName();
-		} else {
-			new_start_node = selected_node;
-		}
-
-		updating = true;
-		undo_redo->create_action(TTR("Set Start Node (Autoplay)"));
-		undo_redo->add_do_method(state_machine.ptr(), "set_start_node", new_start_node);
-		undo_redo->add_undo_method(state_machine.ptr(), "set_start_node", state_machine->get_start_node());
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
-		undo_redo->commit_action();
-		updating = false;
-		state_machine_draw->update();
-	}
-}
-
-void AnimationNodeStateMachineEditor::_end_selected() {
-	if (selected_node != StringName() && state_machine->has_node(selected_node)) {
-		StringName new_end_node;
-		if (state_machine->get_end_node() == selected_node) { //toggle it
-			new_end_node = StringName();
-		} else {
-			new_end_node = selected_node;
-		}
-
-		updating = true;
-		undo_redo->create_action(TTR("Set Start Node (Autoplay)"));
-		undo_redo->add_do_method(state_machine.ptr(), "set_end_node", new_end_node);
-		undo_redo->add_undo_method(state_machine.ptr(), "set_end_node", state_machine->get_end_node());
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
-		undo_redo->commit_action();
-		updating = false;
-		state_machine_draw->update();
-	}
-}
-
 void AnimationNodeStateMachineEditor::_update_mode() {
 	if (tool_select->is_pressed()) {
 		tool_erase_hb->show();
-		tool_erase->set_disabled(selected_node == StringName() && selected_transition_from == StringName() && selected_transition_to == StringName());
-		tool_autoplay->set_disabled(selected_node == StringName());
-		tool_end->set_disabled(selected_node == StringName());
+		bool nothing_selected = selected_nodes.is_empty() && selected_transition_from == StringName() && selected_transition_to == StringName();
+		bool start_end_selected = selected_nodes.size() == 1 && (selected_nodes.front()->get() == state_machine->start_node || selected_nodes.front()->get() == state_machine->end_node);
+		tool_erase->set_disabled(nothing_selected || start_end_selected);
+
+		if (selected_nodes.is_empty() || start_end_selected) {
+			tool_group->set_disabled(true);
+			tool_group->set_visible(true);
+			tool_ungroup->set_visible(false);
+		} else {
+			Ref<AnimationNodeStateMachine> ansm = state_machine->get_node(selected_nodes.front()->get());
+
+			if (selected_nodes.size() == 1 && ansm.is_valid()) {
+				tool_group->set_disabled(true);
+				tool_group->set_visible(false);
+				tool_ungroup->set_visible(true);
+			} else {
+				tool_group->set_disabled(false);
+				tool_group->set_visible(true);
+				tool_ungroup->set_visible(false);
+			}
+		}
 	} else {
 		tool_erase_hb->hide();
 	}
@@ -1204,10 +1843,13 @@ void AnimationNodeStateMachineEditor::_update_mode() {
 
 void AnimationNodeStateMachineEditor::_bind_methods() {
 	ClassDB::bind_method("_update_graph", &AnimationNodeStateMachineEditor::_update_graph);
-
 	ClassDB::bind_method("_removed_from_graph", &AnimationNodeStateMachineEditor::_removed_from_graph);
-
 	ClassDB::bind_method("_open_editor", &AnimationNodeStateMachineEditor::_open_editor);
+	ClassDB::bind_method("_connect_to", &AnimationNodeStateMachineEditor::_connect_to);
+	ClassDB::bind_method("_stop_connecting", &AnimationNodeStateMachineEditor::_stop_connecting);
+	ClassDB::bind_method("_delete_selected", &AnimationNodeStateMachineEditor::_delete_selected);
+	ClassDB::bind_method("_delete_all", &AnimationNodeStateMachineEditor::_delete_all);
+	ClassDB::bind_method("_delete_tree_draw", &AnimationNodeStateMachineEditor::_delete_tree_draw);
 }
 
 AnimationNodeStateMachineEditor *AnimationNodeStateMachineEditor::singleton = nullptr;
@@ -1227,7 +1869,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_select->set_toggle_mode(true);
 	tool_select->set_button_group(bg);
 	tool_select->set_pressed(true);
-	tool_select->set_tooltip(TTR("Select and move nodes.\nRMB to add new nodes.\nShift+LMB to create connections."));
+	tool_select->set_tooltip(TTR("Select and move nodes.\nRMB: Add node at position clicked.\nShift+LMB+Drag: Connects the selected node with another node or creates a new node if you select an area without nodes."));
 	tool_select->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
 
 	tool_create = memnew(Button);
@@ -1249,28 +1891,27 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_erase_hb = memnew(HBoxContainer);
 	top_hb->add_child(tool_erase_hb);
 	tool_erase_hb->add_child(memnew(VSeparator));
+
+	tool_group = memnew(Button);
+	tool_group->set_flat(true);
+	tool_group->set_tooltip(TTR("Group Selected Node(s)") + " (Ctrl+G)");
+	tool_group->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_group_selected_nodes));
+	tool_group->set_disabled(true);
+	tool_erase_hb->add_child(tool_group);
+
+	tool_ungroup = memnew(Button);
+	tool_ungroup->set_flat(true);
+	tool_ungroup->set_tooltip(TTR("Ungroup Selected Node") + " (Ctrl+Shift+G)");
+	tool_ungroup->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_ungroup_selected_nodes));
+	tool_ungroup->set_visible(false);
+	tool_erase_hb->add_child(tool_ungroup);
+
 	tool_erase = memnew(Button);
 	tool_erase->set_flat(true);
 	tool_erase->set_tooltip(TTR("Remove selected node or transition."));
-	tool_erase_hb->add_child(tool_erase);
-	tool_erase->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_erase_selected));
+	tool_erase->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_erase_selected), varray(false));
 	tool_erase->set_disabled(true);
-
-	tool_erase_hb->add_child(memnew(VSeparator));
-
-	tool_autoplay = memnew(Button);
-	tool_autoplay->set_flat(true);
-	tool_autoplay->set_tooltip(TTR("Toggle autoplay this animation on start, restart or seek to zero."));
-	tool_erase_hb->add_child(tool_autoplay);
-	tool_autoplay->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_autoplay_selected));
-	tool_autoplay->set_disabled(true);
-
-	tool_end = memnew(Button);
-	tool_end->set_flat(true);
-	tool_end->set_tooltip(TTR("Set the end animation. This is useful for sub-transitions."));
-	tool_erase_hb->add_child(tool_end);
-	tool_end->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_end_selected));
-	tool_end->set_disabled(true);
+	tool_erase_hb->add_child(tool_erase);
 
 	top_hb->add_child(memnew(VSeparator));
 	top_hb->add_child(memnew(Label(TTR("Transition: "))));
@@ -1326,11 +1967,27 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	menu = memnew(PopupMenu);
 	add_child(menu);
 	menu->connect("id_pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_add_menu_type));
+	menu->connect("popup_hide", callable_mp(this, &AnimationNodeStateMachineEditor::_stop_connecting));
 
 	animations_menu = memnew(PopupMenu);
 	menu->add_child(animations_menu);
 	animations_menu->set_name("animations");
 	animations_menu->connect("index_pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_add_animation_type));
+
+	connect_menu = memnew(PopupMenu);
+	add_child(connect_menu);
+	connect_menu->connect("id_pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_connect_to));
+	connect_menu->connect("popup_hide", callable_mp(this, &AnimationNodeStateMachineEditor::_stop_connecting));
+
+	state_machine_menu = memnew(PopupMenu);
+	state_machine_menu->set_name("state_machines");
+	state_machine_menu->connect("id_pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_connect_to));
+	connect_menu->add_child(state_machine_menu);
+
+	end_menu = memnew(PopupMenu);
+	end_menu->set_name("end_nodes");
+	end_menu->connect("id_pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_connect_to));
+	connect_menu->add_child(end_menu);
 
 	name_edit_popup = memnew(Popup);
 	add_child(name_edit_popup);
@@ -1346,4 +2003,95 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	open_file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	open_file->connect("file_selected", callable_mp(this, &AnimationNodeStateMachineEditor::_file_opened));
 	undo_redo = EditorNode::get_undo_redo();
+
+	delete_window = memnew(ConfirmationDialog);
+	delete_window->set_flag(Window::FLAG_RESIZE_DISABLED, true);
+	add_child(delete_window);
+
+	delete_tree = memnew(Tree);
+	delete_tree->set_hide_root(true);
+	delete_tree->connect("draw", callable_mp(this, &AnimationNodeStateMachineEditor::_delete_tree_draw));
+	delete_window->add_child(delete_tree);
+
+	Button *ok = delete_window->get_cancel_button();
+	ok->set_text(TTR("Delete Selected"));
+	ok->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_delete_selected));
+
+	Button *delete_all = delete_window->add_button(TTR("Delete All"), true);
+	delete_all->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_delete_all));
+
+	over_node_what = -1;
+	dragging_selected_attempt = false;
+	connecting = false;
+	selected_transition_index = -1;
+
+	last_active = false;
+
+	error_time = 0;
+}
+
+void EditorAnimationMultiTransitionEdit::add_transition(const StringName &p_from, const StringName &p_to, Ref<AnimationNodeStateMachineTransition> p_transition) {
+	Transition tr;
+	tr.from = p_from;
+	tr.to = p_to;
+	tr.transition = p_transition;
+	transitions.push_back(tr);
+}
+
+bool EditorAnimationMultiTransitionEdit::_set(const StringName &p_name, const Variant &p_property) {
+	int index = String(p_name).get_slicec('/', 0).to_int();
+	StringName prop = String(p_name).get_slicec('/', 1);
+
+	bool found;
+	transitions.write[index].transition->set(prop, p_property, &found);
+	if (found) {
+		return true;
+	}
+
+	return false;
+}
+
+bool EditorAnimationMultiTransitionEdit::_get(const StringName &p_name, Variant &r_property) const {
+	int index = String(p_name).get_slicec('/', 0).to_int();
+	StringName prop = String(p_name).get_slicec('/', 1);
+
+	if (prop == "transition_path") {
+		r_property = String(transitions[index].from) + " -> " + transitions[index].to;
+		return true;
+	}
+
+	bool found;
+	r_property = transitions[index].transition->get(prop, &found);
+	if (found) {
+		return true;
+	}
+
+	return false;
+}
+
+void EditorAnimationMultiTransitionEdit::_get_property_list(List<PropertyInfo> *p_list) const {
+	for (int i = 0; i < transitions.size(); i++) {
+		List<PropertyInfo> plist;
+		transitions[i].transition->get_property_list(&plist, true);
+
+		PropertyInfo prop_transition_path;
+		prop_transition_path.type = Variant::STRING;
+		prop_transition_path.name = itos(i) + "/" + "transition_path";
+		p_list->push_back(prop_transition_path);
+
+		for (List<PropertyInfo>::Element *F = plist.front(); F; F = F->next()) {
+			if (F->get().name == "script" || F->get().name == "resource_name" || F->get().name == "resource_path" || F->get().name == "resource_local_to_scene") {
+				continue;
+			}
+
+			if (F->get().usage != PROPERTY_USAGE_DEFAULT) {
+				continue;
+			}
+
+			PropertyInfo prop = F->get();
+			prop.name = itos(i) + "/" + prop.name;
+
+			p_list->push_back(prop);
+		}
+	}
 }

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -50,13 +50,13 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	Button *tool_select = nullptr;
 	Button *tool_create = nullptr;
 	Button *tool_connect = nullptr;
+	Button *tool_group = nullptr;
+	Button *tool_ungroup = nullptr;
 	Popup *name_edit_popup = nullptr;
 	LineEdit *name_edit = nullptr;
 
 	HBoxContainer *tool_erase_hb = nullptr;
 	Button *tool_erase = nullptr;
-	Button *tool_autoplay = nullptr;
-	Button *tool_end = nullptr;
 
 	OptionButton *transition_mode = nullptr;
 	OptionButton *play_mode = nullptr;
@@ -64,6 +64,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	PanelContainer *panel = nullptr;
 
 	StringName selected_node;
+	Set<StringName> selected_nodes;
 
 	HScrollBar *h_scroll = nullptr;
 	VScrollBar *v_scroll = nullptr;
@@ -81,17 +82,30 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	static AnimationNodeStateMachineEditor *singleton;
 
 	void _state_machine_gui_input(const Ref<InputEvent> &p_event);
-	void _connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, bool p_auto_advance);
+	void _connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, bool p_auto_advance, bool p_multi_transitions);
 	void _state_machine_draw();
 	void _state_machine_pos_draw();
 
 	void _update_graph();
 
 	PopupMenu *menu = nullptr;
+	PopupMenu *connect_menu = nullptr;
+	PopupMenu *state_machine_menu = nullptr;
+	PopupMenu *end_menu = nullptr;
 	PopupMenu *animations_menu = nullptr;
 	Vector<String> animations_to_add;
+	Vector<String> nodes_to_connect;
 
 	Vector2 add_node_pos;
+
+	ConfirmationDialog *delete_window;
+	Tree *delete_tree;
+
+	bool box_selecting = false;
+	Point2 box_selecting_from;
+	Point2 box_selecting_to;
+	Rect2 box_selecting_rect;
+	Set<StringName> previous_selected;
 
 	bool dragging_selected_attempt = false;
 	bool dragging_selected = false;
@@ -107,6 +121,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 	void _add_menu_type(int p_index);
 	void _add_animation_type(int p_index);
+	void _connect_to(int p_index);
 
 	void _removed_from_graph();
 
@@ -131,12 +146,34 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 		bool disabled = false;
 		bool auto_advance = false;
 		float width = 0;
+		bool selected;
+		bool travel;
+		bool hidden;
+		int transition_index;
+		Vector<TransitionLine> multi_transitions;
 	};
 
 	Vector<TransitionLine> transition_lines;
 
+	struct NodeUR {
+		StringName name;
+		Ref<AnimationNode> node;
+		Vector2 position;
+	};
+
+	struct TransitionUR {
+		StringName new_from;
+		StringName new_to;
+		StringName old_from;
+		StringName old_to;
+		Ref<AnimationNodeStateMachineTransition> transition;
+	};
+
 	StringName selected_transition_from;
 	StringName selected_transition_to;
+	int selected_transition_index;
+	TransitionLine selected_multi_transition;
+	void _add_transition(const bool p_nested_action = false);
 
 	StringName over_node;
 	int over_node_what = -1;
@@ -150,10 +187,19 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	void _clip_src_line_to_rect(Vector2 &r_from, const Vector2 &p_to, const Rect2 &p_rect);
 	void _clip_dst_line_to_rect(const Vector2 &p_from, Vector2 &r_to, const Rect2 &p_rect);
 
-	void _erase_selected();
+	void _erase_selected(const bool p_nested_action = false);
 	void _update_mode();
-	void _autoplay_selected();
-	void _end_selected();
+	void _open_menu(const Vector2 &p_position);
+	void _open_connect_menu(const Vector2 &p_position);
+	bool _create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path, bool from_root = false, Vector<Ref<AnimationNodeStateMachine>> p_parents = Vector<Ref<AnimationNodeStateMachine>>());
+	void _stop_connecting();
+
+	void _group_selected_nodes();
+	void _ungroup_selected_nodes();
+
+	void _delete_selected();
+	void _delete_all();
+	void _delete_tree_draw();
 
 	bool last_active = false;
 	StringName last_blend_from_node;
@@ -186,6 +232,28 @@ public:
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	AnimationNodeStateMachineEditor();
+};
+
+class EditorAnimationMultiTransitionEdit : public RefCounted {
+	GDCLASS(EditorAnimationMultiTransitionEdit, RefCounted);
+
+	struct Transition {
+		StringName from;
+		StringName to;
+		Ref<AnimationNodeStateMachineTransition> transition;
+	};
+
+	Vector<Transition> transitions;
+
+protected:
+	bool _set(const StringName &p_name, const Variant &p_property);
+	bool _get(const StringName &p_name, Variant &r_property) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+public:
+	void add_transition(const StringName &p_from, const StringName &p_to, Ref<AnimationNodeStateMachineTransition> p_transition);
+
+	EditorAnimationMultiTransitionEdit(){};
 };
 
 #endif // ANIMATION_STATE_MACHINE_EDITOR_H

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -37,6 +37,8 @@
 #include "scene/resources/animation.h"
 
 class AnimationNodeBlendTree;
+class AnimationNodeStartState;
+class AnimationNodeEndState;
 class AnimationPlayer;
 class AnimationTree;
 
@@ -162,6 +164,14 @@ class AnimationRootNode : public AnimationNode {
 
 public:
 	AnimationRootNode() {}
+};
+
+class AnimationNodeStartState : public AnimationRootNode {
+	GDCLASS(AnimationNodeStartState, AnimationRootNode);
+};
+
+class AnimationNodeEndState : public AnimationRootNode {
+	GDCLASS(AnimationNodeEndState, AnimationRootNode);
 };
 
 class AnimationTree : public Node {


### PR DESCRIPTION
Closes #19773.

Notes about the implementation: https://github.com/godotengine/godot/pull/24402#issuecomment-1038117414

Open the menu to add new animation nodes by dragging the transitions to empty areas and automatically connecting them:
![peek 10-02-2019 16-34](https://user-images.githubusercontent.com/1387165/52537828-f2c35800-2d51-11e9-8790-d305ca1f6f05.gif)
Adds box selection to the state machine:
![peek 10-02-2019 16-35](https://user-images.githubusercontent.com/1387165/52537830-f3f48500-2d51-11e9-97d5-83091a5eab49.gif)
Add feature to group/ungroup selected nodes in a "sub" state machine:
![peek 10-02-2019 16-37](https://user-images.githubusercontent.com/1387165/52537842-3cac3e00-2d52-11e9-83a7-e10518398898.gif)
Add popup to connect nodes in sub state machine:
![peek 10-02-2019 16-40](https://user-images.githubusercontent.com/1387165/52537869-9d3b7b00-2d52-11e9-8867-7ae1c4f5f126.gif)
Add new "type" of transition line when multiple transitions are grouped:
![peek 10-02-2019 16-44](https://user-images.githubusercontent.com/1387165/52537906-19ce5980-2d53-11e9-8905-64d006e2ab9a.gif)
Add dialog to select which transitions can be deleted when they are grouped:
![peek 10-02-2019 16-45](https://user-images.githubusercontent.com/1387165/52537922-4b472500-2d53-11e9-8c28-3d40d0a44608.gif)
