### PR TITLE
Add TypeDB. Refactor Custom Types, CreateDialog.

### DIFF
--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -59,7 +59,8 @@ class CreateDialog : public ConfirmationDialog {
 	String preferred_search_result_type;
 	EditorHelpBit *help_bit;
 	List<StringName> type_list;
-	Set<StringName> type_blacklist;
+	Vector<StringName> type_listv;
+	Vector<StringName> type_blacklist;
 
 	void _item_selected();
 
@@ -109,6 +110,8 @@ public:
 	String get_preferred_search_result_type();
 
 	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_select_type = "Node");
+
+	void fs_changed();
 
 	CreateDialog();
 };

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -36,6 +36,7 @@
 #include "core/undo_redo.h"
 #include "editor/editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
+#include "editor/type_db.h"
 #include "scene/resources/texture.h"
 
 class EditorHistory {
@@ -110,7 +111,8 @@ class EditorData {
 public:
 	struct CustomType {
 
-		String name;
+		StringName name;
+		StringName base;
 		Ref<Script> script;
 		Ref<Texture> icon;
 	};
@@ -129,12 +131,15 @@ public:
 private:
 	Vector<EditorPlugin *> editor_plugins;
 
+	TypeDB type_db;
+
 	struct PropertyData {
 
 		String name;
 		Variant value;
 	};
-	Map<String, Vector<CustomType> > custom_types;
+	//Map<String, Vector<CustomType> > custom_types;
+	HashMap<StringName, CustomType> custom_types;
 
 	List<PropertyData> clipboard;
 	UndoRedo undo_redo;
@@ -149,11 +154,16 @@ private:
 	HashMap<StringName, String> _script_class_icon_paths;
 	HashMap<String, StringName> _script_class_file_to_path;
 
+	HashMap<StringName, List<StringName> > _inheritors_cache;
+	bool _inheritors_dirty;
+
 public:
 	EditorPlugin *get_editor(Object *p_object);
 	EditorPlugin *get_subeditor(Object *p_object);
 	Vector<EditorPlugin *> get_subeditors(Object *p_object);
 	EditorPlugin *get_editor(String p_name);
+	const TypeDB &get_type_db() { return type_db; }
+	void refresh_type_db() { type_db.refresh(); }
 
 	void copy_object_params(Object *p_object);
 	void paste_object_params(Object *p_object);
@@ -178,9 +188,15 @@ public:
 	void restore_editor_global_states();
 
 	void add_custom_type(const String &p_type, const String &p_inherits, const Ref<Script> &p_script, const Ref<Texture> &p_icon);
-	Object *instance_custom_type(const String &p_type, const String &p_inherits);
+	Object *instance_custom_type(const String &p_type);
 	void remove_custom_type(const String &p_type);
-	const Map<String, Vector<CustomType> > &get_custom_types() const { return custom_types; }
+	void get_custom_type_class_list(List<StringName> *p_classes) const;
+	StringName get_custom_type_name(const String &p_path) const;
+	Ref<Script> get_custom_type_script(const StringName &p_type) const;
+	String get_custom_type_path(const StringName &p_type) const;
+	StringName get_custom_type_base(const StringName &p_type) const;
+	Ref<Texture> get_custom_type_icon(const String &p_type) const;
+	bool is_custom_type(const StringName &p_type) const { return custom_types.has(p_type); }
 
 	int add_edited_scene(int p_at_pos);
 	void move_edited_scene_index(int p_idx, int p_to_idx);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -291,7 +291,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 						if (ScriptServer::is_global_class(intype)) {
 							obj = EditorNode::get_editor_data().script_class_instance(intype);
 						} else {
-							obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+							obj = EditorNode::get_editor_data().instance_custom_type(intype);
 						}
 					}
 
@@ -891,12 +891,6 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			} else if (hint_text != "") {
 				int idx = 0;
 
-				Vector<EditorData::CustomType> custom_resources;
-
-				if (EditorNode::get_editor_data().get_custom_types().has("Resource")) {
-					custom_resources = EditorNode::get_editor_data().get_custom_types()["Resource"];
-				}
-
 				for (int i = 0; i < hint_text.get_slice_count(","); i++) {
 
 					String base = hint_text.get_slice(",", i);
@@ -904,47 +898,22 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 					Set<String> valid_inheritors;
 					valid_inheritors.insert(base);
 					List<StringName> inheritors;
-					ClassDB::get_inheriters_from_class(base.strip_edges(), &inheritors);
+					const TypeDB &tdb = EditorNode::get_editor_data().get_type_db();
+					tdb.get_inheritors_from_class(base.strip_edges(), &inheritors);
 
-					for (int j = 0; j < custom_resources.size(); j++) {
-						inheritors.push_back(custom_resources[j].name);
-					}
+					for (List<StringName>::Element *j = inheritors.front(); j; j = j->next()) {
+						String t = j->get();
 
-					List<StringName>::Element *E = inheritors.front();
-					while (E) {
-						valid_inheritors.insert(E->get());
-						E = E->next();
-					}
-
-					for (Set<String>::Element *j = valid_inheritors.front(); j; j = j->next()) {
-						const String &t = j->get();
-
-						bool is_custom_resource = false;
-						Ref<Texture> icon;
-						if (!custom_resources.empty()) {
-							for (int k = 0; k < custom_resources.size(); k++) {
-								if (custom_resources[k].name == t) {
-									is_custom_resource = true;
-									if (custom_resources[k].icon.is_valid())
-										icon = custom_resources[k].icon;
-									break;
-								}
-							}
-						}
-
-						if (!is_custom_resource && !ClassDB::can_instance(t))
+						if (!tdb.can_instance(t))
 							continue;
+
+						Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(t, base);
 
 						inheritors_array.push_back(t);
 
 						int id = TYPE_BASE_ID + idx;
 
-						if (!icon.is_valid() && has_icon(t, "EditorIcons")) {
-							icon = get_icon(t, "EditorIcons");
-						}
-
 						if (icon.is_valid()) {
-
 							menu->add_icon_item(icon, vformat(TTR("New %s"), t), id);
 						} else {
 
@@ -1144,7 +1113,7 @@ void CustomPropertyEditor::_type_create_selected(int p_idx) {
 			if (ScriptServer::is_global_class(intype)) {
 				obj = EditorNode::get_editor_data().script_class_instance(intype);
 			} else {
-				obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+				obj = EditorNode::get_editor_data().instance_custom_type(intype);
 			}
 		}
 
@@ -1350,7 +1319,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 						if (ScriptServer::is_global_class(intype)) {
 							obj = EditorNode::get_editor_data().script_class_instance(intype);
 						} else {
-							obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+							obj = EditorNode::get_editor_data().instance_custom_type(intype);
 						}
 					}
 

--- a/editor/type_db.cpp
+++ b/editor/type_db.cpp
@@ -1,0 +1,217 @@
+/*************************************************************************/
+/*  type_db.cpp                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor/type_db.h"
+#include "editor/editor_node.h"
+
+void TypeDB::refresh() {
+	type_map.clear();
+	path_map.clear();
+	const EditorData &ed = EditorNode::get_editor_data();
+
+	List<StringName> types;
+	ClassDB::get_class_list(&types);
+	for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
+		TypeInfo ti;
+		StringName n = E->get();
+
+		ti.name = n;
+		ti.base = ClassDB::get_parent_class(n);
+		ti.native = n;
+		ti.source = SOURCE_ENGINE;
+
+		type_map[ti.name] = ti;
+	}
+	for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
+		StringName n = E->get();
+		type_map[n].icon = EditorNode::get_singleton()->get_class_icon(n);
+	}
+	types.clear();
+	ScriptServer::get_global_class_list(&types);
+	for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
+		TypeInfo ti;
+		StringName n = E->get();
+
+		ti.name = n;
+		ti.script = ResourceLoader::load(ScriptServer::get_global_class_path(n));
+		if (ti.script.is_null())
+			continue;
+		String icon_path = ed.script_class_get_icon_path(n);
+		if (icon_path.length())
+			ti.icon = ResourceLoader::load(ScriptServer::get_global_class_path(n));
+		ti.native = ti.script->get_instance_base_type();
+		ti.base = ScriptServer::get_global_class_base(n);
+		ti.source = SOURCE_SCRIPT_CLASS;
+
+		type_map[ti.name] = ti;
+		path_map[ti.script->get_path()] = ti.name;
+	}
+	types.clear();
+	ed.get_custom_type_class_list(&types);
+	for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
+		TypeInfo ti;
+		StringName n = E->get();
+
+		ti.name = n;
+		ti.script = ResourceLoader::load(ScriptServer::get_global_class_path(n));
+		if (ti.script.is_null())
+			continue;
+		RES icon = ed.get_custom_type_icon(n);
+		if (icon.is_valid())
+			ti.icon = icon;
+		ti.native = ti.script->get_instance_base_type();
+		ti.base = ed.get_custom_type_base(n);
+		ti.source = SOURCE_CUSTOM_TYPE;
+
+		type_map[ti.name] = ti;
+		path_map[ti.script->get_path()] = ti.name;
+	}
+	//types.clear();
+	//List<String> paths;
+	//path_map.get_key_list(&paths);
+	//for (List<String>::Element *E = paths.front(); E; E = E->next()) {
+	//	TypeInfo &ti = type_map[path_map[E->get()]];
+	//	if (ti.base == StringName())
+	//		continue;
+	//	Ref<Script> script = ti.script;
+	//	if (script.is_null())
+	//		continue;
+	//	script = script->get_base_script();
+	//	while (script.is_valid()) {
+	//		const String &p = script->get_path();
+	//		if (path_map.has(p)) {
+	//			ti.base = path_map[p];
+	//			break;
+	//		}
+	//	}
+	//	if (script.is_null())
+	//		ti.base = ti.native;
+	//}
+}
+
+bool TypeDB::class_exists(const StringName &p_type) const {
+	return type_map.has(p_type);
+}
+
+bool TypeDB::path_exists(const String &p_path) const {
+	return path_map.has(p_path);
+}
+
+StringName TypeDB::get_class_by_path(const String &p_path) const {
+	return path_exists(p_path) ? path_map[p_path] : StringName();
+}
+
+String TypeDB::get_path_by_class(const StringName &p_type) const {
+	if (!class_exists(p_type))
+		return String();
+	Ref<Script> script = type_map[p_type].script;
+	if (script.is_null())
+		return String();
+	return script->get_path();
+}
+
+StringName TypeDB::get_native(const StringName &p_type) const {
+	ERR_FAIL_COND_V(!type_map.has(p_type), StringName());
+	return type_map[p_type].native;
+}
+
+Object *TypeDB::instance(const StringName &p_type) const {
+	ERR_FAIL_COND_V(!type_map.has(p_type), NULL);
+
+	const TypeInfo &ti = type_map[p_type];
+
+	switch (ti.source) {
+		case SOURCE_ENGINE: {
+			return ClassDB::instance(ti.name);
+		} break;
+		case SOURCE_SCRIPT_CLASS:
+		case SOURCE_CUSTOM_TYPE: {
+			Object *obj = ClassDB::instance(ti.native);
+			if (!obj)
+				return NULL;
+			if (ti.script.is_null())
+				return NULL;
+			obj->set_script(ti.script.get_ref_ptr());
+			return obj;
+		} break;
+		case SOURCE_NONE: {
+			return NULL;
+		} break;
+	}
+	return NULL;
+}
+
+RES TypeDB::get_icon(const StringName &p_type) const {
+	ERR_FAIL_COND_V(!type_map.has(p_type), NULL);
+	return type_map[p_type].icon;
+}
+
+bool TypeDB::can_instance(const StringName &p_type) const {
+	ERR_FAIL_COND_V(!type_map.has(p_type), false);
+	return ClassDB::can_instance(type_map[p_type].native);
+}
+
+void TypeDB::get_class_list(List<StringName> *p_class_list) const {
+	type_map.get_key_list(p_class_list);
+}
+
+bool TypeDB::is_parent_class(const String &p_type, const String &p_inherits) const {
+	ERR_FAIL_COND_V(!type_map.has(p_type), false);
+	const TypeInfo *ti = &type_map[p_type];
+	while (ti) {
+		if (ti->name == p_inherits)
+			return true;
+		ti = type_map.has(ti->base) ? &type_map[ti->base] : NULL;
+	}
+	return false;
+}
+
+String TypeDB::get_parent_class(const String &p_type) const {
+	ERR_FAIL_COND_V(!type_map.has(p_type), String());
+	return type_map[p_type].base;
+}
+
+void TypeDB::get_inheritors_from_class(const String &p_type, List<StringName> *p_classes) const {
+	ERR_FAIL_COND(!type_map.has(p_type));
+	ERR_FAIL_COND(!p_classes);
+
+	const TypeInfo &ti = type_map[p_type];
+	List<StringName> types;
+	type_map.get_key_list(&types);
+	for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
+		const TypeInfo &a_ti = type_map[E->get()];
+		if (is_parent_class(a_ti.name, ti.name))
+			p_classes->push_back(a_ti.name);
+	}
+}
+
+void TypeDB::_bind_methods() {}
+
+TypeDB::TypeDB() {}

--- a/editor/type_db.h
+++ b/editor/type_db.h
@@ -1,0 +1,87 @@
+/*************************************************************************/
+/*  type_db.h                                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TYPE_DB_H
+#define TYPE_DB_H
+
+#include "core/script_language.h"
+#include "core/ustring.h"
+
+class TypeDB : public Reference {
+	GDCLASS(TypeDB, Reference);
+
+	enum {
+		SOURCE_NONE,
+		SOURCE_ENGINE,
+		SOURCE_SCRIPT_CLASS,
+		SOURCE_CUSTOM_TYPE
+	};
+
+	struct TypeInfo {
+		StringName name;
+		StringName base;
+		StringName native;
+		Ref<Script> script;
+		RES icon;
+		int source = SOURCE_NONE;
+	};
+
+	typedef HashMap<StringName, TypeInfo> TypeMap;
+	typedef HashMap<String, StringName> PathMap;
+
+	TypeMap type_map;
+	PathMap path_map;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void refresh();
+
+	bool path_exists(const String &p_path) const;
+	StringName get_class_by_path(const String &p_path) const;
+	String get_path_by_class(const StringName &p_type) const;
+	StringName get_native(const StringName &p_type) const;
+
+	RES get_icon(const StringName &p_type) const;
+
+	Object *instance(const StringName &p_type) const;
+	bool can_instance(const StringName &p_type) const;
+
+	bool class_exists(const StringName &p_type) const;
+	void get_class_list(List<StringName> *p_class_list) const;
+	bool is_parent_class(const String &p_type, const String &p_inherits) const;
+	String get_parent_class(const String &p_type) const;
+	void get_inheritors_from_class(const String &p_type, List<StringName> *p_classes) const;
+
+	TypeDB();
+};
+
+#endif // TYPE_DB_H


### PR DESCRIPTION
- Create a lightweight editor-only TypeDB mimicry of ClassDB which is aware of inheritance data pertaining to engine classes, script classes, and custom types.
- Refactor custom types to be indexed by name. This greatly speeds up many operations associated with them.
- The CreateDialog has undergone numerous optimizations to improve its performance, as well as simplifying the code overall to avoid handling special cases for the type blacklist and the various handling logic for engine classes, script classes, and custom types using the TypeDB as an agnostic wrapper around type names.
    - All CreateDialogs now update their data automatically in response to "filesystem_changed" signal emissions. They do not waste time updating their type list when opened, nor when the search filter is updated.
    - Class-specific exceptions used to be applied during the update search operations. Now the CreateDialog performs these checks when it updates its data. These include...
        - The type blacklist (types that are not allowed to be instantiated from the CreateDialog)
        - Types for which `ClassDB::can_instance(type)` returns `false`.
        - Nodes with "Editor" in the first part of their name.
    - Previously, the CreateDialog would check inheritance hierarchies at least twice for *all* type names, regardless of whether their name is a subsequence match to the search filter's TextEdit content. Now, inheritance checks during Tree building are only performed on types that are a match.
    - The inheritance checks made at runtime are now purely HashMap lookups in the cached inheritance data of the TypeDB. It no longer needs to load scripts and iterate through their base scripts whilst building the tree.

Closes #27333, #24557, #24041 (Issues). Closes #25675 and #25676 (PRs).
