### PR TITLE
Free server id pools directly on closing

### DIFF
--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -50,7 +50,7 @@
 	}                                                                                      \
 	void m_type##_free_cached_ids() {                                                      \
 		while (m_type##_id_pool.size()) {                                                  \
-			free(m_type##_id_pool.front()->get());                                         \
+			server_name->free(m_type##_id_pool.front()->get());                            \
 			m_type##_id_pool.pop_front();                                                  \
 		}                                                                                  \
 	}                                                                                      \


### PR DESCRIPTION
When closing the game, we flush the command queue, but after we are pushing the freeing calls of the id pools to the command queue and they are never being run. Now we free them directly.

@qarmin can you check if it closes #29233 ?