### PR TITLE
Fix WebSocketServer relaying message twice.

### DIFF
--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -296,8 +296,6 @@ void WebSocketMultiplayerPeer::_process_multiplayer(Ref<WebSocketPeer> p_peer, u
 		ERR_FAIL_COND(type != SYS_NONE); // Only server sends sys messages
 		ERR_FAIL_COND(from != p_peer_id); // Someone is cheating
 
-		_server_relay(from, to, in_buffer, size); // Relay if needed
-
 		if (to == 1) { // This is for the server
 
 			_store_pkt(from, to, in_buffer, data_size);
@@ -312,13 +310,9 @@ void WebSocketMultiplayerPeer::_process_multiplayer(Ref<WebSocketPeer> p_peer, u
 			// All but one, for us if not excluded
 			if (_peer_id != -(int32_t)p_peer_id)
 				_store_pkt(from, to, in_buffer, data_size);
-
-		} else {
-
-			// Send to specific peer
-			ERR_FAIL_COND(!_peer_map.has(to));
-			get_peer(to)->put_packet(in_buffer, size);
 		}
+		// Relay if needed (i.e. "to" includes a peer that is not the server)
+		_server_relay(from, to, in_buffer, size);
 
 	} else {
 


### PR DESCRIPTION
The WebSocketMultiplayerPeer was relaying the same message two times,
both in _server_relay and _process_multiplayer (which was only supposed
to store the packet, given the server was one of the destination).

_process_multiplayer now only store the packet, and calls _server_relay
which will relay the message to other clients if needed.

This could probably be cherry-picked in `3.1` if we plan to have another `3.1` release.