### PR TITLE
Fix "Auto Brace Complete" inserting extra quotation character sometimes in a string.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1494,8 +1494,7 @@ void TextEdit::_consume_pair_symbol(CharType ch) {
 	}
 
 	if ((ch == '\'' || ch == '"') &&
-			cursor_get_column() > 0 &&
-			_is_text_char(text[cursor.line][cursor_get_column() - 1])) {
+			cursor_get_column() > 0 && _is_text_char(text[cursor.line][cursor_get_column() - 1]) && !_is_pair_right_symbol(text[cursor.line][cursor_get_column()])) {
 		insert_text_at_cursor(ch_single);
 		cursor_set_column(cursor_position_to_move);
 		return;


### PR DESCRIPTION
Brace completion for quotation marks was introducing another quotation mark at the end of the string, I think because it wasn't checking that the quotation mark didn't exist at the current cursors position. Simple change, first attempt at contributing to Godot so apologies for anything wrong. 

Fixes #25084