### PR TITLE
Fix crash in visual shader preview when SCREEN_TEXTURE being show up

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1160,7 +1160,11 @@ void RasterizerCanvasGLES3::_copy_texscreen(const Rect2 &p_rect) {
 		storage->shaders.copy.set_conditional(CopyShaderGLES3::USE_COPY_SECTION, true);
 	}
 
-	glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo);
+	if (storage->frame.current_rt->effects.mip_maps[0].sizes.size() > 0) {
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo);
+	} else {
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	}
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->color);
 


### PR DESCRIPTION
My attempt to fix #24749, read pre-last comment of that issue for details

after this change preview will shows in visual script correctly

![image](https://user-images.githubusercontent.com/3036176/50848281-e29c0f80-1384-11e9-81df-6bc46421cc59.png)

before it will crash..




