### PR TITLE
Add process_mode property to Camera2D

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -61,6 +61,20 @@ void Camera2D::_update_scroll() {
 	};
 }
 
+void Camera2D::_update_process_mode() {
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		set_process_internal(false);
+		set_physics_process_internal(false);
+	} else if (process_mode == CAMERA2D_PROCESS_IDLE) {
+		set_process_internal(true);
+		set_physics_process_internal(false);
+	} else {
+		set_process_internal(false);
+		set_physics_process_internal(true);
+	}
+}
+
 void Camera2D::set_zoom(const Vector2 &p_zoom) {
 
 	zoom = p_zoom;
@@ -143,7 +157,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 		if (smoothing_enabled && !Engine::get_singleton()->is_editor_hint()) {
 
-			float c = smoothing * get_process_delta_time();
+			float c = smoothing * (process_mode == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time());
 			smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
 			ret_camera_pos = smoothed_camera_pos;
 			//camera_pos=camera_pos*(1.0-smoothing)+new_camera_pos*smoothing;
@@ -217,14 +231,15 @@ void Camera2D::_notification(int p_what) {
 
 	switch (p_what) {
 
-		case NOTIFICATION_INTERNAL_PROCESS: {
+		case NOTIFICATION_INTERNAL_PROCESS:
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 
 			_update_scroll();
 
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 
-			if (!is_processing_internal())
+			if (!is_processing_internal() && !is_physics_processing_internal())
 				_update_scroll();
 
 		} break;
@@ -245,10 +260,7 @@ void Camera2D::_notification(int p_what) {
 			add_to_group(group_name);
 			add_to_group(canvas_group_name);
 
-			if (Engine::get_singleton()->is_editor_hint()) {
-				set_process_internal(false);
-			}
-
+			_update_process_mode();
 			_update_scroll();
 			first = true;
 
@@ -377,6 +389,20 @@ void Camera2D::set_rotating(bool p_rotating) {
 bool Camera2D::is_rotating() const {
 
 	return rotating;
+}
+
+void Camera2D::set_process_mode(Camera2DProcessMode p_mode) {
+
+	if (process_mode == p_mode)
+		return;
+
+	process_mode = p_mode;
+	_update_process_mode();
+}
+
+Camera2D::Camera2DProcessMode Camera2D::get_process_mode() const {
+
+	return process_mode;
 }
 
 void Camera2D::_make_current(Object *p_which) {
@@ -657,6 +683,9 @@ void Camera2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_update_scroll"), &Camera2D::_update_scroll);
 
+	ClassDB::bind_method(D_METHOD("set_process_mode", "mode"), &Camera2D::set_process_mode);
+	ClassDB::bind_method(D_METHOD("get_process_mode"), &Camera2D::get_process_mode);
+
 	ClassDB::bind_method(D_METHOD("_set_current", "current"), &Camera2D::_set_current);
 	ClassDB::bind_method(D_METHOD("is_current"), &Camera2D::is_current);
 
@@ -717,6 +746,7 @@ void Camera2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "current"), "_set_current", "is_current");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "zoom"), "set_zoom", "get_zoom");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "custom_viewport", PROPERTY_HINT_RESOURCE_TYPE, "Viewport", 0), "set_custom_viewport", "get_custom_viewport");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Physics,Idle"), "set_process_mode", "get_process_mode");
 
 	ADD_GROUP("Limit", "limit_");
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "limit_left"), "set_limit", "get_limit", MARGIN_LEFT);
@@ -750,6 +780,8 @@ void Camera2D::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(ANCHOR_MODE_FIXED_TOP_LEFT);
 	BIND_ENUM_CONSTANT(ANCHOR_MODE_DRAG_CENTER);
+	BIND_ENUM_CONSTANT(CAMERA2D_PROCESS_PHYSICS);
+	BIND_ENUM_CONSTANT(CAMERA2D_PROCESS_IDLE);
 }
 
 Camera2D::Camera2D() {
@@ -772,6 +804,7 @@ Camera2D::Camera2D() {
 	limit_smoothing_enabled = false;
 	custom_viewport = NULL;
 	custom_viewport_id = 0;
+	process_mode = CAMERA2D_PROCESS_IDLE;
 
 	smoothing = 5.0;
 	zoom = Vector2(1, 1);

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -44,6 +44,11 @@ public:
 		ANCHOR_MODE_DRAG_CENTER
 	};
 
+	enum Camera2DProcessMode {
+		CAMERA2D_PROCESS_PHYSICS,
+		CAMERA2D_PROCESS_IDLE
+	};
+
 protected:
 	Point2 camera_pos;
 	Point2 smoothed_camera_pos;
@@ -73,6 +78,7 @@ protected:
 	float v_ofs;
 
 	Point2 camera_screen_center;
+	void _update_process_mode();
 	void _update_scroll();
 
 	void _make_current(Object *p_which);
@@ -83,6 +89,8 @@ protected:
 	bool screen_drawing_enabled;
 	bool limit_drawing_enabled;
 	bool margin_drawing_enabled;
+
+	Camera2DProcessMode process_mode;
 
 protected:
 	virtual Transform2D get_camera_transform();
@@ -126,6 +134,9 @@ public:
 	void set_follow_smoothing(float p_speed);
 	float get_follow_smoothing() const;
 
+	void set_process_mode(Camera2DProcessMode p_mode);
+	Camera2DProcessMode get_process_mode() const;
+
 	void make_current();
 	void clear_current();
 	bool is_current() const;
@@ -156,5 +167,6 @@ public:
 };
 
 VARIANT_ENUM_CAST(Camera2D::AnchorMode);
+VARIANT_ENUM_CAST(Camera2D::Camera2DProcessMode);
 
 #endif // CAMERA_2D_H


### PR DESCRIPTION
This allows the user to choose if the camera should update in _process or _physics_process.

Closes #24594
Maybe related: #6373