### PR TITLE
Fix Find in Files Not Working Properly

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -44,6 +44,7 @@
 #include "editor/script_editor_debugger.h"
 #include "scene/main/viewport.h"
 #include "script_text_editor.h"
+#include "text_editor.h"
 
 /*** SCRIPT EDITOR ****/
 
@@ -2995,11 +2996,26 @@ void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_numb
 		shader_editor->make_visible(true);
 		shader_editor->get_shader_editor()->goto_line_selection(line_number - 1, begin, end);
 	} else {
-		edit(res);
+		Ref<Script> script = res;
+		if (script.is_valid()) {
+			edit(script);
 
-		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
-		if (ste) {
-			ste->goto_line_selection(line_number - 1, begin, end);
+			ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
+			if (ste) {
+				ste->goto_line_selection(line_number - 1, begin, end);
+			}
+		} else { //if file is not valid script, load as text file
+
+			Error err;
+			Ref<TextFile> text_file = _load_text_file(fpath, &err);
+			if (text_file.is_valid()) {
+				edit(text_file);
+
+				TextEditor *te = Object::cast_to<TextEditor>(_get_current_editor());
+				if (te) {
+					te->goto_line_selection(line_number - 1, begin, end);
+				}
+			}
 		}
 	}
 }

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -313,6 +313,11 @@ void TextEditor::goto_line(int p_line, bool p_with_error) {
 	code_editor->goto_line(p_line);
 }
 
+void TextEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
+
+	code_editor->goto_line_selection(p_line, p_begin, p_end);
+}
+
 void TextEditor::set_executing_line(int p_line) {
 
 	code_editor->set_executing_line(p_line);

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -131,6 +131,7 @@ public:
 	virtual Vector<String> get_functions();
 	virtual void get_breakpoints(List<int> *p_breakpoints);
 	virtual void goto_line(int p_line, bool p_with_error = false);
+	void goto_line_selection(int p_line, int p_begin, int p_end);
 	virtual void set_executing_line(int p_line);
 	virtual void clear_executing_line();
 	virtual void trim_trailing_whitespace();


### PR DESCRIPTION
When using the "Find in Files" option to search in non-script files (e.g. .tscn), the search does not work properly.

Closes: #20692