### PR TITLE
Improve AudioStreamSample and AudioStreamGenerator documentation

### DIFF
--- a/doc/classes/AudioStreamGenerator.xml
+++ b/doc/classes/AudioStreamGenerator.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://github.com/godotengine/godot-demo-projects/tree/master/audio/generator</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AudioStreamGeneratorPlayback.xml
+++ b/doc/classes/AudioStreamGeneratorPlayback.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://github.com/godotengine/godot-demo-projects/tree/master/audio/generator</link>
 	</tutorials>
 	<methods>
 		<method name="can_push_buffer" qualifiers="const">

--- a/doc/classes/AudioStreamSample.xml
+++ b/doc/classes/AudioStreamSample.xml
@@ -24,6 +24,7 @@
 	<members>
 		<member name="data" type="PoolByteArray" setter="set_data" getter="get_data" default="PoolByteArray(  )">
 			Contains the audio data in bytes.
+			[b]Note:[/b] This property expects signed PCM8 data. To convert unsigned PCM8 to signed PCM8, subtract 128 from each byte.
 		</member>
 		<member name="format" type="int" setter="set_format" getter="get_format" enum="AudioStreamSample.Format" default="0">
 			Audio format. See [code]FORMAT_*[/code] constants for values.


### PR DESCRIPTION
- Add a link to the audio generator demo in AudioStreamGenerator and AudioStreamGeneratorPlayback.
- Mention that signed PCM8 data is expected in AudioStreamSample (and how to convert unsigned PCM8 to signed PCM8).

Thanks @BenMcLean for providing feedback on this :slightly_smiling_face: