### PR TITLE
Improve the gizmo axis colors and increase the manipulator opacity

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -528,7 +528,8 @@ private:
 	Ref<ArrayMesh> move_gizmo[3], move_plane_gizmo[3], rotate_gizmo[3], scale_gizmo[3], scale_plane_gizmo[3];
 	Ref<SpatialMaterial> gizmo_color[3];
 	Ref<SpatialMaterial> plane_gizmo_color[3];
-	Ref<SpatialMaterial> gizmo_hl;
+	Ref<SpatialMaterial> gizmo_color_hl[3];
+	Ref<SpatialMaterial> plane_gizmo_color_hl[3];
 
 	int over_gizmo_handle;
 
@@ -635,6 +636,7 @@ private:
 	Node *custom_camera;
 
 	Object *_get_editor_data(Object *p_what);
+	Color _get_axis_color(int axis);
 
 	Ref<Environment> viewport_environment;
 


### PR DESCRIPTION
The new colors should make it easier to see the manipulator gizmo. Highlighted gizmos are now fully opaque (instead of being white), keeping the color information while a gizmo is highlighted.

This also adds a setting hint for the manipulator gizmo opacity editor setting.

Axis colors were taken from Blender 2.80.

This partially addresses #16154.

## Preview

### Normal

![image](https://user-images.githubusercontent.com/180032/62293147-3f1d6400-b468-11e9-8f1d-7ef2b7f47e4c.png)

### X axis arrow highlighted

![image](https://user-images.githubusercontent.com/180032/62293259-77bd3d80-b468-11e9-96ad-514392e764fc.png)