### PR TITLE
GIProbe::bake(): special handling of spatial

### DIFF
--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -386,11 +386,7 @@ void GIProbe::_find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes) {
 	}
 
 	for (int i = 0; i < p_at_node->get_child_count(); i++) {
-
 		Node *child = p_at_node->get_child(i);
-		if (!child->get_owner())
-			continue; //maybe a helper
-
 		_find_meshes(child, plot_meshes);
 	}
 }


### PR DESCRIPTION
I expected that the engine would use dynamically placed meshes for the baking of the GI.

A issue was that embeded scene Nodes are simply ignored, because they have no owner.

So this PR fixes this by just checking for this special case.

Fixes #28508 