### PR TITLE
Feature/fix toggle comment indent

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1132,7 +1132,7 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		}
 
 		// Adjust selection & cursor position.
-		int offset = is_commented ? -1 : 1;
+		int offset = (is_commented ? -1 : 1) * delimiter.length();
 		int col_from = text_editor->get_selection_from_column() > 0 ? text_editor->get_selection_from_column() + offset : 0;
 
 		if (is_commented && text_editor->cursor_get_column() == text_editor->get_line(text_editor->cursor_get_line()).length() + 1)
@@ -1150,14 +1150,15 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 	} else {
 		int begin = text_editor->cursor_get_line();
 		String line_text = text_editor->get_line(begin);
+		int delimiter_length = delimiter.length();
 
 		int col = text_editor->cursor_get_column();
 		if (line_text.begins_with(delimiter)) {
-			line_text = line_text.substr(delimiter.length(), line_text.length());
-			col -= 1;
+			line_text = line_text.substr(delimiter_length, line_text.length());
+			col -= delimiter_length;
 		} else {
 			line_text = delimiter + line_text;
-			col += 1;
+			col += delimiter_length;
 		}
 
 		text_editor->set_line(begin, line_text);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1095,6 +1095,78 @@ void CodeTextEditor::clone_lines_down() {
 	text_editor->update();
 }
 
+void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
+	text_editor->begin_complex_operation();
+	if (text_editor->is_selection_active()) {
+		int begin = text_editor->get_selection_from_line();
+		int end = text_editor->get_selection_to_line();
+
+		// End of selection ends on the first column of the last line, ignore it.
+		if (text_editor->get_selection_to_column() == 0)
+			end -= 1;
+
+		int col_to = text_editor->get_selection_to_column();
+		int cursor_pos = text_editor->cursor_get_column();
+
+		// Check if all lines in the selected block are commented
+		bool is_commented = true;
+		for (int i = begin; i <= end; i++) {
+			if (!text_editor->get_line(i).begins_with(delimiter)) {
+				is_commented = false;
+				break;
+			}
+		}
+		for (int i = begin; i <= end; i++) {
+			String line_text = text_editor->get_line(i);
+
+			if (line_text.strip_edges().empty()) {
+				line_text = delimiter;
+			} else {
+				if (is_commented) {
+					line_text = line_text.substr(delimiter.length(), line_text.length());
+				} else {
+					line_text = delimiter + line_text;
+				}
+			}
+			text_editor->set_line(i, line_text);
+		}
+
+		// Adjust selection & cursor position.
+		int offset = is_commented ? -1 : 1;
+		int col_from = text_editor->get_selection_from_column() > 0 ? text_editor->get_selection_from_column() + offset : 0;
+
+		if (is_commented && text_editor->cursor_get_column() == text_editor->get_line(text_editor->cursor_get_line()).length() + 1)
+			cursor_pos += 1;
+
+		if (text_editor->get_selection_to_column() != 0 && col_to != text_editor->get_line(text_editor->get_selection_to_line()).length() + 1)
+			col_to += offset;
+
+		if (text_editor->cursor_get_column() != 0)
+			cursor_pos += offset;
+
+		text_editor->select(begin, col_from, text_editor->get_selection_to_line(), col_to);
+		text_editor->cursor_set_column(cursor_pos);
+
+	} else {
+		int begin = text_editor->cursor_get_line();
+		String line_text = text_editor->get_line(begin);
+
+		int col = text_editor->cursor_get_column();
+		if (line_text.begins_with(delimiter)) {
+			line_text = line_text.substr(delimiter.length(), line_text.length());
+			col -= 1;
+		} else {
+			line_text = delimiter + line_text;
+			col += 1;
+		}
+
+		text_editor->set_line(begin, line_text);
+		text_editor->cursor_set_column(col);
+	}
+	text_editor->end_complex_operation();
+	text_editor->update();
+}
+
 void CodeTextEditor::goto_line(int p_line) {
 	text_editor->deselect();
 	text_editor->unfold_line(p_line);

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -206,6 +206,10 @@ public:
 	void delete_lines();
 	void clone_lines_down();
 
+	/// Toggle inline comment on currently selected lines, or on current line if nothing is selected,
+	/// by adding or removing comment delimiter
+	void toggle_inline_comment(const String &delimiter);
+
 	void goto_line(int p_line);
 	void goto_line_selection(int p_line, int p_begin, int p_end);
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -800,92 +800,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		} break;
 		case EDIT_TOGGLE_COMMENT: {
 
-			Ref<Script> scr = script;
-			if (scr.is_null())
-				return;
-
-			String delimiter = "#";
-			List<String> comment_delimiters;
-			scr->get_language()->get_comment_delimiters(&comment_delimiters);
-
-			for (List<String>::Element *E = comment_delimiters.front(); E; E = E->next()) {
-				String script_delimiter = E->get();
-				if (script_delimiter.find(" ") == -1) {
-					delimiter = script_delimiter;
-					break;
-				}
-			}
-
-			tx->begin_complex_operation();
-			if (tx->is_selection_active()) {
-				int begin = tx->get_selection_from_line();
-				int end = tx->get_selection_to_line();
-
-				// End of selection ends on the first column of the last line, ignore it.
-				if (tx->get_selection_to_column() == 0)
-					end -= 1;
-
-				int col_to = tx->get_selection_to_column();
-				int cursor_pos = tx->cursor_get_column();
-
-				// Check if all lines in the selected block are commented
-				bool is_commented = true;
-				for (int i = begin; i <= end; i++) {
-					if (!tx->get_line(i).begins_with(delimiter)) {
-						is_commented = false;
-						break;
-					}
-				}
-				for (int i = begin; i <= end; i++) {
-					String line_text = tx->get_line(i);
-
-					if (line_text.strip_edges().empty()) {
-						line_text = delimiter;
-					} else {
-						if (is_commented) {
-							line_text = line_text.substr(delimiter.length(), line_text.length());
-						} else {
-							line_text = delimiter + line_text;
-						}
-					}
-					tx->set_line(i, line_text);
-				}
-
-				// Adjust selection & cursor position.
-				int offset = is_commented ? -1 : 1;
-				int col_from = tx->get_selection_from_column() > 0 ? tx->get_selection_from_column() + offset : 0;
-
-				if (is_commented && tx->cursor_get_column() == tx->get_line(tx->cursor_get_line()).length() + 1)
-					cursor_pos += 1;
-
-				if (tx->get_selection_to_column() != 0 && col_to != tx->get_line(tx->get_selection_to_line()).length() + 1)
-					col_to += offset;
-
-				if (tx->cursor_get_column() != 0)
-					cursor_pos += offset;
-
-				tx->select(begin, col_from, tx->get_selection_to_line(), col_to);
-				tx->cursor_set_column(cursor_pos);
-
-			} else {
-				int begin = tx->cursor_get_line();
-				String line_text = tx->get_line(begin);
-
-				int col = tx->cursor_get_column();
-				if (line_text.begins_with(delimiter)) {
-					line_text = line_text.substr(delimiter.length(), line_text.length());
-					col -= 1;
-				} else {
-					line_text = delimiter + line_text;
-					col += 1;
-				}
-
-				tx->set_line(begin, line_text);
-				tx->cursor_set_column(col);
-			}
-			tx->end_complex_operation();
-			tx->update();
-
+			_edit_option_toggle_inline_comment();
 		} break;
 		case EDIT_COMPLETE: {
 
@@ -1070,6 +985,25 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			}
 		} break;
 	}
+}
+
+void ScriptTextEditor::_edit_option_toggle_inline_comment() {
+	if (script.is_null())
+		return;
+
+	String delimiter = "#";
+	List<String> comment_delimiters;
+	script->get_language()->get_comment_delimiters(&comment_delimiters);
+
+	for (List<String>::Element *E = comment_delimiters.front(); E; E = E->next()) {
+		String script_delimiter = E->get();
+		if (script_delimiter.find(" ") == -1) {
+			delimiter = script_delimiter;
+			break;
+		}
+	}
+
+	code_editor->toggle_inline_comment(delimiter);
 }
 
 void ScriptTextEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -136,6 +136,7 @@ protected:
 	void _change_syntax_highlighter(int p_idx);
 
 	void _edit_option(int p_op);
+	void _edit_option_toggle_inline_comment();
 	void _make_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, bool p_goto_definition);
 	void _text_edit_gui_input(const Ref<InputEvent> &ev);
 	void _color_changed(const Color &p_color);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -244,19 +244,19 @@ void ShaderEditor::_menu_option(int p_option) {
 		} break;
 		case EDIT_INDENT_LEFT: {
 
-			TextEdit *tx = shader_editor->get_text_edit();
 			if (shader.is_null())
 				return;
 
+			TextEdit *tx = shader_editor->get_text_edit();
 			tx->indent_left();
 
 		} break;
 		case EDIT_INDENT_RIGHT: {
 
-			TextEdit *tx = shader_editor->get_text_edit();
 			if (shader.is_null())
 				return;
 
+			TextEdit *tx = shader_editor->get_text_edit();
 			tx->indent_right();
 
 		} break;
@@ -268,54 +268,10 @@ void ShaderEditor::_menu_option(int p_option) {
 		} break;
 		case EDIT_TOGGLE_COMMENT: {
 
-			TextEdit *tx = shader_editor->get_text_edit();
 			if (shader.is_null())
 				return;
 
-			tx->begin_complex_operation();
-			if (tx->is_selection_active()) {
-				int begin = tx->get_selection_from_line();
-				int end = tx->get_selection_to_line();
-
-				// End of selection ends on the first column of the last line, ignore it.
-				if (tx->get_selection_to_column() == 0)
-					end -= 1;
-
-				// Check if all lines in the selected block are commented
-				bool is_commented = true;
-				for (int i = begin; i <= end; i++) {
-					if (!tx->get_line(i).begins_with("//")) {
-						is_commented = false;
-						break;
-					}
-				}
-				for (int i = begin; i <= end; i++) {
-					String line_text = tx->get_line(i);
-
-					if (line_text.strip_edges().empty()) {
-						line_text = "//";
-					} else {
-						if (is_commented) {
-							line_text = line_text.substr(2, line_text.length());
-						} else {
-							line_text = "//" + line_text;
-						}
-					}
-					tx->set_line(i, line_text);
-				}
-			} else {
-				int begin = tx->cursor_get_line();
-				String line_text = tx->get_line(begin);
-
-				if (line_text.begins_with("//"))
-					line_text = line_text.substr(2, line_text.length());
-				else
-					line_text = "//" + line_text;
-				tx->set_line(begin, line_text);
-			}
-			tx->end_complex_operation();
-			tx->update();
-			//tx->deselect();
+			shader_editor->toggle_inline_comment("//");
 
 		} break;
 		case EDIT_COMPLETE: {


### PR DESCRIPTION
Fix #25780

The PR has 2 commits for 2 steps: refactor and fix.

Refactor step slightly changes the behaviour of toggle_comment in the Shader Editor, updating the caret position but by the wrong offset (hardcoded 1 instead of 2 since comment delimiter is "//").
Fix replaces the hardcoded 1 with delimiter length to make solution generic.

After discussion with @Paulb23, I decided to extract the toggle_inline_comment method in `CodeTextEditor` (child of `ScriptTextEditor`, and also the base class for `ShaderTextEditor`) rather than `TextEdit` (the actual part where you read and edit text). Technically it could be part of `TextEdit`, but the current convention seems to move higher-level text manipulation to the `CodeTextEditor`. On my next PR (for #22177), I will probably have a pass on the comment-related methods still in TextEdit.