### PR TITLE
Add docstring for Object.set_deferred

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -374,6 +374,7 @@
 			<argument index="1" name="value" type="Variant">
 			</argument>
 			<description>
+				Set property into the object, after the current frame's physics step. This is equivalent to calling [method set] via [method call_deferred], i.e. [code]call_deferred("set", [property, value])[/code].
 			</description>
 		</method>
 		<method name="set_indexed">


### PR DESCRIPTION
As I was making my way through the ["Your first game" tutorial](https://docs.godotengine.org/en/3.1/getting_started/step_by_step/your_first_game.html) I realized `Object.set_deferred` was missing a docstring. The added documentation is based on my understanding from that tutorial. Let me know if it needs to be updated to be more clear/accurate, as I am not an expert with Godot (just yet).