### PR TITLE
Importer for scenes only overrides the base Node if differently specified by the user

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1240,7 +1240,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 
 	String root_type = p_options["nodes/root_type"];
 
-	if (scene->get_class() != root_type) {
+	if (root_type != "Spatial") {
 		Node *base_node = Object::cast_to<Node>(ClassDB::instance(root_type));
 
 		if (base_node) {


### PR DESCRIPTION
This PR allows to use Nodes of different types as a root node of an imported scene: previously, they were substituted by a Spatial node.
It should not break compatibility with previous imported scenes while enabling the exporters to specify a node_type for the root node of the scene that does not get ignored by Godot.
