### PR TITLE
Mono: Logging improvements

### DIFF
--- a/modules/mono/mono_gd/gd_mono_log.h
+++ b/modules/mono/mono_gd/gd_mono_log.h
@@ -41,7 +41,6 @@ class GDMonoLog {
 	String log_file_path;
 
 	bool _try_create_logs_dir(const String &p_logs_dir);
-	void _open_log_file(const String &p_file_path);
 	void _delete_old_log_files(const String &p_logs_dir);
 
 	static GDMonoLog *singleton;


### PR DESCRIPTION
- The default log level in debug builds is now 'info' instead of 'debug'.
- Add option to specify a different log level with the 'GODOT_MONO_LOG_LEVEL' environment variable.
- The name of log files is now a readable date and time.
- Always print the log file path (previously it was printed only it in verbose mode).