### PR TITLE
Fixed undefined behavior when loading dynamic font settings

### DIFF
--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -54,8 +54,9 @@ public:
 			struct {
 				uint32_t size : 16;
 				uint32_t outline_size : 8;
-				bool mipmaps : 1;
-				bool filter : 1;
+				uint32_t mipmaps : 1;
+				uint32_t filter : 1;
+				uint32_t unused : 6;
 			};
 			uint32_t key;
 		};


### PR DESCRIPTION
Platform: Windows 10
Compiler: MSVC x86_amd64

This changes fixes undefined behavior when initializing dynamic font settings. At least when compiling in Visual Studio, setting `key = 0` was only initializing a part of the struct with 0, the two booleans were set with random values instead.

This was leading to all dynamic font resources being loaded and saved based on different default values for `mipmaps` and `filter` on each run of the editor.