### PR TITLE
fix getting correct mingw-w64 version

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -617,7 +617,11 @@ def detect_darwin_sdk_path(platform, env):
             raise
 
 def get_compiler_version(env):
-    version = decode_utf8(subprocess.check_output([env['CXX'], '--version']).strip())
+    # Not using this method on clang because it returns 4.2.1 # https://reviews.llvm.org/D56803
+    if using_gcc(env):
+        version = decode_utf8(subprocess.check_output([env['CXX'], '-dumpversion']).strip())
+    else:
+        version = decode_utf8(subprocess.check_output([env['CXX'], '--version']).strip())
     match = re.search('[0-9][0-9.]*', version)
     if match is not None:
         return match.group().split('.')


### PR DESCRIPTION
When checking mingw-w64 version, at least on debian, the regex being used returned 86 because the name of the binary in debian starts with x86_64-w64 so we use the dumpversion option that gcc has. This fixes not compiling because gcc versions < 7 don't have some checks like shadow-local