### PR TITLE
Fixed shortcut events in BaseButton (now acts the same as ui_accept action)

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -61,37 +61,7 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 
 	bool button_masked = mouse_button.is_valid() && ((1 << (mouse_button->get_button_index() - 1)) & button_mask) > 0;
 	if (button_masked || ui_accept) {
-		if (p_event->is_pressed()) {
-			status.press_attempt = true;
-			status.pressing_inside = true;
-			emit_signal("button_down");
-		}
-
-		if (status.press_attempt && status.pressing_inside) {
-			if (toggle_mode) {
-				if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
-					if (action_mode == ACTION_MODE_BUTTON_PRESS) {
-						status.press_attempt = false;
-						status.pressing_inside = false;
-					}
-					status.pressed = !status.pressed;
-					_unpress_group();
-					_toggled(status.pressed);
-					_pressed();
-				}
-			} else {
-				if (!p_event->is_pressed()) {
-					_pressed();
-				}
-			}
-		}
-
-		if (!p_event->is_pressed()) { // pressed state should be correct with button_up signal
-			emit_signal("button_up");
-			status.press_attempt = false;
-		}
-
-		update();
+		on_action_event(p_event);
 		return;
 	}
 
@@ -175,6 +145,41 @@ void BaseButton::_toggled(bool p_pressed) {
 	}
 	toggled(p_pressed);
 	emit_signal("toggled", p_pressed);
+}
+
+void BaseButton::on_action_event(Ref<InputEvent> p_event) {
+
+	if (p_event->is_pressed()) {
+		status.press_attempt = true;
+		status.pressing_inside = true;
+		emit_signal("button_down");
+	}
+
+	if (status.press_attempt && status.pressing_inside) {
+		if (toggle_mode) {
+			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
+				if (action_mode == ACTION_MODE_BUTTON_PRESS) {
+					status.press_attempt = false;
+					status.pressing_inside = false;
+				}
+				status.pressed = !status.pressed;
+				_unpress_group();
+				_toggled(status.pressed);
+				_pressed();
+			}
+		} else {
+			if (!p_event->is_pressed()) {
+				_pressed();
+			}
+		}
+	}
+
+	if (!p_event->is_pressed()) { // pressed state should be correct with button_up signal
+		emit_signal("button_up");
+		status.press_attempt = false;
+	}
+
+	update();
 }
 
 void BaseButton::pressed() {
@@ -345,16 +350,12 @@ Ref<ShortCut> BaseButton::get_shortcut() const {
 
 void BaseButton::_unhandled_input(Ref<InputEvent> p_event) {
 
-	if (!is_disabled() && is_visible_in_tree() && p_event->is_pressed() && !p_event->is_echo() && shortcut.is_valid() && shortcut->is_shortcut(p_event)) {
+	if (!is_disabled() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->is_shortcut(p_event)) {
 
 		if (get_viewport()->get_modal_stack_top() && !get_viewport()->get_modal_stack_top()->is_a_parent_of(this))
 			return; //ignore because of modal window
 
-		if (is_toggle_mode()) {
-			set_pressed(!is_pressed()); // Also calls _toggled() internally.
-		}
-
-		_pressed();
+		on_action_event(p_event);
 	}
 }
 

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -74,6 +74,8 @@ private:
 	void _pressed();
 	void _toggled(bool p_pressed);
 
+	void on_action_event(Ref<InputEvent> p_event);
+
 protected:
 	virtual void pressed();
 	virtual void toggled(bool p_pressed);


### PR DESCRIPTION
This change allows TextureButton to show expected behavior when a shortcut is set.

BaseButton used to only send "pressed" signal when a shortcut is pressed, without changing any of its internal state.

Now all signals and button state changes in BaseButton are sharing the same logic as "ui_accept" action when a shortcut event is triggered.

Note: the diff shows a lot of changes, but I've really just moved the logic from "ui_accept" events into a private method to re-use it for the shortcut event case.

Fixes #21261, fixes #18715.