### PR TITLE
Implement error macros that come with an error message, replacing ERR_EXPLAIN.

### DIFF
--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -140,6 +140,16 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                  \
+	do {                                                                                                            \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+			ERR_EXPLAIN(m_msg);                                                                                     \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return;                                                                                                 \
+		}                                                                                                           \
+		_err_error_exists = false;                                                                                  \
+	} while (0); // (*)
+
 /** An index has failed if m_index<0 or m_index >=m_size, the function exits.
 * This function returns an error value, if returning Error, please select the most
 * appropriate error condition from error_macros.h
@@ -148,6 +158,16 @@ extern bool _err_error_exists;
 #define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                 \
 	do {                                                                                                            \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return m_retval;                                                                                        \
+		}                                                                                                           \
+		_err_error_exists = false;                                                                                  \
+	} while (0); // (*)
+
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                      \
+	do {                                                                                                            \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+			ERR_EXPLAIN(m_msg);                                                                                     \
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return m_retval;                                                                                        \
 		}                                                                                                           \
@@ -168,12 +188,31 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                             \
+	do {                                                                                                            \
+		if (unlikely((m_index) >= (m_size))) {                                                                      \
+			ERR_EXPLAIN(m_msg);                                                                                     \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return m_retval;                                                                                        \
+		}                                                                                                           \
+		_err_error_exists = false;                                                                                  \
+	} while (0); // (*)
+
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
 *   We'll return a null reference and try to keep running.
 */
 #define CRASH_BAD_INDEX(m_index, m_size)                                                                                  \
 	do {                                                                                                                  \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                           \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), true); \
+			GENERATE_TRAP                                                                                                 \
+		}                                                                                                                 \
+	} while (0); // (*)
+
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                       \
+	do {                                                                                                                  \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                           \
+			ERR_EXPLAIN(m_msg);                                                                                           \
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), true); \
 			GENERATE_TRAP                                                                                                 \
 		}                                                                                                                 \
@@ -192,9 +231,29 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                          \
 	}
 
+#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                   \
+	{                                                                                                       \
+		if (unlikely(!m_param)) {                                                                           \
+			ERR_EXPLAIN(m_msg);                                                                             \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null."); \
+			return;                                                                                         \
+		}                                                                                                   \
+		_err_error_exists = false;                                                                          \
+	}
+
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                                  \
 	{                                                                                                       \
 		if (unlikely(!m_param)) {                                                                           \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null."); \
+			return m_retval;                                                                                \
+		}                                                                                                   \
+		_err_error_exists = false;                                                                          \
+	}
+
+#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                       \
+	{                                                                                                       \
+		if (unlikely(!m_param)) {                                                                           \
+			ERR_EXPLAIN(m_msg);                                                                             \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null."); \
 			return m_retval;                                                                                \
 		}                                                                                                   \
@@ -214,12 +273,31 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                         \
 	}
 
+#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                   \
+	{                                                                                                      \
+		if (unlikely(m_cond)) {                                                                            \
+			ERR_EXPLAIN(m_msg);                                                                            \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true."); \
+			return;                                                                                        \
+		}                                                                                                  \
+		_err_error_exists = false;                                                                         \
+	}
+
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
  */
 
 #define CRASH_COND(m_cond)                                                                                        \
 	{                                                                                                             \
 		if (unlikely(m_cond)) {                                                                                   \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition ' " _STR(m_cond) " ' is true."); \
+			GENERATE_TRAP                                                                                         \
+		}                                                                                                         \
+	}
+
+#define CRASH_COND_MSG(m_cond, m_msg)                                                                             \
+	{                                                                                                             \
+		if (unlikely(m_cond)) {                                                                                   \
+			ERR_EXPLAIN(m_msg);                                                                                   \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition ' " _STR(m_cond) " ' is true."); \
 			GENERATE_TRAP                                                                                         \
 		}                                                                                                         \
@@ -240,6 +318,16 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                                   \
 	}
 
+#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                 \
+	{                                                                                                                                \
+		if (unlikely(m_cond)) {                                                                                                      \
+			ERR_EXPLAIN(m_msg);                                                                                                      \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. returned: " _STR(m_retval)); \
+			return m_retval;                                                                                                         \
+		}                                                                                                                            \
+		_err_error_exists = false;                                                                                                   \
+	}
+
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
  * the loop will skip to the next iteration.
  */
@@ -247,6 +335,16 @@ extern bool _err_error_exists;
 #define ERR_CONTINUE(m_cond)                                                                                             \
 	{                                                                                                                    \
 		if (unlikely(m_cond)) {                                                                                          \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Continuing..:"); \
+			continue;                                                                                                    \
+		}                                                                                                                \
+		_err_error_exists = false;                                                                                       \
+	}
+
+#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                  \
+	{                                                                                                                    \
+		if (unlikely(m_cond)) {                                                                                          \
+			ERR_EXPLAIN(m_msg);                                                                                          \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Continuing..:"); \
 			continue;                                                                                                    \
 		}                                                                                                                \
@@ -266,6 +364,16 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                     \
 	}
 
+#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                   \
+	{                                                                                                                  \
+		if (unlikely(m_cond)) {                                                                                        \
+			ERR_EXPLAIN(m_msg);                                                                                        \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:"); \
+			break;                                                                                                     \
+		}                                                                                                              \
+		_err_error_exists = false;                                                                                     \
+	}
+
 /** Print an error string and return
  */
 
@@ -274,6 +382,12 @@ extern bool _err_error_exists;
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed."); \
 		_err_error_exists = false;                                                     \
 		return;                                                                        \
+	}
+
+#define ERR_FAIL_MSG(m_msg) \
+	{                       \
+		ERR_EXPLAIN(m_msg); \
+		ERR_FAIL();         \
 	}
 
 /** Print an error string and return with value
@@ -286,6 +400,12 @@ extern bool _err_error_exists;
 		return m_value;                                                                                           \
 	}
 
+#define ERR_FAIL_V_MSG(m_value, m_msg) \
+	{                                  \
+		ERR_EXPLAIN(m_msg);            \
+		ERR_FAIL_V(m_value);           \
+	}
+
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
  */
 
@@ -293,6 +413,12 @@ extern bool _err_error_exists;
 	{                                                                                         \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/Function Failed."); \
 		GENERATE_TRAP                                                                         \
+	}
+
+#define CRASH_NOW_MSG(m_msg) \
+	{                        \
+		ERR_EXPLAIN(m_msg);  \
+		CRASH_NOW();         \
 	}
 
 /** Print an error string.
@@ -349,6 +475,17 @@ extern bool _err_error_exists;
 	{                                                                                                                                                     \
 		static volatile bool warning_shown = false;                                                                                                       \
 		if (!warning_shown) {                                                                                                                             \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future", ERR_HANDLER_WARNING); \
+			_err_error_exists = false;                                                                                                                    \
+			warning_shown = true;                                                                                                                         \
+		}                                                                                                                                                 \
+	}
+
+#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                        \
+	{                                                                                                                                                     \
+		static volatile bool warning_shown = false;                                                                                                       \
+		if (!warning_shown) {                                                                                                                             \
+			ERR_EXPLAIN(m_msg);                                                                                                                           \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future", ERR_HANDLER_WARNING); \
 			_err_error_exists = false;                                                                                                                    \
 			warning_shown = true;                                                                                                                         \


### PR DESCRIPTION
# Motivation
[ERR_EXPLAIN](https://github.com/godotengine/godot/blob/52355c638b03ff9316ee3f39e32ac968252489d3/core/error_macros.h#L101) will currently evaluate whatever you pass to it in full regardless of whether the accompanying assertion actually fails, this can be a problem if you have a debug build (or release_debug like the editor) and in a loop have an assert + an error message with some string concatenation in it.

Personally I ran into it when evaluating my new astar implementation, and realised I'd come to a 30-50% slowdown once I'd inserted `ERR_EXPLAIN` usage for nice error messages, even though no errors were occurring. (our_no_err here still using asserts, but no `ERR_EXPLAIN`)

![image](https://user-images.githubusercontent.com/2816340/62009027-7cc57880-b15a-11e9-832c-4cc1fea1203a.png)


# Solution
The error macro and the error message should be consolidated, so that for error macros that only need the error message when the assertion actually fails (like `ERR_FAIL_COND`) only then evaluate the operand for the message then, leading to less performance ache from this.

And so, I've implemented alternatives to our current error macros that look like so:
* `ERR_FAIL_COND` -> `ERR_FAIL_COND_MSG` etc.
```cpp
// previously, always evaluated
ERR_EXPLAIN("x must be positive, was: " + itos(x));
ERR_FAIL_COND(x < 0);

// now becomes, rhs only evaluated when it fails
ERR_FAIL_COND_MSG(x < 0, "x must be positive, was: " + itos(x));

```

# Finally
I'm making this a draft PR so I can get some feedback on the implementation (the duplication might not be great, if someone has ideas for a neater implementation, I'm all ears) before I potentially sweep through the codebase and replace all usages of `ERR_EXPLAIN`, all feedback welcome!