### PR TITLE
FIX Script editor doesn´t send unsaved script #28693

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -388,6 +388,14 @@ void ScriptEditor::_save_history() {
 
 void ScriptEditor::_go_to_tab(int p_idx) {
 
+	ScriptEditorBase *current = _get_current_editor();
+	if (current) {
+		if (current->is_unsaved()) {
+
+			current->apply_code();
+		}
+	}
+
 	Control *c = Object::cast_to<Control>(tab_container->get_child(p_idx));
 	if (!c)
 		return;


### PR DESCRIPTION
This commit fix #28693.
Script editor doesn´t send unsaved version of a script in editor_script_changed signal (sends disk stored version) unless you close other script and apply_scripts() is performed.
I did this pull request https://github.com/godotengine/godot/pull/28694 but i will sure that test eliminating "if (current)" comprobation but don´t. sorry about that. This commit is tested, works, respect changing script -> docs docs -> script, respect undo, etc...