### PR TITLE
Dim the editor window while it's quitting

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2622,6 +2622,13 @@ void EditorNode::_exit_editor() {
 	exiting = true;
 	resource_preview->stop(); //stop early to avoid crashes
 	_save_docks();
+
+	// Dim the editor window while it's quitting to make it clearer that it's busy.
+	// No transition is applied, as the effect needs to be visible immediately
+	float c = 1.0f - float(EDITOR_GET("interface/editor/dim_amount"));
+	Color dim_color = Color(c, c, c);
+	gui_base->set_modulate(dim_color);
+
 	get_tree()->quit();
 }
 


### PR DESCRIPTION
Follow-up to #29636.

This makes it clearer that the editor window is busy while it's quitting (which can take a while on slower PCs). This also makes it feel more responsive to user input.

Note that the effect is only visible if **Interface → Editor → Quit Confirmation** is disabled in the Editor Settings, as the quit confirmation already makes the editor window dim while quitting.