### PR TITLE
Use Mono script metadata also for class->script mapping

### DIFF
--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -307,7 +307,10 @@ class CSharpLanguage : public ScriptLanguage {
 
 	int lang_idx;
 
-	Dictionary scripts_metadata;
+	// Bidirectional mapping loaded from the script metadata
+	// The String is the res://<script> path
+	Map<String, GDMonoClass *> script_to_class_map;
+	Map<GDMonoClass *, String> class_to_script_map;
 
 	// For debug_break and debug_break_parse
 	int _debug_parse_err_line;
@@ -342,7 +345,24 @@ public:
 
 	void project_assembly_loaded();
 
-	_FORCE_INLINE_ const Dictionary &get_scripts_metadata() { return scripts_metadata; }
+	/**
+	 * Find the resource path of the script for a given Mono class, which corresponds
+	 * to the path of the source file (i.e. res://MyScript.cs).
+	 * May be an empty string in case the Mono class is not usable as a script,
+	 * or the script metadata JSON file was not correctly loaded.
+	 */
+	String get_script_for_class(GDMonoClass *mono_class) const;
+	/**
+	 * Given the resource path of a C# script, this method resolves the 
+	 * corresponding Mono class from the project assembly, using the
+	 * script metadata JSON file.
+	 */
+	GDMonoClass *get_class_for_script(const String &p_script) const;
+
+	/**
+	 * Loads a script metadata JSON file into the given dictionary.
+	 */
+	static Error load_scripts_metadata(const String &p_path, Dictionary &scripts_metadata);
 
 	virtual String get_name() const;
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -427,11 +427,13 @@ void GDMono::_initialize_and_check_api_hashes() {
 #ifdef MONO_GLUE_ENABLED
 	if (get_api_core_hash() != GodotSharpBindings::get_core_api_hash()) {
 		ERR_PRINT("Mono: Core API hash mismatch!");
+		ERR_PRINT("You need to regenerate the Mono glue and rebuild Godot!");
 	}
 
 #ifdef TOOLS_ENABLED
 	if (get_api_editor_hash() != GodotSharpBindings::get_editor_api_hash()) {
 		ERR_PRINT("Mono: Editor API hash mismatch!");
+		ERR_PRINT("You need to regenerate the Mono glue and rebuild Godot!");
 	}
 #endif // TOOLS_ENABLED
 #endif // MONO_GLUE_ENABLED


### PR DESCRIPTION
This fixes #27095 by enabling the appropriate CSharpScript's to be reused when the mono module attempts to get a CSharpScript for a given Mono class.
This primarily occurs when one does:

```
in "MyNodeSubclass.cs":
class MyNodeSubclass : Node { ... }
```

When `new MyNodeSubclass()` is used, Godot will now correctly assign the script "res://MyNodeSubclass.cs" to the newly created Node, instead of assigning a script with an empty path (which will not be saved to the Scene).

The script metadata is now kept in-memory in two Map's to enable bi-directional lookup. 

The only caveat is that during _update_exports, we need to pre-allocate the native Node before we call the user's constructor. Otherwise the default constructor would call back into C++ to create the native Node, which would trigger a call to `ResourceLoader::load` for the script that is in the process of being created. This would simply fail. If the managed object is already associated with a native object before the constructor is called, this doesn't happen.