### PR TITLE
Partially implement enet_socket_set_option

### DIFF
--- a/thirdparty/enet/godot.cpp
+++ b/thirdparty/enet/godot.cpp
@@ -216,6 +216,46 @@ int enet_socket_listen(ENetSocket socket, int backlog) {
 
 int enet_socket_set_option(ENetSocket socket, ENetSocketOption option, int value) {
 
+	NetSocket *sock = (NetSocket *)socket;
+
+	switch (option) {
+		case ENET_SOCKOPT_NONBLOCK: {
+			sock->set_blocking_enabled(value ? false : true);
+			return 0;
+		} break;
+
+		case ENET_SOCKOPT_BROADCAST: {
+			sock->set_broadcasting_enabled(value ? true : false);
+			return 0;
+		} break;
+
+		case ENET_SOCKOPT_REUSEADDR: {
+			sock->set_reuse_address_enabled(value ? true : false);
+			return 0;
+		} break;
+
+		case ENET_SOCKOPT_RCVBUF: {
+			return -1;
+		} break;
+
+		case ENET_SOCKOPT_SNDBUF: {
+			return -1;
+		} break;
+
+		case ENET_SOCKOPT_RCVTIMEO: {
+			return -1;
+		} break;
+
+		case ENET_SOCKOPT_SNDTIMEO: {
+			return -1;
+		} break;
+
+		case ENET_SOCKOPT_NODELAY: {
+			sock->set_tcp_no_delay_enabled(value ? true : false);
+			return 0;
+		} break;
+	}
+
 	return -1;
 }
 

--- a/thirdparty/enet/godot.cpp
+++ b/thirdparty/enet/godot.cpp
@@ -95,7 +95,6 @@ ENetSocket enet_socket_create(ENetSocketType type) {
 	NetSocket *socket = NetSocket::create();
 	IP::Type ip_type = IP::TYPE_ANY;
 	socket->open(NetSocket::TYPE_UDP, ip_type);
-	socket->set_blocking_enabled(false);
 
 	return socket;
 }


### PR DESCRIPTION
This is needed because I use Godot's ENet in custom module and I want to create a socket using `enet_socket_create` and configure it using `enet_socket_set_option`. Since it's not implemented, I created this PR.

There's non-implemented options since Godot's class `NetSocket` has no corresponding methods.

Implemented options:
 - ENET_SOCKOPT_NONBLOCK
 - ENET_SOCKOPT_BROADCAST
 - ENET_SOCKOPT_REUSEADDR
 - ENET_SOCKOPT_NODELAY

Not implemented options:
 - ENET_SOCKOPT_RCVBUF
 - ENET_SOCKOPT_SNDBUF
 - ENET_SOCKOPT_RCVTIMEO
 - ENET_SOCKOPT_SNDTIMEO

Also, I removed a call to `set_blocking_enabled` from function `enet_socket_create` since it is already called from https://github.com/godotengine/godot/blob/master/thirdparty/enet/host.c#L63