### PR TITLE
Improve 2D RayCast and one-way collision drawing

### DIFF
--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -97,15 +97,8 @@ void CollisionShape2D::_notification(int p_what) {
 			}
 			owner_id = 0;
 			parent = NULL;
+
 		} break;
-		/*
-		case NOTIFICATION_TRANSFORM_CHANGED: {
-
-			if (!is_inside_scene())
-				break;
-			_update_parent();
-
-		} break;*/
 		case NOTIFICATION_DRAW: {
 
 			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
@@ -131,10 +124,13 @@ void CollisionShape2D::_notification(int p_what) {
 			rect = rect.grow(3);
 
 			if (one_way_collision) {
-				Color dcol = get_tree()->get_debug_collisions_color(); //0.9,0.2,0.2,0.4);
-				dcol.a = 1.0;
+				// Draw an arrow indicating the one-way collision direction
+				draw_col = get_tree()->get_debug_collisions_color().inverted();
+				if (disabled) {
+					draw_col = draw_col.darkened(0.25);
+				}
 				Vector2 line_to(0, 20);
-				draw_line(Vector2(), line_to, dcol, 3);
+				draw_line(Vector2(), line_to, draw_col, 2, true);
 				Vector<Vector2> pts;
 				float tsize = 8;
 				pts.push_back(line_to + (Vector2(0, tsize)));
@@ -142,9 +138,9 @@ void CollisionShape2D::_notification(int p_what) {
 				pts.push_back(line_to + (Vector2(-0.707 * tsize, 0)));
 				Vector<Color> cols;
 				for (int i = 0; i < 3; i++)
-					cols.push_back(dcol);
+					cols.push_back(draw_col);
 
-				draw_primitive(pts, cols, Vector<Vector2>()); //small arrow
+				draw_primitive(pts, cols, Vector<Vector2>());
 			}
 		} break;
 	}

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -100,6 +100,7 @@ Vector2 RayCast2D::get_collision_normal() const {
 void RayCast2D::set_enabled(bool p_enabled) {
 
 	enabled = p_enabled;
+	update();
 	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint())
 		set_physics_process_internal(p_enabled);
 	if (!p_enabled)
@@ -167,19 +168,25 @@ void RayCast2D::_notification(int p_what) {
 			xf.rotate(cast_to.angle());
 			xf.translate(Vector2(cast_to.length(), 0));
 
-			//Vector2 tip = Vector2(0,s->get_length());
-			Color dcol = get_tree()->get_debug_collisions_color(); //0.9,0.2,0.2,0.4);
-			draw_line(Vector2(), cast_to, dcol, 3);
+			// Draw an arrow indicating where the RayCast is pointing to
+			Color draw_col = get_tree()->get_debug_collisions_color();
+			if (!enabled) {
+				float g = draw_col.get_v();
+				draw_col.r = g;
+				draw_col.g = g;
+				draw_col.b = g;
+			}
+			draw_line(Vector2(), cast_to, draw_col, 2, true);
 			Vector<Vector2> pts;
-			float tsize = 4;
+			float tsize = 8;
 			pts.push_back(xf.xform(Vector2(tsize, 0)));
 			pts.push_back(xf.xform(Vector2(0, 0.707 * tsize)));
 			pts.push_back(xf.xform(Vector2(0, -0.707 * tsize)));
 			Vector<Color> cols;
 			for (int i = 0; i < 3; i++)
-				cols.push_back(dcol);
+				cols.push_back(draw_col);
 
-			draw_primitive(pts, cols, Vector<Vector2>()); //small arrow
+			draw_primitive(pts, cols, Vector<Vector2>());
 
 		} break;
 


### PR DESCRIPTION
- Make RayCast2D gray when it's disabled
- Make the one-way collision arrow use the inverted shape debugging
  color (will result in an orange color by default)
  - This makes it easier to distinguish it from RayCast2D arrows
- Make lines slightly thinner
- Make the RayCast2D arrow tip larger
- Use anti-aliasing for the RayCast2D and one-way collision lines

## Preview

(Both previews are heavily zoomed in.)

### RayCasts and shapes enabled

![shapes_enabled](https://user-images.githubusercontent.com/180032/61160561-24f30480-a500-11e9-8cd1-a6bed86594ba.png)

### RayCasts and shapes disabled

![shapes_disabled](https://user-images.githubusercontent.com/180032/61160549-186eac00-a500-11e9-8efe-8edbad365805.png)
