### PR TITLE
Mark the V-Sync project setting to require an editor restart

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -944,7 +944,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", false);
 	}
 
-	video_mode.use_vsync = GLOBAL_DEF("display/window/vsync/use_vsync", true);
+	video_mode.use_vsync = GLOBAL_DEF_RST("display/window/vsync/use_vsync", true);
 	OS::get_singleton()->_use_vsync = video_mode.use_vsync;
 
 	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);


### PR DESCRIPTION
The V-Sync project setting also applies to the editor, but it will only take effect when the editor is restarted.

This was inspired by a [discussion on Reddit](https://www.reddit.com/r/godot/comments/cvi8ko/disabling_vsync_in_the_editor_is_there_a_way/).