### PR TITLE
Mono: Fix assemblies path String incorrectly constructed from utf8

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -288,7 +288,7 @@ void GDMono::initialize() {
 
 	mono_install_unhandled_exception_hook(&unhandled_exception_hook, NULL);
 
-#ifdef TOOLS_ENABLED
+#ifndef TOOLS_ENABLED
 	if (!DirAccess::exists("res://.mono")) {
 		// 'res://.mono/' is missing so there is nothing to load. We don't need to initialize mono, but
 		// we still do so unless mscorlib is missing (which is the case for projects that don't use C#).

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -50,7 +50,7 @@ void GDMonoAssembly::fill_search_dirs(Vector<String> &r_search_dirs, const Strin
 
 	const char *rootdir = mono_assembly_getrootdir();
 	if (rootdir) {
-		String framework_dir = String(rootdir).plus_file("mono").plus_file("4.5");
+		String framework_dir = String::utf8(rootdir).plus_file("mono").plus_file("4.5");
 		r_search_dirs.push_back(framework_dir);
 		r_search_dirs.push_back(framework_dir.plus_file("Facades"));
 	}


### PR DESCRIPTION
Also fixed a wrong ifdef that was causing Mono to never be initialized if mscorlib was not found (which was the case with the utf8 assemblies path bug this commit fixes).
This condition was meant for exported projects only, not for the editor only.

Fixes #26834
