### PR TITLE
Setting project metadata doesn't fail when project_metadata.cfg doesn't exist

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -201,7 +201,7 @@ Error ConfigFile::load(const String &p_path) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);
 
 	if (!f)
-		return ERR_CANT_OPEN;
+		return err;
 
 	return _internal_load(p_path, f);
 }

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -38,6 +38,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <errno.h>
+
 #if defined(UNIX_ENABLED)
 #include <unistd.h>
 #endif
@@ -112,8 +114,15 @@ Error FileAccessUnix::_open(const String &p_path, int p_mode_flags) {
 	f = fopen(path.utf8().get_data(), mode_string);
 
 	if (f == NULL) {
-		last_error = ERR_FILE_CANT_OPEN;
-		return ERR_FILE_CANT_OPEN;
+		switch (errno) {
+			case ENOENT: {
+				last_error = ERR_FILE_NOT_FOUND;
+			} break;
+			default: {
+				last_error = ERR_FILE_CANT_OPEN;
+			} break;
+		}
+		return last_error;
 	} else {
 		last_error = OK;
 		flags = p_mode_flags;

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -114,11 +114,18 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 		path = path + ".tmp";
 	}
 
-	_wfopen_s(&f, path.c_str(), mode_string);
+	errno_t errcode = _wfopen_s(&f, path.c_str(), mode_string);
 
 	if (f == NULL) {
-		last_error = ERR_FILE_CANT_OPEN;
-		return ERR_FILE_CANT_OPEN;
+		switch (errcode) {
+			case ENOENT: {
+				last_error = ERR_FILE_NOT_FOUND;
+			} break;
+			default: {
+				last_error = ERR_FILE_CANT_OPEN;
+			} break;
+		}
+		return last_error;
 	} else {
 		last_error = OK;
 		flags = p_mode_flags;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2954,7 +2954,6 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 
 	EditorPlugin *ep = memnew(EditorPlugin);
 	ep->set_script(script.get_ref_ptr());
-	ep->set_dir_cache(p_addon);
 	plugin_addons[p_addon] = ep;
 	add_editor_plugin(ep, p_config_changed);
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -324,13 +324,6 @@ void EditorPlugin::remove_autoload_singleton(const String &p_name) {
 	EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_remove(p_name);
 }
 
-Ref<ConfigFile> EditorPlugin::get_config() {
-	Ref<ConfigFile> cf = memnew(ConfigFile);
-	Error err = cf->load(_dir_cache.plus_file("plugin.cfg"));
-	ERR_FAIL_COND_V(err != OK, cf);
-	return cf;
-}
-
 ToolButton *EditorPlugin::add_control_to_bottom_panel(Control *p_control, const String &p_title) {
 	ERR_FAIL_NULL_V(p_control, NULL);
 	return EditorNode::get_singleton()->add_bottom_panel_item(p_title, p_control);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -117,7 +117,6 @@ class EditorPlugin : public Node {
 	bool force_draw_over_forwarding_enabled;
 
 	String last_main_screen_name;
-	String _dir_cache;
 
 protected:
 	static void _bind_methods();
@@ -235,10 +234,6 @@ public:
 
 	void add_autoload_singleton(const String &p_name, const String &p_path);
 	void remove_autoload_singleton(const String &p_name);
-
-	void set_dir_cache(const String &p_dir) { _dir_cache = p_dir; }
-	String get_dir_cache() { return _dir_cache; }
-	Ref<ConfigFile> get_config();
 
 	void enable_plugin();
 	void disable_plugin();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1216,7 +1216,7 @@ void EditorSettings::set_project_metadata(const String &p_section, const String 
 	String path = get_project_settings_dir().plus_file("project_metadata.cfg");
 	Error err;
 	err = cf->load(path);
-	ERR_FAIL_COND(err != OK);
+	ERR_FAIL_COND(err != OK && err != ERR_FILE_NOT_FOUND);
 	cf->set_value(p_section, p_key, p_data);
 	err = cf->save(path);
 	ERR_FAIL_COND(err != OK);


### PR DESCRIPTION
Implemented specific errors for file not found in windows/unix, used for loading project metadata file when setting a value. If the file doesn't exist it will create one instead of failing.

Fixes #31444