### PR TITLE
SCons: Keep exceptions and rtti on Android, iOS and HTML5 tools build

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -214,13 +214,14 @@ def configure(env):
     lib_sysroot = env["ANDROID_NDK_ROOT"] + "/platforms/" + env['ndk_platform'] + "/" + env['ARCH']
 
     ## Compile flags
-
-    if env['android_stl']:
+    # Disable exceptions and rtti on non-tools (template) builds
+    if env['tools'] or env['android_stl']:
         env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++/include"])
         env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++abi/include"])
         env.Append(CXXFLAGS=['-frtti', "-std=gnu++14"])
     else:
         env.Append(CXXFLAGS=['-fno-rtti', '-fno-exceptions'])
+        # Don't use dynamic_cast, necessary with no-rtti.
         env.Append(CPPFLAGS=['-DNO_SAFE_CAST'])
 
     ndk_version = get_ndk_version(env["ANDROID_NDK_ROOT"])

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -115,10 +115,12 @@ def configure(env):
         env.Append(CPPFLAGS=['-DNEED_LONG_INT'])
         env.Append(CPPFLAGS=['-DLIBYUV_DISABLE_NEON'])
 
-    if env['ios_exceptions']:
-        env.Append(CCFLAGS=['-fexceptions'])
-    else:
-        env.Append(CCFLAGS=['-fno-exceptions'])
+    # Disable exceptions on non-tools (template) builds
+    if not env['tools']:
+        if env['ios_exceptions']:
+            env.Append(CCFLAGS=['-fexceptions'])
+        else:
+            env.Append(CCFLAGS=['-fno-exceptions'])
 
     ## Link flags
 

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -110,10 +110,12 @@ def configure(env):
     # once feasible also consider memory buffer size issues.
     env.Append(CPPDEFINES=['NO_THREADS'])
 
-    # These flags help keep the file size down.
-    env.Append(CCFLAGS=['-fno-exceptions', '-fno-rtti'])
-    # Don't use dynamic_cast, necessary with no-rtti.
-    env.Append(CPPDEFINES=['NO_SAFE_CAST'])
+    # Disable exceptions and rtti on non-tools (template) builds
+    if not env['tools']:
+        # These flags help keep the file size down.
+        env.Append(CCFLAGS=['-fno-exceptions', '-fno-rtti'])
+        # Don't use dynamic_cast, necessary with no-rtti.
+        env.Append(CPPDEFINES=['NO_SAFE_CAST'])
 
     if env['javascript_eval']:
         env.Append(CPPDEFINES=['JAVASCRIPT_EVAL_ENABLED'])


### PR DESCRIPTION
Those were disable to keep size small, and on Android avoid the dependency on the STL,
but for tools build (editor) this is not really a concern.

Note: as of today it's not possible to build tools=yes for those platforms, but this
change is one of the necessary steps to enable it.

Fixes #25262.