### PR TITLE
WebSocketServer now sanitize destination peers.

### DIFF
--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -265,7 +265,10 @@ Error WebSocketMultiplayerPeer::_server_relay(int32_t p_from, int32_t p_to, cons
 
 		ERR_FAIL_COND_V(p_to == p_from, FAILED);
 
-		return get_peer(p_to)->put_packet(p_buffer, p_buffer_size); // Sending to specific peer
+		Ref<WebSocketPeer> peer_to = get_peer(p_to);
+		ERR_FAIL_COND_V(peer_to.is_null(), FAILED);
+
+		return peer_to->put_packet(p_buffer, p_buffer_size); // Sending to specific peer
 	}
 }
 


### PR DESCRIPTION
When relaying messages in multiplayer mode.
Could cause a crash in case a malicious client sends a bogus packet and for those cases where a peer has just disconnected and a message arrive from another peer with the disconnected one as destination.

Fixes #31106