### PR TITLE
Allow parameters passed to GDScript functions to be nulled

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -329,10 +329,15 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					}
 
 					if (!argument_types[i].is_type(*p_args[i], true)) {
-						r_err.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
-						r_err.argument = i;
-						r_err.expected = argument_types[i].kind == GDScriptDataType::BUILTIN ? argument_types[i].builtin_type : Variant::OBJECT;
-						return Variant();
+						if (argument_types[i].is_type(Variant(), true)) {
+							memnew_placement(&stack[i], Variant);
+							continue;
+						} else {
+							r_err.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
+							r_err.argument = i;
+							r_err.expected = argument_types[i].kind == GDScriptDataType::BUILTIN ? argument_types[i].builtin_type : Variant::OBJECT;
+							return Variant();
+						}
 					}
 					if (argument_types[i].kind == GDScriptDataType::BUILTIN) {
 						Variant arg = Variant::construct(argument_types[i].builtin_type, &p_args[i], 1, r_err);


### PR DESCRIPTION
Previous version resulted in confusing (but actually right) errors about converting "from Object to Object", since CallError does not include information about the actual types involved.

Basically, checks if the passed argument can be implicitly converted to null if it doesn't match type, and avoids erroring then.

Should fix #26047.