### PR TITLE
Allow to create scene from FileSystem dock

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -537,6 +537,7 @@ int EditorData::add_edited_scene(int p_at_pos) {
 		p_at_pos = edited_scene.size();
 	EditedScene es;
 	es.root = NULL;
+	es.path = String();
 	es.history_current = -1;
 	es.version = 0;
 	es.live_edit_root = NodePath(String("/root"));
@@ -653,6 +654,8 @@ bool EditorData::check_and_update_scene(int p_idx) {
 
 		memdelete(edited_scene[p_idx].root);
 		edited_scene.write[p_idx].root = new_scene;
+		if (new_scene->get_filename() != "")
+			edited_scene.write[p_idx].path = new_scene->get_filename();
 		edited_scene.write[p_idx].selection = new_selection;
 
 		return true;
@@ -684,6 +687,12 @@ void EditorData::set_edited_scene_root(Node *p_root) {
 
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
 	edited_scene.write[current_edited_scene].root = p_root;
+	if (p_root) {
+		if (p_root->get_filename() != "")
+			edited_scene.write[current_edited_scene].path = p_root->get_filename();
+		else
+			p_root->set_filename(edited_scene[current_edited_scene].path);
+	}
 }
 
 int EditorData::get_edited_scene_count() const {
@@ -773,6 +782,7 @@ String EditorData::get_scene_title(int p_idx) const {
 void EditorData::set_scene_path(int p_idx, const String &p_path) {
 
 	ERR_FAIL_INDEX(p_idx, edited_scene.size());
+	edited_scene.write[p_idx].path = p_path;
 
 	if (!edited_scene[p_idx].root)
 		return;
@@ -783,9 +793,14 @@ String EditorData::get_scene_path(int p_idx) const {
 
 	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), String());
 
-	if (!edited_scene[p_idx].root)
-		return "";
-	return edited_scene[p_idx].root->get_filename();
+	if (edited_scene[p_idx].root) {
+		if (edited_scene[p_idx].root->get_filename() == "")
+			edited_scene[p_idx].root->set_filename(edited_scene[p_idx].path);
+		else
+			return edited_scene[p_idx].root->get_filename();
+	}
+
+	return edited_scene[p_idx].path;
 }
 
 void EditorData::set_edited_scene_live_edit_root(const NodePath &p_root) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -117,6 +117,7 @@ public:
 
 	struct EditedScene {
 		Node *root;
+		String path;
 		Dictionary editor_states;
 		List<Node *> selection;
 		Vector<EditorHistory::History> history_stored;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1926,10 +1926,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 	switch (p_option) {
 		case FILE_NEW_SCENE: {
 
-			int idx = editor_data.add_edited_scene(-1);
-			_scene_tab_changed(idx);
-			editor_data.clear_editor_states();
-			_update_scene_tabs();
+			new_scene();
 
 		} break;
 		case FILE_NEW_INHERITED_SCENE:
@@ -3160,6 +3157,14 @@ bool EditorNode::is_scene_open(const String &p_path) {
 
 void EditorNode::fix_dependencies(const String &p_for_file) {
 	dependency_fixer->edit(p_for_file);
+}
+
+int EditorNode::new_scene() {
+	int idx = editor_data.add_edited_scene(-1);
+	_scene_tab_changed(idx);
+	editor_data.clear_editor_states();
+	_update_scene_tabs();
+	return idx;
 }
 
 Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, bool p_set_inherited, bool p_clear_errors, bool p_force_open_imported) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -745,6 +745,7 @@ public:
 
 	void fix_dependencies(const String &p_for_file);
 	void clear_scene() { _cleanup_scene(); }
+	int new_scene();
 	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_clear_errors = true, bool p_force_open_imported = false);
 	Error load_resource(const String &p_resource, bool p_ignore_broken_deps = false);
 

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -87,6 +87,7 @@ private:
 		FILE_INFO,
 		FILE_NEW_FOLDER,
 		FILE_NEW_SCRIPT,
+		FILE_NEW_SCENE,
 		FILE_SHOW_IN_EXPLORER,
 		FILE_COPY_PATH,
 		FILE_NEW_RESOURCE,
@@ -135,6 +136,8 @@ private:
 	LineEdit *duplicate_dialog_text;
 	ConfirmationDialog *make_dir_dialog;
 	LineEdit *make_dir_dialog_text;
+	ConfirmationDialog *make_scene_dialog;
+	LineEdit *make_scene_dialog_text;
 	ConfirmationDialog *overwrite_dialog;
 	ScriptCreateDialog *make_script_dialog_text;
 	CreateDialog *new_resource_dialog;
@@ -213,6 +216,7 @@ private:
 
 	void _resource_created() const;
 	void _make_dir_confirm();
+	void _make_scene_confirm();
 	void _rename_operation_confirm();
 	void _duplicate_operation_confirm();
 	void _move_with_overwrite();


### PR DESCRIPTION
This PR makes scene path stored in EditedScene directly, not only in its root filename. With this change, there's a new "New Scene" button in FileSystem dock, that creates an empty scene with provided path and name.

Fixes #28864
Closes #26377
Probably related: #24469