### PR TITLE
Scale quickhull tolerance with mesh size

### DIFF
--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -36,8 +36,6 @@ uint32_t QuickHull::debug_stop_after = 0xFFFFFFFF;
 
 Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_mesh) {
 
-	static const real_t over_tolerance = 0.0001;
-
 	/* CREATE AABB VOLUME */
 
 	AABB aabb;
@@ -179,6 +177,8 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_me
 
 		faces.push_back(f);
 	}
+
+	real_t over_tolerance = 3 * UNIT_EPSILON * (aabb.size.x + aabb.size.y + aabb.size.z);
 
 	/* COMPUTE AVAILABLE VERTICES */
 

--- a/core/math/quick_hull.h
+++ b/core/math/quick_hull.h
@@ -64,7 +64,7 @@ public:
 	struct Face {
 
 		Plane plane;
-		int vertices[3];
+		uint32_t vertices[3];
 		Vector<int> points_over;
 
 		bool operator<(const Face &p_face) const {


### PR DESCRIPTION
Taken from three.js's implementation. Tested with a wide variety of
meshes.

This fixes #21141