### PR TITLE
Implemented sub-functions for visual shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -36,6 +36,7 @@
 #include "editor/property_editor.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/tree.h"
 #include "scene/resources/visual_shader.h"
@@ -58,10 +59,13 @@ class VisualShaderEditor : public VBoxContainer {
 	CustomPropertyEditor *property_editor;
 	int editing_node;
 	int editing_port;
+	int custom_function_input_count;
 
 	Ref<VisualShader> visual_shader;
 	GraphEdit *graph;
 	ToolButton *add_node;
+	ToolButton *add_function;
+	ToolButton *remove_function;
 
 	OptionButton *edit_type;
 
@@ -74,20 +78,45 @@ class VisualShaderEditor : public VBoxContainer {
 
 	ConfirmationDialog *members_dialog;
 	MenuButton *tools;
+	ConfirmationDialog *function_create_dialog;
+	ConfirmationDialog *function_remove_dialog;
 
 	enum ToolsMenuOptions {
 		EXPAND_ALL,
 		COLLAPSE_ALL
 	};
 
+	// node's member dialog entries
 	Tree *members;
 	AcceptDialog *alert;
 	LineEdit *node_filter;
 	RichTextLabel *node_desc;
 
+	// function create dialog entries
+	LineEdit *func_name_box;
+	OptionButton *func_output_type_box;
+	VBoxContainer *func_input_vbox;
+
+	// function change dialog entries
+	LineEdit *func_name_box2;
+	OptionButton *func_output_type_box2;
+	VBoxContainer *func_input_vbox2;
+
+	// function delete dialog entries
+	Label *function_remove_attention;
+
+	void _set_current_function(int p_idx);
 	void _tools_menu_option(int p_idx);
 	void _show_members_dialog(bool at_mouse_pos);
+	void _show_function_create_dialog();
+	void _show_function_setup_dialog();
+	void _show_function_remove_dialog();
 
+	void _add_func_input();
+	void _remove_func_input(int p_idx);
+	void _deselect_input_names();
+
+	void _update_func_list();
 	void _update_graph();
 
 	struct AddOption {
@@ -111,6 +140,7 @@ class VisualShaderEditor : public VBoxContainer {
 			sub_category = p_sub_category;
 			description = p_description;
 			sub_func = p_sub_func;
+			sub_func_str = String("");
 			return_type = p_return_type;
 			mode = p_mode;
 			func = p_func;
@@ -191,6 +221,8 @@ class VisualShaderEditor : public VBoxContainer {
 	void _remove_output_port(int p_node, int p_port);
 	void _change_output_port_type(int p_type, int p_node, int p_port);
 	void _change_output_port_name(const String &p_text, Object *line_edit, int p_node, int p_port);
+	void _set_call(int p_id, int p_node);
+	void _goto_call(int p_node);
 
 	void _expression_focus_out(Object *text_edit, int p_node);
 
@@ -206,6 +238,15 @@ class VisualShaderEditor : public VBoxContainer {
 	void _member_unselected();
 	void _member_create();
 	void _member_cancel();
+
+	int _get_function_index() const;
+
+	bool _check_func_name(const String &p_name, ConfirmationDialog *caller);
+	void _function_create();
+	void _function_remove();
+
+	String _get_current_func_name() const;
+	int _get_current_func_type() const;
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -527,6 +527,7 @@ void register_scene_types() {
 	ClassDB::register_class<VisualShaderNodeSwitch>();
 	ClassDB::register_class<VisualShaderNodeFresnel>();
 	ClassDB::register_class<VisualShaderNodeExpression>();
+	ClassDB::register_class<VisualShaderNodeCall>();
 
 	ClassDB::register_class<ShaderMaterial>();
 	ClassDB::register_virtual_class<CanvasItem>();


### PR DESCRIPTION
This commit adds the ability to define and call custom functions inside the VisualShader. This will signfically ease out writing the big shaders by giving the user way to define parts of them in separate functions and way to call them from standart Vertex/Fragment/Light and itself. 

![vs_new](https://user-images.githubusercontent.com/3036176/60665838-3e47e100-9e6e-11e9-853b-6ce3a2e3f638.png)

So lets explain what this PR will do.

- Added new button 'Add function...' on the top bar

![image](https://user-images.githubusercontent.com/3036176/60665949-836c1300-9e6e-11e9-9b06-d66b26e6b886.png)

- When pressed - the new dialog will be popup

![image](https://user-images.githubusercontent.com/3036176/60665997-a0a0e180-9e6e-11e9-95d7-c19101725488.png)


Here you can configure the function name, input ports and output type.

![image](https://user-images.githubusercontent.com/3036176/60666032-badabf80-9e6e-11e9-82ed-26c7bda2ab43.png)

- When you press "Create and open"  your function will be opened for edit, and pushed to the graph list where you can easily get it. If you make any mistake at previous step and entered invalid func name or repeat the input name twise, the alert will popup.

![image](https://user-images.githubusercontent.com/3036176/60666701-54ef3780-9e70-11e9-866f-775c7622bd8a.png)

The inputs are automatically created for user comfortability. ^^

- When you finish to edit your function you can call it by using new 'Call' node located under the 'Special' tab

![image](https://user-images.githubusercontent.com/3036176/60667086-4a816d80-9e71-11e9-8cfd-714ebcd94150.png)

- The _Call_ node provide the updated list of the functions. When you change the selection, ports related to that function will be created.

![image](https://user-images.githubusercontent.com/3036176/60667147-77358500-9e71-11e9-8b23-2d165442a2fa.png)

- If your function have multiple input ports and not all of them are used - the unused will be setted to its default values.

![image](https://user-images.githubusercontent.com/3036176/60668180-ff1c8e80-9e73-11e9-9722-4856a1d9d82b.png)

**Note**: _The little pencil (Edit) button allows user to jump into the selected function_.

- You cannot use _Call_ to invoke function itself cuz the recursion is not allowed.

![image](https://user-images.githubusercontent.com/3036176/60667502-5588cd80-9e72-11e9-8131-9b7fe28bd8a0.png)

- The _Remove Function_ button provide the way to remove the function - your undo history will be wipe out, to prevent connection errors. Every Call node in all functions including main (vertex/fragment/light), will be checked up and if its calling the removed function they will be pointed to [None]. 

**Note**: _This button is visible only when the custom function is selected - the vertex/fragment/light is obviously cannot be removed_

![image](https://user-images.githubusercontent.com/3036176/60668328-60446200-9e74-11e9-825f-765c23553215.png)


**Note**: _The order of function is important since you cannot call the function located below the caller. There should be a way to lift up and down them, but at this time I pretty tired, and need to rest (will release it later as separate PR)._

**Note**: _There also no way to add/remove/change inputs other than directly edit visual shader file. Also delayed for separate PR.._

I spended several days to create this submission - I changed and added many internal visual shader functions  for help me make it possible, I tested them as much as I can. I think there is no critical bugs which may make the engine crash.. still - If the other contributors could test this PR - that would be pretty good !

Exposed classes/methods:

- **VisualShaderNodeCall**
- **bool VisualShaderGroupBase->is_resizable**
- **bool VisualShaderGroupBase->is_editable**