### PR TITLE
Indicate empty tileset in TileMap- and TileSet-editor

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -405,8 +405,11 @@ void TileMapEditor::_update_palette() {
 	manual_palette->hide();
 
 	Ref<TileSet> tileset = node->get_tileset();
-	if (tileset.is_null())
+	if (tileset.is_null()) {
+		palette->set_fixed_column_width(get_minimum_size().x);
+		palette->add_item(String("No TileSet selected"));
 		return;
+	}
 
 	List<int> tiles;
 	tileset->get_tile_list(&tiles);

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -1033,8 +1033,16 @@ void TileSetEditor::_on_workspace_process() {
 
 void TileSetEditor::_on_workspace_overlay_draw() {
 
-	if (!tileset.is_valid() || !get_current_texture().is_valid())
+	if (!tileset.is_valid())
 		return;
+
+	if (!get_current_texture().is_valid()) {
+		Ref<Font> font = get_font("font", "Label");
+		Color color = get_color("font_color", "Editor");
+		Point2i offset(workspace_overlay->get_margin(Margin::MARGIN_LEFT), WORKSPACE_MARGIN.y);
+		workspace_overlay->draw_string(font, offset, String("Select texture to edit from the left"), color);
+		return;
+	}
 
 	const Color COLOR_AUTOTILE = Color(0.266373, 0.565288, 0.988281);
 	const Color COLOR_SINGLE = Color(0.988281, 0.909323, 0.266373);


### PR DESCRIPTION
Implements #31500 
![tilemapeditor](https://user-images.githubusercontent.com/16364388/63454353-5a6e0480-c453-11e9-9a2c-1b1d9b753792.PNG)
![tileseteditor](https://user-images.githubusercontent.com/16364388/63454358-5b9f3180-c453-11e9-8c3c-466fe293fe4a.PNG)

The first change is a bit more janky than I'd like but it seems decent considering the alternatives that came to mind and ended up not working due to margins behaving in a weird way.