### PR TITLE
Persist ColorPicker color mode

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5637,6 +5637,8 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("interface/inspector/horizontal_vector_types_editing", true);
 	EDITOR_DEF("interface/inspector/open_resources_in_current_inspector", true);
 	EDITOR_DEF("interface/inspector/resources_to_open_in_new_inspector", "SpatialMaterial,Script,MeshLibrary,TileSet");
+	EDITOR_DEF("interface/inspector/default_color_picker_mode", 0);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_color_picker_mode", PROPERTY_HINT_ENUM, "RGB,HSV,RAW", PROPERTY_USAGE_DEFAULT));
 	EDITOR_DEF("run/auto_save/save_before_running", true);
 
 	theme_base = memnew(Control);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1842,10 +1842,20 @@ void EditorPropertyColor::_popup_closed() {
 	emit_changed(get_edited_property(), picker->get_pick_color(), "", false);
 }
 
+void EditorPropertyColor::_picker_created() {
+	// get default color picker mode from editor settings
+	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
+	if (default_color_mode == 1)
+		picker->get_picker()->set_hsv_mode(true);
+	else if (default_color_mode == 2)
+		picker->get_picker()->set_raw_mode(true);
+}
+
 void EditorPropertyColor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_color_changed"), &EditorPropertyColor::_color_changed);
 	ClassDB::bind_method(D_METHOD("_popup_closed"), &EditorPropertyColor::_popup_closed);
+	ClassDB::bind_method(D_METHOD("_picker_created"), &EditorPropertyColor::_picker_created);
 }
 
 void EditorPropertyColor::update_property() {
@@ -1864,6 +1874,7 @@ EditorPropertyColor::EditorPropertyColor() {
 	picker->set_flat(true);
 	picker->connect("color_changed", this, "_color_changed");
 	picker->connect("popup_closed", this, "_popup_closed");
+	picker->connect("picker_created", this, "_picker_created");
 }
 
 ////////////// NODE PATH //////////////////////

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -493,6 +493,7 @@ class EditorPropertyColor : public EditorProperty {
 	ColorPickerButton *picker;
 	void _color_changed(const Color &p_color);
 	void _popup_closed();
+	void _picker_created();
 
 protected:
 	static void _bind_methods();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1741,6 +1741,13 @@ ScriptTextEditor::ScriptTextEditor() {
 	color_panel->add_child(color_picker);
 	color_picker->connect("color_changed", this, "_color_changed");
 
+	// get default color picker mode from editor settings
+	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
+	if (default_color_mode == 1)
+		color_picker->set_hsv_mode(true);
+	else if (default_color_mode == 2)
+		color_picker->set_raw_mode(true);
+
 	edit_hb = memnew(HBoxContainer);
 
 	edit_menu = memnew(MenuButton);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -859,6 +859,13 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				add_child(color_picker);
 				color_picker->hide();
 				color_picker->connect("color_changed", this, "_color_changed");
+
+				// get default color picker mode from editor settings
+				int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
+				if (default_color_mode == 1)
+					color_picker->set_hsv_mode(true);
+				else if (default_color_mode == 2)
+					color_picker->set_raw_mode(true);
 			}
 
 			color_picker->show();

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -964,6 +964,7 @@ void ColorPickerButton::_update_picker() {
 		popup->connect("popup_hide", this, "set_pressed", varray(false));
 		picker->set_pick_color(color);
 		picker->set_edit_alpha(edit_alpha);
+		emit_signal("picker_created");
 	}
 }
 
@@ -980,6 +981,7 @@ void ColorPickerButton::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("color_changed", PropertyInfo(Variant::COLOR, "color")));
 	ADD_SIGNAL(MethodInfo("popup_closed"));
+	ADD_SIGNAL(MethodInfo("picker_created"));
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_pick_color", "get_pick_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "edit_alpha"), "set_edit_alpha", "is_editing_alpha");
 }


### PR DESCRIPTION
Color mode will be saved and retrieved from project metadata in EditorSettings.
Need for using a default color picker has been eliminated as this will set the last used mode by the user.

Fixes #30755 and #30754

![test](https://user-images.githubusercontent.com/4707543/63981620-d688cd80-ca8d-11e9-8da6-14be5948c256.gif)
