### PR TITLE
base64.h: Fix return type mismatch

### DIFF
--- a/thirdparty/misc/base64.h
+++ b/thirdparty/misc/base64.h
@@ -11,8 +11,8 @@
 
 extern "C" {
 
-uint32_t base64_encode(char *to, char *from, uint32_t len);
-uint32_t base64_decode(char *to, char *from, uint32_t len);
+long base64_encode(char *to, char *from, unsigned int len);
+long base64_decode(char *to, char *from, unsigned int len);
 };
 
 #endif /* BASE64_H */


### PR DESCRIPTION
Fixes #25220.

Seems that it was our own mistake when writing this header, the one provided by upstream uses `long`: http://episec.com/people/edelkind/arc/c/misc/base64.h