### PR TITLE
[WIP] Add command parser

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -185,6 +185,10 @@ _ResourceSaver::_ResourceSaver() {
 
 /////////////////OS
 
+CommandParser *_OS::get_command_parser() const {
+	return OS::get_singleton()->get_command_parser();
+}
+
 void _OS::global_menu_add_item(const String &p_menu, const String &p_label, const Variant &p_signal, const Variant &p_meta) {
 
 	OS::get_singleton()->global_menu_add_item(p_menu, p_label, p_signal, p_meta);
@@ -533,6 +537,18 @@ String _OS::get_name() const {
 Vector<String> _OS::get_cmdline_args() {
 
 	List<String> cmdline = OS::get_singleton()->get_cmdline_args();
+	Vector<String> cmdlinev;
+	for (List<String>::Element *E = cmdline.front(); E; E = E->next()) {
+
+		cmdlinev.push_back(E->get());
+	}
+
+	return cmdlinev;
+}
+
+Vector<String> _OS::get_project_args() {
+
+	List<String> cmdline = OS::get_singleton()->get_project_args();
 	Vector<String> cmdlinev;
 	for (List<String>::Element *E = cmdline.front(); E; E = E->next()) {
 
@@ -1160,6 +1176,8 @@ _OS *_OS::singleton = NULL;
 
 void _OS::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("get_command_parser"), &_OS::get_command_parser);
+
 	//ClassDB::bind_method(D_METHOD("get_mouse_position"),&_OS::get_mouse_position);
 	//ClassDB::bind_method(D_METHOD("is_mouse_grab_enabled"),&_OS::is_mouse_grab_enabled);
 
@@ -1258,6 +1276,7 @@ void _OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_name"), &_OS::get_name);
 	ClassDB::bind_method(D_METHOD("get_cmdline_args"), &_OS::get_cmdline_args);
+	ClassDB::bind_method(D_METHOD("get_project_args"), &_OS::get_project_args);
 
 	ClassDB::bind_method(D_METHOD("get_datetime", "utc"), &_OS::get_datetime, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_date", "utc"), &_OS::get_date, DEFVAL(false));

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -143,6 +143,8 @@ public:
 		MONTH_DECEMBER
 	};
 
+	CommandParser *get_command_parser() const;
+
 	void global_menu_add_item(const String &p_menu, const String &p_label, const Variant &p_signal, const Variant &p_meta);
 	void global_menu_add_separator(const String &p_menu);
 	void global_menu_remove_item(const String &p_menu, int p_idx);
@@ -238,6 +240,7 @@ public:
 
 	String get_name() const;
 	Vector<String> get_cmdline_args();
+	Vector<String> get_project_args();
 
 	String get_locale() const;
 	String get_latin_keyboard_variant() const;

--- a/core/cli_parser.cpp
+++ b/core/cli_parser.cpp
@@ -1,0 +1,958 @@
+/*************************************************************************/
+/*  cli_parser.cpp                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "cli_parser.h"
+#include "core/os/os.h"
+#include "core/translation.h"
+#include "core/version.h"
+#include "core/version_hash.gen.h"
+#include "main/tests/test_main.h"
+
+#define COMMAND_SEPARATOR "--"
+
+// Checkers
+
+struct CommandFlag::CommandChecker {
+
+	virtual bool check(const String &p_arg) const = 0;
+
+	String error_msg;
+
+	virtual ~CommandChecker() {}
+};
+
+struct CommandFlag::FunctionChecker : public CommandFlag::CommandChecker {
+
+	bool check(const String &p_arg) const override {
+		return function(p_arg);
+	}
+
+	CommandFlag::check_function function;
+};
+
+struct CommandFlag::ObjectChecker : public CommandFlag::CommandChecker {
+
+	bool check(const String &p_arg) const override {
+		Variant::CallError ce;
+		Variant v_arg = (Variant)p_arg;
+		const Variant *arg[1] = { &v_arg };
+
+		bool res = obj->call(func, arg, 1, ce);
+		if (ce.error != Variant::CallError::CALL_OK) {
+			res = false;
+		}
+		return res;
+	}
+
+	StringName func;
+	Object *obj;
+};
+
+// CommandFlag
+
+void CommandFlag::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("set_argument_name", "argument_name"), &CommandFlag::set_argument_name);
+	ClassDB::bind_method(D_METHOD("get_argument_name"), &CommandFlag::get_argument_name);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "argument_name"), "set_argument_name", "get_argument_name");
+	ClassDB::bind_method(D_METHOD("set_description", "description"), &CommandFlag::set_description);
+	ClassDB::bind_method(D_METHOD("get_description"), &CommandFlag::get_description);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "description"), "set_description", "get_description");
+	ClassDB::bind_method(D_METHOD("set_category", "category"), &CommandFlag::set_category);
+	ClassDB::bind_method(D_METHOD("get_category"), &CommandFlag::get_category);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "category"), "set_category", "get_category");
+	ClassDB::bind_method(D_METHOD("set_flag", "flag"), &CommandFlag::set_flag);
+	ClassDB::bind_method(D_METHOD("get_flag"), &CommandFlag::get_flag);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "flag"), "set_flag", "get_flag");
+	ClassDB::bind_method(D_METHOD("set_short_flag", "args"), &CommandFlag::set_short_flag);
+	ClassDB::bind_method(D_METHOD("get_short_flag"), &CommandFlag::get_short_flag);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "short_flag"), "set_short_flag", "get_short_flag");
+	ClassDB::bind_method(D_METHOD("set_show_in_help", "show_in_help"), &CommandFlag::set_show_in_help);
+	ClassDB::bind_method(D_METHOD("get_show_in_help"), &CommandFlag::get_show_in_help);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "show_in_help"), "set_show_in_help", "get_show_in_help");
+
+	ClassDB::bind_method(D_METHOD("needs_argument"), &CommandFlag::needs_argument);
+	ClassDB::bind_method(D_METHOD("set_flags", "flag", "short_flag"), &CommandFlag::set_flags);
+	ClassDB::bind_method(D_METHOD("set_data", "description", "category"), &CommandFlag::set_data);
+	ClassDB::bind_method(D_METHOD("add_object_checker", "obj", "func", "err_msg"), &CommandFlag::add_object_checker);
+	ClassDB::bind_method(D_METHOD("clear_checkers"), &CommandFlag::clear_checkers);
+}
+
+bool CommandFlag::locale_checker(const String &p_arg) {
+	String univ_locale = TranslationServer::standardize_locale(p_arg);
+	return TranslationServer::is_locale_valid(univ_locale);
+}
+
+bool CommandFlag::numeric_checker(const String &p_arg) {
+	return p_arg.is_numeric();
+}
+
+bool CommandFlag::resolution_checker(const String &p_arg) {
+	bool res = (p_arg.find("x") != -1) &&
+			   (p_arg.get_slice("x", 0).to_int() <= 0) &&
+			   (p_arg.get_slice("x", 1).to_int() <= 0);
+	return res;
+}
+
+bool CommandFlag::position_checker(const String &p_arg) {
+	Vector<String> coords = p_arg.split(",");
+	return coords.size() == 2 && coords[0].is_numeric() && coords[1].is_numeric();
+}
+
+bool CommandFlag::host_address_checker(const String &p_arg) {
+	return p_arg.find(":") != -1;
+}
+
+bool CommandFlag::audio_driver_checker(const String &p_arg) {
+	bool res = false;
+	for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {
+		res = (OS::get_singleton()->get_audio_driver_name(i) == p_arg);
+		if (res)
+			break;
+	}
+	return res;
+}
+
+bool CommandFlag::video_driver_checker(const String &p_arg) {
+	bool res = false;
+	for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
+		res = (OS::get_singleton()->get_video_driver_name(i) == p_arg);
+		if (res)
+			break;
+	}
+	return res;
+}
+
+bool CommandFlag::render_thread_checker(const String &p_arg) {
+	return p_arg == "unsafe" || p_arg == "safe" || p_arg == "separate";
+}
+
+void CommandFlag::set_argument_name(const String &p_arg_name) {
+
+	_arg_name = p_arg_name;
+}
+
+String CommandFlag::get_argument_name() const {
+	return _arg_name;
+}
+
+void CommandFlag::set_description(const String &p_description) {
+	_description = p_description;
+}
+
+String CommandFlag::get_description() const {
+	return _description;
+}
+
+void CommandFlag::set_category(const String &p_category) {
+	_category = p_category;
+}
+
+String CommandFlag::get_category() const {
+	return _category;
+}
+
+void CommandFlag::set_flag(const String &p_flag) {
+	_flag = p_flag;
+}
+
+String CommandFlag::get_flag() const {
+	return _flag;
+}
+
+void CommandFlag::set_short_flag(const String &p_short_flag) {
+	_short_flag = p_short_flag;
+}
+
+String CommandFlag::get_short_flag() const {
+	return _short_flag;
+}
+
+void CommandFlag::set_show_in_help(const bool p_enabled) {
+	_show_in_help = p_enabled;
+}
+
+bool CommandFlag::get_show_in_help() const {
+	return _show_in_help;
+}
+
+void CommandFlag::set_flags(const String &p_flag, const String &p_short_flag) {
+
+	_flag = p_flag;
+	_short_flag = p_short_flag;
+}
+
+void CommandFlag::set_data(const String &p_description, const String &p_category) {
+
+	_description = p_description;
+	_category = p_category;
+}
+
+void CommandFlag::add_checker(check_function p_f, const String &p_error_msg) {
+	FunctionChecker *check = memnew(FunctionChecker);
+	check->function = p_f;
+	check->error_msg = p_error_msg;
+	check_list.push_back(check);
+}
+
+void CommandFlag::add_object_checker(Object *p_obj, const StringName &p_function, const String &p_error_msg) {
+	ObjectChecker *check = memnew(ObjectChecker);
+	check->error_msg = p_error_msg;
+	check->obj = p_obj;
+	check->func = p_function;
+	check_list.push_back(check);
+}
+
+void CommandFlag::clear_checkers() {
+	for (int i = 0; i < check_list.size(); i++) {
+		memdelete(check_list[i]);
+	}
+	check_list.clear();
+}
+
+bool CommandFlag::needs_argument() const {
+
+	return _arg_name.length() > 0;
+}
+
+CommandFlag::CommandFlag() :
+		_show_in_help(true) {
+}
+
+CommandFlag::CommandFlag(const String &p_flag) :
+		_show_in_help(true) {
+	_flag = p_flag;
+}
+
+CommandFlag::CommandFlag(const String &p_flag, const String &p_short_flag) :
+		_show_in_help(true) {
+	_flag = p_flag;
+	_short_flag = p_short_flag;
+}
+
+CommandFlag::~CommandFlag() {
+	clear_checkers();
+}
+
+// CommandParser
+
+void CommandParser::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("parse_arguments", "args"), &CommandParser::parse_arguments);
+	ClassDB::bind_method(D_METHOD("print_help"), &CommandParser::print_help);
+	ClassDB::bind_method(D_METHOD("print_version"), &CommandParser::print_version);
+	ClassDB::bind_method(D_METHOD("add_command", "command"), &CommandParser::add_command);
+	ClassDB::bind_method(D_METHOD("is_argument_set", "flag"), &CommandParser::is_argument_set);
+	ClassDB::bind_method(D_METHOD("needs_argument", "flag"), &CommandParser::needs_argument);
+	ClassDB::bind_method(D_METHOD("get_argument", "flag"), &CommandParser::get_argument);
+	ClassDB::bind_method(D_METHOD("has_scene_defined"), &CommandParser::has_scene_defined);
+	ClassDB::bind_method(D_METHOD("has_project_defined"), &CommandParser::has_project_defined);
+	ClassDB::bind_method(D_METHOD("has_script_defined"), &CommandParser::has_script_defined);
+	ClassDB::bind_method(D_METHOD("has_shader_defined"), &CommandParser::has_shader_defined);
+	ClassDB::bind_method(D_METHOD("clear"), &CommandParser::clear);
+	ClassDB::bind_method(D_METHOD("check_command_flag_collision"), &CommandParser::check_command_flag_collision);
+
+	ClassDB::bind_method(D_METHOD("set_search_project_file", "enable"), &CommandParser::set_search_project_file);
+	ClassDB::bind_method(D_METHOD("get_search_project_file"), &CommandParser::get_search_project_file);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "search_project_file"), "set_search_project_file", "get_search_project_file");
+	ClassDB::bind_method(D_METHOD("set_help_header", "help_header"), &CommandParser::set_help_header);
+	ClassDB::bind_method(D_METHOD("get_help_header"), &CommandParser::get_help_header);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "help_header"), "set_help_header", "get_help_header");
+	ClassDB::bind_method(D_METHOD("set_help_footer", "help_footer"), &CommandParser::set_help_footer);
+	ClassDB::bind_method(D_METHOD("get_help_footer"), &CommandParser::get_help_footer);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "help_footer"), "set_help_footer", "get_help_footer");
+	ClassDB::bind_method(D_METHOD("set_version", "version"), &CommandParser::set_version);
+	ClassDB::bind_method(D_METHOD("get_version"), &CommandParser::get_version);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "version"), "set_version", "get_version");
+}
+
+void CommandParser::init_engine_defaults() {
+
+	_separator_enabled = true;
+	_search_project_file = true;
+
+	_version = get_full_version_string();
+	_help_header = String(VERSION_NAME) + " v" + _version + " - https://godotengine.org\n" +
+				   "(c) 2007-2019 Juan Linietsky, Ariel Manzur.\n" +
+				   "(c) 2014-2019 Godot Engine contributors.\n\n" +
+				   "Usage: " + OS::get_singleton()->get_executable_path().utf8().get_data() +
+				   " [options] [path to scene or 'project.godot' file] " + String(COMMAND_SEPARATOR) + " [project options]\n";
+	// General options
+	Ref<CommandFlag> help_command = memnew(CommandFlag("--help", "-h"));
+	help_command->set_data("Display this help message.", "General options");
+	add_command(help_command);
+
+	Ref<CommandFlag> version_command = memnew(CommandFlag("--version"));
+	version_command->set_data("Display the version string.", "General options");
+	add_command(version_command);
+
+	Ref<CommandFlag> verbose_command = memnew(CommandFlag("--verbose", "-v"));
+	verbose_command->set_data("Use verbose stdout mode.", "General options");
+	add_command(verbose_command);
+
+	Ref<CommandFlag> quiet_command = memnew(CommandFlag("--quiet"));
+	quiet_command->set_data("Quiet mode, silences stdout messages. Errors are still displayed.", "General options");
+	add_command(quiet_command);
+
+	// Run options
+	Ref<CommandFlag> editor_command = memnew(CommandFlag("--editor", "-e"));
+	editor_command->set_data("Start the editor instead of running the scene.", "Run options");
+	add_command(editor_command);
+
+	Ref<CommandFlag> project_manager_command = memnew(CommandFlag("--project-manager", "-p"));
+	project_manager_command->set_data("Start the project manager, even if a project is auto-detected.", "Run options");
+	add_command(project_manager_command);
+
+	Ref<CommandFlag> quit_command = memnew(CommandFlag("--quit", "-q"));
+	quit_command->set_data("Quit after the first iteration.", "Run options");
+	add_command(quit_command);
+
+	Ref<CommandFlag> language_command = memnew(CommandFlag("--language", "-l"));
+	language_command->set_data("Use a specific locale (<locale> being a two-letter code).", "Run options");
+	language_command->set_argument_name("<locale>");
+	language_command->add_checker(CommandFlag::locale_checker, "Invalid locale.");
+	add_command(language_command);
+
+	Ref<CommandFlag> path_command = memnew(CommandFlag("--path"));
+	path_command->set_data("Path to a project (<directory> must contain a 'project.godot' file).", "Run options");
+	path_command->set_argument_name("<directory>");
+	add_command(path_command);
+
+	Ref<CommandFlag> upwards_command = memnew(CommandFlag("--upwards", "-u"));
+	upwards_command->set_data("Scan folders upwards for project.godot file.", "Run options");
+	add_command(upwards_command);
+
+	Ref<CommandFlag> main_pack_command = memnew(CommandFlag("--main-pack"));
+	main_pack_command->set_data("Path to a pack (.pck) file to load.", "Run options");
+	main_pack_command->set_argument_name("<file>");
+	add_command(main_pack_command);
+
+	Ref<CommandFlag> render_thread_command = memnew(CommandFlag("--render-thread"));
+	render_thread_command->set_data("Render thread mode ('unsafe', 'safe', 'separate').", "Run options");
+	render_thread_command->set_argument_name("<mode>");
+	render_thread_command->add_checker(CommandFlag::render_thread_checker, "The argument must be a valid render-thread.");
+	add_command(render_thread_command);
+
+	Ref<CommandFlag> remote_fs_command = memnew(CommandFlag("--remote-fs"));
+	remote_fs_command->set_data("Remote filesystem (<host/IP>[:<port>] address).", "Run options");
+	remote_fs_command->set_argument_name("<address>");
+	add_command(remote_fs_command);
+
+	Ref<CommandFlag> remote_fs_password_command = memnew(CommandFlag("--remote-fs-password"));
+	remote_fs_password_command->set_data("Password for remote filesystem.", "Run options");
+	remote_fs_password_command->set_argument_name("<password>");
+	add_command(remote_fs_password_command);
+
+	Ref<CommandFlag> audio_driver_command = memnew(CommandFlag("--audio-driver"));
+	String audio_driver_description = "Audio driver (";
+	for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {
+		if (i != 0)
+			audio_driver_description += ", ";
+		audio_driver_description += OS::get_singleton()->get_audio_driver_name(i);
+	}
+	audio_driver_description += ").";
+	audio_driver_command->set_data(audio_driver_description, "Run options");
+	audio_driver_command->add_checker(CommandFlag::audio_driver_checker, "The argument is an invalid audio driver.");
+	add_command(audio_driver_command);
+
+	Ref<CommandFlag> video_driver_command = memnew(CommandFlag("--video-driver"));
+	String video_driver_description = "Video driver (";
+	for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
+		if (i != 0)
+			video_driver_description += ", ";
+		video_driver_description += OS::get_singleton()->get_video_driver_name(i);
+	}
+	video_driver_description += ").";
+	video_driver_command->set_data(video_driver_description, "Run options");
+	video_driver_command->add_checker(CommandFlag::video_driver_checker, "The argument is an invalid video driver.");
+	add_command(video_driver_command);
+
+	// Display options
+#ifndef SERVER_ENABLED
+	Ref<CommandFlag> fullscreen_command = memnew(CommandFlag("--fullscreen", "-f"));
+	fullscreen_command->set_data("Request fullscreen mode.", "Display options");
+	add_command(fullscreen_command);
+
+	Ref<CommandFlag> maximized_command = memnew(CommandFlag("--maximized", "-m"));
+	maximized_command->set_data("Request a maximized window.", "Display options");
+	add_command(maximized_command);
+
+	Ref<CommandFlag> windowed_command = memnew(CommandFlag("--windowed", "-w"));
+	windowed_command->set_data("Request windowed mode.", "Display options");
+	add_command(windowed_command);
+
+	Ref<CommandFlag> always_on_top_command = memnew(CommandFlag("--always-on-top", "-t"));
+	always_on_top_command->set_data("Request an always-on-top window.", "Display options");
+	add_command(always_on_top_command);
+
+	Ref<CommandFlag> resolution_command = memnew(CommandFlag("--resolution"));
+	resolution_command->set_data("Request window resolution.", "Display options");
+	resolution_command->set_argument_name("<W>x<H>");
+	resolution_command->add_checker(CommandFlag::resolution_checker, "Invalid resolution, it should be e.g. '1280x720' and the values must be above 0.");
+	add_command(resolution_command);
+
+	Ref<CommandFlag> position_command = memnew(CommandFlag("--position"));
+	position_command->set_data("Request window position.", "Display options");
+	position_command->set_argument_name("<X>,<Y>");
+	position_command->add_checker(CommandFlag::position_checker, "Invalid position, it should be e.g. '80,128'.");
+	add_command(position_command);
+
+	Ref<CommandFlag> low_dpi_command = memnew(CommandFlag("--low-dpi"));
+	low_dpi_command->set_data("Force low-DPI mode (macOS and Windows only).", "Display options");
+	add_command(low_dpi_command);
+
+	Ref<CommandFlag> no_window_command = memnew(CommandFlag("--no-window"));
+	no_window_command->set_data("Disable window creation (Windows only). Useful together with --script.", "Display options");
+	add_command(no_window_command);
+
+	Ref<CommandFlag> no_window_command = memnew(CommandFlag("--enable-vsync-via-compositor"));
+	no_window_command->set_data("When vsync is enabled, vsync via the OS' window compositor (Windows only).", "Display options");
+	add_command(no_window_command);
+
+	Ref<CommandFlag> no_window_command = memnew(CommandFlag("--disable-vsync-via-compositor"));
+	no_window_command->set_data("Disable vsync via the OS' window compositor (Windows only).", "Display options");
+	add_command(no_window_command);
+#endif
+
+	// Debug options
+	Ref<CommandFlag> steal_pid_command = memnew(CommandFlag("--allow_focus_steal_pid"));
+	steal_pid_command->set_data("Allow set window to the foreground.", "Debug options");
+	steal_pid_command->set_argument_name("<PID>");
+	add_command(steal_pid_command);
+
+	Ref<CommandFlag> debug_command = memnew(CommandFlag("--debug", "-d"));
+	debug_command->set_data("Debug (local stdout debugger).", "Debug options");
+	add_command(debug_command);
+
+	Ref<CommandFlag> breakpoints_command = memnew(CommandFlag("--breakpoints", "-b"));
+	breakpoints_command->set_data("Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).", "Debug options");
+	breakpoints_command->set_argument_name("<pairs>");
+	add_command(breakpoints_command);
+
+	Ref<CommandFlag> profiling_command = memnew(CommandFlag("--profiling"));
+	profiling_command->set_data("Enable profiling in the script debugger.", "Debug options");
+	add_command(profiling_command);
+
+	Ref<CommandFlag> remote_debug_command = memnew(CommandFlag("--remote-debug"));
+	remote_debug_command->set_data("Remote debug (<host/IP>:<port> address).", "Debug options");
+	remote_debug_command->set_argument_name("<address>");
+	remote_debug_command->add_checker(CommandFlag::host_address_checker, "Invalid debug host address, it should be of the form <host/IP>:<port>.");
+	add_command(remote_debug_command);
+
+#if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
+	Ref<CommandFlag> debug_collisions_command = memnew(CommandFlag("--debug-collisions"));
+	debug_collisions_command->set_data("Show collisions shapes when running the scene.", "Debug options");
+	add_command(debug_collisions_command);
+
+	Ref<CommandFlag> debug_navigation_command = memnew(CommandFlag("--debug-navigation"));
+	debug_navigation_command->set_data("Show navigation polygons when running the scene.", "Debug options");
+	add_command(debug_navigation_command);
+#endif
+
+	Ref<CommandFlag> frame_delay_command = memnew(CommandFlag("--frame-delay"));
+	frame_delay_command->set_data("Simulate high CPU load (delay each frame by <ms> milliseconds).", "Debug options");
+	frame_delay_command->set_argument_name("<ms>");
+	frame_delay_command->add_checker(CommandFlag::numeric_checker, "Invalid delay value. Must be numeric above 0");
+	add_command(frame_delay_command);
+
+	Ref<CommandFlag> time_scale_command = memnew(CommandFlag("--time-scale"));
+	time_scale_command->set_data("Force time scale (higher values are faster, 1.0 is normal speed).", "Debug options");
+	time_scale_command->set_argument_name("<scale>");
+	time_scale_command->add_checker(CommandFlag::numeric_checker, "Invalid scale value. Must be numeric above 0");
+	add_command(time_scale_command);
+
+	Ref<CommandFlag> disable_render_loop_command = memnew(CommandFlag("--disable-render-loop"));
+	disable_render_loop_command->set_data("Disable render loop so rendering only occurs when called explicitly from script.", "Debug options");
+	add_command(disable_render_loop_command);
+
+	Ref<CommandFlag> disable_crash_handler_command = memnew(CommandFlag("--disable-crash-handler"));
+	disable_crash_handler_command->set_data("Disable crash handler when supported by the platform code.", "Debug options");
+	add_command(disable_crash_handler_command);
+
+	Ref<CommandFlag> skip_breakpoints_command = memnew(CommandFlag("--skip-breakpoints"));
+	skip_breakpoints_command->set_data("Disable breakpoints.", "Debug options");
+	add_command(skip_breakpoints_command);
+
+	Ref<CommandFlag> fixed_fps_command = memnew(CommandFlag("--fixed-fps"));
+	fixed_fps_command->set_data("Force a fixed number of frames per second. This setting disables real-time synchronization.", "Debug options");
+	fixed_fps_command->set_argument_name("<fps>");
+	fixed_fps_command->add_checker(CommandFlag::numeric_checker, "Invalid fps value. Must be numeric above 0.");
+	add_command(fixed_fps_command);
+
+	Ref<CommandFlag> print_fps_command = memnew(CommandFlag("--print-fps"));
+	print_fps_command->set_data("Print the frames per second to the stdout.", "Debug options");
+	add_command(print_fps_command);
+
+	// Standalone tools
+	Ref<CommandFlag> script_command = memnew(CommandFlag("--script", "-s"));
+	script_command->set_data("Run a script.", "Standalone options");
+	script_command->set_argument_name("<script>");
+	add_command(script_command);
+
+	Ref<CommandFlag> check_only_command = memnew(CommandFlag("--check-only"));
+	check_only_command->set_data("Only parse for errors and quit (use with --script).", "Standalone options");
+	add_command(check_only_command);
+
+#ifdef TOOLS_ENABLED
+	Ref<CommandFlag> export_command = memnew(CommandFlag("--export"));
+	export_command->set_data("Export the project using the given export target. Export only main pack if path ends with .pck or .zip.", "Standalone options");
+	export_command->set_argument_name("<target>");
+	add_command(export_command);
+
+	Ref<CommandFlag> export_debug_command = memnew(CommandFlag("--export-debug"));
+	export_debug_command->set_data("Like --export, but use debug template.", "Standalone options");
+	export_debug_command->set_argument_name("<target>");
+	add_command(export_debug_command);
+
+	Ref<CommandFlag> doctool_command = memnew(CommandFlag("--doctool"));
+	doctool_command->set_data("Dump the engine API reference to the given <path> in XML format, merging if existing files are found.", "Standalone options");
+	doctool_command->set_argument_name("<path>");
+	add_command(doctool_command);
+
+	Ref<CommandFlag> no_docbase_command = memnew(CommandFlag("--no-docbase"));
+	no_docbase_command->set_data("Disallow dumping the base types (used with --doctool).", "Standalone options");
+	add_command(no_docbase_command);
+
+	Ref<CommandFlag> build_solutions_command = memnew(CommandFlag("--build-solutions"));
+	build_solutions_command->set_data("Build the scripting solutions (e.g. for C# projects).", "Standalone options");
+	add_command(build_solutions_command);
+
+#ifdef DEBUG_METHODS_ENABLED
+	Ref<CommandFlag> gdnative_generate_json_api_command = memnew(CommandFlag("--gdnative-generate-json-api"));
+	gdnative_generate_json_api_command->set_data("Generate JSON dump of the Godot API for GDNative bindings.", "Standalone options");
+	add_command(gdnative_generate_json_api_command);
+#endif
+	Ref<CommandFlag> test_command = memnew(CommandFlag("--test"));
+	String test_description = "Run a unit test (";
+	const char **test_names = tests_get_names();
+	const char *comma = "";
+	while (*test_names) {
+		test_description += comma;
+		test_description += *test_names;
+		test_names++;
+		comma = ", ";
+	}
+	test_description += ").";
+	test_command->set_data(test_description, "Standalone options");
+	test_command->set_argument_name("<test>");
+	add_command(test_command);
+#endif
+}
+
+Error CommandParser::parse() {
+
+	_data_found.clear();
+	_game_args.clear();
+	_project_file.clear();
+
+	int args_flag_pos = _args.size();
+
+	for (int i = 0; i < _args.size(); i++) {
+
+		// Split engine commands from project commands
+		if (_separator_enabled && _args[i] == COMMAND_SEPARATOR) {
+			args_flag_pos = i;
+		}
+	}
+
+	// We need COMMAND_SEPARATOR and an actual command at the end to have
+	// content.
+	if (args_flag_pos + 1 < _args.size()) {
+
+		for (int i = args_flag_pos + 1; i < _args.size(); i++) {
+			_game_args.push_back(_args[i]);
+		}
+	}
+
+	if (args_flag_pos == 0) {
+		return OK;
+	}
+
+	if (_search_project_file) {
+		// Project file defined: scene, script, path, etc.
+		// It is viable to check if we have a file or path a the end if we only
+		// have one engine arg or if the previous command doesn't require argument.
+		const bool file_viable = (args_flag_pos == 1) || (args_flag_pos > 1 && !needs_argument(_args[args_flag_pos - 2]));
+		const String &last_engine_arg = _args[args_flag_pos - 1];
+
+		if (file_viable && !last_engine_arg.begins_with("-")) {
+
+			_project_file = last_engine_arg;
+			args_flag_pos--;
+
+			if (args_flag_pos == 0) {
+				return OK;
+			}
+		}
+	}
+
+	Vector<String> engine_args;
+	engine_args.resize(args_flag_pos);
+	for (int i = 0; i < args_flag_pos; i++) {
+		engine_args.write[i] = _args[i];
+	}
+
+	for (int i = 0; i < engine_args.size(); i++) {
+		String arg = engine_args[i];
+		String value = "";
+
+		const CommandFlag *command = find_command(arg);
+		if (!command) {
+			print_line("'" + arg + "' is not a valid command. Use '" + OS::get_singleton()->get_executable_path() + " --help' to get help.");
+			// Try to suggest the correct command.
+			command = find_most_similar_command(arg);
+			if (command) {
+				print_line("  Maybe you wanted to use: '" + command->_flag + "'.");
+			}
+			return ERR_INVALID_DATA;
+		}
+
+		if (command->needs_argument()) {
+
+			i++;
+			if (i == engine_args.size()) {
+				print_command_error(arg, "Missing argument.");
+				return ERR_INVALID_DATA;
+			}
+
+			value = engine_args[i];
+
+			for (int j = 0; j < command->check_list.size(); j++) {
+
+				if (!command->check_list[j]->check(value)) {
+					print_command_error(arg + " " + value, command->check_list[j]->error_msg);
+					return ERR_INVALID_DATA;
+				}
+			}
+		}
+		// Register 2 to be able to search result by short and normal form.
+		_data_found[command->_flag] = value;
+		_data_found[command->_short_flag] = value;
+	}
+	return OK;
+}
+
+Error CommandParser::parse_arguments(const PoolStringArray &p_args) {
+
+	List<String> args;
+	PoolStringArray::Read r = p_args.read();
+	for (int i = 0; i < p_args.size(); i++) {
+		args.push_back(r[i]);
+	}
+	set_cmdline_args(args);
+	return parse();
+}
+
+void CommandParser::print_help() const {
+
+	int longest_length = 0;
+
+	Vector<String> tmp_lines;
+	tmp_lines.resize(_commands.size());
+
+	// Build the formated " -x, --xxxxx" and save the longest size
+	// to align the descriptions.
+	for (int i = 0; i < _commands.size(); i++) {
+
+		const CommandFlag *command = _commands[i].ptr();
+		if (!command->_show_in_help) {
+			continue;
+		}
+		String line = "  ";
+		if (!command->_short_flag.empty()) {
+			line += command->_short_flag + ", ";
+		}
+		line += command->_flag;
+		if (!command->_arg_name.empty()) {
+			line += " " + command->_arg_name + "  ";
+		}
+
+		longest_length = MAX(longest_length, line.size());
+		tmp_lines.write[i] = line;
+	}
+
+	HashMap<String, Vector<String> > category_data;
+	Vector<String> ordered_categories;
+
+	// Fill category_data and ordered_categories
+	for (int i = 0; i < _commands.size(); i++) {
+
+		String line = tmp_lines[i].rpad(longest_length);
+		const String description = _commands[i]->_description;
+		line += description;
+
+		const String &category = _commands[i]->_category;
+
+		if (category_data.has(category)) {
+
+			category_data[category].push_back(line);
+		} else {
+
+			Vector<String> cat_lines;
+			cat_lines.push_back(line);
+			category_data[category] = cat_lines;
+
+			ordered_categories.push_back(category);
+		}
+	}
+
+	ordered_categories.sort();
+
+	// Start printing
+	print_line(_help_header);
+
+	for (int i = 0; i < ordered_categories.size(); i++) {
+
+		const String &category = ordered_categories[i];
+
+		const Vector<String> &lines = category_data[category];
+
+		print_line(" "); //add a blank line for readability
+		if (!category.empty()) {
+			print_line(category + ":");
+		}
+		for (int j = 0; j < lines.size(); j++) {
+			print_line(lines[j]);
+		}
+	}
+
+	print_line(_help_footer);
+	print_line(" "); //add a blank line for readability
+}
+
+void CommandParser::print_version() const {
+	print_line(_version);
+}
+
+void CommandParser::add_command(const Ref<CommandFlag> &p_command) {
+
+	_commands.push_back(p_command);
+}
+
+bool CommandParser::is_argument_set(const String &p_flag) const {
+
+	return _data_found.has(p_flag);
+}
+
+bool CommandParser::needs_argument(const String &p_flag) const {
+
+	const CommandFlag *command = find_command(p_flag);
+	return command && command->needs_argument();
+}
+
+String CommandParser::get_argument(const String &p_flag) const {
+
+	const String *result = _data_found.getptr(p_flag);
+	if (!result) {
+		return "";
+	}
+
+	return *result;
+}
+
+String CommandParser::get_defined_project_file() const {
+	return _project_file;
+}
+
+bool CommandParser::has_scene_defined() const {
+
+	return _project_file.ends_with(".tscn") || _project_file.ends_with(".scn") || _project_file.ends_with(".escn");
+}
+
+bool CommandParser::has_project_defined() const {
+
+	return _project_file.ends_with("project.godot");
+}
+
+bool CommandParser::has_script_defined() const {
+
+	return _project_file.ends_with(".gd") || _project_file.ends_with(".gdc");
+}
+
+bool CommandParser::has_shader_defined() const {
+
+	return _project_file.ends_with(".shader");
+}
+
+List<String> CommandParser::get_project_args() const {
+	List<String> res;
+	for (int i = 0; i < _game_args.size(); i++) { // TODOcli
+		res.push_back(_game_args[i]);
+	}
+	return res;
+}
+
+List<String> CommandParser::get_args() const {
+	List<String> res;
+	for (int i = 0; i < _args.size(); i++) { // TODOcli
+		res.push_back(_args[i]);
+	}
+	return res;
+}
+
+void CommandParser::set_cmdline_args(const List<String> &p_args) {
+	_game_args.clear();
+	_args.clear();
+
+	for (const List<String>::Element *E = p_args.front(); E; E = E->next()) {
+		// Unescape cmd commands
+		_args.push_back(E->get().strip_edges().replace("%20", " "));
+	}
+}
+
+void CommandParser::clear() {
+	_commands.clear();
+	_game_args.clear();
+	_data_found.clear();
+	_project_file.clear();
+}
+
+void CommandParser::set_help_header(const String &p_help_header) {
+	_help_header = p_help_header;
+}
+
+String CommandParser::get_help_header() const {
+	return _help_header;
+}
+
+void CommandParser::set_help_footer(const String &p_help_footer) {
+	_help_footer = p_help_footer;
+}
+
+String CommandParser::get_help_footer() const {
+	return _help_footer;
+}
+
+void CommandParser::set_version(const String &p_version) {
+	_version = p_version;
+}
+
+String CommandParser::get_version() const {
+	return _version;
+}
+
+void CommandParser::set_search_project_file(const bool p_enable) {
+	_search_project_file = p_enable;
+}
+
+bool CommandParser::get_search_project_file() const {
+	return _search_project_file;
+}
+
+bool CommandParser::check_command_flag_collision() const {
+	Set<String> ocurrences;
+	Vector<String> repeated;
+
+	for (int i = 0; i < _commands.size(); i++) {
+
+		if (ocurrences.has(_commands[i]->_flag)) {
+			repeated.push_back(_commands[i]->_flag);
+		} else {
+			ocurrences.insert(_commands[i]->_flag);
+		}
+		if (ocurrences.has(_commands[i]->_short_flag)) {
+			repeated.push_back(_commands[i]->_short_flag);
+		} else {
+			ocurrences.insert(_commands[i]->_short_flag);
+		}
+	}
+
+	bool has_collision = repeated.size() != 0;
+
+	if (has_collision) {
+
+		String msg = "Repeated flags: " + repeated[0];
+		for (int i = 1; i < repeated.size(); i++) {
+			msg += ", " + repeated[i];
+		}
+		msg += ".";
+
+		print_line(msg);
+	}
+
+	return has_collision;
+}
+
+String CommandParser::get_full_version_string() const {
+
+	String version(VERSION_FULL_BUILD);
+
+	String hash = String(VERSION_HASH);
+	if (hash.length() != 0) {
+		hash = "." + hash.left(9);
+	}
+	return version + hash;
+}
+
+const CommandFlag *CommandParser::find_command(const String &p_flag) const {
+
+	const CommandFlag *res = NULL;
+
+	for (int i = 0; i < _commands.size(); i++) {
+
+		if (_commands[i]->_flag == p_flag || _commands[i]->_short_flag == p_flag) {
+			res = _commands[i].ptr();
+		}
+	}
+	return res;
+}
+
+const CommandFlag *CommandParser::find_most_similar_command(const String &p_flag) const {
+
+	const CommandFlag *res = NULL;
+
+	float max_similarity = 0.0;
+	for (int i = 0; i < _commands.size(); i++) {
+
+		float similarity = MAX(_commands[i]->_flag.similarity(p_flag), _commands[i]->_short_flag.similarity(p_flag));
+
+		if (max_similarity < similarity) {
+			res = _commands[i].ptr();
+			max_similarity = similarity;
+		}
+	}
+	if (max_similarity < 0.5) { // Don't return unrelated commands
+		res = NULL;
+	}
+	return res;
+}
+
+void CommandParser::print_command_error(const String &cause, const String &msg) const {
+
+	print_line("Error in '" + cause + "': " + msg);
+}
+
+CommandParser::CommandParser() :
+		_separator_enabled(false),
+		_search_project_file(false) {
+}
+
+CommandParser::~CommandParser() {
+}

--- a/core/cli_parser.h
+++ b/core/cli_parser.h
@@ -1,0 +1,187 @@
+/*************************************************************************/
+/*  cli_parser.h                                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef CLIPARSER_H
+#define CLIPARSER_H
+
+#include "core/object.h"
+#include "core/reference.h"
+
+// Types
+
+class CommandParser;
+
+class CommandFlag : public Reference {
+
+	GDCLASS(CommandFlag, Reference);
+
+protected:
+	static void _bind_methods();
+
+public:
+	// Use functions in the format bool check(const String &data)
+	typedef bool (*check_function)(const String &);
+
+	// Checkers
+	// They are exposed so they can be reused in other parts of the engine
+	static bool locale_checker(const String &p_arg);
+	static bool numeric_checker(const String &p_arg);
+	static bool resolution_checker(const String &p_arg);
+	static bool position_checker(const String &p_arg);
+	static bool host_address_checker(const String &p_arg);
+
+private:
+	// Private checkers
+	static bool audio_driver_checker(const String &p_arg);
+	static bool video_driver_checker(const String &p_arg);
+	static bool render_thread_checker(const String &p_arg);
+
+	friend class CommandParser;
+
+	// Flags for the command. e.g help, h, version, v.
+	String _flag;
+	String _short_flag;
+	// Name of the argument passed to the flag, empty if none.
+	String _arg_name;
+	// Command description
+	String _description;
+	// Command category, commands sharing the same category are grouped
+	// together in the help message.
+	String _category;
+
+	bool _show_in_help;
+
+	struct CommandChecker;
+	struct FunctionChecker;
+	struct ObjectChecker;
+
+	Vector<CommandChecker *> check_list;
+
+public:
+	void set_argument_name(const String &p_arg_name);
+	String get_argument_name() const;
+	void set_description(const String &p_description);
+	String get_description() const;
+	void set_category(const String &p_category);
+	String get_category() const;
+	void set_flag(const String &p_flag);
+	String get_flag() const;
+	void set_short_flag(const String &p_short_flag);
+	String get_short_flag() const;
+	void set_show_in_help(const bool p_enabled);
+	bool get_show_in_help() const;
+
+	void set_flags(const String &p_flag, const String &p_short_flag = "");
+	void set_data(const String &p_description, const String &p_category = "");
+	void add_checker(check_function p_f, const String &p_error_msg = "");
+	void add_object_checker(Object *p_obj, const StringName &p_function, const String &p_error_msg);
+	void clear_checkers();
+	bool needs_argument() const;
+
+	CommandFlag();
+	CommandFlag(const String &p_flag);
+	CommandFlag(const String &p_flag, const String &p_short_flag);
+	virtual ~CommandFlag();
+};
+
+class CommandParser : public Object {
+
+	GDCLASS(CommandParser, Object);
+
+protected:
+	static void _bind_methods();
+
+private:
+	Vector<Ref<CommandFlag> > _commands;
+
+	Vector<String> _game_args;
+	Vector<String> _args;
+
+	// Ocurrences of the parsed data and their values.
+	HashMap<String, String> _data_found;
+
+	String _project_file;
+
+	String _help_header;
+	String _help_footer;
+	String _version;
+
+	// Utility
+	String get_full_version_string() const;
+	const CommandFlag *find_command(const String &p_flag) const;
+	const CommandFlag *find_most_similar_command(const String &p_flag) const;
+	void print_command_error(const String &cause, const String &msg) const;
+
+	bool _separator_enabled;
+	bool _search_project_file;
+
+public:
+	void init_engine_defaults();
+
+	Error parse();
+	// Method to expose to scriping API
+	Error parse_arguments(const PoolStringArray &p_args);
+
+	void print_help() const;
+	void print_version() const;
+
+	void add_command(const Ref<CommandFlag> &p_command);
+
+	bool is_argument_set(const String &p_flag) const;
+	bool needs_argument(const String &p_flag) const;
+	String get_argument(const String &p_flag) const;
+
+	String get_defined_project_file() const;
+	bool has_scene_defined() const;
+	bool has_project_defined() const;
+	bool has_script_defined() const;
+	bool has_shader_defined() const;
+	List<String> get_project_args() const;
+	List<String> get_args() const;
+	void set_cmdline_args(const List<String> &p_args);
+
+	void clear();
+
+	void set_help_header(const String &p_help_header);
+	String get_help_header() const;
+	void set_help_footer(const String &p_help_footer);
+	String get_help_footer() const;
+	void set_version(const String &p_version);
+	String get_version() const;
+	void set_search_project_file(const bool p_enable);
+	bool get_search_project_file() const;
+
+	bool check_command_flag_collision() const;
+
+	CommandParser();
+	virtual ~CommandParser();
+};
+
+#endif // CLIPARSER_H

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -465,6 +465,15 @@ void OS::_ensure_user_data_dir() {
 	memdelete(da);
 }
 
+void OS::delete_command_parser() {
+
+	if (_command_parser) {
+		_command_parser->clear();
+		memdelete(_command_parser);
+		_command_parser = NULL;
+	}
+}
+
 void OS::set_native_icon(const String &p_filename) {
 }
 
@@ -479,7 +488,7 @@ String OS::get_model_name() const {
 void OS::set_cmdline(const char *p_execpath, const List<String> &p_args) {
 
 	_execpath = p_execpath;
-	_cmdline = p_args;
+	_command_parser->set_cmdline_args(p_args);
 };
 
 void OS::release_rendering_thread() {
@@ -759,5 +768,10 @@ OS::OS() {
 
 OS::~OS() {
 	memdelete(_logger);
+	if (_command_parser) {
+		_command_parser->clear();
+		memdelete(_command_parser);
+		_command_parser = NULL;
+	}
 	singleton = NULL;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -31,6 +31,7 @@
 #ifndef OS_H
 #define OS_H
 
+#include "core/cli_parser.h"
 #include "core/engine.h"
 #include "core/image.h"
 #include "core/io/logger.h"
@@ -47,7 +48,6 @@ class OS {
 
 	static OS *singleton;
 	String _execpath;
-	List<String> _cmdline;
 	bool _keep_screen_on;
 	bool low_processor_usage_mode;
 	int low_processor_usage_mode_sleep_usec;
@@ -64,6 +64,8 @@ class OS {
 	void *_stack_bottom;
 
 	CompositeLogger *_logger;
+
+	CommandParser *_command_parser;
 
 	bool restart_on_exit;
 	List<String> restart_commandline;
@@ -136,10 +138,14 @@ protected:
 	void _ensure_user_data_dir();
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
 
+	void delete_command_parser();
+
 public:
 	typedef int64_t ProcessID;
 
 	static OS *get_singleton();
+
+	CommandParser *get_command_parser() { return _command_parser; };
 
 	virtual void global_menu_add_item(const String &p_menu, const String &p_label, const Variant &p_signal, const Variant &p_meta){};
 	virtual void global_menu_add_separator(const String &p_menu){};
@@ -274,7 +280,8 @@ public:
 	virtual bool set_environment(const String &p_var, const String &p_value) const = 0;
 
 	virtual String get_name() const = 0;
-	virtual List<String> get_cmdline_args() const { return _cmdline; }
+	virtual List<String> get_cmdline_args() const { return _command_parser->get_args(); }
+	virtual List<String> get_project_args() const { return _command_parser->get_project_args(); }
 	virtual String get_model_name() const;
 
 	virtual MainLoop *get_main_loop() const = 0;

--- a/doc/classes/CommandFlag.xml
+++ b/doc/classes/CommandFlag.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CommandFlag" inherits="Reference" category="Core" version="3.2">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_object_checker">
+			<return type="void">
+			</return>
+			<argument index="0" name="obj" type="Object">
+			</argument>
+			<argument index="1" name="func" type="String">
+			</argument>
+			<argument index="2" name="err_msg" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="clear_checkers">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="needs_argument" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="set_data">
+			<return type="void">
+			</return>
+			<argument index="0" name="description" type="String">
+			</argument>
+			<argument index="1" name="category" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_flags">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="String">
+			</argument>
+			<argument index="1" name="short_flag" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="argument_name" type="String" setter="set_argument_name" getter="get_argument_name" default="&quot;&quot;">
+		</member>
+		<member name="category" type="String" setter="set_category" getter="get_category" default="&quot;&quot;">
+		</member>
+		<member name="description" type="String" setter="set_description" getter="get_description" default="&quot;&quot;">
+		</member>
+		<member name="flag" type="String" setter="set_flag" getter="get_flag" default="&quot;&quot;">
+		</member>
+		<member name="short_flag" type="String" setter="set_short_flag" getter="get_short_flag" default="&quot;&quot;">
+		</member>
+		<member name="show_in_help" type="bool" setter="set_show_in_help" getter="get_show_in_help" default="true">
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/CommandParser.xml
+++ b/doc/classes/CommandParser.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CommandParser" inherits="Object" category="Core" version="3.2">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_command">
+			<return type="void">
+			</return>
+			<argument index="0" name="command" type="CommandFlag">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="check_command_flag_collision" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="clear">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_argument" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="flag" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="has_project_defined" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="has_scene_defined" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="has_script_defined" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="has_shader_defined" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="is_argument_set" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="needs_argument" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="parse_arguments">
+			<return type="int" enum="Error">
+			</return>
+			<argument index="0" name="args" type="PoolStringArray">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="print_help" qualifiers="const">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="print_version" qualifiers="const">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="help_footer" type="String" setter="set_help_footer" getter="get_help_footer" default="&quot;&quot;">
+		</member>
+		<member name="help_header" type="String" setter="set_help_header" getter="get_help_header" default="&quot;&quot;">
+		</member>
+		<member name="search_project_file" type="bool" setter="set_search_project_file" getter="get_search_project_file" default="false">
+		</member>
+		<member name="version" type="String" setter="set_version" getter="get_version" default="&quot;&quot;">
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -65,6 +65,7 @@
 #include "scene/resources/packed_scene.h"
 #include "servers/arvr_server.h"
 #include "servers/audio_server.h"
+#include "servers/camera_server.h"
 #include "servers/physics_2d_server.h"
 #include "servers/physics_server.h"
 #include "servers/register_server_types.h"
@@ -97,52 +98,41 @@ static MessageQueue *message_queue = NULL;
 
 // Initialized in setup2()
 static AudioServer *audio_server = NULL;
+static CameraServer *camera_server = NULL;
 static ARVRServer *arvr_server = NULL;
 static PhysicsServer *physics_server = NULL;
 static Physics2DServer *physics_2d_server = NULL;
-// We error out if setup2() doesn't turn this true
-static bool _start_success = false;
+
+// Data only needed to initialize after the argument parsing
 
 // Drivers
-
 static int video_driver_idx = -1;
 static int audio_driver_idx = -1;
 
 // Engine config/tools
-
-static bool editor = false;
-static bool project_manager = false;
 static String locale;
-static bool show_help = false;
-static bool auto_quit = false;
 static OS::ProcessID allow_focus_steal_pid = 0;
 #ifdef TOOLS_ENABLED
 static bool auto_build_solutions = false;
 #endif
 
 // Display
-
 static OS::VideoMode video_mode;
+static Vector2 init_custom_pos;
 static int init_screen = -1;
 static bool init_fullscreen = false;
 static bool init_maximized = false;
 static bool init_windowed = false;
 static bool init_always_on_top = false;
 static bool init_use_custom_pos = false;
-static Vector2 init_custom_pos;
 static bool force_lowdpi = false;
 
 // Debug
-
-static bool use_debug_profiler = false;
 #ifdef DEBUG_ENABLED
 static bool debug_collisions = false;
 static bool debug_navigation = false;
 #endif
 static int frame_delay = 0;
-static bool disable_render_loop = false;
-static int fixed_fps = -1;
-static bool print_fps = false;
 
 /* Helper methods */
 
@@ -151,17 +141,6 @@ static bool print_fps = false;
 // but not if e.g. we fail to load and project and fallback to the manager.
 bool Main::is_project_manager() {
 	return project_manager;
-}
-
-static String unescape_cmdline(const String &p_str) {
-	return p_str.replace("%20", " ");
-}
-
-static String get_full_version_string() {
-	String hash = String(VERSION_HASH);
-	if (hash.length() != 0)
-		hash = "." + hash.left(9);
-	return String(VERSION_FULL_BUILD) + hash;
 }
 
 // FIXME: Could maybe be moved to PhysicsServerManager and Physics2DServerManager directly
@@ -201,106 +180,6 @@ void finalize_physics() {
 #define MAIN_PRINT(m_txt)
 #endif
 
-void Main::print_help(const char *p_binary) {
-
-	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
-	OS::get_singleton()->print("Free and open source software under the terms of the MIT license.\n");
-	OS::get_singleton()->print("(c) 2007-2019 Juan Linietsky, Ariel Manzur.\n");
-	OS::get_singleton()->print("(c) 2014-2019 Godot Engine contributors.\n");
-	OS::get_singleton()->print("\n");
-	OS::get_singleton()->print("Usage: %s [options] [path to scene or 'project.godot' file]\n", p_binary);
-	OS::get_singleton()->print("\n");
-
-	OS::get_singleton()->print("General options:\n");
-	OS::get_singleton()->print("  -h, --help                       Display this help message.\n");
-	OS::get_singleton()->print("  --version                        Display the version string.\n");
-	OS::get_singleton()->print("  -v, --verbose                    Use verbose stdout mode.\n");
-	OS::get_singleton()->print("  --quiet                          Quiet mode, silences stdout messages. Errors are still displayed.\n");
-	OS::get_singleton()->print("\n");
-
-	OS::get_singleton()->print("Run options:\n");
-#ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  -e, --editor                     Start the editor instead of running the scene.\n");
-	OS::get_singleton()->print("  -p, --project-manager            Start the project manager, even if a project is auto-detected.\n");
-#endif
-	OS::get_singleton()->print("  -q, --quit                       Quit after the first iteration.\n");
-	OS::get_singleton()->print("  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).\n");
-	OS::get_singleton()->print("  --path <directory>               Path to a project (<directory> must contain a 'project.godot' file).\n");
-	OS::get_singleton()->print("  -u, --upwards                    Scan folders upwards for project.godot file.\n");
-	OS::get_singleton()->print("  --main-pack <file>               Path to a pack (.pck) file to load.\n");
-	OS::get_singleton()->print("  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').\n");
-	OS::get_singleton()->print("  --remote-fs <address>            Remote filesystem (<host/IP>[:<port>] address).\n");
-	OS::get_singleton()->print("  --remote-fs-password <password>  Password for remote filesystem.\n");
-	OS::get_singleton()->print("  --audio-driver <driver>          Audio driver (");
-	for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {
-		if (i != 0)
-			OS::get_singleton()->print(", ");
-		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_audio_driver_name(i));
-	}
-	OS::get_singleton()->print(").\n");
-	OS::get_singleton()->print("  --video-driver <driver>          Video driver (");
-	for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
-		if (i != 0)
-			OS::get_singleton()->print(", ");
-		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_video_driver_name(i));
-	}
-	OS::get_singleton()->print(").\n");
-	OS::get_singleton()->print("\n");
-
-#ifndef SERVER_ENABLED
-	OS::get_singleton()->print("Display options:\n");
-	OS::get_singleton()->print("  -f, --fullscreen                 Request fullscreen mode.\n");
-	OS::get_singleton()->print("  -m, --maximized                  Request a maximized window.\n");
-	OS::get_singleton()->print("  -w, --windowed                   Request windowed mode.\n");
-	OS::get_singleton()->print("  -t, --always-on-top              Request an always-on-top window.\n");
-	OS::get_singleton()->print("  --resolution <W>x<H>             Request window resolution.\n");
-	OS::get_singleton()->print("  --position <X>,<Y>               Request window position.\n");
-	OS::get_singleton()->print("  --low-dpi                        Force low-DPI mode (macOS and Windows only).\n");
-	OS::get_singleton()->print("  --no-window                      Disable window creation (Windows only). Useful together with --script.\n");
-	OS::get_singleton()->print("\n");
-#endif
-
-	OS::get_singleton()->print("Debug options:\n");
-	OS::get_singleton()->print("  -d, --debug                      Debug (local stdout debugger).\n");
-	OS::get_singleton()->print("  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
-	OS::get_singleton()->print("  --profiling                      Enable profiling in the script debugger.\n");
-	OS::get_singleton()->print("  --remote-debug <address>         Remote debug (<host/IP>:<port> address).\n");
-#if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
-	OS::get_singleton()->print("  --debug-collisions               Show collision shapes when running the scene.\n");
-	OS::get_singleton()->print("  --debug-navigation               Show navigation polygons when running the scene.\n");
-#endif
-	OS::get_singleton()->print("  --frame-delay <ms>               Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
-	OS::get_singleton()->print("  --time-scale <scale>             Force time scale (higher values are faster, 1.0 is normal speed).\n");
-	OS::get_singleton()->print("  --disable-render-loop            Disable render loop so rendering only occurs when called explicitly from script.\n");
-	OS::get_singleton()->print("  --disable-crash-handler          Disable crash handler when supported by the platform code.\n");
-	OS::get_singleton()->print("  --fixed-fps <fps>                Force a fixed number of frames per second. This setting disables real-time synchronization.\n");
-	OS::get_singleton()->print("  --print-fps                      Print the frames per second to the stdout.\n");
-	OS::get_singleton()->print("\n");
-
-	OS::get_singleton()->print("Standalone tools:\n");
-	OS::get_singleton()->print("  -s, --script <script>            Run a script.\n");
-	OS::get_singleton()->print("  --check-only                     Only parse for errors and quit (use with --script).\n");
-#ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  --export <target>                Export the project using the given export target. Export only main pack if path ends with .pck or .zip.\n");
-	OS::get_singleton()->print("  --export-debug <target>          Like --export, but use debug template.\n");
-	OS::get_singleton()->print("  --doctool <path>                 Dump the engine API reference to the given <path> in XML format, merging if existing files are found.\n");
-	OS::get_singleton()->print("  --no-docbase                     Disallow dumping the base types (used with --doctool).\n");
-	OS::get_singleton()->print("  --build-solutions                Build the scripting solutions (e.g. for C# projects).\n");
-#ifdef DEBUG_METHODS_ENABLED
-	OS::get_singleton()->print("  --gdnative-generate-json-api     Generate JSON dump of the Godot API for GDNative bindings.\n");
-#endif
-	OS::get_singleton()->print("  --test <test>                    Run a unit test (");
-	const char **test_names = tests_get_names();
-	const char *comma = "";
-	while (*test_names) {
-		OS::get_singleton()->print("%s'%s'", comma, *test_names);
-		test_names++;
-		comma = ", ";
-	}
-	OS::get_singleton()->print(").\n");
-#endif
-}
-
 /* Engine initialization
  *
  * Consists of several methods that are called by each platform's specific main(argc, argv).
@@ -323,8 +202,6 @@ void Main::print_help(const char *p_binary) {
  * - start() is the last step and that's where command line tools can run, or the main loop
  *   can be created eventually and the project settings put into action. That's also where
  *   the editor node is created, if relevant.
- *   start() does it own argument parsing for a subset of the command line arguments described
- *   in help, it's a bit messy and should be globalized with the setup() parsing somehow.
  */
 
 Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_phase) {
@@ -359,36 +236,27 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	MAIN_PRINT("Main: Parse CMDLine");
 
+	OS::get_singleton()->_command_parser = memnew(CommandParser);
+	ClassDB::register_class<CommandParser>();
+	ClassDB::register_class<CommandFlag>();
 	/* argument parsing and main creation */
 	List<String> args;
-	List<String> main_args;
-
+	// Save cmd args
 	for (int i = 0; i < argc; i++) {
-
 		args.push_back(String::utf8(argv[i]));
 	}
+	OS::get_singleton()->set_cmdline(execpath, args);
 
-	List<String>::Element *I = args.front();
-
-	I = args.front();
-
-	while (I) {
-
-		I->get() = unescape_cmdline(I->get().strip_edges());
-		I = I->next();
-	}
-
-	I = args.front();
-
-	String video_driver = "";
-	String audio_driver = "";
-	String project_path = ".";
-	bool upwards = false;
-	String debug_mode;
-	String debug_host;
-	bool skip_breakpoints = false;
+	String video_driver;
+	String audio_driver;
 	String main_pack;
 	bool quiet_stdout = false;
+	bool upwards = false;
+	bool skip_breakpoints = false;
+
+	String project_path = ".";
+	String debug_mode;
+	String debug_host;
 	int rtm = -1;
 
 	String remotefs;
@@ -417,387 +285,267 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	packed_data->add_pack_source(zip_packed_data);
 #endif
 
-	I = args.front();
-	while (I) {
-
-		List<String>::Element *N = I->next();
-
-		if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
-
-			show_help = true;
-			goto error;
-
-		} else if (I->get() == "--version") {
-
-			print_line(get_full_version_string());
-			goto error;
-
-		} else if (I->get() == "-v" || I->get() == "--verbose") { // verbose output
-
-			OS::get_singleton()->_verbose_stdout = true;
-		} else if (I->get() == "--quiet") { // quieter output
-
-			quiet_stdout = true;
-
-		} else if (I->get() == "--audio-driver") { // audio driver
-
-			if (I->next()) {
-
-				audio_driver = I->next()->get();
-
-				bool found = false;
-				for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {
-					if (audio_driver == OS::get_singleton()->get_audio_driver_name(i)) {
-						found = true;
-					}
-				}
-
-				if (!found) {
-					OS::get_singleton()->print("Unknown audio driver '%s', aborting.\nValid options are ", audio_driver.utf8().get_data());
-
-					for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {
-						if (i == OS::get_singleton()->get_audio_driver_count() - 1) {
-							OS::get_singleton()->print(" and ");
-						} else if (i != 0) {
-							OS::get_singleton()->print(", ");
-						}
-
-						OS::get_singleton()->print("'%s'", OS::get_singleton()->get_audio_driver_name(i));
-					}
-
-					OS::get_singleton()->print(".\n");
-
-					goto error;
-				}
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing audio driver argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--video-driver") { // force video driver
-
-			if (I->next()) {
-
-				video_driver = I->next()->get();
-
-				bool found = false;
-				for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
-					if (video_driver == OS::get_singleton()->get_video_driver_name(i)) {
-						found = true;
-					}
-				}
-
-				if (!found) {
-					OS::get_singleton()->print("Unknown video driver '%s', aborting.\nValid options are ", video_driver.utf8().get_data());
-
-					for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
-						if (i == OS::get_singleton()->get_video_driver_count() - 1) {
-							OS::get_singleton()->print(" and ");
-						} else if (i != 0) {
-							OS::get_singleton()->print(", ");
-						}
-
-						OS::get_singleton()->print("'%s'", OS::get_singleton()->get_video_driver_name(i));
-					}
-
-					OS::get_singleton()->print(".\n");
-
-					goto error;
-				}
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing video driver argument, aborting.\n");
-				goto error;
-			}
-#ifndef SERVER_ENABLED
-		} else if (I->get() == "-f" || I->get() == "--fullscreen") { // force fullscreen
-
-			init_fullscreen = true;
-		} else if (I->get() == "-m" || I->get() == "--maximized") { // force maximized window
-
-			init_maximized = true;
-			video_mode.maximized = true;
-
-		} else if (I->get() == "-w" || I->get() == "--windowed") { // force windowed window
-
-			init_windowed = true;
-		} else if (I->get() == "-t" || I->get() == "--always-on-top") { // force always-on-top window
-
-			init_always_on_top = true;
-		} else if (I->get() == "--resolution") { // force resolution
-
-			if (I->next()) {
-
-				String vm = I->next()->get();
-
-				if (vm.find("x") == -1) { // invalid parameter format
-
-					OS::get_singleton()->print("Invalid resolution '%s', it should be e.g. '1280x720'.\n", vm.utf8().get_data());
-					goto error;
-				}
-
-				int w = vm.get_slice("x", 0).to_int();
-				int h = vm.get_slice("x", 1).to_int();
-
-				if (w <= 0 || h <= 0) {
-
-					OS::get_singleton()->print("Invalid resolution '%s', width and height must be above 0.\n", vm.utf8().get_data());
-					goto error;
-				}
-
-				video_mode.width = w;
-				video_mode.height = h;
-				force_res = true;
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing resolution argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--position") { // set window position
-
-			if (I->next()) {
-
-				String vm = I->next()->get();
-
-				if (vm.find(",") == -1) { // invalid parameter format
-
-					OS::get_singleton()->print("Invalid position '%s', it should be e.g. '80,128'.\n", vm.utf8().get_data());
-					goto error;
-				}
-
-				int x = vm.get_slice(",", 0).to_int();
-				int y = vm.get_slice(",", 1).to_int();
-
-				init_custom_pos = Point2(x, y);
-				init_use_custom_pos = true;
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing position argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--low-dpi") { // force low DPI (macOS only)
-
-			force_lowdpi = true;
-		} else if (I->get() == "--no-window") { // disable window creation (Windows only)
-
-			OS::get_singleton()->set_no_window_mode(true);
-#endif
-		} else if (I->get() == "--profiling") { // enable profiling
-
-			use_debug_profiler = true;
-
-		} else if (I->get() == "-l" || I->get() == "--language") { // language
-
-			if (I->next()) {
-
-				locale = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing language argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--remote-fs") { // remote filesystem
-
-			if (I->next()) {
-
-				remotefs = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing remote filesystem address, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--remote-fs-password") { // remote filesystem password
-
-			if (I->next()) {
-
-				remotefs_pass = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing remote filesystem password, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--render-thread") { // render thread mode
-
-			if (I->next()) {
-
-				if (I->next()->get() == "safe")
-					rtm = OS::RENDER_THREAD_SAFE;
-				else if (I->next()->get() == "unsafe")
-					rtm = OS::RENDER_THREAD_UNSAFE;
-				else if (I->next()->get() == "separate")
-					rtm = OS::RENDER_SEPARATE_THREAD;
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing render thread mode argument, aborting.\n");
-				goto error;
-			}
-#ifdef TOOLS_ENABLED
-		} else if (I->get() == "-e" || I->get() == "--editor") { // starts editor
-
-			editor = true;
-		} else if (I->get() == "-p" || I->get() == "--project-manager") { // starts project manager
-
-			project_manager = true;
-		} else if (I->get() == "--build-solutions") { // Build the scripting solution such C#
-
-			auto_build_solutions = true;
-			editor = true;
-#ifdef DEBUG_METHODS_ENABLED
-		} else if (I->get() == "--gdnative-generate-json-api") {
-			// Register as an editor instance to use the GLES2 fallback automatically on hardware that doesn't support the GLES3 backend
-			editor = true;
-
-			// We still pass it to the main arguments since the argument handling itself is not done in this function
-			main_args.push_back(I->get());
-#endif
-		} else if (I->get() == "--export" || I->get() == "--export-debug") { // Export project
-
-			editor = true;
-			main_args.push_back(I->get());
-#endif
-		} else if (I->get() == "--path") { // set path of project to start or edit
-
-			if (I->next()) {
-
-				String p = I->next()->get();
-				if (OS::get_singleton()->set_cwd(p) == OK) {
-					//nothing
-				} else {
-					project_path = I->next()->get(); //use project_path instead
-				}
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing relative or absolute path, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "-u" || I->get() == "--upwards") { // scan folders upwards
-			upwards = true;
-		} else if (I->get() == "-q" || I->get() == "--quit") { // Auto quit at the end of the first main loop iteration
-			auto_quit = true;
-		} else if (I->get().ends_with("project.godot")) {
-			String path;
-			String file = I->get();
-			int sep = MAX(file.find_last("/"), file.find_last("\\"));
-			if (sep == -1)
-				path = ".";
-			else {
-				path = file.substr(0, sep);
-			}
-			if (OS::get_singleton()->set_cwd(path) == OK) {
-				// path already specified, don't override
-			} else {
-				project_path = path;
-			}
-#ifdef TOOLS_ENABLED
-			editor = true;
-#endif
-		} else if (I->get() == "-b" || I->get() == "--breakpoints") { // add breakpoints
-
-			if (I->next()) {
-
-				String bplist = I->next()->get();
-				breakpoints = bplist.split(",");
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing list of breakpoints, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--frame-delay") { // force frame delay
-
-			if (I->next()) {
-
-				frame_delay = I->next()->get().to_int();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing frame delay argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--time-scale") { // force time scale
-
-			if (I->next()) {
-
-				Engine::get_singleton()->set_time_scale(I->next()->get().to_double());
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing time scale argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--main-pack") {
-
-			if (I->next()) {
-
-				main_pack = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing path to main pack file, aborting.\n");
-				goto error;
-			};
-
-		} else if (I->get() == "-d" || I->get() == "--debug") {
-			debug_mode = "local";
-#if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
-		} else if (I->get() == "--debug-collisions") {
-			debug_collisions = true;
-		} else if (I->get() == "--debug-navigation") {
-			debug_navigation = true;
-#endif
-		} else if (I->get() == "--remote-debug") {
-			if (I->next()) {
-
-				debug_mode = "remote";
-				debug_host = I->next()->get();
-				if (debug_host.find(":") == -1) { // wrong address
-					OS::get_singleton()->print("Invalid debug host address, it should be of the form <host/IP>:<port>.\n");
-					goto error;
-				}
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing remote debug host address, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--allow_focus_steal_pid") { // not exposed to user
-			if (I->next()) {
-
-				allow_focus_steal_pid = I->next()->get().to_int64();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--disable-render-loop") {
-			disable_render_loop = true;
-		} else if (I->get() == "--fixed-fps") {
-			if (I->next()) {
-				fixed_fps = I->next()->get().to_int();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing fixed-fps argument, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--print-fps") {
-			print_fps = true;
-		} else if (I->get() == "--disable-crash-handler") {
-			OS::get_singleton()->disable_crash_handler();
-		} else if (I->get() == "--skip-breakpoints") {
-			skip_breakpoints = true;
-		} else {
-			main_args.push_back(I->get());
-		}
-
-		I = N;
+	CommandParser *cli_parser = OS::get_singleton()->get_command_parser();
+	cli_parser->init_engine_defaults();
+	Error parse_err = cli_parser->parse();
+
+	if (parse_err) {
+		goto error;
 	}
+
+	if (cli_parser->is_argument_set("--help")) { // display help
+
+		cli_parser->print_help();
+		goto error;
+	}
+	if (cli_parser->is_argument_set("--version")) {
+
+		cli_parser->print_version();
+		goto error;
+	}
+
+	if (cli_parser->is_argument_set("--print-fps")) {
+
+		print_fps = true;
+	}
+	if (cli_parser->is_argument_set("--windowed")) { // force windowed window
+
+		init_windowed = true;
+	}
+	if (cli_parser->is_argument_set("--always-on-top")) { // force always-on-top window
+
+		init_always_on_top = true;
+	}
+	if (cli_parser->is_argument_set("--profiling")) { // enable profiling
+
+		use_debug_profiler = true;
+	}
+	if (cli_parser->is_argument_set("--low-dpi")) { // force low DPI (macOS only)
+
+		force_lowdpi = true;
+	}
+	if (cli_parser->is_argument_set("--upwards")) { // scan folders upwards
+
+		upwards = true;
+	}
+	if (cli_parser->is_argument_set("--video-driver")) { // force video driver
+
+		video_driver = cli_parser->get_argument("--video-driver");
+	}
+	if (cli_parser->is_argument_set("--language")) { // language
+
+		locale = cli_parser->get_argument("--language");
+	}
+	if (cli_parser->is_argument_set("--script")) {
+
+		script = cli_parser->get_argument("--script");
+	}
+	if (cli_parser->is_argument_set("--check-only")) {
+
+		check_only = true;
+	}
+	if (cli_parser->is_argument_set("--disable-render-loop")) {
+
+		disable_render_loop = true;
+	}
+	if (cli_parser->is_argument_set("--test")) {
+
+		test = cli_parser->get_argument("--test");
+	}
+	if (cli_parser->is_argument_set("--no-docbase")) {
+
+		doc_base = !cli_parser->is_argument_set("--no-docbase");
+	}
+	if (cli_parser->is_argument_set("--video-driver")) {
+
+		video_driver = cli_parser->get_argument("--video-driver");
+	}
+	if (cli_parser->is_argument_set("--audio-driver")) {
+
+		audio_driver = cli_parser->get_argument("--audio-driver");
+	}
+	if (cli_parser->is_argument_set("--main-pack")) {
+
+		main_pack = cli_parser->get_argument("--main-pack");
+	}
+	if (cli_parser->is_argument_set("--quiet")) {
+
+		quiet_stdout = true;
+	}
+	if (cli_parser->is_argument_set("--upwards")) {
+
+		upwards = true;
+	}
+	if (cli_parser->is_argument_set("--remote-fs")) {
+
+		remotefs = cli_parser->get_argument("--remote-fs");
+	}
+	if (cli_parser->is_argument_set("--remote-fs-password")) {
+
+		remotefs_pass = cli_parser->get_argument("--remote-fs-password");
+	}
+	if (cli_parser->is_argument_set("--resolution")) { // force resolution
+
+		String vm = cli_parser->get_argument("--resolution");
+
+		int w = vm.get_slice("x", 0).to_int();
+		int h = vm.get_slice("x", 1).to_int();
+
+		video_mode.width = w;
+		video_mode.height = h;
+		force_res = true;
+	}
+	if (cli_parser->is_argument_set("--position")) { // set window position
+
+		String vm = cli_parser->get_argument("--position");
+
+		int x = vm.get_slice(",", 0).to_int();
+		int y = vm.get_slice(",", 1).to_int();
+
+		init_custom_pos = Point2(x, y);
+		init_use_custom_pos = true;
+	}
+	if (cli_parser->is_argument_set("--maximized")) { // force maximized window
+
+		init_maximized = true;
+		video_mode.maximized = true;
+	}
+	if (cli_parser->is_argument_set("--render-thread")) { // render thread mode
+
+		String rtm_str = cli_parser->get_argument("--render-thread");
+		if (rtm_str == "safe")
+			rtm = OS::RENDER_THREAD_SAFE;
+		else if (rtm_str == "unsafe")
+			rtm = OS::RENDER_THREAD_UNSAFE;
+		else if (rtm_str == "separate")
+			rtm = OS::RENDER_SEPARATE_THREAD;
+	}
+	if (cli_parser->is_argument_set("--fullscreen")) { // force fullscreen
+
+		//video_mode.fullscreen=false;
+		init_fullscreen = true;
+	}
+#ifdef TOOLS_ENABLED
+	if (cli_parser->is_argument_set("--editor")) { // starts editor
+		editor = true;
+	}
+	if (cli_parser->is_argument_set("--project-manager")) { // starts project manager
+		project_manager = true;
+	}
+#ifdef DEBUG_METHODS_ENABLED
+	if (cli_parser->is_argument_set("--gdnative-generate-json-api")) {
+		// Register as an editor instance to use the GLES2 fallback automatically on hardware that doesn't support the GLES3 backend
+		editor = true;
+	}
+#endif
+
+	if (cli_parser->is_argument_set("--build-solutions")) { // Build the scripting solution such C#
+
+		auto_build_solutions = true;
+		editor = true;
+	}
+#endif
+	if (cli_parser->is_argument_set("--no-window")) { // disable window creation, Windows only
+
+		OS::get_singleton()->set_no_window_mode(true);
+	}
+	if (cli_parser->is_argument_set("--verbose")) { // verbose output
+
+		OS::get_singleton()->_verbose_stdout = true;
+	}
+	if (cli_parser->is_argument_set("--path")) { // set path of project to start or edit
+
+		String p = cli_parser->get_argument("--path");
+		if (OS::get_singleton()->set_cwd(p) != OK) {
+			project_path = p; //use project_path instead
+		}
+	}
+	if (cli_parser->is_argument_set("--quit")) { // Auto quit at the end of the first main loop iteration
+		auto_quit = true;
+	}
+	if (cli_parser->has_project_defined()) {
+		String path;
+		String file = cli_parser->get_defined_project_file();
+
+		int sep = MAX(file.find_last("/"), file.find_last("\\"));
+		if (sep == -1)
+			path = ".";
+		else {
+			path = file.substr(0, sep);
+		}
+		if (OS::get_singleton()->set_cwd(path) == OK) {
+			// path already specified, don't override
+		} else {
+			project_path = path;
+		}
+#ifdef TOOLS_ENABLED
+		editor = true;
+#endif
+	}
+	if (cli_parser->has_scene_defined()) {
+
+		game_path = cli_parser->get_defined_project_file();
+	}
+	if (cli_parser->is_argument_set("--breakpoints")) { // add breakpoints
+
+		String bplist = cli_parser->get_argument("--breakpoints");
+		breakpoints = bplist.split(",");
+	}
+	if (cli_parser->is_argument_set("--frame-delay")) { // force frame delay
+
+		frame_delay = cli_parser->get_argument("--frame-delay").to_int();
+	}
+	if (cli_parser->is_argument_set("--time-scale")) { // force time scale
+
+		Engine::get_singleton()->set_time_scale(cli_parser->get_argument("--time-scale").to_double());
+	}
+	if (cli_parser->is_argument_set("--debug")) {
+		debug_mode = "local";
+	}
+#ifdef DEBUG_ENABLED
+	if (cli_parser->is_argument_set("--debug-collisions")) {
+		debug_collisions = true;
+	}
+	if (cli_parser->is_argument_set("--debug-navigation")) {
+		debug_navigation = true;
+	}
+#endif
+	if (cli_parser->is_argument_set("--remote-debug")) {
+
+		debug_mode = "remote";
+		debug_host = cli_parser->get_argument("--remote-debug");
+	}
+	if (cli_parser->is_argument_set("--allow_focus_steal_pid")) {
+
+		allow_focus_steal_pid = cli_parser->get_argument("--allow_focus_steal_pid").to_int64();
+	}
+	if (cli_parser->is_argument_set("--fixed-fps")) {
+
+		fixed_fps = cli_parser->get_argument("--fixed-fps").to_int();
+	}
+	if (cli_parser->is_argument_set("--disable-crash-handler")) {
+
+		OS::get_singleton()->disable_crash_handler();
+	}
+	if (cli_parser->is_argument_set("--skip-breakpoints")) {
+		skip_breakpoints = true;
+	}
+#ifdef TOOLS_ENABLED
+	if (cli_parser->is_argument_set("--doctool")) {
+		doc_tool = cli_parser->get_argument("--doctool");
+	}
+	if (cli_parser->is_argument_set("--export")) {
+		editor = true; //needs editor
+		_export_preset = cli_parser->get_argument("--export");
+		game_path = cli_parser->get_defined_project_file();
+	}
+	if (cli_parser->is_argument_set("--export-debug")) {
+		editor = true; //needs editor
+		_export_preset = cli_parser->get_argument("--export-debug");
+		export_debug = true;
+		game_path = cli_parser->get_defined_project_file();
+	}
+#endif
 
 	// Network file system needs to be configured before globals, since globals are based on the
 	// 'project.godot' file which will only be available through the network if this is enabled
@@ -907,7 +655,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 	if (editor) {
 		Engine::get_singleton()->set_editor_hint(true);
-		main_args.push_back("--editor");
 		if (!init_windowed) {
 			init_maximized = true;
 			video_mode.maximized = true;
@@ -916,11 +663,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (!project_manager) {
 		// Determine if the project manager should be requested
-		project_manager = main_args.size() == 0 && !found_project;
+		project_manager = !found_project && game_path.empty();
 	}
 #endif
 
-	if (main_args.size() == 0 && String(GLOBAL_DEF("application/run/main_scene", "")) == "") {
+	if (String(GLOBAL_DEF("application/run/main_scene", "")) == "" && game_path == "") {
 #ifdef TOOLS_ENABLED
 		if (!editor && !project_manager) {
 #endif
@@ -948,8 +695,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (quiet_stdout)
 		_print_line_enabled = false;
-
-	OS::get_singleton()->set_cmdline(execpath, main_args);
 
 	GLOBAL_DEF("rendering/quality/driver/driver_name", "GLES3");
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/driver/driver_name", PropertyInfo(Variant::STRING, "rendering/quality/driver/driver_name", PROPERTY_HINT_ENUM, "GLES2,GLES3"));
@@ -1007,6 +752,19 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	video_mode.use_vsync = GLOBAL_DEF_RST("display/window/vsync/use_vsync", true);
 	OS::get_singleton()->_use_vsync = video_mode.use_vsync;
 
+	if (cli_parser->is_argument_set("--enable-vsync-via-compositor")) {
+		video_mode.vsync_via_compositor = true;
+	} else if (cli_parser->is_argument_set("--disable-vsync-via-compositor")) {
+		video_mode.vsync_via_compositor = false;
+	} else {
+		// If one of the command line options to enable/disable vsync via the
+		// window compositor ("--enable-vsync-via-compositor" or
+		// "--disable-vsync-via-compositor") was present then it overrides the
+		// project setting.
+		video_mode.vsync_via_compositor = GLOBAL_DEF("display/window/vsync/vsync_via_compositor", false);
+	}
+	OS::get_singleton()->_vsync_via_compositor = video_mode.vsync_via_compositor;
+
 	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);
 	video_mode.layered = GLOBAL_DEF("display/window/per_pixel_transparency/enabled", false);
 
@@ -1044,7 +802,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (video_driver_idx < 0) {
+
+		//OS::get_singleton()->alert("Invalid Video Driver: " + video_driver);
 		video_driver_idx = 0;
+		//goto error;
 	}
 
 	if (audio_driver == "") { // specified in project.godot
@@ -1061,7 +822,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (audio_driver_idx < 0) {
+
+		OS::get_singleton()->alert("Invalid Audio Driver: " + audio_driver);
 		audio_driver_idx = 0;
+		//goto error;
 	}
 
 	{
@@ -1118,12 +882,6 @@ error:
 	audio_driver = "";
 	project_path = "";
 
-	args.clear();
-	main_args.clear();
-
-	if (show_help)
-		print_help(execpath);
-
 	if (performance)
 		memdelete(performance);
 	if (input_map)
@@ -1141,10 +899,10 @@ error:
 	if (file_access_network_client)
 		memdelete(file_access_network_client);
 
+	OS::get_singleton()->delete_command_parser();
+
 	unregister_core_driver_types();
 	unregister_core_types();
-
-	OS::get_singleton()->_cmdline.clear();
 
 	if (message_queue)
 		memdelete(message_queue);
@@ -1157,7 +915,7 @@ error:
 Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	// Print engine name and version
-	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
+	print_line(String(VERSION_NAME) + " v" + OS::get_singleton()->get_command_parser()->get_version() + " - " + String(VERSION_WEBSITE));
 
 	if (p_main_tid_override) {
 		Thread::_main_thread_id = p_main_tid_override;
@@ -1318,6 +1076,8 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	register_platform_apis();
 	register_module_types();
 
+	camera_server = CameraServer::create();
+
 	initialize_physics();
 	register_server_singletons();
 
@@ -1363,65 +1123,8 @@ bool Main::start() {
 	ERR_FAIL_COND_V(!_start_success, false);
 
 	bool hasicon = false;
-	String doc_tool;
-	List<String> removal_docs;
-#ifdef TOOLS_ENABLED
-	bool doc_base = true;
-#endif
-	String game_path;
-	String script;
-	String test;
-	String _export_preset;
-	bool export_debug = false;
-	bool check_only = false;
 
 	main_timer_sync.init(OS::get_singleton()->get_ticks_usec());
-
-	List<String> args = OS::get_singleton()->get_cmdline_args();
-	for (int i = 0; i < args.size(); i++) {
-		//parameters that do not have an argument to the right
-		if (args[i] == "--check-only") {
-			check_only = true;
-#ifdef TOOLS_ENABLED
-		} else if (args[i] == "--no-docbase") {
-			doc_base = false;
-		} else if (args[i] == "-e" || args[i] == "--editor") {
-			editor = true;
-		} else if (args[i] == "-p" || args[i] == "--project-manager") {
-			project_manager = true;
-#endif
-		} else if (args[i].length() && args[i][0] != '-' && game_path == "") {
-			game_path = args[i];
-		}
-		//parameters that have an argument to the right
-		else if (i < (args.size() - 1)) {
-			bool parsed_pair = true;
-			if (args[i] == "-s" || args[i] == "--script") {
-				script = args[i + 1];
-			} else if (args[i] == "--test") {
-				test = args[i + 1];
-#ifdef TOOLS_ENABLED
-			} else if (args[i] == "--doctool") {
-				doc_tool = args[i + 1];
-				for (int j = i + 2; j < args.size(); j++)
-					removal_docs.push_back(args[j]);
-			} else if (args[i] == "--export") {
-				editor = true; //needs editor
-				_export_preset = args[i + 1];
-			} else if (args[i] == "--export-debug") {
-				editor = true; //needs editor
-				_export_preset = args[i + 1];
-				export_debug = true;
-#endif
-			} else {
-				// The parameter does not match anything known, don't skip the next argument
-				parsed_pair = false;
-			}
-			if (parsed_pair) {
-				i++;
-			}
-		}
-	}
 
 	String main_loop_type;
 #ifdef TOOLS_ENABLED
@@ -1505,10 +1208,11 @@ bool Main::start() {
 
 	if (test != "") {
 #ifdef TOOLS_ENABLED
-		main_loop = test_main(test, args);
+		main_loop = test_main(test, OS::get_singleton()->get_cmdline_args());
 
 		if (!main_loop)
 			return false;
+
 #endif
 
 	} else if (script != "") {
@@ -1517,6 +1221,9 @@ bool Main::start() {
 		ERR_FAIL_COND_V_MSG(script_res.is_null(), false, "Can't load script: " + script);
 
 		if (check_only) {
+			if (!script_res->is_valid()) {
+				OS::get_singleton()->set_exit_code(1);
+			}
 			return false;
 		}
 
@@ -1861,7 +1568,7 @@ bool Main::start() {
 			bool hide_console = EditorSettings::get_singleton()->get_setting("interface/editor/hide_console_window");
 			OS::get_singleton()->set_console_visible(!hide_console);
 
-			// Load SSL Certificates from Editor Settings (or builtin)
+			// Load SSL Certificates from Editor Settings (or builtin).
 			Crypto::load_default_certificates(EditorSettings::get_singleton()->get_setting("network/ssl/editor_ssl_certificates").operator String());
 		}
 #endif
@@ -1893,6 +1600,25 @@ uint32_t Main::frames = 0;
 uint32_t Main::frame = 0;
 bool Main::force_redraw_requested = false;
 int Main::iterating = 0;
+
+bool Main::_start_success = false;
+bool Main::project_manager = false;
+bool Main::editor = false;
+bool Main::use_debug_profiler = false;
+bool Main::disable_render_loop = false;
+bool Main::print_fps = false;
+bool Main::auto_quit = false;
+int Main::fixed_fps = -1;
+
+bool Main::doc_base = true;
+bool Main::export_debug = false;
+bool Main::check_only = false;
+String Main::doc_tool = "";
+String Main::game_path = "";
+String Main::script = "";
+String Main::test = "";
+String Main::_export_preset = "";
+
 bool Main::is_iterating() {
 	return iterating > 0;
 }
@@ -2087,6 +1813,11 @@ void Main::cleanup() {
 
 	ERR_FAIL_COND(!_start_success);
 
+	if (script_debugger) {
+		// Flush any remaining messages
+		script_debugger->idle_poll();
+	}
+
 	ResourceLoader::remove_custom_loaders();
 	ResourceSaver::remove_custom_savers();
 
@@ -2103,7 +1834,7 @@ void Main::cleanup() {
 
 	OS::get_singleton()->delete_main_loop();
 
-	OS::get_singleton()->_cmdline.clear();
+	OS::get_singleton()->delete_command_parser();
 	OS::get_singleton()->_execpath = "";
 	OS::get_singleton()->_local_clipboard = "";
 
@@ -2132,6 +1863,10 @@ void Main::cleanup() {
 	if (audio_server) {
 		audio_server->finish();
 		memdelete(audio_server);
+	}
+
+	if (camera_server) {
+		memdelete(camera_server);
 	}
 
 	OS::get_singleton()->finalize();

--- a/main/main.h
+++ b/main/main.h
@@ -45,6 +45,25 @@ class Main {
 	static bool force_redraw_requested;
 	static int iterating;
 
+	// Auxiliar variables
+	static int fixed_fps;
+	static bool project_manager;
+	static bool editor;
+	static bool use_debug_profiler;
+	static bool disable_render_loop;
+	static bool print_fps;
+	static bool auto_quit;
+	static bool _start_success; // We error out if setup2() doesn't turn this true
+
+	static bool doc_base;
+	static bool export_debug;
+	static bool check_only;
+	static String doc_tool;
+	static String game_path;
+	static String script;
+	static String test;
+	static String _export_preset;
+
 public:
 	static bool is_project_manager();
 


### PR DESCRIPTION
Initial work for https://github.com/godotengine/godot/issues/20000

Proposal: https://github.com/godotengine/godot-proposals/issues/137

The parser is pretty simple. We have the class `CommandFlag` which represents a single commands and its properties (the code is self explanatory). The class `CommandParser` contains the list of `CommandFlag` and process the arguments in the `parse` method.
The method `init_defaults` adds all the commands of the engine.
With a centralised point with all the data of the commands  the --help can be generated dynamically. This has some advantages such as proper alignment of descriptions based on the largest line, and even splitting the lines if they exceed the 80 characters.

Engine arguments and project arguments are separated by a -- as it was suggested in the issue:
godot --godot-command -- project-command 333 4

TODO:
- [x] Implement a way to add `CommandFlag` checkers from gdscript.
- [x] Method name cleanup.
- [ ] Decide about List vs Vector internal storage.
- [ ] Add class documentation.