### PR TITLE
Saving/deleting editor layouts dialog with layout list

### DIFF
--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  editor_name_dialog.cpp                                               */
+/*  editor_layouts_dialog.cpp                                            */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,13 +28,15 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "editor_name_dialog.h"
-
+#include "editor_layouts_dialog.h"
 #include "core/class_db.h"
+#include "core/io/config_file.h"
 #include "core/os/keyboard.h"
+#include "editor/editor_settings.h"
+#include "scene/gui/item_list.h"
+#include "scene/gui/line_edit.h"
 
-void EditorNameDialog::_line_gui_input(const Ref<InputEvent> &p_event) {
-
+void EditorLayoutsDialog::_line_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
 
 	if (k.is_valid()) {
@@ -60,34 +62,77 @@ void EditorNameDialog::_line_gui_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
-void EditorNameDialog::_post_popup() {
-
-	ConfirmationDialog::_post_popup();
-	name->clear();
-	name->grab_focus();
-}
-
-void EditorNameDialog::ok_pressed() {
-
-	if (name->get_text() != "") {
-		emit_signal("name_confirmed", name->get_text());
-	}
-}
-
-void EditorNameDialog::_bind_methods() {
-
-	ClassDB::bind_method("_line_gui_input", &EditorNameDialog::_line_gui_input);
+void EditorLayoutsDialog::_bind_methods() {
+	ClassDB::bind_method("_line_gui_input", &EditorLayoutsDialog::_line_gui_input);
 
 	ADD_SIGNAL(MethodInfo("name_confirmed", PropertyInfo(Variant::STRING, "name")));
 }
 
-EditorNameDialog::EditorNameDialog() {
+void EditorLayoutsDialog::ok_pressed() {
+
+	if (layout_names->is_anything_selected()) {
+
+		Vector<int> const selected_items = layout_names->get_selected_items();
+		for (int i = 0; i < selected_items.size(); ++i) {
+
+			emit_signal("name_confirmed", layout_names->get_item_text(selected_items[i]));
+		}
+	} else if (name->is_visible() && name->get_text() != "") {
+
+		emit_signal("name_confirmed", name->get_text());
+	}
+}
+
+void EditorLayoutsDialog::_post_popup() {
+
+	ConfirmationDialog::_post_popup();
+	name->clear();
+	layout_names->clear();
+
+	Ref<ConfigFile> config;
+	config.instance();
+	Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());
+	if (err != OK) {
+
+		return;
+	}
+
+	List<String> layouts;
+	config.ptr()->get_sections(&layouts);
+
+	for (List<String>::Element *E = layouts.front(); E; E = E->next()) {
+
+		layout_names->add_item(**E);
+	}
+}
+
+EditorLayoutsDialog::EditorLayoutsDialog() {
+
 	makevb = memnew(VBoxContainer);
 	add_child(makevb);
+	makevb->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 5);
+	makevb->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, -5);
+
+	layout_names = memnew(ItemList);
+	makevb->add_child(layout_names);
+	layout_names->set_visible(true);
+	layout_names->set_margin(MARGIN_TOP, 5);
+	layout_names->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 5);
+	layout_names->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, -5);
+	layout_names->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	layout_names->set_select_mode(ItemList::SelectMode::SELECT_MULTI);
+	layout_names->set_allow_rmb_select(true);
+
 	name = memnew(LineEdit);
 	makevb->add_child(name);
 	name->set_margin(MARGIN_TOP, 5);
 	name->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 5);
 	name->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, -5);
 	name->connect("gui_input", this, "_line_gui_input");
+	name->connect("focus_entered", layout_names, "unselect_all");
+}
+
+void EditorLayoutsDialog::set_name_line_enabled(bool p_enabled) {
+
+	name->set_visible(p_enabled);
 }

--- a/editor/editor_layouts_dialog.h
+++ b/editor/editor_layouts_dialog.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  editor_name_dialog.h                                                 */
+/*  editor_layouts_dialog.h                                              */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,18 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITOR_NAME_DIALOG_H
-#define EDITOR_NAME_DIALOG_H
+#ifndef EDITOR_LAYOUTS_DIALOG_H
+#define EDITOR_LAYOUTS_DIALOG_H
 
 #include "scene/gui/dialogs.h"
-#include "scene/gui/line_edit.h"
 
-class EditorNameDialog : public ConfirmationDialog {
+class LineEdit;
+class ItemList;
 
-	GDCLASS(EditorNameDialog, ConfirmationDialog);
+class EditorLayoutsDialog : public ConfirmationDialog {
 
-	VBoxContainer *makevb;
+	GDCLASS(EditorLayoutsDialog, ConfirmationDialog);
+
 	LineEdit *name;
+	ItemList *layout_names;
+	VBoxContainer *makevb;
 
 	void _line_gui_input(const Ref<InputEvent> &p_event);
 
@@ -49,9 +52,9 @@ protected:
 	virtual void _post_popup();
 
 public:
-	LineEdit *get_line_edit() { return name; }
+	EditorLayoutsDialog();
 
-	EditorNameDialog();
+	void set_name_line_enabled(bool p_enabled);
 };
 
-#endif // EDITOR_NAME_DIALOG_H
+#endif // EDITOR_LAYOUTS_DIALOG_H

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4249,6 +4249,7 @@ void EditorNode::_layout_menu_option(int p_id) {
 			layout_dialog->set_title(TTR("Save Layout"));
 			layout_dialog->get_ok()->set_text(TTR("Save"));
 			layout_dialog->popup_centered();
+			layout_dialog->set_name_line_enabled(true);
 		} break;
 		case SETTINGS_LAYOUT_DELETE: {
 
@@ -4256,6 +4257,7 @@ void EditorNode::_layout_menu_option(int p_id) {
 			layout_dialog->set_title(TTR("Delete Layout"));
 			layout_dialog->get_ok()->set_text(TTR("Delete"));
 			layout_dialog->popup_centered();
+			layout_dialog->set_name_line_enabled(false);
 		} break;
 		case SETTINGS_LAYOUT_DEFAULT: {
 
@@ -6019,10 +6021,10 @@ EditorNode::EditorNode() {
 
 	progress_hb = memnew(BackgroundProgress);
 
-	layout_dialog = memnew(EditorNameDialog);
+	layout_dialog = memnew(EditorLayoutsDialog);
 	gui_base->add_child(layout_dialog);
 	layout_dialog->set_hide_on_ok(false);
-	layout_dialog->set_size(Size2(175, 70) * EDSCALE);
+	layout_dialog->set_size(Size2(225, 270) * EDSCALE);
 	layout_dialog->connect("name_confirmed", this, "_dialog_action");
 
 	update_menu = memnew(MenuButton);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -41,8 +41,8 @@
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_folding.h"
 #include "editor/editor_inspector.h"
+#include "editor/editor_layouts_dialog.h"
 #include "editor/editor_log.h"
-#include "editor/editor_name_dialog.h"
 #include "editor/editor_plugin.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_run.h"
@@ -85,6 +85,7 @@
 #include "scene/gui/tool_button.h"
 #include "scene/gui/tree.h"
 #include "scene/gui/viewport_container.h"
+
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
@@ -307,7 +308,7 @@ private:
 	int overridden_default_layout;
 	Ref<ConfigFile> default_layout;
 	PopupMenu *editor_layouts;
-	EditorNameDialog *layout_dialog;
+	EditorLayoutsDialog *layout_dialog;
 
 	ConfirmationDialog *custom_build_manage_templates;
 	ConfirmationDialog *install_android_build_template;

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -31,7 +31,6 @@
 #ifndef TILE_SET_EDITOR_PLUGIN_H
 #define TILE_SET_EDITOR_PLUGIN_H
 
-#include "editor/editor_name_dialog.h"
 #include "editor/editor_node.h"
 #include "scene/2d/sprite.h"
 #include "scene/resources/concave_polygon_shape_2d.h"


### PR DESCRIPTION
With this dialog you no longer need to type layout name in order to save or delete it. 
You can choose layout (or multiple layouts) from a list.

![deleteLayoutDialog](https://user-images.githubusercontent.com/29497869/58748264-4202d500-8476-11e9-8384-e564b24012ea.png)

Save layout dialog still has line edit for inputting layout name. List selection has a priority over this line edit.
To deselect everything from the list simply focus line edit.

Previous dialog - EditorNameDialog - isn't used anywhere else. Should i delete it?

Another thing - if layouts can only be deleted through a dialog it should not be possible to input wrong name when deleting a layout since it's now done with list selection. Should i make an assert in this code (editor/editor_node.cpp):

		case SETTINGS_LAYOUT_DELETE: {

			if (p_file.empty())
				return;

			Ref<ConfigFile> config;
			config.instance();
			Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());

			if (err != OK || !config->has_section(p_file)) {
				show_warning(TTR("Layout name not found!"));
				return;
			}

