### PR TITLE
Fix some bugs inside ColorPicker

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -173,7 +173,7 @@ void ColorPicker::_value_changed(double) {
 		color.set_hsv(scroll[0]->get_value() / 360.0,
 				scroll[1]->get_value() / 100.0,
 				scroll[2]->get_value() / 100.0,
-				scroll[3]->get_value() / 100.0);
+				scroll[3]->get_value() / 255.0);
 	} else {
 		for (int i = 0; i < 4; i++) {
 			color.components[i] = scroll[i]->get_value() / (raw_mode_enabled ? 1.0 : 255.0);
@@ -209,17 +209,17 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 
 		if (hsv_mode_enabled) {
 			for (int i = 0; i < 4; i++) {
-				scroll[i]->set_step(0.1);
+				scroll[i]->set_step(1.0);
 			}
 
-			scroll[0]->set_max(360);
+			scroll[0]->set_max(359);
 			scroll[0]->set_value(h * 360.0);
 			scroll[1]->set_max(100);
 			scroll[1]->set_value(s * 100.0);
 			scroll[2]->set_max(100);
 			scroll[2]->set_value(v * 100.0);
-			scroll[3]->set_max(100);
-			scroll[3]->set_value(color.components[3] * 100.0);
+			scroll[3]->set_max(255);
+			scroll[3]->set_value(color.components[3] * 255.0);
 		} else {
 			for (int i = 0; i < 4; i++) {
 				if (raw_mode_enabled) {


### PR DESCRIPTION
Here I found and fix some bugs related to HSV mode in ColorPicker

![image](https://user-images.githubusercontent.com/3036176/60350840-1d464280-99cd-11e9-8cd0-0f0e66e9de60.png)

1. Here I removed a fractional part from sliders so the values like 244.4 will not be committed - they are useless and incorrect

2. Changed alpha from (0-100) to RGBA range (0-255). HSV mode is not intended to affect the alpha channel.

3. Limit the H value from (0-360) to (0-359) to prevent wrap behavior on color slider. 0 is actually equivalent of 360, this fix makes it compatible with other sliders (which do not have wrap behavior).
