### PR TITLE
AudioStreamSample: Don't crash when writing to file fails

### DIFF
--- a/doc/classes/AudioStreamSample.xml
+++ b/doc/classes/AudioStreamSample.xml
@@ -12,11 +12,13 @@
 	</demos>
 	<methods>
 		<method name="save_to_wav">
-			<return type="void">
+			<return type="int" enum="Error">
 			</return>
 			<argument index="0" name="path" type="String">
 			</argument>
 			<description>
+				Saves the AudioStreamSample as a WAV file to [code]path[/code]. Samples with IMA ADPCM format can't be saved.
+				Note that a [code].wav[/code] extension is automatically appended to [code]path[/code] if it is missing.
 			</description>
 		</method>
 	</methods>

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -515,10 +515,10 @@ PoolVector<uint8_t> AudioStreamSample::get_data() const {
 	return pv;
 }
 
-void AudioStreamSample::save_to_wav(String p_path) {
+Error AudioStreamSample::save_to_wav(const String &p_path) {
 	if (format == AudioStreamSample::FORMAT_IMA_ADPCM) {
 		WARN_PRINTS("Saving IMA_ADPC samples are not supported yet");
-		return;
+		return ERR_UNAVAILABLE;
 	}
 
 	int sub_chunk_2_size = data_bytes; //Subchunk2Size = Size of data in bytes
@@ -544,8 +544,9 @@ void AudioStreamSample::save_to_wav(String p_path) {
 		file_path += ".wav";
 	}
 
-	Error err;
-	FileAccess *file = FileAccess::open(file_path, FileAccess::WRITE, &err); //Overrides existing file if present
+	FileAccessRef file = FileAccess::open(file_path, FileAccess::WRITE); //Overrides existing file if present
+
+	ERR_FAIL_COND_V(!file, ERR_FILE_CANT_WRITE);
 
 	// Create WAV Header
 	file->store_string("RIFF"); //ChunkID
@@ -583,6 +584,8 @@ void AudioStreamSample::save_to_wav(String p_path) {
 	}
 
 	file->close();
+
+	return OK;
 }
 
 Ref<AudioStreamPlayback> AudioStreamSample::instance_playback() {

--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -141,7 +141,7 @@ public:
 	void set_data(const PoolVector<uint8_t> &p_data);
 	PoolVector<uint8_t> get_data() const;
 
-	void save_to_wav(String p_path);
+	Error save_to_wav(const String &p_path);
 
 	virtual Ref<AudioStreamPlayback> instance_playback();
 	virtual String get_stream_name() const;


### PR DESCRIPTION
`AudioStreamSample::save_to_wav` would crash Godot if you tried to save to a path that didn't exist or where it had no write access. I also changed it to return `Error` so the developer can react in such cases, this shouldn't be a BC break as the method didn't return anything previously but maybe this change can also still slip into 3.1 :)

Docs for the method were added as well.