### PR TITLE
Display invalid value keys in AnimationTrackEdit

### DIFF
--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -31,6 +31,11 @@
 #ifndef ANIMATION_TRACK_EDITOR_H
 #define ANIMATION_TRACK_EDITOR_H
 
+#include "editor/editor_data.h"
+#include "editor/editor_spin_slider.h"
+#include "editor/property_editor.h"
+#include "editor/property_selector.h"
+#include "scene/animation/animation_cache.h"
 #include "scene/gui/control.h"
 #include "scene/gui/file_dialog.h"
 #include "scene/gui/menu_button.h"
@@ -40,12 +45,6 @@
 #include "scene/gui/tab_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tool_button.h"
-
-#include "editor/property_selector.h"
-#include "editor_data.h"
-#include "editor_spin_slider.h"
-#include "property_editor.h"
-#include "scene/animation/animation_cache.h"
 #include "scene/resources/animation.h"
 #include "scene_tree_editor.h"
 
@@ -175,8 +174,9 @@ class AnimationTrackEdit : public Control {
 
 	void _path_entered(const String &p_text);
 	void _play_position_draw();
-	mutable int dropping_at;
+	bool _is_value_key_valid(const Variant &p_key_value, Variant::Type &r_valid_type) const;
 
+	mutable int dropping_at;
 	float insert_at_pos;
 	bool moving_selection_attempt;
 	int select_single_attempt;

--- a/editor/icons/icon_key_valid.svg
+++ b/editor/icons/icon_key_valid.svg
@@ -1,5 +1,0 @@
-<svg width="8" height="8" version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
-<g transform="translate(0 -1044.4)">
-<rect transform="rotate(-45)" x="-741.53" y="741.08" width="6.1027" height="6.1027" ry=".76286" fill="#fff"/>
-</g>
-</svg>


### PR DESCRIPTION
Godot 2.1 and 3.0 had this feature but it was lost in the rewrite
of the animation editor in 3.1.
Drop unused `KeyValid` icon, since all valid keys now have a custom
type icon.

![Screenshot_20190623_195452](https://user-images.githubusercontent.com/4701338/59980055-c5849180-95f0-11e9-9174-576aaa3d2645.png)