### PR TITLE
Fix polygon drawing on WebGL1

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -112,15 +112,6 @@ void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid 
 	}, target, offset, data, size);
 	/* clang-format on */
 }
-
-void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const GLvoid *data) {
-
-	/* clang-format off */
-	EM_ASM({
-	    GLctx.bufferSubData($0, $1, HEAPU8, $2, $3);
-	}, target, offset, data, size);
-	/* clang-format on */
-}
 #endif
 
 void glTexStorage2DCustom(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLenum format, GLenum type) {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -46,7 +46,6 @@
 // WebGL 2.0 has no MapBufferRange/UnmapBuffer, but offers a non-ES style BufferSubData API instead.
 #ifdef __EMSCRIPTEN__
 void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data);
-void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const GLvoid *data);
 #endif
 
 class RasterizerCanvasGLES3;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/25351

With @muiroc help, we found that Emscripten's version of glBufferSubData is overridden by implementation found in [rasterizer_storage_gles3.cpp](https://github.com/godotengine/godot/blob/0d438c7b18521833be23af37e0d9c1c7a66b669c/drivers/gles3/rasterizer_storage_gles3.cpp#L116-L123) file. This PR removes it and allows to use proper function compatible with WebGL1 and WebGL2.