### PR TITLE
Prevents a Null Reference in deleting Animations.

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3424,6 +3424,10 @@ void AnimationTrackEditor::_animation_update() {
 
 	bool same = true;
 
+	if (animation.is_null()) {
+		return;
+	}
+
 	if (track_edits.size() == animation->get_track_count()) {
 		//check tracks are the same
 


### PR DESCRIPTION
A null Animation would cause a crash by accessing restricted memory.
Solved by checking if the animation track is null before using the
animation.

Fixes: #26829