### PR TITLE
Small changes to the SpriteFrames editor

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -40,10 +40,8 @@ void SpriteFramesEditor::_gui_input(Ref<InputEvent> p_event) {
 
 void SpriteFramesEditor::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_PHYSICS_PROCESS) {
-	}
-
 	if (p_what == NOTIFICATION_ENTER_TREE) {
+
 		load->set_icon(get_icon("Load", "EditorIcons"));
 		copy->set_icon(get_icon("ActionCopy", "EditorIcons"));
 		paste->set_icon(get_icon("ActionPaste", "EditorIcons"));
@@ -54,14 +52,9 @@ void SpriteFramesEditor::_notification(int p_what) {
 		_delete->set_icon(get_icon("Remove", "EditorIcons"));
 		new_anim->set_icon(get_icon("New", "EditorIcons"));
 		remove_anim->set_icon(get_icon("Remove", "EditorIcons"));
-	}
+	} else if (p_what == NOTIFICATION_READY) {
 
-	if (p_what == NOTIFICATION_READY) {
-
-		//NodePath("/root")->connect("node_removed", this,"_node_removed",Vector<Variant>(),true);
-	}
-
-	if (p_what == NOTIFICATION_DRAW) {
+		add_constant_override("autohide", 1); // Fixes the dragger always showing up.
 	}
 }
 
@@ -673,31 +666,25 @@ void SpriteFramesEditor::_bind_methods() {
 
 SpriteFramesEditor::SpriteFramesEditor() {
 
-	//add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel","Panel"));
-
-	split = memnew(HSplitContainer);
-	add_child(split);
-
 	VBoxContainer *vbc_animlist = memnew(VBoxContainer);
-	split->add_child(vbc_animlist);
+	add_child(vbc_animlist);
 	vbc_animlist->set_custom_minimum_size(Size2(150, 0) * EDSCALE);
-	//vbc_animlist->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	VBoxContainer *sub_vb = memnew(VBoxContainer);
-	vbc_animlist->add_margin_child(TTR("Animations"), sub_vb, true);
+	vbc_animlist->add_margin_child(TTR("Animations:"), sub_vb, true);
 	sub_vb->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	HBoxContainer *hbc_animlist = memnew(HBoxContainer);
 	sub_vb->add_child(hbc_animlist);
 
-	new_anim = memnew(Button);
-	new_anim->set_flat(true);
+	new_anim = memnew(ToolButton);
+	new_anim->set_tooltip(TTR("New Animation"));
 	hbc_animlist->add_child(new_anim);
 	new_anim->set_h_size_flags(SIZE_EXPAND_FILL);
 	new_anim->connect("pressed", this, "_animation_add");
 
-	remove_anim = memnew(Button);
-	remove_anim->set_flat(true);
+	remove_anim = memnew(ToolButton);
+	remove_anim->set_tooltip(TTR("Remove Animation"));
 	hbc_animlist->add_child(remove_anim);
 	remove_anim->connect("pressed", this, "_animation_remove");
 
@@ -722,56 +709,47 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	anim_loop->connect("pressed", this, "_animation_loop_changed");
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
-	split->add_child(vbc);
+	add_child(vbc);
 	vbc->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	sub_vb = memnew(VBoxContainer);
-	vbc->add_margin_child(TTR("Animation Frames"), sub_vb, true);
+	vbc->add_margin_child(TTR("Animation Frames:"), sub_vb, true);
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	sub_vb->add_child(hbc);
 
-	//animations = memnew( ItemList );
-
-	load = memnew(Button);
-	load->set_flat(true);
+	load = memnew(ToolButton);
 	load->set_tooltip(TTR("Load Resource"));
 	hbc->add_child(load);
 
-	copy = memnew(Button);
-	copy->set_flat(true);
+	copy = memnew(ToolButton);
 	copy->set_tooltip(TTR("Copy"));
 	hbc->add_child(copy);
 
-	paste = memnew(Button);
-	paste->set_flat(true);
+	paste = memnew(ToolButton);
 	paste->set_tooltip(TTR("Paste"));
 	hbc->add_child(paste);
 
-	empty = memnew(Button);
-	empty->set_flat(true);
+	empty = memnew(ToolButton);
 	empty->set_tooltip(TTR("Insert Empty (Before)"));
 	hbc->add_child(empty);
 
-	empty2 = memnew(Button);
-	empty2->set_flat(true);
+	empty2 = memnew(ToolButton);
 	empty2->set_tooltip(TTR("Insert Empty (After)"));
 	hbc->add_child(empty2);
 
 	hbc->add_spacer(false);
 
-	move_up = memnew(Button);
-	move_up->set_flat(true);
+	move_up = memnew(ToolButton);
 	move_up->set_tooltip(TTR("Move (Before)"));
 	hbc->add_child(move_up);
 
-	move_down = memnew(Button);
-	move_down->set_flat(true);
+	move_down = memnew(ToolButton);
 	move_down->set_tooltip(TTR("Move (After)"));
 	hbc->add_child(move_down);
 
-	_delete = memnew(Button);
-	_delete->set_flat(true);
+	_delete = memnew(ToolButton);
+	_delete->set_tooltip(TTR("Delete"));
 	hbc->add_child(_delete);
 
 	file = memnew(EditorFileDialog);
@@ -787,7 +765,6 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	tree->set_fixed_column_width(thumbnail_size * 3 / 2);
 	tree->set_max_text_lines(2);
 	tree->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
-	//tree->set_min_icon_size(Size2(thumbnail_size,thumbnail_size));
 	tree->set_drag_forwarding(this);
 
 	sub_vb->add_child(tree);

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -39,25 +39,25 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
 
-class SpriteFramesEditor : public PanelContainer {
+class SpriteFramesEditor : public HSplitContainer {
 
-	GDCLASS(SpriteFramesEditor, PanelContainer);
+	GDCLASS(SpriteFramesEditor, HSplitContainer);
 
-	Button *load;
-	Button *_delete;
-	Button *copy;
-	Button *paste;
-	Button *empty;
-	Button *empty2;
-	Button *move_up;
-	Button *move_down;
+	ToolButton *load;
+	ToolButton *_delete;
+	ToolButton *copy;
+	ToolButton *paste;
+	ToolButton *empty;
+	ToolButton *empty2;
+	ToolButton *move_up;
+	ToolButton *move_down;
 	ItemList *tree;
 	bool loading_scene;
 	int sel;
 
 	HSplitContainer *split;
-	Button *new_anim;
-	Button *remove_anim;
+	ToolButton *new_anim;
+	ToolButton *remove_anim;
 
 	Tree *animations;
 	SpinBox *anim_speed;


### PR DESCRIPTION
Very minor stuff. Made the editor itself inherent `HSplitContainer` directly, added some tooltips, and turned the `Button`s into `ToolButton`s, to save a few code lines.