### PR TITLE
Improve the `String::humanize_size()` method

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3285,7 +3285,7 @@ static int _humanize_digits(int p_num) {
 String String::humanize_size(size_t p_size) {
 
 	uint64_t _div = 1;
-	static const char *prefix[] = { " Bytes", " KB", " MB", " GB", " TB", " PB", " EB", "" };
+	static const char *prefix[] = { " B", " KiB", " MiB", " GiB", " TiB", " PiB", " EiB", "" };
 	int prefix_idx = 0;
 
 	while (p_size > (_div * 1024) && prefix[prefix_idx][0]) {
@@ -3296,7 +3296,7 @@ String String::humanize_size(size_t p_size) {
 	int digits = prefix_idx > 0 ? _humanize_digits(p_size / _div) : 0;
 	double divisor = prefix_idx > 0 ? _div : 1;
 
-	return String::num(p_size / divisor).pad_decimals(digits) + prefix[prefix_idx];
+	return String::num(p_size / divisor).pad_decimals(digits) + RTR(prefix[prefix_idx]);
 }
 bool String::is_abs_path() const {
 

--- a/editor/editor_network_profiler.cpp
+++ b/editor/editor_network_profiler.cpp
@@ -92,22 +92,6 @@ void EditorNetworkProfiler::_clear_pressed() {
 	}
 }
 
-String EditorNetworkProfiler::_format_bandwidth(int p_value) {
-	String unit = "B";
-	float v = p_value;
-	if (v > 1073741824.0) {
-		unit = "GiB";
-		v /= 1073741824.0;
-	} else if (v > 1048576.0) {
-		unit = "MiB";
-		v /= 1048576.0;
-	} else if (v > 1024.0) {
-		unit = "KiB";
-		v /= 1024.0;
-	}
-	return vformat("%.1f %s/s", v, unit);
-}
-
 void EditorNetworkProfiler::add_node_frame_data(const MultiplayerAPI::ProfilingInfo p_frame) {
 
 	if (!nodes_data.has(p_frame.node)) {
@@ -127,8 +111,8 @@ void EditorNetworkProfiler::add_node_frame_data(const MultiplayerAPI::ProfilingI
 
 void EditorNetworkProfiler::set_bandwidth(int p_incoming, int p_outgoing) {
 
-	incoming_bandwidth_text->set_text(_format_bandwidth(p_incoming));
-	outgoing_bandwidth_text->set_text(_format_bandwidth(p_outgoing));
+	incoming_bandwidth_text->set_text(vformat(TTR("%s/s"), String::humanize_size(p_incoming)));
+	outgoing_bandwidth_text->set_text(vformat(TTR("%s/s"), String::humanize_size(p_outgoing)));
 }
 
 bool EditorNetworkProfiler::is_profiling() {

--- a/editor/editor_network_profiler.h
+++ b/editor/editor_network_profiler.h
@@ -56,7 +56,6 @@ private:
 
 	void _activate_pressed();
 	void _clear_pressed();
-	String _format_bandwidth(int p_value);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
- Use "B" insted of "Bytes" to be more compact
- Use suffixes that denote a binary prefix
- Make suffixes localizable

This removes the need for the custom `EditorNetworkProfiler:_format_bandwidth()` method, see discussion in #31870. We could also consider exposing this method to scripts, so that projects that need to display file sizes can use it directly.

cc @Faless