### PR TITLE
Fix res:// error when dragging file from outside of editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4419,7 +4419,7 @@ void EditorNode::remove_tool_menu_item(const String &p_name) {
 
 void EditorNode::_dropped_files(const Vector<String> &p_files, int p_screen) {
 
-	String to_path = ProjectSettings::get_singleton()->globalize_path(get_filesystem_dock()->get_current_path());
+	String to_path = ProjectSettings::get_singleton()->globalize_path(get_filesystem_dock()->get_selected_path());
 	DirAccessRef dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 
 	Vector<String> just_copy = String("ttf,otf").split(",");


### PR DESCRIPTION
If file in file system dock is selected, then dragging file outside editor try to copy it to unknown folder `res://selected_file.txt `(it is really a file path)

This PR extract directory from selected file so instead trying to create file
`res://selected_file.txt/new_file.txt`, create `res://new_file.txt`

Fix #25625