### PR TITLE
Add NULL-terminator the string passed to strtol.

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3338,7 +3338,7 @@ String String::http_unescape() const {
 			if ((ord1 >= '0' && ord1 <= '9') || (ord1 >= 'A' && ord1 <= 'Z')) {
 				CharType ord2 = ord_at(i + 2);
 				if ((ord2 >= '0' && ord2 <= '9') || (ord2 >= 'A' && ord2 <= 'Z')) {
-					char bytes[2] = { (char)ord1, (char)ord2 };
+					char bytes[3] = { (char)ord1, (char)ord2, 0 };
 					res += (char)strtol(bytes, NULL, 16);
 					i += 2;
 				}


### PR DESCRIPTION
This is actually expected by the function although it was apparently
working in GCC without the terminator, it breaks (at least some) clang
versions.

Fixes #30409 