### PR TITLE
Fixes iOS>=11 stealing touch events

### DIFF
--- a/platform/iphone/view_controller.h
+++ b/platform/iphone/view_controller.h
@@ -39,6 +39,10 @@
 
 - (void)didReceiveMemoryWarning;
 
+- (void)viewDidLoad;
+
+- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures;
+
 - (BOOL)prefersStatusBarHidden;
 
 @end

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -83,6 +83,18 @@ int add_cmdline(int p_argc, char **p_args) {
 	printf("*********** did receive memory warning!\n");
 };
 
+- (void)viewDidLoad {
+	[super viewDidLoad];
+
+	if (@available(iOS 11.0, *)) {
+		[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
+	}
+}
+
+- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures {
+	return UIRectEdgeAll;
+}
+
 - (BOOL)shouldAutorotate {
 	switch (OS::get_singleton()->get_screen_orientation()) {
 		case OS::SCREEN_SENSOR:


### PR DESCRIPTION
Solves an issue where iOS would steal `InputEventTouch` events when near
screen edges in order to handle system wide gestures.

This makes it behave in expected way - that is - simple touch events are priority handled by apps and when making a swipe gesture which is recognized by host OS, `iOS` shows simple overlay, signalizing the user should make the gesture again in order to be handled by OS.

Fixes #31503

Tested on real `iOS 12` device.  
Test build compiled against stable `3.1.1-stable`.
When compiling against master which is successful, `xcode` reports unrelated errors due to unrecognized constants in exported xcode project - if this is not due to some other work in progress, I can make a separate issue.  