### PR TITLE
Implement support for linear filtering in the root viewport

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -256,8 +256,11 @@
 			</argument>
 			<argument index="3" name="shrink" type="float" default="1">
 			</argument>
+			<argument index="4" name="use_filter" type="bool" default="false">
+			</argument>
 			<description>
-				Configures screen stretching to the given [enum StretchMode], [enum StretchAspect], minimum size and [code]shrink[/code].
+				Configures screen stretching to the given [enum StretchMode], [enum StretchAspect], minimum size and [code]shrink[/code]. Screen stretch settings define how the viewport will be resized or scaled when the window size changes.
+				If [code]use_filter[/code] is [code]true[/code], the root viewport will be stretched with linear interpolation. If [code]use_filter[/code] is [code]false[/code], the root viewport will be scaled with nearest-neighbor interpolation (recommended for pixel art).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -152,7 +152,11 @@
 			</return>
 			<argument index="0" name="rect" type="Rect2">
 			</argument>
+			<argument index="1" name="use_filter" type="bool" default="false">
+			</argument>
 			<description>
+				Attaches the viewport to the screen.
+				If [code]use_filter[/code] is [code]true[/code], the viewport will be stretched with linear interpolation. If [code]false[/code], the viewport will be scaled with nearest-neighbor interpolation (recommended for pixel art).
 			</description>
 		</method>
 		<method name="set_input_as_handled">

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -3602,8 +3602,10 @@
 			</argument>
 			<argument index="2" name="screen" type="int" default="0">
 			</argument>
+			<argument index="3" name="use_filter" type="bool" default="false">
+			</argument>
 			<description>
-				Copies viewport to a region of the screen specified by [code]rect[/code]. If Viewport.[member Viewport.render_direct_to_screen] is [code]true[/code], then viewport does not use a framebuffer and the contents of the viewport are rendered directly to screen. However, note that the root viewport is drawn last, therefore it will draw over the screen. Accordingly, you must set the root viewport to an area that does not cover the area that you have attached this viewport to.
+				Copies viewport to a region of the screen specified by [code]rect[/code]. If [member Viewport.render_direct_to_screen] is [code]true[/code], then viewport does not use a framebuffer and the contents of the viewport are rendered directly to screen. However, note that the root viewport is drawn last, therefore it will draw over the screen. Accordingly, you must set the root viewport to an area that does not cover the area that you have attached this viewport to.
 				For example, you can set the root viewport to not render at all with the following code:
 				[codeblock]
 				func _ready():
@@ -3611,6 +3613,7 @@
 				    $Viewport.set_attach_to_screen_rect(Rect2(0, 0, 600, 600))
 				[/codeblock]
 				Using this can result in significant optimization, especially on lower-end devices. However, it comes at the cost of having to manage your viewports manually. For a further optimization see, [method viewport_set_render_direct_to_screen].
+				If [code]use_filter[/code] is [code]true[/code], [code]viewport[/code] will be stretched with linear interpolation. If [code]use_filter[/code] is [code]false[/code], [code]viewport[/code] will be scaled with nearest-neighbor interpolation (recommended for pixel art).
 			</description>
 		</method>
 		<method name="viewport_create">

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -789,7 +789,7 @@ public:
 	void set_current_render_target(RID p_render_target) {}
 	void restore_render_target(bool p_3d_was_drawn) {}
 	void clear_render_target(const Color &p_color) {}
-	void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0) {}
+	void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0, bool p_use_filter = false) {}
 	void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) {}
 	void end_frame(bool p_swap_buffers) {}
 	void finalize() {}

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -397,7 +397,7 @@ void RasterizerGLES2::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	end_frame(true);
 }
 
-void RasterizerGLES2::blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen) {
+void RasterizerGLES2::blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen, bool p_use_filter) {
 
 	ERR_FAIL_COND(storage->frame.current_rt);
 
@@ -419,7 +419,11 @@ void RasterizerGLES2::blit_render_target_to_screen(RID p_render_target, const Re
 		glBindTexture(GL_TEXTURE_2D, rt->color);
 	}
 
-	// TODO normals
+	// TODO: Normals
+	// TODO: Implement `p_use_filter` for linear filtering
+	if (p_use_filter) {
+		WARN_PRINT_ONCE("Linear filtering is only available in the GLES3 backend.");
+	}
 
 	canvas->draw_generic_textured_rect(p_screen_rect, Rect2(0, 0, 1, -1));
 

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -58,7 +58,7 @@ public:
 	virtual void set_current_render_target(RID p_render_target);
 	virtual void restore_render_target(bool p_3d_was_drawn);
 	virtual void clear_render_target(const Color &p_color);
-	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0);
+	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0, bool p_use_filter = false);
 	virtual void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample);
 	virtual void end_frame(bool p_swap_buffers);
 	virtual void finalize();

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -333,7 +333,7 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	end_frame(true);
 }
 
-void RasterizerGLES3::blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen) {
+void RasterizerGLES3::blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen, bool p_use_filter) {
 
 	ERR_FAIL_COND(storage->frame.current_rt);
 
@@ -350,7 +350,7 @@ void RasterizerGLES3::blit_render_target_to_screen(RID p_render_target, const Re
 	}
 	glReadBuffer(GL_COLOR_ATTACHMENT0);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, RasterizerStorageGLES3::system_fbo);
-	glBlitFramebuffer(0, 0, rt->width, rt->height, p_screen_rect.position.x, win_size.height - p_screen_rect.position.y - p_screen_rect.size.height, p_screen_rect.position.x + p_screen_rect.size.width, win_size.height - p_screen_rect.position.y, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	glBlitFramebuffer(0, 0, rt->width, rt->height, p_screen_rect.position.x, win_size.height - p_screen_rect.position.y - p_screen_rect.size.height, p_screen_rect.position.x + p_screen_rect.size.width, win_size.height - p_screen_rect.position.y, GL_COLOR_BUFFER_BIT, p_use_filter ? GL_LINEAR : GL_NEAREST);
 
 #else
 	canvas->canvas_begin();

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -58,7 +58,7 @@ public:
 	virtual void set_current_render_target(RID p_render_target);
 	virtual void restore_render_target(bool p_3d_was_drawn);
 	virtual void clear_render_target(const Color &p_color);
-	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0);
+	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0, bool p_use_filter = false);
 	virtual void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample);
 	virtual void end_frame(bool p_swap_buffers);
 	virtual void finalize();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1635,6 +1635,7 @@ bool Main::start() {
 			String stretch_aspect = GLOBAL_DEF("display/window/stretch/aspect", "ignore");
 			Size2i stretch_size = Size2(GLOBAL_DEF("display/window/size/width", 0), GLOBAL_DEF("display/window/size/height", 0));
 			real_t stretch_shrink = GLOBAL_DEF("display/window/stretch/shrink", 1.0);
+			bool stretch_use_filter = bool(GLOBAL_DEF("display/window/stretch/use_filter", false));
 
 			SceneTree::StretchMode sml_sm = SceneTree::STRETCH_MODE_DISABLED;
 			if (stretch_mode == "2d")
@@ -1652,7 +1653,7 @@ bool Main::start() {
 			else if (stretch_aspect == "expand")
 				sml_aspect = SceneTree::STRETCH_ASPECT_EXPAND;
 
-			sml->set_screen_stretch(sml_sm, sml_aspect, stretch_size, stretch_shrink);
+			sml->set_screen_stretch(sml_sm, sml_aspect, stretch_size, stretch_shrink, stretch_use_filter);
 
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
@@ -1688,6 +1689,8 @@ bool Main::start() {
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/aspect", PropertyInfo(Variant::STRING, "display/window/stretch/aspect", PROPERTY_HINT_ENUM, "ignore,keep,keep_width,keep_height,expand"));
 			GLOBAL_DEF("display/window/stretch/shrink", 1.0);
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/shrink", PropertyInfo(Variant::REAL, "display/window/stretch/shrink", PROPERTY_HINT_RANGE, "1.0,8.0,0.1"));
+			GLOBAL_DEF("display/window/stretch/use_filter", false);
+			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/use_filter", PropertyInfo(Variant::BOOL, "display/window/stretch/use_filter"));
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
 			GLOBAL_DEF("gui/common/snap_controls_to_pixels", true);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1143,7 +1143,7 @@ void SceneTree::_update_root_rect() {
 
 		_update_font_oversampling(1.0);
 		root->set_size((last_screen_size / stretch_shrink).floor());
-		root->set_attach_to_screen_rect(Rect2(Point2(), last_screen_size));
+		root->set_attach_to_screen_rect(Rect2(Point2(), last_screen_size), stretch_use_filter);
 		root->set_size_override_stretch(false);
 		root->set_size_override(false, Size2());
 		root->update_canvas_items();
@@ -1228,7 +1228,7 @@ void SceneTree::_update_root_rect() {
 
 			_update_font_oversampling(screen_size.x / viewport_size.x); //screen / viewport radio drives oversampling
 			root->set_size((screen_size / stretch_shrink).floor());
-			root->set_attach_to_screen_rect(Rect2(margin, screen_size));
+			root->set_attach_to_screen_rect(Rect2(margin, screen_size), stretch_use_filter);
 			root->set_size_override_stretch(true);
 			root->set_size_override(true, (viewport_size / stretch_shrink).floor());
 			root->update_canvas_items(); //force them to update just in case
@@ -1238,7 +1238,7 @@ void SceneTree::_update_root_rect() {
 
 			_update_font_oversampling(1.0);
 			root->set_size((viewport_size / stretch_shrink).floor());
-			root->set_attach_to_screen_rect(Rect2(margin, screen_size));
+			root->set_attach_to_screen_rect(Rect2(margin, screen_size), stretch_use_filter);
 			root->set_size_override_stretch(false);
 			root->set_size_override(false, Size2());
 			root->update_canvas_items(); //force them to update just in case
@@ -1251,12 +1251,13 @@ void SceneTree::_update_root_rect() {
 	}
 }
 
-void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 p_minsize, real_t p_shrink) {
+void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 p_minsize, real_t p_shrink, bool p_use_filter) {
 
 	stretch_mode = p_mode;
 	stretch_aspect = p_aspect;
 	stretch_min = p_minsize;
 	stretch_shrink = p_shrink;
+	stretch_use_filter = p_use_filter;
 	_update_root_rect();
 }
 
@@ -1826,7 +1827,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_frame"), &SceneTree::get_frame);
 	ClassDB::bind_method(D_METHOD("quit"), &SceneTree::quit);
 
-	ClassDB::bind_method(D_METHOD("set_screen_stretch", "mode", "aspect", "minsize", "shrink"), &SceneTree::set_screen_stretch, DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("set_screen_stretch", "mode", "aspect", "minsize", "shrink", "use_filter"), &SceneTree::set_screen_stretch, DEFVAL(1), DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("queue_delete", "obj"), &SceneTree::queue_delete);
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -152,6 +152,7 @@ private:
 	StretchAspect stretch_aspect;
 	Size2i stretch_min;
 	real_t stretch_shrink;
+	bool stretch_use_filter;
 
 	void _update_font_oversampling(float p_ratio);
 	void _update_root_rect();
@@ -386,7 +387,7 @@ public:
 	void get_nodes_in_group(const StringName &p_group, List<Node *> *p_list);
 	bool has_group(const StringName &p_identifier) const;
 
-	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 p_minsize, real_t p_shrink = 1);
+	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 p_minsize, real_t p_shrink = 1, bool p_use_filter = false);
 
 	void set_use_font_oversampling(bool p_oversampling);
 	bool is_using_font_oversampling() const;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2728,9 +2728,9 @@ bool Viewport::is_using_own_world() const {
 	return own_world.is_valid();
 }
 
-void Viewport::set_attach_to_screen_rect(const Rect2 &p_rect) {
+void Viewport::set_attach_to_screen_rect(const Rect2 &p_rect, bool p_use_filter) {
 
-	VS::get_singleton()->viewport_attach_to_screen(viewport, p_rect);
+	VS::get_singleton()->viewport_attach_to_screen(viewport, p_rect, 0, p_use_filter);
 	to_screen_rect = p_rect;
 }
 
@@ -3016,7 +3016,7 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_as_audio_listener_2d", "enable"), &Viewport::set_as_audio_listener_2d);
 	ClassDB::bind_method(D_METHOD("is_audio_listener_2d"), &Viewport::is_audio_listener_2d);
-	ClassDB::bind_method(D_METHOD("set_attach_to_screen_rect", "rect"), &Viewport::set_attach_to_screen_rect);
+	ClassDB::bind_method(D_METHOD("set_attach_to_screen_rect", "rect", "use_filter"), &Viewport::set_attach_to_screen_rect, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_use_render_direct_to_screen", "enable"), &Viewport::set_use_render_direct_to_screen);
 	ClassDB::bind_method(D_METHOD("is_using_render_direct_to_screen"), &Viewport::is_using_render_direct_to_screen);
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -479,7 +479,7 @@ public:
 	void set_keep_3d_linear(bool p_keep_3d_linear);
 	bool get_keep_3d_linear() const;
 
-	void set_attach_to_screen_rect(const Rect2 &p_rect);
+	void set_attach_to_screen_rect(const Rect2 &p_rect, bool p_use_filter = false);
 	Rect2 get_attach_to_screen_rect() const;
 
 	void set_use_render_direct_to_screen(bool p_render_direct_to_screen);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1112,7 +1112,7 @@ public:
 	virtual void set_current_render_target(RID p_render_target) = 0;
 	virtual void restore_render_target(bool p_3d) = 0;
 	virtual void clear_render_target(const Color &p_color) = 0;
-	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0) = 0;
+	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0, bool p_use_filter = false) = 0;
 	virtual void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) = 0;
 	virtual void end_frame(bool p_swap_buffers) = 0;
 	virtual void finalize() = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -454,7 +454,7 @@ public:
 
 	BIND2(viewport_set_clear_mode, RID, ViewportClearMode)
 
-	BIND3(viewport_attach_to_screen, RID, const Rect2 &, int)
+	BIND4(viewport_attach_to_screen, RID, const Rect2 &, int, bool)
 	BIND2(viewport_set_render_direct_to_screen, RID, bool)
 	BIND1(viewport_detach, RID)
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -346,7 +346,7 @@ void VisualServerViewport::draw_viewports() {
 			if (vp->viewport_to_screen_rect != Rect2() && (!vp->viewport_render_direct_to_screen || !VSG::rasterizer->is_low_end())) {
 				//copy to screen if set as such
 				VSG::rasterizer->set_current_render_target(RID());
-				VSG::rasterizer->blit_render_target_to_screen(vp->render_target, vp->viewport_to_screen_rect, vp->viewport_to_screen);
+				VSG::rasterizer->blit_render_target_to_screen(vp->render_target, vp->viewport_to_screen_rect, vp->viewport_to_screen, vp->use_filter);
 			}
 		}
 
@@ -420,7 +420,7 @@ void VisualServerViewport::viewport_set_clear_mode(RID p_viewport, VS::ViewportC
 	viewport->clear_mode = p_clear_mode;
 }
 
-void VisualServerViewport::viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect, int p_screen) {
+void VisualServerViewport::viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect, int p_screen, bool p_use_filter) {
 
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);
@@ -435,6 +435,7 @@ void VisualServerViewport::viewport_attach_to_screen(RID p_viewport, const Rect2
 
 	viewport->viewport_to_screen_rect = p_rect;
 	viewport->viewport_to_screen = p_screen;
+	viewport->use_filter = p_use_filter;
 }
 
 void VisualServerViewport::viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable) {

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -66,6 +66,7 @@ public:
 		bool disable_3d;
 		bool disable_3d_by_usage;
 		bool keep_3d_linear;
+		bool use_filter;
 
 		RID shadow_atlas;
 		int shadow_atlas_size;
@@ -119,6 +120,7 @@ public:
 			disable_3d = false;
 			disable_3d_by_usage = false;
 			keep_3d_linear = false;
+			use_filter = false;
 			debug_draw = VS::VIEWPORT_DEBUG_DRAW_DISABLED;
 			for (int i = 0; i < VS::VIEWPORT_RENDER_INFO_MAX; i++) {
 				render_info[i] = 0;
@@ -158,7 +160,7 @@ public:
 
 	void viewport_set_size(RID p_viewport, int p_width, int p_height);
 
-	void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), int p_screen = 0);
+	void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), int p_screen = 0, bool p_use_filter = false);
 	void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable);
 	void viewport_detach(RID p_viewport);
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -381,7 +381,7 @@ public:
 
 	FUNC2(viewport_set_clear_mode, RID, ViewportClearMode)
 
-	FUNC3(viewport_attach_to_screen, RID, const Rect2 &, int)
+	FUNC4(viewport_attach_to_screen, RID, const Rect2 &, int, bool)
 	FUNC2(viewport_set_render_direct_to_screen, RID, bool)
 	FUNC1(viewport_detach, RID)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1876,7 +1876,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &VisualServer::viewport_set_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_active", "viewport", "active"), &VisualServer::viewport_set_active);
 	ClassDB::bind_method(D_METHOD("viewport_set_parent_viewport", "viewport", "parent_viewport"), &VisualServer::viewport_set_parent_viewport);
-	ClassDB::bind_method(D_METHOD("viewport_attach_to_screen", "viewport", "rect", "screen"), &VisualServer::viewport_attach_to_screen, DEFVAL(Rect2()), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("viewport_attach_to_screen", "viewport", "rect", "screen", "use_filter"), &VisualServer::viewport_attach_to_screen, DEFVAL(Rect2()), DEFVAL(0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("viewport_set_render_direct_to_screen", "viewport", "enabled"), &VisualServer::viewport_set_render_direct_to_screen);
 	ClassDB::bind_method(D_METHOD("viewport_detach", "viewport"), &VisualServer::viewport_detach);
 	ClassDB::bind_method(D_METHOD("viewport_set_update_mode", "viewport", "update_mode"), &VisualServer::viewport_set_update_mode);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -610,7 +610,7 @@ public:
 	virtual void viewport_set_active(RID p_viewport, bool p_active) = 0;
 	virtual void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport) = 0;
 
-	virtual void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), int p_screen = 0) = 0;
+	virtual void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), int p_screen = 0, bool p_use_filter = false) = 0;
 	virtual void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable) = 0;
 	virtual void viewport_detach(RID p_viewport) = 0;
 


### PR DESCRIPTION
This makes it easier to configure a root viewport that uses linear filtering instead of nearest-neighbor filtering. Linear filtering is better suited to realistic-looking games and supersampling.

Currently only implemented in the GLES3 renderer. Help is welcome to get it working in GLES2 :slightly_smiling_face:

## Preview

### Nearest-neighbor filtering

![viewport_nearest](https://user-images.githubusercontent.com/180032/60043272-fbdd1200-96bf-11e9-8b6c-89281579c351.png)

### Linear filtering

![viewport_linear](https://user-images.githubusercontent.com/180032/60043277-fda6d580-96bf-11e9-89d6-48be3e64406d.png)