### PR TITLE
Separate culling state management from material state in GLES2

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -198,13 +198,14 @@ public:
 		int directional_light_count;
 		int reflection_probe_count;
 
-		bool cull_front;
-		bool cull_disabled;
 		bool used_sss;
 		bool using_contact_shadows;
 
 		VS::ViewportDebugDraw debug_draw;
 		*/
+
+		bool cull_front;
+		bool cull_disabled;
 
 		bool used_screen_texture;
 		bool shadow_is_dual_parabolloid;
@@ -503,8 +504,7 @@ public:
 		enum {
 			MAX_LIGHTS = 255,
 			MAX_REFLECTION_PROBES = 255,
-			DEFAULT_MAX_ELEMENTS = 65536,
-			SORT_KEY_PRIORITY_SHIFT = 56
+			DEFAULT_MAX_ELEMENTS = 65536
 		};
 
 		int max_elements;
@@ -518,6 +518,7 @@ public:
 
 			bool use_accum; //is this an add pass for multipass
 			bool *use_accum_ptr;
+			bool front_facing;
 
 			union {
 				//TODO: should be endian swapped on big endian
@@ -685,7 +686,8 @@ public:
 
 	void _draw_sky(RasterizerStorageGLES2::Sky *p_sky, const CameraMatrix &p_projection, const Transform &p_transform, bool p_vflip, float p_custom_fov, float p_energy, const Basis &p_sky_orientation);
 
-	_FORCE_INLINE_ bool _setup_material(RasterizerStorageGLES2::Material *p_material, bool p_reverse_cull, bool p_alpha_pass, Size2i p_skeleton_tex_size = Size2i(0, 0));
+	_FORCE_INLINE_ void _set_cull(bool p_front, bool p_disabled, bool p_reverse_cull);
+	_FORCE_INLINE_ bool _setup_material(RasterizerStorageGLES2::Material *p_material, bool p_alpha_pass, Size2i p_skeleton_tex_size = Size2i(0, 0));
 	_FORCE_INLINE_ void _setup_geometry(RenderList::Element *p_element, RasterizerStorageGLES2::Skeleton *p_skeleton);
 	_FORCE_INLINE_ void _setup_light_type(LightInstance *p_light, ShadowAtlas *shadow_atlas);
 	_FORCE_INLINE_ void _setup_light(LightInstance *p_light, ShadowAtlas *shadow_atlas, const Transform &p_view_transform);


### PR DESCRIPTION
Sets culling state separately from material and includes ``mirror`` property in culling operation. 

This change is necessary because when an object is given a negative size the culling operation needs to be mirrored, however, GLES2 only updated the culling state when there was a change in material. So if two objects used the same material (e.g. the default SpatialMaterial) but one had a negative scale, the second one to be drawn would have culling flipped. 

Fixes: https://github.com/godotengine/godot/issues/27900 and 
Partly fixes: https://github.com/godotengine/godot/issues/26627 (includes a few unrelated issues), https://github.com/godotengine/godot/issues/25696 (still needs fix for when cull is disabled) and https://github.com/godotengine/godot/issues/26710 (still needs fix for when cull is disabled)