### PR TITLE
Better and non-buggy Polygon2D editing disabling

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -297,12 +297,6 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 
 	if (mb.is_valid()) {
 
-		String cant_edit = _why_cant_edit_polygon();
-		if (cant_edit != String()) {
-			EditorNode::get_singleton()->show_warning(cant_edit);
-			return true;
-		}
-
 		Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_global_transform();
 
 		Vector2 gpoint = mb->get_position();

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -275,9 +275,30 @@ void AbstractPolygon2DEditor::_wip_close() {
 	selected_point = Vertex();
 }
 
+void AbstractPolygon2DEditor::disable_polygon_editing(bool p_disable, String p_reason) {
+
+	_polygon_editing_enabled = !p_disable;
+
+	button_create->set_disabled(p_disable);
+	button_edit->set_disabled(p_disable);
+	button_delete->set_disabled(p_disable);
+
+	if (p_disable) {
+
+		button_create->set_tooltip(p_reason);
+		button_edit->set_tooltip(p_reason);
+		button_delete->set_tooltip(p_reason);
+	} else {
+
+		button_create->set_tooltip(TTR("Create points."));
+		button_edit->set_tooltip(TTR("Edit points.\nLMB: Move Point\nRMB: Erase Point"));
+		button_delete->set_tooltip(TTR("Erase points."));
+	}
+}
+
 bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
-	if (!_get_node())
+	if (!_get_node() || !_polygon_editing_enabled)
 		return false;
 
 	Ref<InputEventMouseButton> mb = p_event;
@@ -627,9 +648,8 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 
 void AbstractPolygon2DEditor::edit(Node *p_polygon) {
 
-	if (!canvas_item_editor) {
+	if (!canvas_item_editor)
 		canvas_item_editor = CanvasItemEditor::get_singleton();
-	}
 
 	if (p_polygon) {
 
@@ -648,7 +668,6 @@ void AbstractPolygon2DEditor::edit(Node *p_polygon) {
 		selected_point = Vertex();
 
 		canvas_item_editor->update_viewport();
-
 	} else {
 
 		_set_node(NULL);
@@ -778,24 +797,23 @@ AbstractPolygon2DEditor::AbstractPolygon2DEditor(EditorNode *p_editor, bool p_wi
 	selected_point = Vertex();
 	edge_point = PosVertex();
 
+	disable_polygon_editing(false, String());
+
 	add_child(memnew(VSeparator));
 	button_create = memnew(ToolButton);
 	add_child(button_create);
 	button_create->connect("pressed", this, "_menu_option", varray(MODE_CREATE));
 	button_create->set_toggle_mode(true);
-	button_create->set_tooltip(TTR("Create points."));
 
 	button_edit = memnew(ToolButton);
 	add_child(button_edit);
 	button_edit->connect("pressed", this, "_menu_option", varray(MODE_EDIT));
 	button_edit->set_toggle_mode(true);
-	button_edit->set_tooltip(TTR("Edit points.\nLMB: Move Point\nRMB: Erase Point"));
 
 	button_delete = memnew(ToolButton);
 	add_child(button_delete);
 	button_delete->connect("pressed", this, "_menu_option", varray(MODE_DELETE));
 	button_delete->set_toggle_mode(true);
-	button_delete->set_tooltip(TTR("Erase points."));
 
 	create_resource = memnew(ConfirmationDialog);
 	add_child(create_resource);

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -81,6 +81,8 @@ class AbstractPolygon2DEditor : public HBoxContainer {
 	bool wip_active;
 	bool wip_destructive;
 
+	bool _polygon_editing_enabled;
+
 	CanvasItemEditor *canvas_item_editor;
 	EditorNode *editor;
 	Panel *panel;
@@ -135,6 +137,8 @@ protected:
 	virtual void _create_resource();
 
 public:
+	void disable_polygon_editing(bool p_disable, String p_reason);
+
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -134,8 +134,6 @@ protected:
 	virtual bool _has_resource() const;
 	virtual void _create_resource();
 
-	virtual String _why_cant_edit_polygon() const { return String(); }
-
 public:
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
 	void forward_canvas_draw_over_viewport(Control *p_overlay);

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -52,16 +52,6 @@ Vector2 Polygon2DEditor::_get_offset(int p_idx) const {
 	return node->get_offset();
 }
 
-String Polygon2DEditor::_why_cant_edit_polygon() const {
-
-	if (node->get_internal_vertex_count() > 0) {
-
-		return TTR("Polygon 2D has internal vertices, so it can no longer be edited in the viewport.");
-	}
-
-	return String();
-}
-
 int Polygon2DEditor::_get_polygon_count() const {
 	if (node->get_internal_vertex_count() > 0) {
 		return 0; //do not edit if internal vertices exist

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -45,6 +45,7 @@ Node2D *Polygon2DEditor::_get_node() const {
 void Polygon2DEditor::_set_node(Node *p_polygon) {
 
 	node = Object::cast_to<Polygon2D>(p_polygon);
+	_update_polygon_editing_state();
 }
 
 Vector2 Polygon2DEditor::_get_offset(int p_idx) const {
@@ -53,6 +54,7 @@ Vector2 Polygon2DEditor::_get_offset(int p_idx) const {
 }
 
 int Polygon2DEditor::_get_polygon_count() const {
+
 	if (node->get_internal_vertex_count() > 0) {
 		return 0; //do not edit if internal vertices exist
 	} else {
@@ -365,6 +367,8 @@ void Polygon2DEditor::_cancel_editing() {
 		node->set_vertex_colors(uv_create_colors_prev);
 		node->call("_set_bones", uv_create_bones_prev);
 		node->set_polygons(polygons_prev);
+
+		_update_polygon_editing_state();
 	} else if (uv_drag) {
 		uv_drag = false;
 		if (uv_edit_mode[0]->is_pressed()) { // Edit UV.
@@ -377,9 +381,20 @@ void Polygon2DEditor::_cancel_editing() {
 	polygon_create.clear();
 }
 
+void Polygon2DEditor::_update_polygon_editing_state() {
+
+	if (!_get_node())
+		return;
+
+	if (node->get_internal_vertex_count() > 0)
+		disable_polygon_editing(true, TTR("Polygon 2D has internal vertices, so it can no longer be edited in the viewport."));
+	else
+		disable_polygon_editing(false, String());
+}
+
 void Polygon2DEditor::_commit_action() {
 
-	// Makes that undo/redoing actions made outside of the UV editor still affects its polygon.
+	// Makes that undo/redoing actions made outside of the UV editor still affect its polygon.
 	undo_redo->add_do_method(uv_edit_draw, "update");
 	undo_redo->add_undo_method(uv_edit_draw, "update");
 	undo_redo->add_do_method(CanvasItemEditor::get_singleton(), "update_viewport");
@@ -480,6 +495,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 						uv_create_colors_prev = node->get_vertex_colors();
 						uv_create_bones_prev = node->call("_get_bones");
 						polygons_prev = node->get_polygons();
+						disable_polygon_editing(false, String());
 						node->set_polygon(points_prev);
 						node->set_uv(points_prev);
 						node->set_internal_vertex_count(0);
@@ -501,6 +517,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 							undo_redo->add_undo_method(node, "set_vertex_colors", uv_create_colors_prev);
 							undo_redo->add_do_method(node, "clear_bones");
 							undo_redo->add_undo_method(node, "_set_bones", uv_create_bones_prev);
+							undo_redo->add_do_method(this, "_update_polygon_editing_state");
+							undo_redo->add_undo_method(this, "_update_polygon_editing_state");
 							undo_redo->add_do_method(uv_edit_draw, "update");
 							undo_redo->add_undo_method(uv_edit_draw, "update");
 							undo_redo->commit_action();
@@ -552,7 +570,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					}
 					undo_redo->add_do_method(node, "set_internal_vertex_count", internal_vertices + 1);
 					undo_redo->add_undo_method(node, "set_internal_vertex_count", internal_vertices);
-
+					undo_redo->add_do_method(this, "_update_polygon_editing_state");
+					undo_redo->add_undo_method(this, "_update_polygon_editing_state");
 					undo_redo->add_do_method(uv_edit_draw, "update");
 					undo_redo->add_undo_method(uv_edit_draw, "update");
 					undo_redo->commit_action();
@@ -606,7 +625,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					}
 					undo_redo->add_do_method(node, "set_internal_vertex_count", internal_vertices - 1);
 					undo_redo->add_undo_method(node, "set_internal_vertex_count", internal_vertices);
-
+					undo_redo->add_do_method(this, "_update_polygon_editing_state");
+					undo_redo->add_undo_method(this, "_update_polygon_editing_state");
 					undo_redo->add_do_method(uv_edit_draw, "update");
 					undo_redo->add_undo_method(uv_edit_draw, "update");
 					undo_redo->commit_action();
@@ -1223,6 +1243,7 @@ void Polygon2DEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_uv_edit_popup_hide"), &Polygon2DEditor::_uv_edit_popup_hide);
 	ClassDB::bind_method(D_METHOD("_sync_bones"), &Polygon2DEditor::_sync_bones);
 	ClassDB::bind_method(D_METHOD("_update_bone_list"), &Polygon2DEditor::_update_bone_list);
+	ClassDB::bind_method(D_METHOD("_update_polygon_editing_state"), &Polygon2DEditor::_update_polygon_editing_state);
 	ClassDB::bind_method(D_METHOD("_bone_paint_selected"), &Polygon2DEditor::_bone_paint_selected);
 }
 

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -128,6 +128,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	virtual void _menu_option(int p_option);
 
 	void _cancel_editing();
+	void _update_polygon_editing_state();
 
 	void _uv_scroll_changed(float);
 	void _uv_input(const Ref<InputEvent> &p_input);

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -152,7 +152,6 @@ protected:
 	virtual void _set_node(Node *p_polygon);
 
 	virtual Vector2 _get_offset(int p_idx) const;
-	virtual String _why_cant_edit_polygon() const;
 
 	virtual bool _has_uv() const { return true; };
 	virtual void _commit_action();


### PR DESCRIPTION
This implementation reverts 419fb45a3eea68516828fe4541a62f8641cf13ef and places a better option which enables moving the node, doesn't make the canvas editor unusable, as well as not crashing the editor itself.

Fixes #25860.