### PR TITLE
Fix resizer icon visiblity on light theme in GraphNode

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -257,6 +257,8 @@
 		</theme_item>
 		<theme_item name="resizer" type="Texture">
 		</theme_item>
+		<theme_item name="resizer_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		</theme_item>
 		<theme_item name="selectedframe" type="StyleBox">
 		</theme_item>
 		<theme_item name="separation" type="int" default="1">

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1066,6 +1066,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("title_color", "GraphNode", default_node_color);
 	default_node_color.a = 0.7;
 	theme->set_color("close_color", "GraphNode", default_node_color);
+	theme->set_color("resizer_color", "GraphNode", default_node_color);
 
 	theme->set_constant("port_offset", "GraphNode", 14 * EDSCALE);
 	theme->set_constant("title_h_offset", "GraphNode", -16 * EDSCALE);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -249,6 +249,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			node->add_color_override("title_color", c);
 			c.a = 0.7;
 			node->add_color_override("close_color", c);
+			node->add_color_override("resizer_color", c);
 		}
 	}
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -410,6 +410,7 @@ void VisualShaderEditor::_update_created_node(GraphNode *node) {
 		node->add_color_override("title_color", c);
 		c.a = 0.7;
 		node->add_color_override("close_color", c);
+		node->add_color_override("resizer_color", c);
 	}
 }
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -591,6 +591,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			gnode->add_color_override("title_color", c);
 			c.a = 0.7;
 			gnode->add_color_override("close_color", c);
+			gnode->add_color_override("resizer_color", c);
 			gnode->add_style_override("frame", sbf);
 		}
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -210,6 +210,7 @@ void GraphNode::_notification(int p_what) {
 			int close_offset = get_constant("close_offset");
 			int close_h_offset = get_constant("close_h_offset");
 			Color close_color = get_color("close_color");
+			Color resizer_color = get_color("resizer_color");
 			Ref<Font> title_font = get_font("title_font");
 			int title_offset = get_constant("title_offset");
 			int title_h_offset = get_constant("title_h_offset");
@@ -274,7 +275,7 @@ void GraphNode::_notification(int p_what) {
 			}
 
 			if (resizable) {
-				draw_texture(resizer, get_size() - resizer->get_size());
+				draw_texture(resizer, get_size() - resizer->get_size(), resizer_color);
 			}
 		} break;
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -611,6 +611,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font("title_font", "GraphNode", default_font);
 	theme->set_color("title_color", "GraphNode", Color(0, 0, 0, 1));
 	theme->set_color("close_color", "GraphNode", Color(0, 0, 0, 1));
+	theme->set_color("resizer_color", "GraphNode", Color(0, 0, 0, 1));
 	theme->set_constant("title_offset", "GraphNode", 20 * scale);
 	theme->set_constant("close_offset", "GraphNode", 18 * scale);
 	theme->set_constant("port_offset", "GraphNode", 3 * scale);


### PR DESCRIPTION
Makes this visible..

![image](https://user-images.githubusercontent.com/3036176/64072432-e0315180-cc96-11e9-9e46-2b5c906d5079.png)
