### PR TITLE
Expose OS::get_current_video_driver to scripting languages

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -225,8 +225,12 @@ int _OS::get_video_driver_count() const {
 	return OS::get_singleton()->get_video_driver_count();
 }
 
-String _OS::get_video_driver_name(int p_driver) const {
-	return OS::get_singleton()->get_video_driver_name(p_driver);
+String _OS::get_video_driver_name(VideoDriver p_driver) const {
+	return OS::get_singleton()->get_video_driver_name((int)p_driver);
+}
+
+_OS::VideoDriver _OS::get_current_video_driver() const {
+	return (VideoDriver)OS::get_singleton()->get_current_video_driver();
 }
 
 int _OS::get_audio_driver_count() const {
@@ -1108,6 +1112,8 @@ void _OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_video_driver_count"), &_OS::get_video_driver_count);
 	ClassDB::bind_method(D_METHOD("get_video_driver_name", "driver"), &_OS::get_video_driver_name);
+	ClassDB::bind_method(D_METHOD("get_current_video_driver"), &_OS::get_current_video_driver);
+
 	ClassDB::bind_method(D_METHOD("get_audio_driver_count"), &_OS::get_audio_driver_count);
 	ClassDB::bind_method(D_METHOD("get_audio_driver_name", "driver"), &_OS::get_audio_driver_name);
 	ClassDB::bind_method(D_METHOD("get_connected_midi_inputs"), &_OS::get_connected_midi_inputs);
@@ -1275,6 +1281,9 @@ void _OS::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_resizable"), "set_window_resizable", "is_window_resizable");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "window_position"), "set_window_position", "get_window_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "window_size"), "set_window_size", "get_window_size");
+
+	BIND_ENUM_CONSTANT(VIDEO_DRIVER_GLES2);
+	BIND_ENUM_CONSTANT(VIDEO_DRIVER_GLES3);
 
 	BIND_ENUM_CONSTANT(DAY_SUNDAY);
 	BIND_ENUM_CONSTANT(DAY_MONDAY);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -103,6 +103,11 @@ protected:
 	static _OS *singleton;
 
 public:
+	enum VideoDriver {
+		VIDEO_DRIVER_GLES3,
+		VIDEO_DRIVER_GLES2,
+	};
+
 	enum PowerState {
 		POWERSTATE_UNKNOWN, /**< cannot determine power status */
 		POWERSTATE_ON_BATTERY, /**< Not plugged in, running on the battery */
@@ -152,7 +157,8 @@ public:
 	Array get_fullscreen_mode_list(int p_screen = 0) const;
 
 	virtual int get_video_driver_count() const;
-	virtual String get_video_driver_name(int p_driver) const;
+	virtual String get_video_driver_name(VideoDriver p_driver) const;
+	virtual VideoDriver get_current_video_driver() const;
 
 	virtual int get_audio_driver_count() const;
 	virtual String get_audio_driver_name(int p_driver) const;
@@ -355,6 +361,7 @@ public:
 	_OS();
 };
 
+VARIANT_ENUM_CAST(_OS::VideoDriver);
 VARIANT_ENUM_CAST(_OS::PowerState);
 VARIANT_ENUM_CAST(_OS::Weekday);
 VARIANT_ENUM_CAST(_OS::Month);

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -648,6 +648,12 @@
 			The animation step value.
 		</member>
 	</members>
+	<signals>
+		<signal name="tracks_changed">
+			<description>
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="TYPE_VALUE" value="0" enum="TrackType">
 			Value tracks set values in node properties, but only those which can be Interpolated.

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -48,6 +48,14 @@
 				Return the transform of a specific instance.
 			</description>
 		</method>
+		<method name="get_instance_transform_2d" qualifiers="const">
+			<return type="Transform2D">
+			</return>
+			<argument index="0" name="instance" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_instance_color">
 			<return type="void">
 			</return>
@@ -79,6 +87,16 @@
 			</argument>
 			<description>
 				Set the transform for a specific instance.
+			</description>
+		</method>
+		<method name="set_instance_transform_2d">
+			<return type="void">
+			</return>
+			<argument index="0" name="instance" type="int">
+			</argument>
+			<argument index="1" name="transform" type="Transform2D">
+			</argument>
+			<description>
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -159,6 +159,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_current_video_driver" qualifiers="const">
+			<return type="int" enum="OS.VideoDriver">
+			</return>
+			<description>
+				Returns the currently used video driver, using one of the values from [enum OS.VideoDriver].
+			</description>
+		</method>
 		<method name="get_date" qualifiers="const">
 			<return type="Dictionary">
 			</return>
@@ -459,14 +466,16 @@
 			<return type="int">
 			</return>
 			<description>
+				Returns the number of video drivers supported on the current platform.
 			</description>
 		</method>
 		<method name="get_video_driver_name" qualifiers="const">
 			<return type="String">
 			</return>
-			<argument index="0" name="driver" type="int">
+			<argument index="0" name="driver" type="int" enum="OS.VideoDriver">
 			</argument>
 			<description>
+				Returns the name of the video driver matching the given [code]driver[/code] index. This index is a value from [enum OS.VideoDriver], and you can use [method get_current_video_driver] to get the current backend's index.
 			</description>
 		</method>
 		<method name="get_virtual_keyboard_height">
@@ -806,6 +815,12 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="VIDEO_DRIVER_GLES2" value="1" enum="VideoDriver">
+			The GLES2 rendering backend. It uses OpenGL ES 2.0 on mobile devices, OpenGL 2.1 on desktop platforms and WebGL 1.0 on the web.
+		</constant>
+		<constant name="VIDEO_DRIVER_GLES3" value="0" enum="VideoDriver">
+			The GLES3 rendering backend. It uses OpenGL ES 3.0 on mobile devices, OpenGL 3.3 on desktop platforms and WebGL 2.0 on the web.
+		</constant>
 		<constant name="DAY_SUNDAY" value="0" enum="Weekday">
 			Sunday.
 		</constant>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -74,15 +74,15 @@
 				Return the ID of the item at index [code]idx[/code].
 			</description>
 		</method>
-                <method name="get_item_index" qualifiers="const">
-                        <return type="int">
-                        </return>
-                        <argument index="0" name="id" type="int">
-                        </argument>
-                        <description>
-                                Return the index of the item with the given [code]id[/code].
-                        </description>
-                </method>
+		<method name="get_item_index" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+				Return the index of the item with the given [code]id[/code].
+			</description>
+		</method>
 		<method name="get_item_metadata" qualifiers="const">
 			<return type="Variant">
 			</return>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -216,6 +216,8 @@
 		</theme_item>
 		<theme_item name="tab_bg" type="StyleBox">
 		</theme_item>
+		<theme_item name="tab_disabled" type="StyleBox">
+		</theme_item>
 		<theme_item name="tab_fg" type="StyleBox">
 		</theme_item>
 		<theme_item name="top_margin" type="int">

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -279,6 +279,8 @@
 		</theme_item>
 		<theme_item name="tab_bg" type="StyleBox">
 		</theme_item>
+		<theme_item name="tab_disabled" type="StyleBox">
+		</theme_item>
 		<theme_item name="tab_fg" type="StyleBox">
 		</theme_item>
 		<theme_item name="top_margin" type="int">


### PR DESCRIPTION
Without this there's no easy way to check in-game what renderer is used, as the ProjectSettings entry can be overridden by command line or fallback.