### PR TITLE
Expose a method for calculating polygon's signed area

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1606,6 +1606,11 @@ PoolVector<Vector3> _Geometry::segment_intersects_convex(const Vector3 &p_from, 
 	return r;
 }
 
+real_t _Geometry::get_polygon_area(const Vector<Vector2> &p_polygon) {
+
+	return Geometry::get_polygon_area(p_polygon);
+}
+
 bool _Geometry::is_polygon_clockwise(const Vector<Vector2> &p_polygon) {
 
 	return Geometry::is_polygon_clockwise(p_polygon);
@@ -1793,6 +1798,7 @@ void _Geometry::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("segment_intersects_convex", "from", "to", "planes"), &_Geometry::segment_intersects_convex);
 	ClassDB::bind_method(D_METHOD("point_is_inside_triangle", "point", "a", "b", "c"), &_Geometry::point_is_inside_triangle);
 
+	ClassDB::bind_method(D_METHOD("get_polygon_area", "polygon"), &_Geometry::get_polygon_area);
 	ClassDB::bind_method(D_METHOD("is_polygon_clockwise", "polygon"), &_Geometry::is_polygon_clockwise);
 	ClassDB::bind_method(D_METHOD("is_point_in_polygon", "point", "polygon"), &_Geometry::is_point_in_polygon);
 	ClassDB::bind_method(D_METHOD("triangulate_polygon", "polygon"), &_Geometry::triangulate_polygon);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -401,6 +401,7 @@ public:
 	real_t segment_intersects_circle(const Vector2 &p_from, const Vector2 &p_to, const Vector2 &p_circle_pos, real_t p_circle_radius);
 	int get_uv84_normal_bit(const Vector3 &p_vector);
 
+	real_t get_polygon_area(const Vector<Vector2> &p_polygon);
 	bool is_polygon_clockwise(const Vector<Vector2> &p_polygon);
 	bool is_point_in_polygon(const Point2 &p_point, const Vector<Vector2> &p_polygon);
 	Vector<int> triangulate_polygon(const Vector<Vector2> &p_polygon);

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -852,6 +852,11 @@ public:
 			return Vector<int>(); //fail
 		return triangles;
 	}
+	
+	static real_t get_polygon_area(const Vector<Vector2> &p_polygon) {
+		ERR_FAIL_COND_V_MSG(p_polygon.size() < 3, 0.0, "Bad polygon: cannot compute area with less than 3 vertices.");
+		return Triangulate::get_area(p_polygon);
+	}
 
 	static bool is_polygon_clockwise(const Vector<Vector2> &p_polygon) {
 		int c = p_polygon.size();
@@ -864,7 +869,6 @@ public:
 			const Vector2 &v2 = p[(i + 1) % c];
 			sum += (v2.x - v1.x) * (v2.y + v1.y);
 		}
-
 		return sum > 0.0f;
 	}
 

--- a/doc/classes/Geometry.xml
+++ b/doc/classes/Geometry.xml
@@ -187,6 +187,15 @@
 				Given the two 2D segments ([code]p1[/code], [code]p2[/code]) and ([code]q1[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PoolVector2Array] that contains this point on ([code]p1[/code], [code]p2[/code]) as well the accompanying point on ([code]q1[/code], [code]q2[/code]).
 			</description>
 		</method>
+		<method name="get_polygon_area">
+			<return type="float">
+			</return>
+			<argument index="0" name="polygon" type="PoolVector2Array">
+			</argument>
+			<description>
+				Returns [code]polygon[/code]'s positive or negative area depending on whether vertices are ordered in counterclockwise or anticlockwise order. See also [method is_polygon_clockwise].
+			</description>
+		</method>
 		<method name="get_uv84_normal_bit">
 			<return type="int">
 			</return>
@@ -249,7 +258,7 @@
 			<argument index="0" name="polygon" type="PoolVector2Array">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [code]polygon[/code]'s vertices are ordered in clockwise order, otherwise returns [code]false[/code].
+				Returns [code]true[/code] if [code]polygon[/code]'s vertices are ordered in clockwise order, otherwise returns [code]false[/code]. If the order is clockwise, the polygon can be interpreted as an inner polygon (hole), otherwise it's an outer polygon (boundary).
 			</description>
 		</method>
 		<method name="line_intersects_line_2d">


### PR DESCRIPTION
Required for #29867 to work for calculating the inertia of polygon shapes.

Also see https://github.com/godotengine/godot/pull/30222#issuecomment-507610468.

---

The area of a polygon is tightly connected with polygon orientation as it's often used to determine whether polygon's vertices are ordered in clockwise or counterclockwise order.

![GIF](https://user-images.githubusercontent.com/17108460/60513800-c26c5e00-9ce0-11e9-9ade-1ec976f499cb.gif)

On the animation you can see the example when using methods like `offset_polyline_2d` (deflating a polyline) with parameters set to `END_JOINED` which would result in outer and inner polygons to be produced (a donut). The area of those polygons determines the actual area as outer polygon will have positive area, while inner polygons will have negative area.

@raphael10241024 done!