### PR TITLE
Improve custom thread numbering for POSIX

### DIFF
--- a/platform/android/thread_jandroid.cpp
+++ b/platform/android/thread_jandroid.cpp
@@ -34,9 +34,13 @@
 #include "core/safe_refcount.h"
 #include "core/script_language.h"
 
+static void _thread_id_key_destr_callback(void *p_value) {
+	memdelete(static_cast<Thread::ID *>(p_value));
+}
+
 static pthread_key_t _create_thread_id_key() {
 	pthread_key_t key;
-	pthread_key_create(&key, NULL);
+	pthread_key_create(&key, &_thread_id_key_destr_callback);
 	return key;
 }
 
@@ -59,7 +63,7 @@ void *ThreadAndroid::thread_callback(void *userdata) {
 	setup_thread();
 	ScriptServer::thread_enter(); //scripts may need to attach a stack
 	t->id = atomic_increment(&next_thread_id);
-	pthread_setspecific(thread_id_key, (void *)t->id);
+	pthread_setspecific(thread_id_key, (void *)memnew(ID(t->id)));
 	t->callback(t->user);
 	ScriptServer::thread_exit();
 	return NULL;
@@ -80,7 +84,14 @@ Thread *ThreadAndroid::create_func_jandroid(ThreadCreateCallback p_callback, voi
 
 Thread::ID ThreadAndroid::get_thread_id_func_jandroid() {
 
-	return (ID)pthread_getspecific(thread_id_key);
+	void *value = pthread_getspecific(thread_id_key);
+
+	if (value)
+		return *static_cast<ID *>(value);
+
+	ID new_id = atomic_increment(&next_thread_id);
+	pthread_setspecific(thread_id_key, (void *)memnew(ID(new_id)));
+	return new_id;
 }
 
 void ThreadAndroid::wait_to_finish_func_jandroid(Thread *p_thread) {


### PR DESCRIPTION
We lazily assign new IDs to threads that do not have one. This is the case for threads not created by the Godot API.

Rather than reverting d806ad4a3dcf7308147e1a243092d22091560d7d, this PR improves over it.

Supersedes #25299
Fixes #23709