### PR TITLE
Autocomplete for enum values

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2054,7 +2054,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionContext &p_context
 
 				if (!p_only_functions) {
 					List<PropertyInfo> members;
-					tmp.get_property_list(&members);
+					p_base.value.get_property_list(&members);
 
 					for (List<PropertyInfo>::Element *E = members.front(); E; E = E->next()) {
 						if (String(E->get().name).find("/") == -1) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/22333

It also works with enums from other scripts, unlike Godot 3.0.6
![GodotEnumAutocomplete](https://user-images.githubusercontent.com/29497869/58381009-f30df900-7fb8-11e9-97af-c77969b0060d.png)

I'm not to be credited for that last part. I just unlocked it accidentally (: