### PR TITLE
Fix BitMap calculating incorrect true bit count

### DIFF
--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -96,7 +96,7 @@ int BitMap::get_true_bit_count() const {
 	const uint8_t *d = bitmask.ptr();
 	int c = 0;
 
-	//fast, almot branchless version
+	//fast, almost branchless version
 
 	for (int i = 0; i < ds; i++) {
 
@@ -106,6 +106,7 @@ int BitMap::get_true_bit_count() const {
 		c += (d[i] & (1 << 4)) >> 4;
 		c += (d[i] & (1 << 3)) >> 3;
 		c += (d[i] & (1 << 2)) >> 2;
+		c += (d[i] & (1 << 1)) >> 1;
 		c += d[i] & 1;
 	}
 


### PR DESCRIPTION
Simply fixes #27681 without reinventing anything.