### PR TITLE
Fix "Method not found" message emitted when ShaderMaterial is created

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1941,7 +1941,7 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 
 		Resource *r = Object::cast_to<Resource>(object);
 		if (r) {
-			if (!r->is_edited() && String(p_name) != "resource/edited") {
+			if (!r->is_edited() && r->has_method("set_edited") && String(p_name) != "resource/edited") {
 				undo_redo->add_do_method(r, "set_edited", true);
 				undo_redo->add_undo_method(r, "set_edited", false);
 			}


### PR DESCRIPTION
By checking for existing "set_edited" method I removed unnecessary error message emitted every time the user created new ShaderMaterial and assign Shader resource to it

![image](https://user-images.githubusercontent.com/3036176/50558887-a02e5f00-0d02-11e9-9f09-f23fbe8b50cf.png)
