### PR TITLE
Expose ResourceImporter to the scripting API

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -190,6 +190,8 @@ void register_core_types() {
 
 	ClassDB::register_class<JSONParseResult>();
 
+	ClassDB::register_virtual_class<ResourceImporter>();
+
 	ip = IP::create();
 
 	_geometry = memnew(_Geometry);


### PR DESCRIPTION
Fixes #30127

Another option would be to just revert to the previous `GDCLASS(EditorImportPlugin, Reference)`.
