### PR TITLE
Added Viewport canvas cull mask feature

### DIFF
--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -224,6 +224,8 @@ private:
 
 	static CanvasItem *current_item_drawn;
 
+	int layers;
+
 protected:
 	_FORCE_INLINE_ void _notify_transform() {
 		if (!is_inside_tree()) return;
@@ -299,6 +301,12 @@ public:
 
 	void set_self_modulate(const Color &p_self_modulate);
 	Color get_self_modulate() const;
+
+	void set_layer_mask(int p_mask);
+	int get_layer_mask() const;
+
+	void set_layer_mask_bit(int p_layer, bool p_enable);
+	bool get_layer_mask_bit(int p_layer) const;
 
 	/* DRAWING API */
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -519,6 +519,14 @@ public:
 
 	bool gui_is_dragging() const;
 
+	int canvas_cull_mask;
+
+	void set_canvas_cull_mask(int p_layers);
+	int get_canvas_cull_mask() const;
+
+	void set_canvas_cull_mask_bit(int p_layer, bool p_enable);
+	bool get_canvas_cull_mask_bit(int p_layer) const;
+
 	Viewport();
 	~Viewport();
 };

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -52,6 +52,7 @@ public:
 		Color ysort_modulate;
 		Transform2D ysort_xform;
 		Vector2 ysort_pos;
+		int layer_mask;
 
 		Vector<Item *> child_items;
 
@@ -68,6 +69,7 @@ public:
 			ysort_children_count = -1;
 			ysort_xform = Transform2D();
 			ysort_pos = Vector2();
+			layer_mask = 0xfffff;
 		}
 	};
 
@@ -157,15 +159,15 @@ public:
 	bool disable_scale;
 
 private:
-	void _render_canvas_item_tree(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RasterizerCanvas::Light *p_lights);
-	void _render_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner);
+	void _render_canvas_item_tree(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RasterizerCanvas::Light *p_lights, int mask);
+	void _render_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, int mask);
 	void _light_mask_canvas_items(int p_z, RasterizerCanvas::Item *p_canvas_item, RasterizerCanvas::Light *p_masked_lights);
 
 	RasterizerCanvas::Item **z_list;
 	RasterizerCanvas::Item **z_last_list;
 
 public:
-	void render_canvas(Canvas *p_canvas, const Transform2D &p_transform, RasterizerCanvas::Light *p_lights, RasterizerCanvas::Light *p_masked_lights, const Rect2 &p_clip_rect);
+	void render_canvas(Canvas *p_canvas, const Transform2D &p_transform, RasterizerCanvas::Light *p_lights, RasterizerCanvas::Light *p_masked_lights, const Rect2 &p_clip_rect, int layer_mask);
 
 	RID canvas_create();
 	void canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring);
@@ -178,6 +180,9 @@ public:
 
 	void canvas_item_set_visible(RID p_item, bool p_visible);
 	void canvas_item_set_light_mask(RID p_item, int p_mask);
+
+	void canvas_item_set_layer_mask(RID p_item, int p_mask);
+	int canvas_item_get_layer_mask(RID p_item);
 
 	void canvas_item_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_set_clip(RID p_item, bool p_clip);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -481,6 +481,7 @@ public:
 	BIND2(viewport_set_msaa, RID, ViewportMSAA)
 	BIND2(viewport_set_hdr, RID, bool)
 	BIND2(viewport_set_usage, RID, ViewportUsage)
+	BIND2(viewport_set_canvas_layer_mask, RID, int)
 
 	BIND2R(int, viewport_get_render_info, RID, ViewportRenderInfo)
 	BIND2(viewport_set_debug_draw, RID, ViewportDebugDraw)
@@ -579,6 +580,7 @@ public:
 
 	BIND2(canvas_item_set_visible, RID, bool)
 	BIND2(canvas_item_set_light_mask, RID, int)
+	BIND2(canvas_item_set_layer_mask, RID, int)
 
 	BIND2(canvas_item_set_update_when_visible, RID, bool)
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -237,7 +237,7 @@ void VisualServerViewport::_draw_viewport(Viewport *p_viewport, ARVRInterface::E
 				ptr = ptr->filter_next_ptr;
 			}
 
-			VSG::canvas->render_canvas(canvas, xform, canvas_lights, lights_with_mask, clip_rect);
+			VSG::canvas->render_canvas(canvas, xform, canvas_lights, lights_with_mask, clip_rect, p_viewport->canvas_layer_mask);
 			i++;
 
 			if (scenario_draw_canvas_bg && E->key().get_layer() >= scenario_canvas_max_layer) {
@@ -742,6 +742,12 @@ bool VisualServerViewport::free(RID p_rid) {
 
 void VisualServerViewport::set_default_clear_color(const Color &p_color) {
 	clear_color = p_color;
+}
+
+void VisualServerViewport::viewport_set_canvas_layer_mask(RID p_viewport, int mask) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+	viewport->canvas_layer_mask = mask;
 }
 
 VisualServerViewport::VisualServerViewport() {

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -77,6 +77,8 @@ public:
 
 		bool transparent_bg;
 
+		int canvas_layer_mask;
+
 		struct CanvasKey {
 
 			int64_t stacking;
@@ -185,7 +187,7 @@ public:
 
 	void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform);
 	void viewport_set_canvas_stacking(RID p_viewport, RID p_canvas, int p_layer, int p_sublayer);
-
+	void viewport_set_canvas_layer_mask(RID p_viewport, int mask);
 	void viewport_set_shadow_atlas_size(RID p_viewport, int p_size);
 	void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv);
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -409,6 +409,8 @@ public:
 	FUNC2(viewport_set_hdr, RID, bool)
 	FUNC2(viewport_set_usage, RID, ViewportUsage)
 
+	FUNC2(viewport_set_canvas_layer_mask, RID, int)
+
 	//this passes directly to avoid stalling, but it's pretty dangerous, so don't call after freeing a viewport
 	virtual int viewport_get_render_info(RID p_viewport, ViewportRenderInfo p_info) {
 		return visual_server->viewport_get_render_info(p_viewport, p_info);
@@ -497,6 +499,7 @@ public:
 
 	FUNC2(canvas_item_set_visible, RID, bool)
 	FUNC2(canvas_item_set_light_mask, RID, int)
+	FUNC2(canvas_item_set_layer_mask, RID, int)
 
 	FUNC2(canvas_item_set_update_when_visible, RID, bool)
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -610,6 +610,7 @@ public:
 	virtual void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), int p_screen = 0) = 0;
 	virtual void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable) = 0;
 	virtual void viewport_detach(RID p_viewport) = 0;
+	virtual void viewport_set_canvas_layer_mask(RID p_viewport, int mask) = 0;
 
 	enum ViewportUpdateMode {
 		VIEWPORT_UPDATE_DISABLED,
@@ -872,6 +873,7 @@ public:
 
 	virtual void canvas_item_set_visible(RID p_item, bool p_visible) = 0;
 	virtual void canvas_item_set_light_mask(RID p_item, int p_mask) = 0;
+	virtual void canvas_item_set_layer_mask(RID p_item, int p_mask) = 0;
 
 	virtual void canvas_item_set_update_when_visible(RID p_item, bool p_update) = 0;
 


### PR DESCRIPTION
There was no way to render canvasitems in specific viewports and this commit fixes that.
Added "Layers" property to canvas items and "Canvas Cull Mask" property to viewports so you can now enable / disable layers of canvas items per viewport.
Hopefully this will also help in adding effects to nodes (like glow) that need rendering
to texture.

_Bugsquad edit: Fix #31312, Fix #5441, Fix #31856_