### PR TITLE
Make the Tooltip Position Offset Configurable

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -319,6 +319,9 @@
 		<member name="display/mouse_cursor/custom_image_hotspot" type="Vector2" setter="" getter="">
 			Hotspot for the custom mouse cursor image.
 		</member>
+		<member name="display/mouse_cursor/tooltip_position_offset" type="Vector2" setter="" getter="">
+			Position offset for tooltips, relative to the hotspot of the mouse cursor.
+		</member>
 		<member name="display/window/dpi/allow_hidpi" type="bool" setter="" getter="">
 			Allow HiDPI display on Windows and OSX. On Desktop Linux, this can't be enabled or disabled.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1209,6 +1209,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	GLOBAL_DEF("display/mouse_cursor/custom_image", String());
 	GLOBAL_DEF("display/mouse_cursor/custom_image_hotspot", Vector2());
+	GLOBAL_DEF("display/mouse_cursor/tooltip_position_offset", Point2(10, 10));
 	ProjectSettings::get_singleton()->set_custom_property_info("display/mouse_cursor/custom_image", PropertyInfo(Variant::STRING, "display/mouse_cursor/custom_image", PROPERTY_HINT_FILE, "*.png,*.webp"));
 
 	if (String(ProjectSettings::get_singleton()->get("display/mouse_cursor/custom_image")) != String()) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1486,7 +1486,8 @@ void Viewport::_gui_show_tooltip() {
 	gui.tooltip_popup->set_as_toplevel(true);
 	//gui.tooltip_popup->hide();
 
-	Rect2 r(gui.tooltip_pos + Point2(10, 10), gui.tooltip_popup->get_minimum_size());
+	Point2 tooltip_offset = ProjectSettings::get_singleton()->get("display/mouse_cursor/tooltip_position_offset");
+	Rect2 r(gui.tooltip_pos + tooltip_offset, gui.tooltip_popup->get_minimum_size());
 	Rect2 vr = gui.tooltip_popup->get_viewport_rect();
 	if (r.size.x + r.position.x > vr.size.x)
 		r.position.x = vr.size.x - r.size.x;


### PR DESCRIPTION
The offset for the tooltip position is at present hardcoded in \scene\main\viewport.cpp to be (10, 10), in the Viewport::_gui_show_tooltip() function.

This can be problematic for certain cursor images; if the image fills most of the 32x32 space cursors should have, then tooltips will appear partially below the cursor.

This pull request adds a project setting which allows configuring the tooltip position offset. The default for this setting is the same as the previous hardcoded value (10, 10).