### PR TITLE
Properly catch certain errors in Dictionary and Array declarations

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -6021,7 +6021,11 @@ bool GDScriptParser::_is_type_compatible(const DataType &p_container, const Data
 }
 
 GDScriptParser::DataType GDScriptParser::_reduce_node_type(Node *p_node) {
+#ifdef DEBUG_ENABLED
+	if (p_node->get_datatype().has_type && p_node->type != Node::TYPE_ARRAY && p_node->type != Node::TYPE_DICTIONARY) {
+#else
 	if (p_node->get_datatype().has_type) {
+#endif
 		return p_node->get_datatype();
 	}
 


### PR DESCRIPTION
Fixes #29406.

> Premature optimization is the root of all evil. [Donald Knuth](https://en.wikiquote.org/wiki/Donald_Knuth)

Yet another case of something being done "properly" in multiple places, only for the end product to fail because of the wrong place taking precedence.