### PR TITLE
Fix strip out spaces while generating serial number for node name

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1070,7 +1070,7 @@ String Node::_generate_serial_child_name(Node *p_child) {
 
 	// Assign the base name + separator to name if we have numbers preceded by a separator
 	if (nums.length() > 0 && name.substr(name_last_index, nnsep.length()) == nnsep) {
-		name = name.substr(0, name_last_index + nnsep.length()).strip_edges();
+		name = name.substr(0, name_last_index + nnsep.length());
 	} else {
 		nums = "";
 	}


### PR DESCRIPTION
Fix #24088, fix #24473

This causes "Animation 2" becomes "Animation2" which is not desired.
Also "Node 1" becomes "Node1" on scene dock in editor.