### PR TITLE
Add a method for calculating the centroid of a polygon

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1529,6 +1529,11 @@ bool _Geometry::is_point_in_polygon(const Point2 &p_point, const Vector<Vector2>
 	return Geometry::is_point_in_polygon(p_point, p_polygon);
 }
 
+Vector2 _Geometry::get_polygon_centroid(const Vector<Vector2> &p_polygon) {
+
+	return Geometry::get_polygon_centroid(p_polygon);
+}
+
 Vector<int> _Geometry::triangulate_polygon(const Vector<Vector2> &p_polygon) {
 
 	return Geometry::triangulate_polygon(p_polygon);
@@ -1712,6 +1717,7 @@ void _Geometry::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_polygon_clockwise", "polygon"), &_Geometry::is_polygon_clockwise);
 	ClassDB::bind_method(D_METHOD("is_point_in_polygon", "point", "polygon"), &_Geometry::is_point_in_polygon);
+	ClassDB::bind_method(D_METHOD("get_polygon_centroid", "polygon"), &_Geometry::get_polygon_centroid);
 	ClassDB::bind_method(D_METHOD("triangulate_polygon", "polygon"), &_Geometry::triangulate_polygon);
 	ClassDB::bind_method(D_METHOD("triangulate_delaunay_2d", "points"), &_Geometry::triangulate_delaunay_2d);
 	ClassDB::bind_method(D_METHOD("convex_hull_2d", "points"), &_Geometry::convex_hull_2d);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -409,6 +409,7 @@ public:
 
 	bool is_polygon_clockwise(const Vector<Vector2> &p_polygon);
 	bool is_point_in_polygon(const Point2 &p_point, const Vector<Vector2> &p_polygon);
+	Vector2 get_polygon_centroid(const Vector<Vector2> &p_polygon);
 	Vector<int> triangulate_polygon(const Vector<Vector2> &p_polygon);
 	Vector<int> triangulate_delaunay_2d(const Vector<Vector2> &p_points);
 	Vector<Point2> convex_hull_2d(const Vector<Point2> &p_points);

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -933,6 +933,37 @@ public:
 		return (intersections & 1);
 	}
 
+	static Vector2 get_polygon_centroid(const Vector<Vector2> &p_polygon) {
+
+		// Based on formulae from:
+		// "Calculating The Area And Centroid Of A Polygon" Written by Paul Bourke July 1988
+		// https://www.seas.upenn.edu/~sys502/extra_materials/Polygon%20Area%20and%20Centroid.pdf
+
+		int c = p_polygon.size();
+		ERR_FAIL_COND_V(c < 3, Vector2());
+
+		const Vector2 *p = p_polygon.ptr();
+
+		Vector2 centroid;
+
+		real_t signed_area = 0.0;
+		real_t a = 0.0;
+
+		for (int i = 0; i < c; i++) {
+			const Vector2 &v1 = p[i];
+			const Vector2 &v2 = p[(i + 1) % c];
+
+			a = v1.x * v2.y - v2.x * v1.y;
+			signed_area += a;
+			centroid += (v1 + v2) * a;
+		}
+
+		signed_area *= 0.5;
+		centroid /= (6.0 * signed_area);
+
+		return centroid;
+	}
+
 	static PoolVector<PoolVector<Face3> > separate_objects(PoolVector<Face3> p_array);
 
 	static PoolVector<Face3> wrap_geometry(PoolVector<Face3> p_array, real_t *p_error = NULL); ///< create a "wrap" that encloses the given geometry

--- a/doc/classes/Geometry.xml
+++ b/doc/classes/Geometry.xml
@@ -185,6 +185,15 @@
 				Given the two 2d segments ([code]p1[/code], [code]p2[/code]) and ([code]q1[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PoolVector2Array] that contains this point on ([code]p1[/code], [code]p2[/code]) as well the accompanying point on ([code]q1[/code], [code]q2[/code]).
 			</description>
 		</method>
+		<method name="get_polygon_centroid">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="polygon" type="PoolVector2Array">
+			</argument>
+			<description>
+				Calculates the centroid (also known as "center of mass" or "center of gravity") of the [code]polygon[/code] and returns the consistent result regardless of polygon orientation, see [method is_polygon_clockwise]. For accurate results, the polygon must be strictly simple, meaning there should be no self-intersecting edges.
+			</description>
+		</method>
 		<method name="get_uv84_normal_bit">
 			<return type="int">
 			</return>


### PR DESCRIPTION
Required for #29867 to work for calculating the exact center of mass of polygon shapes.

![polygon_centroid](https://user-images.githubusercontent.com/17108460/60437576-54a82f80-9c17-11e9-92a5-64becd5d5b07.gif)

C++:
```cpp
Vector2 centroid = Geometry::get_polygon_centroid(polygon)
```
GDScript:
```gdscript
var centroid = Geometry.get_polygon_centroid(polygon)
```
@raphael10241024 please take a look at this. 🙂