### PR TITLE
Fix GetTypeInfo error due to missing include

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "visual_shader.h"
+
 #include "core/vmap.h"
 #include "servers/visual/shader_types.h"
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -32,6 +32,7 @@
 #define VISUAL_SHADER_H
 
 #include "core/string_builder.h"
+#include "scene/gui/control.h"
 #include "scene/resources/shader.h"
 
 class VisualShaderNodeUniform;


### PR DESCRIPTION
It was using the forward declared `Control` class from [`core/variant.h`](https://github.com/godotengine/godot/blob/7487d2f8521d895df2f16b36d21992f8fde99f75/core/variant.h#L59), so it could not use the template specialization of `GetTypeInfo` for classes that inherit `Object`. I have no idea what the difference between `debug` and `release_debug` was, but I could only reproduce this with the latter.

Fixes #29117
