### PR TITLE
Don't modify font which could potentially not be the editor one yet

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -65,7 +65,6 @@ void EditorLog::_notification(int p_what) {
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
 		Ref<DynamicFont> df_output_code = get_font("output_source", "EditorFonts");
 		if (df_output_code.is_valid()) {
-			df_output_code->set_size(int(EDITOR_DEF("run/output/font_size", 13)) * EDSCALE);
 			if (log != NULL) {
 				log->add_font_override("normal_font", get_font("output_source", "EditorFonts"));
 			}


### PR DESCRIPTION
`EditorLog` adds itself a theme override in its constructor, which causes `NOTIFICATION_THEME_CHANGED`, which was triggering code in which the font was forcefully set to 13. But because this happens in constructor, the theme you get is not the editor one but the default game one, so it ends up modifying the game's theme font.

Because the size of this font is already set in `editor_fonts.cpp`, I simply removed the assignment.

On the other hand, I'm not sure wether or not adding theme overrides in constructor is a good idea in the editor, because of this issue.

You may also need  #25546 to test this PR.

Fixes https://github.com/godotengine/godot/issues/24604