### PR TITLE
Let EditorPlugins set editor/distraction-free mode

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2775,6 +2775,20 @@ void EditorNode::_editor_select(int p_which) {
 	}
 }
 
+void EditorNode::select_editor_by_name(const String &p_name) {
+	ERR_FAIL_COND(p_name == "");
+
+	for (int i = 0; i < main_editor_buttons.size(); i++) {
+		if (main_editor_buttons[i]->get_text() == p_name) {
+			_editor_select(i);
+			return;
+		}
+	}
+
+	ERR_EXPLAIN("The editor name '" + p_name + "' was not found.");
+	ERR_FAIL();
+}
+
 void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed) {
 
 	if (p_editor->has_main_screen()) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -732,6 +732,8 @@ public:
 	bool item_has_editor(Object *p_object);
 	void hide_top_editors();
 
+	void select_editor_by_name(const String &p_name);
+
 	void open_request(const String &p_path);
 
 	bool is_changing_scene() const;

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -149,6 +149,10 @@ Vector<Ref<Texture> > EditorInterface::make_mesh_previews(const Vector<Ref<Mesh>
 	return textures;
 }
 
+void EditorInterface::set_main_screen_editor(const String &p_name) {
+	EditorNode::get_singleton()->select_editor_by_name(p_name);
+}
+
 Control *EditorInterface::get_editor_viewport() {
 
 	return EditorNode::get_singleton()->get_viewport();
@@ -260,6 +264,10 @@ void EditorInterface::save_scene_as(const String &p_scene, bool p_with_preview) 
 	EditorNode::get_singleton()->save_scene_to_path(p_scene, p_with_preview);
 }
 
+void EditorInterface::set_distraction_free_mode(bool p_enter) {
+	EditorNode::get_singleton()->set_distraction_free_mode(p_enter);
+}
+
 EditorInterface *EditorInterface::singleton = NULL;
 
 void EditorInterface::_bind_methods() {
@@ -288,6 +296,9 @@ void EditorInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);
 	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));
+
+	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
+	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);
 }
 
 EditorInterface::EditorInterface() {

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -103,6 +103,9 @@ public:
 
 	Vector<Ref<Texture> > make_mesh_previews(const Vector<Ref<Mesh> > &p_meshes, Vector<Transform> *p_transforms, int p_preview_size);
 
+	void set_main_screen_editor(const String &p_name);
+	void set_distraction_free_mode(bool p_enter);
+
 	EditorInterface();
 };
 


### PR DESCRIPTION
Give plugin creators the ability to manipulate which main screen editor is displayed and whether the editor takes up the window's space or not. This also applies to a plugin's custom editor.