### PR TITLE
Buildsystem and workflow improvements to the new Android custom builds

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6411,13 +6411,13 @@ EditorNode::EditorNode() {
 	gui_base->add_child(custom_build_manage_templates);
 
 	install_android_build_template = memnew(ConfirmationDialog);
-	install_android_build_template->set_text(TTR("This will install the Android project for custom builds.\nNote that, in order to use it, it needs to be enabled per export preset."));
+	install_android_build_template->set_text(TTR("This will set up your project for custom Android builds by installing the source template to \"res://android/build\".\nYou can then apply modifications and build your own custom APK on export (adding modules, changing the AndroidManifest.xml, etc.).\nNote that in order to make custom builds instead of using pre-built APKs, the \"Use Custom Build\" option should be enabled in the Android export preset."));
 	install_android_build_template->get_ok()->set_text(TTR("Install"));
 	install_android_build_template->connect("confirmed", this, "_menu_confirm_current");
 	gui_base->add_child(install_android_build_template);
 
 	remove_android_build_template = memnew(ConfirmationDialog);
-	remove_android_build_template->set_text(TTR("Android build template is already installed and it won't be overwritten.\nRemove the \"build\" directory manually before attempting this operation again."));
+	remove_android_build_template->set_text(TTR("The Android build template is already installed in this project and it won't be overwritten.\nRemove the \"res://android/build\" directory manually before attempting this operation again."));
 	remove_android_build_template->get_ok()->set_text(TTR("Show in File Manager"));
 	remove_android_build_template->connect("confirmed", this, "_menu_option", varray(FILE_EXPLORE_ANDROID_BUILD_TEMPLATES));
 	gui_base->add_child(remove_android_build_template);

--- a/editor/export_template_manager.h
+++ b/editor/export_template_manager.h
@@ -72,6 +72,8 @@ class ExportTemplateManager : public ConfirmationDialog {
 	virtual void ok_pressed();
 	bool _install_from_file(const String &p_file, bool p_use_progress = true);
 
+	Error _extract_libs_from_apk(const String &p_target_name);
+
 	void _http_download_mirror_completed(int p_status, int p_code, const PoolStringArray &headers, const PoolByteArray &p_data);
 	void _http_download_templates_completed(int p_status, int p_code, const PoolStringArray &headers, const PoolByteArray &p_data);
 

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -55,3 +55,25 @@ if lib_arch_dir != '':
 
     stl_lib_path = str(env['ANDROID_NDK_ROOT']) + '/sources/cxx-stl/llvm-libc++/libs/' + lib_arch_dir + '/libc++_shared.so'
     env_android.Command(out_dir + '/libc++_shared.so', stl_lib_path, Copy("$TARGET", "$SOURCE"))
+
+# Zip android/java folder for the source export template.
+print("Archiving platform/android/java as bin/android_source.zip...")
+import os
+import zipfile
+# Change dir to avoid have zipped paths start from the android/java folder.
+olddir = os.getcwd()
+os.chdir(Dir('#platform/android/java').abspath)
+bindir = Dir('#bin').abspath
+# Make 'bin' dir if missing, can happen on fresh clone.
+if not os.path.exists(bindir):
+    os.makedirs(bindir)
+zipf = zipfile.ZipFile(os.path.join(bindir, 'android_source.zip'), 'w', zipfile.ZIP_DEFLATED)
+exclude_dirs = ['.gradle', 'build', 'libs', 'patches']
+for root, dirs, files in os.walk('.', topdown=True):
+    # Change 'dirs' in place to exclude folders we don't want.
+    # https://stackoverflow.com/a/19859907
+    dirs[:] = [d for d in dirs if d not in exclude_dirs]
+    for f in files:
+        zipf.write(os.path.join(root, f))
+zipf.close()
+os.chdir(olddir)

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1610,19 +1610,16 @@ public:
 				valid = false;
 			} else {
 				Error errn;
-				DirAccess *da = DirAccess::open(sdk_path.plus_file("tools"), &errn);
+				DirAccessRef da = DirAccess::open(sdk_path.plus_file("tools"), &errn);
 				if (errn != OK) {
 					err += TTR("Invalid Android SDK path for custom build in Editor Settings.") + "\n";
 					valid = false;
-				}
-				if (da) {
-					memdelete(da);
 				}
 			}
 
 			if (!FileAccess::exists("res://android/build/build.gradle")) {
 
-				err += TTR("Android project is not installed for compiling. Install from Editor menu.") + "\n";
+				err += TTR("Android build template not installed in the project. Install it from the Project menu.") + "\n";
 				valid = false;
 			}
 		}
@@ -2513,7 +2510,7 @@ void register_android_exporter() {
 	EDITOR_DEF("export/android/debug_keystore_pass", "android");
 	EDITOR_DEF("export/android/force_system_user", false);
 	EDITOR_DEF("export/android/custom_build_sdk_path", "");
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/custom_build_sdk_path", PROPERTY_HINT_GLOBAL_DIR, "*.keystore"));
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/custom_build_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 
 	EDITOR_DEF("export/android/timestamping_authority_url", "");
 	EDITOR_DEF("export/android/shutdown_adb_on_exit", true);


### PR DESCRIPTION
- SCons: Generate `android_source.zip` during build

This is now needed after #27781, as this `android_source.zip` template
is used for custom Android builds from the editor.

I have yet to confirm that it works as expected though, my first test gave me a different and non-working APK when using a custom build with no custom config, compared to normal builds.

- Android: Improve dialogs about custom build template

Still not perfect but it makes things a bit clearer regarding the fact that it's going to install source code in the project folder for custom Android builds, as opposed to downloading the regular templates.

Fixes #28736 - at least to some extent, the rest of the confusion is simply due to no official templates existing yet with this `android_source.zip` file.

- Android: Extract libs from pre-built APKs when installing build template

First commit ignored the `libs` folder in the `android_source.zip`, but I learned that it's actually necessary. Instead of zipping it, we extract the libs directly from the pre-built APKs, so the `android_source.zip` stays 250 kiB instead of 54 MiB :)

---

Other things I plan to work on:

- Bring back the move of the generated APK to `bin/` when building the default templates. Need to find a way to have this behavior when building from Godot's repo, but not with custom builds. Any clue @godotengine/android @m4gr3d?
- Adjust docs for 3.2 (godotengine/godot-docs#2599).