### PR TITLE
Add Color Mask Flags to Materials

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -1264,6 +1264,12 @@ bool RasterizerSceneGLES2::_setup_material(RasterizerStorageGLES2::Material *p_m
 		} break;
 	}
 
+	glColorMask(
+			p_material->shader->spatial.no_color_write_red ? GL_FALSE : GL_TRUE,
+			p_material->shader->spatial.no_color_write_green ? GL_FALSE : GL_TRUE,
+			p_material->shader->spatial.no_color_write_blue ? GL_FALSE : GL_TRUE,
+			p_material->shader->spatial.no_color_write_alpha ? GL_FALSE : GL_TRUE);
+
 	int tc = p_material->textures.size();
 	Pair<StringName, RID> *textures = p_material->textures.ptrw();
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1267,6 +1267,10 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			p_shader->spatial.uses_vertex = false;
 			p_shader->spatial.writes_modelview_or_projection = false;
 			p_shader->spatial.uses_world_coordinates = false;
+			p_shader->spatial.no_color_write_red = false;
+			p_shader->spatial.no_color_write_green = false;
+			p_shader->spatial.no_color_write_blue = false;
+			p_shader->spatial.no_color_write_alpha = false;
 
 			shaders.actions_scene.render_mode_values["blend_add"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_ADD);
 			shaders.actions_scene.render_mode_values["blend_mix"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MIX);
@@ -1284,6 +1288,11 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 
 			shaders.actions_scene.render_mode_flags["unshaded"] = &p_shader->spatial.unshaded;
 			shaders.actions_scene.render_mode_flags["depth_test_disable"] = &p_shader->spatial.no_depth_test;
+
+			shaders.actions_scene.render_mode_flags["color_write_red_disable"] = &p_shader->spatial.no_color_write_red;
+			shaders.actions_scene.render_mode_flags["color_write_green_disable"] = &p_shader->spatial.no_color_write_green;
+			shaders.actions_scene.render_mode_flags["color_write_blue_disable"] = &p_shader->spatial.no_color_write_blue;
+			shaders.actions_scene.render_mode_flags["color_write_alpha_disable"] = &p_shader->spatial.no_color_write_alpha;
 
 			shaders.actions_scene.render_mode_flags["vertex_lighting"] = &p_shader->spatial.uses_vertex_lighting;
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -473,6 +473,10 @@ public:
 			bool writes_modelview_or_projection;
 			bool uses_vertex_lighting;
 			bool uses_world_coordinates;
+			bool no_color_write_red;
+			bool no_color_write_green;
+			bool no_color_write_blue;
+			bool no_color_write_alpha;
 
 		} spatial;
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1130,6 +1130,24 @@ bool RasterizerSceneGLES3::_setup_material(RasterizerStorageGLES3::Material *p_m
 		state.current_depth_draw = p_material->shader->spatial.depth_draw_mode;
 	}
 
+	if (state.current_color_mask_unknown ||
+			state.current_color_mask_red != !p_material->shader->spatial.no_color_write_red ||
+			state.current_color_mask_green != !p_material->shader->spatial.no_color_write_green ||
+			state.current_color_mask_blue != !p_material->shader->spatial.no_color_write_blue ||
+			state.current_color_mask_alpha != !p_material->shader->spatial.no_color_write_alpha) {
+		glColorMask(
+				p_material->shader->spatial.no_color_write_red ? GL_FALSE : GL_TRUE,
+				p_material->shader->spatial.no_color_write_green ? GL_FALSE : GL_TRUE,
+				p_material->shader->spatial.no_color_write_blue ? GL_FALSE : GL_TRUE,
+				p_material->shader->spatial.no_color_write_alpha ? GL_FALSE : GL_TRUE);
+
+		state.current_color_mask_unknown = false;
+		state.current_color_mask_red = !p_material->shader->spatial.no_color_write_red;
+		state.current_color_mask_green = !p_material->shader->spatial.no_color_write_green;
+		state.current_color_mask_blue = !p_material->shader->spatial.no_color_write_blue;
+		state.current_color_mask_alpha = !p_material->shader->spatial.no_color_write_alpha;
+	}
+
 #if 0
 	//blend mode
 	if (state.current_blend_mode!=p_material->shader->spatial.blend_mode) {
@@ -2035,6 +2053,7 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 	state.current_blend_mode = -1;
 	state.current_line_width = -1;
 	state.current_depth_draw = -1;
+	state.current_color_mask_unknown = true;
 
 	RasterizerStorageGLES3::Material *prev_material = NULL;
 	RasterizerStorageGLES3::Geometry *prev_geometry = NULL;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -100,6 +100,11 @@ public:
 		int current_depth_draw;
 		bool current_depth_test;
 		GLuint current_main_tex;
+		bool current_color_mask_unknown;
+		bool current_color_mask_red;
+		bool current_color_mask_green;
+		bool current_color_mask_blue;
+		bool current_color_mask_alpha;
 
 		SceneShaderGLES3 scene_shader;
 		CubeToDpShaderGLES3 cube_to_dp_shader;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2097,6 +2097,10 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			p_shader->spatial.uses_vertex = false;
 			p_shader->spatial.writes_modelview_or_projection = false;
 			p_shader->spatial.uses_world_coordinates = false;
+			p_shader->spatial.no_color_write_red = false;
+			p_shader->spatial.no_color_write_green = false;
+			p_shader->spatial.no_color_write_blue = false;
+			p_shader->spatial.no_color_write_alpha = false;
 
 			shaders.actions_scene.render_mode_values["blend_add"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_ADD);
 			shaders.actions_scene.render_mode_values["blend_mix"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MIX);
@@ -2114,6 +2118,11 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 
 			shaders.actions_scene.render_mode_flags["unshaded"] = &p_shader->spatial.unshaded;
 			shaders.actions_scene.render_mode_flags["depth_test_disable"] = &p_shader->spatial.no_depth_test;
+
+			shaders.actions_scene.render_mode_flags["color_write_red_disable"] = &p_shader->spatial.no_color_write_red;
+			shaders.actions_scene.render_mode_flags["color_write_green_disable"] = &p_shader->spatial.no_color_write_green;
+			shaders.actions_scene.render_mode_flags["color_write_blue_disable"] = &p_shader->spatial.no_color_write_blue;
+			shaders.actions_scene.render_mode_flags["color_write_alpha_disable"] = &p_shader->spatial.no_color_write_alpha;
 
 			shaders.actions_scene.render_mode_flags["vertex_lighting"] = &p_shader->spatial.uses_vertex_lighting;
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -493,6 +493,10 @@ public:
 			bool writes_modelview_or_projection;
 			bool uses_vertex_lighting;
 			bool uses_world_coordinates;
+			bool no_color_write_red;
+			bool no_color_write_green;
+			bool no_color_write_blue;
+			bool no_color_write_alpha;
 
 		} spatial;
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -458,6 +458,18 @@ void SpatialMaterial::_update_shader() {
 	if (flags[FLAG_ENSURE_CORRECT_NORMALS]) {
 		code += ",ensure_correct_normals";
 	}
+	if (flags[FLAG_DISABLE_COLOR_WRITE_RED]) {
+		code += ",color_write_red_disable";
+	}
+	if (flags[FLAG_DISABLE_COLOR_WRITE_GREEN]) {
+		code += ",color_write_green_disable";
+	}
+	if (flags[FLAG_DISABLE_COLOR_WRITE_BLUE]) {
+		code += ",color_write_blue_disable";
+	}
+	if (flags[FLAG_DISABLE_COLOR_WRITE_ALPHA]) {
+		code += ",color_write_alpha_disable";
+	}
 	code += ";\n";
 
 	code += "uniform vec4 albedo : hint_color;\n";
@@ -2060,6 +2072,11 @@ void SpatialMaterial::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags_do_not_receive_shadows"), "set_flag", "get_flag", FLAG_DONT_RECEIVE_SHADOWS);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags_disable_ambient_light"), "set_flag", "get_flag", FLAG_DISABLE_AMBIENT_LIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags_ensure_correct_normals"), "set_flag", "get_flag", FLAG_ENSURE_CORRECT_NORMALS);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags_disable_color_write_red"), "set_flag", "get_flag", FLAG_DISABLE_COLOR_WRITE_RED);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags_disable_color_write_green"), "set_flag", "get_flag", FLAG_DISABLE_COLOR_WRITE_GREEN);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags_disable_color_write_blue"), "set_flag", "get_flag", FLAG_DISABLE_COLOR_WRITE_BLUE);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags_disable_color_write_alpha"), "set_flag", "get_flag", FLAG_DISABLE_COLOR_WRITE_ALPHA);
+
 	ADD_GROUP("Vertex Color", "vertex_color");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "vertex_color_use_as_albedo"), "set_flag", "get_flag", FLAG_ALBEDO_FROM_VERTEX_COLOR);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "vertex_color_is_srgb"), "set_flag", "get_flag", FLAG_SRGB_VERTEX_COLOR);
@@ -2256,6 +2273,10 @@ void SpatialMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_DONT_RECEIVE_SHADOWS);
 	BIND_ENUM_CONSTANT(FLAG_DISABLE_AMBIENT_LIGHT);
 	BIND_ENUM_CONSTANT(FLAG_ENSURE_CORRECT_NORMALS);
+	BIND_ENUM_CONSTANT(FLAG_DISABLE_COLOR_WRITE_RED);
+	BIND_ENUM_CONSTANT(FLAG_DISABLE_COLOR_WRITE_GREEN);
+	BIND_ENUM_CONSTANT(FLAG_DISABLE_COLOR_WRITE_BLUE);
+	BIND_ENUM_CONSTANT(FLAG_DISABLE_COLOR_WRITE_ALPHA);
 	BIND_ENUM_CONSTANT(FLAG_MAX);
 
 	BIND_ENUM_CONSTANT(DIFFUSE_BURLEY);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -196,6 +196,12 @@ public:
 		FLAG_DONT_RECEIVE_SHADOWS,
 		FLAG_ENSURE_CORRECT_NORMALS,
 		FLAG_DISABLE_AMBIENT_LIGHT,
+		FLAG_DISABLE_COLOR_WRITE_RED,
+		FLAG_DISABLE_COLOR_WRITE_BLUE,
+		FLAG_DISABLE_COLOR_WRITE_GREEN,
+		FLAG_DISABLE_COLOR_WRITE_ALPHA,
+		// When adding flags, make sure the bit-field
+		// width in SpatialMaterial::MaterialKey is increased
 		FLAG_MAX
 	};
 
@@ -251,7 +257,8 @@ private:
 			uint64_t blend_mode : 2;
 			uint64_t depth_draw_mode : 2;
 			uint64_t cull_mode : 2;
-			uint64_t flags : 18;
+			// This has to have enough bits to store up to FLAG_MAX bits
+			uint64_t flags : 22;
 			uint64_t detail_blend_mode : 2;
 			uint64_t diffuse_mode : 3;
 			uint64_t specular_mode : 2;

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -163,6 +163,11 @@ ShaderTypes::ShaderTypes() {
 
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("depth_test_disable");
 
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("color_write_red_disable");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("color_write_green_disable");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("color_write_blue_disable");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("color_write_alpha_disable");
+
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("cull_back");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("cull_front");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("cull_disabled");


### PR DESCRIPTION
Added the ability to manipulate the OpenGL color mask to materials. This allows for materials that only write to the dept buffer, or other special effects.

This should fix #18901 

In essence it introduces the necessary plumbing to control `glColorMask` from shaders via four new render modes, and adds the necessary flags to SpatialMaterial to easily control these flags without using shaders directly.