### PR TITLE
Show icons for code completion options

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -216,6 +216,7 @@ struct ScriptCodeCompletionOption {
 	Kind kind;
 	String display;
 	String insert_text;
+	RES icon;
 
 	ScriptCodeCompletionOption() {
 		kind = KIND_PLAIN_TEXT;

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -734,15 +734,54 @@ void CodeTextEditor::_complete_request() {
 	if (entries.size() == 0)
 		return;
 
-	Vector<String> options;
-	options.resize(entries.size());
-	size_t i = 0;
 	for (List<ScriptCodeCompletionOption>::Element *E = entries.front(); E; E = E->next()) {
-		options.write[i] = E->get().insert_text;
-		i++;
+		E->get().icon = _get_completion_icon(E->get());
 	}
+	text_editor->code_complete(entries, forced);
+}
 
-	text_editor->code_complete(options, forced);
+Ref<Texture> CodeTextEditor::_get_completion_icon(const ScriptCodeCompletionOption &p_option) {
+	Ref<Texture> tex;
+	switch (p_option.kind) {
+		case ScriptCodeCompletionOption::KIND_CLASS: {
+			if (has_icon(p_option.display, "EditorIcons")) {
+				tex = get_icon(p_option.display, "EditorIcons");
+			} else {
+				tex = get_icon("Object", "EditorIcons");
+			}
+		} break;
+		case ScriptCodeCompletionOption::KIND_ENUM:
+			tex = get_icon("Enum", "EditorIcons");
+			break;
+		case ScriptCodeCompletionOption::KIND_FILE_PATH:
+			tex = get_icon("File", "EditorIcons");
+			break;
+		case ScriptCodeCompletionOption::KIND_NODE_PATH:
+			tex = get_icon("NodePath", "EditorIcons");
+			break;
+		case ScriptCodeCompletionOption::KIND_VARIABLE:
+			tex = get_icon("Variant", "EditorIcons");
+			break;
+		case ScriptCodeCompletionOption::KIND_CONSTANT:
+			tex = get_icon("MemberConstant", "EditorIcons");
+			break;
+		case ScriptCodeCompletionOption::KIND_MEMBER:
+			tex = get_icon("MemberProperty", "EditorIcons");
+			break;
+		case ScriptCodeCompletionOption::KIND_SIGNAL:
+			tex = get_icon("MemberSignal", "EditorIcons");
+			break;
+		case ScriptCodeCompletionOption::KIND_FUNCTION:
+			tex = get_icon("MemberMethod", "EditorIcons");
+			break;
+		case ScriptCodeCompletionOption::KIND_PLAIN_TEXT:
+			tex = get_icon("CubeMesh", "EditorIcons");
+			break;
+		default:
+			tex = get_icon("String", "EditorIcons");
+			break;
+	}
+	return tex;
 }
 
 void CodeTextEditor::_font_resize_timeout() {

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -162,6 +162,7 @@ class CodeTextEditor : public VBoxContainer {
 
 	void _update_font();
 	void _complete_request();
+	Ref<Texture> _get_completion_icon(const ScriptCodeCompletionOption &p_option);
 	void _font_resize_timeout();
 	bool _add_font_size(int p_delta);
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -255,11 +255,11 @@ private:
 
 	Set<String> completion_prefixes;
 	bool completion_enabled;
-	Vector<String> completion_strings;
-	Vector<String> completion_options;
+	List<ScriptCodeCompletionOption> completion_sources;
+	Vector<ScriptCodeCompletionOption> completion_options;
 	bool completion_active;
 	bool completion_forced;
-	String completion_current;
+	ScriptCodeCompletionOption completion_current;
 	String completion_base;
 	int completion_index;
 	Rect2i completion_rect;
@@ -704,7 +704,7 @@ public:
 	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
 
 	void set_completion(bool p_enabled, const Vector<String> &p_prefixes);
-	void code_complete(const Vector<String> &p_strings, bool p_forced = false);
+	void code_complete(const List<ScriptCodeCompletionOption> &p_strings, bool p_forced = false);
 	void set_code_hint(const String &p_hint);
 	void query_code_comple();
 


### PR DESCRIPTION
The second PR based on #29626 

* Show different icons for different type of completion options

![Peek 2019-06-09 17-42](https://user-images.githubusercontent.com/6964556/59157685-7ebb7580-8ae1-11e9-95c0-2b2179985fa8.gif)
