### PR TITLE
HTML5: Fix ETC export for GLES2 fallback on mobile

### DIFF
--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -114,6 +114,9 @@ void EditorExportPlatformJavaScript::get_preset_features(const Ref<EditorExportP
 			r_features->push_back("etc");
 		} else if (driver == "GLES3") {
 			r_features->push_back("etc2");
+			if (ProjectSettings::get_singleton()->get("rendering/quality/driver/fallback_to_gles2")) {
+				r_features->push_back("etc");
+			}
 		}
 	}
 }


### PR DESCRIPTION
I forgot this one in #26633.

Note that it shouldn't solve #26899, which is about desktop HTML5 and should thus use S3TC for both GLES3 and GLES2.