### PR TITLE
Revert "Fix 'UndoRedo's 'MERGE_ALL' mode repeating instructions when quickly commiting actions"

### DIFF
--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -63,37 +63,43 @@ void UndoRedo::create_action(const String &p_name, MergeMode p_mode) {
 		_discard_redo();
 
 		// Check if the merge operation is valid
-		if (p_mode == MERGE_ENDS && actions.size() && actions[actions.size() - 1].name == p_name && actions[actions.size() - 1].last_tick + 800 > ticks) {
+		if (p_mode != MERGE_DISABLE && actions.size() && actions[actions.size() - 1].name == p_name && actions[actions.size() - 1].last_tick + 800 > ticks) {
 
 			current_action = actions.size() - 2;
 
-			// Clear all do ops from last action, and delete all object references
-			List<Operation>::Element *E = actions.write[current_action + 1].do_ops.front();
+			if (p_mode == MERGE_ENDS) {
 
-			while (E) {
+				// Clear all do ops from last action, and delete all object references
+				List<Operation>::Element *E = actions.write[current_action + 1].do_ops.front();
 
-				if (E->get().type == Operation::TYPE_REFERENCE) {
+				while (E) {
 
-					Object *obj = ObjectDB::get_instance(E->get().object);
+					if (E->get().type == Operation::TYPE_REFERENCE) {
 
-					if (obj)
-						memdelete(obj);
+						Object *obj = ObjectDB::get_instance(E->get().object);
+
+						if (obj)
+							memdelete(obj);
+					}
+
+					E = E->next();
+					actions.write[current_action + 1].do_ops.pop_front();
 				}
-
-				E = E->next();
-				actions.write[current_action + 1].do_ops.pop_front();
 			}
 
 			actions.write[actions.size() - 1].last_tick = ticks;
+
+			merge_mode = p_mode;
+
 		} else {
 
 			Action new_action;
 			new_action.name = p_name;
 			new_action.last_tick = ticks;
 			actions.push_back(new_action);
-		}
 
-		merge_mode = p_mode;
+			merge_mode = MERGE_DISABLE;
+		}
 	}
 
 	action_level++;


### PR DESCRIPTION
This reverts commit 79f1d8b4fbac564cb55669bbf05034bb9e15ae4a.

After further testing, it seems that my "fix" actually made things worse, so I'm reverting it. Issue #26118 should be reopened as well.