### PR TITLE
Fix File switching between reading and writing, opened with READ_WRITE on Windows

### DIFF
--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -47,6 +47,7 @@ class FileAccessWindows : public FileAccess {
 	FILE *f;
 	int flags;
 	void check_errors() const;
+	mutable int prev_op;
 	mutable Error last_error;
 	String path;
 	String path_src;


### PR DESCRIPTION
According to official MS documentation (https://docs.microsoft.com/en-US/cpp/c-runtime-library/reference/fopen-wfopen?view=vs-2017) -

> When the "r+", "w+", or "a+" access type is specified, both reading and writing are enabled (the file is said to be open for "update"). However, when you switch from reading to writing, the input operation must encounter an EOF marker. If there is no EOF, you must use an intervening call to a file positioning function. The file positioning functions are fsetpos, fseek, and rewind. When you switch from writing to reading, you must use an intervening call to either fflush or to a file positioning function.

After readed a discussion in https://stackoverflow.com/questions/14878574/the-use-of-r-in-fopen-on-windows-vs-linux I've added these steps

1. Added call of fseek (if not EOF) when switching from reading to writing
2. Added call of fflush when switching from writing to reading

Fix #24393
 


