### PR TITLE
Minor English fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ each of them.
 Everything referred to hereafter as "bug" also applies for feature requests.
 
 If you are reporting a new issue, you will make our life much simpler (and the
-fix come much sooner) by following those guidelines:
+fix come much sooner) by following these guidelines:
 
 #### Search first in the existing database
 


### PR DESCRIPTION
CONTRIBUTING.md would use the phrase "those guidelines" to introduce a
list. In general, the word "these" is used to refer to something that is
being introduced or has recently been introduced, and "those" is used to
refer to something that had been previously introduced.

This change also makes CONTRIBUTING.md consistent with the
documentation. The documentation guidelines at
https://docs.godotengine.org/en/latest/community/contributing/documentation_guidelines.html
use "these" to introduce a list and its singular form, "this", to
introduce items.