### PR TITLE
Remove vsgdnative loader on exit

### DIFF
--- a/modules/gdnative/videodecoder/register_types.cpp
+++ b/modules/gdnative/videodecoder/register_types.cpp
@@ -33,18 +33,18 @@
 #include "core/class_db.h"
 #include "video_stream_gdnative.h"
 
-static ResourceFormatLoaderVideoStreamGDNative *resource_loader_vsgdnative = NULL;
+static Ref<ResourceFormatLoaderVideoStreamGDNative> resource_loader_vsgdnative;
 
 void register_videodecoder_types() {
 
-	resource_loader_vsgdnative = memnew(ResourceFormatLoaderVideoStreamGDNative);
+	resource_loader_vsgdnative.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_vsgdnative, true);
+
 	ClassDB::register_class<VideoStreamGDNative>();
 }
 
 void unregister_videodecoder_types() {
 
-	if (resource_loader_vsgdnative) {
-		memdelete(resource_loader_vsgdnative);
-	}
+	ResourceLoader::remove_resource_format_loader(resource_loader_vsgdnative);
+	resource_loader_vsgdnative.unref();
 }


### PR DESCRIPTION
A lack of the remove_resource_format_loader call has caused a crash on exit due a rw_lock->write_lock call in ObjectDB::remove_instance after ObjectDB::cleanup has been called (and freed rw_lock).