### PR TITLE
Fix builds made with Clang on some Linux distros (the equivalent of #23542 but for Clang)

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -1,7 +1,7 @@
 import os
 import platform
 import sys
-from methods import get_compiler_version, using_gcc
+from methods import get_compiler_version, using_gcc, using_clang
 
 
 def is_active():
@@ -182,6 +182,12 @@ def configure(env):
     if using_gcc(env):
         version = get_compiler_version(env)
         if version != None and version[0] >= '6':
+            env.Append(CCFLAGS=['-fpie'])
+            env.Append(LINKFLAGS=['-no-pie'])
+    # Do the same for clang should be fine with Clang 4 and higher
+    if using_clang(env):
+        version = get_compiler_version(env)
+        if version != None and version[0] >= '4':
             env.Append(CCFLAGS=['-fpie'])
             env.Append(LINKFLAGS=['-no-pie'])
 


### PR DESCRIPTION
This is the same as #23542 (Fix binaries incorrectly detected as shared
libraries on some linux distros) from @marcelofg55 but for Clang.

 It should be fine with
Clang 4 or higher (it was introduced on llvmorg-4.0.0-rc1 as one can see here:  
( https://github.com/llvm/llvm-project/commit/c3c4f46d07e397f76044a3c9c4888816ae3cc703  
_Hint: here it was introduced as -nopie since OpenBSD's binutils ld used to call it this way, but later they added an alias to be compatible with Gold, so **no-pie** should be fine )._

Tested it with the **PCManFM Filemanager** (which is still used by many lighter Linux distros) and now it can launch the result of a build directly when double clicking as one would expect by an executable. Before it was not possible after a build with clang. Now it also shows the typical executable icon for it.
 
Also the "file" command on Linux returned these results before:
```
file godot.x11.opt.tools.64.llvm 
godot.x11.opt.tools.64.llvm: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, with debug_info, not stripped

```

while now it brings this:
```
file godot.x11.opt.tools.64.llvm
godot.x11.opt.tools.64.llvm: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, with debug_info, not stripped

```

EDIT: on a second note this seems to also reduce the size for few megabytes, it's not much but could make a difference in game jams^^