### PR TITLE
SCons: Fix uses of [].append instead of env.add_source_files()

### DIFF
--- a/editor/SCsub
+++ b/editor/SCsub
@@ -31,7 +31,7 @@ if env['tools']:
     reg_exporters_inc = '#include "register_exporters.h"\n'
     reg_exporters = 'void register_exporters() {\n'
     for e in env.platform_exporters:
-        env.editor_sources.append("#platform/" + e + "/export/export.cpp")
+        env.add_source_files(env.editor_sources, "#platform/" + e + "/export/export.cpp")
         reg_exporters += '\tregister_' + e + '_exporter();\n'
         reg_exporters_inc += '#include "platform/' + e + '/export/export.h"\n'
     reg_exporters += '}\n'

--- a/main/SCsub
+++ b/main/SCsub
@@ -6,6 +6,7 @@ from platform_methods import run_in_subprocess
 import main_builders
 
 env.main_sources = []
+
 env.add_source_files(env.main_sources, "*.cpp")
 
 # order matters here.  higher index controller database files write on top of lower index database files
@@ -14,7 +15,9 @@ controller_databases = ["#main/gamecontrollerdb.txt", "#main/gamecontrollerdb_20
 env.Depends("#main/default_controller_mappings.gen.cpp", controller_databases)
 env.CommandNoCache("#main/default_controller_mappings.gen.cpp", controller_databases, run_in_subprocess(main_builders.make_default_controller_mappings))
 
-env.main_sources.append("#main/default_controller_mappings.gen.cpp")
+# Don't warn about duplicate entry here, we need it registered manually for first build,
+# even if later builds will pick it up twice due to above *.cpp globbing.
+env.add_source_files(env.main_sources, "#main/default_controller_mappings.gen.cpp", warn_duplicates=False)
 
 env.Depends("#main/splash.gen.h", "#main/splash.png")
 env.CommandNoCache("#main/splash.gen.h", "#main/splash.png", run_in_subprocess(main_builders.make_splash))

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -6,9 +6,9 @@ env_modules = env.Clone()
 
 Export('env_modules')
 
-env.modules_sources = [
-    "register_module_types.gen.cpp",
-]
+env.modules_sources = []
+
+env_modules.add_source_files(env.modules_sources, "register_module_types.gen.cpp")
 
 for x in env.module_list:
     if (x in env.disabled_modules):

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -3,7 +3,8 @@
 from compat import open_utf8
 
 Import('env')
-platform_sources = []
+
+env.platform_sources = []
 
 # Register platform-exclusive APIs
 reg_apis_inc = '#include "register_platform_apis.h"\n'
@@ -11,7 +12,7 @@ reg_apis = 'void register_platform_apis() {\n'
 unreg_apis = 'void unregister_platform_apis() {\n'
 for platform in env.platform_apis:
     platform_dir = env.Dir(platform)
-    platform_sources.append(platform_dir.File('api/api.cpp'))
+    env.add_source_files(env.platform_sources, platform + '/api/api.cpp')
     reg_apis += '\tregister_' + platform + '_api();\n'
     unreg_apis += '\tunregister_' + platform + '_api();\n'
     reg_apis_inc += '#include "' + platform + '/api/api.h"\n'
@@ -25,7 +26,7 @@ with open_utf8('register_platform_apis.gen.cpp', 'w') as f:
     f.write(reg_apis)
     f.write(unreg_apis)
 
-platform_sources.append('register_platform_apis.gen.cpp')
+env.add_source_files(env.platform_sources, 'register_platform_apis.gen.cpp')
 
-lib = env.add_library('platform', platform_sources)
+lib = env.add_library('platform', env.platform_sources)
 env.Prepend(LIBS=lib)

--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -3,10 +3,10 @@
 Import('env')
 
 if env['disable_3d']:
-    env.scene_sources.append("3d/spatial.cpp")
-    env.scene_sources.append("3d/skeleton.cpp")
-    env.scene_sources.append("3d/particles.cpp")
-    env.scene_sources.append("3d/visual_instance.cpp")
-    env.scene_sources.append("3d/world_environment.cpp")
+    env.add_source_files(env.scene_sources, "spatial.cpp")
+    env.add_source_files(env.scene_sources, "skeleton.cpp")
+    env.add_source_files(env.scene_sources, "particles.cpp")
+    env.add_source_files(env.scene_sources, "visual_instance.cpp")
+    env.add_source_files(env.scene_sources, "world_environment.cpp")
 else:
     env.add_source_files(env.scene_sources, "*.cpp")


### PR DESCRIPTION
Also added support for SCons project-absolute paths (starting with #) and
warning about duplicates in add_source_files(), and fixed
default_controller_mappings.gen.cpp being included twice after first build
due to *.cpp globbing.

Part of #30270.