### PR TITLE
Improve the default project naming in the Project Manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -294,13 +294,13 @@ private:
 		String sp = _test_path();
 		if (sp != "") {
 
-			// set the project name to the select folder name
-			if (project_name->get_text() == "") {
+			// If the project name is empty or default, infer the project name from the selected folder name
+			if (project_name->get_text() == "" || project_name->get_text() == TTR("New Game Project")) {
 				sp = sp.replace("\\", "/");
 				int lidx = sp.find_last("/");
 
 				if (lidx != -1) {
-					sp = sp.substr(lidx + 1, sp.length());
+					sp = sp.substr(lidx + 1, sp.length()).capitalize();
 				}
 				if (sp == "" && mode == MODE_IMPORT)
 					sp = TTR("Imported Project");


### PR DESCRIPTION
The Project Manager will now infer a project name from the project path if the name is empty or equal to the default value. The project name will also be capitalized automatically.

Having decent automatic naming out of the box makes it faster to set up a bunch of projects for testing purposes :slightly_smiling_face:

## Preview

![godot_project_manager_default_naming](https://user-images.githubusercontent.com/180032/59541228-98552680-8f00-11e9-9ab6-e102ded6dcd8.png)