### PR TITLE
Require only one click to deploy to Android if one device is connected

### DIFF
--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -56,7 +56,7 @@ void EditorRunNative::_notification(int p_what) {
 					small_icon->create_from_image(im, 0);
 					MenuButton *mb = memnew(MenuButton);
 					mb->get_popup()->connect("id_pressed", this, "_run_native", varray(i));
-					//mb->connect("pressed", this, "_run_native", varray(-1, i));
+					mb->connect("pressed", this, "_run_native", varray(-1, i));
 					mb->set_icon(small_icon);
 					add_child(mb);
 					menus[i] = mb;
@@ -82,10 +82,14 @@ void EditorRunNative::_notification(int p_what) {
 				} else {
 					mb->get_popup()->clear();
 					mb->show();
-					mb->set_tooltip(TTR("Select device from the list"));
-					for (int i = 0; i < dc; i++) {
-						mb->get_popup()->add_icon_item(get_icon("Play", "EditorIcons"), eep->get_device_name(i));
-						mb->get_popup()->set_item_tooltip(mb->get_popup()->get_item_count() - 1, eep->get_device_info(i).strip_edges());
+					if (dc == 1) {
+						mb->set_tooltip(eep->get_device_name(0) + "\n\n" + eep->get_device_info(0).strip_edges());
+					} else {
+						mb->set_tooltip("Select device from the list");
+						for (int i = 0; i < dc; i++) {
+							mb->get_popup()->add_icon_item(get_icon("Play", "EditorIcons"), eep->get_device_name(i));
+							mb->get_popup()->set_item_tooltip(mb->get_popup()->get_item_count() - 1, eep->get_device_info(i).strip_edges());
+						}
 					}
 				}
 			}
@@ -99,14 +103,15 @@ void EditorRunNative::_run_native(int p_idx, int p_platform) {
 
 	Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(p_platform);
 	ERR_FAIL_COND(eep.is_null());
-	/*if (p_idx == -1) {
+
+	if (p_idx == -1) {
 		if (eep->get_device_count() == 1) {
 			menus[p_platform]->get_popup()->hide();
 			p_idx = 0;
 		} else {
 			return;
 		}
-	}*/
+	}
 
 	Ref<EditorExportPreset> preset;
 


### PR DESCRIPTION
This restores changes introduced by 938f9388ddc5b3def60e4aefbeb1beed09599493, which were reverted by efaeebab4d83e5657288b7b20db6ce4ccf987a01.

## Preview

### One device connected (clicking will deploy immediately)

![android_one_click_deploy_single](https://user-images.githubusercontent.com/180032/56459028-7d49b880-638e-11e9-88c7-9f2fc0a0c687.png)

### Several devices connected (clicking will display the menu)

![android_one_click_deploy_multi](https://user-images.githubusercontent.com/180032/56459027-7cb12200-638e-11e9-9acf-81d06a144687.png)