### PR TITLE
Fixes color picker in code editor - it now only changes one color

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1572,7 +1572,9 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 
 			if (has_color) {
 				String line = tx->get_line(row);
-				color_line = row;
+				color_position.x = row;
+				color_position.y = col;
+
 				int begin = 0;
 				int end = 0;
 				bool valid = false;
@@ -1612,10 +1614,15 @@ void ScriptTextEditor::_color_changed(const Color &p_color) {
 		new_args = String("(" + rtos(p_color.r) + ", " + rtos(p_color.g) + ", " + rtos(p_color.b) + ", " + rtos(p_color.a) + ")");
 	}
 
-	String line = code_editor->get_text_edit()->get_line(color_line);
-	String new_line = line.replace(color_args, new_args);
+	String line = code_editor->get_text_edit()->get_line(color_position.x);
+	int color_args_pos = line.find(color_args, color_position.y);
+	String line_with_replaced_args = line;
+	line_with_replaced_args.erase(color_args_pos, color_args.length());
+	line_with_replaced_args = line_with_replaced_args.insert(color_args_pos, new_args);
+
 	color_args = new_args;
-	code_editor->get_text_edit()->set_line(color_line, new_line);
+	code_editor->get_text_edit()->set_line(color_position.x, line_with_replaced_args);
+	code_editor->get_text_edit()->update();
 }
 
 void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, bool p_goto_definition) {
@@ -1710,6 +1717,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	color_panel = memnew(PopupPanel);
 	add_child(color_panel);
 	color_picker = memnew(ColorPicker);
+	color_picker->set_deferred_mode(true);
 	color_panel->add_child(color_picker);
 	color_picker->connect("color_changed", this, "_color_changed");
 

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -81,7 +81,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 
 	PopupPanel *color_panel;
 	ColorPicker *color_picker;
-	int color_line;
+	Vector2 color_position;
 	String color_args;
 
 	void _update_member_keywords();


### PR DESCRIPTION
Closes #29100
This PR fixes multiple issues with color picker that can be used in code editor. 

### Before:
![old_picker](https://user-images.githubusercontent.com/9964886/62397294-b7258000-b575-11e9-857e-10ac37ea1c3d.gif)
Notice that all matching arguments list in line are changing (also function argument list not only colors!) and there is delay before change.

### After:
![correct_picker](https://user-images.githubusercontent.com/9964886/62397348-e0dea700-b575-11e9-985b-dfda6598a966.gif)

### Fixes include:
1) Now only argument list of color under cursor changes
2) Now values update without delay
3) ColorPicker is correctly (I believe) set to deffered mode so change signal function gets called only when user actually selects color and not at every mouse movement - this can update performance quite a bit

### Not fixed:
Changes done via color picker in this way can't be undone, will create issue for that.