### PR TITLE
Fix animation editor's bottom panel button not being pressed on certain occasions

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -97,8 +97,6 @@ class AnimationPlayerEditor : public VBoxContainer {
 	Button *play_from;
 	Button *play_bw;
 	Button *play_bw_from;
-
-	//Button *pause;
 	Button *autoplay;
 
 	MenuButton *tool_anim;
@@ -231,7 +229,6 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
-	void _gui_input(Ref<InputEvent> p_event);
 	void _node_removed(Node *p_node);
 	static void _bind_methods();
 
@@ -260,6 +257,7 @@ class AnimationPlayerEditorPlugin : public EditorPlugin {
 
 	AnimationPlayerEditor *anim_editor;
 	EditorNode *editor;
+	Button *button;
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
When switching from a scene with the animation editor closed to one with an `AnimationPlayer` selected, while the editor will be opened, the bottom panel button will not be pressed. This commit fixes that.

It also fixes the "Node not found:" error when switching scenes when the animation editor is opened.