### PR TITLE
Change *_slot to *_port on get_connection_list

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -82,7 +82,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Return an Array containing the list of connections. A connection consists in a structure of the form {from_slot: 0, from: "GraphNode name 0", to_slot: 1, to: "GraphNode name 1" }
+				Return an Array containing the list of connections. A connection consists in a structure of the form {from_port: 0, from: "GraphNode name 0", to_port: 1, to: "GraphNode name 1" }
 			</description>
 		</method>
 		<method name="get_zoom_hbox">


### PR DESCRIPTION
In the [current documentation](https://docs.godotengine.org/en/latest/classes/class_graphedit.html), it's stated that `get_connection_list()` does the following:

> Return an Array containing the list of connections. A connection consists in a structure of the form {from_slot: 0, from: “GraphNode name 0”, to_slot: 1, to: “GraphNode name 1” }

However, when analyzing the return of this function, it actually returns `from_port` and `to_port` instead of `from_slot` and `to_slot`. This can also be noticed on [the GraphEditor header](https://github.com/godotengine/godot/blob/596ba888690fee0abf99a5dddf022555b00d62a1/scene/gui/graph_edit.h), as the `Connection` structure is defined as `*_port`.