### PR TITLE
Linux: Check return value of chdir on cleanup

### DIFF
--- a/platform/x11/godot_x11.cpp
+++ b/platform/x11/godot_x11.cpp
@@ -55,8 +55,11 @@ int main(int argc, char *argv[]) {
 		os.run(); // it is actually the OS that decides how to run
 	Main::cleanup();
 
-	if (ret)
-		chdir(cwd);
+	if (ret) { // Previous getcwd was successful
+		if (chdir(cwd) != 0) {
+			ERR_PRINT("Couldn't return to previous working directory.");
+		}
+	}
 	free(cwd);
 
 	return os.get_exit_code();


### PR DESCRIPTION
Some compilers trigger a warning for it if we do not bother
checking the return value.

Fixes #29849.