### PR TITLE
ProjectManager: Warn when projects have different config_version

### DIFF
--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -106,7 +106,7 @@ protected:
 
 	Error _save_custom_bnd(const String &p_file);
 
-	void _convert_to_last_version();
+	void _convert_to_last_version(int p_from_version);
 
 	bool _load_resource_pack(const String &p_pack);
 
@@ -118,6 +118,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static const int CONFIG_VERSION = 4;
+
 	void set_setting(const String &p_setting, const Variant &p_value);
 	Variant get_setting(const String &p_setting) const;
 

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -49,43 +49,41 @@ class ProjectManager : public Control {
 	Button *rename_btn;
 	Button *run_btn;
 
-	FileDialog *scan_dir;
-
 	EditorAssetLibrary *asset_library;
 
 	ProjectListFilter *project_filter;
 	ProjectListFilter *project_order_filter;
 
+	FileDialog *scan_dir;
 	ConfirmationDialog *language_restart_ask;
 	ConfirmationDialog *erase_ask;
 	ConfirmationDialog *multi_open_ask;
 	ConfirmationDialog *multi_run_ask;
 	ConfirmationDialog *multi_scan_ask;
+	ConfirmationDialog *ask_update_settings;
+	ConfirmationDialog *open_templates;
 	AcceptDialog *run_error_diag;
 	AcceptDialog *dialog_error;
 	ProjectDialog *npdialog;
+
 	ScrollContainer *scroll;
 	VBoxContainer *scroll_children;
-	Map<String, String> selected_list; // name -> main_scene
-	String last_clicked;
-	bool importing;
-
 	HBoxContainer *projects_hb;
-
 	TabContainer *tabs;
 
 	OptionButton *language_btn;
-
 	Control *gui_base;
 
-	ConfirmationDialog *open_templates;
+	Map<String, String> selected_list; // name -> main_scene
+	String last_clicked;
+	bool importing;
 
 	void _open_asset_library();
 	void _scan_projects();
 	void _run_project();
 	void _run_project_confirm();
-	void _open_project();
-	void _open_project_confirm();
+	void _open_selected_projects();
+	void _open_selected_projects_ask();
 	void _show_project(const String &p_path);
 	void _import_project();
 	void _new_project();
@@ -98,9 +96,11 @@ class ProjectManager : public Control {
 	void _exit_dialog();
 	void _scan_begin(const String &p_base);
 
+	void _confirm_update_settings();
+
 	void _load_recent_projects();
 	void _on_project_created(const String &dir);
-	void _on_project_renamed();
+	void _on_projects_updated();
 	void _update_scroll_position(const String &dir);
 	void _scan_dir(DirAccess *da, float pos, float total, List<String> *r_projects);
 


### PR DESCRIPTION
When opening projects for edition through the project manager, the
following checks are now done:

1. If the config_version is lower than the one used by the current
  engine version, users are asked if they want to convert to the new
  format or abort editing. Fixes #20626.
2. If the config_version is higher than the expected one (project
  from a more recent and incompatible engine version), projects are
  grayed out and can't be edited. Fixes #18758.

When editing from the command line, the behaviour is unchanged:
projects in situation (1) are automatically converted, while projects
in situation (2) show an error message (made more explicit).

The "Run" option from the project manager was not changed, so it will
still run (1) projects without converting them, and fail running (2)
projects.

Supersedes #22452, diff of my changes to this PR: https://github.com/akien-mga/godot/commit/4888b974ad8071413ebe26b722d03d33d01a075c