### PR TITLE
SceneTreeDock will now only attach scripts to the selected node if the ScriptCreateDialog was opened from the SceneTreeDock

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -418,6 +418,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					}
 				}
 			}
+			script_create_dialog->connect("script_created", this, "_script_created");
+			script_create_dialog->connect("popup_hide", this, "_script_creation_closed");
 			script_create_dialog->config(inherits, path);
 			script_create_dialog->popup_centered();
 
@@ -1647,6 +1649,11 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 	_update_script_button();
 }
 
+void SceneTreeDock::_script_creation_closed() {
+	script_create_dialog->disconnect("script_created", this, "_script_created");
+	script_create_dialog->disconnect("popup_hide", this, "_script_creation_closed");
+}
+
 void SceneTreeDock::_toggle_editable_children_from_selection() {
 
 	List<Node *> selection = editor_selection->get_selected_node_list();
@@ -2506,6 +2513,7 @@ void SceneTreeDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_node_selected"), &SceneTreeDock::_node_selected);
 	ClassDB::bind_method(D_METHOD("_node_renamed"), &SceneTreeDock::_node_renamed);
 	ClassDB::bind_method(D_METHOD("_script_created"), &SceneTreeDock::_script_created);
+	ClassDB::bind_method(D_METHOD("_script_creation_closed"), &SceneTreeDock::_script_creation_closed);
 	ClassDB::bind_method(D_METHOD("_load_request"), &SceneTreeDock::_load_request);
 	ClassDB::bind_method(D_METHOD("_script_open_request"), &SceneTreeDock::_script_open_request);
 	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &SceneTreeDock::_unhandled_key_input);
@@ -2661,7 +2669,6 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	script_create_dialog = memnew(ScriptCreateDialog);
 	script_create_dialog->set_inheritance_base_type("Node");
 	add_child(script_create_dialog);
-	script_create_dialog->connect("script_created", this, "_script_created");
 
 	reparent_dialog = memnew(ReparentDialog);
 	add_child(reparent_dialog);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -170,6 +170,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _node_selected();
 	void _node_renamed();
 	void _script_created(Ref<Script> p_script);
+	void _script_creation_closed();
 
 	void _delete_confirm();
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -286,8 +286,8 @@ void ScriptCreateDialog::_create_new() {
 		}
 	}
 
-	hide();
 	emit_signal("script_created", scr);
+	hide();
 }
 
 void ScriptCreateDialog::_load_exist() {
@@ -300,8 +300,8 @@ void ScriptCreateDialog::_load_exist() {
 		return;
 	}
 
-	hide();
 	emit_signal("script_created", p_script.get_ref_ptr());
+	hide();
 }
 
 void ScriptCreateDialog::_lang_changed(int l) {


### PR DESCRIPTION
I found that the SceneTreeDock previously did not account for whether it was the one that opened the ScriptCreateDialog, when attaching scripts. This meant that if a editor plugin opened the ScriptCreateDialog, and a script was actually created from this, the SceneTreeDock would add that script to any selected nodes.

This fixes the issue by having the SceneTreeDock listen for the `script_created` signal *only* when it was the one who opened the dialog.

I am not sure if the way I made this fix is the best way, so feedback would be appreciated if there's a better way I could do this.

----
This also changes ScriptCreateDialog to emit the `script_created` signal before the `popup_hide` signal, rather than the other way around, when a script is created/loaded successfully. As far as I'm aware, this shouldn't break much of anything (except those specifically relying on the `popup_hide` signal coming first, which I'm not sure would make sense anyways since `popup_hide` typically indicates that the dialog was cancelled).

I put this change in this PR as its own commit because I'm not sure putting it in its own PR would be better, as this PR would just end up relying on that PR being merged first anyways, plus I'm not sure how "Try to make simple PRs that handle one specific topic" would apply here. Please let me know if putting this sort of stuff in their own PRs would be preferred in the future.