### PR TITLE
SpriteFramesEditor improvements around deleting animations

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -73,6 +73,8 @@ class SpriteFramesEditor : public HSplitContainer {
 
 	StringName edited_anim;
 
+	ConfirmationDialog *delete_dialog;
+
 	ConfirmationDialog *split_sheet_dialog;
 	ScrollContainer *splite_sheet_scroll;
 	TextureRect *split_sheet_preview;
@@ -98,6 +100,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _animation_name_edited();
 	void _animation_add();
 	void _animation_remove();
+	void _animation_remove_confirmed();
 	void _animation_loop_changed();
 	void _animation_fps_changed(double p_value);
 


### PR DESCRIPTION
Made some changes in the frames editor for AnimatedSprite based on suggestions from #31963 (this PR only fixes it partially).

1. Reorganized buttons layout to make it clearer between deleting animation & frame
2. Added a confirmation popup for deleting an animation
3. Fixed errors on selecting an animation after deleting one