### PR TITLE
Improve new Connections dialog

### DIFF
--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -67,9 +67,9 @@ class ConnectDialog : public ConfirmationDialog {
 	ConfirmationDialog *error;
 	EditorInspector *bind_editor;
 	OptionButton *type_list;
-	CheckButton *deferred;
-	CheckButton *oneshot;
-	CheckBox *advanced;
+	CheckBox *deferred;
+	CheckBox *oneshot;
+	CheckButton *advanced;
 
 	Label *error_label;
 
@@ -99,7 +99,7 @@ public:
 
 	void init(Connection c, bool bEdit = false);
 
-	void popup_dialog(const String &p_for_signal, bool p_advanced);
+	void popup_dialog(const String &p_for_signal);
 	ConnectDialog();
 	~ConnectDialog();
 };


### PR DESCRIPTION
- Fixed dialog not correctly reopening in advanced mode once enabled and closed,
- Added tooltips to "Deferred" and "Oneshot".
- Made "Advanced" into a `CheckButton` and the "Deferred" and "Oneshot" into `CheckBox`es (see [here](https://uxmovement.com/buttons/when-to-use-a-switch-or-checkbox/) why).
- Made the dialog just readjust its size instead of reopening when advanced mode is enabled.