### PR TITLE
Updates error label font in script's status bar

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1144,6 +1144,7 @@ void CodeTextEditor::_update_font() {
 	text_editor->add_font_override("font", get_font("source", "EditorFonts"));
 
 	Ref<Font> status_bar_font = get_font("status_source", "EditorFonts");
+	error->add_font_override("font", status_bar_font);
 	int count = status_bar->get_child_count();
 	for (int i = 0; i < count; i++) {
 		Control *n = Object::cast_to<Control>(status_bar->get_child(i));


### PR DESCRIPTION
If you changes a font for code editor that label does not changes until restart - this will fix it