### PR TITLE
Call out scaling in Spatial.translate docstring

### DIFF
--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -274,6 +274,7 @@
 			</argument>
 			<description>
 				Changes the node's position by given offset [Vector3].
+				Note that the translation [code]offset[/code] is affected by the node's scale, so if scaled by e.g. [code](10, 1, 1)[/code], a translation by an offset of [code](2, 0, 0)[/code] would actually add 20 ([code]2 * 10[/code]) to the X coordinate.
 			</description>
 		</method>
 		<method name="translate_object_local">


### PR DESCRIPTION
Add a note to make it clear that `Spatial.translate` is affected by the object's scale.

*Bugsquad edit:* Fixes #26938.