### PR TITLE
Fix few GCC9 warnings:

### DIFF
--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -233,6 +233,13 @@ private:
 			render_db_value = n.render_db_value;
 		}
 
+		_FORCE_INLINE_ AudioNotch operator=(const EditorAudioMeterNotches::AudioNotch &n) {
+			relative_position = n.relative_position;
+			db_value = n.db_value;
+			render_db_value = n.render_db_value;
+			return *this;
+		}
+
 		_FORCE_INLINE_ AudioNotch() {}
 	};
 

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -31,7 +31,7 @@
 #include "texture_loader_dds.h"
 #include "core/os/file_access.h"
 
-#define PF_FOURCC(s) (((s)[3] << 24U) | ((s)[2] << 16U) | ((s)[1] << 8U) | ((s)[0]))
+#define PF_FOURCC(s) ((uint32_t)(((s)[3] << 24U) | ((s)[2] << 16U) | ((s)[1] << 8U) | ((s)[0])))
 
 enum {
 	DDS_MAGIC = 0x20534444,

--- a/thirdparty/assimp/include/assimp/types.h
+++ b/thirdparty/assimp/include/assimp/types.h
@@ -161,7 +161,14 @@ struct aiColor3D
     explicit aiColor3D (ai_real _r) : r(_r), g(_r), b(_r) {}
     aiColor3D (const aiColor3D& o) : r(o.r), g(o.g), b(o.b) {}
 
-    /** Component-wise comparison */
+	aiColor3D &operator=(const aiColor3D &o) {
+		r = o.r;
+		g = o.g;
+		b = o.b;
+		return *this;
+	}
+
+	/** Component-wise comparison */
     // TODO: add epsilon?
     bool operator == (const aiColor3D& other) const
         {return r == other.r && g == other.g && b == other.b;}


### PR DESCRIPTION
```
thirdparty/assimp/include/assimp/material.inl: In member function 'aiReturn aiMaterial::Get(const char*, unsigned int, unsigned int, aiColor3D&) const':
thirdparty/assimp/include/assimp/material.inl:176:33: error: implicitly-declared 'aiColor3D& aiColor3D::operator=(const aiColor3D&)' is deprecated [-Werror=deprecated-copy]
  176 |     pOut = aiColor3D(c.r,c.g,c.b);

modules/dds/texture_loader_dds.cpp:167:50: error: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
  167 |  if (format_flags & DDPF_FOURCC && format_fourcc == PF_FOURCC("DXT1")) {
      |                                                  ^
[ 28%] modules/dds/texture_loader_dds.cpp:170:57: error: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
  170 |  } else if (format_flags & DDPF_FOURCC && format_fourcc == PF_FOURCC("DXT3")) {
      |                                                         ^
modules/dds/texture_loader_dds.cpp:174:57: error: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
  174 |  } else if (format_flags & DDPF_FOURCC && format_fourcc == PF_FOURCC("DXT5")) {
      |                                                         ^
modules/dds/texture_loader_dds.cpp:177:57: error: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
  177 |  } else if (format_flags & DDPF_FOURCC && format_fourcc == PF_FOURCC("ATI1")) {
      |                                                         ^
modules/dds/texture_loader_dds.cpp:180:57: error: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
  180 |  } else if (format_flags & DDPF_FOURCC && format_fourcc == PF_FOURCC("ATI2")) {
      |                                                         ^
modules/dds/texture_loader_dds.cpp:183:57: error: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
  183 |  } else if (format_flags & DDPF_FOURCC && format_fourcc == PF_FOURCC("A2XY")) {
      |                                                         ^

thirdparty/assimp/include/assimp/material.inl: In member function 'aiReturn aiMaterial::Get(const char*, unsigned int, unsigned int, aiColor3D&) const':
thirdparty/assimp/include/assimp/material.inl:176:33: error: implicitly-declared 'aiColor3D& aiColor3D::operator=(const aiColor3D&)' is deprecated [-Werror=deprecated-copy]
  176 |     pOut = aiColor3D(c.r,c.g,c.b);
```