### PR TITLE
Fix editor's GraphEdit lines color on light theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -995,8 +995,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// GraphEdit
 	theme->set_stylebox("bg", "GraphEdit", style_tree_bg);
-	theme->set_color("grid_major", "GraphEdit", Color(1.0, 1.0, 1.0, 0.15));
-	theme->set_color("grid_minor", "GraphEdit", Color(1.0, 1.0, 1.0, 0.07));
+	if (dark_theme) {
+		theme->set_color("grid_major", "GraphEdit", Color(1.0, 1.0, 1.0, 0.15));
+		theme->set_color("grid_minor", "GraphEdit", Color(1.0, 1.0, 1.0, 0.07));
+	} else {
+		theme->set_color("grid_major", "GraphEdit", Color(0.0, 0.0, 0.0, 0.15));
+		theme->set_color("grid_minor", "GraphEdit", Color(0.0, 0.0, 0.0, 0.07));
+	}
 	theme->set_color("activity", "GraphEdit", accent_color);
 	theme->set_icon("minus", "GraphEdit", theme->get_icon("ZoomLess", "EditorIcons"));
 	theme->set_icon("more", "GraphEdit", theme->get_icon("ZoomMore", "EditorIcons"));


### PR DESCRIPTION
I guess this is not desired look

![image](https://user-images.githubusercontent.com/3036176/64007701-514cf980-cb1d-11e9-8e62-04b2dafa3677.png)

so I've changed it to

![image](https://user-images.githubusercontent.com/3036176/64007721-5a3dcb00-cb1d-11e9-9c1c-979de94b5745.png)
