### PR TITLE
Provide `find_node_by_type` and `find_nodes_by_type` functions to Node

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -179,6 +179,34 @@
 				If [code]owned[/code] is [code]true[/code], this method only finds nodes whose owner is this node. This is especially important for scenes instantiated through script, because those scenes don't have an owner.
 			</description>
 		</method>
+		<method name="find_node_by_type" qualifiers="const">
+			<return type="Node">
+			</return>
+			<argument index="0" name="type" type="Object">
+			</argument>
+			<argument index="1" name="recursive" type="bool" default="true">
+			</argument>
+			<argument index="2" name="owned" type="bool" default="true">
+			</argument>
+			<description>
+				Finds a descendant of this node whose type matches [code]type[/code].
+				If [code]owned[/code] is [code]true[/code], this method only finds nodes whose owner is this node. This is especially important for scenes instantiated through script, because those scenes don't have an owner.
+			</description>
+		</method>
+		<method name="find_nodes_by_type" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="type" type="Object">
+			</argument>
+			<argument index="1" name="recursive" type="bool" default="true">
+			</argument>
+			<argument index="2" name="owned" type="bool" default="true">
+			</argument>
+			<description>
+				Finds all descendants of this node whose type matches [code]type[/code].
+				If [code]owned[/code] is [code]true[/code], this method only finds nodes whose owner is this node. This is especially important for scenes instantiated through script, because those scenes don't have an owner.
+			</description>
+		</method>
 		<method name="find_parent" qualifiers="const">
 			<return type="Node">
 			</return>

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -253,6 +253,8 @@ public:
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *find_node(const String &p_mask, bool p_recursive = true, bool p_owned = true) const;
+	Node *find_node_by_type(Object *p_type, bool p_recursive = true, bool p_owned = true) const;
+	Array find_nodes_by_type(Object *p_type, bool p_recursive = true, bool p_owned = true) const;
 	bool has_node_and_resource(const NodePath &p_path) const;
 	Node *get_node_and_resource(const NodePath &p_path, RES &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property = true) const;
 


### PR DESCRIPTION
A possible solution for #24193.

I opted for `find_` instead of `get_` to have consistency with the already existent `find_node` function.

`find_node_by_type` has both `recursive` and `owned` parameters, but I opted to remove `recursive` from `find_nodes_by_type` because it would be either a flattened `Array` or a confusing tree-like structure. I think both are not the purpose of the function.

What do you guys think about this solution?