### PR TITLE
doc: Make all tutorial links track "latest" in master branch

### DIFF
--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -7,7 +7,7 @@
 		Resource is the base class for all resource types, serving primarily as data containers. They are reference counted and freed when no longer in use. They are also loaded only once from disk, and further attempts to load the resource will return the same reference (all this in contrast to a [Node], which is not reference counted and can be instanced from disk as many times as desired). Resources can be saved externally on disk or bundled into another object, such as a [Node] or another resource.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/stable/getting_started/step_by_step/resources.html</link>
+		<link>https://docs.godotengine.org/en/latest/getting_started/step_by_step/resources.html</link>
 	</tutorials>
 	<methods>
 		<method name="_setup_local_to_scene" qualifiers="virtual">

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -7,7 +7,7 @@
 		This is the built-in string class (and the one used by GDScript). It supports Unicode and provides all necessary means for string handling. Strings are reference counted and use a copy-on-write approach, so passing them around is cheap in resources.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_format_string.html</link>
+		<link>https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_format_string.html</link>
 	</tutorials>
 	<methods>
 		<method name="String">

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -8,7 +8,7 @@
 		Theme resources can be alternatively loaded by writing them in a .theme file, see docs for more info.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/stable/tutorials/gui/gui_skinning.html</link>
+		<link>https://docs.godotengine.org/en/latest/tutorials/gui/gui_skinning.html</link>
 	</tutorials>
 	<methods>
 		<method name="clear">

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -7,8 +7,8 @@
 		Translations are resources that can be loaded/unloaded on demand. They map a string to another string.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html</link>
-		<link>https://docs.godotengine.org/en/stable/tutorials/i18n/locales.html</link>
+		<link>https://docs.godotengine.org/en/latest/tutorials/i18n/internationalizing_games.html</link>
+		<link>https://docs.godotengine.org/en/latest/tutorials/i18n/locales.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_message">

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -7,8 +7,8 @@
 		Server that manages all translations. Translations can be set to it and removed from it.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html</link>
-		<link>https://docs.godotengine.org/en/stable/tutorials/i18n/locales.html</link>
+		<link>https://docs.godotengine.org/en/latest/tutorials/i18n/internationalizing_games.html</link>
+		<link>https://docs.godotengine.org/en/latest/tutorials/i18n/locales.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_translation">


### PR DESCRIPTION
While the master branch is in development state for the next stable branch,
its links should point to the "latest" docs branch, to ensure that users of
the unstable builds are linked to the relevant documentation.

Those links could be switched to stable branch subdomains before branching
off for a new major or minor release, to start tracking the frozen stable
docs branches.

See discussion in #29104.