### PR TITLE
Create indicators for skeleton bones.

### DIFF
--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -136,7 +136,8 @@ public:
 	bool has_gizmo(Spatial *p_spatial);
 	String get_name() const;
 	void redraw(EditorSpatialGizmo *p_gizmo);
-
+	String get_handle_name(const EditorSpatialGizmo *p_gizmo, int p_idx) const;
+	Variant get_handle_value(EditorSpatialGizmo *p_gizmo, int p_idx) const;
 	SkeletonSpatialGizmoPlugin();
 };
 

--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -331,7 +331,7 @@ void Skeleton::_notification(int p_what) {
 					sp->set_transform(b.pose_global);
 				}
 			}
-
+			update_gizmo();
 			dirty = false;
 		} break;
 	}


### PR DESCRIPTION
Show indicators for where the skeleton bone is.

A future feature enhancement is being able to move the bones. Not currently working on that.

Sponsored by IMVU.

How to use?

Click on the skeleton node and the indicators will appear. Click on another node and they'll disappear.

![2019-02-27_07-08-19](https://user-images.githubusercontent.com/32321/53500113-8ee1a480-3a5e-11e9-9973-70232c7d223b.png)
