### PR TITLE
Renames captions of Scalar/VectorInterp in Visual Shaders

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -2350,7 +2350,7 @@ VisualShaderNodeVectorRefract::VisualShaderNodeVectorRefract() {
 ////////////// Scalar Interp
 
 String VisualShaderNodeScalarInterp::get_caption() const {
-	return "ScalarInterp";
+	return "Mix";
 }
 
 int VisualShaderNodeScalarInterp::get_input_port_count() const {
@@ -2392,7 +2392,7 @@ VisualShaderNodeScalarInterp::VisualShaderNodeScalarInterp() {
 ////////////// Vector Interp
 
 String VisualShaderNodeVectorInterp::get_caption() const {
-	return "VectorInterp";
+	return "Mix";
 }
 
 int VisualShaderNodeVectorInterp::get_input_port_count() const {


### PR DESCRIPTION
Seems like these captions are making confusion to peoples. I didnt changed the actual class names cuz it's will be a serious break of backward compatibility(prefer to delay it to 4.0). Addressed #28515