### PR TITLE
Add icon for the ruler tool

### DIFF
--- a/editor/icons/icon_ruler.svg
+++ b/editor/icons/icon_ruler.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 4.2333 4.2333" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 -292.77)">
+<path transform="matrix(.26458 0 0 .26458 0 292.77)" d="m1 1v7.5 6.5h14l-14-14zm3 7 4 4h-4v-4z" fill="#e0e0e0"/>
+</g>
+</svg>

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3663,7 +3663,7 @@ void CanvasItemEditor::_notification(int p_what) {
 		snap_config_menu->set_icon(get_icon("GuiMiniTabMenu", "EditorIcons"));
 		skeleton_menu->set_icon(get_icon("Bone", "EditorIcons"));
 		pan_button->set_icon(get_icon("ToolPan", "EditorIcons"));
-		ruler_button->set_icon(get_icon("LineEdit", "EditorIcons")); //Needs a new icon.
+		ruler_button->set_icon(get_icon("Ruler", "EditorIcons"));
 		pivot_button->set_icon(get_icon("EditPivot", "EditorIcons"));
 		select_handle = get_icon("EditorHandle", "EditorIcons");
 		anchor_handle = get_icon("EditorControlAnchor", "EditorIcons");


### PR DESCRIPTION
The icon has been optimized. The original one will be commit in the [godot-design](https://github.com/godotengine/godot-design) repository if this is merged.

![Screenshot_20190902_114212](https://user-images.githubusercontent.com/30739239/64121990-ea834680-cd8f-11e9-9676-ddebd5a0e7f3.png)