### PR TITLE
DocData: Re-expose parametric setters and getters

### DIFF
--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -7,6 +7,42 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_input_caption" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="input" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="is_input_set_as_auto_advance" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="input" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_input_as_auto_advance">
+			<return type="void">
+			</return>
+			<argument index="0" name="input" type="int">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_input_caption">
+			<return type="void">
+			</return>
+			<argument index="0" name="input" type="int">
+			</argument>
+			<argument index="1" name="caption" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="input_0/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">

--- a/doc/classes/AudioEffectChorus.xml
+++ b/doc/classes/AudioEffectChorus.xml
@@ -9,6 +9,114 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_voice_cutoff_hz" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_voice_delay_ms" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_voice_depth_ms" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_voice_level_db" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_voice_pan" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_voice_rate_hz" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_voice_cutoff_hz">
+			<return type="void">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<argument index="1" name="cutoff_hz" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_voice_delay_ms">
+			<return type="void">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<argument index="1" name="delay_ms" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_voice_depth_ms">
+			<return type="void">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<argument index="1" name="depth_ms" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_voice_level_db">
+			<return type="void">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<argument index="1" name="level_db" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_voice_pan">
+			<return type="void">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<argument index="1" name="pan" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_voice_rate_hz">
+			<return type="void">
+			</return>
+			<argument index="0" name="voice_idx" type="int">
+			</argument>
+			<argument index="1" name="rate_hz" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="dry" type="float" setter="set_dry" getter="get_dry" default="1.0">

--- a/doc/classes/CPUParticles.xml
+++ b/doc/classes/CPUParticles.xml
@@ -19,11 +19,83 @@
 				Sets this node's properties to match a given [Particles] node with an assigned [ParticlesMaterial].
 			</description>
 		</method>
+		<method name="get_param" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles.Parameter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param_curve" qualifiers="const">
+			<return type="Curve">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles.Parameter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param_randomness" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles.Parameter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_particle_flag" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="CPUParticles.Flags">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="restart">
 			<return type="void">
 			</return>
 			<description>
 				Restarts the particle emitter.
+			</description>
+		</method>
+		<method name="set_param">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles.Parameter">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param_curve">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles.Parameter">
+			</argument>
+			<argument index="1" name="curve" type="Curve">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param_randomness">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles.Parameter">
+			</argument>
+			<argument index="1" name="randomness" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_particle_flag">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="CPUParticles.Flags">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -20,11 +20,83 @@
 				Sets this node's properties to match a given [Particles2D] node with an assigned [ParticlesMaterial].
 			</description>
 		</method>
+		<method name="get_param" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param_curve" qualifiers="const">
+			<return type="Curve">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param_randomness" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_particle_flag" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="CPUParticles2D.Flags">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="restart">
 			<return type="void">
 			</return>
 			<description>
 				Restarts the particle emitter.
+			</description>
+		</method>
+		<method name="set_param">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param_curve">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter">
+			</argument>
+			<argument index="1" name="curve" type="Curve">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param_randomness">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter">
+			</argument>
+			<argument index="1" name="randomness" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_particle_flag">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="CPUParticles2D.Flags">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -45,6 +45,22 @@
 				Returns the location of the [Camera2D]'s screen-center, relative to the origin.
 			</description>
 		</method>
+		<method name="get_drag_margin" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_limit" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="make_current">
 			<return type="void">
 			</return>
@@ -58,6 +74,26 @@
 			<description>
 				Sets the camera's position immediately to its current smoothing destination.
 				This has no effect if smoothing is disabled.
+			</description>
+		</method>
+		<method name="set_drag_margin">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="drag_margin" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_limit">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="limit" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ConeTwistJoint.xml
+++ b/doc/classes/ConeTwistJoint.xml
@@ -11,6 +11,24 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_param" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="ConeTwistJoint.Param">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="ConeTwistJoint.Param">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="bias" type="float" setter="set_param" getter="get_param" default="0.3">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -173,6 +173,14 @@
 				The methods [method can_drop_data] and [method drop_data] must be implemented on controls that want to receive drop data.
 			</description>
 		</method>
+		<method name="get_anchor" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_begin" qualifiers="const">
 			<return type="Vector2">
 			</return>
@@ -240,6 +248,14 @@
 				Returns [member margin_right] and [member margin_bottom].
 			</description>
 		</method>
+		<method name="get_focus_neighbour" qualifiers="const">
+			<return type="NodePath">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_focus_owner" qualifiers="const">
 			<return type="Control">
 			</return>
@@ -270,6 +286,14 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_margin" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
 			</argument>
 			<description>
 			</description>
@@ -574,12 +598,32 @@
 				Sets [member margin_right] and [member margin_bottom] at the same time.
 			</description>
 		</method>
+		<method name="set_focus_neighbour">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="neighbour" type="NodePath">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_global_position">
 			<return type="void">
 			</return>
 			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="keep_margins" type="bool" default="false">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_margin">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="offset" type="float">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/DynamicFont.xml
+++ b/doc/classes/DynamicFont.xml
@@ -40,6 +40,14 @@
 				Returns the number of fallback fonts.
 			</description>
 		</method>
+		<method name="get_spacing" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="type" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="remove_fallback">
 			<return type="void">
 			</return>
@@ -58,6 +66,16 @@
 			</argument>
 			<description>
 				Sets the fallback font at index [code]idx[/code].
+			</description>
+		</method>
+		<method name="set_spacing">
+			<return type="void">
+			</return>
+			<argument index="0" name="type" type="int">
+			</argument>
+			<argument index="1" name="value" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -15,6 +15,24 @@
 		<link>https://docs.godotengine.org/en/latest/tutorials/3d/high_dynamic_range.html</link>
 	</tutorials>
 	<methods>
+		<method name="is_glow_level_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_glow_level">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="adjustment_brightness" type="float" setter="set_adjustment_brightness" getter="get_adjustment_brightness" default="1.0">

--- a/doc/classes/Generic6DOFJoint.xml
+++ b/doc/classes/Generic6DOFJoint.xml
@@ -9,6 +9,114 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_flag_x" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_flag_y" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_flag_z" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param_x" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param_y" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param_z" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_flag_x">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag">
+			</argument>
+			<argument index="1" name="value" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_flag_y">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag">
+			</argument>
+			<argument index="1" name="value" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_flag_z">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag">
+			</argument>
+			<argument index="1" name="value" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param_x">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param_y">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param_z">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="angular_limit_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="1.0">

--- a/doc/classes/GeometryInstance.xml
+++ b/doc/classes/GeometryInstance.xml
@@ -9,6 +9,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_flag" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="GeometryInstance.Flags">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_custom_aabb">
 			<return type="void">
 			</return>
@@ -16,6 +24,16 @@
 			</argument>
 			<description>
 				Overrides the bounding box of this node with a custom one. To remove it, set an [AABB] with all fields set to zero.
+			</description>
+		</method>
+		<method name="set_flag">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="GeometryInstance.Flags">
+			</argument>
+			<argument index="1" name="value" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/HingeJoint.xml
+++ b/doc/classes/HingeJoint.xml
@@ -9,6 +9,42 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_flag" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="HingeJoint.Flag">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="HingeJoint.Param">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_flag">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="HingeJoint.Flag">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="HingeJoint.Param">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="angular_limit/bias" type="float" setter="set_param" getter="get_param" default="0.3">

--- a/doc/classes/KinematicBody.xml
+++ b/doc/classes/KinematicBody.xml
@@ -12,6 +12,14 @@
 		<link>https://docs.godotengine.org/en/latest/tutorials/physics/kinematic_character_2d.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_axis_lock" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="axis" type="int" enum="PhysicsServer.BodyAxis">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_floor_velocity" qualifiers="const">
 			<return type="Vector3">
 			</return>
@@ -118,6 +126,16 @@
 			<description>
 				Moves the body while keeping it attached to slopes. Similar to [method move_and_slide].
 				As long as the [code]snap[/code] vector is in contact with the ground, the body will remain attached to the surface. This means you must disable snap in order to jump, for example. You can do this by setting[code]snap[/code] to[code](0, 0, 0)[/code] or by using [method move_and_slide] instead.
+			</description>
+		</method>
+		<method name="set_axis_lock">
+			<return type="void">
+			</return>
+			<argument index="0" name="axis" type="int" enum="PhysicsServer.BodyAxis">
+			</argument>
+			<argument index="1" name="lock" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="test_move">

--- a/doc/classes/Light.xml
+++ b/doc/classes/Light.xml
@@ -10,6 +10,24 @@
 		<link>https://docs.godotengine.org/en/latest/tutorials/3d/lights_and_shadows.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_param" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="Light.Param">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="Light.Param">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="editor_only" type="bool" setter="set_editor_only" getter="is_editor_only" default="false">

--- a/doc/classes/NinePatchRect.xml
+++ b/doc/classes/NinePatchRect.xml
@@ -9,6 +9,24 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_patch_margin" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_patch_margin">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="value" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="axis_stretch_horizontal" type="int" setter="set_h_axis_stretch_mode" getter="get_h_axis_stretch_mode" enum="NinePatchRect.AxisStretchMode" default="0">

--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -18,11 +18,29 @@
 				Returns the axis-aligned bounding box that contains all the particles that are active in the current frame.
 			</description>
 		</method>
+		<method name="get_draw_pass_mesh" qualifiers="const">
+			<return type="Mesh">
+			</return>
+			<argument index="0" name="pass" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="restart">
 			<return type="void">
 			</return>
 			<description>
 				Restarts the particle emission, clearing existing particles.
+			</description>
+		</method>
+		<method name="set_draw_pass_mesh">
+			<return type="void">
+			</return>
+			<argument index="0" name="pass" type="int">
+			</argument>
+			<argument index="1" name="mesh" type="Mesh">
+			</argument>
+			<description>
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -11,6 +11,78 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_flag" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="ParticlesMaterial.Flags">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param_randomness" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_param_texture" qualifiers="const">
+			<return type="Texture">
+			</return>
+			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_flag">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="ParticlesMaterial.Flags">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param_randomness">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter">
+			</argument>
+			<argument index="1" name="randomness" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param_texture">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter">
+			</argument>
+			<argument index="1" name="texture" type="Texture">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="angle" type="float" setter="set_param" getter="get_param" default="0.0">

--- a/doc/classes/PinJoint.xml
+++ b/doc/classes/PinJoint.xml
@@ -9,6 +9,24 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_param" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="PinJoint.Param">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="PinJoint.Param">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="params/bias" type="float" setter="set_param" getter="get_param" default="0.3">

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -82,12 +82,30 @@
 				Applies a torque impulse which will be affected by the body mass and shape. This will rotate the body around the [code]impulse[/code] vector passed.
 			</description>
 		</method>
+		<method name="get_axis_lock" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="axis" type="int" enum="PhysicsServer.BodyAxis">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_colliding_bodies" qualifiers="const">
 			<return type="Array">
 			</return>
 			<description>
 				Returns a list of the bodies colliding with this one. By default, number of max contacts reported is at 0, see the [member contacts_reported] property to increase it.
 				[b]Note:[/b] The result of this test is not immediate after moving objects. For performance, list of collisions is updated once per frame and before the physics step. Consider using signals instead.
+			</description>
+		</method>
+		<method name="set_axis_lock">
+			<return type="void">
+			</return>
+			<argument index="0" name="axis" type="int" enum="PhysicsServer.BodyAxis">
+			</argument>
+			<argument index="1" name="lock" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_axis_velocity">

--- a/doc/classes/SliderJoint.xml
+++ b/doc/classes/SliderJoint.xml
@@ -9,6 +9,24 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_param" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="param" type="int" enum="SliderJoint.Param">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_param">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="SliderJoint.Param">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="angular_limit/damping" type="float" setter="set_param" getter="get_param" default="0.0">

--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -10,6 +10,60 @@
 		<link>https://docs.godotengine.org/en/latest/tutorials/3d/spatial_material.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_feature" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="feature" type="int" enum="SpatialMaterial.Feature">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_flag" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="SpatialMaterial.Flags">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_texture" qualifiers="const">
+			<return type="Texture">
+			</return>
+			<argument index="0" name="param" type="int" enum="SpatialMaterial.TextureParam">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_feature">
+			<return type="void">
+			</return>
+			<argument index="0" name="feature" type="int" enum="SpatialMaterial.Feature">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_flag">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="SpatialMaterial.Flags">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_texture">
+			<return type="void">
+			</return>
+			<argument index="0" name="param" type="int" enum="SpatialMaterial.TextureParam">
+			</argument>
+			<argument index="1" name="texture" type="Texture">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="albedo_color" type="Color" setter="set_albedo" getter="get_albedo" default="Color( 1, 1, 1, 1 )">

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -15,9 +15,27 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_draw_flag" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="flag" type="int" enum="SpriteBase3D.DrawFlags">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_item_rect" qualifiers="const">
 			<return type="Rect2">
 			</return>
+			<description>
+			</description>
+		</method>
+		<method name="set_draw_flag">
+			<return type="void">
+			</return>
+			<argument index="0" name="flag" type="int" enum="SpriteBase3D.DrawFlags">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
 			<description>
 			</description>
 		</method>

--- a/doc/classes/StreamTexture.xml
+++ b/doc/classes/StreamTexture.xml
@@ -9,6 +9,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="load">
+			<return type="int" enum="Error">
+			</return>
+			<argument index="0" name="path" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="load_path" type="String" setter="load" getter="get_load_path" default="&quot;&quot;">

--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -31,6 +31,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_default_margin" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_margin" qualifiers="const">
 			<return type="float">
 			</return>
@@ -53,6 +61,16 @@
 			</return>
 			<description>
 				Returns the "offset" of a stylebox. This helper function returns a value equivalent to [code]Vector2(style.get_margin(MARGIN_LEFT), style.get_margin(MARGIN_TOP))[/code].
+			</description>
+		</method>
+		<method name="set_default_margin">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="offset" type="float">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="test_mask" qualifiers="const">

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -24,9 +24,43 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_border_width" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_border_width_min" qualifiers="const">
 			<return type="int">
 			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_corner_radius" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="corner" type="int" enum="Corner">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_expand_margin" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_border_width">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="width" type="int">
+			</argument>
 			<description>
 			</description>
 		</method>
@@ -34,6 +68,16 @@
 			<return type="void">
 			</return>
 			<argument index="0" name="width" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_corner_radius">
+			<return type="void">
+			</return>
+			<argument index="0" name="corner" type="int" enum="Corner">
+			</argument>
+			<argument index="1" name="radius" type="int">
 			</argument>
 			<description>
 			</description>
@@ -56,6 +100,16 @@
 			<argument index="2" name="radius_bottom_right" type="int">
 			</argument>
 			<argument index="3" name="radius_bottom_left" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_expand_margin">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="size" type="float">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -9,6 +9,22 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_expand_margin_size" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_margin_size" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_expand_margin_all">
 			<return type="void">
 			</return>
@@ -27,6 +43,26 @@
 			<argument index="2" name="size_right" type="float">
 			</argument>
 			<argument index="3" name="size_bottom" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_expand_margin_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="size" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_margin_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="size" type="float">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/TextureProgress.xml
+++ b/doc/classes/TextureProgress.xml
@@ -9,6 +9,24 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_stretch_margin" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_stretch_margin">
+			<return type="void">
+			</return>
+			<argument index="0" name="margin" type="int" enum="Margin">
+			</argument>
+			<argument index="1" name="value" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="fill_mode" type="int" setter="set_fill_mode" getter="get_fill_mode" default="0">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -67,6 +67,14 @@
 				Returns information about the viewport from the rendering pipeline.
 			</description>
 		</method>
+		<method name="get_shadow_atlas_quadrant_subdiv" qualifiers="const">
+			<return type="int" enum="Viewport.ShadowAtlasQuadrantSubdiv">
+			</return>
+			<argument index="0" name="quadrant" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_size_override" qualifiers="const">
 			<return type="Vector2">
 			</return>
@@ -159,6 +167,16 @@
 		<method name="set_input_as_handled">
 			<return type="void">
 			</return>
+			<description>
+			</description>
+		</method>
+		<method name="set_shadow_atlas_quadrant_subdiv">
+			<return type="void">
+			</return>
+			<argument index="0" name="quadrant" type="int">
+			</argument>
+			<argument index="1" name="subdiv" type="int" enum="Viewport.ShadowAtlasQuadrantSubdiv">
+			</argument>
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VisibilityEnabler.xml
+++ b/doc/classes/VisibilityEnabler.xml
@@ -9,6 +9,24 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="is_enabler_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="enabler" type="int" enum="VisibilityEnabler.Enabler">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_enabler">
+			<return type="void">
+			</return>
+			<argument index="0" name="enabler" type="int" enum="VisibilityEnabler.Enabler">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="freeze_bodies" type="bool" setter="set_enabler" getter="is_enabler_enabled" default="true">

--- a/doc/classes/VisibilityEnabler2D.xml
+++ b/doc/classes/VisibilityEnabler2D.xml
@@ -9,6 +9,24 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="is_enabler_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="enabler" type="int" enum="VisibilityEnabler2D.Enabler">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_enabler">
+			<return type="void">
+			</return>
+			<argument index="0" name="enabler" type="int" enum="VisibilityEnabler2D.Enabler">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="freeze_bodies" type="bool" setter="set_enabler" getter="is_enabler_enabled" default="true">

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -323,8 +323,14 @@ void DocData::generate(bool p_basic_types) {
 			if (E->get().name == "" || (E->get().name[0] == '_' && !(E->get().flags & METHOD_FLAG_VIRTUAL)))
 				continue; //hidden, don't count
 
-			if (skip_setter_getter_methods && setters_getters.has(E->get().name) && E->get().name.find("/") == -1)
-				continue;
+			if (skip_setter_getter_methods && setters_getters.has(E->get().name)) {
+				// Don't skip parametric setters and getters, i.e. method which require
+				// one or more parameters to define what property should be set or retrieved.
+				// E.g. CPUParticles::set_param(Parameter param, float value).
+				if (E->get().arguments.size() == 0 /* getter */ || (E->get().arguments.size() == 1 && E->get().return_val.type == Variant::NIL /* setter */)) {
+					continue;
+				}
+			}
 
 			MethodDoc method;
 
@@ -366,21 +372,6 @@ void DocData::generate(bool p_basic_types) {
 
 					method.arguments.push_back(argument);
 				}
-
-				/*
-				String hint;
-				switch(arginfo.hint) {
-					case PROPERTY_HINT_DIR: hint="A directory."; break;
-					case PROPERTY_HINT_RANGE: hint="Range - min: "+arginfo.hint_string.get_slice(",",0)+" max: "+arginfo.hint_string.get_slice(",",1)+" step: "+arginfo.hint_string.get_slice(",",2); break;
-					case PROPERTY_HINT_ENUM: hint="Values: "; for(int j=0;j<arginfo.hint_string.get_slice_count(",");j++) { if (j>0) hint+=", "; hint+=arginfo.hint_string.get_slice(",",j)+"="+itos(j); } break;
-					case PROPERTY_HINT_LENGTH: hint="Length: "+arginfo.hint_string; break;
-					case PROPERTY_HINT_FLAGS: hint="Values: "; for(int j=0;j<arginfo.hint_string.get_slice_count(",");j++) { if (j>0) hint+=", "; hint+=arginfo.hint_string.get_slice(",",j)+"="+itos(1<<j); } break;
-					case PROPERTY_HINT_FILE: hint="A file:"; break;
-					//case PROPERTY_HINT_RESOURCE_TYPE: hint="Type: "+arginfo.hint_string; break;
-				};
-				if (hint!="")
-					_write_string(f,4,hint);
-*/
 			}
 
 			c.methods.push_back(method);


### PR DESCRIPTION
Setters and getters have been hidden from the documentation when the matching
properties have been exposed, but some of them are parametric and require the
name or index of a given parameter to be used. So they need to be properly
documented with the type and name of the arguments they take.

For example, CPUParticles' `set_param(Parameter param, float value)`.

---

WDYT @godotengine/documentation? I don't like giving us more stuff to document, but it seems to me that those setters and getters need to be documented properly, as they encompass several properties depending on the parameter used when calling them.