### PR TITLE
Added get_noise_1d

### DIFF
--- a/modules/opensimplex/open_simplex_noise.cpp
+++ b/modules/opensimplex/open_simplex_noise.cpp
@@ -173,6 +173,7 @@ void OpenSimplexNoise::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_image", "width", "height"), &OpenSimplexNoise::get_image);
 	ClassDB::bind_method(D_METHOD("get_seamless_image", "size"), &OpenSimplexNoise::get_seamless_image);
 
+	ClassDB::bind_method(D_METHOD("get_noise_1d", "x"), &OpenSimplexNoise::get_noise_1d);
 	ClassDB::bind_method(D_METHOD("get_noise_2d", "x", "y"), &OpenSimplexNoise::get_noise_2d);
 	ClassDB::bind_method(D_METHOD("get_noise_3d", "x", "y", "z"), &OpenSimplexNoise::get_noise_3d);
 	ClassDB::bind_method(D_METHOD("get_noise_4d", "x", "y", "z", "w"), &OpenSimplexNoise::get_noise_4d);
@@ -185,6 +186,11 @@ void OpenSimplexNoise::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "period", PROPERTY_HINT_RANGE, "0.1,256.0,0.1"), "set_period", "get_period");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "persistence", PROPERTY_HINT_RANGE, "0.0,1.0,0.001"), "set_persistence", "get_persistence");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lacunarity", PROPERTY_HINT_RANGE, "0.1,4.0,0.01"), "set_lacunarity", "get_lacunarity");
+}
+
+float OpenSimplexNoise::get_noise_1d(float x) {
+
+	return get_noise_2d(x, 1.0);
 }
 
 float OpenSimplexNoise::get_noise_2d(float x, float y) {

--- a/modules/opensimplex/open_simplex_noise.h
+++ b/modules/opensimplex/open_simplex_noise.h
@@ -73,6 +73,7 @@ public:
 	Ref<Image> get_image(int p_width, int p_height);
 	Ref<Image> get_seamless_image(int p_size);
 
+	float get_noise_1d(float x);
 	float get_noise_2d(float x, float y);
 	float get_noise_3d(float x, float y, float z);
 	float get_noise_4d(float x, float y, float z, float w);


### PR DESCRIPTION
Referencing #26457 . Although it seems trivial, it would be useful to have a `get_noise_1d()` function to build procedurally generated heightmaps ( used in 2D games like Terraria or Worms). This can be used directly without needing to understand how to generate it through `get_noise_2d()`.

*Bugsquad edit:* Fixes #26457.