### PR TITLE
Automatically add new line to scripts

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -801,6 +801,24 @@ void CodeTextEditor::trim_trailing_whitespace() {
 	}
 }
 
+void CodeTextEditor::insert_final_newline() {
+	int final_line = text_editor->get_line_count() - 1;
+
+	String line = text_editor->get_line(final_line);
+
+	//length 0 means it's already an empty line,
+	//no need to add a newline
+	if (line.length() > 0 && !line.ends_with("\n")) {
+		text_editor->begin_complex_operation();
+
+		line += "\n";
+		text_editor->set_line(final_line, line);
+
+		text_editor->end_complex_operation();
+		text_editor->update();
+	}
+}
+
 void CodeTextEditor::convert_indent_to_spaces() {
 	int indent_size = EditorSettings::get_singleton()->get("text_editor/indent/size");
 	String indent = "";

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -195,6 +195,7 @@ protected:
 
 public:
 	void trim_trailing_whitespace();
+	void insert_final_newline();
 
 	void convert_indent_to_spaces();
 	void convert_indent_to_tabs();

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -681,6 +681,8 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 			se->trim_trailing_whitespace();
 		}
 
+		se->insert_final_newline();
+
 		if (convert_indent_on_save) {
 			if (use_space_indentation) {
 				se->convert_indent_to_spaces();
@@ -1033,6 +1035,8 @@ void ScriptEditor::_menu_option(int p_option) {
 				if (trim_trailing_whitespace_on_save)
 					current->trim_trailing_whitespace();
 
+				current->insert_final_newline();
+
 				if (convert_indent_on_save) {
 					if (use_space_indentation) {
 						current->convert_indent_to_spaces();
@@ -1052,7 +1056,10 @@ void ScriptEditor::_menu_option(int p_option) {
 			} break;
 			case FILE_SAVE_AS: {
 
-				current->trim_trailing_whitespace();
+				if (trim_trailing_whitespace_on_save)
+					current->trim_trailing_whitespace();
+
+				current->insert_final_newline();
 
 				if (convert_indent_on_save) {
 					if (use_space_indentation) {
@@ -2045,6 +2052,8 @@ void ScriptEditor::save_all_scripts() {
 		if (trim_trailing_whitespace_on_save) {
 			se->trim_trailing_whitespace();
 		}
+
+		se->insert_final_newline();
 
 		if (!se->is_unsaved())
 			continue;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -97,6 +97,7 @@ public:
 	virtual void set_edit_state(const Variant &p_state) = 0;
 	virtual void goto_line(int p_line, bool p_with_error = false) = 0;
 	virtual void trim_trailing_whitespace() = 0;
+	virtual void insert_final_newline() = 0;
 	virtual void convert_indent_to_spaces() = 0;
 	virtual void convert_indent_to_tabs() = 0;
 	virtual void ensure_focus() = 0;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -375,6 +375,11 @@ void ScriptTextEditor::trim_trailing_whitespace() {
 	code_editor->trim_trailing_whitespace();
 }
 
+void ScriptTextEditor::insert_final_newline() {
+
+	code_editor->insert_final_newline();
+}
+
 void ScriptTextEditor::convert_indent_to_spaces() {
 
 	code_editor->convert_indent_to_spaces();

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -166,6 +166,7 @@ public:
 	virtual void set_edit_state(const Variant &p_state);
 	virtual void ensure_focus();
 	virtual void trim_trailing_whitespace();
+	virtual void insert_final_newline();
 	virtual void convert_indent_to_spaces();
 	virtual void convert_indent_to_tabs();
 	virtual void tag_saved_version();

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -241,6 +241,11 @@ void TextEditor::trim_trailing_whitespace() {
 	code_editor->trim_trailing_whitespace();
 }
 
+void TextEditor::insert_final_newline() {
+
+	code_editor->insert_final_newline();
+}
+
 void TextEditor::convert_indent_to_spaces() {
 
 	code_editor->convert_indent_to_spaces();

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -124,6 +124,7 @@ public:
 	virtual void get_breakpoints(List<int> *p_breakpoints);
 	virtual void goto_line(int p_line, bool p_with_error = false);
 	virtual void trim_trailing_whitespace();
+	virtual void insert_final_newline();
 	virtual void convert_indent_to_spaces();
 	virtual void convert_indent_to_tabs();
 	virtual void ensure_focus();

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2102,6 +2102,9 @@ void VisualScriptEditor::goto_line(int p_line, bool p_with_error) {
 void VisualScriptEditor::trim_trailing_whitespace() {
 }
 
+void VisualScriptEditor::insert_final_newline() {
+}
+
 void VisualScriptEditor::convert_indent_to_spaces() {
 }
 

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -264,6 +264,7 @@ public:
 	virtual void set_edit_state(const Variant &p_state);
 	virtual void goto_line(int p_line, bool p_with_error = false);
 	virtual void trim_trailing_whitespace();
+	virtual void insert_final_newline();
 	virtual void convert_indent_to_spaces();
 	virtual void convert_indent_to_tabs();
 	virtual void ensure_focus();


### PR DESCRIPTION
As stated in #27476:

"For better compliance and ease of use with editorconfig and git, i would like it if godot automatically added a new empty line to the end of any script that does not have it."

Other than that, I also added a missing "if" before trimming whitespaces when choosing "Save File as" (editor/plugins/script_editor_plugin.cpp, line 1055).