### PR TITLE
Add Min/Max Window Size Setting

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -902,6 +902,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/width", PropertyInfo(Variant::INT, "display/window/size/width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
 	GLOBAL_DEF("display/window/size/height", 600);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/height", PropertyInfo(Variant::INT, "display/window/size/height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/min_width", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/min_width", PropertyInfo(Variant::INT, "display/window/size/min_width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/min_height", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/min_height", PropertyInfo(Variant::INT, "display/window/size/min_height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/max_width", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/max_width", PropertyInfo(Variant::INT, "display/window/size/max_width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/max_height", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/max_height", PropertyInfo(Variant::INT, "display/window/size/max_height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
 	GLOBAL_DEF("display/window/size/resizable", true);
 	GLOBAL_DEF("display/window/size/borderless", false);
 	GLOBAL_DEF("display/window/size/fullscreen", false);
@@ -926,6 +934,18 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				}
 			}
 		}
+
+		int mw = GLOBAL_GET("display/window/size/min_width");
+		int mh = GLOBAL_GET("display/window/size/min_height");
+		OS::get_singleton()->set_min_window_size(Size2(mw, mh));
+
+		mw = GLOBAL_GET("display/window/size/max_width");
+		if (mw <= 0)
+			mw = 7680;
+		mh = GLOBAL_GET("display/window/size/max_height");
+		if (mh <= 0)
+			mh = 4320;
+		OS::get_singleton()->set_max_window_size(Size2(mw, mh));
 
 		video_mode.resizable = GLOBAL_GET("display/window/size/resizable");
 		video_mode.borderless_window = GLOBAL_GET("display/window/size/borderless");


### PR DESCRIPTION
Add project settings to easily set the minimum and maximum window size.

Imitates Test Width/Height Setting, meaning you need to set both the width and the height, otherwise it does nothing. Is that intended behavior?

Closes: #31303