### PR TITLE
Upgrade & fix Android build scripts

### DIFF
--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -1,9 +1,11 @@
 buildscript {
 	repositories {
 		jcenter()
+		mavenCentral()
+		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.3.3'
+		classpath 'com.android.tools.build:gradle:3.3.2'
 		$$GRADLE_CLASSPATH$$
 	}
 }
@@ -11,14 +13,13 @@ buildscript {
 apply plugin: 'com.android.application'
 
 allprojects {
-    repositories {
-    	jcenter()
-	mavenCentral()
-	google()
-	$$GRADLE_REPOSITORY_URLS$$
-    }
+	repositories {
+		jcenter()
+		mavenCentral()
+		google()
+		$$GRADLE_REPOSITORY_URLS$$
+	}
 }
-
 dependencies {
 	$$GRADLE_DEPENDENCIES$$
 }
@@ -31,7 +32,7 @@ android {
 	}
 
 	compileSdkVersion 27
-	buildToolsVersion "27.0.3"
+	buildToolsVersion "28.0.3"
 	useLibrary 'org.apache.http.legacy'
 
 	packagingOptions {
@@ -74,9 +75,11 @@ android {
 			$$GRADLE_JNI_DIRS$$
 		]
 	}
+	// Undocumented; may break in a future Gradle version
 	applicationVariants.all { variant ->
-		// ApplicationVariant is undocumented, but this method is widely used; may break with another version of the Android Gradle plugin
-		variant.outputs.get(0).setOutputFile(new File("${projectDir}/../../../bin", "android_${variant.name}.apk"))
+		variant.outputs.all {
+			outputFileName = "../../../../../../../bin/android_${variant.name}.apk"
+		}
 	}
 }
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -91,8 +91,6 @@ def configure(env):
 
         env['SPAWN'] = mySpawn
 
-    ndk_platform = env['ndk_platform']
-
     if env['android_arch'] not in ['armv7', 'armv6', 'arm64v8', 'x86', 'x86_64']:
         env['android_arch'] = 'armv7'
 
@@ -115,9 +113,9 @@ def configure(env):
         arch_subpath = "x86"
         env["x86_libtheora_opt_gcc"] = True
     elif env['android_arch'] == 'x86_64':
-        if get_platform(env["ndk_platform"]) < 21:
+        if get_platform(env['ndk_platform']) < 21:
             print("WARNING: android_arch=x86_64 is not supported by ndk_platform lower than android-21; setting ndk_platform=android-21")
-            env["ndk_platform"] = "android-21"
+            env['ndk_platform'] = "android-21"
         env['ARCH'] = 'arch-x86_64'
         env.extra_suffix = ".x86_64" + env.extra_suffix
         target_subpath = "x86_64-4.9"
@@ -140,9 +138,9 @@ def configure(env):
         else:
             env.extra_suffix = ".armv7" + env.extra_suffix
     elif env["android_arch"] == "arm64v8":
-        if get_platform(ndk_platform) < 21:
+        if get_platform(env['ndk_platform']) < 21:
             print("WARNING: android_arch=arm64v8 is not supported by ndk_platform lower than android-21; setting ndk_platform=android-21")
-            ndk_platform = "android-21"
+            env['ndk_platform'] = "android-21"
         env['ARCH'] = 'arch-arm64'
         target_subpath = "aarch64-linux-android-4.9"
         abi_subpath = "aarch64-linux-android"
@@ -203,7 +201,7 @@ def configure(env):
         env.Append(CPPFLAGS=["-isystem", sysroot + "/usr/include/" + abi_subpath])
         env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/android/support/include"])
         # For unified headers this define has to be set manually
-        env.Append(CPPFLAGS=["-D__ANDROID_API__=" + str(get_platform(ndk_platform))])
+        env.Append(CPPFLAGS=["-D__ANDROID_API__=" + str(get_platform(env['ndk_platform']))])
     else:
         print("Using NDK deprecated headers")
         env.Append(CPPFLAGS=["-isystem", lib_sysroot + "/usr/include"])

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
As well as upgrading Android build tools to the latest, this fixes a bug that was breaking 64-bit builds because of `ndk_platform` not always matching `env['ndk_platform']`.