### PR TITLE
Add XR mode selection to the Android export process.

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -668,6 +668,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		bool screen_support_large = p_preset->get("screen/support_large");
 		bool screen_support_xlarge = p_preset->get("screen/support_xlarge");
 
+		int xr_mode_index = p_preset->get("graphics/xr_mode");
+
 		Vector<String> perms;
 
 		const char **aperms = android_perms;
@@ -823,6 +825,14 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 						if (tname == "uses-feature" && attrname == "glEsVersion") {
 
 							encode_uint32(min_gles3 ? 0x00030000 : 0x00020000, &p_manifest.write[iofs + 16]);
+						}
+
+						if (tname == "meta-data" && attrname == "value") {
+							if (xr_mode_index == 1 /* XRMode.OVR */) {
+								string_table.write[attr_value] = "vr_only";
+							} else {
+								string_table.write[attr_value] = "";
+							}
 						}
 
 						iofs += 20;
@@ -1142,6 +1152,7 @@ public:
 
 	virtual void get_export_options(List<ExportOption> *r_options) {
 
+		r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "graphics/xr_mode", PROPERTY_HINT_ENUM, "Regular,Oculus Mobile VR"), 0));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "graphics/32_bits_framebuffer"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "one_click_deploy/clear_previous_install"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_package/debug", PROPERTY_HINT_GLOBAL_FILE, "*.apk"), ""));
@@ -2072,6 +2083,14 @@ public:
 					store_in_apk(&ed, launcher_icons[i].export_path, data);
 				}
 			}
+		}
+
+		int xr_mode_index = p_preset->get("graphics/xr_mode");
+		if (xr_mode_index == 1 /* XRMode.OVR */) {
+			cl.push_back("--xr_mode_ovr");
+		} else {
+			// XRMode.REGULAR is the default.
+			cl.push_back("--xr_mode_regular");
 		}
 
 		if (use_32_fb)

--- a/platform/android/java/AndroidManifest.xml
+++ b/platform/android/java/AndroidManifest.xml
@@ -13,7 +13,7 @@
 
 <!--glEsVersion is modified by the exporter, changing this value here has no effect-->
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
-<!--Adding custom text to manifest is fine, but do it outside the custom user and application BEGIN/ENDregions, as that gets rewritten-->
+<!--Adding custom text to manifest is fine, but do it outside the custom user and application BEGIN/END regions, as that gets rewritten-->
 
 <!--Custom permissions XML added by add-ons. It's recommended to add them from the export preset, though-->
 <!--CHUNK_USER_PERMISSIONS_BEGIN-->
@@ -25,12 +25,15 @@
 <!--The following values are replaced when Godot exports, modifying them here has no effect. Do these changes in the-->
 <!--export preset. Adding new ones is fine.-->
 
+<!-- Metadata for VR app detection on Oculus devices. This is modified by the exporter based on the selected xr mode. Changing this value here has no effect. -->
+        <meta-data android:name="com.samsung.android.vr.application.mode" android:value=""/>
+
         <activity android:name="org.godotengine.godot.Godot"
                   android:label="@string/godot_project_name_string"
-                  android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+                  android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
                   android:launchMode="singleTask"
                   android:screenOrientation="landscape"
-                  android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize"
+                  android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
                   android:resizeableActivity="false"
                   tools:ignore="UnusedAttribute">
 

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -58,7 +58,6 @@ import android.os.Environment;
 import android.os.Messenger;
 import android.provider.Settings.Secure;
 import android.support.v4.content.ContextCompat;
-import android.util.Log;
 import android.view.Display;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -115,6 +114,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 	private Button mPauseButton;
 	private Button mWiFiSettingsButton;
 
+	private XRMode xrMode = XRMode.REGULAR;
 	private boolean use_32_bits = false;
 	private boolean use_immersive = false;
 	private boolean use_debug_opengl = false;
@@ -282,7 +282,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		// ...add to FrameLayout
 		layout.addView(edittext);
 
-		mView = new GodotView(this, XRMode.PANCAKE, use_gl3, use_32_bits, use_debug_opengl);
+		mView = new GodotView(this, xrMode, use_gl3, use_32_bits, use_debug_opengl);
 		layout.addView(mView, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 		edittext.setView(mView);
 		io.setEdit(edittext);
@@ -488,7 +488,11 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 			for (int i = 0; i < command_line.length; i++) {
 
 				boolean has_extra = i < command_line.length - 1;
-				if (command_line[i].equals("--use_depth_32")) {
+				if (command_line[i].equals(XRMode.REGULAR.cmdLineArg)) {
+					xrMode = XRMode.REGULAR;
+				} else if (command_line[i].equals(XRMode.OVR.cmdLineArg)) {
+					xrMode = XRMode.OVR;
+				} else if (command_line[i].equals("--use_depth_32")) {
 					use_32_bits = true;
 				} else if (command_line[i].equals("--debug_opengl")) {
 					use_debug_opengl = true;

--- a/platform/android/java/src/org/godotengine/godot/GodotView.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotView.java
@@ -40,9 +40,9 @@ import org.godotengine.godot.xr.XRMode;
 import org.godotengine.godot.xr.ovr.OvrConfigChooser;
 import org.godotengine.godot.xr.ovr.OvrContextFactory;
 import org.godotengine.godot.xr.ovr.OvrWindowSurfaceFactory;
-import org.godotengine.godot.xr.pancake.PancakeConfigChooser;
-import org.godotengine.godot.xr.pancake.PancakeContextFactory;
-import org.godotengine.godot.xr.pancake.PancakeFallbackConfigChooser;
+import org.godotengine.godot.xr.regular.RegularConfigChooser;
+import org.godotengine.godot.xr.regular.RegularContextFactory;
+import org.godotengine.godot.xr.regular.RegularFallbackConfigChooser;
 
 /**
  * A simple GLSurfaceView sub-class that demonstrate how to perform
@@ -123,7 +123,7 @@ public class GodotView extends GLSurfaceView {
 				setEGLWindowSurfaceFactory(new OvrWindowSurfaceFactory());
 				break;
 
-			case PANCAKE:
+			case REGULAR:
 			default:
 				/* By default, GLSurfaceView() creates a RGB_565 opaque surface.
 				 * If we want a translucent one, we should change the surface's
@@ -137,7 +137,7 @@ public class GodotView extends GLSurfaceView {
 				/* Setup the context factory for 2.0 rendering.
 				 * See ContextFactory class definition below
 				 */
-				setEGLContextFactory(new PancakeContextFactory());
+				setEGLContextFactory(new RegularContextFactory());
 
 				/* We need to choose an EGLConfig that matches the format of
 				 * our surface exactly. This is going to be done in our
@@ -147,15 +147,15 @@ public class GodotView extends GLSurfaceView {
 
 				if (GLUtils.use_32) {
 					setEGLConfigChooser(translucent ?
-												new PancakeFallbackConfigChooser(8, 8, 8, 8, 24, stencil,
-														new PancakeConfigChooser(8, 8, 8, 8, 16, stencil)) :
-												new PancakeFallbackConfigChooser(8, 8, 8, 8, 24, stencil,
-														new PancakeConfigChooser(5, 6, 5, 0, 16, stencil)));
+												new RegularFallbackConfigChooser(8, 8, 8, 8, 24, stencil,
+														new RegularConfigChooser(8, 8, 8, 8, 16, stencil)) :
+												new RegularFallbackConfigChooser(8, 8, 8, 8, 24, stencil,
+														new RegularConfigChooser(5, 6, 5, 0, 16, stencil)));
 
 				} else {
 					setEGLConfigChooser(translucent ?
-												new PancakeConfigChooser(8, 8, 8, 8, 16, stencil) :
-												new PancakeConfigChooser(5, 6, 5, 0, 16, stencil));
+												new RegularConfigChooser(8, 8, 8, 8, 16, stencil) :
+												new RegularConfigChooser(5, 6, 5, 0, 16, stencil));
 				}
 				break;
 		}

--- a/platform/android/java/src/org/godotengine/godot/xr/XRMode.java
+++ b/platform/android/java/src/org/godotengine/godot/xr/XRMode.java
@@ -34,6 +34,16 @@ package org.godotengine.godot.xr;
  * Godot available XR modes.
  */
 public enum XRMode {
-	PANCAKE, // Regular/flatscreen
-	OVR, // Oculus mobile VR SDK
+	REGULAR(0, "Regular", "--xr_mode_regular"), // Regular/flatscreen
+	OVR(1, "Oculus Mobile VR", "--xr_mode_ovr");
+
+	final int index;
+	final String label;
+	public final String cmdLineArg;
+
+	XRMode(int index, String label, String cmdLineArg) {
+		this.index = index;
+		this.label = label;
+		this.cmdLineArg = cmdLineArg;
+	}
 }

--- a/platform/android/java/src/org/godotengine/godot/xr/regular/RegularConfigChooser.java
+++ b/platform/android/java/src/org/godotengine/godot/xr/regular/RegularConfigChooser.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  PancakeConfigChooser.java                                            */
+/*  RegularConfigChooser.java                                            */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-package org.godotengine.godot.xr.pancake;
+package org.godotengine.godot.xr.regular;
 
 import android.opengl.GLSurfaceView;
 import javax.microedition.khronos.egl.EGL10;
@@ -39,9 +39,9 @@ import org.godotengine.godot.utils.GLUtils;
 /**
  * Used to select the egl config for pancake games.
  */
-public class PancakeConfigChooser implements GLSurfaceView.EGLConfigChooser {
+public class RegularConfigChooser implements GLSurfaceView.EGLConfigChooser {
 
-	private static final String TAG = PancakeConfigChooser.class.getSimpleName();
+	private static final String TAG = RegularConfigChooser.class.getSimpleName();
 
 	private int[] mValue = new int[1];
 
@@ -69,7 +69,7 @@ public class PancakeConfigChooser implements GLSurfaceView.EGLConfigChooser {
 		EGL10.EGL_NONE
 	};
 
-	public PancakeConfigChooser(int r, int g, int b, int a, int depth, int stencil) {
+	public RegularConfigChooser(int r, int g, int b, int a, int depth, int stencil) {
 		mRedSize = r;
 		mGreenSize = g;
 		mBlueSize = b;

--- a/platform/android/java/src/org/godotengine/godot/xr/regular/RegularContextFactory.java
+++ b/platform/android/java/src/org/godotengine/godot/xr/regular/RegularContextFactory.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  PancakeContextFactory.java                                           */
+/*  RegularContextFactory.java                                           */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-package org.godotengine.godot.xr.pancake;
+package org.godotengine.godot.xr.regular;
 
 import android.opengl.GLSurfaceView;
 import android.util.Log;
@@ -42,8 +42,8 @@ import org.godotengine.godot.utils.GLUtils;
 /**
  * Factory used to setup the opengl context for pancake games.
  */
-public class PancakeContextFactory implements GLSurfaceView.EGLContextFactory {
-	private static final String TAG = PancakeContextFactory.class.getSimpleName();
+public class RegularContextFactory implements GLSurfaceView.EGLContextFactory {
+	private static final String TAG = RegularContextFactory.class.getSimpleName();
 
 	private static final int _EGL_CONTEXT_FLAGS_KHR = 0x30FC;
 	private static final int _EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR = 0x00000001;

--- a/platform/android/java/src/org/godotengine/godot/xr/regular/RegularFallbackConfigChooser.java
+++ b/platform/android/java/src/org/godotengine/godot/xr/regular/RegularFallbackConfigChooser.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  PancakeFallbackConfigChooser.java                                    */
+/*  RegularFallbackConfigChooser.java                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-package org.godotengine.godot.xr.pancake;
+package org.godotengine.godot.xr.regular;
 
 import android.util.Log;
 import javax.microedition.khronos.egl.EGL10;
@@ -37,13 +37,13 @@ import javax.microedition.khronos.egl.EGLDisplay;
 import org.godotengine.godot.utils.GLUtils;
 
 /* Fallback if 32bit View is not supported*/
-public class PancakeFallbackConfigChooser extends PancakeConfigChooser {
+public class RegularFallbackConfigChooser extends RegularConfigChooser {
 
-	private static final String TAG = PancakeFallbackConfigChooser.class.getSimpleName();
+	private static final String TAG = RegularFallbackConfigChooser.class.getSimpleName();
 
-	private PancakeConfigChooser fallback;
+	private RegularConfigChooser fallback;
 
-	public PancakeFallbackConfigChooser(int r, int g, int b, int a, int depth, int stencil, PancakeConfigChooser fallback) {
+	public RegularFallbackConfigChooser(int r, int g, int b, int a, int depth, int stencil, RegularConfigChooser fallback) {
 		super(r, g, b, a, depth, stencil);
 		this.fallback = fallback;
 	}


### PR DESCRIPTION
Follow up to PR #29325.

This allows the user to select the XR mode in the Android export screen. Doing so properly configures GodotView when the Android app starts running.

The changes in this PR are as follow:
- Rename XRMode.PANCAKE to XRMode.REGULAR, and update its command line parameter and related classes accordingly.
- Set the default XR mode to `REGULAR` (regular/flatscreen). 
- Update the `export.cpp` file to properly configure the manifest `meta-data` entry based on the selected XR mode.