### PR TITLE
In EditorInspector make use_doc_hints true by default

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2421,6 +2421,7 @@ void EditorPropertyResource::update_property() {
 			if (!sub_inspector) {
 				sub_inspector = memnew(EditorInspector);
 				sub_inspector->set_enable_v_scroll(false);
+				sub_inspector->set_use_doc_hints(true);
 
 				sub_inspector->set_use_sub_inspector_bg(true);
 				sub_inspector->set_enable_capitalize_paths(true);


### PR DESCRIPTION
When looking at a resource that was not the  main resource in the inspector, the tooltips would not display correctly, they would just print the name with nothing from the docs. However, when that resource was opened up as the primary resource in the inspector the tooltips displayed fine. 

Setting ``use_doc_hints`` to true by default in editor_inspector solves this problem. It makes sense to have it true by default as there are likely few situations where it should be turned off in the first place. 

_Bugsquad edit:_ Fixes #24784 