### PR TITLE
Change rules of indenting for spaces

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -430,6 +430,9 @@ private:
 	void _confirm_completion();
 	void _update_completion_candidates();
 
+	int _calculate_spaces_till_next_left_indent(int column);
+	int _calculate_spaces_till_next_right_indent(int column);
+
 protected:
 	virtual String get_tooltip(const Point2 &p_pos) const;
 


### PR DESCRIPTION
Hello,

even though #28724 did not find much traction i was toying around with editor code to the point when I decided it's worthwhile to create draft PR of this improvement if not for merge then for future reference. This PR fixes multiple issues with spaces indentation and brings more consistency into this mechanic. I'd like to point out that those 'small issues' are really big annoyance in my everyday work with godot - that's why I decided to take time to fix them.

### **FEATURES AND FIXES**
When talking about spaces indenting in Godot editor there are five main cases to consider - clicking backspace without selection, tab and shift+tab without selection and tab and shift+tab with selection. Each of this cases has unique (and somewhat duplicated) code that provides indenting mechanism. As you will see I extracted some common methods but reality is that what we need is only two functions that handle indenting and unindenting - that is however, distant future (that I will be more than happy to work on if this subject gains some traction and support).

At this point it is worth noting that even though I carried out pretty careful testing efforts this code is pretty complicated and it has some regression potential.

**All below examples use space indentation with 4 spaces indent size, my work did not concern any of tabs issues. All screenshots of old behavior come from Godot 3.1 (I did not notice any changes to this on master)**

### Backspace at selection
In Godot there is feature that if you hit backspace (with no selection) and  there is only indentation before cursor the text gets unindented by configured indentation_size. This feature is standard in any IDE but Godot's implementation had two issues:

- If cursor column is less then indentation_size feature does not work and spaces are removed one by one
- Number of removed spaces was always equal to indentation_size - this means that if you hit accidental space you cant delete it easily with backspace because it will move you back to one-off position of previous indentation level. To visualize see below gif where I only click backspace (notice the indentation level is off by two and it remains so until all spaces get delete from the line).
![backspace_old](https://user-images.githubusercontent.com/9964886/57538481-ca46fc00-7348-11e9-8a04-e6d086cd62d2.gif)

I fixed it - when unindenting code first deletes spaces up until closest full indentation level and then removes whole levels. Feature works too if cursor column is smaller than indentation_size. Notice how at first two spaces are removed and then at next backspace click whole indentation level disappears.

![backspace_new](https://user-images.githubusercontent.com/9964886/57538666-33c70a80-7349-11e9-8416-e6b8d7802fd7.gif)

### Unindenting with shift+tab
It is very similar as in 'Backspace at selection'. Code was always removing number of spaces equal to indentation_size. Example below - as you can see line  22 is slightly off (two spaces more than correct indentation level) and shift tabbing does not bring it to round indentation level - it just removes 4 spaces in this case.
![shift_tab_no_selection_old](https://user-images.githubusercontent.com/9964886/57538817-7ab50000-7349-11e9-8c28-0aa792da2ea5.gif)

I fixed it! Just as before - first we remove enough spaces so that cursor ends up at full indentation level and then we remove whole level as before:

![shift_tab_no_selection_new](https://user-images.githubusercontent.com/9964886/57539055-ee570d00-7349-11e9-9913-c8f6dcc260a1.gif)

### Indenting with tab

Similar issue - tabbing was always adding four spaces to the line. Usually when indenting you want to move stuff at cursor to new indentation level. Old mechanic:
![tab_no_selection_old](https://user-images.githubusercontent.com/9964886/57539244-61608380-734a-11e9-941d-b8aafa327f67.gif)

My 'improvement' (not total fix since it still depends on cursor position in relation to the closest indent level - maybe we should look at position of first non-whitespace character?). Please notice how we at first 'even up' word after cursor to nearest selection and only at next tabs we move by whole indentation level:
![tab_no_selection_new](https://user-images.githubusercontent.com/9964886/57539430-c9af6500-734a-11e9-9cb2-31241d737e2f.gif)

### Indenting selection with tab and unindenting with shift+tab

Now it is where fun begins. Select something (can be multi-line) and hit that tab. I was actually unable to find similar feature in any of IDEs I'm using (QT-Creator, Intellij IDEA, Sublime Text) since there tab or untab when having selection would delete it but Godot attempts to indent all lines with selection. I kept this feature and improved it a bit. Here are the issues with current implementation:

- Selection changes weirdly when using this mechanic.
- Cursor moves weirdly (it is because correct cursor offset was only supported for tabs!)
- We always only insert indent_size number of spaces at the beginning of the line not caring for correct indentation level.
 
Preview of old mechanic:
![tab_selection_multiline_old](https://user-images.githubusercontent.com/9964886/57539881-bd77d780-734b-11e9-9bda-87a0c772f43a.gif)
![tab_selection_single_line_old](https://user-images.githubusercontent.com/9964886/57540068-1ba4ba80-734c-11e9-9420-58b434cf79dc.gif)

Similar stuff was going on for unindenting selection, Not aligning to closest indentation level, moving selection and cursor. See (the cursor moves is me just holding shift+tab!):

![shift_tab_selection_single_line](https://user-images.githubusercontent.com/9964886/57540199-6f170880-734c-11e9-945a-9709e66d78a8.gif)
![shift_tab_selection_multiline_old](https://user-images.githubusercontent.com/9964886/57540205-72aa8f80-734c-11e9-8345-a3fac6f859c5.gif)

I fixed cursor and selection changes issue (it keeps on same selection all the time - I thought it is ok) and also move text at first to closest full indentation level at first. My version with single line selection:

![indenting_selection_single_line](https://user-images.githubusercontent.com/9964886/57540121-3ecf6a00-734c-11e9-92ac-4264f0ce5805.gif)

And with multiline:

![indenting_multiline_new](https://user-images.githubusercontent.com/9964886/57540359-d7fe8080-734c-11e9-87e1-2d6c865adbeb.gif)

To be honest this part of the feature was most difficult to implement as it is not so obvious how it should work.


I think adding or improving this PR would be huge QOL improvement for Godot which would bring its indentation mechanics if not on par then close to other modern IDEs. 

Thanks for reading. Have a nice day.:)




