### PR TITLE
Update Windows global mouse position at startup

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1395,6 +1395,8 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 		SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
 	}
 
+	update_real_mouse_position();
+
 	return OK;
 }
 
@@ -1596,6 +1598,19 @@ Point2 OS_Windows::get_mouse_position() const {
 	return Point2(old_x, old_y);
 }
 
+void OS_Windows::update_real_mouse_position() {
+
+	POINT mouse_pos;
+	if (GetCursorPos(&mouse_pos) && ScreenToClient(hWnd, &mouse_pos)) {
+		if (mouse_pos.x > 0 && mouse_pos.y > 0 && mouse_pos.x <= video_mode.width && mouse_pos.y <= video_mode.height) {
+			old_x = mouse_pos.x;
+			old_y = mouse_pos.y;
+			old_invalid = false;
+			input->set_mouse_position(Point2i(mouse_pos.x, mouse_pos.y));
+		}
+	}
+}
+
 int OS_Windows::get_mouse_button_state() const {
 
 	return last_button_state;
@@ -1738,6 +1753,7 @@ void OS_Windows::set_window_position(const Point2 &p_position) {
 	}
 
 	last_pos = p_position;
+	update_real_mouse_position();
 }
 Size2 OS_Windows::get_window_size() const {
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -197,6 +197,7 @@ public:
 
 	virtual void warp_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
+	void update_real_mouse_position();
 	virtual int get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);
 


### PR DESCRIPTION
Fixes issue #8145 for Windows, in the same manner as
issue #21910 fixed it for X11.