### PR TITLE
Fix: RichTextLabel Crash - meta_hover_ended

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1136,8 +1136,8 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 				emit_signal("meta_hover_started", meta);
 			}
 		} else if (meta_hovering) {
-			emit_signal("meta_hover_ended", current_meta);
 			meta_hovering = NULL;
+			emit_signal("meta_hover_ended", current_meta);
 			current_meta = false;
 		}
 	}


### PR DESCRIPTION
Fixed an issue where changing the cursor using `Input.set_default_cursor_shape(...)` on RichTextLabel's `meta_hover_ended` signal caused the program to crash.
Fixes #26368 

**I'm not entirely sure how this worked.** 
What I  do understand is that the `emit_signal(...)` function seemed to never return to its starting point. This lead to the `meta_hovering` variable to never be nullified, and so the `meta_hover_ended` signal kept on being sent infinitely which caused the project to crash. 
**Not sure why the** `emit_signal(...)` **behaved that way, though.**