### PR TITLE
Editor debugger now always handle connections.

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1132,10 +1132,13 @@ void ScriptEditorDebugger::_notification(int p_what) {
 				last_warning_count = warning_count;
 			}
 
-			if (connection.is_null()) {
-
-				if (server->is_connection_available()) {
-
+			if (server->is_connection_available()) {
+				if (connection.is_valid()) {
+					// We already have a valid connection. Disconnecting any new connecting client to prevent it from hanging.
+					// (If we don't keep a reference to the connection it will be destroyed and disconnect_from_host will be called internally)
+					server->take_connection();
+				} else {
+					// We just got the first connection.
 					connection = server->take_connection();
 					if (connection.is_null())
 						break;
@@ -1169,12 +1172,11 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					if (profiler->is_profiling()) {
 						_profiler_activate(true);
 					}
-
-				} else {
-
-					break;
 				}
-			};
+			}
+
+			if (connection.is_null())
+				break;
 
 			if (!connection->is_connected_to_host()) {
 				stop();


### PR DESCRIPTION
The editor debugger used to only take the first client connection,
leaving potential new connections hanging until TCP timeout.
This caused a lock after some time when running multiple game/editor
instances, as the client will fill the write buffer, and then lock until
timeout (as the editor server would never read from that socket).

The editor now drops new connections immediately if it is already
connected to a client.

Fixes #28168