### PR TITLE
Change hint_color to hint_albedo for sampler2ds

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -324,7 +324,7 @@ String VisualShaderNodeTexture::generate_global(Shader::Mode p_mode, VisualShade
 		String u = "uniform sampler2D " + make_unique_id(p_type, p_id, "tex");
 		switch (texture_type) {
 			case TYPE_DATA: break;
-			case TYPE_COLOR: u += " : hint_color"; break;
+			case TYPE_COLOR: u += " : hint_albedo"; break;
 			case TYPE_NORMALMAP: u += " : hint_normal"; break;
 		}
 		return u + ";";
@@ -554,7 +554,7 @@ String VisualShaderNodeCubeMap::generate_global(Shader::Mode p_mode, VisualShade
 	String u = "uniform sampler2DCube " + make_unique_id(p_type, p_id, "cube");
 	switch (texture_type) {
 		case TYPE_DATA: break;
-		case TYPE_COLOR: u += " : hint_color"; break;
+		case TYPE_COLOR: u += " : hint_albedo"; break;
 		case TYPE_NORMALMAP: u += " : hint_normal"; break;
 	}
 	return u + ";";


### PR DESCRIPTION
When you would set the type to color in visual shaders you would get an error saying that hint_color can only be used with vec4s. The proper hint for sampler2ds is hint_albedo. 