### PR TITLE
Fix AnimationTree editor messing up parameters when nested

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -878,9 +878,7 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 		blend_tree->disconnect("removed_from_graph", this, "_removed_from_graph");
 	}
 
-	if (p_node.is_valid()) {
-		blend_tree = p_node;
-	}
+	blend_tree = p_node;
 
 	if (blend_tree.is_null()) {
 		hide();

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -115,6 +115,8 @@ void AnimationTreeEditor::edit_path(const Vector<String> &p_path) {
 			button_path.push_back(p_path[i]);
 		}
 
+		edited_path = button_path;
+
 		for (int i = 0; i < editors.size(); i++) {
 			if (editors[i]->can_edit(node)) {
 				editors[i]->edit(node);
@@ -126,9 +128,8 @@ void AnimationTreeEditor::edit_path(const Vector<String> &p_path) {
 		}
 	} else {
 		current_root = 0;
+		edited_path = button_path;
 	}
-
-	edited_path = button_path;
 
 	_update_path();
 }


### PR DESCRIPTION
Fixes #29436.

The problem occurred because `AnimationNodeBlendTreeEditor::_update_graph()` used `AnimationTreeEditor::get_base_path()` which uses `AnimationTreeEditor::edited_path`. Since the `edited_path` was updated a bit after the graph was updated, the nodes with properties did not work until something changed the graph (renaming, removing, or adding a node).