### PR TITLE
Pause AudioStreamPlayer on SceneTree pause

### DIFF
--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -91,8 +91,10 @@ void AudioStreamPlayer::_mix_internal(bool p_fadeout) {
 
 void AudioStreamPlayer::_mix_audio() {
 
-	if (!stream_playback.is_valid() || !active)
+	if (!stream_playback.is_valid() || !active ||
+			(stream_paused && !stream_fade)) {
 		return;
+	}
 
 	if (stream_fade) {
 		_mix_internal(true);


### PR DESCRIPTION
As title says. Done analogically to AudioStreamPlayer2D/3D. The other two have some `stream_fade_out` and `stream_fade_in` properties, while AudioStreamPlayer has just `stream_fade`, but seems to work anyways.

Fixes #26512