### PR TITLE
FIX unsaved script doesn´t actualize #28693

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -388,6 +388,12 @@ void ScriptEditor::_save_history() {
 
 void ScriptEditor::_go_to_tab(int p_idx) {
 
+	ScriptEditorBase *current = _get_current_editor();
+	if (current->is_unsaved()) {
+
+		current->apply_code();
+	}
+
 	Control *c = Object::cast_to<Control>(tab_container->get_child(p_idx));
 	if (!c)
 		return;


### PR DESCRIPTION
This fix issue #28693 
https://github.com/godotengine/godot/issues/28693
Script editor doesn´t send an unsaved script in signal "editor_script_changed" ,it sends the last "disk stored" script unless you close other script. This commit fix that.