### PR TITLE
Fix error when building assimp on older Mac OS X version

### DIFF
--- a/thirdparty/assimp/include/assimp/scene.h
+++ b/thirdparty/assimp/include/assimp/scene.h
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "material.h"
 #include "anim.h"
 #include "metadata.h"
+#include <cstdlib>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Prevents this error when building with Mac OS X 10.9 SDK:

    error: no member named 'atoi' in namespace 'std'; did you mean simply 'atoi'?

As this fix relates to third party code, I assume it would be preferred to get the fix accepted upstream? Have made this PR so it can be included in Godot immediately, if desired, but will also aim to PR upstream.

### References/related links

* Issue introduced by this recent commit: https://github.com/assimp/assimp/commit/575ef4d9276c4755ce168e116e8248d123b93d2a#diff-1a9ad172ca41bc12efb1483ce5b2b48eR392

* Similar fixes/issues:
    * https://github.com/assimp/assimp/pull/541/files
    * https://github.com/assimp/assimp/commit/f435712273a7bfec295e341e1d19910d837b4303
    * https://trac.macports.org/ticket/41049
    * https://trac.macports.org/attachment/ticket/41049/ipe-cstdlib.patch
    * https://trac.macports.org/ticket/41371

### Full error message

```
...
[  8%] Compiling ==> thirdparty/assimp/code/Common/ScenePreprocessor.cpp
In file included from thirdparty/assimp/code/Common/ScenePreprocessor.cpp:45:
thirdparty/assimp/include/assimp/scene.h:394:25: error: no member named 'atoi' in namespace 'std'; did you mean simply 'atoi'?
            int index = std::atoi(filename + 1);
                        ^~~~~~~~~
                        atoi
/Developer/SDKs/MacOSX10.9.sdk/usr/include/stdlib.h:132:6: note: 'atoi' declared here
int      atoi(const char *);
         ^
1 error generated.
scons: *** [thirdparty/assimp/code/Common/ScenePreprocessor.osx.tools.64.o] Error 1
scons: building terminated because of errors.
```
