### PR TITLE
make core/Reference thread safe

### DIFF
--- a/core/reference.cpp
+++ b/core/reference.cpp
@@ -36,12 +36,7 @@ bool Reference::init_ref() {
 
 	if (reference()) {
 
-		// this may fail in the scenario of two threads assigning the pointer for the FIRST TIME
-		// at the same time, which is never likely to happen (would be crazy to do)
-		// so don't do it.
-
-		if (refcount_init.get() > 0) {
-			refcount_init.unref();
+		if (!is_referenced() && refcount_init.unref()) {
 			unreference(); // first referencing is already 1, so compensate for the ref above
 		}
 
@@ -64,9 +59,11 @@ int Reference::reference_get_count() const {
 }
 
 bool Reference::reference() {
-	bool success = refcount.ref();
 
-	if (success && refcount.get() <= 2 /* higher is not relevant */) {
+	uint32_t rc_val = refcount.refval();
+	bool success = rc_val != 0;
+
+	if (success && rc_val <= 2 /* higher is not relevant */) {
 		if (get_script_instance()) {
 			get_script_instance()->refcount_incremented();
 		}
@@ -84,9 +81,10 @@ bool Reference::reference() {
 
 bool Reference::unreference() {
 
-	bool die = refcount.unref();
+	uint32_t rc_val = refcount.unrefval();
+	bool die = rc_val == 0;
 
-	if (refcount.get() <= 1 /* higher is not relevant */) {
+	if (rc_val <= 1 /* higher is not relevant */) {
 		if (get_script_instance()) {
 			bool script_ret = get_script_instance()->refcount_decremented();
 			die = die && script_ret;

--- a/core/reference.h
+++ b/core/reference.h
@@ -47,7 +47,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	_FORCE_INLINE_ bool is_referenced() const { return refcount_init.get() < 1; }
+	_FORCE_INLINE_ bool is_referenced() const { return refcount_init.get() != 1; }
 	bool init_ref();
 	bool reference(); // returns false if refcount is at zero and didn't get increased
 	bool unreference();

--- a/core/safe_refcount.h
+++ b/core/safe_refcount.h
@@ -177,12 +177,12 @@ struct SafeRefCount {
 public:
 	// destroy() is called when weak_count_ drops to zero.
 
-	_ALWAYS_INLINE_ bool ref() { //true on success
+	_ALWAYS_INLINE_ bool ref() { // true on success
 
 		return atomic_conditional_increment(&count) != 0;
 	}
 
-	_ALWAYS_INLINE_ uint32_t refval() { //true on success
+	_ALWAYS_INLINE_ uint32_t refval() { // none-zero on success
 
 		return atomic_conditional_increment(&count);
 	}
@@ -190,6 +190,11 @@ public:
 	_ALWAYS_INLINE_ bool unref() { // true if must be disposed of
 
 		return atomic_decrement(&count) == 0;
+	}
+
+	_ALWAYS_INLINE_ uint32_t unrefval() { // 0 if must be disposed of
+
+		return atomic_decrement(&count);
 	}
 
 	_ALWAYS_INLINE_ uint32_t get() const { // nothrow


### PR DESCRIPTION
In the old implementation, all methods of the class `Reference` is not thread safe, and calling them without extra locks will cause bug. Such safety comes by free with minor modification.

The key is:
+ Calling `get` on `SafeRefCount` after `ref`/`unref` might not yield correct results, since other threads might have inc the ref count between these invocation. To solve this, just manipulate and return ref count value at the same time.
+ Handling nasty negative overflow of `uint32_t`

It should be noticed that even after these modification, `refcount` can overflow due to unpaired call to `reference` and `unreference`. Overflow checking in dev build might be helpful (though I did't add such functionality).

It seems to be a common requirement in cocurrent programming to modify and return modified value at the same time, while `unrefval` method is just newly added to `SafeRefCount`. I guess there might be more such hidden problem in the code base.