### PR TITLE
Fix endless controller iteration on windows

### DIFF
--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -334,7 +334,7 @@ void JoypadWindows::process_joypads() {
 		if (joy.state.dwPacketNumber != joy.last_packet) {
 
 			int button_mask = XINPUT_GAMEPAD_DPAD_UP;
-			for (int j = 0; j <= 16; i++) {
+			for (int j = 0; j <= 16; j++) {
 
 				input->joy_button(joy.id, j, joy.state.Gamepad.wButtons & button_mask);
 				button_mask = button_mask * 2;


### PR DESCRIPTION
Fixes #29846

Error introduced a couple of days ago in 68735d2a886bc2cf6b0a4300d1aa5ece952929ed 

The iteration variable wasn't changed with the rename