### PR TITLE
Add ability to specify font size for RichTextLabel

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -508,6 +508,9 @@ void EditorHelp::_update_doc() {
 
 			_add_text(cd.properties[i].name);
 
+			class_desc->pop();
+			class_desc->pop();
+
 			if (describe) {
 				class_desc->pop();
 				property_descr = true;
@@ -524,9 +527,6 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text("]");
 				class_desc->pop();
 			}
-
-			class_desc->pop();
-			class_desc->pop();
 
 			class_desc->pop();
 		}

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -61,6 +61,7 @@ public:
 		ITEM_IMAGE,
 		ITEM_NEWLINE,
 		ITEM_FONT,
+		ITEM_FONT_SCALE,
 		ITEM_COLOR,
 		ITEM_UNDERLINE,
 		ITEM_STRIKETHROUGH,
@@ -155,6 +156,12 @@ private:
 	struct ItemFont : public Item {
 		Ref<Font> font;
 		ItemFont() { type = ITEM_FONT; }
+	};
+
+	struct ItemScaleFont : public Item {
+
+		real_t scale;
+		ItemScaleFont() { type = ITEM_FONT_SCALE; }
 	};
 
 	struct ItemColor : public Item {
@@ -372,6 +379,7 @@ private:
 	void _find_click(ItemFrame *p_frame, const Point2i &p_click, Item **r_click_item = NULL, int *r_click_char = NULL, bool *r_outside = NULL);
 
 	Ref<Font> _find_font(Item *p_item);
+	real_t _find_font_scale(Item *p_item);
 	int _find_margin(Item *p_item, const Ref<Font> &p_base_font);
 	Align _find_align(Item *p_item);
 	Color _find_color(Item *p_item, const Color &p_default_color);
@@ -416,6 +424,7 @@ public:
 	void push_bold_italics();
 	void push_italics();
 	void push_mono();
+	void push_font_scale(real_t scale);
 	void push_color(const Color &p_color);
 	void push_underline();
 	void push_strikethrough();

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -192,7 +192,10 @@ public:
 
 	Size2 get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks) const;
 
-	float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks, bool p_advance_only = false) const;
+	float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks, bool p_advance_only = false) const {
+		return draw_char_scaled(p_canvas_item, p_pos, 1.0, p_char, p_next, p_modulate, p_fallbacks, p_advance_only);
+	}
+	float draw_char_scaled(RID p_canvas_item, const Point2 &p_pos, float p_scale, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks, bool p_advance_only = false) const;
 
 	void set_texture_flags(uint32_t p_flags);
 	void update_oversampling();
@@ -283,7 +286,7 @@ public:
 
 	virtual bool has_outline() const;
 
-	virtual float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next = 0, const Color &p_modulate = Color(1, 1, 1), bool p_outline = false) const;
+	virtual float draw_char_scaled(RID p_canvas_item, const Point2 &p_pos, float p_scale, CharType p_char, CharType p_next = 0, const Color &p_modulate = Color(1, 1, 1), bool p_outline = false) const;
 
 	SelfList<DynamicFont> font_list;
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -540,26 +540,26 @@ Ref<BitmapFont> BitmapFont::get_fallback() const {
 	return fallback;
 }
 
-float BitmapFont::draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, bool p_outline) const {
+float BitmapFont::draw_char_scaled(RID p_canvas_item, const Point2 &p_pos, float p_scale, CharType p_char, CharType p_next, const Color &p_modulate, bool p_outline) const {
 
 	const Character *c = char_map.getptr(p_char);
 
 	if (!c) {
 		if (fallback.is_valid())
-			return fallback->draw_char(p_canvas_item, p_pos, p_char, p_next, p_modulate, p_outline);
+			return fallback->draw_char_scaled(p_canvas_item, p_pos, p_scale, p_char, p_next, p_modulate, p_outline);
 		return 0;
 	}
 
 	ERR_FAIL_COND_V(c->texture_idx < -1 || c->texture_idx >= textures.size(), 0);
 	if (!p_outline && c->texture_idx != -1) {
 		Point2 cpos = p_pos;
-		cpos.x += c->h_align;
-		cpos.y -= ascent;
-		cpos.y += c->v_align;
-		VisualServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, Rect2(cpos, c->rect.size), textures[c->texture_idx]->get_rid(), c->rect, p_modulate, false, RID(), false);
+		cpos.x += c->h_align * p_scale;
+		cpos.y -= ascent * p_scale;
+		cpos.y += c->v_align * p_scale;
+		VisualServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, Rect2(cpos, c->rect.size * p_scale), textures[c->texture_idx]->get_rid(), c->rect, p_modulate, false, RID(), false);
 	}
 
-	return get_char_size(p_char, p_next).width;
+	return get_char_size(p_char, p_next).width * p_scale;
 }
 
 Size2 BitmapFont::get_char_size(CharType p_char, CharType p_next) const {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -58,7 +58,10 @@ public:
 	void draw_halign(RID p_canvas_item, const Point2 &p_pos, HAlign p_align, float p_width, const String &p_text, const Color &p_modulate = Color(1, 1, 1), const Color &p_outline_modulate = Color(1, 1, 1)) const;
 
 	virtual bool has_outline() const { return false; }
-	virtual float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next = 0, const Color &p_modulate = Color(1, 1, 1), bool p_outline = false) const = 0;
+	virtual float draw_char_scaled(RID p_canvas_item, const Point2 &p_pos, float p_scale, CharType p_char, CharType p_next = 0, const Color &p_modulate = Color(1, 1, 1), bool p_outline = false) const = 0;
+	float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next = 0, const Color &p_modulate = Color(1, 1, 1), bool p_outline = false) const {
+		return draw_char_scaled(p_canvas_item, p_pos, 1.0, p_char, p_next, p_modulate, p_outline);
+	}
 
 	void update_changes();
 	Font();
@@ -73,6 +76,7 @@ class FontDrawer {
 	struct PendingDraw {
 		RID canvas_item;
 		Point2 pos;
+		float scale;
 		CharType chr;
 		CharType next;
 		Color modulate;
@@ -88,17 +92,21 @@ public:
 	}
 
 	float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next = 0, const Color &p_modulate = Color(1, 1, 1)) {
+		return draw_char_scaled(p_canvas_item, p_pos, 1.0, p_char, p_next, p_modulate);
+	}
+
+	float draw_char_scaled(RID p_canvas_item, const Point2 &p_pos, float p_scale, CharType p_char, CharType p_next = 0, const Color &p_modulate = Color(1, 1, 1)) {
 		if (has_outline) {
-			PendingDraw draw = { p_canvas_item, p_pos, p_char, p_next, p_modulate };
+			PendingDraw draw = { p_canvas_item, p_pos, p_scale, p_char, p_next, p_modulate };
 			pending_draws.push_back(draw);
 		}
-		return font->draw_char(p_canvas_item, p_pos, p_char, p_next, has_outline ? outline_color : p_modulate, has_outline);
+		return font->draw_char_scaled(p_canvas_item, p_pos, p_scale, p_char, p_next, has_outline ? outline_color : p_modulate, has_outline);
 	}
 
 	~FontDrawer() {
 		for (int i = 0; i < pending_draws.size(); ++i) {
 			const PendingDraw &draw = pending_draws[i];
-			font->draw_char(draw.canvas_item, draw.pos, draw.chr, draw.next, draw.modulate, false);
+			font->draw_char_scaled(draw.canvas_item, draw.pos, draw.scale, draw.chr, draw.next, draw.modulate, false);
 		}
 	}
 };
@@ -192,7 +200,7 @@ public:
 	void set_distance_field_hint(bool p_distance_field);
 	bool is_distance_field_hint() const;
 
-	float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next = 0, const Color &p_modulate = Color(1, 1, 1), bool p_outline = false) const;
+	float draw_char_scaled(RID p_canvas_item, const Point2 &p_pos, float p_scale, CharType p_char, CharType p_next = 0, const Color &p_modulate = Color(1, 1, 1), bool p_outline = false) const;
 
 	BitmapFont();
 	~BitmapFont();


### PR DESCRIPTION
Label has a new property to specify the font size and RichTextLabel has a new item to do the same, as well as BBCode tag `[size=N]some text at font size N[/size]`

Right now this works by using a new `draw_char_scaled` function inside the Font which allows you to draw a char at a specific scale. This simply scales the texture being drawn, which means that using font sizes that diverge too much from the original font size in the Font resource will create not so great looking text, but it's good to allow for some range.

*Bugsquad edit:* Fixes #5557.