### PR TITLE
[GDNative] fix crash at shutdown when using singleton libraries and NativeScript

### DIFF
--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -414,6 +414,7 @@ bool GDNative::terminate() {
 	if (error || !library_terminate) {
 		OS::get_singleton()->close_dynamic_library(native_handle);
 		native_handle = NULL;
+		initialized = false;
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #25854 

When a singleton library was exposing NativeScript functionality,
the NativeScriptLanguage would attempt to terminate the library at
shutdown.

Since the GDNative module itself handles singleton libraries,
it closes all singleton libraries at shutdown as well. This double free
could cause a crash, since the library referenced would no longer be alive.