### PR TITLE
`GodotRestInfoContactResultCallback::addSingleResult` now returns normal

### DIFF
--- a/modules/bullet/godot_result_callbacks.cpp
+++ b/modules/bullet/godot_result_callbacks.cpp
@@ -304,6 +304,7 @@ btScalar GodotRestInfoContactResultCallback::addSingleResult(btManifoldPoint &cp
 			colObj = static_cast<CollisionObjectBullet *>(colObj1Wrap->getCollisionObject()->getUserPointer());
 			m_result->shape = cp.m_index1;
 			B_TO_G(cp.getPositionWorldOnB(), m_result->point);
+			B_TO_G(cp.m_normalWorldOnB, m_result->normal);
 			m_rest_info_bt_point = cp.getPositionWorldOnB();
 			m_rest_info_collision_object = colObj1Wrap->getCollisionObject();
 		} else {


### PR DESCRIPTION
Fixes #24558 

Calling `PhysicsDirectSpaceState.get_rest_info()` while using Bullet physics will now return expected normals, rather than (0, 0, 0).