### PR TITLE
Disable support for VIA Padlock

### DIFF
--- a/thirdparty/mbedtls/include/mbedtls/config.h
+++ b/thirdparty/mbedtls/include/mbedtls/config.h
@@ -2389,20 +2389,6 @@
 #define MBEDTLS_OID_C
 
 /**
- * \def MBEDTLS_PADLOCK_C
- *
- * Enable VIA Padlock support on x86.
- *
- * Module:  library/padlock.c
- * Caller:  library/aes.c
- *
- * Requires: MBEDTLS_HAVE_ASM
- *
- * This modules adds support for the VIA PadLock on x86.
- */
-#define MBEDTLS_PADLOCK_C
-
-/**
  * \def MBEDTLS_PEM_PARSE_C
  *
  * Enable PEM decoding / parsing.


### PR DESCRIPTION
This code defines a symbol 'unsupported' which is also in a newer
version of libwebsockets. To fix 32bit linux builds just disable
padlock support. Processors that support this are rare and old.