### PR TITLE
Validate Object existence when casting

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -2037,6 +2037,7 @@ void postinitialize_handler(Object *p_object) {
 HashMap<ObjectID, Object *> ObjectDB::instances;
 ObjectID ObjectDB::instance_counter = 1;
 HashMap<Object *, ObjectID, ObjectDB::ObjectPtrHash> ObjectDB::instance_checks;
+
 ObjectID ObjectDB::add_instance(Object *p_object) {
 
 	ERR_FAIL_COND_V(p_object->get_instance_id() != 0, 0);


### PR DESCRIPTION
When `Object::cast_to<>()` is used from a message it's possible that the
object has been deleted by the time the method is actually called. This
can then lead to a crash when trying to use `dynamic_cast<>`.

This commit adds a check to `Object::cast_to<>` to check in ObjectDB if
the object is in fact still valid. This appears to have a positive
impact on performance. I can't entirely explain why though. I assume it
is because we actually return `NULL` From `dynamic_cast<>` way more often
than we think. The hashtable lookup may be faster than a `dynamic_cast<>`
on a `NULL` object.

Some Bunnymark results:
```
Before:
benchmark output: 5497
benchmark output: 5460
benchmark output: 5584
benchmark output: 5587
benchmark output: 5611

After:
benchmark output: 5830
benchmark output: 5679
benchmark output: 5696
benchmark output: 5758
benchmark output: 5705
```

This fixes #26394 (The other case) and probably many other random crashes.