### PR TITLE
Fix CSGShape not updating on changing visibility

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -531,6 +531,13 @@ void CSGShape::_notification(int p_what) {
 		}
 	}
 
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+
+		if (parent) {
+			parent->_make_dirty();
+		}
+	}
+
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
 		if (parent)


### PR DESCRIPTION
Hiding CSGShape should force the CSG operation to skip it which is intended
behaviour according to how CSGBrush is created for each shape.

https://github.com/godotengine/godot/blob/095f472a0b162508f67604ea1409d38c52b1ce51/modules/csg/csg_shape.cpp#L163-L169