### PR TITLE
Define android/modules globally so it appears in Project Settings

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1185,6 +1185,9 @@ ProjectSettings::ProjectSettings() {
 	Compression::gzip_level = GLOBAL_DEF("compression/formats/gzip/compression_level", Z_DEFAULT_COMPRESSION);
 	custom_prop_info["compression/formats/gzip/compression_level"] = PropertyInfo(Variant::INT, "compression/formats/gzip/compression_level", PROPERTY_HINT_RANGE, "-1,9,1");
 
+	// Would ideally be defined in an Android-specific file, but then it doesn't appear in the docs
+	GLOBAL_DEF("android/modules", "");
+
 	using_datapack = false;
 }
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -163,7 +163,11 @@
 		</method>
 	</methods>
 	<members>
+		<member name="android/modules" type="String" setter="" getter="">
+			Comma-separated list of custom Android modules (which must have been built in the Android export templates) using their Java package path, e.g. [code]org/godotengine/org/GodotPaymentV3,org/godotengine/godot/MyCustomSingleton"[/code].
+		</member>
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="">
+			Background color for the boot splash.
 		</member>
 		<member name="application/boot_splash/fullsize" type="bool" setter="" getter="">
 			Scale the boot splash image to the full window length when engine starts (will leave it as default pixel size otherwise).

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -833,7 +833,6 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *en
 static void _initialize_java_modules() {
 
 	if (!ProjectSettings::get_singleton()->has_setting("android/modules")) {
-		print_line("Android modules: Nothing to load, aborting");
 		return;
 	}
 
@@ -853,19 +852,16 @@ static void _initialize_java_modules() {
 		jmethodID getClassLoader = env->GetMethodID(activityClass, "getClassLoader", "()Ljava/lang/ClassLoader;");
 
 		jobject cls = env->CallObjectMethod(_godot_instance, getClassLoader);
-		//cls=env->NewGlobalRef(cls);
 
 		jclass classLoader = env->FindClass("java/lang/ClassLoader");
-		//classLoader=(jclass)env->NewGlobalRef(classLoader);
 
 		jmethodID findClass = env->GetMethodID(classLoader, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
 
 		for (int i = 0; i < mods.size(); i++) {
 
 			String m = mods[i];
-			//jclass singletonClass = env->FindClass(m.utf8().get_data());
 
-			print_line("Loading module: " + m);
+			print_line("Loading Android module: " + m);
 			jstring strClassName = env->NewStringUTF(m.utf8().get_data());
 			jclass singletonClass = (jclass)env->CallObjectMethod(cls, findClass, strClassName);
 
@@ -874,7 +870,6 @@ static void _initialize_java_modules() {
 				ERR_EXPLAIN("Couldn't find singleton for class: " + m);
 				ERR_CONTINUE(!singletonClass);
 			}
-			//singletonClass=(jclass)env->NewGlobalRef(singletonClass);
 
 			jmethodID initialize = env->GetStaticMethodID(singletonClass, "initialize", "(Landroid/app/Activity;)Lorg/godotengine/godot/Godot$SingletonBase;");
 
@@ -1577,7 +1572,3 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *
 	// something
 	env->PopLocalFrame(NULL);
 }
-
-//Main::cleanup();
-
-//return os.get_exit_code();


### PR DESCRIPTION
Define android/modules globally so it appears in Project Settings

Until now people had to add it manually to project.godot to load custom modules.