### PR TITLE
Fix an exception when trying to close down editor with plugins using autoload singletons

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -439,11 +439,11 @@ void EditorAutoloadSettings::update_autoload() {
 		}
 		if (info.in_editor) {
 			ERR_CONTINUE(!info.node);
-			get_tree()->get_root()->remove_child(info.node);
+			get_tree()->get_root()->call_deferred("remove_child", info.node);
 		}
 
 		if (info.node) {
-			memdelete(info.node);
+			info.node->queue_delete();
 			info.node = NULL;
 		}
 	}


### PR DESCRIPTION
Fixes an issue where if you attempt to close down the editor while you have a plugin scripted to call remove_autoload_singleton when it exits the tree, it will result in memory exception. This is due to the function attempting directly remove the node from the root and then attempting to directly delete the node, which results in an error since the root node is blocked during the propagation, which causes a crash when memdelete is later called on the entire root node since it's deleting nodes which have already been deleted but are still thought to exist in the tree. This should hopefully solve the issue by making the remove_child call a deferred call, and is using queue_delete on the node rather than directly deleting it. This should hopefully not affect the functionality of disabling an addon, but should allow the editor shutdown error-free too since the singletons will just get deleted during call to memdelete the root node.