### PR TITLE
Fixes Inspector Showing Unselected Info

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -408,6 +408,10 @@ void InspectorDock::update(Object *p_object) {
 		warning->hide();
 		search->set_editable(false);
 
+		editor_path->set_text("");
+		editor_path->set_tooltip("");
+		editor_path->set_icon(NULL);
+
 		return;
 	}
 


### PR DESCRIPTION
When deselecting a node, the inspector would show the name of the last thing selected.

Closes: #31945