### PR TITLE
[WIP] Reworked and more capable ConnectDialog

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5093,11 +5093,11 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	add_child(pick_track);
 	pick_track->set_title(TTR("Pick the node that will be animated:"));
 	pick_track->connect("selected", this, "_new_track_node_selected");
-	prop_selector = memnew(PropertySelector);
+	prop_selector = memnew(PropertySelectorDialog);
 	add_child(prop_selector);
 	prop_selector->connect("selected", this, "_new_track_property_selected");
 
-	method_selector = memnew(PropertySelector);
+	method_selector = memnew(PropertySelectorDialog);
 	add_child(method_selector);
 	method_selector->connect("selected", this, "_add_method_key");
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -334,6 +334,8 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _new_track_node_selected(NodePath p_path);
 	void _new_track_property_selected(String p_name);
 
+	void _update_step_spinbox();
+
 	PropertySelectorDialog *prop_selector;
 	PropertySelectorDialog *method_selector;
 	SceneTreeDialog *pick_track;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -334,10 +334,8 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _new_track_node_selected(NodePath p_path);
 	void _new_track_property_selected(String p_name);
 
-	void _update_step_spinbox();
-
-	PropertySelector *prop_selector;
-	PropertySelector *method_selector;
+	PropertySelectorDialog *prop_selector;
+	PropertySelectorDialog *method_selector;
 	SceneTreeDialog *pick_track;
 	int adding_track_type;
 	NodePath adding_track_path;

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -108,6 +108,162 @@ public:
 };
 
 /*
+Adds a new parameter bind to connection.
+*/
+void ArgumentsBindsDialog::_add_bind() {
+
+	if (cdbinds->params.size() >= VARIANT_ARG_MAX)
+		return;
+	Variant::Type vt = (Variant::Type)type_list->get_item_id(type_list->get_selected());
+
+	Variant value;
+
+	switch (vt) {
+		case Variant::BOOL: value = false; break;
+		case Variant::INT: value = 0; break;
+		case Variant::REAL: value = 0.0; break;
+		case Variant::STRING: value = ""; break;
+		case Variant::VECTOR2: value = Vector2(); break;
+		case Variant::RECT2: value = Rect2(); break;
+		case Variant::VECTOR3: value = Vector3(); break;
+		case Variant::TRANSFORM2D: value = Transform2D(); break;
+		case Variant::PLANE: value = Plane(); break;
+		case Variant::QUAT: value = Quat(); break;
+		case Variant::AABB: value = AABB(); break;
+		case Variant::BASIS: value = Basis(); break;
+		case Variant::TRANSFORM: value = Transform(); break;
+		case Variant::COLOR: value = Color(); break;
+		case Variant::NODE_PATH: value = NodePath(); break;
+		case Variant::_RID: value = RID(); break;
+		case Variant::OBJECT: value = Ref<Reference>(memnew(Reference)); break;
+		case Variant::DICTIONARY: value = Dictionary(); break;
+		case Variant::ARRAY: value = Array(); break;
+		case Variant::POOL_BYTE_ARRAY: value = PoolByteArray(); break;
+		case Variant::POOL_INT_ARRAY: value = PoolIntArray(); break;
+		case Variant::POOL_REAL_ARRAY: value = PoolRealArray(); break;
+		case Variant::POOL_STRING_ARRAY: value = PoolStringArray(); break;
+		case Variant::POOL_VECTOR2_ARRAY: value = PoolVector2Array(); break;
+		case Variant::POOL_VECTOR3_ARRAY: value = PoolVector3Array(); break;
+		case Variant::POOL_COLOR_ARRAY: value = PoolColorArray(); break;
+		default: {
+			ERR_FAIL();
+		} break;
+	}
+
+	ERR_FAIL_COND(value.get_type() == Variant::NIL);
+
+	cdbinds->params.push_back(value);
+	cdbinds->notify_changed();
+}
+
+/*
+Remove parameter bind from connection.
+*/
+void ArgumentsBindsDialog::_remove_bind() {
+
+	String st = bind_editor->get_selected_path();
+	if (st == "")
+		return;
+	int idx = st.get_slice("/", 1).to_int() - 1;
+
+	ERR_FAIL_INDEX(idx, cdbinds->params.size());
+	cdbinds->params.remove(idx);
+	cdbinds->notify_changed();
+}
+
+void ArgumentsBindsDialog::_notification(int p_what) {
+
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		bind_editor->edit(cdbinds);
+	}
+}
+
+void ArgumentsBindsDialog::_bind_methods() {
+
+	ClassDB::bind_method("_add_bind", &ArgumentsBindsDialog::_add_bind);
+	ClassDB::bind_method("_remove_bind", &ArgumentsBindsDialog::_remove_bind);
+}
+
+Vector<Variant> ArgumentsBindsDialog::get_binds() const {
+
+	return cdbinds->params;
+}
+
+void ArgumentsBindsDialog::init(Vector<Variant> p_binds) {
+
+	cdbinds->params.clear();
+	cdbinds->params = p_binds;
+	cdbinds->notify_changed();
+}
+
+ArgumentsBindsDialog::ArgumentsBindsDialog() {
+
+	vb_container = memnew(VBoxContainer);
+	add_child(vb_container);
+	vb_container->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	HBoxContainer *add_bind_hb = memnew(HBoxContainer);
+
+	type_list = memnew(OptionButton);
+	type_list->set_h_size_flags(SIZE_EXPAND_FILL);
+	add_bind_hb->add_child(type_list);
+	type_list->add_item("bool", Variant::BOOL);
+	type_list->add_item("int", Variant::INT);
+	type_list->add_item("real", Variant::REAL);
+	type_list->add_item("string", Variant::STRING);
+	type_list->add_item("Vector2", Variant::VECTOR2);
+	type_list->add_item("Rect2", Variant::RECT2);
+	type_list->add_item("Vector3", Variant::VECTOR3);
+	type_list->add_item("Transform2D", Variant::TRANSFORM2D);
+	type_list->add_item("Plane", Variant::PLANE);
+	type_list->add_item("Quat", Variant::QUAT);
+	type_list->add_item("AABB", Variant::AABB);
+	type_list->add_item("Basis", Variant::BASIS);
+	type_list->add_item("Transform", Variant::TRANSFORM);
+	type_list->add_item("Color", Variant::COLOR);
+	type_list->add_item("NodePath", Variant::NODE_PATH);
+	type_list->add_item("RID", Variant::_RID);
+	type_list->add_item("Object", Variant::OBJECT);
+	type_list->add_item("Dictionary", Variant::DICTIONARY);
+	type_list->add_item("Array", Variant::ARRAY);
+	type_list->add_item("PoolByteArray", Variant::POOL_BYTE_ARRAY);
+	type_list->add_item("PoolIntArray", Variant::POOL_INT_ARRAY);
+	type_list->add_item("PoolRealArray", Variant::POOL_REAL_ARRAY);
+	type_list->add_item("PoolStringArray", Variant::POOL_STRING_ARRAY);
+	type_list->add_item("PoolVector2Array", Variant::POOL_VECTOR2_ARRAY);
+	type_list->add_item("PoolVector3Array", Variant::POOL_VECTOR3_ARRAY);
+	type_list->add_item("PoolColorArray", Variant::POOL_COLOR_ARRAY);
+	type_list->select(0);
+
+	Button *add_bind = memnew(Button);
+	add_bind->set_text(TTR("Add"));
+	add_bind_hb->add_child(add_bind);
+	add_bind->connect("pressed", this, "_add_bind");
+
+	Button *del_bind = memnew(Button);
+	del_bind->set_text(TTR("Remove"));
+	add_bind_hb->add_child(del_bind);
+	del_bind->connect("pressed", this, "_remove_bind");
+
+	vb_container->add_margin_child(TTR("Add Extra Call Argument:"), add_bind_hb);
+
+	bind_editor = memnew(EditorInspector);
+
+	vb_container->add_margin_child(TTR("Extra Call Arguments:"), bind_editor, true);
+
+	set_as_toplevel(true);
+
+	cdbinds = memnew(ConnectDialogBinds);
+}
+
+ArgumentsBindsDialog::~ArgumentsBindsDialog() {
+
+	memdelete(cdbinds);
+}
+
+//ConnectDialog ==========================
+
+/*
 Signal automatically called by parent dialog.
 */
 void ConnectDialog::ok_pressed() {
@@ -146,73 +302,102 @@ void ConnectDialog::_tree_node_selected() {
 
 	dst_path = source->get_path_to(current);
 	get_ok()->set_disabled(false);
+
+	if (mode_list->get_selected() != 0 && current) {
+		selector_right->select_method_from_instance(current);
+	}
 }
 
-/*
-Adds a new parameter bind to connection.
-*/
-void ConnectDialog::_add_bind() {
+void ConnectDialog::_mode_changed(int p_mode) {
 
-	if (cdbinds->params.size() >= VARIANT_ARG_MAX)
-		return;
-	Variant::Type vt = (Variant::Type)type_list->get_item_id(type_list->get_selected());
+	bool show_methods = p_mode != 0;
 
-	Variant value;
+	selector_right->set_visible(show_methods);
+	dst_method->set_editable(!show_methods);
 
-	switch (vt) {
-		case Variant::BOOL: value = false; break;
-		case Variant::INT: value = 0; break;
-		case Variant::REAL: value = 0.0; break;
-		case Variant::STRING: value = ""; break;
-		case Variant::VECTOR2: value = Vector2(); break;
-		case Variant::RECT2: value = Rect2(); break;
-		case Variant::VECTOR3: value = Vector3(); break;
-		case Variant::PLANE: value = Plane(); break;
-		case Variant::QUAT: value = Quat(); break;
-		case Variant::AABB: value = AABB(); break;
-		case Variant::BASIS: value = Basis(); break;
-		case Variant::TRANSFORM: value = Transform(); break;
-		case Variant::COLOR: value = Color(); break;
-		default: {
-			ERR_FAIL();
-		} break;
+	Rect2 new_rect;
+
+	if (show_methods) {
+		new_rect.size = Size2(900, 500) * EDSCALE;
+		connect_to_label->set_text(TTR("Connect To Node:"));
+		tree->set_connect_to_script_mode(false);
+		error_label->hide();
+
+		if (tree->get_selected()) {
+			selector_right->select_method_from_instance(tree->get_selected());
+		}
+	} else {
+		new_rect.size = Size2(700, 500) * EDSCALE;
+		connect_to_label->set_text(TTR("Connect To Script:"));
+		tree->set_connect_to_script_mode(true);
+
+		if (!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root())) {
+			error_label->show();
+		} else {
+			error_label->hide();
+		}
 	}
 
-	ERR_FAIL_COND(value.get_type() == Variant::NIL);
-
-	cdbinds->params.push_back(value);
-	cdbinds->notify_changed();
+	set_position(((get_viewport_rect().size - new_rect.size) / 2.0 + get_position() + get_size() / 2.0 - get_viewport_rect().size / 2.0).floor());
+	set_size(new_rect.size);
 }
 
-/*
-Remove parameter bind from connection.
-*/
-void ConnectDialog::_remove_bind() {
+void ConnectDialog::_method_selected(String p_method) {
 
-	String st = bind_editor->get_selected_path();
-	if (st == "")
+	set_dst_method(p_method);
+}
+
+void ConnectDialog::_settings_flags_changed(int p_setting_idx) {
+
+	settings->get_popup()->set_item_checked(p_setting_idx, !settings->get_popup()->is_item_checked(p_setting_idx));
+
+	_set_settings_flags(settings->get_popup()->is_item_checked(CallMode::DEFERRED), settings->get_popup()->is_item_checked(CallMode::ONESHOT));
+}
+
+void ConnectDialog::_set_settings_flags(bool p_deferred, bool p_oneshot) {
+
+	String menu_button_text = TTR("Default");
+
+	if (!p_deferred && !p_oneshot) {
+		settings->set_text(menu_button_text);
 		return;
-	int idx = st.get_slice("/", 1).to_int() - 1;
+	}
 
-	ERR_FAIL_INDEX(idx, cdbinds->params.size());
-	cdbinds->params.remove(idx);
-	cdbinds->notify_changed();
+	menu_button_text = "";
+
+	if (p_deferred) {
+		menu_button_text += settings->get_popup()->get_item_text(CallMode::DEFERRED) + ", ";
+	}
+	if (p_oneshot) {
+		menu_button_text += settings->get_popup()->get_item_text(CallMode::ONESHOT) + ", ";
+	}
+	menu_button_text = menu_button_text.substr(0, menu_button_text.length() - 2);
+	settings->set_text(menu_button_text);
+}
+
+void ConnectDialog::_edit_arguments_pressed() {
+
+	args_dialog->popup_centered(Size2(500, 400));
+	args_dialog->set_title(TTR("Edit Signal Arguments"));
 }
 
 void ConnectDialog::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		bind_editor->edit(cdbinds);
+	if (p_what == NOTIFICATION_READY || p_what == NOTIFICATION_THEME_CHANGED) {
+		//Ref<Theme> theme = EditorNode::get_singleton()->the
+		settings->set_icon(Control::get_icon("arrow", "OptionButton"));
+		edit_args->set_icon(Control::get_icon("Edit", "EditorIcons"));
 	}
 }
 
 void ConnectDialog::_bind_methods() {
 
-	ClassDB::bind_method("_advanced_pressed", &ConnectDialog::_advanced_pressed);
+	ClassDB::bind_method("_mode_changed", &ConnectDialog::_mode_changed);
+	ClassDB::bind_method("_method_selected", &ConnectDialog::_method_selected);
+	ClassDB::bind_method("_settings_flags_changed", &ConnectDialog::_settings_flags_changed);
 	ClassDB::bind_method("_cancel", &ConnectDialog::_cancel_pressed);
 	ClassDB::bind_method("_tree_node_selected", &ConnectDialog::_tree_node_selected);
-	ClassDB::bind_method("_add_bind", &ConnectDialog::_add_bind);
-	ClassDB::bind_method("_remove_bind", &ConnectDialog::_remove_bind);
+	ClassDB::bind_method("_edit_arguments_pressed", &ConnectDialog::_edit_arguments_pressed);
 
 	ADD_SIGNAL(MethodInfo("connected"));
 }
@@ -252,17 +437,19 @@ void ConnectDialog::set_dst_method(const StringName &p_method) {
 
 Vector<Variant> ConnectDialog::get_binds() const {
 
-	return cdbinds->params;
+	return args_dialog->get_binds();
 }
 
 bool ConnectDialog::get_deferred() const {
 
-	return deferred->is_pressed();
+	//return deferred->is_pressed();
+	return settings->get_popup()->is_item_checked(CallMode::DEFERRED);
 }
 
 bool ConnectDialog::get_oneshot() const {
 
-	return oneshot->is_pressed();
+	//return oneshot->is_pressed();
+	return settings->get_popup()->is_item_checked(CallMode::ONESHOT);
 }
 
 /*
@@ -297,48 +484,41 @@ void ConnectDialog::init(Connection c, bool bEdit) {
 	bool bDeferred = (c.flags & CONNECT_DEFERRED) == CONNECT_DEFERRED;
 	bool bOneshot = (c.flags & CONNECT_ONESHOT) == CONNECT_ONESHOT;
 
+	settings->get_popup()->set_item_checked(CallMode::DEFERRED, bDeferred);
+	settings->get_popup()->set_item_checked(CallMode::ONESHOT, bOneshot);
+	_set_settings_flags(bDeferred, bOneshot);
+
+	/*
 	deferred->set_pressed(bDeferred);
 	oneshot->set_pressed(bOneshot);
+	*/
 
+	args_dialog->init(c.binds);
+	/*
 	cdbinds->params.clear();
 	cdbinds->params = c.binds;
 	cdbinds->notify_changed();
+	*/
 
 	bEditMode = bEdit;
 }
 
-void ConnectDialog::popup_dialog(const String &p_for_signal, bool p_advanced) {
+void ConnectDialog::popup_dialog(const String &p_for_signal, int p_mode) {
 
-	advanced->set_pressed(p_advanced);
 	from_signal->set_text(p_for_signal);
 	error_label->add_color_override("font_color", get_color("error_color", "Editor"));
 	vbc_right->set_visible(p_advanced);
 
-	if (p_advanced) {
+	popup_centered(Size2(700, 500) * EDSCALE);
 
-		popup_centered(Size2(900, 500) * EDSCALE);
-		connect_to_label->set_text("Connect to Node:");
-		tree->set_connect_to_script_mode(false);
-		error_label->hide();
-	} else {
-		popup_centered(Size2(700, 500) * EDSCALE);
-		connect_to_label->set_text("Connect to Script:");
-		tree->set_connect_to_script_mode(true);
-
-		if (!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root())) {
-			error_label->show();
-		} else {
-			error_label->hide();
-		}
-	}
-}
-
-void ConnectDialog::_advanced_pressed() {
-
-	popup_dialog(from_signal->get_text(), advanced->is_pressed());
+	// Index and IDs are the same in this case.
+	mode_list->select(p_mode);
+	_mode_changed(p_mode);
 }
 
 ConnectDialog::ConnectDialog() {
+
+	set_h_grow_direction(GrowDirection::GROW_DIRECTION_BOTH);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
@@ -373,53 +553,29 @@ ConnectDialog::ConnectDialog() {
 	vbc_right->set_h_size_flags(SIZE_EXPAND_FILL);
 	vbc_right->hide();
 
-	HBoxContainer *add_bind_hb = memnew(HBoxContainer);
+	selector_right = memnew(PropertySelector);
+	main_hb->add_child(selector_right);
+	selector_right->set_h_size_flags(SIZE_EXPAND_FILL);
+	selector_right->connect("item_selected", this, "_method_selected");
+	selector_right->connect("request_hide", this, "_closed");
+	selector_right->hide();
 
-	type_list = memnew(OptionButton);
-	type_list->set_h_size_flags(SIZE_EXPAND_FILL);
-	add_bind_hb->add_child(type_list);
-	type_list->add_item("bool", Variant::BOOL);
-	type_list->add_item("int", Variant::INT);
-	type_list->add_item("real", Variant::REAL);
-	type_list->add_item("string", Variant::STRING);
-	type_list->add_item("Vector2", Variant::VECTOR2);
-	type_list->add_item("Rect2", Variant::RECT2);
-	type_list->add_item("Vector3", Variant::VECTOR3);
-	type_list->add_item("Plane", Variant::PLANE);
-	type_list->add_item("Quat", Variant::QUAT);
-	type_list->add_item("AABB", Variant::AABB);
-	type_list->add_item("Basis", Variant::BASIS);
-	type_list->add_item("Transform", Variant::TRANSFORM);
-	type_list->add_item("Color", Variant::COLOR);
-	type_list->select(0);
-
-	Button *add_bind = memnew(Button);
-	add_bind->set_text(TTR("Add"));
-	add_bind_hb->add_child(add_bind);
-	add_bind->connect("pressed", this, "_add_bind");
-
-	Button *del_bind = memnew(Button);
-	del_bind->set_text(TTR("Remove"));
-	add_bind_hb->add_child(del_bind);
-	del_bind->connect("pressed", this, "_remove_bind");
-
-	vbc_right->add_margin_child(TTR("Add Extra Call Argument:"), add_bind_hb);
-
-	bind_editor = memnew(EditorInspector);
-
-	vbc_right->add_margin_child(TTR("Extra Call Arguments:"), bind_editor, true);
 
 	HBoxContainer *dstm_hb = memnew(HBoxContainer);
-	vbc_left->add_margin_child("Method to Create:", dstm_hb);
+	vbc_left->add_margin_child("Connect To:", dstm_hb);
+	//vbc_left->add_child(dstm_hb);
+
+	mode_list = memnew(OptionButton);
+	mode_list->set_h_size_flags(SIZE_FILL);
+	dstm_hb->add_child(mode_list);
+	mode_list->add_item(TTR("New Method"), Mode::NEW_METHOD);
+	mode_list->add_item(TTR("Existing Method"), Mode::EXISTING_METHOD);
+	mode_list->select(0);
+	mode_list->connect("item_selected", this, "_mode_changed");
 
 	dst_method = memnew(LineEdit);
 	dst_method->set_h_size_flags(SIZE_EXPAND_FILL);
 	dstm_hb->add_child(dst_method);
-
-	advanced = memnew(CheckBox);
-	dstm_hb->add_child(advanced);
-	advanced->set_text(TTR("Advanced..."));
-	advanced->connect("pressed", this, "_advanced_pressed");
 
 	/*
 	dst_method_list = memnew( MenuButton );
@@ -432,17 +588,49 @@ ConnectDialog::ConnectDialog() {
 	dst_method_list->set_end( Point2( 15,39  ) );
 	*/
 
-	deferred = memnew(CheckButton);
-	deferred->set_text(TTR("Deferred"));
-	vbc_right->add_child(deferred);
+	settings = memnew(MenuButton);
+	//settings->set_text(TTR("Default"));
 
-	oneshot = memnew(CheckButton);
+	settings->set_h_size_flags(SIZE_FILL);
+	settings->get_popup()->set_hide_on_checkable_item_selection(false);
+	settings->get_popup()->add_check_item(TTR("Deferred"), CallMode::DEFERRED);
+	settings->get_popup()->add_check_item(TTR("Oneshot"), CallMode::ONESHOT);
+	settings->get_popup()->connect("index_pressed", this, "_settings_flags_changed");
+	dstm_hb->add_child(settings);
+
+	/*
+	deferred = memnew(CheckBox);
+	deferred->set_text(TTR("Deferred"));
+	deferred->set_h_size_flags(SIZE_FILL);
+	dstm_hb->add_child(deferred);
+	*/
+
+	HBoxContainer *args_hb = memnew(HBoxContainer);
+	args_hb->set_alignment(BoxContainer::AlignMode::ALIGN_END);
+	vbc_left->add_child(args_hb);
+
+	edit_args = memnew(ToolButton);
+	edit_args->set_text(TTR("Edit Arguments..."));
+	edit_args->set_h_size_flags(SIZE_FILL);
+	edit_args->connect("pressed", this, "_edit_arguments_pressed");
+	args_hb->add_child(edit_args);
+
+	args_info = memnew(Label);
+	args_info->set_text("");
+	args_info->set_h_size_flags(SIZE_EXPAND);
+	//args_hb->add_child(args_info);
+
+	args_dialog = memnew(ArgumentsBindsDialog);
+	args_dialog->set_as_toplevel(true);
+	add_child(args_dialog);
+
+	/*
+	oneshot = memnew(CheckBox);
 	oneshot->set_text(TTR("Oneshot"));
-	vbc_right->add_child(oneshot);
+	args_hb->add_child(oneshot);
+	*/
 
 	set_as_toplevel(true);
-
-	cdbinds = memnew(ConnectDialogBinds);
 
 	error = memnew(ConfirmationDialog);
 	add_child(error);
@@ -450,10 +638,7 @@ ConnectDialog::ConnectDialog() {
 	get_ok()->set_text(TTR("Connect"));
 }
 
-ConnectDialog::~ConnectDialog() {
-
-	memdelete(cdbinds);
-}
+ConnectDialog::~ConnectDialog() { }
 
 //ConnectionsDock ==========================
 
@@ -663,7 +848,7 @@ void ConnectionsDock::_open_connection_dialog(TreeItem &item) {
 	c.method = dst_method;
 
 	//connect_dialog->set_title(TTR("Connect Signal: ") + signalname);
-	connect_dialog->popup_dialog(signalname, false);
+	connect_dialog->popup_dialog(signalname, ConnectDialog::Mode::NEW_METHOD);
 	connect_dialog->init(c);
 	connect_dialog->set_title(TTR("Connect a Signal to a Method"));
 }

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -317,6 +317,11 @@ void ConnectDialog::ok_pressed() {
 		return;
 	}
 	Node *target = tree->get_selected();
+	if (!target) {
+		error->set_text(TTR("No valid target selected!"));
+		error->popup_centered_minsize();
+		return;
+	}
 	if (target->get_script().is_null()) {
 		if (!target->has_method(dst_method->get_text())) {
 			error->set_text(TTR("Target method not found! Specify a valid method or attach a script to target Node."));
@@ -422,7 +427,14 @@ void ConnectDialog::_set_settings_flags(bool p_deferred, bool p_oneshot) {
 void ConnectDialog::_edit_arguments_pressed() {
 
 	args_dialog->set_title(TTR("Edit Signal Arguments"));
-	args_dialog->popup_centered_ratio(0.5);
+
+	Size2 popup_size = Size2(600, 700) * editor_get_scale();
+	Size2 window_size = get_viewport_rect().size;
+
+	popup_size.x = MIN(window_size.x * 0.8, popup_size.x);
+	popup_size.y = MIN(window_size.y * 0.8, popup_size.y);
+
+	args_dialog->popup_centered(popup_size);
 }
 
 void ConnectDialog::_bindings_changed() {
@@ -442,11 +454,8 @@ void ConnectDialog::_check_valid() {
 	error_label->add_color_override("font_color", get_color("error_color", "Editor"));
 
 	Node *target = tree->get_selected();
-	if (!target) {
-		return;
-	}
 
-	if (mode_list->get_selected_id() == Mode::EXISTING_METHOD) {
+	if (mode_list->get_selected_id() == Mode::EXISTING_METHOD && target) {
 
 		if (!target->has_method(dst_method->get_text())) {
 			error_label->set_text(TTR("Method not found in the selected node."));
@@ -459,7 +468,7 @@ void ConnectDialog::_check_valid() {
 			error_label->set_text(TTR("Scene does not contain any script."));
 			show_error = true;
 			disable_ok = true;
-		} else if (target->has_method(dst_method->get_text())) {
+		} else if (target && target->has_method(dst_method->get_text())) {
 			error_label->set_text(TTR("Method already defined. No new method will be created."));
 			error_label->add_color_override("font_color", get_color("warning_color", "Editor"));
 			show_error = true;
@@ -981,7 +990,13 @@ void ConnectionsDock::_open_connection_dialog(TreeItem &item) {
 	connect_dialog->init(signalname, c, ConnectDialog::Mode::NEW_METHOD, false);
 	connect_dialog->set_title(TTR("Connect a Signal to a Method"));
 
-	connect_dialog->popup_centered_ratio();
+	Size2 popup_size = Size2(900, 700) * editor_get_scale();
+	Size2 window_size = get_viewport_rect().size;
+
+	popup_size.x = MIN(window_size.x * 0.8, popup_size.x);
+	popup_size.y = MIN(window_size.y * 0.8, popup_size.y);
+
+	connect_dialog->popup_centered(popup_size);
 }
 
 /*
@@ -996,7 +1011,13 @@ void ConnectionsDock::_open_connection_dialog(Connection cToEdit) {
 		connect_dialog->init(cToEdit.signal, cToEdit, ConnectDialog::Mode::EXISTING_METHOD, true);
 		connect_dialog->set_title(TTR("Edit Connection:") + cToEdit.signal);
 
-		connect_dialog->popup_centered_ratio();
+		Size2 popup_size = Size2(900, 700) * editor_get_scale();
+		Size2 window_size = get_viewport_rect().size;
+
+		popup_size.x = MIN(window_size.x * 0.8, popup_size.x);
+		popup_size.y = MIN(window_size.y * 0.8, popup_size.y);
+
+		connect_dialog->popup_centered(popup_size);
 	}
 }
 

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -99,16 +99,14 @@ private:
 	StringName signal;
 	OptionButton *mode_list;
 	LineEdit *dst_method;
-	//ConnectDialogBinds *cdbinds;
 	bool bEditMode;
 	NodePath dst_path;
-	//VBoxContainer *vbc_right;
-	PropertySelector *selector_right;
+	VBoxContainer *right_container;
+	PropertySelector *method_selector;
+	Label *bind_info;
 
 	SceneTreeEditor *tree;
 	ConfirmationDialog *error;
-	//EditorInspector *bind_editor;
-	//OptionButton *type_list;
 	MenuButton *settings;
 	ArgumentsBindsDialog *args_dialog;
 	ToolButton *edit_args;
@@ -119,14 +117,15 @@ private:
 	void ok_pressed();
 	void _cancel_pressed();
 	void _tree_node_selected();
-	//void _add_bind();
-	//void _remove_bind();
 	void _mode_changed(int p_mode);
+	void _method_text_changed(String p_method_text);
 	void _method_selected(String p_method);
 	void _settings_flags_changed(int p_setting_idx);
 	void _set_settings_flags(bool p_deferred, bool p_oneshot);
 	void _edit_arguments_pressed();
 	void _bindings_changed();
+	void _bind_arguments_pressed();
+	void _check_valid();
 
 protected:
 	void _notification(int p_what);
@@ -145,9 +144,8 @@ public:
 	bool get_oneshot() const;
 	bool is_editing() const;
 
-	void init(Connection c, bool bEdit = false);
+	void init(const String &p_for_signal, Connection c, int p_mode, bool bEdit = false);
 
-	void popup_dialog(const String &p_for_signal, int p_mode);
 	ConnectDialog();
 	~ConnectDialog();
 };

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -38,6 +38,7 @@
 #include "core/undo_redo.h"
 #include "editor/editor_inspector.h"
 #include "editor/scene_tree_editor.h"
+#include "editor/property_selector.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/dialogs.h"
@@ -49,36 +50,81 @@
 class PopupMenu;
 class ConnectDialogBinds;
 
+class ArgumentsBindsDialog : public AcceptDialog {
+
+	GDCLASS(ArgumentsBindsDialog, AcceptDialog);
+
+	ConnectDialogBinds *cdbinds;
+	VBoxContainer *vb_container;
+	OptionButton *type_list;
+	EditorInspector *bind_editor;
+
+	void _add_bind();
+	void _remove_bind();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	Vector<Variant> get_binds() const;
+
+	void init(Vector<Variant> p_binds);
+
+	ArgumentsBindsDialog();
+	~ArgumentsBindsDialog();
+
+};
+
 class ConnectDialog : public ConfirmationDialog {
 
 	GDCLASS(ConnectDialog, ConfirmationDialog);
 
+	enum CallMode {
+		DEFERRED = 0,
+		ONESHOT = 1
+	};
+
+public:
+	enum Mode {
+		NEW_METHOD = 0,
+		EXISTING_METHOD = 1
+	};
+
+private:
 	Label *connect_to_label;
 	LineEdit *from_signal;
 	Node *source;
 	StringName signal;
+	OptionButton *mode_list;
 	LineEdit *dst_method;
-	ConnectDialogBinds *cdbinds;
+	//ConnectDialogBinds *cdbinds;
 	bool bEditMode;
 	NodePath dst_path;
 	VBoxContainer *vbc_right;
+	PropertySelector *selector_right;
 
 	SceneTreeEditor *tree;
 	ConfirmationDialog *error;
-	EditorInspector *bind_editor;
-	OptionButton *type_list;
-	CheckButton *deferred;
-	CheckButton *oneshot;
-	CheckBox *advanced;
+	//EditorInspector *bind_editor;
+	//OptionButton *type_list;
+	MenuButton *settings;
+	ArgumentsBindsDialog *args_dialog;
+	ToolButton *edit_args;
+	Label *args_info;
 
 	Label *error_label;
 
 	void ok_pressed();
 	void _cancel_pressed();
 	void _tree_node_selected();
-	void _add_bind();
-	void _remove_bind();
-	void _advanced_pressed();
+	//void _add_bind();
+	//void _remove_bind();
+	void _mode_changed(int p_mode);
+	void _method_selected(String p_method);
+	void _settings_flags_changed(int p_setting_idx);
+	void _set_settings_flags(bool p_deferred, bool p_oneshot);
+	void _edit_arguments_pressed();
 
 protected:
 	void _notification(int p_what);
@@ -99,7 +145,7 @@ public:
 
 	void init(Connection c, bool bEdit = false);
 
-	void popup_dialog(const String &p_for_signal, bool p_advanced);
+	void popup_dialog(const String &p_for_signal, int p_mode);
 	ConnectDialog();
 	~ConnectDialog();
 };

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -67,9 +67,10 @@ protected:
 	static void _bind_methods();
 
 public:
+	Vector<PropertyInfo> get_params() const;
 	Vector<Variant> get_binds() const;
 
-	void init(Vector<Variant> p_binds);
+	void init(Vector<PropertyInfo> p_arguments, Vector<Variant> p_binds);
 
 	ArgumentsBindsDialog();
 	~ArgumentsBindsDialog();
@@ -101,7 +102,7 @@ private:
 	//ConnectDialogBinds *cdbinds;
 	bool bEditMode;
 	NodePath dst_path;
-	VBoxContainer *vbc_right;
+	//VBoxContainer *vbc_right;
 	PropertySelector *selector_right;
 
 	SceneTreeEditor *tree;
@@ -125,6 +126,7 @@ private:
 	void _settings_flags_changed(int p_setting_idx);
 	void _set_settings_flags(bool p_deferred, bool p_oneshot);
 	void _edit_arguments_pressed();
+	void _bindings_changed();
 
 protected:
 	void _notification(int p_what);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -360,7 +360,7 @@ void EditorPropertyMember::_property_selected(const String &p_selected) {
 void EditorPropertyMember::_property_select() {
 
 	if (!selector) {
-		selector = memnew(PropertySelector);
+		selector = memnew(PropertySelectorDialog);
 		selector->connect("selected", this, "_property_selected");
 		add_child(selector);
 	}

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -162,7 +162,7 @@ public:
 
 private:
 	Type hint;
-	PropertySelector *selector;
+	PropertySelectorDialog *selector;
 	Button *property;
 	String hint_text;
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -600,7 +600,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			} else if (hint == PROPERTY_HINT_METHOD_OF_VARIANT_TYPE) {
 #define MAKE_PROPSELECT                                                          \
 	if (!property_select) {                                                      \
-		property_select = memnew(PropertySelector);                              \
+		property_select = memnew(PropertySelectorDialog);                              \
 		property_select->connect("selected", this, "_create_selected_property"); \
 		add_child(property_select);                                              \
 	}                                                                            \

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -52,7 +52,7 @@
 
 class PropertyValueEvaluator;
 class CreateDialog;
-class PropertySelector;
+class PropertySelectorDialog;
 
 class EditorResourceConversionPlugin : public Reference {
 
@@ -124,7 +124,7 @@ class CustomPropertyEditor : public Popup {
 
 	Control *easing_draw;
 	CreateDialog *create_dialog;
-	PropertySelector *property_select;
+	PropertySelectorDialog *property_select;
 
 	Object *owner;
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -688,6 +688,10 @@ void PropertySelectorDialog::set_type_filter(const Vector<Variant::Type> &p_type
 	selector->set_type_filter(p_type_filter);
 }
 
+PropertySelector* PropertySelectorDialog::get_property_selector() {
+	return selector;
+}
+
 void PropertySelectorDialog::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_selected"), &PropertySelectorDialog::_selected);

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -118,6 +118,8 @@ public:
 
 	void set_type_filter(const Vector<Variant::Type> &p_type_filter);
 
+	PropertySelector *get_property_selector();
+
 	PropertySelectorDialog();
 };
 

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -35,8 +35,8 @@
 #include "editor_help.h"
 #include "scene/gui/rich_text_label.h"
 
-class PropertySelector : public ConfirmationDialog {
-	GDCLASS(PropertySelector, ConfirmationDialog)
+class PropertySelector : public VBoxContainer {
+	GDCLASS(PropertySelector, VBoxContainer)
 
 	LineEdit *search_box;
 	Tree *search_options;
@@ -45,7 +45,6 @@ class PropertySelector : public ConfirmationDialog {
 
 	void _sbox_input(const Ref<InputEvent> &p_ie);
 
-	void _confirmed();
 	void _text_changed(const String &p_newtext);
 
 	EditorHelpBit *help_bit;
@@ -58,9 +57,49 @@ class PropertySelector : public ConfirmationDialog {
 	Object *instance;
 	bool virtuals_only;
 
+	void _item_activated();
 	void _item_selected();
+	void _request_hide();
 
 	Vector<Variant::Type> type_filter;
+
+protected:
+	static void _bind_methods();
+
+public:
+	LineEdit *get_search_box();
+	Tree *get_search_options();
+	EditorHelpBit *get_help_bit();
+
+	void select_method_from_base_type(const String &p_base, const String &p_current = "", bool p_virtuals_only = false);
+	void select_method_from_script(const Ref<Script> &p_script, const String &p_current = "");
+	void select_method_from_basic_type(Variant::Type p_type, const String &p_current = "");
+	void select_method_from_instance(Object *p_instance, const String &p_current = "");
+
+	void select_property_from_base_type(const String &p_base, const String &p_current = "");
+	void select_property_from_script(const Ref<Script> &p_script, const String &p_current = "");
+	void select_property_from_basic_type(Variant::Type p_type, const String &p_current = "");
+	void select_property_from_instance(Object *p_instance, const String &p_current = "");
+
+	void set_type_filter(const Vector<Variant::Type> &p_type_filter);
+
+	bool is_properties_only() const;
+	bool is_virtuals_only() const;
+
+	PropertySelector();
+};
+
+//========================================
+
+class PropertySelectorDialog : public ConfirmationDialog {
+	GDCLASS(PropertySelectorDialog, ConfirmationDialog)
+
+	PropertySelector *selector;
+
+	void _update_title();
+
+	void _selected(String p_name);
+	void _confirmed();
 
 protected:
 	void _notification(int p_what);
@@ -79,7 +118,7 @@ public:
 
 	void set_type_filter(const Vector<Variant::Type> &p_type_filter);
 
-	PropertySelector();
+	PropertySelectorDialog();
 };
 
 #endif // PROPERTYSELECTOR_H

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -44,6 +44,14 @@ class SceneTreeEditor : public Control {
 
 	GDCLASS(SceneTreeEditor, Control);
 
+public:
+	enum ConnectMode {
+		NONE = 0,
+		CONNECT_TO_SCRIPT = 1,
+		CONNECT_TO_NODE = 2
+	};
+
+private:
 	EditorSelection *editor_selection;
 
 	enum {
@@ -67,7 +75,7 @@ class SceneTreeEditor : public Control {
 	AcceptDialog *error;
 	AcceptDialog *warning;
 
-	bool connect_to_script_mode;
+	ConnectMode connect_mode;
 
 	int blocked;
 
@@ -153,7 +161,7 @@ public:
 
 	void update_tree() { _update_tree(); }
 
-	void set_connect_to_script_mode(bool p_enable);
+	void set_connect_mode(ConnectMode p_mode);
 
 	Tree *get_scene_tree() { return tree; }
 


### PR DESCRIPTION
This ConnectDialog gives a comprehensive set of tools to connect signals and to manage their arguments, all in a very discoverable way and still being simple in its initial appearance.

Currently implemented:

- [x] Refactored PropertySelector to make it possible to create one inside any part of the interface. (not only in a ConfirmationDialog)
- [x] There are now two distinct modes in the ConnectDialog: "New Method" and "Existing Method" modes.
- [x] Existing Method mode lets the user select the method of choice inside a list of available methods. The list can be searched and the methods descriptions can be viewed in real-time.
- [x] Adjustments in the UI of the Dialog: Deferred/Oneshot checkboxes and "Edit Arguments..." button.
- [x] Added new bindable argument types: Object, Array, Dictionary, NodePath, PoolArray...
- [x] Added arguments info in the main dialog.
- [x] Added locked arguments info in the bindings dialog for arguments passed directly by the emitting signal.
- [x] Children nodes of instanced scenes are displayed in the Connect Dialog SceneTree if Editable Children is active.
- [x] Fixed (Connecting From) not displaying in "Existing Method" mode.
- [x] The script and instanced scene icons now always appear in the scene tree, with tooltips.
- [x] Disable "New Method" mode if Script Editor is disabled in the current Editor Features profile.
- [x] Added warnings for "inexistent method" in "Existing Method" mode and for "method already defined" in "New Method" mode.
- [ ] Auto binding of the right amount/types of arguments when selecting an existing method.
- [ ] Bind arguments with proper names displayed so that their intent/purpose is clearer.
- [ ] More...

(Outdated gif)
![fkVtIHL](https://user-images.githubusercontent.com/19392104/56082318-c3939a80-5e17-11e9-9f2e-9422ea080557.gif)

(Newer gif)
![Newer gif](https://user-images.githubusercontent.com/19392104/81813649-05fe3e00-9528-11ea-9c03-b985c8f4e63d.gif)