### PR TITLE
BaseButton: Make shortcuts call virtual methods

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -216,9 +216,7 @@ void BaseButton::set_pressed(bool p_pressed) {
 	if (p_pressed) {
 		_unpress_group();
 	}
-	if (toggle_mode) {
-		_toggled(status.pressed);
-	}
+	_toggled(status.pressed);
 
 	update();
 }
@@ -337,9 +335,6 @@ bool BaseButton::is_keep_pressed_outside() const {
 
 void BaseButton::set_shortcut(const Ref<ShortCut> &p_shortcut) {
 
-	if (shortcut.is_null() == p_shortcut.is_null())
-		return;
-
 	shortcut = p_shortcut;
 	set_process_unhandled_input(shortcut.is_valid());
 }
@@ -356,11 +351,10 @@ void BaseButton::_unhandled_input(Ref<InputEvent> p_event) {
 			return; //ignore because of modal window
 
 		if (is_toggle_mode()) {
-			set_pressed(!is_pressed());
-			emit_signal("toggled", is_pressed());
+			set_pressed(!is_pressed()); // Also calls _toggled() internally.
 		}
 
-		emit_signal("pressed");
+		_pressed();
 	}
 }
 


### PR DESCRIPTION
When buttons are not in Toggle Mode, shortcuts used to only trigger the
`pressed` signal, without calling the `_pressed` virtual method,
contrarily to what happens when you click the button.

For Toggle Mode buttons, it did call the `_toggled` virtual method
together with emitting the `toggled` signal *twice*.

This commit harmonizes it all and makes shortcuts behave the same as
mouse clicks or `ui_accept`, for both toggle and non-toggle modes.

Fixes #29604.

----

I briefly tested the editor and the attached MRP, and it seems to work fine, but I'd be glad if others could give it a try too and confirm that the editor and their button-intensive UIs still behave as expected.

MRP: [FullscreenButton.zip](https://github.com/godotengine/godot/files/3281796/FullscreenButton.zip)
Shortcuts on <kbd>F</kbd>, <kbd>G</kbd> and <kbd>H</kbd>.
