### PR TITLE
Implement snapping in the Curve editor

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -167,10 +167,20 @@ void CurveEditor::on_gui_input(const Ref<InputEvent> &p_event) {
 					_has_undo_data = true;
 				}
 
+				const float curve_amplitude = curve.get_max_value() - curve.get_min_value();
+				// Snap to "round" coordinates when holding Ctrl.
+				// Be more precise when holding Shift as well.
+				float snap_threshold;
+				if (mm.get_control()) {
+					snap_threshold = mm.get_shift() ? 0.025 : 0.1;
+				} else {
+					snap_threshold = 0.0;
+				}
+
 				if (_selected_tangent == TANGENT_NONE) {
 					// Drag point
 
-					Vector2 point_pos = get_world_pos(mpos);
+					Vector2 point_pos = get_world_pos(mpos).snapped(Vector2(snap_threshold, snap_threshold * curve_amplitude));
 
 					int i = curve.set_point_offset(_selected_point, point_pos.x);
 					// The index may change if the point is dragged across another one
@@ -188,8 +198,8 @@ void CurveEditor::on_gui_input(const Ref<InputEvent> &p_event) {
 				} else {
 					// Drag tangent
 
-					Vector2 point_pos = curve.get_point_position(_selected_point);
-					Vector2 control_pos = get_world_pos(mpos);
+					const Vector2 point_pos = curve.get_point_position(_selected_point);
+					const Vector2 control_pos = get_world_pos(mpos).snapped(Vector2(snap_threshold, snap_threshold * curve_amplitude));
 
 					Vector2 dir = (control_pos - point_pos).normalized();
 


### PR DESCRIPTION
Holding Ctrl will snap the selected point/tangent by increments of 10% of the curve's width/height. Holding Shift as well will snap by increments of 2.5% instead.