### PR TITLE
Fix rigidbody and rigidbody2d's can_sleep and sleeping properties about

### DIFF
--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -128,7 +128,7 @@
 			RigidBody's bounciness.
 		</member>
 		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep">
-			If [code]true[/code], the RigidBody will not calculate forces and will act as a static body while there is no movement. It will wake up when forces are applied through other collisions or when the [code]apply_impulse[/code] method is used.
+			If [code]true[/code], the RigidBody will auto enter [member sleeping] state if it stays still for some time. Default value: [code]true[/code].
 		</member>
 		<member name="contact_monitor" type="bool" setter="set_contact_monitor" getter="is_contact_monitor_enabled">
 			If [code]true[/code], the RigidBody will emit signals when it collides with another RigidBody.

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -129,7 +129,7 @@
 			The body's bounciness. Default value: [code]0[/code].
 		</member>
 		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep">
-			If [code]true[/code], the body will not calculate forces and will act as a static body if there is no movement. The body will wake up when other forces are applied via collisions or by using [method apply_impulse] or [method add_force]. Default value: [code]true[/code].
+			If [code]true[/code], the RigidBody2D will auto enter [member sleeping] state if it stays still for some time. Default value: [code]true[/code].
 		</member>
 		<member name="contact_monitor" type="bool" setter="set_contact_monitor" getter="is_contact_monitor_enabled">
 			If [code]true[/code], the body will emit signals when it collides with another RigidBody2D. See also [member contacts_reported]. Default value: [code]false[/code].

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -543,6 +543,7 @@ void RigidBodyBullet::set_mode(PhysicsServer::BodyMode p_mode) {
 	// This is necessary to block force_integration untile next move
 	can_integrate_forces = false;
 	destroy_kinematic_utilities();
+	PhysicsServer::BodyMode prev = mode;
 	// The mode change is relevant to its mass
 	switch (p_mode) {
 		case PhysicsServer::BODY_MODE_KINEMATIC:
@@ -561,6 +562,7 @@ void RigidBodyBullet::set_mode(PhysicsServer::BodyMode p_mode) {
 			reload_axis_lock();
 			_internal_set_mass(0 == mass ? 1 : mass);
 			scratch_space_override_modificator();
+			if (prev != mode) set_activation_state(true);
 			break;
 		case PhysicsServer::BODY_MODE_CHARACTER:
 			mode = PhysicsServer::BODY_MODE_CHARACTER;
@@ -594,12 +596,6 @@ void RigidBodyBullet::set_state(PhysicsServer::BodyState p_state, const Variant 
 			break;
 		case PhysicsServer::BODY_STATE_CAN_SLEEP:
 			can_sleep = bool(p_variant);
-			if (!can_sleep) {
-				// Can't sleep
-				btBody->forceActivationState(DISABLE_DEACTIVATION);
-			} else {
-				btBody->forceActivationState(ACTIVE_TAG);
-			}
 			break;
 	}
 }

--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -260,6 +260,7 @@ void BodySW::set_mode(PhysicsServer::BodyMode p_mode) {
 
 			_inv_mass = mass > 0 ? (1.0 / mass) : 0;
 			_set_static(false);
+			if (prev != mode) set_active(true);
 
 		} break;
 		case PhysicsServer::BODY_MODE_CHARACTER: {
@@ -352,8 +353,6 @@ void BodySW::set_state(PhysicsServer::BodyState p_state, const Variant &p_varian
 		} break;
 		case PhysicsServer::BODY_STATE_CAN_SLEEP: {
 			can_sleep = p_variant;
-			if (mode == PhysicsServer::BODY_MODE_RIGID && !active && !can_sleep)
-				set_active(true);
 
 		} break;
 	}
@@ -794,7 +793,7 @@ BodySW::BodySW() :
 
 	still_time = 0;
 	continuous_cd = false;
-	can_sleep = false;
+	can_sleep = true;
 	fi_callback = NULL;
 }
 

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -238,6 +238,7 @@ void Body2DSW::set_mode(Physics2DServer::BodyMode p_mode) {
 
 			_inv_mass = mass > 0 ? (1.0 / mass) : 0;
 			_set_static(false);
+			if (prev != mode) set_active(true);
 
 		} break;
 		case Physics2DServer::BODY_MODE_CHARACTER: {
@@ -332,8 +333,6 @@ void Body2DSW::set_state(Physics2DServer::BodyState p_state, const Variant &p_va
 		} break;
 		case Physics2DServer::BODY_STATE_CAN_SLEEP: {
 			can_sleep = p_variant;
-			if (mode == Physics2DServer::BODY_MODE_RIGID && !active && !can_sleep)
-				set_active(true);
 
 		} break;
 	}
@@ -690,7 +689,7 @@ Body2DSW::Body2DSW() :
 
 	still_time = 0;
 	continuous_cd_mode = Physics2DServer::CCD_MODE_DISABLED;
-	can_sleep = false;
+	can_sleep = true;
 	fi_callback = NULL;
 }
 


### PR DESCRIPTION
fix https://github.com/godotengine/godot/issues/28076
There are three parts of it, I'm not sure all of those are correct:

1. Rigidbody and Rrigidbody2d 's can_sleep member should be default true, and the doc should explain it more cleaner.

2. when switch from non-rigid mode to rigid mode, the rigidbody get out form sleeping state auto.
3. can_sleep and sleeping should be two independent member, if we set can_sleep false, it won't auto set sleeping to false. can_sleep is a member to control whether rigidbody can auto turn into sleeping state, set_sleeping is a method to manually set sleeping state.