### PR TITLE
Make the AnimationTree editor's path section more obvious

### DIFF
--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -90,8 +90,8 @@ void AnimationTreeEditor::_path_button_pressed(int p_path) {
 }
 
 void AnimationTreeEditor::_update_path() {
-	while (path_hb->get_child_count()) {
-		memdelete(path_hb->get_child(0));
+	while (path_hb->get_child_count() > 1) {
+		memdelete(path_hb->get_child(1));
 	}
 
 	Ref<ButtonGroup> group;
@@ -251,6 +251,9 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	path_edit->set_enable_v_scroll(false);
 	path_hb = memnew(HBoxContainer);
 	path_edit->add_child(path_hb);
+	path_hb->add_child(memnew(Label(TTR("Path:"))));
+
+	add_child(memnew(HSeparator));
 
 	current_root = 0;
 	singleton = this;


### PR DESCRIPTION
![screenshot at 2018-12-17 23-51-24](https://user-images.githubusercontent.com/30739239/50127170-e2b65d00-0267-11e9-88c3-43b84925d5c8.png)
