### PR TITLE
Fixed switching back to AnimationPlayerEditor with empty animation list

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -690,8 +690,10 @@ void AnimationPlayerEditor::set_state(const Dictionary &p_state) {
 
 			if (p_state.has("animation")) {
 				String anim = p_state["animation"];
-				_select_anim_by_name(anim);
-				_animation_edit();
+				if (!anim.empty() && player->has_animation(anim)) {
+					_select_anim_by_name(anim);
+					_animation_edit();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Some errors were raised in two cases when restoring the animation player editor:
- No animation in list at all (the last assigned animation is empty)
- All animations have just been deleted (the last assigned animation can't be found)

Fixes #31959