### PR TITLE
Replace 'ERR_EXPLAIN' with 'ERR_FAIL_*_MSG' in "platform", "modules/gdnative", "modules/gdscript" directories.

### DIFF
--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -245,8 +245,7 @@ extern "C" {
 
 void GDAPI godot_arvr_register_interface(const godot_arvr_interface_gdnative *p_interface) {
 	// If our major version is 0 or bigger then 10, we're likely looking at our constructor pointer from an older plugin
-	ERR_EXPLAINC("GDNative ARVR interfaces build for Godot 3.0 are not supported");
-	ERR_FAIL_COND((p_interface->version.major == 0) || (p_interface->version.major > 10));
+	ERR_FAIL_COND_MSG((p_interface->version.major == 0) || (p_interface->version.major > 10), "GDNative ARVR interfaces build for Godot 3.0 are not supported.");
 
 	Ref<ARVRInterfaceGDNative> new_interface;
 	new_interface.instance();

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -268,8 +268,7 @@ void GDNative::_bind_methods() {
 }
 
 void GDNative::set_library(Ref<GDNativeLibrary> p_library) {
-	ERR_EXPLAIN("Tried to change library of GDNative when it is already set");
-	ERR_FAIL_COND(library.is_valid());
+	ERR_FAIL_COND_MSG(library.is_valid(), "Tried to change library of GDNative when it is already set.");
 	library = p_library;
 }
 

--- a/modules/gdnative/nativescript/godot_nativescript.cpp
+++ b/modules/gdnative/nativescript/godot_nativescript.cpp
@@ -104,11 +104,7 @@ void GDAPI godot_nativescript_register_method(void *p_gdnative_handle, const cha
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
-
-	if (!E) {
-		ERR_EXPLAIN("Attempted to register method on non-existent class!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!E, "Attempted to register method on non-existent class.");
 
 	NativeScriptDesc::Method method;
 	method.method = p_method;
@@ -123,11 +119,7 @@ void GDAPI godot_nativescript_register_property(void *p_gdnative_handle, const c
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
-
-	if (!E) {
-		ERR_EXPLAIN("Attempted to register method on non-existent class!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!E, "Attempted to register method on non-existent class.");
 
 	NativeScriptDesc::Property property;
 	property.default_value = *(Variant *)&p_attr->default_value;
@@ -148,11 +140,7 @@ void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const cha
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
-
-	if (!E) {
-		ERR_EXPLAIN("Attempted to register method on non-existent class!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!E, "Attempted to register method on non-existent class.");
 
 	List<PropertyInfo> args;
 	Vector<Variant> default_args;
@@ -213,17 +201,10 @@ void GDAPI godot_nativescript_set_method_argument_information(void *p_gdnative_h
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
-
-	if (!E) {
-		ERR_EXPLAIN("Attempted to add argument information for a method on a non-existent class!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!E, "Attempted to add argument information for a method on a non-existent class.");
 
 	Map<StringName, NativeScriptDesc::Method>::Element *method = E->get().methods.find(p_function_name);
-	if (!method) {
-		ERR_EXPLAIN("Attempted to add argument information to non-existent method!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!method, "Attempted to add argument information to non-existent method.");
 
 	MethodInfo *method_information = &method->get().info;
 
@@ -247,11 +228,7 @@ void GDAPI godot_nativescript_set_class_documentation(void *p_gdnative_handle, c
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
-
-	if (!E) {
-		ERR_EXPLAIN("Attempted to add documentation to a non-existent class!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!E, "Attempted to add documentation to a non-existent class.");
 
 	E->get().documentation = *(String *)&p_documentation;
 }
@@ -260,17 +237,10 @@ void GDAPI godot_nativescript_set_method_documentation(void *p_gdnative_handle, 
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
-
-	if (!E) {
-		ERR_EXPLAIN("Attempted to add documentation to a method on a non-existent class!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!E, "Attempted to add documentation to a method on a non-existent class.");
 
 	Map<StringName, NativeScriptDesc::Method>::Element *method = E->get().methods.find(p_function_name);
-	if (!method) {
-		ERR_EXPLAIN("Attempted to add documentatino to non-existent method!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!method, "Attempted to add documentation to non-existent method.");
 
 	method->get().documentation = *(String *)&p_documentation;
 }
@@ -279,17 +249,10 @@ void GDAPI godot_nativescript_set_property_documentation(void *p_gdnative_handle
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
-
-	if (!E) {
-		ERR_EXPLAIN("Attempted to add documentation to a property on a non-existent class!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!E, "Attempted to add documentation to a property on a non-existent class.");
 
 	OrderedHashMap<StringName, NativeScriptDesc::Property>::Element property = E->get().properties.find(p_path);
-	if (!property) {
-		ERR_EXPLAIN("Attempted to add documentation to non-existent property!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!property, "Attempted to add documentation to non-existent property.");
 
 	property.get().documentation = *(String *)&p_documentation;
 }
@@ -298,17 +261,10 @@ void GDAPI godot_nativescript_set_signal_documentation(void *p_gdnative_handle, 
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
-
-	if (!E) {
-		ERR_EXPLAIN("Attempted to add documentation to a signal on a non-existent class!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!E, "Attempted to add documentation to a signal on a non-existent class.");
 
 	Map<StringName, NativeScriptDesc::Signal>::Element *signal = E->get().signals_.find(p_signal_name);
-	if (!signal) {
-		ERR_EXPLAIN("Attempted to add documentation to non-existent signal!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!signal, "Attempted to add documentation to non-existent signal.");
 
 	signal->get().documentation = *(String *)&p_documentation;
 }
@@ -325,11 +281,7 @@ void GDAPI godot_nativescript_set_type_tag(void *p_gdnative_handle, const char *
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
-
-	if (!E) {
-		ERR_EXPLAIN("Attempted to set type tag on a non-existent class!");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!E, "Attempted to set type tag on a non-existent class.");
 
 	E->get().type_tag = p_type_tag;
 }

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -402,10 +402,7 @@ void NativeScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 String NativeScript::get_class_documentation() const {
 	NativeScriptDesc *script_data = get_script_desc();
 
-	if (!script_data) {
-		ERR_EXPLAIN("Attempt to get class documentation on invalid NativeScript");
-		ERR_FAIL_V("");
-	}
+	ERR_FAIL_COND_V_MSG(!script_data, "", "Attempt to get class documentation on invalid NativeScript.");
 
 	return script_data->documentation;
 }
@@ -413,10 +410,7 @@ String NativeScript::get_class_documentation() const {
 String NativeScript::get_method_documentation(const StringName &p_method) const {
 	NativeScriptDesc *script_data = get_script_desc();
 
-	if (!script_data) {
-		ERR_EXPLAIN("Attempt to get method documentation on invalid NativeScript");
-		ERR_FAIL_V("");
-	}
+	ERR_FAIL_COND_V_MSG(!script_data, "", "Attempt to get method documentation on invalid NativeScript.");
 
 	while (script_data) {
 
@@ -429,17 +423,13 @@ String NativeScript::get_method_documentation(const StringName &p_method) const 
 		script_data = script_data->base_data;
 	}
 
-	ERR_EXPLAIN("Attempt to get method documentation for non-existent method");
-	ERR_FAIL_V("");
+	ERR_FAIL_V_MSG("", "Attempt to get method documentation for non-existent method.");
 }
 
 String NativeScript::get_signal_documentation(const StringName &p_signal_name) const {
 	NativeScriptDesc *script_data = get_script_desc();
 
-	if (!script_data) {
-		ERR_EXPLAIN("Attempt to get signal documentation on invalid NativeScript");
-		ERR_FAIL_V("");
-	}
+	ERR_FAIL_COND_V_MSG(!script_data, "", "Attempt to get signal documentation on invalid NativeScript.");
 
 	while (script_data) {
 
@@ -452,17 +442,13 @@ String NativeScript::get_signal_documentation(const StringName &p_signal_name) c
 		script_data = script_data->base_data;
 	}
 
-	ERR_EXPLAIN("Attempt to get signal documentation for non-existent signal");
-	ERR_FAIL_V("");
+	ERR_FAIL_V_MSG("", "Attempt to get signal documentation for non-existent signal.");
 }
 
 String NativeScript::get_property_documentation(const StringName &p_path) const {
 	NativeScriptDesc *script_data = get_script_desc();
 
-	if (!script_data) {
-		ERR_EXPLAIN("Attempt to get property documentation on invalid NativeScript");
-		ERR_FAIL_V("");
-	}
+	ERR_FAIL_COND_V_MSG(!script_data, "", "Attempt to get property documentation on invalid NativeScript.");
 
 	while (script_data) {
 
@@ -475,8 +461,7 @@ String NativeScript::get_property_documentation(const StringName &p_path) const 
 		script_data = script_data->base_data;
 	}
 
-	ERR_EXPLAIN("Attempt to get property documentation for non-existent signal");
-	ERR_FAIL_V("");
+	ERR_FAIL_V_MSG("", "Attempt to get property documentation for non-existent signal.");
 }
 
 Variant NativeScript::_new(const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
@@ -655,10 +640,7 @@ void NativeScriptInstance::get_property_list(List<PropertyInfo> *p_properties) c
 			Variant res = *(Variant *)&result;
 			godot_variant_destroy(&result);
 
-			if (res.get_type() != Variant::ARRAY) {
-				ERR_EXPLAIN("_get_property_list must return an array of dictionaries");
-				ERR_FAIL();
-			}
+			ERR_FAIL_COND_MSG(res.get_type() != Variant::ARRAY, "_get_property_list must return an array of dictionaries.");
 
 			Array arr = res;
 			for (int i = 0; i < arr.size(); i++) {
@@ -780,8 +762,7 @@ String NativeScriptInstance::to_string(bool *r_valid) {
 			if (ret.get_type() != Variant::STRING) {
 				if (r_valid)
 					*r_valid = false;
-				ERR_EXPLAIN("Wrong type for " + CoreStringNames::get_singleton()->_to_string + ", must be a String.");
-				ERR_FAIL_V(String());
+				ERR_FAIL_V_MSG(String(), "Wrong type for " + CoreStringNames::get_singleton()->_to_string + ", must be a String.");
 			}
 			if (r_valid)
 				*r_valid = true;
@@ -1344,10 +1325,7 @@ void NativeScriptLanguage::unregister_binding_functions(int p_idx) {
 void *NativeScriptLanguage::get_instance_binding_data(int p_idx, Object *p_object) {
 	ERR_FAIL_INDEX_V(p_idx, binding_functions.size(), NULL);
 
-	if (!binding_functions[p_idx].first) {
-		ERR_EXPLAIN("Tried to get binding data for a nativescript binding that does not exist");
-		ERR_FAIL_V(NULL);
-	}
+	ERR_FAIL_COND_V_MSG(!binding_functions[p_idx].first, NULL, "Tried to get binding data for a nativescript binding that does not exist.");
 
 	Vector<void *> *binding_data = (Vector<void *> *)p_object->get_script_instance_binding(lang_idx);
 
@@ -1499,8 +1477,7 @@ void NativeScriptLanguage::init_library(const Ref<GDNativeLibrary> &lib) {
 #endif
 	// See if this library was "registered" already.
 	const String &lib_path = lib->get_current_library_path();
-	ERR_EXPLAIN(lib->get_name() + " does not have a library for the current platform");
-	ERR_FAIL_COND(lib_path.length() == 0);
+	ERR_FAIL_COND_MSG(lib_path.length() == 0, lib->get_name() + " does not have a library for the current platform.");
 	Map<String, Ref<GDNative> >::Element *E = library_gdnatives.find(lib_path);
 
 	if (!E) {

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -35,16 +35,14 @@
 #include "pluginscript_script.h"
 
 #ifdef DEBUG_ENABLED
-#define __ASSERT_SCRIPT_REASON "Cannot retrieve pluginscript class for this script, is you code correct ?"
-#define ASSERT_SCRIPT_VALID()                \
-	{                                        \
-		ERR_EXPLAIN(__ASSERT_SCRIPT_REASON); \
-		ERR_FAIL_COND(!can_instance());      \
+#define __ASSERT_SCRIPT_REASON "Cannot retrieve PluginScript class for this script, is your code correct?"
+#define ASSERT_SCRIPT_VALID()                                       \
+	{                                                               \
+		ERR_FAIL_COND_MSG(!can_instance(), __ASSERT_SCRIPT_REASON); \
 	}
-#define ASSERT_SCRIPT_VALID_V(ret)             \
-	{                                          \
-		ERR_EXPLAIN(__ASSERT_SCRIPT_REASON);   \
-		ERR_FAIL_COND_V(!can_instance(), ret); \
+#define ASSERT_SCRIPT_VALID_V(ret)                                         \
+	{                                                                      \
+		ERR_FAIL_COND_V_MSG(!can_instance(), ret, __ASSERT_SCRIPT_REASON); \
 	}
 #else
 #define ASSERT_SCRIPT_VALID()
@@ -197,8 +195,7 @@ ScriptInstance *PluginScript::instance_create(Object *p_this) {
 			// if (ScriptDebugger::get_singleton()) {
 			// 	_language->debug_break_parse(get_path(), 0, msg);
 			// }
-			ERR_EXPLAIN(msg);
-			ERR_FAIL_V(NULL);
+			ERR_FAIL_V_MSG(NULL, msg);
 		}
 	}
 
@@ -272,8 +269,7 @@ Error PluginScript::reload(bool p_keep_state) {
 				_ref_base_parent = res;
 			} else {
 				String name = *(StringName *)&manifest.name;
-				ERR_EXPLAIN(_path + ": Script '" + name + "' has an invalid parent '" + *base_name + "'.");
-				ERR_FAIL_V(ERR_PARSE_ERROR);
+				ERR_FAIL_V_MSG(ERR_PARSE_ERROR, _path + ": Script '" + name + "' has an invalid parent '" + *base_name + "'.");
 			}
 		}
 	}
@@ -420,8 +416,7 @@ Error PluginScript::load_source_code(const String &p_path) {
 
 	String s;
 	if (s.parse_utf8((const char *)w.ptr())) {
-		ERR_EXPLAIN("Script '" + p_path + "' contains invalid unicode (utf-8), so it was not loaded. Please ensure that scripts are saved in valid utf-8 unicode.");
-		ERR_FAIL_V(ERR_INVALID_DATA);
+		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Script '" + p_path + "' contains invalid unicode (UTF-8), so it was not loaded. Please ensure that scripts are saved in valid UTF-8 unicode.");
 	}
 
 	_source = s;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -67,10 +67,7 @@ void GDScriptNativeClass::_bind_methods() {
 Variant GDScriptNativeClass::_new() {
 
 	Object *o = instance();
-	if (!o) {
-		ERR_EXPLAIN("Class type: '" + String(name) + "' is not instantiable.");
-		ERR_FAIL_V(Variant());
-	}
+	ERR_FAIL_COND_V_MSG(!o, Variant(), "Class type: '" + String(name) + "' is not instantiable.");
 
 	Reference *ref = Object::cast_to<Reference>(o);
 	if (ref) {
@@ -158,8 +155,7 @@ Variant GDScript::_new(const Variant **p_args, int p_argcount, Variant::CallErro
 	} else {
 		owner = memnew(Reference); //by default, no base means use reference
 	}
-	ERR_EXPLAIN("Can't inherit from a virtual class");
-	ERR_FAIL_COND_V(!owner, Variant());
+	ERR_FAIL_COND_V_MSG(!owner, Variant(), "Can't inherit from a virtual class.");
 
 	Reference *r = Object::cast_to<Reference>(owner);
 	if (r) {
@@ -326,8 +322,7 @@ ScriptInstance *GDScript::instance_create(Object *p_this) {
 			if (ScriptDebugger::get_singleton()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(get_path(), 0, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be instanced in object of type: '" + p_this->get_class() + "'");
 			}
-			ERR_EXPLAIN("Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be instanced in object of type: '" + p_this->get_class() + "'");
-			ERR_FAIL_V(NULL);
+			ERR_FAIL_V_MSG(NULL, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be instanced in object of type '" + p_this->get_class() + "'" + ".");
 		}
 	}
 
@@ -648,10 +643,7 @@ Variant GDScript::call(const StringName &p_method, const Variant **p_args, int p
 		Map<StringName, GDScriptFunction *>::Element *E = top->member_functions.find(p_method);
 		if (E) {
 
-			if (!E->get()->is_static()) {
-				ERR_EXPLAIN("Can't call non-static function: '" + String(p_method) + "' in script.");
-				ERR_FAIL_V(Variant());
-			}
+			ERR_FAIL_COND_V_MSG(!E->get()->is_static(), Variant(), "Can't call non-static function '" + String(p_method) + "' in script.");
 
 			return E->get()->call(NULL, p_args, p_argcount, r_error);
 		}
@@ -826,8 +818,7 @@ Error GDScript::load_source_code(const String &p_path) {
 	String s;
 	if (s.parse_utf8((const char *)w.ptr())) {
 
-		ERR_EXPLAIN("Script '" + p_path + "' contains invalid unicode (utf-8), so it was not loaded. Please ensure that scripts are saved in valid utf-8 unicode.");
-		ERR_FAIL_V(ERR_INVALID_DATA);
+		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Script '" + p_path + "' contains invalid unicode (UTF-8), so it was not loaded. Please ensure that scripts are saved in valid UTF-8 unicode.");
 	}
 
 	source = s;
@@ -1079,11 +1070,8 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 			Variant ret = const_cast<GDScriptFunction *>(E->get())->call(const_cast<GDScriptInstance *>(this), NULL, 0, err);
 			if (err.error == Variant::CallError::CALL_OK) {
 
-				if (ret.get_type() != Variant::ARRAY) {
+				ERR_FAIL_COND_MSG(ret.get_type() != Variant::ARRAY, "Wrong type for _get_property_list, must be an array of dictionaries.");
 
-					ERR_EXPLAIN("Wrong type for _get_property list, must be an array of dictionaries.");
-					ERR_FAIL();
-				}
 				Array arr = ret;
 				for (int i = 0; i < arr.size(); i++) {
 
@@ -1243,8 +1231,7 @@ String GDScriptInstance::to_string(bool *r_valid) {
 			if (ret.get_type() != Variant::STRING) {
 				if (r_valid)
 					*r_valid = false;
-				ERR_EXPLAIN("Wrong type for " + CoreStringNames::get_singleton()->_to_string + ", must be a String.");
-				ERR_FAIL_V(String());
+				ERR_FAIL_V_MSG(String(), "Wrong type for " + CoreStringNames::get_singleton()->_to_string + ", must be a String.");
 			}
 			if (r_valid)
 				*r_valid = true;
@@ -2057,8 +2044,7 @@ String GDScriptWarning::get_message() const {
 		} break;
 		case WARNING_MAX: break; // Can't happen, but silences warning
 	}
-	ERR_EXPLAIN("Invalid GDScript warning code: " + get_name_from_code(code));
-	ERR_FAIL_V(String());
+	ERR_FAIL_V_MSG(String(), "Invalid GDScript warning code: " + get_name_from_code(code) + ".");
 
 #undef CHECK_SYMBOLS
 }
@@ -2110,8 +2096,7 @@ GDScriptWarning::Code GDScriptWarning::get_code_from_name(const String &p_name) 
 		}
 	}
 
-	ERR_EXPLAIN("Invalid GDScript warning name: " + p_name);
-	ERR_FAIL_V(WARNING_MAX);
+	ERR_FAIL_V_MSG(WARNING_MAX, "Invalid GDScript warning name: " + p_name);
 }
 
 #endif // DEBUG_ENABLED

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1241,8 +1241,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				} break;
 				default: {
 
-					ERR_EXPLAIN("Bug in bytecode compiler, unexpected operator #" + itos(on->op) + " in parse tree while parsing expression.");
-					ERR_FAIL_V(0); //unreachable code
+					ERR_FAIL_V_MSG(0, "Bug in bytecode compiler, unexpected operator #" + itos(on->op) + " in parse tree while parsing expression."); //unreachable code
 
 				} break;
 			}
@@ -1255,8 +1254,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 		//TYPE_TYPE,
 		default: {
 
-			ERR_EXPLAIN("Bug in bytecode compiler, unexpected node in parse tree while parsing expression.");
-			ERR_FAIL_V(-1); //unreachable code
+			ERR_FAIL_V_MSG(-1, "Bug in bytecode compiler, unexpected node in parse tree while parsing expression."); //unreachable code
 		} break;
 	}
 }

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -86,8 +86,7 @@ Variant *GDScriptFunction::_get_variant(int p_address, GDScriptInstance *p_insta
 				o = o->_owner;
 			}
 
-			ERR_EXPLAIN("GDScriptCompiler bug...");
-			ERR_FAIL_V(NULL);
+			ERR_FAIL_V_MSG(NULL, "GDScriptCompiler bug.");
 		} break;
 		case ADDR_TYPE_LOCAL_CONSTANT: {
 #ifdef DEBUG_ENABLED
@@ -128,8 +127,7 @@ Variant *GDScriptFunction::_get_variant(int p_address, GDScriptInstance *p_insta
 		} break;
 	}
 
-	ERR_EXPLAIN("Bad Code! (Addressing Mode)");
-	ERR_FAIL_V(NULL);
+	ERR_FAIL_V_MSG(NULL, "Bad code! (unknown addressing mode).");
 	return NULL;
 }
 
@@ -1834,8 +1832,7 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 	ERR_FAIL_COND_V(!function, Variant());
 	if (state.instance_id && !ObjectDB::get_instance(state.instance_id)) {
 #ifdef DEBUG_ENABLED
-		ERR_EXPLAIN("Resumed function '" + String(function->get_name()) + "()' after yield, but class instance is gone. At script: " + state.script->get_path() + ":" + itos(state.line));
-		ERR_FAIL_V(Variant());
+		ERR_FAIL_V_MSG(Variant(), "Resumed function '" + String(function->get_name()) + "()' after yield, but class instance is gone. At script: " + state.script->get_path() + ":" + itos(state.line));
 #else
 		return Variant();
 #endif

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -349,8 +349,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 			VALIDATE_ARG_COUNT(1);
 			VALIDATE_ARG_NUM(0);
 			r_ret = Math::step_decimals((double)*p_args[0]);
-			ERR_EXPLAIN("GDScript method 'decimals' is deprecated and has been renamed to 'step_decimals', please update your code accordingly.");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("GDScript method 'decimals' is deprecated and has been renamed to 'step_decimals', please update your code accordingly.");
 		} break;
 		case MATH_STEP_DECIMALS: {
 			VALIDATE_ARG_COUNT(1);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1136,10 +1136,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 			return NULL; //nothing
 		}
 
-		if (!expr) {
-			ERR_EXPLAIN("GDScriptParser bug, couldn't figure out what expression is...");
-			ERR_FAIL_V(NULL);
-		}
+		ERR_FAIL_COND_V_MSG(!expr, NULL, "GDScriptParser bug, couldn't figure out what expression is.");
 
 		/******************/
 		/* Parse Indexing */
@@ -4019,8 +4016,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 										tokenizer->advance();
 
 										if (tokenizer->get_token() == GDScriptTokenizer::TK_PARENTHESIS_CLOSE) {
-											ERR_EXPLAIN("Exporting bit flags hint requires string constants.");
-											WARN_DEPRECATED;
+											WARN_DEPRECATED_MSG("Exporting bit flags hint requires string constants.");
 											break;
 										}
 										if (tokenizer->get_token() != GDScriptTokenizer::TK_COMMA) {
@@ -6695,8 +6691,7 @@ bool GDScriptParser::_get_function_signature(DataType &p_base_type, const String
 	}
 	if (!ClassDB::class_exists(native)) {
 		if (!check_types) return false;
-		ERR_EXPLAIN("Parser bug: Class '" + String(native) + "' not found.");
-		ERR_FAIL_V(false);
+		ERR_FAIL_V_MSG(false, "Parser bug: Class '" + String(native) + "' not found.");
 	}
 
 	MethodBind *method = ClassDB::get_method(native, p_function);
@@ -7204,8 +7199,7 @@ bool GDScriptParser::_get_member_type(const DataType &p_base_type, const StringN
 	}
 	if (!ClassDB::class_exists(native)) {
 		if (!check_types) return false;
-		ERR_EXPLAIN("Parser bug: Class '" + String(native) + "' not found.");
-		ERR_FAIL_V(false);
+		ERR_FAIL_V_MSG(false, "Parser bug: Class '" + String(native) + "' not found.");
 	}
 
 	bool valid = false;

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -357,8 +357,7 @@ StringName GDScriptTokenizer::get_token_literal(int p_offset) const {
 			}
 		}
 	}
-	ERR_EXPLAIN("Failed to get token literal");
-	ERR_FAIL_V("");
+	ERR_FAIL_V_MSG("", "Failed to get token literal.");
 }
 
 static bool _is_text_char(CharType c) {
@@ -1219,10 +1218,8 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 	ERR_FAIL_COND_V(p_buffer.size() < 24 || p_buffer[0] != 'G' || p_buffer[1] != 'D' || p_buffer[2] != 'S' || p_buffer[3] != 'C', ERR_INVALID_DATA);
 
 	int version = decode_uint32(&buf[4]);
-	if (version > BYTECODE_VERSION) {
-		ERR_EXPLAIN("Bytecode is too New! Please use a newer engine version.");
-		ERR_FAIL_V(ERR_INVALID_DATA);
-	}
+	ERR_FAIL_COND_V_MSG(version > BYTECODE_VERSION, ERR_INVALID_DATA, "Bytecode is too recent! Please use a newer engine version.");
+
 	int identifier_count = decode_uint32(&buf[8]);
 	int constant_count = decode_uint32(&buf[12]);
 	int line_count = decode_uint32(&buf[16]);

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -97,17 +97,10 @@ Error AudioDriverOpenSL::init() {
 		{ (SLuint32)SL_ENGINEOPTION_THREADSAFE, (SLuint32)SL_BOOLEAN_TRUE }
 	};
 	res = slCreateEngine(&sl, 1, EngineOption, 0, NULL, NULL);
-	if (res != SL_RESULT_SUCCESS) {
+	ERR_FAIL_COND_V_MSG(res != SL_RESULT_SUCCESS, ERR_INVALID_PARAMETER, "Could not initialize OpenSL.");
 
-		ERR_EXPLAIN("Could not Initialize OpenSL");
-		ERR_FAIL_V(ERR_INVALID_PARAMETER);
-	}
 	res = (*sl)->Realize(sl, SL_BOOLEAN_FALSE);
-	if (res != SL_RESULT_SUCCESS) {
-
-		ERR_EXPLAIN("Could not Realize OpenSL");
-		ERR_FAIL_V(ERR_INVALID_PARAMETER);
-	}
+	ERR_FAIL_COND_V_MSG(res != SL_RESULT_SUCCESS, ERR_INVALID_PARAMETER, "Could not realize OpenSL.");
 
 	return OK;
 }

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -725,8 +725,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 						uint32_t string_at = decode_uint32(&p_manifest[st_offset + i * 4]);
 						string_at += st_offset + string_count * 4;
 
-						ERR_EXPLAIN("Unimplemented, can't read utf8 string table.");
-						ERR_FAIL_COND(string_flags & UTF8_FLAG);
+						ERR_FAIL_COND_MSG(string_flags & UTF8_FLAG, "Unimplemented, can't read UTF-8 string table.");
 
 						if (string_flags & UTF8_FLAG) {
 
@@ -863,8 +862,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 						memcpy(manifest_end.ptrw(), &p_manifest[ofs], manifest_end.size());
 
 						int32_t attr_name_string = string_table.find("name");
-						ERR_EXPLAIN("Template does not have 'name' attribute");
-						ERR_FAIL_COND(attr_name_string == -1);
+						ERR_FAIL_COND_MSG(attr_name_string == -1, "Template does not have 'name' attribute.");
 
 						int32_t ns_android_string = string_table.find("http://schemas.android.com/apk/res/android");
 						if (ns_android_string == -1) {
@@ -896,8 +894,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 						} else if (dof_index == 2) {
 							required_value_string = "true";
 						} else {
-							ERR_EXPLAIN("Unknown dof index " + itos(dof_index));
-							ERR_FAIL();
+							ERR_FAIL_MSG("Unknown DoF index: " + itos(dof_index) + ".");
 						}
 						int32_t required_value = string_table.find(required_value_string);
 						if (required_value == -1) {
@@ -989,12 +986,10 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 						memcpy(manifest_end.ptrw(), &p_manifest[ofs], manifest_end.size());
 
 						int32_t attr_name_string = string_table.find("name");
-						ERR_EXPLAIN("Template does not have 'name' attribute");
-						ERR_FAIL_COND(attr_name_string == -1);
+						ERR_FAIL_COND_MSG(attr_name_string == -1, "Template does not have 'name' attribute.");
 
 						int32_t ns_android_string = string_table.find("android");
-						ERR_EXPLAIN("Template does not have 'android' namespace");
-						ERR_FAIL_COND(ns_android_string == -1);
+						ERR_FAIL_COND_MSG(ns_android_string == -1, "Template does not have 'android' namespace.");
 
 						int32_t attr_uses_permission_string = string_table.find("uses-permission");
 						if (attr_uses_permission_string == -1) {

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -686,20 +686,11 @@ static void _initialize_java_modules() {
 			print_line("Loading Android module: " + m);
 			jstring strClassName = env->NewStringUTF(m.utf8().get_data());
 			jclass singletonClass = (jclass)env->CallObjectMethod(cls, findClass, strClassName);
-
-			if (!singletonClass) {
-
-				ERR_EXPLAIN("Couldn't find singleton for class: " + m);
-				ERR_CONTINUE(!singletonClass);
-			}
+			ERR_CONTINUE_MSG(!singletonClass, "Couldn't find singleton for class: " + m + ".");
 
 			jmethodID initialize = env->GetStaticMethodID(singletonClass, "initialize", "(Landroid/app/Activity;)Lorg/godotengine/godot/Godot$SingletonBase;");
+			ERR_CONTINUE_MSG(!initialize, "Couldn't find proper initialize function 'public static Godot.SingletonBase Class::initialize(Activity p_activity)' initializer for singleton class: " + m + ".");
 
-			if (!initialize) {
-
-				ERR_EXPLAIN("Couldn't find proper initialize function 'public static Godot.SingletonBase Class::initialize(Activity p_activity)' initializer for singleton class: " + m);
-				ERR_CONTINUE(!initialize);
-			}
 			jobject obj = env->CallStaticObjectMethod(singletonClass, initialize, godot_java->get_activity());
 			env->NewGlobalRef(obj);
 		}

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -71,8 +71,7 @@ const char *OS_Android::get_video_driver_name(int p_driver) const {
 		case VIDEO_DRIVER_GLES2:
 			return "GLES2";
 	}
-	ERR_EXPLAIN("Invalid video driver index " + itos(p_driver));
-	ERR_FAIL_V(NULL);
+	ERR_FAIL_V_MSG(NULL, "Invalid video driver index: " + itos(p_driver) + ".");
 }
 int OS_Android::get_audio_driver_count() const {
 
@@ -223,10 +222,7 @@ bool OS_Android::request_permission(const String &p_name) {
 
 Error OS_Android::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path) {
 	p_library_handle = dlopen(p_path.utf8().get_data(), RTLD_NOW);
-	if (!p_library_handle) {
-		ERR_EXPLAIN("Can't open dynamic library: " + p_path + ". Error: " + dlerror());
-		ERR_FAIL_V(ERR_CANT_OPEN);
-	}
+	ERR_FAIL_COND_V_MSG(!p_library_handle, ERR_CANT_OPEN, "Can't open dynamic library: " + p_path + ", error: " + dlerror() + ".");
 	return OK;
 }
 

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -768,8 +768,7 @@ Error EditorExportPlatformIOS::_export_additional_assets(const String &p_out_dir
 			DirAccess *da = DirAccess::create_for_path(asset);
 			if (!da) {
 				memdelete(filesystem_da);
-				ERR_EXPLAIN("Can't create directory: " + asset);
-				ERR_FAIL_V(ERR_CANT_CREATE);
+				ERR_FAIL_V_MSG(ERR_CANT_CREATE, "Can't create directory: " + asset + ".");
 			}
 			bool file_exists = da->file_exists(asset);
 			bool dir_exists = da->dir_exists(asset);
@@ -848,8 +847,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	EditorProgress ep("export", "Exporting for iOS", 5, true);
 
 	String team_id = p_preset->get("application/app_store_team_id");
-	ERR_EXPLAIN("App Store Team ID not specified - cannot configure the project.");
-	ERR_FAIL_COND_V(team_id.length() == 0, ERR_CANT_OPEN);
+	ERR_FAIL_COND_V_MSG(team_id.length() == 0, ERR_CANT_OPEN, "App Store Team ID not specified - cannot configure the project.");
 
 	if (p_debug)
 		src_pkg_name = p_preset->get("custom_package/debug");

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -64,8 +64,7 @@ const char *OSIPhone::get_video_driver_name(int p_driver) const {
 		case VIDEO_DRIVER_GLES2:
 			return "GLES2";
 	}
-	ERR_EXPLAIN("Invalid video driver index " + itos(p_driver));
-	ERR_FAIL_V(NULL);
+	ERR_FAIL_V_MSG(NULL, "Invalid video driver index: " + itos(p_driver) + ".");
 };
 
 OSIPhone *OSIPhone::get_singleton() {

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -68,21 +68,18 @@ Error HTTPClient::connect_to_host(const String &p_host, int p_port, bool p_ssl, 
 
 void HTTPClient::set_connection(const Ref<StreamPeer> &p_connection) {
 
-	ERR_EXPLAIN("Accessing an HTTPClient's StreamPeer is not supported for the HTML5 platform");
-	ERR_FAIL();
+	ERR_FAIL_MSG("Accessing an HTTPClient's StreamPeer is not supported for the HTML5 platform.");
 }
 
 Ref<StreamPeer> HTTPClient::get_connection() const {
 
-	ERR_EXPLAIN("Accessing an HTTPClient's StreamPeer is not supported for the HTML5 platform");
-	ERR_FAIL_V(REF());
+	ERR_FAIL_V_MSG(REF(), "Accessing an HTTPClient's StreamPeer is not supported for the HTML5 platform.");
 }
 
 Error HTTPClient::prepare_request(Method p_method, const String &p_url, const Vector<String> &p_headers) {
 
 	ERR_FAIL_INDEX_V(p_method, METHOD_MAX, ERR_INVALID_PARAMETER);
-	ERR_EXPLAIN("HTTP methods TRACE and CONNECT are not supported for the HTML5 platform");
-	ERR_FAIL_COND_V(p_method == METHOD_TRACE || p_method == METHOD_CONNECT, ERR_UNAVAILABLE);
+	ERR_FAIL_COND_V_MSG(p_method == METHOD_TRACE || p_method == METHOD_CONNECT, ERR_UNAVAILABLE, "HTTP methods TRACE and CONNECT are not supported for the HTML5 platform.");
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(host.empty(), ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(port < 0, ERR_UNCONFIGURED);
@@ -201,8 +198,7 @@ PoolByteArray HTTPClient::read_response_body_chunk() {
 
 void HTTPClient::set_blocking_mode(bool p_enable) {
 
-	ERR_EXPLAIN("HTTPClient blocking mode is not supported for the HTML5 platform");
-	ERR_FAIL_COND(p_enable);
+	ERR_FAIL_COND_MSG(p_enable, "HTTPClient blocking mode is not supported for the HTML5 platform.");
 }
 
 bool HTTPClient::is_blocking_mode_enabled() const {

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -192,9 +192,8 @@ void OS_JavaScript::set_window_fullscreen(bool p_enabled) {
 		strategy.filteringMode = EMSCRIPTEN_FULLSCREEN_FILTERING_DEFAULT;
 		strategy.canvasResizedCallback = NULL;
 		EMSCRIPTEN_RESULT result = emscripten_request_fullscreen_strategy(NULL, false, &strategy);
-		ERR_EXPLAIN("Enabling fullscreen is only possible from an input callback for the HTML5 platform");
-		ERR_FAIL_COND(result == EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED);
-		ERR_FAIL_COND(result != EMSCRIPTEN_RESULT_SUCCESS);
+		ERR_FAIL_COND_MSG(result == EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED, "Enabling fullscreen is only possible from an input callback for the HTML5 platform.");
+		ERR_FAIL_COND_MSG(result != EMSCRIPTEN_RESULT_SUCCESS, "Enabling fullscreen is only possible from an input callback for the HTML5 platform.");
 		// Not fullscreen yet, so prevent "windowed" canvas dimensions from
 		// being overwritten.
 		entering_fullscreen = true;
@@ -582,8 +581,7 @@ void OS_JavaScript::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_s
 
 void OS_JavaScript::set_mouse_mode(OS::MouseMode p_mode) {
 
-	ERR_EXPLAIN("MOUSE_MODE_CONFINED is not supported for the HTML5 platform");
-	ERR_FAIL_COND(p_mode == MOUSE_MODE_CONFINED);
+	ERR_FAIL_COND_MSG(p_mode == MOUSE_MODE_CONFINED, "MOUSE_MODE_CONFINED is not supported for the HTML5 platform.");
 	if (p_mode == get_mouse_mode())
 		return;
 
@@ -602,9 +600,8 @@ void OS_JavaScript::set_mouse_mode(OS::MouseMode p_mode) {
 	} else if (p_mode == MOUSE_MODE_CAPTURED) {
 
 		EMSCRIPTEN_RESULT result = emscripten_request_pointerlock("canvas", false);
-		ERR_EXPLAIN("MOUSE_MODE_CAPTURED can only be entered from within an appropriate input callback");
-		ERR_FAIL_COND(result == EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED);
-		ERR_FAIL_COND(result != EMSCRIPTEN_RESULT_SUCCESS);
+		ERR_FAIL_COND_MSG(result == EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED, "MOUSE_MODE_CAPTURED can only be entered from within an appropriate input callback.");
+		ERR_FAIL_COND_MSG(result != EMSCRIPTEN_RESULT_SUCCESS, "MOUSE_MODE_CAPTURED can only be entered from within an appropriate input callback.");
 		// set_css_cursor must be called before set_cursor_shape to make the cursor visible
 		set_css_cursor(godot2dom_cursor(cursor_shape));
 		set_cursor_shape(cursor_shape);
@@ -810,8 +807,7 @@ const char *OS_JavaScript::get_video_driver_name(int p_driver) const {
 		case VIDEO_DRIVER_GLES2:
 			return "GLES2";
 	}
-	ERR_EXPLAIN("Invalid video driver index " + itos(p_driver));
-	ERR_FAIL_V(NULL);
+	ERR_FAIL_V_MSG(NULL, "Invalid video driver index: " + itos(p_driver) + ".");
 }
 
 // Audio
@@ -846,8 +842,7 @@ void OS_JavaScript::set_clipboard(const String &p_text) {
 		return 0;
 	}, p_text.utf8().get_data());
 	/* clang-format on */
-	ERR_EXPLAIN("Clipboard API is not supported.");
-	ERR_FAIL_COND(err);
+	ERR_FAIL_COND_MSG(err, "Clipboard API is not supported.");
 }
 
 String OS_JavaScript::get_clipboard() const {
@@ -1117,20 +1112,17 @@ void OS_JavaScript::finalize() {
 
 Error OS_JavaScript::execute(const String &p_path, const List<String> &p_arguments, bool p_blocking, ProcessID *r_child_id, String *r_pipe, int *r_exitcode, bool read_stderr, Mutex *p_pipe_mutex) {
 
-	ERR_EXPLAIN("OS::execute() is not available on the HTML5 platform");
-	ERR_FAIL_V(ERR_UNAVAILABLE);
+	ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "OS::execute() is not available on the HTML5 platform.");
 }
 
 Error OS_JavaScript::kill(const ProcessID &p_pid) {
 
-	ERR_EXPLAIN("OS::kill() is not available on the HTML5 platform");
-	ERR_FAIL_V(ERR_UNAVAILABLE);
+	ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "OS::kill() is not available on the HTML5 platform.");
 }
 
 int OS_JavaScript::get_process_id() const {
 
-	ERR_EXPLAIN("OS::get_process_id() is not available on the HTML5 platform");
-	ERR_FAIL_V(0);
+	ERR_FAIL_V_MSG(0, "OS::get_process_id() is not available on the HTML5 platform.");
 }
 
 extern "C" EMSCRIPTEN_KEEPALIVE void send_notification(int p_notification) {

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1719,10 +1719,7 @@ Error OS_OSX::open_dynamic_library(const String p_path, void *&p_library_handle,
 	}
 
 	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);
-	if (!p_library_handle) {
-		ERR_EXPLAIN("Can't open dynamic library: " + p_path + ". Error: " + dlerror());
-		ERR_FAIL_V(ERR_CANT_OPEN);
-	}
+	ERR_FAIL_COND_V_MSG(!p_library_handle, ERR_CANT_OPEN, "Can't open dynamic library: " + p_path + ", error: " + dlerror() + ".");
 	return OK;
 }
 
@@ -1962,15 +1959,10 @@ void OS_OSX::set_native_icon(const String &p_filename) {
 	memdelete(f);
 
 	NSData *icon_data = [[[NSData alloc] initWithBytes:&data.write[0] length:len] autorelease];
-	if (!icon_data) {
-		ERR_EXPLAIN("Error reading icon data");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!icon_data, "Error reading icon data.");
+
 	NSImage *icon = [[[NSImage alloc] initWithData:icon_data] autorelease];
-	if (!icon) {
-		ERR_EXPLAIN("Error loading icon");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!icon, "Error loading icon.");
 
 	[NSApp setApplicationIconImage:icon];
 }

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -901,8 +901,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 			String err_string = "Couldn't save temp logo file.";
 
 			EditorNode::add_io_error(err_string);
-			ERR_EXPLAIN(err_string);
-			ERR_FAIL_V(data);
+			ERR_FAIL_V_MSG(data, err_string);
 		}
 
 		FileAccess *f = FileAccess::open(tmp_path, FileAccess::READ, &err);
@@ -912,8 +911,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 			String err_string = "Couldn't open temp logo file.";
 
 			EditorNode::add_io_error(err_string);
-			ERR_EXPLAIN(err_string);
-			ERR_FAIL_V(data);
+			ERR_FAIL_V_MSG(data, err_string);
 		}
 
 		data.resize(f->get_len());
@@ -930,8 +928,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 			String err_string = "Couldn't open temp path to remove temp logo file.";
 
 			EditorNode::add_io_error(err_string);
-			ERR_EXPLAIN(err_string);
-			ERR_FAIL_V(data);
+			ERR_FAIL_V_MSG(data, err_string);
 		}
 
 		err = dir->remove(tmp_path);
@@ -943,8 +940,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 			String err_string = "Couldn't remove temp logo file.";
 
 			EditorNode::add_io_error(err_string);
-			ERR_EXPLAIN(err_string);
-			ERR_FAIL_V(data);
+			ERR_FAIL_V_MSG(data, err_string);
 		}
 
 		return data;

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -835,11 +835,7 @@ Error OS_UWP::open_dynamic_library(const String p_path, void *&p_library_handle,
 
 	String full_path = "game/" + p_path;
 	p_library_handle = (void *)LoadPackagedLibrary(full_path.c_str(), 0);
-
-	if (!p_library_handle) {
-		ERR_EXPLAIN("Can't open dynamic library: " + full_path + ". Error: " + format_error_message(GetLastError()));
-		ERR_FAIL_V(ERR_CANT_OPEN);
-	}
+	ERR_FAIL_COND_V_MSG(!p_library_handle, ERR_CANT_OPEN, "Can't open dynamic library: " + full_path + ", error: " + format_error_message(GetLastError()) + ".");
 	return OK;
 }
 
@@ -854,8 +850,7 @@ Error OS_UWP::get_dynamic_library_symbol_handle(void *p_library_handle, const St
 	p_symbol_handle = (void *)GetProcAddress((HMODULE)p_library_handle, p_name.utf8().get_data());
 	if (!p_symbol_handle) {
 		if (!p_optional) {
-			ERR_EXPLAIN("Can't resolve symbol " + p_name + ". Error: " + String::num(GetLastError()));
-			ERR_FAIL_V(ERR_CANT_RESOLVE);
+			ERR_FAIL_V_MSG(ERR_CANT_RESOLVE, "Can't resolve symbol " + p_name + ", error: " + String::num(GetLastError()) + ".");
 		} else {
 			return ERR_CANT_RESOLVE;
 		}

--- a/platform/x11/export/export.cpp
+++ b/platform/x11/export/export.cpp
@@ -85,8 +85,7 @@ static Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, 
 
 	if (bits == 32 && p_embedded_size >= 0x100000000) {
 		f->close();
-		ERR_EXPLAIN("32-bit executables cannot have embedded data >= 4 GiB");
-		ERR_FAIL_V(ERR_INVALID_DATA);
+		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "32-bit executables cannot have embedded data >= 4 GiB.");
 	}
 
 	// Get info about the section header table


### PR DESCRIPTION
Also turns a few cases where ifs were used to avoid calling `ERR_EXPLAIN` into usages of the new macro, it leaves usages of `ERR_EXPLAIN` in two places in `modules/gdscript/gdscript_parser.cpp` and in  `modules/gdscript/gdscript_editor.cpp` as they were (as they were disjointed from any direct error macro usage).

The two places in question:
https://github.com/godotengine/godot/blob/fe3cd5175589c27c3564224b317bbc0177a5a735/modules/gdscript/gdscript_parser.cpp#L5764
https://github.com/godotengine/godot/blob/fe3cd5175589c27c3564224b317bbc0177a5a735/modules/gdscript/gdscript_editor.cpp#L637

Part of #31207.