### PR TITLE
SCons: Allow building Mono module with OSXCross

### DIFF
--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -142,7 +142,9 @@ def configure(env):
 
             copy_file(mono_bin_path, 'bin', mono_dll_name + '.dll')
     else:
-        sharedlib_ext = '.dylib' if sys.platform == 'darwin' else '.so'
+        is_apple = (sys.platform == 'darwin' or "osxcross" in env)
+
+        sharedlib_ext = '.dylib' if is_apple else '.so'
 
         mono_root = ''
         mono_lib_path = ''
@@ -154,7 +156,7 @@ def configure(env):
             if os.getenv('MONO64_PREFIX'):
                 mono_root = os.getenv('MONO64_PREFIX')
 
-        if not mono_root and sys.platform == 'darwin':
+        if not mono_root and is_apple:
             # Try with some known directories under OSX
             hint_dirs = ['/Library/Frameworks/Mono.framework/Versions/Current', '/usr/local/var/homebrew/linked/mono']
             for hint_dir in hint_dirs:
@@ -190,14 +192,14 @@ def configure(env):
             if mono_static:
                 mono_lib_file = os.path.join(mono_lib_path, 'lib' + mono_lib + '.a')
 
-                if sys.platform == 'darwin':
+                if is_apple:
                     env.Append(LINKFLAGS=['-Wl,-force_load,' + mono_lib_file])
                 else:
                     env.Append(LINKFLAGS=['-Wl,-whole-archive', mono_lib_file, '-Wl,-no-whole-archive'])
             else:
                 env.Append(LIBS=[mono_lib])
 
-            if sys.platform == 'darwin':
+            if is_apple:
                 env.Append(LIBS=['iconv', 'pthread'])
             else:
                 env.Append(LIBS=['m', 'rt', 'dl', 'pthread'])

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -350,7 +350,7 @@ if webm_multithread:
     env_libvpx.add_source_files(env.modules_sources, libvpx_sources_mt)
 
 if webm_cpu_x86:
-    is_clang_or_gcc = ('gcc' in os.path.basename(env["CC"])) or ('clang' in os.path.basename(env["CC"])) or ("OSXCROSS_ROOT" in os.environ)
+    is_clang_or_gcc = ('gcc' in os.path.basename(env["CC"])) or ('clang' in os.path.basename(env["CC"])) or ("osxcross" in env)
 
     env_libvpx_mmx = env_libvpx.Clone()
     if cpu_bits == '32' and is_clang_or_gcc:

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -23,7 +23,7 @@ ios_lib = env_ios.add_library('iphone', iphone_lib)
 
 def combine_libs(target=None, source=None, env=None):
     lib_path = target[0].srcnode().abspath
-    if ("OSXCROSS_IOS" in os.environ):
+    if "osxcross" in env:
         libtool = '$IPHONEPATH/usr/bin/${ios_triple}libtool'
     else:
         libtool = "$IPHONEPATH/usr/bin/libtool"

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -80,6 +80,10 @@ def configure(env):
 
     ## Compiler configuration
 
+    # Save this in environment for use by other modules
+    if "OSXCROSS_IOS" in os.environ:
+        env["osxcross"] = True
+
     env['ENV']['PATH'] = env['IPHONEPATH'] + "/Developer/usr/bin/:" + env['ENV']['PATH']
 
     compiler_path = '$IPHONEPATH/usr/bin/${ios_triple}'

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -72,7 +72,11 @@ def configure(env):
 
     ## Compiler configuration
 
-    if "OSXCROSS_ROOT" not in os.environ: # regular native build
+    # Save this in environment for use by other modules
+    if "OSXCROSS_ROOT" in os.environ:
+        env["osxcross"] = True
+
+    if not "osxcross" in env: # regular native build
         env.Append(CCFLAGS=['-arch', 'x86_64'])
         env.Append(LINKFLAGS=['-arch', 'x86_64'])
         if (env["macports_clang"] != 'no'):


### PR DESCRIPTION
Improve the test logic to only assume that we're building for macOS
if OSXCROSS_ROOT is defined *and* we requested p=osx.

Supersedes #24480.

Note: Untested, I'd be glad if @hpvb could give this a run before merging.