### PR TITLE
Signal arity warning [#12450]

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -819,6 +819,27 @@ bool Object::has_method(const StringName &p_method) const {
 	return false;
 }
 
+/**
+	If this Object has a method with the given name,
+	then MethodInto is copied into *r_mi* and true is returned.
+	Otherwise just returns false (ignoring *r_mi*).
+*/
+bool Object::get_method(const StringName &p_method_name, MethodInfo &r_mi) const {
+	List<MethodInfo> methods;
+	this->get_method_list(&methods);
+	for (List<MethodInfo>::Element *M = methods.front(); M; M = M->next()) {
+		MethodInfo &mi = M->get();
+
+		// Found the method
+		if (p_method_name == mi.name) {
+			r_mi = mi;
+			return true;
+		}
+	}
+
+	return false;
+}
+
 Variant Object::getvar(const Variant &p_key, bool *r_valid) const {
 
 	if (r_valid)

--- a/core/object.h
+++ b/core/object.h
@@ -649,6 +649,7 @@ public:
 	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false) const;
 
 	bool has_method(const StringName &p_method) const;
+	bool get_method(const StringName &p_method_name, MethodInfo &r_mi) const;
 	void get_method_list(List<MethodInfo> *p_list) const;
 	Variant callv(const StringName &p_method, const Array &p_args);
 	virtual Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error);

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -878,6 +878,27 @@ void ConnectionsDock::update_tree() {
 					path += " )";
 				}
 
+				// Find the connected method in the target Object to check that the arities match
+				int total_expected_args = signal_mi.arguments.size() + c.binds.size();
+				List<MethodInfo> target_methods;
+				target->get_method_list(&target_methods);
+				for (List<MethodInfo>::Element *M = target_methods.front(); M; M = M->next()) {
+					MethodInfo &target_mi = M->get();
+
+					// Found the right method
+					if ( c.method == target_mi.name) {
+						int method_args = target_mi.arguments.size();
+						int def_args = target_mi.default_arguments.size();
+
+						// Mark connection if the number of arguments do not match
+						if (total_expected_args > method_args || total_expected_args < method_args - def_args) {
+							path += " [Invalid arity!]";
+						}
+
+						break;
+					}
+				 }
+
 				// Create UI item for the Connection
 				TreeItem *item2 = tree->create_item(item);
 				item2->set_text(0, path);

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -880,24 +880,16 @@ void ConnectionsDock::update_tree() {
 
 				// Find the connected method in the target Object to check that the arities match
 				int total_expected_args = signal_mi.arguments.size() + c.binds.size();
-				List<MethodInfo> target_methods;
-				target->get_method_list(&target_methods);
-				for (List<MethodInfo>::Element *M = target_methods.front(); M; M = M->next()) {
-					MethodInfo &target_mi = M->get();
+				MethodInfo target_mi;
+				if(target->get_method(c.method, target_mi)){
+					int method_args = target_mi.arguments.size();
+					int def_args = target_mi.default_arguments.size();
 
-					// Found the right method
-					if ( c.method == target_mi.name) {
-						int method_args = target_mi.arguments.size();
-						int def_args = target_mi.default_arguments.size();
-
-						// Mark connection if the number of arguments do not match
-						if (total_expected_args > method_args || total_expected_args < method_args - def_args) {
-							path += " [Invalid arity!]";
-						}
-
-						break;
+					// Mark connection if the number of arguments do not match
+					if (total_expected_args > method_args || total_expected_args < method_args - def_args) {
+						path += " [Invalid arity]";
 					}
-				 }
+				}
 
 				// Create UI item for the Connection
 				TreeItem *item2 = tree->create_item(item);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -230,8 +230,13 @@ void GDScript::get_script_method_list(List<MethodInfo> *p_list) const {
 			GDScriptFunction *func = E->get();
 			MethodInfo mi;
 			mi.name = E->key();
+
 			for (int i = 0; i < func->get_argument_count(); i++) {
 				mi.arguments.push_back(func->get_argument_type(i));
+			}
+
+			for(int i =0; i < func->get_default_argument_count(); i++) {
+				mi.default_arguments.push_back(func->get_default_argument(i) );
 			}
 
 			mi.return_val = func->get_return_type();


### PR DESCRIPTION
Adds a warning in the Connections dialogue when the number of arguments of a signal and the number of arguments on a connected method do not match up.

This solves, or at least alleviates, the problems described in  #12450.

It is a draft because there is still some optimazions/refactorings/tweaks to be explore. This is my first PR to the Godot project and I welcome early feedback.