### PR TITLE
Allow to drop folders onto editor

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -468,6 +468,7 @@ private:
 	void _update_recent_scenes();
 	void _open_recent_scene(int p_idx);
 	void _dropped_files(const Vector<String> &p_files, int p_screen);
+	void _add_dropped_files_recursive(const Vector<String> &p_files, String to_path);
 	String _recent_scene;
 
 	void _exit_editor();


### PR DESCRIPTION
Closes #26741

Solved by recursively importing files from dropped directory, creating any necessary folders on the way.

Though there are two things I'm not sure of:

- `dir` and `just_copy` variables. They are created with each recursive iteration. I thought that either they could be created once and passed as argument (weird) or be some constant. Unless it's ok for them to work that way.

- When dropped directory is empty, no folder is created. The problem is when there's empty folder inside empty folder, which means that the first one is created. I guess it's not an important issue, but just wanted to note >.>

EDIT:
Also closes #20016, which seems to be the same.