### PR TITLE
Make AnimatedSprite able to play backwards

### DIFF
--- a/doc/classes/AnimatedSprite.xml
+++ b/doc/classes/AnimatedSprite.xml
@@ -24,7 +24,7 @@
 			<argument index="0" name="anim" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Play the animation set in parameter. If no parameter is provided, the current animation is played.
+				Play the animation set in parameter. If no parameter is provided, the current animation is played. Property [code]backwards[/code] plays the animation in reverse if set to [code]true[/code].
 			</description>
 		</method>
 		<method name="stop">

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -393,19 +393,30 @@ void AnimatedSprite::_notification(int p_what) {
 					timeout = _get_frame_duration();
 
 					int fc = frames->get_frame_count(animation);
-					if (frame >= fc - 1) {
+					if ((!backwards && frame >= fc - 1) || (backwards && frame <= 0)) {
 						if (frames->get_animation_loop(animation)) {
-							frame = 0;
+							if (backwards)
+								frame = fc - 1;
+							else
+								frame = 0;
+
 							emit_signal(SceneStringNames::get_singleton()->animation_finished);
 						} else {
-							frame = fc - 1;
+							if (backwards)
+								frame = 0;
+							else
+								frame = fc - 1;
+
 							if (!is_over) {
 								is_over = true;
 								emit_signal(SceneStringNames::get_singleton()->animation_finished);
 							}
 						}
 					} else {
-						frame++;
+						if (backwards)
+							frame--;
+						else
+							frame++;
 					}
 
 					update();
@@ -594,10 +605,12 @@ bool AnimatedSprite::_is_playing() const {
 	return playing;
 }
 
-void AnimatedSprite::play(const StringName &p_animation) {
+void AnimatedSprite::play(const StringName &p_animation, const bool p_backwards) {
 
 	if (p_animation)
 		set_animation(p_animation);
+
+	backwards = p_backwards;
 	_set_playing(true);
 }
 
@@ -666,7 +679,7 @@ void AnimatedSprite::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_playing", "playing"), &AnimatedSprite::_set_playing);
 	ClassDB::bind_method(D_METHOD("_is_playing"), &AnimatedSprite::_is_playing);
 
-	ClassDB::bind_method(D_METHOD("play", "anim"), &AnimatedSprite::play, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite::play, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite::stop);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite::is_playing);
 
@@ -713,6 +726,7 @@ AnimatedSprite::AnimatedSprite() {
 	frame = 0;
 	speed_scale = 1.0f;
 	playing = false;
+	backwards = false;
 	animation = "default";
 	timeout = 0;
 	is_over = false;

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -128,6 +128,7 @@ class AnimatedSprite : public Node2D {
 
 	Ref<SpriteFrames> frames;
 	bool playing;
+	bool backwards;
 	StringName animation;
 	int frame;
 	float speed_scale;
@@ -169,7 +170,7 @@ public:
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);
 	Ref<SpriteFrames> get_sprite_frames() const;
 
-	void play(const StringName &p_animation = StringName());
+	void play(const StringName &p_animation = StringName(), const bool p_backwards = false);
 	void stop();
 	bool is_playing() const;
 


### PR DESCRIPTION
Salvaged from #18044. Fixes #17787.