### PR TITLE
Fixes crash with rigged meshes on some OpenGLES2 devices

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -2418,6 +2418,18 @@ void RasterizerStorageGLES2::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 	}
 	surface->data = array;
 	surface->index_data = p_index_array;
+#else
+	// Even on non-tools builds, a copy of the surface->data is needed in certain circumstances.
+	// Rigged meshes using the USE_SKELETON_SOFTWARE path need to read bone data
+	// from surface->data.
+
+	// if USE_SKELETON_SOFTWARE is active
+	if (!config.float_texture_supported) {
+		// if this geometry is used specifically for skinning
+		if (p_format & (VS::ARRAY_FORMAT_BONES | VS::ARRAY_FORMAT_WEIGHTS))
+			surface->data = array;
+	}
+	// An alternative is to always make a copy of surface->data.
 #endif
 
 	surface->total_data_size += surface->array_byte_size + surface->index_array_byte_size;


### PR DESCRIPTION
Fixes #28298

Non-tools OpenGLES2 devices that use the USE_SKELETON_SOFTWARE path (i.e. do not support float texture) depend on surface->data being set containing the bone IDs and weights (rasterizer_scene_gles2.cpp, line 1456, RasterizerSceneGLES2::_setup_geometry):

```
PoolVector<uint8_t>::Read vertex_array_read = s->data.read();
const uint8_t *vertex_data = vertex_array_read.ptr();
```

 However currently if TOOLS_ENABLED is not defined, surface->data is not stored in main memory in rasterizer_storage_gles2.cpp. This causes a crash in rasterizer_scene_gles2.cpp when a rigged object comes into view.

This fix addresses the specific case of skinned objects when USE_SKELETON_SOFTWARE is active, and stores a copy of the bone data, as is done when TOOLS_ENABLED is defined. This fixes the crash by allowing the same mechanism as on desktop, without adding the memory overhead of storing all vertex data where not required.