### PR TITLE
Edit TileMap only with TOOL_SELECT

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3321,6 +3321,10 @@ void CanvasItemEditor::update_viewport() {
 	viewport->update();
 }
 
+void CanvasItemEditor::set_current_tool(Tool p_tool) {
+	_button_tool_select(p_tool);
+}
+
 void CanvasItemEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_PHYSICS_PROCESS) {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -581,6 +581,7 @@ public:
 	void update_viewport();
 
 	Tool get_current_tool() { return tool; }
+	void set_current_tool(Tool p_tool);
 
 	void set_undo_redo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; }
 	void edit(CanvasItem *p_canvas_item);

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -972,7 +972,7 @@ static inline Vector<Point2i> line(int x0, int x1, int y0, int y1) {
 
 bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
-	if (!node || !node->get_tileset().is_valid() || !node->is_visible_in_tree())
+	if (!node || !node->get_tileset().is_valid() || !node->is_visible_in_tree() || CanvasItemEditor::get_singleton()->get_current_tool() != CanvasItemEditor::TOOL_SELECT)
 		return false;
 
 	Transform2D xform = CanvasItemEditor::get_singleton()->get_canvas_transform() * node->get_global_transform();
@@ -1533,7 +1533,7 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 
-	if (!node)
+	if (!node || CanvasItemEditor::get_singleton()->get_current_tool() != CanvasItemEditor::TOOL_SELECT)
 		return;
 
 	Transform2D cell_xf = node->get_cell_transform();
@@ -2136,6 +2136,7 @@ void TileMapEditorPlugin::make_visible(bool p_visible) {
 		tile_map_editor->show();
 		tile_map_editor->get_toolbar()->show();
 		tile_map_editor->get_toolbar_right()->show();
+		CanvasItemEditor::get_singleton()->set_current_tool(CanvasItemEditor::TOOL_SELECT); //Change to TOOL_SELECT when TileMap node is selected, to prevent accidental movement.
 	} else {
 
 		tile_map_editor->hide();


### PR DESCRIPTION
With this change, you can edit TileMap only with select tool. Other tools perform operations on the TileMap node (move, rotate, scale, etc.).
![ezgif-4-4e1daeec2780](https://user-images.githubusercontent.com/2223172/63436625-4ca38980-c429-11e9-88fc-ff91290b62a4.gif)

Closes #23343
