### PR TITLE
Make the AndroidManifest meta-data name attribute settable. 

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -824,11 +824,17 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 							encode_uint32(min_gles3 ? 0x00030000 : 0x00020000, &p_manifest.write[iofs + 16]);
 						}
 
-						if (tname == "meta-data" && attrname == "value") {
+						if (tname == "meta-data" && attrname == "name" && string_table[attr_value] == "xr_mode_metadata_name") {
+							// Update the meta-data 'android:name' attribute based on the selected XR mode.
+							if (xr_mode_index == 1 /* XRMode.OVR */) {
+								string_table.write[attr_value] = "com.samsung.android.vr.application.mode";
+							}
+						}
+
+						if (tname == "meta-data" && attrname == "value" && string_table[attr_value] == "xr_mode_metadata_value") {
+							// Update the meta-data 'android:value' attribute based on the selected XR mode.
 							if (xr_mode_index == 1 /* XRMode.OVR */) {
 								string_table.write[attr_value] = "vr_only";
-							} else {
-								string_table.write[attr_value] = "";
 							}
 						}
 

--- a/platform/android/java/AndroidManifest.xml
+++ b/platform/android/java/AndroidManifest.xml
@@ -25,8 +25,8 @@
 <!--The following values are replaced when Godot exports, modifying them here has no effect. Do these changes in the-->
 <!--export preset. Adding new ones is fine.-->
 
-<!-- Metadata for VR app detection on Oculus devices. This is modified by the exporter based on the selected xr mode. Changing this value here has no effect. -->
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value=""/>
+<!-- XR mode metadata. This is modified by the exporter based on the selected xr mode. DO NOT CHANGE the values here. -->
+        <meta-data android:name="xr_mode_metadata_name" android:value="xr_mode_metadata_value"/>
 
         <activity android:name="org.godotengine.godot.Godot"
                   android:label="@string/godot_project_name_string"


### PR DESCRIPTION
This will facilitate reuse for ARCore integration.