### PR TITLE
Add CSV export to profiling data

### DIFF
--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -625,6 +625,63 @@ bool EditorProfiler::is_profiling() {
 	return activate->is_pressed();
 }
 
+Vector<Vector<String> > EditorProfiler::get_data_as_csv() const {
+	Vector<Vector<String> > res;
+
+	if (frame_metrics.empty()) {
+		return res;
+	}
+
+	// signatures
+	Vector<String> signatures;
+	const Vector<EditorProfiler::Metric::Category> &categories = frame_metrics[0].categories;
+
+	for (int j = 0; j < categories.size(); j++) {
+
+		const EditorProfiler::Metric::Category &c = categories[j];
+		signatures.push_back(c.signature);
+
+		for (int k = 0; k < c.items.size(); k++) {
+			signatures.push_back(c.items[k].signature);
+		}
+	}
+	res.push_back(signatures);
+
+	// values
+	Vector<String> values;
+	values.resize(signatures.size());
+
+	int index = last_metric;
+
+	for (int i = 0; i < frame_metrics.size(); i++) {
+
+		++index;
+
+		if (index >= frame_metrics.size()) {
+			index = 0;
+		}
+
+		if (!frame_metrics[index].valid) {
+			continue;
+		}
+		int it = 0;
+		const Vector<EditorProfiler::Metric::Category> &frame_cat = frame_metrics[index].categories;
+
+		for (int j = 0; j < frame_cat.size(); j++) {
+
+			const EditorProfiler::Metric::Category &c = frame_cat[j];
+			values.write[it++] = String::num_real(c.total_time);
+
+			for (int k = 0; k < c.items.size(); k++) {
+				values.write[it++] = String::num_real(c.items[k].total);
+			}
+		}
+		res.push_back(values);
+	}
+
+	return res;
+}
+
 EditorProfiler::EditorProfiler() {
 
 	HBoxContainer *hb = memnew(HBoxContainer);

--- a/editor/editor_profiler.h
+++ b/editor/editor_profiler.h
@@ -169,6 +169,8 @@ public:
 
 	void clear();
 
+	Vector<Vector<String> > get_data_as_csv() const;
+
 	EditorProfiler();
 };
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -303,12 +303,49 @@ void ScriptEditorDebugger::_scene_tree_rmb_selected(const Vector2 &p_position) {
 }
 
 void ScriptEditorDebugger::_file_selected(const String &p_file) {
-	if (file_dialog->get_mode() == EditorFileDialog::MODE_SAVE_FILE) {
+	if (file_dialog_mode == SAVE_NODE) {
+
 		Array msg;
 		msg.push_back("save_node");
 		msg.push_back(inspected_object_id);
 		msg.push_back(p_file);
 		ppeer->put_var(msg);
+	} else if (file_dialog_mode == SAVE_CSV) {
+
+		Error err;
+		FileAccessRef file = FileAccess::open(p_file, FileAccess::WRITE, &err);
+
+		if (err != OK) {
+			ERR_PRINTS("Failed to open " + p_file);
+			return;
+		}
+		Vector<String> line;
+		line.resize(Performance::MONITOR_MAX);
+
+		// signatures
+		for (int i = 0; i < Performance::MONITOR_MAX; i++) {
+			line.write[i] = Performance::get_singleton()->get_monitor_name(Performance::Monitor(i));
+		}
+		file->store_csv_line(line);
+
+		// values
+		List<Vector<float> >::Element *E = perf_history.back();
+		while (E) {
+
+			Vector<float> &perf_data = E->get();
+			for (int i = 0; i < perf_data.size(); i++) {
+
+				line.write[i] = String::num_real(perf_data[i]);
+			}
+			file->store_csv_line(line);
+			E = E->prev();
+		}
+		file->store_string("\n");
+
+		Vector<Vector<String> > profiler_data = profiler->get_data_as_csv();
+		for (int i = 0; i < profiler_data.size(); i++) {
+			file->store_csv_line(profiler_data[i]);
+		}
 	}
 }
 
@@ -1395,6 +1432,13 @@ void ScriptEditorDebugger::_output_clear() {
 	//output->push_color(Color(0,0,0));
 }
 
+void ScriptEditorDebugger::_export_csv() {
+
+	file_dialog->set_mode(EditorFileDialog::MODE_SAVE_FILE);
+	file_dialog_mode = SAVE_CSV;
+	file_dialog->popup_centered_ratio();
+}
+
 String ScriptEditorDebugger::get_var_value(const String &p_var) const {
 	if (!breaked)
 		return String();
@@ -1880,6 +1924,7 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 
 			file_dialog->set_access(EditorFileDialog::ACCESS_RESOURCES);
 			file_dialog->set_mode(EditorFileDialog::MODE_SAVE_FILE);
+			file_dialog_mode = SAVE_NODE;
 
 			List<String> extensions;
 			Ref<PackedScene> sd = memnew(PackedScene);
@@ -1905,6 +1950,7 @@ void ScriptEditorDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("debug_break"), &ScriptEditorDebugger::debug_break);
 	ClassDB::bind_method(D_METHOD("debug_continue"), &ScriptEditorDebugger::debug_continue);
 	ClassDB::bind_method(D_METHOD("_output_clear"), &ScriptEditorDebugger::_output_clear);
+	ClassDB::bind_method(D_METHOD("_export_csv"), &ScriptEditorDebugger::_export_csv);
 	ClassDB::bind_method(D_METHOD("_performance_draw"), &ScriptEditorDebugger::_performance_draw);
 	ClassDB::bind_method(D_METHOD("_performance_select"), &ScriptEditorDebugger::_performance_select);
 	ClassDB::bind_method(D_METHOD("_scene_tree_request"), &ScriptEditorDebugger::_scene_tree_request);
@@ -2226,10 +2272,13 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	}
 
 	{ // misc
+		VBoxContainer *misc = memnew(VBoxContainer);
+		misc->set_name(TTR("Misc"));
+		tabs->add_child(misc);
+
 		GridContainer *info_left = memnew(GridContainer);
 		info_left->set_columns(2);
-		info_left->set_name(TTR("Misc"));
-		tabs->add_child(info_left);
+		misc->add_child(info_left);
 		clicked_ctrl = memnew(LineEdit);
 		clicked_ctrl->set_h_size_flags(SIZE_EXPAND_FILL);
 		info_left->add_child(memnew(Label(TTR("Clicked Control:"))));
@@ -2254,6 +2303,16 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 			le_set->set_disabled(true);
 			le_clear->set_disabled(true);
 		}
+
+		misc->add_child(memnew(VSeparator));
+
+		HBoxContainer *buttons = memnew(HBoxContainer);
+
+		export_csv = memnew(Button(TTR("Export measures as CSV")));
+		export_csv->connect("pressed", this, "_export_csv");
+		buttons->add_child(export_csv);
+
+		misc->add_child(buttons);
 	}
 
 	msgdialog = memnew(AcceptDialog);

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -77,6 +77,7 @@ class ScriptEditorDebugger : public Control {
 	LineEdit *live_edit_root;
 	Button *le_set;
 	Button *le_clear;
+	Button *export_csv;
 
 	bool updating_scene_tree;
 	float inspect_scene_tree_timeout;
@@ -92,7 +93,13 @@ class ScriptEditorDebugger : public Control {
 	Tree *inspect_scene_tree;
 	Button *clearbutton;
 	PopupMenu *item_menu;
+
 	EditorFileDialog *file_dialog;
+	enum FileDialogMode {
+		SAVE_CSV,
+		SAVE_NODE,
+	};
+	FileDialogMode file_dialog_mode;
 
 	int error_count;
 	int warning_count;
@@ -195,6 +202,8 @@ class ScriptEditorDebugger : public Control {
 
 	void _error_tree_item_rmb_selected(const Vector2 &p_pos);
 	void _item_menu_id_pressed(int p_option);
+
+	void _export_csv();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Export Profiler and Monitors data in CSV format.
This will allow plotting with programs like Libreoffice and performance analysis with custom scritps.

[Video](https://youtu.be/ZUDNugOW5zw)