### PR TITLE
Fix parameterised macros in core. Addresses #25488

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -39,7 +39,7 @@
 // va_copy, otherwise you have to use the internal version (__va_copy).
 #if !defined(va_copy)
 #if defined(__GNUC__)
-#define va_copy(d, s) __va_copy(d, s)
+#define va_copy(d, s) __va_copy((d), (s))
 #else
 #define va_copy(d, s) ((d) = (s))
 #endif

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -514,7 +514,7 @@ static inline void _build_faces(uint8_t ***p_cell_status, int x, int y, int z, i
 		Vector3(1,1,1),
 	};
 */
-#define vert(m_idx) Vector3((m_idx & 4) >> 2, (m_idx & 2) >> 1, m_idx & 1)
+#define vert(m_idx) Vector3(((m_idx)&4) >> 2, ((m_idx)&2) >> 1, (m_idx)&1)
 
 	static const uint8_t indices[6][4] = {
 		{ 7, 6, 4, 5 },

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -135,7 +135,7 @@ T *_nullptr() {
 /** Generic swap template */
 #ifndef SWAP
 
-#define SWAP(m_x, m_y) __swap_tmpl(m_x, m_y)
+#define SWAP(m_x, m_y) __swap_tmpl((m_x), (m_y))
 template <class T>
 inline void __swap_tmpl(T &x, T &y) {
 


### PR DESCRIPTION
This saves the programmer of doing something like SWAP(x++, y--)
and getting the wrong result unless the parameters are evaluated
before use.

Fixes #25488 