### PR TITLE
Add sub-resource name when available to script editor

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1684,7 +1684,19 @@ void ScriptEditor::_update_script_names() {
 			Ref<Texture> icon = se->get_icon();
 			String path = se->get_edited_resource()->get_path();
 			bool built_in = !path.is_resource_file();
-			String name = built_in ? path.get_file() : se->get_name();
+			String name;
+
+			if (built_in) {
+
+				name = path.get_file();
+				String resource_name = se->get_edited_resource()->get_name();
+				if (resource_name != "") {
+					name = name.substr(0, name.find("::", 0) + 2) + resource_name;
+				}
+			} else {
+
+				name = se->get_name();
+			}
 
 			_ScriptEditorItemData sd;
 			sd.icon = icon;


### PR DESCRIPTION
Fixes #24695 missing sub-resource names in script editor

*Bugsquad edit:* Fixes #28615.