### PR TITLE
Now constructors have size argument

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -413,11 +413,7 @@ Array::Array() {
 	_p->refcount.init();
 }
 
-<<<<<<< HEAD
 Array Array::sizeInit(int size) {
-=======
-Array Array::sizeInit(int size){
->>>>>>> refs/remotes/origin/SizedContainers
 	Array arr;
 	arr.resize(size);
 	return arr;

--- a/core/array.cpp
+++ b/core/array.cpp
@@ -412,6 +412,13 @@ Array::Array() {
 	_p = memnew(ArrayPrivate);
 	_p->refcount.init();
 }
+
+Array Array::sizeInit(int size){
+	Array arr;
+	arr.resize(size);
+	return arr;
+}
+
 Array::~Array() {
 
 	_unref();

--- a/core/array.cpp
+++ b/core/array.cpp
@@ -413,7 +413,7 @@ Array::Array() {
 	_p->refcount.init();
 }
 
-Array Array::sizeInit(int size){
+Array Array::sizeInit(int size) {
 	Array arr;
 	arr.resize(size);
 	return arr;

--- a/core/array.h
+++ b/core/array.h
@@ -96,11 +96,7 @@ public:
 
 	Array(const Array &p_from);
 	Array();
-<<<<<<< HEAD
 	static Array sizeInit(int size);
-=======
-	static  Array sizeInit(int size);
->>>>>>> refs/remotes/origin/SizedContainers
 	~Array();
 };
 

--- a/core/array.h
+++ b/core/array.h
@@ -96,6 +96,7 @@ public:
 
 	Array(const Array &p_from);
 	Array();
+	static  Array sizeInit(int size);
 	~Array();
 };
 

--- a/core/array.h
+++ b/core/array.h
@@ -96,7 +96,7 @@ public:
 
 	Array(const Array &p_from);
 	Array();
-	static  Array sizeInit(int size);
+	static Array sizeInit(int size);
 	~Array();
 };
 

--- a/core/dvector.h
+++ b/core/dvector.h
@@ -462,6 +462,20 @@ public:
 
 	void operator=(const PoolVector &p_dvector) { _reference(p_dvector); }
 	PoolVector() { alloc = NULL; }
+
+	static PoolVector<T> sizeInit(int size){
+		PoolVector<T> pool;
+		pool.resize(size);
+		return pool;
+	}
+
+	void setValues(const T &value) {
+		for(int i = 0; i < this->size();i++){
+			this->set(i,value);
+		}
+	}
+
+
 	PoolVector(const PoolVector &p_dvector) {
 		alloc = NULL;
 		_reference(p_dvector);

--- a/core/dvector.h
+++ b/core/dvector.h
@@ -463,18 +463,17 @@ public:
 	void operator=(const PoolVector &p_dvector) { _reference(p_dvector); }
 	PoolVector() { alloc = NULL; }
 
-	static PoolVector<T> sizeInit(int size){
+	static PoolVector<T> sizeInit(int size) {
 		PoolVector<T> pool;
 		pool.resize(size);
 		return pool;
 	}
 
 	void setValues(const T &value) {
-		for(int i = 0; i < this->size();i++){
-			this->set(i,value);
+		for (int i = 0; i < this->size(); i++) {
+			this->set(i, value);
 		}
 	}
-
 
 	PoolVector(const PoolVector &p_dvector) {
 		alloc = NULL;

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -335,6 +335,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 				POOL_COLOR_ARRAY,
 				POOL_VECTOR2_ARRAY,
 				POOL_VECTOR3_ARRAY,
+				INT,
 				NIL
 			};
 
@@ -345,6 +346,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 
 			static const Type valid[] = {
 				ARRAY,
+				INT,
 				NIL
 			};
 
@@ -354,6 +356,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 
 			static const Type valid[] = {
 				ARRAY,
+				INT,
 				NIL
 			};
 			valid_types = valid;
@@ -362,6 +365,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 
 			static const Type valid[] = {
 				ARRAY,
+				INT,
 				NIL
 			};
 
@@ -371,6 +375,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 
 			static const Type valid[] = {
 				ARRAY,
+				INT,
 				NIL
 			};
 			valid_types = valid;
@@ -379,6 +384,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 
 			static const Type valid[] = {
 				ARRAY,
+				INT,
 				NIL
 			};
 			valid_types = valid;
@@ -388,6 +394,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 
 			static const Type valid[] = {
 				ARRAY,
+				INT,
 				NIL
 			};
 			valid_types = valid;
@@ -397,6 +404,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 
 			static const Type valid[] = {
 				ARRAY,
+				INT,
 				NIL
 			};
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -828,6 +828,97 @@ struct _VariantCall {
 
 	static ConstructFunc *construct_funcs;
 
+	static void Array_init1(Variant &r_ret, const Variant **p_args){
+		Array ret;
+		int size = p_args[0]->operator int();
+		ret.resize(size);
+		r_ret = ret;
+	}
+
+	static void Array_init2(Variant &r_ret, const Variant **p_args){
+		Array ret;
+		int size = p_args[0]->operator int();
+		ret.resize(size);
+		for(int i = 0; i < size;i++){
+			ret.set(i,*p_args[1]);
+		}
+		r_ret = ret;
+	}
+
+	static void PoolByteArray_init2(Variant &r_ret, const Variant **p_args){
+		PoolByteArray ret;
+		int size = p_args[0]->operator int();
+		unsigned char byte = p_args[1]->operator unsigned char();
+		ret.resize(size);
+		ret.setValues(byte);
+		r_ret = ret;
+	}
+
+	static void PoolIntArray_init2(Variant &r_ret, const Variant **p_args){
+		PoolIntArray ret;
+		int size = p_args[0]->operator int();
+		int num = p_args[1]->operator int();
+		ret.resize(size);
+		ret.setValues(num);
+		r_ret = ret;
+	}
+
+	static void PoolRealArray_init2(Variant &r_ret, const Variant **p_args){
+		PoolRealArray ret;
+		int size = p_args[0]->operator int();
+		real_t num = p_args[1]->operator real_t();
+		ret.resize(size);
+		ret.setValues(num);
+		r_ret = ret;
+	}
+
+	static void PoolStringArray_init2(Variant &r_ret, const Variant **p_args){
+		PoolStringArray ret;
+		int size = p_args[0]->operator int();
+		String str = p_args[1]->operator String();
+		ret.resize(size);
+		ret.setValues(str);
+		r_ret = ret;
+	}
+
+	static void PoolVector2Array_init2(Variant &r_ret, const Variant **p_args) {
+
+		PoolVector2Array ret;
+		int size = p_args[0]->operator int();
+		Vector2 vec = p_args[1]->operator Vector2();
+		ret.resize(size);
+		ret.setValues(vec);
+		r_ret = ret;
+	}
+
+	static void PoolVector3Array_init1(Variant &r_ret, const Variant **p_args) {
+
+		PoolVector3Array ret;
+		ret.resize(p_args[0]->operator int());
+		r_ret = ret;
+	}
+
+	static void PoolVector3Array_init2(Variant &r_ret, const Variant **p_args) {
+
+		PoolVector3Array ret;
+		int size = p_args[0]->operator int();
+		Vector3 vec = p_args[1]->operator Vector3();
+		ret.resize(size);
+		ret.setValues(vec);
+		r_ret = ret;
+	}
+
+	static void PoolColorArray_init2(Variant &r_ret, const Variant **p_args) {
+
+		PoolColorArray ret;
+		int size = p_args[0]->operator int();
+		Color col = p_args[1]->operator Color();
+		ret.resize(size);
+		ret.setValues(col);
+		r_ret = ret;
+	}
+
+
 	static void Vector2_init1(Variant &r_ret, const Variant **p_args) {
 
 		r_ret = Vector2(*p_args[0], *p_args[1]);
@@ -1192,17 +1283,17 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 			case OBJECT: return ((Object *)(p_args[0]->operator Object *()));
 			case DICTIONARY: return p_args[0]->operator Dictionary();
 			case ARRAY:
-				return p_args[0]->operator Array(); // 20
+				return Array::sizeInit(*p_args[0]); // 20
 
 			// arrays
-			case POOL_BYTE_ARRAY: return (PoolByteArray(*p_args[0]));
-			case POOL_INT_ARRAY: return (PoolIntArray(*p_args[0]));
-			case POOL_REAL_ARRAY: return (PoolRealArray(*p_args[0]));
-			case POOL_STRING_ARRAY: return (PoolStringArray(*p_args[0]));
+			case POOL_BYTE_ARRAY: return PoolVector<unsigned char>::sizeInit(*p_args[0]);
+			case POOL_INT_ARRAY: return PoolVector<int>::sizeInit(*p_args[0]);
+			case POOL_REAL_ARRAY: return PoolVector<real_t>::sizeInit(*p_args[0]);
+			case POOL_STRING_ARRAY: return PoolVector<String>::sizeInit(*p_args[0]);
 			case POOL_VECTOR2_ARRAY:
-				return (PoolVector2Array(*p_args[0])); // 25
-			case POOL_VECTOR3_ARRAY: return (PoolVector3Array(*p_args[0]));
-			case POOL_COLOR_ARRAY: return (PoolColorArray(*p_args[0]));
+				return PoolVector<Vector2>::sizeInit(*p_args[0]); // 25
+			case POOL_VECTOR3_ARRAY: return PoolVector<Vector3>::sizeInit(*p_args[0]);
+			case POOL_COLOR_ARRAY: return PoolVector<Color>::sizeInit(*p_args[0]);
 			default: return Variant();
 		}
 	}
@@ -1853,6 +1944,25 @@ void register_variant_methods() {
 	ADDFUNC1R(TRANSFORM, NIL, Transform, xform_inv, NIL, "v", varray());
 
 	/* REGISTER CONSTRUCTORS */
+
+	_VariantCall::add_constructor(_VariantCall::Array_init1, Variant::ARRAY, "size", Variant::INT);
+	_VariantCall::add_constructor(_VariantCall::Array_init2, Variant::ARRAY, "size", Variant::INT, "value", Variant::NIL);
+
+	_VariantCall::add_constructor(_VariantCall::PoolVector3Array_init1, Variant::POOL_VECTOR3_ARRAY, "size", Variant::INT);
+	_VariantCall::add_constructor(_VariantCall::PoolVector3Array_init2, Variant::POOL_VECTOR3_ARRAY, "size", Variant::INT, "value", Variant::VECTOR3);
+
+	_VariantCall::add_constructor(_VariantCall::PoolByteArray_init2, Variant::POOL_BYTE_ARRAY, "size", Variant::INT, "value", Variant::INT);
+	
+	_VariantCall::add_constructor(_VariantCall::PoolIntArray_init2, Variant::POOL_INT_ARRAY, "size", Variant::INT, "value", Variant::INT);
+	
+	_VariantCall::add_constructor(_VariantCall::PoolRealArray_init2, Variant::POOL_REAL_ARRAY, "size", Variant::INT, "value", Variant::REAL);
+	
+	_VariantCall::add_constructor(_VariantCall::PoolStringArray_init2, Variant::POOL_STRING_ARRAY, "size", Variant::INT, "value", Variant::STRING);
+	
+	_VariantCall::add_constructor(_VariantCall::PoolVector2Array_init2, Variant::POOL_VECTOR2_ARRAY, "size", Variant::INT, "value", Variant::VECTOR2);
+	
+	_VariantCall::add_constructor(_VariantCall::PoolColorArray_init2, Variant::POOL_COLOR_ARRAY, "size", Variant::INT, "value", Variant::COLOR);
+
 
 	_VariantCall::add_constructor(_VariantCall::Vector2_init1, Variant::VECTOR2, "x", Variant::REAL, "y", Variant::REAL);
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -828,24 +828,24 @@ struct _VariantCall {
 
 	static ConstructFunc *construct_funcs;
 
-	static void Array_init1(Variant &r_ret, const Variant **p_args){
+	static void Array_init1(Variant &r_ret, const Variant **p_args) {
 		Array ret;
 		int size = p_args[0]->operator int();
 		ret.resize(size);
 		r_ret = ret;
 	}
 
-	static void Array_init2(Variant &r_ret, const Variant **p_args){
+	static void Array_init2(Variant &r_ret, const Variant **p_args) {
 		Array ret;
 		int size = p_args[0]->operator int();
 		ret.resize(size);
-		for(int i = 0; i < size;i++){
-			ret.set(i,*p_args[1]);
+		for (int i = 0; i < size; i++) {
+			ret.set(i, *p_args[1]);
 		}
 		r_ret = ret;
 	}
 
-	static void PoolByteArray_init2(Variant &r_ret, const Variant **p_args){
+	static void PoolByteArray_init2(Variant &r_ret, const Variant **p_args) {
 		PoolByteArray ret;
 		int size = p_args[0]->operator int();
 		unsigned char byte = p_args[1]->operator unsigned char();
@@ -854,7 +854,7 @@ struct _VariantCall {
 		r_ret = ret;
 	}
 
-	static void PoolIntArray_init2(Variant &r_ret, const Variant **p_args){
+	static void PoolIntArray_init2(Variant &r_ret, const Variant **p_args) {
 		PoolIntArray ret;
 		int size = p_args[0]->operator int();
 		int num = p_args[1]->operator int();
@@ -863,7 +863,7 @@ struct _VariantCall {
 		r_ret = ret;
 	}
 
-	static void PoolRealArray_init2(Variant &r_ret, const Variant **p_args){
+	static void PoolRealArray_init2(Variant &r_ret, const Variant **p_args) {
 		PoolRealArray ret;
 		int size = p_args[0]->operator int();
 		real_t num = p_args[1]->operator real_t();
@@ -872,7 +872,7 @@ struct _VariantCall {
 		r_ret = ret;
 	}
 
-	static void PoolStringArray_init2(Variant &r_ret, const Variant **p_args){
+	static void PoolStringArray_init2(Variant &r_ret, const Variant **p_args) {
 		PoolStringArray ret;
 		int size = p_args[0]->operator int();
 		String str = p_args[1]->operator String();
@@ -917,7 +917,6 @@ struct _VariantCall {
 		ret.setValues(col);
 		r_ret = ret;
 	}
-
 
 	static void Vector2_init1(Variant &r_ret, const Variant **p_args) {
 
@@ -1952,17 +1951,16 @@ void register_variant_methods() {
 	_VariantCall::add_constructor(_VariantCall::PoolVector3Array_init2, Variant::POOL_VECTOR3_ARRAY, "size", Variant::INT, "value", Variant::VECTOR3);
 
 	_VariantCall::add_constructor(_VariantCall::PoolByteArray_init2, Variant::POOL_BYTE_ARRAY, "size", Variant::INT, "value", Variant::INT);
-	
-	_VariantCall::add_constructor(_VariantCall::PoolIntArray_init2, Variant::POOL_INT_ARRAY, "size", Variant::INT, "value", Variant::INT);
-	
-	_VariantCall::add_constructor(_VariantCall::PoolRealArray_init2, Variant::POOL_REAL_ARRAY, "size", Variant::INT, "value", Variant::REAL);
-	
-	_VariantCall::add_constructor(_VariantCall::PoolStringArray_init2, Variant::POOL_STRING_ARRAY, "size", Variant::INT, "value", Variant::STRING);
-	
-	_VariantCall::add_constructor(_VariantCall::PoolVector2Array_init2, Variant::POOL_VECTOR2_ARRAY, "size", Variant::INT, "value", Variant::VECTOR2);
-	
-	_VariantCall::add_constructor(_VariantCall::PoolColorArray_init2, Variant::POOL_COLOR_ARRAY, "size", Variant::INT, "value", Variant::COLOR);
 
+	_VariantCall::add_constructor(_VariantCall::PoolIntArray_init2, Variant::POOL_INT_ARRAY, "size", Variant::INT, "value", Variant::INT);
+
+	_VariantCall::add_constructor(_VariantCall::PoolRealArray_init2, Variant::POOL_REAL_ARRAY, "size", Variant::INT, "value", Variant::REAL);
+
+	_VariantCall::add_constructor(_VariantCall::PoolStringArray_init2, Variant::POOL_STRING_ARRAY, "size", Variant::INT, "value", Variant::STRING);
+
+	_VariantCall::add_constructor(_VariantCall::PoolVector2Array_init2, Variant::POOL_VECTOR2_ARRAY, "size", Variant::INT, "value", Variant::VECTOR2);
+
+	_VariantCall::add_constructor(_VariantCall::PoolColorArray_init2, Variant::POOL_COLOR_ARRAY, "size", Variant::INT, "value", Variant::COLOR);
 
 	_VariantCall::add_constructor(_VariantCall::Vector2_init1, Variant::VECTOR2, "x", Variant::REAL, "y", Variant::REAL);
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -835,12 +835,12 @@ struct _VariantCall {
 		r_ret = ret;
 	}
 
-	static void Array_init2(Variant &r_ret, const Variant **p_args){
+	static void Array_init2(Variant &r_ret, const Variant **p_args) {
 		Array ret;
 		int size = p_args[0]->operator int();
 		ret.resize(size);
-		for(int i = 0; i < size;i++){
-			ret.set(i,*p_args[1]);
+		for (int i = 0; i < size; i++) {
+			ret.set(i, *p_args[1]);
 		}
 		r_ret = ret;
 	}


### PR DESCRIPTION
Just like suggested in [#18328](https://github.com/godotengine/godot/issues/18328), now both Pool*Array and Array have constructors for a predetermined size.

For example, if you want an Array with size 3, you only need to to declare your Array as: var arr = Array(3).
The variable arr will be an Array with size 3. The same logic applies to Pool*Arrays containers.

Also if the user wants to initialize all values with a specific value, there is also a version of both constructors with 2 arguments where the first one is the size of the container and the the second argument is the value of the all elements of the container when initialized. Exemple: var pool = PoolVector3Array(3,Vector3(1,2,3)). The variable pool will be an PoolVector3Array with size 3 and all if its elements are vectors with x=1,y=2,z=3.

## Changes
To implement the new constructors, they were added with **_VariantCall::add_constructor** in **variant_call.pp.** To accept arguments of type int, the method **Variant::can_convert** in **variant.cpp** was modified. The next modified method was **Variant::construct**, where in case of 1 argument of the constructor and the condition **(!p_strict || Variant::can_convert(p_args[0]->type, p_type))** is true, instead calling the defaults constructors of Array and Pool*Array, calls the new static methods: **static  Array Array::sizeInit(int size)** and **static Pool Vector<T> PoolVector<T> ::sizeInit(int size)**. Here is the body of both new methods respectively:

In array.cpp:
<pre><code>
Array Array::sizeInit(int size){
	Array arr;
	arr.resize(size);
	return arr;
}
</pre></code>

In dvector.h
<pre><code>
static PoolVector<T> sizeInit(int size){
	PoolVector<T> pool;
	pool.resize(size);
	return pool;
}
</pre></code>

## To Do
Update the documentation, to include the new methods created.
