### PR TITLE
Improve SSAO performance and quality

### DIFF
--- a/drivers/gles3/shaders/ssao.glsl
+++ b/drivers/gles3/shaders/ssao.glsl
@@ -16,15 +16,15 @@ void main() {
 #define TWO_PI 6.283185307179586476925286766559
 
 #ifdef SSAO_QUALITY_HIGH
-#define NUM_SAMPLES (80)
+#define NUM_SAMPLES (16)
 #endif
 
 #ifdef SSAO_QUALITY_LOW
-#define NUM_SAMPLES (15)
+#define NUM_SAMPLES (8)
 #endif
 
 #if !defined(SSAO_QUALITY_LOW) && !defined(SSAO_QUALITY_HIGH)
-#define NUM_SAMPLES (40)
+#define NUM_SAMPLES (12)
 #endif
 
 // If using depth mip levels, the log of the maximum pixel offset before we need to switch to a lower

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1294,8 +1294,8 @@ void Environment::_bind_methods() {
 Environment::Environment() :
 		bg_mode(BG_CLEAR_COLOR),
 		tone_mapper(TONE_MAPPER_LINEAR),
-		ssao_blur(SSAO_BLUR_DISABLED),
-		ssao_quality(SSAO_QUALITY_LOW),
+		ssao_blur(SSAO_BLUR_3x3),
+		ssao_quality(SSAO_QUALITY_MEDIUM),
 		glow_blend_mode(GLOW_BLEND_MODE_ADDITIVE),
 		dof_blur_far_quality(DOF_BLUR_QUALITY_LOW),
 		dof_blur_near_quality(DOF_BLUR_QUALITY_LOW) {
@@ -1346,7 +1346,7 @@ Environment::Environment() :
 	ssao_ao_channel_affect = 0.0;
 	ssao_blur = SSAO_BLUR_3x3;
 	set_ssao_edge_sharpness(4);
-	set_ssao_quality(SSAO_QUALITY_LOW);
+	set_ssao_quality(SSAO_QUALITY_MEDIUM);
 
 	glow_enabled = false;
 	glow_levels = (1 << 2) | (1 << 4);


### PR DESCRIPTION
This decreases the number of samples significantly, leading to a notable performance increase with only a very slight loss in visual quality.

This also tweaks the default SSAO settings to use 3×3 blurring, which makes noise patterns much less visible. If this is too heavy, we could default to 2×2 blurring instead (or try to find other optimizations in the blurring algorithm).

Thanks to @Outrider0x400 for [proposing these changes](https://github.com/godotengine/godot/issues/17568#issuecomment-494579632) :smiley:

## Preview

### Old default settings (Low quality/15 samples, 1×1 blur)

![sponza_old_default](https://user-images.githubusercontent.com/180032/58380212-d967b400-7fae-11e9-85f3-2f251d00ee9f.png)

### New default settings (Medium quality/12 samples, 3×3 blur)

![sponza_new_default](https://user-images.githubusercontent.com/180032/58380210-d7055a00-7fae-11e9-8ced-4922cbb44c1e.png)

### Before (Medium quality/40 samples, 2×2 blur)

![sponza_2x2_medium_old](https://user-images.githubusercontent.com/180032/58380215-dc62a480-7fae-11e9-8398-12495135879e.png)

### After (Medium quality/12 samples, 2×2 blur)

![sponza_2x2_medium_new](https://user-images.githubusercontent.com/180032/58380217-e2f11c00-7fae-11e9-97e6-0731b864c14d.png)