### PR TITLE
Tweak the size of the multiline text edit popup dialog

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -116,7 +116,7 @@ void EditorPropertyMultilineText::_open_big_text() {
 		add_child(big_text_dialog);
 	}
 
-	big_text_dialog->popup_centered_ratio();
+	big_text_dialog->popup_centered_clamped(Size2(1000, 900) * EDSCALE, 0.8);
 	big_text->set_text(text->get_text());
 	big_text->grab_focus();
 }


### PR DESCRIPTION
This caps its size on large displays. This in turn prevents lines from becoming very long, which could hamper text readability.

## Preview

*Previews below were taken with a window size of 2560×1440 at 100% scaling.*

### Before

![Before](https://user-images.githubusercontent.com/180032/62805987-d8481c80-baf1-11e9-80ed-aaba7baa2685.png)


### After

![After](https://user-images.githubusercontent.com/180032/62805941-bb134e00-baf1-11e9-85ae-dafdbdaed09d.png)
