### PR TITLE
Remove OPCODE_LINE from GDScript

### DIFF
--- a/core/script_debugger_local.cpp
+++ b/core/script_debugger_local.cpp
@@ -178,15 +178,17 @@ void ScriptDebuggerLocal::debug(ScriptLanguage *p_script, bool p_can_continue) {
 
 			if (line.get_slice_count(" ") <= 1) {
 
-				const Map<int, Set<StringName> > &breakpoints = get_breakpoints();
+				const Map<StringName, Set<int> > &breakpoints = get_breakpoints();
 				if (breakpoints.size() == 0) {
 					print_line("No Breakpoints.");
 					continue;
 				}
 
 				print_line("Breakpoint(s): " + itos(breakpoints.size()));
-				for (Map<int, Set<StringName> >::Element *E = breakpoints.front(); E; E = E->next()) {
-					print_line("\t" + String(E->value().front()->get()) + ":" + itos(E->key()));
+				for (Map<StringName, Set<int> >::Element *E = breakpoints.front(); E; E = E->next()) {
+					for (Set<int>::Element *F = E->value().front(); F; F = F->next()) {
+						print_line("\t" + String(E->key()) + ":" + itos(F->get()));
+					}
 				}
 
 			} else {

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -326,29 +326,25 @@ int ScriptDebugger::get_depth() const {
 
 void ScriptDebugger::insert_breakpoint(int p_line, const StringName &p_source) {
 
-	if (!breakpoints.has(p_line))
-		breakpoints[p_line] = Set<StringName>();
-	breakpoints[p_line].insert(p_source);
+	if (!breakpoints.has(p_source))
+		breakpoints[p_source] = Set<int>();
+	breakpoints[p_source].insert(p_line);
 }
 
 void ScriptDebugger::remove_breakpoint(int p_line, const StringName &p_source) {
 
-	if (!breakpoints.has(p_line))
+	if (!breakpoints.has(p_source))
 		return;
 
-	breakpoints[p_line].erase(p_source);
-	if (breakpoints[p_line].size() == 0)
-		breakpoints.erase(p_line);
+	breakpoints[p_source].erase(p_line);
+	if (breakpoints[p_source].size() == 0)
+		breakpoints.erase(p_source);
 }
 bool ScriptDebugger::is_breakpoint(int p_line, const StringName &p_source) const {
 
-	if (!breakpoints.has(p_line))
+	if (!breakpoints.has(p_source))
 		return false;
-	return breakpoints[p_line].has(p_source);
-}
-bool ScriptDebugger::is_breakpoint_line(int p_line) const {
-
-	return breakpoints.has(p_line);
+	return breakpoints[p_source].has(p_line);
 }
 
 String ScriptDebugger::breakpoint_find_source(const String &p_source) const {

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -420,7 +420,7 @@ class ScriptDebugger {
 	int depth;
 
 	static ScriptDebugger *singleton;
-	Map<int, Set<StringName> > breakpoints;
+	Map<StringName, Set<int> > breakpoints;
 
 	ScriptLanguage *break_lang;
 
@@ -461,9 +461,8 @@ public:
 	void insert_breakpoint(int p_line, const StringName &p_source);
 	void remove_breakpoint(int p_line, const StringName &p_source);
 	bool is_breakpoint(int p_line, const StringName &p_source) const;
-	bool is_breakpoint_line(int p_line) const;
 	void clear_breakpoints();
-	const Map<int, Set<StringName> > &get_breakpoints() const { return breakpoints; }
+	const Map<StringName, Set<int> > &get_breakpoints() const { return breakpoints; }
 
 	virtual void debug(ScriptLanguage *p_script, bool p_can_continue = true) = 0;
 	virtual void idle_poll();

--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -885,15 +885,6 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 5;
 
 				} break;
-				case GDScriptFunction::OPCODE_LINE: {
-
-					int line = code[ip + 1] - 1;
-					if (line >= 0 && line < p_code.size())
-						txt = "\n" + itos(line + 1) + ": " + p_code[line] + "\n";
-					else
-						txt = "";
-					incr += 2;
-				} break;
 				case GDScriptFunction::OPCODE_END: {
 
 					txt += " end";

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -328,7 +328,6 @@ class GDScriptLanguage : public ScriptLanguage {
 		GDScriptFunction *function;
 		GDScriptInstance *instance;
 		int *ip;
-		int *line;
 	};
 
 	int _debug_parse_err_line;
@@ -359,7 +358,7 @@ public:
 	bool debug_break(const String &p_error, bool p_allow_continue = true);
 	bool debug_break_parse(const String &p_file, int p_line, const String &p_error);
 
-	_FORCE_INLINE_ void enter_function(GDScriptInstance *p_instance, GDScriptFunction *p_function, Variant *p_stack, int *p_ip, int *p_line) {
+	_FORCE_INLINE_ void enter_function(GDScriptInstance *p_instance, GDScriptFunction *p_function, Variant *p_stack, int *p_ip) {
 
 		if (Thread::get_main_id() != Thread::get_caller_id())
 			return; //no support for other threads than main for now
@@ -378,7 +377,6 @@ public:
 		_call_stack[_debug_call_stack_pos].instance = p_instance;
 		_call_stack[_debug_call_stack_pos].function = p_function;
 		_call_stack[_debug_call_stack_pos].ip = p_ip;
-		_call_stack[_debug_call_stack_pos].line = p_line;
 		_debug_call_stack_pos++;
 	}
 
@@ -407,7 +405,7 @@ public:
 		Vector<StackInfo> csi;
 		csi.resize(_debug_call_stack_pos);
 		for (int i = 0; i < _debug_call_stack_pos; i++) {
-			csi.write[_debug_call_stack_pos - i - 1].line = _call_stack[i].line ? *_call_stack[i].line : 0;
+			csi.write[_debug_call_stack_pos - i - 1].line = _call_stack[i].ip ? _call_stack[i].function->_get_ip_line(*_call_stack[i].ip) : 0;
 			if (_call_stack[i].function) {
 				csi.write[_debug_call_stack_pos - i - 1].func = _call_stack[i].function->get_name();
 				csi.write[_debug_call_stack_pos - i - 1].file = _call_stack[i].function->get_script()->get_path();

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1273,12 +1273,11 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 
 		switch (s->type) {
 			case GDScriptParser::Node::TYPE_NEWLINE: {
-#ifdef DEBUG_ENABLED
 				const GDScriptParser::NewLineNode *nl = static_cast<const GDScriptParser::NewLineNode *>(s);
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_LINE);
-				codegen.opcodes.push_back(nl->line);
+				for (int j = 0; j < nl->line - codegen.current_line; j++) {
+					codegen.line_indices.push_back(codegen.opcodes.size());
+				}
 				codegen.current_line = nl->line;
-#endif
 			} break;
 			case GDScriptParser::Node::TYPE_CONTROL_FLOW: {
 				// try subblocks
@@ -1740,6 +1739,18 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 
 		gdfunc->_code_ptr = NULL;
 		gdfunc->_code_size = 0;
+	}
+
+	if (codegen.line_indices.size()) {
+
+		gdfunc->line_indices = codegen.line_indices;
+		gdfunc->_line_indices_ptr = &gdfunc->line_indices[0];
+		gdfunc->_line_indices_size = codegen.line_indices.size();
+
+	} else {
+
+		gdfunc->_line_indices_ptr = NULL;
+		gdfunc->_line_indices_size = 0;
 	}
 
 	if (defarg_addr.size()) {

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -122,6 +122,7 @@ class GDScriptCompiler {
 		}
 
 		Vector<int> opcodes;
+		Vector<int> line_indices;
 		void alloc_stack(int p_level) {
 			if (p_level >= stack_max) stack_max = p_level + 1;
 		}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -265,7 +265,7 @@ int GDScriptLanguage::debug_get_stack_level_line(int p_level) const {
 
 	int l = _debug_call_stack_pos - p_level - 1;
 
-	return *(_call_stack[l].line);
+	return _call_stack[l].function->_get_ip_line(*_call_stack[l].ip);
 }
 String GDScriptLanguage::debug_get_stack_level_function(int p_level) const {
 
@@ -297,7 +297,7 @@ void GDScriptLanguage::debug_get_stack_level_locals(int p_level, List<String> *p
 
 	List<Pair<StringName, int> > locals;
 
-	f->debug_get_stack_member_state(*_call_stack[l].line, &locals);
+	f->debug_get_stack_member_state(_call_stack[l].function->_get_ip_line(*_call_stack[l].ip), &locals);
 	for (List<Pair<StringName, int> >::Element *E = locals.front(); E; E = E->next()) {
 
 		p_locals->push_back(E->get().first);

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -185,7 +185,6 @@ public:
 		OPCODE_ITERATE,
 		OPCODE_ASSERT,
 		OPCODE_BREAKPOINT,
-		OPCODE_LINE,
 		OPCODE_END
 	};
 
@@ -231,6 +230,8 @@ private:
 	int _default_arg_count;
 	const int *_code_ptr;
 	int _code_size;
+	const int *_line_indices_ptr;
+	int _line_indices_size;
 	int _argument_count;
 	int _stack_size;
 	int _call_size;
@@ -248,6 +249,7 @@ private:
 #endif
 	Vector<int> default_arguments;
 	Vector<int> code;
+	Vector<int> line_indices;
 	Vector<GDScriptDataType> argument_types;
 	GDScriptDataType return_type;
 
@@ -259,8 +261,25 @@ private:
 
 	_FORCE_INLINE_ Variant *_get_variant(int p_address, GDScriptInstance *p_instance, GDScript *p_script, Variant &self, Variant *p_stack, String &r_error) const;
 	_FORCE_INLINE_ String _get_call_error(const Variant::CallError &p_err, const String &p_where, const Variant **argptrs) const;
+	_FORCE_INLINE_ int _get_next_breakpoint(const int &p_ip) const;
 
 	friend class GDScriptLanguage;
+
+	_FORCE_INLINE_ int _get_ip_line(const int &p_ip) const {
+		int lo = 0;
+		int hi = _line_indices_size;
+
+		while (lo < hi) {
+			const int mid = (lo + hi) / 2;
+			if (_line_indices_ptr[mid] <= p_ip) {
+				lo = mid + 1;
+			} else {
+				hi = mid;
+			}
+		}
+
+		return _initial_line + lo;
+	}
 
 	SelfList<GDScriptFunction> function_list;
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
Additionally, refactor `ScriptDebugger::breakpoints` a bit. Also, make `OPCODE` macros more similar between the switch and jump table versions.

I think my implementation still has a few bugs and rough spots, but I'm happy to announce that it works without crashing or getting into endless loops just fine.

This PR is mostly a PoC of something I was thinking of for some time now, but if deemed useful, I could try to fix the remaining issues (most of which are one-by-off errors here and there).