### PR TITLE
Fix display of large sizes in the editor monitors

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3235,7 +3235,7 @@ static int _humanize_digits(int p_num) {
 String String::humanize_size(size_t p_size) {
 
 	uint64_t _div = 1;
-	static const char *prefix[] = { " Bytes", " KB", " MB", " GB", "TB", " PB", "HB", "" };
+	static const char *prefix[] = { " Bytes", " KB", " MB", " GB", " TB", " PB", " EB", "" };
 	int prefix_idx = 0;
 
 	while (p_size > (_div * 1024) && prefix[prefix_idx][0]) {

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -727,20 +727,8 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				String tt = vs;
 				switch (Performance::MonitorType((int)perf_items[i]->get_metadata(1))) {
 					case Performance::MONITOR_TYPE_MEMORY: {
-						// for the time being, going above GBs is a bad sign.
-						String unit = "B";
-						if ((int)v > 1073741824) {
-							unit = "GB";
-							v /= 1073741824.0;
-						} else if ((int)v > 1048576) {
-							unit = "MB";
-							v /= 1048576.0;
-						} else if ((int)v > 1024) {
-							unit = "KB";
-							v /= 1024.0;
-						}
-						tt += " bytes";
-						vs = String::num(v, 2) + " " + unit;
+						vs = String::humanize_size(v);
+						tt = vs;
 					} break;
 					case Performance::MONITOR_TYPE_TIME: {
 						tt += " seconds";


### PR DESCRIPTION
Unlike the old custom method, the `String::humanize_size()` method works well with file sizes above 2 GB.

This also tweaks the suffixes for spacing consistency and uses the correct acronym for exabytes (EB, according to Wikipedia). We could add zettabytes and yottabytes, but that's for later :wink: 

This closes #29610.