### PR TITLE
Sort selected nodes in scene tree before duplication

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -569,7 +569,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			Node *dupsingle = NULL;
 			List<Node *> editable_children;
 
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
+			selection.sort_custom<Node::Comparator>();
+
+			for (List<Node *>::Element *E = selection.back(); E; E = E->prev()) {
 
 				Node *node = E->get();
 				Node *parent = node->get_parent();


### PR DESCRIPTION
Closes #30339 

I used the default node comparator, the iteration over the selection when duplicating is reversed since the sort put the nodes in growing index order while the indexes are expected in reverse order.

![node-dup](https://user-images.githubusercontent.com/18357657/60756893-a4b23800-a003-11e9-84c2-82f362b3d248.gif)