### PR TITLE
Fix tilemap displaced textures and shapes

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -760,7 +760,7 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 		r.position += (r.size + Vector2(spacing, spacing)) * offset;
 	}
 	Size2 sc = p_xform.get_scale();
-
+	Size2 cell_size = node->get_cell_size();
 	Rect2 rect = Rect2();
 	rect.position = node->map_to_world(p_point) + node->get_cell_draw_offset();
 
@@ -770,62 +770,25 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 		rect.size = r.size;
 	}
 
-	if (rect.size.y > rect.size.x) {
-		if ((p_flip_h && (p_flip_v || p_transpose)) || (p_flip_v && !p_transpose))
-			tile_ofs.y += rect.size.y - rect.size.x;
-	} else if (rect.size.y < rect.size.x) {
-		if ((p_flip_v && (p_flip_h || p_transpose)) || (p_flip_h && !p_transpose))
-			tile_ofs.x += rect.size.x - rect.size.y;
-	}
-
 	if (p_transpose) {
 		SWAP(tile_ofs.x, tile_ofs.y);
+		rect.position.x += cell_size.x / 2 - rect.size.y / 2;
+		rect.position.y += cell_size.y / 2 - rect.size.x / 2;
+	} else {
+		rect.position += cell_size / 2 - rect.size / 2;
 	}
+
 	if (p_flip_h) {
 		sc.x *= -1.0;
 		tile_ofs.x *= -1.0;
 	}
+
 	if (p_flip_v) {
 		sc.y *= -1.0;
 		tile_ofs.y *= -1.0;
 	}
 
-	if (node->get_tile_origin() == TileMap::TILE_ORIGIN_TOP_LEFT) {
-
-		rect.position += tile_ofs;
-	} else if (node->get_tile_origin() == TileMap::TILE_ORIGIN_BOTTOM_LEFT) {
-		Size2 cell_size = node->get_cell_size();
-
-		rect.position += tile_ofs;
-
-		if (p_transpose) {
-			if (p_flip_h)
-				rect.position.x -= cell_size.x;
-			else
-				rect.position.x += cell_size.x;
-		} else {
-			if (p_flip_v)
-				rect.position.y -= cell_size.y;
-			else
-				rect.position.y += cell_size.y;
-		}
-
-	} else if (node->get_tile_origin() == TileMap::TILE_ORIGIN_CENTER) {
-		Size2 cell_size = node->get_cell_size();
-
-		rect.position += tile_ofs;
-
-		if (p_flip_h)
-			rect.position.x -= cell_size.x / 2;
-		else
-			rect.position.x += cell_size.x / 2;
-
-		if (p_flip_v)
-			rect.position.y -= cell_size.y / 2;
-		else
-			rect.position.y += cell_size.y / 2;
-	}
-
+	rect.position += tile_ofs;
 	rect.position = p_xform.xform(rect.position);
 	rect.size *= sc;
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -202,47 +202,27 @@ void TileMap::_fix_cell_transform(Transform2D &xform, const Cell &p_cell, const 
 	Size2 s = p_sc;
 	Vector2 offset = p_offset;
 
-	if (tile_origin == TILE_ORIGIN_BOTTOM_LEFT)
-		offset.y += cell_size.y;
-	else if (tile_origin == TILE_ORIGIN_CENTER) {
-		offset += cell_size / 2;
-	}
-
-	if (s.y > s.x) {
-		if ((p_cell.flip_h && (p_cell.flip_v || p_cell.transpose)) || (p_cell.flip_v && !p_cell.transpose))
-			offset.y += s.y - s.x;
-	} else if (s.y < s.x) {
-		if ((p_cell.flip_v && (p_cell.flip_h || p_cell.transpose)) || (p_cell.flip_h && !p_cell.transpose))
-			offset.x += s.x - s.y;
-	}
-
 	if (p_cell.transpose) {
 		SWAP(xform.elements[0].x, xform.elements[0].y);
 		SWAP(xform.elements[1].x, xform.elements[1].y);
 		SWAP(offset.x, offset.y);
 		SWAP(s.x, s.y);
 	}
+
 	if (p_cell.flip_h) {
 		xform.elements[0].x = -xform.elements[0].x;
 		xform.elements[1].x = -xform.elements[1].x;
-		if (tile_origin == TILE_ORIGIN_TOP_LEFT || tile_origin == TILE_ORIGIN_BOTTOM_LEFT)
-			offset.x = s.x - offset.x;
-		else if (tile_origin == TILE_ORIGIN_CENTER)
-			offset.x = s.x - offset.x / 2;
+		offset.x = s.x - offset.x;
 	}
+
 	if (p_cell.flip_v) {
 		xform.elements[0].y = -xform.elements[0].y;
 		xform.elements[1].y = -xform.elements[1].y;
-		if (tile_origin == TILE_ORIGIN_TOP_LEFT)
-			offset.y = s.y - offset.y;
-		else if (tile_origin == TILE_ORIGIN_BOTTOM_LEFT) {
-			offset.y += s.y;
-		} else if (tile_origin == TILE_ORIGIN_CENTER) {
-			offset.y += s.y;
-		}
+		offset.y = s.y - offset.y;
 	}
-	xform.elements[2].x += offset.x;
-	xform.elements[2].y += offset.y;
+
+	offset += cell_size / 2 - s / 2;
+	xform.elements[2] += offset;
 }
 
 void TileMap::update_dirty_quadrants() {
@@ -390,64 +370,25 @@ void TileMap::update_dirty_quadrants() {
 			rect.size.x += fp_adjust;
 			rect.size.y += fp_adjust;
 
-			if (rect.size.y > rect.size.x) {
-				if ((c.flip_h && (c.flip_v || c.transpose)) || (c.flip_v && !c.transpose))
-					tile_ofs.y += rect.size.y - rect.size.x;
-			} else if (rect.size.y < rect.size.x) {
-				if ((c.flip_v && (c.flip_h || c.transpose)) || (c.flip_h && !c.transpose))
-					tile_ofs.x += rect.size.x - rect.size.y;
-			}
-
-			/*	rect.size.x+=fp_adjust;
-			rect.size.y+=fp_adjust;*/
-
-			if (c.transpose)
+			if (c.transpose) {
 				SWAP(tile_ofs.x, tile_ofs.y);
+				rect.position.x += cell_size.x / 2 - rect.size.y / 2;
+				rect.position.y += cell_size.y / 2 - rect.size.x / 2;
+			} else {
+				rect.position += cell_size / 2 - rect.size / 2;
+			}
 
 			if (c.flip_h) {
 				rect.size.x = -rect.size.x;
 				tile_ofs.x = -tile_ofs.x;
 			}
+
 			if (c.flip_v) {
 				rect.size.y = -rect.size.y;
 				tile_ofs.y = -tile_ofs.y;
 			}
 
-			Vector2 center_ofs;
-
-			if (tile_origin == TILE_ORIGIN_TOP_LEFT) {
-				rect.position += tile_ofs;
-
-			} else if (tile_origin == TILE_ORIGIN_BOTTOM_LEFT) {
-
-				rect.position += tile_ofs;
-
-				if (c.transpose) {
-					if (c.flip_h)
-						rect.position.x -= cell_size.x;
-					else
-						rect.position.x += cell_size.x;
-				} else {
-					if (c.flip_v)
-						rect.position.y -= cell_size.y;
-					else
-						rect.position.y += cell_size.y;
-				}
-
-			} else if (tile_origin == TILE_ORIGIN_CENTER) {
-
-				rect.position += tile_ofs;
-
-				if (c.flip_h)
-					rect.position.x -= cell_size.x / 2;
-				else
-					rect.position.x += cell_size.x / 2;
-
-				if (c.flip_v)
-					rect.position.y -= cell_size.y / 2;
-				else
-					rect.position.y += cell_size.y / 2;
-			}
+			rect.position += tile_ofs;
 
 			Ref<Texture> normal_map = tile_set->tile_get_normal_map(c.id);
 			Color modulate = tile_set->tile_get_modulate(c.id);
@@ -471,7 +412,7 @@ void TileMap::update_dirty_quadrants() {
 
 						Vector2 shape_ofs = shapes[j].shape_transform.get_origin();
 
-						_fix_cell_transform(xform, c, shape_ofs + center_ofs, s);
+						_fix_cell_transform(xform, c, shape_ofs, s);
 
 						xform *= shapes[j].shape_transform.untranslated();
 
@@ -523,7 +464,7 @@ void TileMap::update_dirty_quadrants() {
 				if (navpoly.is_valid()) {
 					Transform2D xform;
 					xform.set_origin(offset.floor() + q.pos);
-					_fix_cell_transform(xform, c, npoly_ofs + center_ofs, s);
+					_fix_cell_transform(xform, c, npoly_ofs, s);
 
 					int pid = navigation->navpoly_add(navpoly, nav_rel * xform);
 
@@ -573,7 +514,7 @@ void TileMap::update_dirty_quadrants() {
 								}
 								Transform2D navxform;
 								navxform.set_origin(offset.floor());
-								_fix_cell_transform(navxform, c, npoly_ofs + center_ofs, s);
+								_fix_cell_transform(navxform, c, npoly_ofs, s);
 
 								vs->canvas_item_set_transform(debug_navigation_item, navxform);
 								vs->canvas_item_add_triangle_array(debug_navigation_item, indices, vertices, colors);
@@ -593,7 +534,7 @@ void TileMap::update_dirty_quadrants() {
 				Vector2 occluder_ofs = tile_set->tile_get_occluder_offset(c.id);
 				Transform2D xform;
 				xform.set_origin(offset.floor() + q.pos);
-				_fix_cell_transform(xform, c, occluder_ofs + center_ofs, s);
+				_fix_cell_transform(xform, c, occluder_ofs, s);
 
 				RID orid = VS::get_singleton()->canvas_light_occluder_create();
 				VS::get_singleton()->canvas_light_occluder_set_transform(orid, get_global_transform() * xform);


### PR DESCRIPTION
This commit fixes https://github.com/godotengine/godot/issues/22989, fixing displaced textures and not coincident shapes in tilemap. Also fixes https://github.com/godotengine/godot/issues/15249, fixes https://github.com/godotengine/godot/issues/28206, fixes https://github.com/godotengine/godot/issues/28610, and probably others.
I test in hexagonal tilemap demo and others, works well.
Project to test and fully understand the change:
[Godot Tilemap Test.zip](https://github.com/godotengine/godot/files/3180643/Godot.Tilemap.Test.zip)
![TileMapFix](https://user-images.githubusercontent.com/11712737/57744269-d3c5c080-76c8-11e9-8ef2-d56ba9270bd2.png)
Left -> before this commit
Right ->after this commit
I test extensively the changes, and it seems to work. I would say that i only test with collision, other shapes are not showed in debug, but seeing the changes, the other shapes should work. Commit delete an unused variable too (center_ofs). Changes affects tilemap editor plugin too.

Edit:
Issue from today that probably it´s fixed with this commit: https://github.com/godotengine/godot/issues/28893