### PR TITLE
Assimp map mode is not initialized before use.

### DIFF
--- a/modules/assimp/import_state.h
+++ b/modules/assimp/import_state.h
@@ -79,7 +79,7 @@ struct ImportState {
 struct AssimpImageData {
 	Ref<Image> raw_image;
 	Ref<ImageTexture> texture;
-	aiTextureMapMode *map_mode = NULL;
+	aiTextureMapMode map_mode[2];
 };
 
 /** Recursive state is used to push state into functions instead of specifying them


### PR DESCRIPTION
Assimp map mode is not initialized before use and causes crashes.