### PR TITLE
Document SceneTree.get_frame() and persistent in add_to_group()

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -146,6 +146,7 @@
 			</argument>
 			<description>
 				Adds the node to a group. Groups are helpers to name and organize a subset of nodes, for example "enemies" or "collectables". A node can be in any number of groups. Nodes can be assigned a group at any time, but will not be added until they are inside the scene tree (see [method is_inside_tree]). See notes in the description, and the group methods in [SceneTree].
+				[code]persistent[/code] option is used when packing node to [PackedScene] and saving to file. Non-persistent groups aren't stored.
 			</description>
 		</method>
 		<method name="can_process" qualifiers="const">

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -77,6 +77,7 @@
 			<return type="int">
 			</return>
 			<description>
+				Returns the current frame, i.e. number of frames since the application started.
 			</description>
 		</method>
 		<method name="get_network_connected_peers" qualifiers="const">


### PR DESCRIPTION
So I completely randomly stumbled upon this issue #6852 and noticed that `get_frame` method in SceneTree is the only method not documented there.

To ultimately close #6852 I also documented the `persistent` parameter in Node's `add_to_group`.