### PR TITLE
webm/theora/yuv2rgb/libsimplewebm: Fix colour issues I could find.

### DIFF
--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -94,15 +94,15 @@ void VideoStreamPlaybackTheora::video_write(void) {
 
 		if (px_fmt == TH_PF_444) {
 
-			yuv444_2_rgb8888((uint8_t *)dst, (uint8_t *)yuv[0].data, (uint8_t *)yuv[1].data, (uint8_t *)yuv[2].data, size.x, size.y, yuv[0].stride, yuv[1].stride, size.x << 2, 0);
+			yuv444_2_rgb8888((uint8_t *)dst, (uint8_t *)yuv[0].data, (uint8_t *)yuv[1].data, (uint8_t *)yuv[2].data, size.x, size.y, yuv[0].stride, yuv[1].stride, size.x << 2);
 
 		} else if (px_fmt == TH_PF_422) {
 
-			yuv422_2_rgb8888((uint8_t *)dst, (uint8_t *)yuv[0].data, (uint8_t *)yuv[1].data, (uint8_t *)yuv[2].data, size.x, size.y, yuv[0].stride, yuv[1].stride, size.x << 2, 0);
+			yuv422_2_rgb8888((uint8_t *)dst, (uint8_t *)yuv[0].data, (uint8_t *)yuv[1].data, (uint8_t *)yuv[2].data, size.x, size.y, yuv[0].stride, yuv[1].stride, size.x << 2);
 
 		} else if (px_fmt == TH_PF_420) {
 
-			yuv420_2_rgb8888((uint8_t *)dst, (uint8_t *)yuv[0].data, (uint8_t *)yuv[2].data, (uint8_t *)yuv[1].data, size.x, size.y, yuv[0].stride, yuv[1].stride, size.x << 2, 0);
+			yuv420_2_rgb8888((uint8_t *)dst, (uint8_t *)yuv[0].data, (uint8_t *)yuv[1].data, (uint8_t *)yuv[2].data, size.x, size.y, yuv[0].stride, yuv[1].stride, size.x << 2);
 		};
 
 		format = Image::FORMAT_RGBA8;

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -178,17 +178,20 @@ Files extracted from upstream source:
 ## libsimplewebm
 
 - Upstream: https://github.com/zaps166/libsimplewebm
-- Version: git (05cfdc2, 2016)
-- License: MIT, BSD-3-Clause
+- Version: git (fe57fd3, 2019)
+- License: MIT (main), BSD-3-Clause (libwebm)
+
+This contains libwebm, but the version in use is updated from the one used by libsimplewebm,
+and may have *unmarked* alterations from that.
 
 Files extracted from upstream source:
 
-TODO.
+- all the .cpp, .hpp files in the main folder except `example.cpp`
+- LICENSE
 
 Important: Some files have Godot-made changes.
 They are marked with `// -- GODOT start --` and `// -- GODOT end --`
 comments.
-
 
 ## libtheora
 

--- a/thirdparty/libsimplewebm/OpusVorbisDecoder.cpp
+++ b/thirdparty/libsimplewebm/OpusVorbisDecoder.cpp
@@ -122,6 +122,7 @@ bool OpusVorbisDecoder::getPCMS16(WebMFrame &frame, short *buffer, int &numOutSa
 	return false;
 }
 
+// -- GODOT begin --
 bool OpusVorbisDecoder::getPCMF(WebMFrame &frame, float *buffer, int &numOutSamples) {
 	if (m_vorbis) {
 		m_vorbis->op.packet = frame.buffer;
@@ -158,6 +159,7 @@ bool OpusVorbisDecoder::getPCMF(WebMFrame &frame, float *buffer, int &numOutSamp
 	}
 	return false;
 }
+// -- GODOT end --
 
 bool OpusVorbisDecoder::openVorbis(const WebMDemuxer &demuxer)
 {

--- a/thirdparty/libsimplewebm/OpusVorbisDecoder.hpp
+++ b/thirdparty/libsimplewebm/OpusVorbisDecoder.hpp
@@ -44,8 +44,10 @@ public:
 	{
 		return m_numSamples;
 	}
-	bool getPCMF(WebMFrame &frame, float *buffer, int &numOutSamples);
 	bool getPCMS16(WebMFrame &frame, short *buffer, int &numOutSamples);
+// -- GODOT begin --
+	bool getPCMF(WebMFrame &frame, float *buffer, int &numOutSamples);
+// -- GODOT end --
 
 private:
 	bool openVorbis(const WebMDemuxer &demuxer);

--- a/thirdparty/libsimplewebm/VPXDecoder.hpp
+++ b/thirdparty/libsimplewebm/VPXDecoder.hpp
@@ -37,12 +37,17 @@ public:
 	class Image
 	{
 	public:
+// -- GODOT begin --
 #if 0
+// -- GODOT end --
 		int getWidth(int plane) const;
 		int getHeight(int plane) const;
+// -- GODOT begin --
 #endif
+// -- GODOT end --
 
 		int w, h;
+		int cs;
 		int chromaShiftW, chromaShiftH;
 		unsigned char *planes[3];
 		int linesize[3];
@@ -75,6 +80,7 @@ private:
 	vpx_codec_ctx *m_ctx;
 	const void *m_iter;
 	int m_delay;
+	int m_last_space;
 };
 
 #endif // VPXDECODER_HPP


### PR DESCRIPTION
Modifies yuv2rgb to remove endian-dependency in one of the functions, correctly orders RGBA, and deduplicates the macros.

The Theora and WEBM video players, rather than using reordered UV inputs to fix the yuv2rgb issue (which produces some distortion), now use the correct YUV order, since yuv2rgb is outputting correctly.

Modifies libsimplewebm to output RGBA so it can support the full range of RGBA formats in future.
libsimplewebm is now dependent on yuv2rgb as a result.

NOTE: This is by no means a complete solution for all WEBM formats.
The library is still limited to planar formats.

The following test project contains the WEBM and Theora files I made for testing.
They display correctly in VLC, so I am assuming they are correct.
[VideoColourLab.zip](https://github.com/godotengine/godot/files/2879771/VideoColourLab.zip)

It'd be a good idea to test this on more WEBM files before continuing.

Additional note: The side effects shown when U/V gets swapped suggests issue 18208 *may* be caused by this, but don't rely on it.

Here's the screenshots from v3.1-beta4, Arch Linux x86\_64:
![image](https://user-images.githubusercontent.com/22304167/53013160-f7b49580-343c-11e9-8304-3a473d58014a.png)
![image](https://user-images.githubusercontent.com/22304167/53013207-1581fa80-343d-11e9-988e-e058f75bbdd9.png)
(To my knowledge, master looks the same. This PR shows them all correctly, but of course that's my own test-cases, so please do test with more WEBMs.)
