### PR TITLE
Hide popup menu when OptionButton is hidden

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -776,6 +776,12 @@ void ColorPickerButton::_notification(int p_what) {
 	if (p_what == MainLoop::NOTIFICATION_WM_QUIT_REQUEST && popup) {
 		popup->hide();
 	}
+
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+		if (popup && !is_visible_in_tree()) {
+			popup->hide();
+		}
+	}
 }
 
 void ColorPickerButton::set_pick_color(const Color &p_color) {

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -91,6 +91,16 @@ bool MenuButton::is_switch_on_hover() {
 	return switch_on_hover;
 }
 
+void MenuButton::_notification(int p_what) {
+
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+
+		if (!is_visible_in_tree()) {
+			popup->hide();
+		}
+	}
+}
+
 void MenuButton::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_popup"), &MenuButton::get_popup);

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -52,6 +52,7 @@ class MenuButton : public Button {
 	void _gui_input(Ref<InputEvent> p_event);
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -72,6 +72,11 @@ void OptionButton::_notification(int p_what) {
 
 		Point2 ofs(size.width - arrow->get_width() - get_constant("arrow_margin"), int(Math::abs((size.height - arrow->get_height()) / 2)));
 		arrow->draw(ci, ofs, clr);
+	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+
+		if (!is_visible_in_tree()) {
+			popup->hide();
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #26937

**Problem**: If you hide an OptionButton or its parent node while the popup menu is open, then the popup menu stays visible.

**Solution**: Use signal `visibility_changed` to hide the popup menu when its parent (OptionButton) is hidden.

**Alternative**: Add the following GDScript for every OptionButton

```
extends OptionButton

onready var popup = get_popup()

func _ready():
	connect('visibility_changed', self, 'on_visibility_changed')

func on_visibility_changed():
	if not is_visible_in_tree():
		popup.hide()
```