### PR TITLE
changed the constant scale of cube_normal to -1.0 instead of -1000000…

### DIFF
--- a/drivers/gles3/shaders/copy.glsl
+++ b/drivers/gles3/shaders/copy.glsl
@@ -165,11 +165,11 @@ void main() {
 #elif defined(USE_ASYM_PANO)
 
 	// When an asymmetrical projection matrix is used (applicable for stereoscopic rendering i.e. VR) we need to do this calculation per fragment to get a perspective correct result.
-	// Note that we're ignoring the x-offset for IPD, with Z sufficiently in the distance it becomes neglectible, as a result we could probably just set cube_normal.z to -1.
+	// Asymmetrical projection means the center of projection is no longer in the center of the screen but shifted.
 	// The Matrix[2][0] (= asym_proj.x) and Matrix[2][1] (= asym_proj.z) values are what provide the right shift in the image.
 
 	vec3 cube_normal;
-	cube_normal.z = -1000000.0;
+	cube_normal.z = -1.0;
 	cube_normal.x = (cube_normal.z * (-uv_interp.x - asym_proj.x)) / asym_proj.y;
 	cube_normal.y = (cube_normal.z * (-uv_interp.y - asym_proj.z)) / asym_proj.a;
 	cube_normal = mat3(sky_transform) * mat3(pano_transform) * cube_normal;


### PR DESCRIPTION
This change fixes a rendering issue (https://github.com/GodotVR/godot_oculus_mobile/issues/29) on oculus quest (android).
The change should not change the mathematical outcome of the computation as it is just a constant scale to a vector that is normalized afterwards; but on oculus quest this leads to completly wrong results with using this large constant (details are in the discussion of the issue linked above).