### PR TITLE
Add a `uri` property to `LinkButton`

### DIFF
--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -28,7 +28,23 @@
 			Base text writing direction.
 		</member>
 		<member name="underline" type="int" setter="set_underline_mode" getter="get_underline_mode" enum="LinkButton.UnderlineMode" default="0">
-			Determines when to show the underline. See [enum UnderlineMode] for options.
+			The underline mode to use for the text. See [enum LinkButton.UnderlineMode] for the available modes.
+		</member>
+		<member name="uri" type="String" setter="set_uri" getter="get_uri" default="&quot;&quot;">
+			The [url=https://en.wikipedia.org/wiki/Uniform_Resource_Identifier]URI[/url] for this [LinkButton]. If set to a valid URI, pressing the button opens the URI using the operating system's default program for the protocol (via [method OS.shell_open]). HTTP and HTTPS URLs open the default web browser.
+			[b]Examples:[/b]
+			[codeblocks]
+			[gdscript]
+			uri = "https://godotengine.org"  # Opens the URL in the default web browser.
+			uri = "C:\SomeFolder"  # Opens the file explorer at the given path.
+			uri = "C:\SomeImage.png"  # Opens the given image in the default viewing app.
+			[/gdscript]
+			[csharp]
+			Uri = "https://godotengine.org"; // Opens the URL in the default web browser.
+			Uri = "C:\SomeFolder"; // Opens the file explorer at the given path.
+			Uri = "C:\SomeImage.png"; // Opens the given image in the default viewing app.
+			[/csharp]
+			[/codeblocks]
 		</member>
 	</members>
 	<constants>

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -231,6 +231,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["tcp"] = "TCP";
 	capitalize_string_remaps["tls"] = "TLS";
 	capitalize_string_remaps["ui"] = "UI";
+	capitalize_string_remaps["uri"] = "URI";
 	capitalize_string_remaps["url"] = "URL";
 	capitalize_string_remaps["urls"] = "URLs";
 	capitalize_string_remaps["us"] = String::utf8("(µs)"); // Unit.

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -108,6 +108,14 @@ String LinkButton::get_language() const {
 	return language;
 }
 
+void LinkButton::set_uri(const String &p_uri) {
+	uri = p_uri;
+}
+
+String LinkButton::get_uri() const {
+	return uri;
+}
+
 void LinkButton::set_underline_mode(UnderlineMode p_underline_mode) {
 	if (underline_mode == p_underline_mode) {
 		return;
@@ -119,6 +127,14 @@ void LinkButton::set_underline_mode(UnderlineMode p_underline_mode) {
 
 LinkButton::UnderlineMode LinkButton::get_underline_mode() const {
 	return underline_mode;
+}
+
+void LinkButton::pressed() {
+	if (uri.is_empty()) {
+		return;
+	}
+
+	OS::get_singleton()->shell_open(uri);
 }
 
 Size2 LinkButton::get_minimum_size() const {
@@ -245,6 +261,8 @@ void LinkButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_text_direction"), &LinkButton::get_text_direction);
 	ClassDB::bind_method(D_METHOD("set_language", "language"), &LinkButton::set_language);
 	ClassDB::bind_method(D_METHOD("get_language"), &LinkButton::get_language);
+	ClassDB::bind_method(D_METHOD("set_uri", "uri"), &LinkButton::set_uri);
+	ClassDB::bind_method(D_METHOD("get_uri"), &LinkButton::get_uri);
 	ClassDB::bind_method(D_METHOD("set_underline_mode", "underline_mode"), &LinkButton::set_underline_mode);
 	ClassDB::bind_method(D_METHOD("get_underline_mode"), &LinkButton::get_underline_mode);
 	ClassDB::bind_method(D_METHOD("set_structured_text_bidi_override", "parser"), &LinkButton::set_structured_text_bidi_override);
@@ -258,6 +276,7 @@ void LinkButton::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text"), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "underline", PROPERTY_HINT_ENUM, "Always,On Hover,Never"), "set_underline_mode", "get_underline_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "uri"), "set_uri", "get_uri");
 
 	ADD_GROUP("BiDi", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -49,6 +49,7 @@ private:
 	String xl_text;
 	Ref<TextLine> text_buf;
 	UnderlineMode underline_mode = UNDERLINE_MODE_ALWAYS;
+	String uri;
 
 	String language;
 	TextDirection text_direction = TEXT_DIRECTION_AUTO;
@@ -76,6 +77,7 @@ private:
 	void _shape();
 
 protected:
+	virtual void pressed() override;
 	virtual Size2 get_minimum_size() const override;
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
@@ -84,6 +86,8 @@ protected:
 public:
 	void set_text(const String &p_text);
 	String get_text() const;
+	void set_uri(const String &p_uri);
+	String get_uri() const;
 
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;


### PR DESCRIPTION
This is useful when you want to add link buttons through code (simplifies things) and anyway without this `linkButton` is just a button with an underline. I tried connecting the `pressed` signal instead of launching the URL from the draw event but i couldn't figure it out, any guidance is appreciated. Also documented `linkButton.xml`

If this is going to get merged it would be nice to add:

- [ ] StyleBoxes for the rest of the states (currently only for focused exists).
- [ ] Text alignment.

I wouldn't bother otherwise since you can do all this with a button already, but since this exists, we could improve it.

EDIT: Changed keyword from `Link` to `Url` since its more proper in this case (link most of the times implies a website URL, while URL can be anything from websites, file paths to system paths or even UNC network paths). Also added `launch_url` to manually launch the `Url`. @akien-mga please review.