### PR TITLE
Fix CPU particles bug with local_coords and transform

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -85,7 +85,9 @@ void CPUParticles2D::set_randomness_ratio(float p_ratio) {
 void CPUParticles2D::set_use_local_coordinates(bool p_enable) {
 
 	local_coords = p_enable;
+	set_notify_transform(!p_enable);
 }
+
 void CPUParticles2D::set_speed_scale(float p_scale) {
 
 	speed_scale = p_scale;
@@ -865,11 +867,6 @@ void CPUParticles2D::_update_particle_data_buffer() {
 		PoolVector<Particle>::Read r = particles.read();
 		float *ptr = w.ptr();
 
-		Transform2D un_transform;
-		if (!local_coords) {
-			un_transform = get_global_transform().affine_inverse();
-		}
-
 		if (draw_order != DRAW_ORDER_INDEX) {
 			ow = particle_order.write();
 			order = ow.ptr();
@@ -891,7 +888,7 @@ void CPUParticles2D::_update_particle_data_buffer() {
 			Transform2D t = r[idx].transform;
 
 			if (!local_coords) {
-				t = un_transform * t;
+				t = inv_emission_transform * t;
 			}
 
 			if (r[idx].active) {
@@ -1059,6 +1056,42 @@ void CPUParticles2D::_notification(int p_what) {
 		}
 
 		_update_particle_data_buffer();
+	}
+
+	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
+
+		inv_emission_transform = get_global_transform().affine_inverse();
+
+		if (!local_coords) {
+
+			int pc = particles.size();
+
+			PoolVector<float>::Write w = particle_data.write();
+			PoolVector<Particle>::Read r = particles.read();
+			float *ptr = w.ptr();
+
+			for (int i = 0; i < pc; i++) {
+
+				Transform2D t = inv_emission_transform * r[i].transform;
+
+				if (r[i].active) {
+
+					ptr[0] = t.elements[0][0];
+					ptr[1] = t.elements[1][0];
+					ptr[2] = 0;
+					ptr[3] = t.elements[2][0];
+					ptr[4] = t.elements[0][1];
+					ptr[5] = t.elements[1][1];
+					ptr[6] = 0;
+					ptr[7] = t.elements[2][1];
+
+				} else {
+					zeromem(ptr, sizeof(float) * 8);
+				}
+
+				ptr += 13;
+			}
+		}
 	}
 }
 

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -142,6 +142,8 @@ private:
 	int fixed_fps;
 	bool fractional_delta;
 
+	Transform2D inv_emission_transform;
+
 	DrawOrder draw_order;
 
 	Ref<Texture> texture;

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -910,11 +910,6 @@ void CPUParticles::_update_particle_data_buffer() {
 		PoolVector<Particle>::Read r = particles.read();
 		float *ptr = w.ptr();
 
-		Transform un_transform;
-		if (!local_coords) {
-			un_transform = get_global_transform().affine_inverse();
-		}
-
 		if (draw_order != DRAW_ORDER_INDEX) {
 			ow = particle_order.write();
 			order = ow.ptr();
@@ -932,7 +927,12 @@ void CPUParticles::_update_particle_data_buffer() {
 					Vector3 dir = c->get_global_transform().basis.get_axis(2); //far away to close
 
 					if (local_coords) {
-						dir = un_transform.basis.xform(dir).normalized();
+
+						// will look different from Particles in editor as this is based on the camera in the scenetree
+						// and not the editor camera
+						dir = inv_emission_transform.xform(dir).normalized();
+					} else {
+						dir = dir.normalized();
 					}
 
 					SortArray<int, SortAxis> sorter;
@@ -950,7 +950,7 @@ void CPUParticles::_update_particle_data_buffer() {
 			Transform t = r[idx].transform;
 
 			if (!local_coords) {
-				t = un_transform * t;
+				t = inv_emission_transform * t;
 			}
 
 			if (r[idx].active) {
@@ -1114,6 +1114,46 @@ void CPUParticles::_notification(int p_what) {
 
 		if (processed) {
 			_update_particle_data_buffer();
+		}
+	}
+
+	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
+
+		inv_emission_transform = get_global_transform().affine_inverse();
+
+		if (!local_coords) {
+
+			int pc = particles.size();
+
+			PoolVector<float>::Write w = particle_data.write();
+			PoolVector<Particle>::Read r = particles.read();
+			float *ptr = w.ptr();
+
+			for (int i = 0; i < pc; i++) {
+
+				Transform t = inv_emission_transform * r[i].transform;
+
+				if (r[i].active) {
+					ptr[0] = t.basis.elements[0][0];
+					ptr[1] = t.basis.elements[0][1];
+					ptr[2] = t.basis.elements[0][2];
+					ptr[3] = t.origin.x;
+					ptr[4] = t.basis.elements[1][0];
+					ptr[5] = t.basis.elements[1][1];
+					ptr[6] = t.basis.elements[1][2];
+					ptr[7] = t.origin.y;
+					ptr[8] = t.basis.elements[2][0];
+					ptr[9] = t.basis.elements[2][1];
+					ptr[10] = t.basis.elements[2][2];
+					ptr[11] = t.origin.z;
+				} else {
+					zeromem(ptr, sizeof(float) * 12);
+				}
+
+				ptr += 17;
+			}
+
+			can_update = true;
 		}
 	}
 }
@@ -1392,6 +1432,8 @@ CPUParticles::CPUParticles() {
 	frame_remainder = 0;
 	cycle = 0;
 	redraw = false;
+
+	set_notify_transform(true);
 
 	multimesh = VisualServer::get_singleton()->multimesh_create();
 	VisualServer::get_singleton()->multimesh_set_visible_instances(multimesh, 0);

--- a/scene/3d/cpu_particles.h
+++ b/scene/3d/cpu_particles.h
@@ -116,7 +116,7 @@ private:
 		const Particle *particles;
 
 		bool operator()(int p_a, int p_b) const {
-			return particles[p_a].time < particles[p_b].time;
+			return particles[p_a].time > particles[p_b].time;
 		}
 	};
 
@@ -141,6 +141,8 @@ private:
 	bool local_coords;
 	int fixed_fps;
 	bool fractional_delta;
+
+	Transform inv_emission_transform;
 
 	volatile bool can_update;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/27743

Code graciously donated by Gamblify.

The bug was arising out a situation where the ``global_transform`` of the CPUParticles node was out of sync with the internal ``particle_process``. This became especially apparent when ``fixed_fps`` was set to a low number. 

To understand the issue, you have to consider how CPUParticles previously applied ``local_coords``. Each time the particles updated the individual particle's ``instance_transform`` would be "un-transformed" by taking the ``affine_inverse()`` of the ``global_transform``. The bug arose whenever ``global_transform`` changed before the particles were re-processed. The result is that the particles would slide and then skip at each update. And where the change in position was large (as in #27743), there was a visible stutter. 

The way to fix this is to avoid offsetting the individual ``instance_transform`` of each particle on particle_process by using the same implementation that particles use. To do this, when ``local_coords`` is set, simply ignore the ``WORLD_TRANSFORM`` in the vertex shader and treat the ``instance_transform`` as if it were in world space already. This achieves the same effect as the previous method, only we are avoiding doing a computation instead of nullifying it with another computation. The main benefit is that there is no longer a disconnect between when the ``global_transform`` is updated and when the particle nullifies the effect of the transform. This way, we also avoid performing a transformation on CPU on every particle, every update.

CC: @Keetz, @jesperkondrup, @uldall 