### PR TITLE
Fixed freeze on search previous

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -362,12 +362,14 @@ bool FindReplaceBar::search_prev() {
 	int line, col;
 	_get_search_from(line, col);
 
-	col -= text.length();
-	if (col < 0) {
-		line -= 1;
-		if (line < 0)
-			line = text_edit->get_line_count() - 1;
-		col = text_edit->get_line(line).length();
+	if (line == result_line && col == result_col) {
+		col -= text.length();
+		if (col < 0) {
+			line -= 1;
+			if (line < 0)
+				line = text_edit->get_line_count() - 1;
+			col = text_edit->get_line(line).length();
+		}
 	}
 
 	return _search(flags, line, col);


### PR DESCRIPTION
I've just copied a missing condition from `search_next()` into `search_prev()`.

Searching a previous result was always using the logic for starting on a result from before, and it could cause an infinite loop in some cases.

Here's the correct logic from `search_next()`:
https://github.com/godotengine/godot/blob/7863ea39dbf3c4ac4395f873de28736a64d75f66/editor/code_editor.cpp#L405-L413

Fixes #31328