### PR TITLE
C#: Support resource type hint in exported arrays

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2285,8 +2285,9 @@ bool CSharpScript::_get_member_export(GDMonoClass *p_class, IMonoClassMember *p_
 		hint = PROPERTY_HINT_RESOURCE_TYPE;
 		hint_string = NATIVE_GDMONOCLASS_NAME(field_native_class);
 	} else if (variant_type == Variant::ARRAY && export_info.array.element_type != Variant::NIL) {
+		String elem_type_str = itos(export_info.array.element_type);
 		hint = PROPERTY_HINT_TYPE_STRING;
-		hint_string = itos(export_info.array.element_type) + ":";
+		hint_string = elem_type_str + "/" + elem_type_str + ":" + export_info.array.element_native_name;
 	} else if (variant_type == Variant::DICTIONARY && export_info.dictionary.key_type != Variant::NIL && export_info.dictionary.value_type != Variant::NIL) {
 		// TODO: There is no hint for this yet
 	} else {

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -184,8 +184,13 @@ Variant::Type managed_to_variant_type(const ManagedType &p_type, ExportInfo *r_e
 							reftype, &key_reftype, &value_reftype, &exc);
 					UNLIKELY_UNHANDLED_EXCEPTION(exc);
 
-					r_export_info->dictionary.key_type = managed_to_variant_type(ManagedType::from_reftype(key_reftype));
-					r_export_info->dictionary.value_type = managed_to_variant_type(ManagedType::from_reftype(value_reftype));
+					ManagedType key_type = ManagedType::from_reftype(key_reftype);
+					ManagedType value_type = ManagedType::from_reftype(value_reftype);
+
+					r_export_info->dictionary.key_type = managed_to_variant_type(key_type);
+					r_export_info->dictionary.key_native_name = NATIVE_GDMONOCLASS_NAME(key_type.type_class);
+					r_export_info->dictionary.value_type = managed_to_variant_type(value_type);
+					r_export_info->dictionary.value_native_name = NATIVE_GDMONOCLASS_NAME(value_type.type_class);
 				}
 
 				return Variant::DICTIONARY;
@@ -205,7 +210,10 @@ Variant::Type managed_to_variant_type(const ManagedType &p_type, ExportInfo *r_e
 							reftype, &elem_reftype, &exc);
 					UNLIKELY_UNHANDLED_EXCEPTION(exc);
 
-					r_export_info->array.element_type = managed_to_variant_type(ManagedType::from_reftype(elem_reftype));
+					ManagedType elem_type = ManagedType::from_reftype(elem_reftype);
+
+					r_export_info->array.element_type = managed_to_variant_type(elem_type);
+					r_export_info->array.element_native_name = NATIVE_GDMONOCLASS_NAME(elem_type.type_class);
 				}
 
 				return Variant::ARRAY;

--- a/modules/mono/mono_gd/gd_mono_marshal.h
+++ b/modules/mono/mono_gd/gd_mono_marshal.h
@@ -61,13 +61,16 @@ T unbox(MonoObject *p_obj) {
 struct ExportInfo {
 	struct ArrayInfo {
 		Variant::Type element_type;
+		String element_native_name;
 
 		ArrayInfo() :
 				element_type(Variant::NIL) {}
 	} array;
 	struct DictionaryInfo {
 		Variant::Type key_type;
+		String key_native_name;
 		Variant::Type value_type;
+		String value_native_name;
 
 		DictionaryInfo() :
 				key_type(Variant::NIL),


### PR DESCRIPTION
Elements of types like `PackedScene` will display with the special editor for such type. As discussed recently in #15467
