### PR TITLE
SCons: Drop ios_sim option forcing x86, simulator needs x86_64

### DIFF
--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -271,7 +271,7 @@ if env["platform"] == 'uwp':
 else:
     import platform
     is_x11_or_server_arm = ((env["platform"] == 'x11' or env["platform"] == 'server') and (platform.machine().startswith('arm') or platform.machine().startswith('aarch')))
-    is_ios_x86 = (env["platform"] == 'iphone' and env["ios_sim"])
+    is_ios_x86 = (env["platform"] == 'iphone' and ("arch" in env and env["arch"].startswith('x86')))
     is_android_x86 = (env["platform"] == 'android' and env["android_arch"] == 'x86')
     if is_android_x86:
         cpu_bits = '32'

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -29,7 +29,6 @@ def get_opts():
         BoolVariable('icloud', 'Support for iCloud', True),
         BoolVariable('ios_exceptions', 'Enable exceptions', False),
         ('ios_triple', 'Triple for ios toolchain', ''),
-        BoolVariable('ios_sim', 'Build simulator binary', False),
     ]
 
 
@@ -64,10 +63,7 @@ def configure(env):
         env.Append(LINKFLAGS=['-flto'])
 
     ## Architecture
-    if env["ios_sim"] and not ("arch" in env):
-      env["arch"] = "x86"
-
-    if env["arch"] == "x86":  # i386, simulator
+    if env["arch"] == "x86":  # i386
         env["bits"] = "32"
     elif env["arch"] == "x86_64":
         env["bits"] = "64"


### PR DESCRIPTION
As reported by @alketii, Xcode seems to want `x86_64` binaries to run a project through the simulator, so the previous `ios_sim` option that enforced `x86` build no longer makes sense.

@hpvb I think we might need to add `x86_64` builds to official templates so that people can use the simulator.