### PR TITLE
ColorPicker: Properties to toggle the editability and visibility of presets

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -295,10 +295,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	/* Interface */
 
-	// Color Picker
-	_initial_set("interface/color_picker/presets_visible", true);
-	_initial_set("interface/color_picker/presets_editable", true);
-
 	// Editor
 	_initial_set("interface/editor/display_scale", 0);
 	hints["interface/editor/display_scale"] = PropertyInfo(Variant::INT, "interface/editor/display_scale", PROPERTY_HINT_ENUM, "Auto,75%,100%,125%,150%,175%,200%,Custom", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -295,6 +295,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	/* Interface */
 
+	// Color Picker
+	_initial_set("interface/color_picker/presets_visible", true);
+	_initial_set("interface/color_picker/presets_editable", true);
+
 	// Editor
 	_initial_set("interface/editor/display_scale", 0);
 	hints["interface/editor/display_scale"] = PropertyInfo(Variant::INT, "interface/editor/display_scale", PROPERTY_HINT_ENUM, "Auto,75%,100%,125%,150%,175%,200%,Custom", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);

--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -209,7 +209,7 @@ Error AudioDriverJavaScript::capture_start() {
 		}
 
 		function gotMediaInputError(e) {
-			console.log(e);
+			out(e);
 		}
 
 		if (navigator.mediaDevices.getUserMedia) {

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -129,10 +129,6 @@ def configure(env):
     # us since we don't know requirements at compile-time.
     env.Append(LINKFLAGS=['-s', 'ALLOW_MEMORY_GROWTH=1'])
 
-    # Since we use both memory growth and MEMFS preloading,
-    # this avoids unnecessary copying on start-up.
-    env.Append(LINKFLAGS=['--no-heap-copy'])
-
     # This setting just makes WebGL 2 APIs available, it does NOT disable WebGL 1.
     env.Append(LINKFLAGS=['-s', 'USE_WEBGL2=1'])
 

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -199,7 +199,8 @@
 					}
 					LIBS.FS.mkdirTree(dir);
 				}
-				LIBS.FS.createDataFile('/', file.path, new Uint8Array(file.buffer), true, true, true);
+				// With memory growth, canOwn should be false.
+				LIBS.FS.createDataFile(file.path, null, new Uint8Array(file.buffer), true, true, false);
 			}, this);
 
 			preloadedFiles = null;

--- a/platform/javascript/http_request.js
+++ b/platform/javascript/http_request.js
@@ -82,7 +82,7 @@ var GodotHTTPRequest = {
 
 	godot_xhr_send_string: function(xhrId, strPtr) {
 		if (!strPtr) {
-			console.warn("Failed to send string per XHR: null pointer");
+			err("Failed to send string per XHR: null pointer");
 			return;
 		}
 		GodotHTTPRequest.requests[xhrId].send(UTF8ToString(strPtr));
@@ -90,11 +90,11 @@ var GodotHTTPRequest = {
 
 	godot_xhr_send_data: function(xhrId, ptr, len) {
 		if (!ptr) {
-			console.warn("Failed to send data per XHR: null pointer");
+			err("Failed to send data per XHR: null pointer");
 			return;
 		}
 		if (len < 0) {
-			console.warn("Failed to send data per XHR: buffer length less than 0");
+			err("Failed to send data per XHR: buffer length less than 0");
 			return;
 		}
 		GodotHTTPRequest.requests[xhrId].send(HEAPU8.subarray(ptr, ptr + len));

--- a/platform/javascript/javascript_eval.cpp
+++ b/platform/javascript/javascript_eval.cpp
@@ -69,7 +69,7 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 				eval_ret = eval(UTF8ToString(CODE));
 			}
 		} catch (e) {
-			console.warn(e);
+			err(e);
 			eval_ret = null;
 		}
 
@@ -97,7 +97,7 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 					if (array_ptr!==0) {
 						_free(array_ptr)
 					}
-					console.warn(e);
+					err(e);
 					// fall through
 				}
 				break;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -986,8 +986,8 @@ bool OS_JavaScript::main_loop_iterate() {
 		if (sync_wait_time < 0) {
 			/* clang-format off */
 			EM_ASM(
-				FS.syncfs(function(err) {
-					if (err) { console.warn('Failed to save IDB file system: ' + err.message); }
+				FS.syncfs(function(error) {
+					if (error) { err('Failed to save IDB file system: ' + error.message); }
 				});
 			);
 			/* clang-format on */

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -61,6 +61,7 @@ private:
 	Label *labels[4];
 	Button *text_type;
 	LineEdit *c_text;
+	HBoxContainer *preset_container;
 	bool edit_alpha;
 	Size2i ms;
 	bool text_is_constructor;
@@ -92,6 +93,7 @@ private:
 	void _focus_enter();
 	void _focus_exit();
 	void _html_focus_exit();
+	void _check_preset_settings();
 
 protected:
 	void _notification(int);

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -71,6 +71,8 @@ private:
 	bool deferred_mode_enabled;
 	bool updating;
 	bool changing_color;
+	bool presets_enabled;
+	bool presets_visible;
 	float h, s, v;
 	Color last_hsv;
 
@@ -115,6 +117,12 @@ public:
 
 	void set_deferred_mode(bool p_enabled);
 	bool is_deferred_mode() const;
+
+	void set_presets_enabled(bool p_enabled);
+	bool are_presets_enabled() const;
+
+	void set_presets_visible(bool p_visible);
+	bool are_presets_visible() const;
 
 	void set_focus_on_line_edit();
 


### PR DESCRIPTION
These additions are related to the enhancements suggested in issue #26176. 
![image](https://user-images.githubusercontent.com/23032758/53304734-4ea3db80-383e-11e9-90ca-b7fe54a707d3.png)

**With visibility removed:**
![image](https://user-images.githubusercontent.com/23032758/53295933-6c842880-37cb-11e9-8f9a-f786120a8737.png)

**With editability removed:**
Looks the same but the preset items and button  don't respond to input events.