### PR TITLE
Better pre-selection of search result node in "Create New Node" dialog.

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -191,24 +191,36 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 		item->set_custom_color(0, get_color("disabled_font_color", "Editor"));
 		item->set_selectable(0, false);
 	} else if (!(*to_select && (*to_select)->get_text(0) == search_box->get_text())) {
-		bool is_search_subsequence = search_box->get_text().is_subsequence_ofi(p_type);
-		String to_select_type = *to_select ? (*to_select)->get_text(0) : "";
-		to_select_type = to_select_type.split(" ")[0];
-		bool current_item_is_preferred;
-		if (cpp_type) {
-			String cpp_to_select_type = to_select_type;
-			if (ScriptServer::is_global_class(to_select_type))
-				cpp_to_select_type = ScriptServer::get_global_class_native_base(to_select_type);
-			current_item_is_preferred = ClassDB::is_parent_class(p_type, preferred_search_result_type) && !ClassDB::is_parent_class(cpp_to_select_type, preferred_search_result_type);
-		} else {
-			current_item_is_preferred = ed.script_class_is_parent(p_type, preferred_search_result_type) && !ed.script_class_is_parent(to_select_type, preferred_search_result_type) && search_box->get_text() != to_select_type;
-		}
-		if (search_box->get_text() == p_type || (*to_select && p_type.length() < (*to_select)->get_text(0).length())) {
-			current_item_is_preferred = true;
+		bool current_type_prefered = _is_type_prefered(p_type);
+		bool selected_type_prefered = *to_select ? _is_type_prefered((*to_select)->get_text(0).split(" ")[0]) : false;
+
+		String search_term = search_box->get_text().to_lower();
+		bool is_subsequence_of_type = search_box->get_text().is_subsequence_ofi(p_type);
+		bool is_substring_of_type = p_type.to_lower().find(search_term) >= 0;
+		bool is_substring_of_selected = false;
+		bool is_subsequence_of_selected = false;
+		bool is_selected_equal = false;
+
+		if (*to_select) {
+			String name = (*to_select)->get_text(0).split(" ")[0].to_lower();
+			is_substring_of_selected = name.find(search_term) >= 0;
+			is_subsequence_of_selected = search_term.is_subsequence_of(name);
+			is_selected_equal = name == search_term;
 		}
 
-		if (((!*to_select || current_item_is_preferred) && is_search_subsequence)) {
-			*to_select = item;
+		if (is_subsequence_of_type && !is_selected_equal) {
+			if (is_substring_of_type) {
+				if (!is_substring_of_selected || (is_substring_of_selected && (current_type_prefered && !selected_type_prefered))) {
+					*to_select = item;
+				}
+			} else {
+				// substring results weigh more than subsequences, so let's make sure we don't override them
+				if (!is_substring_of_selected) {
+					if (!is_subsequence_of_selected || (is_subsequence_of_selected && (current_type_prefered && !selected_type_prefered))) {
+						*to_select = item;
+					}
+				}
+			}
 		}
 	}
 
@@ -230,6 +242,16 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 	item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, base_type));
 
 	p_types[p_type] = item;
+}
+
+bool CreateDialog::_is_type_prefered(const String &type) {
+	bool cpp_type = ClassDB::class_exists(type);
+	EditorData &ed = EditorNode::get_editor_data();
+
+	if (cpp_type) {
+		return ClassDB::is_parent_class(type, preferred_search_result_type);
+	}
+	return ed.script_class_is_parent(type, preferred_search_result_type);
 }
 
 bool CreateDialog::_is_class_disabled_by_feature_profile(const StringName &p_class) {
@@ -275,7 +297,6 @@ void CreateDialog::select_type(const String &p_type) {
 }
 
 void CreateDialog::_update_search() {
-
 	search_options->clear();
 	favorite->set_disabled(true);
 

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -90,6 +90,7 @@ class CreateDialog : public ConfirmationDialog {
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 	bool _is_class_disabled_by_feature_profile(const StringName &p_class);
+	bool _is_type_prefered(const String &type);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
I'm not sure what the reasoning behind the current implementation was, but i think this one is more intuative for the user. 
The suggested selection when searching for a node is now based on the prefix of a node. So for example if i search for "Nine" or "nine" the selection would be "NinePatchRect" rather than "Container" (like in current master).

Edit:
After some more thinking i'm not looking for prefixes now but i'm checking for both substrings and subsequences. The current implementation only searched for subsequences. I also value substrings higher than subsequences.

Fixes #26010