### PR TITLE
Got replace-all working without breaking search

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -341,7 +341,11 @@ bool FindReplaceBar::search_prev() {
 bool FindReplaceBar::search_next() {
 
 	uint32_t flags = 0;
-	String text = get_search_text();
+	String text;
+	if (replace_all_mode)
+		text = get_replace_text();
+	else
+		text = get_search_text();
 
 	if (is_whole_words())
 		flags |= TextEdit::SEARCH_WHOLE_WORDS;


### PR DESCRIPTION
Fixes #29922 .
This resolves the issue, but I do think better logic for both search functions and replace functions might exist.
Made a pull request because I feel replace_all is one of the basic and important feature of a code editor and needs to be working properly ASAP.
