### PR TITLE
Fix 3D move_and_slide with stop_on_slope

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1282,7 +1282,7 @@ Vector3 KinematicBody::move_and_slide_with_snap(const Vector3 &p_linear_velocity
 				if (p_stop_on_slope) {
 					// move and collide may stray the object a bit because of pre un-stucking,
 					// so only ensure that motion happens on floor direction in this case.
-					col.travel = p_floor_direction * p_floor_direction.dot(col.travel);
+					col.travel = col.travel.project(p_floor_direction);
 				}
 			} else {
 				apply = false; //snapped with floor direction, but did not snap to a floor, do not snap.

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1218,7 +1218,7 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 						if (p_stop_on_slope) {
 							if ((lv_n + p_floor_direction).length() < 0.01 && collision.travel.length() < 1) {
 								Transform gt = get_global_transform();
-								gt.origin -= collision.travel;
+								gt.origin -= collision.travel.slide(p_floor_direction);
 								set_global_transform(gt);
 								return Vector3();
 							}


### PR DESCRIPTION
Fixes #28412 

KinematicBody::move_and_slide with p_stop_on_slope = true was reversing the entirety of the movement deemed as sliding on a slope, instead of just the movement along the plane defined by p_floor_direction, causing the body to hover above a ground collider in certain cases, then noticeably snap down to it when the movement changed. 

Also applies to 3.1