### PR TITLE
Mono: Use exit(status) instead of abort() in exception hook

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -30,6 +30,7 @@
 
 #include "gd_mono.h"
 
+#include <mono/metadata/environment.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/mono-config.h>
 #include <mono/metadata/mono-debug.h>
@@ -1008,7 +1009,9 @@ void GDMono::unhandled_exception_hook(MonoObject *p_exc, void *) {
 	if (ScriptDebugger::get_singleton())
 		ScriptDebugger::get_singleton()->idle_poll();
 #endif
-	abort();
+
+	exit(mono_environment_exitcode_get());
+
 	GD_UNREACHABLE();
 }
 

--- a/modules/mono/mono_gd/gd_mono_internals.cpp
+++ b/modules/mono/mono_gd/gd_mono_internals.cpp
@@ -111,7 +111,8 @@ void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 
 void unhandled_exception(MonoException *p_exc) {
 	mono_unhandled_exception((MonoObject *)p_exc); // prints the exception as well
-	abort();
+	// Too bad 'mono_invoke_unhandled_exception_hook' is not exposed to embedders
+	GDMono::unhandled_exception_hook((MonoObject *)p_exc, NULL);
 	GD_UNREACHABLE();
 }
 

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -632,11 +632,6 @@ void debug_send_unhandled_exception_error(MonoException *p_exc) {
 }
 
 void debug_unhandled_exception(MonoException *p_exc) {
-#ifdef DEBUG_ENABLED
-	GDMonoUtils::debug_send_unhandled_exception_error(p_exc);
-	if (ScriptDebugger::get_singleton())
-		ScriptDebugger::get_singleton()->idle_poll();
-#endif
 	GDMonoInternals::unhandled_exception(p_exc); // prints the exception as well
 	GD_UNREACHABLE();
 }


### PR DESCRIPTION
This way we no longer hard crash from a unhandled managed exception.
