### PR TITLE
ConnectionsDock: Add tooltip with signal description

### DIFF
--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -106,6 +106,13 @@ public:
 
 //////////////////////////////////////////
 
+// Custom Tree needed to use a RichTextLabel as tooltip control
+// when display signal documentation.
+class ConnectionsDockTree : public Tree {
+
+	virtual Control *make_custom_tooltip(const String &p_text) const;
+};
+
 class ConnectionsDock : public VBoxContainer {
 
 	GDCLASS(ConnectionsDock, VBoxContainer);
@@ -123,7 +130,7 @@ class ConnectionsDock : public VBoxContainer {
 	};
 
 	Node *selectedNode;
-	Tree *tree;
+	ConnectionsDockTree *tree;
 	EditorNode *editor;
 
 	ConfirmationDialog *disconnect_all_dialog;
@@ -132,6 +139,8 @@ class ConnectionsDock : public VBoxContainer {
 	PopupMenu *signal_menu;
 	PopupMenu *slot_menu;
 	UndoRedo *undo_redo;
+
+	Map<StringName, Map<StringName, String> > descr_cache;
 
 	void _make_or_edit_connection();
 	void _connect(Connection cToMake);


### PR DESCRIPTION
Suffers from the same issue that the property tooltips used to have in the Inspector, which is that they are not rich formatted, so no line wrapping nor code blocks or hyperlinks.

![Screenshot_20190702_154723](https://user-images.githubusercontent.com/4701338/60517954-d748f180-9ce0-11e9-9af0-9246f25d3f38.png)

In the Inspector this is solved by using a custom `RichTextLabel` control for the tooltip:
https://github.com/godotengine/godot/blob/e9d624d7ce1d56cf134599a62deea1f5a0848019/editor/editor_inspector.cpp#L761-L773

But this is a virtual method of `Control`, and I'm not sure how to define it for the `TreeItem`s in `ConnectionsDialog`.

Fixes #30244.