### PR TITLE
Fixed CurveTexture with GLES3 on Android

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -632,6 +632,25 @@ void RasterizerStorageGLES3::texture_allocate(RID p_texture, int p_width, int p_
 		p_flags &= ~VS::TEXTURE_FLAG_MIPMAPS; // no mipies for video
 	}
 
+#ifndef GLES_OVER_GL
+	switch (p_format) {
+		case Image::Format::FORMAT_RF:
+		case Image::Format::FORMAT_RGF:
+		case Image::Format::FORMAT_RGBF:
+		case Image::Format::FORMAT_RGBAF:
+		case Image::Format::FORMAT_RH:
+		case Image::Format::FORMAT_RGH:
+		case Image::Format::FORMAT_RGBH:
+		case Image::Format::FORMAT_RGBAH: {
+			if (!config.texture_float_linear_supported) {
+				// disable linear texture filtering when not supported for float format on some devices (issue #24295)
+				p_flags &= ~VS::TEXTURE_FLAG_FILTER;
+			}
+		} break;
+		default: {}
+	}
+#endif
+
 	Texture *texture = texture_owner.get(p_texture);
 	ERR_FAIL_COND(!texture);
 	texture->width = p_width;
@@ -7669,11 +7688,13 @@ void RasterizerStorageGLES3::initialize() {
 	config.etc2_supported = false;
 	config.s3tc_supported = true;
 	config.rgtc_supported = true; //RGTC - core since OpenGL version 3.0
+	config.texture_float_linear_supported = true;
 #else
 	config.etc2_supported = true;
 	config.hdr_supported = false;
 	config.s3tc_supported = config.extensions.has("GL_EXT_texture_compression_dxt1") || config.extensions.has("GL_EXT_texture_compression_s3tc") || config.extensions.has("WEBGL_compressed_texture_s3tc");
 	config.rgtc_supported = config.extensions.has("GL_EXT_texture_compression_rgtc") || config.extensions.has("GL_ARB_texture_compression_rgtc") || config.extensions.has("EXT_texture_compression_rgtc");
+	config.texture_float_linear_supported = config.extensions.has("GL_OES_texture_float_linear");
 #endif
 
 	config.pvrtc_supported = config.extensions.has("GL_IMG_texture_compression_pvrtc");

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -87,6 +87,8 @@ public:
 
 		bool srgb_decode_supported;
 
+		bool texture_float_linear_supported;
+
 		bool use_rgba_2d_shadows;
 
 		float anisotropic_level;


### PR DESCRIPTION
Fix CurveTexture on Android by disabling linear filtering in GLES3 when using float texture format, because it's not supported on some devices.

Tested on Samsung Galaxy S6

Fixes issues #24295 & #24538
Based on instructions from @reduz in PR #15774