### PR TITLE
[WIP] [macOS] Handle keyboard shortcuts using NSMenuItem

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -271,6 +271,9 @@ void OS::clear_last_error() {
 	last_error = NULL;
 }
 
+void OS::add_shortcut(const String &p_name, const Ref<InputEvent> &p_shortcut_event) {
+}
+
 void OS::set_no_window_mode(bool p_enable) {
 
 	_no_window = p_enable;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -160,6 +160,8 @@ public:
 	virtual const char *get_last_error() const;
 	virtual void clear_last_error();
 
+	virtual void add_shortcut(const String &p_name, const Ref<InputEvent> &p_shortcut_event);
+
 	enum MouseMode {
 		MOUSE_MODE_VISIBLE,
 		MOUSE_MODE_HIDDEN,

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1425,6 +1425,7 @@ String EditorSettings::get_editor_layouts_config() const {
 
 void EditorSettings::add_shortcut(const String &p_name, Ref<ShortCut> &p_shortcut) {
 
+	OS::get_singleton()->add_shortcut(p_name, p_shortcut->get_shortcut());
 	shortcuts[p_name] = p_shortcut;
 }
 

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -108,6 +108,12 @@ public:
 	NSOpenGLPixelFormat *pixelFormat;
 	NSOpenGLContext *context;
 
+	NSMenu *menu_bar;
+	NSMenu *shortcuts_menu;
+	Map<String, NSMenu*> shortcut_categories;
+	Map<String, NSMenuItem*> shortcuts;
+	Map<String, Ref<InputEventKey> > shortcut_inputevents;
+
 	bool layered_window;
 	bool waiting_for_vsync;
 	NSCondition *vsync_condition;
@@ -152,6 +158,8 @@ public:
 	int video_driver_index;
 	virtual int get_current_video_driver() const;
 
+	unichar get_key_equivalent(Ref<InputEventKey> &p_event_key);
+
 protected:
 	virtual void initialize_core();
 	virtual Error initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
@@ -185,6 +193,8 @@ public:
 
 	virtual Size2 get_window_size() const;
 	virtual Size2 get_real_window_size() const;
+
+	virtual void add_shortcut(const String &p_name, const Ref<InputEvent> &p_shortcut_event);
 
 	virtual void set_native_icon(const String &p_filename);
 	virtual void set_icon(const Ref<Image> &p_icon);


### PR DESCRIPTION
This allows keyboard shortcuts to be handled by macOS rather than by godot which correctly handles the keyboard layout "Dvorak - QWERTY ⌘".

Fixes #4386

This solution may seem a bit hacky but reading the macOS developer docs, it's the only way I could figure see.
As far as I can tell:
* there is no way to get info on the shortcut remapping done for "Dvorak - QWERTY ⌘" from the macOS API.
* there is no way to create a keyboard shortcut ("keyEquivalent") without adding it to the menu bar.


This code still has a few issues that need worked out:
* the shift modifier is incorrectly being added to shortcuts that don't have shift.
* godot shortcut handling should be disabled so that unremapped keyboard shortcuts don't get triggered.
* shortcuts cannot yet be changed or removed.