### PR TITLE
Fix missing re-activation of bullet physics sleep feature

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -597,6 +597,8 @@ void RigidBodyBullet::set_state(PhysicsServer::BodyState p_state, const Variant 
 			if (!can_sleep) {
 				// Can't sleep
 				btBody->forceActivationState(DISABLE_DEACTIVATION);
+			} else {
+				btBody->forceActivationState(ACTIVE_TAG);
 			}
 			break;
 	}


### PR DESCRIPTION
Adds the missing option of re-enabling the sleep feature in bullet physics once a body had the sleep feature disabled.

Fixes #27715 