### PR TITLE
Add a reference to pow to the description of exp.

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -322,6 +322,7 @@
 			<description>
 				The natural exponential function. It raises the mathematical constant [b]e[/b] to the power of [code]s[/code] and returns it.
 				[b]e[/b] has an approximate value of 2.71828.
+				For exponents to other bases use the method [method pow].
 				[codeblock]
 				a = exp(2) # Approximately 7.39
 				[/codeblock]


### PR DESCRIPTION
This might be especially usefull since godot script doesn't support ** or ^ as operators, so beginners might search for the exponential function, when what they really need is the pow function.

This is exactly what happened to me and since I couldn't find helpfull information in the documentation I had to look it up online, where I found the answer on a helpfull [reddit thread](https://www.reddit.com/r/godot/comments/3mvwz0/how_do_i_do_exponents_in_godot/).

I would have liked to add a link to the pow function, but I don't really see how references work in this setup.

Just for completness sake: This pull request is the result of another one in godot-docs: https://github.com/godotengine/godot-docs/pull/2668
@cbscribe was so friendly to point me to the right repository.