### PR TITLE
Script Text Editor: respect Move Down and Move Up shortcuts on macOS

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -587,6 +587,26 @@ FindReplaceBar::FindReplaceBar() {
 
 /*** CODE EDITOR ****/
 
+// This function should be used to handle shortcuts that could otherwise
+// be handled too late if they weren't handled here.
+void CodeTextEditor::_input(const Ref<InputEvent> &event) {
+
+	const Ref<InputEventKey> key_event = event;
+	if (!key_event.is_valid() || !key_event->is_pressed())
+		return;
+
+	if (ED_IS_SHORTCUT("script_text_editor/move_up", key_event)) {
+		move_lines_up();
+		accept_event();
+		return;
+	}
+	if (ED_IS_SHORTCUT("script_text_editor/move_down", key_event)) {
+		move_lines_down();
+		accept_event();
+		return;
+	}
+}
+
 void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
@@ -1344,6 +1364,9 @@ void CodeTextEditor::_notification(int p_what) {
 			warning_button->set_icon(get_icon("NodeWarning", "EditorIcons"));
 			add_constant_override("separation", 4 * EDSCALE);
 		} break;
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			set_process_input(is_visible_in_tree());
+		} break;
 		default:
 			break;
 	}
@@ -1359,6 +1382,7 @@ void CodeTextEditor::set_warning_nb(int p_warning_nb) {
 
 void CodeTextEditor::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("_input"), &CodeTextEditor::_input);
 	ClassDB::bind_method("_text_editor_gui_input", &CodeTextEditor::_text_editor_gui_input);
 	ClassDB::bind_method("_line_col_changed", &CodeTextEditor::_line_col_changed);
 	ClassDB::bind_method("_text_changed", &CodeTextEditor::_text_changed);

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -165,6 +165,7 @@ class CodeTextEditor : public VBoxContainer {
 	void _font_resize_timeout();
 	bool _add_font_size(int p_delta);
 
+	void _input(const Ref<InputEvent> &event);
 	void _text_editor_gui_input(const Ref<InputEvent> &p_event);
 	void _zoom_in();
 	void _zoom_out();


### PR DESCRIPTION
Handle shortcuts in CodeTextEditor::_input() so that we get them before its
text_editor's TextEdit::_gui_input() function does. If we don't, that
function will execute the following code:

				if (k->get_shift()) {
					_pre_shift_selection();
				}

    #ifdef APPLE_STYLE_KEYS
				if (k->get_command()) {

					cursor_set_line(0);
				} else
    #endif

So using Command+Shift+Up for the Move Up shortcut would just result in
selecting all text to the beginning of the document, rather than moving the
current line up.

Fixes #28059.