### PR TITLE
[macOS] Change `move_window_to_foreground` to take focus.

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -2324,7 +2324,8 @@ bool OS_OSX::is_window_maximized() const {
 
 void OS_OSX::move_window_to_foreground() {
 
-	[window_object orderFrontRegardless];
+	[[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+	[window_object makeKeyAndOrderFront:nil];
 }
 
 void OS_OSX::set_window_always_on_top(bool p_enabled) {


### PR DESCRIPTION
Fixes switching from fullscreen app (#21431) on macOS, mimics `move_window_to_foreground` behaviour on Windows and X11 (both activate window, macOS version was only changing window display order).