### PR TITLE
fixed invalid implementation of Plane::intersects_segment and Plane::intersects_ray

### DIFF
--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -115,15 +115,14 @@ bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 
 		return false;
 	}
 
-	real_t dist = (normal.dot(p_from) - d) / den;
+	real_t dist = (-normal.dot(p_from) - d) / den;
 	//printf("dist is %i\n",dist);
 
-	if (dist > CMP_EPSILON) { //this is a ray, before the emitting pos (p_from) doesn't exist
+	if (dist < -CMP_EPSILON) { //this is a ray, before the emitting pos (p_from) doesn't exist
 
 		return false;
 	}
 
-	dist = -dist;
 	*p_intersection = p_from + segment * dist;
 
 	return true;
@@ -140,7 +139,7 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 		return false;
 	}
 
-	real_t dist = (normal.dot(p_begin) - d) / den;
+	real_t dist = (-normal.dot(p_begin) - d) / den;
 	//printf("dist is %i\n",dist);
 
 	if (dist < -CMP_EPSILON || dist > (1.0 + CMP_EPSILON)) {
@@ -148,7 +147,6 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 		return false;
 	}
 
-	dist = -dist;
 	*p_intersection = p_begin + segment * dist;
 
 	return true;


### PR DESCRIPTION
Corrected intersection point formula: the main mistake (or misprint) is positive sign of dot product in `dist` variable. One can manually check on paper that there are both negative signs of summands.

Tested the same manual function analogue in GDScript, in my project it works, unlike the previous version.