### PR TITLE
Hide hdr and shadow_contact in gles2

### DIFF
--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -210,6 +210,13 @@ bool Light::is_editor_only() const {
 	return editor_only;
 }
 
+void Light::_validate_property(PropertyInfo &property) const {
+
+	if (VisualServer::get_singleton()->is_low_end() && property.name == "shadow_contact") {
+		property.usage = PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL;
+	}
+}
+
 void Light::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_editor_only", "editor_only"), &Light::set_editor_only);

--- a/scene/3d/light.h
+++ b/scene/3d/light.h
@@ -92,6 +92,7 @@ protected:
 
 	static void _bind_methods();
 	void _notification(int p_what);
+	virtual void _validate_property(PropertyInfo &property) const;
 
 	Light(VisualServer::LightType p_type);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2923,6 +2923,13 @@ bool Viewport::is_handling_input_locally() const {
 	return handle_input_locally;
 }
 
+void Viewport::_validate_property(PropertyInfo &property) const {
+
+	if (VisualServer::get_singleton()->is_low_end() && property.name == "hdr") {
+		property.usage = PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL;
+	}
+}
+
 void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_use_arvr", "use"), &Viewport::set_use_arvr);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -390,6 +390,7 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual void _validate_property(PropertyInfo &property) const;
 
 public:
 	Listener *get_listener() const;


### PR DESCRIPTION
Hides properties that are not going to be implemented in GLES2

Relates to: #26509 