### PR TITLE
Fix WebSocketClient consuming data during hanshake

### DIFF
--- a/modules/websocket/wsl_client.cpp
+++ b/modules/websocket/wsl_client.cpp
@@ -92,6 +92,7 @@ void WSLClient::_do_handshake() {
 				data->id = 1;
 				_peer->make_context(data, _in_buf_size, _in_pkt_size, _out_buf_size, _out_pkt_size);
 				_on_connect(protocol);
+				break;
 			}
 			_resp_pos += 1;
 		}


### PR DESCRIPTION
Was missing a break of the while loop on connection.
This potentially caused early data frames to be trashed.

Fixes #30387 