### PR TITLE
Fixed parser treating compound assignment the same as assignment whic…

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -776,8 +776,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 								}
 								_add_warning(GDScriptWarning::UNASSIGNED_VARIABLE_OP_ASSIGN, -1, identifier.operator String());
 							}
-							FALLTHROUGH;
-						}
+						} break;
 						case GDScriptTokenizer::TK_OP_ASSIGN: {
 							lv->assignments += 1;
 							lv->usages--; // Assignment is not really usage


### PR DESCRIPTION
…h gave wrong argument usage count.
Fixes #26850.
Also, I don't know what exactly does `FALLTHROUGH;` do but I thought we should remove it?