### PR TITLE
[WIP] Added simple input filter to LineEdit

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -110,6 +110,9 @@
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" enum="Control.FocusMode">
 			Defines how the [LineEdit] can grab focus (Keyboard and mouse, only keyboard, or none). See [enum Control.FocusMode] in [Control] for details.
 		</member>
+		<member name="input_filter" type="int" setter="set_input_filter" getter="get_input_filter" enum="LineEdit.InputFilter">
+			Allows entering only the defined set of characters to the text field, while other are ignored. See [enum InputFilter] for details. Default value: [code]INPUT_FILTER_DISABLED[/code].
+		</member>
 		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length">
 			Maximum amount of characters that can be entered inside the [LineEdit]. If [code]0[/code], there is no limit.
 		</member>
@@ -157,6 +160,18 @@
 		</constant>
 		<constant name="ALIGN_FILL" value="3" enum="Align">
 			Stretches whitespaces to fit the [LineEdit]'s width.
+		</constant>
+		<constant name="INPUT_FILTER_DISABLED" value="0" enum="InputFilter">
+			Input filter is disabled.
+		</constant>
+		<constant name="INPUT_FILTER_LATIN" value="1" enum="InputFilter">
+			Input filter is enabled and allows only latin symbols (A-Z or a-z).
+		</constant>
+		<constant name="INPUT_FILTER_NUMBERS" value="2" enum="InputFilter">
+			Input filter is enabled and allows only number symbols (0-9).
+		</constant>
+		<constant name="INPUT_FILTER_LATIN_NUMBERS" value="3" enum="InputFilter">
+			Input filter is enabled and allows latin symbols (A-Z or a-z) as well as number symbols (0-9).
 		</constant>
 		<constant name="MENU_CUT" value="0" enum="MenuItems">
 			Cuts (copies and clears) the selected text.

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -62,8 +62,16 @@ public:
 
 	};
 
+	enum InputFilter {
+		INPUT_FILTER_DISABLED,
+		INPUT_FILTER_LATIN,
+		INPUT_FILTER_NUMBERS,
+		INPUT_FILTER_LATIN_NUMBERS
+	};
+
 private:
 	Align align;
+	InputFilter input_filter;
 
 	bool editable;
 	bool pass;
@@ -141,6 +149,8 @@ private:
 	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();
 
+	bool _is_restricted_symbol(CharType p_symbol);
+
 	void clear_internal();
 	void changed_internal();
 
@@ -202,6 +212,9 @@ public:
 	void set_editable(bool p_editable);
 	bool is_editable() const;
 
+	void set_input_filter(InputFilter p_input_filter);
+	InputFilter get_input_filter() const;
+
 	void set_secret(bool p_secret);
 	bool is_secret() const;
 
@@ -225,5 +238,6 @@ public:
 
 VARIANT_ENUM_CAST(LineEdit::Align);
 VARIANT_ENUM_CAST(LineEdit::MenuItems);
+VARIANT_ENUM_CAST(LineEdit::InputFilter);
 
 #endif


### PR DESCRIPTION
 I decided to make a simple enum to filtering the input by the Latin symbols, Numbers or Latin + Numbers combo. By my experience, the LineEdit input is often requires such restrictions, the english or latin symbols are wide-spread over the world, and in many games the input fields are not tolerated for non-latin symbols.

Yes, I know user can override the gui_input method, but its both time-consuming and error-prone process (and in some aspects its not simple to do, for example when user paste to LineEdit instead enter). So the filter in this PR will apply to: set_text method, direct input and copy/paste. The drop behavior is rarely used, and modify the caret position  - I think this should be not affected by filtering so I leave it untouched.

Of course, by default this filtering is disabled and not broke up the existing projects.

![image](https://user-images.githubusercontent.com/3036176/59145278-12aa1600-89ea-11e9-9d50-1a6aa368ec27.png)
