### PR TITLE
Fix memory leaks with SyntaxHighlighters

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2088,16 +2088,18 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 	}
 	ERR_FAIL_COND_V(!se, false);
 
-	bool highlighter_set = false;
-	for (int i = 0; i < syntax_highlighters_func_count; i++) {
-		SyntaxHighlighter *highlighter = syntax_highlighters_funcs[i]();
-		se->add_syntax_highlighter(highlighter);
+	if (p_resource->get_class_name() != StringName("VisualScript")) {
+		bool highlighter_set = false;
+		for (int i = 0; i < syntax_highlighters_func_count; i++) {
+			SyntaxHighlighter *highlighter = syntax_highlighters_funcs[i]();
+			se->add_syntax_highlighter(highlighter);
 
-		if (script != NULL && !highlighter_set) {
-			List<String> languages = highlighter->get_supported_languages();
-			if (languages.find(script->get_language()->get_name())) {
-				se->set_syntax_highlighter(highlighter);
-				highlighter_set = true;
+			if (script != NULL && !highlighter_set) {
+				List<String> languages = highlighter->get_supported_languages();
+				if (languages.find(script->get_language()->get_name())) {
+					se->set_syntax_highlighter(highlighter);
+					highlighter_set = true;
+				}
 			}
 		}
 	}

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1819,6 +1819,15 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor->get_text_edit()->set_drag_forwarding(this);
 }
 
+ScriptTextEditor::~ScriptTextEditor() {
+	for (const Map<String, SyntaxHighlighter *>::Element *E = highlighters.front(); E; E = E->next()) {
+		if (E->get() != NULL) {
+			memdelete(E->get());
+		}
+	}
+	highlighters.clear();
+}
+
 static ScriptEditorBase *create_editor(const RES &p_resource) {
 
 	if (Object::cast_to<Script>(*p_resource)) {

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -231,6 +231,7 @@ public:
 	virtual void validate();
 
 	ScriptTextEditor();
+	~ScriptTextEditor();
 };
 
 #endif // SCRIPT_TEXT_EDITOR_H

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -695,5 +695,14 @@ TextEditor::TextEditor() {
 	code_editor->get_text_edit()->set_drag_forwarding(this);
 }
 
+TextEditor::~TextEditor() {
+	for (const Map<String, SyntaxHighlighter *>::Element *E = highlighters.front(); E; E = E->next()) {
+		if (E->get() != NULL) {
+			memdelete(E->get());
+		}
+	}
+	highlighters.clear();
+}
+
 void TextEditor::validate() {
 }

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -154,6 +154,7 @@ public:
 	static void register_editor();
 
 	TextEditor();
+	~TextEditor();
 };
 
 #endif // TEXT_EDITOR_H


### PR DESCRIPTION
Fixes `SyntaxHighlighter` memory leaks when a script is closed. 

As for `VisualScripts`, `SyntaxHighlighters` are currently unused, therefore rather then allocating then immediately freeing the memory, we no longer create them in the first place.

closes #29500