### PR TITLE
Improve the scene tree signals/groups tooltip

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1415,8 +1415,9 @@ void Object::get_signal_connection_list(const StringName &p_signal, List<Connect
 		p_connections->push_back(s->slot_map.getv(i).conn);
 }
 
-bool Object::has_persistent_signal_connections() const {
+int Object::get_persistent_signal_connection_count() const {
 
+	int count = 0;
 	const StringName *S = NULL;
 
 	while ((S = signal_map.next(S))) {
@@ -1424,13 +1425,13 @@ bool Object::has_persistent_signal_connections() const {
 		const Signal *s = &signal_map[*S];
 
 		for (int i = 0; i < s->slot_map.size(); i++) {
-
-			if (s->slot_map.getv(i).conn.flags & CONNECT_PERSIST)
-				return true;
+			if (s->slot_map.getv(i).conn.flags & CONNECT_PERSIST) {
+				count += 1;
+			}
 		}
 	}
 
-	return false;
+	return count;
 }
 
 void Object::get_signals_connected_to_this(List<Connection> *p_connections) const {

--- a/core/object.h
+++ b/core/object.h
@@ -707,7 +707,7 @@ public:
 	void get_signal_list(List<MethodInfo> *p_signals) const;
 	void get_signal_connection_list(const StringName &p_signal, List<Connection> *p_connections) const;
 	void get_all_signal_connections(List<Connection> *p_connections) const;
-	bool has_persistent_signal_connections() const;
+	int get_persistent_signal_connection_count() const;
 	void get_signals_connected_to_this(List<Connection> *p_connections) const;
 
 	Error connect(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -270,15 +270,30 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			item->add_button(0, get_icon("NodeWarning", "EditorIcons"), BUTTON_WARNING, false, TTR("Node configuration warning:") + "\n" + p_node->get_configuration_warning());
 		}
 
-		bool has_connections = p_node->has_persistent_signal_connections();
-		bool has_groups = p_node->has_persistent_groups();
+		int num_connections = p_node->get_persistent_signal_connection_count();
+		int num_groups = p_node->get_persistent_group_count();
 
-		if (has_connections && has_groups) {
-			item->add_button(0, get_icon("SignalsAndGroups", "EditorIcons"), BUTTON_SIGNALS, false, TTR("Node has connection(s) and group(s).\nClick to show signals dock."));
-		} else if (has_connections) {
-			item->add_button(0, get_icon("Signals", "EditorIcons"), BUTTON_SIGNALS, false, TTR("Node has connections.\nClick to show signals dock."));
-		} else if (has_groups) {
-			item->add_button(0, get_icon("Groups", "EditorIcons"), BUTTON_GROUPS, false, TTR("Node is in group(s).\nClick to show groups dock."));
+		if (num_connections >= 1 && num_groups >= 1) {
+			item->add_button(
+					0,
+					get_icon("SignalsAndGroups", "EditorIcons"),
+					BUTTON_SIGNALS,
+					false,
+					vformat(TTR("Node has %s connection(s) and %s group(s).\nClick to show signals dock."), num_connections, num_groups));
+		} else if (num_connections >= 1) {
+			item->add_button(
+					0,
+					get_icon("Signals", "EditorIcons"),
+					BUTTON_SIGNALS,
+					false,
+					vformat(TTR("Node has %s connection(s).\nClick to show signals dock."), num_connections));
+		} else if (num_groups >= 1) {
+			item->add_button(
+					0,
+					get_icon("Groups", "EditorIcons"),
+					BUTTON_GROUPS,
+					false,
+					vformat(TTR("Node is in %s group(s).\nClick to show groups dock."), num_groups));
 		}
 	}
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1716,14 +1716,17 @@ void Node::get_groups(List<GroupInfo> *p_groups) const {
 	}
 }
 
-bool Node::has_persistent_groups() const {
+int Node::get_persistent_group_count() const {
+
+	int count = 0;
 
 	for (const Map<StringName, GroupData>::Element *E = data.grouped.front(); E; E = E->next()) {
-		if (E->get().persistent)
-			return true;
+		if (E->get().persistent) {
+			count += 1;
+		}
 	}
 
-	return false;
+	return count;
 }
 void Node::_print_tree_pretty(const String &prefix, const bool last) {
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -300,7 +300,7 @@ public:
 	};
 
 	void get_groups(List<GroupInfo> *p_groups) const;
-	bool has_persistent_groups() const;
+	int get_persistent_group_count() const;
 
 	void move_child(Node *p_child, int p_pos);
 	void raise();


### PR DESCRIPTION
The tooltip now displays the number of connections and groups that are assigned to the hovered node.

~~Basic pluralization was also implemented, as in #31239.~~ **Edit:** Removed in the final PR, as it needs to be done properly to handle internationalization. See #31432.

## Preview

![image](https://user-images.githubusercontent.com/180032/63196461-a694ff80-c075-11e9-9f5c-9dc13d6a4011.png)