### PR TITLE
Disable Project Export button after deleting preset

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -631,6 +631,7 @@ void ProjectExportDialog::_delete_preset_confirm() {
 
 	int idx = presets->get_current();
 	_edit_preset(-1);
+	export_button->set_disabled(true);
 	EditorExport::get_singleton()->remove_export_preset(idx);
 	_update_presets();
 }


### PR DESCRIPTION
This PR disable Export Project button, when deleting preset.
It is necessary because a little before, current preset is selected to -1(which doesn't exist) and if user try to click at the button when none of presets are selected, then this error shows:
```
ERROR: get_export_preset: Index p_idx=-1 out of size (export_presets.size()=0)
   At: editor/editor_export.cpp:1194.
ERROR: _export_project: Condition ' current.is_null() ' is true.
   At: editor/project_export.cpp:930.
```