### PR TITLE
Don't add unsaved scene to previous scenes list when closing a tab

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2640,7 +2640,9 @@ void EditorNode::_discard_changes(const String &p_str) {
 			Node *scene = editor_data.get_edited_scene_root(tab_closing);
 			if (scene != NULL) {
 				String scene_filename = scene->get_filename();
-				previous_scenes.push_back(scene_filename);
+				if (scene_filename != "") {
+					previous_scenes.push_back(scene_filename);
+				}
 			}
 
 			_remove_scene(tab_closing);


### PR DESCRIPTION
Add a check I forgot in #27952, it was possible to try to reopen a never saved scene, which would throw an error.