### PR TITLE
[GDNative] various NativeScript fixes around editor functionality

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1691,7 +1691,7 @@ void NativeReloadNode::_notification(int p_what) {
 
 				// since singleton libraries are not unloaded there is no point
 				// in loading them again.
-				if (!gdn->get_library()->is_singleton()) {
+				if (gdn->get_library()->is_singleton()) {
 					continue;
 				}
 

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -160,8 +160,10 @@ bool NativeScript::can_instance() const {
 	NativeScriptDesc *script_data = get_script_desc();
 
 #ifdef TOOLS_ENABLED
-
-	return script_data || (!is_tool() && !ScriptServer::is_scripting_enabled());
+	// Only valid if this is either a tool script or a "regular" script.
+	// (so an environment whre scripting is disabled (and not the editor) would not
+	// create objects).
+	return script_data && (is_tool() || ScriptServer::is_scripting_enabled());
 #else
 	return script_data;
 #endif
@@ -199,25 +201,6 @@ ScriptInstance *NativeScript::instance_create(Object *p_this) {
 		return NULL;
 	}
 
-#ifdef TOOLS_ENABLED
-	if (!ScriptServer::is_scripting_enabled() && !is_tool()) {
-		// placeholder for nodes. For tools we want the rool thing.
-
-		PlaceHolderScriptInstance *sins = memnew(PlaceHolderScriptInstance(NSL, Ref<Script>(this), p_this));
-		placeholders.insert(sins);
-
-		if (script_data->create_func.create_func) {
-			script_data->create_func.create_func(
-					(godot_object *)p_this,
-					script_data->create_func.method_data);
-		}
-
-		_update_placeholder(sins);
-
-		return sins;
-	}
-#endif
-
 	NativeScriptInstance *nsi = memnew(NativeScriptInstance);
 
 	nsi->owner = p_this;
@@ -244,6 +227,19 @@ ScriptInstance *NativeScript::instance_create(Object *p_this) {
 #endif
 
 	return nsi;
+}
+
+PlaceHolderScriptInstance *NativeScript::placeholder_instance_create(Object *p_this) {
+#ifdef TOOLS_ENABLED
+	PlaceHolderScriptInstance *sins = memnew(PlaceHolderScriptInstance(NSL, Ref<Script>(this), p_this));
+	placeholders.insert(sins);
+
+	_update_placeholder(sins);
+
+	return sins;
+#else
+	return NULL;
+#endif
 }
 
 bool NativeScript::instance_has(const Object *p_this) const {

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -149,6 +149,7 @@ public:
 
 	virtual StringName get_instance_base_type() const; // this may not work in all scripts, will return empty if so
 	virtual ScriptInstance *instance_create(Object *p_this);
+	virtual PlaceHolderScriptInstance *placeholder_instance_create(Object *p_this);
 	virtual bool instance_has(const Object *p_this) const;
 
 	virtual bool has_source_code() const;


### PR DESCRIPTION
This PR fixes a logical error in the unloading code that would cause scripts to unload but not load in again, causing the next unload to print error messages.

The other change should fix various issues with NativeScript integration in the editor.
Before this change, every `Node` in the editor with a NativeScript attached would create an instance of the class and keep it in memory without ever freeing it.

Probably fixes:
#19703
#25812
#19676