### PR TITLE
[WIP] New Subspace2D node and Space2D resource

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -187,7 +187,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 
 			//check if any area is diverting sound into a bus
 
-			Physics2DDirectSpaceState *space_state = Physics2DServer::get_singleton()->space_get_direct_state(world_2d->get_space());
+			Physics2DDirectSpaceState *space_state = Physics2DServer::get_singleton()->space_get_direct_state(get_physics_space());
 
 			Physics2DDirectSpaceState::ShapeResult sr[MAX_INTERSECT_AREAS];
 

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -32,6 +32,7 @@
 #include "core/message_queue.h"
 #include "core/method_bind_ext.gen.inc"
 #include "core/os/input.h"
+#include "scene/2d/subspace_2d.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/font.h"
@@ -1009,6 +1010,33 @@ Ref<World2D> CanvasItem::get_world_2d() const {
 	}
 }
 
+RID CanvasItem::get_physics_space() const {
+	ERR_FAIL_COND_V(!is_inside_tree(), RID());
+
+	Node *n = Object::cast_to<Node>(const_cast<CanvasItem *>(this));
+
+	Subspace2D *subspace = Object::cast_to<Subspace2D>(n);
+	if (subspace)
+		return subspace->get_space_2d()->get_rid();
+
+	Viewport *viewport = Object::cast_to<Viewport>(n);
+	if (viewport)
+		return viewport->find_world_2d()->get_space();
+
+	while (Object::cast_to<Node>(n->get_parent())) {
+		n = Object::cast_to<Node>(n->get_parent());
+
+		subspace = Object::cast_to<Subspace2D>(n);
+		if (subspace)
+			return subspace->get_space_2d()->get_rid();
+
+		viewport = Object::cast_to<Viewport>(n);
+		if (viewport)
+			return viewport->find_world_2d()->get_space();
+	}
+	return RID();
+}
+
 RID CanvasItem::get_viewport_rid() const {
 
 	ERR_FAIL_COND_V(!is_inside_tree(), RID());
@@ -1183,6 +1211,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_global_mouse_position"), &CanvasItem::get_global_mouse_position);
 	ClassDB::bind_method(D_METHOD("get_canvas"), &CanvasItem::get_canvas);
 	ClassDB::bind_method(D_METHOD("get_world_2d"), &CanvasItem::get_world_2d);
+	ClassDB::bind_method(D_METHOD("get_physics_space"), &CanvasItem::get_physics_space);
 	//ClassDB::bind_method(D_METHOD("get_viewport"),&CanvasItem::get_viewport);
 
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &CanvasItem::set_material);

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -358,6 +358,7 @@ public:
 	RID get_canvas() const;
 	ObjectID get_canvas_layer_instance_id() const;
 	Ref<World2D> get_world_2d() const;
+	RID get_physics_space() const;
 
 	virtual void set_material(const Ref<Material> &p_material);
 	Ref<Material> get_material() const;

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -48,7 +48,7 @@ void CollisionObject2D::_notification(int p_what) {
 
 			last_transform = global_transform;
 
-			RID space = get_world_2d()->get_space();
+			RID space = get_physics_space();
 			if (area) {
 				Physics2DServer::get_singleton()->area_set_space(rid, space);
 			} else

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -198,7 +198,7 @@ void RayCast2D::_update_raycast_state() {
 	Ref<World2D> w2d = get_world_2d();
 	ERR_FAIL_COND(w2d.is_null());
 
-	Physics2DDirectSpaceState *dss = Physics2DServer::get_singleton()->space_get_direct_state(w2d->get_space());
+	Physics2DDirectSpaceState *dss = Physics2DServer::get_singleton()->space_get_direct_state(get_physics_space());
 	ERR_FAIL_COND(!dss);
 
 	Transform2D gt = get_global_transform();

--- a/scene/2d/subspace_2d.cpp
+++ b/scene/2d/subspace_2d.cpp
@@ -1,0 +1,31 @@
+#include "subspace_2d.h"
+
+void Subspace2D::set_space_2d(const Ref<Space2D> &p_space_2d) {
+	if (space_2d == p_space_2d)
+		return;
+
+	if (p_space_2d.is_valid()) {
+		space_2d = p_space_2d;
+	} else {
+		WARN_PRINT("Invalid Space2D");
+		space_2d = Ref<Space2D>(memnew(Space2D));
+	}
+}
+
+Ref<Space2D> Subspace2D::get_space_2d() const {
+	return space_2d;
+}
+
+void Subspace2D::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("set_space_2d", "space_2d"), &Subspace2D::set_space_2d);
+	ClassDB::bind_method(D_METHOD("get_space_2d"), &Subspace2D::get_space_2d);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "space_2d", PROPERTY_HINT_RESOURCE_TYPE, "Space2D"), "set_space_2d", "get_space_2d");
+}
+
+Subspace2D::Subspace2D() {
+	space_2d = Ref<Space2D>(memnew(Space2D));
+}
+
+Subspace2D::~Subspace2D() {}

--- a/scene/2d/subspace_2d.h
+++ b/scene/2d/subspace_2d.h
@@ -1,0 +1,25 @@
+#ifndef SUBSPACE_2D_H
+#define SUBSPACE_2D_H
+
+#include "scene/2d/node_2d.h"
+#include "scene/resources/space_2d.h"
+
+class Subspace2D : public Node2D {
+
+	GDCLASS(Subspace2D, Node2D)
+
+private:
+	Ref<Space2D> space_2d;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_space_2d(const Ref<Space2D> &p_space_2d);
+	Ref<Space2D> get_space_2d() const;
+
+	Subspace2D();
+	~Subspace2D();
+};
+
+#endif // SUBSPACE_2D_H

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -63,7 +63,7 @@ void TileMap::_notification(int p_what) {
 			pending_update = true;
 			_recreate_quadrants();
 			update_dirty_quadrants();
-			RID space = get_world_2d()->get_space();
+			RID space = get_physics_space();
 			_update_quadrant_transform();
 			_update_quadrant_space(space);
 
@@ -685,7 +685,7 @@ Map<TileMap::PosKey, TileMap::Quadrant>::Element *TileMap::_create_quadrant(cons
 
 	if (is_inside_tree()) {
 		xform = get_global_transform() * xform;
-		RID space = get_world_2d()->get_space();
+		RID space = get_physics_space();
 		Physics2DServer::get_singleton()->body_set_space(q.body, space);
 	}
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -60,6 +60,7 @@
 #include "scene/2d/remote_transform_2d.h"
 #include "scene/2d/skeleton_2d.h"
 #include "scene/2d/sprite.h"
+#include "scene/2d/subspace_2d.h"
 #include "scene/2d/tile_map.h"
 #include "scene/2d/touch_screen_button.h"
 #include "scene/2d/visibility_notifier_2d.h"
@@ -156,6 +157,7 @@
 #include "scene/resources/resource_format_text.h"
 #include "scene/resources/segment_shape_2d.h"
 #include "scene/resources/sky.h"
+#include "scene/resources/space_2d.h"
 #include "scene/resources/sphere_shape.h"
 #include "scene/resources/surface_tool.h"
 #include "scene/resources/text_file.h"
@@ -547,6 +549,7 @@ void register_scene_types() {
 	ClassDB::register_class<KinematicBody2D>();
 	ClassDB::register_class<KinematicCollision2D>();
 	ClassDB::register_class<Area2D>();
+	ClassDB::register_class<Subspace2D>();
 	ClassDB::register_class<CollisionShape2D>();
 	ClassDB::register_class<CollisionPolygon2D>();
 	ClassDB::register_class<RayCast2D>();
@@ -628,6 +631,7 @@ void register_scene_types() {
 	ClassDB::register_class<World>();
 	ClassDB::register_class<Environment>();
 	ClassDB::register_class<World2D>();
+	ClassDB::register_class<Space2D>();
 	ClassDB::register_virtual_class<Texture>();
 	ClassDB::register_virtual_class<Sky>();
 	ClassDB::register_class<PanoramaSky>();

--- a/scene/resources/space_2d.cpp
+++ b/scene/resources/space_2d.cpp
@@ -46,18 +46,80 @@ bool Space2D::is_active() const {
 	return active;
 }
 
+void Space2D::set_gravity(real_t p_gravity) {
+
+	gravity = p_gravity;
+	Physics2DServer::get_singleton()->area_set_param(get_rid(), Physics2DServer::AREA_PARAM_GRAVITY, p_gravity);
+}
+real_t Space2D::get_gravity() const {
+
+	return gravity;
+}
+
+void Space2D::set_gravity_vector(const Vector2 &p_vec) {
+
+	gravity_vec = p_vec;
+	Physics2DServer::get_singleton()->area_set_param(get_rid(), Physics2DServer::AREA_PARAM_GRAVITY_VECTOR, p_vec);
+}
+Vector2 Space2D::get_gravity_vector() const {
+
+	return gravity_vec;
+}
+
+void Space2D::set_linear_damp(real_t p_linear_damp) {
+
+	linear_damp = p_linear_damp;
+	Physics2DServer::get_singleton()->area_set_param(get_rid(), Physics2DServer::AREA_PARAM_LINEAR_DAMP, p_linear_damp);
+}
+real_t Space2D::get_linear_damp() const {
+
+	return linear_damp;
+}
+
+void Space2D::set_angular_damp(real_t p_angular_damp) {
+
+	angular_damp = p_angular_damp;
+	Physics2DServer::get_singleton()->area_set_param(get_rid(), Physics2DServer::AREA_PARAM_ANGULAR_DAMP, p_angular_damp);
+}
+
+real_t Space2D::get_angular_damp() const {
+
+	return angular_damp;
+}
+
 void Space2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &Space2D::set_active);
 	ClassDB::bind_method(D_METHOD("is_active"), &Space2D::is_active);
 
+	ClassDB::bind_method(D_METHOD("set_gravity", "gravity"), &Space2D::set_gravity);
+	ClassDB::bind_method(D_METHOD("get_gravity"), &Space2D::get_gravity);
+
+	ClassDB::bind_method(D_METHOD("set_gravity_vector", "vector"), &Space2D::set_gravity_vector);
+	ClassDB::bind_method(D_METHOD("get_gravity_vector"), &Space2D::get_gravity_vector);
+
+	ClassDB::bind_method(D_METHOD("set_linear_damp", "linear_damp"), &Space2D::set_linear_damp);
+	ClassDB::bind_method(D_METHOD("get_linear_damp"), &Space2D::get_linear_damp);
+
+	ClassDB::bind_method(D_METHOD("set_angular_damp", "angular_damp"), &Space2D::set_angular_damp);
+	ClassDB::bind_method(D_METHOD("get_angular_damp"), &Space2D::get_angular_damp);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "is_active");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "gravity", PROPERTY_HINT_RANGE, "-1024,1024,0.001"), "set_gravity", "get_gravity");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "gravity_vec"), "set_gravity_vector", "get_gravity_vector");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "linear_damp", PROPERTY_HINT_RANGE, "0,100,0.01,or_greater"), "set_linear_damp", "get_linear_damp");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "angular_damp", PROPERTY_HINT_RANGE, "0,100,0.01,or_greater"), "set_angular_damp", "get_angular_damp");
 }
 
 Space2D::Space2D() {
 
-	active = false;
 	space = Physics2DServer::get_singleton()->space_create();
+
+	set_active(true);
+	set_gravity(98);
+	set_gravity_vector(Vector2(0, 1));
+	set_linear_damp(0.1);
+	set_angular_damp(1);
 }
 
 Space2D::~Space2D() {

--- a/scene/resources/space_2d.h
+++ b/scene/resources/space_2d.h
@@ -38,6 +38,10 @@ class Space2D : public Resource {
 
 	GDCLASS(Space2D, Resource);
 	bool active;
+	real_t gravity;
+	Vector2 gravity_vec;
+	real_t linear_damp;
+	real_t angular_damp;
 	RID space;
 
 protected:
@@ -46,6 +50,18 @@ protected:
 public:
 	void set_active(bool p_active);
 	bool is_active() const;
+
+	void set_gravity(real_t p_gravity);
+	real_t get_gravity() const;
+
+	void set_gravity_vector(const Vector2 &p_vec);
+	Vector2 get_gravity_vector() const;
+
+	void set_linear_damp(real_t p_linear_damp);
+	real_t get_linear_damp() const;
+
+	void set_angular_damp(real_t p_angular_damp);
+	real_t get_angular_damp() const;
 
 	virtual RID get_rid() const;
 


### PR DESCRIPTION
- Subspace2D node
  this node requires a Space2D resource and allows you to separate different nodes into different physics spaces. Any node that is a child of a Subspace2D will use the space from the Space2D resource.
- Space2D resource
  this allows you create and configure a physics space that is used with a Subspace2D node.

- modified places I saw using the world_2d space to use get_physics_space which is a function I added to CanvasItem that handles if the node is a child of a Subspace2D node or not.

fixes #28074