### PR TITLE
Fix Object::get_indexed for simple properties.

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -608,18 +608,16 @@ Variant Object::get_indexed(const Vector<StringName> &p_names, bool *r_valid) co
 	}
 	bool valid = false;
 
-	Variant current_value = get(p_names[0]);
+	Variant current_value = get(p_names[0], &valid);
 	for (int i = 1; i < p_names.size(); i++) {
 		current_value = current_value.get_named(p_names[i], &valid);
 
-		if (!valid) {
-			if (r_valid)
-				*r_valid = false;
-			return Variant();
-		}
+		if (!valid)
+			break;
 	}
 	if (r_valid)
-		*r_valid = true;
+		*r_valid = valid;
+
 	return current_value;
 }
 


### PR DESCRIPTION
Object::get_indexed was not correctly reporting invalid keys if the name was a direct property (not a subproperty), causing for example Tween to not report correctly a bad interpolate_property key.

Fixes #25147 .

Demo project (should show 2 errors, shows 1 without the patch):
[proj_tween.zip](https://github.com/godotengine/godot/files/3189120/proj_tween.zip)

I think this is also good for cherry pick.