### PR TITLE
Resolve GLES 2 crash on older iOS devices

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -615,18 +615,6 @@ static int frame_count = 0;
 
 	// Create a full-screen window
 	window = [[UIWindow alloc] initWithFrame:rect];
-	// window.autoresizesSubviews = YES;
-	//[window setAutoresizingMask:UIViewAutoresizingFlexibleWidth |
-	// UIViewAutoresizingFlexibleWidth];
-
-	// Create the OpenGL ES view and add it to the window
-	GLView *glView = [[GLView alloc] initWithFrame:rect];
-	printf("glview is %p\n", glView);
-	//[window addSubview:glView];
-	glView.delegate = self;
-	// glView.autoresizesSubviews = YES;
-	//[glView setAutoresizingMask:UIViewAutoresizingFlexibleWidth |
-	// UIViewAutoresizingFlexibleWidth];
 
 	OS::VideoMode vm = _get_video_mode();
 
@@ -640,6 +628,12 @@ static int frame_count = 0;
 		exit(0);
 		return FALSE;
 	};
+
+	// WARNING: We must *always* create the GLView after we have constructed the
+	// OS with iphone_main. This allows the GLView to access project settings so
+	// it can properly initialize the OpenGL context
+	GLView *glView = [[GLView alloc] initWithFrame:rect];
+	glView.delegate = self;
 
 	view_controller = [[ViewController alloc] init];
 	view_controller.view = glView;

--- a/platform/iphone/gl_view.mm
+++ b/platform/iphone/gl_view.mm
@@ -285,16 +285,26 @@ static void clear_touches() {
 			kEAGLDrawablePropertyColorFormat,
 			nil];
 
-	// Create our EAGLContext, and if successful make it current and create our framebuffer.
-	context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
-
-	if (!context || ![EAGLContext setCurrentContext:context] || ![self createFramebuffer]) {
+	// Create a context based on the gl driver from project settings
+	if (GLOBAL_GET("rendering/quality/driver/driver_name") == "GLES3") {
+		context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
+		NSLog(@"Setting up an OpenGL ES 3 context. Based on Project Settings \"rendering/quality/driver/driver_name\"");
+	} else if (GLOBAL_GET("rendering/quality/driver/driver_name") == "GLES2") {
 		context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
 		gles3_available = false;
-		if (!context || ![EAGLContext setCurrentContext:context] || ![self createFramebuffer]) {
-			[self release];
-			return nil;
-		}
+		NSLog(@"Setting up an OpenGL ES 2 context. Based on Project Settings \"rendering/quality/driver/driver_name\"");
+	}
+	if (!context) {
+		NSLog(@"Failed to create OpenGL ES context!");
+		return nil;
+	}
+	if (![EAGLContext setCurrentContext:context]) {
+		NSLog(@"Failed to set EAGLContext!");
+		return nil;
+	}
+	if (![self createFramebuffer]) {
+		NSLog(@"Failed to create frame buffer!");
+		return nil;
 	}
 
 	// Default the animation interval to 1/60th of a second.

--- a/platform/iphone/gl_view.mm
+++ b/platform/iphone/gl_view.mm
@@ -284,20 +284,28 @@ static void clear_touches() {
 			kEAGLColorFormatRGBA8,
 			kEAGLDrawablePropertyColorFormat,
 			nil];
-
-	// Create a context based on the gl driver from project settings
+	bool fallback_gl2 = false;
+	// Create a GL ES 3 context based on the gl driver from project settings
 	if (GLOBAL_GET("rendering/quality/driver/driver_name") == "GLES3") {
 		context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
-		NSLog(@"Setting up an OpenGL ES 3 context. Based on Project Settings \"rendering/quality/driver/driver_name\"");
-	} else if (GLOBAL_GET("rendering/quality/driver/driver_name") == "GLES2") {
+		NSLog(@"Setting up an OpenGL ES 3.0 context. Based on Project Settings \"rendering/quality/driver/driver_name\"");
+		if (!context && GLOBAL_GET("rendering/quality/driver/fallback_to_gles2")) {
+			gles3_available = false;
+			fallback_gl2 = true;
+			NSLog(@"Failed to create OpenGL ES 3.0 context. Falling back to OpenGL ES 2.0");
+		}
+	}
+
+	// Create GL ES 2 context
+	if (GLOBAL_GET("rendering/quality/driver/driver_name") == "GLES2" || fallback_gl2) {
 		context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
-		gles3_available = false;
-		NSLog(@"Setting up an OpenGL ES 2 context. Based on Project Settings \"rendering/quality/driver/driver_name\"");
+		NSLog(@"Setting up an OpenGL ES 2.0 context.");
+		if (!context) {
+			NSLog(@"Failed to create OpenGL ES 2.0 context!");
+			return nil;
+		}
 	}
-	if (!context) {
-		NSLog(@"Failed to create OpenGL ES context!");
-		return nil;
-	}
+
 	if (![EAGLContext setCurrentContext:context]) {
 		NSLog(@"Failed to set EAGLContext!");
 		return nil;


### PR DESCRIPTION
This resolves #26450.

Since both types `EAGLContext` exists and are valid to create on some devices, the export template would always create a GL ES 3 context, which was causing FBO crashes when the rest of the pipeline was configured as OpenGL ES 2.