### PR TITLE
Fix creating editor data, config and cache paths

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -780,12 +780,6 @@ void EditorSettings::create() {
 		// Validate/create data dir and subdirectories
 
 		dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		if (dir->change_dir(data_path) != OK) {
-			ERR_PRINT("Cannot find path for data directory!");
-			memdelete(dir);
-			goto fail;
-		}
-
 		if (dir->change_dir(data_dir) != OK) {
 			dir->make_dir_recursive(data_dir);
 			if (dir->change_dir(data_dir) != OK) {


### PR DESCRIPTION
We used to abort if the system-specific data folder (e.g. `~/.local`
or `%APPDATA%`) is missing, but the next code chunk actually creates
it with `make_dir_recursive` if missing.

Fixes #26598.

Likely affects 3.0.x too, so should be cherry-picked.