### PR TITLE
Improve timeline drawing in the animation editor

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1748,7 +1748,11 @@ void AnimationTimelineEdit::_play_position_draw() {
 
 	if (px >= get_name_limit() && px < (play_position->get_size().width - get_buttons_width())) {
 		Color color = get_color("accent_color", "Editor");
-		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(EDSCALE));
+		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
+		play_position->draw_texture(
+				get_icon("TimelineIndicator", "EditorIcons"),
+				Point2(px - get_icon("TimelineIndicator", "EditorIcons")->get_width() * 0.5, 0),
+				color);
 	}
 }
 
@@ -2438,7 +2442,7 @@ void AnimationTrackEdit::_play_position_draw() {
 
 	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
 		Color color = get_color("accent_color", "Editor");
-		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(EDSCALE));
+		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 	}
 }
 
@@ -3184,7 +3188,7 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 
 		if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
 			Color accent = get_color("accent_color", "Editor");
-			draw_line(Point2(px, 0), Point2(px, get_size().height), accent, Math::round(EDSCALE));
+			draw_line(Point2(px, 0), Point2(px, get_size().height), accent, Math::round(2 * EDSCALE));
 		}
 	}
 }

--- a/editor/icons/icon_timeline_indicator.svg
+++ b/editor/icons/icon_timeline_indicator.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m3 0h10l-4 4h-2z" fill="#fefefe"/></svg>


### PR DESCRIPTION
A small arrow-like icon is now drawn at the top of the timeline. The timeline is now also wider as to be more visible.

I took inspiration from the DragonBones screenshot in https://github.com/godotengine/godot/issues/18690 :smiley:

*Technical note:* the icon uses the color `#fefefe` instead of `#ffffff` to avoid being replaced automatically when using a light theme. Otherwise, the timeline indicator would become much darker compared to the timeline line.

## Preview

### Before

![timeline_before](https://user-images.githubusercontent.com/180032/63201141-3cd02200-c084-11e9-8d1d-f3c7f91b2e18.png)

### After

![timeline_after](https://user-images.githubusercontent.com/180032/63201140-3cd02200-c084-11e9-9649-42220e3f077d.png)
