### PR TITLE
Fix TextureLayered::create not retaining format

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2067,7 +2067,7 @@ void TextureLayered::create(uint32_t p_width, uint32_t p_height, uint32_t p_dept
 	width = p_width;
 	height = p_height;
 	depth = p_depth;
-
+	format = p_format;
 	flags = p_flags;
 }
 


### PR DESCRIPTION
There was already a fix for this in #21467, but was reverted in #21483. This PR only adds the missing format assignment.