### PR TITLE
Keep editable children on node duplicate

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -517,6 +517,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			editor_data->get_undo_redo().add_do_method(editor_selection, "clear");
 
 			Node *dupsingle = NULL;
+			List<Node *> editable_children;
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
@@ -528,6 +529,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				Map<const Node *, Node *> duplimap;
 				Node *dup = node->duplicate_from_editor(duplimap);
+
+				if (EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node))
+					editable_children.push_back(dup);
 
 				ERR_CONTINUE(!dup);
 
@@ -560,6 +564,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			if (dupsingle)
 				editor->push_item(dupsingle);
+
+			for (List<Node *>::Element *E = editable_children.front(); E; E = E->next())
+				_toggle_editable_children(E->get());
 
 		} break;
 		case TOOL_REPARENT: {
@@ -796,7 +803,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						editable_instance_remove_dialog->popup_centered_minsize();
 						break;
 					}
-					_toggle_editable_children();
+					_toggle_editable_children(node);
 				}
 			}
 		} break;
@@ -1610,30 +1617,27 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 	_update_script_button();
 }
 
-void SceneTreeDock::_toggle_editable_children() {
+void SceneTreeDock::_toggle_editable_children_from_selection() {
+
 	List<Node *> selection = editor_selection->get_selected_node_list();
 	List<Node *>::Element *e = selection.front();
+
 	if (e) {
-		Node *node = e->get();
-		if (node) {
-			bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node);
+		_toggle_editable_children(e->get());
+	}
+}
 
-			int editable_item_idx = menu->get_item_idx_from_text(TTR("Editable Children"));
-			int placeholder_item_idx = menu->get_item_idx_from_text(TTR("Load As Placeholder"));
-			editable = !editable;
+void SceneTreeDock::_toggle_editable_children(Node *p_node) {
 
-			EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, editable);
+	if (p_node) {
+		bool editable = !EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(p_node);
+		EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(p_node, editable);
+		if (editable)
+			p_node->set_scene_instance_load_placeholder(false);
 
-			menu->set_item_checked(editable_item_idx, editable);
-			if (editable) {
-				node->set_scene_instance_load_placeholder(false);
-				menu->set_item_checked(placeholder_item_idx, false);
-			}
+		SpatialEditor::get_singleton()->update_all_gizmos(p_node);
 
-			SpatialEditor::get_singleton()->update_all_gizmos(node);
-
-			scene_tree->update_tree();
-		}
+		scene_tree->update_tree();
 	}
 }
 
@@ -2479,7 +2483,7 @@ void SceneTreeDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_input"), &SceneTreeDock::_input);
 	ClassDB::bind_method(D_METHOD("_nodes_drag_begin"), &SceneTreeDock::_nodes_drag_begin);
 	ClassDB::bind_method(D_METHOD("_delete_confirm"), &SceneTreeDock::_delete_confirm);
-	ClassDB::bind_method(D_METHOD("_toggle_editable_children"), &SceneTreeDock::_toggle_editable_children);
+	ClassDB::bind_method(D_METHOD("_toggle_editable_children_from_selection"), &SceneTreeDock::_toggle_editable_children_from_selection);
 	ClassDB::bind_method(D_METHOD("_node_prerenamed"), &SceneTreeDock::_node_prerenamed);
 	ClassDB::bind_method(D_METHOD("_import_subscene"), &SceneTreeDock::_import_subscene);
 	ClassDB::bind_method(D_METHOD("_selection_changed"), &SceneTreeDock::_selection_changed);
@@ -2647,7 +2651,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	editable_instance_remove_dialog = memnew(ConfirmationDialog);
 	add_child(editable_instance_remove_dialog);
-	editable_instance_remove_dialog->connect("confirmed", this, "_toggle_editable_children");
+	editable_instance_remove_dialog->connect("confirmed", this, "_toggle_editable_children_from_selection");
 
 	import_subscene_dialog = memnew(EditorSubScene);
 	add_child(import_subscene_dialog);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -172,7 +172,8 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _delete_confirm();
 
-	void _toggle_editable_children();
+	void _toggle_editable_children_from_selection();
+	void _toggle_editable_children(Node *p_node);
 
 	void _node_prerenamed(Node *p_node, const String &p_new_name);
 


### PR DESCRIPTION
Fixes #24954

There's a small problem when you duplicate a node, undo/remove clone and duplicate it again, but that's another issue: #28861

btw, are these lines related to menu necessary?
https://github.com/godotengine/godot/blob/86a74e2cb3f22b1d7f84f41cce673679d1b08a18/editor/scene_tree_dock.cpp#L1621-L1631
AFAIK it's impossible to toggle editable children without closing the menu and it's rebuilt on each reopen, so updating it is useless.