### PR TITLE
Project manager improvements

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -39,6 +39,7 @@
 #include "scene/gui/tree.h"
 
 class ProjectDialog;
+class ProjectList;
 class ProjectListFilter;
 
 class ProjectManager : public Control {
@@ -68,16 +69,13 @@ class ProjectManager : public Control {
 	AcceptDialog *dialog_error;
 	ProjectDialog *npdialog;
 
-	ScrollContainer *scroll;
-	VBoxContainer *scroll_children;
 	HBoxContainer *projects_hb;
 	TabContainer *tabs;
+	ProjectList *_project_list;
 
 	OptionButton *language_btn;
 	Control *gui_base;
 
-	Map<String, String> selected_list; // name -> main_scene
-	String last_clicked;
 	bool importing;
 
 	void _open_asset_library();
@@ -86,7 +84,6 @@ class ProjectManager : public Control {
 	void _run_project_confirm();
 	void _open_selected_projects();
 	void _open_selected_projects_ask();
-	void _show_project(const String &p_path);
 	void _import_project();
 	void _new_project();
 	void _rename_project();
@@ -111,12 +108,12 @@ class ProjectManager : public Control {
 	void _install_project(const String &p_zip_path, const String &p_title);
 
 	void _dim_window();
-	void _panel_draw(Node *p_hb);
-	void _panel_input(const Ref<InputEvent> &p_ev, Node *p_hb);
 	void _unhandled_input(const Ref<InputEvent> &p_ev);
-	void _favorite_pressed(Node *p_hb);
 	void _files_dropped(PoolStringArray p_files, int p_screen);
 	void _scan_multiple_folders(PoolStringArray p_files);
+
+	void _on_order_option_changed();
+	void _on_filter_option_changed();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
The project manager was reloading all files and formatting their icons every time it started or any change was made to the list. So when you have 100 projects, it takes a long time and causes lag, especially when the OS didn't cache those files yet.

This PR loads files once on startup, and further operations are done on information which is already loaded instead. This makes sorting, fav'ing, filtering much faster.

Also, icons are now loaded iteratively in a coroutine, which allows a faster start time.

In order to accomplish this, I refactored the project list to have its own class. Structuring it more explicitely made my work easier and I believe it's easier to understand what the code aims to do now, which may help for future changes.

I also changed this icon:
![image](https://user-images.githubusercontent.com/1311555/61596100-19d25f80-abf7-11e9-8c4f-fd158bad2fb8.png)

Closes https://github.com/godotengine/godot/issues/26233

Note 1:
the way we save registered projects and their favorite status complicates things a bit.
They are mixed with other editor settings and it looks like this:
```
...
projects/D:::PROJETS::INFO::GODOT::Plugins::HTerrain::hterrain = "D:/PROJETS/INFO/GODOT/Plugins/HTerrain/hterrain"
favorite_projects/D:::PROJETS::INFO::GODOT::Plugins::HTerrain::hterrain = "D:/PROJETS/INFO/GODOT/Plugins/HTerrain/hterrain"
projects/D:::PROJETS::INFO::GODOT::TESTS::Godot31::DrawCalls = "D:/PROJETS/INFO/GODOT/TESTS/Godot31/DrawCalls"
...
```
I would like to change it to be a simple dictionary like this:
```
projects: {
    "D:/PROJETS/INFO/GODOT/Plugins/HTerrain/hterrain": { "favorite": true },
    "D:/PROJETS/INFO/GODOT/TESTS/Godot31/DrawCalls": { }
}
```
And eventually move those to their own file. However it would break compatibility, unless some migration code is added. It's not hard to do, but I preferred to not do it in this PR as it's just improvements, not features.

Note 2:
The .cpp diff is hard to read, so I'd suggest to just focus on lines from 925 to 2576, which is where I did the changes. Some of the code remained the same, just moved elsewhere.