### PR TITLE
Check for exact equality before approximate equality

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -300,6 +300,11 @@ public:
 	}
 
 	static _ALWAYS_INLINE_ bool is_equal_approx(real_t a, real_t b) {
+		// Check for exact equality first, required to handle "infinity" values.
+		if (a == b) {
+			return true;
+		}
+		// Then check for approximate equality.
 		real_t tolerance = CMP_EPSILON * abs(a);
 		if (tolerance < CMP_EPSILON) {
 			tolerance = CMP_EPSILON;
@@ -308,6 +313,11 @@ public:
 	}
 
 	static _ALWAYS_INLINE_ bool is_equal_approx(real_t a, real_t b, real_t tolerance) {
+		// Check for exact equality first, required to handle "infinity" values.
+		if (a == b) {
+			return true;
+		}
+		// Then check for approximate equality.
 		return abs(a - b) < tolerance;
 	}
 

--- a/modules/mono/glue/Managed/Files/Mathf.cs
+++ b/modules/mono/glue/Managed/Files/Mathf.cs
@@ -158,6 +158,11 @@ namespace Godot
 
         public static bool IsEqualApprox(real_t a, real_t b)
         {
+            // Check for exact equality first, required to handle "infinity" values.
+            if (a == b) {
+                return true;
+            }
+            // Then check for approximate equality.
             real_t tolerance = Epsilon * Abs(a);
             if (tolerance < Epsilon) {
                 tolerance = Epsilon;

--- a/modules/mono/glue/Managed/Files/MathfEx.cs
+++ b/modules/mono/glue/Managed/Files/MathfEx.cs
@@ -48,6 +48,11 @@ namespace Godot
 
         public static bool IsEqualApprox(real_t a, real_t b, real_t tolerance)
         {
+            // Check for exact equality first, required to handle "infinity" values.
+            if (a == b) {
+                return true;
+            }
+            // Then check for approximate equality.
             return Abs(a - b) < tolerance;
         }
     }


### PR DESCRIPTION
Fixes #31859

This means that for every possible case of `==` returning true, `is_equal_approx` will also return true. This will only actually change behavior for `INF` and `-INF` values.

It's possible that performance will be improved, or reduced, or neither. It depends how often things checked for equality are exactly equal, and how the branch predictor is feeling that day. In any case, having correct behavior is more important.