### PR TITLE
Added pause timeline button for scenes within the editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6407,6 +6407,9 @@ EditorNode::EditorNode() {
 
 	preview_gen = memnew(AudioStreamPreviewGenerator);
 	add_child(preview_gen);
+
+	ED_SHORTCUT("editor/editor_timeline_pause", TTR("Pause Timeline"), KEY_PAUSE);
+
 	//plugin stuff
 
 	file_server = memnew(EditorFileServer);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -218,11 +218,16 @@ private:
 
 	HScrollBar *h_scroll;
 	VScrollBar *v_scroll;
+
+	HBoxContainer *main_hb;
 	HBoxContainer *hb;
+	HBoxContainer *extra_hb;
 
 	ToolButton *zoom_minus;
 	ToolButton *zoom_reset;
 	ToolButton *zoom_plus;
+
+	ToolButton *pause_button;
 
 	Map<Control *, Timer *> popup_temporarily_timers;
 
@@ -420,6 +425,7 @@ private:
 	void _snap_changed();
 	void _selection_result_pressed(int);
 	void _selection_menu_hide();
+	void _timeline_pause_button_toggled(bool pressed);
 
 	UndoRedo *undo_redo;
 	bool _build_bones_list(Node *p_node);
@@ -588,6 +594,8 @@ public:
 	void set_undo_redo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; }
 	void edit(CanvasItem *p_canvas_item);
 
+	void set_pause_button_pressed(bool p_pressed);
+
 	void focus_selection();
 
 	bool is_anchors_mode_enabled() { return anchors_mode; };
@@ -610,6 +618,7 @@ public:
 	virtual void make_visible(bool p_visible);
 	virtual Dictionary get_state() const;
 	virtual void set_state(const Dictionary &p_state);
+	virtual void selected_notify();
 
 	CanvasItemEditor *get_canvas_item_editor() { return canvas_item_editor; }
 

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -590,6 +590,8 @@ private:
 	ToolButton *lock_button;
 	ToolButton *unlock_button;
 
+	ToolButton *pause_button;
+
 	AcceptDialog *accept;
 
 	ConfirmationDialog *snap_dialog;
@@ -617,8 +619,11 @@ private:
 	void _menu_item_pressed(int p_option);
 	void _menu_item_toggled(bool pressed, int p_option);
 	void _menu_gizmo_toggled(int p_option);
+	void _timeline_pause_button_toggled(bool pressed);
 
+	HBoxContainer *main_hbc_menu;
 	HBoxContainer *hbc_menu;
+	HBoxContainer *extra_hbc_menu;
 
 	void _generate_selection_box();
 	UndoRedo *undo_redo;
@@ -729,6 +734,8 @@ public:
 	void edit(Spatial *p_spatial);
 	void clear();
 
+	void set_pause_button_pressed(bool p_pressed);
+
 	SpatialEditor(EditorNode *p_editor);
 	~SpatialEditor();
 };
@@ -752,6 +759,7 @@ public:
 	virtual void make_visible(bool p_visible);
 	virtual void edit(Object *p_object);
 	virtual bool handles(Object *p_object) const;
+	virtual void selected_notify();
 
 	virtual Dictionary get_state() const;
 	virtual void set_state(const Dictionary &p_state);


### PR DESCRIPTION
I think its useful to give the user possbility to stop game animations within the editor by setting editor time_scale to zero. Its useful when there is a lot of tool script or dynamic shaders within the scene and you want to pause and look at them at one moment. So I've just added a small button to do it. Its visible in both 2D and 3D editors.

![pause_demo](https://user-images.githubusercontent.com/3036176/62421036-6bbdbf80-b6a4-11e9-99ff-3918c3c45758.gif)

![_pause_demo2](https://user-images.githubusercontent.com/3036176/62421154-f0f5a400-b6a5-11e9-8d11-ca123862e4e8.gif)

Close #16397.