### PR TITLE
Make comparison operator== const in EditorAutoloadSettings

### DIFF
--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -56,7 +56,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 		int order;
 		Node *node;
 
-		bool operator==(const AutoLoadInfo &p_info) {
+		bool operator==(const AutoLoadInfo &p_info) const {
 			return order == p_info.order;
 		}
 


### PR DESCRIPTION
`operator==` of EditorAutoloadSettings is not const for whatever reason...

afaik, this leads to automatic conversion to other types to find `operato==` that fits the requirement...