### PR TITLE
General fixes for the TileSet editor

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -107,7 +107,7 @@ class TileSetEditor : public HSplitContainer {
 
 	bool creating_shape;
 	int dragging_point;
-	float tile_names_opacity;
+	bool tile_names_visible;
 	Vector2 region_from;
 	Rect2 edited_region;
 	bool draw_edited_region;


### PR DESCRIPTION
- Fix general bugs with shape polygons, notably, lines not being fully closed and not following the rest of the polygon when points are being edited.
- Make tile names appear instantly, instead of fading in and out.
- Small reorganization of buttons in the tool menu.