### PR TITLE
NULL global_tag for non exposed classes

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1345,7 +1345,7 @@ void *NativeScriptLanguage::get_instance_binding_data(int p_idx, Object *p_objec
 
 	if (!(*binding_data)[p_idx]) {
 
-		const void *global_type_tag = global_type_tags[p_idx].get(p_object->get_class_name());
+		const void *global_type_tag = get_global_type_tag(p_idx, p_object->get_class_name());
 
 		// no binding data yet, soooooo alloc new one \o/
 		(*binding_data).write[p_idx] = binding_functions[p_idx].second.alloc_instance_binding_data(binding_functions[p_idx].second.data, global_type_tag, (godot_object *)p_object);
@@ -1453,6 +1453,9 @@ const void *NativeScriptLanguage::get_global_type_tag(int p_idx, StringName p_cl
 		return NULL;
 
 	const HashMap<StringName, const void *> &tags = global_type_tags[p_idx];
+
+	if (!tags.has(p_class_name))
+		return NULL;
 
 	const void *tag = tags.get(p_class_name);
 


### PR DESCRIPTION
Temporary fix for editor crash when using `EditorInspectorPlugin`, when EditorInspectorPlugin calls `can_handle` against classes like`SectionedInspectorFilter`, `ImportDockParameters`, and .., whch are not exposed to api bindings, the editor crashes.