### PR TITLE
Fix generation of Mono Glue for Visual Studio 2017+

### DIFF
--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -210,7 +210,7 @@ String str_format(const char *p_format, ...) {
 #endif
 #endif
 
-#if defined(MINGW_ENABLED) || defined(_MSC_VER)
+#if defined(MINGW_ENABLED) || defined(_MSC_VER) && _MSC_VER < 1900
 #define vsnprintf(m_buffer, m_count, m_format, m_argptr) vsnprintf_s(m_buffer, m_count, _TRUNCATE, m_format, m_argptr)
 #endif
 


### PR DESCRIPTION
`vsnprintf` definition should only be changed when MSC version is older/equal 2013. The version check and fix is taken from StringUtils.h in assimp:

https://github.com/godotengine/godot/blob/d8617f237acbed21ca4b1a9e7df2d28b32e511b1/thirdparty/assimp/include/assimp/StringUtils.h#L58

Fixes #28604