### PR TITLE
Tweak the particle animation node configuration warning message

### DIFF
--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -212,7 +212,7 @@ String CPUParticles::get_configuration_warning() const {
 										get_param_curve(PARAM_ANIM_SPEED).is_valid() || get_param_curve(PARAM_ANIM_OFFSET).is_valid())) {
 		if (warnings != String())
 			warnings += "\n";
-		warnings += "- " + TTR("CPUParticles animation requires the usage of a SpatialMaterial with \"Billboard Particles\" enabled.");
+		warnings += "- " + TTR("CPUParticles animation requires the usage of a SpatialMaterial whose Billboard Mode is set to \"Particle Billboard\".");
 	}
 
 	return warnings;

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -268,7 +268,7 @@ String Particles::get_configuration_warning() const {
 						process->get_param_texture(ParticlesMaterial::PARAM_ANIM_SPEED).is_valid() || process->get_param_texture(ParticlesMaterial::PARAM_ANIM_OFFSET).is_valid())) {
 			if (warnings != String())
 				warnings += "\n";
-			warnings += "- " + TTR("Particles animation requires the usage of a SpatialMaterial with \"Billboard Particles\" enabled.");
+			warnings += "- " + TTR("Particles animation requires the usage of a SpatialMaterial whose Billboard Mode is set to \"Particle Billboard\".");
 		}
 	}
 


### PR DESCRIPTION
As suggested by someone on Discord, this makes the warning message use the exact terminology to designate the Particle Billboard mode.