### PR TITLE
Check if autoload nodes are != NULL before deleting them

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -789,7 +789,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 			}
 		}
 
-		if (!info.is_singleton && !info.in_editor) {
+		if (!info.is_singleton && !info.in_editor && info.node != NULL) {
 			memdelete(info.node);
 			info.node = NULL;
 		}


### PR DESCRIPTION
The editor crashed when deleting an autoload script that has been disabled (Singleton: disabled) and then trying to reopen the project. 

Fixes #27854