### PR TITLE
Add a monitor for the orphan nodes

### DIFF
--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -57,58 +57,61 @@
 			Number of resources currently used.
 		</constant>
 		<constant name="OBJECT_NODE_COUNT" value="10" enum="Monitor">
-			Number of nodes currently instanced. This also includes the root node, as well as any nodes not in the scene tree.
+			Number of nodes currently instanced in the scene tree. This also includes the root node.
 		</constant>
-		<constant name="RENDER_OBJECTS_IN_FRAME" value="11" enum="Monitor">
+		<constant name="OBJECT_ORPHANS_NODE_COUNT" value="11" enum="Monitor">
+			Number of instanced nodes that aren't included in the scene tree.
+		</constant>
+		<constant name="RENDER_OBJECTS_IN_FRAME" value="12" enum="Monitor">
 			3D objects drawn per frame.
 		</constant>
-		<constant name="RENDER_VERTICES_IN_FRAME" value="12" enum="Monitor">
+		<constant name="RENDER_VERTICES_IN_FRAME" value="13" enum="Monitor">
 			Vertices drawn per frame. 3D only.
 		</constant>
-		<constant name="RENDER_MATERIAL_CHANGES_IN_FRAME" value="13" enum="Monitor">
+		<constant name="RENDER_MATERIAL_CHANGES_IN_FRAME" value="14" enum="Monitor">
 			Material changes per frame. 3D only
 		</constant>
-		<constant name="RENDER_SHADER_CHANGES_IN_FRAME" value="14" enum="Monitor">
+		<constant name="RENDER_SHADER_CHANGES_IN_FRAME" value="15" enum="Monitor">
 			Shader changes per frame. 3D only.
 		</constant>
-		<constant name="RENDER_SURFACE_CHANGES_IN_FRAME" value="15" enum="Monitor">
+		<constant name="RENDER_SURFACE_CHANGES_IN_FRAME" value="16" enum="Monitor">
 			Render surface changes per frame. 3D only.
 		</constant>
-		<constant name="RENDER_DRAW_CALLS_IN_FRAME" value="16" enum="Monitor">
+		<constant name="RENDER_DRAW_CALLS_IN_FRAME" value="17" enum="Monitor">
 			Draw calls per frame. 3D only.
 		</constant>
-		<constant name="RENDER_VIDEO_MEM_USED" value="17" enum="Monitor">
+		<constant name="RENDER_VIDEO_MEM_USED" value="18" enum="Monitor">
 			Video memory used. Includes both texture and vertex memory.
 		</constant>
-		<constant name="RENDER_TEXTURE_MEM_USED" value="18" enum="Monitor">
+		<constant name="RENDER_TEXTURE_MEM_USED" value="19" enum="Monitor">
 			Texture memory used.
 		</constant>
-		<constant name="RENDER_VERTEX_MEM_USED" value="19" enum="Monitor">
+		<constant name="RENDER_VERTEX_MEM_USED" value="20" enum="Monitor">
 			Vertex memory used.
 		</constant>
-		<constant name="RENDER_USAGE_VIDEO_MEM_TOTAL" value="20" enum="Monitor">
+		<constant name="RENDER_USAGE_VIDEO_MEM_TOTAL" value="21" enum="Monitor">
 		</constant>
-		<constant name="PHYSICS_2D_ACTIVE_OBJECTS" value="21" enum="Monitor">
+		<constant name="PHYSICS_2D_ACTIVE_OBJECTS" value="22" enum="Monitor">
 			Number of active [RigidBody2D] nodes in the game.
 		</constant>
-		<constant name="PHYSICS_2D_COLLISION_PAIRS" value="22" enum="Monitor">
+		<constant name="PHYSICS_2D_COLLISION_PAIRS" value="23" enum="Monitor">
 			Number of collision pairs in the 2D physics engine.
 		</constant>
-		<constant name="PHYSICS_2D_ISLAND_COUNT" value="23" enum="Monitor">
+		<constant name="PHYSICS_2D_ISLAND_COUNT" value="24" enum="Monitor">
 			Number of islands in the 2D physics engine.
 		</constant>
-		<constant name="PHYSICS_3D_ACTIVE_OBJECTS" value="24" enum="Monitor">
+		<constant name="PHYSICS_3D_ACTIVE_OBJECTS" value="25" enum="Monitor">
 			Number of active [RigidBody] and [VehicleBody] nodes in the game.
 		</constant>
-		<constant name="PHYSICS_3D_COLLISION_PAIRS" value="25" enum="Monitor">
+		<constant name="PHYSICS_3D_COLLISION_PAIRS" value="26" enum="Monitor">
 			Number of collision pairs in the 3D physics engine.
 		</constant>
-		<constant name="PHYSICS_3D_ISLAND_COUNT" value="26" enum="Monitor">
+		<constant name="PHYSICS_3D_ISLAND_COUNT" value="27" enum="Monitor">
 			Number of islands in the 3D physics engine.
 		</constant>
-		<constant name="AUDIO_OUTPUT_LATENCY" value="27" enum="Monitor">
+		<constant name="AUDIO_OUTPUT_LATENCY" value="28" enum="Monitor">
 		</constant>
-		<constant name="MONITOR_MAX" value="28" enum="Monitor">
+		<constant name="MONITOR_MAX" value="29" enum="Monitor">
 		</constant>
 	</constants>
 </class>

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -32,6 +32,7 @@
 
 #include "core/message_queue.h"
 #include "core/os/os.h"
+#include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
 #include "servers/audio_server.h"
 #include "servers/physics_2d_server.h"
@@ -55,6 +56,7 @@ void Performance::_bind_methods() {
 	BIND_ENUM_CONSTANT(OBJECT_COUNT);
 	BIND_ENUM_CONSTANT(OBJECT_RESOURCE_COUNT);
 	BIND_ENUM_CONSTANT(OBJECT_NODE_COUNT);
+	BIND_ENUM_CONSTANT(OBJECT_ORPHAN_NODE_COUNT);
 	BIND_ENUM_CONSTANT(RENDER_OBJECTS_IN_FRAME);
 	BIND_ENUM_CONSTANT(RENDER_VERTICES_IN_FRAME);
 	BIND_ENUM_CONSTANT(RENDER_MATERIAL_CHANGES_IN_FRAME);
@@ -76,6 +78,14 @@ void Performance::_bind_methods() {
 	BIND_ENUM_CONSTANT(MONITOR_MAX);
 }
 
+float Performance::_get_node_count() const {
+	MainLoop *ml = OS::get_singleton()->get_main_loop();
+	SceneTree *sml = Object::cast_to<SceneTree>(ml);
+	if (!sml)
+		return 0;
+	return sml->get_node_count();
+}
+
 String Performance::get_monitor_name(Monitor p_monitor) const {
 
 	ERR_FAIL_INDEX_V(p_monitor, MONITOR_MAX, String());
@@ -92,6 +102,7 @@ String Performance::get_monitor_name(Monitor p_monitor) const {
 		"object/objects",
 		"object/resources",
 		"object/nodes",
+		"object/orphan_nodes",
 		"raster/objects_drawn",
 		"raster/vertices_drawn",
 		"raster/mat_changes",
@@ -128,14 +139,8 @@ float Performance::get_monitor(Monitor p_monitor) const {
 		case MEMORY_MESSAGE_BUFFER_MAX: return MessageQueue::get_singleton()->get_max_buffer_usage();
 		case OBJECT_COUNT: return ObjectDB::get_object_count();
 		case OBJECT_RESOURCE_COUNT: return ResourceCache::get_cached_resource_count();
-		case OBJECT_NODE_COUNT: {
-
-			MainLoop *ml = OS::get_singleton()->get_main_loop();
-			SceneTree *sml = Object::cast_to<SceneTree>(ml);
-			if (!sml)
-				return 0;
-			return sml->get_node_count();
-		};
+		case OBJECT_NODE_COUNT: return _get_node_count();
+		case OBJECT_ORPHAN_NODE_COUNT: return Node::orphan_node_count;
 		case RENDER_OBJECTS_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_OBJECTS_IN_FRAME);
 		case RENDER_VERTICES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_VERTICES_IN_FRAME);
 		case RENDER_MATERIAL_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_MATERIAL_CHANGES_IN_FRAME);

--- a/main/performance.h
+++ b/main/performance.h
@@ -43,6 +43,8 @@ class Performance : public Object {
 	static Performance *singleton;
 	static void _bind_methods();
 
+	float _get_node_count() const;
+
 	float _process_time;
 	float _physics_process_time;
 
@@ -60,6 +62,7 @@ public:
 		OBJECT_COUNT,
 		OBJECT_RESOURCE_COUNT,
 		OBJECT_NODE_COUNT,
+		OBJECT_ORPHAN_NODE_COUNT,
 		RENDER_OBJECTS_IN_FRAME,
 		RENDER_VERTICES_IN_FRAME,
 		RENDER_MATERIAL_CHANGES_IN_FRAME,

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -41,6 +41,8 @@
 
 VARIANT_ENUM_CAST(Node::PauseMode);
 
+int Node::orphan_node_count = 0;
+
 void Node::_notification(int p_notification) {
 
 	switch (p_notification) {
@@ -84,11 +86,14 @@ void Node::_notification(int p_notification) {
 				add_to_group("_vp_unhandled_key_input" + itos(get_viewport()->get_instance_id()));
 
 			get_tree()->node_count++;
+			orphan_node_count--;
 
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 
 			get_tree()->node_count--;
+			orphan_node_count++;
+
 			if (data.input)
 				remove_from_group("_vp_input" + itos(get_viewport()->get_instance_id()));
 			if (data.unhandled_input)
@@ -2938,6 +2943,8 @@ Node::Node() {
 	data.use_placeholder = false;
 	data.display_folded = false;
 	data.ready_first = true;
+
+	orphan_node_count++;
 }
 
 Node::~Node() {
@@ -2948,6 +2955,8 @@ Node::~Node() {
 
 	ERR_FAIL_COND(data.parent);
 	ERR_FAIL_COND(data.children.size());
+
+	orphan_node_count--;
 }
 
 ////////////////////////////////

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -75,6 +75,8 @@ public:
 		bool operator()(const Node *p_a, const Node *p_b) const { return p_b->data.process_priority == p_a->data.process_priority ? p_b->is_greater_than(p_a) : p_b->data.process_priority > p_a->data.process_priority; }
 	};
 
+	static int orphan_node_count;
+
 private:
 	struct GroupData {
 


### PR DESCRIPTION
- Allow the user to keep track of the nodes that might leak
- Possible fix for #27103

Hi, this is my first pull request.
It adds a new monitor that shows which nodes aren't currently instanced in the scene tree.

![orphan-nodes](https://user-images.githubusercontent.com/3595817/56321308-a4be3c80-6166-11e9-9518-daf5e5567126.png)

