### PR TITLE
fix transform2d's get_rotation

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -71,12 +71,8 @@ void Transform2D::rotate(real_t p_phi) {
 }
 
 real_t Transform2D::get_rotation() const {
-	real_t det = basis_determinant();
 	Transform2D m = orthonormalized();
-	if (det < 0) {
-		m.scale_basis(Size2(1, -1)); // convention to separate rotation and reflection for 2D is to absorb a flip along y into scaling.
-	}
-	return Math::atan2(m[0].y, m[0].x);
+	return Math::atan2(m[0].y, Math::is_zero_approx(m[0].x) ? 0.0f : m[0].x);
 }
 
 void Transform2D::set_rotation(real_t p_rot) {


### PR DESCRIPTION
fix https://github.com/godotengine/godot/issues/29625

error reason: `atan2(y,x)` will check if x is zero, if x == 0, it returns pi/2 or -pi/2 depends on y is positive or negative. If x is a relative small negative value , then atan2 won't regard it as zero but a common value, you will get -pi/2 when you expect pi/2.

It's not needed to calculate Determinant of Transform2d here, as we always consider scale as (1, -1) when it is flipped with x axis either y axis, it does not effect m[0] vector here. `scale_basis` do nothing here but increase the error here, so it cause errors, just delete it can fix the question.
To prevent potential error, I add a approx zero check below additionally;