### PR TITLE
Restored possibilty to delete multiple nodes in visual shaders via Delete key

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -143,6 +143,7 @@ class VisualShaderEditor : public VBoxContainer {
 	void _node_selected(Object *p_node);
 
 	void _delete_request(int);
+	void _on_nodes_delete();
 
 	void _removed_from_graph();
 


### PR DESCRIPTION
Previously it was not possible because it was not implemented

![fix](https://user-images.githubusercontent.com/3036176/56089427-37c35200-5e9b-11e9-9797-f12c5407003c.gif)
