### PR TITLE
Fixed crash when making subresource unique in inspector dock

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1574,6 +1574,7 @@ void EditorNode::push_item(Object *p_object, const String &p_property, bool p_in
 		get_inspector()->edit(NULL);
 		node_dock->set_node(NULL);
 		scene_tree_dock->set_selected(NULL);
+		inspector_dock->update(NULL);
 		return;
 	}
 
@@ -1662,9 +1663,10 @@ void EditorNode::_edit_current() {
 
 		Resource *current_res = Object::cast_to<Resource>(current_obj);
 		ERR_FAIL_COND(!current_res);
-		scene_tree_dock->set_selected(NULL);
 		get_inspector()->edit(current_res);
+		scene_tree_dock->set_selected(NULL);
 		node_dock->set_node(NULL);
+		inspector_dock->update(NULL);
 		EditorNode::get_singleton()->get_import_dock()->set_edit_path(current_res->get_path());
 
 		int subr_idx = current_res->get_path().find("::");
@@ -1691,9 +1693,11 @@ void EditorNode::_edit_current() {
 		if (current_node->is_inside_tree()) {
 			node_dock->set_node(current_node);
 			scene_tree_dock->set_selected(current_node);
+			inspector_dock->update(current_node);
 		} else {
 			node_dock->set_node(NULL);
 			scene_tree_dock->set_selected(NULL);
+			inspector_dock->update(NULL);
 		}
 
 		if (get_edited_scene() && get_edited_scene()->get_filename() != String()) {
@@ -1713,6 +1717,8 @@ void EditorNode::_edit_current() {
 
 		get_inspector()->edit(current_obj);
 		node_dock->set_node(NULL);
+		scene_tree_dock->set_selected(NULL);
+		inspector_dock->update(NULL);
 	}
 
 	inspector_dock->set_warning(editable_warning);


### PR DESCRIPTION
The problem was that when a Node is deleted, the InspectorDock was left out from the update.
A possible improvement would be to refactor this into its own function as this action is performed several time. 

Fixes #30160

Edit : Don't think its possible to refactor them into a function as many of the updates differently depending on the type of Node being selected etc etc.

Edit: I would like to point out several other places where such update are performed. I am not entirely familiar with the editor and as such cannot make a judgement on whether or not they all do the same thing.

1. https://github.com/godotengine/godot/blob/ad0d87b4dddfe6b9e88510dd526bcd4028ba3030/editor/editor_node.cpp#L1573-L1578
2. https://github.com/godotengine/godot/blob/ad0d87b4dddfe6b9e88510dd526bcd4028ba3030/editor/editor_node.cpp#L1664-L1667
3. https://github.com/godotengine/godot/blob/ad0d87b4dddfe6b9e88510dd526bcd4028ba3030/editor/editor_node.cpp#L1690-L1697
4. https://github.com/godotengine/godot/blob/ad0d87b4dddfe6b9e88510dd526bcd4028ba3030/editor/editor_node.cpp#L1714-L1715

Notice that all of them (except for one in my commit) are not updating `inspector_dock`.

Edit: I forgot to mention that this commit will cause the screwdriver-icon to access the button to make subresource unique to be disabled. I don't even know what it used to do given that "nothing" is selected, but is definitely a UI change.