### PR TITLE
Disable higlighting all occurences of selection in editor if it contains only whitespaces

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -825,6 +825,9 @@ void TextEdit::_notification(int p_what) {
 			// get the highlighted words
 			String highlighted_text = get_selection_text();
 
+			// check if highlighted words contains only whitespaces (tabs or spaces)
+			bool only_whitespaces_highlighted = highlighted_text.strip_edges() == String();
+
 			String line_num_padding = line_numbers_zero_padded ? "0" : " ";
 
 			int cursor_wrap_index = get_cursor_wrap_index();
@@ -1105,7 +1108,7 @@ void TextEdit::_notification(int p_what) {
 								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2i(char_ofs + char_margin + char_w + ofs_x - 1, ofs_y), Size2i(1, get_row_height())), border_color);
 						}
 
-						if (highlight_all_occurrences) {
+						if (highlight_all_occurrences && !only_whitespaces_highlighted) {
 							if (highlighted_text_col != -1) {
 
 								// if we are at the end check for new word on same line


### PR DESCRIPTION
As described in #28446 - do not highlight all occurrences of string in editor if selected string contains only whitespaces. 

No weird highlight with whitespaces anymore:
![image](https://user-images.githubusercontent.com/9964886/56855755-0d6a9d80-694d-11e9-935d-2a39e08f41e6.png)

Highlighting words still works:
![image](https://user-images.githubusercontent.com/9964886/56855786-c03afb80-694d-11e9-89a3-4052f95e3723.png)

Please review. 

*Bugsquad edit:* Fixes #28446.