### PR TITLE
Better detect Emscripten toolchain.

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -69,9 +69,14 @@ def configure(env):
             exec(f.read(), em_config)
         except StandardError as e:
             raise RuntimeError("Emscripten configuration file '%s' is invalid:\n%s" % (em_config_file, e))
-    if 'BINARYEN_ROOT' not in em_config and 'EMSCRIPTEN_ROOT' not in em_config:
+    if 'BINARYEN_ROOT' in em_config and os.path.isdir(os.path.join(em_config.get('BINARYEN_ROOT'), 'emscripten')):
+        # New style, emscripten path as a subfolder of BINARYEN_ROOT
+        env.PrependENVPath('PATH', os.path.join(em_config.get('BINARYEN_ROOT'), 'emscripten'))
+    elif 'EMSCRIPTEN_ROOT' in em_config:
+        # Old style (but can be there as a result from previous activation, so do last)
+        env.PrependENVPath('PATH', em_config.get('EMSCRIPTEN_ROOT'))
+    else:
         raise RuntimeError("'BINARYEN_ROOT' or 'EMSCRIPTEN_ROOT' missing in Emscripten configuration file '%s'" % em_config_file)
-    env.PrependENVPath('PATH', em_config.get('BINARYEN_ROOT', em_config.get('EMSCRIPTEN_ROOT')))
 
     env['CC'] = 'emcc'
     env['CXX'] = 'em++'


### PR DESCRIPTION
Emscripten is apparently changing the variables in its config file,
causing potential breakage of our build system.

Binaries of the latest/latest-upstream releases are located in a
subfolder of BINARYEN_ROOT called emscripten.
Binaries of the other releases (e.g. emscripten-1.38.31) are instead
placed under the EMSCRIPTEN_ROOT folder.

This PR checks if BINARYEN_ROOT has a subfolder called emscripten, if
that does not exists, it falls back to checking the EMSCRIPTEN_ROOT.

This way we give precedence to the new releases, given that activating
multiple releases sequentially might result in having mismatching
BINARYEN_ROOT and EMSCRIPTEN_ROOT.

See discussion in #29482 for more details.