### PR TITLE
Make links to the online docs show the stable branch

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -7,7 +7,7 @@
 		AABB consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/math/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="AABB">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -17,7 +17,7 @@
 		Animations are just data containers, and must be added to nodes such as an [AnimationPlayer] or [AnimationTreePlayer] to be played back.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/animation/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/animation/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_track">

--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -10,7 +10,7 @@
 	</methods>
 	<members>
 		<member name="advance_condition" type="String" setter="set_advance_condition" getter="get_advance_condition">
-			Turn on auto advance when this condition is set. The provided name will become a boolean parameter on the [AnimationTree] that can be controlled from code (see [url=https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html#controlling-from-code][/url]). For example, if [member AnimationTree.tree_root] is an [AnimationNodeStateMachine] and [member advance_condition] is set to "idle":
+			Turn on auto advance when this condition is set. The provided name will become a boolean parameter on the [AnimationTree] that can be controlled from code (see [url=https://docs.godotengine.org/en/stable/tutorials/animation/animation_tree.html#controlling-from-code][/url]). For example, if [member AnimationTree.tree_root] is an [AnimationNodeStateMachine] and [member advance_condition] is set to "idle":
 			[codeblock]
 			$animation_tree["parameters/conditions/idle"] = is_on_floor and linear_velocity.x == 0
 			[/codeblock]

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -7,8 +7,8 @@
 		An animation player is used for general purpose playback of [Animation] resources. It contains a dictionary of animations (referenced by name) and custom blend times between their transitions. Additionally, animations can be played and blended in different channels.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/getting_started/step_by_step/animations.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/animation/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/getting_started/step_by_step/animations.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/animation/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_animation">

--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -5,7 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/animation/animation_tree.html</link>
 		<link>https://github.com/godotengine/tps-demo</link>
 	</tutorials>
 	<methods>

--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -7,7 +7,7 @@
 		AudioServer is a low level server interface for audio access. It is in charge of creating sample data (playable audio) as well as its playback via a voice interface.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/audio/audio_buses.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_bus">

--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -7,7 +7,7 @@
 		Base class for audio streams. Audio streams are used for sound effects and music playback, and support WAV (via [AudioStreamSample]) and OGG (via [AudioStreamOGGVorbis]) file formats.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/audio/audio_streams.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_length" qualifiers="const">

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -7,7 +7,7 @@
 		Plays background audio.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/audio/audio_streams.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_playback_position">

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -7,7 +7,7 @@
 		Plays audio that dampens with distance from screen center.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/audio/audio_streams.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_playback_position">

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -7,7 +7,7 @@
 		Plays a sound effect with directed sound effects, dampens with distance if needed, generates effect of hearable position in space.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/audio/audio_streams.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_playback_position">

--- a/doc/classes/BakedLightmap.xml
+++ b/doc/classes/BakedLightmap.xml
@@ -7,7 +7,7 @@
 		Baked lightmaps are an alternative workflow for adding indirect (or baked) lighting to a scene. Unlike the [GIProbe] approach, baked lightmaps work fine on low-end PCs and mobile devices as they consume almost no resources in run-time.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/baked_lightmaps.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/baked_lightmaps.html</link>
 	</tutorials>
 	<methods>
 		<method name="bake">

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -8,7 +8,7 @@
 		For such use, it is composed of a scaling and a rotation matrix, in that order (M = R.S).
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/using_transforms.html</link>
 	</tutorials>
 	<methods>
 		<method name="Basis">

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -11,8 +11,8 @@
 		Ultimately, a transform notification can be requested, which will notify the node that its global position changed in case the parent tree changed.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/2d_transforms.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/custom_drawing_in_2d.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/2d_transforms.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/custom_drawing_in_2d.html</link>
 	</tutorials>
 	<methods>
 		<method name="_draw" qualifiers="virtual">

--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -7,8 +7,8 @@
 		Canvas drawing layer. [CanvasItem] nodes that are direct or indirect children of a [CanvasLayer] will be drawn in that layer. The layer is a numeric index that defines the draw order. The default 2D scene renders with index 0, so a [CanvasLayer] with index -1 will be drawn below, and one with index 1 will be drawn above. This is very useful for HUDs (in layer 1+ or above), or backgrounds (in layer -1 or below).
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/2d_transforms.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/canvas_layers.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/2d_transforms.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/canvas_layers.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_canvas" qualifiers="const">

--- a/doc/classes/CollisionShape.xml
+++ b/doc/classes/CollisionShape.xml
@@ -7,7 +7,7 @@
 		Editor facility for creating and editing collision shapes in 3D space. You can use this node to represent all sorts of collision shapes, for example, add this to an [Area] to give it a detection shape, or add it to a [PhysicsBody] to create a solid object. [b]IMPORTANT[/b]: this is an Editor-only helper to create shapes, use [method CollisionObject.shape_owner_get_shape] to get the actual shape.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
 		<method name="make_convex_from_brothers">

--- a/doc/classes/CollisionShape2D.xml
+++ b/doc/classes/CollisionShape2D.xml
@@ -7,7 +7,7 @@
 		Editor facility for creating and editing collision shapes in 2D space. You can use this node to represent all sorts of collision shapes, for example, add this to an [Area2D] to give it a detection shape, or add it to a [PhysicsBody2D] to create a solid object. [b]IMPORTANT[/b]: this is an Editor-only helper to create shapes, use [method CollisionObject2D.shape_owner_get_shape] to get the actual shape.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -13,8 +13,8 @@
 		[Theme] resources change the Control's appearance. If you change the [Theme] on a [Control] node, it affects all of its children. To override some of the theme's parameters, call one of the [code]add_*_override[/code] methods, like [method add_font_override]. You can override the theme with the inspector.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/gui/index.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/custom_drawing_in_2d.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/gui/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/custom_drawing_in_2d.html</link>
 	</tutorials>
 	<methods>
 		<method name="_clips_input" qualifiers="virtual">

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -17,7 +17,7 @@
 		[/codeblock]
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_basics.html#dictionary</link>
+		<link>https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_basics.html#dictionary</link>
 	</tutorials>
 	<methods>
 		<method name="clear">

--- a/doc/classes/DirectionalLight.xml
+++ b/doc/classes/DirectionalLight.xml
@@ -7,7 +7,7 @@
 		A directional light is a type of [Light] node that models an infinite number of parallel rays covering the entire scene. It is used for lights with strong intensity that are located far away from the scene to model sunlight or moonlight. The worldspace location of the DirectionalLight transform (origin) is ignored. Only the basis is used do determine light direction.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/lights_and_shadows.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/lights_and_shadows.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -23,7 +23,7 @@
 		[/codeblock]
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/getting_started/step_by_step/filesystem.html</link>
+		<link>https://docs.godotengine.org/en/stable/getting_started/step_by_step/filesystem.html</link>
 	</tutorials>
 	<methods>
 		<method name="change_dir">

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -49,7 +49,7 @@
 		[/codeblock]
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/plugins/editor/import_plugins.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/plugins/editor/import_plugins.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_import_options" qualifiers="virtual">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -7,7 +7,7 @@
 		Plugins are used by the editor to extend functionality. The most common types of plugins are those which edit a given node or resource type, import plugins and export plugins. Also see [EditorScript] to add functions to the editor.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/plugins/editor/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/plugins/editor/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_autoload_singleton">

--- a/doc/classes/EditorScenePostImport.xml
+++ b/doc/classes/EditorScenePostImport.xml
@@ -26,7 +26,7 @@
 		[/codeblock]
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/getting_started/workflow/assets/importing_scenes.html#custom-script</link>
+		<link>https://docs.godotengine.org/en/stable/getting_started/workflow/assets/importing_scenes.html#custom-script</link>
 	</tutorials>
 	<methods>
 		<method name="get_source_file" qualifiers="const">

--- a/doc/classes/EditorSpatialGizmoPlugin.xml
+++ b/doc/classes/EditorSpatialGizmoPlugin.xml
@@ -7,7 +7,7 @@
 		EditorSpatialGizmoPlugin allows you to define a new type of Gizmo. There are two main ways to do so: extending [EditorSpatialGizmoPlugin] for the simpler gizmos, or creating a new [EditorSpatialGizmo] type. See the tutorial in the documentation for more info.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/plugins/editor/spatial_gizmos.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/plugins/editor/spatial_gizmos.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_material">

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -12,8 +12,8 @@
 		- Adjustments
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/environment_and_post_processing.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/high_dynamic_range.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/environment_and_post_processing.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/high_dynamic_range.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -22,7 +22,7 @@
 		[/codeblock]
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/getting_started/step_by_step/filesystem.html</link>
+		<link>https://docs.godotengine.org/en/stable/getting_started/step_by_step/filesystem.html</link>
 	</tutorials>
 	<methods>
 		<method name="close">

--- a/doc/classes/GIProbe.xml
+++ b/doc/classes/GIProbe.xml
@@ -5,7 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/gi_probes.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/gi_probes.html</link>
 	</tutorials>
 	<methods>
 		<method name="bake">

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -10,8 +10,8 @@
 		For more information on HTTP, see https://developer.mozilla.org/en-US/docs/Web/HTTP (or read RFC 2616 to get it straight from the source: https://tools.ietf.org/html/rfc2616).
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/networking/http_client_class.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/networking/ssl_certificates.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/networking/http_client_class.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<methods>
 		<method name="close">

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -8,7 +8,7 @@
 		Can be used to make HTTP requests, i.e. download or upload files or web content via HTTP.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/networking/ssl_certificates.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<methods>
 		<method name="cancel_request">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -7,7 +7,7 @@
 		A Singleton that deals with inputs. This includes key presses, mouse buttons and movement, joypads, and input actions. Actions and their events can be set in the Project Settings / Input Map tab. Or be set with [InputMap].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="action_press">

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -7,8 +7,8 @@
 		Base class of all sort of input event. See [method Node._input].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/2d_transforms.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/2d_transforms.html</link>
 	</tutorials>
 	<methods>
 		<method name="accumulate">

--- a/doc/classes/InputEventAction.xml
+++ b/doc/classes/InputEventAction.xml
@@ -7,7 +7,7 @@
 		Contains a generic action which can be targeted from several type of inputs. Actions can be created from the project settings menu [code]Project &gt; Project Settings &gt; Input Map[/code]. See [method Node._input].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html#actions</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html#actions</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/InputEventJoypadButton.xml
+++ b/doc/classes/InputEventJoypadButton.xml
@@ -7,7 +7,7 @@
 		Input event type for gamepad buttons. For joysticks see [InputEventJoypadMotion].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/InputEventJoypadMotion.xml
+++ b/doc/classes/InputEventJoypadMotion.xml
@@ -7,7 +7,7 @@
 		Stores information about joystick motions. One [InputEventJoypadMotion] represents one axis at a time.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/InputEventKey.xml
+++ b/doc/classes/InputEventKey.xml
@@ -7,7 +7,7 @@
 		Stores key presses on the keyboard. Supports key presses, key releases and [member echo] events.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_scancode_with_modifiers" qualifiers="const">

--- a/doc/classes/InputEventMouse.xml
+++ b/doc/classes/InputEventMouse.xml
@@ -7,7 +7,7 @@
 		Stores general mouse events information.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/InputEventMouseButton.xml
+++ b/doc/classes/InputEventMouseButton.xml
@@ -7,7 +7,7 @@
 		Contains mouse click information. See [method Node._input].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/mouse_and_input_coordinates.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/mouse_and_input_coordinates.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/InputEventMouseMotion.xml
+++ b/doc/classes/InputEventMouseMotion.xml
@@ -7,7 +7,7 @@
 		Contains mouse motion information. Supports relative, absolute positions and speed. See [method Node._input].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/mouse_and_input_coordinates.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/mouse_and_input_coordinates.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/InputEventScreenDrag.xml
+++ b/doc/classes/InputEventScreenDrag.xml
@@ -8,7 +8,7 @@
 		Contains screen drag information. See [method Node._input].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -8,7 +8,7 @@
 		Stores multi-touch press/release information. Supports touch press, touch release and [member index] for multi-touch count and order.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -7,7 +7,7 @@
 		Contains keys events information with modifiers support like [code]SHIFT[/code] or [code]ALT[/code]. See [method Node._input].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -7,7 +7,7 @@
 		Manages all [InputEventAction] which can be created/modified from the project settings menu [code]Project &gt; Project Settings &gt; Input Map[/code] or in code with [method add_action] and [method action_add_event]. See [method Node._input].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html#inputmap</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html#inputmap</link>
 	</tutorials>
 	<methods>
 		<method name="action_add_event">

--- a/doc/classes/JavaScript.xml
+++ b/doc/classes/JavaScript.xml
@@ -7,7 +7,7 @@
 		The JavaScript singleton is implemented only in HTML5 export. It's used to access the browser's JavaScript context. This allows interaction with embedding pages or calling third-party JavaScript APIs.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/getting_started/workflow/export/exporting_for_web.html#calling-javascript-from-script</link>
+		<link>https://docs.godotengine.org/en/stable/getting_started/workflow/export/exporting_for_web.html#calling-javascript-from-script</link>
 	</tutorials>
 	<methods>
 		<method name="eval">

--- a/doc/classes/KinematicBody.xml
+++ b/doc/classes/KinematicBody.xml
@@ -9,7 +9,7 @@
 		Kinematic Characters: KinematicBody also has an API for moving objects (the [method move_and_collide] and [method move_and_slide] methods) while performing collision tests. This makes them really useful to implement characters that collide against a world, but that don't require advanced physics.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/kinematic_character_2d.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/kinematic_character_2d.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_floor_velocity" qualifiers="const">

--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -9,8 +9,8 @@
 		Kinematic Characters: KinematicBody2D also has an API for moving objects (the [method move_and_collide] and [method move_and_slide] methods) while performing collision tests. This makes them really useful to implement characters that collide against a world, but that don't require advanced physics.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/kinematic_character_2d.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/using_kinematic_body_2d.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/kinematic_character_2d.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/using_kinematic_body_2d.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_floor_velocity" qualifiers="const">

--- a/doc/classes/Light.xml
+++ b/doc/classes/Light.xml
@@ -7,7 +7,7 @@
 		Light is the abstract base class for light nodes, so it shouldn't be used directly (It can't be instanced). Other types of light nodes inherit from it. Light contains the common variables and parameters used for lighting.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/lights_and_shadows.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/lights_and_shadows.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/Light2D.xml
+++ b/doc/classes/Light2D.xml
@@ -7,7 +7,7 @@
 		Casts light in a 2D environment. Light is defined by a (usually grayscale) texture, a color, an energy value, a mode (see constants), and various other parameters (range and shadows-related). Note that Light2D can be used as a mask.
 	</description>
 	<tutorials>
-		<link>http://docs.godotengine.org/en/latest/tutorials/2d/2d_lights_and_shadows.html</link>
+		<link>http://docs.godotengine.org/en/stable/tutorials/2d/2d_lights_and_shadows.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/LightOccluder2D.xml
+++ b/doc/classes/LightOccluder2D.xml
@@ -7,7 +7,7 @@
 		Occludes light cast by a Light2D, casting shadows. The LightOccluder2D must be provided with an [OccluderPolygon2D] in order for the shadow to be computed.
 	</description>
 	<tutorials>
-		<link>http://docs.godotengine.org/en/latest/tutorials/2d/2d_lights_and_shadows.html</link>
+		<link>http://docs.godotengine.org/en/stable/tutorials/2d/2d_lights_and_shadows.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/MeshInstance2D.xml
+++ b/doc/classes/MeshInstance2D.xml
@@ -5,7 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
-		<link>http://docs.godotengine.org/en/latest/tutorials/2d/2d_meshes.html</link>
+		<link>http://docs.godotengine.org/en/stable/tutorials/2d/2d_meshes.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -10,7 +10,7 @@
 		Since instances may have any behavior, the AABB used for visibility must be provided by the user.
 	</description>
 	<tutorials>
-		<link>http://docs.godotengine.org/en/latest/tutorials/3d/vertex_animation/animating_thousands_of_fish.html</link>
+		<link>http://docs.godotengine.org/en/stable/tutorials/3d/vertex_animation/animating_thousands_of_fish.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_aabb" qualifiers="const">

--- a/doc/classes/MultiMeshInstance.xml
+++ b/doc/classes/MultiMeshInstance.xml
@@ -8,8 +8,8 @@
 		This is useful to optimize the rendering of a high amount of instances of a given mesh (for example tree in a forest or grass strands).
 	</description>
 	<tutorials>
-		<link>http://docs.godotengine.org/en/latest/tutorials/3d/vertex_animation/animating_thousands_of_fish.html</link>
-		<link>http://docs.godotengine.org/en/latest/tutorials/3d/using_multi_mesh_instance.html</link>
+		<link>http://docs.godotengine.org/en/stable/tutorials/3d/vertex_animation/animating_thousands_of_fish.html</link>
+		<link>http://docs.godotengine.org/en/stable/tutorials/3d/using_multi_mesh_instance.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/NetworkedMultiplayerPeer.xml
+++ b/doc/classes/NetworkedMultiplayerPeer.xml
@@ -7,7 +7,7 @@
 		Manages the connection to network peers. Assigns unique IDs to each client connected to the server.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/networking/high_level_multiplayer.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/networking/high_level_multiplayer.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_connection_status" qualifiers="const">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -17,7 +17,7 @@
 		[b]Networking with nodes:[/b] After connecting to a server (or making one, see [NetworkedMultiplayerENet]) it is possible to use the built-in RPC (remote procedure call) system to communicate over the network. By calling [method rpc] with a method name, it will be called locally and in all connected peers (peers = clients and the server that accepts connections). To identify which node receives the RPC call Godot will use its [NodePath] (make sure node names are the same on all peers). Also take a look at the high-level networking tutorial and corresponding demos.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/getting_started/step_by_step/scenes_and_nodes.html</link>
+		<link>https://docs.godotengine.org/en/stable/getting_started/step_by_step/scenes_and_nodes.html</link>
 	</tutorials>
 	<methods>
 		<method name="_enter_tree" qualifiers="virtual">

--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -7,7 +7,7 @@
 		A 2D game object, with a position, rotation and scale. All 2D physics nodes and sprites inherit from Node2D. Use Node2D as a parent node to move, scale and rotate children in a 2D project. Also gives control on the node's render order.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/custom_drawing_in_2d.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/custom_drawing_in_2d.html</link>
 	</tutorials>
 	<methods>
 		<method name="apply_scale">

--- a/doc/classes/OmniLight.xml
+++ b/doc/classes/OmniLight.xml
@@ -7,7 +7,7 @@
 		An Omnidirectional light is a type of [Light] that emits light in all directions. The light is attenuated by distance and this attenuation can be configured by changing its energy, radius, and attenuation parameters.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/lights_and_shadows.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/lights_and_shadows.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -8,7 +8,7 @@
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
 	</description>
 	<tutorials>
-		<link>http://docs.godotengine.org/en/latest/tutorials/3d/vertex_animation/controlling_thousands_of_fish.html</link>
+		<link>http://docs.godotengine.org/en/stable/tutorials/3d/vertex_animation/controlling_thousands_of_fish.html</link>
 	</tutorials>
 	<methods>
 		<method name="capture_aabb" qualifiers="const">

--- a/doc/classes/Particles2D.xml
+++ b/doc/classes/Particles2D.xml
@@ -8,7 +8,7 @@
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/particle_systems_2d.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/particle_systems_2d.html</link>
 	</tutorials>
 	<methods>
 		<method name="capture_rect" qualifiers="const">

--- a/doc/classes/Physics2DDirectBodyState.xml
+++ b/doc/classes/Physics2DDirectBodyState.xml
@@ -7,7 +7,7 @@
 		Provides direct access to a physics body in the [Physics2DServer], allowing safe changes to physics properties. This object is passed via the direct state callback of rigid/character bodies, and is intended for changing the direct state of that body. See [method RigidBody2D._integrate_forces].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/ray-casting.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_central_force">

--- a/doc/classes/Physics2DDirectSpaceState.xml
+++ b/doc/classes/Physics2DDirectSpaceState.xml
@@ -7,7 +7,7 @@
 		Direct access object to a space in the [Physics2DServer]. It's used mainly to do queries against objects and areas residing in a given space.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/ray-casting.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<methods>
 		<method name="cast_motion">

--- a/doc/classes/PhysicsBody.xml
+++ b/doc/classes/PhysicsBody.xml
@@ -7,7 +7,7 @@
 		PhysicsBody is an abstract base class for implementing a physics body. All *Body types inherit from it.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_collision_exception_with">

--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -7,7 +7,7 @@
 		PhysicsBody2D is an abstract base class for implementing a physics body. All *Body2D types inherit from it.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_collision_exception_with">

--- a/doc/classes/PhysicsDirectSpaceState.xml
+++ b/doc/classes/PhysicsDirectSpaceState.xml
@@ -7,7 +7,7 @@
 		Direct access object to a space in the [PhysicsServer]. It's used mainly to do queries against objects and areas residing in a given space.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/ray-casting.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<methods>
 		<method name="cast_motion">

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -7,7 +7,7 @@
 		Plane represents a normalized plane equation. Basically, "normal" is the normal of the plane (a,b,c normalized), and "d" is the distance from the origin to the plane (in the direction of "normal"). "Over" or "Above" the plane is considered the side of the plane towards where the normal is pointing.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/math/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="Plane">

--- a/doc/classes/Quat.xml
+++ b/doc/classes/Quat.xml
@@ -9,7 +9,7 @@
 		Quaternions need to be (re)normalized.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html#interpolating-with-quaternions</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/using_transforms.html#interpolating-with-quaternions</link>
 	</tutorials>
 	<methods>
 		<method name="Quat">

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -7,7 +7,7 @@
 		Rect2 consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/math/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="Rect2">

--- a/doc/classes/ReflectionProbe.xml
+++ b/doc/classes/ReflectionProbe.xml
@@ -5,7 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/reflection_probes.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/reflection_probes.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -8,7 +8,7 @@
 		Note that assignments to [member bbcode_text] clear the tag stack and reconstruct it from the property's contents. Any edits made to [member bbcode_text] will erase previous edits made from other manual sources such as [method append_bbcode] and the [code]push_*[/code] / [method pop] methods.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/gui/bbcode_in_richtextlabel.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/gui/bbcode_in_richtextlabel.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_image">

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -10,7 +10,7 @@
 		If you need to override the default physics behavior, you can write a custom force integration. See [member custom_integrator].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
 		<method name="_integrate_forces" qualifiers="virtual">

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -7,8 +7,8 @@
 		As one of the most important classes, the [SceneTree] manages the hierarchy of nodes in a scene as well as scenes themselves. Nodes can be added, retrieved and removed. The whole scene tree (and thus the current scene) can be paused. Scenes can be loaded, switched and reloaded. You can also use the SceneTree to organize your nodes into groups: every node can be assigned as many groups as you want to create, e.g. a "enemy" group. You can then iterate these groups or even call methods and set properties on all the group's members at once.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/getting_started/step_by_step/scene_tree.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/viewports/multiple_resolutions.html</link>
+		<link>https://docs.godotengine.org/en/stable/getting_started/step_by_step/scene_tree.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/viewports/multiple_resolutions.html</link>
 	</tutorials>
 	<methods>
 		<method name="call_group" qualifiers="vararg">

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -8,7 +8,7 @@
 		The [code]new[/code] method of a script subclass creates a new instance. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/getting_started/step_by_step/scripting.html</link>
+		<link>https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting.html</link>
 	</tutorials>
 	<methods>
 		<method name="can_instance" qualifiers="const">

--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -7,7 +7,7 @@
 		This class allows you to define a custom shader program that can be used for various materials to render objects.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/shading/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/shading/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_default_texture_param" qualifiers="const">

--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -7,7 +7,7 @@
 		A material that uses a custom [Shader] program to render either items to screen or process particles. You can create multiple materials for the same shader but configure different values for the uniforms defined in the shader.
 	</description>
 	<tutorials>
-		<link>http://docs.godotengine.org/en/latest/tutorials/shading/index.html</link>
+		<link>http://docs.godotengine.org/en/stable/tutorials/shading/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_shader_param" qualifiers="const">

--- a/doc/classes/Shape.xml
+++ b/doc/classes/Shape.xml
@@ -7,7 +7,7 @@
 		Base class for all 3D shape resources. Nodes that inherit from this can be used as shapes for a [PhysicsBody] or [Area] objects.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -7,7 +7,7 @@
 		Base class for all 2D Shapes. All 2D shape types inherit from this.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
 		<method name="collide">

--- a/doc/classes/Skeleton2D.xml
+++ b/doc/classes/Skeleton2D.xml
@@ -5,7 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
-		<link>http://docs.godotengine.org/en/latest/tutorials/animation/2d_skeletons.html</link>
+		<link>http://docs.godotengine.org/en/stable/tutorials/animation/2d_skeletons.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_bone">

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -8,7 +8,7 @@
 		Affine operations (rotate, scale, translate) happen in parent's local coordinate system, unless the [Spatial] object is set as top level. Affine operations in this coordinate system correspond to direct affine operations on the [Spatial]'s transform. The word local below refers to this coordinate system. The coordinate system that is attached to the [Spatial] object itself is referred to as object-local coordinate system.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/introduction_to_3d.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/introduction_to_3d.html</link>
 	</tutorials>
 	<methods>
 		<method name="force_update_transform">

--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -7,7 +7,7 @@
 		This provides a default material with a wide variety of rendering features and properties without the need to write shader code. See the tutorial below for details.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/spatial_material.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/spatial_material.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/SpotLight.xml
+++ b/doc/classes/SpotLight.xml
@@ -7,7 +7,7 @@
 		A SpotLight light is a type of [Light] node that emits lights in a specific direction, in the shape of a cone. The light is attenuated through the distance and this attenuation can be configured by changing the energy, radius and attenuation parameters of [Light].
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/lights_and_shadows.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/lights_and_shadows.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/StreamPeerSSL.xml
+++ b/doc/classes/StreamPeerSSL.xml
@@ -7,7 +7,7 @@
 		SSL Stream peer. This object can be used to connect to SSL servers.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/networking/ssl_certificates.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<methods>
 		<method name="accept_stream">

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -7,7 +7,7 @@
 		Node for 2D tile-based maps. Tilemaps use a [TileSet] which contain a list of tiles (textures plus optional collision, navigation, and/or occluder shapes) which are used to create grid-based maps.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/using_tilemaps.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/using_tilemaps.html</link>
 	</tutorials>
 	<methods>
 		<method name="clear">

--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -7,8 +7,8 @@
 		Represents one or many transformations in 3D space such as translation, rotation, or scaling. It consists of a [Basis] "basis" and an [Vector3] "origin". It is similar to a 3x4 matrix.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/math/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/using_transforms.html</link>
 	</tutorials>
 	<methods>
 		<method name="Transform">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -7,7 +7,7 @@
 		2-element structure that can be used to represent positions in 2d space or any other pair of numeric values.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/math/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="Vector2">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -7,7 +7,7 @@
 		Vector3 is one of the core classes of the engine, and includes several built-in helper functions to perform basic vector math operations.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/math/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="Vector3">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -12,8 +12,8 @@
 		Finally, viewports can also behave as render targets, in which case they will not be visible unless the associated texture is used to draw.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/2d/2d_transforms.html</link>
-		<link>https://docs.godotengine.org/en/latest/tutorials/viewports/index.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/2d/2d_transforms.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/viewports/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="find_world" qualifiers="const">

--- a/doc/classes/World.xml
+++ b/doc/classes/World.xml
@@ -7,7 +7,7 @@
 		Class that has everything pertaining to a world. A physics space, a visual scenario and a sound space. Spatial nodes register their resources into the current world.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/ray-casting.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/World2D.xml
+++ b/doc/classes/World2D.xml
@@ -7,7 +7,7 @@
 		Class that has everything pertaining to a 2D world. A physics space, a visual scenario and a sound space. 2D nodes register their resources into the current 2D world.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/ray-casting.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/WorldEnvironment.xml
+++ b/doc/classes/WorldEnvironment.xml
@@ -9,7 +9,7 @@
 		The [WorldEnvironment] allows the user to specify default lighting parameters (e.g. ambient lighting), various post-processing effects (e.g. SSAO, DOF, Tonemapping), and how to draw the background (e.g. solid color, skybox). Usually, these are added in order to improve the realism/color balance of the scene.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/environment_and_post_processing.html</link>
+		<link>https://docs.godotengine.org/en/stable/tutorials/3d/environment_and_post_processing.html</link>
 	</tutorials>
 	<methods>
 	</methods>


### PR DESCRIPTION
Lots of links to the online docs show the `latest` branch instead of the `stable` one. This is bad because that branch could have things that are not yet available, leaving users confused.