### PR TITLE
CharFXTransform Type Hint Error

### DIFF
--- a/scene/gui/rich_text_effect.cpp
+++ b/scene/gui/rich_text_effect.cpp
@@ -33,7 +33,7 @@
 #include "core/script_language.h"
 
 void RichTextEffect::_bind_methods() {
-	BIND_VMETHOD(MethodInfo(Variant::INT, "_process_custom_fx", PropertyInfo(Variant::OBJECT, "char_fx", PROPERTY_HINT_RESOURCE_TYPE, "CustomFXChar")));
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_process_custom_fx", PropertyInfo(Variant::OBJECT, "char_fx", PROPERTY_HINT_RESOURCE_TYPE, "CharFXTransform")));
 }
 
 Variant RichTextEffect::get_bbcode() const {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -101,6 +101,7 @@
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/progress_bar.h"
 #include "scene/gui/reference_rect.h"
+#include "scene/gui/rich_text_effect.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_bar.h"
 #include "scene/gui/scroll_container.h"
@@ -344,6 +345,7 @@ void register_scene_types() {
 	ClassDB::register_class<ColorPickerButton>();
 	ClassDB::register_class<RichTextLabel>();
 	ClassDB::register_class<RichTextEffect>();
+	ClassDB::register_class<CharFXTransform>();
 	ClassDB::register_class<PopupDialog>();
 	ClassDB::register_class<WindowDialog>();
 	ClassDB::register_class<AcceptDialog>();


### PR DESCRIPTION
Fixed #31973, introduced in my previous PR involving CharFXTransform not allowing the use of type hinting. It now works as intended. This should also help with Godot Mono issues as well, but if issues reoccur, let me know and I'll get on it. 

The appropriate type hinting should look something like: 
```
tool extends RichTextEffect
class_name RichTextGhost

var bbcode = "ghost"

func _init():
	resource_name = "RichTextGhost"

func _process_custom_fx(char_fx: CharFXTransform) -> bool:
	
	var speed = char_fx.get_value_or("freq", 5.0)
	var span = char_fx.get_value_or("span", 10.0)
	
	var alpha = sin(char_fx.elapsed_time * speed + (char_fx.absolute_index / span)) * 0.5 + 0.5
	char_fx.color.a = alpha
	return true;
```

