### PR TITLE
Small improvements to the inspector dock

### DIFF
--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -74,7 +74,12 @@ void EditorPath::_about_to_show() {
 	objects.clear();
 	get_popup()->clear();
 	get_popup()->set_size(Size2(get_size().width, 1));
+
 	_add_children_to_popup(obj);
+	if (get_popup()->get_item_count() == 0) {
+		get_popup()->add_item(TTR("No sub-resources found."));
+		get_popup()->set_item_disabled(0, true);
+	}
 }
 
 void EditorPath::update_path() {

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -253,13 +253,11 @@ void InspectorDock::_prepare_history() {
 			text = obj->get_class();
 		}
 
-		if (i == editor_history->get_history_pos()) {
+		if (i == editor_history->get_history_pos() && current) {
 			text = "[" + text + "]";
 		}
 		history_menu->get_popup()->add_icon_item(icon, text, i);
 	}
-
-	editor_path->update_path();
 }
 
 void InspectorDock::_select_history(int p_idx) const {
@@ -296,7 +294,7 @@ void InspectorDock::_edit_forward() {
 }
 void InspectorDock::_edit_back() {
 	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
-	if (editor_history->previous() || editor_history->get_path_size() == 1)
+	if ((current && editor_history->previous()) || editor_history->get_path_size() == 1)
 		editor->edit_current();
 }
 


### PR DESCRIPTION
- Show a message that a object doesn't have sub-resources, instead of a blank popup.
- Make the object history behave properly when none is selected.