### PR TITLE
A* performance improvements, use OAHashMap.

### DIFF
--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -31,6 +31,7 @@
 #ifndef ASTAR_H
 #define ASTAR_H
 
+#include "core/oa_hash_map.h"
 #include "core/reference.h"
 
 /**
@@ -43,8 +44,6 @@ class AStar : public Reference {
 
 	GDCLASS(AStar, Reference);
 
-	uint64_t pass;
-
 	struct Point {
 
 		int id;
@@ -52,10 +51,10 @@ class AStar : public Reference {
 		real_t weight_scale;
 		bool enabled;
 
-		Set<Point *> neighbours;
-		Set<Point *> unlinked_neighbours;
+		OAHashMap<int, Point *> neighbours;
+		OAHashMap<int, Point *> unlinked_neighbours;
 
-		// Used for pathfinding
+		// Used for pathfinding.
 		Point *prev_point;
 		real_t g_score;
 		real_t f_score;
@@ -63,16 +62,15 @@ class AStar : public Reference {
 		uint64_t closed_pass;
 	};
 
-	Map<int, Point *> points;
-
 	struct SortPoints {
-		_FORCE_INLINE_ bool operator()(const Point *A, const Point *B) const { // Returns true when the Point A is worse than Point B
-			if (A->f_score > B->f_score)
+		_FORCE_INLINE_ bool operator()(const Point *A, const Point *B) const { // Returns true when the Point A is worse than Point B.
+			if (A->f_score > B->f_score) {
 				return true;
-			else if (A->f_score < B->f_score)
+			} else if (A->f_score < B->f_score) {
 				return false;
-			else
-				return A->g_score < B->g_score; // If the f_costs are the same then prioritize the points that are further away from the start
+			} else {
+				return A->g_score < B->g_score; // If the f_costs are the same then prioritize the points that are further away from the start.
+			}
 		}
 	};
 
@@ -100,6 +98,10 @@ class AStar : public Reference {
 		}
 	};
 
+	int last_free_id;
+	uint64_t pass;
+
+	OAHashMap<int, Point *> points;
 	Set<Segment> segments;
 
 	bool _solve(Point *begin_point, Point *end_point);

--- a/core/oa_hash_map.h
+++ b/core/oa_hash_map.h
@@ -62,7 +62,7 @@ private:
 	static const uint32_t EMPTY_HASH = 0;
 	static const uint32_t DELETED_HASH_BIT = 1 << 31;
 
-	_FORCE_INLINE_ uint32_t _hash(const TKey &p_key) {
+	_FORCE_INLINE_ uint32_t _hash(const TKey &p_key) const {
 		uint32_t hash = Hasher::hash(p_key);
 
 		if (hash == EMPTY_HASH) {
@@ -74,7 +74,7 @@ private:
 		return hash;
 	}
 
-	_FORCE_INLINE_ uint32_t _get_probe_length(uint32_t p_pos, uint32_t p_hash) {
+	_FORCE_INLINE_ uint32_t _get_probe_length(uint32_t p_pos, uint32_t p_hash) const {
 		p_hash = p_hash & ~DELETED_HASH_BIT; // we don't care if it was deleted or not
 
 		uint32_t original_pos = p_hash % capacity;
@@ -90,7 +90,7 @@ private:
 		num_elements++;
 	}
 
-	bool _lookup_pos(const TKey &p_key, uint32_t &r_pos) {
+	bool _lookup_pos(const TKey &p_key, uint32_t &r_pos) const {
 		uint32_t hash = _hash(p_key);
 		uint32_t pos = hash % capacity;
 		uint32_t distance = 0;
@@ -151,6 +151,7 @@ private:
 			distance++;
 		}
 	}
+
 	void _resize_and_rehash() {
 
 		TKey *old_keys = keys;
@@ -190,6 +191,26 @@ public:
 	_FORCE_INLINE_ uint32_t get_capacity() const { return capacity; }
 	_FORCE_INLINE_ uint32_t get_num_elements() const { return num_elements; }
 
+	bool empty() const {
+		return num_elements == 0;
+	}
+
+	void clear() {
+
+		for (uint32_t i = 0; i < capacity; i++) {
+
+			if (hashes[i] & DELETED_HASH_BIT) {
+				continue;
+			}
+
+			hashes[i] |= DELETED_HASH_BIT;
+			values[i].~TValue();
+			keys[i].~TKey();
+		}
+
+		num_elements = 0;
+	}
+
 	void insert(const TKey &p_key, const TValue &p_value) {
 
 		if ((float)num_elements / (float)capacity > 0.9) {
@@ -219,7 +240,7 @@ public:
 	 * if r_data is not NULL then the value will be written to the object
 	 * it points to.
 	 */
-	bool lookup(const TKey &p_key, TValue &r_data) {
+	bool lookup(const TKey &p_key, TValue &r_data) const {
 		uint32_t pos = 0;
 		bool exists = _lookup_pos(p_key, pos);
 
@@ -232,7 +253,7 @@ public:
 		return false;
 	}
 
-	_FORCE_INLINE_ bool has(const TKey &p_key) {
+	_FORCE_INLINE_ bool has(const TKey &p_key) const {
 		uint32_t _pos = 0;
 		return _lookup_pos(p_key, _pos);
 	}
@@ -301,6 +322,9 @@ public:
 
 		return it;
 	}
+
+	OAHashMap(const OAHashMap &) = delete; // Delete the copy constructor so we don't get unexpected copies and dangling pointers.
+	OAHashMap &operator=(const OAHashMap &) = delete; // Same for assignment operator.
 
 	OAHashMap(uint32_t p_initial_capacity = 64) {
 


### PR DESCRIPTION
# Motivation
This PR improves the performance of Godot's regular A* a little bit by replacing use of redblack-tree based **Map** and **Set** in it with Godot's **OAHashMap**, as well as improving the interface towards **OAHashMap** a bit, ~~adding subscript operators~~, disabling assignment and copy constructors to avoid nasty surprises there, as well as adding a `clear` and an `empty` method.

# Improvements
It offers a fairly reasonable performance improvement in the general case, somewhere between a 1.15x differential at the minimum and sometimes up to 2-3x the processing rate of the old version:

![image](https://user-images.githubusercontent.com/2816340/63130986-7b9aa500-bfbc-11e9-828f-b0e937860552.png)

# Tests
The A* tests in godot still pass, some manual testing has also been done when benchmarking/comparing it to the old implementation during testing.

But any testing that can be done by community members who are willing is very welcome as well, also would like to know if anyone actually uses the `get_available_point_id` part of the API at all?

# Considerations
Existing tests for A* pass, the main thing which I'd like some guidance on in general is `get_available_point_id` which had a rather silly implementation in the old version, it's still not great now either though..
