### PR TITLE
Fixed uninitialized pointer access due to THEME_CHANGED notification

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -132,7 +132,6 @@ void EditorLog::_bind_methods() {
 EditorLog::EditorLog() {
 
 	VBoxContainer *vb = this;
-	add_constant_override("separation", get_constant("separation", "VBoxContainer"));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	vb->add_child(hb);
@@ -162,6 +161,8 @@ EditorLog::EditorLog() {
 	add_error_handler(&eh);
 
 	current = Thread::get_caller_id();
+
+	add_constant_override("separation", get_constant("separation", "VBoxContainer"));
 
 	EditorNode::get_undo_redo()->set_commit_notify_callback(_undo_redo_cbk, this);
 }


### PR DESCRIPTION
I ran into it while testing another bug.
`EditorLog` is trying to add a theme override to itself at the beginning of the constructor, which triggers `NOTIFICATION_THEME_CHANGED` on itself, and it crashes on garbage because none of the member vars have been set at this stage.
I moved the theme override at the end of the constructor to fix it.