### PR TITLE
Export: Remove temp files from cache after export

### DIFF
--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -97,6 +97,18 @@ public:
 	virtual Error rename(String p_from, String p_to) = 0;
 	virtual Error remove(String p_name) = 0;
 
+	// Meant for editor code when we want to quickly remove a file without custom
+	// handling (e.g. removing a cache file).
+	static void remove_file_or_error(String p_path) {
+		DirAccess *da = create(ACCESS_FILESYSTEM);
+		if (da->file_exists(p_path)) {
+			if (da->remove(p_path) != OK) {
+				ERR_FAIL_MSG("Cannot remove file or directory: " + p_path);
+			}
+		}
+		memdelete(da);
+	}
+
 	virtual String get_filesystem_type() const = 0;
 	static String get_full_path(const String &p_path, AccessType p_access);
 	static DirAccess *create_for_path(const String &p_path);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -422,14 +422,16 @@ void ExportTemplateManager::_http_download_templates_completed(int p_status, int
 				String path = download_templates->get_download_file();
 				template_list_state->set_text(TTR("Download Complete."));
 				template_downloader->hide();
-				int ret = _install_from_file(path, false);
+				bool ret = _install_from_file(path, false);
 				if (ret) {
-					Error err = OS::get_singleton()->move_to_trash(path);
+					// Clean up downloaded file.
+					DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+					Error err = da->remove(path);
 					if (err != OK) {
-						EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:") + "\n" + path + "\n");
+						EditorNode::get_singleton()->add_io_error(TTR("Cannot remove temporary file:") + "\n" + path + "\n");
 					}
 				} else {
-					WARN_PRINTS(vformat(TTR("Templates installation failed. The problematic templates archives can be found at '%s'."), path));
+					EditorNode::get_singleton()->add_io_error(vformat(TTR("Templates installation failed.\nThe problematic templates archives can be found at '%s'."), path));
 				}
 			}
 		} break;
@@ -458,7 +460,7 @@ void ExportTemplateManager::_begin_template_download(const String &p_url) {
 
 	Error err = download_templates->request(p_url);
 	if (err != OK) {
-		EditorNode::get_singleton()->show_warning(TTR("Error requesting url: ") + p_url);
+		EditorNode::get_singleton()->show_warning(TTR("Error requesting URL:") + " " + p_url);
 		return;
 	}
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -354,16 +354,16 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 		} break;
 		case HTTPRequest::RESULT_REQUEST_FAILED: {
 			error_text = TTR("Request failed, return code:") + " " + itos(p_code);
-			status->set_text(TTR("Request Failed."));
+			status->set_text(TTR("Request failed."));
 		} break;
 		case HTTPRequest::RESULT_DOWNLOAD_FILE_CANT_OPEN:
 		case HTTPRequest::RESULT_DOWNLOAD_FILE_WRITE_ERROR: {
-			error_text = TTR("Cannot save response to") + " " + download->get_download_file();
+			error_text = TTR("Cannot save response to:") + " " + download->get_download_file();
 			status->set_text(TTR("Write error."));
 		} break;
 		case HTTPRequest::RESULT_REDIRECT_LIMIT_REACHED: {
 			error_text = TTR("Request failed, too many redirects");
-			status->set_text(TTR("Redirect Loop."));
+			status->set_text(TTR("Redirect loop."));
 		} break;
 		case HTTPRequest::RESULT_TIMEOUT: {
 			error_text = TTR("Request failed, timeout");
@@ -472,9 +472,8 @@ void EditorAssetLibraryItemDownload::_notification(int p_what) {
 }
 void EditorAssetLibraryItemDownload::_close() {
 
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	da->remove(download->get_download_file()); //clean up removed file
-	memdelete(da);
+	// Clean up downloaded file.
+	DirAccess::remove_file_or_error(download->get_download_file());
 	queue_delete();
 }
 

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/file_access_encrypted.h"
 #include "core/io/resource_loader.h"
+#include "core/os/dir_access.h"
 #include "core/os/file_access.h"
 #include "editor/gdscript_highlighter.h"
 #include "gdscript.h"
@@ -116,6 +117,9 @@ public:
 
 				file = FileAccess::get_file_as_array(tmp_path);
 				add_file(p_path.get_basename() + ".gde", file, true);
+
+				// Clean up temporary file.
+				DirAccess::remove_file_or_error(tmp_path);
 
 			} else {
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -362,12 +362,21 @@ int EditorExportPlatformJavaScript::get_device_count() const {
 
 Error EditorExportPlatformJavaScript::run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) {
 
-	String path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp_export.html");
+	String basepath = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp_js_export");
+	String path = basepath + ".html";
 	Error err = export_project(p_preset, true, path, p_debug_flags);
-	if (err) {
+	if (err != OK) {
+		// Export generates several files, clean them up on failure.
+		DirAccess::remove_file_or_error(basepath + ".html");
+		DirAccess::remove_file_or_error(basepath + ".js");
+		DirAccess::remove_file_or_error(basepath + ".pck");
+		DirAccess::remove_file_or_error(basepath + ".png");
+		DirAccess::remove_file_or_error(basepath + ".wasm");
 		return err;
 	}
 	OS::get_singleton()->shell_open(String("file://") + path);
+	// FIXME: Find out how to clean up export files after running the successfully
+	// exported game. Might not be trivial.
 	return OK;
 }
 

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -34,6 +34,7 @@
 #include "core/io/zip_io.h"
 #include "core/math/crypto_core.h"
 #include "core/object.h"
+#include "core/os/dir_access.h"
 #include "core/os/file_access.h"
 #include "core/project_settings.h"
 #include "core/version.h"
@@ -133,8 +134,6 @@ class AppxPackager {
 
 	String progress_task;
 	FileAccess *package;
-	String tmp_blockmap_file_path;
-	String tmp_content_types_file_path;
 
 	Set<String> mime_types;
 
@@ -146,8 +145,8 @@ class AppxPackager {
 
 	String hash_block(const uint8_t *p_block_data, size_t p_block_len);
 
-	void make_block_map();
-	void make_content_types();
+	void make_block_map(const String &p_path);
+	void make_content_types(const String &p_path);
 
 	_FORCE_INLINE_ unsigned int buf_put_int16(uint16_t p_val, uint8_t *p_buf) {
 		for (int i = 0; i < 2; i++) {
@@ -208,9 +207,9 @@ String AppxPackager::hash_block(const uint8_t *p_block_data, size_t p_block_len)
 	return String(base64);
 }
 
-void AppxPackager::make_block_map() {
+void AppxPackager::make_block_map(const String &p_path) {
 
-	FileAccess *tmp_file = FileAccess::open(tmp_blockmap_file_path, FileAccess::WRITE);
+	FileAccess *tmp_file = FileAccess::open(p_path, FileAccess::WRITE);
 
 	tmp_file->store_string("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>");
 	tmp_file->store_string("<BlockMap xmlns=\"http://schemas.microsoft.com/appx/2010/blockmap\" HashMethod=\"http://www.w3.org/2001/04/xmlenc#sha256\">");
@@ -253,9 +252,9 @@ String AppxPackager::content_type(String p_extension) {
 		return "application/octet-stream";
 }
 
-void AppxPackager::make_content_types() {
+void AppxPackager::make_content_types(const String &p_path) {
 
-	FileAccess *tmp_file = FileAccess::open(tmp_content_types_file_path, FileAccess::WRITE);
+	FileAccess *tmp_file = FileAccess::open(p_path, FileAccess::WRITE);
 
 	tmp_file->store_string("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
 	tmp_file->store_string("<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">");
@@ -458,8 +457,6 @@ void AppxPackager::init(FileAccess *p_fa) {
 	package = p_fa;
 	central_dir_offset = 0;
 	end_of_central_dir_offset = 0;
-	tmp_blockmap_file_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmpblockmap.xml");
-	tmp_content_types_file_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmpcontenttypes.xml");
 }
 
 Error AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t p_len, int p_file_no, int p_total_files, bool p_compress) {
@@ -591,7 +588,9 @@ void AppxPackager::finish() {
 	// Create and add block map file
 	EditorNode::progress_task_step("export", "Creating block map...", 4);
 
-	make_block_map();
+	const String &tmp_blockmap_file_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmpblockmap.xml");
+	make_block_map(tmp_blockmap_file_path);
+
 	FileAccess *blockmap_file = FileAccess::open(tmp_blockmap_file_path, FileAccess::READ);
 	Vector<uint8_t> blockmap_buffer;
 	blockmap_buffer.resize(blockmap_file->get_len());
@@ -604,8 +603,11 @@ void AppxPackager::finish() {
 	memdelete(blockmap_file);
 
 	// Add content types
+
 	EditorNode::progress_task_step("export", "Setting content types...", 5);
-	make_content_types();
+
+	const String &tmp_content_types_file_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmpcontenttypes.xml");
+	make_content_types(tmp_content_types_file_path);
 
 	FileAccess *types_file = FileAccess::open(tmp_content_types_file_path, FileAccess::READ);
 	Vector<uint8_t> types_buffer;
@@ -617,6 +619,10 @@ void AppxPackager::finish() {
 
 	types_file->close();
 	memdelete(types_file);
+
+	// Cleanup generated files.
+	DirAccess::remove_file_or_error(tmp_blockmap_file_path);
+	DirAccess::remove_file_or_error(tmp_content_types_file_path);
 
 	// Pre-process central directory before signing
 	for (int i = 0; i < file_metadata.size(); i++) {
@@ -909,7 +915,8 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		if (err != OK) {
 
 			String err_string = "Couldn't open temp logo file.";
-
+			// Cleanup generated file.
+			DirAccess::remove_file_or_error(tmp_path);
 			EditorNode::add_io_error(err_string);
 			ERR_FAIL_V_MSG(data, err_string);
 		}
@@ -919,29 +926,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 
 		f->close();
 		memdelete(f);
-
-		// Delete temp file
-		DirAccess *dir = DirAccess::open(tmp_path.get_base_dir(), &err);
-
-		if (err != OK) {
-
-			String err_string = "Couldn't open temp path to remove temp logo file.";
-
-			EditorNode::add_io_error(err_string);
-			ERR_FAIL_V_MSG(data, err_string);
-		}
-
-		err = dir->remove(tmp_path);
-
-		memdelete(dir);
-
-		if (err != OK) {
-
-			String err_string = "Couldn't remove temp logo file.";
-
-			EditorNode::add_io_error(err_string);
-			ERR_FAIL_V_MSG(data, err_string);
-		}
+		DirAccess::remove_file_or_error(tmp_path);
 
 		return data;
 	}


### PR DESCRIPTION
So far we left most temporary files lying around, so this attempts to
fix that.

I added a helper method to DirAccess to factor out the boilerplate of
creating a DirAccess, checking if the file exists, remove it or print
an error on failure.

---

Note: I haven't tested the new code much yet, I'll try PC and Android exports to see if things behave as expected.