### PR TITLE
Be more tolerant about under-defined spatial viewport state

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4170,9 +4170,13 @@ void SpatialEditor::set_state(const Dictionary &p_state) {
 
 	if (d.has("viewports")) {
 		Array vp = d["viewports"];
-		ERR_FAIL_COND(vp.size() > 4);
+		uint32_t vp_size = static_cast<uint32_t>(vp.size());
+		if (vp_size > VIEWPORTS_COUNT) {
+			WARN_PRINT("Ignoring superfluous viewport settings from spatial editor state.")
+			vp_size = VIEWPORTS_COUNT;
+		}
 
-		for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
+		for (uint32_t i = 0; i < vp_size; i++) {
 			viewports[i]->set_state(vp[i]);
 		}
 	}


### PR DESCRIPTION
Don't crash when the saved editor state contains fewer viewports than currently supported.
Currently the spatial viewport will crash with an index out of bounds error when the state that is being set contains settings for fewer than 4 viewports. 
The change should have no consequences for "normal" set_state usage, but increases the usefulness of #26535 since it allows the settings for just the first viewport to be changed.