### PR TITLE
Make some small enhancements to the ColorPicker

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5635,7 +5635,7 @@ EditorNode::EditorNode() {
 	bottom_panel->add_child(bottom_panel_vb);
 
 	bottom_panel_hb = memnew(HBoxContainer);
-	bottom_panel_hb->set_custom_minimum_size(Size2(0, 24)); // Adjust for the height of the "Expand Bottom Dock" icon.
+	bottom_panel_hb->set_custom_minimum_size(Size2(0, 24 * EDSCALE)); // Adjust for the height of the "Expand Bottom Dock" icon.
 	bottom_panel_vb->add_child(bottom_panel_hb);
 
 	bottom_panel_hb_editors = memnew(HBoxContainer);


### PR DESCRIPTION
- Make the hexadecimal/code toggle actually look like a clickable button. Also hide it together with color `LineEdit`.
- Make the color `LineEdit` uneditable when in code mode.
- Fix #21860 (for real this time).
- Fix color LineEdit setting all values to 0 when focus is lost in code mode.
- Add some tooltips.