### PR TITLE
Added Thread Sanitizer

### DIFF
--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -35,6 +35,7 @@ def get_opts():
         BoolVariable('use_ubsan', 'Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)', False),
         BoolVariable('use_asan', 'Use LLVM/GCC compiler address sanitizer (ASAN))', False),
         BoolVariable('use_lsan', 'Use LLVM/GCC compiler leak sanitizer (LSAN))', False),
+        BoolVariable('use_tsan', 'Use LLVM/GCC compiler thread sanitizer (TSAN))', False),
         EnumVariable('debug_symbols', 'Add debugging symbols to release builds', 'yes', ('yes', 'no', 'full')),
         BoolVariable('separate_debug_symbols', 'Create a separate file containing debugging symbols', False),
         BoolVariable('execinfo', 'Use libexecinfo on systems where glibc is not available', False),
@@ -99,7 +100,7 @@ def configure(env):
         env.extra_suffix = ".llvm" + env.extra_suffix
 
 
-    if env['use_ubsan'] or env['use_asan'] or env['use_lsan']:
+    if env['use_ubsan'] or env['use_asan'] or env['use_lsan'] or env['use_tsan']:
         env.extra_suffix += "s"
 
         if env['use_ubsan']:
@@ -113,6 +114,10 @@ def configure(env):
         if env['use_lsan']:
             env.Append(CCFLAGS=['-fsanitize=leak'])
             env.Append(LINKFLAGS=['-fsanitize=leak'])
+
+        if env['use_tsan']:
+            env.Append(CCFLAGS=['-fsanitize=thread'])
+            env.Append(LINKFLAGS=['-fsanitize=thread'])
 
     if env['use_lto']:
         env.Append(CCFLAGS=['-flto'])

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -64,6 +64,7 @@ def get_opts():
         BoolVariable('use_ubsan', 'Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)', False),
         BoolVariable('use_asan', 'Use LLVM/GCC compiler address sanitizer (ASAN))', False),
         BoolVariable('use_lsan', 'Use LLVM/GCC compiler leak sanitizer (LSAN))', False),
+        BoolVariable('use_tsan', 'Use LLVM/GCC compiler thread sanitizer (TSAN))', False),
         BoolVariable('pulseaudio', 'Detect and use PulseAudio', True),
         BoolVariable('udev', 'Use udev for gamepad connection callbacks', False),
         EnumVariable('debug_symbols', 'Add debugging symbols to release builds', 'yes', ('yes', 'no', 'full')),
@@ -140,7 +141,7 @@ def configure(env):
             print("Using LLD with GCC is not supported yet, try compiling with 'use_llvm=yes'.")
             sys.exit(255)
 
-    if env['use_ubsan'] or env['use_asan'] or env['use_lsan']:
+    if env['use_ubsan'] or env['use_asan'] or env['use_lsan'] or env['use_tsan']:
         env.extra_suffix += "s"
 
         if env['use_ubsan']:
@@ -154,6 +155,10 @@ def configure(env):
         if env['use_lsan']:
             env.Append(CCFLAGS=['-fsanitize=leak'])
             env.Append(LINKFLAGS=['-fsanitize=leak'])
+
+        if env['use_tsan']:
+            env.Append(CCFLAGS=['-fsanitize=thread'])
+            env.Append(LINKFLAGS=['-fsanitize=thread'])
 
     if env['use_lto']:
         if not env['use_llvm'] and env.GetOption("num_jobs") > 1:


### PR DESCRIPTION
PR adds Thread Sanitizer, which can find Data Races
Fixes #31157 

I must add some return, because compiler complains about missing return in non void function.
```
modules/gdscript/gdscript_parser.cpp: In member function 'GDScriptParser::Node* GDScriptParser::_reduce_expression(GDScriptParser::Node*, bool)':
modules/gdscript/gdscript_parser.cpp:1981:1: error: control reaches end of non-void function [-Werror=return-type]
 }
```
Godot seems to work with this option ~100x slower than normal(or even slower)

Example report
```
WARNING: ThreadSanitizer: data race (pid=25245)
  Write of size 4 at 0x000006195e40 by main thread:
    #0 ScriptServer::register_language(ScriptLanguage*) core/script_language.cpp:92 (godot.x11.tools.64s+0x43c85af)
    #1 register_nativescript_types() modules/gdnative/nativescript/register_types.cpp:51 (godot.x11.tools.64s+0x147380c)
    #2 register_gdnative_types() modules/gdnative/register_types.cpp:243 (godot.x11.tools.64s+0x146cec9)
    #3 register_module_types() modules/register_module_types.gen.cpp:78 (godot.x11.tools.64s+0x145ade7)
    #4 Main::setup2(unsigned long) main/main.cpp:1259 (godot.x11.tools.64s+0x13e6cb1)
    #5 Main::setup(char const*, int, char**, bool) main/main.cpp:1051 (godot.x11.tools.64s+0x13e38b2)
    #6 main platform/x11/godot_x11.cpp:49 (godot.x11.tools.64s+0x138d7d7)

  Previous read of size 4 at 0x000006195e40 by thread T1:
    #0 ScriptServer::thread_enter() core/script_language.cpp:150 (godot.x11.tools.64s+0x43c9009)
    #1 ThreadPosix::thread_callback(void*) drivers/unix/thread_posix.cpp:72 (godot.x11.tools.64s+0x22a7f27)
    #2 <null> <null> (libtsan.so.0+0x2b276)

  As if synchronized via sleep:
    #0 nanosleep <null> (libtsan.so.0+0x51a40)
    #1 OS_Unix::delay_usec(unsigned int) const drivers/unix/os_unix.cpp:260 (godot.x11.tools.64s+0x22a1b7e)
    #2 VisualServerWrapMT::init() servers/visual/visual_server_wrap_mt.cpp:117 (godot.x11.tools.64s+0x4007585)
    #3 OS_X11::initialize(OS::VideoMode const&, int, int) platform/x11/os_x11.cpp:582 (godot.x11.tools.64s+0x1394c1a)
    #4 Main::setup2(unsigned long) main/main.cpp:1106 (godot.x11.tools.64s+0x13e5381)
    #5 Main::setup(char const*, int, char**, bool) main/main.cpp:1051 (godot.x11.tools.64s+0x13e38b2)
    #6 main platform/x11/godot_x11.cpp:49 (godot.x11.tools.64s+0x138d7d7)

  Location is global 'ScriptServer::_language_count' of size 4 at 0x000006195e40 (godot.x11.tools.64s+0x000006195e40)

  Thread T1 (tid=25247, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2da8e)
    #1 ThreadPosix::create_func_posix(void (*)(void*), void*, Thread::Settings const&) drivers/unix/thread_posix.cpp:90 (godot.x11.tools.64s+0x22a8073)
    #2 Thread::create(void (*)(void*), void*, Thread::Settings const&) core/os/thread.cpp:51 (godot.x11.tools.64s+0x44dd2d2)
    #3 IP::IP() core/io/ip.cpp:326 (godot.x11.tools.64s+0x459925d)
    #4 IP_Unix::IP_Unix() drivers/unix/ip_unix.cpp:267 (godot.x11.tools.64s+0x23fd606)
    #5 IP_Unix::_create_unix() drivers/unix/ip_unix.cpp:264 (godot.x11.tools.64s+0x23fd5a8)
    #6 IP::create() core/io/ip.cpp:310 (godot.x11.tools.64s+0x4598ff2)
    #7 register_core_types() core/register_core_types.cpp:195 (godot.x11.tools.64s+0x438ab6c)
    #8 Main::setup(char const*, int, char**, bool) main/main.cpp:342 (godot.x11.tools.64s+0x13ddaed)
    #9 main platform/x11/godot_x11.cpp:49 (godot.x11.tools.64s+0x138d7d7)

SUMMARY: ThreadSanitizer: data race core/script_language.cpp:92 in ScriptServer::register_language(ScriptLanguage*)
```

