### PR TITLE
Prevent shader crash in the editor when passing invalid array index

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -587,7 +587,15 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 			if (var_node->index_expression != NULL) {
 				code += "[";
-				code += _dump_node_code(var_node->index_expression, p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+				if (Engine::get_singleton()->is_editor_hint() && var_node->index_expression->type != ShaderLanguage::Node::TYPE_CONSTANT) { // to prevent shader crash in editor mode, when the given expression return incorrect index
+					code += "int(clamp(";
+					code += _dump_node_code(var_node->index_expression, p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+					code += ",0,";
+					code += _mkid(var_node->name);
+					code += ".length()-1))";
+				} else {
+					code += _dump_node_code(var_node->index_expression, p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+				}
 				code += "]";
 			}
 

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -675,7 +675,15 @@ String ShaderCompilerGLES3::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 			if (vnode->index_expression != NULL) {
 				code += "[";
-				code += _dump_node_code(vnode->index_expression, p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+				if (Engine::get_singleton()->is_editor_hint() && vnode->index_expression->type != ShaderLanguage::Node::TYPE_CONSTANT) { // to prevent shader crash in editor mode, when the given expression return incorrect index
+					code += "int(clamp(";
+					code += _dump_node_code(vnode->index_expression, p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+					code += ",0,";
+					code += _mkid(vnode->name);
+					code += ".length()-1))";
+				} else {
+					code += _dump_node_code(vnode->index_expression, p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+				}
 				code += "]";
 			}
 


### PR DESCRIPTION
As @Calinou suggested, its better to have a check in the editor to prevent shader crashes. I used clamp instruction to achieve this result - its works perfectly