### PR TITLE
Display longer Git hashes in engine version dialogs

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -131,7 +131,7 @@ EditorAbout::EditorAbout() {
 
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0)
-		hash = "." + hash.left(7);
+		hash = "." + hash.left(9);
 
 	Label *about_text = memnew(Label);
 	about_text->set_v_size_flags(Control::SIZE_SHRINK_CENTER);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1971,7 +1971,7 @@ ProjectManager::ProjectManager() {
 	l = memnew(Label);
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0)
-		hash = "." + hash.left(7);
+		hash = "." + hash.left(9);
 	l->set_text("v" VERSION_FULL_BUILD "" + hash);
 	l->set_align(Label::ALIGN_CENTER);
 	top_hb->add_child(l);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -161,7 +161,7 @@ static String unescape_cmdline(const String &p_str) {
 static String get_full_version_string() {
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0)
-		hash = "." + hash.left(7);
+		hash = "." + hash.left(9);
 	return String(VERSION_FULL_BUILD) + hash;
 }
 


### PR DESCRIPTION
Due to the high number of commits in the Godot repository, 7-character hashes were starting to become occasionally ambiguous.

In contrast, 9-character hashes are currently unambiguous for all commits.

See [this Stack Overflow question](https://stackoverflow.com/questions/32405922/in-my-repo-how-long-must-the-longest-hash-prefix-be-to-prevent-any-overlap) for reference. Here's one of the commands given run on the Godot repository as of cfb9709c10483f7f58a8b96248c23d0a5f1d5ad7:

```
❯ git rev-list --abbrev=4 --abbrev-commit --all | ( while read -r line; do echo ${#line}; done; ) | sort -n | uniq -c
    785 4
  19065 5
   4289 6
    314 7
     22 8
      1 9
```