### PR TITLE
Properly disable SIGPIPE on OSX/iOS network sockets.

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -56,7 +56,6 @@
 #endif // MINGW hack
 #endif
 #else // UNIX
-#include <net/if.h>
 #include <netdb.h>
 #ifdef ANDROID_ENABLED
 // We could drop this file once we up our API level to 24,
@@ -73,6 +72,7 @@
 #ifdef __FreeBSD__
 #include <netinet/in.h>
 #endif
+#include <net/if.h> // Order is important on OpenBSD, leave as last
 #endif
 
 static IP_Address _sockaddr2ip(struct sockaddr *p_addr) {

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -55,10 +55,6 @@
 
 #include <netinet/tcp.h>
 
-#if defined(__APPLE__)
-#define MSG_NOSIGNAL SO_NOSIGPIPE
-#endif
-
 // BSD calls this flag IPV6_JOIN_GROUP
 #if !defined(IPV6_ADD_MEMBERSHIP) && defined(IPV6_JOIN_GROUP)
 #define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
@@ -87,10 +83,6 @@
 #define SOCK_IOCTL ioctlsocket
 #define SOCK_CLOSE closesocket
 
-// Windows doesn't have this flag
-#ifndef MSG_NOSIGNAL
-#define MSG_NOSIGNAL 0
-#endif
 // Workaround missing flag in MinGW
 #if defined(__MINGW32__) && !defined(SIO_UDP_NETRESET)
 #define SIO_UDP_NETRESET _WSAIOW(IOC_VENDOR, 15)
@@ -342,6 +334,13 @@ Error NetSocketPosix::open(Type p_sock_type, IP::Type &ip_type) {
 		}
 	}
 #endif
+#if defined(SO_NOSIGPIPE)
+	// Disable SIGPIPE (should only be relevant to stream sockets, but seems to affect UDP too on iOS)
+	int par = 1;
+	if (setsockopt(_sock, SOL_SOCKET, SO_NOSIGPIPE, SOCK_CBUF(&par), sizeof(int)) != 0) {
+		print_verbose("Unable to turn off SIGPIPE on socket");
+	}
+#endif
 	return OK;
 }
 
@@ -546,8 +545,10 @@ Error NetSocketPosix::send(const uint8_t *p_buffer, int p_len, int &r_sent) {
 	ERR_FAIL_COND_V(!is_open(), ERR_UNCONFIGURED);
 
 	int flags = 0;
+#ifdef MSG_NOSIGNAL
 	if (_is_stream)
 		flags = MSG_NOSIGNAL;
+#endif
 	r_sent = ::send(_sock, SOCK_CBUF(p_buffer), p_len, flags);
 
 	if (r_sent < 0) {


### PR DESCRIPTION
Disable SO_NOSIGPIPE socket option via `setsockopt` when avaiable.
Use MSG_NOSIGNAL send flag on systems that support it.

Also include an header inclusion order change to fix build on OpenBSD after #29935 .

As always, I run quire a few builds on various OSes, but I can't really test on OSX. So testers are welcome.