### PR TITLE
C#: Add missing ToString() override methods

### DIFF
--- a/modules/mono/glue/Managed/Files/Array.cs
+++ b/modules/mono/glue/Managed/Files/Array.cs
@@ -143,6 +143,11 @@ namespace Godot.Collections
             }
         }
 
+        public override string ToString()
+        {
+            return godot_icall_Array_ToString(GetPtr());
+        }
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static IntPtr godot_icall_Array_Ctor();
 
@@ -190,6 +195,9 @@ namespace Godot.Collections
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static void godot_icall_Array_Generic_GetElementTypeInfo(Type elemType, out int elemTypeEncoding, out IntPtr elemTypeClass);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static string godot_icall_Array_ToString(IntPtr ptr);
     }
 
     public class Array<T> : IList<T>, ICollection<T>, IEnumerable<T>
@@ -353,5 +361,7 @@ namespace Godot.Collections
         {
             return GetEnumerator();
         }
+
+        public override string ToString() => objectArray.ToString();
     }
 }

--- a/modules/mono/glue/Managed/Files/Dictionary.cs
+++ b/modules/mono/glue/Managed/Files/Dictionary.cs
@@ -193,6 +193,11 @@ namespace Godot.Collections
             }
         }
 
+        public override string ToString()
+        {
+            return godot_icall_Dictionary_ToString(GetPtr());
+        }
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static IntPtr godot_icall_Dictionary_Ctor();
 
@@ -243,6 +248,9 @@ namespace Godot.Collections
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static void godot_icall_Dictionary_Generic_GetValueTypeInfo(Type valueType, out int valTypeEncoding, out IntPtr valTypeClass);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static string godot_icall_Dictionary_ToString(IntPtr ptr);
     }
 
     public class Dictionary<TKey, TValue> :
@@ -442,5 +450,7 @@ namespace Godot.Collections
         {
             return GetEnumerator();
         }
+
+        public override string ToString() => objectDict.ToString();
     }
 }

--- a/modules/mono/glue/Managed/Files/DynamicObject.cs
+++ b/modules/mono/glue/Managed/Files/DynamicObject.cs
@@ -26,7 +26,7 @@ namespace Godot
     /// dynamic sprite = GetNode("Sprite").DynamicGodotObject;
     /// sprite.add_child(this);
     ///
-    /// if ((sprite.hframes * sprite.vframes) > 0)
+    /// if ((sprite.hframes * sprite.vframes) &gt; 0)
     ///     sprite.frame = 0;
     /// </code>
     /// </example>

--- a/modules/mono/glue/Managed/Files/Object.base.cs
+++ b/modules/mono/glue/Managed/Files/Object.base.cs
@@ -73,6 +73,11 @@ namespace Godot
             disposed = true;
         }
 
+        public override string ToString()
+        {
+            return godot_icall_Object_ToString(GetPtr(this));
+        }
+
         /// <summary>
         /// Returns a new <see cref="Godot.SignalAwaiter"/> awaiter configured to complete when the instance
         /// <paramref name="source"/> emits the signal specified by the <paramref name="signal"/> parameter.
@@ -88,7 +93,7 @@ namespace Godot
         /// <code>
         /// public override void _Ready()
         /// {
-        ///     for (int i = 0; i < 100; i++)
+        ///     for (int i = 0; i &lt; 100; i++)
         ///     {
         ///         await ToSignal(GetTree(), "idle_frame");
         ///         GD.Print($"Frame {i}");
@@ -114,6 +119,9 @@ namespace Godot
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static void godot_icall_Reference_Disposed(Object obj, IntPtr ptr, bool isFinalizer);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static string godot_icall_Object_ToString(IntPtr ptr);
 
         // Used by the generated API
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/modules/mono/glue/Managed/Files/RID.cs
+++ b/modules/mono/glue/Managed/Files/RID.cs
@@ -70,6 +70,8 @@ namespace Godot
             return godot_icall_RID_get_id(RID.GetPtr(this));
         }
 
+        public override string ToString() => "[RID]";
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static IntPtr godot_icall_RID_Ctor(IntPtr from);
 

--- a/modules/mono/glue/base_object_glue.cpp
+++ b/modules/mono/glue/base_object_glue.cpp
@@ -218,11 +218,16 @@ MonoBoolean godot_icall_DynamicGodotObject_SetMember(Object *p_ptr, MonoString *
 	return valid;
 }
 
+MonoString *godot_icall_Object_ToString(Object *p_ptr) {
+	return GDMonoMarshal::mono_string_from_godot(Variant(p_ptr).operator String());
+}
+
 void godot_register_object_icalls() {
 	mono_add_internal_call("Godot.Object::godot_icall_Object_Ctor", (void *)godot_icall_Object_Ctor);
 	mono_add_internal_call("Godot.Object::godot_icall_Object_Disposed", (void *)godot_icall_Object_Disposed);
 	mono_add_internal_call("Godot.Object::godot_icall_Reference_Disposed", (void *)godot_icall_Reference_Disposed);
 	mono_add_internal_call("Godot.Object::godot_icall_Object_ClassDB_get_method", (void *)godot_icall_Object_ClassDB_get_method);
+	mono_add_internal_call("Godot.Object::godot_icall_Object_ToString", (void *)godot_icall_Object_ToString);
 	mono_add_internal_call("Godot.Object::godot_icall_Object_weakref", (void *)godot_icall_Object_weakref);
 	mono_add_internal_call("Godot.SignalAwaiter::godot_icall_SignalAwaiter_connect", (void *)godot_icall_SignalAwaiter_connect);
 	mono_add_internal_call("Godot.DynamicGodotObject::godot_icall_DynamicGodotObject_SetMemberList", (void *)godot_icall_DynamicGodotObject_SetMemberList);

--- a/modules/mono/glue/base_object_glue.h
+++ b/modules/mono/glue/base_object_glue.h
@@ -60,6 +60,8 @@ MonoBoolean godot_icall_DynamicGodotObject_GetMember(Object *p_ptr, MonoString *
 
 MonoBoolean godot_icall_DynamicGodotObject_SetMember(Object *p_ptr, MonoString *p_name, MonoObject *p_value);
 
+MonoString *godot_icall_Object_ToString(Object *p_ptr);
+
 // Register internal calls
 
 void godot_register_object_icalls();

--- a/modules/mono/glue/collections_glue.cpp
+++ b/modules/mono/glue/collections_glue.cpp
@@ -143,6 +143,10 @@ void godot_icall_Array_Generic_GetElementTypeInfo(MonoReflectionType *refltype, 
 	*type_class = GDMono::get_singleton()->get_class(type_class_raw);
 }
 
+MonoString *godot_icall_Array_ToString(Array *ptr) {
+	return GDMonoMarshal::mono_string_from_godot(Variant(*ptr).operator String());
+}
+
 Dictionary *godot_icall_Dictionary_Ctor() {
 	return memnew(Dictionary);
 }
@@ -264,6 +268,10 @@ void godot_icall_Dictionary_Generic_GetValueTypeInfo(MonoReflectionType *refltyp
 	*type_class = GDMono::get_singleton()->get_class(type_class_raw);
 }
 
+MonoString *godot_icall_Dictionary_ToString(Dictionary *ptr) {
+	return GDMonoMarshal::mono_string_from_godot(Variant(*ptr).operator String());
+}
+
 void godot_register_collections_icalls() {
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Ctor", (void *)godot_icall_Array_Ctor);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Dtor", (void *)godot_icall_Array_Dtor);
@@ -281,6 +289,7 @@ void godot_register_collections_icalls() {
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_RemoveAt", (void *)godot_icall_Array_RemoveAt);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Resize", (void *)godot_icall_Array_Resize);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Generic_GetElementTypeInfo", (void *)godot_icall_Array_Generic_GetElementTypeInfo);
+	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_ToString", (void *)godot_icall_Array_ToString);
 
 	mono_add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Ctor", (void *)godot_icall_Dictionary_Ctor);
 	mono_add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Dtor", (void *)godot_icall_Dictionary_Dtor);
@@ -299,6 +308,7 @@ void godot_register_collections_icalls() {
 	mono_add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_TryGetValue", (void *)godot_icall_Dictionary_TryGetValue);
 	mono_add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_TryGetValue_Generic", (void *)godot_icall_Dictionary_TryGetValue_Generic);
 	mono_add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Generic_GetValueTypeInfo", (void *)godot_icall_Dictionary_Generic_GetValueTypeInfo);
+	mono_add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_ToString", (void *)godot_icall_Dictionary_ToString);
 }
 
 #endif // MONO_GLUE_ENABLED

--- a/modules/mono/glue/collections_glue.h
+++ b/modules/mono/glue/collections_glue.h
@@ -71,6 +71,8 @@ Error godot_icall_Array_Resize(Array *ptr, int new_size);
 
 void godot_icall_Array_Generic_GetElementTypeInfo(MonoReflectionType *refltype, uint32_t *type_encoding, GDMonoClass **type_class);
 
+MonoString *godot_icall_Array_ToString(Array *ptr);
+
 // Dictionary
 
 Dictionary *godot_icall_Dictionary_Ctor();
@@ -106,6 +108,8 @@ MonoBoolean godot_icall_Dictionary_TryGetValue(Dictionary *ptr, MonoObject *key,
 MonoBoolean godot_icall_Dictionary_TryGetValue_Generic(Dictionary *ptr, MonoObject *key, MonoObject **value, uint32_t type_encoding, GDMonoClass *type_class);
 
 void godot_icall_Dictionary_Generic_GetValueTypeInfo(MonoReflectionType *refltype, uint32_t *type_encoding, GDMonoClass **type_class);
+
+MonoString *godot_icall_Dictionary_ToString(Dictionary *ptr);
 
 // Register internal calls
 


### PR DESCRIPTION
Godot.Object, Array, Dictionary and RID were missing ToString() override methods