### PR TITLE
Fix BMP loader to distinguish between compression types

### DIFF
--- a/modules/bmp/image_loader_bmp.h
+++ b/modules/bmp/image_loader_bmp.h
@@ -42,15 +42,15 @@ protected:
 
 	enum bmp_compression_s {
 		BI_RGB = 0x00,
-		BI_RLE8 = 0x01,
-		BI_RLE4 = 0x02,
+		BI_RLE8 = 0x01, // compressed
+		BI_RLE4 = 0x02, // compressed
 		BI_BITFIELDS = 0x03,
 		BI_JPEG = 0x04,
 		BI_PNG = 0x05,
 		BI_ALPHABITFIELDS = 0x06,
 		BI_CMYK = 0x0b,
-		BI_CMYKRLE8 = 0x0c,
-		BI_CMYKRLE4 = 0x0d
+		BI_CMYKRLE8 = 0x0c, // compressed
+		BI_CMYKRLE4 = 0x0d // compressed
 	};
 
 	struct bmp_header_s {


### PR DESCRIPTION
Some of the values in compression enumeration represent uncompressed formats:

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/4e588f70-bd92-4a6f-b77f-35d0feaf7a57

This allows the loader to proceed with uncompressed formats.
Note that loading compressed BMP's is still not supported (likely 🙂).

Fixes loading `icon_from_gimp_32bit.bmp` and `icon_from_imagemagick.bmp` in #30629.