### PR TITLE
Scons: add an option to use extended numeric limits

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -113,6 +113,7 @@ opts.Add(EnumVariable('optimize', "Optimization type", 'speed', ('speed', 'size'
 opts.Add(BoolVariable('tools', "Build the tools (a.k.a. the Godot editor)", True))
 opts.Add(BoolVariable('use_lto', 'Use link-time optimization', False))
 opts.Add(BoolVariable('use_precise_math_checks', 'Math checks use very precise epsilon (useful to debug the engine)', False))
+opts.Add(BoolVariable('use_extended_limits', 'Constants use maximum or extended limits where appropriate (might be platform-dependent)', False))
 
 # Components
 opts.Add(BoolVariable('deprecated', "Enable deprecated features", True))
@@ -197,6 +198,9 @@ env_base.platform_apis = platform_apis
 
 if (env_base["use_precise_math_checks"]):
     env_base.Append(CPPDEFINES=['PRECISE_MATH_CHECKS'])
+    
+if (env_base['use_extended_limits']):
+    env_base.Append(CPPDEFINES=['EXTENDED_LIMITS'])
 
 if (env_base['target'] == 'debug'):
     env_base.Append(CPPDEFINES=['DEBUG_MEMORY_ALLOC','DISABLE_FORCED_INLINE'])

--- a/core/image.h
+++ b/core/image.h
@@ -36,6 +36,10 @@
 #include "core/pool_vector.h"
 #include "core/resource.h"
 
+#ifdef EXTENDED_LIMITS
+#include <limits>
+#endif
+
 /**
  *	@author Juan Linietsky <reduzio@gmail.com>
  *
@@ -55,10 +59,17 @@ class Image : public Resource {
 public:
 	static SavePNGFunc save_png_func;
 
+#ifdef EXTENDED_LIMITS
+	enum {
+		MAX_WIDTH = std::numeric_limits<int>::max(),
+		MAX_HEIGHT = std::numeric_limits<int>::max()
+	};
+#else
 	enum {
 		MAX_WIDTH = 16384, // force a limit somehow
 		MAX_HEIGHT = 16384 // force a limit somehow
 	};
+#endif
 
 	enum Format {
 


### PR DESCRIPTION
This inroduces a new build option: `scons use_extended_limits=yes`

If set, the engine can take advantage of extended numeric limits where developer seems appropriate by using `EXTENDED_LIMITS` preprocessor variable for conditional compilation. The option is disabled by default.

---

As the feature is useless without concrete use cases, the `Image` maximum dimensions  were extended to use a C++ equivalent of `INT_MAX`. The default value is still 16384 if the option is not set, so this makes it more flexible for users to work with.

![image_extended_limits](https://user-images.githubusercontent.com/17108460/61291700-e9925780-a7d7-11e9-8970-de0bd2a585b4.png)

Fixes #30238 yet users will need to recompile the engine in order to take advantage of this (the use case is already specific enough for a user to learn how to do so).

Can also help #30597, remotely related #21793. I'm not sure what other limits are hardcoded!
