### PR TITLE
Fix colored font rendered in wrong size

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -352,7 +352,7 @@ float DynamicFontAtSize::draw_char(RID p_canvas_item, const Point2 &p_pos, CharT
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 			RID texture = font->textures[ch->texture_idx].texture->get_rid();
-			VisualServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, Rect2(cpos, ch->rect.size * Vector2(font->scale_color_font, font->scale_color_font)), texture, ch->rect_uv, modulate, false, RID(), false);
+			VisualServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, Rect2(cpos, ch->rect.size), texture, ch->rect_uv, modulate, false, RID(), false);
 		}
 
 		advance = ch->advance;


### PR DESCRIPTION
Fix #24456

The character->rect.size is properly update at DynamicFontAtSize::_bitmap_to_character
so no need to multiply scale again.

It was changed with https://github.com/godotengine/godot/commit/5cd12f6649387f91d08fd17bf3c70e732798ab58#diff-fce1ec7b33979481c1af96f2d6be6686R565