### PR TITLE
Mono: Don't try to update project assemblies from project manager

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -657,7 +657,14 @@ bool GDMono::_load_core_api_assembly() {
 
 #ifdef TOOLS_ENABLED
 	// For the editor and the editor player we want to load it from a specific path to make sure we can keep it up to date
-	String assembly_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(CORE_API_ASSEMBLY_NAME ".dll");
+
+	// If running the project manager, load it from the prebuilt API directory
+	String assembly_dir = !Main::is_project_manager() ?
+								  GodotSharpDirs::get_res_assemblies_dir() :
+								  GodotSharpDirs::get_data_editor_prebuilt_api_dir().plus_file("Debug");
+
+	String assembly_path = assembly_dir.plus_file(CORE_API_ASSEMBLY_NAME ".dll");
+
 	bool success = FileAccess::exists(assembly_path) &&
 				   load_assembly_from(CORE_API_ASSEMBLY_NAME, assembly_path, &core_api_assembly);
 #else
@@ -688,7 +695,14 @@ bool GDMono::_load_editor_api_assembly() {
 		return true;
 
 	// For the editor and the editor player we want to load it from a specific path to make sure we can keep it up to date
-	String assembly_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(EDITOR_API_ASSEMBLY_NAME ".dll");
+
+	// If running the project manager, load it from the prebuilt API directory
+	String assembly_dir = !Main::is_project_manager() ?
+								  GodotSharpDirs::get_res_assemblies_dir() :
+								  GodotSharpDirs::get_data_editor_prebuilt_api_dir().plus_file("Debug");
+
+	String assembly_path = assembly_dir.plus_file(EDITOR_API_ASSEMBLY_NAME ".dll");
+
 	bool success = FileAccess::exists(assembly_path) &&
 				   load_assembly_from(EDITOR_API_ASSEMBLY_NAME, assembly_path, &editor_api_assembly);
 
@@ -739,6 +753,12 @@ void GDMono::_load_api_assemblies() {
 #ifdef TOOLS_ENABLED
 		// The API assemblies are out of sync. Fine, try one more time, but this time
 		// update them from the prebuilt assemblies directory before trying to load them.
+
+		// Shouldn't happen. The project manager loads the prebuilt API assemblies
+		if (Main::is_project_manager()) {
+			ERR_EXPLAIN("Failed to load one of the prebuilt API assemblies");
+			CRASH_NOW();
+		}
 
 		// 1. Unload the scripts domain
 		if (_unload_scripts_domain() != OK) {


### PR DESCRIPTION
Previously, when running the project manager, we would try to load the API assemblies from the project and fail because we were not editing any project. This would make us try to copy the prebuilt API assemblies to the project. Since there is no project, it would try to copy them to the executable location. This would fail if Godot doesn't have permissions to write to that location.
This commit fixes that by instead trying to load the prebuilt API assemblies in the first place, if running the project manager.

Should fix #28394
