### PR TITLE
Add an "Auto" editor font hinting setting to match OS font rendering

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -94,7 +94,31 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	/* Custom font */
 
 	bool font_antialiased = (bool)EditorSettings::get_singleton()->get("interface/editor/font_antialiased");
-	DynamicFontData::Hinting font_hinting = (DynamicFontData::Hinting)(int)EditorSettings::get_singleton()->get("interface/editor/font_hinting");
+	int font_hinting_setting = (int)EditorSettings::get_singleton()->get("interface/editor/font_hinting");
+
+	DynamicFontData::Hinting font_hinting;
+	switch (font_hinting_setting) {
+		case 0:
+			// The "Auto" setting uses the setting that best matches the OS' font rendering:
+			// - macOS doesn't use font hinting.
+			// - Windows uses ClearType, which is in between "Light" and "Normal" hinting.
+			// - Linux has configurable font hinting, but most distributions including Ubuntu default to "Light".
+#ifdef OSX_ENABLED
+			font_hinting = DynamicFontData::HINTING_NONE;
+#else
+			font_hinting = DynamicFontData::HINTING_LIGHT;
+#endif
+			break;
+		case 1:
+			font_hinting = DynamicFontData::HINTING_NONE;
+			break;
+		case 2:
+			font_hinting = DynamicFontData::HINTING_LIGHT;
+			break;
+		default:
+			font_hinting = DynamicFontData::HINTING_NORMAL;
+			break;
+	}
 
 	String custom_font_path = EditorSettings::get_singleton()->get("interface/editor/main_font");
 	Ref<DynamicFontData> CustomFont;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -324,8 +324,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/code_font_size", 14);
 	hints["interface/editor/code_font_size"] = PropertyInfo(Variant::INT, "interface/editor/code_font_size", PROPERTY_HINT_RANGE, "8,48,1", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/editor/font_antialiased", true);
-	_initial_set("interface/editor/font_hinting", 2);
-	hints["interface/editor/font_hinting"] = PropertyInfo(Variant::INT, "interface/editor/font_hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_DEFAULT);
+	_initial_set("interface/editor/font_hinting", 0);
+	hints["interface/editor/font_hinting"] = PropertyInfo(Variant::INT, "interface/editor/font_hinting", PROPERTY_HINT_ENUM, "Auto,None,Light,Normal", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/editor/main_font", "");
 	hints["interface/editor/main_font"] = PropertyInfo(Variant::STRING, "interface/editor/main_font", PROPERTY_HINT_GLOBAL_FILE, "*.ttf,*.otf", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/editor/main_font_bold", "");


### PR DESCRIPTION


The "Auto" setting picks the font hinting setting that best matches the operating system's font rendering settings. This font hinting setting is now the default to provide better integration with the OS.

I've also considered exposing this as a setting in DynamicFontData so that it can be used in projects, but this would break compatibility, so it'd have to wait for 4.0. Besides, adjusting font hinting to match the OS is usually not desired in games. It'd still be nice to have in non-game applications though.

We could have more accurate detection on Linux using X11 APIs (since hinting is configurable there), but I don't know how to do this. If it doesn't require too much code, help would be appreciated here :slightly_smiling_face:

PS: I've chosen "Light" hinting on Windows, but maybe "Normal" matches ClearType rendering more?

## Preview

### Before (all platforms)


![editor_font_hinting_normal](https://user-images.githubusercontent.com/180032/63025133-db079080-bea8-11e9-882a-a3b4faebdff1.png)

### After (on macOS)

![editor_font_hinting_none](https://user-images.githubusercontent.com/180032/63025140-dd69ea80-bea8-11e9-856a-380e96d76b19.png)

### After (on Linux and Windows)

![editor_font_hinting_light](https://user-images.githubusercontent.com/180032/63025138-dd69ea80-bea8-11e9-9716-76e5cc5f6765.png)