### PR TITLE
Always use the GLES2 backend when generating the GDNative API JSON

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -599,6 +599,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			auto_build_solutions = true;
 			editor = true;
+#ifdef DEBUG_METHODS_ENABLED
+		} else if (I->get() == "--gdnative-generate-json-api") {
+			// Register as an editor instance to use the GLES2 fallback automatically on hardware that doesn't support the GLES3 backend
+			editor = true;
+
+			// We still pass it to the main arguments since the argument handling itself is not done in this function
+			main_args.push_back(I->get());
+#endif
 		} else if (I->get() == "--export" || I->get() == "--export-debug") { // Export project
 
 			editor = true;


### PR DESCRIPTION
The generated file is identical, no matter the backend in use.

I had to do this in `main/main.cpp` as the video driver can't be overridden in `modules/gdnative/nativescript/nativescript.cpp` (to my knowledge).

This closes #27768.