### PR TITLE
Add size tracking to CowData, make it never reallocate when shrinking.

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -119,11 +119,7 @@ private:
 			return false;
 
 		uint8_t *data = (uint8_t *)_ptr;
-		if (p_ptr >= data && p_ptr <= data + _size * sizeof(T)) {
-			return true;
-		}
-
-		return false;
+		return p_ptr >= data && p_ptr <= data + _size * sizeof(T);
 	}
 
 	void _unref(void *p_data);

--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -86,11 +86,11 @@ private:
 
 		if (!_ptr)
 			return NULL;
-		return reinterpret_cast<T *>(_ptr);
+
+		return reinterpret_cast<T *>(_ptr); // TODO: figure out if this is just superstitious? looks like a no-op? (including the above if)
 	}
 
 	_FORCE_INLINE_ size_t _get_alloc_size(size_t p_elements) const {
-		//return nearest_power_of_2_templated(p_elements*sizeof(T)+sizeof(SafeRefCount)+sizeof(int));
 		return next_power_of_2(p_elements * sizeof(T));
 	}
 

--- a/core/vector.h
+++ b/core/vector.h
@@ -80,6 +80,7 @@ public:
 	_FORCE_INLINE_ T get(int p_index) { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ const T get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ int capacity() const { return _cowdata.capacity(); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
 	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }
@@ -149,9 +150,8 @@ void Vector<T>::append_array(const Vector<T> &p_other) {
 template <class T>
 bool Vector<T>::push_back(const T &p_elem) {
 
-	Error err = resize(size() + 1);
+	Error err = _cowdata.insert(size(), p_elem);
 	ERR_FAIL_COND_V(err, true);
-	set(size() - 1, p_elem);
 
 	return false;
 }


### PR DESCRIPTION
# Motivation
Strings/Vectors/etc in GDScript and the core engine alike use CowData as the backing structure, today this structure reallocates its memory on nearly every operation.
(push_back, remove, etc, see: #22561, #24731).

Luckily this is possible to improve without changing any existing Godot code, while making it easier for people to reuse memory in vectors and reduce the amount of necessary overall allocations.

# Usecases in Godot
Currently structures like Godot's A* use Vector for the open list (where a significant improvement can be seen with this change), even the scene tree itself uses vector as the datastructure in nodes to hold children and today incurs a reallocation every time an element is added or removed, so some improvement should be seen in these case (likely not as significant as for something like a stack/queue type usecase, but nonetheless).

# Changes
* Adds tracking of the size to the CowData structure itself.
* Adds a `capacity` method to the public interface of Vector and CowData.
* Fixes inserting elements from within a CowData's own data to itself (per issue surfaced in #16961).
* Changes growth rate to a factor of p_size * 1.618 (also makes growth rate work, per #22561).
* `clear` now only resets size, does not deallocate memory to accomodate reuse.
* `push_back`/`remove` etc do not resize unless capacity is exceeded, shrinking never allocates.

# Discussion
So this change might be slightly controversial but I'd been sitting on this for a while so I figured I'd float this because it doesn't break any existing code and from my own testing does not increase memory usage in any significant way.

(there's probably a bunch in this code that needs looking at by contributors familiar with core)

# Testing
I've tested this on Godot proper as well as a bunch of my own projects and it seems to be operating just fine, given that deploying it in all of Godot is a pretty good benchmark for if it's sane or not, but having more experienced contributors take a look would be much appreciated.

# Future Additions
Most vector implementations also have a way to reserve memory ahead of time without also resizing to that size, so adding a `reserve` method to `CowData` and `Vector` is a logical next step if this change is accepted.

Also adding a `shrink_to_fit` method to shrink to the current logical size would also make sense for cases where you do want it to shrink, even if I think this should not be the default as it is currently.

Probably exposing these in GDScript/GDNative would also be of interest, `capacity`, `reserve`, etc.