### PR TITLE
HTML5: this.rtenv.callMain is not a function when using latest-upstream backend

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -141,3 +141,6 @@ def configure(env):
 
     # TODO: Reevaluate usage of this setting now that engine.js manages engine runtime.
     env.Append(LINKFLAGS=['-s', 'NO_EXIT_RUNTIME=1'])
+
+    #adding flag due to issue with emscripten 1.38.41 callMain method https://github.com/emscripten-core/emscripten/blob/incoming/ChangeLog.md#v13841-08072019
+    env.Append(LINKFLAGS=['-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["callMain"]'])


### PR DESCRIPTION
Added needed changes for normal compiling with emscripten 1.38.41 and later

*Bugsquad edit:* Fixes #31297.