### PR TITLE
Basis comparison is now using is_equal_approx, suits better the most comon use case

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -561,7 +561,7 @@ bool Basis::is_equal_approx(const Basis &a, const Basis &b) const {
 
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
-			if (!Math::is_equal_approx_ratio(a.elements[i][j], b.elements[i][j], UNIT_EPSILON))
+			if (!Math::is_equal_approx(a.elements[i][j], b.elements[i][j], UNIT_EPSILON))
 				return false;
 		}
 	}


### PR DESCRIPTION
After a32b26dfa26f2a039bf9c84b90d10666bcf785c9, Godot seems extremely confused about a basis being orthogonal or not.
This PR reverts the basis equality to be done with the `is_equal_approx` function rather than `is_equal_approx_ratio`

**How to observe the problem**:
apply this patch to godot: 
```
diff --git a/scene/3d/spatial.cpp b/scene/3d/spatial.cpp
index 83f99a2e3..95b8af655 100644
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -687,6 +687,9 @@ void Spatial::look_at(const Vector3 &p_target, const Vector3 &p_up) {
 		ERR_FAIL();
 	}
 	lookat = lookat.looking_at(p_target, p_up);
+	if (!lookat.basis.is_orthogonal()) {
+		print_line("Basis is not orthogonal!");
+	}
 	set_global_transform(lookat);
 }
```
Open the project [not_orthogonal_mrp.zip](https://github.com/godotengine/godot/files/2970503/not_orthogonal_mrp.zip)  
Observe the console: 
```
Basis is not orthogonal!
Is this basis an identity basis?
 1.0000000000 0.0000000000 0.0000000596
 0.0000000000 1.0000000000 0.0000000298
 0.0000000596 0.0000000298 1.0000000000
 Dot product is 0.0000000149
```

The code that prints the identity matrix is taken from Basis::is_orthogonal (core/math/basis.cpp:108).
The basis you see gets compared to an identity matrix but the is_equal_approx_ratio  return false, when with both math precise on and off, it should be treated as equal. 

