### PR TITLE
Reverts the change made to the editor progress dialog

### DIFF
--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -220,9 +220,8 @@ bool ProgressDialog::task_step(const String &p_task, const String &p_state, int 
 	last_progress_tick = OS::get_singleton()->get_ticks_usec();
 	if (cancel_hb->is_visible()) {
 		OS::get_singleton()->force_process_input();
-	} else {
-		OS::get_singleton()->process_and_drop_events();
 	}
+
 	Main::iteration(); // this will not work on a lot of platforms, so it's only meant for the editor
 	return cancelled;
 }


### PR DESCRIPTION
In faaecd6987ba27056b1866bc57e78a7246795c22

It was causing issues on Windows like, for example, when saving with CTRL+S the keys CTRL and S were stuck after saving and pressing only S would save the scene again until CTRL was pressed again.