### PR TITLE
Improve the performance monitor display

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1025,7 +1025,9 @@ void ScriptEditorDebugger::_performance_draw() {
 		int pi = which[i];
 		Color c = get_color("accent_color", "Editor");
 		float h = (float)which[i] / (float)(perf_items.size());
-		c.set_hsv(Math::fmod(h + 0.4, 0.9), c.get_s() * 0.9, c.get_v() * 1.4);
+		// Use a darker color on light backgrounds for better visibility
+		float value_multiplier = EditorSettings::get_singleton()->is_dark_theme() ? 1.4 : 0.55;
+		c.set_hsv(Math::fmod(h + 0.4, 0.9), c.get_s() * 0.9, c.get_v() * value_multiplier);
 
 		c.a = 0.6;
 		perf_draw->draw_string(graph_font, r.position + Point2(0, graph_font->get_ascent()), perf_items[pi]->get_text(0), c, r.size.x);
@@ -1045,9 +1047,8 @@ void ScriptEditorDebugger::_performance_draw() {
 			float h2 = E->get()[pi] / m;
 			h2 = (1.0 - h2) * r.size.y;
 
-			c.a = 0.7;
 			if (E != perf_history.front())
-				perf_draw->draw_line(r.position + Point2(from, h2), r.position + Point2(from + spacing, prev), c, 2.0);
+				perf_draw->draw_line(r.position + Point2(from, h2), r.position + Point2(from + spacing, prev), c, Math::round(EDSCALE), true);
 			prev = h2;
 			E = E->next();
 			from -= spacing;


### PR DESCRIPTION
- Use dark colors when using a light theme for better visibility
- Enable antialiasing (only effective when using the GLES3 renderer)
- Make graph lines thinner but opaque
- Scale graph line widths on hiDPI displays

## Preview

### 100% editor scale, Dark theme

![monitors_1x_dark](https://user-images.githubusercontent.com/180032/58837328-81d6e180-865b-11e9-8cf1-63c2cb19c4c7.png)

### 200% editor scale, Light theme

![monitors_2x_light](https://user-images.githubusercontent.com/180032/58837347-8f8c6700-865b-11e9-89ba-432591b36db0.png)