### PR TITLE
Don't crash on printing nested types

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -401,6 +401,10 @@ Variant Array::max() const {
 	return maxval;
 }
 
+const void *Array::id() const {
+	return _p->array.ptr();
+}
+
 Array::Array(const Array &p_from) {
 
 	_p = NULL;

--- a/core/array.h
+++ b/core/array.h
@@ -94,6 +94,8 @@ public:
 	Variant min() const;
 	Variant max() const;
 
+	const void *id() const;
+
 	Array(const Array &p_from);
 	Array();
 	~Array();

--- a/core/dictionary.cpp
+++ b/core/dictionary.cpp
@@ -270,6 +270,10 @@ void Dictionary::operator=(const Dictionary &p_dictionary) {
 	_ref(p_dictionary);
 }
 
+const void *Dictionary::id() const {
+	return _p->variant_map.id();
+}
+
 Dictionary::Dictionary(const Dictionary &p_from) {
 	_p = NULL;
 	_ref(p_from);

--- a/core/dictionary.h
+++ b/core/dictionary.h
@@ -82,6 +82,8 @@ public:
 
 	Dictionary duplicate(bool p_deep = false) const;
 
+	const void *id() const;
+
 	Dictionary(const Dictionary &p_from);
 	Dictionary();
 	~Dictionary();

--- a/core/list.h
+++ b/core/list.h
@@ -691,6 +691,10 @@ public:
 		memdelete_arr(aux_buffer);
 	}
 
+	const void *id() const {
+		return (void *)_data;
+	}
+
 	/**
 	 * copy constructor for the list
 	 */

--- a/core/ordered_hash_map.h
+++ b/core/ordered_hash_map.h
@@ -274,6 +274,10 @@ public:
 	inline bool empty() const { return list.empty(); }
 	inline int size() const { return list.size(); }
 
+	const void *id() const {
+		return list.id();
+	}
+
 	void clear() {
 		map.clear();
 		list.clear();

--- a/core/variant.h
+++ b/core/variant.h
@@ -401,6 +401,7 @@ public:
 
 	bool hash_compare(const Variant &p_variant) const;
 	bool booleanize() const;
+	String stringify(List<const void *> &stack) const;
 
 	void static_assign(const Variant &p_variant);
 	static void get_constructor_list(Variant::Type p_type, List<MethodInfo> *p_list);


### PR DESCRIPTION
When adding an Array or Dictionary to itself operator String() got in an
infinite loop. This commit adds a stack to operator String() (Through
the use of a new 'stringify method'). This stack keeps track of all
unique Arrays and Dictionaries it has seen. When a duplicate is found
only a static string is printed '[...]' or '{...}'.

This mirror Python's behavior in a similar case.

This fixes #28089