### PR TITLE
C#: Fix trying to build when there's no solution

### DIFF
--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -381,6 +381,9 @@ bool GodotSharpBuilds::build_project_blocking(const String &p_config) {
 
 bool GodotSharpBuilds::editor_build_callback() {
 
+	if (!FileAccess::exists(GodotSharpDirs::get_project_sln_path()))
+		return true; // No solution to build
+
 	String scripts_metadata_path_editor = GodotSharpDirs::get_res_metadata_dir().plus_file("scripts_metadata.editor");
 	String scripts_metadata_path_player = GodotSharpDirs::get_res_metadata_dir().plus_file("scripts_metadata.editor_player");
 

--- a/modules/mono/editor/mono_bottom_panel.cpp
+++ b/modules/mono/editor/mono_bottom_panel.cpp
@@ -150,6 +150,9 @@ void MonoBottomPanel::_errors_toggled(bool p_pressed) {
 
 void MonoBottomPanel::_build_project_pressed() {
 
+	if (!FileAccess::exists(GodotSharpDirs::get_project_sln_path()))
+		return; // No solution to build
+
 	String scripts_metadata_path = GodotSharpDirs::get_res_metadata_dir().plus_file("scripts_metadata.editor");
 	Error metadata_err = CSharpProject::generate_scripts_metadata(GodotSharpDirs::get_project_csproj_path(), scripts_metadata_path);
 	ERR_FAIL_COND(metadata_err != OK);


### PR DESCRIPTION
This would cause errors that shouldn't happen unless there was something to build.

Fixes #23432
