### PR TITLE
[3.2] Fixed Container sorting not working when overriding _sort_children in gdscript

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -938,11 +938,15 @@ Variant Object::call(const StringName &p_method, const Variant **p_args, int p_a
 	return ret;
 }
 
-void Object::notification(int p_notification, bool p_reversed) {
+void Object::notification(int p_notification, bool p_reversed, bool p_script_first) {
+
+	if (script_instance && p_script_first) {
+		script_instance->notification(p_notification);
+	}
 
 	_notificationv(p_notification, p_reversed);
 
-	if (script_instance) {
+	if (script_instance && !p_script_first) {
 		script_instance->notification(p_notification);
 	}
 }
@@ -1689,7 +1693,7 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_indexed", "property"), &Object::_get_indexed_bind);
 	ClassDB::bind_method(D_METHOD("get_property_list"), &Object::_get_property_list_bind);
 	ClassDB::bind_method(D_METHOD("get_method_list"), &Object::_get_method_list_bind);
-	ClassDB::bind_method(D_METHOD("notification", "what", "reversed"), &Object::notification, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("notification", "what", "reversed", "script_first"), &Object::notification, DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("to_string"), &Object::to_string);
 	ClassDB::bind_method(D_METHOD("get_instance_id"), &Object::get_instance_id);
 

--- a/core/object.h
+++ b/core/object.h
@@ -670,7 +670,7 @@ public:
 	Variant call(const StringName &p_name, VARIANT_ARG_LIST); // C++ helper
 	void call_multilevel(const StringName &p_name, VARIANT_ARG_LIST); // C++ helper
 
-	void notification(int p_notification, bool p_reversed = false);
+	void notification(int p_notification, bool p_reversed = false, bool p_script_first = false);
 	String to_string();
 
 	//used mainly by script, get and set all INCLUDING string

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -352,9 +352,12 @@
 			</argument>
 			<argument index="1" name="reversed" type="bool" default="false">
 			</argument>
+			<argument index="2" name="script_first" type="bool" default="false">
+			</argument>
 			<description>
 				Send a given notification to the object, which will also trigger a call to the [method _notification] method of all classes that the object inherits from.
 				If [code]reversed[/code] is [code]true[/code], [method _notification] is called first on the object's own class, and then up to its successive parent classes. If [code]reversed[/code] is [code]false[/code], [method _notification] is called first on the highest ancestor ([Object] itself), and then down to its successive inheriting classes.
+				If [code]script_first[/code] is [code]true[/code], [method _notification] is called first on the script attached to the object if any, and then the object and its inherited classes. If [code]script_first[/code] is [code]false[/code], [method _notification] is called first on the object and its inherited classes, and then on the script attached to the object if any.
 			</description>
 		</method>
 		<method name="property_list_changed_notify">

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -88,7 +88,6 @@ void Container::_sort_children() {
 	if (!is_inside_tree())
 		return;
 
-	notification(NOTIFICATION_SORT_CHILDREN);
 	emit_signal(SceneStringNames::get_singleton()->sort_children);
 	pending_sort = false;
 }
@@ -140,7 +139,7 @@ void Container::queue_sort() {
 	if (pending_sort)
 		return;
 
-	MessageQueue::get_singleton()->push_call(this, "_sort_children");
+	MessageQueue::get_singleton()->push_call(this, "notification", NOTIFICATION_SORT_CHILDREN, true, true);
 	pending_sort = true;
 }
 
@@ -166,6 +165,10 @@ void Container::_notification(int p_what) {
 				queue_sort();
 			}
 		} break;
+		case NOTIFICATION_SORT_CHILDREN: {
+
+			_sort_children();
+		} break;
 	}
 }
 
@@ -184,7 +187,6 @@ String Container::get_configuration_warning() const {
 
 void Container::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_sort_children"), &Container::_sort_children);
 	ClassDB::bind_method(D_METHOD("_child_minsize_changed"), &Container::_child_minsize_changed);
 
 	ClassDB::bind_method(D_METHOD("queue_sort"), &Container::queue_sort);


### PR DESCRIPTION
Removed undocumented bound method `Container::_sort_children`, which can prevent sorting to work correctly if it's overridden in gdscript by mistake.

It's replaced with sending `NOTIFICATION_SORT_CHILDREN` directly:
1. to any attached script instance for custom behavior
2. to any inherited class for sorting implementations
3. to the `Container` class to emit `sort_children` signal and reset `pending_sort` member

It's meant to be in this order to avoid triggering the sorting a second time if an inherited class or a script changes some properties that cause sorting while doing the sorting (like the control's size).

Before this change, it was already notifying the inherited classes before emitting the signal and resetting `pending_sort` in the `Container` class, so the only change is the script is now called first.

In case it's needed, it's still possible for a script to handle sorting after inherited classes by reacting to `sort_children` signal rather than `NOTIFICATION_SORT_CHILDREN`.

Changes on `Object` class:
Added support for `notification` to send notifications to the attached script first and updated the corresponding documentation.

Fixes #31408