### PR TITLE
Fix cursor going to start while editing GraphNode's title

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -164,7 +164,6 @@ void GraphNode::_resort() {
 		vofs += size.y;
 	}
 
-	_change_notify();
 	update();
 	connpos_dirty = true;
 }
@@ -409,9 +408,12 @@ Size2 GraphNode::get_minimum_size() const {
 
 void GraphNode::set_title(const String &p_title) {
 
+	if (title == p_title)
+		return;
 	title = p_title;
-	minimum_size_changed();
 	update();
+	_change_notify("title");
+	minimum_size_changed();
 }
 
 String GraphNode::get_title() const {


### PR DESCRIPTION
Fixes #26816.

The change to `GraphNode::set_title` is just cosmetic, making it look more like `Button::set_text`.