### PR TITLE
Allow to change Position2D gizmo size

### DIFF
--- a/doc/classes/Position2D.xml
+++ b/doc/classes/Position2D.xml
@@ -4,7 +4,7 @@
 		Generic 2D Position hint for editing.
 	</brief_description>
 	<description>
-		Generic 2D Position hint for editing. It's just like a plain [Node2D] but displays as a cross in the 2D-Editor at all times.
+		Generic 2D Position hint for editing. It's just like a plain [Node2D] but displays as a cross in the 2D-Editor at all times. You can set visual size of the cross by changing Gizmo Extents in the inspector.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -35,13 +35,15 @@
 
 void Position2D::_draw_cross() {
 
-	draw_line(Point2(-10, 0), Point2(+10, 0), Color(1, 0.5, 0.5));
-	draw_line(Point2(0, -10), Point2(0, +10), Color(0.5, 1, 0.5));
+	float extents = get_gizmo_extents();
+	draw_line(Point2(-extents, 0), Point2(+extents, 0), Color(1, 0.5, 0.5));
+	draw_line(Point2(0, -extents), Point2(0, +extents), Color(0.5, 1, 0.5));
 }
 
 Rect2 Position2D::_edit_get_rect() const {
 
-	return Rect2(Point2(-10, -10), Size2(20, 20));
+	float extents = get_gizmo_extents();
+	return Rect2(Point2(-extents, -extents), Size2(extents * 2, extents * 2));
 }
 
 bool Position2D::_edit_use_rect() const {
@@ -64,6 +66,32 @@ void Position2D::_notification(int p_what) {
 
 		} break;
 	}
+}
+
+void Position2D::set_gizmo_extents(float p_extents) {
+	if (p_extents == DEFAULT_GIZMO_EXTENTS) {
+		set_meta("_gizmo_extents_", Variant());
+	} else {
+		set_meta("_gizmo_extents_", p_extents);
+	}
+
+	update();
+}
+
+float Position2D::get_gizmo_extents() const {
+	if (has_meta("_gizmo_extents_")) {
+		return get_meta("_gizmo_extents_");
+	} else {
+		return DEFAULT_GIZMO_EXTENTS;
+	}
+}
+
+void Position2D::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("_set_gizmo_extents", "extents"), &Position2D::set_gizmo_extents);
+	ClassDB::bind_method(D_METHOD("_get_gizmo_extents"), &Position2D::get_gizmo_extents);
+
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "gizmo_extents", PROPERTY_HINT_RANGE, "0,1000,0.1,or_greater", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_gizmo_extents", "_get_gizmo_extents");
 }
 
 Position2D::Position2D() {

--- a/scene/2d/position_2d.h
+++ b/scene/2d/position_2d.h
@@ -37,14 +37,21 @@ class Position2D : public Node2D {
 
 	GDCLASS(Position2D, Node2D)
 
+	const float DEFAULT_GIZMO_EXTENTS = 10.0;
+
 	void _draw_cross();
 
 protected:
 	void _notification(int p_what);
+	static void _bind_methods();
 
 public:
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
+
+	void set_gizmo_extents(float p_extents);
+	float get_gizmo_extents() const;
+
 	Position2D();
 };
 


### PR DESCRIPTION
Supposed to fix #7400
Adds `gui/common/position2d_gizmo_size` property to Project Settings (I wasn't sure where to put it). Unfortunately requires scene reload to refresh and, unless that's acceptable, I'd have to find a way to redraw Position2D on settings change.

@mateusak, is that enough? You also mentioned stuff like color and some inspector settings. Colors could be made configurable (although not sure if 2 additional settings are worth it), but adding node properties automatically saves them in scenes and I doubt anyone would want to keep separate gizmo size for each Position2D.

EDIT:
Well, I realized the color is already configurable via modulate property. So only length should be configurable.