### PR TITLE
Fix AnimationPlayer bug where it wouldn't reset its position when finished

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -938,6 +938,7 @@ void AnimationPlayer::_animation_process(float p_delta) {
 			} else {
 				//stop();
 				playing = false;
+				playback.current.pos = 0;
 				_set_process(false);
 				if (end_notify)
 					emit_signal(SceneStringNames::get_singleton()->animation_finished, playback.assigned);


### PR DESCRIPTION
Fixes #25873

This is the simplest solution I found. When it reaches the end and doesn't have a queue, reset its position to 0 at line 941.

https://github.com/godotengine/godot/blob/5ec4f14a245b66b3e268f3c6cbb68a85336c7ca6/scene/animation/animation_player.cpp#L917-L952
