### PR TITLE
ProjectSettings: fix category for per pixel transparency settings

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -319,9 +319,6 @@
 		<member name="display/mouse_cursor/custom_image_hotspot" type="Vector2" setter="" getter="">
 			Hotspot for the custom mouse cursor image.
 		</member>
-		<member name="display/window/allow_per_pixel_transparency" type="bool" setter="" getter="">
-			Allow per pixel transparency in a Desktop window. This affects performance if not needed, so leave it off.
-		</member>
 		<member name="display/window/dpi/allow_hidpi" type="bool" setter="" getter="">
 			Allow HiDPI display on Windows and OSX. On Desktop Linux, this can't be enabled or disabled.
 		</member>
@@ -331,9 +328,12 @@
 		<member name="display/window/handheld/orientation" type="String" setter="" getter="">
 			Default orientation for cell phone or tablet.
 		</member>
-		<member name="display/window/per_pixel_transparency" type="bool" setter="" getter="">
+		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="">
+			Allow per pixel transparency in a Desktop window. This affects performance if not needed, so leave it off.
 		</member>
-		<member name="display/window/per_pixel_transparency_splash" type="bool" setter="" getter="">
+		<member name="display/window/per_pixel_transparency/enabled" type="bool" setter="" getter="">
+		</member>
+		<member name="display/window/per_pixel_transparency/splash" type="bool" setter="" getter="">
 		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="">
 			Force the window to be always on top.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -926,13 +926,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", false);
 	}
 
-	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/allow_per_pixel_transparency", false);
-
 	video_mode.use_vsync = GLOBAL_DEF("display/window/vsync/use_vsync", true);
 	OS::get_singleton()->_use_vsync = video_mode.use_vsync;
 
-	video_mode.layered = GLOBAL_DEF("display/window/per_pixel_transparency", false);
-	video_mode.layered_splash = GLOBAL_DEF("display/window/per_pixel_transparency_splash", false);
+	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);
+	video_mode.layered = GLOBAL_DEF("display/window/per_pixel_transparency/enabled", false);
+	video_mode.layered_splash = GLOBAL_DEF("display/window/per_pixel_transparency/splash", false);
 
 	GLOBAL_DEF("rendering/quality/intended_usage/framebuffer_allocation", 2);
 	GLOBAL_DEF("rendering/quality/intended_usage/framebuffer_allocation.mobile", 3);


### PR DESCRIPTION
CC @bruvzg if you have better name suggestions. All settings in `display/window` have a subsection, so those looked weird at the top without a subsection.

Poke @lekoder, if you're still using those you'll have to update your project settings once this is merged.