### PR TITLE
HTTPClient remains as connected and STATUS_BODY if using event-stream…

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -634,7 +634,18 @@ PoolByteArray HTTPClient::read_response_body_chunk() {
 		} else {
 			if (err == ERR_FILE_EOF) {
 				err = OK; // EOF is expected here
-				close();
+
+				// if response header contains 'text/event-stream',
+				// client status should be remained as STATUS_BODY
+				// to keep reading incoming body
+				bool is_stream = false;
+				for (int i = 0; i < response_headers.size(); i++) {
+					if (response_headers[i].to_lower().find("text/event-stream") >= 0) {
+						is_stream = true;
+						break;
+					}
+				}
+				if (!is_stream) close();
 				return ret;
 			}
 		}


### PR DESCRIPTION
… header

faced this issue while working on streaming from the REST API
https://firebase.google.com/docs/reference/rest/database/#section-streaming

```gdscript
extends Node2D

var client:HTTPClient

func _ready():
    client = HTTPClient.new()
    client.connect_to_host( "godotfirebasetest.firebaseio.com", -1, true, true )
    pass

var req_once = false
func _process(delta):
    if client != null:
        var poll = client.poll()
        if client.get_status() == HTTPClient.STATUS_CONNECTED and !req_once:
            var url = "/test.json"
            client.request(HTTPClient.METHOD_GET, url, ["Accept: text/event-stream"], "")
            req_once = true
        elif client.get_status() == HTTPClient.STATUS_BODY:
            var body = client.read_response_body_chunk()
            if body.size() > 0:
                print("get body\n", body.get_string_from_utf8())
```