### PR TITLE
Make humanized size rounding clearer by padding decimals with zeroes

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3246,7 +3246,7 @@ String String::humanize_size(size_t p_size) {
 	int digits = prefix_idx > 0 ? _humanize_digits(p_size / _div) : 0;
 	double divisor = prefix_idx > 0 ? _div : 1;
 
-	return String::num(p_size / divisor, digits) + prefix[prefix_idx];
+	return String::num(p_size / divisor).pad_decimals(digits) + prefix[prefix_idx];
 }
 bool String::is_abs_path() const {
 


### PR DESCRIPTION
For example, "5 MB" will now be displayed as "5.00 MB" to make the rounding precision clear, regardless of the value being rounded.

This closes #29611.