### PR TITLE
Revert "Feature: Add SHA256 for PoolByteArray"

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -596,16 +596,6 @@ struct _VariantCall {
 		r_ret = decompressed;
 	}
 
-	static void _call_PoolByteArray_sha256_string(Variant &r_ret, Variant &p_self, const Variant **p_args) {
-		PoolByteArray *ba = reinterpret_cast<PoolByteArray *>(p_self._data._mem);
-		PoolByteArray::Read r = ba->read();
-		String s;
-		unsigned char hash[32];
-		CryptoCore::sha256((unsigned char *)r.ptr(), ba->size(), hash);
-		s = String::hex_encode_buffer(hash, 32);
-		r_ret = s;
-	}
-
 	static void _call_PoolByteArray_hex_encode(Variant &r_ret, Variant &p_self, const Variant **p_args) {
 		PoolByteArray *ba = reinterpret_cast<PoolByteArray *>(p_self._data._mem);
 		PoolByteArray::Read r = ba->read();
@@ -1769,7 +1759,6 @@ void register_variant_methods() {
 
 	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, get_string_from_ascii, varray());
 	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, get_string_from_utf8, varray());
-	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, sha256_string, varray());
 	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, hex_encode, varray());
 	ADDFUNC1R(POOL_BYTE_ARRAY, POOL_BYTE_ARRAY, PoolByteArray, compress, INT, "compression_mode", varray(0));
 	ADDFUNC2R(POOL_BYTE_ARRAY, POOL_BYTE_ARRAY, PoolByteArray, decompress, INT, "buffer_size", INT, "compression_mode", varray(0));

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -113,13 +113,6 @@
 				Changes the byte at the given index.
 			</description>
 		</method>
-		<method name="sha256_string">
-			<return type="String">
-			</return>
-			<description>
-				Returns SHA-256 string of the PoolByteArray.
-			</description>
-		</method>
 		<method name="size">
 			<return type="int">
 			</return>


### PR DESCRIPTION
This reverts commit e2c3bbabb0a12f58585bb441d91ee8882225b0ee from #24269.

This was superseded by #29871 which adds more crypto features with a
dedicated interface.

Since this commit was never in a stable release (merged during 3.2 dev),
we revert it to avoid having to deprecate it in favor of the HashingContext API.
See https://github.com/godotengine/godot/pull/31187#issuecomment-523377965

@xsellier FYI