### PR TITLE
[WIP] Make StyleBox use int instead of float for margin/grow

### DIFF
--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -34,7 +34,7 @@
 			</description>
 		</method>
 		<method name="get_margin" qualifiers="const">
-			<return type="float">
+			<return type="int">
 			</return>
 			<argument index="0" name="margin" type="int" enum="Margin">
 			</argument>
@@ -70,21 +70,21 @@
 		</method>
 	</methods>
 	<members>
-		<member name="content_margin_bottom" type="float" setter="set_default_margin" getter="get_default_margin">
+		<member name="content_margin_bottom" type="int" setter="set_default_margin" getter="get_default_margin">
 			The bottom margin for the contents of this style box. Increasing this value reduces the space available to the contents from the bottom.
 			If this value is negative, it is ignored and a child-specific margin is used instead. For example for [StyleBoxFlat] the border thickness (if any) is used instead.
 			It is up to the code using this style box to decide what these contents are: for example, a [Button] respects this content margin for the textual contents of the button.
 			[method get_margin] should be used to fetch this value as consumer instead of reading these properties directly. This is because it correctly respects negative values and the fallback mentioned above.
 		</member>
-		<member name="content_margin_left" type="float" setter="set_default_margin" getter="get_default_margin">
+		<member name="content_margin_left" type="int" setter="set_default_margin" getter="get_default_margin">
 			The left margin for the contents of this style box.	Increasing this value reduces the space available to the contents from the left.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
-		<member name="content_margin_right" type="float" setter="set_default_margin" getter="get_default_margin">
+		<member name="content_margin_right" type="int" setter="set_default_margin" getter="get_default_margin">
 			The right margin for the contents of this style box. Increasing this value reduces the space available to the contents from the right.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
-		<member name="content_margin_top" type="float" setter="set_default_margin" getter="get_default_margin">
+		<member name="content_margin_top" type="int" setter="set_default_margin" getter="get_default_margin">
 			The top margin for the contents of this style box. Increasing this value reduces the space available to the contents from the top.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -65,7 +65,7 @@
 		<method name="set_expand_margin_all">
 			<return type="void">
 			</return>
-			<argument index="0" name="size" type="float">
+			<argument index="0" name="size" type="int">
 			</argument>
 			<description>
 			</description>
@@ -73,13 +73,13 @@
 		<method name="set_expand_margin_individual">
 			<return type="void">
 			</return>
-			<argument index="0" name="size_left" type="float">
+			<argument index="0" name="size_left" type="int">
 			</argument>
-			<argument index="1" name="size_top" type="float">
+			<argument index="1" name="size_top" type="int">
 			</argument>
-			<argument index="2" name="size_right" type="float">
+			<argument index="2" name="size_right" type="int">
 			</argument>
-			<argument index="3" name="size_bottom" type="float">
+			<argument index="3" name="size_bottom" type="int">
 			</argument>
 			<description>
 			</description>
@@ -133,16 +133,16 @@
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled">
 			Toggels drawing of the inner part of the stylebox.
 		</member>
-		<member name="expand_margin_bottom" type="float" setter="set_expand_margin" getter="get_expand_margin">
+		<member name="expand_margin_bottom" type="int" setter="set_expand_margin" getter="get_expand_margin">
 			Expands the stylebox outside of the control rect on the bottom edge. Useful in combination with border_width_bottom. To draw a border outside the control rect.
 		</member>
-		<member name="expand_margin_left" type="float" setter="set_expand_margin" getter="get_expand_margin">
+		<member name="expand_margin_left" type="int" setter="set_expand_margin" getter="get_expand_margin">
 			Expands the stylebox outside of the control rect on the left edge. Useful in combination with border_width_left. To draw a border outside the control rect.
 		</member>
-		<member name="expand_margin_right" type="float" setter="set_expand_margin" getter="get_expand_margin">
-			Expands the stylebox outside of the control rect on the right edge. Useful in combination with border_width_right. To draw a border outside the control rect.
+		<member name="expand_margin_right" type="int" setter="set_expand_margin" getter="get_expand_margin">
+			Expands the stylebox outside of the int rect on the right edge. Useful in combination with border_width_right. To draw a border outside the control rect.
 		</member>
-		<member name="expand_margin_top" type="float" setter="set_expand_margin" getter="get_expand_margin">
+		<member name="expand_margin_top" type="int" setter="set_expand_margin" getter="get_expand_margin">
 			Expands the stylebox outside of the control rect on the top edge. Useful in combination with border_width_top. To draw a border outside the control rect.
 		</member>
 		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color">

--- a/doc/classes/StyleBoxLine.xml
+++ b/doc/classes/StyleBoxLine.xml
@@ -13,9 +13,9 @@
 	<members>
 		<member name="color" type="Color" setter="set_color" getter="get_color">
 		</member>
-		<member name="grow_begin" type="float" setter="set_grow_begin" getter="get_grow_begin">
+		<member name="grow_begin" type="int" setter="set_grow_begin" getter="get_grow_begin">
 		</member>
-		<member name="grow_end" type="float" setter="set_grow_end" getter="get_grow_end">
+		<member name="grow_end" type="int" setter="set_grow_end" getter="get_grow_end">
 		</member>
 		<member name="thickness" type="int" setter="set_thickness" getter="get_thickness">
 		</member>

--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -14,7 +14,7 @@
 		<method name="set_expand_margin_all">
 			<return type="void">
 			</return>
-			<argument index="0" name="size" type="float">
+			<argument index="0" name="size" type="int">
 			</argument>
 			<description>
 			</description>
@@ -22,13 +22,13 @@
 		<method name="set_expand_margin_individual">
 			<return type="void">
 			</return>
-			<argument index="0" name="size_left" type="float">
+			<argument index="0" name="size_left" type="int">
 			</argument>
-			<argument index="1" name="size_top" type="float">
+			<argument index="1" name="size_top" type="int">
 			</argument>
-			<argument index="2" name="size_right" type="float">
+			<argument index="2" name="size_right" type="int">
 			</argument>
-			<argument index="3" name="size_bottom" type="float">
+			<argument index="3" name="size_bottom" type="int">
 			</argument>
 			<description>
 			</description>
@@ -41,34 +41,34 @@
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled">
 		</member>
-		<member name="expand_margin_bottom" type="float" setter="set_expand_margin_size" getter="get_expand_margin_size">
+		<member name="expand_margin_bottom" type="int" setter="set_expand_margin_size" getter="get_expand_margin_size">
 			Expands the bottom margin of this style box when drawing, causing it be drawn larger than requested.
 		</member>
-		<member name="expand_margin_left" type="float" setter="set_expand_margin_size" getter="get_expand_margin_size">
+		<member name="expand_margin_left" type="int" setter="set_expand_margin_size" getter="get_expand_margin_size">
 			Expands the left margin of this style box when drawing, causing it be drawn larger than requested.
 		</member>
-		<member name="expand_margin_right" type="float" setter="set_expand_margin_size" getter="get_expand_margin_size">
+		<member name="expand_margin_right" type="int" setter="set_expand_margin_size" getter="get_expand_margin_size">
 			Expands the right margin of this style box when drawing, causing it be drawn larger than requested.
 		</member>
-		<member name="expand_margin_top" type="float" setter="set_expand_margin_size" getter="get_expand_margin_size">
+		<member name="expand_margin_top" type="int" setter="set_expand_margin_size" getter="get_expand_margin_size">
 			Expands the top margin of this style box when drawing, causing it be drawn larger than requested.
 		</member>
-		<member name="margin_bottom" type="float" setter="set_margin_size" getter="get_margin_size">
+		<member name="margin_bottom" type="int" setter="set_margin_size" getter="get_margin_size">
 			Increases the bottom margin of the 3x3 texture box.
 			A higher value means more of the source texture is considered to be part of the bottom border of the 3x3 box.
 			This is also the value used as fallback for [member StyleBox.content_margin_bottom] if it is negative.
 		</member>
-		<member name="margin_left" type="float" setter="set_margin_size" getter="get_margin_size">
+		<member name="margin_left" type="int" setter="set_margin_size" getter="get_margin_size">
 			Increases the left margin of the 3x3 texture box.
 			A higher value means more of the source texture is considered to be part of the left border of the 3x3 box.
 			This is also the value used as fallback for [member StyleBox.content_margin_left] if it is negative.
 		</member>
-		<member name="margin_right" type="float" setter="set_margin_size" getter="get_margin_size">
+		<member name="margin_right" type="int" setter="set_margin_size" getter="get_margin_size">
 			Increases the right margin of the 3x3 texture box.
 			A higher value means more of the source texture is considered to be part of the right border of the 3x3 box.
 			This is also the value used as fallback for [member StyleBox.content_margin_right] if it is negative.
 		</member>
-		<member name="margin_top" type="float" setter="set_margin_size" getter="get_margin_size">
+		<member name="margin_top" type="int" setter="set_margin_size" getter="get_margin_size">
 			Increases the top margin of the 3x3 texture box.
 			A higher value means more of the source texture is considered to be part of the top border of the 3x3 box.
 			This is also the value used as fallback for [member StyleBox.content_margin_top] if it is negative.

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -38,17 +38,17 @@ bool StyleBox::test_mask(const Point2 &p_point, const Rect2 &p_rect) const {
 	return true;
 }
 
-void StyleBox::set_default_margin(Margin p_margin, float p_value) {
+void StyleBox::set_default_margin(Margin p_margin, int p_value) {
 
 	margin[p_margin] = p_value;
 	emit_changed();
 }
-float StyleBox::get_default_margin(Margin p_margin) const {
+int StyleBox::get_default_margin(Margin p_margin) const {
 
 	return margin[p_margin];
 }
 
-float StyleBox::get_margin(Margin p_margin) const {
+int StyleBox::get_margin(Margin p_margin) const {
 
 	if (margin[p_margin] < 0)
 		return get_style_margin(p_margin);
@@ -94,10 +94,10 @@ void StyleBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "rect"), &StyleBox::draw);
 
 	ADD_GROUP("Content Margin", "content_margin_");
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "content_margin_left", PROPERTY_HINT_RANGE, "-1,2048,1"), "set_default_margin", "get_default_margin", MARGIN_LEFT);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "content_margin_right", PROPERTY_HINT_RANGE, "-1,2048,1"), "set_default_margin", "get_default_margin", MARGIN_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "content_margin_top", PROPERTY_HINT_RANGE, "-1,2048,1"), "set_default_margin", "get_default_margin", MARGIN_TOP);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "content_margin_bottom", PROPERTY_HINT_RANGE, "-1,2048,1"), "set_default_margin", "get_default_margin", MARGIN_BOTTOM);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "content_margin_left", PROPERTY_HINT_RANGE, "-1,2048,1"), "set_default_margin", "get_default_margin", MARGIN_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "content_margin_right", PROPERTY_HINT_RANGE, "-1,2048,1"), "set_default_margin", "get_default_margin", MARGIN_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "content_margin_top", PROPERTY_HINT_RANGE, "-1,2048,1"), "set_default_margin", "get_default_margin", MARGIN_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "content_margin_bottom", PROPERTY_HINT_RANGE, "-1,2048,1"), "set_default_margin", "get_default_margin", MARGIN_BOTTOM);
 }
 
 StyleBox::StyleBox() {
@@ -141,7 +141,7 @@ Ref<Texture> StyleBoxTexture::get_normal_map() const {
 	return normal_map;
 }
 
-void StyleBoxTexture::set_margin_size(Margin p_margin, float p_size) {
+void StyleBoxTexture::set_margin_size(Margin p_margin, int p_size) {
 
 	ERR_FAIL_INDEX((int)p_margin, 4);
 
@@ -155,12 +155,12 @@ void StyleBoxTexture::set_margin_size(Margin p_margin, float p_size) {
 	};
 	_change_notify(margin_prop[p_margin]);
 }
-float StyleBoxTexture::get_margin_size(Margin p_margin) const {
+int StyleBoxTexture::get_margin_size(Margin p_margin) const {
 
 	return margin[p_margin];
 }
 
-float StyleBoxTexture::get_style_margin(Margin p_margin) const {
+int StyleBoxTexture::get_style_margin(Margin p_margin) const {
 
 	return margin[p_margin];
 }
@@ -205,14 +205,14 @@ Size2 StyleBoxTexture::get_center_size() const {
 	return region_rect.size - get_minimum_size();
 }
 
-void StyleBoxTexture::set_expand_margin_size(Margin p_expand_margin, float p_size) {
+void StyleBoxTexture::set_expand_margin_size(Margin p_expand_margin, int p_size) {
 
 	ERR_FAIL_INDEX((int)p_expand_margin, 4);
 	expand_margin[p_expand_margin] = p_size;
 	emit_changed();
 }
 
-void StyleBoxTexture::set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom) {
+void StyleBoxTexture::set_expand_margin_size_individual(int p_left, int p_top, int p_right, int p_bottom) {
 	expand_margin[MARGIN_LEFT] = p_left;
 	expand_margin[MARGIN_TOP] = p_top;
 	expand_margin[MARGIN_RIGHT] = p_right;
@@ -220,7 +220,7 @@ void StyleBoxTexture::set_expand_margin_size_individual(float p_left, float p_to
 	emit_changed();
 }
 
-void StyleBoxTexture::set_expand_margin_size_all(float p_expand_margin_size) {
+void StyleBoxTexture::set_expand_margin_size_all(int p_expand_margin_size) {
 	for (int i = 0; i < 4; i++) {
 
 		expand_margin[i] = p_expand_margin_size;
@@ -228,7 +228,7 @@ void StyleBoxTexture::set_expand_margin_size_all(float p_expand_margin_size) {
 	emit_changed();
 }
 
-float StyleBoxTexture::get_expand_margin_size(Margin p_expand_margin) const {
+int StyleBoxTexture::get_expand_margin_size(Margin p_expand_margin) const {
 
 	ERR_FAIL_INDEX_V((int)p_expand_margin, 4, 0);
 	return expand_margin[p_expand_margin];
@@ -319,15 +319,15 @@ void StyleBoxTexture::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "normal_map", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_normal_map", "get_normal_map");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "region_rect"), "set_region_rect", "get_region_rect");
 	ADD_GROUP("Margin", "margin_");
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "margin_left", PROPERTY_HINT_RANGE, "0,2048,1"), "set_margin_size", "get_margin_size", MARGIN_LEFT);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "margin_right", PROPERTY_HINT_RANGE, "0,2048,1"), "set_margin_size", "get_margin_size", MARGIN_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "margin_top", PROPERTY_HINT_RANGE, "0,2048,1"), "set_margin_size", "get_margin_size", MARGIN_TOP);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1"), "set_margin_size", "get_margin_size", MARGIN_BOTTOM);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "margin_left", PROPERTY_HINT_RANGE, "0,2048,1"), "set_margin_size", "get_margin_size", MARGIN_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "margin_right", PROPERTY_HINT_RANGE, "0,2048,1"), "set_margin_size", "get_margin_size", MARGIN_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "margin_top", PROPERTY_HINT_RANGE, "0,2048,1"), "set_margin_size", "get_margin_size", MARGIN_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1"), "set_margin_size", "get_margin_size", MARGIN_BOTTOM);
 	ADD_GROUP("Expand Margin", "expand_margin_");
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "expand_margin_left", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin_size", "get_expand_margin_size", MARGIN_LEFT);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "expand_margin_right", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin_size", "get_expand_margin_size", MARGIN_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "expand_margin_top", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin_size", "get_expand_margin_size", MARGIN_TOP);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "expand_margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin_size", "get_expand_margin_size", MARGIN_BOTTOM);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "expand_margin_left", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin_size", "get_expand_margin_size", MARGIN_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "expand_margin_right", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin_size", "get_expand_margin_size", MARGIN_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "expand_margin_top", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin_size", "get_expand_margin_size", MARGIN_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "expand_margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin_size", "get_expand_margin_size", MARGIN_BOTTOM);
 	ADD_GROUP("Axis Stretch", "axis_stretch_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis_stretch_horizontal", PROPERTY_HINT_ENUM, "Stretch,Tile,Tile Fit"), "set_h_axis_stretch_mode", "get_h_axis_stretch_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis_stretch_vertical", PROPERTY_HINT_ENUM, "Stretch,Tile,Tile Fit"), "set_v_axis_stretch_mode", "get_v_axis_stretch_mode");
@@ -455,13 +455,13 @@ int StyleBoxFlat::get_corner_radius(const Corner p_corner) const {
 	return corner_radius[p_corner];
 }
 
-void StyleBoxFlat::set_expand_margin_size(Margin p_expand_margin, float p_size) {
+void StyleBoxFlat::set_expand_margin_size(Margin p_expand_margin, int p_size) {
 
 	expand_margin[p_expand_margin] = p_size;
 	emit_changed();
 }
 
-void StyleBoxFlat::set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom) {
+void StyleBoxFlat::set_expand_margin_size_individual(int p_left, int p_top, int p_right, int p_bottom) {
 	expand_margin[MARGIN_LEFT] = p_left;
 	expand_margin[MARGIN_TOP] = p_top;
 	expand_margin[MARGIN_RIGHT] = p_right;
@@ -469,7 +469,7 @@ void StyleBoxFlat::set_expand_margin_size_individual(float p_left, float p_top, 
 	emit_changed();
 }
 
-void StyleBoxFlat::set_expand_margin_size_all(float p_expand_margin_size) {
+void StyleBoxFlat::set_expand_margin_size_all(int p_expand_margin_size) {
 	for (int i = 0; i < 4; i++) {
 
 		expand_margin[i] = p_expand_margin_size;
@@ -477,7 +477,7 @@ void StyleBoxFlat::set_expand_margin_size_all(float p_expand_margin_size) {
 	emit_changed();
 }
 
-float StyleBoxFlat::get_expand_margin_size(Margin p_expand_margin) const {
+int StyleBoxFlat::get_expand_margin_size(Margin p_expand_margin) const {
 
 	return expand_margin[p_expand_margin];
 }
@@ -762,7 +762,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	vs->canvas_item_add_triangle_array(p_canvas_item, indices, verts, colors);
 }
 
-float StyleBoxFlat::get_style_margin(Margin p_margin) const {
+int StyleBoxFlat::get_style_margin(Margin p_margin) const {
 	return border_width[p_margin];
 }
 void StyleBoxFlat::_bind_methods() {
@@ -835,10 +835,10 @@ void StyleBoxFlat::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "corner_detail", PROPERTY_HINT_RANGE, "1,128,1"), "set_corner_detail", "get_corner_detail");
 
 	ADD_GROUP("Expand Margin", "expand_margin_");
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "expand_margin_left", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin", "get_expand_margin", MARGIN_LEFT);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "expand_margin_right", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin", "get_expand_margin", MARGIN_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "expand_margin_top", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin", "get_expand_margin", MARGIN_TOP);
-	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "expand_margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin", "get_expand_margin", MARGIN_BOTTOM);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "expand_margin_left", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin", "get_expand_margin", MARGIN_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "expand_margin_right", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin", "get_expand_margin", MARGIN_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "expand_margin_top", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin", "get_expand_margin", MARGIN_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "expand_margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin", "get_expand_margin", MARGIN_BOTTOM);
 
 	ADD_GROUP("Shadow", "shadow_");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "shadow_color"), "set_shadow_color", "get_shadow_color");
@@ -909,19 +909,19 @@ bool StyleBoxLine::is_vertical() const {
 	return vertical;
 }
 
-void StyleBoxLine::set_grow_end(float p_grow_end) {
+void StyleBoxLine::set_grow_end(int p_grow_end) {
 	grow_end = p_grow_end;
 	emit_changed();
 }
-float StyleBoxLine::get_grow_end() const {
+int StyleBoxLine::get_grow_end() const {
 	return grow_end;
 }
 
-void StyleBoxLine::set_grow_begin(float p_grow_begin) {
+void StyleBoxLine::set_grow_begin(int p_grow_begin) {
 	grow_begin = p_grow_begin;
 	emit_changed();
 }
-float StyleBoxLine::get_grow_begin() const {
+int StyleBoxLine::get_grow_begin() const {
 	return grow_begin;
 }
 
@@ -939,12 +939,12 @@ void StyleBoxLine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_vertical"), &StyleBoxLine::is_vertical);
 
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "grow_begin", PROPERTY_HINT_RANGE, "-300,300,1"), "set_grow_begin", "get_grow_begin");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "grow_end", PROPERTY_HINT_RANGE, "-300,300,1"), "set_grow_end", "get_grow_end");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "grow_begin", PROPERTY_HINT_RANGE, "-300,300,1"), "set_grow_begin", "get_grow_begin");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "grow_end", PROPERTY_HINT_RANGE, "-300,300,1"), "set_grow_end", "get_grow_end");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "thickness", PROPERTY_HINT_RANGE, "0,10"), "set_thickness", "get_thickness");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "vertical"), "set_vertical", "is_vertical");
 }
-float StyleBoxLine::get_style_margin(Margin p_margin) const {
+int StyleBoxLine::get_style_margin(Margin p_margin) const {
 	return thickness;
 }
 Size2 StyleBoxLine::get_center_size() const {

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -44,18 +44,18 @@ class StyleBox : public Resource {
 	GDCLASS(StyleBox, Resource);
 	RES_BASE_EXTENSION("stylebox");
 	OBJ_SAVE_TYPE(StyleBox);
-	float margin[4];
+	int margin[4];
 
 protected:
-	virtual float get_style_margin(Margin p_margin) const = 0;
+	virtual int get_style_margin(Margin p_margin) const = 0;
 	static void _bind_methods();
 
 public:
 	virtual bool test_mask(const Point2 &p_point, const Rect2 &p_rect) const;
 
-	void set_default_margin(Margin p_margin, float p_value);
-	float get_default_margin(Margin p_margin) const;
-	float get_margin(Margin p_margin) const;
+	void set_default_margin(Margin p_margin, int p_value);
+	int get_default_margin(Margin p_margin) const;
+	int get_margin(Margin p_margin) const;
 	virtual Size2 get_center_size() const;
 
 	virtual void draw(RID p_canvas_item, const Rect2 &p_rect) const = 0;
@@ -71,7 +71,7 @@ public:
 class StyleBoxEmpty : public StyleBox {
 
 	GDCLASS(StyleBoxEmpty, StyleBox);
-	virtual float get_style_margin(Margin p_margin) const { return 0; }
+	virtual int get_style_margin(Margin p_margin) const { return 0; }
 
 public:
 	virtual void draw(RID p_canvas_item, const Rect2 &p_rect) const {}
@@ -90,8 +90,8 @@ public:
 	};
 
 private:
-	float expand_margin[4];
-	float margin[4];
+	int expand_margin[4];
+	int margin[4];
 	Rect2 region_rect;
 	Ref<Texture> texture;
 	Ref<Texture> normal_map;
@@ -101,17 +101,17 @@ private:
 	AxisStretchMode axis_v;
 
 protected:
-	virtual float get_style_margin(Margin p_margin) const;
+	virtual int get_style_margin(Margin p_margin) const;
 	static void _bind_methods();
 
 public:
-	void set_expand_margin_size(Margin p_expand_margin, float p_size);
-	void set_expand_margin_size_all(float p_expand_margin_size);
-	void set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom);
-	float get_expand_margin_size(Margin p_expand_margin) const;
+	void set_expand_margin_size(Margin p_expand_margin, int p_size);
+	void set_expand_margin_size_all(int p_expand_margin_size);
+	void set_expand_margin_size_individual(int p_left, int p_top, int p_right, int p_bottom);
+	int get_expand_margin_size(Margin p_expand_margin) const;
 
-	void set_margin_size(Margin p_margin, float p_size);
-	float get_margin_size(Margin p_margin) const;
+	void set_margin_size(Margin p_margin, int p_size);
+	int get_margin_size(Margin p_margin) const;
 
 	void set_region_rect(const Rect2 &p_region_rect);
 	Rect2 get_region_rect() const;
@@ -164,7 +164,7 @@ class StyleBoxFlat : public StyleBox {
 	int aa_size;
 
 protected:
-	virtual float get_style_margin(Margin p_margin) const;
+	virtual int get_style_margin(Margin p_margin) const;
 	static void _bind_methods();
 
 public:
@@ -202,10 +202,10 @@ public:
 	int get_corner_detail() const;
 
 	//EXPANDS
-	void set_expand_margin_size(Margin p_expand_margin, float p_size);
-	void set_expand_margin_size_all(float p_expand_margin_size);
-	void set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom);
-	float get_expand_margin_size(Margin p_expand_margin) const;
+	void set_expand_margin_size(Margin p_expand_margin, int p_size);
+	void set_expand_margin_size_all(int p_expand_margin_size);
+	void set_expand_margin_size_individual(int p_left, int p_top, int p_right, int p_bottom);
+	int get_expand_margin_size(Margin p_expand_margin) const;
 
 	//DRAW CENTER
 	void set_draw_center(bool p_enabled);
@@ -240,11 +240,11 @@ class StyleBoxLine : public StyleBox {
 	Color color;
 	int thickness;
 	bool vertical;
-	float grow_begin;
-	float grow_end;
+	int grow_begin;
+	int grow_end;
 
 protected:
-	virtual float get_style_margin(Margin p_margin) const;
+	virtual int get_style_margin(Margin p_margin) const;
 	static void _bind_methods();
 
 public:
@@ -257,11 +257,11 @@ public:
 	void set_vertical(bool p_vertical);
 	bool is_vertical() const;
 
-	void set_grow_begin(float p_grow);
-	float get_grow_begin() const;
+	void set_grow_begin(int p_grow);
+	int get_grow_begin() const;
 
-	void set_grow_end(float p_grow);
-	float get_grow_end() const;
+	void set_grow_end(int p_grow);
+	int get_grow_end() const;
 
 	virtual Size2 get_center_size() const;
 


### PR DESCRIPTION
Attempt to fix #25845. Not sure if I should try to fix it this way. Maybe I should just convert float to int when setting margin size of StyleBoxTexture in TextureRegion.