### PR TITLE
Fix potential crash caused by type mismatch in Ref

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -70,7 +70,8 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		}
 	} else if (p_id == BUTTON_SCRIPT) {
 		RefPtr script = n->get_script();
-		if (!script.is_null())
+		Ref<Script> script_typed = script;
+		if (!script_typed.is_null())
 			emit_signal("open_script", script);
 
 	} else if (p_id == BUTTON_VISIBILITY) {
@@ -210,7 +211,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	if (connect_to_script_mode) {
 		Color accent = get_color("accent_color", "Editor");
 
-		if (!p_node->get_script().is_null()) {
+		Ref<Script> script = p_node->get_script();
+		if (!script.is_null()) {
 			//has script
 			item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT);
 		} else {
@@ -290,8 +292,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		if (!p_node->is_connected("script_changed", this, "_node_script_changed"))
 			p_node->connect("script_changed", this, "_node_script_changed", varray(p_node));
 
-		if (!p_node->get_script().is_null()) {
-			Ref<Script> script = p_node->get_script();
+		Ref<Script> script = p_node->get_script();
+		if (!script.is_null()) {
 			item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT, false, TTR("Open Script:") + " " + script->get_path());
 		}
 


### PR DESCRIPTION
I have a copy of the [2D platformer demo](https://github.com/godotengine/godot-demo-projects/tree/master/2d/platformer) and today it suddenly starts to crash the editor on startup. I am not sure how I got the files to this state (as I almost haven't touched them), but all modifications are made within the editor. A possible reason can be loading C# files in a non-Mono build, but the editor should not crash anyway.

The crash is caused by converting a `RefPtr` holding a `Ref<TextFile>` into a `Ref<Script>` (through `dynamic_cast`), resulting in a null pointer. It is fixed by performing type cast before the nullity check. Nevertheless, should it be allowed to pass a non-`Script` object to `Object::set_script()`? Will a change be desirable? Would love to hear opinions ^ ^

[Reproduction project](https://github.com/godotengine/godot/files/3387196/GodotPlatformer.zip)