### PR TITLE
Path to DotNet relative to project

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
@@ -38,7 +38,7 @@
       -->
       <HintPath Condition=" '$(SolutionDir)' != '' ">$(SolutionDir)\packages\DotNet.Glob.2.1.1\lib\net45\DotNet.Glob.dll</HintPath>
       <HintPath>$(ProjectDir)\packages\DotNet.Glob.2.1.1\lib\net45\DotNet.Glob.dll</HintPath>
-      <HintPath>packages\DotNet.Glob.2.1.1\lib\net45\DotNet.Glob.dll</HintPath> <!-- Are you happy CI? -->
+      <HintPath>..\packages\DotNet.Glob.2.1.1\lib\net45\DotNet.Glob.dll</HintPath> <!-- Are you happy CI? -->
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
@@ -31,14 +31,7 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.Build" />
     <Reference Include="DotNet.Glob, Version=2.1.1.0, Culture=neutral, PublicKeyToken=b68cc888b4f632d1, processorArchitecture=MSIL">
-      <!--
-      When building Godot with 'mono_glue=no' SCons will build this project alone instead of the
-      entire solution. $(SolutionDir) is not defined in that case, so we need to workaround that.
-      We make SCons restore the NuGet packages in the project directory instead in this case.
-      -->
-      <HintPath Condition=" '$(SolutionDir)' != '' ">$(SolutionDir)\packages\DotNet.Glob.2.1.1\lib\net45\DotNet.Glob.dll</HintPath>
       <HintPath>$(ProjectDir)\packages\DotNet.Glob.2.1.1\lib\net45\DotNet.Glob.dll</HintPath>
-      <HintPath>..\packages\DotNet.Glob.2.1.1\lib\net45\DotNet.Glob.dll</HintPath> <!-- Are you happy CI? -->
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
For a fresh build, more specifically, if GodotTools.ProjectEditor wasn't build and there is no binaries already generated I always get this error:

>   ProjectExtensions.cs(3,7): error CS0246: The type or namespace name 'DotNet' could not be found (are you missing a us
> ing directive or an assembly reference?) [F:\Godot\godot\modules\mono\editor\GodotTools\GodotTools.ProjectEditor\GodotT
> ools.ProjectEditor.csproj]
>   ProjectUtils.cs(6,7): error CS0246: The type or namespace name 'DotNet' could not be found (are you missing a using d
> irective or an assembly reference?) [F:\Godot\godot\modules\mono\editor\GodotTools\GodotTools.ProjectEditor\GodotTools.
> ProjectEditor.csproj]

It builds fine with or without mono_glue with the correct relative HintPath.