### PR TITLE
Fixed multichannel panning for AudioStreamPlayer3D.

### DIFF
--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -115,6 +115,7 @@ private:
 	bool stream_paused_fade_out;
 	StringName bus;
 
+	static void _calc_output_vol(const Vector3 &source_dir, real_t tightness, Output &output);
 	void _mix_audio();
 	static void _mix_audios(void *self) { reinterpret_cast<AudioStreamPlayer3D *>(self)->_mix_audio(); }
 


### PR DESCRIPTION
Implements SPCAP (Speaker-Placement Correction Amplitude Panning) based on "A Novel Multichannel Panning Method for Standard and Arbitrary Loudspeaker Configurations" by Ramy Sadek and Chris Kyriakakis (2004).

Fixing issue https://github.com/godotengine/godot/issues/9494

On Linux using Pulseaudio I also had to explicitly set the channel map - see PR https://github.com/godotengine/godot/pull/30232
