### PR TITLE
Allow move_and_slide_with_snap() to properly detect walls and ceilings during the snap movement

### DIFF
--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "godotsharp_editor.h"
 
+#include "core/message_queue.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "scene/gui/control.h"
@@ -114,10 +115,33 @@ bool GodotSharpEditor::_create_project_solution() {
 
 void GodotSharpEditor::_make_api_solutions_if_needed() {
 	// I'm sick entirely of ProgressDialog
+
+	static int attempts_left = 100;
+
+	if (MessageQueue::get_singleton()->is_flushing() || !SceneTree::get_singleton()) {
+		ERR_FAIL_COND(attempts_left == 0); // You've got to be kidding
+
+		if (SceneTree::get_singleton()) {
+			SceneTree::get_singleton()->connect("idle_frame", this, "_make_api_solutions_if_needed", Vector<Variant>());
+		} else {
+			call_deferred("_make_api_solutions_if_needed");
+		}
+
+		attempts_left--;
+		return;
+	}
+
+	// Recursion guard needed because signals don't play well with ProgressDialog either, but unlike
+	// the message queue, with signals the collateral damage should be minimal in the worst case.
 	static bool recursion_guard = false;
 	if (!recursion_guard) {
 		recursion_guard = true;
+
+		// Oneshot signals don't play well with ProgressDialog either, so we do it this way instead
+		SceneTree::get_singleton()->disconnect("idle_frame", this, "_make_api_solutions_if_needed");
+
 		_make_api_solutions_if_needed_impl();
+
 		recursion_guard = false;
 	}
 }
@@ -434,7 +458,7 @@ GodotSharpEditor::GodotSharpEditor(EditorNode *p_editor) {
 	String csproj_path = GodotSharpDirs::get_project_csproj_path();
 
 	if (FileAccess::exists(sln_path) && FileAccess::exists(csproj_path)) {
-		// We can't use EditorProgress here. It calls Main::iterarion() and the main loop is not initialized yet.
+		// Defer this task because EditorProgress calls Main::iterarion() and the main loop is not yet initialized.
 		call_deferred("_make_api_solutions_if_needed");
 	} else {
 		bottom_panel_btn->hide();

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -134,7 +134,7 @@ void CanvasItemMaterial::_update_shader() {
 		code += "\tint total_frames = particles_anim_h_frames * particles_anim_v_frames;\n";
 		code += "\tint frame = int(float(total_frames) * INSTANCE_CUSTOM.z);\n";
 		code += "\tif (particles_anim_loop) {\n";
-		code += "\t\tframe = abs(frame) % total_frames;\n";
+		code += "\t\tframe = int(abs(frame) % total_frames);\n";
 		code += "\t} else {\n";
 		code += "\t\tframe = clamp(frame, 0, total_frames - 1);\n";
 		code += "\t}\n";

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1328,11 +1328,9 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 Vector2 KinematicBody2D::move_and_slide_with_snap(const Vector2 &p_linear_velocity, const Vector2 &p_snap, const Vector2 &p_floor_direction, bool p_stop_on_slope, int p_max_slides, float p_floor_max_angle, bool p_infinite_inertia) {
 
 	bool was_on_floor = on_floor;
-	bool was_on_ceiling = on_ceiling;
-	bool was_on_wall = on_wall;
 
 	Vector2 ret = move_and_slide(p_linear_velocity, p_floor_direction, p_stop_on_slope, p_max_slides, p_floor_max_angle, p_infinite_inertia);
-	if ((!was_on_floor && !was_on_ceiling && !was_on_wall) || p_snap == Vector2()) {
+	if (!was_on_floor || p_snap == Vector2()) {
 		return ret;
 	}
 
@@ -1341,20 +1339,10 @@ Vector2 KinematicBody2D::move_and_slide_with_snap(const Vector2 &p_linear_veloci
 
 	if (move_and_collide(p_snap, p_infinite_inertia, col, false, true)) {
 		gt.elements[2] += col.travel;
-		colliders.push_back(col);
-		if (p_floor_direction == Vector2()) {
-			//all is a wall
-			on_wall = true;
-		} else {
-			if (col.normal.dot(p_floor_direction) >= Math::cos(p_floor_max_angle + FLOOR_ANGLE_THRESHOLD)) { //floor
-				on_floor = true;
-				on_floor_body = col.collider_rid;
-				floor_velocity = col.collider_vel;
-			} else if (col.normal.dot(-p_floor_direction) >= Math::cos(p_floor_max_angle + FLOOR_ANGLE_THRESHOLD)) { //ceiling
-				on_ceiling = true;
-			} else {
-				on_wall = true;
-			}
+		if (p_floor_direction != Vector2() && Math::acos(p_floor_direction.normalized().dot(col.normal)) < p_floor_max_angle) {
+			on_floor = true;
+			on_floor_body = col.collider_rid;
+			floor_velocity = col.collider_vel;
 		}
 		set_global_transform(gt);
 	}

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1328,9 +1328,11 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 Vector2 KinematicBody2D::move_and_slide_with_snap(const Vector2 &p_linear_velocity, const Vector2 &p_snap, const Vector2 &p_floor_direction, bool p_stop_on_slope, int p_max_slides, float p_floor_max_angle, bool p_infinite_inertia) {
 
 	bool was_on_floor = on_floor;
+	bool was_on_ceiling = on_ceiling;
+	bool was_on_wall = on_wall;
 
 	Vector2 ret = move_and_slide(p_linear_velocity, p_floor_direction, p_stop_on_slope, p_max_slides, p_floor_max_angle, p_infinite_inertia);
-	if (!was_on_floor || p_snap == Vector2()) {
+	if ((!was_on_floor && !was_on_ceiling && !was_on_wall) || p_snap == Vector2()) {
 		return ret;
 	}
 
@@ -1339,10 +1341,20 @@ Vector2 KinematicBody2D::move_and_slide_with_snap(const Vector2 &p_linear_veloci
 
 	if (move_and_collide(p_snap, p_infinite_inertia, col, false, true)) {
 		gt.elements[2] += col.travel;
-		if (p_floor_direction != Vector2() && Math::acos(p_floor_direction.normalized().dot(col.normal)) < p_floor_max_angle) {
-			on_floor = true;
-			on_floor_body = col.collider_rid;
-			floor_velocity = col.collider_vel;
+		colliders.push_back(col);
+		if (p_floor_direction == Vector2()) {
+			//all is a wall
+			on_wall = true;
+		} else {
+			if (col.normal.dot(p_floor_direction) >= Math::cos(p_floor_max_angle + FLOOR_ANGLE_THRESHOLD)) { //floor
+				on_floor = true;
+				on_floor_body = col.collider_rid;
+				floor_velocity = col.collider_vel;
+			} else if (col.normal.dot(-p_floor_direction) >= Math::cos(p_floor_max_angle + FLOOR_ANGLE_THRESHOLD)) { //ceiling
+				on_ceiling = true;
+			} else {
+				on_wall = true;
+			}
 		}
 		set_global_transform(gt);
 	}

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1270,8 +1270,8 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 Vector3 KinematicBody::move_and_slide_with_snap(const Vector3 &p_linear_velocity, const Vector3 &p_snap, const Vector3 &p_floor_direction, bool p_stop_on_slope, int p_max_slides, float p_floor_max_angle, bool p_infinite_inertia) {
 
 	bool was_on_floor = on_floor;
-	bool was_on_ceiling = on_ceiling;
-	bool was_on_wall = on_wall;
+	bool was_on_ceiling = on_ceiling
+	bool was_on_wall = on_wall
 
 	Vector3 ret = move_and_slide(p_linear_velocity, p_floor_direction, p_stop_on_slope, p_max_slides, p_floor_max_angle, p_infinite_inertia);
 	if ((!was_on_floor && !was_on_ceiling && !was_on_wall) || p_snap == Vector3()) {

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1270,8 +1270,8 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 Vector3 KinematicBody::move_and_slide_with_snap(const Vector3 &p_linear_velocity, const Vector3 &p_snap, const Vector3 &p_floor_direction, bool p_stop_on_slope, int p_max_slides, float p_floor_max_angle, bool p_infinite_inertia) {
 
 	bool was_on_floor = on_floor;
-	bool was_on_ceiling = on_ceiling
-	bool was_on_wall = on_wall
+	bool was_on_ceiling = on_ceiling;
+	bool was_on_wall = on_wall;
 
 	Vector3 ret = move_and_slide(p_linear_velocity, p_floor_direction, p_stop_on_slope, p_max_slides, p_floor_max_angle, p_infinite_inertia);
 	if ((!was_on_floor && !was_on_ceiling && !was_on_wall) || p_snap == Vector3()) {

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1270,9 +1270,11 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 Vector3 KinematicBody::move_and_slide_with_snap(const Vector3 &p_linear_velocity, const Vector3 &p_snap, const Vector3 &p_floor_direction, bool p_stop_on_slope, int p_max_slides, float p_floor_max_angle, bool p_infinite_inertia) {
 
 	bool was_on_floor = on_floor;
+	bool was_on_ceiling = on_ceiling
+	bool was_on_wall = on_wall
 
 	Vector3 ret = move_and_slide(p_linear_velocity, p_floor_direction, p_stop_on_slope, p_max_slides, p_floor_max_angle, p_infinite_inertia);
-	if (!was_on_floor || p_snap == Vector3()) {
+	if ((!was_on_floor && !was_on_ceiling && !was_on_wall) || p_snap == Vector3()) {
 		return ret;
 	}
 
@@ -1281,10 +1283,19 @@ Vector3 KinematicBody::move_and_slide_with_snap(const Vector3 &p_linear_velocity
 
 	if (move_and_collide(p_snap, p_infinite_inertia, col, true)) {
 		gt.origin += col.travel;
-		if (p_floor_direction != Vector3() && Math::acos(p_floor_direction.normalized().dot(col.normal)) < p_floor_max_angle) {
-			on_floor = true;
-			on_floor_body = col.collider_rid;
-			floor_velocity = col.collider_vel;
+		if (p_floor_direction == Vector3()) {
+			//all is a wall
+			on_wall = true;
+		} else {
+			if (col.normal.dot(p_floor_direction) >= Math::cos(p_floor_max_angle + FLOOR_ANGLE_THRESHOLD)) { //floor
+				on_floor = true;
+				on_floor_body = col.collider_rid;
+				floor_velocity = col.collider_vel;
+			} else if (col.normal.dot(-p_floor_direction) >= Math::cos(p_floor_max_angle + FLOOR_ANGLE_THRESHOLD)) { //ceiling
+				on_ceiling = true;
+			} else {
+				on_wall = true;
+			}
 		}
 		set_global_transform(gt);
 	}

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1283,6 +1283,7 @@ Vector3 KinematicBody::move_and_slide_with_snap(const Vector3 &p_linear_velocity
 
 	if (move_and_collide(p_snap, p_infinite_inertia, col, true)) {
 		gt.origin += col.travel;
+		colliders.push_back(col)
 		if (p_floor_direction == Vector3()) {
 			//all is a wall
 			on_wall = true;

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1283,7 +1283,7 @@ Vector3 KinematicBody::move_and_slide_with_snap(const Vector3 &p_linear_velocity
 
 	if (move_and_collide(p_snap, p_infinite_inertia, col, true)) {
 		gt.origin += col.travel;
-		colliders.push_back(col)
+		colliders.push_back(col);
 		if (p_floor_direction == Vector3()) {
 			//all is a wall
 			on_wall = true;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -382,36 +382,30 @@ void Sprite3D::_draw() {
 
 	VS::get_singleton()->immediate_clear(immediate);
 	if (!texture.is_valid())
-		return; //no texuture no life
+		return;
 	Vector2 tsize = texture->get_size();
 	if (tsize.x == 0 || tsize.y == 0)
 		return;
 
-	Size2i s;
-	Rect2 src_rect;
+	Rect2 base_rect;
+	if (region)
+		base_rect = region_rect;
+	else
+		base_rect = Rect2(0, 0, texture->get_width(), texture->get_height());
 
-	if (region) {
+	Size2 frame_size = base_rect.size / Size2(hframes, vframes);
+	Point2 frame_offset = Point2(frame % hframes, frame / hframes);
+	frame_offset *= frame_size;
 
-		s = region_rect.size;
-		src_rect = region_rect;
-	} else {
-		s = texture->get_size();
-		s = s / Size2(hframes, vframes);
-
-		src_rect.size = s;
-		src_rect.position.x += (frame % hframes) * s.x;
-		src_rect.position.y += (frame / hframes) * s.y;
-	}
-
-	Point2 ofs = get_offset();
+	Point2 dest_offset = get_offset();
 	if (is_centered())
-		ofs -= s / 2;
+		dest_offset -= frame_size / 2;
 
-	Rect2 dst_rect(ofs, s);
-
+	Rect2 src_rect(base_rect.position + frame_offset, frame_size);
+	Rect2 final_dst_rect(dest_offset, frame_size);
 	Rect2 final_rect;
 	Rect2 final_src_rect;
-	if (!texture->get_rect_region(dst_rect, src_rect, final_rect, final_src_rect))
+	if (!texture->get_rect_region(final_dst_rect, src_rect, final_rect, final_src_rect))
 		return;
 
 	if (final_rect.size.x == 0 || final_rect.size.y == 0)

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2645,24 +2645,26 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 			case KEY_UP: {
 
-				if (k->get_shift())
-					_pre_shift_selection();
 				if (k->get_alt()) {
 					scancode_handled = false;
 					break;
 				}
 #ifndef APPLE_STYLE_KEYS
 				if (k->get_command()) {
-					_scroll_lines_up();
-					break;
-				}
 #else
 				if (k->get_command() && k->get_alt()) {
+#endif
 					_scroll_lines_up();
 					break;
 				}
 
+				if (k->get_shift()) {
+					_pre_shift_selection();
+				}
+
+#ifdef APPLE_STYLE_KEYS
 				if (k->get_command()) {
+
 					cursor_set_line(0);
 				} else
 #endif
@@ -2696,24 +2698,24 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 			case KEY_DOWN: {
 
-				if (k->get_shift())
-					_pre_shift_selection();
 				if (k->get_alt()) {
 					scancode_handled = false;
 					break;
 				}
 #ifndef APPLE_STYLE_KEYS
 				if (k->get_command()) {
-					_scroll_lines_down();
-					break;
-				}
-
 #else
 				if (k->get_command() && k->get_alt()) {
+#endif
 					_scroll_lines_down();
 					break;
 				}
 
+				if (k->get_shift()) {
+					_pre_shift_selection();
+				}
+
+#ifdef APPLE_STYLE_KEYS
 				if (k->get_command()) {
 					cursor_set_line(get_last_unhidden_line(), true, false, 9999);
 				} else


### PR DESCRIPTION
Currently, `move_and_slide_with_snap()` will only tell you if the player is on the ground when it snaps, which felt like an oversight. I also rewrote the floor check in the snap to be more consistent with how it's written in `move_and_slide()` and added the snap collision to the array of slide collisions so users can use it a bit more dynamically.