### PR TITLE
Fix compilation warnings in JS and Windows builds

### DIFF
--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -306,7 +306,7 @@ Error NetSocketPosix::bind(IP_Address p_addr, uint16_t p_port) {
 	sockaddr_storage addr;
 	size_t addr_size = _set_addr_storage(&addr, p_addr, p_port, _ip_type);
 
-	if (::bind(_sock, (struct sockaddr *)&addr, addr_size) == SOCK_EMPTY) {
+	if (::bind(_sock, (struct sockaddr *)&addr, addr_size) != 0) {
 		close();
 		ERR_FAIL_V(ERR_UNAVAILABLE);
 	}
@@ -317,7 +317,7 @@ Error NetSocketPosix::bind(IP_Address p_addr, uint16_t p_port) {
 Error NetSocketPosix::listen(int p_max_pending) {
 	ERR_FAIL_COND_V(!is_open(), ERR_UNCONFIGURED);
 
-	if (::listen(_sock, p_max_pending) == SOCK_EMPTY) {
+	if (::listen(_sock, p_max_pending) != 0) {
 
 		close();
 		ERR_FAIL_V(FAILED);
@@ -334,7 +334,7 @@ Error NetSocketPosix::connect_to_host(IP_Address p_host, uint16_t p_port) {
 	struct sockaddr_storage addr;
 	size_t addr_size = _set_addr_storage(&addr, p_host, p_port, _ip_type);
 
-	if (::connect(_sock, (struct sockaddr *)&addr, addr_size) == SOCK_EMPTY) {
+	if (::connect(_sock, (struct sockaddr *)&addr, addr_size) != 0) {
 
 		NetError err = _get_socket_error();
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -93,7 +93,7 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 	// a file using the wrong case (which *works* on Windows, but won't on other
 	// platforms).
 	if (p_mode_flags == READ) {
-		WIN32_FIND_DATAW d = { 0 };
+		WIN32_FIND_DATAW d;
 		HANDLE f = FindFirstFileW(path.c_str(), &d);
 		if (f) {
 			String fname = d.cFileName;
@@ -302,7 +302,7 @@ void FileAccessWindows::store_buffer(const uint8_t *p_src, int p_length) {
 		}
 		prev_op = WRITE;
 	}
-	ERR_FAIL_COND(fwrite(p_src, 1, p_length, f) != p_length);
+	ERR_FAIL_COND(fwrite(p_src, 1, p_length, f) != (size_t)p_length);
 }
 
 bool FileAccessWindows::file_exists(const String &p_name) {

--- a/modules/webrtc/webrtc_data_channel_js.cpp
+++ b/modules/webrtc/webrtc_data_channel_js.cpp
@@ -68,7 +68,7 @@ void WebRTCDataChannelJS::_on_error() {
 }
 
 void WebRTCDataChannelJS::_on_message(uint8_t *p_data, uint32_t p_size, bool p_is_string) {
-	if (in_buffer.space_left() < p_size + 5) {
+	if (in_buffer.space_left() < (int)(p_size + 5)) {
 		ERR_EXPLAIN("Buffer full! Dropping data");
 		ERR_FAIL();
 	}

--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -99,7 +99,7 @@ Error AudioDriverJavaScript::init() {
 		return FAILED;
 	}
 
-	if (!internal_buffer || memarr_len(internal_buffer) != buffer_length * channel_count) {
+	if (!internal_buffer || (int)memarr_len(internal_buffer) != buffer_length * channel_count) {
 		if (internal_buffer)
 			memdelete_arr(internal_buffer);
 		internal_buffer = memnew_arr(float, buffer_length *channel_count);

--- a/platform/windows/power_windows.cpp
+++ b/platform/windows/power_windows.cpp
@@ -89,7 +89,7 @@ bool PowerWindows::GetPowerInfo_Windows() {
 		if (pct != 255) { /* 255 == unknown */
 			percent_left = (pct > 100) ? 100 : pct; /* clamp between 0%, 100% */
 		}
-		if (secs != 0xFFFFFFFF) { /* ((DWORD)-1) == unknown */
+		if (secs != (int)0xFFFFFFFF) { /* ((DWORD)-1) == unknown */
 			nsecs_left = secs;
 		}
 	}

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -45,7 +45,7 @@ void WindowsTerminalLogger::logv(const char *p_format, va_list p_list, bool p_er
 	int len = vsnprintf(buf, BUFFER_SIZE, p_format, p_list);
 	if (len <= 0)
 		return;
-	if (len >= BUFFER_SIZE)
+	if ((unsigned int)len >= BUFFER_SIZE)
 		len = BUFFER_SIZE; // Output is too big, will be truncated
 	buf[len] = 0;
 

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -33,6 +33,8 @@
 #include "core/engine.h"
 #include "scene/resources/texture.h"
 
+const float DEFAULT_GIZMO_EXTENTS = 10.0;
+
 void Position2D::_draw_cross() {
 
 	float extents = get_gizmo_extents();

--- a/scene/2d/position_2d.h
+++ b/scene/2d/position_2d.h
@@ -37,8 +37,6 @@ class Position2D : public Node2D {
 
 	GDCLASS(Position2D, Node2D)
 
-	const float DEFAULT_GIZMO_EXTENTS = 10.0;
-
 	void _draw_cross();
 
 protected:


### PR DESCRIPTION
Warnings raised by Emscripten 1.38.0 and MinGW64 5.0.4 / GCC 8.3.0.

JS can now build with `werror=yes warnings=extra` (confirmed on `tools=no target=release` and `tools=no target=release_debug`).
MinGW64 still has a few warnings to resolve with `warnings=extra`, and only one with `warnings=all` (see #29801).

Part of #29033 and #29801.