### PR TITLE
AppVeyor: Install SCons from testpypi [do not merge]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ cache:
 install:
   - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - pip install -U wheel  # needed for pip install scons to work, otherwise a flag is missing
-  - pip install scons
+  - pip install --index-url https://test.pypi.org/simple/ scons
   - if defined VS call "%VS%" %ARCH%  # if defined - so we can also use mingw
 
 before_build:


### PR DESCRIPTION
Testing a potential fix from upstream SCons for a 3.0.2 packaging issue on pip.