### PR TITLE
added godot_dictionary_get_with_default to GDNative

### DIFF
--- a/modules/gdnative/gdnative/dictionary.cpp
+++ b/modules/gdnative/gdnative/dictionary.cpp
@@ -155,10 +155,24 @@ godot_string GDAPI godot_dictionary_to_json(const godot_dictionary *p_self) {
 	return raw_dest;
 }
 
+// GDNative core 1.1
+
 godot_bool GDAPI godot_dictionary_erase_with_return(godot_dictionary *p_self, const godot_variant *p_key) {
 	Dictionary *self = (Dictionary *)p_self;
 	const Variant *key = (const Variant *)p_key;
 	return self->erase(*key);
+}
+
+godot_variant GDAPI godot_dictionary_get_with_default(const godot_dictionary *p_self, const godot_variant *p_key, const godot_variant *p_default) {
+	const Dictionary *self = (const Dictionary *)p_self;
+	const Variant *key = (const Variant *)p_key;
+	const Variant *def = (const Variant *)p_default;
+
+	godot_variant raw_dest;
+	Variant *dest = (Variant *)&raw_dest;
+	memnew_placement(dest, Variant(self->get(*key, *def)));
+
+	return raw_dest;
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -107,6 +107,23 @@
           ]
         },
         {
+          "name": "godot_dictionary_get_with_default",
+          "return_type": "godot_variant",
+          "arguments": [
+            ["const godot_dictionary *", "p_self"],
+            ["const godot_variant *", "p_key"],
+            ["const godot_variant *", "p_default"]
+          ]
+        },
+        {
+          "name": "godot_dictionary_erase_with_return",
+          "return_type": "bool",
+          "arguments": [
+            ["godot_dictionary *", "p_self"],
+            ["const godot_variant *", "p_key"]
+          ]
+        },
+        {
           "name": "godot_node_path_get_as_property_path",
           "return_type": "godot_node_path",
           "arguments": [
@@ -231,14 +248,6 @@
             ["godot_basis *", "p_self"],
             ["const godot_quat *", "p_quat"],
             ["const godot_vector3 *", "p_scale"]
-          ]
-        },
-        {
-          "name": "godot_dictionary_erase_with_return",
-          "return_type": "bool",
-          "arguments": [
-            ["godot_dictionary *", "p_self"],
-            ["const godot_variant *", "p_key"]
           ]
         },
         {

--- a/modules/gdnative/include/gdnative/dictionary.h
+++ b/modules/gdnative/include/gdnative/dictionary.h
@@ -94,7 +94,11 @@ godot_bool GDAPI godot_dictionary_operator_equal(const godot_dictionary *p_self,
 
 godot_string GDAPI godot_dictionary_to_json(const godot_dictionary *p_self);
 
+// GDNative core 1.1
+
 godot_bool GDAPI godot_dictionary_erase_with_return(godot_dictionary *p_self, const godot_variant *p_key);
+
+godot_variant GDAPI godot_dictionary_get_with_default(const godot_dictionary *p_self, const godot_variant *p_key, const godot_variant *p_default);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Closes #24101

Recently, Dictionary::get() was introduced, which acts like a index
operator but allows the caller to specify a default value to return
instead of issuing an error.

This commit adds a new GDNative function that includes the default value.