### PR TITLE
Area2D: Fix argument type of body_* signals

### DIFF
--- a/doc/classes/Area.xml
+++ b/doc/classes/Area.xml
@@ -56,7 +56,8 @@
 			<argument index="0" name="body" type="Node">
 			</argument>
 			<description>
-				If [code]true[/code], the given body overlaps the Area. Note that the result of this test is not immediate after moving objects. For performance, list of overlaps is updated once per frame and before the physics step. Consider using signals instead.
+				If [code]true[/code], the given physics body overlaps the Area. Note that the result of this test is not immediate after moving objects. For performance, list of overlaps is updated once per frame and before the physics step. Consider using signals instead.
+				The [code]body[/code] argument can either be a [PhysicsBody] or a [GridMap] instance (while GridMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</method>
 		<method name="set_collision_layer_bit">
@@ -183,14 +184,16 @@
 			<argument index="0" name="body" type="Node">
 			</argument>
 			<description>
-				Emitted when a [PhysicsBody] object enters.
+				Emitted when a physics body enters.
+				The [code]body[/code] argument can either be a [PhysicsBody] or a [GridMap] instance (while GridMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</signal>
 		<signal name="body_exited">
 			<argument index="0" name="body" type="Node">
 			</argument>
 			<description>
-				Emitted when a [PhysicsBody] object exits.
+				Emitted when a physics body exits.
+				The [code]body[/code] argument can either be a [PhysicsBody] or a [GridMap] instance (while GridMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</signal>
 		<signal name="body_shape_entered">
@@ -203,7 +206,8 @@
 			<argument index="3" name="area_shape" type="int">
 			</argument>
 			<description>
-				Emitted when a [PhysicsBody] object enters, reporting which shapes overlapped.
+				Emitted when a physics body enters, reporting which shapes overlapped.
+				The [code]body[/code] argument can either be a [PhysicsBody] or a [GridMap] instance (while GridMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
@@ -216,7 +220,8 @@
 			<argument index="3" name="area_shape" type="int">
 			</argument>
 			<description>
-				Emitted when a [PhysicsBody] object exits, reporting which shapes were overlapping.
+				Emitted when a physics body exits, reporting which shapes were overlapping.
+				The [code]body[/code] argument can either be a [PhysicsBody] or a [GridMap] instance (while GridMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -56,7 +56,8 @@
 			<argument index="0" name="body" type="Node">
 			</argument>
 			<description>
-				If [code]true[/code], the given body overlaps the Area2D. Note that the result of this test is not immediate after moving objects. For performance, list of overlaps is updated once per frame and before the physics step. Consider using signals instead.
+				If [code]true[/code], the given physics body overlaps the Area2D. Note that the result of this test is not immediate after moving objects. For performance, list of overlaps is updated once per frame and before the physics step. Consider using signals instead.
+				The [code]body[/code] argument can either be a [PhysicsBody2D] or a [TileMap] instance (while TileMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</method>
 		<method name="set_collision_layer_bit">
@@ -168,43 +169,47 @@
 			</description>
 		</signal>
 		<signal name="body_entered">
-			<argument index="0" name="body" type="PhysicsBody2D">
+			<argument index="0" name="body" type="Node">
 			</argument>
 			<description>
-				Emitted when a [PhysicsBody2D] object enters.
+				Emitted when a physics body enters.
+				The [code]body[/code] argument can either be a [PhysicsBody2D] or a [TileMap] instance (while TileMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</signal>
 		<signal name="body_exited">
-			<argument index="0" name="body" type="PhysicsBody2D">
+			<argument index="0" name="body" type="Node">
 			</argument>
 			<description>
-				Emitted when a [PhysicsBody2D] object exits.
+				Emitted when a physics body exits.
+				The [code]body[/code] argument can either be a [PhysicsBody2D] or a [TileMap] instance (while TileMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</signal>
 		<signal name="body_shape_entered">
 			<argument index="0" name="body_id" type="int">
 			</argument>
-			<argument index="1" name="body" type="PhysicsBody2D">
+			<argument index="1" name="body" type="Node">
 			</argument>
 			<argument index="2" name="body_shape" type="int">
 			</argument>
 			<argument index="3" name="area_shape" type="int">
 			</argument>
 			<description>
-				Emitted when a [PhysicsBody2D] object enters, reporting which shapes overlapped.
+				Emitted when a physics body enters, reporting which shapes overlapped.
+				The [code]body[/code] argument can either be a [PhysicsBody2D] or a [TileMap] instance (while TileMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
 			<argument index="0" name="body_id" type="int">
 			</argument>
-			<argument index="1" name="body" type="PhysicsBody2D">
+			<argument index="1" name="body" type="Node">
 			</argument>
 			<argument index="2" name="body_shape" type="int">
 			</argument>
 			<argument index="3" name="area_shape" type="int">
 			</argument>
 			<description>
-				Emitted when a [PhysicsBody2D] object exits, reporting which shapes were overlapping.
+				Emitted when a physics body exits, reporting which shapes were overlapping.
+				The [code]body[/code] argument can either be a [PhysicsBody2D] or a [TileMap] instance (while TileMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body).
 			</description>
 		</signal>
 	</signals>

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -657,10 +657,10 @@ void Area2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_body_inout"), &Area2D::_body_inout);
 	ClassDB::bind_method(D_METHOD("_area_inout"), &Area2D::_area_inout);
 
-	ADD_SIGNAL(MethodInfo("body_shape_entered", PropertyInfo(Variant::INT, "body_id"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsBody2D"), PropertyInfo(Variant::INT, "body_shape"), PropertyInfo(Variant::INT, "area_shape")));
-	ADD_SIGNAL(MethodInfo("body_shape_exited", PropertyInfo(Variant::INT, "body_id"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsBody2D"), PropertyInfo(Variant::INT, "body_shape"), PropertyInfo(Variant::INT, "area_shape")));
-	ADD_SIGNAL(MethodInfo("body_entered", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsBody2D")));
-	ADD_SIGNAL(MethodInfo("body_exited", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsBody2D")));
+	ADD_SIGNAL(MethodInfo("body_shape_entered", PropertyInfo(Variant::INT, "body_id"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::INT, "body_shape"), PropertyInfo(Variant::INT, "area_shape")));
+	ADD_SIGNAL(MethodInfo("body_shape_exited", PropertyInfo(Variant::INT, "body_id"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::INT, "body_shape"), PropertyInfo(Variant::INT, "area_shape")));
+	ADD_SIGNAL(MethodInfo("body_entered", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
+	ADD_SIGNAL(MethodInfo("body_exited", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 
 	ADD_SIGNAL(MethodInfo("area_shape_entered", PropertyInfo(Variant::INT, "area_id"), PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area2D"), PropertyInfo(Variant::INT, "area_shape"), PropertyInfo(Variant::INT, "self_shape")));
 	ADD_SIGNAL(MethodInfo("area_shape_exited", PropertyInfo(Variant::INT, "area_id"), PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area2D"), PropertyInfo(Variant::INT, "area_shape"), PropertyInfo(Variant::INT, "self_shape")));


### PR DESCRIPTION
Those signals receive either a PhysicsBody2D or a TileMap object,
and what the emitting method checks internally is only that the
object is a Node. In theory any Node could go through these signals
if they talk directly to the PhysicsServer2D.

Also updated docs.

Fixes #27076.

Might need further (compat breaking) improvement as this API is a
bit confusing, cf. #24739.