### PR TITLE
Support Mac OS default move cursor hotkeys

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2597,6 +2597,15 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 				FALLTHROUGH;
 			}
+#ifdef APPLE_STYLE_KEYS
+			case KEY_B: {
+				if (!k->get_control()) {
+					scancode_handled = false;
+					break;
+				}
+				FALLTHROUGH;
+			}
+#endif
 			case KEY_LEFT: {
 
 				if (k->get_shift())
@@ -2673,6 +2682,15 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 				FALLTHROUGH;
 			}
+#ifdef APPLE_STYLE_KEYS
+			case KEY_F: {
+				if (!k->get_control()) {
+					scancode_handled = false;
+					break;
+				}
+				FALLTHROUGH;
+			}
+#endif
 			case KEY_RIGHT: {
 
 				if (k->get_shift())
@@ -2734,6 +2752,15 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 				FALLTHROUGH;
 			}
+#ifdef APPLE_STYLE_KEYS
+			case KEY_P: {
+				if (!k->get_control()) {
+					scancode_handled = false;
+					break;
+				}
+				FALLTHROUGH;
+			}
+#endif
 			case KEY_UP: {
 
 				if (k->get_alt()) {
@@ -2787,6 +2814,15 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 				FALLTHROUGH;
 			}
+#ifdef APPLE_STYLE_KEYS
+			case KEY_N: {
+				if (!k->get_control()) {
+					scancode_handled = false;
+					break;
+				}
+				FALLTHROUGH;
+			}
+#endif
 			case KEY_DOWN: {
 
 				if (k->get_alt()) {


### PR DESCRIPTION
Support Mac OS default move cursor hotkeys.
Currently in Godot Text Editor already support Ctrl+A && Ctrl+E, but not Ctrl+B, Ctrl+F, Ctrl+N, Ctrl+P.
All Mac OS text editor support it's by default. It's a huge improve to text navigate performance.
For me it was a bottleneck in Godot Editor on Mac.

See page https://support.apple.com/en-us/HT201236