### PR TITLE
Fixed error in ParallaxLayer when set_mirroring is called before entering the tree

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -69,6 +69,9 @@ Size2 ParallaxLayer::get_motion_offset() const {
 
 void ParallaxLayer::_update_mirroring() {
 
+	if (!is_inside_tree())
+		return;
+
 	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
 	if (pb) {
 


### PR DESCRIPTION
Fixes #31300

Mirroring override with `Editable Children` was causing mirroring to be updated before entering the tree and it wasn't supported.

This change avoids this case the same way it's done for `set_base_offset_and_scale`.

Callstack when instanciating the scene:

```
 	godot.windows.opt.tools.64.exe!ParallaxLayer::set_mirroring(const Vector2 & p_mirroring) Line 90	C++
 	godot.windows.opt.tools.64.exe!MethodBind1<ParallaxLayer,Vector2 const &>::call(Object * p_object, const Variant * * p_args, int p_arg_count, Variant::CallError & r_error) Line 867	C++
 	godot.windows.opt.tools.64.exe!ClassDB::set_property(Object * p_object, const StringName & p_property, const Variant & p_value, bool * r_valid) Line 1049	C++
 	godot.windows.opt.tools.64.exe!Object::set(const StringName & p_name, const Variant & p_value, bool * r_valid) Line 422	C++
 	godot.windows.opt.tools.64.exe!SceneState::instance(SceneState::GenEditState p_edit_state) Line 253	C++
 	godot.windows.opt.tools.64.exe!PackedScene::instance(PackedScene::GenEditState p_edit_state) Line 1692	C++
 	godot.windows.opt.tools.64.exe!Main::start() Line 1752	C++
```

Mirroring is properly updated on `NOTIFICATION_ENTER_TREE`