### PR TITLE
Export project dialog initial path is now set correctly

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3758,6 +3758,35 @@ bool String::is_valid_float() const {
 	return numbers_found;
 }
 
+String String::get_final_path_from(const String &p_relative_path) const {
+
+	if (!p_relative_path.is_rel_path()) {
+
+		return *this;
+	}
+	String final_path = this->replace("\\", "/").get_base_dir();
+	String rel = p_relative_path.replace("\\", "/");
+
+	Vector<String> rel_path_slices = rel.split("/");
+	int rel_path_slice_count = rel_path_slices.size();
+	for (int curr_rel_path_slice = 0; curr_rel_path_slice < rel_path_slice_count; curr_rel_path_slice++) {
+
+		String current_slice = rel_path_slices[curr_rel_path_slice];
+		if (current_slice == ".") {
+
+			continue;
+		} else if (current_slice == "..") {
+
+			final_path = final_path.substr(0, final_path.find_last("/"));
+		} else {
+
+			final_path += "/" + current_slice;
+		}
+	}
+
+	return final_path;
+}
+
 String String::path_to_file(const String &p_path) const {
 
 	String src = this->replace("\\", "/").get_base_dir();

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -317,6 +317,7 @@ public:
 	bool is_abs_path() const;
 	bool is_rel_path() const;
 	bool is_resource_file() const;
+	String get_final_path_from(const String &p_relative_path) const;
 	String path_to(const String &p_path) const;
 	String path_to_file(const String &p_path) const;
 	String get_base_dir() const;

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -931,8 +931,25 @@ void ProjectExportDialog::_export_project() {
 		export_project->add_filter("*." + extension_list[i] + " ; " + platform->get_name() + " Export");
 	}
 
-	if (current->get_export_path() != "") {
-		export_project->set_current_path(current->get_export_path());
+	String current_preset_export_path = current->get_export_path();
+	if (current_preset_export_path != "") {
+
+		/* NOTE(SonerSound): If we do not have an option for changing between absolute and relative paths, is this
+		 * check necessary? */
+		if (current_preset_export_path.is_rel_path()) {
+			String res_path = OS::get_singleton()->get_resource_dir() + "/";
+			current_preset_export_path = res_path.get_final_path_from(current_preset_export_path);
+		}
+
+		/* NOTE(SonerSound): If the target directory does not exist, it must be created, otherwise the set_current_path
+		 * call sets the export dialog initial path to the res:// directory. */
+		if (!DirAccess::exists(current_preset_export_path.get_base_dir())) {
+
+			DirAccessRef da(DirAccess::create(DirAccess::ACCESS_FILESYSTEM));
+			da->make_dir_recursive(current_preset_export_path.get_base_dir());
+		}
+
+		export_project->set_current_path(current_preset_export_path);
 	} else {
 		if (extension_list.size() >= 1) {
 			export_project->set_current_file(default_filename + "." + extension_list[0]);


### PR DESCRIPTION
Fixes #31427. (I think)

- Due to just saving specifically the export path as relative, we must convert it back to an absolute path before calling set_current_path on the export_project variable, otherwise it'll be set to the res:// path.