### PR TITLE
AnimationNodeTransition name begins from 0

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -835,12 +835,11 @@ AnimationNodeTransition::AnimationNodeTransition() {
 	time = "time";
 	current = "current";
 	prev_current = "prev_current";
-	;
 
 	enabled_inputs = 0;
 	for (int i = 0; i < MAX_INPUTS; i++) {
 		inputs[i].auto_advance = false;
-		inputs[i].name = itos(i + 1);
+		inputs[i].name = "state " + itos(i);
 	}
 }
 


### PR DESCRIPTION
and added "state" string for default name not to confuse it as number

fix #22550

![screenshot_20190109_144329](https://user-images.githubusercontent.com/8281454/50879228-8933ef00-141d-11e9-981d-6a74feb1b1fd.png)
