### PR TITLE
Fix VisualScript Change Base Type title

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2218,7 +2218,7 @@ Control *VisualScriptEditor::get_edit_menu() {
 
 void VisualScriptEditor::_change_base_type() {
 
-	select_base_type->popup_create(true);
+	select_base_type->popup_create(true, true);
 }
 
 void VisualScriptEditor::clear_edit_menu() {


### PR DESCRIPTION
Fixes #28939 
I didn't see any reason not to make the CreateDialog popup as a change dialog, but if this has consequences I don't know of, please let me know!