### PR TITLE
Replace ` + "/" + ` with `String::file_add()`

### DIFF
--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -378,7 +378,7 @@ Error DirAccess::_copy_dir(DirAccess *p_target_da, String p_to, int p_chmod_flag
 					list_dir_end();
 					return ERR_BUG;
 				}
-				Error err = copy(get_current_dir() + "/" + n, p_to + rel_path, p_chmod_flags);
+				Error err = copy(get_current_dir().plus_file(n), p_to + rel_path, p_chmod_flags);
 				if (err) {
 					list_dir_end();
 					return err;

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -316,7 +316,7 @@ Error DirAccessUnix::change_dir(String p_dir) {
 	// try_dir is the directory we are trying to change into
 	String try_dir = "";
 	if (p_dir.is_rel_path()) {
-		String next_dir = current_dir + "/" + p_dir;
+		String next_dir = current_dir.plus_file(p_dir);
 		next_dir = next_dir.simplify_path();
 		try_dir = next_dir;
 	} else {

--- a/editor/collada/collada.cpp
+++ b/editor/collada/collada.cpp
@@ -308,7 +308,7 @@ void Collada::_parse_image(XMLParser &parser) {
 		String path = parser.get_attribute_value("source").strip_edges();
 		if (path.find("://") == -1 && path.is_rel_path()) {
 			// path is relative to file being loaded, so convert to a resource path
-			image.path = ProjectSettings::get_singleton()->localize_path(state.local_path.get_base_dir() + "/" + path.percent_decode());
+			image.path = ProjectSettings::get_singleton()->localize_path(state.local_path.get_base_dir().plus_file(path.percent_decode()));
 		}
 	} else {
 
@@ -325,7 +325,7 @@ void Collada::_parse_image(XMLParser &parser) {
 
 					if (path.find("://") == -1 && path.is_rel_path()) {
 						// path is relative to file being loaded, so convert to a resource path
-						path = ProjectSettings::get_singleton()->localize_path(state.local_path.get_base_dir() + "/" + path);
+						path = ProjectSettings::get_singleton()->localize_path(state.local_path.get_base_dir().plus_file(path));
 
 					} else if (path.find("file:///") == 0) {
 						path = path.replace_first("file:///", "");

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -96,7 +96,7 @@ String EditorFileSystemDirectory::get_path() const {
 	String p;
 	const EditorFileSystemDirectory *d = this;
 	while (d->parent) {
-		p = d->name + "/" + p;
+		p = d->name.plus_file(p);
 		d = d->parent;
 	}
 
@@ -108,7 +108,7 @@ String EditorFileSystemDirectory::get_file_path(int p_idx) const {
 	String file = get_file(p_idx);
 	const EditorFileSystemDirectory *d = this;
 	while (d->parent) {
-		file = d->name + "/" + file;
+		file = d->name.plus_file(file);
 		d = d->parent;
 	}
 

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1284,7 +1284,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 				end = bbcode.length();
 			String image = bbcode.substr(brk_end + 1, end - brk_end - 1);
 
-			Ref<Texture> texture = ResourceLoader::load(base_path + "/" + image, "Texture");
+			Ref<Texture> texture = ResourceLoader::load(base_path.plus_file(image), "Texture");
 			if (texture.is_valid())
 				p_rt->add_image(texture);
 
@@ -1340,7 +1340,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 
 			String fnt = tag.substr(5, tag.length());
 
-			Ref<Font> font = ResourceLoader::load(base_path + "/" + fnt, "Font");
+			Ref<Font> font = ResourceLoader::load(base_path.plus_file(fnt), "Font");
 			if (font.is_valid())
 				p_rt->push_font(font);
 			else {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2806,7 +2806,7 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 
 	Ref<ConfigFile> cf;
 	cf.instance();
-	String addon_path = "res://addons/" + p_addon + "/plugin.cfg";
+	String addon_path = String("res://addons").plus_file(p_addon).plus_file("plugin.cfg");
 	if (!DirAccess::exists(addon_path.get_base_dir())) {
 		ProjectSettings *ps = ProjectSettings::get_singleton();
 		PoolStringArray enabled_plugins = ps->get("editor_plugins/enabled");
@@ -2833,7 +2833,7 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 	}
 
 	String path = cf->get_value("plugin", "script");
-	path = "res://addons/" + p_addon + "/" + path;
+	path = String("res://addons").plus_file(p_addon).plus_file(path);
 
 	Ref<Script> script = ResourceLoader::load(path);
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -930,7 +930,7 @@ fail:
 		Vector<String> list = extra_config->get_value("init_projects", "list");
 		for (int i = 0; i < list.size(); i++) {
 
-			list.write[i] = exe_path + "/" + list[i];
+			list.write[i] = exe_path.plus_file(list[i]);
 		};
 		extra_config->set_value("init_projects", "list", list);
 	};

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1329,7 +1329,7 @@ void FileSystemDock::_duplicate_operation_confirm() {
 	if (to_duplicate.is_file) {
 		new_path = base_dir.plus_file(new_name);
 	} else {
-		new_path = base_dir.substr(0, base_dir.find_last("/")) + "/" + new_name;
+		new_path = base_dir.substr(0, base_dir.find_last("/")).plus_file(new_name);
 	}
 
 	//Present a more user friendly warning for name conflict

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -59,7 +59,7 @@ void GroupDialog::_group_selected() {
 void GroupDialog::_load_nodes(Node *p_current) {
 	String item_name = p_current->get_name();
 	if (p_current != scene_tree->get_edited_scene_root()) {
-		item_name = String(p_current->get_parent()->get_name()) + "/" + String(item_name);
+		item_name = String(p_current->get_parent()->get_name()) + "/" + item_name;
 	}
 
 	bool keep = true;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -569,8 +569,8 @@ void ScriptTextEditor::_validate_script() {
 				Connection connection = E->get();
 
 				String base_path = base->get_name();
-				String source_path = base == connection.source ? base_path : base_path + "/" + String(base->get_path_to(Object::cast_to<Node>(connection.source)));
-				String target_path = base == connection.target ? base_path : base_path + "/" + String(base->get_path_to(Object::cast_to<Node>(connection.target)));
+				String source_path = base == connection.source ? base_path : base_path + "/" + base->get_path_to(Object::cast_to<Node>(connection.source));
+				String target_path = base == connection.target ? base_path : base_path + "/" + base->get_path_to(Object::cast_to<Node>(connection.target));
 
 				warnings_panel->push_cell();
 				warnings_panel->push_color(warnings_panel->get_color("warning_color", "Editor"));

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1709,13 +1709,13 @@ bool Main::start() {
 
 						if (sep == -1) {
 							DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-							local_game_path = da->get_current_dir() + "/" + local_game_path;
+							local_game_path = da->get_current_dir().plus_file(local_game_path);
 							memdelete(da);
 						} else {
 
 							DirAccess *da = DirAccess::open(local_game_path.substr(0, sep));
 							if (da) {
-								local_game_path = da->get_current_dir() + "/" + local_game_path.substr(sep + 1, local_game_path.length());
+								local_game_path = da->get_current_dir().plus_file(local_game_path.substr(sep + 1, local_game_path.length()));
 								memdelete(da);
 							}
 						}

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -848,7 +848,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 
 		if (AI_SUCCESS == ai_material->GetTexture(tex_normal, 0, &ai_filename, NULL, NULL, NULL, NULL, map_mode)) {
 			filename = _assimp_raw_string_to_string(ai_filename);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -869,7 +869,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_NORMAL_TEXTURE, ai_filename)) {
 			filename = _assimp_raw_string_to_string(ai_filename);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -892,7 +892,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 
 		if (AI_SUCCESS == ai_material->GetTexture(tex_emissive, 0, &ai_filename, NULL, NULL, NULL, NULL, map_mode)) {
 			filename = _assimp_raw_string_to_string(ai_filename);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -914,7 +914,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiTextureMapMode map_mode[2];
 		if (AI_SUCCESS == ai_material->GetTexture(tex_albedo, 0, &ai_filename, NULL, NULL, NULL, NULL, map_mode)) {
 			filename = _assimp_raw_string_to_string(ai_filename);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -944,7 +944,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 	aiTextureMapMode map_mode[2];
 	if (AI_SUCCESS == ai_material->GetTexture(AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_BASE_COLOR_TEXTURE, &tex_gltf_base_color_path, NULL, NULL, NULL, NULL, map_mode)) {
 		String filename = _assimp_raw_string_to_string(tex_gltf_base_color_path);
-		String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+		String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 		bool found = false;
 		_find_texture_path(state.path, path, found);
 		if (found) {
@@ -973,7 +973,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiString tex_fbx_pbs_base_color_path = aiString();
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_MAYA_BASE_COLOR_TEXTURE, tex_fbx_pbs_base_color_path)) {
 			String filename = _assimp_raw_string_to_string(tex_fbx_pbs_base_color_path);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -1005,7 +1005,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiString tex_fbx_pbs_normal_path = aiString();
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_MAYA_NORMAL_TEXTURE, tex_fbx_pbs_normal_path)) {
 			String filename = _assimp_raw_string_to_string(tex_fbx_pbs_normal_path);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -1027,7 +1027,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiString tex_fbx_stingray_normal_path = aiString();
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_MAYA_STINGRAY_NORMAL_TEXTURE, tex_fbx_stingray_normal_path)) {
 			String filename = _assimp_raw_string_to_string(tex_fbx_stingray_normal_path);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -1045,7 +1045,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiString tex_fbx_pbs_base_color_path = aiString();
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_MAYA_STINGRAY_COLOR_TEXTURE, tex_fbx_pbs_base_color_path)) {
 			String filename = _assimp_raw_string_to_string(tex_fbx_pbs_base_color_path);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -1077,7 +1077,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiString tex_fbx_pbs_emissive_path = aiString();
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_MAYA_STINGRAY_EMISSIVE_TEXTURE, tex_fbx_pbs_emissive_path)) {
 			String filename = _assimp_raw_string_to_string(tex_fbx_pbs_emissive_path);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -1107,7 +1107,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 	aiString tex_gltf_pbr_metallicroughness_path;
 	if (AI_SUCCESS == ai_material->GetTexture(AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLICROUGHNESS_TEXTURE, &tex_gltf_pbr_metallicroughness_path)) {
 		String filename = _assimp_raw_string_to_string(tex_gltf_pbr_metallicroughness_path);
-		String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+		String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 		bool found = false;
 		_find_texture_path(state.path, path, found);
 		if (found) {
@@ -1134,7 +1134,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiString tex_fbx_pbs_metallic_path;
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_MAYA_STINGRAY_METALLIC_TEXTURE, tex_fbx_pbs_metallic_path)) {
 			String filename = _assimp_raw_string_to_string(tex_fbx_pbs_metallic_path);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -1154,7 +1154,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiString tex_fbx_pbs_rough_path;
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_MAYA_STINGRAY_ROUGHNESS_TEXTURE, tex_fbx_pbs_rough_path)) {
 			String filename = _assimp_raw_string_to_string(tex_fbx_pbs_rough_path);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -1177,7 +1177,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiString tex_fbx_pbs_metallic_path;
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_MAYA_METALNESS_TEXTURE, tex_fbx_pbs_metallic_path)) {
 			String filename = _assimp_raw_string_to_string(tex_fbx_pbs_metallic_path);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -1197,7 +1197,7 @@ Ref<Material> EditorSceneImporterAssimp::_generate_material_from_index(ImportSta
 		aiString tex_fbx_pbs_rough_path;
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_FBX_MAYA_DIFFUSE_ROUGHNESS_TEXTURE, tex_fbx_pbs_rough_path)) {
 			String filename = _assimp_raw_string_to_string(tex_fbx_pbs_rough_path);
-			String path = state.path.get_base_dir() + "/" + filename.replace("\\", "/");
+			String path = state.path.get_base_dir().plus_file(filename.replace("\\", "/"));
 			bool found = false;
 			_find_texture_path(state.path, path, found);
 			if (found) {
@@ -1684,7 +1684,7 @@ void EditorSceneImporterAssimp::_find_texture_path(const String &p_path, _Direct
 		path = name;
 		return;
 	}
-	String name_ignore_sub_directory = p_path.get_base_dir() + "/" + path.get_file().get_basename() + extension;
+	String name_ignore_sub_directory = p_path.get_base_dir().plus_file(path.get_file().get_basename()) + extension;
 	if (dir.file_exists(name_ignore_sub_directory)) {
 		found = true;
 		path = name_ignore_sub_directory;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -463,7 +463,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 			}
 
 			if (!path.is_abs_path() && base_path != "")
-				path = base_path + "/" + path;
+				path = base_path.plus_file(path);
 			path = path.replace("///", "//").simplify_path();
 			if (path == self_path) {
 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -597,7 +597,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 			if (abi_index != -1) {
 				exported = true;
 				String abi = abis[abi_index];
-				String dst_path = "lib/" + abi + "/" + p_so.path.get_file();
+				String dst_path = String("lib").plus_file(abi).plus_file(p_so.path.get_file());
 				Vector<uint8_t> array = FileAccess::get_file_as_array(p_so.path);
 				Error store_err = store_in_apk(ed, dst_path, array);
 				ERR_FAIL_COND_V(store_err, store_err);

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -564,7 +564,7 @@ Error EditorExportPlatformIOS::_walk_dir_recursive(DirAccess *p_da, FileHandler 
 				dirs.push_back(path);
 			}
 		} else {
-			Error err = p_handler(current_dir + "/" + path, p_userdata);
+			Error err = p_handler(current_dir.plus_file(path), p_userdata);
 			if (err) {
 				p_da->list_dir_end();
 				return err;
@@ -763,7 +763,7 @@ Error EditorExportPlatformIOS::_export_additional_assets(const String &p_out_dir
 				}
 			}
 
-			String destination = destination_dir + "/" + asset.get_file();
+			String destination = destination_dir.plus_file(asset.get_file());
 			Error err = dir_exists ? da->copy_dir(asset, destination) : da->copy(asset, destination);
 			memdelete(da);
 			if (err) {

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -570,7 +570,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 			if (export_format == "dmg") {
 				// write it into our application bundle
-				file = tmp_app_path_name + "/" + file;
+				file = tmp_app_path_name.plus_file(file);
 
 				// write the file, need to add chmod
 				FileAccess *f = FileAccess::open(file, FileAccess::WRITE);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2887,7 +2887,7 @@ void OS_X11::alert(const String &p_alert, const String &p_title) {
 
 	for (int i = 0; i < path_elems.size(); i++) {
 		for (unsigned int k = 0; k < sizeof(message_programs) / sizeof(char *); k++) {
-			String tested_path = path_elems[i] + "/" + message_programs[k];
+			String tested_path = path_elems[i].plus_file(message_programs[k]);
 
 			if (FileAccess::exists(tested_path)) {
 				program = tested_path;


### PR DESCRIPTION
Adresses #29602

I still need a bit of feedback on the following points:
1. There are only 2 cases of string appending (e.g. https://github.com/godotengine/godot/blob/ce8e5413390b48542b98ffafe5fc8b0b8032efa2/core/node_path.cpp#L280 and they have been ignored). This is fine but an alternative is to implement a `plus_file()` function for appending.
2. There are also 2 cases where the class in a `StringName`. This again isn't a problem but an alternative is to implement a `plus_file()` function for `StringName`.
https://github.com/godotengine/godot/blob/ce8e5413390b48542b98ffafe5fc8b0b8032efa2/editor/plugins/spatial_editor_plugin.cpp#L875

I'd like to know if the PR is good as it is or if I should address the two points mentioned.