### PR TITLE
Improve Theme Editor Dialogs

### DIFF
--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -55,12 +55,9 @@ class ThemeEditor : public VBoxContainer {
 
 	MenuButton *theme_menu;
 	ConfirmationDialog *add_del_dialog;
-	HBoxContainer *type_hbc;
-	MenuButton *type_menu;
-	LineEdit *type_edit;
-	HBoxContainer *name_hbc;
-	MenuButton *name_menu;
-	LineEdit *name_edit;
+	OptionButton *type_menu;
+	OptionButton *name_menu;
+	LineEdit *custom_name_edit;
 	OptionButton *type_select;
 	Label *type_select_label;
 	Label *name_select_label;
@@ -81,9 +78,8 @@ class ThemeEditor : public VBoxContainer {
 
 	void _save_template_cbk(String fname);
 	void _dialog_cbk();
-	void _type_menu_cbk(int p_option);
 	void _name_menu_about_to_show();
-	void _name_menu_cbk(int p_option);
+	void _name_selected();
 	void _theme_menu_cbk(int p_option);
 	void _propagate_redraw(Control *p_at);
 	void _refresh_interval();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/29038.

I made the changes from the fix and some others as well. Like removing the excess space and make the name be after data type cause it makes more sense. 
As it's options will be dependent on what we select in data type.
 