### PR TITLE
Exposed set_as_minsize to gdscript

### DIFF
--- a/doc/classes/Popup.xml
+++ b/doc/classes/Popup.xml
@@ -56,6 +56,13 @@
 				Popup (show the control in modal form) in the center of the screen relative to the current canvas transform, scaled at a ratio of size of the screen.
 			</description>
 		</method>
+		<method name="set_as_minsize">
+			<return type="void">
+			</return>
+			<description>
+				Shrink popup to keep to the minimum size of content.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="popup_exclusive" type="bool" setter="set_exclusive" getter="is_exclusive" default="false">

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -207,6 +207,7 @@ bool Popup::is_exclusive() const {
 
 void Popup::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("set_as_minsize"), &Popup::set_as_minsize);
 	ClassDB::bind_method(D_METHOD("popup_centered", "size"), &Popup::popup_centered, DEFVAL(Size2()));
 	ClassDB::bind_method(D_METHOD("popup_centered_ratio", "ratio"), &Popup::popup_centered_ratio, DEFVAL(0.75));
 	ClassDB::bind_method(D_METHOD("popup_centered_minsize", "minsize"), &Popup::popup_centered_minsize, DEFVAL(Size2()));


### PR DESCRIPTION
Exposed set_as_minsize to gdscript to allow popup menus to keep to the minimum size.

(Fixed version of this PR #31343.)