### PR TITLE
Fix AStar crashing with large (>1e30) estimated values

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -260,8 +260,8 @@ bool AStar::_solve(Point *begin_point, Point *end_point) {
 		}
 		// Check open list
 
-		SelfList<Point> *least_cost_point = NULL;
-		real_t least_cost = 1e30;
+		SelfList<Point> *least_cost_point = open_list.first();
+		real_t least_cost = Math_INF;
 
 		// TODO: Cache previous results
 		for (SelfList<Point> *E = open_list.first(); E; E = E->next()) {


### PR DESCRIPTION
Fixes #21601.

Resolved by starting from with the least cost point initialised to the first point and the least code initialised to infinity. There is no performance hit coming from that, nor is there any problem on the first iteration.