### PR TITLE
removed a redundant null check in assimp editor

### DIFF
--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -855,9 +855,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 				Ref<Texture> texture = _load_texture(state, path);
 
 				if (texture != NULL) {
-					if (map_mode != NULL) {
-						_set_texture_mapping_mode(map_mode, texture);
-					}
+					_set_texture_mapping_mode(map_mode, texture);
 					mat->set_feature(SpatialMaterial::Feature::FEATURE_NORMAL_MAPPING, true);
 					mat->set_texture(SpatialMaterial::TEXTURE_NORMAL, texture);
 				}


### PR DESCRIPTION
There is a redundant check in `modules/assimp/editor_scene_importer_assimp.cpp` where the NULL check will always succeed.