### PR TITLE
Change cursor to multi-selection cursor when selecting text in RichTextLabel

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -920,8 +920,11 @@ void RichTextLabel::_find_click(ItemFrame *p_frame, const Point2i &p_click, Item
 
 Control::CursorShape RichTextLabel::get_cursor_shape(const Point2 &p_pos) const {
 
-	if (!underline_meta || selection.click)
+	if (!underline_meta)
 		return CURSOR_ARROW;
+
+	if (selection.click)
+		return CURSOR_IBEAM;
 
 	if (main->first_invalid_line < main->lines.size())
 		return CURSOR_ARROW; //invalid


### PR DESCRIPTION
Fix #27545: returns 'CURSOR_IBEAM' shape when selection is clicked.

