### PR TITLE
add pitch_mix to AudioEffectPitchShift

### DIFF
--- a/servers/audio/effects/audio_effect_pitch_shift.h
+++ b/servers/audio/effects/audio_effect_pitch_shift.h
@@ -54,7 +54,7 @@ class SMBPitchShift {
 	void smbFft(float *fftBuffer, long fftFrameSize, long sign);
 
 public:
-	void PitchShift(float pitchShift, long numSampsToProcess, long fftFrameSize, long osamp, float sampleRate, float *indata, float *outdata, int stride);
+	void PitchShift(float pitchShift, long numSampsToProcess, long fftFrameSize, long osamp, float sampleRate, float *indata, float *outdata, int stride, float pitchMix);
 
 	SMBPitchShift() {
 		gRover = 0;
@@ -92,6 +92,7 @@ class AudioEffectPitchShift : public AudioEffect {
 	int window_size;
 	float wet;
 	float dry;
+	float pitch_mix;
 	bool filter;
 
 protected:
@@ -102,6 +103,9 @@ public:
 
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
+
+	void set_pitch_mix(float p_pitch_mix);
+	float get_pitch_mix() const;
 
 	AudioEffectPitchShift();
 };


### PR DESCRIPTION
Hi, this is my very first pullrequest. Hopefully everything is ok. I will take any advice to do better future pull requests. If there is a better solution to achive the mixin goal for the pitchshift-effect, please say and i will give it a try.
I was in need for a mix for the PitchShift effect to create a robotic voice and i don't want to use two seperate AudioStreamPlayers. It was not easy for me to understand the code and to abstract what i need to do, but at least it seems to work.
![audioeffectpitchshiftmix](https://user-images.githubusercontent.com/33563732/52885519-cce2ec80-3171-11e9-82c8-0b0c2e929a04.png)