### PR TITLE
Fix AnimationPlayer jumping to the beggining after ending on editor.

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -938,7 +938,6 @@ void AnimationPlayer::_animation_process(float p_delta) {
 			} else {
 				//stop();
 				playing = false;
-				playback.current.pos = 0;
 				_set_process(false);
 				if (end_notify)
 					emit_signal(SceneStringNames::get_singleton()->animation_finished, playback.assigned);
@@ -1196,9 +1195,14 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 
 	if (c.assigned != name) { // reset
 		c.current.pos = p_from_end ? c.current.from->animation->get_length() : 0;
-	} else if (p_from_end && c.current.pos == 0) {
-		// Animation reset BUT played backwards, set position to the end
-		c.current.pos = c.current.from->animation->get_length();
+	} else {
+		if (p_from_end && c.current.pos == 0) {
+			// Animation reset BUT played backwards, set position to the end
+			c.current.pos = c.current.from->animation->get_length();
+		} else if (!p_from_end && c.current.pos == c.current.from->animation->get_length()) {
+			// Animation resumed but already ended, set position to the beggining
+			c.current.pos = 0;
+		}
 	}
 
 	c.current.speed_scale = p_custom_scale;


### PR DESCRIPTION
As pointed by @TypeOverride https://github.com/godotengine/godot/pull/25886#commitcomment-32365629 and @mrcdk https://github.com/godotengine/godot/pull/25886#issuecomment-465159646 my PR #25886 introduced a bug where the AnimationPlayer would jump to the beginning of the animation, even on the editor.

This PR fixes this and maintain the intended behaviour from #25776. Now the animation resets its position to 0 only after resuming or starting a new animation, i.e., calling `play()`.

*Bugsquad edit:* Fixes #26083.
