### PR TITLE
Initialize readonly/editable in LineEdit and TextEdit controls

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1656,6 +1656,7 @@ LineEdit::LineEdit() {
 	context_menu_enabled = true;
 	menu = memnew(PopupMenu);
 	add_child(menu);
+	editable = false; // initialise to opposite first, so we get past the early-out in set_editable
 	set_editable(true);
 	menu->connect("id_pressed", this, "menu_option");
 	expand_to_text_length = false;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6661,6 +6661,7 @@ TextEdit::TextEdit() {
 	context_menu_enabled = true;
 	menu = memnew(PopupMenu);
 	add_child(menu);
+	readonly = true; // initialise to opposite first, so we get past the early-out in set_readonly
 	set_readonly(false);
 	menu->connect("id_pressed", this, "menu_option");
 	first_draw = true;


### PR DESCRIPTION
fixing a couple of uninitialized variables from #28287