### PR TITLE
WebGL1 some changes

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -524,7 +524,11 @@ bool RasterizerSceneGLES2::reflection_probe_instance_begin_render(RID p_instance
 		glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
 
 		glBindRenderbuffer(GL_RENDERBUFFER, rpi->depth); //resize depth buffer
+#ifdef JAVASCRIPT_ENABLED
+		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, size, size);
+#else
 		glRenderbufferStorage(GL_RENDERBUFFER, _DEPTH_COMPONENT24_OES, size, size);
+#endif
 
 		for (int i = 0; i < 6; i++) {
 			glBindFramebuffer(GL_FRAMEBUFFER, rpi->fbo[i]);

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4007,7 +4007,11 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 
 	glGenRenderbuffers(1, &rt->depth);
 	glBindRenderbuffer(GL_RENDERBUFFER, rt->depth);
+#ifdef JAVASCRIPT_ENABLED
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, rt->width, rt->height);
+#else
 	glRenderbufferStorage(GL_RENDERBUFFER, _DEPTH_COMPONENT24_OES, rt->width, rt->height);
+#endif
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth);
 
 	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
@@ -4218,7 +4222,11 @@ RID RasterizerStorageGLES2::canvas_light_shadow_buffer_create(int p_width) {
 
 	glGenRenderbuffers(1, &cls->depth);
 	glBindRenderbuffer(GL_RENDERBUFFER, cls->depth);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, cls->size, cls->height);
+#ifdef JAVASCRIPT_ENABLED
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, cls->size, cls->height);
+#else
+	glRenderbufferStorage(GL_RENDERBUFFER, _DEPTH_COMPONENT24_OES, cls->size, cls->height);
+#endif
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, cls->depth);
 	glBindRenderbuffer(GL_RENDERBUFFER, 0);
 

--- a/drivers/gles2/shaders/cubemap_filter.glsl
+++ b/drivers/gles2/shaders/cubemap_filter.glsl
@@ -25,9 +25,17 @@ void main() {
 /* clang-format off */
 [fragment]
 
-#extension GL_ARB_shader_texture_lod : enable
+#ifdef GL_EXT_shader_texture_lod
+#extension GL_EXT_shader_texture_lod : enable
+#define texture2DLod(img, coord, lod) texture2DLodEXT(img, coord, lod)
+#define textureCubeLod(img, coord, lod) textureCubeLodEXT(img, coord, lod)
+#endif
 
-#ifndef GL_ARB_shader_texture_lod
+#ifdef GL_ARB_shader_texture_lod
+#extension GL_ARB_shader_texture_lod : enable
+#endif
+
+#if !defined(GL_EXT_shader_texture_lod) && !defined(GL_ARB_shader_texture_lod)
 #define texture2DLod(img, coord, lod) texture2D(img, coord)
 #define textureCubeLod(img, coord, lod) textureCube(img, coord)
 #endif
@@ -118,7 +126,13 @@ vec3 texelCoordToVec(vec2 uv, int faceID) {
 	faceUvVectors[5][2] = vec3(0.0, 0.0, 1.0); // +z face
 
 	// out = u * s_faceUv[0] + v * s_faceUv[1] + s_faceUv[2].
-	vec3 result = (faceUvVectors[faceID][0] * uv.x) + (faceUvVectors[faceID][1] * uv.y) + faceUvVectors[faceID][2];
+	vec3 result;
+	for (int i = 0; i < 6; i++) {
+		if (i == faceID) {
+			result = (faceUvVectors[i][0] * uv.x) + (faceUvVectors[i][1] * uv.y) + faceUvVectors[i][2];
+			break;
+		}
+	}
 	return normalize(result);
 }
 


### PR DESCRIPTION
glRenderBufferStorage in WebGl1 doesn't accept the rejected _DEPTH_COMPONENT24_OES extension, so I changed it to GL_DEPTH_COMPONENT16
https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/renderbufferStorage
https://www.khronos.org/registry/webgl/extensions/rejected/OES_depth24/

Enabled ext_shader_texture_lod extension. I guess it does the same like the GL_ARB_shader_texture_lod extension, but in WebGL1
https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/

And last WebGL1 doesn't allow indexes not constant, so I changed it into a loop reading this:
https://stackoverflow.com/questions/19529690/index-expression-must-be-constant-webgl-glsl-error

Those fixed almost all errors I had in a simple 2d game, and now it is running, but I don't know if they are correct, because I have no idea of opengl programming, so review @reduz 