### PR TITLE
Remove Editor dependency from SceneTree

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -334,6 +334,11 @@ void EditorNode::_notification(int p_what) {
 			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(EDITOR_GET("interface/editor/unfocused_low_processor_mode_sleep_usec")));
 		} break;
 
+		case MainLoop::NOTIFICATION_WM_ABOUT: {
+
+			show_about();
+		} break;
+
 		case MainLoop::NOTIFICATION_WM_QUIT_REQUEST: {
 
 			_menu_option_confirm(FILE_QUIT, false);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -37,7 +37,6 @@
 #include "core/os/os.h"
 #include "core/print_string.h"
 #include "core/project_settings.h"
-#include "editor/editor_node.h"
 #include "main/input_default.h"
 #include "node.h"
 #include "scene/resources/dynamic_font.h"
@@ -647,7 +646,8 @@ void SceneTree::_notification(int p_notification) {
 		case NOTIFICATION_WM_MOUSE_ENTER:
 		case NOTIFICATION_WM_MOUSE_EXIT:
 		case NOTIFICATION_WM_FOCUS_IN:
-		case NOTIFICATION_WM_FOCUS_OUT: {
+		case NOTIFICATION_WM_FOCUS_OUT:
+		case NOTIFICATION_WM_ABOUT: {
 
 			if (p_notification == NOTIFICATION_WM_FOCUS_IN) {
 				InputDefault *id = Object::cast_to<InputDefault>(Input::get_singleton());
@@ -669,19 +669,6 @@ void SceneTree::_notification(int p_notification) {
 
 			get_root()->propagate_notification(p_notification);
 
-		} break;
-
-		case NOTIFICATION_WM_ABOUT: {
-
-#ifdef TOOLS_ENABLED
-			if (EditorNode::get_singleton()) {
-				EditorNode::get_singleton()->show_about();
-			} else {
-#endif
-				get_root()->propagate_notification(p_notification);
-#ifdef TOOLS_ENABLED
-			}
-#endif
 		} break;
 
 		case NOTIFICATION_CRASH: {


### PR DESCRIPTION
Let `EditorNode` handle the `NOTIFICATION_WM_ABOUT` notification by itself. Not sure why this was put into `SceneTree` in the first place. :eyes: 

Part of #29730.