### PR TITLE
Add an `editor_description` property to Node for documentation purposes

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -174,6 +174,7 @@
 	</methods>
 	<members>
 		<member name="comment" type="bool" setter="set_comment" getter="is_comment" default="false">
+			If [code]true[/code], the GraphNode is a comment node.
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
 			The offset of the GraphNode, relative to the scroll offset of the [GraphEdit].

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -299,16 +299,34 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 
 	if (p_node == get_scene_node() && p_node->get_scene_inherited_state().is_valid()) {
 		item->add_button(0, get_icon("InstanceOptions", "EditorIcons"), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
-		item->set_tooltip(0, TTR("Inherits:") + " " + p_node->get_scene_inherited_state()->get_path() + "\n" + TTR("Type:") + " " + p_node->get_class());
-	} else if (p_node != get_scene_node() && p_node->get_filename() != "" && can_open_instance) {
 
+		String tooltip = TTR("Inherits:") + " " + p_node->get_scene_inherited_state()->get_path() + "\n" + TTR("Type:") + " " + p_node->get_class();
+		if (p_node->get_editor_description() != String()) {
+			tooltip += "\n\n" + p_node->get_editor_description();
+		}
+
+		item->set_tooltip(0, tooltip);
+	} else if (p_node != get_scene_node() && p_node->get_filename() != "" && can_open_instance) {
 		item->add_button(0, get_icon("InstanceOptions", "EditorIcons"), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
-		item->set_tooltip(0, TTR("Instance:") + " " + p_node->get_filename() + "\n" + TTR("Type:") + " " + p_node->get_class());
+
+		String tooltip = TTR("Instance:") + " " + p_node->get_filename() + "\n" + TTR("Type:") + " " + p_node->get_class();
+		if (p_node->get_editor_description() != String()) {
+			tooltip += "\n\n" + p_node->get_editor_description();
+		}
+
+		item->set_tooltip(0, tooltip);
 	} else {
 		StringName type = EditorNode::get_singleton()->get_object_custom_type_name(p_node);
-		if (type == StringName())
+		if (type == StringName()) {
 			type = p_node->get_class();
-		item->set_tooltip(0, String(p_node->get_name()) + "\n" + TTR("Type:") + " " + type);
+		}
+
+		String tooltip = TTR("Type:") + " " + type;
+		if (p_node->get_editor_description() != String()) {
+			tooltip += "\n\n" + p_node->get_editor_description();
+		}
+
+		item->set_tooltip(0, tooltip);
 	}
 
 	if (can_open_instance && undo_redo) { //Show buttons only when necessary(SceneTreeDock) to avoid crashes

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1875,6 +1875,19 @@ String Node::get_filename() const {
 	return data.filename;
 }
 
+void Node::set_editor_description(const String &p_editor_description) {
+
+	set_meta("_editor_description_", p_editor_description);
+}
+String Node::get_editor_description() const {
+
+	if (has_meta("_editor_description_")) {
+		return get_meta("_editor_description_");
+	} else {
+		return "";
+	}
+}
+
 void Node::set_editable_instance(Node *p_node, bool p_editable) {
 
 	ERR_FAIL_NULL(p_node);
@@ -2788,6 +2801,10 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rpc_config", "method", "mode"), &Node::rpc_config);
 	ClassDB::bind_method(D_METHOD("rset_config", "property", "mode"), &Node::rset_config);
 
+	ClassDB::bind_method(D_METHOD("_set_editor_description", "editor_description"), &Node::set_editor_description);
+	ClassDB::bind_method(D_METHOD("_get_editor_description"), &Node::get_editor_description);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_editor_description", "_get_editor_description");
+
 	ClassDB::bind_method(D_METHOD("_set_import_path", "import_path"), &Node::set_import_path);
 	ClassDB::bind_method(D_METHOD("_get_import_path"), &Node::get_import_path);
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "_import_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_import_path", "_get_import_path");
@@ -2860,10 +2877,6 @@ void Node::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("tree_exiting"));
 	ADD_SIGNAL(MethodInfo("tree_exited"));
 
-	//ADD_PROPERTY( PropertyInfo( Variant::BOOL, "process/process" ),"set_process","is_processing") ;
-	//ADD_PROPERTY( PropertyInfo( Variant::BOOL, "process/physics_process" ), "set_physics_process","is_physics_processing") ;
-	//ADD_PROPERTY( PropertyInfo( Variant::BOOL, "process/input" ), "set_process_input","is_processing_input" ) ;
-	//ADD_PROPERTY( PropertyInfo( Variant::BOOL, "process/unhandled_input" ), "set_process_unhandled_input","is_processing_unhandled_input" ) ;
 	ADD_GROUP("Pause", "pause_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "pause_mode", PROPERTY_HINT_ENUM, "Inherit,Stop,Process"), "set_pause_mode", "get_pause_mode");
 
@@ -2887,9 +2900,6 @@ void Node::_bind_methods() {
 	BIND_VMETHOD(MethodInfo("_unhandled_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	BIND_VMETHOD(MethodInfo("_unhandled_key_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEventKey")));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_configuration_warning"));
-
-	//ClassDB::bind_method(D_METHOD("get_child",&Node::get_child,PH("index")));
-	//ClassDB::bind_method(D_METHOD("get_node",&Node::get_node,PH("path")));
 }
 
 String Node::_get_name_num_separator() {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -318,6 +318,9 @@ public:
 	void set_filename(const String &p_filename);
 	String get_filename() const;
 
+	void set_editor_description(const String &p_editor_description);
+	String get_editor_description() const;
+
 	void set_editable_instance(Node *p_node, bool p_editable);
 	bool is_editable_instance(const Node *p_node) const;
 	void set_editable_instances(const HashMap<NodePath, int> &p_editable_instances);
@@ -362,8 +365,6 @@ public:
 #ifdef TOOLS_ENABLED
 	Node *duplicate_from_editor(Map<const Node *, Node *> &r_duplimap) const;
 #endif
-
-	//Node *clone_tree() const;
 
 	// used by editors, to save what has changed only
 	void set_scene_instance_state(const Ref<SceneState> &p_state);


### PR DESCRIPTION
It is implemented using editor-only metadata, in a way similar to edit locking or Position2D gizmo extents.

This closes #2082.

## Caveats

- The tooltip is only updated when the scene is reloaded. How could this be fixed efficiently?
- Due to #29189, comments written on a non-root instanced scene will be lost when the scene is reloaded. Comments written on the root node of the instanced scene will be preserved, but this means it will be shared across all instances.

## Preview

### Edition in the inspector

![node_comment_inspector](https://user-images.githubusercontent.com/180032/63096131-56cb1100-bf6d-11e9-8dc7-c282e1f88b7a.png)

### Display in a tooltip in the scene tree dock

![node_comment_tooltip](https://user-images.githubusercontent.com/180032/63096132-5763a780-bf6d-11e9-9bf4-fadb373073d5.png)