### PR TITLE
Timer and Tween check if they are in SceneTree when starting

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -783,10 +783,12 @@ float Tween::get_speed_scale() const {
 }
 
 bool Tween::start() {
+
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), false, "Tween was not added to the SceneTree!");
+
 	// Are there any pending updates?
 	if (pending_update != 0) {
 		// Start the tweens after deferring
-		call_deferred("start");
 		return true;
 	}
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2149,9 +2149,7 @@ bool Control::has_focus() const {
 
 void Control::grab_focus() {
 
-	if (!is_inside_tree()) {
-		ERR_FAIL_COND(!is_inside_tree());
-	}
+	ERR_FAIL_COND(!is_inside_tree());
 
 	if (data.focus_mode == FOCUS_NONE) {
 		WARN_PRINT("This control can't grab focus. Use set_focus_mode() to allow a control to get focus.");

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -107,6 +107,9 @@ bool Timer::has_autostart() const {
 }
 
 void Timer::start(float p_time) {
+
+	ERR_FAIL_COND_MSG(!is_inside_tree(), "Timer was not added to the SceneTree!");
+
 	if (p_time > 0) {
 		set_wait_time(p_time);
 	}


### PR DESCRIPTION
Implements functionality requested in #31785

### Timer
**Before**: starts when calling Timer.start() even when not inside the SceneTree.
**Now**: Doesn't start if it is NOT added to the SceneTree BEFORE calling Timer.start()

### Tween
**Before**: Returned True even when not inside of the SceneTree
**Now**: will still be started by Tween.start() BUT execution (processing) will always wait for the ENTER_TREE signal. Is this the expected behaviour? Or should Tween be unable to start as well?
Will also return False in this case.

Definition of wanted behavior could be refined a bit more maybe?

Cheerios,