### PR TITLE
Set editor hint early for Project Manager and Editor

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -856,6 +856,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (editor || project_manager) {
+		Engine::get_singleton()->set_editor_hint(true);
 		use_custom_res = false;
 		input_map->load_default(); //keys for editor
 	} else {


### PR DESCRIPTION
We need it in setup() already before initializing the renderer,
as it's used to force fallback to GLES2 if GLES3 fails.

Fixes #26806.

----

Some context on this issue and things we need to improve for 3.2 and later: the fallback mode in `OS::initialize()` for desktop platform checks `Engine::get_singleton()->is_editor_hint()` to know if we're running the editor (or project manager) and enforce fallback there.

Actually this logic was broken, because when `OS::initialize()` is called in `Main::setup()`, we haven't set editor hint yet (it happens later on in `Main::setup2()`. It worked fine in the past because the fallback mode was the default setting (including for the editor).

Now to the funny part: the project manager actually disables the editor hint in its `NOTIFICATION_ENTER_TREE` since 390a202, as it apparently caused issues. So currently to work properly, we rely on the project manager having editor hint while it's constructed, and not when running. This needs a big cleanup, it's a mess.