### PR TITLE
Fix enum scope

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -634,14 +634,14 @@ void RasterizerStorageGLES3::texture_allocate(RID p_texture, int p_width, int p_
 
 #ifndef GLES_OVER_GL
 	switch (p_format) {
-		case Image::Format::FORMAT_RF:
-		case Image::Format::FORMAT_RGF:
-		case Image::Format::FORMAT_RGBF:
-		case Image::Format::FORMAT_RGBAF:
-		case Image::Format::FORMAT_RH:
-		case Image::Format::FORMAT_RGH:
-		case Image::Format::FORMAT_RGBH:
-		case Image::Format::FORMAT_RGBAH: {
+		case Image::FORMAT_RF:
+		case Image::FORMAT_RGF:
+		case Image::FORMAT_RGBF:
+		case Image::FORMAT_RGBAF:
+		case Image::FORMAT_RH:
+		case Image::FORMAT_RGH:
+		case Image::FORMAT_RGBH:
+		case Image::FORMAT_RGBAH: {
 			if (!config.texture_float_linear_supported) {
 				// disable linear texture filtering when not supported for float format on some devices (issue #24295)
 				p_flags &= ~VS::TEXTURE_FLAG_FILTER;


### PR DESCRIPTION
I get an error compiling godot with gcc 4.9.2 (standard compiler in debian jessie). I know gcc 4.9.2 is probably not supported and I shouldn't use it in the first place, but:

- My patch makes the code base more consistent; in other places enums are handled as in the patch
- I think that the current code might not be standard compliant; as far as I know, names in normal enums (i.e. not enum classes) are defined in the enclosing scope
- It is the only change needed to successfully compile godot with gcc 4.9.2