### PR TITLE
Fix Right-Click Menu Deselecting  Edits Content

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -347,6 +347,11 @@ void EditorSpinSlider::_value_input_closed() {
 
 //focus_exited signal
 void EditorSpinSlider::_value_focus_exited() {
+
+	// discontinue because the focus_exit was caused by right-click context menu
+	if (value_input->get_menu()->is_visible())
+		return;
+
 	_evaluate_input_text();
 	// focus is not on the same element after the vlalue_input was exited
 	// -> focus is on next element

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -170,6 +170,10 @@ void SpinBox::_gui_input(const Ref<InputEvent> &p_event) {
 
 void SpinBox::_line_edit_focus_exit() {
 
+	// discontinue because the focus_exit was caused by right-click context menu
+	if (line_edit->get_menu()->is_visible())
+		return;
+
 	_text_entered(line_edit->get_text());
 }
 


### PR DESCRIPTION
Right-clicking a property to open the context menu deselects the text field. This causes the context menu to be useless because it doesn't have anything to edit.

Closes: #31305