### PR TITLE
Remove unused self list include from A*

### DIFF
--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -32,7 +32,6 @@
 #define ASTAR_H
 
 #include "core/reference.h"
-#include "core/self_list.h"
 
 /**
 	A* pathfinding algorithm


### PR DESCRIPTION
Godot's A* used to use SelfList but doesn't anymore, I noticed the include was still in there though while I was going through it and testing other things.