### PR TITLE
[WIP] Adding GridMap mirror/flip option

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -278,7 +278,7 @@ bool GridMap::get_center_z() const {
 	return center_z;
 }
 
-void GridMap::set_cell_item(int p_x, int p_y, int p_z, int p_item, int p_rot) {
+void GridMap::set_cell_item(int p_x, int p_y, int p_z, int p_item, int p_rot, bool p_mirrored_x, bool p_mirrored_y, bool p_mirrored_z) {
 
 	if (baked_meshes.size() && !recreating_octants) {
 		//if you set a cell item, baked meshes go good bye
@@ -350,6 +350,9 @@ void GridMap::set_cell_item(int p_x, int p_y, int p_z, int p_item, int p_rot) {
 	Cell c;
 	c.item = p_item;
 	c.rot = p_rot;
+	c.mirrored_x = p_mirrored_x;
+	c.mirrored_y = p_mirrored_y;
+	c.mirrored_z = p_mirrored_z;
 
 	cell_map[key] = c;
 }
@@ -481,7 +484,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 		xform.basis.set_orthogonal_index(c.rot);
 		xform.set_origin(cellpos * cell_size + ofs);
-		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
+		xform.basis.scale(Vector3(cell_scale * -((!!c.mirrored_x) * 2 - 1), cell_scale * -((!!c.mirrored_y) * 2 - 1), cell_scale * -((!!c.mirrored_z) * 2 - 1)));
 		if (baked_meshes.size() == 0) {
 			if (mesh_library->get_item_mesh(c.item).is_valid()) {
 				if (!multimesh_items.has(c.item)) {
@@ -772,7 +775,7 @@ void GridMap::_recreate_octant_data() {
 	_clear_internal();
 	for (Map<IndexKey, Cell>::Element *E = cell_copy.front(); E; E = E->next()) {
 
-		set_cell_item(E->key().x, E->key().y, E->key().z, E->get().item, E->get().rot);
+		set_cell_item(E->key().x, E->key().y, E->key().z, E->get().item, E->get().rot, E->get().mirrored_x, E->get().mirrored_y, E->get().mirrored_z);
 	}
 	recreating_octants = false;
 }
@@ -855,7 +858,7 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_octant_size", "size"), &GridMap::set_octant_size);
 	ClassDB::bind_method(D_METHOD("get_octant_size"), &GridMap::get_octant_size);
 
-	ClassDB::bind_method(D_METHOD("set_cell_item", "x", "y", "z", "item", "orientation"), &GridMap::set_cell_item, DEFVAL(0));
+	//ClassDB::bind_method(D_METHOD("set_cell_item", "x", "y", "z", "item", "orientation", "mirrored_x", "mirrored_y", "mirrored_z"), &GridMap::set_cell_item, DEFVAL(0), DEFVAL(false), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_cell_item", "x", "y", "z"), &GridMap::get_cell_item);
 	ClassDB::bind_method(D_METHOD("get_cell_item_orientation", "x", "y", "z"), &GridMap::get_cell_item_orientation);
 
@@ -976,7 +979,7 @@ Array GridMap::get_meshes() {
 		xform.basis.set_orthogonal_index(E->get().rot);
 
 		xform.set_origin(cellpos * cell_size + ofs);
-		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
+		xform.basis.scale(Vector3(cell_scale * -((!!E->get().mirrored_x) * 2 - 1), cell_scale * -((!!E->get().mirrored_y) * 2 - 1), cell_scale * -((!!E->get().mirrored_z) * 2 - 1)));
 
 		meshes.push_back(xform);
 		meshes.push_back(mesh);
@@ -1029,7 +1032,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 
 		xform.basis.set_orthogonal_index(E->get().rot);
 		xform.set_origin(cellpos * cell_size + ofs);
-		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
+		xform.basis.scale(Vector3(cell_scale * -((!!E->get().mirrored_x) * 2 - 1), cell_scale * -((!!E->get().mirrored_y) * 2 - 1), cell_scale * -((!!E->get().mirrored_z) * 2 - 1)));
 
 		OctantKey ok;
 		ok.x = key.x / octant_size;

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -69,18 +69,23 @@ class GridMap : public Spatial {
 	 * @brief A Cell is a single cell in the cube map space; it is defined by its coordinates and the populating Item, identified by int id.
 	 */
 	union Cell {
-
 		struct {
 			unsigned int item : 16;
 			unsigned int rot : 5;
 			unsigned int layer : 8;
+			bool mirrored_x : 1;
+			bool mirrored_y : 1;
+			bool mirrored_z : 1;
 		};
 		uint32_t cell;
-
+	
 		Cell() {
 			item = 0;
 			rot = 0;
 			layer = 0;
+			mirrored_x = true;
+			mirrored_y = false;
+			mirrored_z = false;
 		}
 	};
 
@@ -248,7 +253,7 @@ public:
 	void set_center_z(bool p_enable);
 	bool get_center_z() const;
 
-	void set_cell_item(int p_x, int p_y, int p_z, int p_item, int p_rot = 0);
+	void set_cell_item(int p_x, int p_y, int p_z, int p_item, int p_rot = 0, bool p_mirrored_x = false, bool p_mirrored_y = false, bool p_mirrored_z = false);
 	int get_cell_item(int p_x, int p_y, int p_z) const;
 	int get_cell_item_orientation(int p_x, int p_y, int p_z) const;
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -230,6 +230,25 @@ void GridMapEditor::_menu_option(int p_option) {
 			_update_cursor_transform();
 		} break;
 
+		case MENU_OPTION_CURSOR_MIRROR_X: {
+			int idx = options->get_popup()->get_item_index(MENU_OPTION_CURSOR_MIRROR_X);
+			options->get_popup()->set_item_checked(idx, !options->get_popup()->is_item_checked(idx));
+			cursor_scale.x *= -1;
+			_update_cursor_transform();
+		} break;
+		case MENU_OPTION_CURSOR_MIRROR_Y: {
+			int idx = options->get_popup()->get_item_index(MENU_OPTION_CURSOR_MIRROR_Y);
+			options->get_popup()->set_item_checked(idx, !options->get_popup()->is_item_checked(idx));
+			cursor_scale.y *= -1;
+			_update_cursor_transform();
+		} break;
+		case MENU_OPTION_CURSOR_MIRROR_Z: {
+			int idx = options->get_popup()->get_item_index(MENU_OPTION_CURSOR_MIRROR_Z);
+			options->get_popup()->set_item_checked(idx, !options->get_popup()->is_item_checked(idx));
+			cursor_scale.z *= -1;
+			_update_cursor_transform();
+		} break;
+
 		case MENU_OPTION_PASTE_SELECTS: {
 			int idx = options->get_popup()->get_item_index(MENU_OPTION_PASTE_SELECTS);
 			options->get_popup()->set_item_checked(idx, !options->get_popup()->is_item_checked(idx));
@@ -279,6 +298,7 @@ void GridMapEditor::_update_cursor_transform() {
 	cursor_transform = Transform();
 	cursor_transform.origin = cursor_origin;
 	cursor_transform.basis.set_orthogonal_index(cursor_rot);
+	cursor_transform.basis.scale(cursor_scale);
 	cursor_transform = node->get_global_transform() * cursor_transform;
 
 	if (cursor_instance.is_valid()) {
@@ -467,7 +487,7 @@ bool GridMapEditor::do_input_action(Camera *p_camera, const Point2 &p_point, boo
 		si.old_value = node->get_cell_item(cell[0], cell[1], cell[2]);
 		si.old_orientation = node->get_cell_item_orientation(cell[0], cell[1], cell[2]);
 		set_items.push_back(si);
-		node->set_cell_item(cell[0], cell[1], cell[2], selected_palette, cursor_rot);
+		node->set_cell_item(cell[0], cell[1], cell[2], selected_palette, cursor_rot, !!(cursor_scale.x - 1), !!(cursor_scale.y - 1), !!(cursor_scale.z - 1));
 		return true;
 	} else if (input_action == INPUT_ERASE) {
 		SetItem si;
@@ -1262,6 +1282,9 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	options->get_popup()->add_item(TTR("Cursor Back Rotate Y"), MENU_OPTION_CURSOR_BACK_ROTATE_Y, KEY_MASK_SHIFT + KEY_S);
 	options->get_popup()->add_item(TTR("Cursor Back Rotate Z"), MENU_OPTION_CURSOR_BACK_ROTATE_Z, KEY_MASK_SHIFT + KEY_D);
 	options->get_popup()->add_item(TTR("Cursor Clear Rotation"), MENU_OPTION_CURSOR_CLEAR_ROTATION, KEY_W);
+	options->get_popup()->add_check_item(TTR("Cursor Mirror X"), MENU_OPTION_CURSOR_MIRROR_X, KEY_T);
+	options->get_popup()->add_check_item(TTR("Cursor Mirror Y"), MENU_OPTION_CURSOR_MIRROR_Y, KEY_Y);
+	options->get_popup()->add_check_item(TTR("Cursor Mirror Z"), MENU_OPTION_CURSOR_MIRROR_Z, KEY_U);
 	options->get_popup()->add_separator();
 	options->get_popup()->add_check_item("Paste Selects", MENU_OPTION_PASTE_SELECTS);
 	options->get_popup()->add_separator();
@@ -1340,6 +1363,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	selected_palette = -1;
 	lock_view = false;
 	cursor_rot = 0;
+	cursor_scale = Vector3(1, 1, 1);
 	last_mouseover = Vector3(-1, -1, -1);
 
 	selection_mesh = VisualServer::get_singleton()->mesh_create();

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -160,6 +160,7 @@ class GridMapEditor : public VBoxContainer {
 
 	Vector3 cursor_origin;
 	Vector3 last_mouseover;
+	Vector3 cursor_scale;
 
 	int display_mode;
 	int selected_palette;
@@ -183,6 +184,9 @@ class GridMapEditor : public VBoxContainer {
 		MENU_OPTION_CURSOR_BACK_ROTATE_X,
 		MENU_OPTION_CURSOR_BACK_ROTATE_Z,
 		MENU_OPTION_CURSOR_CLEAR_ROTATION,
+		MENU_OPTION_CURSOR_MIRROR_Y,
+		MENU_OPTION_CURSOR_MIRROR_X,
+		MENU_OPTION_CURSOR_MIRROR_Z,
 		MENU_OPTION_PASTE_SELECTS,
 		MENU_OPTION_SELECTION_DUPLICATE,
 		MENU_OPTION_SELECTION_CUT,


### PR DESCRIPTION
Hi Guys, this is more a proof of concept and as a seed for discussion, see #31340 

When you're working with various shapes in GridMaps it can be desirable to be able to mirror or flip them. This gives you greater flexibility and also prevents you having to make mirrored versions of grid items.

Below you can see an example of a staircase that has been made from the same part with one side flipped.
![image](https://user-images.githubusercontent.com/7109951/62971336-73e6cf00-be09-11e9-88d8-cd97f36f0a79.png)

Currently the lighting gets messed up. I believe this is because some of the normals are now facing the incorrect way. This either needs to be programmatically fixed, or only double sided 3d models maybe used this way

Things that need doing if this were to go ahead are:
- [ ] Implement Undo/Redo for mirroring
- [ ] Fix commented out `set_cell_item` `bind_method` error
- [ ] Add a `get_cell_item_mirrored` function
- [ ] Find a solution to the lighting issues