### PR TITLE
Fixed link errors when building in debug with RegEx module disabled

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -484,6 +484,13 @@ if selected_platform in platform_list:
     if env['minizip']:
         env.Append(CPPDEFINES=['MINIZIP_ENABLED'])
 
+    editor_module_list = ['regex']
+    for x in editor_module_list:
+        if not env['module_' + x + '_enabled']:
+            if env['tools']:
+                print("Build option 'module_" + x + "_enabled=no' cannot be used with 'tools=yes' (editor), only with 'tools=no' (export template).")
+                sys.exit(255)
+
     if not env['verbose']:
         methods.no_verbose(sys, env)
 

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -432,6 +432,10 @@ bool test_26() {
 
 	OS::get_singleton()->print("\n\nTest 26: RegEx substitution\n");
 
+#ifndef MODULE_REGEX_ENABLED
+	OS::get_singleton()->print("\tRegEx module disabled, can't run test.");
+	return false;
+#else
 	String s = "Double all the vowels.";
 
 	OS::get_singleton()->print("\tString: %ls\n", s.c_str());
@@ -443,6 +447,7 @@ bool test_26() {
 	OS::get_singleton()->print("\tResult: %ls\n", s.c_str());
 
 	return (s == "Doouublee aall thee vooweels.");
+#endif
 }
 
 struct test_27_data {


### PR DESCRIPTION
This change allows to build godot with a command line like:
`scons platform=windows tools=no target=release_debug module_regex_enabled=no`

One of the string tests involving RegEx was causing link errors. Instead the test will fail with a specific message.

*Bugsquad edit:* Fixes #30761.