### PR TITLE
Android: Add support for x86_64 architecture

### DIFF
--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -272,9 +272,9 @@ else:
     import platform
     is_x11_or_server_arm = ((env["platform"] == 'x11' or env["platform"] == 'server') and (platform.machine().startswith('arm') or platform.machine().startswith('aarch')))
     is_ios_x86 = (env["platform"] == 'iphone' and ("arch" in env and env["arch"].startswith('x86')))
-    is_android_x86 = (env["platform"] == 'android' and env["android_arch"] == 'x86')
+    is_android_x86 = (env["platform"] == 'android' and env["android_arch"].startswith('x86'))
     if is_android_x86:
-        cpu_bits = '32'
+        cpu_bits = '32' if env["android_arch"] == 'x86' else '64'
     webm_cpu_x86 = not is_x11_or_server_arm and (cpu_bits == '32' or cpu_bits == '64') and (env["platform"] == 'windows' or env["platform"] == 'x11' or env["platform"] == 'osx' or env["platform"] == 'haiku' or is_android_x86 or is_ios_x86)
     webm_cpu_arm = is_x11_or_server_arm or (not is_ios_x86 and env["platform"] == 'iphone') or (not is_android_x86 and env["platform"] == 'android')
 

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -152,6 +152,8 @@ elif env['android_arch'] == 'arm64v8':
     lib_arch_dir = 'arm64-v8a'
 elif env['android_arch'] == 'x86':
     lib_arch_dir = 'x86'
+elif env['android_arch'] == 'x86_64':
+    lib_arch_dir = 'x86_64'
 else:
     print('WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin')
 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -552,14 +552,13 @@ class EditorExportAndroid : public EditorExportPlatform {
 
 	static Vector<String> get_abis() {
 		Vector<String> abis;
-		// We can still build armv7 in theory, but it doesn't make much
+		// We can still build armv6 in theory, but it doesn't make much
 		// sense for games, so disabling for now.
 		//abis.push_back("armeabi");
 		abis.push_back("armeabi-v7a");
 		abis.push_back("arm64-v8a");
 		abis.push_back("x86");
-		// Don't expose x86_64 for now, we don't support it in detect.py
-		//abis.push_back("x86_64");
+		abis.push_back("x86_64");
 		return abis;
 	}
 


### PR DESCRIPTION
Part of #25030.

Should be cherry-picked for both `3.0` and `2.1` as per the new Google policy outlined in #25030.