### PR TITLE
TextureButton with click mask only can be clicked

### DIFF
--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -64,7 +64,9 @@ bool TextureButton::has_point(const Point2 &p_point) const {
 		Rect2 rect = Rect2();
 		Size2 mask_size = click_mask->get_size();
 
-		if (_tile) {
+		if (_position_rect.no_area()) {
+			rect.size = mask_size;
+		} else if (_tile) {
 			// if the stretch mode is tile we offset the point to keep it inside the mask size
 			rect.size = mask_size;
 			if (_position_rect.has_point(point)) {
@@ -216,6 +218,8 @@ void TextureButton::_notification(int p_what) {
 					draw_texture_rect(texdraw, _position_rect, _tile);
 				else
 					draw_texture_rect_region(texdraw, _position_rect, _texture_region);
+			} else {
+				_position_rect = Rect2();
 			}
 			if (has_focus() && focused.is_valid()) {
 


### PR DESCRIPTION
This change allows the click mask in TextureButton to work when no other texture is set on the button. It's still clickable in this case and its behavior is consistent with the way the click mask was working in 3.0 (before #15855).

Fixes #25265