### PR TITLE
Fixes NaN errors with anchors mode

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -731,6 +731,8 @@ Vector2 CanvasItemEditor::_position_to_anchor(const Control *p_control, Vector2 
 	ERR_FAIL_COND_V(!p_control, Vector2());
 
 	Rect2 parent_rect = p_control->get_parent_anchorable_rect();
+	ERR_FAIL_COND_V(parent_rect.size.x == 0, Vector2());
+	ERR_FAIL_COND_V(parent_rect.size.y == 0, Vector2());
 
 	return (p_control->get_transform().xform(position) - parent_rect.position) / parent_rect.size;
 }
@@ -3343,9 +3345,6 @@ void CanvasItemEditor::_notification(int p_what) {
 			presets_menu->set_visible(true);
 			anchor_mode_button->set_visible(true);
 
-			// Set the pressed state of the node
-			anchor_mode_button->set_pressed(anchors_mode);
-
 			// Disable if the selected node is child of a container
 			if (has_container_parents) {
 				presets_menu->set_disabled(true);
@@ -3516,6 +3515,7 @@ void CanvasItemEditor::_selection_changed() {
 		}
 	}
 	anchors_mode = (nbValidControls == nbAnchorsMode);
+	anchor_mode_button->set_pressed(anchors_mode);
 }
 
 void CanvasItemEditor::edit(CanvasItem *p_canvas_item) {
@@ -3737,6 +3737,7 @@ void CanvasItemEditor::_set_anchors_and_margins_preset(Control::LayoutPreset p_p
 	undo_redo->commit_action();
 
 	anchors_mode = false;
+	anchor_mode_button->set_pressed(anchors_mode);
 }
 
 void CanvasItemEditor::_set_anchors_and_margins_to_keep_ratio() {
@@ -3761,6 +3762,7 @@ void CanvasItemEditor::_set_anchors_and_margins_to_keep_ratio() {
 			undo_redo->add_undo_method(control, "set_meta", "_edit_use_anchors_", use_anchors);
 
 			anchors_mode = true;
+			anchor_mode_button->set_pressed(anchors_mode);
 		}
 	}
 
@@ -3907,7 +3909,6 @@ void CanvasItemEditor::_button_toggle_anchor_mode(bool p_status) {
 	}
 
 	anchors_mode = p_status;
-
 	viewport->update();
 }
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1749,6 +1749,9 @@ Rect2 Control::_compute_child_rect(const float p_anchors[4], const float p_margi
 void Control::_compute_anchors(Rect2 p_rect, const float p_margins[4], float (&r_anchors)[4]) {
 
 	Size2 parent_rect_size = get_parent_anchorable_rect().size;
+	ERR_FAIL_COND(parent_rect_size.x == 0.0);
+	ERR_FAIL_COND(parent_rect_size.y == 0.0);
+
 	r_anchors[0] = (p_rect.position.x - p_margins[0]) / parent_rect_size.x;
 	r_anchors[1] = (p_rect.position.y - p_margins[1]) / parent_rect_size.y;
 	r_anchors[2] = (p_rect.position.x + p_rect.size.x - p_margins[2]) / parent_rect_size.x;


### PR DESCRIPTION
Fixes #29305

This solution is a little bit dirty, as it prints an error message to the console and prevent any move. I'd rather have an editor-wide system to pop up that kind of message, but until then I think the is the best solution.