### PR TITLE
Document MarginContainer node

### DIFF
--- a/doc/classes/MarginContainer.xml
+++ b/doc/classes/MarginContainer.xml
@@ -4,7 +4,15 @@
 		Simple margin container.
 	</brief_description>
 	<description>
-		Simple margin container. Adds a left margin to anything contained.
+		Adds a top, left, bottom, and right margin to all [Control] nodes that are direct children of the container. To control the [MarginContainer]'s margin, use the [code]margin_*[/code] theme properties listed below.
+		[b]Note:[/b] Be careful, [Control] margin values are different than the constant margin values. If you want to change the custom margin values of the [MarginContainer] by code you should use the following examples:
+		[codeblock]
+		var margin_value = 100
+		set("custom_constants/margin_top", margin_value)
+		set("custom_constants/margin_left", margin_value)
+		set("custom_constants/margin_bottom", margin_value)
+		set("custom_constants/margin_right", margin_value)
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>
@@ -14,12 +22,16 @@
 	</constants>
 	<theme_items>
 		<theme_item name="margin_bottom" type="int">
+			All direct children of [MarginContainer] will have a bottom margin of [code]margin_bottom[/code] pixels.
 		</theme_item>
 		<theme_item name="margin_left" type="int">
+			All direct children of [MarginContainer] will have a left margin of [code]margin_left[/code] pixels.
 		</theme_item>
 		<theme_item name="margin_right" type="int">
+			All direct children of [MarginContainer] will have a right margin of [code]margin_right[/code] pixels.
 		</theme_item>
 		<theme_item name="margin_top" type="int">
+			All direct children of [MarginContainer] will have a top margin of [code]margin_top[/code] pixels.
 		</theme_item>
 	</theme_items>
 </class>


### PR DESCRIPTION
~~Editor values of the MarginContainer node are highly misleading as control margins are different than the MarginContainer margin constants. Users have to change custom_constants/margin_* in order to get the desired effect (these constants can only be set in the editor?). I was not sure how to proceed with the documentation so i just changed the "Theme" properties to "Constants".~~ Changed them back to `theme properties` although i'm not sure if that is the correct category for `custom constants`