### PR TITLE
Fix project_settings entry creation for global scripts.

### DIFF
--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -80,7 +80,7 @@ class SectionedInspectorFilter : public Object {
 			PropertyInfo pi = E->get();
 			int sp = pi.name.find("/");
 
-			if (pi.name == "resource_path" || pi.name == "resource_name" || pi.name == "resource_local_to_scene" || pi.name.begins_with("script/")) //skip resource stuff
+			if (pi.name == "resource_path" || pi.name == "resource_name" || pi.name == "resource_local_to_scene" || pi.name.begins_with("script/") || pi.name.begins_with("_global_script")) //skip resource stuff
 				continue;
 
 			if (sp == -1) {
@@ -233,7 +233,7 @@ void SectionedInspector::update_category_list() {
 		else if (!(pi.usage & PROPERTY_USAGE_EDITOR))
 			continue;
 
-		if (pi.name.find(":") != -1 || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene")
+		if (pi.name.find(":") != -1 || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script"))
 			continue;
 
 		if (search_box && search_box->get_text() != String() && pi.name.findn(search_box->get_text()) == -1)


### PR DESCRIPTION
The global script entries in project settings were created outside the global section. This caused the `Property not found: global/_global_script_class_icons` warning when clicking on Global project setting.

I've added some code to remove incorrect global script entries for existing projects because the properties would appear twice in the global section without removing them.

fixes #26247 

### Issue Visualization:
![wqgqwfqw](https://user-images.githubusercontent.com/8831226/53465788-a2394380-3a4f-11e9-86e8-3a42b552f13e.png)

### Without incorrect global script entry removal
![4g34h46j56j](https://user-images.githubusercontent.com/8831226/53465865-e75d7580-3a4f-11e9-8541-33d58ce98546.PNG)

