### PR TITLE
Multi-focus, player-specific input events.

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -49,7 +49,7 @@ void InputMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("action_has_event", "action", "event"), &InputMap::action_has_event);
 	ClassDB::bind_method(D_METHOD("action_erase_event", "action", "event"), &InputMap::action_erase_event);
 	ClassDB::bind_method(D_METHOD("action_erase_events", "action"), &InputMap::action_erase_events);
-	ClassDB::bind_method(D_METHOD("get_action_list", "action"), &InputMap::_get_action_list);
+	ClassDB::bind_method(D_METHOD("get_action_list", "action"), &InputMap::_get_action_list, DEFVAL(PLAYER_ALL));
 	ClassDB::bind_method(D_METHOD("event_is_action", "event", "action"), &InputMap::event_is_action);
 	ClassDB::bind_method(D_METHOD("load_from_globals"), &InputMap::load_from_globals);
 }

--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -108,7 +108,7 @@ List<Ref<InputEvent> >::Element *InputMap::_find_event(Action &p_action, const R
 		//if (e.type != Ref<InputEvent>::KEY && e.device != p_event.device) -- unsure about the KEY comparison, why is this here?
 		//	continue;
 
-		if (e->get_layer() != p_event->get_layer())
+		if (e->get_player() != p_event->get_player())
 			continue;
 
 		int device = e->get_device();

--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -108,6 +108,9 @@ List<Ref<InputEvent> >::Element *InputMap::_find_event(Action &p_action, const R
 		//if (e.type != Ref<InputEvent>::KEY && e.device != p_event.device) -- unsure about the KEY comparison, why is this here?
 		//	continue;
 
+		if (e->get_layer() != p_event->get_layer())
+			continue;
+
 		int device = e->get_device();
 		if (device == ALL_DEVICES || device == p_event->get_device()) {
 			if (e->action_match(p_event, p_pressed, p_strength, p_action.deadzone)) {

--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -108,8 +108,8 @@ List<Ref<InputEvent> >::Element *InputMap::_find_event(Action &p_action, const R
 		//if (e.type != Ref<InputEvent>::KEY && e.device != p_event.device) -- unsure about the KEY comparison, why is this here?
 		//	continue;
 
-		if (e->get_player() != p_event->get_player())
-			continue;
+		//if (e->get_player() != p_event->get_player())
+		//	continue;
 
 		int device = e->get_device();
 		if (device == ALL_DEVICES || device == p_event->get_device()) {

--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -45,12 +45,12 @@ void InputMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("erase_action", "action"), &InputMap::erase_action);
 
 	ClassDB::bind_method(D_METHOD("action_set_deadzone", "action", "deadzone"), &InputMap::action_set_deadzone);
-	ClassDB::bind_method(D_METHOD("action_add_event", "action", "event"), &InputMap::action_add_event);
-	ClassDB::bind_method(D_METHOD("action_has_event", "action", "event"), &InputMap::action_has_event);
-	ClassDB::bind_method(D_METHOD("action_erase_event", "action", "event"), &InputMap::action_erase_event);
+	ClassDB::bind_method(D_METHOD("action_add_event", "action", "event", "player"), &InputMap::action_add_event, DEFVAL(PLAYER_ALL));
+	ClassDB::bind_method(D_METHOD("action_has_event", "action", "event", "player"), &InputMap::action_has_event, DEFVAL(PLAYER_ALL));
+	ClassDB::bind_method(D_METHOD("action_erase_event", "action", "event", "player"), &InputMap::action_erase_event, DEFVAL(PLAYER_ALL));
 	ClassDB::bind_method(D_METHOD("action_erase_events", "action"), &InputMap::action_erase_events);
-	ClassDB::bind_method(D_METHOD("get_action_list", "action"), &InputMap::_get_action_list, DEFVAL(PLAYER_ALL));
-	ClassDB::bind_method(D_METHOD("event_is_action", "event", "action"), &InputMap::event_is_action);
+	ClassDB::bind_method(D_METHOD("get_action_list", "action", "player"), &InputMap::_get_action_list, DEFVAL(PLAYER_ALL));
+	ClassDB::bind_method(D_METHOD("event_is_action", "event", "action", "player"), &InputMap::event_is_action, DEFVAL(PLAYER_ALL));
 	ClassDB::bind_method(D_METHOD("load_from_globals"), &InputMap::load_from_globals);
 }
 
@@ -105,8 +105,8 @@ List<InputMap::ActionInput>::Element *InputMap::_find_event(Action &p_action, co
 
 		const ActionInput a = E->get();
 
-		if (p_player == PLAYER_ALL) {
-			if (p_exact_player && a.player != p_player)
+		if (p_exact_player) {
+			if (a.player != p_player)
 				continue;
 		} else if (a.player != PLAYER_ALL && a.player != p_player) {
 			continue;
@@ -218,7 +218,7 @@ bool InputMap::event_get_action_status(const Ref<InputEvent> &p_event, const Str
 
 	bool pressed;
 	float strength;
-	List<ActionInput>::Element *a = _find_event(E->get(), p_event, p_player, false, &pressed, &strength);
+	List<ActionInput>::Element *a = _find_event(E->get(), p_event, p_player, true, &pressed, &strength);
 	if (a != NULL) {
 		if (p_pressed != NULL)
 			*p_pressed = pressed;

--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -255,10 +255,12 @@ void InputMap::load_from_globals() {
 
 		add_action(name, deadzone);
 		for (int i = 0; i < events.size(); i++) {
-			Ref<InputEvent> event = events[i];
+			Dictionary ev = events[i];
+			Ref<InputEvent> event = ev["event"];
 			if (event.is_null())
 				continue;
-			action_add_event(name, event);
+			int player = ev["player"];
+			action_add_event(name, event, (ActionPlayer)player);
 		}
 	}
 }

--- a/core/input_map.h
+++ b/core/input_map.h
@@ -39,15 +39,40 @@ class InputMap : public Object {
 	GDCLASS(InputMap, Object);
 
 public:
+	enum ActionPlayer {
+		PLAYER_ALL = 0,
+		PLAYER_1, // 1
+		PLAYER_2,
+		PLAYER_3,
+		PLAYER_4,
+		PLAYER_5,
+		PLAYER_6,
+		PLAYER_7,
+		PLAYER_8,
+		PLAYER_9,
+		PLAYER_10,
+		PLAYER_11,
+		PLAYER_12,
+		PLAYER_13,
+		PLAYER_14,
+		PLAYER_15,
+		PLAYER_16
+	};
+
 	/**
 	* A special value used to signify that a given Action can be triggered by any device
 	*/
 	static int ALL_DEVICES;
 
+	struct ActionInput {
+		ActionPlayer player;
+		Ref<InputEvent> event;
+	};
+
 	struct Action {
 		int id;
 		float deadzone;
-		List<Ref<InputEvent> > inputs;
+		List<ActionInput> inputs;
 	};
 
 private:
@@ -55,9 +80,9 @@ private:
 
 	mutable Map<StringName, Action> input_map;
 
-	List<Ref<InputEvent> >::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool *p_pressed = NULL, float *p_strength = NULL) const;
+	List<ActionInput>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, ActionPlayer p_player = PLAYER_ALL, bool p_exact_player = false, bool *p_pressed = NULL, float *p_strength = NULL) const;
 
-	Array _get_action_list(const StringName &p_action);
+	Array _get_action_list(const StringName &p_action, ActionPlayer player = PLAYER_ALL);
 	Array _get_actions();
 
 protected:
@@ -72,14 +97,14 @@ public:
 	void erase_action(const StringName &p_action);
 
 	void action_set_deadzone(const StringName &p_action, float p_deadzone);
-	void action_add_event(const StringName &p_action, const Ref<InputEvent> &p_event);
-	bool action_has_event(const StringName &p_action, const Ref<InputEvent> &p_event);
-	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event);
+	void action_add_event(const StringName &p_action, const Ref<InputEvent> &p_event, ActionPlayer player = PLAYER_ALL);
+	bool action_has_event(const StringName &p_action, const Ref<InputEvent> &p_event, ActionPlayer player = PLAYER_ALL);
+	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event, ActionPlayer player = PLAYER_ALL);
 	void action_erase_events(const StringName &p_action);
 
-	const List<Ref<InputEvent> > *get_action_list(const StringName &p_action);
-	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action) const;
-	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool *p_pressed = NULL, float *p_strength = NULL) const;
+	const List<ActionInput> *get_action_list(const StringName &p_action, ActionPlayer player = PLAYER_ALL);
+	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action, ActionPlayer player = PLAYER_ALL) const;
+	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool *p_pressed = NULL, float *p_strength = NULL, ActionPlayer player = PLAYER_ALL) const;
 
 	const Map<StringName, Action> &get_action_map() const;
 	void load_from_globals();
@@ -87,5 +112,7 @@ public:
 
 	InputMap();
 };
+
+VARIANT_ENUM_CAST(InputMap::ActionPlayer);
 
 #endif // INPUT_MAP_H

--- a/core/input_map.h
+++ b/core/input_map.h
@@ -80,7 +80,7 @@ private:
 
 	mutable Map<StringName, Action> input_map;
 
-	List<ActionInput>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, ActionPlayer p_player = PLAYER_ALL, bool p_exact_player = false, bool *p_pressed = NULL, float *p_strength = NULL) const;
+	List<ActionInput>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, ActionPlayer p_player = PLAYER_ALL, bool *p_pressed = NULL, float *p_strength = NULL) const;
 
 	Array _get_action_list(const StringName &p_action, ActionPlayer player = PLAYER_ALL);
 	Array _get_actions();
@@ -97,9 +97,9 @@ public:
 	void erase_action(const StringName &p_action);
 
 	void action_set_deadzone(const StringName &p_action, float p_deadzone);
-	void action_add_event(const StringName &p_action, const Ref<InputEvent> &p_event, ActionPlayer player = PLAYER_ALL);
+	void action_add_event(const StringName &p_action, const Ref<InputEvent> &p_event, ActionPlayer player = PLAYER_1);
 	bool action_has_event(const StringName &p_action, const Ref<InputEvent> &p_event, ActionPlayer player = PLAYER_ALL);
-	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event, ActionPlayer player = PLAYER_ALL);
+	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event, ActionPlayer player = PLAYER_1);
 	void action_erase_events(const StringName &p_action);
 
 	const List<ActionInput> *get_action_list(const StringName &p_action, ActionPlayer player = PLAYER_ALL);

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -44,14 +44,6 @@ int InputEvent::get_device() const {
 	return device;
 }
 
-void InputEvent::set_player(int p_player) {
-	player = p_player;
-}
-
-int InputEvent::get_player() const {
-	return player;
-}
-
 bool InputEvent::is_action(const StringName &p_action) const {
 
 	return InputMap::get_singleton()->event_is_action(Ref<InputEvent>((InputEvent *)this), p_action);
@@ -119,9 +111,6 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_device", "device"), &InputEvent::set_device);
 	ClassDB::bind_method(D_METHOD("get_device"), &InputEvent::get_device);
 
-	ClassDB::bind_method(D_METHOD("set_player", "player"), &InputEvent::set_player);
-	ClassDB::bind_method(D_METHOD("get_player"), &InputEvent::get_player);
-
 	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_released", "action"), &InputEvent::is_action_released);
@@ -141,13 +130,11 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("xformed_by", "xform", "local_ofs"), &InputEvent::xformed_by, DEFVAL(Vector2()));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "device"), "set_device", "get_device");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "player"), "set_player", "get_player");
 }
 
 InputEvent::InputEvent() {
 
 	device = 0;
-	player = 0;
 }
 
 //////////////////

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -44,6 +44,14 @@ int InputEvent::get_device() const {
 	return device;
 }
 
+void InputEvent::set_layer(int p_layer) {
+	layer = p_layer;
+}
+
+int InputEvent::get_layer() const {
+	return layer;
+}
+
 bool InputEvent::is_action(const StringName &p_action) const {
 
 	return InputMap::get_singleton()->event_is_action(Ref<InputEvent>((InputEvent *)this), p_action);
@@ -111,6 +119,9 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_device", "device"), &InputEvent::set_device);
 	ClassDB::bind_method(D_METHOD("get_device"), &InputEvent::get_device);
 
+	ClassDB::bind_method(D_METHOD("set_layer", "layer"), &InputEvent::set_layer);
+	ClassDB::bind_method(D_METHOD("get_layer"), &InputEvent::get_layer);
+
 	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_released", "action"), &InputEvent::is_action_released);
@@ -130,11 +141,13 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("xformed_by", "xform", "local_ofs"), &InputEvent::xformed_by, DEFVAL(Vector2()));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "device"), "set_device", "get_device");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "layer"), "set_layer", "get_layer");
 }
 
 InputEvent::InputEvent() {
 
 	device = 0;
+	layer = 0;
 }
 
 //////////////////

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -44,12 +44,12 @@ int InputEvent::get_device() const {
 	return device;
 }
 
-void InputEvent::set_layer(int p_layer) {
-	layer = p_layer;
+void InputEvent::set_player(int p_player) {
+	player = p_player;
 }
 
-int InputEvent::get_layer() const {
-	return layer;
+int InputEvent::get_player() const {
+	return player;
 }
 
 bool InputEvent::is_action(const StringName &p_action) const {
@@ -119,8 +119,8 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_device", "device"), &InputEvent::set_device);
 	ClassDB::bind_method(D_METHOD("get_device"), &InputEvent::get_device);
 
-	ClassDB::bind_method(D_METHOD("set_layer", "layer"), &InputEvent::set_layer);
-	ClassDB::bind_method(D_METHOD("get_layer"), &InputEvent::get_layer);
+	ClassDB::bind_method(D_METHOD("set_player", "player"), &InputEvent::set_player);
+	ClassDB::bind_method(D_METHOD("get_player"), &InputEvent::get_player);
 
 	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed);
@@ -141,13 +141,13 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("xformed_by", "xform", "local_ofs"), &InputEvent::xformed_by, DEFVAL(Vector2()));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "device"), "set_device", "get_device");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "layer"), "set_layer", "get_layer");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "player"), "set_player", "get_player");
 }
 
 InputEvent::InputEvent() {
 
 	device = 0;
-	layer = 0;
+	player = 0;
 }
 
 //////////////////

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -44,30 +44,30 @@ int InputEvent::get_device() const {
 	return device;
 }
 
-bool InputEvent::is_action(const StringName &p_action) const {
+bool InputEvent::is_action(const StringName &p_action, int p_player) const {
 
-	return InputMap::get_singleton()->event_is_action(Ref<InputEvent>((InputEvent *)this), p_action);
+	return InputMap::get_singleton()->event_is_action(Ref<InputEvent>((InputEvent *)this), p_action, (InputMap::ActionPlayer)p_player);
 }
 
-bool InputEvent::is_action_pressed(const StringName &p_action) const {
+bool InputEvent::is_action_pressed(const StringName &p_action, int p_player) const {
 
 	bool pressed;
-	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed);
+	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed, NULL, (InputMap::ActionPlayer)p_player);
 	return valid && pressed && !is_echo();
 }
 
-bool InputEvent::is_action_released(const StringName &p_action) const {
+bool InputEvent::is_action_released(const StringName &p_action, int p_player) const {
 
 	bool pressed;
-	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed);
+	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed, NULL, (InputMap::ActionPlayer)p_player);
 	return valid && !pressed;
 }
 
-float InputEvent::get_action_strength(const StringName &p_action) const {
+float InputEvent::get_action_strength(const StringName &p_action, int p_player) const {
 
 	bool pressed;
 	float strength;
-	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed, &strength);
+	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed, &strength, (InputMap::ActionPlayer)p_player);
 	return valid ? strength : 0.0f;
 }
 
@@ -111,10 +111,10 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_device", "device"), &InputEvent::set_device);
 	ClassDB::bind_method(D_METHOD("get_device"), &InputEvent::get_device);
 
-	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action);
-	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed);
-	ClassDB::bind_method(D_METHOD("is_action_released", "action"), &InputEvent::is_action_released);
-	ClassDB::bind_method(D_METHOD("get_action_strength", "action"), &InputEvent::get_action_strength);
+	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("is_action_released", "action"), &InputEvent::is_action_released, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_action_strength", "action"), &InputEvent::get_action_strength, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEvent::is_pressed);
 	ClassDB::bind_method(D_METHOD("is_echo"), &InputEvent::is_echo);

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -176,6 +176,7 @@ class InputEvent : public Resource {
 	GDCLASS(InputEvent, Resource);
 
 	int device;
+	int layer;
 
 protected:
 	static void _bind_methods();
@@ -186,6 +187,9 @@ public:
 
 	void set_device(int p_device);
 	int get_device() const;
+
+	void set_layer(int p_layer);
+	int get_layer() const;
 
 	bool is_action(const StringName &p_action) const;
 	bool is_action_pressed(const StringName &p_action) const;

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -176,7 +176,6 @@ class InputEvent : public Resource {
 	GDCLASS(InputEvent, Resource);
 
 	int device;
-	int player;
 
 protected:
 	static void _bind_methods();
@@ -187,9 +186,6 @@ public:
 
 	void set_device(int p_device);
 	int get_device() const;
-
-	void set_player(int p_player);
-	int get_player() const;
 
 	bool is_action(const StringName &p_action) const;
 	bool is_action_pressed(const StringName &p_action) const;

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -176,7 +176,7 @@ class InputEvent : public Resource {
 	GDCLASS(InputEvent, Resource);
 
 	int device;
-	int layer;
+	int player;
 
 protected:
 	static void _bind_methods();
@@ -188,8 +188,8 @@ public:
 	void set_device(int p_device);
 	int get_device() const;
 
-	void set_layer(int p_layer);
-	int get_layer() const;
+	void set_player(int p_player);
+	int get_player() const;
 
 	bool is_action(const StringName &p_action) const;
 	bool is_action_pressed(const StringName &p_action) const;

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -187,10 +187,10 @@ public:
 	void set_device(int p_device);
 	int get_device() const;
 
-	bool is_action(const StringName &p_action) const;
-	bool is_action_pressed(const StringName &p_action) const;
-	bool is_action_released(const StringName &p_action) const;
-	float get_action_strength(const StringName &p_action) const;
+	bool is_action(const StringName &p_action, int p_player = 0) const;
+	bool is_action_pressed(const StringName &p_action, int p_player = 0) const;
+	bool is_action_released(const StringName &p_action, int p_player = 0) const;
+	float get_action_strength(const StringName &p_action, int p_player = 0) const;
 
 	// To be removed someday, since they do not make sense for all events
 	virtual bool is_pressed() const;

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -32,6 +32,7 @@
 
 #include "core/bind/core_bind.h"
 #include "core/core_string_names.h"
+#include "core/input_map.h"
 #include "core/io/file_access_network.h"
 #include "core/io/file_access_pack.h"
 #include "core/io/marshalls.h"
@@ -289,6 +290,27 @@ void ProjectSettings::_convert_to_last_version(int p_from_version) {
 				action["deadzone"] = Variant(0.5f);
 				action["events"] = array;
 				E->get().variant = action;
+			}
+		}
+	}
+	if (p_from_version <= 4) {
+		// Converts the input events from array to dictionary (player + event)
+		for (Map<StringName, ProjectSettings::VariantContainer>::Element *E = props.front(); E; E = E->next()) {
+			Variant value = E->get().variant;
+			if (String(E->key()).begins_with("input/") && value.get_type() == Variant::DICTIONARY) {
+				Dictionary dict = value;
+				Array array = dict["events"];
+				for (int i = 0; i < array.size(); i++) {
+					if (array[i].get_type() != Variant::OBJECT)
+						continue;
+					Ref<InputEvent> ev = array[i];
+					if (ev.is_null())
+						continue;
+					Dictionary event;
+					event["event"] = ev;
+					event["player"] = InputMap::PLAYER_1;
+					array[i] = event;
+				}
 			}
 		}
 	}
@@ -996,6 +1018,7 @@ ProjectSettings::ProjectSettings() {
 	registering_order = true;
 
 	Array events;
+	Dictionary event;
 	Dictionary action;
 	Ref<InputEventKey> key;
 	Ref<InputEventJoypadButton> joyb;
@@ -1023,15 +1046,24 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_ENTER);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_KP_ENTER);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_SPACE);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	joyb.instance();
 	joyb->set_button_index(JOY_BUTTON_0);
 	events.push_back(joyb);
@@ -1042,9 +1074,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_SPACE);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	joyb.instance();
 	joyb->set_button_index(JOY_BUTTON_3);
 	events.push_back(joyb);
@@ -1055,9 +1090,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_ESCAPE);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	joyb.instance();
 	joyb->set_button_index(JOY_BUTTON_1);
 	events.push_back(joyb);
@@ -1068,9 +1106,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_TAB);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	action["events"] = events;
 	GLOBAL_DEF("input/ui_focus_next", action);
 	input_presets.push_back("input/ui_focus_next");
@@ -1078,10 +1119,13 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_TAB);
 	key->set_shift(true);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	action["events"] = events;
 	GLOBAL_DEF("input/ui_focus_prev", action);
 	input_presets.push_back("input/ui_focus_prev");
@@ -1089,9 +1133,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_LEFT);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	joyb.instance();
 	joyb->set_button_index(JOY_DPAD_LEFT);
 	events.push_back(joyb);
@@ -1102,9 +1149,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_RIGHT);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	joyb.instance();
 	joyb->set_button_index(JOY_DPAD_RIGHT);
 	events.push_back(joyb);
@@ -1115,9 +1165,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_UP);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	joyb.instance();
 	joyb->set_button_index(JOY_DPAD_UP);
 	events.push_back(joyb);
@@ -1128,9 +1181,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_DOWN);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	joyb.instance();
 	joyb->set_button_index(JOY_DPAD_DOWN);
 	events.push_back(joyb);
@@ -1141,9 +1197,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_PAGEUP);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	action["events"] = events;
 	GLOBAL_DEF("input/ui_page_up", action);
 	input_presets.push_back("input/ui_page_up");
@@ -1151,9 +1210,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_PAGEDOWN);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	action["events"] = events;
 	GLOBAL_DEF("input/ui_page_down", action);
 	input_presets.push_back("input/ui_page_down");
@@ -1161,9 +1223,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_HOME);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	action["events"] = events;
 	GLOBAL_DEF("input/ui_home", action);
 	input_presets.push_back("input/ui_home");
@@ -1171,9 +1236,12 @@ ProjectSettings::ProjectSettings() {
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();
+	event = Dictionary();
+	event["player"] = InputMap::PLAYER_1;
 	key.instance();
 	key->set_scancode(KEY_END);
-	events.push_back(key);
+	event["event"] = key;
+	events.push_back(event);
 	action["events"] = events;
 	GLOBAL_DEF("input/ui_end", action);
 	input_presets.push_back("input/ui_end");

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -118,7 +118,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	static const int CONFIG_VERSION = 4;
+	static const int CONFIG_VERSION = 5;
 
 	void set_setting(const String &p_setting, const Variant &p_value);
 	Variant get_setting(const String &p_setting) const;

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -232,7 +232,7 @@ void ProjectSettingsEditor::_action_edited() {
 		Ref<InputEvent> ie = events[idx];
 		ERR_FAIL_COND(!ie.is_valid());
 
-		ie->set_player(ti->get_range(2));
+		//ie->set_player(ti->get_range(2));
 
 		undo_redo->create_action(TTR("Change Action Event Player"));
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
@@ -804,7 +804,7 @@ void ProjectSettingsEditor::_update_actions() {
 			action2->set_editable(2, true);
 			action2->set_cell_mode(2, TreeItem::CELL_MODE_RANGE);
 			action2->set_range_config(2, 0.0, 20.0, 1.0);
-			action2->set_range(2, event->get_player());
+			//action2->set_range(2, event->get_player());
 
 			action2->add_button(3, get_icon("Edit", "EditorIcons"), 3, false, TTR("Edit"));
 			action2->add_button(3, get_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -220,7 +220,7 @@ void ProjectSettingsEditor::_action_edited() {
 		undo_redo->commit_action();
 	} else if (input_editor->get_selected_column() == 2) {
 
-		// Change action layer
+		// Change action player
 		String name = "input/" + ti->get_parent()->get_text(0);
 		Dictionary old_val = ProjectSettings::get_singleton()->get(name);
 		Dictionary action = old_val.duplicate();
@@ -232,9 +232,9 @@ void ProjectSettingsEditor::_action_edited() {
 		Ref<InputEvent> ie = events[idx];
 		ERR_FAIL_COND(!ie.is_valid());
 
-		ie->set_layer(ti->get_range(2));
+		ie->set_player(ti->get_range(2));
 
-		undo_redo->create_action(TTR("Change Action Event Layer"));
+		undo_redo->create_action(TTR("Change Action Event Player"));
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
 		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
 		undo_redo->add_do_method(this, "_settings_changed");
@@ -804,7 +804,7 @@ void ProjectSettingsEditor::_update_actions() {
 			action2->set_editable(2, true);
 			action2->set_cell_mode(2, TreeItem::CELL_MODE_RANGE);
 			action2->set_range_config(2, 0.0, 20.0, 1.0);
-			action2->set_range(2, event->get_layer());
+			action2->set_range(2, event->get_player());
 
 			action2->add_button(3, get_icon("Edit", "EditorIcons"), 3, false, TTR("Edit"));
 			action2->add_button(3, get_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));
@@ -1867,7 +1867,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	input_editor->set_column_title(1, TTR("Deadzone"));
 	input_editor->set_column_expand(1, false);
 	input_editor->set_column_min_width(1, 80 * EDSCALE);
-	input_editor->set_column_title(2, TTR("Layer"));
+	input_editor->set_column_title(2, TTR("Player"));
 	input_editor->set_column_expand(2, false);
 	input_editor->set_column_min_width(2, 50 * EDSCALE);
 	input_editor->set_column_expand(3, false);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -229,10 +229,8 @@ void ProjectSettingsEditor::_action_edited() {
 		Array events = action["events"];
 		ERR_FAIL_INDEX(idx, events.size());
 
-		Ref<InputEvent> ie = events[idx];
-		ERR_FAIL_COND(!ie.is_valid());
-
-		//ie->set_player(ti->get_range(2));
+		Dictionary event = events[idx];
+		event["player"] = ti->get_range(2);
 
 		undo_redo->create_action(TTR("Change Action Event Player"));
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
@@ -320,10 +318,13 @@ void ProjectSettingsEditor::_device_input_add() {
 		}
 	}
 
+	Dictionary event;
+	event["player"] = 0;
+	event["event"] = ie;
 	if (idx < 0 || idx >= events.size()) {
-		events.push_back(ie);
+		events.push_back(event);
 	} else {
-		events[idx] = ie;
+		events[idx] = event;
 	}
 	action["events"] = events;
 
@@ -373,9 +374,13 @@ void ProjectSettingsEditor::_press_a_key_confirm() {
 	Dictionary action = old_val.duplicate();
 	Array events = action["events"];
 
+	Dictionary event;
+	event["player"] = 0;
+
 	for (int i = 0; i < events.size(); i++) {
 
-		Ref<InputEventKey> aie = events[i];
+		event = events[i];
+		Ref<InputEventKey> aie = event["event"];
 		if (aie.is_null())
 			continue;
 		if (aie->get_scancode_with_modifiers() == ie->get_scancode_with_modifiers()) {
@@ -383,10 +388,11 @@ void ProjectSettingsEditor::_press_a_key_confirm() {
 		}
 	}
 
+	event["event"] = ie;
 	if (idx < 0 || idx >= events.size()) {
-		events.push_back(ie);
+		events.push_back(event);
 	} else {
-		events[idx] = ie;
+		events[idx] = event;
 	}
 	action["events"] = events;
 
@@ -582,7 +588,8 @@ void ProjectSettingsEditor::_action_activated() {
 	Array events = action["events"];
 
 	ERR_FAIL_INDEX(idx, events.size());
-	Ref<InputEvent> event = events[idx];
+	Dictionary ev = events[idx];
+	Ref<InputEvent> event = ev["event"];
 	if (event.is_null())
 		return;
 
@@ -666,7 +673,8 @@ void ProjectSettingsEditor::_action_button_pressed(Object *p_obj, int p_column, 
 			Array events = action["events"];
 			ERR_FAIL_INDEX(idx, events.size());
 
-			Ref<InputEvent> event = events[idx];
+			Dictionary ev = events[idx];
+			Ref<InputEvent> event = ev["event"];
 
 			if (event.is_null())
 				return;
@@ -733,7 +741,8 @@ void ProjectSettingsEditor::_update_actions() {
 
 		for (int i = 0; i < events.size(); i++) {
 
-			Ref<InputEvent> event = events[i];
+			Dictionary ev = events[i];
+			Ref<InputEvent> event = ev["event"];
 			if (event.is_null())
 				continue;
 
@@ -804,7 +813,7 @@ void ProjectSettingsEditor::_update_actions() {
 			action2->set_editable(2, true);
 			action2->set_cell_mode(2, TreeItem::CELL_MODE_RANGE);
 			action2->set_range_config(2, 0.0, 20.0, 1.0);
-			//action2->set_range(2, event->get_player());
+			action2->set_range(2, ev["player"]);
 
 			action2->add_button(3, get_icon("Edit", "EditorIcons"), 3, false, TTR("Edit"));
 			action2->add_button(3, get_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -218,6 +218,28 @@ void ProjectSettingsEditor::_action_edited() {
 		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_action);
 		undo_redo->add_undo_method(this, "_settings_changed");
 		undo_redo->commit_action();
+	} else if (input_editor->get_selected_column() == 2) {
+
+		// Change action layer
+		String name = "input/" + ti->get_parent()->get_text(0);
+		Dictionary old_val = ProjectSettings::get_singleton()->get(name);
+		Dictionary action = old_val.duplicate();
+		int idx = ti->get_metadata(0);
+
+		Array events = action["events"];
+		ERR_FAIL_INDEX(idx, events.size());
+
+		Ref<InputEvent> ie = events[idx];
+		ERR_FAIL_COND(!ie.is_valid());
+
+		ie->set_layer(ti->get_range(2));
+
+		undo_redo->create_action(TTR("Change Action Event Layer"));
+		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
+		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
+		undo_redo->add_do_method(this, "_settings_changed");
+		undo_redo->add_undo_method(this, "_settings_changed");
+		undo_redo->commit_action();
 	}
 }
 
@@ -701,10 +723,11 @@ void ProjectSettingsEditor::_update_actions() {
 		item->set_range_config(1, 0.0, 1.0, 0.01);
 		item->set_range(1, action["deadzone"]);
 		item->set_custom_bg_color(1, get_color("prop_subsection", "Editor"));
+		item->set_custom_bg_color(2, get_color("prop_subsection", "Editor"));
 
-		item->add_button(2, get_icon("Add", "EditorIcons"), 1, false, TTR("Add Event"));
+		item->add_button(3, get_icon("Add", "EditorIcons"), 1, false, TTR("Add Event"));
 		if (!ProjectSettings::get_singleton()->get_input_presets().find(pi.name)) {
-			item->add_button(2, get_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));
+			item->add_button(3, get_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));
 			item->set_editable(0, true);
 		}
 
@@ -778,8 +801,13 @@ void ProjectSettingsEditor::_update_actions() {
 			action2->set_metadata(0, i);
 			action2->set_meta("__input", event);
 
-			action2->add_button(2, get_icon("Edit", "EditorIcons"), 3, false, TTR("Edit"));
-			action2->add_button(2, get_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));
+			action2->set_editable(2, true);
+			action2->set_cell_mode(2, TreeItem::CELL_MODE_RANGE);
+			action2->set_range_config(2, 0.0, 20.0, 1.0);
+			action2->set_range(2, event->get_layer());
+
+			action2->add_button(3, get_icon("Edit", "EditorIcons"), 3, false, TTR("Edit"));
+			action2->add_button(3, get_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));
 		}
 	}
 
@@ -1833,14 +1861,17 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	input_editor = memnew(Tree);
 	vbc->add_child(input_editor);
 	input_editor->set_v_size_flags(SIZE_EXPAND_FILL);
-	input_editor->set_columns(3);
+	input_editor->set_columns(4);
 	input_editor->set_column_titles_visible(true);
 	input_editor->set_column_title(0, TTR("Action"));
 	input_editor->set_column_title(1, TTR("Deadzone"));
 	input_editor->set_column_expand(1, false);
 	input_editor->set_column_min_width(1, 80 * EDSCALE);
+	input_editor->set_column_title(2, TTR("Layer"));
 	input_editor->set_column_expand(2, false);
 	input_editor->set_column_min_width(2, 50 * EDSCALE);
+	input_editor->set_column_expand(3, false);
+	input_editor->set_column_min_width(3, 50 * EDSCALE);
 	input_editor->connect("item_edited", this, "_action_edited");
 	input_editor->connect("item_activated", this, "_action_activated");
 	input_editor->connect("cell_selected", this, "_action_selected");

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -842,7 +842,7 @@ void ProjectSettingsEditor::_update_actions() {
 
 			action2->set_editable(2, true);
 			action2->set_cell_mode(2, TreeItem::CELL_MODE_RANGE);
-			action2->set_range_config(2, 0.0, 20.0, 1.0);
+			action2->set_range_config(2, 1.0, 16.0, 1.0);
 			action2->set_range(2, ev["player"]);
 
 			action2->add_button(3, get_icon("Edit", "EditorIcons"), 3, false, TTR("Edit"));

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -57,7 +57,7 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 		return;
 
 	Ref<InputEventMouseButton> mouse_button = p_event;
-	bool ui_accept = p_event->is_action("ui_accept") && !p_event->is_echo();
+	bool ui_accept = p_event->is_action("ui_accept", get_viewport()->get_input_player()) && !p_event->is_echo();
 
 	bool button_masked = mouse_button.is_valid() && ((1 << (mouse_button->get_button_index() - 1)) & button_mask) > 0;
 	if (button_masked || ui_accept) {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -31,6 +31,7 @@
 #include "item_list.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
+#include "scene/main/viewport.h"
 
 void ItemList::add_item(const String &p_item, const Ref<Texture> &p_texture, bool p_selectable) {
 
@@ -591,7 +592,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (p_event->is_pressed() && items.size() > 0) {
-		if (p_event->is_action("ui_up")) {
+		if (p_event->is_action("ui_up", get_viewport()->get_input_player())) {
 
 			if (search_string != "") {
 
@@ -626,7 +627,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 				}
 				accept_event();
 			}
-		} else if (p_event->is_action("ui_down")) {
+		} else if (p_event->is_action("ui_down", get_viewport()->get_input_player())) {
 
 			if (search_string != "") {
 
@@ -660,7 +661,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 				}
 				accept_event();
 			}
-		} else if (p_event->is_action("ui_page_up")) {
+		} else if (p_event->is_action("ui_page_up", get_viewport()->get_input_player())) {
 
 			search_string = ""; //any mousepress cancels
 
@@ -675,7 +676,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 					break;
 				}
 			}
-		} else if (p_event->is_action("ui_page_down")) {
+		} else if (p_event->is_action("ui_page_down", get_viewport()->get_input_player())) {
 
 			search_string = ""; //any mousepress cancels
 
@@ -691,7 +692,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 					break;
 				}
 			}
-		} else if (p_event->is_action("ui_left")) {
+		} else if (p_event->is_action("ui_left", get_viewport()->get_input_player())) {
 
 			search_string = ""; //any mousepress cancels
 
@@ -703,7 +704,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 				}
 				accept_event();
 			}
-		} else if (p_event->is_action("ui_right")) {
+		} else if (p_event->is_action("ui_right", get_viewport()->get_input_player())) {
 
 			search_string = ""; //any mousepress cancels
 
@@ -715,9 +716,9 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 				}
 				accept_event();
 			}
-		} else if (p_event->is_action("ui_cancel")) {
+		} else if (p_event->is_action("ui_cancel", get_viewport()->get_input_player())) {
 			search_string = "";
-		} else if (p_event->is_action("ui_select") && select_mode == SELECT_MULTI) {
+		} else if (p_event->is_action("ui_select", get_viewport()->get_input_player()) && select_mode == SELECT_MULTI) {
 
 			if (current >= 0 && current < items.size()) {
 				if (items[current].selectable && !items[current].disabled && !items[current].selected) {
@@ -728,7 +729,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 					emit_signal("multi_selected", current, false);
 				}
 			}
-		} else if (p_event->is_action("ui_accept")) {
+		} else if (p_event->is_action("ui_accept", get_viewport()->get_input_player())) {
 			search_string = ""; //any mousepress cance
 
 			if (current >= 0 && current < items.size()) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -34,6 +34,7 @@
 #include "core/os/os.h"
 #include "core/print_string.h"
 #include "core/translation.h"
+#include "scene/main/viewport.h"
 
 String PopupMenu::_get_accel_text(int p_item) const {
 
@@ -213,7 +214,7 @@ void PopupMenu::_scroll(float p_factor, const Point2 &p_over) {
 
 void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 
-	if (p_event->is_action("ui_down") && p_event->is_pressed()) {
+	if (p_event->is_action("ui_down", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		int search_from = mouse_over + 1;
 		if (search_from >= items.size())
@@ -233,7 +234,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 				break;
 			}
 		}
-	} else if (p_event->is_action("ui_up") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_up", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		int search_from = mouse_over - 1;
 		if (search_from < 0)
@@ -253,20 +254,20 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 				break;
 			}
 		}
-	} else if (p_event->is_action("ui_left") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_left", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		Node *n = get_parent();
 		if (n && Object::cast_to<PopupMenu>(n)) {
 			hide();
 			accept_event();
 		}
-	} else if (p_event->is_action("ui_right") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_right", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator && items[mouse_over].submenu != "" && submenu_over != mouse_over) {
 			_activate_submenu(mouse_over);
 			accept_event();
 		}
-	} else if (p_event->is_action("ui_accept") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_accept", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator) {
 

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -33,6 +33,7 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/print_string.h"
+#include "scene/main/viewport.h"
 
 bool ScrollBar::focus_by_default = false;
 
@@ -191,36 +192,36 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 
 	if (p_event->is_pressed()) {
 
-		if (p_event->is_action("ui_left")) {
+		if (p_event->is_action("ui_left", get_viewport()->get_input_player())) {
 
 			if (orientation != HORIZONTAL)
 				return;
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 
-		} else if (p_event->is_action("ui_right")) {
+		} else if (p_event->is_action("ui_right", get_viewport()->get_input_player())) {
 
 			if (orientation != HORIZONTAL)
 				return;
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 
-		} else if (p_event->is_action("ui_up")) {
+		} else if (p_event->is_action("ui_up", get_viewport()->get_input_player())) {
 
 			if (orientation != VERTICAL)
 				return;
 
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 
-		} else if (p_event->is_action("ui_down")) {
+		} else if (p_event->is_action("ui_down", get_viewport()->get_input_player())) {
 
 			if (orientation != VERTICAL)
 				return;
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 
-		} else if (p_event->is_action("ui_home")) {
+		} else if (p_event->is_action("ui_home", get_viewport()->get_input_player())) {
 
 			set_value(get_min());
 
-		} else if (p_event->is_action("ui_end")) {
+		} else if (p_event->is_action("ui_end", get_viewport()->get_input_player())) {
 
 			set_value(get_max());
 		}

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -30,6 +30,7 @@
 
 #include "slider.h"
 #include "core/os/keyboard.h"
+#include "scene/main/viewport.h"
 
 Size2 Slider::get_minimum_size() const {
 
@@ -101,36 +102,36 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 
 	if (!mm.is_valid() && !mb.is_valid()) {
 
-		if (p_event->is_action("ui_left") && p_event->is_pressed()) {
+		if (p_event->is_action("ui_left", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 			if (orientation != HORIZONTAL)
 				return;
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
-		} else if (p_event->is_action("ui_right") && p_event->is_pressed()) {
+		} else if (p_event->is_action("ui_right", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 			if (orientation != HORIZONTAL)
 				return;
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
-		} else if (p_event->is_action("ui_up") && p_event->is_pressed()) {
+		} else if (p_event->is_action("ui_up", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 			if (orientation != VERTICAL)
 				return;
 
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
-		} else if (p_event->is_action("ui_down") && p_event->is_pressed()) {
+		} else if (p_event->is_action("ui_down", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 			if (orientation != VERTICAL)
 				return;
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
-		} else if (p_event->is_action("ui_home") && p_event->is_pressed()) {
+		} else if (p_event->is_action("ui_home", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 			set_value(get_min());
 			accept_event();
-		} else if (p_event->is_action("ui_end") && p_event->is_pressed()) {
+		} else if (p_event->is_action("ui_end", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 			set_value(get_max());
 			accept_event();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2220,7 +2220,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 	Ref<InputEventKey> k = p_event;
 
 	bool is_command = k.is_valid() && k->get_command();
-	if (p_event->is_action("ui_right") && p_event->is_pressed()) {
+	if (p_event->is_action("ui_right", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		if (!cursor_can_exit_tree) accept_event();
 
@@ -2237,7 +2237,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 		} else {
 			_go_right();
 		}
-	} else if (p_event->is_action("ui_left") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_left", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		if (!cursor_can_exit_tree) accept_event();
 
@@ -2256,19 +2256,19 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 			_go_left();
 		}
 
-	} else if (p_event->is_action("ui_up") && p_event->is_pressed() && !is_command) {
+	} else if (p_event->is_action("ui_up", get_viewport()->get_input_player()) && p_event->is_pressed() && !is_command) {
 
 		if (!cursor_can_exit_tree) accept_event();
 
 		_go_up();
 
-	} else if (p_event->is_action("ui_down") && p_event->is_pressed() && !is_command) {
+	} else if (p_event->is_action("ui_down", get_viewport()->get_input_player()) && p_event->is_pressed() && !is_command) {
 
 		if (!cursor_can_exit_tree) accept_event();
 
 		_go_down();
 
-	} else if (p_event->is_action("ui_page_down") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_page_down", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		if (!cursor_can_exit_tree) accept_event();
 
@@ -2306,7 +2306,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 		}
 
 		ensure_cursor_is_visible();
-	} else if (p_event->is_action("ui_page_up") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_page_up", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		if (!cursor_can_exit_tree) accept_event();
 
@@ -2343,7 +2343,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 			prev->select(selected_col);
 		}
 		ensure_cursor_is_visible();
-	} else if (p_event->is_action("ui_accept") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_accept", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		if (selected_item) {
 			//bring up editor if possible
@@ -2353,7 +2353,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 			}
 		}
 		accept_event();
-	} else if (p_event->is_action("ui_select") && p_event->is_pressed()) {
+	} else if (p_event->is_action("ui_select", get_viewport()->get_input_player()) && p_event->is_pressed()) {
 
 		if (select_mode == SELECT_MULTI) {
 			if (!selected_item)

--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -163,7 +163,6 @@ void ViewportContainer::_input(const Ref<InputEvent> &p_event) {
 		if (!c || c->is_input_disabled())
 			continue;
 
-		ev->set_player(c->get_input_player());
 		c->input(ev);
 	}
 }

--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -163,7 +163,7 @@ void ViewportContainer::_input(const Ref<InputEvent> &p_event) {
 		if (!c || c->is_input_disabled())
 			continue;
 
-		ev->set_layer(c->get_input_player());
+		ev->set_player(c->get_input_player());
 		c->input(ev);
 	}
 }

--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -163,7 +163,7 @@ void ViewportContainer::_input(const Ref<InputEvent> &p_event) {
 		if (!c || c->is_input_disabled())
 			continue;
 
-		ev->set_layer(c->get_focus_layer());
+		ev->set_layer(c->get_input_player());
 		c->input(ev);
 	}
 }

--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -163,6 +163,7 @@ void ViewportContainer::_input(const Ref<InputEvent> &p_event) {
 		if (!c || c->is_input_disabled())
 			continue;
 
+		ev->set_layer(c->get_focus_layer());
 		c->input(ev);
 	}
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1274,9 +1274,7 @@ Ref<InputEvent> Viewport::_make_input_local(const Ref<InputEvent> &ev) {
 	Vector2 vp_ofs = _get_window_offset();
 	Transform2D ai = get_final_transform().affine_inverse() * _get_input_pre_xform();
 
-	Ref<InputEvent> out = ev->xformed_by(ai, -vp_ofs);
-
-	return out;
+	return ev->xformed_by(ai, -vp_ofs);
 }
 
 void Viewport::_vp_input_text(const String &p_text) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1274,7 +1274,10 @@ Ref<InputEvent> Viewport::_make_input_local(const Ref<InputEvent> &ev) {
 	Vector2 vp_ofs = _get_window_offset();
 	Transform2D ai = get_final_transform().affine_inverse() * _get_input_pre_xform();
 
-	return ev->xformed_by(ai, -vp_ofs);
+	Ref<InputEvent> out = ev->xformed_by(ai, -vp_ofs);
+	out->set_layer(get_focus_layer());
+
+	return out;
 }
 
 void Viewport::_vp_input_text(const String &p_text) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1275,7 +1275,7 @@ Ref<InputEvent> Viewport::_make_input_local(const Ref<InputEvent> &ev) {
 	Transform2D ai = get_final_transform().affine_inverse() * _get_input_pre_xform();
 
 	Ref<InputEvent> out = ev->xformed_by(ai, -vp_ofs);
-	out->set_layer(get_focus_layer());
+	out->set_layer(get_input_player());
 
 	return out;
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1275,7 +1275,7 @@ Ref<InputEvent> Viewport::_make_input_local(const Ref<InputEvent> &ev) {
 	Transform2D ai = get_final_transform().affine_inverse() * _get_input_pre_xform();
 
 	Ref<InputEvent> out = ev->xformed_by(ai, -vp_ofs);
-	out->set_layer(get_input_player());
+	out->set_player(get_input_player());
 
 	return out;
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1275,7 +1275,6 @@ Ref<InputEvent> Viewport::_make_input_local(const Ref<InputEvent> &ev) {
 	Transform2D ai = get_final_transform().affine_inverse() * _get_input_pre_xform();
 
 	Ref<InputEvent> out = ev->xformed_by(ai, -vp_ofs);
-	out->set_player(get_input_player());
 
 	return out;
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1359,15 +1359,21 @@ void Viewport::_gui_prepare_subwindows() {
 	_gui_sort_subwindows();
 }
 
-void Viewport::set_input_player(int p_input_player) {
+void Viewport::set_focus_group(String p_focus_group) {
 	StringName old = focus_group;
-	input_player = p_input_player;
-	focus_group = "_viewport_focus_" + itos(input_player);
-
+	focus_group = "_viewport_focus_" + p_focus_group;
 	if (is_inside_tree()) {
 		remove_from_group(old);
 		add_to_group(focus_group);
 	}
+}
+
+String Viewport::get_focus_group() const {
+	return String(focus_group).replace("_viewport_focus_", "");
+}
+
+void Viewport::set_input_player(int p_input_player) {
+	input_player = p_input_player;
 }
 
 int Viewport::get_input_player() const {
@@ -3039,6 +3045,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_mouse_position"), &Viewport::get_mouse_position);
 	ClassDB::bind_method(D_METHOD("warp_mouse", "to_position"), &Viewport::warp_mouse);
 
+	ClassDB::bind_method(D_METHOD("set_focus_group", "focus_group"), &Viewport::set_focus_group);
+	ClassDB::bind_method(D_METHOD("get_focus_group"), &Viewport::get_focus_group);
+
 	ClassDB::bind_method(D_METHOD("set_input_player", "input_player"), &Viewport::set_input_player);
 	ClassDB::bind_method(D_METHOD("get_input_player"), &Viewport::get_input_player);
 
@@ -3104,6 +3113,7 @@ void Viewport::_bind_methods() {
 	ADD_GROUP("Physics", "physics_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_object_picking"), "set_physics_object_picking", "get_physics_object_picking");
 	ADD_GROUP("GUI", "gui_");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "gui_focus_group", PROPERTY_HINT_NONE, ""), "set_focus_group", "get_focus_group");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gui_input_player", PROPERTY_HINT_ENUM, "All,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16"), "set_input_player", "get_input_player");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_disable_input"), "set_disable_input", "is_input_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_snap_controls_to_pixels"), "set_snap_controls_to_pixels", "is_snap_controls_to_pixels_enabled");
@@ -3223,8 +3233,9 @@ Viewport::Viewport() {
 	gui_input_group = "_vp_gui_input" + id;
 	unhandled_input_group = "_vp_unhandled_input" + id;
 	unhandled_key_input_group = "_vp_unhandled_key_input" + id;
+	focus_group = "_viewport_focus_main";
 
-	set_input_player(0);
+	input_player = 0;
 	disable_input = false;
 	disable_3d = false;
 	keep_3d_linear = false;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2283,7 +2283,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 		}
 
-		if (p_event->is_pressed() && p_event->is_action("ui_cancel") && !gui.modal_stack.empty()) {
+		if (p_event->is_pressed() && p_event->is_action("ui_cancel", get_viewport()->get_input_player()) && !gui.modal_stack.empty()) {
 
 			_gui_sort_modal_stack();
 			Control *top = gui.modal_stack.back()->get();
@@ -2310,32 +2310,32 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (from && p_event->is_pressed()) {
 			Control *next = NULL;
 
-			if (p_event->is_action_pressed("ui_focus_next")) {
+			if (p_event->is_action_pressed("ui_focus_next", get_viewport()->get_input_player())) {
 
 				next = from->find_next_valid_focus();
 			}
 
-			if (p_event->is_action_pressed("ui_focus_prev")) {
+			if (p_event->is_action_pressed("ui_focus_prev", get_viewport()->get_input_player())) {
 
 				next = from->find_prev_valid_focus();
 			}
 
-			if (!mods && p_event->is_action_pressed("ui_up")) {
+			if (!mods && p_event->is_action_pressed("ui_up", get_viewport()->get_input_player())) {
 
 				next = from->_get_focus_neighbour(MARGIN_TOP);
 			}
 
-			if (!mods && p_event->is_action_pressed("ui_left")) {
+			if (!mods && p_event->is_action_pressed("ui_left", get_viewport()->get_input_player())) {
 
 				next = from->_get_focus_neighbour(MARGIN_LEFT);
 			}
 
-			if (!mods && p_event->is_action_pressed("ui_right")) {
+			if (!mods && p_event->is_action_pressed("ui_right", get_viewport()->get_input_player())) {
 
 				next = from->_get_focus_neighbour(MARGIN_RIGHT);
 			}
 
-			if (!mods && p_event->is_action_pressed("ui_down")) {
+			if (!mods && p_event->is_action_pressed("ui_down", get_viewport()->get_input_player())) {
 
 				next = from->_get_focus_neighbour(MARGIN_BOTTOM);
 			}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -276,6 +276,7 @@ void Viewport::_notification(int p_what) {
 			find_world_2d()->_register_viewport(this, Rect2());
 
 			add_to_group("_viewports");
+			add_to_group(focus_group);
 			if (get_tree()->is_debugging_collisions_hint()) {
 				//2D
 				Physics2DServer::get_singleton()->space_set_debug_contacts(find_world_2d()->get_space(), get_tree()->get_collision_debug_contact_count());
@@ -352,7 +353,7 @@ void Viewport::_notification(int p_what) {
 			}
 
 			remove_from_group("_viewports");
-
+			remove_from_group(focus_group);
 			VS::get_singleton()->viewport_set_active(viewport, false);
 
 		} break;
@@ -1356,6 +1357,21 @@ void Viewport::_gui_prepare_subwindows() {
 	}
 
 	_gui_sort_subwindows();
+}
+
+void Viewport::set_focus_layer(int p_focus_layer) {
+	StringName old = focus_group;
+	focus_layer = p_focus_layer;
+	focus_group = "_viewport_focus_" + itos(focus_layer);
+
+	if (is_inside_tree()) {
+		remove_from_group(old);
+		add_to_group(focus_group);
+	}
+}
+
+int Viewport::get_focus_layer() const {
+	return focus_layer;
 }
 
 void Viewport::_gui_sort_subwindows() {
@@ -2515,7 +2531,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 	//no need for change
 	if (gui.key_focus && gui.key_focus == p_control)
 		return;
-	get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, "_viewports", "_gui_remove_focus");
+	get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, focus_group, "_gui_remove_focus");
 	gui.key_focus = p_control;
 	p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
 	p_control->update();
@@ -3023,6 +3039,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_mouse_position"), &Viewport::get_mouse_position);
 	ClassDB::bind_method(D_METHOD("warp_mouse", "to_position"), &Viewport::warp_mouse);
 
+	ClassDB::bind_method(D_METHOD("set_focus_layer", "focus_layer"), &Viewport::set_focus_layer);
+	ClassDB::bind_method(D_METHOD("get_focus_layer"), &Viewport::get_focus_layer);
+
 	ClassDB::bind_method(D_METHOD("gui_has_modal_stack"), &Viewport::gui_has_modal_stack);
 	ClassDB::bind_method(D_METHOD("gui_get_drag_data"), &Viewport::gui_get_drag_data);
 	ClassDB::bind_method(D_METHOD("gui_is_dragging"), &Viewport::gui_is_dragging);
@@ -3085,6 +3104,7 @@ void Viewport::_bind_methods() {
 	ADD_GROUP("Physics", "physics_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_object_picking"), "set_physics_object_picking", "get_physics_object_picking");
 	ADD_GROUP("GUI", "gui_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "gui_focus_layer", PROPERTY_HINT_RANGE, "0,20"), "set_focus_layer", "get_focus_layer");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_disable_input"), "set_disable_input", "is_input_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_snap_controls_to_pixels"), "set_snap_controls_to_pixels", "is_snap_controls_to_pixels_enabled");
 	ADD_GROUP("Shadow Atlas", "shadow_atlas_");
@@ -3204,6 +3224,7 @@ Viewport::Viewport() {
 	unhandled_input_group = "_vp_unhandled_input" + id;
 	unhandled_key_input_group = "_vp_unhandled_key_input" + id;
 
+	set_focus_layer(0);
 	disable_input = false;
 	disable_3d = false;
 	keep_3d_linear = false;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1362,10 +1362,10 @@ void Viewport::_gui_prepare_subwindows() {
 	_gui_sort_subwindows();
 }
 
-void Viewport::set_focus_layer(int p_focus_layer) {
+void Viewport::set_input_player(int p_input_player) {
 	StringName old = focus_group;
-	focus_layer = p_focus_layer;
-	focus_group = "_viewport_focus_" + itos(focus_layer);
+	input_player = p_input_player;
+	focus_group = "_viewport_focus_" + itos(input_player);
 
 	if (is_inside_tree()) {
 		remove_from_group(old);
@@ -1373,8 +1373,8 @@ void Viewport::set_focus_layer(int p_focus_layer) {
 	}
 }
 
-int Viewport::get_focus_layer() const {
-	return focus_layer;
+int Viewport::get_input_player() const {
+	return input_player;
 }
 
 void Viewport::_gui_sort_subwindows() {
@@ -3042,8 +3042,8 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_mouse_position"), &Viewport::get_mouse_position);
 	ClassDB::bind_method(D_METHOD("warp_mouse", "to_position"), &Viewport::warp_mouse);
 
-	ClassDB::bind_method(D_METHOD("set_focus_layer", "focus_layer"), &Viewport::set_focus_layer);
-	ClassDB::bind_method(D_METHOD("get_focus_layer"), &Viewport::get_focus_layer);
+	ClassDB::bind_method(D_METHOD("set_input_player", "input_player"), &Viewport::set_input_player);
+	ClassDB::bind_method(D_METHOD("get_input_player"), &Viewport::get_input_player);
 
 	ClassDB::bind_method(D_METHOD("gui_has_modal_stack"), &Viewport::gui_has_modal_stack);
 	ClassDB::bind_method(D_METHOD("gui_get_drag_data"), &Viewport::gui_get_drag_data);
@@ -3107,7 +3107,7 @@ void Viewport::_bind_methods() {
 	ADD_GROUP("Physics", "physics_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_object_picking"), "set_physics_object_picking", "get_physics_object_picking");
 	ADD_GROUP("GUI", "gui_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "gui_focus_layer", PROPERTY_HINT_RANGE, "0,20"), "set_focus_layer", "get_focus_layer");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "gui_input_player", PROPERTY_HINT_ENUM, "All,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16"), "set_input_player", "get_input_player");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_disable_input"), "set_disable_input", "is_input_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_snap_controls_to_pixels"), "set_snap_controls_to_pixels", "is_snap_controls_to_pixels_enabled");
 	ADD_GROUP("Shadow Atlas", "shadow_atlas_");
@@ -3227,7 +3227,7 @@ Viewport::Viewport() {
 	unhandled_input_group = "_vp_unhandled_input" + id;
 	unhandled_key_input_group = "_vp_unhandled_key_input" + id;
 
-	set_focus_layer(0);
+	set_input_player(0);
 	disable_input = false;
 	disable_3d = false;
 	keep_3d_linear = false;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -303,6 +303,8 @@ private:
 	} gui;
 
 	bool disable_input;
+	int focus_layer;
+	StringName focus_group;
 
 	void _gui_call_input(Control *p_control, const Ref<InputEvent> &p_input);
 	void _gui_call_notification(Control *p_control, int p_what);
@@ -469,6 +471,9 @@ public:
 
 	void input(const Ref<InputEvent> &p_event);
 	void unhandled_input(const Ref<InputEvent> &p_event);
+
+	void set_focus_layer(int p_focus_layer);
+	int get_focus_layer() const;
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -303,7 +303,7 @@ private:
 	} gui;
 
 	bool disable_input;
-	int focus_layer;
+	int input_player;
 	StringName focus_group;
 
 	void _gui_call_input(Control *p_control, const Ref<InputEvent> &p_input);
@@ -472,8 +472,8 @@ public:
 	void input(const Ref<InputEvent> &p_event);
 	void unhandled_input(const Ref<InputEvent> &p_event);
 
-	void set_focus_layer(int p_focus_layer);
-	int get_focus_layer() const;
+	void set_input_player(int p_input_player);
+	int get_input_player() const;
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -472,6 +472,9 @@ public:
 	void input(const Ref<InputEvent> &p_event);
 	void unhandled_input(const Ref<InputEvent> &p_event);
 
+	String get_focus_group() const;
+	void set_focus_group(String p_focus_group);
+
 	void set_input_player(int p_input_player);
 	int get_input_player() const;
 


### PR DESCRIPTION
Mostly implement what discussed in #20091 . Focus uses group names (strings) instead of booleans.

A demo project with split screen, separate focus and inputs is available here: 
(`W,A,S,D,Space ||| LEFT,RIGHT,UP,DOWN, Enter`)

[ActionPlayer.zip](https://github.com/godotengine/godot/files/3317041/ActionPlayer.zip) ([live HTML5 here](https://no-war.fales.me/ActionLayer.html), you need to first click into the page after loading for input to start working)

The PR basically add a `player` field to each input event in the `InputMap`.
Action related methods have a new parameter for specifying which player to filter (`0` for no filtering).

![viewport_player_filter](https://user-images.githubusercontent.com/1687918/59966748-fac1ae80-9520-11e9-9f46-636888834aa7.png)

![inputmap](https://user-images.githubusercontent.com/1687918/59966791-73c10600-9521-11e9-87a5-a9b15fdcc0a5.png)

Viewport have two new properties under "GUI" section: `input_player` to specify which player the UI will filter (default `0`, i.e. no filtering) and `focus_group`property decides focus sharing. Viewports in the same `focus_group` share focus across them.

![viewportgui](https://user-images.githubusercontent.com/1687918/59966847-390b9d80-9522-11e9-96d4-2dbd46a58236.png)

This change is quite hacky, and we are still trying to figure out if there's a better way then this to get multifocus and UI actions working together. Without overcomplicating things but still allowing people to make split screen games and use Godot UI nodes.

I'm setting this PR to milestone 4.0 so we can get @reduz input once he is done with Vulkan.
If anyone has suggestions, ideas, they are more than welcome.

Fixes #10755