### PR TITLE
Do not lose focus when moving through scene tree

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4922,7 +4922,6 @@ void CanvasItemEditorPlugin::make_visible(bool p_visible) {
 		canvas_item_editor->show();
 		canvas_item_editor->set_physics_process(true);
 		VisualServer::get_singleton()->viewport_set_hide_canvas(editor->get_scene_root()->get_viewport_rid(), false);
-		canvas_item_editor->viewport->grab_focus();
 
 	} else {
 


### PR DESCRIPTION
When I change selection from 3d node to 2d in scene tree via UP and DOWN arrow, then scene tree lost focus which is irritating.


Incorrect: https://streamable.com/4d4j6

This PR: https://streamable.com/5efwt

Fix  #25586