### PR TITLE
Moving Polygon2D vertices along axis

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -481,6 +481,17 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 		if (edited_point.valid() && (wip_active || (mm->get_button_mask() & BUTTON_MASK_LEFT))) {
 
 			Vector2 cpoint = _get_node()->get_global_transform().affine_inverse().xform(canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(gpoint)));
+
+			//Move the point in a single axis. Should only work when editing a polygon and while holding shift.
+			if (mode == MODE_EDIT && mm->get_shift()) {
+				Vector2 old_point = pre_move_edit.get(selected_point.vertex);
+				if (ABS(cpoint.x - old_point.x) > ABS(cpoint.y - old_point.y)) {
+					cpoint.y = old_point.y;
+				} else {
+					cpoint.x = old_point.x;
+				}
+			}
+
 			edited_point = PosVertex(edited_point, cpoint);
 
 			if (!wip_active) {


### PR DESCRIPTION
Resolves #27077

As stated in the original issue:
"When moving a 2D node, you can hold Shift to move it along axis, i.e. it has fixed x or x. Would be nice if polygon vertices could support it to, as right now holding Shift doesn't affect them at all. That would be useful in situations where grid snapping isn't a viable option, but you want the vertex to be aligned."

Usage Example:
![vertex_axis](https://user-images.githubusercontent.com/29317539/56227363-a810d580-604b-11e9-97c6-229962a08614.gif)
