### PR TITLE
Document CollisionObject2D pickable requires collision_layer

### DIFF
--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -215,7 +215,7 @@
 	</methods>
 	<members>
 		<member name="input_pickable" type="bool" setter="set_pickable" getter="is_pickable">
-			If [code]true[/code], this object is pickable. A pickable object can detect the mouse pointer entering/leaving, and if the mouse is inside it, report input events.
+			If [code]true[/code], this object is pickable. A pickable object can detect the mouse pointer entering/leaving, and if the mouse is inside it, report input events. Requires at least one [code]collision_layer[/code] bit to be set.
 		</member>
 	</members>
 	<signals>
@@ -227,17 +227,17 @@
 			<argument index="2" name="shape_idx" type="int">
 			</argument>
 			<description>
-				Emitted when an input event occurs and [code]input_pickable[/code] is [code]true[/code]. See [method _input_event] for details.
+				Emitted when an input event occurs. Requires [code]input_pickable[/code] to be [code]true[/code] and at least one [code]collision_layer[/code] bit to be set. See [method _input_event] for details.
 			</description>
 		</signal>
 		<signal name="mouse_entered">
 			<description>
-				Emitted when the mouse pointer enters any of this object's shapes.
+				Emitted when the mouse pointer enters any of this object's shapes. Requires [code]input_pickable[/code] to be [code]true[/code] and at least one [code]collision_layer[/code] bit to be set.
 			</description>
 		</signal>
 		<signal name="mouse_exited">
 			<description>
-				Emitted when the mouse pointer exits all this object's shapes.
+				Emitted when the mouse pointer exits all this object's shapes. Requires [code]input_pickable[/code] to be [code]true[/code] and at least one [code]collision_layer[/code] bit to be set.
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
Document CollisionObject2D signals ```mouse_entered```, ```mouse_exited``` and ```input_event``` require at least one ```collision_layer``` to be set.

Sadly, ```collision_layer``` is implemented, and thus documented in the child classes ```Area2D``` and ```PhysicsBody2D``` (why not in the parent class?), so this might be a source of confusion.

Clarifies #11159