### PR TITLE
Mono: Add assembly reloading to running games

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -608,30 +608,9 @@ struct CSharpScriptDepSort {
 void CSharpLanguage::reload_all_scripts() {
 
 #ifdef DEBUG_ENABLED
-
-	List<Ref<CSharpScript> > scripts;
-
-	{
-		SCOPED_MUTEX_LOCK(script_instances_mutex);
-
-		SelfList<CSharpScript> *elem = script_list.first();
-		while (elem) {
-			if (elem->self()->get_path().is_resource_file()) {
-				scripts.push_back(Ref<CSharpScript>(elem->self())); //cast to gdscript to avoid being erased by accident
-			}
-			elem = elem->next();
-		}
+	if (is_assembly_reloading_needed()) {
+		reload_assemblies(false);
 	}
-
-	//as scripts are going to be reloaded, must proceed without locking here
-
-	scripts.sort_custom<CSharpScriptDepSort>(); //update in inheritance dependency order
-
-	for (List<Ref<CSharpScript> >::Element *E = scripts.front(); E; E = E->next()) {
-		E->get()->load_source_code(E->get()->get_path());
-		E->get()->reload(true);
-	}
-
 #endif
 }
 
@@ -829,7 +808,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 						CSharpScript::StateBackup &state_backup = scr->pending_reload_state[obj_id];
 
 						// Backup placeholder script instance state before replacing it with a script instance
-						obj->get_script_instance()->get_property_state(state_backup.properties);
+						si->get_property_state(state_backup.properties);
 
 						ScriptInstance *script_instance = scr->instance_create(obj);
 

--- a/modules/mono/editor/mono_bottom_panel.cpp
+++ b/modules/mono/editor/mono_bottom_panel.cpp
@@ -30,6 +30,9 @@
 
 #include "mono_bottom_panel.h"
 
+#include "editor/plugins/script_editor_plugin.h"
+#include "editor/script_editor_debugger.h"
+
 #include "../csharp_script.h"
 #include "../godotsharp_dirs.h"
 #include "csharp_project.h"
@@ -160,7 +163,12 @@ void MonoBottomPanel::_build_project_pressed() {
 	bool build_success = GodotSharpBuilds::get_singleton()->build_project_blocking("Tools");
 
 	if (build_success) {
+		// Notify running game for hot-reload
+		ScriptEditor::get_singleton()->get_debugger()->reload_scripts();
+
+		// Hot-reload in the editor
 		MonoReloadNode::get_singleton()->restart_reload_timer();
+
 		if (CSharpLanguage::get_singleton()->is_assembly_reloading_needed()) {
 			CSharpLanguage::get_singleton()->reload_assemblies(false);
 		}

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -130,9 +130,14 @@ void gdmono_debug_init() {
 	}
 #endif
 
-	CharString da_args = String("--debugger-agent=transport=dt_socket,address=127.0.0.1:" + itos(da_port) +
-								",embedding=1,server=y,suspend=" + (da_suspend ? "y,timeout=" + itos(da_timeout) : "n"))
-								 .utf8();
+	CharString da_args = OS::get_singleton()->get_environment("GODOT_MONO_DEBUGGER_AGENT").utf8();
+
+	if (da_args == "") {
+		da_args = String("--debugger-agent=transport=dt_socket,address=127.0.0.1:" + itos(da_port) +
+						 ",embedding=1,server=y,suspend=" + (da_suspend ? "y,timeout=" + itos(da_timeout) : "n"))
+						  .utf8();
+	}
+
 	// --debugger-agent=help
 	const char *options[] = {
 		"--soft-breakpoints",


### PR DESCRIPTION
Add environment variable to specify a custom `--debugger-agent` for mono.

Keep in mind, restoring the state of instances is not implemented yet, so state is lost on reload.
