### PR TITLE
Allow to import GIF files

### DIFF
--- a/core/animated_image.cpp
+++ b/core/animated_image.cpp
@@ -1,0 +1,189 @@
+/*************************************************************************/
+/*  animated_image.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "animated_image.h"
+
+LoadAnimatedImageFunction AnimatedImage::_load_gif = NULL;
+
+Error AnimatedImage::load_from_file(const String &p_path, int max_frames) {
+
+	clear();
+	String ext = p_path.get_extension().to_lower();
+	if (ext == "gif") {
+
+		Ref<AnimatedImage> animated_image = Ref<AnimatedImage>(this);
+		return _load_gif(animated_image, p_path, max_frames);
+	} else {
+
+		ERR_PRINTS("Unrecognized image: " + p_path);
+		return ERR_FILE_UNRECOGNIZED;
+	}
+}
+
+Error AnimatedImage::load_from_buffer(const PoolByteArray &p_data, int max_frames) {
+
+	clear();
+	if (p_data[0] == 'G') {
+
+		Ref<AnimatedImage> animated_image = Ref<AnimatedImage>(this);
+		return _load_gif(animated_image, p_data, max_frames);
+	} else {
+
+		ERR_PRINTS("Unrecognized image.");
+		return ERR_FILE_UNRECOGNIZED;
+	}
+}
+
+Ref<AnimatedTexture> AnimatedImage::to_animated_texture(uint32_t p_flags, int max_frames) const {
+
+	if (max_frames <= 0 || max_frames > AnimatedTexture::MAX_FRAMES)
+		max_frames = AnimatedTexture::MAX_FRAMES;
+
+	int frames_size = MIN(get_frames(), max_frames);
+
+	Ref<AnimatedTexture> animated_texture = memnew(AnimatedTexture);
+	animated_texture->set_fps(0); // Allow each frame to have a custom delay.
+
+	for (int i = 0; i < frames_size; i++) {
+
+		Ref<ImageTexture> texture = memnew(ImageTexture);
+		texture->create_from_image(frames[i].image, p_flags);
+		animated_texture->set_frame_texture(i, texture);
+		animated_texture->set_frame_delay(i, frames[i].delay);
+	}
+
+	animated_texture->set_frames(frames_size);
+
+	return animated_texture;
+}
+
+Ref<SpriteFrames> AnimatedImage::to_sprite_frames(uint32_t p_flags, int max_frames) const {
+
+	if (max_frames <= 0)
+		max_frames = get_frames();
+
+	int frames_size = MIN(get_frames(), max_frames);
+
+	Ref<SpriteFrames> sprite_frames = memnew(SpriteFrames);
+
+	float time = frames[0].delay;
+	for (int i = 0; i < frames_size; i++) {
+
+		Ref<ImageTexture> texture = memnew(ImageTexture);
+		texture->create_from_image(frames[i].image, p_flags);
+		sprite_frames->add_frame("default", texture);
+		time += frames[i].delay;
+	}
+
+	time /= max_frames; // Use the average time of all the frames.
+	sprite_frames->set_animation_speed("default", 1.0 / time);
+
+	return sprite_frames;
+}
+
+void AnimatedImage::add_frame(const Ref<Image> &p_image, float p_delay, int p_idx) {
+
+	ERR_FAIL_COND(p_idx > get_frames() - 1);
+	Frame frame;
+	frame.image = p_image;
+	frame.delay = p_delay;
+
+	if (p_idx < 0)
+		frames.push_back(frame);
+	else
+		frames.set(p_idx, frame);
+}
+
+void AnimatedImage::remove_frame(int p_idx) {
+
+	ERR_FAIL_COND(p_idx < 0);
+	ERR_FAIL_COND(p_idx > get_frames() - 1);
+	frames.remove(p_idx);
+}
+
+void AnimatedImage::set_image(int p_idx, const Ref<Image> &p_image) {
+
+	ERR_FAIL_COND(p_idx < 0);
+	ERR_FAIL_COND(p_idx > get_frames() - 1);
+	frames.write[p_idx].image = p_image;
+}
+
+Ref<Image> AnimatedImage::get_image(int p_idx) const {
+
+	ERR_FAIL_COND_V(p_idx < 0, Ref<Image>());
+	ERR_FAIL_COND_V(p_idx > get_frames() - 1, Ref<Image>());
+	return frames[p_idx].image;
+}
+
+void AnimatedImage::set_delay(int p_idx, float p_delay) {
+
+	ERR_FAIL_COND(p_idx < 0);
+	ERR_FAIL_COND(p_idx > get_frames() - 1);
+	frames.write[p_idx].delay = p_delay;
+}
+
+float AnimatedImage::get_delay(int p_idx) const {
+
+	ERR_FAIL_COND_V(p_idx < 0, 0);
+	ERR_FAIL_COND_V(p_idx > get_frames() - 1, 0);
+	return frames[p_idx].delay;
+}
+
+int AnimatedImage::get_frames() const {
+
+	return frames.size();
+}
+
+void AnimatedImage::clear() {
+
+	frames.clear();
+}
+
+void AnimatedImage::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("load_from_file", "path", "max_frames"), &AnimatedImage::load_from_file, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("load_from_buffer", "data", "max_frames"), &AnimatedImage::load_from_buffer, DEFVAL(0));
+
+	ClassDB::bind_method(D_METHOD("to_animated_texture", "flags", "max_frames"), &AnimatedImage::to_animated_texture, DEFVAL(0), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("to_sprite_frames", "flags", "max_frames"), &AnimatedImage::to_sprite_frames, DEFVAL(0), DEFVAL(0));
+
+	ClassDB::bind_method(D_METHOD("add_frame", "image", "delay", "idx"), &AnimatedImage::add_frame, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("remove_frame", "idx"), &AnimatedImage::remove_frame);
+
+	ClassDB::bind_method(D_METHOD("set_image", "idx", "image"), &AnimatedImage::set_image);
+	ClassDB::bind_method(D_METHOD("get_image", "idx"), &AnimatedImage::get_image);
+
+	ClassDB::bind_method(D_METHOD("set_delay", "idx", "delay"), &AnimatedImage::set_delay);
+	ClassDB::bind_method(D_METHOD("get_delay", "idx"), &AnimatedImage::get_delay);
+
+	ClassDB::bind_method(D_METHOD("get_frames"), &AnimatedImage::get_frames);
+
+	ClassDB::bind_method(D_METHOD("clear"), &AnimatedImage::clear);
+}

--- a/core/animated_image.h
+++ b/core/animated_image.h
@@ -1,0 +1,91 @@
+/*************************************************************************/
+/*  animated_image.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ANIMATED_IMAGE_H
+#define ANIMATED_IMAGE_H
+
+#include "core/image.h"
+#include "scene/2d/animated_sprite.h"
+
+class AnimatedImage;
+
+typedef Error (*LoadAnimatedImageFunction)(Ref<AnimatedImage> &r_animated_image, const Variant &source, int max_frames);
+
+class AnimatedImage : public Reference {
+	GDCLASS(AnimatedImage, Reference);
+
+	struct Frame {
+
+		Ref<Image> image;
+		float delay;
+	};
+	Vector<Frame> frames;
+
+protected:
+	static void _bind_methods();
+
+public:
+	enum SourceFormat {
+		GIF
+	};
+
+	enum ImportType {
+		ANIMATED_TEXTURE,
+		SPRITE_FRAMES
+	};
+
+	enum SourceType {
+		FILE,
+		BUFFER
+	};
+
+	static LoadAnimatedImageFunction _load_gif;
+
+	Error load_from_file(const String &p_path, int max_frames = 0);
+	Error load_from_buffer(const PoolByteArray &p_data, int max_frames = 0);
+
+	Ref<AnimatedTexture> to_animated_texture(uint32_t p_flags = 0, int max_frames = 0) const;
+	Ref<SpriteFrames> to_sprite_frames(uint32_t p_flags = 0, int max_frames = 0) const;
+
+	void add_frame(const Ref<Image> &p_image, float p_delay, int p_idx = -1);
+	void remove_frame(int p_idx);
+
+	void set_image(int p_idx, const Ref<Image> &p_image);
+	Ref<Image> get_image(int p_idx) const;
+
+	void set_delay(int p_idx, float p_delay);
+	float get_delay(int p_idx) const;
+
+	int get_frames() const;
+
+	void clear();
+};
+
+#endif // ANIMATED_IMAGE_H

--- a/core/io/animated_image_loader.cpp
+++ b/core/io/animated_image_loader.cpp
@@ -1,0 +1,178 @@
+/*************************************************************************/
+/*  animated_image_loader.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "animated_image_loader.h"
+
+#define HEADER_SIZE 6
+
+AnimatedImageFormatLoader::~AnimatedImageFormatLoader() {
+}
+
+Vector<AnimatedImageFormatLoader *> ResourceFormatLoaderAnimatedImage::loaders;
+
+void ResourceFormatLoaderAnimatedImage::add_animated_image_format_loader(AnimatedImageFormatLoader *p_loader) {
+
+	loaders.push_back(p_loader);
+}
+
+void ResourceFormatLoaderAnimatedImage::remove_animated_image_format_loader(AnimatedImageFormatLoader *p_loader) {
+
+	loaders.erase(p_loader);
+}
+
+RES ResourceFormatLoaderAnimatedImage::load(const String &p_path, const String &p_original_path, Error *r_error) {
+
+	Error err;
+	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);
+	if (!f) {
+
+		if (r_error)
+			*r_error = err;
+
+		return RES();
+	}
+
+	uint8_t header[HEADER_SIZE] = { 0 };
+	int header_size = f->get_buffer(header, HEADER_SIZE);
+
+	if (header_size != HEADER_SIZE) {
+
+		if (r_error)
+			*r_error = ERR_FILE_CORRUPT;
+
+		return RES();
+	}
+
+	AnimatedImage::SourceFormat format;
+	AnimatedImage::ImportType type = AnimatedImage::ANIMATED_TEXTURE;
+	int tex_flags = 0;
+	int max_frames = 0;
+
+	uint8_t imported_header[HEADER_SIZE] = { 'G', 'D', 'A', 'I', 'M', 'G' };
+	if (memcmp(&header[0], &imported_header[0], HEADER_SIZE) == 0) { // The file is imported.
+
+		format = AnimatedImage::SourceFormat(f->get_8());
+		type = AnimatedImage::ImportType(f->get_8());
+		tex_flags = f->get_32();
+		max_frames = f->get_32();
+	} else {
+
+		if (header[0] == 'G') { // The only supported format right now.
+
+			format = AnimatedImage::GIF;
+		} else {
+
+			f->close();
+			memdelete(f);
+
+			if (r_error)
+				*r_error = ERR_FILE_CORRUPT;
+
+			return RES();
+		}
+
+		f->seek(0); // Reset the cursor to the beginning of the file.
+	}
+
+	bool loaded = false;
+	Ref<AnimatedImage> animated_image = memnew(AnimatedImage);
+
+	for (int i = 0; i < loaders.size(); i++) {
+
+		if (loaders[i]->recognize_format(format)) {
+			err = loaders[i]->load_animated_image(animated_image, f, max_frames);
+			loaded = true;
+		}
+	}
+
+	f->close();
+	memdelete(f);
+
+	if (err != OK || !loaded) {
+
+		if (r_error)
+			*r_error = err;
+
+		return RES();
+	}
+
+	RES result;
+
+	switch (type) {
+		case AnimatedImage::ANIMATED_TEXTURE: {
+
+			result = animated_image->to_animated_texture(tex_flags, max_frames);
+		} break;
+		case AnimatedImage::SPRITE_FRAMES: {
+
+			result = animated_image->to_sprite_frames(tex_flags, max_frames);
+		} break;
+		default: {
+
+			if (r_error)
+				*r_error = ERR_FILE_CORRUPT;
+
+			return RES();
+		}
+	}
+
+	if (r_error)
+		*r_error = OK;
+
+	return result;
+}
+
+void ResourceFormatLoaderAnimatedImage::get_recognized_extensions(List<String> *p_extensions) const {
+
+	for (int i = 0; i < loaders.size(); i++)
+		loaders[i]->get_recognized_extensions(p_extensions);
+
+	p_extensions->push_back("aimg");
+}
+
+String ResourceFormatLoaderAnimatedImage::get_resource_type(const String &p_path) const {
+
+	String ext = p_path.get_extension();
+
+	List<String> extensions;
+	get_recognized_extensions(&extensions);
+	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
+
+		if (E->get().nocasecmp_to(ext) == 0)
+			return "AnimatedImage";
+	}
+
+	return "";
+}
+
+bool ResourceFormatLoaderAnimatedImage::handles_type(const String &p_type) const {
+
+	return (p_type == "AnimatedTexture" || p_type == "SpriteFrames");
+}

--- a/core/io/animated_image_loader.h
+++ b/core/io/animated_image_loader.h
@@ -1,0 +1,62 @@
+/*************************************************************************/
+/*  animated_image_loader.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ANIMATED_IMAGE_LOADER_H
+#define ANIMATED_IMAGE_LOADER_H
+
+#include "core/animated_image.h"
+#include "core/io/resource_loader.h"
+#include "core/os/file_access.h"
+
+class AnimatedImageFormatLoader {
+
+public:
+	virtual Error load_animated_image(Ref<AnimatedImage> &r_animated_image, FileAccess *f, int max_frames = 0) const = 0;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	virtual bool recognize_format(AnimatedImage::SourceFormat p_format) const = 0;
+
+	virtual ~AnimatedImageFormatLoader();
+};
+
+class ResourceFormatLoaderAnimatedImage : public ResourceFormatLoader {
+
+	static Vector<AnimatedImageFormatLoader *> loaders;
+
+public:
+	static void add_animated_image_format_loader(AnimatedImageFormatLoader *p_loader);
+	static void remove_animated_image_format_loader(AnimatedImageFormatLoader *p_loader);
+
+	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = NULL);
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual bool handles_type(const String &p_type) const;
+	virtual String get_resource_type(const String &p_path) const;
+};
+
+#endif // ANIMATED_IMAGE_LOADER_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -39,6 +39,7 @@
 #include "core/engine.h"
 #include "core/func_ref.h"
 #include "core/input_map.h"
+#include "core/io/animated_image_loader.h"
 #include "core/io/config_file.h"
 #include "core/io/http_client.h"
 #include "core/io/image_loader.h"
@@ -71,6 +72,7 @@ static Ref<ResourceFormatSaverBinary> resource_saver_binary;
 static Ref<ResourceFormatLoaderBinary> resource_loader_binary;
 static Ref<ResourceFormatImporter> resource_format_importer;
 static Ref<ResourceFormatLoaderImage> resource_format_image;
+static Ref<ResourceFormatLoaderAnimatedImage> resource_format_animated_image;
 static Ref<TranslationLoaderPO> resource_format_po;
 static Ref<ResourceFormatSaverCrypto> resource_format_saver_crypto;
 static Ref<ResourceFormatLoaderCrypto> resource_format_loader_crypto;
@@ -124,6 +126,9 @@ void register_core_types() {
 	resource_format_image.instance();
 	ResourceLoader::add_resource_format_loader(resource_format_image);
 
+	resource_format_animated_image.instance();
+	ResourceLoader::add_resource_format_loader(resource_format_animated_image);
+
 	ClassDB::register_class<Object>();
 
 	ClassDB::register_virtual_class<Script>();
@@ -132,6 +137,7 @@ void register_core_types() {
 	ClassDB::register_class<WeakRef>();
 	ClassDB::register_class<Resource>();
 	ClassDB::register_class<Image>();
+	ClassDB::register_class<AnimatedImage>();
 
 	ClassDB::register_virtual_class<InputEvent>();
 	ClassDB::register_virtual_class<InputEventWithModifiers>();
@@ -275,6 +281,9 @@ void unregister_core_types() {
 	memdelete(_json);
 
 	memdelete(_geometry);
+
+	ResourceLoader::remove_resource_format_loader(resource_format_animated_image);
+	resource_format_animated_image.unref();
 
 	ResourceLoader::remove_resource_format_loader(resource_format_image);
 	resource_format_image.unref();

--- a/doc/classes/AnimatedImage.xml
+++ b/doc/classes/AnimatedImage.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimatedImage" inherits="Reference" category="Core" version="3.2">
+	<brief_description>
+		Loads and converts animated images.
+	</brief_description>
+	<description>
+		[AnimatedImage] can load the frames of a GIF and store each of them as an [Image] and a delay. The data can then be used to generate an [AnimatedTexture] or a [SpriteFrames]. The params [code]max_frames[/code] of some methods can limit the number of generated frames.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="load_from_file">
+			<return type="Array">
+			</return>
+			<argument index="0" name="path" type="String">
+			</argument>
+			<argument index="1" name="max_frames" type="int" default="0">
+			</argument>
+			<description>
+				Loads the data from a file located at [code]path[/code].
+			</description>
+		</method>
+		<method name="load_from_buffer">
+			<return type="Array">
+			</return>
+			<argument index="0" name="data" type="PoolByteArray">
+			</argument>
+			<argument index="1" name="max_frames" type="int" default="0">
+			</argument>
+			<description>
+				Loads the data from a [PoolByteArray] buffer.
+			</description>
+		</method>
+		<method name="to_animated_texture">
+			<return type="AnimatedTexture">
+			</return>
+			<argument index="0" name="flags" type="int">
+			</argument>
+			<argument index="1" name="max_frames" type="int" default="0">
+			</argument>
+			<description>
+				Generates an [AnimatedTexture] from the loaded data.
+			</description>
+		</method>
+		<method name="to_sprite_frames">
+			<return type="SpriteFrames">
+			</return>
+			<argument index="0" name="flags" type="int">
+			</argument>
+			<argument index="1" name="max_frames" type="int" default="0">
+			</argument>
+			<description>
+				Generates a [SpriteFrames] from the loaded data.
+			</description>
+		</method>
+		<method name="add_frame">
+			<return type="void">
+			</return>
+			<argument index="0" name="image" type="Image">
+			</argument>
+			<argument index="1" name="delay" type="float">
+			</argument>
+			<argument index="2" name="idx" type="int" default="-1">
+			</argument>
+			<description>
+				Adds a new frame.
+			</description>
+		</method>
+		<method name="remove_frame">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Removes the frame [code]idx[/code].
+			</description>
+		</method>
+		<method name="set_image">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="image" type="Image">
+			</argument>
+			<description>
+				Sets the [Image] of frame [code]idx[/code].
+			</description>
+		</method>
+		<method name="get_image">
+			<return type="Image">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Returns the [Image] of frame [code]idx[/code].
+			</description>
+		</method>
+		<method name="set_delay">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="delay" type="float">
+			</argument>
+			<description>
+				Sets the delay in seconds of frame [code]idx[/code].
+			</description>
+		</method>
+		<method name="get_delay">
+			<return type="float">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Returns the delay of frame [code]idx[/code].
+			</description>
+		</method>
+		<method name="get_frames">
+			<return type="int">
+			</return>
+			<description>
+				Returns the number of loaded frames.
+			</description>
+		</method>
+		<method name="clear">
+			<return type="void">
+			</return>
+			<description>
+				Removes all the loaded frames.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -59,6 +59,7 @@
 #include "editor/editor_themes.h"
 #include "editor/import/editor_import_collada.h"
 #include "editor/import/editor_scene_importer_gltf.h"
+#include "editor/import/resource_importer_animated_texture.h"
 #include "editor/import/resource_importer_bitmask.h"
 #include "editor/import/resource_importer_csv.h"
 #include "editor/import/resource_importer_csv_translation.h"
@@ -66,6 +67,7 @@
 #include "editor/import/resource_importer_layered_texture.h"
 #include "editor/import/resource_importer_obj.h"
 #include "editor/import/resource_importer_scene.h"
+#include "editor/import/resource_importer_sprite_frames.h"
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
 #include "editor/import/resource_importer_wav.h"
@@ -5561,6 +5563,14 @@ EditorNode::EditorNode() {
 		Ref<ResourceImporterTextureAtlas> import_texture_atlas;
 		import_texture_atlas.instance();
 		ResourceFormatImporter::get_singleton()->add_importer(import_texture_atlas);
+
+		Ref<ResourceImporterAnimatedTexture> import_animated_texture;
+		import_animated_texture.instance();
+		ResourceFormatImporter::get_singleton()->add_importer(import_animated_texture);
+
+		Ref<ResourceImporterSpriteFrames> import_sprite_frames;
+		import_sprite_frames.instance();
+		ResourceFormatImporter::get_singleton()->add_importer(import_sprite_frames);
 
 		Ref<ResourceImporterCSVTranslation> import_csv_translation;
 		import_csv_translation.instance();

--- a/editor/import/resource_importer_animated_image.cpp
+++ b/editor/import/resource_importer_animated_image.cpp
@@ -1,0 +1,118 @@
+/*************************************************************************/
+/*  resource_importer_animated_image.cpp                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "resource_importer_animated_image.h"
+
+#include "core/os/file_access.h"
+#include "scene/resources/texture.h"
+
+void ResourceImporterAnimatedImage::get_recognized_extensions(List<String> *p_extensions) const {
+
+	p_extensions->push_back("gif");
+}
+
+String ResourceImporterAnimatedImage::get_save_extension() const {
+
+	return "aimg";
+}
+
+bool ResourceImporterAnimatedImage::get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const {
+
+	return true;
+}
+
+int ResourceImporterAnimatedImage::get_preset_count() const {
+
+	return 0;
+}
+
+String ResourceImporterAnimatedImage::get_preset_name(int p_idx) const {
+
+	return "";
+}
+
+void ResourceImporterAnimatedImage::get_import_options(List<ImportOption> *r_options, int p_preset) const {
+
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "flags/repeat", PROPERTY_HINT_ENUM, "Disabled,Enabled,Mirrored"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "flags/filter"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "flags/mipmaps"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "flags/anisotropic"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "flags/srgb", PROPERTY_HINT_ENUM, "Disable,Enable,Detect"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "max_frames", PROPERTY_HINT_RANGE, "0, 99999, 1"), 0));
+}
+
+Error ResourceImporterAnimatedImage::import_animated_image(AnimatedImage::ImportType type, const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options) {
+
+	int repeat = p_options["flags/repeat"];
+	bool filter = p_options["flags/filter"];
+	bool mipmaps = p_options["flags/mipmaps"];
+	bool anisotropic = p_options["flags/anisotropic"];
+	int srgb = p_options["flags/srgb"];
+	int max_frames = p_options["max_frames"];
+
+	int tex_flags = 0;
+	if (repeat > 0)
+		tex_flags |= Texture::FLAG_REPEAT;
+	if (repeat == 2)
+		tex_flags |= Texture::FLAG_MIRRORED_REPEAT;
+	if (filter)
+		tex_flags |= Texture::FLAG_FILTER;
+	if (mipmaps)
+		tex_flags |= Texture::FLAG_MIPMAPS;
+	if (anisotropic)
+		tex_flags |= Texture::FLAG_ANISOTROPIC_FILTER;
+	if (srgb == 1)
+		tex_flags |= Texture::FLAG_CONVERT_TO_LINEAR;
+
+	FileAccess *f = FileAccess::open(p_source_file, FileAccess::READ);
+	ERR_FAIL_COND_V(!f, ERR_CANT_OPEN);
+	size_t len = f->get_len();
+
+	Vector<uint8_t> data;
+	data.resize(len);
+	f->get_buffer(data.ptrw(), len);
+	f->close();
+	memdelete(f);
+
+	f = FileAccess::open(p_save_path + ".aimg", FileAccess::WRITE);
+	ERR_FAIL_COND_V(!f, ERR_CANT_OPEN);
+
+	const uint8_t header[6] = { 'G', 'D', 'A', 'I', 'M', 'G' };
+	f->store_buffer(header, 6);
+	f->store_8(AnimatedImage::GIF); // The only supported format right now.
+	f->store_8(type);
+	f->store_32(tex_flags);
+	f->store_32(max_frames);
+	f->store_buffer(data.ptr(), len);
+	f->close();
+	memdelete(f);
+
+	return OK;
+}

--- a/editor/import/resource_importer_animated_image.h
+++ b/editor/import/resource_importer_animated_image.h
@@ -1,0 +1,52 @@
+/*************************************************************************/
+/*  resource_importer_animated_image.h                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RESOURCE_IMPORTER_ANIMATED_IMAGE_H
+#define RESOURCE_IMPORTER_ANIMATED_IMAGE_H
+
+#include "core/animated_image.h"
+#include "core/io/resource_importer.h"
+
+class ResourceImporterAnimatedImage : public ResourceImporter {
+
+public:
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual String get_save_extension() const;
+
+	virtual int get_preset_count() const;
+	virtual String get_preset_name(int p_idx) const;
+
+	virtual void get_import_options(List<ImportOption> *r_options, int p_preset = 0) const;
+	virtual bool get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const;
+
+	Error import_animated_image(AnimatedImage::ImportType type, const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options);
+};
+
+#endif // RESOURCE_IMPORTER_ANIMATED_GIF_H

--- a/editor/import/resource_importer_animated_texture.cpp
+++ b/editor/import/resource_importer_animated_texture.cpp
@@ -1,0 +1,51 @@
+/*************************************************************************/
+/*  resource_importer_animated_texture.cpp                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "resource_importer_animated_texture.h"
+
+String ResourceImporterAnimatedTexture::get_resource_type() const {
+
+	return "AnimatedTexture";
+}
+
+String ResourceImporterAnimatedTexture::get_importer_name() const {
+
+	return "animated_texture";
+}
+
+String ResourceImporterAnimatedTexture::get_visible_name() const {
+
+	return "AnimatedTexture";
+}
+
+Error ResourceImporterAnimatedTexture::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+
+	return import_animated_image(AnimatedImage::ANIMATED_TEXTURE, p_source_file, p_save_path, p_options);
+}

--- a/editor/import/resource_importer_animated_texture.h
+++ b/editor/import/resource_importer_animated_texture.h
@@ -1,0 +1,45 @@
+/*************************************************************************/
+/*  resource_importer_animated_texture.h                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RESOURCE_IMPORTER_ANIMATED_TEXTURE_H
+#define RESOURCE_IMPORTER_ANIMATED_TEXTURE_H
+
+#include "editor/import/resource_importer_animated_image.h"
+
+class ResourceImporterAnimatedTexture : public ResourceImporterAnimatedImage {
+
+public:
+	virtual String get_resource_type() const;
+	virtual String get_importer_name() const;
+	virtual String get_visible_name() const;
+	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = NULL, Variant *r_metadata = NULL);
+};
+
+#endif // RESOURCE_IMPORTER_ANIMATED_TEXTURE_H

--- a/editor/import/resource_importer_sprite_frames.cpp
+++ b/editor/import/resource_importer_sprite_frames.cpp
@@ -1,0 +1,51 @@
+/*************************************************************************/
+/*  resource_importer_sprite_frames.cpp                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "resource_importer_sprite_frames.h"
+
+String ResourceImporterSpriteFrames::get_resource_type() const {
+
+	return "SpriteFrames";
+}
+
+String ResourceImporterSpriteFrames::get_importer_name() const {
+
+	return "sprite_frames";
+}
+
+String ResourceImporterSpriteFrames::get_visible_name() const {
+
+	return "SpriteFrames";
+}
+
+Error ResourceImporterSpriteFrames::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+
+	return import_animated_image(AnimatedImage::SPRITE_FRAMES, p_source_file, p_save_path, p_options);
+}

--- a/editor/import/resource_importer_sprite_frames.h
+++ b/editor/import/resource_importer_sprite_frames.h
@@ -1,0 +1,45 @@
+/*************************************************************************/
+/*  resource_importer_sprite_frames.h                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RESOURCE_IMPORTER_SPRITE_FRAMES_H
+#define RESOURCE_IMPORTER_SPRITE_FRAMES_H
+
+#include "editor/import/resource_importer_animated_image.h"
+
+class ResourceImporterSpriteFrames : public ResourceImporterAnimatedImage {
+
+public:
+	virtual String get_resource_type() const;
+	virtual String get_importer_name() const;
+	virtual String get_visible_name() const;
+	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = NULL, Variant *r_metadata = NULL);
+};
+
+#endif // RESOURCE_IMPORTER_SPRITE_FRAMES_H

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "editor/editor_node.h"
 #include "editor/editor_plugin.h"
+#include "scene/2d/animated_sprite.h"
 #include "scene/2d/canvas_item.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
@@ -686,6 +687,7 @@ class CanvasItemEditorViewport : public Control {
 	bool _cyclical_dependency_exists(const String &p_target_scene_path, Node *p_desired_node);
 	bool _only_packed_scenes_selected() const;
 	void _create_nodes(Node *parent, Node *child, String &path, const Point2 &p_point);
+	void _create_animated_sprite(Node *parent, const Ref<SpriteFrames> &sprite_frames, String &path, const Point2 &p_point);
 	bool _create_instance(Node *parent, String &path, const Point2 &p_point);
 	void _perform_drop_data();
 	void _show_resource_type_selector();

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -718,7 +718,11 @@ void SpriteFramesEditor::edit(SpriteFrames *p_frames) {
 	if (frames == p_frames)
 		return;
 
+	if (frames)
+		frames->remove_change_receptor(this);
 	frames = p_frames;
+	if (frames)
+		frames->add_change_receptor(this);
 
 	if (p_frames) {
 
@@ -739,6 +743,12 @@ void SpriteFramesEditor::edit(SpriteFrames *p_frames) {
 
 		hide();
 	}
+}
+
+void SpriteFramesEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+
+	if (frames && frames == p_changed)
+		call_deferred("_update_library");
 }
 
 Variant SpriteFramesEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
@@ -890,6 +900,8 @@ void SpriteFramesEditor::_bind_methods() {
 }
 
 SpriteFramesEditor::SpriteFramesEditor() {
+
+	frames = NULL;
 
 	VBoxContainer *vbc_animlist = memnew(VBoxContainer);
 	add_child(vbc_animlist);

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -122,6 +122,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _sheet_select_clear_all_frames();
 
 protected:
+	void _changed_callback(Object *p_changed, const char *p_prop);
 	void _notification(int p_what);
 	void _gui_input(Ref<InputEvent> p_event);
 	static void _bind_methods();

--- a/modules/gif/SCsub
+++ b/modules/gif/SCsub
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+Import('env')
+Import('env_modules')
+
+env_gif = env_modules.Clone()
+
+# Thirdparty source files
+thirdparty_dir = "#thirdparty/giflib/"
+thirdparty_sources = [
+    "gif_err.c",
+    "dgif_lib.c",
+    "gifalloc.c",
+    "gif_hash.c",
+    "openbsd-reallocarray.c"
+]
+thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
+
+env_gif.Prepend(CPPPATH=[thirdparty_dir])
+
+env_thirdparty = env_gif.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+
+# Godot's own source files
+env_gif.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/gif/config.py
+++ b/modules/gif/config.py
@@ -1,0 +1,5 @@
+def can_build(env, platform):
+    return True
+
+def configure(env):
+    pass

--- a/modules/gif/gif.cpp
+++ b/modules/gif/gif.cpp
@@ -1,0 +1,411 @@
+/*************************************************************************/
+/*  gif.cpp                                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gif.h"
+
+#include <gif_lib.h>
+
+// Custom function to read the GIF data from a file.
+int readFromFile(GifFileType *gif, GifByteType *data, int length) {
+
+	FileAccess *f = (FileAccess *)(gif->UserData); // gif->UserData is the first parameter passed to DGifOpen.
+	return f->get_buffer(data, length);
+}
+
+struct GIFBuffer { // Used to read the GIF data from a buffer.
+
+	const uint8_t *data;
+	int size;
+	int index;
+
+	GIFBuffer(const PoolByteArray &p_data) {
+		data = p_data.read().ptr();
+		size = p_data.size();
+		index = 0;
+	}
+
+	GIFBuffer(const uint8_t *p_data, int p_size) {
+		data = p_data;
+		size = p_size;
+		index = 0;
+	}
+};
+
+// Custom function to read the GIF data from a buffer.
+int readFromBuffer(GifFileType *gif, GifByteType *data, int length) {
+
+	GIFBuffer *f = (GIFBuffer *)(gif->UserData);
+	if (f->index + length > f->size)
+		length = f->size - f->index;
+
+	memcpy(data, &f->data[f->index], length);
+	f->index += length;
+	return length;
+}
+
+Error Gif::parse_error(Error err, const String &message) {
+
+	ERR_PRINTS(message);
+	return err;
+}
+
+Error Gif::gif_error(int err) {
+
+	ERR_PRINT(GifErrorString(err));
+	return FAILED;
+}
+
+Error Gif::_open(void *source, AnimatedImage::SourceType source_type) {
+
+	ERR_FAIL_COND_V(gif != NULL, FAILED);
+
+	int err = 0;
+	gif = DGifOpen(source, source_type == AnimatedImage::FILE ? readFromFile : readFromBuffer, &err); // Loads the headers of the GIF.
+	if (!gif)
+		return gif_error(err);
+
+	return OK;
+}
+
+#define RETURN_ERROR                  \
+	{                                 \
+		memdelete_arr(screen);        \
+		return gif_error(gif->Error); \
+	}
+
+#define RGBA 4
+
+Error Gif::_load_frames(Ref<AnimatedImage> &r_animated_image, int max_frames) {
+
+	ERR_FAIL_COND_V(gif == NULL, FAILED);
+
+	int image_size = gif->SWidth * gif->SHeight * RGBA;
+	uint8_t *screen = memnew_arr(uint8_t, image_size); // Each frame of the GIF is drawn on this buffer.
+	memset(screen, 0, image_size); // Clear the screen.
+
+	int last_undisposed_frame = -1; // Keep track of the last frame that hasn't been cleared.
+	GifRecordType recordType;
+
+	GraphicsControlBlock gcb; // Store the additional information for the next frame.
+	gcb.DisposalMode = DISPOSAL_UNSPECIFIED;
+	gcb.UserInputFlag = false;
+	gcb.DelayTime = 0;
+	gcb.TransparentColor = NO_TRANSPARENT_COLOR;
+
+	do { // Parse every record of the GIF.
+
+		if (DGifGetRecordType(gif, &recordType) == GIF_ERROR)
+			RETURN_ERROR;
+
+		switch (recordType) {
+			case EXTENSION_RECORD_TYPE: { // Record with additional info for the next image.
+
+				int extFunction;
+				GifByteType *extData;
+
+				if (DGifGetExtension(gif, &extFunction, &extData) == GIF_ERROR)
+					RETURN_ERROR;
+
+				if (extData == NULL) {
+
+					break;
+				} else if (extFunction == GRAPHICS_EXT_FUNC_CODE) {
+
+					if (DGifExtensionToGCB(extData[0], &extData[1], &gcb) == GIF_ERROR)
+						RETURN_ERROR;
+				}
+
+				while (true) {
+
+					if (DGifGetExtensionNext(gif, &extData) == GIF_ERROR)
+						RETURN_ERROR;
+
+					if (extData == NULL) {
+
+						break;
+					} else if (extFunction == GRAPHICS_EXT_FUNC_CODE) {
+
+						if (DGifExtensionToGCB(extData[0], &extData[1], &gcb) == GIF_ERROR)
+							RETURN_ERROR;
+					}
+				}
+
+			} break;
+			case IMAGE_DESC_RECORD_TYPE: { // Record with the image data.
+
+				if (DGifGetImageHeader(gif) == GIF_ERROR)
+					RETURN_ERROR;
+
+				GifImageDesc &imageDesc = gif->Image;
+
+				if (imageDesc.Width <= 0 || imageDesc.Width > Image::MAX_WIDTH ||
+						imageDesc.Height <= 0 || imageDesc.Height > Image::MAX_HEIGHT) {
+
+					RETURN_ERROR;
+				}
+
+				// Use the global colorMap if the frame doesn't include one.
+				ColorMapObject *colorMap = imageDesc.ColorMap ? imageDesc.ColorMap : gif->SColorMap;
+
+				int frame_size = imageDesc.Width * imageDesc.Height;
+				GifByteType *rasterBits = memnew_arr(GifByteType, frame_size); // Array with the indices to the colorMap.
+
+				if (imageDesc.Interlace) { // Unwrap the interlaced image.
+					int interlacedOffset[] = { 0, 4, 2, 1 };
+					int interlacedJumps[] = { 8, 8, 4, 2 };
+
+					for (int i = 0; i < 4; i++) {
+
+						for (int j = interlacedOffset[i]; j < imageDesc.Height; j += interlacedJumps[i]) {
+
+							if (DGifGetLine(gif, rasterBits + j * imageDesc.Width, imageDesc.Width) == GIF_ERROR) {
+
+								memdelete_arr(rasterBits);
+								RETURN_ERROR;
+							}
+						}
+					}
+				} else {
+
+					if (DGifGetLine(gif, rasterBits, frame_size) == GIF_ERROR) {
+
+						memdelete_arr(rasterBits);
+						RETURN_ERROR;
+					}
+				}
+
+				// Each frame has a different size and offset.
+				for (int y = 0; y < imageDesc.Height; y++) {
+
+					for (int x = 0; x < imageDesc.Width; x++) {
+
+						int color_map_index = rasterBits[y * imageDesc.Width + x];
+						if (color_map_index == gcb.TransparentColor) // This pixel doesn't change the current content of the screen.
+							continue;
+
+						int write_y = y + imageDesc.Top;
+						int write_x = x + imageDesc.Left;
+						int write_index = (write_y * gif->SWidth + write_x) * RGBA;
+
+						GifColorType color = colorMap->Colors[color_map_index];
+						screen[write_index] = color.Red;
+						screen[write_index + 1] = color.Green;
+						screen[write_index + 2] = color.Blue;
+						screen[write_index + 3] = 255;
+					}
+				}
+
+				memdelete_arr(rasterBits);
+
+				PoolByteArray frame_data;
+				frame_data.resize(image_size);
+				PoolByteArray::Write data_write = frame_data.write();
+				memcpy(data_write.ptr(), screen, image_size);
+
+				float delay = gcb.DelayTime / 100.0;
+				if (delay == 0)
+					delay = 0.05; // Default delay.
+
+				Ref<Image> img = memnew(Image(gif->SWidth, gif->SHeight, false, Image::FORMAT_RGBA8, frame_data));
+				r_animated_image->add_frame(img, delay);
+
+				gif->ImageCount++;
+
+				switch (gcb.DisposalMode) { // What should happen after the frame has been drawn.
+
+					case DISPOSE_BACKGROUND: { // Make the area of the current frame transparent.
+
+						for (int y = 0; y < imageDesc.Height; y++) {
+
+							int write_y = y + imageDesc.Top;
+							int write_index = (write_y * gif->SWidth + imageDesc.Left) * RGBA;
+							memset(&screen[write_index], 0, imageDesc.Width * RGBA);
+						}
+					} break;
+					case DISPOSE_PREVIOUS: { // Reset the screen to the last undisposed frame.
+
+						int row_size = imageDesc.Width * RGBA;
+
+						if (last_undisposed_frame == -1) { // Clear the frame.
+
+							for (int y = 0; y < imageDesc.Height; y++) {
+
+								int write_y = y + imageDesc.Top;
+								int write_index = (write_y * gif->SWidth + imageDesc.Left) * RGBA;
+								memset(&screen[write_index], 0, row_size);
+							}
+						} else {
+
+							PoolByteArray last_frame_data = r_animated_image->get_image(last_undisposed_frame)->get_data();
+							PoolByteArray::Read last_frame_read = last_frame_data.read();
+							for (int y = 0; y < imageDesc.Height; y++) {
+
+								int write_y = y + imageDesc.Top;
+								int write_index = (write_y * gif->SWidth + imageDesc.Left) * RGBA;
+								memcpy(&screen[write_index], &last_frame_read.ptr()[write_index], row_size);
+							}
+						}
+					} break;
+					default: { // Do nothing.
+
+						last_undisposed_frame = gif->ImageCount - 1;
+					}
+				}
+
+				// Reset the GraphicsControlBlock to his default values.
+				gcb.DisposalMode = DISPOSAL_UNSPECIFIED;
+				gcb.UserInputFlag = false;
+				gcb.DelayTime = 0;
+				gcb.TransparentColor = NO_TRANSPARENT_COLOR;
+
+			} break;
+			default: {
+			}
+		}
+
+		if (gif->ImageCount == max_frames && gif->ImageCount > 0)
+			break;
+
+	} while (recordType != TERMINATE_RECORD_TYPE);
+
+	if (gif->ImageCount == 0)
+		return parse_error(ERR_FILE_CORRUPT, "No frames found.");
+
+	memdelete_arr(screen);
+
+	return OK;
+}
+
+Error Gif::_close() {
+
+	int err = 0;
+	if (!DGifCloseFile(gif, &err))
+		return gif_error(err);
+
+	gif = NULL;
+	return OK;
+}
+
+Error Gif::load_from_file_access(Ref<AnimatedImage> &r_animated_image, FileAccess *f, int max_frames) {
+
+	Error err;
+
+	err = _open(f, AnimatedImage::FILE);
+	if (err != OK)
+		return ERR_FILE_CORRUPT;
+
+	err = _load_frames(r_animated_image, max_frames);
+	if (err != OK) {
+
+		_close();
+		return ERR_FILE_CORRUPT;
+	}
+
+	err = _close();
+	if (err != OK)
+		return ERR_FILE_CORRUPT;
+
+	return OK;
+}
+
+Error Gif::load_from_buffer(Ref<AnimatedImage> &r_animated_image, const PoolByteArray &p_data, int max_frames) {
+
+	GIFBuffer f = GIFBuffer(p_data);
+
+	Error err;
+	err = _open(&f, AnimatedImage::BUFFER);
+	if (err != OK)
+		return ERR_FILE_CORRUPT;
+
+	err = _load_frames(r_animated_image, max_frames);
+	if (err != OK) {
+
+		_close();
+		return ERR_FILE_CORRUPT;
+	}
+
+	err = _close();
+	if (err != OK)
+		return ERR_FILE_CORRUPT;
+
+	return OK;
+}
+
+Gif::Gif() :
+		gif(NULL) {}
+
+///////////////
+
+static Error _load_gif(Ref<AnimatedImage> &r_animated_image, const Variant &source, int max_frames) {
+
+	Gif gif;
+
+	if (source.get_type() == Variant::STRING) {
+		Error err;
+		FileAccess *f = FileAccess::open(source, FileAccess::READ, &err);
+		if (!f) {
+
+			ERR_PRINTS("Error opening file '" + String(source) + "'.");
+			return err;
+		}
+
+		err = gif.load_from_file_access(r_animated_image, f, max_frames);
+
+		f->close();
+		memdelete(f);
+		return err;
+	} else {
+
+		return gif.load_from_buffer(r_animated_image, source, max_frames);
+	}
+}
+
+///////////////
+
+Error AnimatedImageLoaderGIF::load_animated_image(Ref<AnimatedImage> &r_animated_image, FileAccess *f, int max_frames) const {
+
+	Gif gif;
+	return gif.load_from_file_access(r_animated_image, f, max_frames);
+}
+
+void AnimatedImageLoaderGIF::get_recognized_extensions(List<String> *p_extensions) const {
+
+	p_extensions->push_back("gif");
+}
+
+bool AnimatedImageLoaderGIF::recognize_format(AnimatedImage::SourceFormat p_format) const {
+
+	return p_format == AnimatedImage::GIF;
+}
+
+AnimatedImageLoaderGIF::AnimatedImageLoaderGIF() {
+
+	AnimatedImage::_load_gif = _load_gif;
+}

--- a/modules/gif/gif.h
+++ b/modules/gif/gif.h
@@ -1,0 +1,66 @@
+/*************************************************************************/
+/*  gif.h                                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GIF_H
+#define GIF_H
+
+#include "core/io/animated_image_loader.h"
+
+struct GifFileType;
+
+class Gif {
+
+	GifFileType *gif;
+
+	Error parse_error(Error parse_error, const String &message);
+	Error gif_error(int gif_error);
+
+	Error _open(void *source, AnimatedImage::SourceType source_type);
+	Error _load_frames(Ref<AnimatedImage> &r_animated_image, int max_frames = 0);
+	Error _close();
+
+public:
+	Error load_from_file_access(Ref<AnimatedImage> &r_animated_image, FileAccess *f, int max_frames = 0);
+	Error load_from_buffer(Ref<AnimatedImage> &r_animated_image, const PoolByteArray &p_data, int max_frames = 0);
+
+	Gif();
+};
+
+class AnimatedImageLoaderGIF : public AnimatedImageFormatLoader {
+
+public:
+	virtual Error load_animated_image(Ref<AnimatedImage> &r_animated_image, FileAccess *f, int max_frames = 0) const;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual bool recognize_format(AnimatedImage::SourceFormat p_format) const;
+
+	AnimatedImageLoaderGIF();
+};
+
+#endif // GIF_H

--- a/modules/gif/register_types.cpp
+++ b/modules/gif/register_types.cpp
@@ -1,0 +1,47 @@
+/*************************************************************************/
+/*  register_types.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "register_types.h"
+
+#include "gif.h"
+
+static AnimatedImageLoaderGIF *animated_image_loader_gif = NULL;
+
+void register_gif_types() {
+
+	animated_image_loader_gif = memnew(AnimatedImageLoaderGIF);
+	ResourceFormatLoaderAnimatedImage::add_animated_image_format_loader(animated_image_loader_gif);
+}
+
+void unregister_gif_types() {
+
+	ResourceFormatLoaderAnimatedImage::remove_animated_image_format_loader(animated_image_loader_gif);
+	memdelete(animated_image_loader_gif);
+}

--- a/modules/gif/register_types.h
+++ b/modules/gif/register_types.h
@@ -1,0 +1,32 @@
+/*************************************************************************/
+/*  register_types.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+void register_gif_types();
+void unregister_gif_types();

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -469,10 +469,10 @@ void AnimatedSprite::_notification(int p_what) {
 void AnimatedSprite::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 	if (frames.is_valid())
-		frames->disconnect("changed", this, "_res_changed");
+		frames->remove_change_receptor(this);
 	frames = p_frames;
 	if (frames.is_valid())
-		frames->connect("changed", this, "_res_changed");
+		frames->add_change_receptor(this);
 
 	if (!frames.is_valid()) {
 		frame = 0;
@@ -666,6 +666,12 @@ String AnimatedSprite::get_configuration_warning() const {
 	}
 
 	return String();
+}
+
+void AnimatedSprite::_changed_callback(Object *p_changed, const char *p_prop) {
+
+	if (frames.is_valid() && frames.ptr() == p_changed)
+		call_deferred("_res_changed");
 }
 
 void AnimatedSprite::_bind_methods() {

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -151,6 +151,7 @@ class AnimatedSprite : public Node2D {
 	Rect2 _get_rect() const;
 
 protected:
+	void _changed_callback(Object *p_changed, const char *p_prop);
 	static void _bind_methods();
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &property) const;
@@ -194,9 +195,6 @@ public:
 
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
-
-	void set_modulate(const Color &p_color);
-	Color get_modulate() const;
 
 	virtual String get_configuration_warning() const;
 	AnimatedSprite();

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -674,11 +674,12 @@ class AnimatedTexture : public Texture {
 	//use readers writers lock for this, since its far more times read than written to
 	RWLock *rw_lock;
 
-private:
+public:
 	enum {
 		MAX_FRAMES = 256
 	};
 
+private:
 	RID proxy;
 
 	struct Frame {

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -132,6 +132,27 @@ Files extracted from upstream source:
 - `docs/{FTL.TXT,LICENSE.TXT}`
 
 
+## giflib
+
+- Upstream: http://sourceforge.net/projects/giflib
+- Version: 5.2.1
+- License: MIT
+
+Files extracted from upstream source:
+
+- gif_err.c
+- gif_lib.h
+- dgif_lib.c
+- gifalloc.c
+- gif_hash.{c,h}
+- gif_lib_private.h
+- openbsd-reallocarray.c
+- COPYING
+
+Important: Some files have Godot-made changes.
+They are marked with `// -- GODOT start --` and `// -- GODOT end --`
+comments.
+
 ## glad
 
 - Upstream: https://github.com/Dav1dde/glad

--- a/thirdparty/giflib/COPYING
+++ b/thirdparty/giflib/COPYING
@@ -1,0 +1,19 @@
+The GIFLIB distribution is Copyright (c) 1997  Eric S. Raymond
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/thirdparty/giflib/dgif_lib.c
+++ b/thirdparty/giflib/dgif_lib.c
@@ -1,0 +1,1241 @@
+/******************************************************************************
+
+dgif_lib.c - GIF decoding
+
+The functions here and in egif_lib.c are partitioned carefully so that
+if you only require one of read and write capability, only one of these
+two modules will be linked.  Preserve this property!
+
+SPDX-License-Identifier: MIT
+
+*****************************************************************************/
+
+#include <stdlib.h>
+#include <limits.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif /* _WIN32 */
+
+#include "gif_lib.h"
+#include "gif_lib_private.h"
+
+/* compose unsigned little endian value */
+#define UNSIGNED_LITTLE_ENDIAN(lo, hi)	((lo) | ((hi) << 8))
+
+/* avoid extra function call in case we use fread (TVT) */
+static int InternalRead(GifFileType *gif, GifByteType *buf, int len) {
+    //fprintf(stderr, "### Read: %d\n", len);
+    return 
+	(((GifFilePrivateType*)gif->Private)->Read ?
+	 ((GifFilePrivateType*)gif->Private)->Read(gif,buf,len) : 
+	 fread(buf,1,len,((GifFilePrivateType*)gif->Private)->File));
+}
+
+static int DGifGetWord(GifFileType *GifFile, GifWord *Word);
+static int DGifSetupDecompress(GifFileType *GifFile);
+static int DGifDecompressLine(GifFileType *GifFile, GifPixelType *Line,
+                              int LineLen);
+static int DGifGetPrefixChar(GifPrefixType *Prefix, int Code, int ClearCode);
+static int DGifDecompressInput(GifFileType *GifFile, int *Code);
+static int DGifBufferedInput(GifFileType *GifFile, GifByteType *Buf,
+                             GifByteType *NextByte);
+
+/******************************************************************************
+ Open a new GIF file for read, given by its name.
+ Returns dynamically allocated GifFileType pointer which serves as the GIF
+ info record.
+******************************************************************************/
+GifFileType *
+DGifOpenFileName(const char *FileName, int *Error)
+{
+    int FileHandle;
+    GifFileType *GifFile;
+
+    if ((FileHandle = open(FileName, O_RDONLY)) == -1) {
+	if (Error != NULL)
+	    *Error = D_GIF_ERR_OPEN_FAILED;
+        return NULL;
+    }
+
+    GifFile = DGifOpenFileHandle(FileHandle, Error);
+    return GifFile;
+}
+
+/******************************************************************************
+ Update a new GIF file, given its file handle.
+ Returns dynamically allocated GifFileType pointer which serves as the GIF
+ info record.
+******************************************************************************/
+GifFileType *
+DGifOpenFileHandle(int FileHandle, int *Error)
+{
+    char Buf[GIF_STAMP_LEN + 1];
+    GifFileType *GifFile;
+    GifFilePrivateType *Private;
+    FILE *f;
+
+    GifFile = (GifFileType *)malloc(sizeof(GifFileType));
+    if (GifFile == NULL) {
+        if (Error != NULL)
+	    *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+        (void)close(FileHandle);
+        return NULL;
+    }
+
+    /*@i1@*/memset(GifFile, '\0', sizeof(GifFileType));
+
+    /* Belt and suspenders, in case the null pointer isn't zero */
+    GifFile->SavedImages = NULL;
+    GifFile->SColorMap = NULL;
+
+    Private = (GifFilePrivateType *)calloc(1, sizeof(GifFilePrivateType));
+    if (Private == NULL) {
+        if (Error != NULL)
+	    *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+        (void)close(FileHandle);
+        free((char *)GifFile);
+        return NULL;
+    }
+
+    /*@i1@*/memset(Private, '\0', sizeof(GifFilePrivateType));
+
+#ifdef _WIN32
+    _setmode(FileHandle, O_BINARY);    /* Make sure it is in binary mode. */
+#endif /* _WIN32 */
+
+    f = fdopen(FileHandle, "rb");    /* Make it into a stream: */
+
+    /*@-mustfreeonly@*/
+    GifFile->Private = (void *)Private;
+    Private->FileHandle = FileHandle;
+    Private->File = f;
+    Private->FileState = FILE_STATE_READ;
+    Private->Read = NULL;        /* don't use alternate input method (TVT) */
+    GifFile->UserData = NULL;    /* TVT */
+    /*@=mustfreeonly@*/
+
+    /* Let's see if this is a GIF file: */
+    /* coverity[check_return] */
+    if (InternalRead(GifFile, (unsigned char *)Buf, GIF_STAMP_LEN) != GIF_STAMP_LEN) {
+        if (Error != NULL)
+	    *Error = D_GIF_ERR_READ_FAILED;
+        (void)fclose(f);
+        free((char *)Private);
+        free((char *)GifFile);
+        return NULL;
+    }
+
+    /* Check for GIF prefix at start of file */
+    Buf[GIF_STAMP_LEN] = 0;
+    if (strncmp(GIF_STAMP, Buf, GIF_VERSION_POS) != 0) {
+        if (Error != NULL)
+	    *Error = D_GIF_ERR_NOT_GIF_FILE;
+        (void)fclose(f);
+        free((char *)Private);
+        free((char *)GifFile);
+        return NULL;
+    }
+
+    if (DGifGetScreenDesc(GifFile) == GIF_ERROR) {
+        (void)fclose(f);
+        free((char *)Private);
+        free((char *)GifFile);
+        return NULL;
+    }
+
+    GifFile->Error = 0;
+
+    /* What version of GIF? */
+    Private->gif89 = (Buf[GIF_VERSION_POS] == '9');
+
+    return GifFile;
+}
+
+/******************************************************************************
+ GifFileType constructor with user supplied input function (TVT)
+******************************************************************************/
+GifFileType *
+DGifOpen(void *userData, InputFunc readFunc, int *Error)
+{
+    char Buf[GIF_STAMP_LEN + 1];
+    GifFileType *GifFile;
+    GifFilePrivateType *Private;
+
+    GifFile = (GifFileType *)malloc(sizeof(GifFileType));
+    if (GifFile == NULL) {
+        if (Error != NULL)
+	    *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+        return NULL;
+    }
+
+    memset(GifFile, '\0', sizeof(GifFileType));
+
+    /* Belt and suspenders, in case the null pointer isn't zero */
+    GifFile->SavedImages = NULL;
+    GifFile->SColorMap = NULL;
+
+    Private = (GifFilePrivateType *)calloc(1, sizeof(GifFilePrivateType));
+    if (!Private) {
+        if (Error != NULL)
+	    *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+        free((char *)GifFile);
+        return NULL;
+    }
+    /*@i1@*/memset(Private, '\0', sizeof(GifFilePrivateType));
+
+    GifFile->Private = (void *)Private;
+    Private->FileHandle = 0;
+    Private->File = NULL;
+    Private->FileState = FILE_STATE_READ;
+
+    Private->Read = readFunc;    /* TVT */
+    GifFile->UserData = userData;    /* TVT */
+
+    /* Lets see if this is a GIF file: */
+    /* coverity[check_return] */
+    if (InternalRead(GifFile, (unsigned char *)Buf, GIF_STAMP_LEN) != GIF_STAMP_LEN) {
+        if (Error != NULL)
+	    *Error = D_GIF_ERR_READ_FAILED;
+        free((char *)Private);
+        free((char *)GifFile);
+        return NULL;
+    }
+
+    /* Check for GIF prefix at start of file */
+    Buf[GIF_STAMP_LEN] = '\0';
+    if (strncmp(GIF_STAMP, Buf, GIF_VERSION_POS) != 0) {
+        if (Error != NULL)
+	    *Error = D_GIF_ERR_NOT_GIF_FILE;
+        free((char *)Private);
+        free((char *)GifFile);
+        return NULL;
+    }
+
+    if (DGifGetScreenDesc(GifFile) == GIF_ERROR) {
+        free((char *)Private);
+        free((char *)GifFile);
+        if (Error != NULL)
+	    *Error = D_GIF_ERR_NO_SCRN_DSCR;
+        return NULL;
+    }
+
+    GifFile->Error = 0;
+
+    /* What version of GIF? */
+    Private->gif89 = (Buf[GIF_VERSION_POS] == '9');
+
+    return GifFile;
+}
+
+/******************************************************************************
+ This routine should be called before any other DGif calls. Note that
+ this routine is called automatically from DGif file open routines.
+******************************************************************************/
+int
+DGifGetScreenDesc(GifFileType *GifFile)
+{
+    int BitsPerPixel;
+    bool SortFlag;
+    GifByteType Buf[3];
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+        GifFile->Error = D_GIF_ERR_NOT_READABLE;
+        return GIF_ERROR;
+    }
+
+    /* Put the screen descriptor into the file: */
+    if (DGifGetWord(GifFile, &GifFile->SWidth) == GIF_ERROR ||
+        DGifGetWord(GifFile, &GifFile->SHeight) == GIF_ERROR)
+        return GIF_ERROR;
+
+    if (InternalRead(GifFile, Buf, 3) != 3) {
+        GifFile->Error = D_GIF_ERR_READ_FAILED;
+	GifFreeMapObject(GifFile->SColorMap);
+	GifFile->SColorMap = NULL;
+        return GIF_ERROR;
+    }
+    GifFile->SColorResolution = (((Buf[0] & 0x70) + 1) >> 4) + 1;
+    SortFlag = (Buf[0] & 0x08) != 0;
+    BitsPerPixel = (Buf[0] & 0x07) + 1;
+    GifFile->SBackGroundColor = Buf[1];
+    GifFile->AspectByte = Buf[2]; 
+    if (Buf[0] & 0x80) {    /* Do we have global color map? */
+	int i;
+
+        GifFile->SColorMap = GifMakeMapObject(1 << BitsPerPixel, NULL);
+        if (GifFile->SColorMap == NULL) {
+            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+            return GIF_ERROR;
+        }
+
+        /* Get the global color map: */
+	GifFile->SColorMap->SortFlag = SortFlag;
+        for (i = 0; i < GifFile->SColorMap->ColorCount; i++) {
+	    /* coverity[check_return] */
+            if (InternalRead(GifFile, Buf, 3) != 3) {
+                GifFreeMapObject(GifFile->SColorMap);
+                GifFile->SColorMap = NULL;
+                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                return GIF_ERROR;
+            }
+            GifFile->SColorMap->Colors[i].Red = Buf[0];
+            GifFile->SColorMap->Colors[i].Green = Buf[1];
+            GifFile->SColorMap->Colors[i].Blue = Buf[2];
+        }
+    } else {
+        GifFile->SColorMap = NULL;
+    }
+
+    /*
+     * No check here for whether the background color is in range for the
+     * screen color map.  Possibly there should be.
+     */
+    
+    return GIF_OK;
+}
+
+const char *
+DGifGetGifVersion(GifFileType *GifFile)
+{
+    GifFilePrivateType *Private = (GifFilePrivateType *) GifFile->Private;
+
+    if (Private->gif89)
+	return GIF89_STAMP;
+    else
+	return GIF87_STAMP;
+}
+
+/******************************************************************************
+ This routine should be called before any attempt to read an image.
+******************************************************************************/
+int
+DGifGetRecordType(GifFileType *GifFile, GifRecordType* Type)
+{
+    GifByteType Buf;
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+        GifFile->Error = D_GIF_ERR_NOT_READABLE;
+        return GIF_ERROR;
+    }
+
+    /* coverity[check_return] */
+    if (InternalRead(GifFile, &Buf, 1) != 1) {
+        GifFile->Error = D_GIF_ERR_READ_FAILED;
+        return GIF_ERROR;
+    }
+
+    //fprintf(stderr, "### DGifGetRecordType: %02x\n", Buf);
+    switch (Buf) {
+      case DESCRIPTOR_INTRODUCER:
+          *Type = IMAGE_DESC_RECORD_TYPE;
+          break;
+      case EXTENSION_INTRODUCER:
+          *Type = EXTENSION_RECORD_TYPE;
+          break;
+      case TERMINATOR_INTRODUCER:
+          *Type = TERMINATE_RECORD_TYPE;
+          break;
+      default:
+          *Type = UNDEFINED_RECORD_TYPE;
+          GifFile->Error = D_GIF_ERR_WRONG_RECORD;
+          return GIF_ERROR;
+    }
+
+    return GIF_OK;
+}
+
+int
+DGifGetImageHeader(GifFileType *GifFile)
+{
+    unsigned int BitsPerPixel;
+    GifByteType Buf[3];
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+        GifFile->Error = D_GIF_ERR_NOT_READABLE;
+        return GIF_ERROR;
+    }
+
+    if (DGifGetWord(GifFile, &GifFile->Image.Left) == GIF_ERROR ||
+        DGifGetWord(GifFile, &GifFile->Image.Top) == GIF_ERROR ||
+        DGifGetWord(GifFile, &GifFile->Image.Width) == GIF_ERROR ||
+        DGifGetWord(GifFile, &GifFile->Image.Height) == GIF_ERROR)
+        return GIF_ERROR;
+    if (InternalRead(GifFile, Buf, 1) != 1) {
+        GifFile->Error = D_GIF_ERR_READ_FAILED;
+        GifFreeMapObject(GifFile->Image.ColorMap);
+        GifFile->Image.ColorMap = NULL;
+        return GIF_ERROR;
+    }
+    BitsPerPixel = (Buf[0] & 0x07) + 1;
+    GifFile->Image.Interlace = (Buf[0] & 0x40) ? true : false;
+
+    /* Setup the colormap */
+    if (GifFile->Image.ColorMap) {
+        GifFreeMapObject(GifFile->Image.ColorMap);
+        GifFile->Image.ColorMap = NULL;
+    }
+    /* Does this image have local color map? */
+    if (Buf[0] & 0x80) {
+        unsigned int i;
+
+        GifFile->Image.ColorMap = GifMakeMapObject(1 << BitsPerPixel, NULL);
+        if (GifFile->Image.ColorMap == NULL) {
+            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+            return GIF_ERROR;
+        }
+
+        /* Get the image local color map: */
+        for (i = 0; i < GifFile->Image.ColorMap->ColorCount; i++) {
+            /* coverity[check_return] */
+            if (InternalRead(GifFile, Buf, 3) != 3) {
+                GifFreeMapObject(GifFile->Image.ColorMap);
+                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                GifFile->Image.ColorMap = NULL;
+                return GIF_ERROR;
+            }
+            GifFile->Image.ColorMap->Colors[i].Red = Buf[0];
+            GifFile->Image.ColorMap->Colors[i].Green = Buf[1];
+            GifFile->Image.ColorMap->Colors[i].Blue = Buf[2];
+        }
+    }
+
+    Private->PixelCount = (long)GifFile->Image.Width *
+       (long)GifFile->Image.Height;
+
+    /* Reset decompress algorithm parameters. */
+    return DGifSetupDecompress(GifFile);
+}
+
+/******************************************************************************
+ This routine should be called before any attempt to read an image.
+ Note it is assumed the Image desc. header has been read.
+******************************************************************************/
+int
+DGifGetImageDesc(GifFileType *GifFile)
+{
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+    SavedImage *sp;
+
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+        GifFile->Error = D_GIF_ERR_NOT_READABLE;
+        return GIF_ERROR;
+    }
+
+    if (DGifGetImageHeader(GifFile) == GIF_ERROR) {
+        return GIF_ERROR;
+    }
+
+    if (GifFile->SavedImages) {
+        SavedImage* new_saved_images =
+            (SavedImage *)reallocarray(GifFile->SavedImages,
+                            (GifFile->ImageCount + 1), sizeof(SavedImage));
+        if (new_saved_images == NULL) {
+            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+            return GIF_ERROR;
+        }
+        GifFile->SavedImages = new_saved_images;
+    } else {
+        if ((GifFile->SavedImages =
+             (SavedImage *) malloc(sizeof(SavedImage))) == NULL) {
+            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+            return GIF_ERROR;
+        }
+    }
+
+    sp = &GifFile->SavedImages[GifFile->ImageCount];
+    memcpy(&sp->ImageDesc, &GifFile->Image, sizeof(GifImageDesc));
+    if (GifFile->Image.ColorMap != NULL) {
+        sp->ImageDesc.ColorMap = GifMakeMapObject(
+                                 GifFile->Image.ColorMap->ColorCount,
+                                 GifFile->Image.ColorMap->Colors);
+        if (sp->ImageDesc.ColorMap == NULL) {
+            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+            return GIF_ERROR;
+        }
+    }
+    sp->RasterBits = (unsigned char *)NULL;
+    sp->ExtensionBlockCount = 0;
+    sp->ExtensionBlocks = (ExtensionBlock *) NULL;
+
+    GifFile->ImageCount++;
+
+    return GIF_OK;
+}
+
+/******************************************************************************
+ Get one full scanned line (Line) of length LineLen from GIF file.
+******************************************************************************/
+int
+DGifGetLine(GifFileType *GifFile, GifPixelType *Line, int LineLen)
+{
+    GifByteType *Dummy;
+    GifFilePrivateType *Private = (GifFilePrivateType *) GifFile->Private;
+
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+        GifFile->Error = D_GIF_ERR_NOT_READABLE;
+        return GIF_ERROR;
+    }
+
+    if (!LineLen)
+        LineLen = GifFile->Image.Width;
+
+    if ((Private->PixelCount -= LineLen) > 0xffff0000UL) {
+        GifFile->Error = D_GIF_ERR_DATA_TOO_BIG;
+        return GIF_ERROR;
+    }
+
+    if (DGifDecompressLine(GifFile, Line, LineLen) == GIF_OK) {
+        if (Private->PixelCount == 0) {
+            /* We probably won't be called any more, so let's clean up
+             * everything before we return: need to flush out all the
+             * rest of image until an empty block (size 0)
+             * detected. We use GetCodeNext.
+	     */
+            do
+                if (DGifGetCodeNext(GifFile, &Dummy) == GIF_ERROR)
+                    return GIF_ERROR;
+            while (Dummy != NULL) ;
+        }
+        return GIF_OK;
+    } else
+        return GIF_ERROR;
+}
+
+/******************************************************************************
+ Put one pixel (Pixel) into GIF file.
+******************************************************************************/
+int
+DGifGetPixel(GifFileType *GifFile, GifPixelType Pixel)
+{
+    GifByteType *Dummy;
+    GifFilePrivateType *Private = (GifFilePrivateType *) GifFile->Private;
+
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+        GifFile->Error = D_GIF_ERR_NOT_READABLE;
+        return GIF_ERROR;
+    }
+    if (--Private->PixelCount > 0xffff0000UL)
+    {
+        GifFile->Error = D_GIF_ERR_DATA_TOO_BIG;
+        return GIF_ERROR;
+    }
+
+    if (DGifDecompressLine(GifFile, &Pixel, 1) == GIF_OK) {
+        if (Private->PixelCount == 0) {
+            /* We probably won't be called any more, so let's clean up
+             * everything before we return: need to flush out all the
+             * rest of image until an empty block (size 0)
+             * detected. We use GetCodeNext.
+	     */
+            do
+                if (DGifGetCodeNext(GifFile, &Dummy) == GIF_ERROR)
+                    return GIF_ERROR;
+            while (Dummy != NULL) ;
+        }
+        return GIF_OK;
+    } else
+        return GIF_ERROR;
+}
+
+/******************************************************************************
+ Get an extension block (see GIF manual) from GIF file. This routine only
+ returns the first data block, and DGifGetExtensionNext should be called
+ after this one until NULL extension is returned.
+ The Extension should NOT be freed by the user (not dynamically allocated).
+ Note it is assumed the Extension description header has been read.
+******************************************************************************/
+int
+DGifGetExtension(GifFileType *GifFile, int *ExtCode, GifByteType **Extension)
+{
+    GifByteType Buf;
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    //fprintf(stderr, "### -> DGifGetExtension:\n");
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+        GifFile->Error = D_GIF_ERR_NOT_READABLE;
+        return GIF_ERROR;
+    }
+
+    /* coverity[check_return] */
+    if (InternalRead(GifFile, &Buf, 1) != 1) {
+        GifFile->Error = D_GIF_ERR_READ_FAILED;
+        return GIF_ERROR;
+    }
+    *ExtCode = Buf;
+    //fprintf(stderr, "### <- DGifGetExtension: %02x, about to call next\n", Buf);
+
+    return DGifGetExtensionNext(GifFile, Extension);
+}
+
+/******************************************************************************
+ Get a following extension block (see GIF manual) from GIF file. This
+ routine should be called until NULL Extension is returned.
+ The Extension should NOT be freed by the user (not dynamically allocated).
+******************************************************************************/
+int
+DGifGetExtensionNext(GifFileType *GifFile, GifByteType ** Extension)
+{
+    GifByteType Buf;
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    //fprintf(stderr, "### -> DGifGetExtensionNext\n");
+    if (InternalRead(GifFile, &Buf, 1) != 1) {
+        GifFile->Error = D_GIF_ERR_READ_FAILED;
+        return GIF_ERROR;
+    }
+    //fprintf(stderr, "### DGifGetExtensionNext sees %d\n", Buf);
+
+    if (Buf > 0) {
+        *Extension = Private->Buf;    /* Use private unused buffer. */
+        (*Extension)[0] = Buf;  /* Pascal strings notation (pos. 0 is len.). */
+	/* coverity[tainted_data,check_return] */
+        if (InternalRead(GifFile, &((*Extension)[1]), Buf) != Buf) {
+            GifFile->Error = D_GIF_ERR_READ_FAILED;
+            return GIF_ERROR;
+        }
+    } else
+        *Extension = NULL;
+    //fprintf(stderr, "### <- DGifGetExtensionNext: %p\n", Extension);
+
+    return GIF_OK;
+}
+
+/******************************************************************************
+ Extract a Graphics Control Block from raw extension data
+******************************************************************************/
+
+int DGifExtensionToGCB(const size_t GifExtensionLength,
+		       const GifByteType *GifExtension,
+		       GraphicsControlBlock *GCB)
+{
+    if (GifExtensionLength != 4) {
+	return GIF_ERROR;
+    }
+
+    GCB->DisposalMode = (GifExtension[0] >> 2) & 0x07;
+    GCB->UserInputFlag = (GifExtension[0] & 0x02) != 0;
+    GCB->DelayTime = UNSIGNED_LITTLE_ENDIAN(GifExtension[1], GifExtension[2]);
+    if (GifExtension[0] & 0x01)
+	GCB->TransparentColor = (int)GifExtension[3];
+    else
+	GCB->TransparentColor = NO_TRANSPARENT_COLOR;
+
+    return GIF_OK;
+}
+
+/******************************************************************************
+ Extract the Graphics Control Block for a saved image, if it exists.
+******************************************************************************/
+
+int DGifSavedExtensionToGCB(GifFileType *GifFile,
+			    int ImageIndex, GraphicsControlBlock *GCB)
+{
+    int i;
+
+    if (ImageIndex < 0 || ImageIndex > GifFile->ImageCount - 1)
+	return GIF_ERROR;
+
+    GCB->DisposalMode = DISPOSAL_UNSPECIFIED;
+    GCB->UserInputFlag = false;
+    GCB->DelayTime = 0;
+    GCB->TransparentColor = NO_TRANSPARENT_COLOR;
+
+    for (i = 0; i < GifFile->SavedImages[ImageIndex].ExtensionBlockCount; i++) {
+	ExtensionBlock *ep = &GifFile->SavedImages[ImageIndex].ExtensionBlocks[i];
+	if (ep->Function == GRAPHICS_EXT_FUNC_CODE)
+	    return DGifExtensionToGCB(ep->ByteCount, ep->Bytes, GCB);
+    }
+
+    return GIF_ERROR;
+}
+
+/******************************************************************************
+ This routine should be called last, to close the GIF file.
+******************************************************************************/
+int
+DGifCloseFile(GifFileType *GifFile, int *ErrorCode)
+{
+    GifFilePrivateType *Private;
+
+    if (GifFile == NULL || GifFile->Private == NULL)
+        return GIF_ERROR;
+
+    if (GifFile->Image.ColorMap) {
+        GifFreeMapObject(GifFile->Image.ColorMap);
+        GifFile->Image.ColorMap = NULL;
+    }
+
+    if (GifFile->SColorMap) {
+        GifFreeMapObject(GifFile->SColorMap);
+        GifFile->SColorMap = NULL;
+    }
+
+    if (GifFile->SavedImages) {
+        GifFreeSavedImages(GifFile);
+        GifFile->SavedImages = NULL;
+    }
+
+    GifFreeExtensions(&GifFile->ExtensionBlockCount, &GifFile->ExtensionBlocks);
+
+    Private = (GifFilePrivateType *) GifFile->Private;
+
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+	if (ErrorCode != NULL)
+	    *ErrorCode = D_GIF_ERR_NOT_READABLE;
+	free((char *)GifFile->Private);
+	free(GifFile);
+        return GIF_ERROR;
+    }
+
+    if (Private->File && (fclose(Private->File) != 0)) {
+	if (ErrorCode != NULL)
+	    *ErrorCode = D_GIF_ERR_CLOSE_FAILED;
+	free((char *)GifFile->Private);
+	free(GifFile);
+        return GIF_ERROR;
+    }
+
+    free((char *)GifFile->Private);
+    free(GifFile);
+    if (ErrorCode != NULL)
+	*ErrorCode = D_GIF_SUCCEEDED;
+    return GIF_OK;
+}
+
+/******************************************************************************
+ Get 2 bytes (word) from the given file:
+******************************************************************************/
+static int
+DGifGetWord(GifFileType *GifFile, GifWord *Word)
+{
+    unsigned char c[2];
+
+    /* coverity[check_return] */
+    if (InternalRead(GifFile, c, 2) != 2) {
+        GifFile->Error = D_GIF_ERR_READ_FAILED;
+        return GIF_ERROR;
+    }
+
+    *Word = (GifWord)UNSIGNED_LITTLE_ENDIAN(c[0], c[1]);
+    return GIF_OK;
+}
+
+/******************************************************************************
+ Get the image code in compressed form.  This routine can be called if the
+ information needed to be piped out as is. Obviously this is much faster
+ than decoding and encoding again. This routine should be followed by calls
+ to DGifGetCodeNext, until NULL block is returned.
+ The block should NOT be freed by the user (not dynamically allocated).
+******************************************************************************/
+int
+DGifGetCode(GifFileType *GifFile, int *CodeSize, GifByteType **CodeBlock)
+{
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+        GifFile->Error = D_GIF_ERR_NOT_READABLE;
+        return GIF_ERROR;
+    }
+
+    *CodeSize = Private->BitsPerPixel;
+
+    return DGifGetCodeNext(GifFile, CodeBlock);
+}
+
+/******************************************************************************
+ Continue to get the image code in compressed form. This routine should be
+ called until NULL block is returned.
+ The block should NOT be freed by the user (not dynamically allocated).
+******************************************************************************/
+int
+DGifGetCodeNext(GifFileType *GifFile, GifByteType **CodeBlock)
+{
+    GifByteType Buf;
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    /* coverity[tainted_data_argument] */
+    /* coverity[check_return] */
+    if (InternalRead(GifFile, &Buf, 1) != 1) {
+        GifFile->Error = D_GIF_ERR_READ_FAILED;
+        return GIF_ERROR;
+    }
+
+    /* coverity[lower_bounds] */
+    if (Buf > 0) {
+        *CodeBlock = Private->Buf;    /* Use private unused buffer. */
+        (*CodeBlock)[0] = Buf;  /* Pascal strings notation (pos. 0 is len.). */
+	/* coverity[tainted_data] */
+        if (InternalRead(GifFile, &((*CodeBlock)[1]), Buf) != Buf) {
+            GifFile->Error = D_GIF_ERR_READ_FAILED;
+            return GIF_ERROR;
+        }
+    } else {
+        *CodeBlock = NULL;
+        Private->Buf[0] = 0;    /* Make sure the buffer is empty! */
+        Private->PixelCount = 0;    /* And local info. indicate image read. */
+    }
+
+    return GIF_OK;
+}
+
+/******************************************************************************
+ Setup the LZ decompression for this image:
+******************************************************************************/
+static int
+DGifSetupDecompress(GifFileType *GifFile)
+{
+    int i, BitsPerPixel;
+    GifByteType CodeSize;
+    GifPrefixType *Prefix;
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    /* coverity[check_return] */
+    if (InternalRead(GifFile, &CodeSize, 1) < 1) {    /* Read Code size from file. */
+	return GIF_ERROR;    /* Failed to read Code size. */
+    }
+    BitsPerPixel = CodeSize;
+
+    /* this can only happen on a severely malformed GIF */
+    if (BitsPerPixel > 8) {
+	GifFile->Error = D_GIF_ERR_READ_FAILED;	/* somewhat bogus error code */
+	return GIF_ERROR;    /* Failed to read Code size. */
+    }
+
+    Private->Buf[0] = 0;    /* Input Buffer empty. */
+    Private->BitsPerPixel = BitsPerPixel;
+    Private->ClearCode = (1 << BitsPerPixel);
+    Private->EOFCode = Private->ClearCode + 1;
+    Private->RunningCode = Private->EOFCode + 1;
+    Private->RunningBits = BitsPerPixel + 1;    /* Number of bits per code. */
+    Private->MaxCode1 = 1 << Private->RunningBits;    /* Max. code + 1. */
+    Private->StackPtr = 0;    /* No pixels on the pixel stack. */
+    Private->LastCode = NO_SUCH_CODE;
+    Private->CrntShiftState = 0;    /* No information in CrntShiftDWord. */
+    Private->CrntShiftDWord = 0;
+
+    Prefix = Private->Prefix;
+    for (i = 0; i <= LZ_MAX_CODE; i++)
+        Prefix[i] = NO_SUCH_CODE;
+
+    return GIF_OK;
+}
+
+/******************************************************************************
+ The LZ decompression routine:
+ This version decompress the given GIF file into Line of length LineLen.
+ This routine can be called few times (one per scan line, for example), in
+ order the complete the whole image.
+******************************************************************************/
+static int
+DGifDecompressLine(GifFileType *GifFile, GifPixelType *Line, int LineLen)
+{
+    int i = 0;
+    int j, CrntCode, EOFCode, ClearCode, CrntPrefix, LastCode, StackPtr;
+    GifByteType *Stack, *Suffix;
+    GifPrefixType *Prefix;
+    GifFilePrivateType *Private = (GifFilePrivateType *) GifFile->Private;
+
+    StackPtr = Private->StackPtr;
+    Prefix = Private->Prefix;
+    Suffix = Private->Suffix;
+    Stack = Private->Stack;
+    EOFCode = Private->EOFCode;
+    ClearCode = Private->ClearCode;
+    LastCode = Private->LastCode;
+
+    if (StackPtr > LZ_MAX_CODE) {
+        return GIF_ERROR;
+    }
+
+    if (StackPtr != 0) {
+        /* Let pop the stack off before continueing to read the GIF file: */
+        while (StackPtr != 0 && i < LineLen)
+            Line[i++] = Stack[--StackPtr];
+    }
+
+    while (i < LineLen) {    /* Decode LineLen items. */
+        if (DGifDecompressInput(GifFile, &CrntCode) == GIF_ERROR)
+            return GIF_ERROR;
+
+        if (CrntCode == EOFCode) {
+            /* Note however that usually we will not be here as we will stop
+             * decoding as soon as we got all the pixel, or EOF code will
+             * not be read at all, and DGifGetLine/Pixel clean everything.  */
+	    GifFile->Error = D_GIF_ERR_EOF_TOO_SOON;
+	    return GIF_ERROR;
+        } else if (CrntCode == ClearCode) {
+            /* We need to start over again: */
+            for (j = 0; j <= LZ_MAX_CODE; j++)
+                Prefix[j] = NO_SUCH_CODE;
+            Private->RunningCode = Private->EOFCode + 1;
+            Private->RunningBits = Private->BitsPerPixel + 1;
+            Private->MaxCode1 = 1 << Private->RunningBits;
+            LastCode = Private->LastCode = NO_SUCH_CODE;
+        } else {
+            /* Its regular code - if in pixel range simply add it to output
+             * stream, otherwise trace to codes linked list until the prefix
+             * is in pixel range: */
+            if (CrntCode < ClearCode) {
+                /* This is simple - its pixel scalar, so add it to output: */
+                Line[i++] = CrntCode;
+            } else {
+                /* Its a code to needed to be traced: trace the linked list
+                 * until the prefix is a pixel, while pushing the suffix
+                 * pixels on our stack. If we done, pop the stack in reverse
+                 * (thats what stack is good for!) order to output.  */
+                if (Prefix[CrntCode] == NO_SUCH_CODE) {
+                    CrntPrefix = LastCode;
+
+                    /* Only allowed if CrntCode is exactly the running code:
+                     * In that case CrntCode = XXXCode, CrntCode or the
+                     * prefix code is last code and the suffix char is
+                     * exactly the prefix of last code! */
+                    if (CrntCode == Private->RunningCode - 2) {
+                        Suffix[Private->RunningCode - 2] =
+                           Stack[StackPtr++] = DGifGetPrefixChar(Prefix,
+                                                                 LastCode,
+                                                                 ClearCode);
+                    } else {
+                        Suffix[Private->RunningCode - 2] =
+                           Stack[StackPtr++] = DGifGetPrefixChar(Prefix,
+                                                                 CrntCode,
+                                                                 ClearCode);
+                    }
+                } else
+                    CrntPrefix = CrntCode;
+
+                /* Now (if image is O.K.) we should not get a NO_SUCH_CODE
+                 * during the trace. As we might loop forever, in case of
+                 * defective image, we use StackPtr as loop counter and stop
+                 * before overflowing Stack[]. */
+                while (StackPtr < LZ_MAX_CODE &&
+                       CrntPrefix > ClearCode && CrntPrefix <= LZ_MAX_CODE) {
+                    Stack[StackPtr++] = Suffix[CrntPrefix];
+                    CrntPrefix = Prefix[CrntPrefix];
+                }
+                if (StackPtr >= LZ_MAX_CODE || CrntPrefix > LZ_MAX_CODE) {
+                    GifFile->Error = D_GIF_ERR_IMAGE_DEFECT;
+                    return GIF_ERROR;
+                }
+                /* Push the last character on stack: */
+                Stack[StackPtr++] = CrntPrefix;
+
+                /* Now lets pop all the stack into output: */
+                while (StackPtr != 0 && i < LineLen)
+                    Line[i++] = Stack[--StackPtr];
+            }
+            if (LastCode != NO_SUCH_CODE && Private->RunningCode - 2 < (LZ_MAX_CODE+1) && Prefix[Private->RunningCode - 2] == NO_SUCH_CODE) {
+                Prefix[Private->RunningCode - 2] = LastCode;
+
+                if (CrntCode == Private->RunningCode - 2) {
+                    /* Only allowed if CrntCode is exactly the running code:
+                     * In that case CrntCode = XXXCode, CrntCode or the
+                     * prefix code is last code and the suffix char is
+                     * exactly the prefix of last code! */
+                    Suffix[Private->RunningCode - 2] =
+                       DGifGetPrefixChar(Prefix, LastCode, ClearCode);
+                } else {
+                    Suffix[Private->RunningCode - 2] =
+                       DGifGetPrefixChar(Prefix, CrntCode, ClearCode);
+                }
+            }
+            LastCode = CrntCode;
+        }
+    }
+
+    Private->LastCode = LastCode;
+    Private->StackPtr = StackPtr;
+
+    return GIF_OK;
+}
+
+/******************************************************************************
+ Routine to trace the Prefixes linked list until we get a prefix which is
+ not code, but a pixel value (less than ClearCode). Returns that pixel value.
+ If image is defective, we might loop here forever, so we limit the loops to
+ the maximum possible if image O.k. - LZ_MAX_CODE times.
+******************************************************************************/
+static int
+DGifGetPrefixChar(GifPrefixType *Prefix, int Code, int ClearCode)
+{
+    int i = 0;
+
+    while (Code > ClearCode && i++ <= LZ_MAX_CODE) {
+        if (Code > LZ_MAX_CODE) {
+            return NO_SUCH_CODE;
+        }
+        Code = Prefix[Code];
+    }
+    return Code;
+}
+
+/******************************************************************************
+ Interface for accessing the LZ codes directly. Set Code to the real code
+ (12bits), or to -1 if EOF code is returned.
+******************************************************************************/
+int
+DGifGetLZCodes(GifFileType *GifFile, int *Code)
+{
+    GifByteType *CodeBlock;
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    if (!IS_READABLE(Private)) {
+        /* This file was NOT open for reading: */
+        GifFile->Error = D_GIF_ERR_NOT_READABLE;
+        return GIF_ERROR;
+    }
+
+    if (DGifDecompressInput(GifFile, Code) == GIF_ERROR)
+        return GIF_ERROR;
+
+    if (*Code == Private->EOFCode) {
+        /* Skip rest of codes (hopefully only NULL terminating block): */
+        do {
+            if (DGifGetCodeNext(GifFile, &CodeBlock) == GIF_ERROR)
+                return GIF_ERROR;
+        } while (CodeBlock != NULL) ;
+
+        *Code = -1;
+    } else if (*Code == Private->ClearCode) {
+        /* We need to start over again: */
+        Private->RunningCode = Private->EOFCode + 1;
+        Private->RunningBits = Private->BitsPerPixel + 1;
+        Private->MaxCode1 = 1 << Private->RunningBits;
+    }
+
+    return GIF_OK;
+}
+
+/******************************************************************************
+ The LZ decompression input routine:
+ This routine is responsable for the decompression of the bit stream from
+ 8 bits (bytes) packets, into the real codes.
+ Returns GIF_OK if read successfully.
+******************************************************************************/
+static int
+DGifDecompressInput(GifFileType *GifFile, int *Code)
+{
+    static const unsigned short CodeMasks[] = {
+	0x0000, 0x0001, 0x0003, 0x0007,
+	0x000f, 0x001f, 0x003f, 0x007f,
+	0x00ff, 0x01ff, 0x03ff, 0x07ff,
+	0x0fff
+    };
+
+    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+
+    GifByteType NextByte;
+
+    /* The image can't contain more than LZ_BITS per code. */
+    if (Private->RunningBits > LZ_BITS) {
+        GifFile->Error = D_GIF_ERR_IMAGE_DEFECT;
+        return GIF_ERROR;
+    }
+    
+    while (Private->CrntShiftState < Private->RunningBits) {
+        /* Needs to get more bytes from input stream for next code: */
+        if (DGifBufferedInput(GifFile, Private->Buf, &NextByte) == GIF_ERROR) {
+            return GIF_ERROR;
+        }
+        Private->CrntShiftDWord |=
+	    ((unsigned long)NextByte) << Private->CrntShiftState;
+        Private->CrntShiftState += 8;
+    }
+    *Code = Private->CrntShiftDWord & CodeMasks[Private->RunningBits];
+
+    Private->CrntShiftDWord >>= Private->RunningBits;
+    Private->CrntShiftState -= Private->RunningBits;
+
+    /* If code cannot fit into RunningBits bits, must raise its size. Note
+     * however that codes above 4095 are used for special signaling.
+     * If we're using LZ_BITS bits already and we're at the max code, just
+     * keep using the table as it is, don't increment Private->RunningCode.
+     */
+    if (Private->RunningCode < LZ_MAX_CODE + 2 &&
+	++Private->RunningCode > Private->MaxCode1 &&
+	Private->RunningBits < LZ_BITS) {
+        Private->MaxCode1 <<= 1;
+        Private->RunningBits++;
+    }
+    return GIF_OK;
+}
+
+/******************************************************************************
+ This routines read one GIF data block at a time and buffers it internally
+ so that the decompression routine could access it.
+ The routine returns the next byte from its internal buffer (or read next
+ block in if buffer empty) and returns GIF_OK if succesful.
+******************************************************************************/
+static int
+DGifBufferedInput(GifFileType *GifFile, GifByteType *Buf, GifByteType *NextByte)
+{
+    if (Buf[0] == 0) {
+        /* Needs to read the next buffer - this one is empty: */
+	/* coverity[check_return] */
+        if (InternalRead(GifFile, Buf, 1) != 1) {
+            GifFile->Error = D_GIF_ERR_READ_FAILED;
+            return GIF_ERROR;
+        }
+        /* There shouldn't be any empty data blocks here as the LZW spec
+         * says the LZW termination code should come first.  Therefore we
+         * shouldn't be inside this routine at that point.
+         */
+        if (Buf[0] == 0) {
+            GifFile->Error = D_GIF_ERR_IMAGE_DEFECT;
+            return GIF_ERROR;
+        }
+        if (InternalRead(GifFile, &Buf[1], Buf[0]) != Buf[0]) {
+            GifFile->Error = D_GIF_ERR_READ_FAILED;
+            return GIF_ERROR;
+        }
+        *NextByte = Buf[1];
+        Buf[1] = 2;    /* We use now the second place as last char read! */
+        Buf[0]--;
+    } else {
+        *NextByte = Buf[Buf[1]++];
+        Buf[0]--;
+    }
+
+    return GIF_OK;
+}
+
+/******************************************************************************
+ This routine reads an entire GIF into core, hanging all its state info off
+ the GifFileType pointer.  Call DGifOpenFileName() or DGifOpenFileHandle()
+ first to initialize I/O.  Its inverse is EGifSpew().
+*******************************************************************************/
+int
+DGifSlurp(GifFileType *GifFile)
+{
+    size_t ImageSize;
+    GifRecordType RecordType;
+    SavedImage *sp;
+    GifByteType *ExtData;
+    int ExtFunction;
+
+    GifFile->ExtensionBlocks = NULL;
+    GifFile->ExtensionBlockCount = 0;
+
+    do {
+        if (DGifGetRecordType(GifFile, &RecordType) == GIF_ERROR)
+            return (GIF_ERROR);
+
+        switch (RecordType) {
+          case IMAGE_DESC_RECORD_TYPE:
+              if (DGifGetImageDesc(GifFile) == GIF_ERROR)
+                  return (GIF_ERROR);
+
+              sp = &GifFile->SavedImages[GifFile->ImageCount - 1];
+              /* Allocate memory for the image */
+              if (sp->ImageDesc.Width <= 0 || sp->ImageDesc.Height <= 0 ||
+                      sp->ImageDesc.Width > (INT_MAX / sp->ImageDesc.Height)) {
+                  return GIF_ERROR;
+              }
+              ImageSize = sp->ImageDesc.Width * sp->ImageDesc.Height;
+
+              if (ImageSize > (SIZE_MAX / sizeof(GifPixelType))) {
+                  return GIF_ERROR;
+              }
+              sp->RasterBits = (unsigned char *)reallocarray(NULL, ImageSize,
+                      sizeof(GifPixelType));
+
+              if (sp->RasterBits == NULL) {
+                  return GIF_ERROR;
+              }
+
+	      if (sp->ImageDesc.Interlace) {
+		  int i, j;
+		   /* 
+		    * The way an interlaced image should be read - 
+		    * offsets and jumps...
+		    */
+		  int InterlacedOffset[] = { 0, 4, 2, 1 };
+		  int InterlacedJumps[] = { 8, 8, 4, 2 };
+		  /* Need to perform 4 passes on the image */
+		  for (i = 0; i < 4; i++)
+		      for (j = InterlacedOffset[i]; 
+			   j < sp->ImageDesc.Height;
+			   j += InterlacedJumps[i]) {
+			  if (DGifGetLine(GifFile, 
+					  sp->RasterBits+j*sp->ImageDesc.Width, 
+					  sp->ImageDesc.Width) == GIF_ERROR)
+			      return GIF_ERROR;
+		      }
+	      }
+	      else {
+		  if (DGifGetLine(GifFile,sp->RasterBits,ImageSize)==GIF_ERROR)
+		      return (GIF_ERROR);
+	      }
+
+              if (GifFile->ExtensionBlocks) {
+                  sp->ExtensionBlocks = GifFile->ExtensionBlocks;
+                  sp->ExtensionBlockCount = GifFile->ExtensionBlockCount;
+
+                  GifFile->ExtensionBlocks = NULL;
+                  GifFile->ExtensionBlockCount = 0;
+              }
+              break;
+
+          case EXTENSION_RECORD_TYPE:
+              if (DGifGetExtension(GifFile,&ExtFunction,&ExtData) == GIF_ERROR)
+                  return (GIF_ERROR);
+	      /* Create an extension block with our data */
+              if (ExtData != NULL) {
+		  if (GifAddExtensionBlock(&GifFile->ExtensionBlockCount,
+					   &GifFile->ExtensionBlocks, 
+					   ExtFunction, ExtData[0], &ExtData[1])
+		      == GIF_ERROR)
+		      return (GIF_ERROR);
+	      }
+              for (;;) {
+                  if (DGifGetExtensionNext(GifFile, &ExtData) == GIF_ERROR)
+                      return (GIF_ERROR);
+		  if (ExtData == NULL)
+		      break;
+                  /* Continue the extension block */
+		  if (ExtData != NULL)
+		      if (GifAddExtensionBlock(&GifFile->ExtensionBlockCount,
+					       &GifFile->ExtensionBlocks,
+					       CONTINUE_EXT_FUNC_CODE, 
+					       ExtData[0], &ExtData[1]) == GIF_ERROR)
+                      return (GIF_ERROR);
+              }
+              break;
+
+          case TERMINATE_RECORD_TYPE:
+              break;
+
+          default:    /* Should be trapped by DGifGetRecordType */
+              break;
+        }
+    } while (RecordType != TERMINATE_RECORD_TYPE);
+
+    /* Sanity check for corrupted file */
+    if (GifFile->ImageCount == 0) {
+	GifFile->Error = D_GIF_ERR_NO_IMAG_DSCR;
+	return(GIF_ERROR);
+    }
+
+    return (GIF_OK);
+}
+
+/* end */

--- a/thirdparty/giflib/gif_err.c
+++ b/thirdparty/giflib/gif_err.c
@@ -1,0 +1,99 @@
+/*****************************************************************************
+
+gif_err.c - handle error reporting for the GIF library.
+
+SPDX-License-Identifier: MIT
+
+****************************************************************************/
+
+#include <stdio.h>
+
+#include "gif_lib.h"
+#include "gif_lib_private.h"
+
+/*****************************************************************************
+ Return a string description of  the last GIF error
+*****************************************************************************/
+const char *
+GifErrorString(int ErrorCode)
+{
+    const char *Err;
+
+    switch (ErrorCode) {
+      case E_GIF_ERR_OPEN_FAILED:
+        Err = "Failed to open given file";
+        break;
+      case E_GIF_ERR_WRITE_FAILED:
+        Err = "Failed to write to given file";
+        break;
+      case E_GIF_ERR_HAS_SCRN_DSCR:
+        Err = "Screen descriptor has already been set";
+        break;
+      case E_GIF_ERR_HAS_IMAG_DSCR:
+        Err = "Image descriptor is still active";
+        break;
+      case E_GIF_ERR_NO_COLOR_MAP:
+        Err = "Neither global nor local color map";
+        break;
+      case E_GIF_ERR_DATA_TOO_BIG:
+        Err = "Number of pixels bigger than width * height";
+        break;
+      case E_GIF_ERR_NOT_ENOUGH_MEM:
+        Err = "Failed to allocate required memory";
+        break;
+      case E_GIF_ERR_DISK_IS_FULL:
+        Err = "Write failed (disk full?)";
+        break;
+      case E_GIF_ERR_CLOSE_FAILED:
+        Err = "Failed to close given file";
+        break;
+      case E_GIF_ERR_NOT_WRITEABLE:
+        Err = "Given file was not opened for write";
+        break;
+      case D_GIF_ERR_OPEN_FAILED:
+        Err = "Failed to open given file";
+        break;
+      case D_GIF_ERR_READ_FAILED:
+        Err = "Failed to read from given file";
+        break;
+      case D_GIF_ERR_NOT_GIF_FILE:
+        Err = "Data is not in GIF format";
+        break;
+      case D_GIF_ERR_NO_SCRN_DSCR:
+        Err = "No screen descriptor detected";
+        break;
+      case D_GIF_ERR_NO_IMAG_DSCR:
+        Err = "No Image Descriptor detected";
+        break;
+      case D_GIF_ERR_NO_COLOR_MAP:
+        Err = "Neither global nor local color map";
+        break;
+      case D_GIF_ERR_WRONG_RECORD:
+        Err = "Wrong record type detected";
+        break;
+      case D_GIF_ERR_DATA_TOO_BIG:
+        Err = "Number of pixels bigger than width * height";
+        break;
+      case D_GIF_ERR_NOT_ENOUGH_MEM:
+        Err = "Failed to allocate required memory";
+        break;
+      case D_GIF_ERR_CLOSE_FAILED:
+        Err = "Failed to close given file";
+        break;
+      case D_GIF_ERR_NOT_READABLE:
+        Err = "Given file was not opened for read";
+        break;
+      case D_GIF_ERR_IMAGE_DEFECT:
+        Err = "Image is defective, decoding aborted";
+        break;
+      case D_GIF_ERR_EOF_TOO_SOON:
+        Err = "Image EOF detected before image complete";
+        break;
+      default:
+        Err = NULL;
+        break;
+    }
+    return Err;
+}
+
+/* end */

--- a/thirdparty/giflib/gif_hash.c
+++ b/thirdparty/giflib/gif_hash.c
@@ -1,0 +1,133 @@
+/*****************************************************************************
+
+gif_hash.c -- module to support the following operations:
+
+1. InitHashTable - initialize hash table.
+2. ClearHashTable - clear the hash table to an empty state.
+2. InsertHashTable - insert one item into data structure.
+3. ExistsHashTable - test if item exists in data structure.
+
+This module is used to hash the GIF codes during encoding.
+
+SPDX-License-Identifier: MIT
+
+*****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "gif_lib.h"
+#include "gif_hash.h"
+#include "gif_lib_private.h"
+
+/* #define  DEBUG_HIT_RATE    Debug number of misses per hash Insert/Exists. */
+
+#ifdef	DEBUG_HIT_RATE
+static long NumberOfTests = 0,
+	    NumberOfMisses = 0;
+#endif	/* DEBUG_HIT_RATE */
+
+static int KeyItem(uint32_t Item);
+
+/******************************************************************************
+ Initialize HashTable - allocate the memory needed and clear it.	      *
+******************************************************************************/
+GifHashTableType *_InitHashTable(void)
+{
+    GifHashTableType *HashTable;
+
+    if ((HashTable = (GifHashTableType *) malloc(sizeof(GifHashTableType)))
+	== NULL)
+	return NULL;
+
+    _ClearHashTable(HashTable);
+
+    return HashTable;
+}
+
+/******************************************************************************
+ Routine to clear the HashTable to an empty state.			      *
+ This part is a little machine depended. Use the commented part otherwise.   *
+******************************************************************************/
+void _ClearHashTable(GifHashTableType *HashTable)
+{
+    memset(HashTable -> HTable, 0xFF, HT_SIZE * sizeof(uint32_t));
+}
+
+/******************************************************************************
+ Routine to insert a new Item into the HashTable. The data is assumed to be  *
+ new one.								      *
+******************************************************************************/
+void _InsertHashTable(GifHashTableType *HashTable, uint32_t Key, int Code)
+{
+    int HKey = KeyItem(Key);
+    uint32_t *HTable = HashTable -> HTable;
+
+#ifdef DEBUG_HIT_RATE
+	NumberOfTests++;
+	NumberOfMisses++;
+#endif /* DEBUG_HIT_RATE */
+
+    while (HT_GET_KEY(HTable[HKey]) != 0xFFFFFL) {
+#ifdef DEBUG_HIT_RATE
+	    NumberOfMisses++;
+#endif /* DEBUG_HIT_RATE */
+	HKey = (HKey + 1) & HT_KEY_MASK;
+    }
+    HTable[HKey] = HT_PUT_KEY(Key) | HT_PUT_CODE(Code);
+}
+
+/******************************************************************************
+ Routine to test if given Key exists in HashTable and if so returns its code *
+ Returns the Code if key was found, -1 if not.				      *
+******************************************************************************/
+int _ExistsHashTable(GifHashTableType *HashTable, uint32_t Key)
+{
+    int HKey = KeyItem(Key);
+    uint32_t *HTable = HashTable -> HTable, HTKey;
+
+#ifdef DEBUG_HIT_RATE
+	NumberOfTests++;
+	NumberOfMisses++;
+#endif /* DEBUG_HIT_RATE */
+
+    while ((HTKey = HT_GET_KEY(HTable[HKey])) != 0xFFFFFL) {
+#ifdef DEBUG_HIT_RATE
+	    NumberOfMisses++;
+#endif /* DEBUG_HIT_RATE */
+	if (Key == HTKey) return HT_GET_CODE(HTable[HKey]);
+	HKey = (HKey + 1) & HT_KEY_MASK;
+    }
+
+    return -1;
+}
+
+/******************************************************************************
+ Routine to generate an HKey for the hashtable out of the given unique key.  *
+ The given Key is assumed to be 20 bits as follows: lower 8 bits are the     *
+ new postfix character, while the upper 12 bits are the prefix code.	      *
+ Because the average hit ratio is only 2 (2 hash references per entry),      *
+ evaluating more complex keys (such as twin prime keys) does not worth it!   *
+******************************************************************************/
+static int KeyItem(uint32_t Item)
+{
+    return ((Item >> 12) ^ Item) & HT_KEY_MASK;
+}
+
+#ifdef	DEBUG_HIT_RATE
+/******************************************************************************
+ Debugging routine to print the hit ratio - number of times the hash table   *
+ was tested per operation. This routine was used to test the KeyItem routine *
+******************************************************************************/
+void HashTablePrintHitRatio(void)
+{
+    printf("Hash Table Hit Ratio is %ld/%ld = %ld%%.\n",
+	NumberOfMisses, NumberOfTests,
+	NumberOfMisses * 100 / NumberOfTests);
+}
+#endif	/* DEBUG_HIT_RATE */
+
+/* end */

--- a/thirdparty/giflib/gif_hash.h
+++ b/thirdparty/giflib/gif_hash.h
@@ -1,0 +1,48 @@
+/******************************************************************************
+
+gif_hash.h - magfic constants and declarations for GIF LZW
+
+SPDX-License-Identifier: MIT
+
+******************************************************************************/
+
+#ifndef _GIF_HASH_H_
+#define _GIF_HASH_H_
+
+// -- GODOT start --
+// Fix compilation on Windows.
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif /* _WIN32 */
+// -- GODOT end --
+#include <stdint.h>
+
+#define HT_SIZE			8192	   /* 12bits = 4096 or twice as big! */
+#define HT_KEY_MASK		0x1FFF			      /* 13bits keys */
+#define HT_KEY_NUM_BITS		13			      /* 13bits keys */
+#define HT_MAX_KEY		8191	/* 13bits - 1, maximal code possible */
+#define HT_MAX_CODE		4095	/* Biggest code possible in 12 bits. */
+
+/* The 32 bits of the long are divided into two parts for the key & code:   */
+/* 1. The code is 12 bits as our compression algorithm is limited to 12bits */
+/* 2. The key is 12 bits Prefix code + 8 bit new char or 20 bits.	    */
+/* The key is the upper 20 bits.  The code is the lower 12. */
+#define HT_GET_KEY(l)	(l >> 12)
+#define HT_GET_CODE(l)	(l & 0x0FFF)
+#define HT_PUT_KEY(l)	(l << 12)
+#define HT_PUT_CODE(l)	(l & 0x0FFF)
+
+typedef struct GifHashTableType {
+    uint32_t HTable[HT_SIZE];
+} GifHashTableType;
+
+GifHashTableType *_InitHashTable(void);
+void _ClearHashTable(GifHashTableType *HashTable);
+void _InsertHashTable(GifHashTableType *HashTable, uint32_t Key, int Code);
+int _ExistsHashTable(GifHashTableType *HashTable, uint32_t Key);
+
+#endif /* _GIF_HASH_H_ */
+
+/* end */

--- a/thirdparty/giflib/gif_lib.h
+++ b/thirdparty/giflib/gif_lib.h
@@ -1,0 +1,303 @@
+/******************************************************************************
+ 
+gif_lib.h - service library for decoding and encoding GIF images
+                                                                             
+SPDX-License-Identifier: MIT
+
+*****************************************************************************/
+
+#ifndef _GIF_LIB_H_
+#define _GIF_LIB_H_ 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#define GIFLIB_MAJOR 5
+#define GIFLIB_MINOR 2
+#define GIFLIB_RELEASE 1
+
+#define GIF_ERROR   0
+#define GIF_OK      1
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#define GIF_STAMP "GIFVER"          /* First chars in file - GIF stamp.  */
+#define GIF_STAMP_LEN sizeof(GIF_STAMP) - 1
+#define GIF_VERSION_POS 3           /* Version first character in stamp. */
+#define GIF87_STAMP "GIF87a"        /* First chars in file - GIF stamp.  */
+#define GIF89_STAMP "GIF89a"        /* First chars in file - GIF stamp.  */
+
+typedef unsigned char GifPixelType;
+typedef unsigned char *GifRowType;
+typedef unsigned char GifByteType;
+typedef unsigned int GifPrefixType;
+typedef int GifWord;
+
+typedef struct GifColorType {
+    GifByteType Red, Green, Blue;
+} GifColorType;
+
+typedef struct ColorMapObject {
+    int ColorCount;
+    int BitsPerPixel;
+    bool SortFlag;
+    GifColorType *Colors;    /* on malloc(3) heap */
+} ColorMapObject;
+
+typedef struct GifImageDesc {
+    GifWord Left, Top, Width, Height;   /* Current image dimensions. */
+    bool Interlace;                     /* Sequential/Interlaced lines. */
+    ColorMapObject *ColorMap;           /* The local color map */
+} GifImageDesc;
+
+typedef struct ExtensionBlock {
+    int ByteCount;
+    GifByteType *Bytes; /* on malloc(3) heap */
+    int Function;       /* The block function code */
+#define CONTINUE_EXT_FUNC_CODE    0x00    /* continuation subblock */
+#define COMMENT_EXT_FUNC_CODE     0xfe    /* comment */
+#define GRAPHICS_EXT_FUNC_CODE    0xf9    /* graphics control (GIF89) */
+#define PLAINTEXT_EXT_FUNC_CODE   0x01    /* plaintext */
+#define APPLICATION_EXT_FUNC_CODE 0xff    /* application block (GIF89) */
+} ExtensionBlock;
+
+typedef struct SavedImage {
+    GifImageDesc ImageDesc;
+    GifByteType *RasterBits;         /* on malloc(3) heap */
+    int ExtensionBlockCount;         /* Count of extensions before image */    
+    ExtensionBlock *ExtensionBlocks; /* Extensions before image */    
+} SavedImage;
+
+typedef struct GifFileType {
+    GifWord SWidth, SHeight;         /* Size of virtual canvas */
+    GifWord SColorResolution;        /* How many colors can we generate? */
+    GifWord SBackGroundColor;        /* Background color for virtual canvas */
+    GifByteType AspectByte;	     /* Used to compute pixel aspect ratio */
+    ColorMapObject *SColorMap;       /* Global colormap, NULL if nonexistent. */
+    int ImageCount;                  /* Number of current image (both APIs) */
+    GifImageDesc Image;              /* Current image (low-level API) */
+    SavedImage *SavedImages;         /* Image sequence (high-level API) */
+    int ExtensionBlockCount;         /* Count extensions past last image */
+    ExtensionBlock *ExtensionBlocks; /* Extensions past last image */    
+    int Error;			     /* Last error condition reported */
+    void *UserData;                  /* hook to attach user data (TVT) */
+    void *Private;                   /* Don't mess with this! */
+} GifFileType;
+
+#define GIF_ASPECT_RATIO(n)	((n)+15.0/64.0)
+
+typedef enum {
+    UNDEFINED_RECORD_TYPE,
+    SCREEN_DESC_RECORD_TYPE,
+    IMAGE_DESC_RECORD_TYPE, /* Begin with ',' */
+    EXTENSION_RECORD_TYPE,  /* Begin with '!' */
+    TERMINATE_RECORD_TYPE   /* Begin with ';' */
+} GifRecordType;
+
+/* func type to read gif data from arbitrary sources (TVT) */
+typedef int (*InputFunc) (GifFileType *, GifByteType *, int);
+
+/* func type to write gif data to arbitrary targets.
+ * Returns count of bytes written. (MRB)
+ */
+typedef int (*OutputFunc) (GifFileType *, const GifByteType *, int);
+
+/******************************************************************************
+ GIF89 structures
+******************************************************************************/
+
+typedef struct GraphicsControlBlock {
+    int DisposalMode;
+#define DISPOSAL_UNSPECIFIED      0       /* No disposal specified. */
+#define DISPOSE_DO_NOT            1       /* Leave image in place */
+#define DISPOSE_BACKGROUND        2       /* Set area too background color */
+#define DISPOSE_PREVIOUS          3       /* Restore to previous content */
+    bool UserInputFlag;      /* User confirmation required before disposal */
+    int DelayTime;           /* pre-display delay in 0.01sec units */
+    int TransparentColor;    /* Palette index for transparency, -1 if none */
+#define NO_TRANSPARENT_COLOR	-1
+} GraphicsControlBlock;
+
+/******************************************************************************
+ GIF encoding routines
+******************************************************************************/
+
+/* Main entry points */
+GifFileType *EGifOpenFileName(const char *GifFileName,
+                              const bool GifTestExistence, int *Error);
+GifFileType *EGifOpenFileHandle(const int GifFileHandle, int *Error);
+GifFileType *EGifOpen(void *userPtr, OutputFunc writeFunc, int *Error);
+int EGifSpew(GifFileType * GifFile);
+const char *EGifGetGifVersion(GifFileType *GifFile); /* new in 5.x */
+int EGifCloseFile(GifFileType *GifFile, int *ErrorCode);
+
+#define E_GIF_SUCCEEDED          0
+#define E_GIF_ERR_OPEN_FAILED    1    /* And EGif possible errors. */
+#define E_GIF_ERR_WRITE_FAILED   2
+#define E_GIF_ERR_HAS_SCRN_DSCR  3
+#define E_GIF_ERR_HAS_IMAG_DSCR  4
+#define E_GIF_ERR_NO_COLOR_MAP   5
+#define E_GIF_ERR_DATA_TOO_BIG   6
+#define E_GIF_ERR_NOT_ENOUGH_MEM 7
+#define E_GIF_ERR_DISK_IS_FULL   8
+#define E_GIF_ERR_CLOSE_FAILED   9
+#define E_GIF_ERR_NOT_WRITEABLE  10
+
+/* These are legacy.  You probably do not want to call them directly */
+int EGifPutScreenDesc(GifFileType *GifFile,
+                      const int GifWidth, const int GifHeight, 
+		      const int GifColorRes,
+                      const int GifBackGround,
+                      const ColorMapObject *GifColorMap);
+int EGifPutImageDesc(GifFileType *GifFile, 
+		     const int GifLeft, const int GifTop,
+                     const int GifWidth, const int GifHeight, 
+		     const bool GifInterlace,
+                     const ColorMapObject *GifColorMap);
+void EGifSetGifVersion(GifFileType *GifFile, const bool gif89);
+int EGifPutLine(GifFileType *GifFile, GifPixelType *GifLine,
+                int GifLineLen);
+int EGifPutPixel(GifFileType *GifFile, const GifPixelType GifPixel);
+int EGifPutComment(GifFileType *GifFile, const char *GifComment);
+int EGifPutExtensionLeader(GifFileType *GifFile, const int GifExtCode);
+int EGifPutExtensionBlock(GifFileType *GifFile,
+                         const int GifExtLen, const void *GifExtension);
+int EGifPutExtensionTrailer(GifFileType *GifFile);
+int EGifPutExtension(GifFileType *GifFile, const int GifExtCode, 
+		     const int GifExtLen,
+                     const void *GifExtension);
+int EGifPutCode(GifFileType *GifFile, int GifCodeSize,
+                const GifByteType *GifCodeBlock);
+int EGifPutCodeNext(GifFileType *GifFile,
+                    const GifByteType *GifCodeBlock);
+
+/******************************************************************************
+ GIF decoding routines
+******************************************************************************/
+
+/* Main entry points */
+GifFileType *DGifOpenFileName(const char *GifFileName, int *Error);
+GifFileType *DGifOpenFileHandle(int GifFileHandle, int *Error);
+int DGifSlurp(GifFileType * GifFile);
+GifFileType *DGifOpen(void *userPtr, InputFunc readFunc, int *Error);    /* new one (TVT) */
+    int DGifCloseFile(GifFileType * GifFile, int *ErrorCode);
+
+#define D_GIF_SUCCEEDED          0
+#define D_GIF_ERR_OPEN_FAILED    101    /* And DGif possible errors. */
+#define D_GIF_ERR_READ_FAILED    102
+#define D_GIF_ERR_NOT_GIF_FILE   103
+#define D_GIF_ERR_NO_SCRN_DSCR   104
+#define D_GIF_ERR_NO_IMAG_DSCR   105
+#define D_GIF_ERR_NO_COLOR_MAP   106
+#define D_GIF_ERR_WRONG_RECORD   107
+#define D_GIF_ERR_DATA_TOO_BIG   108
+#define D_GIF_ERR_NOT_ENOUGH_MEM 109
+#define D_GIF_ERR_CLOSE_FAILED   110
+#define D_GIF_ERR_NOT_READABLE   111
+#define D_GIF_ERR_IMAGE_DEFECT   112
+#define D_GIF_ERR_EOF_TOO_SOON   113
+
+/* These are legacy.  You probably do not want to call them directly */
+int DGifGetScreenDesc(GifFileType *GifFile);
+int DGifGetRecordType(GifFileType *GifFile, GifRecordType *GifType);
+int DGifGetImageHeader(GifFileType *GifFile);
+int DGifGetImageDesc(GifFileType *GifFile);
+int DGifGetLine(GifFileType *GifFile, GifPixelType *GifLine, int GifLineLen);
+int DGifGetPixel(GifFileType *GifFile, GifPixelType GifPixel);
+int DGifGetExtension(GifFileType *GifFile, int *GifExtCode,
+                     GifByteType **GifExtension);
+int DGifGetExtensionNext(GifFileType *GifFile, GifByteType **GifExtension);
+int DGifGetCode(GifFileType *GifFile, int *GifCodeSize,
+                GifByteType **GifCodeBlock);
+int DGifGetCodeNext(GifFileType *GifFile, GifByteType **GifCodeBlock);
+int DGifGetLZCodes(GifFileType *GifFile, int *GifCode);
+const char *DGifGetGifVersion(GifFileType *GifFile);
+
+
+/******************************************************************************
+ Error handling and reporting.
+******************************************************************************/
+extern const char *GifErrorString(int ErrorCode);     /* new in 2012 - ESR */
+
+/*****************************************************************************
+ Everything below this point is new after version 1.2, supporting `slurp
+ mode' for doing I/O in two big belts with all the image-bashing in core.
+******************************************************************************/
+
+/******************************************************************************
+ Color map handling from gif_alloc.c
+******************************************************************************/
+
+extern ColorMapObject *GifMakeMapObject(int ColorCount,
+                                     const GifColorType *ColorMap);
+extern void GifFreeMapObject(ColorMapObject *Object);
+extern ColorMapObject *GifUnionColorMap(const ColorMapObject *ColorIn1,
+                                     const ColorMapObject *ColorIn2,
+                                     GifPixelType ColorTransIn2[]);
+extern int GifBitSize(int n);
+
+/******************************************************************************
+ Support for the in-core structures allocation (slurp mode).              
+******************************************************************************/
+
+extern void GifApplyTranslation(SavedImage *Image, GifPixelType Translation[]);
+extern int GifAddExtensionBlock(int *ExtensionBlock_Count,
+				ExtensionBlock **ExtensionBlocks, 
+				int Function, 
+				unsigned int Len, unsigned char ExtData[]);
+extern void GifFreeExtensions(int *ExtensionBlock_Count,
+			      ExtensionBlock **ExtensionBlocks);
+extern SavedImage *GifMakeSavedImage(GifFileType *GifFile,
+                                  const SavedImage *CopyFrom);
+extern void GifFreeSavedImages(GifFileType *GifFile);
+
+/******************************************************************************
+ 5.x functions for GIF89 graphics control blocks
+******************************************************************************/
+
+int DGifExtensionToGCB(const size_t GifExtensionLength,
+		       const GifByteType *GifExtension,
+		       GraphicsControlBlock *GCB);
+size_t EGifGCBToExtension(const GraphicsControlBlock *GCB,
+		       GifByteType *GifExtension);
+
+int DGifSavedExtensionToGCB(GifFileType *GifFile, 
+			    int ImageIndex, 
+			    GraphicsControlBlock *GCB);
+int EGifGCBToSavedExtension(const GraphicsControlBlock *GCB, 
+			    GifFileType *GifFile, 
+			    int ImageIndex);
+
+/******************************************************************************
+ The library's internal utility font                          
+******************************************************************************/
+
+#define GIF_FONT_WIDTH  8
+#define GIF_FONT_HEIGHT 8
+extern const unsigned char GifAsciiTable8x8[][GIF_FONT_WIDTH];
+
+extern void GifDrawText8x8(SavedImage *Image,
+                     const int x, const int y,
+                     const char *legend, const int color);
+
+extern void GifDrawBox(SavedImage *Image,
+                    const int x, const int y,
+                    const int w, const int d, const int color);
+
+extern void GifDrawRectangle(SavedImage *Image,
+                   const int x, const int y,
+                   const int w, const int d, const int color);
+
+extern void GifDrawBoxedText8x8(SavedImage *Image,
+                          const int x, const int y,
+                          const char *legend,
+                          const int border, const int bg, const int fg);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* _GIF_LIB_H */
+
+/* end */

--- a/thirdparty/giflib/gif_lib_private.h
+++ b/thirdparty/giflib/gif_lib_private.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+
+gif_lib_private.h - internal giflib routines and structures
+
+SPDX-License-Identifier: MIT
+
+****************************************************************************/
+
+#ifndef _GIF_LIB_PRIVATE_H
+#define _GIF_LIB_PRIVATE_H
+
+#include "gif_lib.h"
+#include "gif_hash.h"
+
+#ifndef SIZE_MAX
+    #define SIZE_MAX     UINTPTR_MAX
+#endif
+
+#define EXTENSION_INTRODUCER      0x21
+#define DESCRIPTOR_INTRODUCER     0x2c
+#define TERMINATOR_INTRODUCER     0x3b
+
+#define LZ_MAX_CODE         4095    /* Biggest code possible in 12 bits. */
+#define LZ_BITS             12
+
+#define FLUSH_OUTPUT        4096    /* Impossible code, to signal flush. */
+#define FIRST_CODE          4097    /* Impossible code, to signal first. */
+#define NO_SUCH_CODE        4098    /* Impossible code, to signal empty. */
+
+#define FILE_STATE_WRITE    0x01
+#define FILE_STATE_SCREEN   0x02
+#define FILE_STATE_IMAGE    0x04
+#define FILE_STATE_READ     0x08
+
+#define IS_READABLE(Private)    (Private->FileState & FILE_STATE_READ)
+#define IS_WRITEABLE(Private)   (Private->FileState & FILE_STATE_WRITE)
+
+typedef struct GifFilePrivateType {
+    GifWord FileState, FileHandle,  /* Where all this data goes to! */
+      BitsPerPixel,     /* Bits per pixel (Codes uses at least this + 1). */
+      ClearCode,   /* The CLEAR LZ code. */
+      EOFCode,     /* The EOF LZ code. */
+      RunningCode, /* The next code algorithm can generate. */
+      RunningBits, /* The number of bits required to represent RunningCode. */
+      MaxCode1,    /* 1 bigger than max. possible code, in RunningBits bits. */
+      LastCode,    /* The code before the current code. */
+      CrntCode,    /* Current algorithm code. */
+      StackPtr,    /* For character stack (see below). */
+      CrntShiftState;    /* Number of bits in CrntShiftDWord. */
+    unsigned long CrntShiftDWord;   /* For bytes decomposition into codes. */
+    unsigned long PixelCount;   /* Number of pixels in image. */
+    FILE *File;    /* File as stream. */
+    InputFunc Read;     /* function to read gif input (TVT) */
+    OutputFunc Write;   /* function to write gif output (MRB) */
+    GifByteType Buf[256];   /* Compressed input is buffered here. */
+    GifByteType Stack[LZ_MAX_CODE]; /* Decoded pixels are stacked here. */
+    GifByteType Suffix[LZ_MAX_CODE + 1];    /* So we can trace the codes. */
+    GifPrefixType Prefix[LZ_MAX_CODE + 1];
+    GifHashTableType *HashTable;
+    bool gif89;
+} GifFilePrivateType;
+
+#ifndef HAVE_REALLOCARRAY
+extern void *openbsd_reallocarray(void *optr, size_t nmemb, size_t size);
+#define reallocarray openbsd_reallocarray
+#endif
+
+#endif /* _GIF_LIB_PRIVATE_H */
+
+/* end */

--- a/thirdparty/giflib/gifalloc.c
+++ b/thirdparty/giflib/gifalloc.c
@@ -1,0 +1,420 @@
+/*****************************************************************************
+
+ GIF construction tools
+
+SPDX-License-Identifier: MIT
+
+****************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "gif_lib.h"
+#include "gif_lib_private.h"
+
+#define MAX(x, y)    (((x) > (y)) ? (x) : (y))
+
+/******************************************************************************
+ Miscellaneous utility functions                          
+******************************************************************************/
+
+/* return smallest bitfield size n will fit in */
+int
+GifBitSize(int n)
+{
+    register int i;
+
+    for (i = 1; i <= 8; i++)
+        if ((1 << i) >= n)
+            break;
+    return (i);
+}
+
+/******************************************************************************
+  Color map object functions                              
+******************************************************************************/
+
+/*
+ * Allocate a color map of given size; initialize with contents of
+ * ColorMap if that pointer is non-NULL.
+ */
+ColorMapObject *
+GifMakeMapObject(int ColorCount, const GifColorType *ColorMap)
+{
+    ColorMapObject *Object;
+
+    /*** FIXME: Our ColorCount has to be a power of two.  Is it necessary to
+     * make the user know that or should we automatically round up instead? */
+    if (ColorCount != (1 << GifBitSize(ColorCount))) {
+        return ((ColorMapObject *) NULL);
+    }
+    
+    Object = (ColorMapObject *)malloc(sizeof(ColorMapObject));
+    if (Object == (ColorMapObject *) NULL) {
+        return ((ColorMapObject *) NULL);
+    }
+
+    Object->Colors = (GifColorType *)calloc(ColorCount, sizeof(GifColorType));
+    if (Object->Colors == (GifColorType *) NULL) {
+	free(Object);
+        return ((ColorMapObject *) NULL);
+    }
+
+    Object->ColorCount = ColorCount;
+    Object->BitsPerPixel = GifBitSize(ColorCount);
+    Object->SortFlag = false;
+
+    if (ColorMap != NULL) {
+        memcpy((char *)Object->Colors,
+               (char *)ColorMap, ColorCount * sizeof(GifColorType));
+    }
+
+    return (Object);
+}
+
+/*******************************************************************************
+Free a color map object
+*******************************************************************************/
+void
+GifFreeMapObject(ColorMapObject *Object)
+{
+    if (Object != NULL) {
+        (void)free(Object->Colors);
+        (void)free(Object);
+    }
+}
+
+#ifdef DEBUG
+void
+DumpColorMap(ColorMapObject *Object,
+             FILE * fp)
+{
+    if (Object != NULL) {
+        int i, j, Len = Object->ColorCount;
+
+        for (i = 0; i < Len; i += 4) {
+            for (j = 0; j < 4 && j < Len; j++) {
+                (void)fprintf(fp, "%3d: %02x %02x %02x   ", i + j,
+			      Object->Colors[i + j].Red,
+			      Object->Colors[i + j].Green,
+			      Object->Colors[i + j].Blue);
+            }
+            (void)fprintf(fp, "\n");
+        }
+    }
+}
+#endif /* DEBUG */
+
+/*******************************************************************************
+ Compute the union of two given color maps and return it.  If result can't 
+ fit into 256 colors, NULL is returned, the allocated union otherwise.
+ ColorIn1 is copied as is to ColorUnion, while colors from ColorIn2 are
+ copied iff they didn't exist before.  ColorTransIn2 maps the old
+ ColorIn2 into the ColorUnion color map table./
+*******************************************************************************/
+ColorMapObject *
+GifUnionColorMap(const ColorMapObject *ColorIn1,
+              const ColorMapObject *ColorIn2,
+              GifPixelType ColorTransIn2[])
+{
+    int i, j, CrntSlot, RoundUpTo, NewGifBitSize;
+    ColorMapObject *ColorUnion;
+
+    /*
+     * We don't worry about duplicates within either color map; if
+     * the caller wants to resolve those, he can perform unions
+     * with an empty color map.
+     */
+
+    /* Allocate table which will hold the result for sure. */
+    ColorUnion = GifMakeMapObject(MAX(ColorIn1->ColorCount,
+                               ColorIn2->ColorCount) * 2, NULL);
+
+    if (ColorUnion == NULL)
+        return (NULL);
+
+    /* 
+     * Copy ColorIn1 to ColorUnion.
+     */
+    for (i = 0; i < ColorIn1->ColorCount; i++)
+        ColorUnion->Colors[i] = ColorIn1->Colors[i];
+    CrntSlot = ColorIn1->ColorCount;
+
+    /* 
+     * Potentially obnoxious hack:
+     *
+     * Back CrntSlot down past all contiguous {0, 0, 0} slots at the end
+     * of table 1.  This is very useful if your display is limited to
+     * 16 colors.
+     */
+    while (ColorIn1->Colors[CrntSlot - 1].Red == 0
+           && ColorIn1->Colors[CrntSlot - 1].Green == 0
+           && ColorIn1->Colors[CrntSlot - 1].Blue == 0)
+        CrntSlot--;
+
+    /* Copy ColorIn2 to ColorUnion (use old colors if they exist): */
+    for (i = 0; i < ColorIn2->ColorCount && CrntSlot <= 256; i++) {
+        /* Let's see if this color already exists: */
+        for (j = 0; j < ColorIn1->ColorCount; j++)
+            if (memcmp (&ColorIn1->Colors[j], &ColorIn2->Colors[i], 
+                        sizeof(GifColorType)) == 0)
+                break;
+
+        if (j < ColorIn1->ColorCount)
+            ColorTransIn2[i] = j;    /* color exists in Color1 */
+        else {
+            /* Color is new - copy it to a new slot: */
+            ColorUnion->Colors[CrntSlot] = ColorIn2->Colors[i];
+            ColorTransIn2[i] = CrntSlot++;
+        }
+    }
+
+    if (CrntSlot > 256) {
+        GifFreeMapObject(ColorUnion);
+        return ((ColorMapObject *) NULL);
+    }
+
+    NewGifBitSize = GifBitSize(CrntSlot);
+    RoundUpTo = (1 << NewGifBitSize);
+
+    if (RoundUpTo != ColorUnion->ColorCount) {
+        register GifColorType *Map = ColorUnion->Colors;
+
+        /* 
+         * Zero out slots up to next power of 2.
+         * We know these slots exist because of the way ColorUnion's
+         * start dimension was computed.
+         */
+        for (j = CrntSlot; j < RoundUpTo; j++)
+            Map[j].Red = Map[j].Green = Map[j].Blue = 0;
+
+        /* perhaps we can shrink the map? */
+        if (RoundUpTo < ColorUnion->ColorCount) {
+            GifColorType *new_map = (GifColorType *)reallocarray(Map,
+                                 RoundUpTo, sizeof(GifColorType));
+            if( new_map == NULL ) {
+                GifFreeMapObject(ColorUnion);
+                return ((ColorMapObject *) NULL);
+            }
+            ColorUnion->Colors = new_map;
+        }
+    }
+
+    ColorUnion->ColorCount = RoundUpTo;
+    ColorUnion->BitsPerPixel = NewGifBitSize;
+
+    return (ColorUnion);
+}
+
+/*******************************************************************************
+ Apply a given color translation to the raster bits of an image
+*******************************************************************************/
+void
+GifApplyTranslation(SavedImage *Image, GifPixelType Translation[])
+{
+    register int i;
+    register int RasterSize = Image->ImageDesc.Height * Image->ImageDesc.Width;
+
+    for (i = 0; i < RasterSize; i++)
+        Image->RasterBits[i] = Translation[Image->RasterBits[i]];
+}
+
+/******************************************************************************
+ Extension record functions                              
+******************************************************************************/
+int
+GifAddExtensionBlock(int *ExtensionBlockCount,
+		     ExtensionBlock **ExtensionBlocks,
+		     int Function,
+		     unsigned int Len,
+		     unsigned char ExtData[])
+{
+    ExtensionBlock *ep;
+
+    if (*ExtensionBlocks == NULL)
+        *ExtensionBlocks=(ExtensionBlock *)malloc(sizeof(ExtensionBlock));
+    else {
+        ExtensionBlock* ep_new = (ExtensionBlock *)reallocarray
+				 (*ExtensionBlocks, (*ExtensionBlockCount + 1),
+                                      sizeof(ExtensionBlock));
+        if( ep_new == NULL )
+            return (GIF_ERROR);
+        *ExtensionBlocks = ep_new;
+    }
+
+    if (*ExtensionBlocks == NULL)
+        return (GIF_ERROR);
+
+    ep = &(*ExtensionBlocks)[(*ExtensionBlockCount)++];
+
+    ep->Function = Function;
+    ep->ByteCount=Len;
+    ep->Bytes = (GifByteType *)malloc(ep->ByteCount);
+    if (ep->Bytes == NULL)
+        return (GIF_ERROR);
+
+    if (ExtData != NULL) {
+        memcpy(ep->Bytes, ExtData, Len);
+    }
+
+    return (GIF_OK);
+}
+
+void
+GifFreeExtensions(int *ExtensionBlockCount,
+		  ExtensionBlock **ExtensionBlocks)
+{
+    ExtensionBlock *ep;
+
+    if (*ExtensionBlocks == NULL)
+        return;
+
+    for (ep = *ExtensionBlocks;
+	 ep < (*ExtensionBlocks + *ExtensionBlockCount); 
+	 ep++)
+        (void)free((char *)ep->Bytes);
+    (void)free((char *)*ExtensionBlocks);
+    *ExtensionBlocks = NULL;
+    *ExtensionBlockCount = 0;
+}
+
+/******************************************************************************
+ Image block allocation functions                          
+******************************************************************************/
+
+/* Private Function:
+ * Frees the last image in the GifFile->SavedImages array
+ */
+void
+FreeLastSavedImage(GifFileType *GifFile)
+{
+    SavedImage *sp;
+    
+    if ((GifFile == NULL) || (GifFile->SavedImages == NULL))
+        return;
+
+    /* Remove one SavedImage from the GifFile */
+    GifFile->ImageCount--;
+    sp = &GifFile->SavedImages[GifFile->ImageCount];
+
+    /* Deallocate its Colormap */
+    if (sp->ImageDesc.ColorMap != NULL) {
+        GifFreeMapObject(sp->ImageDesc.ColorMap);
+        sp->ImageDesc.ColorMap = NULL;
+    }
+
+    /* Deallocate the image data */
+    if (sp->RasterBits != NULL)
+        free((char *)sp->RasterBits);
+
+    /* Deallocate any extensions */
+    GifFreeExtensions(&sp->ExtensionBlockCount, &sp->ExtensionBlocks);
+
+    /*** FIXME: We could realloc the GifFile->SavedImages structure but is
+     * there a point to it? Saves some memory but we'd have to do it every
+     * time.  If this is used in GifFreeSavedImages then it would be inefficient
+     * (The whole array is going to be deallocated.)  If we just use it when
+     * we want to free the last Image it's convenient to do it here.
+     */
+}
+
+/*
+ * Append an image block to the SavedImages array  
+ */
+SavedImage *
+GifMakeSavedImage(GifFileType *GifFile, const SavedImage *CopyFrom)
+{
+    if (GifFile->SavedImages == NULL)
+        GifFile->SavedImages = (SavedImage *)malloc(sizeof(SavedImage));
+    else {
+        SavedImage* newSavedImages = (SavedImage *)reallocarray(GifFile->SavedImages,
+                               (GifFile->ImageCount + 1), sizeof(SavedImage));
+        if( newSavedImages == NULL)
+            return ((SavedImage *)NULL);
+        GifFile->SavedImages = newSavedImages;
+    }
+    if (GifFile->SavedImages == NULL)
+        return ((SavedImage *)NULL);
+    else {
+        SavedImage *sp = &GifFile->SavedImages[GifFile->ImageCount++];
+
+        if (CopyFrom != NULL) {
+            memcpy((char *)sp, CopyFrom, sizeof(SavedImage));
+
+            /* 
+             * Make our own allocated copies of the heap fields in the
+             * copied record.  This guards against potential aliasing
+             * problems.
+             */
+
+            /* first, the local color map */
+            if (CopyFrom->ImageDesc.ColorMap != NULL) {
+                sp->ImageDesc.ColorMap = GifMakeMapObject(
+                                         CopyFrom->ImageDesc.ColorMap->ColorCount,
+                                         CopyFrom->ImageDesc.ColorMap->Colors);
+                if (sp->ImageDesc.ColorMap == NULL) {
+                    FreeLastSavedImage(GifFile);
+                    return (SavedImage *)(NULL);
+                }
+            }
+
+            /* next, the raster */
+            sp->RasterBits = (unsigned char *)reallocarray(NULL,
+                                                  (CopyFrom->ImageDesc.Height *
+                                                  CopyFrom->ImageDesc.Width),
+						  sizeof(GifPixelType));
+            if (sp->RasterBits == NULL) {
+                FreeLastSavedImage(GifFile);
+                return (SavedImage *)(NULL);
+            }
+            memcpy(sp->RasterBits, CopyFrom->RasterBits,
+                   sizeof(GifPixelType) * CopyFrom->ImageDesc.Height *
+                   CopyFrom->ImageDesc.Width);
+
+            /* finally, the extension blocks */
+            if (CopyFrom->ExtensionBlocks != NULL) {
+                sp->ExtensionBlocks = (ExtensionBlock *)reallocarray(NULL,
+                                      CopyFrom->ExtensionBlockCount,
+				      sizeof(ExtensionBlock));
+                if (sp->ExtensionBlocks == NULL) {
+                    FreeLastSavedImage(GifFile);
+                    return (SavedImage *)(NULL);
+                }
+                memcpy(sp->ExtensionBlocks, CopyFrom->ExtensionBlocks,
+                       sizeof(ExtensionBlock) * CopyFrom->ExtensionBlockCount);
+            }
+        }
+        else {
+            memset((char *)sp, '\0', sizeof(SavedImage));
+        }
+
+        return (sp);
+    }
+}
+
+void
+GifFreeSavedImages(GifFileType *GifFile)
+{
+    SavedImage *sp;
+
+    if ((GifFile == NULL) || (GifFile->SavedImages == NULL)) {
+        return;
+    }
+    for (sp = GifFile->SavedImages;
+         sp < GifFile->SavedImages + GifFile->ImageCount; sp++) {
+        if (sp->ImageDesc.ColorMap != NULL) {
+            GifFreeMapObject(sp->ImageDesc.ColorMap);
+            sp->ImageDesc.ColorMap = NULL;
+        }
+
+        if (sp->RasterBits != NULL)
+            free((char *)sp->RasterBits);
+	
+	GifFreeExtensions(&sp->ExtensionBlockCount, &sp->ExtensionBlocks);
+    }
+    free((char *)GifFile->SavedImages);
+    GifFile->SavedImages = NULL;
+}
+
+/* end */

--- a/thirdparty/giflib/openbsd-reallocarray.c
+++ b/thirdparty/giflib/openbsd-reallocarray.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <sys/types.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifndef SIZE_MAX
+    #define SIZE_MAX     UINTPTR_MAX
+#endif
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
+
+void *
+openbsd_reallocarray(void *optr, size_t nmemb, size_t size)
+{
+	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    nmemb > 0 && SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	/*
+	 * Head off variations in realloc behavior on different
+	 * platforms (reported by MarkR <mrogers6@users.sf.net>)
+	 *
+	 * The behaviour of reallocarray is implementation-defined if
+	 * nmemb or size is zero. It can return NULL or non-NULL
+	 * depending on the platform.
+	 * https://www.securecoding.cert.org/confluence/display/c/MEM04-C.Beware+of+zero-lengthallocations
+	 *
+	 * Here are some extracts from realloc man pages on different platforms.
+	 *
+	 * void realloc( void memblock, size_t size );
+	 *
+	 * Windows:
+	 *
+	 * If there is not enough available memory to expand the block
+	 * to the given size, the original block is left unchanged,
+	 * and NULL is returned.  If size is zero, then the block
+	 * pointed to by memblock is freed; the return value is NULL,
+	 * and memblock is left pointing at a freed block.
+	 *
+	 * OpenBSD:
+	 *
+	 * If size or nmemb is equal to 0, a unique pointer to an
+	 * access protected, zero sized object is returned. Access via
+	 * this pointer will generate a SIGSEGV exception.
+	 *
+	 * Linux:
+	 *
+	 * If size was equal to 0, either NULL or a pointer suitable
+	 * to be passed to free() is returned.
+	 *
+	 * OS X:
+	 *
+	 * If size is zero and ptr is not NULL, a new, minimum sized
+	 * object is allocated and the original object is freed.
+	 *
+	 * It looks like images with zero width or height can trigger
+	 * this, and fuzzing behaviour will differ by platform, so
+	 * fuzzing on one platform may not detect zero-size allocation
+	 * problems on other platforms.
+	 */
+	if (size == 0 || nmemb == 0)
+	    return NULL;
+	return realloc(optr, size * nmemb);
+}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot-proposals/issues/1433

![godot-gif](https://user-images.githubusercontent.com/3595817/64067219-61e89700-cc25-11e9-8fb9-d2e6a9f9c63e.gif)

This pull allows to directly import GIF files inside Godot.

It adds a module that uses giflib to convert each frame of the GIF to RGBA images.

Inside the third party folder there are only the files of giflib that are required to do this operation ( almost all of the functions are inside dgif_lib.c ). I didn't change the source code of the library, so there are a couple of extra files that are there only because they are required to compile the code.

Right now it only allows to read GIFs, I don't know if saving changes is something that we should handle or not.

I'm not sure of which data structure is the best for this kind of files.
AnimatedTexture is simple and it allows to set a custom delay for each frame of the animation. The problem is that it has a limit of 256 frames.

SpriteFrames has the opposite problem, it doesn't have a limit to the number of frames but it can't set a specific delay for each frame.

Right now they are converted into AnimatedTextures.

Another problem is that there's no way to change the flags of the Texture. To change them you have to manually set them for each frame.

Once completed it will resolve #8599