### PR TITLE
doctool: Fix writing theme_item descriptions

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -521,12 +521,15 @@
 	</constants>
 	<theme_items>
 		<theme_item name="background_color" type="Color">
+			Sets the background [Color] of this [TextEdit]. [member syntax_highlighting] has to be enabled.
 		</theme_item>
 		<theme_item name="bookmark_color" type="Color">
+			Sets the [Color] of the bookmark marker. [member syntax_highlighting] has to be enabled.
 		</theme_item>
 		<theme_item name="brace_mismatch_color" type="Color">
 		</theme_item>
 		<theme_item name="breakpoint_color" type="Color">
+			Sets the [Color] of the breakpoints. [member breakpoint_gutter] has to be enabled.
 		</theme_item>
 		<theme_item name="caret_background_color" type="Color">
 		</theme_item>
@@ -553,6 +556,7 @@
 		<theme_item name="completion_selected_color" type="Color">
 		</theme_item>
 		<theme_item name="current_line_color" type="Color">
+			Sets the [Color] of the breakpoints. [member breakpoint_gutter] has to be enabled.
 		</theme_item>
 		<theme_item name="executing_line_color" type="Color">
 		</theme_item>
@@ -563,38 +567,48 @@
 		<theme_item name="folded" type="Texture">
 		</theme_item>
 		<theme_item name="font" type="Font">
+			Sets the default [Font].
 		</theme_item>
 		<theme_item name="font_color" type="Color">
+			Sets the font [Color].
 		</theme_item>
 		<theme_item name="font_color_selected" type="Color">
 		</theme_item>
 		<theme_item name="function_color" type="Color">
 		</theme_item>
 		<theme_item name="line_number_color" type="Color">
+			Sets the [Color] of the line numbers. [member show_line_numbers] has to be enabled.
 		</theme_item>
 		<theme_item name="line_spacing" type="int">
+			Sets the spacing between the lines.
 		</theme_item>
 		<theme_item name="mark_color" type="Color">
+			Sets the [Color] of marked text.
 		</theme_item>
 		<theme_item name="member_variable_color" type="Color">
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+			Sets the [StyleBox] of this [TextEdit].
 		</theme_item>
 		<theme_item name="number_color" type="Color">
 		</theme_item>
 		<theme_item name="read_only" type="StyleBox">
+			Sets the [StyleBox] of this [TextEdit] when [member readonly] is enabled.
 		</theme_item>
 		<theme_item name="safe_line_number_color" type="Color">
 		</theme_item>
 		<theme_item name="selection_color" type="Color">
+			Sets the highlight [Color] of text selections.
 		</theme_item>
 		<theme_item name="space" type="Texture">
 		</theme_item>
 		<theme_item name="symbol_color" type="Color">
 		</theme_item>
 		<theme_item name="tab" type="Texture">
+			Sets a custom [Texture] for tab text characters.
 		</theme_item>
 		<theme_item name="word_highlighted_color" type="Color">
+			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
 		</theme_item>
 	</theme_items>
 </class>

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -1126,6 +1126,7 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 
 				const PropertyDoc &p = c.theme_properties[i];
 				_write_string(f, 2, "<theme_item name=\"" + p.name + "\" type=\"" + p.type + "\">");
+				_write_string(f, 3, p.description.strip_edges().xml_escape());
 				_write_string(f, 2, "</theme_item>");
 			}
 			_write_string(f, 1, "</theme_items>");


### PR DESCRIPTION
We already had support for parsing and saving theme_item descriptions
in DocData, and displaying it in the editor, but doctool would drop the
changes as it was not writing them back to the XML.

Part of #29868.