### PR TITLE
Workaround GCC 6 & 7 ICE on armv7hl

### DIFF
--- a/modules/gdnative/gdnative/variant.cpp
+++ b/modules/gdnative/gdnative/variant.cpp
@@ -37,7 +37,21 @@
 extern "C" {
 #endif
 
+// Workaround GCC ICE on armv7hl which was affected GCC 6.0 up to 8.0 (GH-16100).
+// It was fixed upstream in 8.1, and a fix was backported to 7.4.
+// This can be removed once no supported distro ships with versions older than 7.4.
+#if defined(__arm__) && defined(__GNUC__) && !defined(__clang__) && \
+		(__GNUC__ == 6 || (__GNUC__ == 7 && __GNUC_MINOR__ < 4) || (__GNUC__ == 8 && __GNUC_MINOR__ < 1))
+#pragma GCC push_options
+#pragma GCC optimize("-O0")
+#endif
+
 #define memnew_placement_custom(m_placement, m_class, m_constr) _post_initialize(new (m_placement, sizeof(m_class), "") m_constr)
+
+#if defined(__arm__) && defined(__GNUC__) && !defined(__clang__) && \
+		(__GNUC__ == 6 || (__GNUC__ == 7 && __GNUC_MINOR__ < 4) || (__GNUC__ == 8 && __GNUC_MINOR__ < 1))
+#pragma GCC pop_options
+#endif
 
 // Constructors
 


### PR DESCRIPTION
Fixes #16100.

I couldn't test it yet myself, I'll see if I can push a build on Fedora's Koji against an older Fedora still using GCC 6 or 7.
Or if someone wants to try it on Raspbian in the meantime, that would be welcome :) (CC @efornara)