### PR TITLE
GLES2: Ensure extension checks for texture2DLod

### DIFF
--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -220,29 +220,6 @@ VERTEX_SHADER_CODE
 /* clang-format off */
 [fragment]
 
-#ifndef USE_GLES_OVER_GL
-
-#ifdef GL_EXT_shader_texture_lod
-#extension GL_EXT_shader_texture_lod : enable
-#define texture2DLod(img, coord, lod) texture2DLodEXT(img, coord, lod)
-#define textureCubeLod(img, coord, lod) textureCubeLodEXT(img, coord, lod)
-#endif
-
-#endif
-
-#ifdef GL_ARB_shader_texture_lod
-#extension GL_ARB_shader_texture_lod : enable
-#endif
-
-
-#if !defined(GL_EXT_shader_texture_lod) && !defined(GL_ARB_shader_texture_lod)
-#define texture2DLod(img, coord, lod) texture2D(img, coord, lod)
-#define textureCubeLod(img, coord, lod) textureCube(img, coord, lod)
-#endif
-
-
-
-
 #ifdef USE_GLES_OVER_GL
 #define lowp
 #define mediump

--- a/drivers/gles2/shaders/cubemap_filter.glsl
+++ b/drivers/gles2/shaders/cubemap_filter.glsl
@@ -26,14 +26,12 @@ void main() {
 [fragment]
 
 #ifndef USE_GLES_OVER_GL
-
 #ifdef GL_EXT_shader_texture_lod
 #extension GL_EXT_shader_texture_lod : enable
 #define texture2DLod(img, coord, lod) texture2DLodEXT(img, coord, lod)
 #define textureCubeLod(img, coord, lod) textureCubeLodEXT(img, coord, lod)
 #endif
-
-#endif
+#endif // !USE_GLES_OVER_GL
 
 #ifdef GL_ARB_shader_texture_lod
 #extension GL_ARB_shader_texture_lod : enable
@@ -43,8 +41,6 @@ void main() {
 #define texture2DLod(img, coord, lod) texture2D(img, coord, lod)
 #define textureCubeLod(img, coord, lod) textureCube(img, coord, lod)
 #endif
-
-
 
 #ifdef USE_GLES_OVER_GL
 #define lowp
@@ -58,8 +54,7 @@ precision highp int;
 precision mediump float;
 precision mediump int;
 #endif
-
-#endif
+#endif // USE_GLES_OVER_GL
 
 #ifdef USE_SOURCE_PANORAMA
 uniform sampler2D source_panorama; //texunit:0

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -16,7 +16,6 @@ precision highp int;
 
 #define M_PI 3.14159265359
 
-
 //
 // attributes
 //
@@ -676,14 +675,12 @@ VERTEX_SHADER_CODE
 [fragment]
 
 #ifndef USE_GLES_OVER_GL
-
 #ifdef GL_EXT_shader_texture_lod
 #extension GL_EXT_shader_texture_lod : enable
 #define texture2DLod(img, coord, lod) texture2DLodEXT(img, coord, lod)
 #define textureCubeLod(img, coord, lod) textureCubeLodEXT(img, coord, lod)
 #endif
-
-#endif
+#endif // !USE_GLES_OVER_GL
 
 #ifdef GL_ARB_shader_texture_lod
 #extension GL_ARB_shader_texture_lod : enable
@@ -693,9 +690,6 @@ VERTEX_SHADER_CODE
 #define texture2DLod(img, coord, lod) texture2D(img, coord, lod)
 #define textureCubeLod(img, coord, lod) textureCube(img, coord, lod)
 #endif
-
-
-
 
 #ifdef USE_GLES_OVER_GL
 #define lowp
@@ -709,7 +703,7 @@ precision highp int;
 precision mediump float;
 precision mediump int;
 #endif
-#endif
+#endif // USE_GLES_OVER_GL
 
 #include "stdlib.glsl"
 

--- a/drivers/gles2/shaders/stdlib.glsl
+++ b/drivers/gles2/shaders/stdlib.glsl
@@ -1,3 +1,19 @@
+#ifndef USE_GLES_OVER_GL
+#ifdef GL_EXT_shader_texture_lod
+#extension GL_EXT_shader_texture_lod : enable
+#define texture2DLod(img, coord, lod) texture2DLodEXT(img, coord, lod)
+#define textureCubeLod(img, coord, lod) textureCubeLodEXT(img, coord, lod)
+#endif
+#endif // !USE_GLES_OVER_GL
+
+#ifdef GL_ARB_shader_texture_lod
+#extension GL_ARB_shader_texture_lod : enable
+#endif
+
+#if !defined(GL_EXT_shader_texture_lod) && !defined(GL_ARB_shader_texture_lod)
+#define texture2DLod(img, coord, lod) texture2D(img, coord, lod)
+#define textureCubeLod(img, coord, lod) textureCube(img, coord, lod)
+#endif
 
 vec2 select2(vec2 a, vec2 b, bvec2 c) {
 	vec2 ret;


### PR DESCRIPTION
In canvas.glsl and scene.glsl, we were using texel2DFetch from stdlib.glsl,
which uses texture2DLod. In both cases, the stdlib.glsl include came before
the define of texture2DLod.

Might fix issues for drivers that don't support GL_EXT_shader_texture_lod.
I haven't tested if such hardware was actually affected by any issue though,
it's just a shot in the dark from seeing the extension missing in #26924's device.