### PR TITLE
Removed add-to-favorites from root directory (res://) context menu.

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2044,7 +2044,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 		}
 	}
 
-	if (p_paths.size() >= 1) {
+	if (p_paths.size() >= 1 && path != "res://") {
 		if (!all_favorites) {
 			p_popup->add_item(TTR("Add to favorites"), FILE_ADD_FAVORITE);
 		}


### PR DESCRIPTION
IMO, tagging 'res://' as favorites in FileSystem Dock doesn't make sense, as we can find it quickly and also it's always visible (can't be hidden).

![add_to_favorites_-_removed](https://user-images.githubusercontent.com/44079549/51491359-b64ead00-1de0-11e9-8d5c-4e32d57bcdba.png)

