### PR TITLE
Make tooltips display for nested resources

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2421,6 +2421,7 @@ void EditorPropertyResource::update_property() {
 			if (!sub_inspector) {
 				sub_inspector = memnew(EditorInspector);
 				sub_inspector->set_enable_v_scroll(false);
+				sub_inspector->set_use_doc_hints(true);
 
 				sub_inspector->set_use_sub_inspector_bg(true);
 				sub_inspector->set_enable_capitalize_paths(true);


### PR DESCRIPTION
Replaces #24815. Fixes #24784 without setting ``use_doc_hints`` to true by default.

I made a different PR so the commit history makes more sense.
@akien-mga Thanks for the advice on the previous PR!