### PR TITLE
Don't ignore the clip content when drawing the item list bg_focus stylebox

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -845,9 +845,7 @@ void ItemList::_notification(int p_what) {
 		}
 
 		if (has_focus()) {
-			VisualServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
 			draw_style_box(get_stylebox("bg_focus"), Rect2(Point2(), size));
-			VisualServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), false);
 		}
 
 		if (shape_changed) {


### PR DESCRIPTION
Fixes #9612

Explained why I think we should remove this and why the exception was added in the first place here https://github.com/godotengine/godot/issues/9612#issuecomment-495890346

This is, of course, a breaking change. With this change it's not possible to have the focused background `StyleBox` expanding outside of the control, but, it wasn't possible to have the normal background to expand outside before so maybe it's not such a breaking change.