### PR TITLE
Fix incorrect X position of line length guideline

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -683,7 +683,7 @@ void TextEdit::_notification(int p_what) {
 			}
 
 			if (line_length_guideline) {
-				int x = xmargin_beg + cache.font->get_char_size('0').width * line_length_guideline_col - cursor.x_ofs;
+				int x = xmargin_beg + (int)cache.font->get_char_size('0').width * line_length_guideline_col - cursor.x_ofs;
 				if (x > xmargin_beg && x < xmargin_end) {
 					VisualServer::get_singleton()->canvas_item_add_line(ci, Point2(x, 0), Point2(x, size.height), cache.line_length_guideline_color);
 				}


### PR DESCRIPTION
Hi all ^ ^

This fixes #29834. I am able to confirm with different fonts including Hack, Fira Mono and Mononoki.

While font dimensions are fractional, the editor module heavily uses integral coordinates, leading to this problem. It's solved by rounding the character width before multiplying.

Despite the fix, I don't see an obvious reason to round all dimensions to integers. Is it intentional? Shall we switch to `float`'s? If that's desirable I'd be glad to make follow-up changes.