### PR TITLE
Added eye_height, changed description and fixed size of viewport issue

### DIFF
--- a/modules/mobile_vr/doc_classes/MobileVRInterface.xml
+++ b/modules/mobile_vr/doc_classes/MobileVRInterface.xml
@@ -5,7 +5,13 @@
 	</brief_description>
 	<description>
 		This is a generic mobile VR implementation where you need to provide details about the phone and HMD used. It does not rely on any existing framework. This is the most basic interface we have. For the best effect you do need a mobile phone with a gyroscope and accelerometer.
-		Note that even though there is no positional tracking the camera will assume the headset is at a height of 1.85 meters.
+		Note that even though there is no positional tracking the camera will assume the headset is at a height of 1.85 meters, you can change this by setting [member eye_height].
+		You can initialise this interface as follows:
+		[codeblock]
+		var interface = ARVRServer.find_interface("Native mobile")
+		if interface and interface.initialize():
+		    get_viewport().arvr = true
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>
@@ -19,6 +25,9 @@
 		</member>
 		<member name="display_width" type="float" setter="set_display_width" getter="get_display_width">
 			The width of the display in centimeters.
+		</member>
+		<member name="eye_height" type="float" setter="set_eye_height" getter="get_eye_height">
+			The height at which the camera is placed in relation to the ground (i.e. [ARVROrigin] node).
 		</member>
 		<member name="iod" type="float" setter="set_iod" getter="get_iod">
 			The interocular distance, also known as the interpupillary distance. The distance between the pupils of the left and right eye.

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -200,6 +200,9 @@ void MobileVRInterface::set_position_from_sensors() {
 };
 
 void MobileVRInterface::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_eye_height", "eye_height"), &MobileVRInterface::set_eye_height);
+	ClassDB::bind_method(D_METHOD("get_eye_height"), &MobileVRInterface::get_eye_height);
+
 	ClassDB::bind_method(D_METHOD("set_iod", "iod"), &MobileVRInterface::set_iod);
 	ClassDB::bind_method(D_METHOD("get_iod"), &MobileVRInterface::get_iod);
 
@@ -218,12 +221,21 @@ void MobileVRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_k2", "k"), &MobileVRInterface::set_k2);
 	ClassDB::bind_method(D_METHOD("get_k2"), &MobileVRInterface::get_k2);
 
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "eye_height", PROPERTY_HINT_RANGE, "0.0,3.0,0.1"), "set_eye_height", "get_eye_height");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "iod", PROPERTY_HINT_RANGE, "4.0,10.0,0.1"), "set_iod", "get_iod");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "display_width", PROPERTY_HINT_RANGE, "5.0,25.0,0.1"), "set_display_width", "get_display_width");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "display_to_lens", PROPERTY_HINT_RANGE, "5.0,25.0,0.1"), "set_display_to_lens", "get_display_to_lens");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "oversample", PROPERTY_HINT_RANGE, "1.0,2.0,0.1"), "set_oversample", "get_oversample");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "k1", PROPERTY_HINT_RANGE, "0.1,10.0,0.0001"), "set_k1", "get_k1");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "k2", PROPERTY_HINT_RANGE, "0.1,10.0,0.0001"), "set_k2", "get_k2");
+}
+
+void MobileVRInterface::set_eye_height(const real_t p_eye_height) {
+	eye_height = p_eye_height;
+}
+
+real_t MobileVRInterface::get_eye_height() const {
+	return eye_height;
 }
 
 void MobileVRInterface::set_iod(const real_t p_iod) {
@@ -328,6 +340,7 @@ Size2 MobileVRInterface::get_render_targetsize() {
 
 	// we use half our window size
 	Size2 target_size = OS::get_singleton()->get_window_size();
+
 	target_size.x *= 0.5 * oversample;
 	target_size.y *= oversample;
 

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -107,6 +107,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	void set_eye_height(const real_t p_eye_height);
+	real_t get_eye_height() const;
+
 	void set_iod(const real_t p_iod);
 	real_t get_iod() const;
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -295,8 +295,8 @@ void VisualServerViewport::draw_viewports() {
 
 		if (vp->use_arvr && arvr_interface.is_valid()) {
 			// override our size, make sure it matches our required size
-			Size2 size = arvr_interface->get_render_targetsize();
-			VSG::storage->render_target_set_size(vp->render_target, size.x, size.y);
+			vp->size = arvr_interface->get_render_targetsize();
+			VSG::storage->render_target_set_size(vp->render_target, vp->size.x, vp->size.y);
 
 			// render mono or left eye first
 			ARVRInterface::Eyes leftOrMono = arvr_interface->is_stereo() ? ARVRInterface::EYE_LEFT : ARVRInterface::EYE_MONO;


### PR DESCRIPTION
This fixes #27297, turned out that when the ARVR interface overrides the viewports size to be what is needed for stereo scopic rendering it didn't update a variable on the viewport. It was this variable that was used to calculate the aspect ratio which was in turn used to calculate the camera matrix resulting in the reported issue.

While fixing this also added a bit of documentation and exposed the eye_height variable as a property.