### PR TITLE
Improve conections dialog

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -307,38 +307,41 @@ void ConnectDialog::init(Connection c, bool bEdit) {
 	bEditMode = bEdit;
 }
 
-void ConnectDialog::popup_dialog(const String &p_for_signal, bool p_advanced) {
+void ConnectDialog::popup_dialog(const String &p_for_signal) {
 
-	advanced->set_pressed(p_advanced);
 	from_signal->set_text(p_for_signal);
 	error_label->add_color_override("font_color", get_color("error_color", "Editor"));
-	vbc_right->set_visible(p_advanced);
+	if (!advanced->is_pressed())
+		error_label->set_visible(!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root()));
 
-	if (p_advanced) {
-
-		popup_centered(Size2(900, 500) * EDSCALE);
-		connect_to_label->set_text("Connect to Node:");
-		tree->set_connect_to_script_mode(false);
-		error_label->hide();
-	} else {
-		popup_centered(Size2(700, 500) * EDSCALE);
-		connect_to_label->set_text("Connect to Script:");
-		tree->set_connect_to_script_mode(true);
-
-		if (!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root())) {
-			error_label->show();
-		} else {
-			error_label->hide();
-		}
-	}
+	popup_centered();
 }
 
 void ConnectDialog::_advanced_pressed() {
 
-	popup_dialog(from_signal->get_text(), advanced->is_pressed());
+	if (advanced->is_pressed()) {
+		set_custom_minimum_size(Size2(900, 500) * EDSCALE);
+		connect_to_label->set_text(TTR("Connect to Node:"));
+		tree->set_connect_to_script_mode(false);
+
+		vbc_right->show();
+		error_label->hide();
+	} else {
+		set_custom_minimum_size(Size2(600, 500) * EDSCALE);
+		set_size(Size2());
+		connect_to_label->set_text(TTR("Connect to Script:"));
+		tree->set_connect_to_script_mode(true);
+
+		vbc_right->hide();
+		error_label->set_visible(!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root()));
+	}
+
+	set_position((get_viewport_rect().size - get_custom_minimum_size()) / 2);
 }
 
 ConnectDialog::ConnectDialog() {
+
+	set_custom_minimum_size(Size2(600, 500) * EDSCALE);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
@@ -356,6 +359,7 @@ ConnectDialog::ConnectDialog() {
 	vbc_left->add_margin_child(TTR("From Signal:"), from_signal);
 
 	tree = memnew(SceneTreeEditor(false));
+	tree->set_connecting_signal(true);
 	tree->get_scene_tree()->connect("item_activated", this, "_ok");
 	tree->connect("node_selected", this, "_tree_node_selected");
 	tree->set_connect_to_script_mode(true);
@@ -381,7 +385,7 @@ ConnectDialog::ConnectDialog() {
 	type_list->add_item("bool", Variant::BOOL);
 	type_list->add_item("int", Variant::INT);
 	type_list->add_item("real", Variant::REAL);
-	type_list->add_item("string", Variant::STRING);
+	type_list->add_item("String", Variant::STRING);
 	type_list->add_item("Vector2", Variant::VECTOR2);
 	type_list->add_item("Rect2", Variant::RECT2);
 	type_list->add_item("Vector3", Variant::VECTOR3);
@@ -416,28 +420,26 @@ ConnectDialog::ConnectDialog() {
 	dst_method->set_h_size_flags(SIZE_EXPAND_FILL);
 	dstm_hb->add_child(dst_method);
 
-	advanced = memnew(CheckBox);
+	advanced = memnew(CheckButton);
 	dstm_hb->add_child(advanced);
-	advanced->set_text(TTR("Advanced..."));
+	advanced->set_text(TTR("Advanced"));
 	advanced->connect("pressed", this, "_advanced_pressed");
 
-	/*
-	dst_method_list = memnew( MenuButton );
-	dst_method_list->set_text("List...");
-	dst_method_list->set_anchor( MARGIN_RIGHT, ANCHOR_END );
-	dst_method_list->set_anchor( MARGIN_LEFT, ANCHOR_END );
-	dst_method_list->set_anchor( MARGIN_TOP, ANCHOR_END );
-	dst_method_list->set_anchor( MARGIN_BOTTOM, ANCHOR_END );
-	dst_method_list->set_begin( Point2( 70,59) );
-	dst_method_list->set_end( Point2( 15,39  ) );
-	*/
+	// Add spacing so the tree and inspector are the same size.
+	Control *spacing = memnew(Control);
+	spacing->set_custom_minimum_size(Size2(0, 4) * EDSCALE);
+	vbc_right->add_child(spacing);
 
-	deferred = memnew(CheckButton);
+	deferred = memnew(CheckBox);
+	deferred->set_h_size_flags(0);
 	deferred->set_text(TTR("Deferred"));
+	deferred->set_tooltip(TTR("Defers the signal, storing it in a queue and only firing it at idle time."));
 	vbc_right->add_child(deferred);
 
-	oneshot = memnew(CheckButton);
+	oneshot = memnew(CheckBox);
+	oneshot->set_h_size_flags(0);
 	oneshot->set_text(TTR("Oneshot"));
+	oneshot->set_tooltip(TTR("Disconnects the signal after its first emission."));
 	vbc_right->add_child(oneshot);
 
 	set_as_toplevel(true);
@@ -662,9 +664,7 @@ void ConnectionsDock::_open_connection_dialog(TreeItem &item) {
 	c.signal = StringName(signalname);
 	c.target = dst_node;
 	c.method = dst_method;
-
-	//connect_dialog->set_title(TTR("Connect Signal: ") + signalname);
-	connect_dialog->popup_dialog(signalname, false);
+	connect_dialog->popup_dialog(signalname);
 	connect_dialog->init(c);
 	connect_dialog->set_title(TTR("Connect a Signal to a Method"));
 }

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -67,9 +67,9 @@ class ConnectDialog : public ConfirmationDialog {
 	AcceptDialog *error;
 	EditorInspector *bind_editor;
 	OptionButton *type_list;
-	CheckButton *deferred;
-	CheckButton *oneshot;
-	CheckBox *advanced;
+	CheckBox *deferred;
+	CheckBox *oneshot;
+	CheckButton *advanced;
 
 	Label *error_label;
 
@@ -99,7 +99,7 @@ public:
 
 	void init(Connection c, bool bEdit = false);
 
-	void popup_dialog(const String &p_for_signal, bool p_advanced);
+	void popup_dialog(const String &p_for_signal);
 	ConnectDialog();
 	~ConnectDialog();
 };

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -51,6 +51,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 	if (connect_to_script_mode) {
 		return; //don't do anything in this mode
 	}
+
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!item);
 
@@ -220,23 +221,27 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		}
 
 		if (marked.has(p_node)) {
-			item->set_text(0, String(p_node->get_name()) + " " + TTR("(Connecting From)"));
-
+			String node_name = p_node->get_name();
+			if (connecting_signal) {
+				node_name += " " + TTR("(Connecting From)");
+			}
+			item->set_text(0, node_name);
 			item->set_custom_color(0, accent);
 		}
 	} else if (part_of_subscene) {
 
-		//item->set_selectable(0,marked_selectable);
 		if (valid_types.size() == 0) {
 			item->set_custom_color(0, get_color("disabled_font_color", "Editor"));
 		}
-
 	} else if (marked.has(p_node)) {
 
-		if (!connect_to_script_mode) {
-			item->set_selectable(0, marked_selectable);
+		String node_name = p_node->get_name();
+		if (connecting_signal) {
+			node_name += " " + TTR("(Connecting From)");
 		}
-		item->set_custom_color(0, get_color("error_color", "Editor"));
+		item->set_text(0, node_name);
+		item->set_selectable(0, marked_selectable);
+		item->set_custom_color(0, get_color("accent_color", "Editor"));
 	} else if (!marked_selectable && !marked_children_selectable) {
 
 		Node *node = p_node;
@@ -1033,6 +1038,11 @@ void SceneTreeEditor::set_connect_to_script_mode(bool p_enable) {
 	update_tree();
 }
 
+void SceneTreeEditor::set_connecting_signal(bool p_enable) {
+	connecting_signal = p_enable;
+	update_tree();
+}
+
 void SceneTreeEditor::_bind_methods() {
 
 	ClassDB::bind_method("_tree_changed", &SceneTreeEditor::_tree_changed);
@@ -1077,6 +1087,7 @@ void SceneTreeEditor::_bind_methods() {
 SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_open_instance) {
 
 	connect_to_script_mode = false;
+	connecting_signal = false;
 	undo_redo = NULL;
 	tree_dirty = true;
 	selected = NULL;

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -68,6 +68,7 @@ class SceneTreeEditor : public Control {
 	AcceptDialog *warning;
 
 	bool connect_to_script_mode;
+	bool connecting_signal;
 
 	int blocked;
 
@@ -155,6 +156,7 @@ public:
 	void update_tree() { _update_tree(); }
 
 	void set_connect_to_script_mode(bool p_enable);
+	void set_connecting_signal(bool p_enable);
 
 	Tree *get_scene_tree() { return tree; }
 


### PR DESCRIPTION
Resurrected from #27965, as #27988 seems to have stagnated a little, and @reduz being very favorable to my changes.

From the old PR:
- Fixed dialog not correctly reopening in advanced mode once enabled and closed,
- Added tooltips to "Deferred" and "Oneshot".
- Made "Advanced" into a CheckButton and the "Deferred" and "Oneshot" into CheckBoxes (see [here](https://uxmovement.com/buttons/when-to-use-a-switch-or-checkbox/) why).
- Made the dialog just readjust its size instead of reopening when advanced mode is enabled.

Extra new goodies:
- The blue tint and "(Connecting From)" message also appears in advanced mode.
- The tree and inspector are now kept in the same size.