### PR TITLE
Fix S3TC texture loading for WebGL

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -195,11 +195,11 @@ Ref<Image> RasterizerStorageGLES2::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_DXT1: {
 
-			r_compressed = true;
 			if (config.s3tc_supported) {
 				r_gl_internal_format = _EXT_COMPRESSED_RGBA_S3TC_DXT1_EXT;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
+				r_compressed = true;
 			} else {
 				need_decompress = true;
 			}
@@ -4868,8 +4868,8 @@ void RasterizerStorageGLES2::initialize() {
 	config.etc1_supported = false;
 #else
 	config.float_texture_supported = config.extensions.has("GL_ARB_texture_float") || config.extensions.has("GL_OES_texture_float");
-	config.s3tc_supported = config.extensions.has("GL_EXT_texture_compression_s3tc");
-	config.etc1_supported = config.extensions.has("GL_OES_compressed_ETC1_RGB8_texture");
+	config.s3tc_supported = config.extensions.has("GL_EXT_texture_compression_s3tc") || config.extensions.has("WEBGL_compressed_texture_s3tc");
+	config.etc1_supported = config.extensions.has("GL_OES_compressed_ETC1_RGB8_texture") || config.extensions.has("WEBGL_compressed_texture_etc1");
 #endif
 #ifdef GLES_OVER_GL
 	config.use_rgba_2d_shadows = false;


### PR DESCRIPTION
fixes #25321

Reordering the ```r_compressed = true;``` line made the texture load, but then noticed that glCompressedTex was actually never called (it was getting cpu decompressed), and indeed ```config.s3tc_supported``` was always false on the web build.

Also added WEBGL_compressed_texture_etc1 but actually I didnt try it and dont know if the enums are compatible.