### PR TITLE
Keep search and replace texts when changing script

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -556,8 +556,17 @@ void FindReplaceBar::set_error(const String &p_label) {
 void FindReplaceBar::set_text_edit(TextEdit *p_text_edit) {
 
 	results_count = -1;
+	if (text_edit) {
+		text_edit->disconnect("text_changed", this, "_editor_text_changed");
+		text_edit->set_search_text("");
+	}
+
 	text_edit = p_text_edit;
 	text_edit->connect("text_changed", this, "_editor_text_changed");
+
+	if (is_visible()) {
+		text_edit->set_search_text(get_search_text());
+	}
 }
 
 void FindReplaceBar::_bind_methods() {
@@ -1441,6 +1450,20 @@ void CodeTextEditor::goto_error() {
 		text_editor->cursor_set_column(error_column);
 		text_editor->center_viewport_to_cursor();
 	}
+}
+
+void CodeTextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {
+	if (find_replace_bar && find_replace_bar != p_bar) {
+		//this method is intended to be used for shared find/replace bars, so the original one is removed
+		remove_child(find_replace_bar);
+		find_replace_bar->queue_delete();
+	}
+
+	find_replace_bar = p_bar;
+	if (p_bar->get_parent())
+		p_bar->get_parent()->remove_child(p_bar);
+	add_child_below_node(text_editor, p_bar);
+	p_bar->set_text_edit(text_editor);
 }
 
 void CodeTextEditor::_update_font() {

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -527,6 +527,12 @@ String FindReplaceBar::get_replace_text() const {
 	return replace_text->get_text();
 }
 
+void FindReplaceBar::copy_texts_from(FindReplaceBar *p_from) {
+
+	search_text->set_text(p_from->search_text->get_text());
+	replace_text->set_text(p_from->replace_text->get_text());
+}
+
 bool FindReplaceBar::is_case_sensitive() const {
 
 	return case_sensitive->is_pressed();

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -241,6 +241,7 @@ public:
 	void update_line_and_column() { _line_col_changed(); }
 	TextEdit *get_text_edit() { return text_editor; }
 	FindReplaceBar *get_find_replace_bar() { return find_replace_bar; }
+	void set_find_replace_bar(FindReplaceBar *p_bar);
 	virtual void apply_code() {}
 	void goto_error();
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -118,6 +118,8 @@ public:
 	String get_search_text() const;
 	String get_replace_text() const;
 
+	void copy_texts_from(FindReplaceBar *p_from);
+
 	bool is_case_sensitive() const;
 	bool is_whole_words() const;
 	bool is_selection_only() const;

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -118,8 +118,6 @@ public:
 	String get_search_text() const;
 	String get_replace_text() const;
 
-	void copy_texts_from(FindReplaceBar *p_from);
-
 	bool is_case_sensitive() const;
 	bool is_whole_words() const;
 	bool is_selection_only() const;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -430,10 +430,18 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 	history.push_back(sh);
 	history_pos++;
 
+	c = tab_container->get_current_tab_control();
+	if (Object::cast_to<ScriptTextEditor>(c)) {
+		last_editor_find_replace = Object::cast_to<ScriptTextEditor>(c)->get_find_replace_bar();
+	}
+
 	tab_container->set_current_tab(p_idx);
 
 	c = tab_container->get_current_tab_control();
 
+	if (Object::cast_to<ScriptTextEditor>(c) && last_editor_find_replace) {
+		Object::cast_to<ScriptTextEditor>(c)->get_find_replace_bar()->copy_texts_from(last_editor_find_replace);
+	}
 	if (Object::cast_to<ScriptEditorBase>(c)) {
 
 		script_name_label->set_text(Object::cast_to<ScriptEditorBase>(c)->get_name());
@@ -3132,6 +3140,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	members_overview_enabled = EditorSettings::get_singleton()->get("text_editor/open_scripts/show_members_overview");
 	help_overview_enabled = EditorSettings::get_singleton()->get("text_editor/help/show_help_index");
 	editor = p_editor;
+	last_editor_find_replace = NULL;
 
 	VBoxContainer *main_container = memnew(VBoxContainer);
 	add_child(main_container);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -430,18 +430,10 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 	history.push_back(sh);
 	history_pos++;
 
-	c = tab_container->get_current_tab_control();
-	if (Object::cast_to<ScriptTextEditor>(c)) {
-		last_editor_find_replace = Object::cast_to<ScriptTextEditor>(c)->get_find_replace_bar();
-	}
-
 	tab_container->set_current_tab(p_idx);
 
 	c = tab_container->get_current_tab_control();
 
-	if (Object::cast_to<ScriptTextEditor>(c) && last_editor_find_replace) {
-		Object::cast_to<ScriptTextEditor>(c)->get_find_replace_bar()->copy_texts_from(last_editor_find_replace);
-	}
 	if (Object::cast_to<ScriptEditorBase>(c)) {
 
 		script_name_label->set_text(Object::cast_to<ScriptEditorBase>(c)->get_name());
@@ -1601,6 +1593,12 @@ void ScriptEditor::ensure_select_current() {
 
 			if (!grab_focus_block && is_visible_in_tree())
 				se->ensure_focus();
+
+			if (Object::cast_to<ScriptTextEditor>(se)) { //sadly this is necessary, because code_editor is not a property of ScriptEditorBase
+				Object::cast_to<ScriptTextEditor>(se)->get_code_editor()->set_find_replace_bar(shared_find_replace_bar);
+			} else if (Object::cast_to<TextEditor>(se)) {
+				Object::cast_to<TextEditor>(se)->get_code_editor()->set_find_replace_bar(shared_find_replace_bar);
+			}
 		}
 	}
 
@@ -3140,7 +3138,10 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	members_overview_enabled = EditorSettings::get_singleton()->get("text_editor/open_scripts/show_members_overview");
 	help_overview_enabled = EditorSettings::get_singleton()->get("text_editor/help/show_help_index");
 	editor = p_editor;
-	last_editor_find_replace = NULL;
+
+	shared_find_replace_bar = memnew(FindReplaceBar);
+	shared_find_replace_bar->set_h_size_flags(SIZE_EXPAND_FILL);
+	shared_find_replace_bar->hide();
 
 	VBoxContainer *main_container = memnew(VBoxContainer);
 	add_child(main_container);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1594,10 +1594,10 @@ void ScriptEditor::ensure_select_current() {
 			if (!grab_focus_block && is_visible_in_tree())
 				se->ensure_focus();
 
-			if (Object::cast_to<ScriptTextEditor>(se)) { //sadly this is necessary, because code_editor is not a property of ScriptEditorBase
-				Object::cast_to<ScriptTextEditor>(se)->get_code_editor()->set_find_replace_bar(shared_find_replace_bar);
+			if (Object::cast_to<ScriptTextEditor>(se)) { //Sadly this is necessary, because code_editor is not a property of ScriptEditorBase.
+				Object::cast_to<ScriptTextEditor>(se)->set_find_replace_bar(shared_find_replace_bar);
 			} else if (Object::cast_to<TextEditor>(se)) {
-				Object::cast_to<TextEditor>(se)->get_code_editor()->set_find_replace_bar(shared_find_replace_bar);
+				Object::cast_to<TextEditor>(se)->set_find_replace_bar(shared_find_replace_bar);
 			}
 		}
 	}

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -233,6 +233,7 @@ class ScriptEditor : public PanelContainer {
 	ScriptCreateDialog *script_create_dialog;
 	ScriptEditorDebugger *debugger;
 	ToolButton *scripts_visible;
+	FindReplaceBar *last_editor_find_replace;
 
 	String current_theme;
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -233,7 +233,7 @@ class ScriptEditor : public PanelContainer {
 	ScriptCreateDialog *script_create_dialog;
 	ScriptEditorDebugger *debugger;
 	ToolButton *scripts_visible;
-	FindReplaceBar *last_editor_find_replace;
+	FindReplaceBar *shared_find_replace_bar;
 
 	String current_theme;
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -992,11 +992,6 @@ void ScriptTextEditor::_update_connected_methods() {
 	}
 }
 
-FindReplaceBar *ScriptTextEditor::get_find_replace_bar() {
-
-	return code_editor->get_find_replace_bar();
-}
-
 void ScriptTextEditor::_lookup_connections(int p_row, String p_method) {
 	Node *base = get_tree()->get_edited_scene_root();
 	if (!base) {
@@ -1336,6 +1331,10 @@ void ScriptTextEditor::_edit_option_toggle_inline_comment() {
 	}
 
 	code_editor->toggle_inline_comment(delimiter);
+}
+
+CodeTextEditor *ScriptTextEditor::get_code_editor() const {
+	return code_editor;
 }
 
 void ScriptTextEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1333,8 +1333,8 @@ void ScriptTextEditor::_edit_option_toggle_inline_comment() {
 	code_editor->toggle_inline_comment(delimiter);
 }
 
-CodeTextEditor *ScriptTextEditor::get_code_editor() const {
-	return code_editor;
+void ScriptTextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {
+	code_editor->set_find_replace_bar(p_bar);
 }
 
 void ScriptTextEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -992,6 +992,11 @@ void ScriptTextEditor::_update_connected_methods() {
 	}
 }
 
+FindReplaceBar *ScriptTextEditor::get_find_replace_bar() {
+
+	return code_editor->get_find_replace_bar();
+}
+
 void ScriptTextEditor::_lookup_connections(int p_row, String p_method) {
 	Node *base = get_tree()->get_edited_scene_root();
 	if (!base) {

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -186,7 +186,7 @@ protected:
 
 public:
 	void _update_connected_methods();
-	CodeTextEditor *get_code_editor() const;
+	void set_find_replace_bar(FindReplaceBar *p_bar);
 
 	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
 	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -186,7 +186,7 @@ protected:
 
 public:
 	void _update_connected_methods();
-	FindReplaceBar *get_find_replace_bar();
+	CodeTextEditor *get_code_editor() const;
 
 	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
 	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -186,6 +186,7 @@ protected:
 
 public:
 	void _update_connected_methods();
+	FindReplaceBar *get_find_replace_bar();
 
 	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
 	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -145,8 +145,8 @@ void TextEditor::_load_theme_settings() {
 	colors_cache.string_color = string_color;
 }
 
-CodeTextEditor *TextEditor::get_code_editor() const {
-	return code_editor;
+void TextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {
+	code_editor->set_find_replace_bar(p_bar);
 }
 
 String TextEditor::get_name() {

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -145,6 +145,10 @@ void TextEditor::_load_theme_settings() {
 	colors_cache.string_color = string_color;
 }
 
+CodeTextEditor *TextEditor::get_code_editor() const {
+	return code_editor;
+}
+
 String TextEditor::get_name() {
 	String name;
 

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -116,7 +116,7 @@ protected:
 	void _bookmark_item_pressed(int p_idx);
 
 public:
-	CodeTextEditor *get_code_editor() const;
+	void set_find_replace_bar(FindReplaceBar *p_bar);
 
 	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
 	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -116,6 +116,8 @@ protected:
 	void _bookmark_item_pressed(int p_idx);
 
 public:
+	CodeTextEditor *get_code_editor() const;
+
 	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
 	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);
 


### PR DESCRIPTION
Fixes #27003

For some reason, `popup_replace()` was clearing the replace text, so I had to remove this behavior. Otherwise the replace text was lost when switching to script without replace open.