### PR TITLE
Added progress bar when changing type on multiple nodes

### DIFF
--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -265,11 +265,18 @@ void UndoRedo::commit_action() {
 
 void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
 
+	int step = 0;
+
 	for (; E; E = E->next()) {
 
 		Operation &op = E->get();
 
 		Object *obj = ObjectDB::get_instance(op.object);
+
+		if (progress_callback) {
+			progress_callback(progress_callback_ud, obj, op.name, step++);
+		}
+
 		if (!obj) //may have been deleted and this is fine
 			continue;
 
@@ -409,6 +416,12 @@ void UndoRedo::set_property_notify_callback(PropertyNotifyCallback p_property_ca
 	prop_callback_ud = p_ud;
 }
 
+void UndoRedo::set_progress_notify_callback(ProgressNotifyCallback p_progress_callback, void *p_ud) {
+
+	progress_callback = p_progress_callback;
+	progress_callback_ud = p_ud;
+}
+
 UndoRedo::UndoRedo() {
 
 	committing = 0;
@@ -424,6 +437,9 @@ UndoRedo::UndoRedo() {
 	prop_callback_ud = NULL;
 	method_callback = NULL;
 	property_callback = NULL;
+
+	progress_callback_ud = NULL;
+	progress_callback = NULL;
 }
 
 UndoRedo::~UndoRedo() {

--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -53,6 +53,8 @@ public:
 	typedef void (*MethodNotifyCallback)(void *p_ud, Object *p_base, const StringName &p_name, VARIANT_ARG_DECLARE);
 	typedef void (*PropertyNotifyCallback)(void *p_ud, Object *p_base, const StringName &p_property, const Variant &p_value);
 
+	typedef void (*ProgressNotifyCallback)(void *p_ud, Object *p_base, const StringName &p_name, int p_step);
+
 private:
 	struct Operation {
 
@@ -91,9 +93,12 @@ private:
 	void *callback_ud;
 	void *method_callbck_ud;
 	void *prop_callback_ud;
+	void *progress_callback_ud;
 
 	MethodNotifyCallback method_callback;
 	PropertyNotifyCallback property_callback;
+
+	ProgressNotifyCallback progress_callback;
 
 	int committing;
 
@@ -127,6 +132,8 @@ public:
 
 	void set_method_notify_callback(MethodNotifyCallback p_method_callback, void *p_ud);
 	void set_property_notify_callback(PropertyNotifyCallback p_property_callback, void *p_ud);
+
+	void set_progress_notify_callback(ProgressNotifyCallback p_progress_callback, void *p_ud);
 
 	UndoRedo();
 	~UndoRedo();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2006,7 +2006,19 @@ void SceneTreeDock::_create() {
 			ur->add_undo_reference(n);
 		}
 
+		int step_count = selection.size() * 2;
+		EditorProgress *progress = NULL;
+		if (step_count > 20) {
+			progress = new EditorProgress("process_replace", TTR("Process operations"), step_count);
+			ur->set_progress_notify_callback(_progress_callback, progress);
+		}
+
 		ur->commit_action();
+
+		if (progress) {
+			ur->set_progress_notify_callback(NULL, NULL);
+			delete progress;
+		}
 	} else if (current_option == TOOL_REPARENT_TO_NEW_NODE) {
 		List<Node *> selection = editor_selection->get_selected_node_list();
 		ERR_FAIL_COND(selection.size() <= 0);
@@ -2056,6 +2068,14 @@ void SceneTreeDock::_create() {
 	}
 
 	scene_tree->get_scene_tree()->call_deferred("grab_focus");
+}
+
+void SceneTreeDock::_progress_callback(void *p_ud, Object *p_object, const StringName &p_name, int p_step) {
+	if ((p_step % 20) == 0) {
+
+		EditorProgress *progress = (EditorProgress *)p_ud;
+		progress->step("", p_step, false);
+	}
 }
 
 void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties, bool p_remove_old) {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -161,6 +161,8 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _set_owners(Node *p_owner, const Array &p_nodes);
 
+	static void _progress_callback(void *p_ud, Object *p_object, const StringName &p_name, int p_step);
+
 	enum ReplaceOwnerMode {
 		MODE_BIDI,
 		MODE_DO,


### PR DESCRIPTION
This change displays a progress bar while doing operations instead of freezing the editor

The progress bar also flushes the message queue, which fixes these errors in cases with lots of nodes:
```
ERROR: push_call: Message queue out of memory. Try increasing 'message_queue_size_kb' in project settings.
   At: core/message_queue.cpp:56.
```

Fixes #23853