### PR TITLE
Added insert comment option in visual script

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -206,6 +206,11 @@
 				Signal sent when the GraphNode is dragged.
 			</description>
 		</signal>
+		<signal name="double_clicked">
+			<description>
+				Signal sent when the GraphNode is double clicked.
+			</description>
+		</signal>
 		<signal name="offset_changed">
 			<description>
 				Signal sent when the GraphNode is moved.

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -59,6 +59,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 		EDIT_COPY_NODES,
 		EDIT_CUT_NODES,
 		EDIT_PASTE_NODES,
+		EDIT_INSERT_COMMENT
 	};
 
 	enum PortAction {
@@ -196,6 +197,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	void _node_moved(Vector2 p_from, Vector2 p_to, int p_id);
 	void _remove_node(int p_id);
+	void _node_double_clicked(int p_id);
 	void _graph_connected(const String &p_from, int p_from_slot, const String &p_to, int p_to_slot);
 	void _graph_disconnected(const String &p_from, int p_from_slot, const String &p_to, int p_to_slot);
 	void _graph_connect_to_empty(const String &p_from, int p_from_slot, const Vector2 &p_release_pos);
@@ -218,6 +220,8 @@ class VisualScriptEditor : public ScriptEditorBase {
 	void _members_gui_input(const Ref<InputEvent> &p_event);
 	void _on_nodes_delete();
 	void _on_nodes_duplicate();
+
+	Rect2 get_rect_around(List<int> &nodes);
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -618,6 +618,9 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 			}
 
 			emit_signal("raise_request");
+			if (mb->is_doubleclick()) {
+				emit_signal("double_clicked");
+			}
 		}
 
 		if (!mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
@@ -724,6 +727,7 @@ void GraphNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("dragged", PropertyInfo(Variant::VECTOR2, "from"), PropertyInfo(Variant::VECTOR2, "to")));
 	ADD_SIGNAL(MethodInfo("raise_request"));
 	ADD_SIGNAL(MethodInfo("close_request"));
+	ADD_SIGNAL(MethodInfo("double_clicked"));
 	ADD_SIGNAL(MethodInfo("resize_request", PropertyInfo(Variant::VECTOR2, "new_minsize")));
 
 	BIND_ENUM_CONSTANT(OVERLAY_DISABLED);


### PR DESCRIPTION
Closes #28079
You can also double click on comment nodes to update the bounds.
I am making this two commits because they are kinda two separate features.