### PR TITLE
Fix memory leak in ImageLoaderPNG::_lossless_pack_png

### DIFF
--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -283,22 +283,23 @@ static PoolVector<uint8_t> _lossless_pack_png(const Ref<Image> &p_image) {
 
 	ERR_FAIL_COND_V(img->is_compressed(), PoolVector<uint8_t>());
 
-	png_structp png_ptr;
-	png_infop info_ptr;
-	png_bytep *row_pointers;
-
-	/* initialize stuff */
-	png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+	png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 
 	ERR_FAIL_COND_V(!png_ptr, PoolVector<uint8_t>());
 
-	info_ptr = png_create_info_struct(png_ptr);
+	png_infop info_ptr = png_create_info_struct(png_ptr);
 
-	ERR_FAIL_COND_V(!info_ptr, PoolVector<uint8_t>());
-
-	if (setjmp(png_jmpbuf(png_ptr))) {
+	if (!info_ptr) {
+		png_destroy_write_struct(&png_ptr, NULL);
 		ERR_FAIL_V(PoolVector<uint8_t>());
 	}
+
+	// setup libpng error handling
+	if (setjmp(png_jmpbuf(png_ptr))) {
+		png_destroy_write_struct(&png_ptr, &info_ptr);
+		ERR_FAIL_V(PoolVector<uint8_t>());
+	}
+
 	PoolVector<uint8_t> ret;
 	ret.push_back('P');
 	ret.push_back('N');
@@ -307,10 +308,7 @@ static PoolVector<uint8_t> _lossless_pack_png(const Ref<Image> &p_image) {
 
 	png_set_write_fn(png_ptr, &ret, _write_png_data, NULL);
 
-	/* write header */
-	if (setjmp(png_jmpbuf(png_ptr))) {
-		ERR_FAIL_V(PoolVector<uint8_t>());
-	}
+	// write header
 
 	int pngf = 0;
 	int cs = 0;
@@ -318,34 +316,27 @@ static PoolVector<uint8_t> _lossless_pack_png(const Ref<Image> &p_image) {
 	switch (img->get_format()) {
 
 		case Image::FORMAT_L8: {
-
 			pngf = PNG_COLOR_TYPE_GRAY;
 			cs = 1;
 		} break;
 		case Image::FORMAT_LA8: {
-
 			pngf = PNG_COLOR_TYPE_GRAY_ALPHA;
 			cs = 2;
 		} break;
 		case Image::FORMAT_RGB8: {
-
 			pngf = PNG_COLOR_TYPE_RGB;
 			cs = 3;
 		} break;
 		case Image::FORMAT_RGBA8: {
-
 			pngf = PNG_COLOR_TYPE_RGB_ALPHA;
 			cs = 4;
 		} break;
 		default: {
-
 			if (img->detect_alpha()) {
-
 				img->convert(Image::FORMAT_RGBA8);
 				pngf = PNG_COLOR_TYPE_RGB_ALPHA;
 				cs = 4;
 			} else {
-
 				img->convert(Image::FORMAT_RGB8);
 				pngf = PNG_COLOR_TYPE_RGB;
 				cs = 3;
@@ -361,29 +352,26 @@ static PoolVector<uint8_t> _lossless_pack_png(const Ref<Image> &p_image) {
 
 	png_write_info(png_ptr, info_ptr);
 
-	/* write bytes */
+	// write image data
+
+	PoolVector<uint8_t>::Read r = img->get_data().read();
+	png_bytep *row_pointers = (png_bytep *)memalloc(sizeof(png_bytep) * h);
+
+	// update error handling for row_pointers allocation
 	if (setjmp(png_jmpbuf(png_ptr))) {
+		memfree(row_pointers);
+		png_destroy_write_struct(&png_ptr, &info_ptr);
 		ERR_FAIL_V(PoolVector<uint8_t>());
 	}
 
-	PoolVector<uint8_t>::Read r = img->get_data().read();
-
-	row_pointers = (png_bytep *)memalloc(sizeof(png_bytep) * h);
 	for (int i = 0; i < h; i++) {
-
 		row_pointers[i] = (png_bytep)&r[i * w * cs];
 	}
 	png_write_image(png_ptr, row_pointers);
-
 	memfree(row_pointers);
 
-	/* end write */
-	if (setjmp(png_jmpbuf(png_ptr))) {
-
-		ERR_FAIL_V(PoolVector<uint8_t>());
-	}
-
 	png_write_end(png_ptr, NULL);
+	png_destroy_write_struct(&png_ptr, &info_ptr);
 
 	return ret;
 }


### PR DESCRIPTION
Free libpng structures before returning.
Also update libpng error handling as allocations are made.

fix for #29741