### PR TITLE
Draw the script editor's line length guideline below characters

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -681,6 +681,13 @@ void TextEdit::_notification(int p_what) {
 				}
 			}
 
+			if (line_length_guideline) {
+				int x = xmargin_beg + cache.font->get_char_size('0').width * line_length_guideline_col - cursor.x_ofs;
+				if (x > xmargin_beg && x < xmargin_end) {
+					VisualServer::get_singleton()->canvas_item_add_line(ci, Point2(x, 0), Point2(x, size.height), cache.line_length_guideline_color);
+				}
+			}
+
 			int brace_open_match_line = -1;
 			int brace_open_match_column = -1;
 			bool brace_open_matching = false;
@@ -1336,13 +1343,6 @@ void TextEdit::_notification(int p_what) {
 							}
 						}
 					}
-				}
-			}
-
-			if (line_length_guideline) {
-				int x = xmargin_beg + cache.font->get_char_size('0').width * line_length_guideline_col - cursor.x_ofs;
-				if (x > xmargin_beg && x < xmargin_end) {
-					VisualServer::get_singleton()->canvas_item_add_line(ci, Point2(x, 0), Point2(x, size.height), cache.line_length_guideline_color);
 				}
 			}
 


### PR DESCRIPTION
This prevents characters from looking strange if they cross the line length guideline.

## Preview

### Before

![line_length_dark_bad](https://user-images.githubusercontent.com/180032/60402301-19155300-9b8e-11e9-9985-1719bba85012.png)
![line_length_light_bad](https://user-images.githubusercontent.com/180032/60402302-19155300-9b8e-11e9-9698-5c255cc58f05.png)

### After

![line_length_dark_good](https://user-images.githubusercontent.com/180032/60402300-161a6280-9b8e-11e9-824e-1f27b9585f2b.png)
![line_length_light_good](https://user-images.githubusercontent.com/180032/60402303-19ade980-9b8e-11e9-9b61-2d9d81486cc0.png)