### PR TITLE
Fix RayShape collision jitter when used with a RigidBody

### DIFF
--- a/modules/bullet/godot_ray_world_algorithm.cpp
+++ b/modules/bullet/godot_ray_world_algorithm.cpp
@@ -100,8 +100,8 @@ void GodotRayWorldAlgorithm::processCollision(const btCollisionObjectWrapper *bo
 
 		btScalar depth(ray_shape->getScaledLength() * (btResult.m_closestHitFraction - 1));
 
-		if (depth >= -ray_shape->getMargin())
-			depth *= 0.5;
+		if (depth >= -ray_shape->getMargin() * 0.5)
+			depth = 0;
 
 		if (ray_shape->getSlipsOnSlope())
 			resultOut->addContactPoint(btResult.m_hitNormalWorld, btResult.m_hitPointWorld, depth);


### PR DESCRIPTION
Scaling the depth was the wrong solution for the KinematicBody jitter
because it causes jitter with RigidBody. Instead scale the margin that
is ignored to allow KinematicBody to still pick up the ray shape in the
kinematic test when the shape is just at margin distance from another
one. This solution does not cause jitter with either KinematicBody or
RigidBody.