### PR TITLE
Add image color quantization and palette support

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -51,6 +51,7 @@ thirdparty_misc_sources = [
     "fastlz.c",
     "sha256.c",
     "smaz.c",
+    "exoquant.c",
 
     # C++ sources
     "aes256.cpp",

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1632,19 +1632,17 @@ Error Image::apply_palette() {
 	return OK;
 }
 
-void Image::set_palette_data(const PoolVector<uint8_t> &p_palette_data) {
+Error Image::create_palette(const PoolVector<uint8_t> &p_palette_data, const PoolVector<uint8_t> &p_index_data) {
 
 	palette_data = p_palette_data;
+	index_data = p_index_data;
+
+	return OK;
 }
 
 PoolVector<uint8_t> Image::get_palette_data() const {
 
 	return palette_data;
-}
-
-void Image::set_index_data(const PoolVector<uint8_t> &p_index_data) {
-
-	index_data = p_index_data;
 }
 
 PoolVector<uint8_t> Image::get_index_data() const {

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1482,17 +1482,14 @@ PoolColorArray Image::get_palette() const {
 
 	PoolVector<uint8_t>::Read r_pal = palette_data.read();
 	const uint8_t *r = r_pal.ptr();
-	uint8_t *ofs = const_cast<uint8_t *>(r); // perform pointer arithmetic
 
 	for (int i = 0; i < num_colors; i++) {
-		float rc = (r[0] / 255.0f);
-		float gc = (r[1] / 255.0f);
-		float bc = (r[2] / 255.0f);
-		float ac = (r[3] / 255.0f);
+		float rc = r[i * 4 + 0] / 255.0f;
+		float gc = r[i * 4 + 1] / 255.0f;
+		float bc = r[i * 4 + 2] / 255.0f;
+		float ac = r[i * 4 + 3] / 255.0f;
 
 		w[i] = Color(rc, gc, bc, ac);
-
-		ofs += 4;
 	}
 
 	return palette;

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1439,15 +1439,17 @@ real_t Image::generate_palette(int p_num_colors, DitherMode p_dither, bool p_wit
 	const int num_pixels = width * height;
 	const int num_colors = int(CLAMP(p_num_colors, 1, 256));
 
-	// Quantize
+	// Init
 	PoolVector<uint8_t>::Write w_src = data.write();
 	uint8_t *src = w_src.ptr();
 
-	pExq = exq_init();
+	exq_data *pExq = exq_init();
 	if (!p_with_alpha) {
 		exq_no_transparency(pExq);
 	}
 	exq_feed(pExq, src, num_pixels);
+
+	// Quantize
 	exq_quantize_ex(pExq, num_colors, (int)p_high_quality);
 
 	// Extract palette

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1433,7 +1433,8 @@ Error Image::generate_palette(int p_num_colors, DitherMode p_dither, bool p_with
 	ERR_EXPLAIN("Cannot generate a palette, convert to FORMAT_RBGA8 first.");
 	ERR_FAIL_COND_V(format != FORMAT_RGBA8, ERR_UNAVAILABLE);
 
-	ERR_FAIL_COND_V(width == 0 || height == 0, ERR_UNCONFIGURED);
+	ERR_EXPLAIN("Cannot generate a palette from an empty image.");
+	ERR_FAIL_COND_V(empty(), ERR_UNCONFIGURED);
 
 	const int num_pixels = width * height;
 	const int num_colors = int(CLAMP(p_num_colors, 1, 256));

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1554,6 +1554,11 @@ bool Image::has_palette() const {
 	return palette_data.size() > 0;
 }
 
+int Image::get_palette_size() const {
+
+	return palette_data.size() / 4;
+}
+
 Error Image::apply_palette() {
 
 	// Converts indexed data with associated palette to compatible format
@@ -2790,12 +2795,15 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("generate_palette", "num_colors", "high_quality"), &Image::generate_palette, DEFVAL(256), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("clear_palette"), &Image::clear_palette);
+	ClassDB::bind_method(D_METHOD("apply_palette"), &Image::apply_palette);
+
+	ClassDB::bind_method(D_METHOD("has_palette"), &Image::has_palette);
+	ClassDB::bind_method(D_METHOD("get_palette_size"), &Image::get_palette_size);
+
 	ClassDB::bind_method(D_METHOD("set_palette", "palette"), &Image::set_palette);
 	ClassDB::bind_method(D_METHOD("get_palette"), &Image::get_palette);
 	ClassDB::bind_method(D_METHOD("set_palette_color", "index", "color"), &Image::set_palette_color);
 	ClassDB::bind_method(D_METHOD("get_palette_color", "index"), &Image::get_palette_color);
-	ClassDB::bind_method(D_METHOD("has_palette"), &Image::has_palette);
-	ClassDB::bind_method(D_METHOD("apply_palette"), &Image::apply_palette);
 
 	ClassDB::bind_method(D_METHOD("create", "width", "height", "use_mipmaps", "format"), &Image::_create_empty);
 	ClassDB::bind_method(D_METHOD("create_from_data", "width", "height", "use_mipmaps", "format", "data"), &Image::_create_from_data);

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1558,7 +1558,10 @@ Error Image::apply_palette() {
 
 	// Converts indexed data with associated palette to compatible format
 
+	ERR_EXPLAIN("No index data. Generate palette first.");
 	ERR_FAIL_COND_V(index_data.size() == 0, ERR_UNCONFIGURED);
+
+	ERR_EXPLAIN("No palette data. Generate or manually set palette first.");
 	ERR_FAIL_COND_V(palette_data.size() == 0, ERR_UNCONFIGURED);
 
 	PoolVector<uint8_t> dest_data;
@@ -1599,6 +1602,16 @@ Error Image::apply_palette() {
 	create(width, height, mipmaps, format, dest_data);
 
 	return OK;
+}
+
+void Image::set_palette_data(const PoolVector<uint8_t> &p_palette_data) {
+
+	palette_data = p_palette_data;
+}
+
+PoolVector<uint8_t> Image::get_palette_data() const {
+
+	return palette_data;
 }
 
 void Image::set_index_data(const PoolVector<uint8_t> &p_index_data) {

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1717,8 +1717,13 @@ Error Image::apply_palette() {
 			ERR_FAIL_V(ERR_UNAVAILABLE);
 		}
 	}
+	bool used_mipmaps = has_mipmaps();
+
 	create(width, height, mipmaps, format, dest_data);
 
+	if (used_mipmaps) {
+		generate_mipmaps();
+	}
 	return OK;
 }
 

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1594,6 +1594,16 @@ void Image::generate_palette(int p_num_colors, bool p_high_quality) {
 
 	exq_get_palette(pExq, pal_raw, p_num_colors);
 
+	// Finally, map image to palette (doesn't overwrite original image)
+	data_indexed.resize(0);
+	data_indexed.resize(num_pixels);
+
+	PoolVector<uint8_t>::Write w_dest = data_indexed.write();
+	uint8_t *dest = w_dest.ptr();
+
+	exq_map_image(pExq, num_pixels, src, dest);
+
+	// Cleanup
 	exq_free(pExq);
 }
 
@@ -1605,23 +1615,20 @@ PoolColorArray Image::get_palette() {
 	PoolColorArray palette;
 	palette.resize(num_colors);
 
-	PoolColorArray::Write w_pal = palette.write();
-	Color *pal = w_pal.ptr();
+	PoolColorArray::Write w = palette.write();
 
-	palette_data.resize(0);
-	palette_data.resize(num_colors * 4);
-	PoolVector<uint8_t>::Write w_pal_raw = palette_data.write();
-	uint8_t *pal_raw = w_pal_raw.ptr();
+	PoolVector<uint8_t>::Write w_pal = palette_data.write();
+	uint8_t *r = w_pal.ptr(); // pointer arithmetic
 
 	for (int i = 0; i < num_colors; i++) {
-		float rc = (pal_raw[0] / 255.0f);
-		float gc = (pal_raw[1] / 255.0f);
-		float bc = (pal_raw[2] / 255.0f);
-		float ac = (pal_raw[3] / 255.0f);
+		float rc = (r[0] / 255.9f);
+		float gc = (r[1] / 255.9f);
+		float bc = (r[2] / 255.9f);
+		float ac = (r[3] / 255.9f);
 
-		pal[i] = Color(rc, gc, bc, ac);
+		w[i] = Color(rc, gc, bc, ac);
 
-		pal_raw += 4;
+		r += 4;
 	}
 
 	return palette;
@@ -1632,21 +1639,21 @@ void Image::set_palette(const PoolColorArray &p_palette) {
 	// Convert to color array
 	int num_colors = p_palette.size();
 
-	PoolColorArray::Read w_pal = p_palette.read();
-	const Color *pal = w_pal.ptr();
+	PoolColorArray::Read r = p_palette.read();
 
 	palette_data.resize(0);
 	palette_data.resize(num_colors * 4);
-	PoolVector<uint8_t>::Write w_pal_raw = palette_data.write();
-	uint8_t *pal_raw = w_pal_raw.ptr();
+
+	PoolVector<uint8_t>::Write w_pal = palette_data.write();
+	uint8_t *w = w_pal.ptr();
 
 	for (int i = 0; i < num_colors; i++) {
-		pal_raw[0] = pal[i].r * 255.0f;
-		pal_raw[1] = pal[i].g * 255.0f;
-		pal_raw[2] = pal[i].b * 255.0f;
-		pal_raw[3] = pal[i].a * 255.0f;
+		w[0] = r[i].r * 255.0f;
+		w[1] = r[i].g * 255.0f;
+		w[2] = r[i].b * 255.0f;
+		w[3] = r[i].a * 255.0f;
 
-		pal_raw += 4;
+		w += 4;
 	}
 }
 

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -59,7 +59,6 @@ const char *Image::format_names[Image::FORMAT_MAX] = {
 	"RGBHalf",
 	"RGBAHalf",
 	"RGBE9995",
-	"Indexed",
 	"DXT1 RGB8", //s3tc
 	"DXT3 RGBA8",
 	"DXT5 RGBA8",
@@ -426,147 +425,147 @@ void Image::convert(Format p_new_format) {
 		ERR_EXPLAIN("Cannot convert to <-> from compressed formats. Use compress() and decompress() instead.");
 		ERR_FAIL();
 
-	} else if (format == FORMAT_INDEXED) {
+		// } else if (format == FORMAT_INDEXED) {
 
-		ERR_EXPLAIN("Cannot convert indexed image to format other than RGB8 or RGBA8.");
-		ERR_FAIL_COND(p_new_format != FORMAT_RGB8 || p_new_format != FORMAT_RGBA8);
+		// 	ERR_EXPLAIN("Cannot convert indexed image to format other than RGB8 or RGBA8.");
+		// 	ERR_FAIL_COND(p_new_format != FORMAT_RGB8 || p_new_format != FORMAT_RGBA8);
 
-		ERR_EXPLAIN("An indexed image should have a color palette.");
-		ERR_FAIL_COND(!has_palette());
+		// 	ERR_EXPLAIN("An indexed image should have a color palette.");
+		// 	ERR_FAIL_COND(!has_palette());
 
-		int pixel_size = get_format_pixel_size(p_new_format);
-		int num_pixels = data.size();
+		// 	int pixel_size = get_format_pixel_size(p_new_format);
+		// 	int num_pixels = data.size();
 
-		// This
-		PoolVector<uint8_t>::Read r_src = data.read();
-		const uint8_t *src = r_src.ptr();
+		// 	// This
+		// 	PoolVector<uint8_t>::Read r_src = data.read();
+		// 	const uint8_t *src = r_src.ptr();
 
-		// New
-		PoolVector<uint8_t> dest_data;
-		dest_data.resize(data.size() * pixel_size);
-		PoolVector<uint8_t>::Write w_dest = dest_data.write();
-		uint8_t *dest = w_dest.ptr();
+		// 	// New
+		// 	PoolVector<uint8_t> dest_data;
+		// 	dest_data.resize(data.size() * pixel_size);
+		// 	PoolVector<uint8_t>::Write w_dest = dest_data.write();
+		// 	uint8_t *dest = w_dest.ptr();
 
-		// Palette data
-		PoolColorArray::Read r_pal = palette.read();
-		const Color *pal = r_pal.ptr();
+		// 	// Palette data
+		// 	PoolColorArray::Read r_pal = palette.read();
+		// 	const Color *pal = r_pal.ptr();
 
-		for (int i = 0; i < num_pixels; i++) {
-			const Color &c = pal[src[i]];
+		// 	for (int i = 0; i < num_pixels; i++) {
+		// 		const Color &c = pal[src[i]];
 
-			dest[0] = c.r * 255.0;
-			dest[1] = c.g * 255.0;
-			dest[2] = c.b * 255.0;
-			dest[3] = c.a * 255.0;
+		// 		dest[0] = c.r * 255.0;
+		// 		dest[1] = c.g * 255.0;
+		// 		dest[2] = c.b * 255.0;
+		// 		dest[3] = c.a * 255.0;
 
-			dest += pixel_size;
-		}
-
-		data = dest_data;
-
-		// for (int i = 0; i < width; i++) {
-		// 	for (int j = 0; j < height; j++) {
-
-		// 		int pi = r[get_pixel(i, j)];
-		// 		new_img.set_pixel(i, j, );
+		// 		dest += pixel_size;
 		// 	}
-		// }
 
-		format = p_new_format;
+		// 	data = dest_data;
 
-		print_line("converted");
+		// 	// for (int i = 0; i < width; i++) {
+		// 	// 	for (int j = 0; j < height; j++) {
 
-		return;
+		// 	// 		int pi = r[get_pixel(i, j)];
+		// 	// 		new_img.set_pixel(i, j, );
+		// 	// 	}
+		// 	// }
 
-	} else if (p_new_format == FORMAT_INDEXED) {
+		// 	format = p_new_format;
 
-		ERR_EXPLAIN("Cannot convert an image to indexed format other than RGB8 or RGBA8.");
-		ERR_FAIL_COND(format != FORMAT_RGB8 && format != FORMAT_RGBA8);
+		// 	print_line("converted");
 
-		// Map image to palette
-		// clear_mipmaps();
+		// 	return;
 
-		// Init
-		pExq = exq_init();
-		if (format == FORMAT_RGB8) {
-			exq_no_transparency(pExq);
-		}
-		int pixel_size = get_format_pixel_size(format);
-		int num_pixels = data.size() / pixel_size;
+		// } else if (p_new_format == FORMAT_INDEXED) {
 
-		// This
-		PoolVector<uint8_t>::Write w_src = data.write();
-		uint8_t *src = w_src.ptr();
+		// 	ERR_EXPLAIN("Cannot convert an image to indexed format other than RGB8 or RGBA8.");
+		// 	ERR_FAIL_COND(format != FORMAT_RGB8 && format != FORMAT_RGBA8);
 
-		// New
-		PoolVector<uint8_t> dest_data;
-		dest_data.resize(data.size());
-		PoolVector<uint8_t>::Write w_dest = dest_data.write();
-		uint8_t *dest = w_dest.ptr();
+		// 	// Map image to palette
+		// 	// clear_mipmaps();
 
-		// Feed
-		exq_feed(pExq, src, num_pixels);
+		// 	// Init
+		// 	pExq = exq_init();
+		// 	if (format == FORMAT_RGB8) {
+		// 		exq_no_transparency(pExq);
+		// 	}
+		// 	int pixel_size = get_format_pixel_size(format);
+		// 	int num_pixels = data.size() / pixel_size;
 
-		// Palette data
-		PoolVector<uint8_t> palette_data;
-		int num_colors = has_palette() ? palette.size() : 256;
+		// 	// This
+		// 	PoolVector<uint8_t>::Write w_src = data.write();
+		// 	uint8_t *src = w_src.ptr();
 
-		palette_data.resize(0);
-		palette_data.resize(num_colors * pixel_size);
+		// 	// New
+		// 	PoolVector<uint8_t> dest_data;
+		// 	dest_data.resize(data.size());
+		// 	PoolVector<uint8_t>::Write w_dest = dest_data.write();
+		// 	uint8_t *dest = w_dest.ptr();
 
-		PoolVector<uint8_t>::Write w_pal_raw = palette_data.write();
-		uint8_t *pal_raw = w_pal_raw.ptr();
+		// 	// Feed
+		// 	exq_feed(pExq, src, num_pixels);
 
-		if (has_palette()) {
+		// 	// Palette data
+		// 	PoolVector<uint8_t> palette_data;
+		// 	int num_colors = has_palette() ? palette.size() : 256;
 
-			PoolColorArray::Write w_pal = palette.write();
-			Color *pal = w_pal.ptr();
+		// 	palette_data.resize(0);
+		// 	palette_data.resize(num_colors * pixel_size);
 
-			for (int i = 0; i < num_colors; i++) {
-				pal_raw[0] = pal[i].r * 255.0f;
-				pal_raw[1] = pal[i].g * 255.0f;
-				pal_raw[2] = pal[i].b * 255.0f;
-				pal_raw[3] = pal[i].a * 255.0f;
+		// 	PoolVector<uint8_t>::Write w_pal_raw = palette_data.write();
+		// 	uint8_t *pal_raw = w_pal_raw.ptr();
 
-				pal_raw += pixel_size;
-			}
-			exq_set_palette(pExq, pal_raw, num_colors);
+		// 	if (has_palette()) {
 
-		} else {
-			exq_quantize_hq(pExq, num_colors);
-			exq_get_palette(pExq, pal_raw, num_colors);
-		}
+		// 		PoolColorArray::Write w_pal = palette.write();
+		// 		Color *pal = w_pal.ptr();
 
-		// Finally, map image to palette
-		exq_map_image(pExq, num_pixels, src, dest);
+		// 		for (int i = 0; i < num_colors; i++) {
+		// 			pal_raw[0] = pal[i].r * 255.0f;
+		// 			pal_raw[1] = pal[i].g * 255.0f;
+		// 			pal_raw[2] = pal[i].b * 255.0f;
+		// 			pal_raw[3] = pal[i].a * 255.0f;
 
-		data = dest_data;
+		// 			pal_raw += pixel_size;
+		// 		}
+		// 		exq_set_palette(pExq, pal_raw, num_colors);
 
-		if (!has_palette()) {
-			// Convert palette to compatible format
-			palette.resize(num_colors);
+		// 	} else {
+		// 		exq_quantize_hq(pExq, num_colors);
+		// 		exq_get_palette(pExq, pal_raw, num_colors);
+		// 	}
 
-			PoolColorArray::Write w_pal = palette.write();
-			Color *pal = w_pal.ptr();
+		// 	// Finally, map image to palette
+		// 	exq_map_image(pExq, num_pixels, src, dest);
 
-			for (int i = 0; i < num_colors; i++) {
-				float rc = (pal_raw[0] / 255.0f);
-				float gc = (pal_raw[1] / 255.0f);
-				float bc = (pal_raw[2] / 255.0f);
-				float ac = (pal_raw[3] / 255.0f);
+		// 	data = dest_data;
 
-				pal[i] = Color(rc, gc, bc, ac);
+		// 	if (!has_palette()) {
+		// 		// Convert palette to compatible format
+		// 		palette.resize(num_colors);
 
-				pal_raw += pixel_size;
-			}
-		}
-		// format = p_new_format;
+		// 		PoolColorArray::Write w_pal = palette.write();
+		// 		Color *pal = w_pal.ptr();
 
-		// Clean up
-		exq_free(pExq);
-		pExq = NULL;
+		// 		for (int i = 0; i < num_colors; i++) {
+		// 			float rc = (pal_raw[0] / 255.0f);
+		// 			float gc = (pal_raw[1] / 255.0f);
+		// 			float bc = (pal_raw[2] / 255.0f);
+		// 			float ac = (pal_raw[3] / 255.0f);
 
-		return;
+		// 			pal[i] = Color(rc, gc, bc, ac);
+
+		// 			pal_raw += pixel_size;
+		// 		}
+		// 	}
+		// 	// format = p_new_format;
+
+		// 	// Clean up
+		// 	exq_free(pExq);
+		// 	pExq = NULL;
+
+		// 	return;
 
 	} else if (format > FORMAT_RGBA8 || p_new_format > FORMAT_RGBA8) {
 
@@ -1571,80 +1570,121 @@ void Image::clear_mipmaps() {
 	mipmaps = false;
 }
 
-Error Image::generate_palette(int p_num_colors, bool p_high_quality) {
+void Image::generate_palette(int p_num_colors, bool p_high_quality) {
 
-	bool has_alpha = false;
+	ERR_EXPLAIN("Cannot generate a palette, convert to FORMAT_RBGA8 first.");
+	ERR_FAIL_COND(format != FORMAT_RGBA8);
 
-	switch (format) {
-		case FORMAT_RGB8: has_alpha = false; break;
-		case FORMAT_RGBA8: has_alpha = true; break;
-		default: {
-		}
-	}
-
-	pExq = exq_init();
-	pExq->transparency = int(!has_alpha);
-
-	int pixel_size = get_format_pixel_size(format);
-	int num_pixels = data.size() / pixel_size;
+	int num_pixels = data.size() / 4;
 
 	// Quantize
 	PoolVector<uint8_t>::Write w_src = data.write();
 	uint8_t *src = w_src.ptr();
 
+	pExq = exq_init();
 	exq_feed(pExq, src, num_pixels);
 	exq_quantize_ex(pExq, p_num_colors, (int)p_high_quality);
 
 	// Extract palette
-	PoolVector<uint8_t> palette_data;
-	palette_data.resize(pixel_size * p_num_colors);
+	palette_data.resize(0);
+	palette_data.resize(p_num_colors * 4);
 
 	PoolVector<uint8_t>::Write w_pal_raw = palette_data.write();
 	uint8_t *pal_raw = w_pal_raw.ptr();
 
 	exq_get_palette(pExq, pal_raw, p_num_colors);
 
+	exq_free(pExq);
+}
+
+PoolColorArray Image::get_palette() {
+
 	// Convert to color array
-	clear_palette();
-	palette.resize(p_num_colors);
+	int num_colors = palette_data.size() / 4;
+
+	PoolColorArray palette;
+	palette.resize(num_colors);
 
 	PoolColorArray::Write w_pal = palette.write();
 	Color *pal = w_pal.ptr();
 
-	for (int i = 0; i < p_num_colors; i++) {
-		float rc = (pal_raw[0] / 255.9f);
-		float gc = (pal_raw[1] / 255.9f);
-		float bc = (pal_raw[2] / 255.9f);
-		float ac = (pal_raw[3] / 255.9f);
+	palette_data.resize(0);
+	palette_data.resize(num_colors * 4);
+	PoolVector<uint8_t>::Write w_pal_raw = palette_data.write();
+	uint8_t *pal_raw = w_pal_raw.ptr();
+
+	for (int i = 0; i < num_colors; i++) {
+		float rc = (pal_raw[0] / 255.0f);
+		float gc = (pal_raw[1] / 255.0f);
+		float bc = (pal_raw[2] / 255.0f);
+		float ac = (pal_raw[3] / 255.0f);
 
 		pal[i] = Color(rc, gc, bc, ac);
 
-		pal_raw += pixel_size;
+		pal_raw += 4;
 	}
-
-	exq_free(pExq);
-
-	return OK;
-}
-
-PoolColorArray Image::get_palette() const {
 
 	return palette;
 }
 
 void Image::set_palette(const PoolColorArray &p_palette) {
 
-	palette = p_palette;
+	// Convert to color array
+	int num_colors = p_palette.size();
+
+	PoolColorArray::Read w_pal = p_palette.read();
+	const Color *pal = w_pal.ptr();
+
+	palette_data.resize(0);
+	palette_data.resize(num_colors * 4);
+	PoolVector<uint8_t>::Write w_pal_raw = palette_data.write();
+	uint8_t *pal_raw = w_pal_raw.ptr();
+
+	for (int i = 0; i < num_colors; i++) {
+		pal_raw[0] = pal[i].r * 255.0f;
+		pal_raw[1] = pal[i].g * 255.0f;
+		pal_raw[2] = pal[i].b * 255.0f;
+		pal_raw[3] = pal[i].a * 255.0f;
+
+		pal_raw += 4;
+	}
+}
+
+void Image::set_palette_color(int p_idx, const Color p_color) {
+
+	ERR_FAIL_INDEX(p_idx, palette_data.size() / 4);
+
+	PoolVector<uint8_t>::Write w = palette_data.write();
+
+	w[p_idx + 0] = p_color.r * 255.0;
+	w[p_idx + 1] = p_color.g * 255.0;
+	w[p_idx + 2] = p_color.b * 255.0;
+	w[p_idx + 3] = p_color.a * 255.0;
+}
+
+Color Image::get_palette_color(int p_idx) const {
+
+	ERR_FAIL_INDEX_V(p_idx, palette_data.size() / 4, Color());
+
+	PoolVector<uint8_t>::Read r = palette_data.read();
+
+	Color pc;
+	pc.r = r[p_idx + 0] / 255.0;
+	pc.g = r[p_idx + 1] / 255.0;
+	pc.b = r[p_idx + 2] / 255.0;
+	pc.a = r[p_idx + 3] / 255.0;
+
+	return pc;
 }
 
 bool Image::has_palette() const {
 
-	return palette.size() > 0;
+	return palette_data.size() > 0;
 }
 
 void Image::clear_palette() {
 
-	palette.resize(0);
+	palette_data.resize(0);
 }
 
 // void Image::apply_palette() {
@@ -2862,8 +2902,13 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_mipmaps"), &Image::clear_mipmaps);
 
 	ClassDB::bind_method(D_METHOD("generate_palette", "num_colors", "high_quality"), &Image::generate_palette, DEFVAL(256), DEFVAL(true));
+
 	ClassDB::bind_method(D_METHOD("set_palette", "palette"), &Image::set_palette);
 	ClassDB::bind_method(D_METHOD("get_palette"), &Image::get_palette);
+
+	ClassDB::bind_method(D_METHOD("set_palette_color", "index", "color"), &Image::set_palette_color);
+	ClassDB::bind_method(D_METHOD("get_palette_color", "index"), &Image::get_palette_color);
+
 	ClassDB::bind_method(D_METHOD("has_palette"), &Image::has_palette);
 	ClassDB::bind_method(D_METHOD("clear_palette"), &Image::clear_palette);
 
@@ -2915,7 +2960,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_webp_from_buffer", "buffer"), &Image::load_webp_from_buffer);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "_set_data", "_get_data");
-	ADD_PROPERTY(PropertyInfo(Variant::POOL_COLOR_ARRAY, "palette", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_palette", "get_palette");
+	ADD_PROPERTY(PropertyInfo(Variant::POOL_COLOR_ARRAY, "palette"), "set_palette", "get_palette");
 
 	BIND_CONSTANT(MAX_WIDTH);
 	BIND_CONSTANT(MAX_HEIGHT);
@@ -2937,7 +2982,6 @@ void Image::_bind_methods() {
 	BIND_ENUM_CONSTANT(FORMAT_RGBH);
 	BIND_ENUM_CONSTANT(FORMAT_RGBAH);
 	BIND_ENUM_CONSTANT(FORMAT_RGBE9995);
-	BIND_ENUM_CONSTANT(FORMAT_INDEXED);
 	BIND_ENUM_CONSTANT(FORMAT_DXT1); //s3tc bc1
 	BIND_ENUM_CONSTANT(FORMAT_DXT3); //bc2
 	BIND_ENUM_CONSTANT(FORMAT_DXT5); //bc3

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1519,29 +1519,34 @@ void Image::set_palette(const PoolColorArray &p_palette) {
 
 void Image::set_palette_color(int p_idx, const Color p_color) {
 
-	ERR_FAIL_INDEX(p_idx, palette_data.size() / 4);
+	int ofs = p_idx * 4;
 
-	PoolVector<uint8_t>::Write w = palette_data.write();
+	ERR_FAIL_INDEX(ofs, palette_data.size());
 
-	w[p_idx + 0] = p_color.r * 255.0;
-	w[p_idx + 1] = p_color.g * 255.0;
-	w[p_idx + 2] = p_color.b * 255.0;
-	w[p_idx + 3] = p_color.a * 255.0;
+	PoolVector<uint8_t>::Write write = palette_data.write();
+	uint8_t *ptr = write.ptr();
+
+	ptr[ofs + 0] = uint8_t(CLAMP(p_color.r * 255.0, 0, 255));
+	ptr[ofs + 1] = uint8_t(CLAMP(p_color.g * 255.0, 0, 255));
+	ptr[ofs + 2] = uint8_t(CLAMP(p_color.b * 255.0, 0, 255));
+	ptr[ofs + 3] = uint8_t(CLAMP(p_color.a * 255.0, 0, 255));
 }
 
 Color Image::get_palette_color(int p_idx) const {
 
-	ERR_FAIL_INDEX_V(p_idx, palette_data.size() / 4, Color());
+	int ofs = p_idx * 4;
 
-	PoolVector<uint8_t>::Read r = palette_data.read();
+	ERR_FAIL_INDEX_V(ofs, palette_data.size(), Color());
 
-	Color pc;
-	pc.r = r[p_idx + 0] / 255.0;
-	pc.g = r[p_idx + 1] / 255.0;
-	pc.b = r[p_idx + 2] / 255.0;
-	pc.a = r[p_idx + 3] / 255.0;
+	PoolVector<uint8_t>::Read read = palette_data.read();
+	const uint8_t *ptr = read.ptr();
 
-	return pc;
+	float r = ptr[ofs + 0] / 255.0;
+	float g = ptr[ofs + 1] / 255.0;
+	float b = ptr[ofs + 2] / 255.0;
+	float a = ptr[ofs + 3] / 255.0;
+
+	return Color(r, g, b, a);
 }
 
 void Image::clear_palette() {

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1428,13 +1428,13 @@ void Image::clear_mipmaps() {
 	mipmaps = false;
 }
 
-Error Image::generate_palette(int p_num_colors, DitherMode p_dither, bool p_with_alpha, bool p_high_quality) {
+real_t Image::generate_palette(int p_num_colors, DitherMode p_dither, bool p_with_alpha, bool p_high_quality) {
 
 	ERR_EXPLAIN("Cannot generate a palette, convert to FORMAT_RBGA8 first.");
-	ERR_FAIL_COND_V(format != FORMAT_RGBA8, ERR_UNAVAILABLE);
+	ERR_FAIL_COND_V(format != FORMAT_RGBA8, -1.0);
 
 	ERR_EXPLAIN("Cannot generate a palette from an empty image.");
-	ERR_FAIL_COND_V(empty(), ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(empty(), -1.0);
 
 	const int num_pixels = width * height;
 	const int num_colors = int(CLAMP(p_num_colors, 1, 256));
@@ -1477,10 +1477,13 @@ Error Image::generate_palette(int p_num_colors, DitherMode p_dither, bool p_with
 			exq_map_image_random(pExq, num_pixels, src, dest);
 		} break;
 	}
+	// Determine quantization quality
+	real_t mean_error = exq_get_mean_error(pExq);
+
 	// Cleanup
 	exq_free(pExq);
 
-	return OK;
+	return mean_error;
 }
 
 PoolColorArray Image::get_palette() const {

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -425,148 +425,6 @@ void Image::convert(Format p_new_format) {
 		ERR_EXPLAIN("Cannot convert to <-> from compressed formats. Use compress() and decompress() instead.");
 		ERR_FAIL();
 
-		// } else if (format == FORMAT_INDEXED) {
-
-		// 	ERR_EXPLAIN("Cannot convert indexed image to format other than RGB8 or RGBA8.");
-		// 	ERR_FAIL_COND(p_new_format != FORMAT_RGB8 || p_new_format != FORMAT_RGBA8);
-
-		// 	ERR_EXPLAIN("An indexed image should have a color palette.");
-		// 	ERR_FAIL_COND(!has_palette());
-
-		// 	int pixel_size = get_format_pixel_size(p_new_format);
-		// 	int num_pixels = data.size();
-
-		// 	// This
-		// 	PoolVector<uint8_t>::Read r_src = data.read();
-		// 	const uint8_t *src = r_src.ptr();
-
-		// 	// New
-		// 	PoolVector<uint8_t> dest_data;
-		// 	dest_data.resize(data.size() * pixel_size);
-		// 	PoolVector<uint8_t>::Write w_dest = dest_data.write();
-		// 	uint8_t *dest = w_dest.ptr();
-
-		// 	// Palette data
-		// 	PoolColorArray::Read r_pal = palette.read();
-		// 	const Color *pal = r_pal.ptr();
-
-		// 	for (int i = 0; i < num_pixels; i++) {
-		// 		const Color &c = pal[src[i]];
-
-		// 		dest[0] = c.r * 255.0;
-		// 		dest[1] = c.g * 255.0;
-		// 		dest[2] = c.b * 255.0;
-		// 		dest[3] = c.a * 255.0;
-
-		// 		dest += pixel_size;
-		// 	}
-
-		// 	data = dest_data;
-
-		// 	// for (int i = 0; i < width; i++) {
-		// 	// 	for (int j = 0; j < height; j++) {
-
-		// 	// 		int pi = r[get_pixel(i, j)];
-		// 	// 		new_img.set_pixel(i, j, );
-		// 	// 	}
-		// 	// }
-
-		// 	format = p_new_format;
-
-		// 	print_line("converted");
-
-		// 	return;
-
-		// } else if (p_new_format == FORMAT_INDEXED) {
-
-		// 	ERR_EXPLAIN("Cannot convert an image to indexed format other than RGB8 or RGBA8.");
-		// 	ERR_FAIL_COND(format != FORMAT_RGB8 && format != FORMAT_RGBA8);
-
-		// 	// Map image to palette
-		// 	// clear_mipmaps();
-
-		// 	// Init
-		// 	pExq = exq_init();
-		// 	if (format == FORMAT_RGB8) {
-		// 		exq_no_transparency(pExq);
-		// 	}
-		// 	int pixel_size = get_format_pixel_size(format);
-		// 	int num_pixels = data.size() / pixel_size;
-
-		// 	// This
-		// 	PoolVector<uint8_t>::Write w_src = data.write();
-		// 	uint8_t *src = w_src.ptr();
-
-		// 	// New
-		// 	PoolVector<uint8_t> dest_data;
-		// 	dest_data.resize(data.size());
-		// 	PoolVector<uint8_t>::Write w_dest = dest_data.write();
-		// 	uint8_t *dest = w_dest.ptr();
-
-		// 	// Feed
-		// 	exq_feed(pExq, src, num_pixels);
-
-		// 	// Palette data
-		// 	PoolVector<uint8_t> palette_data;
-		// 	int num_colors = has_palette() ? palette.size() : 256;
-
-		// 	palette_data.resize(0);
-		// 	palette_data.resize(num_colors * pixel_size);
-
-		// 	PoolVector<uint8_t>::Write w_pal_raw = palette_data.write();
-		// 	uint8_t *pal_raw = w_pal_raw.ptr();
-
-		// 	if (has_palette()) {
-
-		// 		PoolColorArray::Write w_pal = palette.write();
-		// 		Color *pal = w_pal.ptr();
-
-		// 		for (int i = 0; i < num_colors; i++) {
-		// 			pal_raw[0] = pal[i].r * 255.0f;
-		// 			pal_raw[1] = pal[i].g * 255.0f;
-		// 			pal_raw[2] = pal[i].b * 255.0f;
-		// 			pal_raw[3] = pal[i].a * 255.0f;
-
-		// 			pal_raw += pixel_size;
-		// 		}
-		// 		exq_set_palette(pExq, pal_raw, num_colors);
-
-		// 	} else {
-		// 		exq_quantize_hq(pExq, num_colors);
-		// 		exq_get_palette(pExq, pal_raw, num_colors);
-		// 	}
-
-		// 	// Finally, map image to palette
-		// 	exq_map_image(pExq, num_pixels, src, dest);
-
-		// 	data = dest_data;
-
-		// 	if (!has_palette()) {
-		// 		// Convert palette to compatible format
-		// 		palette.resize(num_colors);
-
-		// 		PoolColorArray::Write w_pal = palette.write();
-		// 		Color *pal = w_pal.ptr();
-
-		// 		for (int i = 0; i < num_colors; i++) {
-		// 			float rc = (pal_raw[0] / 255.0f);
-		// 			float gc = (pal_raw[1] / 255.0f);
-		// 			float bc = (pal_raw[2] / 255.0f);
-		// 			float ac = (pal_raw[3] / 255.0f);
-
-		// 			pal[i] = Color(rc, gc, bc, ac);
-
-		// 			pal_raw += pixel_size;
-		// 		}
-		// 	}
-		// 	// format = p_new_format;
-
-		// 	// Clean up
-		// 	exq_free(pExq);
-		// 	pExq = NULL;
-
-		// 	return;
-
 	} else if (format > FORMAT_RGBA8 || p_new_format > FORMAT_RGBA8) {
 
 		//use put/set pixel which is slower but works with non byte formats
@@ -1575,13 +1433,14 @@ void Image::generate_palette(int p_num_colors, bool p_high_quality) {
 	ERR_EXPLAIN("Cannot generate a palette, convert to FORMAT_RBGA8 first.");
 	ERR_FAIL_COND(format != FORMAT_RGBA8);
 
-	int num_pixels = data.size() / 4;
+	const int num_pixels = width * height;
 
 	// Quantize
 	PoolVector<uint8_t>::Write w_src = data.write();
 	uint8_t *src = w_src.ptr();
 
 	pExq = exq_init();
+	// exq_no_transparency(pExq);
 	exq_feed(pExq, src, num_pixels);
 	exq_quantize_ex(pExq, p_num_colors, (int)p_high_quality);
 
@@ -1594,7 +1453,7 @@ void Image::generate_palette(int p_num_colors, bool p_high_quality) {
 
 	exq_get_palette(pExq, pal_raw, p_num_colors);
 
-	// Finally, map image to palette (doesn't overwrite original image)
+	// Map image to palette (doesn't overwrite original image)
 	data_indexed.resize(0);
 	data_indexed.resize(num_pixels);
 
@@ -1609,8 +1468,8 @@ void Image::generate_palette(int p_num_colors, bool p_high_quality) {
 
 PoolColorArray Image::get_palette() {
 
-	// Convert to color array
-	int num_colors = palette_data.size() / 4;
+	// Convert to compatible format
+	const int num_colors = palette_data.size() / 4;
 
 	PoolColorArray palette;
 	palette.resize(num_colors);
@@ -1621,10 +1480,10 @@ PoolColorArray Image::get_palette() {
 	uint8_t *r = w_pal.ptr(); // pointer arithmetic
 
 	for (int i = 0; i < num_colors; i++) {
-		float rc = (r[0] / 255.9f);
-		float gc = (r[1] / 255.9f);
-		float bc = (r[2] / 255.9f);
-		float ac = (r[3] / 255.9f);
+		float rc = (r[0] / 255.0f);
+		float gc = (r[1] / 255.0f);
+		float bc = (r[2] / 255.0f);
+		float ac = (r[3] / 255.0f);
 
 		w[i] = Color(rc, gc, bc, ac);
 
@@ -1636,8 +1495,7 @@ PoolColorArray Image::get_palette() {
 
 void Image::set_palette(const PoolColorArray &p_palette) {
 
-	// Convert to color array
-	int num_colors = p_palette.size();
+	const int num_colors = p_palette.size();
 
 	PoolColorArray::Read r = p_palette.read();
 
@@ -1684,65 +1542,42 @@ Color Image::get_palette_color(int p_idx) const {
 	return pc;
 }
 
-bool Image::has_palette() const {
-
-	return palette_data.size() > 0;
-}
-
 void Image::clear_palette() {
 
 	palette_data.resize(0);
 }
 
-// void Image::apply_palette() {
+bool Image::has_palette() const {
 
-// 	bool has_alpha = false;
+	return palette_data.size() > 0;
+}
 
-// 	switch (format) {
-// 		case FORMAT_RGB8: has_alpha = false; break;
-// 		case FORMAT_RGBA8: has_alpha = true; break;
-// 		default: {
-// 		}
-// 	}
+Ref<Image> Image::palette_to_rgba() const {
 
-// 	int pixel_size = get_format_pixel_size(format);
-// 	int num_pixels = data.size() / pixel_size;
+	PoolVector<uint8_t> dest_data;
+	dest_data.resize(data.size());
+	PoolVector<uint8_t>::Write w_dest = dest_data.write();
+	uint8_t *dest = w_dest.ptr();
 
-// 	PoolVector<uint8_t> dest_data;
-// 	dest_data.resize(data.size());
+	PoolVector<uint8_t>::Read pal = palette_data.read();
+	PoolVector<uint8_t>::Read indexed = data_indexed.read();
 
-// 	pExq = exq_init();
-// 	pExq->transparency = int(!has_alpha);
+	const int num_pixels = width * height;
 
-// 	PoolVector<uint8_t>::Write w_src = data.write();
-// 	PoolVector<uint8_t>::Write w_dest = dest_data.write();
+	for (int i = 0; i < num_pixels; i++) {
+		dest[0] = pal[indexed[i] * 4 + 0];
+		dest[1] = pal[indexed[i] * 4 + 1];
+		dest[2] = pal[indexed[i] * 4 + 2];
+		dest[3] = pal[indexed[i] * 4 + 3];
 
-// 	// palette_data.resize(0);
-// 	// palette_data.resize(pixel_size * p_num_colors);
+		dest += 4;
+	}
+	Ref<Image> img;
+	img.instance();
+	img->create(width, height, mipmaps, FORMAT_RGBA8, dest_data);
 
-// 	uint8_t *src = w_src.ptr();
-// 	uint8_t *dest = w_dest.ptr();
-
-// 	exq_feed(pExq, src, num_pixels);
-
-// 	// exq_set_palette(pExq, pal, palette_data.size() / pixel_size);
-
-// 	exq_quantize_ex(pExq, 256, 1);
-
-// 	palette_data.resize(0);
-// 	palette_data.resize(pixel_size * 256);
-
-// 	PoolVector<uint8_t>::Write w_pal = palette_data.write();
-// 	uint8_t *pal = w_pal.ptr();
-
-// 	exq_get_palette(pExq, pal, 256);
-
-// 	exq_map_image(pExq, num_pixels, src, dest);
-
-// 	exq_free(pExq);
-
-// 	create(width, height, mipmaps, format, dest_data);
-// }
+	return img;
+}
 
 bool Image::empty() const {
 
@@ -2909,15 +2744,13 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_mipmaps"), &Image::clear_mipmaps);
 
 	ClassDB::bind_method(D_METHOD("generate_palette", "num_colors", "high_quality"), &Image::generate_palette, DEFVAL(256), DEFVAL(true));
-
 	ClassDB::bind_method(D_METHOD("set_palette", "palette"), &Image::set_palette);
 	ClassDB::bind_method(D_METHOD("get_palette"), &Image::get_palette);
-
 	ClassDB::bind_method(D_METHOD("set_palette_color", "index", "color"), &Image::set_palette_color);
 	ClassDB::bind_method(D_METHOD("get_palette_color", "index"), &Image::get_palette_color);
-
 	ClassDB::bind_method(D_METHOD("has_palette"), &Image::has_palette);
 	ClassDB::bind_method(D_METHOD("clear_palette"), &Image::clear_palette);
+	ClassDB::bind_method(D_METHOD("palette_to_rgba"), &Image::palette_to_rgba);
 
 	ClassDB::bind_method(D_METHOD("create", "width", "height", "use_mipmaps", "format"), &Image::_create_empty);
 	ClassDB::bind_method(D_METHOD("create_from_data", "width", "height", "use_mipmaps", "format", "data"), &Image::_create_from_data);

--- a/core/image.h
+++ b/core/image.h
@@ -247,22 +247,23 @@ public:
 	void normalize(); //for normal maps
 
 	/**
-	 * Generate an optimal color palette of this image
+	 * Image color palette interface.
+	 * Can generate an optimal color palette of this image
 	 * The image can be saved as indexed if it has a palette associated with it
 	 * NOTE: there's no actual format for indexed images.
 	 */
 	Error generate_palette(int p_num_colors = 256, bool p_high_quality = true);
 	void clear_palette();
+	Error apply_palette();
+
+	bool has_palette() const;
+	int get_palette_size() const;
 
 	void set_palette(const PoolColorArray &p_palette);
 	PoolColorArray get_palette() const;
 
 	void set_palette_color(int p_idx, const Color p_color);
 	Color get_palette_color(int p_idx) const;
-
-	bool has_palette() const;
-
-	Error apply_palette();
 
 	/**
 	 * Intended to be used by image loaders/savers directly:

--- a/core/image.h
+++ b/core/image.h
@@ -251,21 +251,24 @@ public:
 	 * The image can be saved as indexed if it has a palette associated with it
 	 * NOTE: there's no actual format for indexed images.
 	 */
-	void generate_palette(int p_num_colors = 256, bool p_high_quality = true);
-
+	Error generate_palette(int p_num_colors = 256, bool p_high_quality = true);
 	void clear_palette();
 
 	void set_palette(const PoolColorArray &p_palette);
-	PoolColorArray get_palette();
+	PoolColorArray get_palette() const;
 
 	void set_palette_color(int p_idx, const Color p_color);
 	Color get_palette_color(int p_idx) const;
 
 	bool has_palette() const;
 
-	Ref<Image> palette_to_rgba() const;
+	Error apply_palette();
 
+	/**
+	 * Intended to be used by image loaders/savers directly:
+	 */
 	void set_index_data(const PoolVector<uint8_t> &p_index_data);
+	PoolVector<uint8_t> get_index_data() const;
 
 	/**
 	 * Create a new image of a given size and format. Current image will be lost

--- a/core/image.h
+++ b/core/image.h
@@ -81,7 +81,6 @@ public:
 		FORMAT_RGBH,
 		FORMAT_RGBAH,
 		FORMAT_RGBE9995,
-		FORMAT_INDEXED,
 		FORMAT_DXT1, //s3tc bc1
 		FORMAT_DXT3, //bc2
 		FORMAT_DXT5, //bc3
@@ -164,7 +163,8 @@ private:
 
 	Format format;
 	PoolVector<uint8_t> data;
-	PoolColorArray palette;
+	PoolVector<uint8_t> data_indexed;
+	PoolVector<uint8_t> palette_data;
 	int width, height;
 	bool mipmaps;
 
@@ -247,13 +247,21 @@ public:
 	void normalize(); //for normal maps
 
 	/**
-	 * Generate an optimal color palette of an image
+	 * Generate an optimal color palette of this image
+	 * The image can be saved as indexed if it has a palette associated with it
+	 * NOTE: there's no actual format for indexed images.
 	 */
-	Error generate_palette(int p_num_colors = 256, bool p_high_quality = true);
-	PoolColorArray get_palette() const;
-	void set_palette(const PoolColorArray &p_palette);
-	bool has_palette() const;
+	void generate_palette(int p_num_colors = 256, bool p_high_quality = true);
+
 	void clear_palette();
+
+	void set_palette(const PoolColorArray &p_palette);
+	PoolColorArray get_palette();
+
+	void set_palette_color(int p_idx, const Color p_color);
+	Color get_palette_color(int p_idx) const;
+
+	bool has_palette() const;
 
 	/**
 	 * Create a new image of a given size and format. Current image will be lost

--- a/core/image.h
+++ b/core/image.h
@@ -36,6 +36,8 @@
 #include "core/pool_vector.h"
 #include "core/resource.h"
 
+#include "thirdparty/misc/exoquant.h"
+
 /**
  *	@author Juan Linietsky <reduzio@gmail.com>
  *
@@ -148,6 +150,7 @@ public:
 
 protected:
 	static void _bind_methods();
+	exq_data *pExq;
 
 private:
 	void _create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
@@ -162,6 +165,8 @@ private:
 	PoolVector<uint8_t> data;
 	int width, height;
 	bool mipmaps;
+
+	PoolVector<uint8_t> palette_data;
 
 	void _copy_internals_from(const Image &p_image) {
 		format = p_image.format;
@@ -240,6 +245,14 @@ public:
 
 	void clear_mipmaps();
 	void normalize(); //for normal maps
+
+	/**
+	 * Generate an optimal color palette of an image
+	 */
+	Error generate_palette(int p_num_colors = 256, bool p_high_quality = true);
+	PoolColorArray get_palette();
+	void set_palette(const PoolColorArray &p_palette);
+	void apply_palette();
 
 	/**
 	 * Create a new image of a given size and format. Current image will be lost

--- a/core/image.h
+++ b/core/image.h
@@ -263,6 +263,8 @@ public:
 
 	bool has_palette() const;
 
+	Ref<Image> palette_to_rgba() const;
+
 	/**
 	 * Create a new image of a given size and format. Current image will be lost
 	 */

--- a/core/image.h
+++ b/core/image.h
@@ -81,6 +81,7 @@ public:
 		FORMAT_RGBH,
 		FORMAT_RGBAH,
 		FORMAT_RGBE9995,
+		FORMAT_INDEXED,
 		FORMAT_DXT1, //s3tc bc1
 		FORMAT_DXT3, //bc2
 		FORMAT_DXT5, //bc3
@@ -163,10 +164,9 @@ private:
 
 	Format format;
 	PoolVector<uint8_t> data;
+	PoolColorArray palette;
 	int width, height;
 	bool mipmaps;
-
-	PoolVector<uint8_t> palette_data;
 
 	void _copy_internals_from(const Image &p_image) {
 		format = p_image.format;
@@ -250,9 +250,10 @@ public:
 	 * Generate an optimal color palette of an image
 	 */
 	Error generate_palette(int p_num_colors = 256, bool p_high_quality = true);
-	PoolColorArray get_palette();
+	PoolColorArray get_palette() const;
 	void set_palette(const PoolColorArray &p_palette);
-	void apply_palette();
+	bool has_palette() const;
+	void clear_palette();
 
 	/**
 	 * Create a new image of a given size and format. Current image will be lost

--- a/core/image.h
+++ b/core/image.h
@@ -267,6 +267,9 @@ public:
 	/**
 	 * Intended to be used by image loaders/savers directly:
 	 */
+	void set_palette_data(const PoolVector<uint8_t> &p_palette_data);
+	PoolVector<uint8_t> get_palette_data() const;
+
 	void set_index_data(const PoolVector<uint8_t> &p_index_data);
 	PoolVector<uint8_t> get_index_data() const;
 

--- a/core/image.h
+++ b/core/image.h
@@ -259,25 +259,20 @@ public:
 		DITHER_RANDOM,
 	};
 	real_t generate_palette(int p_num_colors = 256, DitherMode p_dither = DITHER_NONE, bool p_with_alpha = true, bool p_high_quality = false);
+	Error create_palette(const PoolVector<uint8_t> &p_palette_data, const PoolVector<uint8_t> &p_index_data);
 	void clear_palette();
 	Error apply_palette();
 
 	bool has_palette() const;
 	int get_palette_size() const;
 
-	void set_palette(const PoolColorArray &p_palette);
-	PoolColorArray get_palette() const;
+	void set_palette(const PoolVector<Color> &p_palette);
+	PoolVector<Color> get_palette() const;
 
 	void set_palette_color(int p_idx, const Color p_color);
 	Color get_palette_color(int p_idx) const;
 
-	/**
-	 * Intended to be used by image loaders/savers directly:
-	 */
-	void set_palette_data(const PoolVector<uint8_t> &p_palette_data);
 	PoolVector<uint8_t> get_palette_data() const;
-
-	void set_index_data(const PoolVector<uint8_t> &p_index_data);
 	PoolVector<uint8_t> get_index_data() const;
 
 	/**

--- a/core/image.h
+++ b/core/image.h
@@ -163,7 +163,7 @@ private:
 
 	Format format;
 	PoolVector<uint8_t> data;
-	PoolVector<uint8_t> data_indexed;
+	PoolVector<uint8_t> index_data;
 	PoolVector<uint8_t> palette_data;
 	int width, height;
 	bool mipmaps;
@@ -264,6 +264,8 @@ public:
 	bool has_palette() const;
 
 	Ref<Image> palette_to_rgba() const;
+
+	void set_index_data(const PoolVector<uint8_t> &p_index_data);
 
 	/**
 	 * Create a new image of a given size and format. Current image will be lost

--- a/core/image.h
+++ b/core/image.h
@@ -150,7 +150,6 @@ public:
 
 protected:
 	static void _bind_methods();
-	exq_data *pExq;
 
 private:
 	void _create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {

--- a/core/image.h
+++ b/core/image.h
@@ -259,7 +259,7 @@ public:
 		DITHER_ORDERED,
 		DITHER_RANDOM,
 	};
-	Error generate_palette(int p_num_colors = 256, DitherMode p_dither = DITHER_NONE, bool p_with_alpha = true, bool p_high_quality = false);
+	real_t generate_palette(int p_num_colors = 256, DitherMode p_dither = DITHER_NONE, bool p_with_alpha = true, bool p_high_quality = false);
 	void clear_palette();
 	Error apply_palette();
 

--- a/core/image.h
+++ b/core/image.h
@@ -248,11 +248,16 @@ public:
 
 	/**
 	 * Image color palette interface.
-	 * Can generate an optimal color palette of this image
-	 * The image can be saved as indexed if it has a palette associated with it
+	 * Can generate an optimal color palette of this image.
+	 * The image can be saved/loaded as indexed if it has a palette associated.
 	 * NOTE: there's no actual format for indexed images.
 	 */
-	Error generate_palette(int p_num_colors = 256, bool p_high_quality = true);
+	enum DitherMode {
+		DITHER_NONE,
+		DITHER_ORDERED,
+		DITHER_RANDOM,
+	};
+	Error generate_palette(int p_num_colors = 256, DitherMode p_dither = DITHER_NONE, bool p_high_quality = true);
 	void clear_palette();
 	Error apply_palette();
 
@@ -401,6 +406,7 @@ VARIANT_ENUM_CAST(Image::Format)
 VARIANT_ENUM_CAST(Image::Interpolation)
 VARIANT_ENUM_CAST(Image::CompressMode)
 VARIANT_ENUM_CAST(Image::CompressSource)
+VARIANT_ENUM_CAST(Image::DitherMode)
 VARIANT_ENUM_CAST(Image::AlphaMode)
 
 #endif

--- a/core/image.h
+++ b/core/image.h
@@ -253,12 +253,14 @@ public:
 	 * Loaded images will have a color palette (if present) and extended to
 	 * compatible format, as there's no actual support for indexed images.
 	 */
+	static const int MAX_PALETTE_SIZE;
+
 	enum DitherMode {
 		DITHER_NONE,
 		DITHER_ORDERED,
 		DITHER_RANDOM,
 	};
-	real_t generate_palette(int p_num_colors = 256, DitherMode p_dither = DITHER_NONE, bool p_with_alpha = true, bool p_high_quality = false);
+	real_t generate_palette(int p_num_colors = MAX_PALETTE_SIZE, DitherMode p_dither = DITHER_NONE, bool p_with_alpha = true, bool p_high_quality = false);
 	Error create_palette(const PoolVector<uint8_t> &p_palette_data, const PoolVector<uint8_t> &p_index_data);
 	void clear_palette();
 	Error apply_palette();

--- a/core/image.h
+++ b/core/image.h
@@ -248,16 +248,18 @@ public:
 
 	/**
 	 * Image color palette interface.
-	 * Can generate an optimal color palette of this image.
-	 * The image can be saved/loaded as indexed if it has a palette associated.
-	 * NOTE: there's no actual format for indexed images.
+	 *
+	 * Can generate an optimal color palette for this image.
+	 * The image will be saved as indexed if it has a palette associated.
+	 * Loaded images will have a color palette (if present) and extended to
+	 * compatible format, as there's no actual support for indexed images.
 	 */
 	enum DitherMode {
 		DITHER_NONE,
 		DITHER_ORDERED,
 		DITHER_RANDOM,
 	};
-	Error generate_palette(int p_num_colors = 256, DitherMode p_dither = DITHER_NONE, bool p_high_quality = true);
+	Error generate_palette(int p_num_colors = 256, DitherMode p_dither = DITHER_NONE, bool p_with_alpha = true, bool p_high_quality = false);
 	void clear_palette();
 	Error apply_palette();
 

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -107,14 +107,14 @@ Error ImageLoaderPNG::_load_image(void *rf_up, png_rw_ptr p_func, Ref<Image> p_i
 	png_read_info(png, info);
 	png_get_IHDR(png, info, &width, &height, &depth, &color, NULL, NULL, NULL);
 
-	png_colorp png_palette = NULL;
-	int palette_size;
-	bool has_palette = false;
+	// png_colorp png_palette = NULL;
+	// int palette_size;
+	// bool has_palette = false;
 
-	if (png_get_valid(png, info, PNG_INFO_PLTE)) {
-		png_get_PLTE(png, info, &png_palette, &palette_size);
-		has_palette = true;
-	}
+	// if (png_get_valid(png, info, PNG_INFO_PLTE)) {
+	// 	png_get_PLTE(png, info, &png_palette, &palette_size);
+	// 	has_palette = true;
+	// }
 
 	//https://svn.gov.pt/projects/ccidadao/repository/middleware-offline/trunk/_src/eidmw/FreeImagePTEiD/Source/FreeImage/PluginPNG.cpp
 	//png_get_text(png,info,)
@@ -143,18 +143,16 @@ Error ImageLoaderPNG::_load_image(void *rf_up, png_rw_ptr p_func, Ref<Image> p_i
 		update_info = true;
 	}
 
-	png_bytep *png_palette_trans = NULL;
-	int num_trans = 0;
+	// png_bytep *png_palette_trans = NULL;
+	// int num_trans = 0;
 
 	if (png_get_valid(png, info, PNG_INFO_tRNS)) {
 		//png_set_expand_gray_1_2_4_to_8(png);
 
-		if (has_palette) {
-			// Retrieve auxiliary chunk for alpha
-			png_get_tRNS(png, info, png_palette_trans, &num_trans, NULL);
-		} else {
-			png_set_tRNS_to_alpha(png);
-		}
+		// if (has_palette) {
+		// 	// Retrieve auxiliary chunk for alpha
+		// 	png_get_tRNS(png, info, png_palette_trans, &num_trans, NULL);
+		png_set_tRNS_to_alpha(png);
 		update_info = true;
 	}
 
@@ -219,26 +217,26 @@ Error ImageLoaderPNG::_load_image(void *rf_up, png_rw_ptr p_func, Ref<Image> p_i
 
 	p_image->create(width, height, 0, fmt, dstbuff);
 
-	if (has_palette) {
+	// if (has_palette) {
 
-		PoolColorArray palette;
-		palette.resize(palette_size);
-		PoolColorArray::Write w = palette.write();
+	// 	PoolColorArray palette;
+	// 	palette.resize(palette_size);
+	// 	PoolColorArray::Write w = palette.write();
 
-		for (int i = 0; i < palette_size; i++) {
-			png_colorp c = &png_palette[i];
-			w[i] = Color(c->red / 255.0, c->green / 255.0, c->blue / 255.0);
-		}
-		// Set alpha from auxiliary chunk
-		if (png_palette_trans && num_trans == palette_size) {
+	// 	for (int i = 0; i < palette_size; i++) {
+	// 		png_colorp c = &png_palette[i];
+	// 		w[i] = Color(c->red / 255.0, c->green / 255.0, c->blue / 255.0);
+	// 	}
+	// 	// Set alpha from auxiliary chunk
+	// 	if (png_palette_trans && num_trans == palette_size) {
 
-			for (int i = 0; i < palette_size; i++) {
-				png_bytep a = png_palette_trans[i];
-				w[i].a = *a / 255.0;
-			}
-		}
-		p_image->set_palette(palette);
-	}
+	// 		for (int i = 0; i < palette_size; i++) {
+	// 			png_bytep a = png_palette_trans[i];
+	// 			w[i].a = *a / 255.0;
+	// 		}
+	// 	}
+	// 	p_image->set_palette(palette);
+	// }
 
 	png_destroy_read_struct(&png, &info, NULL);
 

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -211,7 +211,7 @@ Error ImageLoaderPNG::_load_image(void *rf_up, png_rw_ptr p_func, Ref<Image> p_i
 	memdelete_arr(row_p);
 
 	if (color == PNG_COLOR_TYPE_PALETTE) {
-		// Loaded data is indices
+		// Loaded data are indices
 		fmt = png_palette_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8;
 		int ps = png_palette_alpha ? 4 : 3;
 

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -235,7 +235,7 @@ Error ImageLoaderPNG::_load_image(void *rf_up, png_rw_ptr p_func, Ref<Image> p_i
 				w[i * 4 + 3] = *a;
 			}
 		}
-		// Create image with palette and flatten it
+		// Create image with palette and extend it
 		fmt = png_palette_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8;
 
 		p_image->create(width, height, 0, fmt);

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -103,8 +103,8 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 	int pngf = 0;
 	int cs = 0;
 
-	png_colorp png_palette;
-	png_bytep png_palette_trans;
+	// png_colorp png_palette;
+	// png_bytep png_palette_trans;
 
 	// if (p_img->has_palette()) {
 	// 	pngf = PNG_COLOR_TYPE_PALETTE;

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -127,14 +127,16 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 		png_set_PLTE(png_ptr, info_ptr, png_palette, palette_size);
 
 		// Palette alpha
-		png_palette_trans = (png_byte *)png_malloc(png_ptr, palette_size * sizeof(png_byte));
-		for (int i = 0; i < palette_size; i++) {
-			png_bytep a = &png_palette_trans[i];
-			*a = (uint8_t)(read[i].a * 255.0);
+		if (img->detect_alpha()) {
+			png_palette_trans = (png_byte *)png_malloc(png_ptr, palette_size * sizeof(png_byte));
+			for (int i = 0; i < palette_size; i++) {
+				png_bytep a = &png_palette_trans[i];
+				*a = (uint8_t)(read[i].a * 255.0);
+			}
+			png_set_tRNS(png_ptr, info_ptr, png_palette_trans, palette_size, NULL);
 		}
-		png_set_tRNS(png_ptr, info_ptr, png_palette_trans, palette_size, NULL);
 
-	} else {
+	} else { // has no palette associated
 		switch (img->get_format()) {
 
 			case Image::FORMAT_L8: {
@@ -212,9 +214,7 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 	/* cleanup heap allocation */
 	png_destroy_write_struct(&png_ptr, &info_ptr);
 
-	if (p_img->has_palette()) {
-		png_free(png_ptr, png_palette);
-	}
+	png_free(png_ptr, png_palette);
 
 	return OK;
 }

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -156,7 +156,7 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 
 	// Prepare palette
 	png_colorp png_palette = NULL;
-	png_bytep png_palette_trans = NULL;
+	png_bytep png_palette_alpha = NULL;
 
 	if (has_palette) {
 		PoolVector<uint8_t>::Read r = p_img->get_palette_data().read();
@@ -176,12 +176,12 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 
 		// Alpha
 		if (has_alpha) {
-			png_palette_trans = (png_byte *)png_malloc(png_ptr, palette_size * sizeof(png_byte));
+			png_palette_alpha = (png_byte *)png_malloc(png_ptr, palette_size * sizeof(png_byte));
 			for (int i = 0; i < palette_size; i++) {
-				png_bytep a = &png_palette_trans[i];
+				png_bytep a = &png_palette_alpha[i];
 				*a = r[i * 4 + 3];
 			}
-			png_set_tRNS(png_ptr, info_ptr, png_palette_trans, palette_size, NULL);
+			png_set_tRNS(png_ptr, info_ptr, png_palette_alpha, palette_size, NULL);
 		}
 	}
 	png_write_info(png_ptr, info_ptr);
@@ -221,12 +221,8 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 
 	/* cleanup heap allocation */
 	png_destroy_write_struct(&png_ptr, &info_ptr);
-
-	if (png_palette)
-		png_free(png_ptr, png_palette);
-
-	if (png_palette_trans)
-		png_free(png_ptr, png_palette_trans);
+	png_free(png_ptr, png_palette);
+	png_free(png_ptr, png_palette_alpha);
 
 	return OK;
 }

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -106,75 +106,75 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 	png_colorp png_palette;
 	png_bytep png_palette_trans;
 
-	if (p_img->has_palette()) {
-		pngf = PNG_COLOR_TYPE_PALETTE;
-		cs = 1;
+	// if (p_img->has_palette()) {
+	// 	pngf = PNG_COLOR_TYPE_PALETTE;
+	// 	cs = 1;
 
-		const PoolColorArray &palette = p_img->get_palette();
-		PoolColorArray::Read read = palette.read();
+	// 	const PoolColorArray &palette = p_img->get_palette();
+	// 	PoolColorArray::Read read = palette.read();
 
-		int palette_size = palette.size();
+	// 	int palette_size = palette.size();
 
-		// Palette
-		png_palette = (png_color *)png_malloc(png_ptr, palette_size * sizeof(png_color));
-		for (int i = 0; i < palette_size; i++) {
-			png_color *col = &png_palette[i];
+	// 	// Palette
+	// 	png_palette = (png_color *)png_malloc(png_ptr, palette_size * sizeof(png_color));
+	// 	for (int i = 0; i < palette_size; i++) {
+	// 		png_color *col = &png_palette[i];
 
-			col->red = read[i].r * 255.0;
-			col->green = read[i].g * 255.0;
-			col->blue = read[i].b * 255.0;
-		}
-		png_set_PLTE(png_ptr, info_ptr, png_palette, palette_size);
+	// 		col->red = read[i].r * 255.0;
+	// 		col->green = read[i].g * 255.0;
+	// 		col->blue = read[i].b * 255.0;
+	// 	}
+	// 	png_set_PLTE(png_ptr, info_ptr, png_palette, palette_size);
 
-		// Palette alpha
-		if (img->detect_alpha()) {
-			png_palette_trans = (png_byte *)png_malloc(png_ptr, palette_size * sizeof(png_byte));
-			for (int i = 0; i < palette_size; i++) {
-				png_bytep a = &png_palette_trans[i];
-				*a = (uint8_t)(read[i].a * 255.0);
-			}
-			png_set_tRNS(png_ptr, info_ptr, png_palette_trans, palette_size, NULL);
-		}
+	// 	// Palette alpha
+	// 	if (img->detect_alpha()) {
+	// 		png_palette_trans = (png_byte *)png_malloc(png_ptr, palette_size * sizeof(png_byte));
+	// 		for (int i = 0; i < palette_size; i++) {
+	// 			png_bytep a = &png_palette_trans[i];
+	// 			*a = (uint8_t)(read[i].a * 255.0);
+	// 		}
+	// 		png_set_tRNS(png_ptr, info_ptr, png_palette_trans, palette_size, NULL);
+	// 	}
 
-	} else { // has no palette associated
-		switch (img->get_format()) {
+	// } else { // has no palette associated
+	switch (img->get_format()) {
 
-			case Image::FORMAT_L8: {
+		case Image::FORMAT_L8: {
 
-				pngf = PNG_COLOR_TYPE_GRAY;
-				cs = 1;
-			} break;
-			case Image::FORMAT_LA8: {
+			pngf = PNG_COLOR_TYPE_GRAY;
+			cs = 1;
+		} break;
+		case Image::FORMAT_LA8: {
 
-				pngf = PNG_COLOR_TYPE_GRAY_ALPHA;
-				cs = 2;
-			} break;
-			case Image::FORMAT_RGB8: {
+			pngf = PNG_COLOR_TYPE_GRAY_ALPHA;
+			cs = 2;
+		} break;
+		case Image::FORMAT_RGB8: {
 
-				pngf = PNG_COLOR_TYPE_RGB;
-				cs = 3;
-			} break;
-			case Image::FORMAT_RGBA8: {
+			pngf = PNG_COLOR_TYPE_RGB;
+			cs = 3;
+		} break;
+		case Image::FORMAT_RGBA8: {
 
+			pngf = PNG_COLOR_TYPE_RGB_ALPHA;
+			cs = 4;
+		} break;
+		default: {
+
+			if (img->detect_alpha()) {
+
+				img->convert(Image::FORMAT_RGBA8);
 				pngf = PNG_COLOR_TYPE_RGB_ALPHA;
 				cs = 4;
-			} break;
-			default: {
+			} else {
 
-				if (img->detect_alpha()) {
-
-					img->convert(Image::FORMAT_RGBA8);
-					pngf = PNG_COLOR_TYPE_RGB_ALPHA;
-					cs = 4;
-				} else {
-
-					img->convert(Image::FORMAT_RGB8);
-					pngf = PNG_COLOR_TYPE_RGB;
-					cs = 3;
-				}
+				img->convert(Image::FORMAT_RGB8);
+				pngf = PNG_COLOR_TYPE_RGB;
+				cs = 3;
 			}
 		}
 	}
+	// }
 
 	int w = img->get_width();
 	int h = img->get_height();
@@ -214,7 +214,7 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 	/* cleanup heap allocation */
 	png_destroy_write_struct(&png_ptr, &info_ptr);
 
-	png_free(png_ptr, png_palette);
+	// png_free(png_ptr, png_palette);
 
 	return OK;
 }

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -53,21 +53,20 @@ Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 			err = FAILED;
 		}
 		// Check whether we can load it
-		switch (bits_per_pixel) {
-			case 1:
-				// Requires bit unpacking
-				ERR_FAIL_COND_V(width % 8 != 0, ERR_UNAVAILABLE);
-				ERR_FAIL_COND_V(height % 8 != 0, ERR_UNAVAILABLE);
-			case 4:
-				ERR_FAIL_COND_V(width % 2 != 0, ERR_UNAVAILABLE);
-				ERR_FAIL_COND_V(height % 2 != 0, ERR_UNAVAILABLE);
-			case 8:
-			case 24:
-			case 32:
-				break;
-			default: {
-				ERR_FAIL_V(ERR_UNAVAILABLE);
-			}
+
+		if (bits_per_pixel == 1) {
+			// Requires bit unpacking...
+			ERR_FAIL_COND_V(width % 8 != 0, ERR_UNAVAILABLE);
+			ERR_FAIL_COND_V(height % 8 != 0, ERR_UNAVAILABLE);
+
+		} else if (bits_per_pixel == 4) {
+			// Requires bit unpacking...
+			ERR_FAIL_COND_V(width % 2 != 0, ERR_UNAVAILABLE);
+			ERR_FAIL_COND_V(height % 2 != 0, ERR_UNAVAILABLE);
+
+		} else if (bits_per_pixel == 16) {
+
+			ERR_FAIL_V(ERR_UNAVAILABLE);
 		}
 		if (err == OK) {
 			// Palette data
@@ -109,16 +108,10 @@ Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 			PoolVector<uint8_t> image_data;
 			int image_data_len = 0;
 
-			switch (bits_per_pixel) {
-				case 1:
-				case 4:
-				case 8: { // indexed
-					image_data_len = width * height;
-				} break;
-				case 24:
-				case 32: { // color
-					image_data_len = width * height * 4;
-				} break;
+			if (bits_per_pixel <= 8) { // indexed
+				image_data_len = width * height;
+			} else { // color
+				image_data_len = width * height * 4;
 			}
 			ERR_FAIL_COND_V(image_data_len == 0, ERR_BUG);
 			err = image_data.resize(image_data_len);

--- a/modules/bmp/image_loader_bmp.h
+++ b/modules/bmp/image_loader_bmp.h
@@ -37,6 +37,9 @@ class ImageLoaderBMP : public ImageFormatLoader {
 protected:
 	static const unsigned BITMAP_SIGNATURE = 0x4d42;
 
+	static const unsigned BITMAP_FILE_HEADER_SIZE = 14; // bmp_file_header_s
+	static const unsigned BITMAP_INFO_HEADER_MIN_SIZE = 40; // bmp_info_header_s
+
 	struct bmp_header_s {
 		struct bmp_file_header_s {
 			uint16_t bmp_signature;

--- a/thirdparty/misc/exoquant-LICENSE.md
+++ b/thirdparty/misc/exoquant-LICENSE.md
@@ -1,0 +1,23 @@
+## Licence
+
+ExoQuant v0.7
+
+Copyright (c) 2004 Dennis Ranke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/thirdparty/misc/exoquant.c
+++ b/thirdparty/misc/exoquant.c
@@ -1,0 +1,708 @@
+/*
+ExoQuant v0.7
+
+Copyright (c) 2004 Dennis Ranke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "exoquant.h"
+#include <malloc.h>
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifndef NULL
+#define NULL (0)
+#endif
+
+#define SCALE_R 1.0f
+#define SCALE_G 1.2f
+#define SCALE_B 0.8f
+#define SCALE_A 1.0f
+
+exq_data *exq_init()
+{
+	int i;
+	exq_data *pExq;
+
+	pExq = (exq_data*)malloc(sizeof(exq_data));
+	
+	for(i = 0; i < EXQ_HASH_SIZE; i++)
+		pExq->pHash[i] = NULL;
+
+	pExq->numColors = 0;
+	pExq->optimized = 0;
+	pExq->transparency = 1;
+	pExq->numBitsPerChannel = 8;
+
+	return pExq;
+}
+
+void exq_no_transparency(exq_data *pExq)
+{
+	pExq->transparency = 0;
+}
+
+void exq_free(exq_data *pExq)
+{
+	int i;
+	exq_histogram *pCur, *pNext;
+
+	for(i = 0; i < EXQ_HASH_SIZE; i++)
+		for(pCur = pExq->pHash[i]; pCur != NULL; pCur = pNext)
+		{
+			pNext = pCur->pNextInHash;
+			free(pCur);
+		}
+
+	free(pExq);
+}
+
+static unsigned int exq_make_hash(unsigned int rgba)
+{
+	rgba -= (rgba >> 13) | (rgba << 19);
+	rgba -= (rgba >> 13) | (rgba << 19);
+	rgba -= (rgba >> 13) | (rgba << 19);
+	rgba -= (rgba >> 13) | (rgba << 19);
+	rgba -= (rgba >> 13) | (rgba << 19);
+	rgba &= EXQ_HASH_SIZE - 1;
+	return rgba;
+}
+
+void exq_feed(exq_data *pExq, unsigned char *pData, int nPixels)
+{
+	int i;
+	unsigned int hash;
+	unsigned char r, g, b, a;
+	exq_histogram *pCur;
+	unsigned char channelMask = 0xff00 >> pExq->numBitsPerChannel;
+
+	for(i = 0; i < nPixels; i++)
+	{
+		r = *pData++; g = *pData++; b = *pData++; a = *pData++;
+		hash = exq_make_hash(((unsigned int)r) | (((unsigned int)g) << 8) | (((unsigned int)b) << 16) | (((unsigned int)a) << 24));
+
+		pCur = pExq->pHash[hash];
+		while(pCur != NULL && (pCur->ored != r || pCur->ogreen != g ||
+			pCur->oblue != b || pCur->oalpha != a))
+			pCur = pCur->pNextInHash;
+
+		if(pCur != NULL)
+			pCur->num++;
+		else
+		{
+			pCur = (exq_histogram*)malloc(sizeof(exq_histogram));
+			pCur->pNextInHash = pExq->pHash[hash];
+			pExq->pHash[hash] = pCur;
+			pCur->ored = r; pCur->ogreen = g; pCur->oblue = b; pCur->oalpha = a;
+			r &= channelMask; g &= channelMask; b &= channelMask;
+			pCur->color.r = r / 255.0f * SCALE_R;
+			pCur->color.g = g / 255.0f * SCALE_G;
+			pCur->color.b = b / 255.0f * SCALE_B;
+			pCur->color.a = a / 255.0f * SCALE_A;
+
+			if(pExq->transparency)
+			{
+				pCur->color.r *= pCur->color.a;
+				pCur->color.g *= pCur->color.a;
+				pCur->color.b *= pCur->color.a;
+			}
+
+			pCur->num = 1;
+			pCur->palIndex = -1;
+			pCur->ditherScale.r = pCur->ditherScale.g = pCur->ditherScale.b =
+				pCur->ditherScale.a = -1;
+			pCur->ditherIndex[0] = pCur->ditherIndex[1] = pCur->ditherIndex[2] =
+				pCur->ditherIndex[3] = -1;
+		}
+	}
+}
+
+void exq_quantize(exq_data *pExq, int nColors)
+{
+	exq_quantize_ex(pExq, nColors, 0);
+}
+
+void exq_quantize_hq(exq_data *pExq, int nColors)
+{
+	exq_quantize_ex(pExq, nColors, 1);
+}
+
+void exq_quantize_ex(exq_data *pExq, int nColors, int hq)
+{
+	int besti;
+	exq_float beste;
+	exq_histogram *pCur, *pNext;
+	int i, j;
+
+	if(nColors > 256)
+		nColors = 256;
+
+	if(pExq->numColors == 0)
+	{
+		pExq->node[0].pHistogram = NULL;
+		for(i = 0; i < EXQ_HASH_SIZE; i++)
+			for(pCur = pExq->pHash[i]; pCur != NULL; pCur = pCur->pNextInHash)
+			{
+				pCur->pNext = pExq->node[0].pHistogram;
+				pExq->node[0].pHistogram = pCur;
+			}
+		
+		exq_sum_node(&pExq->node[0]);
+
+		pExq->numColors = 1;
+	}
+
+	for(i = pExq->numColors; i < nColors; i++)
+	{
+		beste = 0;
+		besti = 0;
+		for(j = 0; j < i; j++)
+			if(pExq->node[j].vdif >= beste)
+			{
+				beste = pExq->node[j].vdif;
+				besti = j;
+			}
+
+//		printf("node %d: %d, %f\n", besti, pExq->node[besti].num, beste);
+
+		pCur = pExq->node[besti].pHistogram;
+		pExq->node[besti].pHistogram = NULL;
+		pExq->node[i].pHistogram = NULL;
+		while(pCur != NULL && pCur != pExq->node[besti].pSplit)
+		{
+			pNext = pCur->pNext;
+			pCur->pNext = pExq->node[i].pHistogram;
+			pExq->node[i].pHistogram = pCur;
+			pCur = pNext;
+		}
+
+		while(pCur != NULL)
+		{
+			pNext = pCur->pNext;
+			pCur->pNext = pExq->node[besti].pHistogram;
+			pExq->node[besti].pHistogram = pCur;
+			pCur = pNext;
+		}
+
+		exq_sum_node(&pExq->node[besti]);
+		exq_sum_node(&pExq->node[i]);
+
+		pExq->numColors = i + 1;
+		if(hq)
+			exq_optimize_palette(pExq, 1);
+	}
+
+	pExq->optimized = 0;
+}
+
+exq_float exq_get_mean_error(exq_data *pExq)
+{
+	int i, n;
+	exq_float err;
+
+	n = 0;
+	err = 0;
+	for(i = 0; i < pExq->numColors; i++)
+	{
+		n += pExq->node[i].num;
+		err += pExq->node[i].err;
+	}
+
+	return sqrt(err / n) * 256;
+}
+
+void exq_get_palette(exq_data *pExq, unsigned char *pPal, int nColors)
+{
+	int i, j;
+	exq_float r, g, b, a;
+	unsigned char channelMask = 0xff00 >> pExq->numBitsPerChannel;
+
+	if(nColors > pExq->numColors)
+		nColors = pExq->numColors;
+
+	if(!pExq->optimized)
+		exq_optimize_palette(pExq, 4);
+
+	for(i = 0; i < nColors; i++)
+	{
+		r = pExq->node[i].avg.r;
+		g = pExq->node[i].avg.g;
+		b = pExq->node[i].avg.b;
+		a = pExq->node[i].avg.a;
+
+		if(pExq->transparency == 1 && a != 0)
+		{
+			r /= a; g/= a; b/= a;
+		}
+
+		pPal[0] = (unsigned char)(r / SCALE_R * 255.9f);
+		pPal[1] = (unsigned char)(g / SCALE_G * 255.9f);
+		pPal[2] = (unsigned char)(b / SCALE_B * 255.9f);
+		pPal[3] = (unsigned char)(a / SCALE_A * 255.9f);
+
+		for(j = 0; j < 3; j++)
+			pPal[j] = (pPal[j] + (1 << (8 - pExq->numBitsPerChannel)) / 2) & channelMask;
+		pPal += 4;
+	}
+}
+
+void exq_set_palette(exq_data *pExq, unsigned char *pPal, int nColors)
+{
+	int i;
+
+	pExq->numColors = nColors;
+
+	for(i = 0; i < nColors; i++)
+	{
+		pExq->node[i].avg.r = *pPal++ * SCALE_R / 255.9f;
+		pExq->node[i].avg.g = *pPal++ * SCALE_G / 255.9f;
+		pExq->node[i].avg.b = *pPal++ * SCALE_B / 255.9f;
+		pExq->node[i].avg.a = *pPal++ * SCALE_A / 255.9f;
+	}
+
+	pExq->optimized = 1;
+}
+
+void exq_sum_node(exq_node *pNode)
+{
+	int n, n2;
+	exq_color fsum, fsum2, vc, tmp, tmp2, sum, sum2;
+	exq_histogram *pCur;
+	exq_float isqrt, nv, v;
+
+	n = 0;
+	fsum.r = fsum.g = fsum.b = fsum.a = 0;
+	fsum2.r = fsum2.g = fsum2.b = fsum2.a = 0;
+
+	for(pCur = pNode->pHistogram; pCur != NULL; pCur = pCur->pNext)
+	{
+		n += pCur->num;
+		fsum.r += pCur->color.r * pCur->num;
+		fsum.g += pCur->color.g * pCur->num;
+		fsum.b += pCur->color.b * pCur->num;
+		fsum.a += pCur->color.a * pCur->num;
+		fsum2.r += pCur->color.r * pCur->color.r * pCur->num;
+		fsum2.g += pCur->color.g * pCur->color.g * pCur->num;
+		fsum2.b += pCur->color.b * pCur->color.b * pCur->num;
+		fsum2.a += pCur->color.a * pCur->color.a * pCur->num;
+	}
+	pNode->num = n;
+	if(n == 0)
+	{
+		pNode->vdif = 0;
+		pNode->err = 0;
+		return;
+	}
+
+	pNode->avg.r = fsum.r / n;
+	pNode->avg.g = fsum.g / n;
+	pNode->avg.b = fsum.b / n;
+	pNode->avg.a = fsum.a / n;
+
+	vc.r = fsum2.r - fsum.r * pNode->avg.r;
+	vc.g = fsum2.g - fsum.g * pNode->avg.g;
+	vc.b = fsum2.b - fsum.b * pNode->avg.b;
+	vc.a = fsum2.a - fsum.a * pNode->avg.a;
+
+	v = vc.r + vc.g + vc.b + vc.a;
+	pNode->err = v;
+	pNode->vdif = -v;
+
+	if(vc.r > vc.g && vc.r > vc.b && vc.r > vc.a)
+		exq_sort(&pNode->pHistogram, exq_sort_by_r);
+	else if(vc.g > vc.b && vc.g > vc.a)
+		exq_sort(&pNode->pHistogram, exq_sort_by_g);
+	else if(vc.b > vc.a)
+		exq_sort(&pNode->pHistogram, exq_sort_by_b);
+	else
+		exq_sort(&pNode->pHistogram, exq_sort_by_a);
+
+	pNode->dir.r = pNode->dir.g = pNode->dir.b = pNode->dir.a = 0;
+	for(pCur = pNode->pHistogram; pCur != NULL; pCur = pCur->pNext)
+	{
+		tmp.r = (pCur->color.r - pNode->avg.r) * pCur->num;
+		tmp.g = (pCur->color.g - pNode->avg.g) * pCur->num;
+		tmp.b = (pCur->color.b - pNode->avg.b) * pCur->num;
+		tmp.a = (pCur->color.a - pNode->avg.a) * pCur->num;
+		if(tmp.r * pNode->dir.r + tmp.g * pNode->dir.g +
+			tmp.b * pNode->dir.b + tmp.a * pNode->dir.a < 0)
+		{
+			tmp.r = -tmp.r;
+			tmp.g = -tmp.g;
+			tmp.b = -tmp.b;
+			tmp.a = -tmp.a;
+		}
+		pNode->dir.r += tmp.r;
+		pNode->dir.g += tmp.g;
+		pNode->dir.b += tmp.b;
+		pNode->dir.a += tmp.a;
+	}
+	isqrt = 1 / sqrt(pNode->dir.r * pNode->dir.r +
+		pNode->dir.g * pNode->dir.g + pNode->dir.b * pNode->dir.b +
+		pNode->dir.a * pNode->dir.a);
+	pNode->dir.r *= isqrt;
+	pNode->dir.g *= isqrt;
+	pNode->dir.b *= isqrt;
+	pNode->dir.a *= isqrt;
+
+	exq_sort_dir = pNode->dir;
+	exq_sort(&pNode->pHistogram, exq_sort_by_dir);
+
+	sum.r = sum.g = sum.b = sum.a = 0;
+	sum2.r = sum2.g = sum2.b = sum2.a = 0;
+	n2 = 0;
+	pNode->pSplit = pNode->pHistogram;
+	for(pCur = pNode->pHistogram; pCur != NULL; pCur = pCur->pNext)
+	{
+		if(pNode->pSplit == NULL)
+			pNode->pSplit = pCur;
+
+		n2 += pCur->num;
+		sum.r += pCur->color.r * pCur->num;
+		sum.g += pCur->color.g * pCur->num;
+		sum.b += pCur->color.b * pCur->num;
+		sum.a += pCur->color.a * pCur->num;
+		sum2.r += pCur->color.r * pCur->color.r * pCur->num;
+		sum2.g += pCur->color.g * pCur->color.g * pCur->num;
+		sum2.b += pCur->color.b * pCur->color.b * pCur->num;
+		sum2.a += pCur->color.a * pCur->color.a * pCur->num;
+
+		if(n == n2)
+			break;
+
+		tmp.r = sum2.r - sum.r*sum.r / n2;
+		tmp.g = sum2.g - sum.g*sum.g / n2;
+		tmp.b = sum2.b - sum.b*sum.b / n2;
+		tmp.a = sum2.a - sum.a*sum.a / n2;
+		tmp2.r = (fsum2.r - sum2.r) - (fsum.r-sum.r)*(fsum.r-sum.r) / (n - n2);
+		tmp2.g = (fsum2.g - sum2.g) - (fsum.g-sum.g)*(fsum.g-sum.g) / (n - n2);
+		tmp2.b = (fsum2.b - sum2.b) - (fsum.b-sum.b)*(fsum.b-sum.b) / (n - n2);
+		tmp2.a = (fsum2.a - sum2.a) - (fsum.a-sum.a)*(fsum.a-sum.a) / (n - n2);
+
+		nv = tmp.r + tmp.g + tmp.b + tmp.a + tmp2.r + tmp2.g + tmp2.b + tmp2.a;
+		if(-nv > pNode->vdif)
+		{
+			pNode->vdif = -nv;
+			pNode->pSplit = NULL;
+		}
+	}
+
+	if(pNode->pSplit == pNode->pHistogram)
+		pNode->pSplit = pNode->pSplit->pNext;
+
+	pNode->vdif += v;
+//	printf("error sum: %f, vdif: %f\n", pNode->err, pNode->vdif);
+}
+
+void exq_optimize_palette(exq_data *pExq, int iter)
+{
+	int n, i, j;
+	exq_histogram *pCur;
+
+	pExq->optimized = 1;
+
+	for(n = 0; n < iter; n++)
+	{
+		for(i = 0; i < pExq->numColors; i++)
+			pExq->node[i].pHistogram = NULL;
+
+		for(i = 0; i < EXQ_HASH_SIZE; i++)
+			for(pCur = pExq->pHash[i]; pCur != NULL; pCur = pCur->pNextInHash)
+			{
+				j = exq_find_nearest_color(pExq, &pCur->color);
+				pCur->pNext = pExq->node[j].pHistogram;
+				pExq->node[j].pHistogram = pCur;
+			}
+
+		for(i = 0; i < pExq->numColors; i++)
+			exq_sum_node(&pExq->node[i]);
+	}
+}
+
+void exq_map_image(exq_data *pExq, int nPixels, unsigned char *pIn,
+				   unsigned char *pOut)
+{
+	int i;
+	exq_color c;
+	exq_histogram *pHist;
+
+	if(!pExq->optimized)
+		exq_optimize_palette(pExq, 4);
+
+	for(i = 0; i < nPixels; i++)
+	{
+		pHist = exq_find_histogram(pExq, pIn);
+		if(pHist != NULL && pHist->palIndex != -1)
+		{
+			*pOut++ = (unsigned char)pHist->palIndex;
+			pIn += 4;
+		}
+		else
+		{
+			c.r = *pIn++ / 255.0f * SCALE_R;
+			c.g = *pIn++ / 255.0f * SCALE_G;
+			c.b = *pIn++ / 255.0f * SCALE_B;
+			c.a = *pIn++ / 255.0f * SCALE_A;
+
+			if(pExq->transparency)
+			{
+				c.r *= c.a; c.g *= c.a; c.b *= c.a;
+			}
+
+			*pOut = exq_find_nearest_color(pExq, &c);
+			if(pHist != NULL)
+				pHist->palIndex = *pOut;
+			pOut++;
+		}
+	}
+}
+
+void exq_map_image_ordered(exq_data *pExq, int width, int height,
+						   unsigned char *pIn, unsigned char *pOut)
+{
+	exq_map_image_dither(pExq, width, height, pIn, pOut, 1);
+}
+
+void exq_map_image_random(exq_data *pExq, int nPixels,
+						   unsigned char *pIn, unsigned char *pOut)
+{
+	exq_map_image_dither(pExq, nPixels, 1, pIn, pOut, 0);
+}
+
+void exq_map_image_dither(exq_data *pExq, int width, int height,
+						  unsigned char *pIn, unsigned char *pOut, int ordered)
+{
+	int x, y, i, j, d;
+	exq_color p, scale, tmp;
+	exq_histogram *pHist;
+	const exq_float dither_matrix[4] = { -0.375, 0.125, 0.375, -0.125 };
+
+	if(!pExq->optimized)
+		exq_optimize_palette(pExq, 4);
+
+	for(y = 0; y < height; y++)
+		for(x = 0; x < width; x++)
+		{
+			if(ordered)
+				d = (x & 1) + (y & 1) * 2;
+			else
+				d = rand() & 3;
+			pHist = exq_find_histogram(pExq, pIn);
+			p.r = *pIn++ / 255.0f * SCALE_R;
+			p.g = *pIn++ / 255.0f * SCALE_G;
+			p.b = *pIn++ / 255.0f * SCALE_B;
+			p.a = *pIn++ / 255.0f * SCALE_A;
+
+			if(pExq->transparency)
+			{
+				p.r *= p.a; p.g *= p.a; p.b *= p.a;
+			}
+
+			if(pHist == NULL || pHist->ditherScale.r < 0)
+			{
+				i = exq_find_nearest_color(pExq, &p);
+				scale.r = pExq->node[i].avg.r - p.r;
+				scale.g = pExq->node[i].avg.g - p.g;
+				scale.b = pExq->node[i].avg.b - p.b;
+				scale.a = pExq->node[i].avg.a - p.a;
+				tmp.r = p.r - scale.r / 3;
+				tmp.g = p.g - scale.g / 3;
+				tmp.b = p.b - scale.b / 3;
+				tmp.a = p.a - scale.a / 3;
+				j = exq_find_nearest_color(pExq, &tmp);
+				if(i == j)
+				{
+					tmp.r = p.r - scale.r * 3;
+					tmp.g = p.g - scale.g * 3;
+					tmp.b = p.b - scale.b * 3;
+					tmp.a = p.a - scale.a * 3;
+					j = exq_find_nearest_color(pExq, &tmp);
+				}
+				if(i != j)
+				{
+					scale.r = (pExq->node[j].avg.r - pExq->node[i].avg.r) * 0.8f;
+					scale.g = (pExq->node[j].avg.g - pExq->node[i].avg.g) * 0.8f;
+					scale.b = (pExq->node[j].avg.b - pExq->node[i].avg.b) * 0.8f;
+					scale.a = (pExq->node[j].avg.a - pExq->node[i].avg.a) * 0.8f;
+					if(scale.r < 0) scale.r = -scale.r;
+					if(scale.g < 0) scale.g = -scale.g;
+					if(scale.b < 0) scale.b = -scale.b;
+					if(scale.a < 0) scale.a = -scale.a;
+				}
+				else
+					scale.r = scale.g = scale.b = scale.a = 0;
+
+				if(pHist != NULL)
+				{
+					pHist->ditherScale.r = scale.r;
+					pHist->ditherScale.g = scale.g;
+					pHist->ditherScale.b = scale.b;
+					pHist->ditherScale.a = scale.a;
+				}
+			}
+			else
+			{
+				scale.r = pHist->ditherScale.r;
+				scale.g = pHist->ditherScale.g;
+				scale.b = pHist->ditherScale.b;
+				scale.a = pHist->ditherScale.a;
+			}
+
+			if(pHist != NULL && pHist->ditherIndex[d] >= 0)
+				*pOut++ = (unsigned char)pHist->ditherIndex[d];
+			else
+			{
+				tmp.r = p.r + scale.r * dither_matrix[d];
+				tmp.g = p.g + scale.g * dither_matrix[d];
+				tmp.b = p.b + scale.b * dither_matrix[d];
+				tmp.a = p.a + scale.a * dither_matrix[d];
+				*pOut = exq_find_nearest_color(pExq, &tmp);
+				if(pHist != NULL)
+					pHist->ditherIndex[d] = *pOut;
+				pOut++;
+			}
+		}
+}
+
+exq_histogram *exq_find_histogram(exq_data *pExq, unsigned char *pCol)
+{
+	unsigned int hash;
+	int r, g, b, a;
+	exq_histogram *pCur;
+
+	r = *pCol++; g = *pCol++; b = *pCol++; a = *pCol++;
+	hash = exq_make_hash(((unsigned int)r) | (((unsigned int)g) << 8) | (((unsigned int)b) << 16) | (((unsigned int)a) << 24));
+
+	pCur = pExq->pHash[hash];
+	while(pCur != NULL && (pCur->ored != r || pCur->ogreen != g ||
+		pCur->oblue != b || pCur->oalpha != a))
+		pCur = pCur->pNextInHash;
+
+	return pCur;
+}
+
+unsigned char exq_find_nearest_color(exq_data *pExq, exq_color *pColor)
+{
+	exq_float bestv;
+	int besti, i;
+	exq_color dif;
+
+	bestv = 16;
+	besti = 0;
+	for(i = 0; i < pExq->numColors; i++)
+	{
+		dif.r = pColor->r - pExq->node[i].avg.r;
+		dif.g = pColor->g - pExq->node[i].avg.g;
+		dif.b = pColor->b - pExq->node[i].avg.b;
+		dif.a = pColor->a - pExq->node[i].avg.a;
+		if(dif.r*dif.r + dif.g*dif.g + dif.b*dif.b + dif.a*dif.a < bestv)
+		{
+			bestv = dif.r*dif.r + dif.g*dif.g + dif.b*dif.b + dif.a*dif.a;
+			besti = i;
+		}
+	}
+
+	return (unsigned char)besti;
+}
+
+void exq_sort(exq_histogram **ppHist, exq_float (*sortfunc)(const exq_histogram *pHist))
+{
+	exq_histogram *pLow, *pHigh, *pCur, *pNext;
+	int n = 0;
+	exq_float sum = 0;
+
+	for(pCur = *ppHist; pCur != NULL; pCur = pCur->pNext)
+	{
+		n++;
+		sum += sortfunc(pCur);
+	}
+
+	if(n < 2)
+		return;
+
+	sum /= n;
+
+	pLow = pHigh = NULL;
+	for(pCur = *ppHist; pCur != NULL; pCur = pNext)
+	{
+		pNext = pCur->pNext;
+		if(sortfunc(pCur) < sum)
+		{
+			pCur->pNext = pLow;
+			pLow = pCur;
+		}
+		else
+		{
+			pCur->pNext = pHigh;
+			pHigh = pCur;
+		}
+	}
+
+	if(pLow == NULL)
+	{
+		*ppHist = pHigh;
+		return;
+	}
+	if(pHigh == NULL)
+	{
+		*ppHist = pLow;
+		return;
+	}
+
+	exq_sort(&pLow, sortfunc);
+	exq_sort(&pHigh, sortfunc);
+
+	*ppHist = pLow;
+	while(pLow->pNext != NULL)
+		pLow = pLow->pNext;
+
+	pLow->pNext = pHigh;
+}
+
+exq_float exq_sort_by_r(const exq_histogram *pHist)
+{
+	return pHist->color.r;
+}
+
+exq_float exq_sort_by_g(const exq_histogram *pHist)
+{
+	return pHist->color.g;
+}
+
+exq_float exq_sort_by_b(const exq_histogram *pHist)
+{
+	return pHist->color.b;
+}
+
+exq_float exq_sort_by_a(const exq_histogram *pHist)
+{
+	return pHist->color.a;
+}
+
+exq_color exq_sort_dir;
+
+exq_float exq_sort_by_dir(const exq_histogram *pHist)
+{
+	return pHist->color.r * exq_sort_dir.r +
+		pHist->color.g * exq_sort_dir.g +
+		pHist->color.b * exq_sort_dir.b +
+		pHist->color.a * exq_sort_dir.a;
+}

--- a/thirdparty/misc/exoquant.c
+++ b/thirdparty/misc/exoquant.c
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 
 #include "exoquant.h"
-#include <malloc.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/thirdparty/misc/exoquant.h
+++ b/thirdparty/misc/exoquant.h
@@ -1,0 +1,150 @@
+/*
+ExoQuant v0.7
+
+Copyright (c) 2004 Dennis Ranke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/******************************************************************************
+* Usage:
+* ------
+*
+* exq_data *pExq = exq_init(); // init quantizer (per image)
+* exq_feed(pExq, <ptr to image>, <num of pixels); // feed pixel data (32bpp)
+* exq_quantize(pExq, <num of colors>); // find palette
+* exq_get_palette(pExq, <ptr to buffer>, <num of colors>); // get palette
+* exq_map_image(pExq, <num of pixels>, <ptr to input>, <ptr to output>);
+* or:
+* exq_map_image_ordered(pExq, <width>, <height>, <input>, <output>);
+*     // map image to palette
+* exq_free(pExq); // free memory again
+*
+* Notes:
+* ------
+*
+* All 32bpp data (input data and palette data) is considered a byte stream
+* of the format:
+* R0 G0 B0 A0 R1 G1 B1 A1 ...
+* If you want to use a different order, the easiest way to do this is to
+* change the SCALE_x constants in expquant.h, as those are the only differences
+* between the channels.
+*
+******************************************************************************/
+
+#ifndef __EXOQUANT_H
+#define __EXOQUANT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* type definitions */
+typedef double exq_float;
+
+typedef struct _exq_color
+{
+	exq_float r, g, b, a;
+} exq_color;
+
+typedef struct _exq_histogram
+{
+	exq_color				color;
+	unsigned char			ored, ogreen, oblue, oalpha;
+	int						palIndex;
+	exq_color				ditherScale;
+	int						ditherIndex[4];
+	int						num;
+	struct _exq_histogram	*pNext;
+	struct _exq_histogram	*pNextInHash;
+} exq_histogram;
+
+typedef struct _exq_node
+{
+	exq_color				dir, avg;
+	exq_float					vdif;
+	exq_float					err;
+	int						num;
+	exq_histogram			*pHistogram;
+	exq_histogram			*pSplit;
+} exq_node;
+
+#define EXQ_HASH_BITS			16
+#define EXQ_HASH_SIZE			(1 << (EXQ_HASH_BITS))
+
+typedef struct _exq_data
+{
+	exq_histogram			*pHash[EXQ_HASH_SIZE];
+	exq_node				node[256];
+	int						numColors;
+	int						numBitsPerChannel;
+	int						optimized;
+	int						transparency;
+} exq_data;
+
+/* interface */
+
+exq_data			*exq_init();
+void				exq_no_transparency(exq_data *pExq);
+void				exq_free(exq_data *pExq);
+void				exq_feed(exq_data *pExq, unsigned char *pData,
+							 int nPixels);
+void				exq_quantize(exq_data *pExq, int nColors);
+void				exq_quantize_hq(exq_data *pExq, int nColors);
+void				exq_quantize_ex(exq_data *pExq, int nColors, int hq);
+exq_float			exq_get_mean_error(exq_data *pExq);
+void				exq_get_palette(exq_data *pExq, unsigned char *pPal,
+									int nColors);
+void				exq_set_palette(exq_data *pExq, unsigned char *pPal,
+									int nColors);
+void				exq_map_image(exq_data *pExq, int nPixels,
+								  unsigned char *pIn, unsigned char *pOut);
+void				exq_map_image_ordered(exq_data *pExq, int width,
+										  int height, unsigned char *pIn,
+										  unsigned char *pOut);
+void				exq_map_image_random(exq_data *pExq, int nPixels,
+										  unsigned char *pIn, unsigned char *pOut);
+
+/* internal functions */
+
+void				exq_map_image_dither(exq_data *pExq, int width,
+										 int height, unsigned char *pIn,
+										 unsigned char *pOut, int ordered);
+
+void				exq_sum_node(exq_node *pNode);
+void				exq_optimize_palette(exq_data *pExp, int iter);
+
+unsigned char		exq_find_nearest_color(exq_data *pExp, exq_color *pColor);
+exq_histogram		*exq_find_histogram(exq_data *pExp, unsigned char *pCol);
+
+void				exq_sort(exq_histogram **ppHist,
+						 exq_float (*sortfunc)(const exq_histogram *pHist));
+exq_float			exq_sort_by_r(const exq_histogram *pHist);
+exq_float			exq_sort_by_g(const exq_histogram *pHist);
+exq_float			exq_sort_by_b(const exq_histogram *pHist);
+exq_float			exq_sort_by_a(const exq_histogram *pHist);
+exq_float			exq_sort_by_dir(const exq_histogram *pHist);
+
+extern exq_color	exq_sort_dir;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __EXOQUANT_H


### PR DESCRIPTION
Implemented as part of [ImageTools](https://github.com/Xrayez/godot-imagetools) module via `ImageIndexed` class

<details>
<summary>Initial proposal</summary>

![image-palettes](https://user-images.githubusercontent.com/17108460/56093229-8807d780-5ece-11e9-9cba-aa4853f92169.png)

Closes #27756.
Fixes #28020.
Related: #6532.


## Summary

This PR brings in an ability to create and generate an optimal color palette for an image and basic palette operations, allowing for things like finding dominant/average colors, palette swapping with/without using shaders etc. It also unifies and simplifies different image loaders and savers to use the same palette API, extract existing palette from images, and save PNG indexed images with transparency. This does not add `FORMAT_INDEXED` image format but rather complements the existing formats alongside. Some issues was revealed like `stex` format not supporting palette data that would store existing palette from imported images and wouldn't have to be loaded from within a script manually, which would make this feature more usable for pixel-art developers.

## Features

- [x] generate an optimal palette from an image:
  - with specified number of colors (max: 256);
  - optional dithering (ordered, random).
- [x] create palette and modify palette manually;
- [x] extract color palette from PNG images when loading from disk (instead of expanding);
- [x] save PNG with a palette associated with it:
  - the palette can be modified within Godot;
  - also supports saving indexed color images with "cheap" alpha.
- [x] extract existing palette from other image formats:
  - [x] bmp (8/4/1 bits)
  - [x] tga (8/4 bits)
- [x] implement palette formats:
    - [x] 32 bit
    - [x] 24 bit
- ~~make texture importer (`.stex`) to possibly embed palette data.~~
  - likely should not be part of this PR at least, see "Issues" section.
- ~~generate palette ordered (currently random):~~
  -  it's not ordered to distribution, might be a limitation of underlying quantization lib used...
  - requres modification of thirdparty lib...
  - if ordered, fetching least used colors would be possible, as well as easier to find dominant colors.

## Implementation details
This does **not** actually add a new `FORMAT_INDEXED` image format as modern GPUs don't actually support it as far as I know, but index data is stored internally alongside regular pixels *if* an image has a palette. This allows to interchange (swap, extend) index data to pixel data via `apply_palette()` method. Note that I've also purposely avoided creating and exposing methods for operating on individual indexed pixels for similar reasons (if such a need occurs, it's just better to do this outside of Godot in image editing software).

I've added palette load/save support for PNG and load for TGA/BMP formats. I believe different image loaders/savers could make use of the new palette API that way, [see the full list](https://en.wikipedia.org/wiki/Indexed_color#Image_file_formats_supporting_indexed_color). Note that all support 8-bit palette, so this should cover all cases, the palette bit depth is determined by format pixel size anyway.

I created it in a way that doesn't interfere with the existing image API, and in possibility that this feature is useless for most users so that I can branch off and write it in a separate module instead (not sure how easy would that be, so far it nicely integrates with existing codebase).

### Thirdparty library:
This feature uses [exoquant](https://github.com/exoticorn/exoquant) library for image quantization which is under MIT license and is very lightweight.

#### List of diffs
- removed `#include "malloc.h" as it's not available in iOS and MacOS.

## Issues

When image is imported, the original palette data (loaded from disk) is lost, as `stex` (custom Godot texture format) doesn't store any palette/index data, so one would only be able to retrieve existing palette from an image via `image.load()` or `image.load_png_from_buffer()`.

Here's my attempt to resolve this issue (in a sub-branch):
https://github.com/Xrayez/godot/commit/21f86cd87a73e81bc98593a0632aebc0c44329ca

If the issues in the above example could be resolved, another alternative would be also adding `num_colors` as import option and generate palette on import:
```
num_colors = -1 # default, indicate true color, or MAX_INT, INF...
if num_colors > 0:
    image.generate_palette(num_colors)
    image.apply_palette()
```

This method conveniently helps to implement #18662, which would make Godot to import textures with reduced number of colors automatically while still remaining true color internally, without using shaders at all as textures can always be reimported.


## Use cases and examples

* Taking a screenshot and reducing number of colors to optimize for size:
```gdscript
func save_screenshot():
	get_viewport().render_target_v_flip = true # hmm
	yield(VisualServer, "frame_post_draw")
	get_viewport().render_target_v_flip = false

	screenshot.convert(Image.FORMAT_RGBA8)
	screenshot.generate_palette()
	screenshot.save_png("screenshot_indexed.png")
```

* Finding dominant/average colors in an image:
```gdscript
image.generate_palette(2) # first color is usually background
var dominant_color = image.get_palette_color(1)
# or...
image.generate_palette(8)
var average_colors = image.get_palette()
```
![average-colors](https://user-images.githubusercontent.com/17108460/56416918-01227880-629b-11e9-9d7c-cbfa27b7adf3.png)


* Image posterization? (8-bit feel):
```gdscript
var image = get_node('sprite').texture.get_data()
image.generate_palette(8)
image.apply_palette()
```
![posterization](https://user-images.githubusercontent.com/17108460/56417674-48aa0400-629d-11e9-9edf-79e56d1c6ade.png)


*  (Pseudo) [Palette swapping](https://github.com/HeartoLazor/godot_palette_swap) #12670 (interchangeable with shaders):
```gdscript
var image = get_node('sprite').texture.get_data()
if not image.has_palette():
     image.generate_palette(16)

image.set_palette_color(5, Color.red)
image.set_palette_color(9, Color.gold)
image.set_palette_color(1, Color.darkred)

image.apply_palette()
```
![palette-swapping](https://user-images.githubusercontent.com/17108460/56417395-793d6e00-629c-11e9-91df-a122228825a9.png)


A color palette (array) could be passed to shaders as uniform, yet #10751 needs to be implemented to take advantage of this.

## Specific use cases:
* Suitable as a component for basic image editing in Godot.
* Creating user generated content that must be cross/backward-compatible (can't deal with transparency in images and/or require limited number of colors).

## Example project

You can try/test these features out here:
https://github.com/Xrayez/godot-image-indexed-example

</details>

