### PR TITLE
Documented the Tree column behaviour of min_width in conjunction with expand

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -182,7 +182,7 @@
 			<argument index="1" name="expand" type="bool">
 			</argument>
 			<description>
-				If [code]true[/code], the column will have the "Expand" flag of [Control].
+				If [code]true[/code], the column will have the "Expand" flag of [Control]. Columns that have the "Expand" flag will use their "min_width" in a similar fashion to [member Control.size_flags_stretch_ratio].
 			</description>
 		</method>
 		<method name="set_column_min_width">
@@ -193,7 +193,7 @@
 			<argument index="1" name="min_width" type="int">
 			</argument>
 			<description>
-				Sets the minimum width of a column.
+				Sets the minimum width of a column. Columns that have the "Expand" flag will use their "min_width" in a similar fashion to [member Control.size_flags_stretch_ratio].
 			</description>
 		</method>
 		<method name="set_column_title">


### PR DESCRIPTION
Might close pull request #30399 and issue #30233

The differences between the current behaviour and that in pull request #30399 only really seem to come into play when the tree has been resized to be small enough that the min-sizes cause a horizontal scrollbar to appear, versus getting sized down to almost nothing (if ratios are in use and min_size is low). 
