### PR TITLE
Add Language Server Protocol for GDScript

### DIFF
--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -9,3 +9,4 @@ env_gdscript.add_source_files(env.modules_sources, "*.cpp")
 
 if env['tools']:
 	env_gdscript.add_source_files(env.modules_sources, "./editor/*.cpp")
+	env_gdscript.add_source_files(env.modules_sources, "./language_server/*.cpp")

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8255,6 +8255,10 @@ int GDScriptParser::get_error_column() const {
 	return error_column;
 }
 
+bool GDScriptParser::has_error() const {
+	return error_set;
+}
+
 Error GDScriptParser::_parse(const String &p_base_path) {
 
 	base_path = p_base_path;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -632,6 +632,7 @@ private:
 	Error _parse(const String &p_base_path);
 
 public:
+	bool has_error() const;
 	String get_error() const;
 	int get_error_line() const;
 	int get_error_column() const;

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -1,0 +1,237 @@
+/*************************************************************************/
+/*  gdscript_extend_parser.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_extend_parser.h"
+#include "../gdscript.h"
+
+void ExtendGDScriptParser::update_diagnostics() {
+
+	diagnostics.clear();
+
+	if (has_error()) {
+		lsp::Diagnostic diagnostic;
+		diagnostic.severity = lsp::DiagnosticSeverity::Error;
+		diagnostic.message = get_error();
+		diagnostic.source = "gdscript";
+		diagnostic.code = -1;
+		lsp::Range range;
+		lsp::Position pos;
+		int line = get_error_line() - 1;
+		const String &line_text = get_lines()[line];
+		pos.line = line;
+		pos.character = line_text.length() - line_text.strip_edges(true, false).length();
+		range.start = pos;
+		range.end = range.start;
+		range.end.character = line_text.strip_edges(false).length();
+		diagnostic.range = range;
+		diagnostics.push_back(diagnostic);
+	}
+
+	const List<GDScriptWarning> &warnings = get_warnings();
+	for (const List<GDScriptWarning>::Element *E = warnings.front(); E; E = E->next()) {
+		const GDScriptWarning &warning = E->get();
+		lsp::Diagnostic diagnostic;
+		diagnostic.severity = lsp::DiagnosticSeverity::Warning;
+		diagnostic.message = warning.get_message();
+		diagnostic.source = "gdscript";
+		diagnostic.code = warning.code;
+		lsp::Range range;
+		lsp::Position pos;
+		int line = warning.line - 1;
+		const String &line_text = get_lines()[line];
+		pos.line = line;
+		pos.character = line_text.length() - line_text.strip_edges(true, false).length();
+		range.start = pos;
+		range.end = pos;
+		range.end.character = line_text.strip_edges(false).length();
+		diagnostic.range = range;
+		diagnostics.push_back(diagnostic);
+	}
+}
+
+void ExtendGDScriptParser::update_symbols() {
+	const GDScriptParser::Node *head = get_parse_tree();
+	if (const GDScriptParser::ClassNode *gdclass = dynamic_cast<const GDScriptParser::ClassNode *>(head)) {
+		parse_class_symbol(gdclass, class_symbol);
+	}
+}
+
+void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p_class, lsp::DocumentSymbol &r_symbol) {
+	r_symbol.children.clear();
+	r_symbol.name = p_class->name;
+	if (r_symbol.name.empty())
+		r_symbol.name = path.get_file();
+	r_symbol.kind = lsp::SymbolKind::Class;
+	r_symbol.detail = p_class->get_datatype().to_string();
+	r_symbol.deprecated = false;
+	r_symbol.range.start.line = p_class->line - 1;
+	r_symbol.range.start.character = p_class->column;
+	r_symbol.range.end.line = p_class->end_line - 1;
+	r_symbol.selectionRange.start.line = r_symbol.range.start.line;
+
+	for (int i = 0; i < p_class->variables.size(); ++i) {
+
+		const GDScriptParser::ClassNode::Member &m = p_class->variables[i];
+
+		lsp::DocumentSymbol symbol;
+		symbol.name = m.identifier;
+		symbol.kind = lsp::SymbolKind::Variable;
+		symbol.detail = m.data_type.to_string();
+		symbol.deprecated = false;
+		const int line = m.line - 1;
+		symbol.range.start.line = line;
+		symbol.range.start.character = lines[line].length() - lines[line].strip_edges(true, false).length();
+		symbol.range.end.line = line;
+		symbol.range.end.character = lines[line].length();
+		symbol.selectionRange.start.line = symbol.range.start.line;
+
+		r_symbol.children.push_back(symbol);
+	}
+
+	for (int i = 0; i < p_class->_signals.size(); ++i) {
+		const GDScriptParser::ClassNode::Signal &signal = p_class->_signals[i];
+
+		lsp::DocumentSymbol symbol;
+		symbol.name = signal.name;
+		symbol.kind = lsp::SymbolKind::Event;
+		symbol.deprecated = false;
+		const int line = signal.line - 1;
+		symbol.range.start.line = line;
+		symbol.range.start.character = lines[line].length() - lines[line].strip_edges(true, false).length();
+		symbol.range.end.line = symbol.range.start.line;
+		symbol.range.end.character = lines[line].length();
+		symbol.selectionRange.start.line = symbol.range.start.line;
+
+		r_symbol.children.push_back(symbol);
+	}
+
+	for (Map<StringName, GDScriptParser::ClassNode::Constant>::Element *E = p_class->constant_expressions.front(); E; E = E->next()) {
+		lsp::DocumentSymbol symbol;
+		symbol.name = E->key();
+		symbol.kind = lsp::SymbolKind::Constant;
+		symbol.deprecated = false;
+		const int line = E->get().expression->line - 1;
+		symbol.range.start.line = line;
+		symbol.range.start.character = E->get().expression->column;
+		symbol.range.end.line = symbol.range.start.line;
+		symbol.range.end.character = lines[line].length();
+		symbol.selectionRange.start.line = symbol.range.start.line;
+
+		r_symbol.children.push_back(symbol);
+	}
+
+	for (int i = 0; i < p_class->functions.size(); ++i) {
+		const GDScriptParser::FunctionNode *func = p_class->functions[i];
+		lsp::DocumentSymbol symbol;
+		parse_function_symbol(func, symbol);
+		r_symbol.children.push_back(symbol);
+	}
+
+	for (int i = 0; i < p_class->static_functions.size(); ++i) {
+		const GDScriptParser::FunctionNode *func = p_class->static_functions[i];
+		lsp::DocumentSymbol symbol;
+		parse_function_symbol(func, symbol);
+		r_symbol.children.push_back(symbol);
+	}
+
+	for (int i = 0; i < p_class->subclasses.size(); ++i) {
+		const GDScriptParser::ClassNode *subclass = p_class->subclasses[i];
+		lsp::DocumentSymbol symbol;
+		parse_class_symbol(subclass, symbol);
+		r_symbol.children.push_back(symbol);
+	}
+}
+
+void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionNode *p_func, lsp::DocumentSymbol &r_symbol) {
+	r_symbol.name = p_func->name;
+	r_symbol.kind = lsp::SymbolKind::Function;
+	r_symbol.detail = p_func->get_datatype().to_string();
+	r_symbol.deprecated = false;
+	const int line = p_func->line - 1;
+	r_symbol.range.start.line = line;
+	r_symbol.range.start.character = p_func->column;
+	r_symbol.range.end.line = MAX(p_func->body->end_line - 2, p_func->body->line);
+	r_symbol.range.end.character = lines[r_symbol.range.end.line].length();
+	r_symbol.selectionRange.start.line = r_symbol.range.start.line;
+
+	for (const Map<StringName, LocalVarNode *>::Element *E = p_func->body->variables.front(); E; E = E->next()) {
+		lsp::DocumentSymbol symbol;
+		symbol.name = E->key();
+		symbol.kind = lsp::SymbolKind::Variable;
+		symbol.range.start.line = E->get()->line - 1;
+		symbol.range.start.character = E->get()->column;
+		symbol.range.end.line = symbol.range.start.line;
+		symbol.range.end.character = lines[symbol.range.end.line].length();
+		r_symbol.children.push_back(symbol);
+	}
+	for (int i = 0; i < p_func->arguments.size(); i++) {
+		lsp::DocumentSymbol symbol;
+		symbol.kind = lsp::SymbolKind::Variable;
+		symbol.name = p_func->arguments[i];
+		symbol.range.start.line = p_func->body->line - 1;
+		symbol.range.start.character = p_func->body->column;
+		symbol.range.end = symbol.range.start;
+		r_symbol.children.push_back(symbol);
+	}
+}
+
+String ExtendGDScriptParser::get_text_for_completion(const lsp::Position &p_cursor) {
+
+	String longthing;
+	int len = lines.size();
+	for (int i = 0; i < len; i++) {
+
+		if (i == p_cursor.line) {
+			longthing += lines[i].substr(0, p_cursor.character);
+			longthing += String::chr(0xFFFF); //not unicode, represents the cursor
+			longthing += lines[i].substr(p_cursor.character, lines[i].size());
+		} else {
+
+			longthing += lines[i];
+		}
+
+		if (i != len - 1)
+			longthing += "\n";
+	}
+
+	return longthing;
+}
+
+Error ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
+	path = p_path;
+	code = p_code;
+	lines = p_code.split("\n");
+
+	Error err = GDScriptParser::parse(p_code, p_path.get_base_dir(), false, p_path, false, NULL, false);
+	update_diagnostics();
+	update_symbols();
+
+	return err;
+}

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -30,6 +30,9 @@
 
 #include "gdscript_extend_parser.h"
 #include "../gdscript.h"
+#include "core/io/json.h"
+#include "gdscript_language_protocol.h"
+#include "gdscript_workspace.h"
 
 void ExtendGDScriptParser::update_diagnostics() {
 
@@ -43,7 +46,7 @@ void ExtendGDScriptParser::update_diagnostics() {
 		diagnostic.code = -1;
 		lsp::Range range;
 		lsp::Position pos;
-		int line = get_error_line() - 1;
+		int line = LINE_NUMBER_TO_INDEX(get_error_line());
 		const String &line_text = get_lines()[line];
 		pos.line = line;
 		pos.character = line_text.length() - line_text.strip_edges(true, false).length();
@@ -64,7 +67,7 @@ void ExtendGDScriptParser::update_diagnostics() {
 		diagnostic.code = warning.code;
 		lsp::Range range;
 		lsp::Position pos;
-		int line = warning.line - 1;
+		int line = LINE_NUMBER_TO_INDEX(warning.line);
 		const String &line_text = get_lines()[line];
 		pos.line = line;
 		pos.character = line_text.length() - line_text.strip_edges(true, false).length();
@@ -84,17 +87,23 @@ void ExtendGDScriptParser::update_symbols() {
 }
 
 void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p_class, lsp::DocumentSymbol &r_symbol) {
+
+	const String uri = get_uri();
+
+	r_symbol.uri = uri;
+	r_symbol.script_path = path;
 	r_symbol.children.clear();
 	r_symbol.name = p_class->name;
 	if (r_symbol.name.empty())
 		r_symbol.name = path.get_file();
 	r_symbol.kind = lsp::SymbolKind::Class;
-	r_symbol.detail = p_class->get_datatype().to_string();
 	r_symbol.deprecated = false;
-	r_symbol.range.start.line = p_class->line - 1;
+	r_symbol.range.start.line = LINE_NUMBER_TO_INDEX(p_class->line);
 	r_symbol.range.start.character = p_class->column;
-	r_symbol.range.end.line = p_class->end_line - 1;
+	r_symbol.range.end.line = LINE_NUMBER_TO_INDEX(p_class->end_line);
 	r_symbol.selectionRange.start.line = r_symbol.range.start.line;
+	r_symbol.detail = "class " + r_symbol.name;
+	r_symbol.documentation = parse_documentation(LINE_NUMBER_TO_INDEX(p_class->line));
 
 	for (int i = 0; i < p_class->variables.size(); ++i) {
 
@@ -103,14 +112,22 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 		lsp::DocumentSymbol symbol;
 		symbol.name = m.identifier;
 		symbol.kind = lsp::SymbolKind::Variable;
-		symbol.detail = m.data_type.to_string();
 		symbol.deprecated = false;
-		const int line = m.line - 1;
+		const int line = LINE_NUMBER_TO_INDEX(m.line);
 		symbol.range.start.line = line;
 		symbol.range.start.character = lines[line].length() - lines[line].strip_edges(true, false).length();
 		symbol.range.end.line = line;
 		symbol.range.end.character = lines[line].length();
 		symbol.selectionRange.start.line = symbol.range.start.line;
+		symbol.detail = "var " + m.identifier;
+		if (m.data_type.kind != GDScriptParser::DataType::UNRESOLVED) {
+			symbol.detail += ": " + m.data_type.to_string();
+		}
+		symbol.detail += " = " + String(m.default_value);
+
+		symbol.documentation = parse_documentation(line);
+		symbol.uri = uri;
+		symbol.script_path = path;
 
 		r_symbol.children.push_back(symbol);
 	}
@@ -122,27 +139,49 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 		symbol.name = signal.name;
 		symbol.kind = lsp::SymbolKind::Event;
 		symbol.deprecated = false;
-		const int line = signal.line - 1;
+		const int line = LINE_NUMBER_TO_INDEX(signal.line);
 		symbol.range.start.line = line;
 		symbol.range.start.character = lines[line].length() - lines[line].strip_edges(true, false).length();
 		symbol.range.end.line = symbol.range.start.line;
 		symbol.range.end.character = lines[line].length();
 		symbol.selectionRange.start.line = symbol.range.start.line;
+		symbol.documentation = parse_documentation(line);
+		symbol.uri = uri;
+		symbol.script_path = path;
+		symbol.detail = "signal " + signal.name + "(";
+		for (int j = 0; j < signal.arguments.size(); j++) {
+			if (j > 0) {
+				symbol.detail += ", ";
+			}
+			symbol.detail += signal.arguments[j];
+		}
+		symbol.detail += ")";
 
 		r_symbol.children.push_back(symbol);
 	}
 
 	for (Map<StringName, GDScriptParser::ClassNode::Constant>::Element *E = p_class->constant_expressions.front(); E; E = E->next()) {
 		lsp::DocumentSymbol symbol;
+		const GDScriptParser::ClassNode::Constant &c = E->value();
+		const GDScriptParser::ConstantNode *node = dynamic_cast<const GDScriptParser::ConstantNode *>(c.expression);
 		symbol.name = E->key();
 		symbol.kind = lsp::SymbolKind::Constant;
 		symbol.deprecated = false;
-		const int line = E->get().expression->line - 1;
+		const int line = LINE_NUMBER_TO_INDEX(E->get().expression->line);
 		symbol.range.start.line = line;
 		symbol.range.start.character = E->get().expression->column;
 		symbol.range.end.line = symbol.range.start.line;
 		symbol.range.end.character = lines[line].length();
 		symbol.selectionRange.start.line = symbol.range.start.line;
+		symbol.documentation = parse_documentation(line);
+		symbol.uri = uri;
+		symbol.script_path = path;
+
+		symbol.detail = "const " + symbol.name;
+		if (c.type.kind != GDScriptParser::DataType::UNRESOLVED) {
+			symbol.detail += ": " + c.type.to_string();
+		}
+		symbol.detail += " = " + String(node->value);
 
 		r_symbol.children.push_back(symbol);
 	}
@@ -170,39 +209,120 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 }
 
 void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionNode *p_func, lsp::DocumentSymbol &r_symbol) {
+
+	const String uri = get_uri();
+
 	r_symbol.name = p_func->name;
 	r_symbol.kind = lsp::SymbolKind::Function;
-	r_symbol.detail = p_func->get_datatype().to_string();
+	r_symbol.detail = "func " + p_func->name + "(";
 	r_symbol.deprecated = false;
-	const int line = p_func->line - 1;
+	const int line = LINE_NUMBER_TO_INDEX(p_func->line);
 	r_symbol.range.start.line = line;
 	r_symbol.range.start.character = p_func->column;
 	r_symbol.range.end.line = MAX(p_func->body->end_line - 2, p_func->body->line);
 	r_symbol.range.end.character = lines[r_symbol.range.end.line].length();
 	r_symbol.selectionRange.start.line = r_symbol.range.start.line;
+	r_symbol.documentation = GDScriptWorkspace::marked_documentation(parse_documentation(line));
+	r_symbol.uri = uri;
+	r_symbol.script_path = path;
 
-	for (const Map<StringName, LocalVarNode *>::Element *E = p_func->body->variables.front(); E; E = E->next()) {
-		lsp::DocumentSymbol symbol;
-		symbol.name = E->key();
-		symbol.kind = lsp::SymbolKind::Variable;
-		symbol.range.start.line = E->get()->line - 1;
-		symbol.range.start.character = E->get()->column;
-		symbol.range.end.line = symbol.range.start.line;
-		symbol.range.end.character = lines[symbol.range.end.line].length();
-		r_symbol.children.push_back(symbol);
-	}
+	String arguments;
 	for (int i = 0; i < p_func->arguments.size(); i++) {
 		lsp::DocumentSymbol symbol;
 		symbol.kind = lsp::SymbolKind::Variable;
 		symbol.name = p_func->arguments[i];
-		symbol.range.start.line = p_func->body->line - 1;
+		symbol.range.start.line = LINE_NUMBER_TO_INDEX(p_func->body->line);
 		symbol.range.start.character = p_func->body->column;
 		symbol.range.end = symbol.range.start;
+		symbol.uri = uri;
+		symbol.script_path = path;
+		r_symbol.children.push_back(symbol);
+		if (i > 0) {
+			arguments += ", ";
+		}
+		arguments += String(p_func->arguments[i]);
+		if (p_func->argument_types[i].kind != GDScriptParser::DataType::UNRESOLVED) {
+			arguments += ": " + p_func->argument_types[i].to_string();
+		}
+		int default_value_idx = i - (p_func->arguments.size() - p_func->default_values.size());
+		if (default_value_idx >= 0) {
+			const GDScriptParser::ConstantNode *const_node = dynamic_cast<const GDScriptParser::ConstantNode *>(p_func->default_values[default_value_idx]);
+			if (const_node == NULL) {
+				const GDScriptParser::OperatorNode *operator_node = dynamic_cast<const GDScriptParser::OperatorNode *>(p_func->default_values[default_value_idx]);
+				if (operator_node) {
+					const_node = dynamic_cast<const GDScriptParser::ConstantNode *>(operator_node->next);
+				}
+			}
+
+			if (const_node) {
+				String value = JSON::print(const_node->value);
+				arguments += " = " + value;
+			}
+		}
+	}
+	r_symbol.detail += arguments + ")";
+	if (p_func->return_type.kind != GDScriptParser::DataType::UNRESOLVED) {
+		r_symbol.detail += " -> " + p_func->return_type.to_string();
+	}
+
+	for (const Map<StringName, LocalVarNode *>::Element *E = p_func->body->variables.front(); E; E = E->next()) {
+		lsp::DocumentSymbol symbol;
+		const GDScriptParser::LocalVarNode *var = E->value();
+		symbol.name = E->key();
+		symbol.kind = lsp::SymbolKind::Variable;
+		symbol.range.start.line = LINE_NUMBER_TO_INDEX(E->get()->line);
+		symbol.range.start.character = E->get()->column;
+		symbol.range.end.line = symbol.range.start.line;
+		symbol.range.end.character = lines[symbol.range.end.line].length();
+		symbol.uri = uri;
+		symbol.script_path = path;
+		symbol.detail = "var " + symbol.name;
+		if (var->datatype.kind != GDScriptParser::DataType::UNRESOLVED) {
+			symbol.detail += ": " + var->datatype.to_string();
+		}
+		symbol.documentation = GDScriptWorkspace::marked_documentation(parse_documentation(line));
 		r_symbol.children.push_back(symbol);
 	}
 }
 
-String ExtendGDScriptParser::get_text_for_completion(const lsp::Position &p_cursor) {
+String ExtendGDScriptParser::parse_documentation(int p_line) {
+	ERR_FAIL_INDEX_V(p_line, lines.size(), String());
+
+	List<String> doc_lines;
+
+	// inline comment
+	String inline_comment = lines[p_line];
+	int comment_start = inline_comment.find("#");
+	if (comment_start != -1) {
+		inline_comment = inline_comment.substr(comment_start, inline_comment.length());
+		if (inline_comment.length() > 1) {
+			doc_lines.push_back(inline_comment.substr(1, inline_comment.length()));
+		}
+	}
+
+	// upper line comments
+	for (int i = p_line - 1; i >= 0; --i) {
+		String line_comment = lines[i].strip_edges(true, false);
+		if (line_comment.begins_with("#")) {
+			if (line_comment.length() > 1) {
+				doc_lines.push_front(line_comment.substr(1, line_comment.length()));
+			} else {
+				doc_lines.push_front("");
+			}
+		} else {
+			break;
+		}
+	}
+
+	String doc;
+	for (List<String>::Element *E = doc_lines.front(); E; E = E->next()) {
+		String content = E->get();
+		doc += content + "\n";
+	}
+	return doc;
+}
+
+String ExtendGDScriptParser::get_text_for_completion(const lsp::Position &p_cursor) const {
 
 	String longthing;
 	int len = lines.size();
@@ -224,6 +344,164 @@ String ExtendGDScriptParser::get_text_for_completion(const lsp::Position &p_curs
 	return longthing;
 }
 
+String ExtendGDScriptParser::get_text_for_lookup_symbol(const lsp::Position &p_cursor, const String &p_symbol, bool p_func_requred) const {
+	String longthing;
+	int len = lines.size();
+	for (int i = 0; i < len; i++) {
+
+		if (i == p_cursor.line) {
+			String line = lines[i];
+			String first_part = line.substr(0, p_cursor.character);
+			String last_part = line.substr(p_cursor.character, lines[i].size());
+			if (!p_symbol.empty()) {
+				String left_cursor_text;
+				for (int c = p_cursor.character - 1; c >= 0; c--) {
+					left_cursor_text = line.substr(c, p_cursor.character - c);
+					if (p_symbol.begins_with(left_cursor_text)) {
+						first_part = line.substr(0, c);
+						first_part += p_symbol;
+						break;
+					}
+				}
+			}
+
+			longthing += first_part;
+			longthing += String::chr(0xFFFF); //not unicode, represents the cursor
+			if (p_func_requred) {
+				longthing += "("; // tell the parser this is a function call
+			}
+			longthing += last_part;
+		} else {
+
+			longthing += lines[i];
+		}
+
+		if (i != len - 1)
+			longthing += "\n";
+	}
+
+	return longthing;
+}
+
+String ExtendGDScriptParser::get_identifier_under_position(const lsp::Position &p_position, Vector2i &p_offset) const {
+
+	ERR_FAIL_INDEX_V(p_position.line, lines.size(), "");
+	String line = lines[p_position.line];
+	ERR_FAIL_INDEX_V(p_position.character, line.size(), "");
+
+	int start_pos = p_position.character;
+	for (int c = p_position.character; c >= 0; c--) {
+		start_pos = c;
+		CharType ch = line[c];
+		bool valid_char = (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_';
+		if (!valid_char) {
+			break;
+		}
+	}
+
+	int end_pos = p_position.character;
+	for (int c = p_position.character; c < line.length(); c++) {
+		CharType ch = line[c];
+		bool valid_char = (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_';
+		if (!valid_char) {
+			break;
+		}
+		end_pos = c;
+	}
+	if (start_pos < end_pos) {
+		p_offset.x = start_pos - p_position.character;
+		p_offset.y = end_pos - p_position.character;
+		return line.substr(start_pos + 1, end_pos - start_pos);
+	}
+
+	return "";
+}
+
+String ExtendGDScriptParser::get_uri() const {
+	return GDScriptLanguageProtocol::get_singleton()->get_workspace().get_file_uri(path);
+}
+
+const lsp::DocumentSymbol *ExtendGDScriptParser::search_symbol_defined_at_line(int p_line, const lsp::DocumentSymbol &p_parent) const {
+	const lsp::DocumentSymbol *ret = NULL;
+	if (p_line < p_parent.range.start.line) {
+		return ret;
+	} else if (p_parent.range.start.line == p_line) {
+		return &p_parent;
+	} else {
+		for (int i = 0; i < p_parent.children.size(); i++) {
+			ret = search_symbol_defined_at_line(p_line, p_parent.children[i]);
+			if (ret) {
+				break;
+			}
+		}
+	}
+	return ret;
+}
+
+const lsp::DocumentSymbol *ExtendGDScriptParser::get_symbol_defined_at_line(int p_line) const {
+	if (p_line <= 0) {
+		return &class_symbol;
+	}
+	return search_symbol_defined_at_line(p_line, class_symbol);
+}
+
+const lsp::DocumentSymbol *ExtendGDScriptParser::get_member_symbol(const String &p_name) const {
+	const GDScriptParser::Node *head = get_parse_tree();
+
+	if (const GDScriptParser::ClassNode *gdclass = dynamic_cast<const GDScriptParser::ClassNode *>(head)) {
+
+		if (const Map<StringName, GDScriptParser::ClassNode::Constant>::Element *E = gdclass->constant_expressions.find(p_name)) {
+			return get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(E->get().expression->line));
+		}
+
+		for (int i = 0; i < gdclass->subclasses.size(); i++) {
+			const ClassNode *m = gdclass->subclasses[i];
+			if (m && m->name == p_name) {
+				return get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(m->line));
+			}
+		}
+
+		for (int i = 0; i < gdclass->variables.size(); i++) {
+			const GDScriptParser::ClassNode::Member &m = gdclass->variables[i];
+			if (m.identifier == p_name) {
+				return get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(m.line));
+			}
+		}
+
+		for (int i = 0; i < gdclass->functions.size(); i++) {
+			const GDScriptParser::FunctionNode *m = gdclass->functions[i];
+			if (m->name == p_name) {
+				return get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(m->line));
+			}
+		}
+
+		for (int i = 0; i < gdclass->static_functions.size(); i++) {
+			const GDScriptParser::FunctionNode *m = gdclass->static_functions[i];
+			if (m->name == p_name) {
+				return get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(m->line));
+			}
+		}
+
+		for (int i = 0; i < gdclass->_signals.size(); i++) {
+			const GDScriptParser::ClassNode::Signal &m = gdclass->_signals[i];
+			if (m.name == p_name) {
+				return get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(m.line));
+			}
+		}
+	}
+
+	return NULL;
+}
+
+void ExtendGDScriptParser::dump_symbols(HashMap<String, lsp::DocumentedSymbolInformation> &r_symbols) {
+	Vector<lsp::DocumentedSymbolInformation> list;
+	class_symbol.symbol_tree_as_list(path, list, path, true);
+	for (int i = 0; i < list.size(); i++) {
+		const lsp::DocumentedSymbolInformation &symbol = list[i];
+		r_symbols.set(symbol.name, symbol);
+	}
+}
+
 Error ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
 	path = p_path;
 	code = p_code;
@@ -232,6 +510,5 @@ Error ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
 	Error err = GDScriptParser::parse(p_code, p_path.get_base_dir(), false, p_path, false, NULL, false);
 	update_diagnostics();
 	update_symbols();
-
 	return err;
 }

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -557,7 +557,6 @@ const Array &ExtendGDScriptParser::get_member_completions() {
 
 Error ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
 	path = p_path;
-	code = p_code;
 	lines = p_code.split("\n");
 
 	Error err = GDScriptParser::parse(p_code, p_path.get_base_dir(), false, p_path, false, NULL, false);

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -1,0 +1,64 @@
+/*************************************************************************/
+/*  gdscript_extend_parser.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_EXTEND_PARSER_H
+#define GDSCRIPT_EXTEND_PARSER_H
+
+#include "../gdscript_parser.h"
+#include "core/variant.h"
+#include "lsp.hpp"
+
+class ExtendGDScriptParser : public GDScriptParser {
+	String path;
+	String code;
+	Vector<String> lines;
+
+	lsp::DocumentSymbol class_symbol;
+	Vector<lsp::Diagnostic> diagnostics;
+
+	void update_diagnostics();
+	void update_symbols();
+
+	void parse_class_symbol(const GDScriptParser::ClassNode *p_class, lsp::DocumentSymbol &r_symbol);
+	void parse_function_symbol(const GDScriptParser::FunctionNode *p_func, lsp::DocumentSymbol &r_symbol);
+
+public:
+	_FORCE_INLINE_ const String &get_path() const { return path; }
+	_FORCE_INLINE_ const String &get_code() const { return code; }
+	_FORCE_INLINE_ const Vector<String> &get_lines() const { return lines; }
+	_FORCE_INLINE_ const lsp::DocumentSymbol &get_symbols() const { return class_symbol; }
+	_FORCE_INLINE_ const Vector<lsp::Diagnostic> &get_diagnostics() const { return diagnostics; }
+
+	String get_text_for_completion(const lsp::Position &p_cursor);
+
+	Error parse(const String &p_code, const String &p_path);
+};
+
+#endif

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -65,6 +65,9 @@ class ExtendGDScriptParser : public GDScriptParser {
 	void parse_class_symbol(const GDScriptParser::ClassNode *p_class, lsp::DocumentSymbol &r_symbol);
 	void parse_function_symbol(const GDScriptParser::FunctionNode *p_func, lsp::DocumentSymbol &r_symbol);
 
+	Dictionary dump_function_api(const GDScriptParser::FunctionNode *p_func) const;
+	Dictionary dump_class_api(const GDScriptParser::ClassNode *p_class) const;
+
 	String parse_documentation(int p_line, bool p_docs_down = false);
 	const lsp::DocumentSymbol *search_symbol_defined_at_line(int p_line, const lsp::DocumentSymbol &p_parent) const;
 
@@ -87,6 +90,7 @@ public:
 	const lsp::DocumentSymbol *get_member_symbol(const String &p_name, const String &p_subclass = "") const;
 
 	const Array &get_member_completions();
+	Dictionary generate_api() const;
 
 	Error parse(const String &p_code, const String &p_path);
 };

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -73,6 +73,11 @@ class ExtendGDScriptParser : public GDScriptParser {
 
 	Array member_completions;
 
+	String parse_documentation_as_markdown(int p_line, bool p_docs_down = false);
+
+public:
+	static String marked_documentation(const String &p_bbcode);
+
 public:
 	_FORCE_INLINE_ const String &get_path() const { return path; }
 	_FORCE_INLINE_ const Vector<String> &get_lines() const { return lines; }

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -43,22 +43,28 @@
 #define JOIN_SYMBOLS(p_path, name) ((p_path) + "." + (name))
 #endif
 
+typedef HashMap<String, const lsp::DocumentSymbol *> ClassMembers;
+
 class ExtendGDScriptParser : public GDScriptParser {
+
 	String path;
 	String code;
 	Vector<String> lines;
 
 	lsp::DocumentSymbol class_symbol;
 	Vector<lsp::Diagnostic> diagnostics;
+	ClassMembers members;
 
 	void update_diagnostics();
-	void update_symbols();
 
+	void update_symbols();
 	void parse_class_symbol(const GDScriptParser::ClassNode *p_class, lsp::DocumentSymbol &r_symbol);
 	void parse_function_symbol(const GDScriptParser::FunctionNode *p_func, lsp::DocumentSymbol &r_symbol);
-	String parse_documentation(int p_line);
 
+	String parse_documentation(int p_line);
 	const lsp::DocumentSymbol *search_symbol_defined_at_line(int p_line, const lsp::DocumentSymbol &p_parent) const;
+
+	Array member_completions;
 
 public:
 	_FORCE_INLINE_ const String &get_path() const { return path; }
@@ -66,6 +72,7 @@ public:
 	_FORCE_INLINE_ const Vector<String> &get_lines() const { return lines; }
 	_FORCE_INLINE_ const lsp::DocumentSymbol &get_symbols() const { return class_symbol; }
 	_FORCE_INLINE_ const Vector<lsp::Diagnostic> &get_diagnostics() const { return diagnostics; }
+	_FORCE_INLINE_ const ClassMembers &get_members() const { return members; }
 
 	String get_text_for_completion(const lsp::Position &p_cursor) const;
 	String get_text_for_lookup_symbol(const lsp::Position &p_cursor, const String &p_symbol = "", bool p_func_requred = false) const;
@@ -74,7 +81,8 @@ public:
 
 	const lsp::DocumentSymbol *get_symbol_defined_at_line(int p_line) const;
 	const lsp::DocumentSymbol *get_member_symbol(const String &p_name) const;
-	void dump_member_symbols(Map<String, const lsp::DocumentSymbol *> &r_symbols);
+
+	const Array &get_member_completions();
 
 	Error parse(const String &p_code, const String &p_path);
 };

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -35,6 +35,10 @@
 #include "core/variant.h"
 #include "lsp.hpp"
 
+#ifndef LINE_NUMBER_TO_INDEX
+#define LINE_NUMBER_TO_INDEX(p_line) ((p_line)-1)
+#endif
+
 class ExtendGDScriptParser : public GDScriptParser {
 	String path;
 	String code;
@@ -48,6 +52,9 @@ class ExtendGDScriptParser : public GDScriptParser {
 
 	void parse_class_symbol(const GDScriptParser::ClassNode *p_class, lsp::DocumentSymbol &r_symbol);
 	void parse_function_symbol(const GDScriptParser::FunctionNode *p_func, lsp::DocumentSymbol &r_symbol);
+	String parse_documentation(int p_line);
+
+	const lsp::DocumentSymbol *search_symbol_defined_at_line(int p_line, const lsp::DocumentSymbol &p_parent) const;
 
 public:
 	_FORCE_INLINE_ const String &get_path() const { return path; }
@@ -56,7 +63,15 @@ public:
 	_FORCE_INLINE_ const lsp::DocumentSymbol &get_symbols() const { return class_symbol; }
 	_FORCE_INLINE_ const Vector<lsp::Diagnostic> &get_diagnostics() const { return diagnostics; }
 
-	String get_text_for_completion(const lsp::Position &p_cursor);
+	String get_text_for_completion(const lsp::Position &p_cursor) const;
+	String get_text_for_lookup_symbol(const lsp::Position &p_cursor, const String &p_symbol = "", bool p_func_requred = false) const;
+	String get_identifier_under_position(const lsp::Position &p_position, Vector2i &p_offset) const;
+	String get_uri() const;
+
+	const lsp::DocumentSymbol *get_symbol_defined_at_line(int p_line) const;
+	const lsp::DocumentSymbol *get_member_symbol(const String &p_name) const;
+
+	void dump_symbols(HashMap<String, lsp::DocumentedSymbolInformation> &r_symbols);
 
 	Error parse(const String &p_code, const String &p_path);
 };

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -52,7 +52,6 @@ typedef HashMap<String, const lsp::DocumentSymbol *> ClassMembers;
 class ExtendGDScriptParser : public GDScriptParser {
 
 	String path;
-	String code;
 	Vector<String> lines;
 
 	lsp::DocumentSymbol class_symbol;
@@ -73,7 +72,6 @@ class ExtendGDScriptParser : public GDScriptParser {
 
 public:
 	_FORCE_INLINE_ const String &get_path() const { return path; }
-	_FORCE_INLINE_ const String &get_code() const { return code; }
 	_FORCE_INLINE_ const Vector<String> &get_lines() const { return lines; }
 	_FORCE_INLINE_ const lsp::DocumentSymbol &get_symbols() const { return class_symbol; }
 	_FORCE_INLINE_ const Vector<lsp::Diagnostic> &get_diagnostics() const { return diagnostics; }

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -39,6 +39,10 @@
 #define LINE_NUMBER_TO_INDEX(p_line) ((p_line)-1)
 #endif
 
+#ifndef JOIN_SYMBOLS
+#define JOIN_SYMBOLS(p_path, name) ((p_path) + "." + (name))
+#endif
+
 class ExtendGDScriptParser : public GDScriptParser {
 	String path;
 	String code;
@@ -70,8 +74,7 @@ public:
 
 	const lsp::DocumentSymbol *get_symbol_defined_at_line(int p_line) const;
 	const lsp::DocumentSymbol *get_member_symbol(const String &p_name) const;
-
-	void dump_symbols(HashMap<String, lsp::DocumentedSymbolInformation> &r_symbols);
+	void dump_member_symbols(Map<String, const lsp::DocumentSymbol *> &r_symbols);
 
 	Error parse(const String &p_code, const String &p_path);
 };

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -39,8 +39,12 @@
 #define LINE_NUMBER_TO_INDEX(p_line) ((p_line)-1)
 #endif
 
+#ifndef SYMBOL_SEPERATOR
+#define SYMBOL_SEPERATOR "::"
+#endif
+
 #ifndef JOIN_SYMBOLS
-#define JOIN_SYMBOLS(p_path, name) ((p_path) + "." + (name))
+#define JOIN_SYMBOLS(p_path, name) ((p_path) + SYMBOL_SEPERATOR + (name))
 #endif
 
 typedef HashMap<String, const lsp::DocumentSymbol *> ClassMembers;
@@ -54,6 +58,7 @@ class ExtendGDScriptParser : public GDScriptParser {
 	lsp::DocumentSymbol class_symbol;
 	Vector<lsp::Diagnostic> diagnostics;
 	ClassMembers members;
+	HashMap<String, ClassMembers> inner_classes;
 
 	void update_diagnostics();
 
@@ -61,7 +66,7 @@ class ExtendGDScriptParser : public GDScriptParser {
 	void parse_class_symbol(const GDScriptParser::ClassNode *p_class, lsp::DocumentSymbol &r_symbol);
 	void parse_function_symbol(const GDScriptParser::FunctionNode *p_func, lsp::DocumentSymbol &r_symbol);
 
-	String parse_documentation(int p_line);
+	String parse_documentation(int p_line, bool p_docs_down = false);
 	const lsp::DocumentSymbol *search_symbol_defined_at_line(int p_line, const lsp::DocumentSymbol &p_parent) const;
 
 	Array member_completions;
@@ -73,6 +78,7 @@ public:
 	_FORCE_INLINE_ const lsp::DocumentSymbol &get_symbols() const { return class_symbol; }
 	_FORCE_INLINE_ const Vector<lsp::Diagnostic> &get_diagnostics() const { return diagnostics; }
 	_FORCE_INLINE_ const ClassMembers &get_members() const { return members; }
+	_FORCE_INLINE_ const HashMap<String, ClassMembers> &get_inner_classes() const { return inner_classes; }
 
 	String get_text_for_completion(const lsp::Position &p_cursor) const;
 	String get_text_for_lookup_symbol(const lsp::Position &p_cursor, const String &p_symbol = "", bool p_func_requred = false) const;
@@ -80,7 +86,7 @@ public:
 	String get_uri() const;
 
 	const lsp::DocumentSymbol *get_symbol_defined_at_line(int p_line) const;
-	const lsp::DocumentSymbol *get_member_symbol(const String &p_name) const;
+	const lsp::DocumentSymbol *get_member_symbol(const String &p_name, const String &p_subclass = "") const;
 
 	const Array &get_member_completions();
 

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -90,7 +90,7 @@ void GDScriptLanguageProtocol::_bind_methods() {
 Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 
 	lsp::InitializeResult ret;
-
+	workspace.initialize();
 	return ret.to_json();
 }
 
@@ -163,6 +163,7 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 	server = NULL;
 	singleton = this;
 	set_scope("textDocument", &text_document);
+	set_scope("completionItem", &text_document);
 	set_scope("workspace", &workspace);
 	workspace.root = ProjectSettings::get_singleton()->get_resource_path();
 }

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -189,6 +189,10 @@ bool GDScriptLanguageProtocol::is_smart_resolve_enabled() const {
 	return bool(_EDITOR_GET("network/language_server/enable_smart_resolve"));
 }
 
+bool GDScriptLanguageProtocol::is_goto_native_symbols_enabled() const {
+	return bool(_EDITOR_GET("network/language_server/show_native_symbols_in_editor"));
+}
+
 GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 	server = NULL;
 	singleton = this;

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -103,7 +103,18 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 	if (root_uri.length() && is_same_workspace) {
 		workspace.root_uri = root_uri;
 	} else {
+
 		workspace.root_uri = "file://" + workspace.root;
+
+		Dictionary params;
+		params["path"] = workspace.root;
+		Dictionary request = make_notification("gdscrip_client/changeWorkspace", params);
+		if (Ref<WebSocketPeer> *peer = clients.getptr(lastest_client_id)) {
+			String msg = JSON::print(request);
+			msg = format_output(msg);
+			CharString charstr = msg.utf8();
+			(*peer)->put_packet((const uint8_t *)charstr.ptr(), charstr.length());
+		}
 	}
 
 	if (!_initialized) {
@@ -116,18 +127,6 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 }
 
 void GDScriptLanguageProtocol::initialized(const Variant &p_params) {
-
-	Dictionary params;
-	params["type"] = 3;
-	params["message"] = "GDScript Language Server initialized!";
-	Dictionary test_message = make_notification("window/showMessage", params);
-
-	if (Ref<WebSocketPeer> *peer = clients.getptr(lastest_client_id)) {
-		String msg = JSON::print(test_message);
-		msg = format_output(msg);
-		CharString charstr = msg.utf8();
-		(*peer)->put_packet((const uint8_t *)charstr.ptr(), charstr.length());
-	}
 }
 
 void GDScriptLanguageProtocol::poll() {

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -1,0 +1,173 @@
+/*************************************************************************/
+/*  gdscript_language_protocol.cpp                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_language_protocol.h"
+#include "core/io/json.h"
+#include "core/os/copymem.h"
+#include "core/project_settings.h"
+
+GDScriptLanguageProtocol *GDScriptLanguageProtocol::singleton = NULL;
+
+void GDScriptLanguageProtocol::on_data_received(int p_id) {
+	lastest_client_id = p_id;
+	Ref<WebSocketPeer> peer = server->get_peer(p_id);
+	PoolByteArray data;
+	if (OK == peer->get_packet_buffer(data)) {
+		String message;
+		message.parse_utf8((const char *)data.read().ptr(), data.size());
+		if (message.begins_with("Content-Length:")) return;
+		String output = process_message(message);
+		if (!output.empty()) {
+			CharString charstr = output.utf8();
+			peer->put_packet((const uint8_t *)charstr.ptr(), charstr.length());
+		}
+	}
+}
+
+void GDScriptLanguageProtocol::on_client_connected(int p_id, const String &p_protocal) {
+	clients.set(p_id, server->get_peer(p_id));
+}
+
+void GDScriptLanguageProtocol::on_client_disconnected(int p_id, bool p_was_clean_close) {
+	clients.erase(p_id);
+}
+
+String GDScriptLanguageProtocol::process_message(const String &p_text) {
+	String ret = process_string(p_text);
+	if (ret.empty()) {
+		return ret;
+	} else {
+		return format_output(ret);
+	}
+}
+
+String GDScriptLanguageProtocol::format_output(const String &p_text) {
+
+	String header = "Content-Length: ";
+	CharString charstr = p_text.utf8();
+	size_t len = charstr.length();
+	header += itos(len);
+	header += "\r\n\r\n";
+
+	return header + p_text;
+}
+
+void GDScriptLanguageProtocol::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("initialize", "params"), &GDScriptLanguageProtocol::initialize);
+	ClassDB::bind_method(D_METHOD("initialized", "params"), &GDScriptLanguageProtocol::initialized);
+	ClassDB::bind_method(D_METHOD("on_data_received"), &GDScriptLanguageProtocol::on_data_received);
+	ClassDB::bind_method(D_METHOD("on_client_connected"), &GDScriptLanguageProtocol::on_client_connected);
+	ClassDB::bind_method(D_METHOD("on_client_disconnected"), &GDScriptLanguageProtocol::on_client_disconnected);
+}
+
+Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
+
+	lsp::InitializeResult ret;
+
+	return ret.to_json();
+}
+
+void GDScriptLanguageProtocol::initialized(const Variant &p_params) {
+
+	Dictionary params;
+	params["type"] = 3;
+	params["message"] = "GDScript Language Server initialized!";
+	Dictionary test_message = make_notification("window/showMessage", params);
+
+	if (Ref<WebSocketPeer> *peer = clients.getptr(lastest_client_id)) {
+		String msg = JSON::print(test_message);
+		msg = format_output(msg);
+		CharString charstr = msg.utf8();
+		(*peer)->put_packet((const uint8_t *)charstr.ptr(), charstr.length());
+	}
+}
+
+void GDScriptLanguageProtocol::poll() {
+	server->poll();
+}
+
+Error GDScriptLanguageProtocol::start(int p_port) {
+	if (server == NULL) {
+		server = dynamic_cast<WebSocketServer *>(ClassDB::instance("WebSocketServer"));
+		server->set_buffers(8192, 1024, 8192, 1024); // 8mb should be way more than enough
+		server->connect("data_received", this, "on_data_received");
+		server->connect("client_connected", this, "on_client_connected");
+		server->connect("client_disconnected", this, "on_client_disconnected");
+	}
+	return server->listen(p_port);
+}
+
+void GDScriptLanguageProtocol::stop() {
+	server->stop();
+}
+
+void GDScriptLanguageProtocol::notify_all_clients(const String &p_method, const Variant &p_params) {
+
+	Dictionary message = make_notification(p_method, p_params);
+	String msg = JSON::print(message);
+	msg = format_output(msg);
+	CharString charstr = msg.utf8();
+	const int *p_id = clients.next(NULL);
+	while (p_id != NULL) {
+		Ref<WebSocketPeer> peer = clients.get(*p_id);
+		(*peer)->put_packet((const uint8_t *)charstr.ptr(), charstr.length());
+		p_id = clients.next(p_id);
+	}
+}
+
+void GDScriptLanguageProtocol::notify_client(const String &p_method, const Variant &p_params, int p_client) {
+
+	if (p_client == -1) {
+		p_client = lastest_client_id;
+	}
+
+	Ref<WebSocketPeer> *peer = clients.getptr(p_client);
+	ERR_FAIL_COND(peer == NULL);
+
+	Dictionary message = make_notification(p_method, p_params);
+	String msg = JSON::print(message);
+	msg = format_output(msg);
+	CharString charstr = msg.utf8();
+
+	(*peer)->put_packet((const uint8_t *)charstr.ptr(), charstr.length());
+}
+
+GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
+	server = NULL;
+	singleton = this;
+	set_scope("textDocument", &text_document);
+	set_scope("workspace", &workspace);
+	workspace.root = ProjectSettings::get_singleton()->get_resource_path();
+}
+
+GDScriptLanguageProtocol::~GDScriptLanguageProtocol() {
+	memdelete(server);
+	server = NULL;
+}

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -32,6 +32,7 @@
 #include "core/io/json.h"
 #include "core/os/copymem.h"
 #include "core/project_settings.h"
+#include "editor/editor_node.h"
 
 GDScriptLanguageProtocol *GDScriptLanguageProtocol::singleton = NULL;
 
@@ -157,6 +158,10 @@ void GDScriptLanguageProtocol::notify_client(const String &p_method, const Varia
 	CharString charstr = msg.utf8();
 
 	(*peer)->put_packet((const uint8_t *)charstr.ptr(), charstr.length());
+}
+
+bool GDScriptLanguageProtocol::is_smart_resolve_enabled() const {
+	return bool(_EDITOR_GET("network/language_server/enable_smart_resolve"));
 }
 
 GDScriptLanguageProtocol::GDScriptLanguageProtocol() {

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -1,0 +1,86 @@
+/*************************************************************************/
+/*  gdscript_language_protocol.h                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_PROTOCAL_SERVER_H
+#define GDSCRIPT_PROTOCAL_SERVER_H
+
+#include "gdscript_text_document.h"
+#include "gdscript_workspace.h"
+#include "lsp.hpp"
+#include "modules/jsonrpc/jsonrpc.h"
+#include "modules/websocket/websocket_peer.h"
+#include "modules/websocket/websocket_server.h"
+
+class GDScriptLanguageProtocol : public JSONRPC {
+	GDCLASS(GDScriptLanguageProtocol, JSONRPC)
+
+	enum LSPErrorCode {
+		RequestCancelled = -32800,
+		ContentModified = -32801,
+	};
+
+	static GDScriptLanguageProtocol *singleton;
+
+	HashMap<int, Ref<WebSocketPeer> > clients;
+	WebSocketServer *server;
+	int lastest_client_id;
+
+	GDScriptTextDocument text_document;
+	GDScriptWorkspace workspace;
+
+	void on_data_received(int p_id);
+	void on_client_connected(int p_id, const String &p_protocal);
+	void on_client_disconnected(int p_id, bool p_was_clean_close);
+
+	String process_message(const String &p_text);
+	String format_output(const String &p_text);
+
+protected:
+	static void _bind_methods();
+
+	Dictionary initialize(const Dictionary &p_params);
+	void initialized(const Variant &p_params);
+
+public:
+	_FORCE_INLINE_ static GDScriptLanguageProtocol *get_singleton() { return singleton; }
+	_FORCE_INLINE_ GDScriptWorkspace &get_workspace() { return workspace; }
+
+	void poll();
+	Error start(int p_port);
+	void stop();
+
+	void notify_all_clients(const String &p_method, const Variant &p_params = Variant());
+	void notify_client(const String &p_method, const Variant &p_params = Variant(), int p_client = -1);
+
+	GDScriptLanguageProtocol();
+	~GDScriptLanguageProtocol();
+};
+
+#endif

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -84,6 +84,7 @@ public:
 	void notify_client(const String &p_method, const Variant &p_params = Variant(), int p_client = -1);
 
 	bool is_smart_resolve_enabled() const;
+	bool is_goto_native_symbols_enabled() const;
 
 	GDScriptLanguageProtocol();
 	~GDScriptLanguageProtocol();

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -62,6 +62,8 @@ class GDScriptLanguageProtocol : public JSONRPC {
 	String process_message(const String &p_text);
 	String format_output(const String &p_text);
 
+	bool _initialized;
+
 protected:
 	static void _bind_methods();
 

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -79,6 +79,8 @@ public:
 	void notify_all_clients(const String &p_method, const Variant &p_params = Variant());
 	void notify_client(const String &p_method, const Variant &p_params = Variant(), int p_client = -1);
 
+	bool is_smart_resolve_enabled() const;
+
 	GDScriptLanguageProtocol();
 	~GDScriptLanguageProtocol();
 };

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -52,8 +52,8 @@ class GDScriptLanguageProtocol : public JSONRPC {
 	WebSocketServer *server;
 	int lastest_client_id;
 
-	GDScriptTextDocument text_document;
-	GDScriptWorkspace workspace;
+	Ref<GDScriptTextDocument> text_document;
+	Ref<GDScriptWorkspace> workspace;
 
 	void on_data_received(int p_id);
 	void on_client_connected(int p_id, const String &p_protocal);
@@ -72,7 +72,9 @@ protected:
 
 public:
 	_FORCE_INLINE_ static GDScriptLanguageProtocol *get_singleton() { return singleton; }
-	_FORCE_INLINE_ GDScriptWorkspace &get_workspace() { return workspace; }
+	_FORCE_INLINE_ Ref<GDScriptWorkspace> get_workspace() { return workspace; }
+	_FORCE_INLINE_ Ref<GDScriptTextDocument> get_text_document() { return text_document; }
+	_FORCE_INLINE_ bool is_initialized() const { return _initialized; }
 
 	void poll();
 	Error start(int p_port);

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -1,0 +1,86 @@
+/*************************************************************************/
+/*  gdscript_language_server.cpp                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_language_server.h"
+#include "core/os/file_access.h"
+#include "core/os/os.h"
+#include "editor/editor_node.h"
+
+GDScriptLanguageServer::GDScriptLanguageServer() {
+	thread = NULL;
+	thread_exit = false;
+	_EDITOR_DEF("network/language_server/remote_port", 6008);
+}
+
+void GDScriptLanguageServer::_notification(int p_what) {
+
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+			start();
+			break;
+		case NOTIFICATION_EXIT_TREE:
+			stop();
+			break;
+	}
+}
+
+void GDScriptLanguageServer::thread_main(void *p_userdata) {
+	GDScriptLanguageServer *self = static_cast<GDScriptLanguageServer *>(p_userdata);
+	while (!self->thread_exit) {
+		self->protocol.poll();
+		OS::get_singleton()->delay_usec(10);
+	}
+}
+
+void GDScriptLanguageServer::start() {
+	int port = (int)_EDITOR_GET("network/language_server/remote_port");
+	if (protocol.start(port) == OK) {
+		EditorNode::get_log()->add_message("** GDScript Language Server Started **");
+		ERR_FAIL_COND(thread != NULL || thread_exit);
+		thread_exit = false;
+		thread = Thread::create(GDScriptLanguageServer::thread_main, this);
+	}
+}
+
+void GDScriptLanguageServer::stop() {
+	ERR_FAIL_COND(NULL == thread || thread_exit);
+	thread_exit = true;
+	Thread::wait_to_finish(thread);
+	memdelete(thread);
+	thread = NULL;
+	protocol.stop();
+	EditorNode::get_log()->add_message("** GDScript Language Server Stopped **");
+}
+
+void register_lsp_types() {
+	ClassDB::register_class<GDScriptLanguageProtocol>();
+	ClassDB::register_class<GDScriptTextDocument>();
+	ClassDB::register_class<GDScriptWorkspace>();
+}

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -38,6 +38,7 @@ GDScriptLanguageServer::GDScriptLanguageServer() {
 	thread_exit = false;
 	_EDITOR_DEF("network/language_server/remote_port", 6008);
 	_EDITOR_DEF("network/language_server/enable_smart_resolve", false);
+	_EDITOR_DEF("network/language_server/show_native_symbols_in_editor", false);
 }
 
 void GDScriptLanguageServer::_notification(int p_what) {

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -37,6 +37,7 @@ GDScriptLanguageServer::GDScriptLanguageServer() {
 	thread = NULL;
 	thread_exit = false;
 	_EDITOR_DEF("network/language_server/remote_port", 6008);
+	_EDITOR_DEF("network/language_server/enable_smart_resolve", false);
 }
 
 void GDScriptLanguageServer::_notification(int p_what) {

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -1,0 +1,60 @@
+/*************************************************************************/
+/*  gdscript_language_server.h                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_LANGUAGE_SERVER_H
+#define GDSCRIPT_LANGUAGE_SERVER_H
+
+#include "../gdscript_parser.h"
+#include "editor/editor_plugin.h"
+#include "gdscript_language_protocol.h"
+
+class GDScriptLanguageServer : public EditorPlugin {
+	GDCLASS(GDScriptLanguageServer, EditorPlugin);
+
+	GDScriptLanguageProtocol protocol;
+
+	Thread *thread;
+	bool thread_exit;
+	static void thread_main(void *p_userdata);
+
+private:
+	void _notification(int p_what);
+	void _iteration();
+
+public:
+	Error parse_script_file(const String &p_path);
+	GDScriptLanguageServer();
+	void start();
+	void stop();
+};
+
+void register_lsp_types();
+
+#endif // GDSCRIPT_LANGUAGE_SERVER_H

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -244,7 +244,7 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 		item.documentation = symbol->render();
 	}
 
-	if (item.kind == lsp::CompletionItemKind::Method || item.kind == lsp::CompletionItemKind::Function) {
+	if ((item.kind == lsp::CompletionItemKind::Method || item.kind == lsp::CompletionItemKind::Function) && !item.label.ends_with("):")) {
 		item.insertText = item.label + "(";
 		if (symbol && symbol->detail.find(",") == -1) {
 			item.insertText += ")";

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -1,0 +1,177 @@
+/*************************************************************************/
+/*  gdscript_text_document.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_text_document.h"
+#include "../gdscript.h"
+#include "gdscript_language_protocol.h"
+
+void GDScriptTextDocument::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("didOpen"), &GDScriptTextDocument::didOpen);
+	ClassDB::bind_method(D_METHOD("didChange"), &GDScriptTextDocument::didChange);
+	ClassDB::bind_method(D_METHOD("documentSymbol"), &GDScriptTextDocument::documentSymbol);
+	ClassDB::bind_method(D_METHOD("completion"), &GDScriptTextDocument::completion);
+	ClassDB::bind_method(D_METHOD("foldingRange"), &GDScriptTextDocument::foldingRange);
+	ClassDB::bind_method(D_METHOD("codeLens"), &GDScriptTextDocument::codeLens);
+	ClassDB::bind_method(D_METHOD("documentLink"), &GDScriptTextDocument::documentLink);
+	ClassDB::bind_method(D_METHOD("colorPresentation"), &GDScriptTextDocument::colorPresentation);
+	ClassDB::bind_method(D_METHOD("hover"), &GDScriptTextDocument::hover);
+}
+
+void GDScriptTextDocument::didOpen(const Variant &p_param) {
+	lsp::TextDocumentItem doc = load_document_item(p_param);
+	sync_script_content(doc.uri, doc.text);
+}
+
+void GDScriptTextDocument::didChange(const Variant &p_param) {
+	lsp::TextDocumentItem doc = load_document_item(p_param);
+	Dictionary dict = p_param;
+	Array contentChanges = dict["contentChanges"];
+	for (int i = 0; i < contentChanges.size(); ++i) {
+		lsp::TextDocumentContentChangeEvent evt;
+		evt.load(contentChanges[i]);
+		doc.text = evt.text;
+	}
+	sync_script_content(doc.uri, doc.text);
+}
+
+lsp::TextDocumentItem GDScriptTextDocument::load_document_item(const Variant &p_param) {
+	lsp::TextDocumentItem doc;
+	Dictionary params = p_param;
+	doc.load(params["textDocument"]);
+	print_line(doc.text);
+	return doc;
+}
+
+Array GDScriptTextDocument::documentSymbol(const Dictionary &p_params) {
+	Dictionary params = p_params["textDocument"];
+	String uri = params["uri"];
+	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace().get_file_path(uri);
+	Array arr;
+	if (const Map<String, ExtendGDScriptParser *>::Element *parser = GDScriptLanguageProtocol::get_singleton()->get_workspace().scripts.find(path)) {
+		Vector<lsp::SymbolInformation> list;
+		parser->get()->get_symbols().symbol_tree_as_list(uri, list);
+		for (int i = 0; i < list.size(); i++) {
+			arr.push_back(list[i].to_json());
+		}
+	}
+	return arr;
+}
+
+Array GDScriptTextDocument::completion(const Dictionary &p_params) {
+	Array arr;
+
+	lsp::CompletionParams params;
+	params.load(p_params);
+	Dictionary request_data = params.to_json();
+
+	List<ScriptCodeCompletionOption> options;
+	GDScriptLanguageProtocol::get_singleton()->get_workspace().completion(params, &options);
+
+	for (const List<ScriptCodeCompletionOption>::Element *E = options.front(); E; E = E->next()) {
+		const ScriptCodeCompletionOption &option = E->get();
+		lsp::CompletionItem item;
+		item.label = option.display;
+		item.insertText = option.insert_text;
+		item.data = request_data;
+
+		if (params.context.triggerKind == lsp::CompletionTriggerKind::TriggerCharacter && (params.context.triggerCharacter == "'" || params.context.triggerCharacter == "\"") && (option.insert_text.begins_with("'") || option.insert_text.begins_with("\""))) {
+			item.insertText = option.insert_text.substr(1, option.insert_text.length() - 2);
+		}
+
+		switch (option.kind) {
+			case ScriptCodeCompletionOption::KIND_ENUM:
+				item.kind = lsp::CompletionItemKind::Enum;
+				break;
+			case ScriptCodeCompletionOption::KIND_CLASS:
+				item.kind = lsp::CompletionItemKind::Class;
+				break;
+			case ScriptCodeCompletionOption::KIND_MEMBER:
+				item.kind = lsp::CompletionItemKind::Property;
+				break;
+			case ScriptCodeCompletionOption::KIND_FUNCTION:
+				item.kind = lsp::CompletionItemKind::Method;
+				break;
+			case ScriptCodeCompletionOption::KIND_SIGNAL:
+				item.kind = lsp::CompletionItemKind::Event;
+				break;
+			case ScriptCodeCompletionOption::KIND_CONSTANT:
+				item.kind = lsp::CompletionItemKind::Constant;
+				break;
+			case ScriptCodeCompletionOption::KIND_VARIABLE:
+				item.kind = lsp::CompletionItemKind::Variable;
+				break;
+			case ScriptCodeCompletionOption::KIND_FILE_PATH:
+				item.kind = lsp::CompletionItemKind::File;
+				break;
+			case ScriptCodeCompletionOption::KIND_NODE_PATH:
+				item.kind = lsp::CompletionItemKind::Snippet;
+				break;
+			case ScriptCodeCompletionOption::KIND_PLAIN_TEXT:
+				item.kind = lsp::CompletionItemKind::Text;
+				break;
+		}
+
+		arr.push_back(item.to_json());
+	}
+
+	return arr;
+}
+
+Array GDScriptTextDocument::foldingRange(const Dictionary &p_params) {
+	Dictionary params = p_params["textDocument"];
+	String path = params["uri"];
+	Array arr;
+	return arr;
+}
+
+Array GDScriptTextDocument::codeLens(const Dictionary &p_params) {
+	Array arr;
+	return arr;
+}
+
+Variant GDScriptTextDocument::documentLink(const Dictionary &p_params) {
+	Variant ret;
+	return ret;
+}
+
+Array GDScriptTextDocument::colorPresentation(const Dictionary &p_params) {
+	Array arr;
+	return arr;
+}
+
+Variant GDScriptTextDocument::hover(const Dictionary &p_params) {
+	Variant ret;
+	return ret;
+}
+
+void GDScriptTextDocument::sync_script_content(const String &p_uri, const String &p_content) {
+	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace().get_file_path(p_uri);
+	GDScriptLanguageProtocol::get_singleton()->get_workspace().parse_script(path, p_content);
+}

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -1,0 +1,60 @@
+/*************************************************************************/
+/*  gdscript_text_document.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_TEXT_DOCUMENT_H
+#define GDSCRIPT_TEXT_DOCUMENT_H
+
+#include "core/reference.h"
+#include "lsp.hpp"
+
+class GDScriptTextDocument : public Reference {
+	GDCLASS(GDScriptTextDocument, Reference)
+protected:
+	static void _bind_methods();
+
+	void didOpen(const Variant &p_param);
+	void didChange(const Variant &p_param);
+
+	void sync_script_content(const String &p_path, const String &p_content);
+
+private:
+	lsp::TextDocumentItem load_document_item(const Variant &p_param);
+
+public:
+	Array documentSymbol(const Dictionary &p_params);
+	Array completion(const Dictionary &p_params);
+	Array foldingRange(const Dictionary &p_params);
+	Array codeLens(const Dictionary &p_params);
+	Variant documentLink(const Dictionary &p_params);
+	Array colorPresentation(const Dictionary &p_params);
+	Variant hover(const Dictionary &p_params);
+};
+
+#endif

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -31,6 +31,7 @@
 #ifndef GDSCRIPT_TEXT_DOCUMENT_H
 #define GDSCRIPT_TEXT_DOCUMENT_H
 
+#include "core/os/file_access.h"
 #include "core/reference.h"
 #include "lsp.hpp"
 
@@ -38,6 +39,8 @@ class GDScriptTextDocument : public Reference {
 	GDCLASS(GDScriptTextDocument, Reference)
 protected:
 	static void _bind_methods();
+
+	FileAccess *file_checker;
 
 	void didOpen(const Variant &p_param);
 	void didChange(const Variant &p_param);
@@ -50,11 +53,16 @@ private:
 public:
 	Array documentSymbol(const Dictionary &p_params);
 	Array completion(const Dictionary &p_params);
+	Dictionary resolve(const Dictionary &p_params);
 	Array foldingRange(const Dictionary &p_params);
 	Array codeLens(const Dictionary &p_params);
 	Variant documentLink(const Dictionary &p_params);
 	Array colorPresentation(const Dictionary &p_params);
 	Variant hover(const Dictionary &p_params);
+	Array definition(const Dictionary &p_params);
+
+	GDScriptTextDocument();
+	virtual ~GDScriptTextDocument();
 };
 
 #endif

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -46,6 +46,7 @@ protected:
 	void didChange(const Variant &p_param);
 
 	void sync_script_content(const String &p_path, const String &p_content);
+	void show_native_symbol_in_editor(const String &p_symbol_id);
 
 	Array native_member_completions;
 

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -47,6 +47,8 @@ protected:
 
 	void sync_script_content(const String &p_path, const String &p_content);
 
+	Array native_member_completions;
+
 private:
 	lsp::TextDocumentItem load_document_item(const Variant &p_param);
 
@@ -60,6 +62,8 @@ public:
 	Array colorPresentation(const Dictionary &p_params);
 	Variant hover(const Dictionary &p_params);
 	Array definition(const Dictionary &p_params);
+
+	void initialize();
 
 	GDScriptTextDocument();
 	virtual ~GDScriptTextDocument();

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -1,0 +1,153 @@
+/*************************************************************************/
+/*  gdscript_workspace.cpp                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_workspace.h"
+#include "../gdscript.h"
+#include "../gdscript_parser.h"
+#include "core/project_settings.h"
+#include "gdscript_language_protocol.h"
+
+void GDScriptWorkspace::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("symbol"), &GDScriptWorkspace::symbol);
+}
+
+void GDScriptWorkspace::remove_cache_parser(const String &p_path) {
+	Map<String, ExtendGDScriptParser *>::Element *parser = parse_results.find(p_path);
+	Map<String, ExtendGDScriptParser *>::Element *script = scripts.find(p_path);
+	if (parser && script) {
+		if (script->get() && script->get() == script->get()) {
+			memdelete(script->get());
+		} else {
+			memdelete(script->get());
+			memdelete(parser->get());
+		}
+		parse_results.erase(p_path);
+		scripts.erase(p_path);
+	} else if (parser) {
+		memdelete(parser->get());
+		parse_results.erase(p_path);
+	} else if (script) {
+		memdelete(script->get());
+		scripts.erase(p_path);
+	}
+}
+
+Array GDScriptWorkspace::symbol(const Dictionary &p_params) {
+	String query = p_params["query"];
+	Array arr;
+	if (!query.empty()) {
+		for (Map<String, ExtendGDScriptParser *>::Element *E = scripts.front(); E; E = E->next()) {
+			Vector<lsp::SymbolInformation> script_symbols;
+			E->get()->get_symbols().symbol_tree_as_list(E->key(), script_symbols);
+			for (int i = 0; i < script_symbols.size(); ++i) {
+				if (query.is_subsequence_ofi(script_symbols[i].name)) {
+					arr.push_back(script_symbols[i].to_json());
+				}
+			}
+		}
+	}
+	return arr;
+}
+
+Error GDScriptWorkspace::parse_script(const String &p_path, const String &p_content) {
+	ExtendGDScriptParser *parser = memnew(ExtendGDScriptParser);
+	Error err = parser->parse(p_content, p_path);
+	Map<String, ExtendGDScriptParser *>::Element *last_parser = parse_results.find(p_path);
+	Map<String, ExtendGDScriptParser *>::Element *last_script = scripts.find(p_path);
+
+	if (err == OK) {
+		remove_cache_parser(p_path);
+		parse_results[p_path] = parser;
+		scripts[p_path] = parser;
+	} else {
+		if (last_parser && last_script && last_parser->get() != last_script->get()) {
+			memdelete(last_parser->get());
+		}
+		parse_results[p_path] = parser;
+	}
+
+	publish_diagnostics(p_path);
+
+	return err;
+}
+
+String GDScriptWorkspace::get_file_path(const String &p_uri) const {
+	String path = p_uri.replace("file://", "").http_unescape();
+	path = path.replace(root + "/", "res://");
+	return ProjectSettings::get_singleton()->localize_path(path);
+}
+
+String GDScriptWorkspace::get_file_uri(const String &p_path) const {
+	String path = ProjectSettings::get_singleton()->globalize_path(p_path);
+	return "file://" + path;
+}
+
+void GDScriptWorkspace::publish_diagnostics(const String &p_path) {
+	Dictionary params;
+	Array errors;
+	const Map<String, ExtendGDScriptParser *>::Element *ele = parse_results.find(p_path);
+	if (ele) {
+		const Vector<lsp::Diagnostic> &list = ele->get()->get_diagnostics();
+		errors.resize(list.size());
+		for (int i = 0; i < list.size(); ++i) {
+			errors[i] = list[i].to_json();
+		}
+	}
+	params["diagnostics"] = errors;
+	params["uri"] = get_file_uri(p_path);
+	GDScriptLanguageProtocol::get_singleton()->notify_client("textDocument/publishDiagnostics", params);
+}
+
+void GDScriptWorkspace::completion(const lsp::CompletionParams &p_params, List<ScriptCodeCompletionOption> *r_options) {
+	String path = get_file_path(p_params.textDocument.uri);
+	String call_hint;
+	bool forced = false;
+	if (Map<String, ExtendGDScriptParser *>::Element *E = parse_results.find(path)) {
+		String code = E->get()->get_text_for_completion(p_params.position);
+		GDScriptLanguage::get_singleton()->complete_code(code, path, NULL, r_options, forced, call_hint);
+	}
+}
+
+GDScriptWorkspace::GDScriptWorkspace() {
+	ProjectSettings::get_singleton()->get_resource_path();
+}
+
+GDScriptWorkspace::~GDScriptWorkspace() {
+	Set<String> cached_parsers;
+	for (Map<String, ExtendGDScriptParser *>::Element *E = parse_results.front(); E; E = E->next()) {
+		cached_parsers.insert(E->key());
+	}
+	for (Map<String, ExtendGDScriptParser *>::Element *E = scripts.front(); E; E = E->next()) {
+		cached_parsers.insert(E->key());
+	}
+	for (Set<String>::Element *E = cached_parsers.front(); E; E = E->next()) {
+		remove_cache_parser(E->get());
+	}
+}

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -382,6 +382,11 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 	if (const ExtendGDScriptParser *parser = get_parse_result(path)) {
 
 		String symbol_identifier = p_symbol_name;
+		Vector<String> identifier_parts = symbol_identifier.split("(");
+		if (identifier_parts.size()) {
+			symbol_identifier = identifier_parts[0];
+		}
+
 		lsp::Position pos = p_doc_pos.position;
 		if (symbol_identifier.empty()) {
 			Vector2i offset;

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -38,6 +38,12 @@
 
 void GDScriptWorkspace::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("symbol"), &GDScriptWorkspace::symbol);
+	ClassDB::bind_method(D_METHOD("parse_script", "p_path", "p_content"), &GDScriptWorkspace::parse_script);
+	ClassDB::bind_method(D_METHOD("parse_local_script", "p_path"), &GDScriptWorkspace::parse_local_script);
+	ClassDB::bind_method(D_METHOD("get_file_path", "p_uri"), &GDScriptWorkspace::get_file_path);
+	ClassDB::bind_method(D_METHOD("get_file_uri", "p_path"), &GDScriptWorkspace::get_file_uri);
+	ClassDB::bind_method(D_METHOD("publish_diagnostics", "p_path"), &GDScriptWorkspace::publish_diagnostics);
+	ClassDB::bind_method(D_METHOD("generate_script_api", "p_path"), &GDScriptWorkspace::generate_script_api);
 }
 
 void GDScriptWorkspace::remove_cache_parser(const String &p_path) {
@@ -510,6 +516,14 @@ void GDScriptWorkspace::resolve_related_symbols(const lsp::TextDocumentPositionP
 			}
 		}
 	}
+}
+
+Dictionary GDScriptWorkspace::generate_script_api(const String &p_path) {
+	Dictionary api;
+	if (const ExtendGDScriptParser *parser = get_parse_successed_script(p_path)) {
+		api = parser->generate_api();
+	}
+	return api;
 }
 
 GDScriptWorkspace::GDScriptWorkspace() {

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -1,0 +1,65 @@
+/*************************************************************************/
+/*  gdscript_workspace.h                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_WORKSPACE_H
+#define GDSCRIPT_WORKSPACE_H
+
+#include "../gdscript_parser.h"
+#include "core/variant.h"
+#include "gdscript_extend_parser.h"
+#include "lsp.hpp"
+
+class GDScriptWorkspace : public Reference {
+	GDCLASS(GDScriptWorkspace, Reference);
+
+protected:
+	static void _bind_methods();
+	void remove_cache_parser(const String &p_path);
+
+public:
+	String root;
+	Map<String, ExtendGDScriptParser *> scripts;
+	Map<String, ExtendGDScriptParser *> parse_results;
+
+public:
+	Array symbol(const Dictionary &p_params);
+
+public:
+	Error parse_script(const String &p_path, const String &p_content);
+	String get_file_path(const String &p_uri) const;
+	String get_file_uri(const String &p_path) const;
+	void publish_diagnostics(const String &p_path);
+	void completion(const lsp::CompletionParams &p_params, List<ScriptCodeCompletionOption> *r_options);
+
+	GDScriptWorkspace();
+	~GDScriptWorkspace();
+};
+
+#endif

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -84,8 +84,6 @@ public:
 
 	Dictionary generate_script_api(const String &p_path);
 
-	static String marked_documentation(const String &p_bbcode);
-
 	GDScriptWorkspace();
 	~GDScriptWorkspace();
 };

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -58,10 +58,11 @@ protected:
 
 public:
 	String root;
+	String root_uri;
 
 	Map<String, ExtendGDScriptParser *> scripts;
 	Map<String, ExtendGDScriptParser *> parse_results;
-	Map<String, const lsp::DocumentSymbol *> flat_symbols;
+	HashMap<StringName, ClassMembers> native_members;
 
 public:
 	Array symbol(const Dictionary &p_params);

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -50,27 +50,37 @@ protected:
 
 	void reload_all_workspace_scripts();
 
-	void list_script_files(const String &p_root_dir, List<String> &r_files);
 	ExtendGDScriptParser *get_parse_successed_script(const String &p_path);
 	ExtendGDScriptParser *get_parse_result(const String &p_path);
 
+	void strip_flat_symbols(const String &p_branch);
+	void list_script_files(const String &p_root_dir, List<String> &r_files);
+
 public:
 	String root;
+
 	Map<String, ExtendGDScriptParser *> scripts;
 	Map<String, ExtendGDScriptParser *> parse_results;
+	Map<String, const lsp::DocumentSymbol *> flat_symbols;
 
 public:
 	Array symbol(const Dictionary &p_params);
 
 public:
 	Error initialize();
+
 	Error parse_script(const String &p_path, const String &p_content);
 	Error parse_local_script(const String &p_path);
+
 	String get_file_path(const String &p_uri) const;
 	String get_file_uri(const String &p_path) const;
+
 	void publish_diagnostics(const String &p_path);
 	void completion(const lsp::CompletionParams &p_params, List<ScriptCodeCompletionOption> *r_options);
+
 	const lsp::DocumentSymbol *resolve_symbol(const lsp::TextDocumentPositionParams &p_doc_pos, const String &p_symbol_name = "", bool p_func_requred = false);
+	void resolve_related_symbols(const lsp::TextDocumentPositionParams &p_doc_pos, List<const lsp::DocumentSymbol *> &r_list);
+
 	static String marked_documentation(const String &p_bbcode);
 
 	GDScriptWorkspace();

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -82,6 +82,8 @@ public:
 	const lsp::DocumentSymbol *resolve_symbol(const lsp::TextDocumentPositionParams &p_doc_pos, const String &p_symbol_name = "", bool p_func_requred = false);
 	void resolve_related_symbols(const lsp::TextDocumentPositionParams &p_doc_pos, List<const lsp::DocumentSymbol *> &r_list);
 
+	Dictionary generate_script_api(const String &p_path);
+
 	static String marked_documentation(const String &p_bbcode);
 
 	GDScriptWorkspace();

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -42,6 +42,17 @@ class GDScriptWorkspace : public Reference {
 protected:
 	static void _bind_methods();
 	void remove_cache_parser(const String &p_path);
+	bool initialized = false;
+	Map<StringName, lsp::DocumentSymbol> native_symbols;
+
+	const lsp::DocumentSymbol *get_native_symbol(const String &p_class, const String &p_member = "") const;
+	const lsp::DocumentSymbol *get_script_symbol(const String &p_path) const;
+
+	void reload_all_workspace_scripts();
+
+	void list_script_files(const String &p_root_dir, List<String> &r_files);
+	ExtendGDScriptParser *get_parse_successed_script(const String &p_path);
+	ExtendGDScriptParser *get_parse_result(const String &p_path);
 
 public:
 	String root;
@@ -52,11 +63,15 @@ public:
 	Array symbol(const Dictionary &p_params);
 
 public:
+	Error initialize();
 	Error parse_script(const String &p_path, const String &p_content);
+	Error parse_local_script(const String &p_path);
 	String get_file_path(const String &p_uri) const;
 	String get_file_uri(const String &p_path) const;
 	void publish_diagnostics(const String &p_path);
 	void completion(const lsp::CompletionParams &p_params, List<ScriptCodeCompletionOption> *r_options);
+	const lsp::DocumentSymbol *resolve_symbol(const lsp::TextDocumentPositionParams &p_doc_pos, const String &p_symbol_name = "", bool p_func_requred = false);
+	static String marked_documentation(const String &p_bbcode);
 
 	GDScriptWorkspace();
 	~GDScriptWorkspace();

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -1,0 +1,1309 @@
+/*************************************************************************/
+/*  lsp.hpp                                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GODOT_LSP_H
+#define GODOT_LSP_H
+
+#include "core/variant.h"
+
+namespace lsp {
+
+typedef String DocumentUri;
+
+/**
+ * Text documents are identified using a URI. On the protocol level, URIs are passed as strings.
+ */
+struct TextDocumentIdentifier {
+	/**
+	 * The text document's URI.
+	 */
+	DocumentUri uri;
+
+	void load(const Dictionary &p_params) {
+		uri = p_params["uri"];
+	}
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["uri"] = uri;
+		return dict;
+	}
+};
+
+/**
+ * Position in a text document expressed as zero-based line and zero-based character offset.
+ * A position is between two characters like an ‘insert’ cursor in a editor.
+ * Special values like for example -1 to denote the end of a line are not supported.
+ */
+struct Position {
+	/**
+	 * Line position in a document (zero-based).
+	 */
+	int line = 0;
+
+	/**
+	 * Character offset on a line in a document (zero-based). Assuming that the line is
+	 * represented as a string, the `character` value represents the gap between the
+	 * `character` and `character + 1`.
+	 *
+	 * If the character value is greater than the line length it defaults back to the
+	 * line length.
+	 */
+	int character = 0;
+
+	void load(const Dictionary &p_params) {
+		line = p_params["line"];
+		character = p_params["character"];
+	}
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["line"] = line;
+		dict["character"] = character;
+		return dict;
+	}
+};
+
+/**
+ * A range in a text document expressed as (zero-based) start and end positions.
+ * A range is comparable to a selection in an editor. Therefore the end position is exclusive.
+ * If you want to specify a range that contains a line including the line ending character(s) then use an end position denoting the start of the next line.
+ */
+struct Range {
+	/**
+	 * The range's start position.
+	 */
+	Position start;
+
+	/**
+	 * The range's end position.
+	 */
+	Position end;
+
+	void load(const Dictionary &p_params) {
+		start.load(p_params["start"]);
+		end.load(p_params["end"]);
+	}
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["start"] = start.to_json();
+		dict["end"] = end.to_json();
+		return dict;
+	}
+};
+
+/**
+ * Represents a location inside a resource, such as a line inside a text file.
+ */
+struct Location {
+	DocumentUri uri;
+	Range range;
+
+	void load(const Dictionary &p_params) {
+		uri = p_params["uri"];
+		range.load(p_params["range"]);
+	}
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["uri"] = uri;
+		dict["range"] = range.to_json();
+		return dict;
+	}
+};
+
+/**
+ * Represents a link between a source and a target location.
+ */
+struct LocationLink {
+
+	/**
+	 * Span of the origin of this link.
+	 *
+	 * Used as the underlined span for mouse interaction. Defaults to the word range at
+	 * the mouse position.
+	 */
+	Range *originSelectionRange = NULL;
+
+	/**
+	 * The target resource identifier of this link.
+	 */
+	String targetUri;
+
+	/**
+	 * The full target range of this link. If the target for example is a symbol then target range is the
+	 * range enclosing this symbol not including leading/trailing whitespace but everything else
+	 * like comments. This information is typically used to highlight the range in the editor.
+	 */
+	Range targetRange;
+
+	/**
+	 * The range that should be selected and revealed when this link is being followed, e.g the name of a function.
+	 * Must be contained by the the `targetRange`. See also `DocumentSymbol#range`
+	 */
+	Range targetSelectionRange;
+};
+
+/**
+ * A parameter literal used in requests to pass a text document and a position inside that document.
+ */
+struct TextDocumentPositionParams {
+	/**
+	 * The text document.
+	 */
+	TextDocumentIdentifier textDocument;
+
+	/**
+	 * The position inside the text document.
+	 */
+	Position position;
+
+	void load(const Dictionary &p_params) {
+		textDocument.load(p_params["textDocument"]);
+		position.load(p_params["position"]);
+	}
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["textDocument"] = textDocument.to_json();
+		dict["position"] = position.to_json();
+		return dict;
+	}
+};
+
+namespace TextDocumentSyncKind {
+/**
+	 * Documents should not be synced at all.
+	 */
+static const int None = 0;
+
+/**
+	 * Documents are synced by always sending the full content
+	 * of the document.
+	 */
+static const int Full = 1;
+
+/**
+	 * Documents are synced by sending the full content on open.
+	 * After that only incremental updates to the document are
+	 * send.
+	 */
+static const int Incremental = 2;
+}; // namespace TextDocumentSyncKind
+
+/**
+ * Completion options.
+ */
+struct CompletionOptions {
+	/**
+	 * The server provides support to resolve additional
+	 * information for a completion item.
+	 */
+	bool resolveProvider = true;
+
+	/**
+	 * The characters that trigger completion automatically.
+	 */
+	Vector<String> triggerCharacters;
+
+	CompletionOptions() {
+		triggerCharacters.push_back(".");
+		triggerCharacters.push_back("$");
+		triggerCharacters.push_back("'");
+		triggerCharacters.push_back("\"");
+		triggerCharacters.push_back("(");
+		triggerCharacters.push_back(",");
+	}
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["resolveProvider"] = resolveProvider;
+		dict["triggerCharacters"] = triggerCharacters;
+		return dict;
+	}
+};
+
+/**
+ * Signature help options.
+ */
+struct SignatureHelpOptions {
+	/**
+	 * The characters that trigger signature help
+	 * automatically.
+	 */
+	Vector<String> triggerCharacters;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["triggerCharacters"] = triggerCharacters;
+		return dict;
+	}
+};
+
+/**
+ * Code Lens options.
+ */
+struct CodeLensOptions {
+	/**
+	 * Code lens has a resolve provider as well.
+	 */
+	bool resolveProvider = false;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["resolveProvider"] = resolveProvider;
+		return dict;
+	}
+};
+
+/**
+ * Rename options
+ */
+struct RenameOptions {
+	/**
+	 * Renames should be checked and tested before being executed.
+	 */
+	bool prepareProvider = false;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["prepareProvider"] = prepareProvider;
+		return dict;
+	}
+};
+
+/**
+ * Document link options.
+ */
+struct DocumentLinkOptions {
+	/**
+	 * Document links have a resolve provider as well.
+	 */
+	bool resolveProvider = false;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["resolveProvider"] = resolveProvider;
+		return dict;
+	}
+};
+
+/**
+ * Execute command options.
+ */
+struct ExecuteCommandOptions {
+	/**
+	 * The commands to be executed on the server
+	 */
+	Vector<String> commands;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["commands"] = commands;
+		return dict;
+	}
+};
+
+/**
+ * Save options.
+ */
+struct SaveOptions {
+	/**
+	 * The client is supposed to include the content on save.
+	 */
+	bool includeText = true;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["includeText"] = includeText;
+		return dict;
+	}
+};
+
+/**
+ * Color provider options.
+ */
+struct ColorProviderOptions {
+	Dictionary to_json() {
+		Dictionary dict;
+		return dict;
+	}
+};
+
+/**
+ * Folding range provider options.
+ */
+struct FoldingRangeProviderOptions {
+	Dictionary to_json() {
+		Dictionary dict;
+		return dict;
+	}
+};
+
+struct TextDocumentSyncOptions {
+	/**
+	 * Open and close notifications are sent to the server. If omitted open close notification should not
+	 * be sent.
+	 */
+	bool openClose = true;
+
+	/**
+	 * Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+	 * and TextDocumentSyncKind.Incremental. If omitted it defaults to TextDocumentSyncKind.None.
+	 */
+	int change = TextDocumentSyncKind::Full;
+
+	/**
+	 * If present will save notifications are sent to the server. If omitted the notification should not be
+	 * sent.
+	 */
+	bool willSave = false;
+
+	/**
+	 * If present will save wait until requests are sent to the server. If omitted the request should not be
+	 * sent.
+	 */
+	bool willSaveWaitUntil = false;
+
+	/**
+	 * If present save notifications are sent to the server. If omitted the notification should not be
+	 * sent.
+	 */
+	SaveOptions save;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["willSaveWaitUntil"] = willSaveWaitUntil;
+		dict["willSave"] = willSave;
+		dict["openClose"] = openClose;
+		dict["change"] = change;
+		dict["change"] = save.to_json();
+		return dict;
+	}
+};
+
+/**
+ * Static registration options to be returned in the initialize request.
+ */
+struct StaticRegistrationOptions {
+	/**
+	 * The id used to register the request. The id can be used to deregister
+	 * the request again. See also Registration#id.
+	 */
+	String id;
+};
+
+/**
+ * Format document on type options.
+ */
+struct DocumentOnTypeFormattingOptions {
+	/**
+	 * A character on which formatting should be triggered, like `}`.
+	 */
+	String firstTriggerCharacter;
+
+	/**
+	 * More trigger characters.
+	 */
+	Vector<String> moreTriggerCharacter;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["firstTriggerCharacter"] = firstTriggerCharacter;
+		dict["moreTriggerCharacter"] = moreTriggerCharacter;
+		return dict;
+	}
+};
+
+struct TextDocumentItem {
+	/**
+	 * The text document's URI.
+	 */
+	DocumentUri uri;
+
+	/**
+	 * The text document's language identifier.
+	 */
+	String languageId;
+
+	/**
+	 * The version number of this document (it will increase after each
+	 * change, including undo/redo).
+	 */
+	int version;
+
+	/**
+	 * The content of the opened text document.
+	 */
+	String text;
+
+	void load(const Dictionary &p_dict) {
+		uri = p_dict["uri"];
+		languageId = p_dict["languageId"];
+		version = p_dict["version"];
+		text = p_dict["text"];
+	}
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["uri"] = uri;
+		dict["languageId"] = languageId;
+		dict["version"] = version;
+		dict["text"] = text;
+		return dict;
+	}
+};
+
+/**
+ * An event describing a change to a text document. If range and rangeLength are omitted
+ * the new text is considered to be the full content of the document.
+ */
+struct TextDocumentContentChangeEvent {
+	/**
+	 * The range of the document that changed.
+	 */
+	Range range;
+
+	/**
+	 * The length of the range that got replaced.
+	 */
+	int rangeLength;
+
+	/**
+	 * The new text of the range/document.
+	 */
+	String text;
+
+	void load(const Dictionary &p_params) {
+		text = p_params["text"];
+		rangeLength = p_params["rangeLength"];
+		range.load(p_params["range"]);
+	}
+};
+
+namespace DiagnosticSeverity {
+/**
+	 * Reports an error.
+	 */
+static const int Error = 1;
+/**
+	 * Reports a warning.
+	 */
+static const int Warning = 2;
+/**
+	 * Reports an information.
+	 */
+static const int Information = 3;
+/**
+	 * Reports a hint.
+	 */
+static const int Hint = 4;
+}; // namespace DiagnosticSeverity
+
+/**
+ * Represents a related message and source code location for a diagnostic. This should be
+ * used to point to code locations that cause or related to a diagnostics, e.g when duplicating
+ * a symbol in a scope.
+ */
+struct DiagnosticRelatedInformation {
+	/**
+	 * The location of this related diagnostic information.
+	 */
+	Location location;
+
+	/**
+	 * The message of this related diagnostic information.
+	 */
+	String message;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["location"] = location.to_json(),
+		dict["message"] = message;
+		return dict;
+	}
+};
+
+/**
+ * Represents a diagnostic, such as a compiler error or warning.
+ * Diagnostic objects are only valid in the scope of a resource.
+ */
+struct Diagnostic {
+	/**
+	 * The range at which the message applies.
+	 */
+	Range range;
+
+	/**
+	 * The diagnostic's severity. Can be omitted. If omitted it is up to the
+	 * client to interpret diagnostics as error, warning, info or hint.
+	 */
+	int severity;
+
+	/**
+	 * The diagnostic's code, which might appear in the user interface.
+	 */
+	int code;
+
+	/**
+	 * A human-readable string describing the source of this
+	 * diagnostic, e.g. 'typescript' or 'super lint'.
+	 */
+	String source;
+
+	/**
+	 * The diagnostic's message.
+	 */
+	String message;
+
+	/**
+	 * An array of related diagnostic information, e.g. when symbol-names within
+	 * a scope collide all definitions can be marked via this property.
+	 */
+	Vector<DiagnosticRelatedInformation> relatedInformation;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["range"] = range.to_json();
+		dict["code"] = code;
+		dict["severity"] = severity;
+		dict["message"] = message;
+		dict["source"] = source;
+		if (!relatedInformation.empty()) {
+			Array arr;
+			arr.resize(relatedInformation.size());
+			for (int i = 0; i < relatedInformation.size(); i++) {
+				arr[i] = relatedInformation[i].to_json();
+			}
+			dict["relatedInformation"] = arr;
+		}
+		return dict;
+	}
+};
+
+/**
+ * A symbol kind.
+ */
+namespace SymbolKind {
+static const int File = 1;
+static const int Module = 2;
+static const int Namespace = 3;
+static const int Package = 4;
+static const int Class = 5;
+static const int Method = 6;
+static const int Property = 7;
+static const int Field = 8;
+static const int Constructor = 9;
+static const int Enum = 10;
+static const int Interface = 11;
+static const int Function = 12;
+static const int Variable = 13;
+static const int Constant = 14;
+static const int String = 15;
+static const int Number = 16;
+static const int Boolean = 17;
+static const int Array = 18;
+static const int Object = 19;
+static const int Key = 20;
+static const int Null = 21;
+static const int EnumMember = 22;
+static const int Struct = 23;
+static const int Event = 24;
+static const int Operator = 25;
+static const int TypeParameter = 26;
+}; // namespace SymbolKind
+
+/**
+ * Represents information about programming constructs like variables, classes,
+ * interfaces etc.
+ */
+struct SymbolInformation {
+	/**
+	 * The name of this symbol.
+	 */
+	String name;
+
+	/**
+	 * The kind of this symbol.
+	 */
+	int kind = SymbolKind::File;
+
+	/**
+	 * Indicates if this symbol is deprecated.
+	 */
+	bool deprecated = false;
+
+	/**
+	 * The location of this symbol. The location's range is used by a tool
+	 * to reveal the location in the editor. If the symbol is selected in the
+	 * tool the range's start information is used to position the cursor. So
+	 * the range usually spans more then the actual symbol's name and does
+	 * normally include things like visibility modifiers.
+	 *
+	 * The range doesn't have to denote a node range in the sense of a abstract
+	 * syntax tree. It can therefore not be used to re-construct a hierarchy of
+	 * the symbols.
+	 */
+	Location location;
+
+	/**
+	 * The name of the symbol containing this symbol. This information is for
+	 * user interface purposes (e.g. to render a qualifier in the user interface
+	 * if necessary). It can't be used to re-infer a hierarchy for the document
+	 * symbols.
+	 */
+	String containerName;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["name"] = name;
+		dict["kind"] = kind;
+		dict["deprecated"] = deprecated;
+		dict["location"] = location.to_json();
+		dict["containerName"] = containerName;
+		return dict;
+	}
+};
+
+/**
+ * Represents programming constructs like variables, classes, interfaces etc. that appear in a document. Document symbols can be
+ * hierarchical and they have two ranges: one that encloses its definition and one that points to its most interesting range,
+ * e.g. the range of an identifier.
+ */
+struct DocumentSymbol {
+
+	/**
+	 * The name of this symbol. Will be displayed in the user interface and therefore must not be
+	 * an empty string or a string only consisting of white spaces.
+	 */
+	String name;
+
+	/**
+	 * More detail for this symbol, e.g the signature of a function.
+	 */
+	String detail;
+
+	/**
+	 * The kind of this symbol.
+	 */
+	int kind = SymbolKind::File;
+
+	/**
+	 * Indicates if this symbol is deprecated.
+	 */
+	bool deprecated = false;
+
+	/**
+	 * The range enclosing this symbol not including leading/trailing whitespace but everything else
+	 * like comments. This information is typically used to determine if the clients cursor is
+	 * inside the symbol to reveal in the symbol in the UI.
+	 */
+	Range range;
+
+	/**
+	 * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+	 * Must be contained by the `range`.
+	 */
+	Range selectionRange;
+
+	/**
+	 * Children of this symbol, e.g. properties of a class.
+	 */
+	Vector<DocumentSymbol> children;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["name"] = name;
+		dict["detail"] = detail;
+		dict["kind"] = kind;
+		dict["deprecated"] = deprecated;
+		dict["range"] = range.to_json();
+		dict["selectionRange"] = selectionRange.to_json();
+		Array arr;
+		arr.resize(children.size());
+		for (int i = 0; i < children.size(); i++) {
+			arr[i] = children[i].to_json();
+		}
+		dict["children"] = arr;
+		return dict;
+	}
+
+	void symbol_tree_as_list(const String &p_uri, Vector<SymbolInformation> &r_list, const String &p_container = "") const {
+		SymbolInformation si;
+		si.name = name;
+		si.kind = kind;
+		si.containerName = p_container;
+		si.deprecated = deprecated;
+		si.location.uri = p_uri;
+		si.location.range = range;
+		r_list.push_back(si);
+		for (int i = 0; i < children.size(); i++) {
+			children[i].symbol_tree_as_list(p_uri, r_list, name);
+		}
+	}
+};
+
+/**
+ * A textual edit applicable to a text document.
+ */
+struct TextEdit {
+	/**
+	 * The range of the text document to be manipulated. To insert
+	 * text into a document create a range where start === end.
+	 */
+	Range range;
+
+	/**
+	 * The string to be inserted. For delete operations use an
+	 * empty string.
+	 */
+	String newText;
+};
+
+/**
+ * Represents a reference to a command.
+ * Provides a title which will be used to represent a command in the UI.
+ * Commands are identified by a string identifier.
+ * The recommended way to handle commands is to implement their execution on the server side if the client and server provides the corresponding capabilities.
+ * Alternatively the tool extension code could handle the command. The protocol currently doesn’t specify a set of well-known commands.
+ */
+struct Command {
+	/**
+	 * Title of the command, like `save`.
+	 */
+	String title;
+	/**
+	 * The identifier of the actual command handler.
+	 */
+	String command;
+	/**
+	 * Arguments that the command handler should be
+	 * invoked with.
+	 */
+	Array arguments;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["title"] = title;
+		dict["command"] = command;
+		if (arguments.size()) dict["arguments"] = arguments;
+		return dict;
+	}
+};
+
+/**
+ * The kind of a completion entry.
+ */
+namespace CompletionItemKind {
+static const int Text = 1;
+static const int Method = 2;
+static const int Function = 3;
+static const int Constructor = 4;
+static const int Field = 5;
+static const int Variable = 6;
+static const int Class = 7;
+static const int Interface = 8;
+static const int Module = 9;
+static const int Property = 10;
+static const int Unit = 11;
+static const int Value = 12;
+static const int Enum = 13;
+static const int Keyword = 14;
+static const int Snippet = 15;
+static const int Color = 16;
+static const int File = 17;
+static const int Reference = 18;
+static const int Folder = 19;
+static const int EnumMember = 20;
+static const int Constant = 21;
+static const int Struct = 22;
+static const int Event = 23;
+static const int Operator = 24;
+static const int TypeParameter = 25;
+}; // namespace CompletionItemKind
+
+/**
+ * Defines whether the insert text in a completion item should be interpreted as
+ * plain text or a snippet.
+ */
+namespace InsertTextFormat {
+/**
+	 * The primary text to be inserted is treated as a plain string.
+	 */
+static const int PlainText = 1;
+
+/**
+	 * The primary text to be inserted is treated as a snippet.
+	 *
+	 * A snippet can define tab stops and placeholders with `$1`, `$2`
+	 * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+	 * the end of the snippet. Placeholders with equal identifiers are linked,
+	 * that is typing in one will update others too.
+	 */
+static const int Snippet = 2;
+}; // namespace InsertTextFormat
+
+struct CompletionItem {
+	/**
+	 * The label of this completion item. By default
+	 * also the text that is inserted when selecting
+	 * this completion.
+	 */
+	String label;
+
+	/**
+	 * The kind of this completion item. Based of the kind
+	 * an icon is chosen by the editor. The standardized set
+	 * of available values is defined in `CompletionItemKind`.
+	 */
+	int kind;
+
+	/**
+	 * A human-readable string with additional information
+	 * about this item, like type or symbol information.
+	 */
+	String detail;
+
+	/**
+	 * A human-readable string that represents a doc-comment.
+	 */
+	String documentation;
+
+	/**
+	 * Indicates if this item is deprecated.
+	 */
+	bool deprecated = false;
+
+	/**
+	 * Select this item when showing.
+	 *
+	 * *Note* that only one completion item can be selected and that the
+	 * tool / client decides which item that is. The rule is that the *first*
+	 * item of those that match best is selected.
+	 */
+	bool preselect = false;
+
+	/**
+	 * A string that should be used when comparing this item
+	 * with other items. When `falsy` the label is used.
+	 */
+	String sortText;
+
+	/**
+	 * A string that should be used when filtering a set of
+	 * completion items. When `falsy` the label is used.
+	 */
+	String filterText;
+
+	/**
+	 * A string that should be inserted into a document when selecting
+	 * this completion. When `falsy` the label is used.
+	 *
+	 * The `insertText` is subject to interpretation by the client side.
+	 * Some tools might not take the string literally. For example
+	 * VS Code when code complete is requested in this example `con<cursor position>`
+	 * and a completion item with an `insertText` of `console` is provided it
+	 * will only insert `sole`. Therefore it is recommended to use `textEdit` instead
+	 * since it avoids additional client side interpretation.
+	 *
+	 * @deprecated Use textEdit instead.
+	 */
+	String insertText;
+
+	/**
+	 * The format of the insert text. The format applies to both the `insertText` property
+	 * and the `newText` property of a provided `textEdit`.
+	 */
+	int insertTextFormat;
+
+	/**
+	 * An edit which is applied to a document when selecting this completion. When an edit is provided the value of
+	 * `insertText` is ignored.
+	 *
+	 * *Note:* The range of the edit must be a single line range and it must contain the position at which completion
+	 * has been requested.
+	 */
+	TextEdit textEdit;
+
+	/**
+	 * An optional array of additional text edits that are applied when
+	 * selecting this completion. Edits must not overlap (including the same insert position)
+	 * with the main edit nor with themselves.
+	 *
+	 * Additional text edits should be used to change text unrelated to the current cursor position
+	 * (for example adding an import statement at the top of the file if the completion item will
+	 * insert an unqualified type).
+	 */
+	Vector<TextEdit> additionalTextEdits;
+
+	/**
+	 * An optional set of characters that when pressed while this completion is active will accept it first and
+	 * then type that character. *Note* that all commit characters should have `length=1` and that superfluous
+	 * characters will be ignored.
+	 */
+	Vector<String> commitCharacters;
+
+	/**
+	 * An optional command that is executed *after* inserting this completion. *Note* that
+	 * additional modifications to the current document should be described with the
+	 * additionalTextEdits-property.
+	 */
+	Command command;
+
+	/**
+	 * A data entry field that is preserved on a completion item between
+	 * a completion and a completion resolve request.
+	 */
+	Variant data;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["label"] = label;
+		dict["kind"] = kind;
+		dict["kind"] = kind;
+		dict["detail"] = detail;
+		dict["documentation"] = documentation;
+		dict["deprecated"] = deprecated;
+		dict["preselect"] = preselect;
+		dict["sortText"] = sortText;
+		dict["filterText"] = filterText;
+		dict["insertText"] = insertText;
+		if (commitCharacters.size()) dict["commitCharacters"] = commitCharacters;
+		dict["command"] = command.to_json();
+		dict["data"] = data;
+		return dict;
+	}
+};
+
+/**
+ * Represents a collection of [completion items](#CompletionItem) to be presented
+ * in the editor.
+ */
+struct CompletionList {
+	/**
+	 * This list it not complete. Further typing should result in recomputing
+	 * this list.
+	 */
+	bool isIncomplete;
+
+	/**
+	 * The completion items.
+	 */
+	Vector<CompletionItem> items;
+};
+
+/**
+ * Enum of known range kinds
+ */
+namespace FoldingRangeKind {
+/**
+	 * Folding range for a comment
+	 */
+static const String Comment = "comment";
+/**
+	 * Folding range for a imports or includes
+	 */
+static const String Imports = "imports";
+/**
+	 * Folding range for a region (e.g. `#region`)
+	 */
+static const String Region = "region";
+} // namespace FoldingRangeKind
+
+/**
+ * Represents a folding range.
+ */
+struct FoldingRange {
+
+	/**
+	 * The zero-based line number from where the folded range starts.
+	 */
+	int startLine = 0;
+
+	/**
+	 * The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
+	 */
+	int startCharacter = 0;
+
+	/**
+	 * The zero-based line number where the folded range ends.
+	 */
+	int endLine = 0;
+
+	/**
+	 * The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
+	 */
+	int endCharacter = 0;
+
+	/**
+	 * Describes the kind of the folding range such as `comment' or 'region'. The kind
+	 * is used to categorize folding ranges and used by commands like 'Fold all comments'. See
+	 * [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
+	 */
+	String kind = FoldingRangeKind::Region;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["startLine"] = startLine;
+		dict["startCharacter"] = startCharacter;
+		dict["endLine"] = endLine;
+		dict["endCharacter"] = endCharacter;
+		return dict;
+	}
+};
+
+/**
+ * How a completion was triggered
+ */
+namespace CompletionTriggerKind {
+/**
+	 * Completion was triggered by typing an identifier (24x7 code
+	 * complete), manual invocation (e.g Ctrl+Space) or via API.
+	 */
+static const int Invoked = 1;
+
+/**
+	 * Completion was triggered by a trigger character specified by
+	 * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+	 */
+static const int TriggerCharacter = 2;
+
+/**
+	 * Completion was re-triggered as the current completion list is incomplete.
+	 */
+static const int TriggerForIncompleteCompletions = 3;
+} // namespace CompletionTriggerKind
+
+/**
+ * Contains additional information about the context in which a completion request is triggered.
+ */
+struct CompletionContext {
+	/**
+	* How the completion was triggered.
+	*/
+	int triggerKind = CompletionTriggerKind::TriggerCharacter;
+
+	/**
+	 * The trigger character (a single character) that has trigger code complete.
+	 * Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+	 */
+	String triggerCharacter;
+
+	void load(const Dictionary &p_params) {
+		triggerKind = int(p_params["triggerKind"]);
+		triggerCharacter = p_params["triggerCharacter"];
+	}
+};
+
+struct CompletionParams : public TextDocumentPositionParams {
+
+	/**
+	 * The completion context. This is only available if the client specifies
+	 * to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
+	 */
+	CompletionContext context;
+
+	void load(const Dictionary &p_params) {
+		TextDocumentPositionParams::load(p_params);
+		context.load(p_params["context"]);
+	}
+};
+
+struct ServerCapabilities {
+	/**
+	 * Defines how text documents are synced. Is either a detailed structure defining each notification or
+	 * for backwards compatibility the TextDocumentSyncKind number. If omitted it defaults to `TextDocumentSyncKind.None`.
+	 */
+	TextDocumentSyncOptions textDocumentSync;
+
+	/**
+	 * The server provides hover support.
+	 */
+	bool hoverProvider = true;
+
+	/**
+	 * The server provides completion support.
+	 */
+	CompletionOptions completionProvider;
+
+	/**
+	 * The server provides signature help support.
+	 */
+	SignatureHelpOptions signatureHelpProvider;
+
+	/**
+	 * The server provides goto definition support.
+	 */
+	bool definitionProvider = false;
+
+	/**
+	 * The server provides Goto Type Definition support.
+	 *
+	 * Since 3.6.0
+	 */
+	bool typeDefinitionProvider = false;
+
+	/**
+	 * The server provides Goto Implementation support.
+	 *
+	 * Since 3.6.0
+	 */
+	bool implementationProvider = false;
+
+	/**
+	 * The server provides find references support.
+	 */
+	bool referencesProvider = false;
+
+	/**
+	 * The server provides document highlight support.
+	 */
+	bool documentHighlightProvider = false;
+
+	/**
+	 * The server provides document symbol support.
+	 */
+	bool documentSymbolProvider = true;
+
+	/**
+	 * The server provides workspace symbol support.
+	 */
+	bool workspaceSymbolProvider = true;
+
+	/**
+	 * The server provides code actions. The `CodeActionOptions` return type is only
+	 * valid if the client signals code action literal support via the property
+	 * `textDocument.codeAction.codeActionLiteralSupport`.
+	 */
+	bool codeActionProvider = false;
+
+	/**
+	 * The server provides code lens.
+	 */
+	CodeLensOptions codeLensProvider;
+
+	/**
+	 * The server provides document formatting.
+	 */
+	bool documentFormattingProvider = false;
+
+	/**
+	 * The server provides document range formatting.
+	 */
+	bool documentRangeFormattingProvider = false;
+
+	/**
+	 * The server provides document formatting on typing.
+	 */
+	DocumentOnTypeFormattingOptions documentOnTypeFormattingProvider;
+
+	/**
+	 * The server provides rename support. RenameOptions may only be
+	 * specified if the client states that it supports
+	 * `prepareSupport` in its initial `initialize` request.
+	 */
+	RenameOptions renameProvider;
+
+	/**
+	 * The server provides document link support.
+	 */
+	DocumentLinkOptions documentLinkProvider;
+
+	/**
+	 * The server provides color provider support.
+	 *
+	 * Since 3.6.0
+	 */
+	ColorProviderOptions colorProvider;
+
+	/**
+	 * The server provides folding provider support.
+	 *
+	 * Since 3.10.0
+	 */
+	FoldingRangeProviderOptions foldingRangeProvider;
+
+	/**
+	 * The server provides go to declaration support.
+	 *
+	 * Since 3.14.0
+	 */
+	bool declarationProvider = true;
+
+	/**
+	 * The server provides execute command support.
+	 */
+	ExecuteCommandOptions executeCommandProvider;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["textDocumentSync"] = (int)textDocumentSync.change;
+		dict["completionProvider"] = completionProvider.to_json();
+		dict["signatureHelpProvider"] = signatureHelpProvider.to_json();
+		dict["codeLensProvider"] = false; // codeLensProvider.to_json();
+		dict["documentOnTypeFormattingProvider"] = documentOnTypeFormattingProvider.to_json();
+		dict["renameProvider"] = renameProvider.to_json();
+		dict["documentLinkProvider"] = documentLinkProvider.to_json();
+		dict["colorProvider"] = false; // colorProvider.to_json();
+		dict["foldingRangeProvider"] = false; //foldingRangeProvider.to_json();
+		dict["executeCommandProvider"] = executeCommandProvider.to_json();
+		dict["hoverProvider"] = hoverProvider;
+		dict["definitionProvider"] = definitionProvider;
+		dict["typeDefinitionProvider"] = typeDefinitionProvider;
+		dict["implementationProvider"] = implementationProvider;
+		dict["referencesProvider"] = referencesProvider;
+		dict["documentHighlightProvider"] = documentHighlightProvider;
+		dict["documentSymbolProvider"] = documentSymbolProvider;
+		dict["workspaceSymbolProvider"] = workspaceSymbolProvider;
+		dict["codeActionProvider"] = codeActionProvider;
+		dict["documentFormattingProvider"] = documentFormattingProvider;
+		dict["documentRangeFormattingProvider"] = documentRangeFormattingProvider;
+		dict["declarationProvider"] = declarationProvider;
+		return dict;
+	}
+};
+
+struct InitializeResult {
+	/**
+	 * The capabilities the language server provides.
+	 */
+	ServerCapabilities capabilities;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["capabilities"] = capabilities.to_json();
+		return dict;
+	}
+};
+
+} // namespace lsp
+
+#endif

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -1064,6 +1064,11 @@ struct DocumentSymbol {
 	String documentation;
 
 	/**
+	 * Class name for the native symbols
+	 */
+	String native_class;
+
+	/**
 	 * The kind of this symbol.
 	 */
 	int kind = SymbolKind::File;

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -886,12 +886,12 @@ struct CompletionItem {
 	 */
 	Variant data;
 
-	_FORCE_INLINE_ Dictionary to_json(bool minimized = false) const {
+	_FORCE_INLINE_ Dictionary to_json(bool resolved = false) const {
 		Dictionary dict;
 		dict["label"] = label;
 		dict["kind"] = kind;
 		dict["data"] = data;
-		if (!minimized) {
+		if (resolved) {
 			dict["insertText"] = insertText;
 			dict["detail"] = detail;
 			dict["documentation"] = documentation.to_json();
@@ -1145,12 +1145,12 @@ struct DocumentSymbol {
 		return markdown;
 	}
 
-	_FORCE_INLINE_ CompletionItem make_completion_item(bool with_doc = false) const {
+	_FORCE_INLINE_ CompletionItem make_completion_item(bool resolved = false) const {
 
 		lsp::CompletionItem item;
 		item.label = name;
 
-		if (with_doc) {
+		if (resolved) {
 			item.documentation = render();
 		}
 

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -36,6 +36,7 @@
 #include "editor/gdscript_highlighter.h"
 #include "gdscript.h"
 #include "gdscript_tokenizer.h"
+#include "language_server/gdscript_language_server.h"
 
 GDScriptLanguage *script_language_gd = NULL;
 Ref<ResourceFormatLoaderGDScript> resource_loader_gd;
@@ -130,6 +131,8 @@ static void _editor_init() {
 	Ref<EditorExportGDScript> gd_export;
 	gd_export.instance();
 	EditorExport::get_singleton()->add_export_plugin(gd_export);
+	EditorNode::get_singleton()->add_editor_plugin(memnew(GDScriptLanguageServer));
+	register_lsp_types();
 }
 
 #endif

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -44,6 +44,7 @@ Ref<ResourceFormatSaverGDScript> resource_saver_gd;
 
 #ifdef TOOLS_ENABLED
 
+#include "core/engine.h"
 #include "editor/editor_export.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
@@ -131,8 +132,11 @@ static void _editor_init() {
 	Ref<EditorExportGDScript> gd_export;
 	gd_export.instance();
 	EditorExport::get_singleton()->add_export_plugin(gd_export);
-	EditorNode::get_singleton()->add_editor_plugin(memnew(GDScriptLanguageServer));
+
 	register_lsp_types();
+	GDScriptLanguageServer *lsp_plugin = memnew(GDScriptLanguageServer);
+	EditorNode::get_singleton()->add_editor_plugin(lsp_plugin);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("GDScriptLanguageProtocol", GDScriptLanguageProtocol::get_singleton()));
 }
 
 #endif

--- a/modules/jsonrpc/SCsub
+++ b/modules/jsonrpc/SCsub
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+Import('env')
+Import('env_modules')
+
+env_jsonrpc = env_modules.Clone()
+env_jsonrpc.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/jsonrpc/config.py
+++ b/modules/jsonrpc/config.py
@@ -1,0 +1,5 @@
+def can_build(env, platform):
+	return True
+
+def configure(env):
+	pass

--- a/modules/jsonrpc/jsonrpc.cpp
+++ b/modules/jsonrpc/jsonrpc.cpp
@@ -1,0 +1,171 @@
+/*************************************************************************/
+/*  jsonrpc.cpp                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "jsonrpc.h"
+#include "core/io/json.h"
+
+JSONRPC::JSONRPC() {
+}
+
+JSONRPC::~JSONRPC() {
+}
+
+void JSONRPC::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_scope", "scope", "target"), &JSONRPC::set_scope);
+	ClassDB::bind_method(D_METHOD("process_action", "action", "recurse"), &JSONRPC::process_action, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("process_string", "action"), &JSONRPC::process_string);
+
+	ClassDB::bind_method(D_METHOD("make_request", "method", "params", "id"), &JSONRPC::make_request);
+	ClassDB::bind_method(D_METHOD("make_response", "result", "id"), &JSONRPC::make_response);
+	ClassDB::bind_method(D_METHOD("make_notification", "method", "params"), &JSONRPC::make_notification);
+	ClassDB::bind_method(D_METHOD("make_response_error", "code", "message", "id"), &JSONRPC::make_response_error, DEFVAL(Variant()));
+
+	BIND_ENUM_CONSTANT(ParseError)
+	BIND_ENUM_CONSTANT(InvalidRequest)
+	BIND_ENUM_CONSTANT(MethodNotFound)
+	BIND_ENUM_CONSTANT(InvalidParams)
+	BIND_ENUM_CONSTANT(InternalError)
+}
+
+Dictionary JSONRPC::make_response_error(int p_code, const String &p_message, const Variant &p_id) const {
+	Dictionary dict;
+	dict["jsonrpc"] = "2.0";
+
+	Dictionary err;
+	err["code"] = p_code;
+	err["message"] = p_message;
+
+	dict["error"] = err;
+	dict["id"] = p_id;
+
+	return dict;
+}
+
+Dictionary JSONRPC::make_response(const Variant &p_value, const Variant &p_id) {
+	Dictionary dict;
+	dict["jsonrpc"] = "2.0";
+	dict["id"] = p_id;
+	dict["result"] = p_value;
+	return dict;
+}
+
+Dictionary JSONRPC::make_notification(const String &p_method, const Variant &p_params) {
+	Dictionary dict;
+	dict["jsonrpc"] = "2.0";
+	dict["method"] = p_method;
+	dict["params"] = p_params;
+	return dict;
+}
+
+Dictionary JSONRPC::make_request(const String &p_method, const Variant &p_params, const Variant &p_id) {
+	Dictionary dict;
+	dict["jsonrpc"] = "2.0";
+	dict["method"] = p_method;
+	dict["params"] = p_params;
+	dict["id"] = p_id;
+	return dict;
+}
+
+Variant JSONRPC::process_action(const Variant &p_action, bool p_process_arr_elements) {
+	Variant ret;
+	if (p_action.get_type() == Variant::DICTIONARY) {
+		Dictionary dict = p_action;
+		String method = dict.get("method", "");
+		Array args;
+		if (dict.has("params")) {
+			Variant params = dict.get("params", Variant());
+			if (params.get_type() == Variant::ARRAY) {
+				args = params;
+			} else {
+				args.push_back(params);
+			}
+		}
+
+		Object *object = this;
+		if (method_scopes.has(method.get_base_dir())) {
+			object = method_scopes[method.get_base_dir()];
+			method = method.get_file();
+		}
+
+		Variant id;
+		if (dict.has("id")) {
+			id = dict["id"];
+		}
+
+		if (object == NULL || !object->has_method(method)) {
+			ret = make_response_error(JSONRPC::MethodNotFound, "Method not found", id);
+		} else {
+			Variant call_ret = object->callv(method, args);
+			if (id.get_type() != Variant::NIL) {
+				ret = make_response(call_ret, id);
+			}
+		}
+	} else if (p_action.get_type() == Variant::ARRAY && p_process_arr_elements) {
+		Array arr = p_action;
+		int size = arr.size();
+		if (size) {
+			Array arr_ret;
+			for (int i = 0; i < size; i++) {
+				const Variant &var = arr.get(i);
+				arr_ret.push_back(process_action(var));
+			}
+			ret = arr_ret;
+		} else {
+			ret = make_response_error(JSONRPC::InvalidRequest, "Invalid Request");
+		}
+	} else {
+		ret = make_response_error(JSONRPC::InvalidRequest, "Invalid Request");
+	}
+	return ret;
+}
+
+String JSONRPC::process_string(const String &p_input) {
+
+	if (p_input.empty()) return String();
+
+	Variant ret;
+	Variant input;
+	String err_message;
+	int err_line;
+	if (OK != JSON::parse(p_input, input, err_message, err_line)) {
+		ret = make_response_error(JSONRPC::ParseError, "Parse error");
+	} else {
+		ret = process_action(input, true);
+	}
+
+	if (ret.get_type() == Variant::NIL) {
+		return "";
+	}
+	return JSON::print(ret);
+}
+
+void JSONRPC::set_scope(const String &p_scope, Object *p_obj) {
+	method_scopes[p_scope] = p_obj;
+}

--- a/modules/jsonrpc/jsonrpc.h
+++ b/modules/jsonrpc/jsonrpc.h
@@ -1,0 +1,70 @@
+/*************************************************************************/
+/*  jsonrpc.h                                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GODOT_JSON_RPC_H
+#define GODOT_JSON_RPC_H
+
+#include "core/object.h"
+#include "core/variant.h"
+
+class JSONRPC : public Object {
+	GDCLASS(JSONRPC, Object)
+
+	Map<String, Object *> method_scopes;
+
+protected:
+	static void _bind_methods();
+
+public:
+	JSONRPC();
+	~JSONRPC();
+
+	enum ErrorCode {
+		ParseError = -32700,
+		InvalidRequest = -32600,
+		MethodNotFound = -32601,
+		InvalidParams = -32602,
+		InternalError = -32603,
+	};
+
+	Dictionary make_response_error(int p_code, const String &p_message, const Variant &p_id = Variant()) const;
+	Dictionary make_response(const Variant &p_value, const Variant &p_id);
+	Dictionary make_notification(const String &p_method, const Variant &p_params);
+	Dictionary make_request(const String &p_method, const Variant &p_params, const Variant &p_id);
+
+	Variant process_action(const Variant &p_action, bool p_process_arr_elements = false);
+	String process_string(const String &p_input);
+
+	void set_scope(const String &p_scope, Object *p_obj);
+};
+
+VARIANT_ENUM_CAST(JSONRPC::ErrorCode);
+
+#endif

--- a/modules/jsonrpc/register_types.cpp
+++ b/modules/jsonrpc/register_types.cpp
@@ -1,0 +1,40 @@
+/*************************************************************************/
+/*  register_types.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "register_types.h"
+#include "core/class_db.h"
+#include "jsonrpc.h"
+
+void register_jsonrpc_types() {
+	ClassDB::register_class<JSONRPC>();
+}
+
+void unregister_jsonrpc_types() {
+}

--- a/modules/jsonrpc/register_types.h
+++ b/modules/jsonrpc/register_types.h
@@ -1,0 +1,32 @@
+/*************************************************************************/
+/*  register_types.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+void register_jsonrpc_types();
+void unregister_jsonrpc_types();


### PR DESCRIPTION
It basicly works but not finished yet.

Add a plugin for godot editor to provide  a [LSP](https://microsoft.github.io/language-server-protocol) Server for GDScript language.

More features would be added in the future by @ankitpriyarup  who's the selected student of this slot of the GSoC this year.

This PR contains a commit of #29626 for the code completion usage.

I submit the PR to master. Once it was meged @ankitpriyarup could add  other features by submit other PRs based on this to master branch.

UPDATE: 2019-06-30
------------
The LSP implementation is works correctly both the server and client side.

Current supported features:
- document symbols
- workspace symbols
- diagnostics
- completion
- completion resolve
- hover
- definition
- **Smart resolve mode**:  to resolve symbols for dynamic typed variables to seed up coding.
- Script API dump

Planning features:
- signatureHelp
- documentLink

Testers are wellcomed. Here is the client for Visual Studio Code extension
[godot-tools-0.9.0.zip](https://github.com/godotengine/godot/files/3329595/godot-tools-0.9.0.zip)


![ezgif-2-81c8438ce5be](https://user-images.githubusercontent.com/6964556/60088350-1ae7ac80-9771-11e9-856e-8aa0e9ad35f3.gif)
