### PR TITLE
Fix missing placeholders for exports when invalid script is saved

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -386,6 +386,20 @@ void GDScript::_update_exports_values(Map<StringName, Variant> &values, List<Pro
 		propnames.push_back(E->get());
 	}
 }
+
+void GDScript::_update_placeholders() {
+	if (placeholders.size()) { //hm :(
+
+		// update placeholders if any
+		Map<StringName, Variant> values;
+		List<PropertyInfo> propnames;
+		_update_exports_values(values, propnames);
+
+		for (Set<PlaceHolderScriptInstance *>::Element *E = placeholders.front(); E; E = E->next()) {
+			E->get()->update(propnames, values);
+		}
+	}
+}
 #endif
 
 bool GDScript::_update_exports() {
@@ -478,6 +492,7 @@ bool GDScript::_update_exports() {
 			for (Set<PlaceHolderScriptInstance *>::Element *E = placeholders.front(); E; E = E->next()) {
 				E->get()->set_build_failed(true);
 			}
+			_update_placeholders();
 			return false;
 		}
 	} else {
@@ -485,6 +500,7 @@ bool GDScript::_update_exports() {
 			for (Set<PlaceHolderScriptInstance *>::Element *E = placeholders.front(); E; E = E->next()) {
 				E->get()->set_build_failed(true);
 			}
+			_update_placeholders();
 			return false;
 		}
 	}
@@ -495,19 +511,7 @@ bool GDScript::_update_exports() {
 		}
 	}
 
-	if (placeholders.size()) { //hm :(
-
-		// update placeholders if any
-		Map<StringName, Variant> values;
-		List<PropertyInfo> propnames;
-		_update_exports_values(values, propnames);
-
-		for (Set<PlaceHolderScriptInstance *>::Element *E = placeholders.front(); E; E = E->next()) {
-			E->get()->set_build_failed(false);
-			E->get()->update(propnames, values);
-		}
-	}
-
+	_update_placeholders();
 	return changed;
 
 #else

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -98,6 +98,7 @@ class GDScript : public Script {
 	Set<ObjectID> inheriters_cache;
 	bool source_changed_cache;
 	void _update_exports_values(Map<StringName, Variant> &values, List<PropertyInfo> &propnames);
+	void _update_placeholders();
 
 #endif
 	Map<StringName, PropertyInfo> member_info;


### PR DESCRIPTION
When saving an invalid script, the export values should have been being
locked.  Instead, they were being destroyed/reset.  This correctly calls
the update for placeholders to exported values so that they don't get
lost.

Tested with a simple exported float value, which was printed in _ready.
Invalidated the script; still saw the exported value in the inspector.
Fixed the script, ran the node, and saw the old value printed out as
expected.

_bugsquad edit_ : Fix #24280