### PR TITLE
Geometry shader support

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -731,7 +731,7 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 Error ShaderCompilerGLES2::compile(VS::ShaderMode p_mode, const String &p_code, IdentifierActions *p_actions, const String &p_path, GeneratedCode &r_gen_code) {
 
-	Error err = parser.compile(p_code, ShaderTypes::get_singleton()->get_functions(p_mode), ShaderTypes::get_singleton()->get_modes(p_mode), ShaderTypes::get_singleton()->get_types());
+	Error err = parser.compile(p_code, ShaderTypes::get_singleton()->get_functions(p_mode), ShaderTypes::get_singleton()->get_modes(p_mode), ShaderTypes::get_singleton()->get_ranges(p_mode), ShaderTypes::get_singleton()->get_types());
 
 	if (err != OK) {
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2361,7 +2361,7 @@ void RasterizerSceneGLES3::_add_geometry_with_material(RasterizerStorageGLES3::G
 		if (has_blend_alpha || p_material->shader->spatial.uses_depth_texture || (has_base_alpha && p_material->shader->spatial.depth_draw_mode != RasterizerStorageGLES3::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS) || p_material->shader->spatial.depth_draw_mode == RasterizerStorageGLES3::Shader::Spatial::DEPTH_DRAW_NEVER || p_material->shader->spatial.no_depth_test)
 			return; //bye
 
-		if (!p_material->shader->spatial.uses_alpha_scissor && !p_material->shader->spatial.writes_modelview_or_projection && !p_material->shader->spatial.uses_vertex && !p_material->shader->spatial.uses_discard && p_material->shader->spatial.depth_draw_mode != RasterizerStorageGLES3::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS) {
+		if (!p_material->shader->spatial.uses_alpha_scissor && !p_material->shader->spatial.writes_modelview_or_projection && !p_material->shader->spatial.uses_vertex && !p_material->shader->spatial.uses_geometry && !p_material->shader->spatial.uses_discard && p_material->shader->spatial.depth_draw_mode != RasterizerStorageGLES3::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS) {
 			//shader does not use discard and does not write a vertex position, use generic material
 			if (p_instance->cast_shadows == VS::SHADOW_CASTING_SETTING_DOUBLE_SIDED) {
 				p_material = storage->material_owner.getptr(!p_shadow_pass && p_material->shader->spatial.uses_world_coordinates ? default_worldcoord_material_twosided : default_material_twosided);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -479,12 +479,14 @@ public:
 			};
 
 			int cull_mode;
+			int max_vertices;
 
 			bool uses_alpha;
 			bool uses_alpha_scissor;
 			bool unshaded;
 			bool no_depth_test;
 			bool uses_vertex;
+			bool uses_geometry;
 			bool uses_discard;
 			bool uses_sss;
 			bool uses_screen_texture;
@@ -501,6 +503,7 @@ public:
 		} particles;
 
 		bool uses_vertex_time;
+		bool uses_geometry_time;
 		bool uses_fragment_time;
 
 		Shader() :

--- a/drivers/gles3/shader_compiler_gles3.h
+++ b/drivers/gles3/shader_compiler_gles3.h
@@ -41,6 +41,7 @@ public:
 	struct IdentifierActions {
 
 		Map<StringName, Pair<int *, int> > render_mode_values;
+		Map<StringName, int *> render_mode_ranges;
 		Map<StringName, bool *> render_mode_flags;
 		Map<StringName, bool *> usage_flag_pointers;
 		Map<StringName, bool *> write_flag_pointers;
@@ -60,11 +61,14 @@ public:
 		String uniforms;
 		String vertex_global;
 		String vertex;
+		String geometry_global;
+		String geometry;
 		String fragment_global;
 		String fragment;
 		String light;
 
 		bool uses_fragment_time;
+		bool uses_geometry_time;
 		bool uses_vertex_time;
 	};
 
@@ -84,6 +88,7 @@ private:
 	StringName current_func_name;
 	StringName vertex_name;
 	StringName fragment_name;
+	StringName geometry_name;
 	StringName light_name;
 	StringName time_name;
 
@@ -91,6 +96,7 @@ private:
 	Set<StringName> used_flag_pointers;
 	Set<StringName> used_rmode_defines;
 	Set<StringName> internal_functions;
+	Set<StringName> varyings;
 
 	DefaultIdentifierActions actions[VS::SHADER_MAX];
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -103,6 +103,7 @@ private:
 	int ubo_count;
 	int feedback_count;
 	int vertex_code_start;
+	int geometry_code_start;
 	int fragment_code_start;
 	int attribute_pair_count;
 
@@ -110,10 +111,13 @@ private:
 
 		String vertex;
 		String vertex_globals;
+		String geometry;
+		String geometry_globals;
 		String fragment;
 		String fragment_globals;
 		String light;
 		String uniforms;
+		bool has_geometry;
 		uint32_t version;
 		Vector<StringName> texture_uniforms;
 		Vector<CharString> custom_defines;
@@ -124,6 +128,7 @@ private:
 
 		GLuint id;
 		GLuint vert_id;
+		GLuint geom_id;
 		GLuint frag_id;
 		GLint *uniform_location;
 		Vector<GLint> texture_uniform_locations;
@@ -132,6 +137,7 @@ private:
 		Version() :
 				id(0),
 				vert_id(0),
+				geom_id(0),
 				frag_id(0),
 				uniform_location(NULL),
 				code_version(0),
@@ -174,6 +180,7 @@ private:
 	const UBOPair *ubo_pairs;
 	const Feedback *feedbacks;
 	const char *vertex_code;
+	const char *geometry_code;
 	const char *fragment_code;
 	CharString fragment_code0;
 	CharString fragment_code1;
@@ -185,6 +192,12 @@ private:
 	CharString vertex_code1;
 	CharString vertex_code2;
 	CharString vertex_code3;
+
+	CharString geometry_code0;
+	CharString geometry_code1;
+	CharString geometry_code2;
+	CharString geometry_code3;
+	bool has_geometry;
 
 	Vector<CharString> custom_defines;
 
@@ -303,6 +316,9 @@ protected:
 	_FORCE_INLINE_ void _set_conditional(int p_which, bool p_value);
 
 	void setup(const char **p_conditional_defines, int p_conditional_count, const char **p_uniform_names, int p_uniform_count, const AttributePair *p_attribute_pairs, int p_attribute_count, const TexUnitPair *p_texunit_pairs, int p_texunit_pair_count, const UBOPair *p_ubo_pairs, int p_ubo_pair_count, const Feedback *p_feedback, int p_feedback_count, const char *p_vertex_code, const char *p_fragment_code, int p_vertex_code_start, int p_fragment_code_start);
+	void setup_vertex(const char *p_vertex_code, int p_vertex_code_start);
+	void setup_geometry(const char *p_geometry_code, int p_geometry_code_start);
+	void setup_fragment(const char *p_fragment_code, int p_fragment_code_start);
 
 	ShaderGLES3();
 
@@ -324,7 +340,7 @@ public:
 	void clear_caches();
 
 	uint32_t create_custom_shader();
-	void set_custom_shader_code(uint32_t p_code_id, const String &p_vertex, const String &p_vertex_globals, const String &p_fragment, const String &p_light, const String &p_fragment_globals, const String &p_uniforms, const Vector<StringName> &p_texture_uniforms, const Vector<CharString> &p_custom_defines);
+	void set_custom_shader_code(uint32_t p_code_id, const String &p_vertex, const String &p_vertex_globals, const String &p_geometry, const String &p_geometry_globals, const String &p_fragment, const String &p_light, const String &p_fragment_globals, const String &p_uniforms, const Vector<StringName> &p_texture_uniforms, const Vector<CharString> &p_custom_defines);
 	void set_custom_shader(uint32_t p_code_id);
 	void free_custom_shader(uint32_t p_code_id);
 

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -249,6 +249,109 @@ VERTEX_SHADER_CODE
 }
 
 /* clang-format off */
+[geometry]
+
+/* geometry shader settings */
+
+#ifndef GEOMETRY_IN_MODE
+#define GEOMETRY_IN_MODE 2
+#endif
+
+#ifndef GEOMETRY_OUT_MODE
+#define GEOMETRY_OUT_MODE 2
+#endif
+
+#if GEOMETRY_IN_MODE == 0
+layout (points) in;
+#elif GEOMETRY_IN_MODE == 1
+layout (lines) in;
+#elif GEOMETRY_IN_MODE == 2
+layout (triangles) in;
+#endif
+
+#if GEOMETRY_OUT_MODE == 0
+layout (points) out;
+#elif GEOMETRY_OUT_MODE == 1
+layout (line_strip) out;
+#elif GEOMETRY_OUT_MODE == 2
+layout (triangle_strip) out;
+#endif
+
+#ifndef GEOMETRY_MAX_VERTICES
+#define GEOMETRY_MAX_VERTICES 0
+#endif
+
+layout (max_vertices = GEOMETRY_MAX_VERTICES) out;
+
+/* clang-format on */
+
+layout(std140) uniform CanvasItemData { //ubo:0
+
+	highp mat4 projection_matrix;
+	highp float time;
+};
+
+uniform highp mat4 modelview_matrix;
+uniform highp mat4 extra_matrix;
+
+out highp vec2 uv_interp;
+out mediump vec4 color_interp;
+
+#if defined(USE_MATERIAL)
+
+/* clang-format off */
+layout(std140) uniform UniformData { //ubo:1
+
+MATERIAL_UNIFORMS
+
+};
+/* clang-format on */
+
+#endif
+
+/* clang-format off */
+
+GEOMETRY_SHADER_GLOBALS
+
+/* clang-format on */
+
+vec4 tpos(float x, float y) {
+	return projection_matrix * modelview_matrix * vec4(x, y, 0, 0);
+}
+
+vec4 tpos(vec2 v) {
+	return projection_matrix * modelview_matrix * vec4(v.x, v.y, 0, 0);
+}
+
+vec4 tpos(float x, float y, float z) {
+	return projection_matrix * modelview_matrix * vec4(x, y, z, 0);
+}
+
+vec4 tpos(vec3 v) {
+	return projection_matrix * modelview_matrix * vec4(v.x, v.y, v.z, 0);
+}
+
+vec4 tpos(float x, float y, float z, float w) {
+	return projection_matrix * modelview_matrix * vec4(x, y, z, w);
+}
+
+vec4 tpos(vec4 v) {
+	return projection_matrix * modelview_matrix * vec4(v.x, v.y, v.z, v.w);
+}
+
+void main() {
+	int index = 0;
+
+	{
+		/* clang-format off */
+
+GEOMETRY_SHADER_CODE
+
+		/* clang-format on */
+	}
+}
+
+/* clang-format off */
 [fragment]
 
 uniform mediump sampler2D color_texture; // texunit:0

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -444,9 +444,10 @@ void main() {
 #endif
 
 	highp mat4 modelview = camera_inverse_matrix * world_matrix;
+
 	{
 		/* clang-format off */
-
+		
 VERTEX_SHADER_CODE
 
 		/* clang-format on */
@@ -575,6 +576,173 @@ VERTEX_SHADER_CODE
 #endif //USE_LIGHT_DIRECTIONAL
 
 #endif // USE_VERTEX_LIGHTING
+}
+
+/* clang-format off */
+[geometry]
+
+/* geometry shader settings */
+
+#ifndef GEOMETRY_IN_MODE
+#define GEOMETRY_IN_MODE 2
+#endif
+
+#ifndef GEOMETRY_OUT_MODE
+#define GEOMETRY_OUT_MODE 2
+#endif
+
+#if GEOMETRY_IN_MODE == 0
+layout (points) in;
+#elif GEOMETRY_IN_MODE == 1
+layout (lines) in;
+#elif GEOMETRY_IN_MODE == 2
+layout (triangles) in;
+#endif
+
+#if GEOMETRY_OUT_MODE == 0
+layout (points) out;
+#elif GEOMETRY_OUT_MODE == 1
+layout (line_strip) out;
+#elif GEOMETRY_OUT_MODE == 2
+layout (triangle_strip) out;
+#endif
+
+#ifndef GEOMETRY_MAX_VERTICES
+#define GEOMETRY_MAX_VERTICES 0
+#endif
+
+layout (max_vertices = GEOMETRY_MAX_VERTICES) out;
+
+/* clang-format on */
+
+layout(std140) uniform SceneData { // ubo:0
+
+	highp mat4 projection_matrix;
+	highp mat4 inv_projection_matrix;
+	highp mat4 camera_inverse_matrix;
+	highp mat4 camera_matrix;
+
+	mediump vec4 ambient_light_color;
+	mediump vec4 bg_color;
+
+	mediump vec4 fog_color_enabled;
+	mediump vec4 fog_sun_color_amount;
+
+	mediump float ambient_energy;
+	mediump float bg_energy;
+
+	mediump float z_offset;
+	mediump float z_slope_scale;
+	highp float shadow_dual_paraboloid_render_zfar;
+	highp float shadow_dual_paraboloid_render_side;
+
+	highp vec2 viewport_size;
+	highp vec2 screen_pixel_size;
+	highp vec2 shadow_atlas_pixel_size;
+	highp vec2 directional_shadow_pixel_size;
+
+	highp float time;
+	highp float z_far;
+	mediump float reflection_multiplier;
+	mediump float subsurface_scatter_width;
+	mediump float ambient_occlusion_affect_light;
+	mediump float ambient_occlusion_affect_ao_channel;
+	mediump float opaque_prepass_threshold;
+
+	bool fog_depth_enabled;
+	highp float fog_depth_begin;
+	highp float fog_depth_end;
+	mediump float fog_density;
+	highp float fog_depth_curve;
+	bool fog_transmit_enabled;
+	highp float fog_transmit_curve;
+	bool fog_height_enabled;
+	highp float fog_height_min;
+	highp float fog_height_max;
+	highp float fog_height_curve;
+};
+
+uniform highp mat4 world_transform;
+
+/* Varyings */
+
+out vec3 normal_interp;
+
+#if defined(ENABLE_COLOR_INTERP)
+out vec4 color_interp;
+#endif
+
+#if defined(ENABLE_UV_INTERP)
+out vec2 uv_interp;
+#endif
+
+#if defined(ENABLE_UV2_INTERP) || defined(USE_LIGHTMAP)
+out vec2 uv2_interp;
+#endif
+
+#if defined(ENABLE_TANGENT_INTERP) || defined(ENABLE_NORMALMAP) || defined(LIGHT_USE_ANISOTROPY)
+out vec3 tangent_interp;
+out vec3 binormal_interp;
+#endif
+
+/* Material Uniforms */
+
+#if defined(USE_MATERIAL)
+
+/* clang-format off */
+layout(std140) uniform UniformData { // ubo:1
+
+MATERIAL_UNIFORMS
+
+};
+/* clang-format on */
+
+#endif
+
+/* clang-format off */
+
+GEOMETRY_SHADER_GLOBALS
+
+/* clang-format on */
+
+vec4 tpos(float x, float y) {
+	return projection_matrix * (camera_inverse_matrix * world_transform) * vec4(x, y, 0, 0);
+}
+
+vec4 tpos(vec2 v) {
+	return projection_matrix * (camera_inverse_matrix * world_transform) * vec4(v.x, v.y, 0, 0);
+}
+
+vec4 tpos(float x, float y, float z) {
+	return projection_matrix * (camera_inverse_matrix * world_transform) * vec4(x, y, z, 0);
+}
+
+vec4 tpos(vec3 v) {
+	return projection_matrix * (camera_inverse_matrix * world_transform) * vec4(v.x, v.y, v.z, 0);
+}
+
+vec4 tpos(float x, float y, float z, float w) {
+	return projection_matrix * (camera_inverse_matrix * world_transform) * vec4(x, y, z, w);
+}
+
+vec4 tpos(vec4 v) {
+	return projection_matrix * (camera_inverse_matrix * world_transform) * vec4(v.x, v.y, v.z, v.w);
+}
+
+void main() {
+	int index = 0;
+
+	highp mat4 world_matrix = world_transform;
+
+	highp mat4 modelview = camera_inverse_matrix * world_matrix;
+
+	{
+		/* clang-format off */
+
+GEOMETRY_SHADER_CODE
+
+		/* clang-format on */
+	}
 }
 
 /* clang-format off */

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -134,6 +134,11 @@ void ShaderTextEditor::_load_theme_settings() {
 
 			keywords.push_back(ShaderTypes::get_singleton()->get_modes(VisualServer::ShaderMode(shader->get_mode()))[i]);
 		}
+
+		for (int i = 0; i < ShaderTypes::get_singleton()->get_ranges(VisualServer::ShaderMode(shader->get_mode())).size(); i++) {
+
+			keywords.push_back(ShaderTypes::get_singleton()->get_ranges(VisualServer::ShaderMode(shader->get_mode()))[i]);
+		}
 	}
 
 	for (List<String>::Element *E = keywords.front(); E; E = E->next()) {
@@ -173,7 +178,7 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<String> 
 	ShaderLanguage sl;
 	String calltip;
 
-	Error err = sl.complete(p_code, ShaderTypes::get_singleton()->get_functions(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_modes(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_types(), r_options, calltip);
+	Error err = sl.complete(p_code, ShaderTypes::get_singleton()->get_functions(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_modes(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_ranges(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_types(), r_options, calltip);
 	if (err != OK)
 		ERR_PRINT("Shaderlang complete failed");
 
@@ -192,7 +197,7 @@ void ShaderTextEditor::_validate_script() {
 
 	ShaderLanguage sl;
 
-	Error err = sl.compile(code, ShaderTypes::get_singleton()->get_functions(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_modes(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_types());
+	Error err = sl.compile(code, ShaderTypes::get_singleton()->get_functions(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_modes(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_ranges(VisualServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_types());
 
 	if (err != OK) {
 		String error_text = "error(" + itos(sl.get_error_line()) + "): " + sl.get_error_text();

--- a/main/tests/test_shader_lang.cpp
+++ b/main/tests/test_shader_lang.cpp
@@ -328,8 +328,9 @@ MainLoop *test() {
 	rm.push_back("popo");
 	Set<String> types;
 	types.insert("spatial");
+	Vector<StringName> rr;
 
-	Error err = sl.compile(code, dt, rm, types);
+	Error err = sl.compile(code, dt, rm, rr, types);
 
 	if (err) {
 

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -495,6 +495,7 @@ public:
 		Map<StringName, Varying> varyings;
 		Map<StringName, Uniform> uniforms;
 		Vector<StringName> render_modes;
+		Map<StringName, int> render_ranges;
 
 		Vector<Function> functions;
 
@@ -670,7 +671,7 @@ private:
 
 	Node *_parse_and_reduce_expression(BlockNode *p_block, const Map<StringName, BuiltInInfo> &p_builtin_types);
 	Error _parse_block(BlockNode *p_block, const Map<StringName, BuiltInInfo> &p_builtin_types, bool p_just_one = false, bool p_can_break = false, bool p_can_continue = false);
-	Error _parse_shader(const Map<StringName, FunctionInfo> &p_functions, const Vector<StringName> &p_render_modes, const Set<String> &p_shader_types);
+	Error _parse_shader(const Map<StringName, FunctionInfo> &p_functions, const Vector<StringName> &p_render_modes, const Vector<StringName> &p_ranges, const Set<String> &p_shader_types);
 
 public:
 	//static void get_keyword_list(ShaderType p_type,List<String> *p_keywords);
@@ -678,8 +679,8 @@ public:
 	void clear();
 
 	static String get_shader_type(const String &p_code);
-	Error compile(const String &p_code, const Map<StringName, FunctionInfo> &p_functions, const Vector<StringName> &p_render_modes, const Set<String> &p_shader_types);
-	Error complete(const String &p_code, const Map<StringName, FunctionInfo> &p_functions, const Vector<StringName> &p_render_modes, const Set<String> &p_shader_types, List<String> *r_options, String &r_call_hint);
+	Error compile(const String &p_code, const Map<StringName, FunctionInfo> &p_functions, const Vector<StringName> &p_render_modes, const Vector<StringName> &p_ranges, const Set<String> &p_shader_types);
+	Error complete(const String &p_code, const Map<StringName, FunctionInfo> &p_functions, const Vector<StringName> &p_render_modes, const Vector<StringName> &p_ranges, const Set<String> &p_shader_types, List<String> *r_options, String &r_call_hint);
 
 	String get_error_text();
 	int get_error_line();

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -40,6 +40,11 @@ const Vector<StringName> &ShaderTypes::get_modes(VS::ShaderMode p_mode) {
 	return shader_modes[p_mode].modes;
 }
 
+const Vector<StringName> &ShaderTypes::get_ranges(VS::ShaderMode p_mode) {
+
+	return shader_modes[p_mode].ranges;
+}
+
 const Set<String> &ShaderTypes::get_types() {
 	return shader_types;
 }
@@ -55,6 +60,8 @@ ShaderTypes::ShaderTypes() {
 	singleton = this;
 
 	/*************** SPATIAL ***********************/
+
+	// SPATIAL-VERTEX
 
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["VERTEX"] = ShaderLanguage::TYPE_VEC3;
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["NORMAL"] = ShaderLanguage::TYPE_VEC3;
@@ -80,6 +87,44 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["VIEWPORT_SIZE"] = constt(ShaderLanguage::TYPE_VEC2);
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["OUTPUT_IS_SRGB"] = constt(ShaderLanguage::TYPE_BOOL);
+
+	// SPATIAL-GEOMETRY
+
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["LENGTH"] = constt(ShaderLanguage::TYPE_INT);
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["INDEX"] = ShaderLanguage::TYPE_INT;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["IN_VERTEX"] = constt(ShaderLanguage::TYPE_VEC4);
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["OUT_VERTEX"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["OUT_NORMAL"] = ShaderLanguage::TYPE_VEC3;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["OUT_TANGENT"] = ShaderLanguage::TYPE_VEC3;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["OUT_BINORMAL"] = ShaderLanguage::TYPE_VEC3;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["OUT_UV"] = ShaderLanguage::TYPE_VEC2;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["OUT_UV2"] = ShaderLanguage::TYPE_VEC2;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["OUT_COLOR"] = ShaderLanguage::TYPE_VEC4;
+
+	//builtins
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["WORLD_MATRIX"] = ShaderLanguage::TYPE_MAT4;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["INV_CAMERA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["CAMERA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["PROJECTION_MATRIX"] = ShaderLanguage::TYPE_MAT4;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["MODELVIEW_MATRIX"] = ShaderLanguage::TYPE_MAT4;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["INV_PROJECTION_MATRIX"] = ShaderLanguage::TYPE_MAT4;
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["VIEWPORT_SIZE"] = constt(ShaderLanguage::TYPE_VEC2);
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].built_ins["OUTPUT_IS_SRGB"] = constt(ShaderLanguage::TYPE_BOOL);
+	shader_modes[VS::SHADER_SPATIAL].functions["geometry"].can_discard = false;
+
+	//ranges
+	shader_modes[VS::SHADER_SPATIAL].ranges.push_back("geometry_max_vertices");
+
+	//modes
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("geometry_in_points");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("geometry_in_lines");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("geometry_in_triangles");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("geometry_out_points");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("geometry_out_lines");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("geometry_out_triangles");
+
+	// SPATIAL-FRAGMENT
 
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["VERTEX"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["FRAGCOORD"] = constt(ShaderLanguage::TYPE_VEC4);
@@ -116,8 +161,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["POINT_COORD"] = constt(ShaderLanguage::TYPE_VEC2);
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["ALPHA_SCISSOR"] = ShaderLanguage::TYPE_FLOAT;
 
-	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["OUTPUT_IS_SRGB"] = constt(ShaderLanguage::TYPE_BOOL);
-
+	//builtins
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["WORLD_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["INV_CAMERA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["CAMERA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
@@ -125,7 +169,10 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["INV_PROJECTION_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["VIEWPORT_SIZE"] = constt(ShaderLanguage::TYPE_VEC2);
+	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].built_ins["OUTPUT_IS_SRGB"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[VS::SHADER_SPATIAL].functions["fragment"].can_discard = true;
+
+	// SPATIAL-LIGHT
 
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].built_ins["WORLD_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].built_ins["INV_CAMERA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
@@ -135,6 +182,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].built_ins["VIEWPORT_SIZE"] = constt(ShaderLanguage::TYPE_VEC2);
 
+	//builtins
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].built_ins["FRAGCOORD"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].built_ins["NORMAL"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].built_ins["VIEW"] = constt(ShaderLanguage::TYPE_VEC3);
@@ -149,6 +197,8 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].built_ins["OUTPUT_IS_SRGB"] = constt(ShaderLanguage::TYPE_BOOL);
 
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].can_discard = true;
+
+	// RENDER_MODES
 
 	//order used puts first enum mode (default) first
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_mix");
@@ -192,6 +242,8 @@ ShaderTypes::ShaderTypes() {
 
 	/************ CANVAS ITEM **************************/
 
+	// CANVAS-ITEM-VERTEX
+
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["VERTEX"] = ShaderLanguage::TYPE_VEC2;
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["UV"] = ShaderLanguage::TYPE_VEC2;
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["COLOR"] = ShaderLanguage::TYPE_VEC4;
@@ -205,6 +257,35 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["AT_LIGHT_PASS"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["TEXTURE_PIXEL_SIZE"] = constt(ShaderLanguage::TYPE_VEC2);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].can_discard = false;
+
+	// CANVAS-ITEM-GEOMETRY
+
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["LENGTH"] = constt(ShaderLanguage::TYPE_INT);
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["INDEX"] = ShaderLanguage::TYPE_INT;
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["IN_VERTEX"] = constt(ShaderLanguage::TYPE_VEC4);
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["OUT_VERTEX"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["OUT_COLOR"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["OUT_UV"] = ShaderLanguage::TYPE_VEC2;
+
+	//builtins
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["WORLD_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["PROJECTION_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["EXTRA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["geometry"].can_discard = false;
+
+	//ranges
+	shader_modes[VS::SHADER_CANVAS_ITEM].ranges.push_back("geometry_max_vertices");
+
+	//modes
+	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("geometry_in_points");
+	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("geometry_in_lines");
+	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("geometry_in_triangles");
+	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("geometry_out_points");
+	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("geometry_out_lines");
+	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("geometry_out_triangles");
+
+	// CANVAS-ITEM-FRAGMENT
 
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["fragment"].built_ins["FRAGCOORD"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["fragment"].built_ins["NORMAL"] = ShaderLanguage::TYPE_VEC3;
@@ -223,6 +304,8 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["fragment"].built_ins["SCREEN_TEXTURE"] = constt(ShaderLanguage::TYPE_SAMPLER2D);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["fragment"].can_discard = true;
 
+	// CANVAS-ITEM-LIGHT
+
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["light"].built_ins["FRAGCOORD"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["light"].built_ins["NORMAL"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["light"].built_ins["UV"] = constt(ShaderLanguage::TYPE_VEC2);
@@ -239,6 +322,8 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["light"].built_ins["POINT_COORD"] = constt(ShaderLanguage::TYPE_VEC2);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["light"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["light"].can_discard = true;
+
+	// RENDER_MODES
 
 	shader_modes[VS::SHADER_CANVAS_ITEM].modes.push_back("skip_vertex_transform");
 

--- a/servers/visual/shader_types.h
+++ b/servers/visual/shader_types.h
@@ -41,6 +41,7 @@ class ShaderTypes {
 
 		Map<StringName, ShaderLanguage::FunctionInfo> functions;
 		Vector<StringName> modes;
+		Vector<StringName> ranges;
 	};
 
 	Map<VS::ShaderMode, Type> shader_modes;
@@ -54,6 +55,7 @@ public:
 
 	const Map<StringName, ShaderLanguage::FunctionInfo> &get_functions(VS::ShaderMode p_mode);
 	const Vector<StringName> &get_modes(VS::ShaderMode p_mode);
+	const Vector<StringName> &get_ranges(VS::ShaderMode p_mode);
 	const Set<String> &get_types();
 
 	ShaderTypes();


### PR DESCRIPTION
This PR is adding the geometry shader support. I decided to try to create it and (after several hours of moderate suffering) I get success ! Fix #10817

![image](https://user-images.githubusercontent.com/3036176/56564905-c03aa480-65b7-11e9-839c-2c4c563ee536.png)

The geometry shader is optional stage between vertex and fragment and can be used to achieve complex effects which are almost impossible to replicate without it. 

A basic GLSL shader which replicate the surface on which it applyed, has looking like this :

```
layout(triangles) in;
layout(triangle_strip, max_vertices=3) out;

void main()
{	
  for(int i=0; i<gl_in.length(); i++)
  {
    gl_Position = gl_in[i].gl_Position;
    EmitVertex();
  }
  EndPrimitive();
}  
```

in the proposal geometry shader for similar code currently looking like this:

```
shader_type spatial;
render_mode geometry_in_triangles, geometry_out_triangles, geometry_max_vertices(3);

void geometry()
{
	for(int i = 0; i < LENGTH; i++)
	{
		INDEX = i;
		OUT_VERTEX = IN_VERTEX;
		EmitVertex();
	} 
	
	EndPrimitive();
}
```
## Current Parts:

- IN_VERTEX - internally this is array of vertexes in generated primitive. It's vec4 type.
- INDEX - index of the primitive applied to IN_VERTEX and varyings, 0 by default
- OUT_VERTEX - the output for the vertex(should be setted up before EmitVertex(). It's vec4 type.
- OUT_NORMAL,OUT_BINORMAL,OUT_TANGENT,OUT_UV,OUT_UV2,OUT_COLOR - they are similar to their alternatives in Vertex shaders, use them before EmitVertex to setup your geometry.
- EmitVertex(), EndPrimitive() - these GLSL functions are required to create and send primitives from the geometry shader.

## New render mode flags

- geometry_in_points
- geometry_in_lines
- geometry_in_triangles
- geometry_out_points
- geometry_out_lines
- geometry_out_triangles

These flags contolling the type of the geometry, 'in' types should be used on geometry with this type, otherwise the output will be invisible, while 'out' can be used freely.

- geometry_max_vertices

This mode is required to be defined before usage of geometry shader. The maximum value can be larger than actual invokation. The larger value can cause geometry shader crash due to increased amount of shader inputs.

This flag also belongs to new "range" render mode family. You need to specify an integer constant in quotes after it. 

## Notes

- Currently travis / appveyor cannot accept this due to changed signature of the input function in the GLES3 shader headers. You should manually removes auto-generated shader headers from your drivers/gles3/shaders folder before compile.

- Only spatial shader mode for now, no visual shader support (yet) of course.. 

- If you merge this PR, you can run this demo - 
[blast.zip](https://github.com/godotengine/godot/files/3103238/blast.zip)

## Current goals

- [x] Configurable max_vertices
- [x] CanvasItem shader support

## Q/A



### How to pass data from Vertex Shader to Geometry Shader ?

In order to simplify the internal code the embedded varyings such as COLOR or NORMAL are not defined, but you can define it yourself using varyings. Note that each varying is internally converted into array type for using with geometry shader, so you should configurate max_vertices(WIP) amount in render_mode if you dont want to reach a hardware limit.

For example to pass Color use code like this:

```
varying vec4 test;

void vertex()
{
	COLOR = vec4(1, 0, 0, 1);	
	test = COLOR;
}

void geometry()
{
	for(int i = 0; i < LENGTH; i++)
	{
		INDEX = i;
		OUT_VERTEX = IN_VERTEX;
		OUT_COLOR = test;
		EmitVertex();
	}
	
	EndPrimitive();
}
```

### My initial geometry is dissappear !?

The geometry shader override the output vertexes of the Vertex shader, so you need to generate it again, to replace it with correct COLOR, UV, NORMAL etc.. For example you wanted to add geometry shader to the following shader code -

```
shader_type spatial;

void vertex()
{
	COLOR = vec4(1, 1, 1, 1);
}

void fragment()
{
	ALBEDO = COLOR.rgb;
}
```

To replicate the result - for example

![image](https://user-images.githubusercontent.com/3036176/56499474-36cf9780-650f-11e9-854b-099c729abe71.png)

you need to write similar code

```
shader_type spatial;

render_mode geometry_max_vertices(3);

varying vec4 color;
varying vec3 normal;

void vertex()
{
	COLOR = vec4(1, 1, 1, 1);
	color = COLOR;
	normal = NORMAL;
}

void geometry()
{
        // Duplicate initial geometry inputs

	for(int i = 0; i < LENGTH; i++)
	{
		INDEX = i;
		OUT_VERTEX = IN_VERTEX;
		OUT_COLOR = color;
		OUT_NORMAL = normal;
		EmitVertex();
	}
	EndPrimitive();

        // Your code 
}

void fragment()
{
	ALBEDO = COLOR.rgb;
}
```


## Screenshots

![image](https://user-images.githubusercontent.com/3036176/56461676-9ae34600-63bf-11e9-8531-cd34ff5b2c43.png)

Lines generation can be used to visualize geometry normals

![image](https://user-images.githubusercontent.com/3036176/56560228-81532180-65ac-11e9-945b-a6588b8be9c8.png)

Points generation

![image](https://user-images.githubusercontent.com/3036176/56512194-52e72f00-6537-11e9-8c18-f8ca35c62e3a.png)