### PR TITLE
clang-format config changes to discuss

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ AlignAfterOpenBracket: DontAlign
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: false
 # AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: true
+# AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: true
 # AllowShortLoopsOnASingleLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,7 @@ AllowAllParametersOfDeclarationOnNextLine: false
 # AllowShortBlocksOnASingleLine: false
 # AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: true
+# AllowShortIfStatementsOnASingleLine: false
 # AllowShortLoopsOnASingleLine: false
 # AlwaysBreakAfterDefinitionReturnType: None
 # AlwaysBreakAfterReturnType: None

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -516,14 +516,22 @@ String _OS::get_locale() const {
 
 String _OS::get_latin_keyboard_variant() const {
 	switch (OS::get_singleton()->get_latin_keyboard_variant()) {
-		case OS::LATIN_KEYBOARD_QWERTY: return "QWERTY";
-		case OS::LATIN_KEYBOARD_QWERTZ: return "QWERTZ";
-		case OS::LATIN_KEYBOARD_AZERTY: return "AZERTY";
-		case OS::LATIN_KEYBOARD_QZERTY: return "QZERTY";
-		case OS::LATIN_KEYBOARD_DVORAK: return "DVORAK";
-		case OS::LATIN_KEYBOARD_NEO: return "NEO";
-		case OS::LATIN_KEYBOARD_COLEMAK: return "COLEMAK";
-		default: return "ERROR";
+		case OS::LATIN_KEYBOARD_QWERTY:
+			return "QWERTY";
+		case OS::LATIN_KEYBOARD_QWERTZ:
+			return "QWERTZ";
+		case OS::LATIN_KEYBOARD_AZERTY:
+			return "AZERTY";
+		case OS::LATIN_KEYBOARD_QZERTY:
+			return "QZERTY";
+		case OS::LATIN_KEYBOARD_DVORAK:
+			return "DVORAK";
+		case OS::LATIN_KEYBOARD_NEO:
+			return "NEO";
+		case OS::LATIN_KEYBOARD_COLEMAK:
+			return "COLEMAK";
+		default:
+			return "ERROR";
 	}
 }
 

--- a/core/color.cpp
+++ b/core/color.cpp
@@ -415,7 +415,8 @@ bool Color::html_is_valid(const String &p_color) {
 }
 
 Color Color::named(const String &p_name) {
-	if (_named_colors.empty()) _populate_named_colors(); // from color_names.inc
+	if (_named_colors.empty())
+		_populate_named_colors(); // from color_names.inc
 	String name = p_name;
 	// Normalize name
 	name = name.replace(" ", "");

--- a/core/color_names.inc
+++ b/core/color_names.inc
@@ -3,7 +3,8 @@
 
 static Map<String, Color> _named_colors;
 static void _populate_named_colors() {
-	if (!_named_colors.empty()) return;
+	if (!_named_colors.empty())
+		return;
 	_named_colors.insert("aliceblue", Color(0.94, 0.97, 1.00));
 	_named_colors.insert("antiquewhite", Color(0.98, 0.92, 0.84));
 	_named_colors.insert("aqua", Color(0.00, 1.00, 1.00));

--- a/core/command_queue_mt.h
+++ b/core/command_queue_mt.h
@@ -237,7 +237,8 @@
 		cmd->method = p_method;                                              \
 		SEMIC_SEP_LIST(CMD_ASSIGN_PARAM, N);                                 \
 		unlock();                                                            \
-		if (sync) sync->post();                                              \
+		if (sync)                                                            \
+			sync->post();                                                    \
 	}
 
 #define CMD_RET_TYPE(N) CommandRet##N<T, M, COMMA_SEP_LIST(TYPE_ARG, N) COMMA(N) R>
@@ -253,7 +254,8 @@
 		cmd->ret = r_ret;                                                                      \
 		cmd->sync_sem = ss;                                                                    \
 		unlock();                                                                              \
-		if (sync) sync->post();                                                                \
+		if (sync)                                                                              \
+			sync->post();                                                                      \
 		ss->sem->wait();                                                                       \
 		ss->in_use = false;                                                                    \
 	}
@@ -270,7 +272,8 @@
 		SEMIC_SEP_LIST(CMD_ASSIGN_PARAM, N);                                          \
 		cmd->sync_sem = ss;                                                           \
 		unlock();                                                                     \
-		if (sync) sync->post();                                                       \
+		if (sync)                                                                     \
+			sync->post();                                                             \
 		ss->sem->wait();                                                              \
 		ss->in_use = false;                                                           \
 	}
@@ -402,12 +405,14 @@ class CommandQueueMT {
 	}
 
 	bool flush_one(bool p_lock = true) {
-		if (p_lock) lock();
+		if (p_lock)
+			lock();
 	tryagain:
 
 		// tried to read an empty queue
 		if (read_ptr == write_ptr) {
-			if (p_lock) unlock();
+			if (p_lock)
+				unlock();
 			return false;
 		}
 
@@ -426,15 +431,18 @@ class CommandQueueMT {
 
 		read_ptr += size;
 
-		if (p_lock) unlock();
+		if (p_lock)
+			unlock();
 		cmd->call();
-		if (p_lock) lock();
+		if (p_lock)
+			lock();
 
 		cmd->post();
 		cmd->~CommandBase();
 		*(uint32_t *)&command_mem[size_ptr] &= ~1;
 
-		if (p_lock) unlock();
+		if (p_lock)
+			unlock();
 		return true;
 	}
 

--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -94,7 +94,8 @@ private:
 			return false;
 		}
 		*out = next_power_of_2(o);
-		if (_add_overflow(o, static_cast<size_t>(32), &p)) return false; //no longer allocated here
+		if (_add_overflow(o, static_cast<size_t>(32), &p))
+			return false; //no longer allocated here
 		return true;
 #else
 		// Speed is more important than correctness here, do the operations unchecked

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -109,23 +109,36 @@ int Image::get_format_pixel_size(Format p_format) {
 			return 1; //luminance
 		case FORMAT_LA8:
 			return 2; //luminance-alpha
-		case FORMAT_R8: return 1;
-		case FORMAT_RG8: return 2;
-		case FORMAT_RGB8: return 3;
-		case FORMAT_RGBA8: return 4;
-		case FORMAT_RGBA4444: return 2;
-		case FORMAT_RGBA5551: return 2;
+		case FORMAT_R8:
+			return 1;
+		case FORMAT_RG8:
+			return 2;
+		case FORMAT_RGB8:
+			return 3;
+		case FORMAT_RGBA8:
+			return 4;
+		case FORMAT_RGBA4444:
+			return 2;
+		case FORMAT_RGBA5551:
+			return 2;
 		case FORMAT_RF:
 			return 4; //float
-		case FORMAT_RGF: return 8;
-		case FORMAT_RGBF: return 12;
-		case FORMAT_RGBAF: return 16;
+		case FORMAT_RGF:
+			return 8;
+		case FORMAT_RGBF:
+			return 12;
+		case FORMAT_RGBAF:
+			return 16;
 		case FORMAT_RH:
 			return 2; //half float
-		case FORMAT_RGH: return 4;
-		case FORMAT_RGBH: return 6;
-		case FORMAT_RGBAH: return 8;
-		case FORMAT_RGBE9995: return 4;
+		case FORMAT_RGH:
+			return 4;
+		case FORMAT_RGBH:
+			return 6;
+		case FORMAT_RGBAH:
+			return 8;
+		case FORMAT_RGBE9995:
+			return 4;
 		case FORMAT_DXT1:
 			return 1; //s3tc bc1
 		case FORMAT_DXT3:
@@ -144,20 +157,28 @@ int Image::get_format_pixel_size(Format p_format) {
 			return 1; //unsigned float
 		case FORMAT_PVRTC2:
 			return 1; //pvrtc
-		case FORMAT_PVRTC2A: return 1;
-		case FORMAT_PVRTC4: return 1;
-		case FORMAT_PVRTC4A: return 1;
+		case FORMAT_PVRTC2A:
+			return 1;
+		case FORMAT_PVRTC4:
+			return 1;
+		case FORMAT_PVRTC4A:
+			return 1;
 		case FORMAT_ETC:
 			return 1; //etc1
 		case FORMAT_ETC2_R11:
 			return 1; //etc2
 		case FORMAT_ETC2_R11S:
 			return 1; //signed: return 1; NOT srgb.
-		case FORMAT_ETC2_RG11: return 1;
-		case FORMAT_ETC2_RG11S: return 1;
-		case FORMAT_ETC2_RGB8: return 1;
-		case FORMAT_ETC2_RGBA8: return 1;
-		case FORMAT_ETC2_RGB8A1: return 1;
+		case FORMAT_ETC2_RG11:
+			return 1;
+		case FORMAT_ETC2_RG11S:
+			return 1;
+		case FORMAT_ETC2_RGB8:
+			return 1;
+		case FORMAT_ETC2_RGBA8:
+			return 1;
+		case FORMAT_ETC2_RGB8A1:
+			return 1;
 		case FORMAT_MAX: {
 		}
 	}
@@ -463,36 +484,96 @@ void Image::convert(Format p_new_format) {
 
 	switch (conversion_type) {
 
-		case FORMAT_L8 | (FORMAT_LA8 << 8): _convert<1, false, 1, true, true, true>(width, height, rptr, wptr); break;
-		case FORMAT_L8 | (FORMAT_R8 << 8): _convert<1, false, 1, false, true, false>(width, height, rptr, wptr); break;
-		case FORMAT_L8 | (FORMAT_RG8 << 8): _convert<1, false, 2, false, true, false>(width, height, rptr, wptr); break;
-		case FORMAT_L8 | (FORMAT_RGB8 << 8): _convert<1, false, 3, false, true, false>(width, height, rptr, wptr); break;
-		case FORMAT_L8 | (FORMAT_RGBA8 << 8): _convert<1, false, 3, true, true, false>(width, height, rptr, wptr); break;
-		case FORMAT_LA8 | (FORMAT_L8 << 8): _convert<1, true, 1, false, true, true>(width, height, rptr, wptr); break;
-		case FORMAT_LA8 | (FORMAT_R8 << 8): _convert<1, true, 1, false, true, false>(width, height, rptr, wptr); break;
-		case FORMAT_LA8 | (FORMAT_RG8 << 8): _convert<1, true, 2, false, true, false>(width, height, rptr, wptr); break;
-		case FORMAT_LA8 | (FORMAT_RGB8 << 8): _convert<1, true, 3, false, true, false>(width, height, rptr, wptr); break;
-		case FORMAT_LA8 | (FORMAT_RGBA8 << 8): _convert<1, true, 3, true, true, false>(width, height, rptr, wptr); break;
-		case FORMAT_R8 | (FORMAT_L8 << 8): _convert<1, false, 1, false, false, true>(width, height, rptr, wptr); break;
-		case FORMAT_R8 | (FORMAT_LA8 << 8): _convert<1, false, 1, true, false, true>(width, height, rptr, wptr); break;
-		case FORMAT_R8 | (FORMAT_RG8 << 8): _convert<1, false, 2, false, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_R8 | (FORMAT_RGB8 << 8): _convert<1, false, 3, false, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_R8 | (FORMAT_RGBA8 << 8): _convert<1, false, 3, true, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_RG8 | (FORMAT_L8 << 8): _convert<2, false, 1, false, false, true>(width, height, rptr, wptr); break;
-		case FORMAT_RG8 | (FORMAT_LA8 << 8): _convert<2, false, 1, true, false, true>(width, height, rptr, wptr); break;
-		case FORMAT_RG8 | (FORMAT_R8 << 8): _convert<2, false, 1, false, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_RG8 | (FORMAT_RGB8 << 8): _convert<2, false, 3, false, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_RG8 | (FORMAT_RGBA8 << 8): _convert<2, false, 3, true, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_RGB8 | (FORMAT_L8 << 8): _convert<3, false, 1, false, false, true>(width, height, rptr, wptr); break;
-		case FORMAT_RGB8 | (FORMAT_LA8 << 8): _convert<3, false, 1, true, false, true>(width, height, rptr, wptr); break;
-		case FORMAT_RGB8 | (FORMAT_R8 << 8): _convert<3, false, 1, false, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_RGB8 | (FORMAT_RG8 << 8): _convert<3, false, 2, false, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_RGB8 | (FORMAT_RGBA8 << 8): _convert<3, false, 3, true, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_RGBA8 | (FORMAT_L8 << 8): _convert<3, true, 1, false, false, true>(width, height, rptr, wptr); break;
-		case FORMAT_RGBA8 | (FORMAT_LA8 << 8): _convert<3, true, 1, true, false, true>(width, height, rptr, wptr); break;
-		case FORMAT_RGBA8 | (FORMAT_R8 << 8): _convert<3, true, 1, false, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_RGBA8 | (FORMAT_RG8 << 8): _convert<3, true, 2, false, false, false>(width, height, rptr, wptr); break;
-		case FORMAT_RGBA8 | (FORMAT_RGB8 << 8): _convert<3, true, 3, false, false, false>(width, height, rptr, wptr); break;
+		case FORMAT_L8 | (FORMAT_LA8 << 8):
+			_convert<1, false, 1, true, true, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_L8 | (FORMAT_R8 << 8):
+			_convert<1, false, 1, false, true, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_L8 | (FORMAT_RG8 << 8):
+			_convert<1, false, 2, false, true, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_L8 | (FORMAT_RGB8 << 8):
+			_convert<1, false, 3, false, true, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_L8 | (FORMAT_RGBA8 << 8):
+			_convert<1, false, 3, true, true, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_LA8 | (FORMAT_L8 << 8):
+			_convert<1, true, 1, false, true, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_LA8 | (FORMAT_R8 << 8):
+			_convert<1, true, 1, false, true, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_LA8 | (FORMAT_RG8 << 8):
+			_convert<1, true, 2, false, true, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_LA8 | (FORMAT_RGB8 << 8):
+			_convert<1, true, 3, false, true, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_LA8 | (FORMAT_RGBA8 << 8):
+			_convert<1, true, 3, true, true, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_R8 | (FORMAT_L8 << 8):
+			_convert<1, false, 1, false, false, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_R8 | (FORMAT_LA8 << 8):
+			_convert<1, false, 1, true, false, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_R8 | (FORMAT_RG8 << 8):
+			_convert<1, false, 2, false, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_R8 | (FORMAT_RGB8 << 8):
+			_convert<1, false, 3, false, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_R8 | (FORMAT_RGBA8 << 8):
+			_convert<1, false, 3, true, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RG8 | (FORMAT_L8 << 8):
+			_convert<2, false, 1, false, false, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RG8 | (FORMAT_LA8 << 8):
+			_convert<2, false, 1, true, false, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RG8 | (FORMAT_R8 << 8):
+			_convert<2, false, 1, false, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RG8 | (FORMAT_RGB8 << 8):
+			_convert<2, false, 3, false, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RG8 | (FORMAT_RGBA8 << 8):
+			_convert<2, false, 3, true, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGB8 | (FORMAT_L8 << 8):
+			_convert<3, false, 1, false, false, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGB8 | (FORMAT_LA8 << 8):
+			_convert<3, false, 1, true, false, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGB8 | (FORMAT_R8 << 8):
+			_convert<3, false, 1, false, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGB8 | (FORMAT_RG8 << 8):
+			_convert<3, false, 2, false, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGB8 | (FORMAT_RGBA8 << 8):
+			_convert<3, false, 3, true, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGBA8 | (FORMAT_L8 << 8):
+			_convert<3, true, 1, false, false, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGBA8 | (FORMAT_LA8 << 8):
+			_convert<3, true, 1, true, false, true>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGBA8 | (FORMAT_R8 << 8):
+			_convert<3, true, 1, false, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGBA8 | (FORMAT_RG8 << 8):
+			_convert<3, true, 2, false, false, false>(width, height, rptr, wptr);
+			break;
+		case FORMAT_RGBA8 | (FORMAT_RGB8 << 8):
+			_convert<3, true, 3, false, false, false>(width, height, rptr, wptr);
+			break;
 	}
 
 	r = PoolVector<uint8_t>::Read();
@@ -946,25 +1027,49 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
 			if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
 				switch (get_format_pixel_size(format)) {
-					case 1: _scale_nearest<1, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 2: _scale_nearest<2, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 3: _scale_nearest<3, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 4: _scale_nearest<4, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
+					case 1:
+						_scale_nearest<1, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 2:
+						_scale_nearest<2, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 3:
+						_scale_nearest<3, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 4:
+						_scale_nearest<4, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
 				}
 			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
 				switch (get_format_pixel_size(format)) {
-					case 4: _scale_nearest<1, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 8: _scale_nearest<2, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 12: _scale_nearest<3, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 16: _scale_nearest<4, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
+					case 4:
+						_scale_nearest<1, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 8:
+						_scale_nearest<2, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 12:
+						_scale_nearest<3, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 16:
+						_scale_nearest<4, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
 				}
 
 			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
 				switch (get_format_pixel_size(format)) {
-					case 2: _scale_nearest<1, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 4: _scale_nearest<2, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 6: _scale_nearest<3, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 8: _scale_nearest<4, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
+					case 2:
+						_scale_nearest<1, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 4:
+						_scale_nearest<2, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 6:
+						_scale_nearest<3, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 8:
+						_scale_nearest<4, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
 				}
 			}
 
@@ -1010,24 +1115,48 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
 				if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
 					switch (get_format_pixel_size(format)) {
-						case 1: _scale_bilinear<1, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
-						case 2: _scale_bilinear<2, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
-						case 3: _scale_bilinear<3, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
-						case 4: _scale_bilinear<4, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
+						case 1:
+							_scale_bilinear<1, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
+						case 2:
+							_scale_bilinear<2, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
+						case 3:
+							_scale_bilinear<3, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
+						case 4:
+							_scale_bilinear<4, uint8_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
 					}
 				} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
 					switch (get_format_pixel_size(format)) {
-						case 4: _scale_bilinear<1, float>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
-						case 8: _scale_bilinear<2, float>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
-						case 12: _scale_bilinear<3, float>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
-						case 16: _scale_bilinear<4, float>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
+						case 4:
+							_scale_bilinear<1, float>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
+						case 8:
+							_scale_bilinear<2, float>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
+						case 12:
+							_scale_bilinear<3, float>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
+						case 16:
+							_scale_bilinear<4, float>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
 					}
 				} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
 					switch (get_format_pixel_size(format)) {
-						case 2: _scale_bilinear<1, uint16_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
-						case 4: _scale_bilinear<2, uint16_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
-						case 6: _scale_bilinear<3, uint16_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
-						case 8: _scale_bilinear<4, uint16_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height); break;
+						case 2:
+							_scale_bilinear<1, uint16_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
+						case 4:
+							_scale_bilinear<2, uint16_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
+						case 6:
+							_scale_bilinear<3, uint16_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
+						case 8:
+							_scale_bilinear<4, uint16_t>(src_ptr, w_ptr, src_width, src_height, p_width, p_height);
+							break;
 					}
 				}
 			}
@@ -1043,24 +1172,48 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
 			if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
 				switch (get_format_pixel_size(format)) {
-					case 1: _scale_cubic<1, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 2: _scale_cubic<2, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 3: _scale_cubic<3, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 4: _scale_cubic<4, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
+					case 1:
+						_scale_cubic<1, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 2:
+						_scale_cubic<2, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 3:
+						_scale_cubic<3, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 4:
+						_scale_cubic<4, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
 				}
 			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
 				switch (get_format_pixel_size(format)) {
-					case 4: _scale_cubic<1, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 8: _scale_cubic<2, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 12: _scale_cubic<3, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 16: _scale_cubic<4, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
+					case 4:
+						_scale_cubic<1, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 8:
+						_scale_cubic<2, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 12:
+						_scale_cubic<3, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 16:
+						_scale_cubic<4, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
 				}
 			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
 				switch (get_format_pixel_size(format)) {
-					case 2: _scale_cubic<1, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 4: _scale_cubic<2, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 6: _scale_cubic<3, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 8: _scale_cubic<4, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
+					case 2:
+						_scale_cubic<1, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 4:
+						_scale_cubic<2, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 6:
+						_scale_cubic<3, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 8:
+						_scale_cubic<4, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
 				}
 			}
 		} break;
@@ -1068,24 +1221,48 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
 			if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
 				switch (get_format_pixel_size(format)) {
-					case 1: _scale_lanczos<1, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 2: _scale_lanczos<2, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 3: _scale_lanczos<3, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 4: _scale_lanczos<4, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
+					case 1:
+						_scale_lanczos<1, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 2:
+						_scale_lanczos<2, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 3:
+						_scale_lanczos<3, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 4:
+						_scale_lanczos<4, uint8_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
 				}
 			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
 				switch (get_format_pixel_size(format)) {
-					case 4: _scale_lanczos<1, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 8: _scale_lanczos<2, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 12: _scale_lanczos<3, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 16: _scale_lanczos<4, float>(r_ptr, w_ptr, width, height, p_width, p_height); break;
+					case 4:
+						_scale_lanczos<1, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 8:
+						_scale_lanczos<2, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 12:
+						_scale_lanczos<3, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 16:
+						_scale_lanczos<4, float>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
 				}
 			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
 				switch (get_format_pixel_size(format)) {
-					case 2: _scale_lanczos<1, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 4: _scale_lanczos<2, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 6: _scale_lanczos<3, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
-					case 8: _scale_lanczos<4, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height); break;
+					case 2:
+						_scale_lanczos<1, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 4:
+						_scale_lanczos<2, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 6:
+						_scale_lanczos<3, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
+					case 8:
+						_scale_lanczos<4, uint16_t>(r_ptr, w_ptr, width, height, p_width, p_height);
+						break;
 				}
 			}
 		} break;
@@ -1399,23 +1576,51 @@ void Image::shrink_x2() {
 			switch (format) {
 
 				case FORMAT_L8:
-				case FORMAT_R8: _generate_po2_mipmap<uint8_t, 1, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height); break;
-				case FORMAT_LA8: _generate_po2_mipmap<uint8_t, 2, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height); break;
-				case FORMAT_RG8: _generate_po2_mipmap<uint8_t, 2, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height); break;
-				case FORMAT_RGB8: _generate_po2_mipmap<uint8_t, 3, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height); break;
-				case FORMAT_RGBA8: _generate_po2_mipmap<uint8_t, 4, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height); break;
+				case FORMAT_R8:
+					_generate_po2_mipmap<uint8_t, 1, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height);
+					break;
+				case FORMAT_LA8:
+					_generate_po2_mipmap<uint8_t, 2, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height);
+					break;
+				case FORMAT_RG8:
+					_generate_po2_mipmap<uint8_t, 2, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height);
+					break;
+				case FORMAT_RGB8:
+					_generate_po2_mipmap<uint8_t, 3, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height);
+					break;
+				case FORMAT_RGBA8:
+					_generate_po2_mipmap<uint8_t, 4, false, Image::average_4_uint8, Image::renormalize_uint8>(r.ptr(), w.ptr(), width, height);
+					break;
 
-				case FORMAT_RF: _generate_po2_mipmap<float, 1, false, Image::average_4_float, Image::renormalize_float>(reinterpret_cast<const float *>(r.ptr()), reinterpret_cast<float *>(w.ptr()), width, height); break;
-				case FORMAT_RGF: _generate_po2_mipmap<float, 2, false, Image::average_4_float, Image::renormalize_float>(reinterpret_cast<const float *>(r.ptr()), reinterpret_cast<float *>(w.ptr()), width, height); break;
-				case FORMAT_RGBF: _generate_po2_mipmap<float, 3, false, Image::average_4_float, Image::renormalize_float>(reinterpret_cast<const float *>(r.ptr()), reinterpret_cast<float *>(w.ptr()), width, height); break;
-				case FORMAT_RGBAF: _generate_po2_mipmap<float, 4, false, Image::average_4_float, Image::renormalize_float>(reinterpret_cast<const float *>(r.ptr()), reinterpret_cast<float *>(w.ptr()), width, height); break;
+				case FORMAT_RF:
+					_generate_po2_mipmap<float, 1, false, Image::average_4_float, Image::renormalize_float>(reinterpret_cast<const float *>(r.ptr()), reinterpret_cast<float *>(w.ptr()), width, height);
+					break;
+				case FORMAT_RGF:
+					_generate_po2_mipmap<float, 2, false, Image::average_4_float, Image::renormalize_float>(reinterpret_cast<const float *>(r.ptr()), reinterpret_cast<float *>(w.ptr()), width, height);
+					break;
+				case FORMAT_RGBF:
+					_generate_po2_mipmap<float, 3, false, Image::average_4_float, Image::renormalize_float>(reinterpret_cast<const float *>(r.ptr()), reinterpret_cast<float *>(w.ptr()), width, height);
+					break;
+				case FORMAT_RGBAF:
+					_generate_po2_mipmap<float, 4, false, Image::average_4_float, Image::renormalize_float>(reinterpret_cast<const float *>(r.ptr()), reinterpret_cast<float *>(w.ptr()), width, height);
+					break;
 
-				case FORMAT_RH: _generate_po2_mipmap<uint16_t, 1, false, Image::average_4_half, Image::renormalize_half>(reinterpret_cast<const uint16_t *>(r.ptr()), reinterpret_cast<uint16_t *>(w.ptr()), width, height); break;
-				case FORMAT_RGH: _generate_po2_mipmap<uint16_t, 2, false, Image::average_4_half, Image::renormalize_half>(reinterpret_cast<const uint16_t *>(r.ptr()), reinterpret_cast<uint16_t *>(w.ptr()), width, height); break;
-				case FORMAT_RGBH: _generate_po2_mipmap<uint16_t, 3, false, Image::average_4_half, Image::renormalize_half>(reinterpret_cast<const uint16_t *>(r.ptr()), reinterpret_cast<uint16_t *>(w.ptr()), width, height); break;
-				case FORMAT_RGBAH: _generate_po2_mipmap<uint16_t, 4, false, Image::average_4_half, Image::renormalize_half>(reinterpret_cast<const uint16_t *>(r.ptr()), reinterpret_cast<uint16_t *>(w.ptr()), width, height); break;
+				case FORMAT_RH:
+					_generate_po2_mipmap<uint16_t, 1, false, Image::average_4_half, Image::renormalize_half>(reinterpret_cast<const uint16_t *>(r.ptr()), reinterpret_cast<uint16_t *>(w.ptr()), width, height);
+					break;
+				case FORMAT_RGH:
+					_generate_po2_mipmap<uint16_t, 2, false, Image::average_4_half, Image::renormalize_half>(reinterpret_cast<const uint16_t *>(r.ptr()), reinterpret_cast<uint16_t *>(w.ptr()), width, height);
+					break;
+				case FORMAT_RGBH:
+					_generate_po2_mipmap<uint16_t, 3, false, Image::average_4_half, Image::renormalize_half>(reinterpret_cast<const uint16_t *>(r.ptr()), reinterpret_cast<uint16_t *>(w.ptr()), width, height);
+					break;
+				case FORMAT_RGBAH:
+					_generate_po2_mipmap<uint16_t, 4, false, Image::average_4_half, Image::renormalize_half>(reinterpret_cast<const uint16_t *>(r.ptr()), reinterpret_cast<uint16_t *>(w.ptr()), width, height);
+					break;
 
-				case FORMAT_RGBE9995: _generate_po2_mipmap<uint32_t, 1, false, Image::average_4_rgbe9995, Image::renormalize_rgbe9995>(reinterpret_cast<const uint32_t *>(r.ptr()), reinterpret_cast<uint32_t *>(w.ptr()), width, height); break;
+				case FORMAT_RGBE9995:
+					_generate_po2_mipmap<uint32_t, 1, false, Image::average_4_rgbe9995, Image::renormalize_rgbe9995>(reinterpret_cast<const uint32_t *>(r.ptr()), reinterpret_cast<uint32_t *>(w.ptr()), width, height);
+					break;
 				default: {
 				}
 			}
@@ -1486,9 +1691,13 @@ Error Image::generate_mipmaps(bool p_renormalize) {
 		switch (format) {
 
 			case FORMAT_L8:
-			case FORMAT_R8: _generate_po2_mipmap<uint8_t, 1, false, Image::average_4_uint8, Image::renormalize_uint8>(&wp[prev_ofs], &wp[ofs], prev_w, prev_h); break;
+			case FORMAT_R8:
+				_generate_po2_mipmap<uint8_t, 1, false, Image::average_4_uint8, Image::renormalize_uint8>(&wp[prev_ofs], &wp[ofs], prev_w, prev_h);
+				break;
 			case FORMAT_LA8:
-			case FORMAT_RG8: _generate_po2_mipmap<uint8_t, 2, false, Image::average_4_uint8, Image::renormalize_uint8>(&wp[prev_ofs], &wp[ofs], prev_w, prev_h); break;
+			case FORMAT_RG8:
+				_generate_po2_mipmap<uint8_t, 2, false, Image::average_4_uint8, Image::renormalize_uint8>(&wp[prev_ofs], &wp[ofs], prev_w, prev_h);
+				break;
 			case FORMAT_RGB8:
 				if (p_renormalize)
 					_generate_po2_mipmap<uint8_t, 3, true, Image::average_4_uint8, Image::renormalize_uint8>(&wp[prev_ofs], &wp[ofs], prev_w, prev_h);
@@ -1715,12 +1924,24 @@ void Image::create(const char **p_xpm) {
 								break;
 
 							switch (i) {
-								case 0: col_r = v << 4; break;
-								case 1: col_r |= v; break;
-								case 2: col_g = v << 4; break;
-								case 3: col_g |= v; break;
-								case 4: col_b = v << 4; break;
-								case 5: col_b |= v; break;
+								case 0:
+									col_r = v << 4;
+									break;
+								case 1:
+									col_r |= v;
+									break;
+								case 2:
+									col_g = v << 4;
+									break;
+								case 3:
+									col_g |= v;
+									break;
+								case 4:
+									col_b = v << 4;
+									break;
+								case 5:
+									col_b |= v;
+									break;
 							};
 						}
 
@@ -2707,12 +2928,24 @@ Image::DetectChannels Image::get_detected_channels() {
 
 void Image::optimize_channels() {
 	switch (get_detected_channels()) {
-		case DETECTED_L: convert(FORMAT_L8); break;
-		case DETECTED_LA: convert(FORMAT_LA8); break;
-		case DETECTED_R: convert(FORMAT_R8); break;
-		case DETECTED_RG: convert(FORMAT_RG8); break;
-		case DETECTED_RGB: convert(FORMAT_RGB8); break;
-		case DETECTED_RGBA: convert(FORMAT_RGBA8); break;
+		case DETECTED_L:
+			convert(FORMAT_L8);
+			break;
+		case DETECTED_LA:
+			convert(FORMAT_LA8);
+			break;
+		case DETECTED_R:
+			convert(FORMAT_R8);
+			break;
+		case DETECTED_RG:
+			convert(FORMAT_RG8);
+			break;
+		case DETECTED_RGB:
+			convert(FORMAT_RGB8);
+			break;
+		case DETECTED_RGBA:
+			convert(FORMAT_RGBA8);
+			break;
 	}
 }
 

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -3162,11 +3162,13 @@ void Image::bumpmap_to_normalmap(float bump_scale) {
 
 		for (int ty = 0; ty < height; ty++) {
 			int py = ty + 1;
-			if (py >= height) py -= height;
+			if (py >= height)
+				py -= height;
 
 			for (int tx = 0; tx < width; tx++) {
 				int px = tx + 1;
-				if (px >= width) px -= width;
+				if (px >= width)
+					px -= width;
 				float here = read_ptr[ty * width + tx];
 				float to_right = read_ptr[ty * width + px];
 				float above = read_ptr[py * width + tx];

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -408,7 +408,8 @@ Error DirAccessPack::change_dir(String p_dir) {
 
 	nd = nd.simplify_path();
 
-	if (nd == "") nd = ".";
+	if (nd == "")
+		nd = ".";
 
 	if (nd.begins_with("/")) {
 		nd = nd.replace_first("/", "");

--- a/core/io/ip_address.h
+++ b/core/io/ip_address.h
@@ -52,16 +52,20 @@ protected:
 public:
 	//operator Variant() const;
 	bool operator==(const IP_Address &p_ip) const {
-		if (p_ip.valid != valid) return false;
-		if (!valid) return false;
+		if (p_ip.valid != valid)
+			return false;
+		if (!valid)
+			return false;
 		for (int i = 0; i < 4; i++)
 			if (field32[i] != p_ip.field32[i])
 				return false;
 		return true;
 	}
 	bool operator!=(const IP_Address &p_ip) const {
-		if (p_ip.valid != valid) return true;
-		if (!valid) return true;
+		if (p_ip.valid != valid)
+			return true;
+		if (!valid)
+			return true;
 		for (int i = 0; i < 4; i++)
 			if (field32[i] != p_ip.field32[i])
 				return true;

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -67,10 +67,14 @@ String JSON::_print_var(const Variant &p_var, const String &p_indent, int p_cur_
 
 	switch (p_var.get_type()) {
 
-		case Variant::NIL: return "null";
-		case Variant::BOOL: return p_var.operator bool() ? "true" : "false";
-		case Variant::INT: return itos(p_var);
-		case Variant::REAL: return rtos(p_var);
+		case Variant::NIL:
+			return "null";
+		case Variant::BOOL:
+			return p_var.operator bool() ? "true" : "false";
+		case Variant::INT:
+			return itos(p_var);
+		case Variant::REAL:
+			return rtos(p_var);
 		case Variant::POOL_INT_ARRAY:
 		case Variant::POOL_REAL_ARRAY:
 		case Variant::POOL_STRING_ARRAY:
@@ -114,7 +118,8 @@ String JSON::_print_var(const Variant &p_var, const String &p_indent, int p_cur_
 			s += end_statement + _make_indent(p_indent, p_cur_indent) + "}";
 			return s;
 		};
-		default: return "\"" + String(p_var).json_escape() + "\"";
+		default:
+			return "\"" + String(p_var).json_escape() + "\"";
 	}
 }
 
@@ -197,11 +202,21 @@ Error JSON::_get_token(const CharType *p_str, int &index, int p_len, Token &r_to
 
 						switch (next) {
 
-							case 'b': res = 8; break;
-							case 't': res = 9; break;
-							case 'n': res = 10; break;
-							case 'f': res = 12; break;
-							case 'r': res = 13; break;
+							case 'b':
+								res = 8;
+								break;
+							case 't':
+								res = 9;
+								break;
+							case 'n':
+								res = 10;
+								break;
+							case 'f':
+								res = 12;
+								break;
+							case 'r':
+								res = 13;
+								break;
 							case 'u': {
 								//hexnumbarh - oct is deprecated
 

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -60,11 +60,21 @@ void Logger::log_error(const char *p_function, const char *p_file, int p_line, c
 
 	const char *err_type = "**ERROR**";
 	switch (p_type) {
-		case ERR_ERROR: err_type = "**ERROR**"; break;
-		case ERR_WARNING: err_type = "**WARNING**"; break;
-		case ERR_SCRIPT: err_type = "**SCRIPT ERROR**"; break;
-		case ERR_SHADER: err_type = "**SHADER ERROR**"; break;
-		default: ERR_PRINT("Unknown error type"); break;
+		case ERR_ERROR:
+			err_type = "**ERROR**";
+			break;
+		case ERR_WARNING:
+			err_type = "**WARNING**";
+			break;
+		case ERR_SCRIPT:
+			err_type = "**SCRIPT ERROR**";
+			break;
+		case ERR_SHADER:
+			err_type = "**SHADER ERROR**";
+			break;
+		default:
+			ERR_PRINT("Unknown error type");
+			break;
 	}
 
 	const char *err_details;

--- a/core/io/marshalls.h
+++ b/core/io/marshalls.h
@@ -121,7 +121,8 @@ static inline int encode_cstring(const char *p_string, uint8_t *p_data) {
 		len++;
 	};
 
-	if (p_data) *p_data = 0;
+	if (p_data)
+		*p_data = 0;
 	return len + 1;
 }
 

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -133,7 +133,8 @@ void MultiplayerAPI::set_root_node(Node *p_node) {
 
 void MultiplayerAPI::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_peer) {
 
-	if (p_peer == network_peer) return; // Nothing to do
+	if (p_peer == network_peer)
+		return; // Nothing to do
 
 	if (network_peer.is_valid()) {
 		network_peer->disconnect("peer_connected", this, "_add_peer");
@@ -507,8 +508,9 @@ void MultiplayerAPI::_send_rpc(Node *p_from, int p_to, bool p_unreliable, bool p
 
 	int ofs = 0;
 
-#define MAKE_ROOM(m_amount) \
-	if (packet_cache.size() < m_amount) packet_cache.resize(m_amount);
+#define MAKE_ROOM(m_amount)             \
+	if (packet_cache.size() < m_amount) \
+		packet_cache.resize(m_amount);
 
 	// Encode type.
 	MAKE_ROOM(1);

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -164,7 +164,8 @@ public:
 	static bool get_timestamp_on_load() { return timestamp_on_load; }
 
 	static void notify_load_error(const String &p_err) {
-		if (err_notify) err_notify(err_notify_ud, p_err);
+		if (err_notify)
+			err_notify(err_notify_ud, p_err);
 	}
 	static void set_error_notify_func(void *p_ud, ResourceLoadErrorNotify p_err_notify) {
 		err_notify = p_err_notify;
@@ -172,7 +173,8 @@ public:
 	}
 
 	static void notify_dependency_error(const String &p_path, const String &p_dependency, const String &p_type) {
-		if (dep_err_notify) dep_err_notify(dep_err_notify_ud, p_path, p_dependency, p_type);
+		if (dep_err_notify)
+			dep_err_notify(dep_err_notify_ud, p_path, p_dependency, p_type);
 	}
 	static void set_dependency_error_notify_func(void *p_ud, DependencyErrorNotify p_err_notify) {
 		dep_err_notify = p_err_notify;

--- a/core/list.h
+++ b/core/list.h
@@ -352,7 +352,8 @@ public:
 
 		Element *it = front();
 		while (it) {
-			if (it->value == p_val) return it;
+			if (it->value == p_val)
+				return it;
 			it = it->next();
 		};
 

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -176,14 +176,22 @@ Vector3 AABB::get_support(const Vector3 &p_normal) const {
 Vector3 AABB::get_endpoint(int p_point) const {
 
 	switch (p_point) {
-		case 0: return Vector3(position.x, position.y, position.z);
-		case 1: return Vector3(position.x, position.y, position.z + size.z);
-		case 2: return Vector3(position.x, position.y + size.y, position.z);
-		case 3: return Vector3(position.x, position.y + size.y, position.z + size.z);
-		case 4: return Vector3(position.x + size.x, position.y, position.z);
-		case 5: return Vector3(position.x + size.x, position.y, position.z + size.z);
-		case 6: return Vector3(position.x + size.x, position.y + size.y, position.z);
-		case 7: return Vector3(position.x + size.x, position.y + size.y, position.z + size.z);
+		case 0:
+			return Vector3(position.x, position.y, position.z);
+		case 1:
+			return Vector3(position.x, position.y, position.z + size.z);
+		case 2:
+			return Vector3(position.x, position.y + size.y, position.z);
+		case 3:
+			return Vector3(position.x, position.y + size.y, position.z + size.z);
+		case 4:
+			return Vector3(position.x + size.x, position.y, position.z);
+		case 5:
+			return Vector3(position.x + size.x, position.y, position.z + size.z);
+		case 6:
+			return Vector3(position.x + size.x, position.y + size.y, position.z);
+		case 7:
+			return Vector3(position.x + size.x, position.y + size.y, position.z + size.z);
 	};
 
 	ERR_FAIL_V(Vector3());

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -785,7 +785,8 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 	real_t s = Math::sqrt((elements[1][2] - elements[2][1]) * (elements[1][2] - elements[2][1]) + (elements[2][0] - elements[0][2]) * (elements[2][0] - elements[0][2]) + (elements[0][1] - elements[1][0]) * (elements[0][1] - elements[1][0])); // s=|axis||sin(angle)|, used to normalise
 
 	angle = Math::acos((elements[0][0] + elements[1][1] + elements[2][2] - 1) / 2);
-	if (angle < 0) s = -s;
+	if (angle < 0)
+		s = -s;
 	x = (elements[2][1] - elements[1][2]) / s;
 	y = (elements[0][2] - elements[2][0]) / s;
 	z = (elements[1][0] - elements[0][1]) / s;

--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -440,20 +440,23 @@ void CameraMatrix::invert() {
 
 		/** Divide column by minus pivot value **/
 		for (i = 0; i < 4; i++) {
-			if (i != k) matrix[i][k] /= (-pvt_val);
+			if (i != k)
+				matrix[i][k] /= (-pvt_val);
 		}
 
 		/** Reduce the matrix **/
 		for (i = 0; i < 4; i++) {
 			hold = matrix[i][k];
 			for (j = 0; j < 4; j++) {
-				if (i != k && j != k) matrix[i][j] += hold * matrix[k][j];
+				if (i != k && j != k)
+					matrix[i][j] += hold * matrix[k][j];
 			}
 		}
 
 		/** Divide row by pivot **/
 		for (j = 0; j < 4; j++) {
-			if (j != k) matrix[k][j] /= pvt_val;
+			if (j != k)
+				matrix[k][j] /= pvt_val;
 		}
 
 		/** Replace pivot by reciprocal (at last we can touch it). **/

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -989,11 +989,21 @@ Error Expression::_get_token(Token &r_token) {
 
 						switch (next) {
 
-							case 'b': res = 8; break;
-							case 't': res = 9; break;
-							case 'n': res = 10; break;
-							case 'f': res = 12; break;
-							case 'r': res = 13; break;
+							case 'b':
+								res = 8;
+								break;
+							case 't':
+								res = 9;
+								break;
+							case 'n':
+								res = 10;
+								break;
+							case 'f':
+								res = 12;
+								break;
+							case 'r':
+								res = 13;
+								break;
 							case 'u': {
 								//hexnumbarh - oct is deprecated
 
@@ -1675,27 +1685,69 @@ Expression::ENode *Expression::_parse_expression() {
 		Variant::Operator op = Variant::OP_MAX;
 
 		switch (tk.type) {
-			case TK_OP_IN: op = Variant::OP_IN; break;
-			case TK_OP_EQUAL: op = Variant::OP_EQUAL; break;
-			case TK_OP_NOT_EQUAL: op = Variant::OP_NOT_EQUAL; break;
-			case TK_OP_LESS: op = Variant::OP_LESS; break;
-			case TK_OP_LESS_EQUAL: op = Variant::OP_LESS_EQUAL; break;
-			case TK_OP_GREATER: op = Variant::OP_GREATER; break;
-			case TK_OP_GREATER_EQUAL: op = Variant::OP_GREATER_EQUAL; break;
-			case TK_OP_AND: op = Variant::OP_AND; break;
-			case TK_OP_OR: op = Variant::OP_OR; break;
-			case TK_OP_NOT: op = Variant::OP_NOT; break;
-			case TK_OP_ADD: op = Variant::OP_ADD; break;
-			case TK_OP_SUB: op = Variant::OP_SUBTRACT; break;
-			case TK_OP_MUL: op = Variant::OP_MULTIPLY; break;
-			case TK_OP_DIV: op = Variant::OP_DIVIDE; break;
-			case TK_OP_MOD: op = Variant::OP_MODULE; break;
-			case TK_OP_SHIFT_LEFT: op = Variant::OP_SHIFT_LEFT; break;
-			case TK_OP_SHIFT_RIGHT: op = Variant::OP_SHIFT_RIGHT; break;
-			case TK_OP_BIT_AND: op = Variant::OP_BIT_AND; break;
-			case TK_OP_BIT_OR: op = Variant::OP_BIT_OR; break;
-			case TK_OP_BIT_XOR: op = Variant::OP_BIT_XOR; break;
-			case TK_OP_BIT_INVERT: op = Variant::OP_BIT_NEGATE; break;
+			case TK_OP_IN:
+				op = Variant::OP_IN;
+				break;
+			case TK_OP_EQUAL:
+				op = Variant::OP_EQUAL;
+				break;
+			case TK_OP_NOT_EQUAL:
+				op = Variant::OP_NOT_EQUAL;
+				break;
+			case TK_OP_LESS:
+				op = Variant::OP_LESS;
+				break;
+			case TK_OP_LESS_EQUAL:
+				op = Variant::OP_LESS_EQUAL;
+				break;
+			case TK_OP_GREATER:
+				op = Variant::OP_GREATER;
+				break;
+			case TK_OP_GREATER_EQUAL:
+				op = Variant::OP_GREATER_EQUAL;
+				break;
+			case TK_OP_AND:
+				op = Variant::OP_AND;
+				break;
+			case TK_OP_OR:
+				op = Variant::OP_OR;
+				break;
+			case TK_OP_NOT:
+				op = Variant::OP_NOT;
+				break;
+			case TK_OP_ADD:
+				op = Variant::OP_ADD;
+				break;
+			case TK_OP_SUB:
+				op = Variant::OP_SUBTRACT;
+				break;
+			case TK_OP_MUL:
+				op = Variant::OP_MULTIPLY;
+				break;
+			case TK_OP_DIV:
+				op = Variant::OP_DIVIDE;
+				break;
+			case TK_OP_MOD:
+				op = Variant::OP_MODULE;
+				break;
+			case TK_OP_SHIFT_LEFT:
+				op = Variant::OP_SHIFT_LEFT;
+				break;
+			case TK_OP_SHIFT_RIGHT:
+				op = Variant::OP_SHIFT_RIGHT;
+				break;
+			case TK_OP_BIT_AND:
+				op = Variant::OP_BIT_AND;
+				break;
+			case TK_OP_BIT_OR:
+				op = Variant::OP_BIT_OR;
+				break;
+			case TK_OP_BIT_XOR:
+				op = Variant::OP_BIT_XOR;
+				break;
+			case TK_OP_BIT_INVERT:
+				op = Variant::OP_BIT_NEGATE;
+				break;
 			default: {
 			};
 		}
@@ -1744,36 +1796,74 @@ Expression::ENode *Expression::_parse_expression() {
 					unary = true;
 					break;
 
-				case Variant::OP_MULTIPLY: priority = 2; break;
-				case Variant::OP_DIVIDE: priority = 2; break;
-				case Variant::OP_MODULE: priority = 2; break;
+				case Variant::OP_MULTIPLY:
+					priority = 2;
+					break;
+				case Variant::OP_DIVIDE:
+					priority = 2;
+					break;
+				case Variant::OP_MODULE:
+					priority = 2;
+					break;
 
-				case Variant::OP_ADD: priority = 3; break;
-				case Variant::OP_SUBTRACT: priority = 3; break;
+				case Variant::OP_ADD:
+					priority = 3;
+					break;
+				case Variant::OP_SUBTRACT:
+					priority = 3;
+					break;
 
-				case Variant::OP_SHIFT_LEFT: priority = 4; break;
-				case Variant::OP_SHIFT_RIGHT: priority = 4; break;
+				case Variant::OP_SHIFT_LEFT:
+					priority = 4;
+					break;
+				case Variant::OP_SHIFT_RIGHT:
+					priority = 4;
+					break;
 
-				case Variant::OP_BIT_AND: priority = 5; break;
-				case Variant::OP_BIT_XOR: priority = 6; break;
-				case Variant::OP_BIT_OR: priority = 7; break;
+				case Variant::OP_BIT_AND:
+					priority = 5;
+					break;
+				case Variant::OP_BIT_XOR:
+					priority = 6;
+					break;
+				case Variant::OP_BIT_OR:
+					priority = 7;
+					break;
 
-				case Variant::OP_LESS: priority = 8; break;
-				case Variant::OP_LESS_EQUAL: priority = 8; break;
-				case Variant::OP_GREATER: priority = 8; break;
-				case Variant::OP_GREATER_EQUAL: priority = 8; break;
+				case Variant::OP_LESS:
+					priority = 8;
+					break;
+				case Variant::OP_LESS_EQUAL:
+					priority = 8;
+					break;
+				case Variant::OP_GREATER:
+					priority = 8;
+					break;
+				case Variant::OP_GREATER_EQUAL:
+					priority = 8;
+					break;
 
-				case Variant::OP_EQUAL: priority = 8; break;
-				case Variant::OP_NOT_EQUAL: priority = 8; break;
+				case Variant::OP_EQUAL:
+					priority = 8;
+					break;
+				case Variant::OP_NOT_EQUAL:
+					priority = 8;
+					break;
 
-				case Variant::OP_IN: priority = 10; break;
+				case Variant::OP_IN:
+					priority = 10;
+					break;
 
 				case Variant::OP_NOT:
 					priority = 11;
 					unary = true;
 					break;
-				case Variant::OP_AND: priority = 12; break;
-				case Variant::OP_OR: priority = 13; break;
+				case Variant::OP_AND:
+					priority = 12;
+					break;
+				case Variant::OP_OR:
+					priority = 13;
+					break;
 
 				default: {
 					_set_error("Parser bug, invalid operator in expression: " + itos(expression[i].op));

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -472,7 +472,8 @@ static inline void _mark_outside(uint8_t ***p_cell_status, int x, int y, int z, 
 				next_z--;
 				prev = _CELL_PREV_Z_POS;
 			} break;
-			default: ERR_FAIL();
+			default:
+				ERR_FAIL();
 		}
 
 		//printf("testing if new cell will be ok...!\n");
@@ -1145,10 +1146,18 @@ Vector<Vector<Point2> > Geometry::_polypaths_do_operation(PolyBooleanOperation p
 	ClipType op = ctUnion;
 
 	switch (p_op) {
-		case OPERATION_UNION: op = ctUnion; break;
-		case OPERATION_DIFFERENCE: op = ctDifference; break;
-		case OPERATION_INTERSECTION: op = ctIntersection; break;
-		case OPERATION_XOR: op = ctXor; break;
+		case OPERATION_UNION:
+			op = ctUnion;
+			break;
+		case OPERATION_DIFFERENCE:
+			op = ctDifference;
+			break;
+		case OPERATION_INTERSECTION:
+			op = ctIntersection;
+			break;
+		case OPERATION_XOR:
+			op = ctXor;
+			break;
 	}
 	Path path_a, path_b;
 
@@ -1197,19 +1206,35 @@ Vector<Vector<Point2> > Geometry::_polypath_offset(const Vector<Point2> &p_polyp
 	JoinType jt = jtSquare;
 
 	switch (p_join_type) {
-		case JOIN_SQUARE: jt = jtSquare; break;
-		case JOIN_ROUND: jt = jtRound; break;
-		case JOIN_MITER: jt = jtMiter; break;
+		case JOIN_SQUARE:
+			jt = jtSquare;
+			break;
+		case JOIN_ROUND:
+			jt = jtRound;
+			break;
+		case JOIN_MITER:
+			jt = jtMiter;
+			break;
 	}
 
 	EndType et = etClosedPolygon;
 
 	switch (p_end_type) {
-		case END_POLYGON: et = etClosedPolygon; break;
-		case END_JOINED: et = etClosedLine; break;
-		case END_BUTT: et = etOpenButt; break;
-		case END_SQUARE: et = etOpenSquare; break;
-		case END_ROUND: et = etOpenRound; break;
+		case END_POLYGON:
+			et = etClosedPolygon;
+			break;
+		case END_JOINED:
+			et = etClosedLine;
+			break;
+		case END_BUTT:
+			et = etOpenButt;
+			break;
+		case END_SQUARE:
+			et = etOpenSquare;
+			break;
+		case END_ROUND:
+			et = etOpenRound;
+			break;
 	}
 	ClipperOffset co;
 	Path path;

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -117,10 +117,14 @@ public:
 		real_t mub = (d_of(p1, q1, q2, q1) + mua * d_of(q2, q1, p2, p1)) / d_of(q2, q1, q2, q1);
 
 		//clip the value between [0..1] constraining the solution to lie on the original curves
-		if (mua < 0) mua = 0;
-		if (mub < 0) mub = 0;
-		if (mua > 1) mua = 1;
-		if (mub > 1) mub = 1;
+		if (mua < 0)
+			mua = 0;
+		if (mub < 0)
+			mub = 0;
+		if (mua > 1)
+			mua = 1;
+		if (mub > 1)
+			mub = 1;
 		c1 = p1.linear_interpolate(p2, mua);
 		c2 = q1.linear_interpolate(q2, mub);
 	}
@@ -510,7 +514,8 @@ public:
 
 		bool orientation = an.cross(bn) > 0;
 
-		if ((bn.cross(cn) > 0) != orientation) return false;
+		if ((bn.cross(cn) > 0) != orientation)
+			return false;
 
 		return (cn.cross(an) > 0) == orientation;
 	}
@@ -698,15 +703,18 @@ public:
 		real_t sqrtterm = b * b - 4 * a * c;
 
 		/* if the term we intend to square root is less than 0 then the answer won't be real, so it definitely won't be t in the range 0 to 1 */
-		if (sqrtterm < 0) return -1;
+		if (sqrtterm < 0)
+			return -1;
 
 		/* if we can assume that the line segment starts outside the circle (e.g. for continuous time collision detection) then the following can be skipped and we can just return the equivalent of res1 */
 		sqrtterm = Math::sqrt(sqrtterm);
 		real_t res1 = (-b - sqrtterm) / (2 * a);
 		real_t res2 = (-b + sqrtterm) / (2 * a);
 
-		if (res1 >= 0 && res1 <= 1) return res1;
-		if (res2 >= 0 && res2 <= 1) return res2;
+		if (res1 >= 0 && res1 <= 1)
+			return res1;
+		if (res2 >= 0 && res2 <= 1)
+			return res2;
 		return -1;
 	}
 

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -215,12 +215,14 @@ public:
 	static _ALWAYS_INLINE_ float range_lerp(float p_value, float p_istart, float p_istop, float p_ostart, float p_ostop) { return Math::lerp(p_ostart, p_ostop, Math::inverse_lerp(p_istart, p_istop, p_value)); }
 
 	static _ALWAYS_INLINE_ double smoothstep(double p_from, double p_to, double p_weight) {
-		if (is_equal_approx(p_from, p_to)) return p_from;
+		if (is_equal_approx(p_from, p_to))
+			return p_from;
 		double x = CLAMP((p_weight - p_from) / (p_to - p_from), 0.0, 1.0);
 		return x * x * (3.0 - 2.0 * x);
 	}
 	static _ALWAYS_INLINE_ float smoothstep(float p_from, float p_to, float p_weight) {
-		if (is_equal_approx(p_from, p_to)) return p_from;
+		if (is_equal_approx(p_from, p_to))
+			return p_from;
 		float x = CLAMP((p_weight - p_from) / (p_to - p_from), 0.0f, 1.0f);
 		return x * x * (3.0f - 2.0f * x);
 	}

--- a/core/math/quat.cpp
+++ b/core/math/quat.cpp
@@ -201,7 +201,8 @@ Quat Quat::slerpni(const Quat &q, const real_t &t) const {
 
 	real_t dot = from.dot(q);
 
-	if (Math::absf(dot) > 0.9999) return from;
+	if (Math::absf(dot) > 0.9999)
+		return from;
 
 	real_t theta = Math::acos(dot),
 		   sinT = 1.0 / Math::sin(theta),

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -570,14 +570,16 @@ bool TriangleMesh::intersect_convex_shape(const Plane *p_planes, int p_plane_cou
 								if (p.intersects_segment(point, next_point, &res)) {
 									bool inisde = true;
 									for (int k = 0; k < p_plane_count; k++) {
-										if (k == i) continue;
+										if (k == i)
+											continue;
 										const Plane &pp = p_planes[k];
 										if (pp.is_point_over(res)) {
 											inisde = false;
 											break;
 										}
 									}
-									if (inisde) return true;
+									if (inisde)
+										return true;
 								}
 
 								if (p.is_point_over(point)) {
@@ -585,7 +587,8 @@ bool TriangleMesh::intersect_convex_shape(const Plane *p_planes, int p_plane_cou
 									break;
 								}
 							}
-							if (over) return true;
+							if (over)
+								return true;
 						}
 
 						stack[level] = (VISIT_DONE_BIT << VISITED_BIT_SHIFT) | node;
@@ -667,7 +670,8 @@ bool TriangleMesh::inside_convex_shape(const Plane *p_planes, int p_plane_count,
 			case TEST_AABB_BIT: {
 
 				bool intersects = scale.xform(b.aabb).intersects_convex_shape(p_planes, p_plane_count);
-				if (!intersects) return false;
+				if (!intersects)
+					return false;
 
 				bool inside = scale.xform(b.aabb).inside_convex_shape(p_planes, p_plane_count);
 				if (inside) {
@@ -682,7 +686,8 @@ bool TriangleMesh::inside_convex_shape(const Plane *p_planes, int p_plane_count,
 							Vector3 point = scale.xform(vertexptr[s.indices[j]]);
 							for (int i = 0; i < p_plane_count; i++) {
 								const Plane &p = p_planes[i];
-								if (p.is_point_over(point)) return false;
+								if (p.is_point_over(point))
+									return false;
 							}
 						}
 

--- a/core/math/triangulate.cpp
+++ b/core/math/triangulate.cpp
@@ -103,13 +103,16 @@ bool Triangulate::snip(const Vector<Vector2> &p_contour, int u, int v, int w, in
 	// To avoid that we allow zero-area triangles if all else failed.
 	float threshold = relaxed ? -CMP_EPSILON : CMP_EPSILON;
 
-	if (threshold > (((Bx - Ax) * (Cy - Ay)) - ((By - Ay) * (Cx - Ax)))) return false;
+	if (threshold > (((Bx - Ax) * (Cy - Ay)) - ((By - Ay) * (Cx - Ax))))
+		return false;
 
 	for (p = 0; p < n; p++) {
-		if ((p == u) || (p == v) || (p == w)) continue;
+		if ((p == u) || (p == v) || (p == w))
+			continue;
 		Px = contour[V[p]].x;
 		Py = contour[V[p]].y;
-		if (is_inside_triangle(Ax, Ay, Bx, By, Cx, Cy, Px, Py, relaxed)) return false;
+		if (is_inside_triangle(Ax, Ay, Bx, By, Cx, Cy, Px, Py, relaxed))
+			return false;
 	}
 
 	return true;
@@ -119,7 +122,8 @@ bool Triangulate::triangulate(const Vector<Vector2> &contour, Vector<int> &resul
 	/* allocate and initialize list of Vertices in polygon */
 
 	int n = contour.size();
-	if (n < 3) return false;
+	if (n < 3)
+		return false;
 
 	Vector<int> V;
 	V.resize(n);
@@ -161,11 +165,14 @@ bool Triangulate::triangulate(const Vector<Vector2> &contour, Vector<int> &resul
 
 		/* three consecutive vertices in current polygon, <u,v,w> */
 		int u = v;
-		if (nv <= u) u = 0; /* previous */
+		if (nv <= u)
+			u = 0; /* previous */
 		v = u + 1;
-		if (nv <= v) v = 0; /* new v    */
+		if (nv <= v)
+			v = 0; /* new v    */
 		int w = v + 1;
-		if (nv <= w) w = 0; /* next     */
+		if (nv <= w)
+			w = 0; /* next     */
 
 		if (snip(contour, u, v, w, nv, V, relaxed)) {
 			int a, b, c, s, t;

--- a/core/method_bind.h
+++ b/core/method_bind.h
@@ -169,7 +169,8 @@ struct VariantObjectClassChecker<Control *> {
 #define CHECK_NOARG(m_arg)                             \
 	{                                                  \
 		if (p_arg##m_arg.get_type() != Variant::NIL) { \
-			if (r_argerror) *r_argerror = (m_arg - 1); \
+			if (r_argerror)                            \
+				*r_argerror = (m_arg - 1);             \
 			return CALL_ERROR_EXTRA_ARGUMENT;          \
 		}                                              \
 	}

--- a/core/node_path.cpp
+++ b/core/node_path.cpp
@@ -373,7 +373,8 @@ NodePath::NodePath(const String &p_path) {
 
 				String str = path.substr(from, i - from);
 				if (str == "") {
-					if (path[i] == 0) continue; // Allow end-of-path :
+					if (path[i] == 0)
+						continue; // Allow end-of-path :
 
 					ERR_EXPLAIN("Invalid NodePath: " + p_path);
 					ERR_FAIL();

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -561,7 +561,8 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 	}
 
 	bool valid = false;
-	if (!r_valid) r_valid = &valid;
+	if (!r_valid)
+		r_valid = &valid;
 
 	List<Variant> value_stack;
 

--- a/core/object.h
+++ b/core/object.h
@@ -332,7 +332,8 @@ protected:                                                                      
 		return (bool (Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                 \
 	}                                                                                                                                   \
 	virtual bool _setv(const StringName &p_name, const Variant &p_property) {                                                           \
-		if (m_inherits::_setv(p_name, p_property)) return true;                                                                         \
+		if (m_inherits::_setv(p_name, p_property))                                                                                      \
+			return true;                                                                                                                \
 		if (m_class::_get_set() != m_inherits::_get_set()) {                                                                            \
 			return _set(p_name, p_property);                                                                                            \
 		}                                                                                                                               \

--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -39,9 +39,12 @@ String DirAccess::_get_root_path() const {
 
 	switch (_access_type) {
 
-		case ACCESS_RESOURCES: return ProjectSettings::get_singleton()->get_resource_path();
-		case ACCESS_USERDATA: return OS::get_singleton()->get_user_data_dir();
-		default: return "";
+		case ACCESS_RESOURCES:
+			return ProjectSettings::get_singleton()->get_resource_path();
+		case ACCESS_USERDATA:
+			return OS::get_singleton()->get_user_data_dir();
+		default:
+			return "";
 	}
 
 	return "";
@@ -50,9 +53,12 @@ String DirAccess::_get_root_string() const {
 
 	switch (_access_type) {
 
-		case ACCESS_RESOURCES: return "res://";
-		case ACCESS_USERDATA: return "user://";
-		default: return "";
+		case ACCESS_RESOURCES:
+			return "res://";
+		case ACCESS_USERDATA:
+			return "user://";
+		default:
+			return "";
 	}
 
 	return "";
@@ -227,7 +233,8 @@ String DirAccess::fix_path(String p_path) const {
 
 			return p_path;
 		} break;
-		case ACCESS_MAX: break; // Can't happen, but silences warning
+		case ACCESS_MAX:
+			break; // Can't happen, but silences warning
 	}
 
 	return p_path;

--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -137,7 +137,8 @@ struct DirAccessRef {
 	DirAccess *f;
 	DirAccessRef(DirAccess *fa) { f = fa; }
 	~DirAccessRef() {
-		if (f) memdelete(f);
+		if (f)
+			memdelete(f);
 	}
 };
 

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -165,7 +165,8 @@ String FileAccess::fix_path(const String &p_path) const {
 
 			return r_path;
 		} break;
-		case ACCESS_MAX: break; // Can't happen, but silences warning
+		case ACCESS_MAX:
+			break; // Can't happen, but silences warning
 	}
 
 	return r_path;

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -192,7 +192,8 @@ struct FileAccessRef {
 	operator FileAccess *() { return f; }
 	FileAccessRef(FileAccess *fa) { f = fa; }
 	~FileAccessRef() {
-		if (f) memdelete(f);
+		if (f)
+			memdelete(f);
 	}
 };
 

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -133,9 +133,10 @@ void memdelete_allocator(T *p_class) {
 	A::free(p_class);
 }
 
-#define memdelete_notnull(m_v)   \
-	{                            \
-		if (m_v) memdelete(m_v); \
+#define memdelete_notnull(m_v) \
+	{                          \
+		if (m_v)               \
+			memdelete(m_v);    \
 	}
 
 #define memnew_arr(m_class, m_count) memnew_arr_template<m_class>(m_count)

--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -63,10 +63,12 @@ class MutexLock {
 public:
 	MutexLock(Mutex *p_mutex) {
 		mutex = p_mutex;
-		if (mutex) mutex->lock();
+		if (mutex)
+			mutex->lock();
 	}
 	~MutexLock() {
-		if (mutex) mutex->unlock();
+		if (mutex)
+			mutex->unlock();
 	}
 };
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -369,7 +369,8 @@ Error OS::dialog_show(String p_title, String p_description, Vector<String> p_but
 
 		print("%ls\n--------\n%ls\n", p_title.c_str(), p_description.c_str());
 		for (int i = 0; i < p_buttons.size(); i++) {
-			if (i > 0) print(", ");
+			if (i > 0)
+				print(", ");
 			print("%i=%ls", i + 1, p_buttons[i].c_str());
 		};
 		print("\n");
@@ -655,7 +656,8 @@ bool OS::has_feature(const String &p_feature) {
 
 void OS::center_window() {
 
-	if (is_window_fullscreen()) return;
+	if (is_window_fullscreen())
+		return;
 
 	Point2 sp = get_screen_position(get_current_screen());
 	Size2 scr = get_screen_size(get_current_screen());

--- a/core/os/rw_lock.h
+++ b/core/os/rw_lock.h
@@ -58,10 +58,12 @@ class RWLockRead {
 public:
 	RWLockRead(const RWLock *p_lock) {
 		lock = const_cast<RWLock *>(p_lock);
-		if (lock) lock->read_lock();
+		if (lock)
+			lock->read_lock();
 	}
 	~RWLockRead() {
-		if (lock) lock->read_unlock();
+		if (lock)
+			lock->read_unlock();
 	}
 };
 
@@ -72,10 +74,12 @@ class RWLockWrite {
 public:
 	RWLockWrite(RWLock *p_lock) {
 		lock = p_lock;
-		if (lock) lock->write_lock();
+		if (lock)
+			lock->write_lock();
 	}
 	~RWLockWrite() {
-		if (lock) lock->write_unlock();
+		if (lock)
+			lock->write_unlock();
 	}
 };
 

--- a/core/os/thread_safe.h
+++ b/core/os/thread_safe.h
@@ -39,10 +39,12 @@ class ThreadSafe {
 
 public:
 	inline void lock() const {
-		if (mutex) mutex->lock();
+		if (mutex)
+			mutex->lock();
 	}
 	inline void unlock() const {
-		if (mutex) mutex->unlock();
+		if (mutex)
+			mutex->unlock();
 	}
 
 	ThreadSafe();

--- a/core/pool_allocator.cpp
+++ b/core/pool_allocator.cpp
@@ -182,7 +182,8 @@ PoolAllocator::ID PoolAllocator::alloc(int p_size) {
 
 	ERR_FAIL_COND_V(p_size < 1, POOL_ALLOCATOR_INVALID_ID);
 #ifdef DEBUG_ENABLED
-	if (p_size > free_mem) OS::get_singleton()->debug_break();
+	if (p_size > free_mem)
+		OS::get_singleton()->debug_break();
 #endif
 	ERR_FAIL_COND_V(p_size > free_mem, POOL_ALLOCATOR_INVALID_ID);
 

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -978,7 +978,8 @@ String TranslationServer::get_locale() const {
 
 String TranslationServer::get_locale_name(const String &p_locale) const {
 
-	if (!locale_name_map.has(p_locale)) return String();
+	if (!locale_name_map.has(p_locale))
+		return String();
 	return locale_name_map[p_locale];
 }
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1856,7 +1856,8 @@ bool String::is_numeric() const {
 	};
 
 	int s = 0;
-	if (operator[](0) == '-') ++s;
+	if (operator[](0) == '-')
+		++s;
 	bool dot = false;
 	for (int i = s; i < length(); i++) {
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -4054,9 +4054,14 @@ String String::sprintf(const Array &values, bool *error) const {
 					int base = 16;
 					bool capitalize = false;
 					switch (c) {
-						case 'd': base = 10; break;
-						case 'o': base = 8; break;
-						case 'x': break;
+						case 'd':
+							base = 10;
+							break;
+						case 'o':
+							base = 8;
+							break;
+						case 'x':
+							break;
 						case 'X':
 							base = 16;
 							capitalize = true;

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1052,17 +1052,38 @@ void Variant::reference(const Variant &p_variant) {
 
 void Variant::zero() {
 	switch (type) {
-		case NIL: break;
-		case BOOL: this->_data._bool = false; break;
-		case INT: this->_data._int = 0; break;
-		case REAL: this->_data._real = 0; break;
-		case VECTOR2: *reinterpret_cast<Vector2 *>(this->_data._mem) = Vector2(); break;
-		case RECT2: *reinterpret_cast<Rect2 *>(this->_data._mem) = Rect2(); break;
-		case VECTOR3: *reinterpret_cast<Vector3 *>(this->_data._mem) = Vector3(); break;
-		case PLANE: *reinterpret_cast<Plane *>(this->_data._mem) = Plane(); break;
-		case QUAT: *reinterpret_cast<Quat *>(this->_data._mem) = Quat(); break;
-		case COLOR: *reinterpret_cast<Color *>(this->_data._mem) = Color(); break;
-		default: this->clear(); break;
+		case NIL:
+			break;
+		case BOOL:
+			this->_data._bool = false;
+			break;
+		case INT:
+			this->_data._int = 0;
+			break;
+		case REAL:
+			this->_data._real = 0;
+			break;
+		case VECTOR2:
+			*reinterpret_cast<Vector2 *>(this->_data._mem) = Vector2();
+			break;
+		case RECT2:
+			*reinterpret_cast<Rect2 *>(this->_data._mem) = Rect2();
+			break;
+		case VECTOR3:
+			*reinterpret_cast<Vector3 *>(this->_data._mem) = Vector3();
+			break;
+		case PLANE:
+			*reinterpret_cast<Plane *>(this->_data._mem) = Plane();
+			break;
+		case QUAT:
+			*reinterpret_cast<Quat *>(this->_data._mem) = Quat();
+			break;
+		case COLOR:
+			*reinterpret_cast<Color *>(this->_data._mem) = Color();
+			break;
+		default:
+			this->clear();
+			break;
 	}
 }
 
@@ -1161,11 +1182,16 @@ Variant::operator signed int() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int();
 		default: {
 
 			return 0;
@@ -1178,11 +1204,16 @@ Variant::operator unsigned int() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int();
 		default: {
 
 			return 0;
@@ -1196,11 +1227,16 @@ Variant::operator int64_t() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int64();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int64();
 		default: {
 
 			return 0;
@@ -1234,11 +1270,16 @@ Variant::operator uint64_t() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int();
 		default: {
 
 			return 0;
@@ -1253,11 +1294,16 @@ Variant::operator signed long() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int();
 		default: {
 
 			return 0;
@@ -1271,11 +1317,16 @@ Variant::operator unsigned long() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int();
 		default: {
 
 			return 0;
@@ -1290,11 +1341,16 @@ Variant::operator signed short() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int();
 		default: {
 
 			return 0;
@@ -1307,11 +1363,16 @@ Variant::operator unsigned short() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int();
 		default: {
 
 			return 0;
@@ -1324,11 +1385,16 @@ Variant::operator signed char() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int();
 		default: {
 
 			return 0;
@@ -1341,11 +1407,16 @@ Variant::operator unsigned char() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_int();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1 : 0;
+		case INT:
+			return _data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_int();
 		default: {
 
 			return 0;
@@ -1364,11 +1435,16 @@ Variant::operator float() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1.0 : 0.0;
-		case INT: return (float)_data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_double();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1.0 : 0.0;
+		case INT:
+			return (float)_data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_double();
 		default: {
 
 			return 0;
@@ -1381,11 +1457,16 @@ Variant::operator double() const {
 
 	switch (type) {
 
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1.0 : 0.0;
-		case INT: return (double)_data._int;
-		case REAL: return _data._real;
-		case STRING: return operator String().to_double();
+		case NIL:
+			return 0;
+		case BOOL:
+			return _data._bool ? 1.0 : 0.0;
+		case INT:
+			return (double)_data._int;
+		case REAL:
+			return _data._real;
+		case STRING:
+			return operator String().to_double();
 		default: {
 
 			return 0;
@@ -1423,24 +1504,34 @@ Variant::operator String() const {
 String Variant::stringify(List<const void *> &stack) const {
 	switch (type) {
 
-		case NIL: return "Null";
-		case BOOL: return _data._bool ? "True" : "False";
-		case INT: return itos(_data._int);
-		case REAL: return rtos(_data._real);
-		case STRING: return *reinterpret_cast<const String *>(_data._mem);
-		case VECTOR2: return "(" + operator Vector2() + ")";
-		case RECT2: return "(" + operator Rect2() + ")";
+		case NIL:
+			return "Null";
+		case BOOL:
+			return _data._bool ? "True" : "False";
+		case INT:
+			return itos(_data._int);
+		case REAL:
+			return rtos(_data._real);
+		case STRING:
+			return *reinterpret_cast<const String *>(_data._mem);
+		case VECTOR2:
+			return "(" + operator Vector2() + ")";
+		case RECT2:
+			return "(" + operator Rect2() + ")";
 		case TRANSFORM2D: {
 
 			Transform2D mat32 = operator Transform2D();
 			return "(" + Variant(mat32.elements[0]).operator String() + ", " + Variant(mat32.elements[1]).operator String() + ", " + Variant(mat32.elements[2]).operator String() + ")";
 		} break;
-		case VECTOR3: return "(" + operator Vector3() + ")";
+		case VECTOR3:
+			return "(" + operator Vector3() + ")";
 		case PLANE:
 			return operator Plane();
 		//case QUAT:
-		case AABB: return operator ::AABB();
-		case QUAT: return "(" + operator Quat() + ")";
+		case AABB:
+			return operator ::AABB();
+		case QUAT:
+			return "(" + operator Quat() + ")";
 		case BASIS: {
 
 			Basis mat3 = operator Basis();
@@ -1466,9 +1557,12 @@ String Variant::stringify(List<const void *> &stack) const {
 
 			return mtx + ")";
 		} break;
-		case TRANSFORM: return operator Transform();
-		case NODE_PATH: return operator NodePath();
-		case COLOR: return String::num(operator Color().r) + "," + String::num(operator Color().g) + "," + String::num(operator Color().b) + "," + String::num(operator Color().a);
+		case TRANSFORM:
+			return operator Transform();
+		case NODE_PATH:
+			return operator NodePath();
+		case COLOR:
+			return String::num(operator Color().r) + "," + String::num(operator Color().g) + "," + String::num(operator Color().b) + "," + String::num(operator Color().a);
 		case DICTIONARY: {
 
 			const Dictionary &d = *reinterpret_cast<const Dictionary *>(_data._mem);
@@ -3195,9 +3289,12 @@ bool Variant::is_shared() const {
 
 	switch (type) {
 
-		case OBJECT: return true;
-		case ARRAY: return true;
-		case DICTIONARY: return true;
+		case OBJECT:
+			return true;
+		case ARRAY:
+			return true;
+		case DICTIONARY:
+			return true;
 		default: {
 		}
 	}

--- a/core/variant.h
+++ b/core/variant.h
@@ -419,7 +419,8 @@ public:
 	Variant(const Variant &p_variant);
 	_FORCE_INLINE_ Variant() { type = NIL; }
 	_FORCE_INLINE_ ~Variant() {
-		if (type != Variant::NIL) clear();
+		if (type != Variant::NIL)
+			clear();
 	}
 };
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -744,9 +744,14 @@ struct _VariantCall {
 
 		switch (p_args[0]->type) {
 
-			case Variant::VECTOR2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform(p_args[0]->operator Vector2()); return;
-			case Variant::RECT2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform(p_args[0]->operator Rect2()); return;
-			default: r_ret = Variant();
+			case Variant::VECTOR2:
+				r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform(p_args[0]->operator Vector2());
+				return;
+			case Variant::RECT2:
+				r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform(p_args[0]->operator Rect2());
+				return;
+			default:
+				r_ret = Variant();
 		}
 	}
 
@@ -754,9 +759,14 @@ struct _VariantCall {
 
 		switch (p_args[0]->type) {
 
-			case Variant::VECTOR2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Vector2()); return;
-			case Variant::RECT2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Rect2()); return;
-			default: r_ret = Variant();
+			case Variant::VECTOR2:
+				r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Vector2());
+				return;
+			case Variant::RECT2:
+				r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Rect2());
+				return;
+			default:
+				r_ret = Variant();
 		}
 	}
 
@@ -764,8 +774,11 @@ struct _VariantCall {
 
 		switch (p_args[0]->type) {
 
-			case Variant::VECTOR2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->basis_xform(p_args[0]->operator Vector2()); return;
-			default: r_ret = Variant();
+			case Variant::VECTOR2:
+				r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->basis_xform(p_args[0]->operator Vector2());
+				return;
+			default:
+				r_ret = Variant();
 		}
 	}
 
@@ -773,8 +786,11 @@ struct _VariantCall {
 
 		switch (p_args[0]->type) {
 
-			case Variant::VECTOR2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->basis_xform_inv(p_args[0]->operator Vector2()); return;
-			default: r_ret = Variant();
+			case Variant::VECTOR2:
+				r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->basis_xform_inv(p_args[0]->operator Vector2());
+				return;
+			default:
+				r_ret = Variant();
 		}
 	}
 
@@ -809,10 +825,17 @@ struct _VariantCall {
 
 		switch (p_args[0]->type) {
 
-			case Variant::VECTOR3: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator Vector3()); return;
-			case Variant::PLANE: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator Plane()); return;
-			case Variant::AABB: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator ::AABB()); return;
-			default: r_ret = Variant();
+			case Variant::VECTOR3:
+				r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator Vector3());
+				return;
+			case Variant::PLANE:
+				r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator Plane());
+				return;
+			case Variant::AABB:
+				r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator ::AABB());
+				return;
+			default:
+				r_ret = Variant();
 		}
 	}
 
@@ -820,10 +843,17 @@ struct _VariantCall {
 
 		switch (p_args[0]->type) {
 
-			case Variant::VECTOR3: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Vector3()); return;
-			case Variant::PLANE: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Plane()); return;
-			case Variant::AABB: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator ::AABB()); return;
-			default: r_ret = Variant();
+			case Variant::VECTOR3:
+				r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Vector3());
+				return;
+			case Variant::PLANE:
+				r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Plane());
+				return;
+			case Variant::AABB:
+				r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator ::AABB());
+				return;
+			default:
+				r_ret = Variant();
 		}
 	}
 
@@ -1106,44 +1136,64 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 				return Variant();
 
 			// atomic types
-			case BOOL: return Variant(false);
-			case INT: return 0;
-			case REAL: return 0.0f;
+			case BOOL:
+				return Variant(false);
+			case INT:
+				return 0;
+			case REAL:
+				return 0.0f;
 			case STRING:
 				return String();
 
 			// math types
 			case VECTOR2:
 				return Vector2(); // 5
-			case RECT2: return Rect2();
-			case VECTOR3: return Vector3();
-			case TRANSFORM2D: return Transform2D();
-			case PLANE: return Plane();
-			case QUAT: return Quat();
+			case RECT2:
+				return Rect2();
+			case VECTOR3:
+				return Vector3();
+			case TRANSFORM2D:
+				return Transform2D();
+			case PLANE:
+				return Plane();
+			case QUAT:
+				return Quat();
 			case AABB:
 				return ::AABB(); // 10
-			case BASIS: return Basis();
+			case BASIS:
+				return Basis();
 			case TRANSFORM:
 				return Transform();
 
 			// misc types
-			case COLOR: return Color();
+			case COLOR:
+				return Color();
 			case NODE_PATH:
 				return NodePath(); // 15
-			case _RID: return RID();
-			case OBJECT: return (Object *)NULL;
-			case DICTIONARY: return Dictionary();
+			case _RID:
+				return RID();
+			case OBJECT:
+				return (Object *)NULL;
+			case DICTIONARY:
+				return Dictionary();
 			case ARRAY:
 				return Array(); // 20
-			case POOL_BYTE_ARRAY: return PoolByteArray();
-			case POOL_INT_ARRAY: return PoolIntArray();
-			case POOL_REAL_ARRAY: return PoolRealArray();
-			case POOL_STRING_ARRAY: return PoolStringArray();
+			case POOL_BYTE_ARRAY:
+				return PoolByteArray();
+			case POOL_INT_ARRAY:
+				return PoolIntArray();
+			case POOL_REAL_ARRAY:
+				return PoolRealArray();
+			case POOL_STRING_ARRAY:
+				return PoolStringArray();
 			case POOL_VECTOR2_ARRAY:
 				return PoolVector2Array(); // 25
-			case POOL_VECTOR3_ARRAY: return PoolVector3Array();
-			case POOL_COLOR_ARRAY: return PoolColorArray();
-			default: return Variant();
+			case POOL_VECTOR3_ARRAY:
+				return PoolVector3Array();
+			case POOL_COLOR_ARRAY:
+				return PoolColorArray();
+			default:
+				return Variant();
 		}
 
 	} else if (p_argcount > 1) {
@@ -1196,36 +1246,52 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 			case VECTOR2: {
 				return Vector2(*p_args[0]);
 			}
-			case RECT2: return (Rect2(*p_args[0]));
-			case VECTOR3: return (Vector3(*p_args[0]));
-			case PLANE: return (Plane(*p_args[0]));
-			case QUAT: return (p_args[0]->operator Quat());
+			case RECT2:
+				return (Rect2(*p_args[0]));
+			case VECTOR3:
+				return (Vector3(*p_args[0]));
+			case PLANE:
+				return (Plane(*p_args[0]));
+			case QUAT:
+				return (p_args[0]->operator Quat());
 			case AABB:
 				return (::AABB(*p_args[0])); // 10
-			case BASIS: return (Basis(p_args[0]->operator Basis()));
+			case BASIS:
+				return (Basis(p_args[0]->operator Basis()));
 			case TRANSFORM:
 				return (Transform(p_args[0]->operator Transform()));
 
 			// misc types
-			case COLOR: return p_args[0]->type == Variant::STRING ? Color::html(*p_args[0]) : Color::hex(*p_args[0]);
+			case COLOR:
+				return p_args[0]->type == Variant::STRING ? Color::html(*p_args[0]) : Color::hex(*p_args[0]);
 			case NODE_PATH:
 				return (NodePath(p_args[0]->operator NodePath())); // 15
-			case _RID: return (RID(*p_args[0]));
-			case OBJECT: return ((Object *)(p_args[0]->operator Object *()));
-			case DICTIONARY: return p_args[0]->operator Dictionary();
+			case _RID:
+				return (RID(*p_args[0]));
+			case OBJECT:
+				return ((Object *)(p_args[0]->operator Object *()));
+			case DICTIONARY:
+				return p_args[0]->operator Dictionary();
 			case ARRAY:
 				return p_args[0]->operator Array(); // 20
 
 			// arrays
-			case POOL_BYTE_ARRAY: return (PoolByteArray(*p_args[0]));
-			case POOL_INT_ARRAY: return (PoolIntArray(*p_args[0]));
-			case POOL_REAL_ARRAY: return (PoolRealArray(*p_args[0]));
-			case POOL_STRING_ARRAY: return (PoolStringArray(*p_args[0]));
+			case POOL_BYTE_ARRAY:
+				return (PoolByteArray(*p_args[0]));
+			case POOL_INT_ARRAY:
+				return (PoolIntArray(*p_args[0]));
+			case POOL_REAL_ARRAY:
+				return (PoolRealArray(*p_args[0]));
+			case POOL_STRING_ARRAY:
+				return (PoolStringArray(*p_args[0]));
 			case POOL_VECTOR2_ARRAY:
 				return (PoolVector2Array(*p_args[0])); // 25
-			case POOL_VECTOR3_ARRAY: return (PoolVector3Array(*p_args[0]));
-			case POOL_COLOR_ARRAY: return (PoolColorArray(*p_args[0]));
-			default: return Variant();
+			case POOL_VECTOR3_ARRAY:
+				return (PoolVector3Array(*p_args[0]));
+			case POOL_COLOR_ARRAY:
+				return (PoolColorArray(*p_args[0]));
+			default:
+				return Variant();
 		}
 	}
 	r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD; //no such constructor

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -165,21 +165,26 @@ bool Variant::booleanize() const {
 		return;          \
 	}
 
-#define DEFAULT_OP_NUM(m_prefix, m_op_name, m_name, m_op, m_type)             \
-	CASE_TYPE(m_prefix, m_op_name, m_name) {                                  \
-		if (p_b.type == INT) _RETURN(p_a._data.m_type m_op p_b._data._int);   \
-		if (p_b.type == REAL) _RETURN(p_a._data.m_type m_op p_b._data._real); \
-                                                                              \
-		_RETURN_FAIL                                                          \
+#define DEFAULT_OP_NUM(m_prefix, m_op_name, m_name, m_op, m_type) \
+	CASE_TYPE(m_prefix, m_op_name, m_name) {                      \
+		if (p_b.type == INT)                                      \
+			_RETURN(p_a._data.m_type m_op p_b._data._int);        \
+		if (p_b.type == REAL)                                     \
+			_RETURN(p_a._data.m_type m_op p_b._data._real);       \
+                                                                  \
+		_RETURN_FAIL                                              \
 	};
 
-#define DEFAULT_OP_NUM_NULL(m_prefix, m_op_name, m_name, m_op, m_type)        \
-	CASE_TYPE(m_prefix, m_op_name, m_name) {                                  \
-		if (p_b.type == INT) _RETURN(p_a._data.m_type m_op p_b._data._int);   \
-		if (p_b.type == REAL) _RETURN(p_a._data.m_type m_op p_b._data._real); \
-		if (p_b.type == NIL) _RETURN(!(p_b.type m_op NIL));                   \
-                                                                              \
-		_RETURN_FAIL                                                          \
+#define DEFAULT_OP_NUM_NULL(m_prefix, m_op_name, m_name, m_op, m_type) \
+	CASE_TYPE(m_prefix, m_op_name, m_name) {                           \
+		if (p_b.type == INT)                                           \
+			_RETURN(p_a._data.m_type m_op p_b._data._int);             \
+		if (p_b.type == REAL)                                          \
+			_RETURN(p_a._data.m_type m_op p_b._data._real);            \
+		if (p_b.type == NIL)                                           \
+			_RETURN(!(p_b.type m_op NIL));                             \
+                                                                       \
+		_RETURN_FAIL                                                   \
 	};
 
 #ifdef DEBUG_ENABLED
@@ -203,12 +208,14 @@ bool Variant::booleanize() const {
 		_RETURN_FAIL                                            \
 	};
 #else
-#define DEFAULT_OP_NUM_DIV(m_prefix, m_op_name, m_name, m_type)            \
-	CASE_TYPE(m_prefix, m_op_name, m_name) {                               \
-		if (p_b.type == INT) _RETURN(p_a._data.m_type / p_b._data._int);   \
-		if (p_b.type == REAL) _RETURN(p_a._data.m_type / p_b._data._real); \
-                                                                           \
-		_RETURN_FAIL                                                       \
+#define DEFAULT_OP_NUM_DIV(m_prefix, m_op_name, m_name, m_type) \
+	CASE_TYPE(m_prefix, m_op_name, m_name) {                    \
+		if (p_b.type == INT)                                    \
+			_RETURN(p_a._data.m_type / p_b._data._int);         \
+		if (p_b.type == REAL)                                   \
+			_RETURN(p_a._data.m_type / p_b._data._real);        \
+                                                                \
+		_RETURN_FAIL                                            \
 	};
 #endif
 
@@ -222,39 +229,50 @@ bool Variant::booleanize() const {
 		_RETURN(p_a._data.m_type);                              \
 	};
 
-#define DEFAULT_OP_NUM_VEC(m_prefix, m_op_name, m_name, m_op, m_type)                                               \
-	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                        \
-		if (p_b.type == INT) _RETURN(p_a._data.m_type m_op p_b._data._int);                                         \
-		if (p_b.type == REAL) _RETURN(p_a._data.m_type m_op p_b._data._real);                                       \
-		if (p_b.type == VECTOR2) _RETURN(p_a._data.m_type m_op *reinterpret_cast<const Vector2 *>(p_b._data._mem)); \
-		if (p_b.type == VECTOR3) _RETURN(p_a._data.m_type m_op *reinterpret_cast<const Vector3 *>(p_b._data._mem)); \
-                                                                                                                    \
-		_RETURN_FAIL                                                                                                \
+#define DEFAULT_OP_NUM_VEC(m_prefix, m_op_name, m_name, m_op, m_type)                          \
+	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                   \
+		if (p_b.type == INT)                                                                   \
+			_RETURN(p_a._data.m_type m_op p_b._data._int);                                     \
+		if (p_b.type == REAL)                                                                  \
+			_RETURN(p_a._data.m_type m_op p_b._data._real);                                    \
+		if (p_b.type == VECTOR2)                                                               \
+			_RETURN(p_a._data.m_type m_op *reinterpret_cast<const Vector2 *>(p_b._data._mem)); \
+		if (p_b.type == VECTOR3)                                                               \
+			_RETURN(p_a._data.m_type m_op *reinterpret_cast<const Vector3 *>(p_b._data._mem)); \
+                                                                                               \
+		_RETURN_FAIL                                                                           \
 	};
 
-#define DEFAULT_OP_STR_REV(m_prefix, m_op_name, m_name, m_op, m_type)                                                                                   \
-	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                                            \
-		if (p_b.type == STRING) _RETURN(*reinterpret_cast<const m_type *>(p_b._data._mem) m_op *reinterpret_cast<const String *>(p_a._data._mem));      \
-		if (p_b.type == NODE_PATH) _RETURN(*reinterpret_cast<const m_type *>(p_b._data._mem) m_op *reinterpret_cast<const NodePath *>(p_a._data._mem)); \
-                                                                                                                                                        \
-		_RETURN_FAIL                                                                                                                                    \
+#define DEFAULT_OP_STR_REV(m_prefix, m_op_name, m_name, m_op, m_type)                                                            \
+	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                     \
+		if (p_b.type == STRING)                                                                                                  \
+			_RETURN(*reinterpret_cast<const m_type *>(p_b._data._mem) m_op *reinterpret_cast<const String *>(p_a._data._mem));   \
+		if (p_b.type == NODE_PATH)                                                                                               \
+			_RETURN(*reinterpret_cast<const m_type *>(p_b._data._mem) m_op *reinterpret_cast<const NodePath *>(p_a._data._mem)); \
+                                                                                                                                 \
+		_RETURN_FAIL                                                                                                             \
 	};
 
-#define DEFAULT_OP_STR(m_prefix, m_op_name, m_name, m_op, m_type)                                                                                       \
-	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                                            \
-		if (p_b.type == STRING) _RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const String *>(p_b._data._mem));      \
-		if (p_b.type == NODE_PATH) _RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const NodePath *>(p_b._data._mem)); \
-                                                                                                                                                        \
-		_RETURN_FAIL                                                                                                                                    \
+#define DEFAULT_OP_STR(m_prefix, m_op_name, m_name, m_op, m_type)                                                                \
+	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                     \
+		if (p_b.type == STRING)                                                                                                  \
+			_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const String *>(p_b._data._mem));   \
+		if (p_b.type == NODE_PATH)                                                                                               \
+			_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const NodePath *>(p_b._data._mem)); \
+                                                                                                                                 \
+		_RETURN_FAIL                                                                                                             \
 	};
 
-#define DEFAULT_OP_STR_NULL(m_prefix, m_op_name, m_name, m_op, m_type)                                                                                  \
-	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                                            \
-		if (p_b.type == STRING) _RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const String *>(p_b._data._mem));      \
-		if (p_b.type == NODE_PATH) _RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const NodePath *>(p_b._data._mem)); \
-		if (p_b.type == NIL) _RETURN(!(p_b.type m_op NIL));                                                                                             \
-                                                                                                                                                        \
-		_RETURN_FAIL                                                                                                                                    \
+#define DEFAULT_OP_STR_NULL(m_prefix, m_op_name, m_name, m_op, m_type)                                                           \
+	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                     \
+		if (p_b.type == STRING)                                                                                                  \
+			_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const String *>(p_b._data._mem));   \
+		if (p_b.type == NODE_PATH)                                                                                               \
+			_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const NodePath *>(p_b._data._mem)); \
+		if (p_b.type == NIL)                                                                                                     \
+			_RETURN(!(p_b.type m_op NIL));                                                                                       \
+                                                                                                                                 \
+		_RETURN_FAIL                                                                                                             \
 	};
 
 #define DEFAULT_OP_LOCALMEM_REV(m_prefix, m_op_name, m_name, m_op, m_type)                                                     \
@@ -293,13 +311,16 @@ bool Variant::booleanize() const {
 		_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem));  \
 	}
 
-#define DEFAULT_OP_LOCALMEM_NUM(m_prefix, m_op_name, m_name, m_op, m_type)                                                                         \
-	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                                       \
-		if (p_b.type == m_name) _RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const m_type *>(p_b._data._mem)); \
-		if (p_b.type == INT) _RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op p_b._data._int);                                       \
-		if (p_b.type == REAL) _RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op p_b._data._real);                                     \
-                                                                                                                                                   \
-		_RETURN_FAIL                                                                                                                               \
+#define DEFAULT_OP_LOCALMEM_NUM(m_prefix, m_op_name, m_name, m_op, m_type)                                                     \
+	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                   \
+		if (p_b.type == m_name)                                                                                                \
+			_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const m_type *>(p_b._data._mem)); \
+		if (p_b.type == INT)                                                                                                   \
+			_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op p_b._data._int);                                    \
+		if (p_b.type == REAL)                                                                                                  \
+			_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op p_b._data._real);                                   \
+                                                                                                                               \
+		_RETURN_FAIL                                                                                                           \
 	}
 
 #define DEFAULT_OP_PTR(m_op, m_name, m_sub)                \
@@ -397,7 +418,8 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 	SWITCH(math, p_op, p_a.type) {
 		SWITCH_OP(math, OP_EQUAL, p_a.type) {
 			CASE_TYPE(math, OP_EQUAL, NIL) {
-				if (p_b.type == NIL) _RETURN(true);
+				if (p_b.type == NIL)
+					_RETURN(true);
 				if (p_b.type == OBJECT)
 					_RETURN(p_b._get_obj().obj == NULL);
 
@@ -484,7 +506,8 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 
 		SWITCH_OP(math, OP_NOT_EQUAL, p_a.type) {
 			CASE_TYPE(math, OP_NOT_EQUAL, NIL) {
-				if (p_b.type == NIL) _RETURN(false);
+				if (p_b.type == NIL)
+					_RETURN(false);
 				if (p_b.type == OBJECT)
 					_RETURN(p_b._get_obj().obj != NULL);
 

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -870,7 +870,8 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 					case VECTOR2: {
 						_RETURN(p_a._data._transform2d->xform(*(const Vector2 *)p_b._data._mem));
 					}
-					default: _RETURN_FAIL;
+					default:
+						_RETURN_FAIL;
 				}
 			}
 
@@ -885,7 +886,8 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 					case REAL: {
 						_RETURN(*reinterpret_cast<const Quat *>(p_a._data._mem) * p_b._data._real);
 					}
-					default: _RETURN_FAIL;
+					default:
+						_RETURN_FAIL;
 				}
 			}
 
@@ -897,7 +899,8 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 					case BASIS: {
 						_RETURN(*p_a._data._basis * *p_b._data._basis);
 					}
-					default: _RETURN_FAIL;
+					default:
+						_RETURN_FAIL;
 				}
 			}
 
@@ -909,7 +912,8 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 					case TRANSFORM: {
 						_RETURN(*p_a._data._transform * *p_b._data._transform);
 					}
-					default: _RETURN_FAIL;
+					default:
+						_RETURN_FAIL;
 				}
 			}
 

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -223,11 +223,21 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 
 						switch (next) {
 
-							case 'b': res = 8; break;
-							case 't': res = 9; break;
-							case 'n': res = 10; break;
-							case 'f': res = 12; break;
-							case 'r': res = 13; break;
+							case 'b':
+								res = 8;
+								break;
+							case 't':
+								res = 9;
+								break;
+							case 'n':
+								res = 10;
+								break;
+							case 'f':
+								res = 12;
+								break;
+							case 'r':
+								res = 13;
+								break;
 							case 'u': {
 								//hexnumbarh - oct is deprecated
 

--- a/core/vector.h
+++ b/core/vector.h
@@ -68,7 +68,8 @@ public:
 	void remove(int p_index) { _cowdata.remove(p_index); }
 	void erase(const T &p_val) {
 		int idx = find(p_val);
-		if (idx >= 0) remove(idx);
+		if (idx >= 0)
+			remove(idx);
 	};
 	void invert();
 

--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -55,10 +55,14 @@ static String _typestr(SL::DataType p_type) {
 static String _prestr(SL::DataPrecision p_pres) {
 
 	switch (p_pres) {
-		case SL::PRECISION_LOWP: return "lowp ";
-		case SL::PRECISION_MEDIUMP: return "mediump ";
-		case SL::PRECISION_HIGHP: return "highp ";
-		case SL::PRECISION_DEFAULT: return "";
+		case SL::PRECISION_LOWP:
+			return "lowp ";
+		case SL::PRECISION_MEDIUMP:
+			return "mediump ";
+		case SL::PRECISION_HIGHP:
+			return "highp ";
+		case SL::PRECISION_DEFAULT:
+			return "";
 	}
 	return "";
 }
@@ -66,9 +70,12 @@ static String _prestr(SL::DataPrecision p_pres) {
 static String _qualstr(SL::ArgumentQualifier p_qual) {
 
 	switch (p_qual) {
-		case SL::ARGUMENT_QUALIFIER_IN: return "in ";
-		case SL::ARGUMENT_QUALIFIER_OUT: return "out ";
-		case SL::ARGUMENT_QUALIFIER_INOUT: return "inout ";
+		case SL::ARGUMENT_QUALIFIER_IN:
+			return "in ";
+		case SL::ARGUMENT_QUALIFIER_OUT:
+			return "out ";
+		case SL::ARGUMENT_QUALIFIER_INOUT:
+			return "inout ";
 	}
 	return "";
 }
@@ -96,7 +103,8 @@ static String f2sp0(float p_float) {
 static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNode::Value> &p_values) {
 
 	switch (p_type) {
-		case SL::TYPE_BOOL: return p_values[0].boolean ? "true" : "false";
+		case SL::TYPE_BOOL:
+			return p_values[0].boolean ? "true" : "false";
 		case SL::TYPE_BVEC2:
 		case SL::TYPE_BVEC3:
 		case SL::TYPE_BVEC4: {
@@ -118,7 +126,8 @@ static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNo
 		}
 
 		// GLSL ES 2 doesn't support uints, so we just use signed ints instead...
-		case SL::TYPE_UINT: return itos(p_values[0].uint);
+		case SL::TYPE_UINT:
+			return itos(p_values[0].uint);
 		case SL::TYPE_UVEC2:
 		case SL::TYPE_UVEC3:
 		case SL::TYPE_UVEC4: {
@@ -140,7 +149,8 @@ static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNo
 
 		} break;
 
-		case SL::TYPE_INT: return itos(p_values[0].sint);
+		case SL::TYPE_INT:
+			return itos(p_values[0].sint);
 		case SL::TYPE_IVEC2:
 		case SL::TYPE_IVEC3:
 		case SL::TYPE_IVEC4: {
@@ -161,7 +171,8 @@ static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNo
 			return text.as_string();
 
 		} break;
-		case SL::TYPE_FLOAT: return f2sp0(p_values[0].real);
+		case SL::TYPE_FLOAT:
+			return f2sp0(p_values[0].real);
 		case SL::TYPE_VEC2:
 		case SL::TYPE_VEC3:
 		case SL::TYPE_VEC4: {
@@ -202,7 +213,8 @@ static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNo
 			return text.as_string();
 
 		} break;
-		default: ERR_FAIL_V(String());
+		default:
+			ERR_FAIL_V(String());
 	}
 }
 

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1125,7 +1125,8 @@ float SchlickFresnel(float u) {
 }
 
 float GTR1(float NdotH, float a) {
-	if (a >= 1.0) return 1.0 / M_PI;
+	if (a >= 1.0)
+		return 1.0 / M_PI;
 	float a2 = a * a;
 	float t = 1.0 + (a2 - 1.0) * NdotH * NdotH;
 	return (a2 - 1.0) / (M_PI * log(a2) * t);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -440,7 +440,9 @@ int RasterizerSceneGLES3::get_directional_light_shadow_size(RID p_light_intance)
 		case VS::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL:
 			break; //none
 		case VS::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_2_SPLITS:
-		case VS::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_4_SPLITS: shadow_size /= 2; break;
+		case VS::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_4_SPLITS:
+			shadow_size /= 2;
+			break;
 	}
 
 	return shadow_size;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2221,8 +2221,12 @@ void RasterizerStorageGLES3::shader_get_param_list(RID p_shader, List<PropertyIn
 		ShaderLanguage::ShaderNode::Uniform &u = shader->uniforms[E->get()];
 		pi.name = E->get();
 		switch (u.type) {
-			case ShaderLanguage::TYPE_VOID: pi.type = Variant::NIL; break;
-			case ShaderLanguage::TYPE_BOOL: pi.type = Variant::BOOL; break;
+			case ShaderLanguage::TYPE_VOID:
+				pi.type = Variant::NIL;
+				break;
+			case ShaderLanguage::TYPE_BOOL:
+				pi.type = Variant::BOOL;
+				break;
 			case ShaderLanguage::TYPE_BVEC2:
 				pi.type = Variant::INT;
 				pi.hint = PROPERTY_HINT_FLAGS;
@@ -2264,8 +2268,12 @@ void RasterizerStorageGLES3::shader_get_param_list(RID p_shader, List<PropertyIn
 				}
 
 			} break;
-			case ShaderLanguage::TYPE_VEC2: pi.type = Variant::VECTOR2; break;
-			case ShaderLanguage::TYPE_VEC3: pi.type = Variant::VECTOR3; break;
+			case ShaderLanguage::TYPE_VEC2:
+				pi.type = Variant::VECTOR2;
+				break;
+			case ShaderLanguage::TYPE_VEC3:
+				pi.type = Variant::VECTOR3;
+				break;
 			case ShaderLanguage::TYPE_VEC4: {
 				if (u.hint == ShaderLanguage::ShaderNode::Uniform::HINT_COLOR) {
 					pi.type = Variant::COLOR;
@@ -2273,9 +2281,15 @@ void RasterizerStorageGLES3::shader_get_param_list(RID p_shader, List<PropertyIn
 					pi.type = Variant::PLANE;
 				}
 			} break;
-			case ShaderLanguage::TYPE_MAT2: pi.type = Variant::TRANSFORM2D; break;
-			case ShaderLanguage::TYPE_MAT3: pi.type = Variant::BASIS; break;
-			case ShaderLanguage::TYPE_MAT4: pi.type = Variant::TRANSFORM; break;
+			case ShaderLanguage::TYPE_MAT2:
+				pi.type = Variant::TRANSFORM2D;
+				break;
+			case ShaderLanguage::TYPE_MAT3:
+				pi.type = Variant::BASIS;
+				break;
+			case ShaderLanguage::TYPE_MAT4:
+				pi.type = Variant::TRANSFORM;
+				break;
 			case ShaderLanguage::TYPE_SAMPLER2D:
 			case ShaderLanguage::TYPE_ISAMPLER2D:
 			case ShaderLanguage::TYPE_USAMPLER2D: {

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -54,38 +54,66 @@ static int _get_datatype_size(SL::DataType p_type) {
 
 	switch (p_type) {
 
-		case SL::TYPE_VOID: return 0;
-		case SL::TYPE_BOOL: return 4;
-		case SL::TYPE_BVEC2: return 8;
-		case SL::TYPE_BVEC3: return 12;
-		case SL::TYPE_BVEC4: return 16;
-		case SL::TYPE_INT: return 4;
-		case SL::TYPE_IVEC2: return 8;
-		case SL::TYPE_IVEC3: return 12;
-		case SL::TYPE_IVEC4: return 16;
-		case SL::TYPE_UINT: return 4;
-		case SL::TYPE_UVEC2: return 8;
-		case SL::TYPE_UVEC3: return 12;
-		case SL::TYPE_UVEC4: return 16;
-		case SL::TYPE_FLOAT: return 4;
-		case SL::TYPE_VEC2: return 8;
-		case SL::TYPE_VEC3: return 12;
-		case SL::TYPE_VEC4: return 16;
+		case SL::TYPE_VOID:
+			return 0;
+		case SL::TYPE_BOOL:
+			return 4;
+		case SL::TYPE_BVEC2:
+			return 8;
+		case SL::TYPE_BVEC3:
+			return 12;
+		case SL::TYPE_BVEC4:
+			return 16;
+		case SL::TYPE_INT:
+			return 4;
+		case SL::TYPE_IVEC2:
+			return 8;
+		case SL::TYPE_IVEC3:
+			return 12;
+		case SL::TYPE_IVEC4:
+			return 16;
+		case SL::TYPE_UINT:
+			return 4;
+		case SL::TYPE_UVEC2:
+			return 8;
+		case SL::TYPE_UVEC3:
+			return 12;
+		case SL::TYPE_UVEC4:
+			return 16;
+		case SL::TYPE_FLOAT:
+			return 4;
+		case SL::TYPE_VEC2:
+			return 8;
+		case SL::TYPE_VEC3:
+			return 12;
+		case SL::TYPE_VEC4:
+			return 16;
 		case SL::TYPE_MAT2:
 			return 32; //4 * 4 + 4 * 4
 		case SL::TYPE_MAT3:
 			return 48; // 4 * 4 + 4 * 4 + 4 * 4
-		case SL::TYPE_MAT4: return 64;
-		case SL::TYPE_SAMPLER2D: return 16;
-		case SL::TYPE_ISAMPLER2D: return 16;
-		case SL::TYPE_USAMPLER2D: return 16;
-		case SL::TYPE_SAMPLER2DARRAY: return 16;
-		case SL::TYPE_ISAMPLER2DARRAY: return 16;
-		case SL::TYPE_USAMPLER2DARRAY: return 16;
-		case SL::TYPE_SAMPLER3D: return 16;
-		case SL::TYPE_ISAMPLER3D: return 16;
-		case SL::TYPE_USAMPLER3D: return 16;
-		case SL::TYPE_SAMPLERCUBE: return 16;
+		case SL::TYPE_MAT4:
+			return 64;
+		case SL::TYPE_SAMPLER2D:
+			return 16;
+		case SL::TYPE_ISAMPLER2D:
+			return 16;
+		case SL::TYPE_USAMPLER2D:
+			return 16;
+		case SL::TYPE_SAMPLER2DARRAY:
+			return 16;
+		case SL::TYPE_ISAMPLER2DARRAY:
+			return 16;
+		case SL::TYPE_USAMPLER2DARRAY:
+			return 16;
+		case SL::TYPE_SAMPLER3D:
+			return 16;
+		case SL::TYPE_ISAMPLER3D:
+			return 16;
+		case SL::TYPE_USAMPLER3D:
+			return 16;
+		case SL::TYPE_SAMPLERCUBE:
+			return 16;
 	}
 
 	ERR_FAIL_V(0);
@@ -95,36 +123,66 @@ static int _get_datatype_alignment(SL::DataType p_type) {
 
 	switch (p_type) {
 
-		case SL::TYPE_VOID: return 0;
-		case SL::TYPE_BOOL: return 4;
-		case SL::TYPE_BVEC2: return 8;
-		case SL::TYPE_BVEC3: return 16;
-		case SL::TYPE_BVEC4: return 16;
-		case SL::TYPE_INT: return 4;
-		case SL::TYPE_IVEC2: return 8;
-		case SL::TYPE_IVEC3: return 16;
-		case SL::TYPE_IVEC4: return 16;
-		case SL::TYPE_UINT: return 4;
-		case SL::TYPE_UVEC2: return 8;
-		case SL::TYPE_UVEC3: return 16;
-		case SL::TYPE_UVEC4: return 16;
-		case SL::TYPE_FLOAT: return 4;
-		case SL::TYPE_VEC2: return 8;
-		case SL::TYPE_VEC3: return 16;
-		case SL::TYPE_VEC4: return 16;
-		case SL::TYPE_MAT2: return 16;
-		case SL::TYPE_MAT3: return 16;
-		case SL::TYPE_MAT4: return 16;
-		case SL::TYPE_SAMPLER2D: return 16;
-		case SL::TYPE_ISAMPLER2D: return 16;
-		case SL::TYPE_USAMPLER2D: return 16;
-		case SL::TYPE_SAMPLER2DARRAY: return 16;
-		case SL::TYPE_ISAMPLER2DARRAY: return 16;
-		case SL::TYPE_USAMPLER2DARRAY: return 16;
-		case SL::TYPE_SAMPLER3D: return 16;
-		case SL::TYPE_ISAMPLER3D: return 16;
-		case SL::TYPE_USAMPLER3D: return 16;
-		case SL::TYPE_SAMPLERCUBE: return 16;
+		case SL::TYPE_VOID:
+			return 0;
+		case SL::TYPE_BOOL:
+			return 4;
+		case SL::TYPE_BVEC2:
+			return 8;
+		case SL::TYPE_BVEC3:
+			return 16;
+		case SL::TYPE_BVEC4:
+			return 16;
+		case SL::TYPE_INT:
+			return 4;
+		case SL::TYPE_IVEC2:
+			return 8;
+		case SL::TYPE_IVEC3:
+			return 16;
+		case SL::TYPE_IVEC4:
+			return 16;
+		case SL::TYPE_UINT:
+			return 4;
+		case SL::TYPE_UVEC2:
+			return 8;
+		case SL::TYPE_UVEC3:
+			return 16;
+		case SL::TYPE_UVEC4:
+			return 16;
+		case SL::TYPE_FLOAT:
+			return 4;
+		case SL::TYPE_VEC2:
+			return 8;
+		case SL::TYPE_VEC3:
+			return 16;
+		case SL::TYPE_VEC4:
+			return 16;
+		case SL::TYPE_MAT2:
+			return 16;
+		case SL::TYPE_MAT3:
+			return 16;
+		case SL::TYPE_MAT4:
+			return 16;
+		case SL::TYPE_SAMPLER2D:
+			return 16;
+		case SL::TYPE_ISAMPLER2D:
+			return 16;
+		case SL::TYPE_USAMPLER2D:
+			return 16;
+		case SL::TYPE_SAMPLER2DARRAY:
+			return 16;
+		case SL::TYPE_ISAMPLER2DARRAY:
+			return 16;
+		case SL::TYPE_USAMPLER2DARRAY:
+			return 16;
+		case SL::TYPE_SAMPLER3D:
+			return 16;
+		case SL::TYPE_ISAMPLER3D:
+			return 16;
+		case SL::TYPE_USAMPLER3D:
+			return 16;
+		case SL::TYPE_SAMPLERCUBE:
+			return 16;
 	}
 
 	ERR_FAIL_V(0);
@@ -132,8 +190,10 @@ static int _get_datatype_alignment(SL::DataType p_type) {
 static String _interpstr(SL::DataInterpolation p_interp) {
 
 	switch (p_interp) {
-		case SL::INTERPOLATION_FLAT: return "flat ";
-		case SL::INTERPOLATION_SMOOTH: return "";
+		case SL::INTERPOLATION_FLAT:
+			return "flat ";
+		case SL::INTERPOLATION_SMOOTH:
+			return "";
 	}
 	return "";
 }
@@ -141,10 +201,14 @@ static String _interpstr(SL::DataInterpolation p_interp) {
 static String _prestr(SL::DataPrecision p_pres) {
 
 	switch (p_pres) {
-		case SL::PRECISION_LOWP: return "lowp ";
-		case SL::PRECISION_MEDIUMP: return "mediump ";
-		case SL::PRECISION_HIGHP: return "highp ";
-		case SL::PRECISION_DEFAULT: return "";
+		case SL::PRECISION_LOWP:
+			return "lowp ";
+		case SL::PRECISION_MEDIUMP:
+			return "mediump ";
+		case SL::PRECISION_HIGHP:
+			return "highp ";
+		case SL::PRECISION_DEFAULT:
+			return "";
 	}
 	return "";
 }
@@ -152,9 +216,12 @@ static String _prestr(SL::DataPrecision p_pres) {
 static String _qualstr(SL::ArgumentQualifier p_qual) {
 
 	switch (p_qual) {
-		case SL::ARGUMENT_QUALIFIER_IN: return "";
-		case SL::ARGUMENT_QUALIFIER_OUT: return "out ";
-		case SL::ARGUMENT_QUALIFIER_INOUT: return "inout ";
+		case SL::ARGUMENT_QUALIFIER_IN:
+			return "";
+		case SL::ARGUMENT_QUALIFIER_OUT:
+			return "out ";
+		case SL::ARGUMENT_QUALIFIER_INOUT:
+			return "inout ";
 	}
 	return "";
 }
@@ -182,7 +249,8 @@ static String f2sp0(float p_float) {
 static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNode::Value> &p_values) {
 
 	switch (p_type) {
-		case SL::TYPE_BOOL: return p_values[0].boolean ? "true" : "false";
+		case SL::TYPE_BOOL:
+			return p_values[0].boolean ? "true" : "false";
 		case SL::TYPE_BVEC2:
 		case SL::TYPE_BVEC3:
 		case SL::TYPE_BVEC4: {
@@ -198,7 +266,8 @@ static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNo
 			return text;
 		}
 
-		case SL::TYPE_INT: return itos(p_values[0].sint);
+		case SL::TYPE_INT:
+			return itos(p_values[0].sint);
 		case SL::TYPE_IVEC2:
 		case SL::TYPE_IVEC3:
 		case SL::TYPE_IVEC4: {
@@ -214,7 +283,8 @@ static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNo
 			return text;
 
 		} break;
-		case SL::TYPE_UINT: return itos(p_values[0].uint) + "u";
+		case SL::TYPE_UINT:
+			return itos(p_values[0].uint) + "u";
 		case SL::TYPE_UVEC2:
 		case SL::TYPE_UVEC3:
 		case SL::TYPE_UVEC4: {
@@ -229,7 +299,8 @@ static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNo
 			text += ")";
 			return text;
 		} break;
-		case SL::TYPE_FLOAT: return f2sp0(p_values[0].real);
+		case SL::TYPE_FLOAT:
+			return f2sp0(p_values[0].real);
 		case SL::TYPE_VEC2:
 		case SL::TYPE_VEC3:
 		case SL::TYPE_VEC4: {
@@ -260,7 +331,8 @@ static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNo
 			return text;
 
 		} break;
-		default: ERR_FAIL_V(String());
+		default:
+			ERR_FAIL_V(String());
 	}
 }
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -980,7 +980,8 @@ float SchlickFresnel(float u) {
 }
 
 float GTR1(float NdotH, float a) {
-	if (a >= 1.0) return 1.0 / M_PI;
+	if (a >= 1.0)
+		return 1.0 / M_PI;
 	float a2 = a * a;
 	float t = 1.0 + (a2 - 1.0) * NdotH * NdotH;
 	return (a2 - 1.0) / (M_PI * log(a2) * t);

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -65,7 +65,8 @@ static void _png_error_function(png_structp, png_const_charp text) {
 static void _png_warn_function(png_structp, png_const_charp text) {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		if (String(text).begins_with("iCCP")) return; // silences annoying spam emitted to output every time the user opened assetlib
+		if (String(text).begins_with("iCCP"))
+			return; // silences annoying spam emitted to output every time the user opened assetlib
 	}
 #endif
 	WARN_PRINT(text);

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -226,7 +226,8 @@ void IP_Unix::get_local_addresses(List<IP_Address> *r_addresses) const {
 		r_addresses->push_back(ip);
 	}
 
-	if (ifAddrStruct != NULL) freeifaddrs(ifAddrStruct);
+	if (ifAddrStruct != NULL)
+		freeifaddrs(ifAddrStruct);
 }
 #endif
 

--- a/drivers/unix/syslog_logger.cpp
+++ b/drivers/unix/syslog_logger.cpp
@@ -49,11 +49,21 @@ void SyslogLogger::print_error(const char *p_function, const char *p_file, int p
 
 	const char *err_type = "**ERROR**";
 	switch (p_type) {
-		case ERR_ERROR: err_type = "**ERROR**"; break;
-		case ERR_WARNING: err_type = "**WARNING**"; break;
-		case ERR_SCRIPT: err_type = "**SCRIPT ERROR**"; break;
-		case ERR_SHADER: err_type = "**SHADER ERROR**"; break;
-		default: ERR_PRINT("Unknown error type"); break;
+		case ERR_ERROR:
+			err_type = "**ERROR**";
+			break;
+		case ERR_WARNING:
+			err_type = "**WARNING**";
+			break;
+		case ERR_SCRIPT:
+			err_type = "**SCRIPT ERROR**";
+			break;
+		case ERR_SHADER:
+			err_type = "**SHADER ERROR**";
+			break;
+		default:
+			ERR_PRINT("Unknown error type");
+			break;
 	}
 
 	const char *err_details;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4548,10 +4548,18 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				}
 
 				switch (animation->track_get_type(i)) {
-					case Animation::TYPE_TRANSFORM: text += " (Transform)"; break;
-					case Animation::TYPE_METHOD: text += " (Methods)"; break;
-					case Animation::TYPE_BEZIER: text += " (Bezier)"; break;
-					case Animation::TYPE_AUDIO: text += " (Audio)"; break;
+					case Animation::TYPE_TRANSFORM:
+						text += " (Transform)";
+						break;
+					case Animation::TYPE_METHOD:
+						text += " (Methods)";
+						break;
+					case Animation::TYPE_BEZIER:
+						text += " (Bezier)";
+						break;
+					case Animation::TYPE_AUDIO:
+						text += " (Audio)";
+						break;
 					default: {
 					};
 				}

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -159,19 +159,45 @@ void ConnectDialog::_add_bind() {
 	Variant value;
 
 	switch (vt) {
-		case Variant::BOOL: value = false; break;
-		case Variant::INT: value = 0; break;
-		case Variant::REAL: value = 0.0; break;
-		case Variant::STRING: value = ""; break;
-		case Variant::VECTOR2: value = Vector2(); break;
-		case Variant::RECT2: value = Rect2(); break;
-		case Variant::VECTOR3: value = Vector3(); break;
-		case Variant::PLANE: value = Plane(); break;
-		case Variant::QUAT: value = Quat(); break;
-		case Variant::AABB: value = AABB(); break;
-		case Variant::BASIS: value = Basis(); break;
-		case Variant::TRANSFORM: value = Transform(); break;
-		case Variant::COLOR: value = Color(); break;
+		case Variant::BOOL:
+			value = false;
+			break;
+		case Variant::INT:
+			value = 0;
+			break;
+		case Variant::REAL:
+			value = 0.0;
+			break;
+		case Variant::STRING:
+			value = "";
+			break;
+		case Variant::VECTOR2:
+			value = Vector2();
+			break;
+		case Variant::RECT2:
+			value = Rect2();
+			break;
+		case Variant::VECTOR3:
+			value = Vector3();
+			break;
+		case Variant::PLANE:
+			value = Plane();
+			break;
+		case Variant::QUAT:
+			value = Quat();
+			break;
+		case Variant::AABB:
+			value = AABB();
+			break;
+		case Variant::BASIS:
+			value = Basis();
+			break;
+		case Variant::TRANSFORM:
+			value = Transform();
+			break;
+		case Variant::COLOR:
+			value = Color();
+			break;
 		default: {
 			ERR_FAIL();
 		} break;

--- a/editor/doc/doc_dump.cpp
+++ b/editor/doc/doc_dump.cpp
@@ -210,8 +210,12 @@ void DocDump::dump(const String &p_file) {
 
 				String hint;
 				switch (arginfo.hint) {
-					case PROPERTY_HINT_DIR: hint = "A directory."; break;
-					case PROPERTY_HINT_RANGE: hint = "Range - min: " + arginfo.hint_string.get_slice(",", 0) + " max: " + arginfo.hint_string.get_slice(",", 1) + " step: " + arginfo.hint_string.get_slice(",", 2); break;
+					case PROPERTY_HINT_DIR:
+						hint = "A directory.";
+						break;
+					case PROPERTY_HINT_RANGE:
+						hint = "Range - min: " + arginfo.hint_string.get_slice(",", 0) + " max: " + arginfo.hint_string.get_slice(",", 1) + " step: " + arginfo.hint_string.get_slice(",", 2);
+						break;
 					case PROPERTY_HINT_ENUM:
 						hint = "Values: ";
 						for (int j = 0; j < arginfo.hint_string.get_slice_count(","); j++) {
@@ -219,7 +223,9 @@ void DocDump::dump(const String &p_file) {
 							hint += arginfo.hint_string.get_slice(",", j) + "=" + itos(j);
 						}
 						break;
-					case PROPERTY_HINT_LENGTH: hint = "Length: " + arginfo.hint_string; break;
+					case PROPERTY_HINT_LENGTH:
+						hint = "Length: " + arginfo.hint_string;
+						break;
 					case PROPERTY_HINT_FLAGS:
 						hint = "Values: ";
 						for (int j = 0; j < arginfo.hint_string.get_slice_count(","); j++) {
@@ -227,7 +233,9 @@ void DocDump::dump(const String &p_file) {
 							hint += arginfo.hint_string.get_slice(",", j) + "=" + itos((uint64_t)1 << j);
 						}
 						break;
-					case PROPERTY_HINT_FILE: hint = "A file:"; break;
+					case PROPERTY_HINT_FILE:
+						hint = "A file:";
+						break;
 					default: {
 					}
 						//case PROPERTY_HINT_RESOURCE_TYPE: hint="Type: "+arginfo.hint_string; break;

--- a/editor/doc/doc_dump.cpp
+++ b/editor/doc/doc_dump.cpp
@@ -219,7 +219,8 @@ void DocDump::dump(const String &p_file) {
 					case PROPERTY_HINT_ENUM:
 						hint = "Values: ";
 						for (int j = 0; j < arginfo.hint_string.get_slice_count(","); j++) {
-							if (j > 0) hint += ", ";
+							if (j > 0)
+								hint += ", ";
 							hint += arginfo.hint_string.get_slice(",", j) + "=" + itos(j);
 						}
 						break;
@@ -229,7 +230,8 @@ void DocDump::dump(const String &p_file) {
 					case PROPERTY_HINT_FLAGS:
 						hint = "Values: ";
 						for (int j = 0; j < arginfo.hint_string.get_slice_count(","); j++) {
-							if (j > 0) hint += ", ";
+							if (j > 0)
+								hint += ", ";
 							hint += arginfo.hint_string.get_slice(",", j) + "=" + itos((uint64_t)1 << j);
 						}
 						break;

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1381,7 +1381,8 @@ void EditorHelp::_notification(int p_what) {
 			_update_doc();
 
 		} break;
-		default: break;
+		default:
+			break;
 	}
 }
 
@@ -1522,7 +1523,8 @@ void EditorHelpBit::_notification(int p_what) {
 			rich_text->add_color_override("selection_color", get_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
 		} break;
 
-		default: break;
+		default:
+			break;
 	}
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2649,12 +2649,18 @@ void EditorNode::_update_debug_options() {
 	bool check_live_debug = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_live_debug", false);
 	bool check_reload_scripts = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_reload_scripts", false);
 
-	if (check_deploy_remote) _menu_option_confirm(RUN_DEPLOY_REMOTE_DEBUG, true);
-	if (check_file_server) _menu_option_confirm(RUN_FILE_SERVER, true);
-	if (check_debug_collisons) _menu_option_confirm(RUN_DEBUG_COLLISONS, true);
-	if (check_debug_navigation) _menu_option_confirm(RUN_DEBUG_NAVIGATION, true);
-	if (check_live_debug) _menu_option_confirm(RUN_LIVE_DEBUG, true);
-	if (check_reload_scripts) _menu_option_confirm(RUN_RELOAD_SCRIPTS, true);
+	if (check_deploy_remote)
+		_menu_option_confirm(RUN_DEPLOY_REMOTE_DEBUG, true);
+	if (check_file_server)
+		_menu_option_confirm(RUN_FILE_SERVER, true);
+	if (check_debug_collisons)
+		_menu_option_confirm(RUN_DEBUG_COLLISONS, true);
+	if (check_debug_navigation)
+		_menu_option_confirm(RUN_DEBUG_NAVIGATION, true);
+	if (check_live_debug)
+		_menu_option_confirm(RUN_LIVE_DEBUG, true);
+	if (check_reload_scripts)
+		_menu_option_confirm(RUN_RELOAD_SCRIPTS, true);
 }
 
 Control *EditorNode::get_viewport() {
@@ -2890,7 +2896,8 @@ void EditorNode::_remove_edited_scene(bool p_change_tab) {
 		ScriptEditor::get_singleton()->close_builtin_scripts_from_scene(editor_data.get_scene_path(old_index));
 	}
 
-	if (p_change_tab) _scene_tab_changed(new_index);
+	if (p_change_tab)
+		_scene_tab_changed(new_index);
 	editor_data.remove_scene(old_index);
 	editor_data.get_undo_redo().clear_history(false);
 	_update_title();

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3023,13 +3023,27 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 
 				EditorPropertyMember::Type type = EditorPropertyMember::MEMBER_METHOD_OF_BASE_TYPE;
 				switch (p_hint) {
-					case PROPERTY_HINT_METHOD_OF_BASE_TYPE: type = EditorPropertyMember::MEMBER_METHOD_OF_BASE_TYPE; break;
-					case PROPERTY_HINT_METHOD_OF_INSTANCE: type = EditorPropertyMember::MEMBER_METHOD_OF_INSTANCE; break;
-					case PROPERTY_HINT_METHOD_OF_SCRIPT: type = EditorPropertyMember::MEMBER_METHOD_OF_SCRIPT; break;
-					case PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE: type = EditorPropertyMember::MEMBER_PROPERTY_OF_VARIANT_TYPE; break;
-					case PROPERTY_HINT_PROPERTY_OF_BASE_TYPE: type = EditorPropertyMember::MEMBER_PROPERTY_OF_BASE_TYPE; break;
-					case PROPERTY_HINT_PROPERTY_OF_INSTANCE: type = EditorPropertyMember::MEMBER_PROPERTY_OF_INSTANCE; break;
-					case PROPERTY_HINT_PROPERTY_OF_SCRIPT: type = EditorPropertyMember::MEMBER_PROPERTY_OF_SCRIPT; break;
+					case PROPERTY_HINT_METHOD_OF_BASE_TYPE:
+						type = EditorPropertyMember::MEMBER_METHOD_OF_BASE_TYPE;
+						break;
+					case PROPERTY_HINT_METHOD_OF_INSTANCE:
+						type = EditorPropertyMember::MEMBER_METHOD_OF_INSTANCE;
+						break;
+					case PROPERTY_HINT_METHOD_OF_SCRIPT:
+						type = EditorPropertyMember::MEMBER_METHOD_OF_SCRIPT;
+						break;
+					case PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE:
+						type = EditorPropertyMember::MEMBER_PROPERTY_OF_VARIANT_TYPE;
+						break;
+					case PROPERTY_HINT_PROPERTY_OF_BASE_TYPE:
+						type = EditorPropertyMember::MEMBER_PROPERTY_OF_BASE_TYPE;
+						break;
+					case PROPERTY_HINT_PROPERTY_OF_INSTANCE:
+						type = EditorPropertyMember::MEMBER_PROPERTY_OF_INSTANCE;
+						break;
+					case PROPERTY_HINT_PROPERTY_OF_SCRIPT:
+						type = EditorPropertyMember::MEMBER_PROPERTY_OF_SCRIPT;
+						break;
 					default: {
 					}
 				}

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -198,7 +198,8 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 	if (!p_only_thumbs)
 		for (int i = 0; i < editor_icons_count; i++) {
 			List<String>::Element *is_exception = exceptions.find(editor_icons_names[i]);
-			if (is_exception) exceptions.erase(is_exception);
+			if (is_exception)
+				exceptions.erase(is_exception);
 			Ref<ImageTexture> icon = editor_generate_icon(i, !is_exception);
 			p_theme->set_icon(editor_icons_names[i], "EditorIcons", icon);
 		}
@@ -210,7 +211,8 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 		for (int i = 0; i < editor_bg_thumbs_count; i++) {
 			int index = editor_bg_thumbs_indices[i];
 			List<String>::Element *is_exception = exceptions.find(editor_icons_names[index]);
-			if (is_exception) exceptions.erase(is_exception);
+			if (is_exception)
+				exceptions.erase(is_exception);
 			Ref<ImageTexture> icon = editor_generate_icon(index, !p_dark_theme && !is_exception, scale, force_filter);
 			p_theme->set_icon(editor_icons_names[index], "EditorIcons", icon);
 		}
@@ -219,7 +221,8 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 		for (int i = 0; i < editor_md_thumbs_count; i++) {
 			int index = editor_md_thumbs_indices[i];
 			List<String>::Element *is_exception = exceptions.find(editor_icons_names[index]);
-			if (is_exception) exceptions.erase(is_exception);
+			if (is_exception)
+				exceptions.erase(is_exception);
 			Ref<ImageTexture> icon = editor_generate_icon(index, !p_dark_theme && !is_exception, scale, force_filter);
 			p_theme->set_icon(editor_icons_names[index], "EditorIcons", icon);
 		}

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -500,18 +500,26 @@ void ExportTemplateManager::_notification(int p_what) {
 				status = TTR("Disconnected");
 				errored = true;
 				break;
-			case HTTPClient::STATUS_RESOLVING: status = TTR("Resolving"); break;
+			case HTTPClient::STATUS_RESOLVING:
+				status = TTR("Resolving");
+				break;
 			case HTTPClient::STATUS_CANT_RESOLVE:
 				status = TTR("Can't Resolve");
 				errored = true;
 				break;
-			case HTTPClient::STATUS_CONNECTING: status = TTR("Connecting..."); break;
+			case HTTPClient::STATUS_CONNECTING:
+				status = TTR("Connecting...");
+				break;
 			case HTTPClient::STATUS_CANT_CONNECT:
 				status = TTR("Can't Connect");
 				errored = true;
 				break;
-			case HTTPClient::STATUS_CONNECTED: status = TTR("Connected"); break;
-			case HTTPClient::STATUS_REQUESTING: status = TTR("Requesting..."); break;
+			case HTTPClient::STATUS_CONNECTED:
+				status = TTR("Connected");
+				break;
+			case HTTPClient::STATUS_REQUESTING:
+				status = TTR("Requesting...");
+				break;
 			case HTTPClient::STATUS_BODY:
 				status = TTR("Downloading");
 				if (download_templates->get_body_size() > 0) {

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -458,12 +458,18 @@ Error EditorSceneImporterGLTF::_parse_accessors(GLTFState &state) {
 String EditorSceneImporterGLTF::_get_component_type_name(uint32_t p_component) {
 
 	switch (p_component) {
-		case COMPONENT_TYPE_BYTE: return "Byte";
-		case COMPONENT_TYPE_UNSIGNED_BYTE: return "UByte";
-		case COMPONENT_TYPE_SHORT: return "Short";
-		case COMPONENT_TYPE_UNSIGNED_SHORT: return "UShort";
-		case COMPONENT_TYPE_INT: return "Int";
-		case COMPONENT_TYPE_FLOAT: return "Float";
+		case COMPONENT_TYPE_BYTE:
+			return "Byte";
+		case COMPONENT_TYPE_UNSIGNED_BYTE:
+			return "UByte";
+		case COMPONENT_TYPE_SHORT:
+			return "Short";
+		case COMPONENT_TYPE_UNSIGNED_SHORT:
+			return "UShort";
+		case COMPONENT_TYPE_INT:
+			return "Int";
+		case COMPONENT_TYPE_FLOAT:
+			return "Float";
 	}
 
 	return "<Error>";
@@ -575,12 +581,24 @@ Error EditorSceneImporterGLTF::_decode_buffer_view(GLTFState &state, int p_buffe
 int EditorSceneImporterGLTF::_get_component_type_size(int component_type) {
 
 	switch (component_type) {
-		case COMPONENT_TYPE_BYTE: return 1; break;
-		case COMPONENT_TYPE_UNSIGNED_BYTE: return 1; break;
-		case COMPONENT_TYPE_SHORT: return 2; break;
-		case COMPONENT_TYPE_UNSIGNED_SHORT: return 2; break;
-		case COMPONENT_TYPE_INT: return 4; break;
-		case COMPONENT_TYPE_FLOAT: return 4; break;
+		case COMPONENT_TYPE_BYTE:
+			return 1;
+			break;
+		case COMPONENT_TYPE_UNSIGNED_BYTE:
+			return 1;
+			break;
+		case COMPONENT_TYPE_SHORT:
+			return 2;
+			break;
+		case COMPONENT_TYPE_UNSIGNED_SHORT:
+			return 2;
+			break;
+		case COMPONENT_TYPE_INT:
+			return 4;
+			break;
+		case COMPONENT_TYPE_FLOAT:
+			return 4;
+			break;
 		default: {
 			ERR_FAIL_V(0);
 		}

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -83,9 +83,15 @@ Error ResourceImporterCSVTranslation::import(const String &p_source_file, const 
 
 	String delimiter;
 	switch ((int)p_options["delimiter"]) {
-		case 0: delimiter = ","; break;
-		case 1: delimiter = ";"; break;
-		case 2: delimiter = "\t"; break;
+		case 0:
+			delimiter = ",";
+			break;
+		case 1:
+			delimiter = ";";
+			break;
+		case 2:
+			delimiter = "\t";
+			break;
 	}
 
 	FileAccessRef f = FileAccess::open(p_source_file, FileAccess::READ);

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -224,16 +224,26 @@ int ResourceImporterScene::get_preset_count() const {
 String ResourceImporterScene::get_preset_name(int p_idx) const {
 
 	switch (p_idx) {
-		case PRESET_SINGLE_SCENE: return TTR("Import as Single Scene");
-		case PRESET_SEPARATE_ANIMATIONS: return TTR("Import with Separate Animations");
-		case PRESET_SEPARATE_MATERIALS: return TTR("Import with Separate Materials");
-		case PRESET_SEPARATE_MESHES: return TTR("Import with Separate Objects");
-		case PRESET_SEPARATE_MESHES_AND_MATERIALS: return TTR("Import with Separate Objects+Materials");
-		case PRESET_SEPARATE_MESHES_AND_ANIMATIONS: return TTR("Import with Separate Objects+Animations");
-		case PRESET_SEPARATE_MATERIALS_AND_ANIMATIONS: return TTR("Import with Separate Materials+Animations");
-		case PRESET_SEPARATE_MESHES_MATERIALS_AND_ANIMATIONS: return TTR("Import with Separate Objects+Materials+Animations");
-		case PRESET_MULTIPLE_SCENES: return TTR("Import as Multiple Scenes");
-		case PRESET_MULTIPLE_SCENES_AND_MATERIALS: return TTR("Import as Multiple Scenes+Materials");
+		case PRESET_SINGLE_SCENE:
+			return TTR("Import as Single Scene");
+		case PRESET_SEPARATE_ANIMATIONS:
+			return TTR("Import with Separate Animations");
+		case PRESET_SEPARATE_MATERIALS:
+			return TTR("Import with Separate Materials");
+		case PRESET_SEPARATE_MESHES:
+			return TTR("Import with Separate Objects");
+		case PRESET_SEPARATE_MESHES_AND_MATERIALS:
+			return TTR("Import with Separate Objects+Materials");
+		case PRESET_SEPARATE_MESHES_AND_ANIMATIONS:
+			return TTR("Import with Separate Objects+Animations");
+		case PRESET_SEPARATE_MATERIALS_AND_ANIMATIONS:
+			return TTR("Import with Separate Materials+Animations");
+		case PRESET_SEPARATE_MESHES_MATERIALS_AND_ANIMATIONS:
+			return TTR("Import with Separate Objects+Materials+Animations");
+		case PRESET_MULTIPLE_SCENES:
+			return TTR("Import as Multiple Scenes");
+		case PRESET_MULTIPLE_SCENES_AND_MATERIALS:
+			return TTR("Import as Multiple Scenes+Materials");
 	}
 
 	return "";

--- a/editor/plugins/animation_tree_player_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_player_editor_plugin.cpp
@@ -528,26 +528,49 @@ void AnimationTreePlayerEditor::_draw_node(const StringName &p_node) {
 			switch (type) {
 
 				case AnimationTreePlayer::NODE_TIMESCALE:
-				case AnimationTreePlayer::NODE_TIMESEEK: text = "in"; break;
-				case AnimationTreePlayer::NODE_OUTPUT: text = "out"; break;
-				case AnimationTreePlayer::NODE_ANIMATION: break;
-				case AnimationTreePlayer::NODE_ONESHOT: text = (i == 0 ? "in" : "add"); break;
+				case AnimationTreePlayer::NODE_TIMESEEK:
+					text = "in";
+					break;
+				case AnimationTreePlayer::NODE_OUTPUT:
+					text = "out";
+					break;
+				case AnimationTreePlayer::NODE_ANIMATION:
+					break;
+				case AnimationTreePlayer::NODE_ONESHOT:
+					text = (i == 0 ? "in" : "add");
+					break;
 				case AnimationTreePlayer::NODE_BLEND2:
-				case AnimationTreePlayer::NODE_MIX: text = (i == 0 ? "a" : "b"); break;
+				case AnimationTreePlayer::NODE_MIX:
+					text = (i == 0 ? "a" : "b");
+					break;
 				case AnimationTreePlayer::NODE_BLEND3:
 					switch (i) {
-						case 0: text = "b-"; break;
-						case 1: text = "a"; break;
-						case 2: text = "b+"; break;
+						case 0:
+							text = "b-";
+							break;
+						case 1:
+							text = "a";
+							break;
+						case 2:
+							text = "b+";
+							break;
 					}
 					break;
 
 				case AnimationTreePlayer::NODE_BLEND4:
 					switch (i) {
-						case 0: text = "a0"; break;
-						case 1: text = "b0"; break;
-						case 2: text = "a1"; break;
-						case 3: text = "b1"; break;
+						case 0:
+							text = "a0";
+							break;
+						case 1:
+							text = "b0";
+							break;
+						case 2:
+							text = "a1";
+							break;
+						case 3:
+							text = "b1";
+							break;
 					}
 					break;
 
@@ -598,7 +621,8 @@ void AnimationTreePlayerEditor::_draw_node(const StringName &p_node) {
 
 			font->draw_halign(ci, ofs + ascofs, HALIGN_CENTER, w, "edit...", font_color_title);
 		} break;
-		default: editable = false;
+		default:
+			editable = false;
 	}
 
 	if (editable) {

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1275,7 +1275,8 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				}
 			}
 		} break;
-		default: break;
+		default:
+			break;
 	}
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1460,20 +1460,28 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 
 			switch (drag_type) {
 				case DRAG_ANCHOR_TOP_LEFT:
-					if (!use_single_axis || !use_y) control->set_anchor(MARGIN_LEFT, new_anchor.x, false, false);
-					if (!use_single_axis || use_y) control->set_anchor(MARGIN_TOP, new_anchor.y, false, false);
+					if (!use_single_axis || !use_y)
+						control->set_anchor(MARGIN_LEFT, new_anchor.x, false, false);
+					if (!use_single_axis || use_y)
+						control->set_anchor(MARGIN_TOP, new_anchor.y, false, false);
 					break;
 				case DRAG_ANCHOR_TOP_RIGHT:
-					if (!use_single_axis || !use_y) control->set_anchor(MARGIN_RIGHT, new_anchor.x, false, false);
-					if (!use_single_axis || use_y) control->set_anchor(MARGIN_TOP, new_anchor.y, false, false);
+					if (!use_single_axis || !use_y)
+						control->set_anchor(MARGIN_RIGHT, new_anchor.x, false, false);
+					if (!use_single_axis || use_y)
+						control->set_anchor(MARGIN_TOP, new_anchor.y, false, false);
 					break;
 				case DRAG_ANCHOR_BOTTOM_RIGHT:
-					if (!use_single_axis || !use_y) control->set_anchor(MARGIN_RIGHT, new_anchor.x, false, false);
-					if (!use_single_axis || use_y) control->set_anchor(MARGIN_BOTTOM, new_anchor.y, false, false);
+					if (!use_single_axis || !use_y)
+						control->set_anchor(MARGIN_RIGHT, new_anchor.x, false, false);
+					if (!use_single_axis || use_y)
+						control->set_anchor(MARGIN_BOTTOM, new_anchor.y, false, false);
 					break;
 				case DRAG_ANCHOR_BOTTOM_LEFT:
-					if (!use_single_axis || !use_y) control->set_anchor(MARGIN_LEFT, new_anchor.x, false, false);
-					if (!use_single_axis || use_y) control->set_anchor(MARGIN_BOTTOM, new_anchor.y, false, false);
+					if (!use_single_axis || !use_y)
+						control->set_anchor(MARGIN_LEFT, new_anchor.x, false, false);
+					if (!use_single_axis || use_y)
+						control->set_anchor(MARGIN_BOTTOM, new_anchor.y, false, false);
 					break;
 				case DRAG_ANCHOR_ALL:
 					if (!use_single_axis || !use_y) {
@@ -4434,7 +4442,8 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 	Map<Node *, Object *> &selection = editor_selection->get_selection();
 	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
-		if (!canvas_item) continue;
+		if (!canvas_item)
+			continue;
 		if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
 			continue;
 
@@ -4462,7 +4471,8 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 			rect = rect.merge(canvas_item_rect);
 		}
 	};
-	if (count == 0) return;
+	if (count == 0)
+		return;
 
 	if (p_op == VIEW_CENTER_TO_SELECTION) {
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5586,7 +5586,8 @@ void CanvasItemEditorViewport::_notification(int p_what) {
 			disconnect("mouse_exited", this, "_on_mouse_exit");
 		} break;
 
-		default: break;
+		default:
+			break;
 	}
 }
 

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -287,8 +287,10 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 			Vector2 gpoint = mm->get_position();
 
 			Ref<Curve2D> curve = node->get_curve();
-			if (curve == NULL) return true;
-			if (curve->get_point_count() < 2) return true;
+			if (curve == NULL)
+				return true;
+			if (curve->get_point_count() < 2)
+				return true;
 
 			// Find edge
 			edge_point = xform.xform(curve->get_closest_point(xform.affine_inverse().xform(mm->get_position())));

--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -629,7 +629,8 @@ Ref<EditorSpatialGizmo> PathSpatialGizmoPlugin::create_gizmo(Spatial *p_spatial)
 	Ref<PathSpatialGizmo> ref;
 
 	Path *path = Object::cast_to<Path>(p_spatial);
-	if (path) ref = Ref<PathSpatialGizmo>(memnew(PathSpatialGizmo(path)));
+	if (path)
+		ref = Ref<PathSpatialGizmo>(memnew(PathSpatialGizmo(path)));
 
 	return ref;
 }

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -738,7 +738,8 @@ void ScriptTextEditor::_code_complete_scripts(void *p_ud, const String &p_code, 
 
 void ScriptTextEditor::_code_complete_script(const String &p_code, List<String> *r_options, bool &r_force) {
 
-	if (color_panel->is_visible_in_tree()) return;
+	if (color_panel->is_visible_in_tree())
+		return;
 	Node *base = get_tree()->get_edited_scene_root();
 	if (base) {
 		base = _find_node_for_script(base, base, script);

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -534,7 +534,8 @@ void SpatialEditorViewport::_select_region() {
 			item = sel;
 		}
 
-		if (selected.find(item) != -1) continue;
+		if (selected.find(item) != -1)
+			continue;
 
 		Ref<EditorSpatialGizmo> seg = sp->get_gizmo();
 
@@ -1170,7 +1171,8 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 					if (cursor.region_select) {
 
-						if (!clicked_wants_append) _clear_selected();
+						if (!clicked_wants_append)
+							_clear_selected();
 
 						_select_region();
 						cursor.region_select = false;
@@ -1870,7 +1872,8 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 
 		if (k->get_scancode() == KEY_SPACE) {
-			if (!k->is_pressed()) emit_signal("toggle_maximize_view", this);
+			if (!k->is_pressed())
+				emit_signal("toggle_maximize_view", this);
 		}
 	}
 
@@ -4063,7 +4066,8 @@ void _update_all_gizmos(Node *p_node) {
 }
 
 void SpatialEditor::update_all_gizmos(Node *p_node) {
-	if (!p_node) p_node = SceneTree::get_singleton()->get_root();
+	if (!p_node)
+		p_node = SceneTree::get_singleton()->get_root();
 	_update_all_gizmos(p_node);
 }
 
@@ -4162,7 +4166,8 @@ Dictionary SpatialEditor::get_state() const {
 
 	Dictionary gizmos_status;
 	for (int i = 0; i < gizmo_plugins_by_name.size(); i++) {
-		if (!gizmo_plugins_by_name[i]->can_be_hidden()) continue;
+		if (!gizmo_plugins_by_name[i]->can_be_hidden())
+			continue;
 		int state = gizmos_menu->get_item_state(gizmos_menu->get_item_index(i));
 		String name = gizmo_plugins_by_name[i]->get_name();
 		gizmos_status[name] = state;
@@ -4254,7 +4259,8 @@ void SpatialEditor::set_state(const Dictionary &p_state) {
 		gizmos_status.get_key_list(&keys);
 
 		for (int j = 0; j < gizmo_plugins_by_name.size(); ++j) {
-			if (!gizmo_plugins_by_name[j]->can_be_hidden()) continue;
+			if (!gizmo_plugins_by_name[j]->can_be_hidden())
+				continue;
 			int state = EditorSpatialGizmoPlugin::VISIBLE;
 			for (int i = 0; i < keys.size(); i++) {
 				if (gizmo_plugins_by_name.write[j]->get_name() == keys[i]) {
@@ -4937,7 +4943,8 @@ void SpatialEditor::_update_gizmos_menu() {
 	gizmos_menu->clear();
 
 	for (int i = 0; i < gizmo_plugins_by_name.size(); ++i) {
-		if (!gizmo_plugins_by_name[i]->can_be_hidden()) continue;
+		if (!gizmo_plugins_by_name[i]->can_be_hidden())
+			continue;
 		String plugin_name = gizmo_plugins_by_name[i]->get_name();
 		const int plugin_state = gizmo_plugins_by_name[i]->get_state();
 		gizmos_menu->add_multistate_item(TTR(plugin_name), 3, plugin_state, i);
@@ -4958,7 +4965,8 @@ void SpatialEditor::_update_gizmos_menu() {
 
 void SpatialEditor::_update_gizmos_menu_theme() {
 	for (int i = 0; i < gizmo_plugins_by_name.size(); ++i) {
-		if (!gizmo_plugins_by_name[i]->can_be_hidden()) continue;
+		if (!gizmo_plugins_by_name[i]->can_be_hidden())
+			continue;
 		const int plugin_state = gizmo_plugins_by_name[i]->get_state();
 		const int idx = gizmos_menu->get_item_index(i);
 		switch (plugin_state) {
@@ -5365,9 +5373,11 @@ void SpatialEditor::_request_gizmo(Object *p_obj) {
 }
 
 void SpatialEditor::_toggle_maximize_view(Object *p_viewport) {
-	if (!p_viewport) return;
+	if (!p_viewport)
+		return;
 	SpatialEditorViewport *current_viewport = Object::cast_to<SpatialEditorViewport>(p_viewport);
-	if (!current_viewport) return;
+	if (!current_viewport)
+		return;
 
 	int index = -1;
 	bool maximized = false;
@@ -5379,7 +5389,8 @@ void SpatialEditor::_toggle_maximize_view(Object *p_viewport) {
 			break;
 		}
 	}
-	if (index == -1) return;
+	if (index == -1)
+		return;
 
 	if (!maximized) {
 
@@ -6082,7 +6093,8 @@ Ref<SpatialMaterial> EditorSpatialGizmoPlugin::get_material(const String &p_name
 	ERR_FAIL_COND_V(!materials.has(p_name), Ref<SpatialMaterial>());
 	ERR_FAIL_COND_V(materials[p_name].size() == 0, Ref<SpatialMaterial>());
 
-	if (p_gizmo.is_null() || materials[p_name].size() == 1) return materials[p_name][0];
+	if (p_gizmo.is_null() || materials[p_name].size() == 1)
+		return materials[p_name][0];
 
 	int index = (p_gizmo->is_selected() ? 1 : 0) + (p_gizmo->is_editable() ? 2 : 0);
 
@@ -6119,7 +6131,8 @@ Ref<EditorSpatialGizmo> EditorSpatialGizmoPlugin::get_gizmo(Spatial *p_spatial) 
 
 	Ref<EditorSpatialGizmo> ref = create_gizmo(p_spatial);
 
-	if (ref.is_null()) return ref;
+	if (ref.is_null())
+		return ref;
 
 	ref->set_plugin(this);
 	ref->set_spatial_node(p_spatial);
@@ -6178,7 +6191,8 @@ Ref<EditorSpatialGizmo> EditorSpatialGizmoPlugin::create_gizmo(Spatial *p_spatia
 	}
 
 	Ref<EditorSpatialGizmo> ref;
-	if (has_gizmo(p_spatial)) ref.instance();
+	if (has_gizmo(p_spatial))
+		ref.instance();
 	return ref;
 }
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -593,11 +593,16 @@ static int _get_key_modifier_setting(const String &p_property) {
 
 	switch (EditorSettings::get_singleton()->get(p_property).operator int()) {
 
-		case 0: return 0;
-		case 1: return KEY_SHIFT;
-		case 2: return KEY_ALT;
-		case 3: return KEY_META;
-		case 4: return KEY_CONTROL;
+		case 0:
+			return 0;
+		case 1:
+			return KEY_SHIFT;
+		case 2:
+			return KEY_ALT;
+		case 3:
+			return KEY_META;
+		case 4:
+			return KEY_CONTROL;
 	}
 	return 0;
 }

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -70,11 +70,21 @@ void ThemeEditor::_name_menu_about_to_show() {
 
 		switch (type_select->get_selected()) {
 
-			case 0: Theme::get_default()->get_icon_list(fromtype, &names); break;
-			case 1: Theme::get_default()->get_stylebox_list(fromtype, &names); break;
-			case 2: Theme::get_default()->get_font_list(fromtype, &names); break;
-			case 3: Theme::get_default()->get_color_list(fromtype, &names); break;
-			case 4: Theme::get_default()->get_constant_list(fromtype, &names); break;
+			case 0:
+				Theme::get_default()->get_icon_list(fromtype, &names);
+				break;
+			case 1:
+				Theme::get_default()->get_stylebox_list(fromtype, &names);
+				break;
+			case 2:
+				Theme::get_default()->get_font_list(fromtype, &names);
+				break;
+			case 3:
+				Theme::get_default()->get_color_list(fromtype, &names);
+				break;
+			case 4:
+				Theme::get_default()->get_constant_list(fromtype, &names);
+				break;
 		}
 	} else if (popup_mode == POPUP_REMOVE) {
 
@@ -322,11 +332,21 @@ void ThemeEditor::_dialog_cbk() {
 
 			switch (type_select->get_selected()) {
 
-				case 0: theme->set_icon(name_edit->get_text(), type_edit->get_text(), Ref<Texture>()); break;
-				case 1: theme->set_stylebox(name_edit->get_text(), type_edit->get_text(), Ref<StyleBox>()); break;
-				case 2: theme->set_font(name_edit->get_text(), type_edit->get_text(), Ref<Font>()); break;
-				case 3: theme->set_color(name_edit->get_text(), type_edit->get_text(), Color()); break;
-				case 4: theme->set_constant(name_edit->get_text(), type_edit->get_text(), 0); break;
+				case 0:
+					theme->set_icon(name_edit->get_text(), type_edit->get_text(), Ref<Texture>());
+					break;
+				case 1:
+					theme->set_stylebox(name_edit->get_text(), type_edit->get_text(), Ref<StyleBox>());
+					break;
+				case 2:
+					theme->set_font(name_edit->get_text(), type_edit->get_text(), Ref<Font>());
+					break;
+				case 3:
+					theme->set_color(name_edit->get_text(), type_edit->get_text(), Color());
+					break;
+				case 4:
+					theme->set_constant(name_edit->get_text(), type_edit->get_text(), 0);
+					break;
 			}
 
 		} break;
@@ -374,11 +394,21 @@ void ThemeEditor::_dialog_cbk() {
 		case POPUP_REMOVE: {
 			switch (type_select->get_selected()) {
 
-				case 0: theme->clear_icon(name_edit->get_text(), type_edit->get_text()); break;
-				case 1: theme->clear_stylebox(name_edit->get_text(), type_edit->get_text()); break;
-				case 2: theme->clear_font(name_edit->get_text(), type_edit->get_text()); break;
-				case 3: theme->clear_color(name_edit->get_text(), type_edit->get_text()); break;
-				case 4: theme->clear_constant(name_edit->get_text(), type_edit->get_text()); break;
+				case 0:
+					theme->clear_icon(name_edit->get_text(), type_edit->get_text());
+					break;
+				case 1:
+					theme->clear_stylebox(name_edit->get_text(), type_edit->get_text());
+					break;
+				case 2:
+					theme->clear_font(name_edit->get_text(), type_edit->get_text());
+					break;
+				case 3:
+					theme->clear_color(name_edit->get_text(), type_edit->get_text());
+					break;
+				case 4:
+					theme->clear_constant(name_edit->get_text(), type_edit->get_text());
+					break;
 			}
 
 		} break;

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -125,7 +125,8 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 			sb->get_shape_owners(&shapes);
 
 			for (List<uint32_t>::Element *E = shapes.front(); E; E = E->next()) {
-				if (sb->is_shape_owner_disabled(E->get())) continue;
+				if (sb->is_shape_owner_disabled(E->get()))
+					continue;
 
 				Transform2D shape_transform = sb->get_transform() * sb->shape_owner_get_transform(E->get());
 				bool one_way = sb->is_shape_owner_one_way_collision_enabled(E->get());

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1071,11 +1071,13 @@ void VisualShaderEditor::_port_name_focus_out(Object *line_edit, int p_node_id, 
 	List<String> output_names;
 
 	for (int i = 0; i < node->get_input_port_count(); i++) {
-		if (!p_output && i == p_port_id) continue;
+		if (!p_output && i == p_port_id)
+			continue;
 		input_names.push_back(node->get_input_port_name(i));
 	}
 	for (int i = 0; i < node->get_output_port_count(); i++) {
-		if (p_output && i == p_port_id) continue;
+		if (p_output && i == p_port_id)
+			continue;
 		output_names.push_back(node->get_output_port_name(i));
 	}
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1038,9 +1038,12 @@ void ProjectManager::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 			int last_clicked_id = -1;
 			for (int i = 0; i < scroll_children->get_child_count(); i++) {
 				HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_children->get_child(i));
-				if (!hb) continue;
-				if (hb->get_meta("name") == clicked) clicked_id = i;
-				if (hb->get_meta("name") == last_clicked) last_clicked_id = i;
+				if (!hb)
+					continue;
+				if (hb->get_meta("name") == clicked)
+					clicked_id = i;
+				if (hb->get_meta("name") == last_clicked)
+					last_clicked_id = i;
 			}
 
 			if (last_clicked_id != -1 && clicked_id != -1) {
@@ -1048,7 +1051,8 @@ void ProjectManager::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 				int max = clicked_id > last_clicked_id ? clicked_id : last_clicked_id;
 				for (int i = 0; i < scroll_children->get_child_count(); ++i) {
 					HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_children->get_child(i));
-					if (!hb) continue;
+					if (!hb)
+						continue;
 					if (i != clicked_id && (i < min || i > max) && !mb->get_control()) {
 						selected_list.erase(hb->get_meta("name"));
 					} else if (i >= min && i <= max) {
@@ -1145,7 +1149,8 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 					for (int i = scroll_children->get_child_count() - 1; i >= 0; i--) {
 
 						HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_children->get_child(i));
-						if (!hb) continue;
+						if (!hb)
+							continue;
 
 						String current = hb->get_meta("name");
 
@@ -1182,7 +1187,8 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 				for (int i = 0; i < scroll_children->get_child_count(); i++) {
 
 					HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_children->get_child(i));
-					if (!hb) continue;
+					if (!hb)
+						continue;
 
 					String current = hb->get_meta("name");
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -407,11 +407,13 @@ void ProjectSettingsEditor::_show_last_added(const Ref<InputEvent> &p_event, con
 			}
 			child = child->get_next();
 		}
-		if (found) break;
+		if (found)
+			break;
 		r = r->get_next();
 	}
 
-	if (found) input_editor->ensure_cursor_is_visible();
+	if (found)
+		input_editor->ensure_cursor_is_visible();
 }
 
 void ProjectSettingsEditor::_wait_for_key(const Ref<InputEvent> &p_event) {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -752,12 +752,23 @@ void ProjectSettingsEditor::_update_actions() {
 			if (mb.is_valid()) {
 				String str = _get_device_string(mb->get_device()) + ", ";
 				switch (mb->get_button_index()) {
-					case BUTTON_LEFT: str += TTR("Left Button."); break;
-					case BUTTON_RIGHT: str += TTR("Right Button."); break;
-					case BUTTON_MIDDLE: str += TTR("Middle Button."); break;
-					case BUTTON_WHEEL_UP: str += TTR("Wheel Up."); break;
-					case BUTTON_WHEEL_DOWN: str += TTR("Wheel Down."); break;
-					default: str += TTR("Button") + " " + itos(mb->get_button_index()) + ".";
+					case BUTTON_LEFT:
+						str += TTR("Left Button.");
+						break;
+					case BUTTON_RIGHT:
+						str += TTR("Right Button.");
+						break;
+					case BUTTON_MIDDLE:
+						str += TTR("Middle Button.");
+						break;
+					case BUTTON_WHEEL_UP:
+						str += TTR("Wheel Up.");
+						break;
+					case BUTTON_WHEEL_DOWN:
+						str += TTR("Wheel Down.");
+						break;
+					default:
+						str += TTR("Button") + " " + itos(mb->get_button_index()) + ".";
 				}
 
 				action2->set_text(0, str);
@@ -825,10 +836,18 @@ void ProjectSettingsEditor::_item_add() {
 
 	Variant value;
 	switch (type->get_selected()) {
-		case 0: value = false; break;
-		case 1: value = 0; break;
-		case 2: value = 0.0; break;
-		case 3: value = ""; break;
+		case 0:
+			value = false;
+			break;
+		case 1:
+			value = 0;
+			break;
+		case 2:
+			value = 0.0;
+			break;
+		case 3:
+			value = "";
+			break;
 	}
 
 	String catname = category->get_text().strip_edges();

--- a/editor/pvrtc_compress.cpp
+++ b/editor/pvrtc_compress.cpp
@@ -59,7 +59,8 @@ static void _compress_image(Image::CompressMode p_mode, Image *p_image) {
 					_base_image_compress_pvrtc4_func(p_image);
 
 				break;
-			default: ERR_FAIL();
+			default:
+				ERR_FAIL();
 		}
 		return;
 	}
@@ -77,10 +78,17 @@ static void _compress_image(Image::CompressMode p_mode, Image *p_image) {
 	args.push_back("-f");
 	switch (p_mode) {
 
-		case Image::COMPRESS_PVRTC2: args.push_back("PVRTC2"); break;
-		case Image::COMPRESS_PVRTC4: args.push_back("PVRTC4"); break;
-		case Image::COMPRESS_ETC: args.push_back("ETC"); break;
-		default: ERR_FAIL();
+		case Image::COMPRESS_PVRTC2:
+			args.push_back("PVRTC2");
+			break;
+		case Image::COMPRESS_PVRTC4:
+			args.push_back("PVRTC4");
+			break;
+		case Image::COMPRESS_ETC:
+			args.push_back("ETC");
+			break;
+		default:
+			ERR_FAIL();
 	}
 
 	if (EditorSettings::get_singleton()->get("filesystem/import/pvrtc_fast_conversion").operator bool()) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -930,8 +930,12 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				}
 			} else {
 				switch (p_tool) {
-					case TOOL_CREATE_2D_SCENE: new_node = memnew(Node2D); break;
-					case TOOL_CREATE_3D_SCENE: new_node = memnew(Spatial); break;
+					case TOOL_CREATE_2D_SCENE:
+						new_node = memnew(Node2D);
+						break;
+					case TOOL_CREATE_3D_SCENE:
+						new_node = memnew(Spatial);
+						break;
 					case TOOL_CREATE_USER_INTERFACE: {
 						Control *node = memnew(Control);
 						node->set_anchors_and_margins_preset(PRESET_WIDE); //more useful for resizable UIs.

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -460,8 +460,10 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 				int index = E->get()->get_index();
 
-				if (index > highest_id) highest_id = index;
-				if (index < lowest_id) lowest_id = index;
+				if (index > highest_id)
+					highest_id = index;
+				if (index < lowest_id)
+					lowest_id = index;
 
 				if (E->get()->get_parent() != common_parent)
 					common_parent = NULL;
@@ -470,8 +472,10 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (!common_parent || (MOVING_DOWN && highest_id >= common_parent->get_child_count() - MOVING_DOWN) || (MOVING_UP && lowest_id == 0))
 				break; // one or more nodes can not be moved
 
-			if (selection.size() == 1) editor_data->get_undo_redo().create_action(TTR("Move Node In Parent"));
-			if (selection.size() > 1) editor_data->get_undo_redo().create_action(TTR("Move Nodes In Parent"));
+			if (selection.size() == 1)
+				editor_data->get_undo_redo().create_action(TTR("Move Node In Parent"));
+			if (selection.size() > 1)
+				editor_data->get_undo_redo().create_action(TTR("Move Nodes In Parent"));
 
 			for (int i = 0; i < selection.size(); i++) {
 				Node *top_node = selection[i];

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -139,11 +139,14 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 
 	String p = p_path.strip_edges();
 
-	if (p == "") return TTR("Path is empty.");
-	if (p.get_file().get_basename() == "") return TTR("Filename is empty.");
+	if (p == "")
+		return TTR("Path is empty.");
+	if (p.get_file().get_basename() == "")
+		return TTR("Filename is empty.");
 
 	p = ProjectSettings::get_singleton()->localize_path(p);
-	if (!p.begins_with("res://")) return TTR("Path is not local.");
+	if (!p.begins_with("res://"))
+		return TTR("Path is not local.");
 
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	if (d->change_dir(p.get_base_dir()) != OK) {
@@ -188,12 +191,15 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 		index++;
 	}
 
-	if (!found) return TTR("Invalid extension.");
-	if (!match) return TTR("Wrong extension chosen.");
+	if (!found)
+		return TTR("Invalid extension.");
+	if (!match)
+		return TTR("Wrong extension chosen.");
 
 	/* Let ScriptLanguage do custom validation */
 	String path_error = ScriptServer::get_language(language_menu->get_selected())->validate_path(p);
-	if (path_error != "") return path_error;
+	if (path_error != "")
+		return path_error;
 
 	/* All checks passed */
 	return "";

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -197,7 +197,8 @@ public:
 
 void ScriptEditorDebugger::debug_copy() {
 	String msg = reason->get_text();
-	if (msg == "") return;
+	if (msg == "")
+		return;
 	OS::get_singleton()->set_clipboard(msg);
 }
 

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -414,7 +414,8 @@ bool EditorSpatialGizmo::intersect_frustum(const Camera *p_camera, const Vector<
 	ERR_FAIL_COND_V(!spatial_node, false);
 	ERR_FAIL_COND_V(!valid, false);
 
-	if (hidden && !gizmo_plugin->is_selectable_when_hidden()) return false;
+	if (hidden && !gizmo_plugin->is_selectable_when_hidden())
+		return false;
 
 	if (selectable_icon_size > 0.0f) {
 		Vector3 origin = spatial_node->get_global_transform().get_origin();
@@ -455,10 +456,12 @@ bool EditorSpatialGizmo::intersect_frustum(const Camera *p_camera, const Vector<
 					break;
 				}
 			}
-			if (any_out) break;
+			if (any_out)
+				break;
 		}
 
-		if (!any_out) return true;
+		if (!any_out)
+			return true;
 	}
 
 	if (collision_mesh.is_valid()) {
@@ -488,7 +491,8 @@ bool EditorSpatialGizmo::intersect_ray(Camera *p_camera, const Point2 &p_point, 
 	ERR_FAIL_COND_V(!spatial_node, false);
 	ERR_FAIL_COND_V(!valid, false);
 
-	if (hidden && !gizmo_plugin->is_selectable_when_hidden()) return false;
+	if (hidden && !gizmo_plugin->is_selectable_when_hidden())
+		return false;
 
 	if (r_gizmo_handle && !hidden) {
 
@@ -771,7 +775,8 @@ EditorSpatialGizmo::EditorSpatialGizmo() {
 
 EditorSpatialGizmo::~EditorSpatialGizmo() {
 
-	if (gizmo_plugin != NULL) gizmo_plugin->unregister_gizmo(this);
+	if (gizmo_plugin != NULL)
+		gizmo_plugin->unregister_gizmo(this);
 	clear();
 }
 

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -2270,12 +2270,18 @@ int VisibilityNotifierGizmoPlugin::get_priority() const {
 String VisibilityNotifierGizmoPlugin::get_handle_name(const EditorSpatialGizmo *p_gizmo, int p_idx) const {
 
 	switch (p_idx) {
-		case 0: return "Size X";
-		case 1: return "Size Y";
-		case 2: return "Size Z";
-		case 3: return "Pos X";
-		case 4: return "Pos Y";
-		case 5: return "Pos Z";
+		case 0:
+			return "Size X";
+		case 1:
+			return "Size Y";
+		case 2:
+			return "Size Z";
+		case 3:
+			return "Pos X";
+		case 4:
+			return "Pos Y";
+		case 5:
+			return "Pos Z";
 	}
 
 	return "";
@@ -2428,12 +2434,18 @@ bool ParticlesGizmoPlugin::is_selectable_when_hidden() const {
 String ParticlesGizmoPlugin::get_handle_name(const EditorSpatialGizmo *p_gizmo, int p_idx) const {
 
 	switch (p_idx) {
-		case 0: return "Size X";
-		case 1: return "Size Y";
-		case 2: return "Size Z";
-		case 3: return "Pos X";
-		case 4: return "Pos Y";
-		case 5: return "Pos Z";
+		case 0:
+			return "Size X";
+		case 1:
+			return "Size Y";
+		case 2:
+			return "Size Z";
+		case 3:
+			return "Pos X";
+		case 4:
+			return "Pos Y";
+		case 5:
+			return "Pos Z";
 	}
 
 	return "";
@@ -2587,12 +2599,18 @@ int ReflectionProbeGizmoPlugin::get_priority() const {
 String ReflectionProbeGizmoPlugin::get_handle_name(const EditorSpatialGizmo *p_gizmo, int p_idx) const {
 
 	switch (p_idx) {
-		case 0: return "Extents X";
-		case 1: return "Extents Y";
-		case 2: return "Extents Z";
-		case 3: return "Origin X";
-		case 4: return "Origin Y";
-		case 5: return "Origin Z";
+		case 0:
+			return "Extents X";
+		case 1:
+			return "Extents Y";
+		case 2:
+			return "Extents Z";
+		case 3:
+			return "Origin X";
+		case 4:
+			return "Origin Y";
+		case 5:
+			return "Origin Z";
 	}
 
 	return "";
@@ -2767,9 +2785,12 @@ int GIProbeGizmoPlugin::get_priority() const {
 String GIProbeGizmoPlugin::get_handle_name(const EditorSpatialGizmo *p_gizmo, int p_idx) const {
 
 	switch (p_idx) {
-		case 0: return "Extents X";
-		case 1: return "Extents Y";
-		case 2: return "Extents Z";
+		case 0:
+			return "Extents X";
+		case 1:
+			return "Extents Y";
+		case 2:
+			return "Extents Z";
 	}
 
 	return "";
@@ -2932,9 +2953,12 @@ BakedIndirectLightGizmoPlugin::BakedIndirectLightGizmoPlugin() {
 String BakedIndirectLightGizmoPlugin::get_handle_name(const EditorSpatialGizmo *p_gizmo, int p_idx) const {
 
 	switch (p_idx) {
-		case 0: return "Extents X";
-		case 1: return "Extents Y";
-		case 2: return "Extents Z";
+		case 0:
+			return "Extents X";
+		case 1:
+			return "Extents Y";
+		case 2:
+			return "Extents Z";
 	}
 
 	return "";

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1996,7 +1996,8 @@ bool Main::iteration() {
 		uint64_t time_step = 1000000L / target_fps;
 		target_ticks += time_step;
 		uint64_t current_ticks = OS::get_singleton()->get_ticks_usec();
-		if (current_ticks < target_ticks) OS::get_singleton()->delay_usec(target_ticks - current_ticks);
+		if (current_ticks < target_ticks)
+			OS::get_singleton()->delay_usec(target_ticks - current_ticks);
 		current_ticks = OS::get_singleton()->get_ticks_usec();
 		target_ticks = MIN(MAX(target_ticks, current_ticks - time_step), current_ticks + time_step);
 	}

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -129,35 +129,64 @@ String Performance::get_monitor_name(Monitor p_monitor) const {
 float Performance::get_monitor(Monitor p_monitor) const {
 
 	switch (p_monitor) {
-		case TIME_FPS: return Engine::get_singleton()->get_frames_per_second();
-		case TIME_PROCESS: return _process_time;
-		case TIME_PHYSICS_PROCESS: return _physics_process_time;
-		case MEMORY_STATIC: return Memory::get_mem_usage();
-		case MEMORY_DYNAMIC: return MemoryPool::total_memory;
-		case MEMORY_STATIC_MAX: return Memory::get_mem_max_usage();
-		case MEMORY_DYNAMIC_MAX: return MemoryPool::max_memory;
-		case MEMORY_MESSAGE_BUFFER_MAX: return MessageQueue::get_singleton()->get_max_buffer_usage();
-		case OBJECT_COUNT: return ObjectDB::get_object_count();
-		case OBJECT_RESOURCE_COUNT: return ResourceCache::get_cached_resource_count();
-		case OBJECT_NODE_COUNT: return _get_node_count();
-		case OBJECT_ORPHAN_NODE_COUNT: return Node::orphan_node_count;
-		case RENDER_OBJECTS_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_OBJECTS_IN_FRAME);
-		case RENDER_VERTICES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_VERTICES_IN_FRAME);
-		case RENDER_MATERIAL_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_MATERIAL_CHANGES_IN_FRAME);
-		case RENDER_SHADER_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_SHADER_CHANGES_IN_FRAME);
-		case RENDER_SURFACE_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_SURFACE_CHANGES_IN_FRAME);
-		case RENDER_DRAW_CALLS_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_DRAW_CALLS_IN_FRAME);
-		case RENDER_VIDEO_MEM_USED: return VS::get_singleton()->get_render_info(VS::INFO_VIDEO_MEM_USED);
-		case RENDER_TEXTURE_MEM_USED: return VS::get_singleton()->get_render_info(VS::INFO_TEXTURE_MEM_USED);
-		case RENDER_VERTEX_MEM_USED: return VS::get_singleton()->get_render_info(VS::INFO_VERTEX_MEM_USED);
-		case RENDER_USAGE_VIDEO_MEM_TOTAL: return VS::get_singleton()->get_render_info(VS::INFO_USAGE_VIDEO_MEM_TOTAL);
-		case PHYSICS_2D_ACTIVE_OBJECTS: return Physics2DServer::get_singleton()->get_process_info(Physics2DServer::INFO_ACTIVE_OBJECTS);
-		case PHYSICS_2D_COLLISION_PAIRS: return Physics2DServer::get_singleton()->get_process_info(Physics2DServer::INFO_COLLISION_PAIRS);
-		case PHYSICS_2D_ISLAND_COUNT: return Physics2DServer::get_singleton()->get_process_info(Physics2DServer::INFO_ISLAND_COUNT);
-		case PHYSICS_3D_ACTIVE_OBJECTS: return PhysicsServer::get_singleton()->get_process_info(PhysicsServer::INFO_ACTIVE_OBJECTS);
-		case PHYSICS_3D_COLLISION_PAIRS: return PhysicsServer::get_singleton()->get_process_info(PhysicsServer::INFO_COLLISION_PAIRS);
-		case PHYSICS_3D_ISLAND_COUNT: return PhysicsServer::get_singleton()->get_process_info(PhysicsServer::INFO_ISLAND_COUNT);
-		case AUDIO_OUTPUT_LATENCY: return AudioServer::get_singleton()->get_output_latency();
+		case TIME_FPS:
+			return Engine::get_singleton()->get_frames_per_second();
+		case TIME_PROCESS:
+			return _process_time;
+		case TIME_PHYSICS_PROCESS:
+			return _physics_process_time;
+		case MEMORY_STATIC:
+			return Memory::get_mem_usage();
+		case MEMORY_DYNAMIC:
+			return MemoryPool::total_memory;
+		case MEMORY_STATIC_MAX:
+			return Memory::get_mem_max_usage();
+		case MEMORY_DYNAMIC_MAX:
+			return MemoryPool::max_memory;
+		case MEMORY_MESSAGE_BUFFER_MAX:
+			return MessageQueue::get_singleton()->get_max_buffer_usage();
+		case OBJECT_COUNT:
+			return ObjectDB::get_object_count();
+		case OBJECT_RESOURCE_COUNT:
+			return ResourceCache::get_cached_resource_count();
+		case OBJECT_NODE_COUNT:
+			return _get_node_count();
+		case OBJECT_ORPHAN_NODE_COUNT:
+			return Node::orphan_node_count;
+		case RENDER_OBJECTS_IN_FRAME:
+			return VS::get_singleton()->get_render_info(VS::INFO_OBJECTS_IN_FRAME);
+		case RENDER_VERTICES_IN_FRAME:
+			return VS::get_singleton()->get_render_info(VS::INFO_VERTICES_IN_FRAME);
+		case RENDER_MATERIAL_CHANGES_IN_FRAME:
+			return VS::get_singleton()->get_render_info(VS::INFO_MATERIAL_CHANGES_IN_FRAME);
+		case RENDER_SHADER_CHANGES_IN_FRAME:
+			return VS::get_singleton()->get_render_info(VS::INFO_SHADER_CHANGES_IN_FRAME);
+		case RENDER_SURFACE_CHANGES_IN_FRAME:
+			return VS::get_singleton()->get_render_info(VS::INFO_SURFACE_CHANGES_IN_FRAME);
+		case RENDER_DRAW_CALLS_IN_FRAME:
+			return VS::get_singleton()->get_render_info(VS::INFO_DRAW_CALLS_IN_FRAME);
+		case RENDER_VIDEO_MEM_USED:
+			return VS::get_singleton()->get_render_info(VS::INFO_VIDEO_MEM_USED);
+		case RENDER_TEXTURE_MEM_USED:
+			return VS::get_singleton()->get_render_info(VS::INFO_TEXTURE_MEM_USED);
+		case RENDER_VERTEX_MEM_USED:
+			return VS::get_singleton()->get_render_info(VS::INFO_VERTEX_MEM_USED);
+		case RENDER_USAGE_VIDEO_MEM_TOTAL:
+			return VS::get_singleton()->get_render_info(VS::INFO_USAGE_VIDEO_MEM_TOTAL);
+		case PHYSICS_2D_ACTIVE_OBJECTS:
+			return Physics2DServer::get_singleton()->get_process_info(Physics2DServer::INFO_ACTIVE_OBJECTS);
+		case PHYSICS_2D_COLLISION_PAIRS:
+			return Physics2DServer::get_singleton()->get_process_info(Physics2DServer::INFO_COLLISION_PAIRS);
+		case PHYSICS_2D_ISLAND_COUNT:
+			return Physics2DServer::get_singleton()->get_process_info(Physics2DServer::INFO_ISLAND_COUNT);
+		case PHYSICS_3D_ACTIVE_OBJECTS:
+			return PhysicsServer::get_singleton()->get_process_info(PhysicsServer::INFO_ACTIVE_OBJECTS);
+		case PHYSICS_3D_COLLISION_PAIRS:
+			return PhysicsServer::get_singleton()->get_process_info(PhysicsServer::INFO_COLLISION_PAIRS);
+		case PHYSICS_3D_ISLAND_COUNT:
+			return PhysicsServer::get_singleton()->get_process_info(PhysicsServer::INFO_ISLAND_COUNT);
+		case AUDIO_OUTPUT_LATENCY:
+			return AudioServer::get_singleton()->get_output_latency();
 
 		default: {
 		}

--- a/main/tests/test_math.cpp
+++ b/main/tests/test_math.cpp
@@ -199,14 +199,24 @@ class GetClassAndNamespace {
 
 							switch (next) {
 
-								case 'b': res = 8; break;
-								case 't': res = 9; break;
-								case 'n': res = 10; break;
-								case 'f': res = 12; break;
+								case 'b':
+									res = 8;
+									break;
+								case 't':
+									res = 9;
+									break;
+								case 'n':
+									res = 10;
+									break;
+								case 'f':
+									res = 12;
+									break;
 								case 'r':
 									res = 13;
 									break;
-								case '\"': res = '\"'; break;
+								case '\"':
+									res = '\"';
+									break;
 								case '\\':
 									res = '\\';
 									break;

--- a/main/tests/test_shader_lang.cpp
+++ b/main/tests/test_shader_lang.cpp
@@ -61,10 +61,14 @@ static String _typestr(SL::DataType p_type) {
 static String _prestr(SL::DataPrecision p_pres) {
 
 	switch (p_pres) {
-		case SL::PRECISION_LOWP: return "lowp ";
-		case SL::PRECISION_MEDIUMP: return "mediump ";
-		case SL::PRECISION_HIGHP: return "highp ";
-		case SL::PRECISION_DEFAULT: return "";
+		case SL::PRECISION_LOWP:
+			return "lowp ";
+		case SL::PRECISION_MEDIUMP:
+			return "mediump ";
+		case SL::PRECISION_HIGHP:
+			return "highp ";
+		case SL::PRECISION_DEFAULT:
+			return "";
 	}
 	return "";
 }
@@ -77,23 +81,40 @@ static String _opstr(SL::Operator p_op) {
 static String get_constant_text(SL::DataType p_type, const Vector<SL::ConstantNode::Value> &p_values) {
 
 	switch (p_type) {
-		case SL::TYPE_BOOL: return p_values[0].boolean ? "true" : "false";
-		case SL::TYPE_BVEC2: return String() + "bvec2(" + (p_values[0].boolean ? "true" : "false") + (p_values[1].boolean ? "true" : "false") + ")";
-		case SL::TYPE_BVEC3: return String() + "bvec3(" + (p_values[0].boolean ? "true" : "false") + "," + (p_values[1].boolean ? "true" : "false") + "," + (p_values[2].boolean ? "true" : "false") + ")";
-		case SL::TYPE_BVEC4: return String() + "bvec4(" + (p_values[0].boolean ? "true" : "false") + "," + (p_values[1].boolean ? "true" : "false") + "," + (p_values[2].boolean ? "true" : "false") + "," + (p_values[3].boolean ? "true" : "false") + ")";
-		case SL::TYPE_INT: return rtos(p_values[0].sint);
-		case SL::TYPE_IVEC2: return String() + "ivec2(" + rtos(p_values[0].sint) + "," + rtos(p_values[1].sint) + ")";
-		case SL::TYPE_IVEC3: return String() + "ivec3(" + rtos(p_values[0].sint) + "," + rtos(p_values[1].sint) + "," + rtos(p_values[2].sint) + ")";
-		case SL::TYPE_IVEC4: return String() + "ivec4(" + rtos(p_values[0].sint) + "," + rtos(p_values[1].sint) + "," + rtos(p_values[2].sint) + "," + rtos(p_values[3].sint) + ")";
-		case SL::TYPE_UINT: return rtos(p_values[0].real);
-		case SL::TYPE_UVEC2: return String() + "uvec2(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + ")";
-		case SL::TYPE_UVEC3: return String() + "uvec3(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + "," + rtos(p_values[2].real) + ")";
-		case SL::TYPE_UVEC4: return String() + "uvec4(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + "," + rtos(p_values[2].real) + "," + rtos(p_values[3].real) + ")";
-		case SL::TYPE_FLOAT: return rtos(p_values[0].real);
-		case SL::TYPE_VEC2: return String() + "vec2(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + ")";
-		case SL::TYPE_VEC3: return String() + "vec3(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + "," + rtos(p_values[2].real) + ")";
-		case SL::TYPE_VEC4: return String() + "vec4(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + "," + rtos(p_values[2].real) + "," + rtos(p_values[3].real) + ")";
-		default: ERR_FAIL_V(String());
+		case SL::TYPE_BOOL:
+			return p_values[0].boolean ? "true" : "false";
+		case SL::TYPE_BVEC2:
+			return String() + "bvec2(" + (p_values[0].boolean ? "true" : "false") + (p_values[1].boolean ? "true" : "false") + ")";
+		case SL::TYPE_BVEC3:
+			return String() + "bvec3(" + (p_values[0].boolean ? "true" : "false") + "," + (p_values[1].boolean ? "true" : "false") + "," + (p_values[2].boolean ? "true" : "false") + ")";
+		case SL::TYPE_BVEC4:
+			return String() + "bvec4(" + (p_values[0].boolean ? "true" : "false") + "," + (p_values[1].boolean ? "true" : "false") + "," + (p_values[2].boolean ? "true" : "false") + "," + (p_values[3].boolean ? "true" : "false") + ")";
+		case SL::TYPE_INT:
+			return rtos(p_values[0].sint);
+		case SL::TYPE_IVEC2:
+			return String() + "ivec2(" + rtos(p_values[0].sint) + "," + rtos(p_values[1].sint) + ")";
+		case SL::TYPE_IVEC3:
+			return String() + "ivec3(" + rtos(p_values[0].sint) + "," + rtos(p_values[1].sint) + "," + rtos(p_values[2].sint) + ")";
+		case SL::TYPE_IVEC4:
+			return String() + "ivec4(" + rtos(p_values[0].sint) + "," + rtos(p_values[1].sint) + "," + rtos(p_values[2].sint) + "," + rtos(p_values[3].sint) + ")";
+		case SL::TYPE_UINT:
+			return rtos(p_values[0].real);
+		case SL::TYPE_UVEC2:
+			return String() + "uvec2(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + ")";
+		case SL::TYPE_UVEC3:
+			return String() + "uvec3(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + "," + rtos(p_values[2].real) + ")";
+		case SL::TYPE_UVEC4:
+			return String() + "uvec4(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + "," + rtos(p_values[2].real) + "," + rtos(p_values[3].real) + ")";
+		case SL::TYPE_FLOAT:
+			return rtos(p_values[0].real);
+		case SL::TYPE_VEC2:
+			return String() + "vec2(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + ")";
+		case SL::TYPE_VEC3:
+			return String() + "vec3(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + "," + rtos(p_values[2].real) + ")";
+		case SL::TYPE_VEC4:
+			return String() + "vec4(" + rtos(p_values[0].real) + "," + rtos(p_values[1].real) + "," + rtos(p_values[2].real) + "," + rtos(p_values[3].real) + ")";
+		default:
+			ERR_FAIL_V(String());
 	}
 }
 

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -963,22 +963,26 @@ bool test_31() {
 	String a = "";
 	success = a[0] == 0;
 	OS::get_singleton()->print("Is 0 String[0]:, %s\n", success ? "OK" : "FAIL");
-	if (!success) state = false;
+	if (!success)
+		state = false;
 
 	String b = "Godot";
 	success = b[b.size()] == 0;
 	OS::get_singleton()->print("Is 0 String[size()]:, %s\n", success ? "OK" : "FAIL");
-	if (!success) state = false;
+	if (!success)
+		state = false;
 
 	const String c = "";
 	success = c[0] == 0;
 	OS::get_singleton()->print("Is 0 const String[0]:, %s\n", success ? "OK" : "FAIL");
-	if (!success) state = false;
+	if (!success)
+		state = false;
 
 	const String d = "Godot";
 	success = d[d.size()] == 0;
 	OS::get_singleton()->print("Is 0 const String[size()]:, %s\n", success ? "OK" : "FAIL");
-	if (!success) state = false;
+	if (!success)
+		state = false;
 
 	return state;
 };

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -719,20 +719,34 @@ void EditorSceneImporterAssimp::_import_animation(ImportState &state, int p_anim
 
 float EditorSceneImporterAssimp::_get_fbx_fps(int32_t time_mode, const aiScene *p_scene) {
 	switch (time_mode) {
-		case AssetImportFbx::TIME_MODE_DEFAULT: return 24; //hack
-		case AssetImportFbx::TIME_MODE_120: return 120;
-		case AssetImportFbx::TIME_MODE_100: return 100;
-		case AssetImportFbx::TIME_MODE_60: return 60;
-		case AssetImportFbx::TIME_MODE_50: return 50;
-		case AssetImportFbx::TIME_MODE_48: return 48;
-		case AssetImportFbx::TIME_MODE_30: return 30;
-		case AssetImportFbx::TIME_MODE_30_DROP: return 30;
-		case AssetImportFbx::TIME_MODE_NTSC_DROP_FRAME: return 29.9700262f;
-		case AssetImportFbx::TIME_MODE_NTSC_FULL_FRAME: return 29.9700262f;
-		case AssetImportFbx::TIME_MODE_PAL: return 25;
-		case AssetImportFbx::TIME_MODE_CINEMA: return 24;
-		case AssetImportFbx::TIME_MODE_1000: return 1000;
-		case AssetImportFbx::TIME_MODE_CINEMA_ND: return 23.976f;
+		case AssetImportFbx::TIME_MODE_DEFAULT:
+			return 24; //hack
+		case AssetImportFbx::TIME_MODE_120:
+			return 120;
+		case AssetImportFbx::TIME_MODE_100:
+			return 100;
+		case AssetImportFbx::TIME_MODE_60:
+			return 60;
+		case AssetImportFbx::TIME_MODE_50:
+			return 50;
+		case AssetImportFbx::TIME_MODE_48:
+			return 48;
+		case AssetImportFbx::TIME_MODE_30:
+			return 30;
+		case AssetImportFbx::TIME_MODE_30_DROP:
+			return 30;
+		case AssetImportFbx::TIME_MODE_NTSC_DROP_FRAME:
+			return 29.9700262f;
+		case AssetImportFbx::TIME_MODE_NTSC_FULL_FRAME:
+			return 29.9700262f;
+		case AssetImportFbx::TIME_MODE_PAL:
+			return 25;
+		case AssetImportFbx::TIME_MODE_CINEMA:
+			return 24;
+		case AssetImportFbx::TIME_MODE_1000:
+			return 1000;
+		case AssetImportFbx::TIME_MODE_CINEMA_ND:
+			return 23.976f;
 		case AssetImportFbx::TIME_MODE_CUSTOM:
 			int32_t frame_rate;
 			p_scene->mMetaData->Get("FrameRate", frame_rate);

--- a/modules/bullet/hinge_joint_bullet.cpp
+++ b/modules/bullet/hinge_joint_bullet.cpp
@@ -159,7 +159,8 @@ void HingeJointBullet::set_flag(PhysicsServer::HingeJointFlag p_flag, bool p_val
 		case PhysicsServer::HINGE_JOINT_FLAG_ENABLE_MOTOR:
 			hingeConstraint->enableMotor(p_value);
 			break;
-		case PhysicsServer::HINGE_JOINT_FLAG_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::HINGE_JOINT_FLAG_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -81,7 +81,8 @@ void ShapeBullet::add_owner(ShapeOwnerBullet *p_owner) {
 
 void ShapeBullet::remove_owner(ShapeOwnerBullet *p_owner, bool p_permanentlyFromThisBody) {
 	Map<ShapeOwnerBullet *, int>::Element *E = owners.find(p_owner);
-	if (!E) return;
+	if (!E)
+		return;
 	E->get()--;
 	if (p_permanentlyFromThisBody || 0 >= E->get()) {
 		owners.erase(E);

--- a/modules/bullet/slider_joint_bullet.cpp
+++ b/modules/bullet/slider_joint_bullet.cpp
@@ -344,56 +344,123 @@ real_t SliderJointBullet::getLinearPos() {
 
 void SliderJointBullet::set_param(PhysicsServer::SliderJointParam p_param, real_t p_value) {
 	switch (p_param) {
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_UPPER: setUpperLinLimit(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_LOWER: setLowerLinLimit(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS: setSoftnessLimLin(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION: setRestitutionLimLin(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_DAMPING: setDampingLimLin(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS: setSoftnessDirLin(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION: setRestitutionDirLin(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_DAMPING: setDampingDirLin(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS: setSoftnessOrthoLin(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION: setRestitutionOrthoLin(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING: setDampingOrthoLin(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_UPPER: setUpperAngLimit(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_LOWER: setLowerAngLimit(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS: setSoftnessLimAng(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION: setRestitutionLimAng(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING: setDampingLimAng(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS: setSoftnessDirAng(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION: setRestitutionDirAng(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_DAMPING: setDampingDirAng(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS: setSoftnessOrthoAng(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION: setRestitutionOrthoAng(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING: setDampingOrthoAng(p_value); break;
-		case PhysicsServer::SLIDER_JOINT_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_UPPER:
+			setUpperLinLimit(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_LOWER:
+			setLowerLinLimit(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS:
+			setSoftnessLimLin(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION:
+			setRestitutionLimLin(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_DAMPING:
+			setDampingLimLin(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS:
+			setSoftnessDirLin(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION:
+			setRestitutionDirLin(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_DAMPING:
+			setDampingDirLin(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS:
+			setSoftnessOrthoLin(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION:
+			setRestitutionOrthoLin(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING:
+			setDampingOrthoLin(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_UPPER:
+			setUpperAngLimit(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_LOWER:
+			setLowerAngLimit(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS:
+			setSoftnessLimAng(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION:
+			setRestitutionLimAng(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING:
+			setDampingLimAng(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS:
+			setSoftnessDirAng(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION:
+			setRestitutionDirAng(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_DAMPING:
+			setDampingDirAng(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS:
+			setSoftnessOrthoAng(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION:
+			setRestitutionOrthoAng(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING:
+			setDampingOrthoAng(p_value);
+			break;
+		case PhysicsServer::SLIDER_JOINT_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 
 real_t SliderJointBullet::get_param(PhysicsServer::SliderJointParam p_param) const {
 	switch (p_param) {
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_UPPER: return getUpperLinLimit();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_LOWER: return getLowerLinLimit();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS: return getSoftnessLimLin();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION: return getRestitutionLimLin();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_DAMPING: return getDampingLimLin();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS: return getSoftnessDirLin();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION: return getRestitutionDirLin();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_DAMPING: return getDampingDirLin();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS: return getSoftnessOrthoLin();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION: return getRestitutionOrthoLin();
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING: return getDampingOrthoLin();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_UPPER: return getUpperAngLimit();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_LOWER: return getLowerAngLimit();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS: return getSoftnessLimAng();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION: return getRestitutionLimAng();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING: return getDampingLimAng();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS: return getSoftnessDirAng();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION: return getRestitutionDirAng();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_DAMPING: return getDampingDirAng();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS: return getSoftnessOrthoAng();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION: return getRestitutionOrthoAng();
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING: return getDampingOrthoAng();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_UPPER:
+			return getUpperLinLimit();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_LOWER:
+			return getLowerLinLimit();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS:
+			return getSoftnessLimLin();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION:
+			return getRestitutionLimLin();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_DAMPING:
+			return getDampingLimLin();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS:
+			return getSoftnessDirLin();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION:
+			return getRestitutionDirLin();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_DAMPING:
+			return getDampingDirLin();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS:
+			return getSoftnessOrthoLin();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION:
+			return getRestitutionOrthoLin();
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING:
+			return getDampingOrthoLin();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_UPPER:
+			return getUpperAngLimit();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_LOWER:
+			return getLowerAngLimit();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS:
+			return getSoftnessLimAng();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION:
+			return getRestitutionLimAng();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING:
+			return getDampingLimAng();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS:
+			return getSoftnessDirAng();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION:
+			return getRestitutionDirAng();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_DAMPING:
+			return getDampingDirAng();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS:
+			return getSoftnessOrthoAng();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION:
+			return getRestitutionOrthoAng();
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING:
+			return getDampingOrthoAng();
 		default:
 			return 0;
 	}

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -166,7 +166,8 @@ public:
 		contactDebugCount = 0;
 	}
 	_FORCE_INLINE_ void add_debug_contact(const Vector3 &p_contact) {
-		if (contactDebugCount < contactDebug.size()) contactDebug.write[contactDebugCount++] = p_contact;
+		if (contactDebugCount < contactDebug.size())
+			contactDebug.write[contactDebugCount++] = p_contact;
 	}
 	_FORCE_INLINE_ Vector<Vector3> get_debug_contacts() { return contactDebug; }
 	_FORCE_INLINE_ int get_debug_contact_count() { return contactDebugCount; }

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -80,9 +80,12 @@ Variant CSGShapeSpatialGizmoPlugin::get_handle_value(EditorSpatialGizmo *p_gizmo
 
 		CSGBox *s = Object::cast_to<CSGBox>(cs);
 		switch (p_idx) {
-			case 0: return s->get_width();
-			case 1: return s->get_height();
-			case 2: return s->get_depth();
+			case 0:
+				return s->get_width();
+			case 1:
+				return s->get_height();
+			case 2:
+				return s->get_depth();
 		}
 	}
 
@@ -139,9 +142,15 @@ void CSGShapeSpatialGizmoPlugin::set_handle(EditorSpatialGizmo *p_gizmo, int p_i
 			d = 0.001;
 
 		switch (p_idx) {
-			case 0: s->set_width(d * 2); break;
-			case 1: s->set_height(d * 2); break;
-			case 2: s->set_depth(d * 2); break;
+			case 0:
+				s->set_width(d * 2);
+				break;
+			case 1:
+				s->set_height(d * 2);
+				break;
+			case 2:
+				s->set_depth(d * 2);
+				break;
 		}
 	}
 
@@ -205,9 +214,15 @@ void CSGShapeSpatialGizmoPlugin::commit_handle(EditorSpatialGizmo *p_gizmo, int 
 		CSGBox *s = Object::cast_to<CSGBox>(cs);
 		if (p_cancel) {
 			switch (p_idx) {
-				case 0: s->set_width(p_restore); break;
-				case 1: s->set_height(p_restore); break;
-				case 2: s->set_depth(p_restore); break;
+				case 0:
+					s->set_width(p_restore);
+					break;
+				case 1:
+					s->set_height(p_restore);
+					break;
+				case 2:
+					s->set_depth(p_restore);
+					break;
 			}
 			return;
 		}
@@ -217,9 +232,15 @@ void CSGShapeSpatialGizmoPlugin::commit_handle(EditorSpatialGizmo *p_gizmo, int 
 		static const char *method[3] = { "set_width", "set_height", "set_depth" };
 		float current = 0;
 		switch (p_idx) {
-			case 0: current = s->get_width(); break;
-			case 1: current = s->get_height(); break;
-			case 2: current = s->get_depth(); break;
+			case 0:
+				current = s->get_width();
+				break;
+			case 1:
+				current = s->get_height();
+				break;
+			case 2:
+				current = s->get_depth();
+				break;
 		}
 
 		ur->add_do_method(s, method[p_idx], current);

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1794,11 +1794,15 @@ CSGBrush *CSGPolygon::_build_brush() {
 			final_polygon_min = p;
 			final_polygon_max = final_polygon_min;
 		} else {
-			if (p.x < final_polygon_min.x) final_polygon_min.x = p.x;
-			if (p.y < final_polygon_min.y) final_polygon_min.y = p.y;
+			if (p.x < final_polygon_min.x)
+				final_polygon_min.x = p.x;
+			if (p.y < final_polygon_min.y)
+				final_polygon_min.y = p.y;
 
-			if (p.x > final_polygon_max.x) final_polygon_max.x = p.x;
-			if (p.y > final_polygon_max.y) final_polygon_max.y = p.y;
+			if (p.x > final_polygon_max.x)
+				final_polygon_max.x = p.x;
+			if (p.y > final_polygon_max.y)
+				final_polygon_max.y = p.y;
 		}
 	}
 	Vector2 final_polygon_size = final_polygon_max - final_polygon_min;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -185,9 +185,15 @@ CSGBrush *CSGShape::_get_brush() {
 				CSGBrushOperation bop;
 
 				switch (child->get_operation()) {
-					case CSGShape::OPERATION_UNION: bop.merge_brushes(CSGBrushOperation::OPERATION_UNION, *n, *nn2, *nn, snap); break;
-					case CSGShape::OPERATION_INTERSECTION: bop.merge_brushes(CSGBrushOperation::OPERATION_INTERSECTION, *n, *nn2, *nn, snap); break;
-					case CSGShape::OPERATION_SUBTRACTION: bop.merge_brushes(CSGBrushOperation::OPERATION_SUBSTRACTION, *n, *nn2, *nn, snap); break;
+					case CSGShape::OPERATION_UNION:
+						bop.merge_brushes(CSGBrushOperation::OPERATION_UNION, *n, *nn2, *nn, snap);
+						break;
+					case CSGShape::OPERATION_INTERSECTION:
+						bop.merge_brushes(CSGBrushOperation::OPERATION_INTERSECTION, *n, *nn2, *nn, snap);
+						break;
+					case CSGShape::OPERATION_SUBTRACTION:
+						bop.merge_brushes(CSGBrushOperation::OPERATION_SUBSTRACTION, *n, *nn2, *nn, snap);
+						break;
 				}
 				memdelete(n);
 				memdelete(nn2);
@@ -1833,8 +1839,12 @@ CSGBrush *CSGPolygon::_build_brush() {
 	int face_count = 0;
 
 	switch (mode) {
-		case MODE_DEPTH: face_count = triangles.size() * 2 / 3 + (final_polygon.size()) * 2; break;
-		case MODE_SPIN: face_count = (spin_degrees < 360 ? triangles.size() * 2 / 3 : 0) + (final_polygon.size()) * 2 * spin_sides; break;
+		case MODE_DEPTH:
+			face_count = triangles.size() * 2 / 3 + (final_polygon.size()) * 2;
+			break;
+		case MODE_SPIN:
+			face_count = (spin_degrees < 360 ? triangles.size() * 2 / 3 : 0) + (final_polygon.size()) * 2 * spin_sides;
+			break;
 		case MODE_PATH: {
 			float bl = curve->get_baked_length();
 			int splits = MAX(2, Math::ceil(bl / path_interval));

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2055,7 +2055,8 @@ String GDScriptWarning::get_message() const {
 			CHECK_SYMBOLS(2);
 			return "The '" + symbols[0] + "' keyword is deprecated and will be removed in a future release, please replace its uses by '" + symbols[1] + "'.";
 		} break;
-		case WARNING_MAX: break; // Can't happen, but silences warning
+		case WARNING_MAX:
+			break; // Can't happen, but silences warning
 	}
 	ERR_EXPLAIN("Invalid GDScript warning code: " + get_name_from_code(code));
 	ERR_FAIL_V(String());

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -177,16 +177,36 @@ int GDScriptCompiler::_parse_assign_right_expression(CodeGen &codegen, const GDS
 
 	switch (p_expression->op) {
 
-		case GDScriptParser::OperatorNode::OP_ASSIGN_ADD: var_op = Variant::OP_ADD; break;
-		case GDScriptParser::OperatorNode::OP_ASSIGN_SUB: var_op = Variant::OP_SUBTRACT; break;
-		case GDScriptParser::OperatorNode::OP_ASSIGN_MUL: var_op = Variant::OP_MULTIPLY; break;
-		case GDScriptParser::OperatorNode::OP_ASSIGN_DIV: var_op = Variant::OP_DIVIDE; break;
-		case GDScriptParser::OperatorNode::OP_ASSIGN_MOD: var_op = Variant::OP_MODULE; break;
-		case GDScriptParser::OperatorNode::OP_ASSIGN_SHIFT_LEFT: var_op = Variant::OP_SHIFT_LEFT; break;
-		case GDScriptParser::OperatorNode::OP_ASSIGN_SHIFT_RIGHT: var_op = Variant::OP_SHIFT_RIGHT; break;
-		case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_AND: var_op = Variant::OP_BIT_AND; break;
-		case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_OR: var_op = Variant::OP_BIT_OR; break;
-		case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_XOR: var_op = Variant::OP_BIT_XOR; break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_ADD:
+			var_op = Variant::OP_ADD;
+			break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_SUB:
+			var_op = Variant::OP_SUBTRACT;
+			break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_MUL:
+			var_op = Variant::OP_MULTIPLY;
+			break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_DIV:
+			var_op = Variant::OP_DIVIDE;
+			break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_MOD:
+			var_op = Variant::OP_MODULE;
+			break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_SHIFT_LEFT:
+			var_op = Variant::OP_SHIFT_LEFT;
+			break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_SHIFT_RIGHT:
+			var_op = Variant::OP_SHIFT_RIGHT;
+			break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_AND:
+			var_op = Variant::OP_BIT_AND;
+			break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_OR:
+			var_op = Variant::OP_BIT_OR;
+			break;
+		case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_XOR:
+			var_op = Variant::OP_BIT_XOR;
+			break;
 		case GDScriptParser::OperatorNode::OP_INIT_ASSIGN:
 		case GDScriptParser::OperatorNode::OP_ASSIGN: {
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -879,71 +879,92 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				} break;
 				//unary operators
 				case GDScriptParser::OperatorNode::OP_NEG: {
-					if (!_create_unary_operator(codegen, on, Variant::OP_NEGATE, p_stack_level)) return -1;
+					if (!_create_unary_operator(codegen, on, Variant::OP_NEGATE, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_POS: {
-					if (!_create_unary_operator(codegen, on, Variant::OP_POSITIVE, p_stack_level)) return -1;
+					if (!_create_unary_operator(codegen, on, Variant::OP_POSITIVE, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_NOT: {
-					if (!_create_unary_operator(codegen, on, Variant::OP_NOT, p_stack_level)) return -1;
+					if (!_create_unary_operator(codegen, on, Variant::OP_NOT, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_BIT_INVERT: {
-					if (!_create_unary_operator(codegen, on, Variant::OP_BIT_NEGATE, p_stack_level)) return -1;
+					if (!_create_unary_operator(codegen, on, Variant::OP_BIT_NEGATE, p_stack_level))
+						return -1;
 				} break;
 				//binary operators (in precedence order)
 				case GDScriptParser::OperatorNode::OP_IN: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_IN, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_IN, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_EQUAL: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_EQUAL, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_EQUAL, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_NOT_EQUAL: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_NOT_EQUAL, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_NOT_EQUAL, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_LESS: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_LESS, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_LESS, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_LESS_EQUAL: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_LESS_EQUAL, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_LESS_EQUAL, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_GREATER: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_GREATER, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_GREATER, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_GREATER_EQUAL: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_GREATER_EQUAL, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_GREATER_EQUAL, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_ADD: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_ADD, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_ADD, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_SUB: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_SUBTRACT, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_SUBTRACT, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_MUL: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_MULTIPLY, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_MULTIPLY, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_DIV: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_DIVIDE, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_DIVIDE, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_MOD: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_MODULE, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_MODULE, p_stack_level))
+						return -1;
 				} break;
 				//case GDScriptParser::OperatorNode::OP_SHIFT_LEFT: { if (!_create_binary_operator(codegen,on,Variant::OP_SHIFT_LEFT,p_stack_level)) return -1;} break;
 				//case GDScriptParser::OperatorNode::OP_SHIFT_RIGHT: { if (!_create_binary_operator(codegen,on,Variant::OP_SHIFT_RIGHT,p_stack_level)) return -1;} break;
 				case GDScriptParser::OperatorNode::OP_BIT_AND: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_BIT_AND, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_BIT_AND, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_BIT_OR: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_BIT_OR, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_BIT_OR, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_BIT_XOR: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_BIT_XOR, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_BIT_XOR, p_stack_level))
+						return -1;
 				} break;
 				//shift
 				case GDScriptParser::OperatorNode::OP_SHIFT_LEFT: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_SHIFT_LEFT, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_SHIFT_LEFT, p_stack_level))
+						return -1;
 				} break;
 				case GDScriptParser::OperatorNode::OP_SHIFT_RIGHT: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_SHIFT_RIGHT, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_SHIFT_RIGHT, p_stack_level))
+						return -1;
 				} break;
 				//assignment operators
 				case GDScriptParser::OperatorNode::OP_ASSIGN_ADD:

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -123,10 +123,12 @@ class GDScriptCompiler {
 
 		Vector<int> opcodes;
 		void alloc_stack(int p_level) {
-			if (p_level >= stack_max) stack_max = p_level + 1;
+			if (p_level >= stack_max)
+				stack_max = p_level + 1;
 		}
 		void alloc_call(int p_params) {
-			if (p_params >= call_max) call_max = p_params;
+			if (p_params >= call_max)
+				call_max = p_params;
 		}
 
 		int current_line;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1062,16 +1062,36 @@ static bool _guess_expression_type(GDScriptCompletionContext &p_context, const G
 
 					Variant::Operator vop = Variant::OP_MAX;
 					switch (op->op) {
-						case GDScriptParser::OperatorNode::OP_ADD: vop = Variant::OP_ADD; break;
-						case GDScriptParser::OperatorNode::OP_SUB: vop = Variant::OP_SUBTRACT; break;
-						case GDScriptParser::OperatorNode::OP_MUL: vop = Variant::OP_MULTIPLY; break;
-						case GDScriptParser::OperatorNode::OP_DIV: vop = Variant::OP_DIVIDE; break;
-						case GDScriptParser::OperatorNode::OP_MOD: vop = Variant::OP_MODULE; break;
-						case GDScriptParser::OperatorNode::OP_SHIFT_LEFT: vop = Variant::OP_SHIFT_LEFT; break;
-						case GDScriptParser::OperatorNode::OP_SHIFT_RIGHT: vop = Variant::OP_SHIFT_RIGHT; break;
-						case GDScriptParser::OperatorNode::OP_BIT_AND: vop = Variant::OP_BIT_AND; break;
-						case GDScriptParser::OperatorNode::OP_BIT_OR: vop = Variant::OP_BIT_OR; break;
-						case GDScriptParser::OperatorNode::OP_BIT_XOR: vop = Variant::OP_BIT_XOR; break;
+						case GDScriptParser::OperatorNode::OP_ADD:
+							vop = Variant::OP_ADD;
+							break;
+						case GDScriptParser::OperatorNode::OP_SUB:
+							vop = Variant::OP_SUBTRACT;
+							break;
+						case GDScriptParser::OperatorNode::OP_MUL:
+							vop = Variant::OP_MULTIPLY;
+							break;
+						case GDScriptParser::OperatorNode::OP_DIV:
+							vop = Variant::OP_DIVIDE;
+							break;
+						case GDScriptParser::OperatorNode::OP_MOD:
+							vop = Variant::OP_MODULE;
+							break;
+						case GDScriptParser::OperatorNode::OP_SHIFT_LEFT:
+							vop = Variant::OP_SHIFT_LEFT;
+							break;
+						case GDScriptParser::OperatorNode::OP_SHIFT_RIGHT:
+							vop = Variant::OP_SHIFT_RIGHT;
+							break;
+						case GDScriptParser::OperatorNode::OP_BIT_AND:
+							vop = Variant::OP_BIT_AND;
+							break;
+						case GDScriptParser::OperatorNode::OP_BIT_OR:
+							vop = Variant::OP_BIT_OR;
+							break;
+						case GDScriptParser::OperatorNode::OP_BIT_XOR:
+							vop = Variant::OP_BIT_XOR;
+							break;
 						default: {
 						}
 					}

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -56,7 +56,8 @@ struct GDScriptDataType {
 	Ref<Script> script_type;
 
 	bool is_type(const Variant &p_variant, bool p_allow_implicit_conversion = false) const {
-		if (!has_type) return true; // Can't type check
+		if (!has_type)
+			return true; // Can't type check
 
 		switch (kind) {
 			case UNINITIALIZED:

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3401,7 +3401,8 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 
 				_parse_pattern_block(compiled_branches, match_node->branches, p_static);
 
-				if (error_set) return;
+				if (error_set)
+					return;
 
 				ControlFlowNode *match_cf_node = alloc_node<ControlFlowNode>();
 				match_cf_node->cf_type = ControlFlowNode::CF_MATCH;
@@ -5418,8 +5419,10 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class) {
 					}
 				}
 
-				if (base_class) break;
-				if (found) continue;
+				if (base_class)
+					break;
+				if (found)
+					continue;
 
 				if (p->constant_expressions.has(base)) {
 					if (p->constant_expressions[base].expression->type != Node::TYPE_CONSTANT) {
@@ -5519,10 +5522,12 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class) {
 }
 
 String GDScriptParser::DataType::to_string() const {
-	if (!has_type) return "var";
+	if (!has_type)
+		return "var";
 	switch (kind) {
 		case BUILTIN: {
-			if (builtin_type == Variant::NIL) return "null";
+			if (builtin_type == Variant::NIL)
+				return "null";
 			return Variant::get_type_name(builtin_type);
 		} break;
 		case NATIVE: {
@@ -5686,8 +5691,10 @@ bool GDScriptParser::_parse_type(DataType &r_type, bool p_can_be_void) {
 }
 
 GDScriptParser::DataType GDScriptParser::_resolve_type(const DataType &p_source, int p_line) {
-	if (!p_source.has_type) return p_source;
-	if (p_source.kind != DataType::UNRESOLVED) return p_source;
+	if (!p_source.has_type)
+		return p_source;
+	if (p_source.kind != DataType::UNRESOLVED)
+		return p_source;
 
 	Vector<String> full_name = p_source.native_type.operator String().split(".", false);
 	int name_part = 0;
@@ -6838,7 +6845,8 @@ bool GDScriptParser::_get_function_signature(DataType &p_base_type, const String
 		native = "_" + native.operator String();
 	}
 	if (!ClassDB::class_exists(native)) {
-		if (!check_types) return false;
+		if (!check_types)
+			return false;
 		ERR_EXPLAIN("Parser bug: Class '" + String(native) + "' not found.");
 		ERR_FAIL_V(false);
 	}
@@ -6930,7 +6938,8 @@ GDScriptParser::DataType GDScriptParser::_reduce_function_call_type(const Operat
 				par_types.write[i - 1] = _reduce_node_type(p_call->arguments[i]);
 			}
 
-			if (error_set) return DataType();
+			if (error_set)
+				return DataType();
 
 			bool match = false;
 			List<MethodInfo> constructors;
@@ -6987,7 +6996,8 @@ GDScriptParser::DataType GDScriptParser::_reduce_function_call_type(const Operat
 				err += "' matches the signature '";
 				err += Variant::get_type_name(tn->vtype) + "(";
 				for (int i = 0; i < par_types.size(); i++) {
-					if (i > 0) err += ", ";
+					if (i > 0)
+						err += ", ";
 					err += par_types[i].to_string();
 				}
 				err += ")'.";
@@ -7347,7 +7357,8 @@ bool GDScriptParser::_get_member_type(const DataType &p_base_type, const StringN
 		native = "_" + native.operator String();
 	}
 	if (!ClassDB::class_exists(native)) {
-		if (!check_types) return false;
+		if (!check_types)
+			return false;
 		ERR_EXPLAIN("Parser bug: Class '" + String(native) + "' not found.");
 		ERR_FAIL_V(false);
 	}
@@ -7634,12 +7645,14 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 	// Function declarations
 	for (int i = 0; i < p_class->static_functions.size(); i++) {
 		_check_function_types(p_class->static_functions[i]);
-		if (error_set) return;
+		if (error_set)
+			return;
 	}
 
 	for (int i = 0; i < p_class->functions.size(); i++) {
 		_check_function_types(p_class->functions[i]);
-		if (error_set) return;
+		if (error_set)
+			return;
 	}
 
 	// Class variables
@@ -7714,7 +7727,8 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 		}
 
 		// Setter and getter
-		if (v.setter == StringName() && v.getter == StringName()) continue;
+		if (v.setter == StringName() && v.getter == StringName())
+			continue;
 
 		bool found_getter = false;
 		bool found_setter = false;
@@ -7757,10 +7771,12 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 					return;
 				}
 			}
-			if (found_getter && found_setter) break;
+			if (found_getter && found_setter)
+				break;
 		}
 
-		if ((found_getter || v.getter == StringName()) && (found_setter || v.setter == StringName())) continue;
+		if ((found_getter || v.getter == StringName()) && (found_setter || v.setter == StringName()))
+			continue;
 
 		// Check for static functions
 		for (int j = 0; j < p_class->static_functions.size(); j++) {
@@ -7791,7 +7807,8 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 	for (int i = 0; i < p_class->subclasses.size(); i++) {
 		current_class = p_class->subclasses[i];
 		_check_class_level_types(current_class);
-		if (error_set) return;
+		if (error_set)
+			return;
 		current_class = p_class;
 	}
 }
@@ -7939,7 +7956,8 @@ void GDScriptParser::_check_class_blocks_types(ClassNode *p_class) {
 		_check_block_types(current_block);
 		current_block = NULL;
 		current_function = NULL;
-		if (error_set) return;
+		if (error_set)
+			return;
 	}
 
 	for (int i = 0; i < p_class->functions.size(); i++) {
@@ -7949,7 +7967,8 @@ void GDScriptParser::_check_class_blocks_types(ClassNode *p_class) {
 		_check_block_types(current_block);
 		current_block = NULL;
 		current_function = NULL;
-		if (error_set) return;
+		if (error_set)
+			return;
 	}
 
 #ifdef DEBUG_ENABLED
@@ -7970,7 +7989,8 @@ void GDScriptParser::_check_class_blocks_types(ClassNode *p_class) {
 	for (int i = 0; i < p_class->subclasses.size(); i++) {
 		current_class = p_class->subclasses[i];
 		_check_class_blocks_types(current_class);
-		if (error_set) return;
+		if (error_set)
+			return;
 		current_class = p_class;
 	}
 }
@@ -8217,7 +8237,8 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 							_add_warning(GDScriptWarning::RETURN_VALUE_DISCARDED, op->line, func_name);
 						}
 #endif // DEBUG_ENABLED
-						if (error_set) return;
+						if (error_set)
+							return;
 					} break;
 					case OperatorNode::OP_YIELD: {
 						_mark_line_as_safe(op->line);
@@ -8248,7 +8269,8 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 							}
 						}
 
-						if (!function_type.has_type) break;
+						if (!function_type.has_type)
+							break;
 
 						if (function_type.kind == DataType::BUILTIN && function_type.builtin_type == Variant::NIL) {
 							// Return void, should not have arguments
@@ -8308,7 +8330,8 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 		current_block = p_block->sub_blocks[i];
 		_check_block_types(current_block);
 		current_block = p_block;
-		if (error_set) return;
+		if (error_set)
+			return;
 	}
 
 #ifdef DEBUG_ENABLED
@@ -8438,7 +8461,8 @@ Error GDScriptParser::_parse(const String &p_base_path) {
 	current_function = NULL;
 	current_block = NULL;
 #ifdef DEBUG_ENABLED
-	if (for_completion) check_types = false;
+	if (for_completion)
+		check_types = false;
 #else
 	check_types = false;
 #endif

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -883,10 +883,18 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 			e.is_op = true;
 
 			switch (tokenizer->get_token()) {
-				case GDScriptTokenizer::TK_OP_ADD: e.op = OperatorNode::OP_POS; break;
-				case GDScriptTokenizer::TK_OP_SUB: e.op = OperatorNode::OP_NEG; break;
-				case GDScriptTokenizer::TK_OP_NOT: e.op = OperatorNode::OP_NOT; break;
-				case GDScriptTokenizer::TK_OP_BIT_INVERT: e.op = OperatorNode::OP_BIT_INVERT; break;
+				case GDScriptTokenizer::TK_OP_ADD:
+					e.op = OperatorNode::OP_POS;
+					break;
+				case GDScriptTokenizer::TK_OP_SUB:
+					e.op = OperatorNode::OP_NEG;
+					break;
+				case GDScriptTokenizer::TK_OP_NOT:
+					e.op = OperatorNode::OP_NOT;
+					break;
+				case GDScriptTokenizer::TK_OP_BIT_INVERT:
+					e.op = OperatorNode::OP_BIT_INVERT;
+					break;
 				default: {
 				}
 			}
@@ -1309,25 +1317,55 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 
 		switch (tokenizer->get_token()) { //see operator
 
-			case GDScriptTokenizer::TK_OP_IN: op = OperatorNode::OP_IN; break;
-			case GDScriptTokenizer::TK_OP_EQUAL: op = OperatorNode::OP_EQUAL; break;
-			case GDScriptTokenizer::TK_OP_NOT_EQUAL: op = OperatorNode::OP_NOT_EQUAL; break;
-			case GDScriptTokenizer::TK_OP_LESS: op = OperatorNode::OP_LESS; break;
-			case GDScriptTokenizer::TK_OP_LESS_EQUAL: op = OperatorNode::OP_LESS_EQUAL; break;
-			case GDScriptTokenizer::TK_OP_GREATER: op = OperatorNode::OP_GREATER; break;
-			case GDScriptTokenizer::TK_OP_GREATER_EQUAL: op = OperatorNode::OP_GREATER_EQUAL; break;
-			case GDScriptTokenizer::TK_OP_AND: op = OperatorNode::OP_AND; break;
-			case GDScriptTokenizer::TK_OP_OR: op = OperatorNode::OP_OR; break;
-			case GDScriptTokenizer::TK_OP_ADD: op = OperatorNode::OP_ADD; break;
-			case GDScriptTokenizer::TK_OP_SUB: op = OperatorNode::OP_SUB; break;
-			case GDScriptTokenizer::TK_OP_MUL: op = OperatorNode::OP_MUL; break;
-			case GDScriptTokenizer::TK_OP_DIV: op = OperatorNode::OP_DIV; break;
+			case GDScriptTokenizer::TK_OP_IN:
+				op = OperatorNode::OP_IN;
+				break;
+			case GDScriptTokenizer::TK_OP_EQUAL:
+				op = OperatorNode::OP_EQUAL;
+				break;
+			case GDScriptTokenizer::TK_OP_NOT_EQUAL:
+				op = OperatorNode::OP_NOT_EQUAL;
+				break;
+			case GDScriptTokenizer::TK_OP_LESS:
+				op = OperatorNode::OP_LESS;
+				break;
+			case GDScriptTokenizer::TK_OP_LESS_EQUAL:
+				op = OperatorNode::OP_LESS_EQUAL;
+				break;
+			case GDScriptTokenizer::TK_OP_GREATER:
+				op = OperatorNode::OP_GREATER;
+				break;
+			case GDScriptTokenizer::TK_OP_GREATER_EQUAL:
+				op = OperatorNode::OP_GREATER_EQUAL;
+				break;
+			case GDScriptTokenizer::TK_OP_AND:
+				op = OperatorNode::OP_AND;
+				break;
+			case GDScriptTokenizer::TK_OP_OR:
+				op = OperatorNode::OP_OR;
+				break;
+			case GDScriptTokenizer::TK_OP_ADD:
+				op = OperatorNode::OP_ADD;
+				break;
+			case GDScriptTokenizer::TK_OP_SUB:
+				op = OperatorNode::OP_SUB;
+				break;
+			case GDScriptTokenizer::TK_OP_MUL:
+				op = OperatorNode::OP_MUL;
+				break;
+			case GDScriptTokenizer::TK_OP_DIV:
+				op = OperatorNode::OP_DIV;
+				break;
 			case GDScriptTokenizer::TK_OP_MOD:
 				op = OperatorNode::OP_MOD;
 				break;
 			//case GDScriptTokenizer::TK_OP_NEG: op=OperatorNode::OP_NEG ; break;
-			case GDScriptTokenizer::TK_OP_SHIFT_LEFT: op = OperatorNode::OP_SHIFT_LEFT; break;
-			case GDScriptTokenizer::TK_OP_SHIFT_RIGHT: op = OperatorNode::OP_SHIFT_RIGHT; break;
+			case GDScriptTokenizer::TK_OP_SHIFT_LEFT:
+				op = OperatorNode::OP_SHIFT_LEFT;
+				break;
+			case GDScriptTokenizer::TK_OP_SHIFT_RIGHT:
+				op = OperatorNode::OP_SHIFT_RIGHT;
+				break;
 			case GDScriptTokenizer::TK_OP_ASSIGN: {
 				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN;
 
@@ -1344,23 +1382,57 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 				}
 
 			} break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_ADD: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_ADD; break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_SUB: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_SUB; break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_MUL: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_MUL; break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_DIV: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_DIV; break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_MOD: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_MOD; break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_SHIFT_LEFT: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_SHIFT_LEFT; break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_SHIFT_RIGHT: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_SHIFT_RIGHT; break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_BIT_AND: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_BIT_AND; break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_BIT_OR: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_BIT_OR; break;
-			case GDScriptTokenizer::TK_OP_ASSIGN_BIT_XOR: _VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_BIT_XOR; break;
-			case GDScriptTokenizer::TK_OP_BIT_AND: op = OperatorNode::OP_BIT_AND; break;
-			case GDScriptTokenizer::TK_OP_BIT_OR: op = OperatorNode::OP_BIT_OR; break;
-			case GDScriptTokenizer::TK_OP_BIT_XOR: op = OperatorNode::OP_BIT_XOR; break;
-			case GDScriptTokenizer::TK_PR_IS: op = OperatorNode::OP_IS; break;
-			case GDScriptTokenizer::TK_CF_IF: op = OperatorNode::OP_TERNARY_IF; break;
-			case GDScriptTokenizer::TK_CF_ELSE: op = OperatorNode::OP_TERNARY_ELSE; break;
-			default: valid = false; break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_ADD:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_ADD;
+				break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_SUB:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_SUB;
+				break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_MUL:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_MUL;
+				break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_DIV:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_DIV;
+				break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_MOD:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_MOD;
+				break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_SHIFT_LEFT:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_SHIFT_LEFT;
+				break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_SHIFT_RIGHT:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_SHIFT_RIGHT;
+				break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_BIT_AND:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_BIT_AND;
+				break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_BIT_OR:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_BIT_OR;
+				break;
+			case GDScriptTokenizer::TK_OP_ASSIGN_BIT_XOR:
+				_VALIDATE_ASSIGN op = OperatorNode::OP_ASSIGN_BIT_XOR;
+				break;
+			case GDScriptTokenizer::TK_OP_BIT_AND:
+				op = OperatorNode::OP_BIT_AND;
+				break;
+			case GDScriptTokenizer::TK_OP_BIT_OR:
+				op = OperatorNode::OP_BIT_OR;
+				break;
+			case GDScriptTokenizer::TK_OP_BIT_XOR:
+				op = OperatorNode::OP_BIT_XOR;
+				break;
+			case GDScriptTokenizer::TK_PR_IS:
+				op = OperatorNode::OP_IS;
+				break;
+			case GDScriptTokenizer::TK_CF_IF:
+				op = OperatorNode::OP_TERNARY_IF;
+				break;
+			case GDScriptTokenizer::TK_CF_ELSE:
+				op = OperatorNode::OP_TERNARY_ELSE;
+				break;
+			default:
+				valid = false;
+				break;
 		}
 
 		if (valid) {
@@ -1416,36 +1488,74 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 					unary = true;
 					break;
 
-				case OperatorNode::OP_MUL: priority = 2; break;
-				case OperatorNode::OP_DIV: priority = 2; break;
-				case OperatorNode::OP_MOD: priority = 2; break;
+				case OperatorNode::OP_MUL:
+					priority = 2;
+					break;
+				case OperatorNode::OP_DIV:
+					priority = 2;
+					break;
+				case OperatorNode::OP_MOD:
+					priority = 2;
+					break;
 
-				case OperatorNode::OP_ADD: priority = 3; break;
-				case OperatorNode::OP_SUB: priority = 3; break;
+				case OperatorNode::OP_ADD:
+					priority = 3;
+					break;
+				case OperatorNode::OP_SUB:
+					priority = 3;
+					break;
 
-				case OperatorNode::OP_SHIFT_LEFT: priority = 4; break;
-				case OperatorNode::OP_SHIFT_RIGHT: priority = 4; break;
+				case OperatorNode::OP_SHIFT_LEFT:
+					priority = 4;
+					break;
+				case OperatorNode::OP_SHIFT_RIGHT:
+					priority = 4;
+					break;
 
-				case OperatorNode::OP_BIT_AND: priority = 5; break;
-				case OperatorNode::OP_BIT_XOR: priority = 6; break;
-				case OperatorNode::OP_BIT_OR: priority = 7; break;
+				case OperatorNode::OP_BIT_AND:
+					priority = 5;
+					break;
+				case OperatorNode::OP_BIT_XOR:
+					priority = 6;
+					break;
+				case OperatorNode::OP_BIT_OR:
+					priority = 7;
+					break;
 
-				case OperatorNode::OP_LESS: priority = 8; break;
-				case OperatorNode::OP_LESS_EQUAL: priority = 8; break;
-				case OperatorNode::OP_GREATER: priority = 8; break;
-				case OperatorNode::OP_GREATER_EQUAL: priority = 8; break;
+				case OperatorNode::OP_LESS:
+					priority = 8;
+					break;
+				case OperatorNode::OP_LESS_EQUAL:
+					priority = 8;
+					break;
+				case OperatorNode::OP_GREATER:
+					priority = 8;
+					break;
+				case OperatorNode::OP_GREATER_EQUAL:
+					priority = 8;
+					break;
 
-				case OperatorNode::OP_EQUAL: priority = 8; break;
-				case OperatorNode::OP_NOT_EQUAL: priority = 8; break;
+				case OperatorNode::OP_EQUAL:
+					priority = 8;
+					break;
+				case OperatorNode::OP_NOT_EQUAL:
+					priority = 8;
+					break;
 
-				case OperatorNode::OP_IN: priority = 10; break;
+				case OperatorNode::OP_IN:
+					priority = 10;
+					break;
 
 				case OperatorNode::OP_NOT:
 					priority = 11;
 					unary = true;
 					break;
-				case OperatorNode::OP_AND: priority = 12; break;
-				case OperatorNode::OP_OR: priority = 13; break;
+				case OperatorNode::OP_AND:
+					priority = 12;
+					break;
+				case OperatorNode::OP_OR:
+					priority = 13;
+					break;
 
 				case OperatorNode::OP_TERNARY_IF:
 					priority = 14;
@@ -1458,17 +1568,39 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 					// Rigth-to-left should be false in this case, otherwise it would always error.
 					break;
 
-				case OperatorNode::OP_ASSIGN: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_ADD: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_SUB: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_MUL: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_DIV: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_MOD: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_SHIFT_LEFT: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_SHIFT_RIGHT: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_BIT_AND: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_BIT_OR: priority = 15; break;
-				case OperatorNode::OP_ASSIGN_BIT_XOR: priority = 15; break;
+				case OperatorNode::OP_ASSIGN:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_ADD:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_SUB:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_MUL:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_DIV:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_MOD:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_SHIFT_LEFT:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_SHIFT_RIGHT:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_BIT_AND:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_BIT_OR:
+					priority = 15;
+					break;
+				case OperatorNode::OP_ASSIGN_BIT_XOR:
+					priority = 15;
+					break;
 
 				default: {
 					_set_error("GDScriptParser bug, invalid operator in expression: " + itos(expression[i].op));
@@ -3104,9 +3236,15 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 
 								ConstantNode *cn = alloc_node<ConstantNode>();
 								switch (args.size()) {
-									case 1: cn->value = (int)constants[0]; break;
-									case 2: cn->value = Vector2(constants[0], constants[1]); break;
-									case 3: cn->value = Vector3(constants[0], constants[1], constants[2]); break;
+									case 1:
+										cn->value = (int)constants[0];
+										break;
+									case 2:
+										cn->value = Vector2(constants[0], constants[1]);
+										break;
+									case 3:
+										cn->value = Vector3(constants[0], constants[1], constants[2]);
+										break;
 								}
 								cn->datatype = _type_from_variant(cn->value);
 								container = cn;
@@ -3118,9 +3256,15 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 								on->arguments.push_back(tn);
 
 								switch (args.size()) {
-									case 1: tn->vtype = Variant::INT; break;
-									case 2: tn->vtype = Variant::VECTOR2; break;
-									case 3: tn->vtype = Variant::VECTOR3; break;
+									case 1:
+										tn->vtype = Variant::INT;
+										break;
+									case 2:
+										tn->vtype = Variant::VECTOR2;
+										break;
+									case 3:
+										tn->vtype = Variant::VECTOR3;
+										break;
 								}
 
 								for (int i = 0; i < args.size(); i++) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -620,12 +620,14 @@ private:
 	void _check_block_types(BlockNode *p_block);
 	_FORCE_INLINE_ void _mark_line_as_safe(int p_line) const {
 #ifdef DEBUG_ENABLED
-		if (safe_lines) safe_lines->insert(p_line);
+		if (safe_lines)
+			safe_lines->insert(p_line);
 #endif // DEBUG_ENABLED
 	}
 	_FORCE_INLINE_ void _mark_line_as_unsafe(int p_line) const {
 #ifdef DEBUG_ENABLED
-		if (safe_lines) safe_lines->erase(p_line);
+		if (safe_lines)
+			safe_lines->erase(p_line);
 #endif // DEBUG_ENABLED
 	}
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -796,16 +796,36 @@ void GDScriptTokenizerText::_advance() {
 
 						switch (next) {
 
-							case 'a': res = 7; break;
-							case 'b': res = 8; break;
-							case 't': res = 9; break;
-							case 'n': res = 10; break;
-							case 'v': res = 11; break;
-							case 'f': res = 12; break;
-							case 'r': res = 13; break;
-							case '\'': res = '\''; break;
-							case '\"': res = '\"'; break;
-							case '\\': res = '\\'; break;
+							case 'a':
+								res = 7;
+								break;
+							case 'b':
+								res = 8;
+								break;
+							case 't':
+								res = 9;
+								break;
+							case 'n':
+								res = 10;
+								break;
+							case 'v':
+								res = 11;
+								break;
+							case 'f':
+								res = 12;
+								break;
+							case 'r':
+								res = 13;
+								break;
+							case '\'':
+								res = '\'';
+								break;
+							case '\"':
+								res = '\"';
+								break;
+							case '\\':
+								res = '\\';
+								break;
 							case '/':
 								res = '/';
 								break; //wtf

--- a/modules/mbedtls/stream_peer_mbed_tls.cpp
+++ b/modules/mbedtls/stream_peer_mbed_tls.cpp
@@ -50,7 +50,8 @@ void _print_error(int ret) {
 
 int StreamPeerMbedTLS::bio_send(void *ctx, const unsigned char *buf, size_t len) {
 
-	if (buf == NULL || len <= 0) return 0;
+	if (buf == NULL || len <= 0)
+		return 0;
 
 	StreamPeerMbedTLS *sp = (StreamPeerMbedTLS *)ctx;
 
@@ -69,7 +70,8 @@ int StreamPeerMbedTLS::bio_send(void *ctx, const unsigned char *buf, size_t len)
 
 int StreamPeerMbedTLS::bio_recv(void *ctx, unsigned char *buf, size_t len) {
 
-	if (buf == NULL || len <= 0) return 0;
+	if (buf == NULL || len <= 0)
+		return 0;
 
 	StreamPeerMbedTLS *sp = (StreamPeerMbedTLS *)ctx;
 

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -59,13 +59,19 @@ Vector3 MobileVRInterface::scale_magneto(const Vector3 &p_magnetometer) {
 	};
 
 	// adjust our min and max
-	if (mag_raw.x > mag_next_max.x) mag_next_max.x = mag_raw.x;
-	if (mag_raw.y > mag_next_max.y) mag_next_max.y = mag_raw.y;
-	if (mag_raw.z > mag_next_max.z) mag_next_max.z = mag_raw.z;
+	if (mag_raw.x > mag_next_max.x)
+		mag_next_max.x = mag_raw.x;
+	if (mag_raw.y > mag_next_max.y)
+		mag_next_max.y = mag_raw.y;
+	if (mag_raw.z > mag_next_max.z)
+		mag_next_max.z = mag_raw.z;
 
-	if (mag_raw.x < mag_next_min.x) mag_next_min.x = mag_raw.x;
-	if (mag_raw.y < mag_next_min.y) mag_next_min.y = mag_raw.y;
-	if (mag_raw.z < mag_next_min.z) mag_next_min.z = mag_raw.z;
+	if (mag_raw.x < mag_next_min.x)
+		mag_next_min.x = mag_raw.x;
+	if (mag_raw.y < mag_next_min.y)
+		mag_next_min.y = mag_raw.y;
+	if (mag_raw.z < mag_next_min.z)
+		mag_next_min.z = mag_raw.z;
 
 	// scale our x, y and z
 	if (!(mag_current_max.x - mag_current_min.x)) {

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -552,7 +552,8 @@ class BindingsGenerator {
 	const List<InternalCall>::Element *find_icall_by_name(const String &p_name, const List<InternalCall> &p_list) {
 		const List<InternalCall>::Element *it = p_list.front();
 		while (it) {
-			if (it->get().name == p_name) return it;
+			if (it->get().name == p_name)
+				return it;
 			it = it->next();
 		}
 		return NULL;

--- a/modules/mono/editor/script_class_parser.cpp
+++ b/modules/mono/editor/script_class_parser.cpp
@@ -181,14 +181,24 @@ ScriptClassParser::Token ScriptClassParser::get_token() {
 						CharType res = 0;
 
 						switch (next) {
-							case 'b': res = 8; break;
-							case 't': res = 9; break;
-							case 'n': res = 10; break;
-							case 'f': res = 12; break;
+							case 'b':
+								res = 8;
+								break;
+							case 't':
+								res = 9;
+								break;
+							case 'n':
+								res = 10;
+								break;
+							case 'f':
+								res = 12;
+								break;
 							case 'r':
 								res = 13;
 								break;
-							case '\"': res = '\"'; break;
+							case '\"':
+								res = '\"';
+								break;
 							case '\\':
 								res = '\\';
 								break;

--- a/modules/mono/mono_gd/gd_mono_field.cpp
+++ b/modules/mono/mono_gd/gd_mono_field.cpp
@@ -445,7 +445,8 @@ void GDMonoField::set_value_from_variant(MonoObject *p_object, const Variant &p_
 				case Variant::POOL_COLOR_ARRAY: {
 					SET_FROM_ARRAY(PoolColorArray);
 				} break;
-				default: break;
+				default:
+					break;
 			}
 		} break;
 

--- a/modules/opensimplex/noise_texture.cpp
+++ b/modules/opensimplex/noise_texture.cpp
@@ -132,7 +132,8 @@ Ref<Image> NoiseTexture::_generate_texture() {
 
 	update_queued = false;
 
-	if (noise.is_null()) return Ref<Image>();
+	if (noise.is_null())
+		return Ref<Image>();
 
 	Ref<Image> image;
 
@@ -191,19 +192,22 @@ Ref<OpenSimplexNoise> NoiseTexture::get_noise() {
 }
 
 void NoiseTexture::set_width(int p_width) {
-	if (p_width == size.x) return;
+	if (p_width == size.x)
+		return;
 	size.x = p_width;
 	_queue_update();
 }
 
 void NoiseTexture::set_height(int p_height) {
-	if (p_height == size.y) return;
+	if (p_height == size.y)
+		return;
 	size.y = p_height;
 	_queue_update();
 }
 
 void NoiseTexture::set_seamless(bool p_seamless) {
-	if (p_seamless == seamless) return;
+	if (p_seamless == seamless)
+		return;
 	seamless = p_seamless;
 	_queue_update();
 }
@@ -213,7 +217,8 @@ bool NoiseTexture::get_seamless() {
 }
 
 void NoiseTexture::set_as_normalmap(bool p_as_normalmap) {
-	if (p_as_normalmap == as_normalmap) return;
+	if (p_as_normalmap == as_normalmap)
+		return;
 	as_normalmap = p_as_normalmap;
 	_queue_update();
 	_change_notify();
@@ -225,7 +230,8 @@ bool NoiseTexture::is_normalmap() {
 
 void NoiseTexture::set_bump_strength(float p_bump_strength) {
 
-	if (p_bump_strength == bump_strength) return;
+	if (p_bump_strength == bump_strength)
+		return;
 	bump_strength = p_bump_strength;
 	if (as_normalmap)
 		_queue_update();

--- a/modules/opensimplex/open_simplex_noise.cpp
+++ b/modules/opensimplex/open_simplex_noise.cpp
@@ -70,25 +70,29 @@ int OpenSimplexNoise::get_seed() {
 }
 
 void OpenSimplexNoise::set_octaves(int p_octaves) {
-	if (p_octaves == octaves) return;
+	if (p_octaves == octaves)
+		return;
 	octaves = CLAMP(p_octaves, 1, 6);
 	emit_changed();
 }
 
 void OpenSimplexNoise::set_period(float p_period) {
-	if (p_period == period) return;
+	if (p_period == period)
+		return;
 	period = p_period;
 	emit_changed();
 }
 
 void OpenSimplexNoise::set_persistence(float p_persistence) {
-	if (p_persistence == persistence) return;
+	if (p_persistence == persistence)
+		return;
 	persistence = p_persistence;
 	emit_changed();
 }
 
 void OpenSimplexNoise::set_lacunarity(float p_lacunarity) {
-	if (p_lacunarity == lacunarity) return;
+	if (p_lacunarity == lacunarity)
+		return;
 	lacunarity = p_lacunarity;
 	emit_changed();
 }

--- a/modules/opus/audio_stream_opus.cpp
+++ b/modules/opus/audio_stream_opus.cpp
@@ -260,7 +260,8 @@ void AudioStreamPlaybackOpus::stop() {
 }
 
 void AudioStreamPlaybackOpus::seek(float p_time) {
-	if (!playing) return;
+	if (!playing)
+		return;
 	ogg_int64_t pcm_offset = (ogg_int64_t)(p_time * osrate);
 	bool ok = op_pcm_seek(opus_file, pcm_offset) == 0;
 	if (!ok) {

--- a/modules/pvr/texture_loader_pvr.cpp
+++ b/modules/pvr/texture_loader_pvr.cpp
@@ -111,9 +111,13 @@ RES ResourceFormatPVR::load(const String &p_path, const String &p_original_path,
 	switch (flags & 0xFF) {
 
 		case 0x18:
-		case 0xC: format = (flags & PVR_HAS_ALPHA) ? Image::FORMAT_PVRTC2A : Image::FORMAT_PVRTC2; break;
+		case 0xC:
+			format = (flags & PVR_HAS_ALPHA) ? Image::FORMAT_PVRTC2A : Image::FORMAT_PVRTC2;
+			break;
 		case 0x19:
-		case 0xD: format = (flags & PVR_HAS_ALPHA) ? Image::FORMAT_PVRTC4A : Image::FORMAT_PVRTC4; break;
+		case 0xD:
+			format = (flags & PVR_HAS_ALPHA) ? Image::FORMAT_PVRTC4A : Image::FORMAT_PVRTC4;
+			break;
 		case 0x16:
 			format = Image::FORMAT_L8;
 			break;

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -210,7 +210,8 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 
 	while (!stateflag) {
 		int ret = buffer_data();
-		if (ret == 0) break;
+		if (ret == 0)
+			break;
 		while (ogg_sync_pageout(&oy, &og) > 0) {
 			ogg_stream_state test;
 
@@ -287,7 +288,8 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 				return;
 			}
 			vorbis_p++;
-			if (vorbis_p == 3) break;
+			if (vorbis_p == 3)
+				break;
 		}
 
 		/* The header pages/packets will arrive before anything else we

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -341,74 +341,182 @@ static Color _color_from_type(Variant::Type p_type, bool dark_theme = true) {
 	Color color;
 	if (dark_theme)
 		switch (p_type) {
-			case Variant::NIL: color = Color::html("#69ecbd"); break;
+			case Variant::NIL:
+				color = Color::html("#69ecbd");
+				break;
 
-			case Variant::BOOL: color = Color::html("#8da6f0"); break;
-			case Variant::INT: color = Color::html("#7dc6ef"); break;
-			case Variant::REAL: color = Color::html("#61daf4"); break;
-			case Variant::STRING: color = Color::html("#6ba7ec"); break;
+			case Variant::BOOL:
+				color = Color::html("#8da6f0");
+				break;
+			case Variant::INT:
+				color = Color::html("#7dc6ef");
+				break;
+			case Variant::REAL:
+				color = Color::html("#61daf4");
+				break;
+			case Variant::STRING:
+				color = Color::html("#6ba7ec");
+				break;
 
-			case Variant::VECTOR2: color = Color::html("#bd91f1"); break;
-			case Variant::RECT2: color = Color::html("#f191a5"); break;
-			case Variant::VECTOR3: color = Color::html("#d67dee"); break;
-			case Variant::TRANSFORM2D: color = Color::html("#c4ec69"); break;
-			case Variant::PLANE: color = Color::html("#f77070"); break;
-			case Variant::QUAT: color = Color::html("#ec69a3"); break;
-			case Variant::AABB: color = Color::html("#ee7991"); break;
-			case Variant::BASIS: color = Color::html("#e3ec69"); break;
-			case Variant::TRANSFORM: color = Color::html("#f6a86e"); break;
+			case Variant::VECTOR2:
+				color = Color::html("#bd91f1");
+				break;
+			case Variant::RECT2:
+				color = Color::html("#f191a5");
+				break;
+			case Variant::VECTOR3:
+				color = Color::html("#d67dee");
+				break;
+			case Variant::TRANSFORM2D:
+				color = Color::html("#c4ec69");
+				break;
+			case Variant::PLANE:
+				color = Color::html("#f77070");
+				break;
+			case Variant::QUAT:
+				color = Color::html("#ec69a3");
+				break;
+			case Variant::AABB:
+				color = Color::html("#ee7991");
+				break;
+			case Variant::BASIS:
+				color = Color::html("#e3ec69");
+				break;
+			case Variant::TRANSFORM:
+				color = Color::html("#f6a86e");
+				break;
 
-			case Variant::COLOR: color = Color::html("#9dff70"); break;
-			case Variant::NODE_PATH: color = Color::html("#6993ec"); break;
-			case Variant::_RID: color = Color::html("#69ec9a"); break;
-			case Variant::OBJECT: color = Color::html("#79f3e8"); break;
-			case Variant::DICTIONARY: color = Color::html("#77edb1"); break;
+			case Variant::COLOR:
+				color = Color::html("#9dff70");
+				break;
+			case Variant::NODE_PATH:
+				color = Color::html("#6993ec");
+				break;
+			case Variant::_RID:
+				color = Color::html("#69ec9a");
+				break;
+			case Variant::OBJECT:
+				color = Color::html("#79f3e8");
+				break;
+			case Variant::DICTIONARY:
+				color = Color::html("#77edb1");
+				break;
 
-			case Variant::ARRAY: color = Color::html("#e0e0e0"); break;
-			case Variant::POOL_BYTE_ARRAY: color = Color::html("#aaf4c8"); break;
-			case Variant::POOL_INT_ARRAY: color = Color::html("#afdcf5"); break;
-			case Variant::POOL_REAL_ARRAY: color = Color::html("#97e7f8"); break;
-			case Variant::POOL_STRING_ARRAY: color = Color::html("#9dc4f2"); break;
-			case Variant::POOL_VECTOR2_ARRAY: color = Color::html("#d1b3f5"); break;
-			case Variant::POOL_VECTOR3_ARRAY: color = Color::html("#df9bf2"); break;
-			case Variant::POOL_COLOR_ARRAY: color = Color::html("#e9ff97"); break;
+			case Variant::ARRAY:
+				color = Color::html("#e0e0e0");
+				break;
+			case Variant::POOL_BYTE_ARRAY:
+				color = Color::html("#aaf4c8");
+				break;
+			case Variant::POOL_INT_ARRAY:
+				color = Color::html("#afdcf5");
+				break;
+			case Variant::POOL_REAL_ARRAY:
+				color = Color::html("#97e7f8");
+				break;
+			case Variant::POOL_STRING_ARRAY:
+				color = Color::html("#9dc4f2");
+				break;
+			case Variant::POOL_VECTOR2_ARRAY:
+				color = Color::html("#d1b3f5");
+				break;
+			case Variant::POOL_VECTOR3_ARRAY:
+				color = Color::html("#df9bf2");
+				break;
+			case Variant::POOL_COLOR_ARRAY:
+				color = Color::html("#e9ff97");
+				break;
 
 			default:
 				color.set_hsv(p_type / float(Variant::VARIANT_MAX), 0.7, 0.7);
 		}
 	else
 		switch (p_type) {
-			case Variant::NIL: color = Color::html("#25e3a0"); break;
+			case Variant::NIL:
+				color = Color::html("#25e3a0");
+				break;
 
-			case Variant::BOOL: color = Color::html("#6d8eeb"); break;
-			case Variant::INT: color = Color::html("#4fb2e9"); break;
-			case Variant::REAL: color = Color::html("#27ccf0"); break;
-			case Variant::STRING: color = Color::html("#4690e7"); break;
+			case Variant::BOOL:
+				color = Color::html("#6d8eeb");
+				break;
+			case Variant::INT:
+				color = Color::html("#4fb2e9");
+				break;
+			case Variant::REAL:
+				color = Color::html("#27ccf0");
+				break;
+			case Variant::STRING:
+				color = Color::html("#4690e7");
+				break;
 
-			case Variant::VECTOR2: color = Color::html("#ad76ee"); break;
-			case Variant::RECT2: color = Color::html("#ee758e"); break;
-			case Variant::VECTOR3: color = Color::html("#dc6aed"); break;
-			case Variant::TRANSFORM2D: color = Color::html("#96ce1a"); break;
-			case Variant::PLANE: color = Color::html("#f77070"); break;
-			case Variant::QUAT: color = Color::html("#ec69a3"); break;
-			case Variant::AABB: color = Color::html("#ee7991"); break;
-			case Variant::BASIS: color = Color::html("#b2bb19"); break;
-			case Variant::TRANSFORM: color = Color::html("#f49047"); break;
+			case Variant::VECTOR2:
+				color = Color::html("#ad76ee");
+				break;
+			case Variant::RECT2:
+				color = Color::html("#ee758e");
+				break;
+			case Variant::VECTOR3:
+				color = Color::html("#dc6aed");
+				break;
+			case Variant::TRANSFORM2D:
+				color = Color::html("#96ce1a");
+				break;
+			case Variant::PLANE:
+				color = Color::html("#f77070");
+				break;
+			case Variant::QUAT:
+				color = Color::html("#ec69a3");
+				break;
+			case Variant::AABB:
+				color = Color::html("#ee7991");
+				break;
+			case Variant::BASIS:
+				color = Color::html("#b2bb19");
+				break;
+			case Variant::TRANSFORM:
+				color = Color::html("#f49047");
+				break;
 
-			case Variant::COLOR: color = Color::html("#3cbf00"); break;
-			case Variant::NODE_PATH: color = Color::html("#6993ec"); break;
-			case Variant::_RID: color = Color::html("#2ce573"); break;
-			case Variant::OBJECT: color = Color::html("#12d5c3"); break;
-			case Variant::DICTIONARY: color = Color::html("#57e99f"); break;
+			case Variant::COLOR:
+				color = Color::html("#3cbf00");
+				break;
+			case Variant::NODE_PATH:
+				color = Color::html("#6993ec");
+				break;
+			case Variant::_RID:
+				color = Color::html("#2ce573");
+				break;
+			case Variant::OBJECT:
+				color = Color::html("#12d5c3");
+				break;
+			case Variant::DICTIONARY:
+				color = Color::html("#57e99f");
+				break;
 
-			case Variant::ARRAY: color = Color::html("#737373"); break;
-			case Variant::POOL_BYTE_ARRAY: color = Color::html("#61ea98"); break;
-			case Variant::POOL_INT_ARRAY: color = Color::html("#61baeb"); break;
-			case Variant::POOL_REAL_ARRAY: color = Color::html("#40d3f2"); break;
-			case Variant::POOL_STRING_ARRAY: color = Color::html("#609fea"); break;
-			case Variant::POOL_VECTOR2_ARRAY: color = Color::html("#9d5dea"); break;
-			case Variant::POOL_VECTOR3_ARRAY: color = Color::html("#ca5aea"); break;
-			case Variant::POOL_COLOR_ARRAY: color = Color::html("#92ba00"); break;
+			case Variant::ARRAY:
+				color = Color::html("#737373");
+				break;
+			case Variant::POOL_BYTE_ARRAY:
+				color = Color::html("#61ea98");
+				break;
+			case Variant::POOL_INT_ARRAY:
+				color = Color::html("#61baeb");
+				break;
+			case Variant::POOL_REAL_ARRAY:
+				color = Color::html("#40d3f2");
+				break;
+			case Variant::POOL_STRING_ARRAY:
+				color = Color::html("#609fea");
+				break;
+			case Variant::POOL_VECTOR2_ARRAY:
+				color = Color::html("#9d5dea");
+				break;
+			case Variant::POOL_VECTOR3_ARRAY:
+				color = Color::html("#ca5aea");
+				break;
+			case Variant::POOL_COLOR_ARRAY:
+				color = Color::html("#92ba00");
+				break;
 
 			default:
 				color.set_hsv(p_type / float(Variant::VARIANT_MAX), 0.3, 0.3);

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -386,11 +386,21 @@ Error VisualScriptExpression::_get_token(Token &r_token) {
 
 						switch (next) {
 
-							case 'b': res = 8; break;
-							case 't': res = 9; break;
-							case 'n': res = 10; break;
-							case 'f': res = 12; break;
-							case 'r': res = 13; break;
+							case 'b':
+								res = 8;
+								break;
+							case 't':
+								res = 9;
+								break;
+							case 'n':
+								res = 10;
+								break;
+							case 'f':
+								res = 12;
+								break;
+							case 'r':
+								res = 13;
+								break;
 							case 'u': {
 								//hexnumbarh - oct is deprecated
 
@@ -1011,27 +1021,69 @@ VisualScriptExpression::ENode *VisualScriptExpression::_parse_expression() {
 		Variant::Operator op = Variant::OP_MAX;
 
 		switch (tk.type) {
-			case TK_OP_IN: op = Variant::OP_IN; break;
-			case TK_OP_EQUAL: op = Variant::OP_EQUAL; break;
-			case TK_OP_NOT_EQUAL: op = Variant::OP_NOT_EQUAL; break;
-			case TK_OP_LESS: op = Variant::OP_LESS; break;
-			case TK_OP_LESS_EQUAL: op = Variant::OP_LESS_EQUAL; break;
-			case TK_OP_GREATER: op = Variant::OP_GREATER; break;
-			case TK_OP_GREATER_EQUAL: op = Variant::OP_GREATER_EQUAL; break;
-			case TK_OP_AND: op = Variant::OP_AND; break;
-			case TK_OP_OR: op = Variant::OP_OR; break;
-			case TK_OP_NOT: op = Variant::OP_NOT; break;
-			case TK_OP_ADD: op = Variant::OP_ADD; break;
-			case TK_OP_SUB: op = Variant::OP_SUBTRACT; break;
-			case TK_OP_MUL: op = Variant::OP_MULTIPLY; break;
-			case TK_OP_DIV: op = Variant::OP_DIVIDE; break;
-			case TK_OP_MOD: op = Variant::OP_MODULE; break;
-			case TK_OP_SHIFT_LEFT: op = Variant::OP_SHIFT_LEFT; break;
-			case TK_OP_SHIFT_RIGHT: op = Variant::OP_SHIFT_RIGHT; break;
-			case TK_OP_BIT_AND: op = Variant::OP_BIT_AND; break;
-			case TK_OP_BIT_OR: op = Variant::OP_BIT_OR; break;
-			case TK_OP_BIT_XOR: op = Variant::OP_BIT_XOR; break;
-			case TK_OP_BIT_INVERT: op = Variant::OP_BIT_NEGATE; break;
+			case TK_OP_IN:
+				op = Variant::OP_IN;
+				break;
+			case TK_OP_EQUAL:
+				op = Variant::OP_EQUAL;
+				break;
+			case TK_OP_NOT_EQUAL:
+				op = Variant::OP_NOT_EQUAL;
+				break;
+			case TK_OP_LESS:
+				op = Variant::OP_LESS;
+				break;
+			case TK_OP_LESS_EQUAL:
+				op = Variant::OP_LESS_EQUAL;
+				break;
+			case TK_OP_GREATER:
+				op = Variant::OP_GREATER;
+				break;
+			case TK_OP_GREATER_EQUAL:
+				op = Variant::OP_GREATER_EQUAL;
+				break;
+			case TK_OP_AND:
+				op = Variant::OP_AND;
+				break;
+			case TK_OP_OR:
+				op = Variant::OP_OR;
+				break;
+			case TK_OP_NOT:
+				op = Variant::OP_NOT;
+				break;
+			case TK_OP_ADD:
+				op = Variant::OP_ADD;
+				break;
+			case TK_OP_SUB:
+				op = Variant::OP_SUBTRACT;
+				break;
+			case TK_OP_MUL:
+				op = Variant::OP_MULTIPLY;
+				break;
+			case TK_OP_DIV:
+				op = Variant::OP_DIVIDE;
+				break;
+			case TK_OP_MOD:
+				op = Variant::OP_MODULE;
+				break;
+			case TK_OP_SHIFT_LEFT:
+				op = Variant::OP_SHIFT_LEFT;
+				break;
+			case TK_OP_SHIFT_RIGHT:
+				op = Variant::OP_SHIFT_RIGHT;
+				break;
+			case TK_OP_BIT_AND:
+				op = Variant::OP_BIT_AND;
+				break;
+			case TK_OP_BIT_OR:
+				op = Variant::OP_BIT_OR;
+				break;
+			case TK_OP_BIT_XOR:
+				op = Variant::OP_BIT_XOR;
+				break;
+			case TK_OP_BIT_INVERT:
+				op = Variant::OP_BIT_NEGATE;
+				break;
 			default: {
 			};
 		}
@@ -1080,36 +1132,74 @@ VisualScriptExpression::ENode *VisualScriptExpression::_parse_expression() {
 					unary = true;
 					break;
 
-				case Variant::OP_MULTIPLY: priority = 2; break;
-				case Variant::OP_DIVIDE: priority = 2; break;
-				case Variant::OP_MODULE: priority = 2; break;
+				case Variant::OP_MULTIPLY:
+					priority = 2;
+					break;
+				case Variant::OP_DIVIDE:
+					priority = 2;
+					break;
+				case Variant::OP_MODULE:
+					priority = 2;
+					break;
 
-				case Variant::OP_ADD: priority = 3; break;
-				case Variant::OP_SUBTRACT: priority = 3; break;
+				case Variant::OP_ADD:
+					priority = 3;
+					break;
+				case Variant::OP_SUBTRACT:
+					priority = 3;
+					break;
 
-				case Variant::OP_SHIFT_LEFT: priority = 4; break;
-				case Variant::OP_SHIFT_RIGHT: priority = 4; break;
+				case Variant::OP_SHIFT_LEFT:
+					priority = 4;
+					break;
+				case Variant::OP_SHIFT_RIGHT:
+					priority = 4;
+					break;
 
-				case Variant::OP_BIT_AND: priority = 5; break;
-				case Variant::OP_BIT_XOR: priority = 6; break;
-				case Variant::OP_BIT_OR: priority = 7; break;
+				case Variant::OP_BIT_AND:
+					priority = 5;
+					break;
+				case Variant::OP_BIT_XOR:
+					priority = 6;
+					break;
+				case Variant::OP_BIT_OR:
+					priority = 7;
+					break;
 
-				case Variant::OP_LESS: priority = 8; break;
-				case Variant::OP_LESS_EQUAL: priority = 8; break;
-				case Variant::OP_GREATER: priority = 8; break;
-				case Variant::OP_GREATER_EQUAL: priority = 8; break;
+				case Variant::OP_LESS:
+					priority = 8;
+					break;
+				case Variant::OP_LESS_EQUAL:
+					priority = 8;
+					break;
+				case Variant::OP_GREATER:
+					priority = 8;
+					break;
+				case Variant::OP_GREATER_EQUAL:
+					priority = 8;
+					break;
 
-				case Variant::OP_EQUAL: priority = 8; break;
-				case Variant::OP_NOT_EQUAL: priority = 8; break;
+				case Variant::OP_EQUAL:
+					priority = 8;
+					break;
+				case Variant::OP_NOT_EQUAL:
+					priority = 8;
+					break;
 
-				case Variant::OP_IN: priority = 10; break;
+				case Variant::OP_IN:
+					priority = 10;
+					break;
 
 				case Variant::OP_NOT:
 					priority = 11;
 					unary = true;
 					break;
-				case Variant::OP_AND: priority = 12; break;
-				case Variant::OP_OR: priority = 13; break;
+				case Variant::OP_AND:
+					priority = 12;
+					break;
+				case Variant::OP_OR:
+					priority = 13;
+					break;
 
 				default: {
 					_set_error("Parser bug, invalid operator in expression: " + itos(expression[i].op));

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -81,10 +81,18 @@ String VisualScriptYield::get_caption() const {
 String VisualScriptYield::get_text() const {
 
 	switch (yield_mode) {
-		case YIELD_RETURN: return ""; break;
-		case YIELD_FRAME: return "Next Frame"; break;
-		case YIELD_PHYSICS_FRAME: return "Next Physics Frame"; break;
-		case YIELD_WAIT: return rtos(wait_time) + " sec(s)"; break;
+		case YIELD_RETURN:
+			return "";
+			break;
+		case YIELD_FRAME:
+			return "Next Frame";
+			break;
+		case YIELD_PHYSICS_FRAME:
+			return "Next Physics Frame";
+			break;
+		case YIELD_WAIT:
+			return rtos(wait_time) + " sec(s)";
+			break;
 	}
 
 	return String();
@@ -122,9 +130,15 @@ public:
 				case VisualScriptYield::YIELD_RETURN:
 					ret = STEP_EXIT_FUNCTION_BIT;
 					break; //return the yield
-				case VisualScriptYield::YIELD_FRAME: state->connect_to_signal(tree, "idle_frame", Array()); break;
-				case VisualScriptYield::YIELD_PHYSICS_FRAME: state->connect_to_signal(tree, "physics_frame", Array()); break;
-				case VisualScriptYield::YIELD_WAIT: state->connect_to_signal(tree->create_timer(wait_time).ptr(), "timeout", Array()); break;
+				case VisualScriptYield::YIELD_FRAME:
+					state->connect_to_signal(tree, "idle_frame", Array());
+					break;
+				case VisualScriptYield::YIELD_PHYSICS_FRAME:
+					state->connect_to_signal(tree, "physics_frame", Array());
+					break;
+				case VisualScriptYield::YIELD_WAIT:
+					state->connect_to_signal(tree->create_timer(wait_time).ptr(), "timeout", Array());
+					break;
 			}
 
 			*p_working_mem = state;

--- a/modules/webrtc/webrtc_multiplayer.cpp
+++ b/modules/webrtc/webrtc_multiplayer.cpp
@@ -144,7 +144,8 @@ void WebRTCMultiplayer::poll() {
 
 void WebRTCMultiplayer::_find_next_peer() {
 	Map<int, Ref<ConnectedPeer> >::Element *E = peer_map.find(next_packet_peer);
-	if (E) E = E->next();
+	if (E)
+		E = E->next();
 	// After last.
 	while (E) {
 		for (List<Ref<WebRTCDataChannel> >::Element *F = E->get()->channels.front(); F; F = F->next()) {

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -344,7 +344,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 							}
 
 							d.name = vendor + " " + device;
-							if (device == String()) continue;
+							if (device == String())
+								continue;
 						}
 
 						ndevices.push_back(d);

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -613,7 +613,8 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 	@Override
 	protected void onDestroy() {
 
-		if (mPaymentsManager != null) mPaymentsManager.destroy();
+		if (mPaymentsManager != null)
+			mPaymentsManager.destroy();
 		for (int i = 0; i < singleton_count; i++) {
 			singletons[i].onMainDestroy();
 		}
@@ -930,7 +931,8 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		int cnt = 0;
 		for (int i = cc.length; --i >= 0; cnt += cc[i] != 0 ? 1 : 0)
 			;
-		if (cnt == 0) return super.onKeyMultiple(inKeyCode, repeatCount, event);
+		if (cnt == 0)
+			return super.onKeyMultiple(inKeyCode, repeatCount, event);
 		final Activity me = this;
 		queueEvent(new Runnable() {
 			// This method will be called on the rendering thread:

--- a/platform/android/java_class_wrapper.h
+++ b/platform/android/java_class_wrapper.h
@@ -77,9 +77,13 @@ class JavaClass : public Reference {
 
 		switch (p_sig) {
 
-			case ARG_TYPE_VOID: r_type = Variant::NIL; break;
+			case ARG_TYPE_VOID:
+				r_type = Variant::NIL;
+				break;
 			case ARG_TYPE_BOOLEAN | ARG_NUMBER_CLASS_BIT:
-			case ARG_TYPE_BOOLEAN: r_type = Variant::BOOL; break;
+			case ARG_TYPE_BOOLEAN:
+				r_type = Variant::BOOL;
+				break;
 			case ARG_TYPE_BYTE | ARG_NUMBER_CLASS_BIT:
 			case ARG_TYPE_BYTE:
 				r_type = Variant::INT;
@@ -115,10 +119,18 @@ class JavaClass : public Reference {
 				r_type = Variant::REAL;
 				likelihood = 0.5;
 				break;
-			case ARG_TYPE_STRING: r_type = Variant::STRING; break;
-			case ARG_TYPE_CLASS: r_type = Variant::OBJECT; break;
-			case ARG_ARRAY_BIT | ARG_TYPE_VOID: r_type = Variant::NIL; break;
-			case ARG_ARRAY_BIT | ARG_TYPE_BOOLEAN: r_type = Variant::ARRAY; break;
+			case ARG_TYPE_STRING:
+				r_type = Variant::STRING;
+				break;
+			case ARG_TYPE_CLASS:
+				r_type = Variant::OBJECT;
+				break;
+			case ARG_ARRAY_BIT | ARG_TYPE_VOID:
+				r_type = Variant::NIL;
+				break;
+			case ARG_ARRAY_BIT | ARG_TYPE_BOOLEAN:
+				r_type = Variant::ARRAY;
+				break;
 			case ARG_ARRAY_BIT | ARG_TYPE_BYTE:
 				r_type = Variant::POOL_BYTE_ARRAY;
 				likelihood = 1.0;
@@ -147,8 +159,12 @@ class JavaClass : public Reference {
 				r_type = Variant::POOL_REAL_ARRAY;
 				likelihood = 0.5;
 				break;
-			case ARG_ARRAY_BIT | ARG_TYPE_STRING: r_type = Variant::POOL_STRING_ARRAY; break;
-			case ARG_ARRAY_BIT | ARG_TYPE_CLASS: r_type = Variant::ARRAY; break;
+			case ARG_ARRAY_BIT | ARG_TYPE_STRING:
+				r_type = Variant::POOL_STRING_ARRAY;
+				break;
+			case ARG_ARRAY_BIT | ARG_TYPE_CLASS:
+				r_type = Variant::ARRAY;
+				break;
 		}
 	}
 

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -429,7 +429,8 @@ String EditorExportPlatformIOS::_get_linker_flags() {
 	String result;
 	for (int i = 0; i < export_plugins.size(); ++i) {
 		String flags = export_plugins[i]->get_ios_linker_flags();
-		if (flags.length() == 0) continue;
+		if (flags.length() == 0)
+			continue;
 		if (result.length() > 0) {
 			result += ' ';
 		}

--- a/platform/iphone/godot_iphone.cpp
+++ b/platform/iphone/godot_iphone.cpp
@@ -50,7 +50,8 @@ int iphone_main(int width, int height, int argc, char **argv, String data_dir) {
 	int len = strlen(argv[0]);
 
 	while (len--) {
-		if (argv[0][len] == '/') break;
+		if (argv[0][len] == '/')
+			break;
 	}
 
 	if (len >= 0) {

--- a/platform/javascript/dom_keys.inc
+++ b/platform/javascript/dom_keys.inc
@@ -237,9 +237,12 @@ int dom2godot_scancode(int dom_keycode) {
 
 	switch (dom_keycode) {
 		//case DOM_VK_CANCEL: return KEY_UNKNOWN;
-		case DOM_VK_HELP: return KEY_HELP;
-		case DOM_VK_BACK_SPACE: return KEY_BACKSPACE;
-		case DOM_VK_TAB: return KEY_TAB;
+		case DOM_VK_HELP:
+			return KEY_HELP;
+		case DOM_VK_BACK_SPACE:
+			return KEY_BACKSPACE;
+		case DOM_VK_TAB:
+			return KEY_TAB;
 
 		case DOM_VK_CLEAR:
 		case DOM_VK_WIN_OEM_CLEAR: // OEM duplicate
@@ -249,14 +252,17 @@ int dom2godot_scancode(int dom_keycode) {
 		case DOM_VK_ENTER: // unused according to MDN
 			return KEY_ENTER;
 
-		case DOM_VK_SHIFT: return KEY_SHIFT;
-		case DOM_VK_CONTROL: return KEY_CONTROL;
+		case DOM_VK_SHIFT:
+			return KEY_SHIFT;
+		case DOM_VK_CONTROL:
+			return KEY_CONTROL;
 
 		case DOM_VK_ALT:
 		case DOM_VK_ALTGR:
 			return KEY_ALT;
 
-		case DOM_VK_PAUSE: return KEY_PAUSE;
+		case DOM_VK_PAUSE:
+			return KEY_PAUSE;
 		case DOM_VK_CAPS_LOCK:
 			return KEY_CAPSLOCK;
 
@@ -279,14 +285,22 @@ int dom2godot_scancode(int dom_keycode) {
 		case DOM_VK_MODECHANGE: return KEY_UNKNOWN;
 		*/
 
-		case DOM_VK_SPACE: return KEY_SPACE;
-		case DOM_VK_PAGE_UP: return KEY_PAGEUP;
-		case DOM_VK_PAGE_DOWN: return KEY_PAGEDOWN;
-		case DOM_VK_END: return KEY_END;
-		case DOM_VK_HOME: return KEY_HOME;
-		case DOM_VK_LEFT: return KEY_LEFT;
-		case DOM_VK_UP: return KEY_UP;
-		case DOM_VK_RIGHT: return KEY_RIGHT;
+		case DOM_VK_SPACE:
+			return KEY_SPACE;
+		case DOM_VK_PAGE_UP:
+			return KEY_PAGEUP;
+		case DOM_VK_PAGE_DOWN:
+			return KEY_PAGEDOWN;
+		case DOM_VK_END:
+			return KEY_END;
+		case DOM_VK_HOME:
+			return KEY_HOME;
+		case DOM_VK_LEFT:
+			return KEY_LEFT;
+		case DOM_VK_UP:
+			return KEY_UP;
+		case DOM_VK_RIGHT:
+			return KEY_RIGHT;
 		case DOM_VK_DOWN:
 			return KEY_DOWN;
 
@@ -297,24 +311,31 @@ int dom2godot_scancode(int dom_keycode) {
 			return KEY_PRINT;
 
 		//case DOM_VK_EXECUTE: return KEY_UNKNOWN;
-		case DOM_VK_INSERT: return KEY_INSERT;
-		case DOM_VK_DELETE: return KEY_DELETE;
+		case DOM_VK_INSERT:
+			return KEY_INSERT;
+		case DOM_VK_DELETE:
+			return KEY_DELETE;
 
 		case DOM_VK_META:
 		case DOM_VK_WIN:
 			return KEY_META;
 
-		case DOM_VK_CONTEXT_MENU: return KEY_MENU;
+		case DOM_VK_CONTEXT_MENU:
+			return KEY_MENU;
 		case DOM_VK_SLEEP:
 			return KEY_STANDBY;
 
 		// Numpad keys
-		case DOM_VK_MULTIPLY: return KEY_KP_MULTIPLY;
-		case DOM_VK_ADD: return KEY_KP_ADD;
+		case DOM_VK_MULTIPLY:
+			return KEY_KP_MULTIPLY;
+		case DOM_VK_ADD:
+			return KEY_KP_ADD;
 		case DOM_VK_SEPARATOR:
 			return KEY_KP_PERIOD; // Good enough?
-		case DOM_VK_SUBTRACT: return KEY_KP_SUBTRACT;
-		case DOM_VK_DECIMAL: return KEY_KP_PERIOD;
+		case DOM_VK_SUBTRACT:
+			return KEY_KP_SUBTRACT;
+		case DOM_VK_DECIMAL:
+			return KEY_KP_PERIOD;
 		case DOM_VK_DIVIDE:
 			return KEY_KP_DIVIDE;
 
@@ -329,7 +350,8 @@ int dom2godot_scancode(int dom_keycode) {
 		case DOM_VK_F24: return KEY_UNKNOWN;
 		*/
 
-		case DOM_VK_NUM_LOCK: return KEY_NUMLOCK;
+		case DOM_VK_NUM_LOCK:
+			return KEY_NUMLOCK;
 		case DOM_VK_SCROLL_LOCK:
 			return KEY_SCROLLLOCK;
 
@@ -341,40 +363,68 @@ int dom2godot_scancode(int dom_keycode) {
 		case DOM_VK_WIN_OEM_FJ_ROYA: return KEY_UNKNOWN;
 		*/
 
-		case DOM_VK_CIRCUMFLEX: return KEY_ASCIICIRCUM;
-		case DOM_VK_EXCLAMATION: return KEY_EXCLAM;
-		case DOM_VK_DOUBLE_QUOTE: return KEY_QUOTEDBL;
-		case DOM_VK_HASH: return KEY_NUMBERSIGN;
-		case DOM_VK_DOLLAR: return KEY_DOLLAR;
-		case DOM_VK_PERCENT: return KEY_PERCENT;
-		case DOM_VK_AMPERSAND: return KEY_AMPERSAND;
-		case DOM_VK_UNDERSCORE: return KEY_UNDERSCORE;
-		case DOM_VK_OPEN_PAREN: return KEY_PARENLEFT;
-		case DOM_VK_CLOSE_PAREN: return KEY_PARENRIGHT;
-		case DOM_VK_ASTERISK: return KEY_ASTERISK;
-		case DOM_VK_PLUS: return KEY_PLUS;
-		case DOM_VK_PIPE: return KEY_BAR;
-		case DOM_VK_HYPHEN_MINUS: return KEY_MINUS;
-		case DOM_VK_OPEN_CURLY_BRACKET: return KEY_BRACELEFT;
-		case DOM_VK_CLOSE_CURLY_BRACKET: return KEY_BRACERIGHT;
-		case DOM_VK_TILDE: return KEY_ASCIITILDE;
+		case DOM_VK_CIRCUMFLEX:
+			return KEY_ASCIICIRCUM;
+		case DOM_VK_EXCLAMATION:
+			return KEY_EXCLAM;
+		case DOM_VK_DOUBLE_QUOTE:
+			return KEY_QUOTEDBL;
+		case DOM_VK_HASH:
+			return KEY_NUMBERSIGN;
+		case DOM_VK_DOLLAR:
+			return KEY_DOLLAR;
+		case DOM_VK_PERCENT:
+			return KEY_PERCENT;
+		case DOM_VK_AMPERSAND:
+			return KEY_AMPERSAND;
+		case DOM_VK_UNDERSCORE:
+			return KEY_UNDERSCORE;
+		case DOM_VK_OPEN_PAREN:
+			return KEY_PARENLEFT;
+		case DOM_VK_CLOSE_PAREN:
+			return KEY_PARENRIGHT;
+		case DOM_VK_ASTERISK:
+			return KEY_ASTERISK;
+		case DOM_VK_PLUS:
+			return KEY_PLUS;
+		case DOM_VK_PIPE:
+			return KEY_BAR;
+		case DOM_VK_HYPHEN_MINUS:
+			return KEY_MINUS;
+		case DOM_VK_OPEN_CURLY_BRACKET:
+			return KEY_BRACELEFT;
+		case DOM_VK_CLOSE_CURLY_BRACKET:
+			return KEY_BRACERIGHT;
+		case DOM_VK_TILDE:
+			return KEY_ASCIITILDE;
 
-		case DOM_VK_VOLUME_MUTE: return KEY_VOLUMEMUTE;
-		case DOM_VK_VOLUME_DOWN: return KEY_VOLUMEDOWN;
-		case DOM_VK_VOLUME_UP: return KEY_VOLUMEUP;
+		case DOM_VK_VOLUME_MUTE:
+			return KEY_VOLUMEMUTE;
+		case DOM_VK_VOLUME_DOWN:
+			return KEY_VOLUMEDOWN;
+		case DOM_VK_VOLUME_UP:
+			return KEY_VOLUMEUP;
 
-		case DOM_VK_COMMA: return KEY_COMMA;
-		case DOM_VK_PERIOD: return KEY_PERIOD;
-		case DOM_VK_SLASH: return KEY_SLASH;
-		case DOM_VK_BACK_QUOTE: return KEY_QUOTELEFT;
-		case DOM_VK_OPEN_BRACKET: return KEY_BRACKETLEFT;
-		case DOM_VK_BACK_SLASH: return KEY_BACKSLASH;
-		case DOM_VK_CLOSE_BRACKET: return KEY_BRACKETRIGHT;
+		case DOM_VK_COMMA:
+			return KEY_COMMA;
+		case DOM_VK_PERIOD:
+			return KEY_PERIOD;
+		case DOM_VK_SLASH:
+			return KEY_SLASH;
+		case DOM_VK_BACK_QUOTE:
+			return KEY_QUOTELEFT;
+		case DOM_VK_OPEN_BRACKET:
+			return KEY_BRACKETLEFT;
+		case DOM_VK_BACK_SLASH:
+			return KEY_BACKSLASH;
+		case DOM_VK_CLOSE_BRACKET:
+			return KEY_BRACKETRIGHT;
 		case DOM_VK_QUOTE:
 			return KEY_APOSTROPHE;
 
 			// The rest is OEM/unusual.
 
-		default: return KEY_UNKNOWN;
+		default:
+			return KEY_UNKNOWN;
 	};
 }

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -303,12 +303,23 @@ EM_BOOL OS_JavaScript::mouse_button_callback(int p_event_type, const EmscriptenM
 	ev->set_global_position(ev->get_position());
 	dom2godot_mod(p_event, ev);
 	switch (p_event->button) {
-		case DOM_BUTTON_LEFT: ev->set_button_index(BUTTON_LEFT); break;
-		case DOM_BUTTON_MIDDLE: ev->set_button_index(BUTTON_MIDDLE); break;
-		case DOM_BUTTON_RIGHT: ev->set_button_index(BUTTON_RIGHT); break;
-		case DOM_BUTTON_XBUTTON1: ev->set_button_index(BUTTON_XBUTTON1); break;
-		case DOM_BUTTON_XBUTTON2: ev->set_button_index(BUTTON_XBUTTON2); break;
-		default: return false;
+		case DOM_BUTTON_LEFT:
+			ev->set_button_index(BUTTON_LEFT);
+			break;
+		case DOM_BUTTON_MIDDLE:
+			ev->set_button_index(BUTTON_MIDDLE);
+			break;
+		case DOM_BUTTON_RIGHT:
+			ev->set_button_index(BUTTON_RIGHT);
+			break;
+		case DOM_BUTTON_XBUTTON1:
+			ev->set_button_index(BUTTON_XBUTTON1);
+			break;
+		case DOM_BUTTON_XBUTTON2:
+			ev->set_button_index(BUTTON_XBUTTON2);
+			break;
+		default:
+			return false;
 	}
 
 	if (ev->is_pressed()) {
@@ -392,22 +403,38 @@ static const char *godot2dom_cursor(OS::CursorShape p_shape) {
 		case OS::CURSOR_ARROW:
 		default:
 			return "auto";
-		case OS::CURSOR_IBEAM: return "text";
-		case OS::CURSOR_POINTING_HAND: return "pointer";
-		case OS::CURSOR_CROSS: return "crosshair";
-		case OS::CURSOR_WAIT: return "progress";
-		case OS::CURSOR_BUSY: return "wait";
-		case OS::CURSOR_DRAG: return "grab";
-		case OS::CURSOR_CAN_DROP: return "grabbing";
-		case OS::CURSOR_FORBIDDEN: return "no-drop";
-		case OS::CURSOR_VSIZE: return "ns-resize";
-		case OS::CURSOR_HSIZE: return "ew-resize";
-		case OS::CURSOR_BDIAGSIZE: return "nesw-resize";
-		case OS::CURSOR_FDIAGSIZE: return "nwse-resize";
-		case OS::CURSOR_MOVE: return "move";
-		case OS::CURSOR_VSPLIT: return "row-resize";
-		case OS::CURSOR_HSPLIT: return "col-resize";
-		case OS::CURSOR_HELP: return "help";
+		case OS::CURSOR_IBEAM:
+			return "text";
+		case OS::CURSOR_POINTING_HAND:
+			return "pointer";
+		case OS::CURSOR_CROSS:
+			return "crosshair";
+		case OS::CURSOR_WAIT:
+			return "progress";
+		case OS::CURSOR_BUSY:
+			return "wait";
+		case OS::CURSOR_DRAG:
+			return "grab";
+		case OS::CURSOR_CAN_DROP:
+			return "grabbing";
+		case OS::CURSOR_FORBIDDEN:
+			return "no-drop";
+		case OS::CURSOR_VSIZE:
+			return "ns-resize";
+		case OS::CURSOR_HSIZE:
+			return "ew-resize";
+		case OS::CURSOR_BDIAGSIZE:
+			return "nesw-resize";
+		case OS::CURSOR_FDIAGSIZE:
+			return "nwse-resize";
+		case OS::CURSOR_MOVE:
+			return "move";
+		case OS::CURSOR_VSPLIT:
+			return "row-resize";
+		case OS::CURSOR_HSPLIT:
+			return "col-resize";
+		case OS::CURSOR_HELP:
+			return "help";
 	}
 }
 

--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -49,7 +49,8 @@ int main(int argc, char **argv) {
 		//potentially launched from finder
 		int len = strlen(argv[0]);
 		while (len--) {
-			if (argv[0][len] == '/') break;
+			if (argv[0][len] == '/')
+				break;
 		}
 		if (len >= 0) {
 			char *path = (char *)malloc(len + 1);

--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -376,7 +376,8 @@ bool joypad::check_ff_features() {
 	if (ret == FF_OK && (features.supportedEffects & FFCAP_ET_CONSTANTFORCE)) {
 		uint32_t val;
 		ret = FFDeviceGetForceFeedbackProperty(ff_device, FFPROP_FFGAIN, &val, sizeof(val));
-		if (ret != FF_OK) return false;
+		if (ret != FF_OK)
+			return false;
 		int num_axes = features.numFfAxes;
 		ff_axes = (DWORD *)memalloc(sizeof(DWORD) * num_axes);
 		ff_directions = (LONG *)memalloc(sizeof(LONG) * num_axes);
@@ -511,7 +512,8 @@ void JoypadOSX::joypad_vibration_stop(int p_id, uint64_t p_timestamp) {
 
 int JoypadOSX::get_joy_index(int p_id) const {
 	for (int i = 0; i < device_list.size(); i++) {
-		if (device_list[i].id == p_id) return i;
+		if (device_list[i].id == p_id)
+			return i;
 	}
 	return -1;
 }

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -2572,13 +2572,15 @@ void OS_OSX::request_attention() {
 
 bool OS_OSX::get_window_per_pixel_transparency_enabled() const {
 
-	if (!is_layered_allowed()) return false;
+	if (!is_layered_allowed())
+		return false;
 	return layered_window;
 }
 
 void OS_OSX::set_window_per_pixel_transparency_enabled(bool p_enabled) {
 
-	if (!is_layered_allowed()) return;
+	if (!is_layered_allowed())
+		return;
 	if (layered_window != p_enabled) {
 		if (p_enabled) {
 			set_borderless_window(true);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1736,23 +1736,57 @@ void OS_OSX::set_cursor_shape(CursorShape p_shape) {
 		[cursors[p_shape] set];
 	} else {
 		switch (p_shape) {
-			case CURSOR_ARROW: [[NSCursor arrowCursor] set]; break;
-			case CURSOR_IBEAM: [[NSCursor IBeamCursor] set]; break;
-			case CURSOR_POINTING_HAND: [[NSCursor pointingHandCursor] set]; break;
-			case CURSOR_CROSS: [[NSCursor crosshairCursor] set]; break;
-			case CURSOR_WAIT: [[NSCursor arrowCursor] set]; break;
-			case CURSOR_BUSY: [[NSCursor arrowCursor] set]; break;
-			case CURSOR_DRAG: [[NSCursor closedHandCursor] set]; break;
-			case CURSOR_CAN_DROP: [[NSCursor openHandCursor] set]; break;
-			case CURSOR_FORBIDDEN: [[NSCursor arrowCursor] set]; break;
-			case CURSOR_VSIZE: [[NSCursor resizeUpDownCursor] set]; break;
-			case CURSOR_HSIZE: [[NSCursor resizeLeftRightCursor] set]; break;
-			case CURSOR_BDIAGSIZE: [[NSCursor arrowCursor] set]; break;
-			case CURSOR_FDIAGSIZE: [[NSCursor arrowCursor] set]; break;
-			case CURSOR_MOVE: [[NSCursor arrowCursor] set]; break;
-			case CURSOR_VSPLIT: [[NSCursor resizeUpDownCursor] set]; break;
-			case CURSOR_HSPLIT: [[NSCursor resizeLeftRightCursor] set]; break;
-			case CURSOR_HELP: [[NSCursor arrowCursor] set]; break;
+			case CURSOR_ARROW:
+				[[NSCursor arrowCursor] set];
+				break;
+			case CURSOR_IBEAM:
+				[[NSCursor IBeamCursor] set];
+				break;
+			case CURSOR_POINTING_HAND:
+				[[NSCursor pointingHandCursor] set];
+				break;
+			case CURSOR_CROSS:
+				[[NSCursor crosshairCursor] set];
+				break;
+			case CURSOR_WAIT:
+				[[NSCursor arrowCursor] set];
+				break;
+			case CURSOR_BUSY:
+				[[NSCursor arrowCursor] set];
+				break;
+			case CURSOR_DRAG:
+				[[NSCursor closedHandCursor] set];
+				break;
+			case CURSOR_CAN_DROP:
+				[[NSCursor openHandCursor] set];
+				break;
+			case CURSOR_FORBIDDEN:
+				[[NSCursor arrowCursor] set];
+				break;
+			case CURSOR_VSIZE:
+				[[NSCursor resizeUpDownCursor] set];
+				break;
+			case CURSOR_HSIZE:
+				[[NSCursor resizeLeftRightCursor] set];
+				break;
+			case CURSOR_BDIAGSIZE:
+				[[NSCursor arrowCursor] set];
+				break;
+			case CURSOR_FDIAGSIZE:
+				[[NSCursor arrowCursor] set];
+				break;
+			case CURSOR_MOVE:
+				[[NSCursor arrowCursor] set];
+				break;
+			case CURSOR_VSPLIT:
+				[[NSCursor resizeUpDownCursor] set];
+				break;
+			case CURSOR_HSPLIT:
+				[[NSCursor resizeLeftRightCursor] set];
+				break;
+			case CURSOR_HELP:
+				[[NSCursor arrowCursor] set];
+				break;
 			default: {
 			};
 		}

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -270,7 +270,8 @@ void AppxPackager::make_content_types() {
 
 		String ext = file_metadata[i].name.get_extension();
 
-		if (types.has(ext)) continue;
+		if (types.has(ext))
+			continue;
 
 		types[ext] = content_type(ext);
 
@@ -660,8 +661,10 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 
 	bool _valid_resource_name(const String &p_name) const {
 
-		if (p_name.empty()) return false;
-		if (p_name.ends_with(".")) return false;
+		if (p_name.empty())
+			return false;
+		if (p_name.ends_with("."))
+			return false;
 
 		static const char *invalid_names[] = {
 			"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
@@ -671,7 +674,8 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 
 		const char **t = invalid_names;
 		while (*t) {
-			if (p_name == *t) return false;
+			if (p_name == *t)
+				return false;
 			t++;
 		}
 
@@ -682,19 +686,25 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 
 		Vector<String> parts = p_guid.split("-");
 
-		if (parts.size() != 5) return false;
-		if (parts[0].length() != 8) return false;
+		if (parts.size() != 5)
+			return false;
+		if (parts[0].length() != 8)
+			return false;
 		for (int i = 1; i < 4; i++)
-			if (parts[i].length() != 4) return false;
-		if (parts[4].length() != 12) return false;
+			if (parts[i].length() != 4)
+				return false;
+		if (parts[4].length() != 12)
+			return false;
 
 		return true;
 	}
 
 	bool _valid_bgcolor(const String &p_color) const {
 
-		if (p_color.empty()) return true;
-		if (p_color.begins_with("#") && p_color.is_valid_html_color()) return true;
+		if (p_color.empty())
+			return true;
+		if (p_color.begins_with("#") && p_color.is_valid_html_color())
+			return true;
 
 		// Colors from https://msdn.microsoft.com/en-us/library/windows/apps/dn934817.aspx
 		static const char *valid_colors[] = {
@@ -728,7 +738,8 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		const char **color = valid_colors;
 
 		while (*color) {
-			if (p_color == *color) return true;
+			if (p_color == *color)
+				return true;
 			color++;
 		}
 
@@ -892,7 +903,8 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 			ERR_PRINT("Unable to load logo");
 		}
 
-		if (!image) return data;
+		if (!image)
+			return data;
 
 		String tmp_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("uwp_tmp_logo.png");
 
@@ -1325,7 +1337,8 @@ public:
 				path = path.replace(".scale-100", "");
 
 				data = _get_image_data(p_preset, path);
-				if (data.size() > 0) do_read = false;
+				if (data.size() > 0)
+					do_read = false;
 			}
 
 			//read

--- a/platform/uwp/joypad_uwp.cpp
+++ b/platform/uwp/joypad_uwp.cpp
@@ -48,7 +48,8 @@ void JoypadUWP::process_controllers() {
 
 		ControllerDevice &joy = controllers[i];
 
-		if (!joy.connected) break;
+		if (!joy.connected)
+			break;
 
 		switch (joy.type) {
 

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -124,7 +124,8 @@ bool OS_UWP::is_window_fullscreen() const {
 
 void OS_UWP::set_keep_screen_on(bool p_enabled) {
 
-	if (is_keep_screen_on() == p_enabled) return;
+	if (is_keep_screen_on() == p_enabled)
+		return;
 
 	if (p_enabled)
 		display_request->RequestActive();
@@ -878,7 +879,8 @@ void OS_UWP::run() {
 	while (!force_quit) {
 
 		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
-		if (managed_object->alert_close_handle) continue;
+		if (managed_object->alert_close_handle)
+			continue;
 		process_events(); // get rid of pending events
 		if (Main::iteration())
 			break;

--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -107,7 +107,8 @@ bool JoypadWindows::is_xinput_device(const GUID *p_guid) {
 		return false;
 	}
 	dev_list = (PRAWINPUTDEVICELIST)malloc(sizeof(RAWINPUTDEVICELIST) * dev_list_count);
-	if (!dev_list) return false;
+	if (!dev_list)
+		return false;
 
 	if (GetRawInputDeviceList(dev_list, &dev_list_count, sizeof(RAWINPUTDEVICELIST)) == (UINT)-1) {
 		free(dev_list);
@@ -262,7 +263,8 @@ void JoypadWindows::close_joypad(int id) {
 		return;
 	}
 
-	if (!d_joypads[id].attached) return;
+	if (!d_joypads[id].attached)
+		return;
 
 	d_joypads[id].di_joy->Unacquire();
 	d_joypads[id].di_joy->Release();

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1770,7 +1770,8 @@ Point2 OS_Windows::get_window_position() const {
 
 void OS_Windows::set_window_position(const Point2 &p_position) {
 
-	if (video_mode.fullscreen) return;
+	if (video_mode.fullscreen)
+		return;
 	RECT r;
 	GetWindowRect(hWnd, &r);
 	MoveWindow(hWnd, p_position.x, p_position.y, r.right - r.left, r.bottom - r.top, TRUE);
@@ -1981,13 +1982,15 @@ bool OS_Windows::is_window_always_on_top() const {
 
 bool OS_Windows::get_window_per_pixel_transparency_enabled() const {
 
-	if (!is_layered_allowed()) return false;
+	if (!is_layered_allowed())
+		return false;
 	return layered_window;
 }
 
 void OS_Windows::set_window_per_pixel_transparency_enabled(bool p_enabled) {
 
-	if (!is_layered_allowed()) return;
+	if (!is_layered_allowed())
+		return;
 	if (layered_window != p_enabled) {
 		if (p_enabled) {
 			set_borderless_window(true);
@@ -2949,19 +2952,22 @@ OS::LatinKeyboardVariant OS_Windows::get_latin_keyboard_variant() const {
 
 	int i = 0;
 	while (azerty[i] != 0) {
-		if (azerty[i] == hex) return LATIN_KEYBOARD_AZERTY;
+		if (azerty[i] == hex)
+			return LATIN_KEYBOARD_AZERTY;
 		i++;
 	}
 
 	i = 0;
 	while (qwertz[i] != 0) {
-		if (qwertz[i] == hex) return LATIN_KEYBOARD_QWERTZ;
+		if (qwertz[i] == hex)
+			return LATIN_KEYBOARD_QWERTZ;
 		i++;
 	}
 
 	i = 0;
 	while (dvorak[i] != 0) {
-		if (dvorak[i] == hex) return LATIN_KEYBOARD_DVORAK;
+		if (dvorak[i] == hex)
+			return LATIN_KEYBOARD_DVORAK;
 		i++;
 	}
 

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -90,10 +90,18 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 
 		uint32_t basecol = 0;
 		switch (p_type) {
-			case ERR_ERROR: basecol = FOREGROUND_RED; break;
-			case ERR_WARNING: basecol = FOREGROUND_RED | FOREGROUND_GREEN; break;
-			case ERR_SCRIPT: basecol = FOREGROUND_RED | FOREGROUND_BLUE; break;
-			case ERR_SHADER: basecol = FOREGROUND_GREEN | FOREGROUND_BLUE; break;
+			case ERR_ERROR:
+				basecol = FOREGROUND_RED;
+				break;
+			case ERR_WARNING:
+				basecol = FOREGROUND_RED | FOREGROUND_GREEN;
+				break;
+			case ERR_SCRIPT:
+				basecol = FOREGROUND_RED | FOREGROUND_BLUE;
+				break;
+			case ERR_SHADER:
+				basecol = FOREGROUND_GREEN | FOREGROUND_BLUE;
+				break;
 		}
 
 		basecol |= current_bg;
@@ -102,10 +110,18 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 
 			SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
 			switch (p_type) {
-				case ERR_ERROR: logf("ERROR: "); break;
-				case ERR_WARNING: logf("WARNING: "); break;
-				case ERR_SCRIPT: logf("SCRIPT ERROR: "); break;
-				case ERR_SHADER: logf("SHADER ERROR: "); break;
+				case ERR_ERROR:
+					logf("ERROR: ");
+					break;
+				case ERR_WARNING:
+					logf("WARNING: ");
+					break;
+				case ERR_SCRIPT:
+					logf("SCRIPT ERROR: ");
+					break;
+				case ERR_SHADER:
+					logf("SHADER ERROR: ");
+					break;
 			}
 
 			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
@@ -113,10 +129,18 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 
 			SetConsoleTextAttribute(hCon, basecol);
 			switch (p_type) {
-				case ERR_ERROR: logf("   At: "); break;
-				case ERR_WARNING: logf("     At: "); break;
-				case ERR_SCRIPT: logf("          At: "); break;
-				case ERR_SHADER: logf("          At: "); break;
+				case ERR_ERROR:
+					logf("   At: ");
+					break;
+				case ERR_WARNING:
+					logf("     At: ");
+					break;
+				case ERR_SCRIPT:
+					logf("          At: ");
+					break;
+				case ERR_SHADER:
+					logf("          At: ");
+					break;
 			}
 
 			SetConsoleTextAttribute(hCon, current_fg | current_bg);
@@ -126,10 +150,18 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 
 			SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
 			switch (p_type) {
-				case ERR_ERROR: logf("ERROR: %s: ", p_function); break;
-				case ERR_WARNING: logf("WARNING: %s: ", p_function); break;
-				case ERR_SCRIPT: logf("SCRIPT ERROR: %s: ", p_function); break;
-				case ERR_SHADER: logf("SCRIPT ERROR: %s: ", p_function); break;
+				case ERR_ERROR:
+					logf("ERROR: %s: ", p_function);
+					break;
+				case ERR_WARNING:
+					logf("WARNING: %s: ", p_function);
+					break;
+				case ERR_SCRIPT:
+					logf("SCRIPT ERROR: %s: ", p_function);
+					break;
+				case ERR_SHADER:
+					logf("SCRIPT ERROR: %s: ", p_function);
+					break;
 			}
 
 			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
@@ -137,10 +169,18 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 
 			SetConsoleTextAttribute(hCon, basecol);
 			switch (p_type) {
-				case ERR_ERROR: logf("   At: "); break;
-				case ERR_WARNING: logf("     At: "); break;
-				case ERR_SCRIPT: logf("          At: "); break;
-				case ERR_SHADER: logf("          At: "); break;
+				case ERR_ERROR:
+					logf("   At: ");
+					break;
+				case ERR_WARNING:
+					logf("     At: ");
+					break;
+				case ERR_SCRIPT:
+					logf("          At: ");
+					break;
+				case ERR_SHADER:
+					logf("          At: ");
+					break;
 			}
 
 			SetConsoleTextAttribute(hCon, current_fg | current_bg);

--- a/platform/x11/detect_prime.cpp
+++ b/platform/x11/detect_prime.cpp
@@ -174,7 +174,8 @@ int detect_prime() {
 
 			close(fdset[0]);
 
-			if (i) setenv("DRI_PRIME", "1", 1);
+			if (i)
+				setenv("DRI_PRIME", "1", 1);
 			create_context();
 
 			const char *vendor = (const char *)glGetString(GL_VENDOR);

--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -461,7 +461,8 @@ void JoypadLinux::process_joypads() {
 	}
 	for (int i = 0; i < JOYPADS_MAX; i++) {
 
-		if (joypads[i].fd == -1) continue;
+		if (joypads[i].fd == -1)
+			continue;
 
 		input_event events[32];
 		Joypad *joy = &joypads[i];

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -927,13 +927,15 @@ Point2 OS_X11::get_mouse_position() const {
 
 bool OS_X11::get_window_per_pixel_transparency_enabled() const {
 
-	if (!is_layered_allowed()) return false;
+	if (!is_layered_allowed())
+		return false;
 	return layered_window;
 }
 
 void OS_X11::set_window_per_pixel_transparency_enabled(bool p_enabled) {
 
-	if (!is_layered_allowed()) return;
+	if (!is_layered_allowed())
+		return;
 	if (layered_window != p_enabled) {
 		if (p_enabled) {
 			set_borderless_window(true);
@@ -1065,7 +1067,8 @@ int OS_X11::get_screen_count() const {
 	// Using Xinerama Extension
 	int event_base, error_base;
 	const Bool ext_okay = XineramaQueryExtension(x11_display, &event_base, &error_base);
-	if (!ext_okay) return 0;
+	if (!ext_okay)
+		return 0;
 
 	int count;
 	XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &count);
@@ -1090,7 +1093,8 @@ int OS_X11::get_current_screen() const {
 
 void OS_X11::set_current_screen(int p_screen) {
 	int count = get_screen_count();
-	if (p_screen >= count) return;
+	if (p_screen >= count)
+		return;
 
 	if (current_videomode.fullscreen) {
 		Point2i position = get_screen_position(p_screen);
@@ -1138,11 +1142,13 @@ Size2 OS_X11::get_screen_size(int p_screen) const {
 	// Using Xinerama Extension
 	int event_base, error_base;
 	const Bool ext_okay = XineramaQueryExtension(x11_display, &event_base, &error_base);
-	if (!ext_okay) return Size2i(0, 0);
+	if (!ext_okay)
+		return Size2i(0, 0);
 
 	int count;
 	XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &count);
-	if (p_screen >= count) return Size2i(0, 0);
+	if (p_screen >= count)
+		return Size2i(0, 0);
 
 	Size2i size = Point2i(xsi[p_screen].width, xsi[p_screen].height);
 	XFree(xsi);

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -102,18 +102,35 @@ void CanvasItemMaterial::_update_shader() {
 
 	String code = "shader_type canvas_item;\nrender_mode ";
 	switch (blend_mode) {
-		case BLEND_MODE_MIX: code += "blend_mix"; break;
-		case BLEND_MODE_ADD: code += "blend_add"; break;
-		case BLEND_MODE_SUB: code += "blend_sub"; break;
-		case BLEND_MODE_MUL: code += "blend_mul"; break;
-		case BLEND_MODE_PREMULT_ALPHA: code += "blend_premul_alpha"; break;
-		case BLEND_MODE_DISABLED: code += "blend_disabled"; break;
+		case BLEND_MODE_MIX:
+			code += "blend_mix";
+			break;
+		case BLEND_MODE_ADD:
+			code += "blend_add";
+			break;
+		case BLEND_MODE_SUB:
+			code += "blend_sub";
+			break;
+		case BLEND_MODE_MUL:
+			code += "blend_mul";
+			break;
+		case BLEND_MODE_PREMULT_ALPHA:
+			code += "blend_premul_alpha";
+			break;
+		case BLEND_MODE_DISABLED:
+			code += "blend_disabled";
+			break;
 	}
 
 	switch (light_mode) {
-		case LIGHT_MODE_NORMAL: break;
-		case LIGHT_MODE_UNSHADED: code += ",unshaded"; break;
-		case LIGHT_MODE_LIGHT_ONLY: code += ",light_only"; break;
+		case LIGHT_MODE_NORMAL:
+			break;
+		case LIGHT_MODE_UNSHADED:
+			code += ",unshaded";
+			break;
+		case LIGHT_MODE_LIGHT_ONLY:
+			code += ",light_only";
+			break;
 	}
 
 	code += ";\n";

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -226,9 +226,11 @@ private:
 
 protected:
 	_FORCE_INLINE_ void _notify_transform() {
-		if (!is_inside_tree()) return;
+		if (!is_inside_tree())
+			return;
 		_notify_transform(this);
-		if (!block_transform_notify && notify_local_transform) notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+		if (!block_transform_notify && notify_local_transform)
+			notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 	}
 
 	void item_rect_changed(bool p_size_changed = true);

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -837,7 +837,8 @@ void CPUParticles2D::_particles_process(float p_delta) {
 
 		//scale by scale
 		float base_scale = Math::lerp(parameters[PARAM_SCALE] * tex_scale, 1.0f, p.scale_rand * randomness[PARAM_SCALE]);
-		if (base_scale == 0.0) base_scale = 0.000001;
+		if (base_scale == 0.0)
+			base_scale = 0.000001;
 
 		p.transform.elements[0] *= base_scale;
 		p.transform.elements[1] *= base_scale;
@@ -1141,7 +1142,8 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 	set_param(m_param, material->get_param(ParticlesMaterial::m_param));                  \
 	{                                                                                     \
 		Ref<CurveTexture> ctex = material->get_param_texture(ParticlesMaterial::m_param); \
-		if (ctex.is_valid()) set_param_curve(m_param, ctex->get_curve());                 \
+		if (ctex.is_valid())                                                              \
+			set_param_curve(m_param, ctex->get_curve());                                  \
 	}                                                                                     \
 	set_param_randomness(m_param, material->get_param_randomness(ParticlesMaterial::m_param));
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -218,7 +218,8 @@ float AudioStreamPlayer3D::_get_attenuation_db(float p_distance) const {
 		case ATTENUATION_LOGARITHMIC: {
 			att = -20 * Math::log(p_distance / unit_size + CMP_EPSILON);
 		} break;
-		case ATTENUATION_DISABLED: break;
+		case ATTENUATION_DISABLED:
+			break;
 		default: {
 			ERR_PRINT("Unknown attenuation type");
 			break;

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -886,7 +886,8 @@ void CPUParticles::_particles_process(float p_delta) {
 
 		//scale by scale
 		float base_scale = Math::lerp(parameters[PARAM_SCALE] * tex_scale, 1.0f, p.scale_rand * randomness[PARAM_SCALE]);
-		if (base_scale == 0.0) base_scale = 0.000001;
+		if (base_scale == 0.0)
+			base_scale = 0.000001;
 
 		p.transform.basis.scale(Vector3(1, 1, 1) * base_scale);
 
@@ -1210,7 +1211,8 @@ void CPUParticles::convert_from_particles(Node *p_particles) {
 	set_param(m_param, material->get_param(ParticlesMaterial::m_param));                  \
 	{                                                                                     \
 		Ref<CurveTexture> ctex = material->get_param_texture(ParticlesMaterial::m_param); \
-		if (ctex.is_valid()) set_param_curve(m_param, ctex->get_curve());                 \
+		if (ctex.is_valid())                                                              \
+			set_param_curve(m_param, ctex->get_curve());                                  \
 	}                                                                                     \
 	set_param_randomness(m_param, material->get_param_randomness(ParticlesMaterial::m_param));
 

--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -291,9 +291,15 @@ Light::Light(VisualServer::LightType p_type) {
 
 	type = p_type;
 	switch (p_type) {
-		case VS::LIGHT_DIRECTIONAL: light = VisualServer::get_singleton()->directional_light_create(); break;
-		case VS::LIGHT_OMNI: light = VisualServer::get_singleton()->omni_light_create(); break;
-		case VS::LIGHT_SPOT: light = VisualServer::get_singleton()->spot_light_create(); break;
+		case VS::LIGHT_DIRECTIONAL:
+			light = VisualServer::get_singleton()->directional_light_create();
+			break;
+		case VS::LIGHT_OMNI:
+			light = VisualServer::get_singleton()->omni_light_create();
+			break;
+		case VS::LIGHT_SPOT:
+			light = VisualServer::get_singleton()->spot_light_create();
+			break;
 		default: {
 		};
 	}

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -243,7 +243,8 @@ String Particles::get_configuration_warning() const {
 				SpatialMaterial *spat = Object::cast_to<SpatialMaterial>(draw_passes[i]->surface_get_material(j).ptr());
 				anim_material_found = anim_material_found || (spat && spat->get_billboard_mode() == SpatialMaterial::BILLBOARD_PARTICLES);
 			}
-			if (meshes_found && anim_material_found) break;
+			if (meshes_found && anim_material_found)
+				break;
 		}
 	}
 

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -36,10 +36,14 @@
 
 #define FINDMINMAX(x0, x1, x2, min, max) \
 	min = max = x0;                      \
-	if (x1 < min) min = x1;              \
-	if (x1 > max) max = x1;              \
-	if (x2 < min) min = x2;              \
-	if (x2 > max) max = x2;
+	if (x1 < min)                        \
+		min = x1;                        \
+	if (x1 > max)                        \
+		max = x1;                        \
+	if (x2 < min)                        \
+		min = x2;                        \
+	if (x2 > max)                        \
+		max = x2;
 
 static bool planeBoxOverlap(Vector3 normal, float d, Vector3 maxbox) {
 	int q;
@@ -53,8 +57,10 @@ static bool planeBoxOverlap(Vector3 normal, float d, Vector3 maxbox) {
 			vmax[q] = -maxbox[q];
 		}
 	}
-	if (normal.dot(vmin) + d > 0.0f) return false;
-	if (normal.dot(vmax) + d >= 0.0f) return true;
+	if (normal.dot(vmin) + d > 0.0f)
+		return false;
+	if (normal.dot(vmax) + d >= 0.0f)
+		return true;
 
 	return false;
 }
@@ -71,7 +77,8 @@ static bool planeBoxOverlap(Vector3 normal, float d, Vector3 maxbox) {
 		max = p0;                                  \
 	}                                              \
 	rad = fa * boxhalfsize.y + fb * boxhalfsize.z; \
-	if (min > rad || max < -rad) return false;
+	if (min > rad || max < -rad)                   \
+		return false;
 
 #define AXISTEST_X2(a, b, fa, fb)                  \
 	p0 = a * v0.y - b * v0.z;                      \
@@ -84,7 +91,8 @@ static bool planeBoxOverlap(Vector3 normal, float d, Vector3 maxbox) {
 		max = p0;                                  \
 	}                                              \
 	rad = fa * boxhalfsize.y + fb * boxhalfsize.z; \
-	if (min > rad || max < -rad) return false;
+	if (min > rad || max < -rad)                   \
+		return false;
 
 /*======================== Y-tests ========================*/
 #define AXISTEST_Y02(a, b, fa, fb)                 \
@@ -98,7 +106,8 @@ static bool planeBoxOverlap(Vector3 normal, float d, Vector3 maxbox) {
 		max = p0;                                  \
 	}                                              \
 	rad = fa * boxhalfsize.x + fb * boxhalfsize.z; \
-	if (min > rad || max < -rad) return false;
+	if (min > rad || max < -rad)                   \
+		return false;
 
 #define AXISTEST_Y1(a, b, fa, fb)                  \
 	p0 = -a * v0.x + b * v0.z;                     \
@@ -111,7 +120,8 @@ static bool planeBoxOverlap(Vector3 normal, float d, Vector3 maxbox) {
 		max = p0;                                  \
 	}                                              \
 	rad = fa * boxhalfsize.x + fb * boxhalfsize.z; \
-	if (min > rad || max < -rad) return false;
+	if (min > rad || max < -rad)                   \
+		return false;
 
 /*======================== Z-tests ========================*/
 
@@ -126,7 +136,8 @@ static bool planeBoxOverlap(Vector3 normal, float d, Vector3 maxbox) {
 		max = p2;                                  \
 	}                                              \
 	rad = fa * boxhalfsize.x + fb * boxhalfsize.y; \
-	if (min > rad || max < -rad) return false;
+	if (min > rad || max < -rad)                   \
+		return false;
 
 #define AXISTEST_Z0(a, b, fa, fb)                  \
 	p0 = a * v0.x - b * v0.y;                      \
@@ -139,7 +150,8 @@ static bool planeBoxOverlap(Vector3 normal, float d, Vector3 maxbox) {
 		max = p0;                                  \
 	}                                              \
 	rad = fa * boxhalfsize.x + fb * boxhalfsize.y; \
-	if (min > rad || max < -rad) return false;
+	if (min > rad || max < -rad)                   \
+		return false;
 
 static bool fast_tri_box_overlap(const Vector3 &boxcenter, const Vector3 boxhalfsize, const Vector3 *triverts) {
 
@@ -197,22 +209,26 @@ static bool fast_tri_box_overlap(const Vector3 &boxcenter, const Vector3 boxhalf
 
 	/* test in X-direction */
 	FINDMINMAX(v0.x, v1.x, v2.x, min, max);
-	if (min > boxhalfsize.x || max < -boxhalfsize.x) return false;
+	if (min > boxhalfsize.x || max < -boxhalfsize.x)
+		return false;
 
 	/* test in Y-direction */
 	FINDMINMAX(v0.y, v1.y, v2.y, min, max);
-	if (min > boxhalfsize.y || max < -boxhalfsize.y) return false;
+	if (min > boxhalfsize.y || max < -boxhalfsize.y)
+		return false;
 
 	/* test in Z-direction */
 	FINDMINMAX(v0.z, v1.z, v2.z, min, max);
-	if (min > boxhalfsize.z || max < -boxhalfsize.z) return false;
+	if (min > boxhalfsize.z || max < -boxhalfsize.z)
+		return false;
 
 	/* Bullet 2: */
 	/*  test if the box intersects the plane of the triangle */
 	/*  compute plane equation of triangle: normal*x+d=0 */
 	normal = e0.cross(e1);
 	d = -normal.dot(v0); /* plane eq: normal.x+d=0 */
-	if (!planeBoxOverlap(normal, d, boxhalfsize)) return false;
+	if (!planeBoxOverlap(normal, d, boxhalfsize))
+		return false;
 
 	return true; /* box and triangle overlaps */
 }

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1477,9 +1477,14 @@ void AnimationPlayer::_set_process(bool p_process, bool p_force) {
 
 	switch (animation_process_mode) {
 
-		case ANIMATION_PROCESS_PHYSICS: set_physics_process_internal(p_process && active); break;
-		case ANIMATION_PROCESS_IDLE: set_process_internal(p_process && active); break;
-		case ANIMATION_PROCESS_MANUAL: break;
+		case ANIMATION_PROCESS_PHYSICS:
+			set_physics_process_internal(p_process && active);
+			break;
+		case ANIMATION_PROCESS_IDLE:
+			set_process_internal(p_process && active);
+			break;
+		case ANIMATION_PROCESS_MANUAL:
+			break;
 	}
 
 	processing = p_process;

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -57,8 +57,12 @@ void AnimationTreePlayer::_set_process(bool p_process, bool p_force) {
 
 	switch (animation_process_mode) {
 
-		case ANIMATION_PROCESS_PHYSICS: set_physics_process_internal(p_process && active); break;
-		case ANIMATION_PROCESS_IDLE: set_process_internal(p_process && active); break;
+		case ANIMATION_PROCESS_PHYSICS:
+			set_physics_process_internal(p_process && active);
+			break;
+		case ANIMATION_PROCESS_IDLE:
+			set_process_internal(p_process && active);
+			break;
 	}
 
 	processing = p_process;
@@ -250,17 +254,39 @@ bool AnimationTreePlayer::_get(const StringName &p_name, Variant &r_ret) const {
 		node["position"] = n->pos;
 
 		switch (n->type) {
-			case NODE_OUTPUT: node["type"] = "output"; break;
-			case NODE_ANIMATION: node["type"] = "animation"; break;
-			case NODE_ONESHOT: node["type"] = "oneshot"; break;
-			case NODE_MIX: node["type"] = "mix"; break;
-			case NODE_BLEND2: node["type"] = "blend2"; break;
-			case NODE_BLEND3: node["type"] = "blend3"; break;
-			case NODE_BLEND4: node["type"] = "blend4"; break;
-			case NODE_TIMESCALE: node["type"] = "timescale"; break;
-			case NODE_TIMESEEK: node["type"] = "timeseek"; break;
-			case NODE_TRANSITION: node["type"] = "transition"; break;
-			default: node["type"] = ""; break;
+			case NODE_OUTPUT:
+				node["type"] = "output";
+				break;
+			case NODE_ANIMATION:
+				node["type"] = "animation";
+				break;
+			case NODE_ONESHOT:
+				node["type"] = "oneshot";
+				break;
+			case NODE_MIX:
+				node["type"] = "mix";
+				break;
+			case NODE_BLEND2:
+				node["type"] = "blend2";
+				break;
+			case NODE_BLEND3:
+				node["type"] = "blend3";
+				break;
+			case NODE_BLEND4:
+				node["type"] = "blend4";
+				break;
+			case NODE_TIMESCALE:
+				node["type"] = "timescale";
+				break;
+			case NODE_TIMESEEK:
+				node["type"] = "timeseek";
+				break;
+			case NODE_TRANSITION:
+				node["type"] = "transition";
+				break;
+			default:
+				node["type"] = "";
+				break;
 		}
 
 		switch (n->type) {

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1559,7 +1559,8 @@ AnimationTreePlayer::Track *AnimationTreePlayer::_find_track(const NodePath &p_p
 		tr.skeleton = Object::cast_to<Skeleton>(child);
 		tr.spatial = Object::cast_to<Spatial>(child);
 		tr.bone_idx = bone_idx;
-		if (bone_idx == -1) tr.subpath = leftover_path;
+		if (bone_idx == -1)
+			tr.subpath = leftover_path;
 
 		track_map[key] = tr;
 	}

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -353,7 +353,8 @@ Variant &Tween::_get_delta_val(InterpolateData &p_data) {
 
 			// If we're looking at an INT value, instead convert it to a REAL
 			// This is better for interpolation
-			if (final_val.get_type() == Variant::INT) final_val = final_val.operator real_t();
+			if (final_val.get_type() == Variant::INT)
+				final_val = final_val.operator real_t();
 
 			// Calculate the delta based on the initial value and the final value
 			_calc_delta_val(p_data.initial_val, final_val, p_data.delta_val);
@@ -367,7 +368,8 @@ Variant &Tween::_get_delta_val(InterpolateData &p_data) {
 
 			// If we're looking at an INT value, instead convert it to a REAL
 			// This is better for interpolation
-			if (initial_val.get_type() == Variant::INT) initial_val = initial_val.operator real_t();
+			if (initial_val.get_type() == Variant::INT)
+				initial_val = initial_val.operator real_t();
 
 			// Calculate the delta based on the initial value and the final value
 			_calc_delta_val(initial_val, p_data.final_val, p_data.delta_val);
@@ -1265,11 +1267,14 @@ bool Tween::interpolate_property(Object *p_object, NodePath p_property, Variant 
 
 	// If no initial value given, grab the initial value from the object
 	// TODO: Is this documented? This is very useful and removes a lot of clutter from tweens!
-	if (p_initial_val.get_type() == Variant::NIL) p_initial_val = p_object->get_indexed(p_property.get_subnames());
+	if (p_initial_val.get_type() == Variant::NIL)
+		p_initial_val = p_object->get_indexed(p_property.get_subnames());
 
 	// Convert any integers into REALs as they are better for interpolation
-	if (p_initial_val.get_type() == Variant::INT) p_initial_val = p_initial_val.operator real_t();
-	if (p_final_val.get_type() == Variant::INT) p_final_val = p_final_val.operator real_t();
+	if (p_initial_val.get_type() == Variant::INT)
+		p_initial_val = p_initial_val.operator real_t();
+	if (p_final_val.get_type() == Variant::INT)
+		p_final_val = p_final_val.operator real_t();
 
 	// Build the interpolation data
 	bool result = _build_interpolation(INTER_PROPERTY, p_object, &p_property, NULL, p_initial_val, p_final_val, p_duration, p_trans_type, p_ease_type, p_delay);
@@ -1284,8 +1289,10 @@ bool Tween::interpolate_method(Object *p_object, StringName p_method, Variant p_
 	}
 
 	// Convert any integers into REALs as they are better for interpolation
-	if (p_initial_val.get_type() == Variant::INT) p_initial_val = p_initial_val.operator real_t();
-	if (p_final_val.get_type() == Variant::INT) p_final_val = p_final_val.operator real_t();
+	if (p_initial_val.get_type() == Variant::INT)
+		p_initial_val = p_initial_val.operator real_t();
+	if (p_final_val.get_type() == Variant::INT)
+		p_final_val = p_final_val.operator real_t();
 
 	// Build the interpolation data
 	bool result = _build_interpolation(INTER_METHOD, p_object, NULL, &p_method, p_initial_val, p_final_val, p_duration, p_trans_type, p_ease_type, p_delay);
@@ -1425,10 +1432,12 @@ bool Tween::follow_property(Object *p_object, NodePath p_property, Variant p_ini
 
 	// If no initial value is given, grab it from the source object
 	// TODO: Is this documented? It's really helpful for decluttering tweens
-	if (p_initial_val.get_type() == Variant::NIL) p_initial_val = p_object->get_indexed(p_property.get_subnames());
+	if (p_initial_val.get_type() == Variant::NIL)
+		p_initial_val = p_object->get_indexed(p_property.get_subnames());
 
 	// Convert initial INT values to REAL as they are better for interpolation
-	if (p_initial_val.get_type() == Variant::INT) p_initial_val = p_initial_val.operator real_t();
+	if (p_initial_val.get_type() == Variant::INT)
+		p_initial_val = p_initial_val.operator real_t();
 
 	// Confirm the source and target objects are valid
 	ERR_FAIL_COND_V(p_object == NULL, false);
@@ -1456,7 +1465,8 @@ bool Tween::follow_property(Object *p_object, NodePath p_property, Variant p_ini
 	ERR_FAIL_COND_V(!target_prop_valid, false);
 
 	// Convert target INT to REAL since it is better for interpolation
-	if (target_val.get_type() == Variant::INT) target_val = target_val.operator real_t();
+	if (target_val.get_type() == Variant::INT)
+		target_val = target_val.operator real_t();
 
 	// Verify that the target value and initial value are the same type
 	ERR_FAIL_COND_V(target_val.get_type() != p_initial_val.get_type(), false);
@@ -1492,7 +1502,8 @@ bool Tween::follow_method(Object *p_object, StringName p_method, Variant p_initi
 		return true;
 	}
 	// Convert initial INT values to REAL as they are better for interpolation
-	if (p_initial_val.get_type() == Variant::INT) p_initial_val = p_initial_val.operator real_t();
+	if (p_initial_val.get_type() == Variant::INT)
+		p_initial_val = p_initial_val.operator real_t();
 
 	// Verify the source and target objects are valid
 	ERR_FAIL_COND_V(p_object == NULL, false);
@@ -1522,7 +1533,8 @@ bool Tween::follow_method(Object *p_object, StringName p_method, Variant p_initi
 	ERR_FAIL_COND_V(error.error != Variant::CallError::CALL_OK, false);
 
 	// Convert target INT values to REAL as they are better for interpolation
-	if (target_val.get_type() == Variant::INT) target_val = target_val.operator real_t();
+	if (target_val.get_type() == Variant::INT)
+		target_val = target_val.operator real_t();
 	ERR_FAIL_COND_V(target_val.get_type() != p_initial_val.get_type(), false);
 
 	// Make the new InterpolateData for the method follow
@@ -1560,7 +1572,8 @@ bool Tween::targeting_property(Object *p_object, NodePath p_property, Object *p_
 	p_initial_property = p_initial_property.get_as_property_path();
 
 	// Convert the initial INT values to REAL as they are better for Interpolation
-	if (p_final_val.get_type() == Variant::INT) p_final_val = p_final_val.operator real_t();
+	if (p_final_val.get_type() == Variant::INT)
+		p_final_val = p_final_val.operator real_t();
 
 	// Verify both objects are valid
 	ERR_FAIL_COND_V(p_object == NULL, false);
@@ -1588,7 +1601,8 @@ bool Tween::targeting_property(Object *p_object, NodePath p_property, Object *p_
 	ERR_FAIL_COND_V(!initial_prop_valid, false);
 
 	// Convert the initial INT value to REAL as it is better for interpolation
-	if (initial_val.get_type() == Variant::INT) initial_val = initial_val.operator real_t();
+	if (initial_val.get_type() == Variant::INT)
+		initial_val = initial_val.operator real_t();
 	ERR_FAIL_COND_V(initial_val.get_type() != p_final_val.get_type(), false);
 
 	// Build the InterpolateData object
@@ -1628,7 +1642,8 @@ bool Tween::targeting_method(Object *p_object, StringName p_method, Object *p_in
 	}
 
 	// Convert final INT values to REAL as they are better for interpolation
-	if (p_final_val.get_type() == Variant::INT) p_final_val = p_final_val.operator real_t();
+	if (p_final_val.get_type() == Variant::INT)
+		p_final_val = p_final_val.operator real_t();
 
 	// Make sure the given objects are valid
 	ERR_FAIL_COND_V(p_object == NULL, false);
@@ -1658,7 +1673,8 @@ bool Tween::targeting_method(Object *p_object, StringName p_method, Object *p_in
 	ERR_FAIL_COND_V(error.error != Variant::CallError::CALL_OK, false);
 
 	// Convert initial INT values to REAL as they aer better for interpolation
-	if (initial_val.get_type() == Variant::INT) initial_val = initial_val.operator real_t();
+	if (initial_val.get_type() == Variant::INT)
+		initial_val = initial_val.operator real_t();
 	ERR_FAIL_COND_V(initial_val.get_type() != p_final_val.get_type(), false);
 
 	// Build the new InterpolateData object

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -763,8 +763,12 @@ void Tween::set_active(bool p_active) {
 
 	// Depending on physics or idle, set processing
 	switch (tween_process_mode) {
-		case TWEEN_PROCESS_IDLE: set_process_internal(p_active); break;
-		case TWEEN_PROCESS_PHYSICS: set_physics_process_internal(p_active); break;
+		case TWEEN_PROCESS_IDLE:
+			set_process_internal(p_active);
+			break;
+		case TWEEN_PROCESS_PHYSICS:
+			set_physics_process_internal(p_active);
+			break;
 	}
 }
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -443,14 +443,16 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 				case KEY_UP: {
 
 					shift_selection_check_pre(k->get_shift());
-					if (get_cursor_position() == 0) handled = false;
+					if (get_cursor_position() == 0)
+						handled = false;
 					set_cursor_position(0);
 					shift_selection_check_post(k->get_shift());
 				} break;
 				case KEY_DOWN: {
 
 					shift_selection_check_pre(k->get_shift());
-					if (get_cursor_position() == text.length()) handled = false;
+					if (get_cursor_position() == text.length())
+						handled = false;
 					set_cursor_position(text.length());
 					shift_selection_check_post(k->get_shift());
 				} break;
@@ -928,7 +930,8 @@ void LineEdit::paste_text() {
 
 	if (paste_buffer != "") {
 
-		if (selection.enabled) selection_delete();
+		if (selection.enabled)
+			selection_delete();
 		append_at_cursor(paste_buffer);
 
 		if (!text_changed_dirty) {
@@ -1080,7 +1083,8 @@ void LineEdit::_toggle_draw_caret() {
 
 void LineEdit::delete_char() {
 
-	if ((text.length() <= 0) || (cursor_pos == 0)) return;
+	if ((text.length() <= 0) || (cursor_pos == 0))
+		return;
 
 	Ref<Font> font = get_font("font");
 	if (font != NULL) {
@@ -1245,7 +1249,8 @@ int LineEdit::get_cursor_position() const {
 void LineEdit::set_window_pos(int p_pos) {
 
 	window_pos = p_pos;
-	if (window_pos < 0) window_pos = 0;
+	if (window_pos < 0)
+		window_pos = 0;
 }
 
 void LineEdit::append_at_cursor(String p_text) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -217,10 +217,18 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 		} else {                                                                                                                                                \
 			int used = wofs - margin;                                                                                                                           \
 			switch (align) {                                                                                                                                    \
-				case ALIGN_LEFT: l.offset_caches.push_back(0); break;                                                                                           \
-				case ALIGN_CENTER: l.offset_caches.push_back(((p_width - margin) - used) / 2); break;                                                           \
-				case ALIGN_RIGHT: l.offset_caches.push_back(((p_width - margin) - used)); break;                                                                \
-				case ALIGN_FILL: l.offset_caches.push_back(line_wrapped ? ((p_width - margin) - used) : 0); break;                                              \
+				case ALIGN_LEFT:                                                                                                                                \
+					l.offset_caches.push_back(0);                                                                                                               \
+					break;                                                                                                                                      \
+				case ALIGN_CENTER:                                                                                                                              \
+					l.offset_caches.push_back(((p_width - margin) - used) / 2);                                                                                 \
+					break;                                                                                                                                      \
+				case ALIGN_RIGHT:                                                                                                                               \
+					l.offset_caches.push_back(((p_width - margin) - used));                                                                                     \
+					break;                                                                                                                                      \
+				case ALIGN_FILL:                                                                                                                                \
+					l.offset_caches.push_back(line_wrapped ? ((p_width - margin) - used) : 0);                                                                  \
+					break;                                                                                                                                      \
 			}                                                                                                                                                   \
 			l.height_caches.push_back(line_height);                                                                                                             \
 			l.ascent_caches.push_back(line_ascent);                                                                                                             \
@@ -1089,7 +1097,8 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 					}
 
 				} break;
-				default: handled = false;
+				default:
+					handled = false;
 			}
 
 			if (handled)

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -250,7 +250,8 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 			line_descent = line < l.descent_caches.size() ? l.descent_caches[line] : 1;                                                                         \
 		}                                                                                                                                                       \
 		if (p_mode == PROCESS_POINTER && r_click_item && p_click_pos.y >= p_ofs.y + y && p_click_pos.y <= p_ofs.y + y + lh && p_click_pos.x < p_ofs.x + wofs) { \
-			if (r_outside) *r_outside = true;                                                                                                                   \
+			if (r_outside)                                                                                                                                      \
+				*r_outside = true;                                                                                                                              \
 			*r_click_item = it;                                                                                                                                 \
 			*r_click_char = rchar;                                                                                                                              \
 			RETURN;                                                                                                                                             \
@@ -269,7 +270,8 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 				spaces -= 1;                                                                                                                                    \
 		}                                                                                                                                                       \
 		if (p_mode == PROCESS_POINTER && r_click_item && p_click_pos.y >= p_ofs.y + y && p_click_pos.y <= p_ofs.y + y + lh && p_click_pos.x > p_ofs.x + wofs) { \
-			if (r_outside) *r_outside = true;                                                                                                                   \
+			if (r_outside)                                                                                                                                      \
+				*r_outside = true;                                                                                                                              \
 			*r_click_item = it;                                                                                                                                 \
 			*r_click_char = rchar;                                                                                                                              \
 			RETURN;                                                                                                                                             \
@@ -280,7 +282,8 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 #define ADVANCE(m_width)                                                                                                                                                                                     \
 	{                                                                                                                                                                                                        \
 		if (p_mode == PROCESS_POINTER && r_click_item && p_click_pos.y >= p_ofs.y + y && p_click_pos.y <= p_ofs.y + y + lh && p_click_pos.x >= p_ofs.x + wofs && p_click_pos.x < p_ofs.x + wofs + m_width) { \
-			if (r_outside) *r_outside = false;                                                                                                                                                               \
+			if (r_outside)                                                                                                                                                                                   \
+				*r_outside = false;                                                                                                                                                                          \
 			*r_click_item = it;                                                                                                                                                                              \
 			*r_click_char = rchar;                                                                                                                                                                           \
 			RETURN;                                                                                                                                                                                          \
@@ -738,7 +741,8 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 
 			if (p_mode == PROCESS_POINTER && r_click_item && p_click_pos.y >= p_ofs.y + y && p_click_pos.y <= p_ofs.y + y + lh) {
 				//went to next line, but pointer was on the previous one
-				if (r_outside) *r_outside = true;
+				if (r_outside)
+					*r_outside = true;
 				*r_click_item = itp;
 				*r_click_char = rchar;
 				RETURN;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -379,8 +379,10 @@ void ScrollContainer::update_scrollbars() {
 
 	Size2 hmin;
 	Size2 vmin;
-	if (scroll_h) hmin = h_scroll->get_combined_minimum_size();
-	if (scroll_v) vmin = v_scroll->get_combined_minimum_size();
+	if (scroll_h)
+		hmin = h_scroll->get_combined_minimum_size();
+	if (scroll_v)
+		vmin = v_scroll->get_combined_minimum_size();
 
 	Size2 min = child_max_size;
 

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -185,7 +185,8 @@ void Slider::_notification(int p_what) {
 				if (ticks > 1) {
 					int grabber_offset = (grabber->get_size().height / 2 - tick->get_height() / 2);
 					for (int i = 0; i < ticks; i++) {
-						if (!ticks_on_borders && (i == 0 || i + 1 == ticks)) continue;
+						if (!ticks_on_borders && (i == 0 || i + 1 == ticks))
+							continue;
 						int ofs = (i * areasize / (ticks - 1)) + grabber_offset;
 						tick->draw(ci, Point2i((size.width - widget_width) / 2, ofs));
 					}
@@ -206,7 +207,8 @@ void Slider::_notification(int p_what) {
 				if (ticks > 1) {
 					int grabber_offset = (grabber->get_size().width / 2 - tick->get_width() / 2);
 					for (int i = 0; i < ticks; i++) {
-						if ((!ticks_on_borders) && ((i == 0) || ((i + 1) == ticks))) continue;
+						if ((!ticks_on_borders) && ((i == 0) || ((i + 1) == ticks)))
+							continue;
 						int ofs = (i * areasize / (ticks - 1)) + grabber_offset;
 						tick->draw(ci, Point2i(ofs, (size.height - widget_height) / 2));
 					}

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -408,7 +408,8 @@ int Tabs::get_tab_count() const {
 
 void Tabs::set_current_tab(int p_current) {
 
-	if (current == p_current) return;
+	if (current == p_current)
+		return;
 	ERR_FAIL_INDEX(p_current, get_tab_count());
 
 	current = p_current;
@@ -864,7 +865,8 @@ void Tabs::ensure_tab_visible(int p_idx) {
 	if (!is_inside_tree())
 		return;
 
-	if (tabs.size() == 0) return;
+	if (tabs.size() == 0)
+		return;
 	ERR_FAIL_INDEX(p_idx, tabs.size());
 
 	if (p_idx == offset) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2556,7 +2556,8 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 			} break;
 			case KEY_TAB: {
-				if (k->get_command()) break; // avoid tab when command
+				if (k->get_command())
+					break; // avoid tab when command
 
 				if (readonly)
 					break;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2222,7 +2222,8 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 	bool is_command = k.is_valid() && k->get_command();
 	if (p_event->is_action("ui_right") && p_event->is_pressed()) {
 
-		if (!cursor_can_exit_tree) accept_event();
+		if (!cursor_can_exit_tree)
+			accept_event();
 
 		if (!selected_item || select_mode == SELECT_ROW || selected_col > (columns.size() - 1)) {
 			return;
@@ -2239,7 +2240,8 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 		}
 	} else if (p_event->is_action("ui_left") && p_event->is_pressed()) {
 
-		if (!cursor_can_exit_tree) accept_event();
+		if (!cursor_can_exit_tree)
+			accept_event();
 
 		if (!selected_item || select_mode == SELECT_ROW || selected_col < 0) {
 			return;
@@ -2258,19 +2260,22 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 	} else if (p_event->is_action("ui_up") && p_event->is_pressed() && !is_command) {
 
-		if (!cursor_can_exit_tree) accept_event();
+		if (!cursor_can_exit_tree)
+			accept_event();
 
 		_go_up();
 
 	} else if (p_event->is_action("ui_down") && p_event->is_pressed() && !is_command) {
 
-		if (!cursor_can_exit_tree) accept_event();
+		if (!cursor_can_exit_tree)
+			accept_event();
 
 		_go_down();
 
 	} else if (p_event->is_action("ui_page_down") && p_event->is_pressed()) {
 
-		if (!cursor_can_exit_tree) accept_event();
+		if (!cursor_can_exit_tree)
+			accept_event();
 
 		TreeItem *next = NULL;
 		if (!selected_item)
@@ -2308,7 +2313,8 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 		ensure_cursor_is_visible();
 	} else if (p_event->is_action("ui_page_up") && p_event->is_pressed()) {
 
-		if (!cursor_can_exit_tree) accept_event();
+		if (!cursor_can_exit_tree)
+			accept_event();
 
 		TreeItem *prev = NULL;
 		if (!selected_item)

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -744,10 +744,14 @@ const Map<StringName, MultiplayerAPI::RPCMode>::Element *Node::get_node_rset_mod
 
 bool Node::can_process_notification(int p_what) const {
 	switch (p_what) {
-		case NOTIFICATION_PHYSICS_PROCESS: return data.physics_process;
-		case NOTIFICATION_PROCESS: return data.idle_process;
-		case NOTIFICATION_INTERNAL_PROCESS: return data.idle_process_internal;
-		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: return data.physics_process_internal;
+		case NOTIFICATION_PHYSICS_PROCESS:
+			return data.physics_process;
+		case NOTIFICATION_PROCESS:
+			return data.idle_process;
+		case NOTIFICATION_INTERNAL_PROCESS:
+			return data.idle_process_internal;
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS:
+			return data.physics_process_internal;
 	}
 
 	return true;
@@ -2918,10 +2922,14 @@ void Node::_bind_methods() {
 
 String Node::_get_name_num_separator() {
 	switch (ProjectSettings::get_singleton()->get("node/name_num_separator").operator int()) {
-		case 0: return "";
-		case 1: return " ";
-		case 2: return "_";
-		case 3: return "-";
+		case 0:
+			return "";
+		case 1:
+			return " ";
+		case 2:
+			return "_";
+		case 3:
+			return "-";
 	}
 	return " ";
 }

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -171,8 +171,12 @@ Timer::TimerProcessMode Timer::get_timer_process_mode() const {
 
 void Timer::_set_process(bool p_process, bool p_force) {
 	switch (timer_process_mode) {
-		case TIMER_PROCESS_PHYSICS: set_physics_process_internal(p_process && !paused); break;
-		case TIMER_PROCESS_IDLE: set_process_internal(p_process && !paused); break;
+		case TIMER_PROCESS_PHYSICS:
+			set_physics_process_internal(p_process && !paused);
+			break;
+		case TIMER_PROCESS_IDLE:
+			set_process_internal(p_process && !paused);
+			break;
 	}
 	processing = p_process;
 }

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -349,12 +349,24 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 
 			switch (track_get_type(track)) {
 
-				case TYPE_TRANSFORM: r_ret = "transform"; break;
-				case TYPE_VALUE: r_ret = "value"; break;
-				case TYPE_METHOD: r_ret = "method"; break;
-				case TYPE_BEZIER: r_ret = "bezier"; break;
-				case TYPE_AUDIO: r_ret = "audio"; break;
-				case TYPE_ANIMATION: r_ret = "animation"; break;
+				case TYPE_TRANSFORM:
+					r_ret = "transform";
+					break;
+				case TYPE_VALUE:
+					r_ret = "value";
+					break;
+				case TYPE_METHOD:
+					r_ret = "method";
+					break;
+				case TYPE_BEZIER:
+					r_ret = "bezier";
+					break;
+				case TYPE_AUDIO:
+					r_ret = "audio";
+					break;
+				case TYPE_ANIMATION:
+					r_ret = "animation";
+					break;
 			}
 
 			return true;
@@ -1855,7 +1867,8 @@ T Animation::_interpolate(const Vector<TKey<T> > &p_keys, float p_time, Interpol
 			return _cubic_interpolate(p_keys[pre].value, p_keys[idx].value, p_keys[next].value, p_keys[post].value, c);
 
 		} break;
-		default: return p_keys[idx].value;
+		default:
+			return p_keys[idx].value;
 	}
 
 	// do a barrel roll

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -229,9 +229,15 @@ void AudioStreamPlaybackSample::mix(AudioFrame *p_buffer, float p_rate_scale, in
 
 	int len = base->data_bytes;
 	switch (base->format) {
-		case AudioStreamSample::FORMAT_8_BITS: len /= 1; break;
-		case AudioStreamSample::FORMAT_16_BITS: len /= 2; break;
-		case AudioStreamSample::FORMAT_IMA_ADPCM: len *= 2; break;
+		case AudioStreamSample::FORMAT_8_BITS:
+			len /= 1;
+			break;
+		case AudioStreamSample::FORMAT_16_BITS:
+			len /= 2;
+			break;
+		case AudioStreamSample::FORMAT_IMA_ADPCM:
+			len *= 2;
+			break;
 	}
 
 	if (base->stereo) {
@@ -463,9 +469,15 @@ float AudioStreamSample::get_length() const {
 
 	int len = data_bytes;
 	switch (format) {
-		case AudioStreamSample::FORMAT_8_BITS: len /= 1; break;
-		case AudioStreamSample::FORMAT_16_BITS: len /= 2; break;
-		case AudioStreamSample::FORMAT_IMA_ADPCM: len *= 2; break;
+		case AudioStreamSample::FORMAT_8_BITS:
+			len /= 1;
+			break;
+		case AudioStreamSample::FORMAT_16_BITS:
+			len /= 2;
+			break;
+		case AudioStreamSample::FORMAT_IMA_ADPCM:
+			len *= 2;
+			break;
 	}
 
 	if (stereo) {
@@ -534,9 +546,15 @@ Error AudioStreamSample::save_to_wav(const String &p_path) {
 
 	int byte_pr_sample = 0;
 	switch (format) {
-		case AudioStreamSample::FORMAT_8_BITS: byte_pr_sample = 1; break;
-		case AudioStreamSample::FORMAT_16_BITS: byte_pr_sample = 2; break;
-		case AudioStreamSample::FORMAT_IMA_ADPCM: byte_pr_sample = 4; break;
+		case AudioStreamSample::FORMAT_8_BITS:
+			byte_pr_sample = 1;
+			break;
+		case AudioStreamSample::FORMAT_16_BITS:
+			byte_pr_sample = 2;
+			break;
+		case AudioStreamSample::FORMAT_IMA_ADPCM:
+			byte_pr_sample = 4;
+			break;
 	}
 
 	String file_path = p_path;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -414,10 +414,18 @@ void SpatialMaterial::_update_shader() {
 
 	String code = "shader_type spatial;\nrender_mode ";
 	switch (blend_mode) {
-		case BLEND_MODE_MIX: code += "blend_mix"; break;
-		case BLEND_MODE_ADD: code += "blend_add"; break;
-		case BLEND_MODE_SUB: code += "blend_sub"; break;
-		case BLEND_MODE_MUL: code += "blend_mul"; break;
+		case BLEND_MODE_MIX:
+			code += "blend_mix";
+			break;
+		case BLEND_MODE_ADD:
+			code += "blend_add";
+			break;
+		case BLEND_MODE_SUB:
+			code += "blend_sub";
+			break;
+		case BLEND_MODE_MUL:
+			code += "blend_mul";
+			break;
 	}
 
 	DepthDrawMode ddm = depth_draw_mode;
@@ -426,30 +434,64 @@ void SpatialMaterial::_update_shader() {
 	}
 
 	switch (ddm) {
-		case DEPTH_DRAW_OPAQUE_ONLY: code += ",depth_draw_opaque"; break;
-		case DEPTH_DRAW_ALWAYS: code += ",depth_draw_always"; break;
-		case DEPTH_DRAW_DISABLED: code += ",depth_draw_never"; break;
-		case DEPTH_DRAW_ALPHA_OPAQUE_PREPASS: code += ",depth_draw_alpha_prepass"; break;
+		case DEPTH_DRAW_OPAQUE_ONLY:
+			code += ",depth_draw_opaque";
+			break;
+		case DEPTH_DRAW_ALWAYS:
+			code += ",depth_draw_always";
+			break;
+		case DEPTH_DRAW_DISABLED:
+			code += ",depth_draw_never";
+			break;
+		case DEPTH_DRAW_ALPHA_OPAQUE_PREPASS:
+			code += ",depth_draw_alpha_prepass";
+			break;
 	}
 
 	switch (cull_mode) {
-		case CULL_BACK: code += ",cull_back"; break;
-		case CULL_FRONT: code += ",cull_front"; break;
-		case CULL_DISABLED: code += ",cull_disabled"; break;
+		case CULL_BACK:
+			code += ",cull_back";
+			break;
+		case CULL_FRONT:
+			code += ",cull_front";
+			break;
+		case CULL_DISABLED:
+			code += ",cull_disabled";
+			break;
 	}
 	switch (diffuse_mode) {
-		case DIFFUSE_BURLEY: code += ",diffuse_burley"; break;
-		case DIFFUSE_LAMBERT: code += ",diffuse_lambert"; break;
-		case DIFFUSE_LAMBERT_WRAP: code += ",diffuse_lambert_wrap"; break;
-		case DIFFUSE_OREN_NAYAR: code += ",diffuse_oren_nayar"; break;
-		case DIFFUSE_TOON: code += ",diffuse_toon"; break;
+		case DIFFUSE_BURLEY:
+			code += ",diffuse_burley";
+			break;
+		case DIFFUSE_LAMBERT:
+			code += ",diffuse_lambert";
+			break;
+		case DIFFUSE_LAMBERT_WRAP:
+			code += ",diffuse_lambert_wrap";
+			break;
+		case DIFFUSE_OREN_NAYAR:
+			code += ",diffuse_oren_nayar";
+			break;
+		case DIFFUSE_TOON:
+			code += ",diffuse_toon";
+			break;
 	}
 	switch (specular_mode) {
-		case SPECULAR_SCHLICK_GGX: code += ",specular_schlick_ggx"; break;
-		case SPECULAR_BLINN: code += ",specular_blinn"; break;
-		case SPECULAR_PHONG: code += ",specular_phong"; break;
-		case SPECULAR_TOON: code += ",specular_toon"; break;
-		case SPECULAR_DISABLED: code += ",specular_disabled"; break;
+		case SPECULAR_SCHLICK_GGX:
+			code += ",specular_schlick_ggx";
+			break;
+		case SPECULAR_BLINN:
+			code += ",specular_blinn";
+			break;
+		case SPECULAR_PHONG:
+			code += ",specular_phong";
+			break;
+		case SPECULAR_TOON:
+			code += ",specular_toon";
+			break;
+		case SPECULAR_DISABLED:
+			code += ",specular_disabled";
+			break;
 	}
 
 	if (flags[FLAG_UNSHADED]) {

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -690,7 +690,8 @@ void ParticlesMaterial::set_param(Parameter p_param, float p_value) {
 		case PARAM_ANIM_OFFSET: {
 			VisualServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_offset, p_value);
 		} break;
-		case PARAM_MAX: break; // Can't happen, but silences warning
+		case PARAM_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 float ParticlesMaterial::get_param(Parameter p_param) const {
@@ -743,7 +744,8 @@ void ParticlesMaterial::set_param_randomness(Parameter p_param, float p_value) {
 		case PARAM_ANIM_OFFSET: {
 			VisualServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_offset_random, p_value);
 		} break;
-		case PARAM_MAX: break; // Can't happen, but silences warning
+		case PARAM_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 float ParticlesMaterial::get_param_randomness(Parameter p_param) const {
@@ -815,7 +817,8 @@ void ParticlesMaterial::set_param_texture(Parameter p_param, const Ref<Texture> 
 		case PARAM_ANIM_OFFSET: {
 			VisualServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_offset_texture, p_texture);
 		} break;
-		case PARAM_MAX: break; // Can't happen, but silences warning
+		case PARAM_MAX:
+			break; // Can't happen, but silences warning
 	}
 
 	_queue_shader_change();

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1124,8 +1124,10 @@ bool AtlasTexture::is_pixel_opaque(int p_x, int p_y) const {
 	int y = p_y + region.position.y - margin.position.y;
 
 	// margin edge may outside of atlas
-	if (x < 0 || x >= atlas->get_width()) return false;
-	if (y < 0 || y >= atlas->get_height()) return false;
+	if (x < 0 || x >= atlas->get_width())
+		return false;
+	if (y < 0 || y >= atlas->get_height())
+		return false;
 
 	return atlas->is_pixel_opaque(x, y);
 }

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -428,7 +428,8 @@ private:
 
 	_FORCE_INLINE_ bool _is_valid() const {
 		for (int i = 0; i < 6; i++) {
-			if (valid[i]) return true;
+			if (valid[i])
+				return true;
 		}
 		return false;
 	}

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -942,7 +942,8 @@ void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 
 		if (p_shapes[i].get_type() == Variant::OBJECT) {
 			Ref<Shape2D> shape = p_shapes[i];
-			if (shape.is_null()) continue;
+			if (shape.is_null())
+				continue;
 
 			s.shape = shape;
 			s.shape_transform = default_transform;

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -935,10 +935,18 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 
 		outputs[i] = "n_out" + itos(node) + "p" + itos(i);
 		switch (vsnode->get_output_port_type(i)) {
-			case VisualShaderNode::PORT_TYPE_SCALAR: code += String() + "\tfloat " + outputs[i] + ";\n"; break;
-			case VisualShaderNode::PORT_TYPE_VECTOR: code += String() + "\tvec3 " + outputs[i] + ";\n"; break;
-			case VisualShaderNode::PORT_TYPE_BOOLEAN: code += String() + "\tbool " + outputs[i] + ";\n"; break;
-			case VisualShaderNode::PORT_TYPE_TRANSFORM: code += String() + "\tmat4 " + outputs[i] + ";\n"; break;
+			case VisualShaderNode::PORT_TYPE_SCALAR:
+				code += String() + "\tfloat " + outputs[i] + ";\n";
+				break;
+			case VisualShaderNode::PORT_TYPE_VECTOR:
+				code += String() + "\tvec3 " + outputs[i] + ";\n";
+				break;
+			case VisualShaderNode::PORT_TYPE_BOOLEAN:
+				code += String() + "\tbool " + outputs[i] + ";\n";
+				break;
+			case VisualShaderNode::PORT_TYPE_TRANSFORM:
+				code += String() + "\tmat4 " + outputs[i] + ";\n";
+				break;
 			default: {
 			}
 		}

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -384,9 +384,14 @@ String VisualShaderNodeTexture::generate_global(Shader::Mode p_mode, VisualShade
 
 		String u = "uniform sampler2D " + make_unique_id(p_type, p_id, "tex");
 		switch (texture_type) {
-			case TYPE_DATA: break;
-			case TYPE_COLOR: u += " : hint_albedo"; break;
-			case TYPE_NORMALMAP: u += " : hint_normal"; break;
+			case TYPE_DATA:
+				break;
+			case TYPE_COLOR:
+				u += " : hint_albedo";
+				break;
+			case TYPE_NORMALMAP:
+				u += " : hint_normal";
+				break;
 		}
 		return u + ";";
 	}
@@ -614,9 +619,14 @@ String VisualShaderNodeCubeMap::generate_global(Shader::Mode p_mode, VisualShade
 
 	String u = "uniform sampler2DCube " + make_unique_id(p_type, p_id, "cube");
 	switch (texture_type) {
-		case TYPE_DATA: break;
-		case TYPE_COLOR: u += " : hint_albedo"; break;
-		case TYPE_NORMALMAP: u += " : hint_normal"; break;
+		case TYPE_DATA:
+			break;
+		case TYPE_COLOR:
+			u += " : hint_albedo";
+			break;
+		case TYPE_NORMALMAP:
+			u += " : hint_normal";
+			break;
 	}
 	return u + ";";
 }
@@ -718,16 +728,36 @@ String VisualShaderNodeScalarOp::generate_code(Shader::Mode p_mode, VisualShader
 	String code = "\t" + p_output_vars[0] + " = ";
 	switch (op) {
 
-		case OP_ADD: code += p_input_vars[0] + " + " + p_input_vars[1] + ";\n"; break;
-		case OP_SUB: code += p_input_vars[0] + " - " + p_input_vars[1] + ";\n"; break;
-		case OP_MUL: code += p_input_vars[0] + " * " + p_input_vars[1] + ";\n"; break;
-		case OP_DIV: code += p_input_vars[0] + " / " + p_input_vars[1] + ";\n"; break;
-		case OP_MOD: code += "mod( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_POW: code += "pow( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_MAX: code += "max( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_MIN: code += "min( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_ATAN2: code += "atan( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_STEP: code += "step( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
+		case OP_ADD:
+			code += p_input_vars[0] + " + " + p_input_vars[1] + ";\n";
+			break;
+		case OP_SUB:
+			code += p_input_vars[0] + " - " + p_input_vars[1] + ";\n";
+			break;
+		case OP_MUL:
+			code += p_input_vars[0] + " * " + p_input_vars[1] + ";\n";
+			break;
+		case OP_DIV:
+			code += p_input_vars[0] + " / " + p_input_vars[1] + ";\n";
+			break;
+		case OP_MOD:
+			code += "mod( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_POW:
+			code += "pow( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_MAX:
+			code += "max( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_MIN:
+			code += "min( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_ATAN2:
+			code += "atan( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_STEP:
+			code += "step( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
 	}
 
 	return code;
@@ -806,18 +836,42 @@ String VisualShaderNodeVectorOp::generate_code(Shader::Mode p_mode, VisualShader
 	String code = "\t" + p_output_vars[0] + " = ";
 	switch (op) {
 
-		case OP_ADD: code += p_input_vars[0] + " + " + p_input_vars[1] + ";\n"; break;
-		case OP_SUB: code += p_input_vars[0] + " - " + p_input_vars[1] + ";\n"; break;
-		case OP_MUL: code += p_input_vars[0] + " * " + p_input_vars[1] + ";\n"; break;
-		case OP_DIV: code += p_input_vars[0] + " / " + p_input_vars[1] + ";\n"; break;
-		case OP_MOD: code += "mod( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_POW: code += "pow( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_MAX: code += "max( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_MIN: code += "min( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_CROSS: code += "cross( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_ATAN2: code += "atan( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_REFLECT: code += "reflect( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
-		case OP_STEP: code += "step( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n"; break;
+		case OP_ADD:
+			code += p_input_vars[0] + " + " + p_input_vars[1] + ";\n";
+			break;
+		case OP_SUB:
+			code += p_input_vars[0] + " - " + p_input_vars[1] + ";\n";
+			break;
+		case OP_MUL:
+			code += p_input_vars[0] + " * " + p_input_vars[1] + ";\n";
+			break;
+		case OP_DIV:
+			code += p_input_vars[0] + " / " + p_input_vars[1] + ";\n";
+			break;
+		case OP_MOD:
+			code += "mod( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_POW:
+			code += "pow( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_MAX:
+			code += "max( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_MIN:
+			code += "min( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_CROSS:
+			code += "cross( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_ATAN2:
+			code += "atan( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_REFLECT:
+			code += "reflect( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
+		case OP_STEP:
+			code += "step( " + p_input_vars[0] + " , " + p_input_vars[1] + " );\n";
+			break;
 	}
 
 	return code;
@@ -2844,8 +2898,12 @@ String VisualShaderNodeTextureUniform::generate_global(Shader::Mode p_mode, Visu
 			else
 				code += " : hint_albedo;\n";
 			break;
-		case TYPE_NORMALMAP: code += " : hint_normal;\n"; break;
-		case TYPE_ANISO: code += " : hint_aniso;\n"; break;
+		case TYPE_NORMALMAP:
+			code += " : hint_normal;\n";
+			break;
+		case TYPE_ANISO:
+			code += " : hint_aniso;\n";
+			break;
 	}
 
 	return code;

--- a/servers/audio/audio_filter_sw.cpp
+++ b/servers/audio/audio_filter_sw.cpp
@@ -58,7 +58,8 @@ void AudioFilterSW::prepare_coefficients(Coeffs *p_coeffs) {
 	int sr_limit = (sampling_rate / 2) + 512;
 
 	double final_cutoff = (cutoff > sr_limit) ? sr_limit : cutoff;
-	if (final_cutoff < 1) final_cutoff = 1; //don't allow less than this
+	if (final_cutoff < 1)
+		final_cutoff = 1; //don't allow less than this
 
 	double omega = 2.0 * Math_PI * final_cutoff / sampling_rate;
 

--- a/servers/audio/audio_rb_resampler.cpp
+++ b/servers/audio/audio_rb_resampler.cpp
@@ -119,10 +119,18 @@ bool AudioRBResampler::mix(AudioFrame *p_dest, int p_frames) {
 	{
 		int src_read = 0;
 		switch (channels) {
-			case 1: src_read = _resample<1>(p_dest, target_todo, increment); break;
-			case 2: src_read = _resample<2>(p_dest, target_todo, increment); break;
-			case 4: src_read = _resample<4>(p_dest, target_todo, increment); break;
-			case 6: src_read = _resample<6>(p_dest, target_todo, increment); break;
+			case 1:
+				src_read = _resample<1>(p_dest, target_todo, increment);
+				break;
+			case 2:
+				src_read = _resample<2>(p_dest, target_todo, increment);
+				break;
+			case 4:
+				src_read = _resample<4>(p_dest, target_todo, increment);
+				break;
+			case 6:
+				src_read = _resample<6>(p_dest, target_todo, increment);
+				break;
 		}
 
 		if (src_read > read_space)

--- a/servers/audio/effects/audio_effect_filter.h
+++ b/servers/audio/effects/audio_effect_filter.h
@@ -98,7 +98,8 @@ class AudioEffectLowPassFilter : public AudioEffectFilter {
 	GDCLASS(AudioEffectLowPassFilter, AudioEffectFilter)
 
 	void _validate_property(PropertyInfo &property) const {
-		if (property.name == "gain") property.usage = 0;
+		if (property.name == "gain")
+			property.usage = 0;
 	}
 
 public:
@@ -109,7 +110,8 @@ public:
 class AudioEffectHighPassFilter : public AudioEffectFilter {
 	GDCLASS(AudioEffectHighPassFilter, AudioEffectFilter)
 	void _validate_property(PropertyInfo &property) const {
-		if (property.name == "gain") property.usage = 0;
+		if (property.name == "gain")
+			property.usage = 0;
 	}
 
 public:
@@ -120,7 +122,8 @@ public:
 class AudioEffectBandPassFilter : public AudioEffectFilter {
 	GDCLASS(AudioEffectBandPassFilter, AudioEffectFilter)
 	void _validate_property(PropertyInfo &property) const {
-		if (property.name == "gain") property.usage = 0;
+		if (property.name == "gain")
+			property.usage = 0;
 	}
 
 public:

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -50,7 +50,8 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 
 	for (i = 2; i < 2 * fftFrameSize - 2; i += 2) {
 		for (bitm = 2, j = 0; bitm < 2 * fftFrameSize; bitm <<= 1) {
-			if (i & bitm) j++;
+			if (i & bitm)
+				j++;
 			j <<= 1;
 		}
 		if (i < j) {

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -110,9 +110,12 @@ void AudioDriver::input_buffer_write(int32_t sample) {
 
 AudioDriver::SpeakerMode AudioDriver::get_speaker_mode_by_total_channels(int p_channels) const {
 	switch (p_channels) {
-		case 4: return SPEAKER_SURROUND_31;
-		case 6: return SPEAKER_SURROUND_51;
-		case 8: return SPEAKER_SURROUND_71;
+		case 4:
+			return SPEAKER_SURROUND_31;
+		case 6:
+			return SPEAKER_SURROUND_51;
+		case 8:
+			return SPEAKER_SURROUND_71;
 	}
 
 	// Default to STEREO
@@ -121,10 +124,14 @@ AudioDriver::SpeakerMode AudioDriver::get_speaker_mode_by_total_channels(int p_c
 
 int AudioDriver::get_total_channels_by_speaker_mode(AudioDriver::SpeakerMode p_mode) const {
 	switch (p_mode) {
-		case SPEAKER_MODE_STEREO: return 2;
-		case SPEAKER_SURROUND_31: return 4;
-		case SPEAKER_SURROUND_51: return 6;
-		case SPEAKER_SURROUND_71: return 8;
+		case SPEAKER_MODE_STEREO:
+			return 2;
+		case SPEAKER_SURROUND_31:
+			return 4;
+		case SPEAKER_SURROUND_51:
+			return 6;
+		case SPEAKER_SURROUND_71:
+			return 8;
 	}
 
 	ERR_FAIL_V(2);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -278,10 +278,14 @@ protected:
 public:
 	_FORCE_INLINE_ int get_channel_count() const {
 		switch (get_speaker_mode()) {
-			case SPEAKER_MODE_STEREO: return 1;
-			case SPEAKER_SURROUND_31: return 2;
-			case SPEAKER_SURROUND_51: return 3;
-			case SPEAKER_SURROUND_71: return 4;
+			case SPEAKER_MODE_STEREO:
+				return 1;
+			case SPEAKER_SURROUND_31:
+				return 2;
+			case SPEAKER_SURROUND_51:
+				return 3;
+			case SPEAKER_SURROUND_71:
+				return 4;
 		}
 		ERR_FAIL_V(1);
 	}

--- a/servers/physics/area_sw.cpp
+++ b/servers/physics/area_sw.cpp
@@ -126,28 +126,52 @@ void AreaSW::set_space_override_mode(PhysicsServer::AreaSpaceOverrideMode p_mode
 void AreaSW::set_param(PhysicsServer::AreaParameter p_param, const Variant &p_value) {
 
 	switch (p_param) {
-		case PhysicsServer::AREA_PARAM_GRAVITY: gravity = p_value; break;
-		case PhysicsServer::AREA_PARAM_GRAVITY_VECTOR: gravity_vector = p_value; break;
-		case PhysicsServer::AREA_PARAM_GRAVITY_IS_POINT: gravity_is_point = p_value; break;
-		case PhysicsServer::AREA_PARAM_GRAVITY_DISTANCE_SCALE: gravity_distance_scale = p_value; break;
-		case PhysicsServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION: point_attenuation = p_value; break;
-		case PhysicsServer::AREA_PARAM_LINEAR_DAMP: linear_damp = p_value; break;
-		case PhysicsServer::AREA_PARAM_ANGULAR_DAMP: angular_damp = p_value; break;
-		case PhysicsServer::AREA_PARAM_PRIORITY: priority = p_value; break;
+		case PhysicsServer::AREA_PARAM_GRAVITY:
+			gravity = p_value;
+			break;
+		case PhysicsServer::AREA_PARAM_GRAVITY_VECTOR:
+			gravity_vector = p_value;
+			break;
+		case PhysicsServer::AREA_PARAM_GRAVITY_IS_POINT:
+			gravity_is_point = p_value;
+			break;
+		case PhysicsServer::AREA_PARAM_GRAVITY_DISTANCE_SCALE:
+			gravity_distance_scale = p_value;
+			break;
+		case PhysicsServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION:
+			point_attenuation = p_value;
+			break;
+		case PhysicsServer::AREA_PARAM_LINEAR_DAMP:
+			linear_damp = p_value;
+			break;
+		case PhysicsServer::AREA_PARAM_ANGULAR_DAMP:
+			angular_damp = p_value;
+			break;
+		case PhysicsServer::AREA_PARAM_PRIORITY:
+			priority = p_value;
+			break;
 	}
 }
 
 Variant AreaSW::get_param(PhysicsServer::AreaParameter p_param) const {
 
 	switch (p_param) {
-		case PhysicsServer::AREA_PARAM_GRAVITY: return gravity;
-		case PhysicsServer::AREA_PARAM_GRAVITY_VECTOR: return gravity_vector;
-		case PhysicsServer::AREA_PARAM_GRAVITY_IS_POINT: return gravity_is_point;
-		case PhysicsServer::AREA_PARAM_GRAVITY_DISTANCE_SCALE: return gravity_distance_scale;
-		case PhysicsServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION: return point_attenuation;
-		case PhysicsServer::AREA_PARAM_LINEAR_DAMP: return linear_damp;
-		case PhysicsServer::AREA_PARAM_ANGULAR_DAMP: return angular_damp;
-		case PhysicsServer::AREA_PARAM_PRIORITY: return priority;
+		case PhysicsServer::AREA_PARAM_GRAVITY:
+			return gravity;
+		case PhysicsServer::AREA_PARAM_GRAVITY_VECTOR:
+			return gravity_vector;
+		case PhysicsServer::AREA_PARAM_GRAVITY_IS_POINT:
+			return gravity_is_point;
+		case PhysicsServer::AREA_PARAM_GRAVITY_DISTANCE_SCALE:
+			return gravity_distance_scale;
+		case PhysicsServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION:
+			return point_attenuation;
+		case PhysicsServer::AREA_PARAM_LINEAR_DAMP:
+			return linear_damp;
+		case PhysicsServer::AREA_PARAM_ANGULAR_DAMP:
+			return angular_damp;
+		case PhysicsServer::AREA_PARAM_PRIORITY:
+			return priority;
 	}
 
 	return Variant();

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -175,7 +175,8 @@ public:
 	_FORCE_INLINE_ void set_max_contacts_reported(int p_size) {
 		contacts.resize(p_size);
 		contact_count = 0;
-		if (mode == PhysicsServer::BODY_MODE_KINEMATIC && p_size) set_active(true);
+		if (mode == PhysicsServer::BODY_MODE_KINEMATIC && p_size)
+			set_active(true);
 	}
 	_FORCE_INLINE_ int get_max_contacts_reported() const { return contacts.size(); }
 

--- a/servers/physics/collision_object_sw.h
+++ b/servers/physics/collision_object_sw.h
@@ -96,7 +96,8 @@ protected:
 #endif
 
 		transform = p_transform;
-		if (p_update_shapes) _update_shapes();
+		if (p_update_shapes)
+			_update_shapes();
 	}
 	_FORCE_INLINE_ void _set_inv_transform(const Transform &p_transform) { inv_transform = p_transform; }
 	void _set_static(bool p_static);

--- a/servers/physics/joints/cone_twist_joint_sw.cpp
+++ b/servers/physics/joints/cone_twist_joint_sw.cpp
@@ -332,7 +332,8 @@ void ConeTwistJointSW::set_param(PhysicsServer::ConeTwistJointParam p_param, rea
 
 			m_relaxationFactor = p_value;
 		} break;
-		case PhysicsServer::CONE_TWIST_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::CONE_TWIST_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 
@@ -359,7 +360,8 @@ real_t ConeTwistJointSW::get_param(PhysicsServer::ConeTwistJointParam p_param) c
 
 			return m_relaxationFactor;
 		} break;
-		case PhysicsServer::CONE_TWIST_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::CONE_TWIST_MAX:
+			break; // Can't happen, but silences warning
 	}
 
 	return 0;

--- a/servers/physics/joints/generic_6dof_joint_sw.cpp
+++ b/servers/physics/joints/generic_6dof_joint_sw.cpp
@@ -83,7 +83,8 @@ int G6DOFRotationalLimitMotorSW::testLimitValue(real_t test_value) {
 real_t G6DOFRotationalLimitMotorSW::solveAngularLimits(
 		real_t timeStep, Vector3 &axis, real_t jacDiagABInv,
 		BodySW *body0, BodySW *body1) {
-	if (!needApplyTorques()) return 0.0f;
+	if (!needApplyTorques())
+		return 0.0f;
 
 	real_t target_velocity = m_targetVelocity;
 	real_t maxMotorForce = m_maxMotorForce;
@@ -137,7 +138,8 @@ real_t G6DOFRotationalLimitMotorSW::solveAngularLimits(
 	Vector3 motorImp = clippedMotorImpulse * axis;
 
 	body0->apply_torque_impulse(motorImp);
-	if (body1) body1->apply_torque_impulse(-motorImp);
+	if (body1)
+		body1->apply_torque_impulse(-motorImp);
 
 	return clippedMotorImpulse;
 }

--- a/servers/physics/joints/generic_6dof_joint_sw.cpp
+++ b/servers/physics/joints/generic_6dof_joint_sw.cpp
@@ -521,7 +521,8 @@ void Generic6DOFJointSW::set_param(Vector3::Axis p_axis, PhysicsServer::G6DOFJoi
 		case PhysicsServer::G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT: {
 			// Not implemented in GodotPhysics backend
 		} break;
-		case PhysicsServer::G6DOF_JOINT_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::G6DOF_JOINT_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 
@@ -621,7 +622,8 @@ real_t Generic6DOFJointSW::get_param(Vector3::Axis p_axis, PhysicsServer::G6DOFJ
 		case PhysicsServer::G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT: {
 			// Not implemented in GodotPhysics backend
 		} break;
-		case PhysicsServer::G6DOF_JOINT_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::G6DOF_JOINT_MAX:
+			break; // Can't happen, but silences warning
 	}
 	return 0;
 }
@@ -652,7 +654,8 @@ void Generic6DOFJointSW::set_flag(Vector3::Axis p_axis, PhysicsServer::G6DOFJoin
 		case PhysicsServer::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING: {
 			// Not implemented in GodotPhysics backend
 		} break;
-		case PhysicsServer::G6DOF_JOINT_FLAG_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::G6DOF_JOINT_FLAG_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 bool Generic6DOFJointSW::get_flag(Vector3::Axis p_axis, PhysicsServer::G6DOFJointAxisFlag p_flag) const {
@@ -680,7 +683,8 @@ bool Generic6DOFJointSW::get_flag(Vector3::Axis p_axis, PhysicsServer::G6DOFJoin
 		case PhysicsServer::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING: {
 			// Not implemented in GodotPhysics backend
 		} break;
-		case PhysicsServer::G6DOF_JOINT_FLAG_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::G6DOF_JOINT_FLAG_MAX:
+			break; // Can't happen, but silences warning
 	}
 
 	return 0;

--- a/servers/physics/joints/hinge_joint_sw.cpp
+++ b/servers/physics/joints/hinge_joint_sw.cpp
@@ -401,15 +401,32 @@ void HingeJointSW::set_param(PhysicsServer::HingeJointParam p_param, real_t p_va
 
 	switch (p_param) {
 
-		case PhysicsServer::HINGE_JOINT_BIAS: tau = p_value; break;
-		case PhysicsServer::HINGE_JOINT_LIMIT_UPPER: m_upperLimit = p_value; break;
-		case PhysicsServer::HINGE_JOINT_LIMIT_LOWER: m_lowerLimit = p_value; break;
-		case PhysicsServer::HINGE_JOINT_LIMIT_BIAS: m_biasFactor = p_value; break;
-		case PhysicsServer::HINGE_JOINT_LIMIT_SOFTNESS: m_limitSoftness = p_value; break;
-		case PhysicsServer::HINGE_JOINT_LIMIT_RELAXATION: m_relaxationFactor = p_value; break;
-		case PhysicsServer::HINGE_JOINT_MOTOR_TARGET_VELOCITY: m_motorTargetVelocity = p_value; break;
-		case PhysicsServer::HINGE_JOINT_MOTOR_MAX_IMPULSE: m_maxMotorImpulse = p_value; break;
-		case PhysicsServer::HINGE_JOINT_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::HINGE_JOINT_BIAS:
+			tau = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_LIMIT_UPPER:
+			m_upperLimit = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_LIMIT_LOWER:
+			m_lowerLimit = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_LIMIT_BIAS:
+			m_biasFactor = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_LIMIT_SOFTNESS:
+			m_limitSoftness = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_LIMIT_RELAXATION:
+			m_relaxationFactor = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_MOTOR_TARGET_VELOCITY:
+			m_motorTargetVelocity = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_MOTOR_MAX_IMPULSE:
+			m_maxMotorImpulse = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 
@@ -417,15 +434,24 @@ real_t HingeJointSW::get_param(PhysicsServer::HingeJointParam p_param) const {
 
 	switch (p_param) {
 
-		case PhysicsServer::HINGE_JOINT_BIAS: return tau;
-		case PhysicsServer::HINGE_JOINT_LIMIT_UPPER: return m_upperLimit;
-		case PhysicsServer::HINGE_JOINT_LIMIT_LOWER: return m_lowerLimit;
-		case PhysicsServer::HINGE_JOINT_LIMIT_BIAS: return m_biasFactor;
-		case PhysicsServer::HINGE_JOINT_LIMIT_SOFTNESS: return m_limitSoftness;
-		case PhysicsServer::HINGE_JOINT_LIMIT_RELAXATION: return m_relaxationFactor;
-		case PhysicsServer::HINGE_JOINT_MOTOR_TARGET_VELOCITY: return m_motorTargetVelocity;
-		case PhysicsServer::HINGE_JOINT_MOTOR_MAX_IMPULSE: return m_maxMotorImpulse;
-		case PhysicsServer::HINGE_JOINT_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::HINGE_JOINT_BIAS:
+			return tau;
+		case PhysicsServer::HINGE_JOINT_LIMIT_UPPER:
+			return m_upperLimit;
+		case PhysicsServer::HINGE_JOINT_LIMIT_LOWER:
+			return m_lowerLimit;
+		case PhysicsServer::HINGE_JOINT_LIMIT_BIAS:
+			return m_biasFactor;
+		case PhysicsServer::HINGE_JOINT_LIMIT_SOFTNESS:
+			return m_limitSoftness;
+		case PhysicsServer::HINGE_JOINT_LIMIT_RELAXATION:
+			return m_relaxationFactor;
+		case PhysicsServer::HINGE_JOINT_MOTOR_TARGET_VELOCITY:
+			return m_motorTargetVelocity;
+		case PhysicsServer::HINGE_JOINT_MOTOR_MAX_IMPULSE:
+			return m_maxMotorImpulse;
+		case PhysicsServer::HINGE_JOINT_MAX:
+			break; // Can't happen, but silences warning
 	}
 
 	return 0;
@@ -434,17 +460,25 @@ real_t HingeJointSW::get_param(PhysicsServer::HingeJointParam p_param) const {
 void HingeJointSW::set_flag(PhysicsServer::HingeJointFlag p_flag, bool p_value) {
 
 	switch (p_flag) {
-		case PhysicsServer::HINGE_JOINT_FLAG_USE_LIMIT: m_useLimit = p_value; break;
-		case PhysicsServer::HINGE_JOINT_FLAG_ENABLE_MOTOR: m_enableAngularMotor = p_value; break;
-		case PhysicsServer::HINGE_JOINT_FLAG_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::HINGE_JOINT_FLAG_USE_LIMIT:
+			m_useLimit = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_FLAG_ENABLE_MOTOR:
+			m_enableAngularMotor = p_value;
+			break;
+		case PhysicsServer::HINGE_JOINT_FLAG_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 bool HingeJointSW::get_flag(PhysicsServer::HingeJointFlag p_flag) const {
 
 	switch (p_flag) {
-		case PhysicsServer::HINGE_JOINT_FLAG_USE_LIMIT: return m_useLimit;
-		case PhysicsServer::HINGE_JOINT_FLAG_ENABLE_MOTOR: return m_enableAngularMotor;
-		case PhysicsServer::HINGE_JOINT_FLAG_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::HINGE_JOINT_FLAG_USE_LIMIT:
+			return m_useLimit;
+		case PhysicsServer::HINGE_JOINT_FLAG_ENABLE_MOTOR:
+			return m_enableAngularMotor;
+		case PhysicsServer::HINGE_JOINT_FLAG_MAX:
+			break; // Can't happen, but silences warning
 	}
 
 	return false;

--- a/servers/physics/joints/pin_joint_sw.cpp
+++ b/servers/physics/joints/pin_joint_sw.cpp
@@ -129,18 +129,27 @@ void PinJointSW::solve(real_t p_step) {
 void PinJointSW::set_param(PhysicsServer::PinJointParam p_param, real_t p_value) {
 
 	switch (p_param) {
-		case PhysicsServer::PIN_JOINT_BIAS: m_tau = p_value; break;
-		case PhysicsServer::PIN_JOINT_DAMPING: m_damping = p_value; break;
-		case PhysicsServer::PIN_JOINT_IMPULSE_CLAMP: m_impulseClamp = p_value; break;
+		case PhysicsServer::PIN_JOINT_BIAS:
+			m_tau = p_value;
+			break;
+		case PhysicsServer::PIN_JOINT_DAMPING:
+			m_damping = p_value;
+			break;
+		case PhysicsServer::PIN_JOINT_IMPULSE_CLAMP:
+			m_impulseClamp = p_value;
+			break;
 	}
 }
 
 real_t PinJointSW::get_param(PhysicsServer::PinJointParam p_param) const {
 
 	switch (p_param) {
-		case PhysicsServer::PIN_JOINT_BIAS: return m_tau;
-		case PhysicsServer::PIN_JOINT_DAMPING: return m_damping;
-		case PhysicsServer::PIN_JOINT_IMPULSE_CLAMP: return m_impulseClamp;
+		case PhysicsServer::PIN_JOINT_BIAS:
+			return m_tau;
+		case PhysicsServer::PIN_JOINT_DAMPING:
+			return m_damping;
+		case PhysicsServer::PIN_JOINT_IMPULSE_CLAMP:
+			return m_impulseClamp;
 	}
 
 	return 0;

--- a/servers/physics/joints/slider_joint_sw.cpp
+++ b/servers/physics/joints/slider_joint_sw.cpp
@@ -381,62 +381,130 @@ Vector3 SliderJointSW::getAncorInB(void) {
 void SliderJointSW::set_param(PhysicsServer::SliderJointParam p_param, real_t p_value) {
 
 	switch (p_param) {
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_UPPER: m_upperLinLimit = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_LOWER: m_lowerLinLimit = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS: m_softnessLimLin = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION: m_restitutionLimLin = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_DAMPING: m_dampingLimLin = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS: m_softnessDirLin = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION: m_restitutionDirLin = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_DAMPING: m_dampingDirLin = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS: m_softnessOrthoLin = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION: m_restitutionOrthoLin = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING: m_dampingOrthoLin = p_value; break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_UPPER:
+			m_upperLinLimit = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_LOWER:
+			m_lowerLinLimit = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS:
+			m_softnessLimLin = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION:
+			m_restitutionLimLin = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_DAMPING:
+			m_dampingLimLin = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS:
+			m_softnessDirLin = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION:
+			m_restitutionDirLin = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_DAMPING:
+			m_dampingDirLin = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS:
+			m_softnessOrthoLin = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION:
+			m_restitutionOrthoLin = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING:
+			m_dampingOrthoLin = p_value;
+			break;
 
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_UPPER: m_upperAngLimit = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_LOWER: m_lowerAngLimit = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS: m_softnessLimAng = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION: m_restitutionLimAng = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING: m_dampingLimAng = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS: m_softnessDirAng = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION: m_restitutionDirAng = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_DAMPING: m_dampingDirAng = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS: m_softnessOrthoAng = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION: m_restitutionOrthoAng = p_value; break;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING: m_dampingOrthoAng = p_value; break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_UPPER:
+			m_upperAngLimit = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_LOWER:
+			m_lowerAngLimit = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS:
+			m_softnessLimAng = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION:
+			m_restitutionLimAng = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING:
+			m_dampingLimAng = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS:
+			m_softnessDirAng = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION:
+			m_restitutionDirAng = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_DAMPING:
+			m_dampingDirAng = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS:
+			m_softnessOrthoAng = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION:
+			m_restitutionOrthoAng = p_value;
+			break;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING:
+			m_dampingOrthoAng = p_value;
+			break;
 
-		case PhysicsServer::SLIDER_JOINT_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::SLIDER_JOINT_MAX:
+			break; // Can't happen, but silences warning
 	}
 }
 
 real_t SliderJointSW::get_param(PhysicsServer::SliderJointParam p_param) const {
 
 	switch (p_param) {
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_UPPER: return m_upperLinLimit;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_LOWER: return m_lowerLinLimit;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS: return m_softnessLimLin;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION: return m_restitutionLimLin;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_DAMPING: return m_dampingLimLin;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS: return m_softnessDirLin;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION: return m_restitutionDirLin;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_DAMPING: return m_dampingDirLin;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS: return m_softnessOrthoLin;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION: return m_restitutionOrthoLin;
-		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING: return m_dampingOrthoLin;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_UPPER:
+			return m_upperLinLimit;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_LOWER:
+			return m_lowerLinLimit;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS:
+			return m_softnessLimLin;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION:
+			return m_restitutionLimLin;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_LIMIT_DAMPING:
+			return m_dampingLimLin;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS:
+			return m_softnessDirLin;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION:
+			return m_restitutionDirLin;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_MOTION_DAMPING:
+			return m_dampingDirLin;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS:
+			return m_softnessOrthoLin;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION:
+			return m_restitutionOrthoLin;
+		case PhysicsServer::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING:
+			return m_dampingOrthoLin;
 
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_UPPER: return m_upperAngLimit;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_LOWER: return m_lowerAngLimit;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS: return m_softnessLimAng;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION: return m_restitutionLimAng;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING: return m_dampingLimAng;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS: return m_softnessDirAng;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION: return m_restitutionDirAng;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_DAMPING: return m_dampingDirAng;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS: return m_softnessOrthoAng;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION: return m_restitutionOrthoAng;
-		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING: return m_dampingOrthoAng;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_UPPER:
+			return m_upperAngLimit;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_LOWER:
+			return m_lowerAngLimit;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS:
+			return m_softnessLimAng;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION:
+			return m_restitutionLimAng;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING:
+			return m_dampingLimAng;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS:
+			return m_softnessDirAng;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION:
+			return m_restitutionDirAng;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_MOTION_DAMPING:
+			return m_dampingDirAng;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS:
+			return m_softnessOrthoAng;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION:
+			return m_restitutionOrthoAng;
+		case PhysicsServer::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING:
+			return m_dampingOrthoAng;
 
-		case PhysicsServer::SLIDER_JOINT_MAX: break; // Can't happen, but silences warning
+		case PhysicsServer::SLIDER_JOINT_MAX:
+			break; // Can't happen, but silences warning
 	}
 
 	return 0;

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -1156,15 +1156,33 @@ void SpaceSW::set_param(PhysicsServer::SpaceParameter p_param, real_t p_value) {
 
 	switch (p_param) {
 
-		case PhysicsServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS: contact_recycle_radius = p_value; break;
-		case PhysicsServer::SPACE_PARAM_CONTACT_MAX_SEPARATION: contact_max_separation = p_value; break;
-		case PhysicsServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION: contact_max_allowed_penetration = p_value; break;
-		case PhysicsServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD: body_linear_velocity_sleep_threshold = p_value; break;
-		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD: body_angular_velocity_sleep_threshold = p_value; break;
-		case PhysicsServer::SPACE_PARAM_BODY_TIME_TO_SLEEP: body_time_to_sleep = p_value; break;
-		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_DAMP_RATIO: body_angular_velocity_damp_ratio = p_value; break;
-		case PhysicsServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS: constraint_bias = p_value; break;
-		case PhysicsServer::SPACE_PARAM_TEST_MOTION_MIN_CONTACT_DEPTH: test_motion_min_contact_depth = p_value; break;
+		case PhysicsServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS:
+			contact_recycle_radius = p_value;
+			break;
+		case PhysicsServer::SPACE_PARAM_CONTACT_MAX_SEPARATION:
+			contact_max_separation = p_value;
+			break;
+		case PhysicsServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION:
+			contact_max_allowed_penetration = p_value;
+			break;
+		case PhysicsServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD:
+			body_linear_velocity_sleep_threshold = p_value;
+			break;
+		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD:
+			body_angular_velocity_sleep_threshold = p_value;
+			break;
+		case PhysicsServer::SPACE_PARAM_BODY_TIME_TO_SLEEP:
+			body_time_to_sleep = p_value;
+			break;
+		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_DAMP_RATIO:
+			body_angular_velocity_damp_ratio = p_value;
+			break;
+		case PhysicsServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS:
+			constraint_bias = p_value;
+			break;
+		case PhysicsServer::SPACE_PARAM_TEST_MOTION_MIN_CONTACT_DEPTH:
+			test_motion_min_contact_depth = p_value;
+			break;
 	}
 }
 
@@ -1172,15 +1190,24 @@ real_t SpaceSW::get_param(PhysicsServer::SpaceParameter p_param) const {
 
 	switch (p_param) {
 
-		case PhysicsServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS: return contact_recycle_radius;
-		case PhysicsServer::SPACE_PARAM_CONTACT_MAX_SEPARATION: return contact_max_separation;
-		case PhysicsServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION: return contact_max_allowed_penetration;
-		case PhysicsServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD: return body_linear_velocity_sleep_threshold;
-		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD: return body_angular_velocity_sleep_threshold;
-		case PhysicsServer::SPACE_PARAM_BODY_TIME_TO_SLEEP: return body_time_to_sleep;
-		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_DAMP_RATIO: return body_angular_velocity_damp_ratio;
-		case PhysicsServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS: return constraint_bias;
-		case PhysicsServer::SPACE_PARAM_TEST_MOTION_MIN_CONTACT_DEPTH: return test_motion_min_contact_depth;
+		case PhysicsServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS:
+			return contact_recycle_radius;
+		case PhysicsServer::SPACE_PARAM_CONTACT_MAX_SEPARATION:
+			return contact_max_separation;
+		case PhysicsServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION:
+			return contact_max_allowed_penetration;
+		case PhysicsServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD:
+			return body_linear_velocity_sleep_threshold;
+		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD:
+			return body_angular_velocity_sleep_threshold;
+		case PhysicsServer::SPACE_PARAM_BODY_TIME_TO_SLEEP:
+			return body_time_to_sleep;
+		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_DAMP_RATIO:
+			return body_angular_velocity_damp_ratio;
+		case PhysicsServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS:
+			return constraint_bias;
+		case PhysicsServer::SPACE_PARAM_TEST_MOTION_MIN_CONTACT_DEPTH:
+			return test_motion_min_contact_depth;
 	}
 	return 0;
 }

--- a/servers/physics/space_sw.h
+++ b/servers/physics/space_sw.h
@@ -187,7 +187,8 @@ public:
 	void set_debug_contacts(int p_amount) { contact_debug.resize(p_amount); }
 	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contact_debug.empty(); }
 	_FORCE_INLINE_ void add_debug_contact(const Vector3 &p_contact) {
-		if (contact_debug_count < contact_debug.size()) contact_debug.write[contact_debug_count++] = p_contact;
+		if (contact_debug_count < contact_debug.size())
+			contact_debug.write[contact_debug_count++] = p_contact;
 	}
 	_FORCE_INLINE_ Vector<Vector3> get_debug_contacts() { return contact_debug; }
 	_FORCE_INLINE_ int get_debug_contact_count() { return contact_debug_count; }

--- a/servers/physics_2d/area_2d_sw.cpp
+++ b/servers/physics_2d/area_2d_sw.cpp
@@ -126,28 +126,52 @@ void Area2DSW::set_space_override_mode(Physics2DServer::AreaSpaceOverrideMode p_
 void Area2DSW::set_param(Physics2DServer::AreaParameter p_param, const Variant &p_value) {
 
 	switch (p_param) {
-		case Physics2DServer::AREA_PARAM_GRAVITY: gravity = p_value; break;
-		case Physics2DServer::AREA_PARAM_GRAVITY_VECTOR: gravity_vector = p_value; break;
-		case Physics2DServer::AREA_PARAM_GRAVITY_IS_POINT: gravity_is_point = p_value; break;
-		case Physics2DServer::AREA_PARAM_GRAVITY_DISTANCE_SCALE: gravity_distance_scale = p_value; break;
-		case Physics2DServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION: point_attenuation = p_value; break;
-		case Physics2DServer::AREA_PARAM_LINEAR_DAMP: linear_damp = p_value; break;
-		case Physics2DServer::AREA_PARAM_ANGULAR_DAMP: angular_damp = p_value; break;
-		case Physics2DServer::AREA_PARAM_PRIORITY: priority = p_value; break;
+		case Physics2DServer::AREA_PARAM_GRAVITY:
+			gravity = p_value;
+			break;
+		case Physics2DServer::AREA_PARAM_GRAVITY_VECTOR:
+			gravity_vector = p_value;
+			break;
+		case Physics2DServer::AREA_PARAM_GRAVITY_IS_POINT:
+			gravity_is_point = p_value;
+			break;
+		case Physics2DServer::AREA_PARAM_GRAVITY_DISTANCE_SCALE:
+			gravity_distance_scale = p_value;
+			break;
+		case Physics2DServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION:
+			point_attenuation = p_value;
+			break;
+		case Physics2DServer::AREA_PARAM_LINEAR_DAMP:
+			linear_damp = p_value;
+			break;
+		case Physics2DServer::AREA_PARAM_ANGULAR_DAMP:
+			angular_damp = p_value;
+			break;
+		case Physics2DServer::AREA_PARAM_PRIORITY:
+			priority = p_value;
+			break;
 	}
 }
 
 Variant Area2DSW::get_param(Physics2DServer::AreaParameter p_param) const {
 
 	switch (p_param) {
-		case Physics2DServer::AREA_PARAM_GRAVITY: return gravity;
-		case Physics2DServer::AREA_PARAM_GRAVITY_VECTOR: return gravity_vector;
-		case Physics2DServer::AREA_PARAM_GRAVITY_IS_POINT: return gravity_is_point;
-		case Physics2DServer::AREA_PARAM_GRAVITY_DISTANCE_SCALE: return gravity_distance_scale;
-		case Physics2DServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION: return point_attenuation;
-		case Physics2DServer::AREA_PARAM_LINEAR_DAMP: return linear_damp;
-		case Physics2DServer::AREA_PARAM_ANGULAR_DAMP: return angular_damp;
-		case Physics2DServer::AREA_PARAM_PRIORITY: return priority;
+		case Physics2DServer::AREA_PARAM_GRAVITY:
+			return gravity;
+		case Physics2DServer::AREA_PARAM_GRAVITY_VECTOR:
+			return gravity_vector;
+		case Physics2DServer::AREA_PARAM_GRAVITY_IS_POINT:
+			return gravity_is_point;
+		case Physics2DServer::AREA_PARAM_GRAVITY_DISTANCE_SCALE:
+			return gravity_distance_scale;
+		case Physics2DServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION:
+			return point_attenuation;
+		case Physics2DServer::AREA_PARAM_LINEAR_DAMP:
+			return linear_damp;
+		case Physics2DServer::AREA_PARAM_ANGULAR_DAMP:
+			return angular_damp;
+		case Physics2DServer::AREA_PARAM_PRIORITY:
+			return priority;
 	}
 
 	return Variant();

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -47,7 +47,8 @@ void Body2DSW::update_inertias() {
 
 		case Physics2DServer::BODY_MODE_RIGID: {
 
-			if (user_inertia) break;
+			if (user_inertia)
+				break;
 
 			//update tensor for allshapes, not the best way but should be somehow OK. (inspired from bullet)
 			real_t total_area = 0;

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -157,7 +157,8 @@ public:
 	_FORCE_INLINE_ void set_max_contacts_reported(int p_size) {
 		contacts.resize(p_size);
 		contact_count = 0;
-		if (mode == Physics2DServer::BODY_MODE_KINEMATIC && p_size) set_active(true);
+		if (mode == Physics2DServer::BODY_MODE_KINEMATIC && p_size)
+			set_active(true);
 	}
 
 	_FORCE_INLINE_ int get_max_contacts_reported() const { return contacts.size(); }

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -1097,9 +1097,15 @@ void Physics2DServerSW::joint_set_param(RID p_joint, JointParam p_param, real_t 
 	ERR_FAIL_COND(!joint);
 
 	switch (p_param) {
-		case JOINT_PARAM_BIAS: joint->set_bias(p_value); break;
-		case JOINT_PARAM_MAX_BIAS: joint->set_max_bias(p_value); break;
-		case JOINT_PARAM_MAX_FORCE: joint->set_max_force(p_value); break;
+		case JOINT_PARAM_BIAS:
+			joint->set_bias(p_value);
+			break;
+		case JOINT_PARAM_MAX_BIAS:
+			joint->set_max_bias(p_value);
+			break;
+		case JOINT_PARAM_MAX_FORCE:
+			joint->set_max_force(p_value);
+			break;
 	}
 }
 
@@ -1109,9 +1115,15 @@ real_t Physics2DServerSW::joint_get_param(RID p_joint, JointParam p_param) const
 	ERR_FAIL_COND_V(!joint, -1);
 
 	switch (p_param) {
-		case JOINT_PARAM_BIAS: return joint->get_bias(); break;
-		case JOINT_PARAM_MAX_BIAS: return joint->get_max_bias(); break;
-		case JOINT_PARAM_MAX_FORCE: return joint->get_max_force(); break;
+		case JOINT_PARAM_BIAS:
+			return joint->get_bias();
+			break;
+		case JOINT_PARAM_MAX_BIAS:
+			return joint->get_max_bias();
+			break;
+		case JOINT_PARAM_MAX_FORCE:
+			return joint->get_max_force();
+			break;
 	}
 
 	return 0;

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -1283,14 +1283,30 @@ void Space2DSW::set_param(Physics2DServer::SpaceParameter p_param, real_t p_valu
 
 	switch (p_param) {
 
-		case Physics2DServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS: contact_recycle_radius = p_value; break;
-		case Physics2DServer::SPACE_PARAM_CONTACT_MAX_SEPARATION: contact_max_separation = p_value; break;
-		case Physics2DServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION: contact_max_allowed_penetration = p_value; break;
-		case Physics2DServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD: body_linear_velocity_sleep_threshold = p_value; break;
-		case Physics2DServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD: body_angular_velocity_sleep_threshold = p_value; break;
-		case Physics2DServer::SPACE_PARAM_BODY_TIME_TO_SLEEP: body_time_to_sleep = p_value; break;
-		case Physics2DServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS: constraint_bias = p_value; break;
-		case Physics2DServer::SPACE_PARAM_TEST_MOTION_MIN_CONTACT_DEPTH: test_motion_min_contact_depth = p_value; break;
+		case Physics2DServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS:
+			contact_recycle_radius = p_value;
+			break;
+		case Physics2DServer::SPACE_PARAM_CONTACT_MAX_SEPARATION:
+			contact_max_separation = p_value;
+			break;
+		case Physics2DServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION:
+			contact_max_allowed_penetration = p_value;
+			break;
+		case Physics2DServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD:
+			body_linear_velocity_sleep_threshold = p_value;
+			break;
+		case Physics2DServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD:
+			body_angular_velocity_sleep_threshold = p_value;
+			break;
+		case Physics2DServer::SPACE_PARAM_BODY_TIME_TO_SLEEP:
+			body_time_to_sleep = p_value;
+			break;
+		case Physics2DServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS:
+			constraint_bias = p_value;
+			break;
+		case Physics2DServer::SPACE_PARAM_TEST_MOTION_MIN_CONTACT_DEPTH:
+			test_motion_min_contact_depth = p_value;
+			break;
 	}
 }
 
@@ -1298,14 +1314,22 @@ real_t Space2DSW::get_param(Physics2DServer::SpaceParameter p_param) const {
 
 	switch (p_param) {
 
-		case Physics2DServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS: return contact_recycle_radius;
-		case Physics2DServer::SPACE_PARAM_CONTACT_MAX_SEPARATION: return contact_max_separation;
-		case Physics2DServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION: return contact_max_allowed_penetration;
-		case Physics2DServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD: return body_linear_velocity_sleep_threshold;
-		case Physics2DServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD: return body_angular_velocity_sleep_threshold;
-		case Physics2DServer::SPACE_PARAM_BODY_TIME_TO_SLEEP: return body_time_to_sleep;
-		case Physics2DServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS: return constraint_bias;
-		case Physics2DServer::SPACE_PARAM_TEST_MOTION_MIN_CONTACT_DEPTH: return test_motion_min_contact_depth;
+		case Physics2DServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS:
+			return contact_recycle_radius;
+		case Physics2DServer::SPACE_PARAM_CONTACT_MAX_SEPARATION:
+			return contact_max_separation;
+		case Physics2DServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION:
+			return contact_max_allowed_penetration;
+		case Physics2DServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD:
+			return body_linear_velocity_sleep_threshold;
+		case Physics2DServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD:
+			return body_angular_velocity_sleep_threshold;
+		case Physics2DServer::SPACE_PARAM_BODY_TIME_TO_SLEEP:
+			return body_time_to_sleep;
+		case Physics2DServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS:
+			return constraint_bias;
+		case Physics2DServer::SPACE_PARAM_TEST_MOTION_MIN_CONTACT_DEPTH:
+			return test_motion_min_contact_depth;
 	}
 	return 0;
 }

--- a/servers/physics_2d/space_2d_sw.h
+++ b/servers/physics_2d/space_2d_sw.h
@@ -192,7 +192,8 @@ public:
 	void set_debug_contacts(int p_amount) { contact_debug.resize(p_amount); }
 	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contact_debug.empty(); }
 	_FORCE_INLINE_ void add_debug_contact(const Vector2 &p_contact) {
-		if (contact_debug_count < contact_debug.size()) contact_debug.write[contact_debug_count++] = p_contact;
+		if (contact_debug_count < contact_debug.size())
+			contact_debug.write[contact_debug_count++] = p_contact;
 	}
 	_FORCE_INLINE_ Vector<Vector2> get_debug_contacts() { return contact_debug; }
 	_FORCE_INLINE_ int get_debug_contact_count() { return contact_debug_count; }

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1053,7 +1053,8 @@ public:
 		}
 		virtual ~Item() {
 			clear();
-			if (copy_back_buffer) memdelete(copy_back_buffer);
+			if (copy_back_buffer)
+				memdelete(copy_back_buffer);
 		}
 	};
 

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -4792,7 +4792,8 @@ static int _get_first_ident_pos(const String &p_code) {
 		if (GETCHAR(0) == '/' && GETCHAR(1) == '/') {
 			idx += 2;
 			while (true) {
-				if (GETCHAR(0) == 0) return 0;
+				if (GETCHAR(0) == 0)
+					return 0;
 				if (GETCHAR(0) == '\n') {
 					idx++;
 					break; // loop
@@ -4802,7 +4803,8 @@ static int _get_first_ident_pos(const String &p_code) {
 		} else if (GETCHAR(0) == '/' && GETCHAR(1) == '*') {
 			idx += 2;
 			while (true) {
-				if (GETCHAR(0) == 0) return 0;
+				if (GETCHAR(0) == 0)
+					return 0;
 				if (GETCHAR(0) == '*' && GETCHAR(1) == '/') {
 					idx += 2;
 					break; // loop

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -789,36 +789,66 @@ String ShaderLanguage::get_datatype_name(DataType p_type) {
 
 	switch (p_type) {
 
-		case TYPE_VOID: return "void";
-		case TYPE_BOOL: return "bool";
-		case TYPE_BVEC2: return "bvec2";
-		case TYPE_BVEC3: return "bvec3";
-		case TYPE_BVEC4: return "bvec4";
-		case TYPE_INT: return "int";
-		case TYPE_IVEC2: return "ivec2";
-		case TYPE_IVEC3: return "ivec3";
-		case TYPE_IVEC4: return "ivec4";
-		case TYPE_UINT: return "uint";
-		case TYPE_UVEC2: return "uvec2";
-		case TYPE_UVEC3: return "uvec3";
-		case TYPE_UVEC4: return "uvec4";
-		case TYPE_FLOAT: return "float";
-		case TYPE_VEC2: return "vec2";
-		case TYPE_VEC3: return "vec3";
-		case TYPE_VEC4: return "vec4";
-		case TYPE_MAT2: return "mat2";
-		case TYPE_MAT3: return "mat3";
-		case TYPE_MAT4: return "mat4";
-		case TYPE_SAMPLER2D: return "sampler2D";
-		case TYPE_ISAMPLER2D: return "isampler2D";
-		case TYPE_USAMPLER2D: return "usampler2D";
-		case TYPE_SAMPLER2DARRAY: return "sampler2DArray";
-		case TYPE_ISAMPLER2DARRAY: return "isampler2DArray";
-		case TYPE_USAMPLER2DARRAY: return "usampler2DArray";
-		case TYPE_SAMPLER3D: return "sampler3D";
-		case TYPE_ISAMPLER3D: return "isampler3D";
-		case TYPE_USAMPLER3D: return "usampler3D";
-		case TYPE_SAMPLERCUBE: return "samplerCube";
+		case TYPE_VOID:
+			return "void";
+		case TYPE_BOOL:
+			return "bool";
+		case TYPE_BVEC2:
+			return "bvec2";
+		case TYPE_BVEC3:
+			return "bvec3";
+		case TYPE_BVEC4:
+			return "bvec4";
+		case TYPE_INT:
+			return "int";
+		case TYPE_IVEC2:
+			return "ivec2";
+		case TYPE_IVEC3:
+			return "ivec3";
+		case TYPE_IVEC4:
+			return "ivec4";
+		case TYPE_UINT:
+			return "uint";
+		case TYPE_UVEC2:
+			return "uvec2";
+		case TYPE_UVEC3:
+			return "uvec3";
+		case TYPE_UVEC4:
+			return "uvec4";
+		case TYPE_FLOAT:
+			return "float";
+		case TYPE_VEC2:
+			return "vec2";
+		case TYPE_VEC3:
+			return "vec3";
+		case TYPE_VEC4:
+			return "vec4";
+		case TYPE_MAT2:
+			return "mat2";
+		case TYPE_MAT3:
+			return "mat3";
+		case TYPE_MAT4:
+			return "mat4";
+		case TYPE_SAMPLER2D:
+			return "sampler2D";
+		case TYPE_ISAMPLER2D:
+			return "isampler2D";
+		case TYPE_USAMPLER2D:
+			return "usampler2D";
+		case TYPE_SAMPLER2DARRAY:
+			return "sampler2DArray";
+		case TYPE_ISAMPLER2DARRAY:
+			return "isampler2DArray";
+		case TYPE_USAMPLER2DARRAY:
+			return "usampler2DArray";
+		case TYPE_SAMPLER3D:
+			return "sampler3D";
+		case TYPE_ISAMPLER3D:
+			return "isampler3D";
+		case TYPE_USAMPLER3D:
+			return "usampler3D";
+		case TYPE_SAMPLERCUBE:
+			return "samplerCube";
 	}
 
 	return "";
@@ -2929,12 +2959,23 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 			e.is_op = true;
 
 			switch (tk.type) {
-				case TK_OP_SUB: e.op = OP_NEGATE; break;
-				case TK_OP_NOT: e.op = OP_NOT; break;
-				case TK_OP_BIT_INVERT: e.op = OP_BIT_INVERT; break;
-				case TK_OP_INCREMENT: e.op = OP_INCREMENT; break;
-				case TK_OP_DECREMENT: e.op = OP_DECREMENT; break;
-				default: ERR_FAIL_V(NULL);
+				case TK_OP_SUB:
+					e.op = OP_NEGATE;
+					break;
+				case TK_OP_NOT:
+					e.op = OP_NOT;
+					break;
+				case TK_OP_BIT_INVERT:
+					e.op = OP_BIT_INVERT;
+					break;
+				case TK_OP_INCREMENT:
+					e.op = OP_INCREMENT;
+					break;
+				case TK_OP_DECREMENT:
+					e.op = OP_DECREMENT;
+					break;
+				default:
+					ERR_FAIL_V(NULL);
 			}
 
 			expression.push_back(e);
@@ -3147,12 +3188,23 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						}
 
 						switch (expr->get_datatype()) {
-							case TYPE_BVEC2: member_type = TYPE_BOOL; break;
-							case TYPE_VEC2: member_type = TYPE_FLOAT; break;
-							case TYPE_IVEC2: member_type = TYPE_INT; break;
-							case TYPE_UVEC2: member_type = TYPE_UINT; break;
-							case TYPE_MAT2: member_type = TYPE_VEC2; break;
-							default: break;
+							case TYPE_BVEC2:
+								member_type = TYPE_BOOL;
+								break;
+							case TYPE_VEC2:
+								member_type = TYPE_FLOAT;
+								break;
+							case TYPE_IVEC2:
+								member_type = TYPE_INT;
+								break;
+							case TYPE_UVEC2:
+								member_type = TYPE_UINT;
+								break;
+							case TYPE_MAT2:
+								member_type = TYPE_VEC2;
+								break;
+							default:
+								break;
 						}
 
 						break;
@@ -3173,12 +3225,23 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						}
 
 						switch (expr->get_datatype()) {
-							case TYPE_BVEC3: member_type = TYPE_BOOL; break;
-							case TYPE_VEC3: member_type = TYPE_FLOAT; break;
-							case TYPE_IVEC3: member_type = TYPE_INT; break;
-							case TYPE_UVEC3: member_type = TYPE_UINT; break;
-							case TYPE_MAT3: member_type = TYPE_VEC3; break;
-							default: break;
+							case TYPE_BVEC3:
+								member_type = TYPE_BOOL;
+								break;
+							case TYPE_VEC3:
+								member_type = TYPE_FLOAT;
+								break;
+							case TYPE_IVEC3:
+								member_type = TYPE_INT;
+								break;
+							case TYPE_UVEC3:
+								member_type = TYPE_UINT;
+								break;
+							case TYPE_MAT3:
+								member_type = TYPE_VEC3;
+								break;
+							default:
+								break;
 						}
 						break;
 					case TYPE_BVEC4:
@@ -3198,12 +3261,23 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						}
 
 						switch (expr->get_datatype()) {
-							case TYPE_BVEC4: member_type = TYPE_BOOL; break;
-							case TYPE_VEC4: member_type = TYPE_FLOAT; break;
-							case TYPE_IVEC4: member_type = TYPE_INT; break;
-							case TYPE_UVEC4: member_type = TYPE_UINT; break;
-							case TYPE_MAT4: member_type = TYPE_VEC4; break;
-							default: break;
+							case TYPE_BVEC4:
+								member_type = TYPE_BOOL;
+								break;
+							case TYPE_VEC4:
+								member_type = TYPE_FLOAT;
+								break;
+							case TYPE_IVEC4:
+								member_type = TYPE_INT;
+								break;
+							case TYPE_UVEC4:
+								member_type = TYPE_UINT;
+								break;
+							case TYPE_MAT4:
+								member_type = TYPE_VEC4;
+								break;
+							default:
+								break;
 						}
 						break;
 					default: {
@@ -3263,37 +3337,99 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 
 			switch (tk.type) {
 
-				case TK_OP_EQUAL: o.op = OP_EQUAL; break;
-				case TK_OP_NOT_EQUAL: o.op = OP_NOT_EQUAL; break;
-				case TK_OP_LESS: o.op = OP_LESS; break;
-				case TK_OP_LESS_EQUAL: o.op = OP_LESS_EQUAL; break;
-				case TK_OP_GREATER: o.op = OP_GREATER; break;
-				case TK_OP_GREATER_EQUAL: o.op = OP_GREATER_EQUAL; break;
-				case TK_OP_AND: o.op = OP_AND; break;
-				case TK_OP_OR: o.op = OP_OR; break;
-				case TK_OP_ADD: o.op = OP_ADD; break;
-				case TK_OP_SUB: o.op = OP_SUB; break;
-				case TK_OP_MUL: o.op = OP_MUL; break;
-				case TK_OP_DIV: o.op = OP_DIV; break;
-				case TK_OP_MOD: o.op = OP_MOD; break;
-				case TK_OP_SHIFT_LEFT: o.op = OP_SHIFT_LEFT; break;
-				case TK_OP_SHIFT_RIGHT: o.op = OP_SHIFT_RIGHT; break;
-				case TK_OP_ASSIGN: o.op = OP_ASSIGN; break;
-				case TK_OP_ASSIGN_ADD: o.op = OP_ASSIGN_ADD; break;
-				case TK_OP_ASSIGN_SUB: o.op = OP_ASSIGN_SUB; break;
-				case TK_OP_ASSIGN_MUL: o.op = OP_ASSIGN_MUL; break;
-				case TK_OP_ASSIGN_DIV: o.op = OP_ASSIGN_DIV; break;
-				case TK_OP_ASSIGN_MOD: o.op = OP_ASSIGN_MOD; break;
-				case TK_OP_ASSIGN_SHIFT_LEFT: o.op = OP_ASSIGN_SHIFT_LEFT; break;
-				case TK_OP_ASSIGN_SHIFT_RIGHT: o.op = OP_ASSIGN_SHIFT_RIGHT; break;
-				case TK_OP_ASSIGN_BIT_AND: o.op = OP_ASSIGN_BIT_AND; break;
-				case TK_OP_ASSIGN_BIT_OR: o.op = OP_ASSIGN_BIT_OR; break;
-				case TK_OP_ASSIGN_BIT_XOR: o.op = OP_ASSIGN_BIT_XOR; break;
-				case TK_OP_BIT_AND: o.op = OP_BIT_AND; break;
-				case TK_OP_BIT_OR: o.op = OP_BIT_OR; break;
-				case TK_OP_BIT_XOR: o.op = OP_BIT_XOR; break;
-				case TK_QUESTION: o.op = OP_SELECT_IF; break;
-				case TK_COLON: o.op = OP_SELECT_ELSE; break;
+				case TK_OP_EQUAL:
+					o.op = OP_EQUAL;
+					break;
+				case TK_OP_NOT_EQUAL:
+					o.op = OP_NOT_EQUAL;
+					break;
+				case TK_OP_LESS:
+					o.op = OP_LESS;
+					break;
+				case TK_OP_LESS_EQUAL:
+					o.op = OP_LESS_EQUAL;
+					break;
+				case TK_OP_GREATER:
+					o.op = OP_GREATER;
+					break;
+				case TK_OP_GREATER_EQUAL:
+					o.op = OP_GREATER_EQUAL;
+					break;
+				case TK_OP_AND:
+					o.op = OP_AND;
+					break;
+				case TK_OP_OR:
+					o.op = OP_OR;
+					break;
+				case TK_OP_ADD:
+					o.op = OP_ADD;
+					break;
+				case TK_OP_SUB:
+					o.op = OP_SUB;
+					break;
+				case TK_OP_MUL:
+					o.op = OP_MUL;
+					break;
+				case TK_OP_DIV:
+					o.op = OP_DIV;
+					break;
+				case TK_OP_MOD:
+					o.op = OP_MOD;
+					break;
+				case TK_OP_SHIFT_LEFT:
+					o.op = OP_SHIFT_LEFT;
+					break;
+				case TK_OP_SHIFT_RIGHT:
+					o.op = OP_SHIFT_RIGHT;
+					break;
+				case TK_OP_ASSIGN:
+					o.op = OP_ASSIGN;
+					break;
+				case TK_OP_ASSIGN_ADD:
+					o.op = OP_ASSIGN_ADD;
+					break;
+				case TK_OP_ASSIGN_SUB:
+					o.op = OP_ASSIGN_SUB;
+					break;
+				case TK_OP_ASSIGN_MUL:
+					o.op = OP_ASSIGN_MUL;
+					break;
+				case TK_OP_ASSIGN_DIV:
+					o.op = OP_ASSIGN_DIV;
+					break;
+				case TK_OP_ASSIGN_MOD:
+					o.op = OP_ASSIGN_MOD;
+					break;
+				case TK_OP_ASSIGN_SHIFT_LEFT:
+					o.op = OP_ASSIGN_SHIFT_LEFT;
+					break;
+				case TK_OP_ASSIGN_SHIFT_RIGHT:
+					o.op = OP_ASSIGN_SHIFT_RIGHT;
+					break;
+				case TK_OP_ASSIGN_BIT_AND:
+					o.op = OP_ASSIGN_BIT_AND;
+					break;
+				case TK_OP_ASSIGN_BIT_OR:
+					o.op = OP_ASSIGN_BIT_OR;
+					break;
+				case TK_OP_ASSIGN_BIT_XOR:
+					o.op = OP_ASSIGN_BIT_XOR;
+					break;
+				case TK_OP_BIT_AND:
+					o.op = OP_BIT_AND;
+					break;
+				case TK_OP_BIT_OR:
+					o.op = OP_BIT_OR;
+					break;
+				case TK_OP_BIT_XOR:
+					o.op = OP_BIT_XOR;
+					break;
+				case TK_QUESTION:
+					o.op = OP_SELECT_IF;
+					break;
+				case TK_COLON:
+					o.op = OP_SELECT_ELSE;
+					break;
 				default: {
 					_set_error("Invalid token for operator: " + get_token_text(tk));
 					return NULL;
@@ -3329,14 +3465,30 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 
 			int priority;
 			switch (expression[i].op) {
-				case OP_EQUAL: priority = 8; break;
-				case OP_NOT_EQUAL: priority = 8; break;
-				case OP_LESS: priority = 7; break;
-				case OP_LESS_EQUAL: priority = 7; break;
-				case OP_GREATER: priority = 7; break;
-				case OP_GREATER_EQUAL: priority = 7; break;
-				case OP_AND: priority = 12; break;
-				case OP_OR: priority = 14; break;
+				case OP_EQUAL:
+					priority = 8;
+					break;
+				case OP_NOT_EQUAL:
+					priority = 8;
+					break;
+				case OP_LESS:
+					priority = 7;
+					break;
+				case OP_LESS_EQUAL:
+					priority = 7;
+					break;
+				case OP_GREATER:
+					priority = 7;
+					break;
+				case OP_GREATER_EQUAL:
+					priority = 7;
+					break;
+				case OP_AND:
+					priority = 12;
+					break;
+				case OP_OR:
+					priority = 14;
+					break;
 				case OP_NOT:
 					priority = 3;
 					unary = true;
@@ -3345,27 +3497,69 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 					priority = 3;
 					unary = true;
 					break;
-				case OP_ADD: priority = 5; break;
-				case OP_SUB: priority = 5; break;
-				case OP_MUL: priority = 4; break;
-				case OP_DIV: priority = 4; break;
-				case OP_MOD: priority = 4; break;
-				case OP_SHIFT_LEFT: priority = 6; break;
-				case OP_SHIFT_RIGHT: priority = 6; break;
-				case OP_ASSIGN: priority = 16; break;
-				case OP_ASSIGN_ADD: priority = 16; break;
-				case OP_ASSIGN_SUB: priority = 16; break;
-				case OP_ASSIGN_MUL: priority = 16; break;
-				case OP_ASSIGN_DIV: priority = 16; break;
-				case OP_ASSIGN_MOD: priority = 16; break;
-				case OP_ASSIGN_SHIFT_LEFT: priority = 16; break;
-				case OP_ASSIGN_SHIFT_RIGHT: priority = 16; break;
-				case OP_ASSIGN_BIT_AND: priority = 16; break;
-				case OP_ASSIGN_BIT_OR: priority = 16; break;
-				case OP_ASSIGN_BIT_XOR: priority = 16; break;
-				case OP_BIT_AND: priority = 9; break;
-				case OP_BIT_OR: priority = 11; break;
-				case OP_BIT_XOR: priority = 10; break;
+				case OP_ADD:
+					priority = 5;
+					break;
+				case OP_SUB:
+					priority = 5;
+					break;
+				case OP_MUL:
+					priority = 4;
+					break;
+				case OP_DIV:
+					priority = 4;
+					break;
+				case OP_MOD:
+					priority = 4;
+					break;
+				case OP_SHIFT_LEFT:
+					priority = 6;
+					break;
+				case OP_SHIFT_RIGHT:
+					priority = 6;
+					break;
+				case OP_ASSIGN:
+					priority = 16;
+					break;
+				case OP_ASSIGN_ADD:
+					priority = 16;
+					break;
+				case OP_ASSIGN_SUB:
+					priority = 16;
+					break;
+				case OP_ASSIGN_MUL:
+					priority = 16;
+					break;
+				case OP_ASSIGN_DIV:
+					priority = 16;
+					break;
+				case OP_ASSIGN_MOD:
+					priority = 16;
+					break;
+				case OP_ASSIGN_SHIFT_LEFT:
+					priority = 16;
+					break;
+				case OP_ASSIGN_SHIFT_RIGHT:
+					priority = 16;
+					break;
+				case OP_ASSIGN_BIT_AND:
+					priority = 16;
+					break;
+				case OP_ASSIGN_BIT_OR:
+					priority = 16;
+					break;
+				case OP_ASSIGN_BIT_XOR:
+					priority = 16;
+					break;
+				case OP_BIT_AND:
+					priority = 9;
+					break;
+				case OP_BIT_OR:
+					priority = 11;
+					break;
+				case OP_BIT_XOR:
+					priority = 10;
+					break;
 				case OP_BIT_INVERT:
 					priority = 3;
 					unary = true;
@@ -4915,9 +5109,15 @@ Error ShaderLanguage::complete(const String &p_code, const Map<StringName, Funct
 					limit = 4;
 
 				} break;
-				case TYPE_MAT2: limit = 2; break;
-				case TYPE_MAT3: limit = 3; break;
-				case TYPE_MAT4: limit = 4; break;
+				case TYPE_MAT2:
+					limit = 2;
+					break;
+				case TYPE_MAT3:
+					limit = 3;
+					break;
+				case TYPE_MAT4:
+					limit = 4;
+					break;
 				default: {
 				}
 			}

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1369,9 +1369,15 @@ bool VisualServerScene::_light_instance_update_shadow(Instance *p_instance, cons
 
 			int splits = 0;
 			switch (VSG::storage->light_directional_get_shadow_mode(p_instance->base)) {
-				case VS::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL: splits = 1; break;
-				case VS::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_2_SPLITS: splits = 2; break;
-				case VS::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_4_SPLITS: splits = 4; break;
+				case VS::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL:
+					splits = 1;
+					break;
+				case VS::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_2_SPLITS:
+					splits = 2;
+					break;
+				case VS::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_4_SPLITS:
+					splits = 4;
+					break;
 			}
 
 			float distances[5];


### PR DESCRIPTION
I tried two changes to our `clang-format` config which make it stricter, but should also enforce a style that we are more or less using already, with exceptions.

- `AllowShortCaseLabelsOnASingleLine`: If true, short case labels will be contracted to a single line.
- `AllowShortIfStatementsOnASingleLine`: If true, `if (a) return;` can be put on a single line.

*Edit:* To be clear, the proposed changes is to **disable** both of those, so disallow short case labels and if statements on a single line.

See https://clang.llvm.org/docs/ClangFormatStyleOptions.html

I only open this PR for discussion, I'm not necessary convinced that we should do this change, but it's worth discussing.