### PR TITLE
Engine does not crash anymore if a non root node in escn is missing a parent.

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -92,6 +92,8 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 
 		if (i > 0) {
 
+			ERR_EXPLAIN(vformat("Invalid scene: node %s does not specify its parent node.", snames[n.name]))
+			ERR_FAIL_COND_V(n.parent == -1, NULL)
 			NODE_FROM_ID(nparent, n.parent);
 #ifdef DEBUG_ENABLED
 			if (!nparent && (n.parent & FLAG_ID_IS_PATH)) {


### PR DESCRIPTION
Previously, a malformed escn file could cause the engine to crash when attempting to import it.
It was sufficient for the escn file to contain a non root node without the parent path to cause the engine to crash with SIGILL.  
Crash was happening because the NodeData would contain -1 as a parent index and this was put in an "and" with a flag, causing the resulting number to be meaningless.  
Prior to this PR, this file would cause the engine to crash.
[root_node_test.escn.zip](https://github.com/godotengine/godot/files/2919423/root_node_test.escn.zip)
Note the [node type="MeshInstance" name="Cube"] without the parent= at the end of the file.
