### PR TITLE
Make possible to use ETC texture format with GLES3 on Android

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1121,9 +1121,10 @@ public:
 			r_features->push_back("etc");
 		else*/
 		String driver = ProjectSettings::get_singleton()->get("rendering/quality/driver/driver_name");
-		if (driver == "GLES2") {
+		if (driver == "GLES2" || driver == "GLES3") {
 			r_features->push_back("etc");
-		} else {
+		}
+		if (driver == "GLES3") {
 			r_features->push_back("etc2");
 		}
 


### PR DESCRIPTION
Currently, textures are not exported if use ETC on project settings and export project with GLES3.
GLES3 should be able to use ETC format also.

It's definitely needed if want to support both gles3 and gles2 with a single package.