### PR TITLE
Replace 'ERR_EXPLAIN' with 'ERR_FAIL_*_MSG' in rest of 'modules/'

### DIFF
--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -150,8 +150,7 @@ Node *EditorSceneImporterAssimp::import_scene(const String &p_path, uint32_t p_f
 								 0;
 	const aiScene *scene = importer.ReadFile(s_path.c_str(),
 			post_process_Steps);
-	ERR_EXPLAIN(String("Open Asset Import failed to open: ") + String(importer.GetErrorString()));
-	ERR_FAIL_COND_V(scene == NULL, NULL);
+	ERR_FAIL_COND_V_MSG(scene == NULL, NULL, String("Open Asset Import failed to open: ") + String(importer.GetErrorString()) + ".");
 	return _generate_scene(p_path, scene, p_flags, p_bake_fps, max_bone_weights);
 }
 
@@ -348,8 +347,7 @@ void EditorSceneImporterAssimp::_fill_node_relationships(ImportState &state, con
 	} else if (ownership[name] != p_skeleton_id) {
 		//oh, it's from another skeleton? fine.. reparent all bones to this skeleton.
 		int prev_owner = ownership[name];
-		ERR_EXPLAIN("A previous skeleton exists for bone '" + name + "', this type of skeleton layout is unsupported.");
-		ERR_FAIL_COND(skeleton_map.has(prev_owner));
+		ERR_FAIL_COND_MSG(skeleton_map.has(prev_owner), "A previous skeleton exists for bone '" + name + "', this type of skeleton layout is unsupported.");
 		for (Map<String, int>::Element *E = ownership.front(); E; E = E->next()) {
 			if (E->get() == prev_owner) {
 				E->get() = p_skeleton_id;
@@ -779,8 +777,7 @@ Ref<Texture> EditorSceneImporterAssimp::_load_texture(ImportState &state, String
 				t->set_storage(ImageTexture::STORAGE_COMPRESS_LOSSY);
 				return t;
 			} else if (tex->CheckFormat("dds")) {
-				ERR_EXPLAIN("Open Asset Import: Embedded dds not implemented");
-				ERR_FAIL_COND_V(true, Ref<Texture>());
+				ERR_FAIL_V_MSG(Ref<Texture>(), "Open Asset Import: Embedded dds not implemented.");
 				//Ref<Image> img = Image::_dds_mem_loader_func((uint8_t *)tex->pcData, tex->mWidth);
 				//ERR_FAIL_COND_V(img.is_null(), Ref<Texture>());
 				//Ref<ImageTexture> t;

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -241,9 +241,9 @@ Error ImageLoaderBMP::load_image(Ref<Image> p_image, FileAccess *f,
 				case BI_CMYKRLE8:
 				case BI_CMYKRLE4: {
 					// Stop parsing
-					ERR_EXPLAIN("Compressed BMP files are not supported: " + f->get_path());
+					String bmp_path = f->get_path();
 					f->close();
-					ERR_FAIL_V(ERR_UNAVAILABLE);
+					ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Compressed BMP files are not supported: " + bmp_path + ".");
 				} break;
 			}
 			// Don't rely on sizeof(bmp_file_header) as structure padding

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -1548,8 +1548,7 @@ void BulletPhysicsServer::free(RID p_rid) {
 		bulletdelete(space);
 	} else {
 
-		ERR_EXPLAIN("Invalid ID");
-		ERR_FAIL();
+		ERR_FAIL_MSG("Invalid ID.");
 	}
 }
 

--- a/modules/bullet/cone_twist_joint_bullet.cpp
+++ b/modules/bullet/cone_twist_joint_bullet.cpp
@@ -83,8 +83,7 @@ void ConeTwistJointBullet::set_param(PhysicsServer::ConeTwistJointParam p_param,
 			coneConstraint->setLimit(coneConstraint->getSwingSpan1(), coneConstraint->getSwingSpan2(), coneConstraint->getTwistSpan(), coneConstraint->getLimitSoftness(), coneConstraint->getBiasFactor(), p_value);
 			break;
 		default:
-			ERR_EXPLAIN("This parameter " + itos(p_param) + " is deprecated");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("The parameter " + itos(p_param) + " is deprecated.");
 			break;
 	}
 }
@@ -102,8 +101,7 @@ real_t ConeTwistJointBullet::get_param(PhysicsServer::ConeTwistJointParam p_para
 		case PhysicsServer::CONE_TWIST_JOINT_RELAXATION:
 			return coneConstraint->getRelaxationFactor();
 		default:
-			ERR_EXPLAIN("This parameter " + itos(p_param) + " is deprecated");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("The parameter " + itos(p_param) + " is deprecated.");
 			return 0;
 	}
 }

--- a/modules/bullet/generic_6dof_joint_bullet.cpp
+++ b/modules/bullet/generic_6dof_joint_bullet.cpp
@@ -174,8 +174,7 @@ void Generic6DOFJointBullet::set_param(Vector3::Axis p_axis, PhysicsServer::G6DO
 			sixDOFConstraint->getRotationalLimitMotor(p_axis)->m_equilibriumPoint = p_value;
 			break;
 		default:
-			ERR_EXPLAIN("This parameter " + itos(p_param) + " is deprecated");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("The parameter " + itos(p_param) + " is deprecated.");
 			break;
 	}
 }
@@ -216,8 +215,7 @@ real_t Generic6DOFJointBullet::get_param(Vector3::Axis p_axis, PhysicsServer::G6
 		case PhysicsServer::G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT:
 			return sixDOFConstraint->getRotationalLimitMotor(p_axis)->m_equilibriumPoint;
 		default:
-			ERR_EXPLAIN("This parameter " + itos(p_param) + " is deprecated");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("The parameter " + itos(p_param) + " is deprecated.");
 			return 0;
 	}
 }
@@ -255,8 +253,7 @@ void Generic6DOFJointBullet::set_flag(Vector3::Axis p_axis, PhysicsServer::G6DOF
 			sixDOFConstraint->getRotationalLimitMotor(p_axis)->m_enableSpring = p_value;
 			break;
 		default:
-			ERR_EXPLAIN("This flag " + itos(p_flag) + " is deprecated");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("The flag " + itos(p_flag) + " is deprecated.");
 			break;
 	}
 }

--- a/modules/bullet/hinge_joint_bullet.cpp
+++ b/modules/bullet/hinge_joint_bullet.cpp
@@ -117,8 +117,7 @@ void HingeJointBullet::set_param(PhysicsServer::HingeJointParam p_param, real_t 
 			hingeConstraint->setMaxMotorImpulse(p_value);
 			break;
 		default:
-			ERR_EXPLAIN("The HingeJoint parameter " + itos(p_param) + " is deprecated.");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("The HingeJoint parameter " + itos(p_param) + " is deprecated.");
 			break;
 	}
 }
@@ -143,8 +142,7 @@ real_t HingeJointBullet::get_param(PhysicsServer::HingeJointParam p_param) const
 		case PhysicsServer::HINGE_JOINT_MOTOR_MAX_IMPULSE:
 			return hingeConstraint->getMaxMotorImpulse();
 		default:
-			ERR_EXPLAIN("The HingeJoint parameter " + itos(p_param) + " is deprecated.");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("The HingeJoint parameter " + itos(p_param) + " is deprecated.");
 			return 0;
 	}
 }

--- a/modules/bullet/pin_joint_bullet.cpp
+++ b/modules/bullet/pin_joint_bullet.cpp
@@ -85,8 +85,7 @@ real_t PinJointBullet::get_param(PhysicsServer::PinJointParam p_param) const {
 		case PhysicsServer::PIN_JOINT_IMPULSE_CLAMP:
 			return p2pConstraint->m_setting.m_impulseClamp;
 		default:
-			ERR_EXPLAIN("This parameter " + itos(p_param) + " is deprecated");
-			WARN_DEPRECATED;
+			WARN_DEPRECATED_MSG("The parameter " + itos(p_param) + " is deprecated.");
 			return 0;
 	}
 }

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -505,8 +505,7 @@ void HeightMapShapeBullet::set_data(const Variant &p_data) {
 		}
 
 	} else {
-		ERR_EXPLAIN("Expected PoolRealArray or float Image.");
-		ERR_FAIL();
+		ERR_FAIL_MSG("Expected PoolRealArray or float Image.");
 	}
 
 	ERR_FAIL_COND(l_width <= 0);

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -581,10 +581,8 @@ void SpaceBullet::create_empty_world(bool p_create_soft_world) {
 	} else {
 		world_mem = malloc(sizeof(btDiscreteDynamicsWorld));
 	}
-	if (!world_mem) {
-		ERR_EXPLAIN("Out of memory");
-		ERR_FAIL();
-	}
+
+	ERR_FAIL_COND_MSG(!world_mem, "Out of memory.");
 
 	if (p_create_soft_world) {
 		collisionConfiguration = bulletnew(GodotSoftCollisionConfiguration(static_cast<btDiscreteDynamicsWorld *>(world_mem)));

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -108,8 +108,7 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 	if (r_error)
 		*r_error = ERR_FILE_CORRUPT;
 
-	ERR_EXPLAIN("Unable to open DDS texture file: " + p_path);
-	ERR_FAIL_COND_V(err != OK, RES());
+	ERR_FAIL_COND_V_MSG(err != OK, RES(), "Unable to open DDS texture file: " + p_path + ".");
 
 	uint32_t magic = f->get_32();
 	uint32_t hsize = f->get_32();
@@ -128,8 +127,7 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 
 	if (magic != DDS_MAGIC || hsize != 124 || !(flags & DDSD_PIXELFORMAT) || !(flags & DDSD_CAPS)) {
 
-		ERR_EXPLAIN("Invalid or Unsupported DDS texture file: " + p_path);
-		ERR_FAIL_V(RES());
+		ERR_FAIL_V_MSG(RES(), "Invalid or unsupported DDS texture file: " + p_path + ".");
 	}
 
 	/* uint32_t format_size = */ f->get_32();
@@ -218,9 +216,7 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 	} else {
 
 		printf("unrecognized fourcc %x format_flags: %x - rgbbits %i - red_mask %x green mask %x blue mask %x alpha mask %x\n", format_fourcc, format_flags, format_rgb_bits, format_red_mask, format_green_mask, format_blue_mask, format_alpha_mask);
-		ERR_EXPLAIN("Unrecognized or Unsupported color layout in DDS: " + p_path);
-
-		ERR_FAIL_V(RES());
+		ERR_FAIL_V_MSG(RES(), "Unrecognized or unsupported color layout in DDS: " + p_path + ".");
 	}
 
 	if (!(flags & DDSD_MIPMAPCOUNT))

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -543,10 +543,7 @@ Error NetworkedMultiplayerENet::put_packet(const uint8_t *p_buffer, int p_buffer
 	if (target_peer != 0) {
 
 		E = peer_map.find(ABS(target_peer));
-		if (!E) {
-			ERR_EXPLAIN("Invalid Target Peer: " + itos(target_peer));
-			ERR_FAIL_V(ERR_INVALID_PARAMETER);
-		}
+		ERR_FAIL_COND_V_MSG(!E, ERR_INVALID_PARAMETER, "Invalid target peer: " + itos(target_peer) + ".");
 	}
 
 	ENetPacket *packet = enet_packet_create(NULL, p_buffer_size + 8, packet_flags);
@@ -794,11 +791,7 @@ int NetworkedMultiplayerENet::get_peer_port(int p_peer_id) const {
 void NetworkedMultiplayerENet::set_transfer_channel(int p_channel) {
 
 	ERR_FAIL_COND(p_channel < -1 || p_channel >= channel_count);
-
-	if (p_channel == SYSCH_CONFIG) {
-		ERR_EXPLAIN("Channel " + itos(SYSCH_CONFIG) + " is reserved");
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(p_channel == SYSCH_CONFIG, "Channel " + itos(SYSCH_CONFIG) + " is reserved.");
 	transfer_channel = p_channel;
 }
 

--- a/modules/etc/texture_loader_pkm.cpp
+++ b/modules/etc/texture_loader_pkm.cpp
@@ -56,8 +56,7 @@ RES ResourceFormatPKM::load(const String &p_path, const String &p_original_path,
 	if (r_error)
 		*r_error = ERR_FILE_CORRUPT;
 
-	ERR_EXPLAIN("Unable to open PKM texture file: " + p_path);
-	ERR_FAIL_COND_V(err != OK, RES());
+	ERR_FAIL_COND_V_MSG(err != OK, RES(), "Unable to open PKM texture file: " + p_path + ".");
 
 	// big endian
 	f->set_endian_swap(true);

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -196,16 +196,14 @@ bool GridMap::get_collision_layer_bit(int p_bit) const {
 #ifndef DISABLE_DEPRECATED
 void GridMap::set_theme(const Ref<MeshLibrary> &p_theme) {
 
-	ERR_EXPLAIN("GridMap.theme/set_theme() is deprecated and will be removed in a future version. Use GridMap.mesh_library/set_mesh_library() instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("GridMap.theme/set_theme() is deprecated and will be removed in a future version. Use GridMap.mesh_library/set_mesh_library() instead.");
 
 	set_mesh_library(p_theme);
 }
 
 Ref<MeshLibrary> GridMap::get_theme() const {
 
-	ERR_EXPLAIN("GridMap.theme/get_theme() is deprecated and will be removed in a future version. Use GridMap.mesh_library/get_mesh_library() instead.");
-	WARN_DEPRECATED;
+	WARN_DEPRECATED_MSG("GridMap.theme/get_theme() is deprecated and will be removed in a future version. Use GridMap.mesh_library/get_mesh_library() instead.");
 
 	return get_mesh_library();
 }

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -102,10 +102,7 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 				len <<= 8;
 				len |= f->get_8();
 
-				if (len != width) {
-					ERR_EXPLAIN("invalid decoded scanline length, corrupt HDR");
-					ERR_FAIL_V(ERR_FILE_CORRUPT);
-				}
+				ERR_FAIL_COND_V_MSG(len != width, ERR_FILE_CORRUPT, "Invalid decoded scanline length, corrupt HDR.");
 
 				for (int k = 0; k < 4; ++k) {
 					int i = 0;

--- a/modules/opus/audio_stream_opus.cpp
+++ b/modules/opus/audio_stream_opus.cpp
@@ -287,8 +287,7 @@ int AudioStreamPlaybackOpus::mix(int16_t *p_buffer, int p_frames) {
 		int ret = op_read(opus_file, (opus_int16 *)p_buffer, todo * stream_channels, &current_section);
 		if (ret < 0) {
 			playing = false;
-			ERR_EXPLAIN("Error reading Opus File: " + file);
-			ERR_BREAK(ret < 0);
+			ERR_BREAK_MSG(ret < 0, "Error reading Opus file: " + file + ".");
 		} else if (ret == 0) { // end of song, reload?
 			op_free(opus_file);
 

--- a/modules/pvr/texture_loader_pvr.cpp
+++ b/modules/pvr/texture_loader_pvr.cpp
@@ -149,8 +149,7 @@ RES ResourceFormatPVR::load(const String &p_path, const String &p_original_path,
 			format = Image::FORMAT_ETC;
 			break;
 		default:
-			ERR_EXPLAIN("Unsupported format in PVR texture: " + itos(flags & 0xFF));
-			ERR_FAIL_V(RES());
+			ERR_FAIL_V_MSG(RES(), "Unsupported format in PVR texture: " + itos(flags & 0xFF) + ".");
 	}
 
 	w.release();

--- a/modules/squish/image_compress_squish.cpp
+++ b/modules/squish/image_compress_squish.cpp
@@ -57,8 +57,7 @@ void image_decompress_squish(Image *p_image) {
 	} else if (p_image->get_format() == Image::FORMAT_RGTC_RG) {
 		squish_flags = squish::kBc5;
 	} else {
-		ERR_EXPLAIN("Squish: Can't decompress unknown format: " + itos(p_image->get_format()));
-		ERR_FAIL_COND(true);
+		ERR_FAIL_MSG("Squish: Can't decompress unknown format: " + itos(p_image->get_format()) + ".");
 		return;
 	}
 

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -109,12 +109,10 @@ Error ImageLoaderSVG::_create_image(Ref<Image> p_image, const PoolVector<uint8_t
 	float upscale = upsample ? 2.0 : 1.0;
 
 	int w = (int)(svg_image->width * p_scale * upscale);
-	ERR_EXPLAIN(vformat("Can't create image from SVG with scale %s, the resulting image size exceeds max width.", rtos(p_scale)));
-	ERR_FAIL_COND_V(w > Image::MAX_WIDTH, ERR_PARAMETER_RANGE_ERROR);
+	ERR_FAIL_COND_V_MSG(w > Image::MAX_WIDTH, ERR_PARAMETER_RANGE_ERROR, vformat("Can't create image from SVG with scale %s, the resulting image size exceeds max width.", rtos(p_scale)));
 
 	int h = (int)(svg_image->height * p_scale * upscale);
-	ERR_EXPLAIN(vformat("Can't create image from SVG with scale %s, the resulting image size exceeds max height.", rtos(p_scale)));
-	ERR_FAIL_COND_V(h > Image::MAX_HEIGHT, ERR_PARAMETER_RANGE_ERROR);
+	ERR_FAIL_COND_V_MSG(h > Image::MAX_HEIGHT, ERR_PARAMETER_RANGE_ERROR, vformat("Can't create image from SVG with scale %s, the resulting image size exceeds max height.", rtos(p_scale)));
 
 	PoolVector<uint8_t> dst_image;
 	dst_image.resize(w * h * 4);

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -328,8 +328,7 @@ void VisualScript::add_node(const StringName &p_func, int p_id, const Ref<Visual
 
 	if (Object::cast_to<VisualScriptFunction>(*p_node)) {
 		//the function indeed
-		ERR_EXPLAIN("A function node already has been set here.");
-		ERR_FAIL_COND(func.function_id >= 0);
+		ERR_FAIL_COND_MSG(func.function_id >= 0, "A function node has already been set here.");
 
 		func.function_id = p_id;
 	}
@@ -1917,8 +1916,7 @@ Variant VisualScriptInstance::call(const StringName &p_method, const Variant **p
 	if (!E) {
 		r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 
-		ERR_EXPLAIN("No VisualScriptFunction node in function!");
-		ERR_FAIL_V(Variant());
+		ERR_FAIL_V_MSG(Variant(), "No VisualScriptFunction node in function.");
 	}
 
 	VisualScriptNodeInstance *node = E->get();
@@ -1974,8 +1972,7 @@ String VisualScriptInstance::to_string(bool *r_valid) {
 			if (ret.get_type() != Variant::STRING) {
 				if (r_valid)
 					*r_valid = false;
-				ERR_EXPLAIN("Wrong type for " + CoreStringNames::get_singleton()->_to_string + ", must be a String.");
-				ERR_FAIL_V(String());
+				ERR_FAIL_V_MSG(String(), "Wrong type for " + CoreStringNames::get_singleton()->_to_string + ", must be a String.");
 			}
 			if (r_valid)
 				*r_valid = true;
@@ -2262,15 +2259,10 @@ Variant VisualScriptFunctionState::_signal_callback(const Variant **p_args, int 
 	ERR_FAIL_COND_V(function == StringName(), Variant());
 
 #ifdef DEBUG_ENABLED
-	if (instance_id && !ObjectDB::get_instance(instance_id)) {
-		ERR_EXPLAIN("Resumed after yield, but class instance is gone");
-		ERR_FAIL_V(Variant());
-	}
 
-	if (script_id && !ObjectDB::get_instance(script_id)) {
-		ERR_EXPLAIN("Resumed after yield, but script is gone");
-		ERR_FAIL_V(Variant());
-	}
+	ERR_FAIL_COND_V_MSG(instance_id && !ObjectDB::get_instance(instance_id), Variant(), "Resumed after yield, but class instance is gone.");
+	ERR_FAIL_COND_V_MSG(script_id && !ObjectDB::get_instance(script_id), Variant(), "Resumed after yield, but script is gone.");
+
 #endif
 
 	r_error.error = Variant::CallError::CALL_OK;
@@ -2329,15 +2321,10 @@ Variant VisualScriptFunctionState::resume(Array p_args) {
 
 	ERR_FAIL_COND_V(function == StringName(), Variant());
 #ifdef DEBUG_ENABLED
-	if (instance_id && !ObjectDB::get_instance(instance_id)) {
-		ERR_EXPLAIN("Resumed after yield, but class instance is gone");
-		ERR_FAIL_V(Variant());
-	}
 
-	if (script_id && !ObjectDB::get_instance(script_id)) {
-		ERR_EXPLAIN("Resumed after yield, but script is gone");
-		ERR_FAIL_V(Variant());
-	}
+	ERR_FAIL_COND_V_MSG(instance_id && !ObjectDB::get_instance(instance_id), Variant(), "Resumed after yield, but class instance is gone.");
+	ERR_FAIL_COND_V_MSG(script_id && !ObjectDB::get_instance(script_id), Variant(), "Resumed after yield, but script is gone.");
+
 #endif
 
 	Variant::CallError r_error;

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -116,8 +116,7 @@ int AudioStreamPlaybackOGGVorbis::mix(int16_t *p_buffer, int p_frames) {
 		if (ret < 0) {
 
 			playing = false;
-			ERR_EXPLAIN("Error reading OGG Vorbis File: " + file);
-			ERR_BREAK(ret < 0);
+			ERR_BREAK_MSG(ret < 0, "Error reading OGG Vorbis file: " + file + ".");
 		} else if (ret == 0) { // end of song, reload?
 
 			ov_clear(&vf);

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -53,8 +53,7 @@ public:
 
 		file = FileAccess::open(p_file, FileAccess::READ);
 
-		ERR_EXPLAIN("Failed loading resource: '" + p_file + "';");
-		ERR_FAIL_COND(!file);
+		ERR_FAIL_COND_MSG(!file, "Failed loading resource: '" + p_file + "'.");
 	}
 	~MkvReader() {
 

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -84,8 +84,7 @@ static Ref<Image> _webp_lossy_unpack(const PoolVector<uint8_t> &p_buffer) {
 	ERR_FAIL_COND_V(r[0] != 'W' || r[1] != 'E' || r[2] != 'B' || r[3] != 'P', Ref<Image>());
 	WebPBitstreamFeatures features;
 	if (WebPGetFeatures(&r[4], size, &features) != VP8_STATUS_OK) {
-		ERR_EXPLAIN("Error unpacking WEBP image:");
-		ERR_FAIL_V(Ref<Image>());
+		ERR_FAIL_V_MSG(Ref<Image>(), "Error unpacking WEBP image.");
 	}
 
 	/*

--- a/modules/webrtc/webrtc_data_channel_js.cpp
+++ b/modules/webrtc/webrtc_data_channel_js.cpp
@@ -68,10 +68,8 @@ void WebRTCDataChannelJS::_on_error() {
 }
 
 void WebRTCDataChannelJS::_on_message(uint8_t *p_data, uint32_t p_size, bool p_is_string) {
-	if (in_buffer.space_left() < (int)(p_size + 5)) {
-		ERR_EXPLAIN("Buffer full! Dropping data");
-		ERR_FAIL();
-	}
+
+	ERR_FAIL_COND_MSG(in_buffer.space_left() < (int)(p_size + 5), "Buffer full! Dropping data.");
 
 	uint8_t is_string = p_is_string ? 1 : 0;
 	in_buffer.write((uint8_t *)&p_size, 4);

--- a/modules/webrtc/webrtc_multiplayer.cpp
+++ b/modules/webrtc/webrtc_multiplayer.cpp
@@ -321,10 +321,8 @@ Error WebRTCMultiplayer::put_packet(const uint8_t *p_buffer, int p_buffer_size) 
 	if (target_peer > 0) {
 
 		E = peer_map.find(target_peer);
-		if (!E) {
-			ERR_EXPLAIN("Invalid Target Peer: " + itos(target_peer));
-			ERR_FAIL_V(ERR_INVALID_PARAMETER);
-		}
+		ERR_FAIL_COND_V_MSG(!E, ERR_INVALID_PARAMETER, "Invalid target peer: " + itos(target_peer) + ".");
+
 		ERR_FAIL_COND_V(E->value()->channels.size() <= ch, ERR_BUG);
 		ERR_FAIL_COND_V(!E->value()->channels[ch].is_valid(), ERR_BUG);
 		return E->value()->channels[ch]->put_packet(p_buffer, p_buffer_size);

--- a/modules/webrtc/webrtc_peer_connection_gdnative.cpp
+++ b/modules/webrtc/webrtc_peer_connection_gdnative.cpp
@@ -51,13 +51,11 @@ Error WebRTCPeerConnectionGDNative::set_default_library(const godot_net_webrtc_l
 WebRTCPeerConnection *WebRTCPeerConnectionGDNative::_create() {
 
 	WebRTCPeerConnectionGDNative *obj = memnew(WebRTCPeerConnectionGDNative);
-	ERR_EXPLAIN("Default GDNative WebRTC implementation not defined.");
-	ERR_FAIL_COND_V(!default_library, obj);
+	ERR_FAIL_COND_V_MSG(!default_library, obj, "Default GDNative WebRTC implementation not defined.");
 
 	// Call GDNative constructor
 	Error err = (Error)default_library->create_peer_connection(obj);
-	ERR_EXPLAIN("GDNative default library constructor returned an error");
-	ERR_FAIL_COND_V(err != OK, obj);
+	ERR_FAIL_COND_V_MSG(err != OK, obj, "GDNative default library constructor returned an error.");
 
 	return obj;
 }

--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -131,14 +131,12 @@ void EMWSPeer::close(int p_code, String p_reason) {
 
 IP_Address EMWSPeer::get_connected_host() const {
 
-	ERR_EXPLAIN("Not supported in HTML5 export");
-	ERR_FAIL_V(IP_Address());
+	ERR_FAIL_V_MSG(IP_Address(), "Not supported in HTML5 export.");
 };
 
 uint16_t EMWSPeer::get_connected_port() const {
 
-	ERR_EXPLAIN("Not supported in HTML5 export");
-	ERR_FAIL_V(0);
+	ERR_FAIL_V_MSG(0, "Not supported in HTML5 export.");
 };
 
 EMWSPeer::EMWSPeer() {

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -98,16 +98,14 @@ void WebSocketMultiplayerPeer::_bind_methods() {
 //
 int WebSocketMultiplayerPeer::get_available_packet_count() const {
 
-	ERR_EXPLAIN("Please use get_peer(ID).get_available_packet_count to get available packet count from peers when not using the MultiplayerAPI.");
-	ERR_FAIL_COND_V(!_is_multiplayer, ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V_MSG(!_is_multiplayer, ERR_UNCONFIGURED, "Please use get_peer(ID).get_available_packet_count to get available packet count from peers when not using the MultiplayerAPI.");
 
 	return _incoming_packets.size();
 }
 
 Error WebSocketMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 
-	ERR_EXPLAIN("Please use get_peer(ID).get_packet/var to communicate with peers when not using the MultiplayerAPI.");
-	ERR_FAIL_COND_V(!_is_multiplayer, ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V_MSG(!_is_multiplayer, ERR_UNCONFIGURED, "Please use get_peer(ID).get_packet/var to communicate with peers when not using the MultiplayerAPI.");
 
 	r_buffer_size = 0;
 
@@ -127,8 +125,7 @@ Error WebSocketMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buff
 
 Error WebSocketMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 
-	ERR_EXPLAIN("Please use get_peer(ID).put_packet/var to communicate with peers when not using the MultiplayerAPI.");
-	ERR_FAIL_COND_V(!_is_multiplayer, ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V_MSG(!_is_multiplayer, ERR_UNCONFIGURED, "Please use get_peer(ID).put_packet/var to communicate with peers when not using the MultiplayerAPI.");
 
 	PoolVector<uint8_t> buffer = _make_pkt(SYS_NONE, get_unique_id(), _target_peer, p_buffer, p_buffer_size);
 
@@ -160,8 +157,7 @@ void WebSocketMultiplayerPeer::set_target_peer(int p_target_peer) {
 
 int WebSocketMultiplayerPeer::get_packet_peer() const {
 
-	ERR_EXPLAIN("This function is not available when not using the MultiplayerAPI.");
-	ERR_FAIL_COND_V(!_is_multiplayer, 1);
+	ERR_FAIL_COND_V_MSG(!_is_multiplayer, 1, "This function is not available when not using the MultiplayerAPI.");
 	ERR_FAIL_COND_V(_incoming_packets.size() == 0, 1);
 
 	return _incoming_packets.front()->get().source;
@@ -354,8 +350,7 @@ void WebSocketMultiplayerPeer::_process_multiplayer(Ref<WebSocketPeer> p_peer, u
 				_peer_id = id;
 				break;
 			default:
-				ERR_EXPLAIN("Invalid multiplayer message");
-				ERR_FAIL();
+				ERR_FAIL_MSG("Invalid multiplayer message.");
 				break;
 		}
 	}


### PR DESCRIPTION
Went through the rest of 'modules/' to replace most usages remaining of `ERR_EXPLAIN` in there, however left with a few places where it was again disjointed from the error slightly, first one:

https://github.com/godotengine/godot/blob/3418f76a9eab9f496e5b26310bd3bc1125b8119b/modules/etc/texture_loader_pkm.cpp#L66-L69

as well as a second one: https://github.com/godotengine/godot/blob/3418f76a9eab9f496e5b26310bd3bc1125b8119b/modules/hdr/image_loader_hdr.cpp#L47-L51

and lastly one `ERR_EXPLAINC` that was in use inside the xatlas_unwrap module:
https://github.com/godotengine/godot/blob/3418f76a9eab9f496e5b26310bd3bc1125b8119b/modules/xatlas_unwrap/register_types.cpp#L65-L66

In the last case, without importing godot's String, the normal error macro couldn't be used directly, so that's why I decided to just put this up for debate.

Part of #31207.