### PR TITLE
Fix TGA indexed images loaded with flipped color table

### DIFF
--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -148,9 +148,11 @@ Error ImageLoaderTGA::convert_to_image(Ref<Image> p_image, const uint8_t *p_buff
 					uint8_t a = 0xff;
 
 					if (p_header.color_map_depth == 24) {
-						r = (p_palette[(index * 3) + 0]);
+						// Due to low-high byte order, the color table must be
+						// read in the same order as image data (little endian)
+						r = (p_palette[(index * 3) + 2]);
 						g = (p_palette[(index * 3) + 1]);
-						b = (p_palette[(index * 3) + 2]);
+						b = (p_palette[(index * 3) + 0]);
 					} else {
 						return ERR_INVALID_DATA;
 					}


### PR DESCRIPTION
This fixes incorrect color table lookup where red and blue channels were flipped.

![tga-before-after](https://user-images.githubusercontent.com/17108460/56469421-4b922980-6442-11e9-83db-52e8bb371d6a.png)

The fix was part of #28013.

Test project:
[tga-indexed.zip](https://github.com/godotengine/godot/files/3101217/tga-indexed.zip)
