### PR TITLE
Clarify how to use MultiMesh.set_instance_color.

### DIFF
--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -65,6 +65,7 @@
 			</argument>
 			<description>
 				Set the color of a specific instance.
+				For the color to take effect, ensure that [member color_format] is non-[code]null[/code] on the [code]MultiMesh[/code] and [member SpatialMaterial.vertex_color_use_as_albedo] is [code]true[/code] on the material.
 			</description>
 		</method>
 		<method name="set_instance_custom_data">


### PR DESCRIPTION
Just calling set_instance_color will do nothing unless you have set
color_format and vertex_color_use_as_albedo. This is really confusing,
and I only discovered my error by finding godotengine/godot#10217 from
another confused user.

The docs should call out these requirements.