### PR TITLE
Add support for new MSBuild directory naming introduced in VS 2019

### DIFF
--- a/modules/mono/utils/mono_reg_utils.cpp
+++ b/modules/mono/utils/mono_reg_utils.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "mono_reg_utils.h"
+#include "core/os/dir_access.h"
 
 #ifdef WINDOWS_ENABLED
 
@@ -200,6 +201,13 @@ String find_msbuild_tools_path() {
 						val += "\\";
 					}
 
+					// Since VS2019, the directory is simply named "Current"
+					String msBuildDirectory = val + "MSBuild\\Current\\Bin";
+					if (DirAccess::exists(msBuildDirectory)) {
+						return msBuildDirectory;
+					}
+
+					// Directory name "15.0" is used in VS 2017
 					return val + "MSBuild\\15.0\\Bin";
 				}
 			}


### PR DESCRIPTION
Fixes #27269 

See https://github.com/Microsoft/vswhere/wiki/Find-MSBuild for details.

Sadly the new `-find` parameter has only recently been introduced, so I chose to fall back to simply testing for existence of the directory using the new naming scheme, and then falling back to the old naming.