### PR TITLE
General cleanup of script and doc search bars

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -99,9 +99,6 @@ void FindReplaceBar::_notification(int p_what) {
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 
 		set_process_unhandled_input(is_visible_in_tree());
-		if (is_visible_in_tree()) {
-			_update_size();
-		}
 	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
 
 		find_prev->set_icon(get_icon("MoveUp", "EditorIcons"));
@@ -390,7 +387,6 @@ void FindReplaceBar::_show_search() {
 		search_text->set_cursor_position(search_text->get_text().length());
 		search_current();
 	}
-	call_deferred("_update_size");
 }
 
 void FindReplaceBar::popup_search() {
@@ -483,11 +479,6 @@ void FindReplaceBar::set_text_edit(TextEdit *p_text_edit) {
 	text_edit->connect("text_changed", this, "_editor_text_changed");
 }
 
-void FindReplaceBar::_update_size() {
-
-	container->set_size(Size2(hbc->get_size().width, 1));
-}
-
 void FindReplaceBar::_bind_methods() {
 
 	ClassDB::bind_method("_unhandled_input", &FindReplaceBar::_unhandled_input);
@@ -503,7 +494,6 @@ void FindReplaceBar::_bind_methods() {
 	ClassDB::bind_method("_replace_all_pressed", &FindReplaceBar::_replace_all);
 	ClassDB::bind_method("_search_options_changed", &FindReplaceBar::_search_options_changed);
 	ClassDB::bind_method("_hide_pressed", &FindReplaceBar::_hide_bar);
-	ClassDB::bind_method("_update_size", &FindReplaceBar::_update_size);
 
 	ADD_SIGNAL(MethodInfo("search"));
 	ADD_SIGNAL(MethodInfo("error"));
@@ -511,26 +501,16 @@ void FindReplaceBar::_bind_methods() {
 
 FindReplaceBar::FindReplaceBar() {
 
-	container = memnew(MarginContainer);
-	container->add_constant_override("margin_bottom", 5 * EDSCALE);
-	add_child(container);
-	container->set_clip_contents(true);
-	container->set_h_size_flags(SIZE_EXPAND_FILL);
-
 	replace_all_mode = false;
 	preserve_cursor = false;
 
-	hbc = memnew(HBoxContainer);
-	container->add_child(hbc);
-	hbc->set_anchor_and_margin(MARGIN_RIGHT, 1, 0);
-
 	vbc_lineedit = memnew(VBoxContainer);
-	hbc->add_child(vbc_lineedit);
+	add_child(vbc_lineedit);
 	vbc_lineedit->set_h_size_flags(SIZE_EXPAND_FILL);
 	VBoxContainer *vbc_button = memnew(VBoxContainer);
-	hbc->add_child(vbc_button);
+	add_child(vbc_button);
 	VBoxContainer *vbc_option = memnew(VBoxContainer);
-	hbc->add_child(vbc_option);
+	add_child(vbc_option);
 
 	HBoxContainer *hbc_button_search = memnew(HBoxContainer);
 	vbc_button->add_child(hbc_button_search);
@@ -1219,6 +1199,7 @@ void CodeTextEditor::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 			warning_button->set_icon(get_icon("NodeWarning", "EditorIcons"));
+			add_constant_override("separation", 4 * EDSCALE);
 		} break;
 		default:
 			break;
@@ -1267,7 +1248,7 @@ CodeTextEditor::CodeTextEditor() {
 	add_child(text_editor);
 	text_editor->set_v_size_flags(SIZE_EXPAND_FILL);
 
-	// Added second to it opens at the bottom, so it won't shift the entire text editor when opening
+	// Added second so it opens at the bottom, so it won't shift the entire text editor when opening.
 	find_replace_bar = memnew(FindReplaceBar);
 	add_child(find_replace_bar);
 	find_replace_bar->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1282,6 +1263,7 @@ CodeTextEditor::CodeTextEditor() {
 	status_bar = memnew(HBoxContainer);
 	add_child(status_bar);
 	status_bar->set_h_size_flags(SIZE_EXPAND_FILL);
+	status_bar->set_custom_minimum_size(Size2(0, 24 * EDSCALE)); // Adjust for the height of the warning icon.
 
 	idle = memnew(Timer);
 	add_child(idle);
@@ -1338,7 +1320,7 @@ CodeTextEditor::CodeTextEditor() {
 	status_bar->add_child(line_and_col_txt);
 	line_and_col_txt->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	line_and_col_txt->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
-	line_and_col_txt->set_tooltip(TTR("Line and column numbers"));
+	line_and_col_txt->set_tooltip(TTR("Line and column numbers."));
 	line_and_col_txt->set_mouse_filter(MOUSE_FILTER_STOP);
 
 	text_editor->connect("gui_input", this, "_text_editor_gui_input");

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -63,7 +63,6 @@ class FindReplaceBar : public HBoxContainer {
 
 	GDCLASS(FindReplaceBar, HBoxContainer);
 
-	MarginContainer *container;
 	LineEdit *search_text;
 	ToolButton *find_prev;
 	ToolButton *find_next;
@@ -76,7 +75,6 @@ class FindReplaceBar : public HBoxContainer {
 	Button *replace_all;
 	CheckBox *selection_only;
 
-	HBoxContainer *hbc;
 	VBoxContainer *vbc_lineedit;
 	HBoxContainer *hbc_button_replace;
 	HBoxContainer *hbc_option_replace;

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1430,7 +1430,7 @@ EditorHelp::EditorHelp() {
 	class_desc->connect("meta_clicked", this, "_class_desc_select");
 	class_desc->connect("gui_input", this, "_class_desc_input");
 
-	// Added second so it opens at the bottom so it won't offset the entire widget
+	// Added second so it opens at the bottom so it won't offset the entire widget.
 	find_bar = memnew(FindBar);
 	add_child(find_bar);
 	find_bar->hide();
@@ -1440,7 +1440,6 @@ EditorHelp::EditorHelp() {
 
 	scroll_locked = false;
 	select_locked = false;
-	//set_process_unhandled_key_input(true);
 	class_desc->hide();
 }
 
@@ -1509,47 +1508,32 @@ EditorHelpBit::EditorHelpBit() {
 
 	rich_text = memnew(RichTextLabel);
 	add_child(rich_text);
-	//rich_text->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	rich_text->connect("meta_clicked", this, "_meta_clicked");
 	rich_text->add_color_override("selection_color", EditorSettings::get_singleton()->get("text_editor/theme/selection_color"));
 	rich_text->set_override_selected_font_color(false);
-	set_custom_minimum_size(Size2(0, 70 * EDSCALE));
 }
 
 FindBar::FindBar() {
 
-	container = memnew(Control);
-	add_child(container);
-
-	container->set_clip_contents(true);
-	container->set_h_size_flags(SIZE_EXPAND_FILL);
-
-	hbc = memnew(HBoxContainer);
-	container->add_child(hbc);
-
-	vbc_search_text = memnew(VBoxContainer);
-	hbc->add_child(vbc_search_text);
-	vbc_search_text->set_h_size_flags(SIZE_EXPAND_FILL);
-	hbc->set_anchor_and_margin(MARGIN_RIGHT, 1, 0);
-
 	search_text = memnew(LineEdit);
-	vbc_search_text->add_child(search_text);
+	add_child(search_text);
 	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	search_text->set_h_size_flags(SIZE_EXPAND_FILL);
 	search_text->connect("text_changed", this, "_search_text_changed");
 	search_text->connect("text_entered", this, "_search_text_entered");
 
 	find_prev = memnew(ToolButton);
-	hbc->add_child(find_prev);
+	add_child(find_prev);
 	find_prev->set_focus_mode(FOCUS_NONE);
 	find_prev->connect("pressed", this, "_search_prev");
 
 	find_next = memnew(ToolButton);
-	hbc->add_child(find_next);
+	add_child(find_next);
 	find_next->set_focus_mode(FOCUS_NONE);
 	find_next->connect("pressed", this, "_search_next");
 
 	error_label = memnew(Label);
-	hbc->add_child(error_label);
+	add_child(error_label);
 	error_label->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
 
 	hide_button = memnew(TextureButton);
@@ -1576,13 +1560,6 @@ void FindBar::popup_search() {
 			_search();
 		}
 	}
-
-	call_deferred("_update_size");
-}
-
-void FindBar::_update_size() {
-
-	container->set_custom_minimum_size(Size2(0, hbc->get_size().height));
 }
 
 void FindBar::_notification(int p_what) {
@@ -1618,7 +1595,6 @@ void FindBar::_bind_methods() {
 	ClassDB::bind_method("_search_next", &FindBar::search_next);
 	ClassDB::bind_method("_search_prev", &FindBar::search_prev);
 	ClassDB::bind_method("_hide_pressed", &FindBar::_hide_bar);
-	ClassDB::bind_method("_update_size", &FindBar::_update_size);
 
 	ADD_SIGNAL(MethodInfo("search"));
 }
@@ -1677,7 +1653,7 @@ void FindBar::_unhandled_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid()) {
 
-		if (k->is_pressed() && (rich_text_label->has_focus() || hbc->is_a_parent_of(get_focus_owner()))) {
+		if (k->is_pressed() && (rich_text_label->has_focus() || is_a_parent_of(get_focus_owner()))) {
 
 			bool accepted = true;
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -34,6 +34,7 @@
 #include "editor/code_editor.h"
 #include "editor/doc/doc_data.h"
 #include "editor/editor_plugin.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/rich_text_label.h"
@@ -51,10 +52,6 @@ class FindBar : public HBoxContainer {
 	Label *error_label;
 	TextureButton *hide_button;
 	String prev_search;
-
-	Control *container;
-	HBoxContainer *hbc;
-	VBoxContainer *vbc_search_text;
 
 	RichTextLabel *rich_text_label;
 
@@ -191,9 +188,9 @@ public:
 	~EditorHelp();
 };
 
-class EditorHelpBit : public PanelContainer {
+class EditorHelpBit : public MarginContainer {
 
-	GDCLASS(EditorHelpBit, PanelContainer);
+	GDCLASS(EditorHelpBit, MarginContainer);
 
 	RichTextLabel *rich_text;
 	void _go_to_help(String p_what);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -737,7 +737,7 @@ ColorPicker::ColorPicker() :
 
 	bt_add_preset = memnew(Button);
 	bbc->add_child(bt_add_preset);
-	bt_add_preset->set_tooltip(TTR("Add current color as a preset"));
+	bt_add_preset->set_tooltip(TTR("Add current color as a preset."));
 	bt_add_preset->connect("pressed", this, "_add_preset_pressed");
 }
 


### PR DESCRIPTION
- Remove unnecessary nodes.
- Fix separation height between script editor and its search bar.
- Fix status bar height changing when the warning icon appears in certain screens.