### PR TITLE
Fix indexing failure in unregister_binding_functions.

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1309,7 +1309,7 @@ void NativeScriptLanguage::unregister_binding_functions(int p_idx) {
 	for (Set<Vector<void *> *>::Element *E = binding_instances.front(); E; E = E->next()) {
 		Vector<void *> &binding_data = *E->get();
 
-		if (binding_data[p_idx] && binding_functions[p_idx].second.free_instance_binding_data)
+		if (p_idx < binding_data.size() && binding_data[p_idx] && binding_functions[p_idx].second.free_instance_binding_data)
 			binding_functions[p_idx].second.free_instance_binding_data(binding_functions[p_idx].second.data, binding_data[p_idx]);
 	}
 


### PR DESCRIPTION
`binding_functions.size()` and an instance's `binding_data.size()` can get out of sync. They sync up when an instance's bindings are requested. When binding functions are registered after creating an instance's bindings, the instance's bindings are out of sync until requested again. If they're never requested, they're never synced.

`unregister_binding_functions indexes` into `binding_data`, but only checks that its safe to index into `binding_functions`. When they're out of sync, indexing fails.

This revision checks that it's safe to index into `binding_data`.

_Bugsquad edit_: Fixes #28923