### PR TITLE
Adds skip-breakpoints feature

### DIFF
--- a/core/script_debugger_local.cpp
+++ b/core/script_debugger_local.cpp
@@ -33,7 +33,7 @@
 #include "core/os/os.h"
 #include "scene/main/scene_tree.h"
 
-void ScriptDebuggerLocal::debug(ScriptLanguage *p_script, bool p_can_continue) {
+void ScriptDebuggerLocal::debug(ScriptLanguage *p_script, bool p_can_continue, bool p_is_error_breakpoint) {
 
 	if (!target_function.empty()) {
 		String current_function = p_script->debug_get_stack_level_function(0);

--- a/core/script_debugger_local.h
+++ b/core/script_debugger_local.h
@@ -48,7 +48,7 @@ class ScriptDebuggerLocal : public ScriptDebugger {
 	void print_variables(const List<String> &names, const List<Variant> &values, const String &variable_prefix);
 
 public:
-	void debug(ScriptLanguage *p_script, bool p_can_continue);
+	void debug(ScriptLanguage *p_script, bool p_can_continue, bool p_is_error_breakpoint);
 	virtual void send_message(const String &p_message, const Array &p_args);
 	virtual void send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, ErrorHandlerType p_type, const Vector<ScriptLanguage::StackInfo> &p_stack_info);
 

--- a/core/script_debugger_remote.h
+++ b/core/script_debugger_remote.h
@@ -140,6 +140,8 @@ class ScriptDebuggerRemote : public ScriptDebugger {
 
 	void _save_node(ObjectID id, const String &p_path);
 
+	bool skip_breakpoints;
+
 public:
 	struct ResourceUsage {
 
@@ -156,7 +158,7 @@ public:
 	static ResourceUsageFunc resource_usage_func;
 
 	Error connect_to_host(const String &p_host, uint16_t p_port);
-	virtual void debug(ScriptLanguage *p_script, bool p_can_continue = true);
+	virtual void debug(ScriptLanguage *p_script, bool p_can_continue = true, bool p_is_error_breakpoint = false);
 	virtual void idle_poll();
 	virtual void line_poll();
 
@@ -175,6 +177,8 @@ public:
 	virtual void profiling_start();
 	virtual void profiling_end();
 	virtual void profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time);
+
+	virtual void set_skip_breakpoints(bool p_skip_breakpoints);
 
 	ScriptDebuggerRemote();
 	~ScriptDebuggerRemote();

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -467,7 +467,7 @@ public:
 	void clear_breakpoints();
 	const Map<int, Set<StringName> > &get_breakpoints() const { return breakpoints; }
 
-	virtual void debug(ScriptLanguage *p_script, bool p_can_continue = true) = 0;
+	virtual void debug(ScriptLanguage *p_script, bool p_can_continue = true, bool p_is_error_breakpoint = false) = 0;
 	virtual void idle_poll();
 	virtual void line_poll();
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1835,6 +1835,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	String main_scene;
 	String run_filename;
 	String args;
+	bool skip_breakpoints;
 
 	if (p_current || (editor_data.get_edited_scene_root() && p_custom == editor_data.get_edited_scene_root()->get_filename())) {
 
@@ -1900,8 +1901,9 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	editor_data.get_editor_breakpoints(&breakpoints);
 
 	args = ProjectSettings::get_singleton()->get("editor/main_run_args");
+	skip_breakpoints = ScriptEditor::get_singleton()->get_debugger()->is_skip_breakpoints();
 
-	Error error = editor_run.run(run_filename, args, breakpoints);
+	Error error = editor_run.run(run_filename, args, breakpoints, skip_breakpoints);
 
 	if (error != OK) {
 

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -37,7 +37,8 @@ EditorRun::Status EditorRun::get_status() const {
 
 	return status;
 }
-Error EditorRun::run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints) {
+
+Error EditorRun::run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints, const bool &p_skip_breakpoints) {
 
 	List<String> args;
 
@@ -160,6 +161,10 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 		}
 
 		args.push_back(bpoints);
+	}
+
+	if (p_skip_breakpoints) {
+		args.push_back("--skip-breakpoints");
 	}
 
 	if (p_scene != "") {

--- a/editor/editor_run.h
+++ b/editor/editor_run.h
@@ -51,7 +51,7 @@ private:
 
 public:
 	Status get_status() const;
-	Error run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints);
+	Error run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints, const bool &p_skip_breakpoints = false);
 	void run_native_notify() { status = STATUS_PLAY; }
 	void stop();
 

--- a/editor/icons/icon_debug_skip_breakpoints_off.svg
+++ b/editor/icons/icon_debug_skip_breakpoints_off.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="17"
+   height="17"
+   version="1.1"
+   viewBox="0 0 17 17"
+   id="svg3801"
+   sodipodi:docname="icon_debug_skip_breakpoints_off.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata3807">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3805" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1887"
+     inkscape:window-height="2103"
+     id="namedview3803"
+     showgrid="false"
+     inkscape:measure-start="15.5563,28.7373"
+     inkscape:measure-end="0,0"
+     inkscape:zoom="32"
+     inkscape:cx="8.5156226"
+     inkscape:cy="-9.0970543"
+     inkscape:window-x="1953"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3801" />
+  <path
+     id="path3835"
+     sodipodi:type="arc"
+     sodipodi:cx="3.2790968"
+     sodipodi:cy="3.006855"
+     sodipodi:rx="1.6192284"
+     sodipodi:ry="1.3289529"
+     sodipodi:start="0"
+     sodipodi:end="0.0073006075"
+     sodipodi:open="true"
+     d="m 4.8983252,3.006855 a 1.6192284,1.3289529 0 0 1 -4.31e-5,0.0097"
+     style="fill:#000000;stroke-width:0.62631863" />
+  <path
+     style="fill:#000000;stroke-width:0.62631863"
+     id="path3837"
+     sodipodi:type="arc"
+     sodipodi:cx="6.233613"
+     sodipodi:cy="5.0553513"
+     sodipodi:rx="2.563139"
+     sodipodi:ry="3.6270869"
+     sodipodi:start="0"
+     sodipodi:end="0.0073006075"
+     sodipodi:open="true"
+     d="m 8.796752,5.0553513 a 2.563139,3.6270869 0 0 1 -6.83e-5,0.02648" />
+  <path
+     style="fill:#ff8585;fill-opacity:0.99607843;stroke-width:1.01912296"
+     id="path3839"
+     sodipodi:type="arc"
+     sodipodi:cx="8.4689026"
+     sodipodi:cy="8.479969"
+     sodipodi:rx="6.1594577"
+     sodipodi:ry="6.0545759"
+     sodipodi:start="5.5685493"
+     sodipodi:end="5.2409356"
+     d="M 13.121337,4.512148 A 6.1594577,6.0545759 0 0 1 12.87255,12.713238 6.1594577,6.0545759 0 0 1 4.5370096,13.140453 6.1594577,6.0545759 0 0 1 3.4219038,5.0092664 6.1594577,6.0545759 0 0 1 11.574987,3.2515951"
+     sodipodi:open="true" />
+</svg>

--- a/editor/icons/icon_debug_skip_breakpoints_on.svg
+++ b/editor/icons/icon_debug_skip_breakpoints_on.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="17"
+   height="17"
+   version="1.1"
+   viewBox="0 0 17 17"
+   id="svg3801"
+   sodipodi:docname="icon_debug_skip_breakpoints_on.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata3807">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3805" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1887"
+     inkscape:window-height="2105"
+     id="namedview3803"
+     showgrid="false"
+     inkscape:measure-start="15.5563,28.7373"
+     inkscape:measure-end="0,0"
+     inkscape:zoom="40.96"
+     inkscape:cx="12.825686"
+     inkscape:cy="-5.1961973"
+     inkscape:window-x="1953"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="bg" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="fg">
+    <path
+       id="path3835"
+       sodipodi:type="arc"
+       sodipodi:cx="3.2790968"
+       sodipodi:cy="3.006855"
+       sodipodi:rx="1.6192284"
+       sodipodi:ry="1.3289529"
+       sodipodi:start="0"
+       sodipodi:end="0.0073006075"
+       sodipodi:open="true"
+       d="m 4.8983252,3.006855 a 1.6192284,1.3289529 0 0 1 -4.31e-5,0.0097"
+       style="fill:#000000;stroke-width:0.62631863" />
+    <path
+       style="fill:#000000;stroke-width:0.62631863"
+       id="path3837"
+       sodipodi:type="arc"
+       sodipodi:cx="6.233613"
+       sodipodi:cy="5.0553513"
+       sodipodi:rx="2.563139"
+       sodipodi:ry="3.6270869"
+       sodipodi:start="0"
+       sodipodi:end="0.0073006075"
+       sodipodi:open="true"
+       d="m 8.796752,5.0553513 a 2.563139,3.6270869 0 0 1 -6.83e-5,0.02648" />
+    <path
+       style="fill:#ff8585;fill-opacity:0.99607843;stroke-width:1.01912296"
+       id="path3839"
+       sodipodi:type="arc"
+       sodipodi:cx="8.4689026"
+       sodipodi:cy="8.479969"
+       sodipodi:rx="6.1594577"
+       sodipodi:ry="6.0545759"
+       sodipodi:start="5.5685493"
+       sodipodi:end="5.2409356"
+       d="M 13.121337,4.512148 A 6.1594577,6.0545759 0 0 1 12.87255,12.713238 6.1594577,6.0545759 0 0 1 4.5370096,13.140453 6.1594577,6.0545759 0 0 1 3.4219038,5.0092664 6.1594577,6.0545759 0 0 1 11.574987,3.2515951"
+       sodipodi:open="true" />
+    <rect
+       style="fill:#e0e0e0;fill-opacity:1;stroke-width:1.1873318"
+       id="rect5375"
+       width="18.575495"
+       height="2.5187109"
+       x="-9.2906752"
+       y="10.816157"
+       transform="matrix(0.70605846,-0.70815355,0.70605846,0.70815355,0,0)" />
+  </g>
+</svg>

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -201,6 +201,21 @@ void ScriptEditorDebugger::debug_copy() {
 	OS::get_singleton()->set_clipboard(msg);
 }
 
+void ScriptEditorDebugger::debug_skip_breakpoints() {
+	skip_breakpoints_value = !skip_breakpoints_value;
+	if (skip_breakpoints_value)
+		skip_breakpoints->set_icon(get_icon("DebugSkipBreakpointsOn", "EditorIcons"));
+	else
+		skip_breakpoints->set_icon(get_icon("DebugSkipBreakpointsOff", "EditorIcons"));
+
+	if (connection.is_valid()) {
+		Array msg;
+		msg.push_back("set_skip_breakpoints");
+		msg.push_back(skip_breakpoints_value);
+		ppeer->put_var(msg);
+	}
+}
+
 void ScriptEditorDebugger::debug_next() {
 
 	ERR_FAIL_COND(!breaked);
@@ -1083,7 +1098,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 
 			inspector->edit(variables);
-
+			skip_breakpoints->set_icon(get_icon("DebugSkipBreakpointsOff", "EditorIcons"));
 			copy->set_icon(get_icon("ActionCopy", "EditorIcons"));
 
 			step->set_icon(get_icon("DebugStep", "EditorIcons"));
@@ -1785,6 +1800,10 @@ void ScriptEditorDebugger::reload_scripts() {
 	}
 }
 
+bool ScriptEditorDebugger::is_skip_breakpoints() {
+	return skip_breakpoints_value;
+}
+
 void ScriptEditorDebugger::_error_activated() {
 	TreeItem *selected = error_tree->get_selected();
 
@@ -1980,6 +1999,7 @@ void ScriptEditorDebugger::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_stack_dump_frame_selected"), &ScriptEditorDebugger::_stack_dump_frame_selected);
 
+	ClassDB::bind_method(D_METHOD("debug_skip_breakpoints"), &ScriptEditorDebugger::debug_skip_breakpoints);
 	ClassDB::bind_method(D_METHOD("debug_copy"), &ScriptEditorDebugger::debug_copy);
 
 	ClassDB::bind_method(D_METHOD("debug_next"), &ScriptEditorDebugger::debug_next);
@@ -2064,6 +2084,13 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		reason->set_autowrap(true);
 		reason->set_max_lines_visible(3);
 		reason->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+
+		hbc->add_child(memnew(VSeparator));
+
+		skip_breakpoints = memnew(ToolButton);
+		hbc->add_child(skip_breakpoints);
+		skip_breakpoints->set_tooltip(TTR("Skip Breakpoints"));
+		skip_breakpoints->connect("pressed", this, "debug_skip_breakpoints");
 
 		hbc->add_child(memnew(VSeparator));
 

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -109,12 +109,15 @@ class ScriptEditorDebugger : public Control {
 
 	bool hide_on_stop;
 	bool enable_external_editor;
+
+	bool skip_breakpoints_value = false;
 	Ref<Script> stack_script;
 
 	TabContainer *tabs;
 
 	Label *reason;
 
+	Button *skip_breakpoints;
 	Button *copy;
 	Button *step;
 	Button *next;
@@ -219,6 +222,7 @@ public:
 	void unpause();
 	void stop();
 
+	void debug_skip_breakpoints();
 	void debug_copy();
 
 	void debug_next();
@@ -255,6 +259,8 @@ public:
 	void set_tool_button(Button *p_tb) { debugger_button = p_tb; }
 
 	void reload_scripts();
+
+	bool is_skip_breakpoints();
 
 	virtual Size2 get_minimum_size() const;
 	ScriptEditorDebugger(EditorNode *p_editor = NULL);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -386,6 +386,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	bool upwards = false;
 	String debug_mode;
 	String debug_host;
+	bool skip_breakpoints = false;
 	String main_pack;
 	bool quiet_stdout = false;
 	int rtm = -1;
@@ -737,6 +738,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			print_fps = true;
 		} else if (I->get() == "--disable-crash-handler") {
 			OS::get_singleton()->disable_crash_handler();
+		} else if (I->get() == "--skip-breakpoints") {
+			skip_breakpoints = true;
 		} else {
 			main_args.push_back(I->get());
 		}
@@ -805,6 +808,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			debug_host = debug_host.substr(0, sep_pos);
 		}
 		Error derr = sdr->connect_to_host(debug_host, debug_port);
+
+		sdr->set_skip_breakpoints(skip_breakpoints);
 
 		if (derr != OK) {
 			memdelete(sdr);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -223,7 +223,7 @@ bool GDScriptLanguage::debug_break_parse(const String &p_file, int p_line, const
 		_debug_parse_err_line = p_line;
 		_debug_parse_err_file = p_file;
 		_debug_error = p_error;
-		ScriptDebugger::get_singleton()->debug(this, false);
+		ScriptDebugger::get_singleton()->debug(this, false, true);
 		return true;
 	} else {
 		return false;
@@ -237,7 +237,8 @@ bool GDScriptLanguage::debug_break(const String &p_error, bool p_allow_continue)
 		_debug_parse_err_line = -1;
 		_debug_parse_err_file = "";
 		_debug_error = p_error;
-		ScriptDebugger::get_singleton()->debug(this, p_allow_continue);
+		bool is_error_breakpoint = p_error != "Breakpoint";
+		ScriptDebugger::get_singleton()->debug(this, p_allow_continue, is_error_breakpoint);
 		return true;
 	} else {
 		return false;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1101,7 +1101,7 @@ bool CSharpLanguage::debug_break_parse(const String &p_file, int p_line, const S
 		_debug_parse_err_line = p_line;
 		_debug_parse_err_file = p_file;
 		_debug_error = p_error;
-		ScriptDebugger::get_singleton()->debug(this, false);
+		ScriptDebugger::get_singleton()->debug(this, false, true);
 		return true;
 	} else {
 		return false;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2450,7 +2450,7 @@ bool VisualScriptLanguage::debug_break_parse(const String &p_file, int p_node, c
 		_debug_parse_err_node = p_node;
 		_debug_parse_err_file = p_file;
 		_debug_error = p_error;
-		ScriptDebugger::get_singleton()->debug(this, false);
+		ScriptDebugger::get_singleton()->debug(this, false, true);
 		return true;
 	} else {
 		return false;
@@ -2464,7 +2464,7 @@ bool VisualScriptLanguage::debug_break(const String &p_error, bool p_allow_conti
 		_debug_parse_err_node = -1;
 		_debug_parse_err_file = "";
 		_debug_error = p_error;
-		ScriptDebugger::get_singleton()->debug(this, p_allow_continue);
+		ScriptDebugger::get_singleton()->debug(this, p_allow_continue, true);
 		return true;
 	} else {
 		return false;


### PR DESCRIPTION
Closes part of #27028
This implements feature of disabling and enabling breakpoints. I've added button next to debug icons:
Breakpoints enabled:
![image](https://user-images.githubusercontent.com/9964886/62168107-0b85f100-b325-11e9-8172-0a24be308162.png)

Breakpoints disabled:
![image](https://user-images.githubusercontent.com/9964886/62168121-1a6ca380-b325-11e9-9d46-93ab9e408d47.png)


This setting is stored in memory and is set to enabling breakpoints at every editor startup. Skipping breakpoints happens in remote application where flag value is checked. I've added new startup argument for app launched from godot as well as wired up skip-breakpoints button to peer stream communication with remote debugger in case of changes when game is already running.

Feedback very welcome, this is feature draft and can be changed - icons suggestions especially welcome (I sux at drawing). Also I'm not sure if I should do anything with local debugger.

Scenarios tested:

1. Turn on skip breakpoints -> run game -> observe breakpoints not working
2. Don't turn on skipbreakpoints -> run game -> observe breakpoints working
3. Run game with skip breakpoints off -> turn feature on -> observe breakpoints not working
4. Run game with skip breakpoints on -> turn feature off -> observe breakpoints working
5. Run game and stop in breakpoint -> turn skip breakpoints on -> observe breakpoints not working after clicking continue