### PR TITLE
SCons: Reduce spam from x11:can_build

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -20,12 +20,10 @@ def can_build():
     # Check the minimal dependencies
     x11_error = os.system("pkg-config --version > /dev/null")
     if (x11_error):
-        print("pkg-config not found.. x11 disabled.")
         return False
 
     x11_error = os.system("pkg-config x11 --modversion > /dev/null ")
     if (x11_error):
-        print("X11 not found.. x11 disabled.")
         return False
 
     x11_error = os.system("pkg-config xcursor --modversion > /dev/null ")


### PR DESCRIPTION
When cross-compiling for non-X11 on Linux, it used to be quite spammy.
Now it will only print errors if you miss more than just pkg-config and x11.