### PR TITLE
Fix inconsistent lighting in GLES2

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -1133,8 +1133,8 @@ void RasterizerSceneGLES2::_add_geometry_with_material(RasterizerStorageGLES2::G
 
 				LightInstance *li = light_instance_owner.getornull(e->instance->light_instances[i]);
 
-				if (li->light_index >= render_light_instance_count) {
-					continue; // too many
+				if (li->light_index >= render_light_instance_count || render_light_instances[li->light_index] != li) {
+					continue; // too many or light_index did not correspond to the light instances to be rendered
 				}
 
 				if (copy) {


### PR DESCRIPTION
Fixes #28819.
Tested on the editor with the provided minimal production project. Although this fix definitely works, there might be a need to clear all the light_index's from all LightInstances to make sure this wouldn't occur in other renderers. I might be wrong on that though. Thanks @clayjohn for all the help.

Commit description:
- Issue was possibily being caused by duplicating a light even when that light was not in the render_light_instances array.
_bugsquad edit:_ Also closes https://github.com/godotengine/godot/issues/26269