### PR TITLE
Allow only one text selection at a time

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1275,6 +1275,7 @@ CodeTextEditor::CodeTextEditor() {
 	text_editor->set_show_line_numbers(true);
 	text_editor->set_brace_matching(true);
 	text_editor->set_auto_indent(true);
+	text_editor->set_independent_selection(true);
 
 	status_bar = memnew(HBoxContainer);
 	add_child(status_bar);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -841,6 +841,8 @@ void LineEdit::_notification(int p_what) {
 				draw_caret = true;
 			}
 
+			TextSelectionManager::get_singleton()->set_selection_control(this);
+
 			OS::get_singleton()->set_ime_active(true);
 			Point2 cursor_pos = Point2(get_cursor_position(), 1) * get_minimum_size().height;
 			OS::get_singleton()->set_ime_position(get_global_position() + cursor_pos);
@@ -868,6 +870,10 @@ void LineEdit::_notification(int p_what) {
 				update();
 			}
 		} break;
+		case TextSelectionManager::NOTIFICATION_DESELECT_TEXT: {
+			deselect();
+			update();
+		}
 	}
 }
 

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -197,6 +197,7 @@ Popup::Popup() {
 	exclusive = false;
 	popped_up = false;
 	hide();
+	current_selection_control = 0;
 }
 
 String Popup::get_configuration_warning() const {
@@ -268,4 +269,23 @@ void PopupPanel::_notification(int p_what) {
 }
 
 PopupPanel::PopupPanel() {
+}
+
+void TextSelectionManager::set_selection_control(Control *p_control) {
+
+	ObjectID *current_selection_control = &root_current_selection_control;
+	for (Node *node = p_control->get_parent(); node; node = node->get_parent()) {
+		Popup *popup = Object::cast_to<Popup>(node);
+		if (popup) {
+			current_selection_control = &popup->current_selection_control;
+			break;
+		}
+	}
+
+	if (p_control->get_instance_id() != *current_selection_control) {
+		Object *obj = ObjectDB::get_instance(*current_selection_control);
+		if (obj)
+			obj->notification(TextSelectionManager::NOTIFICATION_DESELECT_TEXT);
+		*current_selection_control = p_control->get_instance_id();
+	}
 }

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -36,12 +36,17 @@
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
+
+class TextSelectionManager;
+
 class Popup : public Control {
 
 	GDCLASS(Popup, Control);
 
+	friend class TextSelectionManager;
 	bool exclusive;
 	bool popped_up;
+	ObjectID current_selection_control;
 
 protected:
 	virtual void _post_popup() {}
@@ -84,6 +89,23 @@ public:
 	void set_child_rect(Control *p_child);
 	virtual Size2 get_minimum_size() const;
 	PopupPanel();
+};
+
+class TextSelectionManager {
+public:
+	static TextSelectionManager *get_singleton() {
+
+		static TextSelectionManager sm;
+		return &sm;
+	}
+	void set_selection_control(Control *p_control);
+	enum {
+		NOTIFICATION_DESELECT_TEXT = 100
+	};
+
+private:
+	TextSelectionManager() { root_current_selection_control = 0; }
+	ObjectID root_current_selection_control;
 };
 
 #endif

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1433,6 +1433,8 @@ void TextEdit::_notification(int p_what) {
 				draw_caret = true;
 			}
 
+			TextSelectionManager::get_singleton()->set_selection_control(this);
+
 			OS::get_singleton()->set_ime_active(true);
 			Point2 cursor_pos = Point2(cursor_get_column(), cursor_get_line()) * get_row_height();
 			OS::get_singleton()->set_ime_position(get_global_position() + cursor_pos);
@@ -1458,6 +1460,12 @@ void TextEdit::_notification(int p_what) {
 				update();
 			}
 		} break;
+		case TextSelectionManager::NOTIFICATION_DESELECT_TEXT: {
+			if (!independent_selection) {
+				deselect();
+				update();
+			}
+		}
 	}
 }
 
@@ -4322,6 +4330,16 @@ bool TextEdit::is_wrap_enabled() const {
 	return wrap_enabled;
 }
 
+void TextEdit::set_independent_selection(bool p_independent_selection) {
+
+	independent_selection = p_independent_selection;
+}
+
+bool TextEdit::get_independent_selection() const {
+
+	return independent_selection;
+}
+
 void TextEdit::set_max_chars(int p_max_chars) {
 
 	max_chars = p_max_chars;
@@ -6148,6 +6166,8 @@ void TextEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_wrap_enabled", "enable"), &TextEdit::set_wrap_enabled);
 	ClassDB::bind_method(D_METHOD("is_wrap_enabled"), &TextEdit::is_wrap_enabled);
+	ClassDB::bind_method(D_METHOD("set_independent_selection", "enable"), &TextEdit::set_independent_selection);
+	ClassDB::bind_method(D_METHOD("get_independent_selection"), &TextEdit::get_independent_selection);
 	// ClassDB::bind_method(D_METHOD("set_max_chars", "amount"), &TextEdit::set_max_chars);
 	// ClassDB::bind_method(D_METHOD("get_max_char"), &TextEdit::get_max_chars);
 	ClassDB::bind_method(D_METHOD("set_context_menu_enabled", "enable"), &TextEdit::set_context_menu_enabled);
@@ -6232,6 +6252,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "v_scroll_speed"), "set_v_scroll_speed", "get_v_scroll_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hiding_enabled"), "set_hiding_enabled", "is_hiding_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "wrap_enabled"), "set_wrap_enabled", "is_wrap_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "independent_selection"), "set_independent_selection", "get_independent_selection");
 	// ADD_PROPERTY(PropertyInfo(Variant::BOOL, "max_chars"), "set_max_chars", "get_max_chars");
 
 	ADD_GROUP("Caret", "caret_");
@@ -6268,6 +6289,7 @@ TextEdit::TextEdit() {
 	draw_caret = true;
 	max_chars = 0;
 	clear();
+	independent_selection = false;
 	wrap_enabled = false;
 	wrap_right_offset = 10;
 	set_focus_mode(FOCUS_ALL);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -301,6 +301,7 @@ private:
 	bool insert_mode;
 	bool select_identifiers_enabled;
 
+	bool independent_selection;
 	bool smooth_scroll_enabled;
 	bool scrolling;
 	float target_v_scroll;
@@ -548,6 +549,9 @@ public:
 
 	void set_wrap_enabled(bool p_wrap_enabled);
 	bool is_wrap_enabled() const;
+
+	void set_independent_selection(bool p_independent_selection);
+	bool get_independent_selection() const;
 
 	void clear();
 


### PR DESCRIPTION
Allow only one text selection per window, unless an edit opts out by
setting "independent selection" to true.

Fixes #27511