### PR TITLE
Fix usage of old ERR_FAIL macro when new variant intended.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2743,11 +2743,11 @@ void OS_Windows::set_native_icon(const String &p_filename) {
 
 	SendMessage(hWnd, WM_SETICON, ICON_SMALL, (LPARAM)icon_small);
 	err = GetLastError();
-	ERR_FAIL_COND(err, "Error setting ICON_SMALL: " + format_error_message(err) + ".");
+	ERR_FAIL_COND_MSG(err, "Error setting ICON_SMALL: " + format_error_message(err) + ".");
 
 	SendMessage(hWnd, WM_SETICON, ICON_BIG, (LPARAM)icon_big);
 	err = GetLastError();
-	ERR_FAIL_COND(err, "Error setting ICON_BIG: " + format_error_message(err) + ".");
+	ERR_FAIL_COND_MSG(err, "Error setting ICON_BIG: " + format_error_message(err) + ".");
 
 	memdelete(f);
 	memdelete(icon_dir);


### PR DESCRIPTION
So I managed to get this sin into master with it still building successfully somehow, I'd have expected this to cause a build failure:
https://github.com/godotengine/godot/blob/3ea33c0e455f5e52b73ae5da51d0000e8decef7b/platform/windows/os_windows.cpp#L2744-L2750

I went over the last code changes again and I *think* I didn't leave any more instances like this in.

Relates to #31227