### PR TITLE
Android: Fix support for android_stl=no with NDK r20

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -259,6 +259,9 @@ def configure(env):
                 env.Append(LINKFLAGS=[env["ANDROID_NDK_ROOT"] +"/sources/cxx-stl/llvm-libc++/libs/"+arch_subpath+"/libandroid_support.a"])
             env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++/libs/"+arch_subpath+"/"])
             env.Append(LINKFLAGS=[env["ANDROID_NDK_ROOT"] +"/sources/cxx-stl/llvm-libc++/libs/"+arch_subpath+"/libc++_shared.so"])
+        else:
+            # This is the legacy and minimal 'System STL' with support for basic features like new and delete
+            env.Append(LINKFLAGS=['-stdlib=libstdc++'])
     else:
         if mt_link:
             env.Append(LINKFLAGS=['-Wl,--threads'])


### PR DESCRIPTION
Fixes #30688.

It's not explicit in the [NDK r20 buildsystem docs](https://android.googlesource.com/platform/ndk/+/ndk-release-r20/docs/BuildSystemMaintainers.md#STL), but I assume that previously they linked to that 'System STL' by default, and now they don't anymore.

It's likely going to be phased out so this will stop work in the future. The option is probably not worth keeping for 3.1+ anyway as we have way too many C++ dependencies that require the STL.