### PR TITLE
HTTPRequest add timeout

### DIFF
--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -35,6 +35,7 @@
 #include "core/os/file_access.h"
 #include "core/os/thread.h"
 #include "node.h"
+#include "scene/main/timer.h"
 
 class HTTPRequest : public Node {
 
@@ -53,7 +54,8 @@ public:
 		RESULT_REQUEST_FAILED,
 		RESULT_DOWNLOAD_FILE_CANT_OPEN,
 		RESULT_DOWNLOAD_FILE_WRITE_ERROR,
-		RESULT_REDIRECT_LIMIT_REACHED
+		RESULT_REDIRECT_LIMIT_REACHED,
+		RESULT_TIMEOUT
 
 	};
 
@@ -92,6 +94,8 @@ private:
 
 	int max_redirects;
 
+	int timeout;
+
 	void _redirect_request(const String &p_new_url);
 
 	bool _handle_response(bool *ret_value);
@@ -127,6 +131,13 @@ public:
 
 	void set_max_redirects(int p_max);
 	int get_max_redirects() const;
+
+	Timer *timer;
+
+	void set_timeout(int p_timeout);
+	int get_timeout();
+
+	void _timeout();
 
 	int get_downloaded_bytes() const;
 	int get_body_size() const;


### PR DESCRIPTION
Although this should have been implemented in HTTPClient calls instead of HTTPRequest, i realized that halfway through. I can rewrite it for HTTPClient instead if desired.
Also, timeout could have been a parameter for the request() method instead of a property but i figured out that there is no reason setting the timeout for each request.

**EDIT:** A custom response code should be added for this one? Like RESPONSE_CUSTOM_TIMEOUT since its not a standard socket error, we are forcefully closing the connection after the timeout is reached.
@Faless please review.

This should close #30276