### PR TITLE
Fixed MeshInstance2d copying Line2d's default color

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -834,6 +834,8 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 						// materials are ignored in 2D meshes, could be added but many things (ie, lighting mode, reading from screen, etc) would break as they are not meant be set up at this point of drawing
 						glBindVertexArray(s->array_id);
 
+						glVertexAttrib4f(VS::ARRAY_COLOR, 1, 1, 1, 1);
+
 						if (s->index_array_len) {
 							glDrawElements(gl_primitive[s->primitive], s->index_array_len, (s->array_len >= (1 << 16)) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT, 0);
 						} else {


### PR DESCRIPTION
MeshInstance2d now has a default color. MeshInstance2d was inheriting the color of the Line2d that was rendered before the MeshInstance2d.

Fixes: #25760