### PR TITLE
Add shortcut to the 'Create a new rectangle' collider button in TileSet editor

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -405,6 +405,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	toolbar->add_child(tools[SHAPE_NEW_RECTANGLE]);
 	tools[SHAPE_NEW_RECTANGLE]->set_toggle_mode(true);
 	tools[SHAPE_NEW_RECTANGLE]->set_button_group(tg);
+	tools[SHAPE_NEW_RECTANGLE]->set_shortcut(ED_SHORTCUT("tileset_editor/new_rectangle", TTR("New Rectangle"), KEY_R));
 	tools[SHAPE_NEW_RECTANGLE]->set_tooltip(TTR("Create a new rectangle."));
 
 	tools[SHAPE_NEW_POLYGON] = memnew(ToolButton);


### PR DESCRIPTION
This is a quick idea on how to fix #28123. Basically just adds a shortcut to the following button. See the linked issue for more details on why this is needed (or some other workaround)

![image](https://user-images.githubusercontent.com/123374/56327794-5451d980-617c-11e9-8cc9-86c88146ac53.png)

I don't actually expect this to be merged as is, because it would probably make sense to add the shortcuts to all the buttons. And I'm willing to go through it and do that, but I'd first like to hear from someone that it's the right thing to do :)

Or if you guys have a better idea on how to fix the issue, I don't really mind. The reason I did it this way was to basically quickly fix it for myself so I don't go crazy from doing it by hand.

It also brings out a question. It probably would make sense to have all of these buttons configurable in the editor settings, right? Even without a default hotkey, I'm not sure if there is any harm of having them available in the Shortcuts menu and unbound by default if no good hotkey comes to mind.