### PR TITLE
Allow specifying custom HTTP headers in WebSocket connect_to_url

### DIFF
--- a/modules/websocket/doc_classes/WebSocketClient.xml
+++ b/modules/websocket/doc_classes/WebSocketClient.xml
@@ -23,8 +23,10 @@
 			</argument>
 			<argument index="2" name="gd_mp_api" type="bool" default="false">
 			</argument>
+			<argument index="3" name="http_headers" type="Dictionary" default="Dictionary(  )">
+			</argument>
 			<description>
-				Connect to the given URL requesting one of the given [code]protocols[/code] as sub-protocol.
+				Connect to the given URL requesting one of the given [code]protocols[/code] as sub-protocol. Custom HTTP headers can be specified using [code]http_headers[/code].
 				If [code]true[/code] is passed as [code]gd_mp_api[/code], the client will behave like a network peer for the [MultiplayerAPI], connections to non Godot servers will not work, and [signal data_received] will not be emitted.
 				If [code]false[/code] is passed instead (default), you must call [PacketPeer] functions ([code]put_packet[/code], [code]get_packet[/code], etc.) on the [WebSocketPeer] returned via [code]get_peer(1)[/code] and not on this object directly (e.g. [code]get_peer(1).put_packet(data)[/code]).
 			</description>

--- a/modules/websocket/emws_client.cpp
+++ b/modules/websocket/emws_client.cpp
@@ -64,10 +64,16 @@ EMSCRIPTEN_KEEPALIVE void _esws_on_close(void *obj, int code, char *reason, int 
 }
 }
 
-Error EMWSClient::connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocols) {
+Error EMWSClient::connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocols, Dictionary http_headers) {
 
 	String proto_string = p_protocols.join(",");
 	String str = "ws://";
+
+	// We don't currently support custom WebSocket headers here
+	if (!http_headers.empty()) {
+		print_error("Custom WebSocket HTTP headers are not supported with Emscripten");
+		return ERR_UNAVAILABLE;
+	}
 
 	if (p_ssl)
 		str = "wss://";

--- a/modules/websocket/emws_client.h
+++ b/modules/websocket/emws_client.h
@@ -49,7 +49,7 @@ private:
 public:
 	bool _is_connecting;
 
-	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocol = PoolVector<String>());
+	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocol = PoolVector<String>(), Dictionary http_headers = Dictionary());
 	Ref<WebSocketPeer> get_peer(int p_peer_id) const;
 	void disconnect_from_host(int p_code = 1000, String p_reason = "");
 	IP_Address get_connected_host() const;

--- a/modules/websocket/lws_client.h
+++ b/modules/websocket/lws_client.h
@@ -51,7 +51,7 @@ private:
 	int _out_pkt_size;
 
 public:
-	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocol = PoolVector<String>());
+	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocol = PoolVector<String>(), Dictionary http_headers = Dictionary());
 	int get_max_packet_size() const;
 	Ref<WebSocketPeer> get_peer(int p_peer_id) const;
 	void disconnect_from_host(int p_code = 1000, String p_reason = "");

--- a/modules/websocket/websocket_client.cpp
+++ b/modules/websocket/websocket_client.cpp
@@ -40,7 +40,7 @@ WebSocketClient::WebSocketClient() {
 WebSocketClient::~WebSocketClient() {
 }
 
-Error WebSocketClient::connect_to_url(String p_url, PoolVector<String> p_protocols, bool gd_mp_api) {
+Error WebSocketClient::connect_to_url(String p_url, PoolVector<String> p_protocols, bool gd_mp_api, Dictionary http_headers) {
 	_is_multiplayer = gd_mp_api;
 
 	String host = p_url;
@@ -72,7 +72,7 @@ Error WebSocketClient::connect_to_url(String p_url, PoolVector<String> p_protoco
 		host = host.substr(0, p_len);
 	}
 
-	return connect_to_host(host, path, port, ssl, p_protocols);
+	return connect_to_host(host, path, port, ssl, p_protocols, http_headers);
 }
 
 void WebSocketClient::set_verify_ssl_enabled(bool p_verify_ssl) {

--- a/modules/websocket/websocket_client.h
+++ b/modules/websocket/websocket_client.h
@@ -47,13 +47,13 @@ protected:
 	static void _bind_methods();
 
 public:
-	Error connect_to_url(String p_url, PoolVector<String> p_protocols = PoolVector<String>(), bool gd_mp_api = false);
+	Error connect_to_url(String p_url, PoolVector<String> p_protocols = PoolVector<String>(), bool gd_mp_api = false, Dictionary http_headers = Dictionary());
 
 	void set_verify_ssl_enabled(bool p_verify_ssl);
 	bool is_verify_ssl_enabled() const;
 
 	virtual void poll() = 0;
-	virtual Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocol = PoolVector<String>()) = 0;
+	virtual Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocol = PoolVector<String>(), Dictionary http_headers = Dictionary()) = 0;
 	virtual void disconnect_from_host(int p_code = 1000, String p_reason = "") = 0;
 	virtual IP_Address get_connected_host() const = 0;
 	virtual uint16_t get_connected_port() const = 0;


### PR DESCRIPTION
This PR allows the user to specify a dictionary of custom HTTP headers that will be used during the WebSocket HTTP connection upgrade handshake.

An example of usage:

```
var headers = {"Cookie": "login_token=1JtHVmhWqmvK6KLbVcQ8RT2oEhW9TLAmRv"}
var err = _ws_client.connect_to_url(ws_url, PoolStringArray(), false, headers)
```

Due to limitations in JavaScript, this feature is only available to the native C++ client.