### PR TITLE
Fix order of a nullptr test in canvas item editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -573,10 +573,10 @@ bool CanvasItemEditor::_get_bone_shape(Vector<Vector2> *shape, Vector<Vector2> *
 	Node2D *from_node = Object::cast_to<Node2D>(ObjectDB::get_instance(bone->key().from));
 	Node2D *to_node = Object::cast_to<Node2D>(ObjectDB::get_instance(bone->key().to));
 
-	if (!from_node->is_inside_tree())
-		return false; //may have been removed
 	if (!from_node)
 		return false;
+	if (!from_node->is_inside_tree())
+		return false; //may have been removed
 
 	if (!to_node && bone->get().length == 0)
 		return false;


### PR DESCRIPTION
A test for a null pointer was being used after the pointer itself was, as described in [this issue](https://github.com/godotengine/godot/issues/24014). 

Went ahead and moved the null pointer test to before the check that uses it, as the issue had been open for a while.