### PR TITLE
Fixes for TileSetEditor and TileMapEditor

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -516,6 +516,12 @@ void TileMapEditor::_update_palette() {
 		manual_palette->set_current(selected);
 		manual_palette->show();
 	}
+
+	if (tileset->tile_get_tile_mode(sel_tile) == TileSet::AUTO_TILE) {
+		manual_button->show();
+	} else {
+		manual_button->hide();
+	}
 }
 
 void TileMapEditor::_pick_tile(const Point2 &p_pos) {

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2260,7 +2260,7 @@ void TileSetEditor::update_workspace_tile_mode() {
 		tool_editmode[EDITMODE_BITMASK]->hide();
 		tool_editmode[EDITMODE_PRIORITY]->hide();
 		tool_editmode[EDITMODE_Z_INDEX]->hide();
-	} else if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
+	} else if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE) {
 		if (edit_mode == EDITMODE_ICON)
 			select_coord(tileset->autotile_get_icon_coordinate(get_current_tile()));
 		else

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -840,7 +840,7 @@ void TileMap::update_cell_bitmask(int p_x, int p_y) {
 	Map<PosKey, Cell>::Element *E = tile_map.find(p);
 	if (E != NULL) {
 		int id = get_cell(p_x, p_y);
-		if (tile_set->tile_get_tile_mode(id) == TileSet::AUTO_TILE || tile_set->tile_get_tile_mode(id) == TileSet::ATLAS_TILE) {
+		if (tile_set->tile_get_tile_mode(id) == TileSet::AUTO_TILE) {
 			uint16_t mask = 0;
 			if (tile_set->autotile_get_bitmask_mode(id) == TileSet::BITMASK_2X2) {
 				if (tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y))) {
@@ -904,7 +904,8 @@ void TileMap::update_cell_bitmask(int p_x, int p_y) {
 			PosKey qk(p_x / _get_quadrant_size(), p_y / _get_quadrant_size());
 			Map<PosKey, Quadrant>::Element *Q = quadrant_map.find(qk);
 			_make_quadrant_dirty(Q);
-		} else {
+
+		} else if (tile_set->tile_get_tile_mode(id) == TileSet::SINGLE_TILE) {
 			E->get().autotile_coord_x = 0;
 			E->get().autotile_coord_y = 0;
 		}


### PR DESCRIPTION
[TileSetEditor] Hide Bitmask and Priority for ATLAS_TILE
[TileMapEditor] Hide "Disable autotile" if the selected tile isn't autotile
Fix #22756, don't update bitmask when tilemode is ATLAS_TILE