### PR TITLE
Display a "loading" placeholder while icons are loading in the assetlib

### DIFF
--- a/editor/icons/icon_project_icon_loading.svg
+++ b/editor/icons/icon_project_icon_loading.svg
@@ -1,0 +1,1 @@
+<svg height="64" viewBox="0 0 64 64" width="64" xmlns="http://www.w3.org/2000/svg"><path d="m8 0c-4.432 0-8 3.568-8 8v48c0 4.432 3.568 8 8 8h48c4.432 0 8-3.568 8-8v-48c0-4.432-3.568-8-8-8z" fill="#e0e0e0" fill-opacity=".188235"/></svg>

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -65,7 +65,7 @@ void EditorAssetLibraryItem::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		icon->set_normal_texture(get_icon("DefaultProjectIcon", "EditorIcons"));
+		icon->set_normal_texture(get_icon("ProjectIconLoading", "EditorIcons"));
 		category->add_color_override("font_color", Color(0.5, 0.5, 0.5));
 		author->add_color_override("font_color", Color(0.5, 0.5, 0.5));
 	}


### PR DESCRIPTION
This makes it clearer that some icons are still loading while the user browses pages on the Asset Library. I'll send a PR with the icon to godot-design if this is merged :slightly_smiling_face:

**Update:** godot-design PR sent (https://github.com/godotengine/godot-design/pull/39).

## Preview

### Dark theme

![assetlib_loading_dark](https://user-images.githubusercontent.com/180032/59145082-8db9ff00-89df-11e9-86bb-a559fdb2369b.png)

### Light theme

![assetlib_loading_light](https://user-images.githubusercontent.com/180032/59145079-885cb480-89df-11e9-98ef-46fbc55f2981.png)
