### PR TITLE
Tweak SpatialMaterial's default metallic and roughness texture channels

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1322,9 +1322,7 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 				if (bct.has("index")) {
 					Ref<Texture> t = _get_texture(state, bct["index"]);
 					material->set_texture(SpatialMaterial::TEXTURE_METALLIC, t);
-					material->set_metallic_texture_channel(SpatialMaterial::TEXTURE_CHANNEL_BLUE);
 					material->set_texture(SpatialMaterial::TEXTURE_ROUGHNESS, t);
-					material->set_roughness_texture_channel(SpatialMaterial::TEXTURE_CHANNEL_GREEN);
 					if (!mr.has("metallicFactor")) {
 						material->set_metallic(1);
 					}
@@ -1349,7 +1347,6 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 			Dictionary bct = d["occlusionTexture"];
 			if (bct.has("index")) {
 				material->set_texture(SpatialMaterial::TEXTURE_AMBIENT_OCCLUSION, _get_texture(state, bct["index"]));
-				material->set_ao_texture_channel(SpatialMaterial::TEXTURE_CHANNEL_RED);
 				material->set_feature(SpatialMaterial::FEATURE_AMBIENT_OCCLUSION, true);
 			}
 		}

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2320,8 +2320,8 @@ SpatialMaterial::SpatialMaterial() :
 
 	set_ao_light_affect(0.0);
 
-	set_metallic_texture_channel(TEXTURE_CHANNEL_RED);
-	set_roughness_texture_channel(TEXTURE_CHANNEL_RED);
+	set_metallic_texture_channel(TEXTURE_CHANNEL_BLUE);
+	set_roughness_texture_channel(TEXTURE_CHANNEL_GREEN);
 	set_ao_texture_channel(TEXTURE_CHANNEL_RED);
 	set_refraction_texture_channel(TEXTURE_CHANNEL_RED);
 


### PR DESCRIPTION
To follow the glTF 2.0 specification in all cases (including outside of imported glTF scenes), the blue channel is now used for metallic and the green channel is now used for roughness. This way, less clicks are required when setting up new materials using ORM-packed textures (occlusion, roughness, metallic). This should have no effect on materials using grayscale maps, as the R/G/B channels are identical.

This also removes the need to set channels specifically in the glTF scene importer code.