### PR TITLE
Fix #24470 Atlas Texture with margin setting cause error in editor.

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1087,8 +1087,12 @@ bool AtlasTexture::is_pixel_opaque(int p_x, int p_y) const {
 	if (!atlas.is_valid())
 		return true;
 
-	int x = p_x + region.position.x + margin.position.x;
-	int y = p_y + region.position.y + margin.position.y;
+	int x = p_x + region.position.x - margin.position.x;
+	int y = p_y + region.position.y - margin.position.y;
+
+	// margin edge may outside of atlas
+	if (x < 0 || x >= atlas->get_width()) return false;
+	if (y < 0 || y >= atlas->get_height()) return false;
 
 	return atlas->is_pixel_opaque(x, y);
 }


### PR DESCRIPTION
Fix #24470 by:
- set pixel_pos = region_pos - margin_pos + pointer_pos.
- return false when pointer is outside final texture.