### PR TITLE
Add support for bold fonts in the editor help

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -204,7 +204,6 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	dfmono->set_antialiased(font_source_antialiased);
 	dfmono->set_hinting(font_source_hinting);
 	dfmono->set_font_ptr(_font_Hack_Regular, _font_Hack_Regular_size);
-	//dfd->set_force_autohinter(true); //just looks better..i think?
 
 	int default_font_size = int(EDITOR_GET("interface/editor/main_font_size")) * EDSCALE;
 
@@ -220,15 +219,14 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	MAKE_BOLD_FONT(df_title, default_font_size + 2 * EDSCALE);
 	p_theme->set_font("title", "EditorFonts", df_title);
 
-	// Doc font
-	MAKE_BOLD_FONT(df_doc_title, int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
-
+	// Documentation fonts
 	MAKE_DEFAULT_FONT(df_doc, int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
-
-	p_theme->set_font("doc", "EditorFonts", df_doc);
-	p_theme->set_font("doc_title", "EditorFonts", df_doc_title);
-
+	MAKE_BOLD_FONT(df_doc_bold, int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
+	MAKE_BOLD_FONT(df_doc_title, int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
 	MAKE_SOURCE_FONT(df_doc_code, int(EDITOR_GET("text_editor/help/help_source_font_size")) * EDSCALE);
+	p_theme->set_font("doc", "EditorFonts", df_doc);
+	p_theme->set_font("doc_bold", "EditorFonts", df_doc_bold);
+	p_theme->set_font("doc_title", "EditorFonts", df_doc_title);
 	p_theme->set_font("doc_source", "EditorFonts", df_doc_code);
 
 	// Ruler font

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -325,6 +325,7 @@ void EditorHelp::_update_doc() {
 	DocData::ClassDoc cd = doc->class_list[edited_class]; //make a copy, so we can sort without worrying
 
 	Ref<Font> doc_font = get_font("doc", "EditorFonts");
+	Ref<Font> doc_bold_font = get_font("doc_bold", "EditorFonts");
 	Ref<Font> doc_title_font = get_font("doc_title", "EditorFonts");
 	Ref<Font> doc_code_font = get_font("doc_source", "EditorFonts");
 	String link_color_text = title_color.to_html(false);
@@ -1132,6 +1133,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 	String base_path;
 
 	Ref<Font> doc_font = p_rt->get_font("doc", "EditorFonts");
+	Ref<Font> doc_bold_font = p_rt->get_font("doc_bold", "EditorFonts");
 	Ref<Font> doc_code_font = p_rt->get_font("doc_source", "EditorFonts");
 	Color font_color_hl = p_rt->get_color("headline_color", "EditorHelp");
 	Color link_color = p_rt->get_color("accent_color", "Editor").linear_interpolate(font_color_hl, 0.8);
@@ -1219,7 +1221,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 		} else if (tag == "b") {
 
 			//use bold font
-			p_rt->push_font(doc_code_font);
+			p_rt->push_font(doc_bold_font);
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "i") {
@@ -1237,13 +1239,13 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			tag_stack.push_front(tag);
 		} else if (tag == "center") {
 
-			//use monospace font
+			//align to center
 			p_rt->push_align(RichTextLabel::ALIGN_CENTER);
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "br") {
 
-			//use monospace font
+			//force a line break
 			p_rt->add_newline();
 			pos = brk_end + 1;
 		} else if (tag == "u") {
@@ -1254,14 +1256,13 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			tag_stack.push_front(tag);
 		} else if (tag == "s") {
 
-			//use strikethrough (not supported underline instead)
-			p_rt->push_underline();
+			//use strikethrough
+			p_rt->push_strikethrough();
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 
 		} else if (tag == "url") {
 
-			//use strikethrough (not supported underline instead)
 			int end = bbcode.find("[", brk_end);
 			if (end == -1)
 				end = bbcode.length();
@@ -1278,7 +1279,6 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			tag_stack.push_front("url");
 		} else if (tag == "img") {
 
-			//use strikethrough (not supported underline instead)
 			int end = bbcode.find("[", brk_end);
 			if (end == -1)
 				end = bbcode.length();


### PR DESCRIPTION
This also makes it possible to use the strikethrough tag (`[s]`) in the editor help.

This partially addresses #27456.

## Preview

*(Note: Broken spacing is unrelated to this pull request, see #29810.)*

![doc_font_bold](https://user-images.githubusercontent.com/180032/59554095-99d52c00-8f9e-11e9-8d05-ae9903ae472d.png)