### PR TITLE
C#: Make GD.Range return IEnumerable instead of array

### DIFF
--- a/modules/mono/glue/Managed/Files/GD.cs
+++ b/modules/mono/glue/Managed/Files/GD.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
@@ -125,7 +126,7 @@ namespace Godot
             godot_icall_GD_randomize();
         }
 
-        public static double rand_range(double from, double to)
+        public static double RandRange(double from, double to)
         {
             return godot_icall_GD_rand_range(from, to);
         }
@@ -135,68 +136,34 @@ namespace Godot
             return godot_icall_GD_rand_seed(seed, out newSeed);
         }
 
-        public static int[] Range(int length)
+        public static IEnumerable<int> Range(int end)
         {
-            var ret = new int[length];
-
-            for (int i = 0; i < length; i++)
-            {
-                ret[i] = i;
-            }
-
-            return ret;
+            return Range(0, end, 1);
         }
 
-        public static int[] Range(int from, int to)
+        public static IEnumerable<int> Range(int start, int end)
         {
-            if (to < from)
-                return new int[0];
-
-            var ret = new int[to - from];
-
-            for (int i = from; i < to; i++)
-            {
-                ret[i - from] = i;
-            }
-
-            return ret;
+            return Range(start, end, 1);
         }
 
-        public static int[] Range(int from, int to, int increment)
+        public static IEnumerable<int> Range(int start, int end, int step)
         {
-            if (to < from && increment > 0)
-                return new int[0];
-            if (to > from && increment < 0)
-                return new int[0];
+            if (end < start && step > 0)
+                yield break;
 
-            // Calculate count
-            int count;
+            if (end > start && step < 0)
+                yield break;
 
-            if (increment > 0)
-                count = (to - from - 1) / increment + 1;
-            else
-                count = (from - to - 1) / -increment + 1;
-
-            var ret = new int[count];
-
-            if (increment > 0)
+            if (step > 0)
             {
-                int idx = 0;
-                for (int i = from; i < to; i += increment)
-                {
-                    ret[idx++] = i;
-                }
+                for (int i = start; i < end; i += step)
+                    yield return i;
             }
             else
             {
-                int idx = 0;
-                for (int i = from; i > to; i += increment)
-                {
-                    ret[idx++] = i;
-                }
+                for (int i = start; i > end; i += step)
+                    yield return i;
             }
-
-            return ret;
         }
 
         public static void Seed(ulong seed)

--- a/modules/mono/glue/Managed/Files/NodePath.cs
+++ b/modules/mono/glue/Managed/Files/NodePath.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Godot
 {
-    public partial class NodePath : IDisposable
+    public sealed partial class NodePath : IDisposable
     {
         private bool disposed = false;
 
@@ -31,7 +31,7 @@ namespace Godot
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (disposed)
                 return;

--- a/modules/mono/glue/Managed/Files/RID.cs
+++ b/modules/mono/glue/Managed/Files/RID.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Godot
 {
-    public partial class RID : IDisposable
+    public sealed partial class RID : IDisposable
     {
         private bool disposed = false;
 
@@ -31,7 +31,7 @@ namespace Godot
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (disposed)
                 return;

--- a/modules/mono/glue/Managed/Files/Transform2D.cs
+++ b/modules/mono/glue/Managed/Files/Transform2D.cs
@@ -88,7 +88,6 @@ namespace Godot
             }
         }
 
-
         public real_t this[int index, int axis]
         {
             get


### PR DESCRIPTION
- Make GD.Range return IEnumerable instead of array
- Make NodePath and RID sealed classes.
- Renamed rand_range to RandRange.
