### PR TITLE
See: #29878 Added ERR_FAIL_COND checks for `Ref<AnimationNode>` in `AnimationNodeStateMachine::remove_node`

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -599,6 +599,9 @@ void AnimationNodeStateMachine::remove_node(const StringName &p_name) {
 
 	{
 		Ref<AnimationNode> node = states[p_name].node;
+		
+		ERR_FAIL_COND(node.is_null());
+
 		node->disconnect("tree_changed", this, "_tree_changed");
 	}
 


### PR DESCRIPTION
Fixes #29879 