### PR TITLE
Added XML doc classes for TileSetEditor, TileSetEditorContext, and Ti…

### DIFF
--- a/doc/classes/TileSetEditor.xml
+++ b/doc/classes/TileSetEditor.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TileSetEditor" inherits="HSplitContainer" category="Core" version="3.2">
+	<brief_description>
+		Editor for tilesets.
+	</brief_description>
+	<description>
+		An editor for creating and editing tilesets, including using autotile. Most of the functionality of this class is accessable through [TileSetEditorPlugin].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+    <method name="edit">
+			<return type="void">
+			</return>
+      <argument index="0" name="p_tileset" type="TileSet">
+      </argument>
+			<description>
+        Sets the [code]p_tileset[/code] to the [TileSet] to be edited.
+			</description>
+		</method>
+    <method name="update_library_file">
+      <return type="Error">
+      </return>
+      <argument index="0" name="p_base_scene" type="Node">
+      </argument>
+      <argument index="1" name="ml" type="TileSet">
+      </argument>
+      <argument index="2" name="p_merge" type="bool" default="true">
+      </argument>
+      <description>
+        Updates the current scene with the tileset passed to [code]ml[/code].
+        If [code]p_merge[/code] is set to true (default) [code]ml[/code] is cleared ([code]p_library->clear()[/code] is called).
+      </description>
+    </method>
+	</methods>
+  <signals>
+  </signals>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/TileSetEditorContext.xml
+++ b/doc/classes/TileSetEditorContext.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TileSetEditor" inherits="Object" category="Core" version="3.2">
+	<brief_description>
+		Context for [TileSetEditor].
+	</brief_description>
+	<description>
+		The context for the editor for creating and editing tilesets in [TileSetEditor]. Most of the functionality of this class is accessed through [TileSetEditorPlugin]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+    <method name="_hide_script_from_inspector">
+			<return type="bool">
+			</return>
+			<description>
+				Only returns true.
+			</description>
+		</method>
+    <method name="set_tileset">
+      <return type="void">
+      </return>
+      <argument index="0" name="p_tileset" type="TileSet">
+      </argument>
+      <description>
+        Sets the editor's current tileset.
+      </description>
+    </method>
+	</methods>
+  <signals>
+  </signals>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/TileSetEditorPlugin.xml
+++ b/doc/classes/TileSetEditorPlugin.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TileSetEditor" inherits="EditorPlugin" category="Core" version="3.2">
+	<brief_description>
+		Editor for tilesets.
+	</brief_description>
+	<description>
+		This class is the main access point for most of the functionality for [TileSetEditor].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+    <method name="get_name" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the string "TileSet".
+			</description>
+		</method>
+    <method name="has_main_screen" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns false.
+			</description>
+		</method>
+    <method name="edit">
+			<return type="void">
+			</return>
+      <argument index="0" name="p_node" type="Object">
+			</argument>
+			<description>
+        Sets the [code]p_tileset[/code] to the [TileSet] to be edited.
+			</description>
+		</method>
+    <method name="handles" qualifiers="const">
+			<return type="bool">
+			</return>
+      <argument index="0" name="p_node" type="Object">
+			</argument>
+			<description>
+        Returns [code]true[/code] if [code]p_node[/code] is of type [TileSet] or [TileSetEditorContext].
+			</description>
+		</method>
+    <method name="make_visible">
+			<return type="void">
+			</return>
+      <argument index="0" name="p_visible" type="bool">
+			</argument>
+			<description>
+        Toggles ([code]true[/code]/[code]false[/code]) the visibility of the bottom panel of the [TileSetEditor].
+			</description>
+		</method>
+    <method name="set_state">
+      <return type="void">
+      </return>
+      <argument index="0" name="p_node" type="Dictionary">
+      </argument>
+      <description>
+        Sets the state with a dictionary passed by [code]p_node[/code]. Currently sets the following values:
+        state["snap_step"]
+        state["snap_offset"]
+        state["snap_separation"]
+        state["snap_enabled"]
+        state["keep_inside_tile"]
+        state["show_information"]
+      </description>
+    </method>
+    <method name="get_state" type="void" qualifiers="const">
+      <return type="Dictionary">
+      </return>
+      <description>
+        Returns the state as a dictionary with the following values:
+        state["snap_step"]
+        state["snap_offset"]
+        state["snap_separation"]
+        state["snap_enabled"]
+        state["keep_inside_tile"]
+        state["show_information"]
+      </description>
+    </method>
+	</methods>
+  <signals>
+  </signals>
+	<constants>
+	</constants>
+</class>


### PR DESCRIPTION
Added XML doc classes for TileSetEditor, TileSetEditorContext, and TileSetEditorPlugin.

The three XML doc classes represent the three classes defined in tile_set_editor_plugin.cpp/.h