### PR TITLE
Fixes VideostreamGDNative crash on audio_channel=0.

### DIFF
--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -146,23 +146,25 @@ void VideoStreamPlaybackGDNative::update(float p_delta) {
 	ERR_FAIL_COND(interface == NULL);
 	interface->update(data_struct, p_delta);
 
-	if (pcm_write_idx >= 0) {
-		// Previous remains
-		int mixed = mix_callback(mix_udata, pcm, samples_decoded);
-		if (mixed == samples_decoded) {
-			pcm_write_idx = -1;
-		} else {
-			samples_decoded -= mixed;
-			pcm_write_idx += mixed;
+	if (mix_callback) {
+		if (pcm_write_idx >= 0) {
+			// Previous remains
+			int mixed = mix_callback(mix_udata, pcm, samples_decoded);
+			if (mixed == samples_decoded) {
+				pcm_write_idx = -1;
+			} else {
+				samples_decoded -= mixed;
+				pcm_write_idx += mixed;
+			}
 		}
-	}
-	if (pcm_write_idx < 0) {
-		samples_decoded = interface->get_audioframe(data_struct, pcm, AUX_BUFFER_SIZE);
-		pcm_write_idx = mix_callback(mix_udata, pcm, samples_decoded);
-		if (pcm_write_idx == samples_decoded) {
-			pcm_write_idx = -1;
-		} else {
-			samples_decoded -= pcm_write_idx;
+		if (pcm_write_idx < 0) {
+			samples_decoded = interface->get_audioframe(data_struct, pcm, AUX_BUFFER_SIZE);
+			pcm_write_idx = mix_callback(mix_udata, pcm, samples_decoded);
+			if (pcm_write_idx == samples_decoded) {
+				pcm_write_idx = -1;
+			} else {
+				samples_decoded -= pcm_write_idx;
+			}
 		}
 	}
 


### PR DESCRIPTION
Added an if case to check if the mix_callback exists before running any
of the audio code.

Fixes: #28644