### PR TITLE
Use sun energy for ProceduralSky generation

### DIFF
--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -156,7 +156,10 @@ Ref<Image> ProceduralSky::_generate_sky() {
 		Color ground_bottom_linear = ground_bottom_color.to_linear();
 		Color ground_horizon_linear = ground_horizon_color.to_linear();
 
-		//Color sun_linear = sun_color.to_linear();
+		Color sun_linear;
+		sun_linear.r = sun_color.r * sun_energy;
+		sun_linear.g = sun_color.g * sun_energy;
+		sun_linear.b = sun_color.b * sun_energy;
 
 		Vector3 sun(0, 0, -1);
 
@@ -204,13 +207,13 @@ Ref<Image> ProceduralSky::_generate_sky() {
 					float sun_angle = Math::rad2deg(Math::acos(CLAMP(sun.dot(normal), -1.0, 1.0)));
 
 					if (sun_angle < sun_angle_min) {
-						color = color.blend(sun_color);
+						color = color.blend(sun_linear);
 					} else if (sun_angle < sun_angle_max) {
 
 						float c2 = (sun_angle - sun_angle_min) / (sun_angle_max - sun_angle_min);
 						c2 = Math::ease(c2, sun_curve);
 
-						color = color.blend(sun_color).linear_interpolate(color, c2);
+						color = color.blend(sun_linear).linear_interpolate(color, c2);
 					}
 				}
 
@@ -555,7 +558,7 @@ ProceduralSky::ProceduralSky() {
 	sun_angle_min = 1;
 	sun_angle_max = 100;
 	sun_curve = 0.05;
-	sun_energy = 16;
+	sun_energy = 1;
 
 	texture_size = TEXTURE_SIZE_1024;
 	sky_thread = NULL;


### PR DESCRIPTION
Multiply ProceduralSky sun color by sun energy (sun energy was previously unused, but sky and ground energy was).

No SRGB to linear correction is applied, but I wasn't sure if the color is linear in the first place.