### PR TITLE
Add filter method to Array class

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -335,6 +335,26 @@ Array &Array::invert() {
 	return *this;
 }
 
+Array Array::filter(Object *p_obj, const StringName &p_function,const Variant &p_args) {
+	Array ret;
+
+ 	for (int i = 0; i < size(); i++) {
+
+ 		Variant res = p_obj->call(p_function, get(i), p_args);
+
+ 		if (res.get_type() != Variant::Type::BOOL) {
+			ERR_EXPLAIN("Comparison function must return a value of type bool");
+			ERR_FAIL_V(ret);
+		}
+
+ 		if (((bool)res)) {
+			ret.append(get(i));
+		}
+	}
+
+ 	return ret;
+}
+
 void Array::push_front(const Variant &p_value) {
 
 	_p->array.insert(0, p_value);

--- a/core/array.h
+++ b/core/array.h
@@ -76,6 +76,7 @@ public:
 	int bsearch(const Variant &p_value, bool p_before = true);
 	int bsearch_custom(const Variant &p_value, Object *p_obj, const StringName &p_function, bool p_before = true);
 	Array &invert();
+	Array filter(Object *p_obj, const StringName &p_function, const Variant &p_args);
 
 	int find(const Variant &p_value, int p_from = 0) const;
 	int rfind(const Variant &p_value, int p_from = -1) const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -529,6 +529,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM4R(Array, bsearch_custom);
 	VCALL_LOCALMEM1R(Array, duplicate);
 	VCALL_LOCALMEM0(Array, invert);
+	VCALL_LOCALMEM3R(Array, filter);
 	VCALL_LOCALMEM0R(Array, max);
 	VCALL_LOCALMEM0R(Array, min);
 
@@ -1746,6 +1747,7 @@ void register_variant_methods() {
 	ADDFUNC2R(ARRAY, INT, Array, bsearch, NIL, "value", BOOL, "before", varray(true));
 	ADDFUNC4R(ARRAY, INT, Array, bsearch_custom, NIL, "value", OBJECT, "obj", STRING, "func", BOOL, "before", varray(true));
 	ADDFUNC0NC(ARRAY, NIL, Array, invert, varray());
+	ADDFUNC3R(ARRAY, ARRAY, Array, filter, OBJECT, "obj", STRING, "func", NIL, "args", varray(false));
 	ADDFUNC1R(ARRAY, ARRAY, Array, duplicate, BOOL, "deep", varray(false));
 	ADDFUNC0R(ARRAY, NIL, Array, max, varray());
 	ADDFUNC0R(ARRAY, NIL, Array, min, varray());


### PR DESCRIPTION
Designed in a similar fashion like sort_custom
instead of using FuncRef for the sake of consistency.

The error isn't always accurate, sometimes it is actually
due to the wrong number of arguments passed into the filterer
method.