### PR TITLE
Create New Error Code Invalid Key

### DIFF
--- a/core/error_list.h
+++ b/core/error_list.h
@@ -88,6 +88,7 @@ enum Error {
 	ERR_HELP, ///< user requested help!!
 	ERR_BUG, ///< a bug in the software certainly happened, due to a double check failing or unexpected behavior.
 	ERR_PRINTER_ON_FIRE, /// the parallel port printer is engulfed in flames
+	ERR_INVALID_ENCRYPTION_KEY,
 };
 
 #endif

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -100,7 +100,7 @@ Error FileAccessEncrypted::open_and_parse(FileAccess *p_base, const Vector<uint8
 		MD5Update(&md5, (uint8_t *)data.ptr(), data.size());
 		MD5Final(&md5);
 
-		ERR_FAIL_COND_V(String::md5(md5.digest) != String::md5(md5d), ERR_FILE_CORRUPT);
+		ERR_FAIL_COND_V(String::md5(md5.digest) != String::md5(md5d), ERR_INVALID_ENCRYPTION_KEY);
 
 		file = p_base;
 	}


### PR DESCRIPTION
Addresses Issue #24505 by adding a new error code of 49 ERR_INVALID_ENCRYPTION_KEY to the error list and modifying the according error message to display the invalid encryption key instead of ERR_FILE_CORRUPT
_Bugsquad edit : Fix #24505_