### PR TITLE
Adds open property for retrieve faces to ConcavePolygonShape

### DIFF
--- a/doc/classes/ConcavePolygonShape.xml
+++ b/doc/classes/ConcavePolygonShape.xml
@@ -8,24 +8,11 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="get_faces" qualifiers="const">
-			<return type="PoolVector3Array">
-			</return>
-			<description>
-				Returns the faces (an array of triangles).
-			</description>
-		</method>
-		<method name="set_faces">
-			<return type="void">
-			</return>
-			<argument index="0" name="faces" type="PoolVector3Array">
-			</argument>
-			<description>
-				Sets the faces (an array of triangles).
-			</description>
-		</method>
-	</methods>
+	<members>
+		<member name="faces" type="PoolVector3Array" setter="set_faces" getter="get_faces" default="PoolVector3Array(  )">
+			The array of triangles formed faces.
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/scene/resources/concave_polygon_shape.cpp
+++ b/scene/resources/concave_polygon_shape.cpp
@@ -83,6 +83,7 @@ void ConcavePolygonShape::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_faces", "faces"), &ConcavePolygonShape::set_faces);
 	ClassDB::bind_method(D_METHOD("get_faces"), &ConcavePolygonShape::get_faces);
+	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR3_ARRAY, "faces", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_NETWORK), "set_faces", "get_faces");
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR3_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_faces", "get_faces");
 }
 


### PR DESCRIPTION
I found its lack of this property, so get_faces/set_faces looks improperly. "data" is not open for the editor. I leave it untouched cuz I think it may break the existed projects if I've removes it.