### PR TITLE
Change minimum size when theme changed

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -645,6 +645,7 @@ void Control::_notification(int p_notification) {
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 
+			minimum_size_changed();
 			update();
 		} break;
 		case NOTIFICATION_MODAL_CLOSE: {


### PR DESCRIPTION
Called minimum_size_changed on controls whenever the theme is changed.
Most often then not, minimum size will be changed when a theme changes.

Fixes #29816

![issue29816](https://user-images.githubusercontent.com/4707543/64200792-3b13a600-ce5b-11e9-813f-77e32c46e192.gif)
