### PR TITLE
Emit signal when a thread has finished

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2393,6 +2393,7 @@ void _Thread::_start_func(void *ud) {
 	Thread::set_name(t->target_method);
 
 	t->ret = t->target_instance->call(t->target_method, arg, 1, ce);
+	t->emit_signal(CoreStringNames::get_singleton()->thread_finished);
 	if (ce.error != Variant::CallError::CALL_OK) {
 
 		String reason;
@@ -2483,6 +2484,8 @@ void _Thread::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_id"), &_Thread::get_id);
 	ClassDB::bind_method(D_METHOD("is_active"), &_Thread::is_active);
 	ClassDB::bind_method(D_METHOD("wait_to_finish"), &_Thread::wait_to_finish);
+
+	ADD_SIGNAL(MethodInfo("thread_finished"));
 
 	BIND_ENUM_CONSTANT(PRIORITY_LOW);
 	BIND_ENUM_CONSTANT(PRIORITY_NORMAL);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -31,6 +31,7 @@
 #ifndef CORE_BIND_H
 #define CORE_BIND_H
 
+#include "core/core_string_names.h"
 #include "core/image.h"
 #include "core/io/compression.h"
 #include "core/io/resource_loader.h"

--- a/core/core_string_names.cpp
+++ b/core/core_string_names.cpp
@@ -38,6 +38,7 @@ CoreStringNames::CoreStringNames() :
 		_meta(StaticCString::create("__meta__")),
 		_script(StaticCString::create("script")),
 		script_changed(StaticCString::create("script_changed")),
+		thread_finished(StaticCString::create("thread_finished")),
 		___pdcdata(StaticCString::create("___pdcdata")),
 		__getvar(StaticCString::create("__getvar")),
 		_iter_init(StaticCString::create("_iter_init")),

--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -56,6 +56,7 @@ public:
 	StringName _meta;
 	StringName _script;
 	StringName script_changed;
+	StringName thread_finished;
 	StringName ___pdcdata;
 	StringName __getvar;
 	StringName _iter_init;

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -6,6 +6,13 @@
 	<description>
 		A unit of execution in a process. Can run methods on [Object]s simultaneously. The use of synchronization via [Mutex], [Semaphore] is advised if working with shared objects.
 	</description>
+	<signals>
+		<signal name="thread_finished">
+			<description>
+				Emitted when thread has finished.
+			</description>
+		</signal>
+	</signals>
 	<tutorials>
 	</tutorials>
 	<demos>


### PR DESCRIPTION
`'wait_to_finish` function is a blocking function. If we need a thread it is because we want something to happen without blocking the main thread. So emitting an event once the thread has finished allows the user to `yield(thread, 'thread_finished')` and then to `wait_to_finish`