### PR TITLE
Deal with Google's HTML5 autoplay policy

### DIFF
--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -146,6 +146,15 @@ void AudioDriverJavaScript::start() {
 	/* clang-format on */
 }
 
+void AudioDriverJavaScript::resume() {
+	/* clang-format off */
+	EM_ASM({
+		if (_audioDriver_audioContext.resume)
+			_audioDriver_audioContext.resume();
+	});
+	/* clang-format on */
+}
+
 int AudioDriverJavaScript::get_mix_rate() const {
 
 	/* clang-format off */

--- a/platform/javascript/audio_driver_javascript.h
+++ b/platform/javascript/audio_driver_javascript.h
@@ -49,6 +49,7 @@ public:
 
 	virtual Error init();
 	virtual void start();
+	void resume();
 	virtual int get_mix_rate() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual void lock();

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -245,6 +245,8 @@ EM_BOOL OS_JavaScript::keydown_callback(int p_event_type, const EmscriptenKeyboa
 		return false;
 	}
 	os->input->parse_input_event(ev);
+	// Resume audio context after input in case autoplay was denied.
+	os->audio_driver_javascript.resume();
 	return true;
 }
 
@@ -335,6 +337,8 @@ EM_BOOL OS_JavaScript::mouse_button_callback(int p_event_type, const EmscriptenM
 	ev->set_button_mask(mask);
 
 	os->input->parse_input_event(ev);
+	// Resume audio context after input in case autoplay was denied.
+	os->audio_driver_javascript.resume();
 	// Prevent multi-click text selection and wheel-click scrolling anchor.
 	// Context menu is prevented through contextmenu event.
 	return true;
@@ -663,6 +667,8 @@ EM_BOOL OS_JavaScript::touch_press_callback(int p_event_type, const EmscriptenTo
 
 		os->input->parse_input_event(ev);
 	}
+	// Resume audio context after input in case autoplay was denied.
+	os->audio_driver_javascript.resume();
 	return true;
 }
 


### PR DESCRIPTION
Resume audio context after mouse, touch or key input.
Details at https://sites.google.com/a/chromium.org/dev/audio-video/autoplay
Fix #22036