### PR TITLE
gdscript: Fix build after #24925

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2833,7 +2833,8 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 					if (!s.begins_with("autoload/")) {
 						continue;
 					}
-					options.insert(s.get_slice("/", 1));
+					ScriptCodeCompletionOption option(s.get_slice("/", 1), ScriptCodeCompletionOption::KIND_CLASS);
+					options.insert(option.display, option);
 				}
 			}
 


### PR DESCRIPTION
The PR did not use the ScriptCodeCompletionOption system introduced
later on, and somehow this did not generate a merge conflict even
though neighboring code was changed.