### PR TITLE
Fix negative size rectangle drawing in GLES2

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -465,12 +465,11 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 					state.canvas_shader.use_material((void *)p_material);
 				}
 
-				Size2 abs_size = r->rect.size.abs();
 				Vector2 points[4] = {
 					r->rect.position,
-					r->rect.position + Vector2(abs_size.x, 0.0),
-					r->rect.position + abs_size,
-					r->rect.position + Vector2(0.0, abs_size.y),
+					r->rect.position + Vector2(r->rect.size.x, 0.0),
+					r->rect.position + r->rect.size,
+					r->rect.position + Vector2(0.0, r->rect.size.y),
 				};
 
 				if (r->rect.size.x < 0) {


### PR DESCRIPTION
Fixes rectangle being drawn as it was a non-negative size in case it actually is. This can be observed e.g. when drawing a negative size selection rectangle (i.e. press mouse button and move cursor up and left):

![1](https://user-images.githubusercontent.com/447143/50594761-1ddaa200-0e9e-11e9-8a73-0fac58c10358.gif)

Fixed:
![2](https://user-images.githubusercontent.com/447143/50594818-5aa69900-0e9e-11e9-99cf-fb56343f833b.gif)