### PR TITLE
Consistently wrap booleans in [code]

### DIFF
--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -94,7 +94,7 @@
 			<argument index="0" name="condition" type="bool">
 			</argument>
 			<description>
-				Assert that the [code]condition[/code] is true. If the [code]condition[/code] is false a fatal error is generated and the program is halted. Useful for debugging to make sure a value is always true.
+				Assert that the [code]condition[/code] is [code]true[/code] . If the [code]condition[/code] is [code]false[/code] a fatal error is generated and the program is halted. Useful for debugging to make sure a value is always [code]true[/code].
 				[codeblock]
 				# Speed should always be between 0 and 20
 				speed = -10

--- a/doc/classes/ARVRAnchor.xml
+++ b/doc/classes/ARVRAnchor.xml
@@ -24,7 +24,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns true if the anchor is being tracked and false if no anchor with this id is currently known.
+				Returns [code]true[/code] if the anchor is being tracked and [code]false[/code] if no anchor with this id is currently known.
 			</description>
 		</method>
 		<method name="get_mesh" qualifiers="const">

--- a/doc/classes/ARVRInterface.xml
+++ b/doc/classes/ARVRInterface.xml
@@ -55,7 +55,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns true if the current output of this interface is in stereo.
+				Returns [code]true[/code] if the current output of this interface is in stereo.
 			</description>
 		</method>
 		<method name="uninitialize">

--- a/doc/classes/ARVRServer.xml
+++ b/doc/classes/ARVRServer.xml
@@ -56,7 +56,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Get the number of interfaces currently registered with the AR/VR server. If your game supports multiple AR/VR platforms, you can look through the available interface, and either present the user with a selection or simply try an initialize each interface and use the first one that returns true.
+				Get the number of interfaces currently registered with the AR/VR server. If your game supports multiple AR/VR platforms, you can look through the available interface, and either present the user with a selection or simply try an initialize each interface and use the first one that returns [code]true[/code].
 			</description>
 		</method>
 		<method name="get_interfaces" qualifiers="const">

--- a/doc/classes/AnimatedSprite.xml
+++ b/doc/classes/AnimatedSprite.xml
@@ -15,7 +15,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return true if an animation if currently being played.
+				Return [code]true[/code] if an animation if currently being played.
 			</description>
 		</method>
 		<method name="play">

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -15,7 +15,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return true if an animation if currently being played.
+				Return [code]true[/code] if an animation if currently being played.
 			</description>
 		</method>
 		<method name="play">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -440,7 +440,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return true if the given track is imported. Else, return false.
+				Return [code]true[/code] if the given track is imported. Else, return [code]false[/code].
 			</description>
 		</method>
 		<method name="track_move_down">

--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -54,7 +54,7 @@
 			<argument index="5" name="optimize" type="bool" default="true">
 			</argument>
 			<description>
-				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. Time is a delta, unless "seek" is true, in which case it is absolute. A filter mode may be optionally passed.
+				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. Time is a delta, unless "seek" is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed.
 			</description>
 		</method>
 		<method name="blend_node">
@@ -146,7 +146,7 @@
 			<return type="String">
 			</return>
 			<description>
-				Return true whether you want the blend tree editor to display filter editing on this node.
+				Return [code]true[/code] whether you want the blend tree editor to display filter editing on this node.
 			</description>
 		</method>
 		<method name="is_path_filtered" qualifiers="const">
@@ -155,7 +155,7 @@
 			<argument index="0" name="path" type="NodePath">
 			</argument>
 			<description>
-				Return true wether a given path is filtered.
+				Return [code]true[/code] wether a given path is filtered.
 			</description>
 		</method>
 		<method name="process" qualifiers="virtual">
@@ -166,7 +166,7 @@
 			<argument index="1" name="seek" type="bool">
 			</argument>
 			<description>
-				Called when a custom node is processed. The argument "time" is relative, unless "seek" is true (in which case it is absolute).
+				Called when a custom node is processed. The argument "time" is relative, unless "seek" is [code]true[/code] (in which case it is absolute).
 			Here, call the [method blend_input], [method blend_node] or [method blend_animation] functions.
 			You can also use [method get_parameter] and [method set_parameter] to modify local memory.
 			This function returns the time left for the current animation to finish (if unsure, just pass  the value from the main blend being called).

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -144,7 +144,7 @@
 			<argument index="3" name="from_end" type="bool" default="false">
 			</argument>
 			<description>
-				Play the animation with key [code]name[/code]. Custom speed and blend times can be set. If custom speed is negative (-1), 'from_end' being true can play the animation backwards.
+				Play the animation with key [code]name[/code]. Custom speed and blend times can be set. If custom speed is negative (-1), 'from_end' being [code]true[/code] can play the animation backwards.
 				If the animation has been paused by [code]stop(true)[/code] it will be resumed. Calling [code]play()[/code] without arguments will also resume the animation.
 			</description>
 		</method>

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -105,7 +105,7 @@
 			<argument index="1" name="before" type="bool" default="True">
 			</argument>
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a before specifier can be passed. If false, the returned index comes after all existing entries of the value in the array. Note that calling bsearch on an unsorted array results in unexpected behavior.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a before specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array. Note that calling bsearch on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
 		<method name="bsearch_custom">
@@ -120,7 +120,7 @@
 			<argument index="3" name="before" type="bool" default="True">
 			</argument>
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search and a custom comparison method. Optionally, a before specifier can be passed. If false, the returned index comes after all existing entries of the value in the array. The custom method receives two arguments (an element from the array and the value searched for) and must return true if the first argument is less than the second, and return false otherwise. Note that calling bsearch on an unsorted array results in unexpected behavior.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search and a custom comparison method. Optionally, a before specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array. The custom method receives two arguments (an element from the array and the value searched for) and must return [code]true[/code] if the first argument is less than the second, and return [code]false[/code] otherwise. Note that calling bsearch on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
 		<method name="clear">
@@ -314,7 +314,7 @@
 			<argument index="1" name="func" type="String">
 			</argument>
 			<description>
-				Sorts the array using a custom method. The arguments are an object that holds the method and the name of such method. The custom method receives two arguments (a pair of elements from the array) and must return true if the first argument is less than the second, and return false otherwise.
+				Sorts the array using a custom method. The arguments are an object that holds the method and the name of such method. The custom method receives two arguments (a pair of elements from the array) and must return [code]true[/code] if the first argument is less than the second, and return [code]false[/code] otherwise.
 				[b]Note:[/b] you cannot randomize the return value as the heapsort algorithm expects a deterministic result. Doing so will result in unexpected behavior.
 				[codeblock]
 				class MyCustomSorter:

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -38,7 +38,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return true if the mouse has entered the button and has not left it yet.
+				Return [code]true[/code] if the mouse has entered the button and has not left it yet.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/BitMap.xml
+++ b/doc/classes/BitMap.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="size" type="Vector2">
 			</argument>
 			<description>
-				Creates a bitmap with the specified size, filled with false.
+				Creates a bitmap with the specified size, filled with [code]false[/code].
 			</description>
 		</method>
 		<method name="create_from_image_alpha">
@@ -28,7 +28,7 @@
 			<argument index="1" name="threshold" type="float" default="0.1">
 			</argument>
 			<description>
-				Creates a bitmap that matches the given image dimensions, every element of the bitmap is set to false if the alpha value of the image at that position is equal to [code]threshold[/code] or less, and true in other case.
+				Creates a bitmap that matches the given image dimensions, every element of the bitmap is set to [code]false[/code] if the alpha value of the image at that position is equal to [code]threshold[/code] or less, and [code]true[/code] in other case.
 			</description>
 		</method>
 		<method name="get_bit" qualifiers="const">
@@ -51,7 +51,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the amount of bitmap elements that are set to true.
+				Returns the amount of bitmap elements that are set to [code]true[/code].
 			</description>
 		</method>
 		<method name="grow_mask">

--- a/doc/classes/Camera.xml
+++ b/doc/classes/Camera.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="enable_next" type="bool" default="true">
 			</argument>
 			<description>
-				If this is the current Camera, remove it from being current. If [code]enable_next[/code] is true, request to make the next Camera current, if any.
+				If this is the current Camera, remove it from being current. If [code]enable_next[/code] is [code]true[/code], request to make the next Camera current, if any.
 			</description>
 		</method>
 		<method name="get_camera_transform" qualifiers="const">

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="class" type="String">
 			</argument>
 			<description>
-				Returns true if you can instance objects from the specified 'class', false in other case.
+				Returns [code]true[/code] if you can instance objects from the specified 'class', [code]false[/code] in other case.
 			</description>
 		</method>
 		<method name="class_exists" qualifiers="const">
@@ -68,7 +68,7 @@
 			<argument index="1" name="no_inheritance" type="bool" default="false">
 			</argument>
 			<description>
-				Returns an array with all the methods of 'class' or its ancestry if 'no_inheritance' is false. Every element of the array is a [Dictionary] with the following keys: args, default_args, flags, id, name, return: (class_name, hint, hint_string, name, type, usage).
+				Returns an array with all the methods of 'class' or its ancestry if 'no_inheritance' is [code]false[/code]. Every element of the array is a [Dictionary] with the following keys: args, default_args, flags, id, name, return: (class_name, hint, hint_string, name, type, usage).
 			</description>
 		</method>
 		<method name="class_get_property" qualifiers="const">
@@ -90,7 +90,7 @@
 			<argument index="1" name="no_inheritance" type="bool" default="false">
 			</argument>
 			<description>
-				Returns an array with all the properties of 'class' or its ancestry if 'no_inheritance' is false.
+				Returns an array with all the properties of 'class' or its ancestry if 'no_inheritance' is [code]false[/code].
 			</description>
 		</method>
 		<method name="class_get_signal" qualifiers="const">
@@ -112,7 +112,7 @@
 			<argument index="1" name="no_inheritance" type="bool" default="false">
 			</argument>
 			<description>
-				Returns an array with all the signals of 'class' or its ancestry if 'no_inheritance' is false. Every element of the array is a [Dictionary] as described in [method class_get_signal].
+				Returns an array with all the signals of 'class' or its ancestry if 'no_inheritance' is [code]false[/code]. Every element of the array is a [Dictionary] as described in [method class_get_signal].
 			</description>
 		</method>
 		<method name="class_has_integer_constant" qualifiers="const">

--- a/doc/classes/CollisionPolygon.xml
+++ b/doc/classes/CollisionPolygon.xml
@@ -17,7 +17,7 @@
 			Length that the resulting collision extends in either direction perpendicular to its polygon.
 		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled">
-			If true, no collision will be produced.
+			If [code]true[/code], no collision will be produced.
 		</member>
 		<member name="polygon" type="PoolVector2Array" setter="set_polygon" getter="get_polygon">
 			Array of vertices which define the polygon. Note that the returned value is a copy of the original. Methods which mutate the size or properties of the return value will not impact the original polygon. To change properties of the polygon, assign it to a temporary variable and make changes before reassigning the [code]polygon[/code] member.

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -684,7 +684,7 @@
 			Controls whether the control will be able to receive mouse button input events through [method _gui_input] and how these events should be handled. Also controls whether the control can receive the [signal mouse_entered], and [signal mouse_exited] signals. See the constants to learn what each does.
 		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents">
-			Enables whether rendering of children should be clipped to this control's rectangle. If true, parts of a child which would be visibly outside of this control's rectangle will not be rendered.
+			Enables whether rendering of children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visibly outside of this control's rectangle will not be rendered.
 		</member>
 		<member name="rect_global_position" type="Vector2" setter="set_global_position" getter="get_global_position">
 			The node's global position, relative to the world (usually to the top-left corner of the window).

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -124,7 +124,7 @@
 			</argument>
 			<description>
 				Returns a point within the curve at position [code]offset[/code], where [code]offset[/code] is measured as a pixel distance along the curve.
-				To do that, it finds the two cached points where the [code]offset[/code] lies between, then interpolates the values. This interpolation is cubic if [code]cubic[/code] is set to true, or linear if set to false.
+				To do that, it finds the two cached points where the [code]offset[/code] lies between, then interpolates the values. This interpolation is cubic if [code]cubic[/code] is set to [code]true[/code], or linear if set to [code]false[/code].
 				Cubic interpolation tends to follow the curves better, but linear is faster (and often, precise enough).
 			</description>
 		</method>

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -148,7 +148,7 @@
 			</argument>
 			<description>
 				Returns a point within the curve at position [code]offset[/code], where [code]offset[/code] is measured as a pixel distance along the curve.
-				To do that, it finds the two cached points where the [code]offset[/code] lies between, then interpolates the values. This interpolation is cubic if [code]cubic[/code] is set to true, or linear if set to false.
+				To do that, it finds the two cached points where the [code]offset[/code] lies between, then interpolates the values. This interpolation is cubic if [code]cubic[/code] is set to [code]true[/code], or linear if set to [code]false[/code].
 				Cubic interpolation tends to follow the curves better, but linear is faster (and often, precise enough).
 			</description>
 		</method>

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -40,7 +40,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return true if the dictionary is empty.
+				Return [code]true[/code] if the dictionary is empty.
 			</description>
 		</method>
 		<method name="erase">
@@ -69,7 +69,7 @@
 			<argument index="0" name="key" type="Variant">
 			</argument>
 			<description>
-				Return true if the dictionary has a given key.
+				Return [code]true[/code] if the dictionary has a given key.
 			</description>
 		</method>
 		<method name="has_all">
@@ -78,7 +78,7 @@
 			<argument index="0" name="keys" type="Array">
 			</argument>
 			<description>
-				Return true if the dictionary has all of the keys in the given array.
+				Return [code]true[/code] if the dictionary has all of the keys in the given array.
 			</description>
 		</method>
 		<method name="hash">

--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -47,7 +47,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return true of the filesystem is being scanned.
+				Return [code]true[/code] of the filesystem is being scanned.
 			</description>
 		</method>
 		<method name="scan">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -294,14 +294,14 @@
 			<argument index="0" name="object" type="Object">
 			</argument>
 			<description>
-				Implement this function if your plugin edits a specific type of object (Resource or Node). If you return true, then you will get the functions [method EditorPlugin.edit] and [method EditorPlugin.make_visible] called when the editor requests them. If you have declared the methods [method forward_canvas_gui_input] and [method forward_spatial_gui_input] these will be called too.
+				Implement this function if your plugin edits a specific type of object (Resource or Node). If you return [code]true[/code], then you will get the functions [method EditorPlugin.edit] and [method EditorPlugin.make_visible] called when the editor requests them. If you have declared the methods [method forward_canvas_gui_input] and [method forward_spatial_gui_input] these will be called too.
 			</description>
 		</method>
 		<method name="has_main_screen" qualifiers="virtual">
 			<return type="bool">
 			</return>
 			<description>
-				Return true if this is a main screen editor plugin (it goes in the workspaces selector together with '2D', '3D', and 'Script').
+				Return [code]true[/code] if this is a main screen editor plugin (it goes in the workspaces selector together with '2D', '3D', and 'Script').
 			</description>
 		</method>
 		<method name="hide_bottom_panel">

--- a/doc/classes/EditorSpatialGizmo.xml
+++ b/doc/classes/EditorSpatialGizmo.xml
@@ -99,7 +99,7 @@
 			</argument>
 			<description>
 				Commit a handle being edited (handles must have been previously added by [method add_handles]).
-				If the cancel parameter is true, an option to restore the edited value to the original is provided.
+				If the cancel parameter is [code]true[/code], an option to restore the edited value to the original is provided.
 			</description>
 		</method>
 		<method name="get_handle_name" qualifiers="virtual">

--- a/doc/classes/EditorSpatialGizmoPlugin.xml
+++ b/doc/classes/EditorSpatialGizmoPlugin.xml
@@ -27,7 +27,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Override this method to define whether the gizmo can be hidden or not. Defaults to true.
+				Override this method to define whether the gizmo can be hidden or not. Defaults to [code]true[/code].
 			</description>
 		</method>
 		<method name="commit_handle" qualifiers="virtual">

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -30,7 +30,7 @@
 			Global contrast value of the rendered scene (default value is 1).
 		</member>
 		<member name="adjustment_enabled" type="bool" setter="set_adjustment_enable" getter="is_adjustment_enabled">
-			Enables the adjustment_* options provided by this resource. If false, adjustments modifications will have no effect on the rendered scene.
+			Enables the adjustment_* options provided by this resource. If [code]false[/code], adjustments modifications will have no effect on the rendered scene.
 		</member>
 		<member name="adjustment_saturation" type="float" setter="set_adjustment_saturation" getter="get_adjustment_saturation">
 			Global color saturation value of the rendered scene (default value is 1).

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -103,7 +103,7 @@
 			<argument index="3" name="to_port" type="int">
 			</argument>
 			<description>
-				Return true if the 'from_port' slot of 'from' GraphNode is connected to the 'to_port' slot of 'to' GraphNode.
+				Return [code]true[/code] if the 'from_port' slot of 'from' GraphNode is connected to the 'to_port' slot of 'to' GraphNode.
 			</description>
 		</method>
 		<method name="is_valid_connection_type" qualifiers="const">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -137,7 +137,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return true if left (input) slot 'idx' is enabled. False otherwise.
+				Return [code]true[/code] if left (input) slot 'idx' is enabled, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="is_slot_enabled_right" qualifiers="const">
@@ -146,7 +146,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return true if right (output) slot 'idx' is enabled. False otherwise.
+				Return [code]true[/code] if right (output) slot 'idx' is enabled, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="set_slot">

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -297,7 +297,7 @@
 			HTTP status code [code]303 See Other[/code]. The server is redirecting the user agent to a different resource, as indicated by a URI in the Location header field, which is intended to provide an indirect response to the original request.
 		</constant>
 		<constant name="RESPONSE_NOT_MODIFIED" value="304" enum="ResponseCode">
-			HTTP status code [code]304 Not Modified[/code]. A conditional GET or HEAD request has been received and would have resulted in a 200 OK response if it were not for the fact that the condition evaluated to false.
+			HTTP status code [code]304 Not Modified[/code]. A conditional GET or HEAD request has been received and would have resulted in a 200 OK response if it were not for the fact that the condition evaluated to [code]false[/code].
 		</constant>
 		<constant name="RESPONSE_USE_PROXY" value="305" enum="ResponseCode">
 			HTTP status code [code]305 Use Proxy[/code]. Deprecated. Do not use.
@@ -348,7 +348,7 @@
 			HTTP status code [code]411 Length Required[/code]. The server refuses to accept the request without a defined Content-Length header.
 		</constant>
 		<constant name="RESPONSE_PRECONDITION_FAILED" value="412" enum="ResponseCode">
-			HTTP status code [code]412 Precondition Failed[/code]. One or more conditions given in the request header fields evaluated to false when tested on the server.
+			HTTP status code [code]412 Precondition Failed[/code]. One or more conditions given in the request header fields evaluated to [code]false[/code] when tested on the server.
 		</constant>
 		<constant name="RESPONSE_REQUEST_ENTITY_TOO_LARGE" value="413" enum="ResponseCode">
 			HTTP status code [code]413 Entity Too Large[/code]. The server is refusing to process a request because the request payload is larger than the server is willing or able to process.

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -125,7 +125,7 @@
 			<argument index="3" name="format" type="int" enum="Image.Format">
 			</argument>
 			<description>
-				Creates an empty image of given size and format. See [code]FORMAT_*[/code] constants. If [code]use_mipmaps[/code] is true then generate mipmaps for this image. See the [code]generate_mipmaps[/code] method.
+				Creates an empty image of given size and format. See [code]FORMAT_*[/code] constants. If [code]use_mipmaps[/code] is [code]true[/code] then generate mipmaps for this image. See the [code]generate_mipmaps[/code] method.
 			</description>
 		</method>
 		<method name="create_from_data">
@@ -142,7 +142,7 @@
 			<argument index="4" name="data" type="PoolByteArray">
 			</argument>
 			<description>
-				Creates a new image of given size and format. See [code]FORMAT_*[/code] constants. Fills the image with the given raw data. If [code]use_mipmaps[/code] is true then generate mipmaps for this image. See the [code]generate_mipmaps[/code] method.
+				Creates a new image of given size and format. See [code]FORMAT_*[/code] constants. Fills the image with the given raw data. If [code]use_mipmaps[/code] is [code]true[/code] then generate mipmaps for this image. See the [code]generate_mipmaps[/code] method.
 			</description>
 		</method>
 		<method name="crop">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -199,7 +199,7 @@
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] when the user starts pressing the action event, meaning it's true only on the frame that the user pressed down the button.
+				Returns [code]true[/code] when the user starts pressing the action event, meaning it's [code]true[/code] only on the frame that the user pressed down the button.
 				This is useful for code that needs to run only once when an action is pressed, instead of every frame while it's pressed.
 			</description>
 		</method>
@@ -209,7 +209,7 @@
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] when the user stops pressing the action event, meaning it's true only on the frame that the user released the button.
+				Returns [code]true[/code] when the user stops pressing the action event, meaning it's [code]true[/code] only on the frame that the user released the button.
 			</description>
 		</method>
 		<method name="is_action_pressed" qualifiers="const">

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -34,7 +34,7 @@
 			</argument>
 			<description>
 				Adds an item to the item list with specified text. Specify an icon of null for a list item with no icon.
-				If selectable is true the list item will be selectable.
+				If selectable is [code]true[/code] the list item will be selectable.
 			</description>
 		</method>
 		<method name="clear">

--- a/doc/classes/KinematicBody.xml
+++ b/doc/classes/KinematicBody.xml
@@ -93,10 +93,10 @@
 				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [KinematicBody] or [RigidBody], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
 				[code]linear_velocity[/code] is the velocity vector (typically meters per second). Unlike in [method move_and_collide], you should [i]not[/i] multiply it by [code]delta[/code] — the physics engine handles applying the velocity.
 				[code]floor_normal[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector3(0, 0, 0)[/code], everything is considered a wall. This is useful for topdown games.
-				If [code]stop_on_slope[/code] is true, body will not slide on slopes if you include gravity in [code]linear_velocity[/code].
+				If [code]stop_on_slope[/code] is [code]true[/code], body will not slide on slopes if you include gravity in [code]linear_velocity[/code].
 				If the body collides, it will change direction a maximum of [code]max_slides[/code] times before it stops.
 				[code]floor_max_angle[/code] is the maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall. The default value equals 45 degrees.
-				If [code]infinite_inertia[/code] is true, body will be able to push [RigidBody] nodes, but it won't also detect any collisions with them. When false, it will interact with [RigidBody] nodes like with [StaticBody].
+				If [code]infinite_inertia[/code] is [code]true[/code], body will be able to push [RigidBody] nodes, but it won't also detect any collisions with them. If [code]false[/code] it will interact with [RigidBody] nodes like with [StaticBody].
 				Returns the [code]linear_velocity[/code] vector, rotated and/or scaled if a slide collision occurred. To get detailed information about collisions that occurred, use [method get_slide_collision].
 			</description>
 		</method>

--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -97,10 +97,10 @@
 				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [KinematicBody2D] or [RigidBody2D], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
 				[code]linear_velocity[/code] is the velocity vector in pixels per second. Unlike in [method move_and_collide], you should [i]not[/i] multiply it by [code]delta[/code] — the physics engine handles applying the velocity.
 				[code]floor_normal[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector2(0, 0)[/code], everything is considered a wall. This is useful for topdown games.
-				If [code]stop_on_slope[/code] is true, body will not slide on slopes when you include gravity in [code]linear_velocity[/code] and the body is standing still.
+				If [code]stop_on_slope[/code] is [code]true[/code], body will not slide on slopes when you include gravity in [code]linear_velocity[/code] and the body is standing still.
 				If the body collides, it will change direction a maximum of [code]max_slides[/code] times before it stops.
 				[code]floor_max_angle[/code] is the maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall. The default value equals 45 degrees.
-				If [code]infinite_inertia[/code] is true, body will be able to push [RigidBody2D] nodes, but it won't also detect any collisions with them. When false, it will interact with [RigidBody2D] nodes like with [StaticBody2D].
+				If [code]infinite_inertia[/code] is [code]true[/code], body will be able to push [RigidBody2D] nodes, but it won't also detect any collisions with them. If [code]false[/code] it will interact with [RigidBody2D] nodes like with [StaticBody2D].
 				Returns the [code]linear_velocity[/code] vector, rotated and/or scaled if a slide collision occurred. To get detailed information about collisions that occurred, use [method get_slide_collision].
 			</description>
 		</method>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -46,7 +46,7 @@
 			Controls the text's horizontal align. Supports left, center, right, and fill, or justify. Set it to one of the [code]ALIGN_*[/code] constants.
 		</member>
 		<member name="autowrap" type="bool" setter="set_autowrap" getter="has_autowrap">
-			If [code]true[/code], wraps the text inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. Default: false.
+			If [code]true[/code], wraps the text inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. Default: [code]false[/code].
 		</member>
 		<member name="clip_text" type="bool" setter="set_clip_text" getter="is_clipping_text">
 			If [code]true[/code], the Label only shows the text that fits inside its bounding rectangle. It also lets you scale the node down freely.

--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -65,7 +65,7 @@
 			<argument index="1" name="scaled" type="bool" default="false">
 			</argument>
 			<description>
-				Applies a local translation on the node's X axis based on the [method Node._process]'s [code]delta[/code]. If [code]scaled[/code] is false, normalizes the movement.
+				Applies a local translation on the node's X axis based on the [method Node._process]'s [code]delta[/code]. If [code]scaled[/code] is [code]false[/code], normalizes the movement.
 			</description>
 		</method>
 		<method name="move_local_y">
@@ -76,7 +76,7 @@
 			<argument index="1" name="scaled" type="bool" default="false">
 			</argument>
 			<description>
-				Applies a local translation on the node's Y axis based on the [method Node._process]'s [code]delta[/code]. If [code]scaled[/code] is false, normalizes the movement.
+				Applies a local translation on the node's Y axis based on the [method Node._process]'s [code]delta[/code]. If [code]scaled[/code] is [code]false[/code], normalizes the movement.
 			</description>
 		</method>
 		<method name="rotate">

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -70,14 +70,14 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return true if the node path is absolute (not relative).
+				Return [code]true[/code] if the node path is absolute (not relative).
 			</description>
 		</method>
 		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>
-				Return true if the node path is empty.
+				Return [code]true[/code] if the node path is empty.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -346,7 +346,7 @@
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-				If set to true, signal emission is blocked.
+				If set to [code]true[/code], signal emission is blocked.
 			</description>
 		</method>
 		<method name="set_deferred">
@@ -375,7 +375,7 @@
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-				Define whether the object can translate strings (with calls to [method tr]). Default is true.
+				Define whether the object can translate strings (with calls to [method tr]). Default is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_meta">

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -82,7 +82,7 @@
 			<argument index="1" name="epsilon" type="float" default="0.00001">
 			</argument>
 			<description>
-				Returns true if "point" is inside the plane (by a very minimum threshold).
+				Returns [code]true[/code] if "point" is inside the plane (by a very minimum threshold).
 			</description>
 		</method>
 		<method name="intersect_3">
@@ -124,7 +124,7 @@
 			<argument index="0" name="point" type="Vector3">
 			</argument>
 			<description>
-				Returns true if "point" is located above the plane.
+				Returns [code]true[/code] if "point" is located above the plane.
 			</description>
 		</method>
 		<method name="normalized">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -74,7 +74,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				Return true if a configuration value is present.
+				Return [code]true[/code] if a configuration value is present.
 			</description>
 		</method>
 		<method name="load_resource_pack">
@@ -83,7 +83,7 @@
 			<argument index="0" name="pack" type="String">
 			</argument>
 			<description>
-				Loads the contents of the .pck or .zip file specified by [code]pack[/code] into the resource filesystem (res://). Returns true on success.
+				Loads the contents of the .pck or .zip file specified by [code]pack[/code] into the resource filesystem (res://). Returns [code]true[/code] on success.
 				Note: If a file from [code]pack[/code] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [code]pack[/code].
 			</description>
 		</method>
@@ -102,7 +102,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				Returns true if the specified property exists and its initial value differs from the current value.
+				Returns [code]true[/code] if the specified property exists and its initial value differs from the current value.
 			</description>
 		</method>
 		<method name="property_get_revert">

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -27,7 +27,7 @@
 			<argument index="0" name="resource" type="Resource">
 			</argument>
 			<description>
-				Returns true if the given resource object can be saved by this saver.
+				Returns [code]true[/code] if the given resource object can be saved by this saver.
 			</description>
 		</method>
 		<method name="save" qualifiers="virtual">

--- a/doc/classes/ResourcePreloader.xml
+++ b/doc/classes/ResourcePreloader.xml
@@ -44,7 +44,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				Returns true if the preloader contains a resource associated to [code]name[/code].
+				Returns [code]true[/code] if the preloader contains a resource associated to [code]name[/code].
 			</description>
 		</method>
 		<method name="remove_resource">

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -63,7 +63,7 @@
 			<argument index="1" name="pause_mode_process" type="bool" default="true">
 			</argument>
 			<description>
-				Returns a [SceneTreeTimer] which will [signal SceneTreeTimer.timeout] after the given time in seconds elapsed in this SceneTree. If [code]pause_mode_process[/code] is set to false, pausing the SceneTree will also pause the timer.
+				Returns a [SceneTreeTimer] which will [signal SceneTreeTimer.timeout] after the given time in seconds elapsed in this SceneTree. If [code]pause_mode_process[/code] is set to [code]false[/code], pausing the SceneTree will also pause the timer.
 				Commonly used to create a one-shot delay timer as in the following example:
 				[codeblock]
 				func some_function():

--- a/doc/classes/SphereMesh.xml
+++ b/doc/classes/SphereMesh.xml
@@ -17,7 +17,7 @@
 			Full height of the sphere. Defaults to 2.0.
 		</member>
 		<member name="is_hemisphere" type="bool" setter="set_is_hemisphere" getter="get_is_hemisphere">
-			Determines whether a full sphere or a hemisphere is created. Attention: To get a regular hemisphere the height and radius of the sphere have to equal. Defaults to false.
+			Determines whether a full sphere or a hemisphere is created. Attention: To get a regular hemisphere the height and radius of the sphere have to equal. Defaults to [code]false[/code].
 		</member>
 		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments">
 			Number of radial segments on the sphere. Defaults to 64.

--- a/doc/classes/StreamPeerSSL.xml
+++ b/doc/classes/StreamPeerSSL.xml
@@ -30,7 +30,7 @@
 			<argument index="2" name="for_hostname" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Connect to a peer using an underlying [StreamPeer] "stream", when "validate_certs" is true, [StreamPeerSSL] will validate that the certificate presented by the peer matches the "for_hostname".
+				Connect to a peer using an underlying [StreamPeer] "stream", when "validate_certs" is [code]true[/code], [StreamPeerSSL] will validate that the certificate presented by the peer matches the "for_hostname".
 			</description>
 		</method>
 		<method name="disconnect_from_stream">

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -96,7 +96,7 @@
 			The background color of the stylebox.
 		</member>
 		<member name="border_blend" type="bool" setter="set_border_blend" getter="get_border_blend">
-			When set to true, the border will fade into the background color.
+			When set to [code]true[/code], the border will fade into the background color.
 		</member>
 		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color">
 			Sets the color of the border.

--- a/doc/classes/TCP_Server.xml
+++ b/doc/classes/TCP_Server.xml
@@ -15,7 +15,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return true if a connection is available for taking.
+				Return [code]true[/code] if a connection is available for taking.
 			</description>
 		</method>
 		<method name="listen">

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -102,7 +102,7 @@
 			<argument index="1" name="disabled" type="bool">
 			</argument>
 			<description>
-				If [code]disabled[/code] is false, hides the tab at index [code]tab_idx[/code]. Note that its title text will remain, unless also removed with [method set_tab_title].
+				If [code]disabled[/code] is [code]false[/code], hides the tab at index [code]tab_idx[/code]. Note that its title text will remain, unless also removed with [method set_tab_title].
 			</description>
 		</method>
 		<method name="set_tab_icon">

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -137,7 +137,7 @@
 			<argument index="1" name="disabled" type="bool">
 			</argument>
 			<description>
-				If [code]disabled[/code] is false, hides the tab at index [code]tab_idx[/code]. Note that its title text will remain, unless also removed with [method set_tab_title].
+				If [code]disabled[/code] is [code]false[/code], hides the tab at index [code]tab_idx[/code]. Note that its title text will remain, unless also removed with [method set_tab_title].
 			</description>
 		</method>
 		<method name="set_tab_icon">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -247,7 +247,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return true if the selection is active.
+				Return [code]true[/code] if the selection is active.
 			</description>
 		</method>
 		<method name="menu_option">

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -22,7 +22,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns true if this [Thread] is currently active. An active [Thread] cannot start work on a new method but can be joined with [method wait_to_finish].
+				Returns [code]true[/code] if this [Thread] is currently active. An active [Thread] cannot start work on a new method but can be joined with [method wait_to_finish].
 			</description>
 		</method>
 		<method name="start">

--- a/doc/classes/VehicleBody.xml
+++ b/doc/classes/VehicleBody.xml
@@ -18,11 +18,11 @@
 			Slows down the vehicle by applying a braking force. The vehicle is only slowed down if the wheels are in contact with a surface. The force you need to apply to adequately slow down your vehicle depends on the [member RigidBody.mass] of the vehicle. For a vehicle with a mass set to 1000, try a value in the 25 - 30 range for hard braking.
 		</member>
 		<member name="engine_force" type="float" setter="set_engine_force" getter="get_engine_force">
-			Accelerates the vehicle by applying an engine force. The vehicle is only speed up if the wheels that have [member VehicleWheel.use_as_traction] set to true and are in contact with a surface. The [member RigidBody.mass] of the vehicle has an effect on the acceleration of the vehicle. For a vehicle with a mass set to 1000, try a value in the 25 - 50 range for acceleration. Note that the simulation does not take the effect of gears into account, you will need to add logic for this if you wish to simulate gears.
+			Accelerates the vehicle by applying an engine force. The vehicle is only speed up if the wheels that have [member VehicleWheel.use_as_traction] set to [code]true[/code] and are in contact with a surface. The [member RigidBody.mass] of the vehicle has an effect on the acceleration of the vehicle. For a vehicle with a mass set to 1000, try a value in the 25 - 50 range for acceleration. Note that the simulation does not take the effect of gears into account, you will need to add logic for this if you wish to simulate gears.
 			A negative value will result in the vehicle reversing.
 		</member>
 		<member name="steering" type="float" setter="set_steering" getter="get_steering">
-			The steering angle for the vehicle. Setting this to a non-zero value will result in the vehicle turning when it's moving. Wheels that have [member VehicleWheel.use_as_steering] set to true will automatically be rotated.
+			The steering angle for the vehicle. Setting this to a non-zero value will result in the vehicle turning when it's moving. Wheels that have [member VehicleWheel.use_as_steering] set to [code]true[/code] will automatically be rotated.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VehicleWheel.xml
+++ b/doc/classes/VehicleWheel.xml
@@ -22,7 +22,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns true if this wheel is in contact with a surface.
+				Returns [code]true[/code] if this wheel is in contact with a surface.
 			</description>
 		</method>
 	</methods>
@@ -43,10 +43,10 @@
 			This is the distance the suspension can travel. As Godot measures are in meters keep this setting relatively low. Try a value between 0.1 and 0.3 depending on the type of car .
 		</member>
 		<member name="use_as_steering" type="bool" setter="set_use_as_steering" getter="is_used_as_steering">
-			If true this wheel will be turned when the car steers.
+			If [code]true[/code] this wheel will be turned when the car steers.
 		</member>
 		<member name="use_as_traction" type="bool" setter="set_use_as_traction" getter="is_used_as_traction">
-			If true this wheel transfers engine force to the ground to propel the vehicle forward.
+			If [code]true[/code] this wheel transfers engine force to the ground to propel the vehicle forward.
 		</member>
 		<member name="wheel_friction_slip" type="float" setter="set_friction_slip" getter="get_friction_slip">
 			This determines how much grip this wheel has. It is combined with the friction setting of the surface the wheel is in contact with. 0.0 means no grip, 1.0 is normal grip. For a drift car setup, try setting the grip of the rear wheels slightly lower than the front wheels, or use a lower value to simulate tire wear.

--- a/doc/classes/bool.xml
+++ b/doc/classes/bool.xml
@@ -17,7 +17,7 @@
 			<argument index="0" name="from" type="int">
 			</argument>
 			<description>
-				Cast an [int] value to a boolean value, this method will return true if called with an integer value different to 0 and false in other case.
+				Cast an [int] value to a boolean value, this method will return [code]true[/code] if called with an integer value different to 0 and [code]false[/code] in other case.
 			</description>
 		</method>
 		<method name="bool">
@@ -26,7 +26,7 @@
 			<argument index="0" name="from" type="float">
 			</argument>
 			<description>
-				Cast a [float] value to a boolean value, this method will return true if called with a floating point value different to 0 and false in other case.
+				Cast a [float] value to a boolean value, this method will return [code]true[/code] if called with a floating point value different to 0 and [code]false[/code] in other case.
 			</description>
 		</method>
 		<method name="bool">
@@ -35,7 +35,7 @@
 			<argument index="0" name="from" type="String">
 			</argument>
 			<description>
-				Cast a [String] value to a boolean value, this method will return true if called with a non empty string and false in other case. Examples: [code]bool('False')[/code] returns true, [code]bool('')[/code]. returns false
+				Cast a [String] value to a boolean value, this method will return [code]true[/code] if called with a non empty string and [code]false[/code] in other case. Examples: [code]bool('False')[/code] returns [code]true[/code], [code]bool('')[/code] returns [code]false[/code].
 			</description>
 		</method>
 	</methods>

--- a/modules/csg/doc_classes/CSGCylinder.xml
+++ b/modules/csg/doc_classes/CSGCylinder.xml
@@ -14,7 +14,7 @@
 	</methods>
 	<members>
 		<member name="cone" type="bool" setter="set_cone" getter="is_cone">
-			If true a cone is created, the [member radius] will only apply to one side.
+			If [code]true[/code] a cone is created, the [member radius] will only apply to one side.
 		</member>
 		<member name="height" type="float" setter="set_height" getter="get_height">
 			The height of the cylinder.
@@ -29,7 +29,7 @@
 			The number of sides of the cylinder, the higher this number the more detail there will be in the cylinder.
 		</member>
 		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces">
-			If true the normals of the cylinder are set to give a smooth effect making the cylinder seem rounded. When false the cylinder will have a flat shaded look.
+			If [code]true[/code] the normals of the cylinder are set to give a smooth effect making the cylinder seem rounded. If [code]false[/code] the cylinder will have a flat shaded look.
 		</member>
 	</members>
 	<constants>

--- a/modules/csg/doc_classes/CSGPolygon.xml
+++ b/modules/csg/doc_classes/CSGPolygon.xml
@@ -23,16 +23,16 @@
 			Extrusion mode.
 		</member>
 		<member name="path_continuous_u" type="bool" setter="set_path_continuous_u" getter="is_path_continuous_u">
-			If true the u component of our uv will continuously increase in unison with the distance traveled along our path when [member mode] is [constant MODE_PATH].
+			If [code]true[/code] the u component of our uv will continuously increase in unison with the distance traveled along our path when [member mode] is [constant MODE_PATH].
 		</member>
 		<member name="path_interval" type="float" setter="set_path_interval" getter="get_path_interval">
 			Interval at which a new extrusion slice is added along the path when [member mode] is [constant MODE_PATH].
 		</member>
 		<member name="path_joined" type="bool" setter="set_path_joined" getter="is_path_joined">
-			If true the start and end of our path are joined together ensuring there is no seam when [member mode] is [constant MODE_PATH].
+			If [code]true[/code] the start and end of our path are joined together ensuring there is no seam when [member mode] is [constant MODE_PATH].
 		</member>
 		<member name="path_local" type="bool" setter="set_path_local" getter="is_path_local">
-			If false we extrude centered on our path, if true we extrude in relation to the position of our CSGPolygon when [member mode] is [constant MODE_PATH].
+			If [code]false[/code] we extrude centered on our path, if [code]true[/code] we extrude in relation to the position of our CSGPolygon when [member mode] is [constant MODE_PATH].
 		</member>
 		<member name="path_node" type="NodePath" setter="set_path_node" getter="get_path_node">
 			The [Shape] object containing the path along which we extrude when [member mode] is [constant MODE_PATH].

--- a/modules/csg/doc_classes/CSGShape.xml
+++ b/modules/csg/doc_classes/CSGShape.xml
@@ -39,7 +39,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns true if this is a root shape and is thus the object that is rendered.
+				Returns [code]true[/code] if this is a root shape and is thus the object that is rendered.
 			</description>
 		</method>
 		<method name="set_collision_layer_bit">

--- a/modules/csg/doc_classes/CSGSphere.xml
+++ b/modules/csg/doc_classes/CSGSphere.xml
@@ -26,7 +26,7 @@
 			Number of horizontal slices for the sphere.
 		</member>
 		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces">
-			If true the normals of the sphere are set to give a smooth effect making the sphere seem rounded. When false the sphere will have a flat shaded look.
+			If [code]true[/code] the normals of the sphere are set to give a smooth effect making the sphere seem rounded. If [code]false[/code] the sphere will have a flat shaded look.
 		</member>
 	</members>
 	<constants>

--- a/modules/csg/doc_classes/CSGTorus.xml
+++ b/modules/csg/doc_classes/CSGTorus.xml
@@ -29,7 +29,7 @@
 			The number of slices the torus is constructed of.
 		</member>
 		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces">
-			If true the normals of the torus are set to give a smooth effect making the torus seem rounded. When false the torus will have a flat shaded look.
+			If [code]true[/code] the normals of the torus are set to give a smooth effect making the torus seem rounded. If [code]false[/code] the torus will have a flat shaded look.
 		</member>
 	</members>
 	<constants>

--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -62,7 +62,7 @@
 			<argument index="1" name="now" type="bool" default="false">
 			</argument>
 			<description>
-				Disconnect the given peer. If "now" is set to true, the connection will be closed immediately without flushing queued messages.
+				Disconnect the given peer. If "now" is set to [code]true[/code], the connection will be closed immediately without flushing queued messages.
 			</description>
 		</method>
 		<method name="get_last_packet_channel" qualifiers="const">

--- a/modules/opensimplex/doc_classes/NoiseTexture.xml
+++ b/modules/opensimplex/doc_classes/NoiseTexture.xml
@@ -15,7 +15,7 @@
 	</methods>
 	<members>
 		<member name="as_normalmap" type="bool" setter="set_as_normalmap" getter="is_normalmap">
-			If true, the resulting texture contains a normal map created from the original noise interpreted as a bump map.
+			If [code]true[/code], the resulting texture contains a normal map created from the original noise interpreted as a bump map.
 		</member>
 		<member name="bump_strength" type="float" setter="set_bump_strength" getter="get_bump_strength">
 		</member>

--- a/modules/visual_script/doc_classes/VisualScriptCustomNode.xml
+++ b/modules/visual_script/doc_classes/VisualScriptCustomNode.xml
@@ -145,7 +145,7 @@
 		</constant>
 		<constant name="STEP_PUSH_STACK_BIT" value="16777216">
 			Hint used by [method _step] to tell that control should return to it when there is no other node left to execute.
-			This is used by [VisualScriptCondition] to redirect the sequence to the "Done" port after the true/false branch has finished execution.
+			This is used by [VisualScriptCondition] to redirect the sequence to the "Done" port after the [code]true[/code]/[code]false[/code] branch has finished execution.
 		</constant>
 		<constant name="STEP_GO_BACK_BIT" value="33554432">
 			Hint used by [method _step] to tell that control should return back, either hitting a previous STEP_PUSH_STACK_BIT or exiting the function.


### PR DESCRIPTION
As briefly discussed in #27937 and as stated [here](http://docs.godotengine.org/en/latest/community/contributing/docs_writing_guidelines.html#use-if-true-to-describe-booleans), booleans in docs should be wrapped in [code][/code] block and not all of them were, so this PR makes it consistent.