### PR TITLE
Fixed #28529 : Large fonts Causing Camera Preview button overlapping

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -3566,7 +3566,8 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	ED_SHORTCUT("spatial_editor/freelook_speed_modifier", TTR("Freelook Speed Modifier"), KEY_SHIFT);
 
 	preview_camera = memnew(CheckBox);
-	preview_camera->set_position(Point2(10, 38) * EDSCALE); // Below the 'view_menu' MenuButton.
+	int font_size = EditorSettings::get_singleton()->get("interface/editor/main_font_size");
+	preview_camera->set_position(Point2(10, font_size * 2 + 5) * EDSCALE); // Below the 'view_menu' MenuButton.
 	preview_camera->set_text(TTR("Preview"));
 	surface->add_child(preview_camera);
 	preview_camera->hide();


### PR DESCRIPTION
Fix #28529 by simply placing the Preview box 2*FONT_SIZE + 5 away from the top...

Scales well even with font sizes as big as 40..which is the maximum value afaik.