### PR TITLE
HTML5 default loader: small bugfix

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -175,8 +175,8 @@ $GODOT_HEAD_INCLUDE
 				[statusProgress, statusIndeterminate, statusNotice].forEach(elem => {
 					elem.style.display = 'none';
 				});
-				if (animateStatusIndeterminate in animationCallbacks) {
-					animationCallbacks.erase(animateStatusIndeterminate);
+				animationCallbacks = animationCallbacks.filter(function(value) {
+					return (value != animateStatusIndeterminate);
 				}
 				switch (mode) {
 					case 'progress':


### PR DESCRIPTION
When initialization is completed, there are no reasons to continue calling the animationCallbacks (it would continue to call it also when the game is ready and run).