### PR TITLE
Disable BT_DEBUG, works around #25476 and #25431

### DIFF
--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -187,8 +187,8 @@ if env['builtin_bullet']:
     thirdparty_sources = [thirdparty_dir + file for file in bullet2_src]
 
     env_bullet.Append(CPPPATH=[thirdparty_dir])
-    if env['target'] == "debug" or env['target'] == "release_debug":
-        env_bullet.Append(CCFLAGS=['-DBT_DEBUG'])
+    # if env['target'] == "debug" or env['target'] == "release_debug":
+    #     env_bullet.Append(CCFLAGS=['-DBT_DEBUG'])
 
     env_thirdparty = env_bullet.Clone()
     env_thirdparty.disable_warnings()


### PR DESCRIPTION
Temporarily disable Bullet debug mode for debug and release_debug targets by commenting out https://github.com/godotengine/godot/blob/c21ca98e4c6e6228adefcc696b3ff6a1104c678e/modules/bullet/SCsub#L190 (this way, it can be easily re-enabled for troubleshooting following 3.1 release).

*Bugsquad edit:*
~Fixes~ Works around #25476 and #25431