### PR TITLE
PackedScene resources are freed before they are saved

### DIFF
--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -367,17 +367,38 @@ bool Resource::is_translation_remapped() const {
 //helps keep IDs same number when loading/saving scenes. -1 clears ID and it Returns -1 when no id stored
 void Resource::set_id_for_path(const String &p_path, int p_id) {
 	if (p_id == -1) {
-		id_for_path.erase(p_path);
+		if (ResourceCache::path_cache_lock) {
+			ResourceCache::path_cache_lock->write_lock();
+		}
+		ResourceCache::resource_path_cache[p_path].erase(get_path());
+		if (ResourceCache::path_cache_lock) {
+			ResourceCache::path_cache_lock->write_unlock();
+		}
 	} else {
-		id_for_path[p_path] = p_id;
+		if (ResourceCache::path_cache_lock) {
+			ResourceCache::path_cache_lock->write_lock();
+		}
+		ResourceCache::resource_path_cache[p_path][get_path()] = p_id;
+		if (ResourceCache::path_cache_lock) {
+			ResourceCache::path_cache_lock->write_unlock();
+		}
 	}
 }
 
 int Resource::get_id_for_path(const String &p_path) const {
-
-	if (id_for_path.has(p_path)) {
-		return id_for_path[p_path];
+	if (ResourceCache::path_cache_lock) {
+		ResourceCache::path_cache_lock->read_lock();
+	}
+	if (ResourceCache::resource_path_cache[p_path].has(get_path())) {
+		int result = ResourceCache::resource_path_cache[p_path][get_path()];
+		if (ResourceCache::path_cache_lock) {
+			ResourceCache::path_cache_lock->read_unlock();
+		}
+		return result;
 	} else {
+		if (ResourceCache::path_cache_lock) {
+			ResourceCache::path_cache_lock->read_unlock();
+		}
 		return -1;
 	}
 }
@@ -432,12 +453,21 @@ Resource::~Resource() {
 }
 
 HashMap<String, Resource *> ResourceCache::resources;
+#ifdef TOOLS_ENABLED
+HashMap<String, HashMap<String, int> > ResourceCache::resource_path_cache;
+#endif
 
 RWLock *ResourceCache::lock = NULL;
+#ifdef TOOLS_ENABLED
+RWLock *ResourceCache::path_cache_lock = NULL;
+#endif
 
 void ResourceCache::setup() {
 
 	lock = RWLock::create();
+#ifdef TOOLS_ENABLED
+	path_cache_lock = RWLock::create();
+#endif
 }
 
 void ResourceCache::clear() {

--- a/core/resource.h
+++ b/core/resource.h
@@ -88,9 +88,7 @@ protected:
 
 	void _set_path(const String &p_path);
 	void _take_over_path(const String &p_path);
-#ifdef TOOLS_ENABLED
-	Map<String, int> id_for_path;
-#endif
+
 public:
 	static Node *(*_get_local_scene_func)(); //used by editor
 
@@ -156,6 +154,10 @@ class ResourceCache {
 	friend class ResourceLoader; //need the lock
 	static RWLock *lock;
 	static HashMap<String, Resource *> resources;
+#ifdef TOOLS_ENABLED
+	static HashMap<String, HashMap<String, int> > resource_path_cache; // each tscn has a set of resource paths and IDs
+	static RWLock *path_cache_lock;
+#endif // TOOLS_ENABLED
 	friend void unregister_core_types();
 	static void clear();
 	friend void register_core_types();


### PR DESCRIPTION
 - PackedScenes freed before saved, so their path cache is lost
 - Solution is to move data to persistent static map
 - This patch will fix #30538