### PR TITLE
Initialize TileMap Custom Transform

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1944,6 +1944,7 @@ TileMap::TileMap() {
 	quadrant_order_dirty = false;
 	quadrant_size = 16;
 	cell_size = Size2(64, 64);
+	custom_transform = Transform2D(64, 0, 0, 64, 0, 0);
 	collision_layer = 1;
 	collision_mask = 1;
 	friction = 1;


### PR DESCRIPTION
Initialize TileMap Custom Transform to same as Cell Size (64).
Fixes #30948.

![image](https://user-images.githubusercontent.com/4707543/64083569-9a54a780-ccef-11e9-983a-f4ea53758afc.png)
