### PR TITLE
String::operator= should return a reference to "this"

### DIFF
--- a/core/ustring.h
+++ b/core/ustring.h
@@ -352,7 +352,7 @@ public:
 
 	_FORCE_INLINE_ String() {}
 	_FORCE_INLINE_ String(const String &p_str) { _cowdata._ref(p_str._cowdata); }
-	String operator=(const String &p_str) {
+	String &operator=(const String &p_str) {
 		_cowdata._ref(p_str._cowdata);
 		return *this;
 	}


### PR DESCRIPTION
Avoids copying and I am pretty sure a user would expect `a` and `b` of `const String& a = b` to have the same address.