### PR TITLE
Enhanced preview for a visual shader to show errors

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -70,7 +70,10 @@ class VisualShaderEditor : public VBoxContainer {
 	PanelContainer *error_panel;
 	Label *error_label;
 
+	bool shader_error;
+	VBoxContainer *preview_vbox;
 	TextEdit *preview_text;
+	Label *error_text;
 
 	UndoRedo *undo_redo;
 	Point2 saved_node_pos;


### PR DESCRIPTION
I guess this makes it more useful

![image](https://user-images.githubusercontent.com/3036176/63646060-60ded380-c714-11e9-9470-93e52c26a5d3.png)
