### PR TITLE
Fix wrong method binds and registered class

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -249,6 +249,11 @@ void ClassDB::set_current_api(APIType p_api) {
 	current_api = p_api;
 }
 
+ClassDB::APIType ClassDB::get_current_api() {
+
+	return current_api;
+}
+
 HashMap<StringName, ClassDB::ClassInfo> ClassDB::classes;
 HashMap<StringName, StringName> ClassDB::resource_base_extensions;
 HashMap<StringName, StringName> ClassDB::compat_classes;

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -371,6 +371,7 @@ public:
 	static void init();
 
 	static void set_current_api(APIType p_api);
+	static APIType get_current_api();
 	static void cleanup();
 };
 

--- a/modules/assimp/register_types.cpp
+++ b/modules/assimp/register_types.cpp
@@ -44,7 +44,13 @@ static void _editor_init() {
 void register_assimp_types() {
 
 #ifdef TOOLS_ENABLED
+	ClassDB::APIType prev_api = ClassDB::get_current_api();
+	ClassDB::set_current_api(ClassDB::API_EDITOR);
+
 	ClassDB::register_class<EditorSceneImporterAssimp>();
+
+	ClassDB::set_current_api(prev_api);
+
 	EditorNode::add_init_callback(_editor_init);
 #endif
 }

--- a/modules/mono/glue/base_object_glue.cpp
+++ b/modules/mono/glue/base_object_glue.cpp
@@ -192,7 +192,7 @@ MonoBoolean godot_icall_DynamicGodotObject_InvokeMember(Object *p_ptr, MonoStrin
 
 	*r_result = GDMonoMarshal::variant_to_mono_object(result);
 
-	return error.error == OK;
+	return error.error == Variant::CallError::CALL_OK;
 }
 
 MonoBoolean godot_icall_DynamicGodotObject_GetMember(Object *p_ptr, MonoString *p_name, MonoObject **r_result) {

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -679,7 +679,7 @@ void AnimatedSprite::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_playing", "playing"), &AnimatedSprite::_set_playing);
 	ClassDB::bind_method(D_METHOD("_is_playing"), &AnimatedSprite::_is_playing);
 
-	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite::play, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite::play, DEFVAL(StringName()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite::stop);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite::is_playing);
 


### PR DESCRIPTION
`EditorSceneImporterAssimp` seems to be the first editor class registered from a module. As such, it has to make sure it's registered as part of the editor API and not the core API.
