### PR TITLE
Fix issues where translations doesn't work because of white space in %s

### DIFF
--- a/editor/translations/ar.po
+++ b/editor/translations/ar.po
@@ -2093,7 +2093,7 @@ msgstr "أخلاء الخرج"
 
 #: editor/editor_node.cpp
 msgid "Project export failed with error code %d."
-msgstr "تصدير المشروع فشل, رمز الخطأ % d."
+msgstr "تصدير المشروع فشل, رمز الخطأ %d."
 
 #: editor/editor_node.cpp
 msgid "Imported resources can't be saved."

--- a/editor/translations/bn.po
+++ b/editor/translations/bn.po
@@ -3634,7 +3634,7 @@ msgstr "ফেবরিট/প্রিয়-সমূহ:"
 
 #: editor/filesystem_dock.cpp
 msgid "Cannot navigate to '%s' as it has not been found in the file system!"
-msgstr "'% s' তে নেভিগেট করা যাবে না কারণ এটি ফাইল সিস্টেমে পাওয়া যায়নি!"
+msgstr "'%s' তে নেভিগেট করা যাবে না কারণ এটি ফাইল সিস্টেমে পাওয়া যায়নি!"
 
 #: editor/filesystem_dock.cpp
 #, fuzzy
@@ -4024,11 +4024,11 @@ msgstr "সংরক্ষিত হচ্ছে..."
 
 #: editor/import_dock.cpp
 msgid "Set as Default for '%s'"
-msgstr "'% s' এর জন্য ডিফল্ট হিসাবে সেট করুন"
+msgstr "'%s' এর জন্য ডিফল্ট হিসাবে সেট করুন"
 
 #: editor/import_dock.cpp
 msgid "Clear Default for '%s'"
-msgstr "'% s' এর জন্য ডিফল্ট ক্লিয়ার  করুন"
+msgstr "'%s' এর জন্য ডিফল্ট ক্লিয়ার  করুন"
 
 #: editor/import_dock.cpp
 #, fuzzy
@@ -8471,7 +8471,7 @@ msgstr ""
 #: editor/plugins/visual_shader_editor_plugin.cpp
 #, fuzzy
 msgid "Set Input Default Port"
-msgstr "'% s' এর জন্য ডিফল্ট হিসাবে সেট করুন"
+msgstr "'%s' এর জন্য ডিফল্ট হিসাবে সেট করুন"
 
 #: editor/plugins/visual_shader_editor_plugin.cpp
 #, fuzzy
@@ -9821,7 +9821,7 @@ msgstr "প্রপার্টি:"
 
 #: editor/project_settings_editor.cpp
 msgid "Setting '%s' is internal, and it can't be deleted."
-msgstr "'% s' সেটিংটি অভ্যন্তরীণ, এবং এটি মোছা যাবে না।"
+msgstr "'%s' সেটিংটি অভ্যন্তরীণ, এবং এটি মোছা যাবে না।"
 
 #: editor/project_settings_editor.cpp
 #, fuzzy

--- a/editor/translations/ca.po
+++ b/editor/translations/ca.po
@@ -1265,7 +1265,7 @@ msgstr "Obre un Disseny de Bus d'Àudio"
 
 #: editor/editor_audio_buses.cpp
 msgid "There is no '%s' file."
-msgstr "No hi ha cap fitxer '% s'."
+msgstr "No hi ha cap fitxer '%s'."
 
 #: editor/editor_audio_buses.cpp editor/plugins/canvas_item_editor_plugin.cpp
 msgid "Layout"
@@ -1546,7 +1546,7 @@ msgstr "Sistema de Fitxers"
 
 #: editor/editor_feature_profile.cpp
 msgid "Erase profile '%s'? (no undo)"
-msgstr "Esborra el perfil '% s'? (no es pot desfer)"
+msgstr "Esborra el perfil '%s'? (no es pot desfer)"
 
 #: editor/editor_feature_profile.cpp
 msgid "Profile must be a valid filename and must not contain '.'"
@@ -1590,14 +1590,14 @@ msgstr "Classes Habilitades:"
 
 #: editor/editor_feature_profile.cpp
 msgid "File '%s' format is invalid, import aborted."
-msgstr "El format del fitxer '% s' no és vàlid, s'ha anul·lat la importació."
+msgstr "El format del fitxer '%s' no és vàlid, s'ha anul·lat la importació."
 
 #: editor/editor_feature_profile.cpp
 msgid ""
 "Profile '%s' already exists. Remove it first before importing, import "
 "aborted."
 msgstr ""
-"El perfil '% s' ja existeix. Elimineu-lo primer abans d'importar, importació "
+"El perfil '%s' ja existeix. Elimineu-lo primer abans d'importar, importació "
 "avortada."
 
 #: editor/editor_feature_profile.cpp
@@ -2082,7 +2082,7 @@ msgstr "Falta '%s' o les seves dependències."
 
 #: editor/editor_node.cpp
 msgid "Error while loading '%s'."
-msgstr "S'ha produït un error en carregar '% s'."
+msgstr "S'ha produït un error en carregar '%s'."
 
 #: editor/editor_node.cpp
 msgid "Saving Scene"
@@ -2353,7 +2353,7 @@ msgstr ""
 msgid "Unable to find script field for addon plugin at: 'res://addons/%s'."
 msgstr ""
 "No s'ha pogut trobar el camp d'Script per al complement a: 'res: // addons /"
-"% s'."
+"%s'."
 
 #: editor/editor_node.cpp
 msgid "Unable to load addon script from path: '%s'."
@@ -2371,13 +2371,13 @@ msgstr ""
 msgid ""
 "Unable to load addon script from path: '%s' Base type is not EditorPlugin."
 msgstr ""
-"No es pot carregar l'Script complementari: El tipus base de '% s' no és pas "
+"No es pot carregar l'Script complementari: El tipus base de '%s' no és pas "
 "EditorPlugin."
 
 #: editor/editor_node.cpp
 msgid "Unable to load addon script from path: '%s' Script is not in tool mode."
 msgstr ""
-"No s'ha carregat l'Script d'addon des del camí: L'Script '% s' no és en el "
+"No s'ha carregat l'Script d'addon des del camí: L'Script '%s' no és en el "
 "mode d'Eina."
 
 #: editor/editor_node.cpp
@@ -9187,7 +9187,7 @@ msgstr ""
 
 #: editor/project_settings_editor.cpp
 msgid "An action with the name '%s' already exists."
-msgstr "Ja existeix una acció amb el nom '% s'."
+msgstr "Ja existeix una acció amb el nom '%s'."
 
 #: editor/project_settings_editor.cpp
 msgid "Rename Input Action Event"
@@ -10996,7 +10996,7 @@ msgstr "Un dígit no pot ser el primer caràcter d'un segment de paquets."
 #, fuzzy
 msgid "The character '%s' cannot be the first character in a package segment."
 msgstr ""
-"El caràcter '% s' no pot ser el primer caràcter d'un segment de paquets."
+"El caràcter '%s' no pot ser el primer caràcter d'un segment de paquets."
 
 #: platform/android/export/export.cpp
 msgid "The package must have at least one '.' separator."
@@ -11074,7 +11074,7 @@ msgstr ""
 
 #: platform/iphone/export/export.cpp
 msgid "The character '%s' is not allowed in Identifier."
-msgstr "No es permet el caràcter '% s' en l'Identificador."
+msgstr "No es permet el caràcter '%s' en l'Identificador."
 
 #: platform/iphone/export/export.cpp
 msgid "A digit cannot be the first character in a Identifier segment."
@@ -11084,7 +11084,7 @@ msgstr "Un dígit no pot ser el primer caràcter en un segment Identificador."
 msgid ""
 "The character '%s' cannot be the first character in a Identifier segment."
 msgstr ""
-"El caràcter '% s' no pot ser el primer caràcter en un segment Identificador."
+"El caràcter '%s' no pot ser el primer caràcter en un segment Identificador."
 
 #: platform/iphone/export/export.cpp
 msgid "The Identifier must have at least one '.' separator."

--- a/editor/translations/hi.po
+++ b/editor/translations/hi.po
@@ -34,7 +34,7 @@ msgstr "डीकोडिंग बाइट्स, या अमान्य �
 
 #: core/math/expression.cpp
 msgid "Invalid input %i (not passed) in expression"
-msgstr "अभिव्यक्ति में अमान्य इनपुट % i (पारित नहीं)"
+msgstr "अभिव्यक्ति में अमान्य इनपुट %i (पारित नहीं)"
 
 #: core/math/expression.cpp
 msgid "self can't be used because instance is null (not passed)"
@@ -58,7 +58,7 @@ msgstr "'%s' बनाने के लिए अवैध तर्क"
 
 #: core/math/expression.cpp
 msgid "On call to '%s':"
-msgstr "'% s ' को कॉल करने पर:"
+msgstr "'%s ' को कॉल करने पर:"
 
 #: editor/animation_bezier_editor.cpp
 #: editor/plugins/asset_library_editor_plugin.cpp

--- a/editor/translations/id.po
+++ b/editor/translations/id.po
@@ -2040,7 +2040,7 @@ msgstr "Bersihkan Luaran"
 
 #: editor/editor_node.cpp
 msgid "Project export failed with error code %d."
-msgstr "Ekspor proyek gagal dengan kode kesalahan% d."
+msgstr "Ekspor proyek gagal dengan kode kesalahan %d."
 
 #: editor/editor_node.cpp
 msgid "Imported resources can't be saved."

--- a/editor/translations/pt_BR.po
+++ b/editor/translations/pt_BR.po
@@ -8735,7 +8735,7 @@ msgid ""
 "Failed to export the project for platform '%s'.\n"
 "Export templates seem to be missing or invalid."
 msgstr ""
-"Falha ao exportar o projeto para a plataforma '% s'.\n"
+"Falha ao exportar o projeto para a plataforma '%s'.\n"
 "Os modelos de exportação parecem estar ausentes ou inválidos."
 
 #: editor/project_export.cpp

--- a/editor/translations/ru.po
+++ b/editor/translations/ru.po
@@ -949,7 +949,7 @@ msgid ""
 "Resource '%s' is in use.\n"
 "Changes will only take effect when reloaded."
 msgstr ""
-"Ресурс '% s' используется.\n"
+"Ресурс '%s' используется.\n"
 "Изменения вступят в силу только после перезапуска."
 
 #: editor/dependency_editor.cpp
@@ -2419,7 +2419,7 @@ msgid ""
 "Unable to load addon script from path: '%s' There seems to be an error in "
 "the code, please check the syntax."
 msgstr ""
-"Невозможно загрузить скрипт аддона из источника: \"% s\". В коде есть "
+"Невозможно загрузить скрипт аддона из источника: '%s' В коде есть "
 "ошибка. Пожалуйста, проверьте синтаксис."
 
 #: editor/editor_node.cpp

--- a/editor/translations/te.po
+++ b/editor/translations/te.po
@@ -30,7 +30,7 @@ msgstr "డీకోడింగ్ బైట్లు కోసం తగిన
 #: core/math/expression.cpp
 #, fuzzy
 msgid "Invalid input %i (not passed) in expression"
-msgstr "వ్యక్తీకరణలో చెల్లని ఇన్పుట్% i (ఆమోదించబడలేదు)"
+msgstr "వ్యక్తీకరణలో చెల్లని ఇన్పుట్ %i (ఆమోదించబడలేదు)"
 
 #: core/math/expression.cpp
 #, fuzzy

--- a/editor/translations/tr.po
+++ b/editor/translations/tr.po
@@ -2439,7 +2439,7 @@ msgid ""
 "Scene '%s' was automatically imported, so it can't be modified.\n"
 "To make changes to it, a new inherited scene can be created."
 msgstr ""
-"Sahne '% s' otomatik olarak içe aktarıldı, bu nedenle değiştirilemez.\n"
+"Sahne '%s' otomatik olarak içe aktarıldı, bu nedenle değiştirilemez.\n"
 "Değişiklik yapmak için miras alınmış yeni bir sahne oluşturulabilir."
 
 #: editor/editor_node.cpp

--- a/editor/translations/zh_CN.po
+++ b/editor/translations/zh_CN.po
@@ -10936,7 +10936,7 @@ msgstr "标识符字段不能为空."
 
 #: platform/iphone/export/export.cpp
 msgid "The character '%s' is not allowed in Identifier."
-msgstr "标识符中不允许使用字符 '% s' 。"
+msgstr "标识符中不允许使用字符 '%s' 。"
 
 #: platform/iphone/export/export.cpp
 msgid "A digit cannot be the first character in a Identifier segment."

--- a/editor/translations/zh_TW.po
+++ b/editor/translations/zh_TW.po
@@ -58,7 +58,7 @@ msgstr "無效的內存地址類型 %s，基礎型式 %s"
 
 #: core/math/expression.cpp
 msgid "Invalid named index '%s' for base type %s"
-msgstr "基本類型 %s 的命名索引 '% s' 無效"
+msgstr "基本類型 %s 的命名索引 '%s' 無效"
 
 #: core/math/expression.cpp
 msgid "Invalid arguments to construct '%s'"
@@ -3383,7 +3383,7 @@ msgstr "下載完成。"
 msgid ""
 "Templates installation failed. The problematic templates archives can be "
 "found at '%s'."
-msgstr "範本安裝失敗。有問題的範本存檔可以在 \"% s\" 中找到。"
+msgstr "範本安裝失敗。有問題的範本存檔可以在 \"%s\" 中找到。"
 
 #: editor/export_template_manager.cpp
 #, fuzzy


### PR DESCRIPTION
The crux of the issue is a white space between '%' and 's'.
I have fixed similar problems than found in #30063