### PR TITLE
Profiler list functions from max to less expensive

### DIFF
--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -392,7 +392,7 @@ void EditorProfiler::_update_frame() {
 			category->set_custom_color(0, _get_color_from_signature(m.categories[i].signature));
 		}
 
-		for (int j = 0; j < m.categories[i].items.size(); j++) {
+		for (int j = m.categories[i].items.size() - 1; j >= 0; j--) {
 			const Metric::Category::Item &it = m.categories[i].items[j];
 
 			TreeItem *item = variables->create_item(category);


### PR DESCRIPTION
Solves https://github.com/godotengine/godot/issues/25328 and partially  https://github.com/godotengine/godot/issues/5682

All profiler items are inverted from max expensive to less expensive.