### PR TITLE
Fix misleading modified status of scenes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2852,7 +2852,7 @@ bool EditorNode::is_changing_scene() const {
 
 void EditorNode::_clear_undo_history() {
 
-	get_undo_redo()->clear_history();
+	get_undo_redo()->clear_history(false);
 }
 
 void EditorNode::set_current_scene(int p_idx) {


### PR DESCRIPTION
If a scene is instanced in another scene, any changes to the first
triggers _clear_undo_history in EditorNode::set_current_scene, which
increments the version in UndoRedo::clear_history. This results in a
modified status. Passing false to clear_history fixes this issue.
Fixes #25942