### PR TITLE
Adding missing description for Particles.capture_aabb

### DIFF
--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -15,13 +15,14 @@
 			<return type="AABB">
 			</return>
 			<description>
+				Returns the AABB wrapping by all existing particles at the current frame.
 			</description>
 		</method>
 		<method name="restart">
 			<return type="void">
 			</return>
 			<description>
-				Restarts the particle emmission, clearing existing particles.
+				Restarts the particle emission, clearing existing particles.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
And fixing typo for `emission`.