### PR TITLE
Fix undo references for conversion to CPUParticles

### DIFF
--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -96,9 +96,9 @@ void Particles2DEditorPlugin::_menu_callback(int p_idx) {
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles"));
 			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", particles, cpu_particles, true, false);
-			ur->add_do_reference(particles);
+			ur->add_do_reference(cpu_particles);
 			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, particles, false, false);
-			ur->add_undo_reference(this);
+			ur->add_undo_reference(particles);
 			ur->commit_action();
 
 		} break;

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -315,9 +315,9 @@ void ParticlesEditor::_menu_option(int p_option) {
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles"));
 			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, cpu_particles, true, false);
-			ur->add_do_reference(node);
+			ur->add_do_reference(cpu_particles);
 			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, node, false, false);
-			ur->add_undo_reference(this);
+			ur->add_undo_reference(node);
 			ur->commit_action();
 
 		} break;


### PR DESCRIPTION
The 'undo' reference should be the node to free when the undo history
is lost, i.e. the original (GPU) Particles node. Similarly, the 'do'
reference should point to the CPUParticles (result of the 'do' call).

Fixes #29742.

---

For the reference, I couldn't reproduce #29742 in the CPUParticles (3D) editor, but I fixed the references nevertheless according to the UndoRedo docs.