### PR TITLE
C#: Bindings generator now translates BBCode docs to XML comments

### DIFF
--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -87,8 +87,13 @@ class BindingsGenerator {
 		StringName cname;
 		bool is_enum;
 
-		TypeReference() {
-			is_enum = false;
+		TypeReference() :
+				is_enum(false) {
+		}
+
+		TypeReference(const StringName &p_cname) :
+				cname(p_cname),
+				is_enum(false) {
 		}
 	};
 
@@ -321,6 +326,15 @@ class BindingsGenerator {
 			return NULL;
 		}
 
+		const PropertyInterface *find_property_by_name(const StringName &p_cname) const {
+			for (const List<PropertyInterface>::Element *E = properties.front(); E; E = E->next()) {
+				if (E->get().cname == p_cname)
+					return &E->get();
+			}
+
+			return NULL;
+		}
+
 		const PropertyInterface *find_property_by_proxy_name(const String &p_proxy_name) const {
 			for (const List<PropertyInterface>::Element *E = properties.front(); E; E = E->next()) {
 				if (E->get().proxy_name == p_proxy_name)
@@ -482,6 +496,7 @@ class BindingsGenerator {
 		StringName type_VarArg;
 		StringName type_Object;
 		StringName type_Reference;
+		StringName type_String;
 		StringName enum_Error;
 
 		NameCache() {
@@ -493,6 +508,7 @@ class BindingsGenerator {
 			type_VarArg = StaticCString::create("VarArg");
 			type_Object = StaticCString::create("Object");
 			type_Reference = StaticCString::create("Reference");
+			type_String = StaticCString::create("String");
 			enum_Error = StaticCString::create("Error");
 		}
 
@@ -521,6 +537,8 @@ class BindingsGenerator {
 
 		return p_type.name;
 	}
+
+	String bbcode_to_xml(const String &p_bbcode, const TypeInterface *p_itype);
 
 	int _determine_enum_prefix(const EnumInterface &p_ienum);
 	void _apply_prefix_to_enum_constants(EnumInterface &p_ienum, int p_prefix_length);


### PR DESCRIPTION
It's not perfect, but much better than what we had before.

Here's the full diff of the generated bindings: https://gist.github.com/neikeq/5298b69567a24a683a42777aa3fcdbb7

Regarding member/type/etc references, right now the following are not automatically resolved but it would be possible with some mapping:

```
Generating FuncRef.cs...
Cannot resolve type from method reference in documentation: @GDScript.funcref
Cannot resolve type from method reference in documentation: @GDScript.funcref

Generating GDScriptFunctionState.cs...
Cannot resolve type from method reference in documentation: @GDScript.yield
Cannot resolve type from method reference in documentation: @GDScript.yield

Generating Node.cs...
Cannot resolve method reference for non-Godot.Object type in documentation: String.match
Cannot resolve method reference for non-Godot.Object type in documentation: String.match

Generating Texture.cs...
Cannot resolve type from method reference in documentation: @GDScript.load

Generating WeakRef.cs...
Cannot resolve type from method reference in documentation: @GDScript.weakref
```
