### PR TITLE
Use trilinear filtering for variable-sized images such as project icons

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -745,8 +745,8 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 		if (!image->empty()) {
 			switch (image_queue[p_queue_id].image_type) {
 				case IMAGE_QUEUE_ICON:
-
-					image->resize(64 * EDSCALE, 64 * EDSCALE, Image::INTERPOLATE_CUBIC);
+					image->generate_mipmaps();
+					image->resize(64 * EDSCALE, 64 * EDSCALE, Image::INTERPOLATE_TRILINEAR);
 
 					break;
 				case IMAGE_QUEUE_THUMBNAIL: {
@@ -754,7 +754,8 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 
 					float scale_ratio = max_height / (image->get_height() * EDSCALE);
 					if (scale_ratio < 1) {
-						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_CUBIC);
+						image->generate_mipmaps();
+						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_TRILINEAR);
 					}
 				} break;
 				case IMAGE_QUEUE_SCREENSHOT: {
@@ -762,7 +763,8 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 
 					float scale_ratio = max_height / (image->get_height() * EDSCALE);
 					if (scale_ratio < 1) {
-						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_CUBIC);
+						image->generate_mipmaps();
+						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_TRILINEAR);
 					}
 				} break;
 			}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1321,7 +1321,8 @@ void ProjectManager::_load_recent_projects() {
 				if (err == OK) {
 
 					Ref<Texture> default_icon = get_icon("DefaultProjectIcon", "EditorIcons");
-					img->resize(default_icon->get_width(), default_icon->get_height());
+					img->generate_mipmaps();
+					img->resize(default_icon->get_width(), default_icon->get_height(), Image::INTERPOLATE_TRILINEAR);
 					Ref<ImageTexture> it = memnew(ImageTexture);
 					it->create_from_image(img);
 					icon = it;


### PR DESCRIPTION
This results in better-looking icons with less artifacts induced by downscaling.

## Preview

### Trilinear filtering disabled

![project_manager_no_trilinear](https://user-images.githubusercontent.com/180032/52534377-234ec600-2d41-11e9-9f1a-fdfa2d70d1d7.png)

![assetlib_no_trilinear](https://user-images.githubusercontent.com/180032/52534383-28ac1080-2d41-11e9-9294-5b38e7eb392c.png)


### Trilinear filtering enabled

![project_manager_trilinear](https://user-images.githubusercontent.com/180032/52534379-25188980-2d41-11e9-87a1-f05cfc78e957.png)

![assetlib_trilinear](https://user-images.githubusercontent.com/180032/52534384-29dd3d80-2d41-11e9-90fa-cca7ae58fcba.png)


Note that I called `generate_mipmaps()` on each image before resizing it, as it results in much better-looking images. The [Image documentation](https://docs.godotengine.org/en/latest/classes/class_image.html#class-image-constant-interpolate-trilinear) states that mipmaps are automatically generated when making use of trilinear interpolation, but it doesn't look quite as good.

Some icons still don't look great though (like the Godot Redux one, even though the original is 320×320). For better-looking results on some images, I guess we'd need a mode that uses cubic scaling *and* trilinear filtering. Is this possible to implement with what we have currently?