### PR TITLE
Fix some issues with TileMap's and other nodes' boundaries

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -58,7 +58,7 @@ Rect2 Path2D::_edit_get_rect() const {
 }
 
 bool Path2D::_edit_use_rect() const {
-	return true;
+	return curve.is_valid() && curve->get_point_count() != 0;
 }
 
 bool Path2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -76,7 +76,7 @@ Rect2 Polygon2D::_edit_get_rect() const {
 }
 
 bool Polygon2D::_edit_use_rect() const {
-	return true;
+	return polygon.size() > 0;
 }
 
 bool Polygon2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -861,7 +861,7 @@ void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_
 	if (!E && p_tile == INVALID_CELL)
 		return; //nothing to do
 
-	PosKey qk(p_x / _get_quadrant_size(), p_y / _get_quadrant_size());
+	PosKey qk = pk.to_quadrant(_get_quadrant_size());
 	if (p_tile == INVALID_CELL) {
 		//erase existing
 		tile_map.erase(pk);
@@ -1020,7 +1020,7 @@ void TileMap::update_cell_bitmask(int p_x, int p_y) {
 			E->get().autotile_coord_x = (int)coord.x;
 			E->get().autotile_coord_y = (int)coord.y;
 
-			PosKey qk(p_x / _get_quadrant_size(), p_y / _get_quadrant_size());
+			PosKey qk = p.to_quadrant(_get_quadrant_size());
 			Map<PosKey, Quadrant>::Element *Q = quadrant_map.find(qk);
 			_make_quadrant_dirty(Q);
 
@@ -1117,7 +1117,7 @@ void TileMap::set_cell_autotile_coord(int p_x, int p_y, const Vector2 &p_coord) 
 	c.autotile_coord_y = p_coord.y;
 	tile_map[pk] = c;
 
-	PosKey qk(p_x / _get_quadrant_size(), p_y / _get_quadrant_size());
+	PosKey qk = pk.to_quadrant(_get_quadrant_size());
 	Map<PosKey, Quadrant>::Element *Q = quadrant_map.find(qk);
 
 	if (!Q)
@@ -1144,7 +1144,7 @@ void TileMap::_recreate_quadrants() {
 
 	for (Map<PosKey, Cell>::Element *E = tile_map.front(); E; E = E->next()) {
 
-		PosKey qk(E->key().x / _get_quadrant_size(), E->key().y / _get_quadrant_size());
+		PosKey qk = PosKey(E->key().x, E->key().y).to_quadrant(_get_quadrant_size());
 
 		Map<PosKey, Quadrant>::Element *Q = quadrant_map.find(qk);
 		if (!Q) {
@@ -1281,7 +1281,11 @@ PoolVector<int> TileMap::_get_tile_data() const {
 }
 
 Rect2 TileMap::_edit_get_rect() const {
-	const_cast<TileMap *>(this)->update_dirty_quadrants();
+	if (pending_update) {
+		const_cast<TileMap *>(this)->update_dirty_quadrants();
+	} else {
+		const_cast<TileMap *>(this)->_recompute_rect_cache();
+	}
 	return rect_cache;
 }
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -94,6 +94,13 @@ private:
 
 		bool operator==(const PosKey &p_k) const { return (y == p_k.y && x == p_k.x); }
 
+		PosKey to_quadrant(const int &p_quadrant_size) const {
+			// rounding down, instead of simply rounding towards zero (truncating)
+			return PosKey(
+					x > 0 ? x / p_quadrant_size : (x - (p_quadrant_size - 1)) / p_quadrant_size,
+					y > 0 ? y / p_quadrant_size : (y - (p_quadrant_size - 1)) / p_quadrant_size);
+		}
+
 		PosKey(int16_t p_x, int16_t p_y) {
 			x = p_x;
 			y = p_y;


### PR DESCRIPTION
Fixes #30348.
Addresses a small part of #30012 (node boundary rectangle showing at 0,0 when no points are added).

Note that the bug in TileMap meant that the whole area from (-quadrant_size, -quadrant_size) to (quadrant_size, quadrant_size) was considered to be in the quadrant at (0, 0); likewise, other quadrants with a x or y coordinate equal to 0 were enlarged.