### PR TITLE
 Improve hex_to_int documentation

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -182,7 +182,7 @@
 	</signals>
 	<constants>
 		<constant name="NOTIFICATION_EDITOR_SETTINGS_CHANGED" value="10000">
-				Emitted when editor settings change. It used by various editor plugins to update their visuals on theme changes or logic on configuration changes.
+			Emitted when editor settings change. It used by various editor plugins to update their visuals on theme changes or logic on configuration changes.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -385,7 +385,10 @@
 			<return type="int">
 			</return>
 			<description>
-				Converts a string containing a hexadecimal number into an integer.
+				Converts a string containing a hexadecimal number into an integer. Hexadecimal strings are expected to be prefixed with "[code]0x[/code]" otherwise [code]0[/code] is returned.
+				[codeblock]
+				print("0xff".hex_to_int()) # Print "255"
+				[/codeblock]
 			</description>
 		</method>
 		<method name="http_escape">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -141,13 +141,6 @@
 				Returns [code]true[/code] if the size override is enabled. See [method set_size_override].
 			</description>
 		</method>
-		<method name="is_size_override_stretch_enabled" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-				Returns [code]true[/code] if the size stretch override is enabled. See [method set_size_override_stretch].
-			</description>
-		</method>
 		<method name="set_attach_to_screen_rect">
 			<return type="void">
 			</return>
@@ -173,15 +166,6 @@
 			</argument>
 			<description>
 				Sets the size override of the viewport. If the [code]enable[/code] parameter is [code]true[/code] the override is used, otherwise it uses the default size. If the size parameter is [code](-1, -1)[/code], it won't update the size.
-			</description>
-		</method>
-		<method name="set_size_override_stretch">
-			<return type="void">
-			</return>
-			<argument index="0" name="enabled" type="bool">
-			</argument>
-			<description>
-				If [code]true[/code], the size override affects stretch as well.
 			</description>
 		</method>
 		<method name="unhandled_input">


### PR DESCRIPTION
Clearify how hex_to_int expects a '0x' prefixed string and provide a small hex_to_int example.
![image](https://user-images.githubusercontent.com/768942/60769648-ba426300-a0d2-11e9-8d96-b33e4af7af0a.png)
(Also ran doctool)