### PR TITLE
Fixed GLES2 transparency order

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2845,7 +2845,7 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 	glBlendEquation(GL_FUNC_ADD);
 	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
-	render_list.sort_by_depth(true);
+	render_list.sort_by_reverse_depth_and_priority(true);
 
 	_render_render_list(&render_list.elements[render_list.max_elements - render_list.alpha_element_count], render_list.alpha_element_count, cam_transform, p_cam_projection, p_shadow_atlas, env, env_radiance_tex, 0.0, 0.0, reverse_cull, true, false);
 


### PR DESCRIPTION
GLES2 was using ``sort_by_depth`` but GLES3 uses ``SortByReverseDepthAndPriority``. Now using alpha no longer makes objects render out of order. 

Code comes directly out of the GLES3 backend.

This may also restore render priority to GLES2, but I haven't looked into that in depth yet. 

Fixes: #27141