### PR TITLE
Improve/fix picking

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -355,6 +355,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 				Ref<InputEventMouseButton> button_event;
 				button_event.instance();
 
+				button_event->set_device(-1);
 				button_event->set_position(st->get_position());
 				button_event->set_global_position(st->get_position());
 				button_event->set_pressed(st->is_pressed());
@@ -383,6 +384,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 			Ref<InputEventMouseMotion> motion_event;
 			motion_event.instance();
 
+			motion_event->set_device(-1);
 			motion_event->set_position(sd->get_position());
 			motion_event->set_global_position(sd->get_position());
 			motion_event->set_relative(sd->get_relative());
@@ -600,6 +602,7 @@ void InputDefault::ensure_touch_mouse_raised() {
 		Ref<InputEventMouseButton> button_event;
 		button_event.instance();
 
+		button_event->set_device(-1);
 		button_event->set_position(mouse_pos);
 		button_event->set_global_position(mouse_pos);
 		button_event->set_pressed(false);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -226,7 +226,6 @@ private:
 	bool handle_input_locally;
 	bool local_input_handled;
 
-	void _test_new_mouseover(ObjectID new_collider);
 	Map<ObjectID, uint64_t> physics_2d_mouseover;
 
 	Ref<World2D> world_2d;


### PR DESCRIPTION
- Acknowledge mouse button events as position tellers (to make picking more solid; for instance, the touch mouse is raised with a mouse unpressed event that may have a more current position)
- Forget mouse position for physics if touch mouse raised (because the position known as last is no longer meaningful)
- Remove needless check for mouse over/exit (now there's code to inject an spurious move to ensure repicking if camera/objects have moved) <- @reduz, please confirm my assumption here is valid
- Restrict 2D mouse over/exit to mouse events (including emulated from touch; true touches shouldn't trigger the signals; they are just sent as events)
- Assign a device id of -1 to emulated mouse events

Fixes #26460.