### PR TITLE
Make `make_header.py` functional when run from any location

### DIFF
--- a/scene/resources/default_theme/make_header.py
+++ b/scene/resources/default_theme/make_header.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
 
 import glob
+import os
 
 enc = "utf-8"
+
+# Change to the directory where the script is located,
+# so that the script can be run from any location
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 # Generate include files
 


### PR DESCRIPTION
This removes the need to `cd` to `scene/resources/default_theme/` to get the expected result.

I noticed this while working on #30300 and was wondering why my changes didn't appear after recompiling :wink:

PS: Could `theme_data.h` be generated at build-time in the future, so that it doesn't have to be committed to version control?