### PR TITLE
 Fix keep-alive without header in HTTP client

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -426,11 +426,10 @@ Error HTTPClient::poll() {
 					response_headers.clear();
 					response_num = RESPONSE_OK;
 
-					// Per the HTTP 1.1 spec, keep-alive is the default, but in practice
-					// it's safe to assume it only if the explicit header is found, allowing
-					// to handle body-up-to-EOF responses on naive servers; that's what Curl
-					// and browsers do
-					bool keep_alive = false;
+					// Per the HTTP 1.1 spec, keep-alive is the default.
+					// Not following that specification breaks standard implemetations.
+					// Broken web servers should be fixed.
+					bool keep_alive = true;
 
 					for (int i = 0; i < responses.size(); i++) {
 
@@ -447,8 +446,8 @@ Error HTTPClient::poll() {
 							if (encoding == "chunked") {
 								chunked = true;
 							}
-						} else if (s.begins_with("connection: keep-alive")) {
-							keep_alive = true;
+						} else if (s.begins_with("connection: close")) {
+							keep_alive = false;
 						}
 
 						if (i == 0 && responses[i].begins_with("HTTP")) {

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1338,6 +1338,7 @@ void EditorAssetLibrary::_bind_methods() {
 
 EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
+	requesting = REQUESTING_NONE;
 	templates_only = p_templates_only;
 
 	VBoxContainer *library_main = memnew(VBoxContainer);


### PR DESCRIPTION
Some website (e.g. gitlab.com ) do not specify the HTTP header:
`connection: keep-alive` header even if the connection is kept alive.
This is standard, and must be handled according to the standard.

Fixes #25929 . (The HTTP client was stuck in a loop trying to read server response until EOF, so the thread could not finish, preventing godot from quitting until the connection timed out).

Bonus: Fix jump over uninitialized value detected by valgrind.