### PR TITLE
Don't crash on previewing an AtlasTexture without a region

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -92,7 +92,12 @@ Ref<Texture> EditorTexturePreviewPlugin::generate(const RES &p_from, const Size2
 		if (!tex.is_valid()) {
 			return Ref<Texture>();
 		}
+
 		Ref<Image> atlas = tex->get_data();
+		if (!atlas.is_valid()) {
+			return Ref<Texture>();
+		}
+
 		img = atlas->get_rect(atex->get_region());
 	} else if (ltex.is_valid()) {
 		img = ltex->to_image();

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -426,6 +426,8 @@ ImageTexture::ImageTexture() {
 	texture = VisualServer::get_singleton()->texture_create();
 	storage = STORAGE_RAW;
 	lossy_storage_quality = 0.7;
+	image_stored = false;
+	format = Image::Format::FORMAT_L8;
 }
 
 ImageTexture::~ImageTexture() {
@@ -1514,6 +1516,7 @@ CubeMap::CubeMap() {
 	cubemap = VisualServer::get_singleton()->texture_create();
 	storage = STORAGE_RAW;
 	lossy_storage_quality = 0.7;
+	format = Image::Format::FORMAT_BPTC_RGBA;
 }
 
 CubeMap::~CubeMap() {


### PR DESCRIPTION
This fixes #26284