### PR TITLE
Fix Cursor Color in the Label/RichTextLabel

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -832,7 +832,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("side_margin", "TabContainer", 0);
 	theme->set_icon("tab", "TextEdit", theme->get_icon("GuiTab", "EditorIcons"));
 	theme->set_color("font_color", "TextEdit", font_color);
-	theme->set_color("caret_color", "TextEdit", highlight_color);
+	theme->set_color("caret_color", "TextEdit", font_color);
 	theme->set_color("selection_color", "TextEdit", font_color_selection);
 
 	// H/VSplitContainer


### PR DESCRIPTION
I was able to change the cursor color of the text edit from cursor_color (which displayed a caret with a dull color that was hard to see) to mono_color (which displayed a white caret in the dark theme of godot and black caret in the light theme of godot), making it easier to be seen.

*Bugsquad edit: This closes #26246.*