### PR TITLE
Add Script API for get_state/set_state of other EditorPlugins

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -240,6 +240,22 @@ bool EditorInterface::is_plugin_enabled(const String &p_plugin) const {
 	return EditorNode::get_singleton()->is_addon_plugin_enabled(p_plugin);
 }
 
+void EditorInterface::set_plugin_state(const String &p_plugin, const Dictionary &p_state) {
+	EditorPlugin *plugin = EditorNode::get_singleton()->get_editor_data().get_editor(p_plugin);
+	if (plugin) {
+		plugin->set_state(p_state);
+	}
+}
+
+Dictionary EditorInterface::get_plugin_state(const String &p_plugin) const {
+	EditorPlugin *plugin = EditorNode::get_singleton()->get_editor_data().get_editor(p_plugin);
+	if (plugin) {
+		return plugin->get_state();
+	} else {
+		return Dictionary();
+	}
+}
+
 Error EditorInterface::save_scene() {
 	if (!get_edited_scene_root())
 		return ERR_CANT_CREATE;
@@ -278,6 +294,9 @@ void EditorInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_plugin_enabled", "plugin", "enabled"), &EditorInterface::set_plugin_enabled);
 	ClassDB::bind_method(D_METHOD("is_plugin_enabled", "plugin"), &EditorInterface::is_plugin_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_plugin_state", "plugin", "state"), &EditorInterface::set_plugin_state);
+	ClassDB::bind_method(D_METHOD("get_plugin_state", "plugin"), &EditorInterface::get_plugin_state);
 
 	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);
 	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -95,6 +95,9 @@ public:
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;
 
+	void set_plugin_state(const String &p_plugin, const Dictionary &p_state);
+	Dictionary get_plugin_state(const String &p_plugin) const;
+
 	Error save_scene();
 	void save_scene_as(const String &p_scene, bool p_with_preview = true);
 
@@ -189,7 +192,7 @@ public:
 	virtual void selected_notify() {} //notify that it was raised by the user, not the editor
 	virtual void edit(Object *p_object);
 	virtual bool handles(Object *p_object) const;
-	virtual Dictionary get_state() const; //save editor state so it can't be reloaded when reloading scene
+	virtual Dictionary get_state() const; //save editor state so it can be reloaded when reloading scene
 	virtual void set_state(const Dictionary &p_state); //restore editor state (likely was saved with the scene)
 	virtual void clear(); // clear any temporary data in the editor, reset it (likely new scene or load another scene)
 	virtual void save_external_data(); // if editor references external resources/scenes, save them


### PR DESCRIPTION
Added two functions on EditorInterface to call set_state/get_state for other EditorPlugins. This allows the current state of the SpatialEditorPlugin to be manipulated by other EditorPlugins.

This is intended to be the basis for discussion to solve #26534