### PR TITLE
Fix viewport not updating with make_current() for Camera2D

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -410,6 +410,7 @@ void Camera2D::make_current() {
 	} else {
 		get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, group_name, "_make_current", this);
 	}
+	_update_scroll();
 }
 
 void Camera2D::clear_current() {


### PR DESCRIPTION
Fixes issue #23966 where viewport would not update with new **Camera2D** when `make_current()` was called.  

*Bugsquad edit:* Fixes #23966.