### PR TITLE
Remove underscores of proxy classes in GDCLASS

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -251,7 +251,7 @@ private:                                                                        
                                                                                                                                         \
 public:                                                                                                                                 \
 	virtual String get_class() const {                                                                                                  \
-		return String(#m_class);                                                                                                        \
+		return get_class_static();                                                                                                      \
 	}                                                                                                                                   \
 	virtual const StringName *_get_class_namev() const {                                                                                \
 		if (!_class_name)                                                                                                               \
@@ -263,14 +263,15 @@ public:                                                                         
 		return &ptr;                                                                                                                    \
 	}                                                                                                                                   \
 	static _FORCE_INLINE_ String get_class_static() {                                                                                   \
-		return String(#m_class);                                                                                                        \
+		/* Remove underscore from proxy classes */                                                                                      \
+		return String(#m_class[0] == '_' ? &(#m_class[1]) : #m_class);                                                                  \
 	}                                                                                                                                   \
 	static _FORCE_INLINE_ String get_parent_class_static() {                                                                            \
 		return m_inherits::get_class_static();                                                                                          \
 	}                                                                                                                                   \
 	static void get_inheritance_list_static(List<String> *p_inheritance_list) {                                                         \
 		m_inherits::get_inheritance_list_static(p_inheritance_list);                                                                    \
-		p_inheritance_list->push_back(String(#m_class));                                                                                \
+		p_inheritance_list->push_back(get_class_static());                                                                              \
 	}                                                                                                                                   \
 	static String get_category_static() {                                                                                               \
 		String category = m_inherits::get_category_static();                                                                            \
@@ -282,9 +283,10 @@ public:                                                                         
 		return category;                                                                                                                \
 	}                                                                                                                                   \
 	static String inherits_static() {                                                                                                   \
-		return String(#m_inherits);                                                                                                     \
+		/* Remove underscore from proxy classes */                                                                                      \
+		return String(#m_inherits[0] == '_' ? &(#m_inherits[1]) : #m_inherits);                                                         \
 	}                                                                                                                                   \
-	virtual bool is_class(const String &p_class) const { return (p_class == (#m_class)) ? true : m_inherits::is_class(p_class); }       \
+	virtual bool is_class(const String &p_str) const { return (p_str == get_class_static()) ? true : m_inherits::is_class(p_str); }     \
 	virtual bool is_class_ptr(void *p_ptr) const { return (p_ptr == get_class_ptr_static()) ? true : m_inherits::is_class_ptr(p_ptr); } \
                                                                                                                                         \
 	static void get_valid_parents_static(List<String> *p_parents) {                                                                     \
@@ -346,12 +348,12 @@ protected:                                                                      
 		}                                                                                                                               \
 		p_list->push_back(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));       \
 		if (!_is_gpl_reversed())                                                                                                        \
-			ClassDB::get_property_list(#m_class, p_list, true, this);                                                                   \
+			ClassDB::get_property_list(get_class_static(), p_list, true, this);                                                         \
 		if (m_class::_get_get_property_list() != m_inherits::_get_get_property_list()) {                                                \
 			_get_property_list(p_list);                                                                                                 \
 		}                                                                                                                               \
 		if (_is_gpl_reversed())                                                                                                         \
-			ClassDB::get_property_list(#m_class, p_list, true, this);                                                                   \
+			ClassDB::get_property_list(get_class_static(), p_list, true, this);                                                         \
 		if (p_reversed) {                                                                                                               \
 			m_inherits::_get_property_listv(p_list, p_reversed);                                                                        \
 		}                                                                                                                               \

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -172,8 +172,6 @@ static void return_doc_from_retinfo(DocData::MethodDoc &p_method, const Property
 
 	if (p_retinfo.type == Variant::INT && p_retinfo.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
 		p_method.return_enum = p_retinfo.class_name;
-		if (p_method.return_enum.begins_with("_")) //proxy class
-			p_method.return_enum = p_method.return_enum.substr(1, p_method.return_enum.length());
 		p_method.return_type = "int";
 	} else if (p_retinfo.class_name != StringName()) {
 		p_method.return_type = p_retinfo.class_name;
@@ -194,8 +192,6 @@ static void argument_doc_from_arginfo(DocData::ArgumentDoc &p_argument, const Pr
 
 	if (p_arginfo.type == Variant::INT && p_arginfo.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
 		p_argument.enumeration = p_arginfo.class_name;
-		if (p_argument.enumeration.begins_with("_")) //proxy class
-			p_argument.enumeration = p_argument.enumeration.substr(1, p_argument.enumeration.length());
 		p_argument.type = "int";
 	} else if (p_arginfo.class_name != StringName()) {
 		p_argument.type = p_arginfo.class_name;
@@ -223,8 +219,6 @@ void DocData::generate(bool p_basic_types) {
 
 		String name = classes.front()->get();
 		String cname = name;
-		if (cname.begins_with("_")) //proxy class
-			cname = cname.substr(1, name.length());
 
 		class_list[cname] = ClassDoc();
 		ClassDoc &c = class_list[cname];
@@ -584,8 +578,6 @@ void DocData::generate(bool p_basic_types) {
 			pd.type = s.ptr->get_class();
 			while (String(ClassDB::get_parent_class(pd.type)) != "Object")
 				pd.type = ClassDB::get_parent_class(pd.type);
-			if (pd.type.begins_with("_"))
-				pd.type = pd.type.substr(1, pd.type.length());
 			c.properties.push_back(pd);
 		}
 	}

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -240,11 +240,7 @@ void ScriptTextEditor::_set_theme_for_script() {
 
 	for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
 
-		String n = E->get();
-		if (n.begins_with("_"))
-			n = n.substr(1, n.length());
-
-		text_edit->add_keyword_color(n, colors_cache.type_color);
+		text_edit->add_keyword_color(E->get(), colors_cache.type_color);
 	}
 	_update_member_keywords();
 
@@ -633,8 +629,6 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 	} else if (script->get_language()->lookup_code(code_editor->get_text_edit()->get_text_for_lookup_completion(), p_symbol, script->get_path().get_base_dir(), base, result) == OK) {
 
 		_goto_line(p_row);
-
-		result.class_name = result.class_name.trim_prefix("_");
 
 		switch (result.type) {
 			case ScriptLanguage::LookupResult::RESULT_SCRIPT_LOCATION: {

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -172,13 +172,7 @@ List<ClassAPI> generate_c_api_classes() {
 		class_api.api_type = ClassDB::get_api_type(e->get());
 		class_api.class_name = class_name;
 		class_api.super_class_name = ClassDB::get_parent_class(class_name);
-		{
-			String name = class_name;
-			if (name.begins_with("_")) {
-				name.remove(0);
-			}
-			class_api.is_singleton = Engine::get_singleton()->has_singleton(name);
-		}
+		class_api.is_singleton = Engine::get_singleton()->has_singleton(class_name);
 		class_api.is_instanciable = !class_api.is_singleton && ClassDB::can_instance(class_name);
 
 		{

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1388,8 +1388,6 @@ void GDScriptLanguage::init() {
 
 		StringName n = E->get();
 		String s = String(n);
-		if (s.begins_with("_"))
-			n = s.substr(1, s.length());
 
 		if (globals.has(n))
 			continue;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -771,10 +771,7 @@ static bool _guess_expression_type(GDScriptCompletionContext &p_context, const G
 										native_type.kind = GDScriptParser::DataType::NATIVE;
 										native_type.native_type = native_type.script_type->get_instance_base_type();
 										if (!ClassDB::class_exists(native_type.native_type)) {
-											native_type.native_type = String("_") + native_type.native_type;
-											if (!ClassDB::class_exists(native_type.native_type)) {
-												native_type.has_type = false;
-											}
+											native_type.has_type = false;
 										}
 									}
 								}
@@ -1324,38 +1321,24 @@ static bool _guess_identifier_type(GDScriptCompletionContext &p_context, const S
 		return false;
 	}
 
-	for (int i = 0; i < 2; i++) {
-		StringName target_id;
-		switch (i) {
-			case 0:
-				// Check ClassDB
-				target_id = p_identifier;
-				break;
-			case 1:
-				// ClassDB again for underscore-prefixed classes
-				target_id = String("_") + p_identifier;
-				break;
-		}
-
-		if (ClassDB::class_exists(target_id)) {
-			r_type.type.has_type = true;
-			r_type.type.kind = GDScriptParser::DataType::NATIVE;
-			r_type.type.native_type = target_id;
-			if (Engine::get_singleton()->has_singleton(target_id)) {
-				r_type.type.is_meta_type = false;
-				r_type.value = Engine::get_singleton()->get_singleton_object(target_id);
-			} else {
-				r_type.type.is_meta_type = true;
-				const Map<StringName, int>::Element *target_elem = GDScriptLanguage::get_singleton()->get_global_map().find(target_id);
-				// Check because classes like EditorNode are in ClassDB by now, but unknown to GDScript
-				if (!target_elem) {
-					return false;
-				}
-				int idx = target_elem->get();
-				r_type.value = GDScriptLanguage::get_singleton()->get_global_array()[idx];
+	if (ClassDB::class_exists(p_identifier)) {
+		r_type.type.has_type = true;
+		r_type.type.kind = GDScriptParser::DataType::NATIVE;
+		r_type.type.native_type = p_identifier;
+		if (Engine::get_singleton()->has_singleton(p_identifier)) {
+			r_type.type.is_meta_type = false;
+			r_type.value = Engine::get_singleton()->get_singleton_object(p_identifier);
+		} else {
+			r_type.type.is_meta_type = true;
+			const Map<StringName, int>::Element *target_elem = GDScriptLanguage::get_singleton()->get_global_map().find(p_identifier);
+			// Check because classes like EditorNode are in ClassDB by now, but unknown to GDScript
+			if (!target_elem) {
+				return false;
 			}
-			return true;
+			int idx = target_elem->get();
+			r_type.value = GDScriptLanguage::get_singleton()->get_global_array()[idx];
 		}
+		return true;
 	}
 
 	// Check autoload singletons
@@ -1469,10 +1452,7 @@ static bool _guess_identifier_type_from_base(GDScriptCompletionContext &p_contex
 			case GDScriptParser::DataType::NATIVE: {
 				StringName class_name = base_type.native_type;
 				if (!ClassDB::class_exists(class_name)) {
-					class_name = String("_") + class_name;
-					if (!ClassDB::class_exists(class_name)) {
-						return false;
-					}
+					return false;
 				}
 
 				// Skip constants since they're all integers. Type does not matter because int has no members
@@ -1656,10 +1636,7 @@ static bool _guess_method_return_type_from_base(GDScriptCompletionContext &p_con
 			case GDScriptParser::DataType::NATIVE: {
 				StringName native = base_type.native_type;
 				if (!ClassDB::class_exists(native)) {
-					native = String("_") + native;
-					if (!ClassDB::class_exists(native)) {
-						return false;
-					}
+					return false;
 				}
 				MethodBind *mb = ClassDB::get_method(native, p_method);
 				if (mb) {
@@ -1986,10 +1963,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionContext &p_context
 			case GDScriptParser::DataType::NATIVE: {
 				StringName type = base_type.native_type;
 				if (!ClassDB::class_exists(type)) {
-					type = String("_") + type;
-					if (!ClassDB::class_exists(type)) {
-						return;
-					}
+					return;
 				}
 
 				if (!p_only_functions) {
@@ -2217,11 +2191,8 @@ static void _find_call_arguments(const GDScriptCompletionContext &p_context, con
 			case GDScriptParser::DataType::NATIVE: {
 				StringName class_name = base_type.native_type;
 				if (!ClassDB::class_exists(class_name)) {
-					class_name = String("_") + class_name;
-					if (!ClassDB::class_exists(class_name)) {
-						base_type.has_type = false;
-						break;
-					}
+					base_type.has_type = false;
+					break;
 				}
 
 				List<MethodInfo> methods;
@@ -2585,10 +2556,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 
 			StringName class_name = native_type.native_type;
 			if (!ClassDB::class_exists(class_name)) {
-				class_name = String("_") + class_name;
-				if (!ClassDB::class_exists(class_name)) {
-					break;
-				}
+				break;
 			}
 
 			bool use_type_hint = EditorSettings::get_singleton()->get_setting("text_editor/completion/add_type_hints").operator bool();
@@ -2684,10 +2652,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 
 						StringName class_name = base_type.native_type;
 						if (!ClassDB::class_exists(class_name)) {
-							class_name = String("_") + class_name;
-							if (!ClassDB::class_exists(class_name)) {
-								break;
-							}
+							break;
 						}
 
 						List<MethodInfo> signals;
@@ -2749,9 +2714,6 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 			ClassDB::get_class_list(&native_classes);
 			for (List<StringName>::Element *E = native_classes.front(); E; E = E->next()) {
 				String class_name = E->get().operator String();
-				if (class_name.begins_with("_")) {
-					class_name = class_name.right(1);
-				}
 				if (Engine::get_singleton()->has_singleton(class_name)) {
 					continue;
 				}
@@ -3025,11 +2987,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 			case GDScriptParser::DataType::NATIVE: {
 				StringName class_name = base_type.native_type;
 				if (!ClassDB::class_exists(class_name)) {
-					class_name = String("_") + class_name;
-					if (!ClassDB::class_exists(class_name)) {
-						base_type.has_type = false;
-						break;
-					}
+					base_type.has_type = false;
+					break;
 				}
 
 				if (ClassDB::has_method(class_name, p_symbol, true)) {
@@ -3082,11 +3041,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 
 				StringName parent = ClassDB::get_parent_class(class_name);
 				if (parent != StringName()) {
-					if (String(parent).begins_with("_")) {
-						base_type.native_type = String(parent).right(1);
-					} else {
-						base_type.native_type = parent;
-					}
+					base_type.native_type = parent;
 				} else {
 					base_type.has_type = false;
 				}
@@ -3146,13 +3101,6 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 		r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS;
 		r_result.class_name = p_symbol;
 		return OK;
-	} else {
-		String under_prefix = "_" + p_symbol;
-		if (ClassDB::class_exists(under_prefix)) {
-			r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS;
-			r_result.class_name = p_symbol;
-			return OK;
-		}
 	}
 
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
@@ -3315,10 +3263,6 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 								r_result.class_name = obj->get_class();
 							}
 
-							// proxy class remove the underscore.
-							if (r_result.class_name.begins_with("_")) {
-								r_result.class_name = r_result.class_name.right(1);
-							}
 							return OK;
 						}
 					} else {

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -79,11 +79,7 @@ struct GDScriptDataType {
 				Object *obj = p_variant.operator Object *();
 				if (obj) {
 					if (!ClassDB::is_parent_class(obj->get_class_name(), native_type)) {
-						// Try with underscore prefix
-						StringName underscore_native_type = "_" + native_type;
-						if (!ClassDB::is_parent_class(obj->get_class_name(), underscore_native_type)) {
-							return false;
-						}
+						return false;
 					}
 				}
 				return true;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3547,7 +3547,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 				tokenizer->advance(2);
 
 				// Check if name is shadowing something else
-				if (ClassDB::class_exists(name) || ClassDB::class_exists("_" + name.operator String())) {
+				if (ClassDB::class_exists(name)) {
 					_set_error("Class '" + String(name) + "' shadows a native class.");
 					return;
 				}
@@ -5338,7 +5338,7 @@ bool GDScriptParser::_parse_type(DataType &r_type, bool p_can_be_void) {
 		} break;
 		case GDScriptTokenizer::TK_IDENTIFIER: {
 			r_type.native_type = tokenizer->get_token_identifier();
-			if (ClassDB::class_exists(r_type.native_type) || ClassDB::class_exists("_" + r_type.native_type.operator String())) {
+			if (ClassDB::class_exists(r_type.native_type)) {
 				r_type.kind = DataType::NATIVE;
 			} else {
 				r_type.kind = DataType::UNRESOLVED;
@@ -6556,9 +6556,6 @@ bool GDScriptParser::_get_function_signature(DataType &p_base_type, const String
 
 	// Only native remains
 	if (!ClassDB::class_exists(native)) {
-		native = "_" + native.operator String();
-	}
-	if (!ClassDB::class_exists(native)) {
 		if (!check_types) return false;
 		ERR_EXPLAIN("Parser bug: Class '" + String(native) + "' not found.");
 		ERR_FAIL_V(false);
@@ -7067,9 +7064,6 @@ bool GDScriptParser::_get_member_type(const DataType &p_base_type, const StringN
 
 	// Check ClassDB
 	if (!ClassDB::class_exists(native)) {
-		native = "_" + native.operator String();
-	}
-	if (!ClassDB::class_exists(native)) {
 		if (!check_types) return false;
 		ERR_EXPLAIN("Parser bug: Class '" + String(native) + "' not found.");
 		ERR_FAIL_V(false);
@@ -7187,12 +7181,12 @@ GDScriptParser::DataType GDScriptParser::_reduce_identifier_type(const DataType 
 	if (!p_base_type) {
 		// Possibly this is a global, check before failing
 
-		if (ClassDB::class_exists(p_identifier) || ClassDB::class_exists("_" + p_identifier.operator String())) {
+		if (ClassDB::class_exists(p_identifier)) {
 			DataType result;
 			result.has_type = true;
 			result.is_constant = true;
 			result.is_meta_type = true;
-			if (Engine::get_singleton()->has_singleton(p_identifier) || Engine::get_singleton()->has_singleton("_" + p_identifier.operator String())) {
+			if (Engine::get_singleton()->has_singleton(p_identifier)) {
 				result.is_meta_type = false;
 			}
 			result.kind = DataType::NATIVE;

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -363,7 +363,7 @@ class BindingsGenerator {
 
 			itype.name = p_cname;
 			itype.cname = p_cname;
-			itype.proxy_name = itype.name.begins_with("_") ? itype.name.substr(1, itype.name.length()) : itype.name;
+			itype.proxy_name = itype.name;
 			itype.api_type = p_api_type;
 			itype.is_object_type = true;
 			itype.class_doc = &EditorHelp::get_doc_data()->class_list[itype.proxy_name];


### PR DESCRIPTION
Some classes like ClassDB have a proxy class like _ClassDB to expose
functionality to GDScript. This leads to a lot of checks all over the
codebase when a conversion between the internal(_ClassDB) and
external(ClassDB) version is needed. Removing the underscore directly
in the GDCLASS macro makes these checks obsolete and reduces the risk
of bugs.
Fixes #14872