### PR TITLE
Method Binding Free Function Support

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -146,7 +146,7 @@ env.Depends("#core/io/certs_compressed.gen.h", ["#thirdparty/certs/ca-certificat
 env.CommandNoCache("#core/io/certs_compressed.gen.h", "#thirdparty/certs/ca-certificates.crt", run_in_subprocess(core_builders.make_certs_header))
 
 # Make binders
-env.CommandNoCache(['method_bind.gen.inc', 'method_bind_ext.gen.inc'], 'make_binders.py', run_in_subprocess(make_binders.run))
+env.CommandNoCache(['method_bind.gen.inc', 'method_bind_ext.gen.inc', 'method_bind_free_func.gen.inc'], 'make_binders.py', run_in_subprocess(make_binders.run))
 
 # Authors
 env.Depends('#core/authors.gen.h', "../AUTHORS.md")

--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -191,6 +191,96 @@ MethodBind* create_method_bind($ifret R$ $ifnoret void$ (T::*p_method)($arg, P@$
 """
 
 
+template_typed_free_func = """
+#ifdef TYPED_METHOD_BIND
+template<class T $ifret ,class R$ $ifargs ,$ $arg, class P@$>
+class FunctionBind$argc$$ifret R$$ifconst C$ : public MethodBind {
+public:
+
+	$ifret R$ $ifnoret void$ (*method) ($ifconst const$ T *$ifargs , $$arg, P@$);
+#ifdef DEBUG_METHODS_ENABLED
+	virtual Variant::Type _gen_argument_type(int p_arg) const { return _get_argument_type(p_arg); }
+	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const {
+		$ifret if (p_arg==-1) return GetTypeInfo<R>::METADATA;$
+		$arg if (p_arg==(@-1)) return GetTypeInfo<P@>::METADATA;
+		$
+		return GodotTypeInfo::METADATA_NONE;
+	}
+	Variant::Type _get_argument_type(int p_argument) const {
+		$ifret if (p_argument==-1) return (Variant::Type)GetTypeInfo<R>::VARIANT_TYPE;$
+		$arg if (p_argument==(@-1)) return (Variant::Type)GetTypeInfo<P@>::VARIANT_TYPE;
+		$
+		return Variant::NIL;
+	}
+	virtual PropertyInfo _gen_argument_type_info(int p_argument) const {
+		$ifret if (p_argument==-1) return GetTypeInfo<R>::get_class_info();$
+		$arg if (p_argument==(@-1)) return GetTypeInfo<P@>::get_class_info();
+		$
+		return PropertyInfo();
+	}
+#endif
+	virtual String get_instance_class() const {
+		return T::get_class_static();
+	}
+
+	virtual Variant call(Object* p_object,const Variant** p_args,int p_arg_count, Variant::CallError& r_error) {
+
+		T *instance=Object::cast_to<T>(p_object);
+		r_error.error=Variant::CallError::CALL_OK;
+#ifdef DEBUG_METHODS_ENABLED
+
+		ERR_FAIL_COND_V(!instance,Variant());
+		if (p_arg_count>get_argument_count()) {
+			r_error.error=Variant::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
+			r_error.argument=get_argument_count();
+			return Variant();
+
+		}
+		if (p_arg_count<(get_argument_count()-get_default_argument_count())) {
+
+			r_error.error=Variant::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
+			r_error.argument=get_argument_count()-get_default_argument_count();
+			return Variant();
+		}
+		$arg CHECK_ARG(@);
+		$
+#endif
+		$ifret Variant ret = $(method)(instance$ifargs , $$arg, _VC(@)$);
+		$ifret return Variant(ret);$
+		$ifnoret return Variant();$
+	}
+
+#ifdef PTRCALL_ENABLED
+	virtual void ptrcall(Object*p_object,const void** p_args,void *r_ret) {
+
+		T *instance=Object::cast_to<T>(p_object);
+		$ifret PtrToArg<R>::encode( $ (method)(instance$ifargs , $$arg, PtrToArg<P@>::convert(p_args[@-1])$) $ifret ,r_ret)$ ;
+	}
+#endif
+	FunctionBind$argc$$ifret R$$ifconst C$ () {
+#ifdef DEBUG_METHODS_ENABLED
+		_set_const($ifconst true$$ifnoconst false$);
+		_generate_argument_types($argc$);
+#else
+		set_argument_count($argc$);
+#endif
+
+		$ifret _set_returns(true); $
+	};
+};
+
+template<class T $ifret ,class R$ $ifargs ,$ $arg, class P@$>
+MethodBind* create_method_bind($ifret R$ $ifnoret void$ (*p_method)($ifconst const$ T *$ifargs , $$arg, P@$) ) {
+
+	FunctionBind$argc$$ifret R$$ifconst C$<T $ifret ,R$ $ifargs ,$ $arg, P@$> * a = memnew( (FunctionBind$argc$$ifret R$$ifconst C$<T $ifret ,R$ $ifargs ,$ $arg, P@$>) );
+	a->method=p_method;
+	return a;
+}
+#endif
+"""
+
+
+
 def make_version(template, nargs, argmax, const, ret):
 
     intext = template
@@ -259,6 +349,9 @@ def run(target, source, env):
     versions_ext = 6
     text = ""
     text_ext = ""
+    text_free_func = "#ifndef METHOD_BIND_FREE_FUNC_H\n#define METHOD_BIND_FREE_FUNC_H\n"
+    text_free_func += "\n//including this header file allows method binding to use free functions\n"
+    text_free_func += "//note that the free function must have a pointer to an instance of the class as its first parameter\n"
 
     for i in range(0, versions + 1):
 
@@ -276,11 +369,21 @@ def run(target, source, env):
         else:
             text += t
 
+        text_free_func += make_version(template_typed_free_func, i, versions, False, False)
+        text_free_func += make_version(template_typed_free_func, i, versions, False, True)
+        text_free_func += make_version(template_typed_free_func, i, versions, True, False)
+        text_free_func += make_version(template_typed_free_func, i, versions, True, True)
+
+    text_free_func += "#endif"
+
     with open(target[0], "w") as f:
         f.write(text)
 
     with open(target[1], "w") as f:
         f.write(text_ext)
+
+    with open(target[2], "w") as f:
+        f.write(text_free_func)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request provides support for free function pointers to be used for method bindings, as long as the first parameter of the function is an instance of the class for which the methods are being bound. The usual method binding using member functions is not impacted at all by these changes, functioning as normally.

This can be extremely useful for custom C++ modules (it certainly was in my case), specially since lambdas without captures can be used for the method binding (as they can be referred to with free function pointers). Here is an example:

```
void Deity::_bind_methods()
{
	ClassDB::bind_method(D_METHOD("get_domains"), +[](const Deity *deity){ return ContainerToGodotArray(deity->GetDomains()); });
}
```

The Deity class in the custom module has an std::vector variable called Domains, which is obtained with the GetDomains function. Since a std::vector cannot be used to construct a Variant, a conversion has to be done for the method binding. Instead of filling each class that uses STL containers with functions for converting each of them, a lambda can be used in _bind_methods calling the ContainerToGodotArray function, which is defined elsewhere in the custom module to convert an STL container into a Godot Array. This allows the class definition to be kept clean of methods that would just be used for the binding, making it more readable and better organized.

And here is another example:

```
void Player::_bind_methods()
{	
	ClassDB::bind_method(D_METHOD("get_faction"), +[](const Player *player){ return const_cast<Faction *>(player->GetFaction()); });
}
```

The Player class has a method which returns a const pointer to a Faction instance. Godot bound methods cannot return a const pointer, however, only non-const ones (as discussed in issue #27344 ). With the change in this pull request, a lambda can now be used to use do a const_cast on the pointer for the bound method. This way, there is no need to add an extra method to the class just for doing the const_cast needed for the method binding.

Note: For those wondering about the "+" before the lambdas in the method binding examples, a unary plus there makes a lambda without captures decay to a function pointer.