### PR TITLE
Android: Fixed a possible crash in keyboard hide method.

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotIO.java
@@ -516,14 +516,6 @@ public class GodotIO {
 	public void hideKeyboard() {
 		if (edit != null)
 			edit.hideKeyboard();
-
-		InputMethodManager inputMgr = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
-		View v = activity.getCurrentFocus();
-		if (v != null) {
-			inputMgr.hideSoftInputFromWindow(v.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
-		} else {
-			inputMgr.hideSoftInputFromWindow(new View(activity).getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
-		}
 	};
 
 	public void setScreenOrientation(int p_orientation) {


### PR DESCRIPTION
I had a Java crash with the following stacktrace:
```
android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
	at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:6291)
	at android.view.ViewRootImpl.invalidateChildInParent(ViewRootImpl.java:892)
	at android.view.ViewGroup.invalidateChild(ViewGroup.java:4340)
	at android.view.View.invalidate(View.java:10963)
	at android.view.View.invalidate(View.java:10918)
	at android.widget.TextView.updateAfterEdit(TextView.java:7546)
	at android.widget.Editor.finishBatchEdit(Editor.java:1122)
	at android.widget.Editor.endBatchEdit(Editor.java:1104)
	at android.widget.TextView.endBatchEdit(TextView.java:5968)
	at com.android.internal.widget.EditableInputConnection.endBatchEdit(EditableInputConnection.java:77)
	at android.view.inputmethod.BaseInputConnection.finishComposingText(BaseInputConnection.java:283)
	at android.view.inputmethod.InputMethodManager.checkFocusNoStartInput(InputMethodManager.java:1330)
	at android.view.inputmethod.InputMethodManager.checkFocus(InputMethodManager.java:1290)
	at android.view.inputmethod.InputMethodManager.hideSoftInputFromWindow(InputMethodManager.java:989)
	at android.view.inputmethod.InputMethodManager.hideSoftInputFromWindow(InputMethodManager.java:968)
	at org.godotengine.godot.GodotIO.hideKeyboard(GodotIO.java:528)
	at org.godotengine.godot.GodotLib.step(Native Method)
	at org.godotengine.godot.GodotView$Renderer.onDrawFrame(GodotView.java:640)
	at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1532)
	at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1249)
```
This is because GodotIO.hideKeyboard method is called from GL rendering thread (not main Android thread).
It looks like this bug is due to wrong conflict resolution in past: deleted code duplicates this code in GodotEditText.java:

```
			case HANDLER_CLOSE_IME_KEYBOARD: {
				GodotEditText edit = (GodotEditText)msg.obj;

				edit.removeTextChangedListener(mInputWrapper);
				final InputMethodManager imm = (InputMethodManager)mView.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
				imm.hideSoftInputFromWindow(edit.getWindowToken(), 0);
				edit.mView.requestFocus();
			} break;
```
This code is right: it's called from a right thread, Handler mechanism is used to do it.