### PR TITLE
Improve the node configuration warning display

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -663,7 +663,7 @@ StringName AnimatedSprite::get_animation() const {
 String AnimatedSprite::get_configuration_warning() const {
 
 	if (frames.is_null()) {
-		return TTR("A SpriteFrames resource must be created or set in the 'Frames' property in order for AnimatedSprite to display frames.");
+		return TTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite to display frames.");
 	}
 
 	return String();

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -389,7 +389,7 @@ String CollisionObject2D::get_configuration_warning() const {
 
 	if (shapes.empty()) {
 		if (!warning.empty()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 		warning += TTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape2D or CollisionPolygon2D as a child to define its shape.");
 	}

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -347,7 +347,7 @@ void Light2D::_notification(int p_what) {
 String Light2D::get_configuration_warning() const {
 
 	if (!texture.is_valid()) {
-		return TTR("A texture with the shape of the light must be supplied to the 'texture' property.");
+		return TTR("A texture with the shape of the light must be supplied to the \"Texture\" property.");
 	}
 
 	return String();

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -268,7 +268,7 @@ String LightOccluder2D::get_configuration_warning() const {
 	}
 
 	if (occluder_polygon.is_valid() && occluder_polygon->get_polygon().size() == 0) {
-		return TTR("The occluder polygon for this occluder is empty. Please draw a polygon!");
+		return TTR("The occluder polygon for this occluder is empty. Please draw a polygon.");
 	}
 
 	return String();

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -963,7 +963,7 @@ String RigidBody2D::get_configuration_warning() const {
 
 	if ((get_mode() == MODE_RIGID || get_mode() == MODE_CHARACTER) && (ABS(t.elements[0].length() - 1.0) > 0.05 || ABS(t.elements[1].length() - 1.0) > 0.05)) {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 		warning += TTR("Size changes to RigidBody2D (in character or rigid modes) will be overridden by the physics engine when running.\nChange the size in children collision shapes instead.");
 	}

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -137,7 +137,7 @@ String Bone2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 	if (!skeleton) {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 		if (parent_bone) {
 			warning += TTR("This Bone2D chain should end at a Skeleton2D node.");
@@ -148,7 +148,7 @@ String Bone2D::get_configuration_warning() const {
 
 	if (rest == Transform2D(0, 0, 0, 0, 0, 0)) {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 		warning += TTR("This bone lacks a proper REST pose. Go to the Skeleton2D node and set one.");
 	}

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1780,7 +1780,7 @@ String TileMap::get_configuration_warning() const {
 
 	if (use_parent && !collision_parent) {
 		if (!warning.empty()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 		return TTR("TileMap with Use Parent on needs a parent CollisionObject2D to give shapes to. Please use it as a child of Area2D, StaticBody2D, RigidBody2D, KinematicBody2D, etc. to give them a shape.");
 	}

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -327,7 +327,7 @@ void VisibilityEnabler2D::_node_removed(Node *p_node) {
 String VisibilityEnabler2D::get_configuration_warning() const {
 #ifdef TOOLS_ENABLED
 	if (is_inside_tree() && get_parent() && (get_parent()->get_filename() == String() && get_parent() != get_tree()->get_edited_scene_root())) {
-		return TTR("VisibilityEnable2D works best when used with the edited scene root directly as parent.");
+		return TTR("VisibilityEnabler2D works best when used with the edited scene root directly as parent.");
 	}
 #endif
 	return String();

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -61,7 +61,7 @@ String ARVRCamera::get_configuration_warning() const {
 	// must be child node of ARVROrigin!
 	ARVROrigin *origin = Object::cast_to<ARVROrigin>(get_parent());
 	if (origin == NULL) {
-		return TTR("ARVRCamera must have an ARVROrigin node as its parent");
+		return TTR("ARVRCamera must have an ARVROrigin node as its parent.");
 	};
 
 	return String();

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -371,7 +371,7 @@ String CollisionObject::get_configuration_warning() const {
 
 	if (shapes.empty()) {
 		if (warning == String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 		warning += TTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape or CollisionPolygon as a child to define its shape.");
 	}

--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -120,7 +120,7 @@ String CollisionShape::get_configuration_warning() const {
 	}
 
 	if (!shape.is_valid()) {
-		return TTR("A shape must be provided for CollisionShape to function. Please create a shape resource for it!");
+		return TTR("A shape must be provided for CollisionShape to function. Please create a shape resource for it.");
 	}
 
 	if (shape->is_class("PlaneShape")) {

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -270,7 +270,7 @@ String PathFollow::get_configuration_warning() const {
 	} else {
 		Path *path = Object::cast_to<Path>(get_parent());
 		if (path->get_curve().is_valid() && !path->get_curve()->is_up_vector_enabled() && rotation_mode == ROTATION_ORIENTED) {
-			return TTR("PathFollow ROTATION_ORIENTED requires \"Up Vector\" enabled in its parent Path's Curve resource.");
+			return TTR("PathFollow's ROTATION_ORIENTED requires \"Up Vector\" to be enabled in its parent Path's Curve resource.");
 		}
 	}
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -934,7 +934,7 @@ String RigidBody::get_configuration_warning() const {
 
 	if ((get_mode() == MODE_RIGID || get_mode() == MODE_CHARACTER) && (ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(2).length() - 1.0) > 0.05)) {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 		warning += TTR("Size changes to RigidBody (in character or rigid modes) will be overridden by the physics engine when running.\nChange the size in children collision shapes instead.");
 	}

--- a/scene/3d/remote_transform.cpp
+++ b/scene/3d/remote_transform.cpp
@@ -177,7 +177,7 @@ bool RemoteTransform::get_update_scale() const {
 String RemoteTransform::get_configuration_warning() const {
 
 	if (!has_node(remote_node) || !Object::cast_to<Spatial>(get_node(remote_node))) {
-		return TTR("Path property must point to a valid Spatial node to work.");
+		return TTR("The \"Remote Path\" property must point to a valid Spatial or Spatial-derived node to work.");
 	}
 
 	return String();

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1061,7 +1061,7 @@ StringName AnimatedSprite3D::get_animation() const {
 String AnimatedSprite3D::get_configuration_warning() const {
 
 	if (frames.is_null()) {
-		return TTR("A SpriteFrames resource must be created or set in the 'Frames' property in order for AnimatedSprite3D to display frames.");
+		return TTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite3D to display frames.");
 	}
 
 	return String();

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -80,7 +80,7 @@ Ref<Environment> WorldEnvironment::get_environment() const {
 String WorldEnvironment::get_configuration_warning() const {
 
 	if (!environment.is_valid()) {
-		return TTR("WorldEnvironment needs an Environment resource.");
+		return TTR("WorldEnvironment requires its \"Environment\" property to contain an Environment to have a visible effect.");
 	}
 
 	if (/*!is_visible_in_tree() ||*/ !is_inside_tree())

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1342,15 +1342,15 @@ String AnimationTree::get_configuration_warning() const {
 
 	if (!root.is_valid()) {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
-		warning += TTR("A root AnimationNode for the graph is not set.");
+		warning += TTR("No root AnimationNode for the graph is set.");
 	}
 
 	if (!has_node(animation_player)) {
 
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 
 		warning += TTR("Path to an AnimationPlayer node containing animations is not set.");
@@ -1361,7 +1361,7 @@ String AnimationTree::get_configuration_warning() const {
 
 	if (!player) {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 
 		warning += TTR("Path set for AnimationPlayer does not lead to an AnimationPlayer node.");
@@ -1370,10 +1370,10 @@ String AnimationTree::get_configuration_warning() const {
 
 	if (!player->has_node(player->get_root())) {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 
-		warning += TTR("AnimationPlayer root is not a valid node.");
+		warning += TTR("The AnimationPlayer root node is not a valid node.");
 		return warning;
 	}
 

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -175,9 +175,9 @@ String Container::get_configuration_warning() const {
 
 	if (get_class() == "Container" && get_script().is_null()) {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
-		warning += TTR("Container by itself serves no purpose unless a script configures its children placement behavior.\nIf you don't intend to add a script, then please use a plain 'Control' node instead.");
+		warning += TTR("Container by itself serves no purpose unless a script configures its children placement behavior.\nIf you don't intend to add a script, use a plain Control node instead.");
 	}
 	return warning;
 }

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2711,7 +2711,7 @@ String Control::get_configuration_warning() const {
 
 	if (data.mouse_filter == MOUSE_FILTER_IGNORE && data.tooltip != "") {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
 		warning += TTR("The Hint Tooltip won't be displayed as the control's Mouse Filter is set to \"Ignore\". To solve this, set the Mouse Filter to \"Stop\" or \"Pass\".");
 	}

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -234,7 +234,7 @@ Popup::Popup() {
 String Popup::get_configuration_warning() const {
 
 	if (is_visible_in_tree()) {
-		return TTR("Popups will hide by default unless you call popup() or any of the popup*() functions. Making them visible for editing is fine though, but they will hide upon running.");
+		return TTR("Popups will hide by default unless you call popup() or any of the popup*() functions. Making them visible for editing is fine, but they will hide upon running.");
 	}
 
 	return String();

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -35,9 +35,9 @@ String Range::get_configuration_warning() const {
 
 	if (shared->exp_ratio && shared->min <= 0) {
 		if (warning != String()) {
-			warning += "\n";
+			warning += "\n\n";
 		}
-		warning += TTR("If exp_edit is true min_value must be > 0.");
+		warning += TTR("If \"Exp Edit\" is enabled, \"Min Value\" must be greater than 0.");
 	}
 
 	return warning;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -486,7 +486,7 @@ String ScrollContainer::get_configuration_warning() const {
 	}
 
 	if (found != 1)
-		return TTR("ScrollContainer is intended to work with a single child control.\nUse a container as child (VBox,HBox,etc), or a Control and set the custom minimum size manually.");
+		return TTR("ScrollContainer is intended to work with a single child control.\nUse a container as child (VBox, HBox, etc.), or a Control and set the custom minimum size manually.");
 	else
 		return "";
 }


### PR DESCRIPTION
- Refer to properties explicitly when possible
- When multiple warnings are returned, always separate them by one
  blank line to make them easier to distinguish
- Improve grammar and formatting