### PR TITLE
Allow to filter properties inside inspector with plugins

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -185,6 +185,7 @@ public:
 	void add_property_editor_for_multiple_properties(const String &p_label, const Vector<String> &p_properties, Control *p_prop);
 
 	virtual bool can_handle(Object *p_object);
+	virtual bool filter_property_list(Object *p_object, List<PropertyInfo> *p_list);
 	virtual void parse_begin(Object *p_object);
 	virtual void parse_category(Object *p_object, const String &p_parse_category);
 	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage);


### PR DESCRIPTION
This PR adds `EditorInspectorPlugin::filter_property_list(...)` which allows a plugin to modify property infos before inspector shows them.

This can be used in different use cases. One of those is if you inherit a core resource like `ShaderMaterial`, set all shader parameters through code and do not want the user to edit them.

```
extends EditorInspectorPlugin

func can_handle(object):
	if object is MyShaderMaterial:
		return true;
	return false

func filter_property_list(object, list):
	for p in list:
		if p.name.to_lower().begins_with("shader_param/"):
			p.usage &= ~PROPERTY_USAGE_EDITOR;
	
	return false
```

This PR might fix #23891, #17122 and #5988.