### PR TITLE
Document reproducability of Array.shuffle()

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -291,7 +291,7 @@
 		</method>
 		<method name="shuffle">
 			<description>
-				Shuffles the array such that the items will have a random order.
+				Shuffles the array such that the items will have a random order. This method uses the global random number generator common to methods such as [method @GDScript.randi]. Call [method @GDScript.randomize] to ensure that a new seed will be used each time if you want non-reproducible shuffling.
 			</description>
 		</method>
 		<method name="size">

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -291,11 +291,7 @@
 		</method>
 		<method name="shuffle">
 			<description>
-<<<<<<< HEAD
 				Shuffles the array such that the items will have a random order. This method uses the global random number generator common to methods such as [method @GDScript.randi]. Call [method @GDScript.randomize] to ensure that a new seed will be used each time if you want non-reproducible shuffling.
-=======
-				Shuffles the array such that the items will have a random order. This function will generate reproducible values. To get random values in each runtime, consider using [method randomize].
->>>>>>> ce004e4f4a31af47ef3fe404476903ac3dcc6170
 			</description>
 		</method>
 		<method name="size">

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -291,7 +291,7 @@
 		</method>
 		<method name="shuffle">
 			<description>
-				Shuffles the array such that the items will have a random order.
+				Shuffles the array such that the items will have a random order. This function will generate reproducible values. To get random values in each runtime, consider using [method randomize].
 			</description>
 		</method>
 		<method name="size">

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+scons -j8 platform=x11 && ./bin/godot.x11.tools.64 -v


### PR DESCRIPTION
As mentioned in #28689 the documentation should mention that `shuffle()` is intended to be reproducible.