### PR TITLE
Updated default ctor of Color() and conversion to Color().

### DIFF
--- a/core/color.h
+++ b/core/color.h
@@ -201,12 +201,12 @@ struct Color {
 	operator String() const;
 
 	/**
-	 * No construct parameters, r=0, g=0, b=0. a=255
+	 * No construct parameters, r=255, g=255, b=255, a=255
 	 */
 	_FORCE_INLINE_ Color() {
-		r = 0;
-		g = 0;
-		b = 0;
+		r = 1.0;
+		g = 1.0;
+		b = 1.0;
 		a = 1.0;
 	}
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1209,7 +1209,18 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 				return (Transform(p_args[0]->operator Transform()));
 
 			// misc types
-			case COLOR: return p_args[0]->type == Variant::STRING ? Color::html(*p_args[0]) : Color::hex(*p_args[0]);
+			case COLOR:
+				switch (p_args[0]->type) {
+					case STRING: {
+						return Color::html(*p_args[0]);
+					}
+					case INT: {
+						return Color::hex(*p_args[0]);
+					}
+					default: {
+						return Color();
+					}
+				}
 			case NODE_PATH:
 				return (NodePath(p_args[0]->operator NodePath())); // 15
 			case _RID: return (RID(*p_args[0]));


### PR DESCRIPTION
Fixes #28490

1. Changed the default constructor of Color()
2. Conversion from * to Color() now returns the default Color except from Variant::STRING or Variant::INT

I think I deleted/closed the old PR..cant recover it.