### PR TITLE
Fix general issues with filesystem-related UI components in the editor

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1205,8 +1205,10 @@ void EditorFileDialog::_update_favorites() {
 			if (name == current)
 				setthis = true;
 			name = "/";
+
+			favorites->add_item(name, folder_icon);
 		} else if (name.ends_with("/")) {
-			if (name == current)
+			if (name == current || name == current + "/")
 				setthis = true;
 			name = name.substr(0, name.length() - 1);
 			name = name.get_file();
@@ -1229,6 +1231,8 @@ void EditorFileDialog::_favorite_toggled(bool p_toggle) {
 	bool res = access == ACCESS_RESOURCES;
 
 	String cd = get_current_dir();
+	if (!cd.ends_with("/"))
+		cd += "/";
 
 	Vector<String> favorited = EditorSettings::get_singleton()->get_favorites();
 
@@ -1244,13 +1248,10 @@ void EditorFileDialog::_favorite_toggled(bool p_toggle) {
 		}
 	}
 
-	if (found) {
+	if (found)
 		favorited.erase(cd);
-		favorite->set_pressed(false);
-	} else {
+	else
 		favorited.push_back(cd);
-		favorite->set_pressed(true);
-	}
 
 	EditorSettings::get_singleton()->set_favorites(favorited);
 
@@ -1494,7 +1495,9 @@ EditorFileDialog::EditorFileDialog() {
 	HBoxContainer *pathhb = memnew(HBoxContainer);
 
 	dir_prev = memnew(ToolButton);
+	dir_prev->set_tooltip(TTR("Previous Folder"));
 	dir_next = memnew(ToolButton);
+	dir_next->set_tooltip(TTR("Next Folder"));
 	dir_up = memnew(ToolButton);
 	dir_up->set_tooltip(TTR("Go to parent folder"));
 
@@ -1513,12 +1516,14 @@ EditorFileDialog::EditorFileDialog() {
 	dir->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	refresh = memnew(ToolButton);
+	refresh->set_tooltip(TTR("Refresh"));
 	refresh->connect("pressed", this, "_update_file_list");
 	pathhb->add_child(refresh);
 
 	favorite = memnew(ToolButton);
 	favorite->set_flat(true);
 	favorite->set_toggle_mode(true);
+	favorite->set_tooltip(TTR("(Un)favorite current folder."));
 	favorite->connect("toggled", this, "_favorite_toggled");
 	pathhb->add_child(favorite);
 
@@ -1532,6 +1537,7 @@ EditorFileDialog::EditorFileDialog() {
 	mode_thumbnails->set_toggle_mode(true);
 	mode_thumbnails->set_pressed(display_mode == DISPLAY_THUMBNAILS);
 	mode_thumbnails->set_button_group(view_mode_group);
+	mode_thumbnails->set_tooltip(TTR("View items as a grid of thumbnails."));
 	pathhb->add_child(mode_thumbnails);
 
 	mode_list = memnew(ToolButton);
@@ -1539,6 +1545,7 @@ EditorFileDialog::EditorFileDialog() {
 	mode_list->set_toggle_mode(true);
 	mode_list->set_pressed(display_mode == DISPLAY_LIST);
 	mode_list->set_button_group(view_mode_group);
+	mode_list->set_tooltip(TTR("View items as a list."));
 	pathhb->add_child(mode_list);
 
 	drives = memnew(OptionButton);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -283,7 +283,7 @@ void FileSystemDock::_notification(int p_what) {
 			String ei = "EditorIcons";
 			button_reload->set_icon(get_icon("Reload", ei));
 			button_toggle_display_mode->set_icon(get_icon("Panels2", ei));
-			button_file_list_display_mode->connect("toggled", this, "_toggle_file_display");
+			button_file_list_display_mode->connect("pressed", this, "_toggle_file_display");
 
 			files->connect("item_activated", this, "_file_list_activate_file");
 			button_hist_next->connect("pressed", this, "_fw_history");
@@ -350,7 +350,7 @@ void FileSystemDock::_notification(int p_what) {
 			button_toggle_display_mode->set_icon(get_icon("Panels2", ei));
 			button_hist_next->set_icon(get_icon("Forward", ei));
 			button_hist_prev->set_icon(get_icon("Back", ei));
-			if (button_file_list_display_mode->is_pressed()) {
+			if (file_list_display_mode == FILE_LIST_DISPLAY_THUMBNAILS) {
 				button_file_list_display_mode->set_icon(get_icon("FileThumbnail", "EditorIcons"));
 			} else {
 				button_file_list_display_mode->set_icon(get_icon("FileList", "EditorIcons"));
@@ -501,8 +501,8 @@ void FileSystemDock::_tree_thumbnail_done(const String &p_path, const Ref<Textur
 	}
 }
 
-void FileSystemDock::_toggle_file_display(bool p_active) {
-	_set_file_display(p_active);
+void FileSystemDock::_toggle_file_display() {
+	_set_file_display(file_list_display_mode != FILE_LIST_DISPLAY_LIST);
 	emit_signal("display_mode_changed");
 }
 
@@ -1692,8 +1692,7 @@ void FileSystemDock::set_file_list_display_mode(FileListDisplayMode p_mode) {
 	if (p_mode == file_list_display_mode)
 		return;
 
-	button_file_list_display_mode->set_pressed(p_mode == FILE_LIST_DISPLAY_LIST);
-	_toggle_file_display(p_mode == FILE_LIST_DISPLAY_LIST);
+	_toggle_file_display();
 }
 
 Variant FileSystemDock::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
@@ -2377,29 +2376,6 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	tree_search_box->connect("text_changed", this, "_search_changed", varray(tree_search_box));
 	toolbar2_hbc->add_child(tree_search_box);
 
-	//toolbar_hbc->add_spacer();
-
-	//Control *spacer = memnew( Control);
-
-	/*
-	button_open = memnew( Button );
-	button_open->set_flat(true);
-	button_open->connect("pressed",this,"_tree_toggle_collapsed");
-	toolbar_hbc->add_child(button_open);
-	button_open->hide();
-	button_open->set_focus_mode(FOCUS_NONE);
-	button_open->set_tooltip("Open the selected file.\nOpen as scene if a scene, or as resource otherwise.");
-
-
-	button_instance = memnew( Button );
-	button_instance->set_flat(true);
-	button_instance->connect("pressed",this,"_instance_pressed");
-	toolbar_hbc->add_child(button_instance);
-	button_instance->hide();
-	button_instance->set_focus_mode(FOCUS_NONE);
-	button_instance->set_tooltip(TTR("Instance the selected scene(s) as child of the selected node."));
-
-*/
 	file_list_popup = memnew(PopupMenu);
 	file_list_popup->set_hide_on_window_lose_focus(true);
 	add_child(file_list_popup);
@@ -2441,7 +2417,6 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	path_hb->add_child(file_list_search_box);
 
 	button_file_list_display_mode = memnew(ToolButton);
-	button_file_list_display_mode->set_toggle_mode(true);
 	path_hb->add_child(button_file_list_display_mode);
 
 	files = memnew(ItemList);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -181,7 +181,7 @@ private:
 	void _tree_gui_input(Ref<InputEvent> p_event);
 
 	void _update_file_list(bool p_keep_selection);
-	void _toggle_file_display(bool p_active);
+	void _toggle_file_display();
 	void _set_file_display(bool p_active);
 	void _fs_changed();
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -861,7 +861,7 @@ FileDialog::FileDialog() {
 	HBoxContainer *hbc = memnew(HBoxContainer);
 
 	dir_up = memnew(ToolButton);
-	dir_up->set_tooltip(RTR("Go to parent folder"));
+	dir_up->set_tooltip(RTR("Go to parent folder."));
 	hbc->add_child(dir_up);
 	dir_up->connect("pressed", this, "_go_up");
 
@@ -871,6 +871,7 @@ FileDialog::FileDialog() {
 	dir->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	refresh = memnew(ToolButton);
+	refresh->set_tooltip(RTR("Refresh"));
 	refresh->connect("pressed", this, "_update_file_list");
 	hbc->add_child(refresh);
 


### PR DESCRIPTION
- Fix "index out of size" error when opening the `EditorFileDialog` when "res://" is a favorite directory.
- Fix "res://" not appearing in the `EditorFileDialog`'s favorite list when marked as one.
- Fix favorite toggling in `EditorFileDialog` if the path doesn't end with a "/".
- Change the item view mode button in the `FileSystem` dock to not have a toggle-like look.
- General tooltip additions and touch-ups.