### PR TITLE
Allow setting buffer size of WebRTCDataChannel

### DIFF
--- a/modules/webrtc/register_types.cpp
+++ b/modules/webrtc/register_types.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "register_types.h"
+#include "core/project_settings.h"
 #include "webrtc_data_channel.h"
 #include "webrtc_peer_connection.h"
 
@@ -43,6 +44,12 @@
 #include "webrtc_multiplayer.h"
 
 void register_webrtc_types() {
+#define _SET_HINT(NAME, _VAL_, _MAX_) \
+	GLOBAL_DEF(NAME, _VAL_);          \
+	ProjectSettings::get_singleton()->set_custom_property_info(NAME, PropertyInfo(Variant::INT, NAME, PROPERTY_HINT_RANGE, "2," #_MAX_ ",1,or_greater"));
+
+	_SET_HINT(WRTC_IN_BUF, 64, 4096);
+
 #ifdef JAVASCRIPT_ENABLED
 	WebRTCPeerConnectionJS::make_default();
 #elif defined(WEBRTC_GDNATIVE_ENABLED)

--- a/modules/webrtc/webrtc_data_channel.cpp
+++ b/modules/webrtc/webrtc_data_channel.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "webrtc_data_channel.h"
+#include "core/project_settings.h"
 
 void WebRTCDataChannel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("poll"), &WebRTCDataChannel::poll);
@@ -58,6 +59,7 @@ void WebRTCDataChannel::_bind_methods() {
 }
 
 WebRTCDataChannel::WebRTCDataChannel() {
+	_in_buffer_shift = nearest_shift((int)GLOBAL_GET(WRTC_IN_BUF) - 1) + 10;
 }
 
 WebRTCDataChannel::~WebRTCDataChannel() {

--- a/modules/webrtc/webrtc_data_channel.h
+++ b/modules/webrtc/webrtc_data_channel.h
@@ -33,6 +33,8 @@
 
 #include "core/io/packet_peer.h"
 
+#define WRTC_IN_BUF "network/limits/webrtc/max_channel_in_buffer_kb"
+
 class WebRTCDataChannel : public PacketPeer {
 	GDCLASS(WebRTCDataChannel, PacketPeer);
 
@@ -50,6 +52,8 @@ public:
 	};
 
 protected:
+	unsigned int _in_buffer_shift;
+
 	static void _bind_methods();
 
 public:

--- a/modules/webrtc/webrtc_data_channel_js.cpp
+++ b/modules/webrtc/webrtc_data_channel_js.cpp
@@ -56,7 +56,7 @@ EMSCRIPTEN_KEEPALIVE void _emrtc_on_ch_message(void *obj, uint8_t *p_data, uint3
 }
 
 void WebRTCDataChannelJS::_on_open() {
-	in_buffer.resize(16);
+	in_buffer.resize(_in_buffer_shift);
 }
 
 void WebRTCDataChannelJS::_on_close() {


### PR DESCRIPTION
Resolves: #30605 

Allows setting the size of the incoming packet buffer for a WebRTC Data Channel. Note that the buffer is per channel, not per peer. 