### PR TITLE
Add ability to limit maximum/minimum window size.

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -308,12 +308,28 @@ void _OS::set_window_position(const Point2 &p_position) {
 	OS::get_singleton()->set_window_position(p_position);
 }
 
+Size2 _OS::get_max_window_size() const {
+	return OS::get_singleton()->get_max_window_size();
+}
+
+Size2 _OS::get_min_window_size() const {
+	return OS::get_singleton()->get_min_window_size();
+}
+
 Size2 _OS::get_window_size() const {
 	return OS::get_singleton()->get_window_size();
 }
 
 Size2 _OS::get_real_window_size() const {
 	return OS::get_singleton()->get_real_window_size();
+}
+
+void _OS::set_max_window_size(const Size2 &p_size) {
+	OS::get_singleton()->set_max_window_size(p_size);
+}
+
+void _OS::set_min_window_size(const Size2 &p_size) {
+	OS::get_singleton()->set_min_window_size(p_size);
 }
 
 void _OS::set_window_size(const Size2 &p_size) {
@@ -1139,6 +1155,10 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_window_position"), &_OS::get_window_position);
 	ClassDB::bind_method(D_METHOD("set_window_position", "position"), &_OS::set_window_position);
 	ClassDB::bind_method(D_METHOD("get_window_size"), &_OS::get_window_size);
+	ClassDB::bind_method(D_METHOD("get_max_window_size"), &_OS::get_max_window_size);
+	ClassDB::bind_method(D_METHOD("get_min_window_size"), &_OS::get_min_window_size);
+	ClassDB::bind_method(D_METHOD("set_max_window_size", "size"), &_OS::set_max_window_size);
+	ClassDB::bind_method(D_METHOD("set_min_window_size", "size"), &_OS::set_min_window_size);
 	ClassDB::bind_method(D_METHOD("set_window_size", "size"), &_OS::set_window_size);
 	ClassDB::bind_method(D_METHOD("get_window_safe_area"), &_OS::get_window_safe_area);
 	ClassDB::bind_method(D_METHOD("set_window_fullscreen", "enabled"), &_OS::set_window_fullscreen);
@@ -1284,6 +1304,8 @@ void _OS::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "vsync_enabled"), "set_use_vsync", "is_vsync_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "low_processor_usage_mode"), "set_low_processor_usage_mode", "is_in_low_processor_usage_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_screen_on"), "set_keep_screen_on", "is_keep_screen_on");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "min_window_size"), "set_min_window_size", "get_min_window_size");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "max_window_size"), "set_max_window_size", "get_max_window_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "screen_orientation", PROPERTY_HINT_ENUM, "Landscape,Portrait,Reverse Landscape,Reverse Portrait,Sensor Landscape,Sensor Portrait,Sensor"), "set_screen_orientation", "get_screen_orientation");
 	ADD_GROUP("Window", "window_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_borderless"), "set_borderless_window", "get_borderless_window");

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -175,9 +175,13 @@ public:
 	virtual int get_screen_dpi(int p_screen = -1) const;
 	virtual Point2 get_window_position() const;
 	virtual void set_window_position(const Point2 &p_position);
+	virtual Size2 get_max_window_size() const;
+	virtual Size2 get_min_window_size() const;
 	virtual Size2 get_window_size() const;
 	virtual Size2 get_real_window_size() const;
 	virtual Rect2 get_window_safe_area() const;
+	virtual void set_max_window_size(const Size2 &p_size);
+	virtual void set_min_window_size(const Size2 &p_size);
 	virtual void set_window_size(const Size2 &p_size);
 	virtual void set_window_fullscreen(bool p_enabled);
 	virtual bool is_window_fullscreen() const;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -205,8 +205,12 @@ public:
 	virtual int get_screen_dpi(int p_screen = -1) const { return 72; }
 	virtual Point2 get_window_position() const { return Vector2(); }
 	virtual void set_window_position(const Point2 &p_position) {}
+	virtual Size2 get_max_window_size() const { return Size2(); };
+	virtual Size2 get_min_window_size() const { return Size2(); };
 	virtual Size2 get_window_size() const = 0;
 	virtual Size2 get_real_window_size() const { return get_window_size(); }
+	virtual void set_min_window_size(const Size2 p_size) {}
+	virtual void set_max_window_size(const Size2 p_size) {}
 	virtual void set_window_size(const Size2 p_size) {}
 	virtual void set_window_fullscreen(bool p_enabled) {}
 	virtual bool is_window_fullscreen() const { return true; }

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -810,6 +810,12 @@
 		<member name="low_processor_usage_mode" type="bool" setter="set_low_processor_usage_mode" getter="is_in_low_processor_usage_mode">
 			If [code]true[/code], the engine optimizes for low processor usage by only refreshing the screen if needed. Can improve battery consumption on mobile.
 		</member>
+		<member name="min_window_size" type="Vector2" setter="set_min_window_size" getter="get_min_window_size">
+			The minimum size of the window (without counting window manager decorations). Does not affect fullscreen mode. Set to [code](0, 0)[/code] to reset to the system default value.
+		</member>
+		<member name="max_window_size" type="Vector2" setter="set_max_window_size" getter="get_max_window_size">
+			The maximum size of the window (without counting window manager decorations). Does not affect fullscreen mode. Set to [code](0, 0)[/code] to reset to the system default value.
+		</member>
 		<member name="screen_orientation" type="int" setter="set_screen_orientation" getter="get_screen_orientation" enum="_OS.ScreenOrientation">
 			The current screen orientation.
 		</member>

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -134,6 +134,9 @@ public:
 	String im_text;
 	Point2 im_selection;
 
+	Size2 min_size;
+	Size2 max_size;
+
 	PowerOSX *power_manager;
 
 	CrashHandler crash_handler;
@@ -232,6 +235,10 @@ public:
 
 	virtual Point2 get_window_position() const;
 	virtual void set_window_position(const Point2 &p_position);
+	virtual Size2 get_max_window_size() const;
+	virtual Size2 get_min_window_size() const;
+	virtual void set_min_window_size(const Size2 p_size);
+	virtual void set_max_window_size(const Size2 p_size);
 	virtual void set_window_size(const Size2 p_size);
 	virtual void set_window_fullscreen(bool p_enabled);
 	virtual bool is_window_fullscreen() const;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -353,7 +353,23 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 
 			return 0; // Return To The Message Loop
 		}
-
+		case WM_GETMINMAXINFO: {
+			if (video_mode.resizable && !video_mode.fullscreen) {
+				Size2 decor = get_real_window_size() - get_window_size(); // Size of window decorations
+				MINMAXINFO *min_max_info = (MINMAXINFO *)lParam;
+				if (min_size != Size2()) {
+					min_max_info->ptMinTrackSize.x = min_size.x + decor.x;
+					min_max_info->ptMinTrackSize.y = min_size.y + decor.y;
+				}
+				if (max_size != Size2()) {
+					min_max_info->ptMaxTrackSize.x = max_size.x + decor.x;
+					min_max_info->ptMaxTrackSize.y = max_size.y + decor.y;
+				}
+				return 0;
+			} else {
+				break;
+			}
+		}
 		case WM_PAINT:
 
 			Main::force_redraw();
@@ -1769,6 +1785,7 @@ void OS_Windows::set_window_position(const Point2 &p_position) {
 	last_pos = p_position;
 	update_real_mouse_position();
 }
+
 Size2 OS_Windows::get_window_size() const {
 
 	if (minimized) {
@@ -1781,6 +1798,33 @@ Size2 OS_Windows::get_window_size() const {
 	}
 	return Size2();
 }
+
+Size2 OS_Windows::get_max_window_size() const {
+	return max_size;
+}
+
+Size2 OS_Windows::get_min_window_size() const {
+	return min_size;
+}
+
+void OS_Windows::set_min_window_size(const Size2 p_size) {
+
+	if ((p_size != Size2()) && (max_size != Size2()) && ((p_size.x > max_size.x) || (p_size.y > max_size.y))) {
+		WARN_PRINT("Minimum window size can't be larger than maximum window size!");
+		return;
+	}
+	min_size = p_size;
+}
+
+void OS_Windows::set_max_window_size(const Size2 p_size) {
+
+	if ((p_size != Size2()) && ((p_size.x < min_size.x) || (p_size.y < min_size.y))) {
+		WARN_PRINT("Maximum window size can't be smaller than minimum window size!");
+		return;
+	}
+	max_size = p_size;
+}
+
 Size2 OS_Windows::get_real_window_size() const {
 
 	RECT r;
@@ -1789,6 +1833,7 @@ Size2 OS_Windows::get_real_window_size() const {
 	}
 	return Size2();
 }
+
 void OS_Windows::set_window_size(const Size2 p_size) {
 
 	int w = p_size.width;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -124,6 +124,9 @@ class OS_Windows : public OS {
 
 	HCURSOR hCursor;
 
+	Size2 min_size;
+	Size2 max_size;
+
 	Size2 window_rect;
 	VideoMode video_mode;
 	bool preserve_window_size = false;
@@ -236,6 +239,10 @@ public:
 	virtual void set_window_position(const Point2 &p_position);
 	virtual Size2 get_window_size() const;
 	virtual Size2 get_real_window_size() const;
+	virtual Size2 get_max_window_size() const;
+	virtual Size2 get_min_window_size() const;
+	virtual void set_min_window_size(const Size2 p_size);
+	virtual void set_max_window_size(const Size2 p_size);
 	virtual void set_window_size(const Size2 p_size);
 	virtual void set_window_fullscreen(bool p_enabled);
 	virtual bool is_window_fullscreen() const;

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -119,6 +119,9 @@ class OS_X11 : public OS_Unix {
 	bool im_active;
 	Vector2 im_position;
 
+	Size2 min_size;
+	Size2 max_size;
+
 	Point2 last_mouse_pos;
 	bool last_mouse_pos_valid;
 	Point2i last_click_pos;
@@ -265,6 +268,10 @@ public:
 	virtual void set_window_position(const Point2 &p_position);
 	virtual Size2 get_window_size() const;
 	virtual Size2 get_real_window_size() const;
+	virtual Size2 get_max_window_size() const;
+	virtual Size2 get_min_window_size() const;
+	virtual void set_min_window_size(const Size2 p_size);
+	virtual void set_max_window_size(const Size2 p_size);
 	virtual void set_window_size(const Size2 p_size);
 	virtual void set_window_fullscreen(bool p_enabled);
 	virtual bool is_window_fullscreen() const;


### PR DESCRIPTION
Adds `OS.min_window_size` and `OS.max_window_size` properties to control window resizing limits.

Implemented for macOS, Windows and Linux/X11.

*Demo project: [win_max_min_size.zip](https://github.com/godotengine/godot/files/3286006/win_max_min_size.zip); https://streamable.com/ibf3s*

_Bugsquad edit_: Fixes #14806