### PR TITLE
docs: Elaborate AnimationPlayer manual advancing

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -30,7 +30,7 @@
 			<argument index="0" name="delta" type="float">
 			</argument>
 			<description>
-				Shifts position in the animation timeline. Delta is the time in seconds to shift.
+				Shifts position in the animation timeline. Delta is the time in seconds to shift. Events between the current frame and [code]delta[/code] are handled.
 			</description>
 		</method>
 		<method name="animation_get_next" qualifiers="const">
@@ -197,7 +197,7 @@
 			<argument index="1" name="update" type="bool" default="false">
 			</argument>
 			<description>
-				Seek the animation to the [code]seconds[/code] point in time (in seconds). If [code]update[/code] is [code]true[/code], the animation updates too, otherwise it updates at process time.
+				Seek the animation to the [code]seconds[/code] point in time (in seconds). If [code]update[/code] is [code]true[/code], the animation updates too, otherwise it updates at process time. Events between the current frame and [code]seconds[/code] are skipped.
 			</description>
 		</method>
 		<method name="set_blend_time">

--- a/doc/classes/AnimationTreePlayer.xml
+++ b/doc/classes/AnimationTreePlayer.xml
@@ -29,7 +29,7 @@
 			<argument index="0" name="delta" type="float">
 			</argument>
 			<description>
-				Shifts position in the animation timeline. Delta is the time in seconds to shift.
+				Shifts position in the animation timeline. Delta is the time in seconds to shift. Events between the current frame and [code]delta[/code] are handled.
 			</description>
 		</method>
 		<method name="animation_node_get_animation" qualifiers="const">


### PR DESCRIPTION
Elaborate the difference between AnimationPlayer::advance and
AnimationPlayer::seek, specifically how intermediary events are handled for
each.

From the docs it is unclear that AnimationPlayer::advance is more of a
'fast-forward', playing each event (including function calls) between the two
points.