### PR TITLE
Disallow changing array element types, when using hint (inspector fix)

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -358,10 +358,14 @@ void EditorPropertyArray::update_property() {
 				vbox->add_child(hb);
 				hb->add_child(prop);
 				prop->set_h_size_flags(SIZE_EXPAND_FILL);
-				Button *edit = memnew(Button);
-				edit->set_icon(get_icon("Edit", "EditorIcons"));
-				hb->add_child(edit);
-				edit->connect("pressed", this, "_change_type", varray(edit, i + offset));
+
+				if (subtype == Variant::NIL) {
+					Button *edit = memnew(Button);
+					edit->set_icon(get_icon("Edit", "EditorIcons"));
+					hb->add_child(edit);
+					edit->connect("pressed", this, "_change_type", varray(edit, i + offset));
+				}
+
 			} else {
 				vbox->add_child(prop);
 			}


### PR DESCRIPTION
when an Array defined within the export keyword is given a subtype...

<img width="356" alt="captura de ecra 2019-01-11 as 13 36 26" src="https://user-images.githubusercontent.com/10358443/51036745-f4103200-15a5-11e9-8189-7edbf2a1eea0.png">

the "change type" (pencil) icon doesn't get drawn to avoid/disallow changing types of elements:

<img width="248" alt="captura de ecra 2019-01-11 as 13 36 38" src="https://user-images.githubusercontent.com/10358443/51036820-36d20a00-15a6-11e9-8d9e-21e7954289b8.png">

it's a simple fix, closes #24900!