### PR TITLE
Fix object picking inside ViewportContainers

### DIFF
--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -211,4 +211,5 @@ ViewportContainer::ViewportContainer() {
 	stretch = false;
 	shrink = 1;
 	set_process_input(true);
+	set_process_unhandled_input(true);
 }


### PR DESCRIPTION
fixes #31802 

`ViewportContainer::_unhandled_input` won't be called without it.