### PR TITLE
Fix focus for TextEdit and LineEdit when certain input keys are triggered

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -356,6 +356,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 						set_cursor_position(cc);
 
 					} else {
+						if (get_cursor_position() == 0) handled = false;
 						set_cursor_position(get_cursor_position() - 1);
 					}
 
@@ -399,6 +400,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 						set_cursor_position(cc);
 
 					} else {
+						if (get_cursor_position() == (int)text.length()) handled = false;
 						set_cursor_position(get_cursor_position() + 1);
 					}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2560,7 +2560,8 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 						}
 						cursor_set_column(cc);
 					}
-
+				} else if (cursor.line == 0 && cursor.column == 0) {
+					scancode_handled = false;
 				} else if (cursor.column == 0) {
 
 					if (cursor.line > 0) {
@@ -2621,7 +2622,8 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 						}
 						cursor_set_column(cc);
 					}
-
+				} else if (cursor.line == get_last_unhidden_line() && cursor.column == text[cursor.line].length()) {
+					scancode_handled = false;
 				} else if (cursor.column == text[cursor.line].length()) {
 
 					if (cursor.line < text.size() - 1) {
@@ -2672,6 +2674,8 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					int cur_wrap_index = get_cursor_wrap_index();
 					if (cur_wrap_index > 0) {
 						cursor_set_line(cursor.line, true, false, cur_wrap_index - 1);
+					} else if (cursor.line == 0 && cursor.column == 0) {
+						scancode_handled = false;
 					} else if (cursor.line == 0) {
 						cursor_set_column(0);
 					} else {
@@ -2724,6 +2728,8 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					int cur_wrap_index = get_cursor_wrap_index();
 					if (cur_wrap_index < times_line_wraps(cursor.line)) {
 						cursor_set_line(cursor.line, true, false, cur_wrap_index + 1);
+					} else if (cursor.line == get_last_unhidden_line() && cursor.column == text[cursor.line].length()) {
+						scancode_handled = false;
 					} else if (cursor.line == get_last_unhidden_line()) {
 						cursor_set_column(text[cursor.line].length());
 					} else {


### PR DESCRIPTION
now text_edit and line_edit modules release the focus under certain conditions when KEY_UP,DOWN,RIGHT or LEFT is triggered
_Bugsquad edit:_ Fix #27036