### PR TITLE
Revert back to ignoring LIGHT_VEC for 2D shadows

### DIFF
--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -440,6 +440,10 @@ FRAGMENT_SHADER_CODE
 		color *= light;
 
 #ifdef USE_SHADOWS
+		// Reset light_vec to compute shadows, the shadow map is created from the light origin, so it only
+		// makes sense to compute shadows from there.
+		light_vec = light_uv_interp.zw;
+
 		float angle_to_light = -atan(light_vec.x, light_vec.y);
 		float PI = 3.14159265358979323846264;
 		/*int i = int(mod(floor((angle_to_light+7.0*PI/6.0)/(4.0*PI/6.0))+1.0, 3.0)); // +1 pq os indices estao em ordem 2,0,1 nos arrays

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -549,6 +549,10 @@ FRAGMENT_SHADER_CODE
 		color *= light;
 
 #ifdef USE_SHADOWS
+		// Reset light_vec to compute shadows, the shadow map is created from the light origin, so it only
+		// makes sense to compute shadows from there.
+		light_vec = light_uv_interp.zw;
+
 		float angle_to_light = -atan(light_vec.x, light_vec.y);
 		float PI = 3.14159265358979323846264;
 		/*int i = int(mod(floor((angle_to_light+7.0*PI/6.0)/(4.0*PI/6.0))+1.0, 3.0)); // +1 pq os indices estao em ordem 2,0,1 nos arrays


### PR DESCRIPTION
As commented in the code itself, shadow mapping only works from one unique point (the point from which the shadow map was created) so taking into account `LIGHT_VEC` doesn't make much sense and breaks shadows on rotated lights.

2D shadow mapping will be reworked on 4.0

Fixes #25996.