### PR TITLE
Remove check for class_name and extends order

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3366,7 +3366,7 @@ void GDScriptParser::_parse_extends(ClassNode *p_class) {
 		return;
 	}
 
-	if (!p_class->constant_expressions.empty() || !p_class->subclasses.empty() || !p_class->functions.empty() || !p_class->variables.empty() || p_class->classname_used) {
+	if (!p_class->constant_expressions.empty() || !p_class->subclasses.empty() || !p_class->functions.empty() || !p_class->variables.empty()) {
 
 		_set_error("\"extends\" must be used before anything else.");
 		return;


### PR DESCRIPTION
Closes #31056. Fixes #29345.

No matter how hard I tried, I could not reproduce #24364; when I managed to get close, just alt-tabbing the editor fixed it.

@Zylann would be nice if you can provide a reproduction project for #24364; especially one that remains buggy across restarting and defocusing the editor.

CC @lupoDharkael since this is a partial revert of #27987.