### PR TITLE
Put C++ related warning options to CPPFLAGS (#28322).

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -322,12 +322,13 @@ if selected_platform in platform_list:
             # FIXME: enable -Wlogical-op and -Wduplicated-branches once #27594 is merged
             # Note: enable -Wimplicit-fallthrough for Clang (already part of -Wextra for GCC)
             # once we switch to C++11 or later (necessary for our FALLTHROUGH macro).
-            env.Append(CCFLAGS=['-Wall', '-Wextra', '-Wno-unused-parameter',
-                '-Wctor-dtor-privacy', '-Wnon-virtual-dtor']
+            env.Append(CCFLAGS=['-Wall', '-Wextra', '-Wno-unused-parameter']
                 + all_plus_warnings + shadow_local_warning)
+            env['CPPFLAGS'] += ['-Wctor-dtor-privacy', '-Wnon-virtual-dtor']
             if methods.using_gcc(env):
-                env['CCFLAGS'] += ['-Wno-clobbered', '-Walloc-zero', '-Wnoexcept',
-                    '-Wduplicated-cond', '-Wplacement-new=1', '-Wstringop-overflow=4']
+                env['CCFLAGS'] += ['-Wno-clobbered', '-Walloc-zero',
+                    '-Wduplicated-cond', '-Wstringop-overflow=4']
+                env['CPPFLAGS'] += ['-Wnoexcept', '-Wplacement-new=1']
                 version = methods.get_compiler_version(env)
                 if version != None and version[0] >= '9':
                     env['CCFLAGS'] += ['-Wattribute-alias=2']


### PR DESCRIPTION
Setting `CPPFLAGS` I still see quite some C files using C++ options:

```
$ grep 'Wplacement-new.*not for C' 1 | wc -l
590
```

It happens for various third party code:
```
gcc -o thirdparty/mbedtls/library/x509.x11.opt.tools.64.o -c -g1 -O2 -DDEBUG_ENABLED -pipe -fpie -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wshadow-local -Wno-clobbered -Walloc-zero -Wduplicated-cond -Wstringop-overflow=4 -Werror=return-type -DZSTD_STATIC_LINKING_ONLY -w -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -DJOYDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -DOPENGL_ENABLED -DGLES_ENABLED -Wctor-dtor-privacy -Wnon-virtual-dtor -Wnoexcept -Wplacement-new=1 -DGLAD_ENABLED -DGLES_OVER_GL -DMODULE_ASSIMP_ENABLED -DMODULE_BMP_ENABLED -DMODULE_BULLET_ENABLED -DMODULE_CSG_ENABLED -DMODULE_CVTT_ENABLED -DMODULE_DDS_ENABLED -DMODULE_ENET_ENABLED -DMODULE_ETC_ENABLED -DMODULE_FREETYPE_ENABLED -DMODULE_GDNATIVE_ENABLED -DMODULE_GDSCRIPT_ENABLED -DMODULE_GRIDMAP_ENABLED -DMODULE_HDR_ENABLED -DMODULE_JPG_ENABLED -DMODULE_MBEDTLS_ENABLED -D_REENTRANT -DPTRCALL_ENABLED -DTOOLS_ENABLED -DGDSCRIPT_ENABLED -DMINIZIP_ENABLED -Ithirdparty/mbedtls/include -Ieditor -I. -I/usr/include/freetype2 -I/usr/include/libpng16 -Iplatform/x11 -Ithirdparty/zstd -Ithirdparty/glad thirdparty/mbedtls/library/x509.c
cc1: warning: command line option '-Wctor-dtor-privacy' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-Wnon-virtual-dtor' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-Wnoexcept' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-Wplacement-new=1' is valid for C++ but not for C
...
gcc -o thirdparty/libwebp/src/dsp/dec_mips32.x11.opt.tools.64.o -c -g1 -O2 -DDEBUG_ENABLED -pipe -fpie -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wshadow-local -Wno-clobbered -Walloc-zero -Wduplicated-cond -Wstringop-overflow=4 -Werror=return-type -DZSTD_STATIC_LINKING_ONLY -w -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -DJOYDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -DOPENGL_ENABLED -DGLES_ENABLED -Wctor-dtor-privacy -Wnon-virtual-dtor -Wnoexcept -Wplacement-new=1 -DGLAD_ENABLED -DGLES_OVER_GL -DMODULE_ASSIMP_ENABLED -DMODULE_BMP_ENABLED -DMODULE_BULLET_ENABLED -DMODULE_CSG_ENABLED -DMODULE_CVTT_ENABLED -DMODULE_DDS_ENABLED -DMODULE_ENET_ENABLED -DMODULE_ETC_ENABLED -DMODULE_FREETYPE_ENABLED -DMODULE_GDNATIVE_ENABLED -DMODULE_GDSCRIPT_ENABLED -DMODULE_GRIDMAP_ENABLED -DMODULE_HDR_ENABLED -DMODULE_JPG_ENABLED -DMODULE_MBEDTLS_ENABLED -DMODULE_MOBILE_VR_ENABLED -DMODULE_OGG_ENABLED -DMODULE_OPENSIMPLEX_ENABLED -DMODULE_OPUS_ENABLED -DMODULE_PVR_ENABLED -DMODULE_RECAST_ENABLED -DMODULE_REGEX_ENABLED -DMODULE_SQUISH_ENABLED -DMODULE_STB_VORBIS_ENABLED -DMODULE_SVG_ENABLED -DMODULE_TGA_ENABLED -DMODULE_THEORA_ENABLED -DMODULE_TINYEXR_ENABLED -DMODULE_UPNP_ENABLED -DMODULE_VHACD_ENABLED -DMODULE_VISUAL_SCRIPT_ENABLED -DMODULE_VORBIS_ENABLED -DMODULE_WEBM_ENABLED -DMODULE_WEBP_ENABLED -D_REENTRANT -DPTRCALL_ENABLED -DTOOLS_ENABLED -DGDSCRIPT_ENABLED -DMINIZIP_ENABLED -Ieditor -I. -I/usr/include/freetype2 -I/usr/include/libpng16 -Iplatform/x11 -Ithirdparty/zstd -Ithirdparty/glad -Ithirdparty/libwebp -Ithirdparty/libwebp/src thirdparty/libwebp/src/dsp/dec_mips32.c
cc1: warning: command line option '-Wctor-dtor-privacy' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-Wnon-virtual-dtor' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-Wnoexcept' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-Wplacement-new=1' is valid for C++ but not for C
```

Is it @akien-mga a known issue?