### PR TITLE
Fix button alignment of Package Installer on OSX

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -124,49 +124,22 @@ void Popup::popup_centered_minsize(const Size2 &p_minsize) {
 
 void Popup::popup_centered(const Size2 &p_size) {
 
-	Point2 window_size = get_viewport_rect().size;
-
-	emit_signal("about_to_show");
 	Rect2 rect;
+	Size2 window_size = get_viewport_rect().size;
 	rect.size = p_size == Size2() ? get_size() : p_size;
-
 	rect.position = ((window_size - rect.size) / 2.0).floor();
-	set_position(rect.position);
-	set_size(rect.size);
 
-	show_modal(exclusive);
-	_fix_size();
-
-	Control *focusable = find_next_valid_focus();
-	if (focusable)
-		focusable->grab_focus();
-
-	_post_popup();
-	notification(NOTIFICATION_POST_POPUP);
-	popped_up = true;
+	popup(rect);
 }
 
 void Popup::popup_centered_ratio(float p_screen_ratio) {
 
-	emit_signal("about_to_show");
-
 	Rect2 rect;
-	Point2 window_size = get_viewport_rect().size;
+	Size2 window_size = get_viewport_rect().size;
 	rect.size = (window_size * p_screen_ratio).floor();
 	rect.position = ((window_size - rect.size) / 2.0).floor();
-	set_position(rect.position);
-	set_size(rect.size);
 
-	show_modal(exclusive);
-	_fix_size();
-
-	Control *focusable = find_next_valid_focus();
-	if (focusable)
-		focusable->grab_focus();
-
-	_post_popup();
-	notification(NOTIFICATION_POST_POPUP);
-	popped_up = true;
+	popup(rect);
 }
 
 void Popup::popup(const Rect2 &p_bounds) {


### PR DESCRIPTION
### Before:
<img width="512" alt="before" src="https://user-images.githubusercontent.com/2587873/52720341-ca09bf80-2fea-11e9-90b8-6d05b4067e06.png">

### After:
<img width="512" alt="after" src="https://user-images.githubusercontent.com/2587873/52720500-12c17880-2feb-11e9-9de7-016a84bf3517.png">

### Step to reproduce:
- Set Mac to HiDPI
- Open Godot Editor
- Open Asset Library
- Download Any Asset and Open Package Installer

### Description:

I don't know the exact cause, but it seems that the order of calling show_modal() is related.
When using Popup::popup(const Rect2 &p_bounds), this problem didn't occur.
Eventually, I unified processing to Popup::popup(const Rect2 &p_bounds).

Maybe related to #24554.