### PR TITLE
Mention caveat with looped animations in `AnimationPlayer.queue()`

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -165,6 +165,7 @@
 			</argument>
 			<description>
 				Queues an animation for playback once the current one is done.
+				[b]Note:[/b] If a looped animation is currently playing, the queued animation will never play unless the looped animation is stopped somehow.
 			</description>
 		</method>
 		<method name="remove_animation">


### PR DESCRIPTION
As mentioned in [a Reddit thread](https://www.reddit.com/r/godot/comments/cs9455/animationplayer_queueing/), AnimationPlayer's `queue()` method will not prevent a looped animation from running on forever, which may prevent the queued animation from ever playing.

PS: Is it possible to set an animation as non-looping while it's currently looping? I guess it may be one way to play a queued animation after a looped animation. If not, we could print a warning when an animation is queued after a looped animation.