### PR TITLE
Improve the appearance of 2D path editors

### DIFF
--- a/editor/icons/icon_editor_curve_handle.svg
+++ b/editor/icons/icon_editor_curve_handle.svg
@@ -1,0 +1,1 @@
+<svg height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" fill="#fefefe" r="2.75" stroke="#000" stroke-linecap="square"/></svg>

--- a/editor/icons/icon_editor_path_sharp_handle.svg
+++ b/editor/icons/icon_editor_path_sharp_handle.svg
@@ -1,0 +1,1 @@
+<svg height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><path d="m-3.035534-10.106602h6.071068v6.071068h-6.071068z" fill="#fefefe" stroke="#000" stroke-linecap="square" transform="matrix(-.70710678 .70710678 -.70710678 -.70710678 0 0)"/></svg>

--- a/editor/icons/icon_editor_path_smooth_handle.svg
+++ b/editor/icons/icon_editor_path_smooth_handle.svg
@@ -1,0 +1,1 @@
+<svg height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><path d="m1.5-8.5h7v7h-7z" fill="#fefefe" stroke="#000" stroke-linecap="square" transform="rotate(90)"/></svg>

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -571,7 +571,8 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 		return;
 
 	Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_global_transform();
-	const Ref<Texture> handle = get_icon("EditorHandle", "EditorIcons");
+	// All polygon points are sharp, so use the sharp handle icon
+	const Ref<Texture> handle = get_icon("EditorPathSharpHandle", "EditorIcons");
 
 	const Vertex active_point = get_active_point();
 	const int n_polygons = _get_polygon_count();

--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -652,7 +652,6 @@ PathSpatialGizmoPlugin::PathSpatialGizmoPlugin() {
 
 	Color path_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/path", Color(0.5, 0.5, 1.0, 0.8));
 	create_material("path_material", path_color);
-	path_color.a = 0.4;
-	create_material("path_thin_material", path_color);
+	create_material("path_thin_material", Color(0.5, 0.5, 0.5));
 	create_handle_material("handles");
 }

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1045,8 +1045,8 @@ void Polygon2DEditor::_uv_draw() {
 		}
 	}
 
-	Ref<Texture> handle = get_icon("EditorHandle", "EditorIcons");
-	Ref<Texture> internal_handle = get_icon("EditorInternalHandle", "EditorIcons");
+	// All UV points are sharp, so use the sharp handle icon
+	Ref<Texture> handle = get_icon("EditorPathSharpHandle", "EditorIcons");
 
 	Color poly_line_color = Color(0.9, 0.5, 0.5);
 	if (polygons.size() || polygon_create.size()) {
@@ -1120,7 +1120,8 @@ void Polygon2DEditor::_uv_draw() {
 			if (i < uv_draw_max) {
 				uv_edit_draw->draw_texture(handle, mtx.xform(uvs[i]) - handle->get_size() * 0.5);
 			} else {
-				uv_edit_draw->draw_texture(internal_handle, mtx.xform(uvs[i]) - internal_handle->get_size() * 0.5);
+				// Internal vertex
+				uv_edit_draw->draw_texture(handle, mtx.xform(uvs[i]) - handle->get_size() * 0.5, Color(0.6, 0.8, 1));
 			}
 		}
 	}

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -110,7 +110,7 @@ void Path2D::_notification(int p_what) {
 
 				real_t frac = j / 8.0;
 				Vector2 p = curve->interpolate(i, frac);
-				draw_line(prev_p, p, color, line_width);
+				draw_line(prev_p, p, color, line_width, true);
 				prev_p = p;
 			}
 		}


### PR DESCRIPTION
- Add new handle icons for path/polygon editors
- Add smooth path point icons and curve tangent icons
- Use a gray color for tangent lines in the Path2D and Path editors
- Use antialiasing for Path2D lines

These changes should make it easier to distinguish tangent points from actual curve points. Points in all polygon editors will also be easier to distinguish from Node2D handles.

This partially addresses #31459 (as 3D path editor icons haven't been touched). Adding custom 3D handle icons requires heavier changes, so I guess it will be for a later PR.

The icon shapes were inspired by Inkscape :slightly_smiling_face:

## Preview

### Path2D editor

![path2d_editor](https://user-images.githubusercontent.com/180032/63230018-8d23bd00-c207-11e9-8d66-d593c8bf40e0.png)

### Polygon2D editor

![polygon2d_editor](https://user-images.githubusercontent.com/180032/63230019-8dbc5380-c207-11e9-9282-e760a09f6c75.png)

### CollisionPolygon2D editor

![collisionpolygon2d_editor](https://user-images.githubusercontent.com/180032/63230021-90b74400-c207-11e9-87eb-678b33d44d78.png)