### PR TITLE
Clear cache, .import and data folders directly from Project Manager

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -48,6 +48,9 @@ class ProjectManager : public Control {
 	Button *open_btn;
 	Button *rename_btn;
 	Button *run_btn;
+	Button *clear_project_data_btn;
+	Button *clear_project_import_btn;
+	Button *clear_project_cache_btn;
 
 	EditorAssetLibrary *asset_library;
 
@@ -57,6 +60,9 @@ class ProjectManager : public Control {
 	FileDialog *scan_dir;
 	ConfirmationDialog *language_restart_ask;
 	ConfirmationDialog *erase_ask;
+	ConfirmationDialog *clear_project_data_ask;
+	ConfirmationDialog *clear_project_cache_ask;
+	ConfirmationDialog *clear_project_import_ask;
 	ConfirmationDialog *multi_open_ask;
 	ConfirmationDialog *multi_run_ask;
 	ConfirmationDialog *multi_scan_ask;
@@ -90,6 +96,12 @@ class ProjectManager : public Control {
 	void _rename_project();
 	void _erase_project();
 	void _erase_project_confirm();
+	void _clear_project_data();
+	void _clear_project_data_confirm();
+	void _clear_project_cache();
+	void _clear_project_cache_confirm();
+	void _clear_project_import();
+	void _clear_project_import_confirm();
 	void _update_project_buttons();
 	void _language_selected(int p_id);
 	void _restart_confirm();


### PR DESCRIPTION
This PR add 3 buttons to clear cache, import and data folders which removing can help test projects.
I usually removed these folders manually, but it is much easier to remove them from the project manager.
You need to run editor with verbose (e.g. godot.x11.tools.64 -e -v) to see a list of cleared folders.

1. Clear data - Clear all user data from projects - stored in user://
e.g. /home/rafal/.local/share/godot/app_userdata/PROJECT_NAME

2. Clear import - Delete .import folder stored inside project folder
e.g /home/rafal/Projekty/PROJECT_NAME/.import
When you clear .import files, you will unable to run project from project manager.
This button will be probably useless, when Godot automatically will remove unused and broken entries in .import.

3. Clear cache - Clear godot editor cache and project cache
e.g /home/rafal/.cache/godot - godot cache
and /home/rafal/.config/godot/projects/PROJECT_NAME-32CHARACTERS

Also I centred  labels in popups, because it looks for me better. 

![zrzut ekranu z 2019-02-14 17-21-22](https://user-images.githubusercontent.com/41945903/52801719-cc1d5e00-307e-11e9-99c5-2e9d13466f0e.png)
