### PR TITLE
Mono: Fix crash when re-using script binding after domain reloading

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -985,6 +985,13 @@ bool CSharpLanguage::debug_break(const String &p_error, bool p_allow_continue) {
 	}
 }
 
+void CSharpLanguage::_uninitialize_script_bindings() {
+	for (Map<Object *, CSharpScriptBinding>::Element *E = script_bindings.front(); E; E = E->next()) {
+		CSharpScriptBinding &script_binding = E->value();
+		script_binding.inited = false;
+	}
+}
+
 void CSharpLanguage::set_language_index(int p_idx) {
 
 	ERR_FAIL_COND(lang_idx != -1);

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -309,6 +309,9 @@ class CSharpLanguage : public ScriptLanguage {
 
 	Dictionary scripts_metadata;
 
+	friend class GDMono;
+	void _uninitialize_script_bindings();
+
 public:
 	StringNameCache string_names;
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -848,6 +848,8 @@ Error GDMono::reload_scripts_domain() {
 		}
 	}
 
+	CSharpLanguage::get_singleton()->_uninitialize_script_bindings();
+
 	Error err = _load_scripts_domain();
 	if (err != OK) {
 		ERR_PRINT("Mono: Failed to load scripts domain");


### PR DESCRIPTION
Fixes #25959
