### PR TITLE
Don't crash when parse_utf8 receives a NULL pointer

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1359,6 +1359,9 @@ bool String::parse_utf8(const char *p_utf8, int p_len) {
 
 #define _UNICERROR(m_err) print_line("Unicode error: " + String(m_err));
 
+	if (!p_utf8)
+		return true;
+
 	String aux;
 
 	int cstr_size = 0;

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -1046,6 +1046,13 @@ bool test_32() {
 #undef STRIP_TEST
 }
 
+bool test_33() {
+	OS::get_singleton()->print("\n\nTest 33: parse_utf8(null, -1)\n");
+
+	String empty;
+	return empty.parse_utf8(NULL, -1) == true;
+}
+
 typedef bool (*TestFunc)(void);
 
 TestFunc test_funcs[] = {
@@ -1082,6 +1089,7 @@ TestFunc test_funcs[] = {
 	test_30,
 	test_31,
 	test_32,
+	test_33,
 	0
 
 };


### PR DESCRIPTION
This can happen when chaining calls to various string methods when the
string is empty.