### PR TITLE
Adds ReferenceRect an option to be visible inside the game

### DIFF
--- a/doc/classes/ReferenceRect.xml
+++ b/doc/classes/ReferenceRect.xml
@@ -4,7 +4,7 @@
 		Reference frame for GUI.
 	</brief_description>
 	<description>
-		Reference frame for GUI. It's just like an empty control, except an outline border [member border_color] is displayed while editing around its size at all times.
+		A rectangle box that displays only a [member border_color] border color around its rectangle. [ReferenceRect] has no fill [Color].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -12,7 +12,10 @@
 	</methods>
 	<members>
 		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color">
-			Determines the border [Color] of the [ReferenceRect].
+			Sets the border [Color] of the [ReferenceRect].
+		</member>
+		<member name="editor_only" type="bool" setter="set_editor_only" getter="get_editor_only">
+			If set to [code]true[/code], the [ReferenceRect] will only be visible while in editor. Otherwise, [ReferenceRect] will be visible in game.
 		</member>
 	</members>
 	<constants>

--- a/scene/gui/reference_rect.cpp
+++ b/scene/gui/reference_rect.cpp
@@ -38,26 +38,41 @@ void ReferenceRect::_notification(int p_what) {
 
 		if (!is_inside_tree())
 			return;
-		if (Engine::get_singleton()->is_editor_hint())
+		if (Engine::get_singleton()->is_editor_hint() || !editor_only)
 			draw_rect(Rect2(Point2(), get_size()), border_color, false);
 	}
 }
 
-void ReferenceRect::set_border_color(const Color &color) {
-	border_color = color;
+void ReferenceRect::set_border_color(const Color &p_color) {
+	border_color = p_color;
+	update();
 }
 
 Color ReferenceRect::get_border_color() const {
 	return border_color;
 }
 
+void ReferenceRect::set_editor_only(const bool &p_enabled) {
+	editor_only = p_enabled;
+	update();
+}
+
+bool ReferenceRect::get_editor_only() const {
+	return editor_only;
+}
+
 void ReferenceRect::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_border_color"), &ReferenceRect::get_border_color);
 	ClassDB::bind_method(D_METHOD("set_border_color", "color"), &ReferenceRect::set_border_color);
 
+	ClassDB::bind_method(D_METHOD("get_editor_only"), &ReferenceRect::get_editor_only);
+	ClassDB::bind_method(D_METHOD("set_editor_only", "enabled"), &ReferenceRect::set_editor_only);
+
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "border_color"), "set_border_color", "get_border_color");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editor_only"), "set_editor_only", "get_editor_only");
 }
 
 ReferenceRect::ReferenceRect() {
 	border_color = Color(1, 0, 0);
+	editor_only = true;
 }

--- a/scene/gui/reference_rect.h
+++ b/scene/gui/reference_rect.h
@@ -37,6 +37,7 @@ class ReferenceRect : public Control {
 
 	GDCLASS(ReferenceRect, Control);
 	Color border_color;
+	bool editor_only;
 
 protected:
 	void _notification(int p_what);
@@ -45,8 +46,11 @@ protected:
 public:
 	ReferenceRect();
 
-	void set_border_color(const Color &color);
+	void set_border_color(const Color &p_color);
 	Color get_border_color() const;
+
+	void set_editor_only(const bool &p_enabled);
+	bool get_editor_only() const;
 };
 
 #endif // REFERENCE_RECT_H


### PR DESCRIPTION
ReferenceRect node by default was only displaying in the editor and not when the game is running.

**Issue description:**
ReferenceRect node is only displaying in the editor. When the game is running it is not.

**Expected Behavior**
ReferenceRect should also display when the game is running. In my case i wanted to display a rect border representing the window size because i have set the viewport background to transparent.

```
if (Engine::get_singleton()->is_editor_hint())
	draw_rect(Rect2(Point2(), get_size()), border_color, false);
}
```

~~I have fixed that by removing the editor check from the above code but i suspect this might be a breaking change for those that are actually expecting the ReferenceRect to be visible only in the editor (which i doubt since there was no proper documentation stating that AND also if that was the case, it should be named ReferenceNodeDebug or something).~~