### PR TITLE
SCons: Move platform-specific Opus config to its module

### DIFF
--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -138,7 +138,7 @@ if env['builtin_opus']:
 
     opus_sources_silk = []
 
-    if("opus_fixed_point" in env and env.opus_fixed_point == "yes"):
+    if env["platform"] in ["android", "iphone", "javascript"]:
         env_opus.Append(CFLAGS=["-DFIXED_POINT"])
         opus_sources_silk = [
             "silk/fixed/LTP_analysis_filter_FIX.c",
@@ -219,6 +219,12 @@ if env['builtin_opus']:
         "silk/float",
     ]
     env_opus.Append(CPPPATH=[thirdparty_dir + "/" + dir for dir in thirdparty_include_paths])
+
+    if env["platform"] == "android" or env["platform"] == "iphone":
+        if ("arch" in env and env["arch"] == "arm") or ("android_arch" in env and env["android_arch"] in ["armv6", "armv7"]):
+            env_opus.Append(CFLAGS=["-DOPUS_ARM_OPT"])
+        elif ("arch" in env and env["arch"] == "arm64") or ("android_arch" in env and env["android_arch"] == "arm64v8"):
+            env_opus.Append(CFLAGS=["-DOPUS_ARM64_OPT"])
 
     env_thirdparty = env_opus.Clone()
     env_thirdparty.disable_warnings()

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -298,12 +298,6 @@ def configure(env):
     env.Append(CPPFLAGS=['-DANDROID_ENABLED', '-DUNIX_ENABLED', '-DNO_FCNTL'])
     env.Append(LIBS=['OpenSLES', 'EGL', 'GLESv3', 'android', 'log', 'z', 'dl'])
 
-    # TODO: Move that to opus module's config
-    if 'module_opus_enabled' in env and env['module_opus_enabled']:
-        if (env["android_arch"] == "armv6" or env["android_arch"] == "armv7"):
-            env.Append(CFLAGS=["-DOPUS_ARM_OPT"])
-        env.opus_fixed_point = "yes"
-
 # Return NDK version string in source.properties (adapted from the Chromium project).
 def get_ndk_version(path):
     if path is None:

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -174,11 +174,3 @@ def configure(env):
 
     env.Append(CPPPATH=['#platform/iphone'])
     env.Append(CPPFLAGS=['-DIPHONE_ENABLED', '-DUNIX_ENABLED', '-DGLES_ENABLED', '-DCOREAUDIO_ENABLED'])
-
-    # TODO: Move that to opus module's config
-    if 'module_opus_enabled' in env and env['module_opus_enabled']:
-        env.opus_fixed_point = "yes"
-        if (env["arch"] == "arm"):
-            env.Append(CFLAGS=["-DOPUS_ARM_OPT"])
-        elif (env["arch"] == "arm64"):
-            env.Append(CFLAGS=["-DOPUS_ARM64_OPT"])

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -136,7 +136,3 @@ def configure(env):
 
     # TODO: Reevaluate usage of this setting now that engine.js manages engine runtime.
     env.Append(LINKFLAGS=['-s', 'NO_EXIT_RUNTIME=1'])
-
-    # TODO: Move that to opus module's config.
-    if 'module_opus_enabled' in env and env['module_opus_enabled']:
-        env.opus_fixed_point = 'yes'


### PR DESCRIPTION
Finally fixing this old "TODO".

It's still far from perfect, we enable ARM-specific optimizations but we don't compile the ARM-specific code provided in the thirdparty repo.
But since Opus is on life support and only used by the Webm module, I don't want to spend too much effort on it. We should probably consider dropping it (and thus dropping Opus support in Webm), or find a way to address #7496 and re-enable Opus support as AudioStream.