### PR TITLE
Shows menu when dragging connection on empty space in visual shader

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -211,6 +211,17 @@
 				Signal sent to the GraphEdit when the connection between 'from_slot' slot of 'from' GraphNode and 'to_slot' slot of 'to' GraphNode is attempted to be created.
 			</description>
 		</signal>
+		<signal name="connection_from_empty">
+			<argument index="0" name="to" type="String">
+			</argument>
+			<argument index="1" name="to_slot" type="int">
+			</argument>
+			<argument index="2" name="release_position" type="Vector2">
+			</argument>
+			<description>
+				Signal sent when user dragging connection from input port into empty space of the graph.
+			</description>
+		</signal>
 		<signal name="connection_to_empty">
 			<argument index="0" name="from" type="String">
 			</argument>
@@ -219,6 +230,7 @@
 			<argument index="2" name="release_position" type="Vector2">
 			</argument>
 			<description>
+				Signal sent when user dragging connection from output port into empty space of the graph.
 			</description>
 		</signal>
 		<signal name="delete_nodes_request">

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -160,7 +160,13 @@ class VisualShaderEditor : public VBoxContainer {
 	void _edit_port_default_input(Object *p_button, int p_node, int p_port);
 	void _port_edited();
 
+	int to_node;
+	int to_slot;
+	int from_node;
+	int from_slot;
+
 	void _connection_to_empty(const String &p_from, int p_from_slot, const Vector2 &p_release_position);
+	void _connection_from_empty(const String &p_to, int p_to_slot, const Vector2 &p_release_position);
 
 	void _line_edit_changed(const String &p_text, Object *line_edit, int p_node_id);
 	void _line_edit_focus_out(Object *line_edit, int p_node_id);
@@ -199,6 +205,7 @@ class VisualShaderEditor : public VBoxContainer {
 	void _member_selected();
 	void _member_unselected();
 	void _member_create();
+	void _member_cancel();
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -479,7 +479,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 					connecting_color = gn->get_connection_input_color(j);
 					connecting_target = false;
 					connecting_to = pos;
-					just_disconnected = true;
+					just_disconnected = false;
 
 					return;
 				}
@@ -550,11 +550,18 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 			emit_signal("connection_request", from, from_slot, to, to_slot);
 
 		} else if (!just_disconnected) {
+
 			String from = connecting_from;
 			int from_slot = connecting_index;
 			Vector2 ofs = Vector2(mb->get_position().x, mb->get_position().y);
-			emit_signal("connection_to_empty", from, from_slot, ofs);
+
+			if (!connecting_out) {
+				emit_signal("connection_from_empty", from, from_slot, ofs);
+			} else {
+				emit_signal("connection_to_empty", from, from_slot, ofs);
+			}
 		}
+
 		connecting = false;
 		top_layer->update();
 		update();
@@ -1292,6 +1299,7 @@ void GraphEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("duplicate_nodes_request"));
 	ADD_SIGNAL(MethodInfo("node_selected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("connection_to_empty", PropertyInfo(Variant::STRING, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
+	ADD_SIGNAL(MethodInfo("connection_from_empty", PropertyInfo(Variant::STRING, "to"), PropertyInfo(Variant::INT, "to_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("delete_nodes_request"));
 	ADD_SIGNAL(MethodInfo("_begin_node_move"));
 	ADD_SIGNAL(MethodInfo("_end_node_move"));

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -257,7 +257,7 @@ bool VisualShader::can_connect_nodes(Type p_type, int p_from_node, int p_from_po
 	VisualShaderNode::PortType from_port_type = g->nodes[p_from_node].node->get_output_port_type(p_from_port);
 	VisualShaderNode::PortType to_port_type = g->nodes[p_to_node].node->get_input_port_type(p_to_port);
 
-	if (MAX(0, from_port_type - 2) != (MAX(0, to_port_type - 2))) {
+	if (!is_port_types_compatible(from_port_type, to_port_type)) {
 		return false;
 	}
 
@@ -269,6 +269,10 @@ bool VisualShader::can_connect_nodes(Type p_type, int p_from_node, int p_from_po
 	}
 
 	return true;
+}
+
+bool VisualShader::is_port_types_compatible(int p_a, int p_b) const {
+	return MAX(0, p_a - 2) == (MAX(0, p_b - 2));
 }
 
 void VisualShader::connect_nodes_forced(Type p_type, int p_from_node, int p_from_port, int p_to_node, int p_to_port) {
@@ -295,8 +299,8 @@ Error VisualShader::connect_nodes(Type p_type, int p_from_node, int p_from_port,
 	VisualShaderNode::PortType from_port_type = g->nodes[p_from_node].node->get_output_port_type(p_from_port);
 	VisualShaderNode::PortType to_port_type = g->nodes[p_to_node].node->get_input_port_type(p_to_port);
 
-	if (MAX(0, from_port_type - 2) != (MAX(0, to_port_type - 2))) {
-		ERR_EXPLAIN("Incompatible port types (scalar/vec/bool with transform");
+	if (!is_port_types_compatible(from_port_type, to_port_type)) {
+		ERR_EXPLAIN("Incompatible port types (scalar/vec/bool) with transform");
 		ERR_FAIL_V(ERR_INVALID_PARAMETER);
 		return ERR_INVALID_PARAMETER;
 	}

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -138,6 +138,7 @@ public:
 	Error connect_nodes(Type p_type, int p_from_node, int p_from_port, int p_to_node, int p_to_port);
 	void disconnect_nodes(Type p_type, int p_from_node, int p_from_port, int p_to_node, int p_to_port);
 	void connect_nodes_forced(Type p_type, int p_from_node, int p_from_port, int p_to_node, int p_to_port);
+	bool is_port_types_compatible(int p_a, int p_b) const;
 
 	void rebuild();
 	void get_node_connections(Type p_type, List<Connection> *r_connections) const;


### PR DESCRIPTION
Showing the member menu (and connect to first port after accept) when dragging connection from input/output ports seems like a good idea (and often requested)

![ct](https://user-images.githubusercontent.com/3036176/60245019-58a91a00-98c4-11e9-8c06-b45b09d804a5.gif)

This PR changes GraphEdit a bit by adding new signal and allow to call it when user dragging connection from input ports

Fix #30085 in Godot 3.2
