### PR TITLE
Add 'global_rate_scale' to the AudioServer

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -177,6 +177,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_global_rate_scale">
+			<return type="float">
+			</return>
+			<description>
+				Returns the global rate scale at which audio is being played.
+			</description>
+		</method>
 		<method name="get_mix_rate" qualifiers="const">
 			<return type="float">
 			</return>
@@ -390,6 +397,15 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_global_rate_scale">
+			<return type="void">
+			</return>
+			<argument index="0" name="scale" type="float">
+			</argument>
+			<description>
+				Scales the rate at which audio is played (i.e. setting it to [code]0.5[/code] will make the audio be played twice as fast).
+			</description>
+		</method>
 		<method name="swap_bus_effects">
 			<return type="void">
 			</return>
@@ -411,6 +427,16 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="bus_count" type="int" setter="set_bus_count" getter="get_bus_count">
+			Adds and removes buses to make the number of buses match [code]amount[/code].
+		</member>
+		<member name="device" type="string" setter="set_device" getter="get_device">
+		</member>
+		<member name="global_rate_scale" type="float" setter="set_global_rate_scale" getter="get_global_rate_scale">
+			Scales the rate at which audio is played (i.e. setting it to [code]0.5[/code] will make the audio be played twice as fast).
+		</member>
+	</members>
 	<signals>
 		<signal name="bus_layout_changed">
 			<description>

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -49,8 +49,9 @@ void AudioStreamPlaybackResampled::_begin_resample() {
 void AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
 
 	float target_rate = AudioServer::get_singleton()->get_mix_rate();
+	float global_rate_scale = AudioServer::get_singleton()->get_global_rate_scale();
 
-	uint64_t mix_increment = uint64_t(((get_stream_sampling_rate() * p_rate_scale) / double(target_rate)) * double(FP_LEN));
+	uint64_t mix_increment = uint64_t(((get_stream_sampling_rate() * p_rate_scale) / double(target_rate * global_rate_scale)) * double(FP_LEN));
 
 	for (int i = 0; i < p_frames; i++) {
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -944,6 +944,15 @@ bool AudioServer::is_bus_channel_active(int p_bus, int p_channel) const {
 	return buses[p_bus]->channels[p_channel].active;
 }
 
+void AudioServer::set_global_rate_scale(float p_scale) {
+
+	global_rate_scale = p_scale;
+}
+float AudioServer::get_global_rate_scale() const {
+
+	return global_rate_scale;
+}
+
 void AudioServer::init_channels_and_buffers() {
 	channel_count = get_channel_count();
 	temp_buffer.resize(channel_count);
@@ -1352,6 +1361,9 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bus_peak_volume_left_db", "bus_idx", "channel"), &AudioServer::get_bus_peak_volume_left_db);
 	ClassDB::bind_method(D_METHOD("get_bus_peak_volume_right_db", "bus_idx", "channel"), &AudioServer::get_bus_peak_volume_right_db);
 
+	ClassDB::bind_method(D_METHOD("set_global_rate_scale", "scale"), &AudioServer::set_global_rate_scale);
+	ClassDB::bind_method(D_METHOD("get_global_rate_scale"), &AudioServer::get_global_rate_scale);
+
 	ClassDB::bind_method(D_METHOD("lock"), &AudioServer::lock);
 	ClassDB::bind_method(D_METHOD("unlock"), &AudioServer::unlock);
 
@@ -1371,6 +1383,10 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_bus_layout", "bus_layout"), &AudioServer::set_bus_layout);
 	ClassDB::bind_method(D_METHOD("generate_bus_layout"), &AudioServer::generate_bus_layout);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bus_count"), "set_bus_count", "get_bus_count");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "device"), "set_device", "get_device");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "global_rate_scale"), "set_global_rate_scale", "get_global_rate_scale");
 
 	ADD_SIGNAL(MethodInfo("bus_layout_changed"));
 
@@ -1396,6 +1412,7 @@ AudioServer::AudioServer() {
 #endif
 	mix_time = 0;
 	mix_size = 0;
+	global_rate_scale = 1;
 }
 
 AudioServer::~AudioServer() {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -180,6 +180,8 @@ private:
 	int channel_count;
 	int to_mix;
 
+	float global_rate_scale;
+
 	struct Bus {
 
 		StringName name;
@@ -337,6 +339,9 @@ public:
 	float get_bus_peak_volume_right_db(int p_bus, int p_channel) const;
 
 	bool is_bus_channel_active(int p_bus, int p_channel) const;
+
+	void set_global_rate_scale(float p_scale);
+	float get_global_rate_scale() const;
 
 	virtual void init();
 	virtual void finish();


### PR DESCRIPTION
This makes possible to scale globally the rate of which audio is played.

Closes #28953.