### PR TITLE
Fix radiance map settings

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8158,7 +8158,7 @@ void RasterizerStorageGLES3::initialize() {
 	}
 
 	shaders.cubemap_filter.init();
-	bool ggx_hq = GLOBAL_GET("rendering/quality/reflections/high_quality_ggx.mobile");
+	bool ggx_hq = GLOBAL_GET("rendering/quality/reflections/high_quality_ggx");
 	shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::LOW_QUALITY, !ggx_hq);
 	shaders.particles.init();
 

--- a/drivers/gles3/shaders/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/cubemap_filter.glsl
@@ -163,7 +163,7 @@ vec2 Hammersley(uint i, uint N) {
 
 #else
 
-#define SAMPLE_COUNT 512u
+#define SAMPLE_COUNT 1024u
 
 #endif
 

--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -62,7 +62,7 @@ void Sky::_bind_methods() {
 }
 
 Sky::Sky() {
-	radiance_size = RADIANCE_SIZE_512;
+	radiance_size = RADIANCE_SIZE_128;
 }
 
 /////////////////////////////////////////


### PR DESCRIPTION
This PR fixes a bug where the mobile setting for ``high_quality_ggx`` was used resulting in extremely low quality radiance maps. It also improves the quality of radiance maps. With an increased quality we can use substantially smaller radiance maps that look even better than the current ones. Accordingly, the default size for radiance maps is decreased to 128 (128 with increased samples produces much higher quality radiance maps than the current setting at 512 and does so much faster).

With these new settings radiance maps will be faster to compute and draw, and will look better. However, existing projects will need to manually decrease ``radiance_size`` in all of there skies or else load times will be substantially increased. For this reason I added the "breaks compat" label.

Fixes #21680 and fixes #27422.