### PR TITLE
Shut down Godot processes on app exit.

### DIFF
--- a/misc/ide/jetbrains/build.gradle
+++ b/misc/ide/jetbrains/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
 }
 

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -625,6 +625,10 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		GodotLib.ondestroy(this);
 
 		super.onDestroy();
+
+		// TODO: This is a temp solution. The proper fix will involve tracking down and properly shutting down each
+		// native Godot components that is started in Godot#onVideoInit.
+		forceQuit();
 	}
 
 	@Override


### PR DESCRIPTION
This PR addresses [GodotVR/godot_oculus_mobile#37](https://github.com/GodotVR/godot_oculus_mobile/issues/37), which most likely also affects the proper shutdown of Godot apps and games on regular Android devices.

As mentioned in the change, this is a temporary fix. 
The full fix involves tracking down all the native Godot components that are initialized and setup when the app is started so they can be properly cleaned and shut down. 
That full fix will likely be broken and submitted in several portions to minimize any bugs it could introduce.