### PR TITLE
Use KeyList, ButtonList and JoystickList instead of int where possible

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -199,7 +199,7 @@ void _OS::set_window_title(const String &p_title) {
 	OS::get_singleton()->set_window_title(p_title);
 }
 
-int _OS::get_mouse_button_state() const {
+ButtonList _OS::get_mouse_button_state() const {
 
 	return OS::get_singleton()->get_mouse_button_state();
 }

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -145,7 +145,7 @@ public:
 
 	Point2 get_mouse_position() const;
 	void set_window_title(const String &p_title);
-	int get_mouse_button_state() const;
+	ButtonList get_mouse_button_state() const;
 
 	void set_clipboard(const String &p_text);
 	String get_clipboard() const;

--- a/core/global_constants.cpp
+++ b/core/global_constants.cpp
@@ -85,12 +85,6 @@ static Vector<_GlobalConstant> _global_constants;
 
 #endif
 
-VARIANT_ENUM_CAST(KeyList);
-VARIANT_ENUM_CAST(KeyModifierMask);
-VARIANT_ENUM_CAST(ButtonList);
-VARIANT_ENUM_CAST(JoystickList);
-VARIANT_ENUM_CAST(MidiMessageList);
-
 void register_global_constants() {
 
 	//{ KEY_BACKSPACE, VK_BACK },// (0x08) // backspace

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -79,15 +79,15 @@ public:
 
 	static Input *get_singleton();
 
-	virtual bool is_key_pressed(int p_scancode) const = 0;
-	virtual bool is_mouse_button_pressed(int p_button) const = 0;
-	virtual bool is_joy_button_pressed(int p_device, int p_button) const = 0;
+	virtual bool is_key_pressed(KeyList p_scancode) const = 0;
+	virtual bool is_mouse_button_pressed(ButtonList p_button) const = 0;
+	virtual bool is_joy_button_pressed(int p_device, JoystickList p_button) const = 0;
 	virtual bool is_action_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_released(const StringName &p_action) const = 0;
 	virtual float get_action_strength(const StringName &p_action) const = 0;
 
-	virtual float get_joy_axis(int p_device, int p_axis) const = 0;
+	virtual float get_joy_axis(int p_device, JoystickList p_axis) const = 0;
 	virtual String get_joy_name(int p_idx) = 0;
 	virtual Array get_connected_joypads() = 0;
 	virtual void joy_connection_changed(int p_idx, bool p_connected, String p_name, String p_guid) = 0;
@@ -103,7 +103,7 @@ public:
 
 	virtual Point2 get_mouse_position() const = 0;
 	virtual Point2 get_last_mouse_speed() const = 0;
-	virtual int get_mouse_button_mask() const = 0;
+	virtual ButtonList get_mouse_button_mask() const = 0;
 
 	virtual void warp_mouse_position(const Vector2 &p_to) = 0;
 	virtual Point2i warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect) = 0;
@@ -126,10 +126,10 @@ public:
 	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) = 0;
 	virtual void set_mouse_in_window(bool p_in_window) = 0;
 
-	virtual String get_joy_button_string(int p_button) = 0;
-	virtual String get_joy_axis_string(int p_axis) = 0;
-	virtual int get_joy_button_index_from_string(String p_button) = 0;
-	virtual int get_joy_axis_index_from_string(String p_axis) = 0;
+	virtual String get_joy_button_string(JoystickList p_button) = 0;
+	virtual String get_joy_axis_string(JoystickList p_axis) = 0;
+	virtual JoystickList get_joy_button_index_from_string(String p_button) = 0;
+	virtual JoystickList get_joy_axis_index_from_string(String p_axis) = 0;
 
 	virtual void parse_input_event(const Ref<InputEvent> &p_event) = 0;
 	virtual void accumulate_input_event(const Ref<InputEvent> &p_event) = 0;

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -237,11 +237,11 @@ bool InputEventKey::is_pressed() const {
 	return pressed;
 }
 
-void InputEventKey::set_scancode(uint32_t p_scancode) {
+void InputEventKey::set_scancode(KeyList p_scancode) {
 
 	scancode = p_scancode;
 }
-uint32_t InputEventKey::get_scancode() const {
+KeyList InputEventKey::get_scancode() const {
 
 	return scancode;
 }
@@ -354,18 +354,18 @@ void InputEventKey::_bind_methods() {
 InputEventKey::InputEventKey() {
 
 	pressed = false;
-	scancode = 0;
+	scancode = (KeyList)0;
 	unicode = 0; ///unicode
 	echo = false;
 }
 
 ////////////////////////////////////////
 
-void InputEventMouse::set_button_mask(int p_mask) {
+void InputEventMouse::set_button_mask(ButtonList p_mask) {
 
 	button_mask = p_mask;
 }
-int InputEventMouse::get_button_mask() const {
+ButtonList InputEventMouse::get_button_mask() const {
 
 	return button_mask;
 }
@@ -406,7 +406,7 @@ void InputEventMouse::_bind_methods() {
 
 InputEventMouse::InputEventMouse() {
 
-	button_mask = 0;
+	button_mask = (ButtonList)0;
 }
 
 ///////////////////////////////////////
@@ -421,11 +421,11 @@ float InputEventMouseButton::get_factor() {
 	return factor;
 }
 
-void InputEventMouseButton::set_button_index(int p_index) {
+void InputEventMouseButton::set_button_index(ButtonList p_index) {
 
 	button_index = p_index;
 }
-int InputEventMouseButton::get_button_index() const {
+ButtonList InputEventMouseButton::get_button_index() const {
 
 	return button_index;
 }
@@ -550,7 +550,7 @@ void InputEventMouseButton::_bind_methods() {
 InputEventMouseButton::InputEventMouseButton() {
 
 	factor = 1;
-	button_index = 0;
+	button_index = (ButtonList)0;
 	pressed = false;
 	doubleclick = false;
 }
@@ -680,12 +680,12 @@ InputEventMouseMotion::InputEventMouseMotion() {
 
 ////////////////////////////////////////
 
-void InputEventJoypadMotion::set_axis(int p_axis) {
+void InputEventJoypadMotion::set_axis(JoystickList p_axis) {
 
 	axis = p_axis;
 }
 
-int InputEventJoypadMotion::get_axis() const {
+JoystickList InputEventJoypadMotion::get_axis() const {
 
 	return axis;
 }
@@ -742,17 +742,17 @@ void InputEventJoypadMotion::_bind_methods() {
 
 InputEventJoypadMotion::InputEventJoypadMotion() {
 
-	axis = 0;
+	axis = (JoystickList)0;
 	axis_value = 0;
 }
 /////////////////////////////////
 
-void InputEventJoypadButton::set_button_index(int p_index) {
+void InputEventJoypadButton::set_button_index(JoystickList p_index) {
 
 	button_index = p_index;
 }
 
-int InputEventJoypadButton::get_button_index() const {
+JoystickList InputEventJoypadButton::get_button_index() const {
 
 	return button_index;
 }
@@ -824,7 +824,7 @@ void InputEventJoypadButton::_bind_methods() {
 
 InputEventJoypadButton::InputEventJoypadButton() {
 
-	button_index = 0;
+	button_index = (JoystickList)0;
 	pressure = 0;
 	pressed = false;
 }

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -64,6 +64,28 @@ enum ButtonList {
 	BUTTON_MASK_XBUTTON2 = (1 << (BUTTON_XBUTTON2 - 1))
 };
 
+inline ButtonList operator~(ButtonList a) {
+	return (ButtonList)(~(int)a);
+}
+inline ButtonList operator|(ButtonList a, ButtonList b) {
+	return (ButtonList)((int)a | (int)b);
+}
+inline ButtonList operator&(ButtonList a, ButtonList b) {
+	return (ButtonList)((int)a & (int)b);
+}
+inline ButtonList operator^(ButtonList a, ButtonList b) {
+	return (ButtonList)((int)a ^ (int)b);
+}
+inline ButtonList &operator|=(ButtonList &a, ButtonList b) {
+	return (ButtonList &)((int &)a |= (int)b);
+}
+inline ButtonList &operator&=(ButtonList &a, ButtonList b) {
+	return (ButtonList &)((int &)a |= (int)b);
+}
+inline ButtonList &operator^=(ButtonList &a, ButtonList b) {
+	return (ButtonList &)((int &)a |= (int)b);
+}
+
 enum JoystickList {
 
 	JOY_BUTTON_0 = 0,

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -33,6 +33,7 @@
 
 #include "core/math/transform_2d.h"
 #include "core/os/copymem.h"
+#include "core/os/keyboard.h"
 #include "core/resource.h"
 #include "core/typedefs.h"
 #include "core/ustring.h"
@@ -151,6 +152,12 @@ enum MidiMessageList {
 	MIDI_MESSAGE_PITCH_BEND = 0xE,
 };
 
+VARIANT_ENUM_CAST(KeyList);
+VARIANT_ENUM_CAST(KeyModifierMask);
+VARIANT_ENUM_CAST(ButtonList);
+VARIANT_ENUM_CAST(JoystickList);
+VARIANT_ENUM_CAST(MidiMessageList);
+
 /**
  * Input Modifier Status
  * for keyboard/mouse events.
@@ -244,7 +251,7 @@ class InputEventKey : public InputEventWithModifiers {
 
 	bool pressed; /// otherwise release
 
-	uint32_t scancode; ///< check keyboard.h , KeyCode enum, without modifier masks
+	KeyList scancode; ///< check keyboard.h , KeyCode enum, without modifier masks
 	uint32_t unicode; ///unicode
 
 	bool echo; /// true if this is an echo key
@@ -256,8 +263,8 @@ public:
 	void set_pressed(bool p_pressed);
 	virtual bool is_pressed() const;
 
-	void set_scancode(uint32_t p_scancode);
-	uint32_t get_scancode() const;
+	void set_scancode(KeyList p_scancode);
+	KeyList get_scancode() const;
 
 	void set_unicode(uint32_t p_unicode);
 	uint32_t get_unicode() const;
@@ -281,7 +288,7 @@ class InputEventMouse : public InputEventWithModifiers {
 
 	GDCLASS(InputEventMouse, InputEventWithModifiers)
 
-	int button_mask;
+	ButtonList button_mask;
 
 	Vector2 pos;
 	Vector2 global_pos;
@@ -290,8 +297,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_button_mask(int p_mask);
-	int get_button_mask() const;
+	void set_button_mask(ButtonList p_mask);
+	ButtonList get_button_mask() const;
 
 	void set_position(const Vector2 &p_pos);
 	Vector2 get_position() const;
@@ -307,7 +314,7 @@ class InputEventMouseButton : public InputEventMouse {
 	GDCLASS(InputEventMouseButton, InputEventMouse)
 
 	float factor;
-	int button_index;
+	ButtonList button_index;
 	bool pressed; //otherwise released
 	bool doubleclick; //last even less than doubleclick time
 
@@ -318,8 +325,8 @@ public:
 	void set_factor(float p_factor);
 	float get_factor();
 
-	void set_button_index(int p_index);
-	int get_button_index() const;
+	void set_button_index(ButtonList p_index);
+	ButtonList get_button_index() const;
 
 	void set_pressed(bool p_pressed);
 	virtual bool is_pressed() const;
@@ -363,15 +370,15 @@ public:
 class InputEventJoypadMotion : public InputEvent {
 
 	GDCLASS(InputEventJoypadMotion, InputEvent)
-	int axis; ///< Joypad axis
+	JoystickList axis; ///< Joypad axis
 	float axis_value; ///< -1 to 1
 
 protected:
 	static void _bind_methods();
 
 public:
-	void set_axis(int p_axis);
-	int get_axis() const;
+	void set_axis(JoystickList p_axis);
+	JoystickList get_axis() const;
 
 	void set_axis_value(float p_value);
 	float get_axis_value() const;
@@ -389,15 +396,15 @@ public:
 class InputEventJoypadButton : public InputEvent {
 	GDCLASS(InputEventJoypadButton, InputEvent)
 
-	int button_index;
+	JoystickList button_index;
 	bool pressed;
 	float pressure; //0 to 1
 protected:
 	static void _bind_methods();
 
 public:
-	void set_button_index(int p_index);
-	int get_button_index() const;
+	void set_button_index(JoystickList p_index);
+	JoystickList get_button_index() const;
 
 	void set_pressed(bool p_pressed);
 	virtual bool is_pressed() const;

--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -432,19 +432,19 @@ String keycode_get_string(uint32_t p_code) {
 	return codestr;
 }
 
-int find_keycode(const String &p_code) {
+KeyList find_keycode(const String &p_code) {
 
 	const _KeyCodeText *kct = &_keycodes[0];
 
 	while (kct->text) {
 
 		if (p_code.nocasecmp_to(kct->text) == 0) {
-			return kct->code;
+			return (KeyList)kct->code;
 		}
 		kct++;
 	}
 
-	return 0;
+	return (KeyList)0;
 }
 
 const char *find_keycode_name(int p_keycode) {
@@ -475,8 +475,8 @@ int keycode_get_count() {
 	return count;
 }
 
-int keycode_get_value_by_index(int p_index) {
-	return _keycodes[p_index].code;
+KeyList keycode_get_value_by_index(int p_index) {
+	return (KeyList)_keycodes[p_index].code;
 }
 
 const char *keycode_get_name_by_index(int p_index) {

--- a/core/os/keyboard.h
+++ b/core/os/keyboard.h
@@ -323,10 +323,10 @@ enum KeyModifierMask {
 
 String keycode_get_string(uint32_t p_code);
 bool keycode_has_unicode(uint32_t p_keycode);
-int find_keycode(const String &p_code);
+KeyList find_keycode(const String &p_code);
 const char *find_keycode_name(int p_keycode);
 int keycode_get_count();
-int keycode_get_value_by_index(int p_index);
+KeyList keycode_get_value_by_index(int p_index);
 const char *keycode_get_name_by_index(int p_index);
 
 #endif

--- a/core/os/keyboard.h
+++ b/core/os/keyboard.h
@@ -301,6 +301,28 @@ enum KeyList {
 
 };
 
+inline KeyList operator~(KeyList a) {
+	return (KeyList)(~(int)a);
+}
+inline KeyList operator|(KeyList a, KeyList b) {
+	return (KeyList)((int)a | (int)b);
+}
+inline KeyList operator&(KeyList a, KeyList b) {
+	return (KeyList)((int)a & (int)b);
+}
+inline KeyList operator^(KeyList a, KeyList b) {
+	return (KeyList)((int)a ^ (int)b);
+}
+inline KeyList &operator|=(KeyList &a, KeyList b) {
+	return (KeyList &)((int &)a |= (int)b);
+}
+inline KeyList &operator&=(KeyList &a, KeyList b) {
+	return (KeyList &)((int &)a |= (int)b);
+}
+inline KeyList &operator^=(KeyList &a, KeyList b) {
+	return (KeyList &)((int &)a |= (int)b);
+}
+
 enum KeyModifierMask {
 
 	KEY_CODE_MASK = ((1 << 25) - 1), ///< Apply this mask to any keycode to remove modifiers.

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -170,7 +170,7 @@ public:
 
 	virtual void warp_mouse_position(const Point2 &p_to) {}
 	virtual Point2 get_mouse_position() const = 0;
-	virtual int get_mouse_button_state() const = 0;
+	virtual ButtonList get_mouse_button_state() const = 0;
 	virtual void set_window_title(const String &p_title) = 0;
 
 	virtual void set_clipboard(const String &p_text);

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -913,7 +913,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 					key->set_scancode(find_keycode(name));
 				} else if (token.type == TK_NUMBER) {
 
-					key->set_scancode(token.value);
+					key->set_scancode((KeyList)(int)token.value);
 				} else {
 
 					r_err_str = "Expected string or integer for keycode";
@@ -972,7 +972,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 					return ERR_PARSE_ERROR;
 				}
 
-				mb->set_button_index(token.value);
+				mb->set_button_index((ButtonList)(int)token.value);
 
 				get_token(p_stream, token, line, r_err_str);
 				if (token.type != TK_PARENTHESIS_CLOSE) {
@@ -998,7 +998,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 					return ERR_PARSE_ERROR;
 				}
 
-				jb->set_button_index(token.value);
+				jb->set_button_index((JoystickList)(int)token.value);
 
 				get_token(p_stream, token, line, r_err_str);
 				if (token.type != TK_PARENTHESIS_CLOSE) {
@@ -1024,7 +1024,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 					return ERR_PARSE_ERROR;
 				}
 
-				jm->set_axis(token.value);
+				jm->set_axis((JoystickList)(int)token.value);
 
 				get_token(p_stream, token, line, r_err_str);
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -87,14 +87,14 @@
 			</return>
 			<argument index="0" name="device" type="int">
 			</argument>
-			<argument index="1" name="axis" type="int">
+			<argument index="1" name="axis" type="int" enum="JoystickList">
 			</argument>
 			<description>
 				Returns the current value of the joypad axis at given index (see [enum JoystickList]).
 			</description>
 		</method>
 		<method name="get_joy_axis_index_from_string">
-			<return type="int">
+			<return type="int" enum="JoystickList">
 			</return>
 			<argument index="0" name="axis" type="String">
 			</argument>
@@ -105,14 +105,14 @@
 		<method name="get_joy_axis_string">
 			<return type="String">
 			</return>
-			<argument index="0" name="axis_index" type="int">
+			<argument index="0" name="axis_index" type="int" enum="JoystickList">
 			</argument>
 			<description>
 				Receives a [enum JoystickList] axis and returns its equivalent name as a string.
 			</description>
 		</method>
 		<method name="get_joy_button_index_from_string">
-			<return type="int">
+			<return type="int" enum="JoystickList">
 			</return>
 			<argument index="0" name="button" type="String">
 			</argument>
@@ -123,7 +123,7 @@
 		<method name="get_joy_button_string">
 			<return type="String">
 			</return>
-			<argument index="0" name="button_index" type="int">
+			<argument index="0" name="button_index" type="int" enum="JoystickList">
 			</argument>
 			<description>
 				Receives a joy button from [enum JoystickList] and returns its equivalent name as a string.
@@ -180,7 +180,7 @@
 			</description>
 		</method>
 		<method name="get_mouse_button_mask" qualifiers="const">
-			<return type="int">
+			<return type="int" enum="ButtonList">
 			</return>
 			<description>
 				Returns mouse buttons as a bitmask. If multiple mouse buttons are pressed at the same time the bits are added together.
@@ -226,7 +226,7 @@
 			</return>
 			<argument index="0" name="device" type="int">
 			</argument>
-			<argument index="1" name="button" type="int">
+			<argument index="1" name="button" type="int" enum="JoystickList">
 			</argument>
 			<description>
 				Returns [code]true[/code] if you are pressing the joypad button (see [enum JoystickList]).
@@ -244,7 +244,7 @@
 		<method name="is_key_pressed" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="scancode" type="int">
+			<argument index="0" name="scancode" type="int" enum="KeyList">
 			</argument>
 			<description>
 				Returns [code]true[/code] if you are pressing the key. You can pass a [enum KeyList] constant.
@@ -253,7 +253,7 @@
 		<method name="is_mouse_button_pressed" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="button" type="int">
+			<argument index="0" name="button" type="int" enum="ButtonList">
 			</argument>
 			<description>
 				Returns [code]true[/code] if you are pressing the mouse button specified with [enum ButtonList].

--- a/doc/classes/InputEventJoypadButton.xml
+++ b/doc/classes/InputEventJoypadButton.xml
@@ -14,8 +14,13 @@
 	<methods>
 	</methods>
 	<members>
+<<<<<<< HEAD
 		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index">
 			Button identifier. One of the [enum JoystickList] button constants.
+=======
+		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index" enum="JoystickList">
+			Button identifier. One of the [code]JOY_BUTTON_*[/code] constants from [@GlobalScope].
+>>>>>>> 64f859cf9... WIP Use KeyList, ButtonList and JoystickList instead of int where possible
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed">
 			If [code]true[/code], the button's state is pressed. If [code]false[/code], the button's state is released.

--- a/doc/classes/InputEventJoypadMotion.xml
+++ b/doc/classes/InputEventJoypadMotion.xml
@@ -14,7 +14,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="axis" type="int" setter="set_axis" getter="get_axis">
+		<member name="axis" type="int" setter="set_axis" getter="get_axis" enum="JoystickList">
 			Axis identifier. Use one of the [enum JoystickList] axis constants.
 		</member>
 		<member name="axis_value" type="float" setter="set_axis_value" getter="get_axis_value">

--- a/doc/classes/InputEventKey.xml
+++ b/doc/classes/InputEventKey.xml
@@ -27,7 +27,7 @@
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed">
 			If [code]true[/code], the key's state is pressed. If [code]false[/code], the key's state is released.
 		</member>
-		<member name="scancode" type="int" setter="set_scancode" getter="get_scancode">
+		<member name="scancode" type="int" setter="set_scancode" getter="get_scancode" enum="KeyList">
 			Key scancode, one of the [enum KeyList] constants.
 		</member>
 		<member name="unicode" type="int" setter="set_unicode" getter="get_unicode">

--- a/doc/classes/InputEventMouse.xml
+++ b/doc/classes/InputEventMouse.xml
@@ -14,7 +14,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask">
+		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" enum="ButtonList">
 			Mouse button mask identifier, one of or a bitwise combination of the [enum ButtonList] button masks.
 		</member>
 		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position">

--- a/doc/classes/InputEventMouseButton.xml
+++ b/doc/classes/InputEventMouseButton.xml
@@ -14,7 +14,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index">
+		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index" enum="ButtonList">
 			Mouse button identifier, one of the [enum ButtonList] button or button wheel constants.
 		</member>
 		<member name="doubleclick" type="bool" setter="set_doubleclick" getter="is_doubleclick">

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -72,6 +72,8 @@ void EditorHelpSearch::_search_box_gui_input(const Ref<InputEvent> &p_event) {
 				results_tree->call("_gui_input", key);
 				search_box->accept_event();
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/editor_name_dialog.cpp
+++ b/editor/editor_name_dialog.cpp
@@ -56,6 +56,8 @@ void EditorNameDialog::_line_gui_input(const Ref<InputEvent> &p_event) {
 				hide();
 				accept_event();
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1444,7 +1444,7 @@ Ref<ShortCut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p
 		ie.instance();
 
 		ie->set_unicode(p_keycode & KEY_CODE_MASK);
-		ie->set_scancode(p_keycode & KEY_CODE_MASK);
+		ie->set_scancode((KeyList)(p_keycode & KEY_CODE_MASK));
 		ie->set_shift(bool(p_keycode & KEY_MASK_SHIFT));
 		ie->set_alt(bool(p_keycode & KEY_MASK_ALT));
 		ie->set_control(bool(p_keycode & KEY_MASK_CTRL));

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1300,6 +1300,8 @@ void AnimationPlayerEditor::_unhandled_key_input(const Ref<InputEvent> &p_ev) {
 				else
 					_play_pressed();
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -127,6 +127,9 @@ void CurveEditor::on_gui_input(const Ref<InputEvent> &p_event) {
 				case BUTTON_LEFT:
 					_dragging = true;
 					break;
+
+				default:
+					break;
 			}
 		}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2415,6 +2415,9 @@ void ScriptEditor::_script_list_gui_input(const Ref<InputEvent> &ev) {
 			case BUTTON_RIGHT: {
 				_make_script_list_context_menu();
 			} break;
+
+			default:
+				break;
 		}
 	}
 }

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1472,7 +1472,7 @@ void ScriptEditor::_help_overview_selected(int p_idx) {
 
 void ScriptEditor::_script_selected(int p_idx) {
 
-	grab_focus_block = !Input::get_singleton()->is_mouse_button_pressed(1); //amazing hack, simply amazing
+	grab_focus_block = !Input::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT); //amazing hack, simply amazing
 
 	_go_to_tab(script_list->get_item_metadata(p_idx));
 	grab_focus_block = false;

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -1178,6 +1178,9 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				}
 
 			} break;
+
+			default:
+				break;
 		}
 	}
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2035,7 +2035,7 @@ static bool is_shortcut_pressed(const String &p_path) {
 		return false;
 	}
 	const Input &input = *Input::get_singleton();
-	int scancode = k->get_scancode();
+	KeyList scancode = k->get_scancode();
 	return input.is_key_pressed(scancode);
 }
 

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -283,7 +283,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					for (List<Rect2>::Element *E = autoslice_cache.front(); E; E = E->next()) {
 						if (E->get().has_point(point)) {
 							rect = E->get();
-							if (Input::get_singleton()->is_key_pressed(KEY_CONTROL) && !(Input::get_singleton()->is_key_pressed(KEY_SHIFT | KEY_ALT))) {
+							if (Input::get_singleton()->is_key_pressed(KEY_CONTROL) && !(Input::get_singleton()->is_key_pressed((KeyList)(KEY_SHIFT | KEY_ALT)))) {
 								Rect2 r;
 								if (node_sprite)
 									r = node_sprite->get_region_rect();

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -283,7 +283,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					for (List<Rect2>::Element *E = autoslice_cache.front(); E; E = E->next()) {
 						if (E->get().has_point(point)) {
 							rect = E->get();
-							if (Input::get_singleton()->is_key_pressed(KEY_CONTROL) && !(Input::get_singleton()->is_key_pressed((KeyList)(KEY_SHIFT | KEY_ALT)))) {
+							if (Input::get_singleton()->is_key_pressed(KEY_CONTROL) && !(Input::get_singleton()->is_key_pressed(KEY_SHIFT | KEY_ALT))) {
 								Rect2 r;
 								if (node_sprite)
 									r = node_sprite->get_region_rect();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -236,7 +236,7 @@ void ProjectSettingsEditor::_device_input_add() {
 
 			Ref<InputEventMouseButton> mb;
 			mb.instance();
-			mb->set_button_index(device_index->get_selected() + 1);
+			mb->set_button_index((ButtonList)(device_index->get_selected() + 1));
 			mb->set_device(_get_current_device());
 
 			for (int i = 0; i < events.size(); i++) {
@@ -256,7 +256,7 @@ void ProjectSettingsEditor::_device_input_add() {
 
 			Ref<InputEventJoypadMotion> jm;
 			jm.instance();
-			jm->set_axis(device_index->get_selected() >> 1);
+			jm->set_axis((JoystickList)(device_index->get_selected() >> 1));
 			jm->set_axis_value(device_index->get_selected() & 1 ? 1 : -1);
 			jm->set_device(_get_current_device());
 
@@ -279,7 +279,7 @@ void ProjectSettingsEditor::_device_input_add() {
 			Ref<InputEventJoypadButton> jb;
 			jb.instance();
 
-			jb->set_button_index(device_index->get_selected());
+			jb->set_button_index((JoystickList)device_index->get_selected());
 			jb->set_device(_get_current_device());
 
 			for (int i = 0; i < events.size(); i++) {

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -69,6 +69,8 @@ void PropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 				current->select(0);
 
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -107,6 +107,8 @@ void EditorQuickOpen::_sbox_input(const Ref<InputEvent> &p_ie) {
 				current->select(0);
 
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -283,9 +283,9 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 	if (mb.is_valid()) {
 
 		if (mb->is_pressed()) {
-			mouse_button_mask |= (1 << (mb->get_button_index() - 1));
+			mouse_button_mask |= ButtonList(1 << (mb->get_button_index() - 1));
 		} else {
-			mouse_button_mask &= ~(1 << (mb->get_button_index() - 1));
+			mouse_button_mask &= ButtonList(~(1 << (mb->get_button_index() - 1)));
 		}
 
 		Point2 pos = mb->get_global_position();
@@ -361,9 +361,9 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 				button_event->set_pressed(st->is_pressed());
 				button_event->set_button_index(BUTTON_LEFT);
 				if (st->is_pressed()) {
-					button_event->set_button_mask((ButtonList)(mouse_button_mask | BUTTON_MASK_LEFT));
+					button_event->set_button_mask(mouse_button_mask | BUTTON_MASK_LEFT);
 				} else {
-					button_event->set_button_mask((ButtonList)(mouse_button_mask & ~BUTTON_MASK_LEFT));
+					button_event->set_button_mask(mouse_button_mask & ~BUTTON_MASK_LEFT);
 				}
 
 				_parse_input_event_impl(button_event, true);
@@ -389,7 +389,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 			motion_event->set_global_position(sd->get_position());
 			motion_event->set_relative(sd->get_relative());
 			motion_event->set_speed(sd->get_speed());
-			motion_event->set_button_mask((ButtonList)mouse_button_mask);
+			motion_event->set_button_mask(mouse_button_mask);
 
 			_parse_input_event_impl(motion_event, true);
 		}
@@ -521,7 +521,7 @@ Point2 InputDefault::get_last_mouse_speed() const {
 
 ButtonList InputDefault::get_mouse_button_mask() const {
 
-	return (ButtonList)mouse_button_mask; // do not trust OS implementation, should remove it - OS::get_singleton()->get_mouse_button_state();
+	return mouse_button_mask; // do not trust OS implementation, should remove it - OS::get_singleton()->get_mouse_button_state();
 }
 
 void InputDefault::warp_mouse_position(const Vector2 &p_to) {
@@ -607,7 +607,7 @@ void InputDefault::ensure_touch_mouse_raised() {
 		button_event->set_global_position(mouse_pos);
 		button_event->set_pressed(false);
 		button_event->set_button_index(BUTTON_LEFT);
-		button_event->set_button_mask((ButtonList)(mouse_button_mask & ~BUTTON_MASK_LEFT));
+		button_event->set_button_mask(mouse_button_mask & ~BUTTON_MASK_LEFT);
 
 		_parse_input_event_impl(button_event, true);
 	}
@@ -689,7 +689,7 @@ void InputDefault::set_use_accumulated_input(bool p_enable) {
 InputDefault::InputDefault() {
 
 	use_accumulated_input = true;
-	mouse_button_mask = 0;
+	mouse_button_mask = (ButtonList)0;
 	emulate_touch_from_mouse = false;
 	emulate_mouse_from_touch = false;
 	mouse_from_touch_index = -1;

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -40,7 +40,7 @@ class InputDefault : public Input {
 
 	int mouse_button_mask;
 
-	Set<int> keys_pressed;
+	Set<KeyList> keys_pressed;
 	Set<int> joy_buttons_pressed;
 	Map<int, float> _joy_axis;
 	//Map<StringName,int> custom_action_press;
@@ -159,7 +159,7 @@ private:
 
 	struct JoyEvent {
 		int type;
-		int index;
+		JoystickList index;
 		int value;
 	};
 
@@ -177,9 +177,9 @@ private:
 	Vector<JoyDeviceMapping> map_db;
 
 	JoyEvent _find_to_event(String p_to);
-	void _button_event(int p_device, int p_index, bool p_pressed);
-	void _axis_event(int p_device, int p_axis, float p_value);
-	float _handle_deadzone(int p_device, int p_axis, float p_value);
+	void _button_event(int p_device, JoystickList p_index, bool p_pressed);
+	void _axis_event(int p_device, JoystickList p_axis, float p_value);
+	float _handle_deadzone(int p_device, JoystickList p_axis, float p_value);
 
 	void _parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated);
 
@@ -187,15 +187,15 @@ private:
 	bool use_accumulated_input;
 
 public:
-	virtual bool is_key_pressed(int p_scancode) const;
-	virtual bool is_mouse_button_pressed(int p_button) const;
-	virtual bool is_joy_button_pressed(int p_device, int p_button) const;
+	virtual bool is_key_pressed(KeyList p_scancode) const;
+	virtual bool is_mouse_button_pressed(ButtonList p_button) const;
+	virtual bool is_joy_button_pressed(int p_device, JoystickList p_button) const;
 	virtual bool is_action_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_released(const StringName &p_action) const;
 	virtual float get_action_strength(const StringName &p_action) const;
 
-	virtual float get_joy_axis(int p_device, int p_axis) const;
+	virtual float get_joy_axis(int p_device, JoystickList p_axis) const;
 	String get_joy_name(int p_idx);
 	virtual Array get_connected_joypads();
 	virtual Vector2 get_joy_vibration_strength(int p_device);
@@ -211,7 +211,7 @@ public:
 
 	virtual Point2 get_mouse_position() const;
 	virtual Point2 get_last_mouse_speed() const;
-	virtual int get_mouse_button_mask() const;
+	virtual ButtonList get_mouse_button_mask() const;
 
 	virtual void warp_mouse_position(const Vector2 &p_to);
 	virtual Point2i warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect);
@@ -222,7 +222,7 @@ public:
 	void set_accelerometer(const Vector3 &p_accel);
 	void set_magnetometer(const Vector3 &p_magnetometer);
 	void set_gyroscope(const Vector3 &p_gyroscope);
-	void set_joy_axis(int p_device, int p_axis, float p_value);
+	void set_joy_axis(int p_device, JoystickList p_axis, float p_value);
 
 	virtual void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration = 0);
 	virtual void stop_joy_vibration(int p_device);
@@ -248,8 +248,8 @@ public:
 	virtual void set_mouse_in_window(bool p_in_window);
 
 	void parse_mapping(String p_mapping);
-	void joy_button(int p_device, int p_button, bool p_pressed);
-	void joy_axis(int p_device, int p_axis, const JoyAxis &p_value);
+	void joy_button(int p_device, JoystickList p_button, bool p_pressed);
+	void joy_axis(int p_device, JoystickList p_axis, const JoyAxis &p_value);
 	void joy_hat(int p_device, int p_val);
 
 	virtual void add_joy_mapping(String p_mapping, bool p_update_existing = false);
@@ -257,10 +257,10 @@ public:
 	virtual bool is_joy_known(int p_device);
 	virtual String get_joy_guid(int p_device) const;
 
-	virtual String get_joy_button_string(int p_button);
-	virtual String get_joy_axis_string(int p_axis);
-	virtual int get_joy_axis_index_from_string(String p_axis);
-	virtual int get_joy_button_index_from_string(String p_button);
+	virtual String get_joy_button_string(JoystickList p_button);
+	virtual String get_joy_axis_string(JoystickList p_axis);
+	virtual JoystickList get_joy_axis_index_from_string(String p_axis);
+	virtual JoystickList get_joy_button_index_from_string(String p_button);
 
 	int get_unused_joy_id();
 

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -38,7 +38,7 @@ class InputDefault : public Input {
 	GDCLASS(InputDefault, Input);
 	_THREAD_SAFE_CLASS_
 
-	int mouse_button_mask;
+	ButtonList mouse_button_mask;
 
 	Set<KeyList> keys_pressed;
 	Set<int> joy_buttons_pressed;

--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -364,7 +364,7 @@ void GDAPI godot_arvr_set_controller_button(godot_int p_controller_id, godot_int
 	if (tracker != NULL) {
 		int joyid = tracker->get_joy_id();
 		if (joyid != -1) {
-			input->joy_button(joyid, p_button, p_is_pressed);
+			input->joy_button(joyid, (JoystickList)p_button, p_is_pressed);
 		}
 	}
 }
@@ -383,7 +383,7 @@ void GDAPI godot_arvr_set_controller_axis(godot_int p_controller_id, godot_int p
 			InputDefault::JoyAxis jx;
 			jx.min = p_can_be_negative ? -1 : 0;
 			jx.value = p_value;
-			input->joy_axis(joyid, p_axis, jx);
+			input->joy_axis(joyid, (JoystickList)p_axis, jx);
 		}
 	}
 }

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -75,6 +75,8 @@ void VisualScriptPropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 				current->select(0);
 
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -1096,7 +1096,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joybutton(JNIEnv *env
 	OS_Android::JoypadEvent jevent;
 	jevent.device = p_device;
 	jevent.type = OS_Android::JOY_EVENT_BUTTON;
-	jevent.index = p_button;
+	jevent.index = (JoystickList)p_button;
 	jevent.pressed = p_pressed;
 
 	os_android->process_joy_event(jevent);
@@ -1109,7 +1109,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyaxis(JNIEnv *env, 
 	OS_Android::JoypadEvent jevent;
 	jevent.device = p_device;
 	jevent.type = OS_Android::JOY_EVENT_AXIS;
-	jevent.index = p_axis;
+	jevent.index = (JoystickList)p_axis;
 	jevent.value = p_value;
 
 	os_android->process_joy_event(jevent);
@@ -1155,7 +1155,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_key(JNIEnv *env, jobj
 	ievent.instance();
 	int val = p_unicode_char;
 	int scancode = android_get_keysym(p_scancode);
-	ievent->set_scancode(scancode);
+	ievent->set_scancode((KeyList)scancode);
 	ievent->set_unicode(val);
 	ievent->set_pressed(p_pressed);
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -245,9 +245,9 @@ Point2 OS_Android::get_mouse_position() const {
 	return Point2();
 }
 
-int OS_Android::get_mouse_button_state() const {
+ButtonList OS_Android::get_mouse_button_state() const {
 
-	return 0;
+	return (ButtonList)0;
 }
 
 void OS_Android::set_window_title(const String &p_title) {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -61,7 +61,7 @@ public:
 
 		int device;
 		int type;
-		int index;
+		JoystickList index;
 		bool pressed;
 		float value;
 		int hat;
@@ -128,7 +128,7 @@ public:
 	virtual void set_mouse_grab(bool p_grab);
 	virtual bool is_mouse_grab_enabled() const;
 	virtual Point2 get_mouse_position() const;
-	virtual int get_mouse_button_state() const;
+	virtual ButtonList get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);
 
 	virtual void set_video_mode(const VideoMode &p_video_mode, int p_screen = 0);

--- a/platform/haiku/haiku_direct_window.h
+++ b/platform/haiku/haiku_direct_window.h
@@ -83,7 +83,7 @@ public:
 	virtual void DispatchMessage(BMessage *message, BHandler *handler);
 
 	inline Point2i GetLastMousePosition() { return last_mouse_position; };
-	inline int GetLastButtonMask() { return last_button_mask; };
+	inline ButtonList GetLastButtonMask() { return (ButtonList)last_button_mask; };
 };
 
 #endif

--- a/platform/haiku/os_haiku.cpp
+++ b/platform/haiku/os_haiku.cpp
@@ -195,7 +195,7 @@ Point2 OS_Haiku::get_mouse_position() const {
 	return window->GetLastMousePosition();
 }
 
-int OS_Haiku::get_mouse_button_state() const {
+ButtonList OS_Haiku::get_mouse_button_state() const {
 	return window->GetLastButtonMask();
 }
 

--- a/platform/haiku/os_haiku.h
+++ b/platform/haiku/os_haiku.h
@@ -84,7 +84,7 @@ public:
 	virtual void swap_buffers();
 
 	virtual Point2 get_mouse_position() const;
-	virtual int get_mouse_button_state() const;
+	virtual ButtonList get_mouse_button_state() const;
 	virtual void set_cursor_shape(CursorShape p_shape);
 	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot);
 

--- a/platform/iphone/gl_view.mm
+++ b/platform/iphone/gl_view.mm
@@ -600,7 +600,7 @@ static void clear_touches() {
 	String character;
 	character.parse_utf8([p_text UTF8String]);
 	keyboard_text = keyboard_text + character;
-	OSIPhone::get_singleton()->key(character[0] == 10 ? KEY_ENTER : character[0], true);
+	OSIPhone::get_singleton()->key(character[0] == 10 ? KEY_ENTER : (KeyList)(uint32_t)character[0], true);
 	printf("inserting text with character %lc\n", (CharType)character[0]);
 };
 

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -219,13 +219,13 @@ bool OSIPhone::iterate() {
 	return Main::iteration();
 };
 
-void OSIPhone::key(uint32_t p_key, bool p_pressed) {
+void OSIPhone::key(KeyList p_key, bool p_pressed) {
 
 	Ref<InputEventKey> ev;
 	ev.instance();
 	ev->set_echo(false);
 	ev->set_pressed(p_pressed);
-	ev->set_scancode(p_key);
+	ev->set_scancode((KeyList)p_key);
 	ev->set_unicode(p_key);
 	queue_event(ev);
 };
@@ -338,11 +338,11 @@ void OSIPhone::joy_connection_changed(int p_idx, bool p_connected, String p_name
 	input->joy_connection_changed(p_idx, p_connected, p_name);
 };
 
-void OSIPhone::joy_button(int p_device, int p_button, bool p_pressed) {
+void OSIPhone::joy_button(int p_device, JoystickList p_button, bool p_pressed) {
 	input->joy_button(p_device, p_button, p_pressed);
 };
 
-void OSIPhone::joy_axis(int p_device, int p_axis, const InputDefault::JoyAxis &p_value) {
+void OSIPhone::joy_axis(int p_device, JoystickList p_axis, const InputDefault::JoyAxis &p_value) {
 	input->joy_axis(p_device, p_axis, p_value);
 };
 
@@ -381,9 +381,9 @@ Point2 OSIPhone::get_mouse_position() const {
 	return Point2();
 };
 
-int OSIPhone::get_mouse_button_state() const {
+ButtonList OSIPhone::get_mouse_button_state() const {
 
-	return 0;
+	return (ButtonList)0;
 };
 
 void OSIPhone::set_window_title(const String &p_title){};

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -124,7 +124,7 @@ public:
 	void touch_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_doubleclick);
 	void touch_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_y);
 	void touches_cancelled();
-	void key(uint32_t p_key, bool p_pressed);
+	void key(KeyList p_key, bool p_pressed);
 	void set_virtual_keyboard_height(int p_height);
 
 	int set_base_framebuffer(int p_fb);
@@ -136,8 +136,8 @@ public:
 
 	int get_unused_joy_id();
 	void joy_connection_changed(int p_idx, bool p_connected, String p_name);
-	void joy_button(int p_device, int p_button, bool p_pressed);
-	void joy_axis(int p_device, int p_axis, const InputDefault::JoyAxis &p_value);
+	void joy_button(int p_device, JoystickList p_button, bool p_pressed);
+	void joy_axis(int p_device, JoystickList p_axis, const InputDefault::JoyAxis &p_value);
 
 	static OSIPhone *get_singleton();
 
@@ -145,7 +145,7 @@ public:
 	virtual void set_mouse_grab(bool p_grab);
 	virtual bool is_mouse_grab_enabled() const;
 	virtual Point2 get_mouse_position() const;
-	virtual int get_mouse_button_state() const;
+	virtual ButtonList get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -273,7 +273,7 @@ Point2 OS_JavaScript::get_mouse_position() const {
 	return input->get_mouse_position();
 }
 
-int OS_JavaScript::get_mouse_button_state() const {
+ButtonList OS_JavaScript::get_mouse_button_state() const {
 
 	return input->get_mouse_button_mask();
 }

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -116,7 +116,7 @@ public:
 	virtual Size2 get_screen_size(int p_screen = -1) const;
 
 	virtual Point2 get_mouse_position() const;
-	virtual int get_mouse_button_state() const;
+	virtual ButtonList get_mouse_button_state() const;
 	virtual void set_cursor_shape(CursorShape p_shape);
 	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot);
 	virtual void set_mouse_mode(MouseMode p_mode);

--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -465,11 +465,11 @@ void JoypadOSX::process_joypads() {
 		for (int j = 0; j < joy.axis_elements.size(); j++) {
 			rec_element &elem = joy.axis_elements.write[j];
 			int value = joy.get_hid_element_state(&elem);
-			input->joy_axis(joy.id, j, axis_correct(value, elem.min, elem.max));
+			input->joy_axis(joy.id, (JoystickList)j, axis_correct(value, elem.min, elem.max));
 		}
 		for (int j = 0; j < joy.button_elements.size(); j++) {
 			int value = joy.get_hid_element_state(&joy.button_elements.write[j]);
-			input->joy_button(joy.id, j, (value >= 1));
+			input->joy_button(joy.id, (JoystickList)j, (value >= 1));
 		}
 		for (int j = 0; j < joy.hat_elements.size(); j++) {
 			rec_element &elem = joy.hat_elements.write[j];

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -179,7 +179,7 @@ public:
 	virtual bool is_mouse_grab_enabled() const;
 	virtual void warp_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
-	virtual int get_mouse_button_state() const;
+	virtual ButtonList get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);
 
 	virtual Size2 get_window_size() const;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -590,7 +590,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 	OS_OSX::singleton->set_cursor_shape(p_shape);
 }
 
-static void _mouseDownEvent(NSEvent *event, int index, int mask, bool pressed) {
+static void _mouseDownEvent(NSEvent *event, ButtonList index, int mask, bool pressed) {
 	if (pressed) {
 		button_mask |= mask;
 	} else {
@@ -606,7 +606,7 @@ static void _mouseDownEvent(NSEvent *event, int index, int mask, bool pressed) {
 	mb->set_pressed(pressed);
 	mb->set_position(pos);
 	mb->set_global_position(pos);
-	mb->set_button_mask(button_mask);
+	mb->set_button_mask((ButtonList)button_mask);
 	if (index == BUTTON_LEFT && pressed) {
 		mb->set_doubleclick([event clickCount] == 2);
 	}
@@ -640,7 +640,7 @@ static void _mouseDownEvent(NSEvent *event, int index, int mask, bool pressed) {
 	Ref<InputEventMouseMotion> mm;
 	mm.instance();
 
-	mm->set_button_mask(button_mask);
+	mm->set_button_mask((ButtonList)button_mask);
 	const CGFloat backingScaleFactor = [[event window] backingScaleFactor];
 	const Vector2 pos = get_mouse_pos([event locationInWindow], backingScaleFactor);
 	mm->set_position(pos);
@@ -1125,7 +1125,7 @@ static int remapKey(unsigned int key) {
 	}
 }
 
-inline void sendScrollEvent(int button, double factor, int modifierFlags) {
+inline void sendScrollEvent(ButtonList button, double factor, int modifierFlags) {
 
 	unsigned int mask = 1 << (button - 1);
 	Vector2 mouse_pos = Vector2(mouse_x, mouse_y);
@@ -1140,7 +1140,7 @@ inline void sendScrollEvent(int button, double factor, int modifierFlags) {
 	sc->set_position(mouse_pos);
 	sc->set_global_position(mouse_pos);
 	button_mask |= mask;
-	sc->set_button_mask(button_mask);
+	sc->set_button_mask((ButtonList)button_mask);
 	OS_OSX::singleton->push_input(sc);
 
 	sc.instance();
@@ -1150,7 +1150,7 @@ inline void sendScrollEvent(int button, double factor, int modifierFlags) {
 	sc->set_position(mouse_pos);
 	sc->set_global_position(mouse_pos);
 	button_mask &= ~mask;
-	sc->set_button_mask(button_mask);
+	sc->set_button_mask((ButtonList)button_mask);
 	OS_OSX::singleton->push_input(sc);
 }
 
@@ -1840,8 +1840,8 @@ Point2 OS_OSX::get_mouse_position() const {
 	return Vector2(mouse_x, mouse_y);
 }
 
-int OS_OSX::get_mouse_button_state() const {
-	return button_mask;
+ButtonList OS_OSX::get_mouse_button_state() const {
+	return (ButtonList)button_mask;
 }
 
 void OS_OSX::set_window_title(const String &p_title) {
@@ -2583,7 +2583,7 @@ void OS_OSX::process_key_events() {
 			get_key_modifier_state(ke.osx_state, k);
 			k->set_pressed(ke.pressed);
 			k->set_echo(ke.echo);
-			k->set_scancode(0);
+			k->set_scancode((KeyList)0);
 			k->set_unicode(ke.unicode);
 
 			push_input(k);
@@ -2594,7 +2594,7 @@ void OS_OSX::process_key_events() {
 			get_key_modifier_state(ke.osx_state, k);
 			k->set_pressed(ke.pressed);
 			k->set_echo(ke.echo);
-			k->set_scancode(ke.scancode);
+			k->set_scancode((KeyList)ke.scancode);
 
 			if (i + 1 < key_event_pos && key_event_buffer[i + 1].scancode == 0) {
 				k->set_unicode(key_event_buffer[i + 1].unicode);

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -138,9 +138,9 @@ bool OS_Server::is_mouse_grab_enabled() const {
 	return grab;
 }
 
-int OS_Server::get_mouse_button_state() const {
+ButtonList OS_Server::get_mouse_button_state() const {
 
-	return 0;
+	return (ButtonList)0;
 }
 
 Point2 OS_Server::get_mouse_position() const {

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -102,7 +102,7 @@ public:
 	virtual void set_mouse_grab(bool p_grab);
 	virtual bool is_mouse_grab_enabled() const;
 	virtual Point2 get_mouse_position() const;
-	virtual int get_mouse_button_state() const;
+	virtual ButtonList get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);
 
 	virtual MainLoop *get_main_loop() const;

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -511,9 +511,9 @@ Point2 OS_UWP::get_mouse_position() const {
 	return Point2(old_x, old_y);
 }
 
-int OS_UWP::get_mouse_button_state() const {
+ButtonList OS_UWP::get_mouse_button_state() const {
 
-	return last_button_state;
+	return (ButtonList)last_button_state;
 }
 
 void OS_UWP::set_window_title(const String &p_title) {

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -181,7 +181,7 @@ public:
 	MouseMode get_mouse_mode() const;
 
 	virtual Point2 get_mouse_position() const;
-	virtual int get_mouse_button_state() const;
+	virtual ButtonList get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);
 
 	virtual void set_video_mode(const VideoMode &p_video_mode, int p_screen = 0);

--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -336,7 +336,7 @@ void JoypadWindows::process_joypads() {
 			int button_mask = XINPUT_GAMEPAD_DPAD_UP;
 			for (int i = 0; i <= 16; i++) {
 
-				input->joy_button(joy.id, i, joy.state.Gamepad.wButtons & button_mask);
+				input->joy_button(joy.id, (JoystickList)i, joy.state.Gamepad.wButtons & button_mask);
 				button_mask = button_mask * 2;
 			}
 
@@ -391,14 +391,14 @@ void JoypadWindows::process_joypads() {
 
 				if (!joy->last_buttons[j]) {
 
-					input->joy_button(joy->id, j, true);
+					input->joy_button(joy->id, (JoystickList)j, true);
 					joy->last_buttons[j] = true;
 				}
 			} else {
 
 				if (joy->last_buttons[j]) {
 
-					input->joy_button(joy->id, j, false);
+					input->joy_button(joy->id, (JoystickList)j, false);
 					joy->last_buttons[j] = false;
 				}
 			}
@@ -413,7 +413,7 @@ void JoypadWindows::process_joypads() {
 
 			for (int k = 0; k < count; k++) {
 				if (joy->joy_axis[j] == axes[k]) {
-					input->joy_axis(joy->id, j, axis_correct(values[k]));
+					input->joy_axis(joy->id, (JoystickList)j, axis_correct(values[k]));
 					break;
 				};
 			};

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1621,9 +1621,9 @@ void OS_Windows::update_real_mouse_position() {
 	}
 }
 
-int OS_Windows::get_mouse_button_state() const {
+ButtonList OS_Windows::get_mouse_button_state() const {
 
-	return last_button_state;
+	return (ButtonList)last_button_state;
 }
 
 void OS_Windows::set_window_title(const String &p_title) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -414,7 +414,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				mm->set_shift(shift_mem);
 				mm->set_alt(alt_mem);
 
-				mm->set_button_mask(last_button_state);
+				mm->set_button_mask((ButtonList)last_button_state);
 
 				Point2i c(video_mode.width / 2, video_mode.height / 2);
 
@@ -508,7 +508,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			mm->set_shift((wParam & MK_SHIFT) != 0);
 			mm->set_alt(alt_mem);
 
-			mm->set_button_mask(last_button_state);
+			mm->set_button_mask((ButtonList)last_button_state);
 
 			mm->set_position(Vector2(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
 			mm->set_global_position(Vector2(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
@@ -576,45 +576,45 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			switch (uMsg) {
 				case WM_LBUTTONDOWN: {
 					mb->set_pressed(true);
-					mb->set_button_index(1);
+					mb->set_button_index(BUTTON_LEFT);
 				} break;
 				case WM_LBUTTONUP: {
 					mb->set_pressed(false);
-					mb->set_button_index(1);
+					mb->set_button_index(BUTTON_LEFT);
 				} break;
 				case WM_MBUTTONDOWN: {
 					mb->set_pressed(true);
-					mb->set_button_index(3);
+					mb->set_button_index(BUTTON_MIDDLE);
 
 				} break;
 				case WM_MBUTTONUP: {
 					mb->set_pressed(false);
-					mb->set_button_index(3);
+					mb->set_button_index(BUTTON_MIDDLE);
 				} break;
 				case WM_RBUTTONDOWN: {
 					mb->set_pressed(true);
-					mb->set_button_index(2);
+					mb->set_button_index(BUTTON_RIGHT);
 				} break;
 				case WM_RBUTTONUP: {
 					mb->set_pressed(false);
-					mb->set_button_index(2);
+					mb->set_button_index(BUTTON_RIGHT);
 				} break;
 				case WM_LBUTTONDBLCLK: {
 
 					mb->set_pressed(true);
-					mb->set_button_index(1);
+					mb->set_button_index(BUTTON_LEFT);
 					mb->set_doubleclick(true);
 				} break;
 				case WM_RBUTTONDBLCLK: {
 
 					mb->set_pressed(true);
-					mb->set_button_index(2);
+					mb->set_button_index(BUTTON_RIGHT);
 					mb->set_doubleclick(true);
 				} break;
 				case WM_MBUTTONDBLCLK: {
 
 					mb->set_pressed(true);
-					mb->set_button_index(3);
+					mb->set_button_index(BUTTON_MIDDLE);
 					mb->set_doubleclick(true);
 				} break;
 				case WM_MOUSEWHEEL: {
@@ -681,7 +681,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				last_button_state |= (1 << (mb->get_button_index() - 1));
 			else
 				last_button_state &= ~(1 << (mb->get_button_index() - 1));
-			mb->set_button_mask(last_button_state);
+			mb->set_button_mask((ButtonList)last_button_state);
 
 			mb->set_position(Vector2(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
 
@@ -723,7 +723,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 					//send release for mouse wheel
 					Ref<InputEventMouseButton> mbd = mb->duplicate();
 					last_button_state &= ~(1 << (mbd->get_button_index() - 1));
-					mbd->set_button_mask(last_button_state);
+					mbd->set_button_mask((ButtonList)last_button_state);
 					mbd->set_pressed(false);
 					input->accumulate_input_event(mbd);
 				}
@@ -978,7 +978,7 @@ void OS_Windows::process_key_events() {
 					k->set_control(ke.control);
 					k->set_metakey(ke.meta);
 					k->set_pressed(true);
-					k->set_scancode(KeyMappingWindows::get_keysym(ke.wParam));
+					k->set_scancode((KeyList)KeyMappingWindows::get_keysym(ke.wParam));
 					k->set_unicode(ke.wParam);
 					if (k->get_unicode() && gr_mem) {
 						k->set_alt(false);
@@ -1010,7 +1010,7 @@ void OS_Windows::process_key_events() {
 					// Special case for Numpad Enter key
 					k->set_scancode(KEY_KP_ENTER);
 				} else {
-					k->set_scancode(KeyMappingWindows::get_keysym(ke.wParam));
+					k->set_scancode((KeyList)KeyMappingWindows::get_keysym(ke.wParam));
 				}
 
 				if (i + 1 < key_event_pos && key_event_buffer[i + 1].uMsg == WM_CHAR) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -199,7 +199,7 @@ public:
 	virtual void warp_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
 	void update_real_mouse_position();
-	virtual int get_mouse_button_state() const;
+	virtual ButtonList get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);
 
 	virtual void set_video_mode(const VideoMode &p_video_mode, int p_screen = 0);

--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -481,7 +481,7 @@ void JoypadLinux::process_joypads() {
 
 				switch (ev.type) {
 					case EV_KEY:
-						input->joy_button(i, joy->key_map[ev.code], ev.value);
+						input->joy_button(i, (JoystickList)joy->key_map[ev.code], ev.value);
 						break;
 
 					case EV_ABS:
@@ -525,7 +525,7 @@ void JoypadLinux::process_joypads() {
 		for (int j = 0; j < MAX_ABS; j++) {
 			int index = joy->abs_map[j];
 			if (index != -1) {
-				input->joy_axis(i, index, joy->curr_axis[index]);
+				input->joy_axis(i, (JoystickList)index, joy->curr_axis[index]);
 			}
 		}
 		if (len == 0 || (len < 0 && errno != EAGAIN)) {

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -910,8 +910,8 @@ OS::MouseMode OS_X11::get_mouse_mode() const {
 	return mouse_mode;
 }
 
-int OS_X11::get_mouse_button_state() const {
-	return last_button_state;
+ButtonList OS_X11::get_mouse_button_state() const {
+	return (ButtonList)last_button_state;
 }
 
 Point2 OS_X11::get_mouse_position() const {
@@ -1559,9 +1559,9 @@ void OS_X11::get_key_modifier_state(unsigned int p_x11_state, Ref<InputEventWith
 	state->set_metakey((p_x11_state & Mod4Mask));
 }
 
-unsigned int OS_X11::get_mouse_button_state(unsigned int p_x11_button, int p_x11_type) {
+ButtonList OS_X11::get_mouse_button_state(ButtonList p_x11_button, int p_x11_type) {
 
-	unsigned int mask = 1 << (p_x11_button - 1);
+	unsigned int mask = 1 << ((int)p_x11_button - 1);
 
 	if (p_x11_type == ButtonPress) {
 		last_button_state |= mask;
@@ -1569,7 +1569,7 @@ unsigned int OS_X11::get_mouse_button_state(unsigned int p_x11_button, int p_x11
 		last_button_state &= ~mask;
 	}
 
-	return last_button_state;
+	return (ButtonList)last_button_state;
 }
 
 void OS_X11::handle_key_event(XKeyEvent *p_event, bool p_echo) {
@@ -1650,7 +1650,7 @@ void OS_X11::handle_key_event(XKeyEvent *p_event, bool p_echo) {
 
 				k->set_pressed(keypress);
 
-				k->set_scancode(keycode);
+				k->set_scancode((KeyList)keycode);
 
 				k->set_echo(false);
 
@@ -1768,7 +1768,7 @@ void OS_X11::handle_key_event(XKeyEvent *p_event, bool p_echo) {
 	if (keycode >= 'a' && keycode <= 'z')
 		keycode -= 'a' - 'A';
 
-	k->set_scancode(keycode);
+	k->set_scancode((KeyList)keycode);
 	k->set_unicode(unicode);
 	k->set_echo(p_echo);
 
@@ -2128,11 +2128,11 @@ void OS_X11::process_xevents() {
 				mb.instance();
 
 				get_key_modifier_state(event.xbutton.state, mb);
-				mb->set_button_index(event.xbutton.button);
-				if (mb->get_button_index() == 2)
-					mb->set_button_index(3);
-				else if (mb->get_button_index() == 3)
-					mb->set_button_index(2);
+				mb->set_button_index((ButtonList)event.xbutton.button);
+				if (mb->get_button_index() == BUTTON_RIGHT)
+					mb->set_button_index(BUTTON_MIDDLE);
+				else if (mb->get_button_index() == BUTTON_MIDDLE)
+					mb->set_button_index(BUTTON_RIGHT);
 				mb->set_button_mask(get_mouse_button_state(mb->get_button_index(), event.xbutton.type));
 				mb->set_position(Vector2(event.xbutton.x, event.xbutton.y));
 				mb->set_global_position(mb->get_position());

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -142,7 +142,7 @@ class OS_X11 : public OS_Unix {
 
 	bool refresh_device_info();
 
-	unsigned int get_mouse_button_state(unsigned int p_x11_button, int p_x11_type);
+	ButtonList get_mouse_button_state(ButtonList p_x11_button, int p_x11_type);
 	void get_key_modifier_state(unsigned int p_x11_state, Ref<InputEventWithModifiers> state);
 	void flush_mouse_motion();
 
@@ -226,7 +226,7 @@ public:
 
 	virtual void warp_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
-	virtual int get_mouse_button_state() const;
+	virtual ButtonList get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);
 
 	virtual void set_icon(const Ref<Image> &p_icon);

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -217,7 +217,7 @@ void ARVRController::_notification(int p_what) {
 					// check button states
 					for (int i = 0; i < 16; i++) {
 						bool was_pressed = (button_states & mask) == mask;
-						bool is_pressed = Input::get_singleton()->is_joy_button_pressed(joy_id, i);
+						bool is_pressed = Input::get_singleton()->is_joy_button_pressed(joy_id, (JoystickList)i);
 
 						if (!was_pressed && is_pressed) {
 							emit_signal("button_pressed", i);
@@ -299,7 +299,7 @@ int ARVRController::get_joystick_id() const {
 	return tracker->get_joy_id();
 };
 
-int ARVRController::is_button_pressed(int p_button) const {
+int ARVRController::is_button_pressed(JoystickList p_button) const {
 	int joy_id = get_joystick_id();
 	if (joy_id == -1) {
 		return false;
@@ -308,7 +308,7 @@ int ARVRController::is_button_pressed(int p_button) const {
 	return Input::get_singleton()->is_joy_button_pressed(joy_id, p_button);
 };
 
-float ARVRController::get_joystick_axis(int p_axis) const {
+float ARVRController::get_joystick_axis(JoystickList p_axis) const {
 	int joy_id = get_joystick_id();
 	if (joy_id == -1) {
 		return 0.0;

--- a/scene/3d/arvr_nodes.h
+++ b/scene/3d/arvr_nodes.h
@@ -86,8 +86,8 @@ public:
 	String get_controller_name(void) const;
 
 	int get_joystick_id() const;
-	int is_button_pressed(int p_button) const;
-	float get_joystick_axis(int p_axis) const;
+	int is_button_pressed(JoystickList p_button) const;
+	float get_joystick_axis(JoystickList p_axis) const;
 
 	real_t get_rumble() const;
 	void set_rumble(real_t p_rumble);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -133,6 +133,8 @@ void SpinBox::_gui_input(const Ref<InputEvent> &p_event) {
 					accept_event();
 				}
 			} break;
+			default:
+				break;
 		}
 	}
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2655,6 +2655,8 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 				v_scroll->set_value(v_scroll->get_value() + v_scroll->get_page() * b->get_factor() / 8);
 			} break;
+			default:
+				break;
 		}
 	}
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -419,7 +419,7 @@ void Viewport::_notification(int p_what) {
 						mm->set_shift(physics_last_mouse_state.shift);
 						mm->set_control(physics_last_mouse_state.control);
 						mm->set_metakey(physics_last_mouse_state.meta);
-						mm->set_button_mask(physics_last_mouse_state.mouse_mask);
+						mm->set_button_mask((ButtonList)physics_last_mouse_state.mouse_mask);
 						physics_picking_events.push_back(mm);
 					}
 				}
@@ -2558,7 +2558,7 @@ void Viewport::_drop_mouse_focus() {
 			mb.instance();
 			mb->set_position(c->get_local_mouse_position());
 			mb->set_global_position(c->get_local_mouse_position());
-			mb->set_button_index(i + 1);
+			mb->set_button_index((ButtonList)(i + 1));
 			mb->set_pressed(false);
 			c->call_multilevel(SceneStringNames::get_singleton()->_gui_input, mb);
 		}
@@ -2644,7 +2644,7 @@ void Viewport::_post_gui_grab_click_focus() {
 				//send unclic
 
 				mb->set_position(click);
-				mb->set_button_index(i + 1);
+				mb->set_button_index((ButtonList)(i + 1));
 				mb->set_pressed(false);
 				gui.mouse_focus->call_multilevel(SceneStringNames::get_singleton()->_gui_input, mb);
 			}
@@ -2664,7 +2664,7 @@ void Viewport::_post_gui_grab_click_focus() {
 				//send clic
 
 				mb->set_position(click);
-				mb->set_button_index(i + 1);
+				mb->set_button_index((ButtonList)(i + 1));
 				mb->set_pressed(true);
 				gui.mouse_focus->call_deferred(SceneStringNames::get_singleton()->_gui_input, mb);
 			}


### PR DESCRIPTION
As discussed in #16388

I only made platform dependent changes for Windows, so build is expected to fail on other platforms.

I don't know whether this change is correct or not, but as #16388 has been sitting there without response I though I at least could make a proposal to be reviewed.

The main motivation for this is that in C# casting a enum to `int` has to be explicit, making it an annoyance.
