### PR TITLE
Fixed EOF flag not resetting on seek back in compressed file

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -208,7 +208,8 @@ void FileAccessCompressed::seek(size_t p_position) {
 		if (p_position == read_total) {
 			at_end = true;
 		} else {
-
+			at_end = false;
+			read_eof = false;
 			int block_idx = p_position / block_size;
 			if (block_idx != read_block) {
 


### PR DESCRIPTION
This PR fixes #18352, where reading a compressed file to EOF, then seeking back would not unset `file.eof_reached()`. With how `FileAccessCompressed` is structured, this fix SHOULD work on all platforms.

You can test this commit by creating a project, adding a node, and adding this built-in script:
```
extends Node

func _ready():
	var save = File.new(); # New file
	var compression = File.COMPRESSION_FASTLZ;
	var path = "res://file.txt";
	
	save.open_compressed(path, File.WRITE, compression);
	save.store_line("line 1");
	save.store_line("line 2");
	save.store_line("line 3");
	save.close();
	
	print("Compressed file written");
	
	save.open_compressed(path, File.READ, compression)
	
	print("Beginning Loop 1");
	while not save.eof_reached():
		print("Loop 1: %s" % str(save.get_line()));
	
	print("EOF reached for Loop 1\n");
	print("Seeking to start...");
	save.seek(0);
	
	print("Beginning Loop 2");
	while not save.eof_reached():
		print("Loop 2: %s" % str(save.get_line()));
	
	print("EOF reached for Loop 2\n");
	randomize();
	var randp = randi() % save.get_len();
	print("Seeking to random point %d" % randp);
	save.seek(randp);
	while not save.eof_reached():
		print("Loop 3: %s" % save.get_line());
	
	print("EOF reached for Loop 3");
```
In the master branch, this will not print any lines for loops 2 and 3. In this PR, loop 2 will print the same output as loop 1, and loop 3 will seek to a random position in the file and print what it finds.

This PR has been tested on Windows 10 64-bit and OS X Yosemite 10.10.5