### PR TITLE
Adds support for undo/redo for in-editor color picker

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1621,7 +1621,9 @@ void ScriptTextEditor::_color_changed(const Color &p_color) {
 	line_with_replaced_args = line_with_replaced_args.insert(color_args_pos, new_args);
 
 	color_args = new_args;
+	code_editor->get_text_edit()->begin_complex_operation();
 	code_editor->get_text_edit()->set_line(color_position.x, line_with_replaced_args);
+	code_editor->get_text_edit()->end_complex_operation();
 	code_editor->get_text_edit()->update();
 }
 


### PR DESCRIPTION
Now colors picked in in-editor ColorPicker can be undone and redone, previously it was not possible:

Preview:
![undo_new](https://user-images.githubusercontent.com/9964886/62813222-d7bb8000-bb09-11e9-8ef9-2eee004679d9.gif)

Should have been a part of https://github.com/godotengine/godot/pull/31042/files but I did not have time then to find out how to do it.