### PR TITLE
mentioned possible use of property:component syntax

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -13,7 +13,7 @@
 		        Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
 		tween.start()
 		[/codeblock]
-		Many methods require a property name, such as "position" above. You can find the correct property name by hovering over the property in the Inspector.
+		Many methods require a property name, such as "position" above. You can find the correct property name by hovering over the property in the Inspector. You can also provide the components of a property directly by using "property:component" (eg. [code]position:x[/code]), where it would only apply to that particular component.
 		Many of the methods accept [code]trans_type[/code] and [code]ease_type[/code]. The first accepts an [enum TransitionType] constant, and refers to the way the timing of the animation is handled (see [code]http://easings.net/[/code] for some examples). The second accepts an [enum EaseType] constant, and controls the where [code]trans_type[/code] is applied to the interpolation (in the beginning, the end, or both). If you don't know which transition and easing to pick, you can try different [enum TransitionType] constants with [code]EASE_IN_OUT[/code], and use the one that looks best.
 	</description>
 	<tutorials>


### PR DESCRIPTION
Referencing #26466  , added possible use of property:component syntax for functions like interpolate_property, follow_property,etc.. in the class description.