### PR TITLE
Make tilemap texture origin Top-Left, fix https://github.com/godoteng…

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -792,10 +792,11 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 
 	if (p_transpose) {
 		SWAP(tile_ofs.x, tile_ofs.y);
+		/*		For a future CheckBox to Center Texture:
 		rect.position.x += cell_size.x / 2 - rect.size.y / 2;
 		rect.position.y += cell_size.y / 2 - rect.size.x / 2;
 	} else {
-		rect.position += cell_size / 2 - rect.size / 2;
+		rect.position += cell_size / 2 - rect.size / 2; */
 	}
 
 	if (p_flip_h) {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -220,8 +220,8 @@ void TileMap::_fix_cell_transform(Transform2D &xform, const Cell &p_cell, const 
 		xform.elements[1].y = -xform.elements[1].y;
 		offset.y = s.y - offset.y;
 	}
-
-	offset += cell_size / 2 - s / 2;
+	/* For a future CheckBox to Center Texture:
+	offset += cell_size / 2 - s / 2; */
 	xform.elements[2] += offset;
 }
 
@@ -372,10 +372,11 @@ void TileMap::update_dirty_quadrants() {
 
 			if (c.transpose) {
 				SWAP(tile_ofs.x, tile_ofs.y);
+				/*				For a future CheckBox to Center Texture:
 				rect.position.x += cell_size.x / 2 - rect.size.y / 2;
 				rect.position.y += cell_size.y / 2 - rect.size.x / 2;
 			} else {
-				rect.position += cell_size / 2 - rect.size / 2;
+				rect.position += cell_size / 2 - rect.size / 2; */
 			}
 
 			if (c.flip_h) {


### PR DESCRIPTION
…ine/godot/issues/29487

This commit https://github.com/godotengine/godot/pull/28896 fixed bad offset of textures and shapes, but added auto-center of the tile texture. That idea ended in to much breaking compatibility like showed in the fixed issue. That functionallity can be added in a future with a check box, but for now is needed the top-left texture to not break tilemap demos and current projects.