### PR TITLE
Fix icon color for gizmos menu when theme changed

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4856,6 +4856,13 @@ void SpatialEditor::_update_gizmos_menu() {
 	}
 }
 
+void SpatialEditor::_update_gizmos_menu_theme() {
+	for (int i = 0; i < gizmo_plugins.size(); ++i) {
+		if (!gizmo_plugins[i]->can_be_hidden()) continue;
+		gizmos_menu->set_item_icon(gizmos_menu->get_item_index(i), gizmos_menu->get_icon("visibility_visible"));
+	}
+}
+
 void SpatialEditor::_init_grid() {
 
 	PoolVector<Color> grid_colors[3];
@@ -5145,20 +5152,17 @@ void SpatialEditor::_notification(int p_what) {
 		get_tree()->connect("node_removed", this, "_node_removed");
 		EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->connect("node_changed", this, "_refresh_menu_icons");
 		editor_selection->connect("selection_changed", this, "_refresh_menu_icons");
-	}
-
-	if (p_what == NOTIFICATION_ENTER_TREE) {
+	} else if (p_what == NOTIFICATION_ENTER_TREE) {
 
 		_register_all_gizmos();
 		_update_gizmos_menu();
 		_init_indicators();
-	}
-
-	if (p_what == NOTIFICATION_EXIT_TREE) {
+	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
+		_update_gizmos_menu_theme();
+	} else if (p_what == NOTIFICATION_EXIT_TREE) {
 
 		_finish_indicators();
-	}
-	if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
+	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
 		tool_button[SpatialEditor::TOOL_MODE_SELECT]->set_icon(get_icon("ToolSelect", "EditorIcons"));
 		tool_button[SpatialEditor::TOOL_MODE_MOVE]->set_icon(get_icon("ToolMove", "EditorIcons"));
 		tool_button[SpatialEditor::TOOL_MODE_ROTATE]->set_icon(get_icon("ToolRotate", "EditorIcons"));

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -618,6 +618,7 @@ private:
 	void _instance_scene();
 	void _init_indicators();
 	void _update_gizmos_menu();
+	void _update_gizmos_menu_theme();
 	void _init_grid();
 	void _finish_indicators();
 	void _finish_grid();


### PR DESCRIPTION
Gizmos looks like not changing its icon color when theme switching(its visible if you change from dark to light theme)

For example

![image](https://user-images.githubusercontent.com/3036176/52874003-6eae0d80-3161-11e9-80f9-f7675e06a3f3.png)

whereas it should be

![image](https://user-images.githubusercontent.com/3036176/52874059-8dac9f80-3161-11e9-8280-0497415854a8.png)

I fixed it by introducing new method to update that icons properly(I think the simple usage of _update_gizmos_menu is bad, cuz its recreate that menu from scratch and I think its overkill for this bug )