### PR TITLE
Fix update of canvas AABB with update_when_visible

### DIFF
--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -870,7 +870,7 @@ public:
 		Rect2 global_rect_cache;
 
 		const Rect2 &get_rect() const {
-			if (custom_rect || !rect_dirty)
+			if (custom_rect || (!rect_dirty && !update_when_visible))
 				return rect;
 
 			//must update rect


### PR DESCRIPTION
Ensure the AABB of canvas items is always updated when
`update_when_visible` is enabled.