### PR TITLE
Support for shadow offset in box style

### DIFF
--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -151,6 +151,9 @@
 		<member name="shadow_size" type="int" setter="set_shadow_size" getter="get_shadow_size">
 			The shadow size in pixels.
 		</member>
+		<member name="shadow_offset" type="Vector2" setter="set_shadow_offset" getter="get_shadow_offset">
+			The shadow offset in pixels. Adjusts the position of the shadow relatively to the stylebox.
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -403,7 +403,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// this is the most commonly used stylebox, variations should be made as duplicate of this
 	Ref<StyleBoxFlat> style_default = make_flat_stylebox(base_color, default_margin_size, default_margin_size, default_margin_size, default_margin_size);
 	style_default->set_border_width_all(border_width);
-	style_default->set_border_color_all(base_color);
+	style_default->set_border_color(base_color);
 	style_default->set_draw_center(true);
 
 	// Button and widgets
@@ -415,20 +415,20 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_widget->set_default_margin(MARGIN_RIGHT, (extra_spacing + 6) * EDSCALE);
 	style_widget->set_default_margin(MARGIN_BOTTOM, (extra_spacing + default_margin_size) * EDSCALE);
 	style_widget->set_bg_color(dark_color_1);
-	style_widget->set_border_color_all(dark_color_2);
+	style_widget->set_border_color(dark_color_2);
 
 	Ref<StyleBoxFlat> style_widget_disabled = style_widget->duplicate();
-	style_widget_disabled->set_border_color_all(color_disabled);
+	style_widget_disabled->set_border_color(color_disabled);
 	style_widget_disabled->set_bg_color(color_disabled_bg);
 
 	Ref<StyleBoxFlat> style_widget_focus = style_widget->duplicate();
-	style_widget_focus->set_border_color_all(accent_color);
+	style_widget_focus->set_border_color(accent_color);
 
 	Ref<StyleBoxFlat> style_widget_pressed = style_widget->duplicate();
-	style_widget_pressed->set_border_color_all(accent_color);
+	style_widget_pressed->set_border_color(accent_color);
 
 	Ref<StyleBoxFlat> style_widget_hover = style_widget->duplicate();
-	style_widget_hover->set_border_color_all(contrast_color_1);
+	style_widget_hover->set_border_color(contrast_color_1);
 
 	// style for windows, popups, etc..
 	Ref<StyleBoxFlat> style_popup = style_default->duplicate();
@@ -437,7 +437,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_popup->set_default_margin(MARGIN_TOP, popup_margin_size);
 	style_popup->set_default_margin(MARGIN_RIGHT, popup_margin_size);
 	style_popup->set_default_margin(MARGIN_BOTTOM, popup_margin_size);
-	style_popup->set_border_color_all(contrast_color_1);
+	style_popup->set_border_color(contrast_color_1);
 	style_popup->set_border_width_all(MAX(EDSCALE, border_width));
 	const Color shadow_color = Color(0, 0, 0, dark_theme ? 0.3 : 0.1);
 	style_popup->set_shadow_color(shadow_color);
@@ -470,7 +470,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	style_tab_selected->set_border_width_all(border_width);
 	style_tab_selected->set_border_width(MARGIN_BOTTOM, 0);
-	style_tab_selected->set_border_color_all(dark_color_3);
+	style_tab_selected->set_border_color(dark_color_3);
 	style_tab_selected->set_expand_margin_size(MARGIN_BOTTOM, border_width);
 	style_tab_selected->set_default_margin(MARGIN_LEFT, tab_default_margin_side);
 	style_tab_selected->set_default_margin(MARGIN_RIGHT, tab_default_margin_side);
@@ -480,11 +480,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	Ref<StyleBoxFlat> style_tab_unselected = style_tab_selected->duplicate();
 	style_tab_unselected->set_bg_color(dark_color_1);
-	style_tab_unselected->set_border_color_all(dark_color_2);
+	style_tab_unselected->set_border_color(dark_color_2);
 
 	Ref<StyleBoxFlat> style_tab_disabled = style_tab_selected->duplicate();
 	style_tab_disabled->set_bg_color(color_disabled_bg);
-	style_tab_disabled->set_border_color_all(color_disabled);
+	style_tab_disabled->set_border_color(color_disabled);
 
 	// Editor background
 	theme->set_stylebox("Background", "EditorStyles", make_flat_stylebox(background_color, default_margin_size, default_margin_size, default_margin_size, default_margin_size));
@@ -492,7 +492,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Focus
 	Ref<StyleBoxFlat> style_focus = style_default->duplicate();
 	style_focus->set_draw_center(false);
-	style_focus->set_border_color_all(contrast_color_2);
+	style_focus->set_border_color(contrast_color_2);
 	theme->set_stylebox("Focus", "EditorStyles", style_focus);
 
 	// Menu
@@ -514,7 +514,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_menu_hover_border->set_draw_center(false);
 	style_menu_hover_border->set_border_width_all(0);
 	style_menu_hover_border->set_border_width(MARGIN_BOTTOM, border_width);
-	style_menu_hover_border->set_border_color_all(accent_color);
+	style_menu_hover_border->set_border_color(accent_color);
 
 	Ref<StyleBoxFlat> style_menu_hover_bg = style_widget->duplicate();
 	style_menu_hover_bg->set_border_width_all(0);
@@ -644,11 +644,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	Ref<StyleBoxFlat> sub_inspector_bg = make_flat_stylebox(dark_color_1.linear_interpolate(accent_color, 0.08), 2, 0, 2, 2);
 	sub_inspector_bg->set_border_width(MARGIN_LEFT, 2);
-	sub_inspector_bg->set_border_color(MARGIN_LEFT, accent_color * Color(1, 1, 1, 0.3));
 	sub_inspector_bg->set_border_width(MARGIN_RIGHT, 2);
-	sub_inspector_bg->set_border_color(MARGIN_RIGHT, accent_color * Color(1, 1, 1, 0.3));
 	sub_inspector_bg->set_border_width(MARGIN_BOTTOM, 2);
-	sub_inspector_bg->set_border_color(MARGIN_BOTTOM, accent_color * Color(1, 1, 1, 0.3));
+	sub_inspector_bg->set_border_color(accent_color * Color(1, 1, 1, 0.3));
 	sub_inspector_bg->set_draw_center(true);
 
 	theme->set_stylebox("sub_inspector_bg", "Editor", sub_inspector_bg);
@@ -657,7 +655,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Tree & ItemList background
 	Ref<StyleBoxFlat> style_tree_bg = style_default->duplicate();
 	style_tree_bg->set_bg_color(dark_color_1);
-	style_tree_bg->set_border_color_all(dark_color_3);
+	style_tree_bg->set_border_color(dark_color_3);
 	theme->set_stylebox("bg", "Tree", style_tree_bg);
 
 	const Color guide_color = Color(mono_color.r, mono_color.g, mono_color.b, 0.05);
@@ -708,7 +706,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> style_tree_cursor = style_default->duplicate();
 	style_tree_cursor->set_draw_center(false);
 	style_tree_cursor->set_border_width_all(border_width);
-	style_tree_cursor->set_border_color_all(contrast_color_1);
+	style_tree_cursor->set_border_color(contrast_color_1);
 
 	Ref<StyleBoxFlat> style_tree_title = style_default->duplicate();
 	style_tree_title->set_bg_color(dark_color_3);
@@ -731,12 +729,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> style_itemlist_bg = style_default->duplicate();
 	style_itemlist_bg->set_bg_color(dark_color_1);
 	style_itemlist_bg->set_border_width_all(border_width);
-	style_itemlist_bg->set_border_color_all(dark_color_3);
+	style_itemlist_bg->set_border_color(dark_color_3);
 
 	Ref<StyleBoxFlat> style_itemlist_cursor = style_default->duplicate();
 	style_itemlist_cursor->set_draw_center(false);
 	style_itemlist_cursor->set_border_width_all(border_width);
-	style_itemlist_cursor->set_border_color_all(highlight_color);
+	style_itemlist_cursor->set_border_color(highlight_color);
 	theme->set_stylebox("cursor", "ItemList", style_itemlist_cursor);
 	theme->set_stylebox("cursor_unfocused", "ItemList", style_itemlist_cursor);
 	theme->set_stylebox("selected_focus", "ItemList", style_tree_focus);
@@ -781,7 +779,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Content of each tab
 	Ref<StyleBoxFlat> style_content_panel = style_default->duplicate();
-	style_content_panel->set_border_color_all(dark_color_3);
+	style_content_panel->set_border_color(dark_color_3);
 	style_content_panel->set_border_width_all(border_width);
 	// compensate the border
 	style_content_panel->set_default_margin(MARGIN_TOP, margin_size_extra * EDSCALE);
@@ -859,7 +857,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// WindowDialog
 	Ref<StyleBoxFlat> style_window = style_popup->duplicate();
-	style_window->set_border_color_all(tab_color);
+	style_window->set_border_color(tab_color);
 	style_window->set_border_width(MARGIN_TOP, 24 * EDSCALE);
 	style_window->set_expand_margin_size(MARGIN_TOP, 24 * EDSCALE);
 	theme->set_stylebox("panel", "WindowDialog", style_window);
@@ -874,7 +872,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// complex window, for now only Editor settings and Project settings
 	Ref<StyleBoxFlat> style_complex_window = style_window->duplicate();
 	style_complex_window->set_bg_color(dark_color_2);
-	style_complex_window->set_border_color_all(highlight_tabs ? tab_color : dark_color_2);
+	style_complex_window->set_border_color(highlight_tabs ? tab_color : dark_color_2);
 	theme->set_stylebox("panel", "EditorSettingsDialog", style_complex_window);
 	theme->set_stylebox("panel", "ProjectSettingsEditor", style_complex_window);
 	theme->set_stylebox("panel", "EditorAbout", style_complex_window);
@@ -953,7 +951,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tooltip->set_default_margin(MARGIN_BOTTOM, v);
 	style_tooltip->set_bg_color(Color(mono_color.r, mono_color.g, mono_color.b, 0.9));
 	style_tooltip->set_border_width_all(border_width);
-	style_tooltip->set_border_color_all(mono_color);
+	style_tooltip->set_border_color(mono_color);
 	theme->set_color("font_color", "TooltipLabel", font_color.inverted());
 	theme->set_color("font_color_shadow", "TooltipLabel", mono_color.inverted() * Color(1, 1, 1, 0.1));
 	theme->set_stylebox("panel", "TooltipPanel", style_tooltip);
@@ -988,32 +986,32 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const int gn_margin_side = 28;
 	Ref<StyleBoxFlat> graphsb = make_flat_stylebox(Color(mv, mv, mv, 0.7), gn_margin_side, 24, gn_margin_side, 5);
 	graphsb->set_border_width_all(border_width);
-	graphsb->set_border_color_all(Color(mv2, mv2, mv2, 0.9));
+	graphsb->set_border_color(Color(mv2, mv2, mv2, 0.9));
 	Ref<StyleBoxFlat> graphsbselected = make_flat_stylebox(Color(mv, mv, mv, 0.9), gn_margin_side, 24, gn_margin_side, 5);
 	graphsbselected->set_border_width_all(border_width);
-	graphsbselected->set_border_color_all(Color(accent_color.r, accent_color.g, accent_color.b, 0.9));
+	graphsbselected->set_border_color(Color(accent_color.r, accent_color.g, accent_color.b, 0.9));
 	graphsbselected->set_shadow_size(8 * EDSCALE);
 	graphsbselected->set_shadow_color(shadow_color);
 	Ref<StyleBoxFlat> graphsbcomment = make_flat_stylebox(Color(mv, mv, mv, 0.3), gn_margin_side, 24, gn_margin_side, 5);
 	graphsbcomment->set_border_width_all(border_width);
-	graphsbcomment->set_border_color_all(Color(mv2, mv2, mv2, 0.9));
+	graphsbcomment->set_border_color(Color(mv2, mv2, mv2, 0.9));
 	Ref<StyleBoxFlat> graphsbcommentselected = make_flat_stylebox(Color(mv, mv, mv, 0.4), gn_margin_side, 24, gn_margin_side, 5);
 	graphsbcommentselected->set_border_width_all(border_width);
-	graphsbcommentselected->set_border_color_all(Color(mv2, mv2, mv2, 0.9));
+	graphsbcommentselected->set_border_color(Color(mv2, mv2, mv2, 0.9));
 	Ref<StyleBoxFlat> graphsbbreakpoint = graphsbselected->duplicate();
 	graphsbbreakpoint->set_draw_center(false);
-	graphsbbreakpoint->set_border_color_all(warning_color);
+	graphsbbreakpoint->set_border_color(warning_color);
 	graphsbbreakpoint->set_shadow_color(warning_color * Color(1.0, 1.0, 1.0, 0.1));
 	Ref<StyleBoxFlat> graphsbposition = graphsbselected->duplicate();
 	graphsbposition->set_draw_center(false);
-	graphsbposition->set_border_color_all(error_color);
+	graphsbposition->set_border_color(error_color);
 	graphsbposition->set_shadow_color(error_color * Color(1.0, 1.0, 1.0, 0.2));
 	Ref<StyleBoxFlat> smgraphsb = make_flat_stylebox(Color(mv, mv, mv, 0.7), gn_margin_side, 24, gn_margin_side, 5);
 	smgraphsb->set_border_width_all(border_width);
-	smgraphsb->set_border_color_all(Color(mv2, mv2, mv2, 0.9));
+	smgraphsb->set_border_color(Color(mv2, mv2, mv2, 0.9));
 	Ref<StyleBoxFlat> smgraphsbselected = make_flat_stylebox(Color(mv, mv, mv, 0.9), gn_margin_side, 24, gn_margin_side, 5);
 	smgraphsbselected->set_border_width_all(border_width);
-	smgraphsbselected->set_border_color_all(Color(accent_color.r, accent_color.g, accent_color.b, 0.9));
+	smgraphsbselected->set_border_color(Color(accent_color.r, accent_color.g, accent_color.b, 0.9));
 	smgraphsbselected->set_shadow_size(8 * EDSCALE);
 	smgraphsbselected->set_shadow_color(shadow_color);
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -240,7 +240,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 
 		if (EditorSettings::get_singleton()->get("interface/theme/use_graph_node_headers")) {
 			Ref<StyleBoxFlat> sb = node->get_stylebox("frame", "GraphNode");
-			Color c = sb->get_border_color(MARGIN_TOP);
+			Color c = sb->get_border_color();
 			Color mono_color = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0) : Color(0.0, 0.0, 0.0);
 			mono_color.a = 0.85;
 			c = mono_color;

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -344,7 +344,7 @@ void VisualShaderEditor::_update_graph() {
 
 			if (EditorSettings::get_singleton()->get("interface/theme/use_graph_node_headers")) {
 				Ref<StyleBoxFlat> sb = node->get_stylebox("frame", "GraphNode");
-				Color c = sb->get_border_color(MARGIN_TOP);
+				Color c = sb->get_border_color();
 				Color mono_color = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0) : Color(0.0, 0.0, 0.0);
 				mono_color.a = 0.85;
 				c = mono_color;

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -579,7 +579,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			if (gnode->is_comment())
 				sbf = EditorNode::get_singleton()->get_theme_base()->get_theme()->get_stylebox("comment", "GraphNode");
 
-			Color c = sbf->get_border_color(MARGIN_TOP);
+			Color c = sbf->get_border_color();
 			c.a = 1;
 			if (EditorSettings::get_singleton()->get("interface/theme/use_graph_node_headers")) {
 				Color mono_color = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0) : Color(0.0, 0.0, 0.0);
@@ -3054,10 +3054,10 @@ void VisualScriptEditor::_notification(int p_what) {
 			Ref<StyleBoxFlat> sb = tm->get_stylebox("frame", "GraphNode");
 			if (!sb.is_null()) {
 				Ref<StyleBoxFlat> frame_style = sb->duplicate();
-				Color c = sb->get_border_color(MARGIN_TOP);
+				Color c = sb->get_border_color();
 				Color cn = E->get().second;
 				cn.a = c.a;
-				frame_style->set_border_color_all(cn);
+				frame_style->set_border_color(cn);
 				node_styles[E->get().first] = frame_style;
 			}
 		}

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -368,25 +368,14 @@ Color StyleBoxFlat::get_bg_color() const {
 	return bg_color;
 }
 
-void StyleBoxFlat::set_border_color_all(const Color &p_color) {
-	for (int i = 0; i < 4; i++) {
+void StyleBoxFlat::set_border_color(const Color &p_color) {
 
-		border_color.write()[i] = p_color;
-	}
+	border_color = p_color;
 	emit_changed();
 }
-Color StyleBoxFlat::get_border_color_all() const {
+Color StyleBoxFlat::get_border_color() const {
 
-	return border_color[MARGIN_TOP];
-}
-void StyleBoxFlat::set_border_color(Margin p_border, const Color &p_color) {
-
-	border_color.write()[p_border] = p_color;
-	emit_changed();
-}
-Color StyleBoxFlat::get_border_color(Margin p_border) const {
-
-	return border_color[p_border];
+	return border_color;
 }
 
 void StyleBoxFlat::set_border_width_all(int p_size) {
@@ -562,7 +551,7 @@ inline void set_inner_corner_radius(const Rect2 style_rect, const Rect2 inner_re
 	inner_corner_radius[0] = MAX(corner_radius[0] - rad, 0);
 
 	//tr
-	rad = MIN(border_top, border_bottom);
+	rad = MIN(border_top, border_right);
 	inner_corner_radius[1] = MAX(corner_radius[1] - rad, 0);
 
 	//br
@@ -575,7 +564,7 @@ inline void set_inner_corner_radius(const Rect2 style_rect, const Rect2 inner_re
 }
 
 inline void draw_ring(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color> &colors, const Rect2 style_rect, const int corner_radius[4],
-		const Rect2 ring_rect, const int border_width[4], const Color inner_color[4], const Color outer_color[4], const int corner_detail, const bool fill_center = false) {
+		const Rect2 ring_rect, const int border_width[4], const Color &inner_color, const Color &outer_color, const int corner_detail, const bool fill_center = false) {
 
 	int vert_offset = verts.size();
 	if (!vert_offset) {
@@ -615,11 +604,11 @@ inline void draw_ring(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color
 				Point2 corner_point;
 				if (inner_outer == 0) {
 					radius = inner_corner_radius[corner_index];
-					color = *inner_color;
+					color = inner_color;
 					corner_point = inner_points[corner_index];
 				} else {
 					radius = ring_corner_radius[corner_index];
-					color = *outer_color;
+					color = outer_color;
 					corner_point = outer_points[corner_index];
 				}
 				float x = radius * (float)cos((double)corner_index * Math_PI / 2.0 + (double)detail / (double)adapted_corner_detail * Math_PI / 2.0 + Math_PI) + corner_point.x;
@@ -630,27 +619,27 @@ inline void draw_ring(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color
 		}
 	}
 
-	int vert_count = verts.size() - vert_offset;
+	int ring_vert_count = verts.size() - vert_offset;
 
 	//fill the indices and the colors for the border
-	for (int i = 0; i < vert_count; i++) {
-		indices.push_back(vert_offset + ((i + 0) % vert_count));
-		indices.push_back(vert_offset + ((i + 2) % vert_count));
-		indices.push_back(vert_offset + ((i + 1) % vert_count));
+	for (int i = 0; i < ring_vert_count; i++) {
+		indices.push_back(vert_offset + ((i + 0) % ring_vert_count));
+		indices.push_back(vert_offset + ((i + 2) % ring_vert_count));
+		indices.push_back(vert_offset + ((i + 1) % ring_vert_count));
 	}
 
 	if (fill_center) {
 		//fill the indices and the colors for the center
-		for (int index = 0; index < vert_count / 2; index += 2) {
+		for (int index = 0; index < ring_vert_count / 2; index += 2) {
 			int i = index;
 			//poly 1
 			indices.push_back(vert_offset + i);
-			indices.push_back(vert_offset + vert_count - 4 - i);
+			indices.push_back(vert_offset + ring_vert_count - 4 - i);
 			indices.push_back(vert_offset + i + 2);
 			//poly 2
 			indices.push_back(vert_offset + i);
-			indices.push_back(vert_offset + vert_count - 2 - i);
-			indices.push_back(vert_offset + vert_count - 4 - i);
+			indices.push_back(vert_offset + ring_vert_count - 2 - i);
+			indices.push_back(vert_offset + ring_vert_count - 4 - i);
 		}
 	}
 }
@@ -684,9 +673,21 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	bool rounded_corners = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0);
 	bool aa_on = rounded_corners && anti_aliased;
 
+	bool draw_border = (border_width[0] > 0) || (border_width[1] > 0) || (border_width[2] > 0) || (border_width[3] > 0);
+	Color border_color_alpha = Color(border_color.r, border_color.g, border_color.b, 0);
+
+	bool blend_on = blend_border && draw_border;
+
 	Rect2 style_rect = p_rect.grow_individual(expand_margin[MARGIN_LEFT], expand_margin[MARGIN_TOP], expand_margin[MARGIN_RIGHT], expand_margin[MARGIN_BOTTOM]);
-	if (aa_on) {
-		style_rect = style_rect.grow(-((aa_size + 1) / 2));
+	Rect2 border_style_rect = style_rect;
+	if (aa_on && !blend_on) {
+		float aa_size_grow = 0.5 * ((aa_size + 1) / 2);
+		style_rect = style_rect.grow(-aa_size_grow);
+		for (int i = 0; i < 4; i++) {
+			if (border_width[i] > 0) {
+				border_style_rect = border_style_rect.grow_margin((Margin)i, -aa_size_grow);
+			}
+		}
 	}
 
 	//adapt borders (prevent weird overlapping/glitchy drawings)
@@ -722,63 +723,78 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 		Rect2 shadow_rect = style_rect.grow(shadow_size);
 		shadow_rect.position += shadow_offset;
 
-		Color shadow_colors[4] = { shadow_color, shadow_color, shadow_color, shadow_color };
-		Color shadow_colors_transparent[4];
-		for (int i = 0; i < 4; i++) {
-			shadow_colors_transparent[i] = Color(shadow_color.r, shadow_color.g, shadow_color.b, 0);
-		}
+		Color shadow_color_transparent = Color(shadow_color.r, shadow_color.g, shadow_color.b, 0);
 
 		draw_ring(verts, indices, colors, shadow_inner_rect, adapted_corner,
-				shadow_rect, shadow_width, shadow_colors, shadow_colors_transparent, corner_detail);
+				shadow_rect, shadow_width, shadow_color, shadow_color_transparent, corner_detail);
 
 		if (draw_center) {
 			int no_border[4] = { 0, 0, 0, 0 };
 			draw_ring(verts, indices, colors, shadow_inner_rect, adapted_corner,
-					shadow_inner_rect, no_border, shadow_colors, shadow_colors, corner_detail, true);
+					shadow_inner_rect, no_border, shadow_color, shadow_color, corner_detail, true);
 		}
 	}
 
 	//DRAW border
-	Color bg_color_array[4] = { bg_color, bg_color, bg_color, bg_color };
-	const Color *inner_color = ((blend_border) ? bg_color_array : border_color.read().ptr());
-	draw_ring(verts, indices, colors, style_rect, adapted_corner,
-			style_rect, adapted_border, inner_color, border_color.read().ptr(), corner_detail);
+	if (draw_border) {
+		draw_ring(verts, indices, colors, border_style_rect, adapted_corner,
+				border_style_rect, adapted_border, blend_on ? (draw_center ? bg_color : border_color_alpha) : border_color, border_color, corner_detail);
+	}
 
 	//DRAW INFILL
 	if (draw_center) {
 		int no_border[4] = { 0, 0, 0, 0 };
 		draw_ring(verts, indices, colors, style_rect, adapted_corner,
-				infill_rect, no_border, &bg_color, &bg_color, corner_detail, true);
+				infill_rect, no_border, bg_color, bg_color, corner_detail, true);
 	}
 
 	if (aa_on) {
-
-		//HELPER ARRAYS
-		Color border_color_alpha[4];
-		for (int i = 0; i < 4; i++) {
-			Color c = border_color.read().ptr()[i];
-			border_color_alpha[i] = Color(c.r, c.g, c.b, 0);
+		Rect2 border_inner_rect = infill_rect;
+		int aa_border_width[4];
+		int aa_fill_width[4];
+		if (draw_border) {
+			border_inner_rect = border_style_rect.grow_individual(-adapted_border[MARGIN_LEFT], -adapted_border[MARGIN_TOP], -adapted_border[MARGIN_RIGHT], -adapted_border[MARGIN_BOTTOM]);
+			for (int i = 0; i < 4; i++) {
+				if (border_width[i] > 0) {
+					aa_border_width[i] = aa_size;
+					aa_fill_width[i] = 0;
+				} else {
+					aa_border_width[i] = 0;
+					aa_fill_width[i] = aa_size;
+				}
+			}
+		} else {
+			for (int i = 0; i < 4; i++) {
+				aa_fill_width[i] = aa_size;
+			}
 		}
-		Color alpha_bg = Color(bg_color.r, bg_color.g, bg_color.b, 0);
-		Color bg_color_array_alpha[4] = { alpha_bg, alpha_bg, alpha_bg, alpha_bg };
-
-		int aa_border_width[4] = { aa_size, aa_size, aa_size, aa_size };
 
 		if (draw_center) {
-			if (!blend_border) {
+			if (!draw_border || !blend_on) {
+				Rect2 aa_rect = infill_rect.grow_individual(aa_fill_width[MARGIN_LEFT], aa_fill_width[MARGIN_TOP],
+						aa_fill_width[MARGIN_RIGHT], aa_fill_width[MARGIN_BOTTOM]);
+
+				Color alpha_bg = Color(bg_color.r, bg_color.g, bg_color.b, 0);
+
 				//INFILL AA
 				draw_ring(verts, indices, colors, style_rect, adapted_corner,
-						infill_rect.grow(aa_size), aa_border_width, bg_color_array, bg_color_array_alpha, corner_detail);
+						aa_rect, aa_fill_width, bg_color, alpha_bg, corner_detail);
 			}
-		} else if (!(border_width[0] == 0 && border_width[1] == 0 && border_width[2] == 0 && border_width[3] == 0)) {
-			//DRAW INNER BORDER AA
-			draw_ring(verts, indices, colors, style_rect, adapted_corner,
-					infill_rect, aa_border_width, border_color_alpha, border_color.read().ptr(), corner_detail);
 		}
-		//DRAW OUTER BORDER AA
-		if (!(border_width[0] == 0 && border_width[1] == 0 && border_width[2] == 0 && border_width[3] == 0)) {
-			draw_ring(verts, indices, colors, style_rect, adapted_corner,
-					style_rect.grow(aa_size), aa_border_width, border_color.read().ptr(), border_color_alpha, corner_detail);
+
+		if (draw_border) {
+			if (!blend_on) {
+				//DRAW INNER BORDER AA
+				draw_ring(verts, indices, colors, border_style_rect, adapted_corner,
+						border_inner_rect, aa_border_width, border_color_alpha, border_color, corner_detail);
+			}
+
+			Rect2 aa_rect = border_style_rect.grow_individual(aa_border_width[MARGIN_LEFT], aa_border_width[MARGIN_TOP],
+					aa_border_width[MARGIN_RIGHT], aa_border_width[MARGIN_BOTTOM]);
+
+			//DRAW OUTER BORDER AA
+			draw_ring(verts, indices, colors, border_style_rect, adapted_corner,
+					aa_rect, aa_border_width, border_color, border_color_alpha, corner_detail);
 		}
 	}
 
@@ -793,8 +809,8 @@ void StyleBoxFlat::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bg_color", "color"), &StyleBoxFlat::set_bg_color);
 	ClassDB::bind_method(D_METHOD("get_bg_color"), &StyleBoxFlat::get_bg_color);
 
-	ClassDB::bind_method(D_METHOD("set_border_color", "color"), &StyleBoxFlat::set_border_color_all);
-	ClassDB::bind_method(D_METHOD("get_border_color"), &StyleBoxFlat::get_border_color_all);
+	ClassDB::bind_method(D_METHOD("set_border_color", "color"), &StyleBoxFlat::set_border_color);
+	ClassDB::bind_method(D_METHOD("get_border_color"), &StyleBoxFlat::get_border_color);
 
 	ClassDB::bind_method(D_METHOD("set_border_width_all", "width"), &StyleBoxFlat::set_border_width_all);
 	ClassDB::bind_method(D_METHOD("get_border_width_min"), &StyleBoxFlat::get_border_width_min);
@@ -880,11 +896,7 @@ StyleBoxFlat::StyleBoxFlat() {
 
 	bg_color = Color(0.6, 0.6, 0.6);
 	shadow_color = Color(0, 0, 0, 0.6);
-
-	border_color.append(Color(0.8, 0.8, 0.8));
-	border_color.append(Color(0.8, 0.8, 0.8));
-	border_color.append(Color(0.8, 0.8, 0.8));
-	border_color.append(Color(0.8, 0.8, 0.8));
+	border_color = Color(0.8, 0.8, 0.8);
 
 	blend_border = false;
 	draw_center = true;

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -149,7 +149,7 @@ class StyleBoxFlat : public StyleBox {
 
 	Color bg_color;
 	Color shadow_color;
-	PoolVector<Color> border_color;
+	Color border_color;
 
 	int border_width[4];
 	int expand_margin[4];
@@ -174,10 +174,8 @@ public:
 	Color get_bg_color() const;
 
 	//Border Color
-	void set_border_color_all(const Color &p_color);
-	Color get_border_color_all() const;
-	void set_border_color(Margin p_border, const Color &p_color);
-	Color get_border_color(Margin p_border) const;
+	void set_border_color(const Color &p_color);
+	Color get_border_color() const;
 
 	//BORDER
 	//width

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -161,6 +161,7 @@ class StyleBoxFlat : public StyleBox {
 
 	int corner_detail;
 	int shadow_size;
+	Point2 shadow_offset;
 	int aa_size;
 
 protected:
@@ -217,6 +218,9 @@ public:
 
 	void set_shadow_size(const int &p_size);
 	int get_shadow_size() const;
+
+	void set_shadow_offset(const Point2 &p_offset);
+	Point2 get_shadow_offset() const;
 
 	//ANTI_ALIASING
 	void set_anti_aliased(const bool &p_anti_aliased);


### PR DESCRIPTION
This change adds an offset property to box style shadows that can be used to adjust the position of the shadow behind the panel.

<img src="https://user-images.githubusercontent.com/1075032/53761501-fddb5500-3ec5-11e9-91ae-14592ee6c954.png" width=300 />

<img src="https://user-images.githubusercontent.com/1075032/53761511-00d64580-3ec6-11e9-8bc8-5ae0d850e0cc.png" width=300 />