### PR TITLE
doc: Fix DocData.merge_from copying old setters and getters

### DIFF
--- a/doc/classes/AudioEffectReverb.xml
+++ b/doc/classes/AudioEffectReverb.xml
@@ -21,7 +21,7 @@
 		<member name="hipass" type="float" setter="set_hpf" getter="get_hpf">
 			High-pass filter passes signals with a frequency higher than a certain cutoff frequency and attenuates signals with frequencies lower than the cutoff frequency. Value can range from 0 to 1. Default value: [code]0[/code].
 		</member>
-		<member name="predelay_feedback" type="float" setter="set_predelay_msec" getter="get_predelay_msec">
+		<member name="predelay_feedback" type="float" setter="set_predelay_feedback" getter="get_predelay_feedback">
 			Output percent of predelay. Value can range from 0 to 1. Default value: [code]1[/code].
 		</member>
 		<member name="predelay_msec" type="float" setter="set_predelay_msec" getter="get_predelay_msec">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -714,7 +714,7 @@
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents">
 			Enables whether rendering of children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visibly outside of this control's rectangle will not be rendered.
 		</member>
-		<member name="rect_global_position" type="Vector2" setter="set_global_position" getter="get_global_position">
+		<member name="rect_global_position" type="Vector2" setter="_set_global_position" getter="get_global_position">
 			The node's global position, relative to the world (usually to the top-left corner of the window).
 		</member>
 		<member name="rect_min_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size">
@@ -723,7 +723,7 @@
 		<member name="rect_pivot_offset" type="Vector2" setter="set_pivot_offset" getter="get_pivot_offset">
 			By default, the node's pivot is its top-left corner. When you change its [member rect_scale], it will scale around this pivot. Set this property to [member rect_size] / 2 to center the pivot in the node's rectangle.
 		</member>
-		<member name="rect_position" type="Vector2" setter="set_position" getter="get_position">
+		<member name="rect_position" type="Vector2" setter="_set_position" getter="get_position">
 			The node's position, relative to its parent. It corresponds to the rectangle's top-left corner. The property is not affected by [member rect_pivot_offset].
 		</member>
 		<member name="rect_rotation" type="float" setter="set_rotation_degrees" getter="get_rotation_degrees">
@@ -732,7 +732,7 @@
 		<member name="rect_scale" type="Vector2" setter="set_scale" getter="get_scale">
 			The node's scale, relative to its [member rect_size]. Change this property to scale the node around its [member rect_pivot_offset].
 		</member>
-		<member name="rect_size" type="Vector2" setter="set_size" getter="get_size">
+		<member name="rect_size" type="Vector2" setter="_set_size" getter="get_size">
 			The size of the node's bounding rectangle, in pixels. [Container] nodes update this property automatically.
 		</member>
 		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags">

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -217,7 +217,7 @@
 		</member>
 		<member name="ssao_bias" type="float" setter="set_ssao_bias" getter="get_ssao_bias">
 		</member>
-		<member name="ssao_blur" type="int" setter="set_ssao_blur" getter="is_ssao_blur_enabled" enum="Environment.SSAOBlur">
+		<member name="ssao_blur" type="int" setter="set_ssao_blur" getter="get_ssao_blur" enum="Environment.SSAOBlur">
 		</member>
 		<member name="ssao_color" type="Color" setter="set_ssao_color" getter="get_ssao_color">
 		</member>

--- a/doc/classes/Polygon2D.xml
+++ b/doc/classes/Polygon2D.xml
@@ -109,7 +109,7 @@
 		<member name="texture_offset" type="Vector2" setter="set_texture_offset" getter="get_texture_offset">
 			Amount to offset the polygon's [code]texture[/code]. If [code](0, 0)[/code] the texture's origin (its top-left corner) will be placed at the polygon's [code]position[/code].
 		</member>
-		<member name="texture_rotation" type="float" setter="set_texture_rotation_degrees" getter="get_texture_rotation_degrees">
+		<member name="texture_rotation" type="float" setter="set_texture_rotation" getter="get_texture_rotation">
 			The texture's rotation in radians.
 		</member>
 		<member name="texture_rotation_degrees" type="float" setter="set_texture_rotation_degrees" getter="get_texture_rotation_degrees">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -388,7 +388,7 @@
 		<member name="draw_tabs" type="bool" setter="set_draw_tabs" getter="is_drawing_tabs">
 			If [code]true[/code], the "tab" character will have a visible representation.
 		</member>
-		<member name="fold_gutter" type="bool" setter="set_fold_gutter_enabled" getter="is_fold_gutter_enabled">
+		<member name="fold_gutter" type="bool" setter="set_draw_fold_gutter" getter="is_drawing_fold_gutter">
 			If [code]true[/code], the fold gutter is visible. This enables folding groups of indented lines.
 		</member>
 		<member name="hiding_enabled" type="int" setter="set_hiding_enabled" getter="is_hiding_enabled">

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -136,9 +136,6 @@ void DocData::merge_from(const DocData &p_data) {
 				const PropertyDoc &pf = cf.properties[j];
 
 				p.description = pf.description;
-				p.setter = pf.setter;
-				p.getter = pf.getter;
-
 				break;
 			}
 		}


### PR DESCRIPTION
This is not necessary and means that some setters and getters
can end up wrong if they are changed in the bindings but DocData
does not update them when running --doctool.

Fixes #29425.

Co-authored-by: @bojidar-bg 