### PR TITLE
Fix code completion on nodes in current scene

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2444,7 +2444,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 	context.function = parser.get_completion_function();
 	context.line = parser.get_completion_line();
 
-	if (!context._class) {
+	if (!context._class || context._class->owner == NULL) {
 		context.base = p_owner;
 		context.base_path = p_base_path;
 	}


### PR DESCRIPTION
Followup for https://github.com/godotengine/godot/pull/24741

This fixes code completion on nodes in the current scene.

```
FooNode
|- FooNode2D
```

Script for `Node`:
```gdscript
extends Node

func _ready():
	$FooNode2D. # <- It didn't suggest Node2D methods/properties here (like global_position etc.)
```