### PR TITLE
Improved script attachment/removal buttons behavior a bit

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1615,7 +1615,10 @@ void SceneTreeDock::_delete_confirm() {
 }
 
 void SceneTreeDock::_update_script_button() {
-	if (EditorNode::get_singleton()->get_editor_selection()->get_selection().size() == 1) {
+	if (EditorNode::get_singleton()->get_editor_selection()->get_selection().size() == 0) {
+		button_create_script->hide();
+		button_clear_script->hide();
+	} else if (EditorNode::get_singleton()->get_editor_selection()->get_selection().size() == 1) {
 		Node *n = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list()[0];
 		if (n->get_script().is_null()) {
 			button_create_script->show();
@@ -1626,6 +1629,14 @@ void SceneTreeDock::_update_script_button() {
 		}
 	} else {
 		button_create_script->show();
+		List<Node *> selection = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list();
+		for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
+			Node *n = E->get();
+			if (!n->get_script().is_null()) {
+				button_clear_script->show();
+				return;
+			}
+		}
 		button_clear_script->hide();
 	}
 }


### PR DESCRIPTION
Small change for script buttons - now it will display Attach Script button only if at least one node is selected, and give user possibility to delete script from multiple nodes - before its impossible (through these buttons), because cancel button was hidden

![fix](https://user-images.githubusercontent.com/3036176/50589528-11534b00-0e98-11e9-8c3e-bb8b8bbdfa5e.gif)

Its not compatibility breaking change so it can be merged to 3.1 I guess..