### PR TITLE
fixed AStar improper point deletion (leads to crash)

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -97,11 +97,14 @@ void AStar::remove_point(int p_id) {
 
 	Point *p = points[p_id];
 
-	for (Set<Point *>::Element *E = p->neighbours.front(); E; E = E->next()) {
-
-		Segment s(p_id, E->get()->id);
-		segments.erase(s);
-		E->get()->neighbours.erase(p);
+	Map<int, Point *>::Element *PE = points.front();
+	while (PE) {
+		for (Set<Point *>::Element *E = PE->get()->neighbours.front(); E; E = E->next()) {
+			Segment s(p_id, E->get()->id);
+			segments.erase(s);
+			E->get()->neighbours.erase(p);
+		}
+		PE = PE->next();
 	}
 
 	memdelete(p);


### PR DESCRIPTION
Imagine the situation: we add `p1` and `p2`, connect `p2` -> `p1` (one-way) and then remove `p1`. The old implementation scanned only neighbours of `p1` (which was empty) and removed `p1` itself thus leaving the hanging pointer in `p2` neighbours. This leads to a crash during the next path search. The proper way is to scan all the points and remove the outgoing connections from their neighbours.