### PR TITLE
Fix editor infinite loop in search_prev issue #31328

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -366,14 +366,12 @@ bool FindReplaceBar::search_prev() {
 	if (text_edit->is_selection_active())
 		col--; // Skip currently selected word.
 
-	if (line == result_line && col == result_col) {
-		col -= text.length();
-		if (col < 0) {
-			line -= 1;
-			if (line < 0)
-				line = text_edit->get_line_count() - 1;
-			col = text_edit->get_line(line).length();
-		}
+	col -= text.length();
+	if (col < 0) {
+		line -= 1;
+		if (line < 0)
+			line = text_edit->get_line_count() - 1;
+		col = text_edit->get_line(line).length();
 	}
 
 	return _search(flags, line, col);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5365,6 +5365,9 @@ bool TextEdit::search(const String &p_key, uint32_t p_search_flags, int p_from_l
 						break;
 					}
 					pos_from = last_pos - p_key.length();
+					if (pos_from < 0) {
+						break;
+					}
 				}
 			} else {
 				while ((last_pos = (p_search_flags & SEARCH_MATCH_CASE) ? text_line.find(p_key, pos_from) : text_line.findn(p_key, pos_from)) != -1) {


### PR DESCRIPTION
Also reverted commit 6a842fb, since it is not required for the fix and during my testing it felt like broke prev search in some cases.