### PR TITLE
Mono: Workaround to fix 'flushing' errors when building at editor startup

### DIFF
--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "godotsharp_editor.h"
 
+#include "core/message_queue.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "scene/gui/control.h"
@@ -114,10 +115,33 @@ bool GodotSharpEditor::_create_project_solution() {
 
 void GodotSharpEditor::_make_api_solutions_if_needed() {
 	// I'm sick entirely of ProgressDialog
+
+	static int attempts_left = 100;
+
+	if (MessageQueue::get_singleton()->is_flushing() || !SceneTree::get_singleton()) {
+		ERR_FAIL_COND(attempts_left == 0); // You've got to be kidding
+
+		if (SceneTree::get_singleton()) {
+			SceneTree::get_singleton()->connect("idle_frame", this, "_make_api_solutions_if_needed", Vector<Variant>());
+		} else {
+			call_deferred("_make_api_solutions_if_needed");
+		}
+
+		attempts_left--;
+		return;
+	}
+
+	// Recursion guard needed because signals don't play well with ProgressDialog either, but unlike
+	// the message queue, with signals the collateral damage should be minimal in the worst case.
 	static bool recursion_guard = false;
 	if (!recursion_guard) {
 		recursion_guard = true;
+
+		// Oneshot signals don't play well with ProgressDialog either, so we do it this way instead
+		SceneTree::get_singleton()->disconnect("idle_frame", this, "_make_api_solutions_if_needed");
+
 		_make_api_solutions_if_needed_impl();
+
 		recursion_guard = false;
 	}
 }
@@ -434,7 +458,7 @@ GodotSharpEditor::GodotSharpEditor(EditorNode *p_editor) {
 	String csproj_path = GodotSharpDirs::get_project_csproj_path();
 
 	if (FileAccess::exists(sln_path) && FileAccess::exists(csproj_path)) {
-		// We can't use EditorProgress here. It calls Main::iterarion() and the main loop is not initialized yet.
+		// Defer this task because EditorProgress calls Main::iterarion() and the main loop is not yet initialized.
 		call_deferred("_make_api_solutions_if_needed");
 	} else {
 		bottom_panel_btn->hide();


### PR DESCRIPTION
ProgressDialog won't rest until it has squeezed every last drop of life out of me.

Fixes #25047

Note: This was not an issue for official builds since we bundle prebuilt assemblies.
