### PR TITLE
Add __atomic_* operators support for atomic operations

### DIFF
--- a/core/safe_refcount.h
+++ b/core/safe_refcount.h
@@ -97,8 +97,8 @@ static _ALWAYS_INLINE_ T atomic_exchange_if_greater(volatile T *pw, volatile V v
 
 /* Implementation for GCC & Clang */
 
-// GCC guarantees atomic intrinsics for sizes of 1, 2, 4 and 8 bytes.
-// Clang states it supports GCC atomic builtins.
+#include <stdbool.h>
+#include <atomic>
 
 template <class T>
 static _ALWAYS_INLINE_ T atomic_conditional_increment(volatile T *pw) {
@@ -107,7 +107,7 @@ static _ALWAYS_INLINE_ T atomic_conditional_increment(volatile T *pw) {
 		T tmp = static_cast<T const volatile &>(*pw);
 		if (tmp == 0)
 			return 0; // if zero, can't add to it anymore
-		if (__sync_val_compare_and_swap(pw, tmp, tmp + 1) == tmp)
+		if (__atomic_compare_exchange_n(pw, &tmp, tmp + 1, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) == true)
 			return tmp + 1;
 	}
 }
@@ -115,25 +115,25 @@ static _ALWAYS_INLINE_ T atomic_conditional_increment(volatile T *pw) {
 template <class T>
 static _ALWAYS_INLINE_ T atomic_decrement(volatile T *pw) {
 
-	return __sync_sub_and_fetch(pw, 1);
+	return __atomic_sub_fetch(pw, 1, __ATOMIC_SEQ_CST);
 }
 
 template <class T>
 static _ALWAYS_INLINE_ T atomic_increment(volatile T *pw) {
 
-	return __sync_add_and_fetch(pw, 1);
+	return __atomic_add_fetch(pw, 1, __ATOMIC_SEQ_CST);
 }
 
 template <class T, class V>
 static _ALWAYS_INLINE_ T atomic_sub(volatile T *pw, volatile V val) {
 
-	return __sync_sub_and_fetch(pw, val);
+	return __atomic_sub_fetch(pw, val, __ATOMIC_SEQ_CST);
 }
 
 template <class T, class V>
 static _ALWAYS_INLINE_ T atomic_add(volatile T *pw, volatile V val) {
 
-	return __sync_add_and_fetch(pw, val);
+	return __atomic_add_fetch(pw, val, __ATOMIC_SEQ_CST);
 }
 
 template <class T, class V>
@@ -143,7 +143,7 @@ static _ALWAYS_INLINE_ T atomic_exchange_if_greater(volatile T *pw, volatile V v
 		T tmp = static_cast<T const volatile &>(*pw);
 		if (tmp >= val)
 			return tmp; // already greater, or equal
-		if (__sync_val_compare_and_swap(pw, tmp, val) == tmp)
+		if (__atomic_compare_exchange_n(pw, &tmp, val, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) == true)
 			return val;
 	}
 }


### PR DESCRIPTION
As i was working on getting godot built on OpenBSD/macppc (32-bits), the build was broken due to the use of [legacy `__sync` functions](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fsync-Builtins.html) instead of the modern [`__atomic` ones](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html#g_t_005f_005fatomic-Builtins). This is because on some platforms, 64 bits `__sync` functions are not implemented by gcc.

I did it this way to ensure godot will still build with `__sync` functions when needed, so it doesn't break "backward" compat.

( CC: @ibara @rfht )