### PR TITLE
Add a separator in debug output for readability

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1104,6 +1104,8 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		return err;
 	}
 
+	print_line(" "); //add a blank line for readability
+
 	if (init_use_custom_pos) {
 		OS::get_singleton()->set_window_position(init_custom_pos);
 	}


### PR DESCRIPTION
Supposed to fix #27801

Maybe a separator would be better, but I wasn't sure what char to use and how long should it be.