### PR TITLE
Added an is_valid function to FuncRef

### DIFF
--- a/core/func_ref.cpp
+++ b/core/func_ref.cpp
@@ -51,9 +51,21 @@ void FuncRef::set_instance(Object *p_obj) {
 	ERR_FAIL_NULL(p_obj);
 	id = p_obj->get_instance_id();
 }
+
 void FuncRef::set_function(const StringName &p_func) {
 
 	function = p_func;
+}
+
+bool FuncRef::is_valid() const {
+	if (id == 0)
+		return false;
+
+	Object *obj = ObjectDB::get_instance(id);
+	if (!obj)
+		return false;
+
+	return obj->has_method(function);
 }
 
 void FuncRef::_bind_methods() {
@@ -67,6 +79,7 @@ void FuncRef::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_instance", "instance"), &FuncRef::set_instance);
 	ClassDB::bind_method(D_METHOD("set_function", "name"), &FuncRef::set_function);
+	ClassDB::bind_method(D_METHOD("is_valid"), &FuncRef::is_valid);
 }
 
 FuncRef::FuncRef() :

--- a/core/func_ref.h
+++ b/core/func_ref.h
@@ -46,6 +46,7 @@ public:
 	Variant call_func(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 	void set_instance(Object *p_obj);
 	void set_function(const StringName &p_func);
+	bool is_valid() const;
 	FuncRef();
 };
 


### PR DESCRIPTION
This is mainly for script users as they do not have access to the Variant::CallError parameter in call_func on the C++ side so they have no way to validate in code if a function call was/will be successful or not.