### PR TITLE
Made a few assignment operators return references instead of copies

### DIFF
--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -123,7 +123,7 @@ struct AudioFrame {
 		r = p_frame.r;
 	}
 
-	_ALWAYS_INLINE_ AudioFrame operator=(const AudioFrame &p_frame) {
+	_ALWAYS_INLINE_ AudioFrame &operator=(const AudioFrame &p_frame) {
 		l = p_frame.l;
 		r = p_frame.r;
 		return *this;

--- a/core/math/quat.h
+++ b/core/math/quat.h
@@ -131,7 +131,7 @@ public:
 			w(q.w) {
 	}
 
-	Quat operator=(const Quat &q) {
+	Quat &operator=(const Quat &q) {
 		x = q.x;
 		y = q.y;
 		z = q.z;

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -97,7 +97,7 @@ public:
 
 	_FORCE_INLINE_ CharString() {}
 	_FORCE_INLINE_ CharString(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ CharString operator=(const CharString &p_str) {
+	_FORCE_INLINE_ CharString &operator=(const CharString &p_str) {
 		_cowdata._ref(p_str._cowdata);
 		return *this;
 	}
@@ -352,7 +352,7 @@ public:
 
 	_FORCE_INLINE_ String() {}
 	_FORCE_INLINE_ String(const String &p_str) { _cowdata._ref(p_str._cowdata); }
-	String operator=(const String &p_str) {
+	String &operator=(const String &p_str) {
 		_cowdata._ref(p_str._cowdata);
 		return *this;
 	}

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -233,7 +233,7 @@ private:
 			render_db_value = n.render_db_value;
 		}
 
-		_FORCE_INLINE_ AudioNotch operator=(const EditorAudioMeterNotches::AudioNotch &n) {
+		_FORCE_INLINE_ AudioNotch &operator=(const EditorAudioMeterNotches::AudioNotch &n) {
 			relative_position = n.relative_position;
 			db_value = n.db_value;
 			render_db_value = n.render_db_value;

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -104,7 +104,7 @@ SoftBody::PinnedPoint::PinnedPoint(const PinnedPoint &obj_tocopy) {
 	offset = obj_tocopy.offset;
 }
 
-SoftBody::PinnedPoint SoftBody::PinnedPoint::operator=(const PinnedPoint &obj) {
+SoftBody::PinnedPoint &SoftBody::PinnedPoint::operator=(const PinnedPoint &obj) {
 	point_index = obj.point_index;
 	spatial_attachment_path = obj.spatial_attachment_path;
 	spatial_attachment = obj.spatial_attachment;

--- a/scene/3d/soft_body.h
+++ b/scene/3d/soft_body.h
@@ -75,7 +75,7 @@ public:
 
 		PinnedPoint();
 		PinnedPoint(const PinnedPoint &obj_tocopy);
-		PinnedPoint operator=(const PinnedPoint &obj);
+		PinnedPoint &operator=(const PinnedPoint &obj);
 	};
 
 private:

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -654,7 +654,7 @@ class Physics2DServerManager {
 				name(p_ci.name),
 				create_callback(p_ci.create_callback) {}
 
-		ClassInfo operator=(const ClassInfo &p_ci) {
+		ClassInfo &operator=(const ClassInfo &p_ci) {
 			name = p_ci.name;
 			create_callback = p_ci.create_callback;
 			return *this;

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -795,7 +795,7 @@ class PhysicsServerManager {
 				name(p_ci.name),
 				create_callback(p_ci.create_callback) {}
 
-		ClassInfo operator=(const ClassInfo &p_ci) {
+		ClassInfo &operator=(const ClassInfo &p_ci) {
 			name = p_ci.name;
 			create_callback = p_ci.create_callback;
 			return *this;


### PR DESCRIPTION
Made a few assignment operators return references instead of copies.
Fixes some LGTM warning found at https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=list&id=cpp%2Fassignment-does-not-return-this ([More Info](https://lgtm.com/rules/2164010517/)).
Close if unnecessary/wrong or if it causes bad change in logic.