### PR TITLE
Fixes some AnimationPlayer bugs

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -145,6 +145,7 @@
 			</argument>
 			<description>
 				Play the animation with key [code]name[/code]. Custom speed and blend times can be set. If custom speed is negative (-1), 'from_end' being true can play the animation backwards.
+				If the animation has been paused by [code]stop(true)[/code] it will be resumed. Calling [code]play()[/code] without arguments will also resume the animation.
 			</description>
 		</method>
 		<method name="play_backwards">
@@ -156,6 +157,7 @@
 			</argument>
 			<description>
 				Play the animation with key [code]name[/code] in reverse.
+				If the animation has been paused by [code]stop(true)[/code] it will be resumed backwards. Calling [code]play_backwards()[/code] without arguments will also resume the animation backwards.
 			</description>
 		</method>
 		<method name="queue">
@@ -217,7 +219,8 @@
 			<argument index="0" name="reset" type="bool" default="true">
 			</argument>
 			<description>
-				Stop the currently playing animation. If [code]reset[/code] is [code]true[/code], the anim position is reset to [code]0[/code].
+				Stop the currently playing animation. If [code]reset[/code] is [code]true[/code], the animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code].
+				If [code]reset[/code] is [code]false[/code], then calling [code]play()[/code] without arguments or [code]play("same_as_before")[/code] will resume the animation. Works the same for the [code]play_backwards()[/code] method.
 			</description>
 		</method>
 	</methods>

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1205,9 +1205,16 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 	_stop_playing_caches();
 
 	c.current.from = &animation_set[name];
-	c.current.pos = p_from_end ? c.current.from->animation->get_length() : 0;
+
+	if (c.assigned != name) { // reset
+		c.current.pos = p_from_end ? c.current.from->animation->get_length() : 0;
+	} else if (p_from_end && c.current.pos == 0) {
+		// Animation reset BUT played backwards, set position to the end
+		c.current.pos = c.current.from->animation->get_length();
+	}
+
 	c.current.speed_scale = p_custom_scale;
-	c.assigned = p_name;
+	c.assigned = name;
 	c.seeked = false;
 	c.started = true;
 
@@ -1286,6 +1293,7 @@ void AnimationPlayer::stop(bool p_reset) {
 	if (p_reset) {
 		c.current.from = NULL;
 		c.current.speed_scale = 1;
+		c.current.pos = 0;
 	}
 	_set_process(false);
 	queued.clear();


### PR DESCRIPTION
Fixes #25745 
Fixes #17423

Line _1210_ from animation_player.cpp is:
https://github.com/godotengine/godot/blob/eda4be193fd736d362184bc937efc99c1faa18c3/scene/animation/animation_player.cpp#L1210

Which means that when called without arguments the method would replace the variable `playback.assigned` with an empty String. This makes the signal `animation_finished` give this empty String as an argument.

I've changed it to
https://github.com/godotengine/godot/blob/592d514380eabfc9d36c68b44f263513e823c35b/scene/animation/animation_player.cpp#L1210

The variable `name` in this method has the correct animation name as defined at the beginning of it. This fixes  #25745.

The line _1208_:
https://github.com/godotengine/godot/blob/eda4be193fd736d362184bc937efc99c1faa18c3/scene/animation/animation_player.cpp#L1208

Doesn't have any condition to run, so it resets the position of the animation to 0 every time p_from_end is false. Also, calling `stop(true)` doesn't reset the animation. This PR makes the animation position be 0 when calling `stop(true)` 
https://github.com/godotengine/godot/blob/592d514380eabfc9d36c68b44f263513e823c35b/scene/animation/animation_player.cpp#L1281-L1294

and replaces line _1208_ with
https://github.com/godotengine/godot/blob/592d514380eabfc9d36c68b44f263513e823c35b/scene/animation/animation_player.cpp#L1208

The animation position is reset, or not, at the `stop()` method, so the `play()` method just keeps the decision made there (unless it is told to run the animation backwards), fixing #17423.