### PR TITLE
C#: Deprecate accessor methods and generate correct int and float types

### DIFF
--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -9,6 +9,12 @@ public:
 	$ifret R$ $ifnoret void$ (T::*method)($arg, P@$) $ifconst const$;
 #ifdef DEBUG_METHODS_ENABLED
 	virtual Variant::Type _gen_argument_type(int p_arg) const { return _get_argument_type(p_arg); }
+	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const {
+		$ifret if (p_arg==-1) return GetTypeInfo<R>::METADATA;$
+		$arg if (p_arg==(@-1)) return GetTypeInfo<P@>::METADATA;
+		$
+		return GodotTypeInfo::METADATA_NONE;
+	}
 	Variant::Type _get_argument_type(int p_argument) const {
 		$ifret if (p_argument==-1) return (Variant::Type)GetTypeInfo<R>::VARIANT_TYPE;$
 		$arg if (p_argument==(@-1)) return (Variant::Type)GetTypeInfo<P@>::VARIANT_TYPE;
@@ -94,6 +100,12 @@ public:
 
 #ifdef DEBUG_METHODS_ENABLED
 	virtual Variant::Type _gen_argument_type(int p_arg) const { return _get_argument_type(p_arg); }
+	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const {
+		$ifret if (p_arg==-1) return GetTypeInfo<R>::METADATA;$
+		$arg if (p_arg==(@-1)) return GetTypeInfo<P@>::METADATA;
+		$
+		return GodotTypeInfo::METADATA_NONE;
+	}
 
 	Variant::Type _get_argument_type(int p_argument) const {
 		$ifret if (p_argument==-1) return (Variant::Type)GetTypeInfo<R>::VARIANT_TYPE;$

--- a/core/method_bind.h
+++ b/core/method_bind.h
@@ -273,6 +273,8 @@ public:
 	void set_argument_names(const Vector<StringName> &p_names); //set by class, db, can't be inferred otherwise
 	Vector<StringName> get_argument_names() const;
 
+	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const = 0;
+
 #endif
 	void set_hint_flags(uint32_t p_hint) { hint_flags = p_hint; }
 	uint32_t get_hint_flags() const { return hint_flags | (is_const() ? METHOD_FLAG_CONST : 0) | (is_vararg() ? METHOD_FLAG_VARARG : 0); }
@@ -327,6 +329,10 @@ public:
 
 	virtual Variant::Type _gen_argument_type(int p_arg) const {
 		return _gen_argument_type_info(p_arg).type;
+	}
+
+	virtual GodotTypeInfo::Metadata get_argument_meta(int) const {
+		return GodotTypeInfo::METADATA_NONE;
 	}
 
 #else

--- a/core/reference.h
+++ b/core/reference.h
@@ -375,7 +375,8 @@ struct PtrToArg<const RefPtr &> {
 
 template <class T>
 struct GetTypeInfo<Ref<T> > {
-	enum { VARIANT_TYPE = Variant::OBJECT };
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());
@@ -384,7 +385,8 @@ struct GetTypeInfo<Ref<T> > {
 
 template <class T>
 struct GetTypeInfo<const Ref<T> &> {
-	enum { VARIANT_TYPE = Variant::OBJECT };
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());

--- a/core/type_info.h
+++ b/core/type_info.h
@@ -67,43 +67,80 @@ struct TypeInherits {
 							  !TypesAreSame<B volatile const, void volatile const>::value;
 };
 
+namespace GodotTypeInfo {
+enum Metadata {
+	METADATA_NONE,
+	METADATA_INT_IS_INT8,
+	METADATA_INT_IS_INT16,
+	METADATA_INT_IS_INT32,
+	METADATA_INT_IS_INT64,
+	METADATA_INT_IS_UINT8,
+	METADATA_INT_IS_UINT16,
+	METADATA_INT_IS_UINT32,
+	METADATA_INT_IS_UINT64,
+	METADATA_REAL_IS_FLOAT,
+	METADATA_REAL_IS_DOUBLE
+};
+}
+
 template <class T, typename = void>
 struct GetTypeInfo {
 	static const Variant::Type VARIANT_TYPE = Variant::NIL;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		ERR_PRINT("GetTypeInfo fallback. Bug!");
 		return PropertyInfo(); // Not "Nil", this is an error
 	}
 };
 
-#define MAKE_TYPE_INFO(m_type, m_var_type)                    \
-	template <>                                               \
-	struct GetTypeInfo<m_type> {                              \
-		static const Variant::Type VARIANT_TYPE = m_var_type; \
-		static inline PropertyInfo get_class_info() {         \
-			return PropertyInfo(VARIANT_TYPE, String());      \
-		}                                                     \
-	};                                                        \
-	template <>                                               \
-	struct GetTypeInfo<const m_type &> {                      \
-		static const Variant::Type VARIANT_TYPE = m_var_type; \
-		static inline PropertyInfo get_class_info() {         \
-			return PropertyInfo(VARIANT_TYPE, String());      \
-		}                                                     \
+#define MAKE_TYPE_INFO(m_type, m_var_type)                                            \
+	template <>                                                                       \
+	struct GetTypeInfo<m_type> {                                                      \
+		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() {                                 \
+			return PropertyInfo(VARIANT_TYPE, String());                              \
+		}                                                                             \
+	};                                                                                \
+	template <>                                                                       \
+	struct GetTypeInfo<const m_type &> {                                              \
+		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() {                                 \
+			return PropertyInfo(VARIANT_TYPE, String());                              \
+		}                                                                             \
+	};
+
+#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata)    \
+	template <>                                                     \
+	struct GetTypeInfo<m_type> {                                    \
+		static const Variant::Type VARIANT_TYPE = m_var_type;       \
+		static const GodotTypeInfo::Metadata METADATA = m_metadata; \
+		static inline PropertyInfo get_class_info() {               \
+			return PropertyInfo(VARIANT_TYPE, String());            \
+		}                                                           \
+	};                                                              \
+	template <>                                                     \
+	struct GetTypeInfo<const m_type &> {                            \
+		static const Variant::Type VARIANT_TYPE = m_var_type;       \
+		static const GodotTypeInfo::Metadata METADATA = m_metadata; \
+		static inline PropertyInfo get_class_info() {               \
+			return PropertyInfo(VARIANT_TYPE, String());            \
+		}                                                           \
 	};
 
 MAKE_TYPE_INFO(bool, Variant::BOOL)
-MAKE_TYPE_INFO(uint8_t, Variant::INT)
-MAKE_TYPE_INFO(int8_t, Variant::INT)
-MAKE_TYPE_INFO(uint16_t, Variant::INT)
-MAKE_TYPE_INFO(int16_t, Variant::INT)
-MAKE_TYPE_INFO(uint32_t, Variant::INT)
-MAKE_TYPE_INFO(int32_t, Variant::INT)
-MAKE_TYPE_INFO(int64_t, Variant::INT)
-MAKE_TYPE_INFO(uint64_t, Variant::INT)
+MAKE_TYPE_INFO_WITH_META(uint8_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT8)
+MAKE_TYPE_INFO_WITH_META(int8_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT8)
+MAKE_TYPE_INFO_WITH_META(uint16_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT16)
+MAKE_TYPE_INFO_WITH_META(int16_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT16)
+MAKE_TYPE_INFO_WITH_META(uint32_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT32)
+MAKE_TYPE_INFO_WITH_META(int32_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT32)
+MAKE_TYPE_INFO_WITH_META(uint64_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT64)
+MAKE_TYPE_INFO_WITH_META(int64_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_INT64)
 MAKE_TYPE_INFO(wchar_t, Variant::INT)
-MAKE_TYPE_INFO(float, Variant::REAL)
-MAKE_TYPE_INFO(double, Variant::REAL)
+MAKE_TYPE_INFO_WITH_META(float, Variant::REAL, GodotTypeInfo::METADATA_REAL_IS_FLOAT)
+MAKE_TYPE_INFO_WITH_META(double, Variant::REAL, GodotTypeInfo::METADATA_REAL_IS_DOUBLE)
 
 MAKE_TYPE_INFO(String, Variant::STRING)
 MAKE_TYPE_INFO(Vector2, Variant::VECTOR2)
@@ -138,6 +175,7 @@ MAKE_TYPE_INFO(BSP_Tree, Variant::DICTIONARY)
 template <>
 struct GetTypeInfo<RefPtr> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, "Reference");
 	}
@@ -145,6 +183,7 @@ struct GetTypeInfo<RefPtr> {
 template <>
 struct GetTypeInfo<const RefPtr &> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, "Reference");
 	}
@@ -154,6 +193,7 @@ struct GetTypeInfo<const RefPtr &> {
 template <>
 struct GetTypeInfo<Variant> {
 	static const Variant::Type VARIANT_TYPE = Variant::NIL;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 	}
@@ -162,25 +202,28 @@ struct GetTypeInfo<Variant> {
 template <>
 struct GetTypeInfo<const Variant &> {
 	static const Variant::Type VARIANT_TYPE = Variant::NIL;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 	}
 };
 
-#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type) \
-	template <>                                                 \
-	struct GetTypeInfo<m_template<m_type> > {                   \
-		static const Variant::Type VARIANT_TYPE = m_var_type;   \
-		static inline PropertyInfo get_class_info() {           \
-			return PropertyInfo(VARIANT_TYPE, String());        \
-		}                                                       \
-	};                                                          \
-	template <>                                                 \
-	struct GetTypeInfo<const m_template<m_type> &> {            \
-		static const Variant::Type VARIANT_TYPE = m_var_type;   \
-		static inline PropertyInfo get_class_info() {           \
-			return PropertyInfo(VARIANT_TYPE, String());        \
-		}                                                       \
+#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)                       \
+	template <>                                                                       \
+	struct GetTypeInfo<m_template<m_type> > {                                         \
+		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() {                                 \
+			return PropertyInfo(VARIANT_TYPE, String());                              \
+		}                                                                             \
+	};                                                                                \
+	template <>                                                                       \
+	struct GetTypeInfo<const m_template<m_type> &> {                                  \
+		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() {                                 \
+			return PropertyInfo(VARIANT_TYPE, String());                              \
+		}                                                                             \
 	};
 
 MAKE_TEMPLATE_TYPE_INFO(Vector, uint8_t, Variant::POOL_BYTE_ARRAY)
@@ -202,6 +245,7 @@ MAKE_TEMPLATE_TYPE_INFO(PoolVector, Face3, Variant::POOL_VECTOR3_ARRAY)
 template <typename T>
 struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
 	}
@@ -210,6 +254,7 @@ struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type>
 template <typename T>
 struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
 	}
@@ -219,6 +264,7 @@ struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>:
 	template <>                                                                                                                                                                   \
 	struct GetTypeInfo<m_impl> {                                                                                                                                                  \
 		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                                                   \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                                                             \
 		static inline PropertyInfo get_class_info() {                                                                                                                             \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, String(#m_enum).replace("::", ".")); \
 		}                                                                                                                                                                         \

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -131,14 +131,6 @@ void CSharpLanguage::finish() {
 
 	finalizing = true;
 
-#ifdef TOOLS_ENABLED
-	// Must be here, to avoid StringName leaks
-	if (BindingsGenerator::singleton) {
-		memdelete(BindingsGenerator::singleton);
-		BindingsGenerator::singleton = NULL;
-	}
-#endif
-
 	// Make sure all script binding gchandles are released before finalizing GDMono
 	for (Map<Object *, CSharpScriptBinding>::Element *E = script_bindings.front(); E; E = E->next()) {
 		CSharpScriptBinding &script_binding = E->value();

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -159,6 +159,9 @@ class BindingsGenerator {
 
 		const DocData::MethodDoc *method_doc;
 
+		bool is_deprecated;
+		String deprecation_message;
+
 		void add_argument(const ArgumentInterface &argument) {
 			arguments.push_back(argument);
 		}
@@ -169,6 +172,7 @@ class BindingsGenerator {
 			requires_object_call = false;
 			is_internal = false;
 			method_doc = NULL;
+			is_deprecated = false;
 		}
 	};
 

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -164,7 +164,6 @@ class BindingsGenerator {
 		}
 
 		MethodInterface() {
-			return_type.cname = BindingsGenerator::get_singleton()->name_cache.type_void;
 			is_vararg = false;
 			is_virtual = false;
 			requires_object_call = false;
@@ -469,7 +468,7 @@ class BindingsGenerator {
 		}
 	};
 
-	static bool verbose_output;
+	bool log_print_enabled;
 
 	OrderedHashMap<StringName, TypeInterface> obj_types;
 
@@ -515,6 +514,7 @@ class BindingsGenerator {
 			enum_Error = StaticCString::create("Error");
 		}
 
+	private:
 		NameCache(const NameCache &);
 		NameCache &operator=(const NameCache &);
 	};
@@ -578,33 +578,26 @@ class BindingsGenerator {
 
 	Error _save_file(const String &p_path, const StringBuilder &p_content);
 
-	BindingsGenerator() {}
+	void _log(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;
 
-	BindingsGenerator(const BindingsGenerator &);
-	BindingsGenerator &operator=(const BindingsGenerator &);
-
-	friend class CSharpLanguage;
-	static BindingsGenerator *singleton;
+	void _initialize();
 
 public:
-	Error generate_cs_core_project(const String &p_solution_dir, DotNetSolution &r_solution, bool p_verbose_output = true);
-	Error generate_cs_editor_project(const String &p_solution_dir, DotNetSolution &r_solution, bool p_verbose_output = true);
-	Error generate_cs_api(const String &p_output_dir, bool p_verbose_output = true);
+	Error generate_cs_core_project(const String &p_solution_dir, DotNetSolution &r_solution);
+	Error generate_cs_editor_project(const String &p_solution_dir, DotNetSolution &r_solution);
+	Error generate_cs_api(const String &p_output_dir);
 	Error generate_glue(const String &p_output_dir);
+
+	void set_log_print_enabled(bool p_enabled) { log_print_enabled = p_enabled; }
 
 	static uint32_t get_version();
 
-	void initialize();
-
-	_FORCE_INLINE_ static BindingsGenerator *get_singleton() {
-		if (!singleton) {
-			singleton = memnew(BindingsGenerator);
-			singleton->initialize();
-		}
-		return singleton;
-	}
-
 	static void handle_cmdline_args(const List<String> &p_cmdline_args);
+
+	BindingsGenerator() :
+			log_print_enabled(true) {
+		_initialize();
+	}
 };
 
 #endif

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -403,8 +403,8 @@ class BindingsGenerator {
 		}
 
 		static void postsetup_enum_type(TypeInterface &r_enum_itype) {
-			// C interface is the same as that of 'int'. Remember to apply any
-			// changes done here to the 'int' type interface as well
+			// C interface for enums is the same as that of 'uint32_t'. Remember to apply
+			// any of the changes done here to the 'uint32_t' type interface as well.
 
 			r_enum_itype.c_arg_in = "&%s_in";
 			{
@@ -493,7 +493,6 @@ class BindingsGenerator {
 
 	struct NameCache {
 		StringName type_void;
-		StringName type_int;
 		StringName type_Array;
 		StringName type_Dictionary;
 		StringName type_Variant;
@@ -504,9 +503,19 @@ class BindingsGenerator {
 		StringName type_at_GlobalScope;
 		StringName enum_Error;
 
+		StringName type_sbyte;
+		StringName type_short;
+		StringName type_int;
+		StringName type_long;
+		StringName type_byte;
+		StringName type_ushort;
+		StringName type_uint;
+		StringName type_ulong;
+		StringName type_float;
+		StringName type_double;
+
 		NameCache() {
 			type_void = StaticCString::create("void");
-			type_int = StaticCString::create("int");
 			type_Array = StaticCString::create("Array");
 			type_Dictionary = StaticCString::create("Dictionary");
 			type_Variant = StaticCString::create("Variant");
@@ -516,6 +525,17 @@ class BindingsGenerator {
 			type_String = StaticCString::create("String");
 			type_at_GlobalScope = StaticCString::create("@GlobalScope");
 			enum_Error = StaticCString::create("Error");
+
+			type_sbyte = StaticCString::create("sbyte");
+			type_short = StaticCString::create("short");
+			type_int = StaticCString::create("int");
+			type_long = StaticCString::create("long");
+			type_byte = StaticCString::create("byte");
+			type_ushort = StaticCString::create("ushort");
+			type_uint = StaticCString::create("uint");
+			type_ulong = StaticCString::create("ulong");
+			type_float = StaticCString::create("float");
+			type_double = StaticCString::create("double");
 		}
 
 	private:
@@ -563,6 +583,9 @@ class BindingsGenerator {
 
 	const TypeInterface *_get_type_or_null(const TypeReference &p_typeref);
 	const TypeInterface *_get_type_or_placeholder(const TypeReference &p_typeref);
+
+	StringName _get_int_type_name_from_meta(GodotTypeInfo::Metadata p_meta);
+	StringName _get_float_type_name_from_meta(GodotTypeInfo::Metadata p_meta);
 
 	void _default_argument_from_variant(const Variant &p_val, ArgumentInterface &r_iarg);
 

--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -323,10 +323,13 @@ bool GodotSharpBuilds::make_api_assembly(APIAssembly::Type p_api_type) {
 	String api_sln_file = api_sln_dir.plus_file(API_SOLUTION_NAME ".sln");
 
 	if (!DirAccess::exists(api_sln_dir) || !FileAccess::exists(api_sln_file)) {
-		BindingsGenerator *gen = BindingsGenerator::get_singleton();
-		bool gen_verbose = OS::get_singleton()->is_stdout_verbose();
+		BindingsGenerator bindings_generator;
 
-		Error err = gen->generate_cs_api(api_sln_dir, gen_verbose);
+		if (!OS::get_singleton()->is_stdout_verbose()) {
+			bindings_generator.set_log_print_enabled(false);
+		}
+
+		Error err = bindings_generator.generate_cs_api(api_sln_dir);
 		if (err != OK) {
 			show_build_error_dialog("Failed to generate " API_SOLUTION_NAME " solution. Error: " + itos(err));
 			return false;

--- a/modules/mono/glue/Managed/Files/GD.cs
+++ b/modules/mono/glue/Managed/Files/GD.cs
@@ -111,7 +111,7 @@ namespace Godot
             godot_icall_GD_printt(Array.ConvertAll(what, x => x.ToString()));
         }
 
-        public static double Randf()
+        public static float Randf()
         {
             return godot_icall_GD_randf();
         }
@@ -224,13 +224,14 @@ namespace Godot
         internal extern static void godot_icall_GD_printt(object[] what);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static double godot_icall_GD_randf();
+        internal extern static float godot_icall_GD_randf();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static uint godot_icall_GD_randi();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static void godot_icall_GD_randomize();
+
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static double godot_icall_GD_rand_range(double from, double to);

--- a/modules/mono/glue/gd_glue.cpp
+++ b/modules/mono/glue/gd_glue.cpp
@@ -115,7 +115,7 @@ void godot_icall_GD_printt(MonoArray *p_what) {
 	print_line(str);
 }
 
-double godot_icall_GD_randf() {
+float godot_icall_GD_randf() {
 	return Math::randf();
 }
 

--- a/modules/mono/glue/gd_glue.h
+++ b/modules/mono/glue/gd_glue.h
@@ -53,7 +53,7 @@ void godot_icall_GD_prints(MonoArray *p_what);
 
 void godot_icall_GD_printt(MonoArray *p_what);
 
-double godot_icall_GD_randf();
+float godot_icall_GD_randf();
 
 uint32_t godot_icall_GD_randi();
 

--- a/modules/mono/mono_gd/gd_mono_log.cpp
+++ b/modules/mono/mono_gd/gd_mono_log.cpp
@@ -37,6 +37,7 @@
 #include "core/os/os.h"
 
 #include "../godotsharp_dirs.h"
+#include "../utils/string_utils.h"
 
 static int log_level_get_id(const char *p_log_level) {
 
@@ -125,27 +126,6 @@ void GDMonoLog::_delete_old_log_files(const String &p_logs_dir) {
 	da->list_dir_end();
 }
 
-static String format(const char *p_fmt, ...) {
-	va_list args;
-
-	va_start(args, p_fmt);
-	int len = vsnprintf(NULL, 0, p_fmt, args);
-	va_end(args);
-
-	len += 1; // for the trailing '/0'
-
-	char *buffer(memnew_arr(char, len));
-
-	va_start(args, p_fmt);
-	vsnprintf(buffer, len, p_fmt, args);
-	va_end(args);
-
-	String res(buffer);
-	memdelete_arr(buffer);
-
-	return res;
-}
-
 void GDMonoLog::initialize() {
 
 	CharString log_level = OS::get_singleton()->get_environment("GODOT_MONO_LOG_LEVEL").utf8();
@@ -172,7 +152,7 @@ void GDMonoLog::initialize() {
 		OS::Time time_now = OS::get_singleton()->get_time();
 		int pid = OS::get_singleton()->get_process_id();
 
-		String log_file_name = format("%d_%02d_%02d %02d.%02d.%02d (%d).txt",
+		String log_file_name = str_format("%d_%02d_%02d %02d.%02d.%02d (%d).txt",
 				date_now.year, date_now.month, date_now.day,
 				time_now.hour, time_now.min, time_now.sec, pid);
 

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -32,6 +32,8 @@
 
 #include "core/os/file_access.h"
 
+#include <stdio.h>
+
 namespace {
 
 int sfind(const String &p_text, int p_from) {
@@ -183,4 +185,51 @@ Error read_all_file_utf8(const String &p_path, String &r_content) {
 
 	r_content = source;
 	return OK;
+}
+
+// TODO: Move to variadic templates once we upgrade to C++11
+
+String str_format(const char *p_format, ...) {
+	va_list list;
+
+	va_start(list, p_format);
+	String res = str_format(p_format, list);
+	va_end(list);
+
+	return res;
+}
+// va_copy was defined in the C99, but not in C++ standards before C++11.
+// When you compile C++ without --std=c++<XX> option, compilers still define
+// va_copy, otherwise you have to use the internal version (__va_copy).
+#if !defined(va_copy)
+#if defined(__GNUC__)
+#define va_copy(d, s) __va_copy((d), (s))
+#else
+#define va_copy(d, s) ((d) = (s))
+#endif
+#endif
+
+#if defined(MINGW_ENABLED) || defined(_MSC_VER)
+#define vsnprintf vsnprintf_s
+#endif
+
+String str_format(const char *p_format, va_list p_list) {
+	va_list list;
+
+	va_copy(list, p_list);
+	int len = vsnprintf(NULL, 0, p_format, list);
+	va_end(list);
+
+	len += 1; // for the trailing '/0'
+
+	char *buffer(memnew_arr(char, len));
+
+	va_copy(list, p_list);
+	vsnprintf(buffer, len, p_format, list);
+	va_end(list);
+
+	String res(buffer);
+	memdelete_arr(buffer);
+
+	return res;
 }

--- a/modules/mono/utils/string_utils.h
+++ b/modules/mono/utils/string_utils.h
@@ -34,6 +34,8 @@
 #include "core/ustring.h"
 #include "core/variant.h"
 
+#include <stdarg.h>
+
 String sformat(const String &p_text, const Variant &p1 = Variant(), const Variant &p2 = Variant(), const Variant &p3 = Variant(), const Variant &p4 = Variant(), const Variant &p5 = Variant());
 
 #ifdef TOOLS_ENABLED
@@ -43,5 +45,16 @@ String escape_csharp_keyword(const String &p_name);
 #endif
 
 Error read_all_file_utf8(const String &p_path, String &r_content);
+
+#if defined(__GNUC__)
+#define _PRINTF_FORMAT_ATTRIBUTE_1_0 __attribute__((format(printf, 1, 0)))
+#define _PRINTF_FORMAT_ATTRIBUTE_1_2 __attribute__((format(printf, 1, 2)))
+#else
+#define _PRINTF_FORMAT_ATTRIBUTE_1_0
+#define _PRINTF_FORMAT_ATTRIBUTE_1_2
+#endif
+
+String str_format(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_1_2;
+String str_format(const char *p_format, va_list p_list) _PRINTF_FORMAT_ATTRIBUTE_1_0;
 
 #endif // STRING_FORMAT_H


### PR DESCRIPTION
- Methods that act as accessors for properties in the same class (like `GetPosition` and `SetPosition` are for `Position`) are now marked as obsolete. They will be made private in the future.
- The C# bindings generator correct integer and floating point types (no more int and float everything). Closes #28393
