### PR TITLE
[WIP] Update playing to false when sub state machine stops

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -485,6 +485,11 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *sm, 
 		rem = sm->blend_node(sm->end_node, sm->states[sm->end_node].node, 0, true, 0, AnimationNode::FILTER_IGNORE, false);
 	}
 
+	// When sub state machine stops, update playing to false
+	if (sm->parent != NULL && rem == 0) {
+		playing = false;
+	}
+
 	return rem;
 }
 


### PR DESCRIPTION
Sub state machine doesn't play after the end node already but if you call `is_playing` by code will always return true.

before:
![peek 05-01-2019 11-36](https://user-images.githubusercontent.com/1387165/50725013-30dbb500-10de-11e9-8530-a5f456d4c3d5.gif)
after:
![peek 05-01-2019 11-29](https://user-images.githubusercontent.com/1387165/50725002-0558ca80-10de-11e9-996f-1d4bfc58bbe0.gif)

- Note: root state machine is not affected by this, see:
![peek 05-01-2019 11-43](https://user-images.githubusercontent.com/1387165/50725082-4a313100-10df-11e9-88d0-a57fc277b11e.gif)
