### PR TITLE
Remove unused nodes from the scene import.

### DIFF
--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -120,6 +120,10 @@ class ResourceImporterScene : public ResourceImporter {
 	};
 
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
+	void _keep_node(Node *p_current, Node *p_owner, Set<Node *> &r_keep_nodes);
+	void _clean_animation_player(Node *scene);
+	void _filter_node(Node *p_current, Node *p_owner, const Set<Node *> p_keep_nodes, Set<String> &r_removed_nodes);
+	void _fill_kept_node(Set<Node *> &keep_nodes);
 
 public:
 	static ResourceImporterScene *get_singleton() { return singleton; }
@@ -151,6 +155,8 @@ public:
 	void _create_clips(Node *scene, const Array &p_clips, bool p_bake_all);
 	void _filter_anim_tracks(Ref<Animation> anim, Set<String> &keep);
 	void _filter_tracks(Node *scene, const String &p_text);
+
+	void _optimize_scene(Node *scene);
 	void _optimize_animations(Node *scene, float p_max_lin_error, float p_max_ang_error, float p_max_angle);
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = NULL, Variant *r_metadata = NULL);


### PR DESCRIPTION
Instead of the optimizer in the assimp importer, I made a scene optimizer for the scene importer (parent class). 

Use case: There's a complete skeleton node structure in Assimp and I use the heuristic that if it's connected to a non-spatial node it's kept. This allows me to remove the mostly empty skeleton structure, then I remove the entries in animation player.

You mentioned previously how it's not necessary, but it does cleanup the node tree a lot in my samples.

```
09:42:51reduziFire: My view on this is that it generally depends on how you exported your scene, more than anything else
09:43:16reduziFire: you may want to have empty nodes that don't seem to contribute to anything
09:43:40reduziFire: most, if not all exporters, have options to optimize this, so I'm not super thrilled about doing it from Godot side
09:44:11iFirereduz: would you recommend I turn that option on
09:44:18iFireassimp has one too for that
09:44:19reduziFire: you may have run into scenes that have all the extra crap, but this is is because they were not properly exported, so I'm not sure we should even do anything about this
09:45:04reduziFire: it could be an option in the importer that is disabled by default (optimize empty nodes) but to be honest, since most exporters can do this, there is not much of a point in us doing it
09:45:48iFirehm well I do have it implemented, and changing it to default by default is a single line change. I know you don't like bloat though.
09:46:01reduziFire: it really depends on how much code it is
09:46:11reduziFire: [if it]'s a very large amount of code just do to this, I may not want to merge it
```