### PR TITLE
When triggering completion show all the properties added with _get_property_list()

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1936,9 +1936,18 @@ static void _find_identifiers_in_base(const GDScriptCompletionContext &p_context
 				Ref<GDScript> script = base_type.script_type;
 				if (script.is_valid()) {
 					if (!_static && !p_only_functions) {
-						for (const Set<StringName>::Element *E = script->get_members().front(); E; E = E->next()) {
-							ScriptCodeCompletionOption option(E->get().operator String(), ScriptCodeCompletionOption::KIND_MEMBER);
-							r_result.insert(option.display, option);
+						if (p_context.base && p_context.base->get_script_instance()) {
+							List<PropertyInfo> members;
+							p_context.base->get_script_instance()->get_property_list(&members);
+							for (List<PropertyInfo>::Element *E = members.front(); E; E = E->next()) {
+								ScriptCodeCompletionOption option(E->get().name, ScriptCodeCompletionOption::KIND_MEMBER);
+								r_result.insert(option.display, option);
+							}
+						} else {
+							for (const Set<StringName>::Element *E = script->get_members().front(); E; E = E->next()) {
+								ScriptCodeCompletionOption option(E->get().operator String(), ScriptCodeCompletionOption::KIND_MEMBER);
+								r_result.insert(option.display, option);
+							}
 						}
 					}
 					if (!p_only_functions) {


### PR DESCRIPTION
For example, if we add this as an autoload:

```gdscript
tool
extends Node

var _layers = Dictionary()
	
func _init():
	_layers = _get_layers()

func _get_layers():
	var _layers = {}
	for i in 20:
		var s = ProjectSettings.get('layer_names/2d_physics/layer_%s' % [i+1])
		if s:
			_layers[s] = 1 << i
			
	return _layers

func _get(key):
	if _layers.has(key):
		return _layers[key]
	
	return null
	
func _set(key, value):
	return false
	
func _get_property_list():
	_layers = _get_layers()
	var result = []
	for layer in _layers.keys():
		result.push_back({
			"name": layer,
			"type": TYPE_INT,
			"usage": PROPERTY_USAGE_SCRIPT_VARIABLE
		})
	return result
```

![https://i.imgur.com/gldEumm.png](https://i.imgur.com/gldEumm.png)

I think I only implemented it in gdscript but I'm not sure because I have no idea what I'm doing basically 😅 

Closes https://github.com/godotengine/godot/issues/25097