### PR TITLE
Fix memory leak after closing files

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -733,6 +733,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 
 				image_data = cached_data;
 				file->close();
+				memdelete(file);
 			}
 		}
 
@@ -807,6 +808,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 					if (file) {
 						file->store_line(new_etag);
 						file->close();
+						memdelete(file);
 					}
 
 					int len = p_data.size();
@@ -816,6 +818,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 						file->store_32(len);
 						file->store_buffer(r.ptr(), len);
 						file->close();
+						memdelete(file);
 					}
 
 					break;
@@ -855,6 +858,7 @@ void EditorAssetLibrary::_update_image_queue() {
 				if (file) {
 					headers.push_back("If-None-Match: " + file->get_line());
 					file->close();
+					memdelete(file);
 				}
 			}
 

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -241,7 +241,6 @@ void AppxPackager::make_block_map() {
 
 	tmp_file->close();
 	memdelete(tmp_file);
-	tmp_file = NULL;
 }
 
 String AppxPackager::content_type(String p_extension) {
@@ -291,7 +290,6 @@ void AppxPackager::make_content_types() {
 
 	tmp_file->close();
 	memdelete(tmp_file);
-	tmp_file = NULL;
 }
 
 Vector<uint8_t> AppxPackager::make_file_header(FileMeta p_file_meta) {
@@ -606,7 +604,6 @@ void AppxPackager::finish() {
 
 	blockmap_file->close();
 	memdelete(blockmap_file);
-	blockmap_file = NULL;
 
 	// Add content types
 	EditorNode::progress_task_step("export", "Setting content types...", 5);
@@ -622,7 +619,6 @@ void AppxPackager::finish() {
 
 	types_file->close();
 	memdelete(types_file);
-	types_file = NULL;
 
 	// Pre-process central directory before signing
 	for (int i = 0; i < file_metadata.size(); i++) {


### PR DESCRIPTION
Fix leaks like:
```
1,200 (144 direct, 1,056 indirect) bytes in 2 blocks are definitely lost in loss record 122 of 161
   at 0x583F74F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x37BE101: Memory::alloc_static(unsigned long, bool) (memory.cpp:85)
   by 0x37BE0AA: operator new(unsigned long, char const*) (memory.cpp:42)
   by 0x1E24788: FileAccess* FileAccess::_create_builtin<FileAccessUnix>() (file_access.h:77)
   by 0x379280E: FileAccess::create(FileAccess::AccessType) (file_access.cpp:51)
   by 0x379293D: FileAccess::create_for_path(String const&) (file_access.cpp:85)
   by 0x3792A13: FileAccess::open(String const&, int, Error*) (file_access.cpp:110)
   by 0x2388418: EditorAssetLibrary::_update_image_queue() (asset_library_editor_plugin.cpp:854)
   by 0x2388AA0: EditorAssetLibrary::_request_image(unsigned long, String, EditorAssetLibrary::ImageType, int) (asset_library_editor_plugin.cpp:900)
   by 0x238C38E: EditorAssetLibrary::_http_request_completed(int, int, PoolVector<String> const&, PoolVector<unsigned char> const&) (asset_library_editor_plugin.cpp:1222)
   by 0x21232D3: MethodBind4<int, int, PoolVector<String> const&, PoolVector<unsigned char> const&>::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.gen.inc:3115)
   by 0x3682CA8: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:940)

3,000 (360 direct, 2,640 indirect) bytes in 5 blocks are definitely lost in loss record 131 of 161
   at 0x583F74F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x37BE101: Memory::alloc_static(unsigned long, bool) (memory.cpp:85)
   by 0x37BE0AA: operator new(unsigned long, char const*) (memory.cpp:42)
   by 0x1E24788: FileAccess* FileAccess::_create_builtin<FileAccessUnix>() (file_access.h:77)
   by 0x379280E: FileAccess::create(FileAccess::AccessType) (file_access.cpp:51)
   by 0x379293D: FileAccess::create_for_path(String const&) (file_access.cpp:85)
   by 0x3792A13: FileAccess::open(String const&, int, Error*) (file_access.cpp:110)
   by 0x2388418: EditorAssetLibrary::_update_image_queue() (asset_library_editor_plugin.cpp:854)
   by 0x2387F36: EditorAssetLibrary::_image_request_completed(int, int, PoolVector<String> const&, PoolVector<unsigned char> const&, int) (asset_library_editor_plugin.cpp:838)
   by 0x239A064: MethodBind5<int, int, PoolVector<String> const&, PoolVector<unsigned char> const&, int>::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.gen.inc:3959)
   by 0x3682CA8: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:940)
   by 0x36849C4: Object::emit_signal(StringName const&, Variant const**, int) (object.cpp:1240)

4,200 (504 direct, 3,696 indirect) bytes in 7 blocks are definitely lost in loss record 146 of 161
   at 0x583F74F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x37BE101: Memory::alloc_static(unsigned long, bool) (memory.cpp:85)
   by 0x37BE0AA: operator new(unsigned long, char const*) (memory.cpp:42)
   by 0x1E24788: FileAccess* FileAccess::_create_builtin<FileAccessUnix>() (file_access.h:77)
   by 0x379280E: FileAccess::create(FileAccess::AccessType) (file_access.cpp:51)
   by 0x379293D: FileAccess::create_for_path(String const&) (file_access.cpp:85)
   by 0x3792A13: FileAccess::open(String const&, int, Error*) (file_access.cpp:110)
   by 0x2386A56: EditorAssetLibrary::_image_update(bool, bool, PoolVector<unsigned char> const&, int) (asset_library_editor_plugin.cpp:724)
   by 0x2388A82: EditorAssetLibrary::_request_image(unsigned long, String, EditorAssetLibrary::ImageType, int) (asset_library_editor_plugin.cpp:899)
   by 0x238C38E: EditorAssetLibrary::_http_request_completed(int, int, PoolVector<String> const&, PoolVector<unsigned char> const&) (asset_library_editor_plugin.cpp:1222)
   by 0x21232D3: MethodBind4<int, int, PoolVector<String> const&, PoolVector<unsigned char> const&>::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.gen.inc:3115)
   by 0x3682CA8: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:940)

4,200 (504 direct, 3,696 indirect) bytes in 7 blocks are definitely lost in loss record 147 of 161
   at 0x583F74F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x37BE101: Memory::alloc_static(unsigned long, bool) (memory.cpp:85)
   by 0x37BE0AA: operator new(unsigned long, char const*) (memory.cpp:42)
   by 0x1E24788: FileAccess* FileAccess::_create_builtin<FileAccessUnix>() (file_access.h:77)
   by 0x379280E: FileAccess::create(FileAccess::AccessType) (file_access.cpp:51)
   by 0x379293D: FileAccess::create_for_path(String const&) (file_access.cpp:85)
   by 0x3792A13: FileAccess::open(String const&, int, Error*) (file_access.cpp:110)
   by 0x2386A56: EditorAssetLibrary::_image_update(bool, bool, PoolVector<unsigned char> const&, int) (asset_library_editor_plugin.cpp:724)
   by 0x2387C1F: EditorAssetLibrary::_image_request_completed(int, int, PoolVector<String> const&, PoolVector<unsigned char> const&, int) (asset_library_editor_plugin.cpp:825)
   by 0x239A064: MethodBind5<int, int, PoolVector<String> const&, PoolVector<unsigned char> const&, int>::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.gen.inc:3959)
   by 0x3682CA8: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:940)
   by 0x36849C4: Object::emit_signal(StringName const&, Variant const**, int) (object.cpp:1240)
```