### PR TITLE
 Change empty scene closing on new inherented scene to a better approach

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1271,6 +1271,11 @@ void EditorNode::_dialog_action(String p_file) {
 	switch (current_option) {
 		case FILE_NEW_INHERITED_SCENE: {
 
+			Node *scene = editor_data.get_edited_scene_root();
+			// If the previous scene is rootless, just close it in favor of the new one.
+			if (!scene)
+				_menu_option_confirm(FILE_CLOSE, false);
+
 			load_scene(p_file, false, true);
 		} break;
 		case FILE_OPEN_SCENE: {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -671,7 +671,6 @@ public:
 	static void remove_editor_plugin(EditorPlugin *p_editor, bool p_config_changed = false);
 
 	void new_inherited_scene() { _menu_option_confirm(FILE_NEW_INHERITED_SCENE, false); }
-	void close_current_scene() { _menu_option_confirm(FILE_CLOSE, false); }
 
 	void set_docks_visible(bool p_show);
 	bool get_docks_visible() const;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -334,7 +334,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			Node *scene = edited_scene;
 
 			if (!scene) {
-				EditorNode::get_singleton()->close_current_scene();
 				EditorNode::get_singleton()->new_inherited_scene();
 				break;
 			}


### PR DESCRIPTION
This reverts 0f8356d43994e3b7f054ac223a6681773aeb9330, and replaces it with a better approach that doesn't close the empty scene before the inherented one was created.