### PR TITLE
AStar and AStar2D examples fixed to not use 'as' keyword and also removed error causing code

### DIFF
--- a/doc/classes/AStar.xml
+++ b/doc/classes/AStar.xml
@@ -44,8 +44,8 @@
 			<description>
 				Adds a new point at the given position with the given identifier. The algorithm prefers points with lower [code]weight_scale[/code] to form a path. The [code]id[/code] must be 0 or larger, and the [code]weight_scale[/code] must be 1 or larger.
 				[codeblock]
-				var as = AStar.new()
-				as.add_point(1, Vector3(1, 0, 0), 4) # Adds the point (1, 0, 0) with weight_scale 4 and id 1
+				var astar = AStar.new()
+				astar.add_point(1, Vector3(1, 0, 0), 4) # Adds the point (1, 0, 0) with weight_scale 4 and id 1
 				[/codeblock]
 				If there already exists a point for the given [code]id[/code], its position and weight scale are updated to the given values.
 			</description>
@@ -80,10 +80,10 @@
 			<description>
 				Creates a segment between the given points. If [code]bidirectional[/code] is [code]false[/code], only movement from [code]id[/code] to [code]to_id[/code] is allowed, not the reverse direction.
 				[codeblock]
-				var as = AStar.new()
-				as.add_point(1, Vector3(1, 1, 0))
-				as.add_point(2, Vector3(0, 5, 0))
-				as.connect_points(1, 2, false)
+				var astar = AStar.new()
+				astar.add_point(1, Vector3(1, 1, 0))
+				astar.add_point(2, Vector3(0, 5, 0))
+				astar.connect_points(1, 2, false)
 				[/codeblock]
 			</description>
 		</method>
@@ -122,11 +122,11 @@
 			<description>
 				Returns the closest position to [code]to_position[/code] that resides inside a segment between two connected points.
 				[codeblock]
-				var as = AStar.new()
-				as.add_point(1, Vector3(0, 0, 0))
-				as.add_point(2, Vector3(0, 5, 0))
-				as.connect_points(1, 2)
-				var res = as.get_closest_position_in_segment(Vector3(3, 3, 0)) # Returns (0, 3, 0)
+				var astar = AStar.new()
+				astar.add_point(1, Vector3(0, 0, 0))
+				astar.add_point(2, Vector3(0, 5, 0))
+				astar.connect_points(1, 2)
+				var res = astar.get_closest_position_in_segment(Vector3(3, 3, 0)) # Returns (0, 3, 0)
 				[/codeblock]
 				The result is in the segment that goes from [code]y = 0[/code] to [code]y = 5[/code]. It's the closest position in the segment to the given point.
 			</description>
@@ -141,19 +141,18 @@
 			<description>
 				Returns an array with the IDs of the points that form the path found by AStar between the given points. The array is ordered from the starting point to the ending point of the path.
 				[codeblock]
-				var as = AStar.new()
-				as.add_point(1, Vector3(0, 0, 0))
-				as.add_point(2, Vector3(0, 1, 0), 1) # Default weight is 1
-				as.add_point(3, Vector3(1, 1, 0))
-				as.add_point(4, Vector3(2, 0, 0))
+				var astar = AStar.new()
+				astar.add_point(1, Vector3(0, 0, 0))
+				astar.add_point(2, Vector3(0, 1, 0), 1) # Default weight is 1
+				astar.add_point(3, Vector3(1, 1, 0))
+				astar.add_point(4, Vector3(2, 0, 0))
 
-				as.connect_points(1, 2, false)
-				as.connect_points(2, 3, false)
-				as.connect_points(4, 3, false)
-				as.connect_points(1, 4, false)
-				as.connect_points(5, 4, false)
+				astar.connect_points(1, 2, false)
+				astar.connect_points(2, 3, false)
+				astar.connect_points(4, 3, false)
+				astar.connect_points(1, 4, false)
 
-				var res = as.get_id_path(1, 3) # Returns [1, 2, 3]
+				var res = astar.get_id_path(1, 3) # Returns [1, 2, 3]
 				[/codeblock]
 				If you change the 2nd point's weight to 3, then the result will be [code][1, 4, 3][/code] instead, because now even though the distance is longer, it's "easier" to get through point 4 than through point 2.
 			</description>
@@ -166,16 +165,16 @@
 			<description>
 				Returns an array with the IDs of the points that form the connection with the given point.
 				[codeblock]
-				var as = AStar.new()
-				as.add_point(1, Vector3(0, 0, 0))
-				as.add_point(2, Vector3(0, 1, 0))
-				as.add_point(3, Vector3(1, 1, 0))
-				as.add_point(4, Vector3(2, 0, 0))
+				var astar = AStar.new()
+				astar.add_point(1, Vector3(0, 0, 0))
+				astar.add_point(2, Vector3(0, 1, 0))
+				astar.add_point(3, Vector3(1, 1, 0))
+				astar.add_point(4, Vector3(2, 0, 0))
 
-				as.connect_points(1, 2, true)
-				as.connect_points(1, 3, true)
+				astar.connect_points(1, 2, true)
+				astar.connect_points(1, 3, true)
 
-				var neighbors = as.get_point_connections(1) # Returns [2, 3]
+				var neighbors = astar.get_point_connections(1) # Returns [2, 3]
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -21,8 +21,8 @@
 			<description>
 				Adds a new point at the given position with the given identifier. The algorithm prefers points with lower [code]weight_scale[/code] to form a path. The [code]id[/code] must be 0 or larger, and the [code]weight_scale[/code] must be 1 or larger.
 				[codeblock]
-				var as = AStar2D.new()
-				as.add_point(1, Vector2(1, 0), 4) # Adds the point (1, 0) with weight_scale 4 and id 1
+				var astar = AStar2D.new()
+				astar.add_point(1, Vector2(1, 0), 4) # Adds the point (1, 0) with weight_scale 4 and id 1
 				[/codeblock]
 				If there already exists a point for the given [code]id[/code], its position and weight scale are updated to the given values.
 			</description>
@@ -57,10 +57,10 @@
 			<description>
 				Creates a segment between the given points. If [code]bidirectional[/code] is [code]false[/code], only movement from [code]id[/code] to [code]to_id[/code] is allowed, not the reverse direction.
 				[codeblock]
-				var as = AStar2D.new()
-				as.add_point(1, Vector2(1, 1))
-				as.add_point(2, Vector2(0, 5))
-				as.connect_points(1, 2, false)
+				var astar = AStar2D.new()
+				astar.add_point(1, Vector2(1, 1))
+				astar.add_point(2, Vector2(0, 5))
+				astar.connect_points(1, 2, false)
 				[/codeblock]
 			</description>
 		</method>
@@ -99,11 +99,11 @@
 			<description>
 				Returns the closest position to [code]to_position[/code] that resides inside a segment between two connected points.
 				[codeblock]
-				var as = AStar2D.new()
-				as.add_point(1, Vector2(0, 0))
-				as.add_point(2, Vector2(0, 5))
-				as.connect_points(1, 2)
-				var res = as.get_closest_position_in_segment(Vector2(3, 3)) # Returns (0, 3)
+				var astar = AStar2D.new()
+				astar.add_point(1, Vector2(0, 0))
+				astar.add_point(2, Vector2(0, 5))
+				astar.connect_points(1, 2)
+				var res = astar.get_closest_position_in_segment(Vector2(3, 3)) # Returns (0, 3)
 				[/codeblock]
 				The result is in the segment that goes from [code]y = 0[/code] to [code]y = 5[/code]. It's the closest position in the segment to the given point.
 			</description>
@@ -118,19 +118,18 @@
 			<description>
 				Returns an array with the IDs of the points that form the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
 				[codeblock]
-				var as = AStar2D.new()
-				as.add_point(1, Vector2(0, 0))
-				as.add_point(2, Vector2(0, 1), 1) # Default weight is 1
-				as.add_point(3, Vector2(1, 1))
-				as.add_point(4, Vector2(2, 0))
+				var astar = AStar2D.new()
+				astar.add_point(1, Vector2(0, 0))
+				astar.add_point(2, Vector2(0, 1), 1) # Default weight is 1
+				astar.add_point(3, Vector2(1, 1))
+				astar.add_point(4, Vector2(2, 0))
 
-				as.connect_points(1, 2, false)
-				as.connect_points(2, 3, false)
-				as.connect_points(4, 3, false)
-				as.connect_points(1, 4, false)
-				as.connect_points(5, 4, false)
+				astar.connect_points(1, 2, false)
+				astar.connect_points(2, 3, false)
+				astar.connect_points(4, 3, false)
+				astar.connect_points(1, 4, false)
 
-				var res = as.get_id_path(1, 3) # Returns [1, 2, 3]
+				var res = astar.get_id_path(1, 3) # Returns [1, 2, 3]
 				[/codeblock]
 				If you change the 2nd point's weight to 3, then the result will be [code][1, 4, 3][/code] instead, because now even though the distance is longer, it's "easier" to get through point 4 than through point 2.
 			</description>
@@ -143,16 +142,16 @@
 			<description>
 				Returns an array with the IDs of the points that form the connection with the given point.
 				[codeblock]
-				var as = AStar2D.new()
-				as.add_point(1, Vector2(0, 0))
-				as.add_point(2, Vector2(0, 1))
-				as.add_point(3, Vector2(1, 1))
-				as.add_point(4, Vector2(2, 0))
+				var astar = AStar2D.new()
+				astar.add_point(1, Vector2(0, 0))
+				astar.add_point(2, Vector2(0, 1))
+				astar.add_point(3, Vector2(1, 1))
+				astar.add_point(4, Vector2(2, 0))
 
-				as.connect_points(1, 2, true)
-				as.connect_points(1, 3, true)
+				astar.connect_points(1, 2, true)
+				astar.connect_points(1, 3, true)
 
-				var neighbors = as.get_point_connections(1) # Returns [2, 3]
+				var neighbors = astar.get_point_connections(1) # Returns [2, 3]
 				[/codeblock]
 			</description>
 		</method>


### PR DESCRIPTION
AStar and AStar2D examples in Documentation fixed to not use 'as' keyword and also removed error causing code.
Fixes #30699.