### PR TITLE
Allow floating-point values in the idle parse delay editor setting

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1289,6 +1289,8 @@ void CodeTextEditor::_on_settings_change() {
 	text_editor->set_callhint_settings(
 			EDITOR_DEF("text_editor/completion/put_callhint_tooltip_below_current_line", true),
 			EDITOR_DEF("text_editor/completion/callhint_tooltip_offset", Vector2()));
+
+	idle->set_wait_time(EDITOR_DEF("text_editor/completion/idle_parse_delay", 2.0));
 }
 
 void CodeTextEditor::_text_changed_idle_timeout() {
@@ -1403,7 +1405,7 @@ CodeTextEditor::CodeTextEditor() {
 	idle = memnew(Timer);
 	add_child(idle);
 	idle->set_one_shot(true);
-	idle->set_wait_time(EDITOR_DEF("text_editor/completion/idle_parse_delay", 2));
+	idle->set_wait_time(EDITOR_DEF("text_editor/completion/idle_parse_delay", 2.0));
 
 	code_complete_timer = memnew(Timer);
 	add_child(code_complete_timer);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -459,7 +459,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/cursor/right_click_moves_caret", true);
 
 	// Completion
-	_initial_set("text_editor/completion/idle_parse_delay", 2);
+	_initial_set("text_editor/completion/idle_parse_delay", 2.0);
+	hints["text_editor/completion/idle_parse_delay"] = PropertyInfo(Variant::REAL, "text_editor/completion/idle_parse_delay", PROPERTY_HINT_RANGE, "0.1, 10, 0.01");
 	_initial_set("text_editor/completion/auto_brace_complete", false);
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);
 	_initial_set("text_editor/completion/callhint_tooltip_offset", Vector2());


### PR DESCRIPTION
This also makes value changes effective without having to restart the editor.

> <details>
> <summary>Old version of the pull request</summary>
> <br>
> This also makes safe lines appear faster, since error checking and safe line marking are part of the same process. The error marker lines were also made less opaque to be less jarring, since they will appear more often from now on.
> 
> ## Preview (click for a smoother version)
> 
> [![](https://giant.gfycat.com/UnrulyGoodGopher.gif)](https://gfycat.com/UnrulyGoodGopher)
> 
> I based the 0.5-second delay on other editors like JetBrains IDEs and it seems to work fine. Even a 0.1-second delay works fine (at least on smaller scripts), but it may cause additional strain on CPUs (which isn't ideal on laptops).
> </details>