### PR TITLE
Highlight Scripted Nodes, implements #15339

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -46,9 +46,10 @@ void EditorHelpSearch::_update_icons() {
 }
 
 void EditorHelpSearch::_load_settings() {
-
 	bool enable_rl = EditorSettings::get_singleton()->get("docks/scene_tree/draw_relationship_lines");
+	bool enable_sh = EditorSettings::get_singleton()->get("docks/scene_tree/highlight_scripted_nodes");
 	Color rl_color = EditorSettings::get_singleton()->get("docks/scene_tree/relationship_line_color");
+	Color sh_color = EditorSettings::get_singleton()->get("docks/scene_tree/script_highlight_color");
 
 	if (enable_rl) {
 		results_tree->add_constant_override("draw_relationship_lines", 1);
@@ -57,6 +58,14 @@ void EditorHelpSearch::_load_settings() {
 	} else {
 		results_tree->add_constant_override("draw_relationship_lines", 0);
 		results_tree->add_constant_override("draw_guides", 1);
+	}
+
+	if (enable_sh) {
+		results_tree->add_constant_override("highlight_scripted_nodes", 1);
+		results_tree->add_color_override("script_highlight_color", sh_color);
+	} else {
+		results_tree->add_constant_override("highlight_scripted_nodes", 0);
+		results_tree->add_color_override("script_highlight_color", Color(1, 1, 1, 1));
 	}
 }
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -387,6 +387,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/scene_tree/start_create_dialog_fully_expanded", false);
 	_initial_set("docks/scene_tree/draw_relationship_lines", true);
 	_initial_set("docks/scene_tree/relationship_line_color", Color::html("464646"));
+	_initial_set("docks/scene_tree/highlight_scripted_nodes", true);
+	_initial_set("docks/scene_tree/script_highlight_color", Color::html("ffff00"));
 
 	// FileSystem
 	_initial_set("docks/filesystem/display_mode", 0);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -190,12 +190,12 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	item->set_icon(0, icon);
 	item->set_metadata(0, p_node->get_path());
 
-	if (!p_node->get_script().is_null()) {
-		item->set_custom_color(0, Color(1, 1, 0, 1));
-		// Experimental: Trying to get the script nodes to turn Yellow.
-		// TODO: Update the Attach and Remove scripts for the same.
+	if (tree->allow_script_highlight()) {
+		if (!p_node->get_script().is_null()) {
+			item->set_custom_color(0, tree->get_script_color());
+		}
 	}
-
+	
 	if (part_of_subscene) {
 
 		//item->set_selectable(0,marked_selectable);
@@ -986,7 +986,9 @@ void SceneTreeEditor::_warning_changed(Node *p_for_node) {
 
 void SceneTreeEditor::_editor_settings_changed() {
 	bool enable_rl = EditorSettings::get_singleton()->get("docks/scene_tree/draw_relationship_lines");
+	bool enable_sh = EditorSettings::get_singleton()->get("docks/scene_tree/highlight_scripted_nodes");
 	Color rl_color = EditorSettings::get_singleton()->get("docks/scene_tree/relationship_line_color");
+	Color sh_color = EditorSettings::get_singleton()->get("docks/scene_tree/script_highlight_color");
 
 	if (enable_rl) {
 		tree->add_constant_override("draw_relationship_lines", 1);
@@ -995,6 +997,14 @@ void SceneTreeEditor::_editor_settings_changed() {
 	} else {
 		tree->add_constant_override("draw_relationship_lines", 0);
 		tree->add_constant_override("draw_guides", 1);
+	}
+
+	if (enable_sh) {
+		tree->add_constant_override("highlight_scripted_nodes", 1);
+		tree->add_color_override("script_highlight_color", sh_color);
+	} else {
+		tree->add_constant_override("highlight_scripted_nodes", 0);
+		tree->add_color_override("script_highlight_color", Color(1, 1, 1, 1));
 	}
 }
 

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -190,6 +190,12 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	item->set_icon(0, icon);
 	item->set_metadata(0, p_node->get_path());
 
+	if (!p_node->get_script().is_null()) {
+		item->set_custom_color(0, Color(1, 1, 0, 1));
+		// Experimental: Trying to get the script nodes to turn Yellow.
+		// TODO: Update the Attach and Remove scripts for the same.
+	}
+
 	if (part_of_subscene) {
 
 		//item->set_selectable(0,marked_selectable);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1041,7 +1041,9 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			reason->add_color_override("font_color", get_color("error_color", "Editor"));
 
 			bool enable_rl = EditorSettings::get_singleton()->get("docks/scene_tree/draw_relationship_lines");
+			bool enable_sh = EditorSettings::get_singleton()->get("docks/scene_tree/highlight_scripted_nodes");
 			Color rl_color = EditorSettings::get_singleton()->get("docks/scene_tree/relationship_line_color");
+			Color sh_color = EditorSettings::get_singleton()->get("docks/scene_tree/script_highlight_color");
 
 			if (enable_rl) {
 				inspect_scene_tree->add_constant_override("draw_relationship_lines", 1);
@@ -1050,6 +1052,14 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			} else {
 				inspect_scene_tree->add_constant_override("draw_relationship_lines", 0);
 				inspect_scene_tree->add_constant_override("draw_guides", 1);
+			}
+
+			if (enable_sh) {
+				inspect_scene_tree->add_constant_override("highlight_scripted_nodes", 1);
+				inspect_scene_tree->add_color_override("script_highlight_color", sh_color);
+			} else {
+				inspect_scene_tree->add_constant_override("highlight_scripted_nodes", 0);
+				inspect_scene_tree->add_color_override("script_highlight_color", Color(1, 1, 1, 1));
 			}
 		} break;
 		case NOTIFICATION_PROCESS: {
@@ -1236,13 +1246,26 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			tabs->set_margin(MARGIN_RIGHT, EditorNode::get_singleton()->get_gui_base()->get_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(MARGIN_RIGHT));
 
 			bool enable_rl = EditorSettings::get_singleton()->get("docks/scene_tree/draw_relationship_lines");
+			bool enable_sh = EditorSettings::get_singleton()->get("docks/scene_tree/highlight_scripted_nodes");
 			Color rl_color = EditorSettings::get_singleton()->get("docks/scene_tree/relationship_line_color");
+			Color sh_color = EditorSettings::get_singleton()->get("docks/scene_tree/script_highlight_color");
 
 			if (enable_rl) {
 				inspect_scene_tree->add_constant_override("draw_relationship_lines", 1);
 				inspect_scene_tree->add_color_override("relationship_line_color", rl_color);
-			} else
+				inspect_scene_tree->add_constant_override("draw_guides", 0);
+			} else {
 				inspect_scene_tree->add_constant_override("draw_relationship_lines", 0);
+				inspect_scene_tree->add_constant_override("draw_guides", 1);
+			}
+
+			if (enable_sh) {
+				inspect_scene_tree->add_constant_override("highlight_scripted_nodes", 1);
+				inspect_scene_tree->add_color_override("script_highlight_color", sh_color);
+			} else {
+				inspect_scene_tree->add_constant_override("highlight_scripted_nodes", 0);
+				inspect_scene_tree->add_color_override("script_highlight_color", Color(1, 1, 1, 1));
+			}
 
 			copy->set_icon(get_icon("ActionCopy", "EditorIcons"));
 			step->set_icon(get_icon("DebugStep", "EditorIcons"));

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -906,6 +906,8 @@ void Tree::update_cache() {
 	cache.relationship_line_color = get_color("relationship_line_color");
 	cache.scroll_border = get_constant("scroll_border");
 	cache.scroll_speed = get_constant("scroll_speed");
+	cache.highlight_scripted_nodes = get_constant("highlight_scripted_nodes");
+	cache.script_highlight_color = get_color("script_highlight_color");
 
 	cache.title_button = get_stylebox("title_button_normal");
 	cache.title_button_pressed = get_stylebox("title_button_pressed");
@@ -3768,6 +3770,14 @@ void Tree::set_allow_reselect(bool p_allow) {
 bool Tree::get_allow_reselect() const {
 
 	return allow_reselect;
+}
+
+bool Tree::allow_script_highlight() const {
+	return cache.highlight_scripted_nodes > 0;
+}
+
+Color Tree::get_script_color() const {
+	return cache.script_highlight_color;
 }
 
 void Tree::_bind_methods() {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -428,6 +428,7 @@ private:
 		Color drop_position_color;
 		Color relationship_line_color;
 		Color custom_button_font_highlight;
+		Color script_highlight_color;
 
 		int hseparation;
 		int vseparation;
@@ -439,6 +440,7 @@ private:
 		int draw_guides;
 		int scroll_border;
 		int scroll_speed;
+		int highlight_scripted_nodes;
 
 		enum ClickType {
 			CLICK_NONE,
@@ -601,6 +603,9 @@ public:
 
 	void set_allow_reselect(bool p_allow);
 	bool get_allow_reselect() const;
+
+	bool allow_script_highlight() const;
+	Color get_script_color() const;
 
 	Tree();
 	~Tree();


### PR DESCRIPTION
This enhancement was made in response to #15339. I have added the ability to highlight scripted nodes with a custom color. The highlighter can be disabled and modified from the Editor Settings.

![script highlight 3](https://user-images.githubusercontent.com/24457793/52489558-94c73100-2be8-11e9-8d3e-e2f860d8833c.PNG)
![script highlight 4](https://user-images.githubusercontent.com/24457793/52489559-955fc780-2be8-11e9-860d-e8e6f9ff1371.PNG)
