### PR TITLE
Fix Clearing Inspector for Remote Node

### DIFF
--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -78,6 +78,9 @@ void EditorPath::_about_to_show() {
 }
 
 void EditorPath::update_path() {
+	set_text("");
+	set_tooltip("");
+	set_icon(NULL);
 
 	for (int i = 0; i < history->get_path_size(); i++) {
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1369,7 +1369,7 @@ void ScriptEditorDebugger::stop() {
 	profiler->set_enabled(true);
 
 	inspect_scene_tree->clear();
-	inspector->edit(NULL);
+	EditorNode::get_singleton()->edit_current();
 	EditorNode::get_singleton()->get_pause_button()->set_pressed(false);
 	EditorNode::get_singleton()->get_pause_button()->set_disabled(true);
 	EditorNode::get_singleton()->get_scene_tree_dock()->hide_remote_tree();


### PR DESCRIPTION
Resolves: #30731

When you stop debugging... if you were inspecting a remote node, partial information about the remote node remained in the inspector (e.g. name and warning).

To resolve this, called EditorNode::edit_current() instead of EditorInspector::edit(NULL), which will call all the methods required using "NULL" if the current selected object is NULL.

In EditorPath::update_path() if the selected object is NULL, it does not update the path to reflect this change, basically does nothing. To fix this, we nullify everything, before the history loop.