### PR TITLE
Added native binding for dictionary duplication

### DIFF
--- a/modules/gdnative/gdnative/dictionary.cpp
+++ b/modules/gdnative/gdnative/dictionary.cpp
@@ -55,6 +55,15 @@ void GDAPI godot_dictionary_destroy(godot_dictionary *p_self) {
 	self->~Dictionary();
 }
 
+godot_dictionary GDAPI godot_dictionary_duplicate(const godot_dictionary *p_self, const godot_bool p_deep) {
+	const Dictionary *self = (const Dictionary *)p_self;
+	godot_dictionary res;
+	Dictionary *val = (Dictionary *)&res;
+	memnew_placement(val, Dictionary);
+	*val = self->duplicate(p_deep);
+	return res;
+}
+
 godot_int GDAPI godot_dictionary_size(const godot_dictionary *p_self) {
 	const Dictionary *self = (const Dictionary *)p_self;
 	return self->size();

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -11,7 +11,24 @@
         "major": 1,
         "minor": 1
       },
-      "next": null,
+      "next": {
+        "type": "CORE",
+        "version": {
+          "major": 1,
+          "minor": 2
+        },
+        "next": null,
+        "api": [
+          {
+            "name": "godot_dictionary_duplicate",
+            "return_type": "godot_dictionary",
+            "arguments": [
+              ["const godot_dictionary *", "p_self"],
+              ["const godot_bool", "p_deep"]
+            ]
+          }
+        ]
+      },
       "api": [
         {
           "name": "godot_color_to_abgr32",

--- a/modules/gdnative/include/gdnative/dictionary.h
+++ b/modules/gdnative/include/gdnative/dictionary.h
@@ -63,6 +63,8 @@ void GDAPI godot_dictionary_new(godot_dictionary *r_dest);
 void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *p_src);
 void GDAPI godot_dictionary_destroy(godot_dictionary *p_self);
 
+godot_dictionary GDAPI godot_dictionary_duplicate(const godot_dictionary *p_self, const godot_bool p_deep);
+
 godot_int GDAPI godot_dictionary_size(const godot_dictionary *p_self);
 
 godot_bool GDAPI godot_dictionary_empty(const godot_dictionary *p_self);


### PR DESCRIPTION
There was no native binding for Dictionary duplication.
I took the native binding for array duplication (from modules/gdnative/gdnative/array.cpp)
and modified it for dictionaries.

Was this oversight deliberate? or didn't anyone need to duplicate their dictionaries in native scripts until now?