### PR TITLE
Add `AudioEffectEQCustom`

### DIFF
--- a/doc/classes/AudioEffectEQ.xml
+++ b/doc/classes/AudioEffectEQ.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectEQ" inherits="AudioEffect" category="Core" version="3.2">
 	<brief_description>
-		Base class for audio equalizers. Gives you control over frequencies.
-		Use it to create a custom equalizer if [AudioEffectEQ6], [AudioEffectEQ10] or [AudioEffectEQ21] don't fit your needs.
+		Base class for audio equalizers. Choose among [AudioEffectEQ6], [AudioEffectEQ10], [AudioEffectEQ21] or [AudioEffectEQCustom] according to specific needs.
 	</brief_description>
 	<description>
-		AudioEffectEQ gives you control over frequencies. Use it to compensate for existing deficiencies in audio. AudioEffectEQs are useful on the Master bus to completely master a mix and give it more character. They are also useful when a game is run on a mobile device, to adjust the mix to that kind of speakers (it can be added but disabled when headphones are plugged).
+		An equalizer gives you control over different parts of the audio according to frequencies. It boosts or suppresses certain frequencies (bands) according to the setup.
+		Equalizers can compensate for existing deficiencies in audio as well as create different effects on a sound. An equalizer may be applied on the Master bus to master a mix as a whole and give it more character. They are also useful when a game is run on a mobile device, to adjust the mix to that kind of speakers (for example, an equalizer can be added but disabled when headphones are plugged).
+		[AudioEffectEQ] is the base class and need not be directly used. See [AudioEffectEQ6], [AudioEffectEQ10], [AudioEffectEQ21] and [AudioEffectEQCustom] for different setups.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -15,6 +16,15 @@
 			</return>
 			<description>
 				Returns the number of bands of the equalizer.
+			</description>
+		</method>
+		<method name="get_band_frequency" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="band_idx" type="int">
+			</argument>
+			<description>
+				Returns the band's center frequency at the specified index in hertz.
 			</description>
 		</method>
 		<method name="get_band_gain_db" qualifiers="const">

--- a/doc/classes/AudioEffectEQ10.xml
+++ b/doc/classes/AudioEffectEQ10.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AudioEffectEQ10" inherits="AudioEffectEQ" category="Core" version="3.2">
+<class name="AudioEffectEQ10" inherits="AudioEffectEQPreset" category="Core" version="3.2">
 	<brief_description>
 		Adds a 10-band equalizer audio effect to an Audio bus. Gives you control over frequencies from 31 Hz to 16000 Hz.
 		Each frequency can be modulated between -60/+24 dB.
@@ -16,7 +16,7 @@
 		Band 8: 4000 Hz
 		Band 9: 8000 Hz
 		Band 10: 16000 Hz
-		See also [AudioEffectEQ], [AudioEffectEQ6], [AudioEffectEQ21].
+		See also [AudioEffectEQ6], [AudioEffectEQ21], [AudioEffectEQCustom].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/AudioEffectEQ21.xml
+++ b/doc/classes/AudioEffectEQ21.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AudioEffectEQ21" inherits="AudioEffectEQ" category="Core" version="3.2">
+<class name="AudioEffectEQ21" inherits="AudioEffectEQPreset" category="Core" version="3.2">
 	<brief_description>
 		Adds a 21-band equalizer audio effect to an Audio bus. Gives you control over frequencies from 22 Hz to 22000 Hz.
 		Each frequency can be modulated between -60/+24 dB.
@@ -27,7 +27,7 @@
 		Band 19: 11000 Hz
 		Band 20: 16000 Hz
 		Band 21: 22000 Hz
-		See also [AudioEffectEQ], [AudioEffectEQ6], [AudioEffectEQ10].
+		See also [AudioEffectEQ6], [AudioEffectEQ10], [AudioEffectEQCustom].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/AudioEffectEQ6.xml
+++ b/doc/classes/AudioEffectEQ6.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AudioEffectEQ6" inherits="AudioEffectEQ" category="Core" version="3.2">
+<class name="AudioEffectEQ6" inherits="AudioEffectEQPreset" category="Core" version="3.2">
 	<brief_description>
 		Adds a 6-band equalizer audio effect to an Audio bus. Gives you control over frequencies from 32 Hz to 10000 Hz.
 		Each frequency can be modulated between -60/+24 dB.
@@ -12,7 +12,7 @@
 		Band 4: 1000 Hz
 		Band 5: 3200 Hz
 		Band 6: 10000 Hz
-		See also [AudioEffectEQ], [AudioEffectEQ10], [AudioEffectEQ21].
+		See also [AudioEffectEQ10], [AudioEffectEQ21], [AudioEffectEQCustom].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/AudioEffectEQCustom.xml
+++ b/doc/classes/AudioEffectEQCustom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioEffectEQCustom" inherits="AudioEffectEQ" category="Core" version="3.2">
+	<brief_description>
+		A custom equalizer that allows band frequencies to be customized and changed on the fly.
+		Use it to create a custom equalizer if [AudioEffectEQ6], [AudioEffectEQ10] or [AudioEffectEQ21] don't fit your needs.
+	</brief_description>
+	<description>
+		[AudioEffectEQCustom] is a semi-parametric equalizer that allows a custom setup of band frequencies. The setup can be changed in real time as well.
+		An equalizer should contain at least 2 bands and at most 31 bands. The center frequencies should lie between 10 Hz and 22050 Hz (inclusive).
+		It is suggested to ensure that band frequencies strictly increasing.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="set_band_count">
+			<return type="void">
+			</return>
+			<argument index="0" name="count" type="int">
+			</argument>
+			<description>
+				Sets the number of bands. [code]count[/code] should lie between 2 to 31 (inclusive).
+			</description>
+		</method>
+		<method name="set_band_frequency">
+			<return type="void">
+			</return>
+			<argument index="0" name="band_idx" type="int">
+			</argument>
+			<argument index="1" name="frequency" type="float">
+			</argument>
+			<description>
+				Sets the center frequency (in hertz) of a band. [code]frequency[/code] should lie between 10 to 22050 (inclusive).
+				Band frequencies should be pairwise distinct. Otherwise a warning will be raised.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/AudioEffectEQPreset.xml
+++ b/doc/classes/AudioEffectEQPreset.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioEffectEQPreset" inherits="AudioEffectEQ" category="Core" version="3.2">
+	<brief_description>
+		Base class for audio equalizers with a preset of bands.
+		It is unlikely that this base class will be directly used; instead, see [AudioEffectEQ6], [AudioEffectEQ10] or [AudioEffectEQ21].
+		In case a greater level of customization is needed, see [AudioEffectEQCustom].
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/servers/audio/effects/audio_effect_eq.cpp
+++ b/servers/audio/effects/audio_effect_eq.cpp
@@ -31,7 +31,24 @@
 #include "audio_effect_eq.h"
 #include "servers/audio_server.h"
 
+#define EQ_CUSTOM_BANDS_MAX 31
+#define EQ_CUSTOM_BANDS_HINT "2,31,1"
+#define EQ_CUSTOM_FREQ_MIN 10
+#define EQ_CUSTOM_FREQ_MAX 22050
+#define EQ_CUSTOM_FREQ_HINT "10,22050,1"
+
 void AudioEffectEQInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
+
+	// Update the processor if band frequencies have changed
+	if (base->freqs_rev != cur_freqs_rev) {
+		cur_freqs_rev = base->freqs_rev;
+		for (int i = 0; i < 2; i++) {
+			bands[i].resize(base->eq.get_band_count());
+			for (int j = 0; j < bands[i].size(); j++) {
+				bands[i].write[j] = base->eq.get_band_processor(j, bands[i][j]);
+			}
+		}
+	}
 
 	int band_count = bands[0].size();
 	EQ::BandProcess *proc_l = bands[0].ptrw();
@@ -69,12 +86,20 @@ Ref<AudioEffectInstance> AudioEffectEQ::instance() {
 	ins->gains.resize(eq.get_band_count());
 	for (int i = 0; i < 2; i++) {
 		ins->bands[i].resize(eq.get_band_count());
-		for (int j = 0; j < ins->bands[i].size(); j++) {
-			ins->bands[i].write[j] = eq.get_band_processor(j);
-		}
+		ins->cur_freqs_rev = freqs_rev;
+		freqs_rev++; // An update will be triggered on the first frame
 	}
 
 	return ins;
+}
+
+float AudioEffectEQ::get_band_frequency(int p_band) const {
+	ERR_FAIL_INDEX_V(p_band, gain.size(), 0);
+	return eq.get_band_frequency(p_band);
+}
+
+int AudioEffectEQ::get_band_count() const {
+	return gain.size();
 }
 
 void AudioEffectEQ::set_band_gain_db(int p_band, float p_volume) {
@@ -86,9 +111,6 @@ float AudioEffectEQ::get_band_gain_db(int p_band) const {
 	ERR_FAIL_INDEX_V(p_band, gain.size(), 0);
 
 	return gain[p_band];
-}
-int AudioEffectEQ::get_band_count() const {
-	return gain.size();
 }
 
 bool AudioEffectEQ::_set(const StringName &p_name, const Variant &p_value) {
@@ -123,14 +145,20 @@ void AudioEffectEQ::_get_property_list(List<PropertyInfo> *p_list) const {
 
 void AudioEffectEQ::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("get_band_count"), &AudioEffectEQ::get_band_count);
+	ClassDB::bind_method(D_METHOD("get_band_frequency", "band_idx"), &AudioEffectEQ::get_band_frequency);
 	ClassDB::bind_method(D_METHOD("set_band_gain_db", "band_idx", "volume_db"), &AudioEffectEQ::set_band_gain_db);
 	ClassDB::bind_method(D_METHOD("get_band_gain_db", "band_idx"), &AudioEffectEQ::get_band_gain_db);
-	ClassDB::bind_method(D_METHOD("get_band_count"), &AudioEffectEQ::get_band_count);
 }
 
-AudioEffectEQ::AudioEffectEQ(EQ::Preset p_preset) {
+AudioEffectEQ::AudioEffectEQ() {
 
+	freqs_rev = 0;
 	eq.set_mix_rate(AudioServer::get_singleton()->get_mix_rate());
+}
+
+AudioEffectEQPreset::AudioEffectEQPreset(EQ::Preset p_preset) {
+
 	eq.set_preset_band_mode(p_preset);
 	gain.resize(eq.get_band_count());
 	for (int i = 0; i < gain.size(); i++) {
@@ -139,4 +167,100 @@ AudioEffectEQ::AudioEffectEQ(EQ::Preset p_preset) {
 		prop_band_map[name] = i;
 		band_names.push_back(name);
 	}
+}
+
+void AudioEffectEQCustom::set_band_count(int p_count) {
+
+	ERR_FAIL_COND(p_count < 2 || p_count > EQ_CUSTOM_BANDS_MAX);
+
+	int prev_size = freqs.size();
+	freqs.resize(p_count);
+	for (int i = prev_size; i < p_count; i++)
+		freqs.write[i] = (i == 0 ? EQ_CUSTOM_FREQ_MIN : freqs[i - 1]);
+	eq.set_bands(freqs);
+
+	gain.resize(p_count);
+	prop_band_map.clear();
+	band_names.clear();
+	for (int i = 0; i < gain.size(); i++) {
+		String name = "band_db/band_" + itos(i);
+		prop_band_map[name] = i;
+		band_names.push_back(name);
+	}
+}
+
+void AudioEffectEQCustom::set_band_frequency(int p_band, float p_freq) {
+
+	ERR_FAIL_INDEX(p_band, eq.get_band_count());
+	ERR_FAIL_COND(p_freq < EQ_CUSTOM_FREQ_MIN || p_freq > EQ_CUSTOM_FREQ_MAX);
+
+	freqs.write[p_band] = p_freq;
+	eq.set_bands(freqs);
+	freqs_rev++;
+}
+
+bool AudioEffectEQCustom::_set(const StringName &p_name, const Variant &p_value) {
+
+	if (AudioEffectEQ::_set(p_name, p_value)) return true;
+
+	if (p_name == "band_count") {
+		set_band_count((int)p_value);
+		return true;
+	} else {
+		String prefix = "band_frequency/band_";
+		String name = (String)p_name;
+		if (name.begins_with(prefix)) {
+			int idx = name.substr(prefix.length()).to_int();
+			set_band_frequency(idx, (float)p_value);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool AudioEffectEQCustom::_get(const StringName &p_name, Variant &r_ret) const {
+
+	if (AudioEffectEQ::_get(p_name, r_ret)) return true;
+
+	if (p_name == "band_count") {
+		r_ret = get_band_count();
+		return true;
+	} else {
+		String prefix = "band_frequency/band_";
+		String name = (String)p_name;
+		if (name.begins_with(prefix)) {
+			int idx = name.substr(prefix.length()).to_int();
+			if (idx >= 0 && idx < eq.get_band_count()) {
+				r_ret = freqs[idx];
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+void AudioEffectEQCustom::_get_property_list(List<PropertyInfo> *p_list) const {
+
+	p_list->push_back(PropertyInfo(Variant::INT,
+			"band_count", PROPERTY_HINT_RANGE, EQ_CUSTOM_BANDS_HINT));
+
+	for (int i = 0; i < gain.size(); i++) {
+		p_list->push_back(PropertyInfo(Variant::REAL,
+				"band_frequency/band_" + itos(i), PROPERTY_HINT_EXP_RANGE, EQ_CUSTOM_FREQ_HINT));
+	}
+}
+
+void AudioEffectEQCustom::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("set_band_count", "count"), &AudioEffectEQCustom::set_band_count);
+	ClassDB::bind_method(D_METHOD("set_band_frequency", "frequency"), &AudioEffectEQCustom::set_band_frequency);
+}
+
+AudioEffectEQCustom::AudioEffectEQCustom() {
+
+	// Set to maximum bands on initialization
+	// because gain values will be loaded before band count
+	set_band_count(EQ_CUSTOM_BANDS_MAX);
 }

--- a/servers/audio/effects/audio_effect_eq.cpp
+++ b/servers/audio/effects/audio_effect_eq.cpp
@@ -255,7 +255,7 @@ void AudioEffectEQCustom::_get_property_list(List<PropertyInfo> *p_list) const {
 void AudioEffectEQCustom::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_band_count", "count"), &AudioEffectEQCustom::set_band_count);
-	ClassDB::bind_method(D_METHOD("set_band_frequency", "frequency"), &AudioEffectEQCustom::set_band_frequency);
+	ClassDB::bind_method(D_METHOD("set_band_frequency", "band_idx", "frequency"), &AudioEffectEQCustom::set_band_frequency);
 }
 
 AudioEffectEQCustom::AudioEffectEQCustom() {

--- a/servers/audio/effects/audio_effect_eq.h
+++ b/servers/audio/effects/audio_effect_eq.h
@@ -40,6 +40,7 @@ class AudioEffectEQInstance : public AudioEffectInstance {
 	GDCLASS(AudioEffectEQInstance, AudioEffectInstance);
 	friend class AudioEffectEQ;
 	Ref<AudioEffectEQ> base;
+	int cur_freqs_rev;
 
 	Vector<EQ::BandProcess> bands[2];
 	Vector<float> gains;
@@ -53,12 +54,13 @@ class AudioEffectEQ : public AudioEffect {
 
 	friend class AudioEffectEQInstance;
 
+protected:
 	EQ eq;
 	Vector<float> gain;
 	Map<StringName, int> prop_band_map;
 	Vector<String> band_names;
+	int freqs_rev;
 
-protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
@@ -67,35 +69,62 @@ protected:
 
 public:
 	Ref<AudioEffectInstance> instance();
+	int get_band_count() const;
+	float get_band_frequency(int p_band) const;
 	void set_band_gain_db(int p_band, float p_volume);
 	float get_band_gain_db(int p_band) const;
-	int get_band_count() const;
 
-	AudioEffectEQ(EQ::Preset p_preset = EQ::PRESET_6_BANDS);
+	AudioEffectEQ();
 };
 
-class AudioEffectEQ6 : public AudioEffectEQ {
-	GDCLASS(AudioEffectEQ6, AudioEffectEQ);
+class AudioEffectEQPreset : public AudioEffectEQ {
+	GDCLASS(AudioEffectEQPreset, AudioEffectEQ);
+
+protected:
+	AudioEffectEQPreset(EQ::Preset p_preset = EQ::PRESET_6_BANDS);
+};
+
+class AudioEffectEQ6 : public AudioEffectEQPreset {
+	GDCLASS(AudioEffectEQ6, AudioEffectEQPreset);
 
 public:
 	AudioEffectEQ6() :
-			AudioEffectEQ(EQ::PRESET_6_BANDS) {}
+			AudioEffectEQPreset(EQ::PRESET_6_BANDS) {}
 };
 
-class AudioEffectEQ10 : public AudioEffectEQ {
-	GDCLASS(AudioEffectEQ10, AudioEffectEQ);
+class AudioEffectEQ10 : public AudioEffectEQPreset {
+	GDCLASS(AudioEffectEQ10, AudioEffectEQPreset);
 
 public:
 	AudioEffectEQ10() :
-			AudioEffectEQ(EQ::PRESET_10_BANDS) {}
+			AudioEffectEQPreset(EQ::PRESET_10_BANDS) {}
 };
 
-class AudioEffectEQ21 : public AudioEffectEQ {
-	GDCLASS(AudioEffectEQ21, AudioEffectEQ);
+class AudioEffectEQ21 : public AudioEffectEQPreset {
+	GDCLASS(AudioEffectEQ21, AudioEffectEQPreset);
 
 public:
 	AudioEffectEQ21() :
-			AudioEffectEQ(EQ::PRESET_21_BANDS) {}
+			AudioEffectEQPreset(EQ::PRESET_21_BANDS) {}
+};
+
+class AudioEffectEQCustom : public AudioEffectEQ {
+	GDCLASS(AudioEffectEQCustom, AudioEffectEQ);
+
+protected:
+	Vector<float> freqs;
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+	static void _bind_methods();
+
+public:
+	AudioEffectEQCustom();
+
+	void set_band_count(int p_count);
+	void set_band_frequency(int p_band, float p_freq);
 };
 
 #endif // AUDIOEFFECTEQ_H

--- a/servers/audio/effects/eq.cpp
+++ b/servers/audio/effects/eq.cpp
@@ -106,7 +106,11 @@ void EQ::recalculate_band_coefficients() {
 		double r1, r2; //roots
 		int roots = solve_quadratic(c2a, c2b, c2c, &r1, &r2);
 
-		ERR_CONTINUE(roots == 0);
+		if (roots == 0) {
+
+			WARN_PRINT("Could not process one of the bands; probably caused by coinciding band frequencies");
+			continue;
+		}
 
 		band.write[i].c1 = 2.0 * ((0.5 - r1) / 2.0);
 		band.write[i].c2 = 2.0 * r1;
@@ -170,7 +174,7 @@ int EQ::get_band_count() const {
 
 	return band.size();
 }
-float EQ::get_band_frequency(int p_band) {
+float EQ::get_band_frequency(int p_band) const {
 
 	ERR_FAIL_INDEX_V(p_band, band.size(), 0);
 	return band[p_band].freq;
@@ -192,7 +196,7 @@ void EQ::set_mix_rate(float p_mix_rate) {
 	recalculate_band_coefficients();
 }
 
-EQ::BandProcess EQ::get_band_processor(int p_band) const {
+EQ::BandProcess EQ::get_band_processor(int p_band, const BandProcess &p_cur) const {
 
 	EQ::BandProcess band_proc;
 
@@ -201,6 +205,7 @@ EQ::BandProcess EQ::get_band_processor(int p_band) const {
 	band_proc.c1 = band[p_band].c1;
 	band_proc.c2 = band[p_band].c2;
 	band_proc.c3 = band[p_band].c3;
+	band_proc.history = p_cur.history;
 
 	return band_proc;
 }

--- a/servers/audio/effects/eq.h
+++ b/servers/audio/effects/eq.h
@@ -86,8 +86,10 @@ public:
 	int get_band_count() const;
 	void set_preset_band_mode(Preset p_preset);
 	void set_bands(const Vector<float> &p_bands);
-	BandProcess get_band_processor(int p_band) const;
-	float get_band_frequency(int p_band);
+	float get_band_frequency(int p_band) const;
+
+	// Keeps filter history for fluent transition
+	BandProcess get_band_processor(int p_band, const BandProcess &p_cur) const;
 
 	EQ();
 	~EQ();

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -130,7 +130,6 @@ void register_server_types() {
 	ClassDB::register_class<AudioStreamRandomPitch>();
 	ClassDB::register_virtual_class<AudioEffect>();
 	ClassDB::register_virtual_class<AudioEffectInstance>();
-	ClassDB::register_class<AudioEffectEQ>();
 	ClassDB::register_class<AudioEffectFilter>();
 	ClassDB::register_class<AudioBusLayout>();
 
@@ -154,6 +153,7 @@ void register_server_types() {
 		ClassDB::register_class<AudioEffectEQ6>();
 		ClassDB::register_class<AudioEffectEQ10>();
 		ClassDB::register_class<AudioEffectEQ21>();
+		ClassDB::register_class<AudioEffectEQCustom>();
 
 		ClassDB::register_class<AudioEffectDistortion>();
 


### PR DESCRIPTION
An audio equalizer with customizable band frequencies is added and the documentation has been updated. Closes #27585.

I believe this cannot be worked around by a few lines of code and there are plenty of use cases (a parametric EQ can make up a large part of audio effects), so I made it.

Other changes (none should introduce compatibility breakage):
- Existing preset equalizers (6, 10, 21 bands) are made subclasses of a new class `AudioEffectEQPreset` which inherits `AudioEffectEQ`
- Prevented `AudioEffectEQ` from being created directly on the bus
- Minor changes in logic of class `EQ`

I tried my best to comply with existing conventions, but in case anything is to be changed or discussed please kindly specify! ^ ^