### PR TITLE
Force drawing guides in single-row Tree items in the editor

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -721,6 +721,7 @@ CreateDialog::CreateDialog() {
 	favorites->connect("cell_selected", this, "_favorite_selected");
 	favorites->connect("item_activated", this, "_favorite_activated");
 	favorites->set_drag_forwarding(this);
+	favorites->add_constant_override("draw_guides", 1);
 
 	VBoxContainer *rec_vb = memnew(VBoxContainer);
 	vsc->add_child(rec_vb);
@@ -733,6 +734,7 @@ CreateDialog::CreateDialog() {
 	recent->set_hide_folding(true);
 	recent->connect("cell_selected", this, "_history_selected");
 	recent->connect("item_activated", this, "_history_activated");
+	recent->add_constant_override("draw_guides", 1);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	hsc->add_child(vbc);

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -255,14 +255,19 @@ void EditorQuickOpen::_confirmed() {
 
 void EditorQuickOpen::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
+	switch (p_what) {
 
-		connect("confirmed", this, "_confirmed");
+		case NOTIFICATION_ENTER_TREE: {
 
-		search_box->set_right_icon(get_icon("Search", "EditorIcons"));
-		search_box->set_clear_button_enabled(true);
-	} else if (p_what == NOTIFICATION_EXIT_TREE) {
-		disconnect("confirmed", this, "_confirmed");
+			connect("confirmed", this, "_confirmed");
+
+			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
+			search_box->set_clear_button_enabled(true);
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+
+			disconnect("confirmed", this, "_confirmed");
+		} break;
 	}
 }
 
@@ -297,6 +302,7 @@ EditorQuickOpen::EditorQuickOpen() {
 	set_hide_on_ok(false);
 	search_options->connect("item_activated", this, "_confirmed");
 	search_options->set_hide_root(true);
+	search_options->add_constant_override("draw_guides", 1);
 	ei = "EditorIcons";
 	ot = "Object";
 	add_directories = false;


### PR DESCRIPTION
Now that guides in `Tree` nodes disappear when relationship lines are visible, this prevents them from being drawn in places they should. This commit forces guide drawing in them.