### PR TITLE
Lower the default directional shadow maximum distance to 100

### DIFF
--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -413,7 +413,7 @@ DirectionalLight::DirectionalLight() :
 
 	set_param(PARAM_SHADOW_NORMAL_BIAS, 0.8);
 	set_param(PARAM_SHADOW_BIAS, 0.1);
-	set_param(PARAM_SHADOW_MAX_DISTANCE, 200);
+	set_param(PARAM_SHADOW_MAX_DISTANCE, 100);
 	set_param(PARAM_SHADOW_BIAS_SPLIT_SCALE, 0.25);
 	set_shadow_mode(SHADOW_PARALLEL_4_SPLITS);
 	set_shadow_depth_range(SHADOW_DEPTH_RANGE_STABLE);


### PR DESCRIPTION
With the default camera node settings, this makes directional shadows look consistent between the editor and the running project.

The original issue occurs because the editor camera defaults to a Z-far value of 500, whereas the Camera node defaults to a Z-far value of 100. Since the directional shadow maximum distance is clamped to the Z-far value, it caused the running project's effective shadow distance to be lower compared to the editor (100 instead of 200).

This partially addresses #13575.