### PR TITLE
Fixed Bone Transform Order

### DIFF
--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -320,7 +320,7 @@ void Skeleton::_notification(int p_what) {
 				}
 
 				b.transform_final = b.pose_global * b.rest_global_inverse;
-				vs->skeleton_bone_set_transform(skeleton, i, global_transform * (b.transform_final * global_transform_inverse));
+				vs->skeleton_bone_set_transform(skeleton, order[i], global_transform * (b.transform_final * global_transform_inverse));
 
 				for (List<uint32_t>::Element *E = b.nodes_bound.front(); E; E = E->next()) {
 


### PR DESCRIPTION
The bone index being passed to the visual server is not using the process order and results in incorrect skin deformation if the calculated process order is different from the unordered bones Vector.

Incidentally, this never showed when I exported rigged characters from blender using the Better Collada exporter. This bug only materialised when experimenting with the glTF pipeline from Maya.