### PR TITLE
Add --init cli argument to create new projects

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -963,6 +963,41 @@ bool ProjectSettings::has_custom_feature(const String &p_feature) const {
 	return custom_features.has(p_feature);
 }
 
+ProjectSettings::CustomMap ProjectSettings::get_default_settings(const String &project_name, const String &driver) {
+	ProjectSettings::CustomMap initial_settings;
+
+	if (driver == "GLES3") {
+		initial_settings["rendering/quality/driver/driver_name"] = "GLES3";
+	} else {
+		initial_settings["rendering/quality/driver/driver_name"] = "GLES2";
+		initial_settings["rendering/vram_compression/import_etc2"] = false;
+		initial_settings["rendering/vram_compression/import_etc"] = true;
+	}
+	initial_settings["application/config/name"] = project_name;
+	initial_settings["application/config/icon"] = "res://" + get_default_icon_name();
+	initial_settings["rendering/environment/default_environment"] = "res://" + get_default_env_name();
+
+	return initial_settings;
+}
+
+String ProjectSettings::get_default_env_content() {
+	String default_env_str;
+	default_env_str += "[gd_resource type=\"Environment\" load_steps=2 format=2]\n";
+	default_env_str += "[sub_resource type=\"ProceduralSky\" id=1]\n";
+	default_env_str += "[resource]\n";
+	default_env_str += "background_mode = 2\n";
+	default_env_str += "background_sky = SubResource( 1 )\n";
+	return default_env_str;
+}
+
+String ProjectSettings::get_default_icon_name() {
+	return "icon.png";
+}
+
+String ProjectSettings::get_default_env_name() {
+	return "default_env.tres";
+}
+
 void ProjectSettings::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_setting", "name"), &ProjectSettings::has_setting);

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -120,6 +120,11 @@ protected:
 public:
 	static const int CONFIG_VERSION = 4;
 
+	static CustomMap get_default_settings(const String &project_name, const String &driver = "GLES3");
+	static String get_default_env_content();
+	static String get_default_icon_name();
+	static String get_default_env_name();
+
 	void set_setting(const String &p_setting, const Variant &p_value);
 	Variant get_setting(const String &p_setting) const;
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -472,32 +472,19 @@ private:
 			} else {
 				if (mode == MODE_NEW) {
 
-					ProjectSettings::CustomMap initial_settings;
-					if (rasterizer_button_group->get_pressed_button()->get_meta("driver_name") == "GLES3") {
-						initial_settings["rendering/quality/driver/driver_name"] = "GLES3";
-					} else {
-						initial_settings["rendering/quality/driver/driver_name"] = "GLES2";
-						initial_settings["rendering/vram_compression/import_etc2"] = false;
-						initial_settings["rendering/vram_compression/import_etc"] = true;
-					}
-					initial_settings["application/config/name"] = project_name->get_text();
-					initial_settings["application/config/icon"] = "res://icon.png";
-					initial_settings["rendering/environment/default_environment"] = "res://default_env.tres";
+					ProjectSettings::CustomMap initial_settings = ProjectSettings::get_default_settings(project_name->get_text(),
+							rasterizer_button_group->get_pressed_button()->get_meta("driver_name"));
 
 					if (ProjectSettings::get_singleton()->save_custom(dir.plus_file("project.godot"), initial_settings, Vector<String>(), false) != OK) {
 						set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 					} else {
-						ResourceSaver::save(dir.plus_file("icon.png"), get_icon("DefaultProjectIcon", "EditorIcons"));
+						ResourceSaver::save(dir.plus_file(ProjectSettings::get_default_icon_name()), get_icon("DefaultProjectIcon", "EditorIcons"));
 
-						FileAccess *f = FileAccess::open(dir.plus_file("default_env.tres"), FileAccess::WRITE);
+						FileAccess *f = FileAccess::open(dir.plus_file(ProjectSettings::get_default_env_name()), FileAccess::WRITE);
 						if (!f) {
 							set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 						} else {
-							f->store_line("[gd_resource type=\"Environment\" load_steps=2 format=2]");
-							f->store_line("[sub_resource type=\"ProceduralSky\" id=1]");
-							f->store_line("[resource]");
-							f->store_line("background_mode = 2");
-							f->store_line("background_sky = SubResource( 1 )");
+							f->store_line(ProjectSettings::get_default_env_content());
 							memdelete(f);
 						}
 					}


### PR DESCRIPTION
Solves https://github.com/godotengine/godot/issues/25797

I works as `git init` but you have to pass the name of the project as an argument. I creates project.godot, icon.png and default_env.tres in the directory you call this command.