### PR TITLE
Removes preview from existing transform nodes in visual shader

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -523,7 +523,7 @@ void VisualShaderEditor::_update_graph() {
 			}
 		}
 
-		if (vsnode->get_output_port_for_preview() >= 0) {
+		if (vsnode->get_output_port_for_preview() >= 0 && vsnode->get_output_port_type(vsnode->get_output_port_for_preview()) != VisualShaderNode::PORT_TYPE_TRANSFORM) {
 			VisualShaderNodePortPreview *port_preview = memnew(VisualShaderNodePortPreview);
 			port_preview->setup(visual_shader, type, nodes[n_i], vsnode->get_output_port_for_preview());
 			port_preview->set_h_size_flags(SIZE_SHRINK_CENTER);


### PR DESCRIPTION
Forgot to add it in https://github.com/godotengine/godot/commit/0453e6eddc07895d0683ea8534be531b50cb7cd0 , without it the existing transform nodes with opened preview, does not have a way to close a preview and will emits errors