### PR TITLE
Add copy/paste nodes across scenes and outside editor

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -61,6 +61,9 @@ class SceneTreeDock : public VBoxContainer {
 		TOOL_NEW,
 		TOOL_INSTANCE,
 		TOOL_EXPAND_COLLAPSE,
+		TOOL_CUT,
+		TOOL_COPY,
+		TOOL_PASTE,
 		TOOL_RENAME,
 		TOOL_BATCH_RENAME,
 		TOOL_REPLACE,
@@ -164,10 +167,12 @@ class SceneTreeDock : public VBoxContainer {
 	enum ReplaceOwnerMode {
 		MODE_BIDI,
 		MODE_DO,
+		FORCE_DO,
 		MODE_UNDO
 	};
 
 	void _node_replace_owner(Node *p_base, Node *p_node, Node *p_root, ReplaceOwnerMode p_mode = MODE_BIDI);
+	void _setup_for_copy(Node *p_node, Node *p_owner);
 	void _load_request(const String &p_path);
 	void _script_open_request(const Ref<Script> &p_script);
 
@@ -179,7 +184,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _script_created(Ref<Script> p_script);
 	void _script_creation_closed();
 
-	void _delete_confirm();
+	void _delete_confirm(bool p_cut = false);
 
 	void _toggle_editable_children_from_selection();
 	void _toggle_editable_children(Node *p_node);


### PR DESCRIPTION
Yet another attempt at node copy-pasting. This time it allows to copy nodes outside editor, thus between editor instances or into anything that takes text. It's achieved by converting node data to text and parsing as scene on paste.

Closes #3720
Closes #7605
Closes #13380
Supersedes #19327

Caveats:
- doesn't allow to cut/copy more than one node
- uses intermediate file to get scene text data for clipboard (and to paste it)
- discards any instancing

Unfortunately, I had to apply sort of a hack for converting the node data. I'm saving a file in a cache directory and then load it as text and copy into clipboard. For pasting, I'm creating a temporary file with clipboard contents and instance it into scene. The reason for this is that ResourceSaver/Loader can only work on files and don't operate on strings in memory. Perfectly, it should be changed, but could be done in another PR probably (it works and this feature waited long enough anyways).

Here's a video showcase: https://youtu.be/5vqNqaOtrTI