### PR TITLE
Rename option is no longer suggested when selecting res:// in filesystem dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2146,7 +2146,9 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 
 	if (p_paths.size() == 1) {
 		p_popup->add_item(TTR("Copy Path"), FILE_COPY_PATH);
-		p_popup->add_item(TTR("Rename..."), FILE_RENAME);
+		if (p_paths[0] != "res://") {
+			p_popup->add_item(TTR("Rename..."), FILE_RENAME);
+		}
 		p_popup->add_item(TTR("Duplicate..."), FILE_DUPLICATE);
 	}
 


### PR DESCRIPTION
Fix for small bug found while working on bigger issue:
When selecting res:// in filesystem dock rename option is present in context menu but it does nothing due to validation, it looks like this:
![rename_old](https://user-images.githubusercontent.com/9964886/62813755-da6ba480-bb0c-11e9-8d4c-0cea0d609026.gif)

I've removed this option form menu while selecting res:// folder:
![Screenshot from 2019-08-10 01-11-21](https://user-images.githubusercontent.com/9964886/62813762-f2432880-bb0c-11e9-8386-5c8e20ea75d2.png)

Note that I left validation present while attempting to rename - better safe than sorry