### PR TITLE
Reversed operator in SortLifetime fixing #29440

### DIFF
--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -116,7 +116,7 @@ private:
 		const Particle *particles;
 
 		bool operator()(int p_a, int p_b) const {
-			return particles[p_a].time < particles[p_b].time;
+			return particles[p_a].time > particles[p_b].time;
 		}
 	};
 


### PR DESCRIPTION
This fixes #29440 where SortLifetime is reversed on CPUParticles2D.