### PR TITLE
Project feature warning system

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -48,6 +48,8 @@ public:
 		//properties that are not for built in values begin from this value, so builtin ones are displayed first
 		NO_BUILTIN_ORDER_BASE = 1 << 16
 	};
+	const static PackedStringArray get_required_features();
+	const static PackedStringArray get_unsupported_features(const PackedStringArray &p_project_features);
 
 	struct AutoloadInfo {
 		StringName name;
@@ -111,6 +113,9 @@ protected:
 
 	Error _save_custom_bnd(const String &p_file);
 
+	const static PackedStringArray _get_supported_features();
+	const static PackedStringArray _trim_to_supported_features(const PackedStringArray &p_project_features);
+
 	void _convert_to_last_version(int p_from_version);
 
 	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0);
@@ -125,7 +130,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	static const int CONFIG_VERSION = 4;
+	static const int CONFIG_VERSION = 5;
 
 	void set_setting(const String &p_setting, const Variant &p_value);
 	Variant get_setting(const String &p_setting) const;
@@ -158,6 +163,7 @@ public:
 
 	Error setup(const String &p_path, const String &p_main_pack, bool p_upwards = false, bool p_ignore_override = false);
 
+	Error load_custom(const String &p_path);
 	Error save_custom(const String &p_path = "", const CustomMap &p_custom = CustomMap(), const Vector<String> &p_custom_features = Vector<String>(), bool p_merge_with_current = true);
 	Error save();
 	void set_custom_property_info(const String &p_prop, const PropertyInfo &p_info);

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -183,7 +183,9 @@ Error ConfigFile::_internal_save(FileAccess *file) {
 		if (E != values.front()) {
 			file->store_string("\n");
 		}
-		file->store_string("[" + E.key() + "]\n\n");
+		if (E.key() != "") {
+			file->store_string("[" + E.key() + "]\n\n");
+		}
 
 		for (OrderedHashMap<String, Variant>::Element F = E.get().front(); F; F = F.next()) {
 			String vstr;


### PR DESCRIPTION
(Note: This PR also increments the config version by necessity)

A mostly complete implementation of a feature warning system, implements and closes https://github.com/godotengine/godot-proposals/issues/427, implements and closes https://github.com/godotengine/godot-proposals/issues/237

EDIT: The screenshot is a bit outdated, since now there are more specific error messages available.

![f](https://user-images.githubusercontent.com/1646875/62596124-cec27880-b895-11e9-883d-ad3d6e4e5da5.png)

What works: Reading project features from `project.godot`, displaying unsupported features, warning when trying to open a project with unsupported features, changing the features to comply with currently supported and required features, and saving project features to `project.godot`.

This PR uses the new feature system for the following:

* Saves the Godot version. This is in parallel to `config_version`, so as an example if 4.0 and 4.1 use the same config version then this system will show a warning when opening 4.0 projects in 4.1 and 4.1 projects in 4.0, but if 4.2 uses a higher config version then upgrading to 4.2 would be one-way.
  * Users can also pin a project to a minor version or engine build if they wish, so 4.0.1 as an example.
* Allows different builds of Godot to save feature tags to warn about the different features. In this PR it saves information about:
  * Whether a project is using single-precision or doubles.
  * Which renderer the project is using (Vulkan/GLES/etc).
  * Whether a project is using C#.
  * More can be added later if there's a need for any other feature tags.
* Allows people to make custom builds of Godot and include a feature tag for it. Since this system just saves strings, even official builds of Godot can warn that they are missing features found in custom Godot forks.
