### PR TITLE
Enable gles2 canvas fast path on the Raspberry Pi

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -490,7 +490,7 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 				glVertexAttrib4fv(VS::ARRAY_COLOR, r->modulate.components);
 
 //use a more compatible workaround, as this does not fail on nvidia
-#ifdef GLES_OVER_GL
+#if defined(GLES_OVER_GL) && !defined(__arm__) && !defined(__aarch64__)
 				//more compatible
 				state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_TEXTURE_RECT, false);
 


### PR DESCRIPTION
This allows the Raspberry Pi use the gles2 canvas fast path out of the box.

Not the perfect way to autodetect the Raspberry Pi, but I reckon that this is a fairly non-invasive method and I believe the Raspberry Pi is the most popular "desktop" (i.e. GLES_OVER_GL) running on ARM anyway.

`__aarch64__` is not strictly needed, but some people are running 64 bits distro, and it would be a shame to leave them out.

See https://github.com/godotengine/godot/issues/2671 and https://github.com/godotengine/godot/issues/24466