### PR TITLE
Fix saturate ScalarFunc in Visual Shader

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -1136,7 +1136,7 @@ String VisualShaderNodeScalarFunc::generate_code(Shader::Mode p_mode, VisualShad
 		"round($)",
 		"ceil($)",
 		"fract($)",
-		"min(max($,0),1)",
+		"min(max($,0.0),1.0)",
 		"-($)",
 	};
 


### PR DESCRIPTION
Was getting the following error when using a saturate node. According to the [specification](https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/max.xhtml), max() wants a signed integer if the second parameter is an int.  This change fixes it.
```
 :39 - Invalid arguments for built-in function: max(float,int)
 drivers\gles3\rasterizer_storage_gles3.cpp:2150 - Condition ' err != OK ' is true.
```