### PR TITLE
Fixes export PackedScene "reset to default" throwing errors

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -662,6 +662,9 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 				Ref<Script> scr = object->get_script();
 				Variant orig_value;
 				if (scr->get_property_default_value(property, orig_value)) {
+					if(orig_value.get_type() == Variant::NIL){
+						orig_value = NULL;
+					}
 					emit_signal("property_changed", property, orig_value);
 					update_property();
 					return;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -662,7 +662,7 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 				Ref<Script> scr = object->get_script();
 				Variant orig_value;
 				if (scr->get_property_default_value(property, orig_value)) {
-					if(orig_value.get_type() == Variant::NIL){
+					if (orig_value.get_type() == Variant::NIL){
 						orig_value = NULL;
 					}
 					emit_signal("property_changed", property, orig_value);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -662,7 +662,7 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 				Ref<Script> scr = object->get_script();
 				Variant orig_value;
 				if (scr->get_property_default_value(property, orig_value)) {
-					if (orig_value.get_type() == Variant::NIL){
+					if (orig_value.get_type() == Variant::NIL) {
 						orig_value = NULL;
 					}
 					emit_signal("property_changed", property, orig_value);


### PR DESCRIPTION
First contribution to a project so I don't expect this to get merged, as I'm sure this is just a band aid. This simply adds a check to see if the returned type is Varient NIL and if so sets orig_value to NULL instead.

The main issue is that when a script's property needs to be reset to default, Editor_Inspector makes a variable orig_value of type Varient NIL to hold the value. However, the get_property_default_value function of gdscript.cpp also returns this Varient NIL value, which is also used in object.cpp's call function to detect the end of the arg list it seems. Thus, arg count ends up being 1 under what it should and the error is thrown.

I didn't know what the proper way to fix this was. Should the default value of PackedScene be different? Or a different method of counting arguments in Object? Hopefully this is okay, and if not, helps someone more knowledgeable make a proper fix.

[The Issue](https://github.com/godotengine/godot/issues/24843) 