### PR TITLE
Implement middle-clicking to invert a gradient in the Gradient editor

### DIFF
--- a/scene/gui/gradient_edit.h
+++ b/scene/gui/gradient_edit.h
@@ -41,6 +41,7 @@ class GradientEdit : public Control {
 
 	PopupPanel *popup;
 	ColorPicker *picker;
+	PopupMenu *context_menu;
 
 	Ref<ImageTexture> checker;
 
@@ -55,10 +56,16 @@ class GradientEdit : public Control {
 
 protected:
 	void _gui_input(const Ref<InputEvent> &p_event);
+	void _on_context_menu_item_selected(int p_action_id);
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
+	enum ContextAction {
+		CONTEXT_INVERT,
+		CONTEXT_MAX,
+	};
+
 	void set_ramp(const Vector<float> &p_offsets, const Vector<Color> &p_colors);
 	Vector<float> get_offsets() const;
 	Vector<Color> get_colors() const;


### PR DESCRIPTION
This can make it easier to work on more complex gradients.

PS: Is there a more suited shortcut that could be used for this? I haven't really looked how gradient editors in other software handle this feature.