### PR TITLE
Possible fix for editor property grabing focus when scripting

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1702,7 +1702,7 @@ void EditorInspector::update_tree() {
 					ep->update_property();
 					ep->update_reload_status();
 
-					if (current_selected && ep->property == current_selected) {
+					if (current_selected && ep->property == current_selected && has_focus()) {
 						ep->select(current_focusable);
 					}
 				}


### PR DESCRIPTION
Godot would update the tree on idle of the inspector, and if a property was previously selected, godot would assume it should have focus and select it.

This commit adds a check to see if editor inspector has focus before selecting it.

I took a stab at trying to find the bug and I think this is it, at least I can't get the bug to reproduce after this, and I made sure one could still select a property once it doesn't have focus, however, I am unsure if this would affect other areas of code and feedback on this would be appreciated.

*Bugsquad edit:* Fixes #24979