### PR TITLE
Added No bone set state in the IK

### DIFF
--- a/scene/animation/skeleton_ik.cpp
+++ b/scene/animation/skeleton_ik.cpp
@@ -335,7 +335,7 @@ void SkeletonIK::_validate_property(PropertyInfo &property) const {
 
 		if (skeleton) {
 
-			String names;
+			String names("--,");
 			for (int i = 0; i < skeleton->get_bone_count(); i++) {
 				if (i > 0)
 					names += ",";


### PR DESCRIPTION
The problem is that initially the root bone was not set, and you didn't know that because the "no set" state was missing. Now I've added it. https://github.com/godotengine/godot-docs/issues/2333