### PR TITLE
Cleanup and minor changes in FileSystem Dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -53,10 +53,9 @@ Ref<Texture> FileSystemDock::_get_tree_item_icon(EditorFileSystemDirectory *p_di
 }
 
 bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths, bool p_select_in_favorites) {
-
 	bool parent_should_expand = false;
 
-	// Create a tree item for the subdirectory
+	// Create a tree item for the subdirectory.
 	TreeItem *subdirectory_item = tree->create_item(p_parent);
 	String dname = p_dir->get_name();
 	if (dname == "")
@@ -81,28 +80,28 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 		parent_should_expand = true;
 	}
 
-	// Create items for all subdirectories
+	// Create items for all subdirectories.
 	for (int i = 0; i < p_dir->get_subdir_count(); i++)
 		parent_should_expand = (_create_tree(subdirectory_item, p_dir->get_subdir(i), uncollapsed_paths, p_select_in_favorites) || parent_should_expand);
 
-	// Create all items for the files in the subdirectory
+	// Create all items for the files in the subdirectory.
 	if (display_mode == DISPLAY_MODE_TREE_ONLY) {
 		for (int i = 0; i < p_dir->get_file_count(); i++) {
 
 			String file_type = p_dir->get_file_type(i);
 
 			if (_is_file_type_disabled_by_feature_profile(file_type)) {
-				//if type is disabled, file won't be displayed.
+				// If type is disabled, file won't be displayed.
 				continue;
 			}
 			String file_name = p_dir->get_file(i);
 
 			if (searched_string.length() > 0) {
 				if (file_name.to_lower().find(searched_string) < 0) {
-					// The searched string is not in the file name, we skip it
+					// The searched string is not in the file name, we skip it.
 					continue;
 				} else {
-					// We expand all parents
+					// We expand all parents.
 					parent_should_expand = true;
 				}
 			}
@@ -135,7 +134,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 }
 
 Vector<String> FileSystemDock::_compute_uncollapsed_paths() {
-	// Register currently collapsed paths
+	// Register currently collapsed paths.
 	Vector<String> uncollapsed_paths;
 	TreeItem *root = tree->get_root();
 	if (root) {
@@ -166,14 +165,13 @@ Vector<String> FileSystemDock::_compute_uncollapsed_paths() {
 }
 
 void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, bool p_uncollapse_root, bool p_select_in_favorites) {
-
-	// Recreate the tree
+	// Recreate the tree.
 	tree->clear();
 	tree_update_id++;
 	updating_tree = true;
 	TreeItem *root = tree->create_item();
 
-	// Handles the favorites
+	// Handles the favorites.
 	TreeItem *favorites = tree->create_item(root);
 	favorites->set_icon(0, get_icon("Favorites", "EditorIcons"));
 	favorites->set_text(0, TTR("Favorites:"));
@@ -238,7 +236,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 		uncollapsed_paths.push_back("res://");
 	}
 
-	// Create the remaining of the tree
+	// Create the remaining of the tree.
 	_create_tree(root, EditorFileSystem::get_singleton()->get_filesystem(), uncollapsed_paths, p_select_in_favorites);
 	tree->ensure_cursor_is_visible();
 	updating_tree = false;
@@ -250,7 +248,7 @@ void FileSystemDock::set_display_mode(DisplayMode p_display_mode) {
 }
 
 void FileSystemDock::_update_display_mode(bool p_force) {
-	// Compute the new display mode
+	// Compute the new display mode.
 	if (p_force || old_display_mode != display_mode) {
 		button_toggle_display_mode->set_pressed(display_mode == DISPLAY_MODE_SPLIT);
 		switch (display_mode) {
@@ -283,11 +281,8 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 }
 
 void FileSystemDock::_notification(int p_what) {
-
 	switch (p_what) {
-
 		case NOTIFICATION_ENTER_TREE: {
-
 			if (initialized)
 				return;
 			initialized = true;
@@ -327,18 +322,15 @@ void FileSystemDock::_notification(int p_what) {
 			} else {
 				_update_tree(Vector<String>(), true);
 			}
-
 		} break;
+
 		case NOTIFICATION_PROCESS: {
 			if (EditorFileSystem::get_singleton()->is_scanning()) {
 				scanning_progress->set_value(EditorFileSystem::get_singleton()->get_scanning_progress() * 100);
 			}
 		} break;
-		case NOTIFICATION_EXIT_TREE: {
 
-		} break;
 		case NOTIFICATION_DRAG_BEGIN: {
-
 			Dictionary dd = get_viewport()->gui_get_drag_data();
 			if (tree->is_visible_in_tree() && dd.has("type")) {
 				if ((String(dd["type"]) == "files") || (String(dd["type"]) == "files_and_dirs") || (String(dd["type"]) == "resource")) {
@@ -347,20 +339,20 @@ void FileSystemDock::_notification(int p_what) {
 					tree->set_drop_mode_flags(Tree::DROP_MODE_INBETWEEN);
 				}
 			}
-
 		} break;
+
 		case NOTIFICATION_DRAG_END: {
-
 			tree->set_drop_mode_flags(0);
-
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			if (is_visible_in_tree()) {
 				_update_display_mode(true);
 			}
 		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			// Update icons
+			// Update icons.
 			String ei = "EditorIcons";
 			button_reload->set_icon(get_icon("Reload", ei));
 			button_toggle_display_mode->set_icon(get_icon("Panels2", ei));
@@ -377,48 +369,47 @@ void FileSystemDock::_notification(int p_what) {
 			file_list_search_box->set_right_icon(get_icon("Search", ei));
 			file_list_search_box->set_clear_button_enabled(true);
 
-			// Update always showfolders
+			// Update always show folders.
 			bool new_always_show_folders = bool(EditorSettings::get_singleton()->get("docks/filesystem/always_show_folders"));
 			if (new_always_show_folders != always_show_folders) {
 				always_show_folders = new_always_show_folders;
 				_update_file_list(true);
 			}
 
-			// Change full tree mode
+			// Change full tree mode.
 			_update_display_mode();
-
 		} break;
 	}
 }
 
 void FileSystemDock::_tree_multi_selected(Object *p_item, int p_column, bool p_selected) {
-	// Update the import dock
+	// Update the import dock.
 	import_dock_needs_update = true;
 	call_deferred("_update_import_dock");
 
-	// Return if we don't select something new
+	// Return if we don't select something new.
 	if (!p_selected)
 		return;
 
-	// Tree item selected
+	// Tree item selected.
 	TreeItem *selected = tree->get_selected();
 	if (!selected)
 		return;
 
 	TreeItem *favorites_item = tree->get_root()->get_children();
 	if (selected->get_parent() == favorites_item && !String(selected->get_metadata(0)).ends_with("/")) {
-		// Go to the favorites if we click in the favorites and the path has changed
+		// Go to the favorites if we click in the favorites and the path has changed.
 		path = "Favorites";
 	} else {
 		path = selected->get_metadata(0);
-		// Note: the "Favorites" item also leads to this path
+		// Note: the "Favorites" item also leads to this path.
 	}
 
-	// Set the current path
+	// Set the current path.
 	_set_current_path_text(path);
 	_push_to_history();
 
-	// Update the file list
+	// Update the file list.
 	if (!updating_tree && display_mode == DISPLAY_MODE_SPLIT) {
 		_update_file_list(false);
 	}
@@ -432,7 +423,6 @@ String FileSystemDock::get_selected_path() const {
 }
 
 String FileSystemDock::get_current_path() const {
-
 	return path;
 }
 
@@ -491,7 +481,6 @@ void FileSystemDock::navigate_to_path(const String &p_path) {
 }
 
 void FileSystemDock::_file_list_thumbnail_done(const String &p_path, const Ref<Texture> &p_preview, const Ref<Texture> &p_small_preview, const Variant &p_udata) {
-
 	if ((file_list_vb->is_visible_in_tree() || path == p_path.get_base_dir()) && p_preview.is_valid()) {
 		Array uarr = p_udata;
 		int idx = uarr[0];
@@ -539,7 +528,6 @@ void FileSystemDock::_set_file_display(bool p_active) {
 }
 
 bool FileSystemDock::_is_file_type_disabled_by_feature_profile(const StringName &p_class) {
-
 	Ref<EditorFeatureProfile> profile = EditorFeatureProfileManager::get_singleton()->get_current_profile();
 	if (profile.is_null()) {
 		return false;
@@ -559,7 +547,6 @@ bool FileSystemDock::_is_file_type_disabled_by_feature_profile(const StringName 
 }
 
 void FileSystemDock::_search(EditorFileSystemDirectory *p_path, List<FileInfo> *matches, int p_max_items) {
-
 	if (matches->size() > p_max_items)
 		return;
 
@@ -577,10 +564,9 @@ void FileSystemDock::_search(EditorFileSystemDirectory *p_path, List<FileInfo> *
 			fi.type = p_path->get_file_type(i);
 			fi.path = p_path->get_file_path(i);
 			fi.import_broken = !p_path->get_file_import_is_valid(i);
-			fi.import_status = 0;
 
 			if (_is_file_type_disabled_by_feature_profile(fi.type)) {
-				//this type is disabled, will not appear here
+				// This type is disabled, will not appear here.
 				continue;
 			}
 
@@ -592,8 +578,7 @@ void FileSystemDock::_search(EditorFileSystemDirectory *p_path, List<FileInfo> *
 }
 
 void FileSystemDock::_update_file_list(bool p_keep_selection) {
-
-	// Register the previously selected items
+	// Register the previously selected items.
 	Set<String> cselection;
 	if (p_keep_selection) {
 		for (int i = 0; i < files->get_item_count(); i++) {
@@ -619,7 +604,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	bool use_thumbnails = (file_list_display_mode == FILE_LIST_DISPLAY_THUMBNAILS);
 
 	if (use_thumbnails) {
-		// Thumbnails mode
+		// Thumbnails mode.
 		files->set_max_columns(0);
 		files->set_icon_mode(ItemList::ICON_MODE_TOP);
 		files->set_fixed_column_width(thumbnail_size * 3 / 2);
@@ -636,8 +621,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			file_thumbnail_broken = get_icon("FileDeadBigThumb", ei);
 		}
 	} else {
-
-		// No thumbnails
+		// No thumbnails.
 		files->set_icon_mode(ItemList::ICON_MODE_LEFT);
 		files->set_max_columns(1);
 		files->set_max_text_lines(1);
@@ -648,10 +632,10 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	Ref<Texture> folder_icon = (use_thumbnails) ? folder_thumbnail : get_icon("folder", "FileDialog");
 	const Color folder_color = get_color("folder_icon_modulate", "FileDialog");
 
-	// Build the FileInfo list
+	// Build the FileInfo list.
 	List<FileInfo> filelist;
 	if (path == "Favorites") {
-		// Display the favorites
+		// Display the favorites.
 		Vector<String> favorites = EditorSettings::get_singleton()->get_favorites();
 		for (int i = 0; i < favorites.size(); i++) {
 			String favorite = favorites[i];
@@ -685,7 +669,6 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 					fi.type = "";
 					fi.import_broken = true;
 				}
-				fi.import_status = 0;
 
 				if (searched_string.length() == 0 || fi.name.to_lower().find(searched_string) >= 0) {
 					filelist.push_back(fi);
@@ -693,8 +676,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			}
 		}
 	} else {
-
-		// Get infos on the directory + file
+		// Get infos on the directory + file.
 		if (directory.ends_with("/") && directory != "res://") {
 			directory = directory.substr(0, directory.length() - 1);
 		}
@@ -708,13 +690,11 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			return;
 
 		if (searched_string.length() > 0) {
-			// Display the search results
+			// Display the search results.
 			_search(EditorFileSystem::get_singleton()->get_filesystem(), &filelist, 128);
 		} else {
-
 			if (display_mode == DISPLAY_MODE_TREE_ONLY || always_show_folders) {
-				// Display folders in the list
-
+				// Display folders in the list.
 				if (directory != "res://") {
 					files->add_item("..", folder_icon, true);
 
@@ -728,7 +708,6 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 				}
 
 				for (int i = 0; i < efd->get_subdir_count(); i++) {
-
 					String dname = efd->get_subdir(i)->get_name();
 
 					files->add_item(dname, folder_icon, true);
@@ -741,15 +720,13 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 				}
 			}
 
-			// Display the folder content
+			// Display the folder content.
 			for (int i = 0; i < efd->get_file_count(); i++) {
-
 				FileInfo fi;
 				fi.name = efd->get_file(i);
 				fi.path = directory.plus_file(fi.name);
 				fi.type = efd->get_file_type(i);
 				fi.import_broken = !efd->get_file_import_is_valid(i);
-				fi.import_status = 0;
 
 				filelist.push_back(fi);
 			}
@@ -757,7 +734,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		filelist.sort();
 	}
 
-	// Fills the ItemList control node from the FileInfos
+	// Fills the ItemList control node from the FileInfos.
 	String oi = "Object";
 	for (List<FileInfo>::Element *E = filelist.front(); E; E = E->next()) {
 		FileInfo *finfo = &(E->get());
@@ -770,7 +747,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 
 		String tooltip = fpath;
 
-		// Select the icons
+		// Select the icons.
 		if (!finfo->import_broken) {
 			type_icon = (has_icon(ftype, ei)) ? get_icon(ftype, ei) : get_icon(oi, ei);
 			big_icon = file_thumbnail;
@@ -780,7 +757,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			tooltip += "\n" + TTR("Status: Import of file failed. Please fix file and reimport manually.");
 		}
 
-		// Add the item to the ItemList
+		// Add the item to the ItemList.
 		int item_index;
 		if (use_thumbnails) {
 			files->add_item(fname, big_icon, true);
@@ -794,7 +771,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			files->set_item_metadata(item_index, fpath);
 		}
 
-		// Generate the preview
+		// Generate the preview.
 		if (!finfo->import_broken) {
 			Array udata;
 			udata.resize(2);
@@ -803,7 +780,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			EditorResourcePreview::get_singleton()->queue_resource_preview(fpath, this, "_file_list_thumbnail_done", udata);
 		}
 
-		// Select the items
+		// Select the items.
 		if (cselection.has(fname))
 			files->select(item_index, false);
 
@@ -812,7 +789,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			files->ensure_current_is_visible();
 		}
 
-		// Tooltip
+		// Tooltip.
 		if (finfo->sources.size()) {
 			for (int j = 0; j < finfo->sources.size(); j++) {
 				tooltip += "\nSource: " + finfo->sources[j];
@@ -859,13 +836,12 @@ void FileSystemDock::_file_list_activate_file(int p_idx) {
 }
 
 void FileSystemDock::_preview_invalidated(const String &p_path) {
-
 	if (file_list_display_mode == FILE_LIST_DISPLAY_THUMBNAILS && p_path.get_base_dir() == path && searched_string.length() == 0 && file_list_vb->is_visible_in_tree()) {
 
 		for (int i = 0; i < files->get_item_count(); i++) {
 
 			if (files->get_item_metadata(i) == p_path) {
-				//re-request preview
+				// Re-request preview.
 				Array udata;
 				udata.resize(2);
 				udata[0] = i;
@@ -878,7 +854,6 @@ void FileSystemDock::_preview_invalidated(const String &p_path) {
 }
 
 void FileSystemDock::_fs_changed() {
-
 	button_hist_prev->set_disabled(history_pos == 0);
 	button_hist_next->set_disabled(history_pos == history.size() - 1);
 	scanning_vb->hide();
@@ -896,7 +871,6 @@ void FileSystemDock::_fs_changed() {
 }
 
 void FileSystemDock::_set_scanning_mode() {
-
 	button_hist_prev->set_disabled(true);
 	button_hist_next->set_disabled(true);
 	split_box->hide();
@@ -910,7 +884,6 @@ void FileSystemDock::_set_scanning_mode() {
 }
 
 void FileSystemDock::_fw_history() {
-
 	if (history_pos < history.size() - 1)
 		history_pos++;
 
@@ -988,7 +961,7 @@ void FileSystemDock::_find_remaps(EditorFileSystemDirectory *efsd, const Map<Str
 
 void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_new_path,
 		Map<String, String> &p_file_renames, Map<String, String> &p_folder_renames) {
-	//Ensure folder paths end with "/"
+	// Ensure folder paths end with "/".
 	String old_path = (p_item.is_file || p_item.path.ends_with("/")) ? p_item.path : (p_item.path + "/");
 	String new_path = (p_item.is_file || p_new_path.ends_with("/")) ? p_new_path : (p_new_path + "/");
 
@@ -998,12 +971,12 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		EditorNode::get_singleton()->add_io_error(TTR("Cannot move/rename resources root."));
 		return;
 	} else if (!p_item.is_file && new_path.begins_with(old_path)) {
-		//This check doesn't erroneously catch renaming to a longer name as folder paths always end with "/"
+		// This check doesn't erroneously catch renaming to a longer name as folder paths always end with "/".
 		EditorNode::get_singleton()->add_io_error(TTR("Cannot move a folder into itself.") + "\n" + old_path + "\n");
 		return;
 	}
 
-	//Build a list of files which will have new paths as a result of this operation
+	// Build a list of files which will have new paths as a result of this operation.
 	Vector<String> file_changed_paths;
 	Vector<String> folder_changed_paths;
 	if (p_item.is_file) {
@@ -1017,8 +990,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 	print_verbose("Moving " + old_path + " -> " + new_path);
 	Error err = da->rename(old_path, new_path);
 	if (err == OK) {
-
-		//Move/Rename any corresponding import settings too
+		// Move/Rename any corresponding import settings too.
 		if (p_item.is_file && FileAccess::exists(old_path + ".import")) {
 			err = da->rename(old_path + ".import", new_path + ".import");
 			if (err != OK) {
@@ -1026,7 +998,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			}
 		}
 
-		// update scene if it is open
+		// Update scene if it is open.
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);
 			if (ResourceLoader::get_resource_type(new_item_path) == "PackedScene" && editor->is_scene_open(file_changed_paths[i])) {
@@ -1041,7 +1013,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			}
 		}
 
-		//Only treat as a changed dependency if it was successfully moved
+		// Only treat as a changed dependency if it was successfully moved.
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			p_file_renames[file_changed_paths[i]] = file_changed_paths[i].replace_first(old_path, new_path);
 			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
@@ -1058,7 +1030,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 }
 
 void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const String &p_new_path) const {
-	//Ensure folder paths end with "/"
+	// Ensure folder paths end with "/".
 	String old_path = (p_item.is_file || p_item.path.ends_with("/")) ? p_item.path : (p_item.path + "/");
 	String new_path = (p_item.is_file || p_new_path.ends_with("/")) ? p_new_path : (p_new_path + "/");
 
@@ -1068,7 +1040,7 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 		EditorNode::get_singleton()->add_io_error(TTR("Cannot move/rename resources root."));
 		return;
 	} else if (!p_item.is_file && new_path.begins_with(old_path)) {
-		//This check doesn't erroneously catch renaming to a longer name as folder paths always end with "/"
+		// This check doesn't erroneously catch renaming to a longer name as folder paths always end with "/".
 		EditorNode::get_singleton()->add_io_error(TTR("Cannot move a folder into itself.") + "\n" + old_path + "\n");
 		return;
 	}
@@ -1077,7 +1049,7 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 	print_verbose("Duplicating " + old_path + " -> " + new_path);
 	Error err = p_item.is_file ? da->copy(old_path, new_path) : da->copy_dir(old_path, new_path);
 	if (err == OK) {
-		//Move/Rename any corresponding import settings too
+		// Move/Rename any corresponding import settings too.
 		if (p_item.is_file && FileAccess::exists(old_path + ".import")) {
 			err = da->copy(old_path + ".import", new_path + ".import");
 			if (err != OK) {
@@ -1091,13 +1063,11 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 }
 
 void FileSystemDock::_update_resource_paths_after_move(const Map<String, String> &p_renames) const {
-
-	//Rename all resources loaded, be it subresources or actual resources
+	// Rename all resources loaded, be it subresources or actual resources.
 	List<Ref<Resource> > cached;
 	ResourceCache::get_cached_resources(&cached);
 
 	for (List<Ref<Resource> >::Element *E = cached.front(); E; E = E->next()) {
-
 		Ref<Resource> r = E->get();
 
 		String base_path = r->get_path();
@@ -1116,7 +1086,6 @@ void FileSystemDock::_update_resource_paths_after_move(const Map<String, String>
 	}
 
 	for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); i++) {
-
 		String path;
 		if (i == EditorNode::get_editor_data().get_edited_scene()) {
 			if (!get_tree()->get_edited_scene_root())
@@ -1124,7 +1093,6 @@ void FileSystemDock::_update_resource_paths_after_move(const Map<String, String>
 
 			path = get_tree()->get_edited_scene_root()->get_filename();
 		} else {
-
 			path = EditorNode::get_editor_data().get_scene_path(i);
 		}
 
@@ -1133,23 +1101,21 @@ void FileSystemDock::_update_resource_paths_after_move(const Map<String, String>
 		}
 
 		if (i == EditorNode::get_editor_data().get_edited_scene()) {
-
 			get_tree()->get_edited_scene_root()->set_filename(path);
 		} else {
-
 			EditorNode::get_editor_data().set_scene_path(i, path);
 		}
 	}
 }
 
 void FileSystemDock::_update_dependencies_after_move(const Map<String, String> &p_renames) const {
-	//The following code assumes that the following holds:
+	// The following code assumes that the following holds:
 	// 1) EditorFileSystem contains the old paths/folder structure from before the rename/move.
 	// 2) ResourceLoader can use the new paths without needing to call rescan.
 	Vector<String> remaps;
 	_find_remaps(EditorFileSystem::get_singleton()->get_filesystem(), p_renames, remaps);
 	for (int i = 0; i < remaps.size(); ++i) {
-		//Because we haven't called a rescan yet the found remap might still be an old path itself.
+		// Because we haven't called a rescan yet the found remap might still be an old path itself.
 		String file = p_renames.has(remaps[i]) ? p_renames[remaps[i]] : remaps[i];
 		print_verbose("Remapping dependencies for: " + file);
 		Error err = ResourceLoader::rename_dependencies(file, p_renames);
@@ -1163,8 +1129,7 @@ void FileSystemDock::_update_dependencies_after_move(const Map<String, String> &
 }
 
 void FileSystemDock::_update_project_settings_after_move(const Map<String, String> &p_renames) const {
-
-	// Find all project settings of type FILE and replace them if needed
+	// Find all project settings of type FILE and replace them if needed.
 	const Map<StringName, PropertyInfo> prop_info = ProjectSettings::get_singleton()->get_custom_property_info();
 	for (const Map<StringName, PropertyInfo>::Element *E = prop_info.front(); E; E = E->next()) {
 		if (E->get().hint == PROPERTY_HINT_FILE) {
@@ -1195,7 +1160,6 @@ void FileSystemDock::_update_project_settings_after_move(const Map<String, Strin
 }
 
 void FileSystemDock::_update_favorites_list_after_move(const Map<String, String> &p_files_renames, const Map<String, String> &p_folders_renames) const {
-
 	Vector<String> favorites = EditorSettings::get_singleton()->get_favorites();
 	Vector<String> new_favorites;
 
@@ -1311,7 +1275,6 @@ void FileSystemDock::_folder_deleted(String p_folder) {
 }
 
 void FileSystemDock::_rename_operation_confirm() {
-
 	String new_name = rename_dialog_text->get_text().strip_edges();
 	if (new_name.length() == 0) {
 		EditorNode::get_singleton()->show_warning(TTR("No name provided."));
@@ -1331,10 +1294,10 @@ void FileSystemDock::_rename_operation_confirm() {
 		EditorFileSystem::get_singleton()->move_group_file(old_path, new_path);
 	}
 
-	//Present a more user friendly warning for name conflict
+	// Present a more user friendly warning for name conflict.
 	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 #if defined(WINDOWS_ENABLED) || defined(UWP_ENABLED)
-	// Workaround case insensitivity on Windows
+	// Workaround case insensitivity on Windows.
 	if ((da->file_exists(new_path) || da->dir_exists(new_path)) && new_path.to_lower() != old_path.to_lower()) {
 #else
 	if (da->file_exists(new_path) || da->dir_exists(new_path)) {
@@ -1366,7 +1329,6 @@ void FileSystemDock::_rename_operation_confirm() {
 }
 
 void FileSystemDock::_duplicate_operation_confirm() {
-
 	String new_name = duplicate_dialog_text->get_text().strip_edges();
 	if (new_name.length() == 0) {
 		EditorNode::get_singleton()->show_warning(TTR("No name provided."));
@@ -1384,7 +1346,7 @@ void FileSystemDock::_duplicate_operation_confirm() {
 
 	String new_path = base_dir.plus_file(new_name);
 
-	//Present a more user friendly warning for name conflict
+	// Present a more user friendly warning for name conflict
 	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	if (da->file_exists(new_path) || da->dir_exists(new_path)) {
 		EditorNode::get_singleton()->show_warning(TTR("A file or folder with this name already exists."));
@@ -1395,7 +1357,7 @@ void FileSystemDock::_duplicate_operation_confirm() {
 
 	_try_duplicate_item(to_duplicate, new_path);
 
-	//Rescan everything
+	// Rescan everything.
 	print_verbose("FileSystem: calling rescan.");
 	_rescan();
 }
@@ -1428,14 +1390,14 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool overw
 		to_move_path = p_to_path;
 		bool can_move = _check_existing();
 		if (!can_move) {
-			//ask to do something
+			// Ask to do something.
 			overwrite_dialog->popup_centered_minsize();
 			overwrite_dialog->grab_focus();
 			return;
 		}
 	}
 
-	//check groups
+	// Check groups.
 	for (int i = 0; i < to_move.size(); i++) {
 
 		print_line("is group: " + to_move[i].path + ": " + itos(EditorFileSystem::get_singleton()->is_group_file(to_move[i].path)));
@@ -1476,7 +1438,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool overw
 }
 
 Vector<String> FileSystemDock::_tree_get_selected(bool remove_self_inclusion) {
-	// Build a list of selected items with the active one at the first position
+	// Build a list of selected items with the active one at the first position.
 	Vector<String> selected_strings;
 
 	TreeItem *favorites_item = tree->get_root()->get_children();
@@ -1501,7 +1463,7 @@ Vector<String> FileSystemDock::_tree_get_selected(bool remove_self_inclusion) {
 }
 
 Vector<String> FileSystemDock::_remove_self_included_paths(Vector<String> selected_strings) {
-	// Remove paths or files that are included into another
+	// Remove paths or files that are included into another.
 	if (selected_strings.size() > 1) {
 		selected_strings.sort_custom<NaturalNoCaseComparator>();
 		String last_path = "";
@@ -1519,10 +1481,9 @@ Vector<String> FileSystemDock::_remove_self_included_paths(Vector<String> select
 }
 
 void FileSystemDock::_tree_rmb_option(int p_option) {
-
 	Vector<String> selected_strings = _tree_get_selected(false);
 
-	// Execute the current option
+	// Execute the current option.
 	switch (p_option) {
 		case FOLDER_EXPAND_ALL:
 		case FOLDER_COLLAPSE_ALL: {
@@ -1562,11 +1523,11 @@ void FileSystemDock::_file_list_rmb_option(int p_option) {
 }
 
 void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected) {
-	// The first one should be the active item
+	// The first one should be the active item.
 
 	switch (p_option) {
 		case FILE_SHOW_IN_EXPLORER: {
-			// Show the file / folder in the OS explorer
+			// Show the file/folder in the OS explorer.
 			String fpath = path;
 			if (path == "Favorites") {
 				fpath = p_selected[0];
@@ -1580,7 +1541,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_OPEN: {
-			// Open folders
+			// Open folders.
 			TreeItem *selected = tree->get_root();
 			selected = tree->get_next_selected(selected);
 			while (selected) {
@@ -1589,21 +1550,21 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				}
 				selected = tree->get_next_selected(selected);
 			}
-			// Open the file
+			// Open the file.
 			for (int i = 0; i < p_selected.size(); i++) {
 				_select_file(p_selected[i]);
 			}
 		} break;
 
 		case FILE_INHERIT: {
-			// Create a new scene inherited from the selected one
+			// Create a new scene inherited from the selected one.
 			if (p_selected.size() == 1) {
 				emit_signal("inherit", p_selected[0]);
 			}
 		} break;
 
 		case FILE_INSTANCE: {
-			// Instance all selected scenes
+			// Instance all selected scenes.
 			Vector<String> paths;
 			for (int i = 0; i < p_selected.size(); i++) {
 				String fpath = p_selected[i];
@@ -1617,7 +1578,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_ADD_FAVORITE: {
-			// Add the files from favorites
+			// Add the files from favorites.
 			Vector<String> favorites = EditorSettings::get_singleton()->get_favorites();
 			for (int i = 0; i < p_selected.size(); i++) {
 				if (favorites.find(p_selected[i]) == -1) {
@@ -1629,7 +1590,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_REMOVE_FAVORITE: {
-			// Remove the files from favorites
+			// Remove the files from favorites.
 			Vector<String> favorites = EditorSettings::get_singleton()->get_favorites();
 			for (int i = 0; i < p_selected.size(); i++) {
 				favorites.erase(p_selected[i]);
@@ -1641,7 +1602,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_DEPENDENCIES: {
-			// Checkout the file dependencies
+			// Checkout the file dependencies.
 			if (!p_selected.empty()) {
 				String fpath = p_selected[0];
 				deps_editor->edit(fpath);
@@ -1649,7 +1610,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_OWNERS: {
-			// Checkout the file owners
+			// Checkout the file owners.
 			if (!p_selected.empty()) {
 				String fpath = p_selected[0];
 				owners_editor->show(fpath);
@@ -1657,7 +1618,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_MOVE: {
-			// Move the files to a given location
+			// Move the files to a given location.
 			to_move.clear();
 			Vector<String> collapsed_paths = _remove_self_included_paths(p_selected);
 			for (int i = collapsed_paths.size() - 1; i >= 0; i--) {
@@ -1672,7 +1633,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_RENAME: {
-			// Rename the active file
+			// Rename the active file.
 			if (!p_selected.empty()) {
 				to_rename.path = p_selected[0];
 				if (to_rename.path != "res://") {
@@ -1695,7 +1656,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_REMOVE: {
-			// Remove the selected files
+			// Remove the selected files.
 			Vector<String> remove_files;
 			Vector<String> remove_folders;
 			Vector<String> collapsed_paths = _remove_self_included_paths(p_selected);
@@ -1717,7 +1678,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_DUPLICATE: {
-			// Duplicate the selected files
+			// Duplicate the selected files.
 			for (int i = 0; i < p_selected.size(); i++) {
 				to_duplicate.path = p_selected[i];
 				to_duplicate.is_file = !to_duplicate.path.ends_with("/");
@@ -1742,7 +1703,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_REIMPORT: {
-			// Reimport all selected files
+			// Reimport all selected files.
 			Vector<String> reimport;
 			for (int i = 0; i < p_selected.size(); i++) {
 				reimport.push_back(p_selected[i]);
@@ -1752,7 +1713,6 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_NEW_FOLDER: {
-			// Create a new folder
 			make_dir_dialog_text->set_text("new folder");
 			make_dir_dialog_text->select_all();
 			make_dir_dialog->popup_centered_minsize(Size2(250, 80) * EDSCALE);
@@ -1767,7 +1727,6 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_NEW_SCRIPT: {
-			// Create a new script
 			String fpath = path;
 			if (!fpath.ends_with("/")) {
 				fpath = fpath.get_base_dir();
@@ -1777,7 +1736,6 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_COPY_PATH: {
-			// Copy the file path
 			if (!p_selected.empty()) {
 				String fpath = p_selected[0];
 				OS::get_singleton()->set_clipboard(fpath);
@@ -1785,7 +1743,6 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_NEW_RESOURCE: {
-			// Create a new resource
 			new_resource_dialog->popup_create(true);
 		} break;
 	}
@@ -1813,7 +1770,7 @@ void FileSystemDock::_resource_created() const {
 
 void FileSystemDock::_search_changed(const String &p_text, const Control *p_from) {
 	if (searched_string.length() == 0 && p_text.length() > 0) {
-		// Register the uncollapsed paths before they change
+		// Register the uncollapsed paths before they change.
 		uncollapsed_paths_before_search = _compute_uncollapsed_paths();
 	}
 
@@ -1821,7 +1778,7 @@ void FileSystemDock::_search_changed(const String &p_text, const Control *p_from
 
 	if (p_from == tree_search_box)
 		file_list_search_box->set_text(searched_string);
-	else // file_list_search_box
+	else // File_list_search_box.
 		tree_search_box->set_text(searched_string);
 
 	switch (display_mode) {
@@ -1836,7 +1793,6 @@ void FileSystemDock::_search_changed(const String &p_text, const Control *p_from
 }
 
 void FileSystemDock::_rescan() {
-
 	_set_scanning_mode();
 	EditorFileSystem::get_singleton()->scan();
 }
@@ -1851,12 +1807,10 @@ void FileSystemDock::fix_dependencies(const String &p_for_file) {
 }
 
 void FileSystemDock::focus_on_filter() {
-
 	file_list_search_box->grab_focus();
 }
 
 void FileSystemDock::set_file_list_display_mode(FileListDisplayMode p_mode) {
-
 	if (p_mode == file_list_display_mode)
 		return;
 
@@ -1870,12 +1824,12 @@ Variant FileSystemDock::get_drag_data_fw(const Point2 &p_point, Control *p_from)
 	Vector<String> paths;
 
 	if (p_from == tree) {
-		// Check if the first selected is in favorite
+		// Check if the first selected is in favorite.
 		TreeItem *selected = tree->get_next_selected(tree->get_root());
 		while (selected) {
 			TreeItem *favorites_item = tree->get_root()->get_children();
 			if (selected == favorites_item) {
-				// The "Favorites" item is not draggable
+				// The "Favorites" item is not draggable.
 				return Variant();
 			}
 
@@ -1913,12 +1867,11 @@ Variant FileSystemDock::get_drag_data_fw(const Point2 &p_point, Control *p_from)
 }
 
 bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-
 	Dictionary drag_data = p_data;
 
 	if (drag_data.has("type") && String(drag_data["type"]) == "favorite") {
 
-		// Moving favorite around
+		// Moving favorite around.
 		TreeItem *ti = tree->get_item_at_position(p_point);
 		if (!ti)
 			return false;
@@ -1929,20 +1882,20 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		TreeItem *resources_item = favorites_item->get_next();
 
 		if (ti == favorites_item) {
-			return (drop_section == 1); // The parent, first fav
+			return (drop_section == 1); // The parent, first fav.
 		}
 		if (ti->get_parent() && favorites_item == ti->get_parent()) {
 			return true; // A favorite
 		}
 		if (ti == resources_item) {
-			return (drop_section == -1); // The tree, last fav
+			return (drop_section == -1); // The tree, last fav.
 		}
 
 		return false;
 	}
 
 	if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
-		// Move resources
+		// Move resources.
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
@@ -1950,7 +1903,7 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 	}
 
 	if (drag_data.has("type") && (String(drag_data["type"]) == "files" || String(drag_data["type"]) == "files_and_dirs")) {
-		// Move files or dir
+		// Move files or dir.
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
@@ -1961,8 +1914,8 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		if (to_dir.empty())
 			return false;
 
-		//Attempting to move a folder into itself will fail later
-		//Rather than bring up a message don't try to do it in the first place
+		// Attempting to move a folder into itself will fail later,
+		// rather than bring up a message don't try to do it in the first place
 		to_dir = to_dir.ends_with("/") ? to_dir : (to_dir + "/");
 		Vector<String> fnames = drag_data["files"];
 		for (int i = 0; i < fnames.size(); ++i) {
@@ -1977,7 +1930,6 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 }
 
 void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-
 	if (!can_drop_data_fw(p_point, p_data, p_from))
 		return;
 	Dictionary drag_data = p_data;
@@ -1985,7 +1937,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 	Vector<String> dirs = EditorSettings::get_singleton()->get_favorites();
 
 	if (drag_data.has("type") && String(drag_data["type"]) == "favorite") {
-		// Moving favorite around
+		// Moving favorite around.
 		TreeItem *ti = tree->get_item_at_position(p_point);
 		if (!ti)
 			return;
@@ -1997,20 +1949,20 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 		TreeItem *resources_item = favorites_item->get_next();
 
 		if (ti == favorites_item) {
-			// Drop on the favorite folder
+			// Drop on the favorite folder.
 			drop_position = 0;
 		} else if (ti == resources_item) {
-			// Drop on the resource item
+			// Drop on the resource item.
 			drop_position = dirs.size();
 		} else {
-			// Drop in the list
+			// Drop in the list.
 			drop_position = dirs.find(ti->get_metadata(0));
 			if (drop_section == 1) {
 				drop_position++;
 			}
 		}
 
-		// Remove dragged favorites
+		// Remove dragged favorites.
 		Vector<int> to_remove;
 		int offset = 0;
 		for (int i = 0; i < files.size(); i++) {
@@ -2026,7 +1978,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 			dirs.remove(to_remove[i] - i);
 		}
 
-		// Re-add them at the right position
+		// Re-add them at the right position.
 		for (int i = 0; i < files.size(); i++) {
 			dirs.insert(drop_position, files[i]);
 			drop_position++;
@@ -2041,7 +1993,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 	}
 
 	if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
-		// Moving resource
+		// Moving resource.
 		Ref<Resource> res = drag_data["resource"];
 		String to_dir;
 		bool favorite;
@@ -2053,7 +2005,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 	}
 
 	if (drag_data.has("type") && (String(drag_data["type"]) == "files" || String(drag_data["type"]) == "files_and_dirs")) {
-		// Move files or add to favorites
+		// Move files or add to favorites.
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
@@ -2083,7 +2035,7 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 	target = String();
 	target_favorites = false;
 
-	// In the file list
+	// In the file list.
 	if (p_from == files) {
 		int pos = files->get_item_at_position(p_point, true);
 		if (pos == -1) {
@@ -2095,12 +2047,12 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 		return;
 	}
 
-	// In the tree
+	// In the tree.
 	if (p_from == tree) {
 		TreeItem *ti = tree->get_item_at_position(p_point);
 		int section = tree->get_drop_section_at_position(p_point);
 		if (ti) {
-			// Check the favorites first
+			// Check the favorites first.
 			if (ti == tree->get_root()->get_children() && section >= 0) {
 				target_favorites = true;
 				return;
@@ -2111,13 +2063,13 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 				String fpath = ti->get_metadata(0);
 				if (section == 0) {
 					if (fpath.ends_with("/")) {
-						// We drop on a folder
+						// We drop on a folder.
 						target = fpath;
 						return;
 					}
 				} else {
 					if (ti->get_parent() != tree->get_root()->get_children()) {
-						// Not in the favorite section
+						// Not in the favorite section.
 						if (fpath != "res://") {
 							// We drop between two files
 							if (fpath.ends_with("/")) {
@@ -2134,7 +2086,7 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 }
 
 void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<String> p_paths, bool p_display_path_dependent_options) {
-	// Add options for files and folders
+	// Add options for files and folders.
 	ERR_FAIL_COND(p_paths.empty());
 
 	Vector<String> filenames;
@@ -2158,7 +2110,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 			all_files_scenes &= (EditorFileSystem::get_singleton()->get_file_type(fpath) == "PackedScene");
 		}
 
-		// Check if in favorites
+		// Check if in favorites.
 		bool found = false;
 		for (int j = 0; j < favorites.size(); j++) {
 			if (favorites[j] == fpath) {
@@ -2174,7 +2126,6 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 	}
 
 	if (all_files) {
-
 		if (all_files_scenes) {
 			if (filenames.size() == 1) {
 				p_popup->add_item(TTR("Open Scene"), FILE_OPEN);
@@ -2232,6 +2183,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 			p_popup->add_item(TTR("New Scene..."), FILE_NEW_SCENE);
 			p_popup->add_item(TTR("New Script..."), FILE_NEW_SCRIPT);
 			p_popup->add_item(TTR("New Resource..."), FILE_NEW_RESOURCE);
+			p_popup->add_separator();
 		}
 
 		String fpath = p_paths[0];
@@ -2241,7 +2193,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 }
 
 void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
-	// Right click is pressed in the tree
+	// Right click is pressed in the tree.
 	Vector<String> paths = _tree_get_selected(false);
 
 	if (paths.size() == 1) {
@@ -2252,7 +2204,7 @@ void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
 		}
 	}
 
-	// Popup
+	// Popup.
 	if (!paths.empty()) {
 		tree_popup->clear();
 		tree_popup->set_size(Size2(1, 1));
@@ -2263,7 +2215,7 @@ void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
 }
 
 void FileSystemDock::_tree_rmb_empty(const Vector2 &p_pos) {
-	// Right click is pressed in the empty space of the tree
+	// Right click is pressed in the empty space of the tree.
 	path = "res://";
 	tree_popup->clear();
 	tree_popup->set_size(Size2(1, 1));
@@ -2280,7 +2232,7 @@ void FileSystemDock::_tree_empty_selected() {
 }
 
 void FileSystemDock::_file_list_rmb_select(int p_item, const Vector2 &p_pos) {
-	// Right click is pressed in the file list
+	// Right click is pressed in the file list.
 	Vector<String> paths;
 	for (int i = 0; i < files->get_item_count(); i++) {
 		if (!files->is_selected(i))
@@ -2292,7 +2244,7 @@ void FileSystemDock::_file_list_rmb_select(int p_item, const Vector2 &p_pos) {
 		paths.push_back(files->get_item_metadata(i));
 	}
 
-	// Popup
+	// Popup.
 	if (!paths.empty()) {
 		file_list_popup->clear();
 		file_list_popup->set_size(Size2(1, 1));
@@ -2303,7 +2255,7 @@ void FileSystemDock::_file_list_rmb_select(int p_item, const Vector2 &p_pos) {
 }
 
 void FileSystemDock::_file_list_rmb_pressed(const Vector2 &p_pos) {
-	// Right click on empty space for file list
+	// Right click on empty space for file list.
 	if (searched_string.length() > 0)
 		return;
 
@@ -2314,19 +2266,18 @@ void FileSystemDock::_file_list_rmb_pressed(const Vector2 &p_pos) {
 	file_list_popup->add_item(TTR("New Scene..."), FILE_NEW_SCENE);
 	file_list_popup->add_item(TTR("New Script..."), FILE_NEW_SCRIPT);
 	file_list_popup->add_item(TTR("New Resource..."), FILE_NEW_RESOURCE);
-	file_list_popup->add_item(TTR("Show in File Manager"), FILE_SHOW_IN_EXPLORER);
+	file_list_popup->add_separator();
+	file_list_popup->add_item(TTR("Open in File Manager"), FILE_SHOW_IN_EXPLORER);
 	file_list_popup->set_position(files->get_global_position() + p_pos);
 	file_list_popup->popup();
 }
 
 void FileSystemDock::select_file(const String &p_file) {
-
 	_navigate_to_path(p_file);
 }
 
 void FileSystemDock::_file_multi_selected(int p_index, bool p_selected) {
-
-	// Set the path to the current focused item
+	// Set the path to the current focused item.
 	int current = files->get_current();
 	if (current == p_index) {
 		String fpath = files->get_item_metadata(current);
@@ -2338,15 +2289,14 @@ void FileSystemDock::_file_multi_selected(int p_index, bool p_selected) {
 		}
 	}
 
-	// Update the import dock
+	// Update the import dock.
 	import_dock_needs_update = true;
 	call_deferred("_update_import_dock");
 }
 
 void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
-
 	if (get_viewport()->get_modal_stack_top())
-		return; //ignore because of modal window
+		return; // Ignore because of modal window.
 
 	Ref<InputEventKey> key = p_event;
 	if (key.is_valid() && key->is_pressed() && !key->is_echo()) {
@@ -2363,9 +2313,8 @@ void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
 }
 
 void FileSystemDock::_file_list_gui_input(Ref<InputEvent> p_event) {
-
 	if (get_viewport()->get_modal_stack_top())
-		return; //ignore because of modal window
+		return; // Ignore because of modal window.
 
 	Ref<InputEventKey> key = p_event;
 	if (key.is_valid() && key->is_pressed() && !key->is_echo()) {
@@ -2382,18 +2331,17 @@ void FileSystemDock::_file_list_gui_input(Ref<InputEvent> p_event) {
 }
 
 void FileSystemDock::_update_import_dock() {
-
 	if (!import_dock_needs_update)
 		return;
 
-	// List selected
+	// List selected.
 	Vector<String> selected;
 	if (display_mode == DISPLAY_MODE_TREE_ONLY) {
 		// Use the tree
 		selected = _tree_get_selected();
 
 	} else {
-		// Use the file list
+		// Use the file list.
 		for (int i = 0; i < files->get_item_count(); i++) {
 			if (!files->is_selected(i))
 				continue;
@@ -2402,7 +2350,7 @@ void FileSystemDock::_update_import_dock() {
 		}
 	}
 
-	// Check import
+	// Check import.
 	Vector<String> imports;
 	String import_type;
 	for (int i = 0; i < selected.size(); i++) {
@@ -2429,7 +2377,7 @@ void FileSystemDock::_update_import_dock() {
 		if (import_type == "") {
 			import_type = type;
 		} else if (import_type != type) {
-			//all should be the same type
+			// All should be the same type.
 			imports.clear();
 			break;
 		}
@@ -2448,12 +2396,10 @@ void FileSystemDock::_update_import_dock() {
 }
 
 void FileSystemDock::_feature_profile_changed() {
-
 	_update_display_mode(true);
 }
 
 void FileSystemDock::_bind_methods() {
-
 	ClassDB::bind_method(D_METHOD("_file_list_gui_input"), &FileSystemDock::_file_list_gui_input);
 	ClassDB::bind_method(D_METHOD("_tree_gui_input"), &FileSystemDock::_tree_gui_input);
 
@@ -2518,7 +2464,6 @@ void FileSystemDock::_bind_methods() {
 }
 
 FileSystemDock::FileSystemDock(EditorNode *p_editor) {
-
 	set_name("FileSystem");
 	editor = p_editor;
 	path = "res://";
@@ -2599,7 +2544,6 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	tree->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
 	split_box->add_child(tree);
 
-	tree->connect("item_edited", this, "_favorite_toggled");
 	tree->connect("item_activated", this, "_tree_activate_file");
 	tree->connect("multi_selected", this, "_tree_multi_selected");
 	tree->connect("item_rmb_selected", this, "_tree_rmb_select");

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -171,7 +171,7 @@ private:
 
 	bool updating_tree;
 	int tree_update_id;
-	Tree *tree; //directories
+	Tree *tree;
 	ItemList *files;
 	bool import_dock_needs_update;
 
@@ -250,7 +250,6 @@ private:
 		String name;
 		String path;
 		StringName type;
-		int import_status; //0 not imported, 1 - ok, 2- must reimport, 3- broken
 		Vector<String> sources;
 		bool import_broken;
 


### PR DESCRIPTION
- General cleanup of the file itself.
- Removal of unused code (`import_status`, `_favorite_toggled`).
- Addition of a separation between the "New *..." items and the "Open in File Manager" item:
![Screenshot_20190822_012919](https://user-images.githubusercontent.com/30739239/63486061-74303b80-c495-11e9-8aec-60ba26a4c789.png)