### PR TITLE
Viewport highlight, colour cache and minimap scrolling fixes.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3991,7 +3991,7 @@ void TextEdit::_line_edited_from(int p_line) {
 
 	if (syntax_highlighting_cache.size() > 0) {
 		cache_size = syntax_highlighting_cache.back()->key();
-		for (int i = p_line - 1; i < cache_size; i++) {
+		for (int i = p_line - 1; i <= cache_size; i++) {
 			if (syntax_highlighting_cache.has(i)) {
 				syntax_highlighting_cache.erase(i);
 			}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -918,8 +918,7 @@ void TextEdit::_notification(int p_what) {
 				int minimap_draw_amount = minimap_visible_lines + times_line_wraps(minimap_line + 1);
 
 				// draw the minimap
-				Color viewport_color = cache.current_line_color;
-				viewport_color.a /= 2;
+				Color viewport_color = (cache.background_color.get_v() < 0.5) ? Color(1, 1, 1, 0.1) : Color(0, 0, 0, 0.1);
 				VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2((xmargin_end + 2), viewport_offset_y, cache.minimap_width, viewport_height), viewport_color);
 				for (int i = 0; i < minimap_draw_amount; i++) {
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -596,14 +596,8 @@ void TextEdit::_update_minimap_drag() {
 		return;
 	}
 
-	int control_height = get_size().height;
-	control_height -= cache.style_normal->get_minimum_size().height;
-	if (h_scroll->is_visible_in_tree()) {
-		control_height -= h_scroll->get_size().height;
-	}
-
 	Point2 mp = get_local_mouse_position();
-	double diff = (mp.y - minimap_scroll_click_pos) / control_height;
+	double diff = (mp.y - minimap_scroll_click_pos) / _get_control_height();
 	v_scroll->set_as_ratio(minimap_scroll_ratio + diff);
 }
 
@@ -923,12 +917,7 @@ void TextEdit::_notification(int p_what) {
 
 				// calculate viewport size and y offset
 				int viewport_height = (draw_amount - 1) * minimap_line_height;
-				int control_height = size.height;
-				control_height -= cache.style_normal->get_minimum_size().height;
-				if (h_scroll->is_visible_in_tree()) {
-					control_height -= h_scroll->get_size().height;
-				}
-				control_height -= viewport_height;
+				int control_height = _get_control_height() - viewport_height;
 				int viewport_offset_y = round(get_scroll_pos_for_line(first_visible_line) * control_height) / ((v_scroll->get_max() <= minimap_visible_lines) ? (minimap_visible_lines - draw_amount) : (v_scroll->get_max() - draw_amount));
 
 				// calculate the first line.
@@ -2094,12 +2083,7 @@ void TextEdit::_get_minimap_mouse_row(const Point2i &p_mouse, int &r_row) const 
 
 	// calculate viewport size and y offset
 	int viewport_height = (draw_amount - 1) * minimap_line_height;
-	int control_height = get_size().height;
-	control_height -= cache.style_normal->get_minimum_size().height;
-	if (h_scroll->is_visible_in_tree()) {
-		control_height -= h_scroll->get_size().height;
-	}
-	control_height -= viewport_height;
+	int control_height = _get_control_height() - viewport_height;
 	int viewport_offset_y = round(get_scroll_pos_for_line(first_visible_line) * control_height) / ((v_scroll->get_max() <= minimap_visible_lines) ? (minimap_visible_lines - draw_amount) : (v_scroll->get_max() - draw_amount));
 
 	// calculate the first line.
@@ -4043,23 +4027,21 @@ Size2 TextEdit::get_minimum_size() const {
 	return cache.style_normal->get_minimum_size();
 }
 
-int TextEdit::get_visible_rows() const {
+int TextEdit::_get_control_height() const {
+	int control_height = get_size().height;
+	control_height -= cache.style_normal->get_minimum_size().height;
+	if (h_scroll->is_visible_in_tree()) {
+		control_height -= h_scroll->get_size().height;
+	}
+	return control_height;
+}
 
-	int total = get_size().height;
-	total -= cache.style_normal->get_minimum_size().height;
-	if (h_scroll->is_visible_in_tree())
-		total -= h_scroll->get_size().height;
-	total /= get_row_height();
-	return total;
+int TextEdit::get_visible_rows() const {
+	return _get_control_height() / get_row_height();
 }
 
 int TextEdit::_get_minimap_visible_rows() const {
-	int total = get_size().height;
-	total -= cache.style_normal->get_minimum_size().height;
-	if (h_scroll->is_visible_in_tree())
-		total -= h_scroll->get_size().height;
-	total /= (minimap_char_size.y + minimap_line_spacing);
-	return total;
+	return _get_control_height() / (minimap_char_size.y + minimap_line_spacing);
 }
 
 int TextEdit::get_total_visible_rows() const {
@@ -6150,10 +6132,7 @@ int TextEdit::get_last_visible_line_wrap_index() const {
 
 double TextEdit::get_visible_rows_offset() const {
 
-	double total = get_size().height;
-	total -= cache.style_normal->get_minimum_size().height;
-	if (h_scroll->is_visible_in_tree())
-		total -= h_scroll->get_size().height;
+	double total = _get_control_height();
 	total /= (double)get_row_height();
 	total = total - floor(total);
 	total = -CLAMP(total, 0.001, 1) + 1;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -422,6 +422,7 @@ private:
 
 	//void mouse_motion(const Point& p_pos, const Point& p_rel, int p_button_mask);
 	Size2 get_minimum_size() const;
+	int _get_control_height() const;
 
 	int get_row_height() const;
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -334,7 +334,10 @@ private:
 	bool scrolling;
 	bool dragging_selection;
 	bool dragging_minimap;
+	bool can_drag_minimap;
 	bool minimap_clicked;
+	double minimap_scroll_ratio;
+	double minimap_scroll_click_pos;
 	float target_v_scroll;
 	float v_scroll_speed;
 
@@ -406,7 +409,8 @@ private:
 	void _update_selection_mode_word();
 	void _update_selection_mode_line();
 
-	void _update_minimap_scroll();
+	void _update_minimap_click();
+	void _update_minimap_drag();
 	void _scroll_up(real_t p_delta);
 	void _scroll_down(real_t p_delta);
 


### PR DESCRIPTION
The viewport highlight colour is now based on the background colour, instead of current line colour. 
Fixed syntax highlighting cache not clearing the final line, causing it to not update.
Made scrolling via the minimap act similar to the scrollbar, so it should no longer lag.

I also refactored the control height calculations into its own method.

closes #31584
closes #31617
closes #31582
