### PR TITLE
Update Control margins when size is overridden by change to minsize

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -276,7 +276,7 @@ void Control::_update_minimum_size() {
 	Size2 minsize = get_combined_minimum_size();
 	if (minsize.x > data.size_cache.x ||
 			minsize.y > data.size_cache.y) {
-		_size_changed();
+		set_size(data.size_cache);
 	}
 
 	data.updating_last_minimum_size = false;


### PR DESCRIPTION
Letting the margins and size disagree can cause the size to be reset during unrelated actions:
![margins_bug](https://user-images.githubusercontent.com/49602874/57900532-c9213d80-7826-11e9-9ead-9c6a51268866.gif)

set_size() does everything we need here: enforce the minimum size, set the margins, and call _size_changed()