### PR TITLE
Add check to validate client IDs in ENet.

### DIFF
--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -231,6 +231,13 @@ void NetworkedMultiplayerENet::poll() {
 					break;
 				}
 
+				// A client joined with an invalid ID (neagtive values, 0, and 1 are reserved).
+				// Probably trying to exploit us.
+				if (server && ((int)event.data < 2 || peer_map.has((int)event.data))) {
+					enet_peer_reset(event.peer);
+					ERR_CONTINUE(true);
+				}
+
 				int *new_id = memnew(int);
 				*new_id = event.data;
 


### PR DESCRIPTION
Server now checks that the ID received from the client is not already
used by someone else and is a valid ID (>=2).

Closes #25752 .