### PR TITLE
Fix PhysicsBody ignoring deprecated set_friction/bounce with default value

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -188,7 +188,7 @@ PhysicsBody::PhysicsBody(PhysicsServer::BodyMode p_mode) :
 #ifndef DISABLE_DEPRECATED
 void StaticBody::set_friction(real_t p_friction) {
 
-	if (p_friction == 1.0) { // default value, don't create an override for that
+	if (p_friction == 1.0 && physics_material_override.is_null()) { // default value, don't create an override for that
 		return;
 	}
 
@@ -218,7 +218,7 @@ real_t StaticBody::get_friction() const {
 
 void StaticBody::set_bounce(real_t p_bounce) {
 
-	if (p_bounce == 0.0) { // default value, don't create an override for that
+	if (p_bounce == 0.0 && physics_material_override.is_null()) { // default value, don't create an override for that
 		return;
 	}
 
@@ -632,7 +632,7 @@ real_t RigidBody::get_weight() const {
 #ifndef DISABLE_DEPRECATED
 void RigidBody::set_friction(real_t p_friction) {
 
-	if (p_friction == 1.0) { // default value, don't create an override for that
+	if (p_friction == 1.0 && physics_material_override.is_null()) { // default value, don't create an override for that
 		return;
 	}
 
@@ -661,7 +661,7 @@ real_t RigidBody::get_friction() const {
 
 void RigidBody::set_bounce(real_t p_bounce) {
 
-	if (p_bounce == 0.0) { // default value, don't create an override for that
+	if (p_bounce == 0.0 && physics_material_override.is_null()) { // default value, don't create an override for that
 		return;
 	}
 


### PR DESCRIPTION
The intent was to avoid creating a physics override to set a default value
that doesn't make a difference, but as #22406 shows it can be necessary to
set the default value *back* after an override was created to set a non-default
value.

Fixes #22406.