### PR TITLE
Fixed Area2d input events ignoring the top and left edge of rectangle shape

### DIFF
--- a/servers/physics_2d/shape_2d_sw.cpp
+++ b/servers/physics_2d/shape_2d_sw.cpp
@@ -369,8 +369,11 @@ void RectangleShape2DSW::get_supports(const Vector2 &p_normal, Vector2 *r_suppor
 }
 
 bool RectangleShape2DSW::contains_point(const Vector2 &p_point) const {
-
-	return Math::abs(p_point.x) < half_extents.x && Math::abs(p_point.y) < half_extents.y;
+	float x = p_point.x;
+	float y = p_point.y;
+	float edge_x = half_extents.x;
+	float edge_y = half_extents.y;
+	return (x >= -edge_x) && (x < edge_x) && (y >= -edge_y) && (y < edge_y);
 }
 
 bool RectangleShape2DSW::intersect_segment(const Vector2 &p_begin, const Vector2 &p_end, Vector2 &r_point, Vector2 &r_normal) const {


### PR DESCRIPTION
This changes allows rectangle shapes used in Area2D nodes to trigger input events on the first row and column of pixels.

`RectangleShape2DSW::contains_point` now uses the same logic as in `Rect2::has_point`, i.e the given point can be considered inside when it's exactly on the left or top edge. That makes this collision check consistent with the logic used for Control node rectangles.

Fixes #25462