### PR TITLE
Script callback for enabling/disabling EditorPlugin

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -238,7 +238,7 @@ Control *EditorInterface::get_base_control() {
 }
 
 void EditorInterface::set_plugin_enabled(const String &p_plugin, bool p_enabled) {
-	EditorNode::get_singleton()->set_addon_plugin_enabled(p_plugin, p_enabled);
+	EditorNode::get_singleton()->set_addon_plugin_enabled(p_plugin, p_enabled, true);
 }
 
 bool EditorInterface::is_plugin_enabled(const String &p_plugin) const {


### PR DESCRIPTION
Parameter `p_config_changes` should be passed as `true` to enable callback to user scripts
for enabling or disabling of the `EditorPlugin`.
Fixes #30654

![test](https://user-images.githubusercontent.com/4707543/64072946-5917b580-cc65-11e9-9f87-8b150a82fd50.gif)
