### PR TITLE
TreeItem: Added a setter for the disabled-property of buttons

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -571,7 +571,14 @@ int TreeItem::get_button_by_id(int p_column, int p_id) const {
 
 	return -1;
 }
+void TreeItem::set_disable_button(int p_column, int p_idx, bool p_disabled) {
 
+	ERR_FAIL_INDEX(p_column, cells.size());
+	ERR_FAIL_INDEX(p_idx, cells[p_column].buttons.size());
+
+	cells.write[p_column].buttons.write[p_idx].disabled = p_disabled;
+	_changed_notify(p_column);
+}
 bool TreeItem::is_button_disabled(int p_column, int p_idx) const {
 
 	ERR_FAIL_INDEX_V(p_column, cells.size(), false);
@@ -786,6 +793,7 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_button", "column", "button_idx", "button"), &TreeItem::set_button);
 	ClassDB::bind_method(D_METHOD("erase_button", "column", "button_idx"), &TreeItem::erase_button);
 	ClassDB::bind_method(D_METHOD("is_button_disabled", "column", "button_idx"), &TreeItem::is_button_disabled);
+	ClassDB::bind_method(D_METHOD("set_disable_button", "column", "button_idx", "disabled"), &TreeItem::set_disable_button);
 
 	ClassDB::bind_method(D_METHOD("set_expand_right", "column", "enable"), &TreeItem::set_expand_right);
 	ClassDB::bind_method(D_METHOD("get_expand_right", "column"), &TreeItem::get_expand_right);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -212,6 +212,7 @@ public:
 	bool is_button_disabled(int p_column, int p_idx) const;
 	void set_button(int p_column, int p_idx, const Ref<Texture> &p_button);
 	void set_button_color(int p_column, int p_idx, const Color &p_color);
+	void set_disable_button(int p_column, int p_idx, bool p_disabled);
 
 	/* range works for mode number or mode combo */
 


### PR DESCRIPTION
Closes #30362, not sure whether there is an actual button to expose beyond the disable.

I did not find any unexpected issues when testing with the code below in a tree node, the buttons in the last column are added and fade in and out as they are enabled (clickable) and disabled every 2 seconds:
```
extends Tree

var root
var treeitems:Dictionary = {}
func timer_timed_out():
  for i in treeitems:
    var item:TreeItem = treeitems[i]
    var disabled = item.is_button_disabled(2, 0)
    item.set_disable_button(2,0,not disabled)

func _ready():
  var cols: Dictionary = {
      0:{'title':'zero', 'exp':true},
      1:{'title':'one', 'exp':true},
      2:{'title':'two', 'exp':true},
   }
  self.set_columns(cols.size())

  var t: Timer = Timer.new()
  t.wait_time = 2;  t.autostart = true;  t.one_shot = false
  t.connect("timeout", self, "timer_timed_out")
  self.add_child(t)
  
  self.root = self.create_item()
  self.set_column_titles_visible(true)
  for key in cols:
    set_column_title(key, cols[key]['title'])
    set_column_expand(key, cols[key]['exp'])
  
  for i in range(100):
    var ti:TreeItem = self.create_item(root)
    set_text(ti, cols.size(), i)
    treeitems[i] = ti

func set_text(item:TreeItem, cols:int, counter:int):
  var button:Texture = load("icon.png")
  for i in range(cols):
    item.set_text(i, "%s" % [randi()])
  item.add_button(0, button)
  item.add_button(2, button)
  item.set_disable_button(2, 0, true)
```