### PR TITLE
 Android: Include Joysticks/Gamepads which are available on app start.

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -1059,4 +1059,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		mProgressFraction.setText(Helpers.getDownloadProgressString(progress.mOverallProgress,
 				progress.mOverallTotal));
 	}
+	public void initInputDevices() {
+		mView.initInputDevices();
+	}
 }

--- a/platform/android/java/src/org/godotengine/godot/GodotView.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotView.java
@@ -111,6 +111,18 @@ public class GodotView extends GLSurfaceView implements InputDeviceListener {
 		init(translucent, depth, stencil);
 	}
 
+	public void initInputDevices() {
+		/* initially add input devices*/
+		int[] deviceIds = mInputManager.getInputDeviceIds();
+		for (int deviceId : deviceIds) {
+			InputDevice device = mInputManager.getInputDevice(deviceId);
+			if (DEBUG) {
+				Log.v("GodotView", String.format("init() deviceId:%d, Name:%s\n", deviceId, device.getName()));
+			}
+			onInputDeviceAdded(deviceId);
+		}
+	}
+
 	@SuppressLint("ClickableViewAccessibility")
 	@Override
 	public boolean onTouchEvent(MotionEvent event) {
@@ -217,36 +229,42 @@ public class GodotView extends GLSurfaceView implements InputDeviceListener {
 		// Check if the device has not been already added
 		if (id < 0) {
 			InputDevice device = mInputManager.getInputDevice(deviceId);
+			//device can be null if deviceId is not found
+			if (device != null) {
+				int sources = device.getSources();
+				if (((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD) ||
+						((sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK)) {
+					id = joy_devices.size();
 
-			id = joy_devices.size();
+					joystick joy = new joystick();
+					joy.device_id = deviceId;
+					joy.name = device.getName();
+					joy.axes = new ArrayList<InputDevice.MotionRange>();
+					joy.hats = new ArrayList<InputDevice.MotionRange>();
 
-			joystick joy = new joystick();
-			joy.device_id = deviceId;
-			joy.name = device.getName();
-			joy.axes = new ArrayList<InputDevice.MotionRange>();
-			joy.hats = new ArrayList<InputDevice.MotionRange>();
+					List<InputDevice.MotionRange> ranges = device.getMotionRanges();
+					Collections.sort(ranges, new RangeComparator());
 
-			List<InputDevice.MotionRange> ranges = device.getMotionRanges();
-			Collections.sort(ranges, new RangeComparator());
+					for (InputDevice.MotionRange range : ranges) {
+						if (range.getAxis() == MotionEvent.AXIS_HAT_X || range.getAxis() == MotionEvent.AXIS_HAT_Y) {
+							joy.hats.add(range);
+						} else {
+							joy.axes.add(range);
+						}
+					}
 
-			for (InputDevice.MotionRange range : ranges) {
-				if (range.getAxis() == MotionEvent.AXIS_HAT_X || range.getAxis() == MotionEvent.AXIS_HAT_Y) {
-					joy.hats.add(range);
-				} else {
-					joy.axes.add(range);
+					joy_devices.add(joy);
+
+					final int device_id = id;
+					final String name = joy.name;
+					queueEvent(new Runnable() {
+						@Override
+						public void run() {
+							GodotLib.joyconnectionchanged(device_id, true, name);
+						}
+					});
 				}
 			}
-
-			joy_devices.add(joy);
-
-			final int device_id = id;
-			final String name = joy.name;
-			queueEvent(new Runnable() {
-				@Override
-				public void run() {
-					GodotLib.joyconnectionchanged(device_id, true, name);
-				}
-			});
 		}
 	}
 
@@ -269,6 +287,8 @@ public class GodotView extends GLSurfaceView implements InputDeviceListener {
 
 	@Override
 	public void onInputDeviceChanged(int deviceId) {
+		onInputDeviceRemoved(deviceId);
+		onInputDeviceAdded(deviceId);
 	}
 	@Override
 	public boolean onKeyUp(final int keyCode, KeyEvent event) {

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -59,6 +59,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance) {
 	_get_clipboard = p_env->GetMethodID(cls, "getClipboard", "()Ljava/lang/String;");
 	_set_clipboard = p_env->GetMethodID(cls, "setClipboard", "(Ljava/lang/String;)V");
 	_request_permission = p_env->GetMethodID(cls, "requestPermission", "(Ljava/lang/String;)Z");
+	_init_input_devices = p_env->GetMethodID(cls, "initInputDevices", "()V");
 }
 
 GodotJavaWrapper::~GodotJavaWrapper() {
@@ -181,5 +182,12 @@ bool GodotJavaWrapper::request_permission(const String &p_name) {
 		return env->CallBooleanMethod(godot_instance, _request_permission, jStrName);
 	} else {
 		return false;
+	}
+}
+
+void GodotJavaWrapper::init_input_devices() {
+	if (_init_input_devices) {
+		JNIEnv *env = ThreadAndroid::get_env();
+		env->CallVoidMethod(godot_instance, _init_input_devices);
 	}
 }

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -54,6 +54,7 @@ private:
 	jmethodID _get_clipboard = 0;
 	jmethodID _set_clipboard = 0;
 	jmethodID _request_permission = 0;
+	jmethodID _init_input_devices = 0;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance);
@@ -76,6 +77,7 @@ public:
 	bool has_set_clipboard();
 	void set_clipboard(const String &p_text);
 	bool request_permission(const String &p_name);
+	void init_input_devices();
 };
 
 #endif /* !JAVA_GODOT_WRAPPER_H */

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -251,6 +251,10 @@ int OS_Android::get_mouse_button_state() const {
 }
 
 void OS_Android::set_window_title(const String &p_title) {
+	//This queries/updates the currently connected devices/joypads
+	//Set_window_title is called when initializing the main loop (main.cpp)
+	//therefore this place is found to be suitable (I found no better).
+	godot_java->init_input_devices();
 }
 
 void OS_Android::set_video_mode(const VideoMode &p_video_mode, int p_screen) {


### PR DESCRIPTION
Previously, the Android gamepad/input code ignored any gamepads/joystick which were connected before the app was started.

This update is supposed to fix https://github.com/godotengine/godot/issues/25151 (at least partly).

This code update introduces a method "initInputDevices" which iterates all input devices and adds any unknown (so it can be safely called multiple times).

onInputDevices is called once per device (as is now already done on devices connecting while the app runs) and has been updated to only add Joysticks and Gamepads. It has also been updated to handle the (valid) result "null" of mInputManager.getInputDevice() so this doesn't lead to a "java.lang.NullPointerException" on the following device.getName().

onInputDeviceChanged now simply removes the device and adds it again. This may change the device number but takes into account if a device changes its class (i.e. from Pointer/Mouse to Joystick or vice versa).

"initInputDevices" is called in this code update by set_window_title(). This is debatable but works well at least. 
Calling the method in the constructors/setup of Godot.java or GodotView.java didn't work as Godot/Input doesn't seem to be "ready" to receive the callbacks for the new input devices at that point. set_window_title() is called inside main.cpp quite late in the startup though.

Feel free to find a better place to call initInputDevices.