### PR TITLE
Fixed possible crash in pck_packer.cpp due to wrong memory freeing.

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -175,7 +175,7 @@ Error PCKPacker::flush(bool p_verbose) {
 		printf("\n");
 
 	file->close();
-	memdelete(buf);
+	memdelete_arr(buf);
 
 	return OK;
 };


### PR DESCRIPTION
**memdelete_arr** must be used instead of **memdelete**.