### PR TITLE
fixed a crash when moving tscn file together with its dependencies

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2816,10 +2816,7 @@ Dictionary EditorNode::_get_main_scene_state() {
 	return state;
 }
 
-void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
-
-	if (get_edited_scene() != p_for_scene && p_for_scene != NULL)
-		return; //not for this scene
+void EditorNode::_set_main_scene_state(Dictionary p_state) {
 
 	changing_scene = false;
 
@@ -2919,7 +2916,7 @@ void EditorNode::set_current_scene(int p_idx) {
 
 	_update_title();
 
-	call_deferred("_set_main_scene_state", state, get_edited_scene()); //do after everything else is done setting up
+	call_deferred("_set_main_scene_state", state); //do after everything else is done setting up
 }
 
 bool EditorNode::is_scene_open(const String &p_path) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -550,7 +550,7 @@ private:
 	void _scene_tab_script_edited(int p_tab);
 
 	Dictionary _get_main_scene_state();
-	void _set_main_scene_state(Dictionary p_state, Node *p_for_scene);
+	void _set_main_scene_state(Dictionary p_state);
 
 	int _get_current_main_editor();
 


### PR DESCRIPTION
Partially solves #26394

Seems like the Node passed at editor/editor_node.cpp:2923 was becoming garbage when the message queue was flushed.  
I am not sure this is the correct fix. Feedback (and testing!!!) is welcome, but it seems to fix the reproduction MRP with the images being moved.