### PR TITLE
Fixed regression in Godot Physics

### DIFF
--- a/servers/physics/collision_solver_sat.cpp
+++ b/servers/physics/collision_solver_sat.cpp
@@ -274,8 +274,8 @@ static void _generate_contacts_from_supports(const Vector3 *p_points_A, int p_po
 		points_B = p_points_B;
 	}
 
-	int version_A = (pointcount_A > 2 ? 2 : pointcount_A) - 1;
-	int version_B = (pointcount_B > 2 ? 2 : pointcount_B) - 1;
+	int version_A = (pointcount_A > 3 ? 3 : pointcount_A) - 1;
+	int version_B = (pointcount_B > 3 ? 3 : pointcount_B) - 1;
 
 	GenerateContactsFunc contacts_func = generate_contacts_func_table[version_A][version_B];
 	ERR_FAIL_COND(!contacts_func);


### PR DESCRIPTION
Reverted a fix that makes sense for collision_solver_2d_sat but not for the 3d version.
Original commit: aab8da25ad2c3e6d2df03abbc8e35c1725938c40
Fixes #30886

@qarmin: Looks like the fix in the 2d solver was made in the 3d solver as well by mistake, but better for you to review it to make sure I'm not missing something :)

In  servers/physics/collision_solver_2d_sat.cpp:
`static const GenerateContactsFunc generate_contacts_func_table[2][2]`

So it makes sense to use:
```
int version_A = (pointcount_A > 2 ? 2 : pointcount_A) - 1;
int version_B = (pointcount_B > 2 ? 2 : pointcount_B) - 1;
```

But in  servers/physics/collision_solver_sat.cpp:
`static const GenerateContactsFunc generate_contacts_func_table[3][3]`

It has to stay as it was before:
```
int version_A = (pointcount_A > 3 ? 3 : pointcount_A) - 1;
int version_B = (pointcount_B > 3 ? 3 : pointcount_B) - 1;
```