### PR TITLE
Make Button shortcuts triggerable by gamepads

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -749,6 +749,15 @@ bool InputEventJoypadButton::action_match(const Ref<InputEvent> &p_event, bool *
 	return match;
 }
 
+bool InputEventJoypadButton::shortcut_match(const Ref<InputEvent> &p_event) const {
+
+	Ref<InputEventJoypadButton> button = p_event;
+	if (button.is_null())
+		return false;
+
+	return button_index == button->button_index;
+}
+
 String InputEventJoypadButton::as_text() const {
 
 	return "InputEventJoypadButton : button_index=" + itos(button_index) + ", pressed=" + (pressed ? "true" : "false") + ", pressure=" + String(Variant(pressure));
@@ -950,11 +959,10 @@ bool InputEventAction::is_pressed() const {
 }
 
 bool InputEventAction::shortcut_match(const Ref<InputEvent> &p_event) const {
-	Ref<InputEventKey> event = p_event;
-	if (event.is_null())
+	if (p_event.is_null())
 		return false;
 
-	return event->is_action(action);
+	return p_event->is_action(action);
 }
 
 bool InputEventAction::is_action(const StringName &p_action) const {

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -400,6 +400,7 @@ public:
 	float get_pressure() const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const;
+	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
 
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;


### PR DESCRIPTION
This can be tested in [Escape Space](https://github.com/Calinou/escape-space) by starting the game with a controller connected, entering a submenu then pressing B (Xbox) or Circle (PlayStation) to go back to the main menu.

Please test in your projects if you can :slightly_smiling_face:

This closes #25741.