### PR TITLE
Mono: Add option to print MSBuild output and improve out of sync error

### DIFF
--- a/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
@@ -21,6 +21,8 @@ namespace GodotSharpTools.Build
         private extern static string godot_icall_BuildInstance_get_MonoWindowsBinDir();
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern static bool godot_icall_BuildInstance_get_UsingMonoMSBuildOnWindows();
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern static bool godot_icall_BuildInstance_get_PrintBuildOutput();
 
         private static string GetMSBuildPath()
         {
@@ -53,6 +55,14 @@ namespace GodotSharpTools.Build
             }
         }
 
+        private static bool PrintBuildOutput
+        {
+            get
+            {
+                return godot_icall_BuildInstance_get_PrintBuildOutput();
+            }
+        }
+
         private string solution;
         private string config;
 
@@ -71,8 +81,6 @@ namespace GodotSharpTools.Build
 
         public bool Build(string loggerAssemblyPath, string loggerOutputDir, string[] customProperties = null)
         {
-            bool debugMSBuild = IsDebugMSBuildRequested();
-
             List<string> customPropertiesList = new List<string>();
 
             if (customProperties != null)
@@ -82,7 +90,7 @@ namespace GodotSharpTools.Build
 
             ProcessStartInfo startInfo = new ProcessStartInfo(GetMSBuildPath(), compilerArgs);
 
-            bool redirectOutput = !debugMSBuild;
+            bool redirectOutput = !IsDebugMSBuildRequested() && !PrintBuildOutput;
 
             startInfo.RedirectStandardOutput = redirectOutput;
             startInfo.RedirectStandardError = redirectOutput;
@@ -123,8 +131,6 @@ namespace GodotSharpTools.Build
 
         public bool BuildAsync(string loggerAssemblyPath, string loggerOutputDir, string[] customProperties = null)
         {
-            bool debugMSBuild = IsDebugMSBuildRequested();
-
             if (process != null)
                 throw new InvalidOperationException("Already in use");
 
@@ -137,7 +143,7 @@ namespace GodotSharpTools.Build
 
             ProcessStartInfo startInfo = new ProcessStartInfo(GetMSBuildPath(), compilerArgs);
 
-            bool redirectOutput = !debugMSBuild;
+            bool redirectOutput = !IsDebugMSBuildRequested() && !PrintBuildOutput;
 
             startInfo.RedirectStandardOutput = redirectOutput;
             startInfo.RedirectStandardError = redirectOutput;

--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -195,6 +195,11 @@ MonoBoolean godot_icall_BuildInstance_get_UsingMonoMSBuildOnWindows() {
 #endif
 }
 
+MonoBoolean godot_icall_BuildInstance_get_PrintBuildOutput() {
+
+	return (bool)EDITOR_GET("mono/builds/print_build_output");
+}
+
 void GodotSharpBuilds::register_internal_calls() {
 
 	static bool registered = false;
@@ -205,6 +210,7 @@ void GodotSharpBuilds::register_internal_calls() {
 	mono_add_internal_call("GodotSharpTools.Build.BuildInstance::godot_icall_BuildInstance_get_MSBuildPath", (void *)godot_icall_BuildInstance_get_MSBuildPath);
 	mono_add_internal_call("GodotSharpTools.Build.BuildInstance::godot_icall_BuildInstance_get_MonoWindowsBinDir", (void *)godot_icall_BuildInstance_get_MonoWindowsBinDir);
 	mono_add_internal_call("GodotSharpTools.Build.BuildInstance::godot_icall_BuildInstance_get_UsingMonoMSBuildOnWindows", (void *)godot_icall_BuildInstance_get_UsingMonoMSBuildOnWindows);
+	mono_add_internal_call("GodotSharpTools.Build.BuildInstance::godot_icall_BuildInstance_get_PrintBuildOutput", (void *)godot_icall_BuildInstance_get_PrintBuildOutput);
 }
 
 void GodotSharpBuilds::show_build_error_dialog(const String &p_message) {
@@ -457,6 +463,8 @@ GodotSharpBuilds::GodotSharpBuilds() {
 			"," PROP_NAME_MSBUILD_VS
 #endif
 			"," PROP_NAME_XBUILD));
+
+	EDITOR_DEF("mono/builds/print_build_output", false);
 }
 
 GodotSharpBuilds::~GodotSharpBuilds() {

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -54,6 +54,10 @@
 #include "main/main.h"
 #endif
 
+#define OUT_OF_SYNC_ERR_MESSAGE(m_assembly_name) "The assembly '" m_assembly_name "' is out of sync. "                    \
+												 "This error is expected if you just upgraded to a newer Godot version. " \
+												 "Building the project will update the assembly to the correct version."
+
 GDMono *GDMono::singleton = NULL;
 
 namespace {
@@ -353,15 +357,15 @@ void GDMono::initialize() {
 			// metadata, so we invalidate the version in the metadata and unload the script domain.
 
 			if (core_api_assembly_out_of_sync) {
-				ERR_PRINT("The loaded Core API assembly is out of sync");
+				ERR_PRINT(OUT_OF_SYNC_ERR_MESSAGE(CORE_API_ASSEMBLY_NAME));
 				metadata_set_api_assembly_invalidated(APIAssembly::API_CORE, true);
 			} else if (!GDMonoUtils::mono_cache.godot_api_cache_updated) {
-				ERR_PRINT("The loaded Core API assembly is in sync, but the cache update failed");
+				ERR_PRINT("The loaded assembly '" CORE_API_ASSEMBLY_NAME "' is in sync, but the cache update failed");
 				metadata_set_api_assembly_invalidated(APIAssembly::API_CORE, true);
 			}
 
 			if (editor_api_assembly_out_of_sync) {
-				ERR_PRINT("The loaded Editor API assembly is out of sync");
+				ERR_PRINT(OUT_OF_SYNC_ERR_MESSAGE(EDITOR_API_ASSEMBLY_NAME));
 				metadata_set_api_assembly_invalidated(APIAssembly::API_EDITOR, true);
 			}
 
@@ -852,7 +856,7 @@ Error GDMono::reload_scripts_domain() {
 			// metadata, so we invalidate the version in the metadata and unload the script domain.
 
 			if (core_api_assembly_out_of_sync) {
-				ERR_PRINT("The loaded Core API assembly is out of sync");
+				ERR_PRINT(OUT_OF_SYNC_ERR_MESSAGE(CORE_API_ASSEMBLY_NAME));
 				metadata_set_api_assembly_invalidated(APIAssembly::API_CORE, true);
 			} else if (!GDMonoUtils::mono_cache.godot_api_cache_updated) {
 				ERR_PRINT("The loaded Core API assembly is in sync, but the cache update failed");
@@ -860,7 +864,7 @@ Error GDMono::reload_scripts_domain() {
 			}
 
 			if (editor_api_assembly_out_of_sync) {
-				ERR_PRINT("The loaded Editor API assembly is out of sync");
+				ERR_PRINT(OUT_OF_SYNC_ERR_MESSAGE(EDITOR_API_ASSEMBLY_NAME));
 				metadata_set_api_assembly_invalidated(APIAssembly::API_EDITOR, true);
 			}
 


### PR DESCRIPTION
The new option does the same as running Godot with the environment variable `GODOT_DEBUG_MSBUILD=1`.

Improved the "assembly out of sync" error to clarify that it's expected after upgrading to a newer Godot version and building the project should fix it (if not done automatically by the editor).
