### PR TITLE
Fix minor onion layering control errors

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -170,7 +170,6 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _play_bw_from_pressed();
 	void _autoplay_pressed();
 	void _stop_pressed();
-	void _pause_pressed();
 	void _animation_selected(int p_which);
 	void _animation_new();
 	void _animation_rename();


### PR DESCRIPTION
- Fixed errors when switching to an AnimationPlayer without animations when onion layering is enabled.
- Fixed onion toggle not being disabled when no animations are present.
- Misc formatting changes and dead code removal.