### PR TITLE
Pass mouse events to SpinBox from its LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -68,6 +68,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 		_reset_caret_blink_timer();
 		if (b->is_pressed()) {
 
+			accept_event(); //don't pass event further when clicked on text field
 			if (!text.empty() && is_editable() && _is_over_clear_button(b->get_position())) {
 				clear_button_status.press_attempt = true;
 				clear_button_status.pressing_inside = true;

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -277,6 +277,7 @@ SpinBox::SpinBox() {
 	add_child(line_edit);
 
 	line_edit->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	line_edit->set_mouse_filter(MOUSE_FILTER_PASS);
 	//connect("value_changed",this,"_value_changed");
 	line_edit->connect("text_entered", this, "_text_entered", Vector<Variant>(), CONNECT_DEFERRED);
 	line_edit->connect("focus_exited", this, "_line_edit_focus_exit", Vector<Variant>(), CONNECT_DEFERRED);


### PR DESCRIPTION
Fixes #6328
Fixes #15965

I had to add an `accept_event()` to LineEdit to make this work (alternative would be checking if mouse isn't over LineEdit when clicking SpinBox) and not sure if it won't break anything.