### PR TITLE
Fix loading EXR with alpha channel

### DIFF
--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -131,7 +131,7 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 	Image::Format format;
 	int output_channels = 0;
 
-	if (idxA > 0) {
+	if (idxA != -1) {
 
 		imgdata.resize(exr_image.width * exr_image.height * 8); //RGBA16
 		format = Image::FORMAT_RGBAH;
@@ -187,7 +187,7 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 			const float *b_channel_start = reinterpret_cast<const float *>(tile.images[idxB]);
 			const float *a_channel_start = NULL;
 
-			if (idxA > 0) {
+			if (idxA != -1) {
 				a_channel_start = reinterpret_cast<const float *>(tile.images[idxA]);
 			}
 
@@ -216,7 +216,7 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 					*row_w++ = Math::make_half_float(color.g);
 					*row_w++ = Math::make_half_float(color.b);
 
-					if (idxA > 0) {
+					if (idxA != -1) {
 						*row_w++ = Math::make_half_float(*a_channel++);
 					}
 				}


### PR DESCRIPTION
Fixes #24659.

`0` is a valid index, and actually the one used by the images in #24659 which are encoded as ABGR.