### PR TITLE
Make second parameter of substr optional

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2292,6 +2292,9 @@ String String::insert(int p_at_pos, const String &p_string) const {
 }
 String String::substr(int p_from, int p_chars) const {
 
+	if (p_chars == -1)
+		p_chars = length() - p_from;
+
 	if (empty() || p_from < 0 || p_from >= length() || p_chars <= 0)
 		return "";
 

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -201,7 +201,7 @@ public:
 	}
 
 	/* complex helpers */
-	String substr(int p_from, int p_chars) const;
+	String substr(int p_from, int p_chars = -1) const;
 	int find(const String &p_str, int p_from = 0) const; ///< return <0 if failed
 	int find(const char *p_str, int p_from = 0) const; ///< return <0 if failed
 	int find_char(const CharType &p_char, int p_from = 0) const; ///< return <0 if failed

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1494,7 +1494,7 @@ void register_variant_methods() {
 	ADDFUNC1R(STRING, INT, String, casecmp_to, STRING, "to", varray());
 	ADDFUNC1R(STRING, INT, String, nocasecmp_to, STRING, "to", varray());
 	ADDFUNC0R(STRING, INT, String, length, varray());
-	ADDFUNC2R(STRING, STRING, String, substr, INT, "from", INT, "len", varray());
+	ADDFUNC2R(STRING, STRING, String, substr, INT, "from", INT, "len", varray(-1));
 
 	ADDFUNC2R(STRING, INT, String, find, STRING, "what", INT, "from", varray(0));
 

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -748,10 +748,10 @@
 			</return>
 			<argument index="0" name="from" type="int">
 			</argument>
-			<argument index="1" name="len" type="int">
+			<argument index="1" name="len" type="int" default="-1">
 			</argument>
 			<description>
-				Returns part of the string from the position [code]from[/code] with length [code]len[/code].
+				Returns part of the string from the position [code]from[/code] with length [code]len[/code]. Argument [code]len[/code] is optional and using -1 will return remaining characters from given position.
 			</description>
 		</method>
 		<method name="to_ascii">


### PR DESCRIPTION
Closes #15991

With this PR, substr without second argument is an alias for `String.right`. See [#16863 (comment) and discussion below](https://github.com/godotengine/godot/issues/16863#issuecomment-419635744)