### PR TITLE
Add Android "R/W External Storage" runtime permission request

### DIFF
--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -61,6 +61,8 @@ void MainLoop::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_WM_ABOUT);
 	BIND_CONSTANT(NOTIFICATION_CRASH);
 	BIND_CONSTANT(NOTIFICATION_OS_IME_UPDATE);
+
+	ADD_SIGNAL(MethodInfo("_permission_results", PropertyInfo(Variant::STRING, "permission"), PropertyInfo(Variant::BOOL, "granted")));
 };
 
 void MainLoop::set_init_script(const Ref<Script> &p_init_script) {

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -104,6 +104,8 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 	static final int MAX_SINGLETONS = 64;
 	static final int REQUEST_RECORD_AUDIO_PERMISSION = 1;
 	static final int REQUEST_CAMERA_PERMISSION = 2;
+	static final int REQUEST_READ_EXTERNAL_STORAGE_PERMISSION = 3;
+	static final int REQUEST_WRITE_EXTERNAL_STORAGE_PERMISSION = 4;
 	private IStub mDownloaderClientStub;
 	private IDownloaderService mRemoteService;
 	private TextView mStatusText;
@@ -964,6 +966,21 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 				return false;
 			}
 		}
+
+		if ("READ_EXTERNAL".equals(p_name)) {
+			if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+				requestPermissions(new String[] { Manifest.permission.READ_EXTERNAL_STORAGE }, REQUEST_READ_EXTERNAL_STORAGE_PERMISSION);
+				return false;
+			}
+		}
+
+		if ("WRITE_EXTERNAL".equals(p_name)) {
+			if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+				requestPermissions(new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE }, REQUEST_WRITE_EXTERNAL_STORAGE_PERMISSION);
+				return false;
+			}
+		}
+
 		return true;
 	}
 

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -1586,4 +1586,5 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResu
 	if (permission == "android.permission.RECORD_AUDIO" && p_result) {
 		AudioDriver::get_singleton()->capture_start();
 	}
+	os_android->permission_results(permission, p_result == JNI_TRUE);
 }

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -698,6 +698,10 @@ String OS_Android::get_joy_guid(int p_device) const {
 	return input->get_joy_guid_remapped(p_device);
 }
 
+void OS_Android::permission_results(String permission, bool granted) {
+	main_loop->emit_signal("_permission_results", permission, granted);
+}
+
 bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 	if (p_feature == "mobile") {
 		//TODO support etc2 only if GLES3 driver is selected

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -240,6 +240,8 @@ public:
 	virtual String get_joy_guid(int p_device) const;
 	void joy_connection_changed(int p_device, bool p_connected, String p_name);
 
+	void permission_results(String permission, bool granted);
+
 	virtual bool _check_internal_feature_support(const String &p_feature);
 	OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetUserDataDirFunc p_get_user_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, GetGLVersionCodeFunc p_get_gl_version_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, SetClipboardFunc p_set_clipboard, GetClipboardFunc p_get_clipboard, RequestPermissionFunc p_request_permission, bool p_use_apk_expansion);
 	~OS_Android();


### PR DESCRIPTION
Permission request came with Android 6. Because if you need to make sensitive operation like write or read external storage, you need to ask to user for permission an make this operation. In Godot has only include camera, record audio and vibration permission. We need to write and read some data in game for save and load states. So I add write and read external storage permission requests and all permission request result callback but I am not sure results were emiting on Main Loop.  