### PR TITLE
Fix metadata storing empty dictionary in scenes

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -639,7 +639,11 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 #ifdef TOOLS_ENABLED
 	p_list->push_back(PropertyInfo(Variant::NIL, "Metadata", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
 #endif
-	p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT));
+	int metadata_property_usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_NETWORK;
+	if (!metadata.empty()) {
+		metadata_property_usage |= PROPERTY_USAGE_STORAGE;
+	}
+	p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", metadata_property_usage));
 
 	if (script_instance && !p_reversed) {
 		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));


### PR DESCRIPTION
Fixes an issue described in https://github.com/godotengine/godot/pull/22642#issuecomment-513301193.

Completely not sure whether it's a good way to manipulate property usage flags this way. There was some flags that allowed this kind of usage but those are deprecated now (which might explain why it worked a year ago @YeldhamDev):
https://github.com/godotengine/godot/blob/2ca3e47d66fe3f3d849e2084d516949c84011f4b/core/object.h#L107-L109

This would prevent unnecessary noise in version control systems for projects already in work.