### PR TITLE
Partial Javascript clipboard support

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -819,6 +819,23 @@ void OS_JavaScript::set_clipboard(const String &p_text) {
 	ERR_FAIL_COND(err);
 }
 
+String OS_JavaScript::get_clipboard() const {
+	/* clang-format off */
+	EM_ASM({
+		try {
+			navigator.clipboard.readText().then(function (result) {
+				ccall('update_clipboard', 'void', ['string'], [result]);
+			}).catch(function (e) {
+				// Fail graciously.
+			});
+		} catch (e) {
+			// Fail graciously.
+		}
+	});
+	/* clang-format on */
+	return this->OS::get_clipboard();
+}
+
 // Lifecycle
 int OS_JavaScript::get_current_video_driver() const {
 	return video_driver_index;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -796,6 +796,11 @@ const char *OS_JavaScript::get_audio_driver_name(int p_driver) const {
 }
 
 // Clipboard
+extern "C" EMSCRIPTEN_KEEPALIVE void update_clipboard(const char *p_text) {
+	// Only call set_clipboard from OS (sets local clipboard)
+	OS::get_singleton()->OS::set_clipboard(p_text);
+}
+
 void OS_JavaScript::set_clipboard(const String &p_text) {
 	OS::set_clipboard(p_text);
 	/* clang-format off */
@@ -958,6 +963,11 @@ Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, 
 		(['mouseover', 'mouseleave', 'focus', 'blur']).forEach(function(event, index) {
 			Module.canvas.addEventListener(event, send_notification.bind(null, notifications[index]));
 		});
+		// Clipboard
+		const update_clipboard = cwrap('update_clipboard', null, ['string']);
+		window.addEventListener('paste', function(evt) {
+			update_clipboard(evt.clipboardData.getData('text'));
+		}, true);
 	},
 		MainLoop::NOTIFICATION_WM_MOUSE_ENTER,
 		MainLoop::NOTIFICATION_WM_MOUSE_EXIT,

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -795,6 +795,25 @@ const char *OS_JavaScript::get_audio_driver_name(int p_driver) const {
 	return "JavaScript";
 }
 
+// Clipboard
+void OS_JavaScript::set_clipboard(const String &p_text) {
+	OS::set_clipboard(p_text);
+	/* clang-format off */
+	int err = EM_ASM_INT({
+		var text = UTF8ToString($0);
+		if (!navigator.clipboard || !navigator.clipboard.writeText)
+			return 1;
+		navigator.clipboard.writeText(text).catch(e => {
+			// Setting OS clipboard is only possible from an input callback.
+			console.error("Setting OS clipboard is only possible from an input callback for the HTML5 plafrom. Exception:", e);
+		});
+		return 0;
+	}, p_text.utf8().get_data());
+	/* clang-format on */
+	ERR_EXPLAIN("Clipboard API is not supported.");
+	ERR_FAIL_COND(err);
+}
+
 // Lifecycle
 int OS_JavaScript::get_current_video_driver() const {
 	return video_driver_index;

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -133,6 +133,8 @@ public:
 	virtual int get_audio_driver_count() const;
 	virtual const char *get_audio_driver_name(int p_driver) const;
 
+	virtual void set_clipboard(const String &p_text);
+
 	virtual MainLoop *get_main_loop() const;
 	void run_async();
 	bool main_loop_iterate();

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -134,6 +134,7 @@ public:
 	virtual const char *get_audio_driver_name(int p_driver) const;
 
 	virtual void set_clipboard(const String &p_text);
+	virtual String get_clipboard() const;
 
 	virtual MainLoop *get_main_loop() const;
 	void run_async();


### PR DESCRIPTION
Partial fix for #12587 . I'm not sure it can be fully fixed for now, see note below. Partially address #12587

In this PR:

### Add OS clipboard set support to OS Javascript

This is straight forward, and seems to work quite well with the `ClipboardAPI`. It's async, so it doesn't happen 

### Add OS clipboard support to paste 'events' (updating local clipboard)

Listen to paste events to update local clipboard.
CTRL+V still not working out of the box.
To do that, We would need to change how we handle keypress, most likely making it worse and less safe. In the end, I'm not sure we can fix it properly for now.
Maybe in the future, with the Clipboard API, support of which is still pretty limited on chrome, and only available to extensions in Firefox.

For now, you can paste via:
- Browser bar -> Edit -> Paste.
- Middle mouse click (Linux only, copies secondary clipboard).

And **THEN press CTRL+V**

### Implement Clipboard API read when supported. (chrome only atm)

Being async, the first time a value is pasted GUI elements will still return the previous one(*).
This at least until 'clipboardchange' window event gets implemented by user agents.

(*)Note: We could implement some sort of clipboard manager that refreshes the value every few seconds and keeps the local keyboard in sync. It would still be chrome only, and it seems a bit hacky, but it would probably work.

Some references:
[Clipboard](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) (`readText` limited to extensions, `writeText` limited to user callbacks. See also [FF1515122](https://bugzilla.mozilla.org/show_bug.cgi?id=1515122) )

[clipboardchange](https://developer.mozilla.org/en-US/docs/Web/API/Window/clipboardchange_event) (supported by no-one).