### PR TITLE
Fix bone aabb calculation, which caused a skeletal mesh culling issue

### DIFF
--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -776,7 +776,7 @@ Error VisualServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint32_
 						continue; //break;
 					ERR_FAIL_INDEX_V(idx, total_bones, ERR_INVALID_DATA);
 
-					if (bptr->size.x < 0) {
+					if (bptr[idx].size.x < 0) {
 						//first
 						bptr[idx] = AABB(v, SMALL_VEC3);
 						any_valid = true;


### PR DESCRIPTION
There was a bug that could result in most bone aabb boxes ending up with
tiny size upon import and mess up with culling of skeletal meshes. This
fixes it.

My model before the fix:
![skeletal_mesh_culling_issue_godot](https://user-images.githubusercontent.com/5029519/54331784-ec92f680-45f1-11e9-808f-fb0d439e690d.gif)

After fix:
![skeletal_mesh_culling_fixed_godot](https://user-images.githubusercontent.com/5029519/54331797-f4eb3180-45f1-11e9-86dd-59228ed3ac84.gif)
