### PR TITLE
Expose current path function to EditorPlugin

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -211,6 +211,10 @@ String EditorInterface::get_selected_path() const {
 	return EditorNode::get_singleton()->get_filesystem_dock()->get_selected_path();
 }
 
+String EditorInterface::get_current_path() const {
+	return EditorNode::get_singleton()->get_filesystem_dock()->get_current_path();
+}
+
 void EditorInterface::inspect_object(Object *p_obj, const String &p_for_property) {
 
 	EditorNode::get_singleton()->push_item(p_obj, p_for_property);
@@ -288,6 +292,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 	ClassDB::bind_method(D_METHOD("select_file", "file"), &EditorInterface::select_file);
 	ClassDB::bind_method(D_METHOD("get_selected_path"), &EditorInterface::get_selected_path);
+	ClassDB::bind_method(D_METHOD("get_current_path"), &EditorInterface::get_current_path);
 
 	ClassDB::bind_method(D_METHOD("set_plugin_enabled", "plugin", "enabled"), &EditorInterface::set_plugin_enabled);
 	ClassDB::bind_method(D_METHOD("is_plugin_enabled", "plugin"), &EditorInterface::is_plugin_enabled);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -78,6 +78,7 @@ public:
 
 	void select_file(const String &p_file);
 	String get_selected_path() const;
+	String get_current_path() const;
 
 	void inspect_object(Object *p_obj, const String &p_for_property = String());
 


### PR DESCRIPTION
`get_current_path` fulfills the need to get the full path including the resource name.
`get_selected_path` returns only the resource directory.
This does not break backward compatibility (if adding resource name to `get_selected_path`) and the function (`get_current_path`) is already available in `FileSystemDock` just like `get_selected_path`.
Fixes #30652.

![Issue30652](https://user-images.githubusercontent.com/4707543/64072385-5a43e500-cc5b-11e9-80d8-9c15a5799aa0.PNG)
