### PR TITLE
Fixed order of parameters when updating resource cache file

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -295,8 +295,9 @@ void EditorResourcePreview::_thread() {
 								//update modified time
 
 								f = FileAccess::open(file, FileAccess::WRITE);
-								f->store_line(itos(modtime));
+								f->store_line(itos(thumbnail_size));
 								f->store_line(itos(has_small_texture));
+								f->store_line(itos(modtime));
 								f->store_line(md5);
 								memdelete(f);
 							}


### PR DESCRIPTION
When EditorResourcePreview was updating cache files, the values were written in the wrong order and one was missing, which caused an int overflow when trying to read such files (trying to read a checksum value and store it as a modification date).

The int overflow errors are going to be still triggered once and will disappear afterwards.

Fixes #31930