### PR TITLE
Fix editor remaining dimmed after certain actions

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4967,18 +4967,18 @@ void EditorNode::dim_editor(bool p_dimming) {
 	static int dim_count = 0;
 	bool dim_ui = EditorSettings::get_singleton()->get("interface/editor/dim_editor_on_dialog_popup");
 	if (p_dimming) {
-		if (dim_ui) {
-			if (dim_count == 0) {
-				_start_dimming(true);
-			}
-			dim_count++;
+		if (dim_ui && dim_count == 0) {
+			_start_dimming(true);
 		}
+		dim_count++;
 	} else {
 		if (dim_count == 1) {
 			_start_dimming(false);
-			dim_count = 0;
-		} else if (dim_ui && dim_count > 0) {
+		}
+		if (dim_count > 0) {
 			dim_count--;
+		} else {
+			ERR_PRINT("Undimmed before dimming!");
 		}
 	}
 }

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -48,6 +48,14 @@ void Popup::_notification(int p_what) {
 		update_configuration_warning();
 	}
 
+	if (p_what == NOTIFICATION_EXIT_TREE) {
+		if (popped_up) {
+			popped_up = false;
+			notification(NOTIFICATION_POPUP_HIDE);
+			emit_signal("popup_hide");
+		}
+	}
+
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 //small helper to make editing of these easier in editor
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Fixes #30368.

Note: this breaks a bit of compatibility, as the `popup_hide` signal will now be emitted whenever removing a popup from the tree. Since the same signal should have been emitted when re-entering the tree (via enter tree -> `hide()`), I think this is mostly fine though.