### PR TITLE
Fake a newline at the end of GDScripts while tokenizing

### DIFF
--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -888,10 +888,11 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 				case GDScriptFunction::OPCODE_LINE: {
 
 					int line = code[ip + 1] - 1;
+					txt = "\n" + txt + "(line: " + itos(line + 1) + ") ";
 					if (line >= 0 && line < p_code.size())
-						txt = "\n" + itos(line + 1) + ": " + p_code[line] + "\n";
+						txt += p_code[line] + "\n";
 					else
-						txt = "";
+						txt += "OOB";
 					incr += 2;
 				} break;
 				case GDScriptFunction::OPCODE_END: {

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -211,6 +211,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 	void _make_constant(const Variant &p_constant);
 	void _make_type(const Variant::Type &p_type);
 	void _make_error(const String &p_error);
+	void _make_eof();
 
 	String code;
 	int len;
@@ -220,6 +221,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 	int column;
 	TokenData tk_rb[TK_RB_SIZE * 2 + 1];
 	int tk_rb_pos;
+	bool last_was_newline;
 	String last_error;
 	bool error_flag;
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
Fixes #28151

Probably not the best solution, but likely the easiest :confused:.