### PR TITLE
Silences annoying "iCCP: known incorrect sRGB profile" spam in the editor

### DIFF
--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -63,7 +63,11 @@ static void _png_error_function(png_structp, png_const_charp text) {
 }
 
 static void _png_warn_function(png_structp, png_const_charp text) {
-
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		if (String(text).begins_with("iCCP")) return; // silences annoying spam emitted to output every time the user opened assetlib
+	}
+#endif
 	WARN_PRINT(text);
 }
 


### PR DESCRIPTION
Fix #22468 - and yes, its only for editor and not for games - its still will warn you if you will use incorrect iCCp profile in your png files