### PR TITLE
Make TileMap overridable "set_cell" function called on undo/redo

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -220,22 +220,23 @@ void TileMapEditor::set_selected_tiles(Vector<int> p_tiles) {
 	palette->ensure_current_is_visible();
 }
 
-void TileMapEditor::_create_set_cell_undo(const Vector2 &p_vec, const CellOp &p_cell_old, const CellOp &p_cell_new) {
+Dictionary TileMapEditor::_create_cell_dictionary(int tile, bool flip_x, bool flip_y, bool transpose, Vector2 autotile_coord) {
 
-	Dictionary cell_old;
-	Dictionary cell_new;
+	Dictionary cell;
 
-	cell_old["id"] = p_cell_old.idx;
-	cell_old["flip_h"] = p_cell_old.xf;
-	cell_old["flip_y"] = p_cell_old.yf;
-	cell_old["transpose"] = p_cell_old.tr;
-	cell_old["auto_coord"] = p_cell_old.ac;
+	cell["id"] = tile;
+	cell["flip_h"] = flip_x;
+	cell["flip_y"] = flip_y;
+	cell["transpose"] = transpose;
+	cell["auto_coord"] = autotile_coord;
 
-	cell_new["id"] = p_cell_new.idx;
-	cell_new["flip_h"] = p_cell_new.xf;
-	cell_new["flip_y"] = p_cell_new.yf;
-	cell_new["transpose"] = p_cell_new.tr;
-	cell_new["auto_coord"] = p_cell_new.ac;
+	return cell;
+}
+
+void TileMapEditor::_create_set_cell_undo_redo(const Vector2 &p_vec, const CellOp &p_cell_old, const CellOp &p_cell_new) {
+
+	Dictionary cell_old = _create_cell_dictionary(p_cell_old.idx, p_cell_old.xf, p_cell_old.yf, p_cell_old.tr, p_cell_old.ac);
+	Dictionary cell_new = _create_cell_dictionary(p_cell_new.idx, p_cell_new.xf, p_cell_new.yf, p_cell_new.tr, p_cell_new.ac);
 
 	undo_redo->add_undo_method(node, "_set_celld", p_vec, cell_old);
 	undo_redo->add_do_method(node, "_set_celld", p_vec, cell_new);
@@ -251,7 +252,7 @@ void TileMapEditor::_finish_undo() {
 
 	if (undo_data.size()) {
 		for (Map<Point2i, CellOp>::Element *E = undo_data.front(); E; E = E->next()) {
-			_create_set_cell_undo(E->key(), E->get(), _get_op_from_cell(E->key()));
+			_create_set_cell_undo_redo(E->key(), E->get(), _get_op_from_cell(E->key()));
 		}
 
 		undo_data.clear();
@@ -299,10 +300,7 @@ void TileMapEditor::_set_cell(const Point2i &p_pos, Vector<int> p_values, bool p
 		}
 	}
 
-	Variant v_pos_x = p_pos.x, v_pos_y = p_pos.y, v_tile = p_value, v_flip_h = p_flip_h, v_flip_v = p_flip_v, v_transpose = p_transpose, v_autotile_coord = Vector2(p_autotile_coord.x, p_autotile_coord.y);
-	const Variant *args[7] = { &v_pos_x, &v_pos_y, &v_tile, &v_flip_h, &v_flip_v, &v_transpose, &v_autotile_coord };
-	Variant::CallError ce;
-	node->call("set_cell", args, 7, ce);
+	node->_set_celld(p_pos, _create_cell_dictionary(p_value, p_flip_h, p_flip_v, p_transpose, p_autotile_coord));
 
 	if (manual_autotile || (p_value != -1 && node->get_tileset()->tile_get_tile_mode(p_value) == TileSet::ATLAS_TILE)) {
 		if (current != -1) {

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -188,9 +188,10 @@ class TileMapEditor : public VBoxContainer {
 	void _palette_selected(int index);
 	void _palette_multi_selected(int index, bool selected);
 
+	Dictionary _create_cell_dictionary(int tile, bool flip_x, bool flip_y, bool transpose, Vector2 autotile_coord);
 	void _start_undo(const String &p_action);
 	void _finish_undo();
-	void _create_set_cell_undo(const Vector2 &p_vec, const CellOp &p_cell_old, const CellOp &p_cell_new);
+	void _create_set_cell_undo_redo(const Vector2 &p_vec, const CellOp &p_cell_old, const CellOp &p_cell_new);
 	void _set_cell(const Point2i &p_pos, Vector<int> p_values, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false, const Point2i p_autotile_coord = Point2());
 
 	void _canvas_mouse_enter();

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -749,7 +749,10 @@ void TileMap::set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x, bool p_
 
 void TileMap::_set_celld(const Vector2 &p_pos, const Dictionary &p_data) {
 
-	set_cell(p_pos.x, p_pos.y, p_data["id"], p_data["flip_h"], p_data["flip_y"], p_data["transpose"], p_data["auto_coord"]);
+	Variant v_pos_x = p_pos.x, v_pos_y = p_pos.y, v_tile = p_data["id"], v_flip_h = p_data["flip_h"], v_flip_v = p_data["flip_y"], v_transpose = p_data["transpose"], v_autotile_coord = p_data["auto_coord"];
+	const Variant *args[7] = { &v_pos_x, &v_pos_y, &v_tile, &v_flip_h, &v_flip_v, &v_transpose, &v_autotile_coord };
+	Variant::CallError ce;
+	call("set_cell", args, 7, ce);
 }
 
 void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, Vector2 p_autotile_coord) {


### PR DESCRIPTION
This is a follow-up to #27500.
The `set_cell `override was working fine in the editor and undo/redo operations were working as always.
The only thing was that the overridden `set_cell` was not called on undo/redo, the default native `set_cell` was called in this case.

This PR fixes that issue, making the editor always call the TileMap `set_celld` method (which is used only in the TileMap editor and is not exposed to scripting languages), even on undo/redo, which then makes the call to `set_cell`.

`set_celld` becomes an utility method to make the call to the overridable `set_cell` method easier.