### PR TITLE
Allow 1 focused UI element per viewport

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2632,7 +2632,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 	//no need for change
 	if (gui.key_focus && gui.key_focus == p_control)
 		return;
-	get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, "_viewports", "_gui_remove_focus");
+	_gui_remove_focus();
 	gui.key_focus = p_control;
 	p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
 	p_control->update();


### PR DESCRIPTION
Allows having 1 focused UI element per viewport, instead of 1 per scenetree. This is needed for the builtin UI to function in a splitscreen environment where different viewports are independently controlled.

However: There are cases where this is NOT the correct behavior, like having multiple viewports in the gui_in_3d demo. I don't really have a good answer for that, but it's probably going to involve game-specific logic like restricting events to viewports that the mouse is over.

Feedback appreciated