### PR TITLE
Fix pointer position in hidpi-corrected resolutions on web

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -162,8 +162,13 @@ $GODOT_HEAD_INCLUDE
 			requestAnimationFrame(animate);
 
 			function adjustCanvasDimensions() {
-				canvas.width = innerWidth;
-				canvas.height = innerHeight;
+				var scale = window.devicePixelRatio || 1;
+				var width = window.innerWidth;
+				var height = window.innerHeight;
+				canvas.width = width * scale;
+				canvas.height = height * scale;
+				canvas.style.width = width + "px";
+				canvas.style.height = height + "px";
 			}
 			animationCallbacks.push(adjustCanvasDimensions);
 			adjustCanvasDimensions();


### PR DESCRIPTION
This fixes #29661.

It transforms the coordinates of pointer events based on the relation of canvas resolution to canvas size, which fixes the discrepancy when the layout's CSS-size is not the same as the canvas' resolution.

The main use cases are when supporting high DPI screens on web, such as regular-sized 4K screens or high-end mobile devices. Additionally it also prevents the general case issue when the canvas resolution not being the exact same as CSS-pixel dimensions of the element itself, such as when stretching the canvas in any way.

Included is also a modification for the full-size HTML template to introduce the previously-buggy high-DPI support, which results in notably crispier graphics on those screens.