### PR TITLE
Produce an error when a class has the same name as a Singleton

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3533,6 +3533,15 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 					return;
 				}
 
+				if (p_class->classname_used && ProjectSettings::get_singleton()->has_setting("autoload/" + p_class->name)) {
+					const String autoload_path = ProjectSettings::get_singleton()->get_setting("autoload/" + p_class->name);
+					if (autoload_path.begins_with("*")) {
+						// It's a singleton, and not just a regular AutoLoad script.
+						_set_error("The class \"" + p_class->name + "\" conflicts with the AutoLoad singleton of the same name, and is therefore redundant. Remove the class_name declaration to fix this error.");
+					}
+					return;
+				}
+
 				tokenizer->advance(2);
 
 				if (tokenizer->get_token() == GDScriptTokenizer::TK_COMMA) {


### PR DESCRIPTION
If you somehow end up with a Singleton.gd that looks like this:

	extends Node

	class_name Singleton

	func foo():
	    pass

You will get an error when using it in another file:

	extends Node2D

	func _init():
	    # Parser Error: Non-static function "foo" can only be called from an instance.
	    Singleton.foo()

This error is confusing. This patch ensures that an error on the class_name line will be produced:

    Parse Error: The class "Singleton" conflicts with the AutoLoad singleton of the same name, and is therefore redundant. Remove the class_name declaration to fix this error.

Fixes #28187.