### PR TITLE
Fix wrong offset in Button when alignment is set to left

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -15,7 +15,7 @@
 			Text alignment policy for the button's text, use one of the [code]ALIGN_*[/code] constants.
 		</member>
 		<member name="clip_text" type="bool" setter="set_clip_text" getter="get_clip_text" default="false">
-			When this property is enabled, text that is too large to fit the button is clipped, when disabled the Button will always be wide enough to hold the text. This property is disabled by default.
+			When this property is enabled, text that is too large to fit the button is clipped, when disabled the Button will always be wide enough to hold the text.
 		</member>
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" default="false">
 			Flat buttons don't display decoration.

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -159,7 +159,11 @@ void Button::_notification(int p_what) {
 
 		switch (align) {
 			case ALIGN_LEFT: {
-				text_ofs.x = style->get_margin(MARGIN_LEFT) + icon_ofs.x + _internal_margin[MARGIN_LEFT] + get_constant("hseparation");
+				if (_internal_margin[MARGIN_LEFT] > 0) {
+					text_ofs.x = style->get_margin(MARGIN_LEFT) + icon_ofs.x + _internal_margin[MARGIN_LEFT] + get_constant("hseparation");
+				} else {
+					text_ofs.x = style->get_margin(MARGIN_LEFT) + icon_ofs.x;
+				}
 				text_ofs.y += style->get_offset().y;
 			} break;
 			case ALIGN_CENTER: {


### PR DESCRIPTION
When a `Button`'s `Align` property is set to "Left", its offset is not quite correct. This can be seen by having it in its minimal horizontal size in comparison with the other alignments:
![Screenshot_20190828_232352](https://user-images.githubusercontent.com/30739239/63905590-376bc380-ca04-11e9-89be-cca97a048ccd.png)