### PR TITLE
Add normalization of quats when deserilization from tscn/escn file

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -114,6 +114,8 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 					tk.value.rot.y = ofs[6];
 					tk.value.rot.z = ofs[7];
 					tk.value.rot.w = ofs[8];
+					// used to sanitize rsc from ESCN file
+					tk.value.rot.normalize();
 
 					tk.value.scale.x = ofs[9];
 					tk.value.scale.y = ofs[10];


### PR DESCRIPTION
fix #26363, the issue is that godot does not seen some quaternion rotation frame from ESCN file as normalized in [interpolation](https://github.com/godotengine/godot/blob/master/scene/resources/animation.cpp#L1510), although those quaternions are already normalized by blender when exporting.

This fix touches the core deserialization of godot scene data, which makes it not appealin :( Or maybe we can make the [quaternion check](https://github.com/godotengine/godot/blob/master/core/math/quat.cpp#L137) less strict, other than these two, I can not think about any good fixes