### PR TITLE
Update emitting status on one-shot particles

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -530,7 +530,8 @@ void CPUParticles2D::_particles_process(float p_delta) {
 		time = Math::fmod(time, lifetime);
 		cycle++;
 		if (one_shot && cycle > 0) {
-			emitting = false;
+			set_emitting(false);
+			_change_notify();
 		}
 	}
 

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -41,6 +41,12 @@
 void Particles2D::set_emitting(bool p_emitting) {
 
 	VS::get_singleton()->particles_set_emitting(particles, p_emitting);
+
+	if (p_emitting && one_shot) {
+		set_process_internal(true);
+	} else if (!p_emitting) {
+		set_process_internal(false);
+	}
 }
 
 void Particles2D::set_amount(int p_amount) {
@@ -60,8 +66,16 @@ void Particles2D::set_one_shot(bool p_enable) {
 
 	one_shot = p_enable;
 	VS::get_singleton()->particles_set_one_shot(particles, one_shot);
-	if (!one_shot && is_emitting())
-		VisualServer::get_singleton()->particles_restart(particles);
+
+	if (is_emitting()) {
+
+		set_process_internal(true);
+		if (!one_shot)
+			VisualServer::get_singleton()->particles_restart(particles);
+	}
+
+	if (!one_shot)
+		set_process_internal(false);
 }
 void Particles2D::set_pre_process_time(float p_time) {
 
@@ -312,6 +326,14 @@ void Particles2D::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
 		_update_particle_emission_transform();
+	}
+
+	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
+
+		if (one_shot && !is_emitting()) {
+			_change_notify();
+			set_process_internal(false);
+		}
 	}
 }
 

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -503,7 +503,8 @@ void CPUParticles::_particles_process(float p_delta) {
 		time = Math::fmod(time, lifetime);
 		cycle++;
 		if (one_shot && cycle > 0) {
-			emitting = false;
+			set_emitting(false);
+			_change_notify();
 		}
 	}
 

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -47,6 +47,12 @@ PoolVector<Face3> Particles::get_faces(uint32_t p_usage_flags) const {
 void Particles::set_emitting(bool p_emitting) {
 
 	VS::get_singleton()->particles_set_emitting(particles, p_emitting);
+
+	if (p_emitting && one_shot) {
+		set_process_internal(true);
+	} else if (!p_emitting) {
+		set_process_internal(false);
+	}
 }
 
 void Particles::set_amount(int p_amount) {
@@ -66,8 +72,16 @@ void Particles::set_one_shot(bool p_one_shot) {
 
 	one_shot = p_one_shot;
 	VS::get_singleton()->particles_set_one_shot(particles, one_shot);
-	if (!one_shot && is_emitting())
-		VisualServer::get_singleton()->particles_restart(particles);
+
+	if (is_emitting()) {
+
+		set_process_internal(true);
+		if (!one_shot)
+			VisualServer::get_singleton()->particles_restart(particles);
+	}
+
+	if (!one_shot)
+		set_process_internal(false);
 }
 
 void Particles::set_pre_process_time(float p_time) {
@@ -304,6 +318,16 @@ void Particles::_notification(int p_what) {
 		} else {
 
 			VS::get_singleton()->particles_set_speed_scale(particles, 0);
+		}
+	}
+
+	// Use internal process when emitting and one_shot are on so that when
+	// the shot ends the editor can properly update
+	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
+
+		if (one_shot && !is_emitting()) {
+			_change_notify();
+			set_process_internal(false);
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/21794 and https://github.com/godotengine/godot/issues/17903

Updates ``emission`` to reflect that ``one_shot`` sets it to ``false`` at end of shot.

