### PR TITLE
Allow to define and load script templates per project

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1019,6 +1019,9 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("editor/search_in_file_extensions", extensions);
 	custom_prop_info["editor/search_in_file_extensions"] = PropertyInfo(Variant::POOL_STRING_ARRAY, "editor/search_in_file_extensions");
 
+	GLOBAL_DEF("editor/script_templates_search_path", "res://script_templates");
+	custom_prop_info["editor/script_templates_search_path"] = PropertyInfo(Variant::STRING, "editor/script_templates_search_path", PROPERTY_HINT_DIR);
+
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);
 	events = Array();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1209,6 +1209,11 @@ String EditorSettings::get_script_templates_dir() const {
 	return get_settings_dir().plus_file("script_templates");
 }
 
+String EditorSettings::get_project_script_templates_dir() const {
+
+	return ProjectSettings::get_singleton()->get("editor/script_templates_search_path");
+}
+
 // Cache directory
 
 String EditorSettings::get_cache_dir() const {
@@ -1429,10 +1434,14 @@ bool EditorSettings::is_default_text_editor_theme() {
 	return _is_default_text_editor_theme(p_file.get_file().to_lower());
 }
 
-Vector<String> EditorSettings::get_script_templates(const String &p_extension) {
+Vector<String> EditorSettings::get_script_templates(const String &p_extension, const String &p_custom_path) {
 
 	Vector<String> templates;
-	DirAccess *d = DirAccess::open(get_script_templates_dir());
+	String template_dir = get_script_templates_dir();
+	if (!p_custom_path.empty()) {
+		template_dir = p_custom_path;
+	}
+	DirAccess *d = DirAccess::open(template_dir);
 	if (d) {
 		d->list_dir_begin();
 		String file = d->get_next();

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -166,6 +166,7 @@ public:
 	String get_project_settings_dir() const;
 	String get_text_editor_themes_dir() const;
 	String get_script_templates_dir() const;
+	String get_project_script_templates_dir() const;
 	String get_cache_dir() const;
 	String get_feature_profiles_dir() const;
 
@@ -187,7 +188,7 @@ public:
 	bool save_text_editor_theme_as(String p_file);
 	bool is_default_text_editor_theme();
 
-	Vector<String> get_script_templates(const String &p_extension);
+	Vector<String> get_script_templates(const String &p_extension, const String &p_custom_path = String());
 	String get_editor_layouts_config() const;
 
 	void add_shortcut(const String &p_name, Ref<ShortCut> &p_shortcut);

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -78,8 +78,25 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	int current_language;
 	int default_language;
 	bool re_check_path;
+
+	enum ScriptOrigin {
+		SCRIPT_ORIGIN_PROJECT,
+		SCRIPT_ORIGIN_EDITOR,
+	};
+	struct ScriptTemplateInfo {
+		int id;
+		ScriptOrigin origin;
+		String dir;
+		String name;
+		String extension;
+	};
+
 	String script_template;
-	Vector<String> template_list;
+	Vector<ScriptTemplateInfo> template_list;
+	Map<String, Vector<int> > template_overrides; // name : indices
+
+	void _update_script_templates(const String &p_extension);
+
 	String base_type;
 
 	void _path_hbox_sorted();


### PR DESCRIPTION
Closes #19145 and likely closes #31037.

## Summary

1. Put your script templates in `res://script_templates` or other place within a project.
2. Use them via script create dialog normally, potentially overriding built-in templates.

## Description

Previously it was only possible to create custom script templates per editor instance which could lead to certain collisions, but now one can create such templates per project tailored for specific use cases.

The default path to search for custom script templates is defined in project settings via `editor/script_templates/paths` setting as `res://script_templates` path, but this can be overridden. 

Also added template override mechanism as described in https://github.com/godotengine/godot/pull/31111#issuecomment-518635426, later revised in https://github.com/godotengine/godot/pull/31111#issuecomment-519088791.

![script_templates](https://user-images.githubusercontent.com/17108460/63538079-d5045600-c51f-11e9-8121-e03605f962c6.png)
![custom_script_templates](https://user-images.githubusercontent.com/17108460/63538120-e51c3580-c51f-11e9-8d6f-098f51925830.png)


### Issues

1. GDScript parser treats templates as invalid. The project runs fine but this could lead to some confusion I believe. These templates must be ignored somehow. (can be salvaged by including .gdignore in template folder).

2. Supporting multiple folders in project resulted in https://github.com/godotengine/godot/pull/31111#issuecomment-519121015, so the feature was dropped.

### Warning
Backup your editor settings before testing this PR!

### Test project
[script-templates-project.zip](https://github.com/godotengine/godot/files/3491820/script-templates-project.zip)


