### PR TITLE
Minor cleanup in the Project Manager

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4990,7 +4990,6 @@ EditorNode::EditorNode() {
 	main_vbox = memnew(VBoxContainer);
 	gui_base->add_child(main_vbox);
 	main_vbox->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 8);
-	main_vbox->set_margin(MARGIN_TOP, 5 * EDSCALE);
 
 	menu_hb = memnew(HBoxContainer);
 	main_vbox->add_child(menu_hb);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1895,13 +1895,11 @@ ProjectManager::ProjectManager() {
 	Panel *panel = memnew(Panel);
 	gui_base->add_child(panel);
 	panel->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	panel->add_style_override("panel", gui_base->get_stylebox("Background", "EditorStyles"));
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 	panel->add_child(vb);
-	vb->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 20 * EDSCALE);
-	vb->set_margin(MARGIN_TOP, 4 * EDSCALE);
-	vb->set_margin(MARGIN_BOTTOM, -4 * EDSCALE);
-	vb->add_constant_override("separation", 15 * EDSCALE);
+	vb->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 8 * EDSCALE);
 
 	String cp;
 	cp += 0xA9;
@@ -1909,11 +1907,9 @@ ProjectManager::ProjectManager() {
 
 	HBoxContainer *top_hb = memnew(HBoxContainer);
 	vb->add_child(top_hb);
-	CenterContainer *ccl = memnew(CenterContainer);
 	Label *l = memnew(Label);
 	l->set_text(VERSION_NAME + String(" - ") + TTR("Project Manager"));
-	ccl->add_child(l);
-	top_hb->add_child(ccl);
+	top_hb->add_child(l);
 	top_hb->add_spacer();
 	l = memnew(Label);
 	String hash = String(VERSION_HASH);
@@ -2060,6 +2056,8 @@ ProjectManager::ProjectManager() {
 	settings_hb->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
 
 	language_btn = memnew(OptionButton);
+	language_btn->set_flat(true);
+	language_btn->set_focus_mode(Control::FOCUS_NONE);
 
 	Vector<String> editor_languages;
 	List<PropertyInfo> editor_settings_properties;


### PR DESCRIPTION
- Remove unnecessary nodes.
- Remove unnecessary margin settings that were doing nothing.
- Tone down the current margin a bit.
- Change background color to be the as the the editor's.
- Make language selector flat.