### PR TITLE
makerst: make vararg methods look the same as in editor help

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -950,6 +950,12 @@ def make_method_signature(class_def, method_def, make_ref, state):  # type: (Cla
         if arg.default_value is not None:
             out += '=' + arg.default_value
 
+    if isinstance(method_def, MethodDef) and method_def.qualifiers is not None and 'vararg' in method_def.qualifiers:
+        if len(method_def.parameters) > 0:
+            out += ', ...'
+        else:
+            out += '...'
+
     out += ' **)**'
 
     if isinstance(method_def, MethodDef) and method_def.qualifiers is not None:


### PR DESCRIPTION
In the editor help methods with variable arguments look like this: `Variant call_group( String group, String method, ... ) vararg` but the online class ref has `Variant call_group ( String group, String method ) vararg`.
This adds the `...` part to the latter.