### PR TITLE
Fixed crash on loading GDNative videos.

### DIFF
--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -355,9 +355,9 @@ RES ResourceFormatLoaderVideoStreamGDNative::load(const String &p_path, const St
 		if (r_error) {
 			*r_error = ERR_CANT_OPEN;
 		}
-		memdelete(f);
 		return RES();
 	}
+	memdelete(f);
 	VideoStreamGDNative *stream = memnew(VideoStreamGDNative);
 	stream->set_file(p_path);
 	Ref<VideoStreamGDNative> ogv_stream = Ref<VideoStreamGDNative>(stream);


### PR DESCRIPTION
Fixed issue with loading a resource supported by the gdnative videodecoders
that does not exist.