### PR TITLE
Bring back script encryption in export preset

### DIFF
--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -52,6 +52,12 @@ public:
 		EXPORT_SELECTED_RESOURCES,
 	};
 
+	enum ScriptExportMode {
+		MODE_SCRIPT_TEXT,
+		MODE_SCRIPT_COMPILED,
+		MODE_SCRIPT_ENCRYPTED,
+	};
+
 private:
 	Ref<EditorExportPlatform> platform;
 	ExportFilter export_filter;
@@ -74,6 +80,9 @@ private:
 	String name;
 
 	String custom_features;
+
+	int script_mode;
+	String script_key;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -117,6 +126,12 @@ public:
 
 	void set_export_path(const String &p_path);
 	String get_export_path() const;
+
+	void set_script_export_mode(int p_mode);
+	int get_script_export_mode() const;
+
+	void set_script_encryption_key(const String &p_key);
+	String get_script_encryption_key() const;
 
 	const List<PropertyInfo> &get_properties() const { return properties; }
 
@@ -260,6 +275,8 @@ class EditorExportPlugin : public Reference {
 
 	friend class EditorExportPlatform;
 
+	Ref<EditorExportPreset> export_preset;
+
 	Vector<SharedObject> shared_objects;
 	struct ExtraFile {
 		String path;
@@ -294,6 +311,9 @@ class EditorExportPlugin : public Reference {
 	void _export_end_script();
 
 protected:
+	void set_export_preset(const Ref<EditorExportPreset> &p_preset);
+	Ref<EditorExportPreset> get_export_preset() const;
+
 	void add_file(const String &p_path, const Vector<uint8_t> &p_file, bool p_remap);
 	void add_shared_object(const String &p_path, const Vector<String> &tags);
 

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -100,6 +100,10 @@ private:
 	LineEdit *custom_features;
 	RichTextLabel *custom_feature_display;
 
+	OptionButton *script_mode;
+	LineEdit *script_key;
+	Label *script_key_error;
+
 	Label *export_error;
 	HBoxContainer *export_templates_error;
 
@@ -119,6 +123,7 @@ private:
 	void _delete_preset_confirm();
 	void _update_export_all();
 
+	void _update_current_preset();
 	void _update_presets();
 
 	void _export_type_changed(int p_which);
@@ -154,6 +159,11 @@ private:
 	void _update_feature_list();
 	void _custom_features_changed(const String &p_text);
 
+	bool updating_script_key;
+	void _script_export_mode_changed(int p_mode);
+	void _script_encryption_key_changed(const String &p_key);
+	bool _validate_script_encryption_key(const String &p_key);
+
 	void _tab_changed(int);
 
 protected:
@@ -165,6 +175,8 @@ public:
 
 	void set_export_path(const String &p_value);
 	String get_export_path();
+
+	Ref<EditorExportPreset> get_current_preset() const;
 
 	ProjectExportDialog();
 	~ProjectExportDialog();


### PR DESCRIPTION
What started as curiosity ended up as an actual implementation. 😁

```
Retrieved working implementation from 2.1 branch and adapted to
existing export preset system.

Added Script tab in export preset to export script as raw text,
compiled, or encrypted (same as in 2.1). The script encryption key is
visually validated. The script export mode and the key is saved per
per preset in `export_presets.cfg`, so it makes sense to ignore this
file in version control system.

Each custom exporting procedure can retrieve an export preset set
during project exporting. Refactored project export dialog a bit to
allow easier code comprehension.
```
Tested in both debug and release modes, with text, compiled, and encrypted modes respectively. If wrong key is provided during export, the exported project will crash, which is expected:
```
ERROR: open_and_parse: Condition ' String::md5(md5.digest) != String::md5(md5d) ' is true. returned: ERR_FILE_CORRUPT
      At: core/io/file_access_encrypted.cpp:103
```

The scripts are exported as `.gde` as before. The default script export mode is still `Compiled`, not `Text`.

I'll also write documentation for this in godot-docs.

Fixes #24121.

![script_encrypt_export](https://user-images.githubusercontent.com/17108460/50402730-462d1700-07a1-11e9-89fc-3000ad20340a.gif)

Also, Merry Christmas! 🎄