### PR TITLE
Restore script editor state between sessions

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1180,17 +1180,57 @@ Variant CodeTextEditor::get_edit_state() {
 	Dictionary state;
 
 	state["scroll_position"] = text_editor->get_v_scroll();
+	state["h_scroll_position"] = text_editor->get_h_scroll();
 	state["column"] = text_editor->cursor_get_column();
 	state["row"] = text_editor->cursor_get_line();
+
+	state["selection"] = get_text_edit()->is_selection_active();
+	if (get_text_edit()->is_selection_active()) {
+		state["selection_from_line"] = text_editor->get_selection_from_line();
+		state["selection_from_column"] = text_editor->get_selection_from_column();
+		state["selection_to_line"] = text_editor->get_selection_to_line();
+		state["selection_to_column"] = text_editor->get_selection_to_column();
+	}
+
+	state["folded_lines"] = text_editor->get_folded_lines();
+	state["breakpoints"] = text_editor->get_breakpoints_array();
+
+	state["syntax_highlighter"] = TTR("Standard");
+	SyntaxHighlighter *syntax_highlighter = text_editor->_get_syntax_highlighting();
+	if (syntax_highlighter) {
+		state["syntax_highlighter"] = syntax_highlighter->get_name();
+	}
 
 	return state;
 }
 
 void CodeTextEditor::set_edit_state(const Variant &p_state) {
 	Dictionary state = p_state;
-	text_editor->cursor_set_column(state["column"]);
+
+	/* update the row first as it sets the column to 0 */
 	text_editor->cursor_set_line(state["row"]);
+	text_editor->cursor_set_column(state["column"]);
 	text_editor->set_v_scroll(state["scroll_position"]);
+	text_editor->set_h_scroll(state["h_scroll_position"]);
+
+	if (state.has("selection")) {
+		text_editor->select(state["selection_from_line"], state["selection_from_column"], state["selection_to_line"], state["selection_to_column"]);
+	}
+
+	if (state.has("folded_lines")) {
+		Vector<int> folded_lines = state["folded_lines"];
+		for (int i = 0; i < folded_lines.size(); i++) {
+			text_editor->fold_line(folded_lines[i]);
+		}
+	}
+
+	if (state.has("breakpoints")) {
+		Array breakpoints = state["breakpoints"];
+		for (int i = 0; i < breakpoints.size(); i++) {
+			text_editor->set_line_as_breakpoint(breakpoints[i], true);
+		}
+	}
+
 	text_editor->grab_focus();
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2521,6 +2521,7 @@ int EditorNode::_next_unsaved_scene(bool p_valid_filename, int p_start) {
 void EditorNode::_exit_editor() {
 	exiting = true;
 	resource_preview->stop(); //stop early to avoid crashes
+	_save_docks();
 	get_tree()->quit();
 }
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -318,7 +318,6 @@ void ScriptTextEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY:
 			_load_theme_settings();
-			_change_syntax_highlighter(EditorSettings::get_singleton()->get_project_metadata("script_text_editor", "syntax_highlighter", 0));
 			break;
 	}
 }
@@ -363,6 +362,14 @@ Variant ScriptTextEditor::get_edit_state() {
 void ScriptTextEditor::set_edit_state(const Variant &p_state) {
 
 	code_editor->set_edit_state(p_state);
+
+	Dictionary state = p_state;
+	if (state.has("syntax_highlighter")) {
+		int idx = highlighter_menu->get_item_idx_from_text(state["syntax_highlighter"]);
+		if (idx >= 0) {
+			_change_syntax_highlighter(idx);
+		}
+	}
 }
 
 void ScriptTextEditor::_convert_case(CodeTextEditor::CaseStyle p_case) {
@@ -1024,7 +1031,6 @@ void ScriptTextEditor::_change_syntax_highlighter(int p_idx) {
 	}
 	// highlighter_menu->set_item_checked(p_idx, true);
 	set_syntax_highlighter(highlighters[highlighter_menu->get_item_text(p_idx)]);
-	EditorSettings::get_singleton()->set_project_metadata("script_text_editor", "syntax_highlighter", p_idx);
 }
 
 void ScriptTextEditor::_bind_methods() {

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -66,7 +66,6 @@ void TextEditor::_change_syntax_highlighter(int p_idx) {
 		el = el->next();
 	}
 	set_syntax_highlighter(highlighters[highlighter_menu->get_item_text(p_idx)]);
-	EditorSettings::get_singleton()->set_project_metadata("text_editor", "syntax_highlighter", p_idx);
 }
 
 void TextEditor::_load_theme_settings() {
@@ -234,6 +233,14 @@ Variant TextEditor::get_edit_state() {
 void TextEditor::set_edit_state(const Variant &p_state) {
 
 	code_editor->set_edit_state(p_state);
+
+	Dictionary state = p_state;
+	if (state.has("syntax_highlighter")) {
+		int idx = highlighter_menu->get_item_idx_from_text(state["syntax_highlighter"]);
+		if (idx >= 0) {
+			_change_syntax_highlighter(idx);
+		}
+	}
 }
 
 void TextEditor::trim_trailing_whitespace() {
@@ -299,7 +306,6 @@ void TextEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY:
 			_load_theme_settings();
-			_change_syntax_highlighter(EditorSettings::get_singleton()->get_project_metadata("text_editor", "syntax_highlighter", 0));
 			break;
 	}
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5189,6 +5189,17 @@ bool TextEdit::is_folded(int p_line) const {
 	return false;
 }
 
+Vector<int> TextEdit::get_folded_lines() const {
+	Vector<int> folded_lines;
+
+	for (int i = 0; i < text.size(); i++) {
+		if (is_folded(i)) {
+			folded_lines.push_back(i);
+		}
+	}
+	return folded_lines;
+}
+
 void TextEdit::fold_line(int p_line) {
 
 	ERR_FAIL_INDEX(p_line, text.size());

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -490,6 +490,7 @@ public:
 
 	bool can_fold(int p_line) const;
 	bool is_folded(int p_line) const;
+	Vector<int> get_folded_lines() const;
 	void fold_line(int p_line);
 	void unfold_line(int p_line);
 	void toggle_fold_line(int p_line);


### PR DESCRIPTION
The script editor will now restore its state between sessions, such as folded lines, breakpoints and caret position. The only pain point is that we have to save the docks on editor exit every time to ensure it's saved.

This change is also forwards compatible not backwards.

closes #22836
closes #27807
closes most of #19109