### PR TITLE
Changes default canvas_item_editor coarse zoom level from 1.5 to sqrt(2)

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3842,7 +3842,7 @@ void CanvasItemEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
 }
 
 void CanvasItemEditor::_button_zoom_minus() {
-	_zoom_on_position(zoom / 1.5, viewport_scrollable->get_size() / 2.0);
+	_zoom_on_position(zoom / Math_SQRT2, viewport_scrollable->get_size() / 2.0);
 }
 
 void CanvasItemEditor::_button_zoom_reset() {
@@ -3850,7 +3850,7 @@ void CanvasItemEditor::_button_zoom_reset() {
 }
 
 void CanvasItemEditor::_button_zoom_plus() {
-	_zoom_on_position(zoom * 1.5, viewport_scrollable->get_size() / 2.0);
+	_zoom_on_position(zoom * Math_SQRT2, viewport_scrollable->get_size() / 2.0);
 }
 
 void CanvasItemEditor::_button_toggle_snap(bool p_status) {


### PR DESCRIPTION
Coarse zooming (using the +/- buttons in the canvas item editor) is changed to have even pixel ratios every other zoom level while providing intermediary zoom levels closer to 3.1 contributor preferences.  Doesn't change the 5% fine zoom when using the scroll wheel.  Simplest proposal to address https://github.com/godotengine/godot/issues/25693.  

*Bugsquad edit:* Fixes #25693.