### PR TITLE
Some small fixes to warnings in python scripts

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -63,8 +63,8 @@ def make_fonts_header(target, source, env):
 
         g.write("static const int _font_" + name + "_size = " + str(len(buf)) + ";\n")
         g.write("static const unsigned char _font_" + name + "[] = {\n")
-        for i in range(len(buf)):
-            g.write("\t" + byte_to_str(buf[i]) + ",\n")
+        for j in range(len(buf)):
+            g.write("\t" + byte_to_str(buf[j]) + ",\n")
 
         g.write("};\n")
 
@@ -97,8 +97,8 @@ def make_translations_header(target, source, env):
         name = os.path.splitext(os.path.basename(sorted_paths[i]))[0]
 
         g.write("static const unsigned char _translation_" + name + "_compressed[] = {\n")
-        for i in range(len(buf)):
-            g.write("\t" + byte_to_str(buf[i]) + ",\n")
+        for j in range(len(buf)):
+            g.write("\t" + byte_to_str(buf[j]) + ",\n")
 
         g.write("};\n")
 

--- a/modules/mono/build_scripts/mono_reg_utils.py
+++ b/modules/mono/build_scripts/mono_reg_utils.py
@@ -116,5 +116,3 @@ def find_msbuild_tools_path_reg():
             return value
     except (WindowsError, OSError):
         return ''
-
-    return ''


### PR DESCRIPTION
Unreachable code ~~, duplicate imports~~ and same variable names in nested loops were removed/replaced.