### PR TITLE
Fix Android keep screen on working properly

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -119,7 +119,6 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 	private boolean use_debug_opengl = false;
 	private boolean mStatePaused;
 	private int mState;
-	private boolean keep_screen_on = true;
 
 	static private Intent mCurrentIntent;
 
@@ -297,31 +296,26 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		});
 
 		final String[] current_command_line = command_line;
-		final GodotView view = mView;
 		mView.queueEvent(new Runnable() {
 			@Override
 			public void run() {
 				GodotLib.setup(current_command_line);
-				runOnUiThread(new Runnable() {
-					@Override
-					public void run() {
-						view.setKeepScreenOn("True".equals(GodotLib.getGlobal("display/window/energy_saving/keep_screen_on")));
-					}
-				});
+				setKeepScreenOn("True".equals(GodotLib.getGlobal("display/window/energy_saving/keep_screen_on")));
 			}
 		});
 	}
 
 	public void setKeepScreenOn(final boolean p_enabled) {
-		keep_screen_on = p_enabled;
-		if (mView != null) {
-			runOnUiThread(new Runnable() {
-				@Override
-				public void run() {
-					mView.setKeepScreenOn(p_enabled);
+		runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
+				if (p_enabled) {
+					getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+				} else {
+					getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 				}
-			});
-		}
+			}
+		});
 	}
 
 	public void alert(final String message, final String title) {


### PR DESCRIPTION
currently, default `keep_screen_on`(true) doesn't work randomly.
I think this fix should be in 3.1

supersedes #25003