### PR TITLE
Fix broken encrypted scripts during export

### DIFF
--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -79,7 +79,7 @@ public:
 
 			if (script_mode == EditorExportPreset::MODE_SCRIPT_ENCRYPTED) {
 
-				String tmp_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp/script.gde");
+				String tmp_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("script.gde");
 				FileAccess *fa = FileAccess::open(tmp_path, FileAccess::WRITE);
 
 				Vector<uint8_t> key;


### PR DESCRIPTION
Use temporary cache directory instead of editor settings directory in order to resolve encrypted file access needed for encrypting scripts on all platforms.

Should fix #24881 but needs testing on Linux/MacOS, @bruvzg @DrMoriarty

Also should note that with #17721 might allow to avoid encrypted file access for exporting scripts in the future and be more efficient I suppose.