### PR TITLE
Editor: remove TOOLS_ENABLED guards

### DIFF
--- a/editor/collada/collada.cpp
+++ b/editor/collada/collada.cpp
@@ -28,8 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef TOOLS_ENABLED
-
 #include "collada.h"
 
 #include <stdio.h>
@@ -2576,5 +2574,3 @@ Error Collada::load(const String &p_path, int p_flags) {
 
 Collada::Collada() {
 }
-
-#endif

--- a/editor/collada/collada.h
+++ b/editor/collada/collada.h
@@ -28,8 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef TOOLS_ENABLED
-
 #ifndef COLLADA_H
 #define COLLADA_H
 
@@ -647,5 +645,3 @@ private: // private stuff
 };
 
 #endif // COLLADA_H
-
-#endif

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1044,7 +1044,6 @@ void EditorInspectorSection::_notification(int p_what) {
 		Ref<Font> font = get_font("font", "Tree");
 		Ref<Texture> arrow;
 
-#ifdef TOOLS_ENABLED
 		if (foldable) {
 			if (object->editor_is_section_unfolded(section)) {
 				arrow = get_icon("arrow_up", "Tree");
@@ -1052,7 +1051,6 @@ void EditorInspectorSection::_notification(int p_what) {
 				arrow = get_icon("arrow", "Tree");
 			}
 		}
-#endif
 
 		Size2 size = get_size();
 		Point2 offset;
@@ -1087,7 +1085,6 @@ void EditorInspectorSection::_notification(int p_what) {
 
 		Ref<Texture> arrow;
 
-#ifdef TOOLS_ENABLED
 		if (foldable) {
 			if (object->editor_is_section_unfolded(section)) {
 				arrow = get_icon("arrow_up", "Tree");
@@ -1095,7 +1092,6 @@ void EditorInspectorSection::_notification(int p_what) {
 				arrow = get_icon("arrow", "Tree");
 			}
 		}
-#endif
 
 		Ref<Font> font = get_font("font", "Tree");
 
@@ -1155,7 +1151,6 @@ void EditorInspectorSection::setup(const String &p_section, const String &p_labe
 		vbox_added = true;
 	}
 
-#ifdef TOOLS_ENABLED
 	if (foldable) {
 		_test_unfold();
 		if (object->editor_is_section_unfolded(section)) {
@@ -1164,7 +1159,6 @@ void EditorInspectorSection::setup(const String &p_section, const String &p_labe
 			vbox->hide();
 		}
 	}
-#endif
 }
 
 void EditorInspectorSection::_gui_input(const Ref<InputEvent> &p_event) {
@@ -1172,7 +1166,6 @@ void EditorInspectorSection::_gui_input(const Ref<InputEvent> &p_event) {
 	if (!foldable)
 		return;
 
-#ifdef TOOLS_ENABLED
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
 
@@ -1191,7 +1184,6 @@ void EditorInspectorSection::_gui_input(const Ref<InputEvent> &p_event) {
 			vbox->hide();
 		}
 	}
-#endif
 }
 
 VBoxContainer *EditorInspectorSection::get_vbox() {
@@ -1205,11 +1197,9 @@ void EditorInspectorSection::unfold() {
 
 	_test_unfold();
 
-#ifdef TOOLS_ENABLED
 	object->editor_set_section_unfold(section, true);
 	vbox->show();
 	update();
-#endif
 }
 
 void EditorInspectorSection::fold() {
@@ -1219,11 +1209,9 @@ void EditorInspectorSection::fold() {
 	if (!vbox_added)
 		return; //kinda pointless
 
-#ifdef TOOLS_ENABLED
 	object->editor_set_section_unfold(section, false);
 	vbox->hide();
 	update();
-#endif
 }
 
 void EditorInspectorSection::_bind_methods() {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2540,7 +2540,7 @@ void EditorPropertyResource::update_property() {
 		if (res.is_valid() != assign->is_toggle_mode()) {
 			assign->set_toggle_mode(res.is_valid());
 		}
-#ifdef TOOLS_ENABLED
+
 		if (res.is_valid() && get_edited_object()->editor_is_section_unfolded(get_edited_property())) {
 
 			if (!sub_inspector) {
@@ -2609,7 +2609,6 @@ void EditorPropertyResource::update_property() {
 				}
 			}
 		}
-#endif
 	}
 
 	preview->set_texture(Ref<Texture>());

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -271,8 +271,6 @@ void EditorPropertyArray::update_property() {
 
 	edit->set_text(arrtype + " (size " + itos(array.call("size")) + ")");
 
-#ifdef TOOLS_ENABLED
-
 	bool unfolded = get_edited_object()->editor_is_section_unfolded(get_edited_property());
 	if (edit->is_pressed() != unfolded) {
 		edit->set_pressed(unfolded);
@@ -397,7 +395,6 @@ void EditorPropertyArray::update_property() {
 			vbox = NULL;
 		}
 	}
-#endif
 }
 
 void EditorPropertyArray::_remove_pressed(int p_index) {
@@ -642,8 +639,6 @@ void EditorPropertyDictionary::update_property() {
 	Dictionary dict = updated_val;
 
 	edit->set_text("Dictionary (size " + itos(dict.size()) + ")");
-
-#ifdef TOOLS_ENABLED
 
 	bool unfolded = get_edited_object()->editor_is_section_unfolded(get_edited_property());
 	if (edit->is_pressed() != unfolded) {
@@ -959,7 +954,6 @@ void EditorPropertyDictionary::update_property() {
 			vbox = NULL;
 		}
 	}
-#endif
 }
 
 void EditorPropertyDictionary::_object_id_selected(const String &p_property, ObjectID p_id) {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1436,8 +1436,6 @@ bool ScriptTextEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_
 	return false;
 }
 
-#ifdef TOOLS_ENABLED
-
 static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const Ref<Script> &script) {
 
 	if (p_edited_scene != p_current_node && p_current_node->get_owner() != p_edited_scene)
@@ -1456,14 +1454,6 @@ static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const
 
 	return NULL;
 }
-
-#else
-
-static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const Ref<Script> &script) {
-
-	return NULL;
-}
-#endif
 
 void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -74,14 +74,6 @@
 #define MIN_FOV 0.01
 #define MAX_FOV 179
 
-#ifdef TOOLS_ENABLED
-#define get_global_gizmo_transform get_global_gizmo_transform
-#define get_local_gizmo_transform get_local_gizmo_transform
-#else
-#define get_global_gizmo_transform get_global_transform
-#define get_local_gizmo_transform get_transform
-#endif
-
 void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 
 	bool is_orthogonal = camera->get_projection() == Camera::PROJECTION_ORTHOGONAL;


### PR DESCRIPTION
For code  inside editor/ `#ifdef TOOLS_ENABLED` is always true so those checks are redundant.