### PR TITLE
Enable ProGuard for Android release builds to decrease APK size

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -183,6 +183,9 @@ android {
             } else {
                 signingConfig null
             }
+
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 

--- a/platform/android/java/app/proguard-rules.pro
+++ b/platform/android/java/app/proguard-rules.pro
@@ -1,0 +1,33 @@
+-keep class com.godot.** { *; }
+-keep class org.godotengine.** { *; }
+-keep class ** extends org.godotengine.godot.plugin.GodotPlugin { *; }
+
+-keep public class * extends android.app.Activity
+-keep public class * extends android.app.Application
+-keep public class * extends android.app.Service
+-keep public class * extends android.content.BroadcastReceiver
+-keep public class * extends android.content.ContentProvider
+-keep public class * extends android.app.backup.BackupAgentHelper
+-keep public class * extends android.preference.Preference
+-keep public class com.android.vending.licensing.ILicensingService
+
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+-keepclasseswithmembernames class * {
+    public <init>(android.content.Context, android.util.AttributeSet);
+}
+
+-keepclasseswithmembernames class * {
+    public <init>(android.content.Context, android.util.AttributeSet, int);
+}
+
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+-keep class * implements android.os.Parcelable {
+  public static final android.os.Parcelable$Creator *;
+}


### PR DESCRIPTION
This reduces the size of release APKs by about 300 KB on average.

I'm marking this as a draft since this will likely conflict with third-party modules in its current state. How could this be integrated so modules can supply their own ProGuard exclusions? (cc @megasoft78)

Also, this should be tested when Mono support is enabled to check for bugs that could appear when using ProGuard alongside. (cc @neikeq)

Other than that, I can confirm it works when exporting the Platformer 2D demo.

If this is merged, we should also update the documentation to mention that release export templates use ProGuard. Since stack traces will be obfuscated, this will require developers to deobfuscate them using the appropriate mapping tools. See *ProGuard and obfuscated stack traces* in [this article](https://medium.com/androiddevelopers/troubleshooting-proguard-issues-on-android-bce9de4f8a74).

Related to #18253.

<details>
<summary>Old `proguard-rules.pro` file from initial PR version (July 2019)</summary>

```
-dontwarn org.godotengine.godot.**

-keep class org.godotengine.godot.** {*;}
-keep class * extends java.util.ListResourceBundle {
   protected java.lang.Object[][] getContents();
}

-keepnames class * implements android.os.Parcelable {
   public static final ** CREATOR;
}
-keepattributes *Annotation*

-optimizations !code/allocation/variable
```
</summary>