### PR TITLE
Added ability to set_instance_transform_2d in multimesh

### DIFF
--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -166,9 +166,20 @@ void MultiMesh::set_instance_transform(int p_instance, const Transform &p_transf
 
 	VisualServer::get_singleton()->multimesh_instance_set_transform(multimesh, p_instance, p_transform);
 }
+
+void MultiMesh::set_instance_transform_2d(int p_instance, const Transform2D &p_transform) {
+
+	VisualServer::get_singleton()->multimesh_instance_set_transform_2d(multimesh, p_instance, p_transform);
+}
+
 Transform MultiMesh::get_instance_transform(int p_instance) const {
 
 	return VisualServer::get_singleton()->multimesh_instance_get_transform(multimesh, p_instance);
+}
+
+Transform2D MultiMesh::get_instance_transform_2d(int p_instance) const {
+
+	return VisualServer::get_singleton()->multimesh_instance_get_transform_2d(multimesh, p_instance);
 }
 
 void MultiMesh::set_instance_color(int p_instance, const Color &p_color) {
@@ -245,7 +256,9 @@ void MultiMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_instance_count", "count"), &MultiMesh::set_instance_count);
 	ClassDB::bind_method(D_METHOD("get_instance_count"), &MultiMesh::get_instance_count);
 	ClassDB::bind_method(D_METHOD("set_instance_transform", "instance", "transform"), &MultiMesh::set_instance_transform);
+	ClassDB::bind_method(D_METHOD("set_instance_transform_2d", "instance", "transform"), &MultiMesh::set_instance_transform_2d);
 	ClassDB::bind_method(D_METHOD("get_instance_transform", "instance"), &MultiMesh::get_instance_transform);
+	ClassDB::bind_method(D_METHOD("get_instance_transform_2d", "instance"), &MultiMesh::get_instance_transform_2d);
 	ClassDB::bind_method(D_METHOD("set_instance_color", "instance", "color"), &MultiMesh::set_instance_color);
 	ClassDB::bind_method(D_METHOD("get_instance_color", "instance"), &MultiMesh::get_instance_color);
 	ClassDB::bind_method(D_METHOD("set_instance_custom_data", "instance", "custom_data"), &MultiMesh::set_instance_custom_data);

--- a/scene/resources/multimesh.h
+++ b/scene/resources/multimesh.h
@@ -94,7 +94,9 @@ public:
 	int get_instance_count() const;
 
 	void set_instance_transform(int p_instance, const Transform &p_transform);
+	void set_instance_transform_2d(int p_instance, const Transform2D &p_transform);
 	Transform get_instance_transform(int p_instance) const;
+	Transform2D get_instance_transform_2d(int p_instance) const;
 
 	void set_instance_color(int p_instance, const Color &p_color);
 	Color get_instance_color(int p_instance) const;


### PR DESCRIPTION
Currently the default ``transform_format`` for MultiMeshes is ``2D``. However, there is no way to set a Transform2D on a MultiMesh instance. The visual server even provides a function, ``multimesh_instance_get_transform_2d`` to set Transform2Ds on MultiMeshes. I figured the best thing to do was to add a way to access it from the class itself so that Transform2Ds can be used. 

If this is not desired, then we should remove the ``transform_format`` property altogether. Or at least set it to ``3D`` by default

fixes: #25597 