### PR TITLE
Support for binary literals in GDScript

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1725,6 +1725,45 @@ int64_t String::hex_to_int64(bool p_with_prefix) const {
 	return hex * sign;
 }
 
+int64_t String::bin_to_int64(bool p_with_prefix) const {
+
+	if (p_with_prefix && length() < 3)
+		return 0;
+
+	const CharType *s = ptr();
+
+	int64_t sign = s[0] == '-' ? -1 : 1;
+
+	if (sign < 0) {
+		s++;
+	}
+
+	if (p_with_prefix) {
+		if (s[0] != '0' || s[1] != 'b')
+			return 0;
+		s += 2;
+	}
+
+	int64_t binary = 0;
+
+	while (*s) {
+
+		CharType c = LOWERCASE(*s);
+		int64_t n;
+		if (c == '0' || c == '1') {
+			n = c - '0';
+		} else {
+			return 0;
+		}
+
+		binary *= 2;
+		binary += n;
+		s++;
+	}
+
+	return binary * sign;
+}
+
 int String::to_int() const {
 
 	if (length() == 0)

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -251,6 +251,7 @@ public:
 	int to_int() const;
 
 	int64_t hex_to_int64(bool p_with_prefix = true) const;
+	int64_t bin_to_int64(bool p_with_prefix = true) const;
 	int64_t to_int64() const;
 	static int to_int(const char *p_str, int p_len = -1);
 	static double to_double(const char *p_str);

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -56,6 +56,10 @@ static bool _is_hex_symbol(CharType c) {
 	return ((c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'));
 }
 
+static bool _is_bin_symbol(CharType c) {
+	return (c == '0' || c == '1');
+}
+
 Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_highlighting(int p_line) {
 	Map<int, TextEdit::HighlighterInfo> color_map;
 
@@ -76,6 +80,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 	bool in_member_variable = false;
 	bool in_node_path = false;
 	bool is_hex_notation = false;
+	bool is_bin_notation = false;
 	bool expect_type = false;
 	Color keyword_color;
 	Color color;
@@ -118,14 +123,26 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 			is_hex_notation = false;
 		}
 
+		// disallow anything not a 0 or 1
+		if (is_bin_notation && (_is_bin_symbol(str[j]))) {
+			is_number = true;
+		} else if (is_bin_notation) {
+			is_bin_notation = false;
+			is_number = false;
+		} else {
+			is_bin_notation = false;
+		}
+
 		// check for dot or underscore or 'x' for hex notation in floating point number or 'e' for scientific notation
-		if ((str[j] == '.' || str[j] == 'x' || str[j] == '_' || str[j] == 'e') && !in_word && prev_is_number && !is_number) {
+		if ((str[j] == '.' || str[j] == 'x' || str[j] == 'b' || str[j] == '_' || str[j] == 'e') && !in_word && prev_is_number && !is_number) {
 			is_number = true;
 			is_symbol = false;
 			is_char = false;
 
 			if (str[j] == 'x' && str[j - 1] == '0') {
 				is_hex_notation = true;
+			} else if (str[j] == 'b' && str[j - 1] == '0') {
+				is_bin_notation = true;
 			}
 		}
 


### PR DESCRIPTION
Adds support for binary literals format `0bxxxx`. Adds highlighting of binary literals in the editor. Adds error for points placed in hex literals

*Bugsquad edit:* Fixes #25755.