### PR TITLE
Fix WASAPI driver not working when the device doesn't supports the mix format

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -238,6 +238,32 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_c
 	hr = p_device->audio_client->GetMixFormat(&pwfex);
 	ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
 
+	print_verbose("WASAPI: wFormatTag = " + itos(pwfex->wFormatTag));
+	print_verbose("WASAPI: nChannels = " + itos(pwfex->nChannels));
+	print_verbose("WASAPI: nSamplesPerSec = " + itos(pwfex->nSamplesPerSec));
+	print_verbose("WASAPI: nAvgBytesPerSec = " + itos(pwfex->nAvgBytesPerSec));
+	print_verbose("WASAPI: nBlockAlign = " + itos(pwfex->nBlockAlign));
+	print_verbose("WASAPI: wBitsPerSample = " + itos(pwfex->wBitsPerSample));
+	print_verbose("WASAPI: cbSize = " + itos(pwfex->cbSize));
+
+	WAVEFORMATEX *closest = NULL;
+	hr = p_device->audio_client->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, pwfex, &closest);
+	if (hr == S_FALSE) {
+		WARN_PRINT("WASAPI: Mix format is not supported by the Device");
+		if (closest) {
+			print_verbose("WASAPI: closest->wFormatTag = " + itos(closest->wFormatTag));
+			print_verbose("WASAPI: closest->nChannels = " + itos(closest->nChannels));
+			print_verbose("WASAPI: closest->nSamplesPerSec = " + itos(closest->nSamplesPerSec));
+			print_verbose("WASAPI: closest->nAvgBytesPerSec = " + itos(closest->nAvgBytesPerSec));
+			print_verbose("WASAPI: closest->nBlockAlign = " + itos(closest->nBlockAlign));
+			print_verbose("WASAPI: closest->wBitsPerSample = " + itos(closest->wBitsPerSample));
+			print_verbose("WASAPI: closest->cbSize = " + itos(closest->cbSize));
+
+			WARN_PRINT("WASAPI: Using closest match instead");
+			pwfex = closest;
+		}
+	}
+
 	// Since we're using WASAPI Shared Mode we can't control any of these, we just tag along
 	p_device->channels = pwfex->nChannels;
 	p_device->format_tag = pwfex->wFormatTag;


### PR DESCRIPTION
Fixes #26152

I've included some `print_verbose` that are usually useful when debugging issues with the WASAPI driver.