### PR TITLE
Enable macOS Mojave "Dark Mode" on the editor title bar

### DIFF
--- a/misc/dist/osx_tools.app/Contents/Info.plist
+++ b/misc/dist/osx_tools.app/Contents/Info.plist
@@ -24,6 +24,8 @@
 	<string>godot</string>
 	<key>CFBundleVersion</key>
 	<string>3.2</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+    	<false />
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2007-2019 Juan Linietsky, Ariel Manzur &amp; Godot Engine contributors</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Enables "Dark Mode" in the editor and project selector title bars in macOS Mojave when selected in macOS System Preferences

*Edit:* Fixes #26515