### PR TITLE
Fix editor crash when converting sprite to 2D mesh

### DIFF
--- a/editor/plugins/sprite_editor_plugin.cpp
+++ b/editor/plugins/sprite_editor_plugin.cpp
@@ -91,6 +91,8 @@ Vector<Vector2> expand(const Vector<Vector2> &points, const Rect2i &rect, float 
 
 	Vector<Vector2> outPoints;
 	ClipperLib::PolyNode *p2 = out.GetFirst();
+	ERR_FAIL_COND_V(!p2, points);
+
 	while (p2->IsHole()) {
 		p2 = p2->GetNext();
 	}


### PR DESCRIPTION
Fix #26527 - note, Its simple hotfix to avoid sudden editor crash, its not a solution for converting sprite with region to mesh..