### PR TITLE
Fix division by zero at wrap functions in mono

### DIFF
--- a/modules/mono/glue/Managed/Files/Mathf.cs
+++ b/modules/mono/glue/Managed/Files/Mathf.cs
@@ -289,13 +289,13 @@ namespace Godot
         public static int Wrap(int value, int min, int max)
         {
             int rng = max - min;
-            return min + ((value - min) % rng + rng) % rng;
+            return rng != 0 ? min + ((value - min) % rng + rng) % rng : min;
         }
 
         public static real_t Wrap(real_t value, real_t min, real_t max)
         {
             real_t rng = max - min;
-            return min + ((value - min) % rng + rng) % rng;
+            return !IsEqualApprox(rng, default(real_t)) ? min + ((value - min) % rng + rng) % rng : min;
         }
     }
 }

--- a/modules/mono/glue/Managed/Files/MathfEx.cs
+++ b/modules/mono/glue/Managed/Files/MathfEx.cs
@@ -35,5 +35,10 @@ namespace Godot
         {
             return (int)Math.Round(s);
         }
+
+        public static bool IsEqualApprox(real_t a, real_t b, real_t ratio = Mathf.Epsilon)
+        {
+            return Abs(a - b) < ratio;
+        }
     }
 }


### PR DESCRIPTION
Simular fix as #26171 but for mono/C#
I've also added IsEqualApprox as a helper function to compare two floating point numbers.