### PR TITLE
Add support for 8bpp bmp files

### DIFF
--- a/modules/bmp/image_loader_bmp.h
+++ b/modules/bmp/image_loader_bmp.h
@@ -37,6 +37,19 @@ class ImageLoaderBMP : public ImageFormatLoader {
 protected:
 	static const unsigned BITMAP_SIGNATURE = 0x4d42;
 
+	enum bmp_compression_s {
+		BI_RGB = 0x00,
+		BI_RLE8 = 0x01,
+		BI_RLE4 = 0x02,
+		BI_BITFIELDS = 0x03,
+		BI_JPEG = 0x04,
+		BI_PNG = 0x05,
+		BI_ALPHABITFIELDS = 0x06,
+		BI_CMYK = 0x0b,
+		BI_CMYKRLE8 = 0x0c,
+		BI_CMYKRLE4 = 0x0d
+	};
+
 	struct bmp_header_s {
 		struct bmp_file_header_s {
 			uint16_t bmp_signature;
@@ -57,15 +70,6 @@ protected:
 			uint32_t bmp_pixels_per_meter_y;
 			uint32_t bmp_colors_used;
 			uint32_t bmp_important_colors;
-			uint32_t bmp_red_mask;
-			uint32_t bmp_green_mask;
-			uint32_t bmp_blue_mask;
-			uint32_t bmp_alpha_mask;
-			uint32_t bmp_cs_type;
-			uint32_t bmp_endpoints[9];
-			uint32_t bmp_gamma_red;
-			uint32_t bmp_gamma_green;
-			uint32_t bmp_gamma_blue;
 		} bmp_info_header;
 	};
 


### PR DESCRIPTION
This PR includes:

* Support for 8bpp bmp files
* Added struct "bmp_compression_s" that contains known compressions
* Removed unused members of "bmp_info_header_s"
* Removed usage of sizeof() for file reading because of structure alignment
* Corrected reading of color table