### PR TITLE
Removed an unused import in platform/android/SCsub

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -2,7 +2,6 @@
 
 Import('env')
 
-from compat import open_utf8
 from distutils.version import LooseVersion
 from detect import get_ndk_version
 


### PR DESCRIPTION
Tiny change as mentioned in title but still didn't wanna put a small python change with other unrelated pull requests. Last usage of open_utf8 in platform/android/SCsub was removed in https://github.com/godotengine/godot/commit/dd03dcbd5a1d4a23d4fb3aa41da0c91fe2c5eda5.