### PR TITLE
Fix InputEvent handling order in ViewportContainer

### DIFF
--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -161,13 +161,39 @@ void ViewportContainer::_input(const Ref<InputEvent> &p_event) {
 		if (!c || c->is_input_disabled())
 			continue;
 
-		c->input(ev);
+		c->call_input(ev);
+	}
+}
+
+void ViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
+
+	if (Engine::get_singleton()->is_editor_hint())
+		return;
+
+	Transform2D xform = get_global_transform();
+
+	if (stretch) {
+		Transform2D scale_xf;
+		scale_xf.scale(Vector2(shrink, shrink));
+		xform *= scale_xf;
+	}
+
+	Ref<InputEvent> ev = p_event->xformed_by(xform.affine_inverse());
+
+	for (int i = 0; i < get_child_count(); i++) {
+
+		Viewport *c = Object::cast_to<Viewport>(get_child(i));
+		if (!c || c->is_input_disabled())
+			continue;
+
+		c->call_gui_input(ev);
 	}
 }
 
 void ViewportContainer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_input", "event"), &ViewportContainer::_input);
+	ClassDB::bind_method(D_METHOD("_gui_input", "event"), &ViewportContainer::_gui_input);
 	ClassDB::bind_method(D_METHOD("set_stretch", "enable"), &ViewportContainer::set_stretch);
 	ClassDB::bind_method(D_METHOD("is_stretch_enabled"), &ViewportContainer::is_stretch_enabled);
 

--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -153,7 +153,7 @@ void ViewportContainer::_input(const Ref<InputEvent> &p_event) {
 		xform *= scale_xf;
 	}
 
-	Ref<InputEvent> ev = p_event->xformed_by(xform.affine_inverse());
+	Ref<InputEvent> ev = p_event->xformed_by(xform.affine_inverse() * xform);
 
 	for (int i = 0; i < get_child_count(); i++) {
 
@@ -178,7 +178,7 @@ void ViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
 		xform *= scale_xf;
 	}
 
-	Ref<InputEvent> ev = p_event->xformed_by(xform.affine_inverse());
+	Ref<InputEvent> ev = p_event->xformed_by(xform.affine_inverse() * xform);
 
 	for (int i = 0; i < get_child_count(); i++) {
 

--- a/scene/gui/viewport_container.h
+++ b/scene/gui/viewport_container.h
@@ -49,6 +49,7 @@ public:
 	bool is_stretch_enabled() const;
 
 	void _input(const Ref<InputEvent> &p_event);
+	void _gui_input(const Ref<InputEvent> &p_event);
 	void set_stretch_shrink(int p_shrink);
 	int get_stretch_shrink() const;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2320,6 +2320,25 @@ void Viewport::_gui_grab_click_focus(Control *p_control) {
 
 ///////////////////////////////
 
+void Viewport::call_input(const Ref<InputEvent> &p_event) {
+
+	ERR_FAIL_COND(!is_inside_tree());
+
+	if (!get_tree()->is_input_handled()) {
+		get_tree()->_call_input_pause(input_group, "_input", p_event); //not a bug, must happen before GUI, order is _input -> gui input -> _unhandled input
+	}
+
+}
+
+void Viewport::call_gui_input(const Ref<InputEvent> &p_event) {
+
+	ERR_FAIL_COND(!is_inside_tree());
+
+	if (!get_tree()->is_input_handled()) {
+		_gui_input_event(p_event);
+	}
+}
+
 void Viewport::input(const Ref<InputEvent> &p_event) {
 
 	ERR_FAIL_COND(!is_inside_tree());

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -422,6 +422,9 @@ public:
 	void set_use_own_world(bool p_world);
 	bool is_using_own_world() const;
 
+	void call_input(const Ref<InputEvent> &p_event);
+	void call_gui_input(const Ref<InputEvent> &p_event);
+
 	void input(const Ref<InputEvent> &p_event);
 	void unhandled_input(const Ref<InputEvent> &p_event);
 


### PR DESCRIPTION
See #25525 

UI components inside a contained `Viewport` are expected to follow
the same global InputEvent handling order, which means `_input`
function in any `Node` shall be honored first, then `_gui_input`
function of those under the cursor / focus.

However, currently implementation of `ViewportContainer` uses its
`_input` to capture events for both `_input` and `_gui_input` of
UI `Control` under contained `Viewport`.  Effectively giving their
`_gui_input` the priority of `_input`.  This could:

1. Errornously triggle `_gui_input` UI `Control` inside contained
 `Viewport`
2. Errornously block `_gui_input` UI `Control` from receiving due
 event. (Due to event being consumed by 1)

Separate the event delivery between `ViewportContainer` and `Viewport`
into `_input` and `_gui_input` so proper InputEvent handling order
is restored.