### PR TITLE
C#: Implement ScriptInstance::to_string

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1855,6 +1855,34 @@ void CSharpInstance::_call_notification(int p_notification) {
 	}
 }
 
+String CSharpInstance::to_string(bool *r_valid) {
+	MonoObject *mono_object = get_mono_object();
+
+	if (mono_object == NULL) {
+		if (r_valid)
+			*r_valid = false;
+		return String();
+	}
+
+	MonoException *exc = NULL;
+	MonoString *result = GDMonoUtils::object_to_string(mono_object, &exc);
+
+	if (exc) {
+		GDMonoUtils::set_pending_exception(exc);
+		if (r_valid)
+			*r_valid = false;
+		return String();
+	}
+
+	if (result == NULL) {
+		if (r_valid)
+			*r_valid = false;
+		return String();
+	}
+
+	return GDMonoMarshal::mono_string_to_godot(result);
+}
+
 Ref<Script> CSharpInstance::get_script() const {
 
 	return script;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -261,6 +261,8 @@ public:
 	virtual void notification(int p_notification);
 	void _call_notification(int p_notification);
 
+	virtual String to_string(bool *r_valid);
+
 	virtual Ref<Script> get_script() const;
 
 	virtual ScriptLanguage *get_language();

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2300,9 +2300,14 @@ void BindingsGenerator::_populate_object_type_interfaces() {
 			if (method_info.name.empty())
 				continue;
 
+			String cname = method_info.name;
+
+			if (blacklisted_methods.find(itype.cname) && blacklisted_methods[itype.cname].find(cname))
+				continue;
+
 			MethodInterface imethod;
 			imethod.name = method_info.name;
-			imethod.cname = imethod.name;
+			imethod.cname = cname;
 
 			if (method_info.flags & METHOD_FLAG_VIRTUAL)
 				imethod.is_virtual = true;
@@ -2975,6 +2980,13 @@ void BindingsGenerator::_populate_global_constants() {
 	}
 }
 
+void BindingsGenerator::_initialize_blacklisted_methods() {
+
+	blacklisted_methods["Object"].push_back("to_string"); // there is already ToString
+	blacklisted_methods["Object"].push_back("_to_string"); // override ToString instead
+	blacklisted_methods["Object"].push_back("_init"); // never called in C# (TODO: implement it)
+}
+
 void BindingsGenerator::_log(const char *p_format, ...) {
 
 	if (log_print_enabled) {
@@ -2991,6 +3003,8 @@ void BindingsGenerator::_initialize() {
 	EditorHelp::generate_doc();
 
 	enum_types.clear();
+
+	_initialize_blacklisted_methods();
 
 	_populate_object_type_interfaces();
 	_populate_builtin_type_interfaces();

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -491,6 +491,10 @@ class BindingsGenerator {
 	List<InternalCall> core_custom_icalls;
 	List<InternalCall> editor_custom_icalls;
 
+	Map<StringName, List<StringName> > blacklisted_methods;
+
+	void _initialize_blacklisted_methods();
+
 	struct NameCache {
 		StringName type_void;
 		StringName type_Array;


### PR DESCRIPTION
Implements `ScriptInstance::to_string` for C# which was introduced in #27886.
Also created a blacklist of methods that must not be generated. Includes: "to_string", "_to_string" and "_init". Fixes #29116
