### PR TITLE
Removed the resource preview thread from the server build

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -188,6 +188,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 
 void EditorResourcePreview::_thread() {
 
+#ifndef SERVER_ENABLED
 	while (!exit) {
 
 		preview_sem->wait();
@@ -313,7 +314,7 @@ void EditorResourcePreview::_thread() {
 			preview_mutex->unlock();
 		}
 	}
-
+#endif
 	exited = true;
 }
 


### PR DESCRIPTION
This solution seems to fix my reproduction case for the hanging server build.
The problem seems to start after e8d31cc765d5 but I could not do a proper bisect, I used revert instead but I am not sure about the outcome.
I was able to reproduce on multiple Linux systems.

I found out that the export process was stuck in the `EditorResourcePreview::stop()` function, in the `while(!exited)` part, so I came up with this "fix" but it seems very dirty.

Comments, opinions and improvements are very very welcome, maybe from @hpvb and @reduz ?
Thanks in advance!