### PR TITLE
SCons: Fix OPUS_ARM_OPT flag applied for all android/iphone arches

### DIFF
--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -220,10 +220,15 @@ if env['builtin_opus']:
     ]
     env_opus.Append(CPPPATH=[thirdparty_dir + "/" + dir for dir in thirdparty_include_paths])
 
-    if env["platform"] == "android" or env["platform"] == "iphone":
-        if ("arch" in env and env["arch"] == "arm") or ("android_arch" in env and env["android_arch"] in ["armv6", "armv7"]):
+    if env["platform"] == "android":
+        if ("android_arch" in env and env["android_arch"] in ["armv6", "armv7"]):
             env_opus.Append(CFLAGS=["-DOPUS_ARM_OPT"])
-        elif ("arch" in env and env["arch"] == "arm64") or ("android_arch" in env and env["android_arch"] == "arm64v8"):
+        elif ("android_arch" in env and env["android_arch"] == "arm64v8"):
+            env_opus.Append(CFLAGS=["-DOPUS_ARM64_OPT"])
+    elif env["platform"] == "iphone":
+        if ("arch" in env and env["arch"] == "arm"):
+            env_opus.Append(CFLAGS=["-DOPUS_ARM_OPT"])
+        elif ("arch" in env and env["arch"] == "arm64"):
             env_opus.Append(CFLAGS=["-DOPUS_ARM64_OPT"])
 
     env_thirdparty = env_opus.Clone()


### PR DESCRIPTION
The first 'if' always evaluated to true, as it evaluated values which are the default
ones for Android and iOS respectively, so even if one of them was overridden, the other
one would be true.

Fixes #27658.