### PR TITLE
Add horizontal margins to the editor help based on width

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -164,6 +164,17 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 void EditorHelp::_class_desc_input(const Ref<InputEvent> &p_input) {
 }
 
+void EditorHelp::_class_desc_resized() {
+	// Add extra horizontal margins for better readability.
+	// The margins increase as the width of the editor help container increases.
+	const int display_margin = MAX(30 * EDSCALE, get_parent_anchorable_rect().size.width - 900 * EDSCALE) * 0.5;
+
+	Ref<StyleBox> class_desc_stylebox = EditorNode::get_singleton()->get_theme_base()->get_stylebox("normal", "RichTextLabel")->duplicate();
+	class_desc_stylebox->set_default_margin(MARGIN_LEFT, display_margin);
+	class_desc_stylebox->set_default_margin(MARGIN_RIGHT, display_margin);
+	class_desc->add_style_override("normal", class_desc_stylebox);
+}
+
 void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 
 	String t = p_type;
@@ -1488,6 +1499,7 @@ void EditorHelp::_bind_methods() {
 	ClassDB::bind_method("_class_list_select", &EditorHelp::_class_list_select);
 	ClassDB::bind_method("_class_desc_select", &EditorHelp::_class_desc_select);
 	ClassDB::bind_method("_class_desc_input", &EditorHelp::_class_desc_input);
+	ClassDB::bind_method("_class_desc_resized", &EditorHelp::_class_desc_resized);
 	ClassDB::bind_method("_request_help", &EditorHelp::_request_help);
 	ClassDB::bind_method("_unhandled_key_input", &EditorHelp::_unhandled_key_input);
 	ClassDB::bind_method("_search", &EditorHelp::_search);
@@ -1506,8 +1518,11 @@ EditorHelp::EditorHelp() {
 	add_child(class_desc);
 	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
 	class_desc->add_color_override("selection_color", get_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
+
 	class_desc->connect("meta_clicked", this, "_class_desc_select");
 	class_desc->connect("gui_input", this, "_class_desc_input");
+	class_desc->connect("resized", this, "_class_desc_resized");
+	_class_desc_resized();
 
 	// Added second so it opens at the bottom so it won't offset the entire widget.
 	find_bar = memnew(FindBar);

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -151,6 +151,7 @@ class EditorHelp : public VBoxContainer {
 	void _class_list_select(const String &p_select);
 	void _class_desc_select(const String &p_select);
 	void _class_desc_input(const Ref<InputEvent> &p_input);
+	void _class_desc_resized();
 
 	Error _goto_desc(const String &p_class, int p_vscr = -1);
 	//void _update_history_buttons();


### PR DESCRIPTION
This decreases the number of characters per line, and therefore helps make the editor help more readable.

PS: Does the way I implemented this leak memory? I can notice RAM usage increasing when I resize the editor window, but this also happens in the `master` branch.

## Preview

### Window maximized on a 1920×1080 monitor

![godot_editor_help_1080p](https://user-images.githubusercontent.com/180032/63557061-689d4d00-c547-11e9-90ce-012ce64e9525.png)

### Window maximized on a 2560×1440 monitor

![godot_editor_help_1440p](https://user-images.githubusercontent.com/180032/63557062-6935e380-c547-11e9-9a91-899ac91e2192.png)