### PR TITLE
Remove unnecessary assignment

### DIFF
--- a/core/list.h
+++ b/core/list.h
@@ -602,9 +602,6 @@ public:
 
 			Element *next = current->next_ptr;
 
-			//disconnect
-			current->next_ptr = NULL;
-
 			if (from != current) {
 
 				current->prev_ptr = NULL;


### PR DESCRIPTION
If my reasoning is correct, the *disconnect* assignment which, based on
**git-blame**, reaches the very first big OPEN SOURCE commit, is superfluous.

From
line 606: `current->next_ptr = NULL;`
we can fall into `if` and immediately do
line 611: `current->next_ptr = from;`
or go into `else` and do
line 631: `current->next_ptr = NULL;`