### PR TITLE
Android: Enable arm64-v8a export by default

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1170,7 +1170,7 @@ public:
 		Vector<String> abis = get_abis();
 		for (int i = 0; i < abis.size(); ++i) {
 			String abi = abis[i];
-			bool is_default = (abi == "armeabi-v7a");
+			bool is_default = (abi == "armeabi-v7a" || abi == "arm64-v8a");
 			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "architectures/" + abi), is_default));
 		}
 


### PR DESCRIPTION
From August 1, 2019, Google Play requires that all new apps and app updates
include 64-bit versions, so we enable ARM64 by default.

IINM support for x86 and x86_64 is still optional, so not enabling them
out of the box.

Part of #25030.