### PR TITLE
Typo fix: "differt" -> "different"

### DIFF
--- a/servers/arvr/arvr_interface.h
+++ b/servers/arvr/arvr_interface.h
@@ -39,7 +39,7 @@
 /**
 	@author Bastiaan Olij <mux213@gmail.com>
 
-	The ARVR interface is a template class ontop of which we build interface to differt AR, VR and tracking SDKs.
+	The ARVR interface is a template class ontop of which we build interface to different AR, VR and tracking SDKs.
 	The idea is that we subclass this class, implement the logic, and then instantiate a singleton of each interface
 	when Godot starts. These instances do not initialize themselves but register themselves with the AR/VR server.
 


### PR DESCRIPTION
Typo fix: "differt" -> "different"

(Also: lol @ https://github.com/godotengine/godot/blob/baab976d0f2853231e8ea2f048f4a32334d635b8/servers/arvr/arvr_interface.h#L64 )