### PR TITLE
Allow panning while moving a node

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -205,8 +205,7 @@ private:
 		DRAG_V_GUIDE,
 		DRAG_H_GUIDE,
 		DRAG_DOUBLE_GUIDE,
-		DRAG_KEY_MOVE,
-		DRAG_PAN
+		DRAG_KEY_MOVE
 	};
 
 	EditorSelection *editor_selection;
@@ -262,6 +261,7 @@ private:
 	bool key_pos;
 	bool key_rot;
 	bool key_scale;
+	bool panning;
 
 	MenuOption last_option;
 


### PR DESCRIPTION
Closes #27300

It's the same as #27528, but I had to close that one after a horrible merge.

Anyways, you might notice that there's one more condition added since last time:
```
if (EditorSettings::get_singleton()->get("editors/2d/simple_spacebar_panning") || !Input::get_singleton()->is_key_pressed(KEY_SPACE)) {
```
I did this so the "regular spacebar panning" doesn't interfere with other tools.