### PR TITLE
Tweak the editor window dimming intensity, remove dim fade animation

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2632,11 +2632,8 @@ void EditorNode::_exit_editor() {
 	resource_preview->stop(); //stop early to avoid crashes
 	_save_docks();
 
-	// Dim the editor window while it's quitting to make it clearer that it's busy.
-	// No transition is applied, as the effect needs to be visible immediately
-	float c = 0.4f;
-	Color dim_color = Color(c, c, c);
-	gui_base->set_modulate(dim_color);
+	// Dim the editor window while it's quitting to make it clearer that it's busy
+	dim_editor(true, true);
 
 	get_tree()->quit();
 }
@@ -5133,46 +5130,12 @@ void EditorNode::_open_imported() {
 	load_scene(open_import_request, true, false, true, true);
 }
 
-void EditorNode::dim_editor(bool p_dimming) {
-	static int dim_count = 0;
-	bool dim_ui = EditorSettings::get_singleton()->get("interface/editor/dim_editor_on_dialog_popup");
-	if (p_dimming) {
-		if (dim_ui && dim_count == 0) {
-			_start_dimming(true);
-		}
-		dim_count++;
+void EditorNode::dim_editor(bool p_dimming, bool p_force_dim) {
+	// Dimming can be forced regardless of the editor setting, which is useful when quitting the editor
+	if ((p_force_dim || EditorSettings::get_singleton()->get("interface/editor/dim_editor_on_dialog_popup")) && p_dimming) {
+		gui_base->set_modulate(Color(0.5, 0.5, 0.5));
 	} else {
-		if (dim_count == 1) {
-			_start_dimming(false);
-		}
-		if (dim_count > 0) {
-			dim_count--;
-		} else {
-			ERR_PRINT("Undimmed before dimming!");
-		}
-	}
-}
-
-void EditorNode::_start_dimming(bool p_dimming) {
-	_dimming = p_dimming;
-	_dim_time = 0.0f;
-	_dim_timer->start();
-}
-
-void EditorNode::_dim_timeout() {
-
-	_dim_time += _dim_timer->get_wait_time();
-	float wait_time = 0.08f;
-	float c = 0.4f;
-
-	Color base = _dimming ? Color(1, 1, 1) : Color(c, c, c);
-	Color final = _dimming ? Color(c, c, c) : Color(1, 1, 1);
-
-	if (_dim_time + _dim_timer->get_wait_time() >= wait_time) {
-		gui_base->set_modulate(final);
-		_dim_timer->stop();
-	} else {
-		gui_base->set_modulate(base.linear_interpolate(final, _dim_time / wait_time));
+		gui_base->set_modulate(Color(1, 1, 1));
 	}
 }
 
@@ -5356,7 +5319,6 @@ void EditorNode::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_open_imported"), &EditorNode::_open_imported);
 	ClassDB::bind_method(D_METHOD("_inherit_imported"), &EditorNode::_inherit_imported);
-	ClassDB::bind_method(D_METHOD("_dim_timeout"), &EditorNode::_dim_timeout);
 
 	ClassDB::bind_method("_copy_warning", &EditorNode::_copy_warning);
 
@@ -6686,13 +6648,6 @@ EditorNode::EditorNode() {
 	FileAccess::set_file_close_fail_notify_callback(_file_access_close_error_notify);
 
 	waiting_for_first_scan = true;
-
-	_dimming = false;
-	_dim_time = 0.0f;
-	_dim_timer = memnew(Timer);
-	_dim_timer->set_wait_time(0.01666f);
-	_dim_timer->connect("timeout", this, "_dim_timeout");
-	add_child(_dim_timer);
 
 	print_handler.printfunc = _print_handler;
 	print_handler.userdata = this;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -633,13 +633,6 @@ private:
 	static int build_callback_count;
 	static EditorBuildCallback build_callbacks[MAX_BUILD_CALLBACKS];
 
-	bool _dimming;
-	float _dim_time;
-	Timer *_dim_timer;
-
-	void _start_dimming(bool p_dimming);
-	void _dim_timeout();
-
 	void _license_tree_selected();
 
 	void _update_update_spinner();
@@ -849,7 +842,7 @@ public:
 	void save_scene_list(Vector<String> p_scene_filenames);
 	void restart_editor();
 
-	void dim_editor(bool p_dimming);
+	void dim_editor(bool p_dimming, bool p_force_dim = false);
 
 	void edit_current() { _edit_current(); };
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1754,7 +1754,7 @@ void ProjectManager::_dim_window() {
 
 	// Dim the project manager window while it's quitting to make it clearer that it's busy.
 	// No transition is applied, as the effect needs to be visible immediately
-	float c = 0.4f;
+	float c = 0.5f;
 	Color dim_color = Color(c, c, c);
 	gui_base->set_modulate(dim_color);
 }


### PR DESCRIPTION
The fade animation tended to give the editor a "sluggish" feel when running at lower FPS (which is common in heavy 3D scenes), so it's probably a good idea to remove it.

This also makes dimming less intense (50% instead of 60%).