### PR TITLE
Enable BC6H compression for all HDR formats

### DIFF
--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -145,7 +145,7 @@ void image_compress_cvtt(Image *p_image, float p_lossy_quality, Image::CompressS
 	int h = p_image->get_height();
 
 	bool is_ldr = (p_image->get_format() <= Image::FORMAT_RGBA8);
-	bool is_hdr = (p_image->get_format() == Image::FORMAT_RGBH);
+	bool is_hdr = (p_image->get_format() >= Image::FORMAT_RH) && (p_image->get_format() <= Image::FORMAT_RGBE9995);
 
 	if (!is_ldr && !is_hdr) {
 		return; // Not a usable source format
@@ -175,6 +175,10 @@ void image_compress_cvtt(Image *p_image, float p_lossy_quality, Image::CompressS
 
 	bool is_signed = false;
 	if (is_hdr) {
+		if (p_image->get_format() != Image::FORMAT_RGBH) {
+			p_image->convert(Image::FORMAT_RGBH);
+		}
+
 		PoolVector<uint8_t>::Read rb = p_image->get_data().read();
 
 		const uint16_t *source_data = reinterpret_cast<const uint16_t *>(&rb[0]);


### PR DESCRIPTION
Previously only RGBH formatted images were compressed to BC6H, this change
enables BC6H compression also for the RH, RGH, and RGBE9995 formats, allowing
1:2, 1:4, and 1:4 size reduction for them, respectively.
This is in particular important for HDRI images which usually come in RGBE9995
format.