### PR TITLE
Fix updating of collision shape when the transform is set

### DIFF
--- a/modules/bullet/collision_object_bullet.cpp
+++ b/modules/bullet/collision_object_bullet.cpp
@@ -305,7 +305,7 @@ void RigidCollisionObjectBullet::set_shape_transform(int p_index, const Transfor
 	ERR_FAIL_INDEX(p_index, get_shape_count());
 
 	shapes.write[p_index].set_transform(p_transform);
-	reload_shapes();
+	shape_changed(p_index);
 }
 
 const btTransform &RigidCollisionObjectBullet::get_bt_shape_transform(int p_index) const {


### PR DESCRIPTION
The set_shape_transform() function was calling reload_shapes() instead of shape_changed().  This prevented the new scale from being applied to the shape.  This fixes #29906.