### PR TITLE
Fix a font oversampling warning being printed when it shouldn't

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1154,13 +1154,14 @@ void SceneTree::_update_root_rect() {
 	float viewport_aspect = desired_res.aspect();
 	float video_mode_aspect = video_mode.aspect();
 
+	if (use_font_oversampling && stretch_aspect == STRETCH_ASPECT_IGNORE) {
+		WARN_PRINT("Font oversampling only works with the resize modes 'Keep Width', 'Keep Height', and 'Expand'.");
+	}
+
 	if (stretch_aspect == STRETCH_ASPECT_IGNORE || ABS(viewport_aspect - video_mode_aspect) < CMP_EPSILON) {
 		//same aspect or ignore aspect
 		viewport_size = desired_res;
 		screen_size = video_mode;
-		if (use_font_oversampling) {
-			WARN_PRINT("Font oversampling only works with the following resize modes 'Keep Width', 'Keep Height', and 'Expand'.")
-		}
 	} else if (viewport_aspect < video_mode_aspect) {
 		// screen ratio is smaller vertically
 


### PR DESCRIPTION
The warning was being printed even when the stretch aspect mode was set to **Keep Width**, **Keep Height** or **Expand**.

Note that it still won't be printed when the stretch mode is set to **Disabled** (as it should be), due to the early `return` statement at the beginning of the function. The warning message was also slightly shortened.

[Demo project for testing](https://github.com/godotengine/godot/files/2818645/oversampling_warning.zip)
