### PR TITLE
Add method to get locales that have loaded translations

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -968,6 +968,19 @@ String TranslationServer::get_locale_name(const String &p_locale) const {
 	return locale_name_map[p_locale];
 }
 
+Array TranslationServer::get_loaded_locales() const {
+	Array locales;
+	for (const Set<Ref<Translation> >::Element *E = translations.front(); E; E = E->next()) {
+
+		const Ref<Translation> &t = E->get();
+		String l = t->get_locale();
+
+		locales.push_back(l);
+	}
+
+	return locales;
+}
+
 Vector<String> TranslationServer::get_all_locales() {
 
 	Vector<String> locales;
@@ -1168,6 +1181,8 @@ void TranslationServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_translation", "translation"), &TranslationServer::remove_translation);
 
 	ClassDB::bind_method(D_METHOD("clear"), &TranslationServer::clear);
+
+	ClassDB::bind_method(D_METHOD("get_loaded_locales"), &TranslationServer::get_loaded_locales);
 }
 
 void TranslationServer::load_translations() {

--- a/core/translation.h
+++ b/core/translation.h
@@ -94,6 +94,8 @@ public:
 
 	String get_locale_name(const String &p_locale) const;
 
+	Array get_loaded_locales() const;
+
 	void add_translation(const Ref<Translation> &p_translation);
 	void remove_translation(const Ref<Translation> &p_translation);
 


### PR DESCRIPTION
TranslationServer::get_all_loaded_locales returns an array of all locales with a loaded Translation.

Closes #28358 