### PR TITLE
AnimationNodeAnimation use speed_scale set in AnimationPlayer

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -87,14 +87,16 @@ float AnimationNodeAnimation::process(float p_time, bool p_seek) {
 
 	Ref<Animation> anim = ap->get_animation(animation);
 
+	float speed_scale = ap->get_speed_scale();
+
 	float step;
 
 	if (p_seek) {
 		time = p_time;
 		step = 0;
 	} else {
-		time = MAX(0, time + p_time);
-		step = p_time;
+		time = MAX(0, time + (p_time * speed_scale));
+		step = p_time * speed_scale;
 	}
 
 	float anim_size = anim->get_length();


### PR DESCRIPTION
This change makes animation nodes take the playback speed set in the animation player into account so that animation nodes in state machines can be played slower and faster by changing the speed in the animation player.

Not sure if this is the correct approach design wise, but I needed a way to slow down/speed up animations that played in a state machine and this was an easy way to achieve that.

Please give me feedback, and let me know if this is something you might want to merge, and if I should make any changes, thanks.