### PR TITLE
Add godot version in backtrace message

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -353,7 +353,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	ClassDB::register_class<Performance>();
 	engine->add_singleton(Engine::Singleton("Performance", performance));
 
-	GLOBAL_DEF("debug/settings/crash_handler/message", String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
+	GLOBAL_DEF("debug/settings/crash_handler/message", "Godot version: " + get_full_version_string() + String("\nPlease include this when reporting the bug on https://github.com/godotengine/godot/issues"));
 
 	MAIN_PRINT("Main: Parse CMDLine");
 


### PR DESCRIPTION
I've seen a lot of users adding backtraces with debug symbols below the original report without debug info in some issues. It is nice to have them but sometimes the information about the line of code is useless if they don't report the compiled commit.

After this change the trace looks like this:

```
handle_crash: Program crashed with signal 11
Dumping the backtrace. Godot version: 3.2.dev.custom_build.3cfab06
Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /lib64/libc.so.6(+0x37f40) [0x7fd71e4baf40] (??:0)
[2] Main::setup(char const*, int, char**, bool) (/home/dharkael/Public/godot/main/main.cpp:768)
[3] ./bin/godot.x11.tools.64(main+0x87) [0x138596d] (/home/dharkael/Public/godot/platform/x11/godot_x11.cpp:48)
[4] /lib64/libc.so.6(__libc_start_main+0xf3) [0x7fd71e4a6f33] (??:0)
[5] ./bin/godot.x11.tools.64(_start+0x2e) [0x138582e] (??:?)
-- END OF BACKTRACE --
Aborted (core dumped)
```
