### PR TITLE
Warn on case mismatch on Unix systems

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -41,6 +41,11 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#if defined(TOOLS_ENABLED)
+#include <limits.h>
+#include <stdlib.h>
+#endif
+
 void FileAccessUnix::check_errors() const {
 	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
 
@@ -86,6 +91,22 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 				return ERR_FILE_CANT_OPEN;
 		}
 	}
+
+#if defined(TOOLS_ENABLED)
+	if (p_mode_flags & READ) {
+		String real_path = get_real_path();
+		if (real_path != path) {
+			// Don't warn on symlinks, since they can be used to simply share addons on multiple projects
+			if (real_path.to_lower() == path.to_lower()) {
+				// The File system is case insensitive, but other platforms can be sensitive to it
+				// To ease cross-platform development, we issue a warning if users try to access
+				// a file using the wrong case (which *works* on Windows and macOS, but won't on other
+				// platforms).
+				WARN_PRINT("Case mismatch opening requested file '" + path + "', stored as '" + real_path + "' in the filesystem. This file will not open when exported to other case-sensitive platforms.");
+			}
+		}
+	}
+#endif
 
 	if (is_backup_save_enabled() && (p_mode_flags == WRITE)) {
 		save_path = path;
@@ -172,6 +193,26 @@ String FileAccessUnix::get_path() const {
 String FileAccessUnix::get_path_absolute() const {
 	return path;
 }
+
+#if defined(TOOLS_ENABLED)
+String FileAccessUnix::get_real_path() const {
+	char *resolved_path = ::realpath(path.utf8().get_data(), nullptr);
+
+	if (!resolved_path) {
+		return path;
+	}
+
+	String result;
+	Error parse_ok = result.parse_utf8(resolved_path);
+	::free(resolved_path);
+
+	if (parse_ok != OK) {
+		return path;
+	}
+
+	return result.simplify_path();
+}
+#endif
 
 void FileAccessUnix::seek(uint64_t p_position) {
 	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -51,6 +51,10 @@ class FileAccessUnix : public FileAccess {
 
 	void _close();
 
+#if defined(TOOLS_ENABLED)
+	String get_real_path() const; /// returns the resolved real path for the current open file
+#endif
+
 public:
 	static CloseNotificationFunc close_notification_func;
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -119,7 +119,7 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 	}
 
 #ifdef TOOLS_ENABLED
-	// Windows is case insensitive, but all other platforms are sensitive to it
+	// Windows is case insensitive, but other platforms can be sensitive to it
 	// To ease cross-platform development, we issue a warning if users try to access
 	// a file using the wrong case (which *works* on Windows, but won't on other
 	// platforms), we only check for relative paths, or paths in res:// or user://,


### PR DESCRIPTION
# Purpose

This pull request aims to fix #23441 (display a warning when using a file with the wrong case).

# Exemples

```gdscript
# Foo.gd

extends Node
```
```gdscript
# res://Bar.gd

extends 'foo.gd'
```

This shows this warning :

```
Case mismatch opening requested file '/Users/valentin/Dev/Projects/Godot/Tests/foo.gd', stored as '/Users/valentin/Dev/Projects/Godot/Tests/Foo.gd' in the filesystem. This file will not open when exported to other case-sensitive platforms.
```

# Caveats

Since I'm using POSIX `realpath` function, this warning will also be displayed if there is a symlink somewhere in the path. This is due to `real_path` resolving all symlinks to find a real path on the disk.

Exemple:

```gdscript
# linked/Foo.gd

extends Node
```

```gdscript
# Bar.gd

extends linked/Foo.gd
```

Here, given that `linked` folder is a symlink, we will get this warning :

```
Case mismatch opening requested file '/Users/valentin/Dev/Projects/Godot/Tests/linked/Foo.gd', stored as '/Users/valentin/Dev/Projects/Godot/Tests/somewhere_else/Foo.gd' in the filesystem. This file will not open when exported to other case-sensitive platforms.
```

I haven't found any way to avoid this problem... So if anyone have an idea...