### PR TITLE
Fix warnings seen with warnings=all and recent GCC 8.2.

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -703,40 +703,38 @@ Variant Object::_call_deferred_bind(const Variant **p_args, int p_argcount, Vari
 }
 
 #ifdef DEBUG_ENABLED
-static bool _test_call_error(const StringName &p_func, const Variant::CallError &error) {
+static void _test_call_error(const StringName &p_func, const Variant::CallError &error) {
 
 	switch (error.error) {
 
 		case Variant::CallError::CALL_OK:
-			return true;
 		case Variant::CallError::CALL_ERROR_INVALID_METHOD:
-			return false;
+			break;
 		case Variant::CallError::CALL_ERROR_INVALID_ARGUMENT: {
 
 			ERR_EXPLAIN("Error Calling Function: " + String(p_func) + " - Invalid type for argument " + itos(error.argument) + ", expected " + Variant::get_type_name(error.expected));
-			ERR_FAIL_V(true);
-		} break;
+			ERR_FAIL();
+			break;
+		}
 		case Variant::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS: {
 
 			ERR_EXPLAIN("Error Calling Function: " + String(p_func) + " - Too many arguments, expected " + itos(error.argument));
-			ERR_FAIL_V(true);
-
-		} break;
+			ERR_FAIL();
+			break;
+		}
 		case Variant::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS: {
 
 			ERR_EXPLAIN("Error Calling Function: " + String(p_func) + " - Too few arguments, expected " + itos(error.argument));
-			ERR_FAIL_V(true);
-
-		} break;
-		case Variant::CallError::CALL_ERROR_INSTANCE_IS_NULL: {
-		} //?
+			ERR_FAIL();
+			break;
+		}
+		case Variant::CallError::CALL_ERROR_INSTANCE_IS_NULL:
+			break;
 	}
-
-	return true;
 }
 #else
 
-#define _test_call_error(m_str, m_err) ((m_err.error == Variant::CallError::CALL_ERROR_INVALID_METHOD) ? false : true)
+#define _test_call_error(m_str, m_err)
 
 #endif
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -394,7 +394,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Vector<String> breakpoints;
 	bool use_custom_res = true;
 	bool force_res = false;
+#ifdef TOOLS_ENABLED
 	bool found_project = false;
+#endif
 
 	packed_data = PackedData::get_singleton();
 	if (!packed_data)
@@ -746,7 +748,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (globals->setup(project_path, main_pack, upwards) == OK) {
+#ifdef TOOLS_ENABLED
 		found_project = true;
+#endif
 	} else {
 
 #ifdef TOOLS_ENABLED
@@ -1273,7 +1277,9 @@ bool Main::start() {
 	bool hasicon = false;
 	String doc_tool;
 	List<String> removal_docs;
+#ifdef TOOLS_ENABLED
 	bool doc_base = true;
+#endif
 	String game_path;
 	String script;
 	String test;
@@ -1286,9 +1292,11 @@ bool Main::start() {
 	List<String> args = OS::get_singleton()->get_cmdline_args();
 	for (int i = 0; i < args.size(); i++) {
 		//parameters that do not have an argument to the right
-		if (args[i] == "--no-docbase") {
-			doc_base = false;
+		if (args[i] == "--check-only") {
+			check_only = true;
 #ifdef TOOLS_ENABLED
+		} else if (args[i] == "--no-docbase") {
+			doc_base = false;
 		} else if (args[i] == "-e" || args[i] == "--editor") {
 			editor = true;
 		} else if (args[i] == "-p" || args[i] == "--project-manager") {
@@ -1296,8 +1304,6 @@ bool Main::start() {
 #endif
 		} else if (args[i].length() && args[i][0] != '-' && game_path == "") {
 			game_path = args[i];
-		} else if (args[i] == "--check-only") {
-			check_only = true;
 		}
 		//parameters that have an argument to the right
 		else if (i < (args.size() - 1)) {

--- a/modules/websocket/lws_peer.cpp
+++ b/modules/websocket/lws_peer.cpp
@@ -102,7 +102,7 @@ Error LWSPeer::write_wsi() {
 		return OK;
 
 	int read = 0;
-	uint8_t is_string;
+	uint8_t is_string = 0;
 	PoolVector<uint8_t>::Write rw = _packet_buffer.write();
 	_out_buffer.read_packet(&(rw[LWS_PRE]), _packet_buffer.size() - LWS_PRE, &is_string, read);
 


### PR DESCRIPTION
I've tested both ```target=release``` and ```target=debug``` and it fixes following warnings:

```
main/main.cpp:397:7: warning: variable 'found_project' set but not used [-Wunused-but-set-variable]
  bool found_project = false;
       ^~~~~~~~~~~~~
main/main.cpp: In static member function 'static bool Main::start()':
main/main.cpp:1276:7: warning: variable 'doc_base' set but not used [-Wunused-but-set-variable]
modules/websocket/lws_peer.cpp:109:43: warning: 'is_string' may be used uninitialized in this function [-Wmaybe-uninitialized]
  enum lws_write_protocol mode = is_string ? LWS_WRITE_TEXT : LWS_WRITE_BINARY;
                                 ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/object.cpp: In member function 'virtual void Object::call_multilevel(const StringName&, const Variant**, int)':
core/object.cpp:780:36: warning: second operand of conditional expression has no effect [-Wunused-value]
   _test_call_error(p_method, error);
                                    ^
core/object.cpp:780:36: warning: third operand of conditional expression has no effect [-Wunused-value]
core/object.cpp: In member function 'virtual void Object::call_multilevel_reversed(const StringName&, const Variant**, int)':
core/object.cpp:794:36: warning: second operand of conditional expression has no effect [-Wunused-value]
   _test_call_error(p_method, error);
                                    ^
core/object.cpp:794:36: warning: third operand of conditional expression has no effect [-Wunused-value]
```