### PR TITLE
Node2D: look_at() return rotation angle

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -369,9 +369,11 @@ Transform2D Node2D::get_relative_transform_to_parent(const Node *p_parent) const
 		return parent_2d->get_relative_transform_to_parent(p_parent) * get_transform();
 }
 
-void Node2D::look_at(const Vector2 &p_pos) {
+float Node2D::look_at(const Vector2 &p_pos) {
 
-	rotate(get_angle_to(p_pos));
+	float rot_angle = get_angle_to(p_pos);
+	rotate(rot_angle);
+	return rot_angle;
 }
 
 float Node2D::get_angle_to(const Vector2 &p_pos) const {

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -102,7 +102,7 @@ public:
 	void set_z_index(int p_z);
 	int get_z_index() const;
 
-	void look_at(const Vector2 &p_pos);
+	float look_at(const Vector2 &p_pos);
 	float get_angle_to(const Vector2 &p_pos) const;
 
 	Point2 to_local(Point2 p_global) const;


### PR DESCRIPTION
Figured it would be nice if the Node2D func `look_at()` would also return the angle of rotation instead of just being void.