### PR TITLE
Add a GitHub "❤️ Sponsor" button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+patreon: godotengine
+custom: https://www.paypal.com/donate/?token=v-mEfr__g1BbOiStnJsgwRib_I8jVSMD_064iu7NizC0Uvm9fSiPYOs-v1VQz9HFK1K8YG


### PR DESCRIPTION
This adds a "Sponsor" button on the Godot GitHub page next to the "Watch" button on the buttons strip.

<img width="219" alt="Screenshot 2019-06-27 at 15 12 08" src="https://user-images.githubusercontent.com/879967/60269100-18f72800-98ee-11e9-9d0e-cacc07911520.png">

Clicking this button will open a popup that has links to the projects Patreon and PayPal accounts. (If there is a shorter PayPal address, please let me know!)

<img width="577" alt="Screenshot 2019-06-27 at 15 13 41" src="https://user-images.githubusercontent.com/879967/60269141-2d3b2500-98ee-11e9-9ffb-e466c1dbe61f.png">

Enabling this functionality also requires [ticking off the "Sponsorships" checkbox in the respository settings](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository).

<img src="https://help.github.com/assets/images/help/sponsors/sponsor-set-up-button.png">