### PR TITLE
Add swap_scene() method for easier changing of instanced scenes

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -55,6 +55,26 @@
 				Changes to the given [PackedScene].
 			</description>
 		</method>
+		<method name="swap_scene">
+			<return type="Node">
+			</return>
+			<argument index="0" name="instanced_scene" type="Node">
+			</argument>
+			<description>
+				Changes current scene to given [Node], i.e. diffrent already instanced scene and returns the previous scene. The previous scene is removed from [SceneTree], but not freed. Useful when you need the old scene for later use.
+				[b]Note:[/b] Since the current scene is removed from tree, it stops all processing, so it's effectively "paused".
+				[b]Example:[/b] You want to change current scene to pause menu, but you need to keep your game scene and return to it later:
+				[codeblock]
+				var pause_menu = preload("res://PauseMenu.tscn").instance()
+				pause_menu.game = get_tree().swap_scene(pause_menu) #game variable in pause menu will hold the old (game) scene
+				[/codeblock]
+				[b]Note:[/b] The variable is set after new scene calls [method Node._ready]. If you need to use the old scene for some initialization, you could use [method Object.call_deferred] or a setter.
+				[b]Important:[/b] Since the old scene is not freed, you have to remember to free it yourself in case you don't need it after swapping. The easiest way to do so is:
+				[codeblock]
+				get_tree().swap_scene(new_scene).queue_free()
+				[/codeblock]
+			</description>
+		</method>
 		<method name="create_timer">
 			<return type="SceneTreeTimer">
 			</return>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1312,6 +1312,20 @@ Error SceneTree::change_scene_to(const Ref<PackedScene> &p_scene) {
 	call_deferred("_change_scene", new_scene);
 	return OK;
 }
+Node *SceneTree::swap_scene(Node *p_to) {
+
+	root->add_child(p_to);
+
+	Node *old_scene = NULL;
+	if (current_scene) {
+		old_scene = current_scene;
+		root->remove_child(current_scene);
+	}
+
+	current_scene = p_to;
+
+	return old_scene;
+}
 Error SceneTree::reload_current_scene() {
 
 	ERR_FAIL_COND_V(!current_scene, ERR_UNCONFIGURED);
@@ -1852,6 +1866,7 @@ void SceneTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("change_scene", "path"), &SceneTree::change_scene);
 	ClassDB::bind_method(D_METHOD("change_scene_to", "packed_scene"), &SceneTree::change_scene_to);
+	ClassDB::bind_method(D_METHOD("swap_scene", "instanced_scene"), &SceneTree::swap_scene);
 
 	ClassDB::bind_method(D_METHOD("reload_current_scene"), &SceneTree::reload_current_scene);
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -399,6 +399,7 @@ public:
 	Node *get_current_scene() const;
 	Error change_scene(const String &p_path);
 	Error change_scene_to(const Ref<PackedScene> &p_scene);
+	Node *swap_scene(Node *p_to);
 	Error reload_current_scene();
 
 	Ref<SceneTreeTimer> create_timer(float p_delay_sec, bool p_process_pause = true);


### PR DESCRIPTION
Closes #24795

Works as described in the linked issue.