### PR TITLE
Fix non-compiling typo in Expression.xml example

### DIFF
--- a/doc/classes/Expression.xml
+++ b/doc/classes/Expression.xml
@@ -16,7 +16,7 @@
 		func _on_text_entered(command):
 		    var error = expression.parse(command, [])
 		    if error != OK:
-		        print(get_error_text())
+		        print(expression.get_error_text())
 		        return
 		    var result = expression.execute([], null, true)
 		    if not expression.has_execute_failed():


### PR DESCRIPTION
Slight typo in Expression.xml prevented compilation when copy/pasted.

If you take a look at the header file at https://github.com/godotengine/godot/blob/master/core/math/expression.h#L351, you can see it does indeed have the function.