### PR TITLE
GLES3 Fragment shader error fix for Android

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2028,7 +2028,7 @@ FRAGMENT_SHADER_CODE
 		//apply fog
 
 		if (fog_depth_enabled) {
-			float fog_far = fog_depth_end > 0 ? fog_depth_end : z_far;
+			float fog_far = fog_depth_end > 0.0 ? fog_depth_end : z_far;
 
 			float fog_z = smoothstep(fog_depth_begin, fog_far, length(vertex));
 


### PR DESCRIPTION
A float/int comparison in scene.glsl was causing a Fragment shader compilation issue on Android, which was preventing the scene to be rendered properly when using GLES3.

Issue: #24535 