### PR TITLE
Make Set methods obsolete

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -914,7 +914,7 @@ struct _VariantCall {
 
 	static void Quat_init2(Variant &r_ret, const Variant **p_args) {
 
-		r_ret = Quat(((Vector3)(*p_args[0])), ((float)(*p_args[1])));
+		r_ret = Quat(((Vector3)(*p_args[0])), ((real_t)(*p_args[1])));
 	}
 
 	static void Quat_init3(Variant &r_ret, const Variant **p_args) {

--- a/modules/mono/glue/Managed/Files/Basis.cs
+++ b/modules/mono/glue/Managed/Files/Basis.cs
@@ -225,7 +225,7 @@ namespace Godot
             return orthonormalizedBasis.Quat();
         }
 
-        internal void SetQuantScale(Quat quat, Vector3 scale)
+        internal void SetQuatScale(Quat quat, Vector3 scale)
         {
             SetDiagonal(scale);
             Rotate(quat);
@@ -241,7 +241,6 @@ namespace Godot
             Row0 = new Vector3(diagonal.x, 0, 0);
             Row1 = new Vector3(0, diagonal.y, 0);
             Row2 = new Vector3(0, 0, diagonal.z);
-
         }
 
         public real_t Determinant()

--- a/modules/mono/glue/Managed/Files/NodePath.cs
+++ b/modules/mono/glue/Managed/Files/NodePath.cs
@@ -55,7 +55,7 @@ namespace Godot
             get { return ptr; }
         }
 
-        public NodePath() : this(string.Empty) { }
+        public NodePath() : this(string.Empty) {}
 
         public NodePath(string path)
         {

--- a/modules/mono/glue/Managed/Files/Quat.cs
+++ b/modules/mono/glue/Managed/Files/Quat.cs
@@ -95,6 +95,7 @@ namespace Godot
             return this / Length;
         }
 
+        [Obsolete("Set is deprecated. Use the Quat(" + nameof(real_t) + ", " + nameof(real_t) + ", " + nameof(real_t) + ", " + nameof(real_t) + ") constructor instead.", error: true)]
         public void Set(real_t x, real_t y, real_t z, real_t w)
         {
             this.x = x;
@@ -103,16 +104,19 @@ namespace Godot
             this.w = w;
         }
 
+        [Obsolete("Set is deprecated. Use the Quat(" + nameof(Quat) + ") constructor instead.", error: true)]
         public void Set(Quat q)
         {
             this = q;
         }
 
+        [Obsolete("SetAxisAngle is deprecated. Use the Quat(" + nameof(Vector3) + ", " + nameof(real_t) + ") constructor instead.", error: true)]
         public void SetAxisAngle(Vector3 axis, real_t angle)
         {
             this = new Quat(axis, angle);
         }
 
+        [Obsolete("SetEuler is deprecated. Use the Quat(" + nameof(Vector3) + ") constructor instead.", error: true)]
         public void SetEuler(Vector3 eulerYXZ)
         {
             this = new Quat(eulerYXZ);
@@ -229,9 +233,9 @@ namespace Godot
 
         public Quat(Vector3 eulerYXZ)
         {
-            real_t half_a1 = eulerYXZ.y * (real_t)0.5;
-            real_t half_a2 = eulerYXZ.x * (real_t)0.5;
-            real_t half_a3 = eulerYXZ.z * (real_t)0.5;
+            real_t half_a1 = eulerYXZ.y * 0.5f;
+            real_t half_a2 = eulerYXZ.x * 0.5f;
+            real_t half_a3 = eulerYXZ.z * 0.5f;
 
             // R = Y(a1).X(a2).Z(a3) convention for Euler angles.
             // Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)
@@ -246,7 +250,7 @@ namespace Godot
 
             x = sin_a1 * cos_a2 * sin_a3 + cos_a1 * sin_a2 * cos_a3;
             y = sin_a1 * cos_a2 * cos_a3 - cos_a1 * sin_a2 * sin_a3;
-            z = -sin_a1 * sin_a2 * cos_a3 + cos_a1 * cos_a2 * sin_a3;
+            z = cos_a1 * cos_a2 * sin_a3 - sin_a1 * sin_a2 * cos_a3;
             w = sin_a1 * sin_a2 * sin_a3 + cos_a1 * cos_a2 * cos_a3;
         }
 

--- a/modules/mono/glue/Managed/Files/Transform.cs
+++ b/modules/mono/glue/Managed/Files/Transform.cs
@@ -33,7 +33,7 @@ namespace Godot
             Vector3 destinationLocation = transform.origin;
 
             var interpolated = new Transform();
-            interpolated.basis.SetQuantScale(sourceRotation.Slerp(destinationRotation, c).Normalized(), sourceScale.LinearInterpolate(destinationScale, c));
+            interpolated.basis.SetQuatScale(sourceRotation.Slerp(destinationRotation, c).Normalized(), sourceScale.LinearInterpolate(destinationScale, c));
             interpolated.origin = sourceLocation.LinearInterpolate(destinationLocation, c);
 
             return interpolated;

--- a/modules/mono/glue/Managed/Files/Vector2.cs
+++ b/modules/mono/glue/Managed/Files/Vector2.cs
@@ -222,11 +222,13 @@ namespace Godot
             return new Vector2(Mathf.Round(x), Mathf.Round(y));
         }
 
+        [Obsolete("Set is deprecated. Use the Vector2(" + nameof(real_t) + ", " + nameof(real_t) + ") constructor instead.", error: true)]
         public void Set(real_t x, real_t y)
         {
             this.x = x;
             this.y = y;
         }
+        [Obsolete("Set is deprecated. Use the Vector2(" + nameof(Vector2) + ") constructor instead.", error: true)]
         public void Set(Vector2 v)
         {
             x = v.x;

--- a/modules/mono/glue/Managed/Files/Vector3.cs
+++ b/modules/mono/glue/Managed/Files/Vector3.cs
@@ -248,12 +248,14 @@ namespace Godot
             return new Basis(axis, phi).Xform(this);
         }
 
+        [Obsolete("Set is deprecated. Use the Vector3(" + nameof(real_t) + ", " + nameof(real_t) + ", " + nameof(real_t) + ") constructor instead.", error: true)]
         public void Set(real_t x, real_t y, real_t z)
         {
             this.x = x;
             this.y = y;
             this.z = z;
         }
+        [Obsolete("Set is deprecated. Use the Vector3(" + nameof(Vector3) + ") constructor instead.", error: true)]
         public void Set(Vector3 v)
         {
             x = v.x;


### PR DESCRIPTION
Mono: Declare all set methods obsolete and suggest using the constructors instead, fixes https://github.com/godotengine/godot/issues/30744

~~Core: Warn when using `set_axis_angle` and suggest using the constructor instead. Previously the constructor called the method, so I copied the logic.~~ We can delete the method in 4.0+. I looked into doing this for `set_euler` too, but the constructor doesn't work.

Partial follow-up to https://github.com/godotengine/godot/pull/21348