### PR TITLE
Enabling ipv6 in libwebsockets

### DIFF
--- a/thirdparty/libwebsockets/lws_config.h
+++ b/thirdparty/libwebsockets/lws_config.h
@@ -78,6 +78,7 @@
 
 /* Build with support for ipv6 */
 /* #undef LWS_WITH_IPV6 */
+#define LWS_WITH_IPV6
 
 /* Build with support for UNIX domain socket */
 /* #undef LWS_WITH_UNIX_SOCK */


### PR DESCRIPTION
Compile libwebsockets with ipv6 support, without it, websockets are not working in ipv6 networks, and the "localhost" keyword is not working in a big number of Operating Systems with predefined ipv6 resolutions of it.