### PR TITLE
 Shortcut to open help menu - Shift + F1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -316,3 +316,10 @@ platform/windows/godot_res.res
 
 # Scons progress indicator
 .scons_node_count
+
+# ccls cache (https://github.com/MaskRay/ccls)
+.ccls-cache/
+
+# compile commands (https://clang.llvm.org/docs/JSONCompilationDatabase.html)
+compile_commands.json
+

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -323,6 +323,9 @@
 		<member name="display/mouse_cursor/custom_image_hotspot" type="Vector2" setter="" getter="">
 			Hotspot for the custom mouse cursor image.
 		</member>
+		<member name="display/mouse_cursor/tooltip_position_offset" type="Vector2" setter="" getter="">
+			Position offset for tooltips, relative to the hotspot of the mouse cursor.
+		</member>
 		<member name="display/window/dpi/allow_hidpi" type="bool" setter="" getter="">
 			Allow HiDPI display on Windows and OSX. On Desktop Linux, this can't be enabled or disabled.
 		</member>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5540,7 +5540,7 @@ EditorNode::EditorNode() {
 	p = help_menu->get_popup();
 	p->set_hide_on_window_lose_focus(true);
 	p->connect("id_pressed", this, "_menu_option");
-	p->add_icon_shortcut(gui_base->get_icon("HelpSearch", "EditorIcons"), ED_SHORTCUT("editor/editor_help", TTR("Search"), KEY_F4), HELP_SEARCH);
+    p->add_icon_shortcut(gui_base->get_icon("HelpSearch", "EditorIcons"), ED_SHORTCUT("editor/editor_help", TTR("Search"), KEY_MASK_SHIFT | KEY_F1), HELP_SEARCH);
 	p->add_separator();
 	p->add_icon_item(gui_base->get_icon("Instance", "EditorIcons"), TTR("Online Docs"), HELP_DOCS);
 	p->add_icon_item(gui_base->get_icon("Instance", "EditorIcons"), TTR("Q&A"), HELP_QA);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1209,6 +1209,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	GLOBAL_DEF("display/mouse_cursor/custom_image", String());
 	GLOBAL_DEF("display/mouse_cursor/custom_image_hotspot", Vector2());
+	GLOBAL_DEF("display/mouse_cursor/tooltip_position_offset", Point2(10, 10));
 	ProjectSettings::get_singleton()->set_custom_property_info("display/mouse_cursor/custom_image", PropertyInfo(Variant::STRING, "display/mouse_cursor/custom_image", PROPERTY_HINT_FILE, "*.png,*.webp"));
 
 	if (String(ProjectSettings::get_singleton()->get("display/mouse_cursor/custom_image")) != String()) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1476,7 +1476,8 @@ void Viewport::_gui_show_tooltip() {
 	gui.tooltip_popup->set_as_toplevel(true);
 	//gui.tooltip_popup->hide();
 
-	Rect2 r(gui.tooltip_pos + Point2(10, 10), gui.tooltip_popup->get_minimum_size());
+	Point2 tooltip_offset = ProjectSettings::get_singleton()->get("display/mouse_cursor/tooltip_position_offset");
+	Rect2 r(gui.tooltip_pos + tooltip_offset, gui.tooltip_popup->get_minimum_size());
 	Rect2 vr = gui.tooltip_popup->get_viewport_rect();
 	if (r.size.x + r.position.x > vr.size.x)
 		r.position.x = vr.size.x - r.size.x;


### PR DESCRIPTION
This mentions issues 

#24211    #3786

I have tried to add the shortcut to open help menu: Shift + F1 which is the standard way of opening help menu and since many of the people needed it.