### PR TITLE
Fix VariantWriter overflow on 64-bit int

### DIFF
--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1597,7 +1597,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 		} break;
 		case Variant::INT: {
 
-			p_store_string_func(p_store_string_ud, itos(p_variant.operator int()));
+			p_store_string_func(p_store_string_ud, itos(p_variant.operator int64_t()));
 		} break;
 		case Variant::REAL: {
 

--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -811,7 +811,7 @@
 			<description>
 				Random range, any floating point value between [code]from[/code] and [code]to[/code].
 				[codeblock]
-				prints(rand_range(0, 1), rand_range(0, 1)) # prints 0.135591 0.405263
+				prints(rand_range(0, 1), rand_range(0, 1)) # prints e.g. 0.135591 0.405263
 				[/codeblock]
 			</description>
 		</method>
@@ -830,7 +830,7 @@
 			<description>
 				Returns a random floating point value on the interval [code][0, 1][/code].
 				[codeblock]
-				randf() # returns 0.375671
+				randf() # returns e.g. 0.375671
 				[/codeblock]
 			</description>
 		</method>
@@ -838,11 +838,12 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns a random 32 bit integer. Use remainder to obtain a random value in the interval [code][0, N][/code] (where N is smaller than 2^32 -1).
+				Returns a random unsigned 32 bit integer. Use remainder to obtain a random value in the interval [code][0, N][/code] (where N is smaller than 2^32 -1).
 				[codeblock]
-				randi() % 20      # returns random number between 0 and 19
-				randi() % 100     # returns random number between 0 and 99
-				randi() % 100 + 1 # returns random number between 1 and 100
+				randi()           # returns random integer between 0 and 2^32 - 1
+				randi() % 20      # returns random integer between 0 and 19
+				randi() % 100     # returns random integer between 0 and 99
+				randi() % 100 + 1 # returns random integer between 1 and 100
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -4,7 +4,21 @@
 		Integer built-in type.
 	</brief_description>
 	<description>
-		Integer built-in type.
+		Signed 64-bit integer type.
+		It can take values in the interval [code][-2^63, 2^63 - 1][/code], i.e. [code][-9223372036854775808, 9223372036854775807][/code]. Exceeding those bounds will wrap around.
+		[code]int[/code] is a [Variant] type, and will thus be used when assigning an integer value to a [Variant]. It can also be enforced with the [code]: int[/code] type hint.
+		[codeblock]
+		var my_variant = 0    # int, value 0
+		my_variant += 4.2     # float, value 4.2
+		var my_int: int = 1   # int, value 1
+		my_int = 4.2          # int, value 4, the right value is implicitly cast to int
+		my_int = int("6.7")   # int, value 6, the String is explicitly cast with [method int]
+
+		var max_int = 9223372036854775807
+		print(max_int)        # 9223372036854775807, OK
+		max_int += 1
+		print(max_int)        # -9223372036854775808, we overflowed and wrapped around
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -483,16 +483,16 @@ EditorPropertyCheck::EditorPropertyCheck() {
 
 void EditorPropertyEnum::_option_selected(int p_which) {
 
-	int val = options->get_item_metadata(p_which);
+	int64_t val = options->get_item_metadata(p_which);
 	emit_changed(get_edited_property(), val);
 }
 
 void EditorPropertyEnum::update_property() {
 
-	int which = get_edited_object()->get(get_edited_property());
+	int64_t which = get_edited_object()->get(get_edited_property());
 
 	for (int i = 0; i < options->get_item_count(); i++) {
-		if (which == (int)options->get_item_metadata(i)) {
+		if (which == (int64_t)options->get_item_metadata(i)) {
 			options->select(i);
 			return;
 		}
@@ -501,11 +501,11 @@ void EditorPropertyEnum::update_property() {
 
 void EditorPropertyEnum::setup(const Vector<String> &p_options) {
 
-	int current_val = 0;
+	int64_t current_val = 0;
 	for (int i = 0; i < p_options.size(); i++) {
 		Vector<String> text_split = p_options[i].split(":");
 		if (text_split.size() != 1)
-			current_val = text_split[1].to_int();
+			current_val = text_split[1].to_int64();
 		options->add_item(text_split[0]);
 		options->set_item_metadata(i, current_val);
 		current_val += 1;
@@ -801,11 +801,11 @@ EditorPropertyLayers::EditorPropertyLayers() {
 void EditorPropertyInteger::_value_changed(double val) {
 	if (setting)
 		return;
-	emit_changed(get_edited_property(), int(val));
+	emit_changed(get_edited_property(), (int64_t)val);
 }
 
 void EditorPropertyInteger::update_property() {
-	int val = get_edited_object()->get(get_edited_property());
+	int64_t val = get_edited_object()->get(get_edited_property());
 	setting = true;
 	spin->set_value(val);
 	setting = false;


### PR DESCRIPTION
Integers in Godot are signed 64-bit ints (int64_t), but var2str used
int behind the scenes and would thus overflow after 2^31.

Also properly documented the actual bounds of int and the behaviour
when overflowing them.

----

Before this fix, this would overflow:
```
var foo = 2147483648   # 2^31, so out of bounds for 32-bit unsigned int [-2^31,-2^31-1]
print(foo)             # 2147483648
print(var2str(foo))    # -2147483648, wraps around
```

Now it works fine:
```
var foo = 2147483648   # 2^31, so out of bounds for 32-bit unsigned int [-2^31,-2^31-1]
print(foo)             # 2147483648
print(var2str(foo))    # 2147483648

var bar = 9223372036854775807     # 2^63-1, upper bound for signed 64-bit int
print(bar)                        # 9223372036854775807
print(var2str(bar))               # 9223372036854775807
print(str2var(var2str(bar)))      # 9223372036854775807
print(bar + 1)                    # -9223372036854775808, wraps around
print(var2str(bar + 1))           # -9223372036854775808, wraps around
print(str2var(var2str(bar + 1)))  # -9223372036854775808, wraps around
```

This was particularly problematic when serializing the output of `randi()`, which gives an **unsigned** 32-bit int, so [0, 2^32-1], which could thus overflow `VariantWriter`. (Thanks @Keetz for the report on IRC.)

*Edit:* Commit 5585420 fixes #26116 and fixes #22004.