### PR TITLE
Fix "not" shader function return type

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -1918,9 +1918,9 @@ const ShaderLanguage::BuiltinFuncDef ShaderLanguage::builtin_func_defs[] = {
 	{ "all", TYPE_BOOL, { TYPE_BVEC3, TYPE_VOID } },
 	{ "all", TYPE_BOOL, { TYPE_BVEC4, TYPE_VOID } },
 
-	{ "not", TYPE_BOOL, { TYPE_BVEC2, TYPE_VOID } },
-	{ "not", TYPE_BOOL, { TYPE_BVEC3, TYPE_VOID } },
-	{ "not", TYPE_BOOL, { TYPE_BVEC4, TYPE_VOID } },
+	{ "not", TYPE_BVEC2, { TYPE_BVEC2, TYPE_VOID } },
+	{ "not", TYPE_BVEC3, { TYPE_BVEC3, TYPE_VOID } },
+	{ "not", TYPE_BVEC4, { TYPE_BVEC4, TYPE_VOID } },
 
 	//builtins - texture
 	{ "textureSize", TYPE_IVEC2, { TYPE_SAMPLER2D, TYPE_INT, TYPE_VOID } },


### PR DESCRIPTION
Detected malfunctioned function -> should return bvec instead bool

https://www.khronos.org/registry/OpenGL-Refpages/es3/html/not.xhtml