### PR TITLE
Mono: Test Windows binaries with lowercase extension

### DIFF
--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -59,7 +59,7 @@ String path_which(const String &p_name) {
 
 #ifdef WINDOWS_ENABLED
 		for (int j = 0; j < exts.size(); j++) {
-			String p2 = p + exts[j];
+			String p2 = p + exts[j].to_lower(); // lowercase to reduce risk of case mismatch warning
 
 			if (FileAccess::exists(p2))
 				return p2;


### PR DESCRIPTION
To help users writing good cross-platform code, Godot's
`FileAccessWindows:open()` will issue a warning on case mismatch, which
happens here with capitalized extensions given by `PATHEXT` compared to
actual file extensions which are lowercase 99% of the time.

Fixes #25368.

I went for the workaround solution, but IMO it should be good enough.