### PR TITLE
Mono: Fix OSX build due to invalid function call

### DIFF
--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -271,7 +271,7 @@ MonoString *godot_icall_Internal_SimplifyGodotPath(MonoString *p_path) {
 MonoBoolean godot_icall_Internal_IsOsxAppBundleInstalled(MonoString *p_bundle_id) {
 #ifdef OSX_ENABLED
 	String bundle_id = GDMonoMarshal::mono_string_to_godot(p_bundle_id);
-	return (MonoBoolean)osx_is_app_bundle_installed;
+	return (MonoBoolean)osx_is_app_bundle_installed(bundle_id);
 #else
 	(void)p_bundle_id; // UNUSED
 	return (MonoBoolean) false;


### PR DESCRIPTION
It would fail building with:
```
modules/mono/editor/editor_internal_calls.cpp:274:9: error: cast from pointer to smaller type 'MonoBoolean' (aka 'unsigned char') loses information
        return (MonoBoolean)osx_is_app_bundle_installed;
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```