### PR TITLE
Fixes error when new name contains only unallowed characters

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -678,6 +678,11 @@ void SceneTreeEditor::_renamed() {
 		error->set_text(TTR("Invalid node name, the following characters are not allowed:") + "\n" + Node::invalid_character);
 		error->popup_centered_minsize();
 
+		if (new_name.empty()) {
+			which->set_text(0, n->get_name());
+			return;
+		}
+
 		which->set_text(0, new_name);
 	}
 


### PR DESCRIPTION
Invalid node name should check if new_name is empty then cancel rename

Bugsquad edit: fixes #25226.