### PR TITLE
Use the editor theme's accent color for 2D/3D selections and rotations

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2828,13 +2828,20 @@ void CanvasItemEditor::_draw_selection() {
 		Point2 bsfrom = transform.xform(drag_from);
 		Point2 bsto = transform.xform(box_selecting_to);
 
-		VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(bsfrom, bsto - bsfrom), Color(0.7, 0.7, 1.0, 0.3));
+		VisualServer::get_singleton()->canvas_item_add_rect(
+				ci,
+				Rect2(bsfrom, bsto - bsfrom),
+				get_color("accent_color", "Editor") * Color(1, 1, 1, 0.375));
 	}
 
-	Color rotate_color(0.4, 0.7, 1.0, 0.8);
 	if (drag_type == DRAG_ROTATE) {
 		// Draw the line when rotating a node
-		viewport->draw_line(transform.xform(drag_rotation_center), transform.xform(drag_to), rotate_color);
+		viewport->draw_line(
+				transform.xform(drag_rotation_center),
+				transform.xform(drag_to),
+				get_color("accent_color", "Editor") * Color(1, 1, 1, 0.6),
+				Math::round(2 * EDSCALE),
+				true);
 	}
 }
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2382,7 +2382,10 @@ void SpatialEditorViewport::_draw() {
 
 	if (cursor.region_select) {
 
-		VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor.region_begin, cursor.region_end - cursor.region_begin), Color(0.7, 0.7, 1.0, 0.3));
+		VisualServer::get_singleton()->canvas_item_add_rect(
+				ci,
+				Rect2(cursor.region_begin, cursor.region_end - cursor.region_begin),
+				get_color("accent_color", "Editor") * Color(1, 1, 1, 0.375));
 	}
 
 	if (message_time > 0) {
@@ -2396,7 +2399,13 @@ void SpatialEditorViewport::_draw() {
 	if (_edit.mode == TRANSFORM_ROTATE) {
 
 		Point2 center = _point_to_screen(_edit.center);
-		VisualServer::get_singleton()->canvas_item_add_line(ci, _edit.mouse_pos, center, Color(0.4, 0.7, 1.0, 0.8));
+		VisualServer::get_singleton()->canvas_item_add_line(
+				ci,
+				_edit.mouse_pos,
+				center,
+				get_color("accent_color", "Editor") * Color(1, 1, 1, 0.6),
+				Math::round(2 * EDSCALE),
+				true);
 	}
 	if (previewing) {
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -770,7 +770,9 @@ void GraphEdit::_top_layer_draw() {
 	}
 
 	if (box_selecting)
-		top_layer->draw_rect(box_selecting_rect, Color(0.7, 0.7, 1.0, 0.3));
+		top_layer->draw_rect(
+				box_selecting_rect,
+				get_color("accent_color", "Editor") * Color(1, 1, 1, 0.375));
 }
 
 void GraphEdit::set_selected(Node *p_child) {


### PR DESCRIPTION
This makes selection colors blend better with the rest of the editor theme.

This also makes the rotation line thicker, antialiased (only in GLES3, due to how line antialiasing is implemented) and scaled on hiDPI displays.

## Preview

### Before

![2d_gizmo_accent_selection_old](https://user-images.githubusercontent.com/180032/55295721-aa025400-5410-11e9-8a66-c9b7754e127a.png)

### After (with the default theme)

![2d_gizmo_accent_selection_new](https://user-images.githubusercontent.com/180032/55295720-aa025400-5410-11e9-8247-97bec37356b6.png)

### 2D rotation line gizmo

![2d_gizmo_accent_rotation](https://user-images.githubusercontent.com/180032/55295719-aa025400-5410-11e9-9e14-96d2401e5f5b.png)