### PR TITLE
Add buttons to remove keys\items from dictionaries\arrays.

### DIFF
--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -105,6 +105,7 @@ class EditorPropertyArray : public EditorProperty {
 	void _change_type_menu(int p_index);
 
 	void _object_id_selected(const String &p_property, ObjectID p_id);
+	void _remove_pressed(int p_index);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
This PR adds a 'remove' button for array items and dictionary items.

Fixes #23058.

![image](https://user-images.githubusercontent.com/1107474/59763895-f8234700-92dd-11e9-838c-912125499191.png)

