### PR TITLE
Make TileSet editor's workspace change size according to region changes

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -210,6 +210,7 @@ private:
 	void select_coord(const Vector2 &coord);
 	Vector2 snap_point(const Vector2 &point);
 	void update_workspace_tile_mode();
+	void update_workspace_minsize();
 	void update_edited_region(const Vector2 &end_point);
 
 	int get_current_tile() const;


### PR DESCRIPTION
![peek 2019-02-27 22-13](https://user-images.githubusercontent.com/30739239/53534310-2c3be780-3af6-11e9-848a-d9c30ec29760.gif)

Fixes #22485.