### PR TITLE
Fix ColorPicker's raw mode

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -178,9 +178,7 @@ void ColorPicker::_update_color() {
 	for (int i = 0; i < 4; i++) {
 		if (raw_mode_enabled) {
 			scroll[i]->set_step(0.01);
-			scroll[i]->set_max(100);
-			if (i == 3)
-				scroll[i]->set_max(1);
+			scroll[i]->set_max(1);
 			scroll[i]->set_value(color.components[i]);
 		} else {
 			scroll[i]->set_step(1);


### PR DESCRIPTION
Now the values are correctly set at 1 max, instead of 100. Fixes #21860.