### PR TITLE
C#: Throw ObjectDisposedException from disposed wrapper classes

### DIFF
--- a/modules/mono/glue/Managed/Files/Array.cs
+++ b/modules/mono/glue/Managed/Files/Array.cs
@@ -50,6 +50,9 @@ namespace Godot.Collections
 
         internal IntPtr GetPtr()
         {
+            if (disposed)
+                throw new ObjectDisposedException(GetType().FullName);
+
             return safeHandle.DangerousGetHandle();
         }
 

--- a/modules/mono/glue/Managed/Files/Dictionary.cs
+++ b/modules/mono/glue/Managed/Files/Dictionary.cs
@@ -54,6 +54,9 @@ namespace Godot.Collections
 
         internal IntPtr GetPtr()
         {
+            if (disposed)
+                throw new ObjectDisposedException(GetType().FullName);
+
             return safeHandle.DangerousGetHandle();
         }
 

--- a/modules/mono/glue/Managed/Files/NodePath.cs
+++ b/modules/mono/glue/Managed/Files/NodePath.cs
@@ -11,7 +11,13 @@ namespace Godot
 
         internal static IntPtr GetPtr(NodePath instance)
         {
-            return instance == null ? IntPtr.Zero : instance.ptr;
+            if (instance == null)
+                return IntPtr.Zero;
+
+            if (instance.disposed)
+                throw new ObjectDisposedException(instance.GetType().FullName);
+
+            return instance.ptr;
         }
 
         ~NodePath()
@@ -49,7 +55,7 @@ namespace Godot
             get { return ptr; }
         }
 
-        public NodePath() : this(string.Empty) {}
+        public NodePath() : this(string.Empty) { }
 
         public NodePath(string path)
         {

--- a/modules/mono/glue/Managed/Files/Object.base.cs
+++ b/modules/mono/glue/Managed/Files/Object.base.cs
@@ -30,7 +30,13 @@ namespace Godot
 
         internal static IntPtr GetPtr(Object instance)
         {
-            return instance == null ? IntPtr.Zero : instance.ptr;
+            if (instance == null)
+                return IntPtr.Zero;
+
+            if (instance.disposed)
+                throw new ObjectDisposedException(instance.GetType().FullName);
+
+            return instance.ptr;
         }
 
         ~Object()

--- a/modules/mono/glue/Managed/Files/RID.cs
+++ b/modules/mono/glue/Managed/Files/RID.cs
@@ -11,7 +11,13 @@ namespace Godot
 
         internal static IntPtr GetPtr(RID instance)
         {
-            return instance == null ? IntPtr.Zero : instance.ptr;
+            if (instance == null)
+                return IntPtr.Zero;
+
+            if (instance.disposed)
+                throw new ObjectDisposedException(instance.GetType().FullName);
+
+            return instance.ptr;
         }
 
         ~RID()


### PR DESCRIPTION
An exception is better than an error being printed from C++.
