### PR TITLE
Possible fix to #30903

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1610,6 +1610,12 @@ void RasterizerCanvasGLES3::canvas_render_items(Item *p_item_list, int p_z, cons
 						glBindTexture(t->target, t->tex_id);
 					}
 
+
+					if (storage->frame.current_rt) {
+						state.canvas_shader.set_uniform(CanvasShaderGLES3::SCREEN_PIXEL_SIZE, Vector2(1.0 / storage->frame.current_rt->width, 1.0 / storage->frame.current_rt->height));
+					} else {
+						state.canvas_shader.set_uniform(CanvasShaderGLES3::SCREEN_PIXEL_SIZE, Vector2(1.0, 1.0));
+					}
 					glActiveTexture(GL_TEXTURE0);
 					_canvas_item_render_commands(ci, current_clip, reclip); //redraw using light
 				}


### PR DESCRIPTION
The problem, apparently: the `screen_pixel_size` uniform is not written to during the light pass, and has a default (?) value of (0, 0).

I've simply explicitly set the `screen_pixel_size` uniform before the lights are rendered. However, there may be a better place to set these uniforms; it seems like they should already be set due to lines 1517-1521 ...?