### PR TITLE
Enforce Unicode encoding in MSVC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -327,6 +327,8 @@ if selected_platform in platform_list:
         env.Append(CCFLAGS=['/EHsc'])
         if (env["werror"]):
             env.Append(CCFLAGS=['/WX'])
+        # Force to use Unicode encoding
+        env.Append(MSVC_FLAGS=['/utf8'])
     else: # Rest of the world
         shadow_local_warning = []
         all_plus_warnings = ['-Wwrite-strings']

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -1017,8 +1017,8 @@ bool test_32() {
 	STRIP_TEST(String("abca").lstrip("a") == "bca");
 	STRIP_TEST(String("abc").rstrip("a") == "abc");
 	STRIP_TEST(String("abca").rstrip("a") == "abc");
-	// in utf-8 "¿" has the same first byte as "µ"
-	// and the same second as "ÿ"
+	// in utf-8 "¿" (\u00bf) has the same first byte as "µ" (\u00b5)
+	// and the same second as "ÿ" (\u00ff)
 	STRIP_TEST(String::utf8("¿").lstrip(String::utf8("µÿ")) == String::utf8("¿"));
 	STRIP_TEST(String::utf8("¿").rstrip(String::utf8("µÿ")) == String::utf8("¿"));
 	STRIP_TEST(String::utf8("µ¿ÿ").lstrip(String::utf8("µÿ")) == String::utf8("¿ÿ"));
@@ -1046,8 +1046,8 @@ bool test_32() {
 	STRIP_TEST(String("abca").lstrip("qwajkl") == "bca");
 	STRIP_TEST(String("abc").rstrip("qwajkl") == "abc");
 	STRIP_TEST(String("abca").rstrip("qwajkl") == "abc");
-	// in utf-8 "¿" has the same first byte as "µ"
-	// and the same second as "ÿ"
+	// in utf-8 "¿" (\u00bf) has the same first byte as "µ" (\u00b5)
+	// and the same second as "ÿ" (\u00ff)
 	STRIP_TEST(String::utf8("¿").lstrip(String::utf8("qwaµÿjkl")) == String::utf8("¿"));
 	STRIP_TEST(String::utf8("¿").rstrip(String::utf8("qwaµÿjkl")) == String::utf8("¿"));
 	STRIP_TEST(String::utf8("µ¿ÿ").lstrip(String::utf8("qwaµÿjkl")) == String::utf8("¿ÿ"));
@@ -1068,8 +1068,8 @@ bool test_33() {
 bool test_34() {
 	OS::get_singleton()->print("\n\nTest 34: Cyrillic to_lower()\n");
 
-	String upper = L"АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ";
-	String lower = L"абвгдеёжзийклмнопрстуфхцчшщъыьэюя";
+	String upper = String::utf8("АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ");
+	String lower = String::utf8("абвгдеёжзийклмнопрстуфхцчшщъыьэюя");
 
 	String test = upper.to_lower();
 


### PR DESCRIPTION
Should hopefully fix #28824 as it's difficult for me to test this. 
All tests pass (34/34) with `godot --test string`

@RicardRC would be nice if you could check this out.

