### PR TITLE
UI: Left-align Signals and Groups buttons' text

### DIFF
--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -107,6 +107,7 @@ NodeDock::NodeDock() {
 	connections_button->set_toggle_mode(true);
 	connections_button->set_pressed(true);
 	connections_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	connections_button->set_text_align(Button::ALIGN_LEFT);
 	mode_hb->add_child(connections_button);
 	connections_button->connect("pressed", this, "show_connections");
 
@@ -115,6 +116,7 @@ NodeDock::NodeDock() {
 	groups_button->set_toggle_mode(true);
 	groups_button->set_pressed(false);
 	groups_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	groups_button->set_text_align(Button::ALIGN_LEFT);
 	mode_hb->add_child(groups_button);
 	groups_button->connect("pressed", this, "show_groups");
 


### PR DESCRIPTION
Just a small QoL thing I noticed to make it clear the text and icons are part of one button.

Before:
![signalsbuttonbefore](https://user-images.githubusercontent.com/3558659/56157065-52680900-600a-11e9-94ff-b679f21765f2.jpg)

After:
![signalsbuttonafter](https://user-images.githubusercontent.com/3558659/56157075-57c55380-600a-11e9-95a6-ffe345ff8de1.jpg)
