### PR TITLE
Add warning to GIProbe when using GLES2

### DIFF
--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -30,6 +30,8 @@
 
 #include "gi_probe.h"
 
+#include "core/os/os.h"
+
 #include "mesh_instance.h"
 #include "voxel_light_baker.h"
 
@@ -488,6 +490,14 @@ AABB GIProbe::get_aabb() const {
 PoolVector<Face3> GIProbe::get_faces(uint32_t p_usage_flags) const {
 
 	return PoolVector<Face3>();
+}
+
+String GIProbe::get_configuration_warning() const {
+
+	if (OS::get_singleton()->get_current_video_driver() == OS::VIDEO_DRIVER_GLES2) {
+		return TTR("GIProbes are not supported by the GLES2 video driver.\nUse a BakedLightmap instead.");
+	}
+	return String();
 }
 
 void GIProbe::_bind_methods() {

--- a/scene/3d/gi_probe.h
+++ b/scene/3d/gi_probe.h
@@ -168,6 +168,8 @@ public:
 	virtual AABB get_aabb() const;
 	virtual PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;
 
+	virtual String get_configuration_warning() const;
+
 	GIProbe();
 	~GIProbe();
 };


### PR DESCRIPTION
This partially addresses #26509.

It adds a little triangle and warning beside the GIProbe node when GLES2 is being used, similar to what is being done currently for Particles and Particles2D.