### PR TITLE
Fix texture type not being initialised

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4104,6 +4104,7 @@ RID RasterizerStorageGLES2::render_target_create() {
 
 	Texture *t = memnew(Texture);
 
+	t->type = VS::TEXTURE_TYPE_2D;
 	t->flags = 0;
 	t->width = 0;
 	t->height = 0;

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -264,6 +264,7 @@ public:
 				alloc_width(0),
 				alloc_height(0),
 				format(Image::FORMAT_L8),
+				type(VS::TEXTURE_TYPE_2D),
 				target(0),
 				data_size(0),
 				total_data_size(0),

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1995,7 +1995,8 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			actions = &shaders.actions_particles;
 			actions->uniforms = &p_shader->uniforms;
 		} break;
-		case VS::SHADER_MAX: break; // Can't happen, but silences warning
+		case VS::SHADER_MAX:
+			break; // Can't happen, but silences warning
 	}
 
 	Error err = shaders.compiler.compile(p_shader->mode, p_shader->code, actions, p_shader->path, gen_code);
@@ -7019,6 +7020,7 @@ RID RasterizerStorageGLES3::render_target_create() {
 
 	Texture *t = memnew(Texture);
 
+	t->type = VS::TEXTURE_TYPE_2D;
 	t->flags = 0;
 	t->width = 0;
 	t->height = 0;

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -291,6 +291,7 @@ public:
 				width(0),
 				height(0),
 				format(Image::FORMAT_L8),
+				type(VS::TEXTURE_TYPE_2D),
 				target(GL_TEXTURE_2D),
 				data_size(0),
 				compressed(false),


### PR DESCRIPTION
This solves the second crash in #24635, this was interesting and all boils down to this bit of code in RasterizerStorageGLES3::texture_get_data:
```
if (texture->type == VS::TEXTURE_TYPE_CUBEMAP && p_layer < 6 && !texture->images[p_layer].is_null()) {
	return texture->images[p_layer];
}
```

There is nothing wrong with that code, if this is a cube map and p_layer is less then 6 (as cubemaps only have 6 sizes) we want to return the correct entry in the images array.

The crash happened because the images array was empty, as we're not dealing with a cubemap.

Our crash log reference this: `[5] EditorInterface::make_mesh_previews (c:\users\basti\development\godot3-git\editor\editor_plugin.cpp:129)`

That points to code that creates thumbnails for the meshes being exported as part of our mesh lib. It creates a temporary viewport, sets up a simple scene and then renders the mesh.

The problem here is that the viewport creates a render target texture, and this texture never got a type. Type was whatever was in memory and luck had it, for me it initialized it with the value for cubemap (1). 

Normally the type of the texture object in the driver is assigned by the texture resource in Godot. But as no such resource is used at this point in time....

The fix simply ensures that the value is initialized when the texture object is constructed. 
I'm also assigning it when the render target is created, not strictly required but if someone ever changes the default setting (say we introduce an uninitialized value) the code doesn't break again. I also feel this is much clearer in what we're trying to achieve. 

The VS::SHADER_MAX change is just clang-format being difficult ;) 