### PR TITLE
Add a "pressed" style to PopupMenu

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -573,11 +573,14 @@
 		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.4, 0.4, 0.4, 0.8)">
 			[Color] used for disabled menu items' text.
 		</theme_item>
-		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
-			[Color] used for the hovered text.
+		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.95, 0.95, 0.95, 1)">
+			[Color] used for the text when an item is hovered with the mouse or selected with the keyboard.
 		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the menu item.
+		</theme_item>
+		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			[Color] used for the text when an item is pressed with the mouse.
 		</theme_item>
 		<theme_item name="font_separator_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			[Color] used for labeled separators' text. See [method add_separator].
@@ -653,7 +656,7 @@
 			[Texture2D] icon for the unchecked checkbox items when they are disabled.
 		</theme_item>
 		<theme_item name="hover" data_type="style" type="StyleBox">
-			[StyleBox] displayed when the [PopupMenu] item is hovered.
+			[StyleBox] displayed when the [PopupMenu] item is hovered with the mouse or selected with the keyboard.
 		</theme_item>
 		<theme_item name="labeled_separator_left" data_type="style" type="StyleBox">
 			[StyleBox] for the left side of labeled separator. See [method add_separator].
@@ -666,6 +669,9 @@
 		</theme_item>
 		<theme_item name="panel_disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [PopupMenu] item is disabled.
+		</theme_item>
+		<theme_item name="pressed" data_type="style" type="StyleBox">
+			[StyleBox] displayed when the [PopupMenu] item is pressed with the mouse.
 		</theme_item>
 		<theme_item name="separator" data_type="style" type="StyleBox">
 			[StyleBox] used for the separators. See [method add_separator].

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1055,9 +1055,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("panel", "PopupMenu", style_popup_menu);
 
 	Ref<StyleBoxFlat> style_menu_hover = style_widget_hover->duplicate();
-	// Don't use rounded corners for hover highlights since the StyleBox touches the PopupMenu's edges.
+	// Don't use rounded corners for hover/pressed highlights since the StyleBox touches the PopupMenu's edges.
 	style_menu_hover->set_corner_radius_all(0);
 	theme->set_stylebox("hover", "PopupMenu", style_menu_hover);
+
+	Ref<StyleBoxFlat> style_menu_pressed = style_widget_pressed->duplicate();
+	style_menu_pressed->set_corner_radius_all(0);
+	theme->set_stylebox("pressed", "PopupMenu", style_menu_pressed);
 
 	theme->set_stylebox("separator", "PopupMenu", style_popup_separator);
 	theme->set_stylebox("labeled_separator_left", "PopupMenu", style_popup_labeled_separator_left);
@@ -1065,6 +1069,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_color("font_color", "PopupMenu", font_color);
 	theme->set_color("font_hover_color", "PopupMenu", font_hover_color);
+	theme->set_color("font_pressed_color", "PopupMenu", font_hover_pressed_color);
 	theme->set_color("font_accelerator_color", "PopupMenu", font_disabled_color);
 	theme->set_color("font_disabled_color", "PopupMenu", font_disabled_color);
 	theme->set_color("font_separator_color", "PopupMenu", font_disabled_color);

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -95,6 +95,7 @@ class PopupMenu : public Popup {
 	Vector<Item> items;
 	BitField<MouseButtonMask> initial_button_mask;
 	bool during_grabbed_click = false;
+	bool is_mouse_pressed = false;
 	int mouse_over = -1;
 	int submenu_over = -1;
 	Rect2 parent_rect;
@@ -136,6 +137,7 @@ class PopupMenu : public Popup {
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;
 		Ref<StyleBox> hover_style;
+		Ref<StyleBox> pressed_style;
 
 		Ref<StyleBox> separator_style;
 		Ref<StyleBox> labeled_separator_left;
@@ -167,6 +169,7 @@ class PopupMenu : public Popup {
 
 		Color font_color;
 		Color font_hover_color;
+		Color font_pressed_color;
 		Color font_disabled_color;
 		Color font_accelerator_color;
 		int font_outline_size = 0;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -654,6 +654,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("panel", "PopupMenu", style_popup_panel);
 	theme->set_stylebox("panel_disabled", "PopupMenu", style_popup_panel_disabled);
 	theme->set_stylebox("hover", "PopupMenu", make_flat_stylebox(style_popup_hover_color));
+	theme->set_stylebox("pressed", "PopupMenu", make_flat_stylebox(style_pressed_color));
 	theme->set_stylebox("separator", "PopupMenu", separator_horizontal);
 	theme->set_stylebox("labeled_separator_left", "PopupMenu", separator_horizontal);
 	theme->set_stylebox("labeled_separator_right", "PopupMenu", separator_horizontal);
@@ -677,7 +678,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color", "PopupMenu", control_font_color);
 	theme->set_color("font_accelerator_color", "PopupMenu", Color(0.7, 0.7, 0.7, 0.8));
 	theme->set_color("font_disabled_color", "PopupMenu", Color(0.4, 0.4, 0.4, 0.8));
-	theme->set_color("font_hover_color", "PopupMenu", control_font_color);
+	theme->set_color("font_hover_color", "PopupMenu", control_font_hover_color);
+	theme->set_color("font_pressed_color", "PopupMenu", control_font_pressed_color);
 	theme->set_color("font_separator_color", "PopupMenu", control_font_color);
 	theme->set_color("font_outline_color", "PopupMenu", Color(1, 1, 1));
 	theme->set_color("font_separator_outline_color", "PopupMenu", Color(1, 1, 1));


### PR DESCRIPTION
This makes PopupMenus (and derivatives such as OptionButtons) feel more responsive to user input, as they can display a different stylebox and font color when an option is pressed.

**Testing project:** [test_popupmenu_pressed.zip](https://github.com/godotengine/godot/files/11253559/test_popupmenu_pressed.zip)

## Preview

*Note: This `pressed` style only applies to mouse input, not keyboard input (as keyboard inputs are accepted as soon as you press the key, not when you release it). In the videos, I use keyboard input near the end to show the difference.*

### Editor - Dark theme

https://user-images.githubusercontent.com/180032/232256581-5e224e96-ba26-4676-bb4e-3236e1e19cb2.mp4

### Editor - Light theme

https://user-images.githubusercontent.com/180032/232256582-2b4c18ab-7e0b-432d-ab93-26c9c24ea866.mp4

### Default project theme

https://user-images.githubusercontent.com/180032/232256580-a7cee8e7-4b75-451a-afc6-1e3eb7f64bbf.mp4

<details>
<summary>July 2020 patch</summary>

```patch
From d2cf3e17a83ca8d75965c54582f14acaa1ace578 Mon Sep 17 00:00:00 2001
From: Hugo Locurcio <hugo.locurcio@hugo.pro>
Date: Wed, 29 May 2019 05:14:37 +0200
Subject: [PATCH] Add a "pressed" style to PopupMenu

This makes PopupMenus (and derivatives such as OptionButtons) feel
more responsive to user input, as they can display a different
stylebox and font color when an option is pressed.
---
 editor/editor_themes.cpp                      |  9 ++++--
 scene/gui/popup_menu.cpp                      | 29 +++++++++++++++----
 scene/gui/popup_menu.h                        |  1 +
 .../resources/default_theme/default_theme.cpp |  7 +++++
 4 files changed, 39 insertions(+), 7 deletions(-)

diff --git a/editor/editor_themes.cpp b/editor/editor_themes.cpp
index a93763810b5e..f44de9b1b802 100644
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -556,7 +556,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	Ref<StyleBoxFlat> style_menu_hover_bg = style_widget->duplicate();
 	style_menu_hover_bg->set_border_width_all(0);
-	style_menu_hover_bg->set_bg_color(dark_color_1);
+	style_menu_hover_bg->set_bg_color(dark_color_1.lightened(dark_theme ? 0.01 : 0.0));
+
+	Ref<StyleBoxFlat> style_menu_pressed_bg = style_widget->duplicate();
+	style_menu_pressed_bg->set_border_width_all(0);
+	style_menu_pressed_bg->set_bg_color(dark_color_2.darkened(0.06));
 
 	theme->set_stylebox("normal", "MenuButton", style_menu);
 	theme->set_stylebox("hover", "MenuButton", style_menu);
@@ -566,7 +570,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_stylebox("normal", "PopupMenu", style_menu);
 	theme->set_stylebox("hover", "PopupMenu", style_menu_hover_bg);
-	theme->set_stylebox("pressed", "PopupMenu", style_menu);
+	theme->set_stylebox("pressed", "PopupMenu", style_menu_pressed_bg);
 	theme->set_stylebox("focus", "PopupMenu", style_menu);
 	theme->set_stylebox("disabled", "PopupMenu", style_menu);
 
@@ -662,6 +666,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_color("font_color", "PopupMenu", font_color);
 	theme->set_color("font_color_hover", "PopupMenu", font_color_hl);
+	theme->set_color("font_color_pressed", "PopupMenu", font_color_hl);
 	theme->set_color("font_color_accel", "PopupMenu", font_color_disabled);
 	theme->set_color("font_color_disabled", "PopupMenu", font_color_disabled);
 	theme->set_icon("checked", "PopupMenu", theme->get_icon("GuiChecked", "EditorIcons"));
diff --git a/scene/gui/popup_menu.cpp b/scene/gui/popup_menu.cpp
index 6e19b820e0c8..8145702fbc9f 100644
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -285,11 +285,20 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> b = p_event;
 
 	if (b.is_valid()) {
+		const int button_idx = b->get_button_index();
+
 		if (b->is_pressed()) {
+			if (button_idx == BUTTON_LEFT) {
+				is_mouse_down = true;
+				// Update to display the "pressed" stylebox
+				control->update();
+			}
+
 			return;
+		} else {
+			is_mouse_down = false;
 		}
 
-		int button_idx = b->get_button_index();
 		switch (button_idx) {
 			case BUTTON_WHEEL_DOWN: {
 				_scroll(-b->get_factor(), b->get_position());
@@ -329,8 +338,6 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 		}
-
-		//control->update();
 	}
 
 	Ref<InputEventMouseMotion> m = p_event;
@@ -421,6 +428,7 @@ void PopupMenu::_draw() {
 
 	Ref<StyleBox> style = get_theme_stylebox("panel");
 	Ref<StyleBox> hover = get_theme_stylebox("hover");
+	Ref<StyleBox> pressed = get_theme_stylebox("pressed");
 	Ref<Font> font = get_theme_font("font");
 	// In Item::checkable_type enum order (less the non-checkable member)
 	Ref<Texture2D> check[] = { get_theme_icon("checked"), get_theme_icon("radio_checked") };
@@ -438,6 +446,7 @@ void PopupMenu::_draw() {
 	Color font_color_disabled = get_theme_color("font_color_disabled");
 	Color font_color_accel = get_theme_color("font_color_accel");
 	Color font_color_hover = get_theme_color("font_color_hover");
+	Color font_color_pressed = get_theme_color("font_color_pressed");
 	float font_h = font->get_height();
 
 	// Add the check and the wider icon to the offset of all items.
@@ -477,7 +486,8 @@ void PopupMenu::_draw() {
 		}
 
 		if (i == mouse_over) {
-			hover->draw(ci, Rect2(item_ofs + Point2(-hseparation, -vseparation / 2), Size2(get_size().width - style->get_minimum_size().width + hseparation * 2, h + vseparation)));
+			Ref<StyleBox> hover_pressed = is_mouse_down ? pressed : hover;
+			hover_pressed->draw(ci, Rect2(item_ofs + Point2(-hseparation, -vseparation / 2), Size2(get_size().width - style->get_minimum_size().width + hseparation * 2, h + vseparation)));
 		}
 
 		String text = items[i].xl_text;
@@ -524,7 +534,16 @@ void PopupMenu::_draw() {
 			}
 		} else {
 			item_ofs.x += icon_ofs + check_ofs;
-			font->draw(ci, item_ofs + Point2(0, Math::floor((h - font_h) / 2.0)), text, items[i].disabled ? font_color_disabled : (i == mouse_over ? font_color_hover : font_color));
+
+			Color item_font_color;
+			if (is_mouse_down && i == mouse_over) {
+				item_font_color = font_color_pressed;
+			} else if (i == mouse_over) {
+				item_font_color = font_color_hover;
+			} else {
+				item_font_color = font_color;
+			}
+			font->draw(ci, item_ofs + Point2(0, Math::floor((h - font_h) / 2.0)), text, items[i].disabled ? font_color_disabled : item_font_color);
 		}
 
 		if (items[i].accel || (items[i].shortcut.is_valid() && items[i].shortcut->is_valid())) {
diff --git a/scene/gui/popup_menu.h b/scene/gui/popup_menu.h
index d03a14d6e4e3..ad6ae8d4e52b 100644
--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -82,6 +82,7 @@ class PopupMenu : public Popup {
 	Vector<Item> items;
 	int initial_button_mask;
 	bool during_grabbed_click;
+	bool is_mouse_down = false;
 	int mouse_over;
 	int submenu_over;
 	Rect2 parent_rect;
diff --git a/scene/resources/default_theme/default_theme.cpp b/scene/resources/default_theme/default_theme.cpp
index 83d4db7bae69..6fdad3833892 100644
--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -509,6 +509,11 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const
 		selected->set_expand_margin_size(Margin(i), 2 * scale);
 	}
 
+	Ref<StyleBoxTexture> pressed = make_stylebox(button_pressed_png, 6, 6, 6, 6);
+	for (int i = 0; i < 4; i++) {
+		pressed->set_expand_margin_size(Margin(i), 2 * scale);
+	}
+
 	theme->set_stylebox("panel", "PopupPanel", style_pp);
 
 	// PopupDialog
@@ -521,6 +526,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const
 	theme->set_stylebox("panel", "PopupMenu", style_pd);
 	theme->set_stylebox("panel_disabled", "PopupMenu", make_stylebox(popup_bg_disabled_png, 4, 4, 4, 4));
 	theme->set_stylebox("hover", "PopupMenu", selected);
+	theme->set_stylebox("pressed", "PopupMenu", pressed);
 	theme->set_stylebox("separator", "PopupMenu", make_stylebox(vseparator_png, 3, 3, 3, 3));
 	theme->set_stylebox("labeled_separator_left", "PopupMenu", make_stylebox(vseparator_png, 0, 0, 0, 0));
 	theme->set_stylebox("labeled_separator_right", "PopupMenu", make_stylebox(vseparator_png, 0, 0, 0, 0));
@@ -537,6 +543,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const
 	theme->set_color("font_color_accel", "PopupMenu", Color(0.7, 0.7, 0.7, 0.8));
 	theme->set_color("font_color_disabled", "PopupMenu", Color(0.4, 0.4, 0.4, 0.8));
 	theme->set_color("font_color_hover", "PopupMenu", control_font_color);
+	theme->set_color("font_color_pressed", "PopupMenu", control_font_color);
 
 	theme->set_constant("hseparation", "PopupMenu", 4 * scale);
 	theme->set_constant("vseparation", "PopupMenu", 4 * scale);

```
</details>