### PR TITLE
Fix self reference issue in core structures for GDNative plugins

### DIFF
--- a/modules/gdnative/gdnative_builders.py
+++ b/modules/gdnative/gdnative_builders.py
@@ -185,7 +185,7 @@ def _build_gdnative_api_struct_source(api):
             'extern const godot_gdnative_core_' + ('{0}_{1}_api_struct api_{0}_{1}'.format(core['version']['major'], core['version']['minor'])) + ' = {',
             '\tGDNATIVE_' + core['type'] + ',',
             '\t{' + str(core['version']['major']) + ', ' + str(core['version']['minor']) + '},',
-            '\t' + ('NULL' if not core['next'] else ('(const godot_gdnative_api_struct *)& api_{0}_{1}'.format(core['version']['major'], core['version']['minor']))) + ','
+            '\t' + ('NULL' if not core['next'] else ('(const godot_gdnative_api_struct *)& api_{0}_{1}'.format(core['next']['version']['major'], core['next']['version']['minor']))) + ','
         ]
 
         for funcdef in core['api']:


### PR DESCRIPTION
This fixes #31313 

We were causing the core structures to point to themselves instead of the next one.
This might need to be cherry picked for 3.1