### PR TITLE
Add option to keep button pressed when moving cursor outside while pressing

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -71,6 +71,9 @@
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode">
 			If [code]true[/code], the button is in toggle mode. Makes the button flip state between pressed and unpressed each time its area is clicked.
 		</member>
+		<member name="keep_pressed_outside" type="bool" setter="set_keep_pressed_outside" getter="is_keep_pressed_outside">
+			If [code]true[/code], the button stays pressed when moving the cursor outside the button while pressing it. Default value: [code]false[/code].
+		</member>
 	</members>
 	<signals>
 		<signal name="button_down">

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -379,7 +379,7 @@ BaseButton::DrawMode BaseButton::get_draw_mode() const {
 		bool pressing;
 		if (status.press_attempt) {
 
-			pressing = status.pressing_inside;
+			pressing = (status.pressing_inside || keep_pressed_outside);
 			if (status.pressed)
 				pressing = !pressing;
 		} else {
@@ -447,6 +447,16 @@ void BaseButton::set_enabled_focus_mode(FocusMode p_mode) {
 Control::FocusMode BaseButton::get_enabled_focus_mode() const {
 
 	return enabled_focus_mode;
+}
+
+void BaseButton::set_keep_pressed_outside(bool p_on) {
+
+	keep_pressed_outside = p_on;
+}
+
+bool BaseButton::is_keep_pressed_outside() const {
+
+	return keep_pressed_outside;
 }
 
 void BaseButton::set_shortcut(const Ref<ShortCut> &p_shortcut) {
@@ -531,6 +541,8 @@ void BaseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_draw_mode"), &BaseButton::get_draw_mode);
 	ClassDB::bind_method(D_METHOD("set_enabled_focus_mode", "mode"), &BaseButton::set_enabled_focus_mode);
 	ClassDB::bind_method(D_METHOD("get_enabled_focus_mode"), &BaseButton::get_enabled_focus_mode);
+	ClassDB::bind_method(D_METHOD("set_keep_pressed_outside", "enabled"), &BaseButton::set_keep_pressed_outside);
+	ClassDB::bind_method(D_METHOD("is_keep_pressed_outside"), &BaseButton::is_keep_pressed_outside);
 
 	ClassDB::bind_method(D_METHOD("set_shortcut", "shortcut"), &BaseButton::set_shortcut);
 	ClassDB::bind_method(D_METHOD("get_shortcut"), &BaseButton::get_shortcut);
@@ -552,6 +564,7 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press,Button Release"), "set_action_mode", "get_action_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask", PROPERTY_HINT_FLAGS, "Mouse Left, Mouse Right, Mouse Middle"), "set_button_mask", "get_button_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "enabled_focus_mode", PROPERTY_HINT_ENUM, "None,Click,All"), "set_enabled_focus_mode", "get_enabled_focus_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_pressed_outside"), "set_keep_pressed_outside", "is_keep_pressed_outside");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, "ShortCut"), "set_shortcut", "get_shortcut");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "group", PROPERTY_HINT_RESOURCE_TYPE, "ButtonGroup"), "set_button_group", "get_button_group");
 
@@ -569,6 +582,7 @@ BaseButton::BaseButton() {
 
 	toggle_mode = false;
 	shortcut_in_tooltip = true;
+	keep_pressed_outside = false;
 	status.pressed = false;
 	status.press_attempt = false;
 	status.hovering = false;

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -52,6 +52,7 @@ private:
 	int button_mask;
 	bool toggle_mode;
 	bool shortcut_in_tooltip;
+	bool keep_pressed_outside;
 	FocusMode enabled_focus_mode;
 	Ref<ShortCut> shortcut;
 
@@ -109,6 +110,9 @@ public:
 
 	void set_action_mode(ActionMode p_mode);
 	ActionMode get_action_mode() const;
+
+	void set_keep_pressed_outside(bool p_on);
+	bool is_keep_pressed_outside() const;
 
 	void set_button_mask(int p_mask);
 	int get_button_mask() const;


### PR DESCRIPTION
Added an option in BaseButton in order to solve the issue #25444 for Button and TextureButton.

The property appears this way in the editor:
<img src=https://user-images.githubusercontent.com/1075032/51934010-e7dbff80-2402-11e9-840b-d26849c643fe.png width=300/>

When this option is checked, it allows the button to stay in a pressed state when moving the cursor outside the button while pressing it, until the user releases it.

Default behavior:
![button-default](https://user-images.githubusercontent.com/1075032/51891572-d1508c80-239f-11e9-821c-e4f11fade1df.gif)

Keep pressed outside:
![button-keep-pressed](https://user-images.githubusercontent.com/1075032/51891594-e1686c00-239f-11e9-8236-76df533a3049.gif)

*Bugsquad edit:* Fixes #25444.