### PR TITLE
Remove bogus nulls from generated default values

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -1397,7 +1397,7 @@ void ClassDB::get_extensions_for_type(const StringName &p_class, List<String> *p
 HashMap<StringName, HashMap<StringName, Variant> > ClassDB::default_values;
 Set<StringName> ClassDB::default_values_cached;
 
-Variant ClassDB::class_get_default_property_value(const StringName &p_class, const StringName &p_property) {
+Variant ClassDB::class_get_default_property_value(const StringName &p_class, const StringName &p_property, bool *r_valid) {
 
 	if (!default_values_cached.has(p_class)) {
 
@@ -1439,13 +1439,16 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 	}
 
 	if (!default_values.has(p_class)) {
+		if (r_valid != NULL) *r_valid = false;
 		return Variant();
 	}
 
 	if (!default_values[p_class].has(p_property)) {
+		if (r_valid != NULL) *r_valid = false;
 		return Variant();
 	}
 
+	if (r_valid != NULL) *r_valid = true;
 	return default_values[p_class][p_property];
 }
 

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -357,7 +357,7 @@ public:
 	static void get_enum_list(const StringName &p_class, List<StringName> *p_enums, bool p_no_inheritance = false);
 	static void get_enum_constants(const StringName &p_class, const StringName &p_enum, List<StringName> *p_constants, bool p_no_inheritance = false);
 
-	static Variant class_get_default_property_value(const StringName &p_class, const StringName &p_property);
+	static Variant class_get_default_property_value(const StringName &p_class, const StringName &p_property, bool *r_valid = NULL);
 
 	static StringName get_category(const StringName &p_node);
 

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -229,6 +229,8 @@ void PluginScript::set_source_code(const String &p_code) {
 }
 
 Error PluginScript::reload(bool p_keep_state) {
+	ERR_FAIL_COND_V(!_language, ERR_UNCONFIGURED);
+
 	_language->lock();
 	ERR_FAIL_COND_V(!p_keep_state && _instances.size(), ERR_ALREADY_IN_USE);
 	_language->unlock();
@@ -473,6 +475,8 @@ MultiplayerAPI::RPCMode PluginScript::get_rset_mode(const StringName &p_variable
 
 PluginScript::PluginScript() :
 		_data(NULL),
+		_desc(NULL),
+		_language(NULL),
 		_tool(false),
 		_valid(false),
 		_script_list(this) {
@@ -490,11 +494,15 @@ void PluginScript::init(PluginScriptLanguage *language) {
 }
 
 PluginScript::~PluginScript() {
-	_desc->finish(_data);
+	if (_desc && _data) {
+		_desc->finish(_data);
+	}
 
 #ifdef DEBUG_ENABLED
-	_language->lock();
-	_language->_script_list.remove(&_script_list);
-	_language->unlock();
+	if (_language) {
+		_language->lock();
+		_language->_script_list.remove(&_script_list);
+		_language->unlock();
+	}
 #endif
 }


### PR DESCRIPTION
Also, fix crash in PluginScript destructor.

The bogus values were caused by properties missing both `EDITOR` and `STORAGE` usage.