### PR TITLE
DirAccessPack: Fix dir_exists and file_exists for res:// paths

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -90,7 +90,7 @@ void PackedData::add_path(const String &pkg_path, const String &path, uint64_t o
 			}
 		}
 		String filename = path.get_file();
-		// Don't add as a file if the path points to a directoryy
+		// Don't add as a file if the path points to a directory
 		if (!filename.empty()) {
 			cd->files.insert(filename);
 		}
@@ -460,10 +460,14 @@ String DirAccessPack::get_current_dir() {
 
 bool DirAccessPack::file_exists(String p_file) {
 
+	p_file = fix_path(p_file);
+
 	return current->files.has(p_file);
 }
 
 bool DirAccessPack::dir_exists(String p_dir) {
+
+	p_dir = fix_path(p_dir);
 
 	return current->subdirs.has(p_dir);
 }


### PR DESCRIPTION
Both methods check against containers using relative paths as index,
so the `res://` part needs to be stripped.

Fixes #26009.

---

This is not perfect yet when it comes to `DirAccessPack::file_exists`, and `FileAccessPack::file_exists` is not implemented (like many other methods).

I'll work on a thorough test case for the `DirAccess` and `FileAccess` APIs to ensure that they behave the same on all platforms + packed flavors, or that expected inconsistencies are well documented.