### PR TITLE
Fix memory leak in Text Editor and FileSystem dock

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -675,14 +675,14 @@ void CodeTextEditor::_line_col_changed() {
 		}
 	}
 
-	StringBuilder *sb = memnew(StringBuilder);
-	sb->append("(");
-	sb->append(itos(text_editor->cursor_get_line() + 1).lpad(3));
-	sb->append(",");
-	sb->append(itos(positional_column + 1).lpad(3));
-	sb->append(")");
+	StringBuilder sb;
+	sb.append("(");
+	sb.append(itos(text_editor->cursor_get_line() + 1).lpad(3));
+	sb.append(",");
+	sb.append(itos(positional_column + 1).lpad(3));
+	sb.append(")");
 
-	line_and_col_txt->set_text(sb->as_string());
+	line_and_col_txt->set_text(sb.as_string());
 }
 
 void CodeTextEditor::_text_changed() {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -451,9 +451,11 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 		} else if (dirAccess->dir_exists(p_path)) {
 			path = target_path + "/";
 		} else {
+			memdelete(dirAccess);
 			ERR_EXPLAIN(vformat(TTR("Cannot navigate to '%s' as it has not been found in the file system!"), p_path));
 			ERR_FAIL();
 		}
+		memdelete(dirAccess);
 	}
 
 	_set_current_path_text(path);


### PR DESCRIPTION
Logs from Valgrind 
```
==11684== 3,608 (616 direct, 2,992 indirect) bytes in 11 blocks are definitely lost in loss record 232,696 of 234,415
==11684==    at 0x582D74F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==11684==    by 0x37AFEDF: Memory::alloc_static(unsigned long, bool) (memory.cpp:85)
==11684==    by 0x37AFE88: operator new(unsigned long, char const*) (memory.cpp:42)
==11684==    by 0x1E20891: DirAccess* DirAccess::_create_builtin<DirAccessUnix>() (dir_access.h:69)
==11684==    by 0x3783781: DirAccess::create(DirAccess::AccessType) (dir_access.cpp:273)
==11684==    by 0x37835E6: DirAccess::create_for_path(String const&) (dir_access.cpp:243)
==11684==    by 0x3783653: DirAccess::open(String const&, Error*) (dir_access.cpp:257)
==11684==    by 0x2123713: FileSystemDock::_navigate_to_path(String const&, bool) (filesystem_dock.cpp:448)
==11684==    by 0x21275AF: FileSystemDock::_select_file(String, bool) (filesystem_dock.cpp:826)
==11684==    by 0x2127884: FileSystemDock::_tree_activate_file() (filesystem_dock.cpp:840)
==11684==    by 0x1426CE2: MethodBind0::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.gen.inc:59)
==11684==    by 0x36759EE: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:940)
```

```
==15117== 1,320 (360 direct, 960 indirect) bytes in 5 blocks are definitely lost in loss record 137 of 164
==15117==    at 0x582E74F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15117==    by 0x37B043D: Memory::alloc_static(unsigned long, bool) (memory.cpp:85)
==15117==    by 0x37B03E6: operator new(unsigned long, char const*) (memory.cpp:42)
==15117==    by 0x271FB11: CodeTextEditor::_line_col_changed() (code_editor.cpp:678)
==15117==    by 0x1426CE2: MethodBind0::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.gen.inc:59)
==15117==    by 0x3675EF2: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:940)
==15117==    by 0x3677C0E: Object::emit_signal(StringName const&, Variant const**, int) (object.cpp:1240)
==15117==    by 0x36782CD: Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (object.cpp:1296)
==15117==    by 0x2ADD057: TextEdit::_cursor_changed_emit() (text_edit.cpp:5125)
==15117==    by 0x1426CE2: MethodBind0::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.gen.inc:59)
==15117==    by 0x3675EF2: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:940)
==15117==    by 0x366CD43: MessageQueue::_call_function(Object*, StringName const&, Variant const*, int, bool) (message_queue.cpp:256)
```