### PR TITLE
makerst: Fix format of [url] links in reST

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -723,7 +723,7 @@
 			Shaders have a time variable that constantly increases. At some point, it needs to be rolled back to zero to avoid precision errors on shader animations. This setting specifies when (in seconds).
 		</member>
 		<member name="rendering/quality/2d/gles2_use_nvidia_rect_flicker_workaround" type="bool" setter="" getter="">
-			Some NVIDIA GPU drivers have a bug which produces flickering issues for the [code]draw_rect[/code] method, especially as used in [TileMap]. Refer to [url=https://github.com/godotengine/godot/issues/9913][/url] for details.
+			Some NVIDIA GPU drivers have a bug which produces flickering issues for the [code]draw_rect[/code] method, especially as used in [TileMap]. Refer to [url=https://github.com/godotengine/godot/issues/9913]GitHub issue 9913[/url] for details.
 			If [code]true[/code], this option enables a "safe" code path for such NVIDIA GPUs at the cost of performance. This option only impacts the GLES2 rendering backend (so the bug stays if you use GLES3), and only desktop platforms.
 		</member>
 		<member name="rendering/quality/2d/use_pixel_snap" type="bool" setter="" getter="">

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -478,24 +478,7 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
         f.write(make_heading('Tutorials', '-'))
         for t in class_def.tutorials:
             link = t.strip()
-            match = GODOT_DOCS_PATTERN.search(link)
-            if match:
-                groups = match.groups()
-                if match.lastindex == 2:
-                    # Doc reference with fragment identifier: emit direct link to section with reference to page, for example:
-                    # `#calling-javascript-from-script in Exporting For Web`
-                    f.write("- `" + groups[1] + " <../" + groups[0] + ".html" + groups[1] + ">`_ in :doc:`../" + groups[0] + "`\n\n")
-                    # Commented out alternative: Instead just emit:
-                    # `Subsection in Exporting For Web`
-                    # f.write("- `Subsection <../" + groups[0] + ".html" + groups[1] + ">`_ in :doc:`../" + groups[0] + "`\n\n")
-                elif match.lastindex == 1:
-                    # Doc reference, for example:
-                    # `Math`
-                    f.write("- :doc:`../" + groups[0] + "`\n\n")
-            else:
-                # External link, for example:
-                # `http://enet.bespin.org/usergroup0.html`
-                f.write("- `" + link + " <" + link + ">`_\n\n")
+            f.write("- " + make_url(link) + "\n\n")
 
     # Property descriptions
     if len(class_def.properties) > 0:
@@ -802,15 +785,16 @@ def rstize_text(text, state):  # type: (str, State) -> str
                 tag_text = ""  # '![](' + cmd[6:] + ')'
             elif cmd.find('url=') == 0:
                 url_link = cmd[4:]
-                tag_text = ':ref:`'
+                tag_text = '`'
                 tag_depth += 1
-                url_has_name = False
                 inside_url = True
+                url_has_name = False
             elif cmd == '/url':
-                tag_text = ('' if url_has_name else url_link) + '<' + url_link + ">`"
+                tag_text = ('' if url_has_name else url_link) + " <" + url_link + ">`_"
                 tag_depth -= 1
                 escape_post = True
                 inside_url = False
+                url_has_name = False
             elif cmd == 'center':
                 tag_depth += 1
                 tag_text = ''
@@ -994,6 +978,27 @@ def make_method_signature(class_def, method_def, make_ref, state):  # type: (Cla
 
 def make_heading(title, underline):  # type: (str, str) -> str
     return title + '\n' + (underline * len(title)) + "\n\n"
+
+
+def make_url(link):  # type: (str) -> str
+    match = GODOT_DOCS_PATTERN.search(link)
+    if match:
+        groups = match.groups()
+        if match.lastindex == 2:
+            # Doc reference with fragment identifier: emit direct link to section with reference to page, for example:
+            # `#calling-javascript-from-script in Exporting For Web`
+            return "`" + groups[1] + " <../" + groups[0] + ".html" + groups[1] + ">`_ in :doc:`../" + groups[0] + "`"
+            # Commented out alternative: Instead just emit:
+            # `Subsection in Exporting For Web`
+            # return "`Subsection <../" + groups[0] + ".html" + groups[1] + ">`__ in :doc:`../" + groups[0] + "`"
+        elif match.lastindex == 1:
+            # Doc reference, for example:
+            # `Math`
+            return ":doc:`../" + groups[0] + "`"
+    else:
+        # External link, for example:
+        # `http://enet.bespin.org/usergroup0.html`
+        return "`" + link + " <" + link + ">`_"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Moved some logic to make_url in an attempt to reuse it in the parser,
but it proved too complex so I ended up not using it. I kept it as a
separate method nevertheless.