### PR TITLE
Display vertex number when hovering point in collision polygon

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -638,6 +638,13 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 
 			const Color modulate = vertex == active_point ? Color(0.5, 1, 2) : Color(1, 1, 1);
 			p_overlay->draw_texture(handle, point - handle->get_size() * 0.5, modulate);
+
+			if (vertex == hover_point) {
+				Ref<Font> font = get_font("font", "Label");
+				String num = String::num(vertex.vertex);
+				Size2 num_size = font->get_string_size(num);
+				p_overlay->draw_string(font, point - num_size * 0.5, num, Color(1.0, 1.0, 1.0, 0.5));
+			}
 		}
 	}
 


### PR DESCRIPTION
I found it quite difficult to edit large collision polygons without knowing which point correspond with which vertex number, so I made this small change to display the vertex number when hovering a point in a collision polygon.

It's then easy to check a number, and after that manually adjust in the vertex list, to for example align etc, or if you want exact numbers etc..

Please give me feedback, and let me know if this is something you might want to merge, and if I should make any changes, thanks.

![example](https://user-images.githubusercontent.com/9007314/54114524-eaab1680-43ea-11e9-8be2-14b7c09efc5d.gif)
![image](https://user-images.githubusercontent.com/9007314/54114580-06162180-43eb-11e9-8f90-0716c2a8721d.png)
