### PR TITLE
Fix regression on 'PopupMenu's minimal size

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -93,14 +93,14 @@ Size2 PopupMenu::get_minimum_size() const {
 		if (items[i].submenu != "")
 			size.width += get_icon("submenu")->get_width();
 
-		if (has_check)
-			size.width += check_w;
-		max_w = MAX(max_w, size.width + icon_w);
+		max_w = MAX(max_w, size.width);
 
 		minsize.height += size.height;
 	}
 
-	minsize.width += max_w + accel_max_w;
+	minsize.width += max_w + icon_w + accel_max_w;
+	if (has_check)
+		minsize.width += check_w;
 
 	return minsize;
 }


### PR DESCRIPTION
The minimal size of `PopupMenu`s was not being calculated correctly.
The regression was caused by me in 0da61614c050c208166f9f860e61b9f4b9e048bb. Apologies.