### PR TITLE
Add HSV mode to color picker

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -49,8 +49,13 @@
 		</member>
 		<member name="presets_visible" type="bool" setter="set_presets_visible" getter="are_presets_visible">
 		</member>
+		<member name="hsv_mode" type="bool" setter="set_hsv_mode" getter="is_hsv_mode">
+			If [code]true[/code], allows to edit color with Hue/Saturation/Value sliders.
+			[b]Note:[/b] Cannot be enabled if raw mode is on.
+		</member>
 		<member name="raw_mode" type="bool" setter="set_raw_mode" getter="is_raw_mode">
 			If [code]true[/code], allows the color R, G, B component values to go beyond 1.0, which can be used for certain special operations that require it (like tinting without darkening or rendering sprites in HDR).
+			[b]Note:[/b] Cannot be enabled if hsv mode is on.
 		</member>
 	</members>
 	<signals>

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -58,7 +58,8 @@ private:
 	Button *bt_add_preset;
 	List<Color> presets;
 	ToolButton *btn_pick;
-	CheckButton *btn_mode;
+	CheckButton *btn_hsv;
+	CheckButton *btn_raw;
 	HSlider *scroll[4];
 	SpinBox *values[4];
 	Label *labels[4];
@@ -70,6 +71,7 @@ private:
 
 	Color color;
 	bool raw_mode_enabled;
+	bool hsv_mode_enabled;
 	bool deferred_mode_enabled;
 	bool updating;
 	bool changing_color;
@@ -81,7 +83,7 @@ private:
 	void _html_entered(const String &p_html);
 	void _value_changed(double);
 	void _update_controls();
-	void _update_color();
+	void _update_color(bool p_update_sliders = true);
 	void _update_presets();
 	void _update_text_value();
 	void _text_type_toggled();
@@ -106,12 +108,15 @@ public:
 	void set_edit_alpha(bool p_show);
 	bool is_editing_alpha() const;
 
-	void set_pick_color(const Color &p_color);
+	void set_pick_color(const Color &p_color, bool p_update_sliders = true);
 	Color get_pick_color() const;
 
 	void add_preset(const Color &p_color);
 	void erase_preset(const Color &p_color);
 	PoolColorArray get_presets() const;
+
+	void set_hsv_mode(bool p_enabled);
+	bool is_hsv_mode() const;
 
 	void set_raw_mode(bool p_enabled);
 	bool is_raw_mode() const;


### PR DESCRIPTION
This is an attempt to resolve #25859

Putting it as draft for now, as I'm not sure if I did UX right:
![image](https://user-images.githubusercontent.com/2223172/57160454-1e059280-6de9-11e9-8d8c-ce33903c9518.png)
![image](https://user-images.githubusercontent.com/2223172/57160459-21008300-6de9-11e9-84a5-b4a8e1ddc0d1.png)
As you can see, it's impossible to use HSV and Raw modes together (they had weird interactions, so I disabled it, but I can change that if requested). Also when changing between RGB/HSV modes, color labels have few pixels of difference in width. It's barely noticeable, but maybe this should be fixed >.>

Also I changed a bit how sliders behave - previously when changing value, it also triggered update of sliders (like, why...) and it totally messed with HSV mode, e.g. it was impossible to set hue to 1, because it was changed back to 0 etc. This change makes sliders more friendly, although it's irrelevant for RGB mode.