### PR TITLE
Add default values to the editor help, docs, and generated RST

### DIFF
--- a/core/class_db.h
+++ b/core/class_db.h
@@ -162,6 +162,7 @@ public:
 	static void _add_class2(const StringName &p_class, const StringName &p_inherits);
 
 	static HashMap<StringName, HashMap<StringName, Variant> > default_values;
+	static Set<StringName> default_values_cached;
 
 public:
 	// DO NOT USE THIS!!!!!! NEEDS TO BE PUBLIC BUT DO NOT USE NO MATTER WHAT!!!
@@ -329,6 +330,7 @@ public:
 
 	static void add_property_group(StringName p_class, const String &p_name, const String &p_prefix = "");
 	static void add_property(StringName p_class, const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter, int p_index = -1);
+	static void set_property_default_value(StringName p_class, const StringName &p_name, const Variant &p_default);
 	static void get_property_list(StringName p_class, List<PropertyInfo> *p_list, bool p_no_inheritance = false, const Object *p_validator = NULL);
 	static bool set_property(Object *p_object, const StringName &p_property, const Variant &p_value, bool *r_valid = NULL);
 	static bool get_property(Object *p_object, const StringName &p_property, Variant &r_value);
@@ -373,6 +375,7 @@ public:
 
 	static void set_current_api(APIType p_api);
 	static APIType get_current_api();
+	static void cleanup_defaults();
 	static void cleanup();
 };
 

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -874,6 +874,7 @@ void MultiplayerAPI::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_object_decoding"), "set_allow_object_decoding", "is_object_decoding_allowed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_network_connections"), "set_refuse_new_network_connections", "is_refusing_new_network_connections");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "network_peer", PROPERTY_HINT_RESOURCE_TYPE, "NetworkedMultiplayerPeer", 0), "set_network_peer", "get_network_peer");
+	ADD_PROPERTY_DEFAULT("refuse_new_network_connections", false);
 
 	ADD_SIGNAL(MethodInfo("network_peer_connected", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("network_peer_disconnected", PropertyInfo(Variant::INT, "id")));

--- a/core/object.h
+++ b/core/object.h
@@ -130,6 +130,7 @@ enum PropertyUsageFlags {
 #define ADD_SIGNAL(m_signal) ClassDB::add_signal(get_class_static(), m_signal)
 #define ADD_PROPERTY(m_property, m_setter, m_getter) ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter))
 #define ADD_PROPERTYI(m_property, m_setter, m_getter, m_index) ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter), m_index)
+#define ADD_PROPERTY_DEFAULT(m_property, m_default) ClassDB::set_property_default_value(get_class_static(), m_property, m_default)
 #define ADD_GROUP(m_name, m_prefix) ClassDB::add_property_group(get_class_static(), m_name, m_prefix)
 
 struct PropertyInfo {

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -273,6 +273,7 @@ void unregister_core_types() {
 
 	ResourceLoader::finalize();
 
+	ClassDB::cleanup_defaults();
 	ObjectDB::cleanup();
 
 	unregister_variant_methods();

--- a/editor/doc/doc_data.h
+++ b/editor/doc/doc_data.h
@@ -73,6 +73,7 @@ public:
 		String enumeration;
 		String description;
 		String setter, getter;
+		String default_value;
 		bool operator<(const PropertyDoc &p_prop) const {
 			return name < p_prop.name;
 		}

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -48,9 +48,9 @@ void EditorHelp::_init_colors() {
 	text_color = get_color("default_color", "RichTextLabel");
 	headline_color = get_color("headline_color", "EditorHelp");
 	base_type_color = title_color.linear_interpolate(text_color, 0.5);
-	comment_color = text_color * Color(1, 1, 1, 0.6);
+	comment_color = text_color * Color(1, 1, 1, 0.4);
 	symbol_color = comment_color;
-	value_color = text_color * Color(1, 1, 1, 0.4);
+	value_color = text_color * Color(1, 1, 1, 0.6);
 	qualifier_color = text_color * Color(1, 1, 1, 0.8);
 	type_color = get_color("accent_color", "Editor").linear_interpolate(text_color, 0.5);
 	class_desc->add_color_override("selection_color", get_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
@@ -258,9 +258,11 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		if (p_method.arguments[j].default_value != "") {
 
 			class_desc->push_color(symbol_color);
-			class_desc->add_text("=");
+			class_desc->add_text(" = ");
 			class_desc->pop();
+			class_desc->push_color(value_color);
 			_add_text(_fix_constant(p_method.arguments[j].default_value));
+			class_desc->pop();
 		}
 
 		class_desc->pop();
@@ -471,22 +473,36 @@ void EditorHelp::_update_doc() {
 			if (cd.properties[i].description != "") {
 				describe = true;
 			}
+
 			class_desc->push_cell();
+			class_desc->push_font(doc_code_font);
+			class_desc->push_color(headline_color);
+
 			if (describe) {
 				class_desc->push_meta("@member " + cd.properties[i].name);
 			}
 
-			class_desc->push_font(doc_code_font);
-			class_desc->push_color(headline_color);
 			_add_text(cd.properties[i].name);
-
-			class_desc->pop();
-			class_desc->pop();
 
 			if (describe) {
 				class_desc->pop();
 				property_descr = true;
 			}
+
+			if (cd.properties[i].default_value != "") {
+				class_desc->push_color(symbol_color);
+				class_desc->add_text(" [default: ");
+				class_desc->pop();
+				class_desc->push_color(value_color);
+				_add_text(_fix_constant(cd.properties[i].default_value));
+				class_desc->pop();
+				class_desc->push_color(symbol_color);
+				class_desc->add_text("]");
+				class_desc->pop();
+			}
+
+			class_desc->pop();
+			class_desc->pop();
 
 			class_desc->pop();
 		}
@@ -613,6 +629,19 @@ void EditorHelp::_update_doc() {
 			class_desc->push_color(headline_color);
 			_add_text(cd.theme_properties[i].name);
 			class_desc->pop();
+
+			if (cd.theme_properties[i].default_value != "") {
+				class_desc->push_color(symbol_color);
+				class_desc->add_text(" [default: ");
+				class_desc->pop();
+				class_desc->push_color(value_color);
+				_add_text(_fix_constant(cd.theme_properties[i].default_value));
+				class_desc->pop();
+				class_desc->push_color(symbol_color);
+				class_desc->add_text("]");
+				class_desc->pop();
+			}
+
 			class_desc->pop();
 
 			if (cd.theme_properties[i].description != "") {
@@ -671,7 +700,7 @@ void EditorHelp::_update_doc() {
 				if (cd.signals[i].arguments[j].default_value != "") {
 
 					class_desc->push_color(symbol_color);
-					class_desc->add_text("=");
+					class_desc->add_text(" = ");
 					class_desc->pop();
 					_add_text(cd.signals[i].arguments[j].default_value);
 				}
@@ -777,7 +806,7 @@ void EditorHelp::_update_doc() {
 					class_desc->add_text(" = ");
 					class_desc->pop();
 					class_desc->push_color(value_color);
-					_add_text(enum_list[i].value);
+					_add_text(_fix_constant(enum_list[i].value));
 					class_desc->pop();
 					class_desc->pop();
 					if (enum_list[i].description != "") {
@@ -843,7 +872,7 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text(" = ");
 				class_desc->pop();
 				class_desc->push_color(value_color);
-				_add_text(constants[i].value);
+				_add_text(_fix_constant(constants[i].value));
 				class_desc->pop();
 
 				class_desc->pop();
@@ -963,6 +992,21 @@ void EditorHelp::_update_doc() {
 			class_desc->push_color(headline_color);
 			_add_text(cd.properties[i].name);
 			class_desc->pop(); // color
+
+			if (cd.properties[i].default_value != "") {
+				class_desc->push_color(symbol_color);
+				class_desc->add_text(" [default: ");
+				class_desc->pop(); // color
+
+				class_desc->push_color(value_color);
+				_add_text(_fix_constant(cd.properties[i].default_value));
+				class_desc->pop(); // color
+
+				class_desc->push_color(symbol_color);
+				class_desc->add_text("]");
+				class_desc->pop(); // color
+			}
+
 			class_desc->pop(); // font
 			class_desc->pop(); // cell
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1473,6 +1473,10 @@ void EditorSettings::get_shortcut_list(List<String> *r_shortcuts) {
 
 Ref<ShortCut> ED_GET_SHORTCUT(const String &p_path) {
 
+	if (!EditorSettings::get_singleton()) {
+		return NULL;
+	}
+
 	Ref<ShortCut> sc = EditorSettings::get_singleton()->get_shortcut(p_path);
 	if (!sc.is_valid()) {
 		ERR_EXPLAIN("Used ED_GET_SHORTCUT with invalid shortcut: " + p_path);
@@ -1506,6 +1510,15 @@ Ref<ShortCut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p
 		ie->set_alt(bool(p_keycode & KEY_MASK_ALT));
 		ie->set_control(bool(p_keycode & KEY_MASK_CTRL));
 		ie->set_metakey(bool(p_keycode & KEY_MASK_META));
+	}
+
+	if (!EditorSettings::get_singleton()) {
+		Ref<ShortCut> sc;
+		sc.instance();
+		sc->set_name(p_name);
+		sc->set_shortcut(ie);
+		sc->set_meta("original", ie);
+		return sc;
 	}
 
 	Ref<ShortCut> sc = EditorSettings::get_singleton()->get_shortcut(p_path);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1375,6 +1375,8 @@ bool Main::start() {
 #ifdef TOOLS_ENABLED
 	if (doc_tool != "") {
 
+		Engine::get_singleton()->set_editor_hint(true); // Needed to instance editor-only classes for their default values
+
 		{
 			DirAccessRef da = DirAccess::open(doc_tool);
 			if (!da) {

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -882,7 +882,9 @@ NetworkedMultiplayerENet::NetworkedMultiplayerENet() {
 
 NetworkedMultiplayerENet::~NetworkedMultiplayerENet() {
 
-	close_connection();
+	if (active) {
+		close_connection();
+	}
 }
 
 // Sets IP for ENet to bind when using create_server or create_client

--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -33,9 +33,13 @@
 #include "servers/arvr/arvr_positional_tracker.h"
 #include "servers/visual/visual_server_globals.h"
 
+void ARVRInterfaceGDNative::_bind_methods() {
+	ADD_PROPERTY_DEFAULT("interface_is_initialized", false);
+	ADD_PROPERTY_DEFAULT("ar_is_anchor_detection_enabled", false);
+}
+
 ARVRInterfaceGDNative::ARVRInterfaceGDNative() {
-	// testing
-	printf("Construct gdnative interface\n");
+	print_verbose("Construct gdnative interface\n");
 
 	// we won't have our data pointer until our library gets set
 	data = NULL;
@@ -44,9 +48,9 @@ ARVRInterfaceGDNative::ARVRInterfaceGDNative() {
 }
 
 ARVRInterfaceGDNative::~ARVRInterfaceGDNative() {
-	printf("Destruct gdnative interface\n");
+	print_verbose("Destruct gdnative interface\n");
 
-	if (is_initialized()) {
+	if (interface != NULL && is_initialized()) {
 		uninitialize();
 	};
 
@@ -99,13 +103,10 @@ int ARVRInterfaceGDNative::get_capabilities() const {
 }
 
 bool ARVRInterfaceGDNative::get_anchor_detection_is_enabled() const {
-	bool enabled;
 
 	ERR_FAIL_COND_V(interface == NULL, false);
 
-	enabled = interface->get_anchor_detection_is_enabled(data);
-
-	return enabled;
+	return interface->get_anchor_detection_is_enabled(data);
 }
 
 void ARVRInterfaceGDNative::set_anchor_detection_is_enabled(bool p_enable) {
@@ -137,21 +138,16 @@ bool ARVRInterfaceGDNative::is_stereo() {
 }
 
 bool ARVRInterfaceGDNative::is_initialized() const {
-	bool initialized;
 
 	ERR_FAIL_COND_V(interface == NULL, false);
 
-	initialized = interface->is_initialized(data);
-
-	return initialized;
+	return interface->is_initialized(data);
 }
 
 bool ARVRInterfaceGDNative::initialize() {
-	bool initialized;
-
 	ERR_FAIL_COND_V(interface == NULL, false);
 
-	initialized = interface->initialize(data);
+	bool initialized = interface->initialize(data);
 
 	if (initialized) {
 		// if we successfully initialize our interface and we don't have a primary interface yet, this becomes our primary interface

--- a/modules/gdnative/arvr/arvr_interface_gdnative.h
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.h
@@ -49,6 +49,8 @@ protected:
 	const godot_arvr_interface_gdnative *interface;
 	void *data;
 
+	static void _bind_methods();
+
 public:
 	/** general interface information **/
 	ARVRInterfaceGDNative();

--- a/modules/gdnative/net/multiplayer_peer_gdnative.cpp
+++ b/modules/gdnative/net/multiplayer_peer_gdnative.cpp
@@ -113,6 +113,8 @@ NetworkedMultiplayerPeer::ConnectionStatus MultiplayerPeerGDNative::get_connecti
 }
 
 void MultiplayerPeerGDNative::_bind_methods() {
+	ADD_PROPERTY_DEFAULT("transfer_mode", TRANSFER_MODE_UNRELIABLE);
+	ADD_PROPERTY_DEFAULT("refuse_new_connections", true);
 }
 
 extern "C" {

--- a/modules/webrtc/webrtc_data_channel_gdnative.cpp
+++ b/modules/webrtc/webrtc_data_channel_gdnative.cpp
@@ -35,6 +35,7 @@
 #include "modules/gdnative/nativescript/nativescript.h"
 
 void WebRTCDataChannelGDNative::_bind_methods() {
+	ADD_PROPERTY_DEFAULT("write_mode", WRITE_MODE_BINARY);
 }
 
 WebRTCDataChannelGDNative::WebRTCDataChannelGDNative() {

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1541,7 +1541,7 @@ Vector2 KinematicCollision2D::get_remainder() const {
 	return collision.remainder;
 }
 Object *KinematicCollision2D::get_local_shape() const {
-	ERR_FAIL_COND_V(!owner, NULL);
+	if (!owner) return NULL;
 	uint32_t ownerid = owner->shape_find_owner(collision.local_shape);
 	return owner->shape_owner_get_owner(ownerid);
 }

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -264,6 +264,7 @@ void ARVRController::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rumble"), &ARVRController::get_rumble);
 	ClassDB::bind_method(D_METHOD("set_rumble", "rumble"), &ARVRController::set_rumble);
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "rumble", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_rumble", "get_rumble");
+	ADD_PROPERTY_DEFAULT("rumble", 0.0);
 
 	ClassDB::bind_method(D_METHOD("get_mesh"), &ARVRController::get_mesh);
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1470,7 +1470,7 @@ Vector3 KinematicCollision::get_remainder() const {
 	return collision.remainder;
 }
 Object *KinematicCollision::get_local_shape() const {
-	ERR_FAIL_COND_V(!owner, NULL);
+	if (!owner) return NULL;
 	uint32_t ownerid = owner->shape_find_owner(collision.local_shape);
 	return owner->shape_owner_get_owner(ownerid);
 }

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -614,6 +614,7 @@ void SceneTree::finish() {
 		root->_set_tree(NULL);
 		root->_propagate_after_exit_tree();
 		memdelete(root); //delete root
+		root = NULL;
 	}
 }
 
@@ -1889,6 +1890,7 @@ void SceneTree::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_navigation_hint"), "set_debug_navigation_hint", "is_debugging_navigation_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused"), "set_pause", "is_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_network_connections"), "set_refuse_new_network_connections", "is_refusing_new_network_connections");
+	ADD_PROPERTY_DEFAULT("refuse_new_network_connections", false);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_font_oversampling"), "set_use_font_oversampling", "is_using_font_oversampling");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "edited_scene_root", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0), "set_edited_scene_root", "get_edited_scene_root");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "current_scene", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0), "set_current_scene", "get_current_scene");
@@ -1962,7 +1964,7 @@ bool SceneTree::is_using_font_oversampling() const {
 
 SceneTree::SceneTree() {
 
-	singleton = this;
+	if (singleton == NULL) singleton = this;
 	_quit = false;
 	accept_quit = true;
 	quit_on_go_back = true;
@@ -2107,4 +2109,11 @@ SceneTree::SceneTree() {
 }
 
 SceneTree::~SceneTree() {
+	if (root) {
+		root->_set_tree(NULL);
+		root->_propagate_after_exit_tree();
+		memdelete(root);
+	}
+
+	if (singleton == this) singleton = NULL;
 }

--- a/scene/resources/concave_polygon_shape_2d.cpp
+++ b/scene/resources/concave_polygon_shape_2d.cpp
@@ -104,4 +104,6 @@ void ConcavePolygonShape2D::_bind_methods() {
 
 ConcavePolygonShape2D::ConcavePolygonShape2D() :
 		Shape2D(Physics2DServer::get_singleton()->concave_polygon_shape_create()) {
+	PoolVector<Vector2> empty;
+	set_segments(empty);
 }


### PR DESCRIPTION
Also, make spacing of "=" in the editor help a bit more consistent.

To do:
- [x] Add default property values to DocData.
- [x] Export default property values to .xml classes and then to RST.
- [x] Fix or silence these errors produced while getting the default values.
- [x] Add default values for abstract classes like `BaseButton`.
- [x] Add default values to the Properties listing, and not just description in the in-editor help (and maybe in the rst documentation).
- [x] Ensure there are no leftover crashes from the whole process.
- [x] Fix crash at exit from editor/doctool.
- [x] Update docs to remove default values from the descriptions and run doctool (already works, but I don't want to mess up the diff yet). [Done in #30184]

Some screenshots:
![Vector3 docs](https://user-images.githubusercontent.com/5276727/58749391-391dfd80-848e-11e9-9ad6-ec66dea5ac8c.png)
![Button docs](https://user-images.githubusercontent.com/5276727/58749404-6d91b980-848e-11e9-8791-216ab990c675.png)
![GridContainer docs](https://user-images.githubusercontent.com/5276727/58749409-77b3b800-848e-11e9-9da1-93166ef0769b.png)



Closes #16086