### PR TITLE
Minor improvements to the Node dock

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -881,7 +881,6 @@ void ConnectionsDock::update_tree() {
 					icon = get_icon(scr->get_class(), "EditorIcons");
 				}
 			}
-
 		} else {
 
 			ClassDB::get_signal_list(base, &node_signals2, true);
@@ -889,6 +888,10 @@ void ConnectionsDock::update_tree() {
 				icon = get_icon(base, "EditorIcons");
 			}
 			name = base;
+		}
+
+		if (!icon.is_valid()) {
+			icon = get_icon("Object", "EditorIcons");
 		}
 
 		TreeItem *pitem = NULL;
@@ -939,7 +942,7 @@ void ConnectionsDock::update_tree() {
 			item->set_metadata(0, sinfo);
 			item->set_icon(0, get_icon("Signal", "EditorIcons"));
 
-			// Set tooltip with the signal's documentation
+			// Set tooltip with the signal's documentation.
 			{
 				String descr;
 				bool found = false;

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -56,10 +56,7 @@ void NodeDock::_bind_methods() {
 
 void NodeDock::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		connections_button->set_icon(get_icon("Signals", "EditorIcons"));
-		groups_button->set_icon(get_icon("Groups", "EditorIcons"));
-	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
+	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
 		connections_button->set_icon(get_icon("Signals", "EditorIcons"));
 		groups_button->set_icon(get_icon("Groups", "EditorIcons"));
 	}
@@ -131,7 +128,7 @@ NodeDock::NodeDock() {
 	groups->hide();
 
 	select_a_node = memnew(Label);
-	select_a_node->set_text(TTR("Select a Node to edit Signals and Groups."));
+	select_a_node->set_text(TTR("Select a single node to edit its signals and groups."));
 	select_a_node->set_v_size_flags(SIZE_EXPAND_FILL);
 	select_a_node->set_valign(Label::VALIGN_CENTER);
 	select_a_node->set_align(Label::ALIGN_CENTER);


### PR DESCRIPTION
- Show the "Object" icon if a node doesn't have one (`BaseButton`, for example).
- Make it more clear that a single node has to be select for it to be edited in the dock.