### PR TITLE
Improve preview and screenshot display in the asset library

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -177,6 +177,8 @@ void EditorAssetLibraryItemDescription::set_image(int p_type, int p_index, const
 						tex->create_from_image(thumbnail);
 
 						preview_images[i].button->set_icon(tex);
+						// Make it clearer that clicking it will open an external link
+						preview_images[i].button->set_default_cursor_shape(CURSOR_POINTING_HAND);
 					} else {
 						preview_images[i].button->set_icon(p_image);
 					}
@@ -755,7 +757,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 
 					float scale_ratio = max_height / (image->get_height() * EDSCALE);
 					if (scale_ratio < 1) {
-						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_CUBIC);
+						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_LANCZOS);
 					}
 				} break;
 				case IMAGE_QUEUE_SCREENSHOT: {
@@ -763,7 +765,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 
 					float scale_ratio = max_height / (image->get_height() * EDSCALE);
 					if (scale_ratio < 1) {
-						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_CUBIC);
+						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_LANCZOS);
 					}
 				} break;
 			}
@@ -1270,9 +1272,8 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 					if (p.has("thumbnail")) {
 						_request_image(description->get_instance_id(), p["thumbnail"], IMAGE_QUEUE_THUMBNAIL, i);
 					}
-					if (is_video) {
-						//_request_image(description->get_instance_id(),p["link"],IMAGE_QUEUE_SCREENSHOT,i);
-					} else {
+
+					if (!is_video) {
 						_request_image(description->get_instance_id(), p["link"], IMAGE_QUEUE_SCREENSHOT, i);
 					}
 				}


### PR DESCRIPTION
Images are now resized with Lanczos interpolation for higher quality. Video thumbnails now display a "pointing hand" cursor when hovered as they will open in an external browser.

Unlike #25761, this only applies to previews and screenshots, not icons. (We could still re-attempt this for icons now that we have Lanczos filtering, which might look better compared to trilinear filtering.)

## Preview

### Before

![assetlib_cubic](https://user-images.githubusercontent.com/180032/61482287-87358480-a99a-11e9-8e75-c6baa773b101.png)

### After

![assetlib_lanczos](https://user-images.githubusercontent.com/180032/61482194-5e14f400-a99a-11e9-9a00-59e2a8eea4cf.png)
