### PR TITLE
Fix remote scene tree root folding

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -261,7 +261,7 @@ void ScriptEditorDebugger::_scene_tree_folded(Object *obj) {
 		return;
 
 	ObjectID id = item->get_metadata(0);
-	if (item->is_collapsed()) {
+	if (unfold_cache.has(id)) {
 		unfold_cache.erase(id);
 	} else {
 		unfold_cache.insert(id);


### PR DESCRIPTION
Fixes #25487.

Not sure if this is the best fix, since now double-clicking the collapse button would result in the item remaining in the same state.