### PR TITLE
Revert "Update Control margins when size is overridden by change to minsize"

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -289,7 +289,7 @@ void Control::_update_minimum_size() {
 	Size2 minsize = get_combined_minimum_size();
 	if (minsize.x > data.size_cache.x ||
 			minsize.y > data.size_cache.y) {
-		set_size(data.size_cache);
+		_size_changed();
 	}
 
 	data.updating_last_minimum_size = false;


### PR DESCRIPTION
Reverts godotengine/godot#28952

That PR fixed a valid bug but it introduced regressions. It's not obvious how to fix them while keeping the bugfix, so reverting for now as the regressions are worse than the original issue.

Fixes #29289.
Fixes #29495.