### PR TITLE
replaced "divisor" with "delimiter" for methods split,rsplit and split_floats.

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1519,9 +1519,9 @@ void register_variant_methods() {
 	ADDFUNC2R(STRING, STRING, String, replacen, STRING, "what", STRING, "forwhat", varray());
 	ADDFUNC2R(STRING, STRING, String, insert, INT, "position", STRING, "what", varray());
 	ADDFUNC0R(STRING, STRING, String, capitalize, varray());
-	ADDFUNC3R(STRING, POOL_STRING_ARRAY, String, split, STRING, "divisor", BOOL, "allow_empty", INT, "maxsplit", varray(true, 0));
-	ADDFUNC3R(STRING, POOL_STRING_ARRAY, String, rsplit, STRING, "divisor", BOOL, "allow_empty", INT, "maxsplit", varray(true, 0));
-	ADDFUNC2R(STRING, POOL_REAL_ARRAY, String, split_floats, STRING, "divisor", BOOL, "allow_empty", varray(true));
+	ADDFUNC3R(STRING, POOL_STRING_ARRAY, String, split, STRING, "delimiter", BOOL, "allow_empty", INT, "maxsplit", varray(true, 0));
+	ADDFUNC3R(STRING, POOL_STRING_ARRAY, String, rsplit, STRING, "delimiter", BOOL, "allow_empty", INT, "maxsplit", varray(true, 0));
+	ADDFUNC2R(STRING, POOL_REAL_ARRAY, String, split_floats, STRING, "delimiter", BOOL, "allow_empty", varray(true));
 
 	ADDFUNC0R(STRING, STRING, String, to_upper, varray());
 	ADDFUNC0R(STRING, STRING, String, to_lower, varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -662,16 +662,17 @@
 		<method name="rsplit">
 			<return type="PoolStringArray">
 			</return>
-			<argument index="0" name="divisor" type="String">
+			<argument index="0" name="delimiter" type="String">
 			</argument>
 			<argument index="1" name="allow_empty" type="bool" default="True">
 			</argument>
 			<argument index="2" name="maxsplit" type="int" default="0">
 			</argument>
 			<description>
-				Splits the string by a [code]divisor[/code] string and returns an array of the substrings, starting from right.
-				[b]Example:[/b] [code]"One,Two,Three"[/code] will return [code]["One","Two","Three"][/code] if split by [code]","[/code].
-				If [code]maxsplit[/code] is specified, then it is number of splits to do, default is 0 which splits all the items.
+				Splits the string by a [code]delimiter[/code] string and returns an array of the substrings, starting from right.
+				The splits in the returned array are sorted in the same order as the original string, from left to right.
+				If [code]maxsplit[/code] is specified, it defines the number of splits to do from the right up to [code]maxsplit[/code]. The default value of 0 means that all items are split, thus giving the same result as [method split].
+				[b]Example:[/b] [code]"One,Two,Three,Four"[/code] will return [code]["Three","Four"][/code] if split by [code]","[/code] with [code]maxsplit[/code] of 2.
 			</description>
 		</method>
 		<method name="rstrip">
@@ -709,27 +710,27 @@
 		<method name="split">
 			<return type="PoolStringArray">
 			</return>
-			<argument index="0" name="divisor" type="String">
+			<argument index="0" name="delimiter" type="String">
 			</argument>
 			<argument index="1" name="allow_empty" type="bool" default="True">
 			</argument>
 			<argument index="2" name="maxsplit" type="int" default="0">
 			</argument>
 			<description>
-				Splits the string by a divisor string and returns an array of the substrings.
-				[b]Example:[/b] [code]"One,Two,Three"[/code] will return [code]["One","Two","Three"][/code] if split by [code]","[/code].
-				If [code]maxsplit[/code] is given, at most maxsplit number of splits occur, and the remainder of the string is returned as the final element of the list (thus, the list will have at most maxsplit+1 elements)
+				Splits the string by a [code]delimiter[/code] string and returns an array of the substrings.
+				If [code]maxsplit[/code] is specified, it defines the number of splits to do from the left up to [code]maxsplit[/code]. The default value of 0 means that all items are split.
+				[b]Example:[/b] [code]"One,Two,Three"[/code] will return [code]["One","Two"][/code] if split by [code]","[/code] with [code]maxsplit[/code] of 2.
 			</description>
 		</method>
 		<method name="split_floats">
 			<return type="PoolRealArray">
 			</return>
-			<argument index="0" name="divisor" type="String">
+			<argument index="0" name="delimiter" type="String">
 			</argument>
 			<argument index="1" name="allow_empty" type="bool" default="True">
 			</argument>
 			<description>
-				Splits the string in floats by using a divisor string and returns an array of the substrings.
+				Splits the string in floats by using a delimiter string and returns an array of the substrings.
 				[b]Example:[/b] [code]"1,2.5,3"[/code] will return [code][1,2.5,3][/code] if split by [code]","[/code].
 			</description>
 		</method>


### PR DESCRIPTION
Supersedes #29430.
Fixes #29429.