### PR TITLE
Keep GDScript functions in stack while yielding

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -622,8 +622,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			d["frame"] = i;
 			s->set_metadata(0, d);
 
-			//String line = itos(i)+" - "+String(d["file"])+":"+itos(d["line"])+" - at func: "+d["function"];
-			String line = itos(i) + " - " + String(d["file"]) + ":" + itos(d["line"]);
+			String line = itos(i) + " - " + String(d["file"]) + ":" + itos(d["line"]) + " - at function: " + d["function"];
 			s->set_text(0, line);
 
 			if (i == 0)

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1778,7 +1778,7 @@ Variant GDScriptFunctionState::_signal_callback(const Variant **p_args, int p_ar
 
 	if (state.instance_id && !ObjectDB::get_instance(state.instance_id)) {
 #ifdef DEBUG_ENABLED
-		ERR_EXPLAIN("Resumed after yield, but class instance is gone");
+		ERR_EXPLAIN("Resumed function '" + String(function->get_name()) + "()' after yield, but class instance is gone. At script: " + state.script->get_path() + ":" + itos(state.line));
 		ERR_FAIL_V(Variant());
 #else
 		return Variant();
@@ -1874,7 +1874,7 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 	ERR_FAIL_COND_V(!function, Variant());
 	if (state.instance_id && !ObjectDB::get_instance(state.instance_id)) {
 #ifdef DEBUG_ENABLED
-		ERR_EXPLAIN("Resumed after yield, but class instance is gone");
+		ERR_EXPLAIN("Resumed function '" + String(function->get_name()) + "()' after yield, but class instance is gone. At script: " + state.script->get_path() + ":" + itos(state.line));
 		ERR_FAIL_V(Variant());
 #else
 		return Variant();


### PR DESCRIPTION
This prevents GDScript functions from leaving the stack too soon when they are resuming from yield, allowing the ones expecting it to finish to know the caller.

Helps debugging cases when you use: `yield(function_which_yields(), "completed")` since now it shows the call that resumed that function.

Also show the function names in the debugger stack, which helps identify the stack (not sure why that was commented out, it's been like this since the first commit). And show function/script/line when resuming from yield after instance is gone, to help identify the issues.