### PR TITLE
fix 'OptionButton dropdown popup doesn't scale #19451'

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -104,8 +104,10 @@ void OptionButton::_selected(int p_which) {
 void OptionButton::pressed() {
 
 	Size2 size = get_size();
-	popup->set_global_position(get_global_position() + Size2(0, size.height));
+	Vector2 scale = get_scale();
+	popup->set_global_position(get_global_position() + Size2(0, size.height * scale.y));
 	popup->set_size(Size2(size.width, 0));
+	popup->set_scale(scale);
 
 	popup->popup();
 }


### PR DESCRIPTION
This fixes [#19451](https://github.com/godotengine/godot/issues/19451)
Demo of the fixed popup: https://youtu.be/BHZZv8wtHs4
Test project adds 4 buttons to a Node2D scene called test. test's _ready function adds 10 items to each option button, then sets the scales on 3 of the 4 buttons.