### PR TITLE
Make limit for simultaneously playing AudioStreamPlaybackSample.

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -80,6 +80,7 @@ void ResourceImporterWAV::get_import_options(List<ImportOption> *r_options, int 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "edit/normalize"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "edit/loop"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/mode", PROPERTY_HINT_ENUM, "Disabled,RAM (Ima-ADPCM)"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "playback/simultaneously_limit", PROPERTY_HINT_RANGE, "0,1000,1"), 0));
 }
 
 Error ResourceImporterWAV::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
@@ -455,6 +456,8 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 		is16 = false;
 	}
 
+	int simultaneously_limit = p_options["playback/simultaneously_limit"];
+
 	PoolVector<uint8_t> dst_data;
 	AudioStreamSample::Format dst_format;
 
@@ -527,6 +530,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 	sample->set_loop_begin(loop_begin);
 	sample->set_loop_end(loop_end);
 	sample->set_stereo(format_channels == 2);
+	sample->set_simultaneously_limit(simultaneously_limit);
 
 	ResourceSaver::save(p_save_path + ".sample", sample);
 

--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -113,6 +113,8 @@ private:
 	int mix_rate;
 	void *data;
 	uint32_t data_bytes;
+	int playing_instances;
+	int simultaneously_limit;
 
 protected:
 	static void _bind_methods();
@@ -145,6 +147,9 @@ public:
 
 	virtual Ref<AudioStreamPlayback> instance_playback();
 	virtual String get_stream_name() const;
+
+	void set_simultaneously_limit(int limit);
+	int get_simultaneously_limit();
 
 	AudioStreamSample();
 	~AudioStreamSample();


### PR DESCRIPTION
Fix #28379
Someone should set Playback/SimultaneouslyLimit in WAV import dialog. 
The default value is 0. It means no limit (works as before PR).