### PR TITLE
Fixes physic_fps=0 bug that prevented quit.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1881,7 +1881,9 @@ bool Main::iteration() {
 
 	uint64_t idle_begin = OS::get_singleton()->get_ticks_usec();
 
-	OS::get_singleton()->get_main_loop()->idle(step * time_scale);
+	if (OS::get_singleton()->get_main_loop()->idle(step * time_scale)) {
+		exit = true;
+	}
 	message_queue->flush();
 
 	VisualServer::get_singleton()->sync(); //sync if still drawing from previous frames.


### PR DESCRIPTION
Added a condition to check if the loop exited without iteration
being run by checking the return value from idle().

Fixes: #26321