### PR TITLE
Fix GLES2 shadow transparency bug

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2287,19 +2287,6 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 				prev_unshaded = unshaded;
 			}
 
-			bool depth_prepass = false;
-
-			if (!p_alpha_pass && material->shader->spatial.depth_draw_mode == RasterizerStorageGLES2::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS) {
-				depth_prepass = true;
-			}
-
-			if (depth_prepass != prev_depth_prepass) {
-
-				state.scene_shader.set_conditional(SceneShaderGLES2::USE_DEPTH_PREPASS, depth_prepass);
-				prev_depth_prepass = depth_prepass;
-				rebind = true;
-			}
-
 			bool base_pass = !accum_pass && !unshaded; //conditions for a base pass
 
 			if (base_pass != prev_base_pass) {
@@ -2432,6 +2419,19 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 				rebind = true;
 				rebind_lightmap = true;
 			}
+		}
+
+		bool depth_prepass = false;
+
+		if (!p_alpha_pass && material->shader->spatial.depth_draw_mode == RasterizerStorageGLES2::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS) {
+			depth_prepass = true;
+		}
+
+		if (depth_prepass != prev_depth_prepass) {
+
+			state.scene_shader.set_conditional(SceneShaderGLES2::USE_DEPTH_PREPASS, depth_prepass);
+			prev_depth_prepass = depth_prepass;
+			rebind = true;
 		}
 
 		bool instancing = e->instance->base_type == VS::INSTANCE_MULTIMESH;

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1549,7 +1549,7 @@ FRAGMENT_SHADER_CODE
 #endif // ALPHA_SCISSOR_USED
 
 #ifdef USE_DEPTH_PREPASS
-	if (alpha < 0.99) {
+	if (alpha < 0.1) {
 		discard;
 	}
 #endif // USE_DEPTH_PREPASS
@@ -2112,7 +2112,7 @@ FRAGMENT_SHADER_CODE
 #endif // ALPHA_SCISSOR_USED
 
 #ifdef USE_DEPTH_PREPASS
-	if (alpha < 0.99) {
+	if (alpha < 0.1) {
 		discard;
 	}
 #endif // USE_DEPTH_PREPASS


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/26568

Use depth prepass when on shadow pass now as well. This matches GLES3 behaviour. Also depth_prepass threshold is reduced to 0.1 one, again to match GLES3 behaviour. 