### PR TITLE
Make buttons that trigger popups have the same scale

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -758,23 +758,27 @@ void ColorPickerButton::_modal_closed() {
 void ColorPickerButton::pressed() {
 
 	_update_picker();
-	popup->set_position(get_global_position() - picker->get_combined_minimum_size());
+	popup->set_position(get_global_position() - picker->get_combined_minimum_size() * get_global_transform().get_scale());
+	popup->set_scale(get_global_transform().get_scale());
 	popup->popup();
 	picker->set_focus_on_line_edit();
 }
 
 void ColorPickerButton::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_DRAW) {
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
 
-		Ref<StyleBox> normal = get_stylebox("normal");
-		Rect2 r = Rect2(normal->get_offset(), get_size() - normal->get_minimum_size());
-		draw_texture_rect(Control::get_icon("bg", "ColorPickerButton"), r, true);
-		draw_rect(r, color);
-	}
+			Ref<StyleBox> normal = get_stylebox("normal");
+			Rect2 r = Rect2(normal->get_offset(), get_size() - normal->get_minimum_size());
+			draw_texture_rect(Control::get_icon("bg", "ColorPickerButton"), r, true);
+			draw_rect(r, color);
+		} break;
+		case MainLoop::NOTIFICATION_WM_QUIT_REQUEST: {
 
-	if (p_what == MainLoop::NOTIFICATION_WM_QUIT_REQUEST && popup) {
-		popup->hide();
+			if (popup)
+				popup->hide();
+		} break;
 	}
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -56,6 +56,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 		if (b->is_pressed() && b->get_button_index() == BUTTON_RIGHT && context_menu_enabled) {
 			menu->set_position(get_global_transform().xform(get_local_mouse_position()));
 			menu->set_size(Vector2(1, 1));
+			menu->set_scale(get_global_transform().get_scale());
 			menu->popup();
 			grab_focus();
 			return;

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -55,8 +55,9 @@ void MenuButton::pressed() {
 	Size2 size = get_size();
 
 	Point2 gp = get_global_position();
-	popup->set_global_position(gp + Size2(0, size.height));
+	popup->set_global_position(gp + Size2(0, size.height * get_global_transform().get_scale().y));
 	popup->set_size(Size2(size.width, 0));
+	popup->set_scale(get_global_transform().get_scale());
 	popup->set_parent_rect(Rect2(Point2(gp - popup->get_global_position()), get_size()));
 	popup->popup();
 }
@@ -135,7 +136,6 @@ MenuButton::MenuButton() {
 	popup = memnew(PopupMenu);
 	popup->hide();
 	add_child(popup);
-	popup->set_as_toplevel(true);
 	popup->set_pass_on_modal_close_click(false);
 	popup->connect("about_to_show", this, "set_pressed", varray(true)); // For when switching from another MenuButton.
 	popup->connect("popup_hide", this, "set_pressed", varray(false));

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -109,9 +109,9 @@ void OptionButton::_selected(int p_which) {
 void OptionButton::pressed() {
 
 	Size2 size = get_size();
-	popup->set_global_position(get_global_position() + Size2(0, size.height));
+	popup->set_global_position(get_global_position() + Size2(0, size.height * get_global_transform().get_scale().y));
 	popup->set_size(Size2(size.width, 0));
-
+	popup->set_scale(get_global_transform().get_scale());
 	popup->popup();
 }
 
@@ -352,8 +352,8 @@ OptionButton::OptionButton() {
 	popup = memnew(PopupMenu);
 	popup->hide();
 	add_child(popup);
-	popup->set_as_toplevel(true);
 	popup->set_pass_on_modal_close_click(false);
+	popup->set_notify_transform(true);
 	popup->connect("id_pressed", this, "_selected");
 	popup->connect("id_focused", this, "_focused");
 	popup->connect("popup_hide", this, "set_pressed", varray(false));

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -65,7 +65,7 @@ void Popup::_notification(int p_what) {
 void Popup::_fix_size() {
 
 	Point2 pos = get_global_position();
-	Size2 size = get_size();
+	Size2 size = get_size() * get_scale();
 	Point2 window_size = get_viewport_rect().size;
 
 	if (pos.x + size.width > window_size.width)

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -159,13 +159,14 @@ void PopupMenu::_activate_submenu(int over) {
 	Rect2 pr(p, get_size());
 	Ref<StyleBox> style = get_stylebox("panel");
 
-	Point2 pos = p + Point2(get_size().width, items[over]._ofs_cache - style->get_offset().y);
+	Point2 pos = p + Point2(get_size().width, items[over]._ofs_cache - style->get_offset().y) * get_global_transform().get_scale();
 	Size2 size = pm->get_size();
 	// fix pos
 	if (pos.x + size.width > get_viewport_rect().size.width)
 		pos.x = p.x - size.width;
 
 	pm->set_position(pos);
+	pm->set_scale(get_global_transform().get_scale());
 	pm->popup();
 
 	PopupMenu *pum = Object::cast_to<PopupMenu>(pm);
@@ -196,11 +197,11 @@ void PopupMenu::_scroll(float p_factor, const Point2 &p_over) {
 	int vseparation = get_constant("vseparation");
 	Ref<Font> font = get_font("font");
 
-	float dy = (vseparation + font->get_height()) * 3 * p_factor;
+	float dy = (vseparation + font->get_height()) * 3 * p_factor * get_global_transform().get_scale().y;
 	if (dy > 0 && global_y < 0)
 		dy = MIN(dy, -global_y - 1);
-	else if (dy < 0 && global_y + get_size().y > get_viewport_rect().size.y)
-		dy = -MIN(-dy, global_y + get_size().y - get_viewport_rect().size.y - 1);
+	else if (dy < 0 && global_y + get_size().y * get_global_transform().get_scale().y > get_viewport_rect().size.y)
+		dy = -MIN(-dy, global_y + get_size().y * get_global_transform().get_scale().y - get_viewport_rect().size.y - 1);
 	set_position(get_position() + Vector2(0, dy));
 
 	Ref<InputEventMouseMotion> ie;
@@ -289,7 +290,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 
 			case BUTTON_WHEEL_DOWN: {
 
-				if (get_global_position().y + get_size().y > get_viewport_rect().size.y) {
+				if (get_global_position().y + get_size().y * get_global_transform().get_scale().y > get_viewport_rect().size.y) {
 					_scroll(-b->get_factor(), b->get_position());
 				}
 			} break;
@@ -415,7 +416,6 @@ void PopupMenu::_notification(int p_what) {
 
 			minimum_size_changed();
 			update();
-
 		} break;
 		case NOTIFICATION_DRAW: {
 
@@ -528,7 +528,6 @@ void PopupMenu::_notification(int p_what) {
 
 				ofs.y += h;
 			}
-
 		} break;
 		case MainLoop::NOTIFICATION_WM_FOCUS_OUT: {
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -86,8 +86,8 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 			emit_signal("pre_popup_pressed");
 
 			Vector2 popup_pos = get_global_position();
-			popup_pos.x += size.width - popup->get_size().width;
-			popup_pos.y += menu->get_height();
+			popup_pos.x += size.width * get_global_transform().get_scale().x - popup->get_size().width * popup->get_global_transform().get_scale().x;
+			popup_pos.y += menu->get_height() * get_global_transform().get_scale().y;
 
 			popup->set_global_position(popup_pos);
 			popup->popup();
@@ -350,6 +350,7 @@ void TabContainer::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
+
 			minimum_size_changed();
 			call_deferred("_on_theme_changed"); //wait until all changed theme
 		} break;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2009,6 +2009,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				menu->set_position(get_global_transform().xform(get_local_mouse_position()));
 				menu->set_size(Vector2(1, 1));
+				menu->set_scale(get_global_transform().get_scale());
 				menu->popup();
 				grab_focus();
 			}


### PR DESCRIPTION
Things like `MenuButton`, `OptionButton`, and `ColorPickerButtor` now have their popups inherent the scale of the buttons themselves. This will make life easier for those who have the option to scale the UI in their games without having to scale and reposition each popup.
![Peek 23-04-2019 11-43](https://user-images.githubusercontent.com/30739239/56590680-005d4f80-65d7-11e9-8593-c0974b53804c.gif)

Fixes #19451.