### PR TITLE
Add transform methods for PoolVector*Array

### DIFF
--- a/core/math/transform.h
+++ b/core/math/transform.h
@@ -34,6 +34,7 @@
 #include "core/math/aabb.h"
 #include "core/math/basis.h"
 #include "core/math/plane.h"
+#include "core/pool_vector.h"
 
 class Transform {
 public:
@@ -81,6 +82,9 @@ public:
 
 	_FORCE_INLINE_ AABB xform(const AABB &p_aabb) const;
 	_FORCE_INLINE_ AABB xform_inv(const AABB &p_aabb) const;
+
+	_FORCE_INLINE_ PoolVector<Vector3> xform(const PoolVector<Vector3> &p_array) const;
+	_FORCE_INLINE_ PoolVector<Vector3> xform_inv(const PoolVector<Vector3> &p_array) const;
 
 	void operator*=(const Transform &p_transform);
 	Transform operator*(const Transform &p_transform) const;
@@ -196,6 +200,34 @@ _FORCE_INLINE_ AABB Transform::xform_inv(const AABB &p_aabb) const {
 	}
 
 	return ret;
+}
+
+PoolVector<Vector3> Transform::xform(const PoolVector<Vector3> &p_array) const {
+
+	PoolVector<Vector3> array;
+	array.resize(p_array.size());
+
+	PoolVector<Vector3>::Read r = p_array.read();
+	PoolVector<Vector3>::Write w = array.write();
+
+	for (int i = 0; i < p_array.size(); ++i) {
+		w[i] = xform(r[i]);
+	}
+	return array;
+}
+
+PoolVector<Vector3> Transform::xform_inv(const PoolVector<Vector3> &p_array) const {
+
+	PoolVector<Vector3> array;
+	array.resize(p_array.size());
+
+	PoolVector<Vector3>::Read r = p_array.read();
+	PoolVector<Vector3>::Write w = array.write();
+
+	for (int i = 0; i < p_array.size(); ++i) {
+		w[i] = xform_inv(r[i]);
+	}
+	return array;
 }
 
 #endif // TRANSFORM_H

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -32,6 +32,7 @@
 #define TRANSFORM_2D_H
 
 #include "core/math/rect2.h" // also includes vector2, math_funcs, and ustring
+#include "core/pool_vector.h"
 
 struct Transform2D {
 	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of elements array, the basis matrix looks like "on paper":
@@ -110,6 +111,8 @@ struct Transform2D {
 	_FORCE_INLINE_ Vector2 xform_inv(const Vector2 &p_vec) const;
 	_FORCE_INLINE_ Rect2 xform(const Rect2 &p_rect) const;
 	_FORCE_INLINE_ Rect2 xform_inv(const Rect2 &p_rect) const;
+	_FORCE_INLINE_ PoolVector<Vector2> xform(const PoolVector<Vector2> &p_array) const;
+	_FORCE_INLINE_ PoolVector<Vector2> xform_inv(const PoolVector<Vector2> &p_array) const;
 
 	operator String() const;
 
@@ -197,6 +200,34 @@ Rect2 Transform2D::xform_inv(const Rect2 &p_rect) const {
 	new_rect.expand_to(ends[3]);
 
 	return new_rect;
+}
+
+PoolVector<Vector2> Transform2D::xform(const PoolVector<Vector2> &p_array) const {
+
+	PoolVector<Vector2> array;
+	array.resize(p_array.size());
+
+	PoolVector<Vector2>::Read r = p_array.read();
+	PoolVector<Vector2>::Write w = array.write();
+
+	for (int i = 0; i < p_array.size(); ++i) {
+		w[i] = xform(r[i]);
+	}
+	return array;
+}
+
+PoolVector<Vector2> Transform2D::xform_inv(const PoolVector<Vector2> &p_array) const {
+
+	PoolVector<Vector2> array;
+	array.resize(p_array.size());
+
+	PoolVector<Vector2>::Read r = p_array.read();
+	PoolVector<Vector2>::Write w = array.write();
+
+	for (int i = 0; i < p_array.size(); ++i) {
+		w[i] = xform_inv(r[i]);
+	}
+	return array;
 }
 
 #endif // TRANSFORM_2D_H

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -751,6 +751,7 @@ struct _VariantCall {
 
 			case Variant::VECTOR2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform(p_args[0]->operator Vector2()); return;
 			case Variant::RECT2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform(p_args[0]->operator Rect2()); return;
+			case Variant::POOL_VECTOR2_ARRAY: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform(p_args[0]->operator PoolVector2Array()); return;
 			default: r_ret = Variant();
 		}
 	}
@@ -761,6 +762,7 @@ struct _VariantCall {
 
 			case Variant::VECTOR2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Vector2()); return;
 			case Variant::RECT2: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Rect2()); return;
+			case Variant::POOL_VECTOR2_ARRAY: r_ret = reinterpret_cast<Transform2D *>(p_self._data._ptr)->xform_inv(p_args[0]->operator PoolVector2Array()); return;
 			default: r_ret = Variant();
 		}
 	}
@@ -817,6 +819,7 @@ struct _VariantCall {
 			case Variant::VECTOR3: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator Vector3()); return;
 			case Variant::PLANE: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator Plane()); return;
 			case Variant::AABB: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator ::AABB()); return;
+			case Variant::POOL_VECTOR3_ARRAY: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform(p_args[0]->operator ::PoolVector3Array()); return;
 			default: r_ret = Variant();
 		}
 	}
@@ -828,6 +831,7 @@ struct _VariantCall {
 			case Variant::VECTOR3: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Vector3()); return;
 			case Variant::PLANE: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator Plane()); return;
 			case Variant::AABB: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator ::AABB()); return;
+			case Variant::POOL_VECTOR3_ARRAY: r_ret = reinterpret_cast<Transform *>(p_self._data._ptr)->xform_inv(p_args[0]->operator ::PoolVector3Array()); return;
 			default: r_ret = Variant();
 		}
 	}

--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -144,7 +144,7 @@
 			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
-				Transforms the given [Vector3], [Plane], or [AABB] by this transform.
+				Transforms the given [Vector3], [Plane], [AABB], or [PoolVector3Array] by this transform.
 			</description>
 		</method>
 		<method name="xform_inv">
@@ -153,7 +153,7 @@
 			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
-				Inverse-transforms the given [Vector3], [Plane], or [AABB] by this transform.
+				Inverse-transforms the given [Vector3], [Plane], [AABB], or [PoolVector3Array] by this transform.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -146,7 +146,7 @@
 			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
-				Transforms the given [Vector2] or [Rect2] by this transform.
+				Transforms the given [Vector2], [Rect2], or [PoolVector2Array] by this transform.
 			</description>
 		</method>
 		<method name="xform_inv">
@@ -155,7 +155,7 @@
 			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
-				Inverse-transforms the given [Vector2] or [Rect2] by this transform.
+				Inverse-transforms the given [Vector2], [Rect2], or [PoolVector2Array] by this transform.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Added array version of `Vector2` transforms in 2D and `Vector3` in 3D.

`PoolVector2Array` and `PoolVector3Array` were the only missing Variant types in both `Transform2D` and `Transform` respectively.

This should simplify use cases where the points needs to be transformed in batch, and it's not limited to drawing.

This should also help polygon transformations to aid boolean operations: #28987. I'd like to remove exposed `transform_points_2d` there which was included for the same reason if this gets merged (I wasn't aware of this feature myself).

It's going to become as easy as:
```gdscript
points = Transform2D(0, Vector2(100, 100).xform(points)
```
Instead of:
```gdscript
var points_transformed = []
var trans = Transform2D(0, Vector2(100, 100)
for p in points:
	points_transformed.append(trans.xform(p))
```

### Test project
[xform-pool-vector-array.zip](https://github.com/godotengine/godot/files/3555404/xform-pool-vector-array.zip)

