### PR TITLE
Added method to retrieve a direction vector from one point to another

### DIFF
--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -65,6 +65,7 @@ struct Vector2 {
 	real_t distance_squared_to(const Vector2 &p_vector2) const;
 	real_t angle_to(const Vector2 &p_vector2) const;
 	real_t angle_to_point(const Vector2 &p_vector2) const;
+	_FORCE_INLINE_ Vector2 direction_to(const Vector2 &p_b) const;
 
 	real_t dot(const Vector2 &p_other) const;
 	real_t cross(const Vector2 &p_other) const;
@@ -234,6 +235,12 @@ Vector2 Vector2::slerp(const Vector2 &p_b, real_t p_t) const {
 #endif
 	real_t theta = angle_to(p_b);
 	return rotated(theta * p_t);
+}
+
+Vector2 Vector2::direction_to(const Vector2 &p_b) const {
+	Vector2 ret(p_b.x - x, p_b.y - y);
+	ret.normalize();
+	return ret;
 }
 
 Vector2 Vector2::linear_interpolate(const Vector2 &p_a, const Vector2 &p_b, real_t p_t) {

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -112,6 +112,7 @@ struct Vector3 {
 	_FORCE_INLINE_ Vector3 project(const Vector3 &p_b) const;
 
 	_FORCE_INLINE_ real_t angle_to(const Vector3 &p_b) const;
+	_FORCE_INLINE_ Vector3 direction_to(const Vector3 &p_b) const;
 
 	_FORCE_INLINE_ Vector3 slide(const Vector3 &p_normal) const;
 	_FORCE_INLINE_ Vector3 bounce(const Vector3 &p_normal) const;
@@ -242,6 +243,12 @@ Vector3 Vector3::project(const Vector3 &p_b) const {
 real_t Vector3::angle_to(const Vector3 &p_b) const {
 
 	return Math::atan2(cross(p_b).length(), dot(p_b));
+}
+
+Vector3 Vector3::direction_to(const Vector3 &p_b) const {
+	Vector3 ret(p_b.x - x, p_b.y - y, p_b.z - z);
+	ret.normalize();
+	return ret;
 }
 
 /* Operators */

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -341,6 +341,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1R(Vector2, project);
 	VCALL_LOCALMEM1R(Vector2, angle_to);
 	VCALL_LOCALMEM1R(Vector2, angle_to_point);
+	VCALL_LOCALMEM1R(Vector2, direction_to);
 	VCALL_LOCALMEM2R(Vector2, linear_interpolate);
 	VCALL_LOCALMEM2R(Vector2, slerp);
 	VCALL_LOCALMEM4R(Vector2, cubic_interpolate);
@@ -397,6 +398,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1R(Vector3, distance_squared_to);
 	VCALL_LOCALMEM1R(Vector3, project);
 	VCALL_LOCALMEM1R(Vector3, angle_to);
+	VCALL_LOCALMEM1R(Vector3, direction_to);
 	VCALL_LOCALMEM1R(Vector3, slide);
 	VCALL_LOCALMEM1R(Vector3, bounce);
 	VCALL_LOCALMEM1R(Vector3, reflect);
@@ -1554,6 +1556,7 @@ void register_variant_methods() {
 	ADDFUNC0R(VECTOR2, REAL, Vector2, angle, varray());
 	ADDFUNC0R(VECTOR2, REAL, Vector2, length_squared, varray());
 	ADDFUNC0R(VECTOR2, BOOL, Vector2, is_normalized, varray());
+	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, direction_to, VECTOR2, "b", varray());
 	ADDFUNC1R(VECTOR2, REAL, Vector2, distance_to, VECTOR2, "to", varray());
 	ADDFUNC1R(VECTOR2, REAL, Vector2, distance_squared_to, VECTOR2, "to", varray());
 	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, project, VECTOR2, "b", varray());
@@ -1602,6 +1605,7 @@ void register_variant_methods() {
 	ADDFUNC2R(VECTOR3, VECTOR3, Vector3, linear_interpolate, VECTOR3, "b", REAL, "t", varray());
 	ADDFUNC2R(VECTOR3, VECTOR3, Vector3, slerp, VECTOR3, "b", REAL, "t", varray());
 	ADDFUNC4R(VECTOR3, VECTOR3, Vector3, cubic_interpolate, VECTOR3, "b", VECTOR3, "pre_a", VECTOR3, "post_b", REAL, "t", varray());
+	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, direction_to, VECTOR3, "b", varray());
 	ADDFUNC1R(VECTOR3, REAL, Vector3, dot, VECTOR3, "b", varray());
 	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, cross, VECTOR3, "b", varray());
 	ADDFUNC1R(VECTOR3, BASIS, Vector3, outer, VECTOR3, "b", varray());

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -112,6 +112,15 @@
 				Cubicly interpolates between this vector and [code]b[/code] using [code]pre_a[/code] and [code]post_b[/code] as handles, and returns the result at position [code]t[/code]. [code]t[/code] is in the range of [code]0.0 - 1.0[/code], representing the amount of interpolation.
 			</description>
 		</method>
+		<method name="direction_to">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="b" type="Vector2">
+			</argument>
+			<description>
+				Returns the normalized vector pointing from this vector to [code]b[/code].
+			</description>
+		</method>
 		<method name="distance_squared_to">
 			<return type="float">
 			</return>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -81,6 +81,15 @@
 				Performs a cubic interpolation between vectors [code]pre_a[/code], [code]a[/code], [code]b[/code], [code]post_b[/code] ([code]a[/code] is current), by the given amount [code]t[/code]. [code]t[/code] is in the range of [code]0.0 - 1.0[/code], representing the amount of interpolation.
 			</description>
 		</method>
+		<method name="direction_to">
+			<return type="Vector3">
+			</return>
+			<argument index="0" name="b" type="Vector3">
+			</argument>
+			<description>
+				Returns the normalized vector pointing from this vector to [code]b[/code].
+			</description>
+		</method>
 		<method name="distance_squared_to">
 			<return type="float">
 			</return>

--- a/modules/mono/glue/Managed/Files/Vector2.cs
+++ b/modules/mono/glue/Managed/Files/Vector2.cs
@@ -132,6 +132,11 @@ namespace Godot
                                 (-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3);
         }
 
+        public Vector2 DirectionTo(Vector2 b)
+        {
+            return new Vector2(b.x - x, b.y - y).Normalized();
+        }
+
         public real_t DistanceSquaredTo(Vector2 to)
         {
             return (x - to.x) * (x - to.x) + (y - to.y) * (y - to.y);

--- a/modules/mono/glue/Managed/Files/Vector3.cs
+++ b/modules/mono/glue/Managed/Files/Vector3.cs
@@ -126,6 +126,11 @@ namespace Godot
                     );
         }
 
+        public Vector3 DirectionTo(Vector3 b)
+        {
+            return new Vector3(b.x - x, b.y - y, b.z - z).Normalized();
+        }
+
         public real_t DistanceSquaredTo(Vector3 b)
         {
             return (b - this).LengthSquared();


### PR DESCRIPTION
I found its kinda a useful math operation. Direction from vector `a` to vector `b` is : `(b - a).normalized`  so the proposal is to modify it to `a.direction_to(b)` - I think it looks more ellegant and understandable(for newbies especially) than writing it in current form.  I've added it to both Vector2 and Vector3.