### PR TITLE
reverted NotifyAwaiter<T> Reset() to support c#7.0

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Utils/NotifyAwaiter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/NotifyAwaiter.cs
@@ -51,7 +51,7 @@ namespace GodotTools.Utils
         {
             continuation = null;
             exception = null;
-            result = default;
+            result = default(T);
             IsCompleted = false;
             return this;
         }


### PR DESCRIPTION
Out of the box this will not compile with mono 5.x.0, reverting this won't have any conflicts. Just allows the source to build with mono versions older than 6.0

*Bugsquad edit:* Fixes #31626.