### PR TITLE
Added SSR Resolution Selection

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -209,6 +209,8 @@
 		</member>
 		<member name="ss_reflections_fade_out" type="float" setter="set_ssr_fade_out" getter="get_ssr_fade_out">
 		</member>
+		<member name="ss_reflections_resolution" type="int" setter="set_ssr_resolution" getter="get_ssr_resolution" enum="Environment.SSRResolution">
+		</member>
 		<member name="ss_reflections_max_steps" type="int" setter="set_ssr_max_steps" getter="get_ssr_max_steps">
 		</member>
 		<member name="ss_reflections_roughness" type="bool" setter="set_ssr_rough" getter="is_ssr_rough">

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -1254,15 +1254,17 @@
 			</argument>
 			<argument index="1" name="enable" type="bool">
 			</argument>
-			<argument index="2" name="max_steps" type="int">
+			<argument index="2" name="resolution" type="int" enum="VisualServer.EnvironmentSSRResolution">
 			</argument>
-			<argument index="3" name="fade_in" type="float">
+			<argument index="3" name="max_steps" type="int">
 			</argument>
-			<argument index="4" name="fade_out" type="float">
+			<argument index="4" name="fade_in" type="float">
 			</argument>
-			<argument index="5" name="depth_tolerance" type="float">
+			<argument index="5" name="fade_out" type="float">
 			</argument>
-			<argument index="6" name="roughness" type="bool">
+			<argument index="6" name="depth_tolerance" type="float">
+			</argument>
+			<argument index="7" name="roughness" type="bool">
 			</argument>
 			<description>
 			</description>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -68,7 +68,7 @@ public:
 
 	void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) {}
 
-	void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness) {}
+	void environment_set_ssr(RID p_env, bool p_enable, VS::EnvironmentSSRResolution p_resolution, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness) {}
 	void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) {}
 
 	void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) {}

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -789,7 +789,7 @@ void RasterizerSceneGLES2::environment_set_fog(RID p_env, bool p_enable, float p
 	ERR_FAIL_COND(!env);
 }
 
-void RasterizerSceneGLES2::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) {
+void RasterizerSceneGLES2::environment_set_ssr(RID p_env, bool p_enable, VS::EnvironmentSSRResolution p_resolution, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) {
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
 }

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -419,7 +419,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale);
 	virtual void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture);
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness);
+	virtual void environment_set_ssr(RID p_env, bool p_enable, VS::EnvironmentSSRResolution p_resolution, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness);
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness);
 
 	virtual void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -873,12 +873,13 @@ void RasterizerSceneGLES3::environment_set_glow(RID p_env, bool p_enable, int p_
 void RasterizerSceneGLES3::environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) {
 }
 
-void RasterizerSceneGLES3::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) {
+void RasterizerSceneGLES3::environment_set_ssr(RID p_env, bool p_enable, VS::EnvironmentSSRResolution p_resolution, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) {
 
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
 
 	env->ssr_enabled = p_enable;
+	env->ssr_resolution = p_resolution;
 	env->ssr_max_steps = p_max_steps;
 	env->ssr_fade_in = p_fade_in;
 	env->ssr_fade_out = p_fade_out;
@@ -3548,10 +3549,23 @@ void RasterizerSceneGLES3::_render_mrts(Environment *env, const CameraMatrix &p_
 
 		state.ssr_shader.bind();
 
+		float resolution_multiplier = 0.5;
+		switch (env->ssr_resolution) {
+			case VS::ENV_SSR_RESOLUTION_FULL:
+				resolution_multiplier = 1.0;
+				break;
+			case VS::ENV_SSR_RESOLUTION_HALF:
+				resolution_multiplier = 0.5;
+				break;
+			case VS::ENV_SSR_RESOLUTION_QUARTER:
+				resolution_multiplier = 0.25;
+				break;
+		}
+
 		int ssr_w = storage->frame.current_rt->effects.mip_maps[1].sizes[0].width;
 		int ssr_h = storage->frame.current_rt->effects.mip_maps[1].sizes[0].height;
 
-		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::PIXEL_SIZE, Vector2(1.0 / (ssr_w * 0.5), 1.0 / (ssr_h * 0.5)));
+		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::PIXEL_SIZE, Vector2(1.0 / (ssr_w * resolution_multiplier), 1.0 / (ssr_h * resolution_multiplier)));
 		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::CAMERA_Z_NEAR, p_cam_projection.get_z_near());
 		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::CAMERA_Z_FAR, p_cam_projection.get_z_far());
 		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::PROJECTION, p_cam_projection);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -383,6 +383,7 @@ public:
 		int canvas_max_layer;
 
 		bool ssr_enabled;
+		VS::EnvironmentSSRResolution ssr_resolution;
 		int ssr_max_steps;
 		float ssr_fade_in;
 		float ssr_fade_out;
@@ -465,6 +466,7 @@ public:
 				ambient_sky_contribution(0.0),
 				canvas_max_layer(0),
 				ssr_enabled(false),
+				ssr_resolution(VS::ENV_SSR_RESOLUTION_HALF),
 				ssr_max_steps(64),
 				ssr_fade_in(0.15),
 				ssr_fade_out(2.0),
@@ -548,7 +550,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale);
 	virtual void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture);
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness);
+	virtual void environment_set_ssr(RID p_env, bool p_enable, VS::EnvironmentSSRResolution p_resolution, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness);
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness);
 
 	virtual void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale);

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -378,7 +378,7 @@ void Environment::_validate_property(PropertyInfo &property) const {
 void Environment::set_ssr_enabled(bool p_enable) {
 
 	ssr_enabled = p_enable;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, VS::EnvironmentSSRResolution(ssr_resolution), ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
 	_change_notify();
 }
 
@@ -387,10 +387,20 @@ bool Environment::is_ssr_enabled() const {
 	return ssr_enabled;
 }
 
+void Environment::set_ssr_resolution(SSRResolution p_resolution) {
+
+	ssr_resolution = p_resolution;
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, VS::EnvironmentSSRResolution(ssr_resolution), ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+}
+Environment::SSRResolution Environment::get_ssr_resolution() const {
+
+	return ssr_resolution;
+}
+
 void Environment::set_ssr_max_steps(int p_steps) {
 
 	ssr_max_steps = p_steps;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, VS::EnvironmentSSRResolution(ssr_resolution), ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
 }
 int Environment::get_ssr_max_steps() const {
 
@@ -400,7 +410,7 @@ int Environment::get_ssr_max_steps() const {
 void Environment::set_ssr_fade_in(float p_fade_in) {
 
 	ssr_fade_in = p_fade_in;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, VS::EnvironmentSSRResolution(ssr_resolution), ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
 }
 float Environment::get_ssr_fade_in() const {
 
@@ -410,7 +420,7 @@ float Environment::get_ssr_fade_in() const {
 void Environment::set_ssr_fade_out(float p_fade_out) {
 
 	ssr_fade_out = p_fade_out;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, VS::EnvironmentSSRResolution(ssr_resolution), ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
 }
 float Environment::get_ssr_fade_out() const {
 
@@ -420,7 +430,7 @@ float Environment::get_ssr_fade_out() const {
 void Environment::set_ssr_depth_tolerance(float p_depth_tolerance) {
 
 	ssr_depth_tolerance = p_depth_tolerance;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, VS::EnvironmentSSRResolution(ssr_resolution), ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
 }
 float Environment::get_ssr_depth_tolerance() const {
 
@@ -430,7 +440,7 @@ float Environment::get_ssr_depth_tolerance() const {
 void Environment::set_ssr_rough(bool p_enable) {
 
 	ssr_roughness = p_enable;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, VS::EnvironmentSSRResolution(ssr_resolution), ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
 }
 bool Environment::is_ssr_rough() const {
 
@@ -1071,6 +1081,9 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ssr_enabled", "enabled"), &Environment::set_ssr_enabled);
 	ClassDB::bind_method(D_METHOD("is_ssr_enabled"), &Environment::is_ssr_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_ssr_resolution", "resolution"), &Environment::set_ssr_resolution);
+	ClassDB::bind_method(D_METHOD("get_ssr_resolution"), &Environment::get_ssr_resolution);
+
 	ClassDB::bind_method(D_METHOD("set_ssr_max_steps", "max_steps"), &Environment::set_ssr_max_steps);
 	ClassDB::bind_method(D_METHOD("get_ssr_max_steps"), &Environment::get_ssr_max_steps);
 
@@ -1088,6 +1101,7 @@ void Environment::_bind_methods() {
 
 	ADD_GROUP("SS Reflections", "ss_reflections_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ss_reflections_enabled"), "set_ssr_enabled", "is_ssr_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "ss_reflections_resolution", PROPERTY_HINT_ENUM, "Full, Half, Quarter"), "set_ssr_resolution", "get_ssr_resolution");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ss_reflections_max_steps", PROPERTY_HINT_RANGE, "1,512,1"), "set_ssr_max_steps", "get_ssr_max_steps");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ss_reflections_fade_in", PROPERTY_HINT_EXP_EASING), "set_ssr_fade_in", "get_ssr_fade_in");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ss_reflections_fade_out", PROPERTY_HINT_EXP_EASING), "set_ssr_fade_out", "get_ssr_fade_out");
@@ -1281,6 +1295,10 @@ void Environment::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOF_BLUR_QUALITY_MEDIUM);
 	BIND_ENUM_CONSTANT(DOF_BLUR_QUALITY_HIGH);
 
+	BIND_ENUM_CONSTANT(SSR_RESOLUTION_FULL);
+	BIND_ENUM_CONSTANT(SSR_RESOLUTION_HALF);
+	BIND_ENUM_CONSTANT(SSR_RESOLUTION_QUARTER);
+
 	BIND_ENUM_CONSTANT(SSAO_BLUR_DISABLED);
 	BIND_ENUM_CONSTANT(SSAO_BLUR_1x1);
 	BIND_ENUM_CONSTANT(SSAO_BLUR_2x2);
@@ -1294,6 +1312,7 @@ void Environment::_bind_methods() {
 Environment::Environment() :
 		bg_mode(BG_CLEAR_COLOR),
 		tone_mapper(TONE_MAPPER_LINEAR),
+		ssr_resolution(SSR_RESOLUTION_HALF),
 		ssao_blur(SSAO_BLUR_3x3),
 		ssao_quality(SSAO_QUALITY_MEDIUM),
 		glow_blend_mode(GLOW_BLEND_MODE_ADDITIVE),
@@ -1330,6 +1349,7 @@ Environment::Environment() :
 	set_adjustment_enable(adjustment_enabled); //update
 
 	ssr_enabled = false;
+	ssr_resolution = SSR_RESOLUTION_HALF;
 	ssr_max_steps = 64;
 	ssr_fade_in = 0.15;
 	ssr_fade_out = 2.0;

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -72,6 +72,12 @@ public:
 		DOF_BLUR_QUALITY_HIGH,
 	};
 
+	enum SSRResolution {
+		SSR_RESOLUTION_FULL,
+		SSR_RESOLUTION_HALF,
+		SSR_RESOLUTION_QUARTER
+	};
+
 	enum SSAOBlur {
 		SSAO_BLUR_DISABLED,
 		SSAO_BLUR_1x1,
@@ -115,6 +121,7 @@ private:
 	Ref<Texture> adjustment_color_correction;
 
 	bool ssr_enabled;
+	SSRResolution ssr_resolution;
 	int ssr_max_steps;
 	float ssr_fade_in;
 	float ssr_fade_out;
@@ -247,6 +254,9 @@ public:
 
 	void set_ssr_enabled(bool p_enable);
 	bool is_ssr_enabled() const;
+
+	void set_ssr_resolution(SSRResolution p_resolution);
+	SSRResolution get_ssr_resolution() const;
 
 	void set_ssr_max_steps(int p_steps);
 	int get_ssr_max_steps() const;
@@ -411,6 +421,7 @@ VARIANT_ENUM_CAST(Environment::BGMode)
 VARIANT_ENUM_CAST(Environment::ToneMapper)
 VARIANT_ENUM_CAST(Environment::GlowBlendMode)
 VARIANT_ENUM_CAST(Environment::DOFBlurQuality)
+VARIANT_ENUM_CAST(Environment::SSRResolution)
 VARIANT_ENUM_CAST(Environment::SSAOQuality)
 VARIANT_ENUM_CAST(Environment::SSAOBlur)
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -66,7 +66,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale) = 0;
 	virtual void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) = 0;
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness) = 0;
+	virtual void environment_set_ssr(RID p_env, bool p_enable, VS::EnvironmentSSRResolution p_resolution, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness) = 0;
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) = 0;
 
 	virtual void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -503,7 +503,7 @@ public:
 	BIND2(environment_set_bg_energy, RID, float)
 	BIND2(environment_set_canvas_max_layer, RID, int)
 	BIND4(environment_set_ambient_light, RID, const Color &, float, float)
-	BIND7(environment_set_ssr, RID, bool, int, float, float, float, bool)
+	BIND8(environment_set_ssr, RID, bool, EnvironmentSSRResolution, int, float, float, float, bool)
 	BIND13(environment_set_ssao, RID, bool, float, float, float, float, float, float, float, const Color &, EnvironmentSSAOQuality, EnvironmentSSAOBlur, float)
 
 	BIND6(environment_set_dof_blur_near, RID, bool, float, float, float, EnvironmentDOFBlurQuality)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -430,7 +430,7 @@ public:
 	FUNC2(environment_set_bg_energy, RID, float)
 	FUNC2(environment_set_canvas_max_layer, RID, int)
 	FUNC4(environment_set_ambient_light, RID, const Color &, float, float)
-	FUNC7(environment_set_ssr, RID, bool, int, float, float, float, bool)
+	FUNC8(environment_set_ssr, RID, bool, EnvironmentSSRResolution, int, float, float, float, bool)
 	FUNC13(environment_set_ssao, RID, bool, float, float, float, float, float, float, float, const Color &, EnvironmentSSAOQuality, EnvironmentSSAOBlur, float)
 
 	FUNC6(environment_set_dof_blur_near, RID, bool, float, float, float, EnvironmentDOFBlurQuality)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1916,7 +1916,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_glow", "env", "enable", "level_flags", "intensity", "strength", "bloom_threshold", "blend_mode", "hdr_bleed_threshold", "hdr_bleed_scale", "hdr_luminance_cap", "bicubic_upscale"), &VisualServer::environment_set_glow);
 	ClassDB::bind_method(D_METHOD("environment_set_tonemap", "env", "tone_mapper", "exposure", "white", "auto_exposure", "min_luminance", "max_luminance", "auto_exp_speed", "auto_exp_grey"), &VisualServer::environment_set_tonemap);
 	ClassDB::bind_method(D_METHOD("environment_set_adjustment", "env", "enable", "brightness", "contrast", "saturation", "ramp"), &VisualServer::environment_set_adjustment);
-	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "max_steps", "fade_in", "fade_out", "depth_tolerance", "roughness"), &VisualServer::environment_set_ssr);
+	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "resolution", "max_steps", "fade_in", "fade_out", "depth_tolerance", "roughness"), &VisualServer::environment_set_ssr);
 	ClassDB::bind_method(D_METHOD("environment_set_ssao", "env", "enable", "radius", "intensity", "radius2", "intensity2", "bias", "light_affect", "ao_channel_affect", "color", "quality", "blur", "bilateral_sharpness"), &VisualServer::environment_set_ssao);
 	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "color", "sun_color", "sun_amount"), &VisualServer::environment_set_fog);
 
@@ -2295,6 +2295,10 @@ void VisualServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_REINHARD);
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_FILMIC);
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_ACES);
+
+	BIND_ENUM_CONSTANT(ENV_SSR_RESOLUTION_FULL);
+	BIND_ENUM_CONSTANT(ENV_SSR_RESOLUTION_HALF);
+	BIND_ENUM_CONSTANT(ENV_SSR_RESOLUTION_QUARTER);
 
 	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_LOW);
 	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_MEDIUM);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -750,7 +750,13 @@ public:
 	virtual void environment_set_tonemap(RID p_env, EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_grey) = 0;
 	virtual void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) = 0;
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) = 0;
+	enum EnvironmentSSRResolution {
+		ENV_SSR_RESOLUTION_FULL,
+		ENV_SSR_RESOLUTION_HALF,
+		ENV_SSR_RESOLUTION_QUARTER,
+	};
+
+	virtual void environment_set_ssr(RID p_env, bool p_enable, EnvironmentSSRResolution p_resolution, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) = 0;
 
 	enum EnvironmentSSAOQuality {
 		ENV_SSAO_QUALITY_LOW,
@@ -1088,6 +1094,7 @@ VARIANT_ENUM_CAST(VisualServer::EnvironmentBG);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentDOFBlurQuality);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentGlowBlendMode);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentToneMapper);
+VARIANT_ENUM_CAST(VisualServer::EnvironmentSSRResolution);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentSSAOQuality);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentSSAOBlur);
 VARIANT_ENUM_CAST(VisualServer::InstanceFlags);


### PR DESCRIPTION
- Full, Half, and Quarter setting in WorldEnvironment under Ss Reflections.
- Replaces 0.5 with a custom multiplier.
- Higher resolution requires more steps, else the range of the reflections is shorter.
- Slight performance changes per resolution. Quarter res + lowering max depth may be useful for lower end devices.

Note there are minor changes in appearance based on resolution. For ex, blur/roughness is more apparent on higher resolutions.

Closes #19737