### PR TITLE
Revert "Fix GLES3 error 502 on iOS"

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4172,7 +4172,7 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 		if (state.used_contact_shadows) {
 
 			glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->buffers.fbo);
-			glReadBuffer(GL_DEPTH_ATTACHMENT);
+			glReadBuffer(GL_COLOR_ATTACHMENT0);
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->fbo);
 			glBlitFramebuffer(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
 			glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);


### PR DESCRIPTION
Reverts godotengine/godot#25319

This is not the right answer either. glReadBuffer can only be set to GL_NONE, GL_BACK or GL_COLOR_ATTACHMENTi even though we're dealing with depth buffers. 

It looks like glBlitFrameBuffer just doesn't want to play nice on iOS.. 