### PR TITLE
Attachscript via scripteditor

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -473,6 +473,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/cursor/caret_blink_speed", 0.5);
 	hints["text_editor/cursor/caret_blink_speed"] = PropertyInfo(Variant::REAL, "text_editor/cursor/caret_blink_speed", PROPERTY_HINT_RANGE, "0.1, 10, 0.01");
 	_initial_set("text_editor/cursor/right_click_moves_caret", true);
+	_initial_set("text_editor/cursor/drop_data_to_cursor", true);
 
 	// Completion
 	_initial_set("text_editor/completion/idle_parse_delay", 2.0);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1485,8 +1485,10 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			return;
 		}
 
-		te->cursor_set_line(row);
-		te->cursor_set_column(col);
+		if (!EditorSettings::get_singleton()->get("text_editor/cursor/drop_data_to_cursor")) {
+			te->cursor_set_line(row);
+			te->cursor_set_column(col);
+		}
 		te->insert_text_at_cursor(res->get_path());
 	}
 
@@ -1502,8 +1504,10 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			text_to_drop += "\"" + String(files[i]).c_escape() + "\"";
 		}
 
-		te->cursor_set_line(row);
-		te->cursor_set_column(col);
+		if (!EditorSettings::get_singleton()->get("text_editor/cursor/drop_data_to_cursor")) {
+			te->cursor_set_line(row);
+			te->cursor_set_column(col);
+		}
 		te->insert_text_at_cursor(text_to_drop);
 	}
 
@@ -1533,8 +1537,10 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			text_to_drop += "\"" + path.c_escape() + "\"";
 		}
 
-		te->cursor_set_line(row);
-		te->cursor_set_column(col);
+		if (!EditorSettings::get_singleton()->get("text_editor/cursor/drop_data_to_cursor")) {
+			te->cursor_set_line(row);
+			te->cursor_set_column(col);
+		}
 		te->insert_text_at_cursor(text_to_drop);
 	}
 }

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -995,6 +995,18 @@ bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 		return true;
 	}
 
+	if (String(d["type"]) == "script_list_element") {
+		Node *n = d["script_list_element"];
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(n);
+		if (se) {
+			String sp = se->get_edited_resource()->get_path();
+			if (_is_script_type(EditorFileSystem::get_singleton()->get_file_type(sp))) {
+				tree->set_drop_mode_flags(Tree::DROP_MODE_ON_ITEM);
+				return true;
+			}
+		}
+	}
+
 	return String(d["type"]) == "nodes";
 }
 void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
@@ -1030,6 +1042,18 @@ void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 			emit_signal("script_dropped", files[0], np);
 		} else {
 			emit_signal("files_dropped", files, np, section);
+		}
+	}
+
+	if (String(d["type"]) == "script_list_element") {
+
+		Node *n = d["script_list_element"];
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(n);
+		if (se) {
+			String sp = se->get_edited_resource()->get_path();
+			if (_is_script_type(EditorFileSystem::get_singleton()->get_file_type(sp))) {
+				emit_signal("script_dropped", sp, np);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Allows you to attach a script by dragging the script name in the script editor to the node in the scene tree editor.

Closes: #30746