### PR TITLE
Add EditorPropertyRID as read-only label showing RID

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -795,6 +795,7 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	layers->set_hide_on_checkable_item_selection(false);
 	layers->connect("id_pressed", this, "_menu_pressed");
 }
+
 ///////////////////// INT /////////////////////////
 
 void EditorPropertyInteger::_value_changed(double val) {
@@ -1949,6 +1950,23 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 	hbc->add_child(clear);
 
 	scene_tree = NULL; //do not allocate unnecessarily
+}
+
+///////////////////// RID /////////////////////////
+
+void EditorPropertyRID::update_property() {
+	RID rid = get_edited_object()->get(get_edited_property());
+	if (rid.is_valid()) {
+		int id = rid.get_id();
+		label->set_text("RID: " + itos(id));
+	} else {
+		label->set_text(TTR("Invalid RID"));
+	}
+}
+
+EditorPropertyRID::EditorPropertyRID() {
+	label = memnew(Label);
+	add_child(label);
 }
 
 ////////////// RESOURCE //////////////////////
@@ -3117,6 +3135,8 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 
 		} break; // 15
 		case Variant::_RID: {
+			EditorPropertyRID *editor = memnew(EditorPropertyRID);
+			add_property_editor(p_path, editor);
 		} break;
 		case Variant::OBJECT: {
 			EditorPropertyResource *editor = memnew(EditorPropertyResource);

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -515,6 +515,15 @@ public:
 	EditorPropertyNodePath();
 };
 
+class EditorPropertyRID : public EditorProperty {
+	GDCLASS(EditorPropertyRID, EditorProperty)
+	Label *label;
+
+public:
+	virtual void update_property();
+	EditorPropertyRID();
+};
+
 class EditorPropertyResource : public EditorProperty {
 	GDCLASS(EditorPropertyResource, EditorProperty)
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -29,9 +29,11 @@
 /*************************************************************************/
 
 #include "editor_properties_array_dict.h"
+
 #include "core/io/marshalls.h"
 #include "editor/editor_scale.h"
 #include "editor_properties.h"
+
 bool EditorPropertyArrayObject::_set(const StringName &p_name, const Variant &p_value) {
 
 	String pn = p_name;


### PR DESCRIPTION
Fixes #24827.

It works for export variables in the inspector and within the array editor. The use case is quite limited though, maybe only useful to see the RID of preloaded resources:
![screenshot_20190114_120121](https://user-images.githubusercontent.com/4701338/51108997-1eefc580-17f4-11e9-9de9-a89512e9ef76.png)
from:
```
export (Array) var test = [0, RID(preload("res://icon.png")), 1]
export (Array) var test_rid = [0, 2]
export (RID) var my_rid = RID()
export (RID) var my_rid2 = RID(preload("res://icon.png"))
```
The RID entry in `test_rid` is added from the inspector in the array editor. It's of course useless but it no longer crashes.

-----

I couldn't get it to work in the remote debugger though, it seems like getting `Members/my_rid` (in my example) does not return a valid RID.

I investigated some and
```
Variant test = get_edited_object()->get(get_edited_property());
```
does return a `Variant` of type `Variant::_RID`, but then `test.operator RID()` returns a null pointer. I guess the remote debugger might not be getting the actual RID instance, but a new Variant which represents the RID, and in this case it can't be converted back to the RID instance properly.