### PR TITLE
Properly preload files, always use stdout/-err in HTML5 platform

### DIFF
--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -209,7 +209,7 @@ Error AudioDriverJavaScript::capture_start() {
 		}
 
 		function gotMediaInputError(e) {
-			console.log(e);
+			out(e);
 		}
 
 		if (navigator.mediaDevices.getUserMedia) {

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -129,10 +129,6 @@ def configure(env):
     # us since we don't know requirements at compile-time.
     env.Append(LINKFLAGS=['-s', 'ALLOW_MEMORY_GROWTH=1'])
 
-    # Since we use both memory growth and MEMFS preloading,
-    # this avoids unnecessary copying on start-up.
-    env.Append(LINKFLAGS=['--no-heap-copy'])
-
     # This setting just makes WebGL 2 APIs available, it does NOT disable WebGL 1.
     env.Append(LINKFLAGS=['-s', 'USE_WEBGL2=1'])
 

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -199,7 +199,8 @@
 					}
 					LIBS.FS.mkdirTree(dir);
 				}
-				LIBS.FS.createDataFile('/', file.path, new Uint8Array(file.buffer), true, true, true);
+				// With memory growth, canOwn should be false.
+				LIBS.FS.createDataFile(file.path, null, new Uint8Array(file.buffer), true, true, false);
 			}, this);
 
 			preloadedFiles = null;

--- a/platform/javascript/http_request.js
+++ b/platform/javascript/http_request.js
@@ -82,7 +82,7 @@ var GodotHTTPRequest = {
 
 	godot_xhr_send_string: function(xhrId, strPtr) {
 		if (!strPtr) {
-			console.warn("Failed to send string per XHR: null pointer");
+			err("Failed to send string per XHR: null pointer");
 			return;
 		}
 		GodotHTTPRequest.requests[xhrId].send(UTF8ToString(strPtr));
@@ -90,11 +90,11 @@ var GodotHTTPRequest = {
 
 	godot_xhr_send_data: function(xhrId, ptr, len) {
 		if (!ptr) {
-			console.warn("Failed to send data per XHR: null pointer");
+			err("Failed to send data per XHR: null pointer");
 			return;
 		}
 		if (len < 0) {
-			console.warn("Failed to send data per XHR: buffer length less than 0");
+			err("Failed to send data per XHR: buffer length less than 0");
 			return;
 		}
 		GodotHTTPRequest.requests[xhrId].send(HEAPU8.subarray(ptr, ptr + len));

--- a/platform/javascript/javascript_eval.cpp
+++ b/platform/javascript/javascript_eval.cpp
@@ -69,7 +69,7 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 				eval_ret = eval(UTF8ToString(CODE));
 			}
 		} catch (e) {
-			console.warn(e);
+			err(e);
 			eval_ret = null;
 		}
 
@@ -97,7 +97,7 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 					if (array_ptr!==0) {
 						_free(array_ptr)
 					}
-					console.warn(e);
+					err(e);
 					// fall through
 				}
 				break;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -986,8 +986,8 @@ bool OS_JavaScript::main_loop_iterate() {
 		if (sync_wait_time < 0) {
 			/* clang-format off */
 			EM_ASM(
-				FS.syncfs(function(err) {
-					if (err) { console.warn('Failed to save IDB file system: ' + err.message); }
+				FS.syncfs(function(error) {
+					if (error) { err('Failed to save IDB file system: ' + error.message); }
 				});
 			);
 			/* clang-format on */


### PR DESCRIPTION
`--no-heap-copy` is irrelevant to us since we don't use the packager tool, instead I fixed the `createDataFile` call.

Also included a patch that makes sure we always use `out()` and `err()` (implementing stdout and stderr) instead of `console.log`/`warn`. These functions are now always available since we bumped the minimum Emscripten version.