### PR TITLE
Remove thread to prevent memory leak

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2700,6 +2700,8 @@ Variant _Thread::wait_to_finish() {
 	target_method = StringName();
 	target_instance = NULL;
 	userdata = Variant();
+	if (thread)
+		memdelete(thread);
 	thread = NULL;
 
 	return r;


### PR DESCRIPTION
This should fix point 2 from #30138.
I was thinking that 2 points from issue are related to each other, but they probably aren't.