### PR TITLE
Fix ProgressBar Wrong Value with Border

### DIFF
--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -60,7 +60,7 @@ void ProgressBar::_notification(int p_what) {
 		draw_style_box(bg, Rect2(Point2(), get_size()));
 		float r = get_as_ratio();
 		int mp = fg->get_minimum_size().width;
-		int p = r * get_size().width - mp;
+		int p = r * (get_size().width - mp);
 		if (p > 0) {
 
 			draw_style_box(fg, Rect2(Point2(), Size2(p + fg->get_minimum_size().width, get_size().height)));


### PR DESCRIPTION
Closes: #30969

The FG rectangle of the progressbar is incorrect when dealing with a non-zero border. This issue stems from wrong order of operations when drawing the rectangle: https://github.com/godotengine/godot/blob/ce615c1a828db38864b5eec5854376e745e5617e/scene/gui/progress_bar.cpp#L63

The correct solution is to first calculate the width, and then multiply that value by the range value as a ratio (basically, surround with parenthesis so that subtracting by mp isn't the last operation).