### PR TITLE
Remove "Editor" from Windows PE file description

### DIFF
--- a/platform/windows/godot_res.rc
+++ b/platform/windows/godot_res.rc
@@ -21,7 +21,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "CompanyName",            "Godot Engine"
-            VALUE "FileDescription",        VERSION_NAME " Editor"
+            VALUE "FileDescription",        VERSION_NAME
             VALUE "FileVersion",            VERSION_NUMBER
             VALUE "ProductName",            VERSION_NAME
             VALUE "Licence",                "MIT"


### PR DESCRIPTION
Another option would be to make it conditional and have "Godot Engine Editor" for the editor and "Godot Engine Game" or "Godot Engine Project" for the template, but I'm not sure it's worth the trouble to define a constant depending on `TOOLS_ENABLED` for that.

Closes #29569.