### PR TITLE
Small fixes for the AnimationTree editor

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -356,7 +356,7 @@ void AnimationNodeBlendTreeEditor::_connection_request(const String &p_from, int
 
 	undo_redo->create_action("Nodes Connected");
 	undo_redo->add_do_method(blend_tree.ptr(), "connect_node", p_to, p_to_index, p_from);
-	undo_redo->add_undo_method(blend_tree.ptr(), "disconnect_node", p_to, p_to_index, p_from);
+	undo_redo->add_undo_method(blend_tree.ptr(), "disconnect_node", p_to, p_to_index);
 	undo_redo->add_do_method(this, "_update_graph");
 	undo_redo->add_undo_method(this, "_update_graph");
 	undo_redo->commit_action();

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1064,6 +1064,7 @@ void AnimationNodeStateMachineEditor::_open_editor(const String &p_name) {
 }
 
 void AnimationNodeStateMachineEditor::_removed_from_graph() {
+
 	EditorNode::get_singleton()->edit_item(NULL);
 }
 
@@ -1099,7 +1100,13 @@ void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 	name_edit->hide();
 }
 
+void AnimationNodeStateMachineEditor::_name_edited_focus_out() {
+
+	_name_edited(name_edit->get_text());
+}
+
 void AnimationNodeStateMachineEditor::_scroll_changed(double) {
+
 	if (updating)
 		return;
 
@@ -1217,6 +1224,7 @@ void AnimationNodeStateMachineEditor::_bind_methods() {
 	ClassDB::bind_method("_add_animation_type", &AnimationNodeStateMachineEditor::_add_animation_type);
 
 	ClassDB::bind_method("_name_edited", &AnimationNodeStateMachineEditor::_name_edited);
+	ClassDB::bind_method("_name_edited_focus_out", &AnimationNodeStateMachineEditor::_name_edited_focus_out);
 
 	ClassDB::bind_method("_removed_from_graph", &AnimationNodeStateMachineEditor::_removed_from_graph);
 
@@ -1356,6 +1364,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	state_machine_draw->add_child(name_edit);
 	name_edit->hide();
 	name_edit->connect("text_entered", this, "_name_edited");
+	name_edit->connect("focus_exited", this, "_name_edited_focus_out");
 	name_edit->set_as_toplevel(true);
 
 	open_file = memnew(EditorFileDialog);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -143,6 +143,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 	String prev_name;
 	void _name_edited(const String &p_text);
+	void _name_edited_focus_out();
 	void _open_editor(const String &p_name);
 	void _scroll_changed(double);
 


### PR DESCRIPTION
- Fix incorrect signal call when undoing node disconnections in the `BlendTree` editor.
- Make the `StateMachine` editor change a node's name when its `LineEdit` loses focus, like the nodes of other editors.