### PR TITLE
Allow arbitrary content to be appended to build.gradle

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -72,6 +72,7 @@ env_base.android_flat_dirs = []
 env_base.android_dependencies = []
 env_base.android_gradle_plugins = []
 env_base.android_gradle_classpath = []
+env_base.android_gradle_content = []
 env_base.android_java_dirs = []
 env_base.android_res_dirs = []
 env_base.android_asset_dirs = []
@@ -102,6 +103,7 @@ env_base.__class__.android_add_to_permissions = methods.android_add_to_permissio
 env_base.__class__.android_add_to_attributes = methods.android_add_to_attributes
 env_base.__class__.android_add_gradle_plugin = methods.android_add_gradle_plugin
 env_base.__class__.android_add_gradle_classpath = methods.android_add_gradle_classpath
+env_base.__class__.android_add_gradle_content = methods.android_add_gradle_content
 env_base.__class__.disable_module = methods.disable_module
 
 env_base.__class__.add_module_version_string = methods.add_module_version_string

--- a/methods.py
+++ b/methods.py
@@ -257,6 +257,10 @@ def android_add_gradle_classpath(self, classpath):
     if (classpath not in self.android_gradle_classpath):
         self.android_gradle_classpath.append(classpath)
 
+def android_add_gradle_content(self, config):
+    if (config not in self.android_gradle_content):
+        self.android_gradle_content.append(config)
+
 def android_add_default_config(self, config):
     if (config not in self.android_default_config):
         self.android_default_config.append(config)

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -76,6 +76,10 @@ gradle_classpath = ""
 for x in env.android_gradle_classpath:
 	gradle_classpath += "\t\tclasspath \"" + x + "\"\n"
 
+gradle_content = ""
+for x in env.android_gradle_content:
+    gradle_content += x + "\n"
+
 gradle_res_dirs_text = ""
 
 for x in env.android_res_dirs:
@@ -125,6 +129,7 @@ gradle_text = gradle_text.replace("$$GRADLE_JNI_DIRS$$", gradle_jni_dirs_text)
 gradle_text = gradle_text.replace("$$GRADLE_DEFAULT_CONFIG$$", gradle_default_config_text)
 gradle_text = gradle_text.replace("$$GRADLE_PLUGINS$$", gradle_plugins)
 gradle_text = gradle_text.replace("$$GRADLE_CLASSPATH$$", gradle_classpath)
+gradle_text = gradle_text.replace("$$GRADLE_CONTENT$$", gradle_content)
 
 with open_utf8(abspath + "/java/build.gradle", "w") as gradle_baseout:
 	gradle_baseout.write(gradle_text)

--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -86,3 +86,5 @@ android {
 }
 
 $$GRADLE_PLUGINS$$
+
+$$GRADLE_CONTENT$$


### PR DESCRIPTION
This allows easier integration of plugins, since some of those need
entire new sections in the build.gradle file.