### PR TITLE
Do not compute fog when using unshaded in GLES2

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -2133,8 +2133,6 @@ FRAGMENT_SHADER_CODE
 #endif
 	// gl_FragColor = vec4(normal, 1.0);
 
-#endif //unshaded
-
 //apply fog
 #if defined(FOG_DEPTH_ENABLED) || defined(FOG_HEIGHT_ENABLED)
 
@@ -2188,6 +2186,8 @@ FRAGMENT_SHADER_CODE
 #endif //use vertex lit
 
 #endif // defined(FOG_DEPTH_ENABLED) || defined(FOG_HEIGHT_ENABLED)
+
+#endif //unshaded
 
 #else // not RENDER_DEPTH
 //depth render


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/26235

Behaviour now matches GLES3. 