### PR TITLE
Back scroll bar to start when changing folder

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -369,6 +369,7 @@ void ItemList::clear() {
 	update();
 	shape_changed = true;
 	defer_select_single = -1;
+	scroll_bar->set_value(0);
 }
 
 void ItemList::set_fixed_column_width(int p_size) {


### PR DESCRIPTION
Now when changing directory, scroll bar back to start.

Fix #26041