### PR TITLE
Solves ctrl+click on functions by ignoring the cursor

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -252,6 +252,16 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 			}
 		}
 
+		// Check that the next token is not TK_CURSOR and if it is, the offset should be incremented.
+		int next_valid_offset = 1;
+		if (tokenizer->get_token(next_valid_offset) == GDScriptTokenizer::TK_CURSOR) {
+			next_valid_offset++;
+			// There is a chunk of the identifier that also needs to be ignored (not always there!)
+			if (tokenizer->get_token(next_valid_offset) == GDScriptTokenizer::TK_IDENTIFIER) {
+				next_valid_offset++;
+			}
+		}
+
 		if (tokenizer->get_token() == GDScriptTokenizer::TK_PARENTHESIS_OPEN) {
 			//subexpression ()
 			tokenizer->advance();
@@ -668,7 +678,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 				expr = cn;
 			}
 
-		} else if (tokenizer->get_token(1) == GDScriptTokenizer::TK_PARENTHESIS_OPEN && tokenizer->is_token_literal()) {
+		} else if (tokenizer->get_token(next_valid_offset) == GDScriptTokenizer::TK_PARENTHESIS_OPEN && tokenizer->is_token_literal()) {
 			// We check with is_token_literal, as this allows us to use match/sync/etc. as a name
 			//function or constructor
 


### PR DESCRIPTION
(This is a new branch containing the same changes as in PR #31112 as something went wrong with the forks...)

Solves #31036, #20393 and issues discussed in #7080 (partially)

I went through the dismal spaghetti and conquered the legacy.
This PR solves an issue with blocking behavior of TK_CURSOR when control+clicking on an identifier (to jump to the function definition).

**Solution at work:**
(This is not possible with the current gdscript editor!)
![click](https://user-images.githubusercontent.com/42484461/64069865-8e1b0c80-cc53-11e9-9665-139a5e7519f3.gif)

**What does it solve?**
Control+clicking on a function call should normally jump to wherever the function definition is placed. This jump did not happen when the function definition was placed after the function call (see #31036).

**What was the problem?**
The parser expects the next token to be an open parenthesis and the current one to be a literal for proper parsing purposes. Now when the cursor is also part of the token array, this cursor blocks and exits the parser. The result is that ONLY the functions that were defined BEFORE the cursor would be added to the functions array of the Parser. As a result... finding functions that were defined AFTER the cursor was impossible.

**Is this the best implementation?**
I think there might be a more elegant solution somewhere 🤔 (or not)
Please guide me into the right direction!

Cheerios!