### PR TITLE
Prevents OS::get_ticks_usec() from going backwards in time due to OS …

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -60,6 +60,8 @@ class OS {
 	bool _allow_hidpi;
 	bool _allow_layered;
 	bool _use_vsync;
+	uint64_t _ticks_usec_prev;
+	uint64_t _ticks_usec_running_total;
 
 	char *last_error;
 
@@ -137,6 +139,8 @@ protected:
 
 	void _ensure_user_data_dir();
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
+
+	virtual uint64_t get_ticks_raw_usec() const = 0;
 
 public:
 	typedef int64_t ProcessID;
@@ -344,8 +348,8 @@ public:
 	virtual uint64_t get_system_time_msecs() const;
 
 	virtual void delay_usec(uint32_t p_usec) const = 0;
-	virtual uint64_t get_ticks_usec() const = 0;
-	uint32_t get_ticks_msec() const;
+	uint64_t get_ticks_usec();
+	uint32_t get_ticks_msec();
 	uint64_t get_splash_tick_msec() const;
 
 	virtual bool can_draw() const = 0;

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -48,6 +48,8 @@ protected:
 
 	virtual void finalize_core();
 
+	virtual uint64_t get_ticks_raw_usec() const;
+
 	String stdin_buf;
 
 public:
@@ -83,7 +85,6 @@ public:
 	virtual uint64_t get_system_time_msecs() const;
 
 	virtual void delay_usec(uint32_t p_usec) const;
-	virtual uint64_t get_ticks_usec() const;
 
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking, ProcessID *r_child_id = NULL, String *r_pipe = NULL, int *r_exitcode = NULL, bool read_stderr = false, Mutex *p_pipe_mutex = NULL);
 	virtual Error kill(const ProcessID &p_pid);

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -620,7 +620,7 @@ void OS_UWP::delay_usec(uint32_t p_usec) const {
 	// no Sleep()
 	WaitForSingleObjectEx(GetCurrentThread(), msec, false);
 }
-uint64_t OS_UWP::get_ticks_usec() const {
+uint64_t OS_UWP::get_ticks_raw_usec() const {
 
 	uint64_t ticks;
 	uint64_t time;

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -170,6 +170,8 @@ protected:
 
 	void process_key_events();
 
+	virtual uint64_t get_ticks_raw_usec() const;
+
 public:
 	// Event to send to the app wrapper
 	HANDLE mouse_mode_changed;
@@ -206,7 +208,6 @@ public:
 	virtual Error set_cwd(const String &p_cwd);
 
 	virtual void delay_usec(uint32_t p_usec) const;
-	virtual uint64_t get_ticks_usec() const;
 
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking, ProcessID *r_child_id = NULL, String *r_pipe = NULL, int *r_exitcode = NULL, bool read_stderr = false, Mutex *p_pipe_mutex = NULL);
 	virtual Error kill(const ProcessID &p_pid);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2284,7 +2284,7 @@ void OS_Windows::delay_usec(uint32_t p_usec) const {
 	else
 		Sleep(p_usec / 1000);
 }
-uint64_t OS_Windows::get_ticks_usec() const {
+uint64_t OS_Windows::get_ticks_raw_usec() const {
 
 	uint64_t ticks;
 	uint64_t time;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -195,6 +195,8 @@ protected:
 	void process_events();
 	void process_key_events();
 
+	virtual uint64_t get_ticks_raw_usec() const;
+
 	struct ProcessInfo {
 
 		STARTUPINFO si;
@@ -287,7 +289,6 @@ public:
 	virtual Error set_cwd(const String &p_cwd);
 
 	virtual void delay_usec(uint32_t p_usec) const;
-	virtual uint64_t get_ticks_usec() const;
 
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking, ProcessID *r_child_id = NULL, String *r_pipe = NULL, int *r_exitcode = NULL, bool read_stderr = false, Mutex *p_pipe_mutex = NULL);
 	virtual Error kill(const ProcessID &p_pid);


### PR DESCRIPTION
…bugs.

On some hardware / OSes calls to timing APIs may occasionally falsely give the impression time is running backwards (e.g. QueryPerformanceCounter). This can cause bugs in any Godot code that assumes time always goes forwards. This PR simply records the previous time returned by the OS, and returns the previous time if the new time is earlier than the previous time.

May fix #31837, #25166, #26887. Mentioned in #31016.

It does this by changing the original OS function names from get_ticks_usec() to get_ticks_raw_usec() (and making them protected to emphasise not to call them) and making the get_ticks_usec() function into a wrapper which enforces the logic.

This way none of the other Godot code needs to be changed, and it can assume that deltas will always be positive, rather than having each bit of code deal with this possibility.