### PR TITLE
Fix passing by rvalue to const&

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1551,8 +1551,9 @@ bool Main::start() {
 					}
 
 					if (global_var) {
+						Variant v;
 						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-							ScriptServer::get_language(i)->add_global_constant(name, Variant());
+							ScriptServer::get_language(i)->add_global_constant(name, v);
 						}
 					}
 				}


### PR DESCRIPTION
Because `Variant() `is an rvalue, it will be dead within the scope of this function call.