### PR TITLE
Use HSplit to resize presets and options panel on Export window

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1063,7 +1063,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);
-	HBoxContainer *hbox = memnew(HBoxContainer);
+	HSplitContainer *hbox = memnew(HSplitContainer);
 	main_vb->add_child(hbox);
 	hbox->set_v_size_flags(SIZE_EXPAND_FILL);
 


### PR DESCRIPTION
![hsplit](https://user-images.githubusercontent.com/8281454/51048031-4a648b80-160d-11e9-98e1-ed61744a63a8.gif)
