### PR TITLE
Fixed CollisionObject signals do not trigger on Area

### DIFF
--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -756,7 +756,6 @@ Area::Area() :
 	monitorable = false;
 	collision_mask = 1;
 	collision_layer = 1;
-	set_ray_pickable(false);
 	set_monitoring(true);
 	set_monitorable(true);
 


### PR DESCRIPTION
Fixes #27063. Tested on Ubuntu 18.04.2 LTS