### PR TITLE
Fix attaching script after removing one

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -336,9 +336,13 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		} break;
 		case TOOL_ATTACH_SCRIPT: {
 
+			List<Node *> selection = editor_selection->get_selected_node_list();
+			if (selection.empty())
+				break;
+
 			Node *selected = scene_tree->get_selected();
 			if (!selected)
-				break;
+				selected = selection.front()->get();
 
 			Ref<Script> existing = selected->get_script();
 


### PR DESCRIPTION
Fixes #26320

I investigated the issue and the culprit was this:
```
Node *selected = scene_tree->get_selected();
if (!selected)
    break;
```
When scene tree dock loses focus, it still has selection, but `get_selected()` returns NULL. So I did it in similar way as clearing script works, i.e. I get the selection list, but the "selected node" is still used. If there's no "selected node", the first element from selection list is used instead.