### PR TITLE
Fix crash when trying to set as Bitmap Font fallback one of his parent

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -497,7 +497,13 @@ Size2 Font::get_string_size(const String &p_string) const {
 }
 void BitmapFont::set_fallback(const Ref<BitmapFont> &p_fallback) {
 
-	ERR_FAIL_COND(p_fallback == this);
+	for (Ref<BitmapFont> fallback_child = p_fallback; fallback_child != NULL; fallback_child = fallback_child->get_fallback()) {
+		if (fallback_child == this) {
+			ERR_EXPLAIN("Can't set as fallback one of its parents to prevent crashes due to recursive loop.");
+			ERR_FAIL_COND(fallback_child == this);
+		}
+	}
+
 	fallback = p_fallback;
 }
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -34,7 +34,12 @@
 
 void Material::set_next_pass(const Ref<Material> &p_pass) {
 
-	ERR_FAIL_COND(p_pass == this);
+	for (Ref<Material> pass_child = p_pass; pass_child != NULL; pass_child = pass_child->get_next_pass()) {
+		if (pass_child == this) {
+			ERR_EXPLAIN("Can't set as next_pass one of its parents to prevent crashes due to recursive loop.");
+			ERR_FAIL_COND(pass_child == this);
+		}
+	}
 
 	if (next_pass == p_pass)
 		return;


### PR DESCRIPTION
Prevent assign to Bitmap Font fallback one of his parent to avoid crash by recurrence.
EDIT: It also fixed crash with materials
Fix first point of #26939