### PR TITLE
Revert "Implement custom thread numbering for POSIX"

### DIFF
--- a/drivers/unix/thread_posix.cpp
+++ b/drivers/unix/thread_posix.cpp
@@ -38,16 +38,6 @@
 #endif
 
 #include "core/os/memory.h"
-#include "core/safe_refcount.h"
-
-static pthread_key_t _create_thread_id_key() {
-	pthread_key_t key;
-	pthread_key_create(&key, NULL);
-	return key;
-}
-
-pthread_key_t ThreadPosix::thread_id_key = _create_thread_id_key();
-Thread::ID ThreadPosix::next_thread_id = 0;
 
 Thread::ID ThreadPosix::get_id() const {
 
@@ -62,8 +52,7 @@ Thread *ThreadPosix::create_thread_posix() {
 void *ThreadPosix::thread_callback(void *userdata) {
 
 	ThreadPosix *t = reinterpret_cast<ThreadPosix *>(userdata);
-	t->id = atomic_increment(&next_thread_id);
-	pthread_setspecific(thread_id_key, (void *)t->id);
+	t->id = (ID)pthread_self();
 
 	ScriptServer::thread_enter(); //scripts may need to attach a stack
 
@@ -89,7 +78,7 @@ Thread *ThreadPosix::create_func_posix(ThreadCreateCallback p_callback, void *p_
 }
 Thread::ID ThreadPosix::get_thread_id_func_posix() {
 
-	return (ID)pthread_getspecific(thread_id_key);
+	return (ID)pthread_self();
 }
 void ThreadPosix::wait_to_finish_func_posix(Thread *p_thread) {
 

--- a/drivers/unix/thread_posix.h
+++ b/drivers/unix/thread_posix.h
@@ -43,9 +43,6 @@
 
 class ThreadPosix : public Thread {
 
-	static pthread_key_t thread_id_key;
-	static ID next_thread_id;
-
 	pthread_t pthread;
 	pthread_attr_t pthread_attr;
 	ThreadCreateCallback callback;

--- a/platform/android/thread_jandroid.cpp
+++ b/platform/android/thread_jandroid.cpp
@@ -31,17 +31,7 @@
 #include "thread_jandroid.h"
 
 #include "core/os/memory.h"
-#include "core/safe_refcount.h"
 #include "core/script_language.h"
-
-static pthread_key_t _create_thread_id_key() {
-	pthread_key_t key;
-	pthread_key_create(&key, NULL);
-	return key;
-}
-
-pthread_key_t ThreadAndroid::thread_id_key = _create_thread_id_key();
-Thread::ID ThreadAndroid::next_thread_id = 0;
 
 Thread::ID ThreadAndroid::get_id() const {
 
@@ -58,8 +48,7 @@ void *ThreadAndroid::thread_callback(void *userdata) {
 	ThreadAndroid *t = reinterpret_cast<ThreadAndroid *>(userdata);
 	setup_thread();
 	ScriptServer::thread_enter(); //scripts may need to attach a stack
-	t->id = atomic_increment(&next_thread_id);
-	pthread_setspecific(thread_id_key, (void *)t->id);
+	t->id = (ID)pthread_self();
 	t->callback(t->user);
 	ScriptServer::thread_exit();
 	return NULL;
@@ -80,7 +69,7 @@ Thread *ThreadAndroid::create_func_jandroid(ThreadCreateCallback p_callback, voi
 
 Thread::ID ThreadAndroid::get_thread_id_func_jandroid() {
 
-	return (ID)pthread_getspecific(thread_id_key);
+	return (ID)pthread_self();
 }
 
 void ThreadAndroid::wait_to_finish_func_jandroid(Thread *p_thread) {

--- a/platform/android/thread_jandroid.h
+++ b/platform/android/thread_jandroid.h
@@ -42,9 +42,6 @@
 
 class ThreadAndroid : public Thread {
 
-	static pthread_key_t thread_id_key;
-	static ID next_thread_id;
-
 	pthread_t pthread;
 	pthread_attr_t pthread_attr;
 	ThreadCreateCallback callback;


### PR DESCRIPTION
### Superseded by #25300

This reverts commit d806ad4a3dcf7308147e1a243092d22091560d7d.

As discussed on IRC, this is a temporary patch to fix #23709 until we can fix it properly.
