### PR TITLE
Add support to perform boolean operations on array of polypaths

### DIFF
--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -409,14 +409,14 @@ public:
 		OPERATION_XOR
 	};
 	// 2D polygon boolean operations.
-	Array merge_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // Union (add).
-	Array clip_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // Difference (subtract).
-	Array intersect_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // Common area (multiply).
-	Array exclude_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // All but common area (xor).
+	Array merge_polygons_2d(const Variant &p_polygons); // Union (add).
+	Array clip_polygons_2d(const Variant &p_polygons_a, const Variant &p_polygons_b); // Difference (subtract).
+	Array intersect_polygons_2d(const Variant &p_polygons_a, const Variant &p_polygons_b); // Common area (multiply).
+	Array exclude_polygons_2d(const Variant &p_polygons_a, const Variant &p_polygons_b); // All but common area (xor).
 
 	// 2D polyline vs polygon operations.
-	Array clip_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon); // Cut.
-	Array intersect_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon); // Chop.
+	Array clip_polylines_with_polygons_2d(const Variant &p_polylines, const Variant &p_polygons); // Cut.
+	Array intersect_polylines_with_polygons_2d(const Variant &p_polylines, const Variant &p_polygons); // Chop.
 
 	// 2D offset polygons/polylines.
 	enum PolyJoinType {
@@ -431,14 +431,18 @@ public:
 		END_SQUARE,
 		END_ROUND
 	};
-	Array offset_polygon_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type = JOIN_SQUARE);
-	Array offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type = JOIN_SQUARE, PolyEndType p_end_type = END_SQUARE);
+	Array offset_polygons_2d(const Variant &p_polygons, real_t p_delta, PolyJoinType p_join_type = JOIN_SQUARE);
+	Array offset_polylines_2d(const Variant &p_polylines, real_t p_delta, PolyJoinType p_join_type = JOIN_SQUARE, PolyEndType p_end_type = END_SQUARE);
 
 	Vector<Point2> transform_points_2d(const Vector<Point2> &p_points, const Transform2D &p_mat);
 
 	Dictionary make_atlas(const Vector<Size2> &p_rects);
 
 	_Geometry();
+
+private:
+	Array _polypaths_do_operation(PolyBooleanOperation p_op, const Variant &p_polypaths_subject, const Variant &p_polypaths_clip = Variant(), bool is_subject_open = false);
+	void _convert_polypaths(const Variant &p_input, Vector<Vector<Point2> > &r_output);
 };
 
 VARIANT_ENUM_CAST(_Geometry::PolyBooleanOperation);

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -790,46 +790,46 @@ public:
 		END_ROUND
 	};
 
-	static Vector<Vector<Point2> > merge_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
-
-		return _polypaths_do_operation(OPERATION_UNION, p_polygon_a, p_polygon_b);
+	static Vector<Vector<Point2> > merge_polygons_2d(const Vector<Vector<Point2> > &p_subject) {
+		// no need to distinguish between Subject/Clip polygons
+		return _polypaths_do_operation(OPERATION_UNION, p_subject);
 	}
 
-	static Vector<Vector<Point2> > clip_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
+	static Vector<Vector<Point2> > clip_polygons_2d(const Vector<Vector<Point2> > &p_subject, const Vector<Vector<Point2> > &p_clip) {
 
-		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polygon_a, p_polygon_b);
+		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_subject, p_clip);
 	}
 
-	static Vector<Vector<Point2> > intersect_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
+	static Vector<Vector<Point2> > intersect_polygons_2d(const Vector<Vector<Point2> > &p_subject, const Vector<Vector<Point2> > &p_clip) {
 
-		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polygon_a, p_polygon_b);
+		return _polypaths_do_operation(OPERATION_INTERSECTION, p_subject, p_clip);
 	}
 
-	static Vector<Vector<Point2> > exclude_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
+	static Vector<Vector<Point2> > exclude_polygons_2d(const Vector<Vector<Point2> > &p_subject, const Vector<Vector<Point2> > &p_clip) {
 
-		return _polypaths_do_operation(OPERATION_XOR, p_polygon_a, p_polygon_b);
+		return _polypaths_do_operation(OPERATION_XOR, p_subject, p_clip);
 	}
 
-	static Vector<Vector<Point2> > clip_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
+	static Vector<Vector<Point2> > clip_polylines_with_polygons_2d(const Vector<Vector<Point2> > &p_polylines, const Vector<Vector<Point2> > &p_polygons) {
 
-		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polyline, p_polygon, true);
+		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polylines, p_polygons, true);
 	}
 
-	static Vector<Vector<Point2> > intersect_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
+	static Vector<Vector<Point2> > intersect_polylines_with_polygons_2d(const Vector<Vector<Point2> > &p_polylines, const Vector<Vector<Point2> > &p_polygons) {
 
-		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polyline, p_polygon, true);
+		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polylines, p_polygons, true);
 	}
 
-	static Vector<Vector<Point2> > offset_polygon_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
+	static Vector<Vector<Point2> > offset_polygons_2d(const Vector<Vector<Point2> > &p_polygons, real_t p_delta, PolyJoinType p_join_type) {
 
-		return _polypath_offset(p_polygon, p_delta, p_join_type, END_POLYGON);
+		return _polypaths_offset(p_polygons, p_delta, p_join_type, END_POLYGON);
 	}
 
-	static Vector<Vector<Point2> > offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
+	static Vector<Vector<Point2> > offset_polylines_2d(const Vector<Vector<Point2> > &p_polylines, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
 
 		ERR_FAIL_COND_V_MSG(p_end_type == END_POLYGON, Vector<Vector<Point2> >(), "Attempt to offset a polyline like a polygon (use offset_polygon_2d instead).");
 
-		return _polypath_offset(p_polygon, p_delta, p_join_type, p_end_type);
+		return _polypaths_offset(p_polylines, p_delta, p_join_type, p_end_type);
 	}
 
 	static Vector<Point2> transform_points_2d(const Vector<Point2> &p_points, const Transform2D &p_mat) {
@@ -1034,8 +1034,8 @@ public:
 	static void make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_result, Size2i &r_size);
 
 private:
-	static Vector<Vector<Point2> > _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open = false);
-	static Vector<Vector<Point2> > _polypath_offset(const Vector<Point2> &p_polypath, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type);
+	static Vector<Vector<Point2> > _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Vector<Point2> > &p_polypaths_subject, const Vector<Vector<Point2> > &p_polypaths_clip = Vector<Vector<Point2> >(), bool is_a_open = false);
+	static Vector<Vector<Point2> > _polypaths_offset(const Vector<Vector<Point2> > &p_polypaths, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type);
 };
 
 #endif

--- a/doc/classes/Geometry.xml
+++ b/doc/classes/Geometry.xml
@@ -62,24 +62,26 @@
 		<method name="clip_polygons_2d">
 			<return type="Array">
 			</return>
-			<argument index="0" name="polygon_a" type="PoolVector2Array">
+			<argument index="0" name="polygons_a" type="Variant">
 			</argument>
-			<argument index="1" name="polygon_b" type="PoolVector2Array">
+			<argument index="1" name="polygons_b" type="Variant">
 			</argument>
 			<description>
-				Clips [code]polygon_a[/code] against [code]polygon_b[/code] and returns an array of clipped polygons. This performs [constant OPERATION_DIFFERENCE] between polygons. Returns an empty array if [code]polygon_b[/code] completely overlaps [code]polygon_a[/code].
-				If [code]polygon_b[/code] is enclosed by [code]polygon_a[/code], returns an outer polygon (boundary) and inner polygon (hole) which could be distiguished by calling [method is_polygon_clockwise].
+				Clips [code]polygons_a[/code] against [code]polygons_b[/code] and returns an array of clipped polygons. This performs [constant OPERATION_DIFFERENCE] between polygons. Returns an empty array if [code]polygons_b[/code] completely overlap [code]polygons_a[/code].
+				If [code]polygons_b[/code] are enclosed by [code]polygons_a[/code], returns outer polygons (boundary) and inner polygons (hole) which could be distinguished by calling [method is_polygon_clockwise].
+				Both [code]polygons_a[/code] and [code]polygons_b[/code] parameters can either accept [PoolVector2Array] to be interpreted as a single polygon or [Array] of [PoolVector2Array]'s to accept a list of polygons.
 			</description>
 		</method>
-		<method name="clip_polyline_with_polygon_2d">
+		<method name="clip_polylines_with_polygons_2d">
 			<return type="Array">
 			</return>
-			<argument index="0" name="polyline" type="PoolVector2Array">
+			<argument index="0" name="polylines" type="Variant">
 			</argument>
-			<argument index="1" name="polygon" type="PoolVector2Array">
+			<argument index="1" name="polygons" type="Variant">
 			</argument>
 			<description>
-				Clips [code]polyline[/code] against [code]polygon[/code] and returns an array of clipped polylines. This performs [constant OPERATION_DIFFERENCE] between the polyline and the polygon. This operation can be thought of as cutting a line with a closed shape.
+				Clips [code]polylines[/code] against [code]polygons[/code] and returns an array of clipped polylines. This performs [constant OPERATION_DIFFERENCE between polylines and polygons. This operation can be thought of as cutting a line in two with a closed shape.
+				Both [code]polylines[/code] and [code]polygons[/code] parameters can either accept [PoolVector2Array] to be interpreted as a single polypath or [Array] of [PoolVector2Array]'s to accept a list of polypaths.
 			</description>
 		</method>
 		<method name="convex_hull_2d">
@@ -94,13 +96,14 @@
 		<method name="exclude_polygons_2d">
 			<return type="Array">
 			</return>
-			<argument index="0" name="polygon_a" type="PoolVector2Array">
+			<argument index="0" name="polygons_a" type="Variant">
 			</argument>
-			<argument index="1" name="polygon_b" type="PoolVector2Array">
+			<argument index="1" name="polygons_b" type="Variant">
 			</argument>
 			<description>
-				Mutually excludes common area defined by intersection of [code]polygon_a[/code] and [code]polygon_b[/code] (see [method intersect_polygons_2d]) and returns an array of excluded polygons. This performs [constant OPERATION_XOR] between polygons. In other words, returns all but common area between polygons.
-				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distiguished by calling [method is_polygon_clockwise].
+				Mutually excludes common area defined by intersection of [code]polygons_a[/code] and [code]polygons_b[/code] (see [method intersect_polygons_2d]) and returns an array of excluded polygons. This performs [constant OPERATION_XOR] between polygons. In other words, returns all but common area defined by polygons.
+				The operation may result in outer polygons (boundary) and inner polygons (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
+				Both [code]polygons_a[/code] and [code]polygons_b[/code] parameters can either accept [PoolVector2Array] to be interpreted as a single polygon or [Array] of [PoolVector2Array]'s to accept a list of polygons.
 			</description>
 		</method>
 		<method name="get_closest_point_to_segment">
@@ -196,24 +199,26 @@
 		<method name="intersect_polygons_2d">
 			<return type="Array">
 			</return>
-			<argument index="0" name="polygon_a" type="PoolVector2Array">
+			<argument index="0" name="polygons_a" type="Variant">
 			</argument>
-			<argument index="1" name="polygon_b" type="PoolVector2Array">
+			<argument index="1" name="polygons_b" type="Variant">
 			</argument>
 			<description>
-				Intersects [code]polygon_a[/code] with [code]polygon_b[/code] and returns an array of intersected polygons. This performs [constant OPERATION_INTERSECTION] between polygons. In other words, returns common area shared by polygons. Returns an empty array if no intersection occurs.
-				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
+				Intersects [code]polygons_a[/code] with [code]polygons_b[/code] and returns an array of intersected polygons. This performs [constant OPERATION_INTERSECTION] between polygons. In other words, returns common area shared by polygons. Returns an empty array if no intersection occurs.
+				The operation may result in outer polygons (boundary) and inner polygons (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
+				Both [code]polygons_a[/code] and [code]polygons_b[/code] parameters can either accept [PoolVector2Array] to be interpreted as a single polygon or [Array] of [PoolVector2Array]'s to accept a list of polygons.
 			</description>
 		</method>
-		<method name="intersect_polyline_with_polygon_2d">
+		<method name="intersect_polylines_with_polygons_2d">
 			<return type="Array">
 			</return>
-			<argument index="0" name="polyline" type="PoolVector2Array">
+			<argument index="0" name="polylines" type="Variant">
 			</argument>
-			<argument index="1" name="polygon" type="PoolVector2Array">
+			<argument index="1" name="polygons" type="Variant">
 			</argument>
 			<description>
-				Intersects [code]polyline[/code] with [code]polygon[/code] and returns an array of intersected polylines. This performs [constant OPERATION_INTERSECTION] between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
+				Intersects [code]polylines[/code] with [code]polygons[/code] and returns an array of intersected polylines. This performs [constant OPERATION_INTERSECTION] between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
+				Both [code]polylines[/code] and [code]polygons[/code] parameters can either accept [PoolVector2Array] to be interpreted as a single polypath or [Array] of [PoolVector2Array]'s to accept a list of polypaths.
 			</description>
 		</method>
 		<method name="is_point_in_circle">
@@ -277,34 +282,35 @@
 		<method name="merge_polygons_2d">
 			<return type="Array">
 			</return>
-			<argument index="0" name="polygon_a" type="PoolVector2Array">
-			</argument>
-			<argument index="1" name="polygon_b" type="PoolVector2Array">
+			<argument index="0" name="polygons" type="Variant">
 			</argument>
 			<description>
-				Merges (combines) [code]polygon_a[/code] and [code]polygon_b[/code] and returns an array of merged polygons. This performs [constant OPERATION_UNION] between polygons.
-				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
+				Merges (combines) all [code]polygons[/code] and returns an array of merged polygons. This performs [constant OPERATION_UNION] between polygons.
+				Not all polygons may be merged but only those which overlap geometrically. If not, consider using [method offset_polygons_2d] with positive delta before merging, also see [method convex_hull_2d], [method triangulate_delaunay_2d]. Returns original polygons if neither polygon overlap. The method may also attempt to turn self-intersecting polygons into strictly simple even if no merging occurs.
+				The operation may result in outer polygons (boundary) and inner polygons (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
+				[code]polygons[/code] parameter accepts [Array] of [PoolVector2Array]'s to represent a list of polygons. Passing a single [PoolVector2Array] polygon is possible and can be used to eliminate self-intersections.
 			</description>
 		</method>
-		<method name="offset_polygon_2d">
+		<method name="offset_polygons_2d">
 			<return type="Array">
 			</return>
-			<argument index="0" name="polygon" type="PoolVector2Array">
+			<argument index="0" name="polygons" type="Variant">
 			</argument>
 			<argument index="1" name="delta" type="float">
 			</argument>
 			<argument index="2" name="join_type" type="int" enum="Geometry.PolyJoinType" default="0">
 			</argument>
 			<description>
-				Inflates or deflates [code]polygon[/code] by [code]delta[/code] units (pixels). If [code]delta[/code] is positive, makes the polygon grow outward. If [code]delta[/code] is negative, shrinks the polygon inward. Returns an array of polygons because inflating/deflating may result in multiple discrete polygons. Returns an empty array if [code]delta[/code] is negative and the absolute value of it approximately exceeds the minimum bounding rectangle dimensions of the polygon.
+				Inflates or deflates [code]polygons[/code] by [code]delta[/code] units (pixels). If [code]delta[/code] is positive, makes the polygons grow outward. If [code]delta[/code] is negative, shrinks the polygons inward. Returns an array of polygons as inflating/deflating may result in multiple discrete polygons. Returns an empty array if [code]delta[/code] is negative and the absolute value of it approximately exceeds the minimum bounding rectangle dimensions of each polygon.
 				Each polygon's vertices will be rounded as determined by [code]join_type[/code], see [enum PolyJoinType].
-				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
+				The operation may result in outer polygons (boundary) and inner polygons (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
+				[code]polygons[/code] parameter can either accept [PoolVector2Array] to be interpreted as a single polygon or [Array] of [PoolVector2Array]'s to accept a list of polygons.
 			</description>
 		</method>
-		<method name="offset_polyline_2d">
+		<method name="offset_polylines_2d">
 			<return type="Array">
 			</return>
-			<argument index="0" name="polyline" type="PoolVector2Array">
+			<argument index="0" name="polylines" type="Variant">
 			</argument>
 			<argument index="1" name="delta" type="float">
 			</argument>
@@ -313,10 +319,11 @@
 			<argument index="3" name="end_type" type="int" enum="Geometry.PolyEndType" default="3">
 			</argument>
 			<description>
-				Inflates or deflates [code]polyline[/code] by [code]delta[/code] units (pixels), producing polygons. If [code]delta[/code] is positive, makes the polyline grow outward. Returns an array of polygons because inflating/deflating may result in multiple discrete polygons. If [code]delta[/code] is negative, returns an empty array.
+				Inflates or deflates [code]polylines[/code] by [code]delta[/code] units (pixels), producing polygons. If [code]delta[/code] is positive, makes the polylines grow outward. Returns an array of polygons as inflating/deflating may result in multiple discrete polygons. If [code]delta[/code] is negative, returns an empty array.
 				Each polygon's vertices will be rounded as determined by [code]join_type[/code], see [enum PolyJoinType].
 				Each polygon's endpoints will be rounded as determined by [code]end_type[/code], see [enum PolyEndType].
-				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
+				The operation may result in outer polygons (boundary) and inner polygons (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
+				[code]polylines[/code] parameter can either accept [PoolVector2Array] to be interpreted as a single polyline or [Array] of [PoolVector2Array]'s to accept a list of polylines.
 			</description>
 		</method>
 		<method name="point_is_inside_triangle" qualifiers="const">
@@ -486,7 +493,7 @@
 			Create regions where either subject or clip polygons are filled but not where both are filled.
 		</constant>
 		<constant name="JOIN_SQUARE" value="0" enum="PolyJoinType">
-			Squaring is applied uniformally at all convex edge joins at [code]1 * delta[/code].
+			Squaring is applied uniformly at all convex edge joins at [code]1 * delta[/code].
 		</constant>
 		<constant name="JOIN_ROUND" value="1" enum="PolyJoinType">
 			While flattened paths can never perfectly trace an arc, they are approximated by a series of arc chords.


### PR DESCRIPTION
Enhances #28987.
Closes #29784.

![multiple_polygons_clipping](https://user-images.githubusercontent.com/17108460/59851176-a4177180-9374-11e9-8e0e-64e16f48eeb3.gif)

- orange polygons aka `polygons_a` aka `subject`;
- blue polygons aka `polygons_b` aka `clip`;
- green polygons are solution per boolean operation, in order: UNION, DIFFERENCE, INTERSECTION, XOR.

## Changes:
- [x] polygon clipping is done on vector of polygons internally now.
- [x] bind `Variant` to mix and match both single polygon operations and array of polygons/polylines.
- [x] merging polygons requires only one parameter now.
    - NonZero filling was choosen by default to make this happen (see comment [upstream](https://sourceforge.net/p/polyclipping/discussion/1148419/thread/14a1bfc3b4/#6d57/775b)).
- [x] did the same treatment for polygon/polyline inflating/deflating methods.
- [x] update docs.

## Examples:

```gdscript
var poly_a = PoolVector2Array([Vector2(), ...])
var poly_a = PoolVector2Array([Vector2(), ...])
var poly_a = PoolVector2Array([Vector2(), ...])

# before: no total merge guaranteed
var res = Geometry.merge_polygons_2d(poly_a, poly_b)
res = Geometry.merge_polygons_2d(res[0], poly_c)

# after: merge guaranteed if all overlap
var res = Geometry.merge_polygons_2d([poly_a, poly_b, poly_c])

# Mix and match:

# `a` polygon is clipped by both `b` and `c` polygons:
var res = Geometry.clip_polygons_2d(poly_a, [poly_b, poly_c])

# `a` and `b` polygons are clipped by a single `c` polygon:
var res = Geometry.clip_polygons_2d([poly_a, poly_b], poly_c)
```

One could see how this kinda increased complexity a bit internally, but at the same time I've managed to reuse recurrent procedures used for binding. I also wonder how this could affect performance and interfere with static typing.

Feedback welcomed, inviting for discussion people who expressed interest in this: 
@Dr4kzor @avencherus, @Daw11

## Test project
[geometry-clipper-array.zip](https://github.com/godotengine/godot/files/3563674/geometry-clipper-array.zip)

