### PR TITLE
Export path is the only path to be saved as a relative path

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -147,6 +147,12 @@ String EditorExportPreset::get_include_filter() const {
 void EditorExportPreset::set_export_path(const String &p_path) {
 
 	export_path = p_path;
+	/* NOTE(SonerSound): if there is a need to implement a PropertyHint that specifically indicates a relative path,
+	 * this should be removed. */
+	if (export_path.is_abs_path()) {
+		String res_path = OS::get_singleton()->get_resource_dir();
+		export_path = res_path.path_to_file(export_path);
+	}
 	EditorExport::singleton->save_presets();
 }
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -208,13 +208,7 @@ EditorPropertyTextEnum::EditorPropertyTextEnum() {
 
 void EditorPropertyPath::_path_selected(const String &p_path) {
 
-	String final_path = p_path;
-	if (final_path.is_abs_path()) {
-		String res_path = OS::get_singleton()->get_resource_dir() + "/";
-		final_path = res_path.path_to_file(final_path);
-	}
-
-	emit_changed(get_edited_property(), final_path);
+	emit_changed(get_edited_property(), p_path);
 	update_property();
 }
 void EditorPropertyPath::_path_pressed() {
@@ -227,13 +221,6 @@ void EditorPropertyPath::_path_pressed() {
 	}
 
 	String full_path = get_edited_object()->get(get_edited_property());
-	if (full_path.is_rel_path()) {
-
-		if (!DirAccess::exists(full_path.get_base_dir())) {
-			DirAccessRef da(DirAccess::create(DirAccess::ACCESS_FILESYSTEM));
-			da->make_dir_recursive(full_path.get_base_dir());
-		}
-	}
 
 	dialog->clear_filters();
 

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -931,17 +931,8 @@ void ProjectExportDialog::_export_project() {
 		export_project->add_filter("*." + extension_list[i] + " ; " + platform->get_name() + " Export");
 	}
 
-	String current_preset_export_path = current->get_export_path();
-
-	if (current_preset_export_path != "") {
-
-		if (!DirAccess::exists(current_preset_export_path.get_base_dir())) {
-
-			DirAccessRef da(DirAccess::create(DirAccess::ACCESS_FILESYSTEM));
-			da->make_dir_recursive(current_preset_export_path.get_base_dir());
-		}
-
-		export_project->set_current_path(current_preset_export_path);
+	if (current->get_export_path() != "") {
+		export_project->set_current_path(current->get_export_path());
 	} else {
 		if (extension_list.size() >= 1) {
 			export_project->set_current_file(default_filename + "." + extension_list[0]);


### PR DESCRIPTION
- Also reverts #28701.

Fixes #31533.
Issue was caused due to saving any EditorPropertyPath as a relative path when it was saved.