### PR TITLE
Docs: Fix "equal to" and code markup in float.xml

### DIFF
--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="from" type="bool">
 			</argument>
 			<description>
-				Cast a [bool] value to a floating point value, [code]float(true)[/code] will be equals to 1.0 and [code]float(false)[/code] will be equals to 0.0.
+				Cast a [bool] value to a floating point value, [code]float(true)[/code] will be equal to 1.0 and [code]float(false)[/code] will be equal to 0.0.
 			</description>
 		</method>
 		<method name="float">
@@ -26,7 +26,7 @@
 			<argument index="0" name="from" type="int">
 			</argument>
 			<description>
-				Cast an [int] value to a floating point value, [code]float(1)[/code] will be equals to 1.0.
+				Cast an [int] value to a floating point value, [code]float(1)[/code] will be equal to 1.0.
 			</description>
 		</method>
 		<method name="float">
@@ -35,7 +35,7 @@
 			<argument index="0" name="from" type="String">
 			</argument>
 			<description>
-				Cast a [String] value to a floating point value. This method accepts float value strings like [code] '1.23' [/code] and exponential notation strings for its parameter so calling [code] float('1e3') [/code] will return 1000.0 and calling [code] float('1e-3') [/code] will return 0.001.
+				Cast a [String] value to a floating point value. This method accepts float value strings like [code]"1.23"[/code] and exponential notation strings for its parameter so calling [code]float("1e3")[/code] will return 1000.0 and calling [code]float("1e-3")[/code] will return 0.001.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Docs: Fix "be [equal to](https://www.thefreedictionary.com/equal%20to)" in float.xml. Attempt correction of code snippet markup.