### PR TITLE
Add filter method to Array class

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -335,6 +335,26 @@ Array &Array::invert() {
 	return *this;
 }
 
+Array Array::filter(Object *p_obj, const StringName &p_function, const Variant &p_args) {
+	Array ret;
+
+	for (int i = 0; i < size(); i++) {
+
+		Variant res = p_obj->call(p_function, get(i), p_args);
+
+		if (res.get_type() != Variant::Type::BOOL) {
+			ERR_EXPLAIN("Comparison function must return a value of type bool");
+			ERR_FAIL_V(ret);
+		}
+
+		if (res.operator bool()) {
+			ret.append(get(i));
+		}
+	}
+
+	return ret;
+}
+
 void Array::push_front(const Variant &p_value) {
 
 	_p->array.insert(0, p_value);

--- a/core/array.cpp
+++ b/core/array.cpp
@@ -335,24 +335,24 @@ Array &Array::invert() {
 	return *this;
 }
 
-Array Array::filter(Object *p_obj, const StringName &p_function,const Variant &p_args) {
+Array Array::filter(Object *p_obj, const StringName &p_function, const Variant &p_args) {
 	Array ret;
 
- 	for (int i = 0; i < size(); i++) {
+	for (int i = 0; i < size(); i++) {
 
- 		Variant res = p_obj->call(p_function, get(i), p_args);
+		Variant res = p_obj->call(p_function, get(i), p_args);
 
- 		if (res.get_type() != Variant::Type::BOOL) {
+		if (res.get_type() != Variant::Type::BOOL) {
 			ERR_EXPLAIN("Comparison function must return a value of type bool");
 			ERR_FAIL_V(ret);
 		}
 
- 		if (((bool)res)) {
+		if (((bool)res)) {
 			ret.append(get(i));
 		}
 	}
 
- 	return ret;
+	return ret;
 }
 
 void Array::push_front(const Variant &p_value) {

--- a/core/array.cpp
+++ b/core/array.cpp
@@ -335,6 +335,26 @@ Array &Array::invert() {
 	return *this;
 }
 
+Array Array::filter(Object *p_obj, const StringName &p_function,const Variant &p_args) {
+	Array ret;
+
+ 	for (int i = 0; i < size(); i++) {
+
+ 		Variant res = p_obj->call(p_function, get(i), p_args);
+
+ 		if (res.get_type() != Variant::Type::BOOL) {
+			ERR_EXPLAIN("Comparison function must return a value of type bool");
+			ERR_FAIL_V(ret);
+		}
+
+ 		if (((bool)res)) {
+			ret.append(get(i));
+		}
+	}
+
+ 	return ret;
+}
+
 void Array::push_front(const Variant &p_value) {
 
 	_p->array.insert(0, p_value);

--- a/core/array.cpp
+++ b/core/array.cpp
@@ -347,7 +347,7 @@ Array Array::filter(Object *p_obj, const StringName &p_function, const Variant &
 			ERR_FAIL_V(ret);
 		}
 
-		if (((bool)res)) {
+		if (res.operator bool()) {
 			ret.append(get(i));
 		}
 	}

--- a/core/array.h
+++ b/core/array.h
@@ -76,6 +76,7 @@ public:
 	int bsearch(const Variant &p_value, bool p_before = true);
 	int bsearch_custom(const Variant &p_value, Object *p_obj, const StringName &p_function, bool p_before = true);
 	Array &invert();
+	Array filter(Object *p_obj, const StringName &p_function, const Variant &p_args);
 
 	int find(const Variant &p_value, int p_from = 0) const;
 	int rfind(const Variant &p_value, int p_from = -1) const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -529,6 +529,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM4R(Array, bsearch_custom);
 	VCALL_LOCALMEM1R(Array, duplicate);
 	VCALL_LOCALMEM0(Array, invert);
+	VCALL_LOCALMEM3R(Array, filter);
 	VCALL_LOCALMEM0R(Array, max);
 	VCALL_LOCALMEM0R(Array, min);
 
@@ -1746,10 +1747,11 @@ void register_variant_methods() {
 	ADDFUNC2R(ARRAY, INT, Array, bsearch, NIL, "value", BOOL, "before", varray(true));
 	ADDFUNC4R(ARRAY, INT, Array, bsearch_custom, NIL, "value", OBJECT, "obj", STRING, "func", BOOL, "before", varray(true));
 	ADDFUNC0NC(ARRAY, NIL, Array, invert, varray());
+	VCALL_LOCALMEM3R(Array, filter);
 	ADDFUNC1R(ARRAY, ARRAY, Array, duplicate, BOOL, "deep", varray(false));
 	ADDFUNC0R(ARRAY, NIL, Array, max, varray());
 	ADDFUNC0R(ARRAY, NIL, Array, min, varray());
-
+	ADDFUNC3R(ARRAY, ARRAY, Array, filter, OBJECT, "obj", STRING, "func", NIL, "args", varray(false));
 	ADDFUNC0R(POOL_BYTE_ARRAY, INT, PoolByteArray, size, varray());
 	ADDFUNC2(POOL_BYTE_ARRAY, NIL, PoolByteArray, set, INT, "idx", INT, "byte", varray());
 	ADDFUNC1(POOL_BYTE_ARRAY, NIL, PoolByteArray, push_back, INT, "byte", varray());

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1747,7 +1747,6 @@ void register_variant_methods() {
 	ADDFUNC2R(ARRAY, INT, Array, bsearch, NIL, "value", BOOL, "before", varray(true));
 	ADDFUNC4R(ARRAY, INT, Array, bsearch_custom, NIL, "value", OBJECT, "obj", STRING, "func", BOOL, "before", varray(true));
 	ADDFUNC0NC(ARRAY, NIL, Array, invert, varray());
-	VCALL_LOCALMEM3R(Array, filter);
 	ADDFUNC1R(ARRAY, ARRAY, Array, duplicate, BOOL, "deep", varray(false));
 	ADDFUNC0R(ARRAY, NIL, Array, max, varray());
 	ADDFUNC0R(ARRAY, NIL, Array, min, varray());

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -529,6 +529,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM4R(Array, bsearch_custom);
 	VCALL_LOCALMEM1R(Array, duplicate);
 	VCALL_LOCALMEM0(Array, invert);
+	VCALL_LOCALMEM3R(Array, filter);
 	VCALL_LOCALMEM0R(Array, max);
 	VCALL_LOCALMEM0R(Array, min);
 
@@ -1749,7 +1750,7 @@ void register_variant_methods() {
 	ADDFUNC1R(ARRAY, ARRAY, Array, duplicate, BOOL, "deep", varray(false));
 	ADDFUNC0R(ARRAY, NIL, Array, max, varray());
 	ADDFUNC0R(ARRAY, NIL, Array, min, varray());
-
+	ADDFUNC3R(ARRAY, ARRAY, Array, filter, OBJECT, "obj", STRING, "func", NIL, "args", varray(false));
 	ADDFUNC0R(POOL_BYTE_ARRAY, INT, PoolByteArray, size, varray());
 	ADDFUNC2(POOL_BYTE_ARRAY, NIL, PoolByteArray, set, INT, "idx", INT, "byte", varray());
 	ADDFUNC1(POOL_BYTE_ARRAY, NIL, PoolByteArray, push_back, INT, "byte", varray());


### PR DESCRIPTION
Designed to be consistent with similar methods such as
sort_custom instead of using FuncRef.

The error isn't always accurate, it is sometimes due
to the wrong amount of parameters defined in the filterer method
(which should be 2, one for the array element, another for other args)