### PR TITLE
Mono: Better handling of missing/outdated API assemblies

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/CSharpProject.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/CSharpProject.cs
@@ -1,9 +1,9 @@
 using Godot;
 using System;
-using System.Collections.Generic;
 using Godot.Collections;
 using GodotTools.Internals;
 using GodotTools.ProjectEditor;
+using static GodotTools.Internals.Globals;
 using File = GodotTools.Utils.File;
 using Directory = GodotTools.Utils.Directory;
 
@@ -26,7 +26,7 @@ namespace GodotTools
 
         public static void AddItem(string projectPath, string itemType, string include)
         {
-            if (!(bool) Internal.GlobalDef("mono/project/auto_update_project", true))
+            if (!(bool) GlobalDef("mono/project/auto_update_project", true))
                 return;
 
             ProjectUtils.AddItemToProjectChecked(projectPath, itemType, include);

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpBuilds.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpBuilds.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GodotTools.Build;
 using GodotTools.Internals;
 using GodotTools.Utils;
+using static GodotTools.Internals.Globals;
 using Error = Godot.Error;
 using File = GodotTools.Utils.File;
 using Directory = GodotTools.Utils.Directory;
@@ -376,7 +377,7 @@ namespace GodotTools
         {
             // Build tool settings
 
-            Internal.EditorDef("mono/builds/build_tool", OS.IsWindows() ? BuildTool.MsBuildVs : BuildTool.MsBuildMono);
+            EditorDef("mono/builds/build_tool", OS.IsWindows() ? BuildTool.MsBuildVs : BuildTool.MsBuildMono);
 
             var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
 
@@ -390,7 +391,7 @@ namespace GodotTools
                     $"{PropNameMsbuildMono},{PropNameXbuild}"
             });
 
-            Internal.EditorDef("mono/builds/print_build_output", false);
+            EditorDef("mono/builds/print_build_output", false);
         }
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpBuilds.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpBuilds.cs
@@ -193,134 +193,14 @@ namespace GodotTools
             return false;
         }
 
-        private static bool CopyApiAssembly(string srcDir, string dstDir, string assemblyName, ApiAssemblyType apiType)
-        {
-            // Create destination directory if needed
-            if (!Directory.Exists(dstDir))
-            {
-                try
-                {
-                    Directory.CreateDirectory(dstDir);
-                }
-                catch (IOException e)
-                {
-                    ShowBuildErrorDialog($"Failed to create destination directory for the API assemblies. Exception message: {e.Message}");
-                    return false;
-                }
-            }
-
-            string assemblyFile = assemblyName + ".dll";
-            string assemblySrc = Path.Combine(srcDir, assemblyFile);
-            string assemblyDst = Path.Combine(dstDir, assemblyFile);
-
-            if (!File.Exists(assemblyDst) || File.GetLastWriteTime(assemblySrc) > File.GetLastWriteTime(assemblyDst) ||
-                Internal.MetadataIsApiAssemblyInvalidated(apiType))
-            {
-                string xmlFile = $"{assemblyName}.xml";
-                string pdbFile = $"{assemblyName}.pdb";
-
-                try
-                {
-                    File.Copy(Path.Combine(srcDir, xmlFile), Path.Combine(dstDir, xmlFile));
-                }
-                catch (IOException e)
-                {
-                    Godot.GD.PushWarning(e.ToString());
-                }
-
-                try
-                {
-                    File.Copy(Path.Combine(srcDir, pdbFile), Path.Combine(dstDir, pdbFile));
-                }
-                catch (IOException e)
-                {
-                    Godot.GD.PushWarning(e.ToString());
-                }
-
-                try
-                {
-                    File.Copy(assemblySrc, assemblyDst);
-                }
-                catch (IOException e)
-                {
-                    ShowBuildErrorDialog($"Failed to copy {assemblyFile}. Exception message: {e.Message}");
-                    return false;
-                }
-
-                Internal.MetadataSetApiAssemblyInvalidated(apiType, false);
-            }
-
-            return true;
-        }
-
-        public static bool MakeApiAssembly(ApiAssemblyType apiType, string config)
-        {
-            string apiName = apiType == ApiAssemblyType.Core ? ApiAssemblyNames.Core : ApiAssemblyNames.Editor;
-
-            string editorPrebuiltApiDir = Path.Combine(GodotSharpDirs.DataEditorPrebuiltApiDir, config);
-            string resAssembliesDir = Path.Combine(GodotSharpDirs.ResAssembliesBaseDir, config);
-
-            if (File.Exists(Path.Combine(editorPrebuiltApiDir, $"{apiName}.dll")))
-            {
-                using (var copyProgress = new EditorProgress("mono_copy_prebuilt_api_assembly", $"Copying prebuilt {apiName} assembly...", 1))
-                {
-                    copyProgress.Step($"Copying {apiName} assembly", 0);
-                    return CopyApiAssembly(editorPrebuiltApiDir, resAssembliesDir, apiName, apiType);
-                }
-            }
-
-            const string apiSolutionName = ApiAssemblyNames.SolutionName;
-
-            using (var pr = new EditorProgress($"mono_build_release_{apiSolutionName}", $"Building {apiSolutionName} solution...", 3))
-            {
-                pr.Step($"Generating {apiSolutionName} solution", 0);
-
-                string apiSlnDir = Path.Combine(GodotSharpDirs.MonoSolutionsDir, _ApiFolderName(ApiAssemblyType.Core));
-                string apiSlnFile = Path.Combine(apiSlnDir, $"{apiSolutionName}.sln");
-
-                if (!Directory.Exists(apiSlnDir) || !File.Exists(apiSlnFile))
-                {
-                    var bindingsGenerator = new BindingsGenerator();
-
-                    if (!Godot.OS.IsStdoutVerbose())
-                        bindingsGenerator.LogPrintEnabled = false;
-
-                    Error err = bindingsGenerator.GenerateCsApi(apiSlnDir);
-                    if (err != Error.Ok)
-                    {
-                        ShowBuildErrorDialog($"Failed to generate {apiSolutionName} solution. Error: {err}");
-                        return false;
-                    }
-                }
-
-                pr.Step($"Building {apiSolutionName} solution", 1);
-
-                if (!BuildApiSolution(apiSlnDir, config))
-                    return false;
-
-                pr.Step($"Copying {apiName} assembly", 2);
-
-                // Copy the built assembly to the assemblies directory
-                string apiAssemblyDir = Path.Combine(apiSlnDir, apiName, "bin", config);
-                if (!CopyApiAssembly(apiAssemblyDir, resAssembliesDir, apiName, apiType))
-                    return false;
-            }
-
-            return true;
-        }
-
         public static bool BuildProjectBlocking(string config, IEnumerable<string> godotDefines)
         {
             if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
                 return true; // No solution to build
 
-            string apiConfig = config == "Release" ? "Release" : "Debug";
-
-            if (!MakeApiAssembly(ApiAssemblyType.Core, apiConfig))
-                return false;
-
-            if (!MakeApiAssembly(ApiAssemblyType.Editor, apiConfig))
-                return false;
+            // Make sure to update the API assemblies if they happen to be missing. Just in
+            // case the user decided to delete them at some point after they were loaded.
+            Internal.UpdateApiAssembliesFromPrebuilt();
 
             using (var pr = new EditorProgress("mono_project_debug_build", "Building project solution...", 1))
             {

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using GodotTools.Internals;
 using GodotTools.ProjectEditor;
+using static GodotTools.Internals.Globals;
 using File = GodotTools.Utils.File;
 using Path = System.IO.Path;
 using OS = GodotTools.Utils.OS;
@@ -32,9 +33,9 @@ namespace GodotTools
 
         private bool CreateProjectSolution()
         {
-            using (var pr = new EditorProgress("create_csharp_solution", "Generating solution...", 2)) // TTR("Generating solution...")
+            using (var pr = new EditorProgress("create_csharp_solution", "Generating solution...".TTR(), 2))
             {
-                pr.Step("Generating C# project..."); // TTR("Generating C# project...")
+                pr.Step("Generating C# project...".TTR());
 
                 string resourceDir = ProjectSettings.GlobalizePath("res://");
 
@@ -67,7 +68,7 @@ namespace GodotTools
                     }
                     catch (IOException e)
                     {
-                        ShowErrorDialog($"Failed to save solution. Exception message: {e.Message}"); // TTR
+                        ShowErrorDialog("Failed to save solution. Exception message: ".TTR() + e.Message);
                         return false;
                     }
 
@@ -79,14 +80,14 @@ namespace GodotTools
                     if (!GodotSharpBuilds.MakeApiAssembly(ApiAssemblyType.Editor, apiConfig))
                         return false;
 
-                    pr.Step("Done"); // TTR("Done")
+                    pr.Step("Done".TTR());
 
                     // Here, after all calls to progress_task_step
                     CallDeferred(nameof(_RemoveCreateSlnMenuOption));
                 }
                 else
                 {
-                    ShowErrorDialog("Failed to create C# project."); // TTR
+                    ShowErrorDialog("Failed to create C# project.".TTR());
                 }
 
                 return true;
@@ -407,7 +408,7 @@ namespace GodotTools
 
             MonoBottomPanel = new MonoBottomPanel();
 
-            bottomPanelBtn = AddControlToBottomPanel(MonoBottomPanel, "Mono"); // TTR("Mono")
+            bottomPanelBtn = AddControlToBottomPanel(MonoBottomPanel, "Mono".TTR());
 
             AddChild(new HotReloadAssemblyWatcher {Name = "HotReloadAssemblyWatcher"});
 
@@ -419,7 +420,7 @@ namespace GodotTools
 
             // TODO: Remove or edit this info dialog once Mono support is no longer in alpha
             {
-                menuPopup.AddItem("About C# support", (int) MenuOptions.AboutCSharp); // TTR("About C# support")
+                menuPopup.AddItem("About C# support".TTR(), (int) MenuOptions.AboutCSharp);
                 aboutDialog = new AcceptDialog();
                 editorBaseControl.AddChild(aboutDialog);
                 aboutDialog.WindowTitle = "Important: C# support is not feature-complete";
@@ -441,7 +442,7 @@ namespace GodotTools
 
                 var aboutLabel = new Label();
                 aboutHBox.AddChild(aboutLabel);
-                aboutLabel.RectMinSize = new Vector2(600, 150) * Internal.EditorScale;
+                aboutLabel.RectMinSize = new Vector2(600, 150) * EditorScale;
                 aboutLabel.SizeFlagsVertical = (int) Control.SizeFlags.ExpandFill;
                 aboutLabel.Autowrap = true;
                 aboutLabel.Text =
@@ -454,7 +455,7 @@ namespace GodotTools
                     "        https://github.com/godotengine/godot/issues\n\n" +
                     "Your critical feedback at this stage will play a great role in shaping the C# support in future releases, so thank you!";
 
-                Internal.EditorDef("mono/editor/show_info_on_start", true);
+                EditorDef("mono/editor/show_info_on_start", true);
 
                 // CheckBox in main container
                 aboutDialogCheckBox = new CheckBox {Text = "Show this warning when starting the editor"};
@@ -473,7 +474,7 @@ namespace GodotTools
             else
             {
                 bottomPanelBtn.Hide();
-                menuPopup.AddItem("Create C# solution", (int) MenuOptions.CreateSln); // TTR("Create C# solution")
+                menuPopup.AddItem("Create C# solution".TTR(), (int) MenuOptions.CreateSln);
             }
 
             menuPopup.Connect("id_pressed", this, nameof(_MenuOptionPressed));
@@ -488,7 +489,7 @@ namespace GodotTools
             AddControlToContainer(CustomControlContainer.Toolbar, buildButton);
 
             // External editor settings
-            Internal.EditorDef("mono/editor/external_editor", ExternalEditor.None);
+            EditorDef("mono/editor/external_editor", ExternalEditor.None);
 
             string settingsHintStr = "Disabled";
 

--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Internals\GodotSharpDirs.cs" />
     <Compile Include="Internals\Internal.cs" />
     <Compile Include="Internals\ScriptClassParser.cs" />
+    <Compile Include="Internals\Globals.cs" />
     <Compile Include="MonoDevelopInstance.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Build\BuildSystem.cs" />

--- a/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
@@ -1,5 +1,6 @@
 using Godot;
 using GodotTools.Internals;
+using static GodotTools.Internals.Globals;
 
 namespace GodotTools
 {
@@ -37,7 +38,7 @@ namespace GodotTools
             watchTimer = new Timer
             {
                 OneShot = false,
-                WaitTime = (float) Internal.EditorDef("mono/assembly_watch_interval_sec", 0.5)
+                WaitTime = (float) EditorDef("mono/assembly_watch_interval_sec", 0.5)
             };
             watchTimer.Connect("timeout", this, nameof(TimerTimeout));
             AddChild(watchTimer);

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Globals.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Globals.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace GodotTools.Internals
+{
+    public static class Globals
+    {
+        public static float EditorScale => internal_EditorScale();
+
+        public static object GlobalDef(string setting, object defaultValue, bool restartIfChanged = false) =>
+            internal_GlobalDef(setting, defaultValue, restartIfChanged);
+
+        public static object EditorDef(string setting, object defaultValue, bool restartIfChanged = false) =>
+            internal_EditorDef(setting, defaultValue, restartIfChanged);
+
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
+        public static string TTR(this string text) => internal_TTR(text);
+
+        // Internal Calls
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern float internal_EditorScale();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern object internal_GlobalDef(string setting, object defaultValue, bool restartIfChanged);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern object internal_EditorDef(string setting, object defaultValue, bool restartIfChanged);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern string internal_TTR(string text);
+    }
+}

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
@@ -10,20 +10,15 @@ namespace GodotTools.Internals
         public const string CSharpLanguageType = "CSharpScript";
         public const string CSharpLanguageExtension = "cs";
 
+        public static string UpdateApiAssembliesFromPrebuilt() =>
+            internal_UpdateApiAssembliesFromPrebuilt();
+
         public static string FullTemplatesDir =>
             internal_FullTemplatesDir();
 
         public static string SimplifyGodotPath(this string path) => internal_SimplifyGodotPath(path);
 
         public static bool IsOsxAppBundleInstalled(string bundleId) => internal_IsOsxAppBundleInstalled(bundleId);
-
-        public static bool MetadataIsApiAssemblyInvalidated(ApiAssemblyType apiType) =>
-            internal_MetadataIsApiAssemblyInvalidated(apiType);
-
-        public static void MetadataSetApiAssemblyInvalidated(ApiAssemblyType apiType, bool invalidated) =>
-            internal_MetadataSetApiAssemblyInvalidated(apiType, invalidated);
-
-        public static bool IsMessageQueueFlushing() => internal_IsMessageQueueFlushing();
 
         public static bool GodotIs32Bits() => internal_GodotIs32Bits();
 
@@ -54,6 +49,9 @@ namespace GodotTools.Internals
         // Internal Calls
 
         [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern string internal_UpdateApiAssembliesFromPrebuilt();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_FullTemplatesDir();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -61,15 +59,6 @@ namespace GodotTools.Internals
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern bool internal_IsOsxAppBundleInstalled(string bundleId);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern bool internal_MetadataIsApiAssemblyInvalidated(ApiAssemblyType apiType);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern void internal_MetadataSetApiAssemblyInvalidated(ApiAssemblyType apiType, bool invalidated);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern bool internal_IsMessageQueueFlushing();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern bool internal_GodotIs32Bits();

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
@@ -10,14 +10,6 @@ namespace GodotTools.Internals
         public const string CSharpLanguageType = "CSharpScript";
         public const string CSharpLanguageExtension = "cs";
 
-        public static float EditorScale => internal_EditorScale();
-
-        public static object GlobalDef(string setting, object defaultValue, bool restartIfChanged = false) =>
-            internal_GlobalDef(setting, defaultValue, restartIfChanged);
-
-        public static object EditorDef(string setting, object defaultValue, bool restartIfChanged = false) =>
-            internal_EditorDef(setting, defaultValue, restartIfChanged);
-
         public static string FullTemplatesDir =>
             internal_FullTemplatesDir();
 
@@ -60,15 +52,6 @@ namespace GodotTools.Internals
         public static string MonoWindowsInstallRoot => internal_MonoWindowsInstallRoot();
 
         // Internal Calls
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern float internal_EditorScale();
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern object internal_GlobalDef(string setting, object defaultValue, bool restartIfChanged);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern object internal_EditorDef(string setting, object defaultValue, bool restartIfChanged);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_FullTemplatesDir();

--- a/modules/mono/editor/GodotTools/GodotTools/MonoBottomPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/MonoBottomPanel.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using Godot.Collections;
 using GodotTools.Internals;
+using static GodotTools.Internals.Globals;
 using File = GodotTools.Utils.File;
 using Path = System.IO.Path;
 
@@ -254,7 +255,7 @@ namespace GodotTools
             panelTabs = new TabContainer
             {
                 TabAlign = TabContainer.TabAlignEnum.Left,
-                RectMinSize = new Vector2(0, 228) * Internal.EditorScale,
+                RectMinSize = new Vector2(0, 228) * EditorScale,
                 SizeFlagsVertical = (int) SizeFlags.ExpandFill
             };
             panelTabs.AddStyleboxOverride("panel", editorBaseControl.GetStylebox("DebuggerPanel", "EditorStyles"));
@@ -266,7 +267,7 @@ namespace GodotTools
                 // Builds tab
                 panelBuildsTab = new VBoxContainer
                 {
-                    Name = "Builds", // TTR
+                    Name = "Builds".TTR(),
                     SizeFlagsHorizontal = (int) SizeFlags.ExpandFill
                 };
                 panelTabs.AddChild(panelBuildsTab);
@@ -276,7 +277,7 @@ namespace GodotTools
 
                 var buildProjectBtn = new Button
                 {
-                    Text = "Build Project", // TTR
+                    Text = "Build Project".TTR(),
                     FocusMode = FocusModeEnum.None
                 };
                 buildProjectBtn.Connect("pressed", this, nameof(BuildProjectPressed));
@@ -286,7 +287,7 @@ namespace GodotTools
 
                 warningsBtn = new ToolButton
                 {
-                    Text = "Warnings", // TTR
+                    Text = "Warnings".TTR(),
                     ToggleMode = true,
                     Pressed = true,
                     Visible = false,
@@ -297,7 +298,7 @@ namespace GodotTools
 
                 errorsBtn = new ToolButton
                 {
-                    Text = "Errors", // TTR
+                    Text = "Errors".TTR(),
                     ToggleMode = true,
                     Pressed = true,
                     Visible = false,
@@ -310,7 +311,7 @@ namespace GodotTools
 
                 viewLogBtn = new Button
                 {
-                    Text = "View log", // TTR
+                    Text = "View log".TTR(),
                     FocusMode = FocusModeEnum.None,
                     Visible = false
                 };

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -30,7 +30,6 @@
 
 #include "editor_internal_calls.h"
 
-#include "core/message_queue.h"
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
@@ -245,13 +244,18 @@ MonoObject *godot_icall_Globals_GlobalDef(MonoString *p_setting, MonoObject *p_d
 MonoObject *godot_icall_Globals_EditorDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
 	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
 	Variant default_value = GDMonoMarshal::mono_object_to_variant(p_default_value);
-	Variant result = _GLOBAL_DEF(setting, default_value, (bool)p_restart_if_changed);
+	Variant result = _EDITOR_DEF(setting, default_value, (bool)p_restart_if_changed);
 	return GDMonoMarshal::variant_to_mono_object(result);
 }
 
 MonoString *godot_icall_Globals_TTR(MonoString *p_text) {
 	String text = GDMonoMarshal::mono_string_to_godot(p_text);
 	return GDMonoMarshal::mono_string_from_godot(TTR(text));
+}
+
+MonoString *godot_icall_Internal_UpdateApiAssembliesFromPrebuilt() {
+	String error_str = GDMono::get_singleton()->update_api_assemblies_from_prebuilt();
+	return GDMonoMarshal::mono_string_from_godot(error_str);
 }
 
 MonoString *godot_icall_Internal_FullTemplatesDir() {
@@ -272,18 +276,6 @@ MonoBoolean godot_icall_Internal_IsOsxAppBundleInstalled(MonoString *p_bundle_id
 	(void)p_bundle_id; // UNUSED
 	return (MonoBoolean) false;
 #endif
-}
-
-MonoBoolean godot_icall_Internal_MetadataIsApiAssemblyInvalidated(int32_t p_api_type) {
-	return GDMono::get_singleton()->metadata_is_api_assembly_invalidated((APIAssembly::Type)p_api_type);
-}
-
-void godot_icall_Internal_MetadataSetApiAssemblyInvalidated(int32_t p_api_type, MonoBoolean p_invalidated) {
-	GDMono::get_singleton()->metadata_set_api_assembly_invalidated((APIAssembly::Type)p_api_type, (bool)p_invalidated);
-}
-
-MonoBoolean godot_icall_Internal_IsMessageQueueFlushing() {
-	return (MonoBoolean)MessageQueue::get_singleton()->is_flushing();
 }
 
 MonoBoolean godot_icall_Internal_GodotIs32Bits() {
@@ -407,12 +399,10 @@ void register_editor_internal_calls() {
 	mono_add_internal_call("GodotTools.GodotSharpExport::internal_GetExportedAssemblyDependencies", (void *)godot_icall_GodotSharpExport_GetExportedAssemblyDependencies);
 
 	// Internals
+	mono_add_internal_call("GodotTools.Internals.Internal::internal_UpdateApiAssembliesFromPrebuilt", (void *)godot_icall_Internal_UpdateApiAssembliesFromPrebuilt);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_FullTemplatesDir", (void *)godot_icall_Internal_FullTemplatesDir);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_SimplifyGodotPath", (void *)godot_icall_Internal_SimplifyGodotPath);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_IsOsxAppBundleInstalled", (void *)godot_icall_Internal_IsOsxAppBundleInstalled);
-	mono_add_internal_call("GodotTools.Internals.Internal::internal_MetadataIsApiAssemblyInvalidated", (void *)godot_icall_Internal_MetadataIsApiAssemblyInvalidated);
-	mono_add_internal_call("GodotTools.Internals.Internal::internal_MetadataSetApiAssemblyInvalidated", (void *)godot_icall_Internal_MetadataSetApiAssemblyInvalidated);
-	mono_add_internal_call("GodotTools.Internals.Internal::internal_IsMessageQueueFlushing", (void *)godot_icall_Internal_IsMessageQueueFlushing);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_GodotIs32Bits", (void *)godot_icall_Internal_GodotIs32Bits);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_GodotIsRealTDouble", (void *)godot_icall_Internal_GodotIsRealTDouble);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_GodotMainIteration", (void *)godot_icall_Internal_GodotMainIteration);

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -231,22 +231,27 @@ uint32_t godot_icall_GodotSharpExport_GetExportedAssemblyDependencies(MonoString
 	return GodotSharpExport::get_exported_assembly_dependencies(project_dll_name, project_dll_src_path, build_config, custom_lib_dir, dependencies);
 }
 
-float godot_icall_Internal_EditorScale() {
+float godot_icall_Globals_EditorScale() {
 	return EDSCALE;
 }
 
-MonoObject *godot_icall_Internal_GlobalDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
+MonoObject *godot_icall_Globals_GlobalDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
 	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
 	Variant default_value = GDMonoMarshal::mono_object_to_variant(p_default_value);
 	Variant result = _GLOBAL_DEF(setting, default_value, (bool)p_restart_if_changed);
 	return GDMonoMarshal::variant_to_mono_object(result);
 }
 
-MonoObject *godot_icall_Internal_EditorDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
+MonoObject *godot_icall_Globals_EditorDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
 	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
 	Variant default_value = GDMonoMarshal::mono_object_to_variant(p_default_value);
 	Variant result = _GLOBAL_DEF(setting, default_value, (bool)p_restart_if_changed);
 	return GDMonoMarshal::variant_to_mono_object(result);
+}
+
+MonoString *godot_icall_Globals_TTR(MonoString *p_text) {
+	String text = GDMonoMarshal::mono_string_to_godot(p_text);
+	return GDMonoMarshal::mono_string_from_godot(TTR(text));
 }
 
 MonoString *godot_icall_Internal_FullTemplatesDir() {
@@ -402,9 +407,6 @@ void register_editor_internal_calls() {
 	mono_add_internal_call("GodotTools.GodotSharpExport::internal_GetExportedAssemblyDependencies", (void *)godot_icall_GodotSharpExport_GetExportedAssemblyDependencies);
 
 	// Internals
-	mono_add_internal_call("GodotTools.Internals.Internal::internal_EditorScale", (void *)godot_icall_Internal_EditorScale);
-	mono_add_internal_call("GodotTools.Internals.Internal::internal_GlobalDef", (void *)godot_icall_Internal_GlobalDef);
-	mono_add_internal_call("GodotTools.Internals.Internal::internal_EditorDef", (void *)godot_icall_Internal_EditorDef);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_FullTemplatesDir", (void *)godot_icall_Internal_FullTemplatesDir);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_SimplifyGodotPath", (void *)godot_icall_Internal_SimplifyGodotPath);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_IsOsxAppBundleInstalled", (void *)godot_icall_Internal_IsOsxAppBundleInstalled);
@@ -423,6 +425,12 @@ void register_editor_internal_calls() {
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_EditorNodeShowScriptScreen", (void *)godot_icall_Internal_EditorNodeShowScriptScreen);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_GetScriptsMetadataOrNothing", (void *)godot_icall_Internal_GetScriptsMetadataOrNothing);
 	mono_add_internal_call("GodotTools.Internals.Internal::internal_MonoWindowsInstallRoot", (void *)godot_icall_Internal_MonoWindowsInstallRoot);
+
+	// Globals
+	mono_add_internal_call("GodotTools.Internals.Globals::internal_EditorScale", (void *)godot_icall_Globals_EditorScale);
+	mono_add_internal_call("GodotTools.Internals.Globals::internal_GlobalDef", (void *)godot_icall_Globals_GlobalDef);
+	mono_add_internal_call("GodotTools.Internals.Globals::internal_EditorDef", (void *)godot_icall_Globals_EditorDef);
+	mono_add_internal_call("GodotTools.Internals.Globals::internal_TTR", (void *)godot_icall_Globals_TTR);
 
 	// Utils.OS
 	mono_add_internal_call("GodotTools.Utils.OS::GetPlatformName", (void *)godot_icall_Utils_OS_GetPlatformName);

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -104,6 +104,8 @@ class GDMono {
 
 	void _domain_assemblies_cleanup(uint32_t p_domain_id);
 
+	bool _are_api_assemblies_out_of_sync();
+
 	bool _load_corlib_assembly();
 	bool _load_core_api_assembly();
 #ifdef TOOLS_ENABLED
@@ -112,11 +114,8 @@ class GDMono {
 #endif
 	bool _load_project_assembly();
 
-	bool _load_api_assemblies();
-
-#ifdef TOOLS_ENABLED
-	String _get_api_assembly_metadata_path();
-#endif
+	bool _try_load_api_assemblies();
+	void _load_api_assemblies();
 
 	void _install_trace_listener();
 
@@ -157,9 +156,8 @@ public:
 #endif
 
 #ifdef TOOLS_ENABLED
-	void metadata_set_api_assembly_invalidated(APIAssembly::Type p_api_type, bool p_invalidated);
-	bool metadata_is_api_assembly_invalidated(APIAssembly::Type p_api_type);
-	String get_invalidated_api_assembly_path(APIAssembly::Type p_api_type);
+	bool copy_prebuilt_api_assembly(APIAssembly::Type p_api_type);
+	String update_api_assemblies_from_prebuilt();
 #endif
 
 	static GDMono *get_singleton() { return singleton; }
@@ -203,6 +201,7 @@ public:
 	Error finalize_and_unload_domain(MonoDomain *p_domain);
 
 	void initialize();
+	void initialize_load_assemblies();
 
 	GDMono();
 	~GDMono();


### PR DESCRIPTION
Remove the old API assembly invalidation system. It's pretty simple since now the editor has a hard dependency on the API assemblies and SCons takes care of prebuilding them.
If we fail to load a project's API assembly because it was either missing or outdated, we just copy the prebuilt assemblies to the project and try again. We also do this when creating the solution and before building, just in case the user removed them from the disk after they were loaded.
This way the API assemblies will be always loaded successfully. If they are not, it's a bug.

Also add old TTRs to GodotTools (these were commented out during the rewrite in C# and I forgot to add them back) and fixed:

- EditorDef was behaving like GlobalDef in GodotTools.
- NullReferenceException because we can't serialize System.WeakReference yet. Use Godot.WeakRef in the mean time.

