### PR TITLE
fix animation freeze when playing animation from another AnimationPlayer

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1200,7 +1200,9 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 		}
 	}
 
-	_stop_playing_caches();
+	if (get_current_animation() != p_name) {
+		_stop_playing_caches();
+	}
 
 	c.current.from = &animation_set[name];
 


### PR DESCRIPTION
Donated by IMVU, Inc.

Fixes #31410
When we create an animation player with an animation from which we will start another AnimationPlayer's animation at the moment when that animation is already active - it will  be stopped.  When starting an animation with `play()` all the 'outside' animations for animation player were always removed (`_stop_playing_caches` func). This pr prevents this behavior for the case when play is called for animation that's still active. This way the behavior is the same between "Animation Playback track" and other tracks (tested with value track)