### PR TITLE
Fixing misleading error message when trying to export

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1456,6 +1456,10 @@ List<String> EditorExportPlatformPC::get_binary_extensions(const Ref<EditorExpor
 Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
+	if (!FileAccess::exists(p_path.get_base_dir())) {
+		return ERR_FILE_BAD_PATH;
+	}
+
 	String custom_debug = p_preset->get("custom_template/debug");
 	String custom_release = p_preset->get("custom_template/release");
 

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1012,7 +1012,11 @@ void ProjectExportDialog::_export_all(bool p_debug) {
 
 		Error err = platform->export_project(preset, p_debug, preset->get_export_path(), 0);
 		if (err != OK) {
-			error_dialog->set_text(TTR("Export templates for this platform are missing/corrupted:") + " " + platform->get_name());
+			if (err == ERR_FILE_BAD_PATH) {
+				error_dialog->set_text(TTR("The given export path doesn't exist:") + "\n" + preset->get_export_path().get_base_dir());
+			} else {
+				error_dialog->set_text(TTR("Export templates for this platform are missing/corrupted:") + " " + platform->get_name());
+			}
 			error_dialog->show();
 			error_dialog->popup_centered_minsize(Size2(300, 80));
 			ERR_PRINT("Failed to export project");

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1489,6 +1489,10 @@ public:
 			}
 		}
 
+		if (!FileAccess::exists(p_path.get_base_dir())) {
+			return ERR_FILE_BAD_PATH;
+		}
+
 		FileAccess *src_f = NULL;
 		zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
 

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -840,6 +840,10 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 		}
 	}
 
+	if (!FileAccess::exists(dest_dir)) {
+		return ERR_FILE_BAD_PATH;
+	}
+
 	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	if (da) {
 		String current_dir = da->get_current_dir();

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -211,6 +211,10 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 			template_path = find_export_template(EXPORT_TEMPLATE_WEBASSEMBLY_RELEASE);
 	}
 
+	if (!FileAccess::exists(p_path.get_base_dir())) {
+		return ERR_FILE_BAD_PATH;
+	}
+
 	if (template_path != String() && !FileAccess::exists(template_path)) {
 		EditorNode::get_singleton()->show_warning(TTR("Template file not found:") + "\n" + template_path);
 		return ERR_FILE_NOT_FOUND;

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -425,6 +425,10 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		}
 	}
 
+	if (!FileAccess::exists(p_path.get_base_dir())) {
+		return ERR_FILE_BAD_PATH;
+	}
+
 	FileAccess *src_f = NULL;
 	zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
 

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1265,6 +1265,10 @@ public:
 			}
 		}
 
+		if (!FileAccess::exists(p_path.get_base_dir())) {
+			return ERR_FILE_BAD_PATH;
+		}
+
 		Error err = OK;
 
 		FileAccess *fa_pack = FileAccess::open(p_path, FileAccess::WRITE, &err);


### PR DESCRIPTION
This patch fixes the misleading error message when users try to "Export all" into an invalid destination path.

It's not perfect, but I think that it will do the job. It's being a while since I wrote something in C++, but I would like to get back my skills, in this case, I'm all in for constructive reviews.

Also, I notice that we have too many places throwing errors, is that expected? Sometimes we have two messages, one for warning immediately followed by an error message.

Closes #26539