### PR TITLE
Fixes #27063 CollisionObject signals do not trigger on Area

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -401,7 +401,7 @@
 			String value of the [TextEdit].
 		</member>
 		<member name="v_scroll_speed" type="float" setter="set_v_scroll_speed" getter="get_v_scroll_speed">
-			If [code]true[/code], enables text wrapping when it goes beyond he edge of what is visible.
+			Adjust [code]Vertical[/code] Scroll Sensitivity of Text Editor.
 		</member>
 		<member name="wrap_enabled" type="bool" setter="set_wrap_enabled" getter="is_wrap_enabled">
 		</member>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -404,6 +404,7 @@
 			Adjust [code]Vertical[/code] Scroll Sensitivity of Text Editor.
 		</member>
 		<member name="wrap_enabled" type="bool" setter="set_wrap_enabled" getter="is_wrap_enabled">
+            If [code]true[/code], enables text wrapping when it goes beyond the edge of what is visible.
 		</member>
 	</members>
 	<signals>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -647,7 +647,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 	_initial_set("text_editor/highlighting/breakpoint_color", Color(0.8, 0.8, 0.4, 0.2));
 	_initial_set("text_editor/highlighting/code_folding_color", Color(0.8, 0.8, 0.8, 0.8));
 	_initial_set("text_editor/highlighting/search_result_color", Color(0.05, 0.25, 0.05, 1));
-	_initial_set("text_editor/highlighting/search_result_border_color", Color(0.1, 0.45, 0.1, 1));
+	_initial_set("text_editor/highlighting/search_result_border_color", Color(255, 255, 0, 0.5));
 }
 
 bool EditorSettings::_save_text_editor_theme(String p_file) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -647,7 +647,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 	_initial_set("text_editor/highlighting/breakpoint_color", Color(0.8, 0.8, 0.4, 0.2));
 	_initial_set("text_editor/highlighting/code_folding_color", Color(0.8, 0.8, 0.8, 0.8));
 	_initial_set("text_editor/highlighting/search_result_color", Color(0.05, 0.25, 0.05, 1));
-	_initial_set("text_editor/highlighting/search_result_border_color", Color(255, 255, 0, 0.5));
+	_initial_set("text_editor/highlighting/search_result_border_color", Color(1.0, 1.0, 0, 0.8));
 }
 
 bool EditorSettings::_save_text_editor_theme(String p_file) {

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -756,7 +756,6 @@ Area::Area() :
 	monitorable = false;
 	collision_mask = 1;
 	collision_layer = 1;
-	set_ray_pickable(false);
 	set_monitoring(true);
 	set_monitorable(true);
 


### PR DESCRIPTION

Removed **set_ray_pickable(false)** from **godot/scene/3d/area.cpp**.
Property moved into CollisionObject hence we do not initialise it to false.