### PR TITLE
Added scalar/vector clamp functions to visual shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -838,6 +838,8 @@ VisualShaderEditor::VisualShaderEditor() {
 	add_options.push_back(AddOption("VectorFunc", "Functions", "VisualShaderNodeVectorFunc"));
 	add_options.push_back(AddOption("DotProduct", "Functions", "VisualShaderNodeDotProduct"));
 	add_options.push_back(AddOption("VectorLen", "Functions", "VisualShaderNodeVectorLen"));
+	add_options.push_back(AddOption("ScalarClamp", "Clamping", "VisualShaderNodeScalarClamp"));
+	add_options.push_back(AddOption("VectorClamp", "Clamping", "VisualShaderNodeVectorClamp"));
 	add_options.push_back(AddOption("ScalarInterp", "Interpolation", "VisualShaderNodeScalarInterp"));
 	add_options.push_back(AddOption("VectorInterp", "Interpolation", "VisualShaderNodeVectorInterp"));
 	add_options.push_back(AddOption("VectorCompose", "Compose", "VisualShaderNodeVectorCompose"));

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -488,6 +488,8 @@ void register_scene_types() {
 	ClassDB::register_class<VisualShaderNodeVectorFunc>();
 	ClassDB::register_class<VisualShaderNodeDotProduct>();
 	ClassDB::register_class<VisualShaderNodeVectorLen>();
+	ClassDB::register_class<VisualShaderNodeScalarClamp>();
+	ClassDB::register_class<VisualShaderNodeVectorClamp>();
 	ClassDB::register_class<VisualShaderNodeScalarInterp>();
 	ClassDB::register_class<VisualShaderNodeVectorInterp>();
 	ClassDB::register_class<VisualShaderNodeVectorCompose>();

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -1364,6 +1364,98 @@ VisualShaderNodeVectorLen::VisualShaderNodeVectorLen() {
 	set_input_port_default_value(0, Vector3());
 }
 
+////////////// Scalar Clamp
+
+String VisualShaderNodeScalarClamp::get_caption() const {
+	return "ScalarClamp";
+}
+
+int VisualShaderNodeScalarClamp::get_input_port_count() const {
+	return 3;
+}
+
+VisualShaderNodeScalarClamp::PortType VisualShaderNodeScalarClamp::get_input_port_type(int p_port) const {
+	return PORT_TYPE_SCALAR;
+}
+
+String VisualShaderNodeScalarClamp::get_input_port_name(int p_port) const {
+	if (p_port == 0)
+		return "";
+	else if (p_port == 1)
+		return "min";
+	else if (p_port == 2)
+		return "max";
+	return "";
+}
+
+int VisualShaderNodeScalarClamp::get_output_port_count() const {
+	return 1;
+}
+
+VisualShaderNodeScalarClamp::PortType VisualShaderNodeScalarClamp::get_output_port_type(int p_port) const {
+	return PORT_TYPE_SCALAR;
+}
+
+String VisualShaderNodeScalarClamp::get_output_port_name(int p_port) const {
+	return "";
+}
+
+String VisualShaderNodeScalarClamp::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars) const {
+	return "\t" + p_output_vars[0] + " = clamp( " + p_input_vars[0] + ", " + p_input_vars[1] + ", " + p_input_vars[2] + " );\n";
+}
+
+VisualShaderNodeScalarClamp::VisualShaderNodeScalarClamp() {
+	set_input_port_default_value(0, 0.0);
+	set_input_port_default_value(1, 0.0);
+	set_input_port_default_value(2, 1.0);
+}
+
+////////////// Vector Clamp
+
+String VisualShaderNodeVectorClamp::get_caption() const {
+	return "VectorClamp";
+}
+
+int VisualShaderNodeVectorClamp::get_input_port_count() const {
+	return 3;
+}
+
+VisualShaderNodeVectorClamp::PortType VisualShaderNodeVectorClamp::get_input_port_type(int p_port) const {
+	return PORT_TYPE_VECTOR;
+}
+
+String VisualShaderNodeVectorClamp::get_input_port_name(int p_port) const {
+	if (p_port == 0)
+		return "";
+	else if (p_port == 1)
+		return "min";
+	else if (p_port == 2)
+		return "max";
+	return "";
+}
+
+int VisualShaderNodeVectorClamp::get_output_port_count() const {
+	return 1;
+}
+
+VisualShaderNodeVectorClamp::PortType VisualShaderNodeVectorClamp::get_output_port_type(int p_port) const {
+	return PORT_TYPE_VECTOR;
+}
+
+String VisualShaderNodeVectorClamp::get_output_port_name(int p_port) const {
+	return "";
+}
+
+String VisualShaderNodeVectorClamp::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars) const {
+	return "\t" + p_output_vars[0] + " = clamp( " + p_input_vars[0] + ", " + p_input_vars[1] + ", " + p_input_vars[2] + " );\n";
+}
+
+VisualShaderNodeVectorClamp::VisualShaderNodeVectorClamp() {
+	set_input_port_default_value(0, Vector3(0, 0, 0));
+	set_input_port_default_value(1, Vector3(0, 0, 0));
+	set_input_port_default_value(2, Vector3(1, 1, 1));
+}
+
 ////////////// Scalar Interp
 
 String VisualShaderNodeScalarInterp::get_caption() const {

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -609,6 +609,48 @@ public:
 
 ///////////////////////////////////////
 
+class VisualShaderNodeScalarClamp : public VisualShaderNode {
+	GDCLASS(VisualShaderNodeScalarClamp, VisualShaderNode)
+
+public:
+	virtual String get_caption() const;
+
+	virtual int get_input_port_count() const;
+	virtual PortType get_input_port_type(int p_port) const;
+	virtual String get_input_port_name(int p_port) const;
+
+	virtual int get_output_port_count() const;
+	virtual PortType get_output_port_type(int p_port) const;
+	virtual String get_output_port_name(int p_port) const;
+
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
+
+	VisualShaderNodeScalarClamp();
+};
+
+///////////////////////////////////////
+
+class VisualShaderNodeVectorClamp : public VisualShaderNode {
+	GDCLASS(VisualShaderNodeVectorClamp, VisualShaderNode)
+
+public:
+	virtual String get_caption() const;
+
+	virtual int get_input_port_count() const;
+	virtual PortType get_input_port_type(int p_port) const;
+	virtual String get_input_port_name(int p_port) const;
+
+	virtual int get_output_port_count() const;
+	virtual PortType get_output_port_type(int p_port) const;
+	virtual String get_output_port_name(int p_port) const;
+
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
+
+	VisualShaderNodeVectorClamp();
+};
+
+///////////////////////////////////////
+
 class VisualShaderNodeScalarInterp : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeScalarInterp, VisualShaderNode)
 


### PR DESCRIPTION
I guess its useful for various things, where simple saturate(clamping between 0 and 1) is not enough..

![image](https://user-images.githubusercontent.com/3036176/51345841-1e358880-1aad-11e9-98ee-411c675473bd.png)
