### PR TITLE
Allow constructing larger data types by swizzling

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2968,6 +2968,10 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 							member_type = DataType(dt - 1);
 						} else if (l == 2) {
 							member_type = dt;
+						} else if (l == 3) {
+							member_type = DataType(dt + 1);
+						} else if (l == 4) {
+							member_type = DataType(dt + 2);
 						} else {
 							ok = false;
 							break;
@@ -3001,6 +3005,8 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 							member_type = DataType(dt - 1);
 						} else if (l == 3) {
 							member_type = dt;
+						} else if (l == 4) {
+							member_type = DataType(dt + 1);
 						} else {
 							ok = false;
 							break;


### PR DESCRIPTION
First PR to Godot! Hello world! :wave::blush:

---

GLSL allows the construction of larger data types by swizzling smaller
ones, but Godot shading language treated this as an error:

```glsl
vec2 test2 = vec2(0.0, 1.0);
vec3 test3 = test2.xxx; // error: Invalid member for vec2 expression
```

This commit updates the expression parser for the 2 and 3-component data
types accordingly.

Fixes #10496