### PR TITLE
Don't accidentally convert string content to char

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -395,7 +395,7 @@ void Label::regenerate_word_cache() {
 
 	for (int i = 0; i <= xl_text.length(); i++) {
 
-		CharType current = i < xl_text.length() ? xl_text[i] : ' '; //always a space at the end, so the algo works
+		CharType current = i < xl_text.length() ? xl_text[i] : L' '; //always a space at the end, so the algo works
 
 		if (uppercase)
 			current = String::char_uppercase(current);


### PR DESCRIPTION
Due to the right hand side of the :? trickery the rhs was cast to a
char losing precision. Previously this didn't matter, but with
CharProxy it does. (Previously we could just happily cast it back to
a wchar_t and get the original 16 - 32 bits. Now we'll only ever
get the first 8).

this fixes #24424