### PR TITLE
Linux: Check return values of posix read/write

### DIFF
--- a/platform/x11/detect_prime.cpp
+++ b/platform/x11/detect_prime.cpp
@@ -159,10 +159,11 @@ int detect_prime() {
 			if (!stat_loc) {
 				// No need to do anything complicated here. Anything less than
 				// PIPE_BUF will be delivered in one read() call.
-				read(fdset[0], string, sizeof(string) - 1);
-
-				vendors[i] = string;
-				renderers[i] = string + strlen(string) + 1;
+				// Leave it 'Unknown' otherwise.
+				if (read(fdset[0], string, sizeof(string) - 1) > 0) {
+					vendors[i] = string;
+					renderers[i] = string + strlen(string) + 1;
+				}
 			}
 
 			close(fdset[0]);
@@ -190,8 +191,9 @@ int detect_prime() {
 			memcpy(&string, vendor, vendor_len);
 			memcpy(&string[vendor_len], renderer, renderer_len);
 
-			write(fdset[1], string, vendor_len + renderer_len);
-
+			if (write(fdset[1], string, vendor_len + renderer_len) == -1) {
+				print_verbose("Couldn't write vendor/renderer string.");
+			}
 			close(fdset[1]);
 			exit(0);
 		}

--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -414,7 +414,9 @@ void JoypadLinux::joypad_vibration_start(int p_id, float p_weak_magnitude, float
 	play.type = EV_FF;
 	play.code = effect.id;
 	play.value = 1;
-	write(joy.fd, (const void *)&play, sizeof(play));
+	if (write(joy.fd, (const void *)&play, sizeof(play)) == -1) {
+		print_verbose("Couldn't write to Joypad device.");
+	}
 
 	joy.ff_effect_id = effect.id;
 	joy.ff_effect_timestamp = p_timestamp;


### PR DESCRIPTION
Fixes #29849, for real this time.

I don't have the hardware, just tried to guess it from the surrounding code.
Tested that the Ubuntu gcc7/gcc8 now passes with '-Werror'.