### PR TITLE
[WIP] Add semi-fixed timestep and physics time stretching for global timescale

### DIFF
--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -89,6 +89,10 @@ float Engine::get_time_scale() const {
 	return _time_scale;
 }
 
+bool Engine::get_physics_stretch_ticks() const {
+	return _physics_stretch_ticks;
+}
+
 Dictionary Engine::get_version_info() const {
 
 	Dictionary dict;
@@ -232,6 +236,7 @@ Engine::Engine() {
 	_fps = 1;
 	_target_fps = 0;
 	_time_scale = 1.0;
+	_physics_stretch_ticks = true;
 	_pixel_snap = false;
 	_physics_frames = 0;
 	_idle_frames = 0;

--- a/core/engine.h
+++ b/core/engine.h
@@ -61,6 +61,7 @@ private:
 	float _fps;
 	int _target_fps;
 	float _time_scale;
+	bool _physics_stretch_ticks;
 	bool _pixel_snap;
 	uint64_t _physics_frames;
 	float _physics_interpolation_fraction;
@@ -100,6 +101,7 @@ public:
 
 	void set_time_scale(float p_scale);
 	float get_time_scale() const;
+	bool get_physics_stretch_ticks() const;
 
 	void set_frame_delay(uint32_t p_msec);
 	uint32_t get_frame_delay() const;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -78,6 +78,8 @@
 #include "editor/project_manager.h"
 #endif
 
+#include <stdint.h>
+
 /* Static members */
 
 // Singletons
@@ -1026,6 +1028,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Engine::get_singleton()->set_iterations_per_second(GLOBAL_DEF("physics/common/physics_fps", 60));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/common/physics_fps", PropertyInfo(Variant::INT, "physics/common/physics_fps", PROPERTY_HINT_RANGE, "1,120,1,or_greater"));
 	Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_DEF("physics/common/physics_jitter_fix", 0.5));
+	GLOBAL_DEF("physics/common/timestep/method", "Jitter Fix");
+	ProjectSettings::get_singleton()->set_custom_property_info("physics/common/timestep/method", PropertyInfo(Variant::STRING, "physics/common/timestep/method", PROPERTY_HINT_ENUM, "Jitter Fix,Fixed,Semi Fixed"));
+	Engine::get_singleton()->_physics_stretch_ticks = GLOBAL_DEF("physics/common/timestep/timescale_stretch_ticks", true);
+
 	Engine::get_singleton()->set_target_fps(GLOBAL_DEF("debug/settings/fps/force_fps", 0));
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/settings/fps/force_fps", PropertyInfo(Variant::INT, "debug/settings/fps/force_fps", PROPERTY_HINT_RANGE, "0,120,1,or_greater"));
 
@@ -1856,6 +1862,35 @@ bool Main::is_iterating() {
 static uint64_t physics_process_max = 0;
 static uint64_t idle_process_max = 0;
 
+// returns usecs taken by the physics tick
+uint64_t Main::physics_tick(float p_physics_delta) {
+	uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
+
+	PhysicsServer::get_singleton()->sync();
+	PhysicsServer::get_singleton()->flush_queries();
+
+	Physics2DServer::get_singleton()->sync();
+	Physics2DServer::get_singleton()->flush_queries();
+
+	if (OS::get_singleton()->get_main_loop()->iteration(p_physics_delta)) {
+		// UINT64_MAX indicates we want to stop the loop through the physics iterations
+		return UINT64_MAX;
+	}
+
+	message_queue->flush();
+
+	PhysicsServer::get_singleton()->step(p_physics_delta);
+
+	Physics2DServer::get_singleton()->end_sync();
+	Physics2DServer::get_singleton()->step(p_physics_delta);
+
+	message_queue->flush();
+
+	Engine::get_singleton()->_physics_frames++;
+
+	return OS::get_singleton()->get_ticks_usec() - physics_begin;
+}
+
 bool Main::iteration() {
 
 	//for now do not error on this
@@ -1865,21 +1900,21 @@ bool Main::iteration() {
 
 	uint64_t ticks = OS::get_singleton()->get_ticks_usec();
 	Engine::get_singleton()->_frame_ticks = ticks;
-	main_timer_sync.set_cpu_ticks_usec(ticks);
-	main_timer_sync.set_fixed_fps(fixed_fps);
 
 	uint64_t ticks_elapsed = ticks - last_ticks;
 
 	int physics_fps = Engine::get_singleton()->get_iterations_per_second();
-	float frame_slice = 1.0 / physics_fps;
 
-	float time_scale = Engine::get_singleton()->get_time_scale();
+	// main_timer_sync will deal with time_scale and limiting the max number of physics ticks
+	MainFrameTime advance;
+	main_timer_sync.advance(advance, physics_fps, ticks, fixed_fps);
 
-	MainFrameTime advance = main_timer_sync.advance(frame_slice, physics_fps);
-	double step = advance.idle_step;
-	double scaled_step = step * time_scale;
+	double scaled_step = advance.scaled_frame_delta;
 
-	Engine::get_singleton()->_frame_step = step;
+	// Note Engine::_frame_step was previously the step unadjusted for timescale.
+	// It was unused within Godot, although perhaps used in custom Modules, I'm assuming this was a bug
+	// as scaled step makes more sense.
+	Engine::get_singleton()->_frame_step = scaled_step;
 	Engine::get_singleton()->_physics_interpolation_fraction = advance.interpolation_fraction;
 
 	uint64_t physics_process_ticks = 0;
@@ -1889,50 +1924,40 @@ bool Main::iteration() {
 
 	last_ticks = ticks;
 
-	static const int max_physics_steps = 8;
-	if (fixed_fps == -1 && advance.physics_steps > max_physics_steps) {
-		step -= (advance.physics_steps - max_physics_steps) * frame_slice;
-		advance.physics_steps = max_physics_steps;
-	}
-
 	bool exit = false;
 
 	Engine::get_singleton()->_in_physics = true;
 
+	float physics_delta = advance.physics_fixed_step_delta;
+
 	for (int iters = 0; iters < advance.physics_steps; ++iters) {
 
-		uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
+		// special case, if using variable physics timestep and the last physics step
+		if (advance.physics_variable_step && (iters == (advance.physics_steps - 1))) {
+			// substitute the variable delta
+			physics_delta = advance.physics_variable_step_delta;
+		}
 
-		PhysicsServer::get_singleton()->sync();
-		PhysicsServer::get_singleton()->flush_queries();
+		// returns the time taken by the physics tick
+		uint64_t physics_usecs = physics_tick(physics_delta);
 
-		Physics2DServer::get_singleton()->sync();
-		Physics2DServer::get_singleton()->flush_queries();
-
-		if (OS::get_singleton()->get_main_loop()->iteration(frame_slice * time_scale)) {
+		// in the special case of wanting to exit the loop we are passing
+		// UINT64_MAX which will never occur normally.
+		if (physics_usecs == UINT64_MAX) {
 			exit = true;
 			break;
 		}
 
-		message_queue->flush();
-
-		PhysicsServer::get_singleton()->step(frame_slice * time_scale);
-
-		Physics2DServer::get_singleton()->end_sync();
-		Physics2DServer::get_singleton()->step(frame_slice * time_scale);
-
-		message_queue->flush();
-
-		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference
-		physics_process_max = MAX(OS::get_singleton()->get_ticks_usec() - physics_begin, physics_process_max);
-		Engine::get_singleton()->_physics_frames++;
+		// performance stats
+		physics_process_ticks = MAX(physics_process_ticks, physics_usecs); // keep the largest one for reference
+		physics_process_max = MAX(physics_usecs, physics_process_max);
 	}
 
 	Engine::get_singleton()->_in_physics = false;
 
 	uint64_t idle_begin = OS::get_singleton()->get_ticks_usec();
 
-	if (OS::get_singleton()->get_main_loop()->idle(step * time_scale)) {
+	if (OS::get_singleton()->get_main_loop()->idle(scaled_step)) {
 		exit = true;
 	}
 	message_queue->flush();
@@ -1965,6 +1990,8 @@ bool Main::iteration() {
 
 	if (script_debugger) {
 		if (script_debugger->is_profiling()) {
+			// note that frame_slice is original physics delta, before time_scale applied
+			float frame_slice = 1.0 / physics_fps;
 			script_debugger->profiling_set_frame_times(USEC_TO_SEC(frame_time), USEC_TO_SEC(idle_process_ticks), USEC_TO_SEC(physics_process_ticks), frame_slice);
 		}
 		script_debugger->idle_poll();

--- a/main/main.h
+++ b/main/main.h
@@ -57,6 +57,7 @@ public:
 	static bool start();
 
 	static bool iteration();
+	static uint64_t physics_tick(float p_physics_delta);
 	static void force_redraw();
 
 	static bool is_iterating();

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -29,27 +29,236 @@
 /*************************************************************************/
 
 #include "main_timer_sync.h"
+#include "core/project_settings.h"
 
-void MainFrameTime::clamp_idle(float min_idle_step, float max_idle_step) {
-	if (idle_step < min_idle_step) {
-		idle_step = min_idle_step;
-	} else if (idle_step > max_idle_step) {
-		idle_step = max_idle_step;
+/////////////////////////////////////////////////////////////////
+
+void MainFrameTime::clamp_frame_delta(float p_min, float p_max) {
+	if (scaled_frame_delta < p_min) {
+		scaled_frame_delta = p_min;
+	} else if (scaled_frame_delta > p_max) {
+		scaled_frame_delta = p_max;
 	}
 }
 
-/////////////////////////////////
+MainFrameTime::MainFrameTime() {
+	// initialize the timing info with some sensible values, no matter what timestep method is used
+	scaled_frame_delta = 0.0f;
+	physics_steps = 1;
+	physics_fixed_step_delta = 0.0f;
+	physics_variable_step = false;
+	physics_variable_step_delta = 0.0f;
+	interpolation_fraction = 0.0f;
+}
+
+/////////////////////////////////////////////////////////////////
+
+MainTimerSync::MainTimerSync() :
+		last_cpu_ticks_usec(0),
+		current_cpu_ticks_usec(0),
+		fixed_fps(0) {
+	stretch_ticks = true;
+	method = 0;
+}
+
+// start the clock
+void MainTimerSync::init(uint64_t p_cpu_ticks_usec) {
+	current_cpu_ticks_usec = last_cpu_ticks_usec = p_cpu_ticks_usec;
+
+	// Just read the project settings once in init rather than every frame.
+	// Note that this is assuming that ticking is not desired within the editor.
+	// If ticking is to be changed within the editor, MainTimerSync will need to be
+	// informed somehow (e.g. calling this function from here onwards).
+	// This is not requested from the ProjectSettings every frame for efficiency,
+	// primarily because the timestep method is specified as a string (for future expandability
+	// and backward compatibility)
+
+	// which timestep method should we use?
+	String sz = ProjectSettings::get_singleton()->get("physics/common/timestep/method");
+
+	// default
+	method = &ts_jitter_fix;
+
+	if (sz == "Jitter Fix") {
+		method = &ts_jitter_fix;
+	}
+
+	if (sz == "Fixed") {
+		method = &ts_fixed;
+	}
+
+	if (sz == "Semi Fixed") {
+		method = &ts_semi_fixed;
+	}
+
+	// whether to stretch the physics ticks when using global time_scale
+	stretch_ticks = Engine::get_singleton()->get_physics_stretch_ticks();
+}
+
+// determine wall clock step since last iteration
+float MainTimerSync::get_cpu_idle_step() {
+	uint64_t delta = current_cpu_ticks_usec - last_cpu_ticks_usec;
+	last_cpu_ticks_usec = current_cpu_ticks_usec;
+
+	// add delta smoothing here... NYI
+
+	// return as a float in seconds
+	return delta / 1000000.0;
+}
+
+// advance one frame, return timesteps to take
+void MainTimerSync::advance(MainFrameTime &r_mft, int p_iterations_per_second, uint64_t p_cpu_ticks_usec, int p_fixed_fps) {
+
+	// set measured wall clock time
+	current_cpu_ticks_usec = p_cpu_ticks_usec;
+	fixed_fps = p_fixed_fps;
+
+	// safety for divide by zero, might not be needed
+	if (p_iterations_per_second <= 0)
+		p_iterations_per_second = 1;
+
+	// convert p_iterations_per_second to a float because we may need to adjust according to timescale
+	float ticks_per_sec = p_iterations_per_second;
+	float frame_slice_orig = 1.0f / ticks_per_sec;
+
+	// common to all methods
+	float delta;
+	if (fixed_fps <= 0) {
+		delta = get_cpu_idle_step();
+	} else {
+		delta = 1.0f / fixed_fps;
+	}
+
+	// handle global timescale as part of the physics ticking because we may want to adjust the number
+	// of physics ticks
+	float time_scale = Engine::get_singleton()->get_time_scale();
+
+	// if time scaling is active
+	if (time_scale != 1.0f) {
+		// adjust the delta according to the timescale
+		delta *= time_scale;
+
+		// Tick stretching....
+		// If in legacy mode, stretch ticks so that the same number occur in the frame as with no time_scale applied. This will
+		// give unpredictable physics results at different timescales.
+
+		// Alteratively, not stretching ticks will result in more (or less) ticks taking place in the frame according to the timescale.
+		// This will give consistent physics (just sped up or slowed down) but will suffer from judder at low timescales when using
+		// fixed timestep unless interpolation is used.
+		if (stretch_ticks) {
+			// prevent divide by zero
+			// this is just some arbitrary epsilon to prevent divide by zero (can be changed)
+			if (time_scale < 0.0001f)
+				time_scale = 0.0001f;
+
+			ticks_per_sec *= 1.0f / time_scale;
+		}
+	}
+
+	float frame_slice_scaled = 1.0f / ticks_per_sec;
+
+	//  should never happen, but just in case
+	if (!method) {
+		WARN_PRINT("MainTimerSync - Must call init() before calling advance()");
+		method = &ts_jitter_fix;
+	}
+
+	// use the currently selected method to do the timestepping
+	method->advance(r_mft, delta, frame_slice_scaled, ticks_per_sec);
+
+	// limit the number of physics steps to prevent runaway physics
+	static const int max_physics_steps = 8;
+	if (fixed_fps == -1 && r_mft.physics_steps > max_physics_steps) {
+		// this must use the SCALED frame_slice, because at this stage number of ticks is
+		// dependent on the scaled frame_slice (as the overall delta is also scaled)
+		r_mft.scaled_frame_delta -= (r_mft.physics_steps - max_physics_steps) * frame_slice_scaled;
+		r_mft.physics_steps = max_physics_steps;
+	}
+
+	// return the actual used physics step delta, because this
+	// may have changed because of time_scale
+	if (stretch_ticks) {
+		r_mft.physics_fixed_step_delta = frame_slice_scaled;
+	} else {
+		// retain original tick delta (e.g. deterministic bullet time)
+		r_mft.physics_fixed_step_delta = frame_slice_orig;
+
+		// variable time
+		if (r_mft.physics_variable_step) {
+			// in this special case, the variable step delta is stored as a fraction of the SCALED frame slice,
+			// so needs to have this scale removed and rescaled to the original frame slice
+
+			// fraction through the whole tick the variable tick is
+			float f = r_mft.physics_variable_step_delta / frame_slice_scaled;
+
+			// rescale to match the original tick size
+			r_mft.physics_variable_step_delta = f * frame_slice_orig;
+		}
+	}
+}
+
+/////////////////////////////////////////////////////////////////
+
+// advance one frame, return timesteps to take
+void MainTimerSync::Timestep_JitterFix::advance(MainFrameTime &r_mft, float p_idle_step, float p_frame_slice, float p_iterations_per_second) {
+	// calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
+
+	// compensate for last deficit
+	p_idle_step += time_deficit;
+
+	advance_core(r_mft, p_frame_slice, p_iterations_per_second, p_idle_step);
+
+	// we will do some clamping on r_mft.frame_delta and need to sync those changes to time_accum,
+	// that's easiest if we just remember their fixed difference now
+	const double idle_minus_accum = r_mft.scaled_frame_delta - time_accum;
+
+	// first, least important clamping: keep r_mft.frame_delta consistent with typical_physics_steps.
+	// this smoothes out the idle steps and culls small but quick variations.
+	{
+		float min_average_physics_steps, max_average_physics_steps;
+		int consistent_steps = get_average_physics_steps(min_average_physics_steps, max_average_physics_steps);
+		if (consistent_steps > 3) {
+			r_mft.clamp_frame_delta(min_average_physics_steps * p_frame_slice, max_average_physics_steps * p_frame_slice);
+		}
+	}
+
+	// second clamping: keep abs(time_deficit) < jitter_fix * frame_slise
+	float max_clock_deviation = get_physics_jitter_fix() * p_frame_slice;
+	r_mft.clamp_frame_delta(p_idle_step - max_clock_deviation, p_idle_step + max_clock_deviation);
+
+	// last clamping: make sure time_accum is between 0 and p_frame_slice for consistency between physics and idle
+	r_mft.clamp_frame_delta(idle_minus_accum, idle_minus_accum + p_frame_slice);
+
+	// restore time_accum
+	time_accum = r_mft.scaled_frame_delta - idle_minus_accum;
+
+	// track deficit
+	time_deficit = p_idle_step - r_mft.scaled_frame_delta;
+
+	// we will try and work out what is the interpolation fraction
+	// note this is assuming jitter fix is completely turned off when set to 0.0. Is it?
+	r_mft.interpolation_fraction = time_accum / (1.0f / p_iterations_per_second);
+}
+
+MainTimerSync::Timestep_JitterFix::Timestep_JitterFix() :
+		time_accum(0),
+		time_deficit(0) {
+	for (int i = CONTROL_STEPS - 1; i >= 0; --i) {
+		typical_physics_steps[i] = i;
+		accumulated_physics_steps[i] = i;
+	}
+}
 
 // returns the fraction of p_frame_slice required for the timer to overshoot
 // before advance_core considers changing the physics_steps return from
 // the typical values as defined by typical_physics_steps
-float MainTimerSync::get_physics_jitter_fix() {
+float MainTimerSync::Timestep_JitterFix::get_physics_jitter_fix() {
 	return Engine::get_singleton()->get_physics_jitter_fix();
 }
 
 // gets our best bet for the average number of physics steps per render frame
 // return value: number of frames back this data is consistent
-int MainTimerSync::get_average_physics_steps(float &p_min, float &p_max) {
+int MainTimerSync::Timestep_JitterFix::get_average_physics_steps(float &p_min, float &p_max) {
 	p_min = typical_physics_steps[0];
 	p_max = p_min + 1;
 
@@ -71,14 +280,12 @@ int MainTimerSync::get_average_physics_steps(float &p_min, float &p_max) {
 }
 
 // advance physics clock by p_idle_step, return appropriate number of steps to simulate
-MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_per_second, float p_idle_step) {
-	MainFrameTime ret;
-
-	ret.idle_step = p_idle_step;
+void MainTimerSync::Timestep_JitterFix::advance_core(MainFrameTime &r_mft, float p_frame_slice, float p_iterations_per_second, float p_idle_step) {
+	r_mft.scaled_frame_delta = p_idle_step;
 
 	// simple determination of number of physics iteration
-	time_accum += ret.idle_step;
-	ret.physics_steps = floor(time_accum * p_iterations_per_second);
+	time_accum += r_mft.scaled_frame_delta;
+	r_mft.physics_steps = floor(time_accum * p_iterations_per_second);
 
 	int min_typical_steps = typical_physics_steps[0];
 	int max_typical_steps = min_typical_steps + 1;
@@ -102,31 +309,31 @@ MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_
 	}
 
 	// try to keep it consistent with previous iterations
-	if (ret.physics_steps < min_typical_steps) {
+	if (r_mft.physics_steps < min_typical_steps) {
 		const int max_possible_steps = floor((time_accum)*p_iterations_per_second + get_physics_jitter_fix());
 		if (max_possible_steps < min_typical_steps) {
-			ret.physics_steps = max_possible_steps;
+			r_mft.physics_steps = max_possible_steps;
 			update_typical = true;
 		} else {
-			ret.physics_steps = min_typical_steps;
+			r_mft.physics_steps = min_typical_steps;
 		}
-	} else if (ret.physics_steps > max_typical_steps) {
+	} else if (r_mft.physics_steps > max_typical_steps) {
 		const int min_possible_steps = floor((time_accum)*p_iterations_per_second - get_physics_jitter_fix());
 		if (min_possible_steps > max_typical_steps) {
-			ret.physics_steps = min_possible_steps;
+			r_mft.physics_steps = min_possible_steps;
 			update_typical = true;
 		} else {
-			ret.physics_steps = max_typical_steps;
+			r_mft.physics_steps = max_typical_steps;
 		}
 	}
 
-	time_accum -= ret.physics_steps * p_frame_slice;
+	time_accum -= r_mft.physics_steps * p_frame_slice;
 
 	// keep track of accumulated step counts
 	for (int i = CONTROL_STEPS - 2; i >= 0; --i) {
-		accumulated_physics_steps[i + 1] = accumulated_physics_steps[i] + ret.physics_steps;
+		accumulated_physics_steps[i + 1] = accumulated_physics_steps[i] + r_mft.physics_steps;
 	}
-	accumulated_physics_steps[0] = ret.physics_steps;
+	accumulated_physics_steps[0] = r_mft.physics_steps;
 
 	if (update_typical) {
 		for (int i = CONTROL_STEPS - 1; i >= 0; --i) {
@@ -137,91 +344,43 @@ MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_
 			}
 		}
 	}
-
-	return ret;
 }
 
-// calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
-MainFrameTime MainTimerSync::advance_checked(float p_frame_slice, int p_iterations_per_second, float p_idle_step) {
-	if (fixed_fps != -1)
-		p_idle_step = 1.0 / fixed_fps;
+/////////////////////////////////////////////////////////////////
 
-	// compensate for last deficit
-	p_idle_step += time_deficit;
+void MainTimerSync::Timestep_SemiFixed::advance(MainFrameTime &r_mft, float p_delta, float p_sec_per_tick, float p_iterations_per_second) {
 
-	MainFrameTime ret = advance_core(p_frame_slice, p_iterations_per_second, p_idle_step);
+	r_mft.scaled_frame_delta = p_delta;
+	float time_available = p_delta;
 
-	// we will do some clamping on ret.idle_step and need to sync those changes to time_accum,
-	// that's easiest if we just remember their fixed difference now
-	const double idle_minus_accum = ret.idle_step - time_accum;
+	r_mft.physics_steps = floor(time_available * p_iterations_per_second);
+	time_available -= r_mft.physics_steps * p_sec_per_tick;
 
-	// first, least important clamping: keep ret.idle_step consistent with typical_physics_steps.
-	// this smoothes out the idle steps and culls small but quick variations.
-	{
-		float min_average_physics_steps, max_average_physics_steps;
-		int consistent_steps = get_average_physics_steps(min_average_physics_steps, max_average_physics_steps);
-		if (consistent_steps > 3) {
-			ret.clamp_idle(min_average_physics_steps * p_frame_slice, max_average_physics_steps * p_frame_slice);
-		}
-	}
+	// if there is more than a certain amount leftover, have an extra physics tick
+	if (time_available <= 0.0f)
+		return;
 
-	// second clamping: keep abs(time_deficit) < jitter_fix * frame_slise
-	float max_clock_deviation = get_physics_jitter_fix() * p_frame_slice;
-	ret.clamp_idle(p_idle_step - max_clock_deviation, p_idle_step + max_clock_deviation);
-
-	// last clamping: make sure time_accum is between 0 and p_frame_slice for consistency between physics and idle
-	ret.clamp_idle(idle_minus_accum, idle_minus_accum + p_frame_slice);
-
-	// restore time_accum
-	time_accum = ret.idle_step - idle_minus_accum;
-
-	// track deficit
-	time_deficit = p_idle_step - ret.idle_step;
-
-	// p_frame_slice is 1.0 / iterations_per_sec
-	// i.e. the time in seconds taken by a physics tick
-	ret.interpolation_fraction = time_accum / p_frame_slice;
-
-	return ret;
+	r_mft.physics_steps += 1;
+	r_mft.physics_variable_step = true;
+	r_mft.physics_variable_step_delta = time_available;
 }
 
-// determine wall clock step since last iteration
-float MainTimerSync::get_cpu_idle_step() {
-	uint64_t cpu_ticks_elapsed = current_cpu_ticks_usec - last_cpu_ticks_usec;
-	last_cpu_ticks_usec = current_cpu_ticks_usec;
+/////////////////////////////////////////////////////////////////
 
-	return cpu_ticks_elapsed / 1000000.0;
+MainTimerSync::Timestep_Fixed::Timestep_Fixed() {
+	time_left_over = 0.0f;
 }
 
-MainTimerSync::MainTimerSync() :
-		last_cpu_ticks_usec(0),
-		current_cpu_ticks_usec(0),
-		time_accum(0),
-		time_deficit(0),
-		fixed_fps(0) {
-	for (int i = CONTROL_STEPS - 1; i >= 0; --i) {
-		typical_physics_steps[i] = i;
-		accumulated_physics_steps[i] = i;
-	}
-}
+// Simple reference implementation of fixed timestep
+void MainTimerSync::Timestep_Fixed::advance(MainFrameTime &r_mft, float p_delta, float p_sec_per_tick, float p_iterations_per_second) {
 
-// start the clock
-void MainTimerSync::init(uint64_t p_cpu_ticks_usec) {
-	current_cpu_ticks_usec = last_cpu_ticks_usec = p_cpu_ticks_usec;
-}
+	r_mft.scaled_frame_delta = p_delta;
 
-// set measured wall clock time
-void MainTimerSync::set_cpu_ticks_usec(uint64_t p_cpu_ticks_usec) {
-	current_cpu_ticks_usec = p_cpu_ticks_usec;
-}
+	float time_available = time_left_over + p_delta;
 
-void MainTimerSync::set_fixed_fps(int p_fixed_fps) {
-	fixed_fps = p_fixed_fps;
-}
+	r_mft.physics_steps = floor(time_available * p_iterations_per_second);
 
-// advance one frame, return timesteps to take
-MainFrameTime MainTimerSync::advance(float p_frame_slice, int p_iterations_per_second) {
-	float cpu_idle_step = get_cpu_idle_step();
+	time_left_over = time_available - (r_mft.physics_steps * p_sec_per_tick);
 
-	return advance_checked(p_frame_slice, p_iterations_per_second, cpu_idle_step);
+	r_mft.interpolation_fraction = time_left_over / p_sec_per_tick;
 }

--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -33,54 +33,115 @@
 
 #include "core/engine.h"
 
+// Used to return timing information to main::iteration
 struct MainFrameTime {
-	float idle_step; // time to advance idles for (argument to process())
-	int physics_steps; // number of times to iterate the physics engine
-	float interpolation_fraction; // fraction through the current physics tick
+	MainFrameTime();
 
-	void clamp_idle(float min_idle_step, float max_idle_step);
+	// time to advance idles for (argument to process())
+	// timescale has been applied
+	float scaled_frame_delta;
+
+	// number of times to iterate the physics engine
+	int physics_steps;
+	// delta to pass to _physics_process (except for variable steps, see below)
+	float physics_fixed_step_delta;
+
+	// for semi fixed and frame based methods,
+	// the last physics step can optionally have  variable delta to pass
+	// to physics engine
+	bool physics_variable_step; // is the last physics step variable?
+	float physics_variable_step_delta; // if so, what is the delta on this variable step
+
+	// logical fraction through the current physics tick at the time of the frame
+	// useful for fixed timestep interpolation
+	float interpolation_fraction;
+
+	void clamp_frame_delta(float p_min, float p_max);
 };
 
+/////////////////////////////////////////////////////////
+
 class MainTimerSync {
+
+	// we include the timestep methods as nested classes
+	// as they do not need to be visible outside MainTimerSync
+	class Timestep_Base {
+	public:
+		virtual void advance(MainFrameTime &r_mft, float p_delta, float p_sec_per_tick, float p_iterations_per_second) = 0;
+		virtual ~Timestep_Base() {}
+	};
+
+	class Timestep_JitterFix : public Timestep_Base {
+		// logical game time since last physics timestep
+		float time_accum;
+
+		// current difference between wall clock time and reported sum of idle_steps
+		float time_deficit;
+
+		// number of frames back for keeping accumulated physics steps roughly constant.
+		// value of 12 chosen because that is what is required to make 144 Hz monitors
+		// behave well with 60 Hz physics updates. The only worse commonly available refresh
+		// would be 85, requiring CONTROL_STEPS = 17.
+		static const int CONTROL_STEPS = 12;
+
+		// sum of physics steps done over the last (i+1) frames
+		int accumulated_physics_steps[CONTROL_STEPS];
+
+		// typical value for accumulated_physics_steps[i] is either this or this plus one
+		int typical_physics_steps[CONTROL_STEPS];
+
+	protected:
+		// returns the fraction of p_frame_slice required for the timer to overshoot
+		// before advance_core considers changing the physics_steps return from
+		// the typical values as defined by typical_physics_steps
+		float get_physics_jitter_fix();
+
+		// gets our best bet for the average number of physics steps per render frame
+		// return value: number of frames back this data is consistent
+		int get_average_physics_steps(float &p_min, float &p_max);
+
+		// advance physics clock by p_idle_step, return appropriate number of steps to simulate
+		void advance_core(MainFrameTime &r_mft, float p_frame_slice, float p_iterations_per_second, float p_idle_step);
+
+	public:
+		Timestep_JitterFix();
+
+		// advance one frame, return timesteps to take
+		virtual void advance(MainFrameTime &r_mft, float p_idle_step, float p_frame_slice, float p_iterations_per_second);
+	};
+
+	class Timestep_SemiFixed : public Timestep_Base {
+	public:
+		// advance one frame, return timesteps to take
+		virtual void advance(MainFrameTime &r_mft, float p_delta, float p_sec_per_tick, float p_iterations_per_second);
+	};
+
+	// reference fixed timestep implementation
+	class Timestep_Fixed : public Timestep_Base {
+		float time_left_over;
+
+	public:
+		Timestep_Fixed();
+
+		// advance one frame, return timesteps to take
+		virtual void advance(MainFrameTime &r_mft, float p_delta, float p_sec_per_tick, float p_iterations_per_second);
+	};
+
 	// wall clock time measured on the main thread
 	uint64_t last_cpu_ticks_usec;
 	uint64_t current_cpu_ticks_usec;
 
-	// logical game time since last physics timestep
-	float time_accum;
-
-	// current difference between wall clock time and reported sum of idle_steps
-	float time_deficit;
-
-	// number of frames back for keeping accumulated physics steps roughly constant.
-	// value of 12 chosen because that is what is required to make 144 Hz monitors
-	// behave well with 60 Hz physics updates. The only worse commonly available refresh
-	// would be 85, requiring CONTROL_STEPS = 17.
-	static const int CONTROL_STEPS = 12;
-
-	// sum of physics steps done over the last (i+1) frames
-	int accumulated_physics_steps[CONTROL_STEPS];
-
-	// typical value for accumulated_physics_steps[i] is either this or this plus one
-	int typical_physics_steps[CONTROL_STEPS];
-
 	int fixed_fps;
 
-protected:
-	// returns the fraction of p_frame_slice required for the timer to overshoot
-	// before advance_core considers changing the physics_steps return from
-	// the typical values as defined by typical_physics_steps
-	float get_physics_jitter_fix();
+	// whether to stretch the physics ticks when using global time_scale
+	bool stretch_ticks;
 
-	// gets our best bet for the average number of physics steps per render frame
-	// return value: number of frames back this data is consistent
-	int get_average_physics_steps(float &p_min, float &p_max);
+	// the currently selected timestep method
+	Timestep_Base *method;
 
-	// advance physics clock by p_idle_step, return appropriate number of steps to simulate
-	MainFrameTime advance_core(float p_frame_slice, int p_iterations_per_second, float p_idle_step);
-
-	// calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
-	MainFrameTime advance_checked(float p_frame_slice, int p_iterations_per_second, float p_idle_step);
+	Timestep_JitterFix ts_jitter_fix;
+	Timestep_Fixed ts_fixed;
+	Timestep_SemiFixed ts_semi_fixed;
 
 	// determine wall clock step since last iteration
 	float get_cpu_idle_step();
@@ -90,13 +151,9 @@ public:
 
 	// start the clock
 	void init(uint64_t p_cpu_ticks_usec);
-	// set measured wall clock time
-	void set_cpu_ticks_usec(uint64_t p_cpu_ticks_usec);
-	//set fixed fps
-	void set_fixed_fps(int p_fixed_fps);
 
-	// advance one frame, return timesteps to take
-	MainFrameTime advance(float p_frame_slice, int p_iterations_per_second);
+	// advance one frame, return timesteps to take in r_mft
+	void advance(MainFrameTime &r_mft, int p_iterations_per_second, uint64_t p_cpu_ticks_usec, int p_fixed_fps);
 };
 
 #endif // MAIN_TIMER_SYNC_H


### PR DESCRIPTION
Fixes #24769
Fixes #24334

The main change in this PR is adding the option in project settings->physics to choose between the old fixed timestep and a new path for semi-fixed timestep. With semi-fixed timestep users can either choose a high physics fps and get the benefit of matching between physics and frame times, or low physics fps and have physics effectively driven by frame deltas.

There is also a minor refactor to the main::iteration function, notably moving the physics tick into a separate function, as well as a major refactor to main_timer_sync, separating the common components of timing (timescaling, limiting max physics ticks) from the details of the timestep functionality themselves, which are separated into 2 classes, MainTimerSync_JitterFix (the old fixed timestep) and MainTimerSync_SemiFixed.

There is also an added option to allow the existing global time_scale to change the speed of the game without affecting the physics tick rate (i.e. giving consistent physics at different timescales).