### PR TITLE
iOS Microphone and Camera privileges improvements

### DIFF
--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -36,6 +36,8 @@
 	<string>$camera_usage_description</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$photolibrary_usage_description</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>$microphone_usage_description</string>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UIStatusBarHidden</key>

--- a/platform/iphone/camera_ios.mm
+++ b/platform/iphone/camera_ios.mm
@@ -397,6 +397,22 @@ void CameraIOS::update_feeds() {
 };
 
 CameraIOS::CameraIOS() {
+	// check if we have our usage description
+	NSString *usage_desc = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSCameraUsageDescription"];
+	if (usage_desc == NULL) {
+		// don't initialise if we don't get anything
+		print_line("No NSCameraUsageDescription key in pList, no access to cameras.");
+		return;
+	} else if (usage_desc.length == 0) {
+		// don't initialise if we don't get anything
+		print_line("Empty NSCameraUsageDescription key in pList, no access to cameras.");
+		return;
+	}
+
+	// now we'll request access.
+	// If this is the first time the user will be prompted with the string (iOS will read it).
+	// Once a decision is made it is returned. If the user wants to change it later on they
+	// need to go into setting.
 	print_line("Requesting Camera permissions");
 
 	[AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -268,8 +268,9 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/in_app_purchases"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/push_notifications"), false));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/camera_usage_description"), "Godot would like to use your camera"));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/photolibrary_usage_description"), "Godot would like to use your photos"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/camera_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need to use the camera"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/microphone_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need to use the microphone"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/photolibrary_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need access to the photo library"), ""));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/portrait"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/landscape_left"), true));
@@ -398,6 +399,9 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].find("$camera_usage_description") != -1) {
 			String description = p_preset->get("privacy/camera_usage_description");
 			strnew += lines[i].replace("$camera_usage_description", description) + "\n";
+		} else if (lines[i].find("$microphone_usage_description") != -1) {
+			String description = p_preset->get("privacy/microphone_usage_description");
+			strnew += lines[i].replace("$microphone_usage_description", description) + "\n";
 		} else if (lines[i].find("$photolibrary_usage_description") != -1) {
 			String description = p_preset->get("privacy/photolibrary_usage_description");
 			strnew += lines[i].replace("$photolibrary_usage_description", description) + "\n";


### PR DESCRIPTION
This PR reintroduces the microphone privileges back into the export. This was removed because we were having problems before but without these Godot simple doesn't run on newer version of the OS if microphone support is turned on in the project settings.

Apple changed the privileges system a little while ago that if you don't add the plist entries but do run code that triggers the privileges check, instead of just returned false it will hard quit out of the application. Apples way of saying you need to do the right thing (I guess because the plist is also used to display requirements on the app store).

For the camera privileges, because these are now run at startup, I've added code that checks if the plist has the required entry and whether that entry is set. Many games will not require the camera so we do not want the user to be asked about camera privileges. This gives you the opportunity to either leave out the entries in the plist or leave the export properties empty if you aren't using the camera.

The same change should also be added to audio IMHO but I don't understand the audio code, the iOS code doesn't seem to be part of the platform but woven into the audio drivers. Someone who understands this better should make a similar change. That said, leaving audio disabled in the project settings seems to skip the check. 
I do believe the check should be added, if we do we could rewrite the export code to only include the properties in the plist files if they are required.

The docs should also be updated to reflect how these privileges work

Fixes #30261
Fixes #30307 
