### PR TITLE
Exposed custom AABB setter on GeometryInstance

### DIFF
--- a/doc/classes/GeometryInstance.xml
+++ b/doc/classes/GeometryInstance.xml
@@ -11,6 +11,15 @@
 	<demos>
 	</demos>
 	<methods>
+		<method name="set_custom_aabb">
+			<return type="void">
+			</return>
+			<argument index="0" name="aabb" type="AABB">
+			</argument>
+			<description>
+				Overrides the bounding box of this node with a custom one. To remove it, set an AABB with all fields set to zero.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="GeometryInstance.ShadowCastingSetting">

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -263,6 +263,11 @@ float GeometryInstance::get_extra_cull_margin() const {
 	return extra_cull_margin;
 }
 
+void GeometryInstance::set_custom_aabb(AABB aabb) {
+
+	VS::get_singleton()->instance_set_custom_aabb(get_instance(), aabb);
+}
+
 void GeometryInstance::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_material_override", "material"), &GeometryInstance::set_material_override);
@@ -288,6 +293,8 @@ void GeometryInstance::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_extra_cull_margin", "margin"), &GeometryInstance::set_extra_cull_margin);
 	ClassDB::bind_method(D_METHOD("get_extra_cull_margin"), &GeometryInstance::get_extra_cull_margin);
+
+	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &GeometryInstance::set_custom_aabb);
 
 	ClassDB::bind_method(D_METHOD("get_aabb"), &GeometryInstance::get_aabb);
 

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -137,6 +137,8 @@ public:
 	void set_extra_cull_margin(float p_margin);
 	float get_extra_cull_margin() const;
 
+	void set_custom_aabb(AABB aabb);
+
 	GeometryInstance();
 };
 


### PR DESCRIPTION
This feature is available in `VisualServer` if you don't use nodes, but there is no workaround to use it with nodes so I made a setter on `GeometryInstance`.
There is no getter because `VisualServer` doesn't have one, also use cases for this involve scripting so there is no inspector exposition either.

Fixes #21758