### PR TITLE
Change "Return" to "Returns" where necessary in XML documentation

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -36,14 +36,14 @@
 			<return type="Label">
 			</return>
 			<description>
-				Return the label used for built-in text.
+				Returns the label used for built-in text.
 			</description>
 		</method>
 		<method name="get_ok">
 			<return type="Button">
 			</return>
 			<description>
-				Return the OK Button.
+				Returns the OK Button.
 			</description>
 		</method>
 		<method name="register_text_enter">

--- a/doc/classes/AnimatedSprite.xml
+++ b/doc/classes/AnimatedSprite.xml
@@ -13,7 +13,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] if an animation if currently being played.
+				Returns [code]true[/code] if an animation if currently being played.
 			</description>
 		</method>
 		<method name="play">

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -13,7 +13,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] if an animation if currently being played.
+				Returns [code]true[/code] if an animation if currently being played.
 			</description>
 		</method>
 		<method name="play">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -263,14 +263,14 @@
 			<argument index="0" name="path" type="NodePath">
 			</argument>
 			<description>
-				Return the index of the specified track. If the track is not found, return -1.
+				Returns the index of the specified track. If the track is not found, return -1.
 			</description>
 		</method>
 		<method name="get_track_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of tracks in the animation.
+				Returns the amount of tracks in the animation.
 			</description>
 		</method>
 		<method name="method_track_get_key_indices" qualifiers="const">
@@ -283,7 +283,7 @@
 			<argument index="2" name="delta" type="float">
 			</argument>
 			<description>
-				Return all the key indices of a method track, given a position and delta time.
+				Returns all the key indices of a method track, given a position and delta time.
 			</description>
 		</method>
 		<method name="method_track_get_name" qualifiers="const">
@@ -294,7 +294,7 @@
 			<argument index="1" name="key_idx" type="int">
 			</argument>
 			<description>
-				Return the method name of a method track.
+				Returns the method name of a method track.
 			</description>
 		</method>
 		<method name="method_track_get_params" qualifiers="const">
@@ -305,7 +305,7 @@
 			<argument index="1" name="key_idx" type="int">
 			</argument>
 			<description>
-				Return the arguments values to be called on a method track for a given key in a given track.
+				Returns the arguments values to be called on a method track for a given key in a given track.
 			</description>
 		</method>
 		<method name="remove_track">
@@ -345,7 +345,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the interpolation type of a given track, from the INTERPOLATION_* enum.
+				Returns the interpolation type of a given track, from the INTERPOLATION_* enum.
 			</description>
 		</method>
 		<method name="track_get_key_count" qualifiers="const">
@@ -354,7 +354,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the amount of keys in a given track.
+				Returns the amount of keys in a given track.
 			</description>
 		</method>
 		<method name="track_get_key_time" qualifiers="const">
@@ -365,7 +365,7 @@
 			<argument index="1" name="key_idx" type="int">
 			</argument>
 			<description>
-				Return the time at which the key is located.
+				Returns the time at which the key is located.
 			</description>
 		</method>
 		<method name="track_get_key_transition" qualifiers="const">
@@ -376,7 +376,7 @@
 			<argument index="1" name="key_idx" type="int">
 			</argument>
 			<description>
-				Return the transition curve (easing) for a specific key (see built-in math function "ease").
+				Returns the transition curve (easing) for a specific key (see built-in math function "ease").
 			</description>
 		</method>
 		<method name="track_get_key_value" qualifiers="const">
@@ -387,7 +387,7 @@
 			<argument index="1" name="key_idx" type="int">
 			</argument>
 			<description>
-				Return the value of a given key in a given track.
+				Returns the value of a given key in a given track.
 			</description>
 		</method>
 		<method name="track_get_path" qualifiers="const">
@@ -438,7 +438,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return [code]true[/code] if the given track is imported. Else, return [code]false[/code].
+				Returns [code]true[/code] if the given track is imported. Else, return [code]false[/code].
 			</description>
 		</method>
 		<method name="track_move_down">
@@ -598,7 +598,7 @@
 			<argument index="1" name="time_sec" type="float">
 			</argument>
 			<description>
-				Return the interpolated value of a transform track at a given time (in seconds). An array consisting of 3 elements: position ([Vector3]), rotation ([Quat]) and scale ([Vector3]).
+				Returns the interpolated value of a transform track at a given time (in seconds). An array consisting of 3 elements: position ([Vector3]), rotation ([Quat]) and scale ([Vector3]).
 			</description>
 		</method>
 		<method name="value_track_get_key_indices" qualifiers="const">
@@ -611,7 +611,7 @@
 			<argument index="2" name="delta" type="float">
 			</argument>
 			<description>
-				Return all the key indices of a value track, given a position and delta time.
+				Returns all the key indices of a value track, given a position and delta time.
 			</description>
 		</method>
 		<method name="value_track_get_update_mode" qualifiers="const">
@@ -620,7 +620,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the update mode of a value track.
+				Returns the update mode of a value track.
 			</description>
 		</method>
 		<method name="value_track_set_update_mode">

--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -144,7 +144,7 @@
 			<return type="String">
 			</return>
 			<description>
-				Return [code]true[/code] whether you want the blend tree editor to display filter editing on this node.
+				Returns [code]true[/code] whether you want the blend tree editor to display filter editing on this node.
 			</description>
 		</method>
 		<method name="is_path_filtered" qualifiers="const">
@@ -153,7 +153,7 @@
 			<argument index="0" name="path" type="NodePath">
 			</argument>
 			<description>
-				Return [code]true[/code] whether a given path is filtered.
+				Returns [code]true[/code] whether a given path is filtered.
 			</description>
 		</method>
 		<method name="process" qualifiers="virtual">
@@ -204,7 +204,7 @@
 	</methods>
 	<members>
 		<member name="filter_enabled" type="bool" setter="set_filter_enabled" getter="is_filter_enabled">
-			Return whether filtering is enabled.
+			Returns whether filtering is enabled.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/AnimationTreePlayer.xml
+++ b/doc/classes/AnimationTreePlayer.xml
@@ -256,7 +256,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
-				Return the input count for a given node. Different types of nodes have different amount of inputs.
+				Returns the input count for a given node. Different types of nodes have different amount of inputs.
 			</description>
 		</method>
 		<method name="node_get_input_source" qualifiers="const">
@@ -267,7 +267,7 @@
 			<argument index="1" name="idx" type="int">
 			</argument>
 			<description>
-				Return the input source for a given node input.
+				Returns the input source for a given node input.
 			</description>
 		</method>
 		<method name="node_get_position" qualifiers="const">

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -15,7 +15,7 @@
 			<argument index="0" name="bit" type="int">
 			</argument>
 			<description>
-				Return an individual bit on the layer mask. Describes whether other areas will collide with this one on the given layer.
+				Returns an individual bit on the layer mask. Describes whether other areas will collide with this one on the given layer.
 			</description>
 		</method>
 		<method name="get_collision_mask_bit" qualifiers="const">
@@ -24,7 +24,7 @@
 			<argument index="0" name="bit" type="int">
 			</argument>
 			<description>
-				Return an individual bit on the collision mask. Describes whether this area will collide with others on the given layer.
+				Returns an individual bit on the collision mask. Describes whether this area will collide with others on the given layer.
 			</description>
 		</method>
 		<method name="get_overlapping_areas" qualifiers="const">

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -98,7 +98,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				Return the index of the first surface with this name held within this [ArrayMesh]. If none are found -1 is returned.
+				Returns the index of the first surface with this name held within this [ArrayMesh]. If none are found -1 is returned.
 			</description>
 		</method>
 		<method name="surface_get_array_index_len" qualifiers="const">
@@ -107,7 +107,7 @@
 			<argument index="0" name="surf_idx" type="int">
 			</argument>
 			<description>
-				Return the length in indices of the index array in the requested surface (see [method add_surface_from_arrays]).
+				Returns the length in indices of the index array in the requested surface (see [method add_surface_from_arrays]).
 			</description>
 		</method>
 		<method name="surface_get_array_len" qualifiers="const">
@@ -116,7 +116,7 @@
 			<argument index="0" name="surf_idx" type="int">
 			</argument>
 			<description>
-				Return the length in vertices of the vertex array in the requested surface (see [method add_surface_from_arrays]).
+				Returns the length in vertices of the vertex array in the requested surface (see [method add_surface_from_arrays]).
 			</description>
 		</method>
 		<method name="surface_get_format" qualifiers="const">
@@ -125,7 +125,7 @@
 			<argument index="0" name="surf_idx" type="int">
 			</argument>
 			<description>
-				Return the format mask of the requested surface (see [method add_surface_from_arrays]).
+				Returns the format mask of the requested surface (see [method add_surface_from_arrays]).
 			</description>
 		</method>
 		<method name="surface_get_name" qualifiers="const">
@@ -143,7 +143,7 @@
 			<argument index="0" name="surf_idx" type="int">
 			</argument>
 			<description>
-				Return the primitive type of the requested surface (see [method add_surface_from_arrays]).
+				Returns the primitive type of the requested surface (see [method add_surface_from_arrays]).
 			</description>
 		</method>
 		<method name="surface_remove">

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -29,14 +29,14 @@
 			<return type="int" enum="BaseButton.DrawMode">
 			</return>
 			<description>
-				Return the visual state used to draw the button. This is useful mainly when implementing your own draw code by either overriding _draw() or connecting to "draw" signal. The visual state of the button is defined by the DRAW_* enum.
+				Returns the visual state used to draw the button. This is useful mainly when implementing your own draw code by either overriding _draw() or connecting to "draw" signal. The visual state of the button is defined by the DRAW_* enum.
 			</description>
 		</method>
 		<method name="is_hovered" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] if the mouse has entered the button and has not left it yet.
+				Returns [code]true[/code] if the mouse has entered the button and has not left it yet.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -57,7 +57,7 @@
 			<return type="float">
 			</return>
 			<description>
-				Return the determinant of the matrix.
+				Returns the determinant of the matrix.
 			</description>
 		</method>
 		<method name="get_euler">
@@ -91,7 +91,7 @@
 			<return type="Basis">
 			</return>
 			<description>
-				Return the inverse of the matrix.
+				Returns the inverse of the matrix.
 			</description>
 		</method>
 		<method name="is_equal_approx">
@@ -108,7 +108,7 @@
 			<return type="Basis">
 			</return>
 			<description>
-				Return the orthonormalized version of the matrix (useful to call from time to time to avoid rounding error for orthogonal matrices). This performs a Gram-Schmidt orthonormalization on the basis of the matrix.
+				Returns the orthonormalized version of the matrix (useful to call from time to time to avoid rounding error for orthogonal matrices). This performs a Gram-Schmidt orthonormalization on the basis of the matrix.
 			</description>
 		</method>
 		<method name="rotated">
@@ -173,7 +173,7 @@
 			<return type="Basis">
 			</return>
 			<description>
-				Return the transposed version of the matrix.
+				Returns the transposed version of the matrix.
 			</description>
 		</method>
 		<method name="xform">
@@ -182,7 +182,7 @@
 			<argument index="0" name="v" type="Vector3">
 			</argument>
 			<description>
-				Return a vector transformed (multiplied) by the matrix.
+				Returns a vector transformed (multiplied) by the matrix.
 			</description>
 		</method>
 		<method name="xform_inv">
@@ -191,7 +191,7 @@
 			<argument index="0" name="v" type="Vector3">
 			</argument>
 			<description>
-				Return a vector transformed (multiplied) by the transposed matrix. Note that this results in a multiplication by the inverse of the matrix only if it represents a rotation-reflection.
+				Returns a vector transformed (multiplied) by the transposed matrix. Note that this results in a multiplication by the inverse of the matrix only if it represents a rotation-reflection.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -35,7 +35,7 @@
 			<return type="Vector2">
 			</return>
 			<description>
-				Return the camera position.
+				Returns the camera position.
 			</description>
 		</method>
 		<method name="get_camera_screen_center" qualifiers="const">

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -342,14 +342,14 @@
 			<return type="RID">
 			</return>
 			<description>
-				Return the [RID] of the [World2D] canvas where this item is in.
+				Returns the [RID] of the [World2D] canvas where this item is in.
 			</description>
 		</method>
 		<method name="get_canvas_item" qualifiers="const">
 			<return type="RID">
 			</return>
 			<description>
-				Return the canvas item RID used by [VisualServer] for this item.
+				Returns the canvas item RID used by [VisualServer] for this item.
 			</description>
 		</method>
 		<method name="get_canvas_transform" qualifiers="const">

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -121,7 +121,7 @@
 			<argument index="1" name="name" type="String">
 			</argument>
 			<description>
-				Return whether 'class' or its ancestry has an integer constant called 'name' or not.
+				Returns whether 'class' or its ancestry has an integer constant called 'name' or not.
 			</description>
 		</method>
 		<method name="class_has_method" qualifiers="const">
@@ -134,7 +134,7 @@
 			<argument index="2" name="no_inheritance" type="bool" default="false">
 			</argument>
 			<description>
-				Return whether 'class' (or its ancestry if 'no_inheritance' is false) has a method called 'method' or not.
+				Returns whether 'class' (or its ancestry if 'no_inheritance' is false) has a method called 'method' or not.
 			</description>
 		</method>
 		<method name="class_has_signal" qualifiers="const">
@@ -145,7 +145,7 @@
 			<argument index="1" name="signal" type="String">
 			</argument>
 			<description>
-				Return whether 'class' or its ancestry has a signal called 'signal' or not.
+				Returns whether 'class' or its ancestry has a signal called 'signal' or not.
 			</description>
 		</method>
 		<method name="class_set_property" qualifiers="const">

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -31,7 +31,7 @@
 			<return type="PoolColorArray">
 			</return>
 			<description>
-				Return the list of colors in the presets of the color picker.
+				Returns the list of colors in the presets of the color picker.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ConcavePolygonShape.xml
+++ b/doc/classes/ConcavePolygonShape.xml
@@ -13,7 +13,7 @@
 			<return type="PoolVector3Array">
 			</return>
 			<description>
-				Return the faces (an array of triangles).
+				Returns the faces (an array of triangles).
 			</description>
 		</method>
 		<method name="set_faces">

--- a/doc/classes/ConfirmationDialog.xml
+++ b/doc/classes/ConfirmationDialog.xml
@@ -13,7 +13,7 @@
 			<return type="Button">
 			</return>
 			<description>
-				Return the cancel button.
+				Returns the cancel button.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -221,7 +221,7 @@
 			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
-				Godot calls this method to get data that can be dragged and dropped onto controls that expect drop data. Return null if there is no data to drag. Controls that want to receive drop data should implement [method can_drop_data] and [method drop_data]. [code]position[/code] is local to this control. Drag may be forced with [method force_drag].
+				Godot calls this method to get data that can be dragged and dropped onto controls that expect drop data. Returns null if there is no data to drag. Controls that want to receive drop data should implement [method can_drop_data] and [method drop_data]. [code]position[/code] is local to this control. Drag may be forced with [method force_drag].
 				A preview that will follow the mouse that should represent the data can be set with [method set_drag_preview]. A good time to set the preview is in this method.
 				[codeblock]
 				extends Control

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -38,7 +38,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] if the dictionary is empty.
+				Returns [code]true[/code] if the dictionary is empty.
 			</description>
 		</method>
 		<method name="erase">
@@ -67,7 +67,7 @@
 			<argument index="0" name="key" type="Variant">
 			</argument>
 			<description>
-				Return [code]true[/code] if the dictionary has a given key.
+				Returns [code]true[/code] if the dictionary has a given key.
 			</description>
 		</method>
 		<method name="has_all">
@@ -76,35 +76,35 @@
 			<argument index="0" name="keys" type="Array">
 			</argument>
 			<description>
-				Return [code]true[/code] if the dictionary has all of the keys in the given array.
+				Returns [code]true[/code] if the dictionary has all of the keys in the given array.
 			</description>
 		</method>
 		<method name="hash">
 			<return type="int">
 			</return>
 			<description>
-				Return a hashed integer value representing the dictionary contents.
+				Returns a hashed integer value representing the dictionary contents.
 			</description>
 		</method>
 		<method name="keys">
 			<return type="Array">
 			</return>
 			<description>
-				Return the list of keys in the [Dictionary].
+				Returns the list of keys in the [Dictionary].
 			</description>
 		</method>
 		<method name="size">
 			<return type="int">
 			</return>
 			<description>
-				Return the size of the dictionary (in pairs).
+				Returns the size of the dictionary (in pairs).
 			</description>
 		</method>
 		<method name="values">
 			<return type="Array">
 			</return>
 			<description>
-				Return the list of values in the [Dictionary].
+				Returns the list of values in the [Dictionary].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -52,7 +52,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return whether the current item processed with the last [method get_next] call is a directory ([code].[/code] and [code]..[/code] are considered directories).
+				Returns whether the current item processed with the last [method get_next] call is a directory ([code].[/code] and [code]..[/code] are considered directories).
 			</description>
 		</method>
 		<method name="dir_exists">
@@ -61,7 +61,7 @@
 			<argument index="0" name="path" type="String">
 			</argument>
 			<description>
-				Return whether the target directory exists. The argument can be relative to the current directory, or an absolute path.
+				Returns whether the target directory exists. The argument can be relative to the current directory, or an absolute path.
 			</description>
 		</method>
 		<method name="file_exists">
@@ -70,14 +70,14 @@
 			<argument index="0" name="path" type="String">
 			</argument>
 			<description>
-				Return whether the target file exists. The argument can be relative to the current directory, or an absolute path.
+				Returns whether the target file exists. The argument can be relative to the current directory, or an absolute path.
 			</description>
 		</method>
 		<method name="get_current_dir">
 			<return type="String">
 			</return>
 			<description>
-				Return the absolute path to the currently opened directory (e.g. [code]res://folder[/code] or [code]C:\tmp\folder[/code]).
+				Returns the absolute path to the currently opened directory (e.g. [code]res://folder[/code] or [code]C:\tmp\folder[/code]).
 			</description>
 		</method>
 		<method name="get_current_drive">
@@ -107,7 +107,7 @@
 			<return type="String">
 			</return>
 			<description>
-				Return the next element (file or directory) in the current directory (including [code].[/code] and [code]..[/code], unless [code]skip_navigational[/code] was given to [method list_dir_begin]).
+				Returns the next element (file or directory) in the current directory (including [code].[/code] and [code]..[/code], unless [code]skip_navigational[/code] was given to [method list_dir_begin]).
 				The name of the file or directory is returned (and not its full path). Once the stream has been fully processed, the method returns an empty String and closes the stream automatically (i.e. [method list_dir_end] would not be mandatory in such a case).
 			</description>
 		</method>
@@ -155,7 +155,7 @@
 			</argument>
 			<description>
 				Create a target directory and all necessary intermediate directories in its path, by calling [method make_dir] recursively. The argument can be relative to the current directory, or an absolute path.
-				Return one of the error code constants defined in [@GlobalScope] (OK, FAILED or ERR_*).
+				Returns one of the error code constants defined in [@GlobalScope] (OK, FAILED or ERR_*).
 			</description>
 		</method>
 		<method name="open">
@@ -175,7 +175,7 @@
 			</argument>
 			<description>
 				Delete the target file or an empty directory. The argument can be relative to the current directory, or an absolute path. If the target directory is not empty, the operation will fail.
-				Return one of the error code constants defined in [@GlobalScope] (OK or FAILED).
+				Returns one of the error code constants defined in [@GlobalScope] (OK or FAILED).
 			</description>
 		</method>
 		<method name="rename">
@@ -187,7 +187,7 @@
 			</argument>
 			<description>
 				Rename (move) the [i]from[/i] file to the [i]to[/i] destination. Both arguments should be paths to files, either relative or absolute. If the destination file exists and is not access-protected, it will be overwritten.
-				Return one of the error code constants defined in [@GlobalScope] (OK or FAILED).
+				Returns one of the error code constants defined in [@GlobalScope] (OK or FAILED).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -38,14 +38,14 @@
 			<return type="float">
 			</return>
 			<description>
-				Return the scan progress for 0 to 1 if the FS is being scanned.
+				Returns the scan progress for 0 to 1 if the FS is being scanned.
 			</description>
 		</method>
 		<method name="is_scanning" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] of the filesystem is being scanned.
+				Returns [code]true[/code] of the filesystem is being scanned.
 			</description>
 		</method>
 		<method name="scan">

--- a/doc/classes/EditorInspectorPlugin.xml
+++ b/doc/classes/EditorInspectorPlugin.xml
@@ -54,7 +54,7 @@
 			<argument index="0" name="object" type="Object">
 			</argument>
 			<description>
-				Return true if this object can be handled by this plugin.
+				Returns true if this object can be handled by this plugin.
 			</description>
 		</method>
 		<method name="parse_begin" qualifiers="virtual">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -241,7 +241,7 @@
 			<return type="EditorInterface">
 			</return>
 			<description>
-				Return the [EditorInterface] object that gives you control over Godot editor's window and its functionalities.
+				Returns the [EditorInterface] object that gives you control over Godot editor's window and its functionalities.
 			</description>
 		</method>
 		<method name="get_plugin_icon" qualifiers="virtual">
@@ -299,7 +299,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] if this is a main screen editor plugin (it goes in the workspaces selector together with '2D', '3D', and 'Script').
+				Returns [code]true[/code] if this is a main screen editor plugin (it goes in the workspaces selector together with '2D', '3D', and 'Script').
 			</description>
 		</method>
 		<method name="hide_bottom_panel">

--- a/doc/classes/EditorResourcePreviewGenerator.xml
+++ b/doc/classes/EditorResourcePreviewGenerator.xml
@@ -57,7 +57,7 @@
 			<argument index="0" name="type" type="String">
 			</argument>
 			<description>
-				Return if your generator supports this resource type.
+				Returns if your generator supports this resource type.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorSpatialGizmo.xml
+++ b/doc/classes/EditorSpatialGizmo.xml
@@ -123,7 +123,7 @@
 			<return type="EditorSpatialGizmoPlugin">
 			</return>
 			<description>
-				Return the [EditorSpatialGizmoPlugin] that owns this gizmo. It's useful to retrieve materials using [method EditorSpatialGizmoPlugin.get_material].
+				Returns the [EditorSpatialGizmoPlugin] that owns this gizmo. It's useful to retrieve materials using [method EditorSpatialGizmoPlugin.get_material].
 			</description>
 		</method>
 		<method name="get_spatial_node" qualifiers="const">

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -43,7 +43,7 @@
 			<return type="VBoxContainer">
 			</return>
 			<description>
-				Return the vertical box container of the dialog, custom controls can be added to it.
+				Returns the vertical box container of the dialog, custom controls can be added to it.
 			</description>
 		</method>
 		<method name="invalidate">

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -51,21 +51,21 @@
 			<return type="float">
 			</return>
 			<description>
-				Return the font ascent (number of pixels above the baseline).
+				Returns the font ascent (number of pixels above the baseline).
 			</description>
 		</method>
 		<method name="get_descent" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
-				Return the font descent (number of pixels below the baseline).
+				Returns the font descent (number of pixels below the baseline).
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
-				Return the total font height (ascent plus descent) in pixels.
+				Returns the total font height (ascent plus descent) in pixels.
 			</description>
 		</method>
 		<method name="get_string_size" qualifiers="const">
@@ -74,7 +74,7 @@
 			<argument index="0" name="string" type="String">
 			</argument>
 			<description>
-				Return the size of a string, taking kerning and advance into account.
+				Returns the size of a string, taking kerning and advance into account.
 			</description>
 		</method>
 		<method name="get_wordwrap_string_size" qualifiers="const">

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -80,7 +80,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Return an Array containing the list of connections. A connection consists in a structure of the form {from_port: 0, from: "GraphNode name 0", to_port: 1, to: "GraphNode name 1" }
+				Returns an Array containing the list of connections. A connection consists in a structure of the form {from_port: 0, from: "GraphNode name 0", to_port: 1, to: "GraphNode name 1" }
 			</description>
 		</method>
 		<method name="get_zoom_hbox">
@@ -101,7 +101,7 @@
 			<argument index="3" name="to_port" type="int">
 			</argument>
 			<description>
-				Return [code]true[/code] if the 'from_port' slot of 'from' GraphNode is connected to the 'to_port' slot of 'to' GraphNode.
+				Returns [code]true[/code] if the 'from_port' slot of 'from' GraphNode is connected to the 'to_port' slot of 'to' GraphNode.
 			</description>
 		</method>
 		<method name="is_valid_connection_type" qualifiers="const">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -31,14 +31,14 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the color of the input connection 'idx'.
+				Returns the color of the input connection 'idx'.
 			</description>
 		</method>
 		<method name="get_connection_input_count">
 			<return type="int">
 			</return>
 			<description>
-				Return the number of enabled input slots (connections) to the GraphNode.
+				Returns the number of enabled input slots (connections) to the GraphNode.
 			</description>
 		</method>
 		<method name="get_connection_input_position">
@@ -47,7 +47,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the position of the input connection 'idx'.
+				Returns the position of the input connection 'idx'.
 			</description>
 		</method>
 		<method name="get_connection_input_type">
@@ -56,7 +56,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the type of the input connection 'idx'.
+				Returns the type of the input connection 'idx'.
 			</description>
 		</method>
 		<method name="get_connection_output_color">
@@ -65,14 +65,14 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the color of the output connection 'idx'.
+				Returns the color of the output connection 'idx'.
 			</description>
 		</method>
 		<method name="get_connection_output_count">
 			<return type="int">
 			</return>
 			<description>
-				Return the number of enabled output slots (connections) of the GraphNode.
+				Returns the number of enabled output slots (connections) of the GraphNode.
 			</description>
 		</method>
 		<method name="get_connection_output_position">
@@ -81,7 +81,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the position of the output connection 'idx'.
+				Returns the position of the output connection 'idx'.
 			</description>
 		</method>
 		<method name="get_connection_output_type">
@@ -90,7 +90,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the type of the output connection 'idx'.
+				Returns the type of the output connection 'idx'.
 			</description>
 		</method>
 		<method name="get_slot_color_left" qualifiers="const">
@@ -99,7 +99,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the color set to 'idx' left (input) slot.
+				Returns the color set to 'idx' left (input) slot.
 			</description>
 		</method>
 		<method name="get_slot_color_right" qualifiers="const">
@@ -108,7 +108,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the color set to 'idx' right (output) slot.
+				Returns the color set to 'idx' right (output) slot.
 			</description>
 		</method>
 		<method name="get_slot_type_left" qualifiers="const">
@@ -117,7 +117,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the (integer) type of left (input) 'idx' slot.
+				Returns the (integer) type of left (input) 'idx' slot.
 			</description>
 		</method>
 		<method name="get_slot_type_right" qualifiers="const">
@@ -126,7 +126,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the (integer) type of right (output) 'idx' slot.
+				Returns the (integer) type of right (output) 'idx' slot.
 			</description>
 		</method>
 		<method name="is_slot_enabled_left" qualifiers="const">
@@ -135,7 +135,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return [code]true[/code] if left (input) slot 'idx' is enabled, [code]false[/code] otherwise.
+				Returns [code]true[/code] if left (input) slot 'idx' is enabled, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="is_slot_enabled_right" qualifiers="const">
@@ -144,7 +144,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return [code]true[/code] if right (output) slot 'idx' is enabled, [code]false[/code] otherwise.
+				Returns [code]true[/code] if right (output) slot 'idx' is enabled, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="set_slot">

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -40,7 +40,7 @@
 			<return type="int" enum="Image.Format">
 			</return>
 			<description>
-				Return the format of the [ImageTexture], one of [enum Image.Format].
+				Returns the format of the [ImageTexture], one of [enum Image.Format].
 			</description>
 		</method>
 		<method name="load">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -194,7 +194,7 @@
 			<return type="int" enum="Input.MouseMode">
 			</return>
 			<description>
-				Return the mouse mode. See the constants for more information.
+				Returns the mouse mode. See the constants for more information.
 			</description>
 		</method>
 		<method name="is_action_just_pressed" qualifiers="const">

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -64,7 +64,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return count of items currently in the item list.
+				Returns count of items currently in the item list.
 			</description>
 		</method>
 		<method name="get_item_custom_bg_color" qualifiers="const">
@@ -122,7 +122,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the text for specified item index.
+				Returns the text for specified item index.
 			</description>
 		</method>
 		<method name="get_item_tooltip" qualifiers="const">
@@ -131,7 +131,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return tooltip hint for specified item index.
+				Returns tooltip hint for specified item index.
 			</description>
 		</method>
 		<method name="get_selected_items">

--- a/doc/classes/Marshalls.xml
+++ b/doc/classes/Marshalls.xml
@@ -15,7 +15,7 @@
 			<argument index="0" name="base64_str" type="String">
 			</argument>
 			<description>
-				Return [PoolByteArray] of a given base64 encoded String.
+				Returns [PoolByteArray] of a given base64 encoded String.
 			</description>
 		</method>
 		<method name="base64_to_utf8">
@@ -24,7 +24,7 @@
 			<argument index="0" name="base64_str" type="String">
 			</argument>
 			<description>
-				Return utf8 String of a given base64 encoded String.
+				Returns utf8 String of a given base64 encoded String.
 			</description>
 		</method>
 		<method name="base64_to_variant">
@@ -35,7 +35,7 @@
 			<argument index="1" name="allow_objects" type="bool" default="false">
 			</argument>
 			<description>
-				Return [Variant] of a given base64 encoded String. When [code]allow_objects[/code] is [code]true[/code] decoding objects is allowed.
+				Returns [Variant] of a given base64 encoded String. When [code]allow_objects[/code] is [code]true[/code] decoding objects is allowed.
 				[b]WARNING:[/b] Deserialized object can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats (remote code execution).
 			</description>
 		</method>
@@ -45,7 +45,7 @@
 			<argument index="0" name="array" type="PoolByteArray">
 			</argument>
 			<description>
-				Return base64 encoded String of a given [PoolByteArray].
+				Returns base64 encoded String of a given [PoolByteArray].
 			</description>
 		</method>
 		<method name="utf8_to_base64">
@@ -54,7 +54,7 @@
 			<argument index="0" name="utf8_str" type="String">
 			</argument>
 			<description>
-				Return base64 encoded String of a given utf8 String.
+				Returns base64 encoded String of a given utf8 String.
 			</description>
 		</method>
 		<method name="variant_to_base64">
@@ -65,7 +65,7 @@
 			<argument index="1" name="full_objects" type="bool" default="false">
 			</argument>
 			<description>
-				Return base64 encoded String of a given [Variant]. When [code]full_objects[/code] is [code]true[/code] encoding objects is allowed (and can potentially include code).
+				Returns base64 encoded String of a given [Variant]. When [code]full_objects[/code] is [code]true[/code] encoding objects is allowed (and can potentially include code).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -13,7 +13,7 @@
 			<return type="PopupMenu">
 			</return>
 			<description>
-				Return the [PopupMenu] contained in this button.
+				Returns the [PopupMenu] contained in this button.
 			</description>
 		</method>
 		<method name="set_disable_shortcuts">

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -50,7 +50,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of surfaces that the [Mesh] holds.
+				Returns the amount of surfaces that the [Mesh] holds.
 			</description>
 		</method>
 		<method name="surface_get_arrays" qualifiers="const">
@@ -77,7 +77,7 @@
 			<argument index="0" name="surf_idx" type="int">
 			</argument>
 			<description>
-				Return a [Material] in a given surface. Surface is rendered using this material.
+				Returns a [Material] in a given surface. Surface is rendered using this material.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -37,7 +37,7 @@
 			<return type="PoolIntArray">
 			</return>
 			<description>
-				Return the list of items.
+				Returns the list of items.
 			</description>
 		</method>
 		<method name="get_item_mesh" qualifiers="const">
@@ -46,7 +46,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Return the mesh of the item.
+				Returns the mesh of the item.
 			</description>
 		</method>
 		<method name="get_item_name" qualifiers="const">
@@ -55,7 +55,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Return the name of the item.
+				Returns the name of the item.
 			</description>
 		</method>
 		<method name="get_item_navmesh" qualifiers="const">

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -17,7 +17,7 @@
 			<return type="AABB">
 			</return>
 			<description>
-				Return the visibility AABB.
+				Returns the visibility AABB.
 			</description>
 		</method>
 		<method name="get_instance_color" qualifiers="const">
@@ -35,7 +35,7 @@
 			<argument index="0" name="instance" type="int">
 			</argument>
 			<description>
-				Return the custom data that has been set for a specific instance.
+				Returns the custom data that has been set for a specific instance.
 			</description>
 		</method>
 		<method name="get_instance_transform" qualifiers="const">
@@ -44,7 +44,7 @@
 			<argument index="0" name="instance" type="int">
 			</argument>
 			<description>
-				Return the [Transform] of a specific instance.
+				Returns the [Transform] of a specific instance.
 			</description>
 		</method>
 		<method name="get_instance_transform_2d" qualifiers="const">
@@ -53,7 +53,7 @@
 			<argument index="0" name="instance" type="int">
 			</argument>
 			<description>
-				Return the [Transform2D] of a specific instance.
+				Returns the [Transform2D] of a specific instance.
 			</description>
 		</method>
 		<method name="set_as_bulk_array">

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -68,14 +68,14 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] if the node path is absolute (not relative).
+				Returns [code]true[/code] if the node path is absolute (not relative).
 			</description>
 		</method>
 		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] if the node path is empty.
+				Returns [code]true[/code] if the node path is empty.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -51,7 +51,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of items in the OptionButton.
+				Returns the amount of items in the OptionButton.
 			</description>
 		</method>
 		<method name="get_item_icon" qualifiers="const">
@@ -60,7 +60,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the icon of the item at index "idx".
+				Returns the icon of the item at index "idx".
 			</description>
 		</method>
 		<method name="get_item_id" qualifiers="const">
@@ -69,7 +69,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the ID of the item at index [code]idx[/code].
+				Returns the ID of the item at index [code]idx[/code].
 			</description>
 		</method>
 		<method name="get_item_index" qualifiers="const">
@@ -78,7 +78,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Return the index of the item with the given [code]id[/code].
+				Returns the index of the item with the given [code]id[/code].
 			</description>
 		</method>
 		<method name="get_item_metadata" qualifiers="const">
@@ -95,14 +95,14 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the text of the item at index "idx".
+				Returns the text of the item at index "idx".
 			</description>
 		</method>
 		<method name="get_popup" qualifiers="const">
 			<return type="PopupMenu">
 			</return>
 			<description>
-				Return the [PopupMenu] contained in this button.
+				Returns the [PopupMenu] contained in this button.
 			</description>
 		</method>
 		<method name="get_selected_id" qualifiers="const">

--- a/doc/classes/PacketPeer.xml
+++ b/doc/classes/PacketPeer.xml
@@ -13,7 +13,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the number of packets currently available in the ring-buffer.
+				Returns the number of packets currently available in the ring-buffer.
 			</description>
 		</method>
 		<method name="get_packet">
@@ -27,7 +27,7 @@
 			<return type="int" enum="Error">
 			</return>
 			<description>
-				Return the error state of the last packet received (via [method get_packet] and [method get_var]).
+				Returns the error state of the last packet received (via [method get_packet] and [method get_var]).
 			</description>
 		</method>
 		<method name="get_var">

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -20,21 +20,21 @@
 			<return type="String">
 			</return>
 			<description>
-				Return the IP of the remote peer that sent the last packet(that was received with [method PacketPeer.get_packet] or [method PacketPeer.get_var]).
+				Returns the IP of the remote peer that sent the last packet(that was received with [method PacketPeer.get_packet] or [method PacketPeer.get_var]).
 			</description>
 		</method>
 		<method name="get_packet_port" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the port of the remote peer that sent the last packet(that was received with [method PacketPeer.get_packet] or [method PacketPeer.get_var]).
+				Returns the port of the remote peer that sent the last packet(that was received with [method PacketPeer.get_packet] or [method PacketPeer.get_var]).
 			</description>
 		</method>
 		<method name="is_listening" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Return whether this [PacketPeerUDP] is listening.
+				Returns whether this [PacketPeerUDP] is listening.
 			</description>
 		</method>
 		<method name="listen">

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -116,14 +116,14 @@
 			<return type="String">
 			</return>
 			<description>
-				Return SHA256 string of the PoolByteArray.
+				Returns SHA256 string of the PoolByteArray.
 			</description>
 		</method>
 		<method name="size">
 			<return type="int">
 			</return>
 			<description>
-				Return the size of the array.
+				Returns the size of the array.
 			</description>
 		</method>
 		<method name="subarray">

--- a/doc/classes/PoolColorArray.xml
+++ b/doc/classes/PoolColorArray.xml
@@ -82,7 +82,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the size of the array.
+				Returns the size of the array.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -82,7 +82,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the array size.
+				Returns the array size.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -82,7 +82,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the size of the array.
+				Returns the size of the array.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PoolStringArray.xml
+++ b/doc/classes/PoolStringArray.xml
@@ -91,7 +91,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the size of the array.
+				Returns the size of the array.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PoolVector2Array.xml
+++ b/doc/classes/PoolVector2Array.xml
@@ -82,7 +82,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the size of the array.
+				Returns the size of the array.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PoolVector3Array.xml
+++ b/doc/classes/PoolVector3Array.xml
@@ -82,7 +82,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the size of the array.
+				Returns the size of the array.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -178,14 +178,14 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the accelerator of the item at index "idx". Accelerators are special combinations of keys that activate the item, no matter which control is focused.
+				Returns the accelerator of the item at index "idx". Accelerators are special combinations of keys that activate the item, no matter which control is focused.
 			</description>
 		</method>
 		<method name="get_item_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of items.
+				Returns the amount of items.
 			</description>
 		</method>
 		<method name="get_item_icon" qualifiers="const">
@@ -194,7 +194,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the icon of the item at index "idx".
+				Returns the icon of the item at index "idx".
 			</description>
 		</method>
 		<method name="get_item_id" qualifiers="const">
@@ -203,7 +203,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the id of the item at index "idx".
+				Returns the id of the item at index "idx".
 			</description>
 		</method>
 		<method name="get_item_index" qualifiers="const">
@@ -221,7 +221,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the metadata of an item, which might be of any type. You can set it with [method set_item_metadata], which provides a simple way of assigning context data to items.
+				Returns the metadata of an item, which might be of any type. You can set it with [method set_item_metadata], which provides a simple way of assigning context data to items.
 			</description>
 		</method>
 		<method name="get_item_shortcut" qualifiers="const">
@@ -238,7 +238,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the submenu name of the item at index "idx".
+				Returns the submenu name of the item at index "idx".
 			</description>
 		</method>
 		<method name="get_item_text" qualifiers="const">
@@ -247,7 +247,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the text of the item at index "idx".
+				Returns the text of the item at index "idx".
 			</description>
 		</method>
 		<method name="get_item_tooltip" qualifiers="const">
@@ -270,7 +270,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return whether the item at index "idx" is checkable in some way, i.e., whether has a checkbox or radio button. Note that checkable items just display a checkmark or radio button, but don't have any built-in checking behavior and must be checked/unchecked manually.
+				Returns whether the item at index "idx" is checkable in some way, i.e., whether has a checkbox or radio button. Note that checkable items just display a checkmark or radio button, but don't have any built-in checking behavior and must be checked/unchecked manually.
 			</description>
 		</method>
 		<method name="is_item_checked" qualifiers="const">
@@ -279,7 +279,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return whether the item at index "idx" is checked.
+				Returns whether the item at index "idx" is checked.
 			</description>
 		</method>
 		<method name="is_item_disabled" qualifiers="const">
@@ -288,7 +288,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return whether the item at index "idx" is disabled. When it is disabled it can't be selected, or its action invoked.
+				Returns whether the item at index "idx" is disabled. When it is disabled it can't be selected, or its action invoked.
 			</description>
 		</method>
 		<method name="is_item_radio_checkable" qualifiers="const">
@@ -297,7 +297,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return whether the item at index "idx" has radio-button-style checkability. Remember this is just cosmetic and you have to add the logic for checking/unchecking items in radio groups.
+				Returns whether the item at index "idx" has radio-button-style checkability. Remember this is just cosmetic and you have to add the logic for checking/unchecking items in radio groups.
 			</description>
 		</method>
 		<method name="is_item_separator" qualifiers="const">
@@ -306,7 +306,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return whether the item is a separator. If it is, it would be displayed as a line.
+				Returns whether the item is a separator. If it is, it would be displayed as a line.
 			</description>
 		</method>
 		<method name="is_item_shortcut_disabled" qualifiers="const">

--- a/doc/classes/Quat.xml
+++ b/doc/classes/Quat.xml
@@ -84,7 +84,7 @@
 			<return type="Vector3">
 			</return>
 			<description>
-				Return Euler angles (in the YXZ convention: first Z, then X, and Y last) corresponding to the rotation represented by the unit quaternion. Returned vector contains the rotation angles in the format (X-angle, Y-angle, Z-angle).
+				Returns Euler angles (in the YXZ convention: first Z, then X, and Y last) corresponding to the rotation represented by the unit quaternion. Returned vector contains the rotation angles in the format (X-angle, Y-angle, Z-angle).
 			</description>
 		</method>
 		<method name="inverse">

--- a/doc/classes/RayCast.xml
+++ b/doc/classes/RayCast.xml
@@ -50,7 +50,7 @@
 			<return type="Object">
 			</return>
 			<description>
-				Return the first object that the ray intersects, or [code]null[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the first object that the ray intersects, or [code]null[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
@@ -87,7 +87,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return whether any object is intersecting with the ray's vector (considering the vector length).
+				Returns whether any object is intersecting with the ray's vector (considering the vector length).
 			</description>
 		</method>
 		<method name="remove_exception">

--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -49,7 +49,7 @@
 			<return type="Object">
 			</return>
 			<description>
-				Return the first object that the ray intersects, or [code]null[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the first object that the ray intersects, or [code]null[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
@@ -65,7 +65,7 @@
 			<argument index="0" name="bit" type="int">
 			</argument>
 			<description>
-				Return an individual bit on the collision mask.
+				Returns an individual bit on the collision mask.
 			</description>
 		</method>
 		<method name="get_collision_normal" qualifiers="const">
@@ -86,7 +86,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return whether any object is intersecting with the ray's vector (considering the vector length).
+				Returns whether any object is intersecting with the ray's vector (considering the vector length).
 			</description>
 		</method>
 		<method name="remove_exception">

--- a/doc/classes/ResourceInteractiveLoader.xml
+++ b/doc/classes/ResourceInteractiveLoader.xml
@@ -13,21 +13,21 @@
 			<return type="Resource">
 			</return>
 			<description>
-				Return the loaded resource (only if loaded). Otherwise, returns null.
+				Returns the loaded resource (only if loaded). Otherwise, returns null.
 			</description>
 		</method>
 		<method name="get_stage" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the load stage. The total amount of stages can be queried with [method get_stage_count]
+				Returns the load stage. The total amount of stages can be queried with [method get_stage_count]
 			</description>
 		</method>
 		<method name="get_stage_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the total amount of stages (calls to [method poll]) needed to completely load this resource.
+				Returns the total amount of stages (calls to [method poll]) needed to completely load this resource.
 			</description>
 		</method>
 		<method name="poll">

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -33,7 +33,7 @@
 			<argument index="0" name="type" type="String">
 			</argument>
 			<description>
-				Return the list of recognized extensions for a resource type.
+				Returns the list of recognized extensions for a resource type.
 			</description>
 		</method>
 		<method name="has">

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -86,7 +86,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Return a list of the bodies colliding with this one. By default, number of max contacts reported is at 0, see the [member contacts_reported] property to increase it. Note that the result of this test is not immediate after moving objects. For performance, list of collisions is updated once per frame and before the physics step. Consider using signals instead.
+				Returns a list of the bodies colliding with this one. By default, number of max contacts reported is at 0, see the [member contacts_reported] property to increase it. Note that the result of this test is not immediate after moving objects. For performance, list of collisions is updated once per frame and before the physics step. Consider using signals instead.
 			</description>
 		</method>
 		<method name="set_axis_velocity">

--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -52,7 +52,7 @@
 			<argument index="4" name="shape_motion" type="Vector2">
 			</argument>
 			<description>
-				Return whether this shape would collide with another, if a given movement was applied.
+				Returns whether this shape would collide with another, if a given movement was applied.
 				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the movement to test on this shape ([code]local_motion[/code]), the shape to check collisions with ([code]with_shape[/code]), the transformation matrix of that shape ([code]shape_xform[/code]), and the movement to test onto the other object ([code]shape_motion[/code]).
 			</description>
 		</method>

--- a/doc/classes/Skeleton.xml
+++ b/doc/classes/Skeleton.xml
@@ -44,14 +44,14 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				Return the bone index that matches "name" as its name.
+				Returns the bone index that matches "name" as its name.
 			</description>
 		</method>
 		<method name="get_bone_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of bones in the skeleton.
+				Returns the amount of bones in the skeleton.
 			</description>
 		</method>
 		<method name="get_bone_custom_pose" qualifiers="const">
@@ -60,7 +60,7 @@
 			<argument index="0" name="bone_idx" type="int">
 			</argument>
 			<description>
-				Return the custom pose of the specified bone. Custom pose is applied on top of the rest pose.
+				Returns the custom pose of the specified bone. Custom pose is applied on top of the rest pose.
 			</description>
 		</method>
 		<method name="get_bone_global_pose" qualifiers="const">
@@ -69,7 +69,7 @@
 			<argument index="0" name="bone_idx" type="int">
 			</argument>
 			<description>
-				Return the overall transform of the specified bone, with respect to the skeleton. Being relative to the skeleton frame, this is not the actual "global" transform of the bone.
+				Returns the overall transform of the specified bone, with respect to the skeleton. Being relative to the skeleton frame, this is not the actual "global" transform of the bone.
 			</description>
 		</method>
 		<method name="get_bone_name" qualifiers="const">
@@ -78,7 +78,7 @@
 			<argument index="0" name="bone_idx" type="int">
 			</argument>
 			<description>
-				Return the name of the bone at index "index".
+				Returns the name of the bone at index "index".
 			</description>
 		</method>
 		<method name="get_bone_parent" qualifiers="const">
@@ -87,7 +87,7 @@
 			<argument index="0" name="bone_idx" type="int">
 			</argument>
 			<description>
-				Return the bone index which is the parent of the bone at "bone_idx". If -1, then bone has no parent. Note that the parent bone returned will always be less than "bone_idx".
+				Returns the bone index which is the parent of the bone at "bone_idx". If -1, then bone has no parent. Note that the parent bone returned will always be less than "bone_idx".
 			</description>
 		</method>
 		<method name="get_bone_pose" qualifiers="const">
@@ -96,7 +96,7 @@
 			<argument index="0" name="bone_idx" type="int">
 			</argument>
 			<description>
-				Return the pose transform of the specified bone. Pose is applied on top of the custom pose, which is applied on top the rest pose.
+				Returns the pose transform of the specified bone. Pose is applied on top of the custom pose, which is applied on top the rest pose.
 			</description>
 		</method>
 		<method name="get_bone_rest" qualifiers="const">
@@ -105,7 +105,7 @@
 			<argument index="0" name="bone_idx" type="int">
 			</argument>
 			<description>
-				Return the rest transform for a bone "bone_idx".
+				Returns the rest transform for a bone "bone_idx".
 			</description>
 		</method>
 		<method name="get_bone_transform" qualifiers="const">
@@ -114,7 +114,7 @@
 			<argument index="0" name="bone_idx" type="int">
 			</argument>
 			<description>
-				Return the combination of custom pose and pose. The returned transform is in skeleton's reference frame.
+				Returns the combination of custom pose and pose. The returned transform is in skeleton's reference frame.
 			</description>
 		</method>
 		<method name="get_bound_child_nodes_to_bone" qualifiers="const">
@@ -229,7 +229,7 @@
 			<argument index="1" name="pose" type="Transform">
 			</argument>
 			<description>
-				Return the pose transform for bone "bone_idx".
+				Returns the pose transform for bone "bone_idx".
 			</description>
 		</method>
 		<method name="set_bone_rest">

--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -41,7 +41,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of bytes this [StreamPeer] has available.
+				Returns the amount of bytes this [StreamPeer] has available.
 			</description>
 		</method>
 		<method name="get_data">
@@ -50,7 +50,7 @@
 			<argument index="0" name="bytes" type="int">
 			</argument>
 			<description>
-				Return a chunk data with the received bytes. The amount of bytes to be received can be requested in the "bytes" argument. If not enough bytes are available, the function will block until the desired amount is received. This function returns two values, an Error code and a data array.
+				Returns a chunk data with the received bytes. The amount of bytes to be received can be requested in the "bytes" argument. If not enough bytes are available, the function will block until the desired amount is received. This function returns two values, an Error code and a data array.
 			</description>
 		</method>
 		<method name="get_double">
@@ -73,7 +73,7 @@
 			<argument index="0" name="bytes" type="int">
 			</argument>
 			<description>
-				Return a chunk data with the received bytes. The amount of bytes to be received can be requested in the "bytes" argument. If not enough bytes are available, the function will return how many were actually received. This function returns two values, an Error code, and a data array.
+				Returns a chunk data with the received bytes. The amount of bytes to be received can be requested in the "bytes" argument. If not enough bytes are available, the function will return how many were actually received. This function returns two values, an Error code, and a data array.
 			</description>
 		</method>
 		<method name="get_string">

--- a/doc/classes/StreamPeerSSL.xml
+++ b/doc/classes/StreamPeerSSL.xml
@@ -42,7 +42,7 @@
 			<return type="int" enum="StreamPeerSSL.Status">
 			</return>
 			<description>
-				Return the status of the connection, one of STATUS_* enum.
+				Returns the status of the connection, one of STATUS_* enum.
 			</description>
 		</method>
 		<method name="poll">

--- a/doc/classes/StreamPeerTCP.xml
+++ b/doc/classes/StreamPeerTCP.xml
@@ -31,21 +31,21 @@
 			<return type="String">
 			</return>
 			<description>
-				Return the IP of this peer.
+				Returns the IP of this peer.
 			</description>
 		</method>
 		<method name="get_connected_port" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the port of this peer.
+				Returns the port of this peer.
 			</description>
 		</method>
 		<method name="get_status">
 			<return type="int" enum="StreamPeerTCP.Status">
 			</return>
 			<description>
-				Return the status of the connection, see [enum StreamPeerTCP.Status].
+				Returns the status of the connection, see [enum StreamPeerTCP.Status].
 			</description>
 		</method>
 		<method name="is_connected_to_host" qualifiers="const">

--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -37,7 +37,7 @@
 			<argument index="0" name="margin" type="int" enum="Margin">
 			</argument>
 			<description>
-				Return the content margin offset for the specified margin
+				Returns the content margin offset for the specified margin
 				Positive values reduce size inwards, unlike [Control]'s margin values.
 			</description>
 		</method>
@@ -45,14 +45,14 @@
 			<return type="Vector2">
 			</return>
 			<description>
-				Return the minimum size that this stylebox can be shrunk to.
+				Returns the minimum size that this stylebox can be shrunk to.
 			</description>
 		</method>
 		<method name="get_offset" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Return the "offset" of a stylebox, this is a helper function, like writing [code]Vector2(style.get_margin(MARGIN_LEFT), style.get_margin(MARGIN_TOP))[/code].
+				Returns the "offset" of a stylebox, this is a helper function, like writing [code]Vector2(style.get_margin(MARGIN_LEFT), style.get_margin(MARGIN_TOP))[/code].
 			</description>
 		</method>
 		<method name="test_mask" qualifiers="const">

--- a/doc/classes/TCP_Server.xml
+++ b/doc/classes/TCP_Server.xml
@@ -13,7 +13,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] if a connection is available for taking.
+				Returns [code]true[/code] if a connection is available for taking.
 			</description>
 		</method>
 		<method name="listen">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -69,14 +69,14 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the column the editing cursor is at.
+				Returns the column the editing cursor is at.
 			</description>
 		</method>
 		<method name="cursor_get_line" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the line the editing cursor is at.
+				Returns the line the editing cursor is at.
 			</description>
 		</method>
 		<method name="cursor_set_column">
@@ -137,7 +137,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Return an array containing the line number of each breakpoint.
+				Returns an array containing the line number of each breakpoint.
 			</description>
 		</method>
 		<method name="get_keyword_color" qualifiers="const">
@@ -154,14 +154,14 @@
 			<argument index="0" name="line" type="int">
 			</argument>
 			<description>
-				Return the text of a specific line.
+				Returns the text of a specific line.
 			</description>
 		</method>
 		<method name="get_line_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the amount of total lines in the text.
+				Returns the amount of total lines in the text.
 			</description>
 		</method>
 		<method name="get_menu" qualifiers="const">
@@ -175,35 +175,35 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the selection begin column.
+				Returns the selection begin column.
 			</description>
 		</method>
 		<method name="get_selection_from_line" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the selection begin line.
+				Returns the selection begin line.
 			</description>
 		</method>
 		<method name="get_selection_text" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
-				Return the text inside the selection.
+				Returns the text inside the selection.
 			</description>
 		</method>
 		<method name="get_selection_to_column" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the selection end column.
+				Returns the selection end column.
 			</description>
 		</method>
 		<method name="get_selection_to_line" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the selection end line.
+				Returns the selection end line.
 			</description>
 		</method>
 		<method name="get_word_under_cursor" qualifiers="const">
@@ -250,7 +250,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return [code]true[/code] if the selection is active.
+				Returns [code]true[/code] if the selection is active.
 			</description>
 		</method>
 		<method name="menu_option">

--- a/doc/classes/Texture.xml
+++ b/doc/classes/Texture.xml
@@ -74,21 +74,21 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the texture height.
+				Returns the texture height.
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Return the texture size.
+				Returns the texture size.
 			</description>
 		</method>
 		<method name="get_width" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the texture width.
+				Returns the texture width.
 			</description>
 		</method>
 		<method name="has_alpha" qualifiers="const">

--- a/doc/classes/WindowDialog.xml
+++ b/doc/classes/WindowDialog.xml
@@ -13,7 +13,7 @@
 			<return type="TextureButton">
 			</return>
 			<description>
-				Return the close [TextureButton].
+				Returns the close [TextureButton].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
In many of the XML files it had been noted that when the documentation
refers to a return value, both "Return" and "Returns" are used. This
has now been fixed to only say "Returns".

Fixes #28867