### PR TITLE
Add descriptive tooltips in VS editor

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -776,8 +776,8 @@ void VisualScriptEditor::_update_members() {
 	TreeItem *functions = members->create_item(root);
 	functions->set_selectable(0, false);
 	functions->set_text(0, TTR("Functions:"));
-	functions->add_button(0, Control::get_icon("Override", "EditorIcons"), 1);
-	functions->add_button(0, Control::get_icon("Add", "EditorIcons"), 0);
+	functions->add_button(0, Control::get_icon("Override", "EditorIcons"), 1, false, TTR("Override an existing built-in function."));
+	functions->add_button(0, Control::get_icon("Add", "EditorIcons"), 0, false, TTR("Create a new function."));
 	functions->set_custom_color(0, Control::get_color("mono_color", "Editor"));
 
 	List<StringName> func_names;
@@ -795,7 +795,7 @@ void VisualScriptEditor::_update_members() {
 	TreeItem *variables = members->create_item(root);
 	variables->set_selectable(0, false);
 	variables->set_text(0, TTR("Variables:"));
-	variables->add_button(0, Control::get_icon("Add", "EditorIcons"));
+	variables->add_button(0, Control::get_icon("Add", "EditorIcons"), -1, false, TTR("Create a new variable."));
 	variables->set_custom_color(0, Control::get_color("mono_color", "Editor"));
 
 	Ref<Texture> type_icons[Variant::VARIANT_MAX] = {
@@ -848,7 +848,7 @@ void VisualScriptEditor::_update_members() {
 	TreeItem *_signals = members->create_item(root);
 	_signals->set_selectable(0, false);
 	_signals->set_text(0, TTR("Signals:"));
-	_signals->add_button(0, Control::get_icon("Add", "EditorIcons"));
+	_signals->add_button(0, Control::get_icon("Add", "EditorIcons"), -1, false, TTR("Create a new signal."));
 	_signals->set_custom_color(0, Control::get_color("mono_color", "Editor"));
 
 	List<StringName> signal_names;


### PR DESCRIPTION
In the Visual Script editor, the override icon is not very clear what it's intended purpose is for. Currently, its tooltip just says: "Function:" which is the same tooltip as the "add new function" icon.

To resolve this issue, this PR adds descriptive tooltips to the following icons in the Visual Script editor: 
-Override Function
-Add Function
-Add Variable
-Add Signal