### PR TITLE
Ignore default ccls cache folder and compile commands json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -316,3 +316,10 @@ platform/windows/godot_res.res
 
 # Scons progress indicator
 .scons_node_count
+
+# ccls cache (https://github.com/MaskRay/ccls)
+.ccls-cache/
+
+# compile commands (https://clang.llvm.org/docs/JSONCompilationDatabase.html)
+compile_commands.json
+


### PR DESCRIPTION
ccls cache folder - https://github.com/MaskRay/ccls
compile_commands.json - https://clang.llvm.org/docs/JSONCompilationDatabase.html

Great tools to use in combo with vscode to do C++ development.