### PR TITLE
Add Android "R/W External Storage" permission request

### DIFF
--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -41,6 +41,7 @@ void MainLoop::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("idle", "delta"), &MainLoop::idle);
 	ClassDB::bind_method(D_METHOD("finish"), &MainLoop::finish);
 
+
 	BIND_VMETHOD(MethodInfo("_input_event", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	BIND_VMETHOD(MethodInfo("_input_text", PropertyInfo(Variant::STRING, "text")));
 	BIND_VMETHOD(MethodInfo("_initialize"));
@@ -61,6 +62,9 @@ void MainLoop::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_WM_ABOUT);
 	BIND_CONSTANT(NOTIFICATION_CRASH);
 	BIND_CONSTANT(NOTIFICATION_OS_IME_UPDATE);
+
+	ADD_SIGNAL(MethodInfo("_permission_results", PropertyInfo(Variant::STRING, "permission"), PropertyInfo(Variant::BOOL, "granted")));
+
 };
 
 void MainLoop::set_init_script(const Ref<Script> &p_init_script) {

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -100,6 +100,8 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 	static final int REQUEST_RECORD_AUDIO_PERMISSION = 1;
 	static final int REQUEST_CAMERA_PERMISSION = 2;
 	static final int REQUEST_VIBRATE_PERMISSION = 3;
+	static final int REQUEST_READ_EXTERNAL_STORAGE_PERMISSION = 3;
+	static final int REQUEST_WRITE_EXTERNAL_STORAGE_PERMISSION = 4;
 	private IStub mDownloaderClientStub;
 	private IDownloaderService mRemoteService;
 	private TextView mStatusText;
@@ -1004,6 +1006,20 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		if (p_name.equals("VIBRATE")) {
 			if (ContextCompat.checkSelfPermission(this, Manifest.permission.VIBRATE) != PackageManager.PERMISSION_GRANTED) {
 				requestPermissions(new String[] { Manifest.permission.VIBRATE }, REQUEST_VIBRATE_PERMISSION);
+				return false;
+			}
+		}
+
+		if ("READ_EXTERNAL".equals(p_name)) {
+			if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+				requestPermissions(new String[] { Manifest.permission.READ_EXTERNAL_STORAGE }, REQUEST_READ_EXTERNAL_STORAGE_PERMISSION);
+				return false;
+			}
+		}
+
+		if ("WRITE_EXTERNAL".equals(p_name)) {
+			if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+				requestPermissions(new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE }, REQUEST_WRITE_EXTERNAL_STORAGE_PERMISSION);
 				return false;
 			}
 		}

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -1386,4 +1386,5 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResu
 	if (permission == "android.permission.RECORD_AUDIO" && p_result) {
 		AudioDriver::get_singleton()->capture_start();
 	}
+	os_android->permission_results(permission, p_result == JNI_TRUE);
 }

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -704,6 +704,10 @@ void OS_Android::vibrate_handheld(int p_duration_ms) {
 	godot_java->vibrate(p_duration_ms);
 }
 
+void OS_Android::permission_results(String permission, bool granted) {
+	main_loop->emit_signal("_permission_results", permission, granted);
+}
+
 bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 	if (p_feature == "mobile") {
 		//TODO support etc2 only if GLES3 driver is selected

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -199,6 +199,7 @@ public:
 	virtual String get_joy_guid(int p_device) const;
 	void joy_connection_changed(int p_device, bool p_connected, String p_name);
 	void vibrate_handheld(int p_duration_ms);
+	void permission_results(String permission, bool granted);
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
 	OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion);


### PR DESCRIPTION
Permission request came with Android 6. Because if you need to make sensitive operation like write or read external storage, you need to ask to user for permission an make this operation. In Godot has only include camera, record audio and vibration permission. We need to write and read some data in game for save and load states. So I add write and read external storage permission requests and all permission request result callback but I am not sure results were emiting on Main Loop.