### PR TITLE
VulkanLoader: Make Windows includes lowercase for MinGW

### DIFF
--- a/thirdparty/vulkan/loader/loader.c
+++ b/thirdparty/vulkan/loader/loader.c
@@ -60,9 +60,9 @@
 #include "murmurhash.h"
 
 #if defined(_WIN32)
-#include <Cfgmgr32.h>
+#include <cfgmgr32.h>
 #include <initguid.h>
-#include <Devpkey.h>
+#include <devpkey.h>
 #endif
 
 // This is a CMake generated file with #defines for any functions/includes

--- a/thirdparty/vulkan/loader/vk_loader_platform.h
+++ b/thirdparty/vulkan/loader/vk_loader_platform.h
@@ -25,7 +25,7 @@
 
 #if defined(_WIN32)
 // WinSock2.h must be included *BEFORE* windows.h
-#include <WinSock2.h>
+#include <winsock2.h>
 #endif  // _WIN32
 
 #include "vulkan/vk_platform.h"


### PR DESCRIPTION
MinGW-w64 ships all Windows SDK headers as lowercase, which prevents
cross-compiling this code from Linux.

Windows filesystems are case insensitive so it should work fine with
lowercase includes.

PR'ed upstream: https://github.com/KhronosGroup/Vulkan-Loader/pull/212

Fixes #31096.