### PR TITLE
Fix BMP loader incorrectly interpreting color table size

### DIFF
--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -257,8 +257,8 @@ Error ImageLoaderBMP::load_image(Ref<Image> p_image, FileAccess *f,
 			if (bmp_header.bmp_info_header.bmp_bit_count <= 8) {
 				// Support 256 colors max
 				color_table_size = 1 << bmp_header.bmp_info_header.bmp_bit_count;
+				ERR_FAIL_COND_V(color_table_size == 0, ERR_BUG);
 			}
-			ERR_FAIL_COND_V(color_table_size == 0, ERR_BUG);
 
 			PoolVector<uint8_t> bmp_color_table;
 			// Color table is usually 4 bytes per color -> [B][G][R][0]


### PR DESCRIPTION
Color table should exist for images with bit count <= 8. Importing 16-bit
BMP images could also likely have a color table but they're not currently
supported in Godot.

Partly fixes some of the importing issues in #30629, namely `icon_from_gimp_24bit.bmp`