### PR TITLE
GLES2 reallocate texture when transparent is set

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4733,6 +4733,7 @@ void RasterizerStorageGLES2::render_target_set_flag(RID p_render_target, RenderT
 	rt->flags[p_flag] = p_value;
 
 	switch (p_flag) {
+		case RENDER_TARGET_TRANSPARENT:
 		case RENDER_TARGET_HDR:
 		case RENDER_TARGET_NO_3D:
 		case RENDER_TARGET_NO_SAMPLING:


### PR DESCRIPTION
fixes #26779 

When the viewport doesn't use a transparent background GLES2 allocates an RGB texture. So when Transparent is set, the texture needs to be reallocated. 