### PR TITLE
Forgot a parameter in the ARVR gdnative bindings for notifications

### DIFF
--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -227,7 +227,7 @@ void ARVRInterfaceGDNative::notification(int p_what) {
 
 	// this is only available in interfaces that implement 1.1 or later
 	if ((interface->version.major > 1) || ((interface->version.major == 1) && (interface->version.minor > 0))) {
-		interface->notification(p_what);
+		interface->notification(data, p_what);
 	}
 }
 

--- a/modules/gdnative/include/arvr/godot_arvr.h
+++ b/modules/gdnative/include/arvr/godot_arvr.h
@@ -63,7 +63,7 @@ typedef struct {
 	void (*process)(void *);
 	// only in 1.1 onwards
 	godot_int (*get_external_texture_for_eye)(void *, godot_int);
-	void (*notification)(godot_int);
+	void (*notification)(void *, godot_int);
 } godot_arvr_interface_gdnative;
 
 void GDAPI godot_arvr_register_interface(const godot_arvr_interface_gdnative *p_interface);


### PR DESCRIPTION
Big oops, only tested this for modules, not yet with GDNative so overlooked this...