### PR TITLE
Don't localize paths that contain but are not in the resource path

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -75,11 +75,19 @@ String ProjectSettings::localize_path(const String &p_path) const {
 
 		memdelete(dir);
 
-		if (!cwd.begins_with(resource_path)) {
+		// Ensure that we end with a '/'.
+		// This is important to ensure that we do not wrongly localize the resource path
+		// in an absolute path that just happens to contain this string but points to a
+		// different folder (e.g. "/my/project" as resource_path would be contained in
+		// "/my/project_data", even though the latter is not part of res://.
+		// `plus_file("")` is an easy way to ensure we have a trailing '/'.
+		const String res_path = resource_path.plus_file("");
+
+		if (!cwd.begins_with(res_path)) {
 			return p_path;
 		};
 
-		return cwd.replace_first(resource_path, "res:/");
+		return cwd.replace_first(res_path, "res://");
 	} else {
 
 		memdelete(dir);


### PR DESCRIPTION
This issue could be triggered if you try to access a path which contains
the resource path string in its absolute path, while pointing to a directory
which is *not* in the resource path.

It's clearer with an example: with `/my/project` as resource path, the
previous logic would also localize `/my/project_data` to `res://data`, which
is incorrect and would lead to a cryptic error.

Fixes #24761.
Supersedes #24772.

Credits to @volzhs for the fix, I just improved the proposed solution and documentation.