### PR TITLE
Fix "Method not found" error message when script is removed from object

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4654,6 +4654,8 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("edit_node", &EditorNode::edit_node);
 	ClassDB::bind_method("_unhandled_input", &EditorNode::_unhandled_input);
 
+	ClassDB::bind_method(D_METHOD("push_item", "object", "property", "inspector_only"), &EditorNode::push_item, DEFVAL(""), DEFVAL(false));
+
 	ClassDB::bind_method("_get_scene_metadata", &EditorNode::_get_scene_metadata);
 	ClassDB::bind_method("set_edited_scene", &EditorNode::set_edited_scene);
 	ClassDB::bind_method("open_request", &EditorNode::open_request);


### PR DESCRIPTION
Fixed error message by exposing push_item method to EditorNode

![image](https://user-images.githubusercontent.com/3036176/50557072-a288bd00-0cf2-11e9-9346-4a9c1d3b2e51.png)

This one is arrived every time the user removed a script from object("Clear a script for the selected node" button)