### PR TITLE
Fix HTML5 build failed due to undefined symbol

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4688,6 +4688,7 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 	/* BACK FBO */
 	/* For MSAA */
 
+#ifndef JAVASCRIPT_ENABLED
 	if (rt->msaa != VS::VIEWPORT_MSAA_DISABLED && config.multisample_supported) {
 
 		rt->multisample_active = true;
@@ -4743,7 +4744,9 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 
 		glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
-	} else {
+	} else
+#endif
+	{
 		rt->multisample_active = false;
 	}
 


### PR DESCRIPTION
Symbol is no longer defined in HTML5 builds as of #29496 (as it's not support in WebGL1).
A bit hacky, but does the job.