### PR TITLE
Cap the number of warnings/errors per second rather than per frame

### DIFF
--- a/core/script_debugger_remote.h
+++ b/core/script_debugger_remote.h
@@ -91,11 +91,15 @@ class ScriptDebuggerRemote : public ScriptDebugger {
 	int max_messages_per_frame;
 	int n_messages_dropped;
 	List<OutputError> errors;
-	int max_errors_per_frame;
+	int max_errors_per_second;
+	int max_warnings_per_second;
 	int n_errors_dropped;
+	int n_warnings_dropped;
 
 	int max_cps;
 	int char_count;
+	int err_count;
+	int warn_count;
 	uint64_t last_msec;
 	uint64_t msec_count;
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -650,11 +650,14 @@
 		<member name="network/limits/debugger_stdout/max_chars_per_second" type="int" setter="" getter="" default="2048">
 			Maximum amount of characters allowed to send as output from the debugger. Over this value, content is dropped. This helps not to stall the debugger connection.
 		</member>
-		<member name="network/limits/debugger_stdout/max_errors_per_frame" type="int" setter="" getter="" default="10">
-			Maximum amount of errors allowed to send as output from the debugger. Over this value, content is dropped. This helps not to stall the debugger connection.
+		<member name="network/limits/debugger_stdout/max_errors_per_second" type="int" setter="" getter="" default="100">
+			Maximum number of errors allowed to be sent as output from the debugger. Over this value, content is dropped. This helps not to stall the debugger connection.
 		</member>
 		<member name="network/limits/debugger_stdout/max_messages_per_frame" type="int" setter="" getter="" default="10">
 			Maximum amount of messages allowed to send as output from the debugger. Over this value, content is dropped. This helps not to stall the debugger connection.
+		</member>
+		<member name="network/limits/debugger_stdout/max_warnings_per_second" type="int" setter="" getter="" default="100">
+			Maximum number of warnings allowed to be sent as output from the debugger. Over this value, content is dropped. This helps not to stall the debugger connection.
 		</member>
 		<member name="network/limits/packet_peer_stream/max_buffer_po2" type="int" setter="" getter="" default="16">
 			Default size of packet peer stream for deserializing Godot data. Over this size, data is dropped.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -783,8 +783,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger_stdout/max_chars_per_second", PropertyInfo(Variant::INT, "network/limits/debugger_stdout/max_chars_per_second", PROPERTY_HINT_RANGE, "0, 4096, 1, or_greater"));
 	GLOBAL_DEF("network/limits/debugger_stdout/max_messages_per_frame", 10);
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger_stdout/max_messages_per_frame", PropertyInfo(Variant::INT, "network/limits/debugger_stdout/max_messages_per_frame", PROPERTY_HINT_RANGE, "0, 20, 1, or_greater"));
-	GLOBAL_DEF("network/limits/debugger_stdout/max_errors_per_frame", 10);
-	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger_stdout/max_errors_per_frame", PropertyInfo(Variant::INT, "network/limits/debugger_stdout/max_errors_per_frame", PROPERTY_HINT_RANGE, "0, 20, 1, or_greater"));
+	GLOBAL_DEF("network/limits/debugger_stdout/max_errors_per_second", 100);
+	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger_stdout/max_errors_per_second", PropertyInfo(Variant::INT, "network/limits/debugger_stdout/max_errors_per_second", PROPERTY_HINT_RANGE, "0, 200, 1, or_greater"));
+	GLOBAL_DEF("network/limits/debugger_stdout/max_warnings_per_second", 100);
+	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger_stdout/max_warnings_per_second", PropertyInfo(Variant::INT, "network/limits/debugger_stdout/max_warnings_per_second", PROPERTY_HINT_RANGE, "0, 200, 1, or_greater"));
 
 	if (debug_mode == "remote") {
 


### PR DESCRIPTION
This reproduces the behavior used for printing when using the remote debugger. The default limit is 100 errors and 100 warnings per second, which makes it possible to display much more GDScript warnings before overflowing.

This also adds a "Too many warnings" message, so that warnings don't look like errors when overflowing anymore.

Please test this in your own projects :smiley:

This closes #21896.