### PR TITLE
Added possibility to cleanup all invalid projects in project manager.

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -45,6 +45,7 @@ class ProjectManager : public Control {
 	GDCLASS(ProjectManager, Control);
 
 	Button *erase_btn;
+	Button *erase_invalid_btn;
 	Button *open_btn;
 	Button *rename_btn;
 	Button *run_btn;
@@ -57,6 +58,7 @@ class ProjectManager : public Control {
 	FileDialog *scan_dir;
 	ConfirmationDialog *language_restart_ask;
 	ConfirmationDialog *erase_ask;
+	ConfirmationDialog *erase_invalid_ask;
 	ConfirmationDialog *multi_open_ask;
 	ConfirmationDialog *multi_run_ask;
 	ConfirmationDialog *multi_scan_ask;
@@ -75,6 +77,7 @@ class ProjectManager : public Control {
 	Control *gui_base;
 
 	Map<String, String> selected_list; // name -> main_scene
+	List<String> invalid_list;
 	String last_clicked;
 	bool importing;
 
@@ -89,7 +92,9 @@ class ProjectManager : public Control {
 	void _new_project();
 	void _rename_project();
 	void _erase_project();
+	void _erase_invalid_projects();
 	void _erase_project_confirm();
+	void _erase_invalid_projects_confirm();
 	void _update_project_buttons();
 	void _language_selected(int p_id);
 	void _restart_confirm();


### PR DESCRIPTION
This PR added new button "Clean" to project manager, this button is invisible if project list does not contains projects with invalid paths(grayed) but will be visible if not. If you click on it it will show confirmation dialog which will suggest you to delete all invalid projects at one click.

![image](https://user-images.githubusercontent.com/3036176/53902210-c5688200-4051-11e9-8c72-a39ed238efee.png)
