### PR TITLE
Add support for 50% editor scale

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -304,7 +304,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/display_scale", 0);
 	hints["interface/editor/display_scale"] = PropertyInfo(Variant::INT, "interface/editor/display_scale", PROPERTY_HINT_ENUM, "Auto,75%,100%,125%,150%,175%,200%,Custom", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/custom_display_scale", 1.0f);
-	hints["interface/editor/custom_display_scale"] = PropertyInfo(Variant::REAL, "interface/editor/custom_display_scale", PROPERTY_HINT_RANGE, "0.75,3,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	hints["interface/editor/custom_display_scale"] = PropertyInfo(Variant::REAL, "interface/editor/custom_display_scale", PROPERTY_HINT_RANGE, "0.5,3,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/main_font_size", 14);
 	hints["interface/editor/main_font_size"] = PropertyInfo(Variant::INT, "interface/editor/main_font_size", PROPERTY_HINT_RANGE, "10,40,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/code_font_size", 14);


### PR DESCRIPTION
This PR add support fot 50% editor scale. 
It is really usable on monitors with big monitors with small resolution or when we need to have open at left and right Godot and other application:
This is comparison how much space Godot take with different scales on display with 1366x768 resolution (text on Godot with 50% scale on 15,6' laptop looks a bit too small so it is possible to change font size to bigger)

Some people can ask why I change editor scale instead changing only font size. 
Changing Godot scale cause that some elements(like docks) change its minimum size(EDSCALE in code)

100%(Auto)
![100PP](https://user-images.githubusercontent.com/41945903/54852356-f6e97a80-4cec-11e9-8580-72602754a70a.png)
![100%%](https://user-images.githubusercontent.com/41945903/54852354-f3ee8a00-4cec-11e9-800f-28aafa98882f.png)

75%
![75PP](https://user-images.githubusercontent.com/41945903/54852361-fb159800-4cec-11e9-8c13-f408d603cb39.png)
![75%%](https://user-images.githubusercontent.com/41945903/54852363-fd77f200-4cec-11e9-9ff2-d149ecdb9b89.png)

50%
![50PP](https://user-images.githubusercontent.com/41945903/54852368-010b7900-4ced-11e9-8a31-7a562587ded0.png)
![50%%](https://user-images.githubusercontent.com/41945903/54852373-04066980-4ced-11e9-90d0-06dfd395af07.png)

50% with default font size 21(changed from 14)
![50PP21](https://user-images.githubusercontent.com/41945903/54852499-521b6d00-4ced-11e9-8d67-28605bd5b8ec.png)
![50%%2](https://user-images.githubusercontent.com/41945903/54852522-695a5a80-4ced-11e9-9c5c-9a8f7381f00c.png)


EDIT:  Now it doesn't break anything, just add values between 50%-75% to custom editor size slider. 
~~ATTENTION: It will break all custom scale selected from menu or slider.~~

~~It can be done without breaking user settings, but this code:~~
~~"Auto,50%,75%,100%,125%,150%,175%,200%,Custom"~~
~~looks better than:~~
~~"Auto,75%,100%,125%,150%,175%,200%,50%,Custom"~~