### PR TITLE
Make size cache dirty when removing tiles in 'TileMap'

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -773,6 +773,7 @@ void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_
 		else
 			_make_quadrant_dirty(Q);
 
+		used_size_cache_dirty = true;
 		return;
 	}
 


### PR DESCRIPTION
Without this, `TileMap.get_used_rect()` returns an incorrect value when tiles have been removed.