### PR TITLE
Remove some redundant lines

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -710,7 +710,6 @@ void EditorFileDialog::update_file_list() {
 	}
 
 	String cdir = dir_access->get_current_dir();
-	bool skip_pp = access == ACCESS_RESOURCES && cdir == "res://";
 
 	dir_access->list_dir_begin();
 
@@ -733,7 +732,7 @@ void EditorFileDialog::update_file_list() {
 		if (show_hidden || !ishidden) {
 			if (!isdir)
 				files.push_back(item);
-			else if (item != ".." || !skip_pp)
+			else
 				dirs.push_back(item);
 		}
 	}
@@ -763,8 +762,6 @@ void EditorFileDialog::update_file_list() {
 
 		dirs.pop_front();
 	}
-
-	dirs.clear();
 
 	List<String> patterns;
 	// build filter
@@ -864,8 +861,6 @@ void EditorFileDialog::update_file_list() {
 			break;
 		}
 	}
-
-	files.clear();
 }
 
 void EditorFileDialog::_filter_selected(int) {

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3619,7 +3619,6 @@ VisualScriptEditor::VisualScriptEditor() {
 	edit_signal_dialog = memnew(AcceptDialog);
 	edit_signal_dialog->get_ok()->set_text(TTR("Close"));
 	add_child(edit_signal_dialog);
-	edit_signal_dialog->set_title(TTR("Edit Signal Arguments:"));
 
 	signal_editor = memnew(VisualScriptEditorSignalEdit);
 	edit_signal_edit = memnew(EditorInspector);
@@ -3630,7 +3629,6 @@ VisualScriptEditor::VisualScriptEditor() {
 	edit_variable_dialog = memnew(AcceptDialog);
 	edit_variable_dialog->get_ok()->set_text(TTR("Close"));
 	add_child(edit_variable_dialog);
-	edit_variable_dialog->set_title(TTR("Edit Variable:"));
 
 	variable_editor = memnew(VisualScriptEditorVariableEdit);
 	edit_variable_edit = memnew(EditorInspector);
@@ -3641,7 +3639,6 @@ VisualScriptEditor::VisualScriptEditor() {
 	select_base_type = memnew(CreateDialog);
 	select_base_type->set_base_type("Object"); //anything goes
 	select_base_type->connect("create", this, "_change_base_type_callback");
-	select_base_type->get_ok()->set_text(TTR("Change"));
 	add_child(select_base_type);
 
 	undo_redo = EditorNode::get_singleton()->get_undo_redo();

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -431,8 +431,6 @@ void FileDialog::update_file_list() {
 		dirs.pop_front();
 	}
 
-	dirs.clear();
-
 	List<String> patterns;
 	// build filter
 	if (filter->get_selected() == filter->get_item_count() - 1) {
@@ -507,8 +505,6 @@ void FileDialog::update_file_list() {
 
 	if (tree->get_root() && tree->get_root()->get_children() && tree->get_selected() == NULL)
 		tree->get_root()->get_children()->select(0);
-
-	files.clear();
 }
 
 void FileDialog::_filter_selected(int) {


### PR DESCRIPTION
- In EditorFileDialog::update_file_list(): remove always-true condition and now-unused variable. Also remove clear() call for lists that are already empty (same for FileDialog)
- In VisualScriptEditor::VisualScriptEditor(): remove dialog text assignments that will be overridden when the dialogs are displayed