### PR TITLE
Fixes being unable to use the Quat(Vector3) constructor

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1126,31 +1126,6 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 			default: return Variant();
 		}
 
-	} else if (p_argcount > 1) {
-
-		_VariantCall::ConstructFunc &c = _VariantCall::construct_funcs[p_type];
-
-		for (List<_VariantCall::ConstructData>::Element *E = c.constructors.front(); E; E = E->next()) {
-			const _VariantCall::ConstructData &cd = E->get();
-
-			if (cd.arg_count != p_argcount)
-				continue;
-
-			//validate parameters
-			for (int i = 0; i < cd.arg_count; i++) {
-				if (!Variant::can_convert(p_args[i]->type, cd.arg_types[i])) {
-					r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT; //no such constructor
-					r_error.argument = i;
-					r_error.expected = cd.arg_types[i];
-					return Variant();
-				}
-			}
-
-			Variant v;
-			cd.func(v, p_args);
-			return v;
-		}
-
 	} else if (p_argcount == 1 && p_args[0]->type == p_type) {
 		return *p_args[0]; //copy construct
 	} else if (p_argcount == 1 && (!p_strict || Variant::can_convert(p_args[0]->type, p_type))) {
@@ -1206,6 +1181,30 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 			case POOL_VECTOR3_ARRAY: return (PoolVector3Array(*p_args[0]));
 			case POOL_COLOR_ARRAY: return (PoolColorArray(*p_args[0]));
 			default: return Variant();
+		}
+	} else if (p_argcount >= 1) {
+
+		_VariantCall::ConstructFunc &c = _VariantCall::construct_funcs[p_type];
+
+		for (List<_VariantCall::ConstructData>::Element *E = c.constructors.front(); E; E = E->next()) {
+			const _VariantCall::ConstructData &cd = E->get();
+
+			if (cd.arg_count != p_argcount)
+				continue;
+
+			//validate parameters
+			for (int i = 0; i < cd.arg_count; i++) {
+				if (!Variant::can_convert(p_args[i]->type, cd.arg_types[i])) {
+					r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT; //no such constructor
+					r_error.argument = i;
+					r_error.expected = cd.arg_types[i];
+					return Variant();
+				}
+			}
+
+			Variant v;
+			cd.func(v, p_args);
+			return v;
 		}
 	}
 	r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD; //no such constructor


### PR DESCRIPTION
Before you could not use Quat's Vector3 constructor due to the following error:

```
Invalid arguments for 'Quat' constructor
```

The Quat(Vector3) constructor, to initialise a Quat by a euler angle, was impossible because Variant::construct would only check for constructors with greater than 1 arguments. I changed it to greater than or equal to 1 and moved it to the bottom of the priority list so it did not overshadow the other checks that checked for arguments equal to 1, for simple copy constructors.

I don't think changing the priority order should affect backwards compatibility since, I think, Quat is the only type with a complex single argument constructor. I would like it if someone could help confirm that.

I don't think there's an issue for this, I tried searching but nothing came up. Let me know and I'll add it to the PR notes.

_Bugsquad edit:_ Fix #28086