### PR TITLE
Fix GPU particle transform delay when created on SceneTree timer timeout

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -567,6 +567,8 @@ bool SceneTree::idle(float p_time) {
 		E = N;
 	}
 
+	flush_transform_notifications(); //additional transforms after timers update
+
 	_call_idle_callbacks();
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
This change adds an extra transforms update during scene update, after updating all the scene timers. It allows changes made to transforms during timer notifications to be applied before rendering, without waiting for one more frame.

Fixes #29952: Particle2D created during a timer timeout were rendered once before their transform is updated.