### PR TITLE
fix near infinite loop when no previous mouse position

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -435,7 +435,7 @@ void Viewport::_notification(int p_what) {
 						}
 					}
 
-					if (!has_mouse_motion) {
+					if (!has_mouse_motion && physics_has_last_mousepos) {
 						Ref<InputEventMouseMotion> mm;
 						mm.instance();
 						mm->set_global_position(physics_last_mousepos);
@@ -465,6 +465,7 @@ void Viewport::_notification(int p_what) {
 
 						pos = mm->get_position();
 						motion_tested = true;
+						physics_has_last_mousepos = true;
 						physics_last_mousepos = pos;
 						physics_last_mouse_state.alt = mm->get_alt();
 						physics_last_mouse_state.shift = mm->get_shift();
@@ -643,7 +644,7 @@ void Viewport::_notification(int p_what) {
 					}
 				}
 
-				if (!motion_tested && camera && physics_last_mousepos != Vector2(1e20, 1e20)) {
+				if (!motion_tested && camera && physics_has_last_mousepos) {
 
 					//test anyway for mouseenter/exit because objects might move
 					Vector3 from = camera->project_ray_origin(physics_last_mousepos);
@@ -3105,7 +3106,8 @@ Viewport::Viewport() {
 	physics_object_picking = false;
 	physics_object_capture = 0;
 	physics_object_over = 0;
-	physics_last_mousepos = Vector2(1e20, 1e20);
+	physics_has_last_mousepos = false;
+	physics_last_mousepos = Vector2(Math_INF, Math_INF);
 
 	shadow_atlas_size = 0;
 	for (int i = 0; i < 4; i++) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -209,6 +209,7 @@ private:
 	Transform physics_last_object_transform;
 	Transform physics_last_camera_transform;
 	ObjectID physics_last_id;
+	bool physics_has_last_mousepos;
 	Vector2 physics_last_mousepos;
 	struct {
 


### PR DESCRIPTION
When starting up a Godot app on my iPhone, it didn't get past the splash screen. It was caused by a near infinite loop that was caused by the simulation of mouse events very far away when no mouse was present. This PR fixes that issue.

Also change the initial value to Math_INF to be able to better discern the initial value