### PR TITLE
Always use lists for `LIBS` in SCons

### DIFF
--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -113,8 +113,8 @@ def configure(env, env_mono):
             else:
                 env.Append(LINKFLAGS=os.path.join(mono_lib_path, mono_static_lib_name + lib_suffix))
 
-                env.Append(LIBS='psapi')
-                env.Append(LIBS='version')
+                env.Append(LIBS=['psapi'])
+                env.Append(LIBS=['version'])
         else:
             mono_lib_name = find_file_in_dir(mono_lib_path, mono_lib_names, extension='.lib')
 
@@ -124,7 +124,7 @@ def configure(env, env_mono):
             if env.msvc:
                 env.Append(LINKFLAGS=mono_lib_name + Environment()['LIBSUFFIX'])
             else:
-                env.Append(LIBS=mono_lib_name)
+                env.Append(LIBS=[mono_lib_name])
 
             mono_bin_path = os.path.join(mono_root, 'bin')
 

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -29,4 +29,4 @@ with open_utf8('register_platform_apis.gen.cpp', 'w') as f:
 env.add_source_files(env.platform_sources, 'register_platform_apis.gen.cpp')
 
 lib = env.add_library('platform', env.platform_sources)
-env.Prepend(LIBS=lib)
+env.Prepend(LIBS=[lib])


### PR DESCRIPTION
This closes #31288.

PS: I haven't tested this when cross-compiling a Mono-enabled Godot binary for Windows, but it *should* fix the bug if we're following Python logic :wink: