### PR TITLE
Optimize Wrap functions

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -255,16 +255,16 @@ public:
 	static _ALWAYS_INLINE_ float round(float p_val) { return (p_val >= 0) ? Math::floor(p_val + 0.5) : -Math::floor(-p_val + 0.5); }
 
 	static _ALWAYS_INLINE_ int64_t wrapi(int64_t value, int64_t min, int64_t max) {
-		int64_t rng = max - min;
-		return (rng != 0) ? min + ((((value - min) % rng) + rng) % rng) : min;
+		int64_t range = max - min;
+		return range == 0 ? min : min + ((((value - min) % range) + range) % range);
 	}
 	static _ALWAYS_INLINE_ double wrapf(double value, double min, double max) {
-		double rng = max - min;
-		return (!is_equal_approx(rng, 0.0)) ? value - (rng * Math::floor((value - min) / rng)) : min;
+		double range = max - min;
+		return is_zero_approx(range) ? min : value - (range * Math::floor((value - min) / range));
 	}
 	static _ALWAYS_INLINE_ float wrapf(float value, float min, float max) {
-		float rng = max - min;
-		return (!is_equal_approx(rng, 0.0f)) ? value - (rng * Math::floor((value - min) / rng)) : min;
+		float range = max - min;
+		return is_zero_approx(range) ? min : value - (range * Math::floor((value - min) / range));
 	}
 
 	// double only, as these functions are mainly used by the editor and not performance-critical,

--- a/modules/mono/glue/Managed/Files/Mathf.cs
+++ b/modules/mono/glue/Managed/Files/Mathf.cs
@@ -336,14 +336,14 @@ namespace Godot
 
         public static int Wrap(int value, int min, int max)
         {
-            int rng = max - min;
-            return rng != 0 ? min + ((value - min) % rng + rng) % rng : min;
+            int range = max - min;
+            return range == 0 ? min : min + ((value - min) % range + range) % range;
         }
 
         public static real_t Wrap(real_t value, real_t min, real_t max)
         {
-            real_t rng = max - min;
-            return !IsEqualApprox(rng, default(real_t)) ? min + ((value - min) % rng + rng) % rng : min;
+            real_t range = max - min;
+            return IsZeroApprox(range) ? min : min + ((value - min) % range + range) % range;
         }
     }
 }


### PR DESCRIPTION
* Use `is_zero_approx()` which has simpler code that runs faster, and avoid a negative. This helper method was not available when these functions were last updated.

* Rename "rng" to "range" to be more clear since I kept reading this as "random number generator". This is an internal rename only, no behavior change.

The changes are made for both core and C#.