### PR TITLE
Check material array size

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -1108,9 +1108,13 @@ void RasterizerSceneGLES2::_fill_render_list(InstanceBase **p_cull_result, int p
 				ERR_CONTINUE(!mesh);
 
 				int num_surfaces = mesh->surfaces.size();
+				int num_materials = instance->materials.size();
 
 				for (int i = 0; i < num_surfaces; i++) {
-					int material_index = instance->materials[i].is_valid() ? i : -1;
+					int material_index = -1;
+					if (i < num_materials) { // possible for a few frames that our materials array hasn't been updated yet, not sure why
+						material_index = instance->materials[i].is_valid() ? i : -1;
+					}
 
 					RasterizerStorageGLES2::Surface *surface = mesh->surfaces[i];
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3164,10 +3164,14 @@ void RasterizerSceneGLES3::_fill_render_list(InstanceBase **p_cull_result, int p
 				ERR_CONTINUE(!mesh);
 
 				int ssize = mesh->surfaces.size();
+				int msize = inst->materials.size();
 
 				for (int i = 0; i < ssize; i++) {
 
-					int mat_idx = inst->materials[i].is_valid() ? i : -1;
+					int mat_idx = -1;
+					if (i < msize) { // possible for a few frames that our materials array hasn't been updated yet, not sure why
+						mat_idx = inst->materials[i].is_valid() ? i : -1;
+					}
 					RasterizerStorageGLES3::Surface *s = mesh->surfaces[i];
 					_add_geometry(s, inst, NULL, mat_idx, p_depth_pass, p_shadow_pass);
 				}


### PR DESCRIPTION
This prevents one of the crashes mentioned in #24635 though it fights a symptom, not the cause.

For some reason there is a delay of a few frames between calling ArrayMesh::add_surface_from_arrays, it causing MeshInstance::_mesh_changed to be executed (which resizes our materials array to match the number of surfaces) and our visual server becoming aware of the resized materials array. That still needs further investigation.

The fix in this PR simply checks if the materials array has the right size and ensures the render pipeline doesn't crash but instead simply uses the default material. This is the same outcome as when the materials array would have been resized as it still would not hold any overridden materials.

*Bugsquad edit:* Fixes #23790.