### PR TITLE
Resolve: #24682 CSGPolygon - weird end cap

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2082,6 +2082,9 @@ CSGBrush *CSGPolygon::_build_brush() {
 				for (int i = 0; i <= splits; i++) {
 
 					float ofs = i * path_interval;
+					if (ofs > bl) {
+						ofs = bl;
+					}
 					if (i == splits && path_joined) {
 						ofs = 0.0;
 					}


### PR DESCRIPTION
Resolve issue: CSGPolygon (with Path Rotation: PathFollow) - weird end cap of mesh #24682

Path offset (ofs) was extending past the curve baked length in the last segment.  Fix limits the last segment to the baked length.

Before:
![Screenshot from 2019-05-17 20-12-05](https://user-images.githubusercontent.com/1886130/57949933-157f8280-78e6-11e9-9826-4934fb73e08f.png)

After:
![Screenshot from 2019-05-17 20-14-35](https://user-images.githubusercontent.com/1886130/57949937-1adccd00-78e6-11e9-91dd-0d4bb7a0bd27.png)

