### PR TITLE
Android: Remove unusable android_stl=no option

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -28,7 +28,6 @@ def get_opts():
         ('ndk_platform', 'Target platform (android-<api>, e.g. "android-18")', "android-18"),
         EnumVariable('android_arch', 'Target architecture', "armv7", ('armv7', 'arm64v8', 'x86', 'x86_64')),
         BoolVariable('android_neon', 'Enable NEON support (armv7 only)', True),
-        BoolVariable('android_stl', 'Enable Android STL support (for modules)', True)
     ]
 
 
@@ -207,11 +206,13 @@ def configure(env):
 
     ## Compile flags
 
+    env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++/include"])
+    env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++abi/include"])
+    env.Append(CXXFLAGS=["-std=gnu++14"])
+
     # Disable exceptions and rtti on non-tools (template) builds
-    if env['tools'] or env['android_stl']:
-        env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++/include"])
-        env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++abi/include"])
-        env.Append(CXXFLAGS=['-frtti', "-std=gnu++14"])
+    if env['tools']:
+        env.Append(CXXFLAGS=['-frtti'])
     else:
         env.Append(CXXFLAGS=['-fno-rtti', '-fno-exceptions'])
         # Don't use dynamic_cast, necessary with no-rtti.


### PR DESCRIPTION
As of 3.1 and later, we have too many thirdparty C++ dependencies
and some internal uses of `new` and `delete` too for it to make
sense to build without the STL on Android.

The option has been broken since 3.0, and the "System STL" that we
relied on for basic support of `new` and `delete` is likely to be
dropped from the NDK:
https://android.googlesource.com/platform/ndk/+/ndk-release-r20/docs/BuildSystemMaintainers.md#System-STL