### PR TITLE
Use uppercase for all hexadecimal constants in the editor help

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -203,8 +203,9 @@ String EditorHelp::_fix_constant(const String &p_constant) const {
 	if (p_constant.strip_edges() == "2147483647") {
 		return "0x7FFFFFFF";
 	}
+
 	if (p_constant.strip_edges() == "1048575") {
-		return "0xfffff";
+		return "0xFFFFF";
 	}
 
 	return p_constant;


### PR DESCRIPTION
Other hexadecimal constants were in uppercase, so I made the last one (`0xFFFFF`) uppercase as well.