### PR TITLE
Fix node naming after using AnimationTree in editor

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -124,6 +124,8 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 	List<StringName> nodes;
 	blend_tree->get_node_list(&nodes);
 
+	bool previous_hrcr = Node::get_human_readable_collision_renaming();
+	Node::set_human_readable_collision_renaming(false);
 	for (List<StringName>::Element *E = nodes.front(); E; E = E->next()) {
 
 		GraphNode *node = memnew(GraphNode);
@@ -132,9 +134,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 		Ref<AnimationNode> agnode = blend_tree->get_node(E->get());
 
 		node->set_offset(blend_tree->get_node_position(E->get()) * EDSCALE);
-
 		node->set_title(agnode->get_caption());
-		node->set_human_readable_collision_renaming(false);
 		node->set_name(E->get());
 
 		int base = 0;
@@ -250,6 +250,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			node->add_color_override("close_color", c);
 		}
 	}
+	Node::set_human_readable_collision_renaming(previous_hrcr);
 
 	List<AnimationNodeBlendTree::NodeConnection> connections;
 	blend_tree->get_node_connections(&connections);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -951,6 +951,11 @@ void Node::init_node_hrcr() {
 	node_hrcr_count.init(1);
 }
 
+bool Node::get_human_readable_collision_renaming() {
+
+	return node_hrcr;
+}
+
 void Node::set_human_readable_collision_renaming(bool p_enabled) {
 
 	node_hrcr = p_enabled;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -379,6 +379,7 @@ public:
 	void queue_delete();
 
 	//hacks for speed
+	static bool get_human_readable_collision_renaming();
 	static void set_human_readable_collision_renaming(bool p_enabled);
 	static void init_node_hrcr();
 


### PR DESCRIPTION
Fixes #24714 

The problem was that `set_human_readable_collision_renaming` is static and was not reset to its previous value.