### PR TITLE
when doing Vector3 slerp it is not necessary to have it normalized.

### DIFF
--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -219,10 +219,6 @@ Vector3 Vector3::linear_interpolate(const Vector3 &p_b, real_t p_t) const {
 }
 
 Vector3 Vector3::slerp(const Vector3 &p_b, real_t p_t) const {
-#ifdef MATH_CHECKS
-	ERR_FAIL_COND_V(!is_normalized(), Vector3());
-#endif
-
 	real_t theta = angle_to(p_b);
 	return rotated(cross(p_b).normalized(), theta * p_t);
 }


### PR DESCRIPTION
Working again with Vector3 slerp method.
I was testing it out, and found out that it required to have the vector normalized in order to do the slerp, but it is actually not necessary.

Removed the requirement, tested with this project, seems to be ok:
[test_SLERP.zip](https://github.com/godotengine/godot/files/3363468/test_SLERP.zip)

See also my previous pull request (that is related to this one):
https://github.com/godotengine/godot/pull/29583