### PR TITLE
Document that the first bit in layers and masks is set by default

### DIFF
--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -33,6 +33,12 @@
 			</argument>
 			<description>
 				Returns an individual bit on the collision mask.
+
+				By default, the first bit is set:
+				[codeblock]
+				print(get_collision_layer_bit(0)) # True
+				[/codeblock]
+				This ensures that newly created physics bodies collide by default.
 			</description>
 		</method>
 		<method name="get_collision_mask_bit" qualifiers="const">
@@ -42,6 +48,12 @@
 			</argument>
 			<description>
 				Returns an individual bit on the collision mask.
+
+				By default, the first bit is set:
+				[codeblock]
+				print(get_collision_mask_bit(0)) # True
+				[/codeblock]
+				This ensures that newly created physics bodies collide by default.
 			</description>
 		</method>
 		<method name="remove_collision_exception_with">
@@ -81,9 +93,19 @@
 			The physics layers this area is in.
 			Collidable objects can exist in any of 32 different layers. These layers work like a tagging system, and are not visual. A collidable can use these layers to select with which objects it can collide, using the collision_mask property.
 			A contact is detected if object A is in any of the layers that object B scans, or object B is in any layer scanned by object A.
+			By default, the first bit is set:
+			[codeblock]
+			print(get_collision_layer_bit(0)) # True
+			[/codeblock]
+			This ensures that newly created physics bodies collide by default.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask">
 			The physics layers this area scans for collisions.
+			By default, the first bit is set:
+			[codeblock]
+			print(get_collision_mask_bit(0)) # True
+			[/codeblock]
+			This ensures that newly created physics bodies collide by default.
 		</member>
 		<member name="layers" type="int" setter="_set_layers" getter="_get_layers">
 			Both [member collision_layer] and [member collision_mask]. Returns [member collision_layer] when accessed. Updates [member collision_layer] and [member collision_mask] when modified.


### PR DESCRIPTION
This surprised me at first, so documentation will save others time.
Eventually I realised that it makes sense: new bodies should collide
by default for a better user experience.