### PR TITLE
[DOCS] Added warnings about Dictionary element erasure while iterating over it

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Dictionary type. Associative container which contains values referenced by unique keys. Dictionaries are always passed by reference.
+		Erasing elements while iterating over them [b]is not supported[/b].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -38,7 +39,7 @@
 			<argument index="0" name="key" type="Variant">
 			</argument>
 			<description>
-				Erase a dictionary key/value pair by key.
+				Erase a dictionary key/value pair by key. Do not erase elements while iterating over the dictionary.
 			</description>
 		</method>
 		<method name="get">


### PR DESCRIPTION
Refers to [#18829](https://github.com/godotengine/godot/issues/18829). Until no solution provided, I've added warning inormation about the problem, because such behaviour is completely undocumented and unpredictable.