### PR TITLE
GridMap editor fixes and improvements

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -54,9 +54,9 @@ class GridMapEditor : public VBoxContainer {
 		INPUT_NONE,
 		INPUT_PAINT,
 		INPUT_ERASE,
-		INPUT_COPY,
+		INPUT_PICK,
 		INPUT_SELECT,
-		INPUT_DUPLICATE,
+		INPUT_PASTE,
 	};
 
 	enum ClipMode {
@@ -116,8 +116,17 @@ class GridMapEditor : public VBoxContainer {
 	RID selection_instance;
 	RID selection_level_mesh[3];
 	RID selection_level_instance[3];
-	RID duplicate_mesh;
-	RID duplicate_instance;
+	RID paste_mesh;
+	RID paste_instance;
+
+	struct ClipboardItem {
+		int cell_item;
+		Vector3 grid_offset;
+		int orientation;
+		RID instance;
+	};
+
+	List<ClipboardItem> clipboard_items;
 
 	Ref<SpatialMaterial> indicator_mat;
 	Ref<SpatialMaterial> inner_mat;
@@ -132,9 +141,19 @@ class GridMapEditor : public VBoxContainer {
 		Vector3 current;
 		Vector3 begin;
 		Vector3 end;
-		int duplicate_rot;
 		bool active;
 	} selection;
+	Selection last_selection;
+
+	struct PasteIndicator {
+
+		Vector3 click;
+		Vector3 current;
+		Vector3 begin;
+		Vector3 end;
+		int orientation;
+	};
+	PasteIndicator paste_indicator;
 
 	bool cursor_visible;
 	Transform cursor_transform;
@@ -148,7 +167,6 @@ class GridMapEditor : public VBoxContainer {
 
 	enum Menu {
 
-		MENU_OPTION_CONFIGURE,
 		MENU_OPTION_NEXT_LEVEL,
 		MENU_OPTION_PREV_LEVEL,
 		MENU_OPTION_LOCK_VIEW,
@@ -165,13 +183,11 @@ class GridMapEditor : public VBoxContainer {
 		MENU_OPTION_CURSOR_BACK_ROTATE_X,
 		MENU_OPTION_CURSOR_BACK_ROTATE_Z,
 		MENU_OPTION_CURSOR_CLEAR_ROTATION,
-		MENU_OPTION_DUPLICATE_SELECTS,
-		MENU_OPTION_SELECTION_MAKE_AREA,
-		MENU_OPTION_SELECTION_MAKE_EXTERIOR_CONNECTOR,
+		MENU_OPTION_PASTE_SELECTS,
 		MENU_OPTION_SELECTION_DUPLICATE,
+		MENU_OPTION_SELECTION_CUT,
 		MENU_OPTION_SELECTION_CLEAR,
 		MENU_OPTION_SELECTION_FILL,
-		MENU_OPTION_REMOVE_AREA,
 		MENU_OPTION_GRIDMAP_SETTINGS
 
 	};
@@ -200,10 +216,13 @@ class GridMapEditor : public VBoxContainer {
 
 	void _icon_size_changed(float p_value);
 
-	void _update_duplicate_indicator();
-	void _duplicate_paste();
+	void _clear_clipboard_data();
+	void _set_clipboard_data();
+	void _update_paste_indicator();
+	void _do_paste();
 	void _update_selection_transform();
 	void _validate_selection();
+	void _set_selection(bool p_active, const Vector3 p_begin = Vector3(), const Vector3 p_end = Vector3());
 
 	void _floor_changed(float p_value);
 


### PR DESCRIPTION
This change fixes a few outstanding issues and greatly improves the usability
of the GridMap editor through the following changes:

- Copied mesh now gets displayed during pasting (also renamed the related
  identifiers accordingly)
- Duplication/paste indicator now gets rotated around the correct pivot point
  (duplication worked properly before, but the indicator was shown misplaced
  when rotated)
- Selected mesh library item cursor is no longer shown during selection and
  duplication/pasting
- Back rotate X/Y/Z is now working during duplication/pasting
- Added true cut operation thanks to now having a proper clipboard (clear
  operation got remapped to the DEL key)
- Got rid of some weird workarounds in the duplication code
- Fill and clear operations now correctly make the selection marker inactive
  as this was broken partly due to the workarounds mentioned above
  (duplication continues to keep the selection marker active to allow
  subsequent duplications)
- Clear current selection on RMB, but treat selection as an action so previous
  selection can be restored on undo
- Separated selection and paste indicator data as it's prone to error and
  confusion and it's anyway needed now that selection is treated as an action
- Added support for cancelling paste, selection, and even unselect the
  currently selected mesh library item with the ESC key (previously there
  wasn't a way to unselect)
- Changed the key binding of fill/clear/duplicate operations to use Ctrl as a
  modifier
- Changed erase to use RMB instead of Shift+RMB (free look is available
  through Shift+F anyway, so no need to occupy RMB for it during gridmap
  editing)
- Removed unused area, external connector, and configure menu items (there's
  also the non-functional clip mode menu items, but I'm not sure whether there
  are any plans with that, I suppose it's meant to be an editor aid)
- Renamed INPUT_COPY to INPUT_PICK to better reflect its purpose
- Added support for using Shift+Q and Shift+E to select multiple floors/planes
  without actually changing the current floor/plane as it happens when using
  e.g. the mouse wheel

Fixes #25373 and fixes #15883