### PR TITLE
Allow setting websocket buffers sizes internally.

### DIFF
--- a/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
+++ b/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
@@ -18,6 +18,24 @@
 				Returns the [WebSocketPeer] associated to the given [code]peer_id[/code].
 			</description>
 		</method>
+		<method name="set_buffers">
+			<return type="int" enum="Error">
+			</return>
+			<argument index="0" name="input_buffer_size_kb" type="int">
+			</argument>
+			<argument index="1" name="input_max_packets" type="int">
+			</argument>
+			<argument index="2" name="output_buffer_size_kb" type="int">
+			</argument>
+			<argument index="3" name="output_max_packets" type="int">
+			</argument>
+			<description>
+				Configure the buffers sizes for this WebSocket peer. Default values can be specified in project settings under [code]network/limits[/code]. For server, values are meant per connected peer.
+				The first two parameters define the size and queued packets limits of the input buffer, the last two of the output buffer.
+				Buffer sizes are expressed in KiB, so [code]4 = 2^12 = 4096 bytes[/code]. All parameters will be rounded up to the nearest power of two.
+				NOTE: HTML5 exports only use the input buffer since the output one is managed by browsers.
+			</description>
+		</method>
 	</methods>
 	<signals>
 		<signal name="peer_packet">

--- a/modules/websocket/emws_client.cpp
+++ b/modules/websocket/emws_client.cpp
@@ -205,6 +205,12 @@ int EMWSClient::get_max_packet_size() const {
 	return (1 << _in_buf_size) - PROTO_SIZE;
 }
 
+Error EMWSClient::set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) {
+	_in_buf_size = nearest_shift(p_in_buffer - 1) + 10;
+	_in_pkt_size = nearest_shift(p_in_packets - 1);
+	return OK;
+}
+
 EMWSClient::EMWSClient() {
 	_in_buf_size = nearest_shift((int)GLOBAL_GET(WSC_IN_BUF) - 1) + 10;
 	_in_pkt_size = nearest_shift((int)GLOBAL_GET(WSC_IN_PKT) - 1);

--- a/modules/websocket/emws_client.h
+++ b/modules/websocket/emws_client.h
@@ -49,6 +49,7 @@ private:
 public:
 	bool _is_connecting;
 
+	Error set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets);
 	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocol = PoolVector<String>());
 	Ref<WebSocketPeer> get_peer(int p_peer_id) const;
 	void disconnect_from_host(int p_code = 1000, String p_reason = "");

--- a/modules/websocket/emws_server.cpp
+++ b/modules/websocket/emws_server.cpp
@@ -79,6 +79,10 @@ int EMWSServer::get_max_packet_size() const {
 	return 0;
 }
 
+Error EMWSServer::set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) {
+	return OK;
+}
+
 EMWSServer::EMWSServer() {
 }
 

--- a/modules/websocket/emws_server.h
+++ b/modules/websocket/emws_server.h
@@ -42,6 +42,7 @@ class EMWSServer : public WebSocketServer {
 	GDCIIMPL(EMWSServer, WebSocketServer);
 
 public:
+	Error set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets);
 	Error listen(int p_port, PoolVector<String> p_protocols = PoolVector<String>(), bool gd_mp_api = false);
 	void stop();
 	bool is_listening() const;

--- a/modules/websocket/lws_client.cpp
+++ b/modules/websocket/lws_client.cpp
@@ -215,6 +215,17 @@ uint16_t LWSClient::get_connected_port() const {
 	return 1025;
 };
 
+Error LWSClient::set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) {
+	ERR_EXPLAIN("Buffers sizes can only be set before listening or connecting");
+	ERR_FAIL_COND_V(context != NULL, FAILED);
+
+	_in_buf_size = nearest_shift(p_in_buffer - 1) + 10;
+	_in_pkt_size = nearest_shift(p_in_packets - 1);
+	_out_buf_size = nearest_shift(p_out_buffer - 1) + 10;
+	_out_pkt_size = nearest_shift(p_out_packets - 1);
+	return OK;
+}
+
 LWSClient::LWSClient() {
 	_in_buf_size = nearest_shift((int)GLOBAL_GET(WSC_IN_BUF) - 1) + 10;
 	_in_pkt_size = nearest_shift((int)GLOBAL_GET(WSC_IN_PKT) - 1);

--- a/modules/websocket/lws_client.h
+++ b/modules/websocket/lws_client.h
@@ -51,6 +51,7 @@ private:
 	int _out_pkt_size;
 
 public:
+	Error set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets);
 	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, PoolVector<String> p_protocol = PoolVector<String>());
 	int get_max_packet_size() const;
 	Ref<WebSocketPeer> get_peer(int p_peer_id) const;

--- a/modules/websocket/lws_server.cpp
+++ b/modules/websocket/lws_server.cpp
@@ -197,6 +197,17 @@ void LWSServer::disconnect_peer(int p_peer_id, int p_code, String p_reason) {
 	get_peer(p_peer_id)->close(p_code, p_reason);
 }
 
+Error LWSServer::set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) {
+	ERR_EXPLAIN("Buffers sizes can only be set before listening or connecting");
+	ERR_FAIL_COND_V(context != NULL, FAILED);
+
+	_in_buf_size = nearest_shift(p_in_buffer - 1) + 10;
+	_in_pkt_size = nearest_shift(p_in_packets - 1);
+	_out_buf_size = nearest_shift(p_out_buffer - 1) + 10;
+	_out_pkt_size = nearest_shift(p_out_packets - 1);
+	return OK;
+}
+
 LWSServer::LWSServer() {
 	_in_buf_size = nearest_shift((int)GLOBAL_GET(WSS_IN_BUF) - 1) + 10;
 	_in_pkt_size = nearest_shift((int)GLOBAL_GET(WSS_IN_PKT) - 1);

--- a/modules/websocket/lws_server.h
+++ b/modules/websocket/lws_server.h
@@ -52,6 +52,7 @@ private:
 	int _out_pkt_size;
 
 public:
+	Error set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets);
 	Error listen(int p_port, PoolVector<String> p_protocols = PoolVector<String>(), bool gd_mp_api = false);
 	void stop();
 	bool is_listening() const;

--- a/modules/websocket/websocket_client.h
+++ b/modules/websocket/websocket_client.h
@@ -67,6 +67,8 @@ public:
 	void _on_disconnect(bool p_was_clean);
 	void _on_error();
 
+	virtual Error set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) = 0;
+
 	WebSocketClient();
 	~WebSocketClient();
 };

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -87,6 +87,7 @@ void WebSocketMultiplayerPeer::_clear() {
 
 void WebSocketMultiplayerPeer::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("set_buffers", "input_buffer_size_kb", "input_max_packets", "output_buffer_size_kb", "output_max_packets"), &WebSocketMultiplayerPeer::set_buffers);
 	ClassDB::bind_method(D_METHOD("get_peer", "peer_id"), &WebSocketMultiplayerPeer::get_peer);
 
 	ADD_SIGNAL(MethodInfo("peer_packet", PropertyInfo(Variant::INT, "peer_source")));

--- a/modules/websocket/websocket_multiplayer_peer.h
+++ b/modules/websocket/websocket_multiplayer_peer.h
@@ -97,6 +97,7 @@ public:
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size);
 
 	/* WebSocketPeer */
+	virtual Error set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) = 0;
 	virtual Ref<WebSocketPeer> get_peer(int p_peer_id) const = 0;
 
 	void _process_multiplayer(Ref<WebSocketPeer> p_peer, uint32_t p_peer_id);

--- a/modules/websocket/websocket_server.h
+++ b/modules/websocket/websocket_server.h
@@ -62,6 +62,8 @@ public:
 	void _on_disconnect(int32_t p_peer_id, bool p_was_clean);
 	void _on_close_request(int32_t p_peer_id, int p_code, String p_reason);
 
+	virtual Error set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) = 0;
+
 	WebSocketServer();
 	~WebSocketServer();
 };


### PR DESCRIPTION
Needed by LSP (#29780).
Could only be set project wise before (#22940).
Should we expose them to GDScript at this point?