### PR TITLE
Fix various memory leaks and errors

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4990,6 +4990,20 @@ bool RasterizerSceneGLES3::free(RID p_rid) {
 		reflection_probe_instance_owner.free(p_rid);
 		memdelete(reflection_instance);
 
+	} else if (environment_owner.owns(p_rid)) {
+
+		Environment *environment = environment_owner.get(p_rid);
+
+		environment_owner.free(p_rid);
+		memdelete(environment);
+
+	} else if (gi_probe_instance_owner.owns(p_rid)) {
+
+		GIProbeInstance *gi_probe_instance = gi_probe_instance_owner.get(p_rid);
+
+		gi_probe_instance_owner.free(p_rid);
+		memdelete(gi_probe_instance);
+
 	} else {
 		return false;
 	}

--- a/modules/gdnative/gdnative.h
+++ b/modules/gdnative/gdnative.h
@@ -47,7 +47,7 @@ class GDNative;
 class GDNativeLibrary : public Resource {
 	GDCLASS(GDNativeLibrary, Resource);
 
-	static Map<String, Vector<Ref<GDNative> > > *loaded_libraries;
+	static Map<String, Vector<Ref<GDNative> > > loaded_libraries;
 
 	friend class GDNativeLibraryResourceLoader;
 	friend class GDNative;

--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -145,6 +145,7 @@ Error ContextGL_X11::initialize() {
 				break;
 			}
 		}
+		XFree(fbc);
 		ERR_FAIL_COND_V(!fbconfig, ERR_UNCONFIGURED);
 
 		swa.background_pixmap = None;
@@ -159,6 +160,7 @@ Error ContextGL_X11::initialize() {
 		vi = glXGetVisualFromFBConfig(x11_display, fbc[0]);
 
 		fbconfig = fbc[0];
+		XFree(fbc);
 	}
 
 	int (*oldHandler)(Display *, XErrorEvent *) = XSetErrorHandler(&ctxErrorHandler);

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -410,6 +410,7 @@ Particles2D::Particles2D() {
 
 	particles = VS::get_singleton()->particles_create();
 
+	one_shot = false; // Needed so that set_emitting doesn't access uninitialized values
 	set_emitting(true);
 	set_one_shot(false);
 	set_amount(8);

--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -571,4 +571,5 @@ GIProbe::GIProbe() {
 }
 
 GIProbe::~GIProbe() {
+	VS::get_singleton()->free(gi_probe);
 }

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -411,6 +411,7 @@ Particles::Particles() {
 
 	particles = VS::get_singleton()->particles_create();
 	set_base(particles);
+	one_shot = false; // Needed so that set_emitting doesn't access uninitialized values
 	set_emitting(true);
 	set_one_shot(false);
 	set_amount(8);

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -712,6 +712,7 @@ SoftBody::SoftBody() :
 }
 
 SoftBody::~SoftBody() {
+	PhysicsServer::get_singleton()->free(physics_rid);
 }
 
 void SoftBody::reset_softbody_pin() {

--- a/scene/animation/skeleton_ik.cpp
+++ b/scene/animation/skeleton_ik.cpp
@@ -406,6 +406,7 @@ void SkeletonIK::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			skeleton = Object::cast_to<Skeleton>(get_parent());
+			set_process_priority(1);
 			reload_chain();
 		} break;
 		case NOTIFICATION_INTERNAL_PROCESS: {
@@ -431,8 +432,6 @@ SkeletonIK::SkeletonIK() :
 		skeleton(NULL),
 		target_node_override(NULL),
 		task(NULL) {
-
-	set_process_priority(1);
 }
 
 SkeletonIK::~SkeletonIK() {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -453,9 +453,6 @@ void SceneTree::init() {
 
 	//_quit=false;
 	initialized = true;
-	input_handled = false;
-
-	pause = false;
 
 	root->_set_tree(this);
 	MainLoop::init();
@@ -1986,6 +1983,8 @@ SceneTree::SceneTree() {
 	idle_process_time = 1;
 
 	root = NULL;
+	input_handled = false;
+	pause = false;
 	current_frame = 0;
 	current_event = 0;
 	tree_changed_name = "tree_changed";

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -77,6 +77,8 @@ void VisualServerRaster::free(RID p_rid) {
 		return;
 	if (VSG::scene->free(p_rid))
 		return;
+	if (VSG::scene_render->free(p_rid))
+		return;
 }
 
 /* EVENT QUEUING */


### PR DESCRIPTION
Fixes #30224.
Likely fixes #17767 as well.
Addresses leaks in https://github.com/godotengine/godot/issues/27265#issuecomment-496263636. 
Fixes `set_process_priority` error introduced by #29980.
Also, fix a random leak from `GDNativeLibrary`, by rewriting the Map similar to `ClassDB::default_values`.

And that's about it!