### PR TITLE
Smarter node placement after duplicating

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -572,6 +572,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				Node *node = E->get();
 				Node *parent = node->get_parent();
+				Node *selection_tail = _get_selection_group_tail(node, selection);
 
 				List<Node *> owned;
 				node->get_owned_by(node->get_owner(), &owned);
@@ -589,7 +590,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				dup->set_name(parent->validate_child_name(dup));
 
-				editor_data->get_undo_redo().add_do_method(parent, "add_child_below_node", node, dup);
+				editor_data->get_undo_redo().add_do_method(parent, "add_child_below_node", selection_tail, dup);
 				for (List<Node *>::Element *F = owned.front(); F; F = F->next()) {
 
 					if (!duplimap.has(F->get())) {
@@ -597,7 +598,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						continue;
 					}
 					Node *d = duplimap[F->get()];
-					editor_data->get_undo_redo().add_do_method(d, "set_owner", node->get_owner());
+					editor_data->get_undo_redo().add_do_method(d, "set_owner", selection_tail->get_owner());
 				}
 				editor_data->get_undo_redo().add_do_method(editor_selection, "add_node", dup);
 				editor_data->get_undo_redo().add_undo_method(parent, "remove_child", dup);
@@ -1882,6 +1883,23 @@ void SceneTreeDock::_selection_changed() {
 		editor->push_item(NULL);
 	}
 	_update_script_button();
+}
+
+Node *SceneTreeDock::_get_selection_group_tail(Node *p_node, List<Node *> p_list) {
+
+	Node *tail = p_node;
+	Node *parent = tail->get_parent();
+
+	for (int i = p_node->get_position_in_parent(); i < parent->get_child_count(); i++) {
+		Node *sibling = parent->get_child(i);
+
+		if (p_list.find(sibling))
+			tail = sibling;
+		else
+			break;
+	}
+
+	return tail;
 }
 
 void SceneTreeDock::_create() {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -195,6 +195,7 @@ class SceneTreeDock : public VBoxContainer {
 	bool _validate_no_foreign();
 	void _selection_changed();
 	void _update_script_button();
+	Node *_get_selection_group_tail(Node *p_node, List<Node *> p_list);
 
 	void _fill_path_renames(Vector<StringName> base_path, Vector<StringName> new_base_path, Node *p_node, List<Pair<NodePath, NodePath> > *p_renames);
 


### PR DESCRIPTION
Closes #28549

![Dup1](https://user-images.githubusercontent.com/2223172/60679702-e5397680-9e88-11e9-97b0-644943c1bb5b.gif)

![Dup2](https://user-images.githubusercontent.com/2223172/60679705-e79bd080-9e88-11e9-90c6-a38a01480d3e.gif)

![Dup3](https://user-images.githubusercontent.com/2223172/60679707-e9659400-9e88-11e9-84f4-9037ed16317b.gif)

...

\>\_>
\<\_<

As you can see in the gifs, I didn't get the ordering right. This is because editor selection is sorted in some random fashion and I have no idea what to do about it .-.
Other than that, it works perfectly.