### PR TITLE
Fix TabContainer's get_minimum_size function

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -787,6 +787,12 @@ Size2 TabContainer::get_minimum_size() const {
 	Size2 ms;
 
 	Vector<Control *> tabs = _get_tabs();
+	if (tabs.size() <= 2) {
+		ms.x = 0;
+		ms.y = 0;
+		return ms;
+	}
+
 	for (int i = 0; i < tabs.size(); i++) {
 
 		Control *c = tabs[i];


### PR DESCRIPTION
tab_container get_minimum_size function seems broken for fewer tabs container returning it as zero fixes #25281 and #25317