### PR TITLE
Expose localize_rests to gdscript.

### DIFF
--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -773,6 +773,8 @@ void Skeleton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bone_rest", "bone_idx"), &Skeleton::get_bone_rest);
 	ClassDB::bind_method(D_METHOD("set_bone_rest", "bone_idx", "rest"), &Skeleton::set_bone_rest);
 
+	ClassDB::bind_method(D_METHOD("localize_rests"), &Skeleton::localize_rests);
+
 	ClassDB::bind_method(D_METHOD("set_bone_disable_rest", "bone_idx", "disable"), &Skeleton::set_bone_disable_rest);
 	ClassDB::bind_method(D_METHOD("is_bone_rest_disabled", "bone_idx"), &Skeleton::is_bone_rest_disabled);
 


### PR DESCRIPTION
Required for skeleton import in gdnative importer plugins.