### PR TITLE
Adds Copy button to output panel

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -78,8 +78,17 @@ void EditorLog::_clear_request() {
 	tool_button->set_icon(Ref<Texture>());
 }
 
+void EditorLog::_copy_request() {
+
+	log->selection_copy();
+}
+
 void EditorLog::clear() {
 	_clear_request();
+}
+
+void EditorLog::copy() {
+	_copy_request();
 }
 
 void EditorLog::add_message(const String &p_msg, MessageType p_type) {
@@ -125,7 +134,9 @@ void EditorLog::_undo_redo_cbk(void *p_self, const String &p_name) {
 void EditorLog::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_clear_request"), &EditorLog::_clear_request);
+	ClassDB::bind_method(D_METHOD("_copy_request"), &EditorLog::_copy_request);
 	ADD_SIGNAL(MethodInfo("clear_request"));
+	ADD_SIGNAL(MethodInfo("copy_request"));
 }
 
 EditorLog::EditorLog() {
@@ -138,6 +149,12 @@ EditorLog::EditorLog() {
 	title->set_text(TTR("Output:"));
 	title->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(title);
+
+	copybutton = memnew(Button);
+	hb->add_child(copybutton);
+	copybutton->set_text(TTR("Copy"));
+	copybutton->set_shortcut(ED_SHORTCUT("editor/copy_output", TTR("Copy Selection"), KEY_MASK_CMD | KEY_C));
+	copybutton->connect("pressed", this, "_copy_request");
 
 	clearbutton = memnew(Button);
 	hb->add_child(clearbutton);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -48,6 +48,7 @@ class EditorLog : public VBoxContainer {
 	GDCLASS(EditorLog, VBoxContainer);
 
 	Button *clearbutton;
+	Button *copybutton;
 	Label *title;
 	RichTextLabel *log;
 	HBoxContainer *title_hb;
@@ -62,6 +63,7 @@ class EditorLog : public VBoxContainer {
 
 	//void _dragged(const Point2& p_ofs);
 	void _clear_request();
+	void _copy_request();
 	static void _undo_redo_cbk(void *p_self, const String &p_name);
 
 protected:
@@ -80,6 +82,7 @@ public:
 	void deinit();
 
 	void clear();
+	void copy();
 	EditorLog();
 	~EditorLog();
 };


### PR DESCRIPTION
Fixes #27543. Adds a context menu to the Editor Log with "Copy" as an option. Could potentially add more, both "Clear" and "Select All" would be relevant (and simple to add on). Will update this PR if we decide to go that path.