### PR TITLE
Replace 'ERR_EXPLAIN' with 'ERR_FAIL_*_MSG' in 'core/' and 'editor/'

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -133,18 +133,12 @@ void Array::erase(const Variant &p_value) {
 }
 
 Variant Array::front() const {
-	if (_p->array.size() == 0) {
-		ERR_EXPLAIN("Can't take value from empty array");
-		ERR_FAIL_V(Variant());
-	}
+	ERR_FAIL_COND_V_MSG(_p->array.size() == 0, Variant(), "Can't take value from empty array.");
 	return operator[](0);
 }
 
 Variant Array::back() const {
-	if (_p->array.size() == 0) {
-		ERR_EXPLAIN("Can't take value from empty array");
-		ERR_FAIL_V(Variant());
-	}
+	ERR_FAIL_COND_V_MSG(_p->array.size() == 0, Variant(), "Can't take value from empty array.");
 	return operator[](_p->array.size() - 1);
 }
 

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -73,10 +73,7 @@ RES _ResourceLoader::load(const String &p_path, const String &p_type_hint, bool 
 	Error err = OK;
 	RES ret = ResourceLoader::load(p_path, p_type_hint, p_no_cache, &err);
 
-	if (err != OK) {
-		ERR_EXPLAIN("Error loading resource: '" + p_path + "'");
-		ERR_FAIL_V(ret);
-	}
+	ERR_FAIL_COND_V_MSG(err != OK, ret, "Error loading resource: '" + p_path + "'.");
 	return ret;
 }
 
@@ -148,10 +145,7 @@ _ResourceLoader::_ResourceLoader() {
 }
 
 Error _ResourceSaver::save(const String &p_path, const RES &p_resource, SaverFlags p_flags) {
-	if (p_resource.is_null()) {
-		ERR_EXPLAIN("Can't save empty resource to path: " + String(p_path))
-		ERR_FAIL_V(ERR_INVALID_PARAMETER);
-	}
+	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, "Can't save empty resource to path: " + String(p_path) + ".");
 	return ResourceSaver::save(p_path, p_resource, p_flags);
 }
 
@@ -727,22 +721,16 @@ int64_t _OS::get_unix_time_from_datetime(Dictionary datetime) const {
 		{ 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 }
 	};
 
-	ERR_EXPLAIN("Invalid second value of: " + itos(second));
-	ERR_FAIL_COND_V(second > 59, 0);
+	ERR_FAIL_COND_V_MSG(second > 59, 0, "Invalid second value of: " + itos(second) + ".");
 
-	ERR_EXPLAIN("Invalid minute value of: " + itos(minute));
-	ERR_FAIL_COND_V(minute > 59, 0);
+	ERR_FAIL_COND_V_MSG(minute > 59, 0, "Invalid minute value of: " + itos(minute) + ".");
 
-	ERR_EXPLAIN("Invalid hour value of: " + itos(hour));
-	ERR_FAIL_COND_V(hour > 23, 0);
+	ERR_FAIL_COND_V_MSG(hour > 23, 0, "Invalid hour value of: " + itos(hour) + ".");
 
-	ERR_EXPLAIN("Invalid month value of: " + itos(month));
-	ERR_FAIL_COND_V(month > 12 || month == 0, 0);
+	ERR_FAIL_COND_V_MSG(month > 12 || month == 0, 0, "Invalid month value of: " + itos(month) + ".");
 
 	// Do this check after month is tested as valid
-	ERR_EXPLAIN("Invalid day value of: " + itos(day) + " which is larger than " + itos(MONTH_DAYS_TABLE[LEAPYEAR(year)][month - 1]) + " or 0");
-	ERR_FAIL_COND_V(day > MONTH_DAYS_TABLE[LEAPYEAR(year)][month - 1] || day == 0, 0);
-
+	ERR_FAIL_COND_V_MSG(day > MONTH_DAYS_TABLE[LEAPYEAR(year)][month - 1] || day == 0, 0, "Invalid day value of: " + itos(day) + " which is larger than " + itos(MONTH_DAYS_TABLE[LEAPYEAR(year)][month - 1]) + " or 0.");
 	// Calculate all the seconds from months past in this year
 	uint64_t SECONDS_FROM_MONTHS_PAST_THIS_YEAR = DAYS_PAST_THIS_YEAR_TABLE[LEAPYEAR(year)][month - 1] * SECONDS_PER_DAY;
 
@@ -2621,8 +2609,7 @@ void _Thread::_start_func(void *ud) {
 			}
 		}
 
-		ERR_EXPLAIN("Could not call function '" + t->target_method.operator String() + "'' starting thread ID: " + t->get_id() + " Reason: " + reason);
-		ERR_FAIL();
+		ERR_FAIL_MSG("Could not call function '" + t->target_method.operator String() + "'' starting thread ID: " + t->get_id() + " Reason: " + reason + ".");
 	}
 }
 
@@ -2704,10 +2691,7 @@ _Thread::_Thread() {
 
 _Thread::~_Thread() {
 
-	if (active) {
-		ERR_EXPLAIN("Reference to a Thread object object was lost while the thread is still running...");
-	}
-	ERR_FAIL_COND(active);
+	ERR_FAIL_COND_MSG(active, "Reference to a Thread object object was lost while the thread is still running...");
 }
 /////////////////////////////////////
 

--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -836,10 +836,7 @@ void ClassDB::add_signal(StringName p_class, const MethodInfo &p_signal) {
 #ifdef DEBUG_METHODS_ENABLED
 	ClassInfo *check = type;
 	while (check) {
-		if (check->signal_map.has(sname)) {
-			ERR_EXPLAIN("Type " + String(p_class) + " already has signal: " + String(sname));
-			ERR_FAIL();
-		}
+		ERR_FAIL_COND_MSG(check->signal_map.has(sname), "Type " + String(p_class) + " already has signal: " + String(sname) + ".");
 		check = check->inherits_ptr;
 	}
 #endif
@@ -924,16 +921,11 @@ void ClassDB::add_property(StringName p_class, const PropertyInfo &p_pinfo, cons
 	if (p_setter) {
 		mb_set = get_method(p_class, p_setter);
 #ifdef DEBUG_METHODS_ENABLED
-		if (!mb_set) {
-			ERR_EXPLAIN("Invalid Setter: " + p_class + "::" + p_setter + " for property: " + p_pinfo.name);
-			ERR_FAIL();
-		} else {
-			int exp_args = 1 + (p_index >= 0 ? 1 : 0);
-			if (mb_set->get_argument_count() != exp_args) {
-				ERR_EXPLAIN("Invalid Function for Setter: " + p_class + "::" + p_setter + " for property: " + p_pinfo.name);
-				ERR_FAIL();
-			}
-		}
+
+		ERR_FAIL_COND_MSG(!mb_set, "Invalid setter: " + p_class + "::" + p_setter + " for property: " + p_pinfo.name + ".");
+
+		int exp_args = 1 + (p_index >= 0 ? 1 : 0);
+		ERR_FAIL_COND_MSG(mb_set->get_argument_count() != exp_args, "Invalid function for setter: " + p_class + "::" + p_setter + " for property: " + p_pinfo.name + ".");
 #endif
 	}
 
@@ -943,25 +935,15 @@ void ClassDB::add_property(StringName p_class, const PropertyInfo &p_pinfo, cons
 		mb_get = get_method(p_class, p_getter);
 #ifdef DEBUG_METHODS_ENABLED
 
-		if (!mb_get) {
-			ERR_EXPLAIN("Invalid Getter: " + p_class + "::" + p_getter + " for property: " + p_pinfo.name);
-			ERR_FAIL();
-		} else {
+		ERR_FAIL_COND_MSG(!mb_get, "Invalid getter: " + p_class + "::" + p_getter + " for property: " + p_pinfo.name + ".");
 
-			int exp_args = 0 + (p_index >= 0 ? 1 : 0);
-			if (mb_get->get_argument_count() != exp_args) {
-				ERR_EXPLAIN("Invalid Function for Getter: " + p_class + "::" + p_getter + " for property: " + p_pinfo.name);
-				ERR_FAIL();
-			}
-		}
+		int exp_args = 0 + (p_index >= 0 ? 1 : 0);
+		ERR_FAIL_COND_MSG(mb_get->get_argument_count() != exp_args, "Invalid function for getter: " + p_class + "::" + p_getter + " for property: " + p_pinfo.name + ".");
 #endif
 	}
 
 #ifdef DEBUG_METHODS_ENABLED
-	if (type->property_setget.has(p_pinfo.name)) {
-		ERR_EXPLAIN("Object " + p_class + " already has property: " + p_pinfo.name);
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(type->property_setget.has(p_pinfo.name), "Object " + p_class + " already has property: " + p_pinfo.name + ".");
 #endif
 
 	OBJTYPE_WLOCK
@@ -1240,32 +1222,26 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const c
 
 #ifdef DEBUG_ENABLED
 
-	if (has_method(instance_type, mdname)) {
-		ERR_EXPLAIN("Class " + String(instance_type) + " already has a method " + String(mdname));
-		ERR_FAIL_V(NULL);
-	}
+	ERR_FAIL_COND_V_MSG(has_method(instance_type, mdname), NULL, "Class " + String(instance_type) + " already has a method " + String(mdname) + ".");
 #endif
 
 	ClassInfo *type = classes.getptr(instance_type);
 	if (!type) {
-		ERR_PRINTS("Couldn't bind method '" + mdname + "' for instance: " + instance_type);
 		memdelete(p_bind);
-		ERR_FAIL_V(NULL);
+		ERR_FAIL_V_MSG(NULL, "Couldn't bind method '" + mdname + "' for instance: " + instance_type + ".");
 	}
 
 	if (type->method_map.has(mdname)) {
 		memdelete(p_bind);
 		// overloading not supported
-		ERR_EXPLAIN("Method already bound: " + instance_type + "::" + mdname);
-		ERR_FAIL_V(NULL);
+		ERR_FAIL_V_MSG(NULL, "Method already bound: " + instance_type + "::" + mdname + ".");
 	}
 
 #ifdef DEBUG_METHODS_ENABLED
 
 	if (method_name.args.size() > p_bind->get_argument_count()) {
 		memdelete(p_bind);
-		ERR_EXPLAIN("Method definition provides more arguments than the method actually has: " + instance_type + "::" + mdname);
-		ERR_FAIL_V(NULL);
+		ERR_FAIL_V_MSG(NULL, "Method definition provides more arguments than the method actually has: " + instance_type + "::" + mdname + ".");
 	}
 
 	p_bind->set_argument_names(method_name.args);

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -306,8 +306,7 @@ public:
 		if (type->method_map.has(p_name)) {
 			memdelete(bind);
 			// overloading not supported
-			ERR_EXPLAIN("Method already bound: " + instance_type + "::" + p_name);
-			ERR_FAIL_V(NULL);
+			ERR_FAIL_V_MSG(NULL, "Method already bound: " + instance_type + "::" + p_name + ".");
 		}
 		type->method_map[p_name] = bind;
 #ifdef DEBUG_METHODS_ENABLED

--- a/core/color.cpp
+++ b/core/color.cpp
@@ -335,36 +335,23 @@ Color Color::html(const String &p_color) {
 	} else if (color.length() == 6) {
 		alpha = false;
 	} else {
-		ERR_EXPLAIN("Invalid Color Code: " + p_color);
-		ERR_FAIL_V(Color());
+		ERR_FAIL_V_MSG(Color(), "Invalid color code: " + p_color + ".");
 	}
 
 	int a = 255;
 	if (alpha) {
 		a = _parse_col(color, 0);
-		if (a < 0) {
-			ERR_EXPLAIN("Invalid Color Code: " + p_color);
-			ERR_FAIL_V(Color());
-		}
+		ERR_FAIL_COND_V_MSG(a < 0, Color(), "Invalid color code: " + p_color + ".");
 	}
 
 	int from = alpha ? 2 : 0;
 
 	int r = _parse_col(color, from + 0);
-	if (r < 0) {
-		ERR_EXPLAIN("Invalid Color Code: " + p_color);
-		ERR_FAIL_V(Color());
-	}
+	ERR_FAIL_COND_V_MSG(r < 0, Color(), "Invalid color code: " + p_color + ".");
 	int g = _parse_col(color, from + 2);
-	if (g < 0) {
-		ERR_EXPLAIN("Invalid Color Code: " + p_color);
-		ERR_FAIL_V(Color());
-	}
+	ERR_FAIL_COND_V_MSG(g < 0, Color(), "Invalid color code: " + p_color + ".");
 	int b = _parse_col(color, from + 4);
-	if (b < 0) {
-		ERR_EXPLAIN("Invalid Color Code: " + p_color);
-		ERR_FAIL_V(Color());
-	}
+	ERR_FAIL_COND_V_MSG(b < 0, Color(), "Invalid color code: " + p_color + ".");
 
 	return Color(r / 255.0, g / 255.0, b / 255.0, a / 255.0);
 }
@@ -425,12 +412,8 @@ Color Color::named(const String &p_name) {
 	name = name.to_lower();
 
 	const Map<String, Color>::Element *color = _named_colors.find(name);
-	if (color) {
-		return color->value();
-	} else {
-		ERR_EXPLAIN("Invalid Color Name: " + p_name);
-		ERR_FAIL_V(Color());
-	}
+	ERR_FAIL_NULL_V_MSG(color, Color(), "Invalid color name: " + p_name + ".");
+	return color->value();
 }
 
 String _to_hex(float p_val) {
@@ -523,8 +506,7 @@ Color Color::from_hsv(float p_h, float p_s, float p_v, float p_a) const {
 // FIXME: Remove once Godot 3.1 has been released
 float Color::gray() const {
 
-	ERR_EXPLAIN("Color.gray() is deprecated and will be removed in a future version. Use Color.get_v() for a better grayscale approximation.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("Color.gray() is deprecated and will be removed in a future version. Use Color.get_v() for a better grayscale approximation.");
 	return (r + g + b) / 3.0;
 }
 

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -197,10 +197,7 @@ void Engine::add_singleton(const Singleton &p_singleton) {
 Object *Engine::get_singleton_object(const String &p_name) const {
 
 	const Map<StringName, Object *>::Element *E = singleton_ptrs.find(p_name);
-	if (!E) {
-		ERR_EXPLAIN("Failed to retrieve non-existent singleton '" + p_name + "'");
-		ERR_FAIL_V(NULL);
-	}
+	ERR_FAIL_COND_V_MSG(!E, NULL, "Failed to retrieve non-existent singleton '" + p_name + "'.");
 	return E->get();
 };
 

--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -151,11 +151,7 @@ private:
 			return;
 
 		Element **new_hash_table = memnew_arr(Element *, ((uint64_t)1 << new_hash_table_power));
-		if (!new_hash_table) {
-
-			ERR_PRINT("Out of Memory");
-			return;
-		}
+		ERR_FAIL_COND_MSG(!new_hash_table, "Out of memory.");
 
 		for (int i = 0; i < (1 << new_hash_table_power); i++) {
 
@@ -208,10 +204,7 @@ private:
 
 		/* if element doesn't exist, create it */
 		Element *e = memnew(Element);
-		if (!e) {
-			ERR_EXPLAIN("Out of memory");
-			ERR_FAIL_V(NULL);
-		}
+		ERR_FAIL_COND_V_MSG(!e, NULL, "Out of memory.");
 		uint32_t hash = Hasher::hash(p_key);
 		uint32_t index = hash & ((1 << hash_table_power) - 1);
 		e->next = hash_table[index];
@@ -498,10 +491,7 @@ public:
 		} else { /* get the next key */
 
 			const Element *e = get_element(*p_key);
-			if (!e) {
-				ERR_EXPLAIN("Invalid key supplied")
-				ERR_FAIL_V(NULL);
-			}
+			ERR_FAIL_COND_V_MSG(!e, NULL, "Invalid key supplied.");
 			if (e->next) {
 				/* if there is a "next" in the list, return that */
 				return &e->next->pair.key;

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -423,8 +423,7 @@ void Image::convert(Format p_new_format) {
 
 	if (format > FORMAT_RGBE9995 || p_new_format > FORMAT_RGBE9995) {
 
-		ERR_EXPLAIN("Cannot convert to <-> from compressed formats. Use compress() and decompress() instead.");
-		ERR_FAIL();
+		ERR_FAIL_MSG("Cannot convert to <-> from compressed formats. Use compress() and decompress() instead.");
 
 	} else if (format > FORMAT_RGBA8 || p_new_format > FORMAT_RGBA8) {
 
@@ -864,10 +863,7 @@ bool Image::is_size_po2() const {
 
 void Image::resize_to_po2(bool p_square) {
 
-	if (!_can_modify(format)) {
-		ERR_EXPLAIN("Cannot resize in indexed, compressed or custom image formats.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot resize in indexed, compressed or custom image formats.");
 
 	int w = next_power_of_2(width);
 	int h = next_power_of_2(height);
@@ -883,15 +879,9 @@ void Image::resize_to_po2(bool p_square) {
 
 void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
-	if (data.size() == 0) {
-		ERR_EXPLAIN("Cannot resize image before creating it, use create() or create_from_data() first.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(data.size() == 0, "Cannot resize image before creating it, use create() or create_from_data() first.");
 
-	if (!_can_modify(format)) {
-		ERR_EXPLAIN("Cannot resize in indexed, compressed or custom image formats.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot resize in indexed, compressed or custom image formats.");
 
 	bool mipmap_aware = p_interpolation == INTERPOLATE_TRILINEAR /* || p_interpolation == INTERPOLATE_TRICUBIC */;
 
@@ -1104,10 +1094,8 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
 void Image::crop_from_point(int p_x, int p_y, int p_width, int p_height) {
 
-	if (!_can_modify(format)) {
-		ERR_EXPLAIN("Cannot crop in indexed, compressed or custom image formats.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot crop in indexed, compressed or custom image formats.");
+
 	ERR_FAIL_COND(p_x < 0);
 	ERR_FAIL_COND(p_y < 0);
 	ERR_FAIL_COND(p_width <= 0);
@@ -1161,10 +1149,7 @@ void Image::crop(int p_width, int p_height) {
 
 void Image::flip_y() {
 
-	if (!_can_modify(format)) {
-		ERR_EXPLAIN("Cannot flip_y in indexed, compressed or custom image formats.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot flip_y in indexed, compressed or custom image formats.");
 
 	bool used_mipmaps = has_mipmaps();
 	if (used_mipmaps) {
@@ -1197,10 +1182,7 @@ void Image::flip_y() {
 
 void Image::flip_x() {
 
-	if (!_can_modify(format)) {
-		ERR_EXPLAIN("Cannot flip_x in indexed, compressed or custom image formats.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot flip_x in indexed, compressed or custom image formats.");
 
 	bool used_mipmaps = has_mipmaps();
 	if (used_mipmaps) {
@@ -1459,15 +1441,9 @@ void Image::normalize() {
 
 Error Image::generate_mipmaps(bool p_renormalize) {
 
-	if (!_can_modify(format)) {
-		ERR_EXPLAIN("Cannot generate mipmaps in indexed, compressed or custom image formats.");
-		ERR_FAIL_V(ERR_UNAVAILABLE);
-	}
+	ERR_FAIL_COND_V_MSG(!_can_modify(format), ERR_UNAVAILABLE, "Cannot generate mipmaps in indexed, compressed or custom image formats.");
 
-	if (width == 0 || height == 0) {
-		ERR_EXPLAIN("Cannot generate mipmaps with width or height equal to 0.");
-		ERR_FAIL_V(ERR_UNCONFIGURED);
-	}
+	ERR_FAIL_COND_V_MSG(width == 0 || height == 0, ERR_UNCONFIGURED, "Cannot generate mipmaps with width or height equal to 0.");
 
 	int mmcount;
 
@@ -1618,10 +1594,7 @@ void Image::create(int p_width, int p_height, bool p_use_mipmaps, Format p_forma
 	int mm;
 	int size = _get_dst_image_size(p_width, p_height, p_format, mm, p_use_mipmaps ? -1 : 0);
 
-	if (size != p_data.size()) {
-		ERR_EXPLAIN("Expected data size of " + itos(size) + " bytes in Image::create(), got instead " + itos(p_data.size()) + " bytes.");
-		ERR_FAIL_COND(p_data.size() != size);
-	}
+	ERR_FAIL_COND_MSG(p_data.size() != size, "Expected data size of " + itos(size) + " bytes in Image::create(), got instead " + itos(p_data.size()) + " bytes.");
 
 	height = p_height;
 	width = p_width;
@@ -2411,10 +2384,7 @@ Color Image::get_pixel(int p_x, int p_y) const {
 
 	uint8_t *ptr = write_lock.ptr();
 #ifdef DEBUG_ENABLED
-	if (!ptr) {
-		ERR_EXPLAIN("Image must be locked with 'lock()' before using get_pixel()");
-		ERR_FAIL_V(Color());
-	}
+	ERR_FAIL_COND_V_MSG(!ptr, Color(), "Image must be locked with 'lock()' before using get_pixel().");
 
 	ERR_FAIL_INDEX_V(p_x, width, Color());
 	ERR_FAIL_INDEX_V(p_y, height, Color());
@@ -2530,8 +2500,7 @@ Color Image::get_pixel(int p_x, int p_y) const {
 			return Color::from_rgbe9995(((uint32_t *)ptr)[ofs]);
 		}
 		default: {
-			ERR_EXPLAIN("Can't get_pixel() on compressed image, sorry.");
-			ERR_FAIL_V(Color());
+			ERR_FAIL_V_MSG(Color(), "Can't get_pixel() on compressed image, sorry.");
 		}
 	}
 }
@@ -2544,10 +2513,7 @@ void Image::set_pixel(int p_x, int p_y, const Color &p_color) {
 
 	uint8_t *ptr = write_lock.ptr();
 #ifdef DEBUG_ENABLED
-	if (!ptr) {
-		ERR_EXPLAIN("Image must be locked with 'lock()' before using set_pixel()");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!ptr, "Image must be locked with 'lock()' before using set_pixel().");
 
 	ERR_FAIL_INDEX(p_x, width);
 	ERR_FAIL_INDEX(p_y, height);
@@ -2659,8 +2625,7 @@ void Image::set_pixel(int p_x, int p_y, const Color &p_color) {
 
 		} break;
 		default: {
-			ERR_EXPLAIN("Can't set_pixel() on compressed image, sorry.");
-			ERR_FAIL();
+			ERR_FAIL_MSG("Can't set_pixel() on compressed image, sorry.");
 		}
 	}
 }

--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -192,10 +192,7 @@ bool InputMap::event_is_action(const Ref<InputEvent> &p_event, const StringName 
 
 bool InputMap::event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool *p_pressed, float *p_strength) const {
 	Map<StringName, Action>::Element *E = input_map.find(p_action);
-	if (!E) {
-		ERR_EXPLAIN("Request for nonexistent InputMap action: " + String(p_action));
-		ERR_FAIL_V(false);
-	}
+	ERR_FAIL_COND_V_MSG(!E, false, "Request for nonexistent InputMap action: " + String(p_action) + ".");
 
 	Ref<InputEventAction> input_event_action = p_event;
 	if (input_event_action.is_valid()) {

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -86,10 +86,7 @@ void ConfigFile::set_value(const String &p_section, const String &p_key, const V
 Variant ConfigFile::get_value(const String &p_section, const String &p_key, Variant p_default) const {
 
 	if (!values.has(p_section) || !values[p_section].has(p_key)) {
-		if (p_default.get_type() == Variant::NIL) {
-			ERR_EXPLAIN("Couldn't find the given section/key and no default was given");
-			ERR_FAIL_V(p_default);
-		}
+		ERR_FAIL_COND_V_MSG(p_default.get_type() == Variant::NIL, p_default, "Couldn't find the given section/key and no default was given.");
 		return p_default;
 	}
 	return values[p_section][p_key];
@@ -271,7 +268,7 @@ Error ConfigFile::_internal_load(const String &p_path, FileAccess *f) {
 			memdelete(f);
 			return OK;
 		} else if (err != OK) {
-			ERR_PRINTS("ConfgFile::load - " + p_path + ":" + itos(lines) + " error: " + error_text);
+			ERR_PRINTS("ConfgFile::load - " + p_path + ":" + itos(lines) + " error: " + error_text + ".");
 			memdelete(f);
 			return err;
 		}

--- a/core/io/file_access_buffered.cpp
+++ b/core/io/file_access_buffered.cpp
@@ -87,10 +87,8 @@ bool FileAccessBuffered::eof_reached() const {
 }
 
 uint8_t FileAccessBuffered::get_8() const {
-	if (!file.open) {
-		ERR_EXPLAIN("Can't get data, when file is not opened.");
-		ERR_FAIL_V(0);
-	}
+
+	ERR_FAIL_COND_V_MSG(!file.open, 0, "Can't get data, when file is not opened.");
 
 	uint8_t byte = 0;
 	if (cache_data_left() >= 1) {
@@ -104,10 +102,8 @@ uint8_t FileAccessBuffered::get_8() const {
 }
 
 int FileAccessBuffered::get_buffer(uint8_t *p_dest, int p_length) const {
-	if (!file.open) {
-		ERR_EXPLAIN("Can't get buffer, when file is not opened.");
-		ERR_FAIL_V(-1);
-	}
+
+	ERR_FAIL_COND_V_MSG(!file.open, -1, "Can't get buffer, when file is not opened.");
 
 	if (p_length > cache_size) {
 

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -94,8 +94,7 @@ Error FileAccessEncrypted::open_and_parse(FileAccess *p_base, const Vector<uint8
 		unsigned char hash[16];
 		ERR_FAIL_COND_V(CryptoCore::md5(data.ptr(), data.size(), hash) != OK, ERR_BUG);
 
-		ERR_EXPLAIN("The MD5 sum of the decrypted file does not match the expected value. It could be that the file is corrupt, or that the provided decryption key is invalid.");
-		ERR_FAIL_COND_V(String::md5(hash) != String::md5(md5d), ERR_FILE_CORRUPT);
+		ERR_FAIL_COND_V_MSG(String::md5(hash) != String::md5(md5d), ERR_FILE_CORRUPT, "The MD5 sum of the decrypted file does not match the expected value. It could be that the file is corrupt, or that the provided decryption key is invalid.");
 
 		file = p_base;
 	}
@@ -298,7 +297,7 @@ uint32_t FileAccessEncrypted::_get_unix_permissions(const String &p_file) {
 }
 
 Error FileAccessEncrypted::_set_unix_permissions(const String &p_file, uint32_t p_permissions) {
-	ERR_PRINT("Setting UNIX permissions on encrypted files is not implemented yet");
+	ERR_PRINT("Setting UNIX permissions on encrypted files is not implemented yet.");
 	return ERR_UNAVAILABLE;
 }
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -171,10 +171,8 @@ bool PackedSourcePCK::try_open_pack(const String &p_path) {
 	uint32_t ver_minor = f->get_32();
 	f->get_32(); // ver_rev
 
-	ERR_EXPLAIN("Pack version unsupported: " + itos(version));
-	ERR_FAIL_COND_V(version != PACK_VERSION, false);
-	ERR_EXPLAIN("Pack created with a newer version of the engine: " + itos(ver_major) + "." + itos(ver_minor));
-	ERR_FAIL_COND_V(ver_major > VERSION_MAJOR || (ver_major == VERSION_MAJOR && ver_minor > VERSION_MINOR), false);
+	ERR_FAIL_COND_V_MSG(version != PACK_VERSION, false, "Pack version unsupported: " + itos(version) + ".");
+	ERR_FAIL_COND_V_MSG(ver_major > VERSION_MAJOR || (ver_major == VERSION_MAJOR && ver_minor > VERSION_MINOR), false, "Pack created with a newer version of the engine: " + itos(ver_major) + "." + itos(ver_minor) + ".");
 
 	for (int i = 0; i < 16; i++) {
 		//reserved
@@ -322,10 +320,9 @@ bool FileAccessPack::file_exists(const String &p_name) {
 FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFile &p_file) :
 		pf(p_file),
 		f(FileAccess::open(pf.pack, FileAccess::READ)) {
-	if (!f) {
-		ERR_EXPLAIN("Can't open pack-referenced file: " + String(pf.pack));
-		ERR_FAIL_COND(!f);
-	}
+
+	ERR_FAIL_COND_MSG(!f, "Can't open pack-referenced file: " + String(pf.pack) + ".");
+
 	f->seek(pf.offset);
 	pos = 0;
 	eof = false;

--- a/core/io/ip_address.cpp
+++ b/core/io/ip_address.cpp
@@ -81,8 +81,7 @@ static void _parse_hex(const String &p_string, int p_start, uint8_t *p_dst) {
 		} else if (c == ':') {
 			break;
 		} else {
-			ERR_EXPLAIN("Invalid character in ipv6 address: " + p_string);
-			ERR_FAIL();
+			ERR_FAIL_MSG("Invalid character in IPv6 address: " + p_string + ".");
 		};
 		ret = ret << 4;
 		ret += n;
@@ -126,9 +125,7 @@ void IP_Address::_parse_ipv6(const String &p_string) {
 				++parts_count;
 			};
 		} else {
-
-			ERR_EXPLAIN("Invalid character in IPv6 address: " + p_string);
-			ERR_FAIL();
+			ERR_FAIL_MSG("Invalid character in IPv6 address: " + p_string + ".");
 		};
 	};
 
@@ -166,10 +163,7 @@ void IP_Address::_parse_ipv4(const String &p_string, int p_start, uint8_t *p_ret
 	};
 
 	int slices = ip.get_slice_count(".");
-	if (slices != 4) {
-		ERR_EXPLAIN("Invalid IP Address String: " + ip);
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(slices != 4, "Invalid IP address string: " + ip + ".");
 	for (int i = 0; i < 4; i++) {
 		p_ret[i] = ip.get_slicec('.', i).to_int();
 	}
@@ -229,7 +223,7 @@ IP_Address::IP_Address(const String &p_string) {
 		valid = true;
 
 	} else {
-		ERR_PRINT("Invalid IP address");
+		ERR_PRINT("Invalid IP address.");
 	}
 }
 

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -377,11 +377,6 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 			}
 
 		} break;
-		/*case Variant::RESOURCE: {
-
-			ERR_EXPLAIN("Can't marshallize resources");
-			ERR_FAIL_V(ERR_INVALID_DATA); //no, i'm sorry, no go
-		} break;*/
 		case Variant::_RID: {
 
 			r_variant = RID();
@@ -1066,11 +1061,6 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			r_len += 4 * 4;
 
 		} break;
-		/*case Variant::RESOURCE: {
-
-			ERR_EXPLAIN("Can't marshallize resources");
-			ERR_FAIL_V(ERR_INVALID_DATA); //no, i'm sorry, no go
-		} break;*/
 		case Variant::_RID: {
 
 		} break;

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -280,8 +280,7 @@ Ref<StreamPeer> PacketPeerStream::get_stream_peer() const {
 void PacketPeerStream::set_input_buffer_max_size(int p_max_size) {
 
 	//warning may lose packets
-	ERR_EXPLAIN("Buffer in use, resizing would cause loss of data");
-	ERR_FAIL_COND(ring_buffer.data_left());
+	ERR_FAIL_COND_MSG(ring_buffer.data_left(), "Buffer in use, resizing would cause loss of data.");
 	ring_buffer.resize(nearest_shift(p_max_size + 4));
 	input_buffer.resize(next_power_of_2(p_max_size + 4));
 }

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -64,10 +64,7 @@ Error PCKPacker::pck_start(const String &p_file, int p_alignment) {
 
 	file = FileAccess::open(p_file, FileAccess::WRITE);
 
-	if (!file) {
-		ERR_EXPLAIN("Can't open file to write: " + String(p_file));
-		ERR_FAIL_V(ERR_CANT_CREATE);
-	}
+	ERR_FAIL_COND_V_MSG(!file, ERR_CANT_CREATE, "Can't open file to write: " + String(p_file) + ".");
 
 	alignment = p_alignment;
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -490,8 +490,7 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant &r_v) {
 #endif
 
 			} else {
-				ERR_EXPLAIN("Vector2 size is NOT 8!");
-				ERR_FAIL_V(ERR_UNAVAILABLE);
+				ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Vector2 size is NOT 8!");
 			}
 			w.release();
 			r_v = array;
@@ -518,8 +517,7 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant &r_v) {
 #endif
 
 			} else {
-				ERR_EXPLAIN("Vector3 size is NOT 12!");
-				ERR_FAIL_V(ERR_UNAVAILABLE);
+				ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Vector3 size is NOT 12!");
 			}
 			w.release();
 			r_v = array;
@@ -546,8 +544,7 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant &r_v) {
 #endif
 
 			} else {
-				ERR_EXPLAIN("Color size is NOT 16!");
-				ERR_FAIL_V(ERR_UNAVAILABLE);
+				ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Color size is NOT 16!");
 			}
 			w.release();
 			r_v = array;
@@ -571,7 +568,7 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant &r_v) {
 				const uint32_t current_version = 0;
 				if (format_version > current_version) {
 
-					ERR_PRINT("Format version for encoded binary image is too new");
+					ERR_PRINT("Format version for encoded binary image is too new.");
 					return ERR_PARSE_ERROR;
 				}
 
@@ -655,8 +652,7 @@ Error ResourceInteractiveLoaderBinary::poll() {
 			} else {
 
 				error = ERR_FILE_MISSING_DEPENDENCIES;
-				ERR_EXPLAIN("Can't load dependency: " + path);
-				ERR_FAIL_V(error);
+				ERR_FAIL_V_MSG(error, "Can't load dependency: " + path + ".");
 			}
 
 		} else {
@@ -711,16 +707,15 @@ Error ResourceInteractiveLoaderBinary::poll() {
 	Object *obj = ClassDB::instance(t);
 	if (!obj) {
 		error = ERR_FILE_CORRUPT;
-		ERR_EXPLAIN(local_path + ":Resource of unrecognized type in file: " + t);
-		ERR_FAIL_V(ERR_FILE_CORRUPT);
+		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, local_path + ":Resource of unrecognized type in file: " + t + ".");
 	}
 
 	Resource *r = Object::cast_to<Resource>(obj);
 	if (!r) {
+		String obj_class = obj->get_class();
 		error = ERR_FILE_CORRUPT;
-		ERR_EXPLAIN(local_path + ":Resource type in resource field not a resource, type is: " + obj->get_class());
 		memdelete(obj); //bye
-		ERR_FAIL_V(ERR_FILE_CORRUPT);
+		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, local_path + ":Resource type in resource field not a resource, type is: " + obj_class + ".");
 	}
 
 	RES res = RES(r);
@@ -850,8 +845,7 @@ void ResourceInteractiveLoaderBinary::open(FileAccess *p_f) {
 		//not normal
 
 		error = ERR_FILE_UNRECOGNIZED;
-		ERR_EXPLAIN("Unrecognized binary resource file: " + local_path);
-		ERR_FAIL();
+		ERR_FAIL_MSG("Unrecognized binary resource file: " + local_path + ".");
 	}
 
 	bool big_endian = f->get_32();
@@ -877,8 +871,7 @@ void ResourceInteractiveLoaderBinary::open(FileAccess *p_f) {
 	if (ver_format > FORMAT_VERSION || ver_major > VERSION_MAJOR) {
 
 		f->close();
-		ERR_EXPLAIN("File Format '" + itos(FORMAT_VERSION) + "." + itos(ver_major) + "." + itos(ver_minor) + "' is too new! Please upgrade to a new engine version: " + local_path);
-		ERR_FAIL();
+		ERR_FAIL_MSG("File format '" + itos(FORMAT_VERSION) + "." + itos(ver_major) + "." + itos(ver_minor) + "' is too new! Please upgrade to a new engine version: " + local_path + ".");
 	}
 
 	type = get_unicode_string();
@@ -926,8 +919,7 @@ void ResourceInteractiveLoaderBinary::open(FileAccess *p_f) {
 	if (f->eof_reached()) {
 
 		error = ERR_FILE_CORRUPT;
-		ERR_EXPLAIN("Premature End Of File: " + local_path);
-		ERR_FAIL();
+		ERR_FAIL_MSG("Premature end of file (EOF): " + local_path + ".");
 	}
 }
 
@@ -1084,8 +1076,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 
 		//error=ERR_FILE_UNRECOGNIZED;
 		memdelete(f);
-		ERR_EXPLAIN("Unrecognized binary resource file: " + local_path);
-		ERR_FAIL_V(ERR_FILE_UNRECOGNIZED);
+		ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "Unrecognized binary resource file: " + local_path + ".");
 	} else {
 		fw = FileAccess::open(p_path + ".depren", FileAccess::WRITE);
 		if (!fw) {
@@ -1122,7 +1113,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		memdelete(da);
 		//use the old approach
 
-		WARN_PRINT(("This file is old, so it can't refactor dependencies, opening and resaving: " + p_path).utf8().get_data());
+		WARN_PRINTS("This file is old, so it can't refactor dependencies, opening and resaving: " + p_path + ".");
 
 		Error err;
 		f = FileAccess::open(p_path, FileAccess::READ, &err);
@@ -1153,8 +1144,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 
 		memdelete(f);
 		memdelete(fw);
-		ERR_EXPLAIN("File Format '" + itos(FORMAT_VERSION) + "." + itos(ver_major) + "." + itos(ver_minor) + "' is too new! Please upgrade to a new engine version: " + local_path);
-		ERR_FAIL_V(ERR_FILE_UNRECOGNIZED);
+		ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "File format '" + itos(FORMAT_VERSION) + "." + itos(ver_major) + "." + itos(ver_minor) + "' is too new! Please upgrade to a new engine version: " + local_path + ".");
 	}
 
 	// Since we're not actually converting the file contents, leave the version
@@ -1477,7 +1467,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(FileAccess *f, const Varia
 		case Variant::_RID: {
 
 			f->store_32(VARIANT_RID);
-			WARN_PRINT("Can't save RIDs");
+			WARN_PRINT("Can't save RIDs.");
 			RID val = p_property;
 			f->store_32(val.get_id());
 		} break;
@@ -1497,8 +1487,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(FileAccess *f, const Varia
 
 				if (!resource_set.has(res)) {
 					f->store_32(OBJECT_EMPTY);
-					ERR_EXPLAIN("Resource was not pre cached for the resource section, most likely due to circular refedence.");
-					ERR_FAIL();
+					ERR_FAIL_MSG("Resource was not pre cached for the resource section, most likely due to circular reference.");
 				}
 
 				f->store_32(OBJECT_INTERNAL_RESOURCE);
@@ -1629,8 +1618,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(FileAccess *f, const Varia
 		} break;
 		default: {
 
-			ERR_EXPLAIN("Invalid variant");
-			ERR_FAIL();
+			ERR_FAIL_MSG("Invalid variant.");
 		}
 	}
 }

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -275,12 +275,9 @@ RES ResourceLoader::_load(const String &p_path, const String &p_original_path, c
 		return res;
 	}
 
-	if (found) {
-		ERR_EXPLAIN("Failed loading resource: " + p_path);
-	} else {
-		ERR_EXPLAIN("No loader found for resource: " + p_path);
-	}
-	ERR_FAIL_V(RES());
+	ERR_FAIL_COND_V_MSG(found, RES(), "Failed loading resource: " + p_path + ".");
+
+	ERR_FAIL_V_MSG(RES(), "No loader found for resource: " + p_path + ".");
 }
 
 bool ResourceLoader::_add_to_loading_map(const String &p_path) {
@@ -355,10 +352,7 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p
 
 		{
 			bool success = _add_to_loading_map(local_path);
-			if (!success) {
-				ERR_EXPLAIN("Resource: '" + local_path + "' is already being loaded. Cyclic reference?");
-				ERR_FAIL_V(RES());
-			}
+			ERR_FAIL_COND_V_MSG(!success, RES(), "Resource: '" + local_path + "' is already being loaded. Cyclic reference?");
 		}
 
 		//lock first if possible
@@ -395,8 +389,7 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p
 		if (!p_no_cache) {
 			_remove_from_loading_map(local_path);
 		}
-		ERR_EXPLAIN("Remapping '" + local_path + "'failed.");
-		ERR_FAIL_V(RES());
+		ERR_FAIL_V_MSG(RES(), "Remapping '" + local_path + "' failed.");
 	}
 
 	print_verbose("Loading resource: " + path);
@@ -479,10 +472,7 @@ Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String &p_
 	if (!p_no_cache) {
 
 		bool success = _add_to_loading_map(local_path);
-		if (!success) {
-			ERR_EXPLAIN("Resource: '" + local_path + "' is already being loaded. Cyclic reference?");
-			ERR_FAIL_V(RES());
-		}
+		ERR_FAIL_COND_V_MSG(!success, RES(), "Resource: '" + local_path + "' is already being loaded. Cyclic reference?");
 
 		if (ResourceCache::has(local_path)) {
 
@@ -503,8 +493,7 @@ Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String &p_
 		if (!p_no_cache) {
 			_remove_from_loading_map(local_path);
 		}
-		ERR_EXPLAIN("Remapping '" + local_path + "'failed.");
-		ERR_FAIL_V(RES());
+		ERR_FAIL_V_MSG(RES(), "Remapping '" + local_path + "' failed.");
 	}
 
 	print_verbose("Loading resource: " + path);
@@ -534,12 +523,9 @@ Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String &p_
 		_remove_from_loading_map(local_path);
 	}
 
-	if (found) {
-		ERR_EXPLAIN("Failed loading resource: " + path);
-	} else {
-		ERR_EXPLAIN("No loader found for resource: " + path);
-	}
-	ERR_FAIL_V(Ref<ResourceInteractiveLoader>());
+	ERR_FAIL_COND_V_MSG(found, Ref<ResourceInteractiveLoader>(), "Failed loading resource: " + path + ".");
+
+	ERR_FAIL_V_MSG(Ref<ResourceInteractiveLoader>(), "No loader found for resource: " + path + ".");
 }
 
 void ResourceLoader::add_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader, bool p_at_front) {
@@ -801,7 +787,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 				if (err == ERR_FILE_EOF) {
 					break;
 				} else if (err != OK) {
-					ERR_PRINTS("Parse error: " + p_path + ".remap:" + itos(lines) + " error: " + error_text);
+					ERR_PRINTS("Parse error: " + p_path + ".remap:" + itos(lines) + " error: " + error_text + ".");
 					break;
 				}
 
@@ -932,13 +918,11 @@ bool ResourceLoader::add_custom_resource_format_loader(String script_path) {
 	Ref<Script> s = res;
 	StringName ibt = s->get_instance_base_type();
 	bool valid_type = ClassDB::is_parent_class(ibt, "ResourceFormatLoader");
-	ERR_EXPLAIN("Script does not inherit a CustomResourceLoader: " + script_path);
-	ERR_FAIL_COND_V(!valid_type, false);
+	ERR_FAIL_COND_V_MSG(!valid_type, false, "Script does not inherit a CustomResourceLoader: " + script_path + ".");
 
 	Object *obj = ClassDB::instance(ibt);
 
-	ERR_EXPLAIN("Cannot instance script as custom resource loader, expected 'ResourceFormatLoader' inheritance, got: " + String(ibt));
-	ERR_FAIL_COND_V(obj == NULL, false);
+	ERR_FAIL_COND_V_MSG(obj == NULL, false, "Cannot instance script as custom resource loader, expected 'ResourceFormatLoader' inheritance, got: " + String(ibt) + ".");
 
 	ResourceFormatLoader *crl = Object::cast_to<ResourceFormatLoader>(obj);
 	crl->set_script(s.get_ref_ptr());

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -214,13 +214,11 @@ bool ResourceSaver::add_custom_resource_format_saver(String script_path) {
 	Ref<Script> s = res;
 	StringName ibt = s->get_instance_base_type();
 	bool valid_type = ClassDB::is_parent_class(ibt, "ResourceFormatSaver");
-	ERR_EXPLAIN("Script does not inherit a CustomResourceSaver: " + script_path);
-	ERR_FAIL_COND_V(!valid_type, false);
+	ERR_FAIL_COND_V_MSG(!valid_type, false, "Script does not inherit a CustomResourceSaver: " + script_path + ".");
 
 	Object *obj = ClassDB::instance(ibt);
 
-	ERR_EXPLAIN("Cannot instance script as custom resource saver, expected 'ResourceFormatSaver' inheritance, got: " + String(ibt));
-	ERR_FAIL_COND_V(obj == NULL, false);
+	ERR_FAIL_COND_V_MSG(obj == NULL, false, "Cannot instance script as custom resource saver, expected 'ResourceFormatSaver' inheritance, got: " + String(ibt) + ".");
 
 	ResourceFormatSaver *crl = Object::cast_to<ResourceFormatSaver>(obj);
 	crl->set_script(s.get_ref_ptr());

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -67,8 +67,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 
 			if (status == STATUS_READING_ID) {
 				memdelete(f);
-				ERR_EXPLAIN(p_path + ":" + itos(line) + " Unexpected EOF while reading 'msgid' at file: ");
-				ERR_FAIL_V(RES());
+				ERR_FAIL_V_MSG(RES(), p_path + ":" + itos(line) + " Unexpected EOF while reading 'msgid' at file: ");
 			} else {
 				break;
 			}
@@ -79,8 +78,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			if (status == STATUS_READING_ID) {
 
 				memdelete(f);
-				ERR_EXPLAIN(p_path + ":" + itos(line) + " Unexpected 'msgid', was expecting 'msgstr' while parsing: ");
-				ERR_FAIL_V(RES());
+				ERR_FAIL_V_MSG(RES(), p_path + ":" + itos(line) + " Unexpected 'msgid', was expecting 'msgstr' while parsing: ");
 			}
 
 			if (msg_id != "") {
@@ -102,8 +100,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			if (status != STATUS_READING_ID) {
 
 				memdelete(f);
-				ERR_EXPLAIN(p_path + ":" + itos(line) + " Unexpected 'msgstr', was expecting 'msgid' while parsing: ");
-				ERR_FAIL_V(RES());
+				ERR_FAIL_V_MSG(RES(), p_path + ":" + itos(line) + " Unexpected 'msgstr', was expecting 'msgid' while parsing: ");
 			}
 
 			l = l.substr(6, l.length()).strip_edges();
@@ -118,11 +115,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			continue; //nothing to read or comment
 		}
 
-		if (!l.begins_with("\"") || status == STATUS_NONE) {
-			//not a string? failure!
-			ERR_EXPLAIN(p_path + ":" + itos(line) + " Invalid line '" + l + "' while parsing: ");
-			ERR_FAIL_V(RES());
-		}
+		ERR_FAIL_COND_V_MSG(!l.begins_with("\"") || status == STATUS_NONE, RES(), p_path + ":" + itos(line) + " Invalid line '" + l + "' while parsing: ");
 
 		l = l.substr(1, l.length());
 		//find final quote
@@ -135,10 +128,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			}
 		}
 
-		if (end_pos == -1) {
-			ERR_EXPLAIN(p_path + ":" + itos(line) + " Expected '\"' at end of message while parsing file: ");
-			ERR_FAIL_V(RES());
-		}
+		ERR_FAIL_COND_V_MSG(end_pos == -1, RES(), p_path + ":" + itos(line) + " Expected '\"' at end of message while parsing file: ");
 
 		l = l.substr(0, end_pos);
 		l = l.c_unescape();
@@ -163,10 +153,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			config = msg_str;
 	}
 
-	if (config == "") {
-		ERR_EXPLAIN("No config found in file: " + p_path);
-		ERR_FAIL_V(RES());
-	}
+	ERR_FAIL_COND_V_MSG(config == "", RES(), "No config found in file: " + p_path + ".");
 
 	Vector<String> configs = config.split("\n");
 	for (int i = 0; i < configs.size(); i++) {

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -443,10 +443,8 @@ String XMLParser::get_attribute_value(const String &p_name) const {
 		}
 	}
 
-	if (idx < 0) {
-		ERR_EXPLAIN("Attribute not found: " + p_name);
-	}
-	ERR_FAIL_COND_V(idx < 0, "");
+	ERR_FAIL_COND_V_MSG(idx < 0, "", "Attribute not found: " + p_name + ".");
+
 	return attributes[idx].value;
 }
 

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -618,10 +618,7 @@ Basis::operator String() const {
 Quat Basis::get_quat() const {
 
 #ifdef MATH_CHECKS
-	if (!is_rotation()) {
-		ERR_EXPLAIN("Basis must be normalized in order to be casted to a Quaternion. Use get_rotation_quat() or call orthonormalized() instead.");
-		ERR_FAIL_V(Quat());
-	}
+	ERR_FAIL_COND_V_MSG(!is_rotation(), Quat(), "Basis must be normalized in order to be casted to a Quaternion. Use get_rotation_quat() or call orthonormalized() instead.");
 #endif
 	/* Allow getting a quaternion from an unnormalized transform */
 	Basis m = *this;

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -2161,10 +2161,8 @@ Error Expression::parse(const String &p_expression, const Vector<String> &p_inpu
 }
 
 Variant Expression::execute(Array p_inputs, Object *p_base, bool p_show_error) {
-	if (error_set) {
-		ERR_EXPLAIN("There was previously a parse error: " + error_str);
-		ERR_FAIL_V(Variant());
-	}
+
+	ERR_FAIL_COND_V_MSG(error_set, Variant(), "There was previously a parse error: " + error_str + ".");
 
 	execution_error = false;
 	Variant output;
@@ -2173,10 +2171,7 @@ Variant Expression::execute(Array p_inputs, Object *p_base, bool p_show_error) {
 	if (err) {
 		execution_error = true;
 		error_str = error_txt;
-		if (p_show_error) {
-			ERR_EXPLAIN(error_str);
-			ERR_FAIL_V(Variant());
-		}
+		ERR_FAIL_COND_V_MSG(p_show_error, Variant(), error_str);
 	}
 
 	return output;

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -834,8 +834,7 @@ public:
 
 	static Vector<Vector<Point2> > offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
 
-		ERR_EXPLAIN("Attempt to offset a polyline like a polygon (use offset_polygon_2d instead).");
-		ERR_FAIL_COND_V(p_end_type == END_POLYGON, Vector<Vector<Point2> >());
+		ERR_FAIL_COND_V_MSG(p_end_type == END_POLYGON, Vector<Vector<Point2> >(), "Attempt to offset a polyline like a polygon (use offset_polygon_2d instead).");
 
 		return _polypath_offset(p_polygon, p_delta, p_join_type, p_end_type);
 	}

--- a/core/math/octree.h
+++ b/core/math/octree.h
@@ -564,10 +564,7 @@ void Octree<T, use_pairs, AL>::_ensure_valid_root(const AABB &p_aabb) {
 
 		while (!base.encloses(p_aabb)) {
 
-			if (base.size.x > OCTREE_SIZE_LIMIT) {
-				ERR_EXPLAIN("Octree upper size limit reeached, does the AABB supplied contain NAN?");
-				ERR_FAIL();
-			}
+			ERR_FAIL_COND_MSG(base.size.x > OCTREE_SIZE_LIMIT, "Octree upper size limit reached, does the AABB supplied contain NAN?");
 
 			Octant *gp = memnew_allocator(Octant, AL);
 			octant_count++;

--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -52,8 +52,7 @@ Error MessageQueue::push_call(ObjectID p_id, const StringName &p_method, const V
 			type = ObjectDB::get_instance(p_id)->get_class();
 		print_line("Failed method: " + type + ":" + p_method + " target ID: " + itos(p_id));
 		statistics();
-		ERR_EXPLAIN("Message queue out of memory. Try increasing 'message_queue_size_kb' in project settings.");
-		ERR_FAIL_V(ERR_OUT_OF_MEMORY);
+		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'message_queue_size_kb' in project settings.");
 	}
 
 	Message *msg = memnew_placement(&buffer[buffer_end], Message);
@@ -103,8 +102,7 @@ Error MessageQueue::push_set(ObjectID p_id, const StringName &p_prop, const Vari
 			type = ObjectDB::get_instance(p_id)->get_class();
 		print_line("Failed set: " + type + ":" + p_prop + " target ID: " + itos(p_id));
 		statistics();
-		ERR_EXPLAIN("Message queue out of memory. Try increasing 'message_queue_size_kb' in project settings.");
-		ERR_FAIL_V(ERR_OUT_OF_MEMORY);
+		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'message_queue_size_kb' in project settings.");
 	}
 
 	Message *msg = memnew_placement(&buffer[buffer_end], Message);
@@ -136,8 +134,7 @@ Error MessageQueue::push_notification(ObjectID p_id, int p_notification) {
 			type = ObjectDB::get_instance(p_id)->get_class();
 		print_line("Failed notification: " + itos(p_notification) + " target ID: " + itos(p_id));
 		statistics();
-		ERR_EXPLAIN("Message queue out of memory. Try increasing 'message_queue_size_kb' in project settings.");
-		ERR_FAIL_V(ERR_OUT_OF_MEMORY);
+		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'message_queue_size_kb' in project settings.");
 	}
 
 	Message *msg = memnew_placement(&buffer[buffer_end], Message);
@@ -256,7 +253,7 @@ void MessageQueue::_call_function(Object *p_target, const StringName &p_func, co
 	p_target->call(p_func, argptrs, p_argcount, ce);
 	if (p_show_error && ce.error != Variant::CallError::CALL_OK) {
 
-		ERR_PRINTS("Error calling deferred method: " + Variant::get_call_error_text(p_target, p_func, argptrs, p_argcount, ce));
+		ERR_PRINTS("Error calling deferred method: " + Variant::get_call_error_text(p_target, p_func, argptrs, p_argcount, ce) + ".");
 	}
 }
 

--- a/core/node_path.cpp
+++ b/core/node_path.cpp
@@ -375,8 +375,7 @@ NodePath::NodePath(const String &p_path) {
 				if (str == "") {
 					if (path[i] == 0) continue; // Allow end-of-path :
 
-					ERR_EXPLAIN("Invalid NodePath: " + p_path);
-					ERR_FAIL();
+					ERR_FAIL_MSG("Invalid NodePath: " + p_path + ".");
 				}
 				subpath.push_back(str);
 

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -709,20 +709,17 @@ static void _test_call_error(const StringName &p_func, const Variant::CallError 
 			break;
 		case Variant::CallError::CALL_ERROR_INVALID_ARGUMENT: {
 
-			ERR_EXPLAIN("Error Calling Function: " + String(p_func) + " - Invalid type for argument " + itos(error.argument) + ", expected " + Variant::get_type_name(error.expected));
-			ERR_FAIL();
+			ERR_FAIL_MSG("Error calling function: " + String(p_func) + " - Invalid type for argument " + itos(error.argument) + ", expected " + Variant::get_type_name(error.expected) + ".");
 			break;
 		}
 		case Variant::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS: {
 
-			ERR_EXPLAIN("Error Calling Function: " + String(p_func) + " - Too many arguments, expected " + itos(error.argument));
-			ERR_FAIL();
+			ERR_FAIL_MSG("Error calling function: " + String(p_func) + " - Too many arguments, expected " + itos(error.argument) + ".");
 			break;
 		}
 		case Variant::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS: {
 
-			ERR_EXPLAIN("Error Calling Function: " + String(p_func) + " - Too few arguments, expected " + itos(error.argument));
-			ERR_FAIL();
+			ERR_FAIL_MSG("Error calling function: " + String(p_func) + " - Too few arguments, expected " + itos(error.argument) + ".");
 			break;
 		}
 		case Variant::CallError::CALL_ERROR_INSTANCE_IS_NULL:
@@ -739,15 +736,9 @@ void Object::call_multilevel(const StringName &p_method, const Variant **p_args,
 
 	if (p_method == CoreStringNames::get_singleton()->_free) {
 #ifdef DEBUG_ENABLED
-		if (Object::cast_to<Reference>(this)) {
-			ERR_EXPLAIN("Can't 'free' a reference.");
-			ERR_FAIL();
-		}
+		ERR_FAIL_COND_MSG(Object::cast_to<Reference>(this), "Can't 'free' a reference.");
 
-		if (_lock_index.get() > 1) {
-			ERR_EXPLAIN("Object is locked and can't be freed.");
-			ERR_FAIL();
-		}
+		ERR_FAIL_COND_MSG(_lock_index.get() > 1, "Object is locked and can't be freed.");
 #endif
 
 		//must be here, must be before everything,
@@ -835,8 +826,7 @@ Variant Object::callv(const StringName &p_method, const Array &p_args) {
 	Variant::CallError ce;
 	Variant ret = call(p_method, argptrs, p_args.size(), ce);
 	if (ce.error != Variant::CallError::CALL_OK) {
-		ERR_EXPLAIN("Error calling method from 'callv': " + Variant::get_call_error_text(this, p_method, argptrs, p_args.size(), ce));
-		ERR_FAIL_V(Variant());
+		ERR_FAIL_V_MSG(Variant(), "Error calling method from 'callv': " + Variant::get_call_error_text(this, p_method, argptrs, p_args.size(), ce) + ".");
 	}
 	return ret;
 }
@@ -888,15 +878,13 @@ Variant Object::call(const StringName &p_method, const Variant **p_args, int p_a
 		if (Object::cast_to<Reference>(this)) {
 			r_error.argument = 0;
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
-			ERR_EXPLAIN("Can't 'free' a reference.");
-			ERR_FAIL_V(Variant());
+			ERR_FAIL_V_MSG(Variant(), "Can't 'free' a reference.");
 		}
 
 		if (_lock_index.get() > 1) {
 			r_error.argument = 0;
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
-			ERR_EXPLAIN("Object is locked and can't be freed.");
-			ERR_FAIL_V(Variant());
+			ERR_FAIL_V_MSG(Variant(), "Object is locked and can't be freed.");
 		}
 
 #endif
@@ -1172,10 +1160,7 @@ Error Object::emit_signal(const StringName &p_name, const Variant **p_args, int 
 #ifdef DEBUG_ENABLED
 		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_name);
 		//check in script
-		if (!signal_is_valid && !script.is_null() && !Ref<Script>(script)->has_script_signal(p_name)) {
-			ERR_EXPLAIN("Can't emit non-existing signal " + String("\"") + p_name + "\".");
-			ERR_FAIL_V(ERR_UNAVAILABLE);
-		}
+		ERR_FAIL_COND_V_MSG(!signal_is_valid && !script.is_null() && !Ref<Script>(script)->has_script_signal(p_name), ERR_UNAVAILABLE, "Can't emit non-existing signal " + String("\"") + p_name + "\".");
 #endif
 		//not connected? just return
 		return ERR_UNAVAILABLE;
@@ -1240,7 +1225,7 @@ Error Object::emit_signal(const StringName &p_name, const Variant **p_args, int 
 				if (ce.error == Variant::CallError::CALL_ERROR_INVALID_METHOD && !ClassDB::class_exists(target->get_class_name())) {
 					//most likely object is not initialized yet, do not throw error.
 				} else {
-					ERR_PRINTS("Error calling method from signal '" + String(p_name) + "': " + Variant::get_call_error_text(target, c.method, args, argc, ce));
+					ERR_PRINTS("Error calling method from signal '" + String(p_name) + "': " + Variant::get_call_error_text(target, c.method, args, argc, ce) + ".");
 					err = ERR_METHOD_NOT_FOUND;
 				}
 			}
@@ -1463,10 +1448,8 @@ Error Object::connect(const StringName &p_signal, Object *p_to_object, const Str
 #endif
 		}
 
-		if (!signal_is_valid) {
-			ERR_EXPLAIN("In Object of type '" + String(get_class()) + "': Attempt to connect nonexistent signal '" + p_signal + "' to method '" + p_to_object->get_class() + "." + p_to_method + "'");
-			ERR_FAIL_V(ERR_INVALID_PARAMETER);
-		}
+		ERR_FAIL_COND_V_MSG(!signal_is_valid, ERR_INVALID_PARAMETER, "In Object of type '" + String(get_class()) + "': Attempt to connect nonexistent signal '" + p_signal + "' to method '" + p_to_object->get_class() + "." + p_to_method + "'.");
+
 		signal_map[p_signal] = Signal();
 		s = &signal_map[p_signal];
 	}
@@ -1477,8 +1460,7 @@ Error Object::connect(const StringName &p_signal, Object *p_to_object, const Str
 			s->slot_map[target].reference_count++;
 			return OK;
 		} else {
-			ERR_EXPLAIN("Signal '" + p_signal + "' is already connected to given method '" + p_to_method + "' in that object.");
-			ERR_FAIL_V(ERR_INVALID_PARAMETER);
+			ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER, "Signal '" + p_signal + "' is already connected to given method '" + p_to_method + "' in that object.");
 		}
 	}
 
@@ -1514,8 +1496,7 @@ bool Object::is_connected(const StringName &p_signal, Object *p_to_object, const
 		if (!script.is_null() && Ref<Script>(script)->has_script_signal(p_signal))
 			return false;
 
-		ERR_EXPLAIN("Nonexistent signal: " + p_signal);
-		ERR_FAIL_V(false);
+		ERR_FAIL_V_MSG(false, "Nonexistent signal: " + p_signal + ".");
 	}
 
 	Signal::Target target(p_to_object->get_instance_id(), p_to_method);
@@ -1533,21 +1514,13 @@ void Object::_disconnect(const StringName &p_signal, Object *p_to_object, const 
 
 	ERR_FAIL_NULL(p_to_object);
 	Signal *s = signal_map.getptr(p_signal);
-	if (!s) {
-		ERR_EXPLAIN("Nonexistent signal: " + p_signal);
-		ERR_FAIL();
-	}
-	if (s->lock > 0) {
-		ERR_EXPLAIN("Attempt to disconnect signal '" + p_signal + "' while emitting (locks: " + itos(s->lock) + ")");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!s, "Nonexistent signal: " + p_signal + ".");
+
+	ERR_FAIL_COND_MSG(s->lock > 0, "Attempt to disconnect signal '" + p_signal + "' while emitting (locks: " + itos(s->lock) + ").");
 
 	Signal::Target target(p_to_object->get_instance_id(), p_to_method);
 
-	if (!s->slot_map.has(target)) {
-		ERR_EXPLAIN("Disconnecting nonexistent signal '" + p_signal + "', slot: " + itos(target._id) + ":" + target.method);
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!s->slot_map.has(target), "Disconnecting nonexistent signal '" + p_signal + "', slot: " + itos(target._id) + ":" + target.method + ".");
 
 	Signal::Slot *slot = &s->slot_map[target];
 
@@ -1974,10 +1947,7 @@ Object::~Object() {
 
 		Signal *s = &signal_map[*S];
 
-		if (s->lock) {
-			ERR_EXPLAIN("Attempt to delete an object in the middle of a signal emission from it");
-			ERR_CONTINUE(s->lock > 0);
-		}
+		ERR_CONTINUE_MSG(s->lock > 0, "Attempt to delete an object in the middle of a signal emission from it.");
 
 		//brute force disconnect for performance
 		int slot_count = s->slot_map.size();

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -599,8 +599,7 @@ Vector<uint8_t> FileAccess::get_file_as_array(const String &p_path, Error *r_err
 		if (r_error) { // if error requested, do not throw error
 			return Vector<uint8_t>();
 		}
-		ERR_EXPLAIN("Can't open file from path: " + String(p_path));
-		ERR_FAIL_V(Vector<uint8_t>());
+		ERR_FAIL_V_MSG(Vector<uint8_t>(), "Can't open file from path: " + String(p_path) + ".");
 	}
 	Vector<uint8_t> data;
 	data.resize(f->get_len());
@@ -620,8 +619,7 @@ String FileAccess::get_file_as_string(const String &p_path, Error *r_error) {
 		if (r_error) {
 			return String();
 		}
-		ERR_EXPLAIN("Can't get file as string from path: " + String(p_path));
-		ERR_FAIL_V(String());
+		ERR_FAIL_V_MSG(String(), "Can't get file as string from path: " + String(p_path) + ".");
 	}
 
 	String ret;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -268,8 +268,7 @@ void OS::print_all_resources(String p_to_file) {
 		_OSPRF = FileAccess::open(p_to_file, FileAccess::WRITE, &err);
 		if (err != OK) {
 			_OSPRF = NULL;
-			ERR_EXPLAIN("Can't print all resources to file: " + String(p_to_file));
-			ERR_FAIL();
+			ERR_FAIL_MSG("Can't print all resources to file: " + String(p_to_file) + ".");
 		}
 	}
 
@@ -487,10 +486,7 @@ void OS::_ensure_user_data_dir() {
 
 	da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	Error err = da->make_dir_recursive(dd);
-	if (err != OK) {
-		ERR_EXPLAIN("Error attempting to create data dir: " + dd);
-	}
-	ERR_FAIL_COND(err != OK);
+	ERR_FAIL_COND_MSG(err != OK, "Error attempting to create data dir: " + dd + ".");
 
 	memdelete(da);
 }

--- a/core/pool_allocator.cpp
+++ b/core/pool_allocator.cpp
@@ -204,10 +204,8 @@ PoolAllocator::ID PoolAllocator::alloc(int p_size) {
 		/* Then search again */
 
 		if (!find_hole(&new_entry_indices_pos, size_to_alloc)) {
-
 			mt_unlock();
-			ERR_EXPLAIN("Memory can't be compacted further");
-			ERR_FAIL_V(POOL_ALLOCATOR_INVALID_ID);
+			ERR_FAIL_V_MSG(POOL_ALLOCATOR_INVALID_ID, "Memory can't be compacted further.");
 		}
 	}
 
@@ -217,8 +215,7 @@ PoolAllocator::ID PoolAllocator::alloc(int p_size) {
 
 	if (!found_free_entry) {
 		mt_unlock();
-		ERR_EXPLAIN("No free entry found in PoolAllocator");
-		ERR_FAIL_V(POOL_ALLOCATOR_INVALID_ID);
+		ERR_FAIL_V_MSG(POOL_ALLOCATOR_INVALID_ID, "No free entry found in PoolAllocator.");
 	}
 
 	/* move all entry indices up, make room for this one */

--- a/core/pool_vector.cpp
+++ b/core/pool_vector.cpp
@@ -66,6 +66,5 @@ void MemoryPool::cleanup() {
 	memdelete_arr(allocs);
 	memdelete(alloc_mutex);
 
-	ERR_EXPLAINC("There are still MemoryPool allocs in use at exit!");
-	ERR_FAIL_COND(allocs_used > 0);
+	ERR_FAIL_COND_MSG(allocs_used > 0, "There are still MemoryPool allocs in use at exit!");
 }

--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -98,8 +98,7 @@ class PoolVector {
 		MemoryPool::alloc_mutex->lock();
 		if (MemoryPool::allocs_used == MemoryPool::alloc_count) {
 			MemoryPool::alloc_mutex->unlock();
-			ERR_EXPLAINC("All memory pool allocations are in use, can't COW.");
-			ERR_FAIL();
+			ERR_FAIL_MSG("All memory pool allocations are in use, can't COW.");
 		}
 
 		MemoryPool::Alloc *old_alloc = alloc;
@@ -520,8 +519,7 @@ Error PoolVector<T>::resize(int p_size) {
 		MemoryPool::alloc_mutex->lock();
 		if (MemoryPool::allocs_used == MemoryPool::alloc_count) {
 			MemoryPool::alloc_mutex->unlock();
-			ERR_EXPLAINC("All memory pool allocations are in use.");
-			ERR_FAIL_V(ERR_OUT_OF_MEMORY);
+			ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "All memory pool allocations are in use.");
 		}
 
 		//take one from the free list

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -500,8 +500,7 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 	if (hdr[0] != 'E' || hdr[1] != 'C' || hdr[2] != 'F' || hdr[3] != 'G') {
 
 		memdelete(f);
-		ERR_EXPLAIN("Corrupted header in binary project.binary (not ECFG)");
-		ERR_FAIL_V(ERR_FILE_CORRUPT);
+		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Corrupted header in binary project.binary (not ECFG).");
 	}
 
 	uint32_t count = f->get_32();
@@ -522,8 +521,7 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 		f->get_buffer(d.ptrw(), vlen);
 		Variant value;
 		err = decode_variant(value, d.ptr(), d.size(), NULL, true);
-		ERR_EXPLAIN("Error decoding property: " + key);
-		ERR_CONTINUE(err != OK);
+		ERR_CONTINUE_MSG(err != OK, "Error decoding property: " + key + ".");
 		set(key, value);
 	}
 
@@ -577,8 +575,7 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 				config_version = value;
 				if (config_version > CONFIG_VERSION) {
 					memdelete(f);
-					ERR_EXPLAIN(vformat("Can't open project at '%s', its `config_version` (%d) is from a more recent and incompatible version of the engine. Expected config version: %d.", p_path, config_version, CONFIG_VERSION));
-					ERR_FAIL_V(ERR_FILE_CANT_OPEN);
+					ERR_FAIL_V_MSG(ERR_FILE_CANT_OPEN, vformat("Can't open project at '%s', its `config_version` (%d) is from a more recent and incompatible version of the engine. Expected config version: %d.", p_path, config_version, CONFIG_VERSION));
 				}
 			} else {
 				if (section == String()) {
@@ -645,11 +642,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 
 	Error err;
 	FileAccess *file = FileAccess::open(p_file, FileAccess::WRITE, &err);
-	if (err != OK) {
-
-		ERR_EXPLAIN("Couldn't save project.binary at " + p_file);
-		ERR_FAIL_COND_V(err, err);
-	}
+	ERR_FAIL_COND_V_MSG(err != OK, err, "Couldn't save project.binary at " + p_file + ".");
 
 	uint8_t hdr[4] = { 'E', 'C', 'F', 'G' };
 	file->store_buffer(hdr, 4);
@@ -738,10 +731,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 	Error err;
 	FileAccess *file = FileAccess::open(p_file, FileAccess::WRITE, &err);
 
-	if (err) {
-		ERR_EXPLAIN("Couldn't save project.godot - " + p_file);
-		ERR_FAIL_COND_V(err, err);
-	}
+	ERR_FAIL_COND_V_MSG(err != OK, err, "Couldn't save project.godot - " + p_file + ".");
 
 	file->store_line("; Engine configuration file.");
 	file->store_line("; It's best edited using the editor UI and not directly,");
@@ -872,8 +862,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		return _save_settings_binary(p_path, props, p_custom, custom_features);
 	else {
 
-		ERR_EXPLAIN("Unknown config file format: " + p_path);
-		ERR_FAIL_V(ERR_FILE_UNRECOGNIZED);
+		ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "Unknown config file format: " + p_path + ".");
 	}
 }
 

--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -75,8 +75,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 			bool exists = ResourceCache::resources.has(p_path);
 			ResourceCache::lock->read_unlock();
 
-			ERR_EXPLAIN("Another resource is loaded from path: " + p_path + " (possible cyclic resource inclusion)");
-			ERR_FAIL_COND(exists);
+			ERR_FAIL_COND_MSG(exists, "Another resource is loaded from path: " + p_path + " (possible cyclic resource inclusion).");
 		}
 	}
 	path_cache = p_path;
@@ -277,8 +276,7 @@ void Resource::notify_change_to_owners() {
 	for (Set<ObjectID>::Element *E = owners.front(); E; E = E->next()) {
 
 		Object *obj = ObjectDB::get_instance(E->get());
-		ERR_EXPLAIN("Object was deleted, while still owning a resource");
-		ERR_CONTINUE(!obj); //wtf
+		ERR_CONTINUE_MSG(!obj, "Object was deleted, while still owning a resource."); //wtf
 		//TODO store string
 		obj->call("resource_changed", RES(this));
 	}
@@ -427,7 +425,7 @@ Resource::~Resource() {
 		ResourceCache::lock->write_unlock();
 	}
 	if (owners.size()) {
-		WARN_PRINT("Resource is still owned");
+		WARN_PRINT("Resource is still owned.");
 	}
 }
 

--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -89,7 +89,7 @@ Error ScriptDebuggerRemote::connect_to_host(const String &p_host, uint16_t p_por
 
 	if (tcp_client->get_status() != StreamPeerTCP::STATUS_CONNECTED) {
 
-		ERR_PRINTS("Remote Debugger: Unable to connect. Status: " + String::num(tcp_client->get_status()));
+		ERR_PRINTS("Remote Debugger: Unable to connect. Status: " + String::num(tcp_client->get_status()) + ".");
 		return FAILED;
 	};
 
@@ -110,7 +110,7 @@ void ScriptDebuggerRemote::_put_variable(const String &p_name, const Variant &p_
 	int len = 0;
 	Error err = encode_variant(var, NULL, len, true);
 	if (err != OK)
-		ERR_PRINT("Failed to encode variant");
+		ERR_PRINT("Failed to encode variant.");
 
 	if (len > packet_peer_stream->get_output_buffer_max_size()) { //limit to max size
 		packet_peer_stream->put_var(Variant());
@@ -134,10 +134,7 @@ void ScriptDebuggerRemote::debug(ScriptLanguage *p_script, bool p_can_continue) 
 	//this function is called when there is a debugger break (bug on script)
 	//or when execution is paused from editor
 
-	if (!tcp_client->is_connected_to_host()) {
-		ERR_EXPLAIN("Script Debugger failed to connect, but being used anyway.");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!tcp_client->is_connected_to_host(), "Script Debugger failed to connect, but being used anyway.");
 
 	packet_peer_stream->put_var("debug_enter");
 	packet_peer_stream->put_var(2);

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -848,8 +848,7 @@ void Translation::set_locale(const String &p_locale) {
 	if (!TranslationServer::is_locale_valid(univ_locale)) {
 		String trimmed_locale = get_trimmed_locale(univ_locale);
 
-		ERR_EXPLAIN("Invalid locale: " + trimmed_locale);
-		ERR_FAIL_COND(!TranslationServer::is_locale_valid(trimmed_locale));
+		ERR_FAIL_COND_MSG(!TranslationServer::is_locale_valid(trimmed_locale), "Invalid locale: " + trimmed_locale + ".");
 
 		locale = trimmed_locale;
 	} else {

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1740,10 +1740,7 @@ Variant::operator RID() const {
 	} else if (type == OBJECT && _get_obj().obj) {
 #ifdef DEBUG_ENABLED
 		if (ScriptDebugger::get_singleton()) {
-			if (!ObjectDB::instance_validate(_get_obj().obj)) {
-				ERR_EXPLAIN("Invalid pointer (object was deleted)");
-				ERR_FAIL_V(RID());
-			};
+			ERR_FAIL_COND_V_MSG(!ObjectDB::instance_validate(_get_obj().obj), RID(), "Invalid pointer (object was deleted).");
 		};
 #endif
 		Variant::CallError ce;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -584,8 +584,7 @@ struct _VariantCall {
 
 		if (buffer_size < 0) {
 			r_ret = decompressed;
-			ERR_EXPLAIN("Decompression buffer size is less than zero");
-			ERR_FAIL();
+			ERR_FAIL_MSG("Decompression buffer size is less than zero.");
 		}
 
 		decompressed.resize(buffer_size);

--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1265,14 +1265,11 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 void RasterizerCanvasGLES2::_copy_screen(const Rect2 &p_rect) {
 
 	if (storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_DIRECT_TO_SCREEN]) {
-		ERR_PRINT_ONCE("Cannot use screen texture copying in render target set to render direct to screen");
+		ERR_PRINT_ONCE("Cannot use screen texture copying in render target set to render direct to screen.");
 		return;
 	}
 
-	if (storage->frame.current_rt->copy_screen_effect.color == 0) {
-		ERR_EXPLAIN("Can't use screen texture copying in a render target configured without copy buffers");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(storage->frame.current_rt->copy_screen_effect.color == 0, "Can't use screen texture copying in a render target configured without copy buffers.");
 
 	glDisable(GL_BLEND);
 

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -882,8 +882,7 @@ RID RasterizerSceneGLES2::light_instance_create(RID p_light) {
 
 	if (!light_instance->light_ptr) {
 		memdelete(light_instance);
-		ERR_EXPLAIN("Condition ' !light_instance->light_ptr ' is true.");
-		ERR_FAIL_V(RID());
+		ERR_FAIL_V_MSG(RID(), "Condition ' !light_instance->light_ptr ' is true.");
 	}
 
 	light_instance->self = light_instance_owner.make_rid(light_instance);

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -2171,8 +2171,7 @@ void RasterizerStorageGLES2::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 	//must have index and bones, both.
 	{
 		uint32_t bones_weight = VS::ARRAY_FORMAT_BONES | VS::ARRAY_FORMAT_WEIGHTS;
-		ERR_EXPLAIN("Array must have both bones and weights in format or none.");
-		ERR_FAIL_COND((p_format & bones_weight) && (p_format & bones_weight) != bones_weight);
+		ERR_FAIL_COND_MSG((p_format & bones_weight) && (p_format & bones_weight) != bones_weight, "Array must have both bones and weights in format or none.");
 	}
 
 	//bool has_morph = p_blend_shapes.size();

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1156,10 +1156,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 
 void RasterizerCanvasGLES3::_copy_texscreen(const Rect2 &p_rect) {
 
-	if (storage->frame.current_rt->effects.mip_maps[0].sizes.size() == 0) {
-		ERR_EXPLAIN("Can't use screen texture copying in a render target configured without copy buffers");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(storage->frame.current_rt->effects.mip_maps[0].sizes.size() == 0, "Can't use screen texture copying in a render target configured without copy buffers.");
 
 	glDisable(GL_BLEND);
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1008,8 +1008,7 @@ RID RasterizerSceneGLES3::light_instance_create(RID p_light) {
 
 	if (!light_instance->light_ptr) {
 		memdelete(light_instance);
-		ERR_EXPLAIN("Condition ' !light_instance->light_ptr ' is true.");
-		ERR_FAIL_V(RID());
+		ERR_FAIL_V_MSG(RID(), "Condition ' !light_instance->light_ptr ' is true.");
 	}
 
 	light_instance->self = light_instance_owner.make_rid(light_instance);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -3191,8 +3191,7 @@ void RasterizerStorageGLES3::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 	//must have index and bones, both.
 	{
 		uint32_t bones_weight = VS::ARRAY_FORMAT_BONES | VS::ARRAY_FORMAT_WEIGHTS;
-		ERR_EXPLAIN("Array must have both bones and weights in format or none.");
-		ERR_FAIL_COND((p_format & bones_weight) && (p_format & bones_weight) != bones_weight);
+		ERR_FAIL_COND_MSG((p_format & bones_weight) && (p_format & bones_weight) != bones_weight, "Array must have both bones and weights in format or none.");
 	}
 
 	//bool has_morph = p_blend_shapes.size();

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -97,7 +97,7 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, Ref<Image> p_image) {
 			break;
 		default:
 			png_image_free(&png_img); // only required when we return before finish_read
-			ERR_PRINT("Unsupported png format");
+			ERR_PRINT("Unsupported png format.");
 			return ERR_UNAVAILABLE;
 	}
 
@@ -179,10 +179,9 @@ Error image_to_png(const Ref<Image> &p_image, PoolVector<uint8_t> &p_buffer) {
 		ERR_FAIL_COND_V(check_error(png_img), FAILED);
 	}
 	if (!success) {
-		if (compressed_size <= png_size_estimate) {
-			// buffer was big enough, must be some other error
-			ERR_FAIL_V(FAILED);
-		}
+
+		// buffer was big enough, must be some other error
+		ERR_FAIL_COND_V(compressed_size <= png_size_estimate, FAILED);
 
 		// write failed due to buffer size, resize and retry
 		Error err = p_buffer.resize(buffer_offset + compressed_size);

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -39,9 +39,8 @@ Error ResourceSaverPNG::save(const String &p_path, const RES &p_resource, uint32
 
 	Ref<ImageTexture> texture = p_resource;
 
-	ERR_FAIL_COND_V(!texture.is_valid(), ERR_INVALID_PARAMETER);
-	ERR_EXPLAIN("Can't save empty texture as PNG");
-	ERR_FAIL_COND_V(!texture->get_width() || !texture->get_height(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as PNG.");
+	ERR_FAIL_COND_V_MSG(!texture->get_width(), ERR_INVALID_PARAMETER, "Can't save empty texture as PNG.");
 
 	Ref<Image> img = texture->get_data();
 

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -288,8 +288,7 @@ uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 	if (!err) {
 		return flags.st_mtime;
 	} else {
-		ERR_EXPLAIN("Failed to get modified time for: " + p_file);
-		ERR_FAIL_V(0);
+		ERR_FAIL_V_MSG(0, "Failed to get modified time for: " + p_file + ".");
 	};
 }
 
@@ -302,8 +301,7 @@ uint32_t FileAccessUnix::_get_unix_permissions(const String &p_file) {
 	if (!err) {
 		return flags.st_mode & 0x7FF; //only permissions
 	} else {
-		ERR_EXPLAIN("Failed to get unix permissions for: " + p_file);
-		ERR_FAIL_V(0);
+		ERR_FAIL_V_MSG(0, "Failed to get unix permissions for: " + p_file + ".");
 	};
 }
 

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -184,9 +184,7 @@ void IP_Unix::get_local_interfaces(Map<String, Interface_Info> *r_interfaces) co
 			continue; // will go back and alloc the right size
 		};
 
-		ERR_EXPLAIN("Call to GetAdaptersAddresses failed with error " + itos(err));
-		ERR_FAIL();
-		return;
+		ERR_FAIL_MSG("Call to GetAdaptersAddresses failed with error " + itos(err) + ".");
 	};
 
 	IP_ADAPTER_ADDRESSES *adapter = addrs;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -72,8 +72,7 @@ static double _clock_scale = 0;
 static void _setup_clock() {
 	mach_timebase_info_data_t info;
 	kern_return_t ret = mach_timebase_info(&info);
-	ERR_EXPLAIN("OS CLOCK IS NOT WORKING!");
-	ERR_FAIL_COND(ret != 0);
+	ERR_FAIL_COND_MSG(ret != 0, "OS CLOCK IS NOT WORKING!");
 	_clock_scale = ((double)info.numer / (double)info.denom) / 1000.0;
 	_clock_start = mach_absolute_time() * _clock_scale;
 }
@@ -85,8 +84,7 @@ static void _setup_clock() {
 #endif
 static void _setup_clock() {
 	struct timespec tv_now = { 0, 0 };
-	ERR_EXPLAIN("OS CLOCK IS NOT WORKING!");
-	ERR_FAIL_COND(clock_gettime(GODOT_CLOCK, &tv_now) != 0);
+	ERR_FAIL_COND_MSG(clock_gettime(GODOT_CLOCK, &tv_now) != 0, "OS CLOCK IS NOT WORKING!");
 	_clock_start = ((uint64_t)tv_now.tv_nsec / 1000L) + (uint64_t)tv_now.tv_sec * 1000000L;
 }
 #endif
@@ -420,10 +418,7 @@ Error OS_Unix::open_dynamic_library(const String p_path, void *&p_library_handle
 	}
 
 	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);
-	if (!p_library_handle) {
-		ERR_EXPLAIN("Can't open dynamic library: " + p_path + ". Error: " + dlerror());
-		ERR_FAIL_V(ERR_CANT_OPEN);
-	}
+	ERR_FAIL_COND_V_MSG(!p_library_handle, ERR_CANT_OPEN, "Can't open dynamic library: " + p_path + ". Error: " + dlerror());
 	return OK;
 }
 
@@ -442,12 +437,9 @@ Error OS_Unix::get_dynamic_library_symbol_handle(void *p_library_handle, const S
 
 	error = dlerror();
 	if (error != NULL) {
-		if (!p_optional) {
-			ERR_EXPLAIN("Can't resolve symbol " + p_name + ". Error: " + error);
-			ERR_FAIL_V(ERR_CANT_RESOLVE);
-		} else {
-			return ERR_CANT_RESOLVE;
-		}
+		ERR_FAIL_COND_V_MSG(!p_optional, ERR_CANT_RESOLVE, "Can't resolve symbol " + p_name + ". Error: " + error + ".");
+
+		return ERR_CANT_RESOLVE;
 	}
 	return OK;
 }

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -296,8 +296,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_c
 	}
 
 	hr = p_device->audio_client->Initialize(AUDCLNT_SHAREMODE_SHARED, streamflags, p_capture ? REFTIMES_PER_SEC : 0, 0, pwfex, NULL);
-	ERR_EXPLAIN("WASAPI: Initialize failed with error 0x" + String::num_uint64(hr, 16));
-	ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
+	ERR_FAIL_COND_V_MSG(hr != S_OK, ERR_CANT_OPEN, "WASAPI: Initialize failed with error 0x" + String::num_uint64(hr, 16) + ".");
 
 	if (p_capture) {
 		hr = p_device->audio_client->GetService(IID_IAudioCaptureClient, (void **)&p_device->capture_client);

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -172,8 +172,6 @@ void FileAccessWindows::close() {
 		}
 
 		save_path = "";
-
-		ERR_FAIL_COND(rename_error);
 	}
 }
 
@@ -334,8 +332,7 @@ uint64_t FileAccessWindows::_get_modified_time(const String &p_file) {
 
 		return st.st_mtime;
 	} else {
-		ERR_EXPLAIN("Failed to get modified time for: " + file);
-		ERR_FAIL_V(0);
+		ERR_FAIL_V_MSG(0, "Failed to get modified time for: " + file + ".");
 	}
 }
 

--- a/editor/collada/collada.cpp
+++ b/editor/collada/collada.cpp
@@ -1903,8 +1903,7 @@ void Collada::_parse_animation(XMLParser &parser) {
 
 			Vector<float> &output = float_sources[output_id];
 
-			ERR_EXPLAIN("Wrong number of keys in output");
-			ERR_CONTINUE((output.size() / stride) != key_count);
+			ERR_CONTINUE_MSG((output.size() / stride) != key_count, "Wrong number of keys in output.");
 
 			for (int j = 0; j < key_count; j++) {
 				track.keys.write[j].data.resize(output_len);
@@ -2447,8 +2446,7 @@ void Collada::_find_morph_nodes(VisualScene *p_vscene, Node *p_node) {
 					state.morph_ownership_map[base] = nj->id;
 					break;
 				} else {
-					ERR_EXPLAIN("Invalid scene");
-					ERR_FAIL();
+					ERR_FAIL_MSG("Invalid scene.");
 				}
 			}
 		}

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -720,8 +720,7 @@ static Error _parse_methods(Ref<XMLParser> &parser, Vector<DocData::MethodDoc> &
 				methods.push_back(method);
 
 			} else {
-				ERR_EXPLAIN("Invalid tag in doc file: " + parser->get_node_name());
-				ERR_FAIL_V(ERR_FILE_CORRUPT);
+				ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + parser->get_node_name() + ".");
 			}
 
 		} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == section)
@@ -841,8 +840,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 								if (parser->get_node_type() == XMLParser::NODE_TEXT)
 									c.tutorials.push_back(parser->get_node_data().strip_edges());
 							} else {
-								ERR_EXPLAIN("Invalid tag in doc file: " + name3);
-								ERR_FAIL_V(ERR_FILE_CORRUPT);
+								ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name3 + ".");
 							}
 						} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "tutorials")
 							break; //end of <tutorials>
@@ -883,8 +881,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 									prop2.description = parser->get_node_data();
 								c.properties.push_back(prop2);
 							} else {
-								ERR_EXPLAIN("Invalid tag in doc file: " + name3);
-								ERR_FAIL_V(ERR_FILE_CORRUPT);
+								ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name3 + ".");
 							}
 
 						} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "members")
@@ -912,8 +909,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 									prop2.description = parser->get_node_data();
 								c.theme_properties.push_back(prop2);
 							} else {
-								ERR_EXPLAIN("Invalid tag in doc file: " + name3);
-								ERR_FAIL_V(ERR_FILE_CORRUPT);
+								ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name3 + ".");
 							}
 
 						} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "theme_items")
@@ -943,8 +939,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 									constant2.description = parser->get_node_data();
 								c.constants.push_back(constant2);
 							} else {
-								ERR_EXPLAIN("Invalid tag in doc file: " + name3);
-								ERR_FAIL_V(ERR_FILE_CORRUPT);
+								ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name3 + ".");
 							}
 
 						} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "constants")
@@ -953,8 +948,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 
 				} else {
 
-					ERR_EXPLAIN("Invalid tag in doc file: " + name2);
-					ERR_FAIL_V(ERR_FILE_CORRUPT);
+					ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name2 + ".");
 				}
 
 			} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "class")
@@ -991,10 +985,8 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 		Error err;
 		String save_file = save_path.plus_file(c.name + ".xml");
 		FileAccessRef f = FileAccess::open(save_file, FileAccess::WRITE, &err);
-		if (err) {
-			ERR_EXPLAIN("Can't write doc file: " + save_file);
-			ERR_CONTINUE(err);
-		}
+
+		ERR_CONTINUE_MSG(err != OK, "Can't write doc file: " + save_file + ".");
 
 		_write_string(f, 0, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
 

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -315,8 +315,7 @@ void EditorAutoloadSettings::_autoload_file_callback(const String &p_path) {
 
 Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
 	RES res = ResourceLoader::load(p_path);
-	ERR_EXPLAIN("Can't autoload: " + p_path);
-	ERR_FAIL_COND_V(res.is_null(), NULL);
+	ERR_FAIL_COND_V_MSG(res.is_null(), NULL, "Can't autoload: " + p_path + ".");
 	Node *n = NULL;
 	if (res->is_class("PackedScene")) {
 		Ref<PackedScene> ps = res;
@@ -325,20 +324,17 @@ Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
 		Ref<Script> s = res;
 		StringName ibt = s->get_instance_base_type();
 		bool valid_type = ClassDB::is_parent_class(ibt, "Node");
-		ERR_EXPLAIN("Script does not inherit a Node: " + p_path);
-		ERR_FAIL_COND_V(!valid_type, NULL);
+		ERR_FAIL_COND_V_MSG(!valid_type, NULL, "Script does not inherit a Node: " + p_path + ".");
 
 		Object *obj = ClassDB::instance(ibt);
 
-		ERR_EXPLAIN("Cannot instance script for autoload, expected 'Node' inheritance, got: " + String(ibt));
-		ERR_FAIL_COND_V(obj == NULL, NULL);
+		ERR_FAIL_COND_V_MSG(obj == NULL, NULL, "Cannot instance script for autoload, expected 'Node' inheritance, got: " + String(ibt) + ".");
 
 		n = Object::cast_to<Node>(obj);
 		n->set_script(s.get_ref_ptr());
 	}
 
-	ERR_EXPLAIN("Path in autoload not a node or script: " + p_path);
-	ERR_FAIL_COND_V(!n, NULL);
+	ERR_FAIL_COND_V_MSG(!n, NULL, "Path in autoload not a node or script: " + p_path + ".");
 
 	return n;
 }

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1011,7 +1011,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 	if (!ftmp) {
 		memdelete(f);
 		DirAccess::remove_file_or_error(tmppath);
-		ERR_FAIL_V_MSG(ERR_CANT_CREATE, "Can't open file to read from path: " + String(tmppath));
+		ERR_FAIL_V_MSG(ERR_CANT_CREATE, "Can't open file to read from path: " + String(tmppath) + ".");
 	}
 
 	const int bufsize = 16384;

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1930,8 +1930,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 			Error err = da->make_dir(".import");
 			if (err) {
 				memdelete(da);
-				ERR_EXPLAIN("Failed to create 'res://.import' folder.");
-				ERR_FAIL();
+				ERR_FAIL_MSG("Failed to create 'res://.import' folder.");
 			}
 		}
 		memdelete(da);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2795,8 +2795,7 @@ void EditorNode::select_editor_by_name(const String &p_name) {
 		}
 	}
 
-	ERR_EXPLAIN("The editor name '" + p_name + "' was not found.");
-	ERR_FAIL();
+	ERR_FAIL_MSG("The editor name '" + p_name + "' was not found.");
 }
 
 void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed) {
@@ -4797,8 +4796,7 @@ void EditorNode::remove_control_from_dock(Control *p_control) {
 		}
 	}
 
-	ERR_EXPLAIN("Control was not in dock");
-	ERR_FAIL_COND(!dock);
+	ERR_FAIL_COND_MSG(!dock, "Control was not in dock.");
 
 	dock->remove_child(p_control);
 	_update_dock_slots_visibility();

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -46,8 +46,7 @@ bool EditorResourcePreviewGenerator::handles(const String &p_type) const {
 	if (get_script_instance() && get_script_instance()->has_method("handles")) {
 		return get_script_instance()->call("handles", p_type);
 	}
-	ERR_EXPLAIN("EditorResourcePreviewGenerator::handles needs to be overridden");
-	ERR_FAIL_V(false);
+	ERR_FAIL_V_MSG(false, "EditorResourcePreviewGenerator::handles needs to be overridden.");
 }
 
 Ref<Texture> EditorResourcePreviewGenerator::generate(const RES &p_from, const Size2 &p_size) const {
@@ -55,8 +54,7 @@ Ref<Texture> EditorResourcePreviewGenerator::generate(const RES &p_from, const S
 	if (get_script_instance() && get_script_instance()->has_method("generate")) {
 		return get_script_instance()->call("generate", p_from, p_size);
 	}
-	ERR_EXPLAIN("EditorResourcePreviewGenerator::generate needs to be overridden");
-	ERR_FAIL_V(Ref<Texture>());
+	ERR_FAIL_V_MSG(Ref<Texture>(), "EditorResourcePreviewGenerator::generate needs to be overridden.");
 }
 
 Ref<Texture> EditorResourcePreviewGenerator::generate_from_path(const String &p_path, const Size2 &p_size) const {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1451,10 +1451,7 @@ void EditorSettings::add_shortcut(const String &p_name, Ref<ShortCut> &p_shortcu
 bool EditorSettings::is_shortcut(const String &p_name, const Ref<InputEvent> &p_event) const {
 
 	const Map<String, Ref<ShortCut> >::Element *E = shortcuts.find(p_name);
-	if (!E) {
-		ERR_EXPLAIN("Unknown Shortcut: " + p_name);
-		ERR_FAIL_V(false);
-	}
+	ERR_FAIL_COND_V_MSG(!E, false, "Unknown Shortcut: " + p_name + ".");
 
 	return E->get()->is_shortcut(p_event);
 }
@@ -1483,10 +1480,8 @@ Ref<ShortCut> ED_GET_SHORTCUT(const String &p_path) {
 	}
 
 	Ref<ShortCut> sc = EditorSettings::get_singleton()->get_shortcut(p_path);
-	if (!sc.is_valid()) {
-		ERR_EXPLAIN("Used ED_GET_SHORTCUT with invalid shortcut: " + p_path);
-		ERR_FAIL_COND_V(!sc.is_valid(), sc);
-	}
+
+	ERR_FAIL_COND_V_MSG(!sc.is_valid(), sc, "Used ED_GET_SHORTCUT with invalid shortcut: " + p_path + ".");
 
 	return sc;
 }

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -321,8 +321,7 @@ bool ExportTemplateManager::_install_from_file(const String &p_file, bool p_use_
 		if (!f) {
 			ret = unzGoToNextFile(pkg);
 			fc++;
-			ERR_EXPLAIN("Can't open file from path: " + String(to_write));
-			ERR_CONTINUE(true);
+			ERR_CONTINUE_MSG(true, "Can't open file from path: " + String(to_write) + ".");
 		}
 
 		f->store_buffer(data.ptr(), data.size());
@@ -591,8 +590,7 @@ Error ExportTemplateManager::install_android_template() {
 	zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
 
 	unzFile pkg = unzOpen2(source_zip.utf8().get_data(), &io);
-	ERR_EXPLAIN("Android sources not in zip format");
-	ERR_FAIL_COND_V(!pkg, ERR_CANT_OPEN);
+	ERR_FAIL_COND_V_MSG(!pkg, ERR_CANT_OPEN, "Android sources not in zip format.");
 
 	int ret = unzGoToFirstFile(pkg);
 

--- a/editor/file_type_cache.cpp
+++ b/editor/file_type_cache.cpp
@@ -83,11 +83,8 @@ void FileTypeCache::save() {
 	GLOBAL_LOCK_FUNCTION
 	String project = ProjectSettings::get_singleton()->get_resource_path();
 	FileAccess *f = FileAccess::open(project + "/file_type_cache.cch", FileAccess::WRITE);
-	if (!f) {
 
-		ERR_EXPLAIN(TTR("Can't open file_type_cache.cch for writing, not saving file type cache!"));
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(!f, "Can't open file_type_cache.cch for writing, not saving file type cache!");
 
 	const String *K = NULL;
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -453,8 +453,7 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 			path = target_path + "/";
 		} else {
 			memdelete(dirAccess);
-			ERR_EXPLAIN(vformat(TTR("Cannot navigate to '%s' as it has not been found in the file system!"), p_path));
-			ERR_FAIL();
+			ERR_FAIL_MSG(vformat("Cannot navigate to '%s' as it has not been found in the file system!", p_path));
 		}
 		memdelete(dirAccess);
 	}

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1204,10 +1204,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 					}
 				}
 
-				if (ngsource != "") {
-					ERR_EXPLAIN("Controller Instance Source '" + ngsource + "' is neither skin or morph!");
-					ERR_FAIL_V(ERR_INVALID_DATA);
-				}
+				ERR_FAIL_COND_V_MSG(ngsource != "", ERR_INVALID_DATA, "Controller instance source '" + ngsource + "' is neither skin or morph!");
 
 			} else {
 				meshid = ng2->source;
@@ -1608,7 +1605,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 				}
 
 				if (xform_idx == -1) {
-					WARN_PRINTS("Collada: Couldn't find matching node " + at.target + " xform for track " + at.param);
+					WARN_PRINTS("Collada: Couldn't find matching node " + at.target + " xform for track " + at.param + ".");
 					continue;
 				}
 
@@ -1630,8 +1627,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 				} else if (data.size() == xf.data.size()) {
 					xf.data = data;
 				} else {
-					ERR_EXPLAIN("Component " + at.component + " has datasize " + itos(data.size()) + ", xfdatasize " + itos(xf.data.size()));
-					ERR_CONTINUE(data.size() != xf.data.size());
+					ERR_CONTINUE_MSG(data.size() != xf.data.size(), "Component " + at.component + " has datasize " + itos(data.size()) + ", xfdatasize " + itos(xf.data.size()) + ".");
 				}
 			}
 

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1544,8 +1544,7 @@ Error EditorSceneImporterGLTF::_parse_cameras(GLTFState &state) {
 				camera.fov_size = 10;
 			}
 		} else {
-			ERR_EXPLAIN("Camera should be in 'orthographic' or 'perspective'");
-			ERR_FAIL_V(ERR_PARSE_ERROR);
+			ERR_FAIL_V_MSG(ERR_PARSE_ERROR, "Camera should be in 'orthographic' or 'perspective'");
 		}
 
 		state.cameras.push_back(camera);

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -101,8 +101,7 @@ Error ResourceImporterCSVTranslation::import(const String &p_source_file, const 
 	for (int i = 1; i < line.size(); i++) {
 
 		String locale = line[i];
-		ERR_EXPLAIN("Error importing CSV translation: '" + locale + "' is not a valid locale");
-		ERR_FAIL_COND_V(!TranslationServer::is_locale_valid(locale), ERR_PARSE_ERROR);
+		ERR_FAIL_COND_V_MSG(!TranslationServer::is_locale_valid(locale), ERR_PARSE_ERROR, "Error importing CSV translation: '" + locale + "' is not a valid locale.");
 
 		locales.push_back(locale);
 		Ref<Translation> translation;

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -45,8 +45,7 @@ uint32_t EditorOBJImporter::get_import_flags() const {
 static Error _parse_material_library(const String &p_path, Map<String, Ref<SpatialMaterial> > &material_map, List<String> *r_missing_deps) {
 
 	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ);
-	ERR_EXPLAIN(vformat("Couldn't open MTL file '%s', it may not exist or not be readable.", p_path));
-	ERR_FAIL_COND_V(!f, ERR_CANT_OPEN);
+	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, vformat("Couldn't open MTL file '%s', it may not exist or not be readable.", p_path));
 
 	Ref<SpatialMaterial> current;
 	String current_name;
@@ -207,8 +206,7 @@ static Error _parse_material_library(const String &p_path, Map<String, Ref<Spati
 static Error _parse_obj(const String &p_path, List<Ref<Mesh> > &r_meshes, bool p_single_mesh, bool p_generate_tangents, bool p_optimize, Vector3 p_scale_mesh, List<String> *r_missing_deps) {
 
 	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ);
-	ERR_EXPLAIN(vformat("Couldn't open OBJ file '%s', it may not exist or not be readable.", p_path));
-	ERR_FAIL_COND_V(!f, ERR_CANT_OPEN);
+	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, vformat("Couldn't open OBJ file '%s', it may not exist or not be readable.", p_path));
 
 	Ref<ArrayMesh> mesh;
 	mesh.instance();

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -123,8 +123,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 
 		file->close();
 		memdelete(file);
-		ERR_EXPLAIN("Not a WAV file (no WAVE RIFF Header)");
-		ERR_FAIL_V(ERR_FILE_UNRECOGNIZED);
+		ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "Not a WAV file (no WAVE RIFF header).");
 	}
 
 	int format_bits = 0;
@@ -166,16 +165,14 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			if (compression_code != 1 && compression_code != 3) {
 				file->close();
 				memdelete(file);
-				ERR_EXPLAIN("Format not supported for WAVE file (not PCM). Save WAVE files as uncompressed PCM instead.");
-				ERR_FAIL_V(ERR_INVALID_DATA);
+				ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Format not supported for WAVE file (not PCM). Save WAVE files as uncompressed PCM instead.");
 			}
 
 			format_channels = file->get_16();
 			if (format_channels != 1 && format_channels != 2) {
 				file->close();
 				memdelete(file);
-				ERR_EXPLAIN("Format not supported for WAVE file (not stereo or mono).");
-				ERR_FAIL_V(ERR_INVALID_DATA);
+				ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Format not supported for WAVE file (not stereo or mono).");
 			}
 
 			format_freq = file->get_32(); //sampling rate
@@ -187,8 +184,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			if (format_bits % 8 || format_bits == 0) {
 				file->close();
 				memdelete(file);
-				ERR_EXPLAIN("Invalid amount of bits in the sample (should be one of 8, 16, 24 or 32).");
-				ERR_FAIL_V(ERR_INVALID_DATA);
+				ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Invalid amount of bits in the sample (should be one of 8, 16, 24 or 32).");
 			}
 
 			/* Don't need anything else, continue */
@@ -258,8 +254,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			if (file->eof_reached()) {
 				file->close();
 				memdelete(file);
-				ERR_EXPLAIN("Premature end of file.");
-				ERR_FAIL_V(ERR_FILE_CORRUPT);
+				ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Premature end of file.");
 			}
 		}
 

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -87,8 +87,7 @@ void CPUParticles2DEditorPlugin::_generate_emission_mask() {
 	Ref<Image> img;
 	img.instance();
 	Error err = ImageLoader::load_image(source_emission_file, img);
-	ERR_EXPLAIN(TTR("Error loading image:") + " " + source_emission_file);
-	ERR_FAIL_COND(err != OK);
+	ERR_FAIL_COND_MSG(err != OK, "Error loading image: " + source_emission_file + ".");
 
 	if (img->is_compressed()) {
 		img->decompress();
@@ -196,8 +195,7 @@ void CPUParticles2DEditorPlugin::_generate_emission_mask() {
 		valid_normals.resize(vpc);
 	}
 
-	ERR_EXPLAIN(TTR("No pixels with transparency > 128 in image..."));
-	ERR_FAIL_COND(valid_positions.size() == 0);
+	ERR_FAIL_COND_MSG(valid_positions.size() == 0, "No pixels with transparency > 128 in image...");
 
 	if (capture_colors) {
 		PoolColorArray pca;

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -147,9 +147,8 @@ void MultiMeshEditor::_populate() {
 	w.release();
 
 	PoolVector<Face3> faces = geometry;
-	ERR_EXPLAIN(TTR("Parent has no solid faces to populate."));
 	int facecount = faces.size();
-	ERR_FAIL_COND(!facecount);
+	ERR_FAIL_COND_MSG(!facecount, "Parent has no solid faces to populate.");
 
 	PoolVector<Face3>::Read r = faces.read();
 
@@ -164,10 +163,8 @@ void MultiMeshEditor::_populate() {
 		area_accum += area;
 	}
 
-	ERR_EXPLAIN(TTR("Couldn't map area."));
-	ERR_FAIL_COND(triangle_area_map.size() == 0);
-	ERR_EXPLAIN(TTR("Couldn't map area."));
-	ERR_FAIL_COND(area_accum == 0);
+	ERR_FAIL_COND_MSG(triangle_area_map.size() == 0, "Couldn't map area.");
+	ERR_FAIL_COND_MSG(area_accum == 0, "Couldn't map area.");
 
 	Ref<MultiMesh> multimesh = memnew(MultiMesh);
 	multimesh->set_mesh(mesh);

--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -160,8 +160,7 @@ void Particles2DEditorPlugin::_generate_emission_mask() {
 	Ref<Image> img;
 	img.instance();
 	Error err = ImageLoader::load_image(source_emission_file, img);
-	ERR_EXPLAIN(TTR("Error loading image:") + " " + source_emission_file);
-	ERR_FAIL_COND(err != OK);
+	ERR_FAIL_COND_MSG(err != OK, "Error loading image: " + source_emission_file + ".");
 
 	if (img->is_compressed()) {
 		img->decompress();
@@ -269,8 +268,7 @@ void Particles2DEditorPlugin::_generate_emission_mask() {
 		valid_normals.resize(vpc);
 	}
 
-	ERR_EXPLAIN(TTR("No pixels with transparency > 128 in image..."));
-	ERR_FAIL_COND(valid_positions.size() == 0);
+	ERR_FAIL_COND_MSG(valid_positions.size() == 0, "No pixels with transparency > 128 in image...");
 
 	PoolVector<uint8_t> texdata;
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -191,11 +191,9 @@ void ThemeEditor::_save_template_cbk(String fname) {
 	}
 
 	FileAccess *file = FileAccess::open(filename, FileAccess::WRITE);
-	if (!file) {
 
-		ERR_EXPLAIN(TTR("Can't save theme to file:") + " " + filename);
-		return;
-	}
+	ERR_FAIL_COND_MSG(!file, "Can't save theme to file: " + filename + ".");
+
 	file->store_line("; ******************* ");
 	file->store_line("; Template Theme File ");
 	file->store_line("; ******************* ");

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -646,8 +646,7 @@ void TileSetEditor::_on_textures_added(const PoolStringArray &p_paths) {
 	for (int i = 0; i < p_paths.size(); i++) {
 		Ref<Texture> t = Ref<Texture>(ResourceLoader::load(p_paths[i]));
 
-		ERR_EXPLAIN("'" + p_paths[i] + "' is not a valid texture.");
-		ERR_CONTINUE(!t.is_valid());
+		ERR_CONTINUE_MSG(!t.is_valid(), "'" + p_paths[i] + "' is not a valid texture.");
 
 		if (texture_map.has(t->get_rid())) {
 			invalid_count++;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -986,9 +986,10 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				} else {
 					new_node = Object::cast_to<Node>(ClassDB::instance(selected_favorite_root));
 				}
+
 				if (!new_node) {
-					ERR_EXPLAIN("Creating root from favorite '" + selected_favorite_root + "' failed. Creating 'Node' instead.");
 					new_node = memnew(Node);
+					ERR_PRINTS("Creating root from favorite '" + selected_favorite_root + "' failed. Creating 'Node' instead.");
 				}
 			} else {
 				switch (p_tool) {
@@ -1537,10 +1538,7 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 	Node *validate = new_parent;
 	while (validate) {
 
-		if (p_nodes.find(validate) != -1) {
-			ERR_EXPLAIN("Selection changed at some point.. can't reparent");
-			ERR_FAIL();
-		}
+		ERR_FAIL_COND_MSG(p_nodes.find(validate) != -1, "Selection changed at some point.. can't reparent.");
 		validate = validate->get_parent();
 	}
 	//ok all valid
@@ -2253,8 +2251,7 @@ void SceneTreeDock::_normalize_drop(Node *&to_node, int &to_pos, int p_type) {
 		//drop at above selected node
 		if (to_node == EditorNode::get_singleton()->get_edited_scene()) {
 			to_node = NULL;
-			ERR_EXPLAIN("Cannot perform drop above the root node!");
-			ERR_FAIL();
+			ERR_FAIL_MSG("Cannot perform drop above the root node!");
 		}
 
 		to_pos = to_node->get_index();


### PR DESCRIPTION
I removed all the EXPLAIN error codes from /core, /drivers, and /editor except for a few files that I had troubles with: 
core/error_macros.h (defines EXPLAIN and uses it in the *_MSG calls, so don't know if it needs changed)
core/io/file_access_buffered_fa.h (couldn't find it in my files)
core/os/memory.cpp (combining CRASH_NOW with the EXPLAINC, seemed to only give errors)
drivers/png/png_driver_common.cpp (wasn't sure how to replace just a EXPLAINC)
drivers/xaudio2/audio_driver_xaudio2.cpp (couldn't find it in my files)

I also removed all the TTR() that I could find, which only existed in editor.

*Bugsquad edit:* Part of #31207.