### PR TITLE
Fix ProjectSettings.add_property_info ERR_FAIL_COND check.

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -916,7 +916,7 @@ void ProjectSettings::_add_property_info_bind(const Dictionary &p_info) {
 
 	PropertyInfo pinfo;
 	pinfo.name = p_info["name"];
-	ERR_FAIL_COND(!props.has(pinfo.name));
+	ERR_FAIL_COND(props.has(pinfo.name));
 	pinfo.type = Variant::Type(p_info["type"].operator int());
 	ERR_FAIL_INDEX(pinfo.type, Variant::VARIANT_MAX);
 


### PR DESCRIPTION
This method currently outputs an error to the console when you "add a property info" that has a unique name. If you add it via the GUI, it takes an entirely separate path and never calls this `_add_property_info_bind` method. The bug only occurs when you use the scripting API method.