### PR TITLE
Fixes build for Windows cross-compilation

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -330,7 +330,7 @@ def configure_mingw(env):
     env.Append(CCFLAGS=['-DWASAPI_ENABLED'])
     env.Append(CCFLAGS=['-DWINMIDI_ENABLED'])
     env.Append(CCFLAGS=['-DWINVER=%s' % env['target_win_version'], '-D_WIN32_WINNT=%s' % env['target_win_version']])
-    env.Append(LIBS=['mingw32', 'opengl32', 'dsound', 'ole32', 'd3d9', 'winmm', 'gdi32', 'iphlpapi', 'shlwapi', 'wsock32', 'ws2_32', 'kernel32', 'oleaut32', 'dinput8', 'dxguid', 'ksuser', 'imm32', 'bcrypt','avrt'])
+    env.Append(LIBS=['mingw32', 'opengl32', 'dsound', 'ole32', 'd3d9', 'winmm', 'gdi32', 'iphlpapi', 'shlwapi', 'wsock32', 'ws2_32', 'kernel32', 'oleaut32', 'dinput8', 'dxguid', 'ksuser', 'imm32', 'bcrypt', 'avrt', 'uuid'])
 
     env.Append(CPPFLAGS=['-DMINGW_ENABLED'])
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -53,6 +53,7 @@
 
 #include <avrt.h>
 #include <direct.h>
+#include <knownfolders.h>
 #include <process.h>
 #include <regstr.h>
 #include <shlobj.h>


### PR DESCRIPTION
The uuid library needed to be included to allow for cross-compilation from Linux.

Tested on a clean Ubuntu install.

Fixes #28299