### PR TITLE
Fix duplicated conditions.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -320,7 +320,7 @@ if selected_platform in platform_list:
 
         if (env["warnings"] == 'extra'):
             # FIXME: enable -Wclobbered once #26351 is fixed
-            # FIXME: enable -Wlogical-op and -Wduplicated-branches once #27594 is merged
+            # FIXME: enable -Wduplicated-branches once #27594 is merged
             # Note: enable -Wimplicit-fallthrough for Clang (already part of -Wextra for GCC)
             # once we switch to C++11 or later (necessary for our FALLTHROUGH macro).
             env.Append(CCFLAGS=['-Wall', '-Wextra', '-Wno-unused-parameter']
@@ -328,7 +328,7 @@ if selected_platform in platform_list:
             env.Append(CXXFLAGS=['-Wctor-dtor-privacy', '-Wnon-virtual-dtor'])
             if methods.using_gcc(env):
                 env.Append(CCFLAGS=['-Wno-clobbered', '-Walloc-zero',
-                    '-Wduplicated-cond', '-Wstringop-overflow=4'])
+                    '-Wduplicated-cond', '-Wstringop-overflow=4', '-Wlogical-op'])
                 env.Append(CXXFLAGS=['-Wnoexcept', '-Wplacement-new=1'])
                 version = methods.get_compiler_version(env)
                 if version != None and version[0] >= '9':

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -177,6 +177,13 @@ NetSocketPosix::~NetSocketPosix() {
 	close();
 }
 
+// Silent a warning reported in #27594
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
+#endif
+
 NetSocketPosix::NetError NetSocketPosix::_get_socket_error() {
 #if defined(WINDOWS_ENABLED)
 	int err = WSAGetLastError();
@@ -200,6 +207,10 @@ NetSocketPosix::NetError NetSocketPosix::_get_socket_error() {
 	return ERR_NET_OTHER;
 #endif
 }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 bool NetSocketPosix::_can_use_ip(const IP_Address p_ip, const bool p_for_bind) const {
 

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -66,7 +66,7 @@ int sfind(const String &p_text, int p_from) {
 					break;
 				case 1: {
 					CharType c = src[read_pos];
-					found = src[read_pos] == 's' || (c >= '0' || c <= '4');
+					found = src[read_pos] == 's' || (c >= '0' && c <= '4');
 					break;
 				}
 				default:


### PR DESCRIPTION
```
drivers/unix/net_socket_posix.cpp: In member function 'NetSocketPosix::NetError NetSocketPosix::_get_socket_error()':
drivers/unix/net_socket_posix.cpp:197:22: warning: logical 'or' of equal expressions [-Wlogical-op]
  197 |  if (errno == EAGAIN || errno == EWOULDBLOCK)
      |                      ^
```
```
editor/import/editor_scene_importer_gltf.cpp:2082:124: warning: this condition has identical branches [-Wduplicated-branches]
 2082 |      animation->track_set_interpolation_type(track_idx, track.weight_tracks[i].interpolation == GLTFAnimation::INTERP_STEP ? Animation::INTERPOLATION_NEAREST : Animation::INTERPOLATION_NEAREST);
```