### PR TITLE
Replace last occurrences of 'ERR_EXPLAIN' with 'ERR_FAIL_*_MSG'

### DIFF
--- a/core/io/file_access_buffered_fa.h
+++ b/core/io/file_access_buffered_fa.h
@@ -40,10 +40,7 @@ class FileAccessBufferedFA : public FileAccessBuffered {
 
 	int read_data_block(int p_offset, int p_size, uint8_t *p_dest = 0) const {
 
-		if (!f.is_open()) {
-			ERR_EXPLAIN("Can't read data block, when file is not opened.");
-			ERR_FAIL_V(-1);
-		}
+		ERR_FAIL_COND_V_MSG(!f.is_open(), -1, "Can't read data block when file is not opened.");
 
 		((T *)&f)->seek(p_offset);
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -125,6 +125,7 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 		return OK;
 	}
 }
+
 void FileAccessWindows::close() {
 
 	if (!f)
@@ -167,11 +168,11 @@ void FileAccessWindows::close() {
 			if (close_fail_notify) {
 				close_fail_notify(save_path);
 			}
-
-			ERR_EXPLAIN("Safe save failed. This may be a permissions problem, but also may happen because you are running a paranoid antivirus. If this is the case, please switch to Windows Defender or disable the 'safe save' option in editor settings. This makes it work, but increases the risk of file corruption in a crash.");
 		}
 
 		save_path = "";
+
+		ERR_FAIL_COND_MSG(rename_error, "Safe save failed. This may be a permissions problem, but also may happen because you are running a paranoid antivirus. If this is the case, please switch to Windows Defender or disable the 'safe save' option in editor settings. This makes it work, but increases the risk of file corruption in a crash.");
 	}
 }
 

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -63,15 +63,10 @@ Error AudioDriverXAudio2::init() {
 
 	HRESULT hr;
 	hr = XAudio2Create(&xaudio, 0, XAUDIO2_DEFAULT_PROCESSOR);
-	if (hr != S_OK) {
-		ERR_EXPLAIN("Error creating XAudio2 engine.");
-		ERR_FAIL_V(ERR_UNAVAILABLE);
-	}
+	ERR_FAIL_COND_V_MSG(hr != S_OK, ERR_UNAVAILABLE, "Error creating XAudio2 engine.");
+
 	hr = xaudio->CreateMasteringVoice(&mastering_voice);
-	if (hr != S_OK) {
-		ERR_EXPLAIN("Error creating XAudio2 mastering voice.");
-		ERR_FAIL_V(ERR_UNAVAILABLE);
-	}
+	ERR_FAIL_COND_V_MSG(hr != S_OK, ERR_UNAVAILABLE, "Error creating XAudio2 mastering voice.");
 
 	wave_format.nChannels = channels;
 	wave_format.cbSize = 0;
@@ -82,10 +77,7 @@ Error AudioDriverXAudio2::init() {
 	wave_format.nAvgBytesPerSec = mix_rate * wave_format.nBlockAlign;
 
 	hr = xaudio->CreateSourceVoice(&source_voice, &wave_format, 0, XAUDIO2_MAX_FREQ_RATIO, &voice_callback);
-	if (hr != S_OK) {
-		ERR_EXPLAIN("Error creating XAudio2 source voice. " + itos(hr));
-		ERR_FAIL_V(ERR_UNAVAILABLE);
-	}
+	ERR_FAIL_COND_V_MSG(hr != S_OK, ERR_UNAVAILABLE, "Error creating XAudio2 source voice. Error code: " + itos(hr) + ".");
 
 	mutex = Mutex::create();
 	thread = Thread::create(AudioDriverXAudio2::thread_func, this);
@@ -140,10 +132,7 @@ void AudioDriverXAudio2::start() {
 
 	active = true;
 	HRESULT hr = source_voice->Start(0);
-	if (hr != S_OK) {
-		ERR_EXPLAIN("XAudio2 start error " + itos(hr));
-		ERR_FAIL();
-	}
+	ERR_FAIL_COND_MSG(hr != S_OK, "Error starting XAudio2 driver. Error code: " + itos(hr) + ".");
 }
 
 int AudioDriverXAudio2::get_mix_rate() const {

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -692,16 +692,6 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 
 				pre_weights[w_i] = weights;
 
-				/*
-				for(Set<int>::Element *E=vertex_map[w_i].front();E;E=E->next()) {
-
-					int dst = E->get();
-					ERR_EXPLAIN("invalid vertex index in array");
-					ERR_FAIL_INDEX_V(dst,vertex_array.size(),ERR_INVALID_DATA);
-					vertex_array[dst].weights=weights;
-
-				}*/
-
 				index_ofs += wstride * amount;
 			}
 
@@ -711,7 +701,6 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 
 		Set<Collada::Vertex> vertex_set; //vertex set will be the vertices
 		List<int> indices_list; //indices will be the indices
-		//Map<int,Set<int> > vertex_map; //map vertices (for setting skinning/morph)
 
 		/**************************/
 		/* CREATE PRIMITIVE ARRAY */
@@ -834,9 +823,6 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 					vertex_set.insert(vertex);
 				}
 
-				/*	if (!vertex_map.has(vertex_index))
-					vertex_map[vertex_index]=Set<int>();
-				vertex_map[vertex_index].insert(index); //should be outside..*/
 				//build triangles if needed
 				if (j == 0)
 					prev2[0] = index;

--- a/modules/etc/texture_loader_pkm.cpp
+++ b/modules/etc/texture_loader_pkm.cpp
@@ -62,10 +62,8 @@ RES ResourceFormatPKM::load(const String &p_path, const String &p_original_path,
 	f->set_endian_swap(true);
 
 	ETC1Header h;
-	ERR_EXPLAIN("Invalid or Unsupported PKM texture file: " + p_path);
 	f->get_buffer((uint8_t *)&h.tag, sizeof(h.tag));
-	if (strncmp(h.tag, "PKM 10", sizeof(h.tag)))
-		ERR_FAIL_V(RES());
+	ERR_FAIL_COND_V_MSG(strncmp(h.tag, "PKM 10", sizeof(h.tag)), RES(), "Invalid or unsupported PKM texture file: " + p_path + ".");
 
 	h.format = f->get_16();
 	h.texWidth = f->get_16();

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -634,7 +634,7 @@ static GDScriptCompletionIdentifier _type_from_gdtype(const GDScriptDataType &p_
 
 	switch (p_gdtype.kind) {
 		case GDScriptDataType::UNINITIALIZED: {
-			ERR_EXPLAIN("Uninitialized completion. Please report a bug.");
+			ERR_PRINT("Uninitialized completion. Please report a bug.");
 		} break;
 		case GDScriptDataType::BUILTIN: {
 			ci.type.kind = GDScriptParser::DataType::BUILTIN;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -5761,7 +5761,7 @@ GDScriptParser::DataType GDScriptParser::_type_from_gdtype(const GDScriptDataTyp
 
 	switch (p_gdtype.kind) {
 		case GDScriptDataType::UNINITIALIZED: {
-			ERR_EXPLAIN("Uninitialized datatype. Please report a bug.");
+			ERR_PRINT("Uninitialized datatype. Please report a bug.");
 		} break;
 		case GDScriptDataType::BUILTIN: {
 			result.kind = DataType::BUILTIN;

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -37,7 +37,7 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 
 	String header = f->get_token();
 
-	ERR_FAIL_COND_V(header != "#?RADIANCE" && header != "#?RGBE", ERR_FILE_UNRECOGNIZED);
+	ERR_FAIL_COND_V_MSG(header != "#?RADIANCE" && header != "#?RGBE", ERR_FILE_UNRECOGNIZED, "Unsupported header information in HDR: " + header + ".");
 
 	while (true) {
 		String line = f->get_line();
@@ -45,12 +45,9 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 		if (line == "") // empty line indicates end of header
 			break;
 		if (line.begins_with("FORMAT=")) { // leave option to implement other commands
-			if (line != "FORMAT=32-bit_rle_rgbe") {
-				ERR_EXPLAIN("Only 32-bit_rle_rgbe is supported for HDR files.");
-				return ERR_FILE_UNRECOGNIZED;
-			}
+			ERR_FAIL_COND_V_MSG(line != "FORMAT=32-bit_rle_rgbe", ERR_FILE_UNRECOGNIZED, "Only 32-bit_rle_rgbe is supported for HDR files.");
 		} else if (!line.begins_with("#")) { // not comment
-			WARN_PRINTS("Ignoring unsupported header information in HDR : " + line);
+			WARN_PRINTS("Ignoring unsupported header information in HDR: " + line + ".");
 		}
 	}
 

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -106,8 +106,7 @@ static Ref<Image> _webp_lossy_unpack(const PoolVector<uint8_t> &p_buffer) {
 		errdec = WebPDecodeRGBInto(&r[4], size, dst_w.ptr(), datasize, 3 * features.width) == NULL;
 	}
 
-	//ERR_EXPLAIN("Error decoding webp! - "+p_file);
-	ERR_FAIL_COND_V(errdec, Ref<Image>());
+	ERR_FAIL_COND_V_MSG(errdec, Ref<Image>(), "Failed decoding WebP image.");
 
 	dst_w.release();
 
@@ -121,7 +120,6 @@ Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 
 	WebPBitstreamFeatures features;
 	if (WebPGetFeatures(p_buffer, p_buffer_len, &features) != VP8_STATUS_OK) {
-		// ERR_EXPLAIN("Error decoding WEBP image");
 		ERR_FAIL_V(ERR_FILE_CORRUPT);
 	}
 
@@ -138,8 +136,7 @@ Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 	}
 	dst_w.release();
 
-	//ERR_EXPLAIN("Error decoding webp!");
-	ERR_FAIL_COND_V(errdec, ERR_FILE_CORRUPT);
+	ERR_FAIL_COND_V_MSG(errdec, ERR_FILE_CORRUPT, "Failed decoding WebP image.");
 
 	p_image->create(features.width, features.height, 0, features.has_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8, dst_image);
 

--- a/modules/websocket/wsl_client.cpp
+++ b/modules/websocket/wsl_client.cpp
@@ -121,17 +121,17 @@ bool WSLClient::_verify_headers(String &r_protocol) {
 			headers[name] = value;
 	}
 
-#define _WLS_EXPLAIN(NAME, VALUE) \
-	ERR_EXPLAIN("Missing or invalid header '" + String(NAME) + "'. Expected value '" + VALUE + "'");
-#define _WLS_CHECK(NAME, VALUE) \
-	_WLS_EXPLAIN(NAME, VALUE);  \
-	ERR_FAIL_COND_V(!headers.has(NAME) || headers[NAME].to_lower() != VALUE, false);
-#define _WLS_CHECK_NC(NAME, VALUE) \
-	_WLS_EXPLAIN(NAME, VALUE);     \
-	ERR_FAIL_COND_V(!headers.has(NAME) || headers[NAME] != VALUE, false);
-	_WLS_CHECK("connection", "upgrade");
-	_WLS_CHECK("upgrade", "websocket");
-	_WLS_CHECK_NC("sec-websocket-accept", WSLPeer::compute_key_response(_key));
+#define _WSL_CHECK(NAME, VALUE)                                                         \
+	ERR_FAIL_COND_V_MSG(!headers.has(NAME) || headers[NAME].to_lower() != VALUE, false, \
+			"Missing or invalid header '" + String(NAME) + "'. Expected value '" + VALUE + "'.");
+#define _WSL_CHECK_NC(NAME, VALUE)                                           \
+	ERR_FAIL_COND_V_MSG(!headers.has(NAME) || headers[NAME] != VALUE, false, \
+			"Missing or invalid header '" + String(NAME) + "'. Expected value '" + VALUE + "'.");
+	_WSL_CHECK("connection", "upgrade");
+	_WSL_CHECK("upgrade", "websocket");
+	_WSL_CHECK_NC("sec-websocket-accept", WSLPeer::compute_key_response(_key));
+#undef _WSL_CHECK_NC
+#undef _WSL_CHECK
 	if (_protocols.size() == 0) {
 		// We didn't request a custom protocol
 		ERR_FAIL_COND_V(headers.has("sec-websocket-protocol"), false);
@@ -148,10 +148,6 @@ bool WSLClient::_verify_headers(String &r_protocol) {
 		if (!valid)
 			return false;
 	}
-#undef _WLS_CHECK_NC
-#undef _WLS_CHECK
-#undef _WLS_EXPLAIN
-
 	return true;
 }
 

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  lws_server.cpp                                                       */
+/*  wsl_server.cpp                                                       */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -64,18 +64,17 @@ bool WSLServer::PendingPeer::_parse_request(const PoolStringArray p_protocols) {
 		else
 			headers[name] = value;
 	}
-#define _WLS_CHECK(NAME, VALUE)                                                                      \
-	ERR_EXPLAIN("Missing or invalid header '" + String(NAME) + "'. Expected value '" + VALUE + "'"); \
-	ERR_FAIL_COND_V(!headers.has(NAME) || headers[NAME].to_lower() != VALUE, false);
-#define _WLS_CHECK_EX(NAME)                                \
-	ERR_EXPLAIN("Missing header '" + String(NAME) + "'."); \
-	ERR_FAIL_COND_V(!headers.has(NAME), false);
-	_WLS_CHECK("upgrade", "websocket");
-	_WLS_CHECK("sec-websocket-version", "13");
-	_WLS_CHECK_EX("sec-websocket-key");
-	_WLS_CHECK_EX("connection");
-#undef _WLS_CHECK_EX
-#undef _WLS_CHECK
+#define _WSL_CHECK(NAME, VALUE)                                                         \
+	ERR_FAIL_COND_V_MSG(!headers.has(NAME) || headers[NAME].to_lower() != VALUE, false, \
+			"Missing or invalid header '" + String(NAME) + "'. Expected value '" + VALUE + "'.");
+#define _WSL_CHECK_EX(NAME) \
+	ERR_FAIL_COND_V_MSG(!headers.has(NAME), false, "Missing header '" + String(NAME) + "'.");
+	_WSL_CHECK("upgrade", "websocket");
+	_WSL_CHECK("sec-websocket-version", "13");
+	_WSL_CHECK_EX("sec-websocket-key");
+	_WSL_CHECK_EX("connection");
+#undef _WSL_CHECK_EX
+#undef _WSL_CHECK
 	key = headers["sec-websocket-key"];
 	if (headers.has("sec-websocket-protocol")) {
 		Vector<String> protos = headers["sec-websocket-protocol"].split(",");

--- a/modules/xatlas_unwrap/register_types.cpp
+++ b/modules/xatlas_unwrap/register_types.cpp
@@ -29,11 +29,14 @@
 /*************************************************************************/
 
 #include "register_types.h"
+
 #include "core/error_macros.h"
+
 #include "thirdparty/xatlas/xatlas.h"
 
 #include <stdio.h>
 #include <stdlib.h>
+
 extern bool (*array_mesh_lightmap_unwrap_callback)(float p_texel_size, const float *p_vertices, const float *p_normals, int p_vertex_count, const int *p_indices, const int *p_face_materials, int p_index_count, float **r_uv, int **r_vertex, int *r_vertex_count, int **r_index, int *r_index_count, int *r_size_hint_x, int *r_size_hint_y);
 
 bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_vertices, const float *p_normals, int p_vertex_count, const int *p_indices, const int *p_face_materials, int p_index_count, float **r_uv, int **r_vertex, int *r_vertex_count, int **r_index, int *r_index_count, int *r_size_hint_x, int *r_size_hint_y) {

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -193,14 +193,6 @@ Error DynamicFontAtSize::_load() {
 
 	ERR_FAIL_COND_V(error, ERR_FILE_CANT_OPEN);
 
-	/*error = FT_Set_Char_Size(face,0,64*size,512,512);
-
-	if ( error ) {
-		FT_Done_FreeType( library );
-		ERR_EXPLAIN(TTR("Invalid font size."));
-		ERR_FAIL_COND_V( error, ERR_INVALID_PARAMETER );
-	}*/
-
 	if (FT_HAS_COLOR(face)) {
 		int best_match = 0;
 		int diff = ABS(id.size - ((int64_t)face->available_sizes[0].width));


### PR DESCRIPTION
The last remaining ERR_EXPLAIN call is in FreeType code and makes sense as is
(conditionally defines the error message).

There are a few ERR_EXPLAINC calls for C-strings where String is not included
which can stay as is to avoid adding additional _MSGC macros just for that.

Part of #31207.