### PR TITLE
AppVeyor: Skip saving cache on non-master branches

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,9 @@ environment:
       TARGET: release_debug
       ARCH: amd64
 
+init:
+  - ps: if ($env:APPVEYOR_REPO_BRANCH -ne "master") { $env:APPVEYOR_CACHE_SKIP_SAVE = "true" }
+
 cache:
   - "%SCONS_CACHE_ROOT%"
 
@@ -26,7 +29,7 @@ before_build:
   - python --version
   - scons --version
   - cl.exe
-  - SET "SCONS_CACHE=%SCONS_CACHE_ROOT%\master"
+  - set "SCONS_CACHE=%SCONS_CACHE_ROOT%\%APPVEYOR_REPO_BRANCH%"
 
 build_script:
-- scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% debug_symbols=no verbose=yes progress=no gdnative_wrapper=yes
+  - scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% debug_symbols=no verbose=yes progress=no gdnative_wrapper=yes


### PR DESCRIPTION
Otherwise we run into situations where commits to stable branches
induce very long build times, as they have to basically build from
scratch but also invalidate the cache for future commits on the
master branch.

This commit also makes the cache folder branch-specific, but since
it's still limited to 1 GB of total cache size, we don't enable it
for non-master, as we would still run into issues with non-master
build invalidating the master cache.