### PR TITLE
Fixes too long textboxes in export window

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -377,6 +377,7 @@ void ProjectExportDialog::_custom_features_changed(const String &p_text) {
 
 void ProjectExportDialog::_tab_changed(int) {
 	_update_feature_list();
+	minimum_size_changed();
 }
 
 void ProjectExportDialog::_patch_button_pressed(Object *p_item, int p_column, int p_id) {


### PR DESCRIPTION
Fixes #21404

Basically the export window uses a `TabContainer`, but when a current tab changes, size of the window is not updated to the new minimum size. 
This PR only fixes the export window, but the bug can also occur in other popup's that use `TabContainer`, e.g. when you resize down project settings too much and change current tab to general.
![settings](https://user-images.githubusercontent.com/10081294/51420743-1f41e500-1b95-11e9-8091-2a9602fff341.png)

The easiest way to reproduce this issue is in export window (should work with any language, but I have only checked this in english and polish):
1. Select any preset
2. Select options tab and resize down the popup as much as you can (horizontally)
3. Select resources tab