### PR TITLE
Add a custom TraceListener on Startup for Mono

### DIFF
--- a/modules/mono/glue/Managed/Files/DebuggingUtils.cs
+++ b/modules/mono/glue/Managed/Files/DebuggingUtils.cs
@@ -19,6 +19,12 @@ namespace Godot
             sb.Append(" ");
         }
 
+        public static void InstallTraceListener()
+        {
+            Trace.Listeners.Clear();
+            Trace.Listeners.Add(new GodotTraceListener());
+        }
+
         public static void GetStackFrameInfo(StackFrame frame, out string fileName, out int fileLineNumber, out string methodDecl)
         {
             fileName = frame.GetFileName();

--- a/modules/mono/glue/Managed/Files/GodotTraceListener.cs
+++ b/modules/mono/glue/Managed/Files/GodotTraceListener.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Diagnostics;
+
+namespace Godot
+{
+    internal class GodotTraceListener : TraceListener
+    {
+        public override void Write(string message)
+        {
+            GD.PrintRaw(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            GD.Print(message);
+        }
+
+        public override void Fail(string message, string detailMessage)
+        {
+            GD.PrintErr("Assertion failed: ", message);
+            if (detailMessage != null)
+            {
+                GD.PrintErr("  Details: ", detailMessage);
+            }
+
+            try
+            {
+                var stackTrace = new StackTrace(true).ToString();
+                GD.PrintErr(stackTrace);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -125,6 +125,8 @@ class GDMono {
 	String _get_api_assembly_metadata_path();
 #endif
 
+	void _install_trace_listener();
+
 	void _register_internal_calls();
 
 	Error _load_scripts_domain();


### PR DESCRIPTION
Added a Godot TraceListener, which is automatically installed on startup. Fixes that Debug/Trace Assertions are simply swallowed by Godot.

**Example:**

Put a failing Debug.Assert or Trace.Assert somewhere into your Mono code and see that the assertion is never shown. If you attach Visual Studio to Godot, you'll see the assertion printed in the debugger output, but not in the Godot console / logfile.

It might be contentious to install the listener only when DEBUG_ENABLED is set, because Trace.Fail will *also* use this listener, and that class is intended for release builds as well.