### PR TITLE
UndoRedo add version changed signal

### DIFF
--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -118,6 +118,9 @@ public:
 	String get_current_action_name() const;
 	void clear_history(bool p_increase_version = true);
 
+	bool has_undo();
+	bool has_redo();
+
 	uint64_t get_version() const;
 
 	void set_commit_notify_callback(CommitNotifyCallback p_callback, void *p_ud);

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -141,6 +141,20 @@
 				This is useful mostly to check if something changed from a saved version.
 			</description>
 		</method>
+		<method name="has_redo">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if an 'redo' action is available.
+			</description>
+		</method>
+		<method name="has_undo">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if an 'undo' action is available.
+			</description>
+		</method>
 		<method name="is_commiting_action" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -162,6 +176,13 @@
 			</description>
 		</method>
 	</methods>
+	<signals>
+		<signal name="version_changed">
+			<description>
+				Called when [method undo] or [method redo] was called.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="MERGE_DISABLE" value="0" enum="MergeMode">
 			Makes [code]do[/code]/[code]undo[/code] operations stay in separate actions.


### PR DESCRIPTION
added some functions to manage undo buttons

EDIT:
```
extends HBoxContainer

var undo_redo = UndoRedo.new()

var undo = Button.new()
var redo = Button.new()
var save = Button.new()

var do = Button.new()
var label = Label.new()
var saved_state = -1

func _ready():
	OS.set_window_size(Vector2(230, 80))
	undo.set_text("Undo")
	redo.set_text("Redo")
	save.set_text("Save")
	
	do.set_text("Do")
	label.set_text("0")
	
	add_child(undo)
	add_child(redo)
	add_child(save)
	
	add_child(do)
	add_child(label)
	
	undo_redo.connect("version_changed", self, "update_undo_button_state")
	
	undo.connect("button_down", undo_redo, "undo")
	redo.connect("button_down", undo_redo, "redo")
	save.connect("button_down", self, "save_state")
	do.connect("button_down", self, "do_changes")
	update_undo_button_state()

func update_undo_button_state():
	undo.set_disabled(!undo_redo.has_undo())
	redo.set_disabled(!undo_redo.has_redo())
	save.set_disabled(saved_state==undo_redo.get_version())

func save_state():
	save.set_disabled(true)
	saved_state = undo_redo.get_version()

func do_changes():
	undo_redo.create_action("do Change")
	undo_redo.add_undo_method(label, "set_text", str(undo_redo.get_version()-1))
	undo_redo.add_do_method(label, "set_text", str(undo_redo.get_version()))
	undo_redo.commit_action()
```