### PR TITLE
Exported Script-type resources will now be treated properly as Scripts in EditorPropertyResource

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2206,7 +2206,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 							}
 						}
 					} else {
-						inherits = "Resource";
+						inherits = "Reference";
 					}
 
 					Node *edited_node = Object::cast_to<Node>(get_edited_object());
@@ -2222,7 +2222,9 @@ void EditorPropertyResource::_menu_option(int p_which) {
 					}
 					// path = <node_or_scene_name>.<property_name>.
 					// The extra period at the end is to prevent the property name from being seen as the type by ScriptCreateDialog
-					path = path + "." + get_edited_property() + ".";
+					String path_property_name = get_edited_property();
+					path_property_name = path_property_name.replace(":", ".").replace("/", ".").replace("\\", ".");
+					path = path + "." + path_property_name + ".";
 
 					ScriptCreateDialog *script_create_dialog = EditorNode::get_singleton()->get_scene_tree_dock()->get_script_create_dialog();
 					script_create_dialog->connect("script_created", this, "_script_created");

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2183,7 +2183,55 @@ void EditorPropertyResource::_menu_option(int p_which) {
 		case OBJ_MENU_NEW_SCRIPT: {
 
 			if (Object::cast_to<Node>(get_edited_object())) {
-				EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(get_edited_object()));
+				if (get_edited_property() == "script") {
+					EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(get_edited_object()));
+				} else {
+					// Copied from editor/scene_tree_dock.cpp#L380 and edited for our purposes
+					// There's a good chance we could merge this back into that code with some modifications
+					//Ref<Script> existing = get_edited_object()->get(get_edited_property());
+					//Script *existing = Object::cast_to<Script>(get_edited_object()->get(get_edited_property()));
+					RES existing = get_edited_object()->get(get_edited_property());
+
+					String inherits;
+					if (existing.is_valid()) {
+						//inherits = existing->get_class();
+						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+							ScriptLanguage *l = ScriptServer::get_language(i);
+							if (l->get_type() == existing->get_class()) {
+								String name = l->get_global_class_name(existing->get_path());
+								if (ScriptServer::is_global_class(name) && EDITOR_GET("interface/editors/derive_script_globals_by_name").operator bool()) {
+									inherits = name;
+								} else if (l->can_inherit_from_file()) {
+									inherits = "\"" + existing->get_path() + "\"";
+								}
+								break;
+							}
+						}
+					} else {
+						inherits = "Resource";
+					}
+
+					Node *edited_node = Object::cast_to<Node>(get_edited_object());
+
+					String path = edited_node->get_filename().get_basename();
+					if (path == "") {
+						String root_path = EditorNode::get_singleton()->get_editor_data().get_edited_scene_root()->get_filename();
+						if (root_path == "") {
+							path = String("res://").plus_file(edited_node->get_name());
+						} else {
+							path = root_path.get_base_dir().plus_file(edited_node->get_name());
+						}
+					}
+					// path = <node_or_scene_name>.<property_name>.
+					// The extra period at the end is to prevent the property name from being seen as the type by ScriptCreateDialog
+					path = path + "." + get_edited_property() + ".";
+
+					ScriptCreateDialog *script_create_dialog = EditorNode::get_singleton()->get_scene_tree_dock()->get_script_create_dialog();
+					script_create_dialog->connect("script_created", this, "_script_created");
+					script_create_dialog->connect("popup_hide", this, "_script_creation_closed");
+					script_create_dialog->config(inherits, path);
+					script_create_dialog->popup_centered();
+				}
 			}
 
 		} break;
@@ -2306,6 +2354,19 @@ void EditorPropertyResource::_resource_preview(const String &p_path, const Ref<T
 			assign->set_text("");
 		}
 	}
+}
+
+void EditorPropertyResource::_script_created(Ref<Script> p_script) {
+
+	// Based partially upon editor/scene_tree_dock.cpp#L1628
+	emit_changed(get_edited_property(), p_script);
+	update_property();
+}
+
+void EditorPropertyResource::_script_creation_closed() {
+	ScriptCreateDialog *script_create_dialog = EditorNode::get_singleton()->get_scene_tree_dock()->get_script_create_dialog();
+	script_create_dialog->disconnect("script_created", this, "_script_created");
+	script_create_dialog->disconnect("popup_hide", this, "_script_creation_closed");
 }
 
 void EditorPropertyResource::_update_menu_items() {
@@ -2833,6 +2894,8 @@ void EditorPropertyResource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_resource_preview"), &EditorPropertyResource::_resource_preview);
 	ClassDB::bind_method(D_METHOD("_resource_selected"), &EditorPropertyResource::_resource_selected);
 	ClassDB::bind_method(D_METHOD("_viewport_selected"), &EditorPropertyResource::_viewport_selected);
+	ClassDB::bind_method(D_METHOD("_script_created"), &EditorPropertyResource::_script_created);
+	ClassDB::bind_method(D_METHOD("_script_creation_closed"), &EditorPropertyResource::_script_creation_closed);
 	ClassDB::bind_method(D_METHOD("_sub_inspector_property_keyed"), &EditorPropertyResource::_sub_inspector_property_keyed);
 	ClassDB::bind_method(D_METHOD("_sub_inspector_resource_selected"), &EditorPropertyResource::_sub_inspector_resource_selected);
 	ClassDB::bind_method(D_METHOD("_sub_inspector_object_id_selected"), &EditorPropertyResource::_sub_inspector_object_id_selected);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2315,7 +2315,7 @@ void EditorPropertyResource::_update_menu_items() {
 
 	menu->clear();
 
-	if (get_edited_property() == "script" && base_type == "Script" && Object::cast_to<Node>(get_edited_object())) {
+	if (base_type == "Script" && Object::cast_to<Node>(get_edited_object())) {
 		menu->add_icon_item(get_icon("Script", "EditorIcons"), TTR("New Script"), OBJ_MENU_NEW_SCRIPT);
 		menu->add_separator();
 	} else if (base_type != "") {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2186,7 +2186,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 				if (get_edited_property() == "script") {
 					EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(get_edited_object()));
 				} else {
-					// Copied from editor/scene_tree_dock.cpp#L380 and edited for our purposes
+					// Copied from editor/scene_tree_dock.cpp#_tool_selected and edited for our purposes
 					// There's a good chance we could merge this back into that code with some modifications
 					//Ref<Script> existing = get_edited_object()->get(get_edited_property());
 					//Script *existing = Object::cast_to<Script>(get_edited_object()->get(get_edited_property()));
@@ -2358,7 +2358,7 @@ void EditorPropertyResource::_resource_preview(const String &p_path, const Ref<T
 
 void EditorPropertyResource::_script_created(Ref<Script> p_script) {
 
-	// Based partially upon editor/scene_tree_dock.cpp#L1628
+	// Based partially upon editor/scene_tree_dock.cpp#_script_created
 	emit_changed(get_edited_property(), p_script);
 	update_property();
 }

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2228,7 +2228,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 
 					ScriptCreateDialog *script_create_dialog = EditorNode::get_singleton()->get_scene_tree_dock()->get_script_create_dialog();
 					script_create_dialog->connect("script_created", this, "_script_created");
-					script_create_dialog->connect("popup_hide", this, "_script_creation_closed");
+					script_create_dialog->connect("popup_hide", this, "_script_creation_closed", varray(), CONNECT_ONESHOT);
 					script_create_dialog->config(inherits, path);
 					script_create_dialog->popup_centered();
 				}
@@ -2366,7 +2366,6 @@ void EditorPropertyResource::_script_created(Ref<Script> p_script) {
 void EditorPropertyResource::_script_creation_closed() {
 	ScriptCreateDialog *script_create_dialog = EditorNode::get_singleton()->get_scene_tree_dock()->get_script_create_dialog();
 	script_create_dialog->disconnect("script_created", this, "_script_created");
-	script_create_dialog->disconnect("popup_hide", this, "_script_creation_closed");
 }
 
 void EditorPropertyResource::_update_menu_items() {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2188,9 +2188,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 				} else {
 					// Copied from editor/scene_tree_dock.cpp#_tool_selected and edited for our purposes
 					// There's a good chance we could merge this back into that code with some modifications
-					//Ref<Script> existing = get_edited_object()->get(get_edited_property());
-					//Script *existing = Object::cast_to<Script>(get_edited_object()->get(get_edited_property()));
-					RES existing = get_edited_object()->get(get_edited_property());
+					Ref<Script> existing = get_edited_object()->get(get_edited_property());
 
 					String inherits;
 					if (existing.is_valid()) {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -574,6 +574,8 @@ class EditorPropertyResource : public EditorProperty {
 	void _resource_preview(const String &p_path, const Ref<Texture> &p_preview, const Ref<Texture> &p_small_preview, ObjectID p_obj);
 	void _resource_selected();
 	void _viewport_selected(const NodePath &p_path);
+	void _script_created(Ref<Script> p_script);
+	void _script_creation_closed();
 
 	void _update_menu_items();
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -419,7 +419,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				}
 			}
 			script_create_dialog->connect("script_created", this, "_script_created");
-			script_create_dialog->connect("popup_hide", this, "_script_creation_closed");
+			script_create_dialog->connect("popup_hide", this, "_script_creation_closed", varray(), CONNECT_ONESHOT);
 			script_create_dialog->config(inherits, path);
 			script_create_dialog->popup_centered();
 
@@ -1650,7 +1650,6 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 
 void SceneTreeDock::_script_creation_closed() {
 	script_create_dialog->disconnect("script_created", this, "_script_created");
-	script_create_dialog->disconnect("popup_hide", this, "_script_creation_closed");
 }
 
 void SceneTreeDock::_toggle_editable_children_from_selection() {


### PR DESCRIPTION
This makes the EditorPropertyResource work properly with exported Script-type resources (that is, properties marked with `export(Script)`).

By default, the ScriptCreateDialog will default "Inherits" to `Resource`. Except, of course, when the property already has a script, where it will default "Inherits" to that script.

By default, the ScriptCreateDialog will default "Path" to `<node_or_scene_name>.<property_name>.` (with a trailing period to prevent the property name from being seen as an extension), with the proper extension being added onto the end by the ScriptCreateDialog (as it already does).

This is a draft because I'd like to make sure everything is in order before it's merged. Please read the review comments below and give me any responses to them that you might have! When the PR is ready for review, I'll merge all the commits and remove the comments I've left behind.