### PR TITLE
Make tilemap texture origin point top-left.

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -780,7 +780,8 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 		r.position += (r.size + Vector2(spacing, spacing)) * offset;
 	}
 	Size2 sc = p_xform.get_scale();
-	Size2 cell_size = node->get_cell_size();
+	/* For a future CheckBox to Center Texture:
+	Size2 cell_size = node->get_cell_size(); */
 	Rect2 rect = Rect2();
 	rect.position = node->map_to_world(p_point) + node->get_cell_draw_offset();
 
@@ -792,10 +793,11 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 
 	if (p_transpose) {
 		SWAP(tile_ofs.x, tile_ofs.y);
+		/* For a future CheckBox to Center Texture:
 		rect.position.x += cell_size.x / 2 - rect.size.y / 2;
 		rect.position.y += cell_size.y / 2 - rect.size.x / 2;
 	} else {
-		rect.position += cell_size / 2 - rect.size / 2;
+		rect.position += cell_size / 2 - rect.size / 2; */
 	}
 
 	if (p_flip_h) {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -220,8 +220,8 @@ void TileMap::_fix_cell_transform(Transform2D &xform, const Cell &p_cell, const 
 		xform.elements[1].y = -xform.elements[1].y;
 		offset.y = s.y - offset.y;
 	}
-
-	offset += cell_size / 2 - s / 2;
+	/* For a future CheckBox to Center Texture:
+	offset += cell_size / 2 - s / 2; */
 	xform.elements[2] += offset;
 }
 
@@ -372,10 +372,11 @@ void TileMap::update_dirty_quadrants() {
 
 			if (c.transpose) {
 				SWAP(tile_ofs.x, tile_ofs.y);
+				/* For a future CheckBox to Center Texture:
 				rect.position.x += cell_size.x / 2 - rect.size.y / 2;
 				rect.position.y += cell_size.y / 2 - rect.size.x / 2;
 			} else {
-				rect.position += cell_size / 2 - rect.size / 2;
+				rect.position += cell_size / 2 - rect.size / 2; */
 			}
 
 			if (c.flip_h) {


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/29487. In this commit: https://github.com/godotengine/godot/pull/28896 bad offset of textures and shapes was fixed, but a center of texture was added too, and this seems not dessired by default because breaks too much compatibility with demos and user projects. A future Check box for center texture can be added