### PR TITLE
[WIP] Improve code editor status bar to make it more readable, specially when with long error messages

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1241,7 +1241,7 @@ CodeTextEditor::CodeTextEditor() {
 	text_editor->set_brace_matching(true);
 	text_editor->set_auto_indent(true);
 
-	status_bar = memnew(HBoxContainer);
+	status_bar = memnew(VBoxContainer);
 	add_child(status_bar);
 	status_bar->set_h_size_flags(SIZE_EXPAND_FILL);
 
@@ -1268,10 +1268,14 @@ CodeTextEditor::CodeTextEditor() {
 	error->set_mouse_filter(MOUSE_FILTER_STOP);
 	find_replace_bar->connect("error", error, "set_text");
 
+	warning_line = memnew(HBoxContainer);
+	status_bar->add_child(warning_line);
+	warning_line->set_h_size_flags(SIZE_EXPAND_FILL);
+
 	status_bar->add_child(memnew(Label)); //to keep the height if the other labels are not visible
 
 	warning_label = memnew(Label);
-	status_bar->add_child(warning_label);
+	warning_line->add_child(warning_label);
 	warning_label->set_align(Label::ALIGN_RIGHT);
 	warning_label->set_valign(Label::VALIGN_CENTER);
 	warning_label->set_v_size_flags(SIZE_FILL);
@@ -1281,7 +1285,7 @@ CodeTextEditor::CodeTextEditor() {
 	warning_label->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
 
 	warning_count_label = memnew(Label);
-	status_bar->add_child(warning_count_label);
+	warning_line->add_child(warning_count_label);
 	warning_count_label->set_valign(Label::VALIGN_CENTER);
 	warning_count_label->set_v_size_flags(SIZE_FILL);
 	warning_count_label->set_autowrap(true); // workaround to prevent resizing the label on each change, do not touch
@@ -1294,7 +1298,7 @@ CodeTextEditor::CodeTextEditor() {
 	warning_count_label->set_text("0");
 
 	Label *font_size_txt = memnew(Label);
-	status_bar->add_child(font_size_txt);
+	warning_line->add_child(font_size_txt);
 	font_size_txt->set_align(Label::ALIGN_RIGHT);
 	font_size_txt->set_valign(Label::VALIGN_CENTER);
 	font_size_txt->set_v_size_flags(SIZE_FILL);
@@ -1302,7 +1306,7 @@ CodeTextEditor::CodeTextEditor() {
 	font_size_txt->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
 
 	font_size_nb = memnew(Label);
-	status_bar->add_child(font_size_nb);
+	warning_line->add_child(font_size_nb);
 	font_size_nb->set_valign(Label::VALIGN_CENTER);
 	font_size_nb->set_v_size_flags(SIZE_FILL);
 	font_size_nb->set_autowrap(true); // workaround to prevent resizing the label on each change, do not touch
@@ -1312,7 +1316,7 @@ CodeTextEditor::CodeTextEditor() {
 	font_size_nb->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
 
 	Label *line_txt = memnew(Label);
-	status_bar->add_child(line_txt);
+	warning_line->add_child(line_txt);
 	line_txt->set_align(Label::ALIGN_RIGHT);
 	line_txt->set_valign(Label::VALIGN_CENTER);
 	line_txt->set_v_size_flags(SIZE_FILL);
@@ -1320,7 +1324,7 @@ CodeTextEditor::CodeTextEditor() {
 	line_txt->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
 
 	line_nb = memnew(Label);
-	status_bar->add_child(line_nb);
+	warning_line->add_child(line_nb);
 	line_nb->set_valign(Label::VALIGN_CENTER);
 	line_nb->set_v_size_flags(SIZE_FILL);
 	line_nb->set_autowrap(true); // workaround to prevent resizing the label on each change, do not touch
@@ -1330,7 +1334,7 @@ CodeTextEditor::CodeTextEditor() {
 	line_nb->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
 
 	Label *col_txt = memnew(Label);
-	status_bar->add_child(col_txt);
+	warning_line->add_child(col_txt);
 	col_txt->set_align(Label::ALIGN_RIGHT);
 	col_txt->set_valign(Label::VALIGN_CENTER);
 	col_txt->set_v_size_flags(SIZE_FILL);
@@ -1338,7 +1342,7 @@ CodeTextEditor::CodeTextEditor() {
 	col_txt->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
 
 	col_nb = memnew(Label);
-	status_bar->add_child(col_nb);
+	warning_line->add_child(col_nb);
 	col_nb->set_valign(Label::VALIGN_CENTER);
 	col_nb->set_v_size_flags(SIZE_FILL);
 	col_nb->set_autowrap(true); // workaround to prevent resizing the label on each change, do not touch

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -141,7 +141,8 @@ class CodeTextEditor : public VBoxContainer {
 
 	TextEdit *text_editor;
 	FindReplaceBar *find_replace_bar;
-	HBoxContainer *status_bar;
+	VBoxContainer *status_bar;
+	HBoxContainer *warning_line;
 	Label *warning_label;
 	Label *warning_count_label;
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -1,3 +1,4 @@
+
 /*************************************************************************/
 /*  code_editor.h                                                        */
 /*************************************************************************/
@@ -141,13 +142,14 @@ class CodeTextEditor : public VBoxContainer {
 
 	TextEdit *text_editor;
 	FindReplaceBar *find_replace_bar;
-	VBoxContainer *status_bar;
+	GridContainer *status_bar;
 	HBoxContainer *warning_line;
-	Label *warning_label;
+	TextureRect *warning_icon;
 	Label *warning_count_label;
 
 	Label *line_nb;
 	Label *col_nb;
+	TextureRect *font_size_icon;
 	Label *font_size_nb;
 	Label *info;
 	Timer *idle;
@@ -168,6 +170,7 @@ class CodeTextEditor : public VBoxContainer {
 	void _font_resize_timeout();
 	bool _add_font_size(int p_delta);
 
+	void _status_bar_resized();
 	void _text_editor_gui_input(const Ref<InputEvent> &p_event);
 	void _zoom_in();
 	void _zoom_out();
@@ -220,7 +223,7 @@ public:
 	TextEdit *get_text_edit() { return text_editor; }
 	FindReplaceBar *get_find_replace_bar() { return find_replace_bar; }
 	Label *get_error_label() const { return error; }
-	Label *get_warning_label() const { return warning_label; }
+	TextureRect *get_warning_icon() const { return warning_icon; }
 	Label *get_warning_count_label() const { return warning_count_label; }
 	virtual void apply_code() {}
 	void goto_error();

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -242,6 +242,6 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	MAKE_SOURCE_FONT(df_output_code, int(EDITOR_DEF("run/output/font_size", 13)) * EDSCALE);
 	p_theme->set_font("output_source", "EditorFonts", df_output_code);
 
-	MAKE_SOURCE_FONT(df_text_editor_status_code, 14 * EDSCALE);
+	MAKE_SOURCE_FONT(df_text_editor_status_code, 11 * EDSCALE);
 	p_theme->set_font("status_source", "EditorFonts", df_text_editor_status_code);
 }

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1446,7 +1446,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	warnings_panel->hide();
 
 	code_editor->get_error_label()->connect("gui_input", this, "_error_pressed");
-	code_editor->get_warning_label()->connect("gui_input", this, "_toggle_warning_pannel");
+	code_editor->get_warning_icon()->connect("gui_input", this, "_toggle_warning_pannel");
 	code_editor->get_warning_count_label()->connect("gui_input", this, "_toggle_warning_pannel");
 	warnings_panel->connect("meta_clicked", this, "_warning_clicked");
 


### PR DESCRIPTION
Possible solution for #22302.

I changed status_bar to VBoxContainer and added a children HBoxContainer to contain warning line alone. The result was the following:

![captura de tela de 2019-01-02 13-04-17](https://user-images.githubusercontent.com/4605213/50603467-b4f52900-0ea1-11e9-829e-2e1b32ad27be.png)

The result is evidently better, but may not be the best solution, so feel free to reject if you think this way.