### PR TITLE
Script editor: Convert indentation on paste

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -928,7 +928,15 @@ void CodeTextEditor::insert_final_newline() {
 	}
 }
 
-void CodeTextEditor::convert_indent_to_spaces() {
+void CodeTextEditor::convert_indent_to_spaces(int p_from, int p_to) {
+
+	int line_count = text_editor->get_line_count();
+	ERR_FAIL_INDEX(p_from, line_count);
+	if (p_to < 0) {
+		p_to = line_count - 1;
+	}
+	ERR_FAIL_INDEX(p_to, line_count);
+
 	int indent_size = EditorSettings::get_singleton()->get("text_editor/indent/size");
 	String indent = "";
 
@@ -940,7 +948,7 @@ void CodeTextEditor::convert_indent_to_spaces() {
 	int cursor_column = text_editor->cursor_get_column();
 
 	bool changed_indentation = false;
-	for (int i = 0; i < text_editor->get_line_count(); i++) {
+	for (int i = p_from; i < p_to + 1; i++) {
 		String line = text_editor->get_line(i);
 
 		if (line.length() <= 0) {
@@ -972,7 +980,15 @@ void CodeTextEditor::convert_indent_to_spaces() {
 	}
 }
 
-void CodeTextEditor::convert_indent_to_tabs() {
+void CodeTextEditor::convert_indent_to_tabs(int p_from, int p_to) {
+
+	int line_count = text_editor->get_line_count();
+	ERR_FAIL_INDEX(p_from, line_count);
+	if (p_to < 0) {
+		p_to = line_count - 1;
+	}
+	ERR_FAIL_INDEX(p_to, line_count);
+
 	int indent_size = EditorSettings::get_singleton()->get("text_editor/indent/size");
 	indent_size -= 1;
 
@@ -980,7 +996,7 @@ void CodeTextEditor::convert_indent_to_tabs() {
 	int cursor_column = text_editor->cursor_get_column();
 
 	bool changed_indentation = false;
-	for (int i = 0; i < text_editor->get_line_count(); i++) {
+	for (int i = p_from; i < p_to + 1; i++) {
 		String line = text_editor->get_line(i);
 
 		if (line.length() <= 0) {

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -201,8 +201,8 @@ public:
 	void trim_trailing_whitespace();
 	void insert_final_newline();
 
-	void convert_indent_to_spaces();
-	void convert_indent_to_tabs();
+	void convert_indent_to_spaces(int p_from = 0, int p_to = -1);
+	void convert_indent_to_tabs(int p_from = 0, int p_to = -1);
 
 	enum CaseStyle {
 		UPPER,

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3445,7 +3445,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	edit_pass = 0;
 	trim_trailing_whitespace_on_save = EditorSettings::get_singleton()->get("text_editor/files/trim_trailing_whitespace_on_save");
 	convert_indent_on_save = EditorSettings::get_singleton()->get("text_editor/indent/convert_indent_on_save");
-	use_space_indentation = EditorSettings::get_singleton()->get("text_editor/indent/type");
+	use_space_indentation = EditorSettings::get_singleton()->get("text_editor/indent/type"); // Tabs 0, spaces 1
 
 	ScriptServer::edit_request_func = _open_script_request;
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -101,8 +101,8 @@ public:
 	virtual void clear_executing_line() = 0;
 	virtual void trim_trailing_whitespace() = 0;
 	virtual void insert_final_newline() = 0;
-	virtual void convert_indent_to_spaces() = 0;
-	virtual void convert_indent_to_tabs() = 0;
+	virtual void convert_indent_to_spaces(int p_from = 0, int p_to = -1) = 0;
+	virtual void convert_indent_to_tabs(int p_from = 0, int p_to = -1) = 0;
 	virtual void ensure_focus() = 0;
 	virtual void tag_saved_version() = 0;
 	virtual void reload(bool p_soft) {}

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -96,6 +96,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 	} colors_cache;
 
 	bool theme_loaded;
+	bool use_space_indentation;
 
 	enum {
 		EDIT_UNDO,
@@ -103,6 +104,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 		EDIT_CUT,
 		EDIT_COPY,
 		EDIT_PASTE,
+		EDIT_PASTE_ORIGINAL_INDENT,
 		EDIT_SELECT_ALL,
 		EDIT_COMPLETE,
 		EDIT_AUTO_INDENT,
@@ -202,8 +204,8 @@ public:
 	virtual void ensure_focus();
 	virtual void trim_trailing_whitespace();
 	virtual void insert_final_newline();
-	virtual void convert_indent_to_spaces();
-	virtual void convert_indent_to_tabs();
+	virtual void convert_indent_to_spaces(int p_from = 0, int p_to = -1);
+	virtual void convert_indent_to_tabs(int p_from = 0, int p_to = -1);
 	virtual void tag_saved_version();
 
 	virtual void goto_line(int p_line, bool p_with_error = false);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -293,14 +293,14 @@ void TextEditor::insert_final_newline() {
 	code_editor->insert_final_newline();
 }
 
-void TextEditor::convert_indent_to_spaces() {
+void TextEditor::convert_indent_to_spaces(int p_from, int p_to) {
 
-	code_editor->convert_indent_to_spaces();
+	code_editor->convert_indent_to_spaces(p_from, p_to);
 }
 
-void TextEditor::convert_indent_to_tabs() {
+void TextEditor::convert_indent_to_tabs(int p_from, int p_to) {
 
-	code_editor->convert_indent_to_tabs();
+	code_editor->convert_indent_to_tabs(p_from, p_to);
 }
 
 void TextEditor::tag_saved_version() {

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -136,8 +136,8 @@ public:
 	virtual void clear_executing_line();
 	virtual void trim_trailing_whitespace();
 	virtual void insert_final_newline();
-	virtual void convert_indent_to_spaces();
-	virtual void convert_indent_to_tabs();
+	virtual void convert_indent_to_spaces(int p_from = 0, int p_to = -1);
+	virtual void convert_indent_to_tabs(int p_from = 0, int p_to = -1);
 	virtual void ensure_focus();
 	virtual void tag_saved_version();
 	virtual void update_settings();

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2116,10 +2116,10 @@ void VisualScriptEditor::trim_trailing_whitespace() {
 void VisualScriptEditor::insert_final_newline() {
 }
 
-void VisualScriptEditor::convert_indent_to_spaces() {
+void VisualScriptEditor::convert_indent_to_spaces(int p_from, int p_to) {
 }
 
-void VisualScriptEditor::convert_indent_to_tabs() {
+void VisualScriptEditor::convert_indent_to_tabs(int p_from, int p_to) {
 }
 
 void VisualScriptEditor::ensure_focus() {

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -267,8 +267,8 @@ public:
 	virtual void clear_executing_line();
 	virtual void trim_trailing_whitespace();
 	virtual void insert_final_newline();
-	virtual void convert_indent_to_spaces();
-	virtual void convert_indent_to_tabs();
+	virtual void convert_indent_to_spaces(int p_from = 0, int p_to = -1);
+	virtual void convert_indent_to_tabs(int p_from = 0, int p_to = -1);
 	virtual void ensure_focus();
 	virtual void tag_saved_version();
 	virtual void reload(bool p_soft);


### PR DESCRIPTION
This is implemented as an editor setting (opt-out), and only for the
script editor (though it's implemented in TextEdit which handles the
paste).

Based on the indent type and size from the editor settings, it will
convert tabs to the expected number of spaces, or spaces to tabs. In
the latter case, it aims to guess the number of spaces used as indent
size in the clipboard.

Fixes #19285.

-----

The implementation is not perfect yet, and likely a bit naive, as my knowledge of the String API is a bit rusty and I didn't pause long to think about what would be the most efficient algorithm. Any feedback/suggestions are welcome.

I've noticed a slight issue with the selection cursor when doing undo, but haven't investigated yet.
*Edit:* Doesn't seem related to this PR, the same bug happens with the option disabled.

I would also have liked the reformatting to happen as a second undoable complex operation (so paste first without changes, then apply changes, and you undo in two steps), but I'm not sure how to do it easily.