### PR TITLE
TileSet/TileMap fixes

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -3061,6 +3061,24 @@ bool TilesetEditorContext::_set(const StringName &p_name, const Variant &p_value
 	} else if (name == "tileset_script") {
 		tileset->set_script(p_value);
 		return true;
+	} else if (name == "selected_collision_one_way") {
+		Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(tileset_editor->get_current_tile());
+		for (int index = 0; index < sd.size(); index++) {
+			if (sd[index].shape == tileset_editor->edited_collision_shape) {
+				tileset->tile_set_shape_one_way(tileset_editor->get_current_tile(), index, p_value);
+				return true;
+			}
+		}
+		return false;
+	} else if (name == "selected_collision_one_way_margin") {
+		Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(tileset_editor->get_current_tile());
+		for (int index = 0; index < sd.size(); index++) {
+			if (sd[index].shape == tileset_editor->edited_collision_shape) {
+				tileset->tile_set_shape_one_way_margin(tileset_editor->get_current_tile(), index, p_value);
+				return true;
+			}
+		}
+		return false;
 	}
 
 	tileset_editor->err_dialog->set_text(TTR("This property can't be changed."));
@@ -3103,6 +3121,24 @@ bool TilesetEditorContext::_get(const StringName &p_name, Variant &r_ret) const 
 	} else if (name == "selected_collision") {
 		r_ret = tileset_editor->edited_collision_shape;
 		v = true;
+	} else if (name == "selected_collision_one_way") {
+		Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(tileset_editor->get_current_tile());
+		for (int index = 0; index < sd.size(); index++) {
+			if (sd[index].shape == tileset_editor->edited_collision_shape) {
+				r_ret = sd[index].one_way_collision;
+				v = true;
+				break;
+			}
+		}
+	} else if (name == "selected_collision_one_way_margin") {
+		Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(tileset_editor->get_current_tile());
+		for (int index = 0; index < sd.size(); index++) {
+			if (sd[index].shape == tileset_editor->edited_collision_shape) {
+				r_ret = sd[index].one_way_collision_margin;
+				v = true;
+				break;
+			}
+		}
 	} else if (name == "selected_navigation") {
 		r_ret = tileset_editor->edited_navigation_shape;
 		v = true;
@@ -3149,6 +3185,10 @@ void TilesetEditorContext::_get_property_list(List<PropertyInfo> *p_list) const 
 	}
 	if (tileset_editor->edit_mode == TileSetEditor::EDITMODE_COLLISION && tileset_editor->edited_collision_shape.is_valid()) {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "selected_collision", PROPERTY_HINT_RESOURCE_TYPE, tileset_editor->edited_collision_shape->get_class()));
+		if (tileset_editor->edited_collision_shape.is_valid()) {
+			p_list->push_back(PropertyInfo(Variant::BOOL, "selected_collision_one_way", PROPERTY_HINT_NONE));
+			p_list->push_back(PropertyInfo(Variant::REAL, "selected_collision_one_way_margin", PROPERTY_HINT_NONE));
+		}
 	}
 	if (tileset_editor->edit_mode == TileSetEditor::EDITMODE_NAVIGATION && tileset_editor->edited_navigation_shape.is_valid()) {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "selected_navigation", PROPERTY_HINT_RESOURCE_TYPE, tileset_editor->edited_navigation_shape->get_class()));

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -78,40 +78,7 @@ void CollisionPolygon2D::_build_polygon() {
 }
 
 Vector<Vector<Vector2> > CollisionPolygon2D::_decompose_in_convex() {
-
-	Vector<Vector<Vector2> > decomp;
-	List<TriangulatorPoly> in_poly, out_poly;
-
-	TriangulatorPoly inp;
-	inp.Init(polygon.size());
-	for (int i = 0; i < polygon.size(); i++) {
-		inp.GetPoint(i) = polygon[i];
-	}
-	inp.SetOrientation(TRIANGULATOR_CCW);
-	in_poly.push_back(inp);
-	TriangulatorPartition tpart;
-	if (tpart.ConvexPartition_HM(&in_poly, &out_poly) == 0) { //failed!
-		ERR_PRINT("Convex decomposing failed!");
-		return decomp;
-	}
-
-	decomp.resize(out_poly.size());
-	int idx = 0;
-
-	for (List<TriangulatorPoly>::Element *I = out_poly.front(); I; I = I->next()) {
-
-		TriangulatorPoly &tp = I->get();
-
-		decomp.write[idx].resize(tp.GetNumPoints());
-
-		for (int i = 0; i < tp.GetNumPoints(); i++) {
-
-			decomp.write[idx].write[i] = tp.GetPoint(i);
-		}
-
-		idx++;
-	}
-
+	Vector<Vector<Vector2> > decomp = Geometry::decompose_polygon_in_convex(polygon);
 	return decomp;
 }
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -479,10 +479,28 @@ void TileMap::update_dirty_quadrants() {
 							vs->canvas_item_add_set_transform(debug_canvas_item, xform);
 							shape->draw(debug_canvas_item, debug_collision_color);
 						}
-						ps->body_add_shape(q.body, shape->get_rid(), xform);
-						ps->body_set_shape_metadata(q.body, shape_idx, Vector2(E->key().x, E->key().y));
-						ps->body_set_shape_as_one_way_collision(q.body, shape_idx, shapes[j].one_way_collision, shapes[j].one_way_collision_margin);
-						shape_idx++;
+
+						if (shape->has_meta("decomposed")) {
+							Array _shapes = shape->get_meta("decomposed");
+							for (int i = 0; i < _shapes.size(); i++) {
+								Ref<ConvexPolygonShape2D> convex = _shapes[i];
+								if (convex.is_valid()) {
+									ps->body_add_shape(q.body, convex->get_rid(), xform);
+									ps->body_set_shape_metadata(q.body, shape_idx, Vector2(E->key().x, E->key().y));
+									ps->body_set_shape_as_one_way_collision(q.body, shape_idx, shapes[j].one_way_collision, shapes[j].one_way_collision_margin);
+									shape_idx++;
+#ifdef DEBUG_ENABLED
+								} else {
+									print_error("The TileSet asigned to the TileMap " + get_name() + " has an invalid convex shape.");
+#endif
+								}
+							}
+						} else {
+							ps->body_add_shape(q.body, shape->get_rid(), xform);
+							ps->body_set_shape_metadata(q.body, shape_idx, Vector2(E->key().x, E->key().y));
+							ps->body_set_shape_as_one_way_collision(q.body, shape_idx, shapes[j].one_way_collision, shapes[j].one_way_collision_margin);
+							shape_idx++;
+						}
 					}
 				}
 			}

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -662,6 +662,7 @@ void TileSet::tile_set_shape(int p_id, int p_shape_id, const Ref<Shape2D> &p_sha
 	if (tile_map[p_id].shapes_data.size() <= p_shape_id)
 		tile_map[p_id].shapes_data.resize(p_shape_id + 1);
 	tile_map[p_id].shapes_data.write[p_shape_id].shape = p_shape;
+	_decompose_convex_shape(p_shape);
 	emit_changed();
 }
 
@@ -844,6 +845,9 @@ void TileSet::tile_set_shapes(int p_id, const Vector<ShapeData> &p_shapes) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].shapes_data = p_shapes;
+	for (int i = 0; i < p_shapes.size(); i++) {
+		_decompose_convex_shape(p_shapes[i].shape);
+	}
 	emit_changed();
 }
 
@@ -888,9 +892,10 @@ void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 		} else if (p_shapes[i].get_type() == Variant::DICTIONARY) {
 			Dictionary d = p_shapes[i];
 
-			if (d.has("shape") && d["shape"].get_type() == Variant::OBJECT)
+			if (d.has("shape") && d["shape"].get_type() == Variant::OBJECT) {
 				s.shape = d["shape"];
-			else
+				_decompose_convex_shape(s.shape);
+			} else
 				continue;
 
 			if (d.has("shape_transform") && d["shape_transform"].get_type() == Variant::TRANSFORM2D)
@@ -954,6 +959,24 @@ Array TileSet::_get_tiles_ids() const {
 	}
 
 	return arr;
+}
+
+void TileSet::_decompose_convex_shape(Ref<Shape2D> p_shape) {
+	Ref<ConvexPolygonShape2D> convex = p_shape;
+	if (!convex.is_valid())
+		return;
+	Vector<Vector<Vector2> > decomp = Geometry::decompose_polygon_in_convex(convex->get_points());
+	if (decomp.size() > 1) {
+		Array sub_shapes;
+		for (int i = 0; i < decomp.size(); i++) {
+			Ref<ConvexPolygonShape2D> _convex = memnew(ConvexPolygonShape2D);
+			_convex->set_points(decomp[i]);
+			sub_shapes.append(_convex);
+		}
+		convex->set_meta("decomposed", sub_shapes);
+	} else {
+		convex->set_meta("decomposed", Variant());
+	}
 }
 
 void TileSet::get_tile_list(List<int> *p_tiles) const {

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -35,6 +35,7 @@
 #include "core/resource.h"
 #include "scene/2d/light_occluder_2d.h"
 #include "scene/2d/navigation_polygon.h"
+#include "scene/resources/convex_polygon_shape_2d.h"
 #include "scene/resources/shape_2d.h"
 #include "scene/resources/texture.h"
 
@@ -134,6 +135,7 @@ protected:
 	void _tile_set_shapes(int p_id, const Array &p_shapes);
 	Array _tile_get_shapes(int p_id) const;
 	Array _get_tiles_ids() const;
+	void _decompose_convex_shape(Ref<Shape2D> p_shape);
 
 	static void _bind_methods();
 


### PR DESCRIPTION
1. Decompose solid non-convex polygons into convexes. Real fix for #24003 
> Before:
> https://gyazo.com/78f161cccb23bf0a41b16d05e68db965
> After:
> https://gyazo.com/c940f20158f95f999f7dea4167021d03

2. TileSetEditor: Expose to the user OneWayCollision+Margin properties. Fixes #25817