### PR TITLE
Fixes for vhacd module 

### DIFF
--- a/modules/vhacd/SCsub
+++ b/modules/vhacd/SCsub
@@ -27,6 +27,10 @@ thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 env_vhacd.Append(CPPPATH=[thirdparty_dir+"/inc"])
 env_vhacd.Append(CPPFLAGS=["-DGODOT_ENET"])
 
+# upstream uses c++11
+if not env.msvc:
+	env_vhacd.Append(CCFLAGS="-std=c++11")
+
 env_thirdparty = env_vhacd.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)

--- a/thirdparty/vhacd/src/btConvexHullComputer.cpp
+++ b/thirdparty/vhacd/src/btConvexHullComputer.cpp
@@ -3,8 +3,8 @@ Copyright (c) 2011 Ole Kniemeyer, MAXON, www.maxon.net
 
 This software is provided 'as-is', without any express or implied warranty.
 In no event will the authors be held liable for any damages arising from the use of this software.
-Permission is granted to anyone to use this software for any purpose, 
-including commercial applications, and to alter it and redistribute it freely, 
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
 subject to the following restrictions:
 
 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
@@ -21,11 +21,6 @@ subject to the following restrictions:
 
 #ifdef __GNUC__
 #include <stdint.h>
-
-//GODOT ADDITION
-namespace VHACD {
-//
-
 #elif defined(_MSC_VER)
 typedef __int32 int32_t;
 typedef __int64 int64_t;
@@ -53,6 +48,10 @@ typedef unsigned long long int32_t uint64_t;
 #if defined(DEBUG_CONVEX_HULL) || defined(SHOW_ITERATIONS)
 #include <stdio.h>
 #endif
+
+//GODOT ADDITION
+namespace VHACD {
+//
 
 // Convex hull implementation based on Preparata and Hong
 // Ole Kniemeyer, MAXON Computer GmbH


### PR DESCRIPTION
1. Fixed misplaced `namespace VHACD` in `btConvexHullComputer.cpp`. It was placed in `#ifdef __GNUC__` which would break Windows builds.
2. 1 alone didn't fix the build, thus used C++11 for vhacd because `VHACD-ASYNC.cpp` is using some C++11 features