### PR TITLE
Send notifications to ARVRInterfaces

### DIFF
--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -222,6 +222,15 @@ void ARVRInterfaceGDNative::process() {
 	interface->process(data);
 }
 
+void ARVRInterfaceGDNative::notification(int p_what) {
+	ERR_FAIL_COND(interface == NULL);
+
+	// this is only available in interfaces that implement 1.1 or later
+	if ((interface->version.major > 1) || ((interface->version.major == 1) && (interface->version.minor > 0))) {
+		interface->notification(p_what);
+	}
+}
+
 /////////////////////////////////////////////////////////////////////////////////////
 // some helper callbacks
 

--- a/modules/gdnative/arvr/arvr_interface_gdnative.h
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.h
@@ -82,6 +82,7 @@ public:
 	virtual void commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect);
 
 	virtual void process();
+	virtual void notification(int p_what);
 };
 
 #endif // ARVR_INTERFACE_GDNATIVE_H

--- a/modules/gdnative/include/arvr/godot_arvr.h
+++ b/modules/gdnative/include/arvr/godot_arvr.h
@@ -63,6 +63,7 @@ typedef struct {
 	void (*process)(void *);
 	// only in 1.1 onwards
 	godot_int (*get_external_texture_for_eye)(void *, godot_int);
+	void (*notification)(godot_int);
 } godot_arvr_interface_gdnative;
 
 void GDAPI godot_arvr_register_interface(const godot_arvr_interface_gdnative *p_interface);

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -440,6 +440,12 @@ void MobileVRInterface::process() {
 	};
 };
 
+void MobileVRInterface::notification(int p_what){
+	_THREAD_SAFE_METHOD_
+
+	// nothing to do here, I guess we could pauze our sensors...
+}
+
 MobileVRInterface::MobileVRInterface() {
 	initialized = false;
 

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -142,6 +142,7 @@ public:
 	virtual void commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect);
 
 	virtual void process();
+	virtual void notification(int p_what);
 
 	MobileVRInterface();
 	~MobileVRInterface();

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -583,6 +583,10 @@ void ARVROrigin::set_world_scale(float p_world_scale) {
 };
 
 void ARVROrigin::_notification(int p_what) {
+	// get our ARVRServer
+	ARVRServer *arvr_server = ARVRServer::get_singleton();
+	ERR_FAIL_NULL(arvr_server);
+
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			set_process_internal(true);
@@ -591,10 +595,6 @@ void ARVROrigin::_notification(int p_what) {
 			set_process_internal(false);
 		}; break;
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			// get our ARVRServer
-			ARVRServer *arvr_server = ARVRServer::get_singleton();
-			ERR_FAIL_NULL(arvr_server);
-
 			// set our world origin to our node transform
 			arvr_server->set_world_origin(get_global_transform());
 
@@ -611,6 +611,14 @@ void ARVROrigin::_notification(int p_what) {
 		default:
 			break;
 	};
+
+	// send our notification to all active ARVR interfaces, they may need to react to it also
+	for (int i = 0; i < arvr_server->get_interface_count(); i++) {
+		Ref<ARVRInterface> interface = arvr_server->get_interface(i);
+		if (interface.is_valid() && interface->is_initialized()) {
+			interface->notification(p_what);
+		}
+	}
 };
 
 ARVROrigin::ARVROrigin() {

--- a/servers/arvr/arvr_interface.h
+++ b/servers/arvr/arvr_interface.h
@@ -112,6 +112,7 @@ public:
 	virtual void commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) = 0; /* output the left or right eye */
 
 	virtual void process() = 0;
+	virtual void notification(int p_what) = 0;
 
 	ARVRInterface();
 	~ARVRInterface();


### PR DESCRIPTION
This solves #26960

I need access to the focus in, focus out and such that the operating system sends to our mainloop. Most of the AR and VR SDKs expect Godot to stop sending updates when focus is lost or when a pause signal is given.

We currently don't react to those as the ARVR interfaces are resources and don't receive these notifications.

This PR solves this by having the ARVROrigin node capture the notifications and forwarding them to any active ARVRInterface.