### PR TITLE
Ensure to disable freelook when leaving spatial editor

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2108,9 +2108,11 @@ void SpatialEditorViewport::_notification(int p_what) {
 
 		set_process(visible);
 
-		if (visible)
+		if (visible) {
 			_update_camera(0);
-
+		} else {
+			set_freelook_active(false);
+		}
 		call_deferred("update_transform_gizmo_view");
 	}
 


### PR DESCRIPTION
Fixes and prevents the problem with mouse getting stuck in MOUSE_MODE_CAPTURED when switching to canvas item editor plugin by any means other than manually (with mouse).

Fixes #25491.