### PR TITLE
Fix font kerning

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -281,18 +281,6 @@ const Pair<const DynamicFontAtSize::Character *, DynamicFontAtSize *> DynamicFon
 	return Pair<const Character *, DynamicFontAtSize *>(chr, const_cast<DynamicFontAtSize *>(this));
 }
 
-float DynamicFontAtSize::_get_kerning_advance(const DynamicFontAtSize *font, CharType p_char, CharType p_next) const {
-	float advance = 0.0;
-
-	if (p_next) {
-		FT_Vector delta;
-		FT_Get_Kerning(font->face, p_char, p_next, FT_KERNING_DEFAULT, &delta);
-		advance = (delta.x / 64.0) / oversampling;
-	}
-
-	return advance;
-}
-
 Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks) const {
 
 	if (!valid)
@@ -301,7 +289,6 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 
 	Pair<const Character *, DynamicFontAtSize *> char_pair_with_font = _find_char_with_font(p_char, p_fallbacks);
 	const Character *ch = char_pair_with_font.first;
-	DynamicFontAtSize *font = char_pair_with_font.second;
 	ERR_FAIL_COND_V(!ch, Size2());
 
 	Size2 ret(0, get_height());
@@ -309,7 +296,6 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 	if (ch->found) {
 		ret.x = ch->advance;
 	}
-	ret.x += _get_kerning_advance(font, p_char, p_next);
 
 	return ret;
 }
@@ -357,8 +343,6 @@ float DynamicFontAtSize::draw_char(RID p_canvas_item, const Point2 &p_pos, CharT
 
 		advance = ch->advance;
 	}
-
-	advance += _get_kerning_advance(font, p_char, p_next);
 
 	return advance;
 }

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -164,7 +164,6 @@ class DynamicFontAtSize : public Reference {
 
 	const Pair<const Character *, DynamicFontAtSize *> _find_char_with_font(CharType p_char, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks) const;
 	Character _make_outline_char(CharType p_char);
-	float _get_kerning_advance(const DynamicFontAtSize *font, CharType p_char, CharType p_next) const;
 	TexturePosition _find_texture_pos_for_glyph(int p_color_size, Image::Format p_image_format, int p_width, int p_height);
 	Character _bitmap_to_character(FT_Bitmap bitmap, int yofs, int xofs, float advance);
 


### PR DESCRIPTION
https://github.com/godotengine/godot/blob/5e6c6f3bb745f8d9be4df938f6cf49dfb552b761/scene/resources/dynamic_font.cpp#L346-L349

`ch->h_align;` has a relative x position to draw current letter at where, like kerning advance.
tested various fonts those seems require kerning, including fonts in #21965 comments.

Before
![screenshot_20190105_092441](https://user-images.githubusercontent.com/8281454/50717615-ec471e00-10cb-11e9-988d-e72ecb2dacea.png)

After
![screenshot_20190105_092428](https://user-images.githubusercontent.com/8281454/50717616-eea97800-10cb-11e9-8674-557a1061d951.png)

Fix #21965 