### PR TITLE
Clarify VisibilityEnabler2D description

### DIFF
--- a/doc/classes/VisibilityEnabler2D.xml
+++ b/doc/classes/VisibilityEnabler2D.xml
@@ -4,7 +4,7 @@
 		Enables certain nodes only when visible.
 	</brief_description>
 	<description>
-		The VisibilityEnabler2D will disable [RigidBody2D], [AnimationPlayer], and other nodes when they are not visible. It will only affect other nodes within the same scene as the VisibilityEnabler2D itself.
+		The VisibilityEnabler2D will disable [RigidBody2D], [AnimationPlayer], and other nodes when they are not visible. It will only affect nodes with the same root node as the VisibilityEnabler2D, and the root node itself.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Fixes [this docs issue](https://github.com/godotengine/godot-docs/issues/2211). Makes the node description more specific.