### PR TITLE
Print the path of a corrupt image

### DIFF
--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -65,6 +65,9 @@ Error ImageLoader::load_image(String p_file, Ref<Image> p_image, FileAccess *p_c
 		if (!loader[i]->recognize(extension))
 			continue;
 		Error err = loader[i]->load_image(p_image, f, p_force_linear, p_scale);
+		if (err != OK) {
+			ERR_PRINTS("Error loading image: " + p_file);
+		}
 
 		if (err != ERR_FILE_UNRECOGNIZED) {
 


### PR DESCRIPTION
After scanning a path in the project manager or starting a project it is not clear which
image can not be loaded.

After errors

```
    ERROR: _png_error_function: Not a PNG file
       At: drivers/png/image_loader_png.cpp:62.
    libpng error: Not a PNG file
    ERROR: _load_image: PNG Corrupted
       At: drivers/png/image_loader_png.cpp:94.
```

add

```
    ERROR: load_image: Error loading image: path/bad.png
       At: core/io/image_loader.cpp:69.
```