### PR TITLE
Fix animation player

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3633,6 +3633,9 @@ void AnimationTrackEditor::_animation_update() {
 	bezier_edit->update();
 
 	_update_step_spinbox();
+	emit_signal("animation_step_changed", animation->get_step());
+	emit_signal("animation_len_changed", animation->get_length());
+	EditorNode::get_singleton()->get_inspector()->refresh();
 
 	animation_changing_awaiting_update = false;
 }

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3685,8 +3685,7 @@ void AnimationTrackEditor::_update_step(double p_new_step) {
 	step->set_block_signals(true);
 	undo_redo->commit_action();
 	step->set_block_signals(false);
-	emit_signal("animation_step_changed", p_new_step);
-	animation->_change_notify("step");
+	emit_signal("animation_step_changed", step_value);
 }
 
 void AnimationTrackEditor::_update_length(double p_new_len) {
@@ -4973,6 +4972,7 @@ void AnimationTrackEditor::_bind_methods() {
 	ClassDB::bind_method("_update_scroll", &AnimationTrackEditor::_update_scroll);
 	ClassDB::bind_method("_update_tracks", &AnimationTrackEditor::_update_tracks);
 	ClassDB::bind_method("_update_step", &AnimationTrackEditor::_update_step);
+	ClassDB::bind_method("_update_length", &AnimationTrackEditor::_update_length);
 	ClassDB::bind_method("_dropped_track", &AnimationTrackEditor::_dropped_track);
 	ClassDB::bind_method("_add_track", &AnimationTrackEditor::_add_track);
 	ClassDB::bind_method("_new_track_node_selected", &AnimationTrackEditor::_new_track_node_selected);
@@ -5033,6 +5033,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline->connect("name_limit_changed", this, "_name_limit_changed");
 	timeline->connect("track_added", this, "_add_track");
 	timeline->connect("value_changed", this, "_timeline_value_changed");
+	timeline->connect("length_changed", this, "_update_length");
 
 	scroll = memnew(ScrollContainer);
 	timeline_vbox->add_child(scroll);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -289,39 +289,24 @@ void AnimationPlayerEditor::_pause_pressed() {
 
 	//player->set_pause( pause->is_pressed() );
 }
-
-String AnimationPlayerEditor::_get_current_animation() const {
-
-	// when selecting an animation, the idea is that the only interesting behavior
-	// ui-wise is that it should play/blend the next one if currently playing
-	if (animation->get_selected() >= 0 && animation->get_selected() < animation->get_item_count()) {
-
-		return animation->get_item_text(animation->get_selected());
-	}
-
-	return "";
-}
-
 void AnimationPlayerEditor::_animation_selected(int p_which) {
 
 	if (updating)
 		return;
+	// when selecting an animation, the idea is that the only interesting behavior
+	// ui-wise is that it should play/blend the next one if currently playing
+	String current;
+	if (animation->get_selected() >= 0 && animation->get_selected() < animation->get_item_count()) {
 
-	_current_animation_updated();
-}
-
-void AnimationPlayerEditor::_current_animation_updated() {
-
-	String current = _get_current_animation();
+		current = animation->get_item_text(animation->get_selected());
+	}
 
 	if (current != "") {
-		Ref<Animation> anim = player->get_animation(current);
 
 		player->set_assigned_animation(current);
-		{
 
-			if (!anim->is_connected("changed", this, "_current_animation_updated"))
-				anim->connect("changed", this, "_current_animation_updated");
+		Ref<Animation> anim = player->get_animation(current);
+		{
 
 			track_editor->set_animation(anim);
 			Node *root = player->get_node(player->get_root());
@@ -1078,19 +1063,17 @@ void AnimationPlayerEditor::_list_changed() {
 		_update_player();
 }
 
+void AnimationPlayerEditor::_animation_key_editor_anim_len_changed(float p_len) {
+
+	frame->set_max(p_len);
+}
+
 void AnimationPlayerEditor::_animation_key_editor_anim_step_changed(float p_len) {
 
 	if (p_len)
 		frame->set_step(p_len);
 	else
 		frame->set_step(0.00001);
-
-	String current = _get_current_animation();
-
-	if (current != "") {
-		Ref<Animation> anim = player->get_animation(current);
-		anim->_change_notify("step");
-	}
 }
 
 void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag) {
@@ -1568,7 +1551,6 @@ void AnimationPlayerEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_autoplay_pressed"), &AnimationPlayerEditor::_autoplay_pressed);
 	ClassDB::bind_method(D_METHOD("_pause_pressed"), &AnimationPlayerEditor::_pause_pressed);
 	ClassDB::bind_method(D_METHOD("_animation_selected"), &AnimationPlayerEditor::_animation_selected);
-	ClassDB::bind_method(D_METHOD("_current_animation_updated"), &AnimationPlayerEditor::_current_animation_updated);
 	ClassDB::bind_method(D_METHOD("_animation_name_edited"), &AnimationPlayerEditor::_animation_name_edited);
 	ClassDB::bind_method(D_METHOD("_animation_new"), &AnimationPlayerEditor::_animation_new);
 	ClassDB::bind_method(D_METHOD("_animation_rename"), &AnimationPlayerEditor::_animation_rename);
@@ -1588,6 +1570,7 @@ void AnimationPlayerEditor::_bind_methods() {
 	//ClassDB::bind_method(D_METHOD("_editor_load_all"),&AnimationPlayerEditor::_editor_load_all);
 	ClassDB::bind_method(D_METHOD("_list_changed"), &AnimationPlayerEditor::_list_changed);
 	ClassDB::bind_method(D_METHOD("_animation_key_editor_seek"), &AnimationPlayerEditor::_animation_key_editor_seek);
+	ClassDB::bind_method(D_METHOD("_animation_key_editor_anim_len_changed"), &AnimationPlayerEditor::_animation_key_editor_anim_len_changed);
 	ClassDB::bind_method(D_METHOD("_animation_key_editor_anim_step_changed"), &AnimationPlayerEditor::_animation_key_editor_anim_step_changed);
 	ClassDB::bind_method(D_METHOD("_hide_anim_editors"), &AnimationPlayerEditor::_hide_anim_editors);
 	ClassDB::bind_method(D_METHOD("_animation_duplicate"), &AnimationPlayerEditor::_animation_duplicate);
@@ -1801,6 +1784,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	add_child(track_editor);
 	track_editor->set_v_size_flags(SIZE_EXPAND_FILL);
 	track_editor->connect("timeline_changed", this, "_animation_key_editor_seek");
+	track_editor->connect("animation_len_changed", this, "_animation_key_editor_anim_len_changed");
 	track_editor->connect("animation_step_changed", this, "_animation_key_editor_anim_step_changed");
 
 	_update_player();

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -171,9 +171,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _autoplay_pressed();
 	void _stop_pressed();
 	void _pause_pressed();
-	String _get_current_animation() const;
 	void _animation_selected(int p_which);
-	void _current_animation_updated();
 	void _animation_new();
 	void _animation_rename();
 	void _animation_name_edited();


### PR DESCRIPTION
This PR reverts #24771 but give the same functionality.
And fixes #29242

![animation_sync](https://user-images.githubusercontent.com/8281454/58667715-c91a5500-8371-11e9-8d8c-0aaa643e409f.gif)

* Sync Length / Loop / Step values in Inspector with Animation editor.
* Dragging timeline bar by correct length and step values.