### PR TITLE
Consistently lexicographical sort external resources

### DIFF
--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -363,25 +363,6 @@ bool Resource::is_translation_remapped() const {
 	return remapped_list.in_list();
 }
 
-#ifdef TOOLS_ENABLED
-//helps keep IDs same number when loading/saving scenes. -1 clears ID and it Returns -1 when no id stored
-void Resource::set_id_for_path(const String &p_path, int p_id) {
-	if (p_id == -1) {
-		id_for_path.erase(p_path);
-	} else {
-		id_for_path[p_path] = p_id;
-	}
-}
-
-int Resource::get_id_for_path(const String &p_path) const {
-
-	if (id_for_path.has(p_path)) {
-		return id_for_path[p_path];
-	} else {
-		return -1;
-	}
-}
-#endif
 
 void Resource::_bind_methods() {
 

--- a/core/resource.h
+++ b/core/resource.h
@@ -88,9 +88,6 @@ protected:
 
 	void _set_path(const String &p_path);
 	void _take_over_path(const String &p_path);
-#ifdef TOOLS_ENABLED
-	Map<String, int> id_for_path;
-#endif
 public:
 	static Node *(*_get_local_scene_func)(); //used by editor
 
@@ -137,13 +134,13 @@ public:
 	void set_as_translation_remapped(bool p_remapped);
 	bool is_translation_remapped() const;
 
-	virtual RID get_rid() const; // some resources may offer conversion to RID
+	struct PathCompare {
+		_FORCE_INLINE_ bool operator()(const Ref<Resource> &l, const Ref<Resource> &r) const {
+			return l->get_path() < r->get_path();
+		}
+	};
 
-#ifdef TOOLS_ENABLED
-	//helps keep IDs same number when loading/saving scenes. -1 clears ID and it Returns -1 when no id stored
-	void set_id_for_path(const String &p_path, int p_id);
-	int get_id_for_path(const String &p_path) const;
-#endif
+	virtual RID get_rid() const; // some resources may offer conversion to RID
 
 	Resource();
 	~Resource();


### PR DESCRIPTION
This removes the existing code for caching which resources has
which path. Closes #30538