### PR TITLE
Mono: Lifetime fixes for CSharpInstance and instance binding data

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1924,6 +1924,11 @@ void *Object::get_script_instance_binding(int p_script_language_index) {
 	return _script_instance_bindings[p_script_language_index];
 }
 
+bool Object::has_script_instance_binding(int p_script_language_index) {
+
+	return _script_instance_bindings[p_script_language_index] != NULL;
+}
+
 Object::Object() {
 
 	_class_ptr = NULL;

--- a/core/object.h
+++ b/core/object.h
@@ -729,6 +729,7 @@ public:
 
 	//used by script languages to store binding data
 	void *get_script_instance_binding(int p_script_language_index);
+	bool has_script_instance_binding(int p_script_language_index);
 
 	void clear_internal_resource_paths();
 

--- a/modules/mono/mono_gc_handle.cpp
+++ b/modules/mono/mono_gc_handle.cpp
@@ -65,7 +65,7 @@ Ref<MonoGCHandle> MonoGCHandle::create_weak(MonoObject *p_object) {
 void MonoGCHandle::release() {
 
 #ifdef DEBUG_ENABLED
-	CRASH_COND(GDMono::get_singleton() == NULL);
+	CRASH_COND(!released && GDMono::get_singleton() == NULL);
 #endif
 
 	if (!released && GDMono::get_singleton()->is_runtime_initialized()) {


### PR DESCRIPTION
Avoid CSharpInstance from accessing its state after self destructing (by deleting the Reference owner).
It's now safe to replace the script instance without leaking or crashing.

Also fixed godot_icall_Object_weakref return reference being freed before returning.
