### PR TITLE
iOS: Fixed possible crash in applicationDidReceiveMemoryWarning

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -598,8 +598,10 @@ static int frame_count = 0;
 };
 
 - (void)applicationDidReceiveMemoryWarning:(UIApplication *)application {
-	OS::get_singleton()->get_main_loop()->notification(
-			MainLoop::NOTIFICATION_OS_MEMORY_WARNING);
+	if (OS::get_singleton()->get_main_loop()) {
+		OS::get_singleton()->get_main_loop()->notification(
+				MainLoop::NOTIFICATION_OS_MEMORY_WARNING);
+	}
 };
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {


### PR DESCRIPTION
Fixed possible crash on iOS in applicationDidReceiveMemoryWarning method: main event loop may be null when it's called.