### PR TITLE
escaped '&' in macos osx_tools.app Info.plist

### DIFF
--- a/misc/dist/osx_tools.app/Contents/Info.plist
+++ b/misc/dist/osx_tools.app/Contents/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>Godot</string>
 	<key>CFBundleGetInfoString</key>
-	<string>(c) 2007-2019 Juan Linietsky, Ariel Manzur & Godot Engine contributors</string>
+	<string>(c) 2007-2019 Juan Linietsky, Ariel Manzur &amp; Godot Engine contributors</string>
 	<key>CFBundleIconFile</key>
 	<string>Godot.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -25,7 +25,7 @@
 	<key>CFBundleVersion</key>
 	<string>3.0</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>© 2007-2019 Juan Linietsky, Ariel Manzur & Godot Engine contributors</string>
+	<string>© 2007-2019 Juan Linietsky, Ariel Manzur &amp; Godot Engine contributors</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.9.0</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>


### PR DESCRIPTION
This fixes macOS failing to open the Godot application when Info.plist failed to parse.