### PR TITLE
Fix type mismatch in iOS interface orientation checks

### DIFF
--- a/modules/arkit/arkit_interface.mm
+++ b/modules/arkit/arkit_interface.mm
@@ -430,7 +430,7 @@ void ARKitInterface::process() {
 
 				// get some info about our screen and orientation
 				Size2 screen_size = OS::get_singleton()->get_window_size();
-				UIDeviceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
+				UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
 
 				// Grab our camera image for our backbuffer
 				CVPixelBufferRef pixelBuffer = current_frame.capturedImage;
@@ -531,7 +531,7 @@ void ARKitInterface::process() {
 						// we need to invert this, probably row v.s. column notation
 						affine_transform = CGAffineTransformInvert(affine_transform);
 
-						if (orientation != UIDeviceOrientationPortrait) {
+						if (orientation != UIInterfaceOrientationPortrait) {
 							affine_transform.b = -affine_transform.b;
 							affine_transform.d = -affine_transform.d;
 							affine_transform.ty = 1.0 - affine_transform.ty;
@@ -582,28 +582,28 @@ void ARKitInterface::process() {
 
 					// copy our current frame transform
 					matrix_float4x4 m44 = camera.transform;
-					if (orientation == UIDeviceOrientationLandscapeLeft) {
+					if (orientation == UIInterfaceOrientationLandscapeLeft) {
 						transform.basis.elements[0].x = m44.columns[0][0];
 						transform.basis.elements[1].x = m44.columns[0][1];
 						transform.basis.elements[2].x = m44.columns[0][2];
 						transform.basis.elements[0].y = m44.columns[1][0];
 						transform.basis.elements[1].y = m44.columns[1][1];
 						transform.basis.elements[2].y = m44.columns[1][2];
-					} else if (orientation == UIDeviceOrientationPortrait) {
+					} else if (orientation == UIInterfaceOrientationPortrait) {
 						transform.basis.elements[0].x = m44.columns[1][0];
 						transform.basis.elements[1].x = m44.columns[1][1];
 						transform.basis.elements[2].x = m44.columns[1][2];
 						transform.basis.elements[0].y = -m44.columns[0][0];
 						transform.basis.elements[1].y = -m44.columns[0][1];
 						transform.basis.elements[2].y = -m44.columns[0][2];
-					} else if (orientation == UIDeviceOrientationLandscapeRight) {
+					} else if (orientation == UIInterfaceOrientationLandscapeRight) {
 						transform.basis.elements[0].x = -m44.columns[0][0];
 						transform.basis.elements[1].x = -m44.columns[0][1];
 						transform.basis.elements[2].x = -m44.columns[0][2];
 						transform.basis.elements[0].y = -m44.columns[1][0];
 						transform.basis.elements[1].y = -m44.columns[1][1];
 						transform.basis.elements[2].y = -m44.columns[1][2];
-					} else if (orientation == UIDeviceOrientationPortraitUpsideDown) {
+					} else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
 						// this may not be correct
 						transform.basis.elements[0].x = m44.columns[1][0];
 						transform.basis.elements[1].x = m44.columns[1][1];

--- a/platform/iphone/camera_ios.mm
+++ b/platform/iphone/camera_ios.mm
@@ -158,7 +158,7 @@
 	} else if (dataCbCr == NULL) {
 		print_line("Couldn't access CbCr pixel buffer data");
 	} else {
-		UIDeviceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
+		UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
 		Ref<Image> img[2];
 
 		{


### PR DESCRIPTION
Not sure why this error popped up when I enabled C++11 on the codebase,
but I guess this should fix it.

I guess these errors possibly pre-existed, but since they were introduced by two old PRs with existing build cache, they were not picked up until 5dae2ea77 forced a rebuild of the whole codebase?