### PR TITLE
Work around a GCC optimizer bug at -O3

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2677,6 +2677,11 @@ void RasterizerSceneGLES3::_setup_environment(Environment *env, const CameraMatr
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
+// Drop -O3 for this function as it triggers a GCC bug up until at least GCC 8.2.1.
+// This refers to GH issue #19633.
+// The bug has been reported to the GCC project.
+#pragma GCC push_options
+#pragma GCC optimize ("-O2")
 void RasterizerSceneGLES3::_setup_directional_light(int p_index, const Transform &p_camera_inverse_transform, bool p_use_shadows) {
 
 	LightInstance *li = directional_lights[p_index];
@@ -2794,6 +2799,7 @@ void RasterizerSceneGLES3::_setup_directional_light(int p_index, const Transform
 
 	glBindBufferBase(GL_UNIFORM_BUFFER, 3, state.directional_ubo);
 }
+#pragma GCC pop_options
 
 void RasterizerSceneGLES3::_setup_lights(RID *p_light_cull_result, int p_light_cull_count, const Transform &p_camera_inverse_transform, const CameraMatrix &p_camera_projection, RID p_shadow_atlas) {
 


### PR DESCRIPTION
This bug has been reported upstream, once it gets fixed we'll add some
version guards to only disable this for specific GCC versions.

This fixes #19633