### PR TITLE
Fixed Tileset Editor bug related to polygon size

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2417,7 +2417,9 @@ void TileSetEditor::draw_polygon_shapes() {
 							colors.push_back(c_bg);
 						}
 					}
-					if (polygon.size() > 2) {
+					if (polygon.size() == 0)
+						continue;
+					else if (polygon.size() > 2) {
 						workspace->draw_polygon(polygon, colors);
 					}
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2417,9 +2417,7 @@ void TileSetEditor::draw_polygon_shapes() {
 							colors.push_back(c_bg);
 						}
 					}
-					if (polygon.size() == 0)
-						continue;
-					else if (polygon.size() > 2) {
+					if (polygon.size() > 2) {
 						workspace->draw_polygon(polygon, colors);
 					}
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2417,6 +2417,8 @@ void TileSetEditor::draw_polygon_shapes() {
 							colors.push_back(c_bg);
 						}
 					}
+					if (polygon.size() == 0)
+						continue;
 					if (polygon.size() > 2) {
 						workspace->draw_polygon(polygon, colors);
 					}

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -756,7 +756,6 @@ Area::Area() :
 	monitorable = false;
 	collision_mask = 1;
 	collision_layer = 1;
-	set_ray_pickable(false);
 	set_monitoring(true);
 	set_monitorable(true);
 

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -756,6 +756,7 @@ Area::Area() :
 	monitorable = false;
 	collision_mask = 1;
 	collision_layer = 1;
+	set_ray_pickable(false);
 	set_monitoring(true);
 	set_monitorable(true);
 


### PR DESCRIPTION
Fixes #27035

1)
Crash was due to null case not taken into account for polygon.size, added if case to fix the problem of not checking for polygon.size() == 0

![gitissue](https://user-images.githubusercontent.com/40488679/54527665-967ed400-49a0-11e9-816e-31cce47175fb.gif)
