### PR TITLE
TileMap, fix #29961 reverting partially #28896, making rotation of non uniform tiles fixed to sub-tile

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -793,6 +793,14 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 		rect.size = r.size;
 	}
 
+	if (rect.size.y > rect.size.x) {
+		if ((p_flip_h && (p_flip_v || p_transpose)) || (p_flip_v && !p_transpose))
+			tile_ofs.y += rect.size.y - rect.size.x;
+	} else if (rect.size.y < rect.size.x) {
+		if ((p_flip_v && (p_flip_h || p_transpose)) || (p_flip_h && !p_transpose))
+			tile_ofs.x += rect.size.x - rect.size.y;
+	}
+
 	if (p_transpose) {
 		SWAP(tile_ofs.x, tile_ofs.y);
 		/* For a future CheckBox to Center Texture:

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -201,6 +201,13 @@ void TileMap::_fix_cell_transform(Transform2D &xform, const Cell &p_cell, const 
 
 	Size2 s = p_sc;
 	Vector2 offset = p_offset;
+	if (s.y > s.x) {
+		if ((p_cell.flip_h && (p_cell.flip_v || p_cell.transpose)) || (p_cell.flip_v && !p_cell.transpose))
+			offset.y += s.y - s.x;
+	} else if (s.y < s.x) {
+		if ((p_cell.flip_v && (p_cell.flip_h || p_cell.transpose)) || (p_cell.flip_h && !p_cell.transpose))
+			offset.x += s.x - s.y;
+	}
 
 	if (p_cell.transpose) {
 		SWAP(xform.elements[0].x, xform.elements[0].y);
@@ -369,6 +376,13 @@ void TileMap::update_dirty_quadrants() {
 			rect.size = s;
 			rect.size.x += fp_adjust;
 			rect.size.y += fp_adjust;
+			if (rect.size.y > rect.size.x) {
+				if ((c.flip_h && (c.flip_v || c.transpose)) || (c.flip_v && !c.transpose))
+					tile_ofs.y += rect.size.y - rect.size.x;
+			} else if (rect.size.y < rect.size.x) {
+				if ((c.flip_v && (c.flip_h || c.transpose)) || (c.flip_h && !c.transpose))
+					tile_ofs.x += rect.size.x - rect.size.y;
+			}
 
 			if (c.transpose) {
 				SWAP(tile_ofs.x, tile_ofs.y);


### PR DESCRIPTION
This commit is a reversion of that other to not break compatibility, but it is needed to note that this behaviour of rotating respecting the "subtile" is only for non uniform tiles, if the tile is uniform, no mathers if the texture is bigger than the tile, there is no rotation (there was the original behavior of tilemap)... so i think that this intrincate if statement should be deleted in the future and if there is needed to rotate the texture, do that no mathers if the texture is uniform or not.

Fixes #29961.

Related:
https://github.com/godotengine/godot/pull/28896
https://github.com/godotengine/godot/pull/29519
https://github.com/godotengine/godot/issues/29961
https://github.com/godotengine/godot/issues/29487
https://github.com/godotengine/godot/issues/22989
https://github.com/godotengine/godot/issues/15249
https://github.com/godotengine/godot/issues/28206
https://github.com/godotengine/godot/issues/28610