### PR TITLE
Optimize Basis constructor for Axis Angle

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -813,21 +813,28 @@ void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_phi) {
 	ERR_FAIL_COND(!p_axis.is_normalized());
 #endif
 	Vector3 axis_sq(p_axis.x * p_axis.x, p_axis.y * p_axis.y, p_axis.z * p_axis.z);
-
 	real_t cosine = Math::cos(p_phi);
-	real_t sine = Math::sin(p_phi);
-
 	elements[0][0] = axis_sq.x + cosine * (1.0 - axis_sq.x);
-	elements[0][1] = p_axis.x * p_axis.y * (1.0 - cosine) - p_axis.z * sine;
-	elements[0][2] = p_axis.z * p_axis.x * (1.0 - cosine) + p_axis.y * sine;
-
-	elements[1][0] = p_axis.x * p_axis.y * (1.0 - cosine) + p_axis.z * sine;
 	elements[1][1] = axis_sq.y + cosine * (1.0 - axis_sq.y);
-	elements[1][2] = p_axis.y * p_axis.z * (1.0 - cosine) - p_axis.x * sine;
-
-	elements[2][0] = p_axis.z * p_axis.x * (1.0 - cosine) - p_axis.y * sine;
-	elements[2][1] = p_axis.y * p_axis.z * (1.0 - cosine) + p_axis.x * sine;
 	elements[2][2] = axis_sq.z + cosine * (1.0 - axis_sq.z);
+
+	real_t sine = Math::sin(p_phi);
+	real_t t = 1 - cosine;
+
+	real_t xyzt = p_axis.x * p_axis.y * t;
+	real_t zyxs = p_axis.z * sine;
+	elements[0][1] = xyzt - zyxs;
+	elements[1][0] = xyzt + zyxs;
+
+	xyzt = p_axis.x * p_axis.z * t;
+	zyxs = p_axis.y * sine;
+	elements[0][2] = xyzt + zyxs;
+	elements[2][0] = xyzt - zyxs;
+
+	xyzt = p_axis.y * p_axis.z * t;
+	zyxs = p_axis.x * sine;
+	elements[1][2] = xyzt - zyxs;
+	elements[2][1] = xyzt + zyxs;
 }
 
 void Basis::set_axis_angle_scale(const Vector3 &p_axis, real_t p_phi, const Vector3 &p_scale) {

--- a/modules/mono/glue/Managed/Files/Basis.cs
+++ b/modules/mono/glue/Managed/Files/Basis.cs
@@ -583,31 +583,29 @@ namespace Godot
 
         public Basis(Vector3 axis, real_t phi)
         {
-            var axis_sq = new Vector3(axis.x * axis.x, axis.y * axis.y, axis.z * axis.z);
-
+            Vector3 axisSq = new Vector3(axis.x * axis.x, axis.y * axis.y, axis.z * axis.z);
             real_t cosine = Mathf.Cos(phi);
+            Row0.x = axisSq.x + cosine * (1.0f - axisSq.x);
+            Row1.y = axisSq.y + cosine * (1.0f - axisSq.y);
+            Row2.z = axisSq.z + cosine * (1.0f - axisSq.z);
+
             real_t sine = Mathf.Sin(phi);
+            real_t t = 1.0f - cosine;
 
-            Row0 = new Vector3
-            (
-                axis_sq.x + cosine * (1.0f - axis_sq.x),
-                axis.x * axis.y * (1.0f - cosine) - axis.z * sine,
-                axis.z * axis.x * (1.0f - cosine) + axis.y * sine
-            );
+            real_t xyzt = axis.x * axis.y * t;
+            real_t zyxs = axis.z * sine;
+            Row0.y = xyzt - zyxs;
+            Row1.x = xyzt + zyxs;
 
-            Row1 = new Vector3
-            (
-                axis.x * axis.y * (1.0f - cosine) + axis.z * sine,
-                axis_sq.y + cosine * (1.0f - axis_sq.y),
-                axis.y * axis.z * (1.0f - cosine) - axis.x * sine
-            );
+            xyzt = axis.x * axis.z * t;
+            zyxs = axis.y * sine;
+            Row0.z = xyzt + zyxs;
+            Row2.x = xyzt - zyxs;
 
-            Row2 = new Vector3
-            (
-                axis.z * axis.x * (1.0f - cosine) - axis.y * sine,
-                axis.y * axis.z * (1.0f - cosine) + axis.x * sine,
-                axis_sq.z + cosine * (1.0f - axis_sq.z)
-            );
+            xyzt = axis.y * axis.z * t;
+            zyxs = axis.x * sine;
+            Row1.z = xyzt - zyxs;
+            Row2.y = xyzt + zyxs;
         }
 
         public Basis(Vector3 column0, Vector3 column1, Vector3 column2)


### PR DESCRIPTION
I noticed that this constructor was doing many of the same things twice. I've optimized it, and now this constructor runs about 10-15% faster in C#. The behavior is the same as before.

These optimizations are roughly based on this implementation: https://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToMatrix/