### PR TITLE
[Mono] Misc Basis and AABB improvements

### DIFF
--- a/modules/mono/glue/Managed/Files/AABB.cs
+++ b/modules/mono/glue/Managed/Files/AABB.cs
@@ -414,6 +414,21 @@ namespace Godot
             _position = position;
             _size = size;
         }
+        public AABB(Vector3 position, real_t width, real_t height, real_t depth)
+        {
+            _position = position;
+            _size = new Vector3(width, height, depth);
+        }
+        public AABB(real_t x, real_t y, real_t z, Vector3 size)
+        {
+            _position = new Vector3(x, y, z);
+            _size = size;
+        }
+        public AABB(real_t x, real_t y, real_t z, real_t width, real_t height, real_t depth)
+        {
+            _position = new Vector3(x, y, z);
+            _size = new Vector3(width, height, depth);
+        }
 
         public static bool operator ==(AABB left, AABB right)
         {

--- a/modules/mono/glue/Managed/Files/Basis.cs
+++ b/modules/mono/glue/Managed/Files/Basis.cs
@@ -260,13 +260,13 @@ namespace Godot
             Vector3 euler;
             euler.z = 0.0f;
 
-            real_t mxy = m.Row1[2];
+            real_t mzy = m.Row1[2];
 
-            if (mxy < 1.0f)
+            if (mzy < 1.0f)
             {
-                if (mxy > -1.0f)
+                if (mzy > -1.0f)
                 {
-                    euler.x = Mathf.Asin(-mxy);
+                    euler.x = Mathf.Asin(-mzy);
                     euler.y = Mathf.Atan2(m.Row0[2], m.Row2[2]);
                     euler.z = Mathf.Atan2(m.Row1[0], m.Row1[1]);
                 }
@@ -418,19 +418,11 @@ namespace Godot
 
         public Basis Scaled(Vector3 scale)
         {
-            var m = this;
-
-            m.Row0[0] *= scale.x;
-            m.Row0[1] *= scale.x;
-            m.Row0[2] *= scale.x;
-            m.Row1[0] *= scale.y;
-            m.Row1[1] *= scale.y;
-            m.Row1[2] *= scale.y;
-            m.Row2[0] *= scale.z;
-            m.Row2[1] *= scale.z;
-            m.Row2[2] *= scale.z;
-
-            return m;
+            var b = this;
+            b.Row0 *= scale.x;
+            b.Row1 *= scale.y;
+            b.Row2 *= scale.z;
+            return b;
         }
 
         public real_t Tdotx(Vector3 with)
@@ -622,11 +614,12 @@ namespace Godot
             // We need to assign the struct fields here first so we can't do it that way...
         }
 
-        internal Basis(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_t yz, real_t zx, real_t zy, real_t zz)
+        // Arguments are named such that xy is equal to calling x.y
+        internal Basis(real_t xx, real_t yx, real_t zx, real_t xy, real_t yy, real_t zy, real_t xz, real_t yz, real_t zz)
         {
-            Row0 = new Vector3(xx, xy, xz);
-            Row1 = new Vector3(yx, yy, yz);
-            Row2 = new Vector3(zx, zy, zz);
+            Row0 = new Vector3(xx, yx, zx);
+            Row1 = new Vector3(xy, yy, zy);
+            Row2 = new Vector3(xz, yz, zz);
         }
 
         public static Basis operator *(Basis left, Basis right)

--- a/modules/mono/glue/Managed/Files/Transform2D.cs
+++ b/modules/mono/glue/Managed/Files/Transform2D.cs
@@ -298,6 +298,7 @@ namespace Godot
             origin = originPos;
         }
 
+        // Arguments are named such that xy is equal to calling x.y
         public Transform2D(real_t xx, real_t xy, real_t yx, real_t yy, real_t ox, real_t oy)
         {
             x = new Vector2(xx, xy);


### PR DESCRIPTION
User-facing changes:

* `AABB` constructors to match with `Rect2` constructors.

Internal changes in Basis:

* Optimize `Scaled()` (or at least, reduce number of lines of code).
* Be consistent with `xy` etc in the internal constructor such that `xy` is equal to `x.y`. `Transform2D` already uses this naming system. Behavior is unchanged.
* Change misleading name of `mxy` which was `m.z.y`, now it's `mzy`.