### PR TITLE
X11: Fix drag and drop from non-latin paths

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2355,7 +2355,7 @@ void OS_X11::process_xevents() {
 
 					Vector<String> files = String((char *)p.data).split("\n", false);
 					for (int i = 0; i < files.size(); i++) {
-						files.write[i] = files[i].replace("file://", "").replace("%20", " ").strip_escapes();
+						files.write[i] = files[i].replace("file://", "").http_unescape().strip_escapes();
 					}
 					main_loop->drop_files(files);
 


### PR DESCRIPTION
Fixes #25826.

Co-authored-by: @bruvzg

---

I confirm that it fixes the bug, now you can drag and drop files from and to paths with extended latin/Unicode characters.

During my tests I had one instance of `Unicode error: invalid skip`, but I couldn't isolate what triggered it nor reproduce, and it's still better anyway than the previous broken behaviour.