### PR TITLE
Increase the minimum width of the editor sectioned inspector

### DIFF
--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -316,7 +316,7 @@ SectionedInspector::SectionedInspector() :
 	add_constant_override("autohide", 1); // Fixes the dragger always showing up
 
 	VBoxContainer *left_vb = memnew(VBoxContainer);
-	left_vb->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
+	left_vb->set_custom_minimum_size(Size2(190, 0) * EDSCALE);
 	add_child(left_vb);
 
 	sections->set_v_size_flags(SIZE_EXPAND_FILL);


### PR DESCRIPTION
This makes sure section names such as "Window Placement" or "Vram Compression" aren't being cut off due to the panel width being too low.

## Preview

![Editor sectioned inspector left panel](https://user-images.githubusercontent.com/180032/64067885-cc9ed000-cc2f-11e9-9432-d91df383005c.png)