### PR TITLE
Fix script create dialog

### DIFF
--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -87,7 +87,8 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	void _path_entered(const String &p_path = String());
 	void _lang_changed(int l = 0);
 	void _built_in_pressed();
-	bool _validate(const String &p_string);
+	bool _validate_parent(const String &p_string);
+	bool _validate_class(const String &p_string);
 	String _validate_path(const String &p_path, bool p_file_must_exist);
 	void _class_name_changed(const String &p_name);
 	void _parent_name_changed(const String &p_parent);


### PR DESCRIPTION
- Correctly validate parent/class names. Fixes #28851
- Trigger parent validation when selecting from buttons
- Fix enabling/disabling parent buttons
- Clear class name if not supported
- Minor cleanup

I haven't used NativeScript; are my assumptions that a class name should not be a path or include a hyphen correct? And should it match (or not match) an existing registered class, or is it a separate thing? 