### PR TITLE
Fix MultiplayerAPI initialization, clear, set_network_peer.

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -132,6 +132,8 @@ void MultiplayerAPI::set_root_node(Node *p_node) {
 
 void MultiplayerAPI::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_peer) {
 
+	if (p_peer == network_peer) return; // Nothing to do
+
 	if (network_peer.is_valid()) {
 		network_peer->disconnect("peer_connected", this, "_add_peer");
 		network_peer->disconnect("peer_disconnected", this, "_del_peer");

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -122,6 +122,7 @@ void MultiplayerAPI::clear() {
 	connected_peers.clear();
 	path_get_cache.clear();
 	path_send_cache.clear();
+	packet_cache.clear();
 	last_send_cache_id = 1;
 }
 
@@ -857,6 +858,8 @@ void MultiplayerAPI::_bind_methods() {
 }
 
 MultiplayerAPI::MultiplayerAPI() {
+	rpc_sender_id = 0;
+	root_node = NULL;
 	clear();
 }
 


### PR DESCRIPTION
`rpc_sender_id` is now correctly initialized to 0 so `get_rpc_sender_id()` work reliably even if called before receiving any RPC.
`root_node` is initialized to NULL (fix crashes when incorrectly using the MultiplayerAPI).
`clear` function now resets the packet cache size to free more memory when not running.

The call to `set_network_peer` is now ignored if the peer that's beeing set is the same as the currently set one:
A GDScript call to `multiplayer.network_peer.some_prop = true` seems to transalte to:
```
var temp = multiplayer.network_peer
temp.some_prop = true
multiplayer.network_peer = temp
```
(@vnen @reduz is that expected?)

Which caused the MultiplayerAPI to be resetted.