### PR TITLE
Allow users to override how motion is projected along each surface type in move_and_slide

### DIFF
--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -325,6 +325,10 @@ private:
 	Transform2D last_valid_transform;
 	void _direct_state_changed(Object *p_state);
 
+	Vector2 slide_floor(Vector2 p_motion, Vector2 p_floor_direction, float p_floor_max_angle, Collision p_collision);
+	Vector2 slide_ceiling(Vector2 p_motion, Vector2 p_floor_direction, float p_floor_max_angle, Collision p_collision);
+	Vector2 slide_wall(Vector2 p_motion, Vector2 p_floor_direction, float p_floor_max_angle, Collision p_collision);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -313,6 +313,10 @@ private:
 	Ref<KinematicCollision> _move(const Vector3 &p_motion, bool p_infinite_inertia = true, bool p_test_only = false);
 	Ref<KinematicCollision> _get_slide_collision(int p_bounce);
 
+	Vector3 slide_floor(Vector3 p_motion, Vector3 p_floor_direction, float p_floor_max_angle, Collision p_collision);
+	Vector3 slide_ceiling(Vector3 p_motion, Vector3 p_floor_direction, float p_floor_max_angle, Collision p_collision);
+	Vector3 slide_wall(Vector3 p_motion, Vector3 p_floor_direction, float p_floor_max_angle, Collision p_collision);
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
When creating character controllers with kinematic bodies I often myself frustrated with how restrictive the `move_and_slide` function can be and end up rewriting it with my own minor changes, so I decided to restructure the function in the engine a bit. Instead of just doing a `Vector3.slide()` along the collision normal, instead for each surface type (floors, ceilings, and walls), motion is passed through a function which then checks the user script for the matching function and if it exists it will call their own behavior for projecting motion instead of just the `.slide`, but if there is no script or the user has not created the function, the motion will be slid across the normal as it always has, so any preexisting systems should still work exactly the same and anyone who doesn't need more complex behavior will be unaffected while still giving much more flexibility in movement without having to completely rewrite movement logic for those who need something more complex.