### PR TITLE
Remove some references to unimplemented features in the assetlib

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -77,7 +77,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, int p_rating, const String &p_cost);
+	void configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, const String &p_cost);
 
 	EditorAssetLibraryItem();
 };
@@ -120,7 +120,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, int p_rating, const String &p_cost, int p_version, const String &p_version_string, const String &p_description, const String &p_download_url, const String &p_browse_url, const String &p_sha256_hash);
+	void configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, const String &p_cost, int p_version, const String &p_version_string, const String &p_description, const String &p_download_url, const String &p_browse_url, const String &p_sha256_hash);
 	void add_preview(int p_id, bool p_video, const String &p_url);
 
 	String get_title() { return title; }
@@ -216,7 +216,6 @@ class EditorAssetLibrary : public PanelContainer {
 	};
 
 	enum SortOrder {
-		SORT_RATING,
 		SORT_DOWNLOADS,
 		SORT_NAME,
 		SORT_COST,


### PR DESCRIPTION
This removes rating icons and the associated sorting option as this feature wasn't implemented (and is unlikely to be in the near future).

This also renames "Cost" to "License", as the "cost" field refers to SPDX license names on the Godot Asset Library.