### PR TITLE
Automatically select the first image of the assets page

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -270,10 +270,10 @@ void EditorAssetLibraryItemDescription::add_preview(int p_id, bool p_video, cons
 	if (!p_video) {
 		preview.image = get_icon("ThumbnailWait", "EditorIcons");
 	}
-	if (preview_images.size() == 0 && !p_video) {
+	preview_images.push_back(preview);
+	if (preview_images.size() == 1 && !p_video) {
 		_preview_click(p_id);
 	}
-	preview_images.push_back(preview);
 }
 
 EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {


### PR DESCRIPTION
This fix a bug in the assets page.
When the user opens a new popup, the first preview image should be automatically selected without requiring a click.

![assets](https://user-images.githubusercontent.com/3595817/63093119-42cee180-bf64-11e9-87b0-6b8317cce0af.png)
