### PR TITLE
webgl1 in firefox doesn't like backslashes in #define directive

### DIFF
--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -433,19 +433,14 @@ FRAGMENT_SHADER_CODE
 
 #ifdef SHADOW_USE_GRADIENT
 
-#define SHADOW_TEST(m_ofs)                                                    \
-	{                                                                         \
-		highp float sd = SHADOW_DEPTH(shadow_texture, vec2(m_ofs, sh));       \
-		shadow_attenuation += 1.0 - smoothstep(sd, sd + shadow_gradient, sz); \
-	}
+		/* clang-format off */
+		/* GLSL es 100 doesn't support line continuation characters(backslashes) */
+#define SHADOW_TEST(m_ofs) { highp float sd = SHADOW_DEPTH(shadow_texture, vec2(m_ofs, sh)); shadow_attenuation += 1.0 - smoothstep(sd, sd + shadow_gradient, sz); }
 
 #else
 
-#define SHADOW_TEST(m_ofs)                                              \
-	{                                                                   \
-		highp float sd = SHADOW_DEPTH(shadow_texture, vec2(m_ofs, sh)); \
-		shadow_attenuation += step(sz, sd);                             \
-	}
+#define SHADOW_TEST(m_ofs) { highp float sd = SHADOW_DEPTH(shadow_texture, vec2(m_ofs, sh)); shadow_attenuation += step(sz, sd); }
+		/* clang-format on */
 
 #endif
 


### PR DESCRIPTION
According to https://www.khronos.org/registry/OpenGL/specs/es/2.0/GLSL_ES_Specification_1.00.pdf , backslashes aren't necessary supported as line continuation characters in preprocessor directives.

Firefox couldn't compile the shader because of this. In the pdf search for "line continuation".