### PR TITLE
Improve the `Engine.get_version_info()` documentation

### DIFF
--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -85,14 +85,16 @@
 			</return>
 			<description>
 				Returns the current engine version information in a Dictionary.
-				"major"    - Holds the major version number as an int
-				"minor"    - Holds the minor version number as an int
-				"patch"    - Holds the patch version number as an int
-				"hex"      - Holds the full version number encoded as an hexadecimal int with one byte (2 places) per number (see example below)
-				"status"   - Holds the status (e.g. "beta", "rc1", "rc2", ... "stable") as a String
-				"build"    - Holds the build name (e.g. "custom-build") as a String
-				"string"   - major + minor + patch + status + build in a single String
-				The "hex" value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code]. Note that it's still an int internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for easy version comparisons from code:
+				[code]major[/code]    - Holds the major version number as an int
+				[code]minor[/code]    - Holds the minor version number as an int
+				[code]patch[/code]    - Holds the patch version number as an int
+				[code]hex[/code]      - Holds the full version number encoded as an hexadecimal int with one byte (2 places) per number (see example below)
+				[code]status[/code]   - Holds the status (e.g. "beta", "rc1", "rc2", ... "stable") as a String
+				[code]build[/code]    - Holds the build name (e.g. "custom_build") as a String
+				[code]hash[/code]     - Holds the full Git commit hash as a String
+				[code]year[/code]     - Holds the year the version was released in as an int
+				[code]string[/code]   - [code]major[/code] + [code]minor[/code] + [code]patch[/code] + [code]status[/code] + [code]build[/code] in a single String
+				The [code]hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code]. Note that it's still an int internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for easy version comparisons from code:
 				[codeblock]
 				if Engine.get_version_info().hex &gt;= 0x030200:
 				    # do things specific to version 3.2 or later


### PR DESCRIPTION
This documents some keys that were missing and improves formatting.