### PR TITLE
Make iOS export fast and easy

### DIFF
--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -435,7 +435,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = $identifier;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "$provisioning_profile_uuid_debug";
+				PROVISIONING_PROFILE_SPECIFIER = "$provisioning_profile_uuid_debug";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "armv7 armv7s arm64 i386 x86_64";
 				WRAPPER_EXTENSION = app;
@@ -461,7 +461,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = $identifier;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "$provisioning_profile_uuid_release";
+				PROVISIONING_PROFILE_SPECIFIER = "$provisioning_profile_uuid_release";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "armv7 armv7s arm64 i386 x86_64";
 				WRAPPER_EXTENSION = app;

--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		1FF4C1881F584E6300A41E41 /* $binary.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = $binary.entitlements; sourceTree = "<group>"; };
 		1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dummy.cpp; sourceTree = "<group>"; };
 		D07CD44D1C5D589C00B7FB28 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		87D30C9722235A2200E688DC /* godot.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = godot.xcconfig; sourceTree = "<group>"; };
 		D0BCFE3418AEBDA2004A7AAE /* $binary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = $binary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0BCFE3718AEBDA2004A7AAE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D0BCFE3918AEBDA2004A7AAE /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -154,6 +155,7 @@
 				D07CD44D1C5D589C00B7FB28 /* Images.xcassets */,
 				D0BCFE4218AEBDA2004A7AAE /* Supporting Files */,
 				1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */,
+				87D30C9722235A2200E688DC /* godot.xcconfig */,
 			);
 			path = $binary;
 			sourceTree = "<group>";
@@ -201,7 +203,7 @@
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.AccessWiFi = {
-								enabled = $access_wifi;
+								enabled = 0;
 							};
 							com.apple.ApplePay = {
 								enabled = 0;
@@ -337,134 +339,62 @@
 /* Begin XCBuildConfiguration section */
 		D0BCFE6F18AEBDA3004A7AAE /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 87D30C9722235A2200E688DC /* godot.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$godot_archs";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "$code_sign_identity_debug";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "$code_sign_identity_debug";
 				COPY_PHASE_STRIP = NO;
-				ENABLE_BITCODE = NO;
-				"FRAMEWORK_SEARCH_PATHS[arch=*]" = "$binary/**";
-				GCC_C_LANGUAGE_STANDARD = gnu99;
+				STRIP_INSTALLED_PRODUCT = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				OTHER_LDFLAGS = "$linker_flags";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				ONLY_ACTIVE_ARCH = YES;
+				ENABLE_TESTABILITY = YES;
 			};
 			name = Debug;
 		};
 		D0BCFE7018AEBDA3004A7AAE /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 87D30C9722235A2200E688DC /* godot.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$godot_archs";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "$code_sign_identity_release";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "$code_sign_identity_release";
 				COPY_PHASE_STRIP = YES;
-				ENABLE_BITCODE = NO;
-				"FRAMEWORK_SEARCH_PATHS[arch=*]" = "$binary/**";
 				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				OTHER_LDFLAGS = "$linker_flags";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				ONLY_ACTIVE_ARCH = NO;
 			};
 			name = Release;
 		};
 		D0BCFE7218AEBDA3004A7AAE /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 87D30C9722235A2200E688DC /* godot.xcconfig */;
 			buildSettings = {
-				ARCHS = "$godot_archs";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CODE_SIGN_ENTITLEMENTS = $binary/$binary.entitlements;
 				CODE_SIGN_IDENTITY = "$code_sign_identity_debug";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "$code_sign_identity_debug";
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				DEVELOPMENT_TEAM = $team_id;
-				INFOPLIST_FILE = "$binary/$binary-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = $identifier;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$provisioning_profile_uuid_debug";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "armv7 armv7s arm64 i386 x86_64";
-				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
 		D0BCFE7318AEBDA3004A7AAE /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 87D30C9722235A2200E688DC /* godot.xcconfig */;
 			buildSettings = {
-				ARCHS = "$godot_archs";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CODE_SIGN_ENTITLEMENTS = $binary/$binary.entitlements;
 				CODE_SIGN_IDENTITY = "$code_sign_identity_release";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "$code_sign_identity_release";
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				DEVELOPMENT_TEAM = $team_id;
-				INFOPLIST_FILE = "$binary/$binary-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = $identifier;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$provisioning_profile_uuid_release";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "armv7 armv7s arm64 i386 x86_64";
-				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};

--- a/misc/dist/ios_xcode/godot_ios/Common.xcconfig
+++ b/misc/dist/ios_xcode/godot_ios/Common.xcconfig
@@ -1,0 +1,229 @@
+// 
+// This file defines common settings that should be enabled for every new
+// project. Typically, you want to use Debug, Release, or a similar variant
+// instead.
+//
+
+SDKROOT = iphoneos;
+ARCHS = $(ARCHS_STANDARD)
+VALID_ARCHS = $(ARCHS_STANDARD) x86_64;
+WRAPPER_EXTENSION = app;
+CLANG_CXX_LANGUAGE_STANDARD = gnu++0x;
+CLANG_CXX_LIBRARY = libc++;
+GCC_C_LANGUAGE_STANDARD = gnu99;
+
+// Disable legacy-compatible header searching
+ALWAYS_SEARCH_USER_PATHS = NO
+
+// Architectures to build
+ARCHS = $(ARCHS_STANDARD)
+
+// Whether to warn when a floating-point value is used as a loop counter
+CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES
+
+// Whether to warn about use of rand() and random() being used instead of arc4random()
+CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES
+
+// Whether to warn about strcpy() and strcat()
+CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES
+
+// Whether to enable module imports
+CLANG_ENABLE_MODULES = YES
+
+// Enable ARC
+CLANG_ENABLE_OBJC_ARC = YES
+
+// Warn about block captures of implicitly autoreleasing parameters.
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES
+
+// Warn about implicit conversions to boolean values that are suspicious.
+// For example, writing 'if (foo)' with 'foo' being the name a function will trigger a warning.
+CLANG_WARN_BOOL_CONVERSION = YES
+
+// Warn about suspicious uses of the comma operator.
+CLANG_WARN_COMMA = YES
+
+// Warn about implicit conversions of constant values that cause the constant value to change,
+// either through a loss of precision, or entirely in its meaning.
+CLANG_WARN_CONSTANT_CONVERSION = YES
+
+// Whether to warn when overriding deprecated methods
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES
+
+// Warn about direct accesses to the Objective-C 'isa' pointer instead of using a runtime API.
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
+
+// Warn about declaring the same method more than once within the same @interface.
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES
+
+// Warn about loop bodies that are suspiciously empty.
+CLANG_WARN_EMPTY_BODY = YES
+
+// Warn about implicit conversions between different kinds of enum values.
+// For example, this can catch issues when using the wrong enum flag as an argument to a function or method.
+CLANG_WARN_ENUM_CONVERSION = YES
+
+// Whether to warn on implicit conversions between signed/unsigned types
+CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO
+
+// Warn about implicit conversions between pointers and integers.
+// For example, this can catch issues when one incorrectly intermixes using NSNumbers and raw integers.
+CLANG_WARN_INT_CONVERSION = YES
+
+// Warn about non-literal expressions that evaluate to zero being treated as a null pointer.
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES
+
+// Warn about implicit capture of self (e.g. direct ivar access)
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES
+
+// Warn about implicit conversions from Objective-C literals to values of incompatible type.
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES
+
+// Don't warn about repeatedly using a weak reference without assigning the weak reference to a strong reference. Too many false positives.
+CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO
+
+// Warn about classes that unintentionally do not subclass a root class (such as NSObject).
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
+
+// Warn about ranged-based for loops.
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES
+
+// Whether to warn on suspicious implicit conversions
+CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
+
+// Warn about non-prototype declarations.
+CLANG_WARN_STRICT_PROTOTYPES = YES
+
+// Warn if an API that is newer than the deployment target is used without "if (@available(...))" guards.
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES
+
+// Warn about incorrect uses of nullable values
+CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION = YES
+
+// Warn for missing nullability attributes
+CLANG_ANALYZER_NONNULL = YES
+
+// Warn when a non-localized string is passed to a user-interface method expecting a localized string
+CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES
+
+// Warn about potentially unreachable code
+CLANG_WARN_UNREACHABLE_CODE = YES
+
+// The format of debugging symbols
+DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
+
+// Whether to compile assertions in
+ENABLE_NS_ASSERTIONS = YES
+
+// Whether to require objc_msgSend to be cast before invocation
+ENABLE_STRICT_OBJC_MSGSEND = YES
+
+// Which C variant to use
+GCC_C_LANGUAGE_STANDARD = gnu99
+
+// Whether to enable exceptions for Objective-C
+GCC_ENABLE_OBJC_EXCEPTIONS = YES
+
+// Whether to generate debugging symbols
+GCC_GENERATE_DEBUGGING_SYMBOLS = YES
+
+// Whether to precompile the prefix header (if one is specified)
+GCC_PRECOMPILE_PREFIX_HEADER = YES
+
+// Whether to enable strict aliasing, meaning that two pointers of different
+// types (other than void * or any id type) cannot point to the same memory
+// location
+GCC_STRICT_ALIASING = YES
+
+// Whether symbols not explicitly exported are hidden by default (this primarily
+// only affects C++ code)
+GCC_SYMBOLS_PRIVATE_EXTERN = NO
+
+// Whether static variables are thread-safe by default
+GCC_THREADSAFE_STATICS = NO
+
+// Which compiler to use
+GCC_VERSION = com.apple.compilers.llvm.clang.1_0
+
+// Whether warnings are treated as errors
+GCC_TREAT_WARNINGS_AS_ERRORS = YES
+SWIFT_TREAT_WARNINGS_AS_ERRORS = YES
+
+// Whether to warn about 64-bit values being implicitly shortened to 32 bits
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES
+
+// Whether to warn about fields missing from structure initializers (only if
+// designated initializers aren't used)
+GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES
+
+// Whether to warn about missing function prototypes
+GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO
+
+// Whether to warn about implicit conversions in the signedness of the type
+// a pointer is pointing to (e.g., 'int *' getting converted to 'unsigned int *')
+GCC_WARN_ABOUT_POINTER_SIGNEDNESS = YES
+
+// Whether to warn when the value returned from a function/method/block does not
+// match its return type
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR
+
+// Whether to warn on a class not implementing all the required methods of
+// a protocol it declares conformance to
+GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = YES
+
+// Whether to warn when switching on an enum value, and all possibilities are
+// not accounted for
+GCC_WARN_CHECK_SWITCH_STATEMENTS = YES
+
+// Whether to warn about the use of four-character constants
+GCC_WARN_FOUR_CHARACTER_CONSTANTS = YES
+
+// Whether to warn about an aggregate data type's initializer not being fully
+// bracketed (e.g., array initializer syntax)
+GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES
+
+// Whether to warn about missing braces or parentheses that make the meaning of
+// the code ambiguous
+GCC_WARN_MISSING_PARENTHESES = YES
+
+// Whether to warn about unsafe comparisons between values of different
+// signedness
+GCC_WARN_SIGN_COMPARE = YES
+
+// Whether to warn about the arguments to printf-style functions not matching
+// the format specifiers
+GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES
+
+// Warn if a "@selector(...)" expression referring to an undeclared selector is found
+GCC_WARN_UNDECLARED_SELECTOR = YES
+
+// Warn if a variable might be clobbered by a setjmp call or if an automatic variable is used without prior initialization.
+GCC_WARN_UNINITIALIZED_AUTOS = YES
+
+// Whether to warn about static functions that are unused
+GCC_WARN_UNUSED_FUNCTION = YES
+
+// Whether to warn about labels that are unused
+GCC_WARN_UNUSED_LABEL = YES
+
+// Whether to warn about variables that are never used
+GCC_WARN_UNUSED_VARIABLE = YES
+
+// Whether to run the static analyzer with every build
+RUN_CLANG_STATIC_ANALYZER = YES
+
+// Don't treat unknown warnings as errors, and disable GCC compatibility warnings and unused static const variable warnings
+WARNING_CFLAGS = -Wno-error=unknown-warning-option -Wno-gcc-compat -Wno-unused-const-variable
+
+// This setting is on for new projects as of Xcode ~6.3, though it is still not
+// the default. It warns if the same variable is declared in two binaries that
+// are linked together.
+GCC_NO_COMMON_BLOCKS = YES
+
+// This warnings detects when a function will recursively call itself on every
+// code path though that function. More information can be found here:
+// http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20131216/096004.html
+CLANG_WARN_INFINITE_RECURSION = YES
+
+CLANG_WARN_SUSPICIOUS_MOVE = YES
+

--- a/misc/dist/ios_xcode/godot_ios/godot.xcconfig
+++ b/misc/dist/ios_xcode/godot_ios/godot.xcconfig
@@ -1,0 +1,22 @@
+#include "Common.xcconfig"
+
+//
+//  Build Settings
+//
+ENABLE_BITCODE = NO;
+
+//
+//  Deploy Settings
+//
+TARGETED_DEVICE_FAMILY = 1,2; // Target iPhone and iPad
+IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+
+PRODUCT_NAME = $(TARGET_NAME);
+
+// 
+// Godot Exported from Editor
+//
+

--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -22,8 +22,6 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$short_version</string>
-	<key>CFBundleSignature</key>
-	<string>$signature</string>
 	<key>CFBundleVersion</key>
 	<string>$version</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -5,19 +5,15 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>$name</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleExecutable</key>
-	<string>$binary</string>
-	<key>CFBundleIcons</key>
-	<dict/>
-	<key>CFBundleIcons~ipad</key>
-	<dict/>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$name</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -262,9 +262,8 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/info"), "Made with Godot Engine"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/identifier", PROPERTY_HINT_PLACEHOLDER_TEXT, "com.example.game"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/signature"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/short_version"), "1.0"));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version"), "1.0"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/public_version"), "1.0.0"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version"), "1.0.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/arkit"), false));
@@ -336,11 +335,9 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].find("$identifier") != -1) {
 			strnew += lines[i].replace("$identifier", p_preset->get("application/identifier")) + "\n";
 		} else if (lines[i].find("$short_version") != -1) {
-			strnew += lines[i].replace("$short_version", p_preset->get("application/short_version")) + "\n";
+			strnew += lines[i].replace("$short_version", p_preset->get("application/public_version")) + "\n";
 		} else if (lines[i].find("$version") != -1) {
 			strnew += lines[i].replace("$version", p_preset->get("application/version")) + "\n";
-		} else if (lines[i].find("$signature") != -1) {
-			strnew += lines[i].replace("$signature", p_preset->get("application/signature")) + "\n";
 		} else if (lines[i].find("$copyright") != -1) {
 			strnew += lines[i].replace("$copyright", p_preset->get("application/copyright")) + "\n";
 		} else if (lines[i].find("$team_id") != -1) {


### PR DESCRIPTION
I'd like to get to 1-click deploy from the editor for iOS games. The first step is ensuring the export pipeline is solid, up-to-date and has very reasonable defaults.

# Changes
* Move to **Truly Automatic** ™️ code-signing. The trick is providing a default value of `iPhone Developer` and `iPhone Distribution` to pick from available code signing identities (Beward, this can cause #24866 and loss of sanity). The old behavior is still here if you choose to modify the export settings. Most of this process should now be automatic for _most users_
* Depend on modifying the `.xcodeproj` **much** less. We want to stay away from modifying this file and instead let Xcode manage it. To that end, most settings have been moved to `xcconfig` files.
* Add `Common.xcconfig` these settings are applied to all (Debug and Release) builds
* Generate tweakable settings in `godot.xcconfig` and add to `xcodeproj`
* Don't require any icons for successful export, iOS will use a white icon with concentric circles until the art is in place. This was just _one more_ hurdle people needed to see their games run on their devices, I've personally spent a bit of time generating random PNGs just to skip an error in this part of the export. Note that we (obviously) still set the icons if the developer provides them.
* Disambiguate the two versions needed on export. One is a 3 digit version that MUST increment, one is for public display.
* Remove **Access WiFi** capability from export option, as it does [something else](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_networking_wifi-info?language=objc).
* Bump deployment target to iOS 10 (to match the export templates).
* Enabled just about every optional warning and set some to errors, to ensure the best hygiene. Also fixed all warnings that resulted from this.

# Resolves
* #25128 - .xcconfig files autoescape all strings by default
* #24866 - This was due to the project not actually forcing the placeholder if the user typed nothing for the code signing identities
* #22197 - Ensures x86_64 slices is added to lipo fat binary
* #19996 - Use injected entitlements based on provisioning profile
* #15997 - Only 2 values (team ID and bundle ID) are now required to properly export to iOS, all other settings are tweakable after export via the `.xcconfig` file.

# Clean Up
* Remove `CFBundleSignature` from `plist` (This is an OS X key).
* Remove `CFBundleIcons` from `plist (We previously migrated to Asset Catalogs)
* Resolve all build warnings from exported Xcode project

# Proposal for future work
* Remove identity and export method entirely and depend on Xcode export from Archive (this allows re-exporting the same build repeatedly with different certs, profiles, and capabilities).
* Add better documentation around `capabilities` and what they mean.