### PR TITLE
Include global class resources in Resource property inspector

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2287,6 +2287,16 @@ void EditorPropertyResource::_update_menu_items() {
 				E = E->next();
 			}
 
+			List<StringName> global_classes;
+			ScriptServer::get_global_class_list(&global_classes);
+			E = global_classes.front();
+			while (E) {
+				if (EditorNode::get_editor_data().script_class_is_parent(E->get(), base_type)) {
+					valid_inheritors.insert(E->get());
+				}
+				E = E->next();
+			}
+
 			for (Set<String>::Element *F = valid_inheritors.front(); F; F = F->next()) {
 				String t = F->get();
 
@@ -2303,7 +2313,7 @@ void EditorPropertyResource::_update_menu_items() {
 					}
 				}
 
-				if (!is_custom_resource && !ClassDB::can_instance(t))
+				if (!is_custom_resource && !(ScriptServer::is_global_class(t) || ClassDB::can_instance(t)))
 					continue;
 
 				inheritors_array.push_back(t);


### PR DESCRIPTION
Much like how script defined global classes can be created from the
"New Resource..." button in the FileSystem panel, this allows the
creation of script defined resources to be embedded.