### PR TITLE
Fixes bug when setting projection matrix in shader GLES2

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -424,9 +424,12 @@ void main() {
 
 #endif
 
+	mat4 local_projection_matrix = projection_matrix;
+
 	mat4 modelview = camera_inverse_matrix * world_matrix;
 	float roughness = 1.0;
 
+#define projection_matrix local_projection_matrix
 #define world_transform world_matrix
 
 	{

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -76,7 +76,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["CAMERA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["PROJECTION_MATRIX"] = ShaderLanguage::TYPE_MAT4;
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["MODELVIEW_MATRIX"] = ShaderLanguage::TYPE_MAT4;
-	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["INV_PROJECTION_MATRIX"] = ShaderLanguage::TYPE_MAT4;
+	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["INV_PROJECTION_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["VIEWPORT_SIZE"] = constt(ShaderLanguage::TYPE_VEC2);
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["OUTPUT_IS_SRGB"] = constt(ShaderLanguage::TYPE_BOOL);


### PR DESCRIPTION
Fixes: #23185

Mirrors the behaviour in GLES3, allows users to write directly to projection matrix. 

Note: I also made `INV_PROJECTION_MATRIX` a const. It doesn't make sense to be able to write to this, plus if anyone actually did it would've caused a bug in both GLES2 and GLES3 currently. So clearly no one is doing this. I will update the docs accordingly once this is merged. 