### PR TITLE
Fix export templates ignoring assemblies in 'res://.mono/assemblies'

### DIFF
--- a/modules/mono/build_scripts/solution_builder.py
+++ b/modules/mono/build_scripts/solution_builder.py
@@ -112,6 +112,11 @@ def find_msbuild_windows(env):
     mono_bin_dir = os.path.join(mono_root, 'bin')
     msbuild_mono = os.path.join(mono_bin_dir, 'msbuild.bat')
 
+    msbuild_tools_path = find_msbuild_tools_path_reg()
+
+    if msbuild_tools_path:
+        return (os.path.join(msbuild_tools_path, 'MSBuild.exe'), framework_path, {})
+
     if os.path.isfile(msbuild_mono):
         # The (Csc/Vbc/Fsc)ToolExe environment variables are required when
         # building with Mono's MSBuild. They must point to the batch files
@@ -122,11 +127,6 @@ def find_msbuild_windows(env):
             'FscToolExe': os.path.join(mono_bin_dir, 'fsharpc.bat')
         }
         return (msbuild_mono, framework_path, mono_msbuild_env)
-
-    msbuild_tools_path = find_msbuild_tools_path_reg()
-
-    if msbuild_tools_path:
-        return (os.path.join(msbuild_tools_path, 'MSBuild.exe'), framework_path, {})
 
     return None
 

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -46,20 +46,6 @@ bool GDMonoAssembly::in_preload = false;
 
 Vector<String> GDMonoAssembly::search_dirs;
 
-static String _get_expected_api_build_config() {
-#ifdef TOOLS_ENABLED
-	return "Debug";
-#else
-
-#ifdef DEBUG_ENABLED
-	return "Debug";
-#else
-	return "Release";
-#endif
-
-#endif
-}
-
 void GDMonoAssembly::fill_search_dirs(Vector<String> &r_search_dirs, const String &p_custom_config, const String &p_custom_bcl_dir) {
 
 	String framework_dir;
@@ -81,11 +67,14 @@ void GDMonoAssembly::fill_search_dirs(Vector<String> &r_search_dirs, const Strin
 		r_search_dirs.push_back(GodotSharpDirs::get_res_temp_assemblies_dir());
 	}
 
-	String api_config = p_custom_config.empty() ? _get_expected_api_build_config() :
-												  (p_custom_config == "Release" ? "Release" : "Debug");
-	r_search_dirs.push_back(GodotSharpDirs::get_res_assemblies_base_dir().plus_file(api_config));
+	if (p_custom_config.empty()) {
+		r_search_dirs.push_back(GodotSharpDirs::get_res_assemblies_dir());
+	} else {
+		String api_config = p_custom_config == "Release" ? "Release" : "Debug";
+		r_search_dirs.push_back(GodotSharpDirs::get_res_assemblies_base_dir().plus_file(api_config));
+	}
 
-	r_search_dirs.push_back(GodotSharpDirs::get_res_assemblies_dir());
+	r_search_dirs.push_back(GodotSharpDirs::get_res_assemblies_base_dir());
 	r_search_dirs.push_back(OS::get_singleton()->get_resource_dir());
 	r_search_dirs.push_back(OS::get_singleton()->get_executable_path().get_base_dir());
 


### PR DESCRIPTION
The idea is for it to look first at `res://.mono/assemblies/{Debug|Release}` and then at `res://.mono/assemblies`, but instead we were looking at the former twice.

Also made SCons check for System MSBuild before Mono's, like the Godot editor does.
