### PR TITLE
Remove references to mouse stuff from OS

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -4,7 +4,7 @@
 		Operating System functions.
 	</brief_description>
 	<description>
-		Operating System functions. OS Wraps the most common functionality to communicate with the host Operating System, such as: mouse grabbing, mouse cursors, clipboard, video mode, date and time, timers, environment variables, execution of binaries, command line, etc.
+		Operating System functions. OS Wraps the most common functionality to communicate with the host Operating System, such as: clipboard, video mode, date and time, timers, environment variables, execution of binaries, command line, etc.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
There is nothing in `OS` about mouse grabbing or mouse cursors, that's in `Input`, so I'm cleaning up those references.