### PR TITLE
Improvements to scroll handling

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -470,6 +470,8 @@ Size2 ItemList::Item::get_icon_size() const {
 
 void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
+	double prev_scroll = scroll_bar->get_value();
+
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (defer_select_single >= 0 && mm.is_valid()) {
 		defer_select_single = -1;
@@ -767,6 +769,9 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 		scroll_bar->set_value(scroll_bar->get_value() + scroll_bar->get_page() * pan_gesture->get_delta().y / 8);
 	}
+
+	if (scroll_bar->get_value() != prev_scroll)
+		accept_event(); //accept event if scroll changed
 }
 
 void ItemList::ensure_current_is_visible() {

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -53,29 +53,19 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 	if (b.is_valid()) {
 		accept_event();
 
-		if (b->get_button_index() == 5 && b->is_pressed()) {
+		if (b->get_button_index() == BUTTON_WHEEL_DOWN && b->is_pressed()) {
 
-			/*
-			if (orientation==VERTICAL)
-				set_val( get_val() + get_page() / 4.0 );
-			else
-			*/
 			set_value(get_value() + get_page() / 4.0);
 			accept_event();
 		}
 
-		if (b->get_button_index() == 4 && b->is_pressed()) {
+		if (b->get_button_index() == BUTTON_WHEEL_UP && b->is_pressed()) {
 
-			/*
-			if (orientation==HORIZONTAL)
-				set_val( get_val() - get_page() / 4.0 );
-			else
-			*/
 			set_value(get_value() - get_page() / 4.0);
 			accept_event();
 		}
 
-		if (b->get_button_index() != 1)
+		if (b->get_button_index() != BUTTON_LEFT)
 			return;
 
 		if (b->is_pressed()) {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -88,13 +88,16 @@ void ScrollContainer::_cancel_drag() {
 
 void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
+	double prev_v_scroll = v_scroll->get_value();
+	double prev_h_scroll = h_scroll->get_value();
+
 	Ref<InputEventMouseButton> mb = p_gui_input;
 
 	if (mb.is_valid()) {
 
 		if (mb->get_button_index() == BUTTON_WHEEL_UP && mb->is_pressed()) {
 			// only horizontal is enabled, scroll horizontally
-			if (h_scroll->is_visible() && !v_scroll->is_visible()) {
+			if (h_scroll->is_visible() && (!v_scroll->is_visible() || mb->get_shift())) {
 				h_scroll->set_value(h_scroll->get_value() - h_scroll->get_page() / 8 * mb->get_factor());
 			} else if (v_scroll->is_visible_in_tree()) {
 				v_scroll->set_value(v_scroll->get_value() - v_scroll->get_page() / 8 * mb->get_factor());
@@ -103,7 +106,7 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		if (mb->get_button_index() == BUTTON_WHEEL_DOWN && mb->is_pressed()) {
 			// only horizontal is enabled, scroll horizontally
-			if (h_scroll->is_visible() && !v_scroll->is_visible()) {
+			if (h_scroll->is_visible() && (!v_scroll->is_visible() || mb->get_shift())) {
 				h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() / 8 * mb->get_factor());
 			} else if (v_scroll->is_visible()) {
 				v_scroll->set_value(v_scroll->get_value() + v_scroll->get_page() / 8 * mb->get_factor());
@@ -121,6 +124,9 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() * mb->get_factor() / 8);
 			}
 		}
+
+		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll)
+			accept_event(); //accept event if scroll changed
 
 		if (!OS::get_singleton()->has_touchscreen_ui_hint())
 			return;
@@ -204,6 +210,9 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			v_scroll->set_value(v_scroll->get_value() + v_scroll->get_page() * pan_gesture->get_delta().y / 8);
 		}
 	}
+
+	if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll)
+		accept_event(); //accept event if scroll changed
 }
 
 void ScrollContainer::_update_scrollbar_position() {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1812,6 +1812,9 @@ void TextEdit::_get_mouse_pos(const Point2i &p_mouse, int &r_row, int &r_col) co
 
 void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
+	double prev_v_scroll = v_scroll->get_value();
+	double prev_h_scroll = h_scroll->get_value();
+
 	Ref<InputEventMouseButton> mb = p_gui_input;
 
 	if (mb.is_valid()) {
@@ -2066,6 +2069,9 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			_scroll_down(delta);
 		}
 		h_scroll->set_value(h_scroll->get_value() + pan_gesture->get_delta().x * 100);
+		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll)
+			accept_event(); //accept event if scroll changed
+
 		return;
 	}
 
@@ -2108,6 +2114,9 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 		}
 	}
+
+	if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll)
+		accept_event(); //accept event if scroll changed
 
 	Ref<InputEventKey> k = p_gui_input;
 


### PR DESCRIPTION
Fixes #21848
Fixes #22459
Fixes #19562
Closes #29072

This PR changes the way how ScrollContainer and similar Controls behave. Previously if you used mouse wheel on something scrollable inside something else scrollable, both of them were scrolled. I changed it so the event is accepted when scroll changes, i.e. in case of nesting, the inner container is scrolled until it can't be scrolled anymore, then outer container is scrolled.

As for ScrollBars, I left them as they are (always accepting the event, even if no scroll happens), but after looking into the code, I did a very small cleanup - removed some unused commented code and changed magic numbers to constants.

Anyways, it works, but isn't fully tested (touch screen controls are not tested, particularly). If there's some scrollable thing I missed or this should be done another way, I'm open to suggestions I guess.

Here's some test scene for testing:
[GUIScene.zip](https://github.com/godotengine/godot/files/3203647/GUIScene.zip)