### PR TITLE
Toggle CPUParticles2D visibility when redrawing

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -962,9 +962,13 @@ void CPUParticles2D::_set_redraw(bool p_redraw) {
 	if (redraw) {
 		VS::get_singleton()->connect("frame_pre_draw", this, "_update_render_thread");
 		VS::get_singleton()->canvas_item_set_update_when_visible(get_canvas_item(), true);
+
+		VS::get_singleton()->multimesh_set_visible_instances(multimesh, -1);
 	} else {
 		VS::get_singleton()->disconnect("frame_pre_draw", this, "_update_render_thread");
 		VS::get_singleton()->canvas_item_set_update_when_visible(get_canvas_item(), false);
+
+		VS::get_singleton()->multimesh_set_visible_instances(multimesh, 0);
 	}
 #ifndef NO_THREADS
 	update_mutex->unlock();


### PR DESCRIPTION
Addresses: https://github.com/godotengine/godot/issues/30672 (not sure if fully fixes)

Code graciously donated by Gamblify

This PR sets the number of visible particles based on the value of ``redraw``. This matches the behaviour of CPUParticles introduced in 24b7f08.

This PR should also regain the performance lost in 24b7f08