### PR TITLE
Make KinematicBody docs consistent regarding `test_only` argument

### DIFF
--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -76,6 +76,7 @@
 			</argument>
 			<description>
 				Moves the body along the vector [code]rel_vec[/code]. The body will stop if it collides. Returns a [KinematicCollision2D], which contains information about the collision.
+				If [code]test_only[/code] is [code]true[/code], the body does not move but the would-be collision information is given.
 			</description>
 		</method>
 		<method name="move_and_slide">


### PR DESCRIPTION
This simply makes the `move_and_collide` method descriptions in both 2D and 3D to be in sync.

Closes #30808.