### PR TITLE
Allow undo of conversion to CPUParticles

### DIFF
--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -94,7 +94,7 @@ void Particles2DEditorPlugin::_menu_callback(int p_idx) {
 			cpu_particles->set_z_index(particles->get_z_index());
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-			ur->create_action(TTR("Convert from Particles2D"));
+			ur->create_action(TTR("Convert to CPUParticles"));
 			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", particles, cpu_particles, true, false);
 			ur->add_do_reference(particles);
 			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, particles, false, false);

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -312,7 +312,13 @@ void ParticlesEditor::_menu_option(int p_option) {
 			cpu_particles->set_visible(node->is_visible());
 			cpu_particles->set_pause_mode(node->get_pause_mode());
 
-			EditorNode::get_singleton()->get_scene_tree_dock()->replace_node(node, cpu_particles, false);
+			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			ur->create_action(TTR("Convert to CPUParticles"));
+			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, cpu_particles, true, false);
+			ur->add_do_reference(node);
+			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, node, false, false);
+			ur->add_undo_reference(this);
+			ur->commit_action();
 
 		} break;
 	}


### PR DESCRIPTION
Fixes² #29250
Follow-up of #29308

Author forgot about Particles (3D), which had the same problem. I also changed the action name to be more consistent with other conversion actions and match menu text.

btw, seeing as it's another similar code, maybe we could add some more smart replace method that automatically creates a UndoRedo action with given name?