### PR TITLE
OS X: do not use cached mouse position on mouse down

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1294,6 +1294,10 @@ void EditorInspector::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &
 	for (int i = idx; i < inspector_plugin_count - 1; i++) {
 		inspector_plugins[i] = inspector_plugins[i + 1];
 	}
+
+	if (idx == inspector_plugin_count - 1)
+		inspector_plugins[idx] = Ref<EditorInspectorPlugin>();
+
 	inspector_plugin_count--;
 }
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -602,11 +602,14 @@ static void _mouseDownEvent(NSEvent *event, int index, int mask, bool pressed) {
 	Ref<InputEventMouseButton> mb;
 	mb.instance();
 
+    const CGFloat backingScaleFactor = [[event window] backingScaleFactor];
+    const Vector2 pos = get_mouse_pos([event locationInWindow], backingScaleFactor);
+    
 	get_key_modifier_state([event modifierFlags], mb);
 	mb->set_button_index(index);
 	mb->set_pressed(pressed);
-	mb->set_position(Vector2(mouse_x, mouse_y));
-	mb->set_global_position(Vector2(mouse_x, mouse_y));
+	mb->set_position(pos);
+	mb->set_global_position(pos);
 	mb->set_button_mask(button_mask);
 	if (index == BUTTON_LEFT && pressed) {
 		mb->set_doubleclick([event clickCount] == 2);


### PR DESCRIPTION
Without this fix, godot becomes unusable with an iiyama touchscreen on OS X.

On OS X godot only updates the mouse position on mouse move. But on a touchscreen there is no mouse move preceding a mouse down event. So the old (cached) mouse move position is used to trigger the touch down event. This results in irratical touch down and up behaviours. This PR makes sure the mouse position is updated from the OS before feeding the event into the Input system.