### PR TITLE
[Mono] Dictionary conversion constructors

### DIFF
--- a/modules/mono/glue/Managed/Files/Dictionary.cs
+++ b/modules/mono/glue/Managed/Files/Dictionary.cs
@@ -288,6 +288,37 @@ namespace Godot.Collections
             }
         }
 
+        public Dictionary(Dictionary<TKey, TValue> dictionary)
+        {
+            objectDict = new Dictionary();
+
+            if (dictionary == null)
+                throw new NullReferenceException($"Parameter '{nameof(dictionary)} cannot be null.'");
+
+            IntPtr godotDictionaryPtr = GetPtr();
+
+            foreach (KeyValuePair<TKey, TValue> entry in dictionary)
+            {
+                Dictionary.godot_icall_Dictionary_Add(godotDictionaryPtr, entry.Key, entry.Value);
+            }
+        }
+
+        // This can likely be removed if Godot requires Mono 6, which doesn't seem to have the bug that this constructor fixes.
+        public Dictionary(System.Collections.Generic.Dictionary<TKey, TValue> dictionary)
+        {
+            objectDict = new Dictionary();
+
+            if (dictionary == null)
+                throw new NullReferenceException($"Parameter '{nameof(dictionary)} cannot be null.'");
+
+            IntPtr godotDictionaryPtr = GetPtr();
+
+            foreach (KeyValuePair<TKey, TValue> entry in dictionary)
+            {
+                Dictionary.godot_icall_Dictionary_Add(godotDictionaryPtr, entry.Key, entry.Value);
+            }
+        }
+
         public Dictionary(Dictionary dictionary)
         {
             objectDict = dictionary;


### PR DESCRIPTION
I was surprised to find that this works perfectly after pretty much just triplicating the constructor. I would have done this earlier if it was going to be so easy. Closes #22300

Test code:

```cs
using Godot;
using GDict = Godot.Collections.Dictionary<int, int>;
using SDict = System.Collections.Generic.Dictionary<int, int>;

public class Test : Node
{
    public override void _Ready()
    {
        GDict g = new GDict();
        g.Add(1, 2);
        g.Add(3, 4);

        g = new GDict(g); // Copy constructor
        GD.Print(g);

        SDict s = new SDict(g); // To my surprise, this works easily!
        s = new SDict(s); // System.C.G dictionaries don't print easily...
        g = new GDict(s);
        GD.Print(g); // but we know they work because this works.
    }
}
```

Output:

```
{1:2, 3:4}
{1:2, 3:4}
```

Also, I fit in a few nitpicking changes, like fixing the internal "Quant", and whitespace.