### PR TITLE
Fixes issue with debug inspecing of nodes that are not in the scene tree

### DIFF
--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -601,9 +601,19 @@ void ScriptDebuggerRemote::_send_object_id(ObjectID p_id) {
 			}
 		}
 	}
+
 	if (Node *node = Object::cast_to<Node>(obj)) {
-		PropertyInfo pi(Variant::NODE_PATH, String("Node/path"));
-		properties.push_front(PropertyDesc(pi, node->get_path()));
+		// in some cases node will not be in tree here
+		// for instance where it created as variable and not yet added to tree
+		// in such cases we can't ask for it's path
+		if (node->is_inside_tree()) {
+			PropertyInfo pi(Variant::NODE_PATH, String("Node/path"));
+			properties.push_front(PropertyDesc(pi, node->get_path()));
+		} else {
+			PropertyInfo pi(Variant::STRING, String("Node/path"));
+			properties.push_front(PropertyDesc(pi, "[Orphan]"));
+		}
+
 	} else if (Resource *res = Object::cast_to<Resource>(obj)) {
 		if (Script *s = Object::cast_to<Script>(res)) {
 			Map<StringName, Variant> constants;


### PR DESCRIPTION
As of master 3418f76a9 there is a bug in debug inspector - clicking on node that has not yet entered scene tree results in node info in inspector showing only for a split second and plethora of errors appearing in error log. Reason is simple - remote debugger is always asking for node path to put it in one in properties that are sent to Godot editor and then displayed in inspector panel (path property). Get_path() method checks if node is in tree and throws error otherwise. Simple check if node is in tree before asking for path fixes issue - path property of such nodes is simply not displayed in inspector.

**Before fix:**
![debugger_before_fix](https://user-images.githubusercontent.com/9964886/62833793-b1e6c600-bc44-11e9-9ec6-3dfc889930b9.gif)

**After fix:**
![debugger_fix](https://user-images.githubusercontent.com/9964886/62833844-6254ca00-bc45-11e9-8d86-938904d9f82f.gif)

