### PR TITLE
Register server classes to fix GDNative binding issues

### DIFF
--- a/modules/bullet/register_types.cpp
+++ b/modules/bullet/register_types.cpp
@@ -49,6 +49,10 @@ void register_bullet_types() {
 	PhysicsServerManager::register_server("Bullet", &_createBulletPhysicsCallback);
 	PhysicsServerManager::set_default_server("Bullet", 1);
 
+	ClassDB::register_class<BulletPhysicsServer>();
+	ClassDB::register_class<BulletPhysicsDirectBodyState>();
+	ClassDB::register_class<BulletPhysicsDirectSpaceState>();
+
 	GLOBAL_DEF("physics/3d/active_soft_world", true);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/active_soft_world", PropertyInfo(Variant::BOOL, "physics/3d/active_soft_world"));
 #endif

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -57,9 +57,8 @@
 	@author AndreaCatania
 */
 
-BulletPhysicsDirectSpaceState::BulletPhysicsDirectSpaceState(SpaceBullet *p_space) :
-		PhysicsDirectSpaceState(),
-		space(p_space) {}
+BulletPhysicsDirectSpaceState::BulletPhysicsDirectSpaceState() :
+		PhysicsDirectSpaceState() {}
 
 int BulletPhysicsDirectSpaceState::intersect_point(const Vector3 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
 
@@ -345,7 +344,8 @@ SpaceBullet::SpaceBullet() :
 		delta_time(0.) {
 
 	create_empty_world(GLOBAL_DEF("physics/3d/active_soft_world", true));
-	direct_access = memnew(BulletPhysicsDirectSpaceState(this));
+	direct_access = memnew(BulletPhysicsDirectSpaceState());
+	direct_access->space = this;
 }
 
 SpaceBullet::~SpaceBullet() {

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -73,8 +73,6 @@ private:
 	SpaceBullet *space;
 
 public:
-	BulletPhysicsDirectSpaceState(SpaceBullet *p_space);
-
 	virtual int intersect_point(const Vector3 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_areas = false);
 	virtual bool intersect_ray(const Vector3 &p_from, const Vector3 &p_to, RayResult &r_result, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_areas = false, bool p_pick_ray = false);
 	virtual int intersect_shape(const RID &p_shape, const Transform &p_xform, float p_margin, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_areas = false);
@@ -83,6 +81,10 @@ public:
 	virtual bool collide_shape(RID p_shape, const Transform &p_shape_xform, float p_margin, Vector3 *r_results, int p_result_max, int &r_result_count, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_areas = false);
 	virtual bool rest_info(RID p_shape, const Transform &p_shape_xform, float p_margin, ShapeRestInfo *r_info, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_areas = false);
 	virtual Vector3 get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const;
+
+	BulletPhysicsDirectSpaceState();
+
+	friend class SpaceBullet;
 };
 
 class SpaceBullet : public RIDBullet {

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -61,6 +61,7 @@
 #include "physics_2d_server.h"
 #include "physics_server.h"
 #include "visual/shader_types.h"
+#include "visual/visual_server_raster.h"
 #include "visual_server.h"
 
 static void _debugger_get_resource_usage(List<ScriptDebuggerRemote::ResourceUsage> *r_usage) {
@@ -110,9 +111,12 @@ void register_server_types() {
 	OS::get_singleton()->set_has_server_feature_callback(has_server_feature_callback);
 
 	ClassDB::register_virtual_class<VisualServer>();
+	ClassDB::register_class<VisualServerRaster>();
 	ClassDB::register_class<AudioServer>();
 	ClassDB::register_virtual_class<PhysicsServer>();
+	ClassDB::register_class<PhysicsServerSW>();
 	ClassDB::register_virtual_class<Physics2DServer>();
+	ClassDB::register_class<Physics2DServerSW>();
 	ClassDB::register_class<ARVRServer>();
 
 	shader_types = memnew(ShaderTypes);
@@ -170,14 +174,18 @@ void register_server_types() {
 	}
 
 	ClassDB::register_virtual_class<Physics2DDirectBodyState>();
+	ClassDB::register_class<Physics2DDirectBodyStateSW>();
 	ClassDB::register_virtual_class<Physics2DDirectSpaceState>();
+	ClassDB::register_class<Physics2DDirectSpaceStateSW>();
 	ClassDB::register_virtual_class<Physics2DShapeQueryResult>();
 	ClassDB::register_class<Physics2DTestMotionResult>();
 	ClassDB::register_class<Physics2DShapeQueryParameters>();
 
 	ClassDB::register_class<PhysicsShapeQueryParameters>();
 	ClassDB::register_virtual_class<PhysicsDirectBodyState>();
+	ClassDB::register_class<PhysicsDirectBodyStateSW>();
 	ClassDB::register_virtual_class<PhysicsDirectSpaceState>();
+	ClassDB::register_class<PhysicsDirectSpaceStateSW>();
 	ClassDB::register_virtual_class<PhysicsShapeQueryResult>();
 
 	ScriptDebuggerRemote::resource_usage_func = _debugger_get_resource_usage;


### PR DESCRIPTION
Due to ClassDB not containing information about the server specific classes
the JSON API file didn't contain those either which caused the GDNative
binding tools to not recognize objects of such classes.

This is needed to fix https://github.com/GodotNativeTools/godot-cpp/issues/175.