### PR TITLE
Implement copy/paste in visual shaders

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -233,6 +233,9 @@
 				Signal sent when user dragging connection from output port into empty space of the graph.
 			</description>
 		</signal>
+		<signal name="copy_nodes_request">
+			Signal sent when the user presses [code]Ctrl + C[/code].
+		</signal>
 		<signal name="delete_nodes_request">
 			<description>
 				Signal sent when a GraphNode is attempted to be removed from the GraphEdit.
@@ -262,6 +265,9 @@
 			<description>
 				Emitted when a GraphNode is selected.
 			</description>
+		</signal>
+		<signal name="paste_nodes_request">
+			Signal sent when the user presses [code]Ctrl + V[/code].
 		</signal>
 		<signal name="popup_request">
 			<argument index="0" name="position" type="Vector2">

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -176,7 +176,20 @@ class VisualShaderEditor : public VBoxContainer {
 
 	void _port_name_focus_out(Object *line_edit, int p_node_id, int p_port_id, bool p_output);
 
+	void _dup_copy_nodes(int p_type, List<int> &r_nodes, Set<int> &r_excluded);
+	void _dup_update_excluded(int p_type, Set<int> &r_excluded);
+	void _dup_paste_nodes(int p_type, List<int> &r_nodes, Set<int> &r_excluded, const Vector2 &p_offset, bool p_select);
+
 	void _duplicate_nodes();
+
+	Vector2 selection_center;
+	int copy_type; // shader type
+	List<int> copy_nodes_buffer;
+	Set<int> copy_nodes_excluded_buffer;
+
+	void _clear_buffer();
+	void _copy_nodes();
+	void _paste_nodes();
 
 	Vector<Ref<VisualShaderNodePlugin> > plugins;
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1030,14 +1030,28 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 	}
 
 	Ref<InputEventKey> k = p_ev;
-	if (k.is_valid() && k->get_scancode() == KEY_D && k->is_pressed() && k->get_command()) {
-		emit_signal("duplicate_nodes_request");
-		accept_event();
-	}
 
-	if (k.is_valid() && k->get_scancode() == KEY_DELETE && k->is_pressed()) {
-		emit_signal("delete_nodes_request");
-		accept_event();
+	if (k.is_valid()) {
+
+		if (k->get_scancode() == KEY_D && k->is_pressed() && k->get_command()) {
+			emit_signal("duplicate_nodes_request");
+			accept_event();
+		}
+
+		if (k->get_scancode() == KEY_C && k->is_pressed() && k->get_command()) {
+			emit_signal("copy_nodes_request");
+			accept_event();
+		}
+
+		if (k->get_scancode() == KEY_V && k->is_pressed() && k->get_command()) {
+			emit_signal("paste_nodes_request");
+			accept_event();
+		}
+
+		if (k->get_scancode() == KEY_DELETE && k->is_pressed()) {
+			emit_signal("delete_nodes_request");
+			accept_event();
+		}
 	}
 
 	Ref<InputEventMagnifyGesture> magnify_gesture = p_ev;
@@ -1297,6 +1311,8 @@ void GraphEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("disconnection_request", PropertyInfo(Variant::STRING, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::STRING, "to"), PropertyInfo(Variant::INT, "to_slot")));
 	ADD_SIGNAL(MethodInfo("popup_request", PropertyInfo(Variant::VECTOR2, "position")));
 	ADD_SIGNAL(MethodInfo("duplicate_nodes_request"));
+	ADD_SIGNAL(MethodInfo("copy_nodes_request"));
+	ADD_SIGNAL(MethodInfo("paste_nodes_request"));
 	ADD_SIGNAL(MethodInfo("node_selected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("connection_to_empty", PropertyInfo(Variant::STRING, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("connection_from_empty", PropertyInfo(Variant::STRING, "to"), PropertyInfo(Variant::INT, "to_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));


### PR DESCRIPTION
Possibility to copy/paste visual shader nodes - useful QoL change. I've also added signals to GraphEdit for future apply to Visual Scripts. Also refactor a duplication code a bit to make it less clumpy by pushing it to separate functions which is used by Duplication and Copy/Paste actions.

![vs_copy_paste](https://user-images.githubusercontent.com/3036176/62153366-10d74180-b30d-11e9-953a-6ff55d9f6022.gif)

Seems worked fine in all graph and editor zoom resolutions

Fix #29089
