### PR TITLE
Added functions to AStar for disable/enable points to effectivly create obstacles

### DIFF
--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -54,6 +54,7 @@ class AStar : public Reference {
 		Vector3 pos;
 		real_t weight_scale;
 		uint64_t last_pass;
+		bool enabled;
 
 		Set<Point *> neighbours;
 
@@ -113,6 +114,9 @@ public:
 	bool has_point(int p_id) const;
 	PoolVector<int> get_point_connections(int p_id);
 	Array get_points();
+
+	void set_point_disabled(int p_id, bool p_disabled = true);
+	bool is_point_disabled(int p_id) const;
 
 	void connect_points(int p_id, int p_with_id, bool bidirectional = true);
 	void disconnect_points(int p_id, int p_with_id);

--- a/doc/classes/AStar.xml
+++ b/doc/classes/AStar.xml
@@ -226,6 +226,15 @@
 				Returns whether a point associated with the given id exists.
 			</description>
 		</method>
+		<method name="is_point_disabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+				Returns whether a point is disabled or not for pathfinding. By default, all points are enabled.
+			</description>
+		</method>
 		<method name="remove_point">
 			<return type="void">
 			</return>
@@ -233,6 +242,17 @@
 			</argument>
 			<description>
 				Removes the point associated with the given id from the points pool.
+			</description>
+		</method>
+		<method name="set_point_disabled">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="disabled" type="bool" default="true">
+			</argument>
+			<description>
+				Disables or enables the specified point for pathfinding. Useful for making a temporary obstacle.
 			</description>
 		</method>
 		<method name="set_point_position">


### PR DESCRIPTION
If you want to remove a point from `AStar `(for example to make a temporary obstacle) currently you should use `remove_point` or maybe somehow modify weight - these approaches are not elegant and have a performance penalty compared to simple boolean check whether the point of the path has an obstacle or not.

For example, when using a `remove_point ` you should always have to check if the point exist manually, then it removes it from an array( which may be undesired) + it does the additional computation in AStar._solve method + if you want to restore a point you should add it again and worst more restore the lost connections to other nodes manually. 

This proposal adds `set_point_disabled(idx, disabled)` and `is_point_disabled(idx)` methods to AStar. By default all nodes are enabled, so its not affected the existing user code base.