### PR TITLE
Use base `Color()` constructors instead of `Color::html()`

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -76,9 +76,9 @@ void EditorAudioBus::_notification(int p_what) {
 
 			disabled_vu = get_icon("BusVuFrozen", "EditorIcons");
 
-			Color solo_color = Color::html(EditorSettings::get_singleton()->is_dark_theme() ? "#ffe337" : "#ffeb70");
-			Color mute_color = Color::html(EditorSettings::get_singleton()->is_dark_theme() ? "#ff2929" : "#ff7070");
-			Color bypass_color = Color::html(EditorSettings::get_singleton()->is_dark_theme() ? "#22ccff" : "#70deff");
+			Color solo_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1.0, 0.89, 0.22) : Color(1.0, 0.92, 0.44);
+			Color mute_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1.0, 0.16, 0.16) : Color(1.0, 0.44, 0.44);
+			Color bypass_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(0.13, 0.8, 1.0) : Color(0.44, 0.87, 1.0);
 
 			solo->set_icon(get_icon("AudioBusSolo", "EditorIcons"));
 			solo->add_color_override("icon_color_pressed", solo_color);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1348,39 +1348,39 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			if (col.begins_with("#"))
 				color = Color::html(col);
 			else if (col == "aqua")
-				color = Color::html("#00FFFF");
+				color = Color(0, 1, 1);
 			else if (col == "black")
-				color = Color::html("#000000");
+				color = Color(0, 0, 0);
 			else if (col == "blue")
-				color = Color::html("#0000FF");
+				color = Color(0, 0, 1);
 			else if (col == "fuchsia")
-				color = Color::html("#FF00FF");
+				color = Color(1, 0, 1);
 			else if (col == "gray" || col == "grey")
-				color = Color::html("#808080");
+				color = Color(0.5, 0.5, 0.5);
 			else if (col == "green")
-				color = Color::html("#008000");
+				color = Color(0, 0.5, 0);
 			else if (col == "lime")
-				color = Color::html("#00FF00");
+				color = Color(0, 1, 0);
 			else if (col == "maroon")
-				color = Color::html("#800000");
+				color = Color(0.5, 0, 0);
 			else if (col == "navy")
-				color = Color::html("#000080");
+				color = Color(0, 0, 0.5);
 			else if (col == "olive")
-				color = Color::html("#808000");
+				color = Color(0.5, 0.5, 0);
 			else if (col == "purple")
-				color = Color::html("#800080");
+				color = Color(0.5, 0, 0.5);
 			else if (col == "red")
-				color = Color::html("#FF0000");
+				color = Color(1, 0, 0);
 			else if (col == "silver")
-				color = Color::html("#C0C0C0");
+				color = Color(0.75, 0.75, 0.75);
 			else if (col == "teal")
-				color = Color::html("#008008");
+				color = Color(0, 0.5, 0.5);
 			else if (col == "white")
-				color = Color::html("#FFFFFF");
+				color = Color(1, 1, 1);
 			else if (col == "yellow")
-				color = Color::html("#FFFF00");
+				color = Color(1, 1, 0);
 			else
-				color = Color(0, 0, 0, 1); //base_color;
+				color = Color(0, 0, 0); //base_color;
 
 			p_rt->push_color(color);
 			pos = brk_end + 1;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -354,9 +354,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/theme/preset"] = PropertyInfo(Variant::STRING, "interface/theme/preset", PROPERTY_HINT_ENUM, "Default,Alien,Arc,Godot 2,Grey,Light,Solarized (Dark),Solarized (Light),Custom", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/theme/icon_and_font_color", 0);
 	hints["interface/theme/icon_and_font_color"] = PropertyInfo(Variant::INT, "interface/theme/icon_and_font_color", PROPERTY_HINT_ENUM, "Auto,Dark,Light", PROPERTY_USAGE_DEFAULT);
-	_initial_set("interface/theme/base_color", Color::html("#323b4f"));
+	_initial_set("interface/theme/base_color", Color(0.2, 0.23, 0.31));
 	hints["interface/theme/base_color"] = PropertyInfo(Variant::COLOR, "interface/theme/base_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
-	_initial_set("interface/theme/accent_color", Color::html("#699ce8"));
+	_initial_set("interface/theme/accent_color", Color(0.41, 0.61, 0.91));
 	hints["interface/theme/accent_color"] = PropertyInfo(Variant::COLOR, "interface/theme/accent_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/theme/contrast", 0.25);
 	hints["interface/theme/contrast"] = PropertyInfo(Variant::REAL, "interface/theme/contrast", PROPERTY_HINT_RANGE, "0.01, 1, 0.01");
@@ -505,10 +505,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/grid_map/pick_distance", 5000.0);
 
 	// 3D
-	_initial_set("editors/3d/primary_grid_color", Color::html("909090"));
+	_initial_set("editors/3d/primary_grid_color", Color(0.56, 0.56, 0.56));
 	hints["editors/3d/primary_grid_color"] = PropertyInfo(Variant::COLOR, "editors/3d/primary_grid_color", PROPERTY_HINT_COLOR_NO_ALPHA, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 
-	_initial_set("editors/3d/secondary_grid_color", Color::html("606060"));
+	_initial_set("editors/3d/secondary_grid_color", Color(0.38, 0.38, 0.38));
 	hints["editors/3d/secondary_grid_color"] = PropertyInfo(Variant::COLOR, "editors/3d/secondary_grid_color", PROPERTY_HINT_COLOR_NO_ALPHA, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 
 	_initial_set("editors/3d/grid_size", 50);
@@ -648,32 +648,32 @@ void EditorSettings::_load_default_text_editor_theme() {
 
 	bool dark_theme = is_dark_theme();
 
-	_initial_set("text_editor/highlighting/symbol_color", Color::html("badfff"));
-	_initial_set("text_editor/highlighting/keyword_color", Color::html("ffffb3"));
-	_initial_set("text_editor/highlighting/base_type_color", Color::html("a4ffd4"));
-	_initial_set("text_editor/highlighting/engine_type_color", Color::html("83d3ff"));
-	_initial_set("text_editor/highlighting/comment_color", Color::html("676767"));
-	_initial_set("text_editor/highlighting/string_color", Color::html("ef6ebe"));
-	_initial_set("text_editor/highlighting/background_color", dark_theme ? Color::html("3b000000") : Color::html("#323b4f"));
-	_initial_set("text_editor/highlighting/completion_background_color", Color::html("2C2A32"));
-	_initial_set("text_editor/highlighting/completion_selected_color", Color::html("434244"));
-	_initial_set("text_editor/highlighting/completion_existing_color", Color::html("21dfdfdf"));
-	_initial_set("text_editor/highlighting/completion_scroll_color", Color::html("ffffff"));
-	_initial_set("text_editor/highlighting/completion_font_color", Color::html("aaaaaa"));
-	_initial_set("text_editor/highlighting/text_color", Color::html("aaaaaa"));
-	_initial_set("text_editor/highlighting/line_number_color", Color::html("66aaaaaa"));
-	_initial_set("text_editor/highlighting/safe_line_number_color", Color::html("99aac8aa"));
-	_initial_set("text_editor/highlighting/caret_color", Color::html("aaaaaa"));
-	_initial_set("text_editor/highlighting/caret_background_color", Color::html("000000"));
-	_initial_set("text_editor/highlighting/text_selected_color", Color::html("000000"));
-	_initial_set("text_editor/highlighting/selection_color", Color::html("5a699ce8"));
+	_initial_set("text_editor/highlighting/symbol_color", Color(0.73, 0.87, 1.0));
+	_initial_set("text_editor/highlighting/keyword_color", Color(1.0, 1.0, 0.7));
+	_initial_set("text_editor/highlighting/base_type_color", Color(0.64, 1.0, 0.83));
+	_initial_set("text_editor/highlighting/engine_type_color", Color(0.51, 0.83, 1.0));
+	_initial_set("text_editor/highlighting/comment_color", Color(0.4, 0.4, 0.4));
+	_initial_set("text_editor/highlighting/string_color", Color(0.94, 0.43, 0.75));
+	_initial_set("text_editor/highlighting/background_color", dark_theme ? Color(0.0, 0.0, 0.0, 0.23) : Color(0.2, 0.23, 0.31));
+	_initial_set("text_editor/highlighting/completion_background_color", Color(0.17, 0.16, 0.2));
+	_initial_set("text_editor/highlighting/completion_selected_color", Color(0.26, 0.26, 0.27));
+	_initial_set("text_editor/highlighting/completion_existing_color", Color(0.13, 0.87, 0.87, 0.87));
+	_initial_set("text_editor/highlighting/completion_scroll_color", Color(1, 1, 1));
+	_initial_set("text_editor/highlighting/completion_font_color", Color(0.67, 0.67, 0.67));
+	_initial_set("text_editor/highlighting/text_color", Color(0.67, 0.67, 0.67));
+	_initial_set("text_editor/highlighting/line_number_color", Color(0.67, 0.67, 0.67, 0.4));
+	_initial_set("text_editor/highlighting/safe_line_number_color", Color(0.67, 0.78, 0.67, 0.6));
+	_initial_set("text_editor/highlighting/caret_color", Color(0.67, 0.67, 0.67));
+	_initial_set("text_editor/highlighting/caret_background_color", Color(0, 0, 0));
+	_initial_set("text_editor/highlighting/text_selected_color", Color(0, 0, 0));
+	_initial_set("text_editor/highlighting/selection_color", Color(0.41, 0.61, 0.91, 0.35));
 	_initial_set("text_editor/highlighting/brace_mismatch_color", Color(1, 0.2, 0.2));
 	_initial_set("text_editor/highlighting/current_line_color", Color(0.3, 0.5, 0.8, 0.15));
 	_initial_set("text_editor/highlighting/line_length_guideline_color", Color(0.3, 0.5, 0.8, 0.1));
 	_initial_set("text_editor/highlighting/word_highlighted_color", Color(0.8, 0.9, 0.9, 0.15));
-	_initial_set("text_editor/highlighting/number_color", Color::html("EB9532"));
-	_initial_set("text_editor/highlighting/function_color", Color::html("66a2ce"));
-	_initial_set("text_editor/highlighting/member_variable_color", Color::html("e64e59"));
+	_initial_set("text_editor/highlighting/number_color", Color(0.92, 0.58, 0.2));
+	_initial_set("text_editor/highlighting/function_color", Color(0.4, 0.64, 0.81));
+	_initial_set("text_editor/highlighting/member_variable_color", Color(0.9, 0.31, 0.35));
 	_initial_set("text_editor/highlighting/mark_color", Color(1.0, 0.4, 0.4, 0.4));
 	_initial_set("text_editor/highlighting/bookmark_color", Color(0.08, 0.49, 0.98));
 	_initial_set("text_editor/highlighting/breakpoint_color", Color(0.8, 0.8, 0.4, 0.2));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -257,44 +257,44 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Please, use alphabet order if you've added new theme here(After "Default" and "Custom")
 
 	if (preset == "Default") {
-		preset_accent_color = Color::html("#699ce8");
-		preset_base_color = Color::html("#323b4f");
+		preset_accent_color = Color(0.41, 0.61, 0.91);
+		preset_base_color = Color(0.2, 0.23, 0.31);
 		preset_contrast = default_contrast;
 	} else if (preset == "Custom") {
 		accent_color = EDITOR_GET("interface/theme/accent_color");
 		base_color = EDITOR_GET("interface/theme/base_color");
 		contrast = EDITOR_GET("interface/theme/contrast");
 	} else if (preset == "Alien") {
-		preset_accent_color = Color::html("#1bfe99");
-		preset_base_color = Color::html("#2f373f");
+		preset_accent_color = Color(0.11, 1.0, 0.6);
+		preset_base_color = Color(0.18, 0.22, 0.25);
 		preset_contrast = 0.25;
 	} else if (preset == "Arc") {
-		preset_accent_color = Color::html("#5294e2");
-		preset_base_color = Color::html("#383c4a");
+		preset_accent_color = Color(0.32, 0.58, 0.89);
+		preset_base_color = Color(0.22, 0.24, 0.29);
 		preset_contrast = 0.25;
 	} else if (preset == "Godot 2") {
-		preset_accent_color = Color::html("#86ace2");
-		preset_base_color = Color::html("#3C3A44");
+		preset_accent_color = Color(0.53, 0.67, 0.89);
+		preset_base_color = Color(0.24, 0.23, 0.27);
 		preset_contrast = 0.25;
 	} else if (preset == "Grey") {
-		preset_accent_color = Color::html("#b8e4ff");
-		preset_base_color = Color::html("#3d3d3d");
+		preset_accent_color = Color(0.72, 0.89, 1.0);
+		preset_base_color = Color(0.24, 0.24, 0.24);
 		preset_contrast = 0.2;
 	} else if (preset == "Light") {
-		preset_accent_color = Color::html("#2070ff");
-		preset_base_color = Color::html("#ffffff");
+		preset_accent_color = Color(0.13, 0.44, 1.0);
+		preset_base_color = Color(1, 1, 1);
 		preset_contrast = 0.08;
 	} else if (preset == "Solarized (Dark)") {
-		preset_accent_color = Color::html("#268bd2");
-		preset_base_color = Color::html("#073642");
+		preset_accent_color = Color(0.15, 0.55, 0.82);
+		preset_base_color = Color(0.03, 0.21, 0.26);
 		preset_contrast = 0.23;
 	} else if (preset == "Solarized (Light)") {
-		preset_accent_color = Color::html("#268bd2");
-		preset_base_color = Color::html("#fdf6e3");
+		preset_accent_color = Color(0.15, 0.55, 0.82);
+		preset_base_color = Color(0.99, 0.96, 0.89);
 		preset_contrast = 0.06;
 	} else { // Default
-		preset_accent_color = Color::html("#699ce8");
-		preset_base_color = Color::html("#323b4f");
+		preset_accent_color = Color(0.41, 0.61, 0.91);
+		preset_base_color = Color(0.2, 0.23, 0.31);
 		preset_contrast = default_contrast;
 	}
 
@@ -1088,14 +1088,14 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color alpha3 = Color(mono_value, mono_value, mono_value, 0.7);
 
 	// editor main color
-	const Color main_color = Color::html(dark_theme ? "#57b3ff" : "#0480ff");
+	const Color main_color = dark_theme ? Color(0.34, 0.7, 1.0) : Color(0.02, 0.5, 1.0);
 
-	const Color symbol_color = Color::html("#5792ff").linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
-	const Color keyword_color = Color::html("#ff7185");
-	const Color basetype_color = Color::html(dark_theme ? "#42ffc2" : "#00c161");
+	const Color symbol_color = Color(0.34, 0.57, 1.0).linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
+	const Color keyword_color = Color(1.0, 0.44, 0.52);
+	const Color basetype_color = dark_theme ? Color(0.26, 1.0, 0.76) : Color(0.0, 0.76, 0.38);
 	const Color type_color = basetype_color.linear_interpolate(mono_color, dark_theme ? 0.7 : 0.5);
 	const Color comment_color = dim_color;
-	const Color string_color = Color::html(dark_theme ? "#ffd942" : "#ffd118").linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
+	const Color string_color = (dark_theme ? Color(1.0, 0.85, 0.26) : Color(1.0, 0.82, 0.09)).linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
 
 	const Color te_background_color = dark_theme ? background_color : base_color;
 	const Color completion_background_color = dark_theme ? base_color : background_color;

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -365,10 +365,10 @@ void VisualShaderEditor::_update_graph() {
 	}
 
 	static const Color type_color[4] = {
-		Color::html("#61daf4"), // scalar
-		Color::html("#d67dee"), // vector
-		Color::html("#8da6f0"), // boolean
-		Color::html("#f6a86e") // transform
+		Color(0.38, 0.85, 0.96), // scalar
+		Color(0.84, 0.49, 0.93), // vector
+		Color(0.55, 0.65, 0.94), // boolean
+		Color(0.96, 0.66, 0.43) // transform
 	};
 
 	List<VisualShader::Connection> connections;

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -19,7 +19,7 @@ def make_splash(target, source, env):
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef BOOT_SPLASH_H\n")
         g.write("#define BOOT_SPLASH_H\n")
-        g.write('static const Color boot_splash_bg_color = Color::html("#232323");\n')
+        g.write('static const Color boot_splash_bg_color = Color(0.14, 0.14, 0.14);\n')
         g.write("static const unsigned char boot_splash_png[] = {\n")
         for i in range(len(buf)):
             g.write(byte_to_str(buf[i]) + ",\n")
@@ -38,7 +38,7 @@ def make_splash_editor(target, source, env):
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef BOOT_SPLASH_EDITOR_H\n")
         g.write("#define BOOT_SPLASH_EDITOR_H\n")
-        g.write('static const Color boot_splash_editor_bg_color = Color::html("#232323");\n')
+        g.write('static const Color boot_splash_editor_bg_color = Color(0.14, 0.14, 0.14);\n')
         g.write("static const unsigned char boot_splash_editor_png[] = {\n")
         for i in range(len(buf)):
             g.write(byte_to_str(buf[i]) + ",\n")

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -370,8 +370,8 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	bool default_theme = text_editor_color_theme == "Default";
 	bool dark_theme = settings->is_dark_theme();
 
-	function_definition_color = Color::html(default_theme ? "#01e1ff" : dark_theme ? "#01e1ff" : "#00a5ba");
-	node_path_color = Color::html(default_theme ? "#64c15a" : dark_theme ? "64c15a" : "#518b4b");
+	function_definition_color = default_theme ? Color(0.0, 0.88, 1.0) : dark_theme ? Color(0.0, 0.88, 1.0) : Color(0.0, 0.65, 0.73);
+	node_path_color = default_theme ? Color(0.39, 0.76, 0.35) : dark_theme ? Color(0.39, 0.76, 0.35) : Color(0.32, 0.55, 0.29);
 
 	EDITOR_DEF("text_editor/highlighting/gdscript/function_definition_color", function_definition_color);
 	EDITOR_DEF("text_editor/highlighting/gdscript/node_path_color", node_path_color);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -341,74 +341,74 @@ static Color _color_from_type(Variant::Type p_type, bool dark_theme = true) {
 	Color color;
 	if (dark_theme)
 		switch (p_type) {
-			case Variant::NIL: color = Color::html("#69ecbd"); break;
+			case Variant::NIL: color = Color(0.41, 0.93, 0.74); break;
 
-			case Variant::BOOL: color = Color::html("#8da6f0"); break;
-			case Variant::INT: color = Color::html("#7dc6ef"); break;
-			case Variant::REAL: color = Color::html("#61daf4"); break;
-			case Variant::STRING: color = Color::html("#6ba7ec"); break;
+			case Variant::BOOL: color = Color(0.55, 0.65, 0.94); break;
+			case Variant::INT: color = Color(0.49, 0.78, 0.94); break;
+			case Variant::REAL: color = Color(0.38, 0.85, 0.96); break;
+			case Variant::STRING: color = Color(0.42, 0.65, 0.93); break;
 
-			case Variant::VECTOR2: color = Color::html("#bd91f1"); break;
-			case Variant::RECT2: color = Color::html("#f191a5"); break;
-			case Variant::VECTOR3: color = Color::html("#d67dee"); break;
-			case Variant::TRANSFORM2D: color = Color::html("#c4ec69"); break;
-			case Variant::PLANE: color = Color::html("#f77070"); break;
-			case Variant::QUAT: color = Color::html("#ec69a3"); break;
-			case Variant::AABB: color = Color::html("#ee7991"); break;
-			case Variant::BASIS: color = Color::html("#e3ec69"); break;
-			case Variant::TRANSFORM: color = Color::html("#f6a86e"); break;
+			case Variant::VECTOR2: color = Color(0.74, 0.57, 0.95); break;
+			case Variant::RECT2: color = Color(0.95, 0.57, 0.65); break;
+			case Variant::VECTOR3: color = Color(0.84, 0.49, 0.93); break;
+			case Variant::TRANSFORM2D: color = Color(0.77, 0.93, 0.41); break;
+			case Variant::PLANE: color = Color(0.97, 0.44, 0.44); break;
+			case Variant::QUAT: color = Color(0.93, 0.41, 0.64); break;
+			case Variant::AABB: color = Color(0.93, 0.47, 0.57); break;
+			case Variant::BASIS: color = Color(0.89, 0.93, 0.41); break;
+			case Variant::TRANSFORM: color = Color(0.96, 0.66, 0.43); break;
 
-			case Variant::COLOR: color = Color::html("#9dff70"); break;
-			case Variant::NODE_PATH: color = Color::html("#6993ec"); break;
-			case Variant::_RID: color = Color::html("#69ec9a"); break;
-			case Variant::OBJECT: color = Color::html("#79f3e8"); break;
-			case Variant::DICTIONARY: color = Color::html("#77edb1"); break;
+			case Variant::COLOR: color = Color(0.62, 1.0, 0.44); break;
+			case Variant::NODE_PATH: color = Color(0.41, 0.58, 0.93); break;
+			case Variant::_RID: color = Color(0.41, 0.93, 0.6); break;
+			case Variant::OBJECT: color = Color(0.47, 0.95, 0.91); break;
+			case Variant::DICTIONARY: color = Color(0.47, 0.93, 0.69); break;
 
-			case Variant::ARRAY: color = Color::html("#e0e0e0"); break;
-			case Variant::POOL_BYTE_ARRAY: color = Color::html("#aaf4c8"); break;
-			case Variant::POOL_INT_ARRAY: color = Color::html("#afdcf5"); break;
-			case Variant::POOL_REAL_ARRAY: color = Color::html("#97e7f8"); break;
-			case Variant::POOL_STRING_ARRAY: color = Color::html("#9dc4f2"); break;
-			case Variant::POOL_VECTOR2_ARRAY: color = Color::html("#d1b3f5"); break;
-			case Variant::POOL_VECTOR3_ARRAY: color = Color::html("#df9bf2"); break;
-			case Variant::POOL_COLOR_ARRAY: color = Color::html("#e9ff97"); break;
+			case Variant::ARRAY: color = Color(0.88, 0.88, 0.88); break;
+			case Variant::POOL_BYTE_ARRAY: color = Color(0.67, 0.96, 0.78); break;
+			case Variant::POOL_INT_ARRAY: color = Color(0.69, 0.86, 0.96); break;
+			case Variant::POOL_REAL_ARRAY: color = Color(0.59, 0.91, 0.97); break;
+			case Variant::POOL_STRING_ARRAY: color = Color(0.62, 0.77, 0.95); break;
+			case Variant::POOL_VECTOR2_ARRAY: color = Color(0.82, 0.7, 0.96); break;
+			case Variant::POOL_VECTOR3_ARRAY: color = Color(0.87, 0.61, 0.95); break;
+			case Variant::POOL_COLOR_ARRAY: color = Color(0.91, 1.0, 0.59); break;
 
 			default:
 				color.set_hsv(p_type / float(Variant::VARIANT_MAX), 0.7, 0.7);
 		}
 	else
 		switch (p_type) {
-			case Variant::NIL: color = Color::html("#25e3a0"); break;
+			case Variant::NIL: color = Color(0.15, 0.89, 0.63); break;
 
-			case Variant::BOOL: color = Color::html("#6d8eeb"); break;
-			case Variant::INT: color = Color::html("#4fb2e9"); break;
-			case Variant::REAL: color = Color::html("#27ccf0"); break;
-			case Variant::STRING: color = Color::html("#4690e7"); break;
+			case Variant::BOOL: color = Color(0.43, 0.56, 0.92); break;
+			case Variant::INT: color = Color(0.31, 0.7, 0.91); break;
+			case Variant::REAL: color = Color(0.15, 0.8, 0.94); break;
+			case Variant::STRING: color = Color(0.27, 0.56, 0.91); break;
 
-			case Variant::VECTOR2: color = Color::html("#ad76ee"); break;
-			case Variant::RECT2: color = Color::html("#ee758e"); break;
-			case Variant::VECTOR3: color = Color::html("#dc6aed"); break;
-			case Variant::TRANSFORM2D: color = Color::html("#96ce1a"); break;
-			case Variant::PLANE: color = Color::html("#f77070"); break;
-			case Variant::QUAT: color = Color::html("#ec69a3"); break;
-			case Variant::AABB: color = Color::html("#ee7991"); break;
-			case Variant::BASIS: color = Color::html("#b2bb19"); break;
-			case Variant::TRANSFORM: color = Color::html("#f49047"); break;
+			case Variant::VECTOR2: color = Color(0.68, 0.46, 0.93); break;
+			case Variant::RECT2: color = Color(0.93, 0.46, 0.56); break;
+			case Variant::VECTOR3: color = Color(0.86, 0.42, 0.93); break;
+			case Variant::TRANSFORM2D: color = Color(0.59, 0.81, 0.1); break;
+			case Variant::PLANE: color = Color(0.97, 0.44, 0.44); break;
+			case Variant::QUAT: color = Color(0.93, 0.41, 0.64); break;
+			case Variant::AABB: color = Color(0.93, 0.47, 0.57); break;
+			case Variant::BASIS: color = Color(0.7, 0.73, 0.1); break;
+			case Variant::TRANSFORM: color = Color(0.96, 0.56, 0.28); break;
 
-			case Variant::COLOR: color = Color::html("#3cbf00"); break;
-			case Variant::NODE_PATH: color = Color::html("#6993ec"); break;
-			case Variant::_RID: color = Color::html("#2ce573"); break;
-			case Variant::OBJECT: color = Color::html("#12d5c3"); break;
-			case Variant::DICTIONARY: color = Color::html("#57e99f"); break;
+			case Variant::COLOR: color = Color(0.24, 0.75, 0.0); break;
+			case Variant::NODE_PATH: color = Color(0.41, 0.58, 0.93); break;
+			case Variant::_RID: color = Color(0.17, 0.9, 0.45); break;
+			case Variant::OBJECT: color = Color(0.07, 0.84, 0.76); break;
+			case Variant::DICTIONARY: color = Color(0.34, 0.91, 0.62); break;
 
-			case Variant::ARRAY: color = Color::html("#737373"); break;
-			case Variant::POOL_BYTE_ARRAY: color = Color::html("#61ea98"); break;
-			case Variant::POOL_INT_ARRAY: color = Color::html("#61baeb"); break;
-			case Variant::POOL_REAL_ARRAY: color = Color::html("#40d3f2"); break;
-			case Variant::POOL_STRING_ARRAY: color = Color::html("#609fea"); break;
-			case Variant::POOL_VECTOR2_ARRAY: color = Color::html("#9d5dea"); break;
-			case Variant::POOL_VECTOR3_ARRAY: color = Color::html("#ca5aea"); break;
-			case Variant::POOL_COLOR_ARRAY: color = Color::html("#92ba00"); break;
+			case Variant::ARRAY: color = Color(0.45, 0.45, 0.45); break;
+			case Variant::POOL_BYTE_ARRAY: color = Color(0.38, 0.92, 0.6); break;
+			case Variant::POOL_INT_ARRAY: color = Color(0.38, 0.73, 0.92); break;
+			case Variant::POOL_REAL_ARRAY: color = Color(0.25, 0.83, 0.95); break;
+			case Variant::POOL_STRING_ARRAY: color = Color(0.38, 0.62, 0.92); break;
+			case Variant::POOL_VECTOR2_ARRAY: color = Color(0.62, 0.36, 0.92); break;
+			case Variant::POOL_VECTOR3_ARRAY: color = Color(0.79, 0.35, 0.92); break;
+			case Variant::POOL_COLOR_ARRAY: color = Color(0.57, 0.73, 0.0); break;
 
 			default:
 				color.set_hsv(p_type / float(Variant::VARIANT_MAX), 0.3, 0.3);
@@ -3054,19 +3054,19 @@ void VisualScriptEditor::_notification(int p_what) {
 
 		List<Pair<String, Color> > colors;
 		if (dark_theme) {
-			colors.push_back(Pair<String, Color>("flow_control", Color::html("#f4f4f4")));
-			colors.push_back(Pair<String, Color>("functions", Color::html("#f58581")));
-			colors.push_back(Pair<String, Color>("data", Color::html("#80f6cf")));
-			colors.push_back(Pair<String, Color>("operators", Color::html("#ab97df")));
-			colors.push_back(Pair<String, Color>("custom", Color::html("#80bbf6")));
-			colors.push_back(Pair<String, Color>("constants", Color::html("#f680b0")));
+			colors.push_back(Pair<String, Color>("flow_control", Color(0.96, 0.96, 0.96)));
+			colors.push_back(Pair<String, Color>("functions", Color(0.96, 0.52, 0.51)));
+			colors.push_back(Pair<String, Color>("data", Color(0.5, 0.96, 0.81)));
+			colors.push_back(Pair<String, Color>("operators", Color(0.67, 0.59, 0.87)));
+			colors.push_back(Pair<String, Color>("custom", Color(0.5, 0.73, 0.96)));
+			colors.push_back(Pair<String, Color>("constants", Color(0.96, 0.5, 0.69)));
 		} else {
-			colors.push_back(Pair<String, Color>("flow_control", Color::html("#424242")));
-			colors.push_back(Pair<String, Color>("functions", Color::html("#f26661")));
-			colors.push_back(Pair<String, Color>("data", Color::html("#13bb83")));
-			colors.push_back(Pair<String, Color>("operators", Color::html("#8265d0")));
-			colors.push_back(Pair<String, Color>("custom", Color::html("#4ea0f2")));
-			colors.push_back(Pair<String, Color>("constants", Color::html("#f02f7d")));
+			colors.push_back(Pair<String, Color>("flow_control", Color(0.26, 0.26, 0.26)));
+			colors.push_back(Pair<String, Color>("functions", Color(0.95, 0.4, 0.38)));
+			colors.push_back(Pair<String, Color>("data", Color(0.07, 0.73, 0.51)));
+			colors.push_back(Pair<String, Color>("operators", Color(0.51, 0.4, 0.82)));
+			colors.push_back(Pair<String, Color>("custom", Color(0.31, 0.63, 0.95)));
+			colors.push_back(Pair<String, Color>("constants", Color(0.94, 0.18, 0.49)));
 		}
 
 		for (List<Pair<String, Color> >::Element *E = colors.front(); E; E = E->next()) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1942,37 +1942,37 @@ Error RichTextLabel::append_bbcode(const String &p_bbcode) {
 			if (col.begins_with("#"))
 				color = Color::html(col);
 			else if (col == "aqua")
-				color = Color::html("#00FFFF");
+				color = Color(0, 1, 1);
 			else if (col == "black")
-				color = Color::html("#000000");
+				color = Color(0, 0, 0);
 			else if (col == "blue")
-				color = Color::html("#0000FF");
+				color = Color(0, 0, 1);
 			else if (col == "fuchsia")
-				color = Color::html("#FF00FF");
+				color = Color(1, 0, 1);
 			else if (col == "gray" || col == "grey")
-				color = Color::html("#808080");
+				color = Color(0.5, 0.5, 0.5);
 			else if (col == "green")
-				color = Color::html("#008000");
+				color = Color(0, 0.5, 0);
 			else if (col == "lime")
-				color = Color::html("#00FF00");
+				color = Color(0, 1, 0);
 			else if (col == "maroon")
-				color = Color::html("#800000");
+				color = Color(0.5, 0, 0);
 			else if (col == "navy")
-				color = Color::html("#000080");
+				color = Color(0, 0, 0.5);
 			else if (col == "olive")
-				color = Color::html("#808000");
+				color = Color(0.5, 0.5, 0);
 			else if (col == "purple")
-				color = Color::html("#800080");
+				color = Color(0.5, 0, 0.5);
 			else if (col == "red")
-				color = Color::html("#FF0000");
+				color = Color(1, 0, 0);
 			else if (col == "silver")
-				color = Color::html("#C0C0C0");
+				color = Color(0.75, 0.75, 0.75);
 			else if (col == "teal")
-				color = Color::html("#008008");
+				color = Color(0, 0.5, 0.5);
 			else if (col == "white")
-				color = Color::html("#FFFFFF");
+				color = Color(1, 1, 1);
 			else if (col == "yellow")
-				color = Color::html("#FFFF00");
+				color = Color(1, 1, 0);
 			else
 				color = base_color;
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -177,13 +177,13 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// Font Colors
 
-	Color control_font_color = Color::html("e0e0e0");
-	Color control_font_color_lower = Color::html("a0a0a0");
-	Color control_font_color_low = Color::html("b0b0b0");
-	Color control_font_color_hover = Color::html("f0f0f0");
+	Color control_font_color = Color(0.88, 0.88, 0.88);
+	Color control_font_color_lower = Color(0.63, 0.63, 0.63);
+	Color control_font_color_low = Color(0.69, 0.69, 0.69);
+	Color control_font_color_hover = Color(0.94, 0.94, 0.94);
 	Color control_font_color_disabled = Color(0.9, 0.9, 0.9, 0.2);
-	Color control_font_color_pressed = Color::html("ffffff");
-	Color font_color_selection = Color::html("7d7d7d");
+	Color control_font_color_pressed = Color(1, 1, 1);
+	Color font_color_selection = Color(0.49, 0.49, 0.49);
 
 	// Panel
 
@@ -432,12 +432,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_font("font", "TextEdit", default_font);
 
-	theme->set_color("background_color", "TextEdit", Color(0, 0, 0, 0));
-	theme->set_color("completion_background_color", "TextEdit", Color::html("2C2A32"));
-	theme->set_color("completion_selected_color", "TextEdit", Color::html("434244"));
-	theme->set_color("completion_existing_color", "TextEdit", Color::html("21dfdfdf"));
+	theme->set_color("background_color", "TextEdit", Color(0, 0, 0));
+	theme->set_color("completion_background_color", "TextEdit", Color(0.17, 0.16, 0.2));
+	theme->set_color("completion_selected_color", "TextEdit", Color(0.26, 0.26, 0.27));
+	theme->set_color("completion_existing_color", "TextEdit", Color(0.87, 0.87, 0.87, 0.13));
 	theme->set_color("completion_scroll_color", "TextEdit", control_font_color_pressed);
-	theme->set_color("completion_font_color", "TextEdit", Color::html("aaaaaa"));
+	theme->set_color("completion_font_color", "TextEdit", Color(0.67, 0.67, 0.67));
 	theme->set_color("font_color", "TextEdit", control_font_color);
 	theme->set_color("font_color_selected", "TextEdit", Color(0, 0, 0));
 	theme->set_color("font_color_readonly", "TextEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
@@ -449,14 +449,14 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("code_folding_color", "TextEdit", Color(0.8, 0.8, 0.8, 0.8));
 	theme->set_color("current_line_color", "TextEdit", Color(0.25, 0.25, 0.26, 0.8));
 	theme->set_color("caret_color", "TextEdit", control_font_color);
-	theme->set_color("caret_background_color", "TextEdit", Color::html("000000"));
+	theme->set_color("caret_background_color", "TextEdit", Color(0, 0, 0));
 	theme->set_color("symbol_color", "TextEdit", control_font_color_hover);
 	theme->set_color("brace_mismatch_color", "TextEdit", Color(1, 0.2, 0.2));
-	theme->set_color("line_number_color", "TextEdit", Color::html("66aaaaaa"));
-	theme->set_color("safe_line_number_color", "TextEdit", Color::html("99aac8aa"));
-	theme->set_color("function_color", "TextEdit", Color::html("66a2ce"));
-	theme->set_color("member_variable_color", "TextEdit", Color::html("e64e59"));
-	theme->set_color("number_color", "TextEdit", Color::html("EB9532"));
+	theme->set_color("line_number_color", "TextEdit", Color(0.67, 0.67, 0.67, 0.4));
+	theme->set_color("safe_line_number_color", "TextEdit", Color(0.67, 0.78, 0.67, 0.6));
+	theme->set_color("function_color", "TextEdit", Color(0.4, 0.64, 0.81));
+	theme->set_color("member_variable_color", "TextEdit", Color(0.9, 0.31, 0.35));
+	theme->set_color("number_color", "TextEdit", Color(0.92, 0.58, 0.2));
 	theme->set_color("word_highlighted_color", "TextEdit", Color(0.8, 0.9, 0.9, 0.15));
 
 	theme->set_constant("completion_lines", "TextEdit", 7);
@@ -651,7 +651,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("cursor_color", "Tree", Color(0, 0, 0));
 	theme->set_color("guide_color", "Tree", Color(0, 0, 0, 0.1));
 	theme->set_color("drop_position_color", "Tree", Color(1, 0.3, 0.2));
-	theme->set_color("relationship_line_color", "Tree", Color::html("464646"));
+	theme->set_color("relationship_line_color", "Tree", Color(0.27, 0.27, 0.27));
 	theme->set_color("custom_button_font_highlight", "Tree", control_font_color_hover);
 
 	theme->set_constant("hseparation", "Tree", 4 * scale);


### PR DESCRIPTION
This results in slightly smaller binaries (-17 KB for an editor binary) as no strings need to be allocated. This also has the benefit of providing compile-time checking and better syntax consistency.