### PR TITLE
Added a new member to Node's data called "time_scale"

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -69,7 +69,7 @@ void Node::_notification(int p_notification) {
 
 			set_time_scale_inherit(is_time_scale_inheriting());
 			set_time_scale_value(get_time_scale_value());
-		}
+		} break;
 		case NOTIFICATION_ENTER_TREE: {
 			ERR_FAIL_COND(!get_viewport());
 			ERR_FAIL_COND(!get_tree());

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -836,11 +836,35 @@ bool Node::can_process() const {
 }
 
 float Node::get_physics_process_delta_time() const {
-	if (data.tree) {
-		return data.tree->get_physics_process_time();
-	} else {
+
+	if (data.tree)
+		if (data.physics_time_scale_inherit && data.parent)
+			return data.parent->get_physics_process_delta_time() * data.physics_time_scale_value;
+		else
+			return data.tree->get_physics_process_time() * data.physics_time_scale_value;
+	else
 		return 0;
 	}
+}
+
+void Node::set_physics_time_scale_value(float p_time_scale) {
+
+	data.physics_time_scale_value = p_time_scale;
+}
+
+float Node::get_physics_time_scale_value() const {
+
+	return data.physics_time_scale_value;
+}
+
+void Node::set_physics_time_scale_inherit(bool p_time_scale_inherit) {
+
+	data.physics_time_scale_inherit = p_time_scale_inherit;
+}
+
+bool Node::is_physics_time_scale_inheriting() const {
+
+	return data.physics_time_scale_inherit;
 }
 
 float Node::get_process_delta_time() const {
@@ -2753,6 +2777,10 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_process", "enable"), &Node::set_physics_process);
 	ClassDB::bind_method(D_METHOD("get_physics_process_delta_time"), &Node::get_physics_process_delta_time);
 	ClassDB::bind_method(D_METHOD("is_physics_processing"), &Node::is_physics_processing);
+	ClassDB::bind_method(D_METHOD("set_physics_time_scale_value"), &Node::set_physics_time_scale_value);
+	ClassDB::bind_method(D_METHOD("get_physics_time_scale_value"), &Node::get_physics_time_scale_value);
+	ClassDB::bind_method(D_METHOD("is_physics_time_scale_inheriting"), &Node::is_physics_time_scale_inheriting);
+	ClassDB::bind_method(D_METHOD("set_physics_time_scale_inherit"), &Node::set_physics_time_scale_inherit);
 	ClassDB::bind_method(D_METHOD("get_process_delta_time"), &Node::get_process_delta_time);
 	ClassDB::bind_method(D_METHOD("set_process", "enable"), &Node::set_process);
 	ClassDB::bind_method(D_METHOD("set_process_priority", "priority"), &Node::set_process_priority);
@@ -2889,7 +2917,11 @@ void Node::_bind_methods() {
 	ADD_GROUP("Pause", "pause_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "pause_mode", PROPERTY_HINT_ENUM, "Inherit,Stop,Process"), "set_pause_mode", "get_pause_mode");
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "name", PROPERTY_HINT_NONE, "", 0), "set_name", "get_name");
+	ADD_GROUP("Time Scale", "physics_time_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "physics_time_scale_value", PROPERTY_HINT_NONE, ""), "set_physics_time_scale_value", "get_physics_time_scale_value");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_time_scale_inherit", PROPERTY_HINT_NONE, ""), "set_physics_time_scale_inherit", "is_physics_time_scale_inheriting");
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE, "", 0), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "filename", PROPERTY_HINT_NONE, "", 0), "set_filename", "get_filename");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "owner", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0), "set_owner", "get_owner");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multiplayer", PROPERTY_HINT_RESOURCE_TYPE, "MultiplayerAPI", 0), "", "get_multiplayer");
@@ -2942,6 +2974,8 @@ Node::Node() {
 	data.unhandled_key_input = false;
 	data.pause_mode = PAUSE_MODE_INHERIT;
 	data.pause_owner = nullptr;
+	data.physics_time_scale_value = 1.0f;
+	data.physics_time_scale_inherit = false;
 	data.network_master = 1; //server by default
 	data.path_cache = nullptr;
 	data.parent_owned = false;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -66,7 +66,6 @@ void Node::_notification(int p_notification) {
 
 		} break;
 		case NOTIFICATION_PARENTED: {
-
 			set_time_scale_inherit(is_time_scale_inheriting());
 			set_time_scale_value(get_time_scale_value());
 		} break;
@@ -841,19 +840,16 @@ bool Node::can_process() const {
 }
 
 float Node::get_physics_process_delta_time() const {
-
 	if (data.tree) {
 		if (data.time_scale_inherit && data.parent)
 			return data.tree->get_physics_process_time() * data.time_scale_value * data.time_scale_inherit_value;
 		else
 			return data.tree->get_physics_process_time() * data.time_scale_value;
-	}
-	else
+	} else
 		return 0;
 }
 
 float Node::get_process_delta_time() const {
-
 	if (data.tree)
 		if (data.time_scale_inherit && data.parent)
 			return data.tree->get_idle_process_time() * data.time_scale_value * data.time_scale_inherit_value;
@@ -864,7 +860,6 @@ float Node::get_process_delta_time() const {
 }
 
 void Node::set_time_scale_value(float p_time_scale) {
-
 	data.time_scale_value = p_time_scale;
 
 	Node **children = data.children.ptrw();
@@ -878,7 +873,6 @@ void Node::set_time_scale_value(float p_time_scale) {
 }
 
 float Node::get_time_scale_calculated_value() const {
-
 	if (!data.time_scale_inherit) {
 		return data.time_scale_value;
 	}
@@ -887,26 +881,20 @@ float Node::get_time_scale_calculated_value() const {
 }
 
 float Node::get_time_scale_value() const {
-
 	return data.time_scale_value;
 }
 
 void Node::set_time_scale_inherit(bool p_time_scale_inherit) {
-
 	data.time_scale_inherit = p_time_scale_inherit;
 
 	if (p_time_scale_inherit && data.parent) {
-
 		data.time_scale_inherit_value = data.parent->get_time_scale_calculated_value();
 	} else {
-
 		data.time_scale_inherit_value = 1.0f;
 	}
 }
 
-
 bool Node::is_time_scale_inheriting() const {
-
 	return data.time_scale_inherit;
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -842,14 +842,14 @@ bool Node::can_process() const {
 
 float Node::get_physics_process_delta_time() const {
 
-	if (data.tree)
+	if (data.tree) {
 		if (data.time_scale_inherit && data.parent)
 			return data.tree->get_physics_process_time() * data.time_scale_value * data.time_scale_inherit_value;
 		else
 			return data.tree->get_physics_process_time() * data.time_scale_value;
+	}
 	else
 		return 0;
-	}
 }
 
 float Node::get_process_delta_time() const {
@@ -2954,7 +2954,7 @@ void Node::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "pause_mode", PROPERTY_HINT_ENUM, "Inherit,Stop,Process"), "set_pause_mode", "get_pause_mode");
 
 	ADD_GROUP("Time Scale", "time_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "time_scale_value", PROPERTY_HINT_NONE, ""), "set_time_scale_value", "get_time_scale_value");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_scale_value", PROPERTY_HINT_NONE, ""), "set_time_scale_value", "get_time_scale_value");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "time_scale_inherit", PROPERTY_HINT_NONE, ""), "set_time_scale_inherit", "is_time_scale_inheriting");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE, "", 0), "set_name", "get_name");

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -838,41 +838,45 @@ bool Node::can_process() const {
 float Node::get_physics_process_delta_time() const {
 
 	if (data.tree)
-		if (data.physics_time_scale_inherit && data.parent)
-			return data.parent->get_physics_process_delta_time() * data.physics_time_scale_value;
+		if (data.time_scale_inherit && data.parent)
+			return data.parent->get_physics_process_delta_time() * data.time_scale_value;
 		else
-			return data.tree->get_physics_process_time() * data.physics_time_scale_value;
+			return data.tree->get_physics_process_time() * data.time_scale_value;
 	else
 		return 0;
 	}
 }
 
-void Node::set_physics_time_scale_value(float p_time_scale) {
-
-	data.physics_time_scale_value = p_time_scale;
-}
-
-float Node::get_physics_time_scale_value() const {
-
-	return data.physics_time_scale_value;
-}
-
-void Node::set_physics_time_scale_inherit(bool p_time_scale_inherit) {
-
-	data.physics_time_scale_inherit = p_time_scale_inherit;
-}
-
-bool Node::is_physics_time_scale_inheriting() const {
-
-	return data.physics_time_scale_inherit;
-}
-
 float Node::get_process_delta_time() const {
-	if (data.tree) {
-		return data.tree->get_idle_process_time();
-	} else {
+
+	if (data.tree)
+		if (data.time_scale_inherit && data.parent)
+			return data.parent->get_process_delta_time() * data.time_scale_value;
+		else
+			return data.tree->get_idle_process_time() * data.time_scale_value;
+	else
 		return 0;
-	}
+}
+
+void Node::set_time_scale_value(float p_time_scale) {
+
+	data.time_scale_value = p_time_scale;
+}
+
+float Node::get_time_scale_value() const {
+
+	return data.time_scale_value;
+}
+
+void Node::set_time_scale_inherit(bool p_time_scale_inherit) {
+
+	data.time_scale_inherit = p_time_scale_inherit;
+}
+
+
+bool Node::is_time_scale_inheriting() const {
+
+	return data.time_scale_inherit;
 }
 
 void Node::set_process(bool p_idle_process) {
@@ -2777,10 +2781,10 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_process", "enable"), &Node::set_physics_process);
 	ClassDB::bind_method(D_METHOD("get_physics_process_delta_time"), &Node::get_physics_process_delta_time);
 	ClassDB::bind_method(D_METHOD("is_physics_processing"), &Node::is_physics_processing);
-	ClassDB::bind_method(D_METHOD("set_physics_time_scale_value"), &Node::set_physics_time_scale_value);
-	ClassDB::bind_method(D_METHOD("get_physics_time_scale_value"), &Node::get_physics_time_scale_value);
-	ClassDB::bind_method(D_METHOD("is_physics_time_scale_inheriting"), &Node::is_physics_time_scale_inheriting);
-	ClassDB::bind_method(D_METHOD("set_physics_time_scale_inherit"), &Node::set_physics_time_scale_inherit);
+	ClassDB::bind_method(D_METHOD("set_time_scale_value"), &Node::set_time_scale_value);
+	ClassDB::bind_method(D_METHOD("get_time_scale_value"), &Node::get_time_scale_value);
+	ClassDB::bind_method(D_METHOD("is_time_scale_inheriting"), &Node::is_time_scale_inheriting);
+	ClassDB::bind_method(D_METHOD("set_time_scale_inherit"), &Node::set_time_scale_inherit);
 	ClassDB::bind_method(D_METHOD("get_process_delta_time"), &Node::get_process_delta_time);
 	ClassDB::bind_method(D_METHOD("set_process", "enable"), &Node::set_process);
 	ClassDB::bind_method(D_METHOD("set_process_priority", "priority"), &Node::set_process_priority);
@@ -2917,9 +2921,9 @@ void Node::_bind_methods() {
 	ADD_GROUP("Pause", "pause_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "pause_mode", PROPERTY_HINT_ENUM, "Inherit,Stop,Process"), "set_pause_mode", "get_pause_mode");
 
-	ADD_GROUP("Time Scale", "physics_time_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "physics_time_scale_value", PROPERTY_HINT_NONE, ""), "set_physics_time_scale_value", "get_physics_time_scale_value");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_time_scale_inherit", PROPERTY_HINT_NONE, ""), "set_physics_time_scale_inherit", "is_physics_time_scale_inheriting");
+	ADD_GROUP("Time Scale", "time_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "time_scale_value", PROPERTY_HINT_NONE, ""), "set_time_scale_value", "get_time_scale_value");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "time_scale_inherit", PROPERTY_HINT_NONE, ""), "set_time_scale_inherit", "is_time_scale_inheriting");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE, "", 0), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "filename", PROPERTY_HINT_NONE, "", 0), "set_filename", "get_filename");
@@ -2974,8 +2978,8 @@ Node::Node() {
 	data.unhandled_key_input = false;
 	data.pause_mode = PAUSE_MODE_INHERIT;
 	data.pause_owner = nullptr;
-	data.physics_time_scale_value = 1.0f;
-	data.physics_time_scale_inherit = false;
+	data.time_scale_value = 1.0f;
+	data.time_scale_inherit = false;
 	data.network_master = 1; //server by default
 	data.path_cache = nullptr;
 	data.parent_owned = false;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -118,6 +118,9 @@ private:
 		PauseMode pause_mode;
 		Node *pause_owner;
 
+		float physics_time_scale_value;
+		bool physics_time_scale_inherit;
+
 		int network_master;
 		Vector<NetData> rpc_methods;
 		Vector<NetData> rpc_properties;
@@ -343,6 +346,11 @@ public:
 	void set_physics_process(bool p_process);
 	float get_physics_process_delta_time() const;
 	bool is_physics_processing() const;
+
+	void set_physics_time_scale_value(float p_time_scale);
+	float get_physics_time_scale_value() const;
+	void set_physics_time_scale_inherit(bool p_time_scale_inherit);
+	bool is_physics_time_scale_inheriting() const;
 
 	void set_process(bool p_idle_process);
 	float get_process_delta_time() const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -118,8 +118,8 @@ private:
 		PauseMode pause_mode;
 		Node *pause_owner;
 
-		float physics_time_scale_value;
-		bool physics_time_scale_inherit;
+		float time_scale_value;
+		bool time_scale_inherit;
 
 		int network_master;
 		Vector<NetData> rpc_methods;
@@ -347,10 +347,10 @@ public:
 	float get_physics_process_delta_time() const;
 	bool is_physics_processing() const;
 
-	void set_physics_time_scale_value(float p_time_scale);
-	float get_physics_time_scale_value() const;
-	void set_physics_time_scale_inherit(bool p_time_scale_inherit);
-	bool is_physics_time_scale_inheriting() const;
+	void set_time_scale_value(float p_time_scale);
+	float get_time_scale_value() const;
+	void set_time_scale_inherit(bool p_time_scale_inherit);
+	bool is_time_scale_inheriting() const;
 
 	void set_process(bool p_idle_process);
 	float get_process_delta_time() const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -120,6 +120,7 @@ private:
 
 		float time_scale_value;
 		bool time_scale_inherit;
+		float time_scale_inherit_value;
 
 		int network_master;
 		Vector<NetData> rpc_methods;
@@ -348,6 +349,7 @@ public:
 	bool is_physics_processing() const;
 
 	void set_time_scale_value(float p_time_scale);
+	float get_time_scale_calculated_value() const;
 	float get_time_scale_value() const;
 	void set_time_scale_inherit(bool p_time_scale_inherit);
 	bool is_time_scale_inheriting() const;


### PR DESCRIPTION
Added a new member to Node's data called "physics_time_scale". This allows
speeding up and slowing down the amount of time a node thinks has passed.

For example, a Timer can have its physics_time_scale set to 2.0 to count at
double speed (two seconds per one real time).

Use the inherit bool to inherit changes to the parents timescale

NOTE: This only effects physics processing. Idle processing may find strange behavior were it to have matching implementation.

Adds functionality for #6885