### PR TITLE
Use DEBUG_ENABLED flag for Objective-C code

### DIFF
--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -53,9 +53,10 @@ def configure(env):
 
         if env["target"] == "release_debug":
             env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
+            env.Append(CCFLAGS=['-DDEBUG_ENABLED'])
 
     elif (env["target"] == "debug"):
-        env.Append(CCFLAGS=['-gdwarf-2', '-O0'])
+        env.Append(CCFLAGS=['-gdwarf-2', '-O0', '-DDEBUG_ENABLED'])
         env.Append(CPPFLAGS=['-D_DEBUG', '-DDEBUG=1', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
 
     if (env["use_lto"]):


### PR DESCRIPTION
I already saw using `#ifdef DEBUG_ENABLED` in some Objective-C code, but it seems not working without this patch.