### PR TITLE
Improve VRAM texture compression checks for mobile/web 

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1163,10 +1163,13 @@ void EditorExport::add_export_preset(const Ref<EditorExportPreset> &p_preset, in
 String EditorExportPlatform::test_etc2() const {
 
 	String driver = ProjectSettings::get_singleton()->get("rendering/quality/driver/driver_name");
-	bool etc2_supported = ProjectSettings::get_singleton()->get("rendering/vram_compression/import_etc");
+	bool etc_supported = ProjectSettings::get_singleton()->get("rendering/vram_compression/import_etc");
+	bool etc2_supported = ProjectSettings::get_singleton()->get("rendering/vram_compression/import_etc2");
 
-	if (driver == "GLES2" && !etc2_supported) {
-		return TTR("Target platform requires 'ETC' texture compression for GLES2. Enable support in Project Settings.");
+	if (driver == "GLES2" && !etc_supported) {
+		return TTR("Target platform requires 'ETC' texture compression for GLES2. Enable 'rendering/vram_compression/import_etc' in Project Settings.");
+	} else if (driver == "GLES3" && !etc2_supported) {
+		return TTR("Target platform requires 'ETC2' texture compression for GLES3. Enable 'rendering/vram_compression/import_etc2' in Project Settings.");
 	}
 	return String();
 }

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1114,16 +1114,10 @@ public:
 public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
 
-		// Re-enable when a GLES 2.0 backend is read
-		/*int api = p_preset->get("graphics/api");
-		if (api == 0)
-			r_features->push_back("etc");
-		else*/
 		String driver = ProjectSettings::get_singleton()->get("rendering/quality/driver/driver_name");
-		if (driver == "GLES2" || driver == "GLES3") {
+		if (driver == "GLES2") {
 			r_features->push_back("etc");
-		}
-		if (driver == "GLES3") {
+		} else if (driver == "GLES3") {
 			r_features->push_back("etc2");
 		}
 

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -196,15 +196,13 @@ public:
 
 void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
 
-	if (p_preset->get("texture_format/s3tc")) {
-		r_features->push_back("s3tc");
-	}
-	if (p_preset->get("texture_format/etc")) {
+	String driver = ProjectSettings::get_singleton()->get("rendering/quality/driver/driver_name");
+	if (driver == "GLES2") {
 		r_features->push_back("etc");
-	}
-	if (p_preset->get("texture_format/etc2")) {
+	} else if (driver == "GLES3") {
 		r_features->push_back("etc2");
 	}
+
 	Vector<String> architectures = _get_preset_architectures(p_preset);
 	for (int i = 0; i < architectures.size(); ++i) {
 		r_features->push_back(architectures[i]);
@@ -289,10 +287,6 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	for (unsigned int i = 0; i < sizeof(loading_screen_infos) / sizeof(loading_screen_infos[0]); ++i) {
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, loading_screen_infos[i].preset_key, PROPERTY_HINT_FILE, "*.png"), ""));
 	}
-
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/s3tc"), false));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc"), false));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc2"), true));
 
 	Vector<ExportArchitecture> architectures = _get_supported_architectures();
 	for (int i = 0; i < architectures.size(); ++i) {

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -104,22 +104,24 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 
 void EditorExportPlatformJavaScript::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
 
-	if (p_preset->get("texture_format/s3tc")) {
+	if (p_preset->get("vram_texture_compression/for_desktop")) {
 		r_features->push_back("s3tc");
 	}
-	if (p_preset->get("texture_format/etc")) {
-		r_features->push_back("etc");
-	}
-	if (p_preset->get("texture_format/etc2")) {
-		r_features->push_back("etc2");
+
+	if (p_preset->get("vram_texture_compression/for_mobile")) {
+		String driver = ProjectSettings::get_singleton()->get("rendering/quality/driver/driver_name");
+		if (driver == "GLES2") {
+			r_features->push_back("etc");
+		} else if (driver == "GLES3") {
+			r_features->push_back("etc2");
+		}
 	}
 }
 
 void EditorExportPlatformJavaScript::get_export_options(List<ExportOption> *r_options) {
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/s3tc"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc"), false));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc2"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_desktop"), true)); // S3TC
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_mobile"), false)); // ETC or ETC2, depending on renderer
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/custom_html_shell", PROPERTY_HINT_FILE, "*.html"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/head_include", PROPERTY_HINT_MULTILINE_TEXT), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
@@ -167,16 +169,19 @@ bool EditorExportPlatformJavaScript::can_export(const Ref<EditorExportPreset> &p
 		}
 	}
 
-	String etc_error = test_etc2();
-	if (etc_error != String()) {
-		valid = false;
-		err += etc_error;
+	r_missing_templates = !valid;
+
+	if (p_preset->get("vram_texture_compression/for_mobile")) {
+		String etc_error = test_etc2();
+		if (etc_error != String()) {
+			valid = false;
+			err += etc_error;
+		}
 	}
 
 	if (!err.empty())
 		r_error = err;
 
-	r_missing_templates = !valid;
 	return valid;
 }
 


### PR DESCRIPTION
For HTML5, we need to support S3TC if running on desktop,
and ETC or ETC2 for mobile, so make this explicit.

Add logic to check for ETC2 support on GLES3,
and remove incorrect ETC feature for GLES3 on Android.

Fix ETC check invalidating templates on HTML5.
Fixes #26476.