### PR TITLE
Fix GraphNode immediately losing focus

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -599,6 +599,8 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 
 			Vector2 mpos = Vector2(mb->get_position().x, mb->get_position().y);
 			if (close_rect.size != Size2() && close_rect.has_point(mpos)) {
+				//send focus to parent
+				get_parent_control()->grab_focus();
 				emit_signal("close_request");
 				accept_event();
 				return;
@@ -615,9 +617,7 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 				return;
 			}
 
-			//send focus to parent
 			emit_signal("raise_request");
-			get_parent_control()->grab_focus();
 		}
 
 		if (!mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {


### PR DESCRIPTION
Closes: #30243

GraphNode immediately loses focus, and gives focus to its parent.

This fix changes implementation so that it does not transfer focus to its parent after receiving focus.