### PR TITLE
Changed ImageTexture image cache type to the correct one, fixes #24971

### DIFF
--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -111,7 +111,7 @@ private:
 	Size2 size_override;
 	float lossy_storage_quality;
 	mutable Ref<BitMap> alpha_cache;
-	Ref<ImageTexture> image_cache;
+	Ref<Image> image_cache;
 
 protected:
 	virtual void reload_from_file();


### PR DESCRIPTION
The original attempt to fix the issue was accidentally using the wrong
type for the image cache. This change fixes that.