### PR TITLE
Fix CPUParticles2D and 3D which create particles outside emission shape.

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -856,7 +856,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 		p.transform.elements[0] *= base_scale;
 		p.transform.elements[1] *= base_scale;
 
-		p.transform[2] += p.velocity * local_delta;
+		p.transform[2] += p.velocity * p_delta;
 	}
 }
 

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -901,7 +901,7 @@ void CPUParticles::_particles_process(float p_delta) {
 			p.transform.origin.z = 0.0;
 		}
 
-		p.transform.origin += p.velocity * local_delta;
+		p.transform.origin += p.velocity * p_delta;
 	}
 }
 


### PR DESCRIPTION
I'm totally not sure if this is correct fix but now CPUParticles2D and CPUParticles works fine.

Fix #26648