### PR TITLE
Fix GLES2 Spotlight shadow problem

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1914,7 +1914,6 @@ FRAGMENT_SHADER_CODE
 #ifdef USE_SHADOW
 	{
 		highp vec4 splane = shadow_coord;
-		splane.xyz /= splane.w;
 
 		float shadow = sample_shadow(light_shadow_atlas, splane);
 		light_att *= shadow;


### PR DESCRIPTION
pssm_coord （splane.xyz /= splane.w） already calculate in sample_shadow(), not need to calculate again in Spotlight.
To fix #23275