### PR TITLE
Fix get_meta error and visual bug when editing scene with keyboard

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1181,23 +1181,22 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				}
 			}
 
-			if (p_item->cells[i].selected && select_mode != SELECT_ROW) {
-
+			if (select_mode != SELECT_ROW && (p_item->cells[i].selected || selected_item == p_item)) {
 				Rect2i r(cell_rect.position, cell_rect.size);
+
 				if (p_item->cells[i].text.size() > 0) {
 					float icon_width = p_item->cells[i].get_icon_size().width;
 					r.position.x += icon_width;
 					r.size.x -= icon_width;
 				}
 				p_item->set_meta("__focus_rect", Rect2(r.position, r.size));
-				if (has_focus()) {
-					cache.selected_focus->draw(ci, r);
-				} else {
-					cache.selected->draw(ci, r);
-				}
-				if (text_editor->is_visible_in_tree()) {
-					Vector2 ofs2(0, (text_editor->get_size().height - r.size.height) / 2);
-					text_editor->set_position(get_global_position() + r.position - ofs2);
+
+				if (p_item->cells[i].selected) {
+					if (has_focus()) {
+						cache.selected_focus->draw(ci, r);
+					} else {
+						cache.selected->draw(ci, r);
+					}
 				}
 			}
 


### PR DESCRIPTION
**Problem**
Working in the scene tree sometimes results in this error message being thrown in console:

    ERROR: get_meta: Condition ' !metadata.has(p_name) ' is true. returned: Variant()
       At: core/object.cpp:1059.

This is related to #22021. The error thrown in console
is not very detailed. it just says that something requested some metadata which does not exist. This PR only fixes one possible reason why this error might be thrown.

**Cause**
The error is thrown in `Tree::edit_selected()` on `s->get_meta("__focus_rect")` because the currently selected item does not have this metadata.

The word "selected" has two meanings in the Tree class. The selected item (returned by `Tree::get_selected()` and used in `edit_selected()`) is displayed with a grey border.
The selected cell (used in `Tree::draw_item()` and responsible for setting `__focus_rect`) is displayed with a grey background. This ambiguity is usually not a problem because you most likely use your mouse to select and rename Nodes in your Scene, so that the selected item also contains the selected cells and thus has a `__focus_rect`. This bug occurs when selecting nodes with your keyboard because then you only change the selected item (with the grey border) but not the selected cells. If you then try to rename an item which has never been selected (with the grey background) `__focus_rect` won't be set and this error is thrown.

I also removed a `text_exitor->set_position` because it causes a visual bug where the text editor to change the name of the currently selected item (with the grey border) is placed above the currently selected cell (with the grey background).

Also, it looks like only 3D scenes have this issue? In a 2D scene, I can't have a selected item with only a grey border.

**EDIT** it looks like this non-feature of having separate selection types in 3D scenes creates more problems than solutions, so maybe it would be better to remove this behaviour entirely.