### PR TITLE
Add a configuration warning when using ultrawide SpotLight with shadows

### DIFF
--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -51,6 +51,7 @@ void Light::set_param(Param p_param, float p_value) {
 
 		if (p_param == PARAM_SPOT_ANGLE) {
 			_change_notify("spot_angle");
+			update_configuration_warning();
 		} else if (p_param == PARAM_RANGE) {
 			_change_notify("omni_range");
 			_change_notify("spot_range");
@@ -68,6 +69,10 @@ void Light::set_shadow(bool p_enable) {
 
 	shadow = p_enable;
 	VS::get_singleton()->light_set_shadow(light, p_enable);
+
+	if (type == VisualServer::LIGHT_SPOT) {
+		update_configuration_warning();
+	}
 }
 bool Light::has_shadow() const {
 
@@ -463,6 +468,20 @@ OmniLight::OmniLight() :
 
 	set_shadow_mode(SHADOW_CUBE);
 	set_shadow_detail(SHADOW_DETAIL_HORIZONTAL);
+}
+
+String SpotLight::get_configuration_warning() const {
+	String warning = Light::get_configuration_warning();
+
+	if (has_shadow() && get_param(PARAM_SPOT_ANGLE) >= 90.0) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+
+		warning += TTR("A SpotLight with an angle wider than 90 degrees cannot cast shadows.");
+	}
+
+	return warning;
 }
 
 void SpotLight::_bind_methods() {

--- a/scene/3d/light.h
+++ b/scene/3d/light.h
@@ -221,6 +221,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual String get_configuration_warning() const;
+
 	SpotLight() :
 			Light(VisualServer::LIGHT_SPOT) {}
 };


### PR DESCRIPTION
This partially addresses #12028.