### PR TITLE
Add script to fix style issues and copyright headers

### DIFF
--- a/misc/scripts/fix_style.sh
+++ b/misc/scripts/fix_style.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Command line arguments
+run_clang_format=false
+run_fix_headers=false
+usage="Invalid argument. Usage:\n$0 <option>\n\t--clang-format|-c\n\t--headers|-h\n\t--all|-a"
+
+if [ -z "$1" ]; then
+  echo -e $usage
+  exit 0
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --clang-format|-c)
+      run_clang_format=true
+      ;;
+    --headers|-h)
+      run_fix_headers=true
+      ;;
+    --all|-a)
+      run_clang_format=true
+      run_fix_headers=true
+      ;;
+    *)
+      echo -e $usage
+      exit 0
+  esac
+  shift
+done
+
+echo "Removing generated files, some have binary data and make clang-format freeze."
+find -name "*.gen.*" -delete
+
+# Apply clang-format
+if $run_clang_format; then
+  # Sync list with pre-commit hook
+  FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .m .mm .inc .java .glsl"
+
+  for extension in ${FILE_EXTS}; do
+    echo -e "Formatting ${extension} files..."
+    find \( -path "./.git" \
+            -o -path "./thirdparty" \
+            -o -path "./platform/android/java/src/com" \
+         \) -prune \
+         -o -name "*${extension}" \
+         -exec clang-format -i {} \;
+  done
+fi
+
+# Add missing copyright headers
+if $run_fix_headers; then
+  echo "Fixing copyright headers in Godot code files..."
+  find \( -path "./.git" -o -path "./thirdparty" \) -prune \
+       -o -regex '.*\.\(c\|h\|cpp\|hpp\|cc\|hh\|cxx\|m\|mm\|java\)' \
+       > tmp-files
+  cat tmp-files | grep -v ".git\|thirdparty\|theme_data.h\|platform/android/java/src/com\|platform/android/java/src/org/godotengine/godot/input/InputManager" > files
+  python misc/scripts/fix_headers.py
+  rm -f tmp-files files
+fi

--- a/platform/iphone/camera_ios.h
+++ b/platform/iphone/camera_ios.h
@@ -3,10 +3,10 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/platform/iphone/camera_ios.mm
+++ b/platform/iphone/camera_ios.mm
@@ -3,10 +3,10 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/platform/javascript/http_client.h.inc
+++ b/platform/javascript/http_client.h.inc
@@ -3,7 +3,7 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
 /* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
 /* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */

--- a/platform/osx/camera_osx.h
+++ b/platform/osx/camera_osx.h
@@ -3,10 +3,10 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/platform/osx/camera_osx.mm
+++ b/platform/osx/camera_osx.mm
@@ -3,10 +3,10 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/platform/windows/camera_win.cpp
+++ b/platform/windows/camera_win.cpp
@@ -3,10 +3,10 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/platform/windows/camera_win.h
+++ b/platform/windows/camera_win.h
@@ -3,10 +3,10 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/scene/resources/default_theme/font_hidpi.inc
+++ b/scene/resources/default_theme/font_hidpi.inc
@@ -1,3 +1,4 @@
+/* clang-format off */
 static const int _hidpi_font_height=25;
 static const int _hidpi_font_ascent=19;
 static const int _hidpi_font_charcount=191;
@@ -25459,3 +25460,4 @@ static const unsigned char _hidpi_font_img_data[25255]={
 96,
 130,
 };
+/* clang-format on */

--- a/scene/resources/default_theme/font_lodpi.inc
+++ b/scene/resources/default_theme/font_lodpi.inc
@@ -1,3 +1,4 @@
+/* clang-format off */
 static const int _lodpi_font_height=14;
 static const int _lodpi_font_ascent=11;
 static const int _lodpi_font_charcount=191;
@@ -13113,3 +13114,4 @@ static const unsigned char _lodpi_font_img_data[12909]={
 96,
 130,
 };
+/* clang-format on */

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -3,10 +3,10 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/servers/camera/camera_feed.h
+++ b/servers/camera/camera_feed.h
@@ -3,10 +3,10 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -3,10 +3,10 @@
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -1,12 +1,12 @@
 /*************************************************************************/
-/*  camera_server.h                                                       */
+/*  camera_server.h                                                      */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
-/*                    http://www.godotengine.org                         */
+/*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */


### PR DESCRIPTION
This is only meant to check the validity of the whole codebase every
now and then, or to apply clang-format config changes when relevant.

```
Usage:
./misc/scripts/fix_style.sh <option>
        --clang-format|-c
        --headers|-h
        --all|-a
```

Also fixes some outdated headers from #10643.