### PR TITLE
Disable support for VIA Padlock

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -287,6 +287,7 @@ File extracted from upstream release tarball `mbedtls-2.16.0-apache.tgz`:
 - All `*.h` from `include/mbedtls/` to `thirdparty/mbedtls/include/mbedtls/`
 - All `*.c` from `library/` to `thirdparty/mbedtls/library/`
 - Applied the patch in `thirdparty/mbedtls/1453.diff` (PR 1453). Soon to be merged upstream. Check it out at next update.
+- Applied the patch in `thirdparty/mbedtls/padlock.diff`. This disables VIA padlock support which defines a symbol `unsupported` which clashses with a symbol in libwebsockets.
 
 ## miniupnpc
 

--- a/thirdparty/mbedtls/include/mbedtls/config.h
+++ b/thirdparty/mbedtls/include/mbedtls/config.h
@@ -2477,7 +2477,9 @@
  *
  * This modules adds support for the VIA PadLock on x86.
  */
-#define MBEDTLS_PADLOCK_C
+// -- GODOT start --
+// #define MBEDTLS_PADLOCK_C
+// -- GODOT end --
 
 /**
  * \def MBEDTLS_PEM_PARSE_C

--- a/thirdparty/mbedtls/padlock.diff
+++ b/thirdparty/mbedtls/padlock.diff
@@ -1,0 +1,13 @@
+--- a/thirdparty/mbedtls/include/mbedtls/config.h
++++ b/thirdparty/mbedtls/include/mbedtls/config.h
+@@ -2477,7 +2477,9 @@
+  *
+  * This modules adds support for the VIA PadLock on x86.
+  */
+-#define MBEDTLS_PADLOCK_C
++// -- GODOT start --
++// #define MBEDTLS_PADLOCK_C
++// -- GODOT end --
+ 
+ /**
+  * \def MBEDTLS_PEM_PARSE_C


### PR DESCRIPTION
This code defines a symbol 'unsupported' which is also in a newer
version of libwebsockets. To fix 32bit linux builds just disable
padlock support. Processors that support this are rare and old.