### PR TITLE
SceneTreeDock will reset the ScriptCreateDialog's inheritance base type whenever it opens the dialog

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -439,6 +439,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 			script_create_dialog->connect("script_created", this, "_script_created");
 			script_create_dialog->connect("popup_hide", this, "_script_creation_closed");
+			script_create_dialog->set_inheritance_base_type("Node");
 			script_create_dialog->config(inherits, path);
 			script_create_dialog->popup_centered();
 


### PR DESCRIPTION
As it turns out, I missed a bit in my previous PR #30196. In trying to ensure editor plugins wouldn't conflict with how the SceneTreeDock normally operates, I missed that the ScriptCreateDialog could have its inheritance base type set by editor plugins, which could potentially mess with SceneTreeDock's ability to function properly.

This makes the SceneTreeDock reset the inheritance base type to "Node" whenever it's opened.

As an aside, I decided to avoid removing the line that sets it when the SceneTreeDock is first being created (see [here](https://github.com/godotengine/godot/blob/d2e915623a32a18e334acd03c6ad2a3347a4682c/editor/scene_tree_dock.cpp#L2751)), as I don't want to mess editor plugins that rely on that being the default. Please let me know if I should remove it anyways.