### PR TITLE
Working autocomplete for $" and $'

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5718,6 +5718,7 @@ void TextEdit::_update_completion_candidates() {
 
 	bool inquote = false;
 	int first_quote = -1;
+	int restore_quotes = -1;
 
 	int c = cofs - 1;
 	while (c >= 0) {
@@ -5725,6 +5726,11 @@ void TextEdit::_update_completion_candidates() {
 			inquote = !inquote;
 			if (first_quote == -1)
 				first_quote = c;
+			restore_quotes = 0;
+		} else if (restore_quotes == 0 && l[c] == '$') {
+			restore_quotes = 1;
+		} else if (restore_quotes == 0 && !_is_whitespace(l[c])) {
+			restore_quotes = -1;
 		}
 		c--;
 	}
@@ -5790,6 +5796,11 @@ void TextEdit::_update_completion_candidates() {
 	for (int i = 0; i < completion_strings.size(); i++) {
 		if (single_quote && completion_strings[i].is_quoted()) {
 			completion_strings.write[i] = completion_strings[i].unquote().quote("'");
+		}
+
+		if (inquote && restore_quotes == 1 && !completion_strings[i].is_quoted()) {
+			String quote = single_quote ? "'" : "\"";
+			completion_strings.write[i] = completion_strings[i].quote(quote);
 		}
 
 		if (completion_strings[i].begins_with(s)) {


### PR DESCRIPTION
Fixes #20811.

Problem was caused by $ (no quotes) syntax. If dollar is detected quotation is stripped off node paths regardless of quotation being written after dollar or not. So "" / '' were removed in all following cases:
$
$'
$"

Quotes are still stripped ( in function GDScriptLanguage::complete_code(), file gdscript_editor.cpp) but now they are added back if $ is followed by " or '.
