### PR TITLE
Always treat exponent as float

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -525,7 +525,6 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 					bool exponent_found = false;
 					bool hexa_found = false;
 					bool sign_found = false;
-					bool minus_exponent_found = false;
 					bool float_suffix_found = false;
 
 					String str;
@@ -557,8 +556,6 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 							if (sign_found)
 								return _make_token(TK_ERROR, "Invalid numeric constant");
 							sign_found = true;
-							if (GETCHAR(i) == '-')
-								minus_exponent_found = true;
 						} else
 							break;
 
@@ -571,7 +568,7 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 					if (hexa_found) {
 						//hex integers eg."0xFF" or "0x12AB", etc - NOT supported yet
 						return _make_token(TK_ERROR, "Invalid (hexadecimal) numeric constant - Not supported");
-					} else if (period_found || float_suffix_found) {
+					} else if (period_found || exponent_found || float_suffix_found) {
 						//floats
 						if (period_found) {
 							if (float_suffix_found) {
@@ -614,7 +611,7 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 
 					char_idx += str.length();
 					Token tk;
-					if (period_found || minus_exponent_found || float_suffix_found)
+					if (period_found || exponent_found || float_suffix_found)
 						tk.type = TK_REAL_CONSTANT;
 					else
 						tk.type = TK_INT_CONSTANT;


### PR DESCRIPTION
This fixes #23939 

Don't know when this changed or why but the parser was treating 1e5 (10000.0) as an integer while 1e-5 (0.00001) as a float. While on face value that should be fine two things cause a problem with this:
1) it leads to a call to is_valid_integer which will return false because it doesn't see 1e5 as an integer
2) GLSL treats exponential notation as floating point anyway as far as I understand.

This fix simply ensures the parser treats any exponential notation as floating point and it works perfectly.