### PR TITLE
Fix wrong mouse wheel position for MOUSE_MODE_CAPTURED on Windows

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -719,7 +719,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 						pressrc = 0;
 					}
 				}
-			} else if (mouse_mode != MOUSE_MODE_CAPTURED) {
+			} else {
 				// for reasons unknown to mankind, wheel comes in screen coordinates
 				POINT coords;
 				coords.x = mb->get_position().x;


### PR DESCRIPTION
WM_MOUSEWHEEL and WM_MOUSEHWHEEL report mouse coordinates relative to
the screen (see lParam in [1]), rather than to the window like the rest
of the mouse events.

The current code already makes adjustments to take that into account.

However, it only makes the adjustments if the mouse is not captured, and
the coordinates are always relative to the screen regardless of whether
the mouse is captured or not, so let's fix the code to always
consistently apply the adjustments.

This fixes #29559.

[1] - https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-mousewheel