### PR TITLE
Add Godot constants to Mono project builds

### DIFF
--- a/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
@@ -186,7 +186,7 @@ namespace GodotSharpTools.Build
 
         private string BuildArguments(string loggerAssemblyPath, string loggerOutputDir, List<string> customProperties)
         {
-            string arguments = string.Format(@"""{0}"" /v:normal /t:Build ""/p:{1}"" ""/l:{2},{3};{4}""",
+            string arguments = string.Format(@"""{0}"" /v:normal /t:Rebuild ""/p:{1}"" ""/l:{2},{3};{4}""",
                 solution,
                 "Configuration=" + config,
                 typeof(GodotBuildLogger).FullName,
@@ -196,7 +196,7 @@ namespace GodotSharpTools.Build
 
             foreach (string customProperty in customProperties)
             {
-                arguments += " \"/p:" + customProperty + "\"";
+                arguments += " /p:" + customProperty;
             }
 
             return arguments;

--- a/modules/mono/editor/GodotSharpTools/Project/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotSharpTools/Project/ProjectGenerator.cs
@@ -80,7 +80,7 @@ namespace GodotSharpTools.Project
             toolsGroup.AddProperty("DebugSymbols", "true");
             toolsGroup.AddProperty("DebugType", "portable");
             toolsGroup.AddProperty("Optimize", "false");
-            toolsGroup.AddProperty("DefineConstants", "DEBUG;TOOLS;");
+            toolsGroup.AddProperty("DefineConstants", "$(GodotDefineConstants);GODOT;DEBUG;TOOLS;");
             toolsGroup.AddProperty("ErrorReport", "prompt");
             toolsGroup.AddProperty("WarningLevel", "4");
             toolsGroup.AddProperty("ConsolePause", "false");
@@ -161,7 +161,7 @@ namespace GodotSharpTools.Project
             debugGroup.AddProperty("DebugSymbols", "true");
             debugGroup.AddProperty("DebugType", "portable");
             debugGroup.AddProperty("Optimize", "false");
-            debugGroup.AddProperty("DefineConstants", "DEBUG;");
+            debugGroup.AddProperty("DefineConstants", "$(GodotDefineConstants);GODOT;DEBUG;");
             debugGroup.AddProperty("ErrorReport", "prompt");
             debugGroup.AddProperty("WarningLevel", "4");
             debugGroup.AddProperty("ConsolePause", "false");
@@ -170,6 +170,7 @@ namespace GodotSharpTools.Project
             releaseGroup.Condition = " '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ";
             releaseGroup.AddProperty("DebugType", "portable");
             releaseGroup.AddProperty("Optimize", "true");
+            releaseGroup.AddProperty("DefineConstants", "$(GodotDefineConstants);GODOT;");
             releaseGroup.AddProperty("ErrorReport", "prompt");
             releaseGroup.AddProperty("WarningLevel", "4");
             releaseGroup.AddProperty("ConsolePause", "false");

--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -30,6 +30,7 @@
 
 #include "godotsharp_builds.h"
 
+#include "core/os/os.h"
 #include "core/vector.h"
 #include "main/main.h"
 
@@ -351,7 +352,7 @@ bool GodotSharpBuilds::make_api_assembly(APIAssembly::Type p_api_type) {
 	return true;
 }
 
-bool GodotSharpBuilds::build_project_blocking(const String &p_config) {
+bool GodotSharpBuilds::build_project_blocking(const String &p_config, const Vector<String> &p_godot_defines) {
 
 	if (!FileAccess::exists(GodotSharpDirs::get_project_sln_path()))
 		return true; // No solution to build
@@ -366,6 +367,21 @@ bool GodotSharpBuilds::build_project_blocking(const String &p_config) {
 	pr.step("Building project solution", 0);
 
 	MonoBuildInfo build_info(GodotSharpDirs::get_project_sln_path(), p_config);
+
+	// Add Godot defines
+	String constants = "GodotDefineConstants=\"";
+
+	for (int i = 0; i < p_godot_defines.size(); i++) {
+		constants += "GODOT_" + p_godot_defines[i].to_upper().replace("-", "_").replace(" ", "_").replace(";", "_") + ";";
+	}
+
+#ifdef REAL_T_IS_DOUBLE
+	constants += "GODOT_REAL_T_IS_DOUBLE;";
+#endif
+
+	constants += "\"";
+	build_info.custom_props.push_back(constants);
+
 	if (!GodotSharpBuilds::get_singleton()->build(build_info)) {
 		GodotSharpBuilds::show_build_error_dialog("Failed to build project solution");
 		return false;
@@ -393,7 +409,10 @@ bool GodotSharpBuilds::editor_build_callback() {
 		ERR_FAIL_COND_V(copy_err != OK, false);
 	}
 
-	return build_project_blocking("Tools");
+	Vector<String> godot_defines;
+	godot_defines.push_back(OS::get_singleton()->get_name());
+	godot_defines.push_back(sizeof(void *) == 4 ? "32" : "64");
+	return build_project_blocking("Tools", godot_defines);
 }
 
 GodotSharpBuilds *GodotSharpBuilds::singleton = NULL;

--- a/modules/mono/editor/godotsharp_builds.h
+++ b/modules/mono/editor/godotsharp_builds.h
@@ -92,7 +92,7 @@ public:
 
 	static bool make_api_assembly(APIAssembly::Type p_api_type);
 
-	static bool build_project_blocking(const String &p_config);
+	static bool build_project_blocking(const String &p_config, const Vector<String> &p_godot_defines);
 
 	static bool editor_build_callback();
 

--- a/modules/mono/editor/godotsharp_export.cpp
+++ b/modules/mono/editor/godotsharp_export.cpp
@@ -94,7 +94,12 @@ void GodotSharpExport::_export_begin(const Set<String> &p_features, bool p_debug
 
 		ERR_FAIL_COND(!_add_file(scripts_metadata_path, scripts_metadata_path));
 
-		ERR_FAIL_COND(!GodotSharpBuilds::build_project_blocking(build_config));
+		// Turn export features into defines
+		Vector<String> godot_defines;
+		for (Set<String>::Element *E = p_features.front(); E; E = E->next()) {
+			godot_defines.push_back(E->get());
+		}
+		ERR_FAIL_COND(!GodotSharpBuilds::build_project_blocking(build_config, godot_defines));
 
 		// Add dependency assemblies
 

--- a/modules/mono/editor/mono_bottom_panel.cpp
+++ b/modules/mono/editor/mono_bottom_panel.cpp
@@ -175,7 +175,10 @@ void MonoBottomPanel::_build_project_pressed() {
 		ERR_FAIL_COND(copy_err != OK);
 	}
 
-	bool build_success = GodotSharpBuilds::get_singleton()->build_project_blocking("Tools");
+	Vector<String> godot_defines;
+	godot_defines.push_back(OS::get_singleton()->get_name());
+	godot_defines.push_back((sizeof(void *) == 4 ? "32" : "64"));
+	bool build_success = GodotSharpBuilds::get_singleton()->build_project_blocking("Tools", godot_defines);
 
 	if (build_success) {
 		// Notify running game for hot-reload


### PR DESCRIPTION
This adds constants to projects build via Godot Mono which allows project to conditionally react to different operating systems and 32/64 Bit architecture. Additionally .NET libraries could support multiple engines like Unity and Godot at the same time when compiled from Godot and reacting to definitions.

**How it works**

`GODOT` - Always set (is set in the actual csproj file)

`GODOT_REAL_T_IS_DOUBLE` - Set, if Godot was compiled with `REAL_T_IS_DOUBLE` being defined

When building from the edito, the OS defines are created using OS::get_singleton()->get_name().to_upper() so you can find all possible OS defines on the [official documentation](https://docs.godotengine.org/en/latest/classes/class_os.html#class-os-method-get-name):
`GODOT_WINDOWS` - Godot running on Windows
`GODOT_X11` - Godot running on X11 compatible system
`GODOT_OSX` - Godot running on OSX
etc.

The bitness will be defined as `GODOT_64` for 64 Bit and `GODOT_32` for 32 Bit.

When exporting the entries in the "Feature List" shown in the export dialog will be turned into defines. For example: "Android" will turn into "GODOT_ANDROID" and "arm64-v8a" will turn into "GODOT_ARM64_V8A".

In C# you can write conditional code like
```C#
using Godot;
using System;

public class Main : Node2D
{
    public override void _Ready()
    {
		GD.Print("Startup!");
		
		#if (DEBUG)
			GD.Print("DEBUG is defined!");
		#endif 
		
		#if (TOOLS)
			GD.Print("TOOLS is defined!");
		#endif 
		
        	#if (GODOT)
			GD.Print("GODOT is defined!");
		#endif 
		 
		#if (GODOT_WINDOWS)
			GD.Print("GODOT is running on Windows");
		#endif
		
		#if (GODOT_64)
			GD.Print("GODOT is 64Bit");
		#endif
    }
}

```

**Important**
1. Unfortunately defines that are provided to MSBuild via command line will only be used if the project is being rebuild so the build system has been changed to do rebuilds instead of builds. This increases build time a bit...
2. In order for the defines to show up in the project, existing projects will either have to have their csproj files being recreated or one has to updated them manually. For example:
```XML
<DefineConstants>DEBUG;</DefineConstants>
```
has to be changed into
```XML
<DefineConstants>$(GodotDefineConstants);GODOT;DEBUG;</DefineConstants>
```

Closes #28517
Closes #27227