### PR TITLE
Prevent editing properties managed by parent container

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -30,6 +30,7 @@
 
 #include "control.h"
 
+#include "container.h"
 #include "core/config/project_settings.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/message_queue.h"
@@ -167,6 +168,20 @@ Size2 Control::_edit_get_minimum_size() const {
 	return get_combined_minimum_size();
 }
 #endif
+
+String Control::properties_managed_by_container[] = {
+	"offset_left",
+	"offset_top",
+	"offset_right",
+	"offset_bottom",
+	"anchor_left",
+	"anchor_top",
+	"anchor_right",
+	"anchor_bottom",
+	"rect_position",
+	"rect_scale",
+	"rect_size"
+};
 
 void Control::accept_event() {
 	if (is_inside_tree()) {
@@ -441,6 +456,20 @@ void Control::_validate_property(PropertyInfo &property) const {
 		}
 
 		property.hint_string = hint_string;
+	}
+	if (!Object::cast_to<Container>(get_parent())) {
+		return;
+	}
+	// Disable the property if it's managed by the parent container.
+	bool property_is_managed_by_container = false;
+	for (unsigned i = 0; i < properties_managed_by_container_count; i++) {
+		property_is_managed_by_container = properties_managed_by_container[i] == property.name;
+		if (property_is_managed_by_container) {
+			break;
+		}
+	}
+	if (property_is_managed_by_container) {
+		property.usage |= PROPERTY_USAGE_READ_ONLY;
 	}
 }
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -230,6 +230,9 @@ private:
 
 	} data;
 
+	static constexpr unsigned properties_managed_by_container_count = 11;
+	static String properties_managed_by_container[properties_managed_by_container_count];
+
 	// used internally
 	Control *_find_control_at_pos(CanvasItem *p_node, const Point2 &p_pos, const Transform2D &p_xform, Transform2D &r_inv_xform);
 


### PR DESCRIPTION
Addresses #28718 by making the properties that are managed by parent container not editable inside the inspector.

Currently the properties that get disabled are:
* Anchor
* Margin
* Position
* Scale
* Size

This is achieved by disabling mouse interactions and preventing focus on the aforementioned inspector properties.

This is how it looks when properties get disabled:
![capture](https://user-images.githubusercontent.com/19125153/61315243-a3042380-a7fe-11e9-923c-c890cee30935.png)

*Bugsquad edit:* Fixes #28718 and fixes https://github.com/godotengine/godot-proposals/issues/2202.