### PR TITLE
Fix inability to insert keys via Insert Key context menu

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2487,7 +2487,7 @@ bool Node::has_node_and_resource(const NodePath &p_path) const {
 	Vector<StringName> leftover_path;
 	Node *node = get_node_and_resource(p_path, res, leftover_path, false);
 
-	return (node && res.is_valid());
+	return node;
 }
 
 Array Node::_get_node_and_resource(const NodePath &p_path) {
@@ -2525,9 +2525,15 @@ Node *Node::get_node_and_resource(const NodePath &p_path, RES &r_res, Vector<Str
 		int j = 0;
 		// If not p_last_is_property, we shouldn't consider the last one as part of the resource
 		for (; j < p_path.get_subname_count() - (int)p_last_is_property; j++) {
-			RES new_res = j == 0 ? node->get(p_path.get_subname(j)) : r_res->get(p_path.get_subname(j));
+			Variant new_res_v = j == 0 ? node->get(p_path.get_subname(j)) : r_res->get(p_path.get_subname(j));
 
-			if (new_res.is_null()) {
+			if (new_res_v.get_type() == Variant::NIL) { // Found nothing on that path
+				return NULL;
+			}
+
+			RES new_res = new_res_v;
+
+			if (new_res.is_null()) { // No longer a resource, assume property
 				break;
 			}
 


### PR DESCRIPTION
Fixes #30495.

Note that the cause is a bit complicated:
1. `AnimationTrackEdtior._find_hint_for_track` checks if the passed in path is valid with `has_node_and_resource`.
    https://github.com/godotengine/godot/blob/1abe12f5bb869605646797e043db88bb3d428e62/editor/animation_track_editor.cpp#L3138-L3144
2. The `AnimationTrackEdtior` uses `_find_hint_for_track` to get the value at the given path.
    https://github.com/godotengine/godot/blob/1abe12f5bb869605646797e043db88bb3d428e62/editor/animation_track_editor.cpp#L3948-L3954
3. `UndoRedo` assumes that method arguments end at the first `null` (`Variant()`).
    https://github.com/godotengine/godot/blob/1abe12f5bb869605646797e043db88bb3d428e62/core/undo_redo.cpp#L284-L290
4. Since `has_node_and_resource` returns `false` for a otherwise valid path,
    `_find_hint_for_track` does not set `r_current_val`,
    which results in the 3rd argument to `track_insert_key` ending up `null`.
    Then `UndoRedo._process_operation_list` calls the method with only two parameters,
    and all results in an error message and no work done.

Regression from #30088, CC @akien-mga.