### PR TITLE
Fix macOS accumulated mouse scroll events.

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1096,6 +1096,7 @@ static int remapKey(unsigned int key) {
 inline void sendScrollEvent(int button, double factor, int modifierFlags) {
 
 	unsigned int mask = 1 << (button - 1);
+	Vector2 mouse_pos = Vector2(mouse_x, mouse_y);
 
 	Ref<InputEventMouseButton> sc;
 	sc.instance();
@@ -1104,14 +1105,18 @@ inline void sendScrollEvent(int button, double factor, int modifierFlags) {
 	sc->set_button_index(button);
 	sc->set_factor(factor);
 	sc->set_pressed(true);
-	Vector2 mouse_pos = Vector2(mouse_x, mouse_y);
 	sc->set_position(mouse_pos);
 	sc->set_global_position(mouse_pos);
 	button_mask |= mask;
 	sc->set_button_mask(button_mask);
 	OS_OSX::singleton->push_input(sc);
 
+	sc.instance();
+	sc->set_button_index(button);
+	sc->set_factor(factor);
 	sc->set_pressed(false);
+	sc->set_position(mouse_pos);
+	sc->set_global_position(mouse_pos);
 	button_mask &= ~mask;
 	sc->set_button_mask(button_mask);
 	OS_OSX::singleton->push_input(sc);


### PR DESCRIPTION
Mouse up/down event were using same InputEvent object instance.

Fixes #26677