### PR TITLE
Replace ERR_EXPLAIN in scene/* code

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -642,9 +642,8 @@ void AnimatedSprite::_reset_timeout() {
 
 void AnimatedSprite::set_animation(const StringName &p_animation) {
 
-	ERR_EXPLAIN(vformat("There is no animation with name '%s'.", p_animation));
-	ERR_FAIL_COND(frames == NULL);
-	ERR_FAIL_COND(frames->get_animation_names().find(p_animation) == -1);
+	ERR_FAIL_COND_MSG(frames == NULL, vformat("There is no animation with name '%s'.", p_animation));
+	ERR_FAIL_COND_MSG(frames->get_animation_names().find(p_animation) == -1, vformat("There is no animation with name '%s'.", p_animation));
 
 	if (animation == p_animation)
 		return;

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -321,10 +321,7 @@ void Area2D::_area_inout(int p_status, const RID &p_area, int p_instance, int p_
 
 void Area2D::_clear_monitoring() {
 
-	if (locked) {
-		ERR_EXPLAIN("This function can't be used during the in/out signal.");
-	}
-	ERR_FAIL_COND(locked);
+	ERR_FAIL_COND_MSG(locked, "This function can't be used during the in/out signal.");
 
 	{
 		Map<ObjectID, BodyState> bmcopy = body_map;
@@ -401,10 +398,7 @@ void Area2D::set_monitoring(bool p_enable) {
 
 	if (p_enable == monitoring)
 		return;
-	if (locked) {
-		ERR_EXPLAIN("Function blocked during in/out signal. Use set_deferred(\"monitoring\",true/false)");
-	}
-	ERR_FAIL_COND(locked);
+	ERR_FAIL_COND_MSG(locked, "Function blocked during in/out signal. Use set_deferred(\"monitoring\", true/false).");
 
 	monitoring = p_enable;
 
@@ -427,10 +421,7 @@ bool Area2D::is_monitoring() const {
 
 void Area2D::set_monitorable(bool p_enable) {
 
-	if (locked || (is_inside_tree() && Physics2DServer::get_singleton()->is_flushing_queries())) {
-		ERR_EXPLAIN("Function blocked during in/out signal. Use set_deferred(\"monitorable\",true/false)");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(locked || (is_inside_tree() && Physics2DServer::get_singleton()->is_flushing_queries()), "Function blocked during in/out signal. Use set_deferred(\"monitorable\", true/false).");
 
 	if (p_enable == monitorable)
 		return;

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -707,20 +707,14 @@ void CanvasItem::item_rect_changed(bool p_size_changed) {
 
 void CanvasItem::draw_line(const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width, bool p_antialiased) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	VisualServer::get_singleton()->canvas_item_add_line(canvas_item, p_from, p_to, p_color, p_width, p_antialiased);
 }
 
 void CanvasItem::draw_polyline(const Vector<Point2> &p_points, const Color &p_color, float p_width, bool p_antialiased) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	Vector<Color> colors;
 	colors.push_back(p_color);
@@ -729,20 +723,14 @@ void CanvasItem::draw_polyline(const Vector<Point2> &p_points, const Color &p_co
 
 void CanvasItem::draw_polyline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width, bool p_antialiased) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	VisualServer::get_singleton()->canvas_item_add_polyline(canvas_item, p_points, p_colors, p_width, p_antialiased);
 }
 
 void CanvasItem::draw_multiline(const Vector<Point2> &p_points, const Color &p_color, float p_width, bool p_antialiased) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	Vector<Color> colors;
 	colors.push_back(p_color);
@@ -751,20 +739,14 @@ void CanvasItem::draw_multiline(const Vector<Point2> &p_points, const Color &p_c
 
 void CanvasItem::draw_multiline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width, bool p_antialiased) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	VisualServer::get_singleton()->canvas_item_add_multiline(canvas_item, p_points, p_colors, p_width, p_antialiased);
 }
 
 void CanvasItem::draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_filled, float p_width, bool p_antialiased) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	if (p_filled) {
 		if (p_width != 1.0) {
@@ -819,20 +801,14 @@ void CanvasItem::draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_fil
 
 void CanvasItem::draw_circle(const Point2 &p_pos, float p_radius, const Color &p_color) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	VisualServer::get_singleton()->canvas_item_add_circle(canvas_item, p_pos, p_radius, p_color);
 }
 
 void CanvasItem::draw_texture(const Ref<Texture> &p_texture, const Point2 &p_pos, const Color &p_modulate, const Ref<Texture> &p_normal_map) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	ERR_FAIL_COND(p_texture.is_null());
 
@@ -841,29 +817,20 @@ void CanvasItem::draw_texture(const Ref<Texture> &p_texture, const Point2 &p_pos
 
 void CanvasItem::draw_texture_rect(const Ref<Texture> &p_texture, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose, const Ref<Texture> &p_normal_map) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	ERR_FAIL_COND(p_texture.is_null());
 	p_texture->draw_rect(canvas_item, p_rect, p_tile, p_modulate, p_transpose, p_normal_map);
 }
 void CanvasItem::draw_texture_rect_region(const Ref<Texture> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, const Ref<Texture> &p_normal_map, bool p_clip_uv) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 	ERR_FAIL_COND(p_texture.is_null());
 	p_texture->draw_rect_region(canvas_item, p_rect, p_src_rect, p_modulate, p_transpose, p_normal_map, p_clip_uv);
 }
 
 void CanvasItem::draw_style_box(const Ref<StyleBox> &p_style_box, const Rect2 &p_rect) {
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	ERR_FAIL_COND(p_style_box.is_null());
 
@@ -871,10 +838,7 @@ void CanvasItem::draw_style_box(const Ref<StyleBox> &p_style_box, const Rect2 &p
 }
 void CanvasItem::draw_primitive(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture> p_texture, float p_width, const Ref<Texture> &p_normal_map) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	RID rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 	RID rid_normal = p_normal_map.is_valid() ? p_normal_map->get_rid() : RID();
@@ -883,10 +847,7 @@ void CanvasItem::draw_primitive(const Vector<Point2> &p_points, const Vector<Col
 }
 void CanvasItem::draw_set_transform(const Point2 &p_offset, float p_rot, const Size2 &p_scale) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	Transform2D xform(p_rot, p_offset);
 	xform.scale_basis(p_scale);
@@ -895,20 +856,14 @@ void CanvasItem::draw_set_transform(const Point2 &p_offset, float p_rot, const S
 
 void CanvasItem::draw_set_transform_matrix(const Transform2D &p_matrix) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	VisualServer::get_singleton()->canvas_item_add_set_transform(canvas_item, p_matrix);
 }
 
 void CanvasItem::draw_polygon(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture> p_texture, const Ref<Texture> &p_normal_map, bool p_antialiased) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	RID rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 	RID rid_normal = p_normal_map.is_valid() ? p_normal_map->get_rid() : RID();
@@ -918,10 +873,7 @@ void CanvasItem::draw_polygon(const Vector<Point2> &p_points, const Vector<Color
 
 void CanvasItem::draw_colored_polygon(const Vector<Point2> &p_points, const Color &p_color, const Vector<Point2> &p_uvs, Ref<Texture> p_texture, const Ref<Texture> &p_normal_map, bool p_antialiased) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	Vector<Color> colors;
 	colors.push_back(p_color);
@@ -949,10 +901,7 @@ void CanvasItem::draw_multimesh(const Ref<MultiMesh> &p_multimesh, const Ref<Tex
 
 void CanvasItem::draw_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, const Color &p_modulate, int p_clip_w) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	ERR_FAIL_COND(p_font.is_null());
 	p_font->draw(canvas_item, p_pos, p_text, p_modulate, p_clip_w);
@@ -960,10 +909,7 @@ void CanvasItem::draw_string(const Ref<Font> &p_font, const Point2 &p_pos, const
 
 float CanvasItem::draw_char(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, const String &p_next, const Color &p_modulate) {
 
-	if (!drawing) {
-		ERR_EXPLAIN("Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
-		ERR_FAIL_V(0);
-	}
+	ERR_FAIL_COND_V_MSG(!drawing, 0, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	ERR_FAIL_COND_V(p_char.length() != 1, 0);
 	ERR_FAIL_COND_V(p_font.is_null(), 0);

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -157,10 +157,7 @@ void PhysicsBody2D::add_collision_exception_with(Node *p_node) {
 
 	ERR_FAIL_NULL(p_node);
 	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
-	if (!physics_body) {
-		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
-	}
-	ERR_FAIL_COND(!physics_body);
+	ERR_FAIL_COND_MSG(!physics_body, "Collision exception only works between two objects of PhysicsBody type.");
 	Physics2DServer::get_singleton()->body_add_collision_exception(get_rid(), physics_body->get_rid());
 }
 
@@ -168,10 +165,7 @@ void PhysicsBody2D::remove_collision_exception_with(Node *p_node) {
 
 	ERR_FAIL_NULL(p_node);
 	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
-	if (!physics_body) {
-		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
-	}
-	ERR_FAIL_COND(!physics_body);
+	ERR_FAIL_COND_MSG(!physics_body, "Collision exception only works between two objects of PhysicsBody type.");
 	Physics2DServer::get_singleton()->body_remove_collision_exception(get_rid(), physics_body->get_rid());
 }
 
@@ -203,8 +197,7 @@ void StaticBody2D::set_friction(real_t p_friction) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
 
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
@@ -217,8 +210,7 @@ void StaticBody2D::set_friction(real_t p_friction) {
 
 real_t StaticBody2D::get_friction() const {
 
-	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
 
 	if (physics_material_override.is_null()) {
 		return 1;
@@ -233,8 +225,7 @@ void StaticBody2D::set_bounce(real_t p_bounce) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
 
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
@@ -247,8 +238,7 @@ void StaticBody2D::set_bounce(real_t p_bounce) {
 
 real_t StaticBody2D::get_bounce() const {
 
-	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
 
 	if (physics_material_override.is_null()) {
 		return 0;
@@ -630,8 +620,7 @@ void RigidBody2D::set_friction(real_t p_friction) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
 
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
@@ -643,8 +632,7 @@ void RigidBody2D::set_friction(real_t p_friction) {
 }
 real_t RigidBody2D::get_friction() const {
 
-	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
 
 	if (physics_material_override.is_null()) {
 		return 1;
@@ -659,8 +647,7 @@ void RigidBody2D::set_bounce(real_t p_bounce) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
 
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
@@ -672,8 +659,7 @@ void RigidBody2D::set_bounce(real_t p_bounce) {
 }
 real_t RigidBody2D::get_bounce() const {
 
-	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
 
 	if (physics_material_override.is_null()) {
 		return 0;
@@ -905,10 +891,7 @@ void RigidBody2D::set_contact_monitor(bool p_enabled) {
 
 	if (!p_enabled) {
 
-		if (contact_monitor->locked) {
-			ERR_EXPLAIN("Can't disable contact monitoring during in/out callback. Use call_deferred(\"set_contact_monitor\",false) instead");
-		}
-		ERR_FAIL_COND(contact_monitor->locked);
+		ERR_FAIL_COND_MSG(contact_monitor->locked, "Can't disable contact monitoring during in/out callback. Use call_deferred(\"set_contact_monitor\", false) instead.");
 
 		for (Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
 

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -218,10 +218,7 @@ void Area::_body_inout(int p_status, const RID &p_body, int p_instance, int p_bo
 
 void Area::_clear_monitoring() {
 
-	if (locked) {
-		ERR_EXPLAIN("This function can't be used during the in/out signal.");
-	}
-	ERR_FAIL_COND(locked);
+	ERR_FAIL_COND_MSG(locked, "This function can't be used during the in/out signal.");
 
 	{
 		Map<ObjectID, BodyState> bmcopy = body_map;
@@ -291,10 +288,7 @@ void Area::_notification(int p_what) {
 
 void Area::set_monitoring(bool p_enable) {
 
-	if (locked) {
-		ERR_EXPLAIN("Function blocked during in/out signal. Use set_deferred(\"monitoring\",true/false)");
-	}
-	ERR_FAIL_COND(locked);
+	ERR_FAIL_COND_MSG(locked, "Function blocked during in/out signal. Use set_deferred(\"monitoring\", true/false).");
 
 	if (p_enable == monitoring)
 		return;
@@ -441,10 +435,7 @@ Array Area::get_overlapping_bodies() const {
 
 void Area::set_monitorable(bool p_enable) {
 
-	if (locked || (is_inside_tree() && PhysicsServer::get_singleton()->is_flushing_queries())) {
-		ERR_EXPLAIN("Function blocked during in/out signal. Use set_deferred(\"monitorable\",true/false)");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(locked || (is_inside_tree() && PhysicsServer::get_singleton()->is_flushing_queries()), "Function blocked during in/out signal. Use set_deferred(\"monitorable\", true/false).");
 
 	if (p_enable == monitorable)
 		return;

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -78,10 +78,7 @@ Vector3 ARVRCamera::project_local_ray_normal(const Point2 &p_pos) const {
 		return Camera::project_local_ray_normal(p_pos);
 	}
 
-	if (!is_inside_tree()) {
-		ERR_EXPLAIN("Camera is not inside scene.");
-		ERR_FAIL_COND_V(!is_inside_tree(), Vector3());
-	};
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_camera_rect_size();
 	Vector2 cpos = get_viewport()->get_camera_coords(p_pos);
@@ -106,10 +103,7 @@ Point2 ARVRCamera::unproject_position(const Vector3 &p_pos) const {
 		return Camera::unproject_position(p_pos);
 	}
 
-	if (!is_inside_tree()) {
-		ERR_EXPLAIN("Camera is not inside scene.");
-		ERR_FAIL_COND_V(!is_inside_tree(), Vector2());
-	};
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector2(), "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
@@ -138,10 +132,7 @@ Vector3 ARVRCamera::project_position(const Point2 &p_point, float p_z_depth) con
 		return Camera::project_position(p_point, p_z_depth);
 	}
 
-	if (!is_inside_tree()) {
-		ERR_EXPLAIN("Camera is not inside scene.");
-		ERR_FAIL_COND_V(!is_inside_tree(), Vector3());
-	};
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -279,10 +279,7 @@ Vector3 Camera::project_ray_normal(const Point2 &p_pos) const {
 
 Vector3 Camera::project_local_ray_normal(const Point2 &p_pos) const {
 
-	if (!is_inside_tree()) {
-		ERR_EXPLAIN("Camera is not inside scene.");
-		ERR_FAIL_COND_V(!is_inside_tree(), Vector3());
-	}
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_camera_rect_size();
 	Vector2 cpos = get_viewport()->get_camera_coords(p_pos);
@@ -304,10 +301,7 @@ Vector3 Camera::project_local_ray_normal(const Point2 &p_pos) const {
 
 Vector3 Camera::project_ray_origin(const Point2 &p_pos) const {
 
-	if (!is_inside_tree()) {
-		ERR_EXPLAIN("Camera is not inside scene.");
-		ERR_FAIL_COND_V(!is_inside_tree(), Vector3());
-	}
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_camera_rect_size();
 	Vector2 cpos = get_viewport()->get_camera_coords(p_pos);
@@ -345,10 +339,7 @@ bool Camera::is_position_behind(const Vector3 &p_pos) const {
 }
 
 Vector<Vector3> Camera::get_near_plane_points() const {
-	if (!is_inside_tree()) {
-		ERR_EXPLAIN("Camera is not inside scene.");
-		ERR_FAIL_COND_V(!is_inside_tree(), Vector<Vector3>());
-	}
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector<Vector3>(), "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
@@ -372,10 +363,7 @@ Vector<Vector3> Camera::get_near_plane_points() const {
 
 Point2 Camera::unproject_position(const Vector3 &p_pos) const {
 
-	if (!is_inside_tree()) {
-		ERR_EXPLAIN("Camera is not inside scene.");
-		ERR_FAIL_COND_V(!is_inside_tree(), Vector2());
-	}
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector2(), "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
@@ -400,10 +388,7 @@ Point2 Camera::unproject_position(const Vector3 &p_pos) const {
 
 Vector3 Camera::project_position(const Point2 &p_point, float p_z_depth) const {
 
-	if (!is_inside_tree()) {
-		ERR_EXPLAIN("Camera is not inside scene.");
-		ERR_FAIL_COND_V(!is_inside_tree(), Vector3());
-	}
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
 
 	if (p_z_depth == 0) {
 		return get_global_transform().origin;

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -129,10 +129,7 @@ void PhysicsBody::add_collision_exception_with(Node *p_node) {
 
 	ERR_FAIL_NULL(p_node);
 	CollisionObject *collision_object = Object::cast_to<CollisionObject>(p_node);
-	if (!collision_object) {
-		ERR_EXPLAIN("Collision exception only works between two CollisionObject");
-	}
-	ERR_FAIL_COND(!collision_object);
+	ERR_FAIL_COND_MSG(!collision_object, "Collision exception only works between two CollisionObject.");
 	PhysicsServer::get_singleton()->body_add_collision_exception(get_rid(), collision_object->get_rid());
 }
 
@@ -140,10 +137,7 @@ void PhysicsBody::remove_collision_exception_with(Node *p_node) {
 
 	ERR_FAIL_NULL(p_node);
 	CollisionObject *collision_object = Object::cast_to<CollisionObject>(p_node);
-	if (!collision_object) {
-		ERR_EXPLAIN("Collision exception only works between two CollisionObject");
-	}
-	ERR_FAIL_COND(!collision_object);
+	ERR_FAIL_COND_MSG(!collision_object, "Collision exception only works between two CollisionObject.");
 	PhysicsServer::get_singleton()->body_remove_collision_exception(get_rid(), collision_object->get_rid());
 }
 
@@ -192,8 +186,7 @@ void StaticBody::set_friction(real_t p_friction) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
 
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
@@ -206,8 +199,7 @@ void StaticBody::set_friction(real_t p_friction) {
 
 real_t StaticBody::get_friction() const {
 
-	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
 
 	if (physics_material_override.is_null()) {
 		return 1;
@@ -222,8 +214,7 @@ void StaticBody::set_bounce(real_t p_bounce) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
 
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
@@ -236,8 +227,7 @@ void StaticBody::set_bounce(real_t p_bounce) {
 
 real_t StaticBody::get_bounce() const {
 
-	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
 
 	if (physics_material_override.is_null()) {
 		return 0;
@@ -636,8 +626,7 @@ void RigidBody::set_friction(real_t p_friction) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method set_friction has been deprecated and will be removed in the future, use physics material instead.");
 
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
@@ -649,8 +638,7 @@ void RigidBody::set_friction(real_t p_friction) {
 }
 real_t RigidBody::get_friction() const {
 
-	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method get_friction has been deprecated and will be removed in the future, use physics material instead.");
 
 	if (physics_material_override.is_null()) {
 		return 1;
@@ -665,8 +653,7 @@ void RigidBody::set_bounce(real_t p_bounce) {
 		return;
 	}
 
-	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method set_bounce has been deprecated and will be removed in the future, use physics material instead.");
 
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
@@ -677,8 +664,7 @@ void RigidBody::set_bounce(real_t p_bounce) {
 	physics_material_override->set_bounce(p_bounce);
 }
 real_t RigidBody::get_bounce() const {
-	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("The method get_bounce has been deprecated and will be removed in the future, use physics material instead.");
 	if (physics_material_override.is_null()) {
 		return 0;
 	}
@@ -867,10 +853,7 @@ void RigidBody::set_contact_monitor(bool p_enabled) {
 
 	if (!p_enabled) {
 
-		if (contact_monitor->locked) {
-			ERR_EXPLAIN("Can't disable contact monitoring during in/out callback. Use call_deferred(\"set_contact_monitor\",false) instead");
-		}
-		ERR_FAIL_COND(contact_monitor->locked);
+		ERR_FAIL_COND_MSG(contact_monitor->locked, "Can't disable contact monitoring during in/out callback. Use call_deferred(\"set_contact_monitor\", false) instead.");
 
 		for (Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
 

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -577,20 +577,14 @@ Array SoftBody::get_collision_exceptions() {
 void SoftBody::add_collision_exception_with(Node *p_node) {
 	ERR_FAIL_NULL(p_node);
 	CollisionObject *collision_object = Object::cast_to<CollisionObject>(p_node);
-	if (!collision_object) {
-		ERR_EXPLAIN("Collision exception only works between two CollisionObject");
-	}
-	ERR_FAIL_COND(!collision_object);
+	ERR_FAIL_COND_MSG(!collision_object, "Collision exception only works between two CollisionObject.");
 	PhysicsServer::get_singleton()->soft_body_add_collision_exception(physics_rid, collision_object->get_rid());
 }
 
 void SoftBody::remove_collision_exception_with(Node *p_node) {
 	ERR_FAIL_NULL(p_node);
 	CollisionObject *collision_object = Object::cast_to<CollisionObject>(p_node);
-	if (!collision_object) {
-		ERR_EXPLAIN("Collision exception only works between two CollisionObject");
-	}
-	ERR_FAIL_COND(!collision_object);
+	ERR_FAIL_COND_MSG(!collision_object, "Collision exception only works between two CollisionObject.");
 	PhysicsServer::get_singleton()->soft_body_remove_collision_exception(physics_rid, collision_object->get_rid());
 }
 

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -684,15 +684,8 @@ void Spatial::look_at(const Vector3 &p_target, const Vector3 &p_up) {
 
 void Spatial::look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up) {
 
-	if (p_pos == p_target) {
-		ERR_EXPLAIN("Node origin and target are in the same position, look_at() failed");
-		ERR_FAIL();
-	}
-
-	if (p_up.cross(p_target - p_pos) == Vector3()) {
-		ERR_EXPLAIN("Up vector and direction between node origin and target are aligned, look_at() failed");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(p_pos == p_target, "Node origin and target are in the same position, look_at() failed.");
+	ERR_FAIL_COND_MSG(p_up.cross(p_target - p_pos) == Vector3(), "Up vector and direction between node origin and target are aligned, look_at() failed.");
 
 	Transform lookat;
 	lookat.origin = p_pos;

--- a/scene/animation/animation_cache.cpp
+++ b/scene/animation/animation_cache.cpp
@@ -80,8 +80,7 @@ void AnimationCache::_update_cache() {
 		if (!node) {
 
 			path_cache.push_back(Path());
-			ERR_EXPLAIN("Invalid Track Path in Animation: " + np);
-			ERR_CONTINUE(!node);
+			ERR_CONTINUE_MSG(!node, "Invalid track path in animation: " + np + ".");
 		}
 
 		Path path;
@@ -92,8 +91,7 @@ void AnimationCache::_update_cache() {
 
 			if (np.get_subname_count() > 1) {
 				path_cache.push_back(Path());
-				ERR_EXPLAIN("Transform tracks can't have a subpath: " + np);
-				ERR_CONTINUE(animation->track_get_type(i) == Animation::TYPE_TRANSFORM);
+				ERR_CONTINUE_MSG(animation->track_get_type(i) == Animation::TYPE_TRANSFORM, "Transform tracks can't have a subpath: " + np + ".");
 			}
 
 			Spatial *sp = Object::cast_to<Spatial>(node);
@@ -101,8 +99,7 @@ void AnimationCache::_update_cache() {
 			if (!sp) {
 
 				path_cache.push_back(Path());
-				ERR_EXPLAIN("Transform track not of type Spatial: " + np);
-				ERR_CONTINUE(!sp);
+				ERR_CONTINUE_MSG(!sp, "Transform track not of type Spatial: " + np + ".");
 			}
 
 			if (np.get_subname_count() == 1) {
@@ -113,15 +110,13 @@ void AnimationCache::_update_cache() {
 				if (!sk) {
 
 					path_cache.push_back(Path());
-					ERR_EXPLAIN("Property defined in Transform track, but not a Skeleton!: " + np);
-					ERR_CONTINUE(!sk);
+					ERR_CONTINUE_MSG(!sk, "Property defined in Transform track, but not a Skeleton!: " + np + ".");
 				}
 
 				int idx = sk->find_bone(ps);
 				if (idx == -1) {
 					path_cache.push_back(Path());
-					ERR_EXPLAIN("Property defined in Transform track, but not a Skeleton Bone!: " + np);
-					ERR_CONTINUE(idx == -1);
+					ERR_CONTINUE_MSG(idx == -1, "Property defined in Transform track, but not a Skeleton Bone!: " + np + ".");
 				}
 
 				path.bone_idx = idx;
@@ -161,8 +156,7 @@ void AnimationCache::_update_cache() {
 			if (np.get_subname_count() == 0) {
 
 				path_cache.push_back(Path());
-				ERR_EXPLAIN("Value Track lacks property: " + np);
-				ERR_CONTINUE(np.get_subname_count() == 0);
+				ERR_CONTINUE_MSG(np.get_subname_count() == 0, "Value Track lacks property: " + np + ".");
 			}
 
 		} else if (animation->track_get_type(i) == Animation::TYPE_METHOD) {
@@ -170,8 +164,7 @@ void AnimationCache::_update_cache() {
 			if (path.subpath.size() != 0) { // Trying to call a method of a non-resource
 
 				path_cache.push_back(Path());
-				ERR_EXPLAIN("Method Track has property: " + np);
-				ERR_CONTINUE(path.subpath.size() != 0);
+				ERR_CONTINUE_MSG(path.subpath.size() != 0, "Method Track has property: " + np + ".");
 			}
 		}
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -317,8 +317,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 			if (!playing) {
 				String node_name = start_request;
 				start_request = StringName();
-				ERR_EXPLAIN("Can't travel to '" + node_name + "' if state machine is not playing.");
-				ERR_FAIL_V(0);
+				ERR_FAIL_V_MSG(0, "Can't travel to '" + node_name + "' if state machine is not playing.");
 			}
 
 			if (!_travel(p_state_machine, start_request)) {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -248,10 +248,7 @@ void AnimationPlayer::_ensure_node_caches(AnimationData *p_anim) {
 		RES resource;
 		Vector<StringName> leftover_path;
 		Node *child = parent->get_node_and_resource(a->track_get_path(i), resource, leftover_path);
-		if (!child) {
-			ERR_EXPLAIN("On Animation: '" + p_anim->name + "', couldn't resolve track:  '" + String(a->track_get_path(i)) + "'");
-		}
-		ERR_CONTINUE(!child); // couldn't find the child node
+		ERR_CONTINUE_MSG(!child, "On Animation: '" + p_anim->name + "', couldn't resolve track:  '" + String(a->track_get_path(i)) + "'."); // couldn't find the child node
 		uint32_t id = resource.is_valid() ? resource->get_instance_id() : child->get_instance_id();
 		int bone_idx = -1;
 
@@ -973,8 +970,7 @@ void AnimationPlayer::_animation_process(float p_delta) {
 Error AnimationPlayer::add_animation(const StringName &p_name, const Ref<Animation> &p_animation) {
 
 #ifdef DEBUG_ENABLED
-	ERR_EXPLAIN("Invalid animation name: " + String(p_name));
-	ERR_FAIL_COND_V(String(p_name).find("/") != -1 || String(p_name).find(":") != -1 || String(p_name).find(",") != -1 || String(p_name).find("[") != -1, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V_MSG(String(p_name).find("/") != -1 || String(p_name).find(":") != -1 || String(p_name).find(",") != -1 || String(p_name).find("[") != -1, ERR_INVALID_PARAMETER, "Invalid animation name: " + String(p_name) + ".");
 #endif
 
 	ERR_FAIL_COND_V(p_animation.is_null(), ERR_INVALID_PARAMETER);
@@ -1158,10 +1154,7 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 	if (String(name) == "")
 		name = playback.assigned;
 
-	if (!animation_set.has(name)) {
-		ERR_EXPLAIN("Animation not found: " + name);
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!animation_set.has(name), "Animation not found: " + name + ".");
 
 	Playback &c = playback;
 

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -403,8 +403,7 @@ void AnimationTreePlayer::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
-			ERR_EXPLAIN("AnimationTreePlayer has been deprecated. Use AnimationTree instead.");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("AnimationTreePlayer has been deprecated. Use AnimationTree instead.");
 
 			if (!processing) {
 				//make sure that a previous process state was not saved
@@ -993,10 +992,9 @@ int AnimationTreePlayer::node_get_input_count(const StringName &p_node) const {
 	ERR_FAIL_COND_V(!node_map.has(p_node), -1);
 	return node_map[p_node]->inputs.size();
 }
-#define GET_NODE(m_type, m_cast)                     \
-	ERR_FAIL_COND(!node_map.has(p_node));            \
-	ERR_EXPLAIN("Invalid parameter for node type."); \
-	ERR_FAIL_COND(node_map[p_node]->type != m_type); \
+#define GET_NODE(m_type, m_cast)                                                             \
+	ERR_FAIL_COND(!node_map.has(p_node));                                                    \
+	ERR_FAIL_COND_MSG(node_map[p_node]->type != m_type, "Invalid parameter for node type."); \
 	m_cast *n = static_cast<m_cast *>(node_map[p_node]);
 
 void AnimationTreePlayer::animation_node_set_animation(const StringName &p_node, const Ref<Animation> &p_animation) {
@@ -1209,10 +1207,9 @@ Point2 AnimationTreePlayer::node_get_position(const StringName &p_node) const {
 	return node_map[p_node]->pos;
 }
 
-#define GET_NODE_V(m_type, m_cast, m_ret)                     \
-	ERR_FAIL_COND_V(!node_map.has(p_node), m_ret);            \
-	ERR_EXPLAIN("Invalid parameter for node type.");          \
-	ERR_FAIL_COND_V(node_map[p_node]->type != m_type, m_ret); \
+#define GET_NODE_V(m_type, m_cast, m_ret)                                                             \
+	ERR_FAIL_COND_V(!node_map.has(p_node), m_ret);                                                    \
+	ERR_FAIL_COND_V_MSG(node_map[p_node]->type != m_type, m_ret, "Invalid parameter for node type."); \
 	m_cast *n = static_cast<m_cast *>(node_map[p_node]);
 
 Ref<Animation> AnimationTreePlayer::animation_node_get_animation(const StringName &p_node) const {
@@ -1367,8 +1364,7 @@ void AnimationTreePlayer::get_node_list(List<StringName> *p_node_list) const {
 void AnimationTreePlayer::remove_node(const StringName &p_node) {
 
 	ERR_FAIL_COND(!node_map.has(p_node));
-	ERR_EXPLAIN("Node 0 (output) can't be removed.");
-	ERR_FAIL_COND(p_node == out_name);
+	ERR_FAIL_COND_MSG(p_node == out_name, "Node 0 (output) can't be removed.");
 
 	for (Map<StringName, NodeBase *>::Element *E = node_map.front(); E; E = E->next()) {
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -1185,35 +1185,29 @@ bool Tween::_build_interpolation(InterpolateType p_interpolation_type, Object *p
 	// Validate and apply interpolation data
 
 	// Give it the object
-	ERR_EXPLAIN("Invalid object provided to Tween!");
-	ERR_FAIL_COND_V(p_object == NULL, false); // Is the object real
-	ERR_FAIL_COND_V(!ObjectDB::instance_validate(p_object), false); // Is the object a valid instance?
+	ERR_FAIL_COND_V_MSG(p_object == NULL, false, "Invalid object provided to Tween.");
+	ERR_FAIL_COND_V_MSG(!ObjectDB::instance_validate(p_object), false, "Invalid object provided to Tween.");
 	data.id = p_object->get_instance_id();
 
 	// Validate the initial and final values
-	ERR_EXPLAIN("Initial value type does not match final value type!"); // TODO: Print both types to make debugging easier
-	ERR_FAIL_COND_V(p_initial_val.get_type() != p_final_val.get_type(), false); // Do the initial and final value types match?
+	ERR_FAIL_COND_V_MSG(p_initial_val.get_type() != p_final_val.get_type(), false, "Initial value type '" + Variant::get_type_name(p_initial_val.get_type()) + "' does not match final value type '" + Variant::get_type_name(p_final_val.get_type()) + "'.");
 	data.initial_val = p_initial_val;
 	data.final_val = p_final_val;
 
 	// Check the Duration
-	ERR_EXPLAIN("Only non-negative duration values allowed in Tweens!");
-	ERR_FAIL_COND_V(p_duration < 0, false); // Is the tween duration non-negative
+	ERR_FAIL_COND_V_MSG(p_duration < 0, false, "Only non-negative duration values allowed in Tweens.");
 	data.duration = p_duration;
 
 	// Tween Delay
-	ERR_EXPLAIN("Only non-negative delay values allowed in Tweens!");
-	ERR_FAIL_COND_V(p_delay < 0, false); // Is the delay non-negative?
+	ERR_FAIL_COND_V_MSG(p_delay < 0, false, "Only non-negative delay values allowed in Tweens.");
 	data.delay = p_delay;
 
 	// Transition type
-	ERR_EXPLAIN("Invalid transition type provided to Tween");
-	ERR_FAIL_COND_V(p_trans_type < 0 || p_trans_type >= TRANS_COUNT, false); // Is the transition type valid
+	ERR_FAIL_COND_V_MSG(p_trans_type < 0 || p_trans_type >= TRANS_COUNT, false, "Invalid transition type provided to Tween.");
 	data.trans_type = p_trans_type;
 
 	// Easing type
-	ERR_EXPLAIN("Invalid easing type provided to Tween");
-	ERR_FAIL_COND_V(p_ease_type < 0 || p_ease_type >= EASE_COUNT, false); // Is the easing type valid
+	ERR_FAIL_COND_V_MSG(p_ease_type < 0 || p_ease_type >= EASE_COUNT, false, "Invalid easing type provided to Tween.");
 	data.ease_type = p_ease_type;
 
 	// Is the property defined?
@@ -1221,8 +1215,7 @@ bool Tween::_build_interpolation(InterpolateType p_interpolation_type, Object *p
 		// Check that the object actually contains the given property
 		bool prop_valid = false;
 		p_object->get_indexed(p_property->get_subnames(), &prop_valid);
-		ERR_EXPLAIN("Tween target object has no property named: " + p_property->get_concatenated_subnames());
-		ERR_FAIL_COND_V(!prop_valid, false);
+		ERR_FAIL_COND_V_MSG(!prop_valid, false, "Tween target object has no property named: " + p_property->get_concatenated_subnames() + ".");
 
 		data.key = p_property->get_subnames();
 		data.concatenated_key = p_property->get_concatenated_subnames();
@@ -1231,8 +1224,7 @@ bool Tween::_build_interpolation(InterpolateType p_interpolation_type, Object *p
 	// Is the method defined?
 	if (p_method) {
 		// Does the object even have the requested method?
-		ERR_EXPLAIN("Tween target object has no method named: " + *p_method); // TODO: Fix this error message
-		ERR_FAIL_COND_V(!p_object->has_method(*p_method), false);
+		ERR_FAIL_COND_V_MSG(!p_object->has_method(*p_method), false, "Tween target object has no method named: " + *p_method + ".");
 
 		data.key.push_back(*p_method);
 		data.concatenated_key = *p_method;
@@ -1301,8 +1293,7 @@ bool Tween::interpolate_callback(Object *p_object, real_t p_duration, String p_c
 	ERR_FAIL_COND_V(p_duration < 0, false);
 
 	// Check whether the object even has the callback
-	ERR_EXPLAIN("Object has no callback named: %s" + p_callback);
-	ERR_FAIL_COND_V(!p_object->has_method(p_callback), false);
+	ERR_FAIL_COND_V_MSG(!p_object->has_method(p_callback), false, "Object has no callback named: " + p_callback + ".");
 
 	// Build a new InterpolationData
 	InterpolateData data;
@@ -1361,8 +1352,7 @@ bool Tween::interpolate_deferred_callback(Object *p_object, real_t p_duration, S
 	ERR_FAIL_COND_V(p_duration < 0, false);
 
 	// Confirm the callback exists on the object
-	ERR_EXPLAIN("Object has no callback named: %s" + p_callback);
-	ERR_FAIL_COND_V(!p_object->has_method(p_callback), false);
+	ERR_FAIL_COND_V_MSG(!p_object->has_method(p_callback), false, "Object has no callback named: " + p_callback + ".");
 
 	// Create a new InterpolateData for the callback
 	InterpolateData data;
@@ -1505,10 +1495,8 @@ bool Tween::follow_method(Object *p_object, StringName p_method, Variant p_initi
 	ERR_FAIL_COND_V(p_delay < 0, false);
 
 	// Confirm both objects have the target methods
-	ERR_EXPLAIN("Object has no method named: %s" + p_method);
-	ERR_FAIL_COND_V(!p_object->has_method(p_method), false);
-	ERR_EXPLAIN("Target has no method named: %s" + p_target_method);
-	ERR_FAIL_COND_V(!p_target->has_method(p_target_method), false);
+	ERR_FAIL_COND_V_MSG(!p_object->has_method(p_method), false, "Object has no method named: " + p_method + ".");
+	ERR_FAIL_COND_V_MSG(!p_target->has_method(p_target_method), false, "Target has no method named: " + p_target_method + ".");
 
 	// Call the method to get the target value
 	Variant::CallError error;
@@ -1641,10 +1629,8 @@ bool Tween::targeting_method(Object *p_object, StringName p_method, Object *p_in
 	ERR_FAIL_COND_V(p_delay < 0, false);
 
 	// Make sure both objects have the given method
-	ERR_EXPLAIN("Object has no method named: %s" + p_method);
-	ERR_FAIL_COND_V(!p_object->has_method(p_method), false);
-	ERR_EXPLAIN("Initial Object has no method named: %s" + p_initial_method);
-	ERR_FAIL_COND_V(!p_initial->has_method(p_initial_method), false);
+	ERR_FAIL_COND_V_MSG(!p_object->has_method(p_method), false, "Object has no method named: " + p_method + ".");
+	ERR_FAIL_COND_V_MSG(!p_initial->has_method(p_initial_method), false, "Initial Object has no method named: " + p_initial_method + ".");
 
 	// Call the method to get the initial value
 	Variant::CallError error;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1995,12 +1995,7 @@ Control *Control::find_next_valid_focus() const {
 			Node *n = get_node(data.focus_next);
 			if (n) {
 				from = Object::cast_to<Control>(n);
-
-				if (!from) {
-
-					ERR_EXPLAIN("Next focus node is not a control: " + n->get_name());
-					ERR_FAIL_V(NULL);
-				}
+				ERR_FAIL_COND_V_MSG(!from, NULL, "Next focus node is not a control: " + n->get_name() + ".");
 			} else {
 				return NULL;
 			}
@@ -2090,12 +2085,7 @@ Control *Control::find_prev_valid_focus() const {
 			Node *n = get_node(data.focus_prev);
 			if (n) {
 				from = Object::cast_to<Control>(n);
-
-				if (!from) {
-
-					ERR_EXPLAIN("Previous focus node is not a control: " + n->get_name());
-					ERR_FAIL_V(NULL);
-				}
+				ERR_FAIL_COND_V_MSG(!from, NULL, "Previous focus node is not a control: " + n->get_name() + ".");
 			} else {
 				return NULL;
 			}
@@ -2377,12 +2367,7 @@ Control *Control::_get_focus_neighbour(Margin p_margin, int p_count) {
 		Node *n = get_node(data.focus_neighbour[p_margin]);
 		if (n) {
 			c = Object::cast_to<Control>(n);
-
-			if (!c) {
-
-				ERR_EXPLAIN("Neighbour focus node is not a control: " + n->get_name());
-				ERR_FAIL_V(NULL);
-			}
+			ERR_FAIL_COND_V_MSG(!c, NULL, "Neighbor focus node is not a control: " + n->get_name() + ".");
 		} else {
 			return NULL;
 		}

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -592,8 +592,7 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 	Ref<InputEventMouseButton> mb = p_ev;
 	if (mb.is_valid()) {
 
-		ERR_EXPLAIN("GraphNode must be the child of a GraphEdit node.");
-		ERR_FAIL_COND(get_parent_control() == NULL);
+		ERR_FAIL_COND_MSG(get_parent_control() == NULL, "GraphNode must be the child of a GraphEdit node.");
 
 		if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1405,8 +1405,7 @@ void LineEdit::set_secret_character(const String &p_string) {
 
 	// An empty string as the secret character would crash the engine
 	// It also wouldn't make sense to use multiple characters as the secret character
-	ERR_EXPLAIN("Secret character must be exactly one character long (" + itos(p_string.length()) + " characters given)");
-	ERR_FAIL_COND(p_string.length() != 1);
+	ERR_FAIL_COND_MSG(p_string.length() != 1, "Secret character must be exactly one character long (" + itos(p_string.length()) + " characters given).");
 
 	secret_character = p_string;
 	update();

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -148,11 +148,9 @@ int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
 void PopupMenu::_activate_submenu(int over) {
 
 	Node *n = get_node(items[over].submenu);
-	ERR_EXPLAIN("Item subnode does not exist: " + items[over].submenu);
-	ERR_FAIL_COND(!n);
+	ERR_FAIL_COND_MSG(!n, "Item subnode does not exist: " + items[over].submenu + ".");
 	Popup *pm = Object::cast_to<Popup>(n);
-	ERR_EXPLAIN("Item subnode is not a Popup: " + items[over].submenu);
-	ERR_FAIL_COND(!pm);
+	ERR_FAIL_COND_MSG(!pm, "Item subnode is not a Popup: " + items[over].submenu + ".");
 	if (pm->is_visible_in_tree())
 		return; //already visible!
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2700,12 +2700,10 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 bool Tree::edit_selected() {
 
 	TreeItem *s = get_selected();
-	ERR_EXPLAIN("No item selected!");
-	ERR_FAIL_COND_V(!s, false);
+	ERR_FAIL_COND_V_MSG(!s, false, "No item selected.");
 	ensure_cursor_is_visible();
 	int col = get_selected_column();
-	ERR_EXPLAIN("No item column selected!");
-	ERR_FAIL_INDEX_V(col, columns.size(), false);
+	ERR_FAIL_INDEX_V_MSG(col, columns.size(), false, "No item column selected.");
 
 	if (!s->cells[col].editable)
 		return false;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -60,14 +60,10 @@ Error HTTPRequest::_parse_url(const String &p_url) {
 		use_ssl = true;
 		port = 443;
 	} else {
-		ERR_EXPLAIN("Malformed URL");
-		ERR_FAIL_V(ERR_INVALID_PARAMETER);
+		ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER, "Malformed URL.");
 	}
 
-	if (url.length() < 1) {
-		ERR_EXPLAIN("URL too short");
-		ERR_FAIL_V(ERR_INVALID_PARAMETER);
-	}
+	ERR_FAIL_COND_V_MSG(url.length() < 1, ERR_INVALID_PARAMETER, "URL too short.");
 
 	int slash_pos = url.find("/");
 
@@ -91,10 +87,7 @@ Error HTTPRequest::_parse_url(const String &p_url) {
 Error HTTPRequest::request(const String &p_url, const Vector<String> &p_custom_headers, bool p_ssl_validate_domain, HTTPClient::Method p_method, const String &p_request_data) {
 
 	ERR_FAIL_COND_V(!is_inside_tree(), ERR_UNCONFIGURED);
-	if (requesting) {
-		ERR_EXPLAIN("HTTPRequest is processing a request. Wait for completion or cancel it before attempting a new one.");
-		ERR_FAIL_V(ERR_BUSY);
-	}
+	ERR_FAIL_COND_V_MSG(requesting, ERR_BUSY, "HTTPRequest is processing a request. Wait for completion or cancel it before attempting a new one.");
 
 	if (timeout > 0) {
 		timer->stop();

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -327,14 +327,9 @@ void Node::_propagate_exit_tree() {
 void Node::move_child(Node *p_child, int p_pos) {
 
 	ERR_FAIL_NULL(p_child);
-	ERR_EXPLAIN("Invalid new child position: " + itos(p_pos));
-	ERR_FAIL_INDEX(p_pos, data.children.size() + 1);
-	ERR_EXPLAIN("child is not a child of this node.");
-	ERR_FAIL_COND(p_child->data.parent != this);
-	if (data.blocked > 0) {
-		ERR_EXPLAIN("Parent node is busy setting up children, move_child() failed. Consider using call_deferred(\"move_child\") instead (or \"popup\" if this is from a popup).");
-		ERR_FAIL_COND(data.blocked > 0);
-	}
+	ERR_FAIL_INDEX_MSG(p_pos, data.children.size() + 1, "Invalid new child position: " + itos(p_pos) + ".");
+	ERR_FAIL_COND_MSG(p_child->data.parent != this, "Child is not a child of this node.");
+	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy setting up children, move_child() failed. Consider using call_deferred(\"move_child\") instead (or \"popup\" if this is from a popup).");
 
 	// Specifying one place beyond the end
 	// means the same as moving to the last position
@@ -1165,25 +1160,9 @@ void Node::_add_child_nocheck(Node *p_child, const StringName &p_name) {
 void Node::add_child(Node *p_child, bool p_legible_unique_name) {
 
 	ERR_FAIL_NULL(p_child);
-
-	if (p_child == this) {
-		ERR_EXPLAIN("Can't add child '" + p_child->get_name() + "' to itself.");
-		ERR_FAIL_COND(p_child == this); // adding to itself!
-	}
-
-	/* Fail if node has a parent */
-	if (p_child->data.parent) {
-		ERR_EXPLAIN("Can't add child '" + p_child->get_name() + "' to '" + get_name() + "', already has a parent '" + p_child->data.parent->get_name() + "'.");
-		ERR_FAIL_COND(p_child->data.parent);
-	}
-
-	if (data.blocked > 0) {
-		ERR_EXPLAIN("Parent node is busy setting up children, add_node() failed. Consider using call_deferred(\"add_child\", child) instead.");
-		ERR_FAIL_COND(data.blocked > 0);
-	}
-
-	ERR_EXPLAIN("Can't add child while a notification is happening.");
-	ERR_FAIL_COND(data.blocked > 0);
+	ERR_FAIL_COND_MSG(p_child == this, "Can't add child '" + p_child->get_name() + "' to itself."); // adding to itself!
+	ERR_FAIL_COND_MSG(p_child->data.parent, "Can't add child '" + p_child->get_name() + "' to '" + get_name() + "', already has a parent '" + p_child->data.parent->get_name() + "'."); //Fail if node has a parent
+	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy setting up children, add_node() failed. Consider using call_deferred(\"add_child\", child) instead.");
 
 	/* Validate name */
 	_validate_child_name(p_child, p_legible_unique_name);
@@ -1239,10 +1218,7 @@ void Node::_propagate_validate_owner() {
 void Node::remove_child(Node *p_child) {
 
 	ERR_FAIL_NULL(p_child);
-	if (data.blocked > 0) {
-		ERR_EXPLAIN("Parent node is busy setting up children, remove_node() failed. Consider using call_deferred(\"remove_child\",child) instead.");
-		ERR_FAIL_COND(data.blocked > 0);
-	}
+	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy setting up children, remove_node() failed. Consider using call_deferred(\"remove_child\", child) instead.");
 
 	int child_count = data.children.size();
 	Node **children = data.children.ptrw();
@@ -1265,8 +1241,7 @@ void Node::remove_child(Node *p_child) {
 		}
 	}
 
-	ERR_EXPLAIN("Cannot remove child node " + p_child->to_string() + " as it is not in our list of children");
-	ERR_FAIL_COND(idx == -1);
+	ERR_FAIL_COND_MSG(idx == -1, "Cannot remove child node " + p_child->get_name() + " as it is not a child of this node.");
 	//ERR_FAIL_COND( p_child->data.blocked > 0 );
 
 	//if (data.scene) { does not matter
@@ -1330,10 +1305,7 @@ Node *Node::get_node_or_null(const NodePath &p_path) const {
 		return NULL;
 	}
 
-	if (!data.inside_tree && p_path.is_absolute()) {
-		ERR_EXPLAIN("Can't use get_node() with absolute paths from outside the active scene tree.");
-		ERR_FAIL_V(NULL);
-	}
+	ERR_FAIL_COND_V_MSG(!data.inside_tree && p_path.is_absolute(), NULL, "Can't use get_node() with absolute paths from outside the active scene tree.");
 
 	Node *current = NULL;
 	Node *root = NULL;
@@ -1394,10 +1366,7 @@ Node *Node::get_node_or_null(const NodePath &p_path) const {
 Node *Node::get_node(const NodePath &p_path) const {
 
 	Node *node = get_node_or_null(p_path);
-	if (!node) {
-		ERR_EXPLAIN("Node not found: " + p_path);
-		ERR_FAIL_V(NULL);
-	}
+	ERR_FAIL_COND_V_MSG(!node, NULL, "Node not found: " + p_path + ".");
 	return node;
 }
 
@@ -1665,8 +1634,7 @@ NodePath Node::get_path_to(const Node *p_node) const {
 
 NodePath Node::get_path() const {
 
-	ERR_EXPLAIN("Cannot get path of node as it is not in a scene tree");
-	ERR_FAIL_COND_V(!is_inside_tree(), NodePath());
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), NodePath(), "Cannot get path of node as it is not in a scene tree.");
 
 	if (data.path_cache)
 		return *data.path_cache;
@@ -2193,13 +2161,11 @@ void Node::_duplicate_and_reown(Node *p_new_parent, const Map<Node *, Node *> &p
 	} else {
 
 		Object *obj = ClassDB::instance(get_class());
-		ERR_EXPLAIN("Node: Could not duplicate: " + String(get_class()));
-		ERR_FAIL_COND(!obj);
+		ERR_FAIL_COND_MSG(!obj, "Node: Could not duplicate: " + String(get_class()) + ".");
 		node = Object::cast_to<Node>(obj);
 		if (!node) {
 			memdelete(obj);
-			ERR_EXPLAIN("Node: Could not duplicate: " + String(get_class()));
-			ERR_FAIL();
+			ERR_FAIL_MSG("Node: Could not duplicate: " + String(get_class()) + ".");
 		}
 	}
 
@@ -2297,14 +2263,12 @@ Node *Node::duplicate_and_reown(const Map<Node *, Node *> &p_reown_map) const {
 	ERR_FAIL_COND_V(get_filename() != "", NULL);
 
 	Object *obj = ClassDB::instance(get_class());
-	ERR_EXPLAIN("Node: Could not duplicate: " + String(get_class()));
-	ERR_FAIL_COND_V(!obj, NULL);
+	ERR_FAIL_COND_V_MSG(!obj, NULL, "Node: Could not duplicate: " + String(get_class()) + ".");
 
 	Node *node = Object::cast_to<Node>(obj);
 	if (!node) {
 		memdelete(obj);
-		ERR_EXPLAIN("Node: Could not duplicate: " + String(get_class()));
-		ERR_FAIL_V(NULL);
+		ERR_FAIL_V_MSG(NULL, "Node: Could not duplicate: " + String(get_class()) + ".");
 	}
 	node->set_name(get_name());
 
@@ -2441,8 +2405,7 @@ void Node::_replace_connections_target(Node *p_new_target) {
 		if (c.flags & CONNECT_PERSIST) {
 			c.source->disconnect(c.signal, this, c.method);
 			bool valid = p_new_target->has_method(c.method) || Ref<Script>(p_new_target->get_script()).is_null() || Ref<Script>(p_new_target->get_script())->has_method(c.method);
-			ERR_EXPLAIN("Attempt to connect signal \'" + c.source->get_class() + "." + c.signal + "\' to nonexistent method \'" + c.target->get_class() + "." + c.method + "\'");
-			ERR_CONTINUE(!valid);
+			ERR_CONTINUE_MSG(!valid, "Attempt to connect signal '" + c.source->get_class() + "." + c.signal + "' to nonexistent method '" + c.target->get_class() + "." + c.method + "'.");
 			c.source->connect(c.signal, p_new_target, c.method, c.binds, c.flags);
 		}
 	}

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -116,10 +116,7 @@ SceneTree::Group *SceneTree::add_to_group(const StringName &p_group, Node *p_nod
 		E = group_map.insert(p_group, Group());
 	}
 
-	if (E->get().nodes.find(p_node) != -1) {
-		ERR_EXPLAIN("Already in group: " + p_group);
-		ERR_FAIL_V(&E->get());
-	}
+	ERR_FAIL_COND_V_MSG(E->get().nodes.find(p_node) != -1, &E->get(), "Already in group: " + p_group + ".");
 	E->get().nodes.push_back(p_node);
 	//E->get().last_tree_version=0;
 	E->get().changed = true;

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -80,8 +80,7 @@ void Timer::_notification(int p_what) {
 }
 
 void Timer::set_wait_time(float p_time) {
-	ERR_EXPLAIN("time should be greater than zero.");
-	ERR_FAIL_COND(p_time <= 0);
+	ERR_FAIL_COND_MSG(p_time <= 0, "Time should be greater than zero.");
 	wait_time = p_time;
 }
 float Timer::get_wait_time() const {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -65,13 +65,11 @@ void ViewportTexture::setup_local_to_scene() {
 	}
 
 	Node *vpn = local_scene->get_node(path);
-	ERR_EXPLAIN("ViewportTexture: Path to node is invalid");
-	ERR_FAIL_COND(!vpn);
+	ERR_FAIL_COND_MSG(!vpn, "ViewportTexture: Path to node is invalid.");
 
 	vp = Object::cast_to<Viewport>(vpn);
 
-	ERR_EXPLAIN("ViewportTexture: Path to node does not point to a viewport");
-	ERR_FAIL_COND(!vp);
+	ERR_FAIL_COND_MSG(!vp, "ViewportTexture: Path to node does not point to a viewport.");
 
 	vp->viewport_textures.insert(this);
 
@@ -2393,8 +2391,7 @@ void Viewport::_gui_remove_from_modal_stack(List<Control *>::Element *MI, Object
 
 void Viewport::_gui_force_drag(Control *p_base, const Variant &p_data, Control *p_control) {
 
-	ERR_EXPLAIN("Drag data must be a value");
-	ERR_FAIL_COND(p_data.get_type() == Variant::NIL);
+	ERR_FAIL_COND_MSG(p_data.get_type() == Variant::NIL, "Drag data must be a value.");
 
 	gui.dragging = true;
 	gui.drag_data = p_data;

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -765,10 +765,7 @@ Vector2 Curve2D::interpolate_baked(float p_offset, bool p_cubic) const {
 
 	//validate//
 	int pc = baked_point_cache.size();
-	if (pc == 0) {
-		ERR_EXPLAIN("No points in Curve2D.");
-		ERR_FAIL_V(Vector2());
-	}
+	ERR_FAIL_COND_V_MSG(pc == 0, Vector2(), "No points in Curve2D.");
 
 	if (pc == 1)
 		return baked_point_cache.get(0);
@@ -831,10 +828,7 @@ Vector2 Curve2D::get_closest_point(const Vector2 &p_to_point) const {
 
 	//validate//
 	int pc = baked_point_cache.size();
-	if (pc == 0) {
-		ERR_EXPLAIN("No points in Curve2D.");
-		ERR_FAIL_V(Vector2());
-	}
+	ERR_FAIL_COND_V_MSG(pc == 0, Vector2(), "No points in Curve2D.");
 
 	if (pc == 1)
 		return baked_point_cache.get(0);
@@ -870,10 +864,7 @@ float Curve2D::get_closest_offset(const Vector2 &p_to_point) const {
 
 	//validate//
 	int pc = baked_point_cache.size();
-	if (pc == 0) {
-		ERR_EXPLAIN("No points in Curve2D.");
-		ERR_FAIL_V(0.0f);
-	}
+	ERR_FAIL_COND_V_MSG(pc == 0, 0.0f, "No points in Curve2D.");
 
 	if (pc == 1)
 		return 0.0f;
@@ -1336,10 +1327,7 @@ Vector3 Curve3D::interpolate_baked(float p_offset, bool p_cubic) const {
 
 	//validate//
 	int pc = baked_point_cache.size();
-	if (pc == 0) {
-		ERR_EXPLAIN("No points in Curve3D.");
-		ERR_FAIL_V(Vector3());
-	}
+	ERR_FAIL_COND_V_MSG(pc == 0, Vector3(), "No points in Curve3D.");
 
 	if (pc == 1)
 		return baked_point_cache.get(0);
@@ -1381,10 +1369,7 @@ float Curve3D::interpolate_baked_tilt(float p_offset) const {
 
 	//validate//
 	int pc = baked_tilt_cache.size();
-	if (pc == 0) {
-		ERR_EXPLAIN("No tilts in Curve3D.");
-		ERR_FAIL_V(0);
-	}
+	ERR_FAIL_COND_V_MSG(pc == 0, 0, "No tilts in Curve3D.");
 
 	if (pc == 1)
 		return baked_tilt_cache.get(0);
@@ -1420,10 +1405,7 @@ Vector3 Curve3D::interpolate_baked_up_vector(float p_offset, bool p_apply_tilt) 
 	//validate//
 	// curve may not have baked up vectors
 	int count = baked_up_vector_cache.size();
-	if (count == 0) {
-		ERR_EXPLAIN("No up vectors in Curve3D.");
-		ERR_FAIL_V(Vector3(0, 1, 0));
-	}
+	ERR_FAIL_COND_V_MSG(count == 0, Vector3(0, 1, 0), "No up vectors in Curve3D.");
 
 	if (count == 1)
 		return baked_up_vector_cache.get(0);
@@ -1491,10 +1473,7 @@ Vector3 Curve3D::get_closest_point(const Vector3 &p_to_point) const {
 
 	//validate//
 	int pc = baked_point_cache.size();
-	if (pc == 0) {
-		ERR_EXPLAIN("No points in Curve3D.");
-		ERR_FAIL_V(Vector3());
-	}
+	ERR_FAIL_COND_V_MSG(pc == 0, Vector3(), "No points in Curve3D.");
 
 	if (pc == 1)
 		return baked_point_cache.get(0);
@@ -1530,10 +1509,7 @@ float Curve3D::get_closest_offset(const Vector3 &p_to_point) const {
 
 	//validate//
 	int pc = baked_point_cache.size();
-	if (pc == 0) {
-		ERR_EXPLAIN("No points in Curve3D.");
-		ERR_FAIL_V(0.0f);
-	}
+	ERR_FAIL_COND_V_MSG(pc == 0, 0.0f, "No points in Curve3D.");
 
 	if (pc == 1)
 		return 0.0f;

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -118,8 +118,7 @@ Error DynamicFontAtSize::_load() {
 
 	int error = FT_Init_FreeType(&library);
 
-	ERR_EXPLAIN(TTR("Error initializing FreeType."));
-	ERR_FAIL_COND_V(error != 0, ERR_CANT_CREATE);
+	ERR_FAIL_COND_V_MSG(error != 0, ERR_CANT_CREATE, "Error initializing FreeType.");
 
 	// FT_OPEN_STREAM is extremely slow only on Android.
 	if (OS::get_singleton()->get_name() == "Android" && font->font_mem == NULL && font->font_path != String()) {
@@ -177,19 +176,18 @@ Error DynamicFontAtSize::_load() {
 		error = FT_Open_Face(library, &fargs, 0, &face);
 
 	} else {
-		ERR_EXPLAIN("DynamicFont uninitialized");
-		ERR_FAIL_V(ERR_UNCONFIGURED);
+		ERR_FAIL_V_MSG(ERR_UNCONFIGURED, "DynamicFont uninitialized.");
 	}
 
 	//error = FT_New_Face( library, src_path.utf8().get_data(),0,&face );
 
 	if (error == FT_Err_Unknown_File_Format) {
-		ERR_EXPLAIN(TTR("Unknown font format."));
+		ERR_EXPLAIN("Unknown font format.");
 		FT_Done_FreeType(library);
 
 	} else if (error) {
 
-		ERR_EXPLAIN(TTR("Error loading font."));
+		ERR_EXPLAIN("Error loading font.");
 		FT_Done_FreeType(library);
 	}
 
@@ -509,8 +507,7 @@ DynamicFontAtSize::Character DynamicFontAtSize::_bitmap_to_character(FT_Bitmap b
 					} break;
 					// TODO: FT_PIXEL_MODE_LCD
 					default:
-						ERR_EXPLAIN("Font uses unsupported pixel format: " + itos(bitmap.pixel_mode));
-						ERR_FAIL_V(Character::not_found());
+						ERR_FAIL_V_MSG(Character::not_found(), "Font uses unsupported pixel format: " + itos(bitmap.pixel_mode) + ".");
 						break;
 				}
 			}

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -202,10 +202,7 @@ Error BitmapFont::create_from_fnt(const String &p_file) {
 
 	FileAccess *f = FileAccess::open(p_file, FileAccess::READ);
 
-	if (!f) {
-		ERR_EXPLAIN("Can't open font: " + p_file);
-		ERR_FAIL_V(ERR_FILE_NOT_FOUND);
-	}
+	ERR_FAIL_COND_V_MSG(!f, ERR_FILE_NOT_FOUND, "Can't open font: " + p_file + ".");
 
 	clear();
 
@@ -532,10 +529,7 @@ Size2 Font::get_wordwrap_string_size(const String &p_string, float p_width) cons
 void BitmapFont::set_fallback(const Ref<BitmapFont> &p_fallback) {
 
 	for (Ref<BitmapFont> fallback_child = p_fallback; fallback_child != NULL; fallback_child = fallback_child->get_fallback()) {
-		if (fallback_child == this) {
-			ERR_EXPLAIN("Can't set as fallback one of its parents to prevent crashes due to recursive loop.");
-			ERR_FAIL_COND(fallback_child == this);
-		}
+		ERR_FAIL_COND_MSG(fallback_child == this, "Can't set as fallback one of its parents to prevent crashes due to recursive loop.");
 	}
 
 	fallback = p_fallback;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -39,10 +39,7 @@
 void Material::set_next_pass(const Ref<Material> &p_pass) {
 
 	for (Ref<Material> pass_child = p_pass; pass_child != NULL; pass_child = pass_child->get_next_pass()) {
-		if (pass_child == this) {
-			ERR_EXPLAIN("Can't set as next_pass one of its parents to prevent crashes due to recursive loop.");
-			ERR_FAIL_COND(pass_child == this);
-		}
+		ERR_FAIL_COND_MSG(pass_child == this, "Can't set as next_pass one of its parents to prevent crashes due to recursive loop.");
 	}
 
 	if (next_pass == p_pass)

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -883,10 +883,7 @@ int ArrayMesh::get_surface_count() const {
 
 void ArrayMesh::add_blend_shape(const StringName &p_name) {
 
-	if (surfaces.size()) {
-		ERR_EXPLAIN("Can't add a shape key count if surfaces are already created.");
-		ERR_FAIL_COND(surfaces.size());
-	}
+	ERR_FAIL_COND_MSG(surfaces.size(), "Can't add a shape key count if surfaces are already created.");
 
 	StringName name = p_name;
 
@@ -914,10 +911,7 @@ StringName ArrayMesh::get_blend_shape_name(int p_index) const {
 }
 void ArrayMesh::clear_blend_shapes() {
 
-	if (surfaces.size()) {
-		ERR_EXPLAIN("Can't set shape key count if surfaces are already created.");
-		ERR_FAIL_COND(surfaces.size());
-	}
+	ERR_FAIL_COND_MSG(surfaces.size(), "Can't set shape key count if surfaces are already created.");
 
 	blend_shapes.clear();
 }
@@ -1109,8 +1103,7 @@ struct ArrayMeshLightmapSurface {
 Error ArrayMesh::lightmap_unwrap(const Transform &p_base_transform, float p_texel_size) {
 
 	ERR_FAIL_COND_V(!array_mesh_lightmap_unwrap_callback, ERR_UNCONFIGURED);
-	ERR_EXPLAIN("Can't unwrap mesh with blend shapes");
-	ERR_FAIL_COND_V(blend_shapes.size() != 0, ERR_UNAVAILABLE);
+	ERR_FAIL_COND_V_MSG(blend_shapes.size() != 0, ERR_UNAVAILABLE, "Can't unwrap mesh with blend shapes.");
 
 	Vector<float> vertices;
 	Vector<float> normals;
@@ -1124,15 +1117,9 @@ Error ArrayMesh::lightmap_unwrap(const Transform &p_base_transform, float p_texe
 		ArrayMeshLightmapSurface s;
 		s.primitive = surface_get_primitive_type(i);
 
-		if (s.primitive != Mesh::PRIMITIVE_TRIANGLES) {
-			ERR_EXPLAIN("Only triangles are supported for lightmap unwrap");
-			ERR_FAIL_V(ERR_UNAVAILABLE);
-		}
+		ERR_FAIL_COND_V_MSG(s.primitive != Mesh::PRIMITIVE_TRIANGLES, ERR_UNAVAILABLE, "Only triangles are supported for lightmap unwrap.");
 		s.format = surface_get_format(i);
-		if (!(s.format & ARRAY_FORMAT_NORMAL)) {
-			ERR_EXPLAIN("Normals are required for lightmap unwrap");
-			ERR_FAIL_V(ERR_UNAVAILABLE);
-		}
+		ERR_FAIL_COND_V_MSG(!(s.format & ARRAY_FORMAT_NORMAL), ERR_UNAVAILABLE, "Normals are required for lightmap unwrap.");
 
 		Array arrays = surface_get_arrays(i);
 		s.material = surface_get_material(i);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -92,8 +92,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 
 		if (i > 0) {
 
-			ERR_EXPLAIN(vformat("Invalid scene: node %s does not specify its parent node.", snames[n.name]));
-			ERR_FAIL_COND_V(n.parent == -1, NULL);
+			ERR_FAIL_COND_V_MSG(n.parent == -1, NULL, vformat("Invalid scene: node %s does not specify its parent node.", snames[n.name]));
 			NODE_FROM_ID(nparent, n.parent);
 #ifdef DEBUG_ENABLED
 			if (!nparent && (n.parent & FLAG_ID_IS_PATH)) {
@@ -1093,10 +1092,7 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 	if (p_dictionary.has("version"))
 		version = p_dictionary["version"];
 
-	if (version > PACK_VERSION) {
-		ERR_EXPLAIN("Save format version too new!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(version > PACK_VERSION, "Save format version too new.");
 
 	PoolVector<String> snames = p_dictionary["names"];
 	if (snames.size()) {
@@ -1690,10 +1686,7 @@ bool PackedScene::can_instance() const {
 Node *PackedScene::instance(GenEditState p_edit_state) const {
 
 #ifndef TOOLS_ENABLED
-	if (p_edit_state != GEN_EDIT_STATE_DISABLED) {
-		ERR_EXPLAIN("Edit state is only for editors, does not work without tools compiled");
-		ERR_FAIL_COND_V(p_edit_state != GEN_EDIT_STATE_DISABLED, NULL);
-	}
+	ERR_FAIL_COND_V_MSG(p_edit_state != GEN_EDIT_STATE_DISABLED, NULL, "Edit state is only for editors, does not work without tools compiled.");
 #endif
 
 	Node *s = state->instance((SceneState::GenEditState)p_edit_state);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1366,8 +1366,7 @@ String ResourceFormatSaverTextInstance::_write_resource(const RES &res) {
 			String path = relative_paths ? local_path.path_to_file(res->get_path()) : res->get_path();
 			return "Resource( \"" + path + "\" )";
 		} else {
-			ERR_EXPLAIN("Resource was not pre cached for the resource section, bug?");
-			ERR_FAIL_V("null");
+			ERR_FAIL_V_MSG("null", "Resource was not pre cached for the resource section, bug?");
 			//internal resource
 		}
 	}

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -67,10 +67,7 @@ Error TextFile::load_text(const String &p_path) {
 	w[len] = 0;
 
 	String s;
-	if (s.parse_utf8((const char *)w.ptr())) {
-		ERR_EXPLAIN("Script '" + p_path + "' contains invalid unicode (utf-8), so it was not loaded. Please ensure that scripts are saved in valid utf-8 unicode.");
-		ERR_FAIL_V(ERR_INVALID_DATA);
-	}
+	ERR_FAIL_COND_V_MSG(s.parse_utf8((const char *)w.ptr()), ERR_INVALID_DATA, "Script '" + p_path + "' contains invalid unicode (UTF-8), so it was not loaded. Please ensure that scripts are saved in valid UTF-8 unicode.");
 	text = s;
 	path = p_path;
 	return OK;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2351,8 +2351,7 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 		texarr.instance();
 		lt = texarr;
 	} else {
-		ERR_EXPLAIN("Unrecognized layered texture extension");
-		ERR_FAIL_V(RES());
+		ERR_FAIL_V_MSG(RES(), "Unrecognized layered texture extension.");
 	}
 
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
@@ -2373,8 +2372,7 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 		}
 	} else {
 
-		ERR_EXPLAIN("Unrecognized layered texture file format: " + String((const char *)header));
-		ERR_FAIL_V(RES());
+		ERR_FAIL_V_MSG(RES(), "Unrecognized layered texture file format: " + String((const char *)header) + ".");
 	}
 
 	int tw = f->get_32();

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -1006,8 +1006,7 @@ void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 				s.autotile_coord = default_autotile_coord;
 
 		} else {
-			ERR_EXPLAIN("Expected an array of objects or dictionaries for tile_set_shapes");
-			ERR_CONTINUE(true);
+			ERR_CONTINUE_MSG(true, "Expected an array of objects or dictionaries for tile_set_shapes.");
 		}
 
 		shapes_data.push_back(s);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -307,11 +307,7 @@ Error VisualShader::connect_nodes(Type p_type, int p_from_node, int p_from_port,
 	VisualShaderNode::PortType from_port_type = g->nodes[p_from_node].node->get_output_port_type(p_from_port);
 	VisualShaderNode::PortType to_port_type = g->nodes[p_to_node].node->get_input_port_type(p_to_port);
 
-	if (!is_port_types_compatible(from_port_type, to_port_type)) {
-		ERR_EXPLAIN("Incompatible port types (scalar/vec/bool) with transform");
-		ERR_FAIL_V(ERR_INVALID_PARAMETER);
-		return ERR_INVALID_PARAMETER;
-	}
+	ERR_FAIL_COND_V_MSG(!is_port_types_compatible(from_port_type, to_port_type), ERR_INVALID_PARAMETER, "Incompatible port types (scalar/vec/bool) with transform.");
 
 	for (List<Connection>::Element *E = g->connections.front(); E; E = E->next()) {
 


### PR DESCRIPTION
Addresses part of #31207

Aside from straightforward adding `_MSG `, I changed some `if` conditions to `FAIL_COND_*` macros. There are however two `EXPLAIN`s I didn't know what to do about, as they come with some font-specific macro (which doesn't have `MSG` version):
https://github.com/godotengine/godot/blob/d2a67c9c1fdee470064f2b3c5750c98f174b5399/scene/resources/dynamic_font.cpp#L187-L188
(and below)