### PR TITLE
Revert "Add godot version in backtrace message"

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -356,7 +356,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	ClassDB::register_class<Performance>();
 	engine->add_singleton(Engine::Singleton("Performance", performance));
 
-	GLOBAL_DEF("debug/settings/crash_handler/message", "Godot version: " + get_full_version_string() + String("\nPlease include this when reporting the bug on https://github.com/godotengine/godot/issues"));
+	GLOBAL_DEF("debug/settings/crash_handler/message", String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
 
 	MAIN_PRINT("Main: Parse CMDLine");
 


### PR DESCRIPTION
Reverts godotengine/godot#28572

The idea is good, but we can't use the configurable crash handler message to display the version string, it should be hardcoded in the crash handler print code for each platform instead.