### PR TITLE
Showing only working options in filesystem dock menu

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1484,8 +1484,15 @@ Vector<String> FileSystemDock::_tree_get_selected(bool remove_self_inclusion) {
 		selected = tree->get_next_selected(selected);
 	}
 
+	if (remove_self_inclusion) {
+		selected_strings = _remove_self_included_paths(selected_strings);
+	}
+	return selected_strings;
+}
+
+Vector<String> FileSystemDock::_remove_self_included_paths(Vector<String> selected_strings) {
 	// Remove paths or files that are included into another
-	if (remove_self_inclusion && selected_strings.size() > 1) {
+	if (selected_strings.size() > 1) {
 		selected_strings.sort_custom<NaturalNoCaseComparator>();
 		String last_path = "";
 		for (int i = 0; i < selected_strings.size(); i++) {
@@ -1503,7 +1510,7 @@ Vector<String> FileSystemDock::_tree_get_selected(bool remove_self_inclusion) {
 
 void FileSystemDock::_tree_rmb_option(int p_option) {
 
-	Vector<String> selected_strings = _tree_get_selected();
+	Vector<String> selected_strings = _tree_get_selected(false);
 
 	// Execute the current option
 	switch (p_option) {
@@ -1642,8 +1649,9 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		case FILE_MOVE: {
 			// Move the files to a given location
 			to_move.clear();
-			for (int i = 0; i < p_selected.size(); i++) {
-				String fpath = p_selected[i];
+			Vector<String> collapsed_paths = _remove_self_included_paths(p_selected);
+			for (int i = collapsed_paths.size() - 1; i >= 0; i--) {
+				String fpath = collapsed_paths[i];
 				if (fpath != "res://") {
 					to_move.push_back(FileOrFolder(fpath, !fpath.ends_with("/")));
 				}
@@ -1680,9 +1688,10 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			// Remove the selected files
 			Vector<String> remove_files;
 			Vector<String> remove_folders;
+			Vector<String> collapsed_paths = _remove_self_included_paths(p_selected);
 
-			for (int i = 0; i < p_selected.size(); i++) {
-				String fpath = p_selected[i];
+			for (int i = 0; i < collapsed_paths.size(); i++) {
+				String fpath = collapsed_paths[i];
 				if (fpath != "res://") {
 					if (fpath.ends_with("/")) {
 						remove_folders.push_back(fpath);
@@ -2195,12 +2204,16 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 
 	if (p_paths.size() == 1) {
 		p_popup->add_item(TTR("Copy Path"), FILE_COPY_PATH);
-		p_popup->add_item(TTR("Rename..."), FILE_RENAME);
-		p_popup->add_item(TTR("Duplicate..."), FILE_DUPLICATE);
+		if (p_paths[0] != "res://") {
+			p_popup->add_item(TTR("Rename..."), FILE_RENAME);
+			p_popup->add_item(TTR("Duplicate..."), FILE_DUPLICATE);
+		}
 	}
 
-	p_popup->add_item(TTR("Move To..."), FILE_MOVE);
-	p_popup->add_item(TTR("Delete"), FILE_REMOVE);
+	if (p_paths.size() > 1 || p_paths[0] != "res://") {
+		p_popup->add_item(TTR("Move To..."), FILE_MOVE);
+		p_popup->add_item(TTR("Delete"), FILE_REMOVE);
+	}
 
 	if (p_paths.size() == 1) {
 		p_popup->add_separator();
@@ -2219,7 +2232,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 
 void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
 	// Right click is pressed in the tree
-	Vector<String> paths = _tree_get_selected();
+	Vector<String> paths = _tree_get_selected(false);
 
 	if (paths.size() == 1) {
 		if (paths[0].ends_with("/")) {

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -279,6 +279,7 @@ private:
 	bool _is_file_type_disabled_by_feature_profile(const StringName &p_class);
 
 	void _feature_profile_changed();
+	Vector<String> _remove_self_included_paths(Vector<String> selected_strings);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
This is follow-up to https://github.com/godotengine/godot/pull/31256 - I decided to close that one since scope of improvements got bigger.

####  **What is this PR about?**

My code fixes two issues with filesystem dock - one  of fixes relates to removing unnecessary options from context menu while only "res://" folder is selected. Other fix resolves issues that occur when multiple nested folders are selected -> normally when selecting multiple folder list of options is limited, however in case of selecting multiple nested folders/files that was not the case because before passing them to function that creates menu all nested paths were removed and if their common root was selected it was treated as if it was only selected thing. This was done for moving and deleting to work correctly (I think). Now collapsing is done when those operations are confirmed and not while building menu.

### **Fixes**

**1. Removal of unsupported options when selecting only "res://" folder**

Before [in current 3.1 release]:

![image](https://user-images.githubusercontent.com/9964886/63292118-3f6d8a00-c2c5-11e9-817e-3d0395649d4f.png)

Rename, Duplicate, Move To and Delete options are not allowed for root folder. See https://github.com/godotengine/godot/pull/31256 for detailed description of how they fail to work! With my fix those options are not visible.

After:

![image](https://user-images.githubusercontent.com/9964886/63292286-95dac880-c2c5-11e9-9189-7040875d875a.png)

**2. Wrong set of options suggested while selecting nested folders/files**

Godot's filesystem dock shows different set of options while selecting one item and different if multiple items are selected -> most of hidden options are not designed to work with multiple items. However this behaviour breaks when all of selected items are nested into some root folder that is also selected.

Before:

Correct behavior: options are hidden when selecting not nested files:
![image](https://user-images.githubusercontent.com/9964886/63292616-5bbdf680-c2c6-11e9-8526-85313e94f93d.png)

Bug: options are not hidden when selecting nested files:
![image](https://user-images.githubusercontent.com/9964886/63292801-d0913080-c2c6-11e9-9d55-fd7dc46dd524.png)

After:

![image](https://user-images.githubusercontent.com/9964886/63293060-688f1a00-c2c7-11e9-8fef-8bffc27436b3.png)

### **Regression tests**

I've clicked a lot in filesystem dock and some things are still broken but they were before, I did not notice any new regression with multifolder/multifiles actions. Here are two most obvious things that my code could break:

**1. Deleting nested files still works**

![removing_still_works](https://user-images.githubusercontent.com/9964886/63294571-f1f41b80-c2ca-11e9-9d6c-477e88585a59.gif)

Note: When res:// will be selected with other files no deletion will be made. This is how it worked before -> the reason is that all paths are collapsed to res:// and it is not allowed to be deleted

**2. Moving nested files still works**
![moving_still_works](https://user-images.githubusercontent.com/9964886/63294781-7ba3e900-c2cb-11e9-9c40-2f3b3437fd30.gif)

Note: When res:// will be selected with other files move to option will be doing nothing. This is how it worked before -> the reason is that all paths are collapsed to res:// and it is not allowed to be moved.

Thanks for reading!
