### PR TITLE
Set WINVER and _WIN32_WINNT values in VS project

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -208,8 +208,8 @@ def configure_msvc(env, manual_msvc_config):
                                    'RTAUDIO_ENABLED', 'WASAPI_ENABLED',
                                    'WINMIDI_ENABLED', 'TYPED_METHOD_BIND',
                                    'WIN32', 'MSVC',
-                                   'WINVER=$target_win_version',
-                                   '_WIN32_WINNT=$target_win_version'])
+                                   'WINVER=%s' % env["target_win_version"],
+                                   '_WIN32_WINNT=%s' % env["target_win_version"]])
     env.AppendUnique(CPPDEFINES=['NOMINMAX']) # disable bogus min/max WinDef.h macros
     if env["bits"] == "64":
         env.AppendUnique(CPPDEFINES=['_WIN64'])


### PR DESCRIPTION
While looking into a different issue, I've noticed that Visual Studio Intellisense does not work well for Godot project when using Windows Vista+ APIs (e.g. CreateThreadpool), i.e. it does not recognise the APIs because they are defined in Windows header files for Vista+ only.

This is because the WINVER and _WIN32_WINNT symbols don't have their values set in the generated Godot project file. This fixes the problem by setting the values when generating the project file.