### PR TITLE
Tweak the default fog depth end to use a fixed value

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -146,10 +146,11 @@
 		<member name="fog_depth_enabled" type="bool" setter="set_fog_depth_enabled" getter="is_fog_depth_enabled" default="true">
 			Enables the fog depth.
 		</member>
-		<member name="fog_depth_end" type="float" setter="set_fog_depth_end" getter="get_fog_depth_end" default="0.0">
+		<member name="fog_depth_end" type="float" setter="set_fog_depth_end" getter="get_fog_depth_end" default="100.0">
+			Fog's depth end distance from the camera. If this value is set to 0, it will be equal to the current camera's [member Camera.far] value.
 		</member>
 		<member name="fog_enabled" type="bool" setter="set_fog_enabled" getter="is_fog_enabled" default="false">
-			Enables the fog. Needs fog_height_enabled and/or for_depth_enabled to actually display fog.
+			Enables the fog. Needs [member fog_height_enabled] and/or [member fog_depth_enabled] to actually display fog.
 		</member>
 		<member name="fog_height_curve" type="float" setter="set_fog_height_curve" getter="get_fog_height_curve" default="1.0">
 			Value defining the fog height intensity.

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1399,7 +1399,7 @@ Environment::Environment() :
 	fog_depth_enabled = true;
 
 	fog_depth_begin = 10;
-	fog_depth_end = 0;
+	fog_depth_end = 100;
 	fog_depth_curve = 1;
 
 	fog_transmit_enabled = false;


### PR DESCRIPTION
The previous value (0) was a special case in the fog shader. It made the shader use the Camera's `far` value as the fog depth end value, which led to an inconsistency in the fog rendering between the editor and a running project. This is because the editor camera uses a `far` property of 500 by default, whereas the Camera node's `far` property is set to 100 by default.

The new fixed value is equal to the default `far` property in Camera, which leads to a consistent appearance between the editor and a running project.

This closes #31686.