### PR TITLE
Drop the physics mouseover whenever a input has been handled.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2905,6 +2905,7 @@ bool Viewport::gui_is_dragging() const {
 }
 
 void Viewport::set_input_as_handled() {
+	_drop_physics_mouseover();
 	if (handle_input_locally) {
 		local_input_handled = true;
 	} else {


### PR DESCRIPTION
Should fix #29575

Not sure if this is the correct fix or not but make sense to drop the physics mouseover events if the input has been already handled. 