### PR TITLE
Handle spaces correctly for base / parent scripts in the "New Script" dialog

### DIFF
--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -87,6 +87,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	void _lang_changed(int l = 0);
 	void _built_in_pressed();
 	bool _validate(const String &p_string);
+	String _validate_path(const String &p_path, bool p_file_must_exist);
 	void _class_name_changed(const String &p_name);
 	void _parent_name_changed(const String &p_parent);
 	void _template_changed(int p_template = 0);


### PR DESCRIPTION
The validation algorithm used for the selected parent script ("Inherits") did not account for spaces. If the parent script had a space in its name/path, an error was reported by the dialog. This made it impossible to inherit from a script with a space in its name.

This change unifies the path validation algorithm for the parent script's path with the one that is used for the path of the new script. This ensures that spaces are handled correctly and helps with a consistent path validation across the dialog.

fixes #27547