### PR TITLE
Improve the CSG shape gizmo drawing

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -557,6 +557,7 @@ void CSGShape::set_operation(Operation p_operation) {
 
 	operation = p_operation;
 	_make_dirty();
+	update_gizmo();
 }
 
 CSGShape::Operation CSGShape::get_operation() const {


### PR DESCRIPTION
The gizmo colors now depend on the operation. Subtraction will result in an inverted gizmo color, whereas intersection is now displayed as white.

A solid translucent overlay is now drawn over a selected node to make it easier to distinguish.

Note that Z-fighting may be visible in some cases. I tried to solve this by using the grow property, but it didn't have any effect (maybe because the mesh lacks normals?).

## Preview

### Union

![csg_union](https://user-images.githubusercontent.com/180032/60701842-6599bf00-9efd-11e9-89fc-7cb2f8ceb903.png)

### Intersection

![csg_intersection](https://user-images.githubusercontent.com/180032/60701817-4dc23b00-9efd-11e9-89bd-645e219e1158.png)

### Subtraction

![csg_subtraction](https://user-images.githubusercontent.com/180032/60701821-4ef36800-9efd-11e9-957c-986b19b91b6a.png)