### PR TITLE
Fix VisibilityEnabler2D behavior on start

### DIFF
--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -252,10 +252,19 @@ void VisibilityEnabler2D::_notification(int p_what) {
 
 		_find_nodes(from);
 
-		if (enabler[ENABLER_PARENT_PHYSICS_PROCESS] && get_parent())
-			get_parent()->set_physics_process(false);
-		if (enabler[ENABLER_PARENT_PROCESS] && get_parent())
-			get_parent()->set_process(false);
+		// We need to defer the call of set_process and set_physics_process,
+		// otherwise they are overwritten inside NOTIFICATION_READY.
+		// We can't use call_deferred, because it happens after a physics frame.
+		// The ready signal works as it's emitted immediately after NOTIFICATION_READY.
+
+		if (enabler[ENABLER_PARENT_PHYSICS_PROCESS] && get_parent()) {
+			get_parent()->connect(SceneStringNames::get_singleton()->ready,
+					callable_mp(get_parent(), &Node::set_physics_process), varray(false), CONNECT_ONESHOT);
+		}
+		if (enabler[ENABLER_PARENT_PROCESS] && get_parent()) {
+			get_parent()->connect(SceneStringNames::get_singleton()->ready,
+					callable_mp(get_parent(), &Node::set_process), varray(false), CONNECT_ONESHOT);
+		}
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {


### PR DESCRIPTION
Fixes #9321

The bug was caused by parent's `NOTIFICATION_READY` overwriting the `set_process(false)`. Deferring the call helped, but for `_physics_process` I had to use a _little_ hack, because the deferred call happens after physics frame.