### PR TITLE
Mono: Get rid of irrelevant error and fix export template build errors

### DIFF
--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -99,13 +99,16 @@ public:
 	String sln_filepath;
 	String csproj_filepath;
 
-	String data_mono_bin_dir;
 	String data_editor_tools_dir;
 	String data_editor_prebuilt_api_dir;
 #endif
 
 	String data_mono_etc_dir;
 	String data_mono_lib_dir;
+
+#ifdef WINDOWS_ENABLED
+	String data_mono_bin_dir;
+#endif
 
 private:
 	_GodotSharpDirs() {
@@ -146,9 +149,12 @@ private:
 		data_editor_prebuilt_api_dir = data_dir_root.plus_file("Api");
 
 		String data_mono_root_dir = data_dir_root.plus_file("Mono");
-		data_mono_bin_dir = data_mono_root_dir.plus_file("bin");
 		data_mono_etc_dir = data_mono_root_dir.plus_file("etc");
 		data_mono_lib_dir = data_mono_root_dir.plus_file("lib");
+
+#ifdef WINDOWS_ENABLED
+		data_mono_bin_dir = data_mono_root_dir.plus_file("bin");
+#endif
 
 #ifdef OSX_ENABLED
 		if (!DirAccess::exists(data_editor_tools_dir)) {
@@ -160,7 +166,6 @@ private:
 		}
 
 		if (!DirAccess::exists(data_mono_root_dir)) {
-			data_mono_bin_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Mono/bin");
 			data_mono_etc_dir = exe_dir.plus_file("../Resources/GodotSharp/Mono/etc");
 			data_mono_lib_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Mono/lib");
 		}
@@ -177,6 +182,10 @@ private:
 		String data_mono_root_dir = data_dir_root.plus_file("Mono");
 		data_mono_etc_dir = data_mono_root_dir.plus_file("etc");
 		data_mono_lib_dir = data_mono_root_dir.plus_file("lib");
+
+#ifdef WINDOWS_ENABLED
+		data_mono_bin_dir = data_mono_root_dir.plus_file("bin");
+#endif
 
 #ifdef OSX_ENABLED
 		if (!DirAccess::exists(data_mono_root_dir)) {
@@ -251,10 +260,6 @@ String get_project_csproj_path() {
 	return _GodotSharpDirs::get_singleton().csproj_filepath;
 }
 
-String get_data_mono_bin_dir() {
-	return _GodotSharpDirs::get_singleton().data_mono_bin_dir;
-}
-
 String get_data_editor_tools_dir() {
 	return _GodotSharpDirs::get_singleton().data_editor_tools_dir;
 }
@@ -271,5 +276,11 @@ String get_data_mono_etc_dir() {
 String get_data_mono_lib_dir() {
 	return _GodotSharpDirs::get_singleton().data_mono_lib_dir;
 }
+
+#ifdef WINDOWS_ENABLED
+String get_data_mono_bin_dir() {
+	return _GodotSharpDirs::get_singleton().data_mono_bin_dir;
+}
+#endif
 
 } // namespace GodotSharpDirs

--- a/modules/mono/godotsharp_dirs.h
+++ b/modules/mono/godotsharp_dirs.h
@@ -53,13 +53,16 @@ String get_build_logs_dir();
 String get_project_sln_path();
 String get_project_csproj_path();
 
-String get_data_mono_bin_dir();
 String get_data_editor_tools_dir();
 String get_data_editor_prebuilt_api_dir();
 #endif
 
 String get_data_mono_etc_dir();
 String get_data_mono_lib_dir();
+
+#ifdef WINDOWS_ENABLED
+String get_data_mono_bin_dir();
+#endif
 
 } // namespace GodotSharpDirs
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -241,11 +241,21 @@ void GDMono::initialize() {
 		assembly_rootdir = bundled_assembly_rootdir;
 		config_dir = bundled_config_dir;
 	}
+
+#ifdef WINDOWS_ENABLED
+	if (assembly_rootdir.empty() || config_dir.empty()) {
+		// Assertion: if they are not set, then they weren't found in the registry
+		CRASH_COND(mono_reg_info.assembly_dir.length() > 0 || mono_reg_info.config_dir.length() > 0);
+
+		ERR_PRINT("Cannot find Mono in the registry");
+	}
+#endif // WINDOWS_ENABLED
+
 #else
 	// These are always the directories in export templates
 	assembly_rootdir = bundled_assembly_rootdir;
 	config_dir = bundled_config_dir;
-#endif
+#endif // TOOLS_ENABLED
 
 	// Leak if we call mono_set_dirs more than once
 	mono_set_dirs(assembly_rootdir.length() ? assembly_rootdir.utf8().get_data() : NULL,

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -157,7 +157,17 @@ void GDMono::add_mono_shared_libs_dir_to_path() {
 	path_value += ';';
 
 	String bundled_bin_dir = GodotSharpDirs::get_data_mono_bin_dir();
-	path_value += DirAccess::exists(bundled_bin_dir) ? bundled_bin_dir : mono_reg_info.bin_dir;
+#ifdef TOOLS_ENABLED
+	if (DirAccess::exists(bundled_bin_dir)) {
+		path_value += bundled_bin_dir;
+	} else {
+		path_value += mono_reg_info.bin_dir;
+	}
+#else
+	if (DirAccess::exists(bundled_bin_dir))
+		path_value += bundled_bin_dir;
+#endif // TOOLS_ENABLED
+
 #else
 	path_value += ':';
 
@@ -167,10 +177,10 @@ void GDMono::add_mono_shared_libs_dir_to_path() {
 	} else {
 		// TODO: Do we need to add the lib dir when using the system installed Mono on Unix platforms?
 	}
-#endif
+#endif // WINDOWS_ENABLED
 
 	OS::get_singleton()->set_environment(path_var, path_value);
-#endif
+#endif // WINDOWS_ENABLED || UNIX_ENABLED
 }
 
 void GDMono::initialize() {

--- a/modules/mono/utils/mono_reg_utils.cpp
+++ b/modules/mono/utils/mono_reg_utils.cpp
@@ -158,8 +158,6 @@ MonoRegInfo find_mono() {
 	if (_find_mono_in_reg_old("Software\\Novell\\Mono", info) == ERROR_SUCCESS)
 		return info;
 
-	ERR_PRINT("Cannot find mono in the registry");
-
 	return MonoRegInfo();
 }
 


### PR DESCRIPTION
- Fix mono export template build errors. Fixes #25903
- Don't print 'Cannot find Mono in the registry' if bundled with Godot. Closes #24753
