### PR TITLE
 Keep GDScript functions in stack while yielding

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -622,8 +622,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			d["frame"] = i;
 			s->set_metadata(0, d);
 
-			//String line = itos(i)+" - "+String(d["file"])+":"+itos(d["line"])+" - at func: "+d["function"];
-			String line = itos(i) + " - " + String(d["file"]) + ":" + itos(d["line"]);
+			String line = itos(i) + " - " + String(d["file"]) + ":" + itos(d["line"]) + " - at function: " + d["function"];
 			s->set_text(0, line);
 
 			if (i == 0)

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1583,7 +1583,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		GDScriptLanguage::get_singleton()->script_frame_time += time_taken - function_call_time;
 	}
 
-	if (ScriptDebugger::get_singleton())
+	if (ScriptDebugger::get_singleton() && !p_state)
 		GDScriptLanguage::get_singleton()->exit_function();
 #endif
 
@@ -1885,6 +1885,11 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 			emit_signal("completed", ret);
 		}
 	}
+
+#ifdef DEBUG_ENABLED
+	if (ScriptDebugger::get_singleton())
+		GDScriptLanguage::get_singleton()->exit_function();
+#endif
 
 	return ret;
 }


### PR DESCRIPTION
This prevents GDScript functions from leaving the stack too soon when they are resuming from yield, allowing the ones expecting it to finish to know the caller.

Helps debugging cases when you use: `yield(function_which_yields(), "completed")` since now it shows the call that resumed that function.

Also show the function names in the debugger stack, which helps identify the stack (not sure why that was commented out, it's been like this since the first commit).