### PR TITLE
Fix GridMap transform problems

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -279,7 +279,7 @@ void GridMapEditor::_update_cursor_transform() {
 	cursor_transform = Transform();
 	cursor_transform.origin = cursor_origin;
 	cursor_transform.basis.set_orthogonal_index(cursor_rot);
-	cursor_transform = node->get_transform() * cursor_transform;
+	cursor_transform = node->get_global_transform() * cursor_transform;
 
 	if (cursor_instance.is_valid()) {
 		VisualServer::get_singleton()->instance_set_transform(cursor_instance, cursor_transform);
@@ -420,7 +420,7 @@ bool GridMapEditor::do_input_action(Camera *p_camera, const Point2 &p_point, boo
 	}
 
 	last_mouseover = Vector3(cell[0], cell[1], cell[2]);
-	VS::get_singleton()->instance_set_transform(grid_instance[edit_axis], Transform(Basis(), grid_ofs));
+	VS::get_singleton()->instance_set_transform(grid_instance[edit_axis], node->get_global_transform() * edit_grid_xform);
 
 	if (cursor_instance.is_valid()) {
 


### PR DESCRIPTION
GridMap's preview cursor appeared in the wrong place when the parent's transform was modified.
The cursor's transform was being set with get_transform, but its get_global_transform that considers the parent's transform.
Fixes #2668

Also, the grid itself (orange lines in editor) would reset when the mouse moved in the editor area while a MeshLibrary item was selected.
Removing the line fixes the issue but I decided to change it instead, in case it has some other effect I couldn't see...
(I couldn't find an open issue for this one)