### PR TITLE
[Core] [Mono] Transform2D rotation and scale fixes

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -258,7 +258,7 @@ Vector3 Basis::get_scale_abs() const {
 }
 
 Vector3 Basis::get_scale_local() const {
-	real_t det_sign = determinant() > 0 ? 1 : -1;
+	real_t det_sign = SGN(determinant());
 	return det_sign * Vector3(elements[0].length(), elements[1].length(), elements[2].length());
 }
 
@@ -284,7 +284,7 @@ Vector3 Basis::get_scale() const {
 	// matrix elements.
 	//
 	// The rotation part of this decomposition is returned by get_rotation* functions.
-	real_t det_sign = determinant() > 0 ? 1 : -1;
+	real_t det_sign = SGN(determinant());
 	return det_sign * Vector3(
 							  Vector3(elements[0][0], elements[1][0], elements[2][0]).length(),
 							  Vector3(elements[0][1], elements[1][1], elements[2][1]).length(),

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -80,13 +80,14 @@ real_t Transform2D::get_rotation() const {
 }
 
 void Transform2D::set_rotation(real_t p_rot) {
-
+	Size2 scale = get_scale();
 	real_t cr = Math::cos(p_rot);
 	real_t sr = Math::sin(p_rot);
 	elements[0][0] = cr;
 	elements[0][1] = sr;
 	elements[1][0] = -sr;
 	elements[1][1] = cr;
+	set_scale(scale);
 }
 
 Transform2D::Transform2D(real_t p_rot, const Vector2 &p_pos) {
@@ -101,8 +102,15 @@ Transform2D::Transform2D(real_t p_rot, const Vector2 &p_pos) {
 }
 
 Size2 Transform2D::get_scale() const {
-	real_t det_sign = basis_determinant() > 0 ? 1 : -1;
+	real_t det_sign = SGN(basis_determinant());
 	return Size2(elements[0].length(), det_sign * elements[1].length());
+}
+
+void Transform2D::set_scale(Size2 &p_scale) {
+	elements[0].normalize();
+	elements[1].normalize();
+	elements[0] *= p_scale.x;
+	elements[1] *= p_scale.y;
 }
 
 void Transform2D::scale(const Size2 &p_scale) {

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -81,6 +81,7 @@ struct Transform2D {
 	real_t basis_determinant() const;
 
 	Size2 get_scale() const;
+	void set_scale(Size2 &p_scale);
 
 	_FORCE_INLINE_ const Vector2 &get_origin() const { return elements[2]; }
 	_FORCE_INLINE_ void set_origin(const Vector2 &p_origin) { elements[2] = p_origin; }


### PR DESCRIPTION
Core:

* Add `set_scale` method to Transform2D. Not exposed to GDScript yet, no user-facing changes.

* Fix `set_rotation` to work with scaled transforms. Also not exposed to GDScript.

* Use `SGN()` method instead of manually writing `> 0 ? 1 : -1`.

Mono: @neikeq 

* Fix rotation and scale getters.

* Add rotation and scale setters.

* Some internal code refactoring.