### PR TITLE
Force utf-8 source file encoding in MSVC

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -195,7 +195,7 @@ def configure_msvc(env, manual_msvc_config):
 
     ## Compile/link flags
 
-    env.AppendUnique(CCFLAGS=['/MT', '/Gd', '/GR', '/nologo'])
+    env.AppendUnique(CCFLAGS=['/MT', '/Gd', '/GR', '/nologo', '/utf-8'])
     env.AppendUnique(CXXFLAGS=['/TP']) # assume all sources are C++
     if manual_msvc_config: # should be automatic if SCons found it
         if os.getenv("WindowsSdkDir") is not None:


### PR DESCRIPTION
On Windows, when "Language for non-Unicode programs" were set to "Japanese (Japan)", MSVC would by default use Shift JIS (code page 932) to interpret source files, which would result in `/main/tests/test_string.cpp` failing to compile because of characters in `test_34()`. Forcing utf-8 for MSVC fixes the issue.