### PR TITLE
Added "can_brake" variable for VehicleWheel

### DIFF
--- a/doc/classes/VehicleWheel.xml
+++ b/doc/classes/VehicleWheel.xml
@@ -46,6 +46,9 @@
 		<member name="use_as_traction" type="bool" setter="set_use_as_traction" getter="is_used_as_traction">
 			If [code]true[/code] this wheel transfers engine force to the ground to propel the vehicle forward.
 		</member>
+		<member name="use_as_traction" type="bool" setter="set_use_as_traction" getter="is_used_as_traction">
+			If [code]true[/code], this wheel can transmit braking force to the ground to brake the vehicle.
+		</member>
 		<member name="wheel_friction_slip" type="float" setter="set_friction_slip" getter="get_friction_slip">
 			This determines how much grip this wheel has. It is combined with the friction setting of the surface the wheel is in contact with. 0.0 means no grip, 1.0 is normal grip. For a drift car setup, try setting the grip of the rear wheels slightly lower than the front wheels, or use a lower value to simulate tire wear.
 			It's best to set this to 1.0 when starting out.

--- a/scene/3d/vehicle_body.h
+++ b/scene/3d/vehicle_body.h
@@ -45,6 +45,7 @@ class VehicleWheel : public Spatial {
 	Transform local_xform;
 	bool engine_traction;
 	bool steers;
+	bool can_brake;
 
 	Vector3 m_chassisConnectionPointCS; //const
 	Vector3 m_wheelDirectionCS; //const
@@ -126,6 +127,9 @@ public:
 
 	void set_use_as_steering(bool p_enabled);
 	bool is_used_as_steering() const;
+
+	void set_use_as_brake(bool p_enable);
+	bool is_used_as_brake() const;
 
 	bool is_in_contact() const;
 


### PR DESCRIPTION
Now you can choose which wheels will brake.
Previously, the `brake` parameter affects only those wheels where `engine_traction == false`.

*This pull request refers to #28733 issue.*