### PR TITLE
[StateMachine] Fix error message for travel method

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -314,8 +314,9 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *sm, 
 
 		if (start_request_travel) {
 			if (!playing) {
+				String node_name = start_request;
 				start_request = StringName();
-				ERR_EXPLAIN("Can't travel to '" + String(start_request) + "' if state machine is not active.");
+				ERR_EXPLAIN("Can't travel to '" + node_name + "' if state machine is not playing.");
 				ERR_FAIL_V(0);
 			}
 


### PR DESCRIPTION
Fix #28969

I've changed `active` to `playing` because I think it will be more explicit to users that this can be verified with the `is_playing` method.