### PR TITLE
Add scrollwheel input to spin slider

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -132,20 +132,39 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
+
+	if (grabbing_grabber) {
+		if (mb.is_valid()) {
+
+			if (mb->get_button_index() == BUTTON_WHEEL_UP) {
+				set_value(get_value() + get_step());
+				mousewheel_over_grabber = true;
+			} else if (mb->get_button_index() == BUTTON_WHEEL_DOWN) {
+				set_value(get_value() - get_step());
+				mousewheel_over_grabber = true;
+			}
+		}
+	}
+
 	if (mb.is_valid() && mb->get_button_index() == BUTTON_LEFT) {
 
 		if (mb->is_pressed()) {
 
 			grabbing_grabber = true;
-			grabbing_ratio = get_as_ratio();
-			grabbing_from = grabber->get_transform().xform(mb->get_position()).x;
+			if (!mousewheel_over_grabber) {
+				grabbing_ratio = get_as_ratio();
+				grabbing_from = grabber->get_transform().xform(mb->get_position()).x;
+			}
 		} else {
 			grabbing_grabber = false;
+			mousewheel_over_grabber = false;
 		}
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid() && grabbing_grabber) {
+		if (mousewheel_over_grabber)
+			return;
 
 		float grabbing_ofs = (grabber->get_transform().xform(mm->get_position()).x - grabbing_from) / float(grabber_range);
 		set_as_ratio(grabbing_ratio + grabbing_ofs);
@@ -261,6 +280,11 @@ void EditorSpinSlider::_notification(int p_what) {
 
 				grabber->set_size(Size2(0, 0));
 				grabber->set_position(get_global_position() + grabber_rect.position + grabber_rect.size * 0.5 - grabber->get_size() * 0.5);
+
+				if (mousewheel_over_grabber) {
+					Input::get_singleton()->warp_mouse_position(grabber->get_position() + grabber_rect.size);
+				}
+
 				grabber_range = width;
 			}
 		}
@@ -456,6 +480,7 @@ EditorSpinSlider::EditorSpinSlider() {
 	grabber->connect("gui_input", this, "_grabber_gui_input");
 	mouse_over_spin = false;
 	mouse_over_grabber = false;
+	mousewheel_over_grabber = false;
 	grabbing_grabber = false;
 	grabber_range = 1;
 	value_input = memnew(LineEdit);

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -48,6 +48,7 @@ class EditorSpinSlider : public Range {
 
 	bool mouse_over_spin;
 	bool mouse_over_grabber;
+	bool mousewheel_over_grabber;
 
 	bool grabbing_grabber;
 	int grabbing_from;


### PR DESCRIPTION
Adds the ability to adjust the editor's spin slider with the mouse wheel, when hovering over the spin slider's grabber. By requiring the mouse to be hovered over the grabber, using the mouse wheel for scrolling up and down the inspector is still possible.

Scrolling only works if you hold down the mouse button on the grabber to verify intent to actually modify data.

Closes #17371.