### PR TITLE
Fix Offset with OptionButton Popup

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -74,7 +74,7 @@ void Popup::_fix_size() {
 
 	Point2 pos = get_global_position();
 	Size2 size = get_size() * get_scale();
-	Point2 window_size = get_viewport_rect().size;
+	Point2 window_size = get_viewport_rect().size - get_viewport_transform().get_origin();
 
 	if (pos.x + size.width > window_size.width)
 		pos.x = window_size.width - size.width;


### PR DESCRIPTION
Fixes the offset issue with the OptionButton's popup.

The popup of an OptionButton offsets itself to stay within the viewport bounds. When the viewport position is not zero, the offset is incorrect because it does not check the viewport position when offsetting.

Example project with two scenes (one with a camera and one without a camera)
http://s000.tinyupload.com/index.php?file_id=49870689348996793563

Closes: #31098 and closes #18441