### PR TITLE
Fix editor crash when saving a scene containing an inherited scene instance.

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -165,6 +165,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _script_open_request(const Ref<Script> &p_script);
 
 	bool _cyclical_dependency_exists(const String &p_target_scene_path, Node *p_desired_node);
+	bool _track_inherit(const String &p_target_scene_path, Node *p_desired_node);
 
 	void _node_selected();
 	void _node_renamed();


### PR DESCRIPTION
Fixes #26694 by adding check for target scene's parent scene when instance scene.