### PR TITLE
Un-collapses parents when changing node

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -109,7 +109,6 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, Node *or
 		node_to_replace = original_node;
 		replace_parents.clear();
 		
-		// Initialize set containing all the parents of the node to be replaced.
 		StringName node_class = node_to_replace->get_class_name();
 		while(ClassDB::get_parent_class(node_class) != base_type) {
 			node_class = ClassDB::get_parent_class(node_class);
@@ -208,8 +207,6 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 		item->set_selectable(0, false);
 	} else if (!(*to_select && (*to_select)->get_text(0) == search_box->get_text())) {
 		bool is_search_subsequence = search_box->get_text().is_subsequence_ofi(p_type);
-		
-		
 		String to_select_type = *to_select ? (*to_select)->get_text(0) : "";
 		to_select_type = to_select_type.split(" ")[0];
 		bool current_item_is_preferred;

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -38,7 +38,7 @@
 #include "editor_settings.h"
 #include "scene/gui/box_container.h"
 
-void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, StringName &class_to_replace) {
+void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, StringName *class_to_replace) {
 
 	type_list.clear();
 	ClassDB::get_class_list(&type_list);
@@ -106,13 +106,13 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, StringNa
 	is_replace_mode = p_replace_mode;
 
 	if (p_replace_mode) {
-		
+
 		replace_parents.clear();
 
-		while (ClassDB::get_parent_class(class_to_replace) != base_type) {
+		while (ClassDB::get_parent_class(*class_to_replace) != base_type) {
 
-			class_to_replace = ClassDB::get_parent_class(class_to_replace);
-			replace_parents.insert(class_to_replace);
+			*class_to_replace = ClassDB::get_parent_class(*class_to_replace);
+			replace_parents.insert(*class_to_replace);
 		}
 
 		set_title(vformat(TTR("Change %s Type"), base_type));

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -38,7 +38,7 @@
 #include "editor_settings.h"
 #include "scene/gui/box_container.h"
 
-void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, StringName *original_node_class) {
+void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, StringName &class_to_replace) {
 
 	type_list.clear();
 	ClassDB::get_class_list(&type_list);
@@ -109,7 +109,6 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, StringNa
 		
 		replace_parents.clear();
 
-		StringName class_to_replace = *original_node_class;
 		while (ClassDB::get_parent_class(class_to_replace) != base_type) {
 
 			class_to_replace = ClassDB::get_parent_class(class_to_replace);

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -103,7 +103,7 @@ public:
 	void set_preferred_search_result_type(const String &p_preferred_type);
 	String get_preferred_search_result_type();
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, StringName *original_node_class = NULL);
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false, StringName *class_to_replace = NULL);
 
 	CreateDialog();
 };

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -54,13 +54,12 @@ class CreateDialog : public ConfirmationDialog {
 	LineEdit *search_box;
 	Tree *search_options;
 	bool is_replace_mode;
-	Node *node_to_replace;
 	String base_type;
 	String preferred_search_result_type;
 	EditorHelpBit *help_bit;
 	List<StringName> type_list;
 	Set<StringName> type_blacklist;
-	Set<String> replace_parents;
+	Set<StringName> replace_parents;
 
 	void _item_selected();
 
@@ -104,7 +103,7 @@ public:
 	void set_preferred_search_result_type(const String &p_preferred_type);
 	String get_preferred_search_result_type();
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, Node *original_node = nullptr);
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false, StringName *original_node_class = NULL);
 
 	CreateDialog();
 };

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -103,7 +103,7 @@ public:
 	void set_preferred_search_result_type(const String &p_preferred_type);
 	String get_preferred_search_result_type();
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, StringName *original_node_class = NULL);
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false, StringName& original_node_class = NULL);
 
 	CreateDialog();
 };

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -54,11 +54,13 @@ class CreateDialog : public ConfirmationDialog {
 	LineEdit *search_box;
 	Tree *search_options;
 	bool is_replace_mode;
+	Node *node_to_replace;
 	String base_type;
 	String preferred_search_result_type;
 	EditorHelpBit *help_bit;
 	List<StringName> type_list;
 	Set<StringName> type_blacklist;
+	Set<String> replace_parents;
 
 	void _item_selected();
 
@@ -102,7 +104,7 @@ public:
 	void set_preferred_search_result_type(const String &p_preferred_type);
 	String get_preferred_search_result_type();
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false);
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false, Node *original_node = nullptr);
 
 	CreateDialog();
 };

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -103,7 +103,7 @@ public:
 	void set_preferred_search_result_type(const String &p_preferred_type);
 	String get_preferred_search_result_type();
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, StringName& original_node_class = NULL);
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false, StringName *original_node_class = NULL);
 
 	CreateDialog();
 };

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -307,7 +307,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			String preferred = "";
 			Node *current_edited_scene_root = EditorNode::get_singleton()->get_edited_scene();
 
-			if (current_edited_scene_root) {	
+			if (current_edited_scene_root) {
 				if (ClassDB::is_parent_class(current_edited_scene_root->get_class_name(), "Node2D"))
 					preferred = "Node2D";
 				else if (ClassDB::is_parent_class(current_edited_scene_root->get_class_name(), "Spatial"))
@@ -331,7 +331,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		} break;
 		case TOOL_REPLACE: {
 			Node *selected = scene_tree->get_selected();
-			
 			create_dialog->popup_create(false, true, selected);
 		} break;
 		case TOOL_ATTACH_SCRIPT: {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -333,7 +333,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		case TOOL_REPLACE: {
 
 			StringName selected = scene_tree->get_selected()->get_class_name();
-			create_dialog->popup_create(false, true, &selected);
+			create_dialog->popup_create(false, true, selected);
 		} break;
 		case TOOL_ATTACH_SCRIPT: {
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -308,6 +308,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			Node *current_edited_scene_root = EditorNode::get_singleton()->get_edited_scene();
 
 			if (current_edited_scene_root) {
+
 				if (ClassDB::is_parent_class(current_edited_scene_root->get_class_name(), "Node2D"))
 					preferred = "Node2D";
 				else if (ClassDB::is_parent_class(current_edited_scene_root->get_class_name(), "Spatial"))
@@ -330,8 +331,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 		} break;
 		case TOOL_REPLACE: {
-			Node *selected = scene_tree->get_selected();
-			create_dialog->popup_create(false, true, selected);
+
+			StringName selected = scene_tree->get_selected()->get_class_name();
+			create_dialog->popup_create(false, true, &selected);
 		} break;
 		case TOOL_ATTACH_SCRIPT: {
 
@@ -376,7 +378,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		} break;
 		case TOOL_CLEAR_SCRIPT: {
 
- 			Array selection = editor_selection->get_selected_nodes();
+			Array selection = editor_selection->get_selected_nodes();
 
 			if (selection.empty())
 				return;
@@ -384,8 +386,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			editor_data->get_undo_redo().create_action(TTR("Clear Script"));
 			editor_data->get_undo_redo().add_do_method(editor, "push_item", (Script *)NULL);
 
- 			for (int i = 0; i < selection.size(); i++) {
-				 
+			for (int i = 0; i < selection.size(); i++) {
+
 				Node *n = Object::cast_to<Node>(selection[i]);
 				Ref<Script> existing = n->get_script();
 				if (existing.is_valid()) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -307,8 +307,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			String preferred = "";
 			Node *current_edited_scene_root = EditorNode::get_singleton()->get_edited_scene();
 
-			if (current_edited_scene_root) {
-
+			if (current_edited_scene_root) {	
 				if (ClassDB::is_parent_class(current_edited_scene_root->get_class_name(), "Node2D"))
 					preferred = "Node2D";
 				else if (ClassDB::is_parent_class(current_edited_scene_root->get_class_name(), "Spatial"))
@@ -331,8 +330,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 		} break;
 		case TOOL_REPLACE: {
-
-			create_dialog->popup_create(false, true);
+			Node *selected = scene_tree->get_selected();
+			
+			create_dialog->popup_create(false, true, selected);
 		} break;
 		case TOOL_ATTACH_SCRIPT: {
 
@@ -377,7 +377,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		} break;
 		case TOOL_CLEAR_SCRIPT: {
 
-			Array selection = editor_selection->get_selected_nodes();
+ 			Array selection = editor_selection->get_selected_nodes();
 
 			if (selection.empty())
 				return;
@@ -385,8 +385,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			editor_data->get_undo_redo().create_action(TTR("Clear Script"));
 			editor_data->get_undo_redo().add_do_method(editor, "push_item", (Script *)NULL);
 
-			for (int i = 0; i < selection.size(); i++) {
-
+ 			for (int i = 0; i < selection.size(); i++) {
+				 
 				Node *n = Object::cast_to<Node>(selection[i]);
 				Ref<Script> existing = n->get_script();
 				if (existing.is_valid()) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -333,7 +333,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		case TOOL_REPLACE: {
 
 			StringName selected = scene_tree->get_selected()->get_class_name();
-			create_dialog->popup_create(false, true, selected);
+			create_dialog->popup_create(false, true, &selected);
 		} break;
 		case TOOL_ATTACH_SCRIPT: {
 


### PR DESCRIPTION
Fixes issue #26389 

Changed the create dialog script, so when replacing a node, it un-collapses all the parent nodes, so it becomes easier to replace a node by something similar (e.g. RigidBody to KinematicBody).

Had some problems in the previous merge, hopefully they are now fixed! 