### PR TITLE
Improve image loading performance in the asset library

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -827,7 +827,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 
 void EditorAssetLibrary::_update_image_queue() {
 
-	int max_images = 2;
+	const int max_images = 6;
 	int current_images = 0;
 
 	List<int> to_delete;


### PR DESCRIPTION
This closes #31614.

This seems to be a reasonably high value, as higher values will cause the editor to stutter more often when loading images (from my testing).