### PR TITLE
Fix going to script line on VisualScript errors

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -301,7 +301,7 @@ void ScriptEditor::_goto_script_line2(int p_line) {
 void ScriptEditor::_goto_script_line(REF p_script, int p_line) {
 
 	Ref<Script> script = Object::cast_to<Script>(*p_script);
-	if (!script.is_null() && script->has_source_code()) {
+	if (script.is_valid() && (script->has_source_code() || script->get_path().is_resource_file())) {
 		if (edit(p_script, p_line, 0)) {
 			editor->push_item(p_script.ptr());
 


### PR DESCRIPTION
Fixes #18103, which was a regression from #16888.

I've confirmed that #15784 is still fixed.