### PR TITLE
Add button in Project Manager to remove all missing projects

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -987,6 +987,24 @@ void ProjectManager::_update_project_buttons() {
 	open_btn->set_disabled(empty_selection);
 	rename_btn->set_disabled(empty_selection);
 	run_btn->set_disabled(empty_selection);
+
+	bool missing_projects = false;
+	Map<String, String> list_all_projects;
+	for (int i = 0; i < scroll_children->get_child_count(); i++) {
+		HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_children->get_child(i));
+		if (hb) {
+			list_all_projects.insert(hb->get_meta("name"), hb->get_meta("main_scene"));
+		}
+	}
+	for (Map<String, String>::Element *E = list_all_projects.front(); E; E = E->next()) {
+		String project_name = E->key().replace("::", "/") + "/project.godot";
+		if (!FileAccess::exists(project_name)) {
+			missing_projects = true;
+			break;
+		}
+	}
+
+	erase_missing_btn->set_visible(missing_projects);
 }
 
 void ProjectManager::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
@@ -1692,6 +1710,39 @@ void ProjectManager::_erase_project_confirm() {
 	_load_recent_projects();
 }
 
+void ProjectManager::_erase_missing_projects_confirm() {
+
+	Map<String, String> list_all_projects;
+	for (int i = 0; i < scroll_children->get_child_count(); i++) {
+		HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_children->get_child(i));
+		if (hb) {
+			list_all_projects.insert(hb->get_meta("name"), hb->get_meta("main_scene"));
+		}
+	}
+
+	if (list_all_projects.size() == 0) {
+		return;
+	}
+
+	int deleted_projects = 0;
+	int remaining_projects = 0;
+	for (Map<String, String>::Element *E = list_all_projects.front(); E; E = E->next()) {
+		String project_name = E->key().replace("::", "/") + "/project.godot";
+		if (!FileAccess::exists(project_name)) {
+			deleted_projects++;
+			EditorSettings::get_singleton()->erase("projects/" + E->key());
+			EditorSettings::get_singleton()->erase("favorite_projects/" + E->key());
+		} else {
+			remaining_projects++;
+		}
+	}
+	print_line("Deleted " + itos(deleted_projects) + " projects, remaining " + itos(remaining_projects) + " projects");
+	EditorSettings::get_singleton()->save();
+	selected_list.clear();
+	last_clicked = "";
+	_load_recent_projects();
+}
+
 void ProjectManager::_erase_project() {
 
 	if (selected_list.size() == 0)
@@ -1699,6 +1750,12 @@ void ProjectManager::_erase_project() {
 
 	erase_ask->set_text(TTR("Remove project from the list? (Folder contents will not be modified)"));
 	erase_ask->popup_centered_minsize();
+}
+
+void ProjectManager::_erase_missing_projects() {
+
+	erase_missing_ask->set_text(TTR("Remove all missing projects from the list? (Folders contents will not be modified)"));
+	erase_missing_ask->popup_centered_minsize();
 }
 
 void ProjectManager::_language_selected(int p_id) {
@@ -1796,7 +1853,9 @@ void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_new_project", &ProjectManager::_new_project);
 	ClassDB::bind_method("_rename_project", &ProjectManager::_rename_project);
 	ClassDB::bind_method("_erase_project", &ProjectManager::_erase_project);
+	ClassDB::bind_method("_erase_missing_projects", &ProjectManager::_erase_missing_projects);
 	ClassDB::bind_method("_erase_project_confirm", &ProjectManager::_erase_project_confirm);
+	ClassDB::bind_method("_erase_missing_projects_confirm", &ProjectManager::_erase_missing_projects_confirm);
 	ClassDB::bind_method("_language_selected", &ProjectManager::_language_selected);
 	ClassDB::bind_method("_restart_confirm", &ProjectManager::_restart_confirm);
 	ClassDB::bind_method("_exit_dialog", &ProjectManager::_exit_dialog);
@@ -2037,6 +2096,12 @@ ProjectManager::ProjectManager() {
 	erase->connect("pressed", this, "_erase_project");
 	erase_btn = erase;
 
+	Button *erase_missing = memnew(Button);
+	erase_missing->set_text(TTR("Remove Missing"));
+	tree_vb->add_child(erase_missing);
+	erase_missing->connect("pressed", this, "_erase_missing_projects");
+	erase_missing_btn = erase_missing;
+
 	tree_vb->add_spacer();
 
 	if (StreamPeerSSL::is_available()) {
@@ -2097,6 +2162,11 @@ ProjectManager::ProjectManager() {
 	language_restart_ask->get_ok()->connect("pressed", this, "_restart_confirm");
 	language_restart_ask->get_cancel()->set_text(TTR("Continue"));
 	gui_base->add_child(language_restart_ask);
+
+	erase_missing_ask = memnew(ConfirmationDialog);
+	erase_missing_ask->get_ok()->set_text(TTR("Remove All"));
+	erase_missing_ask->get_ok()->connect("pressed", this, "_erase_missing_projects_confirm");
+	gui_base->add_child(erase_missing_ask);
 
 	erase_ask = memnew(ConfirmationDialog);
 	erase_ask->get_ok()->set_text(TTR("Remove"));

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -45,6 +45,7 @@ class ProjectManager : public Control {
 	GDCLASS(ProjectManager, Control);
 
 	Button *erase_btn;
+	Button *erase_missing_btn;
 	Button *open_btn;
 	Button *rename_btn;
 	Button *run_btn;
@@ -57,6 +58,7 @@ class ProjectManager : public Control {
 	FileDialog *scan_dir;
 	ConfirmationDialog *language_restart_ask;
 	ConfirmationDialog *erase_ask;
+	ConfirmationDialog *erase_missing_ask;
 	ConfirmationDialog *multi_open_ask;
 	ConfirmationDialog *multi_run_ask;
 	ConfirmationDialog *multi_scan_ask;
@@ -89,7 +91,9 @@ class ProjectManager : public Control {
 	void _new_project();
 	void _rename_project();
 	void _erase_project();
+	void _erase_missing_projects();
 	void _erase_project_confirm();
+	void _erase_missing_projects_confirm();
 	void _update_project_buttons();
 	void _language_selected(int p_id);
 	void _restart_confirm();


### PR DESCRIPTION
This PR add a button to automatically delete missing projects.
Once the missing projects have been removed, a short summary appears in the console.
When there is no more empty projects, then button become disabled.

EDIT: Button now is not visible instead disabled, when there is not missing projects
EDIT2: Added break, when found first project, to not do empty iterations

Before clicking at button:
![zrzut ekranu z 2019-02-11 17-47-12](https://user-images.githubusercontent.com/41945903/52578989-9598d680-2e25-11e9-9fb0-3edce0b4d876.png)

After clicking at button:
![zrzut ekranu z 2019-02-11 17-48-15](https://user-images.githubusercontent.com/41945903/52578995-992c5d80-2e25-11e9-9207-67f32a997324.png)
