### PR TITLE
fix GDNative binding generation for object types

### DIFF
--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -279,7 +279,7 @@ List<ClassAPI> generate_c_api_classes() {
 				MethodInfo &method_info = m->get();
 
 				//method name
-				method_api.method_name = m->get().name;
+				method_api.method_name = method_info.name;
 				//method return type
 				if (method_api.method_name.find(":") != -1) {
 					method_api.return_type = method_api.method_name.get_slice(":", 1);
@@ -321,6 +321,8 @@ List<ClassAPI> generate_c_api_classes() {
 						arg_type = arg_info.hint_string;
 					} else if (arg_info.type == Variant::NIL) {
 						arg_type = "Variant";
+					} else if (arg_info.type == Variant::OBJECT) {
+						arg_type = arg_info.class_name;
 					} else {
 						arg_type = Variant::get_type_name(arg_info.type);
 					}


### PR DESCRIPTION
Many object types (for example `Node`) would often only show up as `Object`. This PR should fix this.

(I noticed while working on updating the `godot-rust` repository to 3.1, there are some other outstanding issues, so this fix was only inspected manually and not yet used in "production". I will post an update when I'm certain this works properly!)