### PR TITLE
Fix "no depth test" and render_priority sorting

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -603,12 +603,10 @@ public:
 		struct SortByReverseDepthAndPriority {
 
 			_FORCE_INLINE_ bool operator()(const Element *A, const Element *B) const {
-				uint32_t layer_A = uint32_t(A->sort_key >> SORT_KEY_PRIORITY_SHIFT);
-				uint32_t layer_B = uint32_t(B->sort_key >> SORT_KEY_PRIORITY_SHIFT);
-				if (layer_A == layer_B) {
+				if (A->priority == B->priority) {
 					return A->instance->depth > B->instance->depth;
 				} else {
-					return layer_A < layer_B;
+					return A->priority < B->priority;
 				}
 			}
 		};

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2374,7 +2374,7 @@ void RasterizerSceneGLES3::_add_geometry_with_material(RasterizerStorageGLES3::G
 		has_alpha = false;
 	}
 
-	RenderList::Element *e = has_alpha ? render_list.add_alpha_element() : render_list.add_element();
+	RenderList::Element *e = (has_alpha || p_material->shader->spatial.no_depth_test) ? render_list.add_alpha_element() : render_list.add_element();
 
 	if (!e)
 		return;


### PR DESCRIPTION
supercedes #29113

Fixes #29108 and fixes #27739.

In GLES3, instead of rendering the sky earlier, render the "no depth test" objects as part of alpha pass.

In GLES2, move the sky rendering after opaque pass, render "no depth test" objects as part of alpha pass. And use ``priority`` in alpha pass instead of ``sort key`` (which is only used in GLES3).

This was the fix that reduz prefers, as discussed on IRC.