### PR TITLE
Fix the edges of the mesh vertex

### DIFF
--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -165,11 +165,12 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 				e.vertex[0] = edge.x;
 				e.vertex[1] = edge.y;
 				edges.push_back(e);
+				v[j]->edges.push_back(face.edges[j]);
+				v[(j + 1) % 3]->edges.push_back(face.edges[j]);
 			}
 
 			edges.write[face.edges[j]].faces.push_back(fidx);
 			v[j]->faces.push_back(fidx);
-			v[j]->edges.push_back(face.edges[j]);
 		}
 
 		faces.push_back(face);


### PR DESCRIPTION
fix #27508 

Add the edges from double-sided of the vertices.
Only save the new edge to deal with the duplicated edge. 
