### PR TITLE
Adds automatic update for StyleBoxTexture > region_rect

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -875,7 +875,7 @@ void TextureRegionEditor::_changed_callback(Object *p_changed, const char *p_pro
 	if (!is_visible()) {
 		return;
 	}
-	if (p_prop == StringName("atlas") || p_prop == StringName("texture")) {
+	if (p_prop == StringName("atlas") || p_prop == StringName("texture") || p_prop == StringName("region")) {
 		_edit_region();
 	}
 }

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -245,6 +245,7 @@ void StyleBoxTexture::set_region_rect(const Rect2 &p_region_rect) {
 
 	region_rect = p_region_rect;
 	emit_changed();
+	_change_notify("region");
 }
 
 Rect2 StyleBoxTexture::get_region_rect() const {


### PR DESCRIPTION
Small fix for a `StyleBoxTexture`, when its `region_rect` was changed, the change was not automatically updated in the texture editor until you clicked on it.

I believe this closes #29035