### PR TITLE
Workaround for bug with Mono's MSBuild and BaseIntermediateOutputPath

### DIFF
--- a/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
@@ -257,7 +257,7 @@ namespace GodotSharpTools.Build
             if (null == Parameters)
                 throw new LoggerException("Log directory was not set.");
 
-            string[] parameters = Parameters.Split(';');
+            string[] parameters = Parameters.Split(new[] { ';' });
 
             string logDir = parameters[0];
 

--- a/modules/mono/editor/GodotSharpTools/Project/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotSharpTools/Project/ProjectGenerator.cs
@@ -21,6 +21,7 @@ namespace GodotSharpTools.Project
             mainGroup.AddProperty("DocumentationFile", Path.Combine("$(OutputPath)", "$(AssemblyName).xml"));
             mainGroup.SetProperty("RootNamespace", "Godot");
             mainGroup.SetProperty("ProjectGuid", CoreApiProjectGuid);
+            mainGroup.SetProperty("BaseIntermediateOutputPath", "obj");
 
             GenAssemblyInfoFile(root, dir, CoreApiProjectName,
                                 new string[] { "[assembly: InternalsVisibleTo(\"" + EditorApiProjectName + "\")]" },
@@ -46,6 +47,7 @@ namespace GodotSharpTools.Project
             mainGroup.AddProperty("DocumentationFile", Path.Combine("$(OutputPath)", "$(AssemblyName).xml"));
             mainGroup.SetProperty("RootNamespace", "Godot");
             mainGroup.SetProperty("ProjectGuid", EditorApiProjectGuid);
+            mainGroup.SetProperty("BaseIntermediateOutputPath", "obj");
 
             GenAssemblyInfoFile(root, dir, EditorApiProjectName);
 

--- a/modules/mono/editor/csharp_project.cpp
+++ b/modules/mono/editor/csharp_project.cpp
@@ -228,6 +228,15 @@ Error generate_scripts_metadata(const String &p_project_path, const String &p_ou
 	if (new_dict.size()) {
 		String json = JSON::print(new_dict, "", false);
 
+		String base_dir = p_output_path.get_base_dir();
+
+		if (!DirAccess::exists(base_dir)) {
+			DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+
+			Error err = da->make_dir_recursive(base_dir);
+			ERR_FAIL_COND_V(err != OK, ERR_CANT_CREATE);
+		}
+
 		Error ferr;
 		FileAccess *f = FileAccess::open(p_output_path, FileAccess::WRITE, &ferr);
 		ERR_EXPLAIN("Cannot open file for writing: " + p_output_path);


### PR DESCRIPTION
Fixes #21834

For some reason `BaseIntermediateOutputPath` seems to be empty by default with Mono's MSBuild, so it was trying to write to `\Release` rather than `obj\Release`. This looks like a Mono bug.
