### PR TITLE
Fix StreamPeerSSL connect_to_stream w/ custom cert.

### DIFF
--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -69,7 +69,7 @@ Error CryptoKeyMbedTLS::load(String p_path) {
 	int ret = mbedtls_pk_parse_key(&pkey, out.read().ptr(), out.size(), NULL, 0);
 	// We MUST zeroize the memory for safety!
 	mbedtls_platform_zeroize(out.write().ptr(), out.size());
-	ERR_FAIL_COND_V_MSG(ret, FAILED, "Error parsing some certificates: " + itos(ret));
+	ERR_FAIL_COND_V_MSG(ret, FAILED, "Error parsing private key: " + itos(ret));
 
 	return OK;
 }

--- a/modules/mbedtls/ssl_context_mbedtls.cpp
+++ b/modules/mbedtls/ssl_context_mbedtls.cpp
@@ -96,7 +96,7 @@ Error SSLContextMbedTLS::init_server(int p_transport, int p_authmode, Ref<Crypto
 Error SSLContextMbedTLS::init_client(int p_transport, int p_authmode, Ref<X509CertificateMbedTLS> p_valid_cas) {
 	X509CertificateMbedTLS *cas = NULL;
 
-	if (certs.is_valid()) {
+	if (p_valid_cas.is_valid()) {
 		// Locking CA certificates
 		certs = p_valid_cas;
 		certs->lock();


### PR DESCRIPTION
Was checking the wrong parameter, causing the code to ignore provided stream-specific SSL certificate.
Better error handling in SSLContext and Crypto.

Follow up on #29871.