### PR TITLE
Fixed TextureProgress in Radial Mode when using center offset

### DIFF
--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -160,23 +160,27 @@ Point2 TextureProgress::unit_val_to_uv(float val) {
 		if (edge == 0) {
 			if (dir.x > 0)
 				continue;
-			cp = -dir.x;
 			cq = -(edgeLeft - p.x);
+			dir.x *= 2.0 * cq;
+			cp = -dir.x;
 		} else if (edge == 1) {
 			if (dir.x < 0)
 				continue;
-			cp = dir.x;
 			cq = (edgeRight - p.x);
+			dir.x *= 2.0 * cq;
+			cp = dir.x;
 		} else if (edge == 2) {
 			if (dir.y > 0)
 				continue;
-			cp = -dir.y;
 			cq = -(edgeBottom - p.y);
+			dir.y *= 2.0 * cq;
+			cp = -dir.y;
 		} else if (edge == 3) {
 			if (dir.y < 0)
 				continue;
-			cp = dir.y;
 			cq = (edgeTop - p.y);
+			dir.y *= 2.0 * cq;
+			cp = dir.y;
 		}
 		cr = cq / cp;
 		if (cr >= 0 && cr < t1)


### PR DESCRIPTION
Made a fix in the implementation of Liang-Barsky line clipping algorithm (introduced in #17422) to take the distance to edges into account for uv calculations.

With this change, the radial progress in TextureProgress is drawn correctly when changing the center offset.

Before:
<img src="https://user-images.githubusercontent.com/1075032/52904667-5ad0dd00-322f-11e9-99bb-bd8724be9296.png" height="64" />

After:
<img src="https://user-images.githubusercontent.com/1075032/52904652-24935d80-322f-11e9-9bab-3f79983718f0.png" height="64" />

The calculated uv values are still exactly the same when the center offset is (0,0).

Fixes #25757