### PR TITLE
Tweak the default low-processor usage mode to be 144 Hz-friendly

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1027,7 +1027,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	OS::get_singleton()->set_low_processor_usage_mode(GLOBAL_DEF("application/run/low_processor_mode", false));
-	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(GLOBAL_DEF("application/run/low_processor_mode_sleep_usec", 8000));
+	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(GLOBAL_DEF("application/run/low_processor_mode_sleep_usec", 6900)); // Roughly 144 FPS
 	ProjectSettings::get_singleton()->set_custom_property_info("application/run/low_processor_mode_sleep_usec", PropertyInfo(Variant::INT, "application/run/low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "0,33200,1,or_greater")); // No negative numbers
 
 	Engine::get_singleton()->set_frame_delay(frame_delay);
@@ -1949,7 +1949,7 @@ bool Main::iteration() {
 		return exit;
 
 	if (OS::get_singleton()->is_in_low_processor_usage_mode() || !OS::get_singleton()->can_draw())
-		OS::get_singleton()->delay_usec(OS::get_singleton()->get_low_processor_usage_mode_sleep_usec()); //apply some delay to force idle time (results in about 60 FPS max)
+		OS::get_singleton()->delay_usec(OS::get_singleton()->get_low_processor_usage_mode_sleep_usec()); //apply some delay to force idle time
 	else {
 		uint32_t frame_delay = Engine::get_singleton()->get_frame_delay();
 		if (frame_delay)


### PR DESCRIPTION
On high-refresh rate displays, the old default value (8000) effectively limited redrawing to 125 FPS, no matter whether V-Sync was enabled or not. The new value limits redrawing to a value slightly above 144 FPS, decreasing input lag and making the editor feel smoother when using freelook.

60 Hz displays aren't affected by this change when V-Sync is enabled, since V-Sync will take care of limiting redrawing to 60 FPS.

Also, I think it'd make sense to make this setting configurable for the editor, so that one can set a low FPS limit to save battery when using a laptop.

Note that this doesn't fully address https://github.com/godotengine/godot/issues/11030, but it helps make the issue less visible on 144 Hz displays (or 60 Hz displays with V-Sync disabled).