### PR TITLE
Prevent upscaled SVG from exceeding Image bounds

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2632,6 +2632,9 @@ void Image::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "_set_data", "_get_data");
 
+	BIND_CONSTANT(MAX_WIDTH);
+	BIND_CONSTANT(MAX_HEIGHT);
+
 	BIND_ENUM_CONSTANT(FORMAT_L8); //luminance
 	BIND_ENUM_CONSTANT(FORMAT_LA8); //luminance-alpha
 	BIND_ENUM_CONSTANT(FORMAT_R8);

--- a/core/image.h
+++ b/core/image.h
@@ -52,13 +52,13 @@ typedef Ref<Image> (*ImageMemLoadFunc)(const uint8_t *p_png, int p_size);
 class Image : public Resource {
 	GDCLASS(Image, Resource);
 
+public:
+	static SavePNGFunc save_png_func;
+
 	enum {
 		MAX_WIDTH = 16384, // force a limit somehow
 		MAX_HEIGHT = 16384 // force a limit somehow
 	};
-
-public:
-	static SavePNGFunc save_png_func;
 
 	enum Format {
 

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -4,7 +4,7 @@
 		Image datatype.
 	</brief_description>
 	<description>
-		Native image datatype. Contains image data, which can be converted to a [Texture], and several functions to interact with it. The maximum width and height for an [code]Image[/code] is 16384 pixels.
+		Native image datatype. Contains image data, which can be converted to a [Texture], and several functions to interact with it. The maximum width and height for an [code]Image[/code] are [constant MAX_WIDTH] and [constant MAX_HEIGHT].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -476,6 +476,12 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="MAX_WIDTH" value="16384">
+			The maximal width allowed for [code]Image[/code] resources.
+		</constant>
+		<constant name="MAX_HEIGHT" value="16384">
+			The maximal height allowed for [code]Image[/code] resources.
+		</constant>
 		<constant name="FORMAT_L8" value="0" enum="Format">
 		</constant>
 		<constant name="FORMAT_LA8" value="1" enum="Format">

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -109,7 +109,12 @@ Error ImageLoaderSVG::_create_image(Ref<Image> p_image, const PoolVector<uint8_t
 	float upscale = upsample ? 2.0 : 1.0;
 
 	int w = (int)(svg_image->width * p_scale * upscale);
+	ERR_EXPLAIN(vformat("Can't create image from SVG with scale %s, the resulting image size exceeds max width.", rtos(p_scale)));
+	ERR_FAIL_COND_V(w > Image::MAX_WIDTH, ERR_PARAMETER_RANGE_ERROR);
+
 	int h = (int)(svg_image->height * p_scale * upscale);
+	ERR_EXPLAIN(vformat("Can't create image from SVG with scale %s, the resulting image size exceeds max height.", rtos(p_scale)));
+	ERR_FAIL_COND_V(h > Image::MAX_HEIGHT, ERR_PARAMETER_RANGE_ERROR);
 
 	PoolVector<uint8_t> dst_image;
 	dst_image.resize(w * h * 4);


### PR DESCRIPTION
Also expose Image MAX_WIDTH and MAX_HEIGHT.

Fixes #24455.