### PR TITLE
Add some documentation for methods that return Copy-on-Write arrays.

### DIFF
--- a/doc/classes/CollisionPolygon.xml
+++ b/doc/classes/CollisionPolygon.xml
@@ -20,7 +20,7 @@
 			If true, no collision will be produced.
 		</member>
 		<member name="polygon" type="PoolVector2Array" setter="set_polygon" getter="get_polygon">
-			Array of vertices which define the polygon.
+			Array of vertices which define the polygon. Note that the returned value is a copy of the original. Methods which mutate the size or properties of the return value will not impact the original polygon. To change properties of the polygon, assign it to a temporary variable and make changes before reassigning the [code]polygon[/code] member.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/CollisionPolygon2D.xml
+++ b/doc/classes/CollisionPolygon2D.xml
@@ -25,7 +25,7 @@
 		<member name="one_way_collision_margin" type="float" setter="set_one_way_collision_margin" getter="get_one_way_collision_margin">
 		</member>
 		<member name="polygon" type="PoolVector2Array" setter="set_polygon" getter="get_polygon">
-			The polygon's list of vertices. The final point will be connected to the first.
+			The polygon's list of vertices. The final point will be connected to the first. The returned value is a clone of the PoolVector2Array, not a reference.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/OccluderPolygon2D.xml
+++ b/doc/classes/OccluderPolygon2D.xml
@@ -20,7 +20,7 @@
 			Set the direction of the occlusion culling when not [code]CULL_DISABLED[/code]. Default value [code]DISABLED[/code].
 		</member>
 		<member name="polygon" type="PoolVector2Array" setter="set_polygon" getter="get_polygon">
-			A [Vector2] array with the index for polygon's vertices positions.
+			A [Vector2] array with the index for polygon's vertices positions. Note that the returned value is a copy of the underlying array, rather than a reference.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Polygon2D.xml
+++ b/doc/classes/Polygon2D.xml
@@ -99,7 +99,7 @@
 			The offset applied to each vertex.
 		</member>
 		<member name="polygon" type="PoolVector2Array" setter="set_polygon" getter="get_polygon">
-			The polygon's list of vertices. The final point will be connected to the first.
+			The polygon's list of vertices. The final point will be connected to the first. Note that this returns a copy of the [PoolVector2Array] rather than a reference.
 		</member>
 		<member name="polygons" type="Array" setter="set_polygons" getter="get_polygons">
 		</member>


### PR DESCRIPTION
"Fixes" #18573.  Realistically, adds some warnings about potential foot-guns.  Some classes have a .polygon attribute which actually returns a new array, not a reference to the old one.  This may lead some inexperienced developers to attempt things that appear reasonable, like `obj.polygon.resize(10)`, but do not actually change the underlying polygon.