### PR TITLE
Bugfix GLTF import: Do not reindex when blend shapes are present.

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -986,7 +986,7 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 				Ref<SurfaceTool> st;
 				st.instance();
 				st->create_from_triangle_arrays(array);
-				if (p.has("targets")) {
+				if (!p.has("targets")) {
 					//morph targets should not be reindexed, as array size might differ
 					//removing indices is the best bet here
 					st->deindex();


### PR DESCRIPTION
Comparison of GLTF2 import before/after:

Before:

![60213892-4aea8a80-9819-11e9-9851-10cc0ae99784](https://user-images.githubusercontent.com/2160055/61999720-24b84480-b07c-11e9-8362-7f9bcb2a5005.gif)

After:

![2019-07-27_14-32-08](https://user-images.githubusercontent.com/2160055/61999728-34d02400-b07c-11e9-9f21-75d59fda7651.gif)
