### PR TITLE
Flush MessageQueue while loading script in editor

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "script_editor_plugin.h"
 
 #include "core/io/resource_loader.h"
+#include "core/message_queue.h"
 #include "core/os/file_access.h"
 #include "core/os/input.h"
 #include "core/os/keyboard.h"
@@ -2681,6 +2682,11 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 			if (se) {
 				se->set_edit_state(script_info["state"]);
 			}
+		}
+
+		if ((i > 0) && (i % 50 == 0)) {
+			ERR_CONTINUE(MessageQueue::get_singleton()->is_flushing());
+			MessageQueue::get_singleton()->flush();
 		}
 	}
 


### PR DESCRIPTION
Flushing the message queue while loading all the scripts in the editor when there are many of them as a possible fix to avoid "Message queue out of memory" errors.

Each edited script causes 210 calls to `MessageQueue::push_call` when the project is loaded, and almost all of them are from this line:
https://github.com/godotengine/godot/blob/8bcf6ca95317329242e954a71047ce1183cfe5f8/editor/plugins/script_editor_plugin.cpp#L2154

There are mostly due to `update_callback` from `CanvasItem` and `sort_children` from `Container` when all the controls for the script editor are added to the tree for each script: text editor, menus, etc...

Fixes #17693