### PR TITLE
Ignore the prefix and suffix in the SpinBox expression

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -53,7 +53,8 @@ void SpinBox::_text_entered(const String &p_string) {
 
 	Ref<Expression> expr;
 	expr.instance();
-	Error err = expr->parse(p_string);
+	// Ignore the prefix and suffix in the expression
+	Error err = expr->parse(p_string.trim_prefix(prefix + " ").trim_suffix(" " + suffix));
 	if (err != OK) {
 		return;
 	}


### PR DESCRIPTION
Follow-up to #31781.

This fixes a regression caused by 86a31e9e385c7909a0cdd24a5ee790c3dca03b98.