### PR TITLE
Change color of AnimationPlayer curve to "highlight"

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -408,7 +408,8 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			}
 
 			//draw edited curve
-			_draw_track(track, accent);
+			const Color highlight = get_color("highlight_color", "Editor");
+			_draw_track(track, highlight);
 		}
 
 		//draw editor handles


### PR DESCRIPTION
Fixes #19432.

I chose the "highlight" color so it will be consistent with the Curve resource editor, but if anyone here think another color should be used, just say it and I will change it.

![captura de tela de 2018-12-18 13-49-26](https://user-images.githubusercontent.com/4605213/50165282-c3511b80-02cb-11e9-9031-5edb21b4abce.png)
