### PR TITLE
doc: Document EncodedObjectAsID, expose its property

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -37,13 +37,11 @@
 #include <limits.h>
 #include <stdio.h>
 
-#define _S(a) ((int32_t)a)
-#define ERR_FAIL_ADD_OF(a, b, err) ERR_FAIL_COND_V(_S(b) < 0 || _S(a) < 0 || _S(a) > INT_MAX - _S(b), err)
-#define ERR_FAIL_MUL_OF(a, b, err) ERR_FAIL_COND_V(_S(a) < 0 || _S(b) <= 0 || _S(a) > INT_MAX / _S(b), err)
-
 void EncodedObjectAsID::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_object_id", "id"), &EncodedObjectAsID::set_object_id);
 	ClassDB::bind_method(D_METHOD("get_object_id"), &EncodedObjectAsID::get_object_id);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "object_id"), "set_object_id", "get_object_id");
 }
 
 void EncodedObjectAsID::set_object_id(ObjectID p_id) {
@@ -58,6 +56,10 @@ ObjectID EncodedObjectAsID::get_object_id() const {
 EncodedObjectAsID::EncodedObjectAsID() :
 		id(0) {
 }
+
+#define _S(a) ((int32_t)a)
+#define ERR_FAIL_ADD_OF(a, b, err) ERR_FAIL_COND_V(_S(b) < 0 || _S(a) < 0 || _S(a) > INT_MAX - _S(b), err)
+#define ERR_FAIL_MUL_OF(a, b, err) ERR_FAIL_COND_V(_S(a) < 0 || _S(b) <= 0 || _S(a) > INT_MAX / _S(b), err)
 
 #define ENCODE_MASK 0xFF
 #define ENCODE_FLAG_64 1 << 16

--- a/doc/classes/EncodedObjectAsID.xml
+++ b/doc/classes/EncodedObjectAsID.xml
@@ -1,27 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EncodedObjectAsID" inherits="Reference" category="Core" version="3.2">
 	<brief_description>
+		Holds a reference to an [Object]'s instance ID.
 	</brief_description>
 	<description>
+		Utility class which holds a reference to the internal identifier of an [Object] instance, as given by [method Object.get_instance_id]. This ID can then be used to retrieve the object instance with [method @GDScript.instance_from_id].
+		This class is used internally by the editor inspector and script debugger, but can also be used in plugins to pass and display objects as their IDs.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_object_id" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="set_object_id">
-			<return type="void">
-			</return>
-			<argument index="0" name="id" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
 	</methods>
+	<members>
+		<member name="object_id" type="int" setter="set_object_id" getter="get_object_id">
+			The [Object] identifier stored in this [EncodedObjectAsID] instance. The object instance can be retrieved with [method @GDScript.instance_from_id].
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -203,6 +203,7 @@
 			</return>
 			<description>
 				Returns the object's unique instance ID.
+				This ID can be saved in [EncodedObjectAsID], and can be used to retrieve the object instance with [method @GDScript.instance_from_id].
 			</description>
 		</method>
 		<method name="get_meta" qualifiers="const">


### PR DESCRIPTION
@neikeq Is there any equivalent to GDScript's `instance_from_id` builtin in C#? I think it's weird to have this feature as a builtin, it would be better as an Object static method (but I think we still can't have static methods on non-singletons, right?).