### PR TITLE
Project export path fix

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -150,10 +150,13 @@ void EditorExportPreset::set_export_path(const String &p_path) {
 	export_path = p_path;
 	/* NOTE(SonerSound): if there is a need to implement a PropertyHint that specifically indicates a relative path,
 	 * this should be removed. */
+	/* Setting folder to relative does not seem to be working with project export dialog. */
+	/*
 	if (export_path.is_abs_path()) {
 		String res_path = OS::get_singleton()->get_resource_dir();
 		export_path = res_path.path_to_file(export_path);
 	}
+	*/
 	EditorExport::singleton->save_presets();
 }
 


### PR DESCRIPTION
Setting relative path for export does not seem to be working with the export path folder dialog.

Let me know if this should be handled differently.

Fixes #31427

![test](https://user-images.githubusercontent.com/4707543/63962921-d4a91500-ca61-11e9-9ccf-abf11dc8b3ed.gif)
