### PR TITLE
[DOC] Linked various tutorials in the classref

### DIFF
--- a/doc/classes/Light2D.xml
+++ b/doc/classes/Light2D.xml
@@ -7,6 +7,7 @@
 		Casts light in a 2D environment. Light is defined by a (usually grayscale) texture, a color, an energy value, a mode (see constants), and various other parameters (range and shadows-related). Note that Light2D can be used as a mask.
 	</description>
 	<tutorials>
+		<link>http://docs.godotengine.org/en/latest/tutorials/2d/2d_lights_and_shadows.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/LightOccluder2D.xml
+++ b/doc/classes/LightOccluder2D.xml
@@ -7,6 +7,7 @@
 		Occludes light cast by a Light2D, casting shadows. The LightOccluder2D must be provided with an [OccluderPolygon2D] in order for the shadow to be computed.
 	</description>
 	<tutorials>
+		<link>http://docs.godotengine.org/en/latest/tutorials/2d/2d_lights_and_shadows.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/MeshInstance2D.xml
+++ b/doc/classes/MeshInstance2D.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>http://docs.godotengine.org/en/latest/tutorials/2d/2d_meshes.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -10,6 +10,7 @@
 		Since instances may have any behavior, the AABB used for visibility must be provided by the user.
 	</description>
 	<tutorials>
+		<link>http://docs.godotengine.org/en/latest/tutorials/3d/vertex_animation/animating_thousands_of_fish.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/MultiMeshInstance.xml
+++ b/doc/classes/MultiMeshInstance.xml
@@ -8,6 +8,8 @@
 		This is useful to optimize the rendering of a high amount of instances of a given mesh (for example tree in a forest or grass strands).
 	</description>
 	<tutorials>
+		<link>http://docs.godotengine.org/en/latest/tutorials/3d/vertex_animation/animating_thousands_of_fish.html</link>
+		<link>http://docs.godotengine.org/en/latest/tutorials/3d/using_multi_mesh_instance.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -8,6 +8,7 @@
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
 	</description>
 	<tutorials>
+		<link>http://docs.godotengine.org/en/latest/tutorials/3d/vertex_animation/controlling_thousands_of_fish.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -7,6 +7,7 @@
 		A material that uses a custom [Shader] program to render either items to screen or process particles. You can create multiple materials for the same shader but configure different values for the uniforms defined in the shader.
 	</description>
 	<tutorials>
+		<link>http://docs.godotengine.org/en/latest/tutorials/shading/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Skeleton2D.xml
+++ b/doc/classes/Skeleton2D.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>http://docs.godotengine.org/en/latest/tutorials/animation/2d_skeletons.html</link>
 	</tutorials>
 	<demos>
 	</demos>


### PR DESCRIPTION
This started out as addressing https://github.com/godotengine/godot-docs/issues/2240, but then I figured I would add some other low hanging fruit while I was at it. 