### PR TITLE
iOS export: invalid identifier, the character '-' is not allowed

### DIFF
--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -125,7 +125,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 				first = true;
 				continue;
 			}
-			if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_')) {
+			if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-')) {
 				if (r_error) {
 					*r_error = vformat(TTR("The character '%s' is not allowed in Identifier."), String::chr(c));
 				}
@@ -137,7 +137,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 				}
 				return false;
 			}
-			if (first && c == '_') {
+			if (first && c == '-') {
 				if (r_error) {
 					*r_error = vformat(TTR("The character '%s' cannot be the first character in a Identifier segment."), String::chr(c));
 				}


### PR DESCRIPTION
I tried to set my identifier to co.uk.thingy-ma-jig.MyGameName and I get this:

<img width="442" alt="image" src="https://user-images.githubusercontent.com/384976/60055783-aa8c4d00-96d6-11e9-88c4-13d7e80def39.png">

Except... hyphens are valid. The Apple portal didn't complain when I setup the App ID bundle with hypens.