### PR TITLE
Fix: Cannot find code editor: VSCode; although installed on linux

### DIFF
--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -251,6 +251,14 @@ Error GodotSharpEditor::open_in_external_editor(const Ref<Script> &p_script, int
 				// Try to search it again if it wasn't found last time or if it was removed from its location
 				vscode_path = path_which("code");
 			}
+			if (vscode_path.empty() || !FileAccess::exists(vscode_path)) {
+				// On some Linux distro the executable has the name vscode
+				vscode_path = path_which("vscode");
+			}
+			if (vscode_path.empty() || !FileAccess::exists(vscode_path)) {
+				// Executable name when installing VSCode directly from MS on Linux
+				vscode_path = path_which("visual-studio-code");
+			}
 
 			List<String> args;
 


### PR DESCRIPTION
VSCode's executable name is inconcistent and godot only searches for "code" when opening C# file with external editor set to Visual Studio Code.
When installing VSCode on linux from MS, the executable's name is `visual-studio-code`, but when installing from the repository, the executable's name it's either `code` or `vscode`.

![screenshot from 2018-12-27 15-25-13](https://user-images.githubusercontent.com/19777767/50472494-9e575980-09eb-11e9-9771-f46d06eb8dbf.png)

I haven't tested this on windows yet.
