### PR TITLE
Added autoloads as a potential type.

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2727,6 +2727,15 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 				for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 					options.insert(Variant::get_type_name((Variant::Type)i));
 				}
+				List<PropertyInfo> props;
+				ProjectSettings::get_singleton()->get_property_list(&props);
+				for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
+					String s = E->get().name;
+					if (!s.begins_with("autoload/")) {
+						continue;
+					}
+					options.insert(s.get_slice("/", 1));
+				}
 			}
 
 			List<StringName> native_classes;


### PR DESCRIPTION
As the name implies, allows you to use autoload's as a potential type. For example,
```
# AUTOLOAD NAMED 'Test'

class Testing:
	var test
```
```
# random script

func _process(delta : float) -> void:
	var variable : Test.Testing
	# ...do stuff with variable...
```

I realize that you can just use 'class_name' but that can not have the same name as an autoload which means you have to have two names, one for class_name and one for the autoload. This way only one name is needed. Just a QoL improvement I've been looking for.

And to be clear, the type is only evaluated for things like `var variable : Test`. `Test.function()` will still work like it did previously.