### PR TITLE
Increase line spacing in the editor help and asset library descriptions

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -54,6 +54,7 @@ void EditorHelp::_init_colors() {
 	qualifier_color = text_color * Color(1, 1, 1, 0.8);
 	type_color = get_color("accent_color", "Editor").linear_interpolate(text_color, 0.5);
 	class_desc->add_color_override("selection_color", get_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
+	class_desc->add_constant_override("line_separation", Math::round(5 * EDSCALE));
 }
 
 void EditorHelp::_unhandled_key_input(const Ref<InputEvent> &p_ev) {

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -290,6 +290,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	desc_vbox->add_child(description);
 	description->set_v_size_flags(SIZE_EXPAND_FILL);
 	description->connect("meta_clicked", this, "_link_click");
+	description->add_constant_override("line_separation", Math::round(5 * EDSCALE));
 
 	VBoxContainer *previews_vbox = memnew(VBoxContainer);
 	hbox->add_child(previews_vbox);


### PR DESCRIPTION
This makes for more readable text.

## Preview

### Editor help

![line_spacing_editor_help](https://user-images.githubusercontent.com/180032/64023268-3cca2a80-cb38-11e9-8e26-1c59a72b9222.png)

### Asset library item description

![line_spacing_assetlib_item_description](https://user-images.githubusercontent.com/180032/64023270-3d62c100-cb38-11e9-8233-0af02590c2ec.png)