### PR TITLE
Fix HTML5 build warning

### DIFF
--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -39,9 +39,9 @@ class RandomPCG {
 	pcg32_random_t pcg;
 
 public:
-	static const uint64_t DEFAULT_SEED = 12047754176567800795ULL;
+	static const uint64_t DEFAULT_SEED = 12047754176567800795U;
 	static const uint64_t DEFAULT_INC = PCG_DEFAULT_INC_64;
-	static const uint64_t RANDOM_MAX = 4294967295;
+	static const uint64_t RANDOM_MAX = 0xFFFFFFFF;
 
 	RandomPCG(uint64_t seed = DEFAULT_SEED, uint64_t inc = PCG_DEFAULT_INC_64);
 

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -58,6 +58,7 @@ class OS_JavaScript : public OS_Unix {
 	int last_click_button_index;
 
 	MainLoop *main_loop;
+	int video_driver_index;
 	AudioDriverJavaScript audio_driver_javascript;
 
 	bool idb_available;
@@ -84,8 +85,6 @@ class OS_JavaScript : public OS_Unix {
 	static void main_loop_callback();
 
 	static void file_access_close_callback(const String &p_file, int p_flags);
-
-	int video_driver_index;
 
 protected:
 	virtual int get_current_video_driver() const;


### PR DESCRIPTION
The warning about `4294967295` begin too large for a signed integer is back. By using a hexadecimal literal, it's treated as an unsigned integer.

Also removed the `LL` suffix in `DEFAULT_SEED` since it's C++11 syntax and unnecessary here.

Finally, moved `video_driver_index` to the other private fields in `OS_JavaScript`.