### PR TITLE
Adds color to the audio buses buttons

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -75,9 +75,16 @@ void EditorAudioBus::_notification(int p_what) {
 
 		disabled_vu = get_icon("BusVuFrozen", "EditorIcons");
 
+		Color solo_color = Color::html(EditorSettings::get_singleton()->is_dark_theme() ? "#ffe337" : "#ffeb70");
+		Color mute_color = Color::html(EditorSettings::get_singleton()->is_dark_theme() ? "#ff2929" : "#ff7070");
+		Color bypass_color = Color::html(EditorSettings::get_singleton()->is_dark_theme() ? "#22ccff" : "#70deff");
+
 		solo->set_icon(get_icon("AudioBusSolo", "EditorIcons"));
+		solo->add_color_override("icon_color_pressed", solo_color);
 		mute->set_icon(get_icon("AudioBusMute", "EditorIcons"));
+		mute->add_color_override("icon_color_pressed", mute_color);
 		bypass->set_icon(get_icon("AudioBusBypass", "EditorIcons"));
+		bypass->add_color_override("icon_color_pressed", bypass_color);
 
 		bus_options->set_icon(get_icon("GuiMiniTabMenu", "EditorIcons"));
 


### PR DESCRIPTION
Closes #11459
![2019-01-11-220857_106x232_scrot](https://user-images.githubusercontent.com/6093119/51059777-a8817680-15ed-11e9-93a8-f8d7e969bb3b.png)![2019-01-11-220913_104x202_scrot](https://user-images.githubusercontent.com/6093119/51059778-a91a0d00-15ed-11e9-87e8-b9aa3db19a9b.png)![2019-01-11-220930_104x197_scrot](https://user-images.githubusercontent.com/6093119/51059779-a91a0d00-15ed-11e9-83e9-3d551061a526.png)

Sadly, I could not make it work for the light theme. The way icons color are blended does not work anyway, selected icons are not visible on light themes.
![2019-01-11-220948_100x189_scrot](https://user-images.githubusercontent.com/6093119/51059780-a91a0d00-15ed-11e9-8044-75051e561ccc.png)
![2019-01-11-220954_171x31_scrot](https://user-images.githubusercontent.com/6093119/51059781-a91a0d00-15ed-11e9-9daa-9a6a34bacd6a.png)