### PR TITLE
Fix parsing of enums allowing for juxtaposed identifiers

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -5084,6 +5084,9 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 
 						if (tokenizer->get_token() == GDScriptTokenizer::TK_COMMA) {
 							tokenizer->advance();
+						} else if (tokenizer->is_token_literal(0, true)) {
+							_set_error("Unexpected identifier");
+							return;
 						}
 
 						if (enum_name != "") {


### PR DESCRIPTION
Fixes #28727