### PR TITLE
fix un-scaling in Spatial::look_at_from_position

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -675,28 +675,29 @@ void Spatial::set_identity() {
 
 void Spatial::look_at(const Vector3 &p_target, const Vector3 &p_up) {
 
-	Transform lookat(get_global_transform());
-	if (lookat.origin == p_target) {
-		ERR_EXPLAIN("Node origin and target are in the same position, look_at() failed");
-		ERR_FAIL();
-	}
-
-	if (p_up.cross(p_target - lookat.origin) == Vector3()) {
-		ERR_EXPLAIN("Up vector and direction between node origin and target are aligned, look_at() failed");
-		ERR_FAIL();
-	}
-	Vector3 original_scale(lookat.basis.get_scale());
-	lookat = lookat.looking_at(p_target, p_up);
-	// as basis was normalized, we just need to apply original scale back
-	lookat.basis.scale(original_scale);
-	set_global_transform(lookat);
+	Vector3 origin(get_global_transform().origin);
+	look_at_from_position(origin, p_target, p_up);
 }
 
 void Spatial::look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up) {
 
+	if (p_pos == p_target) {
+		ERR_EXPLAIN("Node origin and target are in the same position, look_at() failed");
+		ERR_FAIL();
+	}
+
+	if (p_up.cross(p_target - p_pos) == Vector3()) {
+		ERR_EXPLAIN("Up vector and direction between node origin and target are aligned, look_at() failed");
+		ERR_FAIL();
+	}
+
 	Transform lookat;
 	lookat.origin = p_pos;
+
+	Vector3 original_scale(get_global_transform().basis.get_scale());
 	lookat = lookat.looking_at(p_target, p_up);
+	// as basis was normalized, we just need to apply original scale back
+	lookat.basis.scale(original_scale);
 	set_global_transform(lookat);
 }
 


### PR DESCRIPTION
As mentioned in
https://github.com/godotengine/godot/pull/26897#issuecomment-491178089

the look-at scaling issue solved by PR #26897 happens also in another
look-at method.

Spatial::look_at_from_position() also does not have same input checking
Spatial::look_at() has. Therefore, I fixed it too at same time.