### PR TITLE
Allow to undo TextEdit.set_text

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -302,7 +302,6 @@ void ScriptTextEditor::reload_text() {
 	int v = te->get_v_scroll();
 
 	te->set_text(script->get_source_code());
-	te->clear_undo_history();
 	te->cursor_set_line(row);
 	te->cursor_set_column(column);
 	te->set_h_scroll(h);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -201,7 +201,6 @@ void TextEditor::reload_text() {
 	int v = te->get_v_scroll();
 
 	te->set_text(text_file->get_text());
-	te->clear_undo_history();
 	te->cursor_set_line(row);
 	te->cursor_set_column(column);
 	te->set_h_scroll(h);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4196,17 +4196,22 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 void TextEdit::set_text(String p_text) {
 
 	setting_text = true;
-	_clear();
-	_insert_text_at_cursor(p_text);
-	clear_undo_history();
-	cursor.column = 0;
-	cursor.line = 0;
-	cursor.x_ofs = 0;
-	cursor.line_ofs = 0;
-	cursor.wrap_ofs = 0;
-	cursor.last_fit_x = 0;
-	cursor_set_line(0);
-	cursor_set_column(0);
+	if (!undo_enabled) {
+		_clear();
+		_insert_text_at_cursor(p_text);
+	}
+
+	if (undo_enabled) {
+		cursor_set_line(0);
+		cursor_set_column(0);
+
+		begin_complex_operation();
+		_remove_text(0, 0, MAX(0, get_line_count() - 1), MAX(get_line(MAX(get_line_count() - 1, 0)).size() - 1, 0));
+		_insert_text_at_cursor(p_text);
+		end_complex_operation();
+		selection.active = false;
+	}
+
 	update();
 	setting_text = false;
 


### PR DESCRIPTION
Closes #20691

With this, `set_text()` is registered as "complex operation" for undo if undo is enabled, so after doing e.g. `$TextEdit.text = "some text"` you can return to previous text with CTRL + Z. It might be considered a minor compatibility breakage, since you need to call `clear_undo_history()` after setting text to keep old behavior. Also cursor moves to the end of the text now, instead of going to beginning after changing text (that change is rather debatable). 

I also cleaned `set_text()` a bit, as it was doing many unnecessary operations already done in `_clear()`.

EDIT:
Now also closes #26325