### PR TITLE
allow nav poly to be directly edited via the vertices. This addresses #25459

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -635,9 +635,12 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 #endif
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));
 	}
-	if (!metadata.empty()) {
-		p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-	}
+
+#ifdef TOOLS_ENABLED
+	p_list->push_back(PropertyInfo(Variant::NIL, "Metadata", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
+#endif
+	p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT));
+
 	if (script_instance && !p_reversed) {
 		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
 		script_instance->get_property_list(p_list);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -46,7 +46,7 @@ class AnimationTrackKeyEdit : public Object {
 public:
 	bool setting;
 
-	bool _hide_script_from_inspector() {
+	bool _hide_object_properties_from_inspector() {
 		return true;
 	}
 
@@ -58,7 +58,7 @@ public:
 
 		ClassDB::bind_method("_update_obj", &AnimationTrackKeyEdit::_update_obj);
 		ClassDB::bind_method("_key_ofs_changed", &AnimationTrackKeyEdit::_key_ofs_changed);
-		ClassDB::bind_method("_hide_script_from_inspector", &AnimationTrackKeyEdit::_hide_script_from_inspector);
+		ClassDB::bind_method("_hide_object_properties_from_inspector", &AnimationTrackKeyEdit::_hide_object_properties_from_inspector);
 		ClassDB::bind_method("get_root_path", &AnimationTrackKeyEdit::get_root_path);
 		ClassDB::bind_method("_dont_undo_redo", &AnimationTrackKeyEdit::_dont_undo_redo);
 	}

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1550,7 +1550,7 @@ void EditorInspector::update_tree() {
 		if (p.usage & PROPERTY_USAGE_HIGH_END_GFX && VS::get_singleton()->is_low_end())
 			continue; //do not show this property in low end gfx
 
-		if (p.name == "script" && (hide_script || bool(object->call("_hide_script_from_inspector")))) {
+		if ((hide_object_properties || bool(object->call("_hide_object_properties_from_inspector"))) && (p.name == "script" || p.name == "__meta__")) {
 			continue;
 		}
 
@@ -1877,8 +1877,8 @@ void EditorInspector::set_use_doc_hints(bool p_enable) {
 	use_doc_hints = p_enable;
 	update_tree();
 }
-void EditorInspector::set_hide_script(bool p_hide) {
-	hide_script = p_hide;
+void EditorInspector::set_hide_object_properties(bool p_hide) {
+	hide_object_properties = p_hide;
 	update_tree();
 }
 void EditorInspector::set_use_filter(bool p_use) {
@@ -2318,7 +2318,7 @@ EditorInspector::EditorInspector() {
 	set_enable_v_scroll(true);
 
 	show_categories = false;
-	hide_script = true;
+	hide_object_properties = true;
 	use_doc_hints = false;
 	capitalize_paths = true;
 	use_filter = false;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -272,7 +272,7 @@ class EditorInspector : public ScrollContainer {
 
 	LineEdit *search_box;
 	bool show_categories;
-	bool hide_script;
+	bool hide_object_properties;
 	bool use_doc_hints;
 	bool capitalize_paths;
 	bool use_filter;
@@ -360,7 +360,7 @@ public:
 
 	void set_show_categories(bool p_show);
 	void set_use_doc_hints(bool p_enable);
-	void set_hide_script(bool p_hide);
+	void set_hide_object_properties(bool p_hide);
 
 	void set_use_filter(bool p_use);
 	void register_text_enter(Node *p_line_edit);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -597,7 +597,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	inspector->set_show_categories(true);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector->set_use_doc_hints(true);
-	inspector->set_hide_script(false);
+	inspector->set_hide_object_properties(false);
 	inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));
 	inspector->set_use_folding(!bool(EDITOR_GET("interface/inspector/disable_folding")));
 	inspector->register_text_enter(search);

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -3369,7 +3369,7 @@ void TilesetEditorContext::_get_property_list(List<PropertyInfo> *p_list) const 
 
 void TilesetEditorContext::_bind_methods() {
 
-	ClassDB::bind_method("_hide_script_from_inspector", &TilesetEditorContext::_hide_script_from_inspector);
+	ClassDB::bind_method("_hide_object_properties_from_inspector", &TilesetEditorContext::_hide_object_properties_from_inspector);
 }
 
 TilesetEditorContext::TilesetEditorContext(TileSetEditor *p_tileset_editor) {

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -252,7 +252,7 @@ class TilesetEditorContext : public Object {
 	bool snap_options_visible;
 
 public:
-	bool _hide_script_from_inspector() { return true; }
+	bool _hide_object_properties_from_inspector() { return true; }
 	void set_tileset(const Ref<TileSet> &p_tileset);
 
 private:

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -32,7 +32,7 @@
 
 #include "core/core_string_names.h"
 #include "core/engine.h"
-#include "navigation_2d.h"
+#include "navigation2d.h"
 
 #include "thirdparty/misc/triangulator.h"
 
@@ -80,6 +80,9 @@ void NavigationPolygon::set_vertices(const PoolVector<Vector2> &p_vertices) {
 
 	vertices = p_vertices;
 	rect_cache_dirty = true;
+	set_outline(0, p_vertices);
+	_change_notify("navpoly");
+	emit_changed();
 }
 
 PoolVector<Vector2> NavigationPolygon::get_vertices() const {
@@ -312,7 +315,7 @@ void NavigationPolygon::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_outlines", "outlines"), &NavigationPolygon::_set_outlines);
 	ClassDB::bind_method(D_METHOD("_get_outlines"), &NavigationPolygon::_get_outlines);
 
-	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR2_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
+	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR2_ARRAY, "vertices"), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "polygons", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_polygons", "_get_polygons");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "outlines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_outlines", "_get_outlines");
 }

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -80,6 +80,9 @@ void NavigationPolygon::set_vertices(const PoolVector<Vector2> &p_vertices) {
 
 	vertices = p_vertices;
 	rect_cache_dirty = true;
+	set_outline(0, p_vertices);
+	_change_notify("navpoly");
+	emit_changed();
 }
 
 PoolVector<Vector2> NavigationPolygon::get_vertices() const {
@@ -312,7 +315,7 @@ void NavigationPolygon::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_outlines", "outlines"), &NavigationPolygon::_set_outlines);
 	ClassDB::bind_method(D_METHOD("_get_outlines"), &NavigationPolygon::_get_outlines);
 
-	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR2_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
+	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR2_ARRAY, "vertices"), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "polygons", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_polygons", "_get_polygons");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "outlines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_outlines", "_get_outlines");
 }

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -80,9 +80,6 @@ void NavigationPolygon::set_vertices(const PoolVector<Vector2> &p_vertices) {
 
 	vertices = p_vertices;
 	rect_cache_dirty = true;
-	set_outline(0, p_vertices);
-	_change_notify("navpoly");
-	emit_changed();
 }
 
 PoolVector<Vector2> NavigationPolygon::get_vertices() const {
@@ -315,7 +312,7 @@ void NavigationPolygon::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_outlines", "outlines"), &NavigationPolygon::_set_outlines);
 	ClassDB::bind_method(D_METHOD("_get_outlines"), &NavigationPolygon::_get_outlines);
 
-	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR2_ARRAY, "vertices"), "set_vertices", "get_vertices");
+	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR2_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "polygons", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_polygons", "_get_polygons");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "outlines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_outlines", "_get_outlines");
 }


### PR DESCRIPTION
Addressing #25459: this should now expose the vertices. Update the outline and poly to the new vertices.

Known Issue:

I found that modifying the outline in the editor doesn't change the vertices value unless you reselect the node. This is equal to the behavior in OccluderPolygon2D and CollisionPolygon2D.