### PR TITLE
Fix GDNative library resource loading.

### DIFF
--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -243,7 +243,7 @@ void GDNativeLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_symbol_prefix", "symbol_prefix"), &GDNativeLibrary::set_symbol_prefix);
 	ClassDB::bind_method(D_METHOD("set_reloadable", "reloadable"), &GDNativeLibrary::set_reloadable);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "config_file", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile"), "set_config_file", "get_config_file");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "config_file", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile", 0), "set_config_file", "get_config_file");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "load_once"), "set_load_once", "should_load_once");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "singleton"), "set_singleton", "is_singleton");

--- a/modules/gdnative/gdnative.h
+++ b/modules/gdnative/gdnative.h
@@ -99,16 +99,20 @@ public:
 	}
 
 	_FORCE_INLINE_ void set_load_once(bool p_load_once) {
+		config_file->set_value("general", "load_once", p_load_once);
 		load_once = p_load_once;
 	}
 	_FORCE_INLINE_ void set_singleton(bool p_singleton) {
+		config_file->set_value("general", "singleton", p_singleton);
 		singleton = p_singleton;
 	}
 	_FORCE_INLINE_ void set_symbol_prefix(String p_symbol_prefix) {
+		config_file->set_value("general", "symbol_prefix", p_symbol_prefix);
 		symbol_prefix = p_symbol_prefix;
 	}
 
 	_FORCE_INLINE_ void set_reloadable(bool p_reloadable) {
+		config_file->set_value("general", "reloadable", p_reloadable);
 		reloadable = p_reloadable;
 	}
 


### PR DESCRIPTION
Store general properties in ConfigFile too when modifying them.
Additionally set config_file property as internal as it's not editable
from inspector. It also does not appear to get saved in a meaningful way
(saved as Object(ConfigFile, ...))