### PR TITLE
Fixed pixel snap precision artifact

### DIFF
--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -162,6 +162,9 @@ VERTEX_SHADER_CODE
 
 #ifdef USE_PIXEL_SNAP
 	outvec.xy = floor(outvec + 0.5).xy;
+	// precision issue on some hardware creates artifacts within texture
+	// offset uv by a small amount to avoid
+	uv += 1e-5;
 #endif
 
 #ifdef USE_SKELETON

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -173,6 +173,9 @@ VERTEX_SHADER_CODE
 
 #ifdef USE_PIXEL_SNAP
 	outvec.xy = floor(outvec + 0.5).xy;
+	// precision issue on some hardware creates artifacts within texture
+	// offset uv by a small amount to avoid
+	uv_interp += 1e-5;
 #endif
 
 #ifdef USE_SKELETON


### PR DESCRIPTION
As described in the thread for this issue. My first solution didn't work because it ended up offsetting the texture by an entire pixel. After some exploring I realized that the artifact looked just like a precision issue. Leading me to realize that all that was needed was to shift the pixel enough that it wouldn't move, but more than the minimum floating point precision. 

Overall, the solution looks pretty hacky, but it works in both GLES2 and GLES3.

fixes #26467