### PR TITLE
Revert "Fix blend tree generating wrong node names"

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -134,7 +134,6 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 		node->set_offset(blend_tree->get_node_position(E->get()) * EDSCALE);
 
 		node->set_title(agnode->get_caption());
-		node->set_human_readable_collision_renaming(false);
 		node->set_name(E->get());
 
 		int base = 0;


### PR DESCRIPTION
Reverts godotengine/godot#24546.

This caused #24714 and @reduz says that it's not the proper way to fix this issue, he'll have a look at it.
Fixes #24714.