### PR TITLE
Improve the performance of AStar

### DIFF
--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -48,25 +48,33 @@ class AStar : public Reference {
 
 	struct Point {
 
-		SelfList<Point> list;
-
 		int id;
 		Vector3 pos;
 		real_t weight_scale;
-		uint64_t last_pass;
 		bool enabled;
 
 		Set<Point *> neighbours;
 
 		// Used for pathfinding
 		Point *prev_point;
-		real_t distance;
-
-		Point() :
-				list(this) {}
+		real_t g_score;
+		real_t f_score;
+		uint64_t open_pass;
+		uint64_t closed_pass;
 	};
 
 	Map<int, Point *> points;
+
+	struct SortPoints {
+		_FORCE_INLINE_ bool operator()(const Point *A, const Point *B) const { // Returns true when the Point A is worse than Point B
+			if (A->f_score > B->f_score)
+				return true;
+			else if (A->f_score < B->f_score)
+				return false;
+			else
+				return A->g_score < B->g_score; // If the f_costs are the same then prioritize the points that are further away from the start
+		}
+	};
 
 	struct Segment {
 		union {


### PR DESCRIPTION
The current implementation of AStar is really slow, especially on large maps.
The problem is that right now his open list is implemented with a really slow linked list.

With this pull the open list of AStar now uses a sorted vector ( also known as binary heap ).

A test path that required 3 seconds to be calculated now only needs 0.06 seconds ( 50 times faster ).

This changes should be tested on multiple case scenarios, to be sure that they don't break anything that currently work.
