### PR TITLE
Limit the size of the Manage Editor Feature Profiles dialog

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2451,7 +2451,13 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case SETTINGS_MANAGE_FEATURE_PROFILES: {
 
-			feature_profile_manager->popup_centered_ratio();
+			Size2 popup_size = Size2(900, 800) * editor_get_scale();
+			Size2 window_size = get_viewport()->get_size();
+
+			popup_size.x = MIN(window_size.x * 0.8, popup_size.x);
+			popup_size.y = MIN(window_size.y * 0.8, popup_size.y);
+
+			feature_profile_manager->popup_centered(popup_size);
 
 		} break;
 		case SETTINGS_TOGGLE_FULLSCREEN: {


### PR DESCRIPTION
This makes it more readable on large monitors.

## Preview

![image](https://user-images.githubusercontent.com/180032/56823463-322f1a00-6854-11e9-8861-d325d839cf31.png)