### PR TITLE
Fix AudioEffectRecord messing up the effect stack by not writing to dst_frames

### DIFF
--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -32,6 +32,9 @@
 
 void AudioEffectRecordInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
 	if (!is_recording) {
+		for (int i = 0; i < p_frame_count; i++) {
+			p_dst_frames[i] = p_src_frames[i];
+		}
 		return;
 	}
 
@@ -39,6 +42,7 @@ void AudioEffectRecordInstance::process(const AudioFrame *p_src_frames, AudioFra
 	const AudioFrame *src = p_src_frames;
 	AudioFrame *rb_buf = ring_buffer.ptrw();
 	for (int i = 0; i < p_frame_count; i++) {
+		p_dst_frames[i] = p_src_frames[i];
 		rb_buf[ring_buffer_pos & ring_buffer_mask] = src[i];
 		ring_buffer_pos++;
 	}


### PR DESCRIPTION
As reported by user `botOnFire` on Discord.

It is possible to do it with just one `for` loop before the `if` statement, but that way might be a teeny-tiny bit slower.