### PR TITLE
Show file path in FileSystem dock tooltip

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -755,7 +755,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		Ref<Texture> type_icon;
 		Ref<Texture> big_icon;
 
-		String tooltip = fname;
+		String tooltip = fpath;
 
 		// Select the icons
 		if (!finfo->import_broken) {


### PR DESCRIPTION
This adding a setting "Docks > File System > Show Path in Tooltip" (unchecked by default), because when using the search, it's not possible to differentiate two files with the same name.

Also, as the the dragged value to script is the complete path of the file, I think it's more convenient to already have the path displayed.