### PR TITLE
Set a default value for project name when installing a project.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -765,6 +765,7 @@ public:
 
 				set_title(TTR("Install Project:") + " " + zip_title);
 				get_ok()->set_text(TTR("Install & Edit"));
+				project_name->set_text(zip_title);
 				name_container->show();
 				install_path_container->hide();
 				rasterizer_container->hide();


### PR DESCRIPTION
If I download a template named KewlGame, we should not force the user to have to type that name in order to complete the installation process.  The user can still rename it if they wish to but we should be providing a default value.  This quality of life enhancement will improve the workflow for newcomers to Godot who typically attempt to install a template as their first action within the program.