### PR TITLE
GLTF2: Resolve #29265

### DIFF
--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -334,6 +334,8 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 	template <class T>
 	T _interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, float p_time, GLTFAnimation::Interpolation p_interp);
 
+	String _canonicalize_name(String p_name);
+
 public:
 	virtual uint32_t get_import_flags() const;
 	virtual void get_extensions(List<String> *r_extensions) const;


### PR DESCRIPTION
* Skeleton element is ignored https://github.com/KhronosGroup/glTF/issues/1270
* Set depth draw mode for transparent materials.
* A -1 parent means it's root, so do not dereference that node

References: https://github.com/godotengine/godot/issues/29265