### PR TITLE
Fixed uninitialized xfade in AnimationNodeTransition

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -857,6 +857,7 @@ AnimationNodeTransition::AnimationNodeTransition() {
 	time = "time";
 	current = "current";
 	prev_current = "prev_current";
+	xfade = 0.0;
 
 	enabled_inputs = 0;
 	for (int i = 0; i < MAX_INPUTS; i++) {


### PR DESCRIPTION
This change fixes xfade being uninitialized in AnimationNodeTransition.

It was causing transition nodes in animation tree to be sometimes loaded with a small negative value for xfade. In this case, an input set with auto-advance couldn't switch to the next input when completed.