### PR TITLE
Fix -Wnon-virtual-dtor warnings.

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -205,6 +205,8 @@ public:
 	static ScriptCodeCompletionCache *get_singleton() { return singleton; }
 
 	ScriptCodeCompletionCache();
+
+	virtual ~ScriptCodeCompletionCache() {}
 };
 
 class ScriptLanguage {

--- a/drivers/gl_context/context_gl.h
+++ b/drivers/gl_context/context_gl.h
@@ -58,7 +58,7 @@ public:
 	virtual bool is_using_vsync() const = 0;
 
 	ContextGL();
-	~ContextGL();
+	virtual ~ContextGL();
 };
 
 #endif

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -683,6 +683,7 @@ protected:
 	TextEdit *text_editor;
 
 public:
+	virtual ~SyntaxHighlighter() {}
 	virtual void _update_cache() = 0;
 	virtual Map<int, TextEdit::HighlighterInfo> _get_line_syntax_highlighting(int p_line) = 0;
 


### PR DESCRIPTION
Example of the warning:
./core/script_language.h:198:7: warning: 'class ScriptCodeCompletionCache' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]