### PR TITLE
SceneTreeDock: dragging node by column != 0 reparents wrong node  #10026 

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -866,7 +866,7 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 		objs.push_back(p);
 	}
 
-	set_drag_preview(vb);
+	//set_drag_preview(vb);
 	Dictionary drag_data;
 	drag_data["type"] = "nodes";
 	drag_data["nodes"] = objs;


### PR DESCRIPTION
Omitted drag preview for visibility icon due to unnecessary preview in addition to displaying wrong name, this way, confusion can be avoided, and no preview is presented since it is not needed in this section. Solution was posed by comment section of the issue  #10026 


