### PR TITLE
Fix -Wsign-compare warnings.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -339,7 +339,6 @@ if selected_platform in platform_list:
         if (env["werror"]):
             env.Append(CCFLAGS=['/WX'])
     else: # Rest of the world
-        disable_nonessential_warnings = ['-Wno-sign-compare']
         shadow_local_warning = []
         all_plus_warnings = ['-Wwrite-strings']
 
@@ -350,9 +349,9 @@ if selected_platform in platform_list:
         if (env["warnings"] == 'extra'):
             env.Append(CCFLAGS=['-Wall', '-Wextra'] + all_plus_warnings + shadow_local_warning)
         elif (env["warnings"] == 'all'):
-            env.Append(CCFLAGS=['-Wall'] + all_plus_warnings + shadow_local_warning + disable_nonessential_warnings)
+            env.Append(CCFLAGS=['-Wall'] + shadow_local_warning)
         elif (env["warnings"] == 'moderate'):
-            env.Append(CCFLAGS=['-Wall', '-Wno-unused'] + shadow_local_warning + disable_nonessential_warnings)
+            env.Append(CCFLAGS=['-Wall', '-Wno-unused']  + shadow_local_warning)
         else: # 'no'
             env.Append(CCFLAGS=['-w'])
         if (env["werror"]):

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -224,7 +224,7 @@ Error PacketPeerStream::get_packet(const uint8_t **r_buffer, int &r_buffer_size)
 	uint32_t len = decode_uint32(lbuf);
 	ERR_FAIL_COND_V(remaining < (int)len, ERR_UNAVAILABLE);
 
-	ERR_FAIL_COND_V(input_buffer.size() < len, ERR_UNAVAILABLE);
+	ERR_FAIL_COND_V(input_buffer.size() < (int)len, ERR_UNAVAILABLE);
 	ring_buffer.read(lbuf, 4); //get rid of first 4 bytes
 	ring_buffer.read(input_buffer.ptrw(), len); // read packet
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -106,7 +106,7 @@ StringName ResourceInteractiveLoaderBinary::_get_string() {
 	uint32_t id = f->get_32();
 	if (id & 0x80000000) {
 		uint32_t len = id & 0x7FFFFFFF;
-		if (len > str_buf.size()) {
+		if ((int)len > str_buf.size()) {
 			str_buf.resize(len);
 		}
 		if (len == 0)

--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -509,7 +509,7 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 
 						texture = texture->get_ptr();
 
-						if (next_power_of_2(texture->alloc_width) != texture->alloc_width && next_power_of_2(texture->alloc_height) != texture->alloc_height) {
+						if (next_power_of_2(texture->alloc_width) != (unsigned int)texture->alloc_width && next_power_of_2(texture->alloc_height) != (unsigned int)texture->alloc_height) {
 							state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_FORCE_REPEAT, true);
 							can_tile = false;
 						}

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -158,7 +158,7 @@ void RasterizerSceneGLES2::shadow_atlas_set_quadrant_subdivision(RID p_atlas, in
 
 	subdiv = int(Math::sqrt((float)subdiv));
 
-	if (shadow_atlas->quadrants[p_quadrant].shadows.size() == subdiv)
+	if (shadow_atlas->quadrants[p_quadrant].shadows.size() == (int)subdiv)
 		return;
 
 	// erase all data from the quadrant

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -246,7 +246,7 @@ void FileAccessUnix::store_8(uint8_t p_dest) {
 
 void FileAccessUnix::store_buffer(const uint8_t *p_src, int p_length) {
 	ERR_FAIL_COND(!f);
-	ERR_FAIL_COND(fwrite(p_src, 1, p_length, f) != p_length);
+	ERR_FAIL_COND((int)fwrite(p_src, 1, p_length, f) != p_length);
 }
 
 bool FileAccessUnix::file_exists(const String &p_path) {

--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -76,7 +76,7 @@ int64_t GDAPI godot_videodecoder_file_seek(void *ptr, int64_t pos, int whence) {
 			} break;
 			case SEEK_CUR: {
 				// Just in case it doesn't exist
-				if (pos < 0 && -pos > file->get_position()) {
+				if (pos < 0 && (size_t)-pos > file->get_position()) {
 					return -1;
 				}
 				pos = pos + static_cast<int>(file->get_position());
@@ -86,7 +86,7 @@ int64_t GDAPI godot_videodecoder_file_seek(void *ptr, int64_t pos, int whence) {
 			} break;
 			case SEEK_END: {
 				// Just in case something goes wrong
-				if (-pos > len) {
+				if ((size_t)-pos > len) {
 					return -1;
 				}
 				file->seek_end(pos);

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1417,7 +1417,7 @@ StringName GDScriptTokenizerBuffer::get_token_identifier(int p_offset) const {
 
 	ERR_FAIL_INDEX_V(offset, tokens.size(), StringName());
 	uint32_t identifier = tokens[offset] >> TOKEN_BITS;
-	ERR_FAIL_UNSIGNED_INDEX_V(identifier, identifiers.size(), StringName());
+	ERR_FAIL_UNSIGNED_INDEX_V(identifier, (uint32_t)identifiers.size(), StringName());
 
 	return identifiers[identifier];
 }
@@ -1473,7 +1473,7 @@ const Variant &GDScriptTokenizerBuffer::get_token_constant(int p_offset) const {
 	int offset = token + p_offset;
 	ERR_FAIL_INDEX_V(offset, tokens.size(), nil);
 	uint32_t constant = tokens[offset] >> TOKEN_BITS;
-	ERR_FAIL_UNSIGNED_INDEX_V(constant, constants.size(), nil);
+	ERR_FAIL_UNSIGNED_INDEX_V(constant, (uint32_t)constants.size(), nil);
 	return constants[constant];
 }
 String GDScriptTokenizerBuffer::get_token_error(int p_offset) const {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -449,7 +449,7 @@ static String variant_type_to_managed_name(const String &p_var_type_name) {
 		Variant::_RID
 	};
 
-	for (int i = 0; i < sizeof(var_types) / sizeof(Variant::Type); i++) {
+	for (unsigned int i = 0; i < sizeof(var_types) / sizeof(Variant::Type); i++) {
 		if (p_var_type_name == Variant::get_type_name(var_types[i]))
 			return p_var_type_name;
 	}
@@ -2172,7 +2172,7 @@ bool CSharpScript::_get_member_export(GDMonoClass *p_class, IMonoClassMember *p_
 				return false;
 			}
 
-			if (val != i) {
+			if (val != (unsigned int)i) {
 				uses_default_values = false;
 			}
 

--- a/modules/mono/glue/collections_glue.cpp
+++ b/modules/mono/glue/collections_glue.cpp
@@ -86,7 +86,7 @@ bool godot_icall_Array_Contains(Array *ptr, MonoObject *item) {
 }
 
 void godot_icall_Array_CopyTo(Array *ptr, MonoArray *array, int array_index) {
-	int count = ptr->size();
+	unsigned int count = ptr->size();
 
 	if (mono_array_length(array) < (array_index + count)) {
 		MonoException *exc = mono_get_exception_argument("", "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
@@ -94,7 +94,7 @@ void godot_icall_Array_CopyTo(Array *ptr, MonoArray *array, int array_index) {
 		return;
 	}
 
-	for (int i = 0; i < count; i++) {
+	for (unsigned int i = 0; i < count; i++) {
 		MonoObject *boxed = GDMonoMarshal::variant_to_mono_object(ptr->operator[](i));
 		mono_array_setref(array, array_index, boxed);
 		array_index++;

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -91,7 +91,7 @@ static bool _wait_for_debugger_msecs(uint32_t p_msecs) {
 
 		OS::get_singleton()->delay_usec((p_msecs < 25 ? p_msecs : 25) * 1000);
 
-		int tdiff = OS::get_singleton()->get_ticks_msec() - last_tick;
+		uint32_t tdiff = OS::get_singleton()->get_ticks_msec() - last_tick;
 
 		if (tdiff > p_msecs) {
 			p_msecs = 0;
@@ -864,7 +864,7 @@ Error GDMono::reload_scripts_domain() {
 				metadata_set_api_assembly_invalidated(APIAssembly::API_EDITOR, true);
 			}
 
-			Error err = _unload_scripts_domain();
+			err = _unload_scripts_domain();
 			if (err != OK) {
 				WARN_PRINT("Mono: Failed to unload scripts domain");
 			}

--- a/modules/pvr/texture_loader_pvr.cpp
+++ b/modules/pvr/texture_loader_pvr.cpp
@@ -216,7 +216,7 @@ static void _compress_pvrtc4(Image *p_img) {
 			int ofs, size, w, h;
 			img->get_mipmap_offset_size_and_dimensions(i, ofs, size, w, h);
 			Javelin::RgbaBitmap bm(w, h);
-			for (unsigned j = 0; j < size / 4; j++) {
+			for (int j = 0; j < size / 4; j++) {
 				Javelin::ColorRgba<unsigned char> *dp = bm.GetData();
 				/* red and Green colors are swapped.  */
 				new (dp) Javelin::ColorRgba<unsigned char>(r[ofs + 4 * j + 2], r[ofs + 4 * j + 1], r[ofs + 4 * j], r[ofs + 4 * j + 3]);

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -421,7 +421,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 		}
 
 		Vector<String> desc = path[path.size() - 1].replace("(", "( ").replace(")", " )").replace(",", ", ").split(" ");
-		for (size_t i = 0; i < desc.size(); i++) {
+		for (int i = 0; i < desc.size(); i++) {
 			desc.write[i] = desc[i].capitalize();
 			if (desc[i].ends_with(",")) {
 				desc.write[i] = desc[i].replace(",", ", ");

--- a/modules/websocket/packet_buffer.h
+++ b/modules/websocket/packet_buffer.h
@@ -50,7 +50,7 @@ public:
 	Error write_packet(const uint8_t *p_payload, uint32_t p_size, const T *p_info) {
 #ifdef TOOLS_ENABLED
 		// Verbose buffer warnings
-		if (p_payload && _payload.space_left() < p_size) {
+		if (p_payload && _payload.space_left() < (int32_t)p_size) {
 			ERR_PRINT("Buffer payload full! Dropping data.");
 			ERR_FAIL_V(ERR_OUT_OF_MEMORY);
 		}
@@ -83,8 +83,8 @@ public:
 		ERR_FAIL_COND_V(_packets.data_left() < 1, ERR_UNAVAILABLE);
 		_Packet p;
 		_packets.read(&p, 1);
-		ERR_FAIL_COND_V(_payload.data_left() < p.size, ERR_BUG);
-		ERR_FAIL_COND_V(p_bytes < p.size, ERR_OUT_OF_MEMORY);
+		ERR_FAIL_COND_V(_payload.data_left() < (int)p.size, ERR_BUG);
+		ERR_FAIL_COND_V(p_bytes < (int)p.size, ERR_OUT_OF_MEMORY);
 
 		r_read = p.size;
 		copymem(r_info, &p.info, sizeof(T));

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -213,7 +213,7 @@ void WebSocketMultiplayerPeer::_send_add(int32_t p_peer_id) {
 	_send_sys(get_peer(p_peer_id), SYS_ADD, 1);
 
 	for (Map<int, Ref<WebSocketPeer> >::Element *E = _peer_map.front(); E; E = E->next()) {
-		uint32_t id = E->key();
+		int32_t id = E->key();
 		if (p_peer_id == id)
 			continue; // Skip the newwly added peer (already confirmed)
 
@@ -226,7 +226,7 @@ void WebSocketMultiplayerPeer::_send_add(int32_t p_peer_id) {
 
 void WebSocketMultiplayerPeer::_send_del(int32_t p_peer_id) {
 	for (Map<int, Ref<WebSocketPeer> >::Element *E = _peer_map.front(); E; E = E->next()) {
-		uint32_t id = E->key();
+		int32_t id = E->key();
 		if (p_peer_id != id)
 			_send_sys(get_peer(id), SYS_DEL, p_peer_id);
 	}
@@ -288,7 +288,7 @@ void WebSocketMultiplayerPeer::_process_multiplayer(Ref<WebSocketPeer> p_peer, u
 	data_size = size - PROTO_SIZE;
 
 	uint8_t type = 0;
-	int32_t from = 0;
+	uint32_t from = 0;
 	int32_t to = 0;
 	copymem(&type, in_buffer, 1);
 	copymem(&from, &in_buffer[1], 4);

--- a/modules/xatlas_unwrap/register_types.cpp
+++ b/modules/xatlas_unwrap/register_types.cpp
@@ -108,7 +108,7 @@ bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_ver
 
 	float max_x = 0;
 	float max_y = 0;
-	for (int i = 0; i < output->vertexCount; i++) {
+	for (uint32_t i = 0; i < output->vertexCount; i++) {
 		(*r_vertex)[i] = output->vertexArray[i].xref;
 		(*r_uv)[i * 2 + 0] = output->vertexArray[i].uv[0] / w;
 		(*r_uv)[i * 2 + 1] = output->vertexArray[i].uv[1] / h;
@@ -119,7 +119,7 @@ bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_ver
 	printf("final texsize: %f,%f - max %f,%f\n", w, h, max_x, max_y);
 	*r_vertex_count = output->vertexCount;
 
-	for (int i = 0; i < output->indexCount; i++) {
+	for (uint32_t i = 0; i < output->indexCount; i++) {
 		(*r_index)[i] = output->indexArray[i];
 	}
 

--- a/platform/x11/detect_prime.cpp
+++ b/platform/x11/detect_prime.cpp
@@ -180,8 +180,8 @@ int detect_prime() {
 			const char *vendor = (const char *)glGetString(GL_VENDOR);
 			const char *renderer = (const char *)glGetString(GL_RENDERER);
 
-			int vendor_len = strlen(vendor) + 1;
-			int renderer_len = strlen(renderer) + 1;
+			unsigned int vendor_len = strlen(vendor) + 1;
+			unsigned int renderer_len = strlen(renderer) + 1;
 
 			if (vendor_len + renderer_len >= sizeof(string)) {
 				renderer_len = 200 - vendor_len;

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -887,7 +887,7 @@ void VoxelLightBaker::plot_light_directional(const Vector3 &p_direction, const C
 			distance -= distance_adv;
 		}
 
-		if (result == idx) {
+		if (result == (uint32_t)idx) {
 			//cell hit itself! hooray!
 
 			Vector3 normal(cells[idx].normal[0], cells[idx].normal[1], cells[idx].normal[2]);
@@ -1018,7 +1018,7 @@ void VoxelLightBaker::plot_light_omni(const Vector3 &p_pos, const Color &p_color
 			distance -= distance_adv;
 		}
 
-		if (result == idx) {
+		if (result == (uint32_t)idx) {
 			//cell hit itself! hooray!
 
 			if (normal == Vector3()) {
@@ -1152,7 +1152,7 @@ void VoxelLightBaker::plot_light_spot(const Vector3 &p_pos, const Vector3 &p_axi
 			distance -= distance_adv;
 		}
 
-		if (result == idx) {
+		if (result == (uint32_t)idx) {
 			//cell hit itself! hooray!
 
 			if (normal == Vector3()) {
@@ -2252,7 +2252,7 @@ void VoxelLightBaker::_debug_mesh(int p_idx, int p_level, const AABB &p_aabb, Re
 
 			uint32_t child = bake_cells[p_idx].children[i];
 
-			if (child == CHILD_EMPTY || child >= max_original_cells)
+			if (child == CHILD_EMPTY || child >= (uint32_t)max_original_cells)
 				continue;
 
 			AABB aabb = p_aabb;

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -332,7 +332,7 @@ Vector<Vector2> BitMap::_march_square(const Rect2i &rect, const Point2i &start) 
 		prevx = stepx;
 		prevy = stepy;
 
-		ERR_FAIL_COND_V(count > width * height, _points);
+		ERR_FAIL_COND_V((int)count > width * height, _points);
 	} while (curx != startx || cury != starty);
 	return _points;
 }

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -138,7 +138,7 @@ void AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fr
 	Vector<int32_t> buf = AudioDriver::get_singleton()->get_input_buffer();
 	unsigned int input_size = AudioDriver::get_singleton()->get_input_size();
 	int mix_rate = AudioDriver::get_singleton()->get_mix_rate();
-	int playback_delay = MIN(((50 * mix_rate) / 1000) * 2, buf.size() >> 1);
+	unsigned int playback_delay = MIN(((50 * mix_rate) / 1000) * 2, buf.size() >> 1);
 #ifdef DEBUG_ENABLED
 	unsigned int input_position = AudioDriver::get_singleton()->get_input_position();
 #endif
@@ -152,11 +152,11 @@ void AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fr
 		for (int i = 0; i < p_frames; i++) {
 			if (input_size > input_ofs) {
 				float l = (buf[input_ofs++] >> 16) / 32768.f;
-				if (input_ofs >= buf.size()) {
+				if ((int)input_ofs >= buf.size()) {
 					input_ofs = 0;
 				}
 				float r = (buf[input_ofs++] >> 16) / 32768.f;
-				if (input_ofs >= buf.size()) {
+				if ((int)input_ofs >= buf.size()) {
 					input_ofs = 0;
 				}
 
@@ -168,7 +168,7 @@ void AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fr
 	}
 
 #ifdef DEBUG_ENABLED
-	if (input_ofs > input_position && (input_ofs - input_position) < (p_frames * 2)) {
+	if (input_ofs > input_position && (int)(input_ofs - input_position) < (p_frames * 2)) {
 		print_verbose(String(get_class_name()) + " buffer underrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
 	}
 #endif

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -91,10 +91,10 @@ void AudioDriver::input_buffer_init(int driver_buffer_frames) {
 void AudioDriver::input_buffer_write(int32_t sample) {
 
 	input_buffer.write[input_position++] = sample;
-	if (input_position >= input_buffer.size()) {
+	if ((int)input_position >= input_buffer.size()) {
 		input_position = 0;
 	}
-	if (input_size < input_buffer.size()) {
+	if ((int)input_size < input_buffer.size()) {
 		input_size++;
 	}
 }


### PR DESCRIPTION
Note that the warning is not enabled in -Wall, but in -Wextra.
I decided to modify code in a defensive way. Ideally functions
like size() or length() should return an unsigned type.