### PR TITLE
Fix crash on right click in "Find in Files" panel

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -547,6 +547,7 @@ FindInFilesPanel::FindInFilesPanel() {
 	_results_display->connect("item_edited", this, "_on_item_edited");
 	_results_display->set_hide_root(true);
 	_results_display->set_select_mode(Tree::SELECT_ROW);
+	_results_display->set_allow_rmb_select(true);
 	_results_display->create_item(); // Root
 	vbc->add_child(_results_display);
 


### PR DESCRIPTION
The find in files panel has two bugs related to right mouse button clicks:

1. Incorrect visual highlight when right clicking on an item that is not currently selected (in replace mode):
![bug2](https://user-images.githubusercontent.com/7817714/62856246-e8bfe900-bce3-11e9-9b7e-ff8109a68139.gif)

2. Editor crashes if no item has previously been selected with LMB (no. 3 and 4 in this trace):

```
#0  0x0000000002c34806 in CowData<TreeItem::Cell>::_get_size (this=0xf8) at ./core/cowdata.h:70
#1  0x0000000002c2f138 in CowData<TreeItem::Cell>::size (this=0xf8) at ./core/cowdata.h:125
#2  0x0000000002c2d2fe in Vector<TreeItem::Cell>::size (this=0xf0) at ./core/vector.h:83
#3  0x0000000002c09ea7 in TreeItem::is_checked (this=0x0, p_column=0) at scene/gui/tree.cpp:154
#4  0x00000000028ac434 in FindInFilesPanel::_on_item_edited (this=0x96aae90) at editor/find_in_files.cpp:712
#5  0x000000000143bd6b in MethodBind0::call (this=0x96bfe30, p_object=0x96aae90, p_args=0x7fffffffba00, p_arg_count=0, r_error=...) at ./core/method_bind.gen.inc:59
#6  0x00000000037b88c3 in Object::call (this=0x96aae90, p_method=..., p_args=0x7fffffffba00, p_argcount=0, r_error=...) at core/object.cpp:933
#7  0x00000000037ba5dd in Object::emit_signal (this=0x96b2120, p_name=..., p_args=0x7fffffffba00, p_argcount=0) at core/object.cpp:1233
#8  0x00000000037bac9c in Object::emit_signal (this=0x96b2120, p_name=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...) at core/object.cpp:1289
#9  0x0000000002c2355a in Tree::item_edited (this=0x96b2120, p_column=0, p_item=0xc9c4ed0, p_lmb=true) at scene/gui/tree.cpp:3104
#10 0x0000000002c1a5bf in Tree::propagate_mouse_event (this=0x96b2120, p_pos=..., x_ofs=12, y_ofs=23, p_doubleclick=false, p_item=0xc9c4ed0, p_button=2, p_mod=...) at scene/gui/tree.cpp:1859
#11 0x0000000002c1b363 in Tree::propagate_mouse_event (this=0x96b2120, p_pos=..., x_ofs=12, y_ofs=23, p_doubleclick=false, p_item=0xc9ca8b0, p_button=2, p_mod=...) at scene/gui/tree.cpp:1988
#12 0x0000000002c1b363 in Tree::propagate_mouse_event (this=0x96b2120, p_pos=..., x_ofs=0, y_ofs=0, p_doubleclick=false, p_item=0x96b9530, p_button=2, p_mod=...) at scene/gui/tree.cpp:1988
#13 0x0000000002c1f7d1 in Tree::_gui_input (this=0x96b2120, p_event=...) at scene/gui/tree.cpp:2641
#14 0x0000000002208a80 in MethodBind1<Ref<InputEvent> >::call (this=0x6018ae0, p_object=0x96b2120, p_args=0x7fffffffc3b0, p_arg_count=1, r_error=...) at ./core/method_bind.gen.inc:775
#15 0x00000000037b7c41 in Object::call_multilevel (this=0x96b2120, p_method=..., p_args=0x7fffffffc3b0, p_argcount=1) at core/object.cpp:772
#16 0x00000000037b8498 in Object::call_multilevel (this=0x96b2120, p_name=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...) at core/object.cpp:873
#17 0x0000000002a1aa17 in Viewport::_gui_call_input (this=0x65e0500, p_control=0x96b2120, p_input=...) at scene/main/viewport.cpp:1524
#18 0x0000000002a1bd62 in Viewport::_gui_input_event (this=0x65e0500, p_event=...) at scene/main/viewport.cpp:1828
#19 0x0000000002a2064b in Viewport::input (this=0x65e0500, p_event=...) at scene/main/viewport.cpp:2672
#20 0x0000000002a197e3 in Viewport::_vp_input (this=0x65e0500, p_ev=...) at scene/main/viewport.cpp:1302
#21 0x0000000001614f4c in MethodBind1<Ref<InputEvent> const&>::call (this=0x5f5fd80, p_object=0x65e0500, p_args=0x7fffffffc990, p_arg_count=1, r_error=...) at ./core/method_bind.gen.inc:775
#22 0x00000000037b88c3 in Object::call (this=0x65e0500, p_method=..., p_args=0x7fffffffc990, p_argcount=1, r_error=...) at core/object.cpp:933
#23 0x00000000037b83c4 in Object::call (this=0x65e0500, p_name=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...) at core/object.cpp:857
#24 0x00000000029ed833 in SceneTree::call_group_flags (this=0x562b9f0, p_call_flags=2, p_group=..., p_function=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...) at scene/main/scene_tree.cpp:263
#25 0x00000000029ee53e in SceneTree::input_event (this=0x562b9f0, p_event=...) at scene/main/scene_tree.cpp:418
#26 0x00000000013b669f in InputDefault::_parse_input_event_impl (this=0x5d2c3e0, p_event=..., p_is_emulated=false) at main/input_default.cpp:442
#27 0x00000000013b5692 in InputDefault::parse_input_event (this=0x5d2c3e0, p_event=...) at main/input_default.cpp:259
#28 0x00000000013b79ca in InputDefault::flush_accumulated_events (this=0x5d2c3e0) at main/input_default.cpp:674
#29 0x00000000013a16da in OS_X11::process_xevents (this=0x7fffffffd100) at platform/x11/os_x11.cpp:2615
#30 0x00000000013a4b9f in OS_X11::run (this=0x7fffffffd100) at platform/x11/os_x11.cpp:3177
#31 0x00000000013949af in main (argc=2, argv=0x7fffffffd898) at platform/x11/godot_x11.cpp:56
```