### PR TITLE
Deprecate support for Android armv6 architecture

### DIFF
--- a/misc/ide/jetbrains/build.gradle
+++ b/misc/ide/jetbrains/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
 def pathToRootDir = "../../../"
 // Note: Only keep the abis you support to speed up the gradle 'assemble' task.
-def supportedAbis = ["armv6", "armv7", "arm64v8", "x86", "x86_64"]
+def supportedAbis = ["armv7", "arm64v8", "x86", "x86_64"]
 
 android {
 

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -221,7 +221,7 @@ if env['builtin_opus']:
     env_opus.Prepend(CPPPATH=[thirdparty_dir + "/" + dir for dir in thirdparty_include_paths])
 
     if env["platform"] == "android":
-        if ("android_arch" in env and env["android_arch"] in ["armv6", "armv7"]):
+        if ("android_arch" in env and env["android_arch"] == "armv7"):
             env_opus.Append(CPPFLAGS=["-DOPUS_ARM_OPT"])
         elif ("android_arch" in env and env["android_arch"] == "arm64v8"):
             env_opus.Append(CPPFLAGS=["-DOPUS_ARM64_OPT"])

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -384,8 +384,6 @@ elif webm_cpu_arm:
         env_libvpx.add_source_files(env.modules_sources, [libvpx_dir + "third_party/android/cpu-features.c"])
 
     env_libvpx_neon = env_libvpx.Clone()
-    if env["platform"] == 'android' and env["android_arch"] == 'armv6':
-        env_libvpx_neon.Append(CCFLAGS=['-mfpu=neon'])
     env_libvpx_neon.add_source_files(env.modules_sources, libvpx_sources_arm_neon)
 
     if env["platform"] == 'uwp':

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -37,9 +37,7 @@ android_objects.append(env_thirdparty.SharedObject('#thirdparty/misc/ifaddrs-and
 lib = env_android.add_shared_library("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
 
 lib_arch_dir = ''
-if env['android_arch'] == 'armv6':
-    lib_arch_dir = 'armeabi'
-elif env['android_arch'] == 'armv7':
+if env['android_arch'] == 'armv7':
     lib_arch_dir = 'armeabi-v7a'
 elif env['android_arch'] == 'arm64v8':
     lib_arch_dir = 'arm64-v8a'

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -26,7 +26,7 @@ def get_opts():
     return [
         ('ANDROID_NDK_ROOT', 'Path to the Android NDK', os.environ.get("ANDROID_NDK_ROOT", 0)),
         ('ndk_platform', 'Target platform (android-<api>, e.g. "android-18")', "android-18"),
-        EnumVariable('android_arch', 'Target architecture', "armv7", ('armv7', 'armv6', 'arm64v8', 'x86', 'x86_64')),
+        EnumVariable('android_arch', 'Target architecture', "armv7", ('armv7', 'arm64v8', 'x86', 'x86_64')),
         BoolVariable('android_neon', 'Enable NEON support (armv7 only)', True),
         BoolVariable('android_stl', 'Enable Android STL support (for modules)', True)
     ]
@@ -93,7 +93,7 @@ def configure(env):
 
     ## Architecture
 
-    if env['android_arch'] not in ['armv7', 'armv6', 'arm64v8', 'x86', 'x86_64']:
+    if env['android_arch'] not in ['armv7', 'arm64v8', 'x86', 'x86_64']:
         env['android_arch'] = 'armv7'
 
     neon_text = ""
@@ -119,13 +119,6 @@ def configure(env):
         abi_subpath = "x86_64-linux-android"
         arch_subpath = "x86_64"
         env["x86_libtheora_opt_gcc"] = True
-    elif env['android_arch'] == 'armv6':
-        env['ARCH'] = 'arch-arm'
-        env.extra_suffix = ".armv6" + env.extra_suffix
-        target_subpath = "arm-linux-androideabi-4.9"
-        abi_subpath = "arm-linux-androideabi"
-        arch_subpath = "armeabi"
-        can_vectorize = False
     elif env["android_arch"] == "armv7":
         env['ARCH'] = 'arch-arm'
         target_subpath = "arm-linux-androideabi-4.9"
@@ -248,11 +241,6 @@ def configure(env):
 
     elif env['android_arch'] == 'x86_64':
         target_opts = ['-target', 'x86_64-none-linux-android']
-
-    elif env["android_arch"] == "armv6":
-        target_opts = ['-target', 'armv6-none-linux-androideabi']
-        env.Append(CCFLAGS='-march=armv6 -mfpu=vfp -mfloat-abi=softfp'.split())
-        env.Append(CPPFLAGS=['-D__ARM_ARCH_6__'])
 
     elif env["android_arch"] == "armv7":
         target_opts = ['-target', 'armv7-none-linux-androideabi']

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -553,9 +553,6 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	static Vector<String> get_abis() {
 		Vector<String> abis;
-		// We can still build armv6 in theory, but it doesn't make much
-		// sense for games, so disabling for now.
-		//abis.push_back("armeabi");
 		abis.push_back("armeabi-v7a");
 		abis.push_back("arm64-v8a");
 		abis.push_back("x86");


### PR DESCRIPTION
This PR deprecates support for Android armv6 architectures.

It hasn't been possible to build Godot for Android armv6 architectures for a while, and based on the comments in the code, it seems that it's no longer a use-case for games.