### PR TITLE
Makes drive letter capitalized

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -118,7 +118,7 @@ String DirAccessWindows::get_drive(int p_drive) {
 	if (p_drive < 0 || p_drive >= drive_count)
 		return "";
 
-	return String::chr(drives[p_drive]) + ":";
+	return String::chr(drives[p_drive]).to_upper() + ":";
 }
 
 Error DirAccessWindows::change_dir(String p_dir) {


### PR DESCRIPTION
Making the drive letter, capital when using get_drive() function. Should reflect in all cases wherever the drive letters are being displayed
![screen](https://user-images.githubusercontent.com/14962635/54078958-75f7af80-42f8-11e9-968f-e71f9a6e9d32.png)

_Bugsquad edit_: potential fix for #26844