### PR TITLE
Fix HTML5 gamepad sampling

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -970,7 +970,8 @@ bool OS_JavaScript::main_loop_iterate() {
 		}
 	}
 
-	process_joypads();
+	if (emscripten_sample_gamepad_data() == EMSCRIPTEN_RESULT_SUCCESS)
+		process_joypads();
 
 	if (just_exited_fullscreen) {
 		if (window_maximized) {


### PR DESCRIPTION
Emscripten compatibility breakage again, from 1.38.22.
Fix #25100
Fix #25123