### PR TITLE
add const to methods that return literals

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -273,7 +273,7 @@ public:
 	virtual String get_environment(const String &p_var) const = 0;
 	virtual bool set_environment(const String &p_var, const String &p_value) const = 0;
 
-	virtual String get_name() = 0;
+	virtual String get_name() const = 0;
 	virtual List<String> get_cmdline_args() const { return _cmdline; }
 	virtual String get_model_name() const;
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -170,7 +170,7 @@ String OS_Unix::get_stdin_string(bool p_block) {
 	return "";
 }
 
-String OS_Unix::get_name() {
+String OS_Unix::get_name() const {
 
 	return "Unix";
 }

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -76,7 +76,7 @@ public:
 
 	virtual Error set_cwd(const String &p_cwd);
 
-	virtual String get_name();
+	virtual String get_name() const;
 
 	virtual Date get_date(bool utc) const;
 	virtual Time get_time(bool utc) const;

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -330,7 +330,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 	return color_map;
 }
 
-String GDScriptSyntaxHighlighter::get_name() {
+String GDScriptSyntaxHighlighter::get_name() const {
 	return "GDScript";
 }
 

--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -65,7 +65,7 @@ public:
 	virtual void _update_cache();
 	virtual Map<int, TextEdit::HighlighterInfo> _get_line_syntax_highlighting(int p_line);
 
-	virtual String get_name();
+	virtual String get_name() const;
 	virtual List<String> get_supported_languages();
 };
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -277,7 +277,7 @@ Size2 OS_Android::get_window_size() const {
 	return Vector2(default_videomode.width, default_videomode.height);
 }
 
-String OS_Android::get_name() {
+String OS_Android::get_name() const {
 
 	return "Android";
 }

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -139,7 +139,7 @@ public:
 
 	virtual Size2 get_window_size() const;
 
-	virtual String get_name();
+	virtual String get_name() const;
 	virtual MainLoop *get_main_loop() const;
 
 	virtual bool can_draw() const;

--- a/platform/haiku/os_haiku.cpp
+++ b/platform/haiku/os_haiku.cpp
@@ -69,7 +69,7 @@ void OS_Haiku::run() {
 	main_loop->finish();
 }
 
-String OS_Haiku::get_name() {
+String OS_Haiku::get_name() const {
 	return "Haiku";
 }
 

--- a/platform/haiku/os_haiku.h
+++ b/platform/haiku/os_haiku.h
@@ -74,7 +74,7 @@ public:
 	OS_Haiku();
 	void run();
 
-	virtual String get_name();
+	virtual String get_name() const;
 
 	virtual MainLoop *get_main_loop() const;
 

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -495,7 +495,7 @@ String OSIPhone::get_user_data_dir() const {
 	return data_dir;
 };
 
-String OSIPhone::get_name() {
+String OSIPhone::get_name() const {
 
 	return "iOS";
 };

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -174,7 +174,7 @@ public:
 
 	void set_data_dir(String p_dir);
 
-	virtual String get_name();
+	virtual String get_name() const;
 
 	Error shell_open(String p_uri);
 

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -1159,7 +1159,7 @@ Error OS_JavaScript::shell_open(String p_uri) {
 	return OK;
 }
 
-String OS_JavaScript::get_name() {
+String OS_JavaScript::get_name() const {
 
 	return "HTML5";
 }

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -146,7 +146,7 @@ public:
 	virtual void set_icon(const Ref<Image> &p_icon);
 	String get_executable_path() const;
 	virtual Error shell_open(String p_uri);
-	virtual String get_name();
+	virtual String get_name() const;
 	virtual bool can_draw() const;
 
 	virtual String get_resource_dir() const;

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -165,7 +165,7 @@ public:
 
 	void wm_minimized(bool p_minimized);
 
-	virtual String get_name();
+	virtual String get_name() const;
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1551,7 +1551,7 @@ void OS_OSX::delete_main_loop() {
 	main_loop = NULL;
 }
 
-String OS_OSX::get_name() {
+String OS_OSX::get_name() const {
 
 	return "OSX";
 }

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -190,7 +190,7 @@ bool OS_Server::can_draw() const {
 	return false; //can never draw
 };
 
-String OS_Server::get_name() {
+String OS_Server::get_name() const {
 
 	return "Server";
 }

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -93,7 +93,7 @@ protected:
 	virtual void set_main_loop(MainLoop *p_main_loop);
 
 public:
-	virtual String get_name();
+	virtual String get_name() const;
 
 	virtual void set_mouse_show(bool p_show);
 	virtual void set_mouse_grab(bool p_grab);

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -530,7 +530,7 @@ OS::VideoMode OS_UWP::get_video_mode(int p_screen) const {
 void OS_UWP::get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen) const {
 }
 
-String OS_UWP::get_name() {
+String OS_UWP::get_name() const {
 
 	return "UWP";
 }

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -195,7 +195,7 @@ public:
 
 	virtual MainLoop *get_main_loop() const;
 
-	virtual String get_name();
+	virtual String get_name() const;
 
 	virtual Date get_date(bool utc) const;
 	virtual Time get_time(bool utc) const;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2119,7 +2119,7 @@ void OS_Windows::request_attention() {
 	FlashWindowEx(&info);
 }
 
-String OS_Windows::get_name() {
+String OS_Windows::get_name() const {
 
 	return "Windows";
 }

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -246,7 +246,7 @@ public:
 
 	virtual MainLoop *get_main_loop() const;
 
-	virtual String get_name();
+	virtual String get_name() const;
 
 	virtual Date get_date(bool utc) const;
 	virtual Time get_time(bool utc) const;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2592,7 +2592,7 @@ String OS_X11::get_clipboard() const {
 	return ret;
 }
 
-String OS_X11::get_name() {
+String OS_X11::get_name() const {
 
 	return "X11";
 }

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -216,7 +216,7 @@ protected:
 	bool is_window_maximize_allowed();
 
 public:
-	virtual String get_name();
+	virtual String get_name() const;
 
 	virtual void set_cursor_shape(CursorShape p_shape);
 	virtual CursorShape get_cursor_shape() const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -720,7 +720,7 @@ public:
 	virtual void _update_cache() = 0;
 	virtual Map<int, TextEdit::HighlighterInfo> _get_line_syntax_highlighting(int p_line) = 0;
 
-	virtual String get_name() = 0;
+	virtual String get_name() const = 0;
 	virtual List<String> get_supported_languages() = 0;
 
 	void set_text_editor(TextEdit *p_text_editor);


### PR DESCRIPTION
These methods are clearly returning literal constants. It would be helpful for the reader (and maybe the compiler) to explicitly describe them as such.