### PR TITLE
Fix order of transformation in GLTF import

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -237,8 +237,7 @@ Error EditorSceneImporterGLTF::_parse_nodes(GLTFState &state) {
 				node->scale = _arr_to_vec3(n["scale"]);
 			}
 
-			node->xform.basis = Basis(node->rotation);
-			node->xform.basis.scale(node->scale);
+			node->xform.basis.set_quat_scale(node->rotation, node->scale);
 			node->xform.origin = node->translation;
 		}
 


### PR DESCRIPTION
From the gltf 2 spec, the order is R  * S. Previously we did S * R, which broke some mesh with non-uniform scale.

Fix #23356, Fix #14725