### PR TITLE
'get_skidinfo()' misleading description

### DIFF
--- a/doc/classes/VehicleWheel.xml
+++ b/doc/classes/VehicleWheel.xml
@@ -19,7 +19,7 @@
 			<return type="float">
 			</return>
 			<description>
-				Returns a value between 0.0 and 1.0 that indicates whether this wheel is skidding. 0.0 is not skidding, 1.0 means the wheel has lost grip.
+				Returns a value between 0.0 and 1.0 that indicates whether this wheel is skidding. 0.0 is skidding (the wheel has lost grip, e.g. icy terrain), 1.0 means not skidding (the wheel has full grip, e.g. dry asphalt road).
 			</description>
 		</method>
 		<method name="is_in_contact" qualifiers="const">


### PR DESCRIPTION
It seems (please correct me if you understand it otherwise) that the description for the `get_skidinfo()` function is the inverse of what actually happens. I have run some simple tests, and it looks like setting low `Friction Slip` (e.g. try `1` or `2`) causes more skidding and returns smaller values for `get_skidinfo()`, while when the `Friction Slip` is increased, the car skids less and values printed to the console increase (get closer to `1.0`). So it seems that a value of `0.0` means skidding, while a value of `1.0` means no skidding (the description says the exact opposite to this, from what I understood).