### PR TITLE
DirAccess: Drop compat get_next(bool *is_dir) which was hidden

### DIFF
--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -179,14 +179,6 @@ Error DirAccess::make_dir_recursive(String p_dir) {
 	return OK;
 }
 
-String DirAccess::get_next(bool *p_is_dir) {
-
-	String next = get_next();
-	if (p_is_dir)
-		*p_is_dir = current_is_dir();
-	return next;
-}
-
 String DirAccess::fix_path(String p_path) const {
 
 	switch (_access_type) {

--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -71,7 +71,6 @@ protected:
 
 public:
 	virtual Error list_dir_begin() = 0; ///< This starts dir listing
-	virtual String get_next(bool *p_is_dir); // compatibility
 	virtual String get_next() = 0;
 	virtual bool current_is_dir() const = 0;
 	virtual bool current_is_hidden() const = 0;

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -741,10 +741,9 @@ Error DocData::load_classes(const String &p_dir) {
 
 	da->list_dir_begin();
 	String path;
-	bool isdir;
-	path = da->get_next(&isdir);
+	path = da->get_next();
 	while (path != String()) {
-		if (!isdir && path.ends_with("xml")) {
+		if (!da->current_is_dir() && path.ends_with("xml")) {
 			Ref<XMLParser> parser = memnew(XMLParser);
 			Error err2 = parser->open(p_dir.plus_file(path));
 			if (err2)
@@ -752,7 +751,7 @@ Error DocData::load_classes(const String &p_dir) {
 
 			_load(parser);
 		}
-		path = da->get_next(&isdir);
+		path = da->get_next();
 	}
 
 	da->list_dir_end();
@@ -771,13 +770,12 @@ Error DocData::erase_classes(const String &p_dir) {
 
 	da->list_dir_begin();
 	String path;
-	bool isdir;
-	path = da->get_next(&isdir);
+	path = da->get_next();
 	while (path != String()) {
-		if (!isdir && path.ends_with("xml")) {
+		if (!da->current_is_dir() && path.ends_with("xml")) {
 			to_erase.push_back(path);
 		}
-		path = da->get_next(&isdir);
+		path = da->get_next();
 	}
 	da->list_dir_end();
 

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "editor_file_dialog.h"
+
 #include "core/os/file_access.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
@@ -731,19 +732,15 @@ void EditorFileDialog::update_file_list() {
 	List<String> files;
 	List<String> dirs;
 
-	bool is_dir;
-	bool is_hidden;
 	String item;
 
-	while ((item = dir_access->get_next(&is_dir)) != "") {
+	while ((item = dir_access->get_next()) != "") {
 
 		if (item == "." || item == "..")
 			continue;
 
-		is_hidden = dir_access->current_is_hidden();
-
-		if (show_hidden_files || !is_hidden) {
-			if (!is_dir)
+		if (show_hidden_files || !dir_access->current_is_hidden()) {
+			if (!dir_access->current_is_dir())
 				files.push_back(item);
 			else
 				dirs.push_back(item);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -673,12 +673,11 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, DirAccess
 	da->list_dir_begin();
 	while (true) {
 
-		bool isdir;
-		String f = da->get_next(&isdir);
+		String f = da->get_next();
 		if (f == "")
 			break;
 
-		if (isdir) {
+		if (da->current_is_dir()) {
 
 			if (f.begins_with(".")) //ignore hidden and . / ..
 				continue;
@@ -870,12 +869,11 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, const 
 		da->list_dir_begin();
 		while (true) {
 
-			bool isdir;
-			String f = da->get_next(&isdir);
+			String f = da->get_next();
 			if (f == "")
 				break;
 
-			if (isdir) {
+			if (da->current_is_dir()) {
 
 				if (f.begins_with(".")) //ignore hidden and . / ..
 					continue;

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -52,18 +52,16 @@ void ExportTemplateManager::_update_template_list() {
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	Error err = d->change_dir(EditorSettings::get_singleton()->get_templates_dir());
 
-	d->list_dir_begin();
 	Set<String> templates;
-
+	d->list_dir_begin();
 	if (err == OK) {
 
-		bool isdir;
-		String c = d->get_next(&isdir);
+		String c = d->get_next();
 		while (c != String()) {
-			if (isdir && !c.begins_with(".")) {
+			if (d->current_is_dir() && !c.begins_with(".")) {
 				templates.insert(c);
 			}
-			c = d->get_next(&isdir);
+			c = d->get_next();
 		}
 	}
 	d->list_dir_end();
@@ -154,18 +152,14 @@ void ExportTemplateManager::_uninstall_template_confirm() {
 	ERR_FAIL_COND(err != OK);
 
 	Vector<String> files;
-
 	d->list_dir_begin();
-
-	bool isdir;
-	String c = d->get_next(&isdir);
+	String c = d->get_next();
 	while (c != String()) {
-		if (!isdir) {
+		if (!d->current_is_dir()) {
 			files.push_back(c);
 		}
-		c = d->get_next(&isdir);
+		c = d->get_next();
 	}
-
 	d->list_dir_end();
 
 	for (int i = 0; i < files.size(); i++) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -403,11 +403,10 @@ void FileDialog::update_file_list() {
 	List<String> files;
 	List<String> dirs;
 
-	bool is_dir;
 	bool is_hidden;
 	String item;
 
-	while ((item = dir_access->get_next(&is_dir)) != "") {
+	while ((item = dir_access->get_next()) != "") {
 
 		if (item == "." || item == "..")
 			continue;
@@ -415,7 +414,7 @@ void FileDialog::update_file_list() {
 		is_hidden = dir_access->current_is_hidden();
 
 		if (show_hidden_files || !is_hidden) {
-			if (!is_dir)
+			if (!dir_access->current_is_dir())
 				files.push_back(item);
 			else
 				dirs.push_back(item);


### PR DESCRIPTION
Fixes this warning:
```
./core/os/dir_access.h:74:17: warning: 'virtual String DirAccess::get_next(bool*)' was hidden [-Woverloaded-virtual]
```

Part of #30790.