### PR TITLE
[3.0] Multiplayer API now respects allow_object_decoding

### DIFF
--- a/doc/classes/PacketPeer.xml
+++ b/doc/classes/PacketPeer.xml
@@ -60,6 +60,8 @@
 	</methods>
 	<members>
 		<member name="allow_object_decoding" type="bool" setter="set_allow_object_decoding" getter="is_object_decoding_allowed">
+			If [code]true[/code] the PacketPeer will allow encoding and decoding of object via [method get_var] and [method put_var].
+			[b]WARNING:[/b] Deserialized object can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats (remote code execution).
 		</member>
 	</members>
 	<constants>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1820,10 +1820,10 @@ void SceneTree::_rpc(Node *p_from, int p_to, bool p_unreliable, bool p_set, cons
 
 	if (p_set) {
 		//set argument
-		Error err = encode_variant(*p_arg[0], NULL, len);
+		Error err = encode_variant(*p_arg[0], NULL, len, !network_peer->is_object_decoding_allowed());
 		ERR_FAIL_COND(err != OK);
 		MAKE_ROOM(ofs + len);
-		encode_variant(*p_arg[0], &packet_cache[ofs], len);
+		encode_variant(*p_arg[0], &packet_cache[ofs], len, !network_peer->is_object_decoding_allowed());
 		ofs += len;
 
 	} else {
@@ -1832,10 +1832,10 @@ void SceneTree::_rpc(Node *p_from, int p_to, bool p_unreliable, bool p_set, cons
 		packet_cache[ofs] = p_argcount;
 		ofs += 1;
 		for (int i = 0; i < p_argcount; i++) {
-			Error err = encode_variant(*p_arg[i], NULL, len);
+			Error err = encode_variant(*p_arg[i], NULL, len, !network_peer->is_object_decoding_allowed());
 			ERR_FAIL_COND(err != OK);
 			MAKE_ROOM(ofs + len);
-			encode_variant(*p_arg[i], &packet_cache[ofs], len);
+			encode_variant(*p_arg[i], &packet_cache[ofs], len, !network_peer->is_object_decoding_allowed());
 			ofs += len;
 		}
 	}
@@ -2018,7 +2018,7 @@ void SceneTree::_network_process_packet(int p_from, const uint8_t *p_packet, int
 
 					ERR_FAIL_COND(ofs >= p_packet_len);
 					int vlen;
-					Error err = decode_variant(args[i], &p_packet[ofs], p_packet_len - ofs, &vlen);
+					Error err = decode_variant(args[i], &p_packet[ofs], p_packet_len - ofs, &vlen, network_peer->is_object_decoding_allowed());
 					ERR_FAIL_COND(err != OK);
 					//args[i]=p_packet[3+i];
 					argp[i] = &args[i];
@@ -2044,7 +2044,7 @@ void SceneTree::_network_process_packet(int p_from, const uint8_t *p_packet, int
 				ERR_FAIL_COND(ofs >= p_packet_len);
 
 				Variant value;
-				decode_variant(value, &p_packet[ofs], p_packet_len - ofs);
+				decode_variant(value, &p_packet[ofs], p_packet_len - ofs, NULL, network_peer->is_object_decoding_allowed());
 
 				bool valid;
 


### PR DESCRIPTION
Also adds doc about allow_object_decoding in PacketPeer.

Limited fix for #27395 dedicated to 3.0 branch.
`bytes2var`, `base64_to_variant` and `File.get_var` are still unsafe, but the high level multiplayer API is now safe.
People using functions that are still unsafe should update to `3.1` (where those functions are safe and have extra parameter to make them unsafe) or get the raw bytes, check that it's not an object type ([first four bytes != 17](https://docs.godotengine.org/en/3.0/tutorials/misc/binary_serialization_api.html)) and only then use `var2bytes`.
This is done to avoid breaking compatibility as much as possible, especially with GDNative plugins.