### PR TITLE
Fix HTML5 WebSocket client buffers size.

### DIFF
--- a/modules/websocket/emws_client.cpp
+++ b/modules/websocket/emws_client.cpp
@@ -205,8 +205,8 @@ int EMWSClient::get_max_packet_size() const {
 }
 
 EMWSClient::EMWSClient() {
-	_in_buf_size = GLOBAL_GET(WSC_IN_BUF);
-	_in_pkt_size = GLOBAL_GET(WSC_IN_PKT);
+	_in_buf_size = nearest_shift((int)GLOBAL_GET(WSC_IN_BUF) - 1) + 10;
+	_in_pkt_size = nearest_shift((int)GLOBAL_GET(WSC_IN_PKT) - 1);
 	_is_connecting = false;
 	_peer = Ref<EMWSPeer>(memnew(EMWSPeer));
 	/* clang-format off */


### PR DESCRIPTION
Properly uses `nearest_shift` when reading buffer sizes from project setting in JS implementation after #22940 (payload is in `KB` so `nearest_shift + 10`, packets is the packet number so simply `nearest_shift`).
Fixes #24423 