### PR TITLE
Hide the warning panel when no warnings presents.

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1177,7 +1177,12 @@ void CodeTextEditor::_warning_label_gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void CodeTextEditor::_warning_button_pressed() {
-	emit_signal("warning_pressed");
+	_set_show_warnings_panel(!is_warnings_panel_opened);
+}
+
+void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
+	is_warnings_panel_opened = p_show;
+	emit_signal("show_warnings_panel", p_show);
 }
 
 void CodeTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
@@ -1210,6 +1215,8 @@ void CodeTextEditor::set_warning_nb(int p_warning_nb) {
 	warning_count_label->set_text(itos(p_warning_nb));
 	warning_count_label->set_visible(p_warning_nb > 0);
 	warning_button->set_visible(p_warning_nb > 0);
+	if (!p_warning_nb)
+		_set_show_warnings_panel(false);
 }
 
 void CodeTextEditor::_bind_methods() {
@@ -1228,7 +1235,7 @@ void CodeTextEditor::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("validate_script"));
 	ADD_SIGNAL(MethodInfo("load_theme_settings"));
-	ADD_SIGNAL(MethodInfo("warning_pressed"));
+	ADD_SIGNAL(MethodInfo("show_warnings_panel"));
 	ADD_SIGNAL(MethodInfo("error_pressed"));
 }
 
@@ -1313,6 +1320,7 @@ CodeTextEditor::CodeTextEditor() {
 	warning_count_label->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
 	warning_count_label->connect("gui_input", this, "_warning_label_gui_input");
 
+	is_warnings_panel_opened = false;
 	set_warning_nb(0);
 
 	// Line and column

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -176,6 +176,7 @@ class CodeTextEditor : public VBoxContainer {
 
 	void _warning_label_gui_input(const Ref<InputEvent> &p_event);
 	void _warning_button_pressed();
+	void _set_show_warnings_panel(bool p_show);
 	void _error_pressed(const Ref<InputEvent> &p_event);
 
 protected:
@@ -189,6 +190,8 @@ protected:
 	void _line_col_changed();
 	void _notification(int);
 	static void _bind_methods();
+
+	bool is_warnings_panel_opened;
 
 public:
 	void trim_trailing_whitespace();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -273,8 +273,8 @@ void ScriptTextEditor::_set_theme_for_script() {
 	}
 }
 
-void ScriptTextEditor::_toggle_warning_pannel() {
-	warnings_panel->set_visible(!warnings_panel->is_visible());
+void ScriptTextEditor::_show_warnings_panel(bool p_show) {
+	warnings_panel->set_visible(p_show);
 }
 
 void ScriptTextEditor::_error_pressed() {
@@ -1101,7 +1101,7 @@ void ScriptTextEditor::_bind_methods() {
 	ClassDB::bind_method("_goto_line", &ScriptTextEditor::_goto_line);
 	ClassDB::bind_method("_lookup_symbol", &ScriptTextEditor::_lookup_symbol);
 	ClassDB::bind_method("_text_edit_gui_input", &ScriptTextEditor::_text_edit_gui_input);
-	ClassDB::bind_method("_toggle_warning_pannel", &ScriptTextEditor::_toggle_warning_pannel);
+	ClassDB::bind_method("_show_warnings_panel", &ScriptTextEditor::_show_warnings_panel);
 	ClassDB::bind_method("_error_pressed", &ScriptTextEditor::_error_pressed);
 	ClassDB::bind_method("_warning_clicked", &ScriptTextEditor::_warning_clicked);
 	ClassDB::bind_method("_color_changed", &ScriptTextEditor::_color_changed);
@@ -1440,7 +1440,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	warnings_panel->hide();
 
 	code_editor->connect("error_pressed", this, "_error_pressed");
-	code_editor->connect("warning_pressed", this, "_toggle_warning_pannel");
+	code_editor->connect("show_warnings_panel", this, "_show_warnings_panel");
 	warnings_panel->connect("meta_clicked", this, "_warning_clicked");
 
 	update_settings();

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -125,7 +125,7 @@ protected:
 	void _code_complete_script(const String &p_code, List<String> *r_options, bool &r_force);
 	void _load_theme_settings();
 	void _set_theme_for_script();
-	void _toggle_warning_pannel();
+	void _show_warnings_panel(bool p_show);
 	void _error_pressed();
 	void _warning_clicked(Variant p_line);
 


### PR DESCRIPTION
When you open the warnings panel and fix warning, panel steel opened and you can't close it.
Before:
![warning_panel](https://user-images.githubusercontent.com/1049442/52621829-773ce480-2ed2-11e9-856e-8b45bee69dd4.gif)
After:
![warning_panel_fixed](https://user-images.githubusercontent.com/1049442/52621837-7a37d500-2ed2-11e9-85ab-1347195ad6bd.gif)
