### PR TITLE
Changed WaitTime visual script node to use input port instead property

### DIFF
--- a/modules/visual_script/visual_script_yield_nodes.h
+++ b/modules/visual_script/visual_script_yield_nodes.h
@@ -47,11 +47,8 @@ public:
 
 private:
 	YieldMode yield_mode;
-	float wait_time;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const;
-
 	static void _bind_methods();
 
 public:
@@ -72,9 +69,6 @@ public:
 
 	void set_yield_mode(YieldMode p_mode);
 	YieldMode get_yield_mode();
-
-	void set_wait_time(float p_time);
-	float get_wait_time();
 
 	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
 


### PR DESCRIPTION
This PR gives user possibility to set up wait time directly through visual script system, I think its more obvious way to do it (rather than using set_wait_time property).

Before

![image](https://user-images.githubusercontent.com/3036176/50994944-a6a4ae00-152e-11e9-8021-22ad848dc2b5.png)

After

![image](https://user-images.githubusercontent.com/3036176/50994870-73fab580-152e-11e9-868f-fff310ad560d.png)

Of course it may break user's scripts, so push it to 4.0(if 3.2 is not enough)...