### PR TITLE
Fix and expose String::strip_escapes(), use it in LineEdit paste

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3102,29 +3102,16 @@ String String::strip_edges(bool left, bool right) const {
 
 String String::strip_escapes() const {
 
-	int len = length();
-	int beg = 0, end = len;
-
+	String new_string;
 	for (int i = 0; i < length(); i++) {
 
-		if (operator[](i) <= 31)
-			beg++;
-		else
-			break;
+		// Escape characters on first page of the ASCII table, before 32 (Space).
+		if (operator[](i) < 32)
+			continue;
+		new_string += operator[](i);
 	}
 
-	for (int i = (int)(length() - 1); i >= 0; i--) {
-
-		if (operator[](i) <= 31)
-			end--;
-		else
-			break;
-	}
-
-	if (beg == 0 && end == len)
-		return *this;
-
-	return substr(beg, end - beg);
+	return new_string;
 }
 
 String String::lstrip(const String &p_chars) const {

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -265,6 +265,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1R(String, right);
 	VCALL_LOCALMEM0R(String, dedent);
 	VCALL_LOCALMEM2R(String, strip_edges);
+	VCALL_LOCALMEM0R(String, strip_escapes);
 	VCALL_LOCALMEM1R(String, lstrip);
 	VCALL_LOCALMEM1R(String, rstrip);
 	VCALL_LOCALMEM0R(String, get_extension);
@@ -1526,6 +1527,7 @@ void register_variant_methods() {
 	ADDFUNC1R(STRING, STRING, String, left, INT, "position", varray());
 	ADDFUNC1R(STRING, STRING, String, right, INT, "position", varray());
 	ADDFUNC2R(STRING, STRING, String, strip_edges, BOOL, "left", BOOL, "right", varray(true, true));
+	ADDFUNC0R(STRING, STRING, String, strip_escapes, varray());
 	ADDFUNC1R(STRING, STRING, String, lstrip, STRING, "chars", varray());
 	ADDFUNC1R(STRING, STRING, String, rstrip, STRING, "chars", varray());
 	ADDFUNC0R(STRING, STRING, String, get_extension, varray());

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -166,6 +166,7 @@
 		</constant>
 		<constant name="MENU_PASTE" value="2" enum="MenuItems">
 			Pastes the clipboard text over the selected text (or at the cursor's position).
+			Non-printable escape characters are automatically stripped from the OS clipboard via [method String.strip_escapes].
 		</constant>
 		<constant name="MENU_CLEAR" value="3" enum="MenuItems">
 			Erases the whole [LineEdit] text.

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -741,7 +741,14 @@
 			<argument index="1" name="right" type="bool" default="True">
 			</argument>
 			<description>
-				Returns a copy of the string stripped of any non-printable character at the beginning and the end. The optional arguments are used to toggle stripping on the left and right edges respectively.
+				Returns a copy of the string stripped of any non-printable character (including tabulations, spaces and line breaks) at the beginning and the end. The optional arguments are used to toggle stripping on the left and right edges respectively.
+			</description>
+		</method>
+		<method name="strip_escapes">
+			<return type="String">
+			</return>
+			<description>
+				Returns a copy of the string stripped of any escape character. These include all non-printable control characters of the first page of the ASCII table (&lt; 32), such as tabulation ([code]\t[/code] in C) and newline ([code]\n[/code] and [code]\r[/code]) characters, but not spaces.
 			</description>
 		</method>
 		<method name="substr">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -375,7 +375,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	while (I) {
 
-		I->get() = unescape_cmdline(I->get().strip_escapes());
+		I->get() = unescape_cmdline(I->get().strip_edges());
 		I = I->next();
 	}
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2378,7 +2378,7 @@ void OS_X11::process_xevents() {
 
 					Vector<String> files = String((char *)p.data).split("\n", false);
 					for (int i = 0; i < files.size(); i++) {
-						files.write[i] = files[i].replace("file://", "").http_unescape().strip_escapes();
+						files.write[i] = files[i].replace("file://", "").http_unescape().strip_edges();
 					}
 					main_loop->drop_files(files);
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -923,7 +923,8 @@ void LineEdit::cut_text() {
 
 void LineEdit::paste_text() {
 
-	String paste_buffer = OS::get_singleton()->get_clipboard();
+	// Strip escape characters like \n and \t as they can't be displayed on LineEdit.
+	String paste_buffer = OS::get_singleton()->get_clipboard().strip_escapes();
 
 	if (paste_buffer != "") {
 


### PR DESCRIPTION
Supersedes #27736.

This is the solution we discussed on IRC with @groud and @mhilbrunner today.

`strip_escapes` was not bound to scripting previously, but it is bound to GDNative, so this breaks compat from GDNative users. Yet the method was pretty much useless (doing the same as `strip_edges` apart from the stripping space characters), so it should not be a big deal for 3.2.