### PR TITLE
Fixing Curve2D/3D baked interpolated values

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -782,7 +782,8 @@ Vector2 Curve2D::interpolate_baked(float p_offset, bool p_cubic) const {
 	if (idx >= bpc - 1) {
 		return r[bpc - 1];
 	} else if (idx == bpc - 2) {
-		frac /= Math::fmod(baked_max_ofs, bake_interval);
+		if (frac > 0)
+			frac /= Math::fmod(baked_max_ofs, bake_interval);
 	} else {
 		frac /= bake_interval;
 	}
@@ -1352,7 +1353,8 @@ Vector3 Curve3D::interpolate_baked(float p_offset, bool p_cubic) const {
 	if (idx >= bpc - 1) {
 		return r[bpc - 1];
 	} else if (idx == bpc - 2) {
-		frac /= Math::fmod(baked_max_ofs, bake_interval);
+		if (frac > 0)
+			frac /= Math::fmod(baked_max_ofs, bake_interval);
 	} else {
 		frac /= bake_interval;
 	}
@@ -1396,7 +1398,8 @@ float Curve3D::interpolate_baked_tilt(float p_offset) const {
 	if (idx >= bpc - 1) {
 		return r[bpc - 1];
 	} else if (idx == bpc - 2) {
-		frac /= Math::fmod(baked_max_ofs, bake_interval);
+		if (frac > 0)
+			frac /= Math::fmod(baked_max_ofs, bake_interval);
 	} else {
 		frac /= bake_interval;
 	}


### PR DESCRIPTION
If bake interval is a multiple of the curve length, the curve would return NaN for some offset values (when `frac == 0.0`, it matches the start and end of the curve segment so `fmod == 0.0`, `frac` becomes NaN)

```
# Godot 3.1.1
var c = Curve3D.new()
c.add_point(Vector3())
c.add_point(Vector3(0.5,0,0))
c.add_point(Vector3(1,0,0))
c.bake_interval = 0.5
c.interpolate_baked(0.5) == Vector3(NAN, NAN, NAN)

```