### PR TITLE
Prevent recursive Main::iteration() calls

### DIFF
--- a/main/main.h
+++ b/main/main.h
@@ -47,6 +47,7 @@ class Main {
 	static uint32_t frames;
 	static uint32_t frame;
 	static bool force_redraw_requested;
+	static bool iteration_finished;
 
 public:
 	static bool is_project_manager();


### PR DESCRIPTION
Same as patch in https://github.com/godotengine/godot/issues/24969#issuecomment-454140904

Fixes #24969, #23572 and maybe other related issues #24672, #23086. I'm unsure this is proper solution.