### PR TITLE
Improvements on searching in the settings dialog

### DIFF
--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -50,6 +50,8 @@ class SectionedInspector : public HSplitContainer {
 	EditorInspector *inspector;
 	LineEdit *search_box;
 
+	String selected_category;
+
 	static void _bind_methods();
 	void _section_selected();
 


### PR DESCRIPTION
Here is a little improvement, hope it will make life better 😝

The functionality used to be broken when the search string contained spaces, or when it is a subsequence (instead of a substring) of the desired items (in which case the panel will find them but the tree won't). This is now fixed, and the first category is selected by default on startup. Project settings and editor settings are both tested.