### PR TITLE
theora: Add upstream patch to fix UB warning

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -202,6 +202,9 @@ Files extracted from upstream source:
 - all .h files in include/theora/ as theora/
 - COPYING and LICENSE
 
+Upstream patches included in the `patches` directory have been applied
+on top of the 1.1.1 source (not included in any stable release yet).
+
 
 ## libvorbis
 

--- a/thirdparty/libtheora/decode.c
+++ b/thirdparty/libtheora/decode.c
@@ -397,10 +397,10 @@ static int oc_dec_init(oc_dec_ctx *_dec,const th_info *_info,
     int qsum;
     qsum=0;
     for(qti=0;qti<2;qti++)for(pli=0;pli<3;pli++){
-      qsum+=_dec->state.dequant_tables[qti][pli][qi][12]+
-       _dec->state.dequant_tables[qti][pli][qi][17]+
-       _dec->state.dequant_tables[qti][pli][qi][18]+
-       _dec->state.dequant_tables[qti][pli][qi][24]<<(pli==0);
+      qsum+=_dec->state.dequant_tables[qi][pli][qti][12]+
+       _dec->state.dequant_tables[qi][pli][qti][17]+
+       _dec->state.dequant_tables[qi][pli][qti][18]+
+       _dec->state.dequant_tables[qi][pli][qti][24]<<(pli==0);
     }
     _dec->pp_sharp_mod[qi]=-(qsum>>11);
   }

--- a/thirdparty/libtheora/patches/theora.git-0ae66d565e6bead8604d312bc1a4e9dccf245c88.patch
+++ b/thirdparty/libtheora/patches/theora.git-0ae66d565e6bead8604d312bc1a4e9dccf245c88.patch
@@ -1,0 +1,38 @@
+From 0ae66d565e6bead8604d312bc1a4e9dccf245c88 Mon Sep 17 00:00:00 2001
+From: Tim Terriberry <tterribe@xiph.org>
+Date: Tue, 8 May 2012 02:51:57 +0000
+Subject: [PATCH] Fix pp_sharp_mod calculation.
+
+This was broken when the dequant_tables indexing changed in commit
+ r16102, but it only affected post-processing quality, so we never
+ noticed.
+With gcc 4.8.0, this can now trigger a segfault during decoder
+ initialization.
+
+svn path=/trunk/theora/; revision=18268
+---
+ decode.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/decode.c b/decode.c
+index b803505..9f2516a 100644
+--- a/decode.c
++++ b/decode.c
+@@ -400,10 +400,10 @@ static int oc_dec_init(oc_dec_ctx *_dec,const th_info *_info,
+     int qsum;
+     qsum=0;
+     for(qti=0;qti<2;qti++)for(pli=0;pli<3;pli++){
+-      qsum+=_dec->state.dequant_tables[qti][pli][qi][12]+
+-       _dec->state.dequant_tables[qti][pli][qi][17]+
+-       _dec->state.dequant_tables[qti][pli][qi][18]+
+-       _dec->state.dequant_tables[qti][pli][qi][24]<<(pli==0);
++      qsum+=_dec->state.dequant_tables[qi][pli][qti][12]+
++       _dec->state.dequant_tables[qi][pli][qti][17]+
++       _dec->state.dequant_tables[qi][pli][qti][18]+
++       _dec->state.dequant_tables[qi][pli][qti][24]<<(pli==0);
+     }
+     _dec->pp_sharp_mod[qi]=-(qsum>>11);
+   }
+-- 
+2.11.0
+


### PR DESCRIPTION
Patch from https://git.xiph.org/?p=theora.git;a=commit;h=0ae66d565e6bead8604d312bc1a4e9dccf245c88
Fixes #25221.