### PR TITLE
[2.1] If WASAPI driver not initialized, fail the init

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -243,6 +243,7 @@ Error AudioDriverWASAPI::init() {
 	Error err = init_device();
 	if (err != OK) {
 		ERR_PRINT("WASAPI: init_device error");
+		ERR_FAIL_V(err);
 	}
 
 	active = false;


### PR DESCRIPTION
It prevents those types of error, there is no need to spawn the thread if the initialization has failed:
```
(callstack:[]), (error:WASAPI: GetCurrentPadding error), (error_descr:), (source_file:drivers\wasapi\audio_driver_wasapi.cpp), (source_func:AudioDriverWASAPI::thread_func), (source_line:411), (warning:False) ([])
```