### PR TITLE
Draw 3D collision shape/raycast gizmos in grayscale when disabled

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -2037,8 +2037,11 @@ PortalSpatialGizmo::PortalSpatialGizmo(Portal *p_portal) {
 
 RayCastSpatialGizmoPlugin::RayCastSpatialGizmoPlugin() {
 
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	const Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
+	const float gizmo_value = gizmo_color.get_v();
+	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
+	create_material("shape_material_disabled", gizmo_color_disabled);
 }
 
 bool RayCastSpatialGizmoPlugin::has_gizmo(Spatial *p_spatial) {
@@ -2064,7 +2067,8 @@ void RayCastSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 	lines.push_back(Vector3());
 	lines.push_back(raycast->get_cast_to());
 
-	Ref<SpatialMaterial> material = get_material("shape_material", p_gizmo);
+	const Ref<SpatialMaterial> material =
+			get_material(raycast->is_enabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
 
 	p_gizmo->add_lines(lines, material);
 	p_gizmo->add_collision_segments(lines);
@@ -3108,8 +3112,11 @@ void BakedIndirectLightGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 ////
 
 CollisionShapeSpatialGizmoPlugin::CollisionShapeSpatialGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	const Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
+	const float gizmo_value = gizmo_color.get_v();
+	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
+	create_material("shape_material_disabled", gizmo_color_disabled);
 	create_handle_material("handles");
 }
 
@@ -3432,7 +3439,8 @@ void CollisionShapeSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 	if (s.is_null())
 		return;
 
-	Ref<Material> material = get_material("shape_material", p_gizmo);
+	const Ref<Material> material =
+			get_material(!cs->is_disabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
 	Ref<Material> handles_material = get_material("handles");
 
 	if (Object::cast_to<SphereShape>(*s)) {
@@ -3733,8 +3741,11 @@ void CollisionShapeSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 /////
 
 CollisionPolygonSpatialGizmoPlugin::CollisionPolygonSpatialGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	const Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
+	const float gizmo_value = gizmo_color.get_v();
+	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
+	create_material("shape_material_disabled", gizmo_color_disabled);
 }
 
 bool CollisionPolygonSpatialGizmoPlugin::has_gizmo(Spatial *p_spatial) {
@@ -3770,7 +3781,8 @@ void CollisionPolygonSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 		lines.push_back(Vector3(points[i].x, points[i].y, -depth));
 	}
 
-	Ref<Material> material = get_material("shape_material", p_gizmo);
+	const Ref<Material> material =
+			get_material(!polygon->is_disabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
 
 	p_gizmo->add_lines(lines, material);
 	p_gizmo->add_collision_segments(lines);

--- a/scene/3d/collision_polygon.cpp
+++ b/scene/3d/collision_polygon.cpp
@@ -151,6 +151,8 @@ float CollisionPolygon::get_depth() const {
 
 void CollisionPolygon::set_disabled(bool p_disabled) {
 	disabled = p_disabled;
+	update_gizmo();
+
 	if (parent) {
 		parent->shape_owner_set_disabled(owner_id, p_disabled);
 	}

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -102,6 +102,8 @@ Vector3 RayCast::get_collision_normal() const {
 void RayCast::set_enabled(bool p_enabled) {
 
 	enabled = p_enabled;
+	update_gizmo();
+
 	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint())
 		set_physics_process_internal(p_enabled);
 	if (!p_enabled)


### PR DESCRIPTION
This makes them easier to distinguish from their enabled counterparts, as is already done in the 2D editor.

## Preview

### Enabled and disabled RayCasts and CollisionShapes (unselected)

![gizmos_disabled_and_enabled](https://user-images.githubusercontent.com/180032/63436171-84f69800-c428-11e9-929f-05274425e413.png)

### Enabled CollisionShape selected

![gizmos_selected_enabled](https://user-images.githubusercontent.com/180032/63436187-8922b580-c428-11e9-9c1c-79984ff514de.png)

### Disabled CollisionShape selected

![gizmos_selected_disabled](https://user-images.githubusercontent.com/180032/63436179-8758f200-c428-11e9-8231-d4911a13fc40.png)