### PR TITLE
Add configurable strength value to InputEventAction

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -202,7 +202,7 @@ bool InputMap::event_get_action_status(const Ref<InputEvent> &p_event, const Str
 		if (p_pressed != NULL)
 			*p_pressed = input_event_action->is_pressed();
 		if (p_strength != NULL)
-			*p_strength = (*p_pressed) ? 1.0f : 0.0f;
+			*p_strength = (*p_pressed) ? input_event_action->get_strength() : 0.0f;
 		return input_event_action->get_action() == p_action;
 	}
 

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -1010,6 +1010,14 @@ bool InputEventAction::is_pressed() const {
 	return pressed;
 }
 
+void InputEventAction::set_strength(float p_strength) {
+	strength = CLAMP(p_strength, 0.0f, 1.0f);
+}
+
+float InputEventAction::get_strength() const {
+	return strength;
+}
+
 bool InputEventAction::shortcut_match(const Ref<InputEvent> &p_event) const {
 	if (p_event.is_null())
 		return false;
@@ -1051,14 +1059,19 @@ void InputEventAction::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventAction::set_pressed);
 	//ClassDB::bind_method(D_METHOD("is_pressed"), &InputEventAction::is_pressed);
 
+	ClassDB::bind_method(D_METHOD("set_strength", "strength"), &InputEventAction::set_strength);
+	ClassDB::bind_method(D_METHOD("get_strength"), &InputEventAction::get_strength);
+
 	//	ClassDB::bind_method(D_METHOD("is_action", "name"), &InputEventAction::is_action);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "action"), "set_action", "get_action");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "strength", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_strength", "get_strength");
 }
 
 InputEventAction::InputEventAction() {
 	pressed = false;
+	strength = 1.0f;
 }
 /////////////////////////////
 

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -475,6 +475,7 @@ class InputEventAction : public InputEvent {
 
 	StringName action;
 	bool pressed;
+	float strength;
 
 protected:
 	static void _bind_methods();
@@ -485,6 +486,9 @@ public:
 
 	void set_pressed(bool p_pressed);
 	virtual bool is_pressed() const;
+
+	void set_strength(float p_strength);
+	float get_strength() const;
 
 	virtual bool is_action(const StringName &p_action) const;
 

--- a/doc/classes/InputEventAction.xml
+++ b/doc/classes/InputEventAction.xml
@@ -18,6 +18,9 @@
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed">
 			If [code]true[/code], the action's state is pressed. If [code]false[/code], the action's state is released.
 		</member>
+		<member name="strength" type="float" setter="set_strength" getter="get_strength">
+			The action's strength between 0 and 1. This value is consired as equal to 0 if pressed is [code]false[/code]. The event strength allows faking analog joypad motion events, by precising how strongly is the joypad axis bent or pressed.
+		</member>
 	</members>
 	<constants>
 	</constants>


### PR DESCRIPTION
This allows generating InputEventAction events with an associated strength value.
This does not break compatility.