### PR TITLE
Displays errors and warnings in a better way in the script editor

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -142,12 +142,12 @@ class CodeTextEditor : public VBoxContainer {
 	TextEdit *text_editor;
 	FindReplaceBar *find_replace_bar;
 	HBoxContainer *status_bar;
-	Label *warning_label;
+
+	ToolButton *warning_button;
 	Label *warning_count_label;
 
-	Label *line_nb;
-	Label *col_nb;
-	Label *font_size_nb;
+	Label *line_and_col_txt;
+
 	Label *info;
 	Timer *idle;
 	Timer *code_complete_timer;
@@ -175,6 +175,10 @@ class CodeTextEditor : public VBoxContainer {
 
 	CodeTextEditorCodeCompleteFunc code_complete_func;
 	void *code_complete_ud;
+
+	void _warning_label_gui_input(const Ref<InputEvent> &p_event);
+	void _warning_button_pressed();
+	void _error_pressed(const Ref<InputEvent> &p_event);
 
 protected:
 	virtual void _load_theme_settings() {}
@@ -212,15 +216,14 @@ public:
 	Variant get_edit_state();
 	void set_edit_state(const Variant &p_state);
 
+	void set_warning_nb(int p_warning_nb);
+
 	void update_editor_settings();
 	void set_error(const String &p_error);
 	void set_error_pos(int p_line, int p_column);
 	void update_line_and_column() { _line_col_changed(); }
 	TextEdit *get_text_edit() { return text_editor; }
 	FindReplaceBar *get_find_replace_bar() { return find_replace_bar; }
-	Label *get_error_label() const { return error; }
-	Label *get_warning_label() const { return warning_label; }
-	Label *get_warning_count_label() const { return warning_count_label; }
 	virtual void apply_code() {}
 	void goto_error();
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -273,18 +273,12 @@ void ScriptTextEditor::_set_theme_for_script() {
 	}
 }
 
-void ScriptTextEditor::_toggle_warning_pannel(const Ref<InputEvent> &p_event) {
-	Ref<InputEventMouseButton> mb = p_event;
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
-		warnings_panel->set_visible(!warnings_panel->is_visible());
-	}
+void ScriptTextEditor::_toggle_warning_pannel() {
+	warnings_panel->set_visible(!warnings_panel->is_visible());
 }
 
-void ScriptTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
-	Ref<InputEventMouseButton> mb = p_event;
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
-		code_editor->goto_error();
-	}
+void ScriptTextEditor::_error_pressed() {
+	code_editor->goto_error();
 }
 
 void ScriptTextEditor::_warning_clicked(Variant p_line) {
@@ -468,7 +462,7 @@ void ScriptTextEditor::_validate_script() {
 		}
 	}
 
-	code_editor->get_warning_count_label()->set_text(itos(warnings.size()));
+	code_editor->set_warning_nb(warnings.size());
 	warnings_panel->clear();
 	warnings_panel->push_table(3);
 	for (List<ScriptLanguage::Warning>::Element *E = warnings.front(); E; E = E->next()) {
@@ -1427,7 +1421,7 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	code_editor = memnew(CodeTextEditor);
 	editor_box->add_child(code_editor);
-	code_editor->add_constant_override("separation", 0);
+	code_editor->add_constant_override("separation", 2);
 	code_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	code_editor->connect("validate_script", this, "_validate_script");
 	code_editor->connect("load_theme_settings", this, "_load_theme_settings");
@@ -1445,9 +1439,8 @@ ScriptTextEditor::ScriptTextEditor() {
 	warnings_panel->set_focus_mode(FOCUS_CLICK);
 	warnings_panel->hide();
 
-	code_editor->get_error_label()->connect("gui_input", this, "_error_pressed");
-	code_editor->get_warning_label()->connect("gui_input", this, "_toggle_warning_pannel");
-	code_editor->get_warning_count_label()->connect("gui_input", this, "_toggle_warning_pannel");
+	code_editor->connect("error_pressed", this, "_error_pressed");
+	code_editor->connect("warning_pressed", this, "_toggle_warning_pannel");
 	warnings_panel->connect("meta_clicked", this, "_warning_clicked");
 
 	update_settings();

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -125,8 +125,8 @@ protected:
 	void _code_complete_script(const String &p_code, List<String> *r_options, bool &r_force);
 	void _load_theme_settings();
 	void _set_theme_for_script();
-	void _toggle_warning_pannel(const Ref<InputEvent> &p_event);
-	void _error_pressed(const Ref<InputEvent> &p_event);
+	void _toggle_warning_pannel();
+	void _error_pressed();
 	void _warning_clicked(Variant p_line);
 
 	void _notification(int p_what);


### PR DESCRIPTION
![peek 01-02-2019 17-25](https://user-images.githubusercontent.com/6093119/52135588-7096ad80-2646-11e9-91a7-ad0bae2dc6c2.gif)

- Removed the font size info,
- Hide the warning number and icon when there is no warning,
- Put the error line into a scroll container,
- Add tooltips,
- Refactor the API a little bit, so that access to labels is no more public.

Closes #22302
Superseedes #24721
