### PR TITLE
Restart game on GL context loss on Android

### DIFF
--- a/platform/android/AndroidManifest.xml.template
+++ b/platform/android/AndroidManifest.xml.template
@@ -36,4 +36,9 @@ $$ADD_APPLICATION_CHUNKS$$
 
     </application>
 
+    <instrumentation android:icon="@drawable/icon"
+                     android:label="@string/godot_project_name_string"
+                     android:name="org.godotengine.godot.GodotInstrumentation"
+                     android:targetPackage="com.godot.game" />
+
 </manifest>

--- a/platform/android/java/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotIO.java
@@ -500,11 +500,6 @@ public class GodotIO {
 		return (int)(metrics.density * 160f);
 	}
 
-	public boolean needsReloadHooks() {
-
-		return false;
-	}
-
 	public void showKeyboard(String p_existing_text) {
 		if (edit != null)
 			edit.showKeyboard(p_existing_text);

--- a/platform/android/java/src/org/godotengine/godot/GodotInstrumentation.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotInstrumentation.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  GodotLib.java                                                        */
+/*  GodotInstrumentation.java                                            */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -30,45 +30,21 @@
 
 package org.godotengine.godot;
 
-// Wrapper for native library
+import android.app.Instrumentation;
+import android.content.Intent;
+import android.os.Bundle;
 
-public class GodotLib {
+public class GodotInstrumentation extends Instrumentation {
+	private Intent intent;
 
-	public static GodotIO io;
-
-	static {
-		System.loadLibrary("godot_android");
+	@Override
+	public void onCreate(Bundle arguments) {
+		intent = arguments.getParcelable("intent");
+		start();
 	}
 
-	/**
-     * @param width the current view width
-     * @param height the current view height
-     */
-
-	public static native void initialize(Godot p_instance, Object p_asset_manager, boolean use_apk_expansion);
-	public static native void setup(String[] p_cmdline);
-	public static native void resize(int width, int height);
-	public static native void newcontext(boolean p_32_bits);
-	public static native void back();
-	public static native void step();
-	public static native void touch(int what, int pointer, int howmany, int[] arr);
-	public static native void accelerometer(float x, float y, float z);
-	public static native void gravity(float x, float y, float z);
-	public static native void magnetometer(float x, float y, float z);
-	public static native void gyroscope(float x, float y, float z);
-	public static native void key(int p_scancode, int p_unicode_char, boolean p_pressed);
-	public static native void joybutton(int p_device, int p_but, boolean p_pressed);
-	public static native void joyaxis(int p_device, int p_axis, float p_value);
-	public static native void joyhat(int p_device, int p_hat_x, int p_hat_y);
-	public static native void joyconnectionchanged(int p_device, boolean p_connected, String p_name);
-	public static native void focusin();
-	public static native void focusout();
-	public static native void audio();
-	public static native void singleton(String p_name, Object p_object);
-	public static native void method(String p_sname, String p_name, String p_ret, String[] p_params);
-	public static native String getGlobal(String p_key);
-	public static native void callobject(int p_ID, String p_method, Object[] p_params);
-	public static native void calldeferred(int p_ID, String p_method, Object[] p_params);
-
-	public static native void setVirtualKeyboardHeight(int p_height);
+	@Override
+	public void onStart() {
+		startActivitySync(intent);
+	}
 }

--- a/platform/android/java/src/org/godotengine/godot/GodotView.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotView.java
@@ -79,7 +79,6 @@ public class GodotView extends GLSurfaceView implements InputDeviceListener {
 	private Context ctx;
 
 	private GodotIO io;
-	private static boolean firsttime = true;
 	private static boolean use_gl3 = false;
 	private static boolean use_32 = false;
 	private static boolean use_debug_opengl = false;
@@ -97,10 +96,8 @@ public class GodotView extends GLSurfaceView implements InputDeviceListener {
 
 		activity = p_activity;
 
-		if (!p_io.needsReloadHooks()) {
-			//will only work on SDK 11+!!
-			setPreserveEGLContextOnPause(true);
-		}
+		setPreserveEGLContextOnPause(true);
+
 		mInputManager = InputManagerCompat.Factory.getInputManager(this.getContext());
 		mInputManager.registerInputDeviceListener(this, null);
 		init(false, 16, 0);
@@ -718,8 +715,7 @@ public class GodotView extends GLSurfaceView implements InputDeviceListener {
 
 		public void onSurfaceChanged(GL10 gl, int width, int height) {
 
-			GodotLib.resize(width, height, !firsttime);
-			firsttime = false;
+			GodotLib.resize(width, height);
 			for (int i = 0; i < Godot.singleton_count; i++) {
 				Godot.singletons[i].onGLSurfaceChanged(gl, width, height);
 			}

--- a/platform/android/java_glue.h
+++ b/platform/android/java_glue.h
@@ -35,9 +35,9 @@
 #include <jni.h>
 
 extern "C" {
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *env, jobject obj, jobject activity, jboolean p_need_reload_hook, jobject p_asset_manager, jboolean p_use_apk_expansion);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *env, jobject obj, jobject activity, jobject p_asset_manager, jboolean p_use_apk_expansion);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jobject obj, jobjectArray p_cmdline);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, jobject obj, jint width, jint height, jboolean reload);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, jobject obj, jint width, jint height);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_newcontext(JNIEnv *env, jobject obj, bool p_32_bits);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jobject obj);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jobject obj);

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -548,14 +548,6 @@ void OS_Android::set_display_size(Size2 p_size) {
 	default_videomode.height = p_size.y;
 }
 
-void OS_Android::reload_gfx() {
-
-	if (gfx_init_func)
-		gfx_init_func(gfx_init_ud, use_gl2);
-	//if (rasterizer)
-	//	rasterizer->reload_vram();
-}
-
 Error OS_Android::shell_open(String p_uri) {
 
 	if (open_uri_func)
@@ -605,11 +597,6 @@ int OS_Android::get_screen_dpi(int p_screen) const {
 		return get_screen_dpi_func();
 	}
 	return 160;
-}
-
-void OS_Android::set_need_reload_hooks(bool p_needs_them) {
-
-	use_reload_hooks = p_needs_them;
 }
 
 String OS_Android::get_user_data_dir() const {
@@ -765,7 +752,6 @@ OS_Android::OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURI
 	set_screen_orientation_func = p_screen_orient;
 	set_keep_screen_on_func = p_set_keep_screen_on_func;
 	alert_func = p_alert_func;
-	use_reload_hooks = false;
 
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(AndroidLogger));

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -94,7 +94,6 @@ private:
 	void *gfx_init_ud;
 
 	bool use_gl2;
-	bool use_reload_hooks;
 	bool use_apk_expansion;
 
 	bool use_16bits_fbo;
@@ -203,10 +202,8 @@ public:
 	void set_opengl_extensions(const char *p_gl_extensions);
 	void set_display_size(Size2 p_size);
 
-	void reload_gfx();
 	void set_context_is_16_bits(bool p_is_16);
 
-	void set_need_reload_hooks(bool p_needs_them);
 	virtual void set_screen_orientation(ScreenOrientation p_orientation);
 
 	virtual Error shell_open(String p_uri);


### PR DESCRIPTION
Bonus:
Remove useless old code about reload hooks

Fixes #22955.

@godotengine/android, I believe that having the app instrumented on subsequent launches will not affect performance since no monitors nor any kind of watching is enabled, but I may be wrong.