### PR TITLE
Make "Export with Debug" more visible in the Export dialog

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1298,12 +1298,12 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_project->connect("file_selected", this, "_export_project_to_path");
 	export_project->get_line_edit()->connect("text_changed", this, "_validate_export_path");
 
-	export_debug = memnew(CheckButton);
+	export_debug = memnew(CheckBox);
 	export_debug->set_text(TTR("Export With Debug"));
 	export_debug->set_pressed(true);
 	export_project->get_vbox()->add_child(export_debug);
 
-	export_pck_zip_debug = memnew(CheckButton);
+	export_pck_zip_debug = memnew(CheckBox);
 	export_pck_zip_debug->set_text(TTR("Export With Debug"));
 	export_pck_zip_debug->set_pressed(true);
 	export_pck_zip->get_vbox()->add_child(export_pck_zip_debug);

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -141,8 +141,8 @@ private:
 
 	FileDialog *export_pck_zip;
 	FileDialog *export_project;
-	CheckButton *export_debug;
-	CheckButton *export_pck_zip_debug;
+	CheckBox *export_debug;
+	CheckBox *export_pck_zip_debug;
 
 	void _open_export_template_manager();
 


### PR DESCRIPTION
This swaps out the CheckButton with a CheckBox, which has two benefits:

- The checkbox icon appears to the left of the text, which moves it closer from the text. This makes it more easily noticeable, as it also appears below the "File:" text now.
- It follows the UI convention of [using checkboxes for options that do not bear an immediate effect](https://uxmovement.com/buttons/when-to-use-a-switch-or-checkbox/), unlike CheckButtons which are expected to have an immediate effect when toggled.

This closes #25170.

### Preview

![export_with_debug_checkbox](https://user-images.githubusercontent.com/180032/51446187-e2016280-1d0e-11e9-998c-c0ca627cf358.png)

The colored text is still not easy to see, but that's a theme issue which can be seen in other places.