### PR TITLE
Fixed scene tree update after changing node name in tool script

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -471,6 +471,17 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 		emit_signal("node_selected");
 	}
 }
+
+void SceneTreeEditor::_node_renamed(Node *p_node) {
+
+	emit_signal("node_renamed");
+
+	if (!tree_dirty) {
+		MessageQueue::get_singleton()->push_call(this, "_update_tree");
+		tree_dirty = true;
+	}
+}
+
 void SceneTreeEditor::_update_tree() {
 
 	if (!is_inside_tree()) {
@@ -594,6 +605,7 @@ void SceneTreeEditor::_notification(int p_what) {
 
 			get_tree()->connect("tree_changed", this, "_tree_changed");
 			get_tree()->connect("node_removed", this, "_node_removed");
+			get_tree()->connect("node_renamed", this, "_node_renamed");
 			get_tree()->connect("node_configuration_warning_changed", this, "_warning_changed");
 
 			tree->connect("item_collapsed", this, "_cell_collapsed");
@@ -604,6 +616,7 @@ void SceneTreeEditor::_notification(int p_what) {
 
 			get_tree()->disconnect("tree_changed", this, "_tree_changed");
 			get_tree()->disconnect("node_removed", this, "_node_removed");
+			get_tree()->disconnect("node_renamed", this, "_node_renamed");
 			tree->disconnect("item_collapsed", this, "_cell_collapsed");
 			get_tree()->disconnect("node_configuration_warning_changed", this, "_warning_changed");
 		} break;
@@ -685,12 +698,6 @@ void SceneTreeEditor::_rename_node(ObjectID p_node, const String &p_name) {
 	n->set_name(p_name);
 	item->set_metadata(0, n->get_path());
 	item->set_text(0, p_name);
-	emit_signal("node_renamed");
-
-	if (!tree_dirty) {
-		MessageQueue::get_singleton()->push_call(this, "_update_tree");
-		tree_dirty = true;
-	}
 }
 
 void SceneTreeEditor::_renamed() {
@@ -1025,6 +1032,7 @@ void SceneTreeEditor::_bind_methods() {
 	ClassDB::bind_method("_tree_changed", &SceneTreeEditor::_tree_changed);
 	ClassDB::bind_method("_update_tree", &SceneTreeEditor::_update_tree);
 	ClassDB::bind_method("_node_removed", &SceneTreeEditor::_node_removed);
+	ClassDB::bind_method("_node_renamed", &SceneTreeEditor::_node_renamed);
 	ClassDB::bind_method("_selected_changed", &SceneTreeEditor::_selected_changed);
 	ClassDB::bind_method("_deselect_items", &SceneTreeEditor::_deselect_items);
 	ClassDB::bind_method("_renamed", &SceneTreeEditor::_renamed);

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -78,6 +78,7 @@ class SceneTreeEditor : public Control {
 	void _update_tree();
 	void _tree_changed();
 	void _node_removed(Node *p_node);
+	void _node_renamed(Node *p_node);
 
 	TreeItem *_find(TreeItem *p_node, const NodePath &p_path);
 	void _notification(int p_what);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -949,6 +949,7 @@ void Node::set_name(const String &p_name) {
 	if (is_inside_tree()) {
 
 		emit_signal("renamed");
+		get_tree()->node_renamed(this);
 		get_tree()->tree_changed();
 	}
 }

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -105,6 +105,11 @@ void SceneTree::node_removed(Node *p_node) {
 		call_skip.insert(p_node);
 }
 
+void SceneTree::node_renamed(Node *p_node) {
+
+	emit_signal(node_renamed_name, p_node);
+}
+
 SceneTree::Group *SceneTree::add_to_group(const StringName &p_group, Node *p_node) {
 
 	Map<StringName, Group>::Element *E = group_map.find(p_group);
@@ -1895,6 +1900,7 @@ void SceneTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("tree_changed"));
 	ADD_SIGNAL(MethodInfo("node_added", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("node_removed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
+	ADD_SIGNAL(MethodInfo("node_renamed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("screen_resized"));
 	ADD_SIGNAL(MethodInfo("node_configuration_warning_changed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 
@@ -1983,6 +1989,7 @@ SceneTree::SceneTree() {
 	tree_changed_name = "tree_changed";
 	node_added_name = "node_added";
 	node_removed_name = "node_removed";
+	node_renamed_name = "node_renamed";
 	ugc_locked = false;
 	call_lock = 0;
 	root_lock = 0;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -126,6 +126,7 @@ private:
 	StringName tree_changed_name;
 	StringName node_added_name;
 	StringName node_removed_name;
+	StringName node_renamed_name;
 
 	bool use_font_oversampling;
 	int64_t current_frame;
@@ -201,6 +202,7 @@ private:
 	void tree_changed();
 	void node_added(Node *p_node);
 	void node_removed(Node *p_node);
+	void node_renamed(Node *p_node);
 
 	Group *add_to_group(const StringName &p_group, Node *p_node);
 	void remove_from_group(const StringName &p_group, Node *p_node);


### PR DESCRIPTION
Propagate notifications to scene tree editor when a node is renamed by script, so that the tree view is updated when changing the name of a node in a tool script.

Fixes #18102