### PR TITLE
Removes redundant "splash" setting, improves per pixel transparency documentation.

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -104,7 +104,6 @@ public:
 		bool maximized;
 		bool always_on_top;
 		bool use_vsync;
-		bool layered_splash;
 		bool layered;
 		float get_aspect() const { return (float)width / (float)height; }
 		VideoMode(int p_width = 1024, int p_height = 600, bool p_fullscreen = false, bool p_resizable = true, bool p_borderless_window = false, bool p_maximized = false, bool p_always_on_top = false, bool p_use_vsync = false) {
@@ -117,7 +116,6 @@ public:
 			always_on_top = p_always_on_top;
 			use_vsync = p_use_vsync;
 			layered = false;
-			layered_splash = false;
 		}
 	};
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -813,6 +813,7 @@
 		</member>
 		<member name="window_borderless" type="bool" setter="set_borderless_window" getter="get_borderless_window">
 			If [code]true[/code], removes the window frame.
+			Note: Setting [code]window_borderless[/code] to [code]false[/code] disables per-pixel transparency.
 		</member>
 		<member name="window_fullscreen" type="bool" setter="set_window_fullscreen" getter="is_window_fullscreen">
 			If [code]true[/code], the window is fullscreen.
@@ -824,6 +825,9 @@
 			If [code]true[/code], the window is minimized.
 		</member>
 		<member name="window_per_pixel_transparency_enabled" type="bool" setter="set_window_per_pixel_transparency_enabled" getter="get_window_per_pixel_transparency_enabled">
+			If [code]true[/code], the window background is transparent and window frame is removed.
+			Use [code]get_tree().get_root().set_transparent_background(true)[/code] to disable main viewport background rendering.
+			Note: This property has no effect if "Project &gt; Project Settings &gt; Display &gt; Window &gt; Per-pixel transparency &gt; Allowed" setting is disabled.
 		</member>
 		<member name="window_position" type="Vector2" setter="set_window_position" getter="get_window_position">
 			The window position relative to the screen, the origin is the top left corner, +Y axis goes to the bottom and +X axis goes to the right.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -374,11 +374,10 @@
 			Default orientation on mobile devices.
 		</member>
 		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="">
-			If [code]true[/code], allows per-pixel transparency in a desktop window. This affects performance if not needed, so leave it on [code]false[/code] unless you need it.
+			If [code]true[/code], allows per-pixel transparency in a desktop window. This affects performance, so leave it on [code]false[/code] unless you need it.
 		</member>
 		<member name="display/window/per_pixel_transparency/enabled" type="bool" setter="" getter="">
-		</member>
-		<member name="display/window/per_pixel_transparency/splash" type="bool" setter="" getter="">
+			Set the window background to transparent when it starts.
 		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="">
 			Force the window to be always on top.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -939,7 +939,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);
 	video_mode.layered = GLOBAL_DEF("display/window/per_pixel_transparency/enabled", false);
-	video_mode.layered_splash = GLOBAL_DEF("display/window/per_pixel_transparency/splash", false);
 
 	GLOBAL_DEF("rendering/quality/intended_usage/framebuffer_allocation", 2);
 	GLOBAL_DEF("rendering/quality/intended_usage/framebuffer_allocation.mobile", 3);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1507,7 +1507,7 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	restore_rect = Rect2(get_window_position(), get_window_size());
 
-	if (p_desired.layered_splash) {
+	if (p_desired.layered) {
 		set_window_per_pixel_transparency_enabled(true);
 	}
 	return OK;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1381,7 +1381,7 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 		SetFocus(hWnd); // Sets Keyboard Focus To
 	}
 
-	if (p_desired.layered_splash) {
+	if (p_desired.layered) {
 		set_window_per_pixel_transparency_enabled(true);
 	}
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -593,7 +593,7 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	power_manager = memnew(PowerX11);
 
-	if (p_desired.layered_splash) {
+	if (p_desired.layered) {
 		set_window_per_pixel_transparency_enabled(true);
 	}
 


### PR DESCRIPTION
Merges redundant `per_pixel_transparency/enabled` and `per_pixel_transparency/splash` settings into one (`per_pixel_transparency/enabled`).

Adds some per pixel transparency documentation.