### PR TITLE
Improve AudioStreamSample documentation.

### DIFF
--- a/doc/classes/AudioStreamSample.xml
+++ b/doc/classes/AudioStreamSample.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioStreamSample" inherits="AudioStream" category="Core" version="3.2">
 	<brief_description>
-		Plays audio.
+		Stores audio data loaded from [code].wav[/code] files.
 	</brief_description>
 	<description>
-		Plays audio, can loop.
+		AudioStreamSample stores sound samples loaded from [code].wav[/code] files. To play the stored sound use an [AudioStreamPlayer] (for background music) or [AudioStreamPlayer2D]/[AudioStreamPlayer3D] (for positional audio). The sound can be looped.
+		This class can also be used to store dynamically generated PCM audio data.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Improves documentation to:

 * Make the description style more consistent with: https://github.com/godotengine/godot/blob/edc9097bc1604f0bd5ea7136c518699e9d64a731/modules/stb_vorbis/doc_classes/AudioStreamOGGVorbis.xml#L3-L8

 * Be more accurate with regard to the fact this class does not *play* the audio data it only stores the data. (I'm not sure that "audio stream driver" is a very useful phrase for either class but at least it's consistent.)

I also added a note that it's possible to generate audio data in a non-real-time fashion as this wasn't readily apparent as discussed in https://github.com/godotengine/godot/issues/18135#issuecomment-481976825.

The actual wording is only intended as a starting point.