### PR TITLE
Fix return value for Dictionary.erase(key) in script

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -480,7 +480,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0(Dictionary, clear);
 	VCALL_LOCALMEM1R(Dictionary, has);
 	VCALL_LOCALMEM1R(Dictionary, has_all);
-	VCALL_LOCALMEM1(Dictionary, erase);
+	VCALL_LOCALMEM1R(Dictionary, erase);
 	VCALL_LOCALMEM0R(Dictionary, hash);
 	VCALL_LOCALMEM0R(Dictionary, keys);
 	VCALL_LOCALMEM0R(Dictionary, values);


### PR DESCRIPTION
21d285e changed return type of erase(key) to bool, but an issue was causing it not returning anything in GDScript thus failing the following assertion. This change fixes the issue.

```
var removed = some_dict.erase(some_key)
assert(removed)
```
 
