### PR TITLE
Fix big text window in TextEdit

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -115,8 +115,8 @@ void EditorPropertyMultilineText::_open_big_text() {
 		add_child(big_text_dialog);
 	}
 
-	big_text->set_text(text->get_text());
 	big_text_dialog->popup_centered_ratio();
+	big_text->set_text(text->get_text());
 }
 
 void EditorPropertyMultilineText::update_property() {


### PR DESCRIPTION
This PR repair showing text in TextEdit with big text window open.

Fix #25463