### PR TITLE
Move the asset library API URL to the Editor Settings

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -624,6 +624,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("network/ssl/editor_ssl_certificates", _SYSTEM_CERTS_PATH);
 	hints["network/ssl/editor_ssl_certificates"] = PropertyInfo(Variant::STRING, "network/ssl/editor_ssl_certificates", PROPERTY_HINT_GLOBAL_FILE, "*.crt,*.pem");
 
+	// Asset library
+	_initial_set("asset_library/use_threads", true);
+	_initial_set("asset_library/api_url", "https://godotengine.org/asset-library/api");
+	hints["asset_library/api_url"] = PropertyInfo(Variant::STRING, "asset_library/api_url", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+
 	/* Extra config */
 
 	_initial_set("project_manager/sorting_order", 0);

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -188,7 +188,6 @@ class EditorAssetLibrary : public PanelContainer {
 	VBoxContainer *library_vb;
 	LineEdit *filter;
 	OptionButton *categories;
-	OptionButton *repository;
 	OptionButton *sort;
 	ToolButton *reverse;
 	Button *search;
@@ -283,7 +282,7 @@ class EditorAssetLibrary : public PanelContainer {
 	void _manage_plugins();
 
 	void _search(int p_page = 0);
-	void _rerun_search(int p_ignore);
+	void _rerun_search();
 	void _search_text_entered(const String &p_text = "");
 	void _api_request(const String &p_request, RequestType p_request_type, const String &p_arguments = "");
 	void _http_request_completed(int p_status, int p_code, const PoolStringArray &headers, const PoolByteArray &p_data);


### PR DESCRIPTION
Since changing the API URL is only needed for people working on the asset library, it doesn't need to be present in the asset library menus.

This also allows setting the API URL to something else than the default or `localhost`.

This also removes some duplicated default setting values.

This closes #22046 and partially addresses #5284.