### PR TITLE
Add font color for buttons when focused

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -99,12 +99,14 @@ void BaseButton::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_FOCUS_ENTER) {
 
-		status.hovering = true;
+		//status.hovering = true;
+		status.focused = true;
 		update();
 	}
 
 	if (p_what == NOTIFICATION_FOCUS_EXIT) {
 
+		status.focused = false;
 		if (status.press_attempt) {
 			status.press_attempt = false;
 			status.hovering = false;
@@ -253,6 +255,10 @@ BaseButton::DrawMode BaseButton::get_draw_mode() const {
 
 		return DRAW_HOVER;
 	} else {
+
+		if (!status.press_attempt && !status.pressed && status.focused) {
+			return DRAW_FOCUSED;
+		}
 		/* determine if pressed or not */
 
 		bool pressing;
@@ -459,6 +465,7 @@ BaseButton::BaseButton() {
 	status.hovering = false;
 	status.pressing_inside = false;
 	status.disabled = false;
+	status.focused = false;
 	set_focus_mode(FOCUS_ALL);
 	enabled_focus_mode = FOCUS_ALL;
 	action_mode = ACTION_MODE_BUTTON_RELEASE;

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -63,6 +63,7 @@ private:
 		bool hovering;
 		bool press_attempt;
 		bool pressing_inside;
+		bool focused;
 
 		bool disabled;
 
@@ -91,6 +92,7 @@ public:
 		DRAW_HOVER,
 		DRAW_DISABLED,
 		DRAW_HOVER_PRESSED,
+		DRAW_FOCUSED,
 	};
 
 	DrawMode get_draw_mode() const;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -138,6 +138,11 @@ void Button::_notification(int p_what) {
 					color_icon = get_color("icon_color_disabled");
 
 			} break;
+			case DRAW_FOCUSED: {
+
+				color = get_color("font_color_focused");
+
+			} break;
 		}
 
 		if (has_focus()) {

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -98,6 +98,10 @@ void LinkButton::_notification(int p_what) {
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
 
 				} break;
+				case DRAW_FOCUSED: {
+
+					color = get_color("font_color_focused");
+				}
 			}
 
 			if (has_focus()) {

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -161,6 +161,13 @@ void TextureButton::_notification(int p_what) {
 					} else
 						texdraw = disabled;
 				} break;
+				case DRAW_FOCUSED: {
+					if (disabled.is_null()) {
+						if (normal.is_valid())
+							texdraw = normal;
+					} else
+						texdraw = disabled;
+				} break;
 			}
 
 			if (texdraw.is_valid()) {

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -182,6 +182,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	Color control_font_color_low = Color(0.69, 0.69, 0.69);
 	Color control_font_color_hover = Color(0.94, 0.94, 0.94);
 	Color control_font_color_disabled = Color(0.9, 0.9, 0.9, 0.2);
+	Color control_font_color_focused = Color(0.88, 0.88, 0.88);
 	Color control_font_color_pressed = Color(1, 1, 1);
 	Color font_color_selection = Color(0.49, 0.49, 0.49);
 
@@ -216,6 +217,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color_pressed", "Button", control_font_color_pressed);
 	theme->set_color("font_color_hover", "Button", control_font_color_hover);
 	theme->set_color("font_color_disabled", "Button", control_font_color_disabled);
+	theme->set_color("font_color_focused", "Button", control_font_color_focused);
 
 	theme->set_constant("hseparation", "Button", 2 * scale);
 


### PR DESCRIPTION
The changes inside default_theme.cpp can be skipped but then users won't know about this feature.

Closes #30614

~~EDIT: NVM about this for now. It overrides other colors so it is not a proper fix.~~ Fixed. Previously it was assumed that mouse enter and focus enter is the same thing, which is not.

EDIT: There is currently an automatic slight highlight of the text when the button is focused, but there is not a way to give the text a custom color on focus.