### PR TITLE
Fix some keyboards not working with Android

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/src/org/godotengine/godot/input/GodotInputHandler.java
@@ -65,6 +65,14 @@ public class GodotInputHandler implements InputDeviceListener {
 		godotView.queueEvent(task);
 	}
 
+	private boolean isKeyEvent_GameDevice(int source) {
+		// Note that keyboards are often (SOURCE_KEYBOARD | SOURCE_DPAD)
+		if (source == (InputDevice.SOURCE_KEYBOARD | InputDevice.SOURCE_DPAD))
+			return false;
+
+		return (source & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK || (source & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD || (source & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD;
+	}
+
 	public boolean onKeyUp(final int keyCode, KeyEvent event) {
 		if (keyCode == KeyEvent.KEYCODE_BACK) {
 			return true;
@@ -75,7 +83,7 @@ public class GodotInputHandler implements InputDeviceListener {
 		};
 
 		int source = event.getSource();
-		if ((source & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK || (source & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD || (source & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD) {
+		if (isKeyEvent_GameDevice(source)) {
 
 			final int button = getGodotButton(keyCode);
 			final int device_id = findJoystickDevice(event.getDeviceId());
@@ -118,7 +126,7 @@ public class GodotInputHandler implements InputDeviceListener {
 		int source = event.getSource();
 		//Log.e(TAG, String.format("Key down! source %d, device %d, joystick %d, %d, %d", event.getDeviceId(), source, (source & InputDevice.SOURCE_JOYSTICK), (source & InputDevice.SOURCE_DPAD), (source & InputDevice.SOURCE_GAMEPAD)));
 
-		if ((source & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK || (source & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD || (source & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD) {
+		if (isKeyEvent_GameDevice(source)) {
 
 			if (event.getRepeatCount() > 0) // ignore key echo
 				return true;


### PR DESCRIPTION
Fixes #17004

Currently the keydown and keyup messages are handled with method like this:

if ((source & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK
|| (source & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD
|| (source & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD) {
// joystick input
}
else
{
// keyboard input
}

The constant for SOURCE_DPAD is 513
10 0000 0001

and the constant for SOURCE_KEYBOARD is 257
1 0000 0001

However, rather confusingly, for many keyboards the source sent by android is 769
11 0000 0001

Thus the keyboard is passing the check as being a DPAD and being processed as a joystick rather than keyboard. This PR handles the specific case of source 769.