### PR TITLE
Fixed TextureArray and Texture3D issues

### DIFF
--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -73,7 +73,11 @@ static void _debugger_get_resource_usage(List<ScriptDebuggerRemote::ResourceUsag
 		usage.vram = E->get().bytes;
 		usage.id = E->get().texture;
 		usage.type = "Texture";
-		usage.format = itos(E->get().width) + "x" + itos(E->get().height) + " " + Image::get_format_name(E->get().format);
+		if (E->get().depth == 0) {
+			usage.format = itos(E->get().width) + "x" + itos(E->get().height) + " " + Image::get_format_name(E->get().format);
+		} else {
+			usage.format = itos(E->get().width) + "x" + itos(E->get().height) + "x" + itos(E->get().depth) + " " + Image::get_format_name(E->get().format);
+		}
 		r_usage->push_back(usage);
 	}
 }


### PR DESCRIPTION
- Texture arrays and 3D textures weren't working previously due to an
  incorrect number of calls to glTexImage3D with incorrect level parameters.
  This change fixes that.
- Fixed the incorrect calculation of the byte size of layered textures.
- Added the layer count to the debugger info when viewing video memory usage.