### PR TITLE
Fix selection undo

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5340,6 +5340,9 @@ void TextEdit::undo() {
 
 	TextOperation op = undo_stack_pos->get();
 	_do_text_op(op, true);
+	if (op.from_line != op.to_line || op.to_column != op.from_column + 1)
+		select(op.from_line, op.from_column, op.to_line, op.to_column);
+
 	current_op.version = op.prev_version;
 	if (undo_stack_pos->get().chain_backward) {
 		while (true) {


### PR DESCRIPTION
Properly resets text selection when an undo occurs
Fully fixes #14835