### PR TITLE
Godot iOS fix: Asmjs support

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -143,6 +143,7 @@ $GODOT_HEAD_INCLUDE
 		(function() {
 
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
+			const MEMORY_SIZE = $GODOT_TOTAL_MEMORY;
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
 			var canvas = document.getElementById('canvas');
@@ -153,6 +154,8 @@ $GODOT_HEAD_INCLUDE
 
 			var initializing = true;
 			var statusMode = 'hidden';
+
+			engine.setMemorySize(MEMORY_SIZE);
 
 			var animationCallbacks = [];
 			function animate(time) {

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -2,6 +2,9 @@
 
 Import('env')
 
+WASM_SUFFIX = '.wasm'
+ASMJS_SUFFIX = '.asmjs'
+
 javascript_files = [
     'audio_driver_javascript.cpp',
     'http_client_javascript.cpp',
@@ -10,35 +13,73 @@ javascript_files = [
     'os_javascript.cpp',
 ]
 
-build = env.add_program(['#bin/godot${PROGSUFFIX}.js', '#bin/godot${PROGSUFFIX}.wasm'], javascript_files);
-js, wasm = build
-
 js_libraries = [
     'http_request.js',
 ]
 for lib in js_libraries:
     env.Append(LINKFLAGS=['--js-library', env.File(lib).path])
-env.Depends(build, js_libraries)
 
 js_modules = [
     'id_handler.js',
 ]
 for module in js_modules:
     env.Append(LINKFLAGS=['--pre-js', env.File(module).path])
+
+wasm_env = env.Clone()
+wasm_env.Append(
+    OBJSUFFIX=WASM_SUFFIX + '.bc',
+    LINKFLAGS=[
+        '-s', 'BINARYEN=1',
+        '-s', 'BINARYEN_TRAP_MODE=\'clamp\'',
+        '-s', 'ALLOW_MEMORY_GROWTH=1'
+    ]
+)
+
+asmjs_env = env.Clone()
+asmjs_env.Append(
+    OBJSUFFIX=ASMJS_SUFFIX + env['OBJSUFFIX'],
+    LINKFLAGS=[
+        '-s', 'ASM_JS=1',
+        '-s', 'WASM=0',
+        '-Wno-separate-asm',
+        '--separate-asm',
+        '--memory-init-file', '1'
+    ]
+)
+
+wasm_module, wasm = wasm_env.add_program([
+    '#bin/godot${PROGSUFFIX}' + WASM_SUFFIX + '.js',
+    '#bin/godot${PROGSUFFIX}' + WASM_SUFFIX + '.wasm'
+], javascript_files)
+asmjs_module, asmjs, memory = asmjs_env.add_program([
+    '#bin/godot${PROGSUFFIX}' + ASMJS_SUFFIX + '.js',
+    '#bin/godot${PROGSUFFIX}' + ASMJS_SUFFIX + '.asm.js',
+    '#bin/godot${PROGSUFFIX}' + ASMJS_SUFFIX + '.js.mem'
+], javascript_files)
+build = (wasm_module, wasm, asmjs_module, asmjs, memory)
+
+env.Depends(build, js_libraries)
 env.Depends(build, js_modules)
 
-wrapper_start = env.File('pre.js')
-wrapper_end = env.File('engine.js')
-js_wrapped = env.Textfile('#bin/godot', [wrapper_start, js, wrapper_end], TEXTFILESUFFIX='${PROGSUFFIX}.wrapped.js')
+engine = env.File('engine.js')
 
 zip_dir = env.Dir('#bin/.javascript_zip')
 zip_files = env.InstallAs([
+    zip_dir.File('godot.module-wasm.js'),
+    zip_dir.File('godot.module-asmjs.js'),
     zip_dir.File('godot.js'),
     zip_dir.File('godot.wasm'),
+    zip_dir.File('godot.asm.js'),
+    zip_dir.File('godot.mem'),
     zip_dir.File('godot.html')
 ], [
-    js_wrapped,
+    wasm_module,
+    asmjs_module,
+    engine,
     wasm,
+    asmjs,
+    memory,
     '#misc/dist/html/full-size.html'
 ])
+
 env.Zip('#bin/godot', zip_files, ZIPROOT=zip_dir, ZIPSUFFIX='${PROGSUFFIX}${ZIPSUFFIX}', ZIPCOMSTR='Archving $SOURCES as $TARGET')

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -127,13 +127,6 @@ def configure(env):
 
     ## Link flags
 
-    env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
-
-    # Allow increasing memory buffer size during runtime. This is efficient
-    # when using WebAssembly (in comparison to asm.js) and works well for
-    # us since we don't know requirements at compile-time.
-    env.Append(LINKFLAGS=['-s', 'ALLOW_MEMORY_GROWTH=1'])
-
     # This setting just makes WebGL 2 APIs available, it does NOT disable WebGL 1.
     env.Append(LINKFLAGS=['-s', 'USE_WEBGL2=1'])
 

--- a/platform/javascript/pre.js
+++ b/platform/javascript/pre.js
@@ -1,5 +1,0 @@
-var Engine = {
-	RuntimeEnvironment: function(Module, exposedLibs) {
-		// The above is concatenated with generated code, and acts as the start of
-		// a wrapper for said code. See engine.js for the other part of the
-		// wrapper.


### PR DESCRIPTION
This PR is needed for all iOS HTML5 build to work well, tested on iPhone 6s, 8, iPad 2015, in browsers: Safari and Chrome. Current implementation works well.
First 5 commits were done by @kroltan, I just wanted to initiate the PR due to @kroltan doesn't have time to do it. Last commit provided in current PR is needed for the HTML5 build to do not give the error of, that engine couldn't find the pkg file. If more detailed information is needed, I can provide it by request.