### PR TITLE
Center script line when double clicked on error in debugger

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1217,6 +1217,11 @@ void CodeTextEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
 	text_editor->select(p_line, p_begin, p_line, p_end);
 }
 
+void CodeTextEditor::goto_line_centered(int p_line) {
+	goto_line(p_line);
+	text_editor->call_deferred("center_viewport_to_cursor");
+}
+
 void CodeTextEditor::set_executing_line(int p_line) {
 	text_editor->set_executing_line(p_line);
 }

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -219,6 +219,7 @@ public:
 
 	void goto_line(int p_line);
 	void goto_line_selection(int p_line, int p_begin, int p_end);
+	void goto_line_centered(int p_line);
 	void set_executing_line(int p_line);
 	void clear_executing_line();
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -306,8 +306,11 @@ void ScriptEditor::_goto_script_line(REF p_script, int p_line) {
 			editor->push_item(p_script.ptr());
 
 			ScriptEditorBase *current = _get_current_editor();
-			if (current)
+			if (ScriptTextEditor *script_text_editor = Object::cast_to<ScriptTextEditor>(current)) {
+				script_text_editor->goto_line_centered(p_line);
+			} else if (current) {
 				current->goto_line(p_line, true);
+			}
 		}
 	}
 }

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -487,6 +487,11 @@ void ScriptTextEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
 	code_editor->goto_line_selection(p_line, p_begin, p_end);
 }
 
+void ScriptTextEditor::goto_line_centered(int p_line) {
+
+	code_editor->goto_line_centered(p_line);
+}
+
 void ScriptTextEditor::set_executing_line(int p_line) {
 	code_editor->set_executing_line(p_line);
 }

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -201,6 +201,7 @@ public:
 
 	virtual void goto_line(int p_line, bool p_with_error = false);
 	void goto_line_selection(int p_line, int p_begin, int p_end);
+	void goto_line_centered(int p_line);
 	virtual void set_executing_line(int p_line);
 	virtual void clear_executing_line();
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6452,6 +6452,7 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_text"), &TextEdit::get_text);
 	ClassDB::bind_method(D_METHOD("get_line", "line"), &TextEdit::get_line);
 
+	ClassDB::bind_method(D_METHOD("center_viewport_to_cursor"), &TextEdit::center_viewport_to_cursor);
 	ClassDB::bind_method(D_METHOD("cursor_set_column", "column", "adjust_viewport"), &TextEdit::cursor_set_column, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("cursor_set_line", "line", "adjust_viewport", "can_be_hidden", "wrap_index"), &TextEdit::cursor_set_line, DEFVAL(true), DEFVAL(true), DEFVAL(0));
 


### PR DESCRIPTION
Fixes #24444

I think this is one of the simplest solution without duplicating code that I could find that wouldn't break anything.

There are some changes to be made if desired:
- The deferred call to `center_viewport_to_cursor` can be replaced by a normal function call inside `cursor_set_line`, but that would require an additional parameter with default value, so we could check if the viewport should be centered.
- We could also replace the ugly cast by passing true to `CodeTextEditor::goto_line` directly from the `ScriptTextEditor::goto_line`, but that would force every call to the latter to be centered, so I don't think that is a good idea unless it's desired.