### PR TITLE
Allow comma prefix in visual shader's expression parser

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2260,6 +2260,7 @@ String VisualShaderNodeExpression::generate_code(Shader::Mode p_mode, VisualShad
 	static Vector<String> pre_symbols;
 	if (pre_symbols.empty()) {
 		pre_symbols.push_back("\t");
+		pre_symbols.push_back(",");
 		pre_symbols.push_back("{");
 		pre_symbols.push_back("[");
 		pre_symbols.push_back("(");


### PR DESCRIPTION
Fix issue described in https://github.com/godotengine/godot/pull/28838#issuecomment-518991560