### PR TITLE
Fix blend tree generating wrong node names

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -134,6 +134,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 		node->set_offset(blend_tree->get_node_position(E->get()) * EDSCALE);
 
 		node->set_title(agnode->get_caption());
+		node->set_human_readable_collision_renaming(false);
 		node->set_name(E->get());
 
 		int base = 0;


### PR DESCRIPTION
Now it's possible to connect nodes again.

Before:
![peek 22-12-2018 12-25](https://user-images.githubusercontent.com/1387165/50375457-b7739b00-05e4-11e9-9535-bc6d5bfbdfc9.gif)

*Bugsquad edit:* Fixes #24473.