### PR TITLE
Clear SearchBox when unclick SearchButton

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1590,6 +1590,7 @@ void ProjectSettingsEditor::_toggle_search_bar(bool p_pressed) {
 		search_box->select_all();
 	} else {
 
+		search_box->clear();
 		search_bar->hide();
 		add_prop_bar->show();
 	}


### PR DESCRIPTION
Now the search field is cleared when it is switched off.

Fix #25160