### PR TITLE
Throw error when canvas background is used without sample buffer

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4335,6 +4335,10 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 			if (storage->frame.current_rt->buffers.active) {
 				current_fbo = storage->frame.current_rt->buffers.fbo;
 			} else {
+				if (storage->frame.current_rt->effects.mip_maps[0].sizes.size() == 0) {
+					ERR_PRINT_ONCE("Can't use canvas background mode in a render target configured without sampling");
+					return;
+				}
 				current_fbo = storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo;
 			}
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/16226

_edit:_ I have updated this PR with a completely different approach. After spending some more time with it, I realized that the render_empty_scene call is needed to actually render the canvas background. So the real problem is that in order to use a canvas background, by nature you have to sample the main buffer. So using "2D - No Sampling" shouldn't be allowed. My new solution is to throw an error and to exit the render_scene function. 