### PR TITLE
Deselect hidden nodes on filter

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -379,6 +379,12 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	}
 
 	if (!keep) {
+		if (editor_selection) {
+			Node *n = get_node(item->get_metadata(0));
+			if (n) {
+				editor_selection->remove_node(n);
+			}
+		}
 		memdelete(item);
 		return false;
 	} else {


### PR DESCRIPTION
Fixes #25794

This is similar to #27659, but instead of awkward NULLing the `editor_selection`, it deselects nodes that become invisible on filter.