### PR TITLE
fixed issue #28490 by using the default constructor for Colors

### DIFF
--- a/core/color.h
+++ b/core/color.h
@@ -204,9 +204,9 @@ struct Color {
 	 * No construct parameters, r=0, g=0, b=0. a=255
 	 */
 	_FORCE_INLINE_ Color() {
-		r = 0;
-		g = 0;
-		b = 0;
+		r = 1.0;
+		g = 1.0;
+		b = 1.0;
 		a = 1.0;
 	}
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1204,7 +1204,13 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 				return (Transform(p_args[0]->operator Transform()));
 
 			// misc types
-			case COLOR: return p_args[0]->type == Variant::STRING ? Color::html(*p_args[0]) : Color();
+			case COLOR:
+				if (p_args[0]->type == Variant::STRING) {
+					return Color::html(*p_args[0]);
+				} else if (p_args[0]->type == Variant::INT) {
+					return Color::hex(*p_args[0]);
+				}
+				return Color();
 			case NODE_PATH:
 				return (NodePath(p_args[0]->operator NodePath())); // 15
 			case _RID: return (RID(*p_args[0]));

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1204,7 +1204,7 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 				return (Transform(p_args[0]->operator Transform()));
 
 			// misc types
-			case COLOR: return p_args[0]->type == Variant::STRING ? Color::html(*p_args[0]) : Color::hex(*p_args[0]);
+			case COLOR: return p_args[0]->type == Variant::STRING ? Color::html(*p_args[0]) : Color();
 			case NODE_PATH:
 				return (NodePath(p_args[0]->operator NodePath())); // 15
 			case _RID: return (RID(*p_args[0]));


### PR DESCRIPTION
There are 2 changes in this PR.

1. Default constructor of Color is now `Color(1,1,1,1)` instead of `Color(0,0,0,1)` which should make it more visible and apparent. Not much of a GUI person myself, but it could be green (green screen??)
2. Previously, when there is only 1 argument passed to construct Color from a Variant::NIL, it will use the 32 bits of the integer, partitioning them into 4 bytes to construct the Color. I believe this method is completely arbitrary and does not convey meaningful conversion at all so it has been replaced.

Fixes: #28490