### PR TITLE
Docs: ARVRController: spelling & punctuation

### DIFF
--- a/doc/classes/ARVRController.xml
+++ b/doc/classes/ARVRController.xml
@@ -4,8 +4,8 @@
 		A spatial node representing a spatially tracked controller.
 	</brief_description>
 	<description>
-		This is a helper spatial node that is linked to the tracking of controllers. It also offers several handy pass throughs to the state of buttons and such on the controllers.
-		Controllers are linked by their id. You can create controller nodes before the controllers are available. Say your game always uses two controllers (one for each hand) you can predefine the controllers with id 1 and 2 and they will become active as soon as the controllers are identified. If you expect additional controllers to be used you should react to the signals and add ARVRController nodes to your scene.
+		This is a helper spatial node that is linked to the tracking of controllers. It also offers several handy passthroughs to the state of buttons and such on the controllers.
+		Controllers are linked by their id. You can create controller nodes before the controllers are available. Say your game always uses two controllers (one for each hand) you can predefine the controllers with id 1 and 2 and they will become active as soon as the controllers are identified. If you expect additional controllers to be used, you should react to the signals and add ARVRController nodes to your scene.
 		The position of the controller node is automatically updated by the ARVR Server. This makes this node ideal to add child nodes to visualise the controller.
 	</description>
 	<tutorials>
@@ -64,7 +64,7 @@
 		<member name="controller_id" type="int" setter="set_controller_id" getter="get_controller_id">
 			The controller's id.
 			A controller id of 0 is unbound and will always result in an inactive node. Controller id 1 is reserved for the first controller that identifies itself as the left hand controller and id 2 is reserved for the first controller that identifies itself as the right hand controller.
-			For any other controller that the [ARVRServer] detects we continue with controller id 3.
+			For any other controller that the [ARVRServer] detects, we continue with controller id 3.
 			When a controller is turned off, its slot is freed. This ensures controllers will keep the same id even when controllers with lower ids are turned off.
 		</member>
 		<member name="rumble" type="float" setter="set_rumble" getter="get_rumble">


### PR DESCRIPTION
Docs: Fix spelling and punctuation in ARVRController.
"pass through"    = verb;
"passthrough(s)" = noun.