### PR TITLE
Print engine version to stdout when starting Godot

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -204,7 +204,8 @@ void finalize_physics() {
 
 void Main::print_help(const char *p_binary) {
 
-	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - https://godotengine.org");
+	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
+	OS::get_singleton()->print("Free and open source software under the terms of the MIT license.\n");
 	OS::get_singleton()->print("(c) 2007-2019 Juan Linietsky, Ariel Manzur.\n");
 	OS::get_singleton()->print("(c) 2014-2019 Godot Engine contributors.\n");
 	OS::get_singleton()->print("\n");
@@ -1090,6 +1091,9 @@ error:
 }
 
 Error Main::setup2(Thread::ID p_main_tid_override) {
+
+	// Print engine name and version
+	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
 
 	if (p_main_tid_override) {
 		Thread::_main_thread_id = p_main_tid_override;

--- a/methods.py
+++ b/methods.py
@@ -61,6 +61,7 @@ def update_version(module_version_string=""):
     f.write("#define VERSION_BUILD \"" + str(build_name) + "\"\n")
     f.write("#define VERSION_MODULE_CONFIG \"" + str(version.module_config) + module_version_string + "\"\n")
     f.write("#define VERSION_YEAR " + str(version.year) + "\n")
+    f.write("#define VERSION_WEBSITE \"" + str(version.website) + "\"\n")
     f.close()
 
     # NOTE: It is safe to generate this file here, since this is still executed serially

--- a/version.py
+++ b/version.py
@@ -5,3 +5,4 @@ minor = 2
 status = "dev"
 module_config = ""
 year = 2019
+website = "https://godotengine.org"


### PR DESCRIPTION
Also include website URL and make it configurable via `version.py`
together with the rest of the engine branding.

Add mention to MIT license in `--help` output.

---

This change should make it easier for users reporting issues to include precise version info in their bug reports. Many do not know about the `--version` option, or don't run Godot from a terminal, so this will be directly visible at least on Windows in the terminal spawned when running the .exe.

As a side effect, this means that games made with Godot will also be identified as such when ran from a terminal. I think it's fine, as it was already simple enough to "figure out" a Godot game by checking its distribution (`.pck` file) or running the binary with `--help` or `--version`.