### PR TITLE
 Fixed cases of unsupported pointers being used to construct variants

### DIFF
--- a/modules/gdnative/gdnative/array.cpp
+++ b/modules/gdnative/gdnative/array.cpp
@@ -305,13 +305,13 @@ void GDAPI godot_array_sort_custom(godot_array *p_self, godot_object *p_obj, con
 
 godot_int GDAPI godot_array_bsearch(godot_array *p_self, const godot_variant *p_value, const godot_bool p_before) {
 	Array *self = (Array *)p_self;
-	return self->bsearch((const Variant *)p_value, p_before);
+	return self->bsearch(*(const Variant *)p_value, p_before);
 }
 
 godot_int GDAPI godot_array_bsearch_custom(godot_array *p_self, const godot_variant *p_value, godot_object *p_obj, const godot_string *p_func, const godot_bool p_before) {
 	Array *self = (Array *)p_self;
 	const String *func = (const String *)p_func;
-	return self->bsearch_custom((const Variant *)p_value, (Object *)p_obj, *func, p_before);
+	return self->bsearch_custom(*(const Variant *)p_value, (Object *)p_obj, *func, p_before);
 }
 
 void GDAPI godot_array_destroy(godot_array *p_self) {

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -216,7 +216,7 @@ void PluginScriptLanguage::get_public_constants(List<Pair<String, Variant> > *p_
 		Dictionary constants;
 		_desc.get_public_constants(_data, (godot_dictionary *)&constants);
 		for (const Variant *key = constants.next(); key; key = constants.next(key)) {
-			Variant value = constants[key];
+			Variant value = constants[*key];
 			p_constants->push_back(Pair<String, Variant>(*key, value));
 		}
 	}

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -284,7 +284,7 @@ Error PluginScript::reload(bool p_keep_state) {
 
 	Dictionary *members = (Dictionary *)&manifest.member_lines;
 	for (const Variant *key = members->next(); key != NULL; key = members->next(key)) {
-		_member_lines[*key] = (*members)[key];
+		_member_lines[*key] = (*members)[*key];
 	}
 	Array *methods = (Array *)&manifest.methods;
 	for (int i = 0; i < methods->size(); ++i) {


### PR DESCRIPTION
Related to issue #30136 .

In four places Variant pointers are given where Variants are expected. This causes the pointers to be implicitly converted to bool, and used to construct a bool Variant (which is obviously not what is wanted).