### PR TITLE
Fix: Keep-custom-tracks option now keeps animation loop property and value track update mode.

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -942,6 +942,7 @@ void ResourceImporterScene::_make_external_resources(Node *p_node, const String 
 									old_anim->copy_track(i, anim);
 								}
 							}
+							anim->set_loop(old_anim->has_loop());
 						}
 					}
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2638,6 +2638,7 @@ void Animation::copy_track(int p_track, Ref<Animation> p_to_animation) {
 	p_to_animation->track_set_enabled(dst_track, track_is_enabled(p_track));
 	p_to_animation->track_set_interpolation_type(dst_track, track_get_interpolation_type(p_track));
 	p_to_animation->track_set_interpolation_loop_wrap(dst_track, track_get_interpolation_loop_wrap(p_track));
+	p_to_animation->value_track_set_update_mode(dst_track, value_track_get_update_mode(p_track));
 	for (int i = 0; i < track_get_key_count(p_track); i++) {
 		p_to_animation->track_insert_key(dst_track, track_get_key_time(p_track, i), track_get_key_value(p_track, i), track_get_key_transition(p_track, i));
 	}


### PR DESCRIPTION
It is very annoying to have to reconfigure this values for ALL animations every time the scene is reimported.