### PR TITLE
Clean up & improve makerst.py

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -24,5 +24,5 @@ rst:
 	rm -rf $(OUTPUTDIR)/rst
 	mkdir -p $(OUTPUTDIR)/rst
 	pushd $(OUTPUTDIR)/rst
-	python $(TOOLSDIR)/makerst.py $(CLASSES)
+	python3 $(TOOLSDIR)/makerst.py $(CLASSES)
 	popd


### PR DESCRIPTION
Man this file even had some semicolons in it.

I cleaned up the entire file, while it's still pretty ugly it's much better now.
I also added type checks so it passes `mypy --strict`.
`make_type` now throws a warning on unresolved type references, which there are a bunch of. I'm not responsible for fixing those though.
Also some more hardening against crashes. For example XML tags without content won't cause crashes now.
Functionality has not been modified as far as I can tell.