### PR TITLE
Improve sorting options in the asset library

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -578,7 +578,6 @@ void EditorAssetLibrary::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 
 			error_tr->set_texture(get_icon("Error", "EditorIcons"));
-			reverse->set_icon(get_icon("Sort", "EditorIcons"));
 			filter->set_right_icon(get_icon("Search", "EditorIcons"));
 			filter->set_clear_button_enabled(true);
 
@@ -612,7 +611,6 @@ void EditorAssetLibrary::_notification(int p_what) {
 			library_scroll_bg->add_style_override("panel", get_stylebox("bg", "Tree"));
 			downloads_scroll->add_style_override("bg", get_stylebox("bg", "Tree"));
 			error_tr->set_texture(get_icon("Error", "EditorIcons"));
-			reverse->set_icon(get_icon("Sort", "EditorIcons"));
 			filter->set_right_icon(get_icon("Search", "EditorIcons"));
 			filter->set_clear_button_enabled(true);
 		} break;
@@ -645,23 +643,27 @@ void EditorAssetLibrary::_install_asset() {
 }
 
 const char *EditorAssetLibrary::sort_key[SORT_MAX] = {
-	"downloads",
+	"updated",
+	"updated",
+	"name",
 	"name",
 	"cost",
-	"updated"
+	"cost",
 };
 
 const char *EditorAssetLibrary::sort_text[SORT_MAX] = {
-	"Downloads",
-	"Name",
-	"License", // "cost" stores the SPDX license name in the Godot Asset Library.
-	"Updated"
+	"Recently Updated",
+	"Least Recently Updated",
+	"Name (A-Z)",
+	"Name (Z-A)",
+	"License (A-Z)", // "cost" stores the SPDX license name in the Godot Asset Library.
+	"License (Z-A)", // "cost" stores the SPDX license name in the Godot Asset Library.
 };
 
 const char *EditorAssetLibrary::support_key[SUPPORT_MAX] = {
 	"official",
 	"community",
-	"testing"
+	"testing",
 };
 
 void EditorAssetLibrary::_select_author(int p_id) {
@@ -928,8 +930,8 @@ void EditorAssetLibrary::_search(int p_page) {
 		args += "&category=" + itos(categories->get_item_metadata(categories->get_selected()));
 	}
 
-	if (reverse->is_pressed()) {
-
+	// Sorting options with an odd index are always the reverse of the previous one
+	if (sort->get_selected() % 2 == 1) {
 		args += "&reverse=true";
 	}
 
@@ -1380,12 +1382,6 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	sort->set_h_size_flags(SIZE_EXPAND_FILL);
 	sort->connect("item_selected", this, "_rerun_search");
-
-	reverse = memnew(ToolButton);
-	reverse->set_toggle_mode(true);
-	reverse->connect("toggled", this, "_rerun_search");
-	reverse->set_tooltip(TTR("Reverse sorting."));
-	search_hb2->add_child(reverse);
 
 	search_hb2->add_child(memnew(VSeparator));
 

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -190,7 +190,6 @@ class EditorAssetLibrary : public PanelContainer {
 	OptionButton *categories;
 	OptionButton *repository;
 	OptionButton *sort;
-	ToolButton *reverse;
 	Button *search;
 	HBoxContainer *error_hb;
 	TextureRect *error_tr;
@@ -216,10 +215,12 @@ class EditorAssetLibrary : public PanelContainer {
 	};
 
 	enum SortOrder {
-		SORT_DOWNLOADS,
-		SORT_NAME,
-		SORT_COST,
 		SORT_UPDATED,
+		SORT_UPDATED_REVERSE,
+		SORT_NAME,
+		SORT_NAME_REVERSE,
+		SORT_COST,
+		SORT_COST_REVERSE,
 		SORT_MAX
 	};
 


### PR DESCRIPTION
The reverse sorting options are now integrated in the list of sorting options, making the "Reverse" button unnecessary. This pattern tends to be easier to discover by users.

The "Downloads" sorting option was also removed as it's not implemented in the backend.

~~**Note:** Don't merge until https://github.com/godotengine/godot-asset-library/pull/188 is merged. Otherwise, the sorting order while sorting by name or license would be contrary to what's indicated in the GUI.~~

**Edit:** https://github.com/godotengine/godot-asset-library/pull/188 is now merged, so this one can now be merged.