### PR TITLE
Expose "meta" to the Inspector. For real.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -641,12 +641,14 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 		}
 	}
 
+	p_list->push_back(PropertyInfo(Variant::NIL, "Metadata", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
+	p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT));
+	p_list->push_back(PropertyInfo(Variant::NIL, "", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
+
 	if (!is_class("Script")) { // can still be set, but this is for user-friendliness
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));
 	}
-	if (!metadata.is_empty()) {
-		p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
-	}
+
 	if (script_instance && !p_reversed) {
 		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
 		script_instance->get_property_list(p_list);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -47,7 +47,7 @@ class AnimationTrackKeyEdit : public Object {
 public:
 	bool setting = false;
 
-	bool _hide_script_from_inspector() {
+	bool _hide_object_properties_from_inspector() {
 		return true;
 	}
 
@@ -58,7 +58,7 @@ public:
 	static void _bind_methods() {
 		ClassDB::bind_method("_update_obj", &AnimationTrackKeyEdit::_update_obj);
 		ClassDB::bind_method("_key_ofs_changed", &AnimationTrackKeyEdit::_key_ofs_changed);
-		ClassDB::bind_method("_hide_script_from_inspector", &AnimationTrackKeyEdit::_hide_script_from_inspector);
+		ClassDB::bind_method("_hide_object_properties_from_inspector", &AnimationTrackKeyEdit::_hide_object_properties_from_inspector);
 		ClassDB::bind_method("get_root_path", &AnimationTrackKeyEdit::get_root_path);
 		ClassDB::bind_method("_dont_undo_redo", &AnimationTrackKeyEdit::_dont_undo_redo);
 	}
@@ -681,7 +681,7 @@ class AnimationMultiTrackKeyEdit : public Object {
 public:
 	bool setting = false;
 
-	bool _hide_script_from_inspector() {
+	bool _hide_object_properties_from_inspector() {
 		return true;
 	}
 
@@ -692,7 +692,7 @@ public:
 	static void _bind_methods() {
 		ClassDB::bind_method("_update_obj", &AnimationMultiTrackKeyEdit::_update_obj);
 		ClassDB::bind_method("_key_ofs_changed", &AnimationMultiTrackKeyEdit::_key_ofs_changed);
-		ClassDB::bind_method("_hide_script_from_inspector", &AnimationMultiTrackKeyEdit::_hide_script_from_inspector);
+		ClassDB::bind_method("_hide_object_properties_from_inspector", &AnimationMultiTrackKeyEdit::_hide_object_properties_from_inspector);
 		ClassDB::bind_method("get_root_path", &AnimationMultiTrackKeyEdit::get_root_path);
 		ClassDB::bind_method("_dont_undo_redo", &AnimationMultiTrackKeyEdit::_dont_undo_redo);
 	}

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2483,8 +2483,7 @@ void EditorInspector::update_tree() {
 			continue;
 		}
 
-		if (p.name == "script" && (hide_script || bool(object->call("_hide_script_from_inspector")))) {
-			// Hide script variables from inspector if required.
+		if ((hide_object_properties || bool(object->call("_hide_object_properties_from_inspector"))) && (p.name == "script" || p.name == "__meta__")) {
 			continue;
 		}
 
@@ -2928,8 +2927,8 @@ void EditorInspector::set_use_doc_hints(bool p_enable) {
 	update_tree();
 }
 
-void EditorInspector::set_hide_script(bool p_hide) {
-	hide_script = p_hide;
+void EditorInspector::set_hide_object_properties(bool p_hide) {
+	hide_object_properties = p_hide;
 	update_tree();
 }
 
@@ -3529,7 +3528,7 @@ EditorInspector::EditorInspector() {
 
 	wide_editors = false;
 	show_categories = false;
-	hide_script = true;
+	hide_object_properties = true;
 	use_doc_hints = false;
 	capitalize_paths = true;
 	use_filter = false;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -424,7 +424,7 @@ class EditorInspector : public ScrollContainer {
 
 	LineEdit *search_box;
 	bool show_categories;
-	bool hide_script;
+	bool hide_object_properties;
 	bool use_doc_hints;
 	bool capitalize_paths;
 	bool use_filter;
@@ -520,7 +520,7 @@ public:
 
 	void set_show_categories(bool p_show);
 	void set_use_doc_hints(bool p_enable);
-	void set_hide_script(bool p_hide);
+	void set_hide_object_properties(bool p_hide);
 
 	void set_use_filter(bool p_use);
 	void register_text_enter(Node *p_line_edit);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -725,7 +725,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	inspector->set_show_categories(true);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector->set_use_doc_hints(true);
-	inspector->set_hide_script(false);
+	inspector->set_hide_object_properties(false);
 	inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));
 	inspector->set_use_folding(!bool(EDITOR_GET("interface/inspector/disable_folding")));
 	inspector->register_text_enter(search);


### PR DESCRIPTION
Second attempt. As requested by @akien-mga here: https://github.com/godotengine/godot/pull/22642#issuecomment-513727886.

**Things that need to be worked out:**
- ~Meta properties being inserted in scene files even if empty. Not caused by commit itself but by how dictionaries are handled. Will be fixed by the merging of either #29222 or #35816~.
- `ProjectSettings` exposes it in its documentation.

(It will, hopefully this time) Closes #5433.