### PR TITLE
GLTF Import fix for Blender duplicate skin exports

### DIFF
--- a/core/vector.h
+++ b/core/vector.h
@@ -82,7 +82,6 @@ public:
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
-	_FORCE_INLINE_ T &operator[](int p_index) { return _cowdata.get_m(p_index); }
 	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }
 	Error insert(int p_pos, const T &p_val) { return _cowdata.insert(p_pos, p_val); }
 	int find(const T &p_val, int p_from = 0) const { return _cowdata.find(p_val, p_from); }

--- a/core/vector.h
+++ b/core/vector.h
@@ -82,6 +82,7 @@ public:
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
+	_FORCE_INLINE_ T &operator[](int p_index) { return _cowdata.get_m(p_index); }
 	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }
 	Error insert(int p_pos, const T &p_val) { return _cowdata.insert(p_pos, p_val); }
 	int find(const T &p_val, int p_from = 0) const { return _cowdata.find(p_val, p_from); }

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1467,7 +1467,7 @@ Error EditorSceneImporterGLTF::_parse_skins(GLTFState &state) {
 
 			GLTFNode::Joint joint;
 			joint.skin = target_skin_id;
-			joint.skin_bone_index = state.nodes[node_index]->joints.size();
+			joint.skin_bone_index = target_skin->bones.size();
 			state.nodes[node_index]->joints.push_back(joint);
 
 			GLTFSkin::Bone bone;

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -94,12 +94,12 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 		struct Joint {
 			int skin;
-			int bone;
+			int skin_bone_index;
 			int godot_bone_index;
 
 			Joint() {
 				skin = -1;
-				bone = -1;
+				skin_bone_index = -1;
 				godot_bone_index = -1;
 			}
 		};

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -187,14 +187,9 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 			int node;
 		};
 
-		int skeleton;
 		Vector<Bone> bones;
 
-		//matrices need to be transformed to this
-
-		GLTFSkin() {
-			skeleton = -1;
-		}
+		// matrices need to be transformed to this
 	};
 
 	struct GLTFMesh {


### PR DESCRIPTION
Currently Blenders GLTF exporter is bugged, and will export a seperate
Skin for each mesh bound to the same skeleton. This results in one
skeleton node hierarchy but multiple skins in the exported file. This
causes each skin to create a new skeleton in Godot.

This fix will ignore duplicate skins from being added to the GLTFState.