### PR TITLE
HTTPClient fixes for EOF read, chunked transfer encoding

### DIFF
--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -172,6 +172,7 @@ private:
 	bool chunked;
 	Vector<uint8_t> chunk;
 	int chunk_left;
+	bool chunk_trailer_part;
 	int body_size;
 	int body_left;
 	bool read_until_eof;


### PR DESCRIPTION
Fix HTTPClient `Connection: close` mode (was disconnecting when the server held back responding like when using event stream). Closes #25985 .

Fix HTTPClient keep alive with chunked encoding.

We need to consume the trailer part and final CRLF after last chunk as per [RFC 7230 section 4.1](https://tools.ietf.org/html/rfc7230#section-4.1):

```
chunked-body   = *chunk
                 last-chunk
                 trailer-part
                 CRLF
```

We do not return the trailer part, just consume it allowing following requests to work as expected when using keep alive.