### PR TITLE
C#: Add DynamicGodotObject class

### DIFF
--- a/modules/mono/glue/Managed/Files/DynamicObject.cs
+++ b/modules/mono/glue/Managed/Files/DynamicObject.cs
@@ -1,0 +1,213 @@
+
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+
+namespace Godot
+{
+    /// <summary>
+    /// Represents an <see cref="Godot.Object"/> whose members can be dynamically accessed at runtime through the Variant API.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="Godot.DynamicGodotObject"/> class enables access to the Variant
+    /// members of a <see cref="Godot.Object"/> instance at runtime.
+    /// </para>
+    /// <para>
+    /// This allows accessing the class members using their original names in the engine as well as the members from the
+    /// script attached to the <see cref="Godot.Object"/>, regardless of the scripting language it was written in.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// This sample shows how to use <see cref="Godot.DynamicGodotObject"/> to dynamically access the engine members of a <see cref="Godot.Object"/>.
+    /// <code>
+    /// dynamic sprite = GetNode("Sprite").DynamicGodotObject;
+    /// sprite.add_child(this);
+    ///
+    /// if ((sprite.hframes * sprite.vframes) > 0)
+    ///     sprite.frame = 0;
+    /// </code>
+    /// </example>
+    /// <example>
+    /// This sample shows how to use <see cref="Godot.DynamicGodotObject"/> to dynamically access the members of the script attached to a <see cref="Godot.Object"/>.
+    /// <code>
+    /// dynamic childNode = GetNode("ChildNode").DynamicGodotObject;
+    ///
+    /// if (childNode.print_allowed)
+    /// {
+    ///     childNode.message = "Hello from C#";
+    ///     childNode.print_message(3);
+    /// }
+    /// </code>
+    /// The <c>ChildNode</c> node has the following GDScript script attached:
+    /// <code>
+    /// // # ChildNode.gd
+    /// // var print_allowed = true
+    /// // var message = ""
+    /// //
+    /// // func print_message(times):
+    /// //     for i in times:
+    /// //         print(message)
+    /// </code>
+    /// </example>
+    public class DynamicGodotObject : DynamicObject
+    {
+        /// <summary>
+        /// Gets the <see cref="Godot.Object"/> associated with this <see cref="Godot.DynamicGodotObject"/>.
+        /// </summary>
+        public Object Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Godot.DynamicGodotObject"/> class.
+        /// </summary>
+        /// <param name="godotObject">
+        /// The <see cref="Godot.Object"/> that will be associated with this <see cref="Godot.DynamicGodotObject"/>.
+        /// </param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when the <paramref name="godotObject"/> parameter is null.
+        /// </exception>
+        public DynamicGodotObject(Object godotObject)
+        {
+            if (godotObject == null)
+                throw new ArgumentNullException(nameof(godotObject));
+
+            this.Value = godotObject;
+        }
+
+        public override IEnumerable<string> GetDynamicMemberNames()
+        {
+            return godot_icall_DynamicGodotObject_SetMemberList(Object.GetPtr(Value));
+        }
+
+        public override bool TryBinaryOperation(BinaryOperationBinder binder, object arg, out object result)
+        {
+            switch (binder.Operation)
+            {
+                case ExpressionType.Equal:
+                case ExpressionType.NotEqual:
+                    if (binder.ReturnType == typeof(bool) || binder.ReturnType.IsAssignableFrom(typeof(bool)))
+                    {
+                        if (arg == null)
+                        {
+                            bool boolResult = Object.IsInstanceValid(Value);
+
+                            if (binder.Operation == ExpressionType.Equal)
+                                boolResult = !boolResult;
+
+                            result = boolResult;
+                            return true;
+                        }
+
+                        if (arg is Object other)
+                        {
+                            bool boolResult = (Value == other);
+
+                            if (binder.Operation == ExpressionType.NotEqual)
+                                boolResult = !boolResult;
+
+                            result = boolResult;
+                            return true;
+                        }
+                    }
+
+                    break;
+                default:
+                    // We're not implementing operators <, <=, >, and >= (LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual).
+                    // These are used on the actual pointers in variant_op.cpp. It's better to let the user do that explicitly.
+                    break;
+            }
+
+            return base.TryBinaryOperation(binder, arg, out result);
+        }
+
+        public override bool TryConvert(ConvertBinder binder, out object result)
+        {
+            if (binder.Type == typeof(Object))
+            {
+                result = Value;
+                return true;
+            }
+
+            if (typeof(Object).IsAssignableFrom(binder.Type))
+            {
+                // Throws InvalidCastException when the cast fails
+                result = Convert.ChangeType(Value, binder.Type);
+                return true;
+            }
+
+            return base.TryConvert(binder, out result);
+        }
+
+        public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
+        {
+            if (indexes.Length == 1)
+            {
+                if (indexes[0] is string name)
+                {
+                    return godot_icall_DynamicGodotObject_GetMember(Object.GetPtr(Value), name, out result);
+                }
+            }
+
+            return base.TryGetIndex(binder, indexes, out result);
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            return godot_icall_DynamicGodotObject_GetMember(Object.GetPtr(Value), binder.Name, out result);
+        }
+
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+        {
+            return godot_icall_DynamicGodotObject_InvokeMember(Object.GetPtr(Value), binder.Name, args, out result);
+        }
+
+        public override bool TrySetIndex(SetIndexBinder binder, object[] indexes, object value)
+        {
+            if (indexes.Length == 1)
+            {
+                if (indexes[0] is string name)
+                {
+                    return godot_icall_DynamicGodotObject_SetMember(Object.GetPtr(Value), name, value);
+                }
+            }
+
+            return base.TrySetIndex(binder, indexes, value);
+        }
+
+        public override bool TrySetMember(SetMemberBinder binder, object value)
+        {
+            return godot_icall_DynamicGodotObject_SetMember(Object.GetPtr(Value), binder.Name, value);
+        }
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static string[] godot_icall_DynamicGodotObject_SetMemberList(IntPtr godotObject);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static bool godot_icall_DynamicGodotObject_InvokeMember(IntPtr godotObject, string name, object[] args, out object result);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static bool godot_icall_DynamicGodotObject_GetMember(IntPtr godotObject, string name, out object result);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static bool godot_icall_DynamicGodotObject_SetMember(IntPtr godotObject, string name, object value);
+
+        #region We don't override these methods
+
+        // Looks like this is not usable from C#
+        //public override bool TryCreateInstance(CreateInstanceBinder binder, object[] args, out object result);
+
+        // Object members cannot be deleted
+        //public override bool TryDeleteIndex(DeleteIndexBinder binder, object[] indexes);
+        //public override bool TryDeleteMember(DeleteMemberBinder binder);
+
+        // Invokation on the object itself, e.g.: obj(param)
+        //public override bool TryInvoke(InvokeBinder binder, object[] args, out object result);
+
+        // No unnary operations to handle
+        //public override bool TryUnaryOperation(UnaryOperationBinder binder, out object result);
+
+        #endregion
+    }
+}

--- a/modules/mono/glue/Managed/Files/Object.base.cs
+++ b/modules/mono/glue/Managed/Files/Object.base.cs
@@ -73,10 +73,38 @@ namespace Godot
             disposed = true;
         }
 
+        /// <summary>
+        /// Returns a new <see cref="Godot.SignalAwaiter"/> awaiter configured to complete when the instance
+        /// <paramref name="source"/> emits the signal specified by the <paramref name="signal"/> parameter.
+        /// </summary>
+        /// <param name="source">
+        /// The instance the awaiter will be listening to.
+        /// </param>
+        /// <param name="signal">
+        /// The signal the awaiter will be waiting for.
+        /// </param>
+        /// <example>
+        /// This sample prints a message once every frame up to 100 times.
+        /// <code>
+        /// public override void _Ready()
+        /// {
+        ///     for (int i = 0; i < 100; i++)
+        ///     {
+        ///         await ToSignal(GetTree(), "idle_frame");
+        ///         GD.Print($"Frame {i}");
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
         public SignalAwaiter ToSignal(Object source, string signal)
         {
             return new SignalAwaiter(source, signal, this);
         }
+
+        /// <summary>
+        /// Gets a new <see cref="Godot.DynamicGodotObject"/> associated with this instance.
+        /// </summary>
+        public dynamic DynamicObject => new DynamicGodotObject(this);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static IntPtr godot_icall_Object_Ctor(Object obj);

--- a/modules/mono/glue/arguments_vector.h
+++ b/modules/mono/glue/arguments_vector.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  glue_header.h                                                        */
+/*  arguments_vector.h                                                   */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,52 +28,33 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef MONO_GLUE_ENABLED
+#ifndef ARGUMENTS_VECTOR_H
+#define ARGUMENTS_VECTOR_H
 
-#include "base_object_glue.h"
-#include "collections_glue.h"
-#include "gd_glue.h"
-#include "nodepath_glue.h"
-#include "rid_glue.h"
-#include "string_glue.h"
+#include "core/os/memory.h"
 
-/**
- * Registers internal calls that were not generated. This function is called
- * from the generated GodotSharpBindings::register_generated_icalls() function.
- */
-void godot_register_glue_header_icalls() {
-	godot_register_collections_icalls();
-	godot_register_gd_icalls();
-	godot_register_nodepath_icalls();
-	godot_register_object_icalls();
-	godot_register_rid_icalls();
-	godot_register_string_icalls();
-}
+template <typename T, int POOL_SIZE = 5>
+struct ArgumentsVector {
 
-// Used by the generated glue
+private:
+	T pool[POOL_SIZE];
+	T *_ptr;
 
-#include "core/array.h"
-#include "core/class_db.h"
-#include "core/dictionary.h"
-#include "core/engine.h"
-#include "core/method_bind.h"
-#include "core/node_path.h"
-#include "core/object.h"
-#include "core/reference.h"
-#include "core/typedefs.h"
-#include "core/ustring.h"
+	ArgumentsVector();
+	ArgumentsVector(const ArgumentsVector &);
 
-#include "../mono_gd/gd_mono_class.h"
-#include "../mono_gd/gd_mono_internals.h"
-#include "../mono_gd/gd_mono_utils.h"
+public:
+	T *ptr() { return _ptr; }
+	T &get(int p_idx) { return _ptr[p_idx]; }
+	void set(int p_idx, const T &p_value) { _ptr[p_idx] = p_value; }
 
-#define GODOTSHARP_INSTANCE_OBJECT(m_instance, m_type) \
-	static ClassDB::ClassInfo *ci = NULL;              \
-	if (!ci) {                                         \
-		ci = ClassDB::classes.getptr(m_type);          \
-	}                                                  \
-	Object *m_instance = ci->creation_func();
+	explicit ArgumentsVector(int size) {
+		if (size <= POOL_SIZE) {
+			_ptr = pool;
+		} else {
+			_ptr = memnew_arr(T, size);
+		}
+	}
+};
 
-#include "arguments_vector.h"
-
-#endif // MONO_GLUE_ENABLED
+#endif // ARGUMENTS_VECTOR_H

--- a/modules/mono/glue/base_object_glue.cpp
+++ b/modules/mono/glue/base_object_glue.cpp
@@ -36,9 +36,11 @@
 #include "core/string_name.h"
 
 #include "../csharp_script.h"
+#include "../mono_gd/gd_mono_class.h"
 #include "../mono_gd/gd_mono_internals.h"
 #include "../mono_gd/gd_mono_utils.h"
 #include "../signal_awaiter_utils.h"
+#include "arguments_vector.h"
 
 Object *godot_icall_Object_Ctor(MonoObject *p_obj) {
 	Object *instance = memnew(Object);
@@ -75,7 +77,7 @@ void godot_icall_Object_Disposed(MonoObject *p_obj, Object *p_ptr) {
 	}
 }
 
-void godot_icall_Reference_Disposed(MonoObject *p_obj, Object *p_ptr, bool p_is_finalizer) {
+void godot_icall_Reference_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoolean p_is_finalizer) {
 #ifdef DEBUG_ENABLED
 	CRASH_COND(p_ptr == NULL);
 	// This is only called with Reference derived classes
@@ -155,6 +157,67 @@ Error godot_icall_SignalAwaiter_connect(Object *p_source, MonoString *p_signal, 
 	return SignalAwaiterUtils::connect_signal_awaiter(p_source, signal, p_target, p_awaiter);
 }
 
+MonoArray *godot_icall_DynamicGodotObject_SetMemberList(Object *p_ptr) {
+	List<PropertyInfo> property_list;
+	p_ptr->get_property_list(&property_list);
+
+	MonoArray *result = mono_array_new(mono_domain_get(), CACHED_CLASS_RAW(String), property_list.size());
+
+	int i = 0;
+	for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
+		MonoString *boxed = GDMonoMarshal::mono_string_from_godot(E->get().name);
+		mono_array_set(result, MonoString *, i, boxed);
+		i++;
+	}
+
+	return result;
+}
+
+MonoBoolean godot_icall_DynamicGodotObject_InvokeMember(Object *p_ptr, MonoString *p_name, MonoArray *p_args, MonoObject **r_result) {
+	String name = GDMonoMarshal::mono_string_to_godot(p_name);
+
+	int argc = mono_array_length(p_args);
+
+	ArgumentsVector<Variant> arg_store(argc);
+	ArgumentsVector<const Variant *> args(argc);
+
+	for (int i = 0; i < argc; i++) {
+		MonoObject *elem = mono_array_get(p_args, MonoObject *, i);
+		arg_store.set(i, GDMonoMarshal::mono_object_to_variant(elem));
+		args.set(i, &arg_store.get(i));
+	}
+
+	Variant::CallError error;
+	Variant result = p_ptr->call(StringName(name), args.ptr(), argc, error);
+
+	*r_result = GDMonoMarshal::variant_to_mono_object(result);
+
+	return error.error == OK;
+}
+
+MonoBoolean godot_icall_DynamicGodotObject_GetMember(Object *p_ptr, MonoString *p_name, MonoObject **r_result) {
+	String name = GDMonoMarshal::mono_string_to_godot(p_name);
+
+	bool valid;
+	Variant value = p_ptr->get(StringName(name), &valid);
+
+	if (valid) {
+		*r_result = GDMonoMarshal::variant_to_mono_object(value);
+	}
+
+	return valid;
+}
+
+MonoBoolean godot_icall_DynamicGodotObject_SetMember(Object *p_ptr, MonoString *p_name, MonoObject *p_value) {
+	String name = GDMonoMarshal::mono_string_to_godot(p_name);
+	Variant value = GDMonoMarshal::mono_object_to_variant(p_value);
+
+	bool valid;
+	p_ptr->set(StringName(name), value, &valid);
+
+	return valid;
+}
+
 void godot_register_object_icalls() {
 	mono_add_internal_call("Godot.Object::godot_icall_Object_Ctor", (void *)godot_icall_Object_Ctor);
 	mono_add_internal_call("Godot.Object::godot_icall_Object_Disposed", (void *)godot_icall_Object_Disposed);
@@ -162,6 +225,10 @@ void godot_register_object_icalls() {
 	mono_add_internal_call("Godot.Object::godot_icall_Object_ClassDB_get_method", (void *)godot_icall_Object_ClassDB_get_method);
 	mono_add_internal_call("Godot.Object::godot_icall_Object_weakref", (void *)godot_icall_Object_weakref);
 	mono_add_internal_call("Godot.SignalAwaiter::godot_icall_SignalAwaiter_connect", (void *)godot_icall_SignalAwaiter_connect);
+	mono_add_internal_call("Godot.DynamicGodotObject::godot_icall_DynamicGodotObject_SetMemberList", (void *)godot_icall_DynamicGodotObject_SetMemberList);
+	mono_add_internal_call("Godot.DynamicGodotObject::godot_icall_DynamicGodotObject_InvokeMember", (void *)godot_icall_DynamicGodotObject_InvokeMember);
+	mono_add_internal_call("Godot.DynamicGodotObject::godot_icall_DynamicGodotObject_GetMember", (void *)godot_icall_DynamicGodotObject_GetMember);
+	mono_add_internal_call("Godot.DynamicGodotObject::godot_icall_DynamicGodotObject_SetMember", (void *)godot_icall_DynamicGodotObject_SetMember);
 }
 
 #endif // MONO_GLUE_ENABLED

--- a/modules/mono/glue/base_object_glue.h
+++ b/modules/mono/glue/base_object_glue.h
@@ -42,13 +42,23 @@ Object *godot_icall_Object_Ctor(MonoObject *p_obj);
 
 void godot_icall_Object_Disposed(MonoObject *p_obj, Object *p_ptr);
 
-void godot_icall_Reference_Disposed(MonoObject *p_obj, Object *p_ptr, bool p_is_finalizer);
+void godot_icall_Reference_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoolean p_is_finalizer);
 
 MethodBind *godot_icall_Object_ClassDB_get_method(MonoString *p_type, MonoString *p_method);
 
 MonoObject *godot_icall_Object_weakref(Object *p_obj);
 
 Error godot_icall_SignalAwaiter_connect(Object *p_source, MonoString *p_signal, Object *p_target, MonoObject *p_awaiter);
+
+// DynamicGodotObject
+
+MonoArray *godot_icall_DynamicGodotObject_SetMemberList(Object *p_ptr);
+
+MonoBoolean godot_icall_DynamicGodotObject_InvokeMember(Object *p_ptr, MonoString *p_name, MonoArray *p_args, MonoObject **r_result);
+
+MonoBoolean godot_icall_DynamicGodotObject_GetMember(Object *p_ptr, MonoString *p_name, MonoObject **r_result);
+
+MonoBoolean godot_icall_DynamicGodotObject_SetMember(Object *p_ptr, MonoString *p_name, MonoObject *p_value);
 
 // Register internal calls
 

--- a/modules/mono/glue/collections_glue.cpp
+++ b/modules/mono/glue/collections_glue.cpp
@@ -81,7 +81,7 @@ void godot_icall_Array_Clear(Array *ptr) {
 	ptr->clear();
 }
 
-bool godot_icall_Array_Contains(Array *ptr, MonoObject *item) {
+MonoBoolean godot_icall_Array_Contains(Array *ptr, MonoObject *item) {
 	return ptr->find(GDMonoMarshal::mono_object_to_variant(item)) != -1;
 }
 
@@ -113,7 +113,7 @@ void godot_icall_Array_Insert(Array *ptr, int index, MonoObject *item) {
 	ptr->insert(index, GDMonoMarshal::mono_object_to_variant(item));
 }
 
-bool godot_icall_Array_Remove(Array *ptr, MonoObject *item) {
+MonoBoolean godot_icall_Array_Remove(Array *ptr, MonoObject *item) {
 	int idx = ptr->find(GDMonoMarshal::mono_object_to_variant(item));
 	if (idx >= 0) {
 		ptr->remove(idx);
@@ -208,21 +208,21 @@ void godot_icall_Dictionary_Clear(Dictionary *ptr) {
 	ptr->clear();
 }
 
-bool godot_icall_Dictionary_Contains(Dictionary *ptr, MonoObject *key, MonoObject *value) {
+MonoBoolean godot_icall_Dictionary_Contains(Dictionary *ptr, MonoObject *key, MonoObject *value) {
 	// no dupes
 	Variant *ret = ptr->getptr(GDMonoMarshal::mono_object_to_variant(key));
 	return ret != NULL && *ret == GDMonoMarshal::mono_object_to_variant(value);
 }
 
-bool godot_icall_Dictionary_ContainsKey(Dictionary *ptr, MonoObject *key) {
+MonoBoolean godot_icall_Dictionary_ContainsKey(Dictionary *ptr, MonoObject *key) {
 	return ptr->has(GDMonoMarshal::mono_object_to_variant(key));
 }
 
-bool godot_icall_Dictionary_RemoveKey(Dictionary *ptr, MonoObject *key) {
+MonoBoolean godot_icall_Dictionary_RemoveKey(Dictionary *ptr, MonoObject *key) {
 	return ptr->erase(GDMonoMarshal::mono_object_to_variant(key));
 }
 
-bool godot_icall_Dictionary_Remove(Dictionary *ptr, MonoObject *key, MonoObject *value) {
+MonoBoolean godot_icall_Dictionary_Remove(Dictionary *ptr, MonoObject *key, MonoObject *value) {
 	Variant varKey = GDMonoMarshal::mono_object_to_variant(key);
 
 	// no dupes
@@ -235,7 +235,7 @@ bool godot_icall_Dictionary_Remove(Dictionary *ptr, MonoObject *key, MonoObject 
 	return false;
 }
 
-bool godot_icall_Dictionary_TryGetValue(Dictionary *ptr, MonoObject *key, MonoObject **value) {
+MonoBoolean godot_icall_Dictionary_TryGetValue(Dictionary *ptr, MonoObject *key, MonoObject **value) {
 	Variant *ret = ptr->getptr(GDMonoMarshal::mono_object_to_variant(key));
 	if (ret == NULL) {
 		*value = NULL;
@@ -245,7 +245,7 @@ bool godot_icall_Dictionary_TryGetValue(Dictionary *ptr, MonoObject *key, MonoOb
 	return true;
 }
 
-bool godot_icall_Dictionary_TryGetValue_Generic(Dictionary *ptr, MonoObject *key, MonoObject **value, uint32_t type_encoding, GDMonoClass *type_class) {
+MonoBoolean godot_icall_Dictionary_TryGetValue_Generic(Dictionary *ptr, MonoObject *key, MonoObject **value, uint32_t type_encoding, GDMonoClass *type_class) {
 	Variant *ret = ptr->getptr(GDMonoMarshal::mono_object_to_variant(key));
 	if (ret == NULL) {
 		*value = NULL;

--- a/modules/mono/glue/collections_glue.h
+++ b/modules/mono/glue/collections_glue.h
@@ -55,7 +55,7 @@ void godot_icall_Array_Add(Array *ptr, MonoObject *item);
 
 void godot_icall_Array_Clear(Array *ptr);
 
-bool godot_icall_Array_Contains(Array *ptr, MonoObject *item);
+MonoBoolean godot_icall_Array_Contains(Array *ptr, MonoObject *item);
 
 void godot_icall_Array_CopyTo(Array *ptr, MonoArray *array, int array_index);
 
@@ -63,7 +63,7 @@ int godot_icall_Array_IndexOf(Array *ptr, MonoObject *item);
 
 void godot_icall_Array_Insert(Array *ptr, int index, MonoObject *item);
 
-bool godot_icall_Array_Remove(Array *ptr, MonoObject *item);
+MonoBoolean godot_icall_Array_Remove(Array *ptr, MonoObject *item);
 
 void godot_icall_Array_RemoveAt(Array *ptr, int index);
 
@@ -93,17 +93,17 @@ void godot_icall_Dictionary_Add(Dictionary *ptr, MonoObject *key, MonoObject *va
 
 void godot_icall_Dictionary_Clear(Dictionary *ptr);
 
-bool godot_icall_Dictionary_Contains(Dictionary *ptr, MonoObject *key, MonoObject *value);
+MonoBoolean godot_icall_Dictionary_Contains(Dictionary *ptr, MonoObject *key, MonoObject *value);
 
-bool godot_icall_Dictionary_ContainsKey(Dictionary *ptr, MonoObject *key);
+MonoBoolean godot_icall_Dictionary_ContainsKey(Dictionary *ptr, MonoObject *key);
 
-bool godot_icall_Dictionary_RemoveKey(Dictionary *ptr, MonoObject *key);
+MonoBoolean godot_icall_Dictionary_RemoveKey(Dictionary *ptr, MonoObject *key);
 
-bool godot_icall_Dictionary_Remove(Dictionary *ptr, MonoObject *key, MonoObject *value);
+MonoBoolean godot_icall_Dictionary_Remove(Dictionary *ptr, MonoObject *key, MonoObject *value);
 
-bool godot_icall_Dictionary_TryGetValue(Dictionary *ptr, MonoObject *key, MonoObject **value);
+MonoBoolean godot_icall_Dictionary_TryGetValue(Dictionary *ptr, MonoObject *key, MonoObject **value);
 
-bool godot_icall_Dictionary_TryGetValue_Generic(Dictionary *ptr, MonoObject *key, MonoObject **value, uint32_t type_encoding, GDMonoClass *type_class);
+MonoBoolean godot_icall_Dictionary_TryGetValue_Generic(Dictionary *ptr, MonoObject *key, MonoObject **value, uint32_t type_encoding, GDMonoClass *type_class);
 
 void godot_icall_Dictionary_Generic_GetValueTypeInfo(MonoReflectionType *refltype, uint32_t *type_encoding, GDMonoClass **type_class);
 

--- a/modules/mono/glue/gd_glue.cpp
+++ b/modules/mono/glue/gd_glue.cpp
@@ -175,7 +175,7 @@ MonoObject *godot_icall_GD_str2var(MonoString *p_str) {
 	return GDMonoMarshal::variant_to_mono_object(ret);
 }
 
-bool godot_icall_GD_type_exists(MonoString *p_type) {
+MonoBoolean godot_icall_GD_type_exists(MonoString *p_type) {
 	return ClassDB::class_exists(GDMonoMarshal::mono_string_to_godot(p_type));
 }
 

--- a/modules/mono/glue/gd_glue.h
+++ b/modules/mono/glue/gd_glue.h
@@ -69,7 +69,7 @@ MonoString *godot_icall_GD_str(MonoArray *p_what);
 
 MonoObject *godot_icall_GD_str2var(MonoString *p_str);
 
-bool godot_icall_GD_type_exists(MonoString *p_type);
+MonoBoolean godot_icall_GD_type_exists(MonoString *p_type);
 
 MonoArray *godot_icall_GD_var2bytes(MonoObject *p_var);
 


### PR DESCRIPTION
This allows duck typing that fallbacks to Object.call, Object.set and Object.get for accessing members.

Here is an example accessing engine members:

``` C#
dynamic sprite = GetNode("Sprite").DynamicObject;
sprite.add_child(this);

if ((sprite.hframes * sprite.vframes) > 0)
    sprite.frame = 0;
```

There is not much of a reason to do something like that. The main purpose is communicating with other script languages.

Suppose you have the following script written in GDScript:

``` GDscript
# ChildNode.gd
var print_allowed = true
var message = ""

func print_message(times):
    for i in times:
        print(message)
```

You can now write code like this:

``` C#
dynamic childNode = GetNode("ChildNode").DynamicObject;

if (childNode.print_allowed)
{
    childNode.message = "Hello from C#";
    childNode.print_message(3);
}
```

where previously you needed this:

``` C#
var childNode = GetNode("ChildNode");

if ((bool)childNode.Get("print_allowed"))
{
    childNode.Set("message", "Hello from C#");
    childNode.Call("print_message", 3);
}
```
