### PR TITLE
Fix text_edit drawing incorrect chars when syntax highlighting enabled

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1072,10 +1072,7 @@ void TextEdit::_notification(int p_what) {
 						}
 
 						if ((char_ofs + char_margin + char_w) >= xmargin_end) {
-							if (syntax_coloring)
-								continue;
-							else
-								break;
+							break;
 						}
 
 						bool in_search_result = false;


### PR DESCRIPTION
Fixes `text_edit` drawing incorrect characters when syntax highlighting is enabled, it now works the same way as having the setting disabled. I believe this is left over from before the syntax highlighter was extracted.

closes #28860