### PR TITLE
Mono: Some assembly referencing changes and cleanup

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -798,8 +798,6 @@ Error GDMono::_unload_scripts_domain() {
 	if (mono_domain_get() != root_domain)
 		mono_domain_set(root_domain, true);
 
-	mono_gc_collect(mono_gc_max_generation());
-
 	finalizing_scripts_domain = true;
 
 	if (!mono_domain_finalize(scripts_domain, 2000)) {
@@ -937,13 +935,19 @@ Error GDMono::finalize_and_unload_domain(MonoDomain *p_domain) {
 	if (mono_domain_get() == p_domain)
 		mono_domain_set(root_domain, true);
 
-	mono_gc_collect(mono_gc_max_generation());
 	if (!mono_domain_finalize(p_domain, 2000)) {
 		ERR_PRINT("Mono: Domain finalization timeout");
 	}
+
 	mono_gc_collect(mono_gc_max_generation());
 
 	_domain_assemblies_cleanup(mono_domain_get_id(p_domain));
+
+#ifdef TOOLS_ENABLED
+	if (p_domain == tools_domain) {
+		editor_tools_assembly = NULL;
+	}
+#endif
 
 	MonoException *exc = NULL;
 	mono_domain_try_unload(p_domain, (MonoObject **)&exc);
@@ -1046,11 +1050,19 @@ GDMono::~GDMono() {
 
 	if (is_runtime_initialized()) {
 
-		if (scripts_domain) {
+#ifdef TOOLS_ENABLED
+		if (tools_domain) {
+			Error err = finalize_and_unload_domain(tools_domain);
+			if (err != OK) {
+				ERR_PRINT("Mono: Failed to unload tools domain");
+			}
+		}
+#endif
 
+		if (scripts_domain) {
 			Error err = _unload_scripts_domain();
 			if (err != OK) {
-				WARN_PRINT("Mono: Failed to unload scripts domain");
+				ERR_PRINT("Mono: Failed to unload scripts domain");
 			}
 		}
 
@@ -1070,6 +1082,8 @@ GDMono::~GDMono() {
 		print_verbose("Mono: Runtime cleanup...");
 
 		mono_jit_cleanup(root_domain);
+
+		print_verbose("Mono: Finalized");
 
 		runtime_initialized = false;
 	}

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -277,6 +277,7 @@ Error GDMonoAssembly::load(bool p_refonly) {
 	ERR_FAIL_NULL_V(image, ERR_FILE_CANT_OPEN);
 
 #ifdef DEBUG_ENABLED
+	Vector<uint8_t> pdb_data;
 	String pdb_path(path + ".pdb");
 
 	if (!FileAccess::exists(pdb_path)) {
@@ -286,8 +287,9 @@ Error GDMonoAssembly::load(bool p_refonly) {
 			goto no_pdb;
 	}
 
-	pdb_data.clear();
 	pdb_data = FileAccess::get_file_as_array(pdb_path);
+
+	// mono_debug_close_image doesn't seem to be needed
 	mono_debug_open_image_from_memory(image, &pdb_data[0], pdb_data.size());
 
 no_pdb:
@@ -306,6 +308,9 @@ no_pdb:
 
 	ERR_FAIL_COND_V(status != MONO_IMAGE_OK || assembly == NULL, ERR_FILE_CANT_OPEN);
 
+	// Decrement refcount which was previously incremented by mono_image_open_from_data_with_name
+	mono_image_close(image);
+
 	loaded = true;
 	modified_time = last_modified_time;
 
@@ -321,8 +326,6 @@ Error GDMonoAssembly::wrapper_for_image(MonoImage *p_image) {
 
 	image = p_image;
 
-	mono_image_addref(image);
-
 	loaded = true;
 
 	return OK;
@@ -332,21 +335,12 @@ void GDMonoAssembly::unload() {
 
 	ERR_FAIL_COND(!loaded);
 
-#ifdef DEBUG_ENABLED
-	if (pdb_data.size()) {
-		mono_debug_close_image(image);
-		pdb_data.clear();
-	}
-#endif
-
 	for (Map<MonoClass *, GDMonoClass *>::Element *E = cached_raw.front(); E; E = E->next()) {
 		memdelete(E->value());
 	}
 
 	cached_classes.clear();
 	cached_raw.clear();
-
-	mono_image_close(image);
 
 	assembly = NULL;
 	image = NULL;

--- a/modules/mono/mono_gd/gd_mono_assembly.h
+++ b/modules/mono/mono_gd/gd_mono_assembly.h
@@ -84,10 +84,6 @@ class GDMonoAssembly {
 	bool gdobject_class_cache_updated;
 	Map<StringName, GDMonoClass *> gdobject_class_cache;
 
-#ifdef DEBUG_ENABLED
-	Vector<uint8_t> pdb_data;
-#endif
-
 	static bool no_search;
 	static bool in_preload;
 	static Vector<String> search_dirs;


### PR DESCRIPTION
Apparently we don't need to call mono_debug_close_image ourselves and we can call mono_image_close right away as it's not our duty to keep that reference.

Fixes #26731
