### PR TITLE
Fix grid view button icon not showing on filesystem dock.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5659,7 +5659,6 @@ EditorNode::EditorNode() {
 
 	filesystem_dock = memnew(FileSystemDock(this));
 	filesystem_dock->connect("open", this, "open_request");
-	filesystem_dock->set_file_list_display_mode(FileSystemDock::FILE_LIST_DISPLAY_LIST);
 	filesystem_dock->connect("instance", this, "_instance_request");
 	filesystem_dock->connect("display_mode_changed", this, "_save_docks");
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -302,6 +302,8 @@ void FileSystemDock::_notification(int p_what) {
 
 			always_show_folders = bool(EditorSettings::get_singleton()->get("docks/filesystem/always_show_folders"));
 
+			set_file_list_display_mode(FileSystemDock::FILE_LIST_DISPLAY_LIST);
+
 			_update_display_mode();
 
 			if (EditorFileSystem::get_singleton()->is_scanning()) {


### PR DESCRIPTION
Fixes #26456, which is also happening on Windows.