### PR TITLE
Fix regression in StreamPeerSSL

### DIFF
--- a/modules/mbedtls/ssl_context_mbedtls.h
+++ b/modules/mbedtls/ssl_context_mbedtls.h
@@ -41,7 +41,6 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/debug.h>
 #include <mbedtls/entropy.h>
-#include <mbedtls/net.h>
 #include <mbedtls/ssl.h>
 
 class SSLContextMbedTLS : public Reference {

--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -108,6 +108,8 @@ Error StreamPeerMbedTLS::_do_handshake() {
 
 Error StreamPeerMbedTLS::connect_to_stream(Ref<StreamPeer> p_base, bool p_validate_certs, const String &p_for_hostname, Ref<X509Certificate> p_ca_certs) {
 
+	ERR_FAIL_COND_V(p_base.is_null(), ERR_INVALID_PARAMETER);
+
 	base = p_base;
 	int ret = 0;
 	int authmode = p_validate_certs ? MBEDTLS_SSL_VERIFY_REQUIRED : MBEDTLS_SSL_VERIFY_NONE;
@@ -129,6 +131,8 @@ Error StreamPeerMbedTLS::connect_to_stream(Ref<StreamPeer> p_base, bool p_valida
 }
 
 Error StreamPeerMbedTLS::accept_stream(Ref<StreamPeer> p_base, Ref<CryptoKey> p_key, Ref<X509Certificate> p_cert, Ref<X509Certificate> p_ca_chain) {
+
+	ERR_FAIL_COND_V(p_base.is_null(), ERR_INVALID_PARAMETER);
 
 	Error err = ssl_ctx->init_server(MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_VERIFY_NONE, p_key, p_cert);
 	ERR_FAIL_COND_V(err != OK, err);

--- a/modules/mbedtls/stream_peer_mbedtls.h
+++ b/modules/mbedtls/stream_peer_mbedtls.h
@@ -34,15 +34,6 @@
 #include "core/io/stream_peer_ssl.h"
 #include "ssl_context_mbedtls.h"
 
-#include <mbedtls/config.h>
-#include <mbedtls/ctr_drbg.h>
-#include <mbedtls/debug.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/ssl.h>
-
-#include <stdio.h>
-#include <stdlib.h>
-
 class StreamPeerMbedTLS : public StreamPeerSSL {
 private:
 	Status status;


### PR DESCRIPTION
Validate that base stream is valid before accepting/connecting.
Also remove unnecessary includes.

Fix regression (#30019) after #29871