### PR TITLE
Fix line 2D intersection behavior

### DIFF
--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -279,6 +279,10 @@ void LineBuilder::build() {
 			}
 		} else {
 			// No intersection: fallback
+			if (current_joint_mode == Line2D::LINE_JOINT_SHARP) {
+				// There is no fallback implementation for LINE_JOINT_SHARP so switch to the LINE_JOINT_BEVEL
+				current_joint_mode = Line2D::LINE_JOINT_BEVEL;
+			}
 			pos_up1 = corner_pos_up;
 			pos_down1 = corner_pos_down;
 		}


### PR DESCRIPTION
Fixes #11533 segment folding

In case of no intersection between line segments, joint's vertices are calculated for bevel and round modes.  This was affecting quad generation for sharp mode later in the code.

As a solution this patch changes joint mode to bevel if there were no intersection and joint mode was sharp.