### PR TITLE
Enabling direct access to viewport texture

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -119,6 +119,12 @@ RID ViewportTexture::get_rid() const {
 	return proxy;
 }
 
+RID ViewportTexture::get_viewport_texture_rid() const {
+
+	ERR_FAIL_COND_V(!vp, RID());
+	return vp->texture_rid;
+}
+
 bool ViewportTexture::has_alpha() const {
 
 	return false;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -77,6 +77,7 @@ public:
 	virtual int get_height() const;
 	virtual Size2 get_size() const;
 	virtual RID get_rid() const;
+	virtual RID get_viewport_texture_rid() const;
 
 	virtual bool has_alpha() const;
 


### PR DESCRIPTION
This feature is required to share viewport texture via Syphon (OSX) and v4l / shmdata (linux).
As ViewportTexture does not inherits from ProxyTexture and is " friended" with Viewport, there is no way to access the viewport's texture via inheritance.
Compilation went fine on OSX.