### PR TITLE
Remove redundant transform method in Geometry singleton

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1689,11 +1689,6 @@ Array _Geometry::offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_d
 	return ret;
 }
 
-Vector<Point2> _Geometry::transform_points_2d(const Vector<Point2> &p_points, const Transform2D &p_mat) {
-
-	return Geometry::transform_points_2d(p_points, p_mat);
-}
-
 Dictionary _Geometry::make_atlas(const Vector<Size2> &p_rects) {
 
 	Dictionary ret;
@@ -1772,8 +1767,6 @@ void _Geometry::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("offset_polygon_2d", "polygon", "delta", "join_type"), &_Geometry::offset_polygon_2d, DEFVAL(JOIN_SQUARE));
 	ClassDB::bind_method(D_METHOD("offset_polyline_2d", "polyline", "delta", "join_type", "end_type"), &_Geometry::offset_polyline_2d, DEFVAL(JOIN_SQUARE), DEFVAL(END_SQUARE));
-
-	ClassDB::bind_method(D_METHOD("transform_points_2d", "points", "transform"), &_Geometry::transform_points_2d);
 
 	ClassDB::bind_method(D_METHOD("make_atlas", "sizes"), &_Geometry::make_atlas);
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -434,8 +434,6 @@ public:
 	Array offset_polygon_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type = JOIN_SQUARE);
 	Array offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type = JOIN_SQUARE, PolyEndType p_end_type = END_SQUARE);
 
-	Vector<Point2> transform_points_2d(const Vector<Point2> &p_points, const Transform2D &p_mat);
-
 	Dictionary make_atlas(const Vector<Size2> &p_rects);
 
 	_Geometry();

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -832,16 +832,6 @@ public:
 		return _polypath_offset(p_polygon, p_delta, p_join_type, p_end_type);
 	}
 
-	static Vector<Point2> transform_points_2d(const Vector<Point2> &p_points, const Transform2D &p_mat) {
-
-		Vector<Point2> points;
-
-		for (int i = 0; i < p_points.size(); ++i) {
-			points.push_back(p_mat.xform(p_points[i]));
-		}
-		return points;
-	}
-
 	static Vector<int> triangulate_delaunay_2d(const Vector<Vector2> &p_points) {
 
 		Vector<Delaunay2D::Triangle> tr = Delaunay2D::triangulate(p_points);

--- a/doc/classes/Geometry.xml
+++ b/doc/classes/Geometry.xml
@@ -441,18 +441,6 @@
 				Tests if the segment ([code]from[/code], [code]to[/code]) intersects the triangle [code]a[/code], [code]b[/code], [code]c[/code]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, an empty [Variant] is returned.
 			</description>
 		</method>
-		<method name="transform_points_2d">
-			<return type="PoolVector2Array">
-			</return>
-			<argument index="0" name="points" type="PoolVector2Array">
-			</argument>
-			<argument index="1" name="transform" type="Transform2D">
-			</argument>
-			<description>
-				Transforms an array of points by [code]transform[/code] and returns the result.
-				Can be useful in conjunction with performing polygon boolean operations in a CSG-like manner, see [method merge_polygons_2d], [method clip_polygons_2d], [method intersect_polygons_2d], [method exclude_polygons_2d].
-			</description>
-		</method>
 		<method name="triangulate_delaunay_2d">
 			<return type="PoolIntArray">
 			</return>


### PR DESCRIPTION
Transform2D's xform method can be used instead which handles `PoolVector2Array` now (as well as 3D version), see #31761.

```gdscript
var trans = Transform2D(0, Vector2(100, 100))

var points = PoolVector2Array([Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(0, 1)])

points = Geometry.transform_points_2d(points, trans) # before
points = trans.xform(points) # after
```