### PR TITLE
Fix fake null-motion mouse event flood

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -33,6 +33,9 @@
 #include "core/input_map.h"
 #include "core/os/keyboard.h"
 
+const int InputEvent::DEVICE_ID_TOUCH_MOUSE = -1;
+const int InputEvent::DEVICE_ID_INTERNAL = -2;
+
 void InputEvent::set_device(int p_device) {
 	device = p_device;
 }

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -165,6 +165,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	static const int DEVICE_ID_TOUCH_MOUSE;
+	static const int DEVICE_ID_INTERNAL;
+
 	void set_device(int p_device);
 	int get_device() const;
 

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -355,7 +355,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 				Ref<InputEventMouseButton> button_event;
 				button_event.instance();
 
-				button_event->set_device(-1);
+				button_event->set_device(InputEvent::DEVICE_ID_TOUCH_MOUSE);
 				button_event->set_position(st->get_position());
 				button_event->set_global_position(st->get_position());
 				button_event->set_pressed(st->is_pressed());
@@ -384,7 +384,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 			Ref<InputEventMouseMotion> motion_event;
 			motion_event.instance();
 
-			motion_event->set_device(-1);
+			motion_event->set_device(InputEvent::DEVICE_ID_TOUCH_MOUSE);
 			motion_event->set_position(sd->get_position());
 			motion_event->set_global_position(sd->get_position());
 			motion_event->set_relative(sd->get_relative());
@@ -602,7 +602,7 @@ void InputDefault::ensure_touch_mouse_raised() {
 		Ref<InputEventMouseButton> button_event;
 		button_event.instance();
 
-		button_event->set_device(-1);
+		button_event->set_device(InputEvent::DEVICE_ID_TOUCH_MOUSE);
 		button_event->set_position(mouse_pos);
 		button_event->set_global_position(mouse_pos);
 		button_event->set_pressed(false);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -221,7 +221,7 @@ private:
 
 	} physics_last_mouse_state;
 
-	void _collision_object_input_event(CollisionObject *p_object, Camera *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape, bool p_discard_empty_motion);
+	void _collision_object_input_event(CollisionObject *p_object, Camera *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);
 
 	bool handle_input_locally;
 	bool local_input_handled;


### PR DESCRIPTION
This commit also improves a bit the code quality by making the intent of
fake events (and themselves) more explicit.

Fixes #26460.