### PR TITLE
Minor English fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ understand that:
   and then figure out why it's failing.
 
 To speed up our work, please prepare for us **a simple project** that isolates
-and reproduces the issue. This is always the **the best way for us to fix it**.
+and reproduces the issue. This is always the **best way for us to fix it**.
 You can attach a zip file with the minimal project directly to the bug report,
 by drag and dropping the file in the GitHub edition field.
 


### PR DESCRIPTION
Small fix to the CONTRIBUTING.md file. Repeated "the" in one of the sentences under the "Provide a simple, example project" section of the file.