### PR TITLE
Enable the script editor's "Auto Brace Complete" by default

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1426,17 +1426,17 @@ void CodeTextEditor::_on_settings_change() {
 
 	// AUTO BRACE COMPLETION
 	text_editor->set_auto_brace_completion(
-			EDITOR_DEF("text_editor/completion/auto_brace_complete", true));
+			EDITOR_GET("text_editor/completion/auto_brace_complete"));
 
 	code_complete_timer->set_wait_time(
-			EDITOR_DEF("text_editor/completion/code_complete_delay", .3f));
+			EDITOR_GET("text_editor/completion/code_complete_delay"));
 
 	// call hint settings
 	text_editor->set_callhint_settings(
-			EDITOR_DEF("text_editor/completion/put_callhint_tooltip_below_current_line", true),
-			EDITOR_DEF("text_editor/completion/callhint_tooltip_offset", Vector2()));
+			EDITOR_GET("text_editor/completion/put_callhint_tooltip_below_current_line"),
+			EDITOR_GET("text_editor/completion/callhint_tooltip_offset"));
 
-	idle->set_wait_time(EDITOR_DEF("text_editor/completion/idle_parse_delay", 2.0));
+	idle->set_wait_time(EDITOR_GET("text_editor/completion/idle_parse_delay"));
 }
 
 void CodeTextEditor::_text_changed_idle_timeout() {
@@ -1622,12 +1622,12 @@ CodeTextEditor::CodeTextEditor() {
 	idle = memnew(Timer);
 	add_child(idle);
 	idle->set_one_shot(true);
-	idle->set_wait_time(EDITOR_DEF("text_editor/completion/idle_parse_delay", 2.0));
+	idle->set_wait_time(EDITOR_GET("text_editor/completion/idle_parse_delay"));
 
 	code_complete_timer = memnew(Timer);
 	add_child(code_complete_timer);
 	code_complete_timer->set_one_shot(true);
-	code_complete_timer->set_wait_time(EDITOR_DEF("text_editor/completion/code_complete_delay", .3f));
+	code_complete_timer->set_wait_time(EDITOR_GET("text_editor/completion/code_complete_delay"));
 
 	error_line = 0;
 	error_column = 0;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -483,7 +483,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Completion
 	_initial_set("text_editor/completion/idle_parse_delay", 2.0);
 	hints["text_editor/completion/idle_parse_delay"] = PropertyInfo(Variant::REAL, "text_editor/completion/idle_parse_delay", PROPERTY_HINT_RANGE, "0.1, 10, 0.01");
-	_initial_set("text_editor/completion/auto_brace_complete", false);
+	_initial_set("text_editor/completion/auto_brace_complete", true);
+	_initial_set("text_editor/completion/code_complete_delay", 0.3);
+	hints["text_editor/completion/code_complete_delay"] = PropertyInfo(Variant::REAL, "text_editor/completion/code_complete_delay", PROPERTY_HINT_RANGE, "0.01, 5, 0.01");
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);
 	_initial_set("text_editor/completion/callhint_tooltip_offset", Vector2());
 	_initial_set("text_editor/completion/complete_file_paths", true);


### PR DESCRIPTION
This also adds a setting hint for the "Code Complete Delay" setting and cleans up some duplicated default setting values.

This feature is often enabled by default in other editors, so it makes sense to have it enabled in Godot as well. This change doesn't affect TextEdit nodes used in projects.

This closes #30662.