### PR TITLE
Fix EditorNavigationMeshGenerator registered in Core API

### DIFF
--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -1,0 +1,242 @@
+/*************************************************************************/
+/*  class_db_api_json.cpp                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "class_db_api_json.h"
+
+#include "core/io/json.h"
+#include "core/os/file_access.h"
+#include "core/project_settings.h"
+#include "core/version.h"
+
+void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
+	Dictionary classes_dict;
+
+	List<StringName> names;
+
+	const StringName *k = NULL;
+
+	while ((k = ClassDB::classes.next(k))) {
+
+		names.push_back(*k);
+	}
+	//must be alphabetically sorted for hash to compute
+	names.sort_custom<StringName::AlphCompare>();
+
+	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+
+		ClassDB::ClassInfo *t = ClassDB::classes.getptr(E->get());
+		ERR_FAIL_COND(!t);
+		if (t->api != p_api || !t->exposed)
+			continue;
+
+		Dictionary class_dict;
+		classes_dict[t->name] = class_dict;
+
+		class_dict["inherits"] = t->inherits;
+
+		{ //methods
+
+			List<StringName> snames;
+
+			k = NULL;
+
+			while ((k = t->method_map.next(k))) {
+
+				snames.push_back(*k);
+			}
+
+			snames.sort_custom<StringName::AlphCompare>();
+
+			Array methods;
+
+			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
+				Dictionary method_dict;
+				methods.push_back(method_dict);
+
+				MethodBind *mb = t->method_map[F->get()];
+				method_dict["name"] = mb->get_name();
+				method_dict["argument_count"] = mb->get_argument_count();
+				method_dict["return_type"] = mb->get_argument_type(-1);
+
+				Array arguments;
+				method_dict["arguments"] = arguments;
+
+				for (int i = 0; i < mb->get_argument_count(); i++) {
+					Dictionary argument_dict;
+					arguments.push_back(argument_dict);
+					const PropertyInfo info = mb->get_argument_info(i);
+					argument_dict["type"] = info.type;
+					argument_dict["name"] = info.name;
+					argument_dict["hint"] = info.hint;
+					argument_dict["hint_string"] = info.hint_string;
+				}
+
+				method_dict["default_argument_count"] = mb->get_default_argument_count();
+
+				Array default_arguments;
+				method_dict["default_arguments"] = default_arguments;
+
+				for (int i = 0; i < mb->get_default_argument_count(); i++) {
+					Dictionary default_argument_dict;
+					default_arguments.push_back(default_argument_dict);
+					//hash should not change, i hope for tis
+					Variant da = mb->get_default_argument(i);
+					default_argument_dict["value"] = da;
+				}
+
+				method_dict["hint_flags"] = mb->get_hint_flags();
+			}
+
+			if (!methods.empty()) {
+				class_dict["methods"] = methods;
+			}
+		}
+
+		{ //constants
+
+			List<StringName> snames;
+
+			k = NULL;
+
+			while ((k = t->constant_map.next(k))) {
+
+				snames.push_back(*k);
+			}
+
+			snames.sort_custom<StringName::AlphCompare>();
+
+			Array constants;
+
+			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
+				Dictionary constant_dict;
+				constants.push_back(constant_dict);
+
+				constant_dict["name"] = F->get();
+				constant_dict["value"] = t->constant_map[F->get()];
+			}
+
+			if (!constants.empty()) {
+				class_dict["constants"] = constants;
+			}
+		}
+
+		{ //signals
+
+			List<StringName> snames;
+
+			k = NULL;
+
+			while ((k = t->signal_map.next(k))) {
+
+				snames.push_back(*k);
+			}
+
+			snames.sort_custom<StringName::AlphCompare>();
+
+			Array signals;
+
+			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
+				Dictionary signal_dict;
+				signals.push_back(signal_dict);
+
+				MethodInfo &mi = t->signal_map[F->get()];
+				signal_dict["name"] = F->get();
+
+				Array arguments;
+				signal_dict["arguments"] = arguments;
+				for (int i = 0; i < mi.arguments.size(); i++) {
+					Dictionary argument_dict;
+					arguments.push_back(argument_dict);
+					argument_dict["type"] = mi.arguments[i].type;
+				}
+			}
+
+			if (!signals.empty()) {
+				class_dict["signals"] = signals;
+			}
+		}
+
+		{ //properties
+
+			List<StringName> snames;
+
+			k = NULL;
+
+			while ((k = t->property_setget.next(k))) {
+
+				snames.push_back(*k);
+			}
+
+			snames.sort_custom<StringName::AlphCompare>();
+
+			Array properties;
+
+			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
+				Dictionary property_dict;
+				properties.push_back(property_dict);
+
+				ClassDB::PropertySetGet *psg = t->property_setget.getptr(F->get());
+
+				property_dict["name"] = F->get();
+				property_dict["setter"] = psg->setter;
+				property_dict["getter"] = psg->getter;
+			}
+
+			if (!properties.empty()) {
+				class_dict["property_setget"] = properties;
+			}
+		}
+
+		Array property_list;
+
+		//property list
+		for (List<PropertyInfo>::Element *F = t->property_list.front(); F; F = F->next()) {
+			Dictionary property_dict;
+			property_list.push_back(property_dict);
+
+			property_dict["name"] = F->get().name;
+			property_dict["type"] = F->get().type;
+			property_dict["hint"] = F->get().hint;
+			property_dict["hint_string"] = F->get().hint_string;
+			property_dict["usage"] = F->get().usage;
+		}
+
+		if (!property_list.empty()) {
+			class_dict["property_list"] = property_list;
+		}
+	}
+
+	FileAccessRef f = FileAccess::open(p_output_file, FileAccess::WRITE);
+	ERR_FAIL_COND(!f);
+	f->store_string(JSON::print(classes_dict, /*indent: */ "\t"));
+	f->close();
+
+	print_line(String() + "ClassDB API JSON written to: " + ProjectSettings::get_singleton()->globalize_path(p_output_file));
+}

--- a/modules/mono/class_db_api_json.h
+++ b/modules/mono/class_db_api_json.h
@@ -1,12 +1,12 @@
 /*************************************************************************/
-/*  register_types.cpp                                                   */
+/*  class_db_api_json.h                                                  */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
 /*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */
@@ -28,34 +28,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "register_types.h"
+#ifndef CLASS_DB_API_JSON_H
+#define CLASS_DB_API_JSON_H
 
-#include "navigation_mesh_editor_plugin.h"
+#include "core/class_db.h"
+#include "core/ustring.h"
 
-#ifdef TOOLS_ENABLED
-EditorNavigationMeshGenerator *_nav_mesh_generator = NULL;
-#endif
+void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api);
 
-void register_recast_types() {
-#ifdef TOOLS_ENABLED
-	EditorPlugins::add_by_type<NavigationMeshEditorPlugin>();
-	_nav_mesh_generator = memnew(EditorNavigationMeshGenerator);
-
-	ClassDB::APIType prev_api = ClassDB::get_current_api();
-	ClassDB::set_current_api(ClassDB::API_EDITOR);
-
-	ClassDB::register_class<EditorNavigationMeshGenerator>();
-
-	ClassDB::set_current_api(prev_api);
-
-	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationMeshGenerator", EditorNavigationMeshGenerator::get_singleton()));
-#endif
-}
-
-void unregister_recast_types() {
-#ifdef TOOLS_ENABLED
-	if (_nav_mesh_generator) {
-		memdelete(_nav_mesh_generator);
-	}
-#endif
-}
+#endif // CLASS_DB_API_JSON_H

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -44,6 +44,10 @@
 #include "editor/editor_node.h"
 #endif
 
+#ifdef DEBUG_METHODS_ENABLED
+#include "class_db_api_json.h"
+#endif
+
 #include "editor/editor_internal_calls.h"
 #include "godotsharp_dirs.h"
 #include "mono_gd/gd_mono_class.h"
@@ -97,6 +101,15 @@ Error CSharpLanguage::execute_file(const String &p_path) {
 }
 
 void CSharpLanguage::init() {
+
+#ifdef DEBUG_METHODS_ENABLED
+	if (OS::get_singleton()->get_cmdline_args().find("--class_db_to_json")) {
+		class_db_api_to_json("user://class_db_api.json", ClassDB::API_CORE);
+#ifdef TOOLS_ENABLED
+		class_db_api_to_json("user://class_db_api_editor.json", ClassDB::API_EDITOR);
+#endif
+	}
+#endif
 
 	gdmono = memnew(GDMono);
 	gdmono->initialize();


### PR DESCRIPTION
EditorNavigationMeshGenerator should be registered as part of the Editor API. This was causing an API hash mismatch in export templates with Mono enabled.

Also added an option to output a json file with all the ClassDB registered classes and its members. This can be used to compare the API of two different builds by a simple diff. Quite useful to find what is causing a API hash mismatch.
