### PR TITLE
Improve error message on project export failure

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -972,10 +972,15 @@ void ProjectExportDialog::_export_project_to_path(const String &p_path) {
 
 	Error err = platform->export_project(current, export_debug->is_pressed(), p_path, 0);
 	if (err != OK) {
-		error_dialog->set_text(TTR("Export templates for this platform are missing/corrupted:") + " " + platform->get_name());
+		if (err == ERR_FILE_NOT_FOUND) {
+			error_dialog->set_text(vformat(TTR("Failed to export the project for platform '%s'.\nExport templates seem to be missing or invalid."), platform->get_name()));
+		} else { // Assume misconfiguration. FIXME: Improve error handling and preset config validation.
+			error_dialog->set_text(vformat(TTR("Failed to export the project for platform '%s'.\nThis might be due to a configuration issue in the export preset or your export settings."), platform->get_name()));
+		}
+
+		ERR_PRINTS(vformat("Failed to export the project for platform '%s'.", platform->get_name()));
 		error_dialog->show();
 		error_dialog->popup_centered_minsize(Size2(300, 80));
-		ERR_PRINT("Failed to export project");
 	}
 }
 


### PR DESCRIPTION
It's still not enough and we need better validation/error checking,
but it should help with people assume corrupted templates when it's
their config which is invalid.

The rest will have to wait for 3.2 (#23172).