### PR TITLE
Give LineEdit/TextEdit a custom color for font while uneditable

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -675,10 +675,8 @@ void LineEdit::_notification(int p_what) {
 			RID ci = get_canvas_item();
 
 			Ref<StyleBox> style = get_stylebox("normal");
-			float disabled_alpha = 1.0; // used to set the disabled input text color
 			if (!is_editable()) {
 				style = get_stylebox("read_only");
-				disabled_alpha = .5;
 				draw_caret = false;
 			}
 
@@ -724,7 +722,7 @@ void LineEdit::_notification(int p_what) {
 			int font_ascent = font->get_ascent();
 
 			Color selection_color = get_color("selection_color");
-			Color font_color = get_color("font_color");
+			Color font_color = is_editable() ? get_color("font_color") : get_color("font_color_uneditable");
 			Color font_color_selected = get_color("font_color_selected");
 			Color cursor_color = get_color("cursor_color");
 
@@ -732,12 +730,11 @@ void LineEdit::_notification(int p_what) {
 			// draw placeholder color
 			if (using_placeholder)
 				font_color.a *= placeholder_alpha;
-			font_color.a *= disabled_alpha;
 
 			bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 			if (right_icon.is_valid() || display_clear_icon) {
 				Ref<Texture> r_icon = display_clear_icon ? Control::get_icon("clear") : right_icon;
-				Color color_icon(1, 1, 1, disabled_alpha * .9);
+				Color color_icon(1, 1, 1, !is_editable() ? .5 * .9 : .9);
 				if (display_clear_icon) {
 					if (clear_button_status.press_attempt && clear_button_status.pressing_inside) {
 						color_icon = get_color("clear_button_color_pressed");

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -662,10 +662,8 @@ void TextEdit::_notification(int p_what) {
 			int xmargin_end = size.width - cache.style_normal->get_margin(MARGIN_RIGHT);
 			//let's do it easy for now:
 			cache.style_normal->draw(ci, Rect2(Point2(), size));
-			float readonly_alpha = 1.0; // used to set the input text color when in read-only mode
 			if (readonly) {
 				cache.style_readonly->draw(ci, Rect2(Point2(), size));
-				readonly_alpha = .5;
 				draw_caret = false;
 			}
 			if (has_focus())
@@ -675,8 +673,7 @@ void TextEdit::_notification(int p_what) {
 
 			int visible_rows = get_visible_rows() + 1;
 
-			Color color = cache.font_color;
-			color.a *= readonly_alpha;
+			Color color = readonly ? cache.font_color_readonly : cache.font_color;
 
 			if (syntax_coloring) {
 				if (cache.background_color.a > 0.01) {
@@ -871,10 +868,7 @@ void TextEdit::_notification(int p_what) {
 					color_map = _get_line_syntax_highlighting(line);
 				}
 				// ensure we at least use the font color
-				Color current_color = cache.font_color;
-				if (readonly) {
-					current_color.a *= readonly_alpha;
-				}
+				Color current_color = readonly ? cache.font_color_readonly : cache.font_color;
 
 				bool underlined = false;
 
@@ -1061,10 +1055,7 @@ void TextEdit::_notification(int p_what) {
 
 						if (syntax_coloring) {
 							if (color_map.has(last_wrap_column + j)) {
-								current_color = color_map[last_wrap_column + j].color;
-								if (readonly) {
-									current_color.a *= readonly_alpha;
-								}
+								current_color = readonly ? cache.font_color_readonly : color_map[last_wrap_column + j].color;
 							}
 							color = current_color;
 						}
@@ -1252,8 +1243,7 @@ void TextEdit::_notification(int p_what) {
 						if (cursor.column == last_wrap_column + j && cursor.line == line && cursor_wrap_index == line_wrap_index && block_caret && draw_caret && !insert_mode) {
 							color = cache.caret_background_color;
 						} else if (!syntax_coloring && block_caret) {
-							color = cache.font_color;
-							color.a *= readonly_alpha;
+							color = readonly ? cache.font_color_readonly : cache.font_color;
 						}
 
 						if (str[j] >= 32) {
@@ -4555,6 +4545,7 @@ void TextEdit::_update_caches() {
 	cache.safe_line_number_color = get_color("safe_line_number_color");
 	cache.font_color = get_color("font_color");
 	cache.font_color_selected = get_color("font_color_selected");
+	cache.font_color_readonly = get_color("font_color_readonly");
 	cache.keyword_color = get_color("keyword_color");
 	cache.function_color = get_color("function_color");
 	cache.member_variable_color = get_color("member_variable_color");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -185,6 +185,7 @@ private:
 		Color safe_line_number_color;
 		Color font_color;
 		Color font_color_selected;
+		Color font_color_readonly;
 		Color keyword_color;
 		Color number_color;
 		Color function_color;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -440,6 +440,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("completion_font_color", "TextEdit", Color::html("aaaaaa"));
 	theme->set_color("font_color", "TextEdit", control_font_color);
 	theme->set_color("font_color_selected", "TextEdit", Color(0, 0, 0));
+	theme->set_color("font_color_readonly", "TextEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
 	theme->set_color("selection_color", "TextEdit", font_color_selection);
 	theme->set_color("mark_color", "TextEdit", Color(1.0, 0.4, 0.4, 0.4));
 	theme->set_color("bookmark_color", "TextEdit", Color(0.08, 0.49, 0.98));

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -398,6 +398,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_color("font_color", "LineEdit", control_font_color);
 	theme->set_color("font_color_selected", "LineEdit", Color(0, 0, 0));
+	theme->set_color("font_color_uneditable", "LineEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
 	theme->set_color("cursor_color", "LineEdit", control_font_color_hover);
 	theme->set_color("selection_color", "LineEdit", font_color_selection);
 	theme->set_color("clear_button_color", "LineEdit", control_font_color);


### PR DESCRIPTION
By default an uneditable LineEdit's text has some transparency hardcoded.
This change adds a custom color to LineEdit for adjusting the font when editable is unchecked.
It also leaves the default behavior (0.5 alpha) unchanged.

Fixes #29814