### PR TITLE
EditorHelp: Improve enum ref resolving and add constant ref support

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -29,7 +29,7 @@
 			<argument index="0" name="with" type="AABB">
 			</argument>
 			<description>
-				Returns [code]true[/code] if this [code]AABB[/code] completely encloses another one.
+				Returns [code]true[/code] if this [AABB] completely encloses another one.
 			</description>
 		</method>
 		<method name="expand">
@@ -38,14 +38,14 @@
 			<argument index="0" name="to_point" type="Vector3">
 			</argument>
 			<description>
-				Returns this [code]AABB[/code] expanded to include a given point.
+				Returns this [AABB] expanded to include a given point.
 			</description>
 		</method>
 		<method name="get_area">
 			<return type="float">
 			</return>
 			<description>
-				Gets the area of the [code]AABB[/code].
+				Gets the area of the [AABB].
 			</description>
 		</method>
 		<method name="get_endpoint">
@@ -54,49 +54,49 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Gets the position of the 8 endpoints of the [code]AABB[/code] in space.
+				Gets the position of the 8 endpoints of the [AABB] in space.
 			</description>
 		</method>
 		<method name="get_longest_axis">
 			<return type="Vector3">
 			</return>
 			<description>
-				Returns the normalized longest axis of the [code]AABB[/code].
+				Returns the normalized longest axis of the [AABB].
 			</description>
 		</method>
 		<method name="get_longest_axis_index">
 			<return type="int">
 			</return>
 			<description>
-				Returns the index of the longest axis of the [code]AABB[/code] (according to [Vector3]::AXIS* enum).
+				Returns the index of the longest axis of the [AABB] (according to [Vector3]::AXIS* enum).
 			</description>
 		</method>
 		<method name="get_longest_axis_size">
 			<return type="float">
 			</return>
 			<description>
-				Returns the scalar length of the longest axis of the [code]AABB[/code].
+				Returns the scalar length of the longest axis of the [AABB].
 			</description>
 		</method>
 		<method name="get_shortest_axis">
 			<return type="Vector3">
 			</return>
 			<description>
-				Returns the normalized shortest axis of the [code]AABB[/code].
+				Returns the normalized shortest axis of the [AABB].
 			</description>
 		</method>
 		<method name="get_shortest_axis_index">
 			<return type="int">
 			</return>
 			<description>
-				Returns the index of the shortest axis of the [code]AABB[/code] (according to [Vector3]::AXIS* enum).
+				Returns the index of the shortest axis of the [AABB] (according to [Vector3]::AXIS* enum).
 			</description>
 		</method>
 		<method name="get_shortest_axis_size">
 			<return type="float">
 			</return>
 			<description>
-				Returns the scalar length of the shortest axis of the [code]AABB[/code].
+				Returns the scalar length of the shortest axis of the [AABB].
 			</description>
 		</method>
 		<method name="get_support">
@@ -114,21 +114,21 @@
 			<argument index="0" name="by" type="float">
 			</argument>
 			<description>
-				Returns a copy of the [code]AABB[/code] grown a given amount of units towards all the sides.
+				Returns a copy of the [AABB] grown a given amount of units towards all the sides.
 			</description>
 		</method>
 		<method name="has_no_area">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the [code]AABB[/code] is flat or empty.
+				Returns [code]true[/code] if the [AABB] is flat or empty.
 			</description>
 		</method>
 		<method name="has_no_surface">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the [code]AABB[/code] is empty.
+				Returns [code]true[/code] if the [AABB] is empty.
 			</description>
 		</method>
 		<method name="has_point">
@@ -137,7 +137,7 @@
 			<argument index="0" name="point" type="Vector3">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [code]AABB[/code] contains a point.
+				Returns [code]true[/code] if the [AABB] contains a point.
 			</description>
 		</method>
 		<method name="intersection">
@@ -146,7 +146,7 @@
 			<argument index="0" name="with" type="AABB">
 			</argument>
 			<description>
-				Returns the intersection between two [code]AABB[/code]. An empty AABB (size 0,0,0) is returned on failure.
+				Returns the intersection between two [AABB]. An empty AABB (size 0,0,0) is returned on failure.
 			</description>
 		</method>
 		<method name="intersects">
@@ -155,7 +155,7 @@
 			<argument index="0" name="with" type="AABB">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [code]AABB[/code] overlaps with another.
+				Returns [code]true[/code] if the [AABB] overlaps with another.
 			</description>
 		</method>
 		<method name="intersects_plane">
@@ -164,7 +164,7 @@
 			<argument index="0" name="plane" type="Plane">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [code]AABB[/code] is on both sides of a plane.
+				Returns [code]true[/code] if the [AABB] is on both sides of a plane.
 			</description>
 		</method>
 		<method name="intersects_segment">
@@ -175,7 +175,7 @@
 			<argument index="1" name="to" type="Vector3">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [code]AABB[/code] intersects the line segment between [code]from[/code] and [code]to[/code].
+				Returns [code]true[/code] if the [AABB] intersects the line segment between [code]from[/code] and [code]to[/code].
 			</description>
 		</method>
 		<method name="merge">

--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -4,9 +4,9 @@
 		Proxy texture for simple frame-based animations.
 	</brief_description>
 	<description>
-		[code]AnimatedTexture[/code] is a resource format for frame-based animations, where multiple textures can be chained automatically with a predefined delay for each frame. Unlike [AnimationPlayer] or [AnimatedSprite], it isn't a [Node], but has the advantage of being usable anywhere a [Texture] resource can be used, e.g. in a [TileSet].
+		[AnimatedTexture] is a resource format for frame-based animations, where multiple textures can be chained automatically with a predefined delay for each frame. Unlike [AnimationPlayer] or [AnimatedSprite], it isn't a [Node], but has the advantage of being usable anywhere a [Texture] resource can be used, e.g. in a [TileSet].
 		The playback of the animation is controlled by the [member fps] property as well as each frame's optional delay (see [method set_frame_delay]). The animation loops, i.e. it will restart at frame 0 automatically after playing the last frame.
-		[code]AnimatedTexture[/code] currently requires all frame textures to have the same size, otherwise the bigger ones will be cropped to match the smallest one.
+		[AnimatedTexture] currently requires all frame textures to have the same size, otherwise the bigger ones will be cropped to match the smallest one.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -73,7 +73,7 @@
 	</members>
 	<constants>
 		<constant name="MAX_FRAMES" value="256">
-			The maximum number of frames supported by [code]AnimatedTexture[/code]. If you need more frames in your animation, use [AnimationPlayer] or [AnimatedSprite].
+			The maximum number of frames supported by [AnimatedTexture]. If you need more frames in your animation, use [AnimationPlayer] or [AnimatedSprite].
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -57,7 +57,7 @@
 			<return type="void">
 			</return>
 			<description>
-				[code]AnimationPlayer[/code] caches animated nodes. It may not notice if a node disappears, so clear_caches forces it to update the cache again.
+				[AnimationPlayer] caches animated nodes. It may not notice if a node disappears, so clear_caches forces it to update the cache again.
 			</description>
 		</method>
 		<method name="clear_queue">
@@ -122,7 +122,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [code]AnimationPlayer[/code] stores an [Animation] with key [code]name[/code].
+				Returns [code]true[/code] if the [AnimationPlayer] stores an [Animation] with key [code]name[/code].
 			</description>
 		</method>
 		<method name="is_playing" qualifiers="const">

--- a/doc/classes/AnimationTreePlayer.xml
+++ b/doc/classes/AnimationTreePlayer.xml
@@ -38,7 +38,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
-				Returns the [AnimationPlayer]'s [Animation] bound to the [code]AnimationTreePlayer[/code]'s animation node with name [code]id[/code].
+				Returns the [AnimationPlayer]'s [Animation] bound to the [AnimationTreePlayer]'s animation node with name [code]id[/code].
 			</description>
 		</method>
 		<method name="animation_node_get_master_animation" qualifiers="const">
@@ -66,7 +66,7 @@
 			<argument index="1" name="animation" type="Animation">
 			</argument>
 			<description>
-				Binds a new [Animation] from the [member master_player] to the [code]AnimationTreePlayer[/code]'s animation node with name [code]id[/code].
+				Binds a new [Animation] from the [member master_player] to the [AnimationTreePlayer]'s animation node with name [code]id[/code].
 			</description>
 		</method>
 		<method name="animation_node_set_filter_path">
@@ -472,7 +472,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Resets this [code]AnimationTreePlayer[/code].
+				Resets this [AnimationTreePlayer].
 			</description>
 		</method>
 		<method name="timescale_node_get_scale" qualifiers="const">
@@ -607,14 +607,14 @@
 	</methods>
 	<members>
 		<member name="active" type="bool" setter="set_active" getter="is_active">
-			If [code]true[/code], the [code]AnimationTreePlayer[/code] is able to play animations. Default value: [code]false[/code].
+			If [code]true[/code], the [AnimationTreePlayer] is able to play animations. Default value: [code]false[/code].
 		</member>
 		<member name="base_path" type="NodePath" setter="set_base_path" getter="get_base_path">
 			The node from which to relatively access other nodes. Default value: [code]".."[/code].
 			It accesses the Bones, so it should point to the same Node the AnimationPlayer would point its Root Node at.
 		</member>
 		<member name="master_player" type="NodePath" setter="set_master_player" getter="get_master_player">
-			The path to the [AnimationPlayer] from which this [code]AnimationTreePlayer[/code] binds animations to animation nodes.
+			The path to the [AnimationPlayer] from which this [AnimationTreePlayer] binds animations to animation nodes.
 			Once set, Animation nodes can be added to the AnimationTreePlayer.
 		</member>
 		<member name="playback_process_mode" type="int" setter="set_animation_process_mode" getter="get_animation_process_mode" enum="AnimationTreePlayer.AnimationProcessMode">

--- a/doc/classes/Area.xml
+++ b/doc/classes/Area.xml
@@ -33,7 +33,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Returns a list of intersecting [code]Area[/code]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
+				Returns a list of intersecting [Area]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
 		<method name="get_overlapping_bodies" qualifiers="const">
@@ -69,7 +69,7 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
-				Set/clear individual bits on the layer mask. This simplifies editing this [code]Area[/code]'s layers.
+				Set/clear individual bits on the layer mask. This simplifies editing this [Area]'s layers.
 			</description>
 		</method>
 		<method name="set_collision_mask_bit">
@@ -80,7 +80,7 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
-				Set/clear individual bits on the collision mask. This simplifies editing which [code]Area[/code] layers this [code]Area[/code] scans.
+				Set/clear individual bits on the collision mask. This simplifies editing which [Area] layers this [Area] scans.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -33,7 +33,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Returns a list of intersecting [code]Area2D[/code]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
+				Returns a list of intersecting [Area2D]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
 		<method name="get_overlapping_bodies" qualifiers="const">

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 	</brief_description>
 	<description>
-		The [code]ArrayMesh[/code] is used to construct a [Mesh] by specifying the attributes as arrays. The most basic example is the creation of a single triangle
+		The [ArrayMesh] is used to construct a [Mesh] by specifying the attributes as arrays. The most basic example is the creation of a single triangle
 		[codeblock]
 		var vertices = PoolVector3Array()
 		vertices.push_back(Vector3(0, 1, 0))
@@ -57,14 +57,14 @@
 			<return type="void">
 			</return>
 			<description>
-				Remove all blend shapes from this [code]ArrayMesh[/code].
+				Remove all blend shapes from this [ArrayMesh].
 			</description>
 		</method>
 		<method name="get_blend_shape_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the number of blend shapes that the [code]ArrayMesh[/code] holds.
+				Returns the number of blend shapes that the [ArrayMesh] holds.
 			</description>
 		</method>
 		<method name="get_blend_shape_name" qualifiers="const">
@@ -84,14 +84,14 @@
 			<argument index="1" name="texel_size" type="float">
 			</argument>
 			<description>
-				Will perform a UV unwrap on the [code]ArrayMesh[/code] to prepare the mesh for lightmapping.
+				Will perform a UV unwrap on the [ArrayMesh] to prepare the mesh for lightmapping.
 			</description>
 		</method>
 		<method name="regen_normalmaps">
 			<return type="void">
 			</return>
 			<description>
-				Will regenerate normal maps for the [code]ArrayMesh[/code].
+				Will regenerate normal maps for the [ArrayMesh].
 			</description>
 		</method>
 		<method name="surface_find_by_name" qualifiers="const">
@@ -100,7 +100,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				Return the index of the first surface with this name held within this [code]ArrayMesh[/code]. If none are found -1 is returned.
+				Return the index of the first surface with this name held within this [ArrayMesh]. If none are found -1 is returned.
 			</description>
 		</method>
 		<method name="surface_get_array_index_len" qualifiers="const">

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -48,7 +48,7 @@
 		</member>
 		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask">
 			Binary mask to choose which mouse buttons this button will respond to.
-			To allow both left-click and right-click, set this to 3, because it's BUTTON_MASK_LEFT | BUTTON_MASK_RIGHT.
+			To allow both left-click and right-click, use [code]BUTTON_MASK_LEFT | BUTTON_MASK_RIGHT[/code].
 		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled">
 			If [code]true[/code], the button is in disabled state and can't be clicked or toggled.

--- a/doc/classes/BitmapFont.xml
+++ b/doc/classes/BitmapFont.xml
@@ -38,7 +38,7 @@
 			<argument index="2" name="kerning" type="int">
 			</argument>
 			<description>
-				Adds a kerning pair to the [code]BitmapFont[/code] as a difference. Kerning pairs are special cases where a typeface advance is determined by the next character.
+				Adds a kerning pair to the [BitmapFont] as a difference. Kerning pairs are special cases where a typeface advance is determined by the next character.
 			</description>
 		</method>
 		<method name="add_texture">
@@ -47,7 +47,7 @@
 			<argument index="0" name="texture" type="Texture">
 			</argument>
 			<description>
-				Adds a texture to the [code]BitmapFont[/code].
+				Adds a texture to the [BitmapFont].
 			</description>
 		</method>
 		<method name="clear">

--- a/doc/classes/ButtonGroup.xml
+++ b/doc/classes/ButtonGroup.xml
@@ -16,7 +16,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Returns an [Array] of [Button]s who have this as their [code]ButtonGroup[/code] (see [member BaseButton.group]).
+				Returns an [Array] of [Button]s who have this as their [ButtonGroup] (see [member BaseButton.group]).
 			</description>
 		</method>
 		<method name="get_pressed_button">

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -23,7 +23,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Removes any [code]Camera2D[/code] from the ancestor [Viewport]'s internal currently-assigned camera.
+				Removes any [Camera2D] from the ancestor [Viewport]'s internal currently-assigned camera.
 			</description>
 		</method>
 		<method name="force_update_scroll">
@@ -44,7 +44,7 @@
 			<return type="Vector2">
 			</return>
 			<description>
-				Returns the location of the [code]Camera2D[/code]'s screen-center, relative to the origin.
+				Returns the location of the [Camera2D]'s screen-center, relative to the origin.
 			</description>
 		</method>
 		<method name="make_current">
@@ -71,7 +71,7 @@
 			If [code]true[/code], the camera is the active camera for the current scene. Only one camera can be current, so setting a different camera [code]current[/code] will disable this one.
 		</member>
 		<member name="custom_viewport" type="Node" setter="set_custom_viewport" getter="get_custom_viewport">
-			The custom [Viewport] node attached to the [code]Camera2D[/code]. If null or not a [Viewport], uses the default viewport instead.
+			The custom [Viewport] node attached to the [Camera2D]. If null or not a [Viewport], uses the default viewport instead.
 		</member>
 		<member name="drag_margin_bottom" type="float" setter="set_drag_margin" getter="get_drag_margin">
 			Bottom margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the edge of the screen.

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -510,16 +510,16 @@
 	</methods>
 	<members>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask">
-			The rendering layers in which this [code]CanvasItem[/code] responds to [Light2D] nodes. Default value: [code]1[/code].
+			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes. Default value: [code]1[/code].
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
-			The material applied to textures on this [code]CanvasItem[/code]. Default value: [code]null[/code].
+			The material applied to textures on this [CanvasItem]. Default value: [code]null[/code].
 		</member>
 		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate">
-			The color applied to textures on this [code]CanvasItem[/code]. Default value: [code]Color(1, 1, 1, 1)[/code] (opaque "white").
+			The color applied to textures on this [CanvasItem]. Default value: [code]Color(1, 1, 1, 1)[/code] (opaque "white").
 		</member>
 		<member name="self_modulate" type="Color" setter="set_self_modulate" getter="get_self_modulate">
-			The color applied to textures on this [code]CanvasItem[/code]. This is not inherited by children [code]CanvasItem[/code]s. Default value: [code]Color(1, 1, 1, 1)[/code] (opaque "white")..
+			The color applied to textures on this [CanvasItem]. This is not inherited by children [CanvasItem]s. Default value: [code]Color(1, 1, 1, 1)[/code] (opaque "white")..
 		</member>
 		<member name="show_behind_parent" type="bool" setter="set_draw_behind_parent" getter="is_draw_behind_parent_enabled">
 			If [code]true[/code], the object draws behind its parent. Default value: [code]false[/code].
@@ -528,10 +528,10 @@
 			If [code]true[/code], the object draws on top of its parent. Default value: [code]true[/code].
 		</member>
 		<member name="use_parent_material" type="bool" setter="set_use_parent_material" getter="get_use_parent_material">
-			If [code]true[/code], the parent [code]CanvasItem[/code]'s [member material] property is used as this one's material. Default value: [code]false[/code].
+			If [code]true[/code], the parent [CanvasItem]'s [member material] property is used as this one's material. Default value: [code]false[/code].
 		</member>
 		<member name="visible" type="bool" setter="set_visible" getter="is_visible">
-			If [code]true[/code], this [code]CanvasItem[/code] is drawn. Default value: [code]true[/code]. For controls that inherit [Popup], the correct way to make them visible is to call one of the multiple popup*() functions instead.
+			If [code]true[/code], this [CanvasItem] is drawn. Default value: [code]true[/code]. For controls that inherit [Popup], the correct way to make them visible is to call one of the multiple popup*() functions instead.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/CanvasItemMaterial.xml
+++ b/doc/classes/CanvasItemMaterial.xml
@@ -4,7 +4,7 @@
 		A material for [CanvasItem]s.
 	</brief_description>
 	<description>
-		[code]CanvasItemMaterial[/code]s provide a means of modifying the textures associated with a CanvasItem. They specialize in describing blend and lighting behaviors for textures. Use a [ShaderMaterial] to more fully customize a material's interactions with a [CanvasItem].
+		[CanvasItemMaterial]s provide a means of modifying the textures associated with a CanvasItem. They specialize in describing blend and lighting behaviors for textures. Use a [ShaderMaterial] to more fully customize a material's interactions with a [CanvasItem].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -4,7 +4,7 @@
 		Canvas drawing layer.
 	</brief_description>
 	<description>
-		Canvas drawing layer. [CanvasItem] nodes that are direct or indirect children of a [code]CanvasLayer[/code] will be drawn in that layer. The layer is a numeric index that defines the draw order. The default 2D scene renders with index 0, so a [code]CanvasLayer[/code] with index -1 will be drawn below, and one with index 1 will be drawn above. This is very useful for HUDs (in layer 1+ or above), or backgrounds (in layer -1 or below).
+		Canvas drawing layer. [CanvasItem] nodes that are direct or indirect children of a [CanvasLayer] will be drawn in that layer. The layer is a numeric index that defines the draw order. The default 2D scene renders with index 0, so a [CanvasLayer] with index -1 will be drawn below, and one with index 1 will be drawn above. This is very useful for HUDs (in layer 1+ or above), or backgrounds (in layer -1 or below).
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/2d/2d_transforms.html</link>
@@ -23,7 +23,7 @@
 	</methods>
 	<members>
 		<member name="custom_viewport" type="Node" setter="set_custom_viewport" getter="get_custom_viewport">
-			The custom [Viewport] node assigned to the [code]CanvasLayer[/code]. If null, uses the default viewport instead.
+			The custom [Viewport] node assigned to the [CanvasLayer]. If null, uses the default viewport instead.
 		</member>
 		<member name="layer" type="int" setter="set_layer" getter="get_layer">
 			Layer index for draw order. Lower values are drawn first. Default value: [code]1[/code].

--- a/doc/classes/CanvasModulate.xml
+++ b/doc/classes/CanvasModulate.xml
@@ -4,7 +4,7 @@
 		Tint the entire canvas.
 	</brief_description>
 	<description>
-		[code]CanvasModulate[/code] tints the canvas elements using its assigned [code]color[/code].
+		[CanvasModulate] tints the canvas elements using its assigned [code]color[/code].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CenterContainer.xml
+++ b/doc/classes/CenterContainer.xml
@@ -14,7 +14,7 @@
 	</methods>
 	<members>
 		<member name="use_top_left" type="bool" setter="set_use_top_left" getter="is_using_top_left">
-			If [code]true[/code], centers children relative to the [code]CenterContainer[/code]'s top left corner. Default value: [code]false[/code].
+			If [code]true[/code], centers children relative to the [CenterContainer]'s top left corner. Default value: [code]false[/code].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/CollisionObject.xml
+++ b/doc/classes/CollisionObject.xml
@@ -183,7 +183,7 @@
 	</methods>
 	<members>
 		<member name="input_capture_on_drag" type="bool" setter="set_capture_input_on_drag" getter="get_capture_input_on_drag">
-			If [code]true[/code], the [code]CollisionObject[/code] will continue to receive input events as the mouse is dragged across its shapes. Default value: [code]false[/code].
+			If [code]true[/code], the [CollisionObject] will continue to receive input events as the mouse is dragged across its shapes. Default value: [code]false[/code].
 		</member>
 		<member name="input_ray_pickable" type="bool" setter="set_ray_pickable" getter="is_ray_pickable">
 			If [code]true[/code], the [CollisionObject]'s shapes will respond to [RayCast]s. Default value: [code]true[/code].

--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -70,7 +70,7 @@
 			<argument index="0" name="owner_id" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if collisions for the shape owner originating from this [code]CollisionObject2D[/code] will not be reported to collided with [code]CollisionObject2D[/code]s.
+				Returns [code]true[/code] if collisions for the shape owner originating from this [CollisionObject2D] will not be reported to collided with [CollisionObject2D]s.
 			</description>
 		</method>
 		<method name="remove_shape_owner">
@@ -190,7 +190,7 @@
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
-				If [code]enable[/code] is [code]true[/code], collisions for the shape owner originating from this [code]CollisionObject2D[/code] will not be reported to collided with [code]CollisionObject2D[/code]s.
+				If [code]enable[/code] is [code]true[/code], collisions for the shape owner originating from this [CollisionObject2D] will not be reported to collided with [CollisionObject2D]s.
 			</description>
 		</method>
 		<method name="shape_owner_set_one_way_collision_margin">

--- a/doc/classes/ConcavePolygonShape2D.xml
+++ b/doc/classes/ConcavePolygonShape2D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Concave polygon 2D shape resource for physics. It is made out of segments and is very optimal for complex polygonal concave collisions. It is really not advised to use for [RigidBody2D] nodes. A CollisionPolygon2D in convex decomposition mode (solids) or several convex objects are advised for that instead. Otherwise, a concave polygon 2D shape is better for static collisions.
-		The main difference between a [ConvexPolygonShape2D] and a [code]ConcavePolygonShape2D[/code] is that a concave polygon assumes it is concave and uses a more complex method of collision detection, and a convex one forces itself to be convex in order to speed up collision detection.
+		The main difference between a [ConvexPolygonShape2D] and a [ConcavePolygonShape2D] is that a concave polygon assumes it is concave and uses a more complex method of collision detection, and a convex one forces itself to be convex in order to speed up collision detection.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -15,7 +15,7 @@
 	</methods>
 	<members>
 		<member name="segments" type="PoolVector2Array" setter="set_segments" getter="get_segments">
-			The array of points that make up the [code]ConcavePolygonShape2D[/code]'s line segments.
+			The array of points that make up the [ConcavePolygonShape2D]'s line segments.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ConeTwistJoint.xml
+++ b/doc/classes/ConeTwistJoint.xml
@@ -28,7 +28,7 @@
 		<member name="swing_span" type="float" setter="_set_swing_span" getter="_get_swing_span">
 			Swing is rotation from side to side, around the axis perpendicular to the twist axis.
 			The swing span defines, how much rotation will not get corrected allong the swing axis.
-			Could be defined as looseness in the [code]ConeTwistJoint[/code].
+			Could be defined as looseness in the [ConeTwistJoint].
 			If below 0.05, this behaviour is locked. Default value: [code]PI/4[/code].
 		</member>
 		<member name="twist_span" type="float" setter="_set_twist_span" getter="_get_twist_span">
@@ -40,7 +40,7 @@
 		<constant name="PARAM_SWING_SPAN" value="0" enum="Param">
 			Swing is rotation from side to side, around the axis perpendicular to the twist axis.
 			The swing span defines, how much rotation will not get corrected allong the swing axis.
-			Could be defined as looseness in the [code]ConeTwistJoint[/code].
+			Could be defined as looseness in the [ConeTwistJoint].
 			If below 0.05, this behaviour is locked. Default value: [code]PI/4[/code].
 		</constant>
 		<constant name="PARAM_TWIST_SPAN" value="1" enum="Param">

--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -4,7 +4,7 @@
 		Base node for containers.
 	</brief_description>
 	<description>
-		Base node for containers. A [code]Container[/code] contains other controls and automatically arranges them in a certain way.
+		Base node for containers. A [Container] contains other controls and automatically arranges them in a certain way.
 		A Control can inherit this to create custom container classes.
 	</description>
 	<tutorials>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -4,13 +4,13 @@
 		All User Interface nodes inherit from Control. A control's anchors and margins adapt its position and size relative to its parent.
 	</brief_description>
 	<description>
-		Base class for all User Interface or [i]UI[/i] related nodes. [code]Control[/code] features a bounding rectangle that defines its extents, an anchor position relative to its parent and margins that represent an offset to the anchor. The margins update automatically when the node, any of its parents, or the screen size change.
-		For more information on Godot's UI system, anchors, margins, and containers, see the related tutorials in the manual. To build flexible UIs, you'll need a mix of UI elements that inherit from [code]Control[/code] and [Container] nodes.
+		Base class for all User Interface or [i]UI[/i] related nodes. [Control] features a bounding rectangle that defines its extents, an anchor position relative to its parent and margins that represent an offset to the anchor. The margins update automatically when the node, any of its parents, or the screen size change.
+		For more information on Godot's UI system, anchors, margins, and containers, see the related tutorials in the manual. To build flexible UIs, you'll need a mix of UI elements that inherit from [Control] and [Container] nodes.
 		[b]User Interface nodes and input[/b]
 		Godot sends input events to the scene's root node first, by calling [method Node._input]. [method Node._input] forwards the event down the node tree to the nodes under the mouse cursor, or on keyboard focus. To do so, it calls [method MainLoop._input_event]. Call [method accept_event] so no other node receives the event. Once you accepted an input, it becomes handled so [method Node._unhandled_input] will not process it.
-		Only one [code]Control[/code] node can be in keyboard focus. Only the node in focus will receive keyboard events. To get the focus, call [method grab_focus]. [code]Control[/code] nodes lose focus when another node grabs it, or if you hide the node in focus.
-		Set [member mouse_filter] to [constant MOUSE_FILTER_IGNORE] to tell a [code]Control[/code] node to ignore mouse or touch events. You'll need it if you place an icon on top of a button.
-		[Theme] resources change the Control's appearance. If you change the [Theme] on a [code]Control[/code] node, it affects all of its children. To override some of the theme's parameters, call one of the [code]add_*_override[/code] methods, like [method add_font_override]. You can override the theme with the inspector.
+		Only one [Control] node can be in keyboard focus. Only the node in focus will receive keyboard events. To get the focus, call [method grab_focus]. [Control] nodes lose focus when another node grabs it, or if you hide the node in focus.
+		Set [member mouse_filter] to [constant MOUSE_FILTER_IGNORE] to tell a [Control] node to ignore mouse or touch events. You'll need it if you place an icon on top of a button.
+		[Theme] resources change the Control's appearance. If you change the [Theme] on a [Control] node, it affects all of its children. To override some of the theme's parameters, call one of the [code]add_*_override[/code] methods, like [method add_font_override]. You can override the theme with the inspector.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/gui/index.html</link>
@@ -632,16 +632,16 @@
 			The focus access mode for the control (None, Click or All). Only one Control can be focused at the same time, and it will receive keyboard signals.
 		</member>
 		<member name="focus_neighbour_bottom" type="NodePath" setter="set_focus_neighbour" getter="get_focus_neighbour">
-			Tells Godot which node it should give keyboard focus to if the user presses the down arrow on the keyboard or down on a gamepad by default. You can change the key by editing the [code]ui_down[/code] input action. The node must be a [code]Control[/code]. If this property is not set, Godot will give focus to the closest [code]Control[/code] to the bottom of this one.
+			Tells Godot which node it should give keyboard focus to if the user presses the down arrow on the keyboard or down on a gamepad by default. You can change the key by editing the [code]ui_down[/code] input action. The node must be a [Control]. If this property is not set, Godot will give focus to the closest [Control] to the bottom of this one.
 		</member>
 		<member name="focus_neighbour_left" type="NodePath" setter="set_focus_neighbour" getter="get_focus_neighbour">
-			Tells Godot which node it should give keyboard focus to if the user presses the left arrow on the keyboard or left on a gamepad by default. You can change the key by editing the [code]ui_left[/code] input action. The node must be a [code]Control[/code]. If this property is not set, Godot will give focus to the closest [code]Control[/code] to the left of this one.
+			Tells Godot which node it should give keyboard focus to if the user presses the left arrow on the keyboard or left on a gamepad by default. You can change the key by editing the [code]ui_left[/code] input action. The node must be a [Control]. If this property is not set, Godot will give focus to the closest [Control] to the left of this one.
 		</member>
 		<member name="focus_neighbour_right" type="NodePath" setter="set_focus_neighbour" getter="get_focus_neighbour">
-			Tells Godot which node it should give keyboard focus to if the user presses the right arrow on the keyboard or right on a gamepad  by default. You can change the key by editing the [code]ui_right[/code] input action. The node must be a [code]Control[/code]. If this property is not set, Godot will give focus to the closest [code]Control[/code] to the bottom of this one.
+			Tells Godot which node it should give keyboard focus to if the user presses the right arrow on the keyboard or right on a gamepad  by default. You can change the key by editing the [code]ui_right[/code] input action. The node must be a [Control]. If this property is not set, Godot will give focus to the closest [Control] to the bottom of this one.
 		</member>
 		<member name="focus_neighbour_top" type="NodePath" setter="set_focus_neighbour" getter="get_focus_neighbour">
-			Tells Godot which node it should give keyboard focus to if the user presses the top arrow on the keyboard or top on a gamepad by default. You can change the key by editing the [code]ui_top[/code] input action. The node must be a [code]Control[/code]. If this property is not set, Godot will give focus to the closest [code]Control[/code] to the bottom of this one.
+			Tells Godot which node it should give keyboard focus to if the user presses the top arrow on the keyboard or top on a gamepad by default. You can change the key by editing the [code]ui_top[/code] input action. The node must be a [Control]. If this property is not set, Godot will give focus to the closest [Control] to the bottom of this one.
 		</member>
 		<member name="focus_next" type="NodePath" setter="set_focus_next" getter="get_focus_next">
 			Tells Godot which node it should give keyboard focus to if the user presses Tab on a keyboard by default. You can change the key by editing the [code]ui_focus_next[/code] input action.
@@ -717,7 +717,7 @@
 			Tells the parent [Container] nodes how they should resize and place the node on the Y axis. Use one of the [code]SIZE_*[/code] constants to change the flags. See the constants to learn what each does.
 		</member>
 		<member name="theme" type="Theme" setter="set_theme" getter="get_theme">
-			Changing this property replaces the current [Theme] resource this node and all its [code]Control[/code] children use.
+			Changing this property replaces the current [Theme] resource this node and all its [Control] children use.
 		</member>
 	</members>
 	<signals>
@@ -745,7 +745,7 @@
 		</signal>
 		<signal name="modal_closed">
 			<description>
-				Emitted when a modal [code]Control[/code] is closed. See [method show_modal].
+				Emitted when a modal [Control] is closed. See [method show_modal].
 			</description>
 		</signal>
 		<signal name="mouse_entered">
@@ -903,7 +903,7 @@
 			Snap all 4 anchors to a horizontal line that cuts the parent control in half. Use with [method set_anchors_preset].
 		</constant>
 		<constant name="PRESET_WIDE" value="15" enum="LayoutPreset">
-			Snap all 4 anchors to the respective corners of the parent control. Set all 4 margins to 0 after you applied this preset and the [code]Control[/code] will fit its parent control. This is equivalent to to the "Full Rect" layout option in the editor. Use with [method set_anchors_preset].
+			Snap all 4 anchors to the respective corners of the parent control. Set all 4 margins to 0 after you applied this preset and the [Control] will fit its parent control. This is equivalent to to the "Full Rect" layout option in the editor. Use with [method set_anchors_preset].
 		</constant>
 		<constant name="PRESET_MODE_MINSIZE" value="0" enum="LayoutPresetMode">
 		</constant>

--- a/doc/classes/ConvexPolygonShape2D.xml
+++ b/doc/classes/ConvexPolygonShape2D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Convex Polygon Shape for 2D physics. A convex polygon, whatever its shape, is internally decomposed into as many convex polygons as needed to ensure all collision checks against it are always done on convex polygons (which are faster to check).
-		The main difference between a [code]ConvexPolygonShape2D[/code] and a [ConcavePolygonShape2D] is that a concave polygon assumes it is concave and uses a more complex method of collision detection, and a convex one forces itself to be convex in order to speed up collision detection.
+		The main difference between a [ConvexPolygonShape2D] and a [ConcavePolygonShape2D] is that a concave polygon assumes it is concave and uses a more complex method of collision detection, and a convex one forces itself to be convex in order to speed up collision detection.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CubeMap.xml
+++ b/doc/classes/CubeMap.xml
@@ -15,7 +15,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the [code]CubeMap[/code]'s height.
+				Returns the [CubeMap]'s height.
 			</description>
 		</method>
 		<method name="get_side" qualifiers="const">
@@ -24,14 +24,14 @@
 			<argument index="0" name="side" type="int" enum="CubeMap.Side">
 			</argument>
 			<description>
-				Returns an [Image] for a side of the [code]CubeMap[/code] using one of the [code]SIDE_*[/code] constants or an integer 0-5.
+				Returns an [Image] for a side of the [CubeMap] using one of the [code]SIDE_*[/code] constants or an integer 0-5.
 			</description>
 		</method>
 		<method name="get_width" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the [code]CubeMap[/code]'s width.
+				Returns the [CubeMap]'s width.
 			</description>
 		</method>
 		<method name="set_side">
@@ -42,48 +42,48 @@
 			<argument index="1" name="image" type="Image">
 			</argument>
 			<description>
-				Sets an [Image] for a side of the [code]CubeMap[/code] using one of the [code]SIDE_*[/code] constants or an integer 0-5.
+				Sets an [Image] for a side of the [CubeMap] using one of the [code]SIDE_*[/code] constants or an integer 0-5.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="flags" type="int" setter="set_flags" getter="get_flags">
-			The render flags for the [code]CubeMap[/code]. See the [code]FLAG_*[/code] constants for details.
+			The render flags for the [CubeMap]. See the [code]FLAG_*[/code] constants for details.
 		</member>
 		<member name="lossy_storage_quality" type="float" setter="set_lossy_storage_quality" getter="get_lossy_storage_quality">
-			The lossy storage quality of the [code]CubeMap[/code] if the storage mode is set to STORAGE_COMPRESS_LOSSY.
+			The lossy storage quality of the [CubeMap] if the storage mode is set to STORAGE_COMPRESS_LOSSY.
 		</member>
 		<member name="storage_mode" type="int" setter="set_storage" getter="get_storage" enum="CubeMap.Storage">
-			The [code]CubeMap[/code]'s storage mode. See [code]STORAGE_*[/code] constants.
+			The [CubeMap]'s storage mode. See [code]STORAGE_*[/code] constants.
 		</member>
 	</members>
 	<constants>
 		<constant name="STORAGE_RAW" value="0" enum="Storage">
-			Store the [code]CubeMap[/code] without any compression.
+			Store the [CubeMap] without any compression.
 		</constant>
 		<constant name="STORAGE_COMPRESS_LOSSY" value="1" enum="Storage">
-			Store the [code]CubeMap[/code] with strong compression that reduces image quality.
+			Store the [CubeMap] with strong compression that reduces image quality.
 		</constant>
 		<constant name="STORAGE_COMPRESS_LOSSLESS" value="2" enum="Storage">
-			Store the [code]CubeMap[/code] with moderate compression that doesn't reduce image quality.
+			Store the [CubeMap] with moderate compression that doesn't reduce image quality.
 		</constant>
 		<constant name="SIDE_LEFT" value="0" enum="Side">
-			Identifier for the left face of the [code]CubeMap[/code].
+			Identifier for the left face of the [CubeMap].
 		</constant>
 		<constant name="SIDE_RIGHT" value="1" enum="Side">
-			Identifier for the right face of the [code]CubeMap[/code].
+			Identifier for the right face of the [CubeMap].
 		</constant>
 		<constant name="SIDE_BOTTOM" value="2" enum="Side">
-			Identifier for the bottom face of the [code]CubeMap[/code].
+			Identifier for the bottom face of the [CubeMap].
 		</constant>
 		<constant name="SIDE_TOP" value="3" enum="Side">
-			Identifier for the top face of the [code]CubeMap[/code].
+			Identifier for the top face of the [CubeMap].
 		</constant>
 		<constant name="SIDE_FRONT" value="4" enum="Side">
-			Identifier for the front face of the [code]CubeMap[/code].
+			Identifier for the front face of the [CubeMap].
 		</constant>
 		<constant name="SIDE_BACK" value="5" enum="Side">
-			Identifier for the back face of the [code]CubeMap[/code].
+			Identifier for the back face of the [CubeMap].
 		</constant>
 		<constant name="FLAG_MIPMAPS" value="1" enum="Flags">
 			Generate mipmaps, to enable smooth zooming out of the texture.

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -60,7 +60,7 @@
 			<argument index="1" name="default" type="Variant" default="Null">
 			</argument>
 			<description>
-				Returns the current value for the specified key in the [code]Dictionary[/code]. If the key does not exist, the method returns the value of the optional default argument, or Null if it is omitted.
+				Returns the current value for the specified key in the [Dictionary]. If the key does not exist, the method returns the value of the optional default argument, or Null if it is omitted.
 			</description>
 		</method>
 		<method name="has">
@@ -92,7 +92,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Return the list of keys in the [code]Dictionary[/code].
+				Return the list of keys in the [Dictionary].
 			</description>
 		</method>
 		<method name="size">
@@ -106,7 +106,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Return the list of values in the [code]Dictionary[/code].
+				Return the list of values in the [Dictionary].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -15,7 +15,7 @@
 			<argument index="0" name="filter" type="String">
 			</argument>
 			<description>
-				Adds a comma-delimited file extension filter option to the [code]EditorFileDialog[/code] with an optional semi-colon-delimited label.
+				Adds a comma-delimited file extension filter option to the [EditorFileDialog] with an optional semi-colon-delimited label.
 				Example: "*.tscn, *.scn; Scenes", results in filter text "Scenes (*.tscn, *.scn)".
 			</description>
 		</method>
@@ -37,7 +37,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Notify the [code]EditorFileDialog[/code] that its view of the data is no longer accurate. Updates the view contents on next view update.
+				Notify the [EditorFileDialog] that its view of the data is no longer accurate. Updates the view contents on next view update.
 			</description>
 		</method>
 	</methods>
@@ -55,16 +55,16 @@
 			The file system path in the address bar.
 		</member>
 		<member name="disable_overwrite_warning" type="bool" setter="set_disable_overwrite_warning" getter="is_overwrite_warning_disabled">
-			If [code]true[/code], the [code]EditorFileDialog[/code] will not warn the user before overwriting files.
+			If [code]true[/code], the [EditorFileDialog] will not warn the user before overwriting files.
 		</member>
 		<member name="display_mode" type="int" setter="set_display_mode" getter="get_display_mode" enum="EditorFileDialog.DisplayMode">
-			The view format in which the [code]EditorFileDialog[/code] displays resources to the user.
+			The view format in which the [EditorFileDialog] displays resources to the user.
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="EditorFileDialog.Mode">
-			The purpose of the [code]EditorFileDialog[/code]. Changes allowed behaviors.
+			The purpose of the [EditorFileDialog]. Changes allowed behaviors.
 		</member>
 		<member name="show_hidden_files" type="bool" setter="set_show_hidden_files" getter="is_showing_hidden_files">
-			If [code]true[/code], hidden files and directories will be visible in the [code]EditorFileDialog[/code].
+			If [code]true[/code], hidden files and directories will be visible in the [EditorFileDialog].
 		</member>
 	</members>
 	<signals>
@@ -92,34 +92,34 @@
 	</signals>
 	<constants>
 		<constant name="MODE_OPEN_FILE" value="0" enum="Mode">
-			The [code]EditorFileDialog[/code] can select only one file. Accepting the window will open the file.
+			The [EditorFileDialog] can select only one file. Accepting the window will open the file.
 		</constant>
 		<constant name="MODE_OPEN_FILES" value="1" enum="Mode">
-			The [code]EditorFileDialog[/code] can select multiple files. Accepting the window will open all files.
+			The [EditorFileDialog] can select multiple files. Accepting the window will open all files.
 		</constant>
 		<constant name="MODE_OPEN_DIR" value="2" enum="Mode">
-			The [code]EditorFileDialog[/code] can select only one directory. Accepting the window will open the directory.
+			The [EditorFileDialog] can select only one directory. Accepting the window will open the directory.
 		</constant>
 		<constant name="MODE_OPEN_ANY" value="3" enum="Mode">
-			The [code]EditorFileDialog[/code] can select a file or directory. Accepting the window will open it.
+			The [EditorFileDialog] can select a file or directory. Accepting the window will open it.
 		</constant>
 		<constant name="MODE_SAVE_FILE" value="4" enum="Mode">
-			The [code]EditorFileDialog[/code] can select only one file. Accepting the window will save the file.
+			The [EditorFileDialog] can select only one file. Accepting the window will save the file.
 		</constant>
 		<constant name="ACCESS_RESOURCES" value="0" enum="Access">
-			The [code]EditorFileDialog[/code] can only view [code]res://[/code] directory contents.
+			The [EditorFileDialog] can only view [code]res://[/code] directory contents.
 		</constant>
 		<constant name="ACCESS_USERDATA" value="1" enum="Access">
-			The [code]EditorFileDialog[/code] can only view [code]user://[/code] directory contents.
+			The [EditorFileDialog] can only view [code]user://[/code] directory contents.
 		</constant>
 		<constant name="ACCESS_FILESYSTEM" value="2" enum="Access">
-			The [code]EditorFileDialog[/code] can view the entire local file system.
+			The [EditorFileDialog] can view the entire local file system.
 		</constant>
 		<constant name="DISPLAY_THUMBNAILS" value="0" enum="DisplayMode">
-			The [code]EditorFileDialog[/code] displays resources as thumbnails.
+			The [EditorFileDialog] displays resources as thumbnails.
 		</constant>
 		<constant name="DISPLAY_LIST" value="1" enum="DisplayMode">
-			The [code]EditorFileDialog[/code] displays resources as a list of filenames.
+			The [EditorFileDialog] displays resources as a list of filenames.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -4,7 +4,7 @@
 		Access to basic engine properties.
 	</brief_description>
 	<description>
-		The [code]Engine[/code] class allows you to query and modify the game's run-time parameters, such as frames per second, time scale, and others.
+		The [Engine] class allows you to query and modify the game's run-time parameters, such as frames per second, time scale, and others.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/FuncRef.xml
+++ b/doc/classes/FuncRef.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		In GDScript, functions are not [i]first-class objects[/i]. This means it is impossible to store them directly as variables, return them from another function, or pass them as arguments.
-		However, by creating a [code]FuncRef[/code] using the [method @GDScript.funcref] function, a reference to a function in a given object can be created, passed around and called.
+		However, by creating a [FuncRef] using the [method @GDScript.funcref] function, a reference to a function in a given object can be created, passed around and called.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/GridContainer.xml
+++ b/doc/classes/GridContainer.xml
@@ -14,7 +14,7 @@
 	</methods>
 	<members>
 		<member name="columns" type="int" setter="set_columns" getter="get_columns">
-			The number of columns in the [code]GridContainer[/code]. If modified, [code]GridContainer[/code] reorders its children to accommodate the new layout.
+			The number of columns in the [GridContainer]. If modified, [GridContainer] reorders its children to accommodate the new layout.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -6,7 +6,7 @@
 	<description>
 		Hyper-text transfer protocol client (sometimes called "User Agent"). Used to make HTTP requests to download web content, upload files and other data or to communicate with various services, among other use cases.
 		Note that this client only needs to connect to a host once (see [method connect_to_host]) to send multiple requests. Because of this, methods that take URLs usually take just the part after the host instead of the full URL, as the client is already connected to a host. See [method request] for a full example and to get started.
-		A [code]HTTPClient[/code] should be reused between multiple requests or to connect to different hosts instead of creating one client per request. Supports SSL and SSL server certificate verification. HTTP status codes in the 2xx range indicate success, 3xx redirection (i.e. "try again, but over here"), 4xx something was wrong with the request, and 5xx something went wrong on the server's side.
+		A [HTTPClient] should be reused between multiple requests or to connect to different hosts instead of creating one client per request. Supports SSL and SSL server certificate verification. HTTP status codes in the 2xx range indicate success, 3xx redirection (i.e. "try again, but over here"), 4xx something was wrong with the request, and 5xx something went wrong on the server's side.
 		For more information on HTTP, see https://developer.mozilla.org/en-US/docs/Web/HTTP (or read RFC 2616 to get it straight from the source: https://tools.ietf.org/html/rfc2616).
 	</description>
 	<tutorials>
@@ -20,7 +20,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Closes the current connection, allowing reuse of this [code]HTTPClient[/code].
+				Closes the current connection, allowing reuse of this [HTTPClient].
 			</description>
 		</method>
 		<method name="connect_to_host">
@@ -82,14 +82,14 @@
 			<return type="bool">
 			</return>
 			<description>
-				If [code]true[/code], this [code]HTTPClient[/code] has a response available.
+				If [code]true[/code], this [HTTPClient] has a response available.
 			</description>
 		</method>
 		<method name="is_response_chunked" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				If [code]true[/code], this [code]HTTPClient[/code] has a response that is chunked.
+				If [code]true[/code], this [HTTPClient] has a response that is chunked.
 			</description>
 		</method>
 		<method name="poll">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -4,7 +4,7 @@
 		Image datatype.
 	</brief_description>
 	<description>
-		Native image datatype. Contains image data, which can be converted to a [Texture], and several functions to interact with it. The maximum width and height for an [code]Image[/code] are [constant MAX_WIDTH] and [constant MAX_HEIGHT].
+		Native image datatype. Contains image data, which can be converted to a [Texture], and several functions to interact with it. The maximum width and height for an [Image] are [constant MAX_WIDTH] and [constant MAX_HEIGHT].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -477,10 +477,10 @@
 	</members>
 	<constants>
 		<constant name="MAX_WIDTH" value="16384">
-			The maximal width allowed for [code]Image[/code] resources.
+			The maximal width allowed for [Image] resources.
 		</constant>
 		<constant name="MAX_HEIGHT" value="16384">
-			The maximal height allowed for [code]Image[/code] resources.
+			The maximal height allowed for [Image] resources.
 		</constant>
 		<constant name="FORMAT_L8" value="0" enum="Format">
 		</constant>

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -23,7 +23,7 @@
 			<argument index="3" name="flags" type="int" default="7">
 			</argument>
 			<description>
-				Create a new [code]ImageTexture[/code] with [code]width[/code] and [code]height[/code].
+				Create a new [ImageTexture] with [code]width[/code] and [code]height[/code].
 				[code]format[/code] is a value from [enum Image.Format], [code]flags[/code] is any combination of [enum Texture.Flags].
 			</description>
 		</method>
@@ -35,14 +35,14 @@
 			<argument index="1" name="flags" type="int" default="7">
 			</argument>
 			<description>
-				Create a new [code]ImageTexture[/code] from an [Image] with [code]flags[/code] from [enum Texture.Flags]. An sRGB to linear color space conversion can take place, according to [enum Image.Format].
+				Create a new [ImageTexture] from an [Image] with [code]flags[/code] from [enum Texture.Flags]. An sRGB to linear color space conversion can take place, according to [enum Image.Format].
 			</description>
 		</method>
 		<method name="get_format" qualifiers="const">
 			<return type="int" enum="Image.Format">
 			</return>
 			<description>
-				Return the format of the [code]ImageTexture[/code], one of [enum Image.Format].
+				Return the format of the [ImageTexture], one of [enum Image.Format].
 			</description>
 		</method>
 		<method name="load">
@@ -51,7 +51,7 @@
 			<argument index="0" name="path" type="String">
 			</argument>
 			<description>
-				Load an [code]ImageTexture[/code] from a file path.
+				Load an [ImageTexture] from a file path.
 			</description>
 		</method>
 		<method name="set_data">
@@ -60,7 +60,7 @@
 			<argument index="0" name="image" type="Image">
 			</argument>
 			<description>
-				Set the [Image] of this [code]ImageTexture[/code].
+				Set the [Image] of this [ImageTexture].
 			</description>
 		</method>
 		<method name="set_size_override">
@@ -69,7 +69,7 @@
 			<argument index="0" name="size" type="Vector2">
 			</argument>
 			<description>
-				Resizes the [code]ImageTexture[/code] to the specified dimensions.
+				Resizes the [ImageTexture] to the specified dimensions.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -90,7 +90,7 @@
 			<argument index="1" name="axis" type="int">
 			</argument>
 			<description>
-				Returns the current value of the joypad axis at given index (see [code]JOY_*[/code] constants in [@GlobalScope])
+				Returns the current value of the joypad axis at given index (see [enum JoystickList]).
 			</description>
 		</method>
 		<method name="get_joy_axis_index_from_string">
@@ -108,7 +108,7 @@
 			<argument index="0" name="axis_index" type="int">
 			</argument>
 			<description>
-				Receives a [code]JOY_AXIS_*[/code] Enum and returns its equivalent name as a string.
+				Receives a [enum JoystickList] axis and returns its equivalent name as a string.
 			</description>
 		</method>
 		<method name="get_joy_button_index_from_string">
@@ -126,7 +126,7 @@
 			<argument index="0" name="button_index" type="int">
 			</argument>
 			<description>
-				Receives a [code]JOY_BUTTON_*[/code] Enum and returns its equivalent name as a string.
+				Receives a joy button from [enum JoystickList] and returns its equivalent name as a string.
 			</description>
 		</method>
 		<method name="get_joy_guid" qualifiers="const">
@@ -229,7 +229,7 @@
 			<argument index="1" name="button" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if you are pressing the joypad button. (see [code]JOY_*[/code] constants in [@GlobalScope])
+				Returns [code]true[/code] if you are pressing the joypad button (see [enum JoystickList]).
 			</description>
 		</method>
 		<method name="is_joy_known">
@@ -238,7 +238,7 @@
 			<argument index="0" name="device" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the system knows the specified device. This means that it sets all button and axis indices exactly as defined in the [code]JOY_*[/code] constants (see [@GlobalScope]). Unknown joypads are not expected to match these constants, but you can still retrieve events from them.
+				Returns [code]true[/code] if the system knows the specified device. This means that it sets all button and axis indices exactly as defined in [enum JoystickList]. Unknown joypads are not expected to match these constants, but you can still retrieve events from them.
 			</description>
 		</method>
 		<method name="is_key_pressed" qualifiers="const">
@@ -247,7 +247,7 @@
 			<argument index="0" name="scancode" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if you are pressing the key. You can pass [code]KEY_*[/code], which are pre-defined constants listed in [@GlobalScope].
+				Returns [code]true[/code] if you are pressing the key. You can pass a [enum KeyList] constant.
 			</description>
 		</method>
 		<method name="is_mouse_button_pressed" qualifiers="const">
@@ -256,7 +256,7 @@
 			<argument index="0" name="button" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if you are pressing the mouse button. You can pass [code]BUTTON_*[/code], which are pre-defined constants listed in [@GlobalScope].
+				Returns [code]true[/code] if you are pressing the mouse button specified with [enum ButtonList].
 			</description>
 		</method>
 		<method name="joy_connection_changed">

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -67,7 +67,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if this input event's type is one of the [code]InputEvent[/code] constants.
+				Returns [code]true[/code] if this input event's type is one of the [InputEvent] constants.
 			</description>
 		</method>
 		<method name="is_echo" qualifiers="const">

--- a/doc/classes/InputEventJoypadButton.xml
+++ b/doc/classes/InputEventJoypadButton.xml
@@ -15,7 +15,7 @@
 	</methods>
 	<members>
 		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index">
-			Button identifier. One of the [code]JOY_BUTTON_*[/code] constants from [@GlobalScope].
+			Button identifier. One of the [enum JoystickList] button constants.
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed">
 			If [code]true[/code], the button's state is pressed. If [code]false[/code], the button's state is released.

--- a/doc/classes/InputEventJoypadMotion.xml
+++ b/doc/classes/InputEventJoypadMotion.xml
@@ -15,7 +15,7 @@
 	</methods>
 	<members>
 		<member name="axis" type="int" setter="set_axis" getter="get_axis">
-			Axis identifier. Use one of the [code]JOY_AXIS_*[/code] constants in [@GlobalScope].
+			Axis identifier. Use one of the [enum JoystickList] axis constants.
 		</member>
 		<member name="axis_value" type="float" setter="set_axis_value" getter="get_axis_value">
 			Current position of the joystick on the given axis. The value ranges from [code]-1.0[/code] to [code]1.0[/code]. A value of [code]0[/code] means the axis is in its resting position.

--- a/doc/classes/InputEventJoypadMotion.xml
+++ b/doc/classes/InputEventJoypadMotion.xml
@@ -4,7 +4,7 @@
 		Input event type for gamepad joysticks and other motions. For buttons see [code]InputEventJoypadButton[/code].
 	</brief_description>
 	<description>
-		Stores information about joystick motions. One [code]InputEventJoypadMotion[/code] represents one axis at a time.
+		Stores information about joystick motions. One [InputEventJoypadMotion] represents one axis at a time.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>

--- a/doc/classes/InputEventKey.xml
+++ b/doc/classes/InputEventKey.xml
@@ -28,7 +28,7 @@
 			If [code]true[/code], the key's state is pressed. If [code]false[/code], the key's state is released.
 		</member>
 		<member name="scancode" type="int" setter="set_scancode" getter="get_scancode">
-			Key scancode, one of the [code]KEY_*[/code] constants in [@GlobalScope].
+			Key scancode, one of the [enum KeyList] constants.
 		</member>
 		<member name="unicode" type="int" setter="set_unicode" getter="get_unicode">
 			Key unicode identifier when relevant.

--- a/doc/classes/InputEventMouse.xml
+++ b/doc/classes/InputEventMouse.xml
@@ -15,7 +15,7 @@
 	</methods>
 	<members>
 		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask">
-			Mouse button mask identifier, one of or a bitwise combination of the BUTTON_MASK_* constants in [@GlobalScope].
+			Mouse button mask identifier, one of or a bitwise combination of the [enum ButtonList] button masks.
 		</member>
 		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position">
 			Mouse position relative to the current [Viewport] when used in [method Control._gui_input], otherwise is at 0,0.

--- a/doc/classes/InputEventMouseButton.xml
+++ b/doc/classes/InputEventMouseButton.xml
@@ -15,7 +15,7 @@
 	</methods>
 	<members>
 		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index">
-			Mouse button identifier, one of the BUTTON_* or BUTTON_WHEEL_* constants in [@GlobalScope].
+			Mouse button identifier, one of the [enum ButtonList] button or button wheel constants.
 		</member>
 		<member name="doubleclick" type="bool" setter="set_doubleclick" getter="is_doubleclick">
 			If [code]true[/code], the mouse button's state is a double-click.

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -72,7 +72,7 @@
 			<argument index="1" name="deadzone" type="float" default="0.5">
 			</argument>
 			<description>
-				Adds an empty action to the [code]InputMap[/code] with a configurable [code]deadzone[/code].
+				Adds an empty action to the [InputMap] with a configurable [code]deadzone[/code].
 				An [InputEvent] can then be added to this action with [method action_add_event].
 			</description>
 		</method>
@@ -82,7 +82,7 @@
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
-				Removes an action from the [code]InputMap[/code].
+				Removes an action from the [InputMap].
 			</description>
 		</method>
 		<method name="event_is_action" qualifiers="const">
@@ -109,7 +109,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Returns an array of all actions in the [code]InputMap[/code].
+				Returns an array of all actions in the [InputMap].
 			</description>
 		</method>
 		<method name="has_action" qualifiers="const">
@@ -118,14 +118,14 @@
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [code]InputMap[/code] has a registered action with the given name.
+				Returns [code]true[/code] if the [InputMap] has a registered action with the given name.
 			</description>
 		</method>
 		<method name="load_from_globals">
 			<return type="void">
 			</return>
 			<description>
-				Clears all [InputEventAction] in the [code]InputMap[/code] and load it anew from [ProjectSettings].
+				Clears all [InputEventAction] in the [InputMap] and load it anew from [ProjectSettings].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/JSONParseResult.xml
+++ b/doc/classes/JSONParseResult.xml
@@ -4,7 +4,7 @@
 		Data class wrapper for decoded JSON.
 	</brief_description>
 	<description>
-		Returned by [method JSON.parse], [code]JSONParseResult[/code] contains decoded JSON or error information if JSON source not successfully parsed. You can check if JSON source was successfully parsed with [code]if json_result.error == OK[/code].
+		Returned by [method JSON.parse], [JSONParseResult] contains decoded JSON or error information if JSON source not successfully parsed. You can check if JSON source was successfully parsed with [code]if json_result.error == OK[/code].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/KinematicBody.xml
+++ b/doc/classes/KinematicBody.xml
@@ -90,7 +90,7 @@
 			<argument index="5" name="infinite_inertia" type="bool" default="true">
 			</argument>
 			<description>
-				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [code]KinematicBody[/code] or [RigidBody], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
+				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [KinematicBody] or [RigidBody], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
 				[code]linear_velocity[/code] is the velocity vector (typically meters per second). Unlike in [method move_and_collide], you should [i]not[/i] multiply it by [code]delta[/code] — the physics engine handles applying the velocity.
 				[code]floor_normal[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector3(0, 0, 0)[/code], everything is considered a wall. This is useful for topdown games.
 				If the body is standing on a slope and the horizontal speed (relative to the floor's speed) goes below [code]slope_stop_min_velocity[/code], the body will stop completely. This prevents the body from sliding down slopes when you include gravity in [code]linear_velocity[/code]. When set to lower values, the body will not be able to stand still on steep slopes.

--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -94,7 +94,7 @@
 			<argument index="5" name="infinite_inertia" type="bool" default="true">
 			</argument>
 			<description>
-				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [code]KinematicBody2D[/code] or [RigidBody2D], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
+				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [KinematicBody2D] or [RigidBody2D], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
 				[code]linear_velocity[/code] is the velocity vector in pixels per second. Unlike in [method move_and_collide], you should [i]not[/i] multiply it by [code]delta[/code] — the physics engine handles applying the velocity.
 				[code]floor_normal[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector2(0, 0)[/code], everything is considered a wall. This is useful for topdown games.
 				If the body is standing on a slope and the horizontal speed (relative to the floor's speed) goes below [code]slope_stop_min_velocity[/code], the body will stop completely. This prevents the body from sliding down slopes when you include gravity in [code]linear_velocity[/code]. When set to lower values, the body will not be able to stand still on steep slopes.

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -37,7 +37,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the number of lines shown. Useful if the [code]Label[/code] 's height cannot currently display all lines.
+				Returns the number of lines shown. Useful if the [Label] 's height cannot currently display all lines.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/LargeTexture.xml
+++ b/doc/classes/LargeTexture.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		A Texture capable of storing many smaller Textures with offsets.
-		You can dynamically add pieces([Texture]) to this [code]LargeTexture[/code] using different offsets.
+		You can dynamically add pieces([Texture]) to this [LargeTexture] using different offsets.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -20,21 +20,21 @@
 			<argument index="1" name="texture" type="Texture">
 			</argument>
 			<description>
-				Add another [Texture] to this [code]LargeTexture[/code], starting on offset "ofs".
+				Add another [Texture] to this [LargeTexture], starting on offset "ofs".
 			</description>
 		</method>
 		<method name="clear">
 			<return type="void">
 			</return>
 			<description>
-				Clears the [code]LargeTexture[/code].
+				Clears the [LargeTexture].
 			</description>
 		</method>
 		<method name="get_piece_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the number of pieces currently in this [code]LargeTexture[/code].
+				Returns the number of pieces currently in this [LargeTexture].
 			</description>
 		</method>
 		<method name="get_piece_offset" qualifiers="const">
@@ -83,7 +83,7 @@
 			<argument index="0" name="size" type="Vector2">
 			</argument>
 			<description>
-				Sets the size of this [code]LargeTexture[/code].
+				Sets the size of this [LargeTexture].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -24,7 +24,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Erases the [code]LineEdit[/code] text.
+				Erases the [LineEdit] text.
 			</description>
 		</method>
 		<method name="deselect">
@@ -38,7 +38,7 @@
 			<return type="PopupMenu">
 			</return>
 			<description>
-				Returns the [PopupMenu] of this [code]LineEdit[/code]. By default, this menu is displayed when right-clicking on the [code]LineEdit[/code].
+				Returns the [PopupMenu] of this [LineEdit]. By default, this menu is displayed when right-clicking on the [LineEdit].
 			</description>
 		</method>
 		<method name="menu_option">
@@ -58,7 +58,7 @@
 			<argument index="1" name="to" type="int" default="-1">
 			</argument>
 			<description>
-				Selects characters inside [code]LineEdit[/code] between [code]from[/code] and [code]to[/code]. By default [code]from[/code] is at the beginning and [code]to[/code] at the end.
+				Selects characters inside [LineEdit] between [code]from[/code] and [code]to[/code]. By default [code]from[/code] is at the beginning and [code]to[/code] at the end.
 				[codeblock]
 				text = "Welcome"
 				select()     # Welcome
@@ -86,10 +86,10 @@
 			Duration (in seconds) of a caret's blinking cycle.
 		</member>
 		<member name="caret_position" type="int" setter="set_cursor_position" getter="get_cursor_position">
-			The cursor's position inside the [code]LineEdit[/code]. When set, the text may scroll to accommodate it.
+			The cursor's position inside the [LineEdit]. When set, the text may scroll to accommodate it.
 		</member>
 		<member name="clear_button_enabled" type="bool" setter="set_clear_button_enabled" getter="is_clear_button_enabled">
-			If [code]true[/code], the [code]LineEdit[/code] will show a clear button if [code]text[/code] is not empty.
+			If [code]true[/code], the [LineEdit] will show a clear button if [code]text[/code] is not empty.
 		</member>
 		<member name="context_menu_enabled" type="bool" setter="set_context_menu_enabled" getter="is_context_menu_enabled">
 			If [code]true[/code], the context menu will appear when right clicked.
@@ -98,19 +98,19 @@
 			If [code]false[/code], existing text cannot be modified and new text cannot be added.
 		</member>
 		<member name="expand_to_text_length" type="bool" setter="set_expand_to_text_length" getter="get_expand_to_text_length">
-			If [code]true[/code], the [code]LineEdit[/code] width will increase to stay longer than the [member text]. It will [b]not[/b] compress if the [member text] is shortened.
+			If [code]true[/code], the [LineEdit] width will increase to stay longer than the [member text]. It will [b]not[/b] compress if the [member text] is shortened.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" enum="Control.FocusMode">
-			Defines how the [code]LineEdit[/code] can grab focus (Keyboard and mouse, only keyboard, or none). See [enum Control.FocusMode] in [Control] for details.
+			Defines how the [LineEdit] can grab focus (Keyboard and mouse, only keyboard, or none). See [enum Control.FocusMode] in [Control] for details.
 		</member>
 		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length">
-			Maximum amount of characters that can be entered inside the [code]LineEdit[/code]. If [code]0[/code], there is no limit.
+			Maximum amount of characters that can be entered inside the [LineEdit]. If [code]0[/code], there is no limit.
 		</member>
 		<member name="placeholder_alpha" type="float" setter="set_placeholder_alpha" getter="get_placeholder_alpha">
 			Opacity of the [member placeholder_text]. From [code]0[/code] to [code]1[/code].
 		</member>
 		<member name="placeholder_text" type="String" setter="set_placeholder" getter="get_placeholder">
-			Text shown when the [code]LineEdit[/code] is empty. It is [b]not[/b] the [code]LineEdit[/code]'s default value (see [member text]).
+			Text shown when the [LineEdit] is empty. It is [b]not[/b] the [LineEdit]'s default value (see [member text]).
 		</member>
 		<member name="secret" type="bool" setter="set_secret" getter="is_secret">
 			If [code]true[/code], every character is replaced with the secret character (see [member secret_character]).
@@ -119,7 +119,7 @@
 			The character to use to mask secret input (defaults to "*"). Only a single character can be used as the secret character.
 		</member>
 		<member name="text" type="String" setter="set_text" getter="get_text">
-			String value of the [code]LineEdit[/code].
+			String value of the [LineEdit].
 		</member>
 	</members>
 	<signals>
@@ -134,22 +134,22 @@
 			<argument index="0" name="new_text" type="String">
 			</argument>
 			<description>
-				Emitted when the user presses [constant KEY_ENTER] on the [code]LineEdit[/code].
+				Emitted when the user presses [constant KEY_ENTER] on the [LineEdit].
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="ALIGN_LEFT" value="0" enum="Align">
-			Aligns the text on the left hand side of the [code]LineEdit[/code].
+			Aligns the text on the left hand side of the [LineEdit].
 		</constant>
 		<constant name="ALIGN_CENTER" value="1" enum="Align">
-			Centers the text in the middle of the [code]LineEdit[/code].
+			Centers the text in the middle of the [LineEdit].
 		</constant>
 		<constant name="ALIGN_RIGHT" value="2" enum="Align">
-			Aligns the text on the right hand side of the [code]LineEdit[/code].
+			Aligns the text on the right hand side of the [LineEdit].
 		</constant>
 		<constant name="ALIGN_FILL" value="3" enum="Align">
-			Stretches whitespaces to fit the [code]LineEdit[/code]'s width.
+			Stretches whitespaces to fit the [LineEdit]'s width.
 		</constant>
 		<constant name="MENU_CUT" value="0" enum="MenuItems">
 			Cuts (copies and clears) the selected text.
@@ -161,10 +161,10 @@
 			Pastes the clipboard text over the selected text (or at the cursor's position).
 		</constant>
 		<constant name="MENU_CLEAR" value="3" enum="MenuItems">
-			Erases the whole [code]LineEdit[/code] text.
+			Erases the whole [LineEdit] text.
 		</constant>
 		<constant name="MENU_SELECT_ALL" value="4" enum="MenuItems">
-			Selects the whole [code]LineEdit[/code] text.
+			Selects the whole [LineEdit] text.
 		</constant>
 		<constant name="MENU_UNDO" value="5" enum="MenuItems">
 			Undoes the previous action.

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -101,7 +101,7 @@
 			If [code]true[/code], the [code]LineEdit[/code] width will increase to stay longer than the [member text]. It will [b]not[/b] compress if the [member text] is shortened.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" enum="Control.FocusMode">
-			Defines how the [code]LineEdit[/code] can grab focus (Keyboard and mouse, only keyboard, or none). See [code]enum FocusMode[/code] in [Control] for details.
+			Defines how the [code]LineEdit[/code] can grab focus (Keyboard and mouse, only keyboard, or none). See [enum Control.FocusMode] in [Control] for details.
 		</member>
 		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length">
 			Maximum amount of characters that can be entered inside the [code]LineEdit[/code]. If [code]0[/code], there is no limit.
@@ -134,7 +134,7 @@
 			<argument index="0" name="new_text" type="String">
 			</argument>
 			<description>
-				Emitted when the user presses [code]KEY_ENTER[/code] on the [code]LineEdit[/code].
+				Emitted when the user presses [constant KEY_ENTER] on the [code]LineEdit[/code].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -4,7 +4,7 @@
 		Main loop is the abstract main loop base class.
 	</brief_description>
 	<description>
-		Main loop is the abstract main loop base class. All other main loop classes are derived from it. Upon application start, a [code]MainLoop[/code] has to be provided to OS, else the application will exit. This happens automatically (and a [SceneTree] is created), unless a main [Script] is supplied, which may or not create and return a [code]MainLoop[/code].
+		Main loop is the abstract main loop base class. All other main loop classes are derived from it. Upon application start, a [MainLoop] has to be provided to OS, else the application will exit. This happens automatically (and a [SceneTree] is created), unless a main [Script] is supplied, which may or not create and return a [MainLoop].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -52,7 +52,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of surfaces that the [code]Mesh[/code] holds.
+				Return the amount of surfaces that the [Mesh] holds.
 			</description>
 		</method>
 		<method name="surface_get_arrays" qualifiers="const">

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -66,7 +66,7 @@
 			</argument>
 			<description>
 				Set the color of a specific instance.
-				For the color to take effect, ensure that [member color_format] is non-[code]null[/code] on the [code]MultiMesh[/code] and [member SpatialMaterial.vertex_color_use_as_albedo] is [code]true[/code] on the material.
+				For the color to take effect, ensure that [member color_format] is non-[code]null[/code] on the [MultiMesh] and [member SpatialMaterial.vertex_color_use_as_albedo] is [code]true[/code] on the material.
 			</description>
 		</method>
 		<method name="set_instance_custom_data">

--- a/doc/classes/MultiMeshInstance.xml
+++ b/doc/classes/MultiMeshInstance.xml
@@ -4,7 +4,7 @@
 		Node that instances a [MultiMesh].
 	</brief_description>
 	<description>
-		[code]MultiMeshInstance[/code] is a specialized node to instance [GeometryInstance]s based on a [MultiMesh] resource.
+		[MultiMeshInstance] is a specialized node to instance [GeometryInstance]s based on a [MultiMesh] resource.
 		This is useful to optimize the rendering of a high amount of instances of a given mesh (for example tree in a forest or grass strands).
 	</description>
 	<tutorials>
@@ -17,7 +17,7 @@
 	</methods>
 	<members>
 		<member name="multimesh" type="MultiMesh" setter="set_multimesh" getter="get_multimesh">
-			The [MultiMesh] resource that will be used and shared among all instances of the [code]MultiMeshInstance[/code].
+			The [MultiMesh] resource that will be used and shared among all instances of the [MultiMeshInstance].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Mutex.xml
+++ b/doc/classes/Mutex.xml
@@ -15,21 +15,21 @@
 			<return type="void">
 			</return>
 			<description>
-				Lock this [code]Mutex[/code], blocks until it is unlocked by the current owner.
+				Lock this [Mutex], blocks until it is unlocked by the current owner.
 			</description>
 		</method>
 		<method name="try_lock">
 			<return type="int" enum="Error">
 			</return>
 			<description>
-				Try locking this [code]Mutex[/code], does not block. Returns [code]OK[/code] on success, [code]ERR_BUSY[/code] otherwise.
+				Try locking this [Mutex], does not block. Returns [code]OK[/code] on success, [code]ERR_BUSY[/code] otherwise.
 			</description>
 		</method>
 		<method name="unlock">
 			<return type="void">
 			</return>
 			<description>
-				Unlock this [code]Mutex[/code], leaving it to other threads.
+				Unlock this [Mutex], leaving it to other threads.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NetworkedMultiplayerPeer.xml
+++ b/doc/classes/NetworkedMultiplayerPeer.xml
@@ -23,14 +23,14 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the ID of the [code]NetworkedMultiplayerPeer[/code] who sent the most recent packet.
+				Returns the ID of the [NetworkedMultiplayerPeer] who sent the most recent packet.
 			</description>
 		</method>
 		<method name="get_unique_id" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the ID of this [code]NetworkedMultiplayerPeer[/code].
+				Returns the ID of this [NetworkedMultiplayerPeer].
 			</description>
 		</method>
 		<method name="poll">
@@ -53,7 +53,7 @@
 	</methods>
 	<members>
 		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections">
-			If [code]true[/code], this [code]NetworkedMultiplayerPeer[/code] refuses new connections. Default value: [code]false[/code].
+			If [code]true[/code], this [NetworkedMultiplayerPeer] refuses new connections. Default value: [code]false[/code].
 		</member>
 		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" enum="NetworkedMultiplayerPeer.TransferMode">
 			The manner in which to send packets to the [code]target_peer[/code]. See [enum TransferMode].

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -275,14 +275,14 @@
 			<argument index="0" name="path" type="NodePath">
 			</argument>
 			<description>
-				Similar to [method get_node], but does not raise an error when [code]path[/code] does not point to a valid [code]Node[/code].
+				Similar to [method get_node], but does not raise an error when [code]path[/code] does not point to a valid [Node].
 			</description>
 		</method>
 		<method name="get_parent" qualifiers="const">
 			<return type="Node">
 			</return>
 			<description>
-				Returns the parent node of the current node, or an empty [code]Node[/code] if the node lacks a parent.
+				Returns the parent node of the current node, or an empty [Node] if the node lacks a parent.
 			</description>
 		</method>
 		<method name="get_path" qualifiers="const">

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -5,8 +5,8 @@
 	</brief_description>
 	<description>
 		A pre-parsed relative or absolute path in a scene tree, for use with [method Node.get_node] and similar functions. It can reference a node, a resource within a node, or a property of a node or resource. For instance, [code]"Path2D/PathFollow2D/Sprite:texture:size"[/code] would refer to the size property of the texture resource on the node named "Sprite" which is a child of the other named nodes in the path. Note that if you want to get a resource, you must end the path with a colon, otherwise the last element will be used as a property name.
-		You will usually just pass a string to [method Node.get_node] and it will be automatically converted, but you may occasionally want to parse a path ahead of time with [code]NodePath[/code] or the literal syntax [code]@"path"[/code]. Exporting a [code]NodePath[/code] variable will give you a node selection widget in the properties panel of the editor, which can often be useful.
-		A [code]NodePath[/code] is made up of a list of node names, a list of "subnode" (resource) names, and the name of a property in the final node or resource.
+		You will usually just pass a string to [method Node.get_node] and it will be automatically converted, but you may occasionally want to parse a path ahead of time with [NodePath] or the literal syntax [code]@"path"[/code]. Exporting a [NodePath] variable will give you a node selection widget in the properties panel of the editor, which can often be useful.
+		A [NodePath] is made up of a list of node names, a list of "subnode" (resource) names, and the name of a property in the final node or resource.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -46,7 +46,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Clear all the items in the [code]OptionButton[/code].
+				Clear all the items in the [OptionButton].
 			</description>
 		</method>
 		<method name="get_item_count" qualifiers="const">

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -15,7 +15,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Close the UDP socket the [code]PacketPeerUDP[/code] is currently listening on.
+				Close the UDP socket the [PacketPeerUDP] is currently listening on.
 			</description>
 		</method>
 		<method name="get_packet_ip" qualifiers="const">
@@ -36,7 +36,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return whether this [code]PacketPeerUDP[/code] is listening.
+				Return whether this [PacketPeerUDP] is listening.
 			</description>
 		</method>
 		<method name="listen">
@@ -49,7 +49,7 @@
 			<argument index="2" name="recv_buf_size" type="int" default="65536">
 			</argument>
 			<description>
-				Make this [code]PacketPeerUDP[/code] listen on the "port" binding to "bind_address" with a buffer size "recv_buf_size".
+				Make this [PacketPeerUDP] listen on the "port" binding to "bind_address" with a buffer size "recv_buf_size".
 				If "bind_address" is set as "*" (default), the peer will listen on all available addresses (both IPv4 and IPv6).
 				If "bind_address" is set as "0.0.0.0" (for IPv4) or "::" (for IPv6), the peer will listen on all available addresses matching that IP type.
 				If "bind_address" is set to any valid address (e.g. "192.168.1.101", "::1", etc), the peer will only listen on the interface with that addresses (or fail if no interface with the given address exists).

--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -4,7 +4,7 @@
 		3D particle emitter.
 	</brief_description>
 	<description>
-		3D particle node used to create a variety of particle systems and effects. [code]Particles[/code] features an emitter that generates some number of particles at a given rate.
+		3D particle node used to create a variety of particle systems and effects. [Particles] features an emitter that generates some number of particles at a given rate.
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
 	</description>
 	<tutorials>

--- a/doc/classes/Particles2D.xml
+++ b/doc/classes/Particles2D.xml
@@ -4,7 +4,7 @@
 		2D particle emitter.
 	</brief_description>
 	<description>
-		2D particle node used to create a variety of particle systems and effects. [code]Particles2D[/code] features an emitter that generates some number of particles at a given rate.
+		2D particle node used to create a variety of particle systems and effects. [Particles2D] features an emitter that generates some number of particles at a given rate.
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
 	</description>
 	<tutorials>

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="from" type="Array">
 			</argument>
 			<description>
-				Construct a new [code]PoolByteArray[/code]. Optionally, you can pass in a generic [Array] that will be converted.
+				Construct a new [PoolByteArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
 		<method name="append">
@@ -31,7 +31,7 @@
 			<argument index="0" name="array" type="PoolByteArray">
 			</argument>
 			<description>
-				Append a [code]PoolByteArray[/code] at the end of this array.
+				Append a [PoolByteArray] at the end of this array.
 			</description>
 		</method>
 		<method name="compress">
@@ -40,7 +40,7 @@
 			<argument index="0" name="compression_mode" type="int" default="0">
 			</argument>
 			<description>
-				Returns a new [code]PoolByteArray[/code] with the data compressed. Set the compression mode using one of [enum File.CompressionMode]'s constants.
+				Returns a new [PoolByteArray] with the data compressed. Set the compression mode using one of [enum File.CompressionMode]'s constants.
 			</description>
 		</method>
 		<method name="decompress">
@@ -51,7 +51,7 @@
 			<argument index="1" name="compression_mode" type="int" default="0">
 			</argument>
 			<description>
-				Returns a new [code]PoolByteArray[/code] with the data decompressed. Set [code]buffer_size[/code] to the size of the uncompressed data. Set the compression mode using one of [enum File.CompressionMode]'s constants.
+				Returns a new [PoolByteArray] with the data decompressed. Set [code]buffer_size[/code] to the size of the uncompressed data. Set the compression mode using one of [enum File.CompressionMode]'s constants.
 			</description>
 		</method>
 		<method name="get_string_from_ascii">
@@ -129,7 +129,7 @@
 			<argument index="1" name="to" type="int">
 			</argument>
 			<description>
-				Returns the slice of the [code]PoolByteArray[/code] between indices (inclusive) as a new [code]PoolByteArray[/code]. Any negative index is considered to be from the end of the array.
+				Returns the slice of the [PoolByteArray] between indices (inclusive) as a new [PoolByteArray]. Any negative index is considered to be from the end of the array.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PoolColorArray.xml
+++ b/doc/classes/PoolColorArray.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="from" type="Array">
 			</argument>
 			<description>
-				Construct a new [code]PoolColorArray[/code]. Optionally, you can pass in a generic [Array] that will be converted.
+				Construct a new [PoolColorArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
 		<method name="append">
@@ -31,7 +31,7 @@
 			<argument index="0" name="array" type="PoolColorArray">
 			</argument>
 			<description>
-				Append a [code]PoolColorArray[/code] at the end of this array.
+				Append a [PoolColorArray] at the end of this array.
 			</description>
 		</method>
 		<method name="insert">

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="from" type="Array">
 			</argument>
 			<description>
-				Construct a new [code]PoolIntArray[/code]. Optionally, you can pass in a generic [Array] that will be converted.
+				Construct a new [PoolIntArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
 		<method name="append">
@@ -31,7 +31,7 @@
 			<argument index="0" name="array" type="PoolIntArray">
 			</argument>
 			<description>
-				Append a [code]PoolIntArray[/code] at the end of this array.
+				Append a [PoolIntArray] at the end of this array.
 			</description>
 		</method>
 		<method name="insert">

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="from" type="Array">
 			</argument>
 			<description>
-				Construct a new [code]PoolRealArray[/code]. Optionally, you can pass in a generic [Array] that will be converted.
+				Construct a new [PoolRealArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
 		<method name="append">
@@ -31,7 +31,7 @@
 			<argument index="0" name="array" type="PoolRealArray">
 			</argument>
 			<description>
-				Append a [code]PoolRealArray[/code] at the end of this array.
+				Append a [PoolRealArray] at the end of this array.
 			</description>
 		</method>
 		<method name="insert">

--- a/doc/classes/PoolStringArray.xml
+++ b/doc/classes/PoolStringArray.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="from" type="Array">
 			</argument>
 			<description>
-				Construct a new [code]PoolStringArray[/code]. Optionally, you can pass in a generic [Array] that will be converted.
+				Construct a new [PoolStringArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
 		<method name="append">
@@ -31,7 +31,7 @@
 			<argument index="0" name="array" type="PoolStringArray">
 			</argument>
 			<description>
-				Append a [code]PoolStringArray[/code] at the end of this array.
+				Append a [PoolStringArray] at the end of this array.
 			</description>
 		</method>
 		<method name="insert">

--- a/doc/classes/PoolVector2Array.xml
+++ b/doc/classes/PoolVector2Array.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="from" type="Array">
 			</argument>
 			<description>
-				Construct a new [code]PoolVector2Array[/code]. Optionally, you can pass in a generic [Array] that will be converted.
+				Construct a new [PoolVector2Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
 		<method name="append">
@@ -31,7 +31,7 @@
 			<argument index="0" name="array" type="PoolVector2Array">
 			</argument>
 			<description>
-				Append a [code]PoolVector2Array[/code] at the end of this array.
+				Append a [PoolVector2Array] at the end of this array.
 			</description>
 		</method>
 		<method name="insert">

--- a/doc/classes/PoolVector3Array.xml
+++ b/doc/classes/PoolVector3Array.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="from" type="Array">
 			</argument>
 			<description>
-				Construct a new [code]PoolVector3Array[/code]. Optionally, you can pass in a generic [Array] that will be converted.
+				Construct a new [PoolVector3Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
 		<method name="append">
@@ -31,7 +31,7 @@
 			<argument index="0" name="array" type="PoolVector3Array">
 			</argument>
 			<description>
-				Append a [code]PoolVector3Array[/code] at the end of this array.
+				Append a [PoolVector3Array] at the end of this array.
 			</description>
 		</method>
 		<method name="insert">

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -20,7 +20,7 @@
 			<argument index="1" name="size" type="Vector2">
 			</argument>
 			<description>
-				Constructs a [code]Rect2[/code] by position and size.
+				Constructs a [Rect2] by position and size.
 			</description>
 		</method>
 		<method name="Rect2">
@@ -35,14 +35,14 @@
 			<argument index="3" name="height" type="float">
 			</argument>
 			<description>
-				Constructs a [code]Rect2[/code] by x, y, width, and height.
+				Constructs a [Rect2] by x, y, width, and height.
 			</description>
 		</method>
 		<method name="abs">
 			<return type="Rect2">
 			</return>
 			<description>
-				Returns a [code]Rect2[/code] with equivalent position and area, modified so that the top-left corner is the origin and [code]width[/code] and [code]height[/code] are positive.
+				Returns a [Rect2] with equivalent position and area, modified so that the top-left corner is the origin and [code]width[/code] and [code]height[/code] are positive.
 			</description>
 		</method>
 		<method name="clip">
@@ -51,7 +51,7 @@
 			<argument index="0" name="b" type="Rect2">
 			</argument>
 			<description>
-				Returns the intersection of this [code]Rect2[/code] and b.
+				Returns the intersection of this [Rect2] and b.
 			</description>
 		</method>
 		<method name="encloses">
@@ -60,7 +60,7 @@
 			<argument index="0" name="b" type="Rect2">
 			</argument>
 			<description>
-				Returns [code]true[/code] if this [code]Rect2[/code] completely encloses another one.
+				Returns [code]true[/code] if this [Rect2] completely encloses another one.
 			</description>
 		</method>
 		<method name="expand">
@@ -69,14 +69,14 @@
 			<argument index="0" name="to" type="Vector2">
 			</argument>
 			<description>
-				Returns this [code]Rect2[/code] expanded to include a given point.
+				Returns this [Rect2] expanded to include a given point.
 			</description>
 		</method>
 		<method name="get_area">
 			<return type="float">
 			</return>
 			<description>
-				Returns the area of the [code]Rect2[/code].
+				Returns the area of the [Rect2].
 			</description>
 		</method>
 		<method name="grow">
@@ -85,7 +85,7 @@
 			<argument index="0" name="by" type="float">
 			</argument>
 			<description>
-				Returns a copy of the [code]Rect2[/code] grown a given amount of units towards all the sides.
+				Returns a copy of the [Rect2] grown a given amount of units towards all the sides.
 			</description>
 		</method>
 		<method name="grow_individual">
@@ -100,7 +100,7 @@
 			<argument index="3" name=" bottom" type="float">
 			</argument>
 			<description>
-				Returns a copy of the [code]Rect2[/code] grown a given amount of units towards each direction individually.
+				Returns a copy of the [Rect2] grown a given amount of units towards each direction individually.
 			</description>
 		</method>
 		<method name="grow_margin">
@@ -111,14 +111,14 @@
 			<argument index="1" name="by" type="float">
 			</argument>
 			<description>
-				Returns a copy of the [code]Rect2[/code] grown a given amount of units towards the [enum Margin] direction.
+				Returns a copy of the [Rect2] grown a given amount of units towards the [enum Margin] direction.
 			</description>
 		</method>
 		<method name="has_no_area">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the [code]Rect2[/code] is flat or empty.
+				Returns [code]true[/code] if the [Rect2] is flat or empty.
 			</description>
 		</method>
 		<method name="has_point">
@@ -127,7 +127,7 @@
 			<argument index="0" name="point" type="Vector2">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [code]Rect2[/code] contains a point.
+				Returns [code]true[/code] if the [Rect2] contains a point.
 			</description>
 		</method>
 		<method name="intersects">
@@ -136,7 +136,7 @@
 			<argument index="0" name="b" type="Rect2">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [code]Rect2[/code] overlaps with another.
+				Returns [code]true[/code] if the [Rect2] overlaps with another.
 			</description>
 		</method>
 		<method name="merge">

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -52,7 +52,7 @@
 			<argument index="0" name="path" type="String">
 			</argument>
 			<description>
-				Sets the path of the resource. Differs from [code]set_path()[/code], if another [code]Resource[/code] exists with "path" it over-takes it, instead of failing.
+				Sets the path of the resource. Differs from [code]set_path()[/code], if another [Resource] exists with "path" it over-takes it, instead of failing.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -4,7 +4,7 @@
 		Saves a specific resource type to a file.
 	</brief_description>
 	<description>
-		The engine can save resources when you do it from the editor, or when you call [method ResourceSaver.save]. This is accomplished with multiple [code]ResourceFormatSaver[/code]s, each handling its own format.
+		The engine can save resources when you do it from the editor, or when you call [method ResourceSaver.save]. This is accomplished with multiple [ResourceFormatSaver]s, each handling its own format.
 		By default, Godot saves resources as [code].tres[/code], [code].res[/code] or another built-in format, but you can choose to create your own format by extending this class. You should give it a global class name with [code]class_name[/code] for it to be registered. You may as well implement a [ResourceFormatLoader].
 	</description>
 	<tutorials>

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -4,7 +4,7 @@
 		Resource Loader.
 	</brief_description>
 	<description>
-		Resource Loader. This is a static object accessible as [code]ResourceLoader[/code]. GDScript has a simplified load() function, though.
+		Resource Loader. This is a static object accessible as [ResourceLoader]. GDScript has a simplified load() function, though.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -4,7 +4,7 @@
 		SceneTree manages a hierarchy of nodes.
 	</brief_description>
 	<description>
-		As one of the most important classes, the [code]SceneTree[/code] manages the hierarchy of nodes in a scene as well as scenes themselves. Nodes can be added, retrieved and removed. The whole scene tree (and thus the current scene) can be paused. Scenes can be loaded, switched and reloaded. You can also use the SceneTree to organize your nodes into groups: every node can be assigned as many groups as you want to create, e.g. a "enemy" group. You can then iterate these groups or even call methods and set properties on all the group's members at once.
+		As one of the most important classes, the [SceneTree] manages the hierarchy of nodes in a scene as well as scenes themselves. Nodes can be added, retrieved and removed. The whole scene tree (and thus the current scene) can be paused. Scenes can be loaded, switched and reloaded. You can also use the SceneTree to organize your nodes into groups: every node can be assigned as many groups as you want to create, e.g. a "enemy" group. You can then iterate these groups or even call methods and set properties on all the group's members at once.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/getting_started/step_by_step/scene_tree.html</link>

--- a/doc/classes/ScriptCreateDialog.xml
+++ b/doc/classes/ScriptCreateDialog.xml
@@ -4,7 +4,7 @@
 		The Editor's popup dialog for creating new [Script] files.
 	</brief_description>
 	<description>
-		The [code]ScriptCreateDialog[/code] creates script files according to a given template for a given scripting language. The standard use is to configure its fields prior to calling one of the [method Popup.popup] methods.
+		The [ScriptCreateDialog] creates script files according to a given template for a given scripting language. The standard use is to configure its fields prior to calling one of the [method Popup.popup] methods.
 		[codeblock]
 		func _ready():
 		    dialog.config("Node", "res://new_node.gd") # for in-engine types

--- a/doc/classes/Semaphore.xml
+++ b/doc/classes/Semaphore.xml
@@ -15,14 +15,14 @@
 			<return type="int" enum="Error">
 			</return>
 			<description>
-				Lowers the [code]Semaphore[/code], allowing one more thread in. Returns [code]OK[/code] on success, [code]ERR_BUSY[/code] otherwise.
+				Lowers the [Semaphore], allowing one more thread in. Returns [code]OK[/code] on success, [code]ERR_BUSY[/code] otherwise.
 			</description>
 		</method>
 		<method name="wait">
 			<return type="int" enum="Error">
 			</return>
 			<description>
-				Tries to wait for the [code]Semaphore[/code], if its value is zero, blocks until non-zero. Returns [code]OK[/code] on success, [code]ERR_BUSY[/code] otherwise.
+				Tries to wait for the [Semaphore], if its value is zero, blocks until non-zero. Returns [code]OK[/code] on success, [code]ERR_BUSY[/code] otherwise.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -4,8 +4,8 @@
 		Most basic 3D game object, parent of all 3D related nodes.
 	</brief_description>
 	<description>
-		Most basic 3D game object, with a 3D [Transform] and visibility settings. All other 3D game objects inherit from Spatial. Use [code]Spatial[/code] as a parent node to move, scale, rotate and show/hide children in a 3D project.
-		Affine operations (rotate, scale, translate) happen in parent's local coordinate system, unless the [code]Spatial[/code] object is set as top level. Affine operations in this coordinate system correspond to direct affine operations on the [code]Spatial[/code]'s transform. The word local below refers to this coordinate system. The coordinate system that is attached to the [code]Spatial[/code] object itself is referred to as object-local coordinate system.
+		Most basic 3D game object, with a 3D [Transform] and visibility settings. All other 3D game objects inherit from Spatial. Use [Spatial] as a parent node to move, scale, rotate and show/hide children in a 3D project.
+		Affine operations (rotate, scale, translate) happen in parent's local coordinate system, unless the [Spatial] object is set as top level. Affine operations in this coordinate system correspond to direct affine operations on the [Spatial]'s transform. The word local below refers to this coordinate system. The coordinate system that is attached to the [Spatial] object itself is referred to as object-local coordinate system.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/3d/introduction_to_3d.html</link>
@@ -23,14 +23,14 @@
 			<return type="Spatial">
 			</return>
 			<description>
-				Returns the parent [code]Spatial[/code], or an empty [Object] if no parent exists or parent is not of type [code]Spatial[/code].
+				Returns the parent [Spatial], or an empty [Object] if no parent exists or parent is not of type [Spatial].
 			</description>
 		</method>
 		<method name="get_world" qualifiers="const">
 			<return type="World">
 			</return>
 			<description>
-				Returns the current [World] resource this [code]Spatial[/code] node is registered to.
+				Returns the current [World] resource this [Spatial] node is registered to.
 			</description>
 		</method>
 		<method name="global_rotate">
@@ -72,7 +72,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns whether node notifies about its local transformation changes. [code]Spatial[/code] will not propagate this by default.
+				Returns whether node notifies about its local transformation changes. [Spatial] will not propagate this by default.
 			</description>
 		</method>
 		<method name="is_scale_disabled" qualifiers="const">
@@ -92,7 +92,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns whether the node notifies about its global and local transformation changes. [code]Spatial[/code] will not propagate this by default.
+				Returns whether the node notifies about its global and local transformation changes. [Spatial] will not propagate this by default.
 			</description>
 		</method>
 		<method name="is_visible_in_tree" qualifiers="const">
@@ -232,7 +232,7 @@
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-				Set whether the node notifies about its local transformation changes. [code]Spatial[/code] will not propagate this by default.
+				Set whether the node notifies about its local transformation changes. [Spatial] will not propagate this by default.
 			</description>
 		</method>
 		<method name="set_notify_transform">
@@ -241,7 +241,7 @@
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-				Set whether the node notifies about its global and local transformation changes. [code]Spatial[/code] will not propagate this by default.
+				Set whether the node notifies about its global and local transformation changes. [Spatial] will not propagate this by default.
 			</description>
 		</method>
 		<method name="show">

--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -43,7 +43,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of bytes this [code]StreamPeer[/code] has available.
+				Return the amount of bytes this [StreamPeer] has available.
 			</description>
 		</method>
 		<method name="get_data">
@@ -269,7 +269,7 @@
 	</methods>
 	<members>
 		<member name="big_endian" type="bool" setter="set_big_endian" getter="is_big_endian_enabled">
-			If [code]true[/code], this [code]StreamPeer[/code] will using big-endian format for encoding and decoding.
+			If [code]true[/code], this [StreamPeer] will using big-endian format for encoding and decoding.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/StreamPeerSSL.xml
+++ b/doc/classes/StreamPeerSSL.xml
@@ -30,7 +30,7 @@
 			<argument index="2" name="for_hostname" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Connect to a peer using an underlying [StreamPeer] "stream", when "validate_certs" is true, [code]StreamPeerSSL[/code] will validate that the certificate presented by the peer matches the "for_hostname".
+				Connect to a peer using an underlying [StreamPeer] "stream", when "validate_certs" is true, [StreamPeerSSL] will validate that the certificate presented by the peer matches the "for_hostname".
 			</description>
 		</method>
 		<method name="disconnect_from_stream">
@@ -61,12 +61,12 @@
 	</members>
 	<constants>
 		<constant name="STATUS_DISCONNECTED" value="0" enum="Status">
-			A status representing a [code]StreamPeerSSL[/code] that is disconnected.
+			A status representing a [StreamPeerSSL] that is disconnected.
 		</constant>
 		<constant name="STATUS_HANDSHAKING" value="1" enum="Status">
 		</constant>
 		<constant name="STATUS_CONNECTED" value="2" enum="Status">
-			A status representing a [code]StreamPeerSSL[/code] that is connected to a host.
+			A status representing a [StreamPeerSSL] that is connected to a host.
 		</constant>
 		<constant name="STATUS_ERROR" value="3" enum="Status">
 		</constant>

--- a/doc/classes/StreamPeerTCP.xml
+++ b/doc/classes/StreamPeerTCP.xml
@@ -70,16 +70,16 @@
 	</methods>
 	<constants>
 		<constant name="STATUS_NONE" value="0" enum="Status">
-			The initial status of the [code]StreamPeerTCP[/code], also the status after a disconnect.
+			The initial status of the [StreamPeerTCP], also the status after a disconnect.
 		</constant>
 		<constant name="STATUS_CONNECTING" value="1" enum="Status">
-			A status representing a [code]StreamPeerTCP[/code] that is connecting to a host.
+			A status representing a [StreamPeerTCP] that is connecting to a host.
 		</constant>
 		<constant name="STATUS_CONNECTED" value="2" enum="Status">
-			A status representing a [code]StreamPeerTCP[/code] that is connected to a host.
+			A status representing a [StreamPeerTCP] that is connected to a host.
 		</constant>
 		<constant name="STATUS_ERROR" value="3" enum="Status">
-			A status representing a [code]StreamPeerTCP[/code] in error state.
+			A status representing a [StreamPeerTCP] in error state.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -4,7 +4,7 @@
 		Helper tool to create geometry.
 	</brief_description>
 	<description>
-		The [code]SurfaceTool[/code] is used to construct a [Mesh] by specifying vertex attributes individually. It can be used to construct a [Mesh] from script. All properties except index need to be added before a call to [method add_vertex]. For example adding vertex colors and UVs looks like
+		The [SurfaceTool] is used to construct a [Mesh] by specifying vertex attributes individually. It can be used to construct a [Mesh] from script. All properties except index need to be added before a call to [method add_vertex]. For example adding vertex colors and UVs looks like
 		[codeblock]
 		var st = SurfaceTool.new()
 		st.begin(Mesh.PRIMITIVE_TRIANGLES)
@@ -12,7 +12,7 @@
 		st.add_uv(Vector2(0, 0))
 		st.add_vertex(Vector3(0, 0, 0))
 		[/codeblock]
-		The [code]SurfaceTool[/code] now contains one vertex of a triangle which has a UV coordinate and a specified [Color]. If another vertex were added without calls to [method add_uv] or [method add_color] then the last values would be used.
+		The [SurfaceTool] now contains one vertex of a triangle which has a UV coordinate and a specified [Color]. If another vertex were added without calls to [method add_uv] or [method add_color] then the last values would be used.
 		It is very important that vertex attributes are passed [b]before[/b] the call to [method add_vertex], failure to do this will result in an error when committing the vertex information to a mesh.
 		Additionally, the attributes used before the first vertex is added determine the format of the mesh. For example if you only add UVs to the first vertex, you cannot add color to any of the subsequent vertices.
 	</description>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -7,7 +7,7 @@
 		Sets the active tab's [code]visible[/code] property to the value [code]true[/code]. Sets all other children's to [code]false[/code].
 		Ignores non-[Control] children.
 		Individual tabs are always visible unless you use [method set_tab_disabled] and [method set_tab_title] to hide it.
-		To hide only a tab's content, nest the content inside a child [Control], so it receives the [code]TabContainer[/code]'s visibility setting instead.
+		To hide only a tab's content, nest the content inside a child [Control], so it receives the [TabContainer]'s visibility setting instead.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -82,7 +82,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the [code]TabContainer[/code] rearrange group id.
+				Returns the [TabContainer] rearrange group id.
 			</description>
 		</method>
 		<method name="set_popup">
@@ -91,7 +91,7 @@
 			<argument index="0" name="popup" type="Node">
 			</argument>
 			<description>
-				If set on a [Popup] node instance, a popup menu icon appears in the top-right corner of the [code]TabContainer[/code]. Clicking it will expand the [Popup] node.
+				If set on a [Popup] node instance, a popup menu icon appears in the top-right corner of the [TabContainer]. Clicking it will expand the [Popup] node.
 			</description>
 		</method>
 		<method name="set_tab_disabled">
@@ -133,7 +133,7 @@
 			<argument index="0" name="group_id" type="int">
 			</argument>
 			<description>
-				Defines rearrange group id, choose for each [code]TabContainer[/code] the same value to enable tab drag between [code]TabContainer[/code]. Enable drag with [code]set_drag_to_rearrange_enabled(true)[/code].
+				Defines rearrange group id, choose for each [TabContainer] the same value to enable tab drag between [TabContainer]. Enable drag with [code]set_drag_to_rearrange_enabled(true)[/code].
 			</description>
 		</method>
 	</methods>
@@ -154,7 +154,7 @@
 	<signals>
 		<signal name="pre_popup_pressed">
 			<description>
-				Emitted when the [code]TabContainer[/code]'s [Popup] button is clicked. See [method set_popup] for details.
+				Emitted when the [TabContainer]'s [Popup] button is clicked. See [method set_popup] for details.
 			</description>
 		</signal>
 		<signal name="tab_changed">

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -97,7 +97,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the [code]Tabs[/code] rearrange group id.
+				Returns the [Tabs] rearrange group id.
 			</description>
 		</method>
 		<method name="move_tab">
@@ -168,7 +168,7 @@
 			<argument index="0" name="group_id" type="int">
 			</argument>
 			<description>
-				Defines rearrange group id, choose for each [code]Tabs[/code] the same value to enable tab drag between [code]Tabs[/code]. Enable drag with [code]set_drag_to_rearrange_enabled(true)[/code].
+				Defines rearrange group id, choose for each [Tabs] the same value to enable tab drag between [Tabs]. Enable drag with [code]set_drag_to_rearrange_enabled(true)[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TextureButton.xml
+++ b/doc/classes/TextureButton.xml
@@ -4,7 +4,7 @@
 		Texture-based button. Supports Pressed, Hover, Disabled and Focused states.
 	</brief_description>
 	<description>
-		[code]TextureButton[/code] has the same functionality as [Button], except it uses sprites instead of Godot's [Theme] resource. It is faster to create, but it doesn't support localization like more complex Controls.
+		[TextureButton] has the same functionality as [Button], except it uses sprites instead of Godot's [Theme] resource. It is faster to create, but it doesn't support localization like more complex Controls.
 		The Normal state's texture is required. Others are optional.
 	</description>
 	<tutorials>

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -15,14 +15,14 @@
 			<return type="String">
 			</return>
 			<description>
-				Returns the current [code]Thread[/code]s id, uniquely identifying it among all threads.
+				Returns the current [Thread]s id, uniquely identifying it among all threads.
 			</description>
 		</method>
 		<method name="is_active" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Returns true if this [code]Thread[/code] is currently active. An active [code]Thread[/code] cannot start work on a new method but can be joined with [method wait_to_finish].
+				Returns true if this [Thread] is currently active. An active [Thread] cannot start work on a new method but can be joined with [method wait_to_finish].
 			</description>
 		</method>
 		<method name="start">
@@ -37,7 +37,7 @@
 			<argument index="3" name="priority" type="int" default="1">
 			</argument>
 			<description>
-				Starts a new [code]Thread[/code] that runs "method" on object "instance" with "userdata" passed as an argument. The "priority" of the [code]Thread[/code] can be changed by passing a PRIORITY_* enum.
+				Starts a new [Thread] that runs "method" on object "instance" with "userdata" passed as an argument. The "priority" of the [Thread] can be changed by passing a PRIORITY_* enum.
 				Returns OK on success, or ERR_CANT_CREATE on failure.
 			</description>
 		</method>
@@ -45,7 +45,7 @@
 			<return type="Variant">
 			</return>
 			<description>
-				Joins the [code]Thread[/code] and waits for it to finish. Returns what the method called returned.
+				Joins the [Thread] and waits for it to finish. Returns what the method called returned.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ToolButton.xml
+++ b/doc/classes/ToolButton.xml
@@ -4,7 +4,7 @@
 		Flat button helper class.
 	</brief_description>
 	<description>
-		This is a helper class to generate a flat [Button] (see [member Button.flat]), creating a [code]ToolButton[/code] is equivalent to:
+		This is a helper class to generate a flat [Button] (see [member Button.flat]), creating a [ToolButton] is equivalent to:
 		[codeblock]
 		var btn = Button.new()
 		btn.flat = true

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -4,7 +4,7 @@
 		Control for a single item inside a [Tree].
 	</brief_description>
 	<description>
-		Control for a single item inside a [Tree]. May have child [code]TreeItem[/code]s and be styled as well as contain buttons.
+		Control for a single item inside a [Tree]. May have child [TreeItem]s and be styled as well as contain buttons.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/WorldEnvironment.xml
+++ b/doc/classes/WorldEnvironment.xml
@@ -4,9 +4,9 @@
 		Default environment properties for the entire scene (post-processing effects, lighting and background settings).
 	</brief_description>
 	<description>
-		The [code]WorldEnvironment[/code] node is used to configure the default [Environment] for the scene.
-		The parameters defined in the [code]WorldEnvironment[/code] can be overridden by an [Environment] node set on the current [Camera]. Additionally, only one [code]WorldEnvironment[/code] may be instanced in a given scene at a time.
-		The [code]WorldEnvironment[/code] allows the user to specify default lighting parameters (e.g. ambient lighting), various post-processing effects (e.g. SSAO, DOF, Tonemapping), and how to draw the background (e.g. solid color, skybox). Usually, these are added in order to improve the realism/color balance of the scene.
+		The [WorldEnvironment] node is used to configure the default [Environment] for the scene.
+		The parameters defined in the [WorldEnvironment] can be overridden by an [Environment] node set on the current [Camera]. Additionally, only one [WorldEnvironment] may be instanced in a given scene at a time.
+		The [WorldEnvironment] allows the user to specify default lighting parameters (e.g. ambient lighting), various post-processing effects (e.g. SSAO, DOF, Tonemapping), and how to draw the background (e.g. solid color, skybox). Usually, these are added in order to improve the realism/color balance of the scene.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/3d/environment_and_post_processing.html</link>
@@ -17,7 +17,7 @@
 	</methods>
 	<members>
 		<member name="environment" type="Environment" setter="set_environment" getter="get_environment">
-			The [Environment] resource used by this [code]WorldEnvironment[/code], defining the default properties.
+			The [Environment] resource used by this [WorldEnvironment], defining the default properties.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -6,7 +6,7 @@
 	<description>
 		Signed 64-bit integer type.
 		It can take values in the interval [code][-2^63, 2^63 - 1][/code], i.e. [code][-9223372036854775808, 9223372036854775807][/code]. Exceeding those bounds will wrap around.
-		[code]int[/code] is a [Variant] type, and will thus be used when assigning an integer value to a [Variant]. It can also be enforced with the [code]: int[/code] type hint.
+		[int] is a [Variant] type, and will thus be used when assigning an integer value to a [Variant]. It can also be enforced with the [code]: int[/code] type hint.
 		[codeblock]
 		var my_variant = 0    # int, value 0
 		my_variant += 4.2     # float, value 4.2

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -702,7 +702,11 @@ def rstize_text(text, state):  # type: (str, State) -> str
         escape_post = False
 
         if tag_text in state.classes:
-            tag_text = make_type(tag_text, state)
+            if tag_text == state.current_class:
+                # We don't want references to the same class
+                tag_text = '``{}``'.format(tag_text)
+            else:
+                tag_text = make_type(tag_text, state)
             escape_post = True
         else:  # command
             cmd = tag_text

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -96,8 +96,8 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		emit_signal("go_to_help", "class_name:" + p_select.substr(1, p_select.length()));
 		return;
 	} else if (p_select.begins_with("@")) {
-		String tag = p_select.substr(1, 6);
-		String link = p_select.substr(7, p_select.length());
+		String tag = p_select.substr(1, 8).rstrip(" ");
+		String link = p_select.substr(9, p_select.length());
 
 		String topic;
 		Map<String, int> *table = NULL;
@@ -108,24 +108,50 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		} else if (tag == "member") {
 			topic = "class_property";
 			table = &this->property_line;
-		} else if (tag == "enum  ") {
+		} else if (tag == "enum") {
 			topic = "class_enum";
 			table = &this->enum_line;
 		} else if (tag == "signal") {
 			topic = "class_signal";
 			table = &this->signal_line;
+		} else if (tag == "constant") {
+			topic = "class_constant";
+			table = &this->constant_line;
 		} else {
 			return;
 		}
 
 		if (link.find(".") != -1) {
-
 			emit_signal("go_to_help", topic + ":" + link.get_slice(".", 0) + ":" + link.get_slice(".", 1));
 		} else {
+			if (table->has(link)) {
+				// Found in the current page
+				class_desc->scroll_to_line((*table)[link]);
+			} else {
+				if (topic == "class_enum") {
+					// Try to find the enum in @GlobalScope
+					const DocData::ClassDoc &cd = doc->class_list["@GlobalScope"];
 
-			if (!table->has(link))
-				return;
-			class_desc->scroll_to_line((*table)[link]);
+					for (int i = 0; i < cd.constants.size(); i++) {
+						if (cd.constants[i].enumeration == link) {
+							// Found in @GlobalScope
+							emit_signal("go_to_help", topic + ":@GlobalScope:" + link);
+							break;
+						}
+					}
+				} else if (topic == "class_constant") {
+					// Try to find the constant in @GlobalScope
+					const DocData::ClassDoc &cd = doc->class_list["@GlobalScope"];
+
+					for (int i = 0; i < cd.constants.size(); i++) {
+						if (cd.constants[i].name == link) {
+							// Found in @GlobalScope
+							emit_signal("go_to_help", topic + ":@GlobalScope:" + link);
+							break;
+						}
+					}
+				}
+			}
 		}
 	} else if (p_select.begins_with("http")) {
 		OS::get_singleton()->shell_open(p_select);
@@ -733,6 +759,9 @@ void EditorHelp::_update_doc() {
 					if (cd.name == "@GlobalScope")
 						enumValuesContainer[enum_list[i].name] = enumStartingLine;
 
+					// Add the enum constant line to the constant_line map so we can locate it as a constant
+					constant_line[enum_list[i].name] = class_desc->get_line_count() - 2;
+
 					class_desc->push_font(doc_code_font);
 					class_desc->push_color(headline_color);
 					_add_text(enum_list[i].name);
@@ -1160,10 +1189,10 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			p_rt->add_text("[");
 			pos = brk_pos + 1;
 
-		} else if (tag.begins_with("method ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ")) {
+		} else if (tag.begins_with("method ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ")) {
 
 			String link_target = tag.substr(tag.find(" ") + 1, tag.length());
-			String link_tag = tag.substr(0, tag.find(" ")).rpad(6);
+			String link_tag = tag.substr(0, tag.find(" ")).rpad(8);
 			p_rt->push_color(link_color);
 			p_rt->push_meta("@" + link_tag + link_target);
 			p_rt->add_text(link_target + (tag.begins_with("method ") ? "()" : ""));

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -497,6 +497,7 @@ class BindingsGenerator {
 		StringName type_Object;
 		StringName type_Reference;
 		StringName type_String;
+		StringName type_at_GlobalScope;
 		StringName enum_Error;
 
 		NameCache() {
@@ -509,6 +510,7 @@ class BindingsGenerator {
 			type_Object = StaticCString::create("Object");
 			type_Reference = StaticCString::create("Reference");
 			type_String = StaticCString::create("String");
+			type_at_GlobalScope = StaticCString::create("@GlobalScope");
 			enum_Error = StaticCString::create("Error");
 		}
 
@@ -524,6 +526,15 @@ class BindingsGenerator {
 			if (it->get().name == p_name) return it;
 			it = it->next();
 		}
+		return NULL;
+	}
+
+	const ConstantInterface *find_constant_by_name(const String &p_name, const List<ConstantInterface> &p_constants) const {
+		for (const List<ConstantInterface>::Element *E = p_constants.front(); E; E = E->next()) {
+			if (E->get().name == p_name)
+				return &E->get();
+		}
+
 		return NULL;
 	}
 


### PR DESCRIPTION
- Enum reference resolving will now search in the `@globalscope` (sorry for accidental tagging 😅) if no class is specified and the enum cannot be resolved in the current class.
- Added support for constant references, e.g.: [const KEY_ENTER] or [const Control.FOCUS_CLICK]. It supports enum constants (the enum name must not be included).

Also made some improvements to the classref regarding references. Some of them make use of the new addition or depend on the fixes introduced with this PR.
