### PR TITLE
Export support for gdscript resource types

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -853,6 +853,14 @@ void EditorData::get_plugin_window_layout(Ref<ConfigFile> p_layout) {
 	}
 }
 
+bool EditorData::class_equals_or_inherits(const String &p_class, const String &p_inherits) {
+	if (p_class == p_inherits)
+		return true;
+	if (ScriptServer::is_global_class(p_class))
+		return script_class_is_parent(p_class, p_inherits);
+	return ClassDB::is_parent_class(p_class, p_inherits);
+}
+
 bool EditorData::script_class_is_parent(const String &p_class, const String &p_inherits) {
 	if (!ScriptServer::is_global_class(p_class))
 		return false;

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -214,6 +214,7 @@ public:
 	void notify_edited_scene_changed();
 	void notify_resource_saved(const Ref<Resource> &p_resource);
 
+	bool class_equals_or_inherits(const String &p_class, const String &p_inherits);
 	bool script_class_is_parent(const String &p_class, const String &p_inherits);
 	StringName script_class_get_base(const String &p_class) const;
 	Object *script_class_instance(const String &p_class);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2287,6 +2287,16 @@ void EditorPropertyResource::_update_menu_items() {
 				E = E->next();
 			}
 
+			List<StringName> global_classes;
+			ScriptServer::get_global_class_list(&global_classes);
+			E = global_classes.front();
+			while (E) {
+				if (EditorNode::get_editor_data().script_class_is_parent(E->get(), base_type)) {
+					valid_inheritors.insert(E->get());
+				}
+				E = E->next();
+			}
+
 			for (Set<String>::Element *F = valid_inheritors.front(); F; F = F->next()) {
 				String t = F->get();
 
@@ -2303,7 +2313,7 @@ void EditorPropertyResource::_update_menu_items() {
 					}
 				}
 
-				if (!is_custom_resource && !ClassDB::can_instance(t))
+				if (!is_custom_resource && !(ScriptServer::is_global_class(t) || ClassDB::can_instance(t)))
 					continue;
 
 				inheritors_array.push_back(t);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1994,15 +1994,16 @@ void EditorPropertyResource::_file_selected(const String &p_path) {
 	if (!property_types.empty()) {
 		bool any_type_matches = false;
 		const Vector<String> split_property_types = property_types.split(",");
+		String res_class = _get_file_script_name_or_default(res);
 		for (int i = 0; i < split_property_types.size(); ++i) {
-			if (res->is_class(split_property_types[i])) {
+			if (EditorNode::get_editor_data().class_equals_or_inherits(res_class, split_property_types[i])) {
 				any_type_matches = true;
 				break;
 			}
 		}
 
 		if (!any_type_matches)
-			EditorNode::get_singleton()->show_warning(vformat(TTR("The selected resource (%s) does not match any type expected for this property (%s)."), res->get_class(), property_types));
+			EditorNode::get_singleton()->show_warning(vformat(TTR("The selected resource (%s) does not match any type expected for this property (%s)."), res_class, property_types));
 	}
 
 	emit_changed(get_edited_property(), res);
@@ -2022,6 +2023,9 @@ void EditorPropertyResource::_menu_option(int p_which) {
 			}
 			file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 			String type = base_type;
+			while (ScriptServer::is_global_class(type)) {
+				type = ScriptServer::get_global_class_base(type);
+			}
 
 			List<String> extensions;
 			for (int i = 0; i < type.get_slice_count(","); i++) {
@@ -2579,7 +2583,7 @@ void EditorPropertyResource::update_property() {
 			assign->set_text(res->get_path().get_file());
 			assign->set_tooltip(res->get_path());
 		} else {
-			assign->set_text(res->get_class());
+			assign->set_text(_get_file_script_name_or_default(res));
 		}
 
 		if (res->get_path().is_resource_file()) {
@@ -2712,10 +2716,12 @@ bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const
 			String ftype = EditorFileSystem::get_singleton()->get_file_type(file);
 
 			if (ftype != "") {
+				RES res = ResourceLoader::load(file);
+				ftype = _get_file_script_name_or_default(res);
 
 				for (int i = 0; i < allowed_type.get_slice_count(","); i++) {
 					String at = allowed_type.get_slice(",", i).strip_edges();
-					if (ClassDB::is_parent_class(ftype, at)) {
+					if (EditorNode::get_editor_data().class_equals_or_inherits(ftype, at)) {
 						return true;
 					}
 				}
@@ -2762,6 +2768,20 @@ void EditorPropertyResource::drop_data_fw(const Point2 &p_point, const Variant &
 
 void EditorPropertyResource::set_use_sub_inspector(bool p_enable) {
 	use_sub_inspector = p_enable;
+}
+
+String EditorPropertyResource::_get_file_script_name_or_default(const RES &p_resource) const {
+	Ref<Script> rscript = p_resource->get_script();
+	if (rscript != 0) {
+		String rscript_path = rscript->get_path();
+		int script_index;
+		EditorFileSystemDirectory *fsdir = EditorFileSystem::get_singleton()->find_file(rscript_path, &script_index);
+		ERR_FAIL_COND_V(!fsdir, p_resource->get_class());
+		String file_script_name = fsdir->get_file_script_class_name(script_index);
+		if (!file_script_name.empty())
+			return file_script_name;
+	}
+	return p_resource->get_class();
 }
 
 void EditorPropertyResource::_bind_methods() {
@@ -3227,8 +3247,7 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 					for (int j = 0; j < p_hint_text.get_slice_count(","); j++) {
 						String inherits = p_hint_text.get_slicec(',', j);
 
-						if (ClassDB::is_parent_class(inherits, type)) {
-
+						if (!ScriptServer::is_global_class(inherits) && ClassDB::is_parent_class(inherits, type)) {
 							editor->set_use_sub_inspector(false);
 						}
 					}

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -582,6 +582,8 @@ class EditorPropertyResource : public EditorProperty {
 	void _button_input(const Ref<InputEvent> &p_event);
 	void _open_editor_pressed();
 	void _fold_other_editors(Object *p_self);
+	
+	String _get_file_script_name_or_default(const RES &p_resource) const;
 
 	bool opened_editor;
 


### PR DESCRIPTION
Allow GDScript export statements to export global class types. 

* Updates gdscriptparser to accept identifiers as export types, and resolve them at around the same time as export-type / type-hint checking.
* Adds a method to editordata to be able to check if one class is equal to, or a parent of another, regardless of whether the class being checked is a native class or a script
* Updated editorpropertyresource to handle the above changes:
    * Filter drag drop
    * Detecting if resources assigned via "Load" are of the correct type
    * Builds on #26122 to provide better property resource inlining

![globalclassexport](https://user-images.githubusercontent.com/46731926/53254887-4b80e200-36bc-11e9-8080-c3dae98f94b5.png)
