### PR TITLE
Allow default audio bus layout modification

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1004,6 +1004,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/config/use_custom_user_dir", false);
 	GLOBAL_DEF("application/config/custom_user_dir_name", "");
 	GLOBAL_DEF("application/config/project_settings_override", "");
+	GLOBAL_DEF("audio/default_bus_layout", "res://default_bus_layout.tres");
+	custom_prop_info["audio/default_bus_layout"] = PropertyInfo(Variant::STRING, "audio/default_bus_layout", PROPERTY_HINT_FILE, "*.tres");
 
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -496,7 +496,8 @@ void DependencyRemoveDialog::ok_pressed() {
 			res->set_path("");
 		}
 
-		// If the file we are deleting for e.g. the main scene or default environment, we must clear its definition in Project Settings.
+		// If the file we are deleting for e.g. the main scene, default environment,
+		// or audio bus layout, we must clear its definition in Project Settings.
 		if (files_to_delete[i] == ProjectSettings::get_singleton()->get("application/config/icon")) {
 			ProjectSettings::get_singleton()->set("application/config/icon", "");
 		}
@@ -517,6 +518,9 @@ void DependencyRemoveDialog::ok_pressed() {
 		}
 		if (files_to_delete[i] == ProjectSettings::get_singleton()->get("gui/theme/custom_font")) {
 			ProjectSettings::get_singleton()->set("gui/theme/custom_font", "");
+		}
+		if (files_to_delete[i] == ProjectSettings::get_singleton()->get("audio/default_bus_layout")) {
+			ProjectSettings::get_singleton()->set("audio/default_bus_layout", "");
 		}
 
 		String path = OS::get_singleton()->get_resource_dir() + files_to_delete[i].replace_first("res://", "/");

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1077,14 +1077,16 @@ void EditorAudioBuses::_load_layout() {
 
 void EditorAudioBuses::_load_default_layout() {
 
-	Ref<AudioBusLayout> state = ResourceLoader::load("res://default_bus_layout.tres");
+	String layout_path = ProjectSettings::get_singleton()->get("audio/default_bus_layout");
+
+	Ref<AudioBusLayout> state = ResourceLoader::load(layout_path);
 	if (state.is_null()) {
-		EditorNode::get_singleton()->show_warning(TTR("There is no 'res://default_bus_layout.tres' file."));
+		EditorNode::get_singleton()->show_warning(vformat(TTR("There is no '%s' file."), layout_path));
 		return;
 	}
 
-	edited_path = "res://default_bus_layout.tres";
-	file->set_text(edited_path.get_file());
+	edited_path = layout_path;
+	file->set_text(layout_path.get_file());
 	AudioServer::get_singleton()->set_bus_layout(state);
 	_update_buses();
 	EditorNode::get_singleton()->get_undo_redo()->clear_history();
@@ -1213,7 +1215,7 @@ EditorAudioBuses::EditorAudioBuses() {
 
 	set_v_size_flags(SIZE_EXPAND_FILL);
 
-	edited_path = "res://default_bus_layout.tres";
+	edited_path = ProjectSettings::get_singleton()->get("audio/default_bus_layout");
 
 	file_dialog = memnew(EditorFileDialog);
 	List<String> ext;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1045,8 +1045,10 @@ void AudioServer::update() {
 
 void AudioServer::load_default_bus_layout() {
 
-	if (ResourceLoader::exists("res://default_bus_layout.tres")) {
-		Ref<AudioBusLayout> default_layout = ResourceLoader::load("res://default_bus_layout.tres");
+	String layout_path = ProjectSettings::get_singleton()->get("audio/default_bus_layout");
+
+	if (ResourceLoader::exists(layout_path)) {
+		Ref<AudioBusLayout> default_layout = ResourceLoader::load(layout_path);
 		if (default_layout.is_valid()) {
 			set_bus_layout(default_layout);
 		}


### PR DESCRIPTION
The actual default bus layout name is hardcoded in Godot. This is an artificial limitation and doesn't allow modifying the name or have it in a folder as you can with the default environment or main scene.

This PR adds a project setting and a button in the bus layout editor to set the actual edited bus as the default.

In project settings:
![image](https://user-images.githubusercontent.com/14951430/55497358-7f4b1200-5641-11e9-826b-3ac132653e0e.png)

Non default layout open (Set Default button enabled):
![image](https://user-images.githubusercontent.com/14951430/55497377-8a05a700-5641-11e9-8fe9-5ab5beec9b7a.png)

Default layout open (button disabled):
![image](https://user-images.githubusercontent.com/14951430/55497383-8bcf6a80-5641-11e9-9a5f-a5c28cf59ebc.png)
