### PR TITLE
remove a branch and uses a casting of said boolean instead

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5110,7 +5110,7 @@ static Node *_resource_get_edited_scene() {
 
 void EditorNode::_print_handler(void *p_this, const String &p_string, bool p_error) {
 	EditorNode *en = (EditorNode *)p_this;
-	en->log->add_message(p_string, p_error ? EditorLog::MSG_TYPE_ERROR : EditorLog::MSG_TYPE_STD);
+	en->log->add_message(p_string, (EditorLog::MessageType)p_error);
 }
 
 static void _execute_thread(void *p_ud) {


### PR DESCRIPTION
This branching can be removed by noting that the boolean can be casted to the appropriate enum.