### PR TITLE
Small improvements to the new Sprite Sheet dialog

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -74,6 +74,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	StringName edited_anim;
 
 	ConfirmationDialog *split_sheet_dialog;
+	ScrollContainer *splite_sheet_scroll;
 	TextureRect *split_sheet_preview;
 	SpinBox *split_sheet_h;
 	SpinBox *split_sheet_v;
@@ -115,6 +116,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _sheet_spin_changed(double);
 	void _sheet_preview_input(const Ref<InputEvent> &p_event);
 	void _sheet_add_frames();
+	void _sheet_select_clear_all_frames();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
- Added option to add all frames.
- Gave a panel styling to the `ScrollContainer`.
- Moved the horizontal/vertical setters to the top and removed the space between them.
- Removed unnecessary labels, as the dialog is self explanatory enough.

![screen-2019-04-14-04-23-44](https://user-images.githubusercontent.com/30739239/56094932-3dcf2800-5ec7-11e9-8aba-3756d6be9c4c.png)