### PR TITLE
Fix Godot.Reference marshalling from MonoObject* to Variant

### DIFF
--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -698,7 +698,11 @@ Variant mono_object_to_variant(MonoObject *p_obj) {
 			// GodotObject
 			if (CACHED_CLASS(GodotObject)->is_assignable_from(type_class)) {
 				Object *ptr = unbox<Object *>(CACHED_FIELD(GodotObject, ptr)->get_value(p_obj));
-				return ptr ? Variant(ptr) : Variant();
+				if (ptr != NULL) {
+					Reference *ref = Object::cast_to<Reference>(ptr);
+					return ref ? Variant(Ref<Reference>(ref)) : Variant(ptr);
+				}
+				return Variant();
 			}
 
 			if (CACHED_CLASS(NodePath) == type_class) {


### PR DESCRIPTION
Need to cast Ref<T> to Variant instead of constructing Variant from Object*, otherwise the Variant won't hold a reference.

Should fix #25818
