### PR TITLE
Node: Fix logic of has/get_node_and_resource and document it

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -268,6 +268,14 @@
 			<argument index="0" name="path" type="NodePath">
 			</argument>
 			<description>
+				Fetches a node and one of its resources as specified by the [NodePath]'s subname (e.g. [code]Area2D/CollisionShape2D:shape[/code]). If several nested resources are specified in the [NodePath], the last one will be fetched.
+				The return value is an array of size 3: the first index points to the [Node] (or [code]null[/code] if not found), the second index points to the [Resource] (or [code]null[/code] if not found), and the third index is the remaining [NodePath], if any.
+				For example, assuming that [code]Area2D/CollisionShape2D[/code] is a valid node and that its [code]shape[/code] property has been assigned a [RectangleShape2D] resource, one could have this kind of output:
+				[codeblock]
+				print(get_node_and_resource("Area2D/CollisionShape2D")) # [[CollisionShape2D:1161], Null, ]
+				print(get_node_and_resource("Area2D/CollisionShape2D:shape")) # [[CollisionShape2D:1161], [RectangleShape2D:1156], ]
+				print(get_node_and_resource("Area2D/CollisionShape2D:shape:extents")) # [[CollisionShape2D:1161], [RectangleShape2D:1156], :extents]
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_node_or_null" qualifiers="const">
@@ -359,6 +367,7 @@
 			<argument index="0" name="path" type="NodePath">
 			</argument>
 			<description>
+				Returns [code]true[/code] if the [NodePath] points to a valid node and its subname points to a valid resource, e.g. [code]Area2D/CollisionShape2D:shape[/code]. Properties with a non-[Resource] type (e.g. nodes or primitive math types) are not considered resources.
 			</description>
 		</method>
 		<method name="is_a_parent_of" qualifiers="const">

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -4,9 +4,9 @@
 		Pre-parsed scene tree path.
 	</brief_description>
 	<description>
-		A pre-parsed relative or absolute path in a scene tree, for use with [method Node.get_node] and similar functions. It can reference a node, a resource within a node, or a property of a node or resource. For instance, [code]"Path2D/PathFollow2D/Sprite:texture:size"[/code] would refer to the size property of the texture resource on the node named "Sprite" which is a child of the other named nodes in the path. Note that if you want to get a resource, you must end the path with a colon, otherwise the last element will be used as a property name.
+		A pre-parsed relative or absolute path in a scene tree, for use with [method Node.get_node] and similar functions. It can reference a node, a resource within a node, or a property of a node or resource. For instance, [code]"Path2D/PathFollow2D/Sprite:texture:size"[/code] would refer to the [code]size[/code] property of the [code]texture[/code] resource on the node named [code]"Sprite"[/code] which is a child of the other named nodes in the path.
 		You will usually just pass a string to [method Node.get_node] and it will be automatically converted, but you may occasionally want to parse a path ahead of time with [NodePath] or the literal syntax [code]@"path"[/code]. Exporting a [NodePath] variable will give you a node selection widget in the properties panel of the editor, which can often be useful.
-		A [NodePath] is made up of a list of node names, a list of "subnode" (resource) names, and the name of a property in the final node or resource.
+		A [NodePath] is composed of a list of slash-separated node names (like a filesystem path) and an optional colon-separated list of "subnames" which can be resources or properties.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -18,18 +18,46 @@
 			</argument>
 			<description>
 				Create a NodePath from a string, e.g. "Path2D/PathFollow2D/Sprite:texture:size". A path is absolute if it starts with a slash. Absolute paths are only valid in the global scene tree, not within individual scenes. In a relative path, [code]"."[/code] and [code]".."[/code] indicate the current node and its parent.
+				The "subnames" optionally included after the path to the target node can point to resources or properties, and can also be nested.
+				Examples of valid NodePaths (assuming that those nodes exist and have the referenced resources or properties):
+				[codeblock]
+				# Points to the Sprite node
+				"Path2D/PathFollow2D/Sprite"
+				# Points to the Sprite node and its 'texture' resource.
+				# get_node() would retrieve "Sprite", while get_node_and_resource()
+				# would retrieve both the Sprite node and the 'texture' resource.
+				"Path2D/PathFollow2D/Sprite:texture"
+				# Points to the Sprite node and its 'position' property.
+				"Path2D/PathFollow2D/Sprite:position"
+				# Points to the Sprite node and the 'x' component of its 'position' property.
+				"Path2D/PathFollow2D/Sprite:position:x"
+				# Absolute path (from 'root')
+				"/root/Level/Path2D"
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_as_property_path">
 			<return type="NodePath">
 			</return>
 			<description>
+				Returns a node path with a colon character ([code]:[/code]) prepended, transforming it to a pure property path with no node name (defaults to resolving from the current node).
+				[codeblock]
+				# This will be parsed as a node path to the 'x' property in the 'position' node
+				var node_path = NodePath("position:x")
+				# This will be parsed as a node path to the 'x' component of the 'position' property in the current node
+				var property_path = node_path.get_as_property_path()
+				print(property_path) # :position:x
 			</description>
 		</method>
 		<method name="get_concatenated_subnames">
 			<return type="String">
 			</return>
 			<description>
+				Returns all subnames concatenated with a colon character ([code]:[/code]) as separator, i.e. the right side of the first colon in a node path.
+				[codeblock]
+				var nodepath = NodePath("Path2D/PathFollow2D/Sprite:texture:load_path")
+				print(nodepath.get_concatenated_subnames()) # texture:load_path
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_name">
@@ -38,14 +66,21 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Get the node name indicated by [code]idx[/code] (0 to [method get_name_count])
+				Get the node name indicated by [code]idx[/code] (0 to [method get_name_count]).
+				[codeblock]
+				var node_path = NodePath("Path2D/PathFollow2D/Sprite")
+				print(node_path.get_name(0)) # Path2D
+				print(node_path.get_name(1)) # PathFollow2D
+				print(node_path.get_name(2)) # Sprite
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_name_count">
 			<return type="int">
 			</return>
 			<description>
-				Get the number of node names which make up the path.
+				Get the number of node names which make up the path. Subnames (see [method get_subname_count]) are not included.
+				For example, [code]"Path2D/PathFollow2D/Sprite"[code] has 3 names.
 			</description>
 		</method>
 		<method name="get_subname">
@@ -54,21 +89,27 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Get the resource name indicated by [code]idx[/code] (0 to [method get_subname_count])
+				Get the resource or property name indicated by [code]idx[/code] (0 to [method get_subname_count]).
+				[codeblock]
+				var node_path = NodePath("Path2D/PathFollow2D/Sprite:texture:load_path")
+				print(node_path.get_subname(0)) # texture
+				print(node_path.get_subname(1)) # load_path
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_subname_count">
 			<return type="int">
 			</return>
 			<description>
-				Get the number of resource names in the path.
+				Get the number of resource or property names ("subnames") in the path. Each subname is listed after a colon character ([code]:[/code]) in the node path.
+				For example, [code]"Path2D/PathFollow2D/Sprite:texture:load_path"[/code] has 2 subnames.
 			</description>
 		</method>
 		<method name="is_absolute">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the node path is absolute (not relative).
+				Returns [code]true[/code] if the node path is absolute (as opposed to relative), which means that it starts with a slash character ([code]/[/code]). Absolute node paths can be used to access the root node ([code]"/root"[/code]) or autoloads (e.g. [code]"/global"[/code] if a "global" autoload was registered).
 			</description>
 		</method>
 		<method name="is_empty">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2477,21 +2477,18 @@ bool Node::has_node_and_resource(const NodePath &p_path) const {
 
 	if (!has_node(p_path))
 		return false;
-	Node *node = get_node(p_path);
+	RES res;
+	Vector<StringName> leftover_path;
+	Node *node = get_node_and_resource(p_path, res, leftover_path, false);
 
-	bool result = false;
-
-	node->get_indexed(p_path.get_subnames(), &result);
-
-	return result;
+	return (node && res.is_valid());
 }
 
 Array Node::_get_node_and_resource(const NodePath &p_path) {
 
-	Node *node;
 	RES res;
 	Vector<StringName> leftover_path;
-	node = get_node_and_resource(p_path, res, leftover_path);
+	Node *node = get_node_and_resource(p_path, res, leftover_path, false);
 	Array result;
 
 	if (node)
@@ -2521,7 +2518,7 @@ Node *Node::get_node_and_resource(const NodePath &p_path, RES &r_res, Vector<Str
 
 		int j = 0;
 		// If not p_last_is_property, we shouldn't consider the last one as part of the resource
-		for (; j < p_path.get_subname_count() - p_last_is_property; j++) {
+		for (; j < p_path.get_subname_count() - (int)p_last_is_property; j++) {
 			RES new_res = j == 0 ? node->get(p_path.get_subname(j)) : r_res->get(p_path.get_subname(j));
 
 			if (new_res.is_null()) {


### PR DESCRIPTION
Also document NodePath.

---

While attempting to document `Node.has/get_node_and_resource`, I found that its behavior is quite unintuitive, as the `has` method would basically always return `true` for a valid NodePath (even when not pointing to a valid resource), while the `get` method would only return the designated resource when using a trailing colon or accessing a property of that resource.

I did some extensive tests and I now have a behavior which seems to match what one would expect (and what I thus documented). It looks like the weird distinction between resource and property in NodePath has been mostly lifted by @bojidar-bg in 0cf9597758f3af3afc951d0bf02dee1aeb9a6daf, so I *think* this should work fine now.

I haven't tested complex animations extensively to make sure that they are still parsed as they should though.

### Test project

[Node-get_node_and_resource.zip](https://github.com/godotengine/godot/files/3330326/Node-get_node_and_resource.zip)

```gdscript
extends Node2D

export (Dictionary) var my_dict = { "key1": load("res://icon.png") }

# Called when the node enters the scene tree for the first time.
func _ready():
	
	# Invalid node
	print("WrongName")
	print(has_node_and_resource("WrongName"))
	print(get_node_and_resource("WrongName"))
	print("WrongName:size")
	print(has_node_and_resource("WrongName:size"))
	print(get_node_and_resource("WrongName:size"))
	
	# Non-resource in valid node
	print("Area2D:gravity_vec")
	print(has_node_and_resource("Area2D:gravity_vec"))
	print(get_node_and_resource("Area2D:gravity_vec"))
	print("Area2D:gravity_vec:y")
	print(has_node_and_resource("Area2D:gravity_vec:y"))
	print(get_node_and_resource("Area2D:gravity_vec:y"))
	
	# Valid resource in valid node
	print("Area2D/CollisionShape2D:shape")
	print(has_node_and_resource("Area2D/CollisionShape2D:shape"))
	print(get_node_and_resource("Area2D/CollisionShape2D:shape"))
	print("Area2D/CollisionShape2D:shape:extents")
	print(has_node_and_resource("Area2D/CollisionShape2D:shape:extents"))
	print(get_node_and_resource("Area2D/CollisionShape2D:shape:extents"))
	print("Area2D/CollisionShape2D:shape:extents:x")
	print(has_node_and_resource("Area2D/CollisionShape2D:shape:extents:x"))
	print(get_node_and_resource("Area2D/CollisionShape2D:shape:extents:x"))

	# Valid nested resource in other resource's custom script
	print("Area2D/CollisionShape2D:shape:my_texture")
	print(has_node_and_resource("Area2D/CollisionShape2D:shape:my_texture"))
	print(get_node_and_resource("Area2D/CollisionShape2D:shape:my_texture"))
	print("Area2D/CollisionShape2D:shape:my_texture:load_path")
	print(has_node_and_resource("Area2D/CollisionShape2D:shape:my_texture:load_path"))
	print(get_node_and_resource("Area2D/CollisionShape2D:shape:my_texture:load_path"))
	print("Area2D/CollisionShape2D:shape:my_texture:wrong_subname")
	print(has_node_and_resource("Area2D/CollisionShape2D:shape:my_texture:wrong_subname"))
	print(get_node_and_resource("Area2D/CollisionShape2D:shape:my_texture:wrong_subname"))
	
	# Dictionary with resource key (not supported)
	print(".:my_dict")
	print(has_node_and_resource(".:my_dict"))
	print(get_node_and_resource(".:my_dict"))
	print(".:my_dict.key1")
	print(has_node_and_resource(".:my_dict.key1"))
	print(get_node_and_resource(".:my_dict.key1"))
	
	# Property of Node type, doesn't count as resource (as expected)
	owner = get_tree().get_root()
	print(".:owner")
	print(has_node_and_resource(".:owner"))
	print(get_node_and_resource(".:owner"))
```

### Before this PR

```
WrongName
False
ERROR: get_node: Node not found: WrongName
   At: scene/main/node.cpp:1382.
[Null, Null, ]
WrongName:size
False
ERROR: get_node: Node not found: WrongName:size
   At: scene/main/node.cpp:1382.
[Null, Null, ]
Area2D:gravity_vec
True
[[Area2D:1134], Null, :gravity_vec]
Area2D:gravity_vec:y
True
[[Area2D:1134], Null, :gravity_vec:y]
Area2D/CollisionShape2D:shape
True
[[CollisionShape2D:1135], Null, :shape]
Area2D/CollisionShape2D:shape:extents
True
[[CollisionShape2D:1135], [RectangleShape2D:1127], :extents]
Area2D/CollisionShape2D:shape:extents:x
True
[[CollisionShape2D:1135], [RectangleShape2D:1127], :extents:x]
Area2D/CollisionShape2D:shape:my_texture
True
[[CollisionShape2D:1135], [RectangleShape2D:1127], :my_texture]
Area2D/CollisionShape2D:shape:my_texture:load_path
False
[[CollisionShape2D:1135], [RectangleShape2D:1127], :my_texture:load_path]
Area2D/CollisionShape2D:shape:my_texture:wrong_subname
False
[[CollisionShape2D:1135], [RectangleShape2D:1127], :my_texture:wrong_subname]
.:my_dict
True
[[Node2D:1130], Null, :my_dict]
.:my_dict.key1
True
[[Node2D:1130], Null, :my_dict.key1]
.:owner
True
[[Node2D:1130], Null, :owner]
```

### After this PR

```
WrongName
False
ERROR: get_node: Node not found: WrongName
   At: scene/main/node.cpp:1396.
[Null, Null, ]
WrongName:size
False
ERROR: get_node: Node not found: WrongName:size
   At: scene/main/node.cpp:1396.
[Null, Null, ]
Area2D:gravity_vec
False
[[Area2D:1160], Null, :gravity_vec]
Area2D:gravity_vec:y
False
[[Area2D:1160], Null, :gravity_vec:y]
Area2D/CollisionShape2D:shape
True
[[CollisionShape2D:1161], [RectangleShape2D:1156], ]
Area2D/CollisionShape2D:shape:extents
True
[[CollisionShape2D:1161], [RectangleShape2D:1156], :extents]
Area2D/CollisionShape2D:shape:extents:x
True
[[CollisionShape2D:1161], [RectangleShape2D:1156], :extents:x]
Area2D/CollisionShape2D:shape:my_texture
True
[[CollisionShape2D:1161], [RectangleShape2D:1156], :my_texture]
Area2D/CollisionShape2D:shape:my_texture:load_path
True
[[CollisionShape2D:1161], [RectangleShape2D:1156], :my_texture:load_path]
Area2D/CollisionShape2D:shape:my_texture:wrong_subname
True
[[CollisionShape2D:1161], [RectangleShape2D:1156], :my_texture:wrong_subname]
{key1:[StreamTexture:1152]}
.:my_dict
False
[[Node2D:1159], Null, :my_dict]
.:my_dict.key1
False
[[Node2D:1159], Null, :my_dict.key1]
.:owner
False
[[Node2D:1159], Null, :owner]
```
