### PR TITLE
Use CheckBoxes in the editor instead of CheckButtons when applicable

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5273,17 +5273,17 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	VBoxContainer *cleanup_vb = memnew(VBoxContainer);
 	cleanup_dialog->add_child(cleanup_vb);
 
-	cleanup_keys = memnew(CheckButton);
+	cleanup_keys = memnew(CheckBox);
 	cleanup_keys->set_text(TTR("Remove invalid keys"));
 	cleanup_keys->set_pressed(true);
 	cleanup_vb->add_child(cleanup_keys);
 
-	cleanup_tracks = memnew(CheckButton);
+	cleanup_tracks = memnew(CheckBox);
 	cleanup_tracks->set_text(TTR("Remove unresolved and empty tracks"));
 	cleanup_tracks->set_pressed(true);
 	cleanup_vb->add_child(cleanup_tracks);
 
-	cleanup_all = memnew(CheckButton);
+	cleanup_all = memnew(CheckBox);
 	cleanup_all->set_text(TTR("Clean-up all animations"));
 	cleanup_vb->add_child(cleanup_all);
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -439,9 +439,9 @@ class AnimationTrackEditor : public VBoxContainer {
 	SpinBox *optimize_max_angle;
 
 	ConfirmationDialog *cleanup_dialog;
-	CheckButton *cleanup_keys;
-	CheckButton *cleanup_tracks;
-	CheckButton *cleanup_all;
+	CheckBox *cleanup_keys;
+	CheckBox *cleanup_tracks;
+	CheckBox *cleanup_all;
 
 	ConfirmationDialog *scale_dialog;
 	SpinBox *scale;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6258,7 +6258,7 @@ EditorNode::EditorNode() {
 	file_export_lib->set_title(TTR("Export Library"));
 	file_export_lib->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	file_export_lib->connect("file_selected", this, "_dialog_action");
-	file_export_lib_merge = memnew(CheckButton);
+	file_export_lib_merge = memnew(CheckBox);
 	file_export_lib_merge->set_text(TTR("Merge With Existing"));
 	file_export_lib_merge->set_pressed(true);
 	file_export_lib->get_vbox()->add_child(file_export_lib_merge);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -330,7 +330,7 @@ private:
 	EditorFileDialog *file_export;
 	EditorFileDialog *file_export_lib;
 	EditorFileDialog *file_script;
-	CheckButton *file_export_lib_merge;
+	CheckBox *file_export_lib_merge;
 	LineEdit *file_export_password;
 	String current_path;
 	MenuButton *update_spinner;

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -131,7 +131,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	vbc_substitute->set_name(TTR("Substitute"));
 	tabc_features->add_child(vbc_substitute);
 
-	cbut_substitute = memnew(CheckButton);
+	cbut_substitute = memnew(CheckBox);
 	cbut_substitute->set_text(TTR("Substitute"));
 	vbc_substitute->add_child(cbut_substitute);
 
@@ -246,7 +246,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	vbc_regex->set_custom_minimum_size(Size2(0, feature_min_height));
 	tabc_features->add_child(vbc_regex);
 
-	cbut_regex = memnew(CheckButton);
+	cbut_regex = memnew(CheckBox);
 	cbut_regex->set_text(TTR("Regular Expressions"));
 	vbc_regex->add_child(cbut_regex);
 
@@ -258,7 +258,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	vbc_process->set_custom_minimum_size(Size2(0, feature_min_height));
 	tabc_features->add_child(vbc_process);
 
-	cbut_process = memnew(CheckButton);
+	cbut_process = memnew(CheckBox);
 	cbut_process->set_text(TTR("Post-Process"));
 	vbc_process->add_child(cbut_process);
 

--- a/editor/rename_dialog.h
+++ b/editor/rename_dialog.h
@@ -32,7 +32,6 @@
 #define RENAME_DIALOG_H
 
 #include "scene/gui/check_box.h"
-#include "scene/gui/check_button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/spin_box.h"
@@ -75,9 +74,9 @@ class RenameDialog : public ConfirmationDialog {
 
 	TabContainer *tabc_features;
 
-	CheckButton *cbut_substitute;
-	CheckButton *cbut_regex;
-	CheckButton *cbut_process;
+	CheckBox *cbut_substitute;
+	CheckBox *cbut_regex;
+	CheckBox *cbut_process;
 	CheckBox *chk_per_level_counter;
 
 	Button *but_insert_name;

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -742,8 +742,8 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	/* Built-in Script */
 
-	internal = memnew(CheckButton);
-	internal->set_h_size_flags(0);
+	internal = memnew(CheckBox);
+	internal->set_text(TTR("On"));
 	internal->connect("pressed", this, "_built_in_pressed");
 	internal_label = memnew(Label(TTR("Built-in Script")));
 	internal_label->set_align(Label::ALIGN_RIGHT);

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -33,7 +33,7 @@
 
 #include "editor/editor_file_dialog.h"
 #include "editor/editor_settings.h"
-#include "scene/gui/check_button.h"
+#include "scene/gui/check_box.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/line_edit.h"
@@ -57,7 +57,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	LineEdit *file_path;
 	Button *path_button;
 	EditorFileDialog *file_browse;
-	CheckButton *internal;
+	CheckBox *internal;
 	Label *internal_label;
 	VBoxContainer *path_vb;
 	AcceptDialog *alert;


### PR DESCRIPTION
[CheckButtons should only be used if toggling them has an immediate effect.](https://uxmovement.com/buttons/when-to-use-a-switch-or-checkbox/) Otherwise, CheckBoxes should be used.

Follow-up to #25175.