### PR TITLE
Fix jump over uninitialized value in OS Unix/X11

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -108,6 +108,7 @@ void OS_Unix::initialize_debugging() {
 
 	if (ScriptDebugger::get_singleton() != NULL) {
 		struct sigaction action;
+		memset(&action, 0, sizeof(action));
 		action.sa_handler = handle_interrupt;
 		sigaction(SIGINT, &action, NULL);
 	}

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -3238,6 +3238,8 @@ OS_X11::OS_X11() {
 	AudioDriverManager::add_driver(&driver_alsa);
 #endif
 
+	xi.opcode = 0;
+	xi.last_relative_time = 0;
 	layered_window = false;
 	minimized = false;
 	xim_style = 0L;


### PR DESCRIPTION
2 warnings I picked up from `valgrind`.