### PR TITLE
Don't use -ffast-math or other unsafe math optimizations

### DIFF
--- a/modules/etc/SCsub
+++ b/modules/etc/SCsub
@@ -33,11 +33,6 @@ env_etc.Append(CPPPATH=[thirdparty_dir])
 if not env.msvc:
 	env_etc.Append(CCFLAGS="-std=c++11")
 
-# -ffast-math seems to be incompatible with etc2comp on recent versions of
-# GCC and Clang
-if '-ffast-math' in env_etc['CCFLAGS']:
-	env_etc['CCFLAGS'].remove('-ffast-math')
-
 env_thirdparty = env_etc.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -141,7 +141,7 @@ def configure(env):
     if (env["target"].startswith("release")):
         if (env["optimize"] == "speed"): #optimize for speed (default)
             env.Append(LINKFLAGS=['-O2'])
-            env.Append(CPPFLAGS=['-O2', '-DNDEBUG', '-ffast-math', '-funsafe-math-optimizations', '-fomit-frame-pointer'])
+            env.Append(CPPFLAGS=['-O2', '-DNDEBUG', '-fomit-frame-pointer'])
         else: #optimize for size
             env.Append(CPPFLAGS=['-Os', '-DNDEBUG'])
             env.Append(LINKFLAGS=['-Os'])

--- a/platform/haiku/detect.py
+++ b/platform/haiku/detect.py
@@ -37,14 +37,14 @@ def configure(env):
     ## Build type
 
     if (env["target"] == "release"):
-        env.Prepend(CCFLAGS=['-O3', '-ffast-math'])
+        env.Prepend(CCFLAGS=['-O3'])
         if (env["debug_symbols"] == "yes"):
             env.Prepend(CCFLAGS=['-g1'])
         if (env["debug_symbols"] == "full"):
             env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "release_debug"):
-        env.Prepend(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
+        env.Prepend(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
         if (env["debug_symbols"] == "yes"):
             env.Prepend(CCFLAGS=['-g1'])
         if (env["debug_symbols"] == "full"):

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -46,7 +46,7 @@ def configure(env):
     if (env["target"].startswith("release")):
         env.Append(CPPFLAGS=['-DNDEBUG', '-DNS_BLOCK_ASSERTIONS=1'])
         if (env["optimize"] == "speed"): #optimize for speed (default)
-            env.Append(CPPFLAGS=['-O2', '-ftree-vectorize', '-fomit-frame-pointer', '-ffast-math', '-funsafe-math-optimizations'])
+            env.Append(CPPFLAGS=['-O2', '-ftree-vectorize', '-fomit-frame-pointer'])
             env.Append(LINKFLAGS=['-O2'])
         else: #optimize for size
             env.Append(CPPFLAGS=['-Os', '-ftree-vectorize'])

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -42,7 +42,7 @@ def configure(env):
 
     if (env["target"] == "release"):
         if (env["optimize"] == "speed"): #optimize for speed (default)
-            env.Prepend(CCFLAGS=['-O3', '-ffast-math', '-fomit-frame-pointer', '-ftree-vectorize', '-msse2'])
+            env.Prepend(CCFLAGS=['-O3', '-fomit-frame-pointer', '-ftree-vectorize', '-msse2'])
         else: #optimize for size
             env.Prepend(CCFLAGS=['-Os','-ftree-vectorize', '-msse2'])
 

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -43,10 +43,10 @@ def configure(env):
     ## Build type
 
     if (env["target"] == "release"):
-        env.Append(CCFLAGS=['-O2', '-ffast-math', '-fomit-frame-pointer'])
+        env.Append(CCFLAGS=['-O2', '-fomit-frame-pointer'])
 
     elif (env["target"] == "release_debug"):
-        env.Append(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
+        env.Append(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
 
     elif (env["target"] == "debug"):
         env.Append(CCFLAGS=['-g2', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -86,10 +86,8 @@ def configure(env):
     ## Build type
 
     if (env["target"] == "release"):
-        # -O3 -ffast-math is identical to -Ofast. We need to split it out so we can selectively disable
-        # -ffast-math in code for which it generates wrong results.
         if (env["optimize"] == "speed"): #optimize for speed (default)
-            env.Prepend(CCFLAGS=['-O3', '-ffast-math'])
+            env.Prepend(CCFLAGS=['-O3'])
         else: #optimize for size
             env.Prepend(CCFLAGS=['-Os'])
 
@@ -100,7 +98,7 @@ def configure(env):
 
     elif (env["target"] == "release_debug"):
         if (env["optimize"] == "speed"): #optimize for speed (default)
-            env.Prepend(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
+            env.Prepend(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
         else: #optimize for size
             env.Prepend(CCFLAGS=['-Os', '-DDEBUG_ENABLED'])
 


### PR DESCRIPTION
Godot supports many different compilers and for production releases we
have to support 3 currently: GCC8, Clang6, and MSVC2017. These compilers
all do slightly different things with -ffast-math and it is causing
issues now. See #24841, #24540, #10758, #10070. And probably other
complaints about physics differences between release and release_debug
builds.

I've done some performance comparisons on Linux x86_64. All tests are
ran 20 times. And bunnymark really was 2% faster, that was not a copy/paste error :)

```
Bunnymark: (higher is better)
(bunnies)    min    max  stdev average
fast-math   7332   7597    71     7432
this pr        7379   7779   108     7621 (102%)

FPBench (gdscript port http://fpbench.org/) (lower is better)
(ms)
fast-math  15441  16127   192    15764
this pr       15671  16855   326    16001  (99%)

Float_add (adding floats in a tight loop) (lower is better)
(sec)
fast-math   5.49   5.78  0.07     5.65
this pr        5.65   5.90  0.06     5.76  (98%)

Float_div (dividing floats in a tight loop) (lower is better)
(sec)
fast-math  11.70  12.36  0.18    11.99
this pr       11.92  12.32  0.12    12.12  (99%)

Float_mul (multiplying floats in a tight loop) (lower is better)
(sec)
fast-math  11.72  12.17  0.12    11.93
this pr       12.01  12.62  0.17    12.26  (97%)
```
I have also looked at FPS numbers for tps-demo, 3d platformer, 2d
platformer, and sponza and could not find any measurable difference.

I believe that given the issues and oft-reported (physics) glitches on
release builds I believe that the couple of percent of tight-loop
floating point performance regression is well worth it.

This fixes #24540 and fixes #24841