### PR TITLE
Revert "Tweak SpatialMaterial's default metallic and roughness texture channels"

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1327,7 +1327,9 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 				if (bct.has("index")) {
 					Ref<Texture> t = _get_texture(state, bct["index"]);
 					material->set_texture(SpatialMaterial::TEXTURE_METALLIC, t);
+					material->set_metallic_texture_channel(SpatialMaterial::TEXTURE_CHANNEL_BLUE);
 					material->set_texture(SpatialMaterial::TEXTURE_ROUGHNESS, t);
+					material->set_roughness_texture_channel(SpatialMaterial::TEXTURE_CHANNEL_GREEN);
 					if (!mr.has("metallicFactor")) {
 						material->set_metallic(1);
 					}
@@ -1352,6 +1354,7 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 			Dictionary bct = d["occlusionTexture"];
 			if (bct.has("index")) {
 				material->set_texture(SpatialMaterial::TEXTURE_AMBIENT_OCCLUSION, _get_texture(state, bct["index"]));
+				material->set_ao_texture_channel(SpatialMaterial::TEXTURE_CHANNEL_RED);
 				material->set_feature(SpatialMaterial::FEATURE_AMBIENT_OCCLUSION, true);
 			}
 		}

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2353,8 +2353,8 @@ SpatialMaterial::SpatialMaterial() :
 
 	set_ao_light_affect(0.0);
 
-	set_metallic_texture_channel(TEXTURE_CHANNEL_BLUE);
-	set_roughness_texture_channel(TEXTURE_CHANNEL_GREEN);
+	set_metallic_texture_channel(TEXTURE_CHANNEL_RED);
+	set_roughness_texture_channel(TEXTURE_CHANNEL_RED);
 	set_ao_texture_channel(TEXTURE_CHANNEL_RED);
 	set_refraction_texture_channel(TEXTURE_CHANNEL_RED);
 


### PR DESCRIPTION
Reverts godotengine/godot#26205

This can break compatibility with 3.1 projects and @reduz wants to do it differently, but only in 4.0.

If this would be useful in 3.2 in the meantime, I suggest that it could be redone via an opt-in project setting (which 4.0 would deprecate).