### PR TITLE
Change LinkLabel back to Label in error status bar

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1129,8 +1129,11 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 void CodeTextEditor::set_error(const String &p_error) {
 
 	error->set_text(p_error);
-	error->set_tooltip(p_error);
-	error->set_visible(p_error != "");
+	if (p_error != "") {
+		error->set_default_cursor_shape(CURSOR_POINTING_HAND);
+	} else {
+		error->set_default_cursor_shape(CURSOR_ARROW);
+	}
 }
 
 void CodeTextEditor::set_error_pos(int p_line, int p_column) {
@@ -1138,10 +1141,12 @@ void CodeTextEditor::set_error_pos(int p_line, int p_column) {
 	error_column = p_column;
 }
 
-void CodeTextEditor::_error_pressed() {
-	text_editor->cursor_set_line(error_line);
-	text_editor->cursor_set_column(error_column);
-	text_editor->center_viewport_to_cursor();
+void CodeTextEditor::goto_error() {
+	if (error->get_text() != "") {
+		text_editor->cursor_set_line(error_line);
+		text_editor->cursor_set_column(error_column);
+		text_editor->center_viewport_to_cursor();
+	}
 }
 
 void CodeTextEditor::_update_font() {
@@ -1204,7 +1209,6 @@ void CodeTextEditor::_bind_methods() {
 	ClassDB::bind_method("_code_complete_timer_timeout", &CodeTextEditor::_code_complete_timer_timeout);
 	ClassDB::bind_method("_complete_request", &CodeTextEditor::_complete_request);
 	ClassDB::bind_method("_font_resize_timeout", &CodeTextEditor::_font_resize_timeout);
-	ClassDB::bind_method("_error_pressed", &CodeTextEditor::_error_pressed);
 
 	ADD_SIGNAL(MethodInfo("validate_script"));
 	ADD_SIGNAL(MethodInfo("load_theme_settings"));
@@ -1254,19 +1258,14 @@ CodeTextEditor::CodeTextEditor() {
 	error_line = 0;
 	error_column = 0;
 
-	Control *error_box = memnew(Control);
-	status_bar->add_child(error_box);
-	error_box->set_v_size_flags(SIZE_EXPAND_FILL);
-	error_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	error_box->set_clip_contents(true);
-
-	error = memnew(LinkButton);
-	error_box->add_child(error);
-	error->set_anchors_and_margins_preset(Control::PRESET_CENTER_LEFT);
-	error->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+	error = memnew(Label);
+	status_bar->add_child(error);
+	error->set_autowrap(true);
+	error->set_valign(Label::VALIGN_CENTER);
+	error->set_h_size_flags(SIZE_EXPAND_FILL); //required for it to display, given now it's clipping contents, do not touch
 	error->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
 	error->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
-	error->connect("pressed", this, "_error_pressed");
+	error->set_mouse_filter(MOUSE_FILTER_STOP);
 	find_replace_bar->connect("error", error, "set_text");
 
 	status_bar->add_child(memnew(Label)); //to keep the height if the other labels are not visible

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -36,7 +36,6 @@
 #include "scene/gui/check_button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
-#include "scene/gui/link_button.h"
 #include "scene/gui/text_edit.h"
 #include "scene/gui/tool_button.h"
 #include "scene/main/timer.h"
@@ -157,7 +156,7 @@ class CodeTextEditor : public VBoxContainer {
 	int font_resize_val;
 	real_t font_size;
 
-	LinkButton *error;
+	Label *error;
 	int error_line;
 	int error_column;
 
@@ -173,7 +172,6 @@ class CodeTextEditor : public VBoxContainer {
 	void _zoom_out();
 	void _zoom_changed();
 	void _reset_zoom();
-	void _error_pressed();
 
 	CodeTextEditorCodeCompleteFunc code_complete_func;
 	void *code_complete_ud;
@@ -220,9 +218,11 @@ public:
 	void update_line_and_column() { _line_col_changed(); }
 	TextEdit *get_text_edit() { return text_editor; }
 	FindReplaceBar *get_find_replace_bar() { return find_replace_bar; }
+	Label *get_error_label() const { return error; }
 	Label *get_warning_label() const { return warning_label; }
 	Label *get_warning_count_label() const { return warning_count_label; }
 	virtual void apply_code() {}
+	void goto_error();
 
 	void set_code_complete_func(CodeTextEditorCodeCompleteFunc p_code_complete_func, void *p_ud);
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -280,6 +280,13 @@ void ScriptTextEditor::_toggle_warning_pannel(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void ScriptTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+		code_editor->goto_error();
+	}
+}
+
 void ScriptTextEditor::_warning_clicked(Variant p_line) {
 	if (p_line.get_type() == Variant::INT) {
 		code_editor->get_text_edit()->cursor_set_line(p_line.operator int64_t());
@@ -1101,6 +1108,7 @@ void ScriptTextEditor::_bind_methods() {
 	ClassDB::bind_method("_lookup_symbol", &ScriptTextEditor::_lookup_symbol);
 	ClassDB::bind_method("_text_edit_gui_input", &ScriptTextEditor::_text_edit_gui_input);
 	ClassDB::bind_method("_toggle_warning_pannel", &ScriptTextEditor::_toggle_warning_pannel);
+	ClassDB::bind_method("_error_pressed", &ScriptTextEditor::_error_pressed);
 	ClassDB::bind_method("_warning_clicked", &ScriptTextEditor::_warning_clicked);
 	ClassDB::bind_method("_color_changed", &ScriptTextEditor::_color_changed);
 
@@ -1437,6 +1445,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	warnings_panel->set_focus_mode(FOCUS_CLICK);
 	warnings_panel->hide();
 
+	code_editor->get_error_label()->connect("gui_input", this, "_error_pressed");
 	code_editor->get_warning_label()->connect("gui_input", this, "_toggle_warning_pannel");
 	code_editor->get_warning_count_label()->connect("gui_input", this, "_toggle_warning_pannel");
 	warnings_panel->connect("meta_clicked", this, "_warning_clicked");

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -126,6 +126,7 @@ protected:
 	void _load_theme_settings();
 	void _set_theme_for_script();
 	void _toggle_warning_pannel(const Ref<InputEvent> &p_event);
+	void _error_pressed(const Ref<InputEvent> &p_event);
 	void _warning_clicked(Variant p_line);
 
 	void _notification(int p_what);


### PR DESCRIPTION
This PR changed LinkLabel(which I changed in https://github.com/godotengine/godot/pull/23875) back to Label - I found it better than current version, because I found that cutting off the long error message is both confusing and annoying - now it will wrap-off as before
![image](https://user-images.githubusercontent.com/3036176/50331776-f0dad680-0510-11e9-9562-760cf1636be4.png)
The error jumping is preserved untouched.