### PR TITLE
Mono: Lazily load scripts metadata file

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -919,7 +919,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 }
 #endif
 
-void CSharpLanguage::project_assembly_loaded() {
+void CSharpLanguage::_load_scripts_metadata() {
 
 	scripts_metadata.clear();
 
@@ -953,6 +953,7 @@ void CSharpLanguage::project_assembly_loaded() {
 		}
 
 		scripts_metadata = old_dict_var.operator Dictionary();
+		scripts_metadata_invalidated = false;
 
 		print_verbose("Successfully loaded scripts metadata");
 	} else {
@@ -1024,11 +1025,13 @@ bool CSharpLanguage::debug_break(const String &p_error, bool p_allow_continue) {
 	}
 }
 
-void CSharpLanguage::_uninitialize_script_bindings() {
+void CSharpLanguage::_on_scripts_domain_unloaded() {
 	for (Map<Object *, CSharpScriptBinding>::Element *E = script_bindings.front(); E; E = E->next()) {
 		CSharpScriptBinding &script_binding = E->value();
 		script_binding.inited = false;
 	}
+
+	scripts_metadata_invalidated = true;
 }
 
 void CSharpLanguage::set_language_index(int p_idx) {
@@ -1086,6 +1089,8 @@ CSharpLanguage::CSharpLanguage() {
 #endif
 
 	lang_idx = -1;
+
+	scripts_metadata_invalidated = true;
 }
 
 CSharpLanguage::~CSharpLanguage() {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -309,14 +309,17 @@ class CSharpLanguage : public ScriptLanguage {
 	int lang_idx;
 
 	Dictionary scripts_metadata;
+	bool scripts_metadata_invalidated;
 
 	// For debug_break and debug_break_parse
 	int _debug_parse_err_line;
 	String _debug_parse_err_file;
 	String _debug_error;
 
+	void _load_scripts_metadata();
+
 	friend class GDMono;
-	void _uninitialize_script_bindings();
+	void _on_scripts_domain_unloaded();
 
 public:
 	StringNameCache string_names;
@@ -341,9 +344,15 @@ public:
 	void reload_assemblies(bool p_soft_reload);
 #endif
 
-	void project_assembly_loaded();
+	_FORCE_INLINE_ Dictionary get_scripts_metadata_or_nothing() {
+		return scripts_metadata_invalidated ? Dictionary() : scripts_metadata;
+	}
 
-	_FORCE_INLINE_ const Dictionary &get_scripts_metadata() { return scripts_metadata; }
+	_FORCE_INLINE_ const Dictionary &get_scripts_metadata() {
+		if (scripts_metadata_invalidated)
+			_load_scripts_metadata();
+		return scripts_metadata;
+	}
 
 	virtual String get_name() const;
 

--- a/modules/mono/editor/csharp_project.cpp
+++ b/modules/mono/editor/csharp_project.cpp
@@ -158,7 +158,7 @@ Error generate_scripts_metadata(const String &p_project_path, const String &p_ou
 	PoolStringArray project_files = GDMonoMarshal::mono_array_to_PoolStringArray(ret);
 	PoolStringArray::Read r = project_files.read();
 
-	Dictionary old_dict = CSharpLanguage::get_singleton()->get_scripts_metadata();
+	Dictionary old_dict = CSharpLanguage::get_singleton()->get_scripts_metadata_or_nothing();
 	Dictionary new_dict;
 
 	for (int i = 0; i < project_files.size(); i++) {

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -658,8 +658,6 @@ bool GDMono::_load_project_assembly() {
 
 	if (success) {
 		mono_assembly_set_main(project_assembly->get_assembly());
-
-		CSharpLanguage::get_singleton()->project_assembly_loaded();
 	} else {
 		if (OS::get_singleton()->is_stdout_verbose())
 			print_error("Mono: Failed to load project assembly");
@@ -866,7 +864,7 @@ Error GDMono::reload_scripts_domain() {
 		}
 	}
 
-	CSharpLanguage::get_singleton()->_uninitialize_script_bindings();
+	CSharpLanguage::get_singleton()->_on_scripts_domain_unloaded();
 
 	Error err = _load_scripts_domain();
 	if (err != OK) {


### PR DESCRIPTION
Only load the scripts metadata file when it's really needed. This way we avoid false errors, when there is no C# project,  about missing scripts metadata file.
