### PR TITLE
Draw the outline as part of the Label font shadow

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -247,11 +247,11 @@ void Label::_notification(int p_what) {
 								n = String::char_uppercase(n);
 							}
 
-							float move = font->draw_char(ci, Point2(x_ofs_shadow, y_ofs) + shadow_ofs, c, n, font_color_shadow, false);
+							float move = drawer.draw_char(ci, Point2(x_ofs_shadow, y_ofs) + shadow_ofs, c, n, font_color_shadow);
 							if (use_outline) {
-								font->draw_char(ci, Point2(x_ofs_shadow, y_ofs) + Vector2(-shadow_ofs.x, shadow_ofs.y), c, n, font_color_shadow, false);
-								font->draw_char(ci, Point2(x_ofs_shadow, y_ofs) + Vector2(shadow_ofs.x, -shadow_ofs.y), c, n, font_color_shadow, false);
-								font->draw_char(ci, Point2(x_ofs_shadow, y_ofs) + Vector2(-shadow_ofs.x, -shadow_ofs.y), c, n, font_color_shadow, false);
+								drawer.draw_char(ci, Point2(x_ofs_shadow, y_ofs) + Vector2(-shadow_ofs.x, shadow_ofs.y), c, n, font_color_shadow);
+								drawer.draw_char(ci, Point2(x_ofs_shadow, y_ofs) + Vector2(shadow_ofs.x, -shadow_ofs.y), c, n, font_color_shadow);
+								drawer.draw_char(ci, Point2(x_ofs_shadow, y_ofs) + Vector2(-shadow_ofs.x, -shadow_ofs.y), c, n, font_color_shadow);
 							}
 							x_ofs_shadow += move;
 							chars_total_shadow++;


### PR DESCRIPTION
This closes #30165. This also affects the legacy font outlines for completeness' sake, but one isn't supposed to use both at the same time :slightly_smiling_face:

Note that the font outline used by the shadow will have the same color as the main font outline. I tried overcoming this limitation by using a second FontDrawer instance dedicated to the shadow, but this caused the shadow's main font area to draw on top of the main font's outline (which looks bad). Therefore, I just made sure to use the main FontDrawer everywhere.

## Preview

In order:

- DynamicFont outline only
- Shadow only
- Shadow and DynamicFont outline

### Before

![label_outline_shadow_before](https://user-images.githubusercontent.com/180032/60372162-f6ebcb80-99fb-11e9-99f9-6c63b5699024.png)

### After

![label_outline_shadow_after](https://user-images.githubusercontent.com/180032/60372161-f6533500-99fb-11e9-84aa-6a5c32dd8d91.png)