### PR TITLE
Fix some ZSTD build problems for (at least) FreeBSD

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -128,7 +128,7 @@ if env['builtin_zstd']:
     ]
     thirdparty_zstd_sources = [thirdparty_zstd_dir + file for file in thirdparty_zstd_sources]
 
-    env_thirdparty.Append(CPPPATH=[thirdparty_zstd_dir, thirdparty_zstd_dir + "common"])
+    env_thirdparty.Prepend(CPPPATH=[thirdparty_zstd_dir, thirdparty_zstd_dir + "common"])
     env_thirdparty.Append(CCFLAGS="-DZSTD_STATIC_LINKING_ONLY")
     env.Append(CPPPATH=thirdparty_zstd_dir)
     # Also needed in main env includes will trigger warnings


### PR DESCRIPTION
Fix some ZSTD build problems for (at least) FreeBSD (headers seems
not be included), as commented in #27358.