### PR TITLE
Tree: fix and expose icon modulation

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -136,6 +136,15 @@
 				Returns the column's icon's maximum width.
 			</description>
 		</method>
+		<method name="get_icon_modulate" qualifiers="const">
+			<return type="Color">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<description>
+				Returns the [Color] modulating the column's icon.
+			</description>
+		</method>
 		<method name="get_icon_region" qualifiers="const">
 			<return type="Rect2">
 			</return>
@@ -462,6 +471,17 @@
 			</argument>
 			<description>
 				Sets the given column's icon's maximum width.
+			</description>
+		</method>
+		<method name="set_icon_modulate">
+			<return type="void">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<argument index="1" name="modulate" type="Color">
+			</argument>
+			<description>
+				Modulates the given column's icon with [code]modulate[/code].
 			</description>
 		</method>
 		<method name="set_icon_region">

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -63,7 +63,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 
 	subdirectory_item->set_text(0, dname);
 	subdirectory_item->set_icon(0, get_icon("Folder", "EditorIcons"));
-	subdirectory_item->set_icon_color(0, get_color("folder_icon_modulate", "FileDialog"));
+	subdirectory_item->set_icon_modulate(0, get_color("folder_icon_modulate", "FileDialog"));
 	subdirectory_item->set_selectable(0, true);
 	String lpath = p_dir->get_path();
 	subdirectory_item->set_metadata(0, lpath);
@@ -214,7 +214,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 			TreeItem *ti = tree->create_item(favorites);
 			ti->set_text(0, text);
 			ti->set_icon(0, icon);
-			ti->set_icon_color(0, color);
+			ti->set_icon_modulate(0, color);
 			ti->set_tooltip(0, fave);
 			ti->set_selectable(0, true);
 			ti->set_metadata(0, fave);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -430,7 +430,7 @@ void FileDialog::update_file_list() {
 		TreeItem *ti = tree->create_item(root);
 		ti->set_text(0, dir_name);
 		ti->set_icon(0, folder);
-		ti->set_icon_color(0, folder_color);
+		ti->set_icon_modulate(0, folder_color);
 
 		Dictionary d;
 		d["name"] = dir_name;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -224,14 +224,14 @@ Rect2 TreeItem::get_icon_region(int p_column) const {
 	return cells[p_column].icon_region;
 }
 
-void TreeItem::set_icon_color(int p_column, const Color &p_icon_color) {
+void TreeItem::set_icon_modulate(int p_column, const Color &p_modulate) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells.write[p_column].icon_color = p_icon_color;
+	cells.write[p_column].icon_color = p_modulate;
 	_changed_notify(p_column);
 }
 
-Color TreeItem::get_icon_color(int p_column) const {
+Color TreeItem::get_icon_modulate(int p_column) const {
 
 	ERR_FAIL_INDEX_V(p_column, cells.size(), Color());
 	return cells[p_column].icon_color;
@@ -743,6 +743,9 @@ void TreeItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_icon_max_width", "column", "width"), &TreeItem::set_icon_max_width);
 	ClassDB::bind_method(D_METHOD("get_icon_max_width", "column"), &TreeItem::get_icon_max_width);
+
+	ClassDB::bind_method(D_METHOD("set_icon_modulate", "column", "modulate"), &TreeItem::set_icon_modulate);
+	ClassDB::bind_method(D_METHOD("get_icon_modulate", "column"), &TreeItem::get_icon_modulate);
 
 	ClassDB::bind_method(D_METHOD("set_range", "column", "value"), &TreeItem::set_range);
 	ClassDB::bind_method(D_METHOD("get_range", "column"), &TreeItem::get_range);
@@ -1259,10 +1262,9 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					check_ofs.y += Math::floor((real_t)(item_rect.size.y - checked->get_height()) / 2);
 
 					if (p_item->cells[i].checked) {
-
-						checked->draw(ci, check_ofs, icon_col);
+						checked->draw(ci, check_ofs);
 					} else {
-						unchecked->draw(ci, check_ofs, icon_col);
+						unchecked->draw(ci, check_ofs);
 					}
 
 					int check_w = checked->get_width() + cache.hseparation;
@@ -1273,8 +1275,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					item_rect.position.x += check_w;
 
 					draw_item_rect(p_item->cells[i], item_rect, col, icon_col);
-
-					//font->draw( ci, text_pos, p_item->cells[i].text, col,item_rect.size.x-check_w );
 
 				} break;
 				case TreeItem::CELL_MODE_RANGE: {
@@ -1305,18 +1305,16 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 						font->draw(ci, text_pos, s, col, item_rect.size.x - downarrow->get_width());
 
-						//?
 						Point2i arrow_pos = item_rect.position;
 						arrow_pos.x += item_rect.size.x - downarrow->get_width();
 						arrow_pos.y += Math::floor(((item_rect.size.y - downarrow->get_height())) / 2.0);
 
-						downarrow->draw(ci, arrow_pos, icon_col);
+						downarrow->draw(ci, arrow_pos);
 					} else {
 
 						Ref<Texture> updown = cache.updown;
 
 						String valtext = String::num(p_item->cells[i].val, Math::range_step_decimals(p_item->cells[i].step));
-						//String valtext = rtos( p_item->cells[i].val );
 
 						if (p_item->cells[i].suffix != String())
 							valtext += " " + p_item->cells[i].suffix;
@@ -1330,7 +1328,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 						updown_pos.x += item_rect.size.x - updown->get_width();
 						updown_pos.y += Math::floor(((item_rect.size.y - updown->get_height())) / 2.0);
 
-						updown->draw(ci, updown_pos, icon_col);
+						updown->draw(ci, updown_pos);
 					}
 
 				} break;
@@ -1348,12 +1346,9 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					icon_ofs += item_rect.position;
 
 					draw_texture_rect(p_item->cells[i].icon, Rect2(icon_ofs, icon_size), false, icon_col);
-					//p_item->cells[i].icon->draw(ci, icon_ofs);
 
 				} break;
 				case TreeItem::CELL_MODE_CUSTOM: {
-
-					//int option = (int)p_item->cells[i].val;
 
 					if (p_item->cells[i].custom_draw_obj) {
 
@@ -1429,10 +1424,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 			arrow->draw(ci, p_pos + p_draw_ofs + Point2i(0, (label_h - arrow->get_height()) / 2) - cache.offset);
 		}
-		//separator
-		//get_painter()->draw_fill_rect( Point2i(0,pos.y),Size2i(get_size().width,1),color( COLOR_TREE_GRID) );
-
-		//pos=p_pos; //reset pos
 	}
 
 	Point2 children_pos = p_pos;

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -193,8 +193,8 @@ public:
 	void set_icon_region(int p_column, const Rect2 &p_icon_region);
 	Rect2 get_icon_region(int p_column) const;
 
-	void set_icon_color(int p_column, const Color &p_icon_color);
-	Color get_icon_color(int p_column) const;
+	void set_icon_modulate(int p_column, const Color &p_modulate);
+	Color get_icon_modulate(int p_column) const;
 
 	void set_icon_max_width(int p_column, int p_max);
 	int get_icon_max_width(int p_column) const;


### PR DESCRIPTION
I was changing the asset installer to look more similiar to the file system panel including the recent changes which show directories in a different color but noticed noticed that checkboxes were also tinted (see image) which doesn't seem like intended so this commit fixes that.
![Screenshot_2019-08-24_15-10-00](https://user-images.githubusercontent.com/17676847/63639719-19663200-c697-11e9-99e8-96b93962fa54.png)


The functions are now also accessible from scripting languages and were renamed to `set/get_icon_modulate` to be consistent with the already exposed `set/get_item_icon_modulate` from ItemList.