### PR TITLE
doc: Mention `Input.MOUSE_MODE_CAPTURED` is raw on Windows and Linux

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -392,7 +392,7 @@
 			Makes the mouse cursor hidden if it is visible.
 		</constant>
 		<constant name="MOUSE_MODE_CAPTURED" value="2" enum="MouseMode">
-			Captures the mouse. The mouse will be hidden and unable to leave the game window, but it will still register movement and mouse button presses.
+			Captures the mouse. The mouse will be hidden and unable to leave the game window, but it will still register movement and mouse button presses. On Windows and Linux, the mouse will use raw input mode, which means the reported movement will be unaffected by the OS' mouse acceleration settings.
 		</constant>
 		<constant name="MOUSE_MODE_CONFINED" value="3" enum="MouseMode">
 			Makes the mouse cursor visible but confines it to the game window.


### PR DESCRIPTION
This was suggested by someone on Discord :slightly_smiling_face: