### PR TITLE
Fix bread crumb of AnimationTree

### DIFF
--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -64,28 +64,9 @@ void AnimationTreeEditor::edit(AnimationTree *p_tree) {
 
 void AnimationTreeEditor::_path_button_pressed(int p_path) {
 
-	Ref<AnimationNode> node = tree->get_tree_root();
-	if (node.is_null())
-		return;
-
 	edited_path.clear();
-	if (p_path >= 0) {
-		for (int i = 0; i <= p_path; i++) {
-			Ref<AnimationNode> child = node->get_child_by_name(button_path[i]);
-			ERR_BREAK(child.is_null());
-			node = child;
-			edited_path.push_back(button_path[i]);
-		}
-	}
-
-	for (int i = 0; i < editors.size(); i++) {
-		if (editors[i]->can_edit(node)) {
-			editors[i]->edit(node);
-			editors[i]->show();
-		} else {
-			editors[i]->edit(Ref<AnimationNode>());
-			editors[i]->hide();
-		}
+	for (int i = 0; i <= p_path; i++) {
+		edited_path.push_back(button_path[i]);
 	}
 }
 
@@ -175,6 +156,10 @@ void AnimationTreeEditor::_notification(int p_what) {
 
 		if (root != current_root) {
 			edit_path(Vector<String>());
+		}
+
+		if (button_path.size() != edited_path.size()) {
+			edit_path(edited_path);
 		}
 	}
 }


### PR DESCRIPTION
Before:
![peek 17-12-2018 17-12](https://user-images.githubusercontent.com/1387165/50109451-00130900-021f-11e9-954e-2a1124df8a12.gif)

After:
![peek 17-12-2018 17-07](https://user-images.githubusercontent.com/1387165/50109447-fdb0af00-021e-11e9-8d32-aa025bce93d4.gif)
