### PR TITLE
Fix Viewport and Camera issues

### DIFF
--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -63,6 +63,7 @@ public:
 private:
 	bool force_change;
 	bool current;
+	Viewport *viewport;
 
 	Projection mode;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -880,7 +880,7 @@ void Viewport::_camera_set(Camera *p_camera) {
 	if (camera == p_camera)
 		return;
 
-	if (camera && find_world().is_valid()) {
+	if (camera) {
 		camera->notification(Camera::NOTIFICATION_LOST_CURRENT);
 	}
 	camera = p_camera;
@@ -889,7 +889,7 @@ void Viewport::_camera_set(Camera *p_camera) {
 	else
 		VisualServer::get_singleton()->viewport_attach_camera(viewport, RID());
 
-	if (camera && find_world().is_valid()) {
+	if (camera) {
 		camera->notification(Camera::NOTIFICATION_BECAME_CURRENT);
 	}
 
@@ -908,9 +908,7 @@ void Viewport::_camera_remove(Camera *p_camera) {
 
 	cameras.erase(p_camera);
 	if (camera == p_camera) {
-		if (camera && find_world().is_valid()) {
-			camera->notification(Camera::NOTIFICATION_LOST_CURRENT);
-		}
+		camera->notification(Camera::NOTIFICATION_LOST_CURRENT);
 		camera = NULL;
 	}
 }
@@ -1007,7 +1005,7 @@ void Viewport::_propagate_enter_world(Node *p_node) {
 			Viewport *v = Object::cast_to<Viewport>(p_node);
 			if (v) {
 
-				if (v->world.is_valid())
+				if (v->world.is_valid() || v->own_world.is_valid())
 					return;
 			}
 		}
@@ -1044,7 +1042,7 @@ void Viewport::_propagate_exit_world(Node *p_node) {
 			Viewport *v = Object::cast_to<Viewport>(p_node);
 			if (v) {
 
-				if (v->world.is_valid())
+				if (v->world.is_valid() || v->own_world.is_valid())
 					return;
 			}
 		}
@@ -1064,22 +1062,10 @@ void Viewport::set_world(const Ref<World> &p_world) {
 	if (is_inside_tree())
 		_propagate_exit_world(this);
 
-#ifndef _3D_DISABLED
-	if (find_world().is_valid() && camera)
-		camera->notification(Camera::NOTIFICATION_LOST_CURRENT);
-#endif
-
 	world = p_world;
 
 	if (is_inside_tree())
 		_propagate_enter_world(this);
-
-#ifndef _3D_DISABLED
-	if (find_world().is_valid() && camera)
-		camera->notification(Camera::NOTIFICATION_BECAME_CURRENT);
-#endif
-
-	//propagate exit
 
 	if (is_inside_tree()) {
 		VisualServer::get_singleton()->viewport_set_scenario(viewport, find_world()->get_scenario());
@@ -2695,11 +2681,6 @@ void Viewport::set_use_own_world(bool p_world) {
 	if (is_inside_tree())
 		_propagate_exit_world(this);
 
-#ifndef _3D_DISABLED
-	if (find_world().is_valid() && camera)
-		camera->notification(Camera::NOTIFICATION_LOST_CURRENT);
-#endif
-
 	if (!p_world)
 		own_world = Ref<World>();
 	else
@@ -2707,13 +2688,6 @@ void Viewport::set_use_own_world(bool p_world) {
 
 	if (is_inside_tree())
 		_propagate_enter_world(this);
-
-#ifndef _3D_DISABLED
-	if (find_world().is_valid() && camera)
-		camera->notification(Camera::NOTIFICATION_BECAME_CURRENT);
-#endif
-
-	//propagate exit
 
 	if (is_inside_tree()) {
 		VisualServer::get_singleton()->viewport_set_scenario(viewport, find_world()->get_scenario());


### PR DESCRIPTION
### Commit 1: Fix Viewport and Camera issues

1. Consider 'own_world' as well as 'world' to stop propagating enter/exit world notifications.
2. Clean & fix handling of camera currency.

This fixes some random crashes and error logs in the editor; namely
- when enabling/disabling own world in a Viewport;
- when switching back from a subscene displayed into a main scene's Viewport;
- when exiting the editor after any of them;
- memory corruption (can that explain certain other seemingly unrelated crash reports?).

This also fixes situations where a Viewport and its main Camera get out of sync about which World is relevant to them.

### ~~Commit 2: Drop mouseover when mouse not in the window~~

~~Not that this is critical, but it makes behavior of GUI and 2D/3D picking consistent among them.~~

~~This also contributes to dropping GUI focus when the mouse leaves the window (in addition to when it loses focus).~~

-----

~~Commit 2 could very well wait for 3.1.1, but it's not dangerous.~~ Furthermore, I've created a test project that ensures lately changes in picking code haven't broken anything. https://github.com/RandomShaper/godot-picking-test

**UPDATE:** Commit 2 moved to its own PR since it contains a behavior change (yet small), and is better for 3.2., with no cherry-picking.