### PR TITLE
Capitalise drive letters

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -394,7 +394,7 @@ DirAccessWindows::DirAccessWindows() {
 
 		if (mask & (1 << i)) { //DRIVE EXISTS
 
-			drives[drive_count] = 'a' + i;
+			drives[drive_count] = 'A' + i;
 			drive_count++;
 		}
 	}


### PR DESCRIPTION
This makes the drive letters match how other Windows applications like to display drive letters in file dialogs.
Fixes #26844 