### PR TITLE
Remove old doc comments in image_loader header

### DIFF
--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -41,19 +41,7 @@
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 
-/**
- * @class ImageScanLineLoader
- * @author Juan Linietsky <reduzio@gmail.com>
- *
-
- */
 class ImageLoader;
-
-/**
- * @class ImageLoader
- * Base Class and singleton for loading images from disk
- * Can load images in one go, or by scanline
- */
 
 class ImageFormatLoader {
 	friend class ImageLoader;


### PR DESCRIPTION
Asked reduz about these on IRC.

```
[15:06:26] <reduz> iamactuallycthul: yeah that looks like a super old comment that remained over the years even after code was rewritten many times
```