### PR TITLE
Fix scaling issue for texture button focus texture.

### DIFF
--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -223,8 +223,7 @@ void TextureButton::_notification(int p_what) {
 			}
 			if (has_focus() && focused.is_valid()) {
 
-				Rect2 drect(Point2(), get_size());
-				draw_texture_rect(focused, drect, false);
+				draw_texture_rect(focused, _position_rect, false);
 			};
 		} break;
 	}


### PR DESCRIPTION
Reproduction project.
[focus_bug.zip](https://github.com/godotengine/godot/files/2970034/focus_bug.zip)

Bug:
![2019-03-15_01-24-57](https://user-images.githubusercontent.com/32321/54418114-339bed00-46c1-11e9-8f65-07fd155a89ed.png)
![2019-03-15_01-25-07](https://user-images.githubusercontent.com/32321/54418116-339bed00-46c1-11e9-9e35-da7ba9928b7d.png)

Fix:

![2019-03-15_01-31-34](https://user-images.githubusercontent.com/32321/54418419-1fa4bb00-46c2-11e9-9c84-97abdea21e72.png)
![2019-03-15_01-31-43](https://user-images.githubusercontent.com/32321/54418420-1fa4bb00-46c2-11e9-9475-73d8a0d3e027.png)


