### PR TITLE
 Improve error message in Node::remove_child() 

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1269,6 +1269,7 @@ void Node::remove_child(Node *p_child) {
 		}
 	}
 
+	ERR_EXPLAIN("Cannot remove child node " + p_child->to_string() + " as it is not in our list of children");
 	ERR_FAIL_COND(idx == -1);
 	//ERR_FAIL_COND( p_child->data.blocked > 0 );
 


### PR DESCRIPTION
Previously, Node::remove_child() produced the following error message:

    Condition 'idx == -1' is true.

Now, it will look like this instead:

    Cannot remove child node [Node:1158] as it is not in our list of children

This makes it immediately obvious what the problem is, without having to expand
the error in the editor's UI to see where the error occurred in C++.