### PR TITLE
Allows to use non-constants in the local shader array initializer

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3958,10 +3958,6 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const Map<StringName, Bui
 								if (!n) {
 									return ERR_PARSE_ERROR;
 								}
-								if (n->type != Node::TYPE_CONSTANT) {
-									_set_error("Expected constant expression in the array declaration");
-									return ERR_PARSE_ERROR;
-								}
 
 								if (var.type != n->get_datatype()) {
 									_set_error("Invalid assignment of '" + get_datatype_name(n->get_datatype()) + "' to '" + get_datatype_name(var.type) + "'");


### PR DESCRIPTION
I forgot to remove the const check in https://github.com/godotengine/godot/pull/30596 User should be able to push the non-constant expression to non-constant array initializer.

It will allows to write such code:
```
float t = 1.0;
float array[2] = {t, 1.0};
```

 Const will be implemented later.