### PR TITLE
FileAccessWindows: Add errno include for MinGW

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -38,6 +38,7 @@
 #include <shlwapi.h>
 #include <windows.h>
 
+#include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <tchar.h>


### PR DESCRIPTION
Apparently MSVC is happy with ENOENT without it, but MinGW seems to
require it.
Follow-up to #31499.