### PR TITLE
Fix Popup::popup_centered not centralizing at the first call

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -141,7 +141,7 @@ void Popup::popup_centered(const Size2 &p_size) {
 	rect.size = p_size == Size2() ? get_size() : p_size;
 	rect.position = ((window_size - rect.size) / 2.0).floor();
 
-	popup(rect);
+	_popup(rect, true);
 }
 
 void Popup::popup_centered_ratio(float p_screen_ratio) {
@@ -151,18 +151,29 @@ void Popup::popup_centered_ratio(float p_screen_ratio) {
 	rect.size = (window_size * p_screen_ratio).floor();
 	rect.position = ((window_size - rect.size) / 2.0).floor();
 
-	popup(rect);
+	_popup(rect, true);
 }
 
 void Popup::popup(const Rect2 &p_bounds) {
+
+	_popup(p_bounds);
+}
+
+void Popup::_popup(const Rect2 &p_bounds, const bool p_centered) {
 
 	emit_signal("about_to_show");
 	show_modal(exclusive);
 
 	// Fit the popup into the optionally provided bounds.
 	if (!p_bounds.has_no_area()) {
-		set_position(p_bounds.position);
 		set_size(p_bounds.size);
+
+		// check if p_bounds.size was using an outdated cached values
+		if (p_centered && p_bounds.size != get_size()) {
+			set_position(p_bounds.position - ((get_size() - p_bounds.size) / 2.0).floor());
+		} else {
+			set_position(p_bounds.position);
+		}
 	}
 	_fix_size();
 

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -43,6 +43,9 @@ class Popup : public Control {
 	bool exclusive;
 	bool popped_up;
 
+private:
+	void _popup(const Rect2 &p_bounds = Rect2(), const bool p_centered = false);
+
 protected:
 	virtual void _post_popup() {}
 


### PR DESCRIPTION
Proper fix for #24907