### PR TITLE
fixes issue #28021:

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -48,6 +48,8 @@ class Panel;
 
 class Control : public CanvasItem {
 
+	friend class TextEdit;
+
 	GDCLASS(Control, CanvasItem);
 	OBJ_CATEGORY("GUI Nodes");
 
@@ -234,7 +236,7 @@ private:
 	void _compute_margins(Rect2 p_rect, const float p_anchors[4], float (&r_margins)[4]);
 	void _compute_anchors(Rect2 p_rect, const float p_margins[4], float (&r_anchors)[4]);
 
-	void _size_changed();
+	virtual void _size_changed();
 	String _get_tooltip() const;
 
 	void _override_changed();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5547,6 +5547,11 @@ void TextEdit::_do_text_op(const TextOperation &p_op, bool p_reverse) {
 	}
 }
 
+void TextEdit::_size_changed() {
+	Control::_size_changed();
+	_update_wrap_at();
+}
+
 void TextEdit::_clear_redo() {
 
 	if (undo_stack_pos == NULL)

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -244,6 +244,8 @@ private:
 	void _clear_redo();
 	void _do_text_op(const TextOperation &p_op, bool p_reverse);
 
+	void _size_changed() override;
+
 	//syntax coloring
 	SyntaxHighlighter *syntax_highlighter;
 	HashMap<String, Color> keywords;


### PR DESCRIPTION
Text in multiline arrays in inspector now wraps correctly after uncollapsing.

`TextEdit` now overrides `Control`'s `_size_changed` method and calls it's `_update_wrap_at` method in it.

*Bugsquad edit:* This closes #28021.