### PR TITLE
[GLES2] Initialize color buffer to white in gles2 multimesh

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -1564,6 +1564,8 @@ void RasterizerSceneGLES2::_render_geometry(RenderList::Element *p_element) {
 					} else {
 						glVertexAttrib4fv(INSTANCE_ATTRIB_BASE + 3, buffer + color_ofs);
 					}
+				} else {
+					glVertexAttrib4f(INSTANCE_ATTRIB_BASE + 3, 1.0, 1.0, 1.0, 1.0);
 				}
 
 				if (multi_mesh->custom_data_floats) {


### PR DESCRIPTION
This fixes #25601 

All it does is initialize the color variable to all 1s when color_format is set to None. 