### PR TITLE
Clarify auto_advance.

### DIFF
--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -10,7 +10,10 @@
 	</methods>
 	<members>
 		<member name="advance_condition" type="String" setter="set_advance_condition" getter="get_advance_condition">
-			Turn on auto advance when this condition is set. This is a custom text field that can be filled with a variable name. The variable can be modified from code.
+			Turn on auto advance when this condition is set. The provided name will become a boolean parameter on the [AnimationTree] that can be controlled from code (see [url=https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html#controlling-from-code][/url]). For example, if [member AnimationTree.tree_root] is an [AnimationNodeStateMachine] and [member advance_condition] is set to "idle":
+			[codeblock]
+			$animation_tree["parameters/conditions/idle"] = is_on_floor and linear_velocity.x == 0
+			[codeblock]
 		</member>
 		<member name="auto_advance" type="bool" setter="set_auto_advance" getter="has_auto_advance">
 			Turn on the transition automatically when this state is reached. This works best with [code]SWITCH_MODE_AT_END[/code].


### PR DESCRIPTION
Make the docs more clear about how you can use auto_advance. Calling it
a "variable" is vague, so I updated the docs to clearly state that it
becomes a boolean parameter on the AnimationTree.
Fixes godotengine/godot-docs#2439.