### PR TITLE
Give up finding item if started at beginning

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -754,7 +754,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 				for (int i = current + 1; i <= items.size(); i++) {
 					if (i == items.size()) {
-						if (current == 0)
+						if (current == 0 || current == -1)
 							break;
 						else
 							i = 0;


### PR DESCRIPTION
When the current item is -1, then the loop will infinitely repeat,
constantly setting i to zero and never exiting.
Fixes #30366 