### PR TITLE
Makes CheckButton Greyed Out When Disabled

### DIFF
--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -104,7 +104,7 @@ public:
 	void set_shortcut_in_tooltip(bool p_on);
 	bool is_shortcut_in_tooltip_enabled() const;
 
-	void set_disabled(bool p_disabled);
+	virtual void set_disabled(bool p_disabled);
 	bool is_disabled() const;
 
 	void set_action_mode(ActionMode p_mode);

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -58,6 +58,14 @@ Size2 CheckButton::get_minimum_size() const {
 	return minsize;
 }
 
+void CheckButton::set_disabled(bool p_disabled) {
+	BaseButton::set_disabled(p_disabled);
+	if (p_disabled)
+		set_modulate(get_color("disabled_font_color", "Editor"));
+	else
+		set_modulate(Color(1, 1, 1)); // default white
+}
+
 void CheckButton::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_THEME_CHANGED) {

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -45,6 +45,7 @@ protected:
 	void _notification(int p_what);
 
 public:
+	void set_disabled(bool p_disabled);
 	CheckButton();
 	~CheckButton();
 };


### PR DESCRIPTION
When the CheckButton is disabled it now changes it color to `get_color("disabled_font_color", "editor")`'s `Color`, and white otherwise. 

_Bugsquad edit:_ Closes #27848