### PR TITLE
Allow whitespaces in warning-ignore comments

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -286,7 +286,7 @@ void ScriptTextEditor::_warning_clicked(Variant p_line) {
 		code_editor->get_text_edit()->cursor_set_line(p_line.operator int64_t());
 	} else if (p_line.get_type() == Variant::DICTIONARY) {
 		Dictionary meta = p_line.operator Dictionary();
-		code_editor->get_text_edit()->insert_at("#warning-ignore:" + meta["code"].operator String(), meta["line"].operator int64_t() - 1);
+		code_editor->get_text_edit()->insert_at("# warning-ignore:" + meta["code"].operator String(), meta["line"].operator int64_t() - 1);
 		_validate_script();
 	}
 }

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -534,13 +534,14 @@ void GDScriptTokenizerText::_advance() {
 					}
 				}
 #ifdef DEBUG_ENABLED
-				if (comment.begins_with("#warning-ignore:")) {
-					String code = comment.get_slice(":", 1);
+				String comment_content = comment.trim_prefix("#").trim_prefix(" ");
+				if (comment_content.begins_with("warning-ignore:")) {
+					String code = comment_content.get_slice(":", 1);
 					warning_skips.push_back(Pair<int, String>(line, code.strip_edges().to_lower()));
-				} else if (comment.begins_with("#warning-ignore-all:")) {
-					String code = comment.get_slice(":", 1);
+				} else if (comment_content.begins_with("warning-ignore-all:")) {
+					String code = comment_content.get_slice(":", 1);
 					warning_global_skips.insert(code.strip_edges().to_lower());
-				} else if (comment.strip_edges() == "#warnings-disable") {
+				} else if (comment_content.strip_edges() == "warnings-disable") {
 					ignore_warnings = true;
 				}
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
Previously, this did not work because of the whitespace after `#`:

```gdscript
# warning-ignore:unused_class_variable
export (int) var player_index = 1
```

This PR looses the parser a bit by allowing multiple whitespaces after the `#`. This matches the comment style used in the default templates.