### PR TITLE
Changed references to array types in arraymesh doc

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -205,31 +205,31 @@
 			Amount of weights/bone indices per vertex (always 4).
 		</constant>
 		<constant name="ARRAY_VERTEX" value="0" enum="ArrayType">
-			Vertex array (array of [Vector3] vertices).
+			[PoolVector3Array], [PoolVector2Array], or [Array] of vertex positions.
 		</constant>
 		<constant name="ARRAY_NORMAL" value="1" enum="ArrayType">
-			Normal array (array of [Vector3] normals).
+			[PoolVector3Array] of vertex normals.
 		</constant>
 		<constant name="ARRAY_TANGENT" value="2" enum="ArrayType">
-			Tangent array, array of groups of 4 floats. first 3 floats determine the tangent, and the last the binormal direction as -1 or 1.
+			[PoolRealArray] of vertex tangents. Each element in groups of 4 floats, first 3 floats determine the tangent, and the last the binormal direction as -1 or 1.
 		</constant>
 		<constant name="ARRAY_COLOR" value="3" enum="ArrayType">
-			Vertex array (array of [Color] colors).
+			[PoolColorArray] of vertex colors.
 		</constant>
 		<constant name="ARRAY_TEX_UV" value="4" enum="ArrayType">
-			UV array (array of [Vector3] UVs or float array of groups of 2 floats (u,v)).
+			[PoolVector2Array] for UV coordinates.
 		</constant>
 		<constant name="ARRAY_TEX_UV2" value="5" enum="ArrayType">
-			Second UV array (array of [Vector3] UVs or float array of groups of 2 floats (u,v)).
+			[PoolVector2Array] for second UV coordinates.
 		</constant>
 		<constant name="ARRAY_BONES" value="6" enum="ArrayType">
-			Array of bone indices, as a float array. Each element in groups of 4 floats.
+			[PoolRealArray] or [PoolIntArray] of bone indices. Each element in groups of 4 floats.
 		</constant>
 		<constant name="ARRAY_WEIGHTS" value="7" enum="ArrayType">
-			Array of bone weights, as a float array. Each element in groups of 4 floats.
+			[PoolRealArray] of bone weights. Each element in groups of 4 floats.
 		</constant>
 		<constant name="ARRAY_INDEX" value="8" enum="ArrayType">
-			[Array] of integers used as indices referencing vertices, colors, normals, tangents, and textures. All of those arrays must have the same number of elements as the vertex array. No index can be beyond the vertex array size. When this index array is present, it puts the function into "index mode," where the index selects the *i*'th vertex, normal, tangent, color, UV, etc. This means if you want to have different normals or colors along an edge, you have to duplicate the vertices.
+			[PoolIntArray] of integers used as indices referencing vertices, colors, normals, tangents, and textures. All of those arrays must have the same number of elements as the vertex array. No index can be beyond the vertex array size. When this index array is present, it puts the function into "index mode," where the index selects the *i*'th vertex, normal, tangent, color, UV, etc. This means if you want to have different normals or colors along an edge, you have to duplicate the vertices.
 			For triangles, the index array is interpreted as triples, referring to the vertices of each triangle. For lines, the index array is in pairs indicating the start and end of each line.
 		</constant>
 		<constant name="ARRAY_MAX" value="9" enum="ArrayType">


### PR DESCRIPTION
Before the references were just to normal Arrays, however, you need to use specific Pool**Arrays otherwise the engine throws an error. 