### PR TITLE
Plugin support for visual shaders

### DIFF
--- a/doc/classes/VisualShaderNode.xml
+++ b/doc/classes/VisualShaderNode.xml
@@ -39,5 +39,20 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="PORT_TYPE_SCALAR" value="0" enum="PortType">
+			Floating-point scalar. Translated to [code]float[/code] type in shader code.
+		</constant>
+		<constant name="PORT_TYPE_VECTOR" value="1" enum="PortType">
+			3D vector of floating-point values. Translated to [code]vec3[/code] type in shader code.
+		</constant>
+		<constant name="PORT_TYPE_BOOLEAN" value="2" enum="PortType">
+			Boolean type. Translated to [code]bool[/code] type in shader code.
+		</constant>
+		<constant name="PORT_TYPE_TRANSFORM" value="3" enum="PortType">
+			Transform type. Translated to [code]mat4[/code] type in shader code.
+		</constant>
+		<constant name="PORT_TYPE_ICON_COLOR" value="4" enum="PortType">
+			Color type. Can be used for return icon type in members dialog (see [method VisualShaderNodeCustom._get_return_icon_type]) - do not use it in other cases!
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisualShaderNodeCustom" inherits="VisualShaderNode" category="Core" version="3.2">
+	<brief_description>
+		Virtual class to define custom [VisualShaderNode]s for use in the Visual Shader Editor.
+	</brief_description>
+	<description>
+		By inheriting this class you can create a custom [VisualShader] script addon which will be automatically added to the Visual Shader Editor. The [VisualShaderNode]'s behavior is defined by overriding the provided virtual methods.
+		In order for the node to be registered as an editor addon, you must use the [code]tool[/code] keyword and provide a [code]class_name[/code] for your custom script. For example:
+		[codeblock]
+		tool
+		extends VisualShaderNodeCustom
+		class_name VisualShaderNodeNoise
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_get_category" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<description>
+				Override this method to define the category of the associated custom node in the Visual Shader Editor's members dialog.
+				Defining this method is [b]optional[/b]. If not overridden, the node will be filed under the "Custom" category.
+			</description>
+			</method>
+		<method name="_get_description" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<description>
+				Override this method to define the description of the associated custom node in the Visual Shader Editor's members dialog.
+				Defining this method is [b]optional[/b].
+			</description>
+		</method>
+		<method name="_get_code" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<argument index="0" name="input_vars" type="Array">
+			</argument>
+			<argument index="1" name="output_vars" type="Array">
+			</argument>
+			<argument index="2" name="mode" type="int" enum="Shader.Mode">
+			</argument>	
+			<argument index="3" name="type" type="int" enum="VisualShader.Type">
+			</argument>
+			<description>
+				Override this method to define the actual shader code of the associated custom node. The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
+				The [code]input_vars[/code] and [code]output_vars[/code] arrays contain the string names of the various input and output variables, as defined by [code]_get_input_*[/code] and [code]_get_output_*[/code] virtual methods in this class.
+				The output ports can be assigned values in the shader code. For example, [code]return output_vars[0] + " = " + input_vars[0] + ";"[/code].
+				You can customize the generated code based on the shader [code]mode[/code] (see [enum Shader.Mode]) and/or [code]type[/code] (see [enum VisualShader.Type]).
+				Defining this method is [b]required[/b].
+			</description>
+		</method>
+		<method name="_get_global_code" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<argument index="0" name="mode" type="int" enum="Shader.Mode">
+			</argument>
+			<description>
+				Override this method to add shader code on top of the global shader, to define your own standard library of reusable methods, varyings, constants, uniforms, etc. The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
+				Be careful with this functionality as it can cause name conflicts with other custom nodes, so be sure to give the defined entities unique names.
+				You can customize the generated code based on the shader [code]mode[/code] (see [enum Shader.Mode]).
+				Defining this method is [b]optional[/b].
+			</description>
+		</method>
+		<method name="_get_input_port_count" qualifiers="virtual">
+			<return type="int">
+			</return>
+			<description>
+				Override this method to define the amount of input ports of the associated custom node.
+				Defining this method is [b]required[/b]. If not overridden, the node has no input ports.
+			</description>
+		</method>
+		<method name="_get_input_port_name" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<argument index="0" name="port" type="int">
+			</argument>
+			<description>
+				Override this method to define the names of input ports of the associated custom node. The names are used both for the input slots in the editor and as identifiers in the shader code, and are passed in the [code]input_vars[/code] array in [method _get_code].
+				Defining this method is [b]optional[/b], but recommended. If not overridden, input ports are named as [code]"in" + str(port)[/code].
+			</description>
+		</method>
+		<method name="_get_input_port_type" qualifiers="virtual">
+			<return type="int" enum="VisualShaderNode.PortType">
+			</return>
+			<argument index="0" name="port" type="int">
+			</argument>
+			<description>
+				Override this method to define the returned type of each input port of the associated custom node (see [enum VisualShaderNode.PortType] for possible types).
+				Defining this method is [b]optional[/b], but recommended. If not overridden, input ports will return the [constant VisualShaderNode.PORT_TYPE_SCALAR] type.
+			</description>
+		</method>
+		<method name="_get_name" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<description>
+				Override this method to define the name of the associated custom node in the Visual Shader Editor's members dialog and graph.
+				Defining this method is [b]optional[/b], but recommended. If not overridden, the node will be named as "Unnamed".
+			</description>
+		</method>
+		<method name="_get_output_port_count" qualifiers="virtual">
+			<return type="int">
+			</return>
+			<description>
+				Override this method to define the amount of output ports of the associated custom node.
+				Defining this method is [b]required[/b]. If not overridden, the node has no output ports.
+			</description>
+		</method>
+		<method name="_get_output_port_name" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<argument index="0" name="port" type="int">
+			</argument>
+			<description>
+				Override this method to define the names of output ports of the associated custom node. The names are used both for the output slots in the editor and as identifiers in the shader code, and are passed in the [code]output_vars[/code] array in [method _get_code].
+				Defining this method is [b]optional[/b], but recommended. If not overridden, output ports are named as [code]"out" + str(port)[/code].
+			</description>
+		</method>
+		<method name="_get_output_port_type" qualifiers="virtual">
+			<return type="int" enum="VisualShaderNode.PortType">
+			</return>
+			<argument index="0" name="port" type="int">
+			</argument>
+			<description>
+				Override this method to define the returned type of each output port of the associated custom node (see [enum VisualShaderNode.PortType] for possible types).
+				Defining this method is [b]optional[/b], but recommended. If not overridden, output ports will return the [constant VisualShaderNode.PORT_TYPE_SCALAR] type.
+			</description>
+		</method>
+		<method name="_get_return_icon_type" qualifiers="virtual">
+			<return type="int" enum="VisualShaderNode.PortType">
+			</return>
+			<description>
+				Override this method to define the return icon of the associated custom node in the Visual Shader Editor's members dialog.
+				Defining this method is [b]optional[/b]. If not overridden, no return icon is shown.
+			</description>
+		</method>
+		<method name="_get_subcategory" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<description>
+				Override this method to define the subcategory of the associated custom node in the Visual Shader Editor's members dialog.
+				Defining this method is [b]optional[/b]. If not overridden, the node will be filed under the root of the main category (see [method _get_category]).
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -104,6 +104,7 @@ class VisualShaderEditor : public VBoxContainer {
 		int func;
 		float value;
 		bool highend;
+		bool is_custom;
 
 		AddOption(const String &p_name = String(), const String &p_category = String(), const String &p_sub_category = String(), const String &p_type = String(), const String &p_description = String(), int p_sub_func = -1, int p_return_type = -1, int p_mode = -1, int p_func = -1, float p_value = -1, bool p_highend = false) {
 			name = p_name;
@@ -117,6 +118,7 @@ class VisualShaderEditor : public VBoxContainer {
 			func = p_func;
 			value = p_value;
 			highend = p_highend;
+			is_custom = false;
 		}
 
 		AddOption(const String &p_name, const String &p_category, const String &p_sub_category, const String &p_type, const String &p_description, const String &p_sub_func, int p_return_type = -1, int p_mode = -1, int p_func = -1, float p_value = -1, bool p_highend = false) {
@@ -131,6 +133,7 @@ class VisualShaderEditor : public VBoxContainer {
 			func = p_func;
 			value = p_value;
 			highend = p_highend;
+			is_custom = false;
 		}
 	};
 
@@ -140,6 +143,7 @@ class VisualShaderEditor : public VBoxContainer {
 	void _draw_color_over_button(Object *obj, Color p_color);
 
 	void _add_node(int p_idx, int p_op_idx = -1);
+	void _update_custom_nodes();
 	void _update_options_menu();
 
 	static VisualShaderEditor *singleton;
@@ -240,8 +244,8 @@ public:
 
 	static VisualShaderEditor *get_singleton() { return singleton; }
 
-	void add_custom_type(const String &p_name, const String &p_category, const Ref<Script> &p_script);
-	void remove_custom_type(const Ref<Script> &p_script);
+	void clear_custom_types();
+	void add_custom_type(const String &p_name, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, const String &p_sub_category);
 
 	virtual Size2 get_minimum_size() const;
 	void edit(VisualShader *p_visual_shader);

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2530,7 +2530,7 @@ String VisualScriptCustomNode::get_category() const {
 	if (get_script_instance() && get_script_instance()->has_method("_get_category")) {
 		return get_script_instance()->call("_get_category");
 	}
-	return "custom";
+	return "Custom";
 }
 
 class VisualScriptNodeInstanceCustomNode : public VisualScriptNodeInstance {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -475,6 +475,7 @@ void register_scene_types() {
 	ClassDB::register_class<Shader>();
 	ClassDB::register_class<VisualShader>();
 	ClassDB::register_virtual_class<VisualShaderNode>();
+	ClassDB::register_class<VisualShaderNodeCustom>();
 	ClassDB::register_class<VisualShaderNodeInput>();
 	ClassDB::register_virtual_class<VisualShaderNodeOutput>();
 	ClassDB::register_class<VisualShaderNodeGroupBase>();

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -183,7 +183,7 @@ public:
 		PORT_TYPE_VECTOR,
 		PORT_TYPE_BOOLEAN,
 		PORT_TYPE_TRANSFORM,
-		PORT_TYPE_COLOR // just a hint for node tree icons, do not use it as actual port type !
+		PORT_TYPE_ICON_COLOR // just a hint for node tree icons, do not use it as actual port type !
 	};
 
 	virtual String get_caption() const = 0;
@@ -216,6 +216,44 @@ public:
 
 	VisualShaderNode();
 };
+
+VARIANT_ENUM_CAST(VisualShaderNode::PortType)
+
+class VisualShaderNodeCustom : public VisualShaderNode {
+	GDCLASS(VisualShaderNodeCustom, VisualShaderNode);
+
+	struct Port {
+		String name;
+		int type;
+	};
+
+	List<Port> input_ports;
+	List<Port> output_ports;
+
+	friend class VisualShaderEditor;
+
+protected:
+	virtual String get_caption() const;
+
+	virtual int get_input_port_count() const;
+	virtual PortType get_input_port_type(int p_port) const;
+	virtual String get_input_port_name(int p_port) const;
+
+	virtual int get_output_port_count() const;
+	virtual PortType get_output_port_type(int p_port) const;
+	virtual String get_output_port_name(int p_port) const;
+
+protected:
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const;
+	virtual String generate_global_per_node(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
+
+	static void _bind_methods();
+
+public:
+	VisualShaderNodeCustom();
+	void update_ports();
+};
+
 /////
 
 class VisualShaderNodeInput : public VisualShaderNode {


### PR DESCRIPTION
This PR allows user to create custom nodes for visual shader editor. ~~The creation process is similar to standart EditorPlugin (described in http://docs.godotengine.org/en/latest/tutorials/plugins/editor/making_plugins.html).~~

Fix #3349

Here is example of creation Noise function plugin (using shader code from https://github.com/curly-brace/Godot-3.0-Noise-Shaders)

```
tool
extends VisualShaderNodeCustom
class_name VisualShaderNodeNoise

func _get_name():
	return "Noise"

func _get_category():
	return "CoolLib"

func _get_subcategory():
	return "Effects"

func _get_description():
	return "My favorite noise function"

func _get_return_icon_type():
	return 0 # scalar

func _get_input_port_count():
	return 2
	
func _get_input_port_type(port):
	match port:
		0:
			return 1 # vector
		1:
			return 0 # scalar
	return 0
	
func _get_input_port_name(port):
	match port:
		0:
			return "offset"
		1:
			return "scale"
	return ""

func _get_output_port_count():
	return 1

func _get_output_port_type(port):
	return 0 # scalar

func _get_output_port_name(port):
	return "output"

func _get_global_code(mode):
	var code := ""
	code += """
	vec3 mod289_3(vec3 x) {
	    return x - floor(x * (1.0 / 289.0)) * 289.0;
	}
	
	vec4 mod289_4(vec4 x) {
	    return x - floor(x * (1.0 / 289.0)) * 289.0;
	}
	
	vec4 permute(vec4 x) {
	    return mod289_4(((x*34.0)+1.0)*x);
	}
	
	vec4 taylorInvSqrt(vec4 r) {
	    return 1.79284291400159 - 0.85373472095314 * r;
	}
	
	vec3 fade(vec3 t) {
	    return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
	}
	
	// Classic Perlin noise
	float cnoise(vec3 P) {
	    vec3 Pi0 = floor(P); // Integer part for indexing
	    vec3 Pi1 = Pi0 + vec3(1.0); // Integer part + 1
	    Pi0 = mod289_3(Pi0);
	    Pi1 = mod289_3(Pi1);
	    vec3 Pf0 = fract(P); // Fractional part for interpolation
	    vec3 Pf1 = Pf0 - vec3(1.0); // Fractional part - 1.0
	    vec4 ix = vec4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
	    vec4 iy = vec4(Pi0.yy, Pi1.yy);
	    vec4 iz0 = vec4(Pi0.z);
	    vec4 iz1 = vec4(Pi1.z);
	    
	    vec4 ixy = permute(permute(ix) + iy);
	    vec4 ixy0 = permute(ixy + iz0);
	    vec4 ixy1 = permute(ixy + iz1);
	    
	    vec4 gx0 = ixy0 * (1.0 / 7.0);
	    vec4 gy0 = fract(floor(gx0) * (1.0 / 7.0)) - 0.5;
	    gx0 = fract(gx0);
	    vec4 gz0 = vec4(0.5) - abs(gx0) - abs(gy0);
	    vec4 sz0 = step(gz0, vec4(0.0));
	    gx0 -= sz0 * (step(0.0, gx0) - 0.5);
	    gy0 -= sz0 * (step(0.0, gy0) - 0.5);
	    
	    vec4 gx1 = ixy1 * (1.0 / 7.0);
	    vec4 gy1 = fract(floor(gx1) * (1.0 / 7.0)) - 0.5;
	    gx1 = fract(gx1);
	    vec4 gz1 = vec4(0.5) - abs(gx1) - abs(gy1);
	    vec4 sz1 = step(gz1, vec4(0.0));
	    gx1 -= sz1 * (step(0.0, gx1) - 0.5);
	    gy1 -= sz1 * (step(0.0, gy1) - 0.5);
	    
	    vec3 g000 = vec3(gx0.x,gy0.x,gz0.x);
	    vec3 g100 = vec3(gx0.y,gy0.y,gz0.y);
	    vec3 g010 = vec3(gx0.z,gy0.z,gz0.z);
	    vec3 g110 = vec3(gx0.w,gy0.w,gz0.w);
	    vec3 g001 = vec3(gx1.x,gy1.x,gz1.x);
	    vec3 g101 = vec3(gx1.y,gy1.y,gz1.y);
	    vec3 g011 = vec3(gx1.z,gy1.z,gz1.z);
	    vec3 g111 = vec3(gx1.w,gy1.w,gz1.w);
	    
	    vec4 norm0 = taylorInvSqrt(vec4(dot(g000, g000), dot(g010, g010), dot(g100, g100), dot(g110, g110)));
	    g000 *= norm0.x;
	    g010 *= norm0.y;
	    g100 *= norm0.z;
	    g110 *= norm0.w;
	    vec4 norm1 = taylorInvSqrt(vec4(dot(g001, g001), dot(g011, g011), dot(g101, g101), dot(g111, g111)));
	    g001 *= norm1.x;
	    g011 *= norm1.y;
	    g101 *= norm1.z;
	    g111 *= norm1.w;
	    
	    float n000 = dot(g000, Pf0);
	    float n100 = dot(g100, vec3(Pf1.x, Pf0.yz));
	    float n010 = dot(g010, vec3(Pf0.x, Pf1.y, Pf0.z));
	    float n110 = dot(g110, vec3(Pf1.xy, Pf0.z));
	    float n001 = dot(g001, vec3(Pf0.xy, Pf1.z));
	    float n101 = dot(g101, vec3(Pf1.x, Pf0.y, Pf1.z));
	    float n011 = dot(g011, vec3(Pf0.x, Pf1.yz));
	    float n111 = dot(g111, Pf1);
	    
	    vec3 fade_xyz = fade(Pf0);
	    vec4 n_z = mix(vec4(n000, n100, n010, n110), vec4(n001, n101, n011, n111), fade_xyz.z);
	    vec2 n_yz = mix(n_z.xy, n_z.zw, fade_xyz.y);
	    float n_xyz = mix(n_yz.x, n_yz.y, fade_xyz.x); 
	    return 2.2 * n_xyz;
	}
	
	// Classic Perlin noise, periodic variant
	float pnoise(vec3 P, vec3 rep) {
	    vec3 Pi0 = mod(floor(P), rep); // Integer part, modulo period
	    vec3 Pi1 = mod(Pi0 + vec3(1.0), rep); // Integer part + 1, mod period
	    Pi0 = mod289_3(Pi0);
	    Pi1 = mod289_3(Pi1);
	    vec3 Pf0 = fract(P); // Fractional part for interpolation
	    vec3 Pf1 = Pf0 - vec3(1.0); // Fractional part - 1.0
	    vec4 ix = vec4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
	    vec4 iy = vec4(Pi0.yy, Pi1.yy);
	    vec4 iz0 = vec4(Pi0.z);
	    vec4 iz1 = vec4(Pi1.z);
	    
	    vec4 ixy = permute(permute(ix) + iy);
	    vec4 ixy0 = permute(ixy + iz0);
	    vec4 ixy1 = permute(ixy + iz1);
	    
	    vec4 gx0 = ixy0 * (1.0 / 7.0);
	    vec4 gy0 = fract(floor(gx0) * (1.0 / 7.0)) - 0.5;
	    gx0 = fract(gx0);
	    vec4 gz0 = vec4(0.5) - abs(gx0) - abs(gy0);
	    vec4 sz0 = step(gz0, vec4(0.0));
	    gx0 -= sz0 * (step(0.0, gx0) - 0.5);
	    gy0 -= sz0 * (step(0.0, gy0) - 0.5);
	    
	    vec4 gx1 = ixy1 * (1.0 / 7.0);
	    vec4 gy1 = fract(floor(gx1) * (1.0 / 7.0)) - 0.5;
	    gx1 = fract(gx1);
	    vec4 gz1 = vec4(0.5) - abs(gx1) - abs(gy1);
	    vec4 sz1 = step(gz1, vec4(0.0));
	    gx1 -= sz1 * (step(0.0, gx1) - 0.5);
	    gy1 -= sz1 * (step(0.0, gy1) - 0.5);
	    
	    vec3 g000 = vec3(gx0.x,gy0.x,gz0.x);
	    vec3 g100 = vec3(gx0.y,gy0.y,gz0.y);
	    vec3 g010 = vec3(gx0.z,gy0.z,gz0.z);
	    vec3 g110 = vec3(gx0.w,gy0.w,gz0.w);
	    vec3 g001 = vec3(gx1.x,gy1.x,gz1.x);
	    vec3 g101 = vec3(gx1.y,gy1.y,gz1.y);
	    vec3 g011 = vec3(gx1.z,gy1.z,gz1.z);
	    vec3 g111 = vec3(gx1.w,gy1.w,gz1.w);
	    
	    vec4 norm0 = taylorInvSqrt(vec4(dot(g000, g000), dot(g010, g010), dot(g100, g100), dot(g110, g110)));
	    g000 *= norm0.x;
	    g010 *= norm0.y;
	    g100 *= norm0.z;
	    g110 *= norm0.w;
	    vec4 norm1 = taylorInvSqrt(vec4(dot(g001, g001), dot(g011, g011), dot(g101, g101), dot(g111, g111)));
	    g001 *= norm1.x;
	    g011 *= norm1.y;
	    g101 *= norm1.z;
	    g111 *= norm1.w;
	    
	    float n000 = dot(g000, Pf0);
	    float n100 = dot(g100, vec3(Pf1.x, Pf0.yz));
	    float n010 = dot(g010, vec3(Pf0.x, Pf1.y, Pf0.z));
	    float n110 = dot(g110, vec3(Pf1.xy, Pf0.z));
	    float n001 = dot(g001, vec3(Pf0.xy, Pf1.z));
	    float n101 = dot(g101, vec3(Pf1.x, Pf0.y, Pf1.z));
	    float n011 = dot(g011, vec3(Pf0.x, Pf1.yz));
	    float n111 = dot(g111, Pf1);
	    
	    vec3 fade_xyz = fade(Pf0);
	    vec4 n_z = mix(vec4(n000, n100, n010, n110), vec4(n001, n101, n011, n111), fade_xyz.z);
	    vec2 n_yz = mix(n_z.xy, n_z.zw, fade_xyz.y);
	    float n_xyz = mix(n_yz.x, n_yz.y, fade_xyz.x); 
	    return 2.2 * n_xyz;
	}"""
	return code

func _get_code(p_input_vars, p_output_vars, mode, type):
	var code = ""
	code += p_output_vars[0] + " = cnoise(vec3((UV + " + p_input_vars[0] + ".xy) * " + p_input_vars[1] + ", TIME)) * 0.5 + 0.5;";
	return code
```

~~After enabling the plugin in editor settings, your visual shader editor member tree will contains a new item:~~

After reloading editor, your visual shader editor member tree will contains a new item:

![image](https://user-images.githubusercontent.com/3036176/62821037-98774880-bb76-11e9-9157-febca28c1c85.png)

And the final looking function in the graph looks like this:

![image](https://user-images.githubusercontent.com/3036176/62821089-e2acf980-bb77-11e9-8b0c-0315cb3a5c60.png)

PS: If you see error message "editor\editor_settings.cpp:1219 - Condition ' err != OK ' is true." is not related to this PR, its just an already existed bug. 