### PR TITLE
WIP: Partial fix to RayShape collision in Bullet

### DIFF
--- a/modules/bullet/collision_object_bullet.cpp
+++ b/modules/bullet/collision_object_bullet.cpp
@@ -337,13 +337,15 @@ void RigidCollisionObjectBullet::reload_shapes() {
 
 	// Try to optimize by not using compound
 	if (1 == shape_count) {
-		shpWrapper = &shapes.write[0];
-		if (shpWrapper->transform.getOrigin().isZero() && shpWrapper->transform.getBasis() == shpWrapper->transform.getBasis().getIdentity()) {
-			shpWrapper->claim_bt_shape(body_scale);
-			mainShape = shpWrapper->bt_shape;
-			main_shape_changed();
-			return;
-		}
+		// This breaks RayShape collision for some reason (probably other collision shapes too), so let's disable it for now.
+		// It seems that the cause is that it gives false positives (shape wrapper has an identity transform, but actual shape doesn't).
+		//shpWrapper = &shapes.write[0];
+		//if (shpWrapper->transform.getOrigin().isZero() && shpWrapper->transform.getBasis() == shpWrapper->transform.getBasis().getIdentity()) {
+		//	shpWrapper->claim_bt_shape(body_scale);
+		//	mainShape = shpWrapper->bt_shape;
+		//	main_shape_changed();
+		//	return;
+		//}
 	}
 
 	// Optimization not possible use a compound shape

--- a/modules/bullet/godot_ray_world_algorithm.cpp
+++ b/modules/bullet/godot_ray_world_algorithm.cpp
@@ -35,8 +35,6 @@
 
 #include <BulletDynamics/Dynamics/btDiscreteDynamicsWorld.h>
 
-#define RAY_STABILITY_MARGIN 0.1
-
 /**
 	@author AndreaCatania
 */
@@ -102,7 +100,7 @@ void GodotRayWorldAlgorithm::processCollision(const btCollisionObjectWrapper *bo
 
 		btScalar depth(ray_shape->getScaledLength() * (btResult.m_closestHitFraction - 1));
 
-		if (depth >= -RAY_STABILITY_MARGIN)
+		if (depth >= -ray_shape->getMargin())
 			depth = 0;
 
 		if (ray_shape->getSlipsOnSlope())


### PR DESCRIPTION
- Removed optimization avoiding the creation of a parent compound shape for
  each rigid body. For some reason it breaks RayShape collision and it seems
  in general the shape wrapper incorrectly has an identity transform when the
  actual shape doesn't.
- Removed arbitrary margin applied in the collision algorithm of RayShapes
  which causes jittered movement. For lack of a better replacement and for
  lack of any explanation on why it has been introduced, it's now using the
  shape's margin property instead which is small enough to not show visible
  jitter.

Fixes #25227.

Known issues:
- Even though the repro case in issue #25227 works fine after this change,
  RayShape still doesn't work in my own test project and in the Godot TPS
  Demo (the latter works at least with Godot Physics though).
- "Slips On Slope" doesn't work in the repro case in issue #25227 but does
  work in another of my own test projects.