### PR TITLE
Revert "RichTextLabel: Adding the ability to change the default cursor"

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -901,13 +901,21 @@ void RichTextLabel::_find_click(ItemFrame *p_frame, const Point2i &p_click, Item
 
 Control::CursorShape RichTextLabel::get_cursor_shape(const Point2 &p_pos) const {
 
-	if (selection.click)
+	if (!underline_meta || selection.click)
 		return CURSOR_ARROW;
 
 	if (main->first_invalid_line < main->lines.size())
 		return CURSOR_ARROW; //invalid
 
-	return get_default_cursor_shape();
+	int line = 0;
+	Item *item = NULL;
+
+	((RichTextLabel *)(this))->_find_click(main, p_pos, &item, &line);
+
+	if (item && ((RichTextLabel *)(this))->_find_meta(item, NULL))
+		return CURSOR_POINTING_HAND;
+
+	return CURSOR_ARROW;
 }
 
 void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {


### PR DESCRIPTION
Reverts godotengine/godot#26788, which caused #27983.

Fixes #27983.