### PR TITLE
Expose ClippedCamera clip_offset

### DIFF
--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -869,6 +869,11 @@ void ClippedCamera::clear_exceptions() {
 	exclude.clear();
 }
 
+float ClippedCamera::get_clip_offset() const {
+
+	return clip_offset;
+}
+
 void ClippedCamera::set_clip_to_areas(bool p_clip) {
 
 	clip_to_areas = p_clip;
@@ -911,6 +916,8 @@ void ClippedCamera::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_clip_to_areas", "enable"), &ClippedCamera::set_clip_to_areas);
 	ClassDB::bind_method(D_METHOD("is_clip_to_areas_enabled"), &ClippedCamera::is_clip_to_areas_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_clip_offset"), &ClippedCamera::get_clip_offset);
 
 	ClassDB::bind_method(D_METHOD("set_clip_to_bodies", "enable"), &ClippedCamera::set_clip_to_bodies);
 	ClassDB::bind_method(D_METHOD("is_clip_to_bodies_enabled"), &ClippedCamera::is_clip_to_bodies_enabled);

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -234,6 +234,8 @@ public:
 	void remove_exception(const Object *p_object);
 	void clear_exceptions();
 
+	float get_clip_offset() const;
+
 	ClippedCamera();
 	~ClippedCamera();
 };


### PR DESCRIPTION
Just exposing `clip_offset` to GDScript as a getter method. 

This value can be useful when implementing advanced camera effects like moving the camera in a certain direction when it gets clipped too far towards the player. 

This work has been kindly sponsored by IMVU.