### PR TITLE
Whitelist Android platform for EGL debugging

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -66,8 +66,8 @@
 #endif
 #endif
 
-#if !defined(GLES_OVER_GL) && !defined(IPHONE_ENABLED)
-// Used for debugging on mobile, but not iOS as EGL is not available
+#ifdef ANDROID_ENABLED
+// Used for debugging on mobile (Android); on iOS, EGL is not available
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include <GLES2/gl2platform.h>
@@ -80,7 +80,7 @@
 #define strcpy strcpy_s
 #endif
 
-#ifndef IPHONE_ENABLED
+#if defined(GLES_OVER_GL) || defined(ANDROID_ENABLED)
 static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
 
 	if (type == _EXT_DEBUG_TYPE_OTHER_ARB)
@@ -128,7 +128,7 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 
 	ERR_PRINTS(output);
 }
-#endif // IPHONE_ENABLED
+#endif // GLES_OVER_GL || ANDROID_ENABLED
 
 typedef void (*DEBUGPROCARB)(GLenum source,
 		GLenum type,
@@ -237,7 +237,7 @@ void RasterizerGLES2::initialize() {
 		*/
 	}
 #else
-#ifndef IPHONE_ENABLED
+#ifdef ANDROID_ENABLED
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		DebugMessageCallbackARB callback = (DebugMessageCallbackARB)eglGetProcAddress("glDebugMessageCallback");
 		if (!callback) {
@@ -252,7 +252,7 @@ void RasterizerGLES2::initialize() {
 			glEnable(_EXT_DEBUG_OUTPUT);
 		}
 	}
-#endif // !IPHONE_ENABLED
+#endif // ANDROID_ENABLED
 #endif // GLES_OVER_GL
 
 	const GLubyte *renderer = glGetString(GL_RENDERER);


### PR DESCRIPTION
Not sure if you would consider this, but I'll give it a try.

I am having a problem compiling a custom platform (FRT, a platform targeting single board computers like the Raspberry Pi) that uses OpenGL ES (i.e. no GLES_OVER_GL).

The EGL debug code in the GLES2 driver blacklists iPhone. My (unknown to the codebase) platform is not being blacklisted, and so the EGL debug code is included. Since my platform uses a custom loader for EGL, the GLES2 driver using EGL directly causes problems. 

Given the comment to the original commit, it looks like the intent was to add some debugging code to the mobile platform. If this is the case, what about whitelisting Android instead of blacklisting iPhone? Or does the EGL debug code also work on other platforms like UWP or WebGL?