### PR TITLE
[Mono] Various Color fixes and improvements

### DIFF
--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -369,8 +369,8 @@ bool Vector3::operator<(const Vector3 &p_v) const {
 
 bool Vector3::operator>(const Vector3 &p_v) const {
 
-	if (x == p_v.x) {
-		if (y == p_v.y)
+	if (Math::is_equal_approx(x, p_v.x)) {
+		if (Math::is_equal_approx(y, p_v.y))
 			return z > p_v.z;
 		else
 			return y > p_v.y;
@@ -393,8 +393,8 @@ bool Vector3::operator<=(const Vector3 &p_v) const {
 
 bool Vector3::operator>=(const Vector3 &p_v) const {
 
-	if (x == p_v.x) {
-		if (y == p_v.y)
+	if (Math::is_equal_approx(x, p_v.x)) {
+		if (Math::is_equal_approx(y, p_v.y))
 			return z >= p_v.z;
 		else
 			return y > p_v.y;

--- a/modules/mono/glue/Managed/Files/Color.cs
+++ b/modules/mono/glue/Managed/Files/Color.cs
@@ -16,7 +16,11 @@ namespace Godot
         {
             get
             {
-                return (int)(r * 255.0f);
+                return (int)Math.Round(r * 255.0f);
+            }
+            set
+            {
+                r = value / 255.0f;
             }
         }
 
@@ -24,7 +28,11 @@ namespace Godot
         {
             get
             {
-                return (int)(g * 255.0f);
+                return (int)Math.Round(g * 255.0f);
+            }
+            set
+            {
+                g = value / 255.0f;
             }
         }
 
@@ -32,7 +40,11 @@ namespace Godot
         {
             get
             {
-                return (int)(b * 255.0f);
+                return (int)Math.Round(b * 255.0f);
+            }
+            set
+            {
+                b = value / 255.0f;
             }
         }
 
@@ -40,7 +52,11 @@ namespace Godot
         {
             get
             {
-                return (int)(a * 255.0f);
+                return (int)Math.Round(a * 255.0f);
+            }
+            set
+            {
+                a = value / 255.0f;
             }
         }
 
@@ -74,7 +90,7 @@ namespace Godot
             }
             set
             {
-                this = FromHsv(value, s, v);
+                this = FromHsv(value, s, v, a);
             }
         }
 
@@ -91,7 +107,7 @@ namespace Godot
             }
             set
             {
-                this = FromHsv(h, value, v);
+                this = FromHsv(h, value, v, a);
             }
         }
 
@@ -103,7 +119,7 @@ namespace Godot
             }
             set
             {
-                this = FromHsv(h, s, value);
+                this = FromHsv(h, s, value, a);
             }
         }
 
@@ -166,12 +182,12 @@ namespace Godot
             }
         }
 
-        public static void ToHsv(Color color, out float hue, out float saturation, out float value)
+        public void ToHsv(out float hue, out float saturation, out float value)
         {
-            int max = Mathf.Max(color.r8, Mathf.Max(color.g8, color.b8));
-            int min = Mathf.Min(color.r8, Mathf.Min(color.g8, color.b8));
+            float max = (float)Mathf.Max(r, Mathf.Max(g, b));
+            float min = (float)Mathf.Min(r, Mathf.Min(g, b));
 
-            int delta = max - min;
+            float delta = max - min;
 
             if (delta == 0)
             {
@@ -179,12 +195,12 @@ namespace Godot
             }
             else
             {
-                if (color.r == max)
-                    hue = (color.g - color.b) / delta; // Between yellow & magenta
-                else if (color.g == max)
-                    hue = 2 + (color.b - color.r) / delta; // Between cyan & yellow
+                if (r == max)
+                    hue = (g - b) / delta; // Between yellow & magenta
+                else if (g == max)
+                    hue = 2 + (b - r) / delta; // Between cyan & yellow
                 else
-                    hue = 4 + (color.r - color.g) / delta; // Between magenta & cyan
+                    hue = 4 + (r - g) / delta; // Between magenta & cyan
 
                 hue /= 6.0f;
 
@@ -193,7 +209,7 @@ namespace Godot
             }
 
             saturation = max == 0 ? 0 : 1f - 1f * min / max;
-            value = max / 255f;
+            value = max;
         }
 
         public static Color FromHsv(float hue, float saturation, float value, float alpha = 1.0f)
@@ -257,7 +273,8 @@ namespace Godot
             return new Color(
                 (r + 0.5f) % 1.0f,
                 (g + 0.5f) % 1.0f,
-                (b + 0.5f) % 1.0f
+                (b + 0.5f) % 1.0f,
+                a
             );
         }
 
@@ -275,7 +292,8 @@ namespace Godot
             return new Color(
                 1.0f - r,
                 1.0f - g,
-                1.0f - b
+                1.0f - b,
+                a
             );
         }
 

--- a/modules/mono/glue/Managed/Files/Colors.cs
+++ b/modules/mono/glue/Managed/Files/Colors.cs
@@ -141,6 +141,7 @@ namespace Godot
             {"teal", new Color(0.00f, 0.50f, 0.50f)},
             {"thistle", new Color(0.85f, 0.75f, 0.85f)},
             {"tomato", new Color(1.00f, 0.39f, 0.28f)},
+            {"transparent", new Color(1.00f, 1.00f, 1.00f, 0.00f)},
             {"turquoise", new Color(0.25f, 0.88f, 0.82f)},
             {"violet", new Color(0.93f, 0.51f, 0.93f)},
             {"webgreen", new Color(0.00f, 0.50f, 0.00f)},
@@ -187,7 +188,7 @@ namespace Godot
         public static Color DarkOrchid { get { return namedColors["darkorchid"]; } }
         public static Color DarkRed { get { return namedColors["darkred"]; } }
         public static Color DarkSalmon { get { return namedColors["darksalmon"]; } }
-        public static Color DarkSeagreen { get { return namedColors["darkseagreen"]; } }
+        public static Color DarkSeaGreen { get { return namedColors["darkseagreen"]; } }
         public static Color DarkSlateBlue { get { return namedColors["darkslateblue"]; } }
         public static Color DarkSlateGray { get { return namedColors["darkslategray"]; } }
         public static Color DarkTurquoise { get { return namedColors["darkturquoise"]; } }
@@ -288,6 +289,7 @@ namespace Godot
         public static Color Teal { get { return namedColors["teal"]; } }
         public static Color Thistle { get { return namedColors["thistle"]; } }
         public static Color Tomato { get { return namedColors["tomato"]; } }
+        public static Color Transparent { get { return namedColors["transparent"]; } }
         public static Color Turquoise { get { return namedColors["turquoise"]; } }
         public static Color Violet { get { return namedColors["violet"]; } }
         public static Color WebGreen { get { return namedColors["webgreen"]; } }


### PR DESCRIPTION
* Fix `Color.ToHSV()`. Previously it was comparing bytes to floats... which does not work at all. We don't need bytes anywhere in here. I also changed it to be non-static, which technically breaks compat, but considering the method didn't work previously anyway...

* Fix setters for HSV, contrasted, and inverted methods not preserving the alpha value.

* Fix `r8`/`g8`/`b8`/`a8` not rounding. Seems that I missed this back in #18282. 

* Add setters for `r8`/`g8`/`b8`/`a8`.

* I compared `Colors.cs` with `System.Drawing.Color`. I fixed one spelling error (`DarkSeagreen` -> `DarkSeaGreen`) and added `Transparent` which was the only color we don't have. Interestingly, `Transparent` does exist in core already in `color_names.inc`.

I also slid in an equality fix to C++ Vector3 > and >=, which was a copy-paste error from #31094. This is so small of a fix that I figured it doesn't need a PR of its own.