### PR TITLE
Print MSBuild command if also printing output

### DIFF
--- a/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
@@ -92,6 +92,9 @@ namespace GodotSharpTools.Build
 
             bool redirectOutput = !IsDebugMSBuildRequested() && !PrintBuildOutput;
 
+            if (!redirectOutput) // TODO: or if stdout verbose
+                Console.WriteLine($"Running: \"{startInfo.FileName}\" {startInfo.Arguments}");
+
             startInfo.RedirectStandardOutput = redirectOutput;
             startInfo.RedirectStandardError = redirectOutput;
             startInfo.UseShellExecute = false;
@@ -144,6 +147,9 @@ namespace GodotSharpTools.Build
             ProcessStartInfo startInfo = new ProcessStartInfo(GetMSBuildPath(), compilerArgs);
 
             bool redirectOutput = !IsDebugMSBuildRequested() && !PrintBuildOutput;
+
+            if (!redirectOutput) // TODO: or if stdout verbose
+                Console.WriteLine($"Running: \"{startInfo.FileName}\" {startInfo.Arguments}");
 
             startInfo.RedirectStandardOutput = redirectOutput;
             startInfo.RedirectStandardError = redirectOutput;


### PR DESCRIPTION
Little change so it's possible to view the command we're running in case we need to see if there is something wrong with it, or for other purposes (like trying to run the same command in a different environment for testing or debugging).
