### PR TITLE
GLES2: Define 'lowp' for OpenGL 2.1

### DIFF
--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -2,6 +2,7 @@
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else
@@ -30,8 +31,6 @@ uniform vec4 src_rect;
 #endif
 
 uniform highp float time;
-
-
 
 #ifdef USE_LIGHTING
 
@@ -62,7 +61,6 @@ const bool at_light_pass = true;
 const bool at_light_pass = false;
 #endif
 
-
 /* clang-format off */
 
 VERTEX_SHADER_GLOBALS
@@ -79,7 +77,6 @@ vec2 select(vec2 a, vec2 b, bvec2 c) {
 }
 
 void main() {
-
 
 	vec4 color = color_attrib;
 
@@ -159,13 +156,13 @@ VERTEX_SHADER_CODE
 #endif
 
 #endif
-
 }
 
 /* clang-format off */
 [fragment]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else
@@ -230,7 +227,6 @@ const bool at_light_pass = false;
 #endif
 
 uniform bool use_default_normal;
-
 
 /* clang-format off */
 

--- a/drivers/gles2/shaders/canvas_shadow.glsl
+++ b/drivers/gles2/shaders/canvas_shadow.glsl
@@ -2,6 +2,7 @@
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else
@@ -29,6 +30,7 @@ void main() {
 [fragment]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else
@@ -38,7 +40,6 @@ precision mediump int;
 
 varying highp vec4 position_interp;
 /* clang-format on */
-
 
 void main() {
 

--- a/drivers/gles2/shaders/copy.glsl
+++ b/drivers/gles2/shaders/copy.glsl
@@ -2,6 +2,7 @@
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else
@@ -56,6 +57,7 @@ void main() {
 #define M_PI 3.14159265359
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else

--- a/drivers/gles2/shaders/cube_to_dp.glsl
+++ b/drivers/gles2/shaders/cube_to_dp.glsl
@@ -2,6 +2,7 @@
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else
@@ -25,6 +26,7 @@ void main() {
 [fragment]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else

--- a/drivers/gles2/shaders/cubemap_filter.glsl
+++ b/drivers/gles2/shaders/cubemap_filter.glsl
@@ -2,6 +2,7 @@
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else
@@ -32,6 +33,7 @@ void main() {
 #endif
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else

--- a/drivers/gles2/shaders/lens_distorted.glsl
+++ b/drivers/gles2/shaders/lens_distorted.glsl
@@ -2,6 +2,7 @@
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else
@@ -29,6 +30,7 @@ void main() {
 [fragment]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -2,6 +2,7 @@
 [vertex]
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else
@@ -653,6 +654,7 @@ VERTEX_SHADER_CODE
 #endif
 
 #ifdef USE_GLES_OVER_GL
+#define lowp
 #define mediump
 #define highp
 #else


### PR DESCRIPTION
Precision qualifiers are only used on OpenGL ES 2.0 and 3.0,
and while OpenGL 3.3 defines them for compatibility (but without
practical effect), they're missing from OpenGL 2.1, so we define
them to prevent compilation errors.

Fixes #24521.