### PR TITLE
Reset button state on exit tree

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -282,10 +282,7 @@ void BaseButton::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 	}
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-	}
-
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED && !is_visible_in_tree()) {
+	if (p_what == NOTIFICATION_EXIT_TREE || (p_what == NOTIFICATION_VISIBILITY_CHANGED && !is_visible_in_tree())) {
 
 		if (!toggle_mode) {
 			status.pressed = false;


### PR DESCRIPTION
Steps to reproduce a bug:
1) Hold / hover the button
2) Remove it (or parent node) from the tree
3) When we return the button back to the tree, it's pressed / hover