### PR TITLE
Add a project description setting

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1000,6 +1000,8 @@ ProjectSettings::ProjectSettings() {
 	Ref<InputEventJoypadButton> joyb;
 
 	GLOBAL_DEF("application/config/name", "");
+	GLOBAL_DEF("application/config/description", "");
+	custom_prop_info["application/config/description"] = PropertyInfo(Variant::STRING, "application/config/description", PROPERTY_HINT_MULTILINE_TEXT);
 	GLOBAL_DEF("application/run/main_scene", "");
 	custom_prop_info["application/run/main_scene"] = PropertyInfo(Variant::STRING, "application/run/main_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res");
 	GLOBAL_DEF("application/run/disable_stdout", false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -180,6 +180,9 @@
 			This user directory is used for storing persistent data ([code]user://[/code] filesystem). If left empty, [code]user://[/code] resolves to a project-specific folder in Godot's own configuration folder (see [method OS.get_user_data_dir]). If a custom directory name is defined, this name will be used instead and appended to the system-specific user data directory (same parent folder as the Godot configuration folder documented in [method OS.get_user_data_dir]).
 			The [member application/config/use_custom_user_dir] setting must be enabled for this to take effect.
 		</member>
+		<member name="application/config/description" type="String" setter="" getter="" default="&quot;&quot;">
+			The project's description, displayed as a tooltip in the Project Manager when hovering the project.
+		</member>
 		<member name="application/config/icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon used for the project, set when project loads. Exporters will also use this icon when possible.
 		</member>

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -955,6 +955,7 @@ public:
 	struct Item {
 		String project_key;
 		String project_name;
+		String description;
 		String path;
 		String icon;
 		String main_scene;
@@ -970,6 +971,7 @@ public:
 
 		Item(const String &p_project,
 				const String &p_name,
+				const String &p_description,
 				const String &p_path,
 				const String &p_icon,
 				const String &p_main_scene,
@@ -981,6 +983,7 @@ public:
 
 			project_key = p_project;
 			project_name = p_name;
+			description = p_description;
 			path = p_path;
 			icon = p_icon;
 			main_scene = p_main_scene;
@@ -1149,6 +1152,7 @@ void ProjectList::load_project_data(const String &p_property_key, Item &p_item, 
 		grayed = true;
 	}
 
+	String description = cf->get_value("application", "config/description", "");
 	String icon = cf->get_value("application", "config/icon", "");
 	String main_scene = cf->get_value("application", "run/main_scene", "");
 
@@ -1170,7 +1174,7 @@ void ProjectList::load_project_data(const String &p_property_key, Item &p_item, 
 
 	String project_key = p_property_key.get_slice("/", 1);
 
-	p_item = Item(project_key, project_name, path, icon, main_scene, last_modified, p_favorite, grayed, missing, config_version);
+	p_item = Item(project_key, project_name, description, path, icon, main_scene, last_modified, p_favorite, grayed, missing, config_version);
 }
 
 void ProjectList::load_projects() {
@@ -1249,6 +1253,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	hb->connect("draw", this, "_panel_draw", varray(hb));
 	hb->connect("gui_input", this, "_panel_input", varray(hb));
 	hb->add_constant_override("separation", 10 * EDSCALE);
+	hb->set_tooltip(item.description);
 
 	VBoxContainer *favorite_box = memnew(VBoxContainer);
 	favorite_box->set_name("FavoriteBox");


### PR DESCRIPTION
The description is displayed as a tooltip when hovering the project in the Project Manager. It can span multiple lines.

This partially addresses #8167.