### PR TITLE
Fix Multiline texts not updating correcly inside arrays

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -616,7 +616,7 @@ void TextEdit::_notification(int p_what) {
 		case NOTIFICATION_RESIZED: {
 
 			_update_scrollbars();
-			call_deferred("_update_wrap_at");
+			_update_wrap_at();
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 


### PR DESCRIPTION
The deferred call was from #24792, and from what I tested, it didn't bring back the bugs it solved.

Fixes #28021.
Supersedes #31165.