### PR TITLE
Document built-in LineEdit keybindings

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -1,10 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="LineEdit" inherits="Control" category="Core" version="3.2">
 	<brief_description>
-		Control that provides single line string editing.
+		Control that provides single-line string editing.
 	</brief_description>
 	<description>
-		LineEdit provides a single line string editor, used for text fields.
+		LineEdit provides a single-line string editor, used for text fields. It features many built-in shortcuts which will always be available:
+		- Ctrl + C: Copy
+		- Ctrl + X: Cut
+		- Ctrl + V or Ctrl + Y: Paste/"yank"
+		- Ctrl + Z: Undo
+		- Ctrl + Shift + Z: Redo
+		- Ctrl + U: Delete text from the cursor position to the beginning of the line
+		- Ctrl + K: Delete text from the cursor position to the end of the line
+		- Ctrl + A: Select all text
+		- Up/Down arrow: Move the cursor to the beginning/end of the line
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Following discussion in https://github.com/godotengine/godot/issues/27613, I thought it'd be useful to document built-in LineEdit keybindings. I mainly documented the less "obivous" bindings here; if you think any is missing ([line_edit.cpp](https://github.com/godotengine/godot/blob/master/scene/gui/line_edit.cpp)), feel free to comment :smiley:

PS: It doesn't look great formatting-wise, is there any way to improve how it displays in the editor help?

![image](https://user-images.githubusercontent.com/180032/55511203-4f5f3700-5660-11e9-8890-1f80cf56e678.png)
