### PR TITLE
Allows auto save when changing resources

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -372,6 +372,10 @@ void InspectorDock::_bind_methods() {
 }
 
 void InspectorDock::edit_resource(const Ref<Resource> &p_resource) {
+	if (EDITOR_GET("interface/inspector/save_resources_upon_reload") && current) {
+		_save_resource(false);
+	}
+
 	_resource_selected(p_resource, "");
 }
 
@@ -608,6 +612,8 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 
 	inspector->connect("resource_selected", this, "_resource_selected");
 	inspector->connect("property_keyed", this, "_property_keyed");
+
+	EDITOR_DEF("interface/inspector/save_resources_upon_reload", true);
 }
 
 InspectorDock::~InspectorDock() {


### PR DESCRIPTION
Refers to #25832
This solution allows to automatically save resources upon changing resource in the Inspector by toggling an option in the Editor Settings panel.

<img width="896" alt="captura de ecra 2019-02-12 as 19 58 08" src="https://user-images.githubusercontent.com/10358443/52664286-8c306c80-2f00-11e9-9e97-3fef0b2d5daf.png">

Very simple edit