### PR TITLE
Add documentation for AnimationNode* resources

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -215,6 +215,7 @@
 		</signal>
 		<signal name="tree_changed">
 			<description>
+				Emitted by nodes that inherit from this class and that have an internal tree when one of their nodes changes. The nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], and [AnimationNodeBlendTree].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AnimationNodeAdd2.xml
+++ b/doc/classes/AnimationNodeAdd2.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeAdd2" inherits="AnimationNode" category="Core" version="3.2">
 	<brief_description>
+		Blends two animations additively inside of an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations additively based on an amount value in the [code][0.0, 1.0][/code] range.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 	</methods>
 	<members>
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync">
+			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AnimationNodeAdd3.xml
+++ b/doc/classes/AnimationNodeAdd3.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeAdd3" inherits="AnimationNode" category="Core" version="3.2">
 	<brief_description>
+		Blends two of three animations additively inside of an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations together additively out of three based on a value in the [-1.0, 1.0] range.
+		This node has three inputs:
+		- The base animation to add to
+		- A -add animation to blend with when the blend amount is in the [-1.0, 0.0] range.
+		- A +add animation to blend with when the blend amount is in the [code][0.0, 1.0][/code] range
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +16,7 @@
 	</methods>
 	<members>
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync">
+			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AnimationNodeAnimation.xml
+++ b/doc/classes/AnimationNodeAnimation.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeAnimation" inherits="AnimationRootNode" category="Core" version="3.2">
 	<brief_description>
+		Input animation to use in an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
+		A resource to add to an [AnimationNodeBlendTree]. Only features one output set using the [member animation] property. Use it as an input for [AnimationNode] that blend animations together.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 	</methods>
 	<members>
 		<member name="animation" type="String" setter="set_animation" getter="get_animation">
+			Animation to use as an output. It is one of the animations provided by [member AnimationTree.anim_player].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AnimationNodeBlend2.xml
+++ b/doc/classes/AnimationNodeBlend2.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeBlend2" inherits="AnimationNode" category="Core" version="3.2">
 	<brief_description>
+		Blends two animations linearly inside of an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations linearly based on an amount value in the [code][0.0, 1.0][/code] range.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 	</methods>
 	<members>
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync">
+			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AnimationNodeBlend3.xml
+++ b/doc/classes/AnimationNodeBlend3.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeBlend3" inherits="AnimationNode" category="Core" version="3.2">
 	<brief_description>
+		Blends two of three animations linearly inside of an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations together linearly out of three based on a value in the [-1.0, 1.0] range.
+		This node has three inputs:
+		- The base animation
+		- A -blend animation to blend with when the blend amount is in the [-1.0, 0.0] range.
+		- A +blend animation to blend with when the blend amount is in the [code][0.0, 1.0][/code] range
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +16,7 @@
 	</methods>
 	<members>
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync">
+			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeBlendSpace1D" inherits="AnimationRootNode" category="Core" version="3.2">
 	<brief_description>
+		Blends linearly between two of any number of [AnimationNode] of any type placed on a virtual axis.
 	</brief_description>
 	<description>
+		A resource to add to an [AnimationNodeBlendTree].
+		This is a virtual axis on which you can add any type of [AnimationNode] using [method add_blend_point].
+		Outputs the linear blend of the two [code]AnimationNode[/code] closest to the node's current [code]value[/code].
+		You can set the extents of the axis using the [member min_space] and [member max_space].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -17,12 +22,14 @@
 			<argument index="2" name="at_index" type="int" default="-1">
 			</argument>
 			<description>
+				Add a new point that represents a [code]node[/code] on the virtual axis at a given position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code] , the point is inserted at the end of the blend points array.
 			</description>
 		</method>
 		<method name="get_blend_point_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
+				Returns the number of points on the blend axis.
 			</description>
 		</method>
 		<method name="get_blend_point_node" qualifiers="const">
@@ -31,6 +38,7 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
+				Returns the [code]AnimationNode[/code] referenced by the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="get_blend_point_position" qualifiers="const">
@@ -39,6 +47,7 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
+				Returns the position of the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="remove_blend_point">
@@ -47,6 +56,7 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
+				Removes the point at index [code]point[/code] from the blend axis.
 			</description>
 		</method>
 		<method name="set_blend_point_node">
@@ -57,6 +67,7 @@
 			<argument index="1" name="node" type="AnimationRootNode">
 			</argument>
 			<description>
+				Changes the AnimationNode referenced by the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="set_blend_point_position">
@@ -67,17 +78,22 @@
 			<argument index="1" name="pos" type="float">
 			</argument>
 			<description>
+				Updates the position of the point at index [code]point[/code] on the blend axis.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="max_space" type="float" setter="set_max_space" getter="get_max_space">
+			The blend space's axis's upper limit for the points' position. See [method add_blend_point].
 		</member>
 		<member name="min_space" type="float" setter="set_min_space" getter="get_min_space">
+			The blend space's axis's lower limit for the points' position. See [method add_blend_point].
 		</member>
 		<member name="snap" type="float" setter="set_snap" getter="get_snap">
+			Position increment to snap to when moving a point on the axis.
 		</member>
 		<member name="value_label" type="String" setter="set_value_label" getter="get_value_label">
+			Label of the virtual axis of the blend space.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeBlendSpace2D" inherits="AnimationRootNode" category="Core" version="3.2">
 	<brief_description>
+		Blends linearly between three [AnimationNode] of any type placed in a 2d space.
 	</brief_description>
 	<description>
+		A resource to add to an [AnimationNodeBlendTree].
+		This node allows you to blend linearly between three animations using a [Vector2] weight.
+		You can add vertices to the blend space with [method add_blend_point] and automatically triangulate it by setting [member auto_triangles] to [code]true[/code]. Otherwise, use [method add_triangle] and [method remove_triangle] to create up the blend space by hand.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -17,6 +21,7 @@
 			<argument index="2" name="at_index" type="int" default="-1">
 			</argument>
 			<description>
+				Add a new point that represents a [code]node[/code] at the position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code] , the point is inserted at the end of the blend points array.
 			</description>
 		</method>
 		<method name="add_triangle">
@@ -31,12 +36,14 @@
 			<argument index="3" name="at_index" type="int" default="-1">
 			</argument>
 			<description>
+				Creates a new triangle using three points [code]x[/code], [code]y[/code], and [code]z[/code]. Triangles can overlap. You can insert the triangle at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code] , the point is inserted at the end of the blend points array.
 			</description>
 		</method>
 		<method name="get_blend_point_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
+				Returns the number of points in the blend space.
 			</description>
 		</method>
 		<method name="get_blend_point_node" qualifiers="const">
@@ -45,6 +52,7 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
+				Returns the [code]AnimationRootNode[/code] referenced by the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="get_blend_point_position" qualifiers="const">
@@ -53,12 +61,14 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
+				Returns the position of the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="get_triangle_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
+				Returns the number of triangles in the blend space.
 			</description>
 		</method>
 		<method name="get_triangle_point">
@@ -69,6 +79,7 @@
 			<argument index="1" name="point" type="int">
 			</argument>
 			<description>
+				Returns the position of the point at index [code]point[/code] in the triangle of index [code]triangle[/code].
 			</description>
 		</method>
 		<method name="remove_blend_point">
@@ -77,6 +88,7 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
+				Removes the point at index [code]point[/code] from the blend space.
 			</description>
 		</method>
 		<method name="remove_triangle">
@@ -85,6 +97,7 @@
 			<argument index="0" name="triangle" type="int">
 			</argument>
 			<description>
+				Removes the triangle at index [code]triangle[/code] from the blend space.
 			</description>
 		</method>
 		<method name="set_blend_point_node">
@@ -95,6 +108,7 @@
 			<argument index="1" name="node" type="AnimationRootNode">
 			</argument>
 			<description>
+				Changes the AnimationNode referenced by the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="set_blend_point_position">
@@ -105,39 +119,49 @@
 			<argument index="1" name="pos" type="Vector2">
 			</argument>
 			<description>
+				Updates the position of the point at index [code]point[/code] on the blend axis.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="auto_triangles" type="bool" setter="set_auto_triangles" getter="get_auto_triangles">
+			If true, the blend space is triangulated automatically. The mesh updates every time you add or remove points with [method add_blend_point] and [method remove_blend_point].
 		</member>
 		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="AnimationNodeBlendSpace2D.BlendMode">
+			Controls the interpolation between animations. See [enum BlendMode] constants.
 		</member>
 		<member name="max_space" type="Vector2" setter="set_max_space" getter="get_max_space">
+			The blend space's X and Y axes' upper limit for the points' position. See [method add_blend_point].
 		</member>
 		<member name="min_space" type="Vector2" setter="set_min_space" getter="get_min_space">
+			The blend space's X and Y axes' lower limit for the points' position. See [method add_blend_point].
 		</member>
 		<member name="snap" type="Vector2" setter="set_snap" getter="get_snap">
+			Position increment to snap to when moving a point.
 		</member>
 		<member name="x_label" type="String" setter="set_x_label" getter="get_x_label">
+			Name of the blend space's X axis.
 		</member>
 		<member name="y_label" type="String" setter="set_y_label" getter="get_y_label">
+			Name of the blend space's Y axis.
 		</member>
 	</members>
 	<signals>
 		<signal name="triangles_updated">
 			<description>
+				Emitted every time the blend space's triangles are created, removed, or when one of their vertices changes position.
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="BLEND_MODE_INTERPOLATED" value="0" enum="BlendMode">
+			The interpolation between animations is linear.
 		</constant>
 		<constant name="BLEND_MODE_DISCRETE" value="1" enum="BlendMode">
-			Useful for frame-by-frame 2D animations.
+			The blend space plays the animation of the node the blending position is closest to. Useful for frame-by-frame 2D animations.
 		</constant>
 		<constant name="BLEND_MODE_DISCRETE_CARRY" value="2" enum="BlendMode">
-			Keep the current play position when switching between discrete animations.
+			Similar to [const BLEND_MODE_DISCRETE], but starts the new animation at the last animation's playback position.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
I'm putting this up as a work-in-progress while I'm streaming and doing the work, as there's repetition between the docstrings and I'd like some feedback, to know if they're clear so far.

- I haven't put [code] bbcode around the amount of the AnimationNodeAdd* classes because it's not exposed to GDScript.
- Same for the +add, -add, etc. labels: they're just labels you can find in the AnimationTree bottom panel.

I need feedback on:

- Is it okay to have a bullet list in some of the classes' descriptions? Should I wrap it in a [codeblock] so each line doesn't generate a new paragraph?
- How can I improve the docstrings? Do they need any changes?
- I put the sentence `A resource to add to an [class AnimationNodeBlendTree].` at the start of every node's description, as although each of the classes contain *Node* in their name, they're not nodes you can add to the scene tree, but only for the animation tree editor. Should I keep it? Put it at the end of the description instead of at the start?