### PR TITLE
Improve snapping in the animation editor

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -31,6 +31,7 @@
 #include "animation_track_editor.h"
 
 #include "animation_track_editor_plugins.h"
+#include "core/os/input.h"
 #include "core/os/keyboard.h"
 #include "editor/animation_bezier_editor.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
@@ -4082,6 +4083,10 @@ bool AnimationTrackEditor::is_selection_active() const {
 	return selection.size();
 }
 
+bool AnimationTrackEditor::is_snap_enabled() const {
+	return snap->is_pressed() ^ Input::get_singleton()->is_key_pressed(KEY_CONTROL);
+}
+
 void AnimationTrackEditor::_update_tracks() {
 
 	int selected = _get_track_selected();
@@ -5679,7 +5684,7 @@ void AnimationTrackEditor::_selection_changed() {
 
 float AnimationTrackEditor::snap_time(float p_value) {
 
-	if (snap->is_pressed()) {
+	if (is_snap_enabled()) {
 
 		double snap_increment;
 		if (timeline->is_using_fps() && step->get_value() > 0)

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -520,8 +520,8 @@ public:
 	bool is_key_selected(int p_track, int p_key) const;
 	bool is_selection_active() const;
 	bool is_moving_selection() const;
+	bool is_snap_enabled() const;
 	float get_moving_selection_offset() const;
-	bool is_snap_enabled();
 	float snap_time(float p_value);
 	bool is_grouping_tracks();
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/os/input.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
 #include "editor/animation_track_editor.h"
@@ -293,10 +294,6 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 			}
 		}
 		frame->set_max(anim->get_length());
-		if (anim->get_step())
-			frame->set_step(anim->get_step());
-		else
-			frame->set_step(0.00001);
 
 	} else {
 		track_editor->set_animation(Ref<Animation>());
@@ -1008,7 +1005,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set) {
 	};
 
 	updating = true;
-	String current = player->get_assigned_animation(); //animation->get_item_text( animation->get_selected() );
+	String current = player->get_assigned_animation();
 	if (current == "" || !player->has_animation(current)) {
 		updating = false;
 		current = "";
@@ -1018,14 +1015,9 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set) {
 	Ref<Animation> anim;
 	anim = player->get_animation(current);
 
-	float pos = anim->get_length() * (p_value / frame->get_max());
-	float step = anim->get_step();
-	if (step) {
-		pos = Math::stepify(pos, step);
-		if (pos < 0)
-			pos = 0;
-		if (pos >= anim->get_length())
-			pos = anim->get_length();
+	float pos = CLAMP(anim->get_length() * (p_value / frame->get_max()), 0, anim->get_length());
+	if (track_editor->is_snap_enabled()) {
+		pos = Math::stepify(pos, anim->get_step());
 	}
 
 	if (player->is_valid() && !p_set) {
@@ -1063,14 +1055,6 @@ void AnimationPlayerEditor::_animation_key_editor_anim_len_changed(float p_len) 
 	frame->set_max(p_len);
 }
 
-void AnimationPlayerEditor::_animation_key_editor_anim_step_changed(float p_len) {
-
-	if (p_len)
-		frame->set_step(p_len);
-	else
-		frame->set_step(0.00001);
-}
-
 void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag) {
 
 	if (!is_visible_in_tree())
@@ -1081,8 +1065,10 @@ void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag)
 	if (player->is_playing())
 		return;
 
+	Ref<Animation> anim = player->get_animation(player->get_assigned_animation());
+
 	updating = true;
-	frame->set_value(p_pos);
+	frame->set_value(Math::stepify(p_pos, track_editor->is_snap_enabled() ? anim->get_step() : 0));
 	updating = false;
 	_seek_value_changed(p_pos, !p_drag);
 
@@ -1558,7 +1544,6 @@ void AnimationPlayerEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_list_changed"), &AnimationPlayerEditor::_list_changed);
 	ClassDB::bind_method(D_METHOD("_animation_key_editor_seek"), &AnimationPlayerEditor::_animation_key_editor_seek);
 	ClassDB::bind_method(D_METHOD("_animation_key_editor_anim_len_changed"), &AnimationPlayerEditor::_animation_key_editor_anim_len_changed);
-	ClassDB::bind_method(D_METHOD("_animation_key_editor_anim_step_changed"), &AnimationPlayerEditor::_animation_key_editor_anim_step_changed);
 	ClassDB::bind_method(D_METHOD("_hide_anim_editors"), &AnimationPlayerEditor::_hide_anim_editors);
 	ClassDB::bind_method(D_METHOD("_animation_duplicate"), &AnimationPlayerEditor::_animation_duplicate);
 	ClassDB::bind_method(D_METHOD("_blend_editor_next_changed"), &AnimationPlayerEditor::_blend_editor_next_changed);
@@ -1621,6 +1606,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	hb->add_child(frame);
 	frame->set_custom_minimum_size(Size2(60, 0));
 	frame->set_stretch_ratio(2);
+	frame->set_step(0.00001);
 	frame->set_tooltip(TTR("Animation position (in seconds)."));
 
 	hb->add_child(memnew(VSeparator));
@@ -1774,7 +1760,6 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	track_editor->set_v_size_flags(SIZE_EXPAND_FILL);
 	track_editor->connect("timeline_changed", this, "_animation_key_editor_seek");
 	track_editor->connect("animation_len_changed", this, "_animation_key_editor_anim_len_changed");
-	track_editor->connect("animation_step_changed", this, "_animation_key_editor_anim_step_changed");
 
 	_update_player();
 

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -203,7 +203,6 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 	void _animation_key_editor_seek(float p_pos, bool p_drag);
 	void _animation_key_editor_anim_len_changed(float p_len);
-	void _animation_key_editor_anim_step_changed(float p_len);
 
 	void _unhandled_key_input(const Ref<InputEvent> &p_ev);
 	void _animation_tool_menu(int p_option);


### PR DESCRIPTION
Snapping can now be toggled temporarily by holding the <kbd>Ctrl</kbd> key. Toggling timeline snapping is now done with the "Snap" checkbox rather than by setting the animation's "Step" setting to 0.

The timeline cursor can no longer exit the animation's boundaries if the animation's "Step" is set to 0.