### PR TITLE
Implement DOF blur, Glow, and BCS in GLES2

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -778,18 +778,44 @@ void RasterizerSceneGLES2::environment_set_camera_feed_id(RID p_env, int p_camer
 }
 
 void RasterizerSceneGLES2::environment_set_dof_blur_far(RID p_env, bool p_enable, float p_distance, float p_transition, float p_amount, VS::EnvironmentDOFBlurQuality p_quality) {
+
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
+
+	env->dof_blur_far_enabled = p_enable;
+	env->dof_blur_far_distance = p_distance;
+	env->dof_blur_far_transition = p_transition;
+	env->dof_blur_far_amount = p_amount;
+	env->dof_blur_far_quality = p_quality;
 }
 
 void RasterizerSceneGLES2::environment_set_dof_blur_near(RID p_env, bool p_enable, float p_distance, float p_transition, float p_amount, VS::EnvironmentDOFBlurQuality p_quality) {
+
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
+
+	env->dof_blur_near_enabled = p_enable;
+	env->dof_blur_near_distance = p_distance;
+	env->dof_blur_near_transition = p_transition;
+	env->dof_blur_near_amount = p_amount;
+	env->dof_blur_near_quality = p_quality;
 }
 
 void RasterizerSceneGLES2::environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale) {
+
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
+
+	env->glow_enabled = p_enable;
+	env->glow_levels = p_level_flags;
+	env->glow_intensity = p_intensity;
+	env->glow_strength = p_strength;
+	env->glow_bloom = p_bloom_threshold;
+	env->glow_blend_mode = p_blend_mode;
+	env->glow_hdr_bleed_threshold = p_hdr_bleed_threshold;
+	env->glow_hdr_bleed_scale = p_hdr_bleed_scale;
+	env->glow_hdr_luminance_cap = p_hdr_luminance_cap;
+	env->glow_bicubic_upscale = p_bicubic_upscale;
 }
 
 void RasterizerSceneGLES2::environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) {
@@ -813,8 +839,15 @@ void RasterizerSceneGLES2::environment_set_tonemap(RID p_env, VS::EnvironmentTon
 }
 
 void RasterizerSceneGLES2::environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) {
+
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
+
+	env->adjustments_enabled = p_enable;
+	env->adjustments_brightness = p_brightness;
+	env->adjustments_contrast = p_contrast;
+	env->adjustments_saturation = p_saturation;
+	env->color_correction = p_ramp;
 }
 
 void RasterizerSceneGLES2::environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount) {
@@ -1174,10 +1207,10 @@ void RasterizerSceneGLES2::_add_geometry_with_material(RasterizerStorageGLES2::G
 	}
 }
 
-void RasterizerSceneGLES2::_copy_texture_to_front_buffer(GLuint p_texture) {
+void RasterizerSceneGLES2::_copy_texture_to_buffer(GLuint p_texture, GLuint p_buffer) {
 
 	//copy to front buffer
-	glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo);
+	glBindFramebuffer(GL_FRAMEBUFFER, p_buffer);
 
 	glDepthMask(GL_FALSE);
 	glDisable(GL_DEPTH_TEST);
@@ -2710,6 +2743,451 @@ void RasterizerSceneGLES2::_draw_sky(RasterizerStorageGLES2::Sky *p_sky, const C
 	storage->shaders.copy.set_conditional(CopyShaderGLES2::USE_CUBEMAP, false);
 }
 
+void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p_cam_projection) {
+
+	//copy to front buffer
+
+	glDepthMask(GL_FALSE);
+	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_CULL_FACE);
+	glDisable(GL_BLEND);
+	glDepthFunc(GL_LEQUAL);
+	glColorMask(1, 1, 1, 1);
+
+	//no post process on small, transparent or render targets without an env
+	bool use_post_process = env && !storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT];
+	use_post_process = use_post_process && storage->frame.current_rt->width >= 4 && storage->frame.current_rt->height >= 4;
+	use_post_process = use_post_process && storage->frame.current_rt->mip_maps_allocated;
+
+	if (env) {
+		use_post_process = use_post_process && (env->adjustments_enabled || env->glow_enabled || env->dof_blur_far_enabled || env->dof_blur_near_enabled);
+	}
+
+	GLuint next_buffer;
+
+	if (use_post_process) {
+		next_buffer = storage->frame.current_rt->mip_maps[0].sizes[0].fbo;
+	} else {
+		// set next_buffer to front buffer so multisample blit can happen if needed
+		next_buffer = storage->frame.current_rt->fbo;
+	}
+
+	// If using multisample buffer, resolve to post_process_effect buffer or to front buffer
+	if (storage->frame.current_rt && storage->frame.current_rt->multisample_active) {
+#ifdef GLES_OVER_GL
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->multisample_fbo);
+		glReadBuffer(GL_COLOR_ATTACHMENT0);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, next_buffer);
+		glBlitFramebuffer(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+#elif IPHONE_ENABLED
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->multisample_fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, next_buffer);
+		glResolveMultisampleFramebufferAPPLE();
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+#elif ANDROID_ENABLED
+
+		// In GLES2 Android Blit is not available, so just copy color texture manually
+		_copy_texture_to_buffer(storage->frame.current_rt->multisample_color, next_buffer);
+#endif
+	} else if (use_post_process) {
+		_copy_texture_to_buffer(storage->frame.current_rt->color, storage->frame.current_rt->mip_maps[0].sizes[0].fbo);
+	}
+
+	if (!use_post_process) {
+		return;
+	}
+
+	// Order of operation
+	//1) DOF Blur (first blur, then copy to buffer applying the blur) //only on desktop
+	//2) Bloom (Glow) //only on desktop
+	//3) Adjustments
+
+	// DOF Blur
+
+	if (env->dof_blur_far_enabled) {
+
+		int vp_h = storage->frame.current_rt->height;
+		int vp_w = storage->frame.current_rt->width;
+
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::USE_ORTHOGONAL_PROJECTION, p_cam_projection.is_orthogonal());
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_FAR_BLUR, true);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_LOW, env->dof_blur_far_quality == VS::ENV_DOF_BLUR_QUALITY_LOW);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_MEDIUM, env->dof_blur_far_quality == VS::ENV_DOF_BLUR_QUALITY_MEDIUM);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_HIGH, env->dof_blur_far_quality == VS::ENV_DOF_BLUR_QUALITY_HIGH);
+
+		state.effect_blur_shader.bind();
+		int qsteps[3] = { 4, 10, 20 };
+
+		float radius = (env->dof_blur_far_amount * env->dof_blur_far_amount) / qsteps[env->dof_blur_far_quality];
+
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_BEGIN, env->dof_blur_far_distance);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_END, env->dof_blur_far_distance + env->dof_blur_far_transition);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_DIR, Vector2(1, 0));
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_RADIUS, radius);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::PIXEL_SIZE, Vector2(1.0 / vp_w, 1.0 / vp_h));
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::CAMERA_Z_NEAR, p_cam_projection.get_z_near());
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::CAMERA_Z_FAR, p_cam_projection.get_z_far());
+
+		glActiveTexture(GL_TEXTURE1);
+		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->depth);
+
+		glActiveTexture(GL_TEXTURE0);
+
+		if (storage->frame.current_rt->mip_maps[0].color) {
+			glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].color);
+		} else {
+			glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[0].color);
+		}
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo); //copy to front first
+
+		storage->_copy_screen();
+
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->color);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_DIR, Vector2(0, 1));
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->mip_maps[0].sizes[0].fbo); // copy to base level
+		storage->_copy_screen();
+
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_FAR_BLUR, false);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_LOW, false);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_MEDIUM, false);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_HIGH, false);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::USE_ORTHOGONAL_PROJECTION, false);
+	}
+
+	if (env->dof_blur_near_enabled) {
+
+		//convert texture to RGBA format if not already
+		if (!storage->frame.current_rt->used_dof_blur_near) {
+			glActiveTexture(GL_TEXTURE0);
+			glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->color);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, storage->frame.current_rt->width, storage->frame.current_rt->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+		}
+
+		int vp_h = storage->frame.current_rt->height;
+		int vp_w = storage->frame.current_rt->width;
+
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::USE_ORTHOGONAL_PROJECTION, p_cam_projection.is_orthogonal());
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_NEAR_BLUR, true);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_NEAR_FIRST_TAP, true);
+
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_LOW, env->dof_blur_near_quality == VS::ENV_DOF_BLUR_QUALITY_LOW);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_MEDIUM, env->dof_blur_near_quality == VS::ENV_DOF_BLUR_QUALITY_MEDIUM);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_HIGH, env->dof_blur_near_quality == VS::ENV_DOF_BLUR_QUALITY_HIGH);
+
+		state.effect_blur_shader.bind();
+		int qsteps[3] = { 4, 10, 20 };
+
+		float radius = (env->dof_blur_near_amount * env->dof_blur_near_amount) / qsteps[env->dof_blur_near_quality];
+
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_BEGIN, env->dof_blur_near_distance);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_END, env->dof_blur_near_distance - env->dof_blur_near_transition);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_DIR, Vector2(1, 0));
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_RADIUS, radius);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::PIXEL_SIZE, Vector2(1.0 / vp_w, 1.0 / vp_h));
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::CAMERA_Z_NEAR, p_cam_projection.get_z_near());
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::CAMERA_Z_FAR, p_cam_projection.get_z_far());
+
+		glActiveTexture(GL_TEXTURE1);
+		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->depth);
+
+		glActiveTexture(GL_TEXTURE0);
+		if (!storage->frame.current_rt->used_dof_blur_near) {
+			if (storage->frame.current_rt->mip_maps[0].color) {
+				glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].color);
+			} else {
+				for (int i = 0; i < storage->frame.current_rt->mip_maps[i].sizes.size(); i++) {
+					glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[i].color);
+					glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, storage->frame.current_rt->mip_maps[0].sizes[i].width, storage->frame.current_rt->mip_maps[0].sizes[i].height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+				}
+				glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[0].color);
+			}
+		}
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo); //copy to front first
+
+		storage->_copy_screen();
+
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_NEAR_FIRST_TAP, false);
+		state.effect_blur_shader.bind();
+
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_BEGIN, env->dof_blur_near_distance);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_END, env->dof_blur_near_distance - env->dof_blur_near_transition);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_DIR, Vector2(0, 1));
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::DOF_RADIUS, radius);
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::PIXEL_SIZE, Vector2(1.0 / vp_w, 1.0 / vp_h));
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::CAMERA_Z_NEAR, p_cam_projection.get_z_near());
+		state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::CAMERA_Z_FAR, p_cam_projection.get_z_far());
+
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->color);
+
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->mip_maps[0].sizes[0].fbo); // copy to base level
+
+		glEnable(GL_BLEND);
+		glBlendEquation(GL_FUNC_ADD);
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+		storage->_copy_screen();
+
+		glDisable(GL_BLEND);
+
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_NEAR_BLUR, false);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_NEAR_FIRST_TAP, false);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_LOW, false);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_MEDIUM, false);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::DOF_QUALITY_HIGH, false);
+		state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::USE_ORTHOGONAL_PROJECTION, false);
+		storage->frame.current_rt->used_dof_blur_near = true;
+	}
+
+	if (env->dof_blur_near_enabled || env->dof_blur_far_enabled) {
+		//these needed to disable filtering, reenamble
+		glActiveTexture(GL_TEXTURE0);
+		if (storage->frame.current_rt->mip_maps[0].color) {
+			glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].color);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		} else {
+			glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[0].color);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		}
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	}
+
+	//glow
+
+	int max_glow_level = -1;
+	int glow_mask = 0;
+
+	if (env->glow_enabled) {
+
+		for (int i = 0; i < VS::MAX_GLOW_LEVELS; i++) {
+			if (env->glow_levels & (1 << i)) {
+
+				if (i >= storage->frame.current_rt->mip_maps[1].sizes.size()) {
+					max_glow_level = storage->frame.current_rt->mip_maps[1].sizes.size() - 1;
+					glow_mask |= 1 << max_glow_level;
+
+				} else {
+					max_glow_level = i;
+					glow_mask |= (1 << i);
+				}
+			}
+		}
+
+		for (int i = 0; i < (max_glow_level + 1); i++) {
+
+			int vp_w = storage->frame.current_rt->mip_maps[1].sizes[i].width;
+			int vp_h = storage->frame.current_rt->mip_maps[1].sizes[i].height;
+			glViewport(0, 0, vp_w, vp_h);
+			//horizontal pass
+			if (i == 0) {
+				state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::GLOW_FIRST_PASS, true);
+			}
+
+			state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::GLOW_GAUSSIAN_HORIZONTAL, true);
+			state.effect_blur_shader.bind();
+			state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::PIXEL_SIZE, Vector2(1.0 / vp_w, 1.0 / vp_h));
+			state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::LOD, storage->frame.current_rt->mip_maps[0].color ? float(i) : 0.0);
+			state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::GLOW_STRENGTH, env->glow_strength);
+			state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::LUMINANCE_CAP, env->glow_hdr_luminance_cap);
+
+			glActiveTexture(GL_TEXTURE0);
+
+			if (storage->frame.current_rt->mip_maps[0].color) {
+				glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].color);
+			} else {
+				glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[i].color);
+			}
+
+			if (i == 0) {
+
+				state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::GLOW_BLOOM, env->glow_bloom);
+				state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::GLOW_HDR_THRESHOLD, env->glow_hdr_bleed_threshold);
+				state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::GLOW_HDR_SCALE, env->glow_hdr_bleed_scale);
+			}
+
+			glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->mip_maps[1].sizes[i].fbo);
+			storage->_copy_screen();
+			state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::GLOW_GAUSSIAN_HORIZONTAL, false);
+			state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::GLOW_FIRST_PASS, false);
+
+			//vertical pass
+			state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::GLOW_GAUSSIAN_VERTICAL, true);
+			state.effect_blur_shader.bind();
+			state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::PIXEL_SIZE, Vector2(1.0 / vp_w, 1.0 / vp_h));
+			state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::LOD, storage->frame.current_rt->mip_maps[0].color ? float(i) : 0.0);
+			state.effect_blur_shader.set_uniform(EffectBlurShaderGLES2::GLOW_STRENGTH, env->glow_strength);
+			glActiveTexture(GL_TEXTURE0);
+
+			if (storage->frame.current_rt->mip_maps[0].color) {
+				glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[1].color);
+			} else {
+				glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[1].sizes[i].color);
+			}
+
+			glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->mip_maps[0].sizes[i + 1].fbo); //next level, since mipmaps[0] starts one level bigger
+			storage->_copy_screen();
+			state.effect_blur_shader.set_conditional(EffectBlurShaderGLES2::GLOW_GAUSSIAN_VERTICAL, false);
+		}
+
+		glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
+	}
+
+	if (storage->frame.current_rt->external.fbo != 0) {
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->external.fbo);
+	} else {
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo);
+	}
+
+	glActiveTexture(GL_TEXTURE0);
+	if (storage->frame.current_rt->mip_maps[0].color) {
+		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].color);
+	} else {
+		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[0].color);
+	}
+
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_FILTER_BICUBIC, env->glow_bicubic_upscale);
+
+	if (max_glow_level >= 0) {
+		if (storage->frame.current_rt->mip_maps[0].color) {
+			for (int i = 0; i < (max_glow_level + 1); i++) {
+
+				if (glow_mask & (1 << i)) {
+					if (i == 0) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL1, true);
+					}
+					if (i == 1) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL2, true);
+					}
+					if (i == 2) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL3, true);
+					}
+					if (i == 3) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL4, true);
+					}
+					if (i == 4) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL5, true);
+					}
+					if (i == 5) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL6, true);
+					}
+					if (i == 6) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL7, true);
+					}
+				}
+			}
+			glActiveTexture(GL_TEXTURE1);
+			glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].color);
+		} else {
+
+			state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_MULTI_TEXTURE_GLOW, true);
+			int active_glow_level = 0;
+			for (int i = 0; i < (max_glow_level + 1); i++) {
+
+				if (glow_mask & (1 << i)) {
+					active_glow_level++;
+					glActiveTexture(GL_TEXTURE0 + active_glow_level);
+					glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[i + 1].color);
+					if (active_glow_level == 1) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL1, true);
+					}
+					if (active_glow_level == 2) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL2, true);
+					}
+					if (active_glow_level == 3) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL3, true);
+					}
+					if (active_glow_level == 4) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL4, true);
+					}
+					if (active_glow_level == 5) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL5, true);
+					}
+					if (active_glow_level == 6) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL6, true);
+					}
+					if (active_glow_level == 7) {
+						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL7, true);
+					}
+				}
+			}
+		}
+
+		state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_SCREEN, env->glow_blend_mode == VS::GLOW_BLEND_MODE_SCREEN);
+		state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_SOFTLIGHT, env->glow_blend_mode == VS::GLOW_BLEND_MODE_SOFTLIGHT);
+		state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_REPLACE, env->glow_blend_mode == VS::GLOW_BLEND_MODE_REPLACE);
+	}
+
+	//Adjustments
+	if (env->adjustments_enabled) {
+
+		state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_BCS, true);
+		RasterizerStorageGLES2::Texture *tex = storage->texture_owner.getornull(env->color_correction);
+		if (tex) {
+			state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_COLOR_CORRECTION, true);
+			glActiveTexture(GL_TEXTURE2);
+			glBindTexture(tex->target, tex->tex_id);
+		}
+	}
+
+	state.tonemap_shader.bind();
+
+	if (max_glow_level >= 0) {
+
+		state.tonemap_shader.set_uniform(TonemapShaderGLES2::GLOW_INTENSITY, env->glow_intensity);
+		int ss[2] = {
+			storage->frame.current_rt->width,
+			storage->frame.current_rt->height,
+		};
+		glUniform2iv(state.tonemap_shader.get_uniform(TonemapShaderGLES2::GLOW_TEXTURE_SIZE), 1, ss);
+	}
+
+	if (env->adjustments_enabled) {
+
+		state.tonemap_shader.set_uniform(TonemapShaderGLES2::BCS, Vector3(env->adjustments_brightness, env->adjustments_contrast, env->adjustments_saturation));
+	}
+
+	storage->_copy_screen();
+
+	//turn off everything used
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL1, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL2, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL3, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL4, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL5, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL6, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL7, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_REPLACE, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_SCREEN, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_SOFTLIGHT, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_FILTER_BICUBIC, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_MULTI_TEXTURE_GLOW, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_BCS, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_COLOR_CORRECTION, false);
+}
+
 void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID *p_light_cull_result, int p_light_cull_count, RID *p_reflection_probe_cull_result, int p_reflection_probe_cull_count, RID p_environment, RID p_shadow_atlas, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass) {
 
 	Transform cam_transform = p_cam_transform;
@@ -3010,7 +3488,7 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 #elif ANDROID_ENABLED
 
 			// In GLES2 AndroidBlit is not available, so just copy color texture manually
-			_copy_texture_to_front_buffer(storage->frame.current_rt->multisample_color);
+			_copy_texture_to_buffer(storage->frame.current_rt->multisample_color, storage->frame.current_rt->fbo);
 #endif
 		}
 
@@ -3031,32 +3509,8 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 
 	_render_render_list(&render_list.elements[render_list.max_elements - render_list.alpha_element_count], render_list.alpha_element_count, cam_transform, p_cam_projection, p_shadow_atlas, env, env_radiance_tex, 0.0, 0.0, reverse_cull, true, false);
 
-	glDisable(GL_DEPTH_TEST);
-
-	if (storage->frame.current_rt && storage->frame.current_rt->multisample_active) {
-#ifdef GLES_OVER_GL
-
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->multisample_fbo);
-		glReadBuffer(GL_COLOR_ATTACHMENT0);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->fbo);
-		glBlitFramebuffer(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
-
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-#elif IPHONE_ENABLED
-
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->multisample_fbo);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->fbo);
-		glResolveMultisampleFramebufferAPPLE();
-
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-#elif ANDROID_ENABLED
-
-		// In GLES2 Android Blit is not available, so just copy color texture manually
-		_copy_texture_to_front_buffer(storage->frame.current_rt->multisample_color);
-#endif
-	}
+	//post process
+	_post_process(env, p_cam_projection);
 
 	//#define GLES2_SHADOW_ATLAS_DEBUG_VIEW
 
@@ -3439,6 +3893,8 @@ void RasterizerSceneGLES2::initialize() {
 
 	state.scene_shader.set_conditional(SceneShaderGLES2::USE_RGBA_SHADOWS, storage->config.use_rgba_3d_shadows);
 	state.cube_to_dp_shader.init();
+	state.effect_blur_shader.init();
+	state.tonemap_shader.init();
 
 	render_list.init();
 

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -35,10 +35,12 @@
 #include "rasterizer_storage_gles2.h"
 
 #include "shaders/cube_to_dp.glsl.gen.h"
+#include "shaders/effect_blur.glsl.gen.h"
 #include "shaders/scene.glsl.gen.h"
+#include "shaders/tonemap.glsl.gen.h"
 /*
 
-#include "drivers/gles3/shaders/effect_blur.glsl.gen.h"
+
 #include "drivers/gles3/shaders/exposure.glsl.gen.h"
 #include "drivers/gles3/shaders/resolve.glsl.gen.h"
 #include "drivers/gles3/shaders/scene.glsl.gen.h"
@@ -47,7 +49,6 @@
 #include "drivers/gles3/shaders/ssao_blur.glsl.gen.h"
 #include "drivers/gles3/shaders/ssao_minify.glsl.gen.h"
 #include "drivers/gles3/shaders/subsurf_scattering.glsl.gen.h"
-#include "drivers/gles3/shaders/tonemap.glsl.gen.h"
 
 */
 
@@ -99,6 +100,8 @@ public:
 
 		SceneShaderGLES2 scene_shader;
 		CubeToDpShaderGLES2 cube_to_dp_shader;
+		TonemapShaderGLES2 tonemap_shader;
+		EffectBlurShaderGLES2 effect_blur_shader;
 
 		GLuint sky_verts;
 
@@ -114,7 +117,6 @@ public:
 		// SsaoShaderGLES3 ssao_shader;
 		// SsaoBlurShaderGLES3 ssao_blur_shader;
 		// ExposureShaderGLES3 exposure_shader;
-		// TonemapShaderGLES3 tonemap_shader;
 
 		/*
 		struct SceneDataUBO {
@@ -362,6 +364,35 @@ public:
 
 		int canvas_max_layer;
 
+		bool glow_enabled;
+		int glow_levels;
+		float glow_intensity;
+		float glow_strength;
+		float glow_bloom;
+		VS::EnvironmentGlowBlendMode glow_blend_mode;
+		float glow_hdr_bleed_threshold;
+		float glow_hdr_bleed_scale;
+		float glow_hdr_luminance_cap;
+		bool glow_bicubic_upscale;
+
+		bool dof_blur_far_enabled;
+		float dof_blur_far_distance;
+		float dof_blur_far_transition;
+		float dof_blur_far_amount;
+		VS::EnvironmentDOFBlurQuality dof_blur_far_quality;
+
+		bool dof_blur_near_enabled;
+		float dof_blur_near_distance;
+		float dof_blur_near_transition;
+		float dof_blur_near_amount;
+		VS::EnvironmentDOFBlurQuality dof_blur_near_quality;
+
+		bool adjustments_enabled;
+		float adjustments_brightness;
+		float adjustments_contrast;
+		float adjustments_saturation;
+		RID color_correction;
+
 		bool fog_enabled;
 		Color fog_color;
 		Color fog_sun_color;
@@ -387,6 +418,30 @@ public:
 				ambient_energy(1.0),
 				ambient_sky_contribution(0.0),
 				canvas_max_layer(0),
+				glow_enabled(false),
+				glow_levels((1 << 2) | (1 << 4)),
+				glow_intensity(1.5),
+				glow_strength(1.3),
+				glow_bloom(0.0),
+				glow_blend_mode(VS::GLOW_BLEND_MODE_SOFTLIGHT),
+				glow_hdr_bleed_threshold(0.9),
+				glow_hdr_bleed_scale(2.0),
+				glow_hdr_luminance_cap(12.0),
+				glow_bicubic_upscale(false),
+				dof_blur_far_enabled(false),
+				dof_blur_far_distance(10),
+				dof_blur_far_transition(5),
+				dof_blur_far_amount(0.1),
+				dof_blur_far_quality(VS::ENV_DOF_BLUR_QUALITY_MEDIUM),
+				dof_blur_near_enabled(false),
+				dof_blur_near_distance(2),
+				dof_blur_near_transition(1),
+				dof_blur_near_amount(0.1),
+				dof_blur_near_quality(VS::ENV_DOF_BLUR_QUALITY_MEDIUM),
+				adjustments_enabled(false),
+				adjustments_brightness(1.0),
+				adjustments_contrast(1.0),
+				adjustments_saturation(1.0),
 				fog_enabled(false),
 				fog_color(Color(0.5, 0.5, 0.5)),
 				fog_sun_color(Color(0.8, 0.8, 0.0)),
@@ -674,7 +729,7 @@ public:
 	void _add_geometry(RasterizerStorageGLES2::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES2::GeometryOwner *p_owner, int p_material, bool p_depth_pass, bool p_shadow_pass);
 	void _add_geometry_with_material(RasterizerStorageGLES2::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES2::GeometryOwner *p_owner, RasterizerStorageGLES2::Material *p_material, bool p_depth_pass, bool p_shadow_pass);
 
-	void _copy_texture_to_front_buffer(GLuint texture);
+	void _copy_texture_to_buffer(GLuint p_texture, GLuint p_buffer);
 	void _fill_render_list(InstanceBase **p_cull_result, int p_cull_count, bool p_depth_pass, bool p_shadow_pass);
 	void _render_render_list(RenderList::Element **p_elements, int p_element_count,
 			const Transform &p_view_transform,
@@ -697,6 +752,8 @@ public:
 	_FORCE_INLINE_ void _setup_light(LightInstance *p_light, ShadowAtlas *shadow_atlas, const Transform &p_view_transform, bool accum_pass);
 	_FORCE_INLINE_ void _setup_refprobes(ReflectionProbeInstance *p_refprobe1, ReflectionProbeInstance *p_refprobe2, const Transform &p_view_transform, Environment *p_env);
 	_FORCE_INLINE_ void _render_geometry(RenderList::Element *p_element);
+
+	void _post_process(Environment *env, const CameraMatrix &p_cam_projection);
 
 	virtual void render_scene(const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID *p_light_cull_result, int p_light_cull_count, RID *p_reflection_probe_cull_result, int p_reflection_probe_cull_count, RID p_environment, RID p_shadow_atlas, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass);
 	virtual void render_shadow(RID p_light, RID p_shadow_atlas, int p_pass, InstanceBase **p_cull_result, int p_cull_count);

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -82,6 +82,8 @@ GLuint RasterizerStorageGLES2::system_fbo = 0;
 #define _DEPTH_COMPONENT24_OES 0x81A6
 
 #ifndef GLES_OVER_GL
+#define glClearDepth glClearDepthf
+
 // enable extensions manually for android and ios
 #include <dlfcn.h> // needed to load extensions
 
@@ -4586,6 +4588,9 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 		color_format = GL_RGB;
 	}
 
+	rt->used_dof_blur_near = false;
+	rt->mip_maps_allocated = false;
+
 	{
 
 		/* Front FBO */
@@ -4780,6 +4785,127 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 		}
 	}
 
+	// Allocate mipmap chains for post_process effects
+	if (!rt->flags[RasterizerStorage::RENDER_TARGET_NO_3D] && rt->width >= 2 && rt->height >= 2) {
+
+		for (int i = 0; i < 2; i++) {
+
+			ERR_FAIL_COND(rt->mip_maps[i].sizes.size());
+			int w = rt->width;
+			int h = rt->height;
+
+			if (i > 0) {
+				w >>= 1;
+				h >>= 1;
+			}
+
+			int level = 0;
+			int fb_w = w;
+			int fb_h = h;
+
+			while (true) {
+
+				RenderTarget::MipMaps::Size mm;
+				mm.width = w;
+				mm.height = h;
+				rt->mip_maps[i].sizes.push_back(mm);
+
+				w >>= 1;
+				h >>= 1;
+
+				if (w < 2 || h < 2)
+					break;
+
+				level++;
+			}
+
+			GLsizei width = fb_w;
+			GLsizei height = fb_h;
+
+			if (config.render_to_mipmap_supported) {
+
+				glGenTextures(1, &rt->mip_maps[i].color);
+				glBindTexture(GL_TEXTURE_2D, rt->mip_maps[i].color);
+
+				for (int l = 0; l < level + 1; l++) {
+					glTexImage2D(GL_TEXTURE_2D, l, color_internal_format, width, height, 0, color_format, color_type, NULL);
+					width = MAX(1, (width / 2));
+					height = MAX(1, (height / 2));
+				}
+#ifdef GLES_OVER_GL
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, level);
+#endif
+			} else {
+
+				// Can't render to specific levels of a mipmap in ES 2.0 or Webgl so create a texture for each level
+				for (int l = 0; l < level + 1; l++) {
+					glGenTextures(1, &rt->mip_maps[i].sizes.write[l].color);
+					glBindTexture(GL_TEXTURE_2D, rt->mip_maps[i].sizes[l].color);
+					glTexImage2D(GL_TEXTURE_2D, 0, color_internal_format, width, height, 0, color_format, color_type, NULL);
+					width = MAX(1, (width / 2));
+					height = MAX(1, (height / 2));
+					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+				}
+			}
+
+			glDisable(GL_SCISSOR_TEST);
+			glColorMask(1, 1, 1, 1);
+			glDepthMask(GL_TRUE);
+
+			for (int j = 0; j < rt->mip_maps[i].sizes.size(); j++) {
+
+				RenderTarget::MipMaps::Size &mm = rt->mip_maps[i].sizes.write[j];
+
+				glGenFramebuffers(1, &mm.fbo);
+				glBindFramebuffer(GL_FRAMEBUFFER, mm.fbo);
+
+				if (config.render_to_mipmap_supported) {
+
+					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->mip_maps[i].color, j);
+				} else {
+
+					glBindTexture(GL_TEXTURE_2D, rt->mip_maps[i].sizes[j].color);
+					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->mip_maps[i].sizes[j].color, 0);
+				}
+
+				bool used_depth = false;
+				if (j == 0 && i == 0) { //use always
+					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
+					used_depth = true;
+				}
+
+				GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+				if (status != GL_FRAMEBUFFER_COMPLETE) {
+					WARN_PRINT_ONCE("Cannot allocate mipmaps for 3D post processing effects");
+					glBindFramebuffer(GL_FRAMEBUFFER, RasterizerStorageGLES2::system_fbo);
+					return;
+				}
+
+				glClearColor(1.0, 0.0, 1.0, 0.0);
+				glViewport(0, 0, rt->mip_maps[i].sizes[j].width, rt->mip_maps[i].sizes[j].height);
+				glClear(GL_COLOR_BUFFER_BIT);
+				if (used_depth) {
+					glClearDepth(1.0);
+					glClear(GL_DEPTH_BUFFER_BIT);
+				}
+			}
+
+			rt->mip_maps[i].levels = level;
+
+			if (config.render_to_mipmap_supported) {
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+			}
+		}
+		rt->mip_maps_allocated = true;
+	}
+
 	glBindFramebuffer(GL_FRAMEBUFFER, RasterizerStorageGLES2::system_fbo);
 }
 
@@ -4835,6 +4961,20 @@ void RasterizerStorageGLES2::_render_target_clear(RenderTarget *rt) {
 
 		glDeleteTextures(1, &rt->copy_screen_effect.color);
 		rt->copy_screen_effect.color = 0;
+	}
+
+	for (int i = 0; i < 2; i++) {
+		if (rt->mip_maps[i].sizes.size()) {
+			for (int j = 0; j < rt->mip_maps[i].sizes.size(); j++) {
+				glDeleteFramebuffers(1, &rt->mip_maps[i].sizes[j].fbo);
+				glDeleteTextures(1, &rt->mip_maps[i].sizes[j].color);
+			}
+
+			glDeleteTextures(1, &rt->mip_maps[i].color);
+			rt->mip_maps[i].sizes.clear();
+			rt->mip_maps[i].levels = 0;
+			rt->mip_maps[i].color = 0;
+		}
 	}
 
 	if (rt->multisample_active) {
@@ -5615,6 +5755,13 @@ void RasterizerStorageGLES2::initialize() {
 
 	// Check for multisample support
 	config.multisample_supported = config.extensions.has("GL_EXT_framebuffer_multisample") || config.extensions.has("GL_EXT_multisampled_render_to_texture") || config.extensions.has("GL_APPLE_framebuffer_multisample");
+
+#ifdef GLES_OVER_GL
+	config.render_to_mipmap_supported = true;
+#else
+	//check if mipmaps can be used for SCREEN_TEXTURE and Glow on Mobile and web platforms
+	config.render_to_mipmap_supported = config.extensions.has("GL_OES_fbo_render_mipmap") && config.extensions.has("GL_EXT_texture_lod");
+#endif
 
 #ifdef GLES_OVER_GL
 	config.use_rgba_2d_shadows = false;

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -95,6 +95,7 @@ public:
 		bool support_shadow_cubemaps;
 
 		bool multisample_supported;
+		bool render_to_mipmap_supported;
 
 		GLuint depth_internalformat;
 		GLuint depth_type;
@@ -1140,12 +1141,6 @@ public:
 		GLuint multisample_depth;
 		bool multisample_active;
 
-		// TODO post processing effects?
-
-		// TODO HDR?
-
-		// TODO this is hardcoded for texscreen copies for now
-
 		struct Effect {
 			GLuint fbo;
 			int width;
@@ -1162,6 +1157,27 @@ public:
 		};
 
 		Effect copy_screen_effect;
+
+		struct MipMaps {
+
+			struct Size {
+				GLuint fbo;
+				GLuint color;
+				int width;
+				int height;
+			};
+
+			Vector<Size> sizes;
+			GLuint color;
+			int levels;
+
+			MipMaps() :
+					color(0),
+					levels(0) {
+			}
+		};
+
+		MipMaps mip_maps[2];
 
 		struct External {
 			GLuint fbo;
@@ -1182,6 +1198,9 @@ public:
 
 		RID texture;
 
+		bool used_dof_blur_near;
+		bool mip_maps_allocated;
+
 		RenderTarget() :
 				fbo(0),
 				color(0),
@@ -1195,7 +1214,9 @@ public:
 				width(0),
 				height(0),
 				used_in_frame(false),
-				msaa(VS::VIEWPORT_MSAA_DISABLED) {
+				msaa(VS::VIEWPORT_MSAA_DISABLED),
+				used_dof_blur_near(false),
+				mip_maps_allocated(false) {
 			for (int i = 0; i < RENDER_TARGET_FLAG_MAX; ++i) {
 				flags[i] = false;
 			}

--- a/drivers/gles2/shaders/SCsub
+++ b/drivers/gles2/shaders/SCsub
@@ -12,12 +12,12 @@ if 'GLES2_GLSL' in env['BUILDERS']:
     env.GLES2_GLSL('cube_to_dp.glsl');
 #    env.GLES2_GLSL('blend_shape.glsl');
 #    env.GLES2_GLSL('screen_space_reflection.glsl');
-#    env.GLES2_GLSL('effect_blur.glsl');
+    env.GLES2_GLSL('effect_blur.glsl');
 #    env.GLES2_GLSL('subsurf_scattering.glsl');
 #    env.GLES2_GLSL('ssao.glsl');
 #    env.GLES2_GLSL('ssao_minify.glsl');
 #    env.GLES2_GLSL('ssao_blur.glsl');
 #    env.GLES2_GLSL('exposure.glsl');
-#    env.GLES2_GLSL('tonemap.glsl');
+    env.GLES2_GLSL('tonemap.glsl');
 #    env.GLES2_GLSL('particles.glsl');
     env.GLES2_GLSL('lens_distorted.glsl');

--- a/drivers/gles2/shaders/canvas_shadow.glsl
+++ b/drivers/gles2/shaders/canvas_shadow.glsl
@@ -34,8 +34,13 @@ void main() {
 #define mediump
 #define highp
 #else
+#if defined(USE_HIGHP_PRECISION)
+precision highp float;
+precision highp int;
+#else
 precision mediump float;
 precision mediump int;
+#endif
 #endif
 
 varying highp vec4 position_interp;

--- a/drivers/gles2/shaders/cube_to_dp.glsl
+++ b/drivers/gles2/shaders/cube_to_dp.glsl
@@ -30,8 +30,13 @@ void main() {
 #define mediump
 #define highp
 #else
+#if defined(USE_HIGHP_PRECISION)
+precision highp float;
+precision highp int;
+#else
 precision mediump float;
 precision mediump int;
+#endif
 #endif
 
 uniform highp samplerCube source_cube; //texunit:0

--- a/drivers/gles2/shaders/effect_blur.glsl
+++ b/drivers/gles2/shaders/effect_blur.glsl
@@ -1,11 +1,20 @@
 /* clang-format off */
 [vertex]
 
-layout(location = 0) in highp vec4 vertex_attrib;
-/* clang-format on */
-layout(location = 4) in vec2 uv_in;
+#ifdef USE_GLES_OVER_GL
+#define lowp
+#define mediump
+#define highp
+#else
+precision highp float;
+precision highp int;
+#endif
 
-out vec2 uv_interp;
+attribute vec2 vertex_attrib; // attrib:0
+/* clang-format on */
+attribute vec2 uv_in; // attrib:4
+
+varying vec2 uv_interp;
 
 #ifdef USE_BLUR_SECTION
 
@@ -16,7 +25,7 @@ uniform vec4 blur_section;
 void main() {
 
 	uv_interp = uv_in;
-	gl_Position = vertex_attrib;
+	gl_Position = vec4(vertex_attrib, 0.0, 1.0);
 #ifdef USE_BLUR_SECTION
 
 	uv_interp = blur_section.xy + uv_interp * blur_section.zw;
@@ -27,28 +36,45 @@ void main() {
 /* clang-format off */
 [fragment]
 
-#if !defined(GLES_OVER_GL)
-precision mediump float;
+// texture2DLodEXT and textureCubeLodEXT are fragment shader specific.
+// Do not copy these defines in the vertex section.
+#ifndef USE_GLES_OVER_GL
+#ifdef GL_EXT_shader_texture_lod
+#extension GL_EXT_shader_texture_lod : enable
+#define texture2DLod(img, coord, lod) texture2DLodEXT(img, coord, lod)
+#define textureCubeLod(img, coord, lod) textureCubeLodEXT(img, coord, lod)
+#endif
+#endif // !USE_GLES_OVER_GL
+
+#ifdef GL_ARB_shader_texture_lod
+#extension GL_ARB_shader_texture_lod : enable
 #endif
 
-in vec2 uv_interp;
+#if !defined(GL_EXT_shader_texture_lod) && !defined(GL_ARB_shader_texture_lod)
+#define texture2DLod(img, coord, lod) texture2D(img, coord, lod)
+#define textureCubeLod(img, coord, lod) textureCube(img, coord, lod)
+#endif
+
+#ifdef USE_GLES_OVER_GL
+#define lowp
+#define mediump
+#define highp
+#else
+#if defined(USE_HIGHP_PRECISION)
+precision highp float;
+precision highp int;
+#else
+precision mediump float;
+precision mediump int;
+#endif
+#endif
+
+varying vec2 uv_interp;
 /* clang-format on */
 uniform sampler2D source_color; //texunit:0
 
-#ifdef SSAO_MERGE
-uniform sampler2D source_ssao; //texunit:1
-#endif
-
 uniform float lod;
 uniform vec2 pixel_size;
-
-layout(location = 0) out vec4 frag_color;
-
-#ifdef SSAO_MERGE
-
-uniform vec4 ssao_color;
-
-#endif
 
 #if defined(GLOW_GAUSSIAN_HORIZONTAL) || defined(GLOW_GAUSSIAN_VERTICAL)
 
@@ -58,6 +84,7 @@ uniform float glow_strength;
 
 #if defined(DOF_FAR_BLUR) || defined(DOF_NEAR_BLUR)
 
+#ifdef USE_GLES_OVER_GL
 #ifdef DOF_QUALITY_LOW
 const int dof_kernel_size = 5;
 const int dof_kernel_from = 2;
@@ -76,6 +103,7 @@ const int dof_kernel_size = 21;
 const int dof_kernel_from = 10;
 const float dof_kernel[21] = float[](0.028174, 0.032676, 0.037311, 0.041944, 0.046421, 0.050582, 0.054261, 0.057307, 0.059587, 0.060998, 0.061476, 0.060998, 0.059587, 0.057307, 0.054261, 0.050582, 0.046421, 0.041944, 0.037311, 0.032676, 0.028174);
 #endif
+#endif
 
 uniform sampler2D dof_source_depth; //texunit:1
 uniform float dof_begin;
@@ -83,24 +111,11 @@ uniform float dof_end;
 uniform vec2 dof_dir;
 uniform float dof_radius;
 
-#ifdef DOF_NEAR_BLUR_MERGE
-
-uniform sampler2D source_dof_original; //texunit:2
-#endif
-
 #endif
 
 #ifdef GLOW_FIRST_PASS
 
-uniform float exposure;
-uniform float white;
-
-#ifdef GLOW_USE_AUTO_EXPOSURE
-
-uniform highp sampler2D source_auto_exposure; //texunit:1
-uniform highp float auto_exposure_grey;
-
-#endif
+uniform highp float luminance_cap;
 
 uniform float glow_bloom;
 uniform float glow_hdr_threshold;
@@ -113,60 +128,95 @@ uniform float camera_z_near;
 
 void main() {
 
-#ifdef GAUSSIAN_HORIZONTAL
-	vec2 pix_size = pixel_size;
-	pix_size *= 0.5; //reading from larger buffer, so use more samples
-	// sigma 2
-	vec4 color = textureLod(source_color, uv_interp + vec2(0.0, 0.0) * pix_size, lod) * 0.214607;
-	color += textureLod(source_color, uv_interp + vec2(1.0, 0.0) * pix_size, lod) * 0.189879;
-	color += textureLod(source_color, uv_interp + vec2(2.0, 0.0) * pix_size, lod) * 0.131514;
-	color += textureLod(source_color, uv_interp + vec2(3.0, 0.0) * pix_size, lod) * 0.071303;
-	color += textureLod(source_color, uv_interp + vec2(-1.0, 0.0) * pix_size, lod) * 0.189879;
-	color += textureLod(source_color, uv_interp + vec2(-2.0, 0.0) * pix_size, lod) * 0.131514;
-	color += textureLod(source_color, uv_interp + vec2(-3.0, 0.0) * pix_size, lod) * 0.071303;
-	frag_color = color;
-#endif
-
-#ifdef GAUSSIAN_VERTICAL
-	vec4 color = textureLod(source_color, uv_interp + vec2(0.0, 0.0) * pixel_size, lod) * 0.38774;
-	color += textureLod(source_color, uv_interp + vec2(0.0, 1.0) * pixel_size, lod) * 0.24477;
-	color += textureLod(source_color, uv_interp + vec2(0.0, 2.0) * pixel_size, lod) * 0.06136;
-	color += textureLod(source_color, uv_interp + vec2(0.0, -1.0) * pixel_size, lod) * 0.24477;
-	color += textureLod(source_color, uv_interp + vec2(0.0, -2.0) * pixel_size, lod) * 0.06136;
-	frag_color = color;
-#endif
-
-	//glow uses larger sigma for a more rounded blur effect
-
 #ifdef GLOW_GAUSSIAN_HORIZONTAL
 	vec2 pix_size = pixel_size;
 	pix_size *= 0.5; //reading from larger buffer, so use more samples
-	vec4 color = textureLod(source_color, uv_interp + vec2(0.0, 0.0) * pix_size, lod) * 0.174938;
-	color += textureLod(source_color, uv_interp + vec2(1.0, 0.0) * pix_size, lod) * 0.165569;
-	color += textureLod(source_color, uv_interp + vec2(2.0, 0.0) * pix_size, lod) * 0.140367;
-	color += textureLod(source_color, uv_interp + vec2(3.0, 0.0) * pix_size, lod) * 0.106595;
-	color += textureLod(source_color, uv_interp + vec2(-1.0, 0.0) * pix_size, lod) * 0.165569;
-	color += textureLod(source_color, uv_interp + vec2(-2.0, 0.0) * pix_size, lod) * 0.140367;
-	color += textureLod(source_color, uv_interp + vec2(-3.0, 0.0) * pix_size, lod) * 0.106595;
+	vec4 color = texture2DLod(source_color, uv_interp + vec2(0.0, 0.0) * pix_size, lod) * 0.174938;
+	color += texture2DLod(source_color, uv_interp + vec2(1.0, 0.0) * pix_size, lod) * 0.165569;
+	color += texture2DLod(source_color, uv_interp + vec2(2.0, 0.0) * pix_size, lod) * 0.140367;
+	color += texture2DLod(source_color, uv_interp + vec2(3.0, 0.0) * pix_size, lod) * 0.106595;
+	color += texture2DLod(source_color, uv_interp + vec2(-1.0, 0.0) * pix_size, lod) * 0.165569;
+	color += texture2DLod(source_color, uv_interp + vec2(-2.0, 0.0) * pix_size, lod) * 0.140367;
+	color += texture2DLod(source_color, uv_interp + vec2(-3.0, 0.0) * pix_size, lod) * 0.106595;
 	color *= glow_strength;
-	frag_color = color;
+	gl_FragColor = color;
 #endif
 
 #ifdef GLOW_GAUSSIAN_VERTICAL
-	vec4 color = textureLod(source_color, uv_interp + vec2(0.0, 0.0) * pixel_size, lod) * 0.288713;
-	color += textureLod(source_color, uv_interp + vec2(0.0, 1.0) * pixel_size, lod) * 0.233062;
-	color += textureLod(source_color, uv_interp + vec2(0.0, 2.0) * pixel_size, lod) * 0.122581;
-	color += textureLod(source_color, uv_interp + vec2(0.0, -1.0) * pixel_size, lod) * 0.233062;
-	color += textureLod(source_color, uv_interp + vec2(0.0, -2.0) * pixel_size, lod) * 0.122581;
+	vec4 color = texture2DLod(source_color, uv_interp + vec2(0.0, 0.0) * pixel_size, lod) * 0.288713;
+	color += texture2DLod(source_color, uv_interp + vec2(0.0, 1.0) * pixel_size, lod) * 0.233062;
+	color += texture2DLod(source_color, uv_interp + vec2(0.0, 2.0) * pixel_size, lod) * 0.122581;
+	color += texture2DLod(source_color, uv_interp + vec2(0.0, -1.0) * pixel_size, lod) * 0.233062;
+	color += texture2DLod(source_color, uv_interp + vec2(0.0, -2.0) * pixel_size, lod) * 0.122581;
 	color *= glow_strength;
-	frag_color = color;
+	gl_FragColor = color;
 #endif
+
+#ifndef USE_GLES_OVER_GL
+#if defined(DOF_FAR_BLUR) || defined(DOF_NEAR_BLUR)
+
+#ifdef DOF_QUALITY_LOW
+	const int dof_kernel_size = 5;
+	const int dof_kernel_from = 2;
+	float dof_kernel[5];
+	dof_kernel[0] = 0.153388;
+	dof_kernel[1] = 0.221461;
+	dof_kernel[2] = 0.250301;
+	dof_kernel[3] = 0.221461;
+	dof_kernel[4] = 0.153388;
+#endif
+
+#ifdef DOF_QUALITY_MEDIUM
+	const int dof_kernel_size = 11;
+	const int dof_kernel_from = 5;
+	float dof_kernel[11];
+	dof_kernel[0] = 0.055037;
+	dof_kernel[1] = 0.072806;
+	dof_kernel[2] = 0.090506;
+	dof_kernel[3] = 0.105726;
+	dof_kernel[4] = 0.116061;
+	dof_kernel[5] = 0.119726;
+	dof_kernel[6] = 0.116061;
+	dof_kernel[7] = 0.105726;
+	dof_kernel[8] = 0.090506;
+	dof_kernel[9] = 0.072806;
+	dof_kernel[10] = 0.055037;
+#endif
+
+#ifdef DOF_QUALITY_HIGH
+	const int dof_kernel_size = 21;
+	const int dof_kernel_from = 10;
+	float dof_kernel[21];
+	dof_kernel[0] = 0.028174;
+	dof_kernel[1] = 0.032676;
+	dof_kernel[2] = 0.037311;
+	dof_kernel[3] = 0.041944;
+	dof_kernel[4] = 0.046421;
+	dof_kernel[5] = 0.050582;
+	dof_kernel[6] = 0.054261;
+	dof_kernel[7] = 0.057307;
+	dof_kernel[8] = 0.059587;
+	dof_kernel[9] = 0.060998;
+	dof_kernel[10] = 0.061476;
+	dof_kernel[11] = 0.060998;
+	dof_kernel[12] = 0.059587;
+	dof_kernel[13] = 0.057307;
+	dof_kernel[14] = 0.054261;
+	dof_kernel[15] = 0.050582;
+	dof_kernel[16] = 0.046421;
+	dof_kernel[17] = 0.041944;
+	dof_kernel[18] = 0.037311;
+	dof_kernel[19] = 0.032676;
+	dof_kernel[20] = 0.028174;
+#endif
+#endif
+#endif //!USE_GLES_OVER_GL
 
 #ifdef DOF_FAR_BLUR
 
 	vec4 color_accum = vec4(0.0);
 
-	float depth = textureLod(dof_source_depth, uv_interp, 0.0).r;
+	float depth = texture2DLod(dof_source_depth, uv_interp, 0.0).r;
 	depth = depth * 2.0 - 1.0;
 #ifdef USE_ORTHOGONAL_PROJECTION
 	depth = ((depth + (camera_z_far + camera_z_near) / (camera_z_far - camera_z_near)) * (camera_z_far - camera_z_near)) / 2.0;
@@ -184,17 +234,17 @@ void main() {
 
 		float tap_k = dof_kernel[i];
 
-		float tap_depth = texture(dof_source_depth, tap_uv, 0.0).r;
+		float tap_depth = texture2D(dof_source_depth, tap_uv, 0.0).r;
 		tap_depth = tap_depth * 2.0 - 1.0;
 #ifdef USE_ORTHOGONAL_PROJECTION
 		tap_depth = ((tap_depth + (camera_z_far + camera_z_near) / (camera_z_far - camera_z_near)) * (camera_z_far - camera_z_near)) / 2.0;
 #else
 		tap_depth = 2.0 * camera_z_near * camera_z_far / (camera_z_far + camera_z_near - tap_depth * (camera_z_far - camera_z_near));
 #endif
-		float tap_amount = mix(smoothstep(dof_begin, dof_end, tap_depth), 1.0, int_ofs == 0);
+		float tap_amount = int_ofs == 0 ? 1.0 : smoothstep(dof_begin, dof_end, tap_depth);
 		tap_amount *= tap_amount * tap_amount; //prevent undesired glow effect
 
-		vec4 tap_color = textureLod(source_color, tap_uv, 0.0) * tap_k;
+		vec4 tap_color = texture2DLod(source_color, tap_uv, 0.0) * tap_k;
 
 		k_accum += tap_k * tap_amount;
 		color_accum += tap_color * tap_amount;
@@ -204,7 +254,7 @@ void main() {
 		color_accum /= k_accum;
 	}
 
-	frag_color = color_accum; ///k_accum;
+	gl_FragColor = color_accum; ///k_accum;
 
 #endif
 
@@ -212,19 +262,19 @@ void main() {
 
 	vec4 color_accum = vec4(0.0);
 
-	float max_accum = 0;
+	float max_accum = 0.0;
 
 	for (int i = 0; i < dof_kernel_size; i++) {
 
 		int int_ofs = i - dof_kernel_from;
 		vec2 tap_uv = uv_interp + dof_dir * float(int_ofs) * dof_radius;
-		float ofs_influence = max(0.0, 1.0 - float(abs(int_ofs)) / float(dof_kernel_from));
+		float ofs_influence = max(0.0, 1.0 - abs(float(int_ofs)) / float(dof_kernel_from));
 
 		float tap_k = dof_kernel[i];
 
-		vec4 tap_color = textureLod(source_color, tap_uv, 0.0);
+		vec4 tap_color = texture2DLod(source_color, tap_uv, 0.0);
 
-		float tap_depth = texture(dof_source_depth, tap_uv, 0.0).r;
+		float tap_depth = texture2D(dof_source_depth, tap_uv, 0.0).r;
 		tap_depth = tap_depth * 2.0 - 1.0;
 #ifdef USE_ORTHOGONAL_PROJECTION
 		tap_depth = ((tap_depth + (camera_z_far + camera_z_near) / (camera_z_far - camera_z_near)) * (camera_z_far - camera_z_near)) / 2.0;
@@ -247,46 +297,16 @@ void main() {
 
 	color_accum.a = max(color_accum.a, sqrt(max_accum));
 
-#ifdef DOF_NEAR_BLUR_MERGE
-
-	vec4 original = textureLod(source_dof_original, uv_interp, 0.0);
-	color_accum = mix(original, color_accum, color_accum.a);
-
-#endif
-
-#ifndef DOF_NEAR_FIRST_TAP
-	//color_accum=vec4(vec3(color_accum.a),1.0);
-#endif
-	frag_color = color_accum;
+	gl_FragColor = color_accum;
 
 #endif
 
 #ifdef GLOW_FIRST_PASS
 
-#ifdef GLOW_USE_AUTO_EXPOSURE
-
-	frag_color /= texelFetch(source_auto_exposure, ivec2(0, 0), 0).r / auto_exposure_grey;
-#endif
-	frag_color *= exposure;
-
-	float luminance = max(frag_color.r, max(frag_color.g, frag_color.b));
+	float luminance = max(gl_FragColor.r, max(gl_FragColor.g, gl_FragColor.b));
 	float feedback = max(smoothstep(glow_hdr_threshold, glow_hdr_threshold + glow_hdr_scale, luminance), glow_bloom);
 
-	frag_color *= feedback;
-
-#endif
-
-#ifdef SIMPLE_COPY
-	vec4 color = textureLod(source_color, uv_interp, 0.0);
-	frag_color = color;
-#endif
-
-#ifdef SSAO_MERGE
-
-	vec4 color = textureLod(source_color, uv_interp, 0.0);
-	float ssao = textureLod(source_ssao, uv_interp, 0.0).r;
-
-	frag_color = vec4(mix(color.rgb, color.rgb * mix(ssao_color.rgb, vec3(1.0), ssao), color.a), 1.0);
+	gl_FragColor = min(gl_FragColor * feedback, vec4(luminance_cap));
 
 #endif
 }

--- a/drivers/gles2/shaders/lens_distorted.glsl
+++ b/drivers/gles2/shaders/lens_distorted.glsl
@@ -34,8 +34,13 @@ void main() {
 #define mediump
 #define highp
 #else
-precision mediump float;
+#if defined(USE_HIGHP_PRECISION)
+precision highp float;
 precision highp int;
+#else
+precision mediump float;
+precision mediump int;
+#endif
 #endif
 
 uniform sampler2D source; //texunit:0

--- a/drivers/gles2/shaders/tonemap.glsl
+++ b/drivers/gles2/shaders/tonemap.glsl
@@ -1,66 +1,103 @@
 /* clang-format off */
 [vertex]
 
-layout(location = 0) in highp vec4 vertex_attrib;
-/* clang-format on */
-layout(location = 4) in vec2 uv_in;
+#ifdef USE_GLES_OVER_GL
+#define lowp
+#define mediump
+#define highp
+#else
+precision highp float;
+precision highp int;
+#endif
 
-out vec2 uv_interp;
+attribute vec2 vertex_attrib; // attrib:0
+/* clang-format on */
+attribute vec2 uv_in; // attrib:4
+
+varying vec2 uv_interp;
 
 void main() {
+	gl_Position = vec4(vertex_attrib, 0.0, 1.0);
 
-	gl_Position = vertex_attrib;
 	uv_interp = uv_in;
-#ifdef V_FLIP
-	uv_interp.y = 1.0 - uv_interp.y;
-#endif
 }
 
 /* clang-format off */
 [fragment]
 
-#if !defined(GLES_OVER_GL)
-precision mediump float;
+
+// texture2DLodEXT and textureCubeLodEXT are fragment shader specific.
+// Do not copy these defines in the vertex section.
+#ifndef USE_GLES_OVER_GL
+#ifdef GL_EXT_shader_texture_lod
+#extension GL_EXT_shader_texture_lod : enable
+#define texture2DLod(img, coord, lod) texture2DLodEXT(img, coord, lod)
+#define textureCubeLod(img, coord, lod) textureCubeLodEXT(img, coord, lod)
+#endif
+#endif // !USE_GLES_OVER_GL
+
+#ifdef GL_ARB_shader_texture_lod
+#extension GL_ARB_shader_texture_lod : enable
 #endif
 
-in vec2 uv_interp;
+#if !defined(GL_EXT_shader_texture_lod) && !defined(GL_ARB_shader_texture_lod)
+#define texture2DLod(img, coord, lod) texture2D(img, coord, lod)
+#define textureCubeLod(img, coord, lod) textureCube(img, coord, lod)
+#endif
+
+// Allows the use of bitshift operators for bicubic upscale
+#ifdef GL_EXT_gpu_shader4
+#extension GL_EXT_gpu_shader4 : enable
+#endif
+
+#ifdef USE_GLES_OVER_GL
+#define lowp
+#define mediump
+#define highp
+#else
+#if defined(USE_HIGHP_PRECISION)
+precision highp float;
+precision highp int;
+#else
+precision mediump float;
+precision mediump int;
+#endif
+#endif
+
+#include "stdlib.glsl"
+
+varying vec2 uv_interp;
 /* clang-format on */
 
 uniform highp sampler2D source; //texunit:0
 
-uniform float exposure;
-uniform float white;
-
-#ifdef USE_AUTO_EXPOSURE
-
-uniform highp sampler2D source_auto_exposure; //texunit:1
-uniform highp float auto_exposure_grey;
-
-#endif
-
 #if defined(USE_GLOW_LEVEL1) || defined(USE_GLOW_LEVEL2) || defined(USE_GLOW_LEVEL3) || defined(USE_GLOW_LEVEL4) || defined(USE_GLOW_LEVEL5) || defined(USE_GLOW_LEVEL6) || defined(USE_GLOW_LEVEL7)
+#define USING_GLOW // only use glow when at least one glow level is selected
 
-uniform highp sampler2D source_glow; //texunit:2
+#ifdef USE_MULTI_TEXTURE_GLOW
+uniform highp sampler2D source_glow1; //texunit:1
+uniform highp sampler2D source_glow2; //texunit:2
+uniform highp sampler2D source_glow3; //texunit:3
+uniform highp sampler2D source_glow4; //texunit:4
+uniform highp sampler2D source_glow5; //texunit:5
+uniform highp sampler2D source_glow6; //texunit:6
+uniform highp sampler2D source_glow7; //texunit:7
+#else
+uniform highp sampler2D source_glow; //texunit:1
+#endif
 uniform highp float glow_intensity;
-
 #endif
 
 #ifdef USE_BCS
-
 uniform vec3 bcs;
-
 #endif
 
 #ifdef USE_COLOR_CORRECTION
-
-uniform sampler2D color_correction; //texunit:3
-
+uniform sampler2D color_correction; //texunit:2
 #endif
 
-layout(location = 0) out vec4 frag_color;
-
+#ifdef GL_EXT_gpu_shader4
 #ifdef USE_GLOW_FILTER_BICUBIC
-
 // w0, w1, w2, and w3 are the four cubic B-spline basis functions
 float w0(float a) {
 	return (1.0 / 6.0) * (a * (a * (-a + 3.0) - 3.0) + 1.0);
@@ -101,8 +138,10 @@ uniform ivec2 glow_texture_size;
 vec4 texture2D_bicubic(sampler2D tex, vec2 uv, int p_lod) {
 	float lod = float(p_lod);
 	vec2 tex_size = vec2(glow_texture_size >> p_lod);
-	vec2 pixel_size = 1.0 / tex_size;
-	uv = uv * tex_size + 0.5;
+	vec2 pixel_size = vec2(1.0) / tex_size;
+
+	uv = uv * tex_size + vec2(0.5);
+
 	vec2 iuv = floor(uv);
 	vec2 fuv = fract(uv);
 
@@ -113,73 +152,97 @@ vec4 texture2D_bicubic(sampler2D tex, vec2 uv, int p_lod) {
 	float h0y = h0(fuv.y);
 	float h1y = h1(fuv.y);
 
-	vec2 p0 = (vec2(iuv.x + h0x, iuv.y + h0y) - 0.5) * pixel_size;
-	vec2 p1 = (vec2(iuv.x + h1x, iuv.y + h0y) - 0.5) * pixel_size;
-	vec2 p2 = (vec2(iuv.x + h0x, iuv.y + h1y) - 0.5) * pixel_size;
-	vec2 p3 = (vec2(iuv.x + h1x, iuv.y + h1y) - 0.5) * pixel_size;
+	vec2 p0 = (vec2(iuv.x + h0x, iuv.y + h0y) - vec2(0.5)) * pixel_size;
+	vec2 p1 = (vec2(iuv.x + h1x, iuv.y + h0y) - vec2(0.5)) * pixel_size;
+	vec2 p2 = (vec2(iuv.x + h0x, iuv.y + h1y) - vec2(0.5)) * pixel_size;
+	vec2 p3 = (vec2(iuv.x + h1x, iuv.y + h1y) - vec2(0.5)) * pixel_size;
 
-	return (g0(fuv.y) * (g0x * textureLod(tex, p0, lod) + g1x * textureLod(tex, p1, lod))) +
-		   (g1(fuv.y) * (g0x * textureLod(tex, p2, lod) + g1x * textureLod(tex, p3, lod)));
+	return (g0(fuv.y) * (g0x * texture2DLod(tex, p0, lod) + g1x * texture2DLod(tex, p1, lod))) +
+		   (g1(fuv.y) * (g0x * texture2DLod(tex, p2, lod) + g1x * texture2DLod(tex, p3, lod)));
 }
 
 #define GLOW_TEXTURE_SAMPLE(m_tex, m_uv, m_lod) texture2D_bicubic(m_tex, m_uv, m_lod)
+#else //!USE_GLOW_FILTER_BICUBIC
+#define GLOW_TEXTURE_SAMPLE(m_tex, m_uv, m_lod) texture2DLod(m_tex, m_uv, float(m_lod))
+#endif //USE_GLOW_FILTER_BICUBIC
 
-#else
+#else //!GL_EXT_gpu_shader4
+#define GLOW_TEXTURE_SAMPLE(m_tex, m_uv, m_lod) texture2DLod(m_tex, m_uv, float(m_lod))
+#endif //GL_EXT_gpu_shader4
 
-#define GLOW_TEXTURE_SAMPLE(m_tex, m_uv, m_lod) textureLod(m_tex, m_uv, float(m_lod))
-
+vec3 apply_glow(vec3 color, vec3 glow) { // apply glow using the selected blending mode
+#ifdef USE_GLOW_REPLACE
+	color = glow;
 #endif
 
-vec3 tonemap_filmic(vec3 color, float white) {
+#ifdef USE_GLOW_SCREEN
+	color = max((color + glow) - (color * glow), vec3(0.0));
+#endif
 
-	float A = 0.15;
-	float B = 0.50;
-	float C = 0.10;
-	float D = 0.20;
-	float E = 0.02;
-	float F = 0.30;
-	float W = 11.2;
+#ifdef USE_GLOW_SOFTLIGHT
+	glow = glow * vec3(0.5) + vec3(0.5);
 
-	vec3 coltn = ((color * (A * color + C * B) + D * E) / (color * (A * color + B) + D * F)) - E / F;
-	float whitetn = ((white * (A * white + C * B) + D * E) / (white * (A * white + B) + D * F)) - E / F;
+	color.r = (glow.r <= 0.5) ? (color.r - (1.0 - 2.0 * glow.r) * color.r * (1.0 - color.r)) : (((glow.r > 0.5) && (color.r <= 0.25)) ? (color.r + (2.0 * glow.r - 1.0) * (4.0 * color.r * (4.0 * color.r + 1.0) * (color.r - 1.0) + 7.0 * color.r)) : (color.r + (2.0 * glow.r - 1.0) * (sqrt(color.r) - color.r)));
+	color.g = (glow.g <= 0.5) ? (color.g - (1.0 - 2.0 * glow.g) * color.g * (1.0 - color.g)) : (((glow.g > 0.5) && (color.g <= 0.25)) ? (color.g + (2.0 * glow.g - 1.0) * (4.0 * color.g * (4.0 * color.g + 1.0) * (color.g - 1.0) + 7.0 * color.g)) : (color.g + (2.0 * glow.g - 1.0) * (sqrt(color.g) - color.g)));
+	color.b = (glow.b <= 0.5) ? (color.b - (1.0 - 2.0 * glow.b) * color.b * (1.0 - color.b)) : (((glow.b > 0.5) && (color.b <= 0.25)) ? (color.b + (2.0 * glow.b - 1.0) * (4.0 * color.b * (4.0 * color.b + 1.0) * (color.b - 1.0) + 7.0 * color.b)) : (color.b + (2.0 * glow.b - 1.0) * (sqrt(color.b) - color.b)));
+#endif
 
-	return coltn / whitetn;
+#if !defined(USE_GLOW_SCREEN) && !defined(USE_GLOW_SOFTLIGHT) && !defined(USE_GLOW_REPLACE) // no other selected -> additive
+	color += glow;
+#endif
+
+	return color;
 }
 
-vec3 tonemap_aces(vec3 color) {
-	float a = 2.51f;
-	float b = 0.03f;
-	float c = 2.43f;
-	float d = 0.59f;
-	float e = 0.14f;
-	return color = clamp((color * (a * color + b)) / (color * (c * color + d) + e), vec3(0.0), vec3(1.0));
+vec3 apply_bcs(vec3 color, vec3 bcs) {
+	color = mix(vec3(0.0), color, bcs.x);
+	color = mix(vec3(0.5), color, bcs.y);
+	color = mix(vec3(dot(vec3(1.0), color) * 0.33333), color, bcs.z);
+
+	return color;
 }
 
-vec3 tonemap_reindhart(vec3 color, float white) {
+vec3 apply_color_correction(vec3 color, sampler2D correction_tex) {
+	color.r = texture2D(correction_tex, vec2(color.r, 0.0)).r;
+	color.g = texture2D(correction_tex, vec2(color.g, 0.0)).g;
+	color.b = texture2D(correction_tex, vec2(color.b, 0.0)).b;
 
-	return (color * (1.0 + (color / (white)))) / (1.0 + color);
+	return color;
 }
 
 void main() {
+	vec3 color = texture2DLod(source, uv_interp, 0.0).rgb;
 
-	vec4 color = textureLod(source, uv_interp, 0.0);
+	// Glow
 
-#ifdef USE_AUTO_EXPOSURE
-
-	color /= texelFetch(source_auto_exposure, ivec2(0, 0), 0).r / auto_exposure_grey;
-#endif
-
-	color *= exposure;
-
-#if defined(USE_GLOW_LEVEL1) || defined(USE_GLOW_LEVEL2) || defined(USE_GLOW_LEVEL3) || defined(USE_GLOW_LEVEL4) || defined(USE_GLOW_LEVEL5) || defined(USE_GLOW_LEVEL6) || defined(USE_GLOW_LEVEL7)
-#define USING_GLOW
-#endif
-
-#if defined(USING_GLOW)
+#ifdef USING_GLOW
 	vec3 glow = vec3(0.0);
+#ifdef USE_MULTI_TEXTURE_GLOW
+#ifdef USE_GLOW_LEVEL1
+	glow += GLOW_TEXTURE_SAMPLE(source_glow1, uv_interp, 0).rgb;
+#ifdef USE_GLOW_LEVEL2
+	glow += GLOW_TEXTURE_SAMPLE(source_glow2, uv_interp, 0).rgb;
+#ifdef USE_GLOW_LEVEL3
+	glow += GLOW_TEXTURE_SAMPLE(source_glow3, uv_interp, 0).rgb;
+#ifdef USE_GLOW_LEVEL4
+	glow += GLOW_TEXTURE_SAMPLE(source_glow4, uv_interp, 0).rgb;
+#ifdef USE_GLOW_LEVEL5
+	glow += GLOW_TEXTURE_SAMPLE(source_glow5, uv_interp, 0).rgb;
+#ifdef USE_GLOW_LEVEL6
+	glow += GLOW_TEXTURE_SAMPLE(source_glow6, uv_interp, 0).rgb;
+#ifdef USE_GLOW_LEVEL7
+	glow += GLOW_TEXTURE_SAMPLE(source_glow7, uv_interp, 0).rgb;
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+
+#else
 
 #ifdef USE_GLOW_LEVEL1
-
 	glow += GLOW_TEXTURE_SAMPLE(source_glow, uv_interp, 1).rgb;
 #endif
 
@@ -206,100 +269,21 @@ void main() {
 #ifdef USE_GLOW_LEVEL7
 	glow += GLOW_TEXTURE_SAMPLE(source_glow, uv_interp, 7).rgb;
 #endif
+#endif //USE_MULTI_TEXTURE_GLOW
 
 	glow *= glow_intensity;
-
+	color = apply_glow(color, glow);
 #endif
 
-#ifdef USE_REINDHART_TONEMAPPER
-
-	color.rgb = tonemap_reindhart(color.rgb, white);
-
-#if defined(USING_GLOW)
-	glow = tonemap_reindhart(glow, white);
-#endif
-
-#endif
-
-#ifdef USE_FILMIC_TONEMAPPER
-
-	color.rgb = tonemap_filmic(color.rgb, white);
-
-#if defined(USING_GLOW)
-	glow = tonemap_filmic(glow, white);
-#endif
-
-#endif
-
-#ifdef USE_ACES_TONEMAPPER
-
-	color.rgb = tonemap_aces(color.rgb);
-
-#if defined(USING_GLOW)
-	glow = tonemap_aces(glow);
-#endif
-
-#endif
-
-	//regular Linear -> SRGB conversion
-	vec3 a = vec3(0.055);
-	color.rgb = mix((vec3(1.0) + a) * pow(color.rgb, vec3(1.0 / 2.4)) - a, 12.92 * color.rgb, lessThan(color.rgb, vec3(0.0031308)));
-
-#if defined(USING_GLOW)
-	glow = mix((vec3(1.0) + a) * pow(glow, vec3(1.0 / 2.4)) - a, 12.92 * glow, lessThan(glow, vec3(0.0031308)));
-#endif
-
-	//glow needs to be added in SRGB space (together with image space effects)
-
-	color.rgb = clamp(color.rgb, 0.0, 1.0);
-
-#if defined(USING_GLOW)
-	glow = clamp(glow, 0.0, 1.0);
-#endif
-
-#ifdef USE_GLOW_REPLACE
-
-	color.rgb = glow;
-
-#endif
-
-#ifdef USE_GLOW_SCREEN
-
-	color.rgb = max((color.rgb + glow) - (color.rgb * glow), vec3(0.0));
-
-#endif
-
-#ifdef USE_GLOW_SOFTLIGHT
-
-	{
-
-		glow = (glow * 0.5) + 0.5;
-		color.r = (glow.r <= 0.5) ? (color.r - (1.0 - 2.0 * glow.r) * color.r * (1.0 - color.r)) : (((glow.r > 0.5) && (color.r <= 0.25)) ? (color.r + (2.0 * glow.r - 1.0) * (4.0 * color.r * (4.0 * color.r + 1.0) * (color.r - 1.0) + 7.0 * color.r)) : (color.r + (2.0 * glow.r - 1.0) * (sqrt(color.r) - color.r)));
-		color.g = (glow.g <= 0.5) ? (color.g - (1.0 - 2.0 * glow.g) * color.g * (1.0 - color.g)) : (((glow.g > 0.5) && (color.g <= 0.25)) ? (color.g + (2.0 * glow.g - 1.0) * (4.0 * color.g * (4.0 * color.g + 1.0) * (color.g - 1.0) + 7.0 * color.g)) : (color.g + (2.0 * glow.g - 1.0) * (sqrt(color.g) - color.g)));
-		color.b = (glow.b <= 0.5) ? (color.b - (1.0 - 2.0 * glow.b) * color.b * (1.0 - color.b)) : (((glow.b > 0.5) && (color.b <= 0.25)) ? (color.b + (2.0 * glow.b - 1.0) * (4.0 * color.b * (4.0 * color.b + 1.0) * (color.b - 1.0) + 7.0 * color.b)) : (color.b + (2.0 * glow.b - 1.0) * (sqrt(color.b) - color.b)));
-	}
-
-#endif
-
-#if defined(USING_GLOW) && !defined(USE_GLOW_SCREEN) && !defined(USE_GLOW_SOFTLIGHT) && !defined(USE_GLOW_REPLACE)
-	//additive
-	color.rgb += glow;
-#endif
+	// Additional effects
 
 #ifdef USE_BCS
-
-	color.rgb = mix(vec3(0.0), color.rgb, bcs.x);
-	color.rgb = mix(vec3(0.5), color.rgb, bcs.y);
-	color.rgb = mix(vec3(dot(vec3(1.0), color.rgb) * 0.33333), color.rgb, bcs.z);
-
+	color = apply_bcs(color, bcs);
 #endif
 
 #ifdef USE_COLOR_CORRECTION
-
-	color.r = texture(color_correction, vec2(color.r, 0.0)).r;
-	color.g = texture(color_correction, vec2(color.g, 0.0)).g;
-	color.b = texture(color_correction, vec2(color.b, 0.0)).b;
+	color = apply_color_correction(color, color_correction);
 #endif
 
-	frag_color = vec4(color.rgb, 1.0);
+	gl_FragColor = vec4(color, 1.0);
 }

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -354,10 +354,6 @@ void Environment::_validate_property(PropertyInfo &property) const {
 		"tonemap_",
 		"ss_reflections_",
 		"ssao_",
-		"dof_blur_far_",
-		"dof_blur_near_",
-		"glow_",
-		"adjustment_",
 		NULL
 
 	};
@@ -1378,6 +1374,11 @@ Environment::Environment() :
 	glow_hdr_luminance_cap = 12.0;
 	glow_hdr_bleed_scale = 2.0;
 	glow_bicubic_upscale = false;
+	if (VisualServer::get_singleton()->is_low_end()) {
+		glow_hdr_bleed_threshold = 0.9;
+		glow_intensity = 1.5;
+		glow_strength = 1.3;
+	}
 
 	dof_blur_far_enabled = false;
 	dof_blur_far_distance = 10;


### PR DESCRIPTION
~~This is the first step in adding post processing effects to GLES2.~~

~~In future PRs I will add Glow and Dof Blur. But I have kept it small for now.~~

This PR implements the post-processing effects from GLES3 in GLES2. The methods are more or less straight ports of the GLES3 methods, just changed enough to work in GLES2.