### PR TITLE
Define a minimum window size in the editor and project manager

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5508,6 +5508,9 @@ EditorNode::EditorNode() {
 		}
 	}
 
+	// Define a minimum window size to prevent UI elements from overlapping or being cut off
+	OS::get_singleton()->set_min_window_size(Size2(1024, 600) * EDSCALE);
+
 	ResourceLoader::set_abort_on_missing_resources(false);
 	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
 	EditorFileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2270,6 +2270,9 @@ ProjectManager::ProjectManager() {
 			} break;
 		}
 
+		// Define a minimum window size to prevent UI elements from overlapping or being cut off
+		OS::get_singleton()->set_min_window_size(Size2(750, 420) * EDSCALE);
+
 #ifndef OSX_ENABLED
 		// The macOS platform implementation uses its own hiDPI window resizing code
 		// TODO: Resize windows on hiDPI displays on Windows and Linux and remove the line below


### PR DESCRIPTION
This prevents most UI elements from overlapping or being cut off as a result of the window being too small. Those minimum sizes were determined through empirical testing with the font size set to 16 (to cover cases where the user uses an increased font size).

Some cases can still cause UI elements to be cut off (such as opening the Audio panel while in the Script tab), but these should be resolved using another method. Otherwise, we'd have to set a much taller minimum window size, which isn't what we want here :slightly_smiling_face:

This closes #20669.