### PR TITLE
Exposed update_cache() of RemoteTransform and RemoteTransform2D

### DIFF
--- a/doc/classes/RemoteTransform.xml
+++ b/doc/classes/RemoteTransform.xml
@@ -10,6 +10,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="force_update_cache">
+			<return type="void">
+			</return>
+			<description>
+				[RemoteTransform] caches the remote node. It may not notice if the remote node disappears; [method force_update_cache] forces it to update the cache again.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="remote_path" type="NodePath" setter="set_remote_node" getter="get_remote_node" default="NodePath(&quot;&quot;)">

--- a/doc/classes/RemoteTransform2D.xml
+++ b/doc/classes/RemoteTransform2D.xml
@@ -10,6 +10,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="force_update_cache">
+			<return type="void">
+			</return>
+			<description>
+				[RemoteTransform2D] caches the remote node. It may not notice if the remote node disappears; [method force_update_cache] forces it to update the cache again.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="remote_path" type="NodePath" setter="set_remote_node" getter="get_remote_node" default="NodePath(&quot;&quot;)">

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -110,7 +110,7 @@ void RemoteTransform2D::_notification(int p_what) {
 
 	switch (p_what) {
 
-		case NOTIFICATION_READY: {
+		case NOTIFICATION_ENTER_TREE: {
 
 			_update_cache();
 
@@ -180,6 +180,10 @@ bool RemoteTransform2D::get_update_scale() const {
 	return update_remote_scale;
 }
 
+void RemoteTransform2D::force_update_cache() {
+	_update_cache();
+}
+
 String RemoteTransform2D::get_configuration_warning() const {
 
 	if (!has_node(remote_node) || !Object::cast_to<Node2D>(get_node(remote_node))) {
@@ -193,6 +197,7 @@ void RemoteTransform2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_remote_node", "path"), &RemoteTransform2D::set_remote_node);
 	ClassDB::bind_method(D_METHOD("get_remote_node"), &RemoteTransform2D::get_remote_node);
+	ClassDB::bind_method(D_METHOD("force_update_cache"), &RemoteTransform2D::force_update_cache);
 
 	ClassDB::bind_method(D_METHOD("set_use_global_coordinates", "use_global_coordinates"), &RemoteTransform2D::set_use_global_coordinates);
 	ClassDB::bind_method(D_METHOD("get_use_global_coordinates"), &RemoteTransform2D::get_use_global_coordinates);

--- a/scene/2d/remote_transform_2d.h
+++ b/scene/2d/remote_transform_2d.h
@@ -69,6 +69,8 @@ public:
 	void set_update_scale(const bool p_update);
 	bool get_update_scale() const;
 
+	void force_update_cache();
+
 	virtual String get_configuration_warning() const;
 
 	RemoteTransform2D();

--- a/scene/3d/remote_transform.cpp
+++ b/scene/3d/remote_transform.cpp
@@ -105,7 +105,7 @@ void RemoteTransform::_notification(int p_what) {
 
 	switch (p_what) {
 
-		case NOTIFICATION_READY: {
+		case NOTIFICATION_ENTER_TREE: {
 
 			_update_cache();
 
@@ -174,6 +174,10 @@ bool RemoteTransform::get_update_scale() const {
 	return update_remote_scale;
 }
 
+void RemoteTransform::force_update_cache() {
+	_update_cache();
+}
+
 String RemoteTransform::get_configuration_warning() const {
 
 	if (!has_node(remote_node) || !Object::cast_to<Spatial>(get_node(remote_node))) {
@@ -187,6 +191,7 @@ void RemoteTransform::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_remote_node", "path"), &RemoteTransform::set_remote_node);
 	ClassDB::bind_method(D_METHOD("get_remote_node"), &RemoteTransform::get_remote_node);
+	ClassDB::bind_method(D_METHOD("force_update_cache"), &RemoteTransform::force_update_cache);
 
 	ClassDB::bind_method(D_METHOD("set_use_global_coordinates", "use_global_coordinates"), &RemoteTransform::set_use_global_coordinates);
 	ClassDB::bind_method(D_METHOD("get_use_global_coordinates"), &RemoteTransform::get_use_global_coordinates);

--- a/scene/3d/remote_transform.h
+++ b/scene/3d/remote_transform.h
@@ -68,6 +68,8 @@ public:
 	void set_update_scale(const bool p_update);
 	bool get_update_scale() const;
 
+	void force_update_cache();
+
 	virtual String get_configuration_warning() const;
 
 	RemoteTransform();


### PR DESCRIPTION
I'm working on a prototype where I have to move many RemoteTransforms around in my scene to affect different nodes. Previously the cached target nodes where not updated and there was no direct way to call for an update.

Changes include:
- exposed `update_cache()` for both RemoteTransform and RemoteTransform2D
- cache will now be rebuilt when the RemoteTransform(2D) is readded to the scene. Does not require workaround to update anymore.

Where manually calling `update_cache()` is still necessary:
- target node is renamed/ moved in the scene and `remote_path` points to an outdated place

Previous workaround:
```gdscript
$RemoteTransform.remote_path = $RemoteTransform.remote_path
# do not remove, this updates cache
```