### PR TITLE
Move enum to int casts from call site into macros, e.g. ERR_FAIL_INDEX

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -124,22 +124,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns.
  */
-#define ERR_FAIL_INDEX(m_index, m_size)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                 \
-	} else                                                                                                      \
+#define ERR_FAIL_INDEX(m_index, m_size)                                                                                                             \
+	if (unlikely(static_cast<int>(m_index) < 0 || static_cast<int>(m_index) >= static_cast<int>(m_size))) {                                         \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<int>(m_index), static_cast<int>(m_size), _STR(m_index), _STR(m_size)); \
+		return;                                                                                                                                     \
+	} else                                                                                                                                          \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return;                                                                                                                   \
-	} else                                                                                                                        \
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                                                    \
+	if (unlikely(static_cast<int>(m_index) < 0 || static_cast<int>(m_index) >= static_cast<int>(m_size))) {                                                           \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<int>(m_index), static_cast<int>(m_size), _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return;                                                                                                                                                       \
+	} else                                                                                                                                                            \
 		((void)0)
 
 /**
@@ -149,22 +149,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                        \
-	} else                                                                                                      \
+#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                                                 \
+	if (unlikely(static_cast<int>(m_index) < 0 || static_cast<int>(m_index) >= static_cast<int>(m_size))) {                                         \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<int>(m_index), static_cast<int>(m_size), _STR(m_index), _STR(m_size)); \
+		return m_retval;                                                                                                                            \
+	} else                                                                                                                                          \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                    \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                                                        \
+	if (unlikely(static_cast<int>(m_index) < 0 || static_cast<int>(m_index) >= static_cast<int>(m_size))) {                                                           \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<int>(m_index), static_cast<int>(m_size), _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                                                              \
+	} else                                                                                                                                                            \
 		((void)0)
 
 /**
@@ -175,11 +175,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the application crashes.
  */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                  \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                               \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
-		GENERATE_TRAP();                                                                                                  \
-	} else                                                                                                                \
+#define CRASH_BAD_INDEX(m_index, m_size)                                                                                                                      \
+	if (unlikely(static_cast<int>(m_index) < 0 || static_cast<int>(m_index) >= static_cast<int>(m_size))) {                                                   \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<int>(m_index), static_cast<int>(m_size), _STR(m_index), _STR(m_size), "", true); \
+		GENERATE_TRAP();                                                                                                                                      \
+	} else                                                                                                                                                    \
 		((void)0)
 
 /**
@@ -189,11 +189,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                     \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                             \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
-		GENERATE_TRAP();                                                                                                                \
-	} else                                                                                                                              \
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                                                         \
+	if (unlikely(static_cast<int>(m_index) < 0 || static_cast<int>(m_index) >= static_cast<int>(m_size))) {                                                                 \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<int>(m_index), static_cast<int>(m_size), _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
+		GENERATE_TRAP();                                                                                                                                                    \
+	} else                                                                                                                                                                  \
 		((void)0)
 
 // Unsigned integer index out of bounds error macros.
@@ -205,22 +205,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                      \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                 \
-	} else                                                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                                                                      \
+	if (unlikely(static_cast<unsigned int>(m_index) >= static_cast<unsigned int>(m_size))) {                                                                          \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<unsigned int>(m_index), static_cast<unsigned int>(m_size), _STR(m_index), _STR(m_size)); \
+		return;                                                                                                                                                       \
+	} else                                                                                                                                                            \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                       \
-	if (unlikely((m_index) >= (m_size))) {                                                                                        \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return;                                                                                                                   \
-	} else                                                                                                                        \
+#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                                                             \
+	if (unlikely(static_cast<unsigned int>(m_index) >= static_cast<unsigned int>(m_size))) {                                                                                            \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<unsigned int>(m_index), static_cast<unsigned int>(m_size), _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return;                                                                                                                                                                         \
+	} else                                                                                                                                                                              \
 		((void)0)
 
 /**
@@ -230,22 +230,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                    \
-	if (unlikely((m_index) >= (m_size))) {                                                                      \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                        \
-	} else                                                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                                                                          \
+	if (unlikely(static_cast<unsigned int>(m_index) >= static_cast<unsigned int>(m_size))) {                                                                          \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<unsigned int>(m_index), static_cast<unsigned int>(m_size), _STR(m_index), _STR(m_size)); \
+		return m_retval;                                                                                                                                              \
+	} else                                                                                                                                                            \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                           \
-	if (unlikely((m_index) >= (m_size))) {                                                                                        \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                                                                 \
+	if (unlikely(static_cast<unsigned int>(m_index) >= static_cast<unsigned int>(m_size))) {                                                                                            \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<unsigned int>(m_index), static_cast<unsigned int>(m_size), _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                                                                                \
+	} else                                                                                                                                                                              \
 		((void)0)
 
 /**
@@ -256,11 +256,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                         \
-	if (unlikely((m_index) >= (m_size))) {                                                                                \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
-		GENERATE_TRAP();                                                                                                  \
-	} else                                                                                                                \
+#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                                                                               \
+	if (unlikely(static_cast<unsigned int>(m_index) >= static_cast<unsigned int>(m_size))) {                                                                                    \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<unsigned int>(m_index), static_cast<unsigned int>(m_size), _STR(m_index), _STR(m_size), "", true); \
+		GENERATE_TRAP();                                                                                                                                                        \
+	} else                                                                                                                                                                      \
 		((void)0)
 
 /**
@@ -270,11 +270,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                            \
-	if (unlikely((m_index) >= (m_size))) {                                                                                              \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
-		GENERATE_TRAP();                                                                                                                \
-	} else                                                                                                                              \
+#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                                                                  \
+	if (unlikely(static_cast<unsigned int>(m_index) >= static_cast<unsigned int>(m_size))) {                                                                                                  \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, static_cast<unsigned int>(m_index), static_cast<unsigned int>(m_size), _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
+		GENERATE_TRAP();                                                                                                                                                                      \
+	} else                                                                                                                                                                                    \
 		((void)0)
 
 // Null reference error macros.

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -85,7 +85,7 @@ Input *Input::get_singleton() {
 }
 
 void Input::set_mouse_mode(MouseMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 5);
+	ERR_FAIL_INDEX(p_mode, 5);
 	set_mouse_mode_func(p_mode);
 }
 

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -442,13 +442,13 @@ void Camera2D::clear_current() {
 }
 
 void Camera2D::set_limit(Side p_side, int p_limit) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	limit[p_side] = p_limit;
 	update();
 }
 
 int Camera2D::get_limit(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return limit[p_side];
 }
 
@@ -462,13 +462,13 @@ bool Camera2D::is_limit_smoothing_enabled() const {
 }
 
 void Camera2D::set_drag_margin(Side p_side, real_t p_drag_margin) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	drag_margin[p_side] = p_drag_margin;
 	update();
 }
 
 real_t Camera2D::get_drag_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return drag_margin[p_side];
 }
 

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -211,7 +211,7 @@ Vector<Point2> CollisionPolygon2D::get_polygon() const {
 }
 
 void CollisionPolygon2D::set_build_mode(BuildMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 2);
+	ERR_FAIL_INDEX(p_mode, 2);
 	build_mode = p_mode;
 	if (parent) {
 		_build_polygon();

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -835,7 +835,7 @@ float AudioStreamPlayer3D::get_attenuation_filter_db() const {
 }
 
 void AudioStreamPlayer3D::set_attenuation_model(AttenuationModel p_model) {
-	ERR_FAIL_INDEX((int)p_model, 4);
+	ERR_FAIL_INDEX(p_model, 4);
 	attenuation_model = p_model;
 }
 
@@ -844,7 +844,7 @@ AudioStreamPlayer3D::AttenuationModel AudioStreamPlayer3D::get_attenuation_model
 }
 
 void AudioStreamPlayer3D::set_out_of_range_mode(OutOfRangeMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 2);
+	ERR_FAIL_INDEX(p_mode, 2);
 	out_of_range_mode = p_mode;
 }
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -453,7 +453,7 @@ Window *Control::get_parent_window() const {
 }
 
 void Control::set_layout_direction(Control::LayoutDirection p_direction) {
-	ERR_FAIL_INDEX((int)p_direction, 4);
+	ERR_FAIL_INDEX(p_direction, 4);
 
 	data.layout_dir = p_direction;
 	data.is_rtl_dirty = true;
@@ -1180,7 +1180,7 @@ void Control::_size_changed() {
 }
 
 void Control::set_anchor(Side p_side, real_t p_anchor, bool p_keep_offset, bool p_push_opposite_anchor) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 
 	Rect2 parent_rect = get_parent_anchorable_rect();
 	real_t parent_range = (p_side == SIDE_LEFT || p_side == SIDE_RIGHT) ? parent_rect.size.x : parent_rect.size.y;
@@ -1221,7 +1221,7 @@ void Control::set_anchor_and_offset(Side p_side, real_t p_anchor, real_t p_pos, 
 }
 
 void Control::set_anchors_preset(LayoutPreset p_preset, bool p_keep_offsets) {
-	ERR_FAIL_INDEX((int)p_preset, 16);
+	ERR_FAIL_INDEX(p_preset, 16);
 
 	//Left
 	switch (p_preset) {
@@ -1337,8 +1337,8 @@ void Control::set_anchors_preset(LayoutPreset p_preset, bool p_keep_offsets) {
 }
 
 void Control::set_offsets_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode, int p_margin) {
-	ERR_FAIL_INDEX((int)p_preset, 16);
-	ERR_FAIL_INDEX((int)p_resize_mode, 4);
+	ERR_FAIL_INDEX(p_preset, 16);
+	ERR_FAIL_INDEX(p_resize_mode, 4);
 
 	// Calculate the size if the node is not resized
 	Size2 min_size = get_minimum_size();
@@ -1477,13 +1477,13 @@ void Control::set_anchors_and_offsets_preset(LayoutPreset p_preset, LayoutPreset
 }
 
 real_t Control::get_anchor(Side p_side) const {
-	ERR_FAIL_INDEX_V(int(p_side), 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	return data.anchor[p_side];
 }
 
 void Control::set_offset(Side p_side, real_t p_value) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 
 	data.offset[p_side] = p_value;
 	_size_changed();
@@ -1502,7 +1502,7 @@ void Control::set_end(const Size2 &p_point) {
 }
 
 real_t Control::get_offset(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 
 	return data.offset[p_side];
 }
@@ -1768,7 +1768,7 @@ void Control::remove_theme_constant_override(const StringName &p_name) {
 }
 
 void Control::set_focus_mode(FocusMode p_focus_mode) {
-	ERR_FAIL_INDEX((int)p_focus_mode, 3);
+	ERR_FAIL_INDEX(p_focus_mode, 3);
 
 	if (is_inside_tree() && p_focus_mode == FOCUS_NONE && data.focus_mode != FOCUS_NONE && has_focus()) {
 		release_focus();
@@ -2108,7 +2108,7 @@ Control *Control::make_custom_tooltip(const String &p_text) const {
 }
 
 void Control::set_default_cursor_shape(CursorShape p_shape) {
-	ERR_FAIL_INDEX(int(p_shape), CURSOR_MAX);
+	ERR_FAIL_INDEX(p_shape, CURSOR_MAX);
 
 	data.default_cursor = p_shape;
 }
@@ -2132,12 +2132,12 @@ String Control::_get_tooltip() const {
 }
 
 void Control::set_focus_neighbor(Side p_side, const NodePath &p_neighbor) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	data.focus_neighbor[p_side] = p_neighbor;
 }
 
 NodePath Control::get_focus_neighbor(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, NodePath());
+	ERR_FAIL_INDEX_V(p_side, 4, NodePath());
 	return data.focus_neighbor[p_side];
 }
 
@@ -2160,7 +2160,7 @@ NodePath Control::get_focus_previous() const {
 #define MAX_NEIGHBOR_SEARCH_COUNT 512
 
 Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
-	ERR_FAIL_INDEX_V((int)p_side, 4, nullptr);
+	ERR_FAIL_INDEX_V(p_side, 4, nullptr);
 
 	if (p_count >= MAX_NEIGHBOR_SEARCH_COUNT) {
 		return nullptr;
@@ -2626,7 +2626,7 @@ bool Control::is_clipping_contents() {
 }
 
 void Control::set_h_grow_direction(GrowDirection p_direction) {
-	ERR_FAIL_INDEX((int)p_direction, 3);
+	ERR_FAIL_INDEX(p_direction, 3);
 
 	data.h_grow = p_direction;
 	_size_changed();
@@ -2637,7 +2637,7 @@ Control::GrowDirection Control::get_h_grow_direction() const {
 }
 
 void Control::set_v_grow_direction(GrowDirection p_direction) {
-	ERR_FAIL_INDEX((int)p_direction, 3);
+	ERR_FAIL_INDEX(p_direction, 3);
 
 	data.v_grow = p_direction;
 	_size_changed();

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -712,7 +712,7 @@ bool FileDialog::is_mode_overriding_title() const {
 }
 
 void FileDialog::set_file_mode(FileMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 5);
+	ERR_FAIL_INDEX(p_mode, 5);
 
 	mode = p_mode;
 	switch (mode) {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -490,7 +490,7 @@ ItemList::SelectMode ItemList::get_select_mode() const {
 }
 
 void ItemList::set_icon_mode(IconMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 2);
+	ERR_FAIL_INDEX(p_mode, 2);
 	if (icon_mode != p_mode) {
 		icon_mode = p_mode;
 		for (int i = 0; i < items.size(); i++) {

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -505,7 +505,7 @@ int Label::get_visible_line_count() const {
 }
 
 void Label::set_align(Align p_align) {
-	ERR_FAIL_INDEX((int)p_align, 4);
+	ERR_FAIL_INDEX(p_align, 4);
 	if (align != p_align) {
 		if (align == ALIGN_FILL || p_align == ALIGN_FILL) {
 			lines_dirty = true; // Reshape lines.
@@ -520,7 +520,7 @@ Label::Align Label::get_align() const {
 }
 
 void Label::set_valign(VAlign p_align) {
-	ERR_FAIL_INDEX((int)p_align, 4);
+	ERR_FAIL_INDEX(p_align, 4);
 	valign = p_align;
 	update();
 }

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -507,7 +507,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 }
 
 void LineEdit::set_align(Align p_align) {
-	ERR_FAIL_INDEX((int)p_align, 4);
+	ERR_FAIL_INDEX(p_align, 4);
 	if (align != p_align) {
 		align = p_align;
 		_shape();

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -106,14 +106,14 @@ Ref<Texture2D> NinePatchRect::get_texture() const {
 }
 
 void NinePatchRect::set_patch_margin(Side p_side, int p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	margin[p_side] = p_size;
 	update();
 	minimum_size_changed();
 }
 
 int NinePatchRect::get_patch_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return margin[p_side];
 }
 

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -55,14 +55,14 @@ Ref<Texture2D> TextureProgressBar::get_over_texture() const {
 }
 
 void TextureProgressBar::set_stretch_margin(Side p_side, int p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	stretch_margin[p_side] = p_size;
 	update();
 	minimum_size_changed();
 }
 
 int TextureProgressBar::get_stretch_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return stretch_margin[p_side];
 }
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1311,7 +1311,7 @@ bool Window::is_clamped_to_embedder() const {
 }
 
 void Window::set_layout_direction(Window::LayoutDirection p_direction) {
-	ERR_FAIL_INDEX((int)p_direction, 4);
+	ERR_FAIL_INDEX(p_direction, 4);
 
 	layout_dir = p_direction;
 	propagate_notification(Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1859,7 +1859,7 @@ void Animation::value_track_set_update_mode(int p_track, UpdateMode p_mode) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_VALUE);
-	ERR_FAIL_INDEX((int)p_mode, 4);
+	ERR_FAIL_INDEX(p_mode, 4);
 
 	ValueTrack *vt = static_cast<ValueTrack *>(t);
 	vt->update_mode = p_mode;

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -39,20 +39,20 @@ bool StyleBox::test_mask(const Point2 &p_point, const Rect2 &p_rect) const {
 }
 
 void StyleBox::set_default_margin(Side p_side, float p_value) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 
 	margin[p_side] = p_value;
 	emit_changed();
 }
 
 float StyleBox::get_default_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	return margin[p_side];
 }
 
 float StyleBox::get_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	if (margin[p_side] < 0) {
 		return get_style_margin(p_side);
@@ -126,20 +126,20 @@ Ref<Texture2D> StyleBoxTexture::get_texture() const {
 }
 
 void StyleBoxTexture::set_margin_size(Side p_side, float p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 
 	margin[p_side] = p_size;
 	emit_changed();
 }
 
 float StyleBoxTexture::get_margin_size(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	return margin[p_side];
 }
 
 float StyleBoxTexture::get_style_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	return margin[p_side];
 }
@@ -184,7 +184,7 @@ Size2 StyleBoxTexture::get_center_size() const {
 }
 
 void StyleBoxTexture::set_expand_margin_size(Side p_side, float p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	expand_margin[p_side] = p_size;
 	emit_changed();
 }
@@ -205,7 +205,7 @@ void StyleBoxTexture::set_expand_margin_size_all(float p_expand_margin_size) {
 }
 
 float StyleBoxTexture::get_expand_margin_size(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return expand_margin[p_side];
 }
 
@@ -223,7 +223,7 @@ Rect2 StyleBoxTexture::get_region_rect() const {
 }
 
 void StyleBoxTexture::set_h_axis_stretch_mode(AxisStretchMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 3);
+	ERR_FAIL_INDEX(p_mode, 3);
 	axis_h = p_mode;
 	emit_changed();
 }
@@ -233,7 +233,7 @@ StyleBoxTexture::AxisStretchMode StyleBoxTexture::get_h_axis_stretch_mode() cons
 }
 
 void StyleBoxTexture::set_v_axis_stretch_mode(AxisStretchMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 3);
+	ERR_FAIL_INDEX(p_mode, 3);
 	axis_v = p_mode;
 	emit_changed();
 }
@@ -342,13 +342,13 @@ int StyleBoxFlat::get_border_width_min() const {
 }
 
 void StyleBoxFlat::set_border_width(Side p_side, int p_width) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	border_width[p_side] = p_width;
 	emit_changed();
 }
 
 int StyleBoxFlat::get_border_width(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return border_width[p_side];
 }
 
@@ -379,18 +379,18 @@ void StyleBoxFlat::set_corner_radius_individual(const int radius_top_left, const
 }
 
 void StyleBoxFlat::set_corner_radius(const Corner p_corner, const int radius) {
-	ERR_FAIL_INDEX((int)p_corner, 4);
+	ERR_FAIL_INDEX(p_corner, 4);
 	corner_radius[p_corner] = radius;
 	emit_changed();
 }
 
 int StyleBoxFlat::get_corner_radius(const Corner p_corner) const {
-	ERR_FAIL_INDEX_V((int)p_corner, 4, 0);
+	ERR_FAIL_INDEX_V(p_corner, 4, 0);
 	return corner_radius[p_corner];
 }
 
 void StyleBoxFlat::set_expand_margin_size(Side p_side, float p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	expand_margin[p_side] = p_size;
 	emit_changed();
 }
@@ -411,7 +411,7 @@ void StyleBoxFlat::set_expand_margin_size_all(float p_expand_margin_size) {
 }
 
 float StyleBoxFlat::get_expand_margin_size(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 	return expand_margin[p_side];
 }
 
@@ -784,7 +784,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 }
 
 float StyleBoxFlat::get_style_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 	return border_width[p_side];
 }
 
@@ -950,7 +950,7 @@ void StyleBoxLine::_bind_methods() {
 }
 
 float StyleBoxLine::get_style_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 
 	if (vertical) {
 		if (p_side == SIDE_LEFT || p_side == SIDE_RIGHT) {

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3025,7 +3025,7 @@ String VisualShaderNodeUniform::get_uniform_name() const {
 }
 
 void VisualShaderNodeUniform::set_qualifier(VisualShaderNodeUniform::Qualifier p_qual) {
-	ERR_FAIL_INDEX(int(p_qual), int(QUAL_MAX));
+	ERR_FAIL_INDEX(p_qual, QUAL_MAX);
 	if (qualifier == p_qual) {
 		return;
 	}
@@ -3353,7 +3353,7 @@ bool VisualShaderNodeGroupBase::is_valid_port_name(const String &p_name) const {
 
 void VisualShaderNodeGroupBase::add_input_port(int p_id, int p_type, const String &p_name) {
 	ERR_FAIL_COND(has_input_port(p_id));
-	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
+	ERR_FAIL_INDEX(p_type, PORT_TYPE_MAX);
 	ERR_FAIL_COND(!is_valid_port_name(p_name));
 
 	String str = itos(p_id) + "," + itos(p_type) + "," + p_name + ";";
@@ -3429,7 +3429,7 @@ bool VisualShaderNodeGroupBase::has_input_port(int p_id) const {
 
 void VisualShaderNodeGroupBase::add_output_port(int p_id, int p_type, const String &p_name) {
 	ERR_FAIL_COND(has_output_port(p_id));
-	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
+	ERR_FAIL_INDEX(p_type, PORT_TYPE_MAX);
 	ERR_FAIL_COND(!is_valid_port_name(p_name));
 
 	String str = itos(p_id) + "," + itos(p_type) + "," + p_name + ";";
@@ -3513,7 +3513,7 @@ void VisualShaderNodeGroupBase::clear_output_ports() {
 
 void VisualShaderNodeGroupBase::set_input_port_type(int p_id, int p_type) {
 	ERR_FAIL_COND(!has_input_port(p_id));
-	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
+	ERR_FAIL_INDEX(p_type, PORT_TYPE_MAX);
 
 	if (input_ports[p_id].type == p_type) {
 		return;
@@ -3585,7 +3585,7 @@ String VisualShaderNodeGroupBase::get_input_port_name(int p_id) const {
 
 void VisualShaderNodeGroupBase::set_output_port_type(int p_id, int p_type) {
 	ERR_FAIL_COND(!has_output_port(p_id));
-	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
+	ERR_FAIL_INDEX(p_type, PORT_TYPE_MAX);
 
 	if (output_ports[p_id].type == p_type) {
 		return;

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -705,7 +705,7 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeTexture::set_source(Source p_source) {
-	ERR_FAIL_INDEX(int(p_source), int(SOURCE_MAX));
+	ERR_FAIL_INDEX(p_source, SOURCE_MAX);
 	if (source == p_source) {
 		return;
 	}
@@ -750,7 +750,7 @@ Ref<Texture2D> VisualShaderNodeTexture::get_texture() const {
 }
 
 void VisualShaderNodeTexture::set_texture_type(TextureType p_texture_type) {
-	ERR_FAIL_INDEX(int(p_texture_type), int(TYPE_MAX));
+	ERR_FAIL_INDEX(p_texture_type, TYPE_MAX);
 	if (texture_type == p_texture_type) {
 		return;
 	}
@@ -1107,7 +1107,7 @@ String VisualShaderNodeSample3D::generate_code(Shader::Mode p_mode, VisualShader
 }
 
 void VisualShaderNodeSample3D::set_source(Source p_source) {
-	ERR_FAIL_INDEX(int(p_source), int(SOURCE_MAX));
+	ERR_FAIL_INDEX(p_source, SOURCE_MAX);
 	if (source == p_source) {
 		return;
 	}
@@ -1404,7 +1404,7 @@ String VisualShaderNodeCubemap::get_input_port_default_hint(int p_port) const {
 }
 
 void VisualShaderNodeCubemap::set_source(Source p_source) {
-	ERR_FAIL_INDEX(int(p_source), int(SOURCE_MAX));
+	ERR_FAIL_INDEX(p_source, SOURCE_MAX);
 	if (source == p_source) {
 		return;
 	}
@@ -1427,7 +1427,7 @@ Ref<Cubemap> VisualShaderNodeCubemap::get_cube_map() const {
 }
 
 void VisualShaderNodeCubemap::set_texture_type(TextureType p_texture_type) {
-	ERR_FAIL_INDEX(int(p_texture_type), int(TYPE_MAX));
+	ERR_FAIL_INDEX(p_texture_type, TYPE_MAX);
 	if (texture_type == p_texture_type) {
 		return;
 	}
@@ -1554,7 +1554,7 @@ String VisualShaderNodeFloatOp::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeFloatOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_ENUM_SIZE));
+	ERR_FAIL_INDEX(p_op, OP_ENUM_SIZE);
 	if (op == p_op) {
 		return;
 	}
@@ -1658,7 +1658,7 @@ String VisualShaderNodeIntOp::generate_code(Shader::Mode p_mode, VisualShader::T
 }
 
 void VisualShaderNodeIntOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), OP_ENUM_SIZE);
+	ERR_FAIL_INDEX(p_op, OP_ENUM_SIZE);
 	if (op == p_op) {
 		return;
 	}
@@ -1774,7 +1774,7 @@ String VisualShaderNodeVectorOp::generate_code(Shader::Mode p_mode, VisualShader
 }
 
 void VisualShaderNodeVectorOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_ENUM_SIZE));
+	ERR_FAIL_INDEX(p_op, OP_ENUM_SIZE);
 	if (op == p_op) {
 		return;
 	}
@@ -1922,7 +1922,7 @@ String VisualShaderNodeColorOp::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeColorOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_MAX));
+	ERR_FAIL_INDEX(p_op, OP_MAX);
 	if (op == p_op) {
 		return;
 	}
@@ -2050,7 +2050,7 @@ String VisualShaderNodeTransformOp::generate_code(Shader::Mode p_mode, VisualSha
 }
 
 void VisualShaderNodeTransformOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_MAX));
+	ERR_FAIL_INDEX(p_op, OP_MAX);
 	if (op == p_op) {
 		return;
 	}
@@ -2134,7 +2134,7 @@ String VisualShaderNodeTransformVecMult::generate_code(Shader::Mode p_mode, Visu
 }
 
 void VisualShaderNodeTransformVecMult::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_MAX));
+	ERR_FAIL_INDEX(p_op, OP_MAX);
 	if (op == p_op) {
 		return;
 	}
@@ -2239,7 +2239,7 @@ String VisualShaderNodeFloatFunc::generate_code(Shader::Mode p_mode, VisualShade
 }
 
 void VisualShaderNodeFloatFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -2343,7 +2343,7 @@ String VisualShaderNodeIntFunc::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeIntFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -2474,7 +2474,7 @@ String VisualShaderNodeVectorFunc::generate_code(Shader::Mode p_mode, VisualShad
 }
 
 void VisualShaderNodeVectorFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -2607,7 +2607,7 @@ String VisualShaderNodeColorFunc::generate_code(Shader::Mode p_mode, VisualShade
 }
 
 void VisualShaderNodeColorFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -2683,7 +2683,7 @@ String VisualShaderNodeTransformFunc::generate_code(Shader::Mode p_mode, VisualS
 }
 
 void VisualShaderNodeTransformFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -2811,7 +2811,7 @@ String VisualShaderNodeUVFunc::generate_code(Shader::Mode p_mode, VisualShader::
 }
 
 void VisualShaderNodeUVFunc::set_function(VisualShaderNodeUVFunc::Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -3008,7 +3008,7 @@ String VisualShaderNodeScalarDerivativeFunc::generate_code(Shader::Mode p_mode, 
 }
 
 void VisualShaderNodeScalarDerivativeFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -3085,7 +3085,7 @@ String VisualShaderNodeVectorDerivativeFunc::generate_code(Shader::Mode p_mode, 
 }
 
 void VisualShaderNodeVectorDerivativeFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -3177,7 +3177,7 @@ String VisualShaderNodeClamp::generate_code(Shader::Mode p_mode, VisualShader::T
 }
 
 void VisualShaderNodeClamp::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX((int)p_op_type, int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -3382,7 +3382,7 @@ String VisualShaderNodeStep::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeStep::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -3506,7 +3506,7 @@ String VisualShaderNodeSmoothStep::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeSmoothStep::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -3728,7 +3728,7 @@ String VisualShaderNodeMix::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeMix::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -4045,7 +4045,7 @@ bool VisualShaderNodeFloatUniform::is_use_prop_slots() const {
 }
 
 void VisualShaderNodeFloatUniform::set_hint(Hint p_hint) {
-	ERR_FAIL_INDEX(int(p_hint), int(HINT_MAX));
+	ERR_FAIL_INDEX(p_hint, HINT_MAX);
 	if (hint == p_hint) {
 		return;
 	}
@@ -4236,7 +4236,7 @@ bool VisualShaderNodeIntUniform::is_use_prop_slots() const {
 }
 
 void VisualShaderNodeIntUniform::set_hint(Hint p_hint) {
-	ERR_FAIL_INDEX(int(p_hint), int(HINT_MAX));
+	ERR_FAIL_INDEX(p_hint, HINT_MAX);
 	if (hint == p_hint) {
 		return;
 	}
@@ -4903,7 +4903,7 @@ String VisualShaderNodeTextureUniform::generate_code(Shader::Mode p_mode, Visual
 }
 
 void VisualShaderNodeTextureUniform::set_texture_type(TextureType p_texture_type) {
-	ERR_FAIL_INDEX(int(p_texture_type), int(TYPE_MAX));
+	ERR_FAIL_INDEX(p_texture_type, TYPE_MAX);
 	if (texture_type == p_texture_type) {
 		return;
 	}
@@ -4916,7 +4916,7 @@ VisualShaderNodeTextureUniform::TextureType VisualShaderNodeTextureUniform::get_
 }
 
 void VisualShaderNodeTextureUniform::set_color_default(ColorDefault p_color_default) {
-	ERR_FAIL_INDEX(int(p_color_default), int(COLOR_DEFAULT_MAX));
+	ERR_FAIL_INDEX(p_color_default, COLOR_DEFAULT_MAX);
 	if (color_default == p_color_default) {
 		return;
 	}
@@ -5443,7 +5443,7 @@ String VisualShaderNodeSwitch::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeSwitch::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -5659,7 +5659,7 @@ String VisualShaderNodeIs::generate_code(Shader::Mode p_mode, VisualShader::Type
 }
 
 void VisualShaderNodeIs::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -5825,7 +5825,7 @@ String VisualShaderNodeCompare::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeCompare::set_comparison_type(ComparisonType p_comparison_type) {
-	ERR_FAIL_INDEX(int(p_comparison_type), int(CTYPE_MAX));
+	ERR_FAIL_INDEX(p_comparison_type, CTYPE_MAX);
 	if (comparison_type == p_comparison_type) {
 		return;
 	}
@@ -5867,7 +5867,7 @@ VisualShaderNodeCompare::ComparisonType VisualShaderNodeCompare::get_comparison_
 }
 
 void VisualShaderNodeCompare::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -5880,7 +5880,7 @@ VisualShaderNodeCompare::Function VisualShaderNodeCompare::get_function() const 
 }
 
 void VisualShaderNodeCompare::set_condition(Condition p_condition) {
-	ERR_FAIL_INDEX(int(p_condition), int(COND_MAX));
+	ERR_FAIL_INDEX(p_condition, COND_MAX);
 	if (condition == p_condition) {
 		return;
 	}
@@ -5991,7 +5991,7 @@ String VisualShaderNodeMultiplyAdd::generate_code(Shader::Mode p_mode, VisualSha
 }
 
 void VisualShaderNodeMultiplyAdd::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX((int)p_op_type, int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -6114,7 +6114,7 @@ bool VisualShaderNodeBillboard::is_show_prop_names() const {
 }
 
 void VisualShaderNodeBillboard::set_billboard_type(BillboardType p_billboard_type) {
-	ERR_FAIL_INDEX(int(p_billboard_type), int(BILLBOARD_TYPE_MAX));
+	ERR_FAIL_INDEX(p_billboard_type, BILLBOARD_TYPE_MAX);
 	if (billboard_type == p_billboard_type) {
 		return;
 	}

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -402,7 +402,7 @@ String VisualShaderNodeParticleRandomness::generate_code(Shader::Mode p_mode, Vi
 }
 
 void VisualShaderNodeParticleRandomness::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -509,7 +509,7 @@ String VisualShaderNodeParticleAccelerator::generate_code(Shader::Mode p_mode, V
 }
 
 void VisualShaderNodeParticleAccelerator::set_mode(Mode p_mode) {
-	ERR_FAIL_INDEX(int(p_mode), int(MODE_MAX));
+	ERR_FAIL_INDEX(p_mode, MODE_MAX);
 	if (mode == p_mode) {
 		return;
 	}

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -2740,7 +2740,7 @@ int RendererStorageRD::mesh_get_blend_shape_count(RID p_mesh) const {
 void RendererStorageRD::mesh_set_blend_shape_mode(RID p_mesh, RS::BlendShapeMode p_mode) {
 	Mesh *mesh = mesh_owner.getornull(p_mesh);
 	ERR_FAIL_COND(!mesh);
-	ERR_FAIL_INDEX((int)p_mode, 2);
+	ERR_FAIL_INDEX(p_mode, 2);
 
 	mesh->blend_shape_mode = p_mode;
 }


### PR DESCRIPTION
Related PR/discussion: https://github.com/godotengine/godot/pull/26868

Most of the times we pass integers to macros ERR_FAIL_INDEX, ERR_FAIL_INDEX_V, CRASH_BAD_INDEX, ERR_FAIL_UNSIGNED_INDEX_V, but sometimes we also want to pass enums. Passing enums requires a cast, so compiler produces no warnings for the comparison `(m_index) >= (m_size)`.

For contributors to not worry about the difference when using the macro, I moved the cast into macros themselves.

I left two occurences intact (`drivers\gles2\rasterizer_scene_gles2.cpp` and `drivers\gles2\rasterizer_scene_gles3.cpp`), because they are casting `uint32_t shadow` (unsigned int) to int, and I think it doesn't hurt to be explicit there.

~~Note: I'm waiting for https://github.com/godotengine/godot/pull/26868 PR to pass CI and merge, so one extra line can be updated in this PR, after rebase.~~