### PR TITLE
 Mono: Some editor usability improvements 

### DIFF
--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -167,9 +167,6 @@ void GodotSharpEditor::_remove_create_sln_menu_option() {
 
 	menu_popup->remove_item(menu_popup->get_item_index(MENU_CREATE_SLN));
 
-	if (menu_popup->get_item_count() == 0)
-		menu_button->hide();
-
 	bottom_panel_btn->show();
 }
 
@@ -413,9 +410,12 @@ GodotSharpEditor::GodotSharpEditor(EditorNode *p_editor) {
 
 	editor->add_child(memnew(MonoReloadNode));
 
-	menu_button = memnew(MenuButton);
-	menu_button->set_text(TTR("Mono"));
-	menu_popup = menu_button->get_popup();
+	menu_popup = memnew(PopupMenu);
+	menu_popup->hide();
+	menu_popup->set_as_toplevel(true);
+	menu_popup->set_pass_on_modal_close_click(false);
+
+	editor->add_tool_submenu_item("Mono", menu_popup);
 
 	// TODO: Remove or edit this info dialog once Mono support is no longer in alpha
 	{
@@ -478,10 +478,12 @@ GodotSharpEditor::GodotSharpEditor(EditorNode *p_editor) {
 
 	menu_popup->connect("id_pressed", this, "_menu_option_pressed");
 
-	if (menu_popup->get_item_count() == 0)
-		menu_button->hide();
-
-	editor->get_menu_hb()->add_child(menu_button);
+	ToolButton *build_button = memnew(ToolButton);
+	build_button->set_text("Build");
+	build_button->set_tooltip("Build solution");
+	build_button->set_focus_mode(Control::FOCUS_NONE);
+	build_button->connect("pressed", MonoBottomPanel::get_singleton(), "_build_project_pressed");
+	editor->get_menu_hb()->add_child(build_button);
 
 	// External editor settings
 	EditorSettings *ed_settings = EditorSettings::get_singleton();

--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -277,40 +277,20 @@ Error GodotSharpEditor::open_in_external_editor(const Ref<Script> &p_script, int
 
 				// TODO: Use initializer lists once C++11 is allowed
 
-				// Try with hint paths
-				static Vector<String> hint_paths;
-#ifdef WINDOWS_ENABLED
-				if (hint_paths.empty()) {
-					hint_paths.push_back(OS::get_singleton()->get_environment("ProgramFiles") + "\\Microsoft VS Code\\Code.exe");
-					if (sizeof(size_t) == 8) {
-						hint_paths.push_back(OS::get_singleton()->get_environment("ProgramFiles(x86)") + "\\Microsoft VS Code\\Code.exe");
-					}
+				static Vector<String> vscode_names;
+				if (vscode_names.empty()) {
+					vscode_names.push_back("code");
+					vscode_names.push_back("code-oss");
+					vscode_names.push_back("vscode");
+					vscode_names.push_back("vscode-oss");
+					vscode_names.push_back("visual-studio-code");
+					vscode_names.push_back("visual-studio-code-oss");
 				}
-#endif
-				for (int i = 0; i < hint_paths.size(); i++) {
-					vscode_path = hint_paths[i];
-					if (FileAccess::exists(vscode_path)) {
+				for (int i = 0; i < vscode_names.size(); i++) {
+					vscode_path = path_which(vscode_names[i]);
+					if (!vscode_path.empty()) {
 						found = true;
 						break;
-					}
-				}
-
-				if (!found) {
-					static Vector<String> vscode_names;
-					if (vscode_names.empty()) {
-						vscode_names.push_back("code");
-						vscode_names.push_back("code-oss");
-						vscode_names.push_back("vscode");
-						vscode_names.push_back("vscode-oss");
-						vscode_names.push_back("visual-studio-code");
-						vscode_names.push_back("visual-studio-code-oss");
-					}
-					for (int i = 0; i < vscode_names.size(); i++) {
-						vscode_path = path_which(vscode_names[i]);
-						if (!vscode_path.empty()) {
-							found = true;
-							break;
-						}
 					}
 				}
 

--- a/modules/mono/editor/mono_bottom_panel.cpp
+++ b/modules/mono/editor/mono_bottom_panel.cpp
@@ -125,8 +125,13 @@ void MonoBottomPanel::_build_tabs_item_selected(int p_idx) {
 
 void MonoBottomPanel::_build_tabs_nothing_selected() {
 
-	if (build_tabs->get_tab_count() != 0) // just in case
+	if (build_tabs->get_tab_count() != 0) { // just in case
 		build_tabs->set_visible(false);
+
+		// This callback is called when clicking on the empty space of the list.
+		// ItemList won't deselect the items automatically, so we must do it ourselves.
+		build_tabs_list->unselect_all();
+	}
 
 	warnings_btn->set_visible(false);
 	errors_btn->set_visible(false);

--- a/modules/mono/editor/mono_bottom_panel.h
+++ b/modules/mono/editor/mono_bottom_panel.h
@@ -51,8 +51,8 @@ class MonoBottomPanel : public VBoxContainer {
 	ItemList *build_tabs_list;
 	TabContainer *build_tabs;
 
-	Button *warnings_btn;
-	Button *errors_btn;
+	ToolButton *warnings_btn;
+	ToolButton *errors_btn;
 	Button *view_log_btn;
 
 	void _update_build_tabs_list();


### PR DESCRIPTION
- Remove problematic VS Code hint path on Windows 
- Mono: Some editor usability improvements
  - Move "Mono" popup menu from the top right corner to `Projects -> Tools` as a submenu.
  - Add "Build solution" button to the top right corner. Makes it more visible and quicker to access.
  - Fix build list in the bottom panel unselect an item when clicking on empty space. Previously it would hide the issues panel but the item would remain selected, making it impossible to display the issues panel again if there was only one item.

Ideally the build solution buttom should only display an icon, but I couldn't find any that would fit the action :(
