### PR TITLE
Fix GridMap list text not expanding when palette is resized

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -863,19 +863,21 @@ void GridMapEditor::_icon_size_changed(float p_value) {
 void GridMapEditor::update_palette() {
 	int selected = mesh_library_palette->get_current();
 
+	float min_size = EDITOR_DEF("editors/grid_map/preview_size", 64);
+	min_size *= EDSCALE;
+
 	mesh_library_palette->clear();
 	if (display_mode == DISPLAY_THUMBNAIL) {
 		mesh_library_palette->set_max_columns(0);
 		mesh_library_palette->set_icon_mode(ItemList::ICON_MODE_TOP);
+		mesh_library_palette->set_fixed_column_width(min_size * MAX(size_slider->get_value(), 1.5));
 	} else if (display_mode == DISPLAY_LIST) {
 		mesh_library_palette->set_max_columns(1);
 		mesh_library_palette->set_icon_mode(ItemList::ICON_MODE_LEFT);
+		mesh_library_palette->set_fixed_column_width(0);
 	}
 
-	float min_size = EDITOR_DEF("editors/grid_map/preview_size", 64);
-	min_size *= EDSCALE;
 	mesh_library_palette->set_fixed_icon_size(Size2(min_size, min_size));
-	mesh_library_palette->set_fixed_column_width(min_size * MAX(size_slider->get_value(), 1.5));
 	mesh_library_palette->set_max_text_lines(2);
 
 	Ref<MeshLibrary> mesh_library = node->get_mesh_library();


### PR DESCRIPTION
This is to close #31304

Before:
![image](https://user-images.githubusercontent.com/7109951/62895165-31a88980-bd46-11e9-958d-6dfccb24810e.png)
After:
![image](https://user-images.githubusercontent.com/7109951/62895197-3cfbb500-bd46-11e9-9e58-8a01154f32a7.png)