### PR TITLE
Fixed vertex color initialization with default value in GLES3

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -200,6 +200,8 @@ void RasterizerCanvasGLES3::canvas_end() {
 	glBindBufferBase(GL_UNIFORM_BUFFER, 0, 0);
 	glColorMask(1, 1, 1, 1);
 
+	glVertexAttrib4f(VS::ARRAY_COLOR, 1, 1, 1, 1);
+
 	state.using_texture_rect = false;
 	state.using_ninepatch = false;
 }


### PR DESCRIPTION
This change makes sure vertex color is initialized with white as a default value, the same way as for GLES2, so materials with 'Use as Albedo' flag don't render with the last used vertex color.

Fixes #30275, fixes #31250.