### PR TITLE
Support baking gridmap navmesh.

### DIFF
--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -49,6 +49,10 @@
 #include "modules/csg/csg_shape.h"
 #endif
 
+#ifdef MODULE_GRIDMAP_ENABLED
+#include "modules/gridmap/grid_map.h"
+#endif
+
 EditorNavigationMeshGenerator *EditorNavigationMeshGenerator::singleton = NULL;
 
 void EditorNavigationMeshGenerator::_add_vertex(const Vector3 &p_vec3, Vector<float> &p_verticies) {
@@ -240,8 +244,21 @@ void EditorNavigationMeshGenerator::_parse_geometry(Transform p_accumulated_tran
 		}
 	}
 
-	if (Object::cast_to<Spatial>(p_node)) {
+#ifdef MODULE_GRIDMAP_ENABLED
+	if (Object::cast_to<GridMap>(p_node) && p_generate_from != NavigationMesh::PARSED_GEOMETRY_STATIC_COLLIDERS) {
+		GridMap *gridmap_instance = Object::cast_to<GridMap>(p_node);
+		Array meshes = gridmap_instance->get_meshes();
+		Transform xform = gridmap_instance->get_transform();
+		for (int i = 0; i < meshes.size(); i += 2) {
+			Ref<Mesh> mesh = meshes[i + 1];
+			if (mesh.is_valid()) {
+				_add_mesh(mesh, p_accumulated_transform * xform * meshes[i], p_verticies, p_indices);
+			}
+		}
+	}
+#endif
 
+	if (Object::cast_to<Spatial>(p_node)) {
 		Spatial *spatial = Object::cast_to<Spatial>(p_node);
 		p_accumulated_transform = p_accumulated_transform * spatial->get_transform();
 	}


### PR DESCRIPTION
Normally it's necessary to add navigation meshes under every tile nodes. One example is described in #17118. Its hard to do this inside the editor for more complex 3d shapes as there is not 3d navmesh editor included.
With this commit it would be possible to omit generating navmeshes for each tile and generate navmesh for gridmap as a whole. This would also make it possible to place obstacles or props with gridmap itself. Look at the following gif for example:
![baking-gridmap](https://user-images.githubusercontent.com/24184354/63223250-0218d780-c1b3-11e9-8f34-03336fb1dfef.gif)

I don't know if this will be useful but i added it for personal project and thought i would share. Along with #22767 it would allow navigating procedurally generated gridmaps. What do you guys think? 

*Bugsquad edit:* Fixes #18837.