### PR TITLE
Fix for "Insert Keyframe" shortcut doing nothing

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -1827,7 +1827,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				if (!sp)
 					continue;
 
-				emit_signal("transform_key_request", sp, "", sp->get_transform());
+				spatial_editor->emit_signal("transform_key_request", sp, "", sp->get_transform());
 			}
 
 			set_message(TTR("Animation Key Inserted."));
@@ -5814,7 +5814,7 @@ SpatialEditorPlugin::SpatialEditorPlugin(EditorNode *p_node) {
 	editor->get_viewport()->add_child(spatial_editor);
 
 	spatial_editor->hide();
-	spatial_editor->connect("transform_key_request", editor, "_transform_keyed");
+	spatial_editor->connect("transform_key_request", editor->get_inspector_dock(), "_transform_keyed");
 }
 
 SpatialEditorPlugin::~SpatialEditorPlugin() {


### PR DESCRIPTION
In a previous refactor (likely [this one](https://github.com/godotengine/godot/commit/9a365a1216b8fe9f394d6efdd9550eab4e899eca)), the shortcut for inserting keyframes ("K") seems to have stopped working. The cause is a signal sent from SpatialEditorViewport ("transform_key_request") that was previously handled by EditorNode doesn't reach its new target in InspectorDock.

Not fully familiar with the Godot source code and may very well have commited a coding style faux pas since I made SpatialEditorViewport emit a signal on its SpatialEditor rather than itself.

Fixes #28025 
