### PR TITLE
Exported script properties and sub-resource scripts will now be properly treated as Scripts

### DIFF
--- a/core/string_name.cpp
+++ b/core/string_name.cpp
@@ -144,6 +144,11 @@ bool StringName::operator!=(const String &p_name) const {
 	return !(operator==(p_name));
 }
 
+bool StringName::operator!=(const char *p_name) const {
+
+	return !(operator==(p_name));
+}
+
 bool StringName::operator!=(const StringName &p_name) const {
 
 	// the real magic of all this mess happens here.

--- a/core/string_name.h
+++ b/core/string_name.h
@@ -98,6 +98,7 @@ public:
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;
 	bool operator!=(const String &p_name) const;
+	bool operator!=(const char *p_name) const;
 	_FORCE_INLINE_ bool operator<(const StringName &p_name) const {
 
 		return _data < p_name._data;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2317,6 +2317,9 @@ EditorInspector::EditorInspector() {
 	set_enable_h_scroll(false);
 	set_enable_v_scroll(true);
 
+	script_create_dialog = memnew(ScriptCreateDialog);
+	add_child(script_create_dialog);
+
 	show_categories = false;
 	hide_script = true;
 	use_doc_hints = false;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -31,6 +31,7 @@
 #ifndef EDITOR_INSPECTOR_H
 #define EDITOR_INSPECTOR_H
 
+#include "editor/script_create_dialog.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/scroll_container.h"
@@ -268,6 +269,8 @@ class EditorInspector : public ScrollContainer {
 	void _clear();
 	Object *object;
 
+	ScriptCreateDialog *script_create_dialog;
+
 	//
 
 	LineEdit *search_box;
@@ -350,6 +353,8 @@ public:
 
 	void edit(Object *p_object);
 	Object *get_edited_object();
+
+	ScriptCreateDialog *get_script_create_dialog() { return script_create_dialog; }
 
 	void set_keying(bool p_active);
 	void set_read_only(bool p_read_only);

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -574,6 +574,8 @@ class EditorPropertyResource : public EditorProperty {
 	void _resource_preview(const String &p_path, const Ref<Texture> &p_preview, const Ref<Texture> &p_small_preview, ObjectID p_obj);
 	void _resource_selected();
 	void _viewport_selected(const NodePath &p_path);
+	void _script_created(Ref<Script> p_script);
+	void _script_creation_closed();
 
 	void _update_menu_items();
 


### PR DESCRIPTION
…and will include the property name in the path if appropriate

This is my second attempt at solving this, and what I feel is a much better attempt than #30272 was.

This could still be a bit better (see my review comments below; plus the code could maybe be a tiny bit tidier, but I'm not sure how I'd go about it), but it is in a state that I'm happy with, and in a state that solves the issue at hand.