### PR TITLE
fixes crash when Body2DSW doesn't have space

### DIFF
--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -1079,6 +1079,7 @@ Physics2DDirectBodyState *Physics2DServerSW::body_get_direct_state(RID p_body) {
 
 	Body2DSW *body = body_owner.get(p_body);
 	ERR_FAIL_COND_V(!body, NULL);
+	ERR_FAIL_COND_V(!body->get_space(), NULL);
 
 	if (body->get_space()->is_locked()) {
 


### PR DESCRIPTION
I don't know the reason behind this, but this at least doesn't crash the game and leaves a nice warning in the log.

*Bugsquad edit:* Fixes #23722.