### PR TITLE
Align the Variant data member

### DIFF
--- a/core/variant.h
+++ b/core/variant.h
@@ -69,6 +69,13 @@ typedef PoolVector<Vector2> PoolVector2Array;
 typedef PoolVector<Vector3> PoolVector3Array;
 typedef PoolVector<Color> PoolColorArray;
 
+// Temporary workaround until c++11 alignas()
+#ifdef __GNUC__
+#define GCC_ALIGNED_8 __attribute__((aligned(8)))
+#else
+#define GCC_ALIGNED_8
+#endif
+
 class Variant {
 public:
 	// If this changes the table in variant_op must be updated
@@ -132,7 +139,6 @@ private:
 	_FORCE_INLINE_ const ObjData &_get_obj() const;
 
 	union {
-
 		bool _bool;
 		int64_t _int;
 		double _real;
@@ -142,7 +148,7 @@ private:
 		Transform *_transform;
 		void *_ptr; //generic pointer
 		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)];
-	} _data;
+	} _data GCC_ALIGNED_8;
 
 	void reference(const Variant &p_variant);
 	void clear();


### PR DESCRIPTION
This should avoid potential alignment issues when _mem holds real
values and speed up some floating point operations in some cases.