### PR TITLE
Support Mac OS default delete char hotkeys

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2277,24 +2277,30 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 #ifdef APPLE_STYLE_KEYS
 		if (k->get_control() && !k->get_shift() && !k->get_alt() && !k->get_command()) {
-			uint32_t move_cursor_key = KEY_UNKNOWN;
+			uint32_t remap_key = KEY_UNKNOWN;
 			switch (k->get_scancode()) {
 				case KEY_F: {
-					move_cursor_key = KEY_RIGHT;
+					remap_key = KEY_RIGHT;
 				} break;
 				case KEY_B: {
-					move_cursor_key = KEY_LEFT;
+					remap_key = KEY_LEFT;
 				} break;
 				case KEY_P: {
-					move_cursor_key = KEY_UP;
+					remap_key = KEY_UP;
 				} break;
 				case KEY_N: {
-					move_cursor_key = KEY_DOWN;
+					remap_key = KEY_DOWN;
+				} break;
+				case KEY_D: {
+					remap_key = KEY_DELETE;
+				} break;
+				case KEY_H: {
+					remap_key = KEY_BACKSPACE;
 				} break;
 			}
 
-			if (move_cursor_key != KEY_UNKNOWN) {
-				k->set_scancode(move_cursor_key);
+			if (remap_key != KEY_UNKNOWN) {
+				k->set_scancode(remap_key);
 				k->set_control(false);
 			}
 		}


### PR DESCRIPTION
With a move cursor hotkeys a lot of usage is delete character hotkeys:

Control-H: Delete the character to the left of the insertion point.
Control-D: Delete the character to the right of the insertion point.

