### PR TITLE
Optimize pooled string array joins

### DIFF
--- a/core/pool_vector.cpp
+++ b/core/pool_vector.cpp
@@ -80,7 +80,7 @@ String PoolVector<String>::join(String delimiter)
 
 	Read r = read();
 	bool useDelimiter = !delimiter.empty();
-	StringBuilder sb;
+	StringBuilder sb; sb.reserve_num_appends(useDelimiter ? s+s-1 : s);
 
 	for (int i = 0; i < s; i++) {
 		if (useDelimiter && (i >= 1)) {

--- a/core/pool_vector.cpp
+++ b/core/pool_vector.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "pool_vector.h"
+#include "string_builder.h"
 
 Mutex *pool_vector_lock = NULL;
 
@@ -68,4 +69,26 @@ void MemoryPool::cleanup() {
 
 	ERR_EXPLAINC("There are still MemoryPool allocs in use at exit!");
 	ERR_FAIL_COND(allocs_used > 0);
+}
+
+template<>
+String PoolVector<String>::join(String delimiter)
+{
+	int s = size();
+	if (s <= 0)
+		return "";
+
+	Read r = read();
+	bool useDelimiter = !delimiter.empty();
+	StringBuilder sb;
+
+	for (int i = 0; i < s; i++) {
+		if (useDelimiter && (i >= 1)) {
+			sb.append(delimiter);
+		}
+
+		sb.append(r[i]);
+	}
+
+	return sb.as_string();
 }

--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -442,14 +442,51 @@ public:
 	}
 
 	String join(String delimiter) {
-		String rs = "";
 		int s = size();
+		if (s <= 0)
+			return "";
+
+		// determine string length
 		Read r = read();
+		int delim_length = delimiter.length();
+		int string_length = -delim_length; // skip last delimiter
 		for (int i = 0; i < s; i++) {
-			rs += r[i] + delimiter;
+			string_length += r[i].length() + delim_length;
 		}
-		rs.erase(rs.length() - delimiter.length(), delimiter.length());
-		return rs;
+
+		if (string_length <= 0)
+			return "";
+
+		CharType *buffer = memnew_arr(CharType, string_length);
+		int current_position = 0;
+
+		for (int i = 0; i < s; i++) {
+			// copy delimiter
+			if (delim_length > 0 && i >= 1) {
+				memcpy(buffer + current_position, delimiter.ptr(), delim_length * sizeof(CharType));
+
+				current_position += delim_length;
+			}
+
+			// copy string
+			const String &str = r[i];
+			int sl = str.length();
+
+			if (sl > 0) {
+				memcpy(buffer + current_position, str.ptr(), sl * sizeof(CharType));
+
+				current_position += sl;
+			}
+		}
+
+		// done
+		CRASH_COND(current_position != string_length);
+
+		String final_string = String(buffer, string_length);
+
+		memdelete_arr(buffer);
+
+		return final_string;
 	}
 
 	bool is_locked() const { return alloc && alloc->lock > 0; }

--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -441,53 +441,7 @@ public:
 		return OK;
 	}
 
-	String join(String delimiter) {
-		int s = size();
-		if (s <= 0)
-			return "";
-
-		// determine string length
-		Read r = read();
-		int delim_length = delimiter.length();
-		int string_length = -delim_length; // skip last delimiter
-		for (int i = 0; i < s; i++) {
-			string_length += r[i].length() + delim_length;
-		}
-
-		if (string_length <= 0)
-			return "";
-
-		CharType *buffer = memnew_arr(CharType, string_length);
-		int current_position = 0;
-
-		for (int i = 0; i < s; i++) {
-			// copy delimiter
-			if (delim_length > 0 && i >= 1) {
-				memcpy(buffer + current_position, delimiter.ptr(), delim_length * sizeof(CharType));
-
-				current_position += delim_length;
-			}
-
-			// copy string
-			const String &str = r[i];
-			int sl = str.length();
-
-			if (sl > 0) {
-				memcpy(buffer + current_position, str.ptr(), sl * sizeof(CharType));
-
-				current_position += sl;
-			}
-		}
-
-		// done
-		CRASH_COND(current_position != string_length);
-
-		String final_string = String(buffer, string_length);
-
-		memdelete_arr(buffer);
-
-		return final_string;
-	}
+	String join(String delimiter);
 
 	bool is_locked() const { return alloc && alloc->lock > 0; }
 

--- a/core/string_builder.cpp
+++ b/core/string_builder.cpp
@@ -107,7 +107,7 @@ String StringBuilder::as_string() const {
 		} else {
 			// char* string
 			for (uint32_t j = 0; j < c.length; j++) {
-				buffer[current_position + j] = (const CharType)c.str_ptr[j];
+				buffer[current_position + j] = (CharType)c.str_ptr[j];
 			}
 
 			current_position += c.length;

--- a/core/string_builder.cpp
+++ b/core/string_builder.cpp
@@ -35,7 +35,7 @@
 StringBuilder &StringBuilder::append(const StringBuilder::Chunk &p_chunk)
 {
 	const double growthFactor = 1.7;
-	const int minCapacity = 4;
+	const int minCapacity = 8;
 	const int capacity = chunks.size();
 
 	if (capacity <= 0) {
@@ -54,6 +54,10 @@ StringBuilder &StringBuilder::append(const StringBuilder::Chunk &p_chunk)
 	chunks.set(chunks_count, p_chunk);
 
 	chunks_count++;
+	string_length += p_chunk.length;
+
+	if (!resultCache.empty())
+		resultCache.clear();
 
 	return *this;
 }
@@ -63,10 +67,7 @@ StringBuilder &StringBuilder::append(const String &p_string) {
 	if (p_string.empty())
 		return *this;
 
-	Chunk c(p_string);
-	append(c);
-
-	string_length += c.length;
+	append(Chunk(p_string));
 
 	return *this;
 }
@@ -80,15 +81,16 @@ StringBuilder &StringBuilder::append(const char *p_cstring) {
 
 	append(c);
 
-	string_length += (uint32_t)c.length;
-
 	return *this;
 }
 
 String StringBuilder::as_string() const {
 
 	if (string_length == 0)
-		return "";
+		return String();
+
+	if (!resultCache.empty())
+		return resultCache;
 
 	CharType *buffer = memnew_arr(CharType, string_length);
 
@@ -115,9 +117,9 @@ String StringBuilder::as_string() const {
 	// done
 	CRASH_COND((uint32_t)current_position != string_length);
 
-	String final_string = String(buffer, (int)string_length);
+	resultCache = String(buffer, (int)string_length);
 
 	memdelete_arr(buffer);
 
-	return final_string;
+	return resultCache;
 }

--- a/core/string_builder.h
+++ b/core/string_builder.h
@@ -54,6 +54,7 @@ class StringBuilder {
 	int chunks_count;
 
 	CowData<Chunk> chunks;
+	mutable String resultCache;
 
 private:
 

--- a/core/string_builder.h
+++ b/core/string_builder.h
@@ -32,21 +32,35 @@
 #define STRING_BUILDER_H
 
 #include "core/ustring.h"
-
-#include "core/vector.h"
+#include "core/cowdata.h"
 
 class StringBuilder {
 
+	struct Chunk {
+
+		const char* str_ptr;
+		String str_string; // if 'str_ptr' == nullptr
+		uint32_t length;
+
+		_FORCE_INLINE_ Chunk& operator = (const Chunk& c) { str_ptr = c.str_ptr; str_string = c.str_string; length = c.length; return *this; }
+		_FORCE_INLINE_ Chunk(const String& s) : str_ptr(nullptr), str_string(s), length((uint32_t)s.length()) {}
+		_FORCE_INLINE_ Chunk(const char* s) : str_ptr(s), length((uint32_t)strlen(s)) {}
+		_FORCE_INLINE_ Chunk() : str_ptr(nullptr), length(0) {}
+		_FORCE_INLINE_ ~Chunk() {}
+
+	};
+
 	uint32_t string_length;
+	int chunks_count;
 
-	Vector<String> strings;
-	Vector<const char *> c_strings;
+	CowData<Chunk> chunks;
 
-	// -1 means it's a Godot String
-	// a natural number means C string.
-	Vector<int32_t> appended_strings;
+private:
+
+	StringBuilder &append(const Chunk &p_chunk);
 
 public:
+
 	StringBuilder &append(const String &p_string);
 	StringBuilder &append(const char *p_cstring);
 
@@ -67,7 +81,7 @@ public:
 	}
 
 	_FORCE_INLINE_ int num_strings_appended() const {
-		return appended_strings.size();
+		return chunks_count;
 	}
 
 	_FORCE_INLINE_ uint32_t get_string_length() const {
@@ -82,6 +96,7 @@ public:
 
 	StringBuilder() {
 		string_length = 0;
+		chunks_count = 0;
 	}
 };
 

--- a/core/string_builder.h
+++ b/core/string_builder.h
@@ -81,6 +81,18 @@ public:
 		append(p_cstring);
 	}
 
+	_FORCE_INLINE_ int reserve_num_appends(int count) {
+		ERR_FAIL_COND_V(count < 0, 0);
+
+		if (count > chunks.size()) {
+			Error err = chunks.resize(count);
+			ERR_FAIL_COND_V(err, 0);
+			return count;
+		}
+
+		return chunks.size();
+	}
+
 	_FORCE_INLINE_ int num_strings_appended() const {
 		return chunks_count;
 	}

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -952,7 +952,7 @@ Vector<int> String::split_ints_mk(const Vector<String> &p_splitters, bool p_allo
 
 String String::join(Vector<String> parts) {
 	int ps = parts.size();
-	StringBuilder sb;
+	StringBuilder sb; sb.reserve_num_appends(ps);
 	for (int i = 0; i < ps; ++i) {
 		if (i > 0) {
 			sb.append(*this);

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -37,6 +37,7 @@
 #include "core/translation.h"
 #include "core/ucaps.h"
 #include "core/variant.h"
+#include "core/string_builder.h"
 
 #include "thirdparty/misc/md5.h"
 #include "thirdparty/misc/sha256.h"
@@ -950,14 +951,15 @@ Vector<int> String::split_ints_mk(const Vector<String> &p_splitters, bool p_allo
 }
 
 String String::join(Vector<String> parts) {
-	String ret;
-	for (int i = 0; i < parts.size(); ++i) {
+	int ps = parts.size();
+	StringBuilder sb;
+	for (int i = 0; i < ps; ++i) {
 		if (i > 0) {
-			ret += *this;
+			sb.append(*this);
 		}
-		ret += parts[i];
+		sb.append(parts[i]);
 	}
-	return ret;
+	return sb;
 }
 
 CharType String::char_uppercase(CharType p_char) {


### PR DESCRIPTION
This PR optimizes the [PoolStringArray.join()](https://docs.godotengine.org/en/3.1/classes/class_poolstringarray.html#class-poolstringarray-method-join) function by applying the logic used by the native [StringBuilder](https://github.com/godotengine/godot/blob/master/core/string_builder.cpp#L57) class. **The new implementation is about 9x faster in general and 4x faster for empty delimitiers.**

*Test A*: A single test joins 1000 random strings of 32 characters (GUIDs) with a comma.
*Test B*: A single test joins 1000 random strings of 32 characters (GUIDs) with an empty string.

Each test ran 100 times and these are the average duration of a single run. The time contains the join() call, only.

Test machine: Windows 10 Pro 1903, i7 3.3 GHz, 16 GB, SSD
Custom Build: VC++ 2019, release_debug, x64

| Build | Test A | Test B |
| --- | --- | --- |
|  | Test A | Test B |
| Exported offical 3.1 | 347 ms | 132 ms |
| Editor offical 3.1 | 368 ms | 136 ms |
| Editor w/ old impl | 423 ms | 171 ms |
| **Editor w/ new impl** | 47 ms | 43 ms |
| Editor w/ old StringBuilder | 1013 ms | 563 ms |
| **Editor w/ new StringBuilder** | 174 ms | 107 ms |

All join-results were tested against a static string to be correct.

The test source can be found here: https://gist.github.com/fkollmann/ee72937393fcff74fcd252cdaf2e2ce6
