### PR TITLE
Redundant brancing in scene tree editor

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -688,8 +688,6 @@ void SceneTreeEditor::set_selected(Node *p_node, bool p_emit_selected) {
 		tree->ensure_cursor_is_visible();
 
 	} else {
-		if (!p_node)
-			selected = NULL;
 		_update_tree();
 		selected = p_node;
 	}


### PR DESCRIPTION
I believe following branch is redundant

For the following branch to succeed,

https://github.com/godotengine/godot/blob/584ca0f156cec64c259382895e105cf27566a987/editor/scene_tree_editor.cpp#L691-L692

`p_node` must be `null`, but given that no modification is made to `p_node` in the function call, then `p_node` must be `null` here too,

https://github.com/godotengine/godot/blob/584ca0f156cec64c259382895e105cf27566a987/editor/scene_tree_editor.cpp#L676