### PR TITLE
Tweak the behavior of search/replace bar

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -283,20 +283,6 @@ void FindReplaceBar::_get_search_from(int &r_line, int &r_col) {
 	r_line = text_edit->cursor_get_line();
 	r_col = text_edit->cursor_get_column();
 
-	if (text_edit->is_selection_active() && !replace_all_mode) {
-
-		int selection_line = text_edit->get_selection_from_line();
-
-		if (text_edit->get_selection_text() == get_search_text() && r_line == selection_line) {
-
-			int selection_from_col = text_edit->get_selection_from_column();
-
-			if (r_col >= selection_from_col && r_col <= text_edit->get_selection_to_column()) {
-				r_col = selection_from_col;
-			}
-		}
-	}
-
 	if (r_line == result_line && r_col >= result_col && r_col <= result_col + get_search_text().length()) {
 		r_col = result_col;
 	}
@@ -361,6 +347,9 @@ bool FindReplaceBar::search_current() {
 
 bool FindReplaceBar::search_prev() {
 
+	if (!is_visible())
+		popup_search(true);
+
 	uint32_t flags = 0;
 	String text = get_search_text();
 
@@ -373,6 +362,8 @@ bool FindReplaceBar::search_prev() {
 
 	int line, col;
 	_get_search_from(line, col);
+	if (text_edit->is_selection_active())
+		col--; //Skip currently selected word.
 
 	col -= text.length();
 	if (col < 0) {
@@ -386,6 +377,9 @@ bool FindReplaceBar::search_prev() {
 }
 
 bool FindReplaceBar::search_next() {
+
+	if (!is_visible())
+		popup_search(true);
 
 	uint32_t flags = 0;
 	String text;
@@ -426,34 +420,51 @@ void FindReplaceBar::_hide_bar() {
 	hide();
 }
 
-void FindReplaceBar::_show_search() {
+void FindReplaceBar::_show_search(bool p_focus_replace, bool p_show_only) {
 
 	show();
-	search_text->call_deferred("grab_focus");
+	if (p_show_only)
+		return;
+
+	if (p_focus_replace) {
+		search_text->deselect();
+		replace_text->call_deferred("grab_focus");
+	} else {
+		replace_text->deselect();
+		search_text->call_deferred("grab_focus");
+	}
 
 	if (text_edit->is_selection_active() && !selection_only->is_pressed()) {
 		search_text->set_text(text_edit->get_selection_text());
 	}
 
 	if (!get_search_text().empty()) {
-		search_text->select_all();
-		search_text->set_cursor_position(search_text->get_text().length());
-		search_current();
+		if (p_focus_replace) {
+			replace_text->select_all();
+			replace_text->set_cursor_position(replace_text->get_text().length());
+		} else {
+			search_text->select_all();
+			search_text->set_cursor_position(search_text->get_text().length());
+		}
+
+		results_count = -1;
+		_update_results_count();
+		_update_matches_label();
 	}
 }
 
-void FindReplaceBar::popup_search() {
+void FindReplaceBar::popup_search(bool p_show_only) {
 
-	replace_text->hide();
+	if (!is_visible())
+		replace_text->hide();
 	hbc_button_replace->hide();
 	hbc_option_replace->hide();
-	_show_search();
+	_show_search(false, p_show_only);
 }
 
 void FindReplaceBar::popup_replace() {
 
 	if (!replace_text->is_visible_in_tree()) {
-		replace_text->clear();
 		replace_text->show();
 		hbc_button_replace->show();
 		hbc_option_replace->show();
@@ -461,7 +472,7 @@ void FindReplaceBar::popup_replace() {
 
 	selection_only->set_pressed((text_edit->is_selection_active() && text_edit->get_selection_from_line() < text_edit->get_selection_to_line()));
 
-	_show_search();
+	_show_search(is_visible() || text_edit->is_selection_active());
 }
 
 void FindReplaceBar::_search_options_changed(bool p_pressed) {

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -93,7 +93,7 @@ class FindReplaceBar : public HBoxContainer {
 	void _update_results_count();
 	void _update_matches_label();
 
-	void _show_search();
+	void _show_search(bool p_focus_replace = false, bool p_show_only = false);
 	void _hide_bar();
 
 	void _editor_text_changed();
@@ -125,7 +125,7 @@ public:
 
 	void set_text_edit(TextEdit *p_text_edit);
 
-	void popup_search();
+	void popup_search(bool p_show_only = false);
 	void popup_replace();
 
 	bool search_current();


### PR DESCRIPTION
This PR brings some changes to how search/replace bar in script editor behaves, inspired by VS Code. This also closes #20643 and probably resolves #19952

The changes are:
- pressing Ctrl + F when search bar is invisible will no longer go to next result
- pressing (Shift +) F3 will now always open search bar
- text in replace bar isn't removed when it's opened
- pressing Ctrl + R with selected text or find bar visible will automatically focus and select replace bar (it doesn't happen when search is hidden and nothing is selected)
- search next/previous will skip the selected word even when the search bar is still invisible

There's one more thing that could be done (auto-fetching the word under cursor on F3 when search text is empty), but I'll leave that for later.