### PR TITLE
Fix First Ctrl+R and Ctrl+F not showing long name variables correctly

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -613,9 +613,7 @@ void LineEdit::_notification(int p_what) {
 #endif
 		case NOTIFICATION_RESIZED: {
 
-			if (expand_to_text_length) {
-				window_pos = 0; //force scroll back since it's expanding to text length
-			}
+			window_pos = 0; //force scroll back since it's expanding to text length
 			set_cursor_position(get_cursor_position());
 
 		} break;


### PR DESCRIPTION
Fixes #26982 