### PR TITLE
Add undo-redo to the TileSet editor, and other improvements

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -76,7 +76,7 @@
 			Set dialog to open or save mode, changes selection behavior. See enum [code]Mode[/code] constants.
 		</member>
 		<member name="mode_overrides_title" type="bool" setter="set_mode_overrides_title" getter="is_mode_overriding_title">
-			If [code]true[/code], changing the [code]Mode[/code] property will set the window title accordingly (e. g. setting mode to [code]MODE_OPEN_FILE[/code] will change the window title to "Open a File").
+			If [code]true[/code], changing the [code]Mode[/code] property will set the window title accordingly (e.g. setting mode to [code]MODE_OPEN_FILE[/code] will change the window title to "Open a File").
 		</member>
 		<member name="show_hidden_files" type="bool" setter="set_show_hidden_files" getter="is_showing_hidden_files">
 			If [code]true[/code], the dialog will show hidden files.

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -36,12 +36,66 @@
 			<description>
 			</description>
 		</method>
+		<method name="autotile_clear_bitmask_map">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+				Clears all bitmask info of the autotile.
+			</description>
+		</method>
+		<method name="autotile_get_bitmask">
+			<return type="int" enum="TileSet.AutotileBindings">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="coord" type="Vector2">
+			</argument>
+			<description>
+				Returns the bitmask of the subtile from an autotile given its coordinates.
+				The value is the sum of the values in [enum TileSet.AutotileBindings] present in the subtile (e.g. a value of 5 means the bitmask has bindings in both the top left and top right).
+			</description>
+		</method>
 		<method name="autotile_get_bitmask_mode" qualifiers="const">
 			<return type="int" enum="TileSet.BitmaskMode">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
+				Returns the [enum TileSet.BitmaskMode] of the autotile.
+			</description>
+		</method>
+		<method name="autotile_get_icon_coordinate" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+				Returns the subtile that's being used as an icon in an atlas/autotile given its coordinates.
+				The subtile defined as the icon will be used as a fallback when the atlas/autotile's bitmask info is incomplete. It will also be used to represent it in the TileSet editor.
+			</description>
+		</method>
+		<method name="autotile_get_light_occluder" qualifiers="const">
+			<return type="OccluderPolygon2D">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="coord" type="Vector2">
+			</argument>
+			<description>
+				Returns the light occluder of the subtile from an atlas/autotile given its coordinates.
+			</description>
+		</method>
+		<method name="autotile_get_navigation_polygon" qualifiers="const">
+			<return type="NavigationPolygon">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="coord" type="Vector2">
+			</argument>
+			<description>
+				Returns the navigation polygon of the subtile from an atlas/autotile given its coordinates.
 			</description>
 		</method>
 		<method name="autotile_get_size" qualifiers="const">
@@ -50,6 +104,53 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
+				Returns the size of the subtiles in an atlas/autotile.
+			</description>
+		</method>
+		<method name="autotile_get_spacing" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+				Returns the spacing between subtiles of the atlas/autotile.
+			</description>
+		</method>
+		<method name="autotile_get_subtile_priority">
+			<return type="int">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="coord" type="Vector2">
+			</argument>
+			<description>
+				Returns the priority of the subtile from an autotile given its coordinates.
+				When more than one subtile has the same bitmask value, one of them will be picked randomly for drawing. Its priority will define how often it will be picked.
+			</description>
+		</method>
+		<method name="autotile_get_z_index">
+			<return type="int">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="coord" type="Vector2">
+			</argument>
+			<description>
+				Returns the drawing index of the subtile from an atlas/autotile given its coordinates.
+			</description>
+		</method>
+		<method name="autotile_set_bitmask">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="bitmask" type="Vector2">
+			</argument>
+			<argument index="2" name="flag" type="int" enum="TileSet.AutotileBindings">
+			</argument>
+			<description>
+				Sets the bitmask of the subtile from an autotile given its coordinates.
+				The value is the sum of the values in [enum TileSet.AutotileBindings] present in the subtile (e.g. a value of 5 means the bitmask has bindings in both the top left and top right).
 			</description>
 		</method>
 		<method name="autotile_set_bitmask_mode">
@@ -60,6 +161,45 @@
 			<argument index="1" name="mode" type="int" enum="TileSet.BitmaskMode">
 			</argument>
 			<description>
+				Sets the [enum TileSet.BitmaskMode] of the autotile.
+			</description>
+		</method>
+		<method name="autotile_set_icon_coordinate">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="coord" type="Vector2">
+			</argument>
+			<description>
+				Sets the subtile that will be used as an icon in an atlas/autotile given its coordinates.
+				The subtile defined as the icon will be used as a fallback when the atlas/autotile's bitmask info is incomplete. It will also be used to represent it in the TileSet editor.
+			</description>
+		</method>
+		<method name="autotile_set_light_occluder">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="light_occluder" type="OccluderPolygon2D">
+			</argument>
+			<argument index="2" name="coord" type="Vector2">
+			</argument>
+			<description>
+				Sets the light occluder of the subtile from an atlas/autotile given its coordinates.
+			</description>
+		</method>
+		<method name="autotile_set_navigation_polygon">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="navigation_polygon" type="NavigationPolygon">
+			</argument>
+			<argument index="2" name="coord" type="Vector2">
+			</argument>
+			<description>
+				Sets the navigation polygon of the subtile from an atlas/autotile given its coordinates.
 			</description>
 		</method>
 		<method name="autotile_set_size">
@@ -70,6 +210,45 @@
 			<argument index="1" name="size" type="Vector2">
 			</argument>
 			<description>
+				Sets the size of the subtiles in an atlas/autotile.
+			</description>
+		</method>
+		<method name="autotile_set_spacing">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="spacing" type="int">
+			</argument>
+			<description>
+				Sets the spacing between subtiles of the atlas/autotile.
+			</description>
+		</method>
+		<method name="autotile_set_subtile_priority">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="coord" type="Vector2">
+			</argument>
+			<argument index="2" name="priority" type="int">
+			</argument>
+			<description>
+				Sets the priority of the subtile from an autotile given its coordinates.
+				When more than one subtile has the same bitmask value, one of them will be picked randomly for drawing. Its priority will define how often it will be picked.
+			</description>
+		</method>
+		<method name="autotile_set_z_index">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="coord" type="Vector2">
+			</argument>
+			<argument index="2" name="z_index" type="int">
+			</argument>
+			<description>
+				Sets the drawing index of the subtile from an atlas/autotile given its coordinates.
 			</description>
 		</method>
 		<method name="clear">
@@ -304,7 +483,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Returns the tile's [enum TileMode].
+				Returns the tile's [enum TileSet.TileMode].
 			</description>
 		</method>
 		<method name="tile_get_z_index" qualifiers="const">
@@ -508,7 +687,7 @@
 			<argument index="1" name="tilemode" type="int" enum="TileSet.TileMode">
 			</argument>
 			<description>
-				Sets the tile's [enum TileMode].
+				Sets the tile's [enum TileSet.TileMode].
 			</description>
 		</method>
 		<method name="tile_set_z_index">

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -517,7 +517,7 @@ void TileMapEditor::_update_palette() {
 		manual_palette->show();
 	}
 
-	if (tileset->tile_get_tile_mode(sel_tile) == TileSet::AUTO_TILE) {
+	if (sel_tile != TileMap::INVALID_CELL && tileset->tile_get_tile_mode(sel_tile) == TileSet::AUTO_TILE) {
 		manual_button->show();
 	} else {
 		manual_button->hide();

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -94,6 +94,7 @@ class TileSetEditor : public HSplitContainer {
 	Ref<TileSet> tileset;
 	TilesetEditorContext *helper;
 	EditorNode *editor;
+	UndoRedo *undo_redo;
 
 	ConfirmationDialog *cd;
 	AcceptDialog *err_dialog;
@@ -151,10 +152,14 @@ class TileSetEditor : public HSplitContainer {
 	void update_texture_list();
 	void update_texture_list_icon();
 
+	void add_texture(Ref<Texture> p_texture);
+	void remove_texture(Ref<Texture> p_texture);
+
 	Ref<Texture> get_current_texture();
 
 	static void _import_node(Node *p_node, Ref<TileSet> p_library);
 	static void _import_scene(Node *p_scene, Ref<TileSet> p_library, bool p_merge);
+	void _undo_redo_import_scene(Node *p_scene, bool p_merge);
 
 protected:
 	static void _bind_methods();
@@ -185,6 +190,10 @@ private:
 	void _set_snap_step(Vector2 p_val);
 	void _set_snap_off(Vector2 p_val);
 	void _set_snap_sep(Vector2 p_val);
+
+	void _validate_current_tile_id();
+	void _select_edited_shape_coord();
+	void _undo_tile_removal(int p_id);
 
 	void _zoom_in();
 	void _zoom_out();

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -507,6 +507,13 @@ int TileSet::autotile_get_subtile_priority(int p_id, const Vector2 &p_coord) {
 	return 1;
 }
 
+const Map<Vector2, int> &TileSet::autotile_get_priority_map(int p_id) const {
+
+	static Map<Vector2, int> dummy;
+	ERR_FAIL_COND_V(!tile_map.has(p_id), dummy);
+	return tile_map[p_id].autotile_data.priority_map;
+}
+
 void TileSet::autotile_set_z_index(int p_id, const Vector2 &p_coord, int p_z_index) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
@@ -524,11 +531,11 @@ int TileSet::autotile_get_z_index(int p_id, const Vector2 &p_coord) {
 	return 0;
 }
 
-const Map<Vector2, int> &TileSet::autotile_get_priority_map(int p_id) const {
+const Map<Vector2, int> &TileSet::autotile_get_z_index_map(int p_id) const {
 
 	static Map<Vector2, int> dummy;
 	ERR_FAIL_COND_V(!tile_map.has(p_id), dummy);
-	return tile_map[p_id].autotile_data.priority_map;
+	return tile_map[p_id].autotile_data.z_index_map;
 }
 
 void TileSet::autotile_set_bitmask(int p_id, Vector2 p_coord, uint16_t p_flag) {
@@ -986,8 +993,23 @@ void TileSet::clear() {
 void TileSet::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("create_tile", "id"), &TileSet::create_tile);
+	ClassDB::bind_method(D_METHOD("autotile_clear_bitmask_map", "id"), &TileSet::autotile_clear_bitmask_map);
+	ClassDB::bind_method(D_METHOD("autotile_set_icon_coordinate", "id", "coord"), &TileSet::autotile_set_icon_coordinate);
+	ClassDB::bind_method(D_METHOD("autotile_get_icon_coordinate", "id"), &TileSet::autotile_get_icon_coordinate);
+	ClassDB::bind_method(D_METHOD("autotile_set_subtile_priority", "id", "coord", "priority"), &TileSet::autotile_set_subtile_priority);
+	ClassDB::bind_method(D_METHOD("autotile_get_subtile_priority", "id", "coord"), &TileSet::autotile_get_subtile_priority);
+	ClassDB::bind_method(D_METHOD("autotile_set_z_index", "id", "coord", "z_index"), &TileSet::autotile_set_z_index);
+	ClassDB::bind_method(D_METHOD("autotile_get_z_index", "id", "coord"), &TileSet::autotile_get_z_index);
+	ClassDB::bind_method(D_METHOD("autotile_set_light_occluder", "id", "light_occluder", "coord"), &TileSet::autotile_set_light_occluder);
+	ClassDB::bind_method(D_METHOD("autotile_get_light_occluder", "id", "coord"), &TileSet::autotile_get_light_occluder);
+	ClassDB::bind_method(D_METHOD("autotile_set_navigation_polygon", "id", "navigation_polygon", "coord"), &TileSet::autotile_set_navigation_polygon);
+	ClassDB::bind_method(D_METHOD("autotile_get_navigation_polygon", "id", "coord"), &TileSet::autotile_get_navigation_polygon);
+	ClassDB::bind_method(D_METHOD("autotile_set_bitmask", "id", "bitmask", "flag"), &TileSet::autotile_set_bitmask);
+	ClassDB::bind_method(D_METHOD("autotile_get_bitmask", "id", "coord"), &TileSet::autotile_get_bitmask);
 	ClassDB::bind_method(D_METHOD("autotile_set_bitmask_mode", "id", "mode"), &TileSet::autotile_set_bitmask_mode);
 	ClassDB::bind_method(D_METHOD("autotile_get_bitmask_mode", "id"), &TileSet::autotile_get_bitmask_mode);
+	ClassDB::bind_method(D_METHOD("autotile_set_spacing", "id", "spacing"), &TileSet::autotile_set_spacing);
+	ClassDB::bind_method(D_METHOD("autotile_get_spacing", "id"), &TileSet::autotile_get_spacing);
 	ClassDB::bind_method(D_METHOD("autotile_set_size", "id", "size"), &TileSet::autotile_set_size);
 	ClassDB::bind_method(D_METHOD("autotile_get_size", "id"), &TileSet::autotile_get_size);
 	ClassDB::bind_method(D_METHOD("tile_set_name", "id", "name"), &TileSet::tile_set_name);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -175,6 +175,7 @@ public:
 
 	void autotile_set_z_index(int p_id, const Vector2 &p_coord, int p_z_index);
 	int autotile_get_z_index(int p_id, const Vector2 &p_coord);
+	const Map<Vector2, int> &autotile_get_z_index_map(int p_id) const;
 
 	void autotile_set_bitmask(int p_id, Vector2 p_coord, uint16_t p_flag);
 	uint16_t autotile_get_bitmask(int p_id, Vector2 p_coord);


### PR DESCRIPTION
In this episode of **"Something That I Thought That Would Be Quick Took Several Hours of My Life"**:

- **Add full undo/redo operation support!**
- Fix shapes not being ready to be edited when switching to another tile in case of autotiles.
- Right mouse click now cancels shape creation.
- Polygon grabbers now appear while creating a shape when there was none previously.
- Make the polygon grabber threshold obey the one specified in the editor settings.
- Fix removal of shapes in single tiles (supersedes #24541).
- Expose (and document) several autotile methods to GDScript.