### PR TITLE
Changed large const string values to const string ref in some assimp functions

### DIFF
--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -1718,7 +1718,7 @@ void EditorSceneImporterAssimp::_find_texture_path(const String &p_path, _Direct
 	}
 }
 
-String EditorSceneImporterAssimp::_assimp_get_string(const aiString p_string) const {
+String EditorSceneImporterAssimp::_assimp_get_string(const aiString &p_string) const {
 	//convert an assimp String to a Godot String
 	String name;
 	name.parse_utf8(p_string.C_Str() /*,p_string.length*/);
@@ -1733,7 +1733,7 @@ String EditorSceneImporterAssimp::_assimp_get_string(const aiString p_string) co
 	return name;
 }
 
-String EditorSceneImporterAssimp::_assimp_anim_string_to_string(const aiString p_string) const {
+String EditorSceneImporterAssimp::_assimp_anim_string_to_string(const aiString &p_string) const {
 
 	String name;
 	name.parse_utf8(p_string.C_Str() /*,p_string.length*/);
@@ -1745,7 +1745,7 @@ String EditorSceneImporterAssimp::_assimp_anim_string_to_string(const aiString p
 	return name;
 }
 
-String EditorSceneImporterAssimp::_assimp_raw_string_to_string(const aiString p_string) const {
+String EditorSceneImporterAssimp::_assimp_raw_string_to_string(const aiString &p_string) const {
 	String name;
 	name.parse_utf8(p_string.C_Str() /*,p_string.length*/);
 	return name;

--- a/modules/assimp/editor_scene_importer_assimp.h
+++ b/modules/assimp/editor_scene_importer_assimp.h
@@ -178,7 +178,7 @@ private:
 	};
 
 	const Transform _assimp_matrix_transform(const aiMatrix4x4 p_matrix);
-	String _assimp_get_string(const aiString p_string) const;
+	String _assimp_get_string(const aiString &p_string) const;
 	Transform _get_global_assimp_node_transform(const aiNode *p_current_node);
 
 	void _calc_tangent_from_mesh(const aiMesh *ai_mesh, int i, int tri_index, int index, PoolColorArray::Write &w);
@@ -200,8 +200,8 @@ private:
 
 	Spatial *_generate_scene(const String &p_path, const aiScene *scene, const uint32_t p_flags, int p_bake_fps, const int32_t p_max_bone_weights);
 
-	String _assimp_anim_string_to_string(const aiString p_string) const;
-	String _assimp_raw_string_to_string(const aiString p_string) const;
+	String _assimp_anim_string_to_string(const aiString &p_string) const;
+	String _assimp_raw_string_to_string(const aiString &p_string) const;
 	float _get_fbx_fps(int32_t time_mode, const aiScene *p_scene);
 	template <class T>
 	T _interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, float p_time, AssetImportAnimation::Interpolation p_interp);


### PR DESCRIPTION
Changed large const string values(i.e, const aiString is 1032 bytes) to const string ref in some assimp functions:
_assimp_anim_string_to_string
_assimp_raw_string_to_string
_assimp_get_string

Haven't tested it for bugs. Please test it before merge.
Fixes warning reported at https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=list&id=cpp%2Flarge-parameter ([more info](https://lgtm.com/rules/2163210742/)).
