### PR TITLE
Fixes error after duplicating a node with no name.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -918,6 +918,10 @@ bool Node::_validate_node_name(String &p_name) {
 		name = name.replace(chars[i], "");
 	}
 	bool is_valid = name == p_name;
+
+	if (name == "") {
+		name = "@Node";
+	}
 	p_name = name;
 	return is_valid;
 }
@@ -927,7 +931,9 @@ void Node::set_name(const String &p_name) {
 	String name = p_name;
 	_validate_node_name(name);
 
+	ERR_EXPLAIN("Node: Incorrect name!");
 	ERR_FAIL_COND(name == "");
+
 	data.name = name;
 
 	if (data.parent) {


### PR DESCRIPTION
This pull request changes "_validate_node_name" method in scene/main/node.cpp.
After duplicating a node with no name, duplicated node's name is set to "@node", because it can't be empty.

This pull request fixes #27319