### PR TITLE
Allow CollisionObject2D to get shapes from tilemaps

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -218,12 +218,13 @@ void CollisionObject2D::shape_owner_set_transform(uint32_t p_owner, const Transf
 	ERR_FAIL_COND(!shapes.has(p_owner));
 
 	ShapeData &sd = shapes[p_owner];
+
 	sd.xform = p_transform;
 	for (int i = 0; i < sd.shapes.size(); i++) {
 		if (area) {
-			Physics2DServer::get_singleton()->area_set_shape_transform(rid, sd.shapes[i].index, p_transform);
+			Physics2DServer::get_singleton()->area_set_shape_transform(rid, sd.shapes[i].index, sd.xform);
 		} else {
-			Physics2DServer::get_singleton()->body_set_shape_transform(rid, sd.shapes[i].index, p_transform);
+			Physics2DServer::get_singleton()->body_set_shape_transform(rid, sd.shapes[i].index, sd.xform);
 		}
 	}
 }
@@ -387,7 +388,7 @@ String CollisionObject2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (shapes.empty()) {
-		if (warning == String()) {
+		if (!warning.empty()) {
 			warning += "\n";
 		}
 		warning += TTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape2D or CollisionPolygon2D as a child to define its shape.");

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -37,6 +37,8 @@
 #include "scene/2d/node_2d.h"
 #include "scene/resources/tile_set.h"
 
+class CollisionObject2D;
+
 class TileMap : public Node2D {
 
 	GDCLASS(TileMap, Node2D);
@@ -74,6 +76,8 @@ private:
 	Mode mode;
 	Transform2D custom_transform;
 	HalfOffset half_offset;
+	bool use_parent;
+	CollisionObject2D *collision_parent;
 	bool use_kinematic;
 	Navigation2D *navigation;
 
@@ -123,6 +127,7 @@ private:
 		Vector2 pos;
 		List<RID> canvas_items;
 		RID body;
+		uint32_t shape_owner_id;
 
 		SelfList<Quadrant> dirty_list;
 
@@ -145,6 +150,7 @@ private:
 			pos = q.pos;
 			canvas_items = q.canvas_items;
 			body = q.body;
+			shape_owner_id = q.shape_owner_id;
 			cells = q.cells;
 			navpoly_ids = q.navpoly_ids;
 			occluder_instances = q.occluder_instances;
@@ -154,6 +160,7 @@ private:
 			pos = q.pos;
 			canvas_items = q.canvas_items;
 			body = q.body;
+			shape_owner_id = q.shape_owner_id;
 			cells = q.cells;
 			occluder_instances = q.occluder_instances;
 			navpoly_ids = q.navpoly_ids;
@@ -188,6 +195,8 @@ private:
 
 	void _fix_cell_transform(Transform2D &xform, const Cell &p_cell, const Vector2 &p_offset, const Size2 &p_sc);
 
+	void _add_shape(int &shape_idx, const Quadrant &p_q, const Ref<Shape2D> &p_shape, const TileSet::ShapeData &p_shape_data, const Transform2D &p_xform, const Vector2 &p_metadata);
+
 	Map<PosKey, Quadrant>::Element *_create_quadrant(const PosKey &p_qk);
 	void _erase_quadrant(Map<PosKey, Quadrant>::Element *Q);
 	void _make_quadrant_dirty(Map<PosKey, Quadrant>::Element *Q, bool update = true);
@@ -218,6 +227,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual void _validate_property(PropertyInfo &property) const;
 	virtual void _changed_callback(Object *p_changed, const char *p_prop);
 
 public:
@@ -271,6 +281,9 @@ public:
 	void set_collision_use_kinematic(bool p_use_kinematic);
 	bool get_collision_use_kinematic() const;
 
+	void set_collision_use_parent(bool p_use_parent);
+	bool get_collision_use_parent() const;
+
 	void set_collision_friction(float p_friction);
 	float get_collision_friction() const;
 
@@ -313,6 +326,8 @@ public:
 
 	void set_clip_uv(bool p_enable);
 	bool get_clip_uv() const;
+
+	String get_configuration_warning() const;
 
 	void fix_invalid_tiles();
 	void clear();


### PR DESCRIPTION
Fixes #4454 and likely resolves #22285.

There are a few additional cosmetic changes to CollisionShape2D. They can potentially be removed from the PR without impacting it.

The way this feature works is by adding a new option to TileMap: `collisions_use_parent` ("Use Parent"). If it is on, the Tilemap will put all its shapes into the parent CollisionShape2D body, which can be an Area2D, RigidBody2D, KinematicBody2D, or, tho that's useless, a StaticBody2D.