### PR TITLE
Fix slider handle being hard to select

### DIFF
--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -34,8 +34,15 @@
 Size2 Slider::get_minimum_size() const {
 
 	Ref<StyleBox> style = get_stylebox("slider");
-	Size2i ms = style->get_minimum_size() + style->get_center_size();
-	return ms;
+	Size2i ss = style->get_minimum_size() + style->get_center_size();
+
+	Ref<Texture> grabber = get_icon("grabber");
+	Size2i rs = grabber->get_size();
+
+	if (orientation == HORIZONTAL)
+		return Size2i(ss.width, MAX(ss.height, rs.height));
+	else
+		return Size2i(MAX(ss.width, rs.width), ss.height);
 }
 
 void Slider::_gui_input(Ref<InputEvent> p_event) {
@@ -134,7 +141,11 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 void Slider::_notification(int p_what) {
 
 	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
 
+			minimum_size_changed();
+			update();
+		} break;
 		case NOTIFICATION_MOUSE_ENTER: {
 
 			mouse_inside = true;


### PR DESCRIPTION
Changed the minimum size of a Slider so it depends on the icon used for the grabber. This prevents the behaviour in the issue #24124.

The horizontal/vertical size for a horizontal/vertical slider are kept the same, so the intended sliding behaviour will not be changed.

*Bugsquad edit:* Fixes #24124.