### PR TITLE
Windows: Default to system MSBuild and add VSCode hint path

### DIFF
--- a/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
@@ -18,8 +18,6 @@ namespace GodotSharpTools.Build
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern static string godot_icall_BuildInstance_get_MSBuildPath();
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern static string godot_icall_BuildInstance_get_FrameworkPath();
-        [MethodImpl(MethodImplOptions.InternalCall)]
         private extern static string godot_icall_BuildInstance_get_MonoWindowsBinDir();
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern static bool godot_icall_BuildInstance_get_UsingMonoMSBuildOnWindows();
@@ -32,11 +30,6 @@ namespace GodotSharpTools.Build
                 throw new FileNotFoundException("Cannot find the MSBuild executable.");
 
             return msbuildPath;
-        }
-
-        private static string GetFrameworkPath()
-        {
-            return godot_icall_BuildInstance_get_FrameworkPath();
         }
 
         private static string MonoWindowsBinDir
@@ -84,11 +77,6 @@ namespace GodotSharpTools.Build
 
             if (customProperties != null)
                 customPropertiesList.AddRange(customProperties);
-
-            string frameworkPath = GetFrameworkPath();
-
-            if (!string.IsNullOrEmpty(frameworkPath))
-                customPropertiesList.Add("FrameworkPathOverride=" + frameworkPath);
 
             string compilerArgs = BuildArguments(loggerAssemblyPath, loggerOutputDir, customPropertiesList);
 
@@ -144,11 +132,6 @@ namespace GodotSharpTools.Build
 
             if (customProperties != null)
                 customPropertiesList.AddRange(customProperties);
-
-            string frameworkPath = GetFrameworkPath();
-
-            if (!string.IsNullOrEmpty(frameworkPath))
-                customPropertiesList.Add("FrameworkPathOverride=" + frameworkPath);
 
             string compilerArgs = BuildArguments(loggerAssemblyPath, loggerOutputDir, customPropertiesList);
 

--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -273,12 +273,14 @@ Error GodotSharpEditor::open_in_external_editor(const Ref<Script> &p_script, int
 
 			if (vscode_path.empty() || !FileAccess::exists(vscode_path)) {
 				static List<String> vscode_name;
-				vscode_name.push_back("code");
-				vscode_name.push_back("code-oss");
-				vscode_name.push_back("vscode");
-				vscode_name.push_back("vscode-oss");
-				vscode_name.push_back("visual-studio-code");
-				vscode_name.push_back("visual-studio-code-oss");
+				if (vscode_name.empty()) {
+					vscode_name.push_back("code");
+					vscode_name.push_back("code-oss");
+					vscode_name.push_back("vscode");
+					vscode_name.push_back("vscode-oss");
+					vscode_name.push_back("visual-studio-code");
+					vscode_name.push_back("visual-studio-code-oss");
+				}
 				// Try to search it again if it wasn't found last time or if it was removed from its location
 				for (int i = 0; i < vscode_name.size(); i++) {
 					vscode_path = path_which(vscode_name[i]);

--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -272,21 +272,50 @@ Error GodotSharpEditor::open_in_external_editor(const Ref<Script> &p_script, int
 			static String vscode_path;
 
 			if (vscode_path.empty() || !FileAccess::exists(vscode_path)) {
-				static List<String> vscode_name;
-				if (vscode_name.empty()) {
-					vscode_name.push_back("code");
-					vscode_name.push_back("code-oss");
-					vscode_name.push_back("vscode");
-					vscode_name.push_back("vscode-oss");
-					vscode_name.push_back("visual-studio-code");
-					vscode_name.push_back("visual-studio-code-oss");
-				}
 				// Try to search it again if it wasn't found last time or if it was removed from its location
-				for (int i = 0; i < vscode_name.size(); i++) {
-					vscode_path = path_which(vscode_name[i]);
-					if (!vscode_path.empty() || FileAccess::exists(vscode_path))
-						break;
+				bool found = false;
+
+				// TODO: Use initializer lists once C++11 is allowed
+
+				// Try with hint paths
+				static Vector<String> hint_paths;
+#ifdef WINDOWS_ENABLED
+				if (hint_paths.empty()) {
+					hint_paths.push_back(OS::get_singleton()->get_environment("ProgramFiles") + "\\Microsoft VS Code\\Code.exe");
+					if (sizeof(size_t) == 8) {
+						hint_paths.push_back(OS::get_singleton()->get_environment("ProgramFiles(x86)") + "\\Microsoft VS Code\\Code.exe");
+					}
 				}
+#endif
+				for (int i = 0; i < hint_paths.size(); i++) {
+					vscode_path = hint_paths[i];
+					if (FileAccess::exists(vscode_path)) {
+						found = true;
+						break;
+					}
+				}
+
+				if (!found) {
+					static Vector<String> vscode_names;
+					if (vscode_names.empty()) {
+						vscode_names.push_back("code");
+						vscode_names.push_back("code-oss");
+						vscode_names.push_back("vscode");
+						vscode_names.push_back("vscode-oss");
+						vscode_names.push_back("visual-studio-code");
+						vscode_names.push_back("visual-studio-code-oss");
+					}
+					for (int i = 0; i < vscode_names.size(); i++) {
+						vscode_path = path_which(vscode_names[i]);
+						if (!vscode_path.empty()) {
+							found = true;
+							break;
+						}
+					}
+				}
+
+				if (!found)
+					vscode_path.clear(); // Not found, clear so next time the empty() check is enough
 			}
 
 			List<String> args;


### PR DESCRIPTION
Also we no longer pass `FrameworkPathOverride` to MSBuild. It was causing issues with some NuGet packages.
