### PR TITLE
Keep syntax highlighting on TextEdit in readonly mode

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -129,7 +129,7 @@ void TextEdit::Text::_update_line_cache(int p_line) const {
 	int len = text[p_line].data.length();
 	const CharType *str = text[p_line].data.c_str();
 
-	//update width
+	// Update width.
 
 	for (int i = 0; i < len; i++) {
 		w += get_char_width(str[i], str[i + 1], w);
@@ -139,7 +139,7 @@ void TextEdit::Text::_update_line_cache(int p_line) const {
 
 	text.write[p_line].wrap_amount_cache = -1;
 
-	//update regions
+	// Update regions.
 
 	text.write[p_line].region_info.clear();
 
@@ -148,7 +148,7 @@ void TextEdit::Text::_update_line_cache(int p_line) const {
 		if (!_is_symbol(str[i]))
 			continue;
 		if (str[i] == '\\') {
-			i++; //skip quoted anything
+			i++; // Skip quoted anything.
 			continue;
 		}
 
@@ -275,7 +275,7 @@ void TextEdit::Text::clear() {
 }
 
 int TextEdit::Text::get_max_width(bool p_exclude_hidden) const {
-	//quite some work.. but should be fast enough.
+	// Quite some work, but should be fast enough.
 
 	int max = 0;
 	for (int i = 0; i < text.size(); i++) {
@@ -323,7 +323,7 @@ int TextEdit::Text::get_char_width(CharType c, CharType next_c, int px) const {
 		if (left == 0)
 			w = tab_w;
 		else
-			w = tab_w - px % tab_w; // is right...
+			w = tab_w - px % tab_w; // Is right.
 	} else {
 
 		w = font->get_char_size(c, next_c).width;
@@ -370,20 +370,18 @@ void TextEdit::_update_scrollbars() {
 	bool use_hscroll = true;
 	bool use_vscroll = true;
 
+	// Thanks yessopie for this clever bit of logic.
 	if (total_rows <= visible_rows && total_width <= visible_width) {
-		//thanks yessopie for this clever bit of logic
+
 		use_hscroll = false;
 		use_vscroll = false;
-
 	} else {
 
 		if (total_rows > visible_rows && total_width <= visible_width) {
-			//thanks yessopie for this clever bit of logic
 			use_hscroll = false;
 		}
 
 		if (total_rows <= visible_rows && total_width > visible_width) {
-			//thanks yessopie for this clever bit of logic
 			use_vscroll = false;
 		}
 	}
@@ -481,7 +479,7 @@ void TextEdit::_update_selection_mode_word() {
 
 	String line = text[row];
 	int beg = CLAMP(col, 0, line.length());
-	// if its the first selection and on whitespace make sure we grab the word instead..
+	// If its the first selection and on whitespace make sure we grab the word instead.
 	if (!selection.active) {
 		while (beg > 0 && line[beg] <= 32) {
 			beg--;
@@ -490,7 +488,7 @@ void TextEdit::_update_selection_mode_word() {
 	int end = beg;
 	bool symbol = beg < line.length() && _is_symbol(line[beg]);
 
-	// get the word end and begin points
+	// Get the word end and begin points.
 	while (beg > 0 && line[beg - 1] > 32 && (symbol == _is_symbol(line[beg - 1]))) {
 		beg--;
 	}
@@ -501,7 +499,7 @@ void TextEdit::_update_selection_mode_word() {
 		end += 1;
 	}
 
-	// initial selection
+	// Initial selection.
 	if (!selection.active) {
 		select(row, beg, row, end);
 		selection.selecting_column = beg;
@@ -537,11 +535,11 @@ void TextEdit::_update_selection_mode_line() {
 
 	col = 0;
 	if (row < selection.selecting_line) {
-		// cursor is above us
+		// Cursor is above us.
 		cursor_set_line(row - 1, false);
 		selection.selecting_column = text[selection.selecting_line].length();
 	} else {
-		// cursor is below us
+		// Cursor is below us.
 		cursor_set_line(row + 1, false);
 		selection.selecting_column = 0;
 		col = text[row].length();
@@ -607,7 +605,7 @@ void TextEdit::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 
 			if (first_draw) {
-				//size may not be the final one, so attempts to ensure cursor was visible may have failed
+				// Size may not be the final one, so attempts to ensure cursor was visible may have failed.
 				adjust_viewport_to_cursor();
 				first_draw = false;
 			}
@@ -661,7 +659,7 @@ void TextEdit::_notification(int p_what) {
 			VisualServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), true);
 			int xmargin_beg = cache.style_normal->get_margin(MARGIN_LEFT) + cache.line_number_w + cache.breakpoint_gutter_width + cache.fold_gutter_width + cache.info_gutter_width;
 			int xmargin_end = size.width - cache.style_normal->get_margin(MARGIN_RIGHT);
-			//let's do it easy for now:
+			// Let's do it easy for now.
 			cache.style_normal->draw(ci, Rect2(Point2(), size));
 			if (readonly) {
 				cache.style_readonly->draw(ci, Rect2(Point2(), size));
@@ -701,7 +699,7 @@ void TextEdit::_notification(int p_what) {
 			if (brace_matching_enabled && cursor.line >= 0 && cursor.line < text.size() && cursor.column >= 0) {
 
 				if (cursor.column < text[cursor.line].length()) {
-					//check for open
+					// Check for open.
 					CharType c = text[cursor.line][cursor.column];
 					CharType closec = 0;
 
@@ -723,7 +721,7 @@ void TextEdit::_notification(int p_what) {
 							for (int j = from; j < text[i].length(); j++) {
 
 								CharType cc = text[i][j];
-								//ignore any brackets inside a string
+								// Ignore any brackets inside a string.
 								if (cc == '"' || cc == '\'') {
 									CharType quotation = cc;
 									do {
@@ -732,7 +730,7 @@ void TextEdit::_notification(int p_what) {
 											break;
 										}
 										cc = text[i][j];
-										//skip over escaped quotation marks inside strings
+										// Skip over escaped quotation marks inside strings.
 										if (cc == '\\') {
 											bool escaped = true;
 											while (j + 1 < text[i].length() && text[i][j + 1] == '\\') {
@@ -789,7 +787,7 @@ void TextEdit::_notification(int p_what) {
 							for (int j = from; j >= 0; j--) {
 
 								CharType cc = text[i][j];
-								//ignore any brackets inside a string
+								// Ignore any brackets inside a string.
 								if (cc == '"' || cc == '\'') {
 									CharType quotation = cc;
 									do {
@@ -798,7 +796,7 @@ void TextEdit::_notification(int p_what) {
 											break;
 										}
 										cc = text[i][j];
-										//skip over escaped quotation marks inside strings
+										// Skip over escaped quotation marks inside strings.
 										if (cc == quotation) {
 											bool escaped = false;
 											while (j - 1 >= 0 && text[i][j - 1] == '\\') {
@@ -837,10 +835,10 @@ void TextEdit::_notification(int p_what) {
 			Point2 cursor_pos;
 			int cursor_insert_offset_y = 0;
 
-			// get the highlighted words
+			// Get the highlighted words.
 			String highlighted_text = get_selection_text();
 
-			// check if highlighted words contains only whitespaces (tabs or spaces)
+			// Check if highlighted words contains only whitespaces (tabs or spaces).
 			bool only_whitespaces_highlighted = highlighted_text.strip_edges() == String();
 
 			String line_num_padding = line_numbers_zero_padded ? "0" : " ";
@@ -875,7 +873,7 @@ void TextEdit::_notification(int p_what) {
 				if (syntax_coloring) {
 					color_map = _get_line_syntax_highlighting(line);
 				}
-				// ensure we at least use the font color
+				// Ensure we at least use the font color.
 				Color current_color = readonly ? cache.font_color_readonly : cache.font_color;
 
 				bool underlined = false;
@@ -916,7 +914,7 @@ void TextEdit::_notification(int p_what) {
 					if (smooth_scroll_enabled)
 						ofs_y += (-get_v_scroll_offset()) * get_row_height();
 
-					// check if line contains highlighted word
+					// Check if line contains highlighted word.
 					int highlighted_text_col = -1;
 					int search_text_col = -1;
 					int highlighted_word_col = -1;
@@ -938,25 +936,25 @@ void TextEdit::_notification(int p_what) {
 					}
 
 					if (str.length() == 0) {
-						// draw line background if empty as we won't loop at at all
+						// Draw line background if empty as we won't loop at at all.
 						if (line == cursor.line && cursor_wrap_index == line_wrap_index && highlight_current_line) {
 							VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(ofs_x, ofs_y, xmargin_end, get_row_height()), cache.current_line_color);
 						}
 
-						// give visual indication of empty selected line
+						// Give visual indication of empty selected line.
 						if (selection.active && line >= selection.from_line && line <= selection.to_line && char_margin >= xmargin_beg) {
 							int char_w = cache.font->get_char_size(' ').width;
 							VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(xmargin_beg + ofs_x, ofs_y, char_w, get_row_height()), cache.selection_color);
 						}
 					} else {
-						// if it has text, then draw current line marker in the margin, as line number etc will draw over it, draw the rest of line marker later.
+						// If it has text, then draw current line marker in the margin, as line number etc will draw over it, draw the rest of line marker later.
 						if (line == cursor.line && cursor_wrap_index == line_wrap_index && highlight_current_line) {
-							VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(0, ofs_y, xmargin_beg, get_row_height()), cache.current_line_color);
+							VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(0, ofs_y, xmargin_beg + ofs_x, get_row_height()), cache.current_line_color);
 						}
 					}
 
 					if (line_wrap_index == 0) {
-						// only do these if we are on the first wrapped part of a line
+						// Only do these if we are on the first wrapped part of a line.
 
 						if (text.is_breakpoint(line) && !draw_breakpoint_gutter) {
 #ifdef TOOLS_ENABLED
@@ -966,7 +964,7 @@ void TextEdit::_notification(int p_what) {
 #endif
 						}
 
-						// draw bookmark marker
+						// Draw bookmark marker.
 						if (text.is_bookmark(line)) {
 							if (draw_bookmark_gutter) {
 								int vertical_gap = (get_row_height() * 40) / 100;
@@ -976,26 +974,26 @@ void TextEdit::_notification(int p_what) {
 							}
 						}
 
-						// draw breakpoint marker
+						// Draw breakpoint marker.
 						if (text.is_breakpoint(line)) {
 							if (draw_breakpoint_gutter) {
 								int vertical_gap = (get_row_height() * 40) / 100;
 								int horizontal_gap = (cache.breakpoint_gutter_width * 30) / 100;
 								int marker_height = get_row_height() - (vertical_gap * 2);
 								int marker_width = cache.breakpoint_gutter_width - (horizontal_gap * 2);
-								// no transparency on marker
+								// No transparency on marker.
 								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cache.style_normal->get_margin(MARGIN_LEFT) + horizontal_gap - 2, ofs_y + vertical_gap, marker_width, marker_height), Color(cache.breakpoint_color.r, cache.breakpoint_color.g, cache.breakpoint_color.b));
 							}
 						}
 
-						// draw info icons
+						// Draw info icons.
 						if (draw_info_gutter && text.has_info_icon(line)) {
 							int vertical_gap = (get_row_height() * 40) / 100;
 							int horizontal_gap = (cache.info_gutter_width * 30) / 100;
 							int gutter_left = cache.style_normal->get_margin(MARGIN_LEFT) + cache.breakpoint_gutter_width;
 
 							Ref<Texture> info_icon = text.get_info_icon(line);
-							// ensure the icon fits the gutter size
+							// Ensure the icon fits the gutter size.
 							Size2i icon_size = info_icon->get_size();
 							if (icon_size.width > cache.info_gutter_width - horizontal_gap) {
 								icon_size.width = cache.info_gutter_width - horizontal_gap;
@@ -1013,7 +1011,7 @@ void TextEdit::_notification(int p_what) {
 							draw_texture_rect(info_icon, Rect2(icon_pos, icon_size));
 						}
 
-						// draw execution marker
+						// Draw execution marker.
 						if (executing_line == line) {
 							if (draw_breakpoint_gutter) {
 								int icon_extra_size = 4;
@@ -1031,7 +1029,7 @@ void TextEdit::_notification(int p_what) {
 							}
 						}
 
-						// draw fold markers
+						// Draw fold markers.
 						if (draw_fold_gutter) {
 							int horizontal_gap = (cache.fold_gutter_width * 30) / 100;
 							int gutter_left = cache.style_normal->get_margin(MARGIN_LEFT) + cache.breakpoint_gutter_width + cache.line_number_w + cache.info_gutter_width;
@@ -1046,7 +1044,7 @@ void TextEdit::_notification(int p_what) {
 							}
 						}
 
-						// draw line numbers
+						// Draw line numbers.
 						if (cache.line_number_w) {
 							int yofs = ofs_y + (get_row_height() - cache.font->get_height()) / 2;
 							String fc = String::num(line + 1);
@@ -1058,32 +1056,35 @@ void TextEdit::_notification(int p_what) {
 						}
 					}
 
-					//loop through characters in one line
+					// Loop through characters in one line.
 					for (int j = 0; j < str.length(); j++) {
 
 						if (syntax_coloring) {
 							if (color_map.has(last_wrap_column + j)) {
-								current_color = readonly ? cache.font_color_readonly : color_map[last_wrap_column + j].color;
+								current_color = color_map[last_wrap_column + j].color;
+								if (readonly && current_color.a > cache.font_color_readonly.a) {
+									current_color.a = cache.font_color_readonly.a;
+								}
 							}
 							color = current_color;
 						}
 
 						int char_w;
 
-						//handle tabulator
+						// Handle tabulator.
 						char_w = text.get_char_width(str[j], str[j + 1], char_ofs);
 
 						if ((char_ofs + char_margin) < xmargin_beg) {
 							char_ofs += char_w;
 
-							// line highlighting handle horizontal clipping
+							// Line highlighting handle horizontal clipping.
 							if (line == cursor.line && cursor_wrap_index == line_wrap_index && highlight_current_line) {
 
 								if (j == str.length() - 1) {
-									// end of line when last char is skipped
+									// End of line when last char is skipped.
 									VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(xmargin_beg + ofs_x, ofs_y, xmargin_end - (char_ofs + char_margin + char_w), get_row_height()), cache.current_line_color);
 								} else if ((char_ofs + char_margin) > xmargin_beg) {
-									// char next to margin is skipped
+									// Char next to margin is skipped.
 									VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(xmargin_beg + ofs_x, ofs_y, (char_ofs + char_margin) - (xmargin_beg + ofs_x), get_row_height()), cache.current_line_color);
 								}
 							}
@@ -1097,7 +1098,7 @@ void TextEdit::_notification(int p_what) {
 						bool in_search_result = false;
 
 						if (search_text_col != -1) {
-							// if we are at the end check for new search result on same line
+							// If we are at the end check for new search result on same line.
 							if (j >= search_text_col + search_text.length())
 								search_text_col = _get_column_pos_of_word(search_text, str, search_flags, j);
 
@@ -1108,19 +1109,19 @@ void TextEdit::_notification(int p_what) {
 							}
 						}
 
-						//current line highlighting
+						// Current line highlighting.
 						bool in_selection = (selection.active && line >= selection.from_line && line <= selection.to_line && (line > selection.from_line || last_wrap_column + j >= selection.from_column) && (line < selection.to_line || last_wrap_column + j < selection.to_column));
 
 						if (line == cursor.line && cursor_wrap_index == line_wrap_index && highlight_current_line) {
-							// draw the wrap indent offset highlight
+							// Draw the wrap indent offset highlight.
 							if (line_wrap_index != 0 && j == 0) {
-								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(char_ofs + char_margin - indent_px, ofs_y, indent_px, get_row_height()), cache.current_line_color);
+								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(char_ofs + char_margin + ofs_x - indent_px, ofs_y, indent_px, get_row_height()), cache.current_line_color);
 							}
-							// if its the last char draw to end of the line
+							// If its the last char draw to end of the line.
 							if (j == str.length() - 1) {
-								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(char_ofs + char_margin + char_w, ofs_y, xmargin_end - (char_ofs + char_margin + char_w), get_row_height()), cache.current_line_color);
+								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(char_ofs + char_margin + char_w + ofs_x, ofs_y, xmargin_end - (char_ofs + char_margin + char_w), get_row_height()), cache.current_line_color);
 							}
-							// actual text
+							// Actual text.
 							if (!in_selection) {
 								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2i(char_ofs + char_margin + ofs_x, ofs_y), Size2i(char_w, get_row_height())), cache.current_line_color);
 							}
@@ -1145,14 +1146,14 @@ void TextEdit::_notification(int p_what) {
 						if (highlight_all_occurrences && !only_whitespaces_highlighted) {
 							if (highlighted_text_col != -1) {
 
-								// if we are at the end check for new word on same line
+								// If we are at the end check for new word on same line.
 								if (j > highlighted_text_col + highlighted_text.length()) {
 									highlighted_text_col = _get_column_pos_of_word(highlighted_text, str, SEARCH_MATCH_CASE | SEARCH_WHOLE_WORDS, j);
 								}
 
 								bool in_highlighted_word = (j >= highlighted_text_col && j < highlighted_text_col + highlighted_text.length());
 
-								// if this is the original highlighted text we don't want to highlight it again
+								// If this is the original highlighted text we don't want to highlight it again.
 								if (cursor.line == line && cursor_wrap_index == line_wrap_index && (cursor.column >= highlighted_text_col && cursor.column <= highlighted_text_col + highlighted_text.length())) {
 									in_highlighted_word = false;
 								}
@@ -1349,7 +1350,7 @@ void TextEdit::_notification(int p_what) {
 
 			bool completion_below = false;
 			if (completion_active) {
-				// code completion box
+				// Code completion box.
 				Ref<StyleBox> csb = get_stylebox("completion");
 				int maxlines = get_constant("completion_lines");
 				int cmax_width = get_constant("completion_max_width") * cache.font->get_char_size('x').x;
@@ -1371,7 +1372,7 @@ void TextEdit::_notification(int p_what) {
 					w = cmax_width;
 				}
 
-				//  Add space for completion icons
+				// Add space for completion icons.
 				const int icon_hsep = get_constant("hseparation", "ItemList");
 				Size2 icon_area_size(get_row_height(), get_row_height());
 				w += icon_area_size.width + icon_hsep;
@@ -1418,7 +1419,7 @@ void TextEdit::_notification(int p_what) {
 					int yofs = (get_row_height() - cache.font->get_height()) / 2;
 					Point2 title_pos(completion_rect.position.x, completion_rect.position.y + i * get_row_height() + cache.font->get_ascent() + yofs);
 
-					//draw completion icon if it is valid
+					// Draw completion icon if it is valid.
 					Ref<Texture> icon = completion_options[l].icon;
 					Rect2 icon_area(completion_rect.position.x, completion_rect.position.y + i * get_row_height(), icon_area_size.width, icon_area_size.height);
 					if (icon.is_valid()) {
@@ -1434,7 +1435,7 @@ void TextEdit::_notification(int p_what) {
 				}
 
 				if (scrollw) {
-					//draw a small scroll rectangle to show a position in the options
+					// Draw a small scroll rectangle to show a position in the options.
 					float r = maxlines / (float)completion_options.size();
 					float o = line_from / (float)completion_options.size();
 					draw_rect(Rect2(completion_rect.position.x + completion_rect.size.width, completion_rect.position.y + o * completion_rect.size.y, scrollw, completion_rect.size.y * r), scrollc);
@@ -1443,7 +1444,7 @@ void TextEdit::_notification(int p_what) {
 				completion_line_ofs = line_from;
 			}
 
-			// check to see if the hint should be drawn
+			// Check to see if the hint should be drawn.
 			bool show_hint = false;
 			if (completion_hint != "") {
 				if (completion_active) {
@@ -1662,9 +1663,9 @@ void TextEdit::backspace_at_cursor() {
 			_is_pair_left_symbol(text[cursor.line][cursor.column - 1])) {
 		_consume_backspace_for_pair_symbol(prev_line, prev_column);
 	} else {
-		// handle space indentation
+		// Handle space indentation.
 		if (cursor.column != 0 && indent_using_spaces) {
-			// check if there are no other chars before cursor, just indentation
+			// Check if there are no other chars before cursor, just indentation.
 			bool unindent = true;
 			int i = 0;
 			while (i < cursor.column && i < text[cursor.line].length()) {
@@ -1675,10 +1676,9 @@ void TextEdit::backspace_at_cursor() {
 				i++;
 			}
 
-			// then we can remove all spaces as a single character.
+			// Then we can remove all spaces as a single character.
 			if (unindent) {
-				// we want to remove spaces up to closest indent
-				// or whole indent if cursor is pointing at it
+				// We want to remove spaces up to closest indent, or whole indent if cursor is pointing at it.
 				int spaces_to_delete = _calculate_spaces_till_next_left_indent(cursor.column);
 				prev_column = cursor.column - spaces_to_delete;
 				_remove_text(cursor.line, prev_column, cursor.line, cursor.column);
@@ -1699,8 +1699,8 @@ void TextEdit::indent_right() {
 	int start_line;
 	int end_line;
 
-	// this value informs us by how much we changed selection position by indenting right
-	// default is 1 for tab indentation
+	// This value informs us by how much we changed selection position by indenting right.
+	// Default is 1 for tab indentation.
 	int selection_offset = 1;
 	begin_complex_operation();
 
@@ -1712,7 +1712,7 @@ void TextEdit::indent_right() {
 		end_line = start_line;
 	}
 
-	// ignore if the cursor is not past the first column
+	// Ignore if the cursor is not past the first column.
 	if (is_selection_active() && get_selection_to_column() == 0) {
 		end_line--;
 	}
@@ -1720,10 +1720,10 @@ void TextEdit::indent_right() {
 	for (int i = start_line; i <= end_line; i++) {
 		String line_text = get_line(i);
 		if (indent_using_spaces) {
-			// we don't really care where selection is - we just need to know indentation level at the beginning of the line
+			// We don't really care where selection is - we just need to know indentation level at the beginning of the line.
 			int left = _find_first_non_whitespace_column_of_line(line_text);
 			int spaces_to_add = _calculate_spaces_till_next_right_indent(left);
-			// since we will add this much spaces we want move whole selection and cursor by this much
+			// Since we will add this much spaces we want move whole selection and cursor by this much.
 			selection_offset = spaces_to_add;
 			for (int j = 0; j < spaces_to_add; j++)
 				line_text = ' ' + line_text;
@@ -1733,7 +1733,7 @@ void TextEdit::indent_right() {
 		set_line(i, line_text);
 	}
 
-	// fix selection and cursor being off after shifting selection right
+	// Fix selection and cursor being off after shifting selection right.
 	if (is_selection_active()) {
 		select(selection.from_line, selection.from_column + selection_offset, selection.to_line, selection.to_column + selection_offset);
 	}
@@ -1747,10 +1747,9 @@ void TextEdit::indent_left() {
 	int start_line;
 	int end_line;
 
-	// moving cursor and selection after unindenting can get tricky
-	// because changing content of line can move cursor and selection on it's own (if new line ends before previous position of either)
-	// therefore we just remember initial values
-	// and at the end of the operation offset them by number of removed characters
+	// Moving cursor and selection after unindenting can get tricky because
+	// changing content of line can move cursor and selection on it's own (if new line ends before previous position of either),
+	// therefore we just remember initial values and at the end of the operation offset them by number of removed characters.
 	int removed_characters = 0;
 	int initial_selection_end_column = selection.to_column;
 	int initial_cursor_column = cursor.column;
@@ -1765,7 +1764,7 @@ void TextEdit::indent_left() {
 		end_line = start_line;
 	}
 
-	// ignore if the cursor is not past the first column
+	// Ignore if the cursor is not past the first column.
 	if (is_selection_active() && get_selection_to_column() == 0) {
 		end_line--;
 	}
@@ -1779,12 +1778,12 @@ void TextEdit::indent_left() {
 			set_line(i, line_text);
 			removed_characters = 1;
 		} else if (line_text.begins_with(" ")) {
-			// when unindenting we aim to remove spaces before line that has selection no matter what is selected
+			// When unindenting we aim to remove spaces before line that has selection no matter what is selected,
 			// so we start of by finding first non whitespace character of line
 			int left = _find_first_non_whitespace_column_of_line(line_text);
 
-			// here we remove only enough spaces to align text to nearest full multiple of indentation_size
-			// in case where selection begins at the start of indentation_size multiple we remove whole indentation level
+			// Here we remove only enough spaces to align text to nearest full multiple of indentation_size.
+			// In case where selection begins at the start of indentation_size multiple we remove whole indentation level.
 			int spaces_to_remove = _calculate_spaces_till_next_left_indent(left);
 
 			line_text = line_text.substr(spaces_to_remove, line_text.length());
@@ -1793,7 +1792,7 @@ void TextEdit::indent_left() {
 		}
 	}
 
-	// fix selection and cursor being off by one on the last line
+	// Fix selection and cursor being off by one on the last line.
 	if (is_selection_active() && last_line_text != get_line(end_line)) {
 		select(selection.from_line, selection.from_column - removed_characters,
 				selection.to_line, initial_selection_end_column - removed_characters);
@@ -1834,7 +1833,7 @@ void TextEdit::_get_mouse_pos(const Point2i &p_mouse, int &r_row, int &r_col) co
 	}
 
 	if (row < 0)
-		row = 0; //todo
+		row = 0; // TODO.
 
 	int col = 0;
 
@@ -1848,7 +1847,7 @@ void TextEdit::_get_mouse_pos(const Point2i &p_mouse, int &r_row, int &r_col) co
 		colx += cursor.x_ofs;
 		col = get_char_pos_for_line(colx, row, wrap_index);
 		if (is_wrap_enabled() && wrap_index < times_line_wraps(row)) {
-			// move back one if we are at the end of the row
+			// Move back one if we are at the end of the row.
 			Vector<String> rows2 = get_wrap_rows_text(row);
 			int row_end_col = 0;
 			for (int i = 0; i < wrap_index + 1; i++) {
@@ -1942,7 +1941,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					return;
 				}
 
-				// toggle breakpoint on gutter click
+				// Toggle breakpoint on gutter click.
 				if (draw_breakpoint_gutter) {
 					int gutter = cache.style_normal->get_margin(MARGIN_LEFT);
 					if (mb->get_position().x > gutter - 6 && mb->get_position().x <= gutter + cache.breakpoint_gutter_width - 3) {
@@ -1952,7 +1951,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					}
 				}
 
-				// emit info clicked
+				// Emit info clicked.
 				if (draw_info_gutter && text.has_info_icon(row)) {
 					int left_margin = cache.style_normal->get_margin(MARGIN_LEFT);
 					int gutter_left = left_margin + cache.breakpoint_gutter_width;
@@ -1962,7 +1961,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					}
 				}
 
-				// toggle fold on gutter click if can
+				// Toggle fold on gutter click if can.
 				if (draw_fold_gutter) {
 
 					int left_margin = cache.style_normal->get_margin(MARGIN_LEFT);
@@ -1977,7 +1976,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					}
 				}
 
-				// unfold on folded icon click
+				// Unfold on folded icon click.
 				if (is_folded(row)) {
 					int line_width = text.get_line_width(row);
 					line_width += cache.style_normal->get_margin(MARGIN_LEFT) + cache.line_number_w + cache.breakpoint_gutter_width + cache.info_gutter_width + cache.fold_gutter_width - cursor.x_ofs;
@@ -2044,9 +2043,6 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				} else {
 
-					//if sel active and dblick last time < something
-
-					//else
 					selection.active = false;
 					selection.selecting_mode = Selection::MODE_POINTER;
 					selection.selecting_line = row;
@@ -2054,14 +2050,14 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 
 				if (!mb->is_doubleclick() && (OS::get_singleton()->get_ticks_msec() - last_dblclk) < 600 && cursor.line == prev_line) {
-					//tripleclick select line
+
+					// Triple-click select line.
 					selection.selecting_mode = Selection::MODE_LINE;
 					_update_selection_mode_line();
 					last_dblclk = 0;
-
 				} else if (mb->is_doubleclick() && text[cursor.line].length()) {
 
-					//doubleclick select word
+					// Double-click select word.
 					selection.selecting_mode = Selection::MODE_WORD;
 					_update_selection_mode_word();
 					last_dblclk = OS::get_singleton()->get_ticks_msec();
@@ -2086,7 +2082,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 						int to_column = get_selection_to_column();
 
 						if (row < from_line || row > to_line || (row == from_line && col < from_column) || (row == to_line && col > to_column)) {
-							// Right click is outside the selected text
+							// Right click is outside the selected text.
 							deselect();
 						}
 					}
@@ -2107,7 +2103,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (mb->get_button_index() == BUTTON_LEFT)
 				click_select_held->stop();
 
-			// notify to show soft keyboard
+			// Notify to show soft keyboard.
 			notification(NOTIFICATION_FOCUS_ENTER);
 		}
 	}
@@ -2123,7 +2119,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 		h_scroll->set_value(h_scroll->get_value() + pan_gesture->get_delta().x * 100);
 		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll)
-			accept_event(); //accept event if scroll changed
+			accept_event(); // Accept event if scroll changed.
 
 		return;
 	}
@@ -2148,7 +2144,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 		}
 
-		if (mm->get_button_mask() & BUTTON_MASK_LEFT && get_viewport()->gui_get_drag_data() == Variant()) { //ignore if dragging
+		if (mm->get_button_mask() & BUTTON_MASK_LEFT && get_viewport()->gui_get_drag_data() == Variant()) { // Ignore if dragging.
 			_reset_caret_blink_timer();
 
 			switch (selection.selecting_mode) {
@@ -2169,13 +2165,13 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 
 	if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll)
-		accept_event(); //accept event if scroll changed
+		accept_event(); // Accept event if scroll changed.
 
 	Ref<InputEventKey> k = p_gui_input;
 
 	if (k.is_valid()) {
 
-		k = k->duplicate(); //it will be modified later on
+		k = k->duplicate(); // It will be modified later on.
 
 #ifdef OSX_ENABLED
 		if (k->get_scancode() == KEY_META) {
@@ -2311,11 +2307,11 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 						_consume_pair_symbol(chr[0]);
 					} else {
 
-						// remove the old character if in insert mode
+						// Remove the old character if in insert mode.
 						if (insert_mode) {
 							begin_complex_operation();
 
-							// make sure we don't try and remove empty space
+							// Make sure we don't try and remove empty space.
 							if (cursor.column < get_line(cursor.line).length()) {
 								_remove_text(cursor.line, cursor.column, cursor.line, cursor.column + 1);
 							}
@@ -2337,9 +2333,9 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			_cancel_completion();
 		}
 
-		/* TEST CONTROL FIRST!! */
+		/* TEST CONTROL FIRST! */
 
-		// some remaps for duplicate functions..
+		// Some remaps for duplicate functions.
 		if (k->get_command() && !k->get_shift() && !k->get_alt() && !k->get_metakey() && k->get_scancode() == KEY_INSERT) {
 
 			k->set_scancode(KEY_C);
@@ -2383,10 +2379,10 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		_reset_caret_blink_timer();
 
-		// save here for insert mode, just in case it is cleared in the following section
+		// Save here for insert mode, just in case it is cleared in the following section.
 		bool had_selection = selection.active;
 
-		// stuff to do when selection is active..
+		// Stuff to do when selection is active.
 		if (!readonly && selection.active) {
 
 			bool clear = false;
@@ -2406,7 +2402,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				} break;
 				case KEY_X:
 				case KEY_C:
-					//special keys often used with control, wait...
+					// Special keys often used with control, wait.
 					clear = (!k->get_command() || k->get_shift() || k->get_alt());
 					break;
 				case KEY_DELETE:
@@ -2431,7 +2427,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				case KEY_PAGEDOWN:
 				case KEY_HOME:
 				case KEY_END:
-					// ignore arrows if any modifiers are held (shift = selecting, others may be used for editor hotkeys)
+					// Ignore arrows if any modifiers are held (shift = selecting, others may be used for editor hotkeys).
 					if (k->get_command() || k->get_shift() || k->get_alt())
 						break;
 					unselect = true;
@@ -2469,7 +2465,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		bool scancode_handled = true;
 
-		// special scancode test...
+		// Special scancode test.
 
 		switch (k->get_scancode()) {
 
@@ -2481,7 +2477,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				String ins = "\n";
 
-				//keep indentation
+				// Keep indentation.
 				int space_count = 0;
 				for (int i = 0; i < cursor.column; i++) {
 					if (text[cursor.line][i] == '\t') {
@@ -2512,10 +2508,10 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				bool brace_indent = false;
 
-				// no need to indent if we are going upwards.
+				// No need to indent if we are going upwards.
 				if (auto_indent && !(k->get_command() && k->get_shift())) {
-					// indent once again if previous line will end with ':' or '{' and the line is not a comment
-					// (i.e. colon/brace precedes current cursor position)
+					// Indent once again if previous line will end with ':' or '{' and the line is not a comment
+					// (i.e. colon/brace precedes current cursor position).
 					if (cursor.column > 0 && (text[cursor.line][cursor.column - 1] == ':' || text[cursor.line][cursor.column - 1] == '{') && !is_line_comment(cursor.line)) {
 						if (indent_using_spaces) {
 							ins += space_indent;
@@ -2523,7 +2519,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 							ins += "\t";
 						}
 
-						// no need to move the brace below if we are not taking the text with us.
+						// No need to move the brace below if we are not taking the text with us.
 						if (text[cursor.line][cursor.column] == '}' && !k->get_command()) {
 							brace_indent = true;
 							ins += "\n" + ins.substr(1, ins.length() - 2);
@@ -2565,7 +2561,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 			} break;
 			case KEY_TAB: {
-				if (k->get_command()) break; // avoid tab when command
+				if (k->get_command()) break; // Avoid tab when command.
 
 				if (readonly)
 					break;
@@ -2579,7 +2575,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				} else {
 					if (k->get_shift()) {
 
-						// simple unindent
+						// Simple unindent.
 						int cc = cursor.column;
 						const String &line = text[cursor.line];
 
@@ -2591,17 +2587,17 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 						if (cc > 0 && cc <= text[cursor.line].length()) {
 							if (text[cursor.line][cc - 1] == '\t') {
-								// tabs unindentation
+								// Tabs unindentation.
 								_remove_text(cursor.line, cc - 1, cursor.line, cc);
 								if (cursor.column >= left)
 									cursor_set_column(MAX(0, cursor.column - 1));
 								update();
 							} else {
-								// spaces unindentation
+								// Spaces unindentation.
 								int spaces_to_remove = _calculate_spaces_till_next_left_indent(cc);
 								if (spaces_to_remove > 0) {
 									_remove_text(cursor.line, cc - spaces_to_remove, cursor.line, cc);
-									if (cursor.column > left - spaces_to_remove) // inside text?
+									if (cursor.column > left - spaces_to_remove) // Inside text?
 										cursor_set_column(MAX(0, cursor.column - spaces_to_remove));
 									update();
 								}
@@ -2611,9 +2607,9 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 							update();
 						}
 					} else {
-						// simple indent
+						// Simple indent.
 						if (indent_using_spaces) {
-							// insert only as much spaces as needed till next indentation level
+							// Insert only as much spaces as needed till next indentation level.
 							int spaces_to_add = _calculate_spaces_till_next_right_indent(cursor.column);
 							String indent_to_insert = String();
 							for (int i = 0; i < spaces_to_add; i++)
@@ -2641,20 +2637,20 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					int line = cursor.line;
 					int column = cursor.column;
 
-					// check if we are removing a single whitespace, if so remove it and the next char type
-					// else we just remove the whitespace
+					// Check if we are removing a single whitespace, if so remove it and the next char type,
+					// else we just remove the whitespace.
 					bool only_whitespace = false;
 					if (_is_whitespace(text[line][column - 1]) && _is_whitespace(text[line][column - 2])) {
 						only_whitespace = true;
 					} else if (_is_whitespace(text[line][column - 1])) {
-						// remove the single whitespace
+						// Remove the single whitespace.
 						column--;
 					}
 
-					// check if its a text char
+					// Check if its a text char.
 					bool only_char = (_is_text_char(text[line][column - 1]) && !only_whitespace);
 
-					// if its not whitespace or char then symbol.
+					// If its not whitespace or char then symbol.
 					bool only_symbols = !(only_whitespace || only_char);
 
 					while (column > 0) {
@@ -2940,7 +2936,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				int curline_len = text[cursor.line].length();
 
 				if (cursor.line == text.size() - 1 && cursor.column == curline_len)
-					break; //nothing to do
+					break; // Nothing to do.
 
 				int next_line = cursor.column < curline_len ? cursor.line : cursor.line + 1;
 				int next_column;
@@ -2957,20 +2953,20 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					int line = cursor.line;
 					int column = cursor.column;
 
-					// check if we are removing a single whitespace, if so remove it and the next char type
-					// else we just remove the whitespace
+					// Check if we are removing a single whitespace, if so remove it and the next char type,
+					// else we just remove the whitespace.
 					bool only_whitespace = false;
 					if (_is_whitespace(text[line][column]) && _is_whitespace(text[line][column + 1])) {
 						only_whitespace = true;
 					} else if (_is_whitespace(text[line][column])) {
-						// remove the single whitespace
+						// Remove the single whitespace.
 						column++;
 					}
 
-					// check if its a text char
+					// Check if its a text char.
 					bool only_char = (_is_text_char(text[line][column]) && !only_whitespace);
 
-					// if its not whitespace or char then symbol.
+					// If its not whitespace or char then symbol.
 					bool only_symbols = !(only_whitespace || only_char);
 
 					while (column < curline_len) {
@@ -3029,7 +3025,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					cursor_set_column(0);
 				} else {
 
-					// move cursor column to start of wrapped row and then to start of text
+					// Move cursor column to start of wrapped row and then to start of text.
 					Vector<String> rows = get_wrap_rows_text(cursor.line);
 					int wi = get_cursor_wrap_index();
 					int row_start_col = 0;
@@ -3037,7 +3033,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 						row_start_col += rows[i].length();
 					}
 					if (cursor.column == row_start_col || wi == 0) {
-						// compute whitespace symbols seq length
+						// Compute whitespace symbols seq length.
 						int current_line_whitespace_len = 0;
 						while (current_line_whitespace_len < text[cursor.line].length()) {
 							CharType c = text[cursor.line][current_line_whitespace_len];
@@ -3088,7 +3084,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				if (k->get_command())
 					cursor_set_line(get_last_unhidden_line(), true, false, 9999);
 
-				// move cursor column to end of wrapped row and then to end of text
+				// Move cursor column to end of wrapped row and then to end of text.
 				Vector<String> rows = get_wrap_rows_text(cursor.line);
 				int wi = get_cursor_wrap_index();
 				int row_end_col = -1;
@@ -3274,7 +3270,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			} break;
 			case KEY_SPACE: {
 #ifdef OSX_ENABLED
-				if (completion_enabled && k->get_metakey()) { //cmd-space is spotlight shortcut in OSX
+				if (completion_enabled && k->get_metakey()) { // cmd-space is spotlight shortcut in OSX
 #else
 				if (completion_enabled && k->get_command()) {
 #endif
@@ -3302,18 +3298,18 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			return;
 		}
 
-		if (!scancode_handled && !k->get_command()) { //for German kbds
+		if (!scancode_handled && !k->get_command()) { // For German keyboards.
 
 			if (k->get_unicode() >= 32) {
 
 				if (readonly)
 					return;
 
-				// remove the old character if in insert mode and no selection
+				// Remove the old character if in insert mode and no selection.
 				if (insert_mode && !had_selection) {
 					begin_complex_operation();
 
-					// make sure we don't try and remove empty space
+					// Make sure we don't try and remove empty space.
 					if (cursor.column < get_line(cursor.line).length()) {
 						_remove_text(cursor.line, cursor.column, cursor.line, cursor.column + 1);
 					}
@@ -3424,10 +3420,10 @@ void TextEdit::_post_shift_selection() {
 void TextEdit::_scroll_lines_up() {
 	scrolling = false;
 
-	// adjust the vertical scroll
+	// Adjust the vertical scroll.
 	set_v_scroll(get_v_scroll() - 1);
 
-	// adjust the cursor to viewport
+	// Adjust the cursor to viewport.
 	if (!selection.active) {
 		int cur_line = cursor.line;
 		int cur_wrap = get_cursor_wrap_index();
@@ -3443,10 +3439,10 @@ void TextEdit::_scroll_lines_up() {
 void TextEdit::_scroll_lines_down() {
 	scrolling = false;
 
-	// adjust the vertical scroll
+	// Adjust the vertical scroll.
 	set_v_scroll(get_v_scroll() + 1);
 
-	// adjust the cursor to viewport
+	// Adjust the cursor to viewport.
 	if (!selection.active) {
 		int cur_line = cursor.line;
 		int cur_wrap = get_cursor_wrap_index();
@@ -3463,15 +3459,15 @@ void TextEdit::_scroll_lines_down() {
 
 void TextEdit::_base_insert_text(int p_line, int p_char, const String &p_text, int &r_end_line, int &r_end_column) {
 
-	//save for undo...
+	// Save for undo.
 	ERR_FAIL_INDEX(p_line, text.size());
 	ERR_FAIL_COND(p_char < 0);
 
-	/* STEP 1 remove \r from source text and separate in substrings */
+	/* STEP 1: Remove \r from source text and separate in substrings. */
 
 	Vector<String> substrings = p_text.replace("\r", "").split("\n");
 
-	/* STEP 2 fire breakpoint_toggled signals */
+	/* STEP 2: Fire breakpoint_toggled signals. */
 
 	// Is this just a new empty line?
 	bool shift_first_line = p_char == 0 && p_text.replace("\r", "") == "\n";
@@ -3487,19 +3483,19 @@ void TextEdit::_base_insert_text(int p_line, int p_char, const String &p_text, i
 		}
 	}
 
-	/* STEP 3 add spaces if the char is greater than the end of the line */
+	/* STEP 3: Add spaces if the char is greater than the end of the line. */
 	while (p_char > text[p_line].length()) {
 
 		text.set(p_line, text[p_line] + String::chr(' '));
 	}
 
-	/* STEP 4 separate dest string in pre and post text */
+	/* STEP 4: Separate dest string in pre and post text. */
 
 	String preinsert_text = text[p_line].substr(0, p_char);
 	String postinsert_text = text[p_line].substr(p_char, text[p_line].size());
 
 	for (int j = 0; j < substrings.size(); j++) {
-		//insert the substrings
+		// Insert the substrings.
 
 		if (j == 0) {
 
@@ -3544,8 +3540,8 @@ String TextEdit::_base_get_text(int p_from_line, int p_from_column, int p_to_lin
 	ERR_FAIL_INDEX_V(p_from_column, text[p_from_line].length() + 1, String());
 	ERR_FAIL_INDEX_V(p_to_line, text.size(), String());
 	ERR_FAIL_INDEX_V(p_to_column, text[p_to_line].length() + 1, String());
-	ERR_FAIL_COND_V(p_to_line < p_from_line, String()); // from > to
-	ERR_FAIL_COND_V(p_to_line == p_from_line && p_to_column < p_from_column, String()); // from > to
+	ERR_FAIL_COND_V(p_to_line < p_from_line, String()); // 'from > to'.
+	ERR_FAIL_COND_V(p_to_line == p_from_line && p_to_column < p_from_column, String()); // 'from > to'.
 
 	String ret;
 
@@ -3568,8 +3564,8 @@ void TextEdit::_base_remove_text(int p_from_line, int p_from_column, int p_to_li
 	ERR_FAIL_INDEX(p_from_column, text[p_from_line].length() + 1);
 	ERR_FAIL_INDEX(p_to_line, text.size());
 	ERR_FAIL_INDEX(p_to_column, text[p_to_line].length() + 1);
-	ERR_FAIL_COND(p_to_line < p_from_line); // from > to
-	ERR_FAIL_COND(p_to_line == p_from_line && p_to_column < p_from_column); // from > to
+	ERR_FAIL_COND(p_to_line < p_from_line); // 'from > to'.
+	ERR_FAIL_COND(p_to_line == p_from_line && p_to_column < p_from_column); // 'from > to'.
 
 	String pre_text = text[p_from_line].substr(0, p_from_column);
 	String post_text = text[p_to_line].substr(p_to_column, text[p_to_line].length());
@@ -3631,22 +3627,22 @@ void TextEdit::_insert_text(int p_line, int p_char, const String &p_text, int *r
 	op.chain_forward = false;
 	op.chain_backward = false;
 
-	//see if it should just be set as current op
+	// See if it should just be set as current op.
 	if (current_op.type != op.type) {
 		op.prev_version = get_version();
 		_push_current_op();
 		current_op = op;
 
-		return; //set as current op, return
+		return; // Set as current op, return.
 	}
-	//see if it can be merged
+	// See if it can be merged.
 	if (current_op.to_line != p_line || current_op.to_column != p_char) {
 		op.prev_version = get_version();
 		_push_current_op();
 		current_op = op;
-		return; //set as current op, return
+		return; // Set as current op, return.
 	}
-	//merge current op
+	// Merge current op.
 
 	current_op.text += p_text;
 	current_op.to_column = retchar;
@@ -3670,7 +3666,7 @@ void TextEdit::_remove_text(int p_from_line, int p_from_column, int p_to_line, i
 	if (!undo_enabled)
 		return;
 
-	/* UNDO!! */
+	/* UNDO! */
 	TextOperation op;
 	op.type = TextOperation::TYPE_REMOVE;
 	op.from_line = p_from_line;
@@ -3682,27 +3678,20 @@ void TextEdit::_remove_text(int p_from_line, int p_from_column, int p_to_line, i
 	op.chain_forward = false;
 	op.chain_backward = false;
 
-	//see if it should just be set as current op
+	// See if it should just be set as current op.
 	if (current_op.type != op.type) {
 		op.prev_version = get_version();
 		_push_current_op();
 		current_op = op;
-		return; //set as current op, return
+		return; // Set as current op, return.
 	}
-	//see if it can be merged
+	// See if it can be merged.
 	if (current_op.from_line == p_to_line && current_op.from_column == p_to_column) {
-		//basckace or similar
+		// Backspace or similar.
 		current_op.text = text + current_op.text;
 		current_op.from_line = p_from_line;
 		current_op.from_column = p_from_column;
-		return; //update current op
-	}
-	if (current_op.from_line == p_from_line && current_op.from_column == p_from_column) {
-
-		//current_op.text=text+current_op.text;
-		//current_op.from_line=p_from_line;
-		//current_op.from_column=p_from_column;
-		//return; //update current op
+		return; // Update current op.
 	}
 
 	op.prev_version = get_version();
@@ -3734,11 +3723,11 @@ int TextEdit::get_char_count() {
 	for (int i = 0; i < text.size(); i++) {
 
 		if (i > 0)
-			totalsize++; // incliude \n
+			totalsize++; // Include \n.
 		totalsize += text[i].length();
 	}
 
-	return totalsize; // omit last \n
+	return totalsize; // Omit last \n.
 }
 
 Size2 TextEdit::get_minimum_size() const {
@@ -3758,7 +3747,7 @@ int TextEdit::get_visible_rows() const {
 
 int TextEdit::get_total_visible_rows() const {
 
-	// returns the total amount of rows we need in the editor.
+	// Returns the total amount of rows we need in the editor.
 	// This skips hidden lines and counts each wrapping of a line.
 	if (!is_hiding_enabled() && !is_wrap_enabled())
 		return text.size();
@@ -3780,7 +3769,7 @@ void TextEdit::_update_wrap_at() {
 	text.clear_wrap_cache();
 
 	for (int i = 0; i < text.size(); i++) {
-		// update all values that wrap
+		// Update all values that wrap.
 		if (!line_wraps(i))
 			continue;
 		Vector<String> rows = get_wrap_rows_text(i);
@@ -3790,7 +3779,7 @@ void TextEdit::_update_wrap_at() {
 
 void TextEdit::adjust_viewport_to_cursor() {
 
-	// make sure cursor is visible on the screen
+	// Make sure cursor is visible on the screen.
 	scrolling = false;
 
 	int cur_line = cursor.line;
@@ -3802,20 +3791,20 @@ void TextEdit::adjust_viewport_to_cursor() {
 	int last_vis_wrap = get_last_visible_line_wrap_index();
 
 	if (cur_line < first_vis_line || (cur_line == first_vis_line && cur_wrap < first_vis_wrap)) {
-		// cursor is above screen
+		// Cursor is above screen.
 		set_line_as_first_visible(cur_line, cur_wrap);
 	} else if (cur_line > last_vis_line || (cur_line == last_vis_line && cur_wrap > last_vis_wrap)) {
-		// cursor is below screen
+		// Cursor is below screen.
 		set_line_as_last_visible(cur_line, cur_wrap);
 	}
 
 	int visible_width = get_size().width - cache.style_normal->get_minimum_size().width - cache.line_number_w - cache.breakpoint_gutter_width - cache.fold_gutter_width - cache.info_gutter_width;
 	if (v_scroll->is_visible_in_tree())
 		visible_width -= v_scroll->get_combined_minimum_size().width;
-	visible_width -= 20; // give it a little more space
+	visible_width -= 20; // Give it a little more space.
 
 	if (!is_wrap_enabled()) {
-		// adjust x offset
+		// Adjust x offset.
 		int cursor_x = get_column_x_offset(cursor.column, text[cursor.line]);
 
 		if (cursor_x > (cursor.x_ofs + visible_width))
@@ -3833,7 +3822,7 @@ void TextEdit::adjust_viewport_to_cursor() {
 
 void TextEdit::center_viewport_to_cursor() {
 
-	// move viewport so the cursor is in the center of the screen
+	// Move viewport so the cursor is in the center of the screen.
 	scrolling = false;
 
 	if (is_line_hidden(cursor.line))
@@ -3843,10 +3832,10 @@ void TextEdit::center_viewport_to_cursor() {
 	int visible_width = get_size().width - cache.style_normal->get_minimum_size().width - cache.line_number_w - cache.breakpoint_gutter_width - cache.fold_gutter_width - cache.info_gutter_width;
 	if (v_scroll->is_visible_in_tree())
 		visible_width -= v_scroll->get_combined_minimum_size().width;
-	visible_width -= 20; // give it a little more space
+	visible_width -= 20; // Give it a little more space.
 
 	if (is_wrap_enabled()) {
-		// center x offset
+		// Center x offset.
 		int cursor_x = get_column_x_offset_for_line(cursor.column, cursor.line);
 
 		if (cursor_x > (cursor.x_ofs + visible_width))
@@ -3888,7 +3877,7 @@ int TextEdit::times_line_wraps(int line) const {
 
 	int wrap_amount = text.get_line_wrap_amount(line);
 	if (wrap_amount == -1) {
-		// update the value
+		// Update the value.
 		Vector<String> rows = get_wrap_rows_text(line);
 		wrap_amount = rows.size() - 1;
 		text.set_line_wrap_amount(line, wrap_amount);
@@ -3928,7 +3917,7 @@ Vector<String> TextEdit::get_wrap_rows_text(int p_line) const {
 		int indent_ofs = (cur_wrap_index != 0 ? tab_offset_px : 0);
 
 		if (indent_ofs + word_px + w > wrap_at) {
-			// not enough space to add this char; start next line
+			// Not enough space to add this char; start next line.
 			wrap_substring += word_str;
 			lines.push_back(wrap_substring);
 			cur_wrap_index++;
@@ -3942,7 +3931,7 @@ Vector<String> TextEdit::get_wrap_rows_text(int p_line) const {
 			word_str += c;
 			word_px += w;
 			if (c == ' ') {
-				// end of a word; add this word to the substring
+				// End of a word; add this word to the substring.
 				wrap_substring += word_str;
 				px += word_px;
 				word_str = "";
@@ -3950,9 +3939,9 @@ Vector<String> TextEdit::get_wrap_rows_text(int p_line) const {
 			}
 
 			if (indent_ofs + px + word_px > wrap_at) {
-				// this word will be moved to the next line
+				// This word will be moved to the next line.
 				lines.push_back(wrap_substring);
-				// reset for next wrap
+				// Reset for next wrap.
 				cur_wrap_index++;
 				wrap_substring = "";
 				px = 0;
@@ -3960,11 +3949,11 @@ Vector<String> TextEdit::get_wrap_rows_text(int p_line) const {
 		}
 		col++;
 	}
-	// line ends before hit wrap_at; add this word to the substring
+	// Line ends before hit wrap_at; add this word to the substring.
 	wrap_substring += word_str;
 	lines.push_back(wrap_substring);
 
-	// update cache
+	// Update cache.
 	text.set_line_wrap_amount(p_line, lines.size() - 1);
 
 	return lines;
@@ -3982,7 +3971,7 @@ int TextEdit::get_line_wrap_index_at_col(int p_line, int p_column) const {
 	if (!line_wraps(p_line))
 		return 0;
 
-	// loop through wraps in the line text until we get to the column
+	// Loop through wraps in the line text until we get to the column.
 	int wrap_index = 0;
 	int col = 0;
 	Vector<String> rows = get_wrap_rows_text(p_line);
@@ -4134,7 +4123,7 @@ void TextEdit::_scroll_moved(double p_to_val) {
 		cursor.x_ofs = h_scroll->get_value();
 	if (v_scroll->is_visible_in_tree()) {
 
-		// set line ofs and wrap ofs
+		// Set line ofs and wrap ofs.
 		int v_scroll_i = floor(get_v_scroll());
 		int sc = 0;
 		int n_line;
@@ -4289,12 +4278,12 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 		_get_mouse_pos(p_pos, row, col);
 		int left_margin = cache.style_normal->get_margin(MARGIN_LEFT);
 
-		// breakpoint icon
+		// Breakpoint icon.
 		if (draw_breakpoint_gutter && p_pos.x > left_margin - 6 && p_pos.x <= left_margin + cache.breakpoint_gutter_width - 3) {
 			return CURSOR_POINTING_HAND;
 		}
 
-		// info icons
+		// Info icons.
 		int gutter_left = left_margin + cache.breakpoint_gutter_width + cache.info_gutter_width;
 		if (draw_info_gutter && p_pos.x > left_margin + cache.breakpoint_gutter_width - 6 && p_pos.x <= gutter_left - 3) {
 			if (text.has_info_icon(row)) {
@@ -4303,7 +4292,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 			return CURSOR_ARROW;
 		}
 
-		// fold icon
+		// Fold icon.
 		if (draw_fold_gutter && p_pos.x > gutter_left + cache.line_number_w - 6 && p_pos.x <= gutter_left + cache.line_number_w + cache.fold_gutter_width - 3) {
 			if (is_folded(row) || can_fold(row))
 				return CURSOR_POINTING_HAND;
@@ -4315,7 +4304,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 	} else {
 		int row, col;
 		_get_mouse_pos(p_pos, row, col);
-		// eol fold icon
+		// EOL fold icon.
 		if (is_folded(row)) {
 			int line_width = text.get_line_width(row);
 			line_width += cache.style_normal->get_margin(MARGIN_LEFT) + cache.line_number_w + cache.breakpoint_gutter_width + cache.fold_gutter_width + cache.info_gutter_width - cursor.x_ofs;
@@ -4349,8 +4338,6 @@ void TextEdit::set_text(String p_text) {
 
 	update();
 	setting_text = false;
-
-	//get_range()->set(0);
 };
 
 String TextEdit::get_text() {
@@ -4377,7 +4364,7 @@ String TextEdit::get_text_for_lookup_completion() {
 
 		if (i == row) {
 			longthing += text[i].substr(0, col);
-			longthing += String::chr(0xFFFF); //not unicode, represents the cursor
+			longthing += String::chr(0xFFFF); // Not unicode, represents the cursor.
 			longthing += text[i].substr(col, text[i].size());
 		} else {
 
@@ -4399,7 +4386,7 @@ String TextEdit::get_text_for_completion() {
 
 		if (i == cursor.line) {
 			longthing += text[i].substr(0, cursor.column);
-			longthing += String::chr(0xFFFF); //not unicode, represents the cursor
+			longthing += String::chr(0xFFFF); // Not unicode, represents the cursor.
 			longthing += text[i].substr(cursor.column, text[i].size());
 		} else {
 
@@ -4587,12 +4574,12 @@ void TextEdit::_set_syntax_highlighting(SyntaxHighlighter *p_syntax_highlighter)
 
 int TextEdit::_is_line_in_region(int p_line) {
 
-	// do we have in cache?
+	// Do we have in cache?
 	if (color_region_cache.has(p_line)) {
 		return color_region_cache[p_line];
 	}
 
-	// if not find the closest line we have
+	// If not find the closest line we have.
 	int previous_line = p_line - 1;
 	for (; previous_line > -1; previous_line--) {
 		if (color_region_cache.has(p_line)) {
@@ -4600,7 +4587,7 @@ int TextEdit::_is_line_in_region(int p_line) {
 		}
 	}
 
-	// calculate up to line we need and update the cache along the way.
+	// Calculate up to line we need and update the cache along the way.
 	int in_region = color_region_cache[previous_line];
 	if (previous_line == -1) {
 		in_region = -1;
@@ -4728,7 +4715,7 @@ void TextEdit::cut() {
 		OS::get_singleton()->set_clipboard(clipboard);
 
 		_remove_text(selection.from_line, selection.from_column, selection.to_line, selection.to_column);
-		cursor_set_line(selection.from_line); // set afterwards else it causes the view to be offset
+		cursor_set_line(selection.from_line); // Set afterwards else it causes the view to be offset.
 		cursor_set_column(selection.from_column);
 
 		selection.active = false;
@@ -4957,7 +4944,7 @@ int TextEdit::_get_column_pos_of_word(const String &p_key, const String &p_searc
 				col = p_search.findn(p_key, p_from_column);
 			}
 
-			// whole words only
+			// Whole words only.
 			if (col != -1 && p_search_flags & SEARCH_WHOLE_WORDS) {
 				p_from_column = col;
 
@@ -4997,14 +4984,12 @@ bool TextEdit::search(const String &p_key, uint32_t p_search_flags, int p_from_l
 	ERR_FAIL_INDEX_V(p_from_line, text.size(), false);
 	ERR_FAIL_INDEX_V(p_from_column, text[p_from_line].length() + 1, false);
 
-	//search through the whole document, but start by current line
+	// Search through the whole document, but start by current line.
 
 	int line = p_from_line;
 	int pos = -1;
 
 	for (int i = 0; i < text.size() + 1; i++) {
-		//backwards is broken...
-		//int idx=(p_search_flags&SEARCH_BACKWARDS)?(text.size()-i):i; //do backwards seearch
 
 		if (line < 0) {
 			line = text.size() - 1;
@@ -5018,7 +5003,7 @@ bool TextEdit::search(const String &p_key, uint32_t p_search_flags, int p_from_l
 		if (line == p_from_line) {
 
 			if (i == text.size()) {
-				//wrapped
+				// Wrapped.
 
 				if (p_search_flags & SEARCH_BACKWARDS) {
 					from_column = text_line.length();
@@ -5066,7 +5051,7 @@ bool TextEdit::search(const String &p_key, uint32_t p_search_flags, int p_from_l
 			bool is_match = true;
 
 			if (pos != -1 && (p_search_flags & SEARCH_WHOLE_WORDS)) {
-				//validate for whole words
+				// Validate for whole words.
 				if (pos > 0 && _is_text_char(text_line[pos - 1]))
 					is_match = false;
 				else if (pos + p_key.length() < text_line.length() && _is_text_char(text_line[pos + p_key.length()]))
@@ -5264,7 +5249,7 @@ void TextEdit::unhide_all_lines() {
 
 int TextEdit::num_lines_from(int p_line_from, int visible_amount) const {
 
-	// returns the number of lines (hidden and unhidden) from p_line_from to (p_line_from + visible_amount of unhidden lines)
+	// Returns the number of lines (hidden and unhidden) from p_line_from to (p_line_from + visible_amount of unhidden lines).
 	ERR_FAIL_INDEX_V(p_line_from, text.size(), ABS(visible_amount));
 
 	if (!is_hiding_enabled())
@@ -5297,8 +5282,8 @@ int TextEdit::num_lines_from(int p_line_from, int visible_amount) const {
 
 int TextEdit::num_lines_from_rows(int p_line_from, int p_wrap_index_from, int visible_amount, int &wrap_index) const {
 
-	// returns the number of lines (hidden and unhidden) from (p_line_from + p_wrap_index_from) row to (p_line_from + visible_amount of unhidden and wrapped rows)
-	// wrap index is set to the wrap index of the last line
+	// Returns the number of lines (hidden and unhidden) from (p_line_from + p_wrap_index_from) row to (p_line_from + visible_amount of unhidden and wrapped rows).
+	// Wrap index is set to the wrap index of the last line.
 	wrap_index = 0;
 	ERR_FAIL_INDEX_V(p_line_from, text.size(), ABS(visible_amount));
 
@@ -5344,7 +5329,7 @@ int TextEdit::num_lines_from_rows(int p_line_from, int p_wrap_index_from, int vi
 
 int TextEdit::get_last_unhidden_line() const {
 
-	// returns the last line in the text that is not hidden
+	// Returns the last line in the text that is not hidden.
 	if (!is_hiding_enabled())
 		return text.size() - 1;
 
@@ -5361,7 +5346,7 @@ int TextEdit::get_indent_level(int p_line) const {
 
 	ERR_FAIL_INDEX_V(p_line, text.size(), 0);
 
-	// counts number of tabs and spaces before line starts
+	// Counts number of tabs and spaces before line starts.
 	int tab_count = 0;
 	int whitespace_count = 0;
 	int line_length = text[p_line].size();
@@ -5379,7 +5364,7 @@ int TextEdit::get_indent_level(int p_line) const {
 
 bool TextEdit::is_line_comment(int p_line) const {
 
-	// checks to see if this line is the start of a comment
+	// Checks to see if this line is the start of a comment.
 	ERR_FAIL_INDEX_V(p_line, text.size(), false);
 
 	const Map<int, Text::ColorRegionInfo> &cri_map = text.get_color_region_info(p_line);
@@ -5459,7 +5444,7 @@ void TextEdit::fold_line(int p_line) {
 	if (!can_fold(p_line))
 		return;
 
-	// hide lines below this one
+	// Hide lines below this one.
 	int start_indent = get_indent_level(p_line);
 	int last_line = start_indent;
 	for (int i = p_line + 1; i < text.size(); i++) {
@@ -5477,7 +5462,7 @@ void TextEdit::fold_line(int p_line) {
 		set_line_as_hidden(i, true);
 	}
 
-	// fix selection
+	// Fix selection.
 	if (is_selection_active()) {
 		if (is_line_hidden(selection.from_line) && is_line_hidden(selection.to_line)) {
 			deselect();
@@ -5488,7 +5473,7 @@ void TextEdit::fold_line(int p_line) {
 		}
 	}
 
-	// reset cursor
+	// Reset cursor.
 	if (is_line_hidden(cursor.line)) {
 		cursor_set_line(p_line, false, false);
 		cursor_set_column(get_line(p_line).length(), false);
@@ -5549,8 +5534,8 @@ void TextEdit::_do_text_op(const TextOperation &p_op, bool p_reverse) {
 		int check_line;
 		int check_column;
 		_base_insert_text(p_op.from_line, p_op.from_column, p_op.text, check_line, check_column);
-		ERR_FAIL_COND(check_line != p_op.to_line); // BUG
-		ERR_FAIL_COND(check_column != p_op.to_column); // BUG
+		ERR_FAIL_COND(check_line != p_op.to_line); // BUG.
+		ERR_FAIL_COND(check_column != p_op.to_column); // BUG.
 	} else {
 
 		_base_remove_text(p_op.from_line, p_op.from_column, p_op.to_line, p_op.to_column);
@@ -5560,7 +5545,7 @@ void TextEdit::_do_text_op(const TextOperation &p_op, bool p_reverse) {
 void TextEdit::_clear_redo() {
 
 	if (undo_stack_pos == NULL)
-		return; //nothing to clear
+		return; // Nothing to clear.
 
 	_push_current_op();
 
@@ -5578,12 +5563,12 @@ void TextEdit::undo() {
 	if (undo_stack_pos == NULL) {
 
 		if (!undo_stack.size())
-			return; //nothing to undo
+			return; // Nothing to undo.
 
 		undo_stack_pos = undo_stack.back();
 
 	} else if (undo_stack_pos == undo_stack.front())
-		return; // at the bottom of the undo stack
+		return; // At the bottom of the undo stack.
 	else
 		undo_stack_pos = undo_stack_pos->prev();
 
@@ -5624,7 +5609,7 @@ void TextEdit::redo() {
 	_push_current_op();
 
 	if (undo_stack_pos == NULL)
-		return; //nothing to do.
+		return; // Nothing to do.
 
 	deselect();
 
@@ -5678,7 +5663,7 @@ void TextEdit::end_complex_operation() {
 void TextEdit::_push_current_op() {
 
 	if (current_op.type == TextOperation::TYPE_NONE)
-		return; // do nothing
+		return; // Nothing to do.
 
 	if (next_operation_is_complex) {
 		current_op.chain_forward = true;
@@ -5778,7 +5763,7 @@ double TextEdit::get_scroll_pos_for_line(int p_line, int p_wrap_index) const {
 	if (!is_wrap_enabled() && !is_hiding_enabled())
 		return p_line;
 
-	// count the number of visible lines up to this line
+	// Count the number of visible lines up to this line.
 	double new_line_scroll_pos = 0;
 	int to = CLAMP(p_line, 0, text.size() - 1);
 	for (int i = 0; i < to; i++) {
@@ -5979,7 +5964,7 @@ void TextEdit::_update_completion_candidates() {
 
 	String s;
 
-	//look for keywords first
+	// Look for keywords first.
 
 	bool inquote = false;
 	int first_quote = -1;
@@ -6004,7 +5989,7 @@ void TextEdit::_update_completion_candidates() {
 	bool cancel = false;
 
 	if (!inquote && first_quote == cofs - 1) {
-		//no completion here
+		// No completion here.
 		cancel = true;
 	} else if (inquote && first_quote != -1) {
 
@@ -6042,11 +6027,12 @@ void TextEdit::_update_completion_candidates() {
 	bool prev_is_prefix = false;
 	if (cofs > 0 && completion_prefixes.has(String::chr(l[cofs - 1])))
 		prev_is_prefix = true;
-	if (cofs > 1 && l[cofs - 1] == ' ' && completion_prefixes.has(String::chr(l[cofs - 2]))) //check with one space before prefix, to allow indent
+	// Check with one space before prefix, to allow indent.
+	if (cofs > 1 && l[cofs - 1] == ' ' && completion_prefixes.has(String::chr(l[cofs - 2])))
 		prev_is_prefix = true;
 
 	if (cancel || (!pre_keyword && s == "" && (cofs == 0 || !prev_is_prefix))) {
-		//none to complete, cancel
+		// None to complete, cancel.
 		_cancel_completion();
 		return;
 	}
@@ -6096,18 +6082,18 @@ void TextEdit::_update_completion_candidates() {
 	}
 
 	if (completion_options.size() == 0) {
-		//no options to complete, cancel
+		// No options to complete, cancel.
 		_cancel_completion();
 		return;
 	}
 
 	if (completion_options.size() == 1 && s == completion_options[0].display) {
-		// A perfect match, stop completion
+		// A perfect match, stop completion.
 		_cancel_completion();
 		return;
 	}
 
-	// The top of the list is the best match
+	// The top of the list is the best match.
 	completion_current = completion_options[0];
 	completion_enabled = true;
 }
@@ -6128,7 +6114,7 @@ void TextEdit::query_code_comple() {
 
 	if (ofs > 0 && (inquote || _is_completable(l[ofs - 1]) || completion_prefixes.has(String::chr(l[ofs - 1]))))
 		emit_signal("request_completion");
-	else if (ofs > 1 && l[ofs - 1] == ' ' && completion_prefixes.has(String::chr(l[ofs - 2]))) //make it work with a space too, it's good enough
+	else if (ofs > 1 && l[ofs - 1] == ' ' && completion_prefixes.has(String::chr(l[ofs - 2]))) // Make it work with a space too, it's good enough.
 		emit_signal("request_completion");
 }
 
@@ -6453,8 +6439,6 @@ void TextEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_wrap_enabled", "enable"), &TextEdit::set_wrap_enabled);
 	ClassDB::bind_method(D_METHOD("is_wrap_enabled"), &TextEdit::is_wrap_enabled);
-	// ClassDB::bind_method(D_METHOD("set_max_chars", "amount"), &TextEdit::set_max_chars);
-	// ClassDB::bind_method(D_METHOD("get_max_char"), &TextEdit::get_max_chars);
 	ClassDB::bind_method(D_METHOD("set_context_menu_enabled", "enable"), &TextEdit::set_context_menu_enabled);
 	ClassDB::bind_method(D_METHOD("is_context_menu_enabled"), &TextEdit::is_context_menu_enabled);
 
@@ -6546,7 +6530,6 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "v_scroll_speed"), "set_v_scroll_speed", "get_v_scroll_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hiding_enabled"), "set_hiding_enabled", "is_hiding_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "wrap_enabled"), "set_wrap_enabled", "is_wrap_enabled");
-	// ADD_PROPERTY(PropertyInfo(Variant::BOOL, "max_chars"), "set_max_chars", "get_max_chars");
 
 	ADD_GROUP("Caret", "caret_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_block_mode"), "cursor_set_block_mode", "cursor_is_block_mode");
@@ -6571,7 +6554,7 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(MENU_MAX);
 
 	GLOBAL_DEF("gui/timers/text_edit_idle_detect_sec", 3);
-	ProjectSettings::get_singleton()->set_custom_property_info("gui/timers/text_edit_idle_detect_sec", PropertyInfo(Variant::REAL, "gui/timers/text_edit_idle_detect_sec", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater")); // No negative numbers
+	ProjectSettings::get_singleton()->set_custom_property_info("gui/timers/text_edit_idle_detect_sec", PropertyInfo(Variant::REAL, "gui/timers/text_edit_idle_detect_sec", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater")); // No negative numbers.
 }
 
 TextEdit::TextEdit() {
@@ -6690,7 +6673,7 @@ TextEdit::TextEdit() {
 	context_menu_enabled = true;
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	readonly = true; // initialise to opposite first, so we get past the early-out in set_readonly
+	readonly = true; // Initialise to opposite first, so we get past the early-out in set_readonly.
 	set_readonly(false);
 	menu->connect("id_pressed", this, "menu_option");
 	first_draw = true;
@@ -6751,14 +6734,14 @@ Map<int, TextEdit::HighlighterInfo> TextEdit::_get_line_syntax_highlighting(int 
 		bool is_symbol = _is_symbol(str[j]);
 		bool is_number = _is_number(str[j]);
 
-		// allow ABCDEF in hex notation
+		// Allow ABCDEF in hex notation.
 		if (is_hex_notation && (_is_hex_symbol(str[j]) || is_number)) {
 			is_number = true;
 		} else {
 			is_hex_notation = false;
 		}
 
-		// check for dot or underscore or 'x' for hex notation in floating point number or 'e' for scientific notation
+		// Check for dot or underscore or 'x' for hex notation in floating point number or 'e' for scientific notation.
 		if ((str[j] == '.' || str[j] == 'x' || str[j] == '_' || str[j] == 'f' || str[j] == 'e') && !in_word && prev_is_number && !is_number) {
 			is_number = true;
 			is_symbol = false;
@@ -6788,7 +6771,7 @@ Map<int, TextEdit::HighlighterInfo> TextEdit::_get_line_syntax_highlighting(int 
 				if (!cri.end) {
 					in_region = cri.region;
 				}
-			} else if (in_region == cri.region && !color_regions[cri.region].line_only) { //ignore otherwise
+			} else if (in_region == cri.region && !color_regions[cri.region].line_only) { // Ignore otherwise.
 				if (cri.end || color_regions[cri.region].eq) {
 					deregion = color_regions[cri.region].eq ? color_regions[cri.region].begin_key.length() : color_regions[cri.region].end_key.length();
 				}
@@ -6816,7 +6799,7 @@ Map<int, TextEdit::HighlighterInfo> TextEdit::_get_line_syntax_highlighting(int 
 				if (col) {
 					for (int k = j - 1; k >= 0; k--) {
 						if (str[k] == '.') {
-							col = NULL; //member indexing not allowed
+							col = NULL; // Member indexing not allowed.
 							break;
 						} else if (str[k] > 32) {
 							break;
@@ -6838,7 +6821,7 @@ Map<int, TextEdit::HighlighterInfo> TextEdit::_get_line_syntax_highlighting(int 
 				k++;
 			}
 
-			// check for space between name and bracket
+			// Check for space between name and bracket.
 			while (k < str.length() && (str[k] == '\t' || str[k] == ' ')) {
 				k++;
 			}


### PR DESCRIPTION
Now when in `readonly` mode, the syntax alpha colors will be set to 0.5, the same value used for the default read-only color.

Also took the time to reformat all comments in the file.