### PR TITLE
Add undo for Sprite Editor

### DIFF
--- a/editor/plugins/sprite_editor_plugin.h
+++ b/editor/plugins/sprite_editor_plugin.h
@@ -84,7 +84,7 @@ class SpriteEditor : public Control {
 	void _create_collision_polygon_2d_node();
 	void _create_light_occluder_2d_node();
 
-	void _add_as_sibling_or_child(Node2D *p_own_node, Node2D *p_new_node);
+	void _add_as_sibling_or_child(Node *p_own_node, Node *p_new_node);
 
 protected:
 	void _node_removed(Node *p_node);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1853,7 +1853,7 @@ void SceneTreeDock::_create() {
 	scene_tree->get_scene_tree()->call_deferred("grab_focus");
 }
 
-void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties) {
+void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties, bool p_remove_old) {
 
 	Node *n = p_node;
 	Node *newnode = p_by_node;
@@ -1917,16 +1917,20 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 		Node *c = newnode->get_child(i);
 		c->call("set_transform", c->call("get_transform"));
 	}
-	editor_data->get_undo_redo().clear_history();
+	//p_remove_old was added to support undo
+	if (p_remove_old)
+		editor_data->get_undo_redo().clear_history();
 	newnode->set_name(newname);
 
 	editor->push_item(newnode);
 
-	memdelete(n);
+	if (p_remove_old) {
+		memdelete(n);
 
-	while (to_erase.front()) {
-		memdelete(to_erase.front()->get());
-		to_erase.pop_front();
+		while (to_erase.front()) {
+			memdelete(to_erase.front()->get());
+			to_erase.pop_front();
+		}
 	}
 }
 
@@ -2495,6 +2499,7 @@ void SceneTreeDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_feature_profile_changed"), &SceneTreeDock::_feature_profile_changed);
 
 	ClassDB::bind_method(D_METHOD("instance"), &SceneTreeDock::instance);
+	ClassDB::bind_method(D_METHOD("replace_node"), &SceneTreeDock::replace_node);
 
 	ADD_SIGNAL(MethodInfo("remote_tree_selected"));
 }

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -243,7 +243,7 @@ public:
 	void show_tab_buttons();
 	void hide_tab_buttons();
 
-	void replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties = true);
+	void replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties = true, bool p_remove_old = true);
 
 	void open_script_dialog(Node *p_for_node);
 


### PR DESCRIPTION
This PR adds undo support for all Sprite Editor actions (which also closes #24820).
I had to change `_add_as_sibling_or_child` to take Nodes as arguments instead of Node2D to use it with `bind_method`.
I also changed `replace_node` in SceneTreeDock to make freeing old node optional, so now it should be easy to add undo support for any action that replaces node with another one (e.g. Particles -> CPUParticles, which doesn't support undo too, yet).