### PR TITLE
Allow moving LineEdit visible window left by more than one symbol.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1154,9 +1154,7 @@ void LineEdit::set_cursor_position(int p_pos) {
 
 	if (cursor_pos <= window_pos) {
 		/* Adjust window if cursor goes too much to the left */
-		if (window_pos > 0)
-			set_window_pos(window_pos - 1);
-
+		set_window_pos(MAX(0, cursor_pos - 1));
 	} else if (cursor_pos > window_pos) {
 		/* Adjust window if cursor goes too much to the right */
 		int window_width = get_size().width - style->get_minimum_size().width;


### PR DESCRIPTION
Fixes #17469.

Looks like the problem was introduced while fixing #11948, my fix doesn't break it.