### PR TITLE
Include setters and getters in help search

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -354,7 +354,7 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 						match.constants.push_back(const_cast<DocData::ConstantDoc *>(&class_doc.constants[i]));
 			if (search_flags & SEARCH_PROPERTIES)
 				for (int i = 0; i < class_doc.properties.size(); i++)
-					if (_match_string(term, class_doc.properties[i].name))
+					if (_match_string(term, class_doc.properties[i].name) || _match_string(term, class_doc.properties[i].getter) || _match_string(term, class_doc.properties[i].setter))
 						match.properties.push_back(const_cast<DocData::PropertyDoc *>(&class_doc.properties[i]));
 			if (search_flags & SEARCH_THEME_ITEMS)
 				for (int i = 0; i < class_doc.theme_properties.size(); i++)


### PR DESCRIPTION
This change makes setters and getters match in property search in Editor Help (although doesn't select the matching property).

Closes #17796