### PR TITLE
Use mix rate and output latency constants in audio drivers

### DIFF
--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -45,12 +45,12 @@ Error AudioDriverXAudio2::init() {
 	pcm_open = false;
 	samples_in = NULL;
 
-	mix_rate = 48000;
+	mix_rate = GLOBAL_DEF_RST("audio/mix_rate", DEFAULT_MIX_RATE);
 	// FIXME: speaker_mode seems unused in the Xaudio2 driver so far
 	speaker_mode = SPEAKER_MODE_STEREO;
 	channels = 2;
 
-	int latency = GLOBAL_DEF_RST("audio/output_latency", 25);
+	int latency = GLOBAL_DEF_RST("audio/output_latency", DEFAULT_OUTPUT_LATENCY);
 	buffer_size = closest_power_of_2(latency * mix_rate / 1000);
 
 	samples_in = memnew_arr(int32_t, buffer_size * channels);

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -326,7 +326,7 @@ Error AudioDriverOpenSL::capture_stop() {
 
 int AudioDriverOpenSL::get_mix_rate() const {
 
-	return 44100;
+	return 44100; // hardcoded for Android, as selected by SL_SAMPLINGRATE_44_1
 }
 
 AudioDriver::SpeakerMode AudioDriverOpenSL::get_speaker_mode() const {

--- a/platform/haiku/audio_driver_media_kit.cpp
+++ b/platform/haiku/audio_driver_media_kit.cpp
@@ -39,11 +39,11 @@ int32_t *AudioDriverMediaKit::samples_in = NULL;
 Error AudioDriverMediaKit::init() {
 	active = false;
 
-	mix_rate = 44100;
+	mix_rate = GLOBAL_DEF_RST("audio/mix_rate", DEFAULT_MIX_RATE);
 	speaker_mode = SPEAKER_MODE_STEREO;
 	channels = 2;
 
-	int latency = GLOBAL_DEF_RST("audio/output_latency", 25);
+	int latency = GLOBAL_DEF_RST("audio/output_latency", DEFAULT_OUTPUT_LATENCY);
 	buffer_size = next_power_of_2(latency * mix_rate / 1000);
 	samples_in = memnew_arr(int32_t, buffer_size * channels);
 


### PR DESCRIPTION
Fix default mix rate in Xaudio2 and potential shadowing issue in JAndroid.

Other places where 44100 or 48000 are hardcoded:
```
$ rg -g'!thirdparty' 44100
servers/audio_server.h
83:     static const int DEFAULT_MIX_RATE = 44100;

scene/resources/audio_stream_sample.cpp
650:    mix_rate = 44100;

servers/audio/audio_filter_sw.cpp
232:    sampling_rate = 44100;

servers/audio/reverb_sw.cpp
461:    current_params->x = (int)(((int64_t)current_params->x * (int64_t)mix_rate * 8L) / (int64_t)44100); \

editor/import/resource_importer_wav.cpp
78:     r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "force/max_rate_hz", PROPERTY_HINT_EXP_RANGE, "11025,192000,1"), 44100));

servers/audio/effects/reverb.cpp
335:    params.mix_rate = 44100;

servers/audio/effects/audio_effect_pitch_shift.cpp
60:* in unit Hz, ie. 44100 for 44.1 kHz audio. The data passed to the routine in

servers/audio/effects/eq.cpp
209:    mix_rate = 44100;

$ rg -g'!thirdparty' 48000
modules/opus/audio_stream_opus.cpp
37:const float AudioStreamPlaybackOpus::osrate = 48000.0f;
```