### PR TITLE
Fix recording bus regression.

### DIFF
--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -217,7 +217,7 @@ Ref<AudioStreamSample> AudioEffectRecord::get_recording() const {
 	PoolVector<uint8_t> dst_data;
 
 	ERR_FAIL_COND_V(current_instance.is_null(), NULL);
-	ERR_FAIL_COND_V(current_instance->recording_data.size(), NULL);
+	ERR_FAIL_COND_V(current_instance->recording_data.size() == 0, NULL);
 
 	if (dst_format == AudioStreamSample::FORMAT_8_BITS) {
 		int data_size = current_instance->recording_data.size();


### PR DESCRIPTION
Adds an explicit check to error check to prevent this function always returning NULL. Fixes #31282