### PR TITLE
Consistency in resource format saver/loader de-registration

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -68,8 +68,8 @@
 static Ref<ResourceFormatSaverBinary> resource_saver_binary;
 static Ref<ResourceFormatLoaderBinary> resource_loader_binary;
 static Ref<ResourceFormatImporter> resource_format_importer;
-
 static Ref<ResourceFormatLoaderImage> resource_format_image;
+static Ref<TranslationLoaderPO> resource_format_po;
 
 static _ResourceLoader *_resource_loader = NULL;
 static _ResourceSaver *_resource_saver = NULL;
@@ -77,7 +77,6 @@ static _OS *_os = NULL;
 static _Engine *_engine = NULL;
 static _ClassDB *_classdb = NULL;
 static _Marshalls *_marshalls = NULL;
-static Ref<TranslationLoaderPO> resource_format_po;
 static _JSON *_json = NULL;
 
 static IP *ip = NULL;
@@ -251,25 +250,17 @@ void unregister_core_types() {
 
 	memdelete(_geometry);
 
-	if (resource_format_image.is_valid()) {
-		ResourceLoader::remove_resource_format_loader(resource_format_image);
-		resource_format_image.unref();
-	}
+	ResourceLoader::remove_resource_format_loader(resource_format_image);
+	resource_format_image.unref();
 
-	if (resource_saver_binary.is_valid()) {
-		ResourceSaver::remove_resource_format_saver(resource_saver_binary);
-		resource_saver_binary.unref();
-	}
+	ResourceSaver::remove_resource_format_saver(resource_saver_binary);
+	resource_saver_binary.unref();
 
-	if (resource_loader_binary.is_valid()) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_binary);
-		resource_loader_binary.unref();
-	}
+	ResourceLoader::remove_resource_format_loader(resource_loader_binary);
+	resource_loader_binary.unref();
 
-	if (resource_format_importer.is_valid()) {
-		ResourceLoader::remove_resource_format_loader(resource_format_importer);
-		resource_format_importer.unref();
-	}
+	ResourceLoader::remove_resource_format_loader(resource_format_importer);
+	resource_format_importer.unref();
 
 	ResourceLoader::remove_resource_format_loader(resource_format_po);
 	resource_format_po.unref();

--- a/drivers/register_driver_types.cpp
+++ b/drivers/register_driver_types.cpp
@@ -59,10 +59,8 @@ void unregister_core_driver_types() {
 	if (image_loader_png)
 		memdelete(image_loader_png);
 
-	if (resource_saver_png.is_valid()) {
-		ResourceSaver::remove_resource_format_saver(resource_saver_png);
-		resource_saver_png.unref();
-	}
+	ResourceSaver::remove_resource_format_saver(resource_saver_png);
+	resource_saver_png.unref();
 }
 
 void register_driver_types() {

--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -314,9 +314,9 @@ void register_gdnative_types() {
 	ClassDB::register_class<GDNative>();
 
 	resource_loader_gdnlib.instance();
-	resource_saver_gdnlib.instance();
-
 	ResourceLoader::add_resource_format_loader(resource_loader_gdnlib);
+
+	resource_saver_gdnlib.instance();
 	ResourceSaver::add_resource_format_saver(resource_saver_gdnlib);
 
 	GDNativeCallRegistry::singleton = memnew(GDNativeCallRegistry);
@@ -395,9 +395,9 @@ void unregister_gdnative_types() {
 #endif
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_gdnlib);
-	ResourceSaver::remove_resource_format_saver(resource_saver_gdnlib);
-
 	resource_loader_gdnlib.unref();
+
+	ResourceSaver::remove_resource_format_saver(resource_saver_gdnlib);
 	resource_saver_gdnlib.unref();
 
 	// This is for printing out the sizes of the core types

--- a/modules/gdnative/videodecoder/video_stream_gdnative.h
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.h
@@ -197,6 +197,7 @@ public:
 };
 
 class ResourceFormatLoaderVideoStreamGDNative : public ResourceFormatLoader {
+	GDCLASS(ResourceFormatLoaderVideoStreamGDNative, ResourceFormatLoader)
 public:
 	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = NULL);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -161,13 +161,9 @@ void unregister_gdscript_types() {
 	if (script_language_gd)
 		memdelete(script_language_gd);
 
-	if (resource_loader_gd.is_valid()) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_gd);
-		resource_loader_gd.unref();
-	}
+	ResourceLoader::remove_resource_format_loader(resource_loader_gd);
+	resource_loader_gd.unref();
 
-	if (resource_saver_gd.is_valid()) {
-		ResourceSaver::remove_resource_format_saver(resource_saver_gd);
-		resource_saver_gd.unref();
-	}
+	ResourceSaver::remove_resource_format_saver(resource_saver_gd);
+	resource_saver_gd.unref();
 }

--- a/modules/mono/register_types.cpp
+++ b/modules/mono/register_types.cpp
@@ -65,15 +65,11 @@ void unregister_mono_types() {
 	if (script_language_cs)
 		memdelete(script_language_cs);
 
-	if (resource_loader_cs.is_valid()) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_cs);
-		resource_loader_cs.unref();
-	}
+	ResourceLoader::remove_resource_format_loader(resource_loader_cs);
+	resource_loader_cs.unref();
 
-	if (resource_saver_cs.is_valid()) {
-		ResourceSaver::remove_resource_format_saver(resource_saver_cs);
-		resource_saver_cs.unref();
-	}
+	ResourceSaver::remove_resource_format_saver(resource_saver_cs);
+	resource_saver_cs.unref();
 
 	if (_godotsharp)
 		memdelete(_godotsharp);

--- a/modules/theora/register_types.cpp
+++ b/modules/theora/register_types.cpp
@@ -45,8 +45,5 @@ void register_theora_types() {
 void unregister_theora_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_theora);
-
-	if (resource_loader_theora.is_valid()) {
-		resource_loader_theora.unref();
-	}
+	resource_loader_theora.unref();
 }

--- a/modules/webm/register_types.cpp
+++ b/modules/webm/register_types.cpp
@@ -45,8 +45,5 @@ void register_webm_types() {
 void unregister_webm_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_webm);
-
-	if (resource_loader_webm.is_valid()) {
-		resource_loader_webm.unref();
-	}
+	resource_loader_webm.unref();
 }

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -746,27 +746,20 @@ void unregister_scene_types() {
 
 	DynamicFont::finish_dynamic_fonts();
 
-	if (resource_saver_text.is_valid()) {
-		ResourceSaver::remove_resource_format_saver(resource_saver_text);
-		resource_saver_text.unref();
-	}
-	if (resource_loader_text.is_valid()) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_text);
-		resource_loader_text.unref();
-	}
+	ResourceSaver::remove_resource_format_saver(resource_saver_text);
+	resource_saver_text.unref();
 
-	if (resource_saver_shader.is_valid()) {
-		ResourceSaver::remove_resource_format_saver(resource_saver_shader);
-		resource_saver_shader.unref();
-	}
-	if (resource_loader_shader.is_valid()) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_shader);
-		resource_loader_shader.unref();
-	}
-	if (resource_loader_bmfont.is_valid()) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_bmfont);
-		resource_loader_bmfont.unref();
-	}
+	ResourceLoader::remove_resource_format_loader(resource_loader_text);
+	resource_loader_text.unref();
+
+	ResourceSaver::remove_resource_format_saver(resource_saver_shader);
+	resource_saver_shader.unref();
+
+	ResourceLoader::remove_resource_format_loader(resource_loader_shader);
+	resource_loader_shader.unref();
+
+	ResourceLoader::remove_resource_format_loader(resource_loader_bmfont);
+	resource_loader_bmfont.unref();
 
 	SpatialMaterial::finish_shaders();
 	ParticlesMaterial::finish_shaders();


### PR DESCRIPTION
Some used 'is_valid()' checks, others not. Validity is already checked in 'unref()',
and 'remove_resource_format_*()' has an ERR_FAIL condition on 'is_null()' already
(which shouldn't happen since we're only unregistering things that we previously
registered.

Also add missing GDCLASS statement in ResourceFormatLoaderVideoStreamGDNative,
missed in #20552 which was last amended before #19501 was merged.

CC @Zylann 

Follow-up to #24878.