### PR TITLE
Use Lanczos filtering for variable-sized images such as project icons

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -758,7 +758,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 			switch (image_queue[p_queue_id].image_type) {
 				case IMAGE_QUEUE_ICON:
 
-					image->resize(64 * EDSCALE, 64 * EDSCALE, Image::INTERPOLATE_CUBIC);
+					image->resize(64 * EDSCALE, 64 * EDSCALE, Image::INTERPOLATE_LANCZOS);
 
 					break;
 				case IMAGE_QUEUE_THUMBNAIL: {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1109,7 +1109,7 @@ void ProjectList::load_project_icon(int p_index) {
 		Error err = img->load(item.icon.replace_first("res://", item.path + "/"));
 		if (err == OK) {
 
-			img->resize(default_icon->get_width(), default_icon->get_height());
+			img->resize(default_icon->get_width(), default_icon->get_height(), Image::INTERPOLATE_LANCZOS);
 			Ref<ImageTexture> it = memnew(ImageTexture);
 			it->create_from_image(img);
 			icon = it;


### PR DESCRIPTION
Follow-up to #30684.

This results in better-looking icons with less artifacts induced by downscaling.

Unlike #25761, this solution doesn't suffer from blurriness at regular sizes.

## Preview

### Before

![assetlib_old](https://user-images.githubusercontent.com/180032/62973894-53be0c80-be17-11e9-8ffa-7f081ce373f4.png)

### After

![assetlib_new](https://user-images.githubusercontent.com/180032/62973917-5d477480-be17-11e9-9c0e-5af265c408c7.png)