### PR TITLE
Consider StaticBody and NavMesh position when converting to a MeshLibrary

### DIFF
--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -127,7 +127,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 						continue;
 					MeshLibrary::ShapeData shape_data;
 					shape_data.shape = collision;
-					shape_data.local_transform = sb->shape_owner_get_transform(E->get());
+					shape_data.local_transform = sb->get_transform() * sb->shape_owner_get_transform(E->get());
 					collisions.push_back(shape_data);
 				}
 			}
@@ -136,17 +136,20 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 		p_library->set_item_shapes(id, collisions);
 
 		Ref<NavigationMesh> navmesh;
+		Transform navmesh_transform;
 		for (int j = 0; j < mi->get_child_count(); j++) {
 			Node *child2 = mi->get_child(j);
 			if (!Object::cast_to<NavigationMeshInstance>(child2))
 				continue;
 			NavigationMeshInstance *sb = Object::cast_to<NavigationMeshInstance>(child2);
 			navmesh = sb->get_navigation_mesh();
+			navmesh_transform = sb->get_transform();
 			if (!navmesh.is_null())
 				break;
 		}
 		if (!navmesh.is_null()) {
 			p_library->set_item_navmesh(id, navmesh);
+			p_library->set_item_navmesh_transform(id, navmesh_transform);
 		}
 	}
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -517,7 +517,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		Ref<NavigationMesh> navmesh = mesh_library->get_item_navmesh(c.item);
 		if (navmesh.is_valid()) {
 			Octant::NavMesh nm;
-			nm.xform = xform;
+			nm.xform = xform * mesh_library->get_item_navmesh_transform(c.item);
 
 			if (navigation) {
 				nm.id = navigation->navmesh_add(navmesh, xform, this);

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -56,6 +56,8 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 			set_item_preview(idx, p_value);
 		else if (what == "navmesh")
 			set_item_navmesh(idx, p_value);
+		else if (what == "navmesh_transform")
+			set_item_navmesh_transform(idx, p_value);
 		else
 			return false;
 
@@ -80,6 +82,8 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = _get_item_shapes(idx);
 	else if (what == "navmesh")
 		r_ret = get_item_navmesh(idx);
+	else if (what == "navmesh_transform")
+		r_ret = get_item_navmesh_transform(idx);
 	else if (what == "preview")
 		r_ret = get_item_preview(idx);
 	else
@@ -95,8 +99,10 @@ void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 		String name = "item/" + itos(E->key()) + "/";
 		p_list->push_back(PropertyInfo(Variant::STRING, name + "name"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, name + "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"));
+		p_list->push_back(PropertyInfo(Variant::TRANSFORM, name + "mesh_transform"));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, name + "shapes"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, name + "navmesh", PROPERTY_HINT_RESOURCE_TYPE, "NavigationMesh"));
+		p_list->push_back(PropertyInfo(Variant::TRANSFORM, name + "navmesh_transform"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, name + "preview", PROPERTY_HINT_RESOURCE_TYPE, "Texture", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_HELPER));
 	}
 }
@@ -116,6 +122,7 @@ void MeshLibrary::set_item_name(int p_item, const String &p_name) {
 	emit_changed();
 	_change_notify();
 }
+
 void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
 
 	ERR_FAIL_COND(!item_map.has(p_item));
@@ -145,6 +152,15 @@ void MeshLibrary::set_item_navmesh(int p_item, const Ref<NavigationMesh> &p_navm
 	_change_notify();
 }
 
+void MeshLibrary::set_item_navmesh_transform(int p_item, const Transform &p_transform) {
+
+	ERR_FAIL_COND(!item_map.has(p_item));
+	item_map[p_item].navmesh_transform = p_transform;
+	notify_change_to_owners();
+	emit_changed();
+	_change_notify();
+}
+
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture> &p_preview) {
 
 	ERR_FAIL_COND(!item_map.has(p_item));
@@ -152,11 +168,13 @@ void MeshLibrary::set_item_preview(int p_item, const Ref<Texture> &p_preview) {
 	emit_changed();
 	_change_notify();
 }
+
 String MeshLibrary::get_item_name(int p_item) const {
 
 	ERR_FAIL_COND_V(!item_map.has(p_item), "");
 	return item_map[p_item].name;
 }
+
 Ref<Mesh> MeshLibrary::get_item_mesh(int p_item) const {
 
 	ERR_FAIL_COND_V(!item_map.has(p_item), Ref<Mesh>());
@@ -173,6 +191,12 @@ Ref<NavigationMesh> MeshLibrary::get_item_navmesh(int p_item) const {
 
 	ERR_FAIL_COND_V(!item_map.has(p_item), Ref<NavigationMesh>());
 	return item_map[p_item].navmesh;
+}
+
+Transform MeshLibrary::get_item_navmesh_transform(int p_item) const {
+
+	ERR_FAIL_COND_V(!item_map.has(p_item), Transform());
+	return item_map[p_item].navmesh_transform;
 }
 
 Ref<Texture> MeshLibrary::get_item_preview(int p_item) const {
@@ -268,11 +292,13 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_name", "id", "name"), &MeshLibrary::set_item_name);
 	ClassDB::bind_method(D_METHOD("set_item_mesh", "id", "mesh"), &MeshLibrary::set_item_mesh);
 	ClassDB::bind_method(D_METHOD("set_item_navmesh", "id", "navmesh"), &MeshLibrary::set_item_navmesh);
+	ClassDB::bind_method(D_METHOD("set_item_navmesh_transform", "id", "navmesh"), &MeshLibrary::set_item_navmesh_transform);
 	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
 	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
 	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
 	ClassDB::bind_method(D_METHOD("get_item_mesh", "id"), &MeshLibrary::get_item_mesh);
 	ClassDB::bind_method(D_METHOD("get_item_navmesh", "id"), &MeshLibrary::get_item_navmesh);
+	ClassDB::bind_method(D_METHOD("get_item_navmesh_transform", "id"), &MeshLibrary::get_item_navmesh_transform);
 	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
 	ClassDB::bind_method(D_METHOD("get_item_preview", "id"), &MeshLibrary::get_item_preview);
 	ClassDB::bind_method(D_METHOD("remove_item", "id"), &MeshLibrary::remove_item);

--- a/scene/resources/mesh_library.h
+++ b/scene/resources/mesh_library.h
@@ -52,6 +52,7 @@ public:
 		Ref<Mesh> mesh;
 		Vector<ShapeData> shapes;
 		Ref<Texture> preview;
+		Transform navmesh_transform;
 		Ref<NavigationMesh> navmesh;
 	};
 
@@ -72,11 +73,13 @@ public:
 	void set_item_name(int p_item, const String &p_name);
 	void set_item_mesh(int p_item, const Ref<Mesh> &p_mesh);
 	void set_item_navmesh(int p_item, const Ref<NavigationMesh> &p_navmesh);
+	void set_item_navmesh_transform(int p_item, const Transform &p_transform);
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 	void set_item_preview(int p_item, const Ref<Texture> &p_preview);
 	String get_item_name(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Ref<NavigationMesh> get_item_navmesh(int p_item) const;
+	Transform get_item_navmesh_transform(int p_item) const;
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 	Ref<Texture> get_item_preview(int p_item) const;
 


### PR DESCRIPTION
Would have added mesh transform as well, but realized that it will cause problems when moving the mesh around the scene for visualization purposes. The issue mentioned that it is not a problem as much as not being able to move the StaticBody around, so it's fine.

Closes #11722.