### PR TITLE
Added a setting for files in which the editor should search (project specific)

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1005,6 +1005,15 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/config/custom_user_dir_name", "");
 	GLOBAL_DEF("application/config/project_settings_override", "");
 
+	PoolStringArray extensions = PoolStringArray();
+	extensions.push_back("gd");
+	if (Engine::get_singleton()->has_singleton("GodotSharp"))
+		extensions.push_back("cs");
+	extensions.push_back("shader");
+
+	GLOBAL_DEF("editor/search_in_file_extensions", extensions);
+	custom_prop_info["editor/search_in_file_extensions"] = PropertyInfo(Variant::POOL_STRING_ARRAY, "editor/search_in_file_extensions");
+
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -367,28 +367,11 @@ FindInFilesDialog::FindInFilesDialog() {
 
 	Label *filter_label = memnew(Label);
 	filter_label->set_text(TTR("Filters:"));
+	filter_label->set_tooltip(TTR("Include the files with the following extensions. Add or remove them in ProjectSettings."));
 	gc->add_child(filter_label);
 
-	{
-		HBoxContainer *hbc = memnew(HBoxContainer);
-
-		// TODO: Unhardcode this.
-		Vector<String> exts;
-		exts.push_back("gd");
-		if (Engine::get_singleton()->has_singleton("GodotSharp"))
-			exts.push_back("cs");
-		exts.push_back("shader");
-
-		for (int i = 0; i < exts.size(); ++i) {
-			CheckBox *cb = memnew(CheckBox);
-			cb->set_text(exts[i]);
-			cb->set_pressed(true);
-			hbc->add_child(cb);
-			_filters.push_back(cb);
-		}
-
-		gc->add_child(hbc);
-	}
+	_filters_container = memnew(HBoxContainer);
+	gc->add_child(_filters_container);
 
 	_find_button = add_button(TTR("Find..."), false, "find");
 	_find_button->set_disabled(true);
@@ -424,11 +407,12 @@ String FindInFilesDialog::get_folder() const {
 }
 
 Set<String> FindInFilesDialog::get_filter() const {
+	// could check the _filters_preferences but it might not have been generated yet.
 	Set<String> filters;
-	for (int i = 0; i < _filters.size(); ++i) {
-		CheckBox *cb = _filters[i];
+	for (int i = 0; i < _filters_container->get_child_count(); ++i) {
+		CheckBox *cb = (CheckBox *)_filters_container->get_child(i);
 		if (cb->is_pressed()) {
-			filters.insert(_filters[i]->get_text());
+			filters.insert(cb->get_text());
 		}
 	}
 	return filters;
@@ -440,6 +424,20 @@ void FindInFilesDialog::_notification(int p_what) {
 			// Doesn't work more than once if not deferred...
 			_search_text_line_edit->call_deferred("grab_focus");
 			_search_text_line_edit->select_all();
+			// Extensions might have changed in the meantime, we clean them and instance them again.
+			for (int i = 0; i < _filters_container->get_child_count(); i++) {
+				_filters_container->get_child(i)->queue_delete();
+			}
+			Array exts = ProjectSettings::get_singleton()->get("editor/search_in_file_extensions");
+			for (int i = 0; i < exts.size(); ++i) {
+				CheckBox *cb = memnew(CheckBox);
+				cb->set_text(exts[i]);
+				if (!_filters_preferences.has(exts[i])) {
+					_filters_preferences[exts[i]] = true;
+				}
+				cb->set_pressed(_filters_preferences[exts[i]]);
+				_filters_container->add_child(cb);
+			}
 		}
 	}
 }
@@ -449,6 +447,10 @@ void FindInFilesDialog::_on_folder_button_pressed() {
 }
 
 void FindInFilesDialog::custom_action(const String &p_action) {
+	for (int i = 0; i < _filters_container->get_child_count(); ++i) {
+		CheckBox *cb = (CheckBox *)_filters_container->get_child(i);
+		_filters_preferences[cb->get_text()] = cb->is_pressed();
+	}
 	if (p_action == "find") {
 		emit_signal(SIGNAL_FIND_REQUESTED);
 		hide();

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -31,6 +31,7 @@
 #ifndef FIND_IN_FILES_H
 #define FIND_IN_FILES_H
 
+#include "core/hash_map.h"
 #include "scene/gui/dialogs.h"
 
 // Performs the actual search
@@ -88,6 +89,7 @@ private:
 class LineEdit;
 class CheckBox;
 class FileDialog;
+class HBoxContainer;
 
 // Prompts search parameters
 class FindInFilesDialog : public AcceptDialog {
@@ -120,12 +122,13 @@ private:
 
 	LineEdit *_search_text_line_edit;
 	LineEdit *_folder_line_edit;
-	Vector<CheckBox *> _filters;
 	CheckBox *_match_case_checkbox;
 	CheckBox *_whole_words_checkbox;
 	Button *_find_button;
 	Button *_replace_button;
 	FileDialog *_folder_dialog;
+	HBoxContainer *_filters_container;
+	HashMap<String, bool> _filters_preferences;
 };
 
 class Button;


### PR DESCRIPTION
Could not figure out how to make the editor insert only strings in the array.

The dialog no longer remembers the checkboxes (they are replaced every time the dialog pops up)
If for any reasons the servers are enabled after the creation of project settings, the .cs extension will not automatically show

*Bugsquad edit:* ~~Fixes~~ Workaround for #25440