### PR TITLE
Update docs and errors for WebSocket module

### DIFF
--- a/modules/websocket/doc_classes/WebSocketClient.xml
+++ b/modules/websocket/doc_classes/WebSocketClient.xml
@@ -25,7 +25,8 @@
 			</argument>
 			<description>
 				Connect to the given URL requesting one of the given [code]protocols[/code] as sub-protocol.
-				If [code]true[/code], is passed as [code]gd_mp_api[/code], the client will behave like a network peer for the [MultiplayerAPI]. Note: connections to non Godot servers will not work, and [signal data_received] will not be emitted when this option is true.
+				If [code]true[/code] is passed as [code]gd_mp_api[/code], the client will behave like a network peer for the [MultiplayerAPI], connections to non Godot servers will not work, and [signal data_received] will not be emitted.
+				If [code]false[/code] is passed instead (default), you must call [PacketPeer] functions ([code]put_packet[/code], [code]get_packet[/code], etc.) on the [WebSocketPeer] returned via [code]get_peer(1)[/code] and not on this object directly (e.g. [code]get_peer(1).put_packet(data)[/code]).
 			</description>
 		</method>
 		<method name="disconnect_from_host">

--- a/modules/websocket/doc_classes/WebSocketServer.xml
+++ b/modules/websocket/doc_classes/WebSocketServer.xml
@@ -72,7 +72,8 @@
 			<description>
 				Start listening on the given port.
 				You can specify the desired subprotocols via the "protocols" array. If the list empty (default), "binary" will be used.
-				You can use this server as a network peer for [MultiplayerAPI] by passing [code]true[/code] as [code]gd_mp_api[/code]. Note: [signal data_received] will not be fired and clients other than Godot will not work in this case.
+				If [code]true[/code] is passed as [code]gd_mp_api[/code], the server will behave like a network peer for the [MultiplayerAPI], connections from non Godot clients will not work, and [signal data_received] will not be emitted.
+				If [code]false[/code] is passed instead (default), you must call [PacketPeer] functions ([code]put_packet[/code], [code]get_packet[/code], etc.), on the [WebSocketPeer] returned via [code]get_peer(ID)[/code] to communicate with the peer with given [code]ID[/code] (e.g. [code]get_peer(ID).get_available_packet_count[/code]).
 			</description>
 		</method>
 		<method name="stop">

--- a/modules/websocket/websocket_multiplayer.cpp
+++ b/modules/websocket/websocket_multiplayer.cpp
@@ -96,6 +96,7 @@ void WebSocketMultiplayerPeer::_bind_methods() {
 //
 int WebSocketMultiplayerPeer::get_available_packet_count() const {
 
+	ERR_EXPLAIN("Please use get_peer(ID).get_available_packet_count to get available packet count from peers when not using the MultiplayerAPI.");
 	ERR_FAIL_COND_V(!_is_multiplayer, ERR_UNCONFIGURED);
 
 	return _incoming_packets.size();
@@ -103,8 +104,10 @@ int WebSocketMultiplayerPeer::get_available_packet_count() const {
 
 Error WebSocketMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 
-	r_buffer_size = 0;
+	ERR_EXPLAIN("Please use get_peer(ID).get_packet/var to communicate with peers when not using the MultiplayerAPI.");
 	ERR_FAIL_COND_V(!_is_multiplayer, ERR_UNCONFIGURED);
+
+	r_buffer_size = 0;
 
 	if (_current_packet.data != NULL) {
 		memfree(_current_packet.data);
@@ -122,6 +125,7 @@ Error WebSocketMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buff
 
 Error WebSocketMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 
+	ERR_EXPLAIN("Please use get_peer(ID).put_packet/var to communicate with peers when not using the MultiplayerAPI.");
 	ERR_FAIL_COND_V(!_is_multiplayer, ERR_UNCONFIGURED);
 
 	PoolVector<uint8_t> buffer = _make_pkt(SYS_NONE, get_unique_id(), _target_peer, p_buffer, p_buffer_size);
@@ -154,6 +158,7 @@ void WebSocketMultiplayerPeer::set_target_peer(int p_target_peer) {
 
 int WebSocketMultiplayerPeer::get_packet_peer() const {
 
+	ERR_EXPLAIN("This function is not available when not using the MultiplayerAPI.");
 	ERR_FAIL_COND_V(!_is_multiplayer, 1);
 	ERR_FAIL_COND_V(_incoming_packets.size() == 0, 1);
 


### PR DESCRIPTION
Specify that you must call Peer functions on the result of `get_peer` when not using the multiplayer API.

Closes #20289