### PR TITLE
Fix crash when using `wrapi()` with a range of zero

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -219,15 +219,15 @@ public:
 
 	static _ALWAYS_INLINE_ int wrapi(int value, int min, int max) {
 		int rng = max - min;
-		return min + ((((value - min) % rng) + rng) % rng);
+		return (rng != 0) ? min + ((((value - min) % rng) + rng) % rng) : min;
 	}
 	static _ALWAYS_INLINE_ double wrapf(double value, double min, double max) {
 		double rng = max - min;
-		return value - (rng * Math::floor((value - min) / rng));
+		return (!is_equal_approx(rng, 0.0)) ? value - (rng * Math::floor((value - min) / rng)) : min;
 	}
 	static _ALWAYS_INLINE_ float wrapf(float value, float min, float max) {
 		float rng = max - min;
-		return value - (rng * Math::floor((value - min) / rng));
+		return (!is_equal_approx(rng, 0.0f)) ? value - (rng * Math::floor((value - min) / rng)) : min;
 	}
 
 	// double only, as these functions are mainly used by the editor and not performance-critical,


### PR DESCRIPTION
`wrapi()` and `wrapf()` will now return the value of the `min` parameter if the range is equal to zero.

The editor crashed as soon as something like `wrapi(0, 0, 0)` was written in the script editor (as it checks for errors when idle). `wrapf(0.0, 0.0, 0.0)` didn't crash, but returned `nan` instead; I changed it to follow `wrapi()` behavior for consistency's sake. I don't know if this is the best fix in terms of performance, please suggest alternatives if you have any.

Thanks to NoOn3Left on IRC for reporting this :slightly_smiling_face: