### PR TITLE
Use CCFLAGS when building freetype, not CPPFLAGS

### DIFF
--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -72,9 +72,11 @@ if env['builtin_freetype']:
     # Also needed in main env for scene/
     env.Prepend(CPPPATH=[thirdparty_dir + "/include"])
 
-    env_freetype.Append(CPPFLAGS=['-DFT2_BUILD_LIBRARY', '-DFT_CONFIG_OPTION_USE_PNG'])
+    # Emscripten (JS export) does not seem to like CPPFLAGS.
+    # And this is a C library, let's use CCFLAGS.
+    env_freetype.Append(CCFLAGS=['-DFT2_BUILD_LIBRARY', '-DFT_CONFIG_OPTION_USE_PNG'])
     if (env['target'] != 'release'):
-        env_freetype.Append(CPPFLAGS=['-DZLIB_DEBUG'])
+        env_freetype.Append(CCFLAGS=['-DZLIB_DEBUG'])
 
     # Also requires libpng headers
     if env['builtin_libpng']:


### PR DESCRIPTION
Emscripten doesn't seem to like them, and break the HTML5 build (after #28396).

```
scons: Reading SConscript files ...
WebM SIMD optimizations are disabled. Check if your CPU architecture, CPU bits or platform are supported!
Checking for C header file mntent.h... (cached) yes
scons: done reading SConscript files.
scons: Building targets ...
[ 96%] emcc -o thirdparty/freetype/src/sfnt/sfnt.javascript.opt.bc -c -Os -fno-exceptions -fno-rtti -Wall -Werror=return-type -U__OPTIMIZE__ -DJAVASCRIPT_ENABLED -DUNIX_ENABLED -DNO_THREADS -DNO_SAFE_CAST -DJAVASCRIPT_EVAL_ENABLED -DNDEBUG -DPTRCALL_ENABLED -DGDSCRIPT_ENABLED -DMINIZIP_ENABLED -Ithirdparty/libpng -Ithirdparty/freetype/include -Ithirdparty/libpng -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/javascript -I. -Ieditor thirdparty/freetype/src/sfnt/sfnt.c
In file included from thirdparty/freetype/src/sfnt/sfnt.c:22:
thirdparty/freetype/src/sfnt/pngshim.c:21:10: error: expected "FILENAME" or <FILENAME>
#include FT_INTERNAL_DEBUG_H
         ^
thirdparty/freetype/src/sfnt/pngshim.c:22:10: error: expected "FILENAME" or <FILENAME>
#include FT_INTERNAL_STREAM_H
         ^
In file included from thirdparty/freetype/src/sfnt/sfnt.c:23:
thirdparty/freetype/src/sfnt/sfdriver.c:20:10: error: expected "FILENAME" or <FILENAME>
#include FT_INTERNAL_DEBUG_H
         ^
thirdparty/freetype/src/sfnt/sfdriver.c:21:10: error: expected "FILENAME" or <FILENAME>
#include FT_INTERNAL_SFNT_H
         ^
thirdparty/freetype/src/sfnt/sfdriver.c:22:10: error: expected "FILENAME" or <FILENAME>
#include FT_INTERNAL_OBJECTS_H
         ^
In file included from thirdparty/freetype/src/sfnt/sfnt.c:23:
In file included from thirdparty/freetype/src/sfnt/sfdriver.c:26:
thirdparty/freetype/src/sfnt/ttload.h:25:10: error: expected "FILENAME" or <FILENAME>
#include FT_INTERNAL_STREAM_H
         ^
thirdparty/freetype/src/sfnt/ttload.h:26:10: error: expected "FILENAME" or <FILENAME>
#include FT_INTERNAL_TRUETYPE_TYPES_H
         ^
thirdparty/freetype/src/sfnt/ttload.h:32:13: error: unknown type name 'TT_Table'
  FT_LOCAL( TT_Table  )
            ^
thirdparty/freetype/src/sfnt/ttload.h:32:3: error: invalid storage class specifier in function declarator
  FT_LOCAL( TT_Table  )
  ^
thirdparty/freetype/include/freetype/config/ftconfig.h:377:28: note: expanded from macro 'FT_LOCAL'
#define FT_LOCAL( x )      static  x
                           ^
In file included from thirdparty/freetype/src/sfnt/sfnt.c:23:
In file included from thirdparty/freetype/src/sfnt/sfdriver.c:26:
thirdparty/freetype/src/sfnt/ttload.h:33:25: error: unknown type name 'TT_Face'; did you mean 'FT_Face'?
  tt_face_lookup_table( TT_Face   face,
                        ^~~~~~~
                        FT_Face
thirdparty/freetype/include/freetype/freetype.h:499:32: note: 'FT_Face' declared here
  typedef struct FT_FaceRec_*  FT_Face;
                               ^
In file included from thirdparty/freetype/src/sfnt/sfnt.c:23:
In file included from thirdparty/freetype/src/sfnt/sfdriver.c:26:
thirdparty/freetype/src/sfnt/ttload.h:33:3: error: parameter named 'tt_face_lookup_table' is missing
  tt_face_lookup_table( TT_Face   face,
  ^
thirdparty/freetype/src/sfnt/ttload.h:36:3: error: invalid storage class specifier in function declarator
  FT_LOCAL( FT_Error )
  ^
thirdparty/freetype/include/freetype/config/ftconfig.h:377:28: note: expanded from macro 'FT_LOCAL'
#define FT_LOCAL( x )      static  x
                           ^
In file included from thirdparty/freetype/src/sfnt/sfnt.c:23:
In file included from thirdparty/freetype/src/sfnt/sfdriver.c:26:
thirdparty/freetype/src/sfnt/ttload.h:37:23: error: unknown type name 'TT_Face'; did you mean 'FT_Face'?
  tt_face_goto_table( TT_Face    face,
                      ^~~~~~~
                      FT_Face
thirdparty/freetype/include/freetype/freetype.h:499:32: note: 'FT_Face' declared here
  typedef struct FT_FaceRec_*  FT_Face;
                               ^
In file included from thirdparty/freetype/src/sfnt/sfnt.c:23:
In file included from thirdparty/freetype/src/sfnt/sfdriver.c:26:
thirdparty/freetype/src/sfnt/ttload.h:37:3: error: parameter named 'tt_face_goto_table' is missing
  tt_face_goto_table( TT_Face    face,
  ^
thirdparty/freetype/src/sfnt/ttload.h:43:3: error: invalid storage class specifier in function declarator
  FT_LOCAL( FT_Error )
  ^
thirdparty/freetype/include/freetype/config/ftconfig.h:377:28: note: expanded from macro 'FT_LOCAL'
#define FT_LOCAL( x )      static  x
                           ^
In file included from thirdparty/freetype/src/sfnt/sfnt.c:23:
In file included from thirdparty/freetype/src/sfnt/sfdriver.c:26:
thirdparty/freetype/src/sfnt/ttload.h:44:26: error: unknown type name 'TT_Face'; did you mean 'FT_Face'?
  tt_face_load_font_dir( TT_Face    face,
                         ^~~~~~~
                         FT_Face
thirdparty/freetype/include/freetype/freetype.h:499:32: note: 'FT_Face' declared here
  typedef struct FT_FaceRec_*  FT_Face;
                               ^
In file included from thirdparty/freetype/src/sfnt/sfnt.c:23:
In file included from thirdparty/freetype/src/sfnt/sfdriver.c:26:
thirdparty/freetype/src/sfnt/ttload.h:44:3: error: parameter named 'tt_face_load_font_dir' is missing
  tt_face_load_font_dir( TT_Face    face,
  ^
thirdparty/freetype/src/sfnt/ttload.h:48:3: error: invalid storage class specifier in function declarator
  FT_LOCAL( FT_Error )
  ^
thirdparty/freetype/include/freetype/config/ftconfig.h:377:28: note: expanded from macro 'FT_LOCAL'
#define FT_LOCAL( x )      static  x
                           ^
In file included from thirdparty/freetype/src/sfnt/sfnt.c:23:
In file included from thirdparty/freetype/src/sfnt/sfdriver.c:26:
thirdparty/freetype/src/sfnt/ttload.h:49:21: error: unknown type name 'TT_Face'; did you mean 'FT_Face'?
  tt_face_load_any( TT_Face    face,
                    ^~~~~~~
                    FT_Face
thirdparty/freetype/include/freetype/freetype.h:499:32: note: 'FT_Face' declared here
  typedef struct FT_FaceRec_*  FT_Face;
                               ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
shared:ERROR: compiler frontend failed to generate LLVM bitcode, halting
scons: *** [thirdparty/freetype/src/sfnt/sfnt.javascript.opt.bc] Error 1
scons: building terminated because of errors.
```