### PR TITLE
Make animation editor change tracks positions instead of swapping them

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -450,6 +450,17 @@
 				Move a track down.
 			</description>
 		</method>
+		<method name="track_move_to">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="to_idx" type="int">
+			</argument>
+			<description>
+				Changes the index position of track [code]idx[/code] to the one defined in [code]to_idx[/code].
+			</description>
+		</method>
 		<method name="track_move_up">
 			<return type="void">
 			</return>
@@ -571,6 +582,7 @@
 			<argument index="1" name="with_idx" type="int">
 			</argument>
 			<description>
+				Swaps the track [code]idx[/code]'s index position with the track [code]with_idx[/code].
 			</description>
 		</method>
 		<method name="transform_track_insert_key">

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -325,6 +325,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _name_limit_changed();
 	void _timeline_changed(float p_new_pos, bool p_drag);
 	void _track_remove_request(int p_track);
+	void _track_grab_focus(int p_track);
 
 	UndoRedo *undo_redo;
 
@@ -513,6 +514,7 @@ public:
 	float get_moving_selection_offset() const;
 	bool is_snap_enabled();
 	float snap_time(float p_value);
+	bool is_grouping_tracks();
 
 	MenuButton *get_edit_menu();
 	AnimationTrackEditor();

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2559,17 +2559,6 @@ bool Animation::has_loop() const {
 	return loop;
 }
 
-void Animation::track_move_up(int p_track) {
-
-	if (p_track >= 0 && p_track < (tracks.size() - 1)) {
-
-		SWAP(tracks.write[p_track], tracks.write[p_track + 1]);
-	}
-
-	emit_changed();
-	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
-}
-
 void Animation::track_set_imported(int p_track, bool p_imported) {
 
 	ERR_FAIL_INDEX(p_track, tracks.size());
@@ -2595,12 +2584,40 @@ bool Animation::track_is_enabled(int p_track) const {
 	return tracks[p_track]->enabled;
 }
 
+void Animation::track_move_up(int p_track) {
+
+	if (p_track >= 0 && p_track < (tracks.size() - 1)) {
+
+		SWAP(tracks.write[p_track], tracks.write[p_track + 1]);
+	}
+
+	emit_changed();
+	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
+}
+
 void Animation::track_move_down(int p_track) {
 
 	if (p_track > 0 && p_track < tracks.size()) {
 
 		SWAP(tracks.write[p_track], tracks.write[p_track - 1]);
 	}
+
+	emit_changed();
+	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
+}
+
+void Animation::track_move_to(int p_track, int p_to_index) {
+
+	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_INDEX(p_to_index, tracks.size() + 1);
+	if (p_track == p_to_index || p_track == p_to_index - 1)
+		return;
+
+	Track *track = tracks.get(p_track);
+	tracks.remove(p_track);
+	// Take into account that the position of the tracks that come after the one removed will change.
+	tracks.insert(p_to_index > p_track ? p_to_index - 1 : p_to_index, track);
+
 	emit_changed();
 	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
@@ -2612,6 +2629,7 @@ void Animation::track_swap(int p_track, int p_with_track) {
 	if (p_track == p_with_track)
 		return;
 	SWAP(tracks.write[p_track], tracks.write[p_with_track]);
+
 	emit_changed();
 	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
@@ -2656,6 +2674,7 @@ void Animation::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("track_move_up", "idx"), &Animation::track_move_up);
 	ClassDB::bind_method(D_METHOD("track_move_down", "idx"), &Animation::track_move_down);
+	ClassDB::bind_method(D_METHOD("track_move_to", "idx", "to_idx"), &Animation::track_move_to);
 	ClassDB::bind_method(D_METHOD("track_swap", "idx", "with_idx"), &Animation::track_swap);
 
 	ClassDB::bind_method(D_METHOD("track_set_imported", "idx", "imported"), &Animation::track_set_imported);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -293,6 +293,7 @@ public:
 
 	void track_move_up(int p_track);
 	void track_move_down(int p_track);
+	void track_move_to(int p_track, int p_to_index);
 	void track_swap(int p_track, int p_with_track);
 
 	void track_set_imported(int p_track, bool p_imported);


### PR DESCRIPTION
In the animation editor dragging and dropping a track doesn't change its position as one would expect, instead, it swaps around the tracks. This commit changes that, by creating a new method: `track_move_to()`, and making use of it there.

Closes #27288.