### PR TITLE
Add class tree selection to script inheritance selection

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2481,6 +2481,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	add_child(rename_dialog);
 
 	script_create_dialog = memnew(ScriptCreateDialog);
+	script_create_dialog->set_inheritance_base_type("Node");
 	add_child(script_create_dialog);
 	script_create_dialog->connect("script_created", this, "_script_created");
 

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -40,6 +40,8 @@
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 
+class CreateDialog;
+
 class ScriptCreateDialog : public ConfirmationDialog {
 	GDCLASS(ScriptCreateDialog, ConfirmationDialog);
 
@@ -49,6 +51,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	PanelContainer *status_panel;
 	LineEdit *parent_name;
 	Button *parent_browse_button;
+	Button *parent_search_button;
 	OptionButton *language_menu;
 	OptionButton *template_menu;
 	LineEdit *file_path;
@@ -57,6 +60,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	CheckButton *internal;
 	VBoxContainer *path_vb;
 	AcceptDialog *alert;
+	CreateDialog *select_class;
 	bool path_valid;
 	bool create_new;
 	bool is_browsing_parent;
@@ -74,6 +78,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool re_check_path;
 	String script_template;
 	Vector<String> template_list;
+	String base_type;
 
 	bool _can_be_built_in();
 	void _path_changed(const String &p_path = String());
@@ -86,6 +91,8 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	void _template_changed(int p_template = 0);
 	void _browse_path(bool browse_parent, bool p_save);
 	void _file_selected(const String &p_file);
+	void _create();
+	void _browse_class_in_tree();
 	virtual void ok_pressed();
 	void _create_new();
 	void _load_exist();
@@ -99,6 +106,7 @@ protected:
 
 public:
 	void config(const String &p_base_name, const String &p_base_path, bool p_built_in_enabled = true);
+	void set_inheritance_base_type(const String &p_base);
 	ScriptCreateDialog();
 };
 


### PR DESCRIPTION
This PR implements a new button to select the parent class of a new script based on a tree view of the available classes.
Before this PR we had 2 options:
- Use the filesystem navigation button and select an script: this only works for scripts you made yourself and not for built-in types.
- Type the name of the class: this works for Godot types but it is error prone as you can write it wrong. You may find yourself not remembering the exact name of the class you want to inherit from so you have to waste time searching it.

Usage example:

![video](https://user-images.githubusercontent.com/14951430/52969105-7c58d280-33af-11e9-826f-bfa678774f45.gif)

Side note: it shows classes based on Node in the scene tree dock and based on Object in the filesystem dock.
