### PR TITLE
Ensure main scene is set when running on device

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -804,6 +804,8 @@ public:
 
 	static void add_init_callback(EditorNodeInitCallback p_callback) { _init_callbacks.push_back(p_callback); }
 	static void add_build_callback(EditorBuildCallback p_callback);
+
+	bool ensure_main_scene(bool p_from_native);
 };
 
 struct EditorProgress {

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -97,6 +97,12 @@ void EditorRunNative::_notification(int p_what) {
 
 void EditorRunNative::_run_native(int p_idx, int p_platform) {
 
+	if (!EditorNode::get_singleton()->ensure_main_scene(true)) {
+		resume_idx = p_idx;
+		resume_platform = p_platform;
+		return;
+	}
+
 	Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(p_platform);
 	ERR_FAIL_COND(eep.is_null());
 	/*if (p_idx == -1) {
@@ -137,6 +143,10 @@ void EditorRunNative::_run_native(int p_idx, int p_platform) {
 		flags |= EditorExportPlatform::DEBUG_FLAG_VIEW_NAVIGATION;
 
 	eep->run(preset, p_idx, flags);
+}
+
+void EditorRunNative::resume_run_native() {
+	_run_native(resume_idx, resume_platform);
 }
 
 void EditorRunNative::_bind_methods() {
@@ -193,4 +203,6 @@ EditorRunNative::EditorRunNative() {
 	deploy_debug_remote = false;
 	debug_collisions = false;
 	debug_navigation = false;
+	resume_idx = 0;
+	resume_platform = 0;
 }

--- a/editor/editor_run_native.h
+++ b/editor/editor_run_native.h
@@ -45,6 +45,9 @@ class EditorRunNative : public HBoxContainer {
 	bool debug_collisions;
 	bool debug_navigation;
 
+	int resume_idx;
+	int resume_platform;
+
 	void _run_native(int p_idx, int p_platform);
 
 protected:
@@ -63,6 +66,8 @@ public:
 
 	void set_debug_navigation(bool p_debug);
 	bool get_debug_navigation() const;
+
+	void resume_run_native();
 
 	EditorRunNative();
 };


### PR DESCRIPTION
Fixes #26008

I wasn't really sure how to determine whether the editor checks scene from normal run or native run, so I went with a meta >.>