### PR TITLE
Support for binary literals

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1725,6 +1725,45 @@ int64_t String::hex_to_int64(bool p_with_prefix) const {
 	return hex * sign;
 }
 
+int64_t String::bin_to_int64(bool p_with_prefix) const {
+
+	if (p_with_prefix && length() < 3)
+		return 0;
+
+	const CharType *s = ptr();
+
+	int64_t sign = s[0] == '-' ? -1 : 1;
+
+	if (sign < 0) {
+		s++;
+	}
+
+	if (p_with_prefix) {
+		if (s[0] != '0' || s[1] != 'b')
+			return 0;
+		s += 2;
+	}
+
+	int64_t binary = 0;
+
+	while (*s) {
+
+		CharType c = LOWERCASE(*s);
+		int64_t n;
+		if (c == '0' || c == '1') {
+			n = c - '0';
+		} else {
+			return 0;
+		}
+
+		binary *= 2;
+		binary += n;
+		s++;
+	}
+
+	return binary * sign;
+}
+
 int String::to_int() const {
 
 	if (length() == 0)

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1761,7 +1761,7 @@ int64_t String::bin_to_int64(bool p_with_prefix) const {
 		s++;
 	}
 
-	return hex * sign;
+	return binary * sign;
 }
 
 int String::to_int() const {

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1725,6 +1725,45 @@ int64_t String::hex_to_int64(bool p_with_prefix) const {
 	return hex * sign;
 }
 
+int64_t String::bin_to_int64(bool p_with_prefix) const {
+
+	if (p_with_prefix && length() < 3)
+		return 0;
+
+	const CharType *s = ptr();
+
+	int64_t sign = s[0] == '-' ? -1 : 1;
+
+	if (sign < 0) {
+		s++;
+	}
+
+	if (p_with_prefix) {
+		if (s[0] != '0' || s[1] != 'b')
+			return 0;
+		s += 2;
+	}
+
+	int64_t binary = 0;
+
+	while (*s) {
+
+		CharType c = LOWERCASE(*s);
+		int64_t n;
+		if (c == '0' || c == '1') {
+			n = c - '0';
+		} else {
+			return 0;
+		}
+
+		binary *= 2;
+		binary += n;
+		s++;
+	}
+
+	return hex * sign;
+}
+
 int String::to_int() const {
 
 	if (length() == 0)

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -251,6 +251,7 @@ public:
 	int to_int() const;
 
 	int64_t hex_to_int64(bool p_with_prefix = true) const;
+	int64_t bin_to_int64(bool p_with_prefix = true) const;
 	int64_t to_int64() const;
 	static int to_int(const char *p_str, int p_len = -1);
 	static double to_double(const char *p_str);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -351,7 +351,6 @@ void VisualShaderEditor::_update_graph() {
 		Ref<VisualShaderNode> vsnode = visual_shader->get_node(type, nodes[n_i]);
 
 		GraphNode *node = memnew(GraphNode);
-		graph->add_child(node);
 
 		/*if (!vsnode->is_connected("changed", this, "_node_changed")) {
 			vsnode->connect("changed", this, "_node_changed", varray(vsnode->get_instance_id()), CONNECT_DEFERRED);
@@ -374,6 +373,8 @@ void VisualShaderEditor::_update_graph() {
 
 		Ref<VisualShaderNodeUniform> uniform = vsnode;
 		if (uniform.is_valid()) {
+			graph->add_child(node);
+
 			LineEdit *uniform_name = memnew(LineEdit);
 			uniform_name->set_text(uniform->get_uniform_name());
 			node->add_child(uniform_name);
@@ -536,6 +537,10 @@ void VisualShaderEditor::_update_graph() {
 			error_label->add_color_override("font_color", get_color("error_color", "Editor"));
 			error_label->set_text(error);
 			node->add_child(error_label);
+		}
+
+		if (!uniform.is_valid()) {
+			graph->add_child(node);
 		}
 	}
 

--- a/methods.py
+++ b/methods.py
@@ -24,10 +24,16 @@ def disable_warnings(self):
         # We have to remove existing warning level defines before appending /w,
         # otherwise we get: "warning D9025 : overriding '/W3' with '/w'"
         warn_flags = ['/Wall', '/W4', '/W3', '/W2', '/W1', '/WX']
-        self['CCFLAGS'] = [x for x in self['CCFLAGS'] if not x in warn_flags]
         self.Append(CCFLAGS=['/w'])
+        self.Append(CFLAGS=['/w'])
+        self.Append(CPPFLAGS=['/w'])
+        self['CCFLAGS'] = [x for x in self['CCFLAGS'] if not x in warn_flags]
+        self['CFLAGS'] = [x for x in self['CFLAGS'] if not x in warn_flags]
+        self['CPPFLAGS'] = [x for x in self['CPPFLAGS'] if not x in warn_flags]
     else:
         self.Append(CCFLAGS=['-w'])
+        self.Append(CFLAGS=['-w'])
+        self.Append(CPPFLAGS=['-w'])
 
 
 def add_module_version_string(self,s):

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -598,6 +598,18 @@ int64_t GDAPI godot_string_hex_to_int64_with_prefix(const godot_string *p_self) 
 	return self->hex_to_int64();
 }
 
+int64_t GDAPI godot_string_bin_to_int64(const godot_string *p_self) {
+	const String *self = (const String *)p_self;
+
+	return self->bin_to_int64(false);
+}
+
+int64_t GDAPI godot_string_bin_to_int64_with_prefix(const godot_string *p_self) {
+	const String *self = (const String *)p_self;
+
+	return self->bin_to_int64();
+}
+
 int64_t GDAPI godot_string_to_int64(const godot_string *p_self) {
 	const String *self = (const String *)p_self;
 

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -56,6 +56,10 @@ static bool _is_hex_symbol(CharType c) {
 	return ((c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'));
 }
 
+static bool _is_bin_symbol(CharType c) {
+	return (c == '0' || c == '1');
+}
+
 Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_highlighting(int p_line) {
 	Map<int, TextEdit::HighlighterInfo> color_map;
 
@@ -76,6 +80,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 	bool in_member_variable = false;
 	bool in_node_path = false;
 	bool is_hex_notation = false;
+	bool is_bin_notation = false;
 	bool expect_type = false;
 	Color keyword_color;
 	Color color;
@@ -118,14 +123,26 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 			is_hex_notation = false;
 		}
 
+		// disallow anything not a 0 or 1
+		if (is_bin_notation && (_is_bin_symbol(str[j]))) {
+			is_number = true;
+		} else if (is_bin_notation) {
+			is_bin_notation = false;
+			is_number = false;
+		} else {
+			is_bin_notation = false;
+		}
+
 		// check for dot or underscore or 'x' for hex notation in floating point number or 'e' for scientific notation
-		if ((str[j] == '.' || str[j] == 'x' || str[j] == '_' || str[j] == 'e') && !in_word && prev_is_number && !is_number) {
+		if ((str[j] == '.' || str[j] == 'x' || str[j] == 'b' || str[j] == '_' || str[j] == 'e') && !in_word && prev_is_number && !is_number) {
 			is_number = true;
 			is_symbol = false;
 			is_char = false;
 
 			if (str[j] == 'x' && str[j - 1] == '0') {
 				is_hex_notation = true;
+			} else if (str[j] == 'b' && str[j - 1] == '0') {
+				is_bin_notation = true;
 			}
 		}
 

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -141,8 +141,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 
 			if (str[j] == 'x' && str[j - 1] == '0') {
 				is_hex_notation = true;
-			}
-			else if (str[j] == 'b' && str[j - 1] == '0') {
+			} else if (str[j] == 'b' && str[j - 1] == '0') {
 				is_bin_notation = true;
 			}
 		}

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -56,6 +56,10 @@ static bool _is_hex_symbol(CharType c) {
 	return ((c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'));
 }
 
+static bool _is_bin_symbol(CharType c) {
+	return (c == '0' || c == '1');
+}
+
 Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_highlighting(int p_line) {
 	Map<int, TextEdit::HighlighterInfo> color_map;
 
@@ -75,7 +79,8 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 	bool in_function_args = false;
 	bool in_member_variable = false;
 	bool in_node_path = false;
-	bool is_hex_binary_notation = false;
+	bool is_hex_notation = false;
+	bool is_bin_notation = false;
 	bool expect_type = false;
 	Color keyword_color;
 	Color color;
@@ -112,10 +117,20 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 		bool is_number = _is_number(str[j]);
 
 		// allow ABCDEF in hex notation
-		if (is_hex_binary_notation && (_is_hex_symbol(str[j]) || is_number)) {
+		if (is_hex_notation && (_is_hex_symbol(str[j]) || is_number)) {
 			is_number = true;
 		} else {
-			is_hex_binary_notation = false;
+			is_hex_notation = false;
+		}
+
+		// disallow anything not a 0 or 1
+		if (is_bin_notation && (_is_bin_symbol(str[j]))) {
+			is_number = true;
+		} else if (is_bin_notation) {
+			is_bin_notation = false;
+			is_number = false;
+		} else {
+			is_bin_notation = false;
 		}
 
 		// check for dot or underscore or 'x' for hex notation in floating point number or 'e' for scientific notation
@@ -124,8 +139,11 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 			is_symbol = false;
 			is_char = false;
 
-			if ((str[j] == 'x' || str[j] == 'b') && str[j - 1] == '0') {
-				is_hex_binary_notation = true;
+			if (str[j] == 'x' && str[j - 1] == '0') {
+				is_hex_notation = true;
+			}
+			else if (str[j] == 'b' && str[j - 1] == '0') {
+				is_bin_notation = true;
 			}
 		}
 
@@ -133,7 +151,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 			in_word = true;
 		}
 
-		if ((in_keyword || in_word) && !is_hex_binary_notation) {
+		if ((in_keyword || in_word) && !is_hex_notation) {
 			is_number = false;
 		}
 

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -75,7 +75,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 	bool in_function_args = false;
 	bool in_member_variable = false;
 	bool in_node_path = false;
-	bool is_hex_notation = false;
+	bool is_hex_binary_notation = false;
 	bool expect_type = false;
 	Color keyword_color;
 	Color color;
@@ -112,20 +112,20 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 		bool is_number = _is_number(str[j]);
 
 		// allow ABCDEF in hex notation
-		if (is_hex_notation && (_is_hex_symbol(str[j]) || is_number)) {
+		if (is_hex_binary_notation && (_is_hex_symbol(str[j]) || is_number)) {
 			is_number = true;
 		} else {
-			is_hex_notation = false;
+			is_hex_binary_notation = false;
 		}
 
 		// check for dot or underscore or 'x' for hex notation in floating point number or 'e' for scientific notation
-		if ((str[j] == '.' || str[j] == 'x' || str[j] == '_' || str[j] == 'e') && !in_word && prev_is_number && !is_number) {
+		if ((str[j] == '.' || str[j] == 'x' || str[j] == 'b' || str[j] == '_' || str[j] == 'e') && !in_word && prev_is_number && !is_number) {
 			is_number = true;
 			is_symbol = false;
 			is_char = false;
 
-			if (str[j] == 'x' && str[j - 1] == '0') {
-				is_hex_notation = true;
+			if ((str[j] == 'x' || str[j] == 'b') && str[j - 1] == '0') {
+				is_hex_binary_notation = true;
 			}
 		}
 
@@ -133,7 +133,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 			in_word = true;
 		}
 
-		if ((in_keyword || in_word) && !is_hex_notation) {
+		if ((in_keyword || in_word) && !is_hex_binary_notation) {
 			is_number = false;
 		}
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -893,12 +893,10 @@ void GDScriptTokenizerText::_advance() {
 							if (period_found || exponent_found) {
 								_make_error("Invalid numeric constant at '.'");
 								return;
-							}
-							else if (bin_found) {
+							} else if (bin_found) {
 								_make_error("Invalid binary constant at '.'");
 								return;
-							}
-							else if (hexa_found) {
+							} else if (hexa_found) {
 								_make_error("Invalid hexadecimal constant at '.'");
 								return;
 							}

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -890,8 +890,16 @@ void GDScriptTokenizerText::_advance() {
 
 					while (true) {
 						if (GETCHAR(i) == '.') {
-							if (period_found || exponent_found || bin_found) {
+							if (period_found || exponent_found) {
 								_make_error("Invalid numeric constant at '.'");
+								return;
+							}
+							else if (bin_found) {
+								_make_error("Invalid binary constant at '.'");
+								return;
+							}
+							else if (hexa_found) {
+								_make_error("Invalid hexadecimal constant at '.'");
 								return;
 							}
 							period_found = true;
@@ -902,7 +910,7 @@ void GDScriptTokenizerText::_advance() {
 							}
 							hexa_found = true;
 						} else if (GETCHAR(i) == 'b') {
-							if (hexa_found || bin_found || period_found || str.length() != 1 || !((i == 1 && str[0] == '0') || (i == 2 && str[1] == '0' && str[0] == '-'))) {
+							if (hexa_found || bin_found || str.length() != 1 || !((i == 1 && str[0] == '0') || (i == 2 && str[1] == '0' && str[0] == '-'))) {
 								_make_error("Invalid numeric constant at 'b'");
 								return;
 							}

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -915,8 +915,8 @@ void GDScriptTokenizerText::_advance() {
 								return;
 							}
 							bin_found = true;
-						} else if (!hexa_found && !bin_found && GETCHAR(i) == 'e') {
-							if (exponent_found) {
+						} else if (!hexa_found && GETCHAR(i) == 'e') {
+							if (exponent_found || bin_found) {
 								_make_error("Invalid numeric constant at 'e'");
 								return;
 							}

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -376,6 +376,11 @@ static bool _is_hex(CharType c) {
 	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
 }
 
+static bool _is_bin(CharType c) {
+
+	return (c == '0' || c == '1');
+}
+
 void GDScriptTokenizerText::_make_token(Token p_type) {
 
 	TokenData &tk = tk_rb[tk_rb_pos];
@@ -877,6 +882,7 @@ void GDScriptTokenizerText::_advance() {
 					bool period_found = false;
 					bool exponent_found = false;
 					bool hexa_found = false;
+					bool bin_found = false;
 					bool sign_found = false;
 
 					String str;
@@ -884,18 +890,24 @@ void GDScriptTokenizerText::_advance() {
 
 					while (true) {
 						if (GETCHAR(i) == '.') {
-							if (period_found || exponent_found) {
+							if (period_found || exponent_found || bin_found) {
 								_make_error("Invalid numeric constant at '.'");
 								return;
 							}
 							period_found = true;
 						} else if (GETCHAR(i) == 'x') {
-							if (hexa_found || str.length() != 1 || !((i == 1 && str[0] == '0') || (i == 2 && str[1] == '0' && str[0] == '-'))) {
+							if (hexa_found || bin_found || str.length() != 1 || !((i == 1 && str[0] == '0') || (i == 2 && str[1] == '0' && str[0] == '-'))) {
 								_make_error("Invalid numeric constant at 'x'");
 								return;
 							}
 							hexa_found = true;
-						} else if (!hexa_found && GETCHAR(i) == 'e') {
+						} else if (GETCHAR(i) == 'b') {
+							if (hexa_found || bin_found || period_found || str.length() != 1 || !((i == 1 && str[0] == '0') || (i == 2 && str[1] == '0' && str[0] == '-'))) {
+								_make_error("Invalid numeric constant at 'b'");
+								return;
+							}
+							bin_found = true;
+						} else if (!hexa_found && !bin_found && GETCHAR(i) == 'e') {
 							if (exponent_found) {
 								_make_error("Invalid numeric constant at 'e'");
 								return;
@@ -904,6 +916,8 @@ void GDScriptTokenizerText::_advance() {
 						} else if (_is_number(GETCHAR(i))) {
 							//all ok
 						} else if (hexa_found && _is_hex(GETCHAR(i))) {
+
+						} else if (bin_found && _is_bin(GETCHAR(i))) {
 
 						} else if ((GETCHAR(i) == '-' || GETCHAR(i) == '+') && exponent_found) {
 							if (sign_found) {
@@ -929,6 +943,9 @@ void GDScriptTokenizerText::_advance() {
 					INCPOS(i);
 					if (hexa_found) {
 						int64_t val = str.hex_to_int64();
+						_make_constant(val);
+					} else if (bin_found) {
+						int64_t val = str.bin_to_int64();
 						_make_constant(val);
 					} else if (period_found || exponent_found) {
 						double val = str.to_double();


### PR DESCRIPTION
~(Almost)~ Resolves #25755

Adds binary literals in the form of `0bxxxx`, e.g `0b01110` => 14
These are useful for things like bitmasking.
MSB is not treated as negative- representation is unsigned.

Issues:
~- No highlighting for binary literals within the script editor~