### PR TITLE
fixed AudioStreamPlayer3D::_get_attenuation_db epsilon value

### DIFF
--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -33,6 +33,7 @@
 #include "scene/3d/area.h"
 #include "scene/3d/camera.h"
 #include "scene/main/viewport.h"
+
 void AudioStreamPlayer3D::_mix_audio() {
 
 	if (!stream_playback.is_valid() || !active ||
@@ -206,15 +207,15 @@ float AudioStreamPlayer3D::_get_attenuation_db(float p_distance) const {
 	float att = 0;
 	switch (attenuation_model) {
 		case ATTENUATION_INVERSE_DISTANCE: {
-			att = Math::linear2db(1.0 / ((p_distance / unit_size) + 000001));
+			att = Math::linear2db(1.0 / ((p_distance / unit_size) + CMP_EPSILON));
 		} break;
 		case ATTENUATION_INVERSE_SQUARE_DISTANCE: {
 			float d = (p_distance / unit_size);
 			d *= d;
-			att = Math::linear2db(1.0 / (d + 0.00001));
+			att = Math::linear2db(1.0 / (d + CMP_EPSILON));
 		} break;
 		case ATTENUATION_LOGARITHMIC: {
-			att = -20 * Math::log(p_distance / unit_size + 000001);
+			att = -20 * Math::log(p_distance / unit_size + CMP_EPSILON);
 		} break;
 		default: {
 			ERR_PRINT("Unknown attenuation type");


### PR DESCRIPTION
Completed version of #25002. Fixed `000001` to `0.00001` typo and value is allocated into named constant.