### PR TITLE
Editor: fix for drag preview in button visibility

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -866,7 +866,6 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 		objs.push_back(p);
 	}
 
-	set_drag_preview(vb);
 	Dictionary drag_data;
 	drag_data["type"] = "nodes";
 	drag_data["nodes"] = objs;


### PR DESCRIPTION
Removed drag preview for the "button visibility", due to the wrong displayal of name, and unnecessary use of preview. According to solution suggested in issue #10026 