### PR TITLE
Fix keyboard navigation in `EditorFileDialog`

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -109,7 +109,7 @@ void EditorFileDialog::_notification(int p_what) {
 	}
 }
 
-void EditorFileDialog::_unhandled_input(const Ref<InputEvent> &p_event) {
+void EditorFileDialog::_item_list_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventKey> k = p_event;
 
@@ -1344,7 +1344,7 @@ EditorFileDialog::DisplayMode EditorFileDialog::get_display_mode() const {
 
 void EditorFileDialog::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_unhandled_input"), &EditorFileDialog::_unhandled_input);
+	ClassDB::bind_method(D_METHOD("_item_list_input"), &EditorFileDialog::_item_list_input);
 
 	ClassDB::bind_method(D_METHOD("_item_selected"), &EditorFileDialog::_item_selected);
 	ClassDB::bind_method(D_METHOD("_multi_selected"), &EditorFileDialog::_multi_selected);
@@ -1634,6 +1634,7 @@ EditorFileDialog::EditorFileDialog() {
 	item_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	item_list->connect("item_rmb_selected", this, "_item_list_item_rmb_selected");
 	item_list->connect("rmb_clicked", this, "_item_list_rmb_clicked");
+	item_list->connect("gui_input", this, "_item_list_input");
 	item_list->set_allow_rmb_select(true);
 	list_vb->add_child(item_list);
 

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -196,7 +196,7 @@ private:
 	void _thumbnail_done(const String &p_path, const Ref<Texture> &p_preview, const Ref<Texture> &p_small_preview, const Variant &p_udata);
 	void _request_single_thumbnail(const String &p_path);
 
-	void _unhandled_input(const Ref<InputEvent> &p_event);
+	void _item_list_input(const Ref<InputEvent> &p_event);
 
 	bool _is_open_should_be_disabled();
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2250,9 +2250,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 			gui.key_event_accepted = false;
 			if (gui.key_focus->can_process()) {
-				gui.key_focus->call_multilevel(SceneStringNames::get_singleton()->_gui_input, p_event);
-				if (gui.key_focus) //maybe lost it
-					gui.key_focus->emit_signal(SceneStringNames::get_singleton()->gui_input, p_event);
+				gui.key_focus->emit_signal(SceneStringNames::get_singleton()->gui_input, p_event);
+				if (gui.key_focus && !gui.key_event_accepted) //maybe lost it
+					gui.key_focus->call_multilevel(SceneStringNames::get_singleton()->_gui_input, p_event);
 			}
 
 			if (gui.key_event_accepted) {


### PR DESCRIPTION
When pressing Alt + Left, the item list already handled the event
and moved the selection to the left, unless the first item was
selected. Because of this, moving up the history didn't work
consistently. By using the gui_input signal to override the event
handling, we can catch these events and handle them before the
item list gets its fingers on them.
Also gui_input should be emitted in viewport.cpp before _gui_input
is called(Like explained in line 1516).

Related to #18793
Might be a better way to do #22198