### PR TITLE
Add hex-encoded version number to Engine singleton for easy comparisons

### DIFF
--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -98,6 +98,7 @@ Dictionary Engine::get_version_info() const {
 #else
 	dict["patch"] = 0;
 #endif
+	dict["hex"] = VERSION_HEX;
 	dict["status"] = VERSION_STATUS;
 	dict["build"] = VERSION_BUILD;
 	dict["year"] = VERSION_YEAR;

--- a/core/version.h
+++ b/core/version.h
@@ -41,9 +41,14 @@
 #ifdef VERSION_PATCH
 // Example: "3.1.4"
 #define VERSION_NUMBER "" VERSION_BRANCH "." _MKSTR(VERSION_PATCH)
+// Version number encoded as hexadecimal int with one byte for each number,
+// for easy comparison from code.
+// Example: 3.1.4 will be 0x030104, making comparison easy from script.
+#define VERSION_HEX 0x10000 * VERSION_MAJOR + 0x100 * VERSION_MINOR + VERSION_PATCH
 #else
 // Example: "3.1"
 #define VERSION_NUMBER "" VERSION_BRANCH
+#define VERSION_HEX 0x10000 * VERSION_MAJOR + 0x100 * VERSION_MINOR
 #endif // VERSION_PATCH
 
 // Describes the full configuration of that Godot version, including the version number,

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -90,9 +90,17 @@
 				"major"    - Holds the major version number as an int
 				"minor"    - Holds the minor version number as an int
 				"patch"    - Holds the patch version number as an int
+				"hex"      - Holds the full version number encoded as an hexadecimal int with one byte (2 places) per number (see example below)
 				"status"   - Holds the status (e.g. "beta", "rc1", "rc2", ... "stable") as a String
 				"build"    - Holds the build name (e.g. "custom-build") as a String
 				"string"   - major + minor + patch + status + build in a single String
+				The "hex" value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code]. Note that it's still an int internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for easy version comparisons from code:
+				[codeblock]
+				if Engine.get_version_info().hex >= 0x030200:
+				    # do things specific to version 3.2 or later
+				else:
+				    # do things specific to versions before 3.2
+				[/codeblock]
 			</description>
 		</method>
 		<method name="has_singleton" qualifiers="const">


### PR DESCRIPTION
This makes it easier to do engine versions comparison from code, e.g.:
```gdscript
# The API used below is only available starting with Godot 3.1
var version = Engine.get_version_info()
if version.major > 3 || (version.major == 3 && version.minor >= 1):
    # GLES2 renders a black screen if WorldEnvironment background mode is "Canvas"
    if OS.get_current_video_driver() == OS.VIDEO_DRIVER_GLES2:
        $WorldEnvironment.environment.background_mode = Environment.BG_CLEAR_COLOR
```
becomes:
```gdscript
if Engine.get_version_info().hex >= 0x030100:
    # GLES2 renders a black screen if WorldEnvironment background mode is "Canvas"
    if OS.get_current_video_driver() == OS.VIDEO_DRIVER_GLES2:
        $WorldEnvironment.environment.background_mode = Environment.BG_CLEAR_COLOR
```

The above example is not really useful right now since this `hex` key is not available in 3.0, but we need to introduce it at some point to be usable for comparison between future releases :)

From experience in Godot's codebase (e.g. checking GCC versions), the non-hex variant above is very error prone and hard to read, so the hex-based version number is quite convenient and something I've seen in various libraries (e.g. OGRE).