### PR TITLE
Allow to reserve space for nodes in A* and elements in OAHashMap explicitly.

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -243,6 +243,20 @@ void AStar::clear() {
 	points.clear();
 }
 
+int AStar::get_point_count() const {
+	return points.get_num_elements();
+}
+
+int AStar::get_point_capacity() const {
+	return points.get_capacity();
+}
+
+void AStar::reserve_space(int p_num_nodes) {
+	ERR_FAIL_COND_MSG(p_num_nodes <= 0, "New capacity must be greater than 0, was: " + itos(p_num_nodes) + ".");
+	ERR_FAIL_COND_MSG((uint32_t)p_num_nodes < points.get_capacity(), "New capacity must be greater than current capacity: " + itos(points.get_capacity()) + ", new was: " + itos(p_num_nodes) + ".");
+	points.reserve(p_num_nodes);
+}
+
 int AStar::get_closest_point(const Vector3 &p_point) const {
 
 	int closest_id = -1;
@@ -521,6 +535,9 @@ void AStar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("disconnect_points", "id", "to_id"), &AStar::disconnect_points);
 	ClassDB::bind_method(D_METHOD("are_points_connected", "id", "to_id"), &AStar::are_points_connected);
 
+	ClassDB::bind_method(D_METHOD("get_point_count"), &AStar::get_point_count);
+	ClassDB::bind_method(D_METHOD("get_point_capacity"), &AStar::get_point_capacity);
+	ClassDB::bind_method(D_METHOD("reserve_space", "num_nodes"), &AStar::reserve_space);
 	ClassDB::bind_method(D_METHOD("clear"), &AStar::clear);
 
 	ClassDB::bind_method(D_METHOD("get_closest_point", "to_position"), &AStar::get_closest_point);
@@ -605,8 +622,20 @@ bool AStar2D::are_points_connected(int p_id, int p_with_id) const {
 	return astar.are_points_connected(p_id, p_with_id);
 }
 
+int AStar2D::get_point_count() const {
+	return astar.get_point_count();
+}
+
+int AStar2D::get_point_capacity() const {
+	return astar.get_point_capacity();
+}
+
 void AStar2D::clear() {
 	astar.clear();
+}
+
+void AStar2D::reserve_space(int p_num_nodes) {
+	astar.reserve_space(p_num_nodes);
 }
 
 int AStar2D::get_closest_point(const Vector2 &p_point) const {
@@ -659,6 +688,9 @@ void AStar2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("disconnect_points", "id", "to_id"), &AStar2D::disconnect_points);
 	ClassDB::bind_method(D_METHOD("are_points_connected", "id", "to_id"), &AStar2D::are_points_connected);
 
+	ClassDB::bind_method(D_METHOD("get_point_count"), &AStar2D::get_point_count);
+	ClassDB::bind_method(D_METHOD("get_point_capacity"), &AStar2D::get_point_capacity);
+	ClassDB::bind_method(D_METHOD("reserve_space", "num_nodes"), &AStar2D::reserve_space);
 	ClassDB::bind_method(D_METHOD("clear"), &AStar2D::clear);
 
 	ClassDB::bind_method(D_METHOD("get_closest_point", "to_position"), &AStar2D::get_closest_point);

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -46,6 +46,10 @@ class AStar : public Reference {
 
 	struct Point {
 
+		Point() :
+				neighbours(4u),
+				unlinked_neighbours(4u) {}
+
 		int id;
 		Vector3 pos;
 		real_t weight_scale;
@@ -132,6 +136,9 @@ public:
 	void disconnect_points(int p_id, int p_with_id);
 	bool are_points_connected(int p_id, int p_with_id) const;
 
+	int get_point_count() const;
+	int get_point_capacity() const;
+	void reserve_space(int p_num_nodes);
 	void clear();
 
 	int get_closest_point(const Vector3 &p_point) const;
@@ -171,6 +178,9 @@ public:
 	void disconnect_points(int p_id, int p_with_id);
 	bool are_points_connected(int p_id, int p_with_id) const;
 
+	int get_point_count() const;
+	int get_point_capacity() const;
+	void reserve_space(int p_num_nodes);
 	void clear();
 
 	int get_closest_point(const Vector2 &p_point) const;

--- a/doc/classes/AStar.xml
+++ b/doc/classes/AStar.xml
@@ -157,6 +157,13 @@
 				If you change the 2nd point's weight to 3, then the result will be [code][1, 4, 3][/code] instead, because now even though the distance is longer, it's "easier" to get through point 4 than through point 2.
 			</description>
 		</method>
+		<method name="get_point_capacity" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the capacity of the structure backing the points, useful in conjunction with [code]reserve_space[/code].
+			</description>
+		</method>
 		<method name="get_point_connections">
 			<return type="PoolIntArray">
 			</return>
@@ -176,6 +183,13 @@
 
 				var neighbors = astar.get_point_connections(1) # Returns [2, 3]
 				[/codeblock]
+			</description>
+		</method>
+		<method name="get_point_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the number of points currently in the points pool.
 			</description>
 		</method>
 		<method name="get_point_path">
@@ -239,6 +253,15 @@
 			</argument>
 			<description>
 				Removes the point associated with the given [code]id[/code] from the points pool.
+			</description>
+		</method>
+		<method name="reserve_space">
+			<return type="void">
+			</return>
+			<argument index="0" name="num_nodes" type="int">
+			</argument>
+			<description>
+				Reserves space internally for [code]num_nodes[/code] points, useful if you're adding a known large number of points at once, for a grid for instance. New capacity must be greater or equals to old capacity.
 			</description>
 		</method>
 		<method name="set_point_disabled">

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -134,6 +134,13 @@
 				If you change the 2nd point's weight to 3, then the result will be [code][1, 4, 3][/code] instead, because now even though the distance is longer, it's "easier" to get through point 4 than through point 2.
 			</description>
 		</method>
+		<method name="get_point_capacity" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the capacity of the structure backing the points, useful in conjunction with [code]reserve_space[/code].
+			</description>
+		</method>
 		<method name="get_point_connections">
 			<return type="PoolIntArray">
 			</return>
@@ -153,6 +160,13 @@
 
 				var neighbors = astar.get_point_connections(1) # Returns [2, 3]
 				[/codeblock]
+			</description>
+		</method>
+		<method name="get_point_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the number of points currently in the points pool.
 			</description>
 		</method>
 		<method name="get_point_path">
@@ -216,6 +230,15 @@
 			</argument>
 			<description>
 				Removes the point associated with the given [code]id[/code] from the points pool.
+			</description>
+		</method>
+		<method name="reserve_space">
+			<return type="void">
+			</return>
+			<argument index="0" name="num_nodes" type="int">
+			</argument>
+			<description>
+				Reserves space internally for [code]num_nodes[/code] points, useful if you're adding a known large number of points at once, for a grid for instance. New capacity must be greater or equals to old capacity.
 			</description>
 		</method>
 		<method name="set_point_disabled">

--- a/main/tests/test_oa_hash_map.cpp
+++ b/main/tests/test_oa_hash_map.cpp
@@ -121,6 +121,25 @@ MainLoop *test() {
 		delete[] keys;
 	}
 
+	// regression test / test for issue related to #31402
+	{
+
+		OS::get_singleton()->print("test for issue #31402 started...\n");
+
+		const int num_test_values = 12;
+		int test_values[num_test_values] = { 0, 24, 48, 72, 96, 120, 144, 168, 192, 216, 240, 264 };
+
+		int dummy = 0;
+		OAHashMap<int, int> map;
+		map.clear();
+
+		for (int i = 0; i < num_test_values; ++i) {
+			map.set(test_values[i], dummy);
+		}
+
+		OS::get_singleton()->print("test for issue #31402 passed.\n");
+	}
+
 	return NULL;
 }
 } // namespace TestOAHashMap


### PR DESCRIPTION
# Motivation
So after the last replacement of Map with OAHashMap in the main A* implementation, usecases that use it as if it was a grid and then add many points in succession incur a lot of overhead from the hashmap growing and then also copying memory around, so the idea is to allow reserving as much space ahead of time as you know is necessary to minimize this as much as possible.

ie. a 6x slowdown at initialization time adding a lot of nodes at once was found: https://github.com/godotengine/godot/pull/31402#issuecomment-524636647
(and me personally testing initialization, also found a nearly 2-4x difference).

# What

## Additions
* Adds `reserve_space(num_nodes)` to A* to reserve space for num_nodes (not necessary but useful if you find cases like this one where it may be slow otherwise).
  * Also adds accompanying `get_point_count()` and `get_point_capacity()` methods.
* Adds `reserve(capacity)` to OAHashMap.
* Preallocates space for only 4 neighbours in each OAHashMap for the nodes, instead of the 64 default.

## Fixes
* Makes sure probe length calculation in OAHashMap does not wrap.
* Fixes `clear` in OAHashMap, it previously incorrectly marked `EMPTY_HASH` entries as deleted.

In my own testing, this achieved parity with the old implementation in initialization time.
**Testing would be much appreciated**, for example with (optionally uses reserve if available): https://github.com/profan/godot-demo-projects/tree/master/2d/navigation_astar
(forked from @alexey-makarenko's repo)

Especially the original reporter: https://github.com/godotengine/godot/pull/31402#issuecomment-524636647 would be appreciated for trying out the change :+1:

If you want to test it but can't compile it on Windows, @ me in discord and I can send you a build.

random note: any and all testing is appreciated!