### PR TITLE
Update CPUParticles.xml

### DIFF
--- a/doc/classes/CPUParticles.xml
+++ b/doc/classes/CPUParticles.xml
@@ -54,6 +54,7 @@
 		<member name="color" type="Color" setter="set_color" getter="get_color">
 		</member>
 		<member name="color_ramp" type="Gradient" setter="set_color_ramp" getter="get_color_ramp">
+			Each particle's vertex color will vary along this [GradientTexture].
 		</member>
 		<member name="damping" type="float" setter="set_param" getter="get_param">
 		</member>


### PR DESCRIPTION
It took me some hours of trying and wondering and one question with a very helpful answer in the facebook group to figure out that the color_ramp gradient actually modifies the vertex color of the particle mesh (but NOT the albedo). After knowing this enabling vertex_color_use_as_albedo in the SpatialMaterial led to success.

I hope adding this little hint:
"Each particle's vertex color will vary along this [GradientTexture]."

Might help other people which stumble upon this...