### PR TITLE
SCons: Review uses of CCFLAGS, CXXFLAGS and CPPFLAGS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -161,8 +161,8 @@ opts.Add("CXX", "C++ compiler")
 opts.Add("CC", "C compiler")
 opts.Add("LINK", "Linker")
 opts.Add("CCFLAGS", "Custom flags for both the C and C++ compilers")
-opts.Add("CXXFLAGS", "Custom flags for the C++ compiler")
 opts.Add("CFLAGS", "Custom flags for the C compiler")
+opts.Add("CXXFLAGS", "Custom flags for the C++ compiler")
 opts.Add("LINKFLAGS", "Custom flags for the linker")
 
 # add platform specific options
@@ -271,17 +271,18 @@ if selected_platform in platform_list:
 
     CCFLAGS = env.get('CCFLAGS', '')
     env['CCFLAGS'] = ''
-
     env.Append(CCFLAGS=str(CCFLAGS).split())
 
     CFLAGS = env.get('CFLAGS', '')
     env['CFLAGS'] = ''
-
     env.Append(CFLAGS=str(CFLAGS).split())
+
+    CXXFLAGS = env.get('CXXFLAGS', '')
+    env['CXXFLAGS'] = ''
+    env.Append(CXXFLAGS=str(CXXFLAGS).split())
 
     LINKFLAGS = env.get('LINKFLAGS', '')
     env['LINKFLAGS'] = ''
-
     env.Append(LINKFLAGS=str(LINKFLAGS).split())
 
     flag_list = platform_flags[selected_platform]
@@ -322,15 +323,16 @@ if selected_platform in platform_list:
             # FIXME: enable -Wlogical-op and -Wduplicated-branches once #27594 is merged
             # Note: enable -Wimplicit-fallthrough for Clang (already part of -Wextra for GCC)
             # once we switch to C++11 or later (necessary for our FALLTHROUGH macro).
-            env.Append(CCFLAGS=['-Wall', '-Wextra', '-Wno-unused-parameter',
-                '-Wctor-dtor-privacy', '-Wnon-virtual-dtor']
+            env.Append(CCFLAGS=['-Wall', '-Wextra', '-Wno-unused-parameter']
                 + all_plus_warnings + shadow_local_warning)
+            env.Append(CXXFLAGS=['-Wctor-dtor-privacy', '-Wnon-virtual-dtor'])
             if methods.using_gcc(env):
-                env['CCFLAGS'] += ['-Wno-clobbered', '-Walloc-zero', '-Wnoexcept',
-                    '-Wduplicated-cond', '-Wplacement-new=1', '-Wstringop-overflow=4']
+                env.Append(CCFLAGS=['-Wno-clobbered', '-Walloc-zero',
+                    '-Wduplicated-cond', '-Wstringop-overflow=4'])
+                env.Append(CXXFLAGS=['-Wnoexcept', '-Wplacement-new=1'])
                 version = methods.get_compiler_version(env)
                 if version != None and version[0] >= '9':
-                    env['CCFLAGS'] += ['-Wattribute-alias=2']
+                    env.Append(CCFLAGS=['-Wattribute-alias=2'])
         elif (env["warnings"] == 'all'):
             env.Append(CCFLAGS=['-Wall'] + shadow_local_warning)
         elif (env["warnings"] == 'moderate'):

--- a/core/SCsub
+++ b/core/SCsub
@@ -129,10 +129,10 @@ if env['builtin_zstd']:
     thirdparty_zstd_sources = [thirdparty_zstd_dir + file for file in thirdparty_zstd_sources]
 
     env_thirdparty.Append(CPPPATH=[thirdparty_zstd_dir, thirdparty_zstd_dir + "common"])
-    env_thirdparty.Append(CCFLAGS="-DZSTD_STATIC_LINKING_ONLY")
+    env_thirdparty.Append(CPPFLAGS="-DZSTD_STATIC_LINKING_ONLY")
     env.Append(CPPPATH=thirdparty_zstd_dir)
     # Also needed in main env includes will trigger warnings
-    env.Append(CCFLAGS="-DZSTD_STATIC_LINKING_ONLY")
+    env.Append(CPPFLAGS="-DZSTD_STATIC_LINKING_ONLY")
 
     env_thirdparty.add_source_files(env.core_sources, thirdparty_zstd_sources)
 

--- a/drivers/xaudio2/SCsub
+++ b/drivers/xaudio2/SCsub
@@ -3,5 +3,5 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
-env.Append(CXXFLAGS=['-DXAUDIO2_ENABLED'])
+env.Append(CPPFLAGS=['-DXAUDIO2_ENABLED'])
 env.Append(LINKFLAGS=['xaudio2_8.lib'])

--- a/methods.py
+++ b/methods.py
@@ -29,11 +29,11 @@ def disable_warnings(self):
         self.Append(CPPFLAGS=['/w'])
         self['CCFLAGS'] = [x for x in self['CCFLAGS'] if not x in warn_flags]
         self['CFLAGS'] = [x for x in self['CFLAGS'] if not x in warn_flags]
-        self['CPPFLAGS'] = [x for x in self['CPPFLAGS'] if not x in warn_flags]
+        self['CXXFLAGS'] = [x for x in self['CXXFLAGS'] if not x in warn_flags]
     else:
         self.Append(CCFLAGS=['-w'])
         self.Append(CFLAGS=['-w'])
-        self.Append(CPPFLAGS=['-w'])
+        self.Append(CXXFLAGS=['-w'])
 
 
 def add_module_version_string(self,s):

--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -188,7 +188,7 @@ if env['builtin_bullet']:
 
     env_bullet.Append(CPPPATH=[thirdparty_dir])
     # if env['target'] == "debug" or env['target'] == "release_debug":
-    #     env_bullet.Append(CCFLAGS=['-DBT_DEBUG'])
+    #     env_bullet.Append(CPPFLAGS=['-DBT_DEBUG'])
 
     env_thirdparty = env_bullet.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/etc/SCsub
+++ b/modules/etc/SCsub
@@ -31,7 +31,7 @@ env_etc.Append(CPPPATH=[thirdparty_dir])
 
 # upstream uses c++11
 if not env.msvc:
-	env_etc.Append(CCFLAGS="-std=c++11")
+	env_etc.Append(CXXFLAGS="-std=c++11")
 
 env_thirdparty = env_etc.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -72,9 +72,9 @@ if env['builtin_freetype']:
     # Also needed in main env for scene/
     env.Append(CPPPATH=[thirdparty_dir + "/include"])
 
-    env_freetype.Append(CCFLAGS=['-DFT2_BUILD_LIBRARY', '-DFT_CONFIG_OPTION_USE_PNG'])
+    env_freetype.Append(CPPFLAGS=['-DFT2_BUILD_LIBRARY', '-DFT_CONFIG_OPTION_USE_PNG'])
     if (env['target'] != 'release'):
-        env_freetype.Append(CCFLAGS=['-DZLIB_DEBUG'])
+        env_freetype.Append(CPPFLAGS=['-DZLIB_DEBUG'])
 
     # Also requires libpng headers
     if env['builtin_libpng']:
@@ -100,4 +100,4 @@ if env['builtin_freetype']:
 # Godot source files
 env_freetype.add_source_files(env.modules_sources, "*.cpp")
 # Used in scene/, needs to be in main env
-env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
+env.Append(CPPFLAGS=['-DFREETYPE_ENABLED'])

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -139,7 +139,7 @@ if env['builtin_opus']:
     opus_sources_silk = []
 
     if env["platform"] in ["android", "iphone", "javascript"]:
-        env_opus.Append(CFLAGS=["-DFIXED_POINT"])
+        env_opus.Append(CPPFLAGS=["-DFIXED_POINT"])
         opus_sources_silk = [
             "silk/fixed/LTP_analysis_filter_FIX.c",
             "silk/fixed/LTP_scale_ctrl_FIX.c",
@@ -208,7 +208,7 @@ if env['builtin_opus']:
     if env['builtin_libogg']:
         env_opus.Append(CPPPATH=["#thirdparty/libogg"])
 
-    env_opus.Append(CFLAGS=["-DHAVE_CONFIG_H"])
+    env_opus.Append(CPPFLAGS=["-DHAVE_CONFIG_H"])
 
     thirdparty_include_paths = [
         "",
@@ -222,14 +222,14 @@ if env['builtin_opus']:
 
     if env["platform"] == "android":
         if ("android_arch" in env and env["android_arch"] in ["armv6", "armv7"]):
-            env_opus.Append(CFLAGS=["-DOPUS_ARM_OPT"])
+            env_opus.Append(CPPFLAGS=["-DOPUS_ARM_OPT"])
         elif ("android_arch" in env and env["android_arch"] == "arm64v8"):
-            env_opus.Append(CFLAGS=["-DOPUS_ARM64_OPT"])
+            env_opus.Append(CPPFLAGS=["-DOPUS_ARM64_OPT"])
     elif env["platform"] == "iphone":
         if ("arch" in env and env["arch"] == "arm"):
-            env_opus.Append(CFLAGS=["-DOPUS_ARM_OPT"])
+            env_opus.Append(CPPFLAGS=["-DOPUS_ARM_OPT"])
         elif ("arch" in env and env["arch"] == "arm64"):
-            env_opus.Append(CFLAGS=["-DOPUS_ARM64_OPT"])
+            env_opus.Append(CPPFLAGS=["-DOPUS_ARM64_OPT"])
 
     env_thirdparty = env_opus.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -16,7 +16,7 @@ env_svg.Append(CPPPATH=[thirdparty_dir])
 # FIXME: Needed in editor/editor_themes.cpp for now, but ideally there
 # shouldn't be a dependency on modules/ and its own 3rd party deps.
 env.Append(CPPPATH=[thirdparty_dir])
-env.Append(CCFLAGS=["-DSVG_ENABLED"])
+env.Append(CPPFLAGS=["-DSVG_ENABLED"])
 
 env_thirdparty = env_svg.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -66,7 +66,7 @@ if env['builtin_libtheora']:
         thirdparty_sources += thirdparty_sources_x86_vc
 
     if (env["x86_libtheora_opt_gcc"] or env["x86_libtheora_opt_vc"]):
-        env_theora.Append(CCFLAGS=["-DOC_X86_ASM"])
+        env_theora.Append(CPPFLAGS=["-DOC_X86_ASM"])
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 

--- a/modules/vhacd/SCsub
+++ b/modules/vhacd/SCsub
@@ -29,7 +29,7 @@ env_vhacd.Append(CPPFLAGS=["-DGODOT_ENET"])
 
 # upstream uses c++11
 if not env.msvc:
-	env_vhacd.Append(CCFLAGS="-std=c++11")
+	env_vhacd.Append(CXXFLAGS="-std=c++11")
 
 env_thirdparty = env_vhacd.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/webm/SCsub
+++ b/modules/webm/SCsub
@@ -19,7 +19,7 @@ env_webm.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "libwebm/"])
 
 # upstream uses c++11
 if (not env_webm.msvc):
-	env_webm.Append(CCFLAGS="-std=c++11")
+	env_webm.Append(CXXFLAGS="-std=c++11")
 
 # also requires libogg, libvorbis and libopus
 if env['builtin_libogg']:

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -323,7 +323,7 @@ if webm_cpu_x86:
     elif cpu_bits == '64':
         env_libvpx["ASCPU"] = 'X86_64'
 
-    env_libvpx.Append(CCFLAGS=['-DWEBM_X86ASM'])
+    env_libvpx.Append(CPPFLAGS=['-DWEBM_X86ASM'])
 
     webm_simd_optimizations = True
 
@@ -337,7 +337,7 @@ if webm_cpu_arm:
         env_libvpx["ASFLAGS"] = ''
         env_libvpx["ASCOM"] = '$AS $ASFLAGS -o $TARGET $SOURCES'
 
-    env_libvpx.Append(CCFLAGS=['-DWEBM_ARMASM'])
+    env_libvpx.Append(CPPFLAGS=['-DWEBM_ARMASM'])
 
     webm_simd_optimizations = True
 

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -88,7 +88,7 @@ if env['builtin_libwebsockets'] and not env["platform"] == "javascript": # alrea
         env_lws.Append(CPPPATH=[helper_dir])
 
     if env["platform"] == "uwp":
-        env_lws.Append(CCFLAGS=["/DLWS_MINGW_SUPPORT"])
+        env_lws.Append(CPPFLAGS=["/DLWS_MINGW_SUPPORT"])
 
     env_thirdparty = env_lws.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -24,18 +24,18 @@ if env['builtin_xatlas']:
     if env["platform"] == 'x11':
         # if not specifically one of the *BSD, then use LINUX as default
         if platform.system() == "FreeBSD":
-            env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])
+            env_xatlas_unwrap.Append(CPPFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])
         elif platform.system() == "OpenBSD":
-            env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_OPENBSD", "-DPOSH_COMPILER_GCC"])
+            env_xatlas_unwrap.Append(CPPFLAGS=["-DNV_OS_OPENBSD", "-DPOSH_COMPILER_GCC"])
         else:
-            env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_LINUX", "-DPOSH_COMPILER_GCC"])
+            env_xatlas_unwrap.Append(CPPFLAGS=["-DNV_OS_LINUX", "-DPOSH_COMPILER_GCC"])
     elif env["platform"] == 'osx':
-        env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_DARWIN", "-DPOSH_COMPILER_GCC"])
+        env_xatlas_unwrap.Append(CPPFLAGS=["-DNV_OS_DARWIN", "-DPOSH_COMPILER_GCC"])
     elif env["platform"] == 'windows':
         if env.msvc:
-            env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_WIN32", "-DNV_CC_MSVC", "-DPOSH_COMPILER_MSVC" ])
+            env_xatlas_unwrap.Append(CPPFLAGS=["-DNV_OS_WIN32", "-DNV_CC_MSVC", "-DPOSH_COMPILER_MSVC" ])
         else:
-            env_xatlas_unwrap.Append(CCFLAGS=["-DNV_OS_MINGW", "-DNV_CC_GNUC", "-DPOSH_COMPILER_GCC", "-U__STRICT_ANSI__"])
+            env_xatlas_unwrap.Append(CPPFLAGS=["-DNV_OS_MINGW", "-DNV_CC_GNUC", "-DPOSH_COMPILER_GCC", "-U__STRICT_ANSI__"])
             env.Append(LIBS=["dbghelp"])
 
     env_thirdparty = env_xatlas_unwrap.Clone()

--- a/platform/haiku/detect.py
+++ b/platform/haiku/detect.py
@@ -150,6 +150,6 @@ def configure(env):
     env.Append(CPPPATH=['#platform/haiku'])
     env.Append(CPPFLAGS=['-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES_ENABLED'])
     env.Append(CPPFLAGS=['-DMEDIA_KIT_ENABLED'])
-    # env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
+    # env.Append(CPPFLAGS=['-DFREETYPE_ENABLED'])
     env.Append(CPPFLAGS=['-DPTHREAD_NO_RENAME'])  # TODO: enable when we have pthread_setname_np
     env.Append(LIBS=['be', 'game', 'media', 'network', 'bnetapi', 'z', 'GL'])

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -45,20 +45,21 @@ def configure(env):
     if (env["target"].startswith("release")):
         env.Append(CPPFLAGS=['-DNDEBUG', '-DNS_BLOCK_ASSERTIONS=1'])
         if (env["optimize"] == "speed"): #optimize for speed (default)
-            env.Append(CPPFLAGS=['-O2', '-ftree-vectorize', '-fomit-frame-pointer'])
+            env.Append(CCFLAGS=['-O2', '-ftree-vectorize', '-fomit-frame-pointer'])
             env.Append(LINKFLAGS=['-O2'])
         else: #optimize for size
-            env.Append(CPPFLAGS=['-Os', '-ftree-vectorize'])
+            env.Append(CCFLAGS=['-Os', '-ftree-vectorize'])
             env.Append(LINKFLAGS=['-Os'])
 
         if env["target"] == "release_debug":
             env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
 
     elif (env["target"] == "debug"):
-        env.Append(CPPFLAGS=['-D_DEBUG', '-DDEBUG=1', '-gdwarf-2', '-O0', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+        env.Append(CCFLAGS=['-gdwarf-2', '-O0'])
+        env.Append(CPPFLAGS=['-D_DEBUG', '-DDEBUG=1', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
 
     if (env["use_lto"]):
-        env.Append(CPPFLAGS=['-flto'])
+        env.Append(CCFLAGS=['-flto'])
         env.Append(LINKFLAGS=['-flto'])
 
     ## Architecture
@@ -104,7 +105,7 @@ def configure(env):
         detect_darwin_sdk_path('iphonesimulator', env)
         env['ENV']['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
         arch_flag = "i386" if env["arch"] == "x86" else env["arch"]
-        env.Append(CCFLAGS=('-arch ' + arch_flag + ' -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fblocks -fasm-blocks -isysroot $IPHONESDK -mios-simulator-version-min=10.0 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"').split())
+        env.Append(CCFLAGS=('-arch ' + arch_flag + ' -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fblocks -fasm-blocks -isysroot $IPHONESDK -mios-simulator-version-min=10.0').split())
     elif (env["arch"] == "arm"):
         detect_darwin_sdk_path('iphone', env)
         env.Append(CCFLAGS='-fno-objc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=10.0 -MMD -MT dependencies'.split())
@@ -115,9 +116,9 @@ def configure(env):
         env.Append(CPPFLAGS=['-DLIBYUV_DISABLE_NEON'])
 
     if env['ios_exceptions']:
-        env.Append(CPPFLAGS=['-fexceptions'])
+        env.Append(CCFLAGS=['-fexceptions'])
     else:
-        env.Append(CPPFLAGS=['-fno-exceptions'])
+        env.Append(CCFLAGS=['-fno-exceptions'])
 
     ## Link flags
 

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -53,16 +53,18 @@ def configure(env):
 
     elif (env["target"] == "release_debug"):
         if (env["optimize"] == "speed"): #optimize for speed (default)
-            env.Prepend(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
+            env.Prepend(CCFLAGS=['-O2'])
         else: #optimize for size
-            env.Prepend(CCFLAGS=['-Os', '-DDEBUG_ENABLED'])
+            env.Prepend(CCFLAGS=['-Os'])
+        env.Prepend(CPPFLAGS=['-DDEBUG_ENABLED'])
         if (env["debug_symbols"] == "yes"):
             env.Prepend(CCFLAGS=['-g1'])
         if (env["debug_symbols"] == "full"):
             env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "debug"):
-        env.Prepend(CCFLAGS=['-g3', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+        env.Prepend(CCFLAGS=['-g3'])
+        env.Prepend(CPPFLAGS=['-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
 
     ## Architecture
 
@@ -88,10 +90,10 @@ def configure(env):
             env['AR'] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ar"
             env['RANLIB'] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ranlib"
             env['AS'] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-as"
-            env.Append(CCFLAGS=['-D__MACPORTS__']) #hack to fix libvpx MM256_BROADCASTSI128_SI256 define
+            env.Append(CPPFLAGS=['-D__MACPORTS__']) #hack to fix libvpx MM256_BROADCASTSI128_SI256 define
 
         detect_darwin_sdk_path('osx', env)
-        env.Append(CPPFLAGS=['-isysroot', '$MACOS_SDK_PATH'])
+        env.Append(CCFLAGS=['-isysroot', '$MACOS_SDK_PATH'])
         env.Append(LINKFLAGS=['-isysroot', '$MACOS_SDK_PATH'])
 
     else: # osxcross build
@@ -110,7 +112,7 @@ def configure(env):
         env['AR'] = basecmd + "ar"
         env['RANLIB'] = basecmd + "ranlib"
         env['AS'] = basecmd + "as"
-        env.Append(CCFLAGS=['-D__MACPORTS__']) #hack to fix libvpx MM256_BROADCASTSI128_SI256 define
+        env.Append(CPPFLAGS=['-D__MACPORTS__']) #hack to fix libvpx MM256_BROADCASTSI128_SI256 define
 
     if (env["CXX"] == "clang++"):
         env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])
@@ -129,5 +131,5 @@ def configure(env):
     env.Append(LINKFLAGS=['-framework', 'Cocoa', '-framework', 'Carbon', '-framework', 'OpenGL', '-framework', 'AGL', '-framework', 'AudioUnit', '-framework', 'CoreAudio', '-framework', 'CoreMIDI', '-lz', '-framework', 'IOKit', '-framework', 'ForceFeedback', '-framework', 'CoreVideo'])
     env.Append(LIBS=['pthread'])
 
-    env.Append(CPPFLAGS=['-mmacosx-version-min=10.9'])
+    env.Append(CCFLAGS=['-mmacosx-version-min=10.9'])
     env.Append(LINKFLAGS=['-mmacosx-version-min=10.9'])

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -63,9 +63,10 @@ def configure(env):
 
     elif (env["target"] == "release_debug"):
         if (env["optimize"] == "speed"): #optimize for speed (default)
-            env.Prepend(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
+            env.Prepend(CCFLAGS=['-O2'])
         else: #optimize for size
-            env.Prepend(CCFLAGS=['-Os', '-DDEBUG_ENABLED'])
+            env.Prepend(CCFLAGS=['-Os'])
+        env.Prepend(CPPFLAGS=['-DDEBUG_ENABLED'])
 
         if (env["debug_symbols"] == "yes"):
             env.Prepend(CCFLAGS=['-g1'])
@@ -73,7 +74,8 @@ def configure(env):
             env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "debug"):
-        env.Prepend(CCFLAGS=['-g3', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+        env.Prepend(CCFLAGS=['-g3'])
+        env.Prepend(CPPFLAGS=['-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
         env.Append(LINKFLAGS=['-rdynamic'])
 
     ## Architecture

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -53,18 +53,20 @@ def configure(env):
     ## Build type
 
     if (env["target"] == "release"):
-        env.Append(CPPFLAGS=['/O2', '/GL'])
-        env.Append(CPPFLAGS=['/MD'])
+        env.Append(CCFLAGS=['/O2', '/GL'])
+        env.Append(CCFLAGS=['/MD'])
         env.Append(LINKFLAGS=['/SUBSYSTEM:WINDOWS', '/LTCG'])
 
     elif (env["target"] == "release_debug"):
-        env.Append(CCFLAGS=['/O2', '/Zi', '/DDEBUG_ENABLED'])
-        env.Append(CPPFLAGS=['/MD'])
+        env.Append(CCFLAGS=['/O2', '/Zi'])
+        env.Append(CCFLAGS=['/MD'])
+        env.Append(CPPFLAGS=['/DDEBUG_ENABLED'])
         env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
 
     elif (env["target"] == "debug"):
-        env.Append(CCFLAGS=['/Zi', '/DDEBUG_ENABLED', '/DDEBUG_MEMORY_ENABLED'])
-        env.Append(CPPFLAGS=['/MDd'])
+        env.Append(CCFLAGS=['/Zi'])
+        env.Append(CCFLAGS=['/MDd'])
+        env.Append(CPPFLAGS=['/DDEBUG_ENABLED', '/DDEBUG_MEMORY_ENABLED'])
         env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
         env.Append(LINKFLAGS=['/DEBUG'])
 
@@ -136,18 +138,19 @@ def configure(env):
     ## Compile flags
 
     env.Append(CPPPATH=['#platform/uwp', '#drivers/windows'])
-    env.Append(CCFLAGS=['/DUWP_ENABLED', '/DWINDOWS_ENABLED', '/DTYPED_METHOD_BIND'])
-    env.Append(CCFLAGS=['/DGLES_ENABLED', '/DGL_GLEXT_PROTOTYPES', '/DEGL_EGLEXT_PROTOTYPES', '/DANGLE_ENABLED'])
+    env.Append(CPPFLAGS=['/DUWP_ENABLED', '/DWINDOWS_ENABLED', '/DTYPED_METHOD_BIND'])
+    env.Append(CPPFLAGS=['/DGLES_ENABLED', '/DGL_GLEXT_PROTOTYPES', '/DEGL_EGLEXT_PROTOTYPES', '/DANGLE_ENABLED'])
     winver = "0x0602" # Windows 8 is the minimum target for UWP build
-    env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
+    env.Append(CPPFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
 
-    env.Append(CPPFLAGS=['/D', '__WRL_NO_DEFAULT_LIB__', '/D', 'WIN32', '/DPNG_ABORT=abort'])
+    env.Append(CPPFLAGS=['/D__WRL_NO_DEFAULT_LIB__', '/DWIN32', '/DPNG_ABORT=abort'])
 
     env.Append(CPPFLAGS=['/AI', vc_base_path + 'lib/store/references'])
     env.Append(CPPFLAGS=['/AI', vc_base_path + 'lib/x86/store/references'])
 
-    env.Append(CCFLAGS='/FS /MP /GS /wd"4453" /wd"28204" /wd"4291" /Zc:wchar_t /Gm- /fp:precise /D "_UNICODE" /D "UNICODE" /D "WINAPI_FAMILY=WINAPI_FAMILY_APP" /errorReport:prompt /WX- /Zc:forScope /Gd /EHsc /nologo'.split())
-    env.Append(CXXFLAGS='/ZW /FS'.split())
+    env.Append(CCFLAGS='/FS /MP /GS /wd"4453" /wd"28204" /wd"4291" /Zc:wchar_t /Gm- /fp:precise /errorReport:prompt /WX- /Zc:forScope /Gd /EHsc /nologo'.split())
+    env.Append(CPPFLAGS=['/D_UNICODE', '/DUNICODE', '/D "WINAPI_FAMILY=WINAPI_FAMILY_APP"'])
+    env.Append(CXXFLAGS=['/ZW'])
     env.Append(CCFLAGS=['/AI', vc_base_path + '\\vcpackages', '/AI', os.environ['WINDOWSSDKDIR'] + '\\References\\CommonConfiguration\\Neutral'])
 
     ## Link flags

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -273,7 +273,8 @@ def configure_mingw(env):
            env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "release_debug"):
-        env.Append(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
+        env.Append(CCFLAGS=['-O2'])
+        env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
         if (env["debug_symbols"] == "yes"):
            env.Prepend(CCFLAGS=['-g1'])
         if (env["debug_symbols"] == "full"):
@@ -284,7 +285,8 @@ def configure_mingw(env):
            env.Prepend(CCFLAGS=['-Os'])
 
     elif (env["target"] == "debug"):
-        env.Append(CCFLAGS=['-g3', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+        env.Append(CCFLAGS=['-g3'])
+        env.Append(CPPFLAGS=['-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
 
     ## Compiler configuration
 
@@ -325,11 +327,12 @@ def configure_mingw(env):
 
     ## Compile flags
 
-    env.Append(CCFLAGS=['-DWINDOWS_ENABLED', '-mwindows'])
-    env.Append(CCFLAGS=['-DOPENGL_ENABLED'])
-    env.Append(CCFLAGS=['-DWASAPI_ENABLED'])
-    env.Append(CCFLAGS=['-DWINMIDI_ENABLED'])
-    env.Append(CCFLAGS=['-DWINVER=%s' % env['target_win_version'], '-D_WIN32_WINNT=%s' % env['target_win_version']])
+    env.Append(CCFLAGS=['-mwindows'])
+    env.Append(CPPFLAGS=['-DWINDOWS_ENABLED'])
+    env.Append(CPPFLAGS=['-DOPENGL_ENABLED'])
+    env.Append(CPPFLAGS=['-DWASAPI_ENABLED'])
+    env.Append(CPPFLAGS=['-DWINMIDI_ENABLED'])
+    env.Append(CPPFLAGS=['-DWINVER=%s' % env['target_win_version'], '-D_WIN32_WINNT=%s' % env['target_win_version']])
     env.Append(LIBS=['mingw32', 'opengl32', 'dsound', 'ole32', 'd3d9', 'winmm', 'gdi32', 'iphlpapi', 'shlwapi', 'wsock32', 'ws2_32', 'kernel32', 'oleaut32', 'dinput8', 'dxguid', 'ksuser', 'imm32', 'bcrypt', 'avrt', 'uuid'])
 
     env.Append(CPPFLAGS=['-DMINGW_ENABLED'])

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -98,9 +98,10 @@ def configure(env):
 
     elif (env["target"] == "release_debug"):
         if (env["optimize"] == "speed"): #optimize for speed (default)
-            env.Prepend(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
+            env.Prepend(CCFLAGS=['-O2'])
         else: #optimize for size
-            env.Prepend(CCFLAGS=['-Os', '-DDEBUG_ENABLED'])
+            env.Prepend(CCFLAGS=['-Os'])
+        env.Prepend(CPPFLAGS=['-DDEBUG_ENABLED'])
 
         if (env["debug_symbols"] == "yes"):
             env.Prepend(CCFLAGS=['-g1'])
@@ -108,7 +109,8 @@ def configure(env):
             env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "debug"):
-        env.Prepend(CCFLAGS=['-g3', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+        env.Prepend(CCFLAGS=['-g3'])
+        env.Prepend(CPPFLAGS=['-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
         env.Append(LINKFLAGS=['-rdynamic'])
 
     ## Architecture
@@ -315,10 +317,10 @@ def configure(env):
     ## Cross-compilation
 
     if (is64 and env["bits"] == "32"):
-        env.Append(CPPFLAGS=['-m32'])
+        env.Append(CCFLAGS=['-m32'])
         env.Append(LINKFLAGS=['-m32', '-L/usr/lib/i386-linux-gnu'])
     elif (not is64 and env["bits"] == "64"):
-        env.Append(CPPFLAGS=['-m64'])
+        env.Append(CCFLAGS=['-m64'])
         env.Append(LINKFLAGS=['-m64', '-L/usr/lib/i686-linux-gnu'])
 
     # Link those statically for portability


### PR DESCRIPTION
Many contributors (me included) did not fully understand what CCFLAGS,
CXXFLAGS and CPPFLAGS refer to exactly, and were thus not using them
in the way they are intended to be.

As per the SCons manual: https://www.scons.org/doc/HTML/scons-user/apa.html

- CCFLAGS: General options that are passed to the C and C++ compilers.
- CFLAGS: General options that are passed to the C compiler (C only;
  not C++).
- CXXFLAGS: General options that are passed to the C++ compiler. By
  default, this includes the value of $CCFLAGS, so that setting
  $CCFLAGS affects both C and C++ compilation.
- CPPFLAGS: User-specified C preprocessor options. These will be
  included in any command that uses the C preprocessor, including not
  just compilation of C and C++ source files [...], but also [...]
  Fortran [...] and [...] assembly language source file[s].

TL;DR: Compiler options go to CCFLAGS, unless they must be restricted
to either C (CFLAGS) or C++ (CXXFLAGS). Preprocessor defines go to
CPPFLAGS.

---

Note: The documentation also mentions `CPPDEFINES` as a portable way to set preprocessor options. Some of our SCons scripts already use it, and we could think to general its use and avoid the ambiguous `CPPFLAGS`.

Supersedes #28373 (changes included in this PR too).