### PR TITLE
Fix titles in graph editors being invisible when headers are enabled

### DIFF
--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -650,6 +650,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	snap->set_toggle_mode(true);
 	top_hb->add_child(snap);
 	snap->set_pressed(true);
+	snap->set_tooltip(TTR("Enable snap and show grid."));
 	snap->connect("pressed", this, "_snap_toggled");
 
 	snap_value = memnew(SpinBox);

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -904,8 +904,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	snap = memnew(ToolButton);
 	snap->set_toggle_mode(true);
 	top_hb->add_child(snap);
-	//snap->set_text(TTR("Snap"));
 	snap->set_pressed(true);
+	snap->set_tooltip(TTR("Enable snap and show grid."));
 	snap->connect("pressed", this, "_snap_toggled");
 
 	snap_x = memnew(SpinBox);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -237,23 +237,17 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			mb->get_popup()->connect("index_pressed", this, "_anim_selected", varray(options, E->get()), CONNECT_DEFERRED);
 		}
 
-		/* should be no longer necessary, as the boolean works
-		Ref<AnimationNodeOneShot> oneshot = agnode;
-		if (oneshot.is_valid()) {
+		if (EditorSettings::get_singleton()->get("interface/theme/use_graph_node_headers")) {
+			Ref<StyleBoxFlat> sb = node->get_stylebox("frame", "GraphNode");
+			Color c = sb->get_border_color(MARGIN_TOP);
+			Color mono_color = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0) : Color(0.0, 0.0, 0.0);
+			mono_color.a = 0.85;
+			c = mono_color;
 
-			HBoxContainer *play_stop = memnew(HBoxContainer);
-			play_stop->add_spacer();
-			Button *play = memnew(Button);
-			play->set_icon(get_icon("Play", "EditorIcons"));
-			play->connect("pressed", this, "_oneshot_start", varray(E->get()), CONNECT_DEFERRED);
-			play_stop->add_child(play);
-			Button *stop = memnew(Button);
-			stop->set_icon(get_icon("Stop", "EditorIcons"));
-			stop->connect("pressed", this, "_oneshot_stop", varray(E->get()), CONNECT_DEFERRED);
-			play_stop->add_child(stop);
-			play_stop->add_spacer();
-			node->add_child(play_stop);
-		} */
+			node->add_color_override("title_color", c);
+			c.a = 0.7;
+			node->add_color_override("close_color", c);
+		}
 	}
 
 	List<AnimationNodeBlendTree::NodeConnection> connections;
@@ -646,6 +640,9 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 
 		error_panel->add_style_override("panel", get_stylebox("bg", "Tree"));
 		error_label->add_color_override("font_color", get_color("error_color", "Editor"));
+
+		if (p_what == NOTIFICATION_THEME_CHANGED && is_visible_in_tree())
+			_update_graph();
 	}
 
 	if (p_what == NOTIFICATION_PROCESS) {

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -118,7 +118,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			menu->add_item(TTR("Paste"), MENU_PASTE);
 		}
 		menu->add_separator();
-		menu->add_item(TTR("Load.."), MENU_LOAD_FILE);
+		menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
 		menu->set_global_position(state_machine_draw->get_global_transform().xform(mb->get_position()));
 		menu->popup();
@@ -1267,7 +1267,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	top_hb->add_child(tool_erase_hb);
 	tool_erase_hb->add_child(memnew(VSeparator));
 	tool_erase = memnew(ToolButton);
-	tool_erase->set_tooltip(TTR("Remove selected node or transition"));
+	tool_erase->set_tooltip(TTR("Remove selected node or transition."));
 	tool_erase_hb->add_child(tool_erase);
 	tool_erase->connect("pressed", this, "_erase_selected");
 	tool_erase->set_disabled(true);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -341,6 +341,18 @@ void VisualShaderEditor::_update_graph() {
 			node->add_child(hb);
 
 			node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], valid_right, port_right, type_color[port_right]);
+
+			if (EditorSettings::get_singleton()->get("interface/theme/use_graph_node_headers")) {
+				Ref<StyleBoxFlat> sb = node->get_stylebox("frame", "GraphNode");
+				Color c = sb->get_border_color(MARGIN_TOP);
+				Color mono_color = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0) : Color(0.0, 0.0, 0.0);
+				mono_color.a = 0.85;
+				c = mono_color;
+
+				node->add_color_override("title_color", c);
+				c.a = 0.7;
+				node->add_color_override("close_color", c);
+			}
 		}
 
 		if (vsnode->get_output_port_for_preview() >= 0) {
@@ -605,6 +617,9 @@ void VisualShaderEditor::_notification(int p_what) {
 
 		error_panel->add_style_override("panel", get_stylebox("bg", "Tree"));
 		error_label->add_color_override("font_color", get_color("error_color", "Editor"));
+
+		if (p_what == NOTIFICATION_THEME_CHANGED && is_visible_in_tree())
+			_update_graph();
 	}
 
 	if (p_what == NOTIFICATION_PROCESS) {


### PR DESCRIPTION
**Before:**
![screenshot at 2018-12-16 23-26-07](https://user-images.githubusercontent.com/30739239/50061736-c993aa80-019a-11e9-9998-091143226ca7.png)
**After:**
![screenshot at 2018-12-16 23-21-55](https://user-images.githubusercontent.com/30739239/50061738-cac4d780-019a-11e9-916f-d4d0cde2b7e3.png)

Also some small tooltip tweaks.