### PR TITLE
Add Basis constants and format Transform constants

### DIFF
--- a/core/math/transform.cpp
+++ b/core/math/transform.cpp
@@ -213,3 +213,8 @@ Transform::Transform(const Basis &p_basis, const Vector3 &p_origin) :
 		basis(p_basis),
 		origin(p_origin) {
 }
+
+Transform::Transform(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_t yz, real_t zx, real_t zy, real_t zz, real_t ox, real_t oy, real_t oz) {
+	basis = Basis(xx, xy, xz, yx, yy, yz, zx, zy, zz);
+	origin = Vector3(ox, oy, oz);
+}

--- a/core/math/transform.h
+++ b/core/math/transform.h
@@ -108,6 +108,7 @@ public:
 
 	operator String() const;
 
+	Transform(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_t yz, real_t zx, real_t zy, real_t zz, real_t ox, real_t oy, real_t oz);
 	Transform(const Basis &p_basis, const Vector3 &p_origin = Vector3());
 	Transform() {}
 };

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1955,19 +1955,27 @@ void register_variant_methods() {
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "UP", Vector2(0, -1));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "DOWN", Vector2(0, 1));
 
-	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "IDENTITY", Transform2D(1, 0, 0, 1, 0, 0));
+	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "IDENTITY", Transform2D());
 	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_X", Transform2D(-1, 0, 0, 1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_Y", Transform2D(1, 0, 0, -1, 0, 0));
 
-	Transform identity_transform, transform_x, transform_y, transform_z;
-	identity_transform.set(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0);
+	Transform identity_transform = Transform();
+	Transform flip_x_transform = Transform(-1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0);
+	Transform flip_y_transform = Transform(1, 0, 0, 0, -1, 0, 0, 0, 1, 0, 0, 0);
+	Transform flip_z_transform = Transform(1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0);
 	_VariantCall::add_variant_constant(Variant::TRANSFORM, "IDENTITY", identity_transform);
-	transform_x.set(-1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM, "FLIP_X", transform_x);
-	transform_y.set(1, 0, 0, 0, -1, 0, 0, 0, 1, 0, 0, 0);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM, "FLIP_Y", transform_y);
-	transform_z.set(1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM, "FLIP_Z", transform_z);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM, "FLIP_X", flip_x_transform);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM, "FLIP_Y", flip_y_transform);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM, "FLIP_Z", flip_z_transform);
+
+	Basis identity_basis = Basis();
+	Basis flip_x_basis = Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1);
+	Basis flip_y_basis = Basis(1, 0, 0, 0, -1, 0, 0, 0, 1);
+	Basis flip_z_basis = Basis(1, 0, 0, 0, 1, 0, 0, 0, -1);
+	_VariantCall::add_variant_constant(Variant::BASIS, "IDENTITY", identity_basis);
+	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_X", flip_x_basis);
+	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Y", flip_y_basis);
+	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Z", flip_z_basis);
 
 	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_YZ", Plane(Vector3(1, 0, 0), 0));
 	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XZ", Plane(Vector3(0, 1, 0), 0));

--- a/modules/mono/glue/Managed/Files/Basis.cs
+++ b/modules/mono/glue/Managed/Files/Basis.cs
@@ -12,40 +12,6 @@ namespace Godot
     [StructLayout(LayoutKind.Sequential)]
     public struct Basis : IEquatable<Basis>
     {
-        private static readonly Basis identity = new Basis
-        (
-            1f, 0f, 0f,
-            0f, 1f, 0f,
-            0f, 0f, 1f
-        );
-
-        private static readonly Basis[] orthoBases = {
-            new Basis(1f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f),
-            new Basis(0f, -1f, 0f, 1f, 0f, 0f, 0f, 0f, 1f),
-            new Basis(-1f, 0f, 0f, 0f, -1f, 0f, 0f, 0f, 1f),
-            new Basis(0f, 1f, 0f, -1f, 0f, 0f, 0f, 0f, 1f),
-            new Basis(1f, 0f, 0f, 0f, 0f, -1f, 0f, 1f, 0f),
-            new Basis(0f, 0f, 1f, 1f, 0f, 0f, 0f, 1f, 0f),
-            new Basis(-1f, 0f, 0f, 0f, 0f, 1f, 0f, 1f, 0f),
-            new Basis(0f, 0f, -1f, -1f, 0f, 0f, 0f, 1f, 0f),
-            new Basis(1f, 0f, 0f, 0f, -1f, 0f, 0f, 0f, -1f),
-            new Basis(0f, 1f, 0f, 1f, 0f, 0f, 0f, 0f, -1f),
-            new Basis(-1f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, -1f),
-            new Basis(0f, -1f, 0f, -1f, 0f, 0f, 0f, 0f, -1f),
-            new Basis(1f, 0f, 0f, 0f, 0f, 1f, 0f, -1f, 0f),
-            new Basis(0f, 0f, -1f, 1f, 0f, 0f, 0f, -1f, 0f),
-            new Basis(-1f, 0f, 0f, 0f, 0f, -1f, 0f, -1f, 0f),
-            new Basis(0f, 0f, 1f, -1f, 0f, 0f, 0f, -1f, 0f),
-            new Basis(0f, 0f, 1f, 0f, 1f, 0f, -1f, 0f, 0f),
-            new Basis(0f, -1f, 0f, 0f, 0f, 1f, -1f, 0f, 0f),
-            new Basis(0f, 0f, -1f, 0f, -1f, 0f, -1f, 0f, 0f),
-            new Basis(0f, 1f, 0f, 0f, 0f, -1f, -1f, 0f, 0f),
-            new Basis(0f, 0f, 1f, 0f, -1f, 0f, 1f, 0f, 0f),
-            new Basis(0f, 1f, 0f, 0f, 0f, 1f, 1f, 0f, 0f),
-            new Basis(0f, 0f, -1f, 0f, 1f, 0f, 1f, 0f, 0f),
-            new Basis(0f, -1f, 0f, 0f, 0f, -1f, 1f, 0f, 0f)
-        };
-
         // NOTE: x, y and z are public-only. Use Column0, Column1 and Column2 internally.
 
         /// <summary>
@@ -64,7 +30,6 @@ namespace Godot
         /// </summary>
         public Vector3 y
         {
-
             get => Column1;
             set => Column1 = value;
         }
@@ -75,7 +40,6 @@ namespace Godot
         /// </summary>
         public Vector3 z
         {
-
             get => Column2;
             set => Column2 = value;
         }
@@ -114,8 +78,6 @@ namespace Godot
                 this.Row2.z = value.z;
             }
         }
-
-        public static Basis Identity => identity;
 
         public Vector3 Scale
         {
@@ -361,7 +323,7 @@ namespace Godot
 
             for (int i = 0; i < 24; i++)
             {
-                if (orthoBases[i] == orth)
+                if (orth == _orthoBases[i])
                     return i;
             }
 
@@ -530,6 +492,43 @@ namespace Godot
                 );
             }
         }
+
+        private static readonly Basis[] _orthoBases = {
+            new Basis(1f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f),
+            new Basis(0f, -1f, 0f, 1f, 0f, 0f, 0f, 0f, 1f),
+            new Basis(-1f, 0f, 0f, 0f, -1f, 0f, 0f, 0f, 1f),
+            new Basis(0f, 1f, 0f, -1f, 0f, 0f, 0f, 0f, 1f),
+            new Basis(1f, 0f, 0f, 0f, 0f, -1f, 0f, 1f, 0f),
+            new Basis(0f, 0f, 1f, 1f, 0f, 0f, 0f, 1f, 0f),
+            new Basis(-1f, 0f, 0f, 0f, 0f, 1f, 0f, 1f, 0f),
+            new Basis(0f, 0f, -1f, -1f, 0f, 0f, 0f, 1f, 0f),
+            new Basis(1f, 0f, 0f, 0f, -1f, 0f, 0f, 0f, -1f),
+            new Basis(0f, 1f, 0f, 1f, 0f, 0f, 0f, 0f, -1f),
+            new Basis(-1f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, -1f),
+            new Basis(0f, -1f, 0f, -1f, 0f, 0f, 0f, 0f, -1f),
+            new Basis(1f, 0f, 0f, 0f, 0f, 1f, 0f, -1f, 0f),
+            new Basis(0f, 0f, -1f, 1f, 0f, 0f, 0f, -1f, 0f),
+            new Basis(-1f, 0f, 0f, 0f, 0f, -1f, 0f, -1f, 0f),
+            new Basis(0f, 0f, 1f, -1f, 0f, 0f, 0f, -1f, 0f),
+            new Basis(0f, 0f, 1f, 0f, 1f, 0f, -1f, 0f, 0f),
+            new Basis(0f, -1f, 0f, 0f, 0f, 1f, -1f, 0f, 0f),
+            new Basis(0f, 0f, -1f, 0f, -1f, 0f, -1f, 0f, 0f),
+            new Basis(0f, 1f, 0f, 0f, 0f, -1f, -1f, 0f, 0f),
+            new Basis(0f, 0f, 1f, 0f, -1f, 0f, 1f, 0f, 0f),
+            new Basis(0f, 1f, 0f, 0f, 0f, 1f, 1f, 0f, 0f),
+            new Basis(0f, 0f, -1f, 0f, 1f, 0f, 1f, 0f, 0f),
+            new Basis(0f, -1f, 0f, 0f, 0f, -1f, 1f, 0f, 0f)
+        };
+
+        private static readonly Basis _identity = new Basis(1, 0, 0, 0, 1, 0, 0, 0, 1);
+        private static readonly Basis _flipX = new Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1);
+        private static readonly Basis _flipY = new Basis(1, 0, 0, 0, -1, 0, 0, 0, 1);
+        private static readonly Basis _flipZ = new Basis(1, 0, 0, 0, 1, 0, 0, 0, -1);
+
+        public static Basis Identity { get { return _identity; } }
+        public static Basis FlipX { get { return _flipX; } }
+        public static Basis FlipY { get { return _flipY; } }
+        public static Basis FlipZ { get { return _flipZ; } }
 
         public Basis(Quat quat)
         {


### PR DESCRIPTION
* Add Basis constants IDENTITY, FLIP_X, FLIP_Y, FLIP_Z to core and C#. Fixes https://github.com/godotengine/godot/issues/26682

* Core: Format Transform and Basis constants to be declaration statements with constructors. This IMO makes the code clearer and avoids repeating the variable name. Also, rename the local variables to `flip_x_transform` etc, and add Transform constructor for twelve `real_t`s.

* C#: Move constants above constructors and format just like Vector2/3/etc code.