### PR TITLE
Fix row-column-swap in TileMap palette

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -521,7 +521,13 @@ void TileMapEditor::_update_palette() {
 			for (const Map<Vector2, uint32_t>::Element *E = tiles2.front(); E; E = E->next()) {
 				entries2.push_back(E->key());
 			}
-			entries2.sort();
+			// Sort tiles in row-major order
+			struct SwapComparator {
+				_FORCE_INLINE_ bool operator()(const Vector2 &v_l, const Vector2 &v_r) const {
+					return v_l.y != v_r.y ? v_l.y < v_r.y : v_l.x < v_r.x;
+				}
+			};
+			entries2.sort_custom<SwapComparator>();
 
 			Ref<Texture> tex = tileset->tile_get_texture(sel_tile);
 


### PR DESCRIPTION
Due to the TileSet coordinates using x for columns and y for rows, the columns are assigned to the rows in the TileMap palette and distort the order. Thus the default sorting algorithm prioritizing x is replaced with a custom one prioritizing y.

Fixes #24751