### PR TITLE
Added signals to AnimationNodeStateMachine

### DIFF
--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -164,6 +164,7 @@ private:
 	Vector2 graph_offset;
 
 	void _tree_changed();
+	void _on_playback_state_changed(const StringName &p_from_state, const StringName &p_to_state);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Sorry for re-opening this PR but I royally screwed the last one (#24328) so please forgive me; it's been recently closed in favor of this PR.

This should expose the `from_state` and `to_state` when an AnimationNodeStateMachine changes states. This should allow for a more direct control with AnimationTrees; by setting "advance parameters" in the tree, there can be a response when the signal is emitted.

I welcome any additional testing but this works on my machine quite well and I can't seem to find errors. Let me know if you can.