### PR TITLE
Return back spacer for non-expression nodes in visual shader

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -604,6 +604,10 @@ void VisualShaderEditor::_update_graph() {
 					}
 				}
 
+				if (!is_group) {
+					hb->add_spacer();
+				}
+
 				if (valid_right) {
 					if (is_group) {
 						Button *remove_btn = memnew(Button);


### PR DESCRIPTION
Just a fix for small regression I made in https://github.com/godotengine/godot/pull/31010
Non-expression nodes should have that offset..

![image](https://user-images.githubusercontent.com/3036176/62414212-a847d780-b620-11e9-948a-b9587ec19248.png)
