### PR TITLE
Fix uninitialized inertia value in Body2DSW

### DIFF
--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -671,6 +671,7 @@ Body2DSW::Body2DSW() :
 	angular_velocity = 0;
 	biased_angular_velocity = 0;
 	mass = 1;
+	inertia = 0;
 	user_inertia = false;
 	_inv_inertia = 0;
 	_inv_mass = 1;


### PR DESCRIPTION
This fixes regression caused by #31386.

In my case, rigid bodies sporadically started disappearing on instancing, I think they just flew away very far because of either too low or too high inertia, not sure. 

For some reason the inertia isn't recomputed in some cases I think.

CC @raphael10241024 🙂

P.S. Thanks [GUT](https://github.com/bitwes/Gut/) for helping to catch this early.