### PR TITLE
Fix error macro calls not ending with semicolon

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -525,7 +525,7 @@ Color Color::from_hsv(float p_h, float p_s, float p_v, float p_a) const {
 float Color::gray() const {
 
 	ERR_EXPLAIN("Color.gray() is deprecated and will be removed in a future version. Use Color.get_v() for a better grayscale approximation.");
-	WARN_DEPRECATED
+	WARN_DEPRECATED;
 	return (r + g + b) / 3.0;
 }
 

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -348,7 +348,7 @@ uint64_t XMLParser::get_node_offset() const {
 
 Error XMLParser::seek(uint64_t p_pos) {
 
-	ERR_FAIL_COND_V(!data, ERR_FILE_EOF)
+	ERR_FAIL_COND_V(!data, ERR_FILE_EOF);
 	ERR_FAIL_COND_V(p_pos >= length, ERR_FILE_EOF);
 
 	P = data + p_pos;

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -489,7 +489,7 @@ Error ProjectSettings::_load_settings_binary(const String p_path) {
 
 		memdelete(f);
 		ERR_EXPLAIN("Corrupted header in binary project.binary (not ECFG)");
-		ERR_FAIL_V(ERR_FILE_CORRUPT;)
+		ERR_FAIL_V(ERR_FILE_CORRUPT);
 	}
 
 	uint32_t count = f->get_32();
@@ -640,7 +640,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 	if (err != OK) {
 
 		ERR_EXPLAIN("Couldn't save project.binary at " + p_file);
-		ERR_FAIL_COND_V(err, err)
+		ERR_FAIL_COND_V(err, err);
 	}
 
 	uint8_t hdr[4] = { 'E', 'C', 'F', 'G' };
@@ -732,7 +732,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 
 	if (err) {
 		ERR_EXPLAIN("Couldn't save project.godot - " + p_file);
-		ERR_FAIL_COND_V(err, err)
+		ERR_FAIL_COND_V(err, err);
 	}
 
 	file->store_line("; Engine configuration file.");

--- a/core/sort_array.h
+++ b/core/sort_array.h
@@ -179,14 +179,14 @@ public:
 		while (true) {
 			while (compare(p_array[p_first], p_pivot)) {
 				if (Validate) {
-					ERR_BAD_COMPARE(p_first == unmodified_last - 1)
+					ERR_BAD_COMPARE(p_first == unmodified_last - 1);
 				}
 				p_first++;
 			}
 			p_last--;
 			while (compare(p_pivot, p_array[p_last])) {
 				if (Validate) {
-					ERR_BAD_COMPARE(p_last == unmodified_first)
+					ERR_BAD_COMPARE(p_last == unmodified_first);
 				}
 				p_last--;
 			}
@@ -259,7 +259,7 @@ public:
 		int next = p_last - 1;
 		while (compare(p_value, p_array[next])) {
 			if (Validate) {
-				ERR_BAD_COMPARE(next == 0)
+				ERR_BAD_COMPARE(next == 0);
 			}
 			p_array[p_last] = p_array[next];
 			p_last = next;

--- a/core/vector.h
+++ b/core/vector.h
@@ -150,7 +150,7 @@ template <class T>
 bool Vector<T>::push_back(const T &p_elem) {
 
 	Error err = resize(size() + 1);
-	ERR_FAIL_COND_V(err, true)
+	ERR_FAIL_COND_V(err, true);
 	set(size() - 1, p_elem);
 
 	return false;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3304,7 +3304,7 @@ void RasterizerSceneGLES3::_prepare_depth_texture() {
 
 void RasterizerSceneGLES3::_bind_depth_texture() {
 	if (!state.bound_depth_texture) {
-		ERR_FAIL_COND(!state.prepared_depth_texture)
+		ERR_FAIL_COND(!state.prepared_depth_texture);
 		//bind depth for read
 		glActiveTexture(GL_TEXTURE0 + storage->config.max_texture_image_units - 8);
 		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->depth);

--- a/editor/collada/collada.cpp
+++ b/editor/collada/collada.cpp
@@ -651,7 +651,7 @@ void Collada::_parse_effect_material(XMLParser &parser, Effect &effect, String &
 													effect.emission.texture = uri;
 												} else if (what == "bump") {
 													if (parser.has_attribute("bumptype") && parser.get_attribute_value("bumptype") != "NORMALMAP") {
-														WARN_PRINT("'bump' texture type is not NORMALMAP, only NORMALMAP is supported.")
+														WARN_PRINT("'bump' texture type is not NORMALMAP, only NORMALMAP is supported.");
 													}
 
 													effect.bump.texture = uri;
@@ -707,7 +707,7 @@ void Collada::_parse_effect_material(XMLParser &parser, Effect &effect, String &
 									String uri = effect.params[surface];
 
 									if (parser.has_attribute("bumptype") && parser.get_attribute_value("bumptype") != "NORMALMAP") {
-										WARN_PRINT("'bump' texture type is not NORMALMAP, only NORMALMAP is supported.")
+										WARN_PRINT("'bump' texture type is not NORMALMAP, only NORMALMAP is supported.");
 									}
 
 									effect.bump.texture = uri;

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -907,7 +907,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 
 	String tmppath = EditorSettings::get_singleton()->get_cache_dir().plus_file("packtmp");
 	FileAccess *ftmp = FileAccess::open(tmppath, FileAccess::WRITE);
-	ERR_FAIL_COND_V(!ftmp, ERR_CANT_CREATE)
+	ERR_FAIL_COND_V(!ftmp, ERR_CANT_CREATE);
 
 	PackData pd;
 	pd.ep = &ep;
@@ -924,7 +924,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 	pd.file_ofs.sort(); //do sort, so we can do binary search later
 
 	FileAccess *f = FileAccess::open(p_path, FileAccess::WRITE);
-	ERR_FAIL_COND_V(!f, ERR_CANT_CREATE)
+	ERR_FAIL_COND_V(!f, ERR_CANT_CREATE);
 	f->store_32(0x43504447); //GDPK
 	f->store_32(1); //pack version
 	f->store_32(VERSION_MAJOR);
@@ -977,7 +977,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 	ftmp = FileAccess::open(tmppath, FileAccess::READ);
 	if (!ftmp) {
 		memdelete(f);
-		ERR_FAIL_COND_V(!ftmp, ERR_CANT_CREATE)
+		ERR_FAIL_COND_V(!ftmp, ERR_CANT_CREATE);
 	}
 
 	const int bufsize = 16384;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1411,7 +1411,7 @@ void EditorNode::_dialog_action(String p_file) {
 		case RESOURCE_SAVE:
 		case RESOURCE_SAVE_AS: {
 
-			ERR_FAIL_COND(saving_resource.is_null())
+			ERR_FAIL_COND(saving_resource.is_null());
 			save_resource_in_path(saving_resource, p_file);
 			saving_resource = Ref<Resource>();
 			ObjectID current = editor_history.get_current();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1123,7 +1123,7 @@ Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_re
 
 Variant _EDITOR_GET(const String &p_setting) {
 
-	ERR_FAIL_COND_V(!EditorSettings::get_singleton()->has_setting(p_setting), Variant())
+	ERR_FAIL_COND_V(!EditorSettings::get_singleton()->has_setting(p_setting), Variant());
 	return EditorSettings::get_singleton()->get(p_setting);
 }
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2069,7 +2069,7 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 
 void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<String> p_paths, bool p_display_path_dependent_options) {
 	// Add options for files and folders
-	ERR_FAIL_COND(p_paths.empty())
+	ERR_FAIL_COND(p_paths.empty());
 
 	Vector<String> filenames;
 	Vector<String> foldernames;

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -119,7 +119,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 
 		file->close();
 		memdelete(file);
-		ERR_EXPLAIN("Not a WAV file (no WAVE RIFF Header)")
+		ERR_EXPLAIN("Not a WAV file (no WAVE RIFF Header)");
 		ERR_FAIL_V(ERR_FILE_UNRECOGNIZED);
 	}
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -169,7 +169,7 @@ void InspectorDock::_save_resource(bool save_as) const {
 	uint32_t current = EditorNode::get_singleton()->get_editor_history()->get_current();
 	Object *current_obj = current > 0 ? ObjectDB::get_instance(current) : NULL;
 
-	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
+	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj));
 
 	RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
@@ -183,7 +183,7 @@ void InspectorDock::_unref_resource() const {
 	uint32_t current = EditorNode::get_singleton()->get_editor_history()->get_current();
 	Object *current_obj = current > 0 ? ObjectDB::get_instance(current) : NULL;
 
-	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
+	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj));
 
 	RES current_res = RES(Object::cast_to<Resource>(current_obj));
 	current_res->set_path("");
@@ -194,7 +194,7 @@ void InspectorDock::_copy_resource() const {
 	uint32_t current = EditorNode::get_singleton()->get_editor_history()->get_current();
 	Object *current_obj = current > 0 ? ObjectDB::get_instance(current) : NULL;
 
-	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
+	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj));
 
 	RES current_res = RES(Object::cast_to<Resource>(current_obj));
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -471,7 +471,7 @@ void AnimationNodeBlendTreeEditor::_node_selected(Object *p_node) {
 void AnimationNodeBlendTreeEditor::_open_in_editor(const String &p_which) {
 
 	Ref<AnimationNode> an = blend_tree->get_node(p_which);
-	ERR_FAIL_COND(!an.is_valid())
+	ERR_FAIL_COND(!an.is_valid());
 	AnimationTreeEditor::get_singleton()->enter_editor(p_which);
 }
 
@@ -798,7 +798,7 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 
 	String new_name = p_text;
 
-	ERR_FAIL_COND(new_name == "" || new_name.find(".") != -1 || new_name.find("/") != -1)
+	ERR_FAIL_COND(new_name == "" || new_name.find(".") != -1 || new_name.find("/") != -1);
 
 	if (new_name == prev_name) {
 		return; //nothing to do

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -769,7 +769,7 @@ void AnimationPlayerEditor::_dialog_action(String p_file) {
 			if (current != "") {
 				Ref<Animation> anim = player->get_animation(current);
 
-				ERR_FAIL_COND(!Object::cast_to<Resource>(*anim))
+				ERR_FAIL_COND(!Object::cast_to<Resource>(*anim));
 
 				RES current_res = RES(Object::cast_to<Resource>(*anim));
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1096,7 +1096,7 @@ void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 
 	String new_name = p_text;
 
-	ERR_FAIL_COND(new_name == "" || new_name.find(".") != -1 || new_name.find("/") != -1)
+	ERR_FAIL_COND(new_name == "" || new_name.find(".") != -1 || new_name.find("/") != -1);
 
 	if (new_name == prev_name) {
 		return; // Nothing to do.

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -197,7 +197,7 @@ void MultiMeshEditor::_populate() {
 		float areapos = Math::random(0.0f, area_accum);
 
 		Map<float, int>::Element *E = triangle_area_map.find_closest(areapos);
-		ERR_FAIL_COND(!E)
+		ERR_FAIL_COND(!E);
 		int index = E->get();
 		ERR_FAIL_INDEX(index, facecount);
 

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -67,7 +67,7 @@ bool ParticlesEditorBase::_generate(PoolVector<Vector3> &points, PoolVector<Vect
 			float areapos = Math::random(0.0f, area_accum);
 
 			Map<float, int>::Element *E = triangle_area_map.find_closest(areapos);
-			ERR_FAIL_COND_V(!E, false)
+			ERR_FAIL_COND_V(!E, false);
 			int index = E->get();
 			ERR_FAIL_INDEX_V(index, geometry.size(), false);
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4211,7 +4211,7 @@ void SpatialEditor::set_state(const Dictionary &p_state) {
 		Array vp = d["viewports"];
 		uint32_t vp_size = static_cast<uint32_t>(vp.size());
 		if (vp_size > VIEWPORTS_COUNT) {
-			WARN_PRINT("Ignoring superfluous viewport settings from spatial editor state.")
+			WARN_PRINT("Ignoring superfluous viewport settings from spatial editor state.");
 			vp_size = VIEWPORTS_COUNT;
 		}
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1754,7 +1754,7 @@ bool Main::start() {
 					scene = scenedata->instance();
 
 				ERR_EXPLAIN("Failed loading scene: " + local_game_path);
-				ERR_FAIL_COND_V(!scene, false)
+				ERR_FAIL_COND_V(!scene, false);
 				sml->add_current_scene(scene);
 
 #ifdef OSX_ENABLED

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -267,7 +267,7 @@ RID BulletPhysicsServer::area_get_space(RID p_area) const {
 
 void BulletPhysicsServer::area_set_space_override_mode(RID p_area, AreaSpaceOverrideMode p_mode) {
 	AreaBullet *area = area_owner.get(p_area);
-	ERR_FAIL_COND(!area)
+	ERR_FAIL_COND(!area);
 
 	area->set_spOv_mode(p_mode);
 }

--- a/modules/bullet/cone_twist_joint_bullet.cpp
+++ b/modules/bullet/cone_twist_joint_bullet.cpp
@@ -84,7 +84,7 @@ void ConeTwistJointBullet::set_param(PhysicsServer::ConeTwistJointParam p_param,
 			break;
 		default:
 			ERR_EXPLAIN("This parameter " + itos(p_param) + " is deprecated");
-			WARN_DEPRECATED
+			WARN_DEPRECATED;
 			break;
 	}
 }

--- a/modules/bullet/generic_6dof_joint_bullet.cpp
+++ b/modules/bullet/generic_6dof_joint_bullet.cpp
@@ -175,7 +175,7 @@ void Generic6DOFJointBullet::set_param(Vector3::Axis p_axis, PhysicsServer::G6DO
 			break;
 		default:
 			ERR_EXPLAIN("This parameter " + itos(p_param) + " is deprecated");
-			WARN_DEPRECATED
+			WARN_DEPRECATED;
 			break;
 	}
 }
@@ -256,7 +256,7 @@ void Generic6DOFJointBullet::set_flag(Vector3::Axis p_axis, PhysicsServer::G6DOF
 			break;
 		default:
 			ERR_EXPLAIN("This flag " + itos(p_flag) + " is deprecated");
-			WARN_DEPRECATED
+			WARN_DEPRECATED;
 			break;
 	}
 }

--- a/modules/bullet/hinge_joint_bullet.cpp
+++ b/modules/bullet/hinge_joint_bullet.cpp
@@ -118,7 +118,7 @@ void HingeJointBullet::set_param(PhysicsServer::HingeJointParam p_param, real_t 
 			break;
 		default:
 			ERR_EXPLAIN("The HingeJoint parameter " + itos(p_param) + " is deprecated.");
-			WARN_DEPRECATED
+			WARN_DEPRECATED;
 			break;
 	}
 }

--- a/modules/bullet/pin_joint_bullet.cpp
+++ b/modules/bullet/pin_joint_bullet.cpp
@@ -86,7 +86,7 @@ real_t PinJointBullet::get_param(PhysicsServer::PinJointParam p_param) const {
 			return p2pConstraint->m_setting.m_impulseClamp;
 		default:
 			ERR_EXPLAIN("This parameter " + itos(p_param) + " is deprecated");
-			WARN_DEPRECATED
+			WARN_DEPRECATED;
 			return 0;
 	}
 }

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -45,7 +45,7 @@ void CSGBrush::build_from_faces(const PoolVector<Vector3> &p_vertices, const Poo
 
 	int vc = p_vertices.size();
 
-	ERR_FAIL_COND((vc % 3) != 0)
+	ERR_FAIL_COND((vc % 3) != 0);
 
 	PoolVector<Vector3>::Read rv = p_vertices.read();
 	int uvc = p_uvs.size();

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -346,7 +346,7 @@ void NetworkedMultiplayerENet::poll() {
 
 					uint32_t *id = (uint32_t *)event.peer->data;
 
-					ERR_CONTINUE(event.packet->dataLength < 8)
+					ERR_CONTINUE(event.packet->dataLength < 8);
 
 					uint32_t source = decode_uint32(&event.packet->data[0]);
 					int target = decode_uint32(&event.packet->data[4]);
@@ -462,7 +462,7 @@ void NetworkedMultiplayerENet::disconnect_peer(int p_peer, bool now) {
 
 	ERR_FAIL_COND(!active);
 	ERR_FAIL_COND(!is_server());
-	ERR_FAIL_COND(!peer_map.has(p_peer))
+	ERR_FAIL_COND(!peer_map.has(p_peer));
 
 	if (now) {
 		enet_peer_disconnect_now(peer_map[p_peer], 0);

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -39,12 +39,12 @@
 #define ASSERT_SCRIPT_VALID()                \
 	{                                        \
 		ERR_EXPLAIN(__ASSERT_SCRIPT_REASON); \
-		ERR_FAIL_COND(!can_instance())       \
+		ERR_FAIL_COND(!can_instance());      \
 	}
-#define ASSERT_SCRIPT_VALID_V(ret)            \
-	{                                         \
-		ERR_EXPLAIN(__ASSERT_SCRIPT_REASON);  \
-		ERR_FAIL_COND_V(!can_instance(), ret) \
+#define ASSERT_SCRIPT_VALID_V(ret)             \
+	{                                          \
+		ERR_EXPLAIN(__ASSERT_SCRIPT_REASON);   \
+		ERR_FAIL_COND_V(!can_instance(), ret); \
 	}
 #else
 #define ASSERT_SCRIPT_VALID()
@@ -77,7 +77,7 @@ PluginScriptInstance *PluginScript::_create_instance(const Variant **p_args, int
 	// There is currently no way to get the constructor function name of the script.
 	// instance->call("__init__", p_args, p_argcount, r_error);
 	if (p_argcount > 0) {
-		WARN_PRINT("PluginScript doesn't support arguments in the constructor")
+		WARN_PRINT("PluginScript doesn't support arguments in the constructor");
 	}
 
 	return instance;

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -342,7 +342,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 			VALIDATE_ARG_NUM(0);
 			r_ret = Math::step_decimals((double)*p_args[0]);
 			ERR_EXPLAIN("GDScript method 'decimals' is deprecated and has been renamed to 'step_decimals', please update your code accordingly.");
-			WARN_DEPRECATED
+			WARN_DEPRECATED;
 		} break;
 		case MATH_STEP_DECIMALS: {
 			VALIDATE_ARG_COUNT(1);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4025,7 +4025,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 
 										if (tokenizer->get_token() == GDScriptTokenizer::TK_PARENTHESIS_CLOSE) {
 											ERR_EXPLAIN("Exporting bit flags hint requires string constants.");
-											WARN_DEPRECATED
+											WARN_DEPRECATED;
 											break;
 										}
 										if (tokenizer->get_token() != GDScriptTokenizer::TK_COMMA) {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -197,7 +197,7 @@ bool GridMap::get_collision_layer_bit(int p_bit) const {
 void GridMap::set_theme(const Ref<MeshLibrary> &p_theme) {
 
 	ERR_EXPLAIN("GridMap.theme/set_theme() is deprecated and will be removed in a future version. Use GridMap.mesh_library/set_mesh_library() instead.");
-	WARN_DEPRECATED
+	WARN_DEPRECATED;
 
 	set_mesh_library(p_theme);
 }
@@ -205,7 +205,7 @@ void GridMap::set_theme(const Ref<MeshLibrary> &p_theme) {
 Ref<MeshLibrary> GridMap::get_theme() const {
 
 	ERR_EXPLAIN("GridMap.theme/get_theme() is deprecated and will be removed in a future version. Use GridMap.mesh_library/get_mesh_library() instead.");
-	WARN_DEPRECATED
+	WARN_DEPRECATED;
 
 	return get_mesh_library();
 }

--- a/modules/opus/audio_stream_opus.cpp
+++ b/modules/opus/audio_stream_opus.cpp
@@ -313,7 +313,7 @@ int AudioStreamPlaybackOpus::mix(int16_t *p_buffer, int p_frames) {
 				bool ok = op_pcm_seek(opus_file, (loop_restart_time * osrate) + pre_skip) == 0;
 				if (!ok) {
 					playing = false;
-					ERR_PRINT("loop restart time rejected")
+					ERR_PRINT("Loop restart time rejected");
 				}
 
 				frames_mixed = (loop_restart_time * osrate) + pre_skip;

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -122,13 +122,13 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 		}
 
 		if (idxG == -1) {
-			ERR_PRINT("TinyEXR: G channel not found.")
+			ERR_PRINT("TinyEXR: G channel not found.");
 			// @todo { free exr_image }
 			return ERR_FILE_CORRUPT;
 		}
 
 		if (idxB == -1) {
-			ERR_PRINT("TinyEXR: B channel not found.")
+			ERR_PRINT("TinyEXR: B channel not found.");
 			// @todo { free exr_image }
 			return ERR_FILE_CORRUPT;
 		}

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -143,8 +143,7 @@ int AudioStreamPlaybackOGGVorbis::mix(int16_t *p_buffer, int p_frames) {
 				bool ok = ov_time_seek(&vf, loop_restart_time) == 0;
 				if (!ok) {
 					playing = false;
-					//ERR_EXPLAIN("loop restart time rejected");
-					ERR_PRINT("loop restart time rejected")
+					ERR_PRINT("Loop restart time rejected");
 				}
 
 				frames_mixed = stream_srate * loop_restart_time;

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -790,7 +790,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 						if (tname == "manifest" && attrname == "versionName") {
 							if (attr_value == 0xFFFFFFFF) {
-								WARN_PRINT("Version name in a resource, should be plaintext")
+								WARN_PRINT("Version name in a resource, should be plain text");
 							} else
 								string_table.write[attr_value] = version_name;
 						}

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -914,7 +914,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	};
 
 	DirAccess *tmp_app_path = DirAccess::create_for_path(dest_dir);
-	ERR_FAIL_COND_V(!tmp_app_path, ERR_CANT_CREATE)
+	ERR_FAIL_COND_V(!tmp_app_path, ERR_CANT_CREATE);
 
 	print_line("Unzipping...");
 	FileAccess *src_f = NULL;

--- a/platform/iphone/icloud.mm
+++ b/platform/iphone/icloud.mm
@@ -138,7 +138,7 @@ Variant nsobject_to_variant(NSObject *object) {
 		//this is a type that icloud supports...but how did you submit it in the first place?
 		//I guess this is a type that *might* show up, if you were, say, trying to make your game
 		//compatible with existing cloud data written by another engine's version of your game
-		WARN_PRINT("NSDate unsupported, returning null Variant")
+		WARN_PRINT("NSDate unsupported, returning null Variant");
 		return Variant();
 	} else if ([object isKindOfClass:[NSNull class]] or object == nil) {
 		return Variant();

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -1144,7 +1144,7 @@ void OS_JavaScript::set_icon(const Ref<Image> &p_icon) {
 	Ref<Image> icon = p_icon;
 	if (icon->is_compressed()) {
 		icon = icon->duplicate();
-		ERR_FAIL_COND(icon->decompress() != OK)
+		ERR_FAIL_COND(icon->decompress() != OK);
 	}
 	if (icon->get_format() != Image::FORMAT_RGBA8) {
 		if (icon == p_icon)

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -646,7 +646,7 @@ void AnimatedSprite::_reset_timeout() {
 void AnimatedSprite::set_animation(const StringName &p_animation) {
 
 	ERR_EXPLAIN(vformat("There is no animation with name '%s'.", p_animation));
-	ERR_FAIL_COND(frames == NULL)
+	ERR_FAIL_COND(frames == NULL);
 	ERR_FAIL_COND(frames->get_animation_names().find(p_animation) == -1);
 
 	if (animation == p_animation)

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -105,7 +105,7 @@ void Line2D::set_point_position(int i, Vector2 pos) {
 }
 
 Vector2 Line2D::get_point_position(int i) const {
-	ERR_FAIL_INDEX_V(i, _points.size(), Vector2())
+	ERR_FAIL_INDEX_V(i, _points.size(), Vector2());
 	return _points.get(i);
 }
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -203,8 +203,8 @@ void StaticBody2D::set_friction(real_t p_friction) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
@@ -217,8 +217,8 @@ void StaticBody2D::set_friction(real_t p_friction) {
 
 real_t StaticBody2D::get_friction() const {
 
-	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	if (physics_material_override.is_null()) {
 		return 1;
@@ -233,8 +233,8 @@ void StaticBody2D::set_bounce(real_t p_bounce) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
@@ -247,8 +247,8 @@ void StaticBody2D::set_bounce(real_t p_bounce) {
 
 real_t StaticBody2D::get_bounce() const {
 
-	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	if (physics_material_override.is_null()) {
 		return 0;
@@ -630,8 +630,8 @@ void RigidBody2D::set_friction(real_t p_friction) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
@@ -643,8 +643,8 @@ void RigidBody2D::set_friction(real_t p_friction) {
 }
 real_t RigidBody2D::get_friction() const {
 
-	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	if (physics_material_override.is_null()) {
 		return 1;
@@ -659,8 +659,8 @@ void RigidBody2D::set_bounce(real_t p_bounce) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
@@ -672,8 +672,8 @@ void RigidBody2D::set_bounce(real_t p_bounce) {
 }
 real_t RigidBody2D::get_bounce() const {
 
-	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	if (physics_material_override.is_null()) {
 		return 0;

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -192,8 +192,8 @@ void StaticBody::set_friction(real_t p_friction) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
@@ -206,8 +206,8 @@ void StaticBody::set_friction(real_t p_friction) {
 
 real_t StaticBody::get_friction() const {
 
-	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	if (physics_material_override.is_null()) {
 		return 1;
@@ -222,8 +222,8 @@ void StaticBody::set_bounce(real_t p_bounce) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
@@ -236,8 +236,8 @@ void StaticBody::set_bounce(real_t p_bounce) {
 
 real_t StaticBody::get_bounce() const {
 
-	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	if (physics_material_override.is_null()) {
 		return 0;
@@ -636,8 +636,8 @@ void RigidBody::set_friction(real_t p_friction) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
@@ -649,8 +649,8 @@ void RigidBody::set_friction(real_t p_friction) {
 }
 real_t RigidBody::get_friction() const {
 
-	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	if (physics_material_override.is_null()) {
 		return 1;
@@ -665,8 +665,8 @@ void RigidBody::set_bounce(real_t p_bounce) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
@@ -677,8 +677,8 @@ void RigidBody::set_bounce(real_t p_bounce) {
 	physics_material_override->set_bounce(p_bounce);
 }
 real_t RigidBody::get_bounce() const {
-	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.")
-	WARN_DEPRECATED
+	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
+	WARN_DEPRECATED;
 	if (physics_material_override.is_null()) {
 		return 0;
 	}

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -316,7 +316,7 @@ String AnimationNode::get_caption() const {
 
 void AnimationNode::add_input(const String &p_name) {
 	//root nodes can't add inputs
-	ERR_FAIL_COND(Object::cast_to<AnimationRootNode>(this) != NULL)
+	ERR_FAIL_COND(Object::cast_to<AnimationRootNode>(this) != NULL);
 	Input input;
 	ERR_FAIL_COND(p_name.find(".") != -1 || p_name.find("/") != -1);
 	input.name = p_name;

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -404,7 +404,7 @@ void AnimationTreePlayer::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 
 			ERR_EXPLAIN("AnimationTreePlayer has been deprecated. Use AnimationTree instead.");
-			WARN_DEPRECATED
+			WARN_DEPRECATED;
 
 			if (!processing) {
 				//make sure that a previous process state was not saved

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4683,7 +4683,7 @@ bool TextEdit::has_keyword_color(String p_keyword) const {
 
 Color TextEdit::get_keyword_color(String p_keyword) const {
 
-	ERR_FAIL_COND_V(!keywords.has(p_keyword), Color())
+	ERR_FAIL_COND_V(!keywords.has(p_keyword), Color());
 	return keywords[p_keyword];
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1165,7 +1165,7 @@ void Node::add_child(Node *p_child, bool p_legible_unique_name) {
 	ERR_FAIL_NULL(p_child);
 
 	if (p_child == this) {
-		ERR_EXPLAIN("Can't add child '" + p_child->get_name() + "' to itself.")
+		ERR_EXPLAIN("Can't add child '" + p_child->get_name() + "' to itself.");
 		ERR_FAIL_COND(p_child == this); // adding to itself!
 	}
 
@@ -1199,7 +1199,7 @@ void Node::add_child_below_node(Node *p_node, Node *p_child, bool p_legible_uniq
 	if (is_a_parent_of(p_node)) {
 		move_child(p_child, p_node->get_position_in_parent() + 1);
 	} else {
-		WARN_PRINTS("Cannot move under node " + p_node->get_name() + " as " + p_child->get_name() + " does not share a parent.")
+		WARN_PRINTS("Cannot move under node " + p_node->get_name() + " as " + p_child->get_name() + " does not share a parent.");
 	}
 }
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1244,7 +1244,7 @@ void SceneTree::_update_root_rect() {
 			root->update_canvas_items(); //force them to update just in case
 
 			if (use_font_oversampling) {
-				WARN_PRINT("Font oversampling does not work in 'Viewport' stretch mode, only '2D'.")
+				WARN_PRINT("Font oversampling does not work in 'Viewport' stretch mode, only '2D'.");
 			}
 
 		} break;

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -93,7 +93,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				TransformTrack *tt = static_cast<TransformTrack *>(tracks[track]);
 				PoolVector<float> values = p_value;
 				int vcount = values.size();
-				ERR_FAIL_COND_V(vcount % 12, false); // shuld be multiple of 11
+				ERR_FAIL_COND_V(vcount % 12, false); // should be multiple of 11
 
 				PoolVector<float>::Read r = values.read();
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -92,8 +92,8 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 
 		if (i > 0) {
 
-			ERR_EXPLAIN(vformat("Invalid scene: node %s does not specify its parent node.", snames[n.name]))
-			ERR_FAIL_COND_V(n.parent == -1, NULL)
+			ERR_EXPLAIN(vformat("Invalid scene: node %s does not specify its parent node.", snames[n.name]));
+			ERR_FAIL_COND_V(n.parent == -1, NULL);
 			NODE_FROM_ID(nparent, n.parent);
 #ifdef DEBUG_ENABLED
 			if (!nparent && (n.parent & FLAG_ID_IS_PATH)) {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -232,7 +232,7 @@ Image::Format ImageTexture::get_format() const {
 #ifndef DISABLE_DEPRECATED
 Error ImageTexture::load(const String &p_path) {
 
-	WARN_DEPRECATED
+	WARN_DEPRECATED;
 	Ref<Image> img;
 	img.instance();
 	Error err = img->load(p_path);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -297,7 +297,7 @@ Error VisualShader::connect_nodes(Type p_type, int p_from_node, int p_from_port,
 
 	if (MAX(0, from_port_type - 2) != (MAX(0, to_port_type - 2))) {
 		ERR_EXPLAIN("Incompatible port types (scalar/vec/bool with transform");
-		ERR_FAIL_V(ERR_INVALID_PARAMETER)
+		ERR_FAIL_V(ERR_INVALID_PARAMETER);
 		return ERR_INVALID_PARAMETER;
 	}
 

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -92,7 +92,7 @@ normal_relative_velocity(Body2DSW *a, Body2DSW *b, Vector2 rA, Vector2 rB, Vecto
 bool PinJoint2DSW::setup(real_t p_step) {
 
 	Space2DSW *space = A->get_space();
-	ERR_FAIL_COND_V(!space, false;)
+	ERR_FAIL_COND_V(!space, false);
 	rA = A->get_transform().basis_xform(anchor_A);
 	rB = B ? B->get_transform().basis_xform(anchor_B) : anchor_B;
 


### PR DESCRIPTION
It's not necessary, but the vast majority of calls of error macros
do have an ending semicolon, so it's best to be consistent.
Most WARN_DEPRECATED calls did *not* have a semicolon, but there's
no reason for them to be treated differently.