### PR TITLE
Fixes Reverse Animation Starting on First Frame

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -604,10 +604,14 @@ bool AnimatedSprite::_is_playing() const {
 
 void AnimatedSprite::play(const StringName &p_animation, const bool p_backwards) {
 
-	if (p_animation)
-		set_animation(p_animation);
-
 	backwards = p_backwards;
+
+	if (p_animation) {
+		set_animation(p_animation);
+		if (backwards && get_frame() == 0)
+			set_frame(frames->get_frame_count(p_animation) - 1);
+	}
+
 	_set_playing(true);
 }
 


### PR DESCRIPTION
When playing an animation in reverse, the animation initially starts on frame 0. If it loops, it'll play normally by going to the last frame of the animation, but if it does not... it prematurely stops, since it is already on the last frame (for reversed animation) by starting on frame 0.

Closes: #31903