### PR TITLE
 Fix crash when using the Tileset Editor when the given shape has no points

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2417,11 +2417,11 @@ void TileSetEditor::draw_polygon_shapes() {
 							colors.push_back(c_bg);
 						}
 					}
-					if (polygon.size() == 0)
+
+					if (polygon.size() < 3)
 						continue;
-					if (polygon.size() > 2) {
-						workspace->draw_polygon(polygon, colors);
-					}
+
+					workspace->draw_polygon(polygon, colors);
 
 					if (coord == edited_shape_coord || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::SINGLE_TILE) {
 						if (!creating_shape) {

--- a/scene/resources/convex_polygon_shape.cpp
+++ b/scene/resources/convex_polygon_shape.cpp
@@ -83,6 +83,4 @@ void ConvexPolygonShape::_bind_methods() {
 
 ConvexPolygonShape::ConvexPolygonShape() :
 		Shape(PhysicsServer::get_singleton()->shape_create(PhysicsServer::SHAPE_CONVEX_POLYGON)) {
-
-	//set_points(Vector3(1,1,1));
 }

--- a/scene/resources/convex_polygon_shape_2d.cpp
+++ b/scene/resources/convex_polygon_shape_2d.cpp
@@ -99,10 +99,4 @@ Rect2 ConvexPolygonShape2D::get_rect() const {
 
 ConvexPolygonShape2D::ConvexPolygonShape2D() :
 		Shape2D(Physics2DServer::get_singleton()->convex_polygon_shape_create()) {
-
-	int pcount = 3;
-	for (int i = 0; i < pcount; i++)
-		points.push_back(Vector2(Math::sin(i * Math_PI * 2 / pcount), -Math::cos(i * Math_PI * 2 / pcount)) * 10);
-
-	_update_shape();
 }


### PR DESCRIPTION
Fixes #27360.