### PR TITLE
Add Material Override to CSGMesh

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -760,7 +760,10 @@ CSGBrush *CSGMesh::_build_brush() {
 			uvr_used = true;
 		}
 
-		Ref<Material> mat = mesh->surface_get_material(i);
+		Ref<Material> mat = material_override;
+		if (mat.is_valid() == false) {
+			mat = mesh->surface_get_material(i);
+		}
 
 		PoolVector<int> aindices = arrays[Mesh::ARRAY_INDEX];
 		if (aindices.size()) {
@@ -871,9 +874,13 @@ void CSGMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &CSGMesh::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &CSGMesh::get_mesh);
 
+	ClassDB::bind_method(D_METHOD("set_material_override", "material_override"), &CSGMesh::set_material_override);
+	ClassDB::bind_method(D_METHOD("get_material_override"), &CSGMesh::get_material_override);
+
 	ClassDB::bind_method(D_METHOD("_mesh_changed"), &CSGMesh::_mesh_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), "set_mesh", "get_mesh");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material_override", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,SpatialMaterial"), "set_material_override", "get_material_override");
 }
 
 void CSGMesh::set_mesh(const Ref<Mesh> &p_mesh) {
@@ -894,6 +901,17 @@ void CSGMesh::set_mesh(const Ref<Mesh> &p_mesh) {
 
 Ref<Mesh> CSGMesh::get_mesh() {
 	return mesh;
+}
+
+void CSGMesh::set_material_override(const Ref<Material> &p_material) {
+	if (material_override == p_material)
+		return;
+	material_override = p_material;
+	_make_dirty();
+}
+
+Ref<Material> CSGMesh::get_material_override() const {
+	return material_override;
 }
 
 ////////////////////////////////

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -187,6 +187,7 @@ class CSGMesh : public CSGPrimitive {
 	virtual CSGBrush *_build_brush();
 
 	Ref<Mesh> mesh;
+	Ref<Material> material_override;
 
 	void _mesh_changed();
 
@@ -196,6 +197,9 @@ protected:
 public:
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh();
+
+	void set_material_override(const Ref<Material> &p_material);
+	Ref<Material> get_material_override() const;
 };
 
 class CSGSphere : public CSGPrimitive {


### PR DESCRIPTION
This PR adds `material_override` to the `CSGMesh` class.
I added this to allow myself to set a material on a mesh like you can do with mesh instance.
The reason being, I had an imported obj mesh with no materials and needed to apply a material to it with csg, and couldn't.