### PR TITLE
Change "ID" to lowercase "id"

### DIFF
--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -58,7 +58,7 @@ Error MessageQueue::push_call(ObjectID p_id, const StringName &p_method, const V
 
 	Message *msg = memnew_placement(&buffer[buffer_end], Message);
 	msg->args = p_argcount;
-	msg->instance_ID = p_id;
+	msg->instance_id = p_id;
 	msg->target = p_method;
 	msg->type = TYPE_CALL;
 	if (p_show_error)
@@ -109,7 +109,7 @@ Error MessageQueue::push_set(ObjectID p_id, const StringName &p_prop, const Vari
 
 	Message *msg = memnew_placement(&buffer[buffer_end], Message);
 	msg->args = 1;
-	msg->instance_ID = p_id;
+	msg->instance_id = p_id;
 	msg->target = p_prop;
 	msg->type = TYPE_SET;
 
@@ -143,7 +143,7 @@ Error MessageQueue::push_notification(ObjectID p_id, int p_notification) {
 	Message *msg = memnew_placement(&buffer[buffer_end], Message);
 
 	msg->type = TYPE_NOTIFICATION;
-	msg->instance_ID = p_id;
+	msg->instance_id = p_id;
 	//msg->target;
 	msg->notification = p_notification;
 
@@ -177,7 +177,7 @@ void MessageQueue::statistics() {
 	while (read_pos < buffer_end) {
 		Message *message = (Message *)&buffer[read_pos];
 
-		Object *target = ObjectDB::get_instance(message->instance_ID);
+		Object *target = ObjectDB::get_instance(message->instance_id);
 
 		if (target != NULL) {
 
@@ -289,7 +289,7 @@ void MessageQueue::flush() {
 
 		_THREAD_SAFE_UNLOCK_
 
-		Object *target = ObjectDB::get_instance(message->instance_ID);
+		Object *target = ObjectDB::get_instance(message->instance_id);
 
 		if (target != NULL) {
 

--- a/core/message_queue.h
+++ b/core/message_queue.h
@@ -54,7 +54,7 @@ class MessageQueue {
 
 	struct Message {
 
-		ObjectID instance_ID;
+		ObjectID instance_id;
 		StringName target;
 		int16_t type;
 		union {

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1947,8 +1947,8 @@ Object::Object() {
 	_class_ptr = NULL;
 	_block_signals = false;
 	_predelete_ok = 0;
-	_instance_ID = 0;
-	_instance_ID = ObjectDB::add_instance(this);
+	_instance_id = 0;
+	_instance_id = ObjectDB::add_instance(this);
 	_can_translate = true;
 	_is_queued_for_deletion = false;
 	instance_binding_count = 0;
@@ -2002,7 +2002,7 @@ Object::~Object() {
 	}
 
 	ObjectDB::remove_instance(this);
-	_instance_ID = 0;
+	_instance_id = 0;
 	_predelete_ok = 2;
 
 	if (!ScriptServer::are_languages_finished()) {
@@ -2050,10 +2050,10 @@ void ObjectDB::remove_instance(Object *p_object) {
 
 	rw_lock->write_unlock();
 }
-Object *ObjectDB::get_instance(ObjectID p_instance_ID) {
+Object *ObjectDB::get_instance(ObjectID p_instance_id) {
 
 	rw_lock->read_lock();
-	Object **obj = instances.getptr(p_instance_ID);
+	Object **obj = instances.getptr(p_instance_id);
 	rw_lock->read_unlock();
 
 	if (!obj)

--- a/core/object.h
+++ b/core/object.h
@@ -465,7 +465,7 @@ private:
 	bool _block_signals;
 	int _predelete_ok;
 	Set<Object *> change_receptors;
-	ObjectID _instance_ID;
+	ObjectID _instance_id;
 	bool _predelete();
 	void _postinitialize();
 	bool _can_translate;
@@ -577,7 +577,7 @@ public:
 
 	bool _is_gpl_reversed() const { return false; }
 
-	_FORCE_INLINE_ ObjectID get_instance_id() const { return _instance_ID; }
+	_FORCE_INLINE_ ObjectID get_instance_id() const { return _instance_id; }
 	// this is used for editors
 
 	void add_change_receptor(Object *p_receptor);
@@ -776,7 +776,7 @@ class ObjectDB {
 public:
 	typedef void (*DebugFunc)(Object *p_obj);
 
-	static Object *get_instance(ObjectID p_instance_ID);
+	static Object *get_instance(ObjectID p_instance_id);
 	static void debug_objects(DebugFunc p_func);
 	static int get_object_count();
 

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -348,13 +348,13 @@ void BulletPhysicsServer::area_set_shape_disabled(RID p_area, int p_shape_idx, b
 	area->set_shape_disabled(p_shape_idx, p_disabled);
 }
 
-void BulletPhysicsServer::area_attach_object_instance_id(RID p_area, ObjectID p_ID) {
+void BulletPhysicsServer::area_attach_object_instance_id(RID p_area, ObjectID p_id) {
 	if (space_owner.owns(p_area)) {
 		return;
 	}
 	AreaBullet *area = area_owner.get(p_area);
 	ERR_FAIL_COND(!area);
-	area->set_instance_id(p_ID);
+	area->set_instance_id(p_id);
 }
 
 ObjectID BulletPhysicsServer::area_get_object_instance_id(RID p_area) const {
@@ -569,11 +569,11 @@ void BulletPhysicsServer::body_clear_shapes(RID p_body) {
 	body->remove_all_shapes();
 }
 
-void BulletPhysicsServer::body_attach_object_instance_id(RID p_body, uint32_t p_ID) {
+void BulletPhysicsServer::body_attach_object_instance_id(RID p_body, uint32_t p_id) {
 	CollisionObjectBullet *body = get_collisin_object(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->set_instance_id(p_ID);
+	body->set_instance_id(p_id);
 }
 
 uint32_t BulletPhysicsServer::body_get_object_instance_id(RID p_body) const {

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -142,7 +142,7 @@ public:
 	virtual void area_remove_shape(RID p_area, int p_shape_idx);
 	virtual void area_clear_shapes(RID p_area);
 	virtual void area_set_shape_disabled(RID p_area, int p_shape_idx, bool p_disabled);
-	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_ID);
+	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id);
 	virtual ObjectID area_get_object_instance_id(RID p_area) const;
 
 	/// If you pass as p_area the SpaceBullet you can set some parameters as specified below
@@ -189,7 +189,7 @@ public:
 	virtual void body_clear_shapes(RID p_body);
 
 	// Used for Rigid and Soft Bodies
-	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_ID);
+	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_id);
 	virtual uint32_t body_get_object_instance_id(RID p_body) const;
 
 	virtual void body_set_enable_continuous_collision_detection(RID p_body, bool p_enable);

--- a/platform/android/java/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotLib.java
@@ -68,8 +68,8 @@ public class GodotLib {
 	public static native void singleton(String p_name, Object p_object);
 	public static native void method(String p_sname, String p_name, String p_ret, String[] p_params);
 	public static native String getGlobal(String p_key);
-	public static native void callobject(int p_ID, String p_method, Object[] p_params);
-	public static native void calldeferred(int p_ID, String p_method, Object[] p_params);
+	public static native void callobject(int p_id, String p_method, Object[] p_params);
+	public static native void calldeferred(int p_id, String p_method, Object[] p_params);
 	public static native void requestPermissionResult(String p_permission, boolean p_result);
 
 	public static native void setVirtualKeyboardHeight(int p_height);

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -52,7 +52,7 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 		_get_locale = p_env->GetMethodID(cls, "getLocale", "()Ljava/lang/String;");
 		_get_model = p_env->GetMethodID(cls, "getModel", "()Ljava/lang/String;");
 		_get_screen_DPI = p_env->GetMethodID(cls, "getScreenDPI", "()I");
-		_get_unique_ID = p_env->GetMethodID(cls, "getUniqueID", "()Ljava/lang/String;");
+		_get_unique_id = p_env->GetMethodID(cls, "getUniqueID", "()Ljava/lang/String;");
 		_show_keyboard = p_env->GetMethodID(cls, "showKeyboard", "(Ljava/lang/String;)V");
 		_hide_keyboard = p_env->GetMethodID(cls, "hideKeyboard", "()V");
 		_set_screen_orientation = p_env->GetMethodID(cls, "setScreenOrientation", "(I)V");
@@ -122,9 +122,9 @@ int GodotIOJavaWrapper::get_screen_dpi() {
 }
 
 String GodotIOJavaWrapper::get_unique_id() {
-	if (_get_unique_ID) {
+	if (_get_unique_id) {
 		JNIEnv *env = ThreadAndroid::get_env();
-		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_unique_ID);
+		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_unique_id);
 		return jstring_to_string(s, env);
 	} else {
 		return String();

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -50,7 +50,7 @@ private:
 	jmethodID _get_locale = 0;
 	jmethodID _get_model = 0;
 	jmethodID _get_screen_DPI = 0;
-	jmethodID _get_unique_ID = 0;
+	jmethodID _get_unique_id = 0;
 	jmethodID _show_keyboard = 0;
 	jmethodID _hide_keyboard = 0;
 	jmethodID _set_screen_orientation = 0;

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -84,14 +84,14 @@ void OSIPhone::set_data_dir(String p_dir) {
 	memdelete(da);
 };
 
-void OSIPhone::set_unique_id(String p_ID) {
+void OSIPhone::set_unique_id(String p_id) {
 
-	unique_ID = p_ID;
+	unique_id = p_id;
 };
 
 String OSIPhone::get_unique_id() const {
 
-	return unique_ID;
+	return unique_id;
 };
 
 void OSIPhone::initialize_core() {

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -107,7 +107,7 @@ private:
 	void queue_event(const Ref<InputEvent> &p_event);
 
 	String data_dir;
-	String unique_ID;
+	String unique_id;
 	String locale_code;
 
 	InputDefault *input;
@@ -183,7 +183,7 @@ public:
 	void set_locale(String p_locale);
 	String get_locale() const;
 
-	void set_unique_id(String p_ID);
+	void set_unique_id(String p_id);
 	String get_unique_id() const;
 
 	virtual Error native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -115,15 +115,15 @@ void OptionButton::pressed() {
 	popup->popup();
 }
 
-void OptionButton::add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID) {
+void OptionButton::add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_id) {
 
-	popup->add_icon_radio_check_item(p_icon, p_label, p_ID);
+	popup->add_icon_radio_check_item(p_icon, p_label, p_id);
 	if (popup->get_item_count() == 1)
 		select(0);
 }
-void OptionButton::add_item(const String &p_label, int p_ID) {
+void OptionButton::add_item(const String &p_label, int p_id) {
 
-	popup->add_radio_check_item(p_label, p_ID);
+	popup->add_radio_check_item(p_label, p_id);
 	if (popup->get_item_count() == 1)
 		select(0);
 }
@@ -136,9 +136,9 @@ void OptionButton::set_item_icon(int p_idx, const Ref<Texture> &p_icon) {
 
 	popup->set_item_icon(p_idx, p_icon);
 }
-void OptionButton::set_item_id(int p_idx, int p_ID) {
+void OptionButton::set_item_id(int p_idx, int p_id) {
 
-	popup->set_item_id(p_idx, p_ID);
+	popup->set_item_id(p_idx, p_id);
 }
 
 void OptionButton::set_item_metadata(int p_idx, const Variant &p_metadata) {
@@ -338,8 +338,8 @@ void OptionButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "items", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_items", "_get_items");
 	// "selected" property must come after "items", otherwise GH-10213 occurs
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "selected"), "_select_int", "get_selected");
-	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "ID")));
-	ADD_SIGNAL(MethodInfo("item_focused", PropertyInfo(Variant::INT, "ID")));
+	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "id")));
+	ADD_SIGNAL(MethodInfo("item_focused", PropertyInfo(Variant::INT, "id")));
 }
 
 OptionButton::OptionButton() {

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -59,12 +59,12 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID = -1);
-	void add_item(const String &p_label, int p_ID = -1);
+	void add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_id = -1);
+	void add_item(const String &p_label, int p_id = -1);
 
 	void set_item_text(int p_idx, const String &p_text);
 	void set_item_icon(int p_idx, const Ref<Texture> &p_icon);
-	void set_item_id(int p_idx, int p_ID);
+	void set_item_id(int p_idx, int p_id);
 	void set_item_metadata(int p_idx, const Variant &p_metadata);
 	void set_item_disabled(int p_idx, bool p_disabled);
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -355,7 +355,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		int over = _get_mouse_over(m->get_position());
-		int id = (over < 0 || items[over].separator || items[over].disabled) ? -1 : (items[over].ID >= 0 ? items[over].ID : over);
+		int id = (over < 0 || items[over].separator || items[over].disabled) ? -1 : (items[over].id >= 0 ? items[over].id : over);
 
 		if (id < 0) {
 			mouse_over = -1;
@@ -591,93 +591,93 @@ void PopupMenu::_notification(int p_what) {
 	}
 }
 
-void PopupMenu::add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID, uint32_t p_accel) {
+void PopupMenu::add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_id, uint32_t p_accel) {
 
 	Item item;
 	item.icon = p_icon;
 	item.text = p_label;
 	item.xl_text = tr(p_label);
 	item.accel = p_accel;
-	item.ID = p_ID;
+	item.id = p_id;
 	items.push_back(item);
 	update();
 	minimum_size_changed();
 }
-void PopupMenu::add_item(const String &p_label, int p_ID, uint32_t p_accel) {
+void PopupMenu::add_item(const String &p_label, int p_id, uint32_t p_accel) {
 
 	Item item;
 	item.text = p_label;
 	item.xl_text = tr(p_label);
 	item.accel = p_accel;
-	item.ID = p_ID == -1 ? items.size() : p_ID;
+	item.id = p_id == -1 ? items.size() : p_id;
 	items.push_back(item);
 	update();
 	minimum_size_changed();
 }
 
-void PopupMenu::add_submenu_item(const String &p_label, const String &p_submenu, int p_ID) {
+void PopupMenu::add_submenu_item(const String &p_label, const String &p_submenu, int p_id) {
 
 	Item item;
 	item.text = p_label;
 	item.xl_text = tr(p_label);
-	item.ID = p_ID;
+	item.id = p_id;
 	item.submenu = p_submenu;
 	items.push_back(item);
 	update();
 	minimum_size_changed();
 }
 
-void PopupMenu::add_icon_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID, uint32_t p_accel) {
+void PopupMenu::add_icon_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_id, uint32_t p_accel) {
 
 	Item item;
 	item.icon = p_icon;
 	item.text = p_label;
 	item.xl_text = tr(p_label);
 	item.accel = p_accel;
-	item.ID = p_ID;
+	item.id = p_id;
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	update();
 	minimum_size_changed();
 }
 
-void PopupMenu::add_check_item(const String &p_label, int p_ID, uint32_t p_accel) {
+void PopupMenu::add_check_item(const String &p_label, int p_id, uint32_t p_accel) {
 
 	Item item;
 	item.text = p_label;
 	item.xl_text = tr(p_label);
 	item.accel = p_accel;
-	item.ID = p_ID == -1 ? items.size() : p_ID;
+	item.id = p_id == -1 ? items.size() : p_id;
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	update();
 	minimum_size_changed();
 }
 
-void PopupMenu::add_radio_check_item(const String &p_label, int p_ID, uint32_t p_accel) {
+void PopupMenu::add_radio_check_item(const String &p_label, int p_id, uint32_t p_accel) {
 
-	add_check_item(p_label, p_ID, p_accel);
+	add_check_item(p_label, p_id, p_accel);
 	items.write[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	update();
 	minimum_size_changed();
 }
 
-void PopupMenu::add_icon_radio_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID, uint32_t p_accel) {
+void PopupMenu::add_icon_radio_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_id, uint32_t p_accel) {
 
-	add_icon_check_item(p_icon, p_label, p_ID, p_accel);
+	add_icon_check_item(p_icon, p_label, p_id, p_accel);
 	items.write[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	update();
 	minimum_size_changed();
 }
 
-void PopupMenu::add_icon_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_ID, bool p_global) {
+void PopupMenu::add_icon_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_id, bool p_global) {
 
 	ERR_FAIL_COND(p_shortcut.is_null());
 
 	_ref_shortcut(p_shortcut);
 
 	Item item;
-	item.ID = p_ID;
+	item.id = p_id;
 	item.icon = p_icon;
 	item.shortcut = p_shortcut;
 	item.shortcut_is_global = p_global;
@@ -686,14 +686,14 @@ void PopupMenu::add_icon_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut
 	minimum_size_changed();
 }
 
-void PopupMenu::add_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID, bool p_global) {
+void PopupMenu::add_shortcut(const Ref<ShortCut> &p_shortcut, int p_id, bool p_global) {
 
 	ERR_FAIL_COND(p_shortcut.is_null());
 
 	_ref_shortcut(p_shortcut);
 
 	Item item;
-	item.ID = p_ID;
+	item.id = p_id;
 	item.shortcut = p_shortcut;
 	item.shortcut_is_global = p_global;
 	items.push_back(item);
@@ -701,14 +701,14 @@ void PopupMenu::add_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID, bool p_g
 	minimum_size_changed();
 }
 
-void PopupMenu::add_icon_check_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_ID, bool p_global) {
+void PopupMenu::add_icon_check_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_id, bool p_global) {
 
 	ERR_FAIL_COND(p_shortcut.is_null());
 
 	_ref_shortcut(p_shortcut);
 
 	Item item;
-	item.ID = p_ID;
+	item.id = p_id;
 	item.shortcut = p_shortcut;
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	item.icon = p_icon;
@@ -718,14 +718,14 @@ void PopupMenu::add_icon_check_shortcut(const Ref<Texture> &p_icon, const Ref<Sh
 	minimum_size_changed();
 }
 
-void PopupMenu::add_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID, bool p_global) {
+void PopupMenu::add_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_id, bool p_global) {
 
 	ERR_FAIL_COND(p_shortcut.is_null());
 
 	_ref_shortcut(p_shortcut);
 
 	Item item;
-	item.ID = p_ID;
+	item.id = p_id;
 	item.shortcut = p_shortcut;
 	item.shortcut_is_global = p_global;
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
@@ -734,21 +734,21 @@ void PopupMenu::add_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID, bo
 	minimum_size_changed();
 }
 
-void PopupMenu::add_radio_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID, bool p_global) {
+void PopupMenu::add_radio_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_id, bool p_global) {
 
-	add_check_shortcut(p_shortcut, p_ID, p_global);
+	add_check_shortcut(p_shortcut, p_id, p_global);
 	items.write[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	update();
 	minimum_size_changed();
 }
 
-void PopupMenu::add_multistate_item(const String &p_label, int p_max_states, int p_default_state, int p_ID, uint32_t p_accel) {
+void PopupMenu::add_multistate_item(const String &p_label, int p_max_states, int p_default_state, int p_id, uint32_t p_accel) {
 
 	Item item;
 	item.text = p_label;
 	item.xl_text = tr(p_label);
 	item.accel = p_accel;
-	item.ID = p_ID;
+	item.id = p_id;
 	item.max_states = p_max_states;
 	item.state = p_default_state;
 	items.push_back(item);
@@ -782,10 +782,10 @@ void PopupMenu::set_item_checked(int p_idx, bool p_checked) {
 	update();
 	minimum_size_changed();
 }
-void PopupMenu::set_item_id(int p_idx, int p_ID) {
+void PopupMenu::set_item_id(int p_idx, int p_id) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items.write[p_idx].ID = p_ID;
+	items.write[p_idx].id = p_id;
 
 	update();
 	minimum_size_changed();
@@ -881,14 +881,14 @@ bool PopupMenu::is_item_checked(int p_idx) const {
 int PopupMenu::get_item_id(int p_idx) const {
 
 	ERR_FAIL_INDEX_V(p_idx, items.size(), 0);
-	return items[p_idx].ID;
+	return items[p_idx].id;
 }
 
-int PopupMenu::get_item_index(int p_ID) const {
+int PopupMenu::get_item_index(int p_id) const {
 
 	for (int i = 0; i < items.size(); i++) {
 
-		if (items[i].ID == p_ID)
+		if (items[i].id == p_id)
 			return i;
 	}
 
@@ -1077,7 +1077,7 @@ void PopupMenu::activate_item(int p_item) {
 
 	ERR_FAIL_INDEX(p_item, items.size());
 	ERR_FAIL_COND(items[p_item].separator);
-	int id = items[p_item].ID >= 0 ? items[p_item].ID : p_item;
+	int id = items[p_item].id >= 0 ? items[p_item].id : p_item;
 
 	//hide all parent PopupMenus
 	Node *next = get_parent();
@@ -1139,7 +1139,7 @@ void PopupMenu::add_separator(const String &p_text) {
 
 	Item sep;
 	sep.separator = true;
-	sep.ID = -1;
+	sep.id = -1;
 	if (p_text != String()) {
 		sep.text = p_text;
 		sep.xl_text = tr(p_text);
@@ -1415,8 +1415,8 @@ void PopupMenu::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_state_item_selection"), "set_hide_on_state_item_selection", "is_hide_on_state_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "submenu_popup_delay"), "set_submenu_popup_delay", "get_submenu_popup_delay");
 
-	ADD_SIGNAL(MethodInfo("id_pressed", PropertyInfo(Variant::INT, "ID")));
-	ADD_SIGNAL(MethodInfo("id_focused", PropertyInfo(Variant::INT, "ID")));
+	ADD_SIGNAL(MethodInfo("id_pressed", PropertyInfo(Variant::INT, "id")));
+	ADD_SIGNAL(MethodInfo("id_focused", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("index_pressed", PropertyInfo(Variant::INT, "index")));
 }
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -55,7 +55,7 @@ class PopupMenu : public Popup {
 		int state;
 		bool separator;
 		bool disabled;
-		int ID;
+		int id;
 		Variant metadata;
 		String submenu;
 		String tooltip;
@@ -120,26 +120,26 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
-	void add_item(const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
-	void add_icon_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
-	void add_check_item(const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
-	void add_radio_check_item(const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
-	void add_icon_radio_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
-	void add_submenu_item(const String &p_label, const String &p_submenu, int p_ID = -1);
+	void add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_id = -1, uint32_t p_accel = 0);
+	void add_item(const String &p_label, int p_id = -1, uint32_t p_accel = 0);
+	void add_icon_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_id = -1, uint32_t p_accel = 0);
+	void add_check_item(const String &p_label, int p_id = -1, uint32_t p_accel = 0);
+	void add_radio_check_item(const String &p_label, int p_id = -1, uint32_t p_accel = 0);
+	void add_icon_radio_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_id = -1, uint32_t p_accel = 0);
+	void add_submenu_item(const String &p_label, const String &p_submenu, int p_id = -1);
 
-	void add_icon_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_ID = -1, bool p_global = false);
-	void add_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID = -1, bool p_global = false);
-	void add_icon_check_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_ID = -1, bool p_global = false);
-	void add_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID = -1, bool p_global = false);
-	void add_radio_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID = -1, bool p_global = false);
+	void add_icon_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_id = -1, bool p_global = false);
+	void add_shortcut(const Ref<ShortCut> &p_shortcut, int p_id = -1, bool p_global = false);
+	void add_icon_check_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_id = -1, bool p_global = false);
+	void add_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_id = -1, bool p_global = false);
+	void add_radio_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_id = -1, bool p_global = false);
 
-	void add_multistate_item(const String &p_label, int p_max_states, int p_default_state, int p_ID = -1, uint32_t p_accel = 0);
+	void add_multistate_item(const String &p_label, int p_max_states, int p_default_state, int p_id = -1, uint32_t p_accel = 0);
 
 	void set_item_text(int p_idx, const String &p_text);
 	void set_item_icon(int p_idx, const Ref<Texture> &p_icon);
 	void set_item_checked(int p_idx, bool p_checked);
-	void set_item_id(int p_idx, int p_ID);
+	void set_item_id(int p_idx, int p_id);
 	void set_item_accelerator(int p_idx, uint32_t p_accel);
 	void set_item_metadata(int p_idx, const Variant &p_meta);
 	void set_item_disabled(int p_idx, bool p_disabled);
@@ -161,7 +161,7 @@ public:
 	Ref<Texture> get_item_icon(int p_idx) const;
 	bool is_item_checked(int p_idx) const;
 	int get_item_id(int p_idx) const;
-	int get_item_index(int p_ID) const;
+	int get_item_index(int p_id) const;
 	uint32_t get_item_accelerator(int p_idx) const;
 	Variant get_item_metadata(int p_idx) const;
 	bool is_item_disabled(int p_idx) const;

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -365,7 +365,7 @@ void PhysicsServerSW::area_set_shape_disabled(RID p_area, int p_shape_idx, bool 
 	area->set_shape_as_disabled(p_shape_idx, p_disabled);
 }
 
-void PhysicsServerSW::area_attach_object_instance_id(RID p_area, ObjectID p_ID) {
+void PhysicsServerSW::area_attach_object_instance_id(RID p_area, ObjectID p_id) {
 
 	if (space_owner.owns(p_area)) {
 		SpaceSW *space = space_owner.get(p_area);
@@ -373,7 +373,7 @@ void PhysicsServerSW::area_attach_object_instance_id(RID p_area, ObjectID p_ID) 
 	}
 	AreaSW *area = area_owner.get(p_area);
 	ERR_FAIL_COND(!area);
-	area->set_instance_id(p_ID);
+	area->set_instance_id(p_id);
 }
 ObjectID PhysicsServerSW::area_get_object_instance_id(RID p_area) const {
 
@@ -673,12 +673,12 @@ uint32_t PhysicsServerSW::body_get_collision_mask(RID p_body) const {
 	return body->get_collision_mask();
 }
 
-void PhysicsServerSW::body_attach_object_instance_id(RID p_body, uint32_t p_ID) {
+void PhysicsServerSW::body_attach_object_instance_id(RID p_body, uint32_t p_id) {
 
 	BodySW *body = body_owner.get(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->set_instance_id(p_ID);
+	body->set_instance_id(p_id);
 };
 
 uint32_t PhysicsServerSW::body_get_object_instance_id(RID p_body) const {

--- a/servers/physics/physics_server_sw.h
+++ b/servers/physics/physics_server_sw.h
@@ -132,7 +132,7 @@ public:
 
 	virtual void area_set_shape_disabled(RID p_area, int p_shape_idx, bool p_disabled);
 
-	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_ID);
+	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id);
 	virtual ObjectID area_get_object_instance_id(RID p_area) const;
 
 	virtual void area_set_param(RID p_area, AreaParameter p_param, const Variant &p_value);
@@ -176,7 +176,7 @@ public:
 	virtual void body_remove_shape(RID p_body, int p_shape_idx);
 	virtual void body_clear_shapes(RID p_body);
 
-	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_ID);
+	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_id);
 	virtual uint32_t body_get_object_instance_id(RID p_body) const;
 
 	virtual void body_set_enable_continuous_collision_detection(RID p_body, bool p_enable);

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -460,7 +460,7 @@ void Physics2DServerSW::area_clear_shapes(RID p_area) {
 		area->remove_shape(0);
 }
 
-void Physics2DServerSW::area_attach_object_instance_id(RID p_area, ObjectID p_ID) {
+void Physics2DServerSW::area_attach_object_instance_id(RID p_area, ObjectID p_id) {
 
 	if (space_owner.owns(p_area)) {
 		Space2DSW *space = space_owner.get(p_area);
@@ -468,7 +468,7 @@ void Physics2DServerSW::area_attach_object_instance_id(RID p_area, ObjectID p_ID
 	}
 	Area2DSW *area = area_owner.get(p_area);
 	ERR_FAIL_COND(!area);
-	area->set_instance_id(p_ID);
+	area->set_instance_id(p_id);
 }
 ObjectID Physics2DServerSW::area_get_object_instance_id(RID p_area) const {
 
@@ -481,7 +481,7 @@ ObjectID Physics2DServerSW::area_get_object_instance_id(RID p_area) const {
 	return area->get_instance_id();
 }
 
-void Physics2DServerSW::area_attach_canvas_instance_id(RID p_area, ObjectID p_ID) {
+void Physics2DServerSW::area_attach_canvas_instance_id(RID p_area, ObjectID p_id) {
 
 	if (space_owner.owns(p_area)) {
 		Space2DSW *space = space_owner.get(p_area);
@@ -489,7 +489,7 @@ void Physics2DServerSW::area_attach_canvas_instance_id(RID p_area, ObjectID p_ID
 	}
 	Area2DSW *area = area_owner.get(p_area);
 	ERR_FAIL_COND(!area);
-	area->set_canvas_instance_id(p_ID);
+	area->set_canvas_instance_id(p_id);
 }
 ObjectID Physics2DServerSW::area_get_canvas_instance_id(RID p_area) const {
 
@@ -763,12 +763,12 @@ Physics2DServerSW::CCDMode Physics2DServerSW::body_get_continuous_collision_dete
 	return body->get_continuous_collision_detection_mode();
 }
 
-void Physics2DServerSW::body_attach_object_instance_id(RID p_body, uint32_t p_ID) {
+void Physics2DServerSW::body_attach_object_instance_id(RID p_body, uint32_t p_id) {
 
 	Body2DSW *body = body_owner.get(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->set_instance_id(p_ID);
+	body->set_instance_id(p_id);
 };
 
 uint32_t Physics2DServerSW::body_get_object_instance_id(RID p_body) const {
@@ -779,12 +779,12 @@ uint32_t Physics2DServerSW::body_get_object_instance_id(RID p_body) const {
 	return body->get_instance_id();
 };
 
-void Physics2DServerSW::body_attach_canvas_instance_id(RID p_body, uint32_t p_ID) {
+void Physics2DServerSW::body_attach_canvas_instance_id(RID p_body, uint32_t p_id) {
 
 	Body2DSW *body = body_owner.get(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->set_canvas_instance_id(p_ID);
+	body->set_canvas_instance_id(p_id);
 };
 
 uint32_t Physics2DServerSW::body_get_canvas_instance_id(RID p_body) const {

--- a/servers/physics_2d/physics_2d_server_sw.h
+++ b/servers/physics_2d/physics_2d_server_sw.h
@@ -144,10 +144,10 @@ public:
 	virtual void area_remove_shape(RID p_area, int p_shape_idx);
 	virtual void area_clear_shapes(RID p_area);
 
-	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_ID);
+	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id);
 	virtual ObjectID area_get_object_instance_id(RID p_area) const;
 
-	virtual void area_attach_canvas_instance_id(RID p_area, ObjectID p_ID);
+	virtual void area_attach_canvas_instance_id(RID p_area, ObjectID p_id);
 	virtual ObjectID area_get_canvas_instance_id(RID p_area) const;
 
 	virtual void area_set_param(RID p_area, AreaParameter p_param, const Variant &p_value);
@@ -191,10 +191,10 @@ public:
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled);
 	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape_idx, bool p_enable, float p_margin);
 
-	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_ID);
+	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_id);
 	virtual uint32_t body_get_object_instance_id(RID p_body) const;
 
-	virtual void body_attach_canvas_instance_id(RID p_body, uint32_t p_ID);
+	virtual void body_attach_canvas_instance_id(RID p_body, uint32_t p_id);
 	virtual uint32_t body_get_canvas_instance_id(RID p_body) const;
 
 	virtual void body_set_continuous_collision_detection_mode(RID p_body, CCDMode p_mode);

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -348,10 +348,10 @@ public:
 
 	virtual void area_set_shape_disabled(RID p_area, int p_shape, bool p_disabled) = 0;
 
-	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_ID) = 0;
+	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id) = 0;
 	virtual ObjectID area_get_object_instance_id(RID p_area) const = 0;
 
-	virtual void area_attach_canvas_instance_id(RID p_area, ObjectID p_ID) = 0;
+	virtual void area_attach_canvas_instance_id(RID p_area, ObjectID p_id) = 0;
 	virtual ObjectID area_get_canvas_instance_id(RID p_area) const = 0;
 
 	virtual void area_set_param(RID p_area, AreaParameter p_param, const Variant &p_value) = 0;
@@ -404,10 +404,10 @@ public:
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) = 0;
 	virtual void body_clear_shapes(RID p_body) = 0;
 
-	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_ID) = 0;
+	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_id) = 0;
 	virtual uint32_t body_get_object_instance_id(RID p_body) const = 0;
 
-	virtual void body_attach_canvas_instance_id(RID p_body, uint32_t p_ID) = 0;
+	virtual void body_attach_canvas_instance_id(RID p_body, uint32_t p_id) = 0;
 	virtual uint32_t body_get_canvas_instance_id(RID p_body) const = 0;
 
 	enum CCDMode {

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -333,7 +333,7 @@ public:
 
 	virtual void area_set_shape_disabled(RID p_area, int p_shape_idx, bool p_disabled) = 0;
 
-	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_ID) = 0;
+	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id) = 0;
 	virtual ObjectID area_get_object_instance_id(RID p_area) const = 0;
 
 	virtual void area_set_param(RID p_area, AreaParameter p_param, const Variant &p_value) = 0;
@@ -385,7 +385,7 @@ public:
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) = 0;
 
-	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_ID) = 0;
+	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_id) = 0;
 	virtual uint32_t body_get_object_instance_id(RID p_body) const = 0;
 
 	virtual void body_set_enable_continuous_collision_detection(RID p_body, bool p_enable) = 0;

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -607,12 +607,12 @@ void VisualServerScene::instance_set_transform(RID p_instance, const Transform &
 	instance->transform = p_transform;
 	_instance_queue_update(instance, true);
 }
-void VisualServerScene::instance_attach_object_instance_id(RID p_instance, ObjectID p_ID) {
+void VisualServerScene::instance_attach_object_instance_id(RID p_instance, ObjectID p_id) {
 
 	Instance *instance = instance_owner.get(p_instance);
 	ERR_FAIL_COND(!instance);
 
-	instance->object_ID = p_ID;
+	instance->object_id = p_id;
 }
 void VisualServerScene::instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight) {
 
@@ -791,10 +791,10 @@ Vector<ObjectID> VisualServerScene::instances_cull_aabb(const AABB &p_aabb, RID 
 
 		Instance *instance = cull[i];
 		ERR_CONTINUE(!instance);
-		if (instance->object_ID == 0)
+		if (instance->object_id == 0)
 			continue;
 
-		instances.push_back(instance->object_ID);
+		instances.push_back(instance->object_id);
 	}
 
 	return instances;
@@ -813,10 +813,10 @@ Vector<ObjectID> VisualServerScene::instances_cull_ray(const Vector3 &p_from, co
 	for (int i = 0; i < culled; i++) {
 		Instance *instance = cull[i];
 		ERR_CONTINUE(!instance);
-		if (instance->object_ID == 0)
+		if (instance->object_id == 0)
 			continue;
 
-		instances.push_back(instance->object_ID);
+		instances.push_back(instance->object_id);
 	}
 
 	return instances;
@@ -837,10 +837,10 @@ Vector<ObjectID> VisualServerScene::instances_cull_convex(const Vector<Plane> &p
 
 		Instance *instance = cull[i];
 		ERR_CONTINUE(!instance);
-		if (instance->object_ID == 0)
+		if (instance->object_id == 0)
 			continue;
 
-		instances.push_back(instance->object_ID);
+		instances.push_back(instance->object_id);
 	}
 
 	return instances;

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -174,7 +174,7 @@ public:
 		AABB transformed_aabb;
 		AABB *custom_aabb; // <Zylann> would using aabb directly with a bool be better?
 		float extra_margin;
-		uint32_t object_ID;
+		uint32_t object_id;
 
 		float lod_begin;
 		float lod_end;
@@ -211,7 +211,7 @@ public:
 
 			extra_margin = 0;
 
-			object_ID = 0;
+			object_id = 0;
 			visible = true;
 
 			lod_begin = 0;
@@ -457,7 +457,7 @@ public:
 	virtual void instance_set_scenario(RID p_instance, RID p_scenario); // from can be mesh, light, poly, area and portal so far.
 	virtual void instance_set_layer_mask(RID p_instance, uint32_t p_mask);
 	virtual void instance_set_transform(RID p_instance, const Transform &p_transform);
-	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_ID);
+	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id);
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight);
 	virtual void instance_set_surface_material(RID p_instance, int p_surface, RID p_material);
 	virtual void instance_set_visible(RID p_instance, bool p_visible);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -814,7 +814,7 @@ public:
 	virtual void instance_set_scenario(RID p_instance, RID p_scenario) = 0; // from can be mesh, light, poly, area and portal so far.
 	virtual void instance_set_layer_mask(RID p_instance, uint32_t p_mask) = 0;
 	virtual void instance_set_transform(RID p_instance, const Transform &p_transform) = 0;
-	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_ID) = 0;
+	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id) = 0;
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight) = 0;
 	virtual void instance_set_surface_material(RID p_instance, int p_surface, RID p_material) = 0;
 	virtual void instance_set_visible(RID p_instance, bool p_visible) = 0;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/28767

Reasoning: ID is not an acronym, it is simply short for identification, so it logically should not be capitalized. But even if it was an acronym, other acronyms in Godot are not capitalized, like `p_rid`, `p_ip`, and `p_json`, as @bojidar-bg pointed out.

Let me know if I missed somewhere. I mostly did a simple find/replace.