### PR TITLE
[WIP] Tree: Added support for expanding columns having a stretch_ratio

### DIFF
--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -349,13 +349,16 @@ private:
 
 		int min_width;
 		bool expand;
+		float stretch_ratio;
 		String title;
 		ColumnInfo() {
 			min_width = 1;
 			expand = true;
+			stretch_ratio = 1.0;
 		}
 	};
 
+	bool column_stretch_ratios_enabled;
 	bool show_column_titles;
 	LineEdit *text_editor;
 	HSlider *value_editor;
@@ -542,6 +545,10 @@ public:
 	TreeItem *get_root();
 	TreeItem *get_last_item();
 
+	void set_column_stretch_ratios_enabled(bool p_enable_ratios);
+	bool are_column_stretch_ratios_enabled();
+	void set_column_stretch_ratio(int p_column, float p_stretch_ratio);
+	float get_column_stretch_ratio(int p_column);
 	void set_column_min_width(int p_column, int p_min_width);
 	void set_column_expand(int p_column, bool p_expand);
 	int get_column_width(int p_column) const;


### PR DESCRIPTION
Probably closes #30233 even if not eventually merged.

[there are likely places in the code that I missed that need to be changed to refer to these new functions, not to mention documenting them]

So it seems the way min_widths of expanding columns work is that if once all non-expanding columns (as well as margins and a vertical scrollbar) has been given its min_width space, the remaining available horizontal area is distributed among the expanding columns using their min_widths as a ratio.

Solutions using this current behaviour then could be to 
* Set column min_widths to a small integer value, say 1 or 2 or 4, and have those act as ratios
* Set column min_widths to larger values (25, 50, 100), and have those be the ratios.

These have some minor issue such as only allowing integer ratios, or (in the case of using larger min_widths like 100 for more leeway in setting the ratio) making columns potentially too wide, even if the box is scaled down.

Having "real" ratios enable expanding columns to expand to the remaining free space independently of their min_widths (but I realize my implementation of this might not be the cleanest). 

To preserve the old behaviour as the default, I added a boolean switch to enable the ratios (in addition to setting them). 

Having the current behaviour of expanding columns with min_widths in mind, If this effort seems wasted then I suppose this could be closed and better documentation for the current behaviour be added. 