### PR TITLE
Fix some code found by Coverity Scan and PVS Studio

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -480,6 +480,7 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
 
 				PropertySetGet *psg = t->property_setget.getptr(F->get());
+				ERR_FAIL_COND_V(!psg, 0);
 
 				hash = hash_djb2_one_64(F->get().hash(), hash);
 				hash = hash_djb2_one_64(psg->setter.hash(), hash);

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -110,10 +110,11 @@ Error PacketPeer::put_var(const Variant &p_packet, bool p_full_objects) {
 
 Variant PacketPeer::_bnd_get_var(bool p_allow_objects) {
 	Variant var;
-	get_var(var, p_allow_objects);
+	Error err = get_var(var, p_allow_objects);
 
+	ERR_FAIL_COND_V(err != OK, Variant());
 	return var;
-};
+}
 
 Error PacketPeer::_put_packet(const PoolVector<uint8_t> &p_buffer) {
 	return put_packet_buffer(p_buffer);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -718,8 +718,8 @@ Error ResourceInteractiveLoaderBinary::poll() {
 	Resource *r = Object::cast_to<Resource>(obj);
 	if (!r) {
 		error = ERR_FILE_CORRUPT;
-		memdelete(obj); //bye
 		ERR_EXPLAIN(local_path + ":Resource type in resource field not a resource, type is: " + obj->get_class());
+		memdelete(obj); //bye
 		ERR_FAIL_V(ERR_FILE_CORRUPT);
 	}
 

--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -334,9 +334,6 @@ def make_version(template, nargs, argmax, const, ret):
         elif (cmd == "noarg"):
             for i in range(nargs + 1, argmax + 1):
                 outtext += data.replace("@", str(i))
-        elif (cmd == "noarg"):
-            for i in range(nargs + 1, argmax + 1):
-                outtext += data.replace("@", str(i))
 
         from_pos = end + 1
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -435,6 +435,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 			Object::cast_to<Spatial>(sb)->set_transform(Object::cast_to<Spatial>(p_node)->get_transform());
 			p_node->replace_by(sb);
 			memdelete(p_node);
+			p_node = NULL;
 			CollisionShape *colshape = memnew(CollisionShape);
 			if (empty_draw_type == "CUBE") {
 				BoxShape *boxShape = memnew(BoxShape);

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -201,6 +201,8 @@ void MeshLibraryEditor::_import_scene_cbk(const String &p_str) {
 	ERR_FAIL_COND(ps.is_null());
 	Node *scene = ps->instance();
 
+	ERR_FAIL_COND(!scene);
+
 	_import_scene(scene, mesh_library, option == MENU_OPTION_UPDATE_FROM_SCENE);
 
 	memdelete(scene);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -301,6 +301,8 @@ bool SceneTreeDock::_track_inherit(const String &p_target_scene_path, Node *p_de
 			Ref<PackedScene> data = ResourceLoader::load(path);
 			if (data.is_valid()) {
 				p = data->instance(PackedScene::GEN_EDIT_STATE_INSTANCE);
+				if (!p)
+					continue;
 				instances.push_back(p);
 			} else
 				break;

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -173,7 +173,7 @@ class ScriptEditorDebugger : public Control {
 	void _set_reason_text(const String &p_reason, MessageType p_type);
 	void _scene_tree_property_select_object(ObjectID p_object);
 	void _scene_tree_property_value_edited(const String &p_prop, const Variant &p_value);
-	int _update_scene_tree(TreeItem *parent, const Array &items, int current_index);
+	int _update_scene_tree(TreeItem *parent, const Array &nodes, int current_index);
 
 	void _video_mem_request();
 

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -581,6 +581,10 @@ void SpaceBullet::create_empty_world(bool p_create_soft_world) {
 	} else {
 		world_mem = malloc(sizeof(btDiscreteDynamicsWorld));
 	}
+	if (!world_mem) {
+		ERR_EXPLAIN("Out of memory");
+		ERR_FAIL();
+	}
 
 	if (p_create_soft_world) {
 		collisionConfiguration = bulletnew(GodotSoftCollisionConfiguration(static_cast<btDiscreteDynamicsWorld *>(world_mem)));

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -519,7 +519,9 @@ Error AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t
 
 			int total_out_before = strm.total_out;
 
-			deflate(&strm, Z_FULL_FLUSH);
+			int err = deflate(&strm, Z_FULL_FLUSH);
+			ERR_FAIL_COND_V(err >= 0, ERR_BUG); // Negative means bug
+
 			bh.compressed_size = strm.total_out - total_out_before;
 
 			//package->store_buffer(strm_out.ptr(), strm.total_out - total_out_before);

--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -513,6 +513,8 @@ void JoypadLinux::process_joypads() {
 								break;
 
 							default:
+								if (ev.code >= MAX_ABS)
+									return;
 								if (joy->abs_map[ev.code] != -1 && joy->abs_info[ev.code]) {
 									InputDefault::JoyAxis value = axis_correct(joy->abs_info[ev.code], ev.value);
 									joy->curr_axis[joy->abs_map[ev.code]] = value;

--- a/platform/x11/power_x11.cpp
+++ b/platform/x11/power_x11.cpp
@@ -268,9 +268,7 @@ bool PowerX11::GetPowerInfo_Linux_proc_acpi() {
 			check_proc_acpi_battery(node.utf8().get_data(), &have_battery, &charging /*, seconds, percent*/);
 			node = dirp->get_next();
 		}
-		memdelete(dirp);
 	}
-
 	dirp->change_dir(proc_acpi_ac_adapter_path);
 	err = dirp->list_dir_begin();
 	if (err != OK) {
@@ -281,7 +279,6 @@ bool PowerX11::GetPowerInfo_Linux_proc_acpi() {
 			check_proc_acpi_ac_adapter(node.utf8().get_data(), &have_ac);
 			node = dirp->get_next();
 		}
-		memdelete(dirp);
 	}
 
 	if (!have_battery) {
@@ -294,6 +291,7 @@ bool PowerX11::GetPowerInfo_Linux_proc_acpi() {
 		this->power_state = OS::POWERSTATE_ON_BATTERY;
 	}
 
+	memdelete(dirp);
 	return true; /* definitive answer. */
 }
 

--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -92,6 +92,8 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 	if (!ps.is_valid())
 		return NULL;
 	Node *scene = ps->instance();
+	if (!scene)
+		return NULL;
 	scene->set_name(get_name());
 	int pos = get_position_in_parent();
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1507,8 +1507,11 @@ void SceneTree::_live_edit_instance_node_func(const NodePath &p_parent, const St
 		Node *n2 = n->get_node(p_parent);
 
 		Node *no = ps->instance();
-		no->set_name(p_name);
+		if (!no) {
+			continue;
+		}
 
+		no->set_name(p_name);
 		n2->add_child(no);
 	}
 }

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1624,13 +1624,13 @@ public:
 
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
-	void set_comparsion_type(ComparsionType p_func);
+	void set_comparsion_type(ComparsionType p_type);
 	ComparsionType get_comparsion_type() const;
 
 	void set_function(Function p_func);
 	Function get_function() const;
 
-	void set_condition(Condition p_mode);
+	void set_condition(Condition p_cond);
 	Condition get_condition() const;
 
 	virtual Vector<StringName> get_editable_properties() const;

--- a/servers/physics/collision_solver_sat.cpp
+++ b/servers/physics/collision_solver_sat.cpp
@@ -274,8 +274,8 @@ static void _generate_contacts_from_supports(const Vector3 *p_points_A, int p_po
 		points_B = p_points_B;
 	}
 
-	int version_A = (pointcount_A > 3 ? 3 : pointcount_A) - 1;
-	int version_B = (pointcount_B > 3 ? 3 : pointcount_B) - 1;
+	int version_A = (pointcount_A > 2 ? 2 : pointcount_A) - 1;
+	int version_B = (pointcount_B > 2 ? 2 : pointcount_B) - 1;
 
 	GenerateContactsFunc contacts_func = generate_contacts_func_table[version_A][version_B];
 	ERR_FAIL_COND(!contacts_func);

--- a/servers/physics/collision_solver_sw.cpp
+++ b/servers/physics/collision_solver_sw.cpp
@@ -233,8 +233,6 @@ bool CollisionSolverSW::solve_static(const ShapeSW *p_shape_A, const Transform &
 
 		return collision_solver(p_shape_A, p_transform_A, p_shape_B, p_transform_B, p_result_callback, p_userdata, false, r_sep_axis, p_margin_A, p_margin_B);
 	}
-
-	return false;
 }
 
 void CollisionSolverSW::concave_distance_callback(void *p_userdata, ShapeSW *p_convex) {
@@ -371,6 +369,4 @@ bool CollisionSolverSW::solve_distance(const ShapeSW *p_shape_A, const Transform
 
 		return gjk_epa_calculate_distance(p_shape_A, p_transform_A, p_shape_B, p_transform_B, r_point_A, r_point_B); //should pass sepaxis..
 	}
-
-	return false;
 }

--- a/servers/physics/joints/hinge_joint_sw.cpp
+++ b/servers/physics/joints/hinge_joint_sw.cpp
@@ -198,7 +198,6 @@ bool HingeJointSW::setup(real_t p_step) {
 
 	plane_space(m_rbAFrame.basis.get_axis(2), jointAxis0local, jointAxis1local);
 
-	A->get_transform().basis.xform(m_rbAFrame.basis.get_axis(2));
 	Vector3 jointAxis0 = A->get_transform().basis.xform(jointAxis0local);
 	Vector3 jointAxis1 = A->get_transform().basis.xform(jointAxis1local);
 	Vector3 hingeAxisWorld = A->get_transform().basis.xform(m_rbAFrame.basis.get_axis(2));

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -185,28 +185,28 @@ real_t Body2DSW::get_param(Physics2DServer::BodyParameter p_param) const {
 		case Physics2DServer::BODY_PARAM_BOUNCE: {
 
 			return bounce;
-		} break;
+		}
 		case Physics2DServer::BODY_PARAM_FRICTION: {
 
 			return friction;
-		} break;
+		}
 		case Physics2DServer::BODY_PARAM_MASS: {
 			return mass;
-		} break;
+		}
 		case Physics2DServer::BODY_PARAM_INERTIA: {
 			return _inv_inertia == 0 ? 0 : 1.0 / _inv_inertia;
-		} break;
+		}
 		case Physics2DServer::BODY_PARAM_GRAVITY_SCALE: {
 			return gravity_scale;
-		} break;
+		}
 		case Physics2DServer::BODY_PARAM_LINEAR_DAMP: {
 
 			return linear_damp;
-		} break;
+		}
 		case Physics2DServer::BODY_PARAM_ANGULAR_DAMP: {
 
 			return angular_damp;
-		} break;
+		}
 		default: {
 		}
 	}
@@ -343,19 +343,19 @@ Variant Body2DSW::get_state(Physics2DServer::BodyState p_state) const {
 	switch (p_state) {
 		case Physics2DServer::BODY_STATE_TRANSFORM: {
 			return get_transform();
-		} break;
+		}
 		case Physics2DServer::BODY_STATE_LINEAR_VELOCITY: {
 			return linear_velocity;
-		} break;
+		}
 		case Physics2DServer::BODY_STATE_ANGULAR_VELOCITY: {
 			return angular_velocity;
-		} break;
+		}
 		case Physics2DServer::BODY_STATE_SLEEPING: {
 			return !is_active();
-		} break;
+		}
 		case Physics2DServer::BODY_STATE_CAN_SLEEP: {
 			return can_sleep;
-		} break;
+		}
 	}
 
 	return Variant();

--- a/servers/physics_2d/collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/collision_solver_2d_sat.cpp
@@ -172,8 +172,8 @@ static void _generate_contacts_from_supports(const Vector2 *p_points_A, int p_po
 		points_B = p_points_B;
 	}
 
-	int version_A = (pointcount_A > 3 ? 3 : pointcount_A) - 1;
-	int version_B = (pointcount_B > 3 ? 3 : pointcount_B) - 1;
+	int version_A = (pointcount_A > 2 ? 2 : pointcount_A) - 1;
+	int version_B = (pointcount_B > 2 ? 2 : pointcount_B) - 1;
 
 	GenerateContactsFunc contacts_func = generate_contacts_func_table[version_A][version_B];
 	ERR_FAIL_COND(!contacts_func);

--- a/servers/physics_2d/collision_solver_2d_sw.cpp
+++ b/servers/physics_2d/collision_solver_2d_sw.cpp
@@ -249,6 +249,4 @@ bool CollisionSolver2DSW::solve(const Shape2DSW *p_shape_A, const Transform2D &p
 
 		return collision_solver(p_shape_A, p_transform_A, p_motion_A, p_shape_B, p_transform_B, p_motion_B, p_result_callback, p_userdata, false, sep_axis, margin_A, margin_B);
 	}
-
-	return false;
 }

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -967,7 +967,7 @@ bool ShaderLanguage::_find_identifier(const BlockNode *p_block, const Map<String
 bool ShaderLanguage::_validate_operator(OperatorNode *p_op, DataType *r_ret_type) {
 
 	bool valid = false;
-	DataType ret_type;
+	DataType ret_type = TYPE_VOID;
 
 	switch (p_op->op) {
 		case OP_EQUAL:
@@ -3059,7 +3059,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 				String ident = identifier;
 
 				bool ok = true;
-				DataType member_type;
+				DataType member_type = TYPE_VOID;
 				switch (dt) {
 					case TYPE_BVEC2:
 					case TYPE_IVEC2:

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1118,7 +1118,7 @@ void VisualServer::mesh_add_surface_from_arrays(RID p_mesh, PrimitiveType p_prim
 				}
 				offsets[i] = elem_size;
 				continue;
-			} break;
+			}
 			default: {
 				ERR_FAIL();
 			}
@@ -1286,7 +1286,7 @@ Array VisualServer::_get_array_from_surface(uint32_t p_format, PoolVector<uint8_
 				}
 				offsets[i] = elem_size;
 				continue;
-			} break;
+			}
 			default: {
 				ERR_FAIL_V(Array());
 			}


### PR DESCRIPTION
Fixes #27638, in others parts(2 - 4) just remain 1/2 open issues so I create another one, which will contain them and also new possible issues found by Coverity Scan

Changes in power_x11.cpp was done because in SDL code(https://github.com/spurious/SDL-mirror/blob/17af4584cb28cdb3c2feba17e7d989a806007d9f/src/power/SDL_power.c), directory was just closed
```
    closedir(dirp);
}
dirp = opendir(proc_acpi_ac_adapter_path);
```
but in Godot, memory was deleted, which can cause crash 
```
    memdelete(dirp);
}
dirp->change_dir(proc_acpi_ac_adapter_path);
```