### PR TITLE
Fix linking errors with Emscripten's latest-upstream LLVM backend

### DIFF
--- a/main/SCsub
+++ b/main/SCsub
@@ -14,7 +14,7 @@ controller_databases = ["#main/gamecontrollerdb.txt", "#main/gamecontrollerdb_20
 env.Depends("#main/default_controller_mappings.gen.cpp", controller_databases)
 env.CommandNoCache("#main/default_controller_mappings.gen.cpp", controller_databases, run_in_subprocess(main_builders.make_default_controller_mappings))
 
-env.main_sources.append("#main/default_controller_mappings.gen.cpp")
+env.add_source_files(env.main_sources, "#main/default_controller_mappings.gen.cpp")
 
 env.Depends("#main/splash.gen.h", "#main/splash.png")
 env.CommandNoCache("#main/splash.gen.h", "#main/splash.png", run_in_subprocess(main_builders.make_splash))

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -128,7 +128,8 @@ def configure(env):
     ## Link flags
 
     env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
-    env.Append(LINKFLAGS=['-s', 'BINARYEN_TRAP_MODE=\'clamp\''])
+    # Not supported by Emscripten's new LLVM backend.
+    #env.Append(LINKFLAGS=['-s', 'BINARYEN_TRAP_MODE=\'clamp\''])
 
     # Allow increasing memory buffer size during runtime. This is efficient
     # when using WebAssembly (in comparison to asm.js) and works well for


### PR DESCRIPTION
Fixes #30270.

I still get a linking error after those fixes, which I did not get previously when working around #30270. I'll check if it might be due to the fix for #30248, and report it upstream.
```
Linking Program        ==> bin/godot.javascript.debug.js
progress_finish(["progress_finish"], [])
cache:INFO: generating system library: libcompiler_rt.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libcompiler_rt.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libc-wasm.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libc-wasm.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libc++-noexcept.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libc++-noexcept.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libc++abi.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libc++abi.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libc-extras.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libc-extras.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libgl-webgl2.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libgl-webgl2.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libdlmalloc-debug.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libdlmalloc-debug.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libpthreads_stub.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libpthreads_stub.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libcompiler_rt_wasm.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libcompiler_rt_wasm.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libc_rt_wasm.a... (this will be cached in "/home/akien/.emscripten_cache/wasm-obj/libc_rt_wasm.a" for subsequent builds)
cache:INFO:  - ok
wasm-ld: /b/s/w/ir/cache/builder/emscripten-releases/llvm-project/llvm/include/llvm/ADT/Optional.h:177: const T &llvm::optional_detail::OptionalStorage<unsigned int, true>::getValue() const & [T = unsigned int]: Assertion `hasVal' failed.
 #0 0x00007f69eb619af4 PrintStackTraceSignalHandler(void*) (/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/../lib/libLLVM-9svn.so+0x6c6af4)
 #1 0x00007f69eb6177ae llvm::sys::RunSignalHandlers() (/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/../lib/libLLVM-9svn.so+0x6c47ae)
 #2 0x00007f69eb619da8 SignalHandler(int) (/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/../lib/libLLVM-9svn.so+0x6c6da8)
 #3 0x00007f69ee42c560 __restore_rt (/lib64/libpthread.so.0+0x13560)
 #4 0x00007f69eaae3a7a raise (/lib64/libc.so.6+0x3ca7a)
 #5 0x00007f69eaacc524 abort (/lib64/libc.so.6+0x25524)
 #6 0x00007f69eaacc40f _nl_load_domain.cold.0 (/lib64/libc.so.6+0x2540f)
 #7 0x00007f69eaad89a2 (/lib64/libc.so.6+0x319a2)
 #8 0x00000000006a7ad2 (/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/wasm-ld+0x6a7ad2)
 #9 0x0000000000690267 lld::wasm::InputChunk::writeTo(unsigned char*) const (/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/wasm-ld+0x690267)
#10 0x00000000006befad lld::wasm::CustomSection::writeTo(unsigned char*) (/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/wasm-ld+0x6befad)
#11 0x00000000006bac7d std::_Function_handler<void (), void llvm::parallel::detail::parallel_for_each<__gnu_cxx::__normal_iterator<lld::wasm::OutputSection**, std::vector<lld::wasm::OutputSection*, std::allocator<lld::wasm::OutputSection*> > >, (anonymous namespace)::Writer::writeSections()::$_0>(__gnu_cxx::__normal_iterator<lld::wasm::OutputSection**, std::vector<lld::wasm::OutputSection*, std::allocator<lld::wasm::OutputSection*> > >, __gnu_cxx::__normal_iterator<lld::wasm::OutputSection**, std::vector<lld::wasm::OutputSection*, std::allocator<lld::wasm::OutputSection*> > >, (anonymous namespace)::Writer::writeSections()::$_0)::'lambda'()>::_M_invoke(std::_Any_data const&) (/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/wasm-ld+0x6bac7d)
#12 0x00007f69eb5af625 std::_Function_handler<void (), llvm::parallel::detail::TaskGroup::spawn(std::function<void ()>)::$_0>::_M_invoke(std::_Any_data const&) (/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/../lib/libLLVM-9svn.so+0x65c625)
#13 0x00007f69eb5af207 llvm::parallel::detail::(anonymous namespace)::ThreadPoolExecutor::work() (/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/../lib/libLLVM-9svn.so+0x65c207)
#14 0x00007f69eae8a3d0 (/lib64/libstdc++.so.6+0xbd3d0)
#15 0x00007f69ee42204c start_thread (/lib64/libpthread.so.0+0x904c)
#16 0x00007f69eababbcf clone (/lib64/libc.so.6+0x104bcf)
shared:ERROR: '/home/akien/Projects/godot/emscripten/emsdk/upstream/bin/wasm-ld -o /tmp/emscripten_temp_SyEM17/godot.javascript.debug.wasm --allow-undefined --import-memory --import-table --lto-O0 platform/javascript/audio_driver_javascript.javascript.debug.bc platform/javascript/http_client_javascript.javascript.debug.bc platform/javascript/javascript_eval.javascript.debug.bc platform/javascript/javascript_main.javascript.debug.bc platform/javascript/os_javascript.javascript.debug.bc main/libmain.javascript.debug.bc main/tests/libtests.javascript.debug.bc modules/libmodules.javascript.debug.bc platform/libplatform.javascript.debug.bc drivers/libdrivers.javascript.debug.bc scene/libscene.javascript.debug.bc servers/libservers.javascript.debug.bc core/libcore.javascript.debug.bc modules/freetype/libfreetype_builtin.javascript.debug.bc /home/akien/.emscripten_cache/wasm-obj/libc.a /home/akien/.emscripten_cache/wasm-obj/libcompiler_rt.a /home/akien/.emscripten_cache/wasm-obj/libc-wasm.a /home/akien/.emscripten_cache/wasm-obj/libc++-noexcept.a /home/akien/.emscripten_cache/wasm-obj/libc++abi.a /home/akien/.emscripten_cache/wasm-obj/libc-extras.a /home/akien/.emscripten_cache/wasm-obj/libgl-webgl2.a /home/akien/.emscripten_cache/wasm-obj/libdlmalloc-debug.a /home/akien/.emscripten_cache/wasm-obj/libpthreads_stub.a /home/akien/.emscripten_cache/wasm-obj/libcompiler_rt_wasm.a /home/akien/.emscripten_cache/wasm-obj/libc_rt_wasm.a -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr --export __wasm_call_ctors --export __data_end --export main --export malloc --export free --export setThrew --export __errno_location --export fflush --export _get_environ --export htonl --export htons --export ntohs --export realloc --export _get_tzname --export _get_daylight --export _get_timezone --export emscripten_GetProcAddress --export strstr -z stack-size=5242880 --initial-memory=16777216 --no-entry --global-base=1024' failed (-6)
scons: *** [bin/godot.javascript.debug.js] Error 1
```