### PR TITLE
Revert " Deprecated Godot 3D physics engine"

### DIFF
--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -81,7 +81,6 @@ static void _debugger_get_resource_usage(List<ScriptDebuggerRemote::ResourceUsag
 ShaderTypes *shader_types = NULL;
 
 PhysicsServer *_createGodotPhysicsCallback() {
-	WARN_PRINT("The GodotPhysics 3D physics engine is deprecated and will be removed in Godot 3.2. You should use the Bullet physics engine instead (configurable in your project settings).");
 	return memnew(PhysicsServerSW);
 }
 
@@ -167,8 +166,8 @@ void register_server_types() {
 	GLOBAL_DEF(PhysicsServerManager::setting_property_name, "DEFAULT");
 	ProjectSettings::get_singleton()->set_custom_property_info(PhysicsServerManager::setting_property_name, PropertyInfo(Variant::STRING, PhysicsServerManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"));
 
-	PhysicsServerManager::register_server("GodotPhysics - deprecated", &_createGodotPhysicsCallback);
-	PhysicsServerManager::set_default_server("GodotPhysics - deprecated");
+	PhysicsServerManager::register_server("GodotPhysics", &_createGodotPhysicsCallback);
+	PhysicsServerManager::set_default_server("GodotPhysics");
 }
 
 void unregister_server_types() {


### PR DESCRIPTION
This reverts commit 5de5a4140b9a397935737c6ce0088602be6840d7.

@reduz still intends to rework it in the future, and it's convenient to
test if issues are specific to Bullet or not, so we keep it around for
the time being.