### PR TITLE
Show play position of sub state machine

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -876,7 +876,7 @@ void AnimationNodeStateMachineEditor::_state_machine_pos_draw() {
 
 	float len = MAX(0.0001, playback->get_current_length());
 
-	float pos = CLAMP(playback->get_current_play_pos(), 0, len);
+	float pos = CLAMP(play_pos, 0, len);
 	float c = pos / len;
 	Color fg = get_color("font_color", "Label");
 	Color bg = fg;
@@ -1011,7 +1011,7 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 		bool is_playing = false;
 		StringName current_node;
 		StringName blend_from_node;
-		float play_pos = 0;
+		play_pos = 0;
 
 		if (playback.is_valid()) {
 			tp = playback->get_travel_path();
@@ -1044,6 +1044,25 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 			last_active = is_playing;
 			last_blend_from_node = blend_from_node;
 			state_machine_play_pos->update();
+		}
+
+		{
+			if (current_node != StringName() && state_machine->has_node(current_node)) {
+
+				String next = current_node;
+				Ref<AnimationNodeStateMachine> anodesm = state_machine->get_node(next);
+				Ref<AnimationNodeStateMachinePlayback> current_node_playback;
+
+				while (anodesm.is_valid()) {
+					current_node_playback = AnimationTreeEditor::get_singleton()->get_tree()->get(AnimationTreeEditor::get_singleton()->get_base_path() + next + "/playback");
+					next += "/" + current_node_playback->get_current_node();
+					anodesm = anodesm->get_node(current_node_playback->get_current_node());
+				}
+
+				// when current_node is a state machine, use playback of current_node to set play_pos
+				if (current_node_playback.is_valid())
+					play_pos = current_node_playback->get_current_play_pos();
+			}
 		}
 
 		if (last_play_pos != play_pos) {

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -160,6 +160,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	StringName last_current_node;
 	Vector<StringName> last_travel_path;
 	float last_play_pos;
+	float play_pos;
 
 	float error_time;
 	String error_text;


### PR DESCRIPTION
Sub state machine now show the play position of the current state playing. (this makes much more sense imo because now we have feedback of what's happening)

before:
![peek 05-01-2019 20-09](https://user-images.githubusercontent.com/1387165/50729717-c9495800-1125-11e9-887f-ddf3912c4ae1.gif)
after:
![peek 05-01-2019 20-14](https://user-images.githubusercontent.com/1387165/50729774-90f64980-1126-11e9-9b31-98905f659553.gif)

This is the sub state machine used in these example:
![captura de tela de 2019-01-05 20-14-27](https://user-images.githubusercontent.com/1387165/50729778-9e133880-1126-11e9-957b-6650b5a46a40.png)

