### PR TITLE
Add fluent syntax option for yield() directive

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1920,6 +1920,12 @@ static void _find_identifiers_in_base(const GDScriptCompletionContext &p_context
 		r_result.insert(option.display, option);
 	}
 
+	if (!_static && base_type.kind != GDScriptParser::DataType::BUILTIN) {
+		ScriptCodeCompletionOption option("yield", ScriptCodeCompletionOption::KIND_FUNCTION);
+		option.insert_text += "(";
+		r_result.insert(option.display, option);
+	}
+
 	while (base_type.has_type) {
 		switch (base_type.kind) {
 			case GDScriptParser::DataType::CLASS: {
@@ -2169,7 +2175,7 @@ static void _find_identifiers(const GDScriptCompletionContext &p_context, bool p
 
 	static const char *_keywords[] = {
 		"and", "in", "not", "or", "false", "PI", "TAU", "INF", "NAN", "self", "true", "as", "assert",
-		"breakpoint", "class", "extends", "is", "func", "preload", "setget", "signal", "tool", "yield",
+		"breakpoint", "class", "extends", "is", "func", "preload", "setget", "signal", "tool",
 		"const", "enum", "export", "onready", "static", "var", "break", "continue", "if", "elif",
 		"else", "for", "pass", "return", "match", "while", "remote", "sync", "master", "puppet", "slave",
 		"remotesync", "mastersync", "puppetsync",
@@ -2779,6 +2785,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 					}
 				}
 			}
+			r_forced = options.size() > 0;
 		} break;
 		case GDScriptParser::COMPLETION_RESOURCE_PATH: {
 			if (EditorSettings::get_singleton()->get("text_editor/completion/complete_file_paths")) {

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1284,11 +1284,11 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 #ifdef DEBUG_ENABLED
 					if (argobj->get_type() != Variant::OBJECT) {
-						err_text = "First argument of yield() not of type object.";
+						err_text = "Subject of yield() not of type object.";
 						OPCODE_BREAK;
 					}
 					if (argname->get_type() != Variant::STRING) {
-						err_text = "Second argument of yield() not a string (for signal name).";
+						err_text = "Signal name in yield() not a string.";
 						OPCODE_BREAK;
 					}
 #endif
@@ -1298,18 +1298,18 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 #ifdef DEBUG_ENABLED
 					if (!obj) {
-						err_text = "First argument of yield() is null.";
+						err_text = "Subject of yield() is null.";
 						OPCODE_BREAK;
 					}
 					if (ScriptDebugger::get_singleton()) {
 						if (!ObjectDB::instance_validate(obj)) {
-							err_text = "First argument of yield() is a previously freed instance.";
+							err_text = "Subject of yield() is a previously freed instance.";
 							OPCODE_BREAK;
 						}
 					}
 					if (signal.length() == 0) {
 
-						err_text = "Second argument of yield() is an empty string (for signal name).";
+						err_text = "Signal name in yield() is an empty string.";
 						OPCODE_BREAK;
 					}
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -277,7 +277,6 @@ bool GDScriptTokenizer::is_token_literal(int p_offset, bool variable_safe) const
 		case TK_PR_FUNCTION:
 		case TK_PR_EXTENDS:
 		case TK_PR_ASSERT:
-		case TK_PR_YIELD:
 		case TK_PR_VAR:
 
 		case TK_CF_IF:


### PR DESCRIPTION
GDScript's current syntax to yield with signals is `yield(subject, signal)`. This style can be difficult to read when calling `yield()` with an expression that takes a lot of visual space, especially when `yield()` calls are nested.

```gdscript
yield(yield(foo(), "completed").bar(), "completed")
```

This change adds a second "fluent" syntax option for yielding with signals that looks like `subject.yield(signal)`.

```gdscript
foo().yield("completed").bar().yield("completed")
```

If the user wishes to wait on the "completed" signal of a GDScriptFunctionState (a very common use case), the argument between the parenthesis can be omitted.

```gdscript
foo().yield().bar().yield()
```

`yield()` still works the same as before under the hood - this is just a cosmetic enhancement.