### PR TITLE
Ignore '/utf-8' flag on Visual Studio 2013

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -195,7 +195,9 @@ def configure_msvc(env, manual_msvc_config):
 
     ## Compile/link flags
 
-    env.AppendUnique(CCFLAGS=['/MT', '/Gd', '/GR', '/nologo', '/utf-8'])
+    env.AppendUnique(CCFLAGS=['/MT', '/Gd', '/GR', '/nologo'])
+    if int(env['MSVC_VERSION'].split('.')[0]) >= 14: #vs2015 and later
+        env.AppendUnique(CCFLAGS=['/utf-8'])
     env.AppendUnique(CXXFLAGS=['/TP']) # assume all sources are C++
     if manual_msvc_config: # should be automatic if SCons found it
         if os.getenv("WindowsSdkDir") is not None:


### PR DESCRIPTION
@Ranoller pointed out the issue at 7f2ad8b caused by #27915, and this may be a fix.

My bad. Didn't realize `/utf-8` flag was only added in one version of Visual Studio 2015.

I am not sure if there is a right way to do it on VS2013, thus Windows with default encoding that are not compatible (such as Japanese) may fail compiling around test_34() on `/main/tests/test_string.cpp` on master branch