### PR TITLE
Notify changes in properties that can be edited by 3D gizmos

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1067,6 +1067,7 @@ void CSGSphere::set_radius(const float p_radius) {
 	radius = p_radius;
 	_make_dirty();
 	update_gizmo();
+	_change_notify("radius");
 }
 
 float CSGSphere::get_radius() const {
@@ -1251,6 +1252,7 @@ void CSGBox::set_width(const float p_width) {
 	width = p_width;
 	_make_dirty();
 	update_gizmo();
+	_change_notify("width");
 }
 
 float CSGBox::get_width() const {
@@ -1261,6 +1263,7 @@ void CSGBox::set_height(const float p_height) {
 	height = p_height;
 	_make_dirty();
 	update_gizmo();
+	_change_notify("height");
 }
 
 float CSGBox::get_height() const {
@@ -1271,6 +1274,7 @@ void CSGBox::set_depth(const float p_depth) {
 	depth = p_depth;
 	_make_dirty();
 	update_gizmo();
+	_change_notify("depth");
 }
 
 float CSGBox::get_depth() const {
@@ -1465,6 +1469,7 @@ void CSGCylinder::set_radius(const float p_radius) {
 	radius = p_radius;
 	_make_dirty();
 	update_gizmo();
+	_change_notify("radius");
 }
 
 float CSGCylinder::get_radius() const {
@@ -1475,6 +1480,7 @@ void CSGCylinder::set_height(const float p_height) {
 	height = p_height;
 	_make_dirty();
 	update_gizmo();
+	_change_notify("height");
 }
 
 float CSGCylinder::get_height() const {
@@ -1690,6 +1696,7 @@ void CSGTorus::set_inner_radius(const float p_inner_radius) {
 	inner_radius = p_inner_radius;
 	_make_dirty();
 	update_gizmo();
+	_change_notify("inner_radius");
 }
 
 float CSGTorus::get_inner_radius() const {
@@ -1700,6 +1707,7 @@ void CSGTorus::set_outer_radius(const float p_outer_radius) {
 	outer_radius = p_outer_radius;
 	_make_dirty();
 	update_gizmo();
+	_change_notify("outer_radius");
 }
 
 float CSGTorus::get_outer_radius() const {

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -791,6 +791,7 @@ void AudioStreamPlayer3D::set_emission_angle(float p_angle) {
 	ERR_FAIL_COND(p_angle < 0 || p_angle > 90);
 	emission_angle = p_angle;
 	update_gizmo();
+	_change_notify("emission_angle");
 }
 
 float AudioStreamPlayer3D::get_emission_angle() const {

--- a/scene/3d/baked_lightmap.cpp
+++ b/scene/3d/baked_lightmap.cpp
@@ -215,6 +215,7 @@ float BakedLightmap::get_capture_cell_size() const {
 void BakedLightmap::set_extents(const Vector3 &p_extents) {
 	extents = p_extents;
 	update_gizmo();
+	_change_notify("bake_extents");
 }
 
 Vector3 BakedLightmap::get_extents() const {

--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -243,6 +243,7 @@ void GIProbe::set_extents(const Vector3 &p_extents) {
 
 	extents = p_extents;
 	update_gizmo();
+	_change_notify("extents");
 }
 
 Vector3 GIProbe::get_extents() const {


### PR DESCRIPTION
This makes the Inspector always display an up-to-date value after editing properties using 3D gizmos.