### PR TITLE
Validate enums to prevent crashes and unexpected behaviour

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -414,6 +414,8 @@ static void _convert(int p_width, int p_height, const uint8_t *p_src, uint8_t *p
 
 void Image::convert(Format p_new_format) {
 
+	ERR_FAIL_INDEX(p_new_format, FORMAT_MAX);
+
 	if (data.size() == 0)
 		return;
 
@@ -885,6 +887,8 @@ void Image::resize_to_po2(bool p_square) {
 
 void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
+	ERR_FAIL_INDEX(p_interpolation, 5); //7);
+
 	if (data.size() == 0) {
 		ERR_EXPLAIN("Cannot resize image before creating it, use create() or create_from_data() first.");
 		ERR_FAIL();
@@ -1282,6 +1286,7 @@ int Image::_get_dst_image_size(int p_width, int p_height, Format p_format, int &
 
 bool Image::_can_modify(Format p_format) const {
 
+	ERR_FAIL_INDEX_V(p_format, FORMAT_MAX, false);
 	return p_format <= FORMAT_RGBE9995;
 }
 
@@ -1595,6 +1600,7 @@ PoolVector<uint8_t> Image::get_data() const {
 
 void Image::create(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
 
+	ERR_FAIL_INDEX(p_format, FORMAT_MAX);
 	ERR_FAIL_INDEX(p_width - 1, MAX_WIDTH);
 	ERR_FAIL_INDEX(p_height - 1, MAX_HEIGHT);
 
@@ -1614,6 +1620,7 @@ void Image::create(int p_width, int p_height, bool p_use_mipmaps, Format p_forma
 
 void Image::create(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const PoolVector<uint8_t> &p_data) {
 
+	ERR_FAIL_INDEX(p_format, FORMAT_MAX);
 	ERR_FAIL_INDEX(p_width - 1, MAX_WIDTH);
 	ERR_FAIL_INDEX(p_height - 1, MAX_HEIGHT);
 
@@ -1962,6 +1969,7 @@ Error Image::decompress() {
 
 Error Image::compress(CompressMode p_mode, CompressSource p_source, float p_lossy_quality) {
 
+	ERR_FAIL_INDEX_V(p_mode, 6, ERR_INVALID_PARAMETER);
 	switch (p_mode) {
 
 		case COMPRESS_S3TC: {

--- a/core/image.h
+++ b/core/image.h
@@ -152,10 +152,12 @@ protected:
 
 private:
 	void _create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
+		ERR_FAIL_INDEX(p_format, FORMAT_MAX);
 		create(p_width, p_height, p_use_mipmaps, p_format);
 	}
 
 	void _create_from_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const PoolVector<uint8_t> &p_data) {
+		ERR_FAIL_INDEX(p_format, FORMAT_MAX);
 		create(p_width, p_height, p_use_mipmaps, p_format, p_data);
 	}
 

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -41,6 +41,7 @@
 
 Error FileAccessEncrypted::open_and_parse(FileAccess *p_base, const Vector<uint8_t> &p_key, Mode p_mode) {
 
+	ERR_FAIL_INDEX_V(p_mode, MODE_MAX, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(file != NULL, ERR_ALREADY_IN_USE);
 	ERR_FAIL_COND_V(p_key.size() != 32, ERR_INVALID_PARAMETER);
 

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -763,6 +763,8 @@ void MultiplayerAPI::rsetp(Node *p_node, int p_peer_id, bool p_unreliable, const
 
 Error MultiplayerAPI::send_bytes(PoolVector<uint8_t> p_data, int p_to, NetworkedMultiplayerPeer::TransferMode p_mode) {
 
+	ERR_EXPLAIN("Trying to set wrong TransferMode");
+	ERR_FAIL_INDEX_V(p_mode, 3, ERR_INVALID_PARAMETER);
 	ERR_EXPLAIN("Trying to send an empty raw packet.");
 	ERR_FAIL_COND_V(p_data.size() < 1, ERR_INVALID_DATA);
 	ERR_EXPLAIN("Trying to send a raw packet while no network peer is active.");

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -951,6 +951,7 @@ PoolVector<Plane> Geometry::build_cylinder_planes(real_t p_radius, real_t p_heig
 }
 
 PoolVector<Plane> Geometry::build_sphere_planes(real_t p_radius, int p_lats, int p_lons, Vector3::Axis p_axis) {
+	ERR_FAIL_INDEX_V(p_axis, 3, PoolVector<Plane>());
 
 	PoolVector<Plane> planes;
 
@@ -984,6 +985,7 @@ PoolVector<Plane> Geometry::build_sphere_planes(real_t p_radius, int p_lats, int
 }
 
 PoolVector<Plane> Geometry::build_capsule_planes(real_t p_radius, real_t p_height, int p_sides, int p_lats, Vector3::Axis p_axis) {
+	ERR_FAIL_INDEX_V(p_axis, 3, PoolVector<Plane>());
 
 	PoolVector<Plane> planes;
 
@@ -1191,6 +1193,9 @@ Vector<Vector<Point2> > Geometry::_polypaths_do_operation(PolyBooleanOperation p
 }
 
 Vector<Vector<Point2> > Geometry::_polypath_offset(const Vector<Point2> &p_polypath, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
+
+	ERR_FAIL_INDEX_V(p_join_type, 3, Vector<Vector<Point2> >());
+	ERR_FAIL_INDEX_V(p_end_type, 3, Vector<Vector<Point2> >());
 
 	using namespace ClipperLib;
 

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -833,11 +833,14 @@ public:
 
 	static Vector<Vector<Point2> > offset_polygon_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
 
+		ERR_FAIL_INDEX_V(p_join_type, 3, Vector<Vector<Point2> >());
 		return _polypath_offset(p_polygon, p_delta, p_join_type, END_POLYGON);
 	}
 
 	static Vector<Vector<Point2> > offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
 
+		ERR_FAIL_INDEX_V(p_join_type, 3, Vector<Vector<Point2> >());
+		ERR_FAIL_INDEX_V(p_end_type, 5, Vector<Vector<Point2> >());
 		ERR_EXPLAIN("Attempt to offset a polyline like a polygon (use offset_polygon_2d instead).");
 		ERR_FAIL_COND_V(p_end_type == END_POLYGON, Vector<Vector<Point2> >());
 

--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -258,6 +258,8 @@ DirAccess *DirAccess::open(const String &p_path, Error *r_error) {
 
 DirAccess *DirAccess::create(AccessType p_access) {
 
+	ERR_FAIL_INDEX_V(p_access, ACCESS_MAX, NULL);
+
 	DirAccess *da = create_func[p_access] ? create_func[p_access]() : NULL;
 	if (da) {
 		da->_access_type = p_access;
@@ -267,6 +269,8 @@ DirAccess *DirAccess::create(AccessType p_access) {
 };
 
 String DirAccess::get_full_path(const String &p_path, AccessType p_access) {
+
+	ERR_FAIL_INDEX_V(p_access, ACCESS_MAX, "");
 
 	DirAccess *d = DirAccess::create(p_access);
 	if (!d)

--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -116,6 +116,7 @@ public:
 	template <class T>
 	static void make_default(AccessType p_access) {
 
+		ERR_FAIL_INDEX(p_access, ACCESS_MAX);
 		create_func[p_access] = _create_builtin<T>;
 	}
 

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -65,8 +65,9 @@ bool FileAccess::exists(const String &p_name) {
 
 void FileAccess::_set_access_type(AccessType p_access) {
 
+	ERR_FAIL_INDEX(p_access, ACCESS_MAX);
 	_access_type = p_access;
-};
+}
 
 FileAccess *FileAccess::create_for_path(const String &p_path) {
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1022,6 +1022,7 @@ void CodeTextEditor::convert_indent_to_tabs() {
 }
 
 void CodeTextEditor::convert_case(CaseStyle p_case) {
+	ERR_FAIL_INDEX(p_case, 3);
 	if (!text_editor->is_selection_active()) {
 		return;
 	}

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -595,6 +595,7 @@ DependencyRemoveDialog::DependencyRemoveDialog() {
 
 void DependencyErrorDialog::show(Mode p_mode, const String &p_for_file, const Vector<String> &report) {
 
+	ERR_FAIL_INDEX(p_mode, 1);
 	mode = p_mode;
 	for_file = p_for_file;
 	set_title(TTR("Error loading:") + " " + p_for_file.get_file());

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -125,6 +125,7 @@ bool EditorExportPreset::is_runnable() const {
 
 void EditorExportPreset::set_export_filter(ExportFilter p_filter) {
 
+	ERR_FAIL_INDEX(p_filter, 3);
 	export_filter = p_filter;
 	EditorExport::singleton->save_presets();
 }

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -93,6 +93,7 @@ void EditorLog::copy() {
 
 void EditorLog::add_message(const String &p_msg, MessageType p_type) {
 
+	ERR_FAIL_INDEX(p_type, 3);
 	log->add_newline();
 
 	bool restore = p_type != MSG_TYPE_STD;

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -326,6 +326,7 @@ ToolButton *EditorPlugin::add_control_to_bottom_panel(Control *p_control, const 
 
 void EditorPlugin::add_control_to_dock(DockSlot p_slot, Control *p_control) {
 
+	ERR_FAIL_INDEX(p_slot, DOCK_SLOT_MAX);
 	ERR_FAIL_NULL(p_control);
 	EditorNode::get_singleton()->add_control_to_dock(EditorNode::DockSlot(p_slot), p_control);
 }
@@ -344,7 +345,7 @@ void EditorPlugin::remove_control_from_bottom_panel(Control *p_control) {
 
 void EditorPlugin::add_control_to_container(CustomControlContainer p_location, Control *p_control) {
 	ERR_FAIL_NULL(p_control);
-
+	ERR_FAIL_INDEX(p_location, 12);
 	switch (p_location) {
 
 		case CONTAINER_TOOLBAR: {
@@ -418,6 +419,7 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 
 void EditorPlugin::remove_control_from_container(CustomControlContainer p_location, Control *p_control) {
 	ERR_FAIL_NULL(p_control);
+	ERR_FAIL_INDEX(p_location, 12);
 
 	switch (p_location) {
 

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -471,7 +471,7 @@ String EditorSceneImporterGLTF::_get_component_type_name(uint32_t p_component) {
 }
 
 String EditorSceneImporterGLTF::_get_type_name(GLTFType p_component) {
-
+	ERR_FAIL_INDEX_V(p_component, 7, "");
 	static const char *names[] = {
 		"float",
 		"vec2",
@@ -487,6 +487,7 @@ String EditorSceneImporterGLTF::_get_type_name(GLTFType p_component) {
 
 Error EditorSceneImporterGLTF::_decode_buffer_view(GLTFState &state, int p_buffer_view, double *dst, int skip_every, int skip_bytes, int element_size, int count, GLTFType type, int component_count, int component_type, int component_size, bool normalized, int byte_offset, bool for_vertex) {
 
+	ERR_FAIL_INDEX_V(type, 7, ERR_INVALID_PARAMETER);
 	const GLTFBufferView &bv = state.buffer_views[p_buffer_view];
 
 	int stride = bv.byte_stride ? bv.byte_stride : element_size;

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -80,7 +80,7 @@ String ResourceImporterLayeredTexture::get_preset_name(int p_idx) const {
 }
 
 void ResourceImporterLayeredTexture::get_import_options(List<ImportOption> *r_options, int p_preset) const {
-
+	ERR_FAIL_INDEX(p_preset, 3);
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/mode", PROPERTY_HINT_ENUM, "Lossless,Video RAM,Uncompressed", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), p_preset == PRESET_3D ? 1 : 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "compress/no_bptc_if_rgb"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "flags/repeat", PROPERTY_HINT_ENUM, "Disabled,Enabled,Mirrored"), 0));
@@ -92,7 +92,7 @@ void ResourceImporterLayeredTexture::get_import_options(List<ImportOption> *r_op
 }
 
 void ResourceImporterLayeredTexture::_save_tex(const Vector<Ref<Image> > &p_images, const String &p_to_path, int p_compress_mode, Image::CompressMode p_vram_compression, bool p_mipmaps, int p_texture_flags) {
-
+	ERR_FAIL_INDEX(p_vram_compression, 6);
 	FileAccess *f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	f->store_8('G');
 	f->store_8('D');

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -298,6 +298,7 @@ static void _gen_shape_list(const Ref<Mesh> &mesh, List<Ref<Shape> > &r_shape_li
 
 Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>, List<Ref<Shape> > > &collision_map, LightBakeMode p_light_bake_mode) {
 
+	ERR_FAIL_INDEX_V(p_light_bake_mode, 3, NULL);
 	// children first
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -220,7 +220,7 @@ void ResourceImporterTexture::get_import_options(List<ImportOption> *r_options, 
 }
 
 void ResourceImporterTexture::_save_stex(const Ref<Image> &p_image, const String &p_to_path, int p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, int p_texture_flags, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_force_rgbe, bool p_detect_normal, bool p_force_normal, bool p_force_po2_for_compressed) {
-
+	ERR_FAIL_INDEX(p_vram_compression, 6);
 	FileAccess *f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	f->store_8('G');
 	f->store_8('D');

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -876,6 +876,7 @@ void EditorAssetLibrary::_update_image_queue() {
 
 void EditorAssetLibrary::_request_image(ObjectID p_for, String p_image_url, ImageType p_type, int p_image_index) {
 
+	ERR_FAIL_INDEX(p_type, 3);
 	ImageQueue iq;
 	iq.image_url = p_image_url;
 	iq.image_index = p_image_index;
@@ -907,6 +908,7 @@ void EditorAssetLibrary::_repository_changed(int p_repository_id) {
 }
 
 void EditorAssetLibrary::_support_toggled(int p_support) {
+	ERR_FAIL_INDEX(p_support, SUPPORT_MAX);
 	support->get_popup()->set_item_checked(p_support, !support->get_popup()->is_item_checked(p_support));
 	_search();
 }

--- a/editor/plugins/cpu_particles_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_editor_plugin.cpp
@@ -48,7 +48,7 @@ void CPUParticlesEditor::_notification(int p_notification) {
 }
 
 void CPUParticlesEditor::_menu_option(int p_option) {
-
+	ERR_FAIL_INDEX(p_option, 4);
 	switch (p_option) {
 
 		case MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_MESH: {

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -451,6 +451,7 @@ void CurveEditor::remove_point(int index) {
 
 void CurveEditor::toggle_linear(TangentIndex tangent) {
 	ERR_FAIL_COND(_curve_ref.is_null());
+	ERR_FAIL_COND(tangent < -1 || tangent > 1);
 
 	UndoRedo &ur = *EditorNode::get_singleton()->get_undo_redo();
 	ur.create_action(TTR("Toggle Curve Linear Tangent"));
@@ -520,6 +521,7 @@ void CurveEditor::update_view_transform() {
 }
 
 Vector2 CurveEditor::get_tangent_view_pos(int i, TangentIndex tangent) const {
+	ERR_FAIL_COND_V(tangent < -1 || tangent > 1, Vector2());
 
 	Vector2 dir;
 	if (tangent == TANGENT_LEFT)

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -270,7 +270,7 @@ void ParticlesEditor::_notification(int p_notification) {
 }
 
 void ParticlesEditor::_menu_option(int p_option) {
-
+	ERR_FAIL_INDEX(p_option, 6);
 	switch (p_option) {
 
 		case MENU_OPTION_GENERATE_AABB: {

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -199,6 +199,7 @@ void Polygon2DEditor::_bone_paint_selected(int p_index) {
 }
 
 void Polygon2DEditor::_uv_edit_mode_select(int p_mode) {
+	ERR_FAIL_INDEX(p_mode, UV_MODE_MAX);
 
 	if (p_mode == 0) { //uv
 
@@ -277,6 +278,7 @@ void Polygon2DEditor::_uv_edit_popup_hide() {
 }
 
 void Polygon2DEditor::_menu_option(int p_option) {
+	ERR_FAIL_COND(p_option > 8 || p_option < 3);
 
 	switch (p_option) {
 
@@ -438,6 +440,7 @@ void Polygon2DEditor::_set_snap_step_y(float p_val) {
 }
 
 void Polygon2DEditor::_uv_mode(int p_mode) {
+	ERR_FAIL_INDEX(p_mode, UV_MODE_MAX);
 
 	polygon_create.clear();
 	uv_drag = false;

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -49,7 +49,7 @@ void Skeleton2DEditor::edit(Skeleton2D *p_sprite) {
 }
 
 void Skeleton2DEditor::_menu_option(int p_option) {
-
+	ERR_FAIL_INDEX(p_option, 2);
 	if (!node) {
 		return;
 	}

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -3951,7 +3951,7 @@ void SpatialEditorViewportContainer::_notification(int p_what) {
 }
 
 void SpatialEditorViewportContainer::set_view(View p_view) {
-
+	ERR_FAIL_INDEX(p_view, 6);
 	view = p_view;
 	queue_sort();
 }

--- a/editor/plugins/sprite_editor_plugin.cpp
+++ b/editor/plugins/sprite_editor_plugin.cpp
@@ -114,6 +114,7 @@ Vector<Vector2> expand(const Vector<Vector2> &points, const Rect2i &rect, float 
 }
 
 void SpriteEditor::_menu_option(int p_option) {
+	ERR_FAIL_INDEX(p_option, 4);
 
 	if (!node) {
 		return;

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -121,6 +121,7 @@ void TileMapEditor::_update_button_tool() {
 }
 
 void TileMapEditor::_button_tool_select(int p_tool) {
+	ERR_FAIL_INDEX(p_tool, 11);
 	tool = (Tool)p_tool;
 	_update_button_tool();
 	switch (tool) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2600,6 +2600,7 @@ ProjectListFilter::FilterOption ProjectListFilter::get_filter_option() {
 }
 
 void ProjectListFilter::set_filter_option(FilterOption option) {
+	ERR_FAIL_INDEX(option, 3);
 	filter_option->select((int)option);
 	_filter_option_selected(0);
 }

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -316,7 +316,7 @@ bool SceneTreeDock::_track_inherit(const String &p_target_scene_path, Node *p_de
 }
 
 void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
-
+	ERR_FAIL_INDEX(p_tool, 32);
 	current_option = p_tool;
 
 	switch (p_tool) {
@@ -1168,7 +1168,7 @@ void SceneTreeDock::_notification(int p_what) {
 }
 
 void SceneTreeDock::_node_replace_owner(Node *p_base, Node *p_node, Node *p_root, ReplaceOwnerMode p_mode) {
-
+	ERR_FAIL_INDEX(p_mode, 3);
 	if (p_node->get_owner() == p_base && p_node != p_root) {
 		UndoRedo *undo_redo = &editor_data->get_undo_redo();
 		switch (p_mode) {

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -985,6 +985,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 }
 
 void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType p_type) {
+	ERR_FAIL_INDEX(p_type, 3);
 	switch (p_type) {
 		case MESSAGE_ERROR:
 			reason->add_color_override("font_color", get_color("error_color", "Editor"));

--- a/modules/bullet/area_bullet.h
+++ b/modules/bullet/area_bullet.h
@@ -115,7 +115,10 @@ public:
 
 	bool is_monitoring() const;
 
-	_FORCE_INLINE_ void set_spOv_mode(PhysicsServer::AreaSpaceOverrideMode p_mode) { spOv_mode = p_mode; }
+	_FORCE_INLINE_ void set_spOv_mode(PhysicsServer::AreaSpaceOverrideMode p_mode) {
+		ERR_FAIL_INDEX(p_mode, 5);
+		spOv_mode = p_mode;
+	}
 	_FORCE_INLINE_ PhysicsServer::AreaSpaceOverrideMode get_spOv_mode() { return spOv_mode; }
 
 	_FORCE_INLINE_ void set_spOv_gravityPoint(bool p_isGP) { spOv_gravityPoint = p_isGP; }

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -1326,7 +1326,7 @@ void CSGBrushOperation::MeshMerge::add_face(const Vector3 &p_a, const Vector3 &p
 }
 
 void CSGBrushOperation::merge_brushes(Operation p_operation, const CSGBrush &p_A, const CSGBrush &p_B, CSGBrush &result, float p_snap) {
-
+	ERR_FAIL_INDEX(p_operation, 3);
 	CallbackData cd;
 	cd.self = this;
 	cd.A = &p_A;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -554,7 +554,7 @@ void CSGShape::_notification(int p_what) {
 }
 
 void CSGShape::set_operation(Operation p_operation) {
-
+	ERR_FAIL_INDEX(p_operation, 3);
 	operation = p_operation;
 	_make_dirty();
 	update_gizmo();
@@ -2344,6 +2344,7 @@ Vector<Vector2> CSGPolygon::get_polygon() const {
 }
 
 void CSGPolygon::set_mode(Mode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	mode = p_mode;
 	_make_dirty();
 	update_gizmo();
@@ -2417,6 +2418,7 @@ float CSGPolygon::get_path_interval() const {
 }
 
 void CSGPolygon::set_path_rotation(PathRotation p_rotation) {
+	ERR_FAIL_INDEX(p_rotation, 3);
 	path_rotation = p_rotation;
 	_make_dirty();
 	update_gizmo();

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -649,7 +649,7 @@ bool NetworkedMultiplayerENet::is_refusing_new_connections() const {
 }
 
 void NetworkedMultiplayerENet::set_compression_mode(CompressionMode p_mode) {
-
+	ERR_FAIL_INDEX(p_mode, 5);
 	compression_mode = p_mode;
 }
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2068,7 +2068,7 @@ String GDScriptWarning::get_name() const {
 }
 
 String GDScriptWarning::get_name_from_code(Code p_code) {
-	ERR_FAIL_COND_V(p_code < 0 || p_code >= WARNING_MAX, String());
+	ERR_FAIL_INDEX_V(p_code, WARNING_MAX, String());
 
 	static const char *names[] = {
 		"UNASSIGNED_VARIABLE",

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -196,7 +196,7 @@ void GDScriptParser::_make_completable_call(int p_arg) {
 }
 
 bool GDScriptParser::_get_completable_identifier(CompletionType p_type, StringName &identifier) {
-
+	ERR_FAIL_INDEX_V(p_type, 15, false);
 	identifier = StringName();
 	if (tokenizer->is_token_literal()) {
 		identifier = tokenizer->get_token_literal();

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -382,7 +382,7 @@ static bool _is_bin(CharType c) {
 }
 
 void GDScriptTokenizerText::_make_token(Token p_type) {
-
+	ERR_FAIL_INDEX(p_type, TK_MAX);
 	TokenData &tk = tk_rb[tk_rb_pos];
 
 	tk.type = p_type;

--- a/modules/mono/mono_gc_handle.h
+++ b/modules/mono/mono_gc_handle.h
@@ -63,6 +63,7 @@ public:
 	_FORCE_INLINE_ MonoObject *get_target() const { return released ? NULL : mono_gchandle_get_target(handle); }
 
 	_FORCE_INLINE_ void set_handle(uint32_t p_handle, HandleType p_handle_type) {
+		ERR_FAIL_INDEX(p_handle_type, 2);
 		released = false;
 		weak = p_handle_type == WEAK_HANDLE;
 		handle = p_handle;

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -518,6 +518,7 @@ bool GDMono::load_assembly_from(const String &p_name, const String &p_path, GDMo
 }
 
 APIAssembly::Version APIAssembly::Version::get_from_loaded_assembly(GDMonoAssembly *p_api_assembly, APIAssembly::Type p_api_type) {
+	ERR_FAIL_INDEX_V(p_api_type, 2, APIAssembly::Version());
 	APIAssembly::Version api_assembly_version;
 
 	const char *nativecalls_name = p_api_type == APIAssembly::API_CORE ?
@@ -544,6 +545,7 @@ APIAssembly::Version APIAssembly::Version::get_from_loaded_assembly(GDMonoAssemb
 }
 
 String APIAssembly::to_string(APIAssembly::Type p_type) {
+	ERR_FAIL_INDEX_V(p_type, 2, "<error>");
 	return p_type == APIAssembly::API_CORE ? "API_CORE" : "API_EDITOR";
 }
 
@@ -562,6 +564,7 @@ bool GDMono::_load_corlib_assembly() {
 
 #ifdef TOOLS_ENABLED
 bool GDMono::copy_prebuilt_api_assembly(APIAssembly::Type p_api_type) {
+	ERR_FAIL_INDEX_V(p_api_type, 2, false);
 
 	bool &api_assembly_out_of_sync = (p_api_type == APIAssembly::API_CORE) ?
 											 GDMono::get_singleton()->core_api_assembly_out_of_sync :

--- a/modules/upnp/upnp_device.cpp
+++ b/modules/upnp/upnp_device.cpp
@@ -133,6 +133,7 @@ String UPNPDevice::get_igd_our_addr() const {
 }
 
 void UPNPDevice::set_igd_status(IGDStatus status) {
+	ERR_FAIL_INDEX(status, 10);
 	igd_status = status;
 }
 

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -465,6 +465,7 @@ NodePath VisualScriptFunctionCall::get_base_path() const {
 
 void VisualScriptFunctionCall::set_call_mode(CallMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 5);
 	if (call_mode == p_mode)
 		return;
 
@@ -488,6 +489,7 @@ void VisualScriptFunctionCall::set_use_default_args(int p_amount) {
 
 void VisualScriptFunctionCall::set_rpc_call_mode(VisualScriptFunctionCall::RPCCallMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 5);
 	if (rpc_call_mode == p_mode)
 		return;
 	rpc_call_mode = p_mode;

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1794,7 +1794,7 @@ String VisualScriptMathConstant::get_caption() const {
 }
 
 void VisualScriptMathConstant::set_math_constant(MathConstant p_which) {
-
+	ERR_FAIL_INDEX(p_which, MATH_CONSTANT_MAX);
 	constant = p_which;
 	_change_notify();
 	ports_changed_notify();
@@ -3390,6 +3390,7 @@ public:
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Variant::CallError &r_error, String &r_error_str) {
 
+		ERR_FAIL_INDEX_V(p_start_mode, 3, 0);
 		switch (mode) {
 			case VisualScriptInputAction::MODE_PRESSED: {
 				*p_outputs[0] = Input::get_singleton()->is_action_pressed(action);

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -401,6 +401,7 @@ NodePath VisualScriptYieldSignal::get_base_path() const {
 
 void VisualScriptYieldSignal::set_call_mode(CallMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	if (call_mode == p_mode)
 		return;
 

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -35,6 +35,7 @@
 
 void Area2D::set_space_override_mode(SpaceOverride p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 5);
 	space_override = p_mode;
 	Physics2DServer::get_singleton()->area_set_space_override_mode(get_rid(), Physics2DServer::AreaSpaceOverrideMode(p_mode));
 }

--- a/scene/2d/back_buffer_copy.cpp
+++ b/scene/2d/back_buffer_copy.cpp
@@ -76,6 +76,7 @@ Rect2 BackBufferCopy::get_rect() const {
 
 void BackBufferCopy::set_copy_mode(CopyMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	copy_mode = p_mode;
 	_update_copy_mode();
 }

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -197,6 +197,7 @@ bool CanvasItemMaterial::_is_shader_dirty() const {
 }
 void CanvasItemMaterial::set_blend_mode(BlendMode p_blend_mode) {
 
+	ERR_FAIL_INDEX(p_blend_mode, 6);
 	blend_mode = p_blend_mode;
 	_queue_shader_change();
 }
@@ -207,6 +208,7 @@ CanvasItemMaterial::BlendMode CanvasItemMaterial::get_blend_mode() const {
 
 void CanvasItemMaterial::set_light_mode(LightMode p_light_mode) {
 
+	ERR_FAIL_INDEX(p_light_mode, 3);
 	light_mode = p_light_mode;
 	_queue_shader_change();
 }

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -419,6 +419,7 @@ bool CPUParticles2D::get_particle_flag(Flags p_flag) const {
 
 void CPUParticles2D::set_emission_shape(EmissionShape p_shape) {
 
+	ERR_FAIL_INDEX(p_shape, 5);
 	emission_shape = p_shape;
 	_change_notify();
 }

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -302,6 +302,7 @@ float Light2D::get_shadow_gradient_length() const {
 }
 
 void Light2D::set_shadow_filter(ShadowFilter p_filter) {
+	ERR_FAIL_INDEX(p_filter, 6);
 	shadow_filter = p_filter;
 	VS::get_singleton()->canvas_light_set_shadow_filter(canvas_light, VS::CanvasLightShadowFilter(p_filter));
 }

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -111,6 +111,7 @@ bool OccluderPolygon2D::is_closed() const {
 
 void OccluderPolygon2D::set_cull_mode(CullMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	cull = p_mode;
 	VS::get_singleton()->canvas_occluder_polygon_set_cull_mode(occ_polygon, VS::CanvasOccluderPolygonCullMode(p_mode));
 }

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -195,6 +195,7 @@ Ref<Texture> Line2D::get_texture() const {
 }
 
 void Line2D::set_texture_mode(const LineTextureMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	_texture_mode = p_mode;
 	update();
 }
@@ -204,6 +205,7 @@ Line2D::LineTextureMode Line2D::get_texture_mode() const {
 }
 
 void Line2D::set_joint_mode(LineJointMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	_joint_mode = p_mode;
 	update();
 }
@@ -213,6 +215,7 @@ Line2D::LineJointMode Line2D::get_joint_mode() const {
 }
 
 void Line2D::set_begin_cap_mode(LineCapMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	_begin_cap_mode = p_mode;
 	update();
 }
@@ -222,6 +225,7 @@ Line2D::LineCapMode Line2D::get_begin_cap_mode() const {
 }
 
 void Line2D::set_end_cap_mode(LineCapMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	_end_cap_mode = p_mode;
 	update();
 }

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -870,6 +870,7 @@ void RigidBody2D::add_torque(const float p_torque) {
 
 void RigidBody2D::set_continuous_collision_detection_mode(CCDMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	ccd_mode = p_mode;
 	Physics2DServer::get_singleton()->body_set_continuous_collision_detection_mode(get_rid(), Physics2DServer::CCDMode(p_mode));
 }

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1425,6 +1425,7 @@ bool TileMap::get_collision_mask_bit(int p_bit) const {
 
 void TileMap::set_mode(Mode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	_clear_quadrants();
 	mode = p_mode;
 	_recreate_quadrants();
@@ -1437,6 +1438,7 @@ TileMap::Mode TileMap::get_mode() const {
 
 void TileMap::set_half_offset(HalfOffset p_half_offset) {
 
+	ERR_FAIL_INDEX(p_half_offset, 5);
 	_clear_quadrants();
 	half_offset = p_half_offset;
 	_recreate_quadrants();
@@ -1445,6 +1447,7 @@ void TileMap::set_half_offset(HalfOffset p_half_offset) {
 
 void TileMap::set_tile_origin(TileOrigin p_tile_origin) {
 
+	ERR_FAIL_INDEX(p_tile_origin, 3);
 	_clear_quadrants();
 	tile_origin = p_tile_origin;
 	_recreate_quadrants();

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -35,6 +35,7 @@
 
 void Area::set_space_override_mode(SpaceOverride p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 5);
 	space_override = p_mode;
 	PhysicsServer::get_singleton()->area_set_space_override_mode(get_rid(), PhysicsServer::AreaSpaceOverrideMode(p_mode));
 }

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -892,6 +892,7 @@ AudioStreamPlayer3D::OutOfRangeMode AudioStreamPlayer3D::get_out_of_range_mode()
 
 void AudioStreamPlayer3D::set_doppler_tracking(DopplerTracking p_tracking) {
 
+	ERR_FAIL_INDEX(p_tracking, 3);
 	if (doppler_tracking == p_tracking)
 		return;
 

--- a/scene/3d/baked_lightmap.cpp
+++ b/scene/3d/baked_lightmap.cpp
@@ -749,6 +749,7 @@ float BakedLightmap::get_energy() const {
 }
 
 void BakedLightmap::set_bake_quality(BakeQuality p_quality) {
+	ERR_FAIL_INDEX(p_quality, 3);
 	bake_quality = p_quality;
 }
 

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -210,6 +210,7 @@ void Camera::set_frustum(float p_size, Vector2 p_offset, float p_z_near, float p
 }
 
 void Camera::set_projection(Camera::Projection p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	if (p_mode == PROJECTION_PERSPECTIVE || p_mode == PROJECTION_ORTHOGONAL || p_mode == PROJECTION_FRUSTUM) {
 		mode = p_mode;
 		_update_camera_mode();
@@ -477,6 +478,7 @@ Camera::KeepAspect Camera::get_keep_aspect_mode() const {
 
 void Camera::set_doppler_tracking(DopplerTracking p_tracking) {
 
+	ERR_FAIL_INDEX(p_tracking, 3);
 	if (doppler_tracking == p_tracking)
 		return;
 

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -151,6 +151,7 @@ float CPUParticles::get_speed_scale() const {
 
 void CPUParticles::set_draw_order(DrawOrder p_order) {
 
+	ERR_FAIL_INDEX(p_order, 3);
 	draw_order = p_order;
 }
 
@@ -397,6 +398,7 @@ bool CPUParticles::get_particle_flag(Flags p_flag) const {
 
 void CPUParticles::set_emission_shape(EmissionShape p_shape) {
 
+	ERR_FAIL_INDEX(p_shape, 5);
 	emission_shape = p_shape;
 }
 

--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -156,6 +156,7 @@ PoolVector<Face3> Light::get_faces(uint32_t p_usage_flags) const {
 }
 
 void Light::set_bake_mode(BakeMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	bake_mode = p_mode;
 	VS::get_singleton()->light_set_use_gi(light, p_mode != BAKE_DISABLED);
 }
@@ -345,6 +346,7 @@ Light::~Light() {
 
 void DirectionalLight::set_shadow_mode(ShadowMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	shadow_mode = p_mode;
 	VS::get_singleton()->light_directional_set_shadow_mode(light, VS::LightDirectionalShadowMode(p_mode));
 }

--- a/scene/3d/navigation_mesh.cpp
+++ b/scene/3d/navigation_mesh.cpp
@@ -65,7 +65,7 @@ void NavigationMesh::create_from_mesh(const Ref<Mesh> &p_mesh) {
 }
 
 void NavigationMesh::set_sample_partition_type(int p_value) {
-	ERR_FAIL_COND(p_value >= SAMPLE_PARTITION_MAX);
+	ERR_FAIL_INDEX(p_value, SAMPLE_PARTITION_MAX);
 	partition_type = static_cast<SamplePartitionType>(p_value);
 }
 
@@ -74,7 +74,7 @@ int NavigationMesh::get_sample_partition_type() const {
 }
 
 void NavigationMesh::set_parsed_geometry_type(int p_value) {
-	ERR_FAIL_COND(p_value >= PARSED_GEOMETRY_MAX);
+	ERR_FAIL_INDEX(p_value, PARSED_GEOMETRY_MAX);
 	parsed_geometry_type = static_cast<ParsedGeometryType>(p_value);
 	_change_notify();
 }

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -177,6 +177,7 @@ float Particles::get_speed_scale() const {
 
 void Particles::set_draw_order(DrawOrder p_order) {
 
+	ERR_FAIL_INDEX(p_order, 3);
 	draw_order = p_order;
 	VS::get_singleton()->particles_set_draw_order(particles, VS::ParticlesDrawOrder(p_order));
 }

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -370,6 +370,7 @@ float PathFollow::get_unit_offset() const {
 
 void PathFollow::set_rotation_mode(RotationMode p_rotation_mode) {
 
+	ERR_FAIL_INDEX(p_rotation_mode, 5);
 	rotation_mode = p_rotation_mode;
 
 	update_configuration_warning();

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -2419,6 +2419,7 @@ Skeleton *PhysicalBone::find_skeleton_parent() {
 
 void PhysicalBone::set_joint_type(JointType p_joint_type) {
 
+	ERR_FAIL_INDEX(p_joint_type, 6);
 	if (p_joint_type == get_joint_type())
 		return;
 

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -718,6 +718,7 @@ void VoxelLightBaker::_init_light_plot(int p_idx, int p_level, int p_x, int p_y,
 }
 
 void VoxelLightBaker::begin_bake_light(BakeQuality p_quality, BakeMode p_bake_mode, float p_propagation, float p_energy) {
+	ERR_FAIL_INDEX(p_quality, 3);
 	_check_init_light();
 	propagation = p_propagation;
 	bake_quality = p_quality;

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -591,6 +591,7 @@ void AnimationNodeBlendSpace2D::_tree_changed() {
 }
 
 void AnimationNodeBlendSpace2D::set_blend_mode(BlendMode p_blend_mode) {
+	ERR_FAIL_INDEX(p_blend_mode, 3);
 	blend_mode = p_blend_mode;
 }
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -34,6 +34,7 @@
 
 void AnimationNodeStateMachineTransition::set_switch_mode(SwitchMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	switch_mode = p_mode;
 }
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1464,6 +1464,7 @@ String AnimationPlayer::get_autoplay() const {
 
 void AnimationPlayer::set_animation_process_mode(AnimationProcessMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	if (animation_process_mode == p_mode)
 		return;
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -515,6 +515,7 @@ bool AnimationTree::is_active() const {
 
 void AnimationTree::set_process_mode(AnimationProcessMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	if (process_mode == p_mode)
 		return;
 

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -929,6 +929,7 @@ void AnimationTreePlayer::_process_animation(float p_delta) {
 
 void AnimationTreePlayer::add_node(NodeType p_type, const StringName &p_node) {
 
+	ERR_FAIL_INDEX(p_type, NODE_MAX);
 	ERR_FAIL_COND(p_type == NODE_OUTPUT);
 	ERR_FAIL_COND(node_map.has(p_node));
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -1208,12 +1208,12 @@ bool Tween::_build_interpolation(InterpolateType p_interpolation_type, Object *p
 
 	// Transition type
 	ERR_EXPLAIN("Invalid transition type provided to Tween");
-	ERR_FAIL_COND_V(p_trans_type < 0 || p_trans_type >= TRANS_COUNT, false); // Is the transition type valid
+	ERR_FAIL_INDEX_V(p_trans_type, TRANS_COUNT, false); // Is the transition type valid
 	data.trans_type = p_trans_type;
 
 	// Easing type
 	ERR_EXPLAIN("Invalid easing type provided to Tween");
-	ERR_FAIL_COND_V(p_ease_type < 0 || p_ease_type >= EASE_COUNT, false); // Is the easing type valid
+	ERR_FAIL_INDEX_V(p_ease_type, EASE_COUNT, false); // Is the easing type valid
 	data.ease_type = p_ease_type;
 
 	// Is the property defined?

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -315,6 +315,7 @@ bool AudioStreamPlayer::is_autoplay_enabled() {
 
 void AudioStreamPlayer::set_mix_target(MixTarget p_target) {
 
+	ERR_FAIL_INDEX(p_target, 3);
 	mix_target = p_target;
 }
 

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -262,6 +262,7 @@ void BoxContainer::_notification(int p_what) {
 }
 
 void BoxContainer::set_alignment(AlignMode p_align) {
+	ERR_FAIL_INDEX(p_align, 3);
 	align = p_align;
 	_resort();
 }

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -250,6 +250,7 @@ bool Button::get_clip_text() const {
 
 void Button::set_text_align(TextAlign p_align) {
 
+	ERR_FAIL_INDEX(p_align, 3);
 	align = p_align;
 	update();
 }

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1961,6 +1961,7 @@ void Control::add_constant_override(const StringName &p_name, int p_constant) {
 
 void Control::set_focus_mode(FocusMode p_focus_mode) {
 
+	ERR_FAIL_INDEX(p_focus_mode, 3);
 	if (is_inside_tree() && p_focus_mode == FOCUS_NONE && data.focus_mode != FOCUS_NONE && has_focus())
 		release_focus();
 
@@ -2320,6 +2321,7 @@ Control *Control::make_custom_tooltip(const String &p_text) const {
 
 void Control::set_default_cursor_shape(CursorShape p_shape) {
 
+	ERR_FAIL_INDEX(p_shape, CURSOR_MAX);
 	data.default_cursor = p_shape;
 }
 
@@ -2787,6 +2789,7 @@ bool Control::is_clipping_contents() {
 
 void Control::set_h_grow_direction(GrowDirection p_direction) {
 
+	ERR_FAIL_INDEX(p_direction, 3);
 	data.h_grow = p_direction;
 	_size_changed();
 }
@@ -2798,6 +2801,7 @@ Control::GrowDirection Control::get_h_grow_direction() const {
 
 void Control::set_v_grow_direction(GrowDirection p_direction) {
 
+	ERR_FAIL_INDEX(p_direction, 3);
 	data.v_grow = p_direction;
 	_size_changed();
 }

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -635,6 +635,7 @@ bool FileDialog::is_mode_overriding_title() const {
 
 void FileDialog::set_mode(Mode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 5);
 	mode = p_mode;
 	switch (mode) {
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -637,6 +637,7 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 
 void GraphNode::set_overlay(Overlay p_overlay) {
 
+	ERR_FAIL_INDEX(p_overlay, 3);
 	overlay = p_overlay;
 	update();
 }

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -43,6 +43,7 @@ String LinkButton::get_text() const {
 
 void LinkButton::set_underline_mode(UnderlineMode p_underline_mode) {
 
+	ERR_FAIL_INDEX(p_underline_mode, 3);
 	underline_mode = p_underline_mode;
 	update();
 }

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -164,6 +164,7 @@ bool NinePatchRect::is_draw_center_enabled() const {
 }
 
 void NinePatchRect::set_h_axis_stretch_mode(AxisStretchMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	axis_h = p_mode;
 	update();
 }
@@ -173,7 +174,7 @@ NinePatchRect::AxisStretchMode NinePatchRect::get_h_axis_stretch_mode() const {
 }
 
 void NinePatchRect::set_v_axis_stretch_mode(AxisStretchMode p_mode) {
-
+	ERR_FAIL_INDEX(p_mode, 3);
 	axis_v = p_mode;
 	update();
 }

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -141,6 +141,7 @@ Rect2 RichTextLabel::_get_text_rect() {
 }
 int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &y, int p_width, int p_line, ProcessMode p_mode, const Ref<Font> &p_base_font, const Color &p_base_color, const Color &p_font_color_shadow, bool p_shadow_as_outline, const Point2 &shadow_ofs, const Point2i &p_click_pos, Item **r_click_item, int *r_click_char, bool *r_outside, int p_char_count) {
 
+	ERR_FAIL_INDEX_V(p_mode, 3, 0);
 	RID ci;
 	if (r_outside)
 		*r_outside = false;

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -318,6 +318,7 @@ void SplitContainer::set_collapsed(bool p_collapsed) {
 
 void SplitContainer::set_dragger_visibility(DraggerVisibility p_visibility) {
 
+	ERR_FAIL_INDEX(p_visibility, 3);
 	dragger_visibility = p_visibility;
 	queue_sort();
 	update();

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -338,6 +338,7 @@ void TextureButton::set_expand(bool p_expand) {
 }
 
 void TextureButton::set_stretch_mode(StretchMode p_stretch_mode) {
+	ERR_FAIL_INDEX(p_stretch_mode, 7);
 	stretch_mode = p_stretch_mode;
 	update();
 }

--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -202,6 +202,7 @@ Point2 TextureProgress::get_relative_center() {
 }
 
 void TextureProgress::draw_nine_patch_stretched(const Ref<Texture> &p_texture, FillMode p_mode, double p_ratio, const Color &p_modulate) {
+	ERR_FAIL_INDEX(p_mode, 9);
 	Vector2 texture_size = p_texture->get_size();
 	Vector2 topleft = Vector2(stretch_margin[MARGIN_LEFT], stretch_margin[MARGIN_TOP]);
 	Vector2 bottomright = Vector2(stretch_margin[MARGIN_RIGHT], stretch_margin[MARGIN_BOTTOM]);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -121,6 +121,7 @@ void TreeItem::_cell_deselected(int p_cell) {
 /* cell mode */
 void TreeItem::set_cell_mode(int p_column, TreeCellMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 5);
 	ERR_FAIL_INDEX(p_column, cells.size());
 	Cell &c = cells.write[p_column];
 	c.mode = p_mode;
@@ -691,6 +692,7 @@ bool TreeItem::is_custom_set_as_button(int p_column) const {
 }
 
 void TreeItem::set_text_align(int p_column, TextAlign p_align) {
+	ERR_FAIL_INDEX(p_align, 3);
 	ERR_FAIL_INDEX(p_column, cells.size());
 	cells.write[p_column].text_align = p_align;
 	_changed_notify(p_column);
@@ -3141,6 +3143,7 @@ void Tree::item_deselected(int p_column, TreeItem *p_item) {
 
 void Tree::set_select_mode(SelectMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	select_mode = p_mode;
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -440,6 +440,7 @@ bool Node::is_physics_processing_internal() const {
 
 void Node::set_pause_mode(PauseMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	if (data.pause_mode == p_mode)
 		return;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1251,6 +1251,8 @@ void SceneTree::_update_root_rect() {
 
 void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 &p_minsize, real_t p_shrink) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
+	ERR_FAIL_INDEX(p_aspect, 5);
 	stretch_mode = p_mode;
 	stretch_aspect = p_aspect;
 	stretch_min = p_minsize;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1205,6 +1205,7 @@ bool Viewport::get_vflip() const {
 
 void Viewport::set_clear_mode(ClearMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	clear_mode = p_mode;
 	VS::get_singleton()->viewport_set_clear_mode(viewport, VS::ViewportClearMode(p_mode));
 }
@@ -2890,6 +2891,7 @@ Viewport::DebugDraw Viewport::get_debug_draw() const {
 
 int Viewport::get_render_info(RenderInfo p_info) {
 
+	ERR_FAIL_INDEX_V(p_info, RENDER_INFO_MAX, 0);
 	return VS::get_singleton()->viewport_get_render_info(viewport, VS::ViewportRenderInfo(p_info));
 }
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -627,7 +627,7 @@ void Animation::_get_property_list(List<PropertyInfo> *p_list) const {
 }
 
 int Animation::add_track(TrackType p_type, int p_at_pos) {
-
+	ERR_FAIL_INDEX_V(p_type, 6, 0);
 	if (p_at_pos < 0 || p_at_pos >= tracks.size())
 		p_at_pos = tracks.size();
 

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -407,6 +407,7 @@ AudioStreamPlaybackSample::AudioStreamPlaybackSample() {
 
 void AudioStreamSample::set_format(Format p_format) {
 
+	ERR_FAIL_INDEX(p_format, 3);
 	format = p_format;
 }
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -55,6 +55,8 @@ Curve::Curve() {
 }
 
 int Curve::add_point(Vector2 p_pos, real_t left_tangent, real_t right_tangent, TangentMode left_mode, TangentMode right_mode) {
+	ERR_FAIL_INDEX_V(left_mode, 3, 0);
+	ERR_FAIL_INDEX_V(right_mode, 3, 0);
 	// Add a point and preserve order
 
 	// Curve bounds is in 0..1
@@ -167,6 +169,7 @@ void Curve::set_point_right_tangent(int i, real_t tangent) {
 }
 
 void Curve::set_point_left_mode(int i, TangentMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	ERR_FAIL_INDEX(i, _points.size());
 	_points.write[i].left_mode = p_mode;
 	if (i > 0) {
@@ -179,6 +182,7 @@ void Curve::set_point_left_mode(int i, TangentMode p_mode) {
 }
 
 void Curve::set_point_right_mode(int i, TangentMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	ERR_FAIL_INDEX(i, _points.size());
 	_points.write[i].right_mode = p_mode;
 	if (i + 1 < _points.size()) {

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -792,6 +792,7 @@ DynamicFontData::Hinting DynamicFontData::get_hinting() const {
 
 void DynamicFontData::set_hinting(Hinting p_hinting) {
 
+	ERR_FAIL_INDEX(p_hinting, 3);
 	if (hinting == p_hinting)
 		return;
 	hinting = p_hinting;

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -40,6 +40,7 @@ RID Environment::get_rid() const {
 
 void Environment::set_background(BGMode p_bg) {
 
+	ERR_FAIL_INDEX(p_bg, BG_MAX);
 	bg_mode = p_bg;
 	VS::get_singleton()->environment_set_background(environment, VS::EnvironmentBG(p_bg));
 	_change_notify();
@@ -558,6 +559,7 @@ Environment::SSAOBlur Environment::get_ssao_blur() const {
 
 void Environment::set_ssao_quality(SSAOQuality p_quality) {
 
+	ERR_FAIL_INDEX(p_quality, 3);
 	ssao_quality = p_quality;
 	VS::get_singleton()->environment_set_ssao(environment, ssao_enabled, ssao_radius, ssao_intensity, ssao_radius2, ssao_intensity2, ssao_bias, ssao_direct_light_affect, ssao_ao_channel_affect, ssao_color, VS::EnvironmentSSAOQuality(ssao_quality), VS::EnvironmentSSAOBlur(ssao_blur), ssao_edge_sharpness);
 }
@@ -739,6 +741,7 @@ float Environment::get_dof_blur_far_amount() const {
 
 void Environment::set_dof_blur_far_quality(DOFBlurQuality p_quality) {
 
+	ERR_FAIL_INDEX(p_quality, 3);
 	dof_blur_far_quality = p_quality;
 	VS::get_singleton()->environment_set_dof_blur_far(environment, dof_blur_far_enabled, dof_blur_far_distance, dof_blur_far_transition, dof_blur_far_amount, VS::EnvironmentDOFBlurQuality(dof_blur_far_quality));
 }
@@ -795,6 +798,7 @@ float Environment::get_dof_blur_near_amount() const {
 
 void Environment::set_dof_blur_near_quality(DOFBlurQuality p_quality) {
 
+	ERR_FAIL_INDEX(p_quality, 3);
 	dof_blur_near_quality = p_quality;
 	VS::get_singleton()->environment_set_dof_blur_near(environment, dof_blur_near_enabled, dof_blur_near_distance, dof_blur_near_transition, dof_blur_near_amount, VS::EnvironmentDOFBlurQuality(dof_blur_near_quality));
 }

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1312,6 +1312,7 @@ SpatialMaterial::DepthDrawMode SpatialMaterial::get_depth_draw_mode() const {
 
 void SpatialMaterial::set_cull_mode(CullMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	if (cull_mode == p_mode)
 		return;
 
@@ -1325,6 +1326,7 @@ SpatialMaterial::CullMode SpatialMaterial::get_cull_mode() const {
 
 void SpatialMaterial::set_diffuse_mode(DiffuseMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 5);
 	if (diffuse_mode == p_mode)
 		return;
 
@@ -1338,6 +1340,7 @@ SpatialMaterial::DiffuseMode SpatialMaterial::get_diffuse_mode() const {
 
 void SpatialMaterial::set_specular_mode(SpecularMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 5);
 	if (specular_mode == p_mode)
 		return;
 
@@ -1410,6 +1413,7 @@ Ref<Texture> SpatialMaterial::get_texture_by_name(StringName p_name) const {
 }
 
 void SpatialMaterial::_validate_feature(const String &text, Feature feature, PropertyInfo &property) const {
+	ERR_FAIL_INDEX(feature, FEATURE_MAX);
 	if (property.name.begins_with(text) && property.name != text + "_enabled" && !features[feature]) {
 		property.usage = 0;
 	}
@@ -1757,6 +1761,7 @@ SpatialMaterial::TextureChannel SpatialMaterial::get_roughness_texture_channel()
 
 void SpatialMaterial::set_ao_texture_channel(TextureChannel p_channel) {
 
+	ERR_FAIL_INDEX(p_channel, 5);
 	ao_texture_channel = p_channel;
 	VS::get_singleton()->material_set_param(_get_material(), shader_names->ao_texture_channel, _get_texture_mask(p_channel));
 }
@@ -1767,6 +1772,7 @@ SpatialMaterial::TextureChannel SpatialMaterial::get_ao_texture_channel() const 
 
 void SpatialMaterial::set_refraction_texture_channel(TextureChannel p_channel) {
 
+	ERR_FAIL_INDEX(p_channel, 5);
 	refraction_texture_channel = p_channel;
 	VS::get_singleton()->material_set_param(_get_material(), shader_names->refraction_texture_channel, _get_texture_mask(p_channel));
 }

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -828,6 +828,7 @@ void ArrayMesh::add_surface(uint32_t p_format, PrimitiveType p_primitive, const 
 
 void ArrayMesh::add_surface_from_arrays(PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes, uint32_t p_flags) {
 
+	ERR_FAIL_INDEX(p_primitive, 7);
 	ERR_FAIL_COND(p_arrays.size() != ARRAY_MAX);
 
 	Surface s;

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -280,6 +280,7 @@ RID MultiMesh::get_rid() const {
 
 void MultiMesh::set_color_format(ColorFormat p_color_format) {
 
+	ERR_FAIL_INDEX(p_color_format, 3);
 	ERR_FAIL_COND(instance_count > 0);
 	color_format = p_color_format;
 }
@@ -291,6 +292,7 @@ MultiMesh::ColorFormat MultiMesh::get_color_format() const {
 
 void MultiMesh::set_custom_data_format(CustomDataFormat p_custom_data_format) {
 
+	ERR_FAIL_INDEX(p_custom_data_format, 3);
 	ERR_FAIL_COND(instance_count > 0);
 	custom_data_format = p_custom_data_format;
 }

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -48,6 +48,7 @@ bool SceneState::can_instance() const {
 
 Node *SceneState::instance(GenEditState p_edit_state) const {
 
+	ERR_FAIL_INDEX_V(p_edit_state, 3, NULL);
 	// nodes where instancing failed (because something is missing)
 	List<Node *> stray_instances;
 
@@ -1689,6 +1690,7 @@ bool PackedScene::can_instance() const {
 
 Node *PackedScene::instance(GenEditState p_edit_state) const {
 
+	ERR_FAIL_INDEX_V(p_edit_state, 3, NULL);
 #ifndef TOOLS_ENABLED
 	if (p_edit_state != GEN_EDIT_STATE_DISABLED) {
 		ERR_EXPLAIN("Edit state is only for editors, does not work without tools compiled");

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -895,6 +895,7 @@ bool ParticlesMaterial::get_flag(Flags p_flag) const {
 
 void ParticlesMaterial::set_emission_shape(EmissionShape p_shape) {
 
+	ERR_FAIL_INDEX(p_shape, 5);
 	emission_shape = p_shape;
 	_change_notify();
 	_queue_shader_change();

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -250,6 +250,7 @@ Rect2 StyleBoxTexture::get_region_rect() const {
 
 void StyleBoxTexture::set_h_axis_stretch_mode(AxisStretchMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	axis_h = p_mode;
 	emit_changed();
 }
@@ -261,6 +262,7 @@ StyleBoxTexture::AxisStretchMode StyleBoxTexture::get_h_axis_stretch_mode() cons
 
 void StyleBoxTexture::set_v_axis_stretch_mode(AxisStretchMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 3);
 	axis_v = p_mode;
 	emit_changed();
 }

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -366,6 +366,7 @@ void ImageTexture::set_path(const String &p_path, bool p_take_over) {
 
 void ImageTexture::set_storage(Storage p_storage) {
 
+	ERR_FAIL_INDEX(p_storage, 3);
 	storage = p_storage;
 }
 
@@ -1530,6 +1531,7 @@ RID CubeMap::get_rid() const {
 
 void CubeMap::set_storage(Storage p_storage) {
 
+	ERR_FAIL_INDEX(p_storage, 3);
 	storage = p_storage;
 }
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -345,6 +345,7 @@ void TileSet::create_tile(int p_id) {
 }
 
 void TileSet::autotile_set_bitmask_mode(int p_id, BitmaskMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, 3);
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].autotile_data.bitmask_mode = p_mode;
 	_change_notify("");
@@ -439,6 +440,7 @@ Rect2 TileSet::tile_get_region(int p_id) const {
 }
 
 void TileSet::tile_set_tile_mode(int p_id, TileMode p_tile_mode) {
+	ERR_FAIL_INDEX(p_tile_mode, 3);
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].tile_mode = p_tile_mode;
 	emit_changed();

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -847,6 +847,7 @@ void VisualShader::_get_property_list(List<PropertyInfo> *p_list) const {
 
 Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBuilder &global_code_per_node, Map<Type, StringBuilder> &global_code_per_func, StringBuilder &code, Vector<VisualShader::DefaultTextureParam> &def_tex_params, const VMap<ConnectionKey, const List<Connection>::Element *> &input_connections, const VMap<ConnectionKey, const List<Connection>::Element *> &output_connections, int node, Set<int> &processed, bool for_preview, Set<StringName> &r_classes) const {
 
+	ERR_FAIL_INDEX_V(type, TYPE_MAX, ERR_INVALID_PARAMETER);
 	const Ref<VisualShaderNode> vsnode = graph[type].nodes[node].node;
 
 	//check inputs recursively first

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -522,6 +522,7 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeTexture::set_source(Source p_source) {
+	ERR_FAIL_INDEX(p_source, 5);
 	source = p_source;
 	emit_changed();
 	emit_signal("editor_refresh_request");
@@ -543,6 +544,7 @@ Ref<Texture> VisualShaderNodeTexture::get_texture() const {
 }
 
 void VisualShaderNodeTexture::set_texture_type(TextureType p_type) {
+	ERR_FAIL_INDEX(p_type, 3);
 	texture_type = p_type;
 	emit_changed();
 }
@@ -701,6 +703,7 @@ Ref<CubeMap> VisualShaderNodeCubeMap::get_cube_map() const {
 }
 
 void VisualShaderNodeCubeMap::set_texture_type(TextureType p_type) {
+	ERR_FAIL_INDEX(p_type, 3);
 	texture_type = p_type;
 	emit_changed();
 }
@@ -783,6 +786,7 @@ String VisualShaderNodeScalarOp::generate_code(Shader::Mode p_mode, VisualShader
 
 void VisualShaderNodeScalarOp::set_operator(Operator p_op) {
 
+	ERR_FAIL_INDEX(p_op, 10);
 	op = p_op;
 	emit_changed();
 }
@@ -873,6 +877,7 @@ String VisualShaderNodeVectorOp::generate_code(Shader::Mode p_mode, VisualShader
 
 void VisualShaderNodeVectorOp::set_operator(Operator p_op) {
 
+	ERR_FAIL_INDEX(p_op, 10);
 	op = p_op;
 	emit_changed();
 }
@@ -1024,6 +1029,7 @@ String VisualShaderNodeColorOp::generate_code(Shader::Mode p_mode, VisualShader:
 
 void VisualShaderNodeColorOp::set_operator(Operator p_op) {
 
+	ERR_FAIL_INDEX(p_op, 9);
 	op = p_op;
 	emit_changed();
 }
@@ -1436,6 +1442,7 @@ String VisualShaderNodeVectorFunc::generate_code(Shader::Mode p_mode, VisualShad
 
 void VisualShaderNodeVectorFunc::set_function(Function p_func) {
 
+	ERR_FAIL_INDEX(p_func, 35);
 	func = p_func;
 	emit_changed();
 }
@@ -1818,6 +1825,7 @@ String VisualShaderNodeScalarDerivativeFunc::generate_code(Shader::Mode p_mode, 
 
 void VisualShaderNodeScalarDerivativeFunc::set_function(Function p_func) {
 
+	ERR_FAIL_INDEX(p_func, 3);
 	func = p_func;
 	emit_changed();
 }
@@ -1895,6 +1903,7 @@ String VisualShaderNodeVectorDerivativeFunc::generate_code(Shader::Mode p_mode, 
 
 void VisualShaderNodeVectorDerivativeFunc::set_function(Function p_func) {
 
+	ERR_FAIL_INDEX(p_func, 3);
 	func = p_func;
 	emit_changed();
 }
@@ -3538,6 +3547,7 @@ VisualShaderNodeCompare::ComparsionType VisualShaderNodeCompare::get_comparsion_
 
 void VisualShaderNodeCompare::set_function(Function p_func) {
 
+	ERR_FAIL_INDEX(p_func, 6);
 	func = p_func;
 	emit_changed();
 }

--- a/servers/arvr/arvr_positional_tracker.cpp
+++ b/servers/arvr/arvr_positional_tracker.cpp
@@ -172,6 +172,7 @@ ARVRPositionalTracker::TrackerHand ARVRPositionalTracker::get_hand() const {
 };
 
 void ARVRPositionalTracker::set_hand(const ARVRPositionalTracker::TrackerHand p_hand) {
+	ERR_FAIL_INDEX(p_hand, 3);
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL(arvr_server);
 

--- a/servers/arvr_server.cpp
+++ b/servers/arvr_server.cpp
@@ -109,6 +109,7 @@ Transform ARVRServer::get_reference_frame() const {
 };
 
 void ARVRServer::center_on_hmd(RotationMode p_rotation_mode, bool p_keep_height) {
+	ERR_FAIL_INDEX(p_rotation_mode, 3);
 	if (primary_interface != NULL) {
 		// clear our current reference frame or we'll end up double adjusting it
 		reference_frame = Transform();

--- a/servers/audio/effects/audio_effect_distortion.cpp
+++ b/servers/audio/effects/audio_effect_distortion.cpp
@@ -110,6 +110,7 @@ Ref<AudioEffectInstance> AudioEffectDistortion::instance() {
 
 void AudioEffectDistortion::set_mode(Mode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 5);
 	mode = p_mode;
 }
 

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -156,6 +156,7 @@ void AudioEffectSpectrumAnalyzerInstance::_bind_methods() {
 
 Vector2 AudioEffectSpectrumAnalyzerInstance::get_magnitude_for_frequency_range(float p_begin, float p_end, MagnitudeMode p_mode) const {
 
+	ERR_FAIL_INDEX_V(p_mode, MAGNITUDE_MAX, Vector2());
 	if (last_fft_time == 0) {
 		return Vector2();
 	}

--- a/servers/audio/effects/eq.cpp
+++ b/servers/audio/effects/eq.cpp
@@ -117,6 +117,7 @@ void EQ::recalculate_band_coefficients() {
 
 void EQ::set_preset_band_mode(Preset p_preset) {
 
+	ERR_FAIL_INDEX(p_preset, 5);
 	band.clear();
 
 #define PUSH_BANDS(m_bands)             \

--- a/servers/audio/reverb_sw.cpp
+++ b/servers/audio/reverb_sw.cpp
@@ -502,6 +502,7 @@ void ReverbSW::adjust_current_params() {
 
 void ReverbSW::set_mode(ReverbMode p_mode) {
 
+	ERR_FAIL_INDEX(p_mode, 9);
 	if (mode == p_mode)
 		return;
 

--- a/servers/physics/space_sw.h
+++ b/servers/physics/space_sw.h
@@ -195,7 +195,10 @@ public:
 	void set_static_global_body(RID p_body) { static_global_body = p_body; }
 	RID get_static_global_body() { return static_global_body; }
 
-	void set_elapsed_time(ElapsedTime p_time, uint64_t p_msec) { elapsed_time[p_time] = p_msec; }
+	void set_elapsed_time(ElapsedTime p_time, uint64_t p_msec) {
+		ERR_FAIL_INDEX(p_time, ELAPSED_TIME_MAX);
+		elapsed_time[p_time] = p_msec;
+	}
 	uint64_t get_elapsed_time(ElapsedTime p_time) const { return elapsed_time[p_time]; }
 
 	int test_body_ray_separation(BodySW *p_body, const Transform &p_transform, bool p_infinite_inertia, Vector3 &r_recover_motion, PhysicsServer::SeparationResult *r_results, int p_result_max, real_t p_margin);


### PR DESCRIPTION
This should help to debug Godot projects, because before wrong values could have could have quietly corrupted the program.

#31358 (or  #28297) should be merged first