### PR TITLE
Use dedicated threadpool for Godot threads

### DIFF
--- a/drivers/windows/thread_windows.cpp
+++ b/drivers/windows/thread_windows.cpp
@@ -33,6 +33,13 @@
 #if defined(WINDOWS_ENABLED) && !defined(UWP_ENABLED)
 
 #include "core/os/memory.h"
+#include "core/project_settings.h"
+
+TP_CALLBACK_ENVIRON env;
+PTP_CLEANUP_GROUP group = NULL;
+PTP_POOL pool = NULL;
+
+const DWORD MaximumThreads = 512;
 
 Thread::ID ThreadWindows::get_id() const {
 
@@ -44,19 +51,17 @@ Thread *ThreadWindows::create_thread_windows() {
 	return memnew(ThreadWindows);
 }
 
-DWORD ThreadWindows::thread_callback(LPVOID userdata) {
+void NTAPI ThreadWindows::thread_callback(PTP_CALLBACK_INSTANCE Instance, PVOID Context, PTP_WORK Work) {
 
-	ThreadWindows *t = reinterpret_cast<ThreadWindows *>(userdata);
+	ThreadWindows *t = reinterpret_cast<ThreadWindows *>(Context);
+	SetEventWhenCallbackReturns(Instance, t->handle);
 
 	ScriptServer::thread_enter(); //scripts may need to attach a stack
 
 	t->id = (ID)GetCurrentThreadId(); // must implement
 	t->callback(t->user);
-	SetEvent(t->handle);
 
 	ScriptServer::thread_exit();
-
-	return 0;
 }
 
 Thread *ThreadWindows::create_func_windows(ThreadCreateCallback p_callback, void *p_user, const Settings &) {
@@ -66,7 +71,8 @@ Thread *ThreadWindows::create_func_windows(ThreadCreateCallback p_callback, void
 	tr->user = p_user;
 	tr->handle = CreateEvent(NULL, TRUE, FALSE, NULL);
 
-	QueueUserWorkItem(thread_callback, tr, WT_EXECUTELONGFUNCTION);
+	PTP_WORK work = CreateThreadpoolWork(thread_callback, tr, &env);
+	SubmitThreadpoolWork(work);
 
 	return tr;
 }
@@ -83,7 +89,34 @@ void ThreadWindows::wait_to_finish_func_windows(Thread *p_thread) {
 	//`memdelete(tp);
 }
 
+void ThreadWindows::cleanup() {
+	CloseThreadpoolCleanupGroupMembers(group, TRUE, NULL);
+	CloseThreadpoolCleanupGroup(group);
+	CloseThreadpool(pool);
+}
+
+void ThreadWindows::initialize() {
+	const DWORD minThreads = MAX(0, (int)GLOBAL_DEF("thread_pool/min", 0));
+	const DWORD maxThreads = MAX(minThreads, MaximumThreads);
+
+	SetThreadpoolThreadMaximum(pool, maxThreads);
+	SetThreadpoolThreadMinimum(pool, minThreads);
+}
+
 void ThreadWindows::make_default() {
+	InitializeThreadpoolEnvironment(&env);
+
+	group = CreateThreadpoolCleanupGroup();
+	ERR_FAIL_COND(!group);
+
+	pool = CreateThreadpool(NULL);
+	ERR_FAIL_COND(!pool);
+
+	SetThreadpoolThreadMaximum(pool, MaximumThreads);
+	SetThreadpoolThreadMinimum(pool, 1);
+
+	SetThreadpoolCallbackPool(&env, pool);
+	SetThreadpoolCallbackCleanupGroup(&env, group, NULL);
 
 	create_func = create_func_windows;
 	get_thread_id_func = get_thread_id_func_windows;

--- a/drivers/windows/thread_windows.h
+++ b/drivers/windows/thread_windows.h
@@ -51,7 +51,7 @@ class ThreadWindows : public Thread {
 
 	static Thread *create_thread_windows();
 
-	static DWORD WINAPI thread_callback(LPVOID userdata);
+	static void NTAPI thread_callback(PTP_CALLBACK_INSTANCE Instance, PVOID Context, PTP_WORK Work);
 
 	static Thread *create_func_windows(ThreadCreateCallback p_callback, void *, const Settings &);
 	static ID get_thread_id_func_windows();
@@ -63,6 +63,9 @@ public:
 	virtual ID get_id() const;
 
 	static void make_default();
+
+	static void initialize();
+	static void cleanup();
 
 	~ThreadWindows();
 };

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1102,6 +1102,8 @@ int OS_Windows::get_current_video_driver() const {
 
 Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {
 
+	ThreadWindows::initialize();
+
 	main_loop = NULL;
 	outside = true;
 	window_has_focus = true;
@@ -1537,6 +1539,7 @@ void OS_Windows::finalize_core() {
 
 	memdelete(process_map);
 	NetSocketPosix::cleanup();
+	ThreadWindows::cleanup();
 }
 
 void OS_Windows::alert(const String &p_alert, const String &p_title) {


### PR DESCRIPTION
Follow up to #25213 which I didn't mean to close.

--

Alternative fix to #25117

Although the concept is the same (i.e. use a thread pool) this implementation uses a dedicated thread pool rather than the default one.

This is better than using QueueUserWorkItem because the dedicated thread pool can be set with a minimum number of threads that are pre-allocated to handle the queue work items.

The minimum number of threads is configured with "thread_pool/min" project setting. By default it's 0 (so for the first work item it works the same as CreateThread) but can be changed to a higher number for projects that use threads extensively.

Please note that this uses Windows Vista+ API however that shoulld be fine as Godot already seems to require Vista+ (I didn't know about it when implmenting #25117 and that's the reason why I'm proposing this alternative now).