### PR TITLE
fix CustomType  error spams in CreateDialog

### DIFF
--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -181,6 +181,12 @@ public:
 	Object *instance_custom_type(const String &p_type, const String &p_inherits);
 	void remove_custom_type(const String &p_type);
 	const Map<String, Vector<CustomType> > &get_custom_types() const { return custom_types; }
+	const CustomType get_custom_type(const String &p_type, String *r_base = NULL) const;
+	bool is_custom_type(const String &p_type) const;
+	String custom_type_get_base(const String &p_type) const;
+	bool custom_type_is_parent_class(const String &p_type, const String &p_inherits) const;
+
+	static bool script_inherits(const Ref<Script> &p_script, const Ref<Script> &p_inherits);
 
 	int add_edited_scene(int p_at_pos);
 	void move_edited_scene_index(int p_idx, int p_to_idx);


### PR DESCRIPTION
This should close #24041. It adds a bunch of logic to account for CustomTypes in the various checks it performs.

It should be noted that the CreateDialog's inheritance and type checking is becoming increasingly complex, so this solution is more of a bandaid. If/when something like #22181 is integrated, allowing scenes to be named entities as well, then there'll be all the more need for something like the ClassType module it includes to greatly simplify all of the logic.