### PR TITLE
Save 4 bytes in ENet multiplayer protocol.

### DIFF
--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -339,11 +339,10 @@ void NetworkedMultiplayerENet::poll() {
 
 					uint32_t *id = (uint32_t *)event.peer->data;
 
-					ERR_CONTINUE(event.packet->dataLength < 12)
+					ERR_CONTINUE(event.packet->dataLength < 8)
 
 					uint32_t source = decode_uint32(&event.packet->data[0]);
 					int target = decode_uint32(&event.packet->data[4]);
-					uint32_t flags = decode_uint32(&event.packet->data[8]);
 
 					packet.from = source;
 					packet.channel = event.channelID;
@@ -364,7 +363,7 @@ void NetworkedMultiplayerENet::poll() {
 								if (uint32_t(E->key()) == source) // Do not resend to self
 									continue;
 
-								ENetPacket *packet2 = enet_packet_create(packet.packet->data, packet.packet->dataLength, flags);
+								ENetPacket *packet2 = enet_packet_create(packet.packet->data, packet.packet->dataLength, packet.packet->flags);
 
 								enet_peer_send(E->get(), event.channelID, packet2);
 							}
@@ -378,7 +377,7 @@ void NetworkedMultiplayerENet::poll() {
 								if (uint32_t(E->key()) == source || E->key() == -target) // Do not resend to self, also do not send to excluded
 									continue;
 
-								ENetPacket *packet2 = enet_packet_create(packet.packet->data, packet.packet->dataLength, flags);
+								ENetPacket *packet2 = enet_packet_create(packet.packet->data, packet.packet->dataLength, packet.packet->flags);
 
 								enet_peer_send(E->get(), event.channelID, packet2);
 							}
@@ -497,8 +496,8 @@ Error NetworkedMultiplayerENet::get_packet(const uint8_t **r_buffer, int &r_buff
 	current_packet = incoming_packets.front()->get();
 	incoming_packets.pop_front();
 
-	*r_buffer = (const uint8_t *)(&current_packet.packet->data[12]);
-	r_buffer_size = current_packet.packet->dataLength - 12;
+	*r_buffer = (const uint8_t *)(&current_packet.packet->data[8]);
+	r_buffer_size = current_packet.packet->dataLength - 8;
 
 	return OK;
 }
@@ -543,11 +542,10 @@ Error NetworkedMultiplayerENet::put_packet(const uint8_t *p_buffer, int p_buffer
 		}
 	}
 
-	ENetPacket *packet = enet_packet_create(NULL, p_buffer_size + 12, packet_flags);
+	ENetPacket *packet = enet_packet_create(NULL, p_buffer_size + 8, packet_flags);
 	encode_uint32(unique_id, &packet->data[0]); // Source ID
 	encode_uint32(target_peer, &packet->data[4]); // Dest ID
-	encode_uint32(packet_flags, &packet->data[8]); // Dest ID
-	copymem(&packet->data[12], p_buffer, p_buffer_size);
+	copymem(&packet->data[8], p_buffer, p_buffer_size);
 
 	if (server) {
 


### PR DESCRIPTION
Avoid sending encoded packet flags (reliable/unreliable/ordered) as that's already been done by ENet itself and we can read them from the incoming packet.

Closes #24496