### PR TITLE
Fixed infinite loop at end of video.

### DIFF
--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -164,7 +164,7 @@ void VideoStreamPlaybackGDNative::update(float p_delta) {
 		}
 	}
 
-	while (interface->get_playback_position(data_struct) < time) {
+	while (interface->get_playback_position(data_struct) < time && playing) {
 
 		update_texture();
 	}


### PR DESCRIPTION
A missing condition caused infinite looping, despite
the video playing flag being set to false.
Small change to fix.

Fixes: #20552