### PR TITLE
Node::duplicate: Don't set name if original node is nameless

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2077,7 +2077,9 @@ Node *Node::_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap) const
 		}
 	}
 
-	node->set_name(get_name());
+	if (get_name() != String()) {
+		node->set_name(get_name());
+	}
 
 #ifdef TOOLS_ENABLED
 	if ((p_flags & DUPLICATE_FROM_EDITOR) && r_duplimap)


### PR DESCRIPTION
In practice this only happens when duplicating a node which is not in
the scene tree yet, as nameless nodes get assigned a generated name
when added to the scene tree.

Fixes #27319.
Supersedes #27581.