### PR TITLE
Added extents for GPU and CPU Particles2D emission points

### DIFF
--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -137,7 +137,7 @@ void CPUParticles2DEditorPlugin::_generate_emission_mask() {
 							valid_colors.write[vpc * 4 + 2] = r[(j * s.width + i) * 4 + 2];
 							valid_colors.write[vpc * 4 + 3] = r[(j * s.width + i) * 4 + 3];
 						}
-						valid_positions.write[vpc++] = Point2(i, j);
+						valid_positions.write[vpc++] = Point2(i, j) / s;
 
 					} else {
 
@@ -156,7 +156,7 @@ void CPUParticles2DEditorPlugin::_generate_emission_mask() {
 						}
 
 						if (on_border) {
-							valid_positions.write[vpc] = Point2(i, j);
+							valid_positions.write[vpc] = Point2(i, j) / s;
 
 							if (emode == EMISSION_MODE_BORDER_DIRECTED) {
 								Vector2 normal;

--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -210,7 +210,7 @@ void Particles2DEditorPlugin::_generate_emission_mask() {
 							valid_colors.write[vpc * 4 + 2] = r[(j * s.width + i) * 4 + 2];
 							valid_colors.write[vpc * 4 + 3] = r[(j * s.width + i) * 4 + 3];
 						}
-						valid_positions.write[vpc++] = Point2(i, j);
+						valid_positions.write[vpc++] = Point2(i, j) / s;
 
 					} else {
 
@@ -229,7 +229,7 @@ void Particles2DEditorPlugin::_generate_emission_mask() {
 						}
 
 						if (on_border) {
-							valid_positions.write[vpc] = Point2(i, j);
+							valid_positions.write[vpc] = Point2(i, j) / s;
 
 							if (emode == EMISSION_MODE_BORDER_DIRECTED) {
 								Vector2 normal;

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -493,7 +493,7 @@ void CPUParticles2D::_validate_property(PropertyInfo &property) const {
 		property.usage = 0;
 	}
 
-	if (property.name == "emission_rect_extents" && emission_shape != EMISSION_SHAPE_RECTANGLE) {
+	if (property.name == "emission_rect_extents" && emission_shape != EMISSION_SHAPE_RECTANGLE && emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
 		property.usage = 0;
 	}
 
@@ -690,7 +690,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 
 					int random_idx = Math::rand() % pc;
 
-					p.transform[2] = emission_points.get(random_idx);
+					p.transform[2] = emission_points.get(random_idx) * emission_rect_extents - (emission_rect_extents * 0.5);
 
 					if (emission_shape == EMISSION_SHAPE_DIRECTED_POINTS && emission_normals.size() == pc) {
 						p.velocity = emission_normals.get(random_idx);

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -192,6 +192,7 @@ void ParticlesMaterial::_update_shader() {
 			FALLTHROUGH;
 		}
 		case EMISSION_SHAPE_POINTS: {
+			code += "uniform vec3 emission_box_extents;\n";
 			code += "uniform sampler2D emission_texture_points : hint_black;\n";
 			code += "uniform int emission_texture_point_count;\n";
 			if (emission_color_texture.is_valid()) {
@@ -350,7 +351,7 @@ void ParticlesMaterial::_update_shader() {
 		} break;
 		case EMISSION_SHAPE_POINTS:
 		case EMISSION_SHAPE_DIRECTED_POINTS: {
-			code += "		TRANSFORM[3].xyz = texelFetch(emission_texture_points, emission_tex_ofs, 0).xyz;\n";
+			code += "		TRANSFORM[3].xyz = texelFetch(emission_texture_points, emission_tex_ofs, 0).xyz * emission_box_extents - (emission_box_extents * 0.5);\n";
 
 			if (emission_shape == EMISSION_SHAPE_DIRECTED_POINTS) {
 				if (flags[FLAG_DISABLE_Z]) {
@@ -1052,7 +1053,7 @@ void ParticlesMaterial::_validate_property(PropertyInfo &property) const {
 		property.usage = 0;
 	}
 
-	if (property.name == "emission_box_extents" && emission_shape != EMISSION_SHAPE_BOX) {
+	if (property.name == "emission_box_extents" && (emission_shape != EMISSION_SHAPE_BOX && emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS)) {
 		property.usage = 0;
 	}
 


### PR DESCRIPTION
The emission mask now uses relative values which are multiplied by the emission extents. This also fixes the issue where emission points are dependent on original texture size.

This commits also change emission points texture to be centered on the particle system instead of placing the top left corner at the center.

I think this also fixes #16411