### PR TITLE
Use a different color for folder icons in file dialogs

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -257,6 +257,7 @@ void EditorFileDialog::_post_popup() {
 
 	if (is_visible_in_tree()) {
 		Ref<Texture> folder = get_icon("folder", "FileDialog");
+		const Color folder_color = get_color("folder", "FileDialog");
 		recent->clear();
 
 		bool res = access == ACCESS_RESOURCES;
@@ -274,6 +275,7 @@ void EditorFileDialog::_post_popup() {
 
 			recent->add_item(name, folder);
 			recent->set_item_metadata(recent->get_item_count() - 1, recentd[i]);
+			recent->set_item_icon_modulate(recent->get_item_count() - 1, folder_color);
 		}
 
 		local_history.clear();
@@ -734,6 +736,7 @@ void EditorFileDialog::update_file_list() {
 	dir_access->list_dir_begin();
 
 	Ref<Texture> folder = get_icon("folder", "FileDialog");
+	const Color folder_color = get_color("folder", "FileDialog");
 	List<String> files;
 	List<String> dirs;
 
@@ -774,6 +777,7 @@ void EditorFileDialog::update_file_list() {
 		d["dir"] = true;
 
 		item_list->set_item_metadata(item_list->get_item_count() - 1, d);
+		item_list->set_item_icon_modulate(item_list->get_item_count() - 1, folder_color);
 
 		dirs.pop_front();
 	}
@@ -1200,6 +1204,7 @@ void EditorFileDialog::_update_favorites() {
 
 	String current = get_current_dir();
 	Ref<Texture> folder_icon = get_icon("Folder", "EditorIcons");
+	const Color folder_color = get_color("folder", "FileDialog");
 	favorites->clear();
 
 	favorite->set_pressed(false);
@@ -1230,6 +1235,7 @@ void EditorFileDialog::_update_favorites() {
 		}
 
 		favorites->set_item_metadata(favorites->get_item_count() - 1, favorited[i]);
+		favorites->set_item_icon_modulate(favorites->get_item_count() - 1, folder_color);
 
 		if (setthis) {
 			favorite->set_pressed(true);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1066,6 +1066,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// FileDialog
 	theme->set_icon("folder", "FileDialog", theme->get_icon("Folder", "EditorIcons"));
+	// Use a different color for folder icons to make them easier to distinguish from files.
+	// On a light theme, the icon will be dark, so we need to lighten it before blending it with the accent color.
+	theme->set_color("folder", "FileDialog", (dark_theme ? Color(1, 1, 1) : Color(5, 5, 5)).linear_interpolate(accent_color, 0.7));
 	theme->set_color("files_disabled", "FileDialog", font_color_disabled);
 
 	// color picker

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -64,6 +64,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 
 	subdirectory_item->set_text(0, dname);
 	subdirectory_item->set_icon(0, get_icon("Folder", "EditorIcons"));
+	subdirectory_item->set_icon_color(0, get_color("folder", "FileDialog"));
 	subdirectory_item->set_selectable(0, true);
 	String lpath = p_dir->get_path();
 	subdirectory_item->set_metadata(0, lpath);
@@ -186,15 +187,19 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 			continue;
 
 		Ref<Texture> folder_icon = get_icon("Folder", "EditorIcons");
+		const Color folder_color = get_color("folder", "FileDialog");
 
 		String text;
 		Ref<Texture> icon;
+		Color color;
 		if (fave == "res://") {
 			text = "/";
 			icon = folder_icon;
+			color = folder_color;
 		} else if (fave.ends_with("/")) {
 			text = fave.substr(0, fave.length() - 1).get_file();
 			icon = folder_icon;
+			color = folder_color;
 		} else {
 			text = fave.get_file();
 			int index;
@@ -204,12 +209,14 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 			} else {
 				icon = get_icon("File", "EditorIcons");
 			}
+			color = Color(1, 1, 1);
 		}
 
 		if (searched_string.length() == 0 || text.to_lower().find(searched_string) >= 0) {
 			TreeItem *ti = tree->create_item(favorites);
 			ti->set_text(0, text);
 			ti->set_icon(0, icon);
+			ti->set_icon_color(0, color);
 			ti->set_tooltip(0, fave);
 			ti->set_selectable(0, true);
 			ti->set_metadata(0, fave);
@@ -639,6 +646,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	}
 
 	Ref<Texture> folder_icon = (use_thumbnails) ? folder_thumbnail : get_icon("folder", "FileDialog");
+	const Color folder_color = get_color("folder", "FileDialog");
 
 	// Build the FileInfo list
 	List<FileInfo> filelist;
@@ -716,6 +724,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 
 					files->set_item_metadata(files->get_item_count() - 1, bd);
 					files->set_item_selectable(files->get_item_count() - 1, false);
+					files->set_item_icon_modulate(files->get_item_count() - 1, folder_color);
 				}
 
 				for (int i = 0; i < efd->get_subdir_count(); i++) {
@@ -724,6 +733,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 
 					files->add_item(dname, folder_icon, true);
 					files->set_item_metadata(files->get_item_count() - 1, directory.plus_file(dname) + "/");
+					files->set_item_icon_modulate(files->get_item_count() - 1, folder_color);
 
 					if (cselection.has(dname)) {
 						files->select(files->get_item_count() - 1, false);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -400,6 +400,7 @@ void FileDialog::update_file_list() {
 
 	TreeItem *root = tree->create_item();
 	Ref<Texture> folder = get_icon("folder");
+	const Color folder_color = get_color("folder");
 	List<String> files;
 	List<String> dirs;
 
@@ -429,6 +430,7 @@ void FileDialog::update_file_list() {
 		TreeItem *ti = tree->create_item(root);
 		ti->set_text(0, dir_name);
 		ti->set_icon(0, folder);
+		ti->set_icon_color(0, folder_color);
 
 		Dictionary d;
 		d["name"] = dir_name;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -760,6 +760,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// FileDialog
 
 	theme->set_icon("folder", "FileDialog", make_icon(icon_folder_png));
+	theme->set_color("folder", "FileDialog", Color(1, 1, 1));
 	theme->set_color("files_disabled", "FileDialog", Color(0, 0, 0, 0.7));
 
 	// colorPicker


### PR DESCRIPTION
This makes them easier to distinguish from files for quick visual grepping.

This can also be used in projects by setting the FileDialog "folder" color. The default value (`Color(1, 1, 1)`) has no visual impact, for compatibility with existing projects.

## Preview

### Dark theme

![file_dialog_dark_1](https://user-images.githubusercontent.com/180032/63303112-27a2ff80-c2df-11e9-9224-3b9134e0b29e.png)

![file_dialog_dark_2](https://user-images.githubusercontent.com/180032/63303118-2a9df000-c2df-11e9-9e14-16549cf643cc.png)

### Light theme

![file_dialog_light_1](https://user-images.githubusercontent.com/180032/63303119-2a9df000-c2df-11e9-8c34-62f4b18c38e7.png)

![file_dialog_light_2](https://user-images.githubusercontent.com/180032/63303120-2b368680-c2df-11e9-9f4e-a9743cf4eecc.png)