### PR TITLE
Make editor close empty scene when creating an inherited one

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -671,6 +671,7 @@ public:
 	static void remove_editor_plugin(EditorPlugin *p_editor, bool p_config_changed = false);
 
 	void new_inherited_scene() { _menu_option_confirm(FILE_NEW_INHERITED_SCENE, false); }
+	void close_current_scene() { _menu_option_confirm(FILE_CLOSE, false); }
 
 	void set_docks_visible(bool p_show);
 	bool get_docks_visible() const;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -334,6 +334,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			Node *scene = edited_scene;
 
 			if (!scene) {
+				EditorNode::get_singleton()->close_current_scene();
 				EditorNode::get_singleton()->new_inherited_scene();
 				break;
 			}


### PR DESCRIPTION
Fixes #28654.