### PR TITLE
Revert "Fix Clearing Inspector for Remote Node"

### DIFF
--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -78,9 +78,6 @@ void EditorPath::_about_to_show() {
 }
 
 void EditorPath::update_path() {
-	set_text("");
-	set_tooltip("");
-	set_icon(NULL);
 
 	for (int i = 0; i < history->get_path_size(); i++) {
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1391,7 +1391,7 @@ void ScriptEditorDebugger::stop() {
 	profiler->set_enabled(true);
 
 	inspect_scene_tree->clear();
-	EditorNode::get_singleton()->edit_current();
+	inspector->edit(NULL);
 	EditorNode::get_singleton()->get_pause_button()->set_pressed(false);
 	EditorNode::get_singleton()->get_pause_button()->set_disabled(true);
 	EditorNode::get_singleton()->get_scene_tree_dock()->hide_remote_tree();


### PR DESCRIPTION
Reverts godotengine/godot#30833

Possibly introduces regression: https://github.com/godotengine/godot/issues/31873

Related issue #31945 has a PR that also fixes the issue that this PR intended to fix: #30731

