### PR TITLE
Remove always true or false expression in enums

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -944,7 +944,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
 		case INTERPOLATE_NEAREST: {
 
-			if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
+			if (format <= FORMAT_RGBA8) {
 				switch (get_format_pixel_size(format)) {
 					case 1: _scale_nearest<1, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
 					case 2: _scale_nearest<2, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
@@ -1008,7 +1008,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 					}
 				}
 
-				if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
+				if (format <= FORMAT_RGBA8) {
 					switch (get_format_pixel_size(format)) {
 						case 1: _scale_bilinear<1, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
 						case 2: _scale_bilinear<2, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
@@ -1041,7 +1041,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 		} break;
 		case INTERPOLATE_CUBIC: {
 
-			if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
+			if (format <= FORMAT_RGBA8) {
 				switch (get_format_pixel_size(format)) {
 					case 1: _scale_cubic<1, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
 					case 2: _scale_cubic<2, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
@@ -1066,7 +1066,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 		} break;
 		case INTERPOLATE_LANCZOS: {
 
-			if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
+			if (format <= FORMAT_RGBA8) {
 				switch (get_format_pixel_size(format)) {
 					case 1: _scale_lanczos<1, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
 					case 2: _scale_lanczos<2, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -235,7 +235,6 @@ void NetSocketPosix::_set_socket(SOCKET_TYPE p_sock, IP::Type p_ip_type, bool p_
 
 Error NetSocketPosix::open(Type p_sock_type, IP::Type &ip_type) {
 	ERR_FAIL_COND_V(is_open(), ERR_ALREADY_IN_USE);
-	ERR_FAIL_COND_V(ip_type > IP::TYPE_ANY || ip_type < IP::TYPE_NONE, ERR_INVALID_PARAMETER);
 
 #if defined(__OpenBSD__)
 	// OpenBSD does not support dual stacking, fallback to IPv4 only.

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -469,7 +469,7 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 
 		bool ok_on_pc = false;
 		bool is_hdr = (image->get_format() >= Image::FORMAT_RF && image->get_format() <= Image::FORMAT_RGBE9995);
-		bool is_ldr = (image->get_format() >= Image::FORMAT_L8 && image->get_format() <= Image::FORMAT_RGBA5551);
+		bool is_ldr = (image->get_format() <= Image::FORMAT_RGBA5551);
 		bool can_bptc = ProjectSettings::get_singleton()->get("rendering/vram_compression/import_bptc");
 		bool can_s3tc = ProjectSettings::get_singleton()->get("rendering/vram_compression/import_s3tc");
 

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -670,7 +670,7 @@ void NativeScriptInstance::get_property_list(List<PropertyInfo> *p_properties) c
 				PropertyInfo info;
 
 				info.type = Variant::Type(d["type"].operator int64_t());
-				ERR_CONTINUE(info.type < 0 || info.type >= Variant::VARIANT_MAX);
+				ERR_CONTINUE(info.type >= Variant::VARIANT_MAX);
 
 				info.name = d["name"];
 				ERR_CONTINUE(info.name == "");

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1092,7 +1092,7 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 					ERR_CONTINUE(!d.has("type"));
 					PropertyInfo pinfo;
 					pinfo.type = Variant::Type(d["type"].operator int());
-					ERR_CONTINUE(pinfo.type < 0 || pinfo.type >= Variant::VARIANT_MAX);
+					ERR_CONTINUE(pinfo.type >= Variant::VARIANT_MAX);
 					pinfo.name = d["name"];
 					ERR_CONTINUE(pinfo.name == "");
 					if (d.has("hint"))
@@ -2068,7 +2068,7 @@ String GDScriptWarning::get_name() const {
 }
 
 String GDScriptWarning::get_name_from_code(Code p_code) {
-	ERR_FAIL_COND_V(p_code < 0 || p_code >= WARNING_MAX, String());
+	ERR_FAIL_COND_V(p_code >= WARNING_MAX, String());
 
 	static const char *names[] = {
 		"UNASSIGNED_VARIABLE",

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -544,7 +544,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type var_type = (Variant::Type)_code_ptr[ip + 2];
 				GET_VARIANT_PTR(dst, 3);
 
-				GD_ERR_BREAK(var_type < 0 || var_type >= Variant::VARIANT_MAX);
+				GD_ERR_BREAK(var_type >= Variant::VARIANT_MAX);
 
 				*dst = value->get_type() == var_type;
 				ip += 4;
@@ -760,7 +760,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 #ifdef DEBUG_ENABLED
 				Variant::Type var_type = (Variant::Type)_code_ptr[ip + 1];
-				GD_ERR_BREAK(var_type < 0 || var_type >= Variant::VARIANT_MAX);
+				GD_ERR_BREAK(var_type >= Variant::VARIANT_MAX);
 
 				if (src->get_type() != var_type) {
 					if (Variant::can_convert_strict(src->get_type(), var_type)) {
@@ -869,7 +869,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_VARIANT_PTR(src, 2);
 				GET_VARIANT_PTR(dst, 3);
 
-				GD_ERR_BREAK(to_type < 0 || to_type >= Variant::VARIANT_MAX);
+				GD_ERR_BREAK(to_type >= Variant::VARIANT_MAX);
 
 				Variant::CallError err;
 				*dst = Variant::construct(to_type, (const Variant **)&src, 1, err);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -663,7 +663,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			if (left_ok) {
 
 				Ref<Texture> t;
-				if (left_type >= 0 && left_type < Variant::VARIANT_MAX) {
+				if (left_type < Variant::VARIANT_MAX) {
 					t = type_icons[left_type];
 				}
 				if (t.is_valid()) {
@@ -730,7 +730,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				hbc->add_child(memnew(Label(right_name)));
 
 				Ref<Texture> t;
-				if (right_type >= 0 && right_type < Variant::VARIANT_MAX) {
+				if (right_type < Variant::VARIANT_MAX) {
 					t = type_icons[right_type];
 				}
 				if (t.is_valid()) {

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -1024,8 +1024,8 @@ bool Tween::interpolate_property(Object *p_object, NodePath p_property, Variant 
 	ERR_FAIL_COND_V(!ObjectDB::instance_validate(p_object), false);
 	ERR_FAIL_COND_V(p_initial_val.get_type() != p_final_val.get_type(), false);
 	ERR_FAIL_COND_V(p_duration <= 0, false);
-	ERR_FAIL_COND_V(p_trans_type < 0 || p_trans_type >= TRANS_COUNT, false);
-	ERR_FAIL_COND_V(p_ease_type < 0 || p_ease_type >= EASE_COUNT, false);
+	ERR_FAIL_COND_V(p_trans_type >= TRANS_COUNT, false);
+	ERR_FAIL_COND_V(p_ease_type >= EASE_COUNT, false);
 	ERR_FAIL_COND_V(p_delay < 0, false);
 
 	bool prop_valid = false;
@@ -1068,8 +1068,8 @@ bool Tween::interpolate_method(Object *p_object, StringName p_method, Variant p_
 	ERR_FAIL_COND_V(!ObjectDB::instance_validate(p_object), false);
 	ERR_FAIL_COND_V(p_initial_val.get_type() != p_final_val.get_type(), false);
 	ERR_FAIL_COND_V(p_duration <= 0, false);
-	ERR_FAIL_COND_V(p_trans_type < 0 || p_trans_type >= TRANS_COUNT, false);
-	ERR_FAIL_COND_V(p_ease_type < 0 || p_ease_type >= EASE_COUNT, false);
+	ERR_FAIL_COND_V(p_trans_type >= TRANS_COUNT, false);
+	ERR_FAIL_COND_V(p_ease_type >= EASE_COUNT, false);
 	ERR_FAIL_COND_V(p_delay < 0, false);
 
 	ERR_EXPLAIN("Object has no method named: %s" + p_method);
@@ -1219,8 +1219,8 @@ bool Tween::follow_property(Object *p_object, NodePath p_property, Variant p_ini
 	ERR_FAIL_COND_V(p_target == NULL, false);
 	ERR_FAIL_COND_V(!ObjectDB::instance_validate(p_target), false);
 	ERR_FAIL_COND_V(p_duration <= 0, false);
-	ERR_FAIL_COND_V(p_trans_type < 0 || p_trans_type >= TRANS_COUNT, false);
-	ERR_FAIL_COND_V(p_ease_type < 0 || p_ease_type >= EASE_COUNT, false);
+	ERR_FAIL_COND_V(p_trans_type >= TRANS_COUNT, false);
+	ERR_FAIL_COND_V(p_ease_type >= EASE_COUNT, false);
 	ERR_FAIL_COND_V(p_delay < 0, false);
 
 	bool prop_valid = false;
@@ -1269,8 +1269,8 @@ bool Tween::follow_method(Object *p_object, StringName p_method, Variant p_initi
 	ERR_FAIL_COND_V(p_target == NULL, false);
 	ERR_FAIL_COND_V(!ObjectDB::instance_validate(p_target), false);
 	ERR_FAIL_COND_V(p_duration <= 0, false);
-	ERR_FAIL_COND_V(p_trans_type < 0 || p_trans_type >= TRANS_COUNT, false);
-	ERR_FAIL_COND_V(p_ease_type < 0 || p_ease_type >= EASE_COUNT, false);
+	ERR_FAIL_COND_V(p_trans_type >= TRANS_COUNT, false);
+	ERR_FAIL_COND_V(p_ease_type >= EASE_COUNT, false);
 	ERR_FAIL_COND_V(p_delay < 0, false);
 
 	ERR_EXPLAIN("Object has no method named: %s" + p_method);
@@ -1324,8 +1324,8 @@ bool Tween::targeting_property(Object *p_object, NodePath p_property, Object *p_
 	ERR_FAIL_COND_V(p_initial == NULL, false);
 	ERR_FAIL_COND_V(!ObjectDB::instance_validate(p_initial), false);
 	ERR_FAIL_COND_V(p_duration <= 0, false);
-	ERR_FAIL_COND_V(p_trans_type < 0 || p_trans_type >= TRANS_COUNT, false);
-	ERR_FAIL_COND_V(p_ease_type < 0 || p_ease_type >= EASE_COUNT, false);
+	ERR_FAIL_COND_V(p_trans_type >= TRANS_COUNT, false);
+	ERR_FAIL_COND_V(p_ease_type >= EASE_COUNT, false);
 	ERR_FAIL_COND_V(p_delay < 0, false);
 
 	bool prop_valid = false;
@@ -1378,8 +1378,8 @@ bool Tween::targeting_method(Object *p_object, StringName p_method, Object *p_in
 	ERR_FAIL_COND_V(p_initial == NULL, false);
 	ERR_FAIL_COND_V(!ObjectDB::instance_validate(p_initial), false);
 	ERR_FAIL_COND_V(p_duration <= 0, false);
-	ERR_FAIL_COND_V(p_trans_type < 0 || p_trans_type >= TRANS_COUNT, false);
-	ERR_FAIL_COND_V(p_ease_type < 0 || p_ease_type >= EASE_COUNT, false);
+	ERR_FAIL_COND_V(p_trans_type >= TRANS_COUNT, false);
+	ERR_FAIL_COND_V(p_ease_type >= EASE_COUNT, false);
 	ERR_FAIL_COND_V(p_delay < 0, false);
 
 	ERR_EXPLAIN("Object has no method named: %s" + p_method);


### PR DESCRIPTION
Note:
format >= FORMAT_L8 is always true because enum Format starts with FORMAT_L8
p_type < IP::TYPE_NONE and ip_type > IP::TYPE_ANY is always false because enum IP have first value TYPE_NONE and last TYPE_ANY
info.type < 0 is always false because it means that info.type < NIL which is first element in enum
left_type >= 0 is always true because that means left_type >= NIL which is first element in enum
