### PR TITLE
Moved script editor search bar to the bottom

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1226,14 +1226,15 @@ CodeTextEditor::CodeTextEditor() {
 	ED_SHORTCUT("script_editor/zoom_out", TTR("Zoom Out"), KEY_MASK_CMD | KEY_MINUS);
 	ED_SHORTCUT("script_editor/reset_zoom", TTR("Reset Zoom"), KEY_MASK_CMD | KEY_0);
 
+	text_editor = memnew(TextEdit);
+	add_child(text_editor);
+	text_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+
+	// Added second to it opens at the bottom, so it won't shift the entire text editor when opening
 	find_replace_bar = memnew(FindReplaceBar);
 	add_child(find_replace_bar);
 	find_replace_bar->set_h_size_flags(SIZE_EXPAND_FILL);
 	find_replace_bar->hide();
-
-	text_editor = memnew(TextEdit);
-	add_child(text_editor);
-	text_editor->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	find_replace_bar->set_text_edit(text_editor);
 

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1423,10 +1423,6 @@ EditorHelp::EditorHelp() {
 
 	EDITOR_DEF("text_editor/help/sort_functions_alphabetically", true);
 
-	find_bar = memnew(FindBar);
-	add_child(find_bar);
-	find_bar->hide();
-
 	class_desc = memnew(RichTextLabel);
 	add_child(class_desc);
 	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -1434,6 +1430,10 @@ EditorHelp::EditorHelp() {
 	class_desc->connect("meta_clicked", this, "_class_desc_select");
 	class_desc->connect("gui_input", this, "_class_desc_input");
 
+	// Added second so it opens at the bottom so it won't offset the entire widget
+	find_bar = memnew(FindBar);
+	add_child(find_bar);
+	find_bar->hide();
 	find_bar->set_rich_text_label(class_desc);
 
 	class_desc->set_selection_enabled(true);


### PR DESCRIPTION
So it doesn't offset the whole text editor when opening.
Fixes https://github.com/godotengine/godot/issues/11114