### PR TITLE
Fixes export PackedScene "reset to default" throwing errors

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4559,6 +4559,10 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 				member.line = tokenizer->get_token_line();
 				member.usages = 0;
 				member.rpc_mode = rpc_mode;
+#ifdef TOOLS_ENABLED
+				Variant::CallError ce;
+				member.default_value = Variant::construct(member._export.type, NULL, 0, ce);
+#endif
 
 				if (current_class->constant_expressions.has(member.identifier)) {
 					_set_error("A constant named '" + String(member.identifier) + "' already exists in this class (at line: " +


### PR DESCRIPTION
When exporting variables from a gdscript, default values of uninitialized variables would never be set. This caused the default value to be Variant::NIL, and when a user tried to reset the variable through the editor, an error would be thrown because too few arguments would be counted(end of argument list for calls are detected by NIL values).

I fixed this by adding a switch statement in the gdscript parser to set the default value to empty variants of the proper type.

Fixes #24843