### PR TITLE
Refactor Godot.Object Subclass Creation for Mono

### DIFF
--- a/modules/mono/glue/Managed/Files/Attributes/ScriptFactoryAttribute.cs
+++ b/modules/mono/glue/Managed/Files/Attributes/ScriptFactoryAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Godot
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// This attribute can be used on your project's assembly to tell Godot
+    /// about a factory for creating Script instances.
+    /// </summary>
+    public class ScriptInstanceFactoryAttribute : Attribute
+    {
+
+        public Type FactoryType { get; }
+
+        public ScriptInstanceFactoryAttribute(Type type)
+        {
+            FactoryType = type;
+        }
+
+    }
+}

--- a/modules/mono/glue/Managed/Files/GDInternal.cs
+++ b/modules/mono/glue/Managed/Files/GDInternal.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reflection;
+
+namespace Godot
+{
+    internal static class GDInternal
+    {
+
+        /// <summary>
+        /// For the project assembly, try finding the script instance factory to use and
+        /// return it. Otherwise return null.
+        /// </summary>
+        public static IScriptInstanceFactory FindScriptInstanceFactory(Assembly projectAssembly)
+        {
+
+            var factoryAttribute = projectAssembly
+                .GetCustomAttribute<ScriptInstanceFactoryAttribute>();
+
+            if (factoryAttribute == null)
+            {
+                return null;
+            }
+
+            var factoryType = factoryAttribute.FactoryType;
+
+            if (!typeof(IScriptInstanceFactory).IsAssignableFrom(factoryType))
+            {
+                GD.PushError($"The type {factoryType} does not implement IScriptInstanceFactory.");
+                return null;
+            }
+
+            return (IScriptInstanceFactory) Activator.CreateInstance(factoryType);
+
+        }
+
+    }
+}

--- a/modules/mono/glue/Managed/Files/Interfaces/IScriptInstanceFactory.cs
+++ b/modules/mono/glue/Managed/Files/Interfaces/IScriptInstanceFactory.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Godot
+{
+    /// <summary>
+    /// Implement this interface to take control of script instance
+    /// creation for scripts that are attached to nodes.
+    /// Use <see cref="Godot.ScriptInstanceFactoryAttribute"/>
+    /// on your assembly to register a factory with Godot.
+    /// </summary>
+    public interface IScriptInstanceFactory
+    {
+
+        void Initialize(Godot.Object uninitializedObject, object[] args);
+
+    }
+}

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -109,6 +109,15 @@ class GDMono {
 
 	HashMap<uint32_t, HashMap<String, GDMonoAssembly *> > assemblies;
 
+	// Allows for a custom script instance factory to be defined in the project assembly
+	// Arguments: factoryThis, scriptObj, ctorArgs, exc
+	typedef void (*ScriptInstanceFactory)(MonoObject *, MonoObject *, MonoObject *, MonoObject **);
+	Ref<MonoGCHandle> script_instance_factory_handle;
+	MonoObject *script_instance_factory;
+	ScriptInstanceFactory script_instance_factory_thunk;
+	void _find_script_instance_factory();
+	void _free_script_instance_factory();
+
 	void _domain_assemblies_cleanup(uint32_t p_domain_id);
 
 	bool _load_corlib_assembly();
@@ -200,6 +209,15 @@ public:
 #if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
 	const MonoRegInfo &get_mono_reg_info() { return mono_reg_info; }
 #endif
+
+	/**
+	 * Constructs and initializes a Mono object from a user-defined class, which derives from a C++-owned 
+	 * Godot.Object and properly links it to this Godot object.
+	 * Returns false in case allocation of a new Mono object, or the constructor invocation failed.
+	 * Optionally takes constructor arguments in case a specific constructor should be called.
+	 * This is used if the Godot Object is being constructed from within a GDScript.
+	 */
+	MonoObject *construct_godot_object(GDMonoClass *class_obj, Object *owner, const Variant **p_args = NULL, int p_argcount = 0);
 
 	GDMonoClass *get_class(MonoClass *p_raw_class);
 

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -231,7 +231,7 @@ void GDMonoAssembly::_wrap_mono_assembly(MonoAssembly *assembly) {
 	String name = mono_assembly_name_get_name(mono_assembly_get_name(assembly));
 
 	MonoImage *image = mono_assembly_get_image(assembly);
-
+		
 	GDMonoAssembly *gdassembly = memnew(GDMonoAssembly(name, mono_image_get_filename(image)));
 	Error err = gdassembly->wrapper_for_image(image);
 
@@ -346,7 +346,11 @@ void GDMonoAssembly::unload() {
 	cached_classes.clear();
 	cached_raw.clear();
 
-	mono_image_close(image);
+	// Dynamic images cannot be closed and will be cleaned up
+	// when the AppDomain is unloaded
+	if (!mono_image_is_dynamic(image)) {
+		mono_image_close(image);
+	}
 
 	assembly = NULL;
 	image = NULL;

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -388,6 +388,8 @@ GDMonoClass *type_get_proxy_class(const StringName &p_type) {
 	return klass;
 }
 
+// For the given class, find the first base class (including itself)
+// that is defined in the core or editor assemblies.
 GDMonoClass *get_class_native_base(GDMonoClass *p_class) {
 	GDMonoClass *klass = p_class;
 
@@ -415,15 +417,7 @@ MonoObject *create_managed_for_godot_object(GDMonoClass *p_class, const StringNa
 		ERR_FAIL_V(NULL);
 	}
 
-	MonoObject *mono_object = mono_object_new(SCRIPTS_DOMAIN, p_class->get_mono_ptr());
-	ERR_FAIL_NULL_V(mono_object, NULL);
-
-	CACHED_FIELD(GodotObject, ptr)->set_value_raw(mono_object, p_object);
-
-	// Construct
-	GDMonoUtils::runtime_object_init(mono_object);
-
-	return mono_object;
+	return GDMono::get_singleton()->construct_godot_object(p_class, p_object);
 }
 
 MonoObject *create_managed_from(const NodePath &p_from) {
@@ -450,6 +444,7 @@ MonoObject *create_managed_from(const RID &p_from) {
 	return mono_object;
 }
 
+// p_class will only ever be Godot.Collections.Array or Godot.Collections.Array<T>
 MonoObject *create_managed_from(const Array &p_from, GDMonoClass *p_class) {
 	MonoObject *mono_object = mono_object_new(SCRIPTS_DOMAIN, p_class->get_mono_ptr());
 	ERR_FAIL_NULL_V(mono_object, NULL);
@@ -480,6 +475,7 @@ MonoObject *create_managed_from(const Array &p_from, GDMonoClass *p_class) {
 	return mono_object;
 }
 
+// p_class will only ever be Godot.Collections.Dictionary or Godot.Collections.Dictionary<K,V>
 MonoObject *create_managed_from(const Dictionary &p_from, GDMonoClass *p_class) {
 	MonoObject *mono_object = mono_object_new(SCRIPTS_DOMAIN, p_class->get_mono_ptr());
 	ERR_FAIL_NULL_V(mono_object, NULL);


### PR DESCRIPTION
This is a proposal to fix #15434

This PR refactors how instances of user-defined classes that subclass Godot.Object (or further subclasses of that, such as Node, Spatial, etc.) are created.
It attempts to centralize it and then introduces a mechanism for developers to customize this creation process.
Developers can now use an Assembly Attribute (`ScriptInstanceFactoryAttribute`) to specify a factory type which becomes responsible for selecting and invoking the constructor for any object that is being created.
The C++ side will still allocate the memory of the object and set the `Ptr` field correctly, so even with this approach, returning proxy objects is decidedly NOT possible, but what it allows is:
- Performing constructor dependency injection
- Performing field injection before the constructor is called
- Performing any other magic that the developer desires whenever one of their Node classes is instantiated

Example:

```
// In AssemblyInfo.cs:

[assembly: ScriptInstanceFactory(typeof(MyScriptInstanceFactory))]

// In some other file:
    public class MyScriptInstanceFactory : IScriptInstanceFactory
    {
        public void Initialize(Object uninitializedObject, object[] args)
        {
            var type = uninitializedObject.GetType();
            // DO MAGIC HERE
            var ctor = type.GetConstructor(Type.EmptyTypes);
            ctor.Invoke(uninitializedObject, args);
        }
    }
```

Open questions:
- Should I rename the C# side code to GodotObjectFactory? I started this for ScrriptInstances but then noticed this might also be used if GDScript tries to instantiate a C# object if I am correct
- Correctness. Various places were creating Mono objects *slightly* differently, so we'll have to see if this still behaves the same
- Refactor out the factory fields from GDMono to a separate class?