### PR TITLE
Add informational messages to various editors

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2466,6 +2466,7 @@ void AnimationTrackEdit::update_play_position() {
 void AnimationTrackEdit::set_root(Node *p_root) {
 	root = p_root;
 }
+
 void AnimationTrackEdit::_zoom_changed() {
 	update();
 	play_position->update();
@@ -3305,6 +3306,7 @@ Ref<Animation> AnimationTrackEditor::get_current_animation() const {
 
 	return animation;
 }
+
 void AnimationTrackEditor::_root_removed(Node *p_root) {
 	root = NULL;
 }
@@ -4079,6 +4081,8 @@ int AnimationTrackEditor::_confirm_insert(InsertData p_id, int p_last_track, boo
 }
 
 void AnimationTrackEditor::show_select_node_warning(bool p_show) {
+
+	info_message->set_visible(p_show);
 }
 
 bool AnimationTrackEditor::is_key_selected(int p_track, int p_key) const {
@@ -5793,6 +5797,14 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
 	timeline_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
 	timeline_vbox->add_constant_override("separation", 0);
+
+	info_message = memnew(Label);
+	info_message->set_text(TTR("Select an AnimationPlayer node to create and edit animations."));
+	info_message->set_valign(Label::VALIGN_CENTER);
+	info_message->set_align(Label::ALIGN_CENTER);
+	info_message->set_autowrap(true);
+	info_message->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
+	main_panel->add_child(info_message);
 
 	timeline = memnew(AnimationTimelineEdit);
 	timeline->set_undo_redo(undo_redo);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -304,6 +304,8 @@ class AnimationTrackEditor : public VBoxContainer {
 	VBoxContainer *track_vbox;
 	AnimationBezierTrackEdit *bezier_edit;
 
+	Label *info_message;
+
 	AnimationTimelineEdit *timeline;
 	HSlider *zoom;
 	EditorSpinSlider *step;

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -132,6 +132,7 @@ void ImportDock::set_edit_path(const String &p_path) {
 	params->paths.push_back(p_path);
 	import->set_disabled(false);
 	import_as->set_disabled(false);
+	preset->set_disabled(false);
 
 	imported->set_text(p_path.get_file());
 }
@@ -287,6 +288,7 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 	params->paths = p_paths;
 	import->set_disabled(false);
 	import_as->set_disabled(false);
+	preset->set_disabled(false);
 
 	imported->set_text(itos(p_paths.size()) + TTR(" Files"));
 }
@@ -367,6 +369,7 @@ void ImportDock::clear() {
 	import->set_disabled(true);
 	import_as->clear();
 	import_as->set_disabled(true);
+	preset->set_disabled(true);
 	params->values.clear();
 	params->properties.clear();
 	params->update();
@@ -528,11 +531,13 @@ ImportDock::ImportDock() {
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_margin_child(TTR("Import As:"), hb);
 	import_as = memnew(OptionButton);
+	import_as->set_disabled(true);
 	import_as->connect("item_selected", this, "_importer_selected");
 	hb->add_child(import_as);
 	import_as->set_h_size_flags(SIZE_EXPAND_FILL);
 	preset = memnew(MenuButton);
-	preset->set_text(TTR("Preset..."));
+	preset->set_text(TTR("Preset"));
+	preset->set_disabled(true);
 	preset->get_popup()->connect("index_pressed", this, "_preset_selected");
 	hb->add_child(preset);
 
@@ -545,6 +550,7 @@ ImportDock::ImportDock() {
 	add_child(hb);
 	import = memnew(Button);
 	import->set_text(TTR("Reimport"));
+	import->set_disabled(true);
 	import->connect("pressed", this, "_reimport_attempt");
 	hb->add_spacer();
 	hb->add_child(import);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -38,7 +38,7 @@
 #include "editor/animation_track_editor.h"
 #include "editor/editor_settings.h"
 
-// For onion skinning
+// For onion skinning.
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/spatial_editor_plugin.h"
 #include "scene/main/viewport.h"
@@ -1088,20 +1088,6 @@ void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag)
 	EditorNode::get_singleton()->get_inspector()->refresh();
 }
 
-void AnimationPlayerEditor::_hide_anim_editors() {
-
-	player = NULL;
-	hide();
-	set_process(false);
-
-	track_editor->set_animation(Ref<Animation>());
-	track_editor->set_root(NULL);
-	track_editor->show_select_node_warning(true);
-}
-
-void AnimationPlayerEditor::_animation_about_to_show_menu() {
-}
-
 void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 
 	String current;
@@ -1489,7 +1475,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 	player->seek(cpos, false);
 	player->restore_animated_values(values_backup);
 
-	// Restor state of main editors.
+	// Restore state of main editors.
 	if (SpatialEditor::get_singleton()->is_visible()) {
 		// 3D
 		SpatialEditor::get_singleton()->set_state(spatial_edit_state);
@@ -1519,7 +1505,7 @@ void AnimationPlayerEditor::_stop_onion_skinning() {
 
 		_free_onion_layers();
 
-		// Clean up the overlay
+		// Clean up the overlay.
 		onion.can_overlay = false;
 		plugin->update_overlays();
 	}
@@ -1557,7 +1543,6 @@ void AnimationPlayerEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_list_changed"), &AnimationPlayerEditor::_list_changed);
 	ClassDB::bind_method(D_METHOD("_animation_key_editor_seek"), &AnimationPlayerEditor::_animation_key_editor_seek);
 	ClassDB::bind_method(D_METHOD("_animation_key_editor_anim_len_changed"), &AnimationPlayerEditor::_animation_key_editor_anim_len_changed);
-	ClassDB::bind_method(D_METHOD("_hide_anim_editors"), &AnimationPlayerEditor::_hide_anim_editors);
 	ClassDB::bind_method(D_METHOD("_animation_duplicate"), &AnimationPlayerEditor::_animation_duplicate);
 	ClassDB::bind_method(D_METHOD("_blend_editor_next_changed"), &AnimationPlayerEditor::_blend_editor_next_changed);
 	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &AnimationPlayerEditor::_unhandled_key_input);
@@ -1776,7 +1761,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	_update_player();
 
-	// Onion skinning
+	// Onion skinning.
 
 	track_editor->connect("visibility_changed", this, "_editor_visibility_changed");
 

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -130,9 +130,9 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 	AnimationTrackEditor *track_editor;
 
-	// Onion skinning
+	// Onion skinning.
 	struct {
-		// Settings
+		// Settings.
 		bool enabled;
 		bool past;
 		bool future;
@@ -142,11 +142,11 @@ class AnimationPlayerEditor : public VBoxContainer {
 		bool include_gizmos;
 
 		int get_needed_capture_count() const {
-			// 'Differences only' needs a capture of the present
+			// 'Differences only' needs a capture of the present.
 			return (past && future ? 2 * steps : steps) + (differences_only ? 1 : 0);
 		}
 
-		// Rendering
+		// Rendering.
 		int64_t last_frame;
 		int can_overlay;
 		Size2 capture_size;
@@ -195,8 +195,6 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _update_player();
 	void _blend_edited();
 
-	void _hide_anim_editors();
-
 	void _animation_player_changed(Object *p_pl);
 
 	void _animation_key_editor_seek(float p_pos, bool p_drag);
@@ -205,7 +203,6 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _unhandled_key_input(const Ref<InputEvent> &p_ev);
 	void _animation_tool_menu(int p_option);
 	void _onion_skinning_menu(int p_option);
-	void _animation_about_to_show_menu();
 
 	void _editor_visibility_changed();
 	bool _are_onion_layers_valid();

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -376,7 +376,7 @@ void TileMapEditor::_sbox_input(const Ref<InputEvent> &p_ie) {
 }
 
 // Implementation detail of TileMapEditor::_update_palette();
-// in modern C++ this could have been inside its body
+// In modern C++ this could have been inside its body.
 namespace {
 struct _PaletteEntry {
 	int id;
@@ -393,10 +393,10 @@ void TileMapEditor::_update_palette() {
 	if (!node)
 		return;
 
-	// Update the clear button
+	// Update the clear button.
 	clear_transform_button->set_disabled(!flip_h && !flip_v && !transpose);
 
-	// Update the palette
+	// Update the palette.
 	Vector<int> selected = get_selected_tiles();
 	int selected_single = palette->get_current();
 	int selected_manual = manual_palette->get_current();
@@ -405,8 +405,15 @@ void TileMapEditor::_update_palette() {
 	manual_palette->hide();
 
 	Ref<TileSet> tileset = node->get_tileset();
-	if (tileset.is_null())
+	if (tileset.is_null()) {
+		search_box->set_text("");
+		search_box->set_editable(false);
+		info_message->show();
 		return;
+	}
+
+	search_box->set_editable(true);
+	info_message->hide();
 
 	List<int> tiles;
 	tileset->get_tile_list(&tiles);
@@ -421,7 +428,6 @@ void TileMapEditor::_update_palette() {
 	bool sort_by_name = bool(EDITOR_DEF("editors/tile_map/sort_tiles_by_name", true));
 
 	palette->add_constant_override("hseparation", hseparation * EDSCALE);
-	palette->add_constant_override("vseparation", 8 * EDSCALE);
 
 	palette->set_fixed_icon_size(Size2(min_size, min_size));
 	palette->set_fixed_column_width(min_size * MAX(size_slider->get_value(), 1));
@@ -479,7 +485,7 @@ void TileMapEditor::_update_palette() {
 				region.position += (region.size + Vector2(spacing, spacing)) * tileset->autotile_get_icon_coordinate(entries[i].id);
 			}
 
-			// Transpose and flip
+			// Transpose and flip.
 			palette->set_item_icon_transposed(palette->get_item_count() - 1, transpose);
 			if (flip_h) {
 				region.size.x = -region.size.x;
@@ -488,14 +494,14 @@ void TileMapEditor::_update_palette() {
 				region.size.y = -region.size.y;
 			}
 
-			// Set region
+			// Set region.
 			if (region.size != Size2())
 				palette->set_item_icon_region(palette->get_item_count() - 1, region);
 
-			// Set icon
+			// Set icon.
 			palette->set_item_icon(palette->get_item_count() - 1, tex);
 
-			// Modulation
+			// Modulation.
 			Color color = tileset->tile_get_modulate(entries[i].id);
 			palette->set_item_icon_modulate(palette->get_item_count() - 1, color);
 		}
@@ -511,50 +517,47 @@ void TileMapEditor::_update_palette() {
 		palette->select(0);
 	}
 
-	if (sel_tile != TileMap::INVALID_CELL) {
-		if ((manual_autotile && tileset->tile_get_tile_mode(sel_tile) == TileSet::AUTO_TILE) ||
-				(!priority_atlastile && tileset->tile_get_tile_mode(sel_tile) == TileSet::ATLAS_TILE)) {
+	if (sel_tile != TileMap::INVALID_CELL && ((manual_autotile && tileset->tile_get_tile_mode(sel_tile) == TileSet::AUTO_TILE) || (!priority_atlastile && tileset->tile_get_tile_mode(sel_tile) == TileSet::ATLAS_TILE))) {
 
-			const Map<Vector2, uint32_t> &tiles2 = tileset->autotile_get_bitmask_map(sel_tile);
+		const Map<Vector2, uint32_t> &tiles2 = tileset->autotile_get_bitmask_map(sel_tile);
 
-			Vector<Vector2> entries2;
-			for (const Map<Vector2, uint32_t>::Element *E = tiles2.front(); E; E = E->next()) {
-				entries2.push_back(E->key());
+		Vector<Vector2> entries2;
+		for (const Map<Vector2, uint32_t>::Element *E = tiles2.front(); E; E = E->next()) {
+			entries2.push_back(E->key());
+		}
+		// Sort tiles in row-major order.
+		struct SwapComparator {
+			_FORCE_INLINE_ bool operator()(const Vector2 &v_l, const Vector2 &v_r) const {
+				return v_l.y != v_r.y ? v_l.y < v_r.y : v_l.x < v_r.x;
 			}
-			// Sort tiles in row-major order
-			struct SwapComparator {
-				_FORCE_INLINE_ bool operator()(const Vector2 &v_l, const Vector2 &v_r) const {
-					return v_l.y != v_r.y ? v_l.y < v_r.y : v_l.x < v_r.x;
-				}
-			};
-			entries2.sort_custom<SwapComparator>();
+		};
+		entries2.sort_custom<SwapComparator>();
 
-			Ref<Texture> tex = tileset->tile_get_texture(sel_tile);
+		Ref<Texture> tex = tileset->tile_get_texture(sel_tile);
 
-			for (int i = 0; i < entries2.size(); i++) {
+		for (int i = 0; i < entries2.size(); i++) {
 
-				manual_palette->add_item(String());
+			manual_palette->add_item(String());
 
-				if (tex.is_valid()) {
+			if (tex.is_valid()) {
 
-					Rect2 region = tileset->tile_get_region(sel_tile);
-					int spacing = tileset->autotile_get_spacing(sel_tile);
-					region.size = tileset->autotile_get_size(sel_tile); // !!
-					region.position += (region.size + Vector2(spacing, spacing)) * entries2[i];
+				Rect2 region = tileset->tile_get_region(sel_tile);
+				int spacing = tileset->autotile_get_spacing(sel_tile);
+				region.size = tileset->autotile_get_size(sel_tile); // !!
+				region.position += (region.size + Vector2(spacing, spacing)) * entries2[i];
 
-					if (!region.has_no_area())
-						manual_palette->set_item_icon_region(manual_palette->get_item_count() - 1, region);
+				if (!region.has_no_area())
+					manual_palette->set_item_icon_region(manual_palette->get_item_count() - 1, region);
 
-					manual_palette->set_item_icon(manual_palette->get_item_count() - 1, tex);
-				}
-
-				manual_palette->set_item_metadata(manual_palette->get_item_count() - 1, entries2[i]);
+				manual_palette->set_item_icon(manual_palette->get_item_count() - 1, tex);
 			}
+
+			manual_palette->set_item_metadata(manual_palette->get_item_count() - 1, entries2[i]);
 		}
 	}
 
 	if (manual_palette->get_item_count() > 0) {
-		// Only show the manual palette if at least tile exists in it
+		// Only show the manual palette if at least tile exists in it.
 		if (selected_manual == -1 || selected_single != palette->get_current())
 			selected_manual = 0;
 		if (selected_manual < manual_palette->get_item_count())
@@ -1951,6 +1954,7 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	add_child(priority_button);
 
 	search_box = memnew(LineEdit);
+	search_box->set_placeholder(TTR("Filter tiles"));
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	search_box->connect("text_entered", this, "_text_entered");
 	search_box->connect("text_changed", this, "_text_changed");
@@ -1973,7 +1977,7 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	palette_container->set_custom_minimum_size(Size2(mw, 0));
 	add_child(palette_container);
 
-	// Add tile palette
+	// Add tile palette.
 	palette = memnew(ItemList);
 	palette->set_h_size_flags(SIZE_EXPAND_FILL);
 	palette->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -1981,11 +1985,21 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	palette->set_icon_mode(ItemList::ICON_MODE_TOP);
 	palette->set_max_text_lines(2);
 	palette->set_select_mode(ItemList::SELECT_MULTI);
+	palette->add_constant_override("vseparation", 8 * EDSCALE);
 	palette->connect("item_selected", this, "_palette_selected");
 	palette->connect("multi_selected", this, "_palette_multi_selected");
 	palette_container->add_child(palette);
 
-	// Add autotile override palette
+	// Add message for when no texture is selected.
+	info_message = memnew(Label);
+	info_message->set_text(TTR("Give a TileSet resource to this TileMap to use its tiles."));
+	info_message->set_valign(Label::VALIGN_CENTER);
+	info_message->set_align(Label::ALIGN_CENTER);
+	info_message->set_autowrap(true);
+	info_message->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
+	palette->add_child(info_message);
+
+	// Add autotile override palette.
 	manual_palette = memnew(ItemList);
 	manual_palette->set_h_size_flags(SIZE_EXPAND_FILL);
 	manual_palette->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -1995,15 +2009,14 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	manual_palette->hide();
 	palette_container->add_child(manual_palette);
 
-	// Add menu items
+	// Add menu items.
 	toolbar = memnew(HBoxContainer);
 	toolbar->hide();
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(toolbar);
 
-	// Separator
 	toolbar->add_child(memnew(VSeparator));
 
-	// Tools
+	// Tools.
 	paint_button = memnew(ToolButton);
 	paint_button->set_shortcut(ED_SHORTCUT("tile_map_editor/paint_tile", TTR("Paint Tile"), KEY_P));
 	paint_button->set_tooltip(TTR("Shift+LMB: Line Draw\nShift+Ctrl+LMB: Rectangle Paint"));
@@ -2031,18 +2044,18 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 
 	_update_button_tool();
 
-	// Container to the right of the toolbar
+	// Container to the right of the toolbar.
 	toolbar_right = memnew(HBoxContainer);
 	toolbar_right->hide();
 	toolbar_right->set_h_size_flags(SIZE_EXPAND_FILL);
 	toolbar_right->set_alignment(BoxContainer::ALIGN_END);
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(toolbar_right);
 
-	// Tile position
+	// Tile position.
 	tile_info = memnew(Label);
 	toolbar_right->add_child(tile_info);
 
-	// Menu
+	// Menu.
 	options = memnew(MenuButton);
 	options->set_text("TileMap");
 	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("TileMap", "EditorIcons"));
@@ -2136,7 +2149,8 @@ void TileMapEditorPlugin::make_visible(bool p_visible) {
 		tile_map_editor->show();
 		tile_map_editor->get_toolbar()->show();
 		tile_map_editor->get_toolbar_right()->show();
-		CanvasItemEditor::get_singleton()->set_current_tool(CanvasItemEditor::TOOL_SELECT); //Change to TOOL_SELECT when TileMap node is selected, to prevent accidental movement.
+		// Change to TOOL_SELECT when TileMap node is selected, to prevent accidental movement.
+		CanvasItemEditor::get_singleton()->set_current_tool(CanvasItemEditor::TOOL_SELECT);
 	} else {
 
 		tile_map_editor->hide();

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -82,6 +82,8 @@ class TileMapEditor : public VBoxContainer {
 	ItemList *palette;
 	ItemList *manual_palette;
 
+	Label *info_message;
+
 	HBoxContainer *toolbar;
 	HBoxContainer *toolbar_right;
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -579,6 +579,14 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
 	scroll->set_clip_contents(true);
 
+	empty_message = memnew(Label);
+	empty_message->set_text(TTR("Add or select a texture on the left panel to edit the tiles bound to it."));
+	empty_message->set_valign(Label::VALIGN_CENTER);
+	empty_message->set_align(Label::ALIGN_CENTER);
+	empty_message->set_autowrap(true);
+	empty_message->set_v_size_flags(SIZE_EXPAND_FILL);
+	main_vb->add_child(empty_message);
+
 	workspace_container = memnew(Control);
 	scroll->add_child(workspace_container);
 
@@ -627,7 +635,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	helper = memnew(TilesetEditorContext(this));
 	tile_names_visible = false;
 
-	// config scale
+	// Config scale.
 	max_scale = 10.0f;
 	min_scale = 0.1f;
 	scale_ratio = 1.2f;
@@ -3123,12 +3131,28 @@ void TileSetEditor::update_workspace_tile_mode() {
 		}
 		tools[SELECT_NEXT]->set_disabled(true);
 		tools[SELECT_PREVIOUS]->set_disabled(true);
+
+		tools[ZOOM_OUT]->hide();
+		tools[ZOOM_1]->hide();
+		tools[ZOOM_IN]->hide();
+		tools[VISIBLE_INFO]->hide();
+
+		scroll->hide();
+		empty_message->show();
 	} else {
 		for (int i = 1; i < WORKSPACE_MODE_MAX; i++) {
 			tool_workspacemode[i]->set_disabled(false);
 		}
 		tools[SELECT_NEXT]->set_disabled(false);
 		tools[SELECT_PREVIOUS]->set_disabled(false);
+
+		tools[ZOOM_OUT]->show();
+		tools[ZOOM_1]->show();
+		tools[ZOOM_IN]->show();
+		tools[VISIBLE_INFO]->show();
+
+		scroll->show();
+		empty_message->hide();
 	}
 
 	if (workspace_mode != WORKSPACE_EDIT) {

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -138,6 +138,7 @@ class TileSetEditor : public HSplitContainer {
 	int current_item_index;
 	Sprite *preview;
 	ScrollContainer *scroll;
+	Label *empty_message;
 	Control *workspace_container;
 	bool draw_handles;
 	Control *workspace_overlay;

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1028,17 +1028,15 @@ void ScriptEditorDebugger::_performance_draw() {
 			which.push_back(i);
 	}
 
-	Ref<Font> graph_font = get_font("font", "TextEdit");
-
 	if (which.empty()) {
-		String text = TTR("Pick one or more items from the list to display the graph.");
-
-		perf_draw->draw_string(graph_font, Point2i(MAX(0, perf_draw->get_size().x - graph_font->get_string_size(text).x), perf_draw->get_size().y + graph_font->get_ascent()) / 2, text, get_color("font_color", "Label"), perf_draw->get_size().x);
-
+		info_message->show();
 		return;
 	}
 
+	info_message->hide();
+
 	Ref<StyleBox> graph_sb = get_stylebox("normal", "TextEdit");
+	Ref<Font> graph_font = get_font("font", "TextEdit");
 
 	int cols = Math::ceil(Math::sqrt((float)which.size()));
 	int rows = Math::ceil((float)which.size() / cols);
@@ -1107,7 +1105,6 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			forward->set_icon(get_icon("Forward", "EditorIcons"));
 			dobreak->set_icon(get_icon("Pause", "EditorIcons"));
 			docontinue->set_icon(get_icon("DebugContinue", "EditorIcons"));
-			//scene_tree_refresh->set_icon( get_icon("Reload","EditorIcons"));
 			le_set->connect("pressed", this, "_live_edit_set");
 			le_clear->connect("pressed", this, "_live_edit_clear");
 			error_tree->connect("item_selected", this, "_error_selected");
@@ -2254,11 +2251,14 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		perf_monitors->set_column_title(0, TTR("Monitor"));
 		perf_monitors->set_column_title(1, TTR("Value"));
 		perf_monitors->set_column_titles_visible(true);
-		hsp->add_child(perf_monitors);
 		perf_monitors->connect("item_edited", this, "_performance_select");
+		hsp->add_child(perf_monitors);
+
 		perf_draw = memnew(Control);
+		perf_draw->set_clip_contents(true);
 		perf_draw->connect("draw", this, "_performance_draw");
 		hsp->add_child(perf_draw);
+
 		hsp->set_name(TTR("Monitors"));
 		hsp->set_split_offset(340 * EDSCALE);
 		tabs->add_child(hsp);
@@ -2292,6 +2292,14 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 			perf_items.push_back(it);
 			perf_max.write[i] = 0;
 		}
+
+		info_message = memnew(Label);
+		info_message->set_text(TTR("Pick one or more items from the list to display the graph."));
+		info_message->set_valign(Label::VALIGN_CENTER);
+		info_message->set_align(Label::ALIGN_CENTER);
+		info_message->set_autowrap(true);
+		info_message->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
+		perf_draw->add_child(info_message);
 	}
 
 	{ //vmem inspect
@@ -2303,7 +2311,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		vmem_hb->add_child(memnew(Label(TTR("Total:") + " ")));
 		vmem_total = memnew(LineEdit);
 		vmem_total->set_editable(false);
-		vmem_total->set_custom_minimum_size(Size2(100, 1) * EDSCALE);
+		vmem_total->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 		vmem_hb->add_child(vmem_total);
 		vmem_refresh = memnew(ToolButton);
 		vmem_hb->add_child(vmem_refresh);

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -134,6 +134,7 @@ class ScriptEditorDebugger : public Control {
 
 	Tree *perf_monitors;
 	Control *perf_draw;
+	Label *info_message;
 
 	Tree *vmem_tree;
 	Button *vmem_refresh;

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -884,8 +884,14 @@ void GridMapEditor::update_palette() {
 
 	if (mesh_library.is_null()) {
 		last_mesh_library = NULL;
+		search_box->set_text("");
+		search_box->set_editable(false);
+		info_message->show();
 		return;
 	}
+
+	search_box->set_editable(true);
+	info_message->hide();
 
 	Vector<int> ids;
 	ids = mesh_library->get_item_list();
@@ -1296,6 +1302,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 
 	search_box = memnew(LineEdit);
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	search_box->set_placeholder(TTR("Filter meshes"));
 	hb->add_child(search_box);
 	search_box->connect("text_changed", this, "_text_changed");
 	search_box->connect("gui_input", this, "_sbox_input");
@@ -1331,6 +1338,14 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	add_child(mesh_library_palette);
 	mesh_library_palette->set_v_size_flags(SIZE_EXPAND_FILL);
 
+	info_message = memnew(Label);
+	info_message->set_text(TTR("Give a MeshLibrary resource to this GridMap to use its meshes."));
+	info_message->set_valign(Label::VALIGN_CENTER);
+	info_message->set_align(Label::ALIGN_CENTER);
+	info_message->set_autowrap(true);
+	info_message->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
+	mesh_library_palette->add_child(info_message);
+
 	edit_axis = Vector3::AXIS_Y;
 	edit_floor[0] = -1;
 	edit_floor[1] = -1;
@@ -1346,7 +1361,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	paste_mesh = VisualServer::get_singleton()->mesh_create();
 
 	{
-		//selection mesh create
+		// Selection mesh create.
 
 		PoolVector<Vector3> lines;
 		PoolVector<Vector3> triangles;
@@ -1424,7 +1439,6 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 
 		inner_mat.instance();
 		inner_mat->set_albedo(Color(0.7, 0.7, 1.0, 0.2));
-		//inner_mat->set_flag(SpatialMaterial::FLAG_ONTOP, true);
 		inner_mat->set_flag(SpatialMaterial::FLAG_UNSHADED, true);
 		inner_mat->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, true);
 
@@ -1444,7 +1458,6 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 		selection_floor_mat->set_on_top_of_alpha();
 		selection_floor_mat->set_flag(SpatialMaterial::FLAG_UNSHADED, true);
 		selection_floor_mat->set_line_width(3.0);
-		//selection_floor_mat->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, true);
 
 		d[VS::ARRAY_VERTEX] = lines;
 		VisualServer::get_singleton()->mesh_add_surface_from_arrays(selection_mesh, VS::PRIMITIVE_LINES, d);

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -197,12 +197,16 @@ class GridMapEditor : public VBoxContainer {
 		RID instance;
 	};
 
+	ItemList *mesh_library_palette;
+	Label *info_message;
+
+	EditorNode *editor;
+
 	void update_grid();
 	void _configure();
 	void _menu_option(int);
 	void update_palette();
 	void _set_display_mode(int p_mode);
-	ItemList *mesh_library_palette;
 	void _item_selected_cbk(int idx);
 	void _update_cursor_transform();
 	void _update_cursor_instance();
@@ -227,7 +231,6 @@ class GridMapEditor : public VBoxContainer {
 	void _delete_selection();
 	void _fill_selection();
 
-	EditorNode *editor;
 	bool do_input_action(Camera *p_camera, const Point2 &p_point, bool p_click);
 
 	friend class GridMapEditorPlugin;


### PR DESCRIPTION
- Add `TileMap` and `GridMap` editors info messages about needing a `TileSet`/`MeshLibrary` resource if none are set.
- Re-add the message about needing to select an `AnimationPlayer` to edit animations (removed when it was re-written).
- Re-do message in the monitor debugger to be a `Label`, so the text wraps when shrunk.
- Minor cleanup.

Closes #31500.
Supersedes #31540.