### PR TITLE
Fix typos with codespell

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -562,7 +562,7 @@ if 'env' in locals():
             # (filename, size, weight).
             current_time = time.time()
             file_stat = [(x[0], x[1][0], (current_time - x[1][1])) for x in file_stat]
-            # Sort by the most resently accessed files (most sensible to keep) first
+            # Sort by the most recently accessed files (most sensible to keep) first
             file_stat.sort(key=lambda x: x[2])
             # Search for the first entry where the storage limit is
             # reached

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -41,7 +41,7 @@
  */
 
 /**
- * Pointer to the error macro priting function. Reassign to any function to have errors printed
+ * Pointer to the error macro printing function. Reassign to any function to have errors printed
  */
 
 /** Function used by the error macros */

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -429,7 +429,7 @@ Error HTTPClient::poll() {
 					response_num = RESPONSE_OK;
 
 					// Per the HTTP 1.1 spec, keep-alive is the default.
-					// Not following that specification breaks standard implemetations.
+					// Not following that specification breaks standard implementations.
 					// Broken web servers should be fixed.
 					bool keep_alive = true;
 

--- a/core/io/zip_io.h
+++ b/core/io/zip_io.h
@@ -33,7 +33,7 @@
 
 #include "core/os/file_access.h"
 
-// Not direclty used in this header, but assumed available in downstream users
+// Not directly used in this header, but assumed available in downstream users
 // like platform/*/export/export.cpp. Could be fixed, but probably better to have
 // thirdparty includes in as little headers as possible.
 #include "thirdparty/minizip/unzip.h"

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -833,7 +833,7 @@ public:
 			further_away_opposite.y = MIN(p[i].y, further_away_opposite.y);
 		}
 
-		further_away += (further_away - further_away_opposite) * Vector2(1.221313, 1.512312); // make point outside that wont intersect with points in segment from p_point
+		further_away += (further_away - further_away_opposite) * Vector2(1.221313, 1.512312); // make point outside that won't intersect with points in segment from p_point
 
 		int intersections = 0;
 		for (int i = 0; i < c; i++) {

--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -239,8 +239,8 @@ void UndoRedo::_pop_history_tail() {
 	}
 }
 
-bool UndoRedo::is_commiting_action() const {
-	return commiting > 0;
+bool UndoRedo::is_committing_action() const {
+	return committing > 0;
 }
 
 void UndoRedo::commit_action() {
@@ -255,9 +255,9 @@ void UndoRedo::commit_action() {
 		merging = false;
 	}
 
-	commiting++;
+	committing++;
 	redo(); // perform action
-	commiting--;
+	committing--;
 	if (callback && actions.size() > 0) {
 		callback(callback_ud, actions[actions.size() - 1].name);
 	}
@@ -396,7 +396,7 @@ void UndoRedo::set_property_notify_callback(PropertyNotifyCallback p_property_ca
 
 UndoRedo::UndoRedo() {
 
-	commiting = 0;
+	committing = 0;
 	version = 1;
 	action_level = 0;
 	current_action = -1;
@@ -496,10 +496,8 @@ void UndoRedo::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("create_action", "name", "merge_mode"), &UndoRedo::create_action, DEFVAL(MERGE_DISABLE));
 	ClassDB::bind_method(D_METHOD("commit_action"), &UndoRedo::commit_action);
-	ClassDB::bind_method(D_METHOD("is_commiting_action"), &UndoRedo::is_commiting_action);
-
-	//ClassDB::bind_method(D_METHOD("add_do_method","p_object", "p_method", "VARIANT_ARG_LIST"),&UndoRedo::add_do_method);
-	//ClassDB::bind_method(D_METHOD("add_undo_method","p_object", "p_method", "VARIANT_ARG_LIST"),&UndoRedo::add_undo_method);
+	// FIXME: Typo in "commiting", fix in 4.0 when breaking compat.
+	ClassDB::bind_method(D_METHOD("is_commiting_action"), &UndoRedo::is_committing_action);
 
 	{
 		MethodInfo mi;

--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -95,7 +95,7 @@ private:
 	MethodNotifyCallback method_callback;
 	PropertyNotifyCallback property_callback;
 
-	int commiting;
+	int committing;
 
 protected:
 	static void _bind_methods();
@@ -110,7 +110,7 @@ public:
 	void add_do_reference(Object *p_object);
 	void add_undo_reference(Object *p_object);
 
-	bool is_commiting_action() const;
+	bool is_committing_action() const;
 	void commit_action();
 
 	bool redo();

--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -153,7 +153,7 @@
 			<argument index="0" name="path" type="NodePath">
 			</argument>
 			<description>
-				Return [code]true[/code] wether a given path is filtered.
+				Return [code]true[/code] whether a given path is filtered.
 			</description>
 		</method>
 		<method name="process" qualifiers="virtual">

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 	</brief_description>
 	<description>
-		Contains multiple root nodes as children in a graph. Each node is used as a state, and provides multiple functions to alternate between states. Retrieve the AnimationNodeStateMachinePlayback object from the [AnimationTree] node to control it programatically.
+		Contains multiple root nodes as children in a graph. Each node is used as a state, and provides multiple functions to alternate between states. Retrieve the AnimationNodeStateMachinePlayback object from the [AnimationTree] node to control it programmatically.
 		[codeblock]
 		var state_machine = anim_tree["parameters/StateMachine/playback"]
 		state_machine.travel("SomeState")

--- a/doc/classes/EditorInspectorPlugin.xml
+++ b/doc/classes/EditorInspectorPlugin.xml
@@ -21,7 +21,7 @@
 			<argument index="0" name="control" type="Control">
 			</argument>
 			<description>
-				Add a custom control, not necesarily a property editor.
+				Add a custom control, not necessarily a property editor.
 			</description>
 		</method>
 		<method name="add_property_editor">

--- a/doc/classes/PrismMesh.xml
+++ b/doc/classes/PrismMesh.xml
@@ -12,7 +12,7 @@
 	</methods>
 	<members>
 		<member name="left_to_right" type="float" setter="set_left_to_right" getter="get_left_to_right">
-			Displacement of the upper edge along the x-axis. 0.0 positions edge straight above the bottome left edge. Defaults to 0.5 (positioned on the midpoint).
+			Displacement of the upper edge along the x-axis. 0.0 positions edge straight above the bottom left edge. Defaults to 0.5 (positioned on the midpoint).
 		</member>
 		<member name="size" type="Vector3" setter="set_size" getter="get_size">
 			Size of the prism. Defaults to (2.0, 2.0, 2.0).

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -141,7 +141,7 @@
 				This is useful mostly to check if something changed from a saved version.
 			</description>
 		</method>
-		<method name="is_commiting_action" qualifiers="const">
+		<method name="is_committing_action" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -580,7 +580,7 @@ bool RasterizerSceneGLES2::reflection_probe_instance_begin_render(RID p_instance
 
 		//the approach below is fatal for powervr
 
-		// Set the initial (empty) mipmaps, all need to be set for this to work in GLES2, even if later wont be used.
+		// Set the initial (empty) mipmaps, all need to be set for this to work in GLES2, even if they won't be used later.
 		while (size >= 1) {
 
 			for (int i = 0; i < 6; i++) {

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -347,7 +347,7 @@ void main() {
 	vec4 color = color_interp;
 	vec2 uv = uv_interp;
 #ifdef USE_FORCE_REPEAT
-	//needs to use this to workaround GLES2/WebGL1 forcing tiling that textures that dont support it
+	//needs to use this to workaround GLES2/WebGL1 forcing tiling that textures that don't support it
 	uv = mod(uv, vec2(1.0, 1.0));
 #endif
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3520,7 +3520,7 @@ void AnimationTrackEditor::_update_tracks() {
 void AnimationTrackEditor::_animation_changed() {
 
 	if (animation_changing_awaiting_update) {
-		return; //all will be updated, dont bother with anything
+		return; //all will be updated, don't bother with anything
 	}
 
 	if (key_edit && key_edit->setting) {

--- a/editor/doc/doc_dump.cpp
+++ b/editor/doc/doc_dump.cpp
@@ -111,7 +111,7 @@ void DocDump::dump(const String &p_file) {
 
 		for (List<MethodInfo>::Element *E = method_list.front(); E; E = E->next()) {
 			if (E->get().name == "" || E->get().name[0] == '_')
-				continue; //hiden
+				continue; //hidden
 
 			MethodBind *m = ClassDB::get_method(name, E->get().name);
 

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -322,13 +322,13 @@ void EditorAudioBus::_volume_changed(float p_normalized) {
 
 float EditorAudioBus::_normalized_volume_to_scaled_db(float normalized) {
 	/* There are three different formulas for the conversion from normalized
-     * values to relative decibal values.
-     * One formula is an exponential graph which intends to counteract
-     * the logorithmic nature of human hearing. This is an approximation
-     * of the behaviour of a 'logarithmic potentiometer' found on most
-     * musical instruments and also emulated in popular software.
-     * The other two equations are hand-tuned linear tapers that intend to
-     * try to ease the exponential equation in areas where it makes sense.*/
+	 * values to relative decibal values.
+	 * One formula is an exponential graph which intends to counteract
+	 * the logorithmic nature of human hearing. This is an approximation
+	 * of the behaviour of a 'logarithmic potentiometer' found on most
+	 * musical instruments and also emulated in popular software.
+	 * The other two equations are hand-tuned linear tapers that intend to
+	 * try to ease the exponential equation in areas where it makes sense.*/
 
 	if (normalized > 0.6f) {
 		return 22.22f * normalized - 16.2f;
@@ -341,16 +341,16 @@ float EditorAudioBus::_normalized_volume_to_scaled_db(float normalized) {
 
 float EditorAudioBus::_scaled_db_to_normalized_volume(float db) {
 	/* Inversion of equations found in _normalized_volume_to_scaled_db.
-     * IMPORTANT: If one function changes, the other much change to reflect it. */
+	 * IMPORTANT: If one function changes, the other much change to reflect it. */
 	if (db > -2.88) {
 		return (db + 16.2f) / 22.22f;
 	} else if (db < -38.602f) {
 		return (db + 80.00f) / 830.72f;
 	} else {
 		if (db < 0.0) {
-			/* To acommodate for NaN on negative numbers for root, we will mirror the
-             * results of the postive db range in order to get the desired numerical
-             * value on the negative side. */
+			/* To accommodate for NaN on negative numbers for root, we will mirror the
+			 * results of the positive db range in order to get the desired numerical
+			 * value on the negative side. */
 			float positive_x = Math::pow(Math::abs(db) / 45.0f, 1.0f / 3.0f) + 1.0f;
 			Vector2 translation = Vector2(1.0f, 0.0f) - Vector2(positive_x, Math::abs(db));
 			Vector2 reflected_position = Vector2(1.0, 0.0f) + translation;

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -218,7 +218,7 @@ void EditorFileSystem::_scan_filesystem() {
 				if (first_scan) {
 					// only use this on first scan, afterwards it gets ignored
 					// this is so on first reimport we synchronize versions, then
-					// we dont care until editor restart. This is for usability mainly so
+					// we don't care until editor restart. This is for usability mainly so
 					// your workflow is not killed after changing a setting by forceful reimporting
 					// everything there is.
 					filesystem_settings_version_for_import = l.strip_edges();

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -645,7 +645,7 @@ void EditorPropertyDictionary::update_property() {
 			page->set_h_size_flags(SIZE_EXPAND_FILL);
 			page->connect("value_changed", this, "_page_changed");
 		} else {
-			// Queue childs for deletion, delete immediately might cause errors.
+			// Queue children for deletion, deleting immediately might cause errors.
 			for (int i = 1; i < vbox->get_child_count(); i++) {
 				vbox->get_child(i)->queue_delete();
 			}

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -566,7 +566,7 @@ Error ExportTemplateManager::install_android_template() {
 		f->close();
 	}
 	{
-		//add version, to ensure building wont work if template and Godot version are mismatch
+		//add version, to ensure building won't work if template and Godot version don't match
 		FileAccessRef f = FileAccess::open("res://android/.build_version", FileAccess::WRITE);
 		ERR_FAIL_COND_V(!f, ERR_CANT_CREATE);
 		f->store_line(VERSION_FULL_CONFIG);
@@ -636,7 +636,7 @@ Error ExportTemplateManager::install_android_template() {
 				FileAccess::set_unix_permissions(to_write, (info.external_fa >> 16) & 0x01FF);
 #endif
 			} else {
-				ERR_PRINTS("Cant uncompress file: " + to_write);
+				ERR_PRINTS("Can't uncompress file: " + to_write);
 			}
 		}
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -90,7 +90,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 			String file_type = p_dir->get_file_type(i);
 
 			if (_is_file_type_disabled_by_feature_profile(file_type)) {
-				//if type is disabled, file wont be displayed.
+				//if type is disabled, file won't be displayed.
 				continue;
 			}
 			String file_name = p_dir->get_file(i);

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -81,7 +81,7 @@ void ResourceImporterTexture::_texture_reimport_normal(const Ref<StreamTexture> 
 void ResourceImporterTexture::update_imports() {
 
 	if (EditorFileSystem::get_singleton()->is_scanning() || EditorFileSystem::get_singleton()->is_importing()) {
-		return; // do nothing for noe
+		return; // do nothing for now
 	}
 	mutex->lock();
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -1654,7 +1654,7 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 				edited_collision_shape = _convex;
 				_set_edited_shape_points(_get_collision_shape_points(concave));
 			} else {
-				// Shoudn't haphen
+				// Shouldn't happen
 			}
 			for (int i = 0; i < sd.size(); i++) {
 				if (sd[i].get("shape") == previous_shape) {
@@ -1892,7 +1892,7 @@ void TileSetEditor::_update_toggle_shape_button() {
 		tools[SHAPE_TOGGLE_TYPE]->set_icon(get_icon("ConcavePolygonShape2D", "EditorIcons"));
 		tools[SHAPE_TOGGLE_TYPE]->set_text("Make Concave");
 	} else {
-		// Shoudn't happen
+		// Shouldn't happen
 		separator_shape_toggle->hide();
 		tools[SHAPE_TOGGLE_TYPE]->hide();
 	}

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -49,7 +49,7 @@ Node *SceneTreeEditor::get_scene_node() {
 void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_id) {
 
 	if (connect_to_script_mode) {
-		return; //dont do anything in this mode
+		return; //don't do anything in this mode
 	}
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!item);

--- a/editor/translations/editor.pot
+++ b/editor/translations/editor.pot
@@ -9860,7 +9860,7 @@ msgstr ""
 msgid ""
 "Container by itself serves no purpose unless a script configures it's "
 "children placement behavior.\n"
-"If you dont't intend to add a script, then please use a plain 'Control' node "
+"If you don't intend to add a script, then please use a plain 'Control' node "
 "instead."
 msgstr ""
 

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -310,8 +310,8 @@ void EditorSceneImporterAssimp::_generate_bone_groups(ImportState &state, const 
 			const aiBone *bone = mesh->mBones[j];
 			String name = _assimp_get_string(bone->mName);
 			ownership[name] = owned_by;
-			//store the actuall full path for the bone transform
-			//when skeleton finds it's place in the tree, it will be restored
+			//store the actual full path for the bone transform
+			//when skeleton finds its place in the tree, it will be restored
 			bind_xforms[name] = mesh_offset * _assimp_matrix_transform(bone->mOffsetMatrix);
 		}
 	}
@@ -1460,7 +1460,7 @@ void EditorSceneImporterAssimp::_generate_node(ImportState &state, const aiNode 
 				int mesh_index = p_assimp_node->mMeshes[i];
 				surface_indices.push_back(mesh_index);
 
-				//take the chane and attempt to find the skeleton from the bones
+				//take the chance and attempt to find the skeleton from the bones
 				if (!skeleton) {
 					aiMesh *ai_mesh = state.assimp_scene->mMeshes[p_assimp_node->mMeshes[i]];
 					for (uint32_t j = 0; j < ai_mesh->mNumBones; j++) {
@@ -1598,7 +1598,7 @@ void EditorSceneImporterAssimp::_generate_node(ImportState &state, const aiNode 
 
 		skeleton->localize_rests();
 		node_name = "Skeleton"; //don't use the bone root name
-		node_transform = Transform(); //dont transform
+		node_transform = Transform(); //don't transform
 
 		new_node = skeleton;
 	} else {

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -1152,7 +1152,7 @@ public:
 
 bool SpaceBullet::recover_from_penetration(RigidBodyBullet *p_body, const btTransform &p_body_position, btScalar p_recover_movement_scale, bool p_infinite_inertia, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result) {
 
-	// Calculate the cummulative AABB of all shapes of the kinematic body
+	// Calculate the cumulative AABB of all shapes of the kinematic body
 	btVector3 aabb_min, aabb_max;
 	bool shapes_found = false;
 
@@ -1347,7 +1347,7 @@ int SpaceBullet::add_separation_result(PhysicsServer::SeparationResult *r_result
 
 int SpaceBullet::recover_from_penetration_ray(RigidBodyBullet *p_body, const btTransform &p_body_position, btScalar p_recover_movement_scale, bool p_infinite_inertia, int p_result_max, btVector3 &r_delta_recover_movement, PhysicsServer::SeparationResult *r_results) {
 
-	// Calculate the cummulative AABB of all shapes of the kinematic body
+	// Calculate the cumulative AABB of all shapes of the kinematic body
 	btVector3 aabb_min, aabb_max;
 	bool shapes_found = false;
 

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -611,7 +611,7 @@ void CSGBrushOperation::_add_poly_points(const BuildPoly &p_poly, int p_edge, in
 
 	{
 		EdgeSort es;
-		es.angle = 0; //wont be checked here
+		es.angle = 0; //won't be checked here
 		es.edge = p_edge;
 		es.prev_point = p_from_point;
 		es.edge_point = p_to_point;

--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -110,7 +110,7 @@
 			Always use [code]TRANSFER_MODE_ORDERED[/code] in place of [code]TRANSFER_MODE_UNRELIABLE[/code]. This is the only way to use ordering with the RPC system.
 		</member>
 		<member name="channel_count" type="int" setter="set_channel_count" getter="get_channel_count">
-			The number of channels to be used by ENet. Default: [code]3[/code]. Channels are used to separate different kinds of data. In realiable or ordered mode, for example, the packet delivery order is ensured on a per channel basis.
+			The number of channels to be used by ENet. Default: [code]3[/code]. Channels are used to separate different kinds of data. In reliable or ordered mode, for example, the packet delivery order is ensured on a per channel basis.
 		</member>
 		<member name="compression_mode" type="int" setter="set_compression_mode" getter="get_compression_mode" enum="NetworkedMultiplayerENet.CompressionMode">
 			The compression method used for network packets. Default is no compression. These have different tradeoffs of compression speed versus bandwidth, you may need to test which one works best for your use case if you use compression at all.

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -231,7 +231,7 @@ void NetworkedMultiplayerENet::poll() {
 					break;
 				}
 
-				// A client joined with an invalid ID (neagtive values, 0, and 1 are reserved).
+				// A client joined with an invalid ID (negative values, 0, and 1 are reserved).
 				// Probably trying to exploit us.
 				if (server && ((int)event.data < 2 || peer_map.has((int)event.data))) {
 					enet_peer_reset(event.peer);

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -404,7 +404,7 @@ bool GDNative::terminate() {
 		} else if (gdnatives->size() == 1) {
 			// we're the last one, terminate!
 			gdnatives->clear();
-			// wew this looks scary, but all it does is remove the entry completely
+			// whew this looks scary, but all it does is remove the entry completely
 			GDNativeLibrary::loaded_libraries->erase(GDNativeLibrary::loaded_libraries->find(library->get_current_library_path()));
 		}
 	}

--- a/modules/gdnative/pluginscript/pluginscript_instance.h
+++ b/modules/gdnative/pluginscript/pluginscript_instance.h
@@ -62,7 +62,7 @@ public:
 	virtual Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 #if 0
     // Rely on default implementations provided by ScriptInstance for the moment.
-    // Note that multilevel call could be removed in 3.0 release, so stay tunned
+    // Note that multilevel call could be removed in 3.0 release, so stay tuned
     // (see https://godotengine.org/qa/9244/can-override-the-_ready-and-_process-functions-child-classes)
     virtual void call_multilevel(const StringName& p_method,const Variant** p_args,int p_argcount);
     virtual void call_multilevel_reversed(const StringName& p_method,const Variant** p_args,int p_argcount);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1064,7 +1064,7 @@ Variant::Type GDScriptInstance::get_property_type(const StringName &p_name, bool
 }
 
 void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const {
-	// exported members, not doen yet!
+	// exported members, not done yet!
 
 	const GDScript *sptr = script.ptr();
 	List<PropertyInfo> props;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -7473,7 +7473,7 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 						return;
 					}
 
-					// Replace assignment with implict conversion
+					// Replace assignment with implicit conversion
 					BuiltInFunctionNode *convert = alloc_node<BuiltInFunctionNode>();
 					convert->line = v.line;
 					convert->function = GDScriptFunctions::TYPE_CONVERT;
@@ -7837,14 +7837,14 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 						if (_is_type_compatible(assign_type, lv->datatype)) {
 							_mark_line_as_unsafe(lv->line);
 						} else {
-							// Try implict conversion
+							// Try implicit conversion
 							if (lv->datatype.kind != DataType::BUILTIN || !_is_type_compatible(lv->datatype, assign_type, true)) {
 								_set_error("Assigned value type (" + assign_type.to_string() + ") doesn't match the variable's type (" +
 												   lv->datatype.to_string() + ").",
 										lv->line);
 								return;
 							}
-							// Replace assignment with implict conversion
+							// Replace assignment with implicit conversion
 							BuiltInFunctionNode *convert = alloc_node<BuiltInFunctionNode>();
 							convert->line = lv->line;
 							convert->function = GDScriptFunctions::TYPE_CONVERT;
@@ -7968,14 +7968,14 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 							if (_is_type_compatible(rh_type, lh_type)) {
 								_mark_line_as_unsafe(op->line);
 							} else {
-								// Try implict conversion
+								// Try implicit conversion
 								if (lh_type.kind != DataType::BUILTIN || !_is_type_compatible(lh_type, rh_type, true)) {
 									_set_error("Assigned value type (" + rh_type.to_string() + ") doesn't match the variable's type (" +
 													   lh_type.to_string() + ").",
 											op->line);
 									return;
 								}
-								// Replace assignment with implict conversion
+								// Replace assignment with implicit conversion
 								BuiltInFunctionNode *convert = alloc_node<BuiltInFunctionNode>();
 								convert->line = op->line;
 								convert->function = GDScriptFunctions::TYPE_CONVERT;

--- a/modules/mono/glue/Managed/Files/DynamicObject.cs
+++ b/modules/mono/glue/Managed/Files/DynamicObject.cs
@@ -202,7 +202,7 @@ namespace Godot
         //public override bool TryDeleteIndex(DeleteIndexBinder binder, object[] indexes);
         //public override bool TryDeleteMember(DeleteMemberBinder binder);
 
-        // Invokation on the object itself, e.g.: obj(param)
+        // Invocation on the object itself, e.g.: obj(param)
         //public override bool TryInvoke(InvokeBinder binder, object[] args, out object result);
 
         // No unnary operations to handle

--- a/platform/android/java/AndroidManifest.xml
+++ b/platform/android/java/AndroidManifest.xml
@@ -22,7 +22,7 @@
 <!--Anything in this line after the icon will be erased when doing custom build. If you want to add tags manually, do before it.-->
     <application android:label="@string/godot_project_name_string" android:allowBackup="false" tools:ignore="GoogleAppIndexingWarning" android:icon="@drawable/icon">
 
-<!--The following values are replaced when Godot exports, modifying them here has no effect. Do theses changes in the-->
+<!--The following values are replaced when Godot exports, modifying them here has no effect. Do these changes in the-->
 <!--export preset. Adding new ones is fine.-->
 
         <activity android:name="org.godotengine.godot.Godot"

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -35,7 +35,7 @@
 #include <jni.h>
 
 // These functions can be called from within JAVA and are the means by which our JAVA implementation calls back into our C++ code.
-// See java/src/org/godotengine/godot/GodotLib.java for the JAVA side of this (yes thats why we have the long names)
+// See java/src/org/godotengine/godot/GodotLib.java for the JAVA side of this (yes that's why we have the long names)
 extern "C" {
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *env, jobject obj, jobject activity, jobject p_asset_manager, jboolean p_use_apk_expansion);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ondestroy(JNIEnv *env);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -705,7 +705,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 					}
 				}
 			} else if (mouse_mode != MOUSE_MODE_CAPTURED) {
-				// for reasons unknown to mankind, wheel comes in screen cordinates
+				// for reasons unknown to mankind, wheel comes in screen coordinates
 				POINT coords;
 				coords.x = mb->get_position().x;
 				coords.y = mb->get_position().y;

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -978,7 +978,7 @@ void CPUParticles2D::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_DRAW) {
 		if (!redraw)
-			return; // dont add to render list
+			return; // don't add to render list
 
 		RID texrid;
 		if (texture.is_valid()) {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -491,7 +491,7 @@ void TileMap::update_dirty_quadrants() {
 									shape_idx++;
 #ifdef DEBUG_ENABLED
 								} else {
-									print_error("The TileSet asigned to the TileMap " + get_name() + " has an invalid convex shape.");
+									print_error("The TileSet assigned to the TileMap " + get_name() + " has an invalid convex shape.");
 #endif
 								}
 							}

--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -162,7 +162,7 @@ void Skeleton::_update_process_order() {
 	//now check process order
 	int pass_count = 0;
 	while (pass_count < len * len) {
-		//using bubblesort because of simplicity, it wont run every frame though.
+		//using bubblesort because of simplicity, it won't run every frame though.
 		//bublesort worst case is O(n^2), and this may be an infinite loop if cyclic
 		bool swapped = false;
 		for (int i = 0; i < len; i++) {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1200,7 +1200,7 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 			// Animation reset BUT played backwards, set position to the end
 			c.current.pos = c.current.from->animation->get_length();
 		} else if (!p_from_end && c.current.pos == c.current.from->animation->get_length()) {
-			// Animation resumed but already ended, set position to the beggining
+			// Animation resumed but already ended, set position to the beginning
 			c.current.pos = 0;
 		}
 	}

--- a/scene/animation/skeleton_ik.cpp
+++ b/scene/animation/skeleton_ik.cpp
@@ -37,20 +37,20 @@
 #ifndef _3D_DISABLED
 
 FabrikInverseKinematic::ChainItem *FabrikInverseKinematic::ChainItem::find_child(const BoneId p_bone_id) {
-	for (int i = childs.size() - 1; 0 <= i; --i) {
-		if (p_bone_id == childs[i].bone) {
-			return &childs.write[i];
+	for (int i = children.size() - 1; 0 <= i; --i) {
+		if (p_bone_id == children[i].bone) {
+			return &children.write[i];
 		}
 	}
 	return NULL;
 }
 
 FabrikInverseKinematic::ChainItem *FabrikInverseKinematic::ChainItem::add_child(const BoneId p_bone_id) {
-	const int infant_child_id = childs.size();
-	childs.resize(infant_child_id + 1);
-	childs.write[infant_child_id].bone = p_bone_id;
-	childs.write[infant_child_id].parent_item = this;
-	return &childs.write[infant_child_id];
+	const int infant_child_id = children.size();
+	children.resize(infant_child_id + 1);
+	children.write[infant_child_id].bone = p_bone_id;
+	children.write[infant_child_id].parent_item = this;
+	return &children.write[infant_child_id];
 }
 
 /// Build a chain that starts from the root to tip
@@ -144,8 +144,8 @@ void FabrikInverseKinematic::update_chain(const Skeleton *p_sk, ChainItem *p_cha
 	p_chain_item->initial_transform = p_sk->get_bone_global_pose(p_chain_item->bone);
 	p_chain_item->current_pos = p_chain_item->initial_transform.origin;
 
-	for (int i = p_chain_item->childs.size() - 1; 0 <= i; --i) {
-		update_chain(p_sk, &p_chain_item->childs.write[i]);
+	for (int i = p_chain_item->children.size() - 1; 0 <= i; --i) {
+		update_chain(p_sk, &p_chain_item->children.write[i]);
 	}
 }
 
@@ -210,9 +210,9 @@ void FabrikInverseKinematic::solve_simple_forwards(Chain &r_chain, bool p_solve_
 	while (sub_chain_root) { // Reach the tip
 		sub_chain_root->current_pos = origin;
 
-		if (!sub_chain_root->childs.empty()) {
+		if (!sub_chain_root->children.empty()) {
 
-			ChainItem &child(sub_chain_root->childs.write[0]);
+			ChainItem &child(sub_chain_root->children.write[0]);
 
 			// Is not tip
 			// So calculate next origin location
@@ -302,10 +302,10 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 		Transform new_bone_pose(ci->initial_transform);
 		new_bone_pose.origin = ci->current_pos;
 
-		if (!ci->childs.empty()) {
+		if (!ci->children.empty()) {
 
 			/// Rotate basis
-			const Vector3 initial_ori((ci->childs[0].initial_transform.origin - ci->initial_transform.origin).normalized());
+			const Vector3 initial_ori((ci->children[0].initial_transform.origin - ci->initial_transform.origin).normalized());
 			const Vector3 rot_axis(initial_ori.cross(ci->current_ori).normalized());
 
 			if (rot_axis[0] != 0 && rot_axis[1] != 0 && rot_axis[2] != 0) {
@@ -322,8 +322,8 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 
 		p_task->skeleton->set_bone_global_pose(ci->bone, new_bone_pose);
 
-		if (!ci->childs.empty())
-			ci = &ci->childs.write[0];
+		if (!ci->children.empty())
+			ci = &ci->children.write[0];
 		else
 			ci = NULL;
 	}

--- a/scene/animation/skeleton_ik.h
+++ b/scene/animation/skeleton_ik.h
@@ -49,7 +49,7 @@ class FabrikInverseKinematic {
 
 	struct ChainItem {
 
-		Vector<ChainItem> childs;
+		Vector<ChainItem> children;
 		ChainItem *parent_item;
 
 		// Bone info

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -177,7 +177,7 @@ String Container::get_configuration_warning() const {
 		if (warning != String()) {
 			warning += "\n";
 		}
-		warning += TTR("Container by itself serves no purpose unless a script configures it's children placement behavior.\nIf you dont't intend to add a script, then please use a plain 'Control' node instead.");
+		warning += TTR("Container by itself serves no purpose unless a script configures it's children placement behavior.\nIf you don't intend to add a script, then please use a plain 'Control' node instead.");
 	}
 	return warning;
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3603,7 +3603,7 @@ void TextEdit::_insert_text(int p_line, int p_char, const String &p_text, int *r
 	op.chain_forward = false;
 	op.chain_backward = false;
 
-	//see if it shold just be set as current op
+	//see if it should just be set as current op
 	if (current_op.type != op.type) {
 		op.prev_version = get_version();
 		_push_current_op();
@@ -3654,7 +3654,7 @@ void TextEdit::_remove_text(int p_from_line, int p_from_column, int p_to_line, i
 	op.chain_forward = false;
 	op.chain_backward = false;
 
-	//see if it shold just be set as current op
+	//see if it should just be set as current op
 	if (current_op.type != op.type) {
 		op.prev_version = get_version();
 		_push_current_op();

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -115,7 +115,7 @@ void SurfaceTool::add_vertex(const Vector3 &p_vertex) {
 		//ensure vertices are the expected amount
 		ERR_FAIL_COND(vtx.weights.size() != vtx.bones.size());
 		if (vtx.weights.size() < expected_vertices) {
-			//less than requred, fill
+			//less than required, fill
 			for (int i = vtx.weights.size(); i < expected_vertices; i++) {
 				vtx.weights.push_back(0);
 				vtx.bones.push_back(0);

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -112,7 +112,7 @@ void AudioEffectSpectrumAnalyzerInstance::process(const AudioFrame *p_src_frames
 	}
 
 	//determine time of capture
-	double remainer_sec = (temporal_fft_pos / mix_rate); //substract remainder from mix time
+	double remainer_sec = (temporal_fft_pos / mix_rate); //subtract remainder from mix time
 	last_fft_time = time - uint64_t(remainer_sec * 1000000.0);
 }
 

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -795,7 +795,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 						cbk.valid_dir = col_obj_shape_xform.get_axis(1).normalized();
 
 						float owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);
-						cbk.valid_depth = MAX(owc_margin, p_margin); //user specified, but never less than actual margin or it wont work
+						cbk.valid_depth = MAX(owc_margin, p_margin); //user specified, but never less than actual margin or it won't work
 						cbk.invalid_by_dir = 0;
 
 						if (col_obj->get_type() == CollisionObject2DSW::TYPE_BODY) {

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -616,7 +616,7 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 					else
 						tk.type = TK_INT_CONSTANT;
 
-					tk.constant = str.to_double(); //wont work with hex
+					tk.constant = str.to_double(); //won't work with hex
 					tk.line = tk_line;
 
 					return tk;


### PR DESCRIPTION
Using codespell 1.15.0.

Method:
```
$ cat > ../godot-word-whitelist.txt << EOF
ang
curvelinear
doubleclick
leapyear
lod
merchantibility
nd
numer
ois
ony
que
seeked
synching
te
uint
unselect
webp
EOF

$ codespell -w -q 3 -I ../godot-word-whitelist.txt --skip="./thirdparty,*.po"
$ git diff // undo unwanted changes
```