### PR TITLE
Added FFT_Size enum binds

### DIFF
--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -240,6 +240,13 @@ void AudioEffectSpectrumAnalyzer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "buffer_length", PROPERTY_HINT_RANGE, "0.1,4,0.1"), "set_buffer_length", "get_buffer_length");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "tap_back_pos", PROPERTY_HINT_RANGE, "0.1,4,0.1"), "set_tap_back_pos", "get_tap_back_pos");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fft_size", PROPERTY_HINT_ENUM, "256,512,1024,2048,4096"), "set_fft_size", "get_fft_size");
+
+	BIND_ENUM_CONSTANT(FFT_SIZE_256);
+	BIND_ENUM_CONSTANT(FFT_SIZE_512);
+	BIND_ENUM_CONSTANT(FFT_SIZE_1024);
+	BIND_ENUM_CONSTANT(FFT_SIZE_2048);
+	BIND_ENUM_CONSTANT(FFT_SIZE_4096);
+	BIND_ENUM_CONSTANT(FFT_SIZE_MAX);
 }
 
 AudioEffectSpectrumAnalyzer::AudioEffectSpectrumAnalyzer() {


### PR DESCRIPTION
Missing FFT_Size enum definition when generating gdnative api.json