### PR TITLE
Fix Segmentation fault and reduce memory consumption

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1627,40 +1627,28 @@ void ProjectManager::_show_project(const String &p_path) {
 	OS::get_singleton()->shell_open(String("file://") + p_path);
 }
 
-void ProjectManager::_scan_dir(DirAccess *da, float pos, float total, List<String> *r_projects) {
-
-	List<String> subdirs;
+void ProjectManager::_scan_dir(const String &path, List<String> *r_projects) {
+	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->change_dir(path);
 	da->list_dir_begin();
 	String n = da->get_next();
 	while (n != String()) {
 		if (da->current_is_dir() && !n.begins_with(".")) {
-			subdirs.push_front(n);
+			_scan_dir(da->get_current_dir().plus_file(n), r_projects);
 		} else if (n == "project.godot") {
 			r_projects->push_back(da->get_current_dir());
 		}
 		n = da->get_next();
 	}
 	da->list_dir_end();
-	int m = 0;
-	for (List<String>::Element *E = subdirs.front(); E; E = E->next()) {
-
-		da->change_dir(E->get());
-
-		float slice = total / subdirs.size();
-		_scan_dir(da, pos + slice * m, slice, r_projects);
-		da->change_dir("..");
-		m++;
-	}
+	memdelete(da);
 }
 
 void ProjectManager::_scan_begin(const String &p_base) {
 
 	print_line("Scanning projects at: " + p_base);
 	List<String> projects;
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	da->change_dir(p_base);
-	_scan_dir(da, 0, 1, &projects);
-	memdelete(da);
+	_scan_dir(p_base, &projects);
 	print_line("Found " + itos(projects.size()) + " projects.");
 
 	for (List<String>::Element *E = projects.front(); E; E = E->next()) {

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -106,7 +106,7 @@ class ProjectManager : public Control {
 	void _on_project_created(const String &dir);
 	void _on_projects_updated();
 	void _update_scroll_position(const String &dir);
-	void _scan_dir(DirAccess *da, float pos, float total, List<String> *r_projects);
+	void _scan_dir(const String &path, List<String> *r_projects);
 
 	void _install_project(const String &p_zip_path, const String &p_title);
 


### PR DESCRIPTION
Addresses problem discussed at #29192.

In terms of memory consumption the memory doesn't grow like it used to as the search goes on.
In terms of execution time using some very basic testing ([clock()](https://stackoverflow.com/a/876970), I cannot discern any performance impact but please feel free to test how much time it takes on your side using [this branch](https://github.com/NilsIrl/godot/tree/seg_fault_perf). The time will be printed on stdout.