### PR TITLE
Label: Fix kerning when using Uppercase mode

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -244,7 +244,7 @@ void Label::_notification(int p_what) {
 							CharType n = xl_text[i + pos + 1];
 							if (uppercase) {
 								c = String::char_uppercase(c);
-								n = String::char_uppercase(c);
+								n = String::char_uppercase(n);
 							}
 
 							float move = font->draw_char(ci, Point2(x_ofs_shadow, y_ofs) + shadow_ofs, c, n, font_color_shadow, false);
@@ -265,7 +265,7 @@ void Label::_notification(int p_what) {
 						CharType n = xl_text[i + pos + 1];
 						if (uppercase) {
 							c = String::char_uppercase(c);
-							n = String::char_uppercase(c);
+							n = String::char_uppercase(n);
 						}
 
 						x_ofs += drawer.draw_char(ci, Point2(x_ofs, y_ofs), c, n, font_color);


### PR DESCRIPTION
Seemingly a typo, I did not check what exact impact it had, but
the x_ofs would likely have accumulated errors when using fonts
with varying char widths.