### PR TITLE
Add and expose to Font a function to get the word-wraped text size

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -96,6 +96,7 @@ void Font::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_height"), &Font::get_height);
 	ClassDB::bind_method(D_METHOD("is_distance_field_hint"), &Font::is_distance_field_hint);
 	ClassDB::bind_method(D_METHOD("get_string_size", "string"), &Font::get_string_size);
+	ClassDB::bind_method(D_METHOD("get_wordwrap_string_size", "string", "p_width"), &Font::get_wordwrap_string_size);
 	ClassDB::bind_method(D_METHOD("has_outline"), &Font::has_outline);
 	ClassDB::bind_method(D_METHOD("draw_char", "canvas_item", "position", "char", "next", "modulate", "outline"), &Font::draw_char, DEFVAL(-1), DEFVAL(Color(1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("update_changes"), &Font::update_changes);
@@ -495,6 +496,38 @@ Size2 Font::get_string_size(const String &p_string) const {
 
 	return Size2(w, get_height());
 }
+
+Size2 Font::get_wordwrap_string_size(const String &p_string, float p_width) const {
+
+	ERR_FAIL_COND_V(p_width <= 0, Vector2(0, get_height()));
+
+	int l = p_string.length();
+	if (l == 0)
+		return Size2(p_width, get_height());
+
+	float line_w = 0;
+	float h = 0;
+	float space_w = get_char_size(' ').width;
+	Vector<String> lines = p_string.split("\n");
+	for (int i = 0; i < lines.size(); i++) {
+		h += get_height();
+		String t = lines[i];
+		line_w = 0;
+		Vector<String> words = t.split(" ");
+		for (int j = 0; j < words.size(); j++) {
+			line_w += get_string_size(words[j]).x;
+			if (line_w > p_width) {
+				h += get_height();
+				line_w = get_string_size(words[j]).x;
+			} else {
+				line_w += space_w;
+			}
+		}
+	}
+
+	return Size2(p_width, h);
+}
+
 void BitmapFont::set_fallback(const Ref<BitmapFont> &p_fallback) {
 
 	ERR_FAIL_COND(p_fallback == this);

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -53,6 +53,7 @@ public:
 
 	virtual Size2 get_char_size(CharType p_char, CharType p_next = 0) const = 0;
 	Size2 get_string_size(const String &p_string) const;
+	Size2 get_wordwrap_string_size(const String &p_string, float p_width) const;
 
 	virtual bool is_distance_field_hint() const = 0;
 


### PR DESCRIPTION
This functions allow to pass the text you want to draw and the available with in your container and will return a Vector2 with the size that the container needs to fit the entire text.

Sponsored by IMVU