### PR TITLE
Make all file access 64-bit

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1728,7 +1728,7 @@ real_t _File::get_real() const {
 	return f->get_real();
 }
 
-PoolVector<uint8_t> _File::get_buffer(int p_length) const {
+PoolVector<uint8_t> _File::get_buffer(int64_t p_length) const {
 
 	PoolVector<uint8_t> data;
 	ERR_FAIL_COND_V(!f, data);
@@ -1739,7 +1739,7 @@ PoolVector<uint8_t> _File::get_buffer(int p_length) const {
 	Error err = data.resize(p_length);
 	ERR_FAIL_COND_V(err != OK, data);
 	PoolVector<uint8_t>::Write w = data.write();
-	int len = f->get_buffer(&w[0], p_length);
+	int64_t len = f->get_buffer(&w[0], p_length);
 	ERR_FAIL_COND_V(len < 0, PoolVector<uint8_t>());
 
 	w = PoolVector<uint8_t>::Write();
@@ -1755,7 +1755,7 @@ String _File::get_as_text() const {
 	ERR_FAIL_COND_V(!f, String());
 
 	String text;
-	size_t original_pos = f->get_position();
+	int64_t original_pos = f->get_position();
 	f->seek(0);
 
 	String l = get_line();
@@ -2147,10 +2147,10 @@ bool _Directory::dir_exists(String p_dir) {
 	}
 }
 
-int _Directory::get_space_left() {
+int64_t _Directory::get_space_left() {
 
 	ERR_FAIL_COND_V(!d, 0);
-	return d->get_space_left() / 1024 * 1024; //return value in megabytes, given binding is int
+	return d->get_space_left();
 }
 
 Error _Directory::copy(String p_from, String p_to) {

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -465,7 +465,7 @@ public:
 
 	Variant get_var(bool p_allow_objects = false) const;
 
-	PoolVector<uint8_t> get_buffer(int p_length) const; ///< get an array of bytes
+	PoolVector<uint8_t> get_buffer(int64_t p_length) const; ///< get an array of bytes
 	String get_line() const;
 	Vector<String> get_csv_line(const String &p_delim = ",") const;
 	String get_as_text() const;
@@ -543,7 +543,7 @@ public:
 	bool file_exists(String p_file);
 	bool dir_exists(String p_dir);
 
-	int get_space_left();
+	int64_t get_space_left();
 
 	Error copy(String p_from, String p_to);
 	Error rename(String p_from, String p_to);

--- a/core/io/file_access_buffered.h
+++ b/core/io/file_access_buffered.h
@@ -43,9 +43,9 @@ public:
 	};
 
 private:
-	int cache_size;
+	int32_t cache_size;
 
-	int cache_data_left() const;
+	int32_t cache_data_left() const;
 	mutable Error last_error;
 
 protected:
@@ -54,8 +54,8 @@ protected:
 	mutable struct File {
 
 		bool open;
-		int size;
-		int offset;
+		int64_t size;
+		int64_t offset;
 		String name;
 		int access_flags;
 	} file;
@@ -63,25 +63,25 @@ protected:
 	mutable struct Cache {
 
 		Vector<uint8_t> buffer;
-		int offset;
+		int32_t offset;
 	} cache;
 
-	virtual int read_data_block(int p_offset, int p_size, uint8_t *p_dest = 0) const = 0;
+	virtual int64_t read_data_block(int64_t p_offset, int64_t p_size, uint8_t *p_dest = 0) const = 0;
 
-	void set_cache_size(int p_size);
-	int get_cache_size();
+	void set_cache_size(int32_t p_size);
+	int32_t get_cache_size();
 
 public:
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
 
 	virtual bool eof_reached() const;
 
 	virtual uint8_t get_8() const;
-	virtual int get_buffer(uint8_t *p_dest, int p_length) const; ///< get an array of bytes
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const; ///< get an array of bytes
 
 	virtual bool is_open() const;
 

--- a/core/io/file_access_buffered_fa.h
+++ b/core/io/file_access_buffered_fa.h
@@ -38,7 +38,7 @@ class FileAccessBufferedFA : public FileAccessBuffered {
 
 	T f;
 
-	int read_data_block(int p_offset, int p_size, uint8_t *p_dest = 0) const {
+	int64_t read_data_block(int64_t p_offset, int64_t p_size, uint8_t *p_dest = 0) const {
 
 		ERR_FAIL_COND_V(!f.is_open(), -1);
 
@@ -87,7 +87,7 @@ public:
 		f.store_8(p_dest);
 	};
 
-	void store_buffer(const uint8_t *p_src, int p_length) {
+	void store_buffer(const uint8_t *p_src, int64_t p_length) {
 
 		f.store_buffer(p_src, p_length);
 	};

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -38,34 +38,34 @@ class FileAccessCompressed : public FileAccess {
 
 	Compression::Mode cmode;
 	bool writing;
-	uint32_t write_pos;
+	int64_t write_pos;
 	uint8_t *write_ptr;
-	uint32_t write_buffer_size;
-	uint32_t write_max;
-	uint32_t block_size;
+	int32_t write_buffer_size;
+	int64_t write_max;
+	int32_t block_size;
 	mutable bool read_eof;
 	mutable bool at_end;
 
 	struct ReadBlock {
-		int csize;
-		int offset;
+		int32_t csize;
+		int64_t offset;
 	};
 
 	mutable Vector<uint8_t> comp_buffer;
 	uint8_t *read_ptr;
-	mutable int read_block;
+	mutable int32_t read_block;
 	int read_block_count;
-	mutable int read_block_size;
-	mutable int read_pos;
+	mutable int32_t read_block_size;
+	mutable int64_t read_pos;
 	Vector<ReadBlock> read_blocks;
-	uint32_t read_total;
+	int64_t read_total;
 
 	String magic;
 	mutable Vector<uint8_t> buffer;
 	FileAccess *f;
 
 public:
-	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, int p_block_size = 4096);
+	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, int32_t p_block_size = 4096);
 
 	Error open_after_magic(FileAccess *p_base);
 
@@ -73,15 +73,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -46,10 +46,10 @@ private:
 	Vector<uint8_t> key;
 	bool writing;
 	FileAccess *file;
-	size_t base;
-	size_t length;
+	int64_t base;
+	int64_t length;
 	Vector<uint8_t> data;
-	mutable int pos;
+	mutable int64_t pos;
 	mutable bool eofed;
 
 public:
@@ -60,21 +60,21 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, int64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -109,8 +109,9 @@ bool FileAccessMemory::is_open() const {
 	return data != NULL;
 }
 
-void FileAccessMemory::seek(size_t p_position) {
+void FileAccessMemory::seek(int64_t p_position) {
 
+	ERR_FAIL_COND(p_position < 0);
 	ERR_FAIL_COND(!data);
 	pos = p_position;
 }
@@ -121,13 +122,13 @@ void FileAccessMemory::seek_end(int64_t p_position) {
 	pos = length + p_position;
 }
 
-size_t FileAccessMemory::get_position() const {
+int64_t FileAccessMemory::get_position() const {
 
 	ERR_FAIL_COND_V(!data, 0);
 	return pos;
 }
 
-size_t FileAccessMemory::get_len() const {
+int64_t FileAccessMemory::get_len() const {
 
 	ERR_FAIL_COND_V(!data, 0);
 	return length;
@@ -149,12 +150,13 @@ uint8_t FileAccessMemory::get_8() const {
 	return ret;
 }
 
-int FileAccessMemory::get_buffer(uint8_t *p_dst, int p_length) const {
+int64_t FileAccessMemory::get_buffer(uint8_t *p_dst, int64_t p_length) const {
 
 	ERR_FAIL_COND_V(!data, -1);
+	ERR_FAIL_COND_V(p_length < 0, 0);
 
-	int left = length - pos;
-	int read = MIN(p_length, left);
+	int64_t left = length - pos;
+	int64_t read = MIN(p_length, left);
 
 	if (read < p_length) {
 		WARN_PRINT("Reading less data than requested");
@@ -182,10 +184,12 @@ void FileAccessMemory::store_8(uint8_t p_byte) {
 	data[pos++] = p_byte;
 }
 
-void FileAccessMemory::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccessMemory::store_buffer(const uint8_t *p_src, int64_t p_length) {
 
-	int left = length - pos;
-	int write = MIN(p_length, left);
+	ERR_FAIL_COND(p_length < 0);
+
+	int64_t left = length - pos;
+	int64_t write = MIN(p_length, left);
 	if (write < p_length) {
 		WARN_PRINT("Writing less data than requested");
 	}

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -36,8 +36,8 @@
 class FileAccessMemory : public FileAccess {
 
 	uint8_t *data;
-	int length;
-	mutable int pos;
+	int64_t length;
+	mutable int64_t pos;
 
 	static FileAccess *create();
 
@@ -50,22 +50,22 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
 
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const; ///< get an array of bytes
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const; ///< get an array of bytes
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_byte); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, int64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -89,18 +89,17 @@ class FileAccessNetwork : public FileAccess {
 	Semaphore *page_sem;
 	Mutex *buffer_mutex;
 	bool opened;
-	size_t total_size;
-	mutable size_t pos;
+	int64_t total_size;
+	mutable int64_t pos;
 	int id;
 	mutable bool eof_flag;
-	mutable int last_page;
+	mutable int32_t last_page;
 	mutable uint8_t *last_page_buff;
 
-	int page_size;
-	int read_ahead;
+	int32_t page_size;
+	int32_t read_ahead;
 
 	mutable int waiting_on_page;
-	mutable int last_activity_val;
 	struct Page {
 		int activity;
 		bool queued;
@@ -117,9 +116,9 @@ class FileAccessNetwork : public FileAccess {
 
 	uint64_t exists_modtime;
 	friend class FileAccessNetworkClient;
-	void _queue_page(int p_page) const;
-	void _respond(size_t p_len, Error p_status);
-	void _set_block(int p_offset, const Vector<uint8_t> &p_block);
+	void _queue_page(int32_t p_page) const;
+	void _respond(int64_t p_len, Error p_status);
+	void _set_block(int64_t p_offset, const Vector<uint8_t> &p_block);
 
 public:
 	enum Command {
@@ -141,15 +140,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -48,8 +48,8 @@ public:
 	struct PackedFile {
 
 		String pack;
-		uint64_t offset; //if offset is ZERO, the file was ERASED
-		uint64_t size;
+		int64_t offset; //if offset is ZERO, the file was ERASED
+		int64_t size;
 		uint8_t md5[16];
 		PackSource *src;
 	};
@@ -102,7 +102,7 @@ private:
 
 public:
 	void add_pack_source(PackSource *p_source);
-	void add_path(const String &pkg_path, const String &path, uint64_t ofs, uint64_t size, const uint8_t *p_md5, PackSource *p_src); // for PackSource
+	void add_path(const String &pkg_path, const String &path, int64_t ofs, int64_t size, const uint8_t *p_md5, PackSource *p_src); // for PackSource
 
 	void set_disabled(bool p_disabled) { disabled = p_disabled; }
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
@@ -136,7 +136,7 @@ class FileAccessPack : public FileAccess {
 
 	PackedData::PackedFile pf;
 
-	mutable size_t pos;
+	mutable int64_t pos;
 	mutable bool eof;
 
 	FileAccess *f;
@@ -149,16 +149,16 @@ public:
 	virtual void close();
 	virtual bool is_open() const;
 
-	virtual void seek(size_t p_position);
+	virtual void seek(int64_t p_position);
 	virtual void seek_end(int64_t p_position = 0);
-	virtual size_t get_position() const;
-	virtual size_t get_len() const;
+	virtual int64_t get_position() const;
+	virtual int64_t get_len() const;
 
 	virtual bool eof_reached() const;
 
 	virtual uint8_t get_8() const;
 
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const;
 
 	virtual void set_endian_swap(bool p_swap);
 
@@ -167,7 +167,7 @@ public:
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest);
 
-	virtual void store_buffer(const uint8_t *p_src, int p_length);
+	virtual void store_buffer(const uint8_t *p_src, int64_t p_length);
 
 	virtual bool file_exists(const String &p_name);
 
@@ -221,7 +221,7 @@ public:
 	virtual Error rename(String p_from, String p_to);
 	virtual Error remove(String p_name);
 
-	size_t get_space_left();
+	int64_t get_space_left();
 
 	virtual String get_filesystem_type() const;
 

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -95,15 +95,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -132,7 +132,7 @@ Error PCKPacker::flush(bool p_verbose) {
 		file->store_32(0);
 	};
 
-	uint64_t ofs = file->get_position();
+	int64_t ofs = file->get_position();
 	ofs = _align(ofs, alignment);
 
 	_pad(file, ofs - file->get_position());
@@ -144,15 +144,15 @@ Error PCKPacker::flush(bool p_verbose) {
 	for (int i = 0; i < files.size(); i++) {
 
 		FileAccess *src = FileAccess::open(files[i].src_path, FileAccess::READ);
-		uint64_t to_write = files[i].size;
+		int64_t to_write = files[i].size;
 		while (to_write > 0) {
 
-			int read = src->get_buffer(buf, MIN(to_write, buf_max));
+			int64_t read = src->get_buffer(buf, MIN(to_write, buf_max));
 			file->store_buffer(buf, read);
 			to_write -= read;
 		};
 
-		uint64_t pos = file->get_position();
+		int64_t pos = file->get_position();
 		file->seek(files[i].offset_offset); // go back to store the file's offset
 		file->store_64(ofs);
 		file->seek(pos);

--- a/core/io/pck_packer.h
+++ b/core/io/pck_packer.h
@@ -48,8 +48,8 @@ class PCKPacker : public Reference {
 
 		String path;
 		String src_path;
-		int size;
-		uint64_t offset_offset;
+		int64_t size;
+		int64_t offset_offset;
 	};
 	Vector<File> files;
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1169,8 +1169,8 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 
 	save_ustring(fw, get_ustring(f)); //type
 
-	size_t md_ofs = f->get_position();
-	size_t importmd_ofs = f->get_64();
+	int64_t md_ofs = f->get_position();
+	int64_t importmd_ofs = f->get_64();
 	fw->store_64(0); //metadata offset
 
 	for (int i = 0; i < 14; i++) {
@@ -1217,7 +1217,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		save_ustring(fw, path);
 	}
 
-	int64_t size_diff = (int64_t)fw->get_position() - (int64_t)f->get_position();
+	int64_t size_diff = fw->get_position() - f->get_position();
 
 	//internal resources
 	uint32_t int_resources_size = f->get_32();

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -46,7 +46,7 @@ class ResourceInteractiveLoaderBinary : public ResourceInteractiveLoader {
 
 	FileAccess *f;
 
-	uint64_t importmd_ofs;
+	int64_t importmd_ofs;
 
 	Vector<char> str_buf;
 	List<RES> resource_cache;
@@ -65,7 +65,7 @@ class ResourceInteractiveLoaderBinary : public ResourceInteractiveLoader {
 
 	struct IntResource {
 		String path;
-		uint64_t offset;
+		int64_t offset;
 	};
 
 	Vector<IntResource> internal_resources;

--- a/core/io/stream_peer_ssl.cpp
+++ b/core/io/stream_peer_ssl.cpp
@@ -75,7 +75,7 @@ PoolByteArray StreamPeerSSL::get_cert_file_as_array(String p_path) {
 	PoolByteArray out;
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	if (f) {
-		int flen = f->get_len();
+		int64_t flen = f->get_len();
 		out.resize(flen + 1);
 		PoolByteArray::Write w = out.write();
 		f->get_buffer(w.ptr(), flen);

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -341,14 +341,15 @@ void XMLParser::_parse_current_node() {
 	}
 }
 
-uint64_t XMLParser::get_node_offset() const {
+int64_t XMLParser::get_node_offset() const {
 
 	return node_offset;
 };
 
-Error XMLParser::seek(uint64_t p_pos) {
+Error XMLParser::seek(int64_t p_pos) {
 
 	ERR_FAIL_COND_V(!data, ERR_FILE_EOF)
+	ERR_FAIL_COND_V(p_pos < 0, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_pos >= length, ERR_FILE_EOF);
 
 	P = data + p_pos;

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -68,13 +68,13 @@ public:
 private:
 	char *data;
 	char *P;
-	uint64_t length;
+	int64_t length;
 	void unescape(String &p_str);
 	Vector<String> special_characters;
 	String node_name;
 	bool node_empty;
 	NodeType node_type;
-	uint64_t node_offset;
+	int64_t node_offset;
 
 	struct Attribute {
 		String name;
@@ -99,7 +99,7 @@ public:
 	NodeType get_node_type();
 	String get_node_name() const;
 	String get_node_data() const;
-	uint64_t get_node_offset() const;
+	int64_t get_node_offset() const;
 	int get_attribute_count() const;
 	String get_attribute_name(int p_idx) const;
 	String get_attribute_value(int p_idx) const;
@@ -110,7 +110,7 @@ public:
 	int get_current_line() const;
 
 	void skip_section();
-	Error seek(uint64_t p_pos);
+	Error seek(int64_t p_pos);
 
 	Error open(const String &p_path);
 	Error open_buffer(const Vector<uint8_t> &p_buffer);

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -75,7 +75,7 @@ long zipio_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 
 	FileAccess *f = *(FileAccess **)opaque;
 
-	int pos = offset;
+	int64_t pos = offset;
 	switch (origin) {
 
 		case ZLIB_FILEFUNC_SEEK_CUR:

--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -91,7 +91,7 @@ public:
 	virtual bool file_exists(String p_file) = 0;
 	virtual bool dir_exists(String p_dir) = 0;
 	static bool exists(String p_dir);
-	virtual size_t get_space_left() = 0;
+	virtual int64_t get_space_left() = 0;
 
 	Error copy_dir(String p_from, String p_to, int p_chmod_flags = -1);
 	virtual Error copy(String p_from, String p_to, int p_chmod_flags = -1);

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -400,9 +400,11 @@ Vector<String> FileAccess::get_csv_line(const String &p_delim) const {
 	return strings;
 }
 
-int FileAccess::get_buffer(uint8_t *p_dst, int p_length) const {
+int64_t FileAccess::get_buffer(uint8_t *p_dst, int64_t p_length) const {
 
-	int i = 0;
+	ERR_FAIL_COND_V(p_length < 0, 0);
+
+	int64_t i = 0;
 	for (i = 0; i < p_length && !eof_reached(); i++)
 		p_dst[i] = get_8();
 
@@ -411,11 +413,11 @@ int FileAccess::get_buffer(uint8_t *p_dst, int p_length) const {
 
 String FileAccess::get_as_utf8_string() const {
 	PoolVector<uint8_t> sourcef;
-	int len = get_len();
+	int64_t len = get_len();
 	sourcef.resize(len + 1);
 
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = get_buffer(w.ptr(), len);
+	int64_t r = get_buffer(w.ptr(), len);
 	ERR_FAIL_COND_V(r != len, String());
 	w[len] = 0;
 
@@ -588,9 +590,11 @@ void FileAccess::store_csv_line(const Vector<String> &p_values, const String &p_
 	store_line(line);
 }
 
-void FileAccess::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccess::store_buffer(const uint8_t *p_src, int64_t p_length) {
 
-	for (int i = 0; i < p_length; i++)
+	ERR_FAIL_COND(p_length < 0);
+
+	for (int64_t i = 0; i < p_length; i++)
 		store_8(p_src[i]);
 }
 
@@ -644,7 +648,7 @@ String FileAccess::get_md5(const String &p_file) {
 
 	while (true) {
 
-		int br = f->get_buffer(step, 32768);
+		int64_t br = f->get_buffer(step, 32768);
 		if (br > 0) {
 
 			MD5Update(&md5, step, br);
@@ -674,7 +678,7 @@ String FileAccess::get_multiple_md5(const Vector<String> &p_file) {
 
 		while (true) {
 
-			int br = f->get_buffer(step, 32768);
+			int64_t br = f->get_buffer(step, 32768);
 			if (br > 0) {
 
 				MD5Update(&md5, step, br);
@@ -705,7 +709,7 @@ String FileAccess::get_sha256(const String &p_file) {
 
 	while (true) {
 
-		int br = f->get_buffer(step, 32768);
+		int64_t br = f->get_buffer(step, 32768);
 		if (br > 0) {
 
 			sha256_hash(&sha256, step, br);

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -96,10 +96,10 @@ public:
 	virtual String get_path() const { return ""; } /// returns the path for the current open file
 	virtual String get_path_absolute() const { return ""; } /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position) = 0; ///< seek to a given position
+	virtual void seek(int64_t p_position) = 0; ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0) = 0; ///< seek from the end of file
-	virtual size_t get_position() const = 0; ///< get position in the file
-	virtual size_t get_len() const = 0; ///< get size of the file
+	virtual int64_t get_position() const = 0; ///< get position in the file
+	virtual int64_t get_len() const = 0; ///< get size of the file
 
 	virtual bool eof_reached() const = 0; ///< reading passed EOF
 
@@ -112,7 +112,7 @@ public:
 	virtual double get_double() const;
 	virtual real_t get_real() const;
 
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const; ///< get an array of bytes
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const; ///< get an array of bytes
 	virtual String get_line() const;
 	virtual String get_token() const;
 	virtual Vector<String> get_csv_line(const String &p_delim = ",") const;
@@ -145,7 +145,7 @@ public:
 	virtual void store_pascal_string(const String &p_string);
 	virtual String get_pascal_string();
 
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, int64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name) = 0; ///< return true if a file exists
 

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -391,7 +391,7 @@ Error DirAccessUnix::remove(String p_path) {
 		return ::unlink(p_path.utf8().get_data()) == 0 ? OK : FAILED;
 }
 
-size_t DirAccessUnix::get_space_left() {
+int64_t DirAccessUnix::get_space_left() {
 
 #ifndef NO_STATVFS
 	struct statvfs vfs;

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -80,7 +80,7 @@ public:
 	virtual Error rename(String p_path, String p_new_path);
 	virtual Error remove(String p_path);
 
-	virtual size_t get_space_left();
+	virtual int64_t get_space_left();
 
 	virtual String get_filesystem_type() const;
 

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -160,12 +160,13 @@ String FileAccessUnix::get_path_absolute() const {
 	return path;
 }
 
-void FileAccessUnix::seek(size_t p_position) {
+void FileAccessUnix::seek(int64_t p_position) {
 
+	ERR_FAIL_COND(p_position < 0);
 	ERR_FAIL_COND(!f);
 
 	last_error = OK;
-	if (fseek(f, p_position, SEEK_SET))
+	if (fseeko(f, p_position, SEEK_SET))
 		check_errors();
 }
 
@@ -173,15 +174,15 @@ void FileAccessUnix::seek_end(int64_t p_position) {
 
 	ERR_FAIL_COND(!f);
 
-	if (fseek(f, p_position, SEEK_END))
+	if (fseeko(f, p_position, SEEK_END))
 		check_errors();
 }
 
-size_t FileAccessUnix::get_position() const {
+int64_t FileAccessUnix::get_position() const {
 
 	ERR_FAIL_COND_V(!f, 0);
 
-	long pos = ftell(f);
+	int64_t pos = ftello(f);
 	if (pos < 0) {
 		check_errors();
 		ERR_FAIL_V(0);
@@ -189,16 +190,16 @@ size_t FileAccessUnix::get_position() const {
 	return pos;
 }
 
-size_t FileAccessUnix::get_len() const {
+int64_t FileAccessUnix::get_len() const {
 
 	ERR_FAIL_COND_V(!f, 0);
 
-	long pos = ftell(f);
+	int64_t pos = ftello(f);
 	ERR_FAIL_COND_V(pos < 0, 0);
-	ERR_FAIL_COND_V(fseek(f, 0, SEEK_END), 0);
-	long size = ftell(f);
+	ERR_FAIL_COND_V(fseeko(f, 0, SEEK_END), 0);
+	int64_t size = ftello(f);
 	ERR_FAIL_COND_V(size < 0, 0);
-	ERR_FAIL_COND_V(fseek(f, pos, SEEK_SET), 0);
+	ERR_FAIL_COND_V(fseeko(f, pos, SEEK_SET), 0);
 
 	return size;
 }
@@ -219,10 +220,12 @@ uint8_t FileAccessUnix::get_8() const {
 	return b;
 }
 
-int FileAccessUnix::get_buffer(uint8_t *p_dst, int p_length) const {
+int64_t FileAccessUnix::get_buffer(uint8_t *p_dst, int64_t p_length) const {
 
 	ERR_FAIL_COND_V(!f, -1);
-	int read = fread(p_dst, 1, p_length, f);
+	ERR_FAIL_COND_V(p_length < 0, 0);
+
+	int64_t read = fread(p_dst, 1, p_length, f);
 	check_errors();
 	return read;
 };
@@ -244,9 +247,10 @@ void FileAccessUnix::store_8(uint8_t p_dest) {
 	ERR_FAIL_COND(fwrite(&p_dest, 1, 1, f) != 1);
 }
 
-void FileAccessUnix::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccessUnix::store_buffer(const uint8_t *p_src, int64_t p_length) {
 	ERR_FAIL_COND(!f);
-	ERR_FAIL_COND((int)fwrite(p_src, 1, p_length, f) != p_length);
+	ERR_FAIL_COND(p_length < 0);
+	ERR_FAIL_COND((int64_t)fwrite(p_src, 1, p_length, f) != p_length);
 }
 
 bool FileAccessUnix::file_exists(const String &p_path) {

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -66,21 +66,21 @@ public:
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, int64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_path); ///< return true if a file exists
 

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -336,14 +336,14 @@ FileType DirAccessWindows::get_file_type(const String& p_file) const {
 	return (attr&FILE_ATTRIBUTE_DIRECTORY)?FILE_TYPE_
 }
 */
-size_t DirAccessWindows::get_space_left() {
+int64_t DirAccessWindows::get_space_left() {
 
 	uint64_t bytes = 0;
 	if (!GetDiskFreeSpaceEx(NULL, (PULARGE_INTEGER)&bytes, NULL, NULL))
 		return 0;
 
 	//this is either 0 or a value in bytes.
-	return (size_t)bytes;
+	return bytes;
 }
 
 String DirAccessWindows::get_filesystem_type() const {

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -80,7 +80,7 @@ public:
 	virtual Error remove(String p_path);
 
 	//virtual FileType get_file_type() const;
-	size_t get_space_left();
+	int64_t get_space_left();
 
 	virtual String get_filesystem_type() const;
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -191,38 +191,39 @@ bool FileAccessWindows::is_open() const {
 
 	return (f != NULL);
 }
-void FileAccessWindows::seek(size_t p_position) {
+void FileAccessWindows::seek(int64_t p_position) {
 
+	ERR_FAIL_COND(p_position < 0);
 	ERR_FAIL_COND(!f);
+
 	last_error = OK;
-	if (fseek(f, p_position, SEEK_SET))
+	if (_fseeki64(f, p_position, SEEK_SET))
 		check_errors();
 	prev_op = 0;
 }
 void FileAccessWindows::seek_end(int64_t p_position) {
 
 	ERR_FAIL_COND(!f);
-	if (fseek(f, p_position, SEEK_END))
+	if (_fseeki64(f, p_position, SEEK_END))
 		check_errors();
 	prev_op = 0;
 }
-size_t FileAccessWindows::get_position() const {
+int64_t FileAccessWindows::get_position() const {
 
-	size_t aux_position = 0;
-	aux_position = ftell(f);
+	int64_t aux_position = _ftelli64(f);
 	if (!aux_position) {
 		check_errors();
 	};
 	return aux_position;
 }
-size_t FileAccessWindows::get_len() const {
+int64_t FileAccessWindows::get_len() const {
 
 	ERR_FAIL_COND_V(!f, 0);
 
-	size_t pos = get_position();
-	fseek(f, 0, SEEK_END);
+	int64_t pos = get_position();
+	_fseeki64(f, 0, SEEK_END);
 	int size = get_position();
-	fseek(f, pos, SEEK_SET);
+	_fseeki64(f, pos, SEEK_SET);
 
 	return size;
 }
@@ -251,16 +252,18 @@ uint8_t FileAccessWindows::get_8() const {
 	return b;
 }
 
-int FileAccessWindows::get_buffer(uint8_t *p_dst, int p_length) const {
+int64_t FileAccessWindows::get_buffer(uint8_t *p_dst, int64_t p_length) const {
 
 	ERR_FAIL_COND_V(!f, -1);
+	ERR_FAIL_COND_V(p_length < 0, 0);
+
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == WRITE) {
 			fflush(f);
 		}
 		prev_op = READ;
 	}
-	int read = fread(p_dst, 1, p_length, f);
+	int64_t read = fread(p_dst, 1, p_length, f);
 	check_errors();
 	return read;
 };
@@ -292,8 +295,9 @@ void FileAccessWindows::store_8(uint8_t p_dest) {
 	fwrite(&p_dest, 1, 1, f);
 }
 
-void FileAccessWindows::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccessWindows::store_buffer(const uint8_t *p_src, int64_t p_length) {
 	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND(p_length < 0);
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == READ) {
 			if (last_error != ERR_FILE_EOF) {

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -61,21 +61,21 @@ public:
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, int64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -918,7 +918,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 
 	f->store_32(pd.file_ofs.size()); //amount of files
 
-	size_t header_size = f->get_position();
+	int64_t header_size = f->get_position();
 
 	//precalculate header size
 
@@ -937,7 +937,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 
 		uint32_t string_len = pd.file_ofs[i].path_utf8.length();
 		uint32_t pad = _get_pad(4, string_len);
-		;
+
 		f->store_32(string_len + pad);
 		f->store_buffer((const uint8_t *)pd.file_ofs[i].path_utf8.get_data(), string_len);
 		for (uint32_t j = 0; j < pad; j++) {
@@ -966,7 +966,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 
 	while (true) {
 
-		int got = ftmp->get_buffer(buf, bufsize);
+		int64_t got = ftmp->get_buffer(buf, bufsize);
 		if (got <= 0)
 			break;
 		f->store_buffer(buf, got);

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -161,8 +161,8 @@ public:
 private:
 	struct SavedData {
 
-		uint64_t ofs;
-		uint64_t size;
+		int64_t ofs;
+		int64_t size;
 		Vector<uint8_t> md5;
 		CharString path_utf8;
 

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -95,7 +95,7 @@ Error EditorSceneImporterGLTF::_parse_glb(const String &p_path, GLTFState &state
 	ERR_FAIL_COND_V(chunk_type != 0x4E4F534A, ERR_PARSE_ERROR); //JSON
 	Vector<uint8_t> json_data;
 	json_data.resize(chunk_length);
-	uint32_t len = f->get_buffer(json_data.ptrw(), chunk_length);
+	int64_t len = f->get_buffer(json_data.ptrw(), chunk_length);
 	ERR_FAIL_COND_V(len != chunk_length, ERR_FILE_CORRUPT);
 
 	String text;

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -81,7 +81,7 @@ Error ResourceImporterImage::import(const String &p_source_file, const String &p
 		ERR_FAIL_COND_V(!f, ERR_CANT_OPEN);
 	}
 
-	size_t len = f->get_len();
+	int64_t len = f->get_len();
 
 	Vector<uint8_t> data;
 	data.resize(len);

--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -943,7 +943,7 @@ MainLoop *test(TestType p_type) {
 	}
 
 	Vector<uint8_t> buf;
-	int flen = fa->get_len();
+	int64_t flen = fa->get_len();
 	buf.resize(fa->get_len() + 1);
 	fa->get_buffer(buf.ptrw(), flen);
 	buf.write[flen] = 0;

--- a/main/tests/test_math.cpp
+++ b/main/tests/test_math.cpp
@@ -501,7 +501,7 @@ MainLoop *test() {
 	}
 
 	Vector<uint8_t> buf;
-	int flen = fa->get_len();
+	int64_t flen = fa->get_len();
 	buf.resize(fa->get_len() + 1);
 	fa->get_buffer(buf.ptrw(), flen);
 	buf.write[flen] = 0;

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -212,7 +212,7 @@ Error ImageLoaderBMP::load_image(Ref<Image> p_image, FileAccess *f,
 
 	// A valid bmp file should always at least have a
 	// file header and a minimal info header
-	if (f->get_len() > BITMAP_FILE_HEADER_SIZE + BITMAP_INFO_HEADER_MIN_SIZE) {
+	if (f->get_len() > (int64_t)(BITMAP_FILE_HEADER_SIZE + BITMAP_INFO_HEADER_MIN_SIZE)) {
 		// File Header
 		bmp_header.bmp_file_header.bmp_signature = f->get_16();
 		if (bmp_header.bmp_file_header.bmp_signature == BITMAP_SIGNATURE) {

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -407,10 +407,10 @@ Error PluginScript::load_source_code(const String &p_path) {
 		ERR_FAIL_COND_V(err, err);
 	}
 
-	int len = f->get_len();
+	int64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = f->get_buffer(w.ptr(), len);
+	int64_t r = f->get_buffer(w.ptr(), len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -47,7 +47,7 @@ godot_int GDAPI godot_videodecoder_file_read(void *ptr, uint8_t *buf, int buf_si
 
 	// if file exists
 	if (file) {
-		long bytes_read = file->get_buffer(buf, buf_size);
+		int64_t bytes_read = file->get_buffer(buf, buf_size);
 		// No bytes to read => EOF
 		if (bytes_read == 0) {
 			return 0;
@@ -62,41 +62,38 @@ int64_t GDAPI godot_videodecoder_file_seek(void *ptr, int64_t pos, int whence) {
 	FileAccess *file = reinterpret_cast<FileAccess *>(ptr);
 
 	if (file) {
-		size_t len = file->get_len();
+		int64_t len = file->get_len();
 		switch (whence) {
 			case SEEK_SET: {
-				// Just for explicitness
-				size_t new_pos = static_cast<size_t>(pos);
-				if (new_pos > len) {
+				if (pos > len) {
 					return -1;
 				}
-				file->seek(new_pos);
-				pos = static_cast<int64_t>(file->get_position());
+				file->seek(pos);
+				pos = file->get_position();
 				return pos;
 			} break;
 			case SEEK_CUR: {
 				// Just in case it doesn't exist
-				if (pos < 0 && (size_t)-pos > file->get_position()) {
+				if (pos < 0 && -pos > file->get_position()) {
 					return -1;
 				}
-				pos = pos + static_cast<int>(file->get_position());
-				file->seek(pos);
-				pos = static_cast<int64_t>(file->get_position());
+				file->seek(file->get_position() + pos);
+				pos = file->get_position();
 				return pos;
 			} break;
 			case SEEK_END: {
 				// Just in case something goes wrong
-				if ((size_t)-pos > len) {
+				if (-pos > len) {
 					return -1;
 				}
 				file->seek_end(pos);
-				pos = static_cast<int64_t>(file->get_position());
+				pos = file->get_position();
 				return pos;
 			} break;
 			default: {
 				// Only 4 possible options, hence default = AVSEEK_SIZE
 				// Asks to return the length of file
-				return static_cast<int64_t>(len);
+				return len;
 			} break;
 		}
 	}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -813,10 +813,10 @@ Error GDScript::load_source_code(const String &p_path) {
 		ERR_FAIL_COND_V(err, err);
 	}
 
-	int len = f->get_len();
+	int64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = f->get_buffer(w.ptr(), len);
+	int64_t r = f->get_buffer(w.ptr(), len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -105,7 +105,7 @@ Error jpeg_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 Error ImageLoaderJPG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 
 	PoolVector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	int64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -170,10 +170,10 @@ Error read_all_file_utf8(const String &p_path, String &r_content) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);
 	ERR_FAIL_COND_V(err != OK, err);
 
-	int len = f->get_len();
+	int64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = f->get_buffer(w.ptr(), len);
+	int64_t r = f->get_buffer(w.ptr(), len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/modules/opus/audio_stream_opus.cpp
+++ b/modules/opus/audio_stream_opus.cpp
@@ -44,7 +44,7 @@ int AudioStreamPlaybackOpus::_op_read_func(void *_stream, unsigned char *_ptr, i
 
 	uint8_t *dst = (uint8_t *)_ptr;
 
-	int read = fa->get_buffer(dst, _nbytes);
+	int64_t read = fa->get_buffer(dst, _nbytes);
 
 	return read;
 }

--- a/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
@@ -86,7 +86,7 @@ Error ResourceImporterOGGVorbis::import(const String &p_source_file, const Strin
 		ERR_FAIL_COND_V(!f, ERR_CANT_OPEN);
 	}
 
-	size_t len = f->get_len();
+	int64_t len = f->get_len();
 
 	PoolVector<uint8_t> data;
 	data.resize(len);

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -146,7 +146,7 @@ Error ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, const char *p
 
 Error ImageLoaderSVG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 
-	uint32_t size = f->get_len();
+	int64_t size = f->get_len();
 	PoolVector<uint8_t> src_image;
 	src_image.resize(size + 1);
 	PoolVector<uint8_t>::Write src_w = src_image.write();

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -209,9 +209,9 @@ Error ImageLoaderTGA::convert_to_image(Ref<Image> p_image, const uint8_t *p_buff
 Error ImageLoaderTGA::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 
 	PoolVector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	int64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
-	ERR_FAIL_COND_V(src_image_len < (int)sizeof(tga_header_s), ERR_FILE_CORRUPT);
+	ERR_FAIL_COND_V(src_image_len < (int64_t)sizeof(tga_header_s), ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 
 	Error err = OK;

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -59,7 +59,7 @@ int VideoStreamPlaybackTheora::buffer_data() {
 
 #else
 
-	int bytes = file->get_buffer((uint8_t *)buffer, 4096);
+	int64_t bytes = file->get_buffer((uint8_t *)buffer, 4096);
 	ogg_sync_wrote(&oy, bytes);
 	return (bytes);
 
@@ -182,7 +182,7 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 	thread_eof = false;
 	//pre-fill buffer
 	int to_read = ring_buffer.space_left();
-	int read = file->get_buffer(read_buffer.ptr(), to_read);
+	int64_t read = file->get_buffer(read_buffer.ptr(), to_read);
 	ring_buffer.write(read_buffer.ptr(), read);
 
 	thread = Thread::create(_streaming_thread, this);
@@ -658,7 +658,7 @@ void VideoStreamPlaybackTheora::_streaming_thread(void *ud) {
 
 			int to_read = vs->ring_buffer.space_left();
 			if (to_read) {
-				int read = vs->file->get_buffer(vs->read_buffer.ptr(), to_read);
+				int64_t read = vs->file->get_buffer(vs->read_buffer.ptr(), to_read);
 				vs->ring_buffer.write(vs->read_buffer.ptr(), read);
 				vs->thread_eof = vs->file->eof_reached();
 			}

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -38,7 +38,7 @@
 Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 
 	PoolVector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	int64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -41,7 +41,7 @@ size_t AudioStreamPlaybackOGGVorbis::_ov_read_func(void *p_dst, size_t p_data, s
 
 	uint8_t *dst = (uint8_t *)p_dst;
 
-	int read = fa->get_buffer(dst, read_total);
+	int64_t read = fa->get_buffer(dst, read_total);
 
 	return read;
 }

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -66,7 +66,7 @@ public:
 
 		if (file) {
 
-			if (file->get_position() != (size_t)pos)
+			if (file->get_position() != pos)
 				file->seek(pos);
 			if (file->get_buffer(buf, len) == len)
 				return 0;
@@ -78,7 +78,7 @@ public:
 
 		if (file) {
 
-			const size_t len = file->get_len();
+			const int64_t len = file->get_len();
 			if (total)
 				*total = len;
 			if (available)

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -159,7 +159,7 @@ static Ref<Image> _webp_mem_loader_func(const uint8_t *p_png, int p_size) {
 Error ImageLoaderWEBP::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 
 	PoolVector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	int64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -236,6 +236,9 @@ def configure(env):
         print("Using NDK deprecated headers")
         env.Append(CPPFLAGS=["-isystem", lib_sysroot + "/usr/include"])
 
+    if get_platform(env["ndk_platform"]) >= 24:
+        env.Append(CPPFLAGS=['-D_FILE_OFFSET_BITS=64'])
+
     env.Append(CCFLAGS='-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'.split())
     env.Append(CPPFLAGS='-DNO_STATVFS -DGLES_ENABLED'.split())
 

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -219,7 +219,7 @@ String DirAccessJAndroid::get_filesystem_type() const {
 }
 
 //FileType get_file_type() const;
-size_t DirAccessJAndroid::get_space_left() {
+int64_t DirAccessJAndroid::get_space_left() {
 
 	return 0;
 }

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -78,7 +78,7 @@ public:
 	virtual String get_filesystem_type() const;
 
 	//virtual FileType get_file_type() const;
-	size_t get_space_left();
+	int64_t get_space_left();
 
 	static void setup(jobject p_io);
 

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -76,9 +76,11 @@ bool FileAccessAndroid::is_open() const {
 	return a != NULL;
 }
 
-void FileAccessAndroid::seek(size_t p_position) {
+void FileAccessAndroid::seek(int64_t p_position) {
 
+	ERR_FAIL_COND(p_position < 0);
 	ERR_FAIL_COND(!a);
+
 	AAsset_seek(a, p_position, SEEK_SET);
 	pos = p_position;
 	if (pos > len) {
@@ -96,12 +98,12 @@ void FileAccessAndroid::seek_end(int64_t p_position) {
 	pos = len + p_position;
 }
 
-size_t FileAccessAndroid::get_position() const {
+int64_t FileAccessAndroid::get_position() const {
 
 	return pos;
 }
 
-size_t FileAccessAndroid::get_len() const {
+int64_t FileAccessAndroid::get_len() const {
 
 	return len;
 }
@@ -124,9 +126,11 @@ uint8_t FileAccessAndroid::get_8() const {
 	return byte;
 }
 
-int FileAccessAndroid::get_buffer(uint8_t *p_dst, int p_length) const {
+int64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, int64_t p_length) const {
 
-	off_t r = AAsset_read(a, p_dst, p_length);
+	ERR_FAIL_COND_V(p_length < 0, 0);
+
+	int64_t r = AAsset_read(a, p_dst, p_length);
 
 	if (pos + p_length > len) {
 		eof = true;

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -41,8 +41,8 @@ class FileAccessAndroid : public FileAccess {
 
 	static FileAccess *create_android();
 	mutable AAsset *a;
-	mutable size_t len;
-	mutable size_t pos;
+	mutable int64_t len;
+	mutable int64_t pos;
 	mutable bool eof;
 
 public:
@@ -52,15 +52,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/platform/android/file_access_jandroid.cpp
+++ b/platform/android/file_access_jandroid.cpp
@@ -90,11 +90,12 @@ bool FileAccessJAndroid::is_open() const {
 	return id != 0;
 }
 
-void FileAccessJAndroid::seek(size_t p_position) {
+void FileAccessJAndroid::seek(int64_t p_position) {
+
+	ERR_FAIL_COND(p_position < 0);
+	ERR_FAIL_COND(!is_open());
 
 	JNIEnv *env = ThreadAndroid::get_env();
-
-	ERR_FAIL_COND(!is_open());
 	env->CallVoidMethod(io, _file_seek, id, p_position);
 }
 
@@ -105,14 +106,14 @@ void FileAccessJAndroid::seek_end(int64_t p_position) {
 	seek(get_len());
 }
 
-size_t FileAccessJAndroid::get_position() const {
+int64_t FileAccessJAndroid::get_position() const {
 
 	JNIEnv *env = ThreadAndroid::get_env();
 	ERR_FAIL_COND_V(!is_open(), 0);
 	return env->CallIntMethod(io, _file_tell, id);
 }
 
-size_t FileAccessJAndroid::get_len() const {
+int64_t FileAccessJAndroid::get_len() const {
 
 	JNIEnv *env = ThreadAndroid::get_env();
 	ERR_FAIL_COND_V(!is_open(), 0);
@@ -133,11 +134,11 @@ uint8_t FileAccessJAndroid::get_8() const {
 	get_buffer(&byte, 1);
 	return byte;
 }
-int FileAccessJAndroid::get_buffer(uint8_t *p_dst, int p_length) const {
+int64_t FileAccessJAndroid::get_buffer(uint8_t *p_dst, int64_t p_length) const {
 
 	ERR_FAIL_COND_V(!is_open(), 0);
-	if (p_length == 0)
-		return 0;
+	ERR_FAIL_COND_V(p_length < 0, 0);
+
 	JNIEnv *env = ThreadAndroid::get_env();
 
 	jbyteArray jca = (jbyteArray)env->CallObjectMethod(io, _file_read, id, p_length);

--- a/platform/android/file_access_jandroid.h
+++ b/platform/android/file_access_jandroid.h
@@ -54,15 +54,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(int64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual int64_t get_position() const; ///< get position in the file
+	virtual int64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual int64_t get_buffer(uint8_t *p_dst, int64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -695,7 +695,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 					while (true) {
 
-						int r = pf->get_buffer(buf, BSIZE);
+						int64_t r = pf->get_buffer(buf, BSIZE);
 						if (r <= 0)
 							break;
 						zipWriteInFileInZip(dst_pkg_zip, buf, r);

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -170,7 +170,7 @@ def configure(env):
             else:
                 env.Append(CCFLAGS=['-flto'])
                 env.Append(LINKFLAGS=['-flto'])
-        
+
         if not env['use_llvm']:
             env['RANLIB'] = 'gcc-ranlib'
             env['AR'] = 'gcc-ar'
@@ -317,7 +317,7 @@ def configure(env):
         env.ParseConfig('pkg-config zlib --cflags --libs')
 
     env.Prepend(CPPPATH=['#platform/x11'])
-    env.Append(CPPFLAGS=['-DX11_ENABLED', '-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES_ENABLED'])
+    env.Append(CPPFLAGS=['-DX11_ENABLED', '-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES_ENABLED', '-D_FILE_OFFSET_BITS=64'])
     env.Append(LIBS=['GL', 'pthread'])
 
     if (platform.system() == "Linux"):

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -133,7 +133,7 @@ Error DynamicFontAtSize::_load() {
 			FileAccess *f = FileAccess::open(font->font_path, FileAccess::READ);
 			ERR_FAIL_COND_V(!f, ERR_CANT_OPEN);
 
-			size_t len = f->get_len();
+			int64_t len = f->get_len();
 			_fontdata[font->font_path] = Vector<uint8_t>();
 			Vector<uint8_t> &fontdata = _fontdata[font->font_path];
 			fontdata.resize(len);
@@ -351,7 +351,7 @@ unsigned long DynamicFontAtSize::_ft_stream_io(FT_Stream stream, unsigned long o
 
 	FileAccess *f = (FileAccess *)stream->descriptor.pointer;
 
-	if (f->get_position() != offset) {
+	if (f->get_position() != (int64_t)offset) {
 		f->seek(offset);
 	}
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -447,9 +447,8 @@ Error ResourceInteractiveLoaderText::poll() {
 			resource_cache.push_back(res);
 #ifdef TOOLS_ENABLED
 			//remember ID for saving
-			res->set_id_for_path(local_path,index);
+			res->set_id_for_path(local_path, index);
 #endif
-
 		}
 
 		ExtResource er;
@@ -732,7 +731,7 @@ Error ResourceInteractiveLoaderText::rename_dependencies(FileAccess *p_f, const 
 
 	String base_path = local_path.get_base_dir();
 
-	uint64_t tag_end = f->get_position();
+	int64_t tag_end = f->get_position();
 
 	while (true) {
 
@@ -936,7 +935,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 		wf->store_32(0); // reserved
 
 	wf->store_32(0); //string table size, will not be in use
-	size_t ext_res_count_pos = wf->get_position();
+	int64_t ext_res_count_pos = wf->get_position();
 
 	wf->store_32(0); //zero ext resources, still parsing them
 
@@ -1000,7 +999,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 
 	//now, save resources to a separate file, for now
 
-	size_t sub_res_count_pos = wf->get_position();
+	int64_t sub_res_count_pos = wf->get_position();
 	wf->store_32(0); //zero sub resources, still parsing them
 
 	String temp_file = p_path + ".temp";
@@ -1009,8 +1008,8 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 		return ERR_CANT_OPEN;
 	}
 
-	Vector<size_t> local_offsets;
-	Vector<size_t> local_pointers_pos;
+	Vector<int64_t> local_offsets;
+	Vector<int64_t> local_pointers_pos;
 
 	while (next_tag.name == "sub_resource" || next_tag.name == "resource") {
 
@@ -1049,7 +1048,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 		wf->store_64(0); //temp local offset
 
 		bs_save_unicode_string(wf2, type);
-		size_t propcount_ofs = wf2->get_position();
+		int64_t propcount_ofs = wf2->get_position();
 		wf2->store_32(0);
 
 		int prop_count = 0;
@@ -1122,7 +1121,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 
 		local_offsets.push_back(wf2->get_position());
 		bs_save_unicode_string(wf2, "PackedScene");
-		size_t propcount_ofs = wf2->get_position();
+		int64_t propcount_ofs = wf2->get_position();
 		wf2->store_32(0);
 
 		int prop_count = 0;
@@ -1148,7 +1147,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 
 	wf2->close();
 
-	size_t offset_from = wf->get_position();
+	int64_t offset_from = wf->get_position();
 	wf->seek(sub_res_count_pos); //plus one because the saved one
 	wf->store_32(local_offsets.size());
 
@@ -1545,9 +1544,6 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 	}
 
 	{
-
-
-
 	}
 
 #ifdef TOOLS_ENABLED
@@ -1569,7 +1565,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 		}
 
 		int attempt = 1; //start from one, more readable format
-		while(cached_ids_found.has(attempt)) {
+		while (cached_ids_found.has(attempt)) {
 			attempt++;
 		}
 
@@ -1577,7 +1573,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 		E->get() = attempt;
 		//update also in resource
 		Ref<Resource> res = E->key();
-		res->set_id_for_path(local_path,attempt);
+		res->set_id_for_path(local_path, attempt);
 	}
 #else
 	//make sure to start from one, as it makes format more readable
@@ -1597,7 +1593,6 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 	}
 
 	sorted_er.sort();
-
 
 	for (int i = 0; i < sorted_er.size(); i++) {
 		String p = sorted_er[i].resource->get_path();

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -57,10 +57,10 @@ Error TextFile::load_text(const String &p_path) {
 		ERR_FAIL_COND_V(err, err);
 	}
 
-	int len = f->get_len();
+	int64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = f->get_buffer(w.ptr(), len);
+	int64_t r = f->get_buffer(w.ptr(), len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -686,7 +686,7 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &tw_
 
 			{
 				PoolVector<uint8_t>::Write w = img_data.write();
-				int bytes = f->get_buffer(w.ptr(), total_size - ofs);
+				int64_t bytes = f->get_buffer(w.ptr(), total_size - ofs);
 				//print_line("requested read: " + itos(total_size - ofs) + " but got: " + itos(bytes));
 
 				memdelete(f);
@@ -2461,7 +2461,7 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 
 			{
 				PoolVector<uint8_t>::Write w = img_data.write();
-				int bytes = f->get_buffer(w.ptr(), total_size);
+				int64_t bytes = f->get_buffer(w.ptr(), total_size);
 				if (bytes != total_size) {
 					if (r_error) {
 						*r_error = ERR_FILE_CORRUPT;


### PR DESCRIPTION
*Bugsquad edit:* Superseded by #48768 and #47254

**DISCLAIMER:**
~~This change is big and can break a lot of stuff. I'm marking it as _[wip]_ until I have done everything needed I can think of.~~
~~Maybe it should go directly to 4.0.~~
**UPDATE:**
This changes a lot of types and may introduce bugs, but it shouldn't break compatibility. Maybe it's suitable for 3.2 or even 3.1.1?

**This is all I can do so far on my side. Now I'm asking the community for testing and feedback.**
**UPDATE:** ~~As soon as I get the build checks to pass. :P~~ CI checks passing!

-----

**UPDATE:** Current commit message after modifications:

This changes the types of a big number of variables.

General rules:
- Using `int64_t` in general. With 64-bit we no longer need to use unsigned type. That matches `Variant` better and avoids akward casts. Checks for negative numbers are performed where they don't make sense (seek, read/write buffer size).
- Previous point means no more `size_t` for file size/offsets.
- Not worrying about `FileAccess::get_64/store_64` working with unsigneds. I haven't found any place where conversion to unsigned will cause trouble and saves us from having to add `get/store_64_signed` or similar.
- Using `int32_t` integers for concepts not needing such a huge range, like pages, blocks, etc.

In addition:
- Improve usage of integer types in some related places; namely, `DirAccess`, core binds.
- The binding for `Directory::get_space_left()` tried to return the size in MiB, but the expression was missing parentheses, so the `1024 * 1024` is removed and it keeps working as usual, returning bytes.

Fixes #27168.
*Bugsquad edit: Fixes https://github.com/godotengine/godot-proposals/issues/400.*