### PR TITLE
[DOCS] minor classref updates

### DIFF
--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -4,7 +4,7 @@
 		Proxy texture for simple frame-based animations.
 	</brief_description>
 	<description>
-		[code]AnimatedTexture[/code] is a resource format for simple frame-based animations, where multiple frames textures can be chained automatically with a predefined delay for each frame. It's not a [Node], contrarily to [AnimationPlayer] or [AnimatedSprite], but has the advantage of being usable at any place where a [Texture] resource can be used, e.g. in a [TileSet].
+		[code]AnimatedTexture[/code] is a resource format for frame-based animations, where multiple textures can be chained automatically with a predefined delay for each frame. Unlike [AnimationPlayer] or [AnimatedSprite], it isn't a [Node], but has the advantage of being usable anywhere a [Texture] resource can be used, e.g. in a [TileSet].
 		The playback of the animation is controlled by the [member fps] property as well as each frame's optional delay (see [method set_frame_delay]). The animation loops, i.e. it will restart at frame 0 automatically after playing the last frame.
 		[code]AnimatedTexture[/code] currently requires all frame textures to have the same size, otherwise the bigger ones will be cropped to match the smallest one.
 	</description>
@@ -19,7 +19,7 @@
 			<argument index="0" name="frame" type="int">
 			</argument>
 			<description>
-				Retrieves the delayed assigned to the given [code]frame[/code] ID.
+				Returns the given frame's delay value.
 			</description>
 		</method>
 		<method name="get_frame_texture" qualifiers="const">
@@ -28,7 +28,7 @@
 			<argument index="0" name="frame" type="int">
 			</argument>
 			<description>
-				Retrieves the [Texture] assigned to the given [code]frame[/code] ID.
+				Returns the given frame's [Texture].
 			</description>
 		</method>
 		<method name="set_frame_delay">
@@ -39,7 +39,7 @@
 			<argument index="1" name="delay" type="float">
 			</argument>
 			<description>
-				Defines an additional delay (in seconds) between this frame and the next one, that will be added to the time interval defined by [member fps]. By default, frames have no delay defined. If a delay value is defined, the final time interval between this frame and the next will be [code]1.0 / fps + delay[/code].
+				Sets an additional delay (in seconds) between this frame and the next one, that will be added to the time interval defined by [member fps]. By default, frames have no delay defined. If a delay value is defined, the final time interval between this frame and the next will be [code]1.0 / fps + delay[/code].
 				For example, for an animation with 3 frames, 2 FPS and a frame delay on the second frame of 1.2, the resulting playback will be:
 				[codeblock]
 				Frame 0: 0.5 s (1 / fps)
@@ -57,15 +57,15 @@
 			<argument index="1" name="texture" type="Texture">
 			</argument>
 			<description>
-				Assigns a [Texture] to the given [code]frame[/code] ID. IDs start at 0 (so the first frame has ID 0, and the last frame of the animation has ID [member frames] - 1).
-				You can define any frame texture up to [constant MAX_FRAMES], but keep in mind that only frames from 0 to [member frames] - 1 will be part of the animation.
+				Assigns a [Texture] to the given frame. Frame IDs start at 0, so the first frame has ID 0, and the last frame of the animation has ID [member frames] - 1.
+				You can define any number of textures up to [constant MAX_FRAMES], but keep in mind that only frames from 0 to [member frames] - 1 will be part of the animation.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="fps" type="float" setter="set_fps" getter="get_fps">
-			Number of frames per second. This value defines the default time interval between two frames of the animation, and thus the overall duration of the animation loop based on the [member frames] property. A value of 0 means no predefined number of frames per second, the animation will play according to each frame's frame delay (see [method set_frame_delay]). Default value: 4.
-			For example, an animation with 8 frames, no frame delay and a [code]fps[/code] value of 2 will run over 4 seconds, with one frame each 0.5 seconds.
+			Animation speed in frames per second. This value defines the default time interval between two frames of the animation, and thus the overall duration of the animation loop based on the [member frames] property. A value of 0 means no predefined number of frames per second, the animation will play according to each frame's frame delay (see [method set_frame_delay]). Default value: 4.
+			For example, an animation with 8 frames, no frame delay and a [code]fps[/code] value of 2 will run for 4 seconds, with each frame lasting 0.5 seconds.
 		</member>
 		<member name="frames" type="int" setter="set_frames" getter="get_frames">
 			Number of frames to use in the animation. While you can create the frames independently with [method set_frame_texture], you need to set this value for the animation to take new frames into account. The maximum number of frames is [constant MAX_FRAMES]. Default value: 1.

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -6,8 +6,18 @@
 	<description>
 		Dictionary type. Associative container which contains values referenced by unique keys. Dictionaries are always passed by reference.
 		Erasing elements while iterating over them [b]is not supported[/b].
+		Creating a dictionary:
+		[codeblock]
+		var d = {4: 5, "A key": "A value", 28: [1, 2, 3]}
+		[/codeblock]
+		To add a key to an existing dictionary, access it like an existing key and assign to it:
+		[codeblock]
+		d[4] = "hello"  # Add integer 4 as a key and assign the String "hello" as its value.
+		d["Godot"] = 3.01  # Add String "Godot" as a key and assign the value 3.01 to it.
+		[/codeblock]
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_basics.html#dictionary</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -27,6 +27,12 @@
 			</argument>
 			<description>
 				Returns a [KinematicCollision2D], which contains information about a collision that occurred during the last [method move_and_slide] call. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_count] - 1).
+				Example usage:
+				[codeblock]
+				for i in get_slide_count():
+				    var collision = get_slide_collision(i)
+				    print("Collided with: ", collision.collider.name)
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_slide_count" qualifiers="const">
@@ -94,7 +100,7 @@
 				If the body is standing on a slope and the horizontal speed (relative to the floor's speed) goes below [code]slope_stop_min_velocity[/code], the body will stop completely. This prevents the body from sliding down slopes when you include gravity in [code]linear_velocity[/code]. When set to lower values, the body will not be able to stand still on steep slopes.
 				If the body collides, it will change direction a maximum of [code]max_slides[/code] times before it stops.
 				[code]floor_max_angle[/code] is the maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall. The default value equals 45 degrees.
-				Returns the [code]linear_velocity[/code] vector, rotated and/or scaled if a slide collision occurred. To get more detailed information about collisions that occurred, use [method get_slide_collision].
+				Returns the [code]linear_velocity[/code] vector, rotated and/or scaled if a slide collision occurred. To get detailed information about collisions that occurred, use [method get_slide_collision].
 			</description>
 		</method>
 		<method name="move_and_slide_with_snap">

--- a/doc/classes/RayCast.xml
+++ b/doc/classes/RayCast.xml
@@ -5,10 +5,10 @@
 	</brief_description>
 	<description>
 		A RayCast represents a line from its origin to its destination position, [code]cast_to[/code]. It is used to query the 3D space in order to find the closest object along the path of the ray.
-		RayCast can ignore some objects by adding them to the exception list via [code]add_exception[/code], by setting proper filtering with collision layers, or by filtering object types with type masks.
+		RayCast can ignore some objects by adding them to the exception list via [code]add_exception[/code] or by setting proper filtering with collision layers and masks.
 		RayCast can be configured to report collisions with [Area]s ([member collide_with_areas]) and/or [PhysicsBody]s ([member collide_with_bodies]).
 		Only enabled raycasts will be able to query the space and report collisions.
-		RayCast calculates intersection every physics frame (see [Node]), and the result is cached so it can be used later until the next frame. If multiple queries are required between physics frames (or during the same frame) use [method force_raycast_update] after adjusting the raycast.
+		RayCast calculates intersection every physics frame (see [Node]), and the result is cached so it can be used later until the next frame. If multiple queries are required between physics frames (or during the same frame), use [method force_raycast_update] after adjusting the raycast.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -145,7 +145,7 @@
 			<argument index="0" name="b" type="Rect2">
 			</argument>
 			<description>
-				Returns a larger Rect2 that contains this Rect2 and [code]with[/code].
+				Returns a larger Rect2 that contains this Rect2 and [code]b[/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
* Added example code for `KinematicBody2D.get_slide_collision()`
* Added example code for `Dictionary`
* Fixed parameter name in `Rect2`, closes https://github.com/godotengine/godot-docs/issues/2217
* `RayCast` removed mention of "type mask"
* Grammar/wording fixes in `AnimatedTexture`