### PR TITLE
Don't allow to pass to _is_node_locked function NULL pointer

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -514,7 +514,7 @@ void SpatialEditorViewport::_select_region() {
 	for (int i = 0; i < instances.size(); i++) {
 
 		Spatial *sp = Object::cast_to<Spatial>(ObjectDB::get_instance(instances[i]));
-		if (!sp && _is_node_locked(sp))
+		if (!sp || _is_node_locked(sp))
 			continue;
 
 		Node *item = Object::cast_to<Node>(sp);


### PR DESCRIPTION
Before, if sp was NULL pointer, then it was passed to _is_node_locked function(Introduced in #30602)

I'm not sure about this line, but maybe it also require NULL checking 		

https://github.com/godotengine/godot/blob/c317a3ce16a35b21d85b250a0e810526bb89db38/editor/plugins/spatial_editor_plugin.cpp#L540