### PR TITLE
Enable "Allow Hidpi" by default

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -931,7 +931,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (!force_lowdpi) {
-		OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", false);
+		OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", true);
 	}
 
 	video_mode.use_vsync = GLOBAL_DEF("display/window/vsync/use_vsync", true);


### PR DESCRIPTION
This makes projects behave better on Windows in fullscreen mode when using a display scale factor above 100%.

This partially addresses #24922 – this was suggested by @akien-mga in https://github.com/godotengine/godot/issues/24922#issuecomment-483203272.

This closes #23203.