### PR TITLE
SCons: Default to builtin libpng/freetype on Linux

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -75,11 +75,7 @@ def get_opts():
 
 def get_flags():
 
-    return [
-        ('builtin_freetype', False),
-        ('builtin_libpng', False),
-        ('builtin_zlib', False),
-    ]
+    return []
 
 
 def configure(env):


### PR DESCRIPTION
The rationale for keeping those shared by default is that they're typical
dependencies found on any Linux system, and it saves compilation time and
binary size to link their dynamically.

But since official builds default to all-builtin, and Debian/Ubuntu still
don't have libpng16 (which we now require since #29874) readily available
on all their supported releases, it's simpler to bundle all the things.

This does not change the fact that those dependencies *can* be unbundled
on Linux, it's only the default option changing.

Cf. #29967 and godotengine/godot-docs#2554.