### PR TITLE
AnimationNode* docs

### DIFF
--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -136,8 +136,10 @@
 		<constant name="BLEND_MODE_INTERPOLATED" value="0" enum="BlendMode">
 		</constant>
 		<constant name="BLEND_MODE_DISCRETE" value="1" enum="BlendMode">
+			Useful for frame-by-frame 2D animations.
 		</constant>
 		<constant name="BLEND_MODE_DISCRETE_CARRY" value="2" enum="BlendMode">
+			Keep the current play position when switching between discrete animations.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -3,6 +3,11 @@
 	<brief_description>
 	</brief_description>
 	<description>
+		Contains multiple root nodes as children in a graph. Each node is used as a state, and provides multiple functions to alternate between states. Retrieve the AnimationNodeStateMachinePlayback object from the [AnimationTree] node to control it programatically.
+		[codeblock]
+		var state_machine = anim_tree["parameters/StateMachine/playback"]
+		state_machine.travel("SomeState")
+		[codeblock]
 	</description>
 	<tutorials>
 	</tutorials>
@@ -170,7 +175,7 @@
 		<method name="set_graph_offset">
 			<return type="void">
 			</return>
-			<argument index="0" name="name" type="Vector2">
+			<argument index="0" name="offset" type="Vector2">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -47,6 +47,7 @@
 			<argument index="0" name="to_node" type="String">
 			</argument>
 			<description>
+				Transition from the current state to another one, while visiting all the intermediate ones. This is done via the A* algorithm.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -12,16 +12,22 @@
 	</methods>
 	<members>
 		<member name="advance_condition" type="String" setter="set_advance_condition" getter="get_advance_condition">
+			Turn on auto advance when this condition is set. This is a custom text field that can be filled with a variable name. The variable can be modified from code.
 		</member>
 		<member name="auto_advance" type="bool" setter="set_auto_advance" getter="has_auto_advance">
+			Turn on the transition automatically when this state is reached. This works best with [code]SWITCH_MODE_AT_END[/code].
 		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled">
+			Don't use this transition during [method AnimationNodeStateMachinePlayback.travel] or [member auto_advance].
 		</member>
 		<member name="priority" type="int" setter="set_priority" getter="get_priority">
+			Lower priority transitions are preferred when travelling through the tree via [method AnimationNodeStateMachinePlayback.travel] or [member auto_advance].
 		</member>
 		<member name="switch_mode" type="int" setter="set_switch_mode" getter="get_switch_mode" enum="AnimationNodeStateMachineTransition.SwitchMode">
+			The transition type.
 		</member>
 		<member name="xfade_time" type="float" setter="set_xfade_time" getter="get_xfade_time">
+			The time to cross-fade between this state and the next.
 		</member>
 	</members>
 	<signals>
@@ -32,10 +38,13 @@
 	</signals>
 	<constants>
 		<constant name="SWITCH_MODE_IMMEDIATE" value="0" enum="SwitchMode">
+			Switch to the next state immediately. The current state will end and blend into the beginning of the new one.
 		</constant>
 		<constant name="SWITCH_MODE_SYNC" value="1" enum="SwitchMode">
+			Switch to the next state immediately, but will seek the new state to the playback position of the old state.
 		</constant>
 		<constant name="SWITCH_MODE_AT_END" value="2" enum="SwitchMode">
+			Wait for the current state playback to end, then switch to the beginning of the next state animation.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -5,8 +5,10 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<demos>
+		<link>https://github.com/godotengine/tps-demo</link>
 	</demos>
 	<methods>
 		<method name="advance">

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -960,7 +960,7 @@ void AnimationNodeStateMachine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_end_node", "name"), &AnimationNodeStateMachine::set_end_node);
 	ClassDB::bind_method(D_METHOD("get_end_node"), &AnimationNodeStateMachine::get_end_node);
 
-	ClassDB::bind_method(D_METHOD("set_graph_offset", "name"), &AnimationNodeStateMachine::set_graph_offset);
+	ClassDB::bind_method(D_METHOD("set_graph_offset", "offset"), &AnimationNodeStateMachine::set_graph_offset);
 	ClassDB::bind_method(D_METHOD("get_graph_offset"), &AnimationNodeStateMachine::get_graph_offset);
 
 	ClassDB::bind_method(D_METHOD("_tree_changed"), &AnimationNodeStateMachine::_tree_changed);


### PR DESCRIPTION
The API docs for `AnimationTree` and the various sub-nodes are pretty bare. I think some of the info from https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html should be reproduced there, and the API docs should link back to the tutorial.

There's also an argument for not having duplicate documentation, but the API docs are usually the first thing I find when I'm looking for info on a particular class.