### PR TITLE
Fix for additional separators appearing when scripts are disabled

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2215,10 +2215,10 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->add_icon_shortcut(get_icon("ScriptRemove", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/clear_script"), TOOL_CLEAR_SCRIPT);
 			menu->add_icon_shortcut(get_icon("ScriptExtend", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/extend_script"), TOOL_ATTACH_SCRIPT);
 		}
+		menu->add_separator();
 	}
 
 	if (profile_allow_editing) {
-		menu->add_separator();
 		if (selection.size() == 1) {
 			menu->add_icon_shortcut(get_icon("Rename", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/rename"), TOOL_RENAME);
 		}


### PR DESCRIPTION
Fix for issue #27866. Moved a separator to a different place.

![gdScreen1](https://user-images.githubusercontent.com/15381918/55974622-9a3c0880-5c77-11e9-87e3-fe9b9d648502.png)

![gdScreen2](https://user-images.githubusercontent.com/15381918/55974666-b9d33100-5c77-11e9-8d1b-4a92855bd54b.png)

![godot3](https://user-images.githubusercontent.com/15381918/56050282-fd42a380-5d3a-11e9-93cb-698cb7017a90.png)

![godot4](https://user-images.githubusercontent.com/15381918/56050289-02075780-5d3b-11e9-9cf6-1dd0aef78ae6.png)

