### PR TITLE
Fix where json exported empty types

### DIFF
--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -323,6 +323,9 @@ List<ClassAPI> generate_c_api_classes() {
 						arg_type = "Variant";
 					} else if (arg_info.type == Variant::OBJECT) {
 						arg_type = arg_info.class_name;
+						if (arg_type == "") {
+							arg_type = Variant::get_type_name(arg_info.type);
+						}
 					} else {
 						arg_type = Variant::get_type_name(arg_info.type);
 					}


### PR DESCRIPTION
class_name turned out to not be consistently filled (I don't know why) so where it is not defined I'm reverting to calling get_type_name. Seems to do the trick.

Applied this on 3.1 because we need to get the json file out for 3.1 in order to make 3.1 gdnative modules. Obviously fix also needs to be applied to master.

Fixes #27670