### PR TITLE
Make Visual Script Available Nodes Search Better

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1169,7 +1169,7 @@ void VisualScriptEditor::_update_available_nodes() {
 
 		Vector<String> path = E->get().split("/");
 
-		if (filter != String() && path.size() && path[path.size() - 1].findn(filter) == -1)
+		if (filter != String() && path.size() && E->get().findn(filter) == -1)
 			continue;
 
 		String sp;


### PR DESCRIPTION
This allows also checking the full path. Rather than just the node name.

So we can search Plane or Quat or Transform or Vector or something and get all related Nodes.