### PR TITLE
Remove added pluginscript resource format loaders and savers on cleanup

### DIFF
--- a/modules/gdnative/pluginscript/register_types.cpp
+++ b/modules/gdnative/pluginscript/register_types.cpp
@@ -114,6 +114,8 @@ void unregister_pluginscript_types() {
 	for (List<PluginScriptLanguage *>::Element *e = pluginscript_languages.front(); e; e = e->next()) {
 		PluginScriptLanguage *language = e->get();
 		ScriptServer::unregister_language(language);
+		ResourceLoader::remove_resource_format_loader(language->get_resource_loader());
+		ResourceSaver::remove_resource_format_saver(language->get_resource_saver());
 		memdelete(language);
 	}
 }


### PR DESCRIPTION
Properly release added resource loader and saver references. Otherwise PluginScript API
may cause "ObjectDB Instances still exist!" warnings and segmentation faults on exit.