### PR TITLE
Fix shader crash when users miss the return statement

### DIFF
--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -750,6 +750,9 @@ private:
 	Error _parse_block(BlockNode *p_block, const Map<StringName, BuiltInInfo> &p_builtin_types, bool p_just_one = false, bool p_can_break = false, bool p_can_continue = false);
 	Error _parse_shader(const Map<StringName, FunctionInfo> &p_functions, const Vector<StringName> &p_render_modes, const Set<String> &p_shader_types);
 
+	Error _find_last_flow_op_in_block(BlockNode *p_block, FlowOperation p_op);
+	Error _find_last_flow_op_in_op(ControlFlowNode *p_flow, FlowOperation p_op);
+
 public:
 	//static void get_keyword_list(ShaderType p_type,List<String> *p_keywords);
 


### PR DESCRIPTION
This will fix the shader crash by forcing a user to define return statement inside non-void functions

![image](https://user-images.githubusercontent.com/3036176/63593317-6c1eeb80-c5bc-11e9-8fe8-1685025748bd.png)
