### PR TITLE
Do not initialize Mono if 'res://.mono/' and mscorlib are missing

### DIFF
--- a/modules/mono/editor/godotsharp_export.cpp
+++ b/modules/mono/editor/godotsharp_export.cpp
@@ -124,7 +124,7 @@ void GodotSharpExport::_export_begin(const Set<String> &p_features, bool p_debug
 			ERR_FAIL_COND(!load_success);
 
 			Vector<String> search_dirs;
-			GDMonoAssembly::fill_search_dirs(search_dirs);
+			GDMonoAssembly::fill_search_dirs(search_dirs, build_config);
 			Error depend_error = _get_assembly_dependencies(scripts_assembly, search_dirs, dependencies);
 			ERR_FAIL_COND(depend_error != OK);
 		}

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -253,6 +253,29 @@ void GDMono::initialize() {
 
 	mono_install_unhandled_exception_hook(&unhandled_exception_hook, NULL);
 
+#ifdef TOOLS_ENABLED
+	if (!DirAccess::exists("res://.mono")) {
+		// 'res://.mono/' is missing so there is nothing to load. We don't need to initialize mono, but
+		// we still do so unless mscorlib is missing (which is the case for projects that don't use C#).
+
+		String mscorlib_fname("mscorlib.dll");
+
+		Vector<String> search_dirs;
+		GDMonoAssembly::fill_search_dirs(search_dirs);
+
+		bool found = false;
+		for (int i = 0; i < search_dirs.size(); i++) {
+			if (FileAccess::exists(search_dirs[i].plus_file(mscorlib_fname))) {
+				found = true;
+				break;
+			}
+		}
+
+		if (!found)
+			return; // mscorlib is missing, do not initialize mono
+	}
+#endif
+
 	root_domain = mono_jit_init_version("GodotEngine.RootDomain", "v4.0.30319");
 
 	ERR_EXPLAIN("Mono: Failed to initialize runtime");


### PR DESCRIPTION
This is needed to avoid aborting due to missing mscorlib for projects that do not use C#.
If 'res://.mono/' exists, then we assume the project uses C#, in which case a missing mscorlib should still abort.

Fixes #25772

Also fixed exporting assemblies from the wrong output path, because I forgot a parameter...
