### PR TITLE
Don't clamp color to [0, 1] in Linear tonemapping

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -306,7 +306,7 @@
 			Replace glow blending mode. Replaces all pixels' color by the glow value.
 		</constant>
 		<constant name="TONE_MAPPER_LINEAR" value="0" enum="ToneMapper">
-			Linear tonemapper operator. Reads the linear data and performs an exposure adjustment.
+			Linear tonemapper operator. Reads the linear data and passes it on unmodified.
 		</constant>
 		<constant name="TONE_MAPPER_REINHARDT" value="1" enum="ToneMapper">
 			Reinhardt tonemapper operator. Performs a variation on rendered pixels' colors by this formula: [code]color = color / (1 + color)[/code].


### PR DESCRIPTION
At the moment there is no possibility to render a 3d scene to an HDR viewport texture without the color being clamped to the range [0.0, 1.0] (the behaviou of the "Linear" tone mapping operator is to just clamp (see https://github.com/godotengine/godot/blob/79a480a55e1ebada7f2987afeeb2039a39c8666b/drivers/gles3/shaders/tonemap.glsl#L180).
 
I ran into this issue when exporting a 3d scene rendered to a viewport texture to an .exr file with the need to retain values > 1.0. 

One potential solution is to disable tonemapping completely via the here proposed tonemapping option "None".

I think this option could also fix https://github.com/godotengine/godot/issues/26821 as an alternative solution.