### PR TITLE
 Add minimap to TextEdit

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -908,6 +908,8 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_hiding_enabled(EditorSettings::get_singleton()->get("text_editor/line_numbers/code_folding"));
 	text_editor->set_draw_fold_gutter(EditorSettings::get_singleton()->get("text_editor/line_numbers/code_folding"));
 	text_editor->set_wrap_enabled(EditorSettings::get_singleton()->get("text_editor/line_numbers/word_wrap"));
+	text_editor->set_draw_minimap(EditorSettings::get_singleton()->get("text_editor/line_numbers/draw_minimap"));
+	text_editor->set_minimap_width(EditorSettings::get_singleton()->get("text_editor/line_numbers/minimap_width"));
 	text_editor->set_draw_info_gutter(EditorSettings::get_singleton()->get("text_editor/line_numbers/show_info_gutter"));
 	text_editor->cursor_set_block_mode(EditorSettings::get_singleton()->get("text_editor/cursor/block_caret"));
 	text_editor->set_smooth_scroll_enabled(EditorSettings::get_singleton()->get("text_editor/open_scripts/smooth_scrolling"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -448,6 +448,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/line_numbers/show_info_gutter", true);
 	_initial_set("text_editor/line_numbers/code_folding", true);
 	_initial_set("text_editor/line_numbers/word_wrap", false);
+	_initial_set("text_editor/line_numbers/draw_minimap", false);
+	_initial_set("text_editor/line_numbers/minimap_width", 80);
+	hints["text_editor/line_numbers/minimap_width"] = PropertyInfo(Variant::INT, "text_editor/line_numbers/minimap_width", PROPERTY_HINT_RANGE, "50,250,1");
 	_initial_set("text_editor/line_numbers/show_line_length_guideline", false);
 	_initial_set("text_editor/line_numbers/line_length_guideline_column", 80);
 	hints["text_editor/line_numbers/line_length_guideline_column"] = PropertyInfo(Variant::INT, "text_editor/line_numbers/line_length_guideline_column", PROPERTY_HINT_RANGE, "20, 160, 1");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -211,6 +211,7 @@ private:
 		int breakpoint_gutter_width;
 		int fold_gutter_width;
 		int info_gutter_width;
+		int minimap_width;
 	} cache;
 
 	Map<int, int> color_region_cache;
@@ -314,6 +315,10 @@ private:
 	bool hiding_enabled;
 	bool draw_info_gutter;
 	int info_gutter_width;
+	bool draw_minimap;
+	int minimap_width;
+	Point2 minimap_char_size;
+	int minimap_line_spacing;
 
 	bool highlight_all_occurrences;
 	bool scroll_past_end_of_file_enabled;
@@ -327,6 +332,9 @@ private:
 
 	bool smooth_scroll_enabled;
 	bool scrolling;
+	bool dragging_selection;
+	bool dragging_minimap;
+	bool minimap_clicked;
 	float target_v_scroll;
 	float v_scroll_speed;
 
@@ -360,6 +368,8 @@ private:
 
 	int get_visible_rows() const;
 	int get_total_visible_rows() const;
+
+	int _get_minimap_visible_rows() const;
 
 	void update_cursor_wrap_offset();
 	void _update_wrap_at();
@@ -396,6 +406,7 @@ private:
 	void _update_selection_mode_word();
 	void _update_selection_mode_line();
 
+	void _update_minimap_scroll();
 	void _scroll_up(real_t p_delta);
 	void _scroll_down(real_t p_delta);
 
@@ -485,6 +496,7 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const;
 
 	void _get_mouse_pos(const Point2i &p_mouse, int &r_row, int &r_col) const;
+	void _get_minimap_mouse_row(const Point2i &p_mouse, int &r_row) const;
 
 	//void delete_char();
 	//void delete_line();
@@ -697,6 +709,12 @@ public:
 
 	void set_info_gutter_width(int p_gutter_width);
 	int get_info_gutter_width() const;
+
+	void set_draw_minimap(bool p_draw);
+	bool is_drawing_minimap() const;
+
+	void set_minimap_width(int p_minimap_width);
+	int get_minimap_width() const;
 
 	void set_hiding_enabled(bool p_enabled);
 	bool is_hiding_enabled() const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -214,6 +214,7 @@ private:
 	} cache;
 
 	Map<int, int> color_region_cache;
+	Map<int, Map<int, HighlighterInfo> > syntax_highlighting_cache;
 
 	struct TextOperation {
 


### PR DESCRIPTION
Adds an optional text minimap to `text_edit` similar to that of sublime text.

It supports wrapping, code folding, and scrolling. In addition it uses full syntax highlighting, current line and viewport outline. However does not highlight beyond that eg searches.  It currently draws the characters as blocks.

Due to the extra processing, there was a significant performance hit around syntax highlighting, to combat this `text_edit` will now cache syntax highlighting colours similar to that of colour regions. 

Preview:

![image](https://user-images.githubusercontent.com/6584330/62838137-14a18700-bc70-11e9-87d7-7f9e31e8a63d.png)

closes #4881