### PR TITLE
Fix ParallaxBackground breaking when moving it out the scene tree

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -105,6 +105,11 @@ void ParallaxLayer::_notification(int p_what) {
 			orig_scale = get_scale();
 			_update_mirroring();
 		} break;
+		case NOTIFICATION_EXIT_TREE: {
+
+			set_position(orig_offset);
+			set_scale(orig_scale);
+		} break;
 	}
 }
 


### PR DESCRIPTION
Entering the tree caused ParallaxLayer to shift its origin to its position, but it would not shift back on exiting, so when it entered again it would shift further.

_Bugsquad edit_: Fixes #26404.