### PR TITLE
Fix parsing of arguments in constant expressions

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -582,7 +582,7 @@ private:
 #endif // DEBUG_ENABLED
 	bool _recover_from_completion();
 
-	bool _parse_arguments(Node *p_parent, Vector<Node *> &p_args, bool p_static, bool p_can_codecomplete = false);
+	bool _parse_arguments(Node *p_parent, Vector<Node *> &p_args, bool p_static, bool p_can_codecomplete = false, bool p_parsing_constant = false);
 	bool _enter_indent_block(BlockNode *p_block = NULL);
 	bool _parse_newline();
 	Node *_parse_expression(Node *p_parent, bool p_static, bool p_allow_assign = false, bool p_parsing_constant = false);


### PR DESCRIPTION
Fixes #8006

Also, remove some somewhat-dead code left after #8217.

Test script which now works:
```gdscript
const a = deg2rad(90.0) # 1.57..
const b = sin(a) # 1
const c = sin(1.57) + cos(1.57) # 1.0..
const d = sin(deg2rad(90.0)) # 1
const e = 32 # 32
const f = pow(2, e) # 2^32
const g = 3.14 # 3.14
const h = sin(1.57) + cos(g) # 0.0...
const i = -1 # -1
const j = sin(1.57) + i # 0.0...
const k = Vector2(i, j) # -1, 0.0...
```