### PR TITLE
Fix: Wrong unreachable warning after returning from match's wildcard pattern #25955

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2211,6 +2211,8 @@ GDScriptParser::PatternNode *GDScriptParser::_parse_pattern(bool p_static) {
 void GDScriptParser::_parse_pattern_block(BlockNode *p_block, Vector<PatternBranchNode *> &p_branches, bool p_static) {
 	int indent_level = tab_level.back()->get();
 
+	p_block->has_return = true;
+
 	while (true) {
 
 		while (tokenizer->get_token() == GDScriptTokenizer::TK_NEWLINE && _parse_newline())
@@ -2268,8 +2270,8 @@ void GDScriptParser::_parse_pattern_block(BlockNode *p_block, Vector<PatternBran
 
 		current_block = p_block;
 
-		if (catch_all && branch->body->has_return) {
-			p_block->has_return = true;
+		if (!branch->body->has_return) {
+			p_block->has_return = false;
 		}
 
 		p_branches.push_back(branch);


### PR DESCRIPTION
Fixes  #25955

# Problem
The parser only checked if the catch-all branch has a return in order to determine if the entire match block has a return.

This code block was assumed to always return.

    match value:
        "test":
            print("test")
        _:
            return

This in turn means that every code following was regarded unreachable.

# Solution
Every match is assumed to have a return, unless we find one branch to not return.
