### PR TITLE
Make AnimatedSprite.animation complain when invalid animation name

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -632,6 +632,9 @@ void AnimatedSprite::_reset_timeout() {
 
 void AnimatedSprite::set_animation(const StringName &p_animation) {
 
+	ERR_EXPLAIN(vformat("There is no animation with name '%s'.", p_animation));
+	ERR_FAIL_COND(frames->get_animation_names().find(p_animation) == -1);
+
 	if (animation == p_animation)
 		return;
 


### PR DESCRIPTION
Solves #18264.

I decided to use `print_error()` because I couldn't find any better way to inform the user that the animation name is not valid. Also, I made the function fail with `ERR_FAIL` without crashing the game, because I don't think it's a case worthy of crashing.

Anyway, free feel to suggest and comment, I'm yet a newbie on Godot source, so surely there's room for improvement.