### PR TITLE
New export options in iOS

### DIFF
--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		1FE9269F1FBBF86B00F53A6F /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE926901FBBF78E00F53A6F /* CoreMedia.framework */; };
 		1FE926A01FBBF86D00F53A6F /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE9268E1FBBF77300F53A6F /* AudioToolbox.framework */; };
 		1FE926A11FBBF86D00F53A6F /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE9268F1FBBF77F00F53A6F /* CoreAudio.framework */; };
+		E360193721F32F38009258C1 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E360193621F32F37009258C1 /* CoreVideo.framework */; };
 		DEADBEEF2F582BE20003B888 /* $binary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DEADBEEF1F582BE20003B888 /* $binary.a */; };
 		1FF8DBB11FBA9DE1009DE660 /* dummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */; };
 		1FF4C1851F584E3F00A41E41 /* GameKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF4C1841F584E3F00A41E41 /* GameKit.framework */; };
@@ -53,6 +54,7 @@
 		D0BCFE3418AEBDA2004A7AAE /* $binary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = $binary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0BCFE3718AEBDA2004A7AAE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D0BCFE3918AEBDA2004A7AAE /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		E360193621F32F37009258C1 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
 		D0BCFE3B18AEBDA2004A7AAE /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		D0BCFE3D18AEBDA2004A7AAE /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		D0BCFE3F18AEBDA2004A7AAE /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
@@ -69,6 +71,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0BCFE3A18AEBDA2004A7AAE /* CoreGraphics.framework in Frameworks */,
+				E360193721F32F38009258C1 /* CoreVideo.framework in Frameworks */,
 				1FE926991FBBF85400F53A6F /* SystemConfiguration.framework in Frameworks */,
 				1FE9269A1FBBF85F00F53A6F /* Security.framework in Frameworks */,
 				1FE9269B1FBBF86200F53A6F /* QuartzCore.framework in Frameworks */,
@@ -124,6 +127,7 @@
 				1FE926911FBBF79500F53A6F /* CoreMotion.framework */,
 				1FE926901FBBF78E00F53A6F /* CoreMedia.framework */,
 				1FE9268F1FBBF77F00F53A6F /* CoreAudio.framework */,
+				E360193621F32F37009258C1 /* CoreVideo.framework */,
 				1FE9268E1FBBF77300F53A6F /* AudioToolbox.framework */,
 				1FF4C1861F584E5600A41E41 /* StoreKit.framework */,
 				1FF4C1841F584E3F00A41E41 /* GameKit.framework */,
@@ -190,15 +194,82 @@
 				TargetAttributes = {
 					D0BCFE3318AEBDA2004A7AAE = {
 						DevelopmentTeam = $team_id;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
-							com.apple.GameCenter = {
-								enabled = 1;
+							com.apple.AccessWiFi = {
+								enabled = $access_wifi;
+							};
+							com.apple.ApplePay = {
+								enabled = 0;
+							};
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 0;
+							};
+							com.apple.AutoFillCredentialProvider = {
+								enabled = 0;
+							};
+							com.apple.BackgroundModes = {
+								enabled = 0;
+							};
+							com.apple.ClassKit = {
+								enabled = 0;
+							};
+							com.apple.DataProtection = {
+								enabled = 0;
+							};
+							com.apple.GameCenter.iOS = {
+								enabled = $game_center;
+							};
+							com.apple.HealthKit = {
+								enabled = 0;
+							};
+							com.apple.HomeKit = {
+								enabled = 0;
+							};
+							com.apple.HotspotConfiguration = {
+								enabled = 0;
 							};
 							com.apple.InAppPurchase = {
-								enabled = 1;
+								enabled = $in_app_purchases;
+							};
+							com.apple.InterAppAudio = {
+								enabled = 0;
+							};
+							com.apple.Keychain = {
+								enabled = 0;
+							};
+							com.apple.Maps.iOS = {
+								enabled = 0;
+							};
+							com.apple.Multipath = {
+								enabled = 0;
+							};
+							com.apple.NearFieldCommunicationTagReading = {
+								enabled = 0;
+							};
+							com.apple.NetworkExtensions.iOS = {
+								enabled = 0;
 							};
 							com.apple.Push = {
-								enabled = 1;
+								enabled = $push_notifications;
+							};
+							com.apple.SafariKeychain = {
+								enabled = 0;
+							};
+							com.apple.Siri = {
+								enabled = 0;
+							};
+							com.apple.VPNLite = {
+								enabled = 0;
+							};
+							com.apple.WAC = {
+								enabled = 0;
+							};
+							com.apple.Wallet = {
+								enabled = 0;
+							};
+							com.apple.iCloud = {
+								enabled = 0;
 							};
 						};
 					};
@@ -277,6 +348,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "$code_sign_identity_debug";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "$code_sign_identity_debug";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_BITCODE = NO;
@@ -400,7 +472,7 @@
 				D0BCFE7018AEBDA3004A7AAE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		D0BCFE7118AEBDA3004A7AAE /* Build configuration list for PBXNativeTarget "$binary" */ = {
 			isa = XCConfigurationList;
@@ -409,7 +481,7 @@
 				D0BCFE7318AEBDA3004A7AAE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};

--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>$identifier</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -30,26 +30,25 @@
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
-		<string>gamekit</string>
+		$required_device_capabilities
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>$camera_usage_description</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>$microphone_usage_description</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>$photolibrary_usage_description</string>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UIStatusBarHidden</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		$interface_orientations
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		$interface_orientations
 	</array>
 	$additional_plist_content
 </dict>

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -246,7 +246,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/app_store_team_id"), ""));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/provisioning_profile_uuid_debug"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/code_sign_identity_debug", PROPERTY_HINT_PLACEHOLDER_TEXT, "iPhone Developer"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/code_sign_identity_debug", PROPERTY_HINT_PLACEHOLDER_TEXT, "iPhone Developer"), "iPhone Developer"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_method_debug", PROPERTY_HINT_ENUM, "App Store,Development,Ad-Hoc,Enterprise"), 1));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/provisioning_profile_uuid_release"), ""));
@@ -255,11 +255,26 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/info"), "Made with Godot Engine"));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/identifier", PROPERTY_HINT_PLACEHOLDER_TEXT, "come.example.game"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/identifier", PROPERTY_HINT_PLACEHOLDER_TEXT, "com.example.game"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/signature"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/short_version"), "1.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version"), "1.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/arkit"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/access_wifi"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/game_center"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/in_app_purchases"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/push_notifications"), false));
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/camera_usage_description"), "Godot would like to use your camera"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/microphone_usage_description"), "Godot would like to use your microphone"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/photolibrary_usage_description"), "Godot would like to use your photos"));
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/portrait"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/landscape_left"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/landscape_right"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/portrait_upside_down"), true));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "required_icons/iphone_120x120", PROPERTY_HINT_FILE, "*.png"), "")); // Home screen on iPhone/iPod Touch with retina display
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "required_icons/ipad_76x76", PROPERTY_HINT_FILE, "*.png"), "")); // Home screen on iPad
@@ -337,6 +352,62 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 			strnew += lines[i].replace("$linker_flags", p_config.linker_flags) + "\n";
 		} else if (lines[i].find("$cpp_code") != -1) {
 			strnew += lines[i].replace("$cpp_code", p_config.cpp_code) + "\n";
+		} else if (lines[i].find("$access_wifi") != -1) {
+			bool is_on = p_preset->get("capabilities/access_wifi");
+			strnew += lines[i].replace("$access_wifi", is_on ? "1" : "0") + "\n";
+		} else if (lines[i].find("$game_center") != -1) {
+			bool is_on = p_preset->get("capabilities/game_center");
+			strnew += lines[i].replace("$game_center", is_on ? "1" : "0") + "\n";
+		} else if (lines[i].find("$in_app_purchases") != -1) {
+			bool is_on = p_preset->get("capabilities/in_app_purchases");
+			strnew += lines[i].replace("$in_app_purchases", is_on ? "1" : "0") + "\n";
+		} else if (lines[i].find("$push_notifications") != -1) {
+			bool is_on = p_preset->get("capabilities/push_notifications");
+			strnew += lines[i].replace("$push_notifications", is_on ? "1" : "0") + "\n";
+		} else if (lines[i].find("$required_device_capabilities") != -1) {
+			String capabilities;
+
+			// I've removed armv7 as we can run on 64bit only devices
+			// Note that capabilities listed here are requirements for the app to be installed.
+			// They don't enable anything.
+
+			if ((bool)p_preset->get("capabilities/arkit")) {
+				capabilities += "<string>arkit</string>\n";
+			}
+			if ((bool)p_preset->get("capabilities/game_center")) {
+				capabilities += "<string>gamekit</string>\n";
+			}
+			if ((bool)p_preset->get("capabilities/access_wifi")) {
+				capabilities += "<string>wifi</string>\n";
+			}
+
+			strnew += lines[i].replace("$required_device_capabilities", capabilities);
+		} else if (lines[i].find("$interface_orientations") != -1) {
+			String orientations;
+
+			if ((bool)p_preset->get("orientation/portrait")) {
+				orientations += "<string>UIInterfaceOrientationPortrait</string>\n";
+			}
+			if ((bool)p_preset->get("orientation/landscape_left")) {
+				orientations += "<string>UIInterfaceOrientationLandscapeLeft</string>\n";
+			}
+			if ((bool)p_preset->get("orientation/landscape_right")) {
+				orientations += "<string>UIInterfaceOrientationLandscapeRight</string>\n";
+			}
+			if ((bool)p_preset->get("orientation/portrait_upside_down")) {
+				orientations += "<string>UIInterfaceOrientationPortraitUpsideDown</string>\n";
+			}
+
+			strnew += lines[i].replace("$interface_orientations", orientations);
+		} else if (lines[i].find("$camera_usage_description") != -1) {
+			String description = p_preset->get("privacy/camera_usage_description");
+			strnew += lines[i].replace("$camera_usage_description", description) + "\n";
+		} else if (lines[i].find("$microphone_usage_description") != -1) {
+			String description = p_preset->get("privacy/microphone_usage_description");
+			strnew += lines[i].replace("$microphone_usage_description", description) + "\n";
+		} else if (lines[i].find("$photolibrary_usage_description") != -1) {
+			String description = p_preset->get("privacy/photolibrary_usage_description");
+			strnew += lines[i].replace("$photolibrary_usage_description", description) + "\n";
 		} else {
 			strnew += lines[i] + "\n";
 		}
@@ -647,6 +718,10 @@ void EditorExportPlatformIOS::_add_assets_to_project(Vector<uint8_t> &p_project_
 		format_dict["file_type"] = type;
 		pbx_files += file_info_format.format(format_dict, "$_");
 	}
+
+	// Note, frameworks like gamekit are always included in our project.pbxprof file
+	// even if turned off in capabilities.
+	// Frameworks that are used by modules (like arkit) we may need to optionally add here.
 
 	String str = String::utf8((const char *)p_project_data.ptr(), p_project_data.size());
 	str = str.replace("$additional_pbx_files", pbx_files);


### PR DESCRIPTION
This PR adds a number of capability switches, adds orientation settings and adds a number of privacy strings you need to set up.

This is by no way complete but I am removing the WIP status. Most of the things not implemented are things Godot currently doesn't support anyway. As there are additional entitlements related to some of the capability switches it is best we leave implementation of those until someone has a usecase and can actually test if things work as expected.

For now, this adds the ones that have an impact on what we currently do such as gamekit, in app purchases etc.

There are two reasons we add these into the export settings even though xcode allows you to toggle them after exporting:

- when you de-select anything in xcode it will also remove the associated frameworks and dylibs, this is a problem because it means we can't link Godot. Even when not used we still have the code in our binaries.
- if you don't have a paid developer account you don't get access to most of the capabilities including not having access to turn them off! 

Both these remarks should probably be in the documentation for exporting to iOS. 