### PR TITLE
Add editor screenshot on control - f12.

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -51,6 +51,35 @@ uint32_t OS::get_ticks_msec() const {
 	return get_ticks_usec() / 1000;
 }
 
+String OS::get_iso_date_time(bool local) const {
+	OS::Date date = get_date(local);
+	OS::Time time = get_time(local);
+
+	String timezone;
+	if (!local) {
+		TimeZoneInfo zone = get_time_zone_info();
+		if (zone.bias >= 0) {
+			timezone = "+";
+		}
+		timezone = timezone + itos(zone.bias / 60).pad_zeros(2) + itos(zone.bias % 60).pad_zeros(2);
+	} else {
+		timezone = "Z";
+	}
+
+	return itos(date.year).pad_zeros(2) +
+		   "-" +
+		   itos(date.month).pad_zeros(2) +
+		   "-" +
+		   itos(date.day).pad_zeros(2) +
+		   "T" +
+		   itos(time.hour).pad_zeros(2) +
+		   ":" +
+		   itos(time.min).pad_zeros(2) +
+		   ":" +
+		   itos(time.sec).pad_zeros(2) +
+		   timezone;
+}
+
 uint64_t OS::get_splash_tick_msec() const {
 	return _msec_splash;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -336,6 +336,7 @@ public:
 	virtual Date get_date(bool local = false) const = 0;
 	virtual Time get_time(bool local = false) const = 0;
 	virtual TimeZoneInfo get_time_zone_info() const = 0;
+	virtual String get_iso_date_time(bool local = false) const;
 	virtual uint64_t get_unix_time() const;
 	virtual uint64_t get_system_time_secs() const;
 	virtual uint64_t get_system_time_msecs() const;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -199,6 +199,9 @@ private:
 		SETTINGS_HELP,
 		SCENE_TAB_CLOSE,
 
+		EDITOR_SCREENSHOT,
+		EDITOR_OPEN_SCREENSHOT,
+
 		HELP_SEARCH,
 		HELP_DOCS,
 		HELP_QA,
@@ -279,6 +282,8 @@ private:
 	ToolButton *play_custom_scene_button;
 	ToolButton *search_button;
 	TextureProgress *audio_vu;
+
+	Timer *screenshot_timer;
 
 	PluginConfigDialog *plugin_config_dialog;
 
@@ -448,6 +453,11 @@ private:
 	void _menu_option(int p_option);
 	void _menu_confirm_current();
 	void _menu_option_confirm(int p_option, bool p_confirmed);
+
+	void _request_screenshot();
+	void _screenshot(bool p_use_utc = false);
+	void _save_screenshot(NodePath p_path);
+
 	void _tool_menu_option(int p_idx);
 	void _update_debug_options();
 
@@ -646,6 +656,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+
 	static void _bind_methods();
 
 protected:


### PR DESCRIPTION
Add a way to screenshot the editor on control - f12.

What shortcut should it be?

I couldn't get screenshots bigger than the screen resolution working.

Also hiding the menu before the menu screenshot doesn't work.

Thanks with help from @Calinou 

Edited:

Use case is for educators to create screenshots of the editor for tutorial purposes.