### PR TITLE
Generate mip-maps in GLES2 with glGenerateMipmap

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1221,6 +1221,9 @@ void RasterizerCanvasGLES2::_copy_screen(const Rect2 &p_rect) {
 
 	glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo); //back to front
 	glEnable(GL_BLEND);
+
+	glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->copy_screen_effect.color);
+	glGenerateMipmap(GL_TEXTURE_2D);
 }
 
 void RasterizerCanvasGLES2::_copy_texscreen(const Rect2 &p_rect) {

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4271,8 +4271,8 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 		glBindTexture(GL_TEXTURE_2D, rt->copy_screen_effect.color);
 
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 


### PR DESCRIPTION
After an unsuccessful day trying to port the GLES3 custom mip-mapping over to GLES2 I opted for the simpler solution, just use the OpenGL built-in ``glGenerateMipmap`` to generate Mip-maps. 

Pros: 
- Simpler code
- Faster

Cons:
- Uses a linear blur instead of gaussian 

I think it is a good idea for GLES2 anyway as the expectation for GLES2 is to have lower quality rendering at the price of much faster render times. 