### PR TITLE
Update exported variables for Mono tool scripts

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2699,6 +2699,7 @@ Error CSharpScript::reload(bool p_keep_state) {
 			}
 
 			load_script_signals(script_class, native);
+			_update_exports();
 		}
 
 		return OK;


### PR DESCRIPTION
Update scripts exports even when normal script instances are created to better support tool scripts with exported variables.

Fixes #26753 

If the Mono script is marked as a tool script, `instance_create` is used over `placeholder_instance_create`, which means _update_exports() is never called. This led to the editor not being able to show the script's exported properties in the inspector.