### PR TITLE
Fix EditorInspector property_changed argument mismatch

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2010,7 +2010,7 @@ void EditorInspector::_property_changed(const String &p_path, const Variant &p_v
 	}
 }
 
-void EditorInspector::_property_changed_update_all(const String &p_path, const Variant &p_value) {
+void EditorInspector::_property_changed_update_all(const String &p_path, const Variant &p_value, const String &p_name, bool p_changing) {
 	update_tree();
 }
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -302,7 +302,7 @@ class EditorInspector : public ScrollContainer {
 	void _edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field);
 
 	void _property_changed(const String &p_path, const Variant &p_value, const String &p_name = "", bool changing = false);
-	void _property_changed_update_all(const String &p_path, const Variant &p_value);
+	void _property_changed_update_all(const String &p_path, const Variant &p_value, const String &p_name = "", bool p_changing = false);
 	void _multiple_properties_changed(Vector<String> p_paths, Array p_values);
 	void _property_keyed(const String &p_path, bool p_advance);
 	void _property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance);


### PR DESCRIPTION
Bug introduced in #21701, missed in 541422a4a28c873142af9bfc988468b3e9e05948.

Fixes this error:
```
ERROR: _call_function: Error calling deferred method: 'EditorInspector::_property_changed_update_all': Method expected 2 arguments, but called with 4.
   At: core/message_queue.cpp:259.
```
e.g. when changing the `frames` property of an AnimatedTexture.