### PR TITLE
Added individual particle random lifetime

### DIFF
--- a/doc/classes/CPUParticles.xml
+++ b/doc/classes/CPUParticles.xml
@@ -220,6 +220,9 @@
 		<member name="lifetime" type="float" setter="set_lifetime" getter="get_lifetime" default="1.0">
 			Amount of time each particle will exist.
 		</member>
+		<member name="lifetime_randomness" type="float" setter="set_lifetime_randomness" getter="get_lifetime_randomness" default="0.0">
+			Particle lifetime randomness ratio.
+		</member>
 		<member name="linear_accel" type="float" setter="set_param" getter="get_param" default="0.0">
 			Linear acceleration applied to each particle in the direction of motion.
 		</member>

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -214,6 +214,9 @@
 		<member name="lifetime" type="float" setter="set_lifetime" getter="get_lifetime" default="1.0">
 			Amount of time each particle will exist.
 		</member>
+		<member name="lifetime_randomness" type="float" setter="set_lifetime_randomness" getter="get_lifetime_randomness" default="0.0">
+			Particle lifetime randomness ratio.
+		</member>
 		<member name="linear_accel" type="float" setter="set_param" getter="get_param" default="0.0">
 			Linear acceleration applied to each particle in the direction of motion.
 		</member>

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -192,6 +192,9 @@
 		<member name="initial_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
 			Initial velocity randomness ratio.
 		</member>
+		<member name="lifetime_randomness" type="float" setter="set_lifetime_randomness" getter="get_lifetime_randomness" default="0.0">
+			Particle lifetime randomness ratio.
+		</member>
 		<member name="linear_accel" type="float" setter="set_param" getter="get_param" default="0.0">
 			Linear acceleration applied to each particle in the direction of motion.
 		</member>

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -83,6 +83,10 @@ void CPUParticles2D::set_randomness_ratio(float p_ratio) {
 
 	randomness_ratio = p_ratio;
 }
+void CPUParticles2D::set_lifetime_randomness(float p_random) {
+
+	lifetime_randomness = p_random;
+}
 void CPUParticles2D::set_use_local_coordinates(bool p_enable) {
 
 	local_coords = p_enable;
@@ -122,6 +126,10 @@ float CPUParticles2D::get_explosiveness_ratio() const {
 float CPUParticles2D::get_randomness_ratio() const {
 
 	return randomness_ratio;
+}
+float CPUParticles2D::get_lifetime_randomness() const {
+
+	return lifetime_randomness;
 }
 
 bool CPUParticles2D::get_use_local_coordinates() const {
@@ -611,6 +619,10 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			}
 		}
 
+		if (p.time * (1.0 - explosiveness_ratio) > p.lifetime) {
+			restart = true;
+		}
+
 		if (restart) {
 
 			if (!emitting) {
@@ -654,6 +666,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			p.custom[3] = 0.0;
 			p.transform = Transform2D();
 			p.time = 0;
+			p.lifetime = lifetime * (1.0 - Math::randf() * lifetime_randomness);
 			p.base_color = Color(1, 1, 1, 1);
 
 			switch (emission_shape) {
@@ -696,6 +709,8 @@ void CPUParticles2D::_particles_process(float p_delta) {
 
 		} else if (!p.active) {
 			continue;
+		} else if (p.time > p.lifetime) {
+			p.active = false;
 		} else {
 
 			uint32_t alt_seed = p.seed;
@@ -1153,6 +1168,7 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 
 	Vector2 gravity = Vector2(material->get_gravity().x, material->get_gravity().y);
 	set_gravity(gravity);
+	set_lifetime_randomness(material->get_lifetime_randomness());
 
 #define CONVERT_PARAM(m_param)                                                            \
 	set_param(m_param, material->get_param(ParticlesMaterial::m_param));                  \
@@ -1187,6 +1203,7 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pre_process_time", "secs"), &CPUParticles2D::set_pre_process_time);
 	ClassDB::bind_method(D_METHOD("set_explosiveness_ratio", "ratio"), &CPUParticles2D::set_explosiveness_ratio);
 	ClassDB::bind_method(D_METHOD("set_randomness_ratio", "ratio"), &CPUParticles2D::set_randomness_ratio);
+	ClassDB::bind_method(D_METHOD("set_lifetime_randomness", "random"), &CPUParticles2D::set_lifetime_randomness);
 	ClassDB::bind_method(D_METHOD("set_use_local_coordinates", "enable"), &CPUParticles2D::set_use_local_coordinates);
 	ClassDB::bind_method(D_METHOD("set_fixed_fps", "fps"), &CPUParticles2D::set_fixed_fps);
 	ClassDB::bind_method(D_METHOD("set_fractional_delta", "enable"), &CPUParticles2D::set_fractional_delta);
@@ -1199,6 +1216,7 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pre_process_time"), &CPUParticles2D::get_pre_process_time);
 	ClassDB::bind_method(D_METHOD("get_explosiveness_ratio"), &CPUParticles2D::get_explosiveness_ratio);
 	ClassDB::bind_method(D_METHOD("get_randomness_ratio"), &CPUParticles2D::get_randomness_ratio);
+	ClassDB::bind_method(D_METHOD("get_lifetime_randomness"), &CPUParticles2D::get_lifetime_randomness);
 	ClassDB::bind_method(D_METHOD("get_use_local_coordinates"), &CPUParticles2D::get_use_local_coordinates);
 	ClassDB::bind_method(D_METHOD("get_fixed_fps"), &CPUParticles2D::get_fixed_fps);
 	ClassDB::bind_method(D_METHOD("get_fractional_delta"), &CPUParticles2D::get_fractional_delta);
@@ -1225,6 +1243,7 @@ void CPUParticles2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "speed_scale", PROPERTY_HINT_RANGE, "0,64,0.01"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "explosiveness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_explosiveness_ratio", "get_explosiveness_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "randomness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_randomness_ratio", "get_randomness_ratio");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lifetime_randomness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_lifetime_randomness", "get_lifetime_randomness");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_fps", PROPERTY_HINT_RANGE, "0,1000,1"), "set_fixed_fps", "get_fixed_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fract_delta"), "set_fractional_delta", "get_fractional_delta");
 	ADD_GROUP("Drawing", "");
@@ -1404,6 +1423,7 @@ CPUParticles2D::CPUParticles2D() {
 	set_pre_process_time(0);
 	set_explosiveness_ratio(0);
 	set_randomness_ratio(0);
+	set_lifetime_randomness(0);
 	set_use_local_coordinates(true);
 
 	set_draw_order(DRAW_ORDER_INDEX);

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -96,6 +96,7 @@ private:
 		float hue_rot_rand;
 		float anim_offset_rand;
 		float time;
+		float lifetime;
 		Color base_color;
 
 		uint32_t seed;
@@ -139,6 +140,7 @@ private:
 	float pre_process_time;
 	float explosiveness_ratio;
 	float randomness_ratio;
+	float lifetime_randomness;
 	float speed_scale;
 	bool local_coords;
 	int fixed_fps;
@@ -200,6 +202,7 @@ public:
 	void set_pre_process_time(float p_time);
 	void set_explosiveness_ratio(float p_ratio);
 	void set_randomness_ratio(float p_ratio);
+	void set_lifetime_randomness(float p_random);
 	void set_visibility_aabb(const Rect2 &p_aabb);
 	void set_use_local_coordinates(bool p_enable);
 	void set_speed_scale(float p_scale);
@@ -211,6 +214,7 @@ public:
 	float get_pre_process_time() const;
 	float get_explosiveness_ratio() const;
 	float get_randomness_ratio() const;
+	float get_lifetime_randomness() const;
 	Rect2 get_visibility_aabb() const;
 	bool get_use_local_coordinates() const;
 	float get_speed_scale() const;

--- a/scene/3d/cpu_particles.h
+++ b/scene/3d/cpu_particles.h
@@ -95,6 +95,7 @@ private:
 		float hue_rot_rand;
 		float anim_offset_rand;
 		float time;
+		float lifetime;
 		Color base_color;
 
 		uint32_t seed;
@@ -137,6 +138,7 @@ private:
 	float pre_process_time;
 	float explosiveness_ratio;
 	float randomness_ratio;
+	float lifetime_randomness;
 	float speed_scale;
 	bool local_coords;
 	int fixed_fps;
@@ -200,6 +202,7 @@ public:
 	void set_pre_process_time(float p_time);
 	void set_explosiveness_ratio(float p_ratio);
 	void set_randomness_ratio(float p_ratio);
+	void set_lifetime_randomness(float p_random);
 	void set_visibility_aabb(const AABB &p_aabb);
 	void set_use_local_coordinates(bool p_enable);
 	void set_speed_scale(float p_scale);
@@ -211,6 +214,7 @@ public:
 	float get_pre_process_time() const;
 	float get_explosiveness_ratio() const;
 	float get_randomness_ratio() const;
+	float get_lifetime_randomness() const;
 	AABB get_visibility_aabb() const;
 	bool get_use_local_coordinates() const;
 	float get_speed_scale() const;

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -185,6 +185,8 @@ private:
 		StringName trail_color_modifier;
 
 		StringName gravity;
+
+		StringName lifetime_randomness;
 	};
 
 	static ShaderNames *shader_names;
@@ -224,6 +226,8 @@ private:
 	Ref<GradientTexture> trail_color_modifier;
 
 	Vector3 gravity;
+
+	float lifetime_randomness;
 
 	//do not save emission points here
 
@@ -286,6 +290,9 @@ public:
 
 	void set_gravity(const Vector3 &p_gravity);
 	Vector3 get_gravity() const;
+
+	void set_lifetime_randomness(float p_lifetime);
+	float get_lifetime_randomness() const;
 
 	static void init_shaders();
 	static void finish_shaders();


### PR DESCRIPTION
Resolves: https://github.com/godotengine/godot/issues/30032

Code graciously donated by Gamblify.

For CPUParticles* I added ``lifetime_randomness`` as a property under ``time`` however, for Particles* the only way for it to work was to make it part of ParticlesMaterial. Accordingly, I made it the first property in the ParticlesMaterial. 

I initially thought we would need to overhaul the timing of particles to do this, but it turns out it can be done quite elegantly under the current system. :)

We could make ``lifetime_randomness`` part of Particles* instead of ParticlesMaterial, but it would require some light changes to the gles3 drivers and we would have to change ``CUSTOM`` into a vec3 (in this way it would be the same as ``VELOCITY`` which is a vec4 internally, but only the first three parts are exposed to the user, the fourth is used for ``ACTIVE``). 