### PR TITLE
Warning once message to detect rare circumstance of negative main delta

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1854,6 +1854,9 @@ bool Main::iteration() {
 	iterating++;
 
 	uint64_t ticks = OS::get_singleton()->get_ticks_usec();
+	if (ticks < Engine::get_singleton()->get_idle_frame_ticks()) {
+		WARN_PRINT_ONCE("Negative delta detected");
+	}
 	Engine::get_singleton()->_frame_ticks = ticks;
 	main_timer_sync.set_cpu_ticks_usec(ticks);
 	main_timer_sync.set_fixed_fps(fixed_fps);


### PR DESCRIPTION
On some hardware / OSes calls to the timing APIs may occasionally give negative deltas in the main loop. This can cause bugs where time is assumed to always goes forward. This PR simply adds a warning once message if this situation is detected. No control flow is changed.

Related to #31837, #25166, #26887. Mentioned in #31016.