### PR TITLE
Correct grayscale to consider luminance value

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -396,8 +396,10 @@ static void _convert(int p_width, int p_height, const uint8_t *p_src, uint8_t *p
 			}
 
 			if (write_gray) {
-				//TODO: not correct grayscale, should use fixed point version of actual weights
-				wofs[0] = uint8_t((uint16_t(rofs[0]) + uint16_t(rofs[1]) + uint16_t(rofs[2])) / 3);
+				wofs[0] = uint8_t((
+						uint16_t(rofs[0]) / 3 +
+						uint16_t(rofs[1]) / 2 +
+						uint16_t(rofs[2]) / 10));
 			} else {
 				for (uint32_t i = 0; i < write_bytes; i++) {
 


### PR DESCRIPTION
According to this article http://www.tannerhelland.com/3643/grayscale-image-algorithm-vb6/ , the human eye does not perceive RGB equally.
The actual formula is given by : Gray = (Red * 0.3 + Green * 0.59 + Blue * 0.11)
But for the sake of computation, I only use its integer approximation.

It was originally a TODO for 3 years.