### PR TITLE
Dictionary values saved for instanced scene only when different from parent

### DIFF
--- a/core/dictionary.cpp
+++ b/core/dictionary.cpp
@@ -76,6 +76,16 @@ Variant Dictionary::get_value_at_index(int p_index) const {
 	return Variant();
 }
 
+void Dictionary::get_entry_list(List<Pair<Variant, Variant> > *p_entries) const {
+
+	if (_p->variant_map.empty())
+		return;
+
+	for (OrderedHashMap<Variant, Variant, VariantHasher, VariantComparator>::Element E = _p->variant_map.front(); E; E = E.next()) {
+		p_entries->push_back(Pair<Variant, Variant>(E.key(), E.get()));
+	}
+}
+
 Variant &Dictionary::operator[](const Variant &p_key) {
 
 	return _p->variant_map[p_key];

--- a/core/dictionary.h
+++ b/core/dictionary.h
@@ -33,6 +33,7 @@
 
 #include "core/array.h"
 #include "core/list.h"
+#include "core/pair.h"
 #include "core/ustring.h"
 
 class Variant;
@@ -50,6 +51,8 @@ public:
 	void get_key_list(List<Variant> *p_keys) const;
 	Variant get_key_at_index(int p_index) const;
 	Variant get_value_at_index(int p_index) const;
+
+	void get_entry_list(List<Pair<Variant, Variant> > *p_entries) const;
 
 	Variant &operator[](const Variant &p_key);
 	const Variant &operator[](const Variant &p_key) const;

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -430,10 +430,28 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 					_RETURN_FAIL;
 				}
 
-				const Dictionary *arr_a = reinterpret_cast<const Dictionary *>(p_a._data._mem);
-				const Dictionary *arr_b = reinterpret_cast<const Dictionary *>(p_b._data._mem);
+				const Dictionary *dict_a = reinterpret_cast<const Dictionary *>(p_a._data._mem);
+				const Dictionary *dict_b = reinterpret_cast<const Dictionary *>(p_b._data._mem);
 
-				_RETURN(*arr_a == *arr_b);
+				int size_a = dict_a->size();
+				if (size_a != dict_b->size())
+					_RETURN(false);
+
+				List<Pair<Variant, Variant> > entries_a;
+				dict_a->get_entry_list(&entries_a);
+
+				for (int i = 0; i < size_a; i++) {
+					const Pair<Variant, Variant> &entry_a = entries_a[i];
+					const Variant *value_b = dict_b->getptr(entry_a.first);
+					if (value_b == NULL) {
+						_RETURN(false);
+					}
+					if (*value_b != entry_a.second) {
+						_RETURN(false);
+					}
+				}
+
+				_RETURN(true);
 			}
 
 			CASE_TYPE(math, OP_EQUAL, ARRAY) {
@@ -518,10 +536,28 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 					_RETURN_FAIL;
 				}
 
-				const Dictionary *arr_a = reinterpret_cast<const Dictionary *>(p_a._data._mem);
-				const Dictionary *arr_b = reinterpret_cast<const Dictionary *>(p_b._data._mem);
+				const Dictionary *dict_a = reinterpret_cast<const Dictionary *>(p_a._data._mem);
+				const Dictionary *dict_b = reinterpret_cast<const Dictionary *>(p_b._data._mem);
 
-				_RETURN(*arr_a != *arr_b);
+				int size_a = dict_a->size();
+				if (size_a != dict_b->size())
+					_RETURN(true);
+
+				List<Pair<Variant, Variant> > entries_a;
+				dict_a->get_entry_list(&entries_a);
+
+				for (int i = 0; i < size_a; i++) {
+					const Pair<Variant, Variant> &entry_a = entries_a[i];
+					const Variant *value_b = dict_b->getptr(entry_a.first);
+					if (value_b == NULL) {
+						_RETURN(true);
+					}
+					if (*value_b != entry_a.second) {
+						_RETURN(true);
+					}
+				}
+
+				_RETURN(false);
 			}
 
 			CASE_TYPE(math, OP_NOT_EQUAL, ARRAY) {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -228,7 +228,7 @@ void ProjectSettingsEditor::_device_input_add() {
 	int idx = edit_idx;
 	Dictionary old_val = ProjectSettings::get_singleton()->get(name);
 	Dictionary action = old_val.duplicate();
-	Array events = action["events"];
+	Array events = action["events"].duplicate();
 
 	switch (add_type) {
 
@@ -349,11 +349,11 @@ void ProjectSettingsEditor::_press_a_key_confirm() {
 
 	Dictionary old_val = ProjectSettings::get_singleton()->get(name);
 	Dictionary action = old_val.duplicate();
-	Array events = action["events"];
+	Array old_events = action["events"];
 
-	for (int i = 0; i < events.size(); i++) {
+	for (int i = 0; i < old_events.size(); i++) {
 
-		Ref<InputEventKey> aie = events[i];
+		Ref<InputEventKey> aie = old_events[i];
 		if (aie.is_null())
 			continue;
 		if (aie->get_scancode_with_modifiers() == ie->get_scancode_with_modifiers()) {
@@ -361,6 +361,22 @@ void ProjectSettingsEditor::_press_a_key_confirm() {
 		}
 	}
 
+	Dictionary init_val = ProjectSettings::get_singleton()->property_get_revert(name);
+	Array init_events = init_val["events"];
+
+	// Re-use input from default values if possible
+	for (int i = 0; i < init_events.size(); i++) {
+
+		Ref<InputEventKey> aie = init_events[i];
+		if (aie.is_null())
+			continue;
+		if (aie->get_scancode_with_modifiers() == ie->get_scancode_with_modifiers()) {
+			ie = aie;
+			break;
+		}
+	}
+
+	Array events = old_events.duplicate();
 	if (idx < 0 || idx >= events.size()) {
 		events.push_back(ie);
 	} else {
@@ -613,7 +629,7 @@ void ProjectSettingsEditor::_action_button_pressed(Object *p_obj, int p_column, 
 			Dictionary action = old_val.duplicate();
 			int idx = ti->get_metadata(0);
 
-			Array events = action["events"];
+			Array events = action["events"].duplicate();
 			ERR_FAIL_INDEX(idx, events.size());
 			events.remove(idx);
 			action["events"] = events;


### PR DESCRIPTION
This change makes dictionary comparison operators to check for differences in data, following the same logic as for arrays.

It allows dictionary export variables in instanced scenes to be compared to parents, so they are saved only when the data has been modified for the instance.

Fixes #29221