### PR TITLE
Replace hardcoded GrooveJoint2D bias with user provided bias

### DIFF
--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -299,9 +299,7 @@ bool GrooveJoint2DSW::setup(real_t p_step) {
 
 	Vector2 delta = (B->get_transform().get_origin() + rB) - (A->get_transform().get_origin() + rA);
 
-	// FIXME: We used to do this assignment and then override it with 0.001 right after. Investigate why.
-	//real_t _b = get_bias();
-	real_t _b = 0.001;
+	real_t _b = get_bias();
 	gbias = (delta * -(_b == 0 ? space->get_constraint_bias() : _b) * (1.0 / p_step)).clamped(get_max_bias());
 
 	// apply accumulated impulse


### PR DESCRIPTION
Use user provided bias instead of hardcoded bias for `GrooveJoint2D`.

There has been a FIXME in the source code... I assume the hardcoded bias has been the remains of some debugging session?

Using the user provided bias instead of the hardcoded one does fix the misbehaviour of the joint in the example project given in #27454, though.

Fixes #27454