### PR TITLE
Fix errors when attempting to set UNIX permissions when unavailable

### DIFF
--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -308,8 +308,8 @@ uint32_t FileAccessEncrypted::_get_unix_permissions(const String &p_file) {
 }
 
 Error FileAccessEncrypted::_set_unix_permissions(const String &p_file, uint32_t p_permissions) {
-
-	return FAILED;
+	ERR_PRINT("Setting UNIX permissions on encrypted files is not implemented yet");
+	return ERR_UNAVAILABLE;
 }
 
 FileAccessEncrypted::FileAccessEncrypted() {

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -501,13 +501,13 @@ uint64_t FileAccessNetwork::_get_modified_time(const String &p_file) {
 }
 
 uint32_t FileAccessNetwork::_get_unix_permissions(const String &p_file) {
-	//could be implemented, not sure if worth it
+	ERR_PRINT("Getting UNIX permissions from network drives is not implemented yet");
 	return 0;
 }
 
 Error FileAccessNetwork::_set_unix_permissions(const String &p_file, uint32_t p_permissions) {
-
-	return FAILED;
+	ERR_PRINT("Setting UNIX permissions on network drives is not implemented yet");
+	return ERR_UNAVAILABLE;
 }
 
 void FileAccessNetwork::configure() {

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -340,13 +340,11 @@ uint64_t FileAccessWindows::_get_modified_time(const String &p_file) {
 }
 
 uint32_t FileAccessWindows::_get_unix_permissions(const String &p_file) {
-	ERR_PRINT("Windows does not support unix permissions");
 	return 0;
 }
 
 Error FileAccessWindows::_set_unix_permissions(const String &p_file, uint32_t p_permissions) {
-	ERR_PRINT("Windows does not support unix permissions");
-	return FAILED;
+	return ERR_UNAVAILABLE;
 }
 
 FileAccessWindows::FileAccessWindows() :


### PR DESCRIPTION
This makes exporting from Windows to Linux work again.

This closes #29416.