### PR TITLE
Solution for memory overflow when too many scripts are open at once

### DIFF
--- a/core/message_queue.h
+++ b/core/message_queue.h
@@ -40,7 +40,7 @@ class MessageQueue {
 
 	enum {
 
-		DEFAULT_QUEUE_SIZE_KB = 1024
+		DEFAULT_QUEUE_SIZE_KB = 4096
 	};
 
 	enum {


### PR DESCRIPTION
Simple fix for #17693 
Bypasses issue by increasing memory buffer for error queue size