### PR TITLE
Export paths are now saved as relative paths

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -208,7 +208,13 @@ EditorPropertyTextEnum::EditorPropertyTextEnum() {
 
 void EditorPropertyPath::_path_selected(const String &p_path) {
 
-	emit_changed(get_edited_property(), p_path);
+	String final_path = p_path;
+	if (final_path.is_abs_path()) {
+		String res_path = OS::get_singleton()->get_resource_dir() + "/";
+		final_path = res_path.path_to_file(final_path);
+	}
+
+	emit_changed(get_edited_property(), final_path);
 	update_property();
 }
 void EditorPropertyPath::_path_pressed() {
@@ -221,6 +227,13 @@ void EditorPropertyPath::_path_pressed() {
 	}
 
 	String full_path = get_edited_object()->get(get_edited_property());
+	if (full_path.is_rel_path()) {
+
+		if (!DirAccess::exists(full_path.get_base_dir())) {
+			DirAccessRef da(DirAccess::create(DirAccess::ACCESS_FILESYSTEM));
+			da->make_dir_recursive(full_path.get_base_dir());
+		}
+	}
 
 	dialog->clear_filters();
 

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -931,8 +931,17 @@ void ProjectExportDialog::_export_project() {
 		export_project->add_filter("*." + extension_list[i] + " ; " + platform->get_name() + " Export");
 	}
 
-	if (current->get_export_path() != "") {
-		export_project->set_current_path(current->get_export_path());
+	String current_preset_export_path = current->get_export_path();
+
+	if (current_preset_export_path != "") {
+
+		if (!DirAccess::exists(current_preset_export_path.get_base_dir())) {
+
+			DirAccessRef da(DirAccess::create(DirAccess::ACCESS_FILESYSTEM));
+			da->make_dir_recursive(current_preset_export_path.get_base_dir());
+		}
+
+		export_project->set_current_path(current_preset_export_path);
 	} else {
 		if (extension_list.size() >= 1) {
 			export_project->set_current_file(default_filename + "." + extension_list[0]);


### PR DESCRIPTION
- Created final_path_from_relative which takes a relative path and outputs the final path from a string that represents a directory.
- Added relative_path_from_final which takes in a final path and outputs a relative path if possible. If not possible it outputs the relative path that represents the current directory (".").
- If the target directory does not exist when exporting the project, then it is recursively created.

Fixes #27849.
There may be issues considering other areas in the editor in which EditorPropertyPath is used, but I haven't tested those options.
I had considered the option of adding a prompt to the user for making the export path relative, but as the user describes in the issue that they may add it to the gitignore file, I believe that keeping it as a relative path from the start would be more benefitial.
Used the 3D Platformer Demo project along with 3.1 export templates to test my changes.