### PR TITLE
Fix "Whole Words" and "Match Cases" checkbox behavior in "Find in Files"

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2800,7 +2800,7 @@ void ScriptEditor::_start_find_in_files(bool with_replace) {
 
 	f->set_search_text(find_in_files_dialog->get_search_text());
 	f->set_match_case(find_in_files_dialog->is_match_case());
-	f->set_whole_words(find_in_files_dialog->is_match_case());
+	f->set_whole_words(find_in_files_dialog->is_whole_words());
 	f->set_folder(find_in_files_dialog->get_folder());
 	f->set_filter(find_in_files_dialog->get_filter());
 


### PR DESCRIPTION
Match case check box was used for whole words as well as match case.

_bugsquad edit_ : Fix #24810