### PR TITLE
Fix crashing when changing Node type.

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -394,7 +394,11 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (!profile_allow_editing) {
 				break;
 			}
-			create_dialog->popup_create(false, true, scene_tree->get_selected()->get_class());
+
+			Node *selected = scene_tree->get_selected();
+			if (selected)
+				create_dialog->popup_create(false, true, selected->get_class());
+
 		} break;
 		case TOOL_ATTACH_SCRIPT: {
 


### PR DESCRIPTION
Checks if selection is not null before accessing it.
Fixes #30493
I think there's a better way to do this...