### PR TITLE
Fixed scripts list ordering despite being disabled

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1558,7 +1558,15 @@ struct _ScriptEditorItemData {
 
 	bool operator<(const _ScriptEditorItemData &id) const {
 
-		return category == id.category ? sort_key < id.sort_key : category < id.category;
+		if (category == id.category) {
+			if (sort_key == id.sort_key) {
+				return index < id.index;
+			} else {
+				return sort_key < id.sort_key;
+			}
+		} else {
+			return category < id.category;
+		}
 	}
 };
 


### PR DESCRIPTION
Fixes #23455 , #26078 and #27831 simply by checking if the current setting is not SORT_BY_NONE then perform ordering instead of doing this all the time.

It is rather curious how this used to _work at all_ because it used to sort all the time....