### PR TITLE
Emscripten: Do not define BINARYEN_TRAP_MODE='clamp'

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -128,7 +128,6 @@ def configure(env):
     ## Link flags
 
     env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
-    env.Append(LINKFLAGS=['-s', 'BINARYEN_TRAP_MODE=\'clamp\''])
 
     # Allow increasing memory buffer size during runtime. This is efficient
     # when using WebAssembly (in comparison to asm.js) and works well for


### PR DESCRIPTION
It is not supported in Emscripten's `latest-upstream` LLVM backend,
and doesn't seem necessary in the `latest` backend either.
It was initially added in #22857 to solve a compilation error with the latter.

Part of #30270.