### PR TITLE
Added a mesh interface to the arvr positional trackers

### DIFF
--- a/doc/classes/ARVRAnchor.xml
+++ b/doc/classes/ARVRAnchor.xml
@@ -27,6 +27,13 @@
 				Returns true if the anchor is being tracked and false if no anchor with this id is currently known.
 			</description>
 		</method>
+		<method name="get_mesh" qualifiers="const">
+			<return type="Mesh">
+			</return>
+			<description>
+				If provided by the ARVR Interface this returns a mesh object for the anchor. For an anchor this can be a shape related to the object being tracked or it can be a mesh that provides topology related to the anchor and can be used to create shadows/reflections on surfaces or for generating collision shapes.
+			</description>
+		</method>
 		<method name="get_plane" qualifiers="const">
 			<return type="Plane">
 			</return>
@@ -47,6 +54,15 @@
 			The anchor's id. You can set this before the anchor itself exists. The first anchor gets an id of [code]1[/code], the second an id of [code]2[/code], etc. When anchors get removed, the engine can then assign the corresponding id to new anchors. The most common situation where anchors 'disappear' is when the AR server identifies that two anchors represent different parts of the same plane and merges them.
 		</member>
 	</members>
+	<signals>
+		<signal name="mesh_updated">
+			<argument index="0" name="mesh" type="Mesh">
+			</argument>
+			<description>
+				Emitted when the mesh associated with the anchor changes or when one becomes available. This is especially important for topology that is constantly being mesh_updated.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/ARVRController.xml
+++ b/doc/classes/ARVRController.xml
@@ -50,6 +50,13 @@
 				Returns the ID of the joystick object bound to this. Every controller tracked by the ARVR Server that has buttons and axis will also be registered as a joystick within Godot. This means that all the normal joystick tracking and input mapping will work for buttons and axis found on the AR/VR controllers. This ID is purely offered as information so you can link up the controller with its joystick entry.
 			</description>
 		</method>
+		<method name="get_mesh" qualifiers="const">
+			<return type="Mesh">
+			</return>
+			<description>
+				If provided by the ARVR Interface this returns a mesh associated with the controller. This can be used to visualise the controller.
+			</description>
+		</method>
 		<method name="is_button_pressed" qualifiers="const">
 			<return type="int">
 			</return>
@@ -84,6 +91,13 @@
 			</argument>
 			<description>
 				Emitted when a button on this controller is released.
+			</description>
+		</signal>
+		<signal name="mesh_updated">
+			<argument index="0" name="mesh" type="Mesh">
+			</argument>
+			<description>
+				Emitted when the mesh associated with the controller changes or when one becomes available. Generally speaking this will be a static mesh after becoming available.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/ARVRPositionalTracker.xml
+++ b/doc/classes/ARVRPositionalTracker.xml
@@ -27,6 +27,13 @@
 				If this is a controller that is being tracked the controller will also be represented by a joystick entry with this id.
 			</description>
 		</method>
+		<method name="get_mesh" qualifiers="const">
+			<return type="Mesh">
+			</return>
+			<description>
+				Returns the mesh related to a controller or anchor point if one is available.
+			</description>
+		</method>
 		<method name="get_name" qualifiers="const">
 			<return type="String">
 			</return>

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -233,6 +233,13 @@ void ARVRController::_notification(int p_what) {
 				} else {
 					button_states = 0;
 				};
+
+				// check for an updated mesh
+				Ref<Mesh> trackerMesh = tracker->get_mesh();
+				if (mesh != trackerMesh) {
+					mesh = trackerMesh;
+					emit_signal("mesh_updated", mesh);
+				}
 			};
 		}; break;
 		default:
@@ -258,8 +265,11 @@ void ARVRController::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_rumble", "rumble"), &ARVRController::set_rumble);
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "rumble", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_rumble", "get_rumble");
 
+	ClassDB::bind_method(D_METHOD("get_mesh"), &ARVRController::get_mesh);
+
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::INT, "button")));
 	ADD_SIGNAL(MethodInfo("button_release", PropertyInfo(Variant::INT, "button")));
+	ADD_SIGNAL(MethodInfo("mesh_updated", PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh")));
 };
 
 void ARVRController::set_controller_id(int p_controller_id) {
@@ -340,6 +350,10 @@ void ARVRController::set_rumble(real_t p_rumble) {
 		tracker->set_rumble(p_rumble);
 	};
 };
+
+Ref<Mesh> ARVRController::get_mesh() const {
+	return mesh;
+}
 
 bool ARVRController::get_is_active() const {
 	return is_active;
@@ -423,6 +437,13 @@ void ARVRAnchor::_notification(int p_what) {
 
 				// apply our reference frame and set our transform
 				set_transform(arvr_server->get_reference_frame() * transform);
+
+				// check for an updated mesh
+				Ref<Mesh> trackerMesh = tracker->get_mesh();
+				if (mesh != trackerMesh) {
+					mesh = trackerMesh;
+					emit_signal("mesh_updated", mesh);
+				}
 			};
 		}; break;
 		default:
@@ -441,6 +462,9 @@ void ARVRAnchor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_size"), &ARVRAnchor::get_size);
 
 	ClassDB::bind_method(D_METHOD("get_plane"), &ARVRAnchor::get_plane);
+
+	ClassDB::bind_method(D_METHOD("get_mesh"), &ARVRAnchor::get_mesh);
+	ADD_SIGNAL(MethodInfo("mesh_updated", PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh")));
 };
 
 void ARVRAnchor::set_anchor_id(int p_anchor_id) {
@@ -500,6 +524,10 @@ Plane ARVRAnchor::get_plane() const {
 
 	return plane;
 };
+
+Ref<Mesh> ARVRAnchor::get_mesh() const {
+	return mesh;
+}
 
 ARVRAnchor::ARVRAnchor() {
 	anchor_id = 0;

--- a/scene/3d/arvr_nodes.h
+++ b/scene/3d/arvr_nodes.h
@@ -33,6 +33,7 @@
 
 #include "scene/3d/camera.h"
 #include "scene/3d/spatial.h"
+#include "scene/resources/mesh.h"
 #include "servers/arvr/arvr_positional_tracker.h"
 
 /**
@@ -75,6 +76,7 @@ private:
 	int controller_id;
 	bool is_active;
 	int button_states;
+	Ref<Mesh> mesh;
 
 protected:
 	void _notification(int p_what);
@@ -95,6 +97,8 @@ public:
 	bool get_is_active() const;
 	ARVRPositionalTracker::TrackerHand get_hand() const;
 
+	Ref<Mesh> get_mesh(void) const;
+
 	String get_configuration_warning() const;
 
 	ARVRController();
@@ -113,6 +117,7 @@ private:
 	int anchor_id;
 	bool is_active;
 	Vector3 size;
+	Ref<Mesh> mesh;
 
 protected:
 	void _notification(int p_what);
@@ -127,6 +132,8 @@ public:
 	Vector3 get_size() const;
 
 	Plane get_plane() const;
+
+	Ref<Mesh> get_mesh(void) const;
 
 	String get_configuration_warning() const;
 

--- a/servers/arvr/arvr_positional_tracker.cpp
+++ b/servers/arvr/arvr_positional_tracker.cpp
@@ -46,6 +46,7 @@ void ARVRPositionalTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_position"), &ARVRPositionalTracker::get_position);
 	ClassDB::bind_method(D_METHOD("get_hand"), &ARVRPositionalTracker::get_hand);
 	ClassDB::bind_method(D_METHOD("get_transform", "adjust_by_reference_frame"), &ARVRPositionalTracker::get_transform);
+	ClassDB::bind_method(D_METHOD("get_mesh"), &ARVRPositionalTracker::get_mesh);
 
 	// these functions we don't want to expose to normal users but do need to be callable from GDNative
 	ClassDB::bind_method(D_METHOD("_set_type", "type"), &ARVRPositionalTracker::set_type);
@@ -53,7 +54,7 @@ void ARVRPositionalTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_joy_id", "joy_id"), &ARVRPositionalTracker::set_joy_id);
 	ClassDB::bind_method(D_METHOD("_set_orientation", "orientation"), &ARVRPositionalTracker::set_orientation);
 	ClassDB::bind_method(D_METHOD("_set_rw_position", "rw_position"), &ARVRPositionalTracker::set_rw_position);
-
+	ClassDB::bind_method(D_METHOD("_set_mesh", "mesh"), &ARVRPositionalTracker::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_rumble"), &ARVRPositionalTracker::get_rumble);
 	ClassDB::bind_method(D_METHOD("set_rumble", "rumble"), &ARVRPositionalTracker::set_rumble);
 
@@ -152,6 +153,18 @@ Vector3 ARVRPositionalTracker::get_rw_position() const {
 	_THREAD_SAFE_METHOD_
 
 	return rw_position;
+};
+
+void ARVRPositionalTracker::set_mesh(const Ref<Mesh> &p_mesh) {
+	_THREAD_SAFE_METHOD_
+
+	mesh = p_mesh;
+};
+
+Ref<Mesh> ARVRPositionalTracker::get_mesh() const {
+	_THREAD_SAFE_METHOD_
+
+	return mesh;
 };
 
 ARVRPositionalTracker::TrackerHand ARVRPositionalTracker::get_hand() const {

--- a/servers/arvr/arvr_positional_tracker.h
+++ b/servers/arvr/arvr_positional_tracker.h
@@ -32,6 +32,7 @@
 #define ARVR_POSITIONAL_TRACKER_H
 
 #include "core/os/thread_safe.h"
+#include "scene/resources/mesh.h"
 #include "servers/arvr_server.h"
 
 /**
@@ -40,9 +41,6 @@
 	The positional tracker object as an object that represents the position and orientation of a tracked object like a controller or headset.
 	An AR/VR Interface will registered the trackers it manages with our AR/VR server and update its position and orientation.
 	This is where potentially additional AR/VR interfaces may be active as there are AR/VR SDKs that solely deal with positional tracking.
-
-	@TODO:
-	- create subclass of spatial node that uses one of our positional trackers to automatically determine its position
 */
 
 class ARVRPositionalTracker : public Object {
@@ -65,6 +63,7 @@ private:
 	Basis orientation; // our orientation
 	bool tracks_position; // do we track position?
 	Vector3 rw_position; // our position "in the real world, so without world_scale applied"
+	Ref<Mesh> mesh; // when available, a mesh that can be used to render this tracker
 	TrackerHand hand; // if known, the hand this tracker is held in
 	real_t rumble; // rumble strength, 0.0 is off, 1.0 is maximum, note that we only record here, arvr_interface is responsible for execution
 
@@ -91,6 +90,8 @@ public:
 	void set_hand(const ARVRPositionalTracker::TrackerHand p_hand);
 	real_t get_rumble() const;
 	void set_rumble(real_t p_rumble);
+	void set_mesh(const Ref<Mesh> &p_mesh);
+	Ref<Mesh> get_mesh() const;
 
 	Transform get_transform(bool p_adjust_by_reference_frame) const;
 


### PR DESCRIPTION
This adds the ability to link a mesh to a positional tracker. This enhancement came out of the work we're doing on ArKit but I wanted to give it it's own PR. 

The use case in AR that we're currently using this for is with Anchors (physical locations in the real world mapped to the virtual world) which are implemented as positional trackers. ArKit 2.0 now has the ability to provide a mesh with a rough shape of the object. Say there is a table and ArKit has figured out the location of the table, it will slowly build a rough mesh for that table. We can use that mesh as a collision shape so objects can be placed on the table, or we can use that mesh for a transparent material and render shadows or reflections of virtual object on the real table.

ArKit will continuously update the shape and provide new meshes. The changes in the PR allow ArKit to store the mesh on the tracker so that we can make it available to the user.

I've also included the ability to use the same mechanism to make controller meshes available. Again the same principle applies, many VR SDKs have an interface to access the mesh of the controller the user is using, we currently have different implementations for each SDK. This allows the SDK to store the mesh on the tracker that tracks the position of the controller and provide a more generic method of optionally rendering the controller. 
