### PR TITLE
Fix audio stream player process

### DIFF
--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -103,7 +103,7 @@ void AudioStreamPlayer::_mix_audio() {
 		if (stream_stop) {
 			stream_playback->stop();
 			active = false;
-			set_process_internal(false);
+			set_physics_process_internal(false);
 		}
 		return;
 	}
@@ -136,7 +136,7 @@ void AudioStreamPlayer::_notification(int p_what) {
 
 		if (!active || (setseek < 0 && !stream_playback->is_playing())) {
 			active = false;
-			set_process_internal(false);
+			set_physics_process_internal(false);
 			emit_signal("finished");
 		}
 	}
@@ -212,7 +212,7 @@ void AudioStreamPlayer::play(float p_from_pos) {
 		stream_stop = false;
 		setseek = p_from_pos;
 		active = true;
-		set_process_internal(true);
+		set_physics_process_internal(true);
 	}
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -409,9 +409,7 @@ void Node::set_physics_process_internal(bool p_process_internal) {
 	if (data.physics_process_internal == p_process_internal)
 		return;
 
-	data.physics_process_internal = p_process_internal;
-
-	if (data.physics_process_internal)
+	if (p_process_internal)
 		add_to_group("physics_process_internal", false);
 	else
 		remove_from_group("physics_process_internal");
@@ -812,9 +810,7 @@ void Node::set_process_internal(bool p_idle_process_internal) {
 	if (data.idle_process_internal == p_idle_process_internal)
 		return;
 
-	data.idle_process_internal = p_idle_process_internal;
-
-	if (data.idle_process_internal)
+	if (p_idle_process_internal)
 		add_to_group("idle_process_internal", false);
 	else
 		remove_from_group("idle_process_internal");


### PR DESCRIPTION
This PR fixes the behavior described by @Keetz in https://github.com/godotengine/godot/issues/27437

Audio stream player were using set_internal_process.
This could somehow cause unpredictability in other nodes using process such as animation players
and particle systems (in our test case they keep speeding up)
They have been changed to using set_physics_process_internal
(this is the case audio_stream_player_2d and audio_stream_player_3d)

Removed weird code in Node.set_process_internal (and set_physics_process_internal)
that sets the same property twice (and before actually removing/adding the node to the process group)