### PR TITLE
Implement snapping in the Gradient editor

### DIFF
--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -241,9 +241,13 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 
 		float newofs = CLAMP(x / float(total_w), 0, 1);
 
-		//Snap to nearest point if holding shift
-		if (mm->get_shift()) {
-			float snap_threshold = 0.03;
+		// Snap to "round" coordinates if holding Ctrl.
+		// Be more precise if holding Shift as well
+		if (mm->get_control()) {
+			newofs = Math::stepify(newofs, mm->get_shift() ? 0.025 : 0.1);
+		} else if (mm->get_shift()) {
+			// Snap to nearest point if holding just Shift
+			const float snap_threshold = 0.03;
 			float smallest_ofs = snap_threshold;
 			bool found = false;
 			int nearest_point = 0;


### PR DESCRIPTION
Holding Ctrl will snap the selected point's position by increments of 0.1. Holding Ctrl + Shift will snap by increments of 0.025 instead.

The previous behavior is preserved when holding just Shift (snapping to other gradient points).