### PR TITLE
GDScript: Disable LSP if either jsonrpc or websocket are disabled

### DIFF
--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -8,5 +8,12 @@ env_gdscript = env_modules.Clone()
 env_gdscript.add_source_files(env.modules_sources, "*.cpp")
 
 if env['tools']:
-	env_gdscript.add_source_files(env.modules_sources, "./editor/*.cpp")
-	env_gdscript.add_source_files(env.modules_sources, "./language_server/*.cpp")
+    env_gdscript.add_source_files(env.modules_sources, "./editor/*.cpp")
+
+    # Those two modules are required for the language server protocol
+    if env['module_jsonrpc_enabled'] and env['module_websocket_enabled']:
+        env_gdscript.add_source_files(env.modules_sources, "./language_server/*.cpp")
+    else:
+        # Using a define in the disabled case, to avoid having an extra define
+        # in regular builds where all modules are enabled.
+        env_gdscript.Append(CPPDEFINES=['GDSCRIPT_NO_LSP'])

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -34,10 +34,8 @@
 #include "core/io/resource_loader.h"
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
-#include "editor/gdscript_highlighter.h"
 #include "gdscript.h"
 #include "gdscript_tokenizer.h"
-#include "language_server/gdscript_language_server.h"
 
 GDScriptLanguage *script_language_gd = NULL;
 Ref<ResourceFormatLoaderGDScript> resource_loader_gd;
@@ -45,10 +43,15 @@ Ref<ResourceFormatSaverGDScript> resource_saver_gd;
 
 #ifdef TOOLS_ENABLED
 
-#include "core/engine.h"
 #include "editor/editor_export.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
+#include "editor/gdscript_highlighter.h"
+
+#ifndef GDSCRIPT_NO_LSP
+#include "core/engine.h"
+#include "language_server/gdscript_language_server.h"
+#endif // !GDSCRIPT_NO_LSP
 
 class EditorExportGDScript : public EditorExportPlugin {
 
@@ -137,13 +140,15 @@ static void _editor_init() {
 	gd_export.instance();
 	EditorExport::get_singleton()->add_export_plugin(gd_export);
 
+#ifndef GDSCRIPT_NO_LSP
 	register_lsp_types();
 	GDScriptLanguageServer *lsp_plugin = memnew(GDScriptLanguageServer);
 	EditorNode::get_singleton()->add_editor_plugin(lsp_plugin);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GDScriptLanguageProtocol", GDScriptLanguageProtocol::get_singleton()));
+#endif // !GDSCRIPT_NO_LSP
 }
 
-#endif
+#endif // TOOLS_ENABLED
 
 void register_gdscript_types() {
 
@@ -162,7 +167,7 @@ void register_gdscript_types() {
 #ifdef TOOLS_ENABLED
 	ScriptEditor::register_create_syntax_highlighter_function(GDScriptSyntaxHighlighter::create);
 	EditorNode::add_init_callback(_editor_init);
-#endif
+#endif // TOOLS_ENABLED
 }
 
 void unregister_gdscript_types() {


### PR DESCRIPTION
Follow-up to #29780, solves this comment: https://github.com/godotengine/godot/pull/29780#discussion_r318520008

CC @Geequlim @ankitpriyarup 