### PR TITLE
Use highp precision in the gles2 fragment shader if available

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -316,9 +316,14 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 			for (Map<StringName, SL::ShaderNode::Uniform>::Element *E = snode->uniforms.front(); E; E = E->next()) {
 				StringBuffer<> uniform_code;
 
-				uniform_code += "uniform ";
+				// use highp if no precision is specified to prevent different default values in fragment and vertex shader
+				SL::DataPrecision precision = E->get().precision;
+				if (precision == SL::PRECISION_DEFAULT) {
+					precision = SL::PRECISION_HIGHP;
+				}
 
-				uniform_code += _prestr(E->get().precision);
+				uniform_code += "uniform ";
+				uniform_code += _prestr(precision);
 				uniform_code += _typestr(E->get().type);
 				uniform_code += " ";
 				uniform_code += _mkid(E->key());


### PR DESCRIPTION
This fixes #28199.

The problem was, that the custom shader code (uniforms starting with m_; added via ShaderCompilerGLES2) did not have explicit precision types set, so the default ones for the fragmant shader (mediump) were used while the vertex used highp.
The specs say, that uniforms should have the same precision.

See the specs (4.5.3 Default Precision Qualifiers):
https://www.khronos.org/registry/OpenGL/specs/es/2.0/GLSL_ES_Specification_1.00.pdf

This fix uses highp for the fragment shader by default (if available).
Another possiblity which also works whould be to set the default precision in the vertex shader to mediump for ints and floats.