### PR TITLE
Enable generation of procedural audio via scripting

### DIFF
--- a/modules/procedural_audio/SCsub
+++ b/modules/procedural_audio/SCsub
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+Import('env')
+Import('env_modules')
+
+sources = [
+    "register_types.cpp",
+    "audiostream_procedural.cpp"
+]
+
+module_env = env.Clone()
+module_env.Append(CXXFLAGS=['-O2', '-std=c++11'])
+
+if ARGUMENTS.get('procedural_audio_shared', 'no') == 'yes':
+    # Shared lib compilation
+    module_env.Append(CXXFLAGS='-fPIC')
+    module_env['LIBS'] = []
+    shared_lib = module_env.SharedLibrary(target='#bin/proceduralaudio', source=sources)
+    shared_lib_shim = shared_lib[0].name.rsplit('.', 1)[0]
+    env.Append(LIBS=[shared_lib_shim])
+    env.Append(LIBPATH=['#bin'])
+else:
+    # Static compilation
+    module_env.add_source_files(env.modules_sources, sources)

--- a/modules/procedural_audio/audiostream_procedural.cpp
+++ b/modules/procedural_audio/audiostream_procedural.cpp
@@ -1,0 +1,293 @@
+/*************************************************************************/
+/*  audiostream_procedural.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "audiostream_procedural.h"
+#include "core/math/math_funcs.h"
+#include "core/print_string.h"
+
+////////////////////////////// AudioStreamProcedural
+
+AudioStreamProcedural::AudioStreamProcedural() :
+		mix_rate(44100),
+		stereo(false),
+		buffer_frame_count(128) {}
+
+AudioStreamProcedural::~AudioStreamProcedural() {}
+
+Ref<AudioStreamPlayback> AudioStreamProcedural::instance_playback() {
+	Ref<AudioStreamPlaybackProcedural> playback;
+	playback.instance();
+
+	playback->stream = Ref<AudioStreamProcedural>((AudioStreamProcedural *)this);
+	playback->active = false;
+	playback->resize_buffer();
+
+	playbacks.insert(playback.ptr());
+
+	return playback;
+}
+
+String AudioStreamProcedural::get_stream_name() const {
+	return "Procedural";
+}
+
+void AudioStreamProcedural::resize_buffer() {
+	for (Set<AudioStreamPlaybackProcedural *>::Element *e = playbacks.front(); e;
+			e = e->next()) {
+		e->get()->resize_buffer();
+	}
+}
+
+void AudioStreamProcedural::reset() {
+	set_position(0);
+}
+
+void AudioStreamProcedural::set_position(uint64_t p) {
+	if (get_script_instance() &&
+			get_script_instance()->has_method("set_position")) {
+		get_script_instance()->call("set_position", p);
+		return;
+	}
+
+	pos = p;
+}
+
+uint64_t AudioStreamProcedural::get_position() {
+	if (get_script_instance() &&
+			get_script_instance()->has_method("get_position")) {
+		return get_script_instance()->call("get_position");
+	}
+
+	return pos;
+}
+
+void AudioStreamProcedural::generate_frames(Ref<StreamPeerBuffer> byte_buffer) {
+	if (get_script_instance() &&
+			get_script_instance()->has_method("generate_frames")) {
+		get_script_instance()->call("generate_frames", byte_buffer);
+		return;
+	}
+
+	double mix_rate_by_tone_1 = double(mix_rate) / double(350);
+	double mix_rate_by_tone_2 = double(mix_rate) / double(440);
+
+	byte_buffer->seek(0);
+	if (stereo) {
+		for (int i = 0; i < buffer_frame_count; i++) {
+			double two_pi_pos = 2.0 * Math_PI * double(pos + i);
+			byte_buffer->put_float(sin(two_pi_pos / mix_rate_by_tone_1));
+			byte_buffer->put_float(sin(two_pi_pos / mix_rate_by_tone_2));
+		}
+	} else {
+		for (int i = 0; i < buffer_frame_count; i++) {
+			double two_pi_pos = 2.0 * Math_PI * double(pos + i);
+			byte_buffer->put_float(
+					(sin(two_pi_pos / mix_rate_by_tone_1) + sin(two_pi_pos / mix_rate_by_tone_2)) *
+					0.5);
+		}
+	}
+	pos += buffer_frame_count;
+}
+
+void AudioStreamProcedural::set_mix_rate(int mix_rate) {
+	if (this->mix_rate != mix_rate) {
+		this->mix_rate = mix_rate;
+		resize_buffer();
+	}
+}
+
+int AudioStreamProcedural::get_mix_rate() {
+	return mix_rate;
+}
+
+bool AudioStreamProcedural::get_stereo() {
+	return stereo;
+}
+
+void AudioStreamProcedural::set_stereo(bool stereo) {
+	if (this->stereo != stereo) {
+		this->stereo = stereo;
+		resize_buffer();
+	}
+}
+
+void AudioStreamProcedural::set_buffer_frame_count(int buffer_frame_count) {
+	if (this->buffer_frame_count != buffer_frame_count) {
+		this->buffer_frame_count = buffer_frame_count;
+		resize_buffer();
+	}
+}
+
+int AudioStreamProcedural::get_buffer_frame_count() {
+	return buffer_frame_count;
+}
+
+void AudioStreamProcedural::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("reset"), &AudioStreamProcedural::reset);
+	ClassDB::bind_method(D_METHOD("get_stream_name"),
+			&AudioStreamProcedural::get_stream_name);
+	ClassDB::bind_method(D_METHOD("generate_frames", "byte_buffer"),
+			&AudioStreamProcedural::generate_frames);
+	ClassDB::bind_method(D_METHOD("set_mix_rate", "mix_rate"),
+			&AudioStreamProcedural::set_mix_rate);
+	ClassDB::bind_method(D_METHOD("get_mix_rate"),
+			&AudioStreamProcedural::get_mix_rate);
+	ClassDB::bind_method(D_METHOD("set_buffer_frame_count", "buffer_frame_count"),
+			&AudioStreamProcedural::set_buffer_frame_count);
+	ClassDB::bind_method(D_METHOD("get_buffer_frame_count"),
+			&AudioStreamProcedural::get_buffer_frame_count);
+	ClassDB::bind_method(D_METHOD("set_position", "position"),
+			&AudioStreamProcedural::set_position);
+	ClassDB::bind_method(D_METHOD("get_position"),
+			&AudioStreamProcedural::get_position);
+	ClassDB::bind_method(D_METHOD("set_stereo", "stereo"),
+			&AudioStreamProcedural::set_stereo);
+	ClassDB::bind_method(D_METHOD("get_stereo"),
+			&AudioStreamProcedural::get_stereo);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "mix_rate"), "set_mix_rate",
+			"get_mix_rate");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "buffer_frame_count"),
+			"set_buffer_frame_count", "get_buffer_frame_count");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "position"), "set_position",
+			"get_position");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stereo"), "set_stereo",
+			"get_stereo");
+}
+
+////////////////////////////// AudioStreamPlaybackProcedural
+
+AudioStreamPlaybackProcedural::AudioStreamPlaybackProcedural() :
+		active(false),
+		internal_frame(0),
+		external_frame(0) {
+	byte_buffer.instance();
+}
+
+AudioStreamPlaybackProcedural::~AudioStreamPlaybackProcedural() {
+	stream->playbacks.erase(this);
+	byte_buffer->clear();
+	byte_buffer.unref();
+}
+
+void AudioStreamPlaybackProcedural::resize_buffer() {
+	// Although this buffer is not allocated by the AudioServer, we're still
+	// taking out a lock to be sure there are no attempts to access it during
+	// a resize...
+	AudioServer::get_singleton()->lock();
+	byte_buffer->resize(stream->buffer_frame_count * 4 *
+						(stream->stereo ? 2 : 1));
+	AudioServer::get_singleton()->unlock();
+}
+
+void AudioStreamPlaybackProcedural::stop() {
+	active = false;
+	stream->reset();
+}
+
+void AudioStreamPlaybackProcedural::start(float p_from_pos) {
+	seek(p_from_pos);
+	active = true;
+}
+
+void AudioStreamPlaybackProcedural::seek(float p_time) {
+	if (p_time < 0) {
+		p_time = 0;
+	}
+	stream->set_position(uint64_t(p_time * stream->mix_rate) << MIX_FRAC_BITS);
+}
+
+void AudioStreamPlaybackProcedural::_mix_internal(AudioFrame *p_buffer,
+		int p_frames) {
+	ERR_FAIL_COND(!active);
+
+	if (!active) {
+		return;
+	}
+
+	// Ensure that p_buffer is filled with p_frames-worth of data while also
+	// allowing arbitrary sizes of byte_buffer...
+	while (internal_frame < p_frames) {
+		if (external_frame == 0)
+			stream->generate_frames(byte_buffer);
+
+		int byte_buffer_pos;
+
+		if (stream->stereo) {
+			byte_buffer_pos = external_frame * 8;
+			for (; internal_frame < p_frames &&
+					external_frame < stream->buffer_frame_count;
+					internal_frame++, external_frame++) {
+				byte_buffer->seek(byte_buffer_pos);
+				float sample_l = byte_buffer->get_float();
+				byte_buffer->seek(byte_buffer_pos + 4);
+				float sample_r = byte_buffer->get_float();
+				p_buffer[internal_frame] = AudioFrame(sample_l, sample_r);
+				byte_buffer_pos += 8;
+			}
+
+		} else {
+			byte_buffer_pos = external_frame * 4;
+			for (; internal_frame < p_frames &&
+					external_frame < stream->buffer_frame_count;
+					internal_frame++, external_frame++) {
+				byte_buffer->seek(byte_buffer_pos);
+				float sample = byte_buffer->get_float();
+				p_buffer[internal_frame] = AudioFrame(sample, sample);
+				byte_buffer_pos += 4;
+			}
+		}
+
+		if (external_frame >= stream->buffer_frame_count)
+			external_frame = 0;
+	}
+
+	internal_frame = 0;
+}
+
+float AudioStreamPlaybackProcedural::get_stream_sampling_rate() {
+	return float(stream->mix_rate);
+}
+
+int AudioStreamPlaybackProcedural::get_loop_count() const {
+	return 0;
+}
+
+float AudioStreamPlaybackProcedural::get_playback_position() const {
+	return 0.0;
+}
+
+float AudioStreamPlaybackProcedural::get_length() const {
+	return 0.0;
+}
+
+bool AudioStreamPlaybackProcedural::is_playing() const {
+	return active;
+}

--- a/modules/procedural_audio/audiostream_procedural.h
+++ b/modules/procedural_audio/audiostream_procedural.h
@@ -1,0 +1,104 @@
+/*************************************************************************/
+/*  audiostream_procedural.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef AUDIOSTREAM_PROCEDURAL_H
+#define AUDIOSTREAM_PROCEDURAL_H
+
+#include "core/io/stream_peer.h"
+#include "core/reference.h"
+#include "core/resource.h"
+#include "servers/audio/audio_stream.h"
+
+class AudioStreamPlaybackProcedural;
+
+class AudioStreamProcedural : public AudioStream {
+	GDCLASS(AudioStreamProcedural, AudioStream)
+private:
+	friend class AudioStreamPlaybackProcedural;
+	uint64_t pos;
+	int mix_rate;
+	bool stereo;
+	int buffer_frame_count;
+	Set<AudioStreamPlaybackProcedural *> playbacks;
+	void resize_buffer();
+
+public:
+	void reset();
+	void set_position(uint64_t pos);
+	uint64_t get_position();
+	void set_stereo(bool stereo);
+	bool get_stereo();
+	virtual Ref<AudioStreamPlayback> instance_playback();
+	virtual String get_stream_name() const;
+	virtual void generate_frames(Ref<StreamPeerBuffer> byte_buffer);
+	virtual float get_length() const { return 0; }
+	void set_mix_rate(int mix_rate);
+	int get_mix_rate();
+	void set_buffer_frame_count(int byte_buffer_size);
+	int get_buffer_frame_count();
+	AudioStreamProcedural();
+	~AudioStreamProcedural();
+
+protected:
+	static void _bind_methods();
+};
+
+class AudioStreamPlaybackProcedural : public AudioStreamPlaybackResampled {
+	GDCLASS(AudioStreamPlaybackProcedural, AudioStreamPlaybackResampled)
+	friend class AudioStreamProcedural;
+
+private:
+	enum {
+		MIX_FRAC_BITS = 13,
+	};
+	bool active;
+	int internal_frame;
+	int external_frame;
+	Ref<AudioStreamProcedural> stream;
+	Ref<StreamPeerBuffer> byte_buffer;
+	void resize_buffer();
+
+protected:
+	virtual void _mix_internal(AudioFrame *p_buffer, int p_frames);
+
+public:
+	virtual void start(float p_from_pos = 0.0);
+	virtual void stop();
+	virtual bool is_playing() const;
+	virtual int get_loop_count() const; // times it looped
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
+	virtual float get_length() const; // if supported, otherwise return 0
+	virtual float get_stream_sampling_rate();
+	AudioStreamPlaybackProcedural();
+	~AudioStreamPlaybackProcedural();
+};
+
+#endif

--- a/modules/procedural_audio/config.py
+++ b/modules/procedural_audio/config.py
@@ -1,0 +1,13 @@
+def can_build(env, platform):
+    return True
+
+def configure(env):
+    pass
+
+def get_doc_classes():
+    return [
+        "AudioStreamProcedural"
+    ]
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/procedural_audio/doc_classes/AudioStreamProcedural.xml
+++ b/modules/procedural_audio/doc_classes/AudioStreamProcedural.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioStreamProcedural" inherits="AudioStream" category="Core" version="3.1">
+	<brief_description>
+		AudioStream for run-time synthesis of audio
+	</brief_description>
+	<description>
+		AudioStreamProcedural enables synthesis of audio via scripting of its [method AudioStreamProcedural.generate_frames] method. Although it is possible to accomplish this using GDScript, it may be necessary for performance reasons to script it via NativeScript. This is a low level module whose purpose is to simplify creation of addons that integrate third-party audio libraries such as libpd or csound.
+	</description>
+	<tutorials>
+	</tutorials>
+	<demos>
+		If not overridden, [method AudioStreamProcedural.generate_frames] will generate two tones (US standard dial tone). Below is an example of generating those tones using GDScript. The frequencies used are different in order to be certain it is the script generating the audio.
+		
+		[codeblock]
+			tool
+			extends AudioStreamProcedural
+
+			func generate_frames(pcm_buf):
+				# this is called on the audio thread which forbids allocations
+
+				var mix_rate_by_tone_1 = mix_rate/1350.0
+				var mix_rate_by_tone_2 = mix_rate/1440.0
+
+				var i = 0;
+
+				pcm_buf.seek(0)
+				if stereo:
+					# generate one tone per channel
+					for i in range(buffer_frame_count):
+						var two_pi_pos = 2.0*PI*(position+i)
+						pcm_buf.put_float(sin(two_pi_pos/mix_rate_by_tone_1))
+						pcm_buf.put_float(sin(two_pi_pos/mix_rate_by_tone_2))
+				else:
+					# mix two tones into one channel
+					for i in range(buffer_frame_count):
+						var two_pi_pos = 2.0*PI*(position+i)
+						pcm_buf.put_float((
+							sin(two_pi_pos/mix_rate_by_tone_1) +
+							sin(two_pi_pos/mix_rate_by_tone_2)) *
+							0.5)
+
+				position += buffer_frame_count
+		[/codeblock]
+	</demos>
+	<methods>
+		<method name="generate_frames">
+			<return type="void">
+			</return>
+			<argument index="0" name="byte_buffer" type="StreamPeerBuffer">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_stream_name" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="reset">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="buffer_frame_count" type="int" setter="set_buffer_frame_count" getter="get_buffer_frame_count">
+			Indicates how many audio frames will be held in the byte_buffer passed to [method AudioStreamProcedural.generate_frames]. When generating stereo, each frame will take up one float for left and one for right, for a total of eight bytes. When generating mono, only one float should be generated for each frame.
+		</member>
+		<member name="mix_rate" type="int" setter="set_mix_rate" getter="get_mix_rate">
+			Indicates the rate (per second) that audio frames are generated.
+		</member>
+		<member name="position" type="int" setter="set_position" getter="get_position">
+		</member>
+		<member name="stereo" type="bool" setter="set_stereo" getter="get_stereo">
+			Indicates whether this stream generates stereo audio.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/modules/procedural_audio/register_types.cpp
+++ b/modules/procedural_audio/register_types.cpp
@@ -1,0 +1,38 @@
+/*************************************************************************/
+/*  register_types.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "register_types.h"
+#include "audiostream_procedural.h"
+
+void register_procedural_audio_types() {
+	ClassDB::register_class<AudioStreamProcedural>();
+}
+
+void unregister_procedural_audio_types() {}

--- a/modules/procedural_audio/register_types.h
+++ b/modules/procedural_audio/register_types.h
@@ -1,0 +1,32 @@
+/*************************************************************************/
+/*  register_types.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+void register_procedural_audio_types();
+void unregister_procedural_audio_types();


### PR DESCRIPTION
This module provides AudioStreamProcedural, which has a scriptable callback for filling a buffer with single-channel or dual-channel PCM audio data. It uses a StreamPeerBuffer instead of a PoolVector to avoid passing arrays by value. I'm not sure what, if anything, needs to be done to make this available to GDNative.

related issues:
#18135
#26067

