### PR TITLE
Mark class_name line as safe in editor

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3472,6 +3472,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 			} break;
 			case GDScriptTokenizer::TK_PR_CLASS_NAME: {
 
+				_mark_line_as_safe(tokenizer->get_token_line());
 				if (p_class->owner) {
 					_set_error("'class_name' is only valid for the main class namespace.");
 					return;


### PR DESCRIPTION
Fixes #21509

Putting "class_name XXX" in front of "extends YYY" is not permitted anymore in latest master branch.
Line that has "class_name XXX" is now properly displayed as a "safe" line

Is just adding the _mark_line_as_safe() the way to do this?

new:
![Capture](https://user-images.githubusercontent.com/42484461/62390193-f5b13f80-b561-11e9-9a01-53315def42f3.PNG)

old:
![old](https://user-images.githubusercontent.com/42484461/62390288-3315cd00-b562-11e9-8e79-68258057cf07.PNG)