### PR TITLE
Fixes WAV import being cut in half with new trim code

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -409,12 +409,12 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			float amp = Math::abs(ampChannelSum / (float)format_channels);
 
 			if (!found && amp > limit) {
-				first = i / format_channels;
+				first = i;
 				found = true;
 			}
 
 			if (found && amp > limit) {
-				last = i / format_channels;
+				last = i;
 			}
 		}
 


### PR DESCRIPTION
Fixes
#27925 "Trim" option on importing WAV stereo audio removes half of it

