### PR TITLE
Make possible to edit multiple keys in an animation again

### DIFF
--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -246,6 +246,7 @@ public:
 };
 
 class AnimationTrackKeyEdit;
+class AnimationMultiTrackKeyEdit;
 class AnimationBezierTrackEdit;
 
 class AnimationTrackEditGroup : public Control {
@@ -415,6 +416,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _move_selection_cancel();
 
 	AnimationTrackKeyEdit *key_edit;
+	AnimationMultiTrackKeyEdit *multi_key_edit;
 	void _update_key_edit();
 
 	void _clear_key_edit();


### PR DESCRIPTION
This makes it possible to once again edit multiple keys in an animation at the same time.

Closes #24520. I also found a bug while doing this, reported here: #30762

Thanks to @avencherus for sponsoring this PR.