### PR TITLE
Display language icons in script create dialog

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -44,6 +44,23 @@ void ScriptCreateDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
+			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+				String lang = ScriptServer::get_language(i)->get_name();
+				Ref<Texture> lang_icon = get_icon(lang, "EditorIcons");
+				if (lang_icon.is_valid()) {
+					language_menu->set_item_icon(i, lang_icon);
+				}
+			}
+			String last_lang = EditorSettings::get_singleton()->get_project_metadata("script_setup", "last_selected_language", "");
+			Ref<Texture> last_lang_icon;
+			if (!last_lang.empty()) {
+				last_lang_icon = get_icon(last_lang, "EditorIcons");
+			} else {
+				last_lang_icon = language_menu->get_item_icon(default_language);
+			}
+			if (last_lang_icon.is_valid()) {
+				language_menu->set_icon(last_lang_icon);
+			}
 			path_button->set_icon(get_icon("Folder", "EditorIcons"));
 			parent_browse_button->set_icon(get_icon("Folder", "EditorIcons"));
 			parent_search_button->set_icon(get_icon("ClassList", "EditorIcons"));
@@ -671,13 +688,13 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	gc->add_child(l);
 	gc->add_child(language_menu);
 
-	int default_lang = 0;
+	default_language = 0;
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 
 		String lang = ScriptServer::get_language(i)->get_name();
 		language_menu->add_item(lang);
 		if (lang == "GDScript") {
-			default_lang = i;
+			default_language = i;
 		}
 	}
 
@@ -691,8 +708,8 @@ ScriptCreateDialog::ScriptCreateDialog() {
 			}
 		}
 	} else {
-		language_menu->select(default_lang);
-		current_language = default_lang;
+		language_menu->select(default_language);
+		current_language = default_language;
 	}
 
 	language_menu->connect("item_selected", this, "_lang_changed");

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -76,6 +76,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool is_built_in;
 	bool built_in_enabled;
 	int current_language;
+	int default_language;
 	bool re_check_path;
 	String script_template;
 	Vector<String> template_list;


### PR DESCRIPTION
![script_create_lang](https://user-images.githubusercontent.com/17108460/62862740-72d17700-bd0f-11e9-9a8c-59a9ea2b4b3c.png)

As languages match respective editor icon names, those are set by traversing each language registered.