### PR TITLE
Add autocomplete support for change_scene()

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -33,6 +33,7 @@
 #include "core/io/marshalls.h"
 #include "core/io/resource_loader.h"
 #include "core/message_queue.h"
+#include "core/os/dir_access.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/print_string.h"
@@ -1951,6 +1952,38 @@ void SceneTree::set_use_font_oversampling(bool p_oversampling) {
 
 bool SceneTree::is_using_font_oversampling() const {
 	return use_font_oversampling;
+}
+
+void SceneTree::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+
+	if (p_function == "change_scene") {
+		DirAccessRef dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		List<String> directories;
+		directories.push_back(dir_access->get_current_dir());
+
+		while (!directories.empty()) {
+			dir_access->change_dir(directories.back()->get());
+			directories.pop_back();
+
+			dir_access->list_dir_begin();
+			String filename = dir_access->get_next();
+
+			while (filename != "") {
+				if (filename == "." || filename == "..") {
+					filename = dir_access->get_next();
+					continue;
+				}
+
+				if (dir_access->dir_exists(filename)) {
+					directories.push_back(dir_access->get_current_dir().plus_file(filename));
+				} else if (filename.ends_with(".tscn") || filename.ends_with(".scn")) {
+					r_options->push_back("\"" + dir_access->get_current_dir().plus_file(filename) + "\"");
+				}
+
+				filename = dir_access->get_next();
+			}
+		}
+	}
 }
 
 SceneTree::SceneTree() {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -408,6 +408,7 @@ public:
 
 	void drop_files(const Vector<String> &p_files, int p_from_screen = 0);
 	void global_menu_action(const Variant &p_id, const Variant &p_meta);
+	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
 
 	//network API
 


### PR DESCRIPTION
Closes #20635

~~Not sure if it's the correct way, but well, works. As a side-effect, any method named `change_scene()` will complete scene names. I didn't know how to do it only for SceneTree, but that actually might be a feature if someone wants a custom `change_scene()`.~~

~~Also I had to implement a function that returns file list with extension filter. It's general-purpose, so it might be useful for filtering specific resources based on context (e.g. supported formats for Textures etc.)~~