### PR TITLE
Fix 'android_mono_config.gen.cpp' not compiled first time it's generated

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -8,13 +8,7 @@ Import('env_modules')
 
 env_mono = env_modules.Clone()
 
-env_mono.add_source_files(env.modules_sources, '*.cpp')
-env_mono.add_source_files(env.modules_sources, 'glue/*.cpp')
-env_mono.add_source_files(env.modules_sources, 'mono_gd/*.cpp')
-env_mono.add_source_files(env.modules_sources, 'utils/*.cpp')
-
 if env['tools']:
-    env_mono.add_source_files(env.modules_sources, 'editor/*.cpp')
     # NOTE: It is safe to generate this file here, since this is still executed serially
     import build_scripts.make_cs_compressed_header as make_cs_compressed_header
     make_cs_compressed_header.generate_header(
@@ -62,3 +56,13 @@ if env_mono['tools']:
         # GodotTools.ProjectEditor which doesn't depend on the Godot API solution and
         # is required by the bindings generator in order to be able to generated it.
         godot_tools_build.build_project_editor_only(env_mono)
+
+# Add sources
+
+env_mono.add_source_files(env.modules_sources, '*.cpp')
+env_mono.add_source_files(env.modules_sources, 'glue/*.cpp')
+env_mono.add_source_files(env.modules_sources, 'mono_gd/*.cpp')
+env_mono.add_source_files(env.modules_sources, 'utils/*.cpp')
+
+if env['tools']:
+    env_mono.add_source_files(env.modules_sources, 'editor/*.cpp')

--- a/modules/mono/build_scripts/make_android_mono_config.py
+++ b/modules/mono/build_scripts/make_android_mono_config.py
@@ -3,23 +3,6 @@ def generate_compressed_config(config_src, output_dir):
     import os.path
     from compat import byte_to_str
 
-    # Header file
-    with open(os.path.join(output_dir, 'android_mono_config.gen.h'), 'w') as header:
-        header.write('''/* THIS FILE IS GENERATED DO NOT EDIT */
-#ifndef ANDROID_MONO_CONFIG_GEN_H
-#define ANDROID_MONO_CONFIG_GEN_H
-
-#ifdef ANDROID_ENABLED
-
-#include "core/ustring.h"
-
-String get_godot_android_mono_config();
-
-#endif // ANDROID_ENABLED
-
-#endif // ANDROID_MONO_CONFIG_GEN_H
-''')
-
     # Source file
     with open(os.path.join(output_dir, 'android_mono_config.gen.cpp'), 'w') as cpp:
         with open(config_src, 'rb') as f:
@@ -36,7 +19,7 @@ String get_godot_android_mono_config();
                 bytes_seq_str += byte_to_str(buf[buf_idx])
 
             cpp.write('''/* THIS FILE IS GENERATED DO NOT EDIT */
-#include "android_mono_config.gen.h"
+#include "android_mono_config.h"
 
 #ifdef ANDROID_ENABLED
 

--- a/modules/mono/mono_gd/android_mono_config.h
+++ b/modules/mono/mono_gd/android_mono_config.h
@@ -1,0 +1,13 @@
+#ifndef ANDROID_MONO_CONFIG_H
+#define ANDROID_MONO_CONFIG_H
+
+#ifdef ANDROID_ENABLED
+
+#include "core/ustring.h"
+
+// This function is defined in an auto-generated source file
+String get_godot_android_mono_config();
+
+#endif // ANDROID_ENABLED
+
+#endif // ANDROID_MONO_CONFIG_H

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -56,7 +56,7 @@
 #endif
 
 #ifdef ANDROID_ENABLED
-#include "android_mono_config.gen.h"
+#include "android_mono_config.h"
 #endif
 
 GDMono *GDMono::singleton = NULL;


### PR DESCRIPTION
Wildcards don't work for files created after the wildcard is added, so we have to add the sources after configuration is done.
