### PR TITLE
Use underline position and thickness value in font file

### DIFF
--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -111,11 +111,11 @@ void LinkButton::_notification(int p_what) {
 			draw_string(font, Vector2(0, font->get_ascent()), text, color);
 
 			if (do_underline) {
-				int underline_spacing = get_theme_constant("underline_spacing");
+				int underline_spacing = get_theme_constant("underline_spacing") + font->get_underline_position();
 				int width = font->get_string_size(text).width;
 				int y = font->get_ascent() + underline_spacing;
 
-				draw_line(Vector2(0, y), Vector2(width, y), color);
+				draw_line(Vector2(0, y), Vector2(width, y), color, font->get_underline_thickness());
 			}
 
 		} break;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -600,8 +600,8 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 						if (underline) {
 							Color uc = color;
 							uc.a *= 0.5;
-							int uy = y + lh - line_descent + 2;
-							float underline_width = 1.0;
+							int uy = y + lh - line_descent + font->get_underline_position();
+							float underline_width = font->get_underline_thickness();
 #ifdef TOOLS_ENABLED
 							underline_width *= EDSCALE;
 #endif
@@ -610,7 +610,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 							Color uc = color;
 							uc.a *= 0.5;
 							int uy = y + lh - (line_ascent + line_descent) / 2;
-							float strikethrough_width = 1.0;
+							float strikethrough_width = font->get_underline_thickness();
 #ifdef TOOLS_ENABLED
 							strikethrough_width *= EDSCALE;
 #endif

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1487,12 +1487,12 @@ void TextEdit::_notification(int p_what) {
 							int yofs = ofs_y + (get_row_height() - cache.font->get_height()) / 2;
 							int w = drawer.draw_char(ci, Point2i(char_ofs + char_margin + ofs_x, yofs + ascent), str[j], str[j + 1], in_selection && override_selected_font_color ? cache.font_color_selected : color);
 							if (underlined) {
-								float line_width = 1.0;
+								float line_width = cache.font->get_underline_thickness();
 #ifdef TOOLS_ENABLED
 								line_width *= EDSCALE;
 #endif
 
-								draw_rect(Rect2(char_ofs + char_margin + ofs_x, yofs + ascent + 2, w, line_width), in_selection && override_selected_font_color ? cache.font_color_selected : color);
+								draw_rect(Rect2(char_ofs + char_margin + ofs_x, yofs + ascent + cache.font->get_underline_position(), w, line_width), in_selection && override_selected_font_color ? cache.font_color_selected : color);
 							}
 						} else if (draw_tabs && str[j] == '\t') {
 							int yofs = (get_row_height() - cache.tab_icon->get_height()) / 2;

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -221,6 +221,8 @@ Error DynamicFontAtSize::_load() {
 
 	ascent = (face->size->metrics.ascender / 64.0) / oversampling * scale_color_font;
 	descent = (-face->size->metrics.descender / 64.0) / oversampling * scale_color_font;
+	underline_position = -face->underline_position / 64.0 / oversampling * scale_color_font;
+	underline_thickness = face->underline_thickness / 64.0 / oversampling * scale_color_font;
 	linegap = 0;
 
 	valid = true;
@@ -241,6 +243,16 @@ float DynamicFontAtSize::get_ascent() const {
 float DynamicFontAtSize::get_descent() const {
 
 	return descent;
+}
+
+float DynamicFontAtSize::get_underline_position() const {
+
+	return underline_position;
+}
+
+float DynamicFontAtSize::get_underline_thickness() const {
+
+	return underline_thickness;
 }
 
 const Pair<const DynamicFontAtSize::Character *, DynamicFontAtSize *> DynamicFontAtSize::_find_char_with_font(CharType p_char, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks) const {
@@ -819,6 +831,22 @@ float DynamicFont::get_descent() const {
 		return 1;
 
 	return data_at_size->get_descent() + spacing_bottom;
+}
+
+float DynamicFont::get_underline_position() const {
+
+	if (!data_at_size.is_valid())
+		return 2;
+
+	return data_at_size->get_underline_position();
+}
+
+float DynamicFont::get_underline_thickness() const {
+
+	if (!data_at_size.is_valid())
+		return 1;
+
+	return data_at_size->get_underline_thickness();
 }
 
 Size2 DynamicFont::get_char_size(CharType p_char, CharType p_next) const {

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -124,6 +124,8 @@ class DynamicFontAtSize : public Reference {
 	float rect_margin;
 	float oversampling;
 	float scale_color_font;
+	float underline_position;
+	float underline_thickness;
 
 	bool valid;
 
@@ -187,6 +189,8 @@ public:
 
 	float get_ascent() const;
 	float get_descent() const;
+	float get_underline_position() const;
+	float get_underline_thickness() const;
 
 	Size2 get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks) const;
 
@@ -274,6 +278,8 @@ public:
 
 	virtual float get_ascent() const;
 	virtual float get_descent() const;
+	virtual float get_underline_position() const;
+	virtual float get_underline_thickness() const;
 
 	virtual Size2 get_char_size(CharType p_char, CharType p_next = 0) const;
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -356,6 +356,16 @@ float BitmapFont::get_descent() const {
 	return height - ascent;
 }
 
+float BitmapFont::get_underline_position() const {
+
+	return 2;
+}
+
+float BitmapFont::get_underline_thickness() const {
+
+	return 1;
+}
+
 void BitmapFont::add_texture(const Ref<Texture2D> &p_texture) {
 
 	ERR_FAIL_COND_MSG(p_texture.is_null(), "It's not a reference to a valid Texture object.");

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -47,6 +47,8 @@ public:
 
 	virtual float get_ascent() const = 0;
 	virtual float get_descent() const = 0;
+	virtual float get_underline_position() const = 0;
+	virtual float get_underline_thickness() const = 0;
 
 	virtual Size2 get_char_size(CharType p_char, CharType p_next = 0) const = 0;
 	Size2 get_string_size(const String &p_string) const;
@@ -167,6 +169,8 @@ public:
 	void set_ascent(float p_ascent);
 	float get_ascent() const;
 	float get_descent() const;
+	float get_underline_position() const;
+	float get_underline_thickness() const;
 
 	void add_texture(const Ref<Texture2D> &p_texture);
 	void add_char(CharType p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance = -1);


### PR DESCRIPTION
not just using constant `2` for position and `1` for thickness.

old on left, new on right.
![underline_1](https://user-images.githubusercontent.com/8281454/62430643-5dca7600-b75a-11e9-9392-41439583077f.png)

old on top, new on bottom.
![underline_2](https://user-images.githubusercontent.com/8281454/62430703-f7922300-b75a-11e9-815b-27934fe53d9f.png)

