### PR TITLE
Fix incorrect scroll when the user perform first action on visual shader

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -69,6 +69,7 @@ void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
 			}
 		}
 		visual_shader = Ref<VisualShader>(p_visual_shader);
+		visual_shader->set_graph_offset(graph->get_scroll_ofs() / EDSCALE);
 	} else {
 		visual_shader.unref();
 	}


### PR DESCRIPTION
When the user fist run the visual shader and do first action the focus is incorrectly get off screen

![bug](https://user-images.githubusercontent.com/3036176/58529994-a824f900-81e5-11e9-8577-de53cb9fb023.gif)

This will fix it..