### PR TITLE
MultiNodeEdit now only shows properties with the exact same PropertyInfo data

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -179,6 +179,15 @@ struct PropertyInfo {
 			usage(PROPERTY_USAGE_DEFAULT) {
 	}
 
+	bool operator==(const PropertyInfo &p_info) const {
+		return ((type == p_info.type) &&
+				(name == p_info.name) &&
+				(class_name == p_info.class_name) &&
+				(hint == p_info.hint) &&
+				(hint_string == p_info.hint_string) &&
+				(usage == p_info.usage));
+	}
+
 	bool operator<(const PropertyInfo &p_info) const {
 		return name < p_info.name;
 	}

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -152,7 +152,9 @@ void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 				datas.push_back(usage.getptr(F->get().name));
 			}
 
-			usage[F->get().name].uses++;
+			// Make sure only properties with the same exact PropertyInfo data will appear
+			if (usage[F->get().name].info == F->get())
+				usage[F->get().name].uses++;
 		}
 
 		nc++;


### PR DESCRIPTION
Fixes #30345.

~~I considered making it only check for type, but I felt that might still create conflict, so I have it check the hint, hint_string, and usage as well.~~ It now makes sure the two `PropertyInfo`s are the same.