### PR TITLE
Fix leftover connection to the "Open" signal in FileSystemDock

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5997,7 +5997,6 @@ EditorNode::EditorNode() {
 	node_dock = memnew(NodeDock);
 
 	filesystem_dock = memnew(FileSystemDock(this));
-	filesystem_dock->connect("open", this, "open_request");
 	filesystem_dock->connect("inherit", this, "_inherit_request");
 	filesystem_dock->connect("instance", this, "_instance_request");
 	filesystem_dock->connect("display_mode_changed", this, "_save_docks");

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -613,7 +613,7 @@ void LineEdit::_notification(int p_what) {
 #endif
 		case NOTIFICATION_RESIZED: {
 
-			window_pos = 0; //force scroll back since it's expanding to text length
+			window_pos = 0;
 			set_cursor_position(get_cursor_position());
 
 		} break;


### PR DESCRIPTION
Fixes #28903. Regression caused by dcf27c71b75452ce5ca0bb849715ce4304ad694d.

~~I still have no clue what this signal is even used for, as it's not fired anywhere. @qarmin, does this fixes it in your side?~~ ~~Wait, no, I'm stupid, when I removed the signal I forgot to remove the actual connection to it, don't merge yet!~~

Okay, good to go.