### PR TITLE
Add allow_object_decoding option to StreamPeer

### DIFF
--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -48,6 +48,7 @@ protected:
 	Array _get_partial_data(int p_bytes);
 
 	bool big_endian;
+	bool allow_object_decoding;
 
 public:
 	virtual Error put_data(const uint8_t *p_data, int p_bytes) = 0; ///< put a whole chunk of data, blocking until it sent
@@ -89,7 +90,10 @@ public:
 	String get_utf8_string(int p_bytes = -1);
 	Variant get_var();
 
-	StreamPeer() { big_endian = false; }
+	void set_allow_object_decoding(bool p_enable);
+	bool is_object_decoding_allowed() const;
+
+	StreamPeer();
 };
 
 class StreamPeerBuffer : public StreamPeer {


### PR DESCRIPTION
Off by default.
This also expose the property to GDScript, which means breaking exported
data compatibility when backporting to 3.1/3.0.
I think we can just not expose it in our cherry pick, and not allow
decoding packets in Streams at all, even if this is still a
compatibility breaking change. But for the good cause of security.
The other option, is break compatibility with the exported data, tell the
users they have to re-export the game.

Related to #27398 .