### PR TITLE
Add "Go To" menu to the script editor and move the bookmark and breakpoint menus there

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -646,19 +646,20 @@ void ScriptTextEditor::_validate_script() {
 
 void ScriptTextEditor::_update_bookmark_list() {
 
-	bookmarks_menu->get_popup()->clear();
+	bookmarks_menu->clear();
+	bookmarks_menu->set_size(Size2(1, 1));
 
-	bookmarks_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
-	bookmarks_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_bookmarks"), BOOKMARK_REMOVE_ALL);
-	bookmarks_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
-	bookmarks_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_bookmarks"), BOOKMARK_REMOVE_ALL);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
 
 	Array bookmark_list = code_editor->get_text_edit()->get_bookmarks_array();
 	if (bookmark_list.size() == 0) {
 		return;
 	}
 
-	bookmarks_menu->get_popup()->add_separator();
+	bookmarks_menu->add_separator();
 
 	for (int i = 0; i < bookmark_list.size(); i++) {
 		String line = code_editor->get_text_edit()->get_line(bookmark_list[i]).strip_edges();
@@ -667,17 +668,17 @@ void ScriptTextEditor::_update_bookmark_list() {
 			line = line.substr(0, 50);
 		}
 
-		bookmarks_menu->get_popup()->add_item(String::num((int)bookmark_list[i] + 1) + " - \"" + line + "\"");
-		bookmarks_menu->get_popup()->set_item_metadata(bookmarks_menu->get_popup()->get_item_count() - 1, bookmark_list[i]);
+		bookmarks_menu->add_item(String::num((int)bookmark_list[i] + 1) + " - \"" + line + "\"");
+		bookmarks_menu->set_item_metadata(bookmarks_menu->get_item_count() - 1, bookmark_list[i]);
 	}
 }
 
 void ScriptTextEditor::_bookmark_item_pressed(int p_idx) {
 
 	if (p_idx < 4) { // Any item before the separator.
-		_edit_option(bookmarks_menu->get_popup()->get_item_id(p_idx));
+		_edit_option(bookmarks_menu->get_item_id(p_idx));
 	} else {
-		code_editor->goto_line(bookmarks_menu->get_popup()->get_item_metadata(p_idx));
+		code_editor->goto_line(bookmarks_menu->get_item_metadata(p_idx));
 	}
 }
 
@@ -789,6 +790,44 @@ void ScriptTextEditor::_code_complete_script(const String &p_code, List<String> 
 	Error err = script->get_language()->complete_code(p_code, script->get_path(), base, r_options, r_force, hint);
 	if (err == OK && hint != "") {
 		code_editor->get_text_edit()->set_code_hint(hint);
+	}
+}
+
+void ScriptTextEditor::_update_breakpoint_list() {
+
+	breakpoints_menu->clear();
+	breakpoints_menu->set_size(Size2(1, 1));
+
+	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_breakpoint"), DEBUG_TOGGLE_BREAKPOINT);
+	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_breakpoints"), DEBUG_REMOVE_ALL_BREAKPOINTS);
+	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_breakpoint"), DEBUG_GOTO_NEXT_BREAKPOINT);
+	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_breakpoint"), DEBUG_GOTO_PREV_BREAKPOINT);
+
+	Array breakpoint_list = code_editor->get_text_edit()->get_breakpoints_array();
+	if (breakpoint_list.size() == 0) {
+		return;
+	}
+
+	breakpoints_menu->add_separator();
+
+	for (int i = 0; i < breakpoint_list.size(); i++) {
+		String line = code_editor->get_text_edit()->get_line(breakpoint_list[i]).strip_edges();
+		// Limit the size of the line if too big.
+		if (line.length() > 50) {
+			line = line.substr(0, 50);
+		}
+
+		breakpoints_menu->add_item(String::num((int)breakpoint_list[i] + 1) + " - \"" + line + "\"");
+		breakpoints_menu->set_item_metadata(breakpoints_menu->get_item_count() - 1, breakpoint_list[i]);
+	}
+}
+
+void ScriptTextEditor::_breakpoint_item_pressed(int p_idx) {
+
+	if (p_idx < 4) { // Any item before the separator.
+		_edit_option(breakpoints_menu->get_item_id(p_idx));
+	} else {
+		code_editor->goto_line(breakpoints_menu->get_item_metadata(p_idx));
 	}
 }
 
@@ -1298,6 +1337,8 @@ void ScriptTextEditor::_bind_methods() {
 	ClassDB::bind_method("_update_bookmark_list", &ScriptTextEditor::_update_bookmark_list);
 	ClassDB::bind_method("_bookmark_item_pressed", &ScriptTextEditor::_bookmark_item_pressed);
 	ClassDB::bind_method("_load_theme_settings", &ScriptTextEditor::_load_theme_settings);
+	ClassDB::bind_method("_update_breakpoint_list", &ScriptTextEditor::_update_breakpoint_list);
+	ClassDB::bind_method("_breakpoint_item_pressed", &ScriptTextEditor::_breakpoint_item_pressed);
 	ClassDB::bind_method("_breakpoint_toggled", &ScriptTextEditor::_breakpoint_toggled);
 	ClassDB::bind_method("_lookup_connections", &ScriptTextEditor::_lookup_connections);
 	ClassDB::bind_method("_update_connected_methods", &ScriptTextEditor::_update_connected_methods);
@@ -1705,11 +1746,6 @@ ScriptTextEditor::ScriptTextEditor() {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/auto_indent"), EDIT_AUTO_INDENT);
 	edit_menu->get_popup()->connect("id_pressed", this, "_edit_option");
 	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_breakpoint"), DEBUG_TOGGLE_BREAKPOINT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_breakpoints"), DEBUG_REMOVE_ALL_BREAKPOINTS);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_breakpoint"), DEBUG_GOTO_NEXT_BREAKPOINT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_breakpoint"), DEBUG_GOTO_PREV_BREAKPOINT);
-	edit_menu->get_popup()->add_separator();
 
 	PopupMenu *convert_case = memnew(PopupMenu);
 	convert_case->set_name("convert_case");
@@ -1749,13 +1785,26 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	edit_hb->add_child(edit_menu);
 
-	bookmarks_menu = memnew(MenuButton);
-	edit_hb->add_child(bookmarks_menu);
-	bookmarks_menu->set_text(TTR("Bookmarks"));
-	bookmarks_menu->set_switch_on_hover(true);
+	MenuButton *goto_menu = memnew(MenuButton);
+	edit_hb->add_child(goto_menu);
+	goto_menu->set_text(TTR("Go To"));
+	goto_menu->set_switch_on_hover(true);
+
+	bookmarks_menu = memnew(PopupMenu);
+	bookmarks_menu->set_name("Bookmarks");
+	goto_menu->get_popup()->add_child(bookmarks_menu);
+	goto_menu->get_popup()->add_submenu_item(TTR("Bookmarks"), "Bookmarks");
 	_update_bookmark_list();
 	bookmarks_menu->connect("about_to_show", this, "_update_bookmark_list");
-	bookmarks_menu->get_popup()->connect("index_pressed", this, "_bookmark_item_pressed");
+	bookmarks_menu->connect("index_pressed", this, "_bookmark_item_pressed");
+
+	breakpoints_menu = memnew(PopupMenu);
+	breakpoints_menu->set_name("Breakpoints");
+	goto_menu->get_popup()->add_child(breakpoints_menu);
+	goto_menu->get_popup()->add_submenu_item(TTR("Breakpoints"), "Breakpoints");
+	_update_breakpoint_list();
+	breakpoints_menu->connect("about_to_show", this, "_update_breakpoint_list");
+	breakpoints_menu->connect("index_pressed", this, "_breakpoint_item_pressed");
 
 	quick_open = memnew(ScriptEditorQuickOpen);
 	add_child(quick_open);

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -70,7 +70,8 @@ class ScriptTextEditor : public ScriptEditorBase {
 
 	MenuButton *edit_menu;
 	MenuButton *search_menu;
-	MenuButton *bookmarks_menu;
+	PopupMenu *bookmarks_menu;
+	PopupMenu *breakpoints_menu;
 	PopupMenu *highlighter_menu;
 	PopupMenu *context_menu;
 
@@ -143,6 +144,8 @@ class ScriptTextEditor : public ScriptEditorBase {
 
 protected:
 	static void _code_complete_scripts(void *p_ud, const String &p_code, List<String> *r_options, bool &r_force);
+	void _update_breakpoint_list();
+	void _breakpoint_item_pressed(int p_idx);
 	void _breakpoint_toggled(int p_row);
 
 	void _validate_script(); // No longer virtual.


### PR DESCRIPTION
Continuing from the ideas suggest in #29071, I created a new "Go To" menu and moved not just the bookmark menu but also the breakpoint menu to it as well, freeing a lot of space from the "Edit" menu.
I also implemented the line list from the bookmarks in the breakpoints as well.
![Screenshot_20190701_161231](https://user-images.githubusercontent.com/30739239/60460814-47e60480-9c34-11e9-836b-1d4ad30294a5.png)