### PR TITLE
Fixed multi selecting when searching node tree

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -584,6 +584,9 @@ TreeItem *SceneTreeEditor::_find(TreeItem *p_node, const NodePath &p_path) {
 		return NULL;
 
 	NodePath np = p_node->get_metadata(0);
+
+	editor_selection = NULL;
+
 	if (np == p_path)
 		return p_node;
 


### PR DESCRIPTION
fix #25794

Set editor selector to null in the find function. This deselects any nodes after another node is selected with a node filter on.