### PR TITLE
Rename nodes with the default name when using the Change Type dialog

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1844,6 +1844,11 @@ void SceneTreeDock::_create() {
 			Node *newnode = Object::cast_to<Node>(c);
 			ERR_FAIL_COND(!newnode);
 
+			// If the old node had the default name, rename it to match the new node type
+			if (n->get_name() == n->get_class()) {
+				n->set_name(newnode->get_class());
+			}
+
 			replace_node(n, newnode);
 		}
 	}


### PR DESCRIPTION
This prevents possible confusion when renaming nodes that resemble each other (such as HBoxContainer and VBoxContainer). The node isn't renamed if it has a non-default name.

This closes #3480.