### PR TITLE
Prevent GLES2 bool uniforms from having a precision type set.

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -318,7 +318,7 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 				// use highp if no precision is specified to prevent different default values in fragment and vertex shader
 				SL::DataPrecision precision = E->get().precision;
-				if (precision == SL::PRECISION_DEFAULT) {
+				if (precision == SL::PRECISION_DEFAULT && E->get().type != SL::TYPE_BOOL) {
 					precision = SL::PRECISION_HIGHP;
 				}
 


### PR DESCRIPTION
When setting the default precision type for uniforms (before compiling the shader) prevent boolean uniforms from having one set. Booleans can't have a precision type and on some Android devices this caused a compilation failure.

Regression from https://github.com/godotengine/godot/pull/29014
Fixes #30317