### PR TITLE
GDScript optimisations, internal storage changed from Map to OrderedHashMap

### DIFF
--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -55,7 +55,7 @@
  *
 */
 
-template <class TKey, class TData, class Hasher = HashMapHasherDefault, class Comparator = HashMapComparatorDefault<TKey>, uint8_t MIN_HASH_TABLE_POWER = 3, uint8_t RELATIONSHIP = 8>
+template <class TKey, class TData, class Hasher = HashMapHasherDefault, class Comparator = HashMapComparatorDefault<TKey>, uint8_t MIN_HASH_TABLE_POWER = 3, uint8_t RELATIONSHIP = 1>
 class HashMap {
 public:
 	struct Pair {

--- a/core/ordered_hash_map.h
+++ b/core/ordered_hash_map.h
@@ -43,7 +43,7 @@
  * codebase.
  * Deletion during iteration is safe and will preserve the order.
  */
-template <class K, class V, class Hasher = HashMapHasherDefault, class Comparator = HashMapComparatorDefault<K>, uint8_t MIN_HASH_TABLE_POWER = 3, uint8_t RELATIONSHIP = 8>
+template <class K, class V, class Hasher = HashMapHasherDefault, class Comparator = HashMapComparatorDefault<K>, uint8_t MIN_HASH_TABLE_POWER = 3, uint8_t RELATIONSHIP = 1>
 class OrderedHashMap {
 	typedef List<Pair<const K *, V> > InternalList;
 	typedef HashMap<K, typename InternalList::Element *, Hasher, Comparator, MIN_HASH_TABLE_POWER, RELATIONSHIP> InternalMap;

--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -531,11 +531,11 @@ static String _disassemble_addr(const Ref<GDScript> &p_script, const GDScriptFun
 
 static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String> &p_code) {
 
-	const Map<StringName, GDScriptFunction *> &mf = p_class->debug_get_member_functions();
+	const OrderedHashMap<StringName, GDScriptFunction *> &mf = p_class->debug_get_member_functions();
 
-	for (const Map<StringName, GDScriptFunction *>::Element *E = mf.front(); E; E = E->next()) {
+	for (OrderedHashMap<StringName, GDScriptFunction *>::ConstElement E = mf.front(); E; E = E.next()) {
 
-		const GDScriptFunction &func = *E->get();
+		const GDScriptFunction &func = *E.get();
 		const int *code = func.get_code();
 		int codelen = func.get_code_size();
 		String defargs;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -226,10 +226,10 @@ void GDScript::get_script_method_list(List<MethodInfo> *p_list) const {
 
 	const GDScript *current = this;
 	while (current) {
-		for (const Map<StringName, GDScriptFunction *>::Element *E = member_functions.front(); E; E = E->next()) {
-			GDScriptFunction *func = E->get();
+		for (OrderedHashMap <StringName, GDScriptFunction *>::ConstElement E = member_functions.front(); E; E = E.next()) {
+			GDScriptFunction *func = E.get();
 			MethodInfo mi;
-			mi.name = E->key();
+			mi.name = E.key();
 			for (int i = 0; i < func->get_argument_count(); i++) {
 				mi.arguments.push_back(func->get_argument_type(i));
 			}
@@ -250,12 +250,12 @@ void GDScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 	while (sptr) {
 
 		Vector<_GDScriptMemberSort> msort;
-		for (Map<StringName, PropertyInfo>::Element *E = sptr->member_info.front(); E; E = E->next()) {
+		for (OrderedHashMap<StringName, PropertyInfo>::ConstElement E = sptr->member_info.front(); E; E = E.next()) {
 
 			_GDScriptMemberSort ms;
-			ERR_CONTINUE(!sptr->member_indices.has(E->key()));
-			ms.index = sptr->member_indices[E->key()].index;
-			ms.name = E->key();
+			ERR_CONTINUE(!sptr->member_indices.has(E.key()));
+			ms.index = sptr->member_indices[E.key()].index;
+			ms.name = E.key();
 			msort.push_back(ms);
 		}
 
@@ -281,13 +281,13 @@ bool GDScript::has_method(const StringName &p_method) const {
 
 MethodInfo GDScript::get_method_info(const StringName &p_method) const {
 
-	const Map<StringName, GDScriptFunction *>::Element *E = member_functions.find(p_method);
+	OrderedHashMap<StringName, GDScriptFunction *>::ConstElement E = member_functions.find(p_method);
 	if (!E)
 		return MethodInfo();
 
-	GDScriptFunction *func = E->get();
+	GDScriptFunction *func = E.get();
 	MethodInfo mi;
-	mi.name = E->key();
+	mi.name = E.key();
 	for (int i = 0; i < func->get_argument_count(); i++) {
 		mi.arguments.push_back(func->get_argument_type(i));
 	}
@@ -537,9 +537,9 @@ void GDScript::update_exports() {
 void GDScript::_set_subclass_path(Ref<GDScript> &p_sc, const String &p_path) {
 
 	p_sc->path = p_path;
-	for (Map<StringName, Ref<GDScript> >::Element *E = p_sc->subclasses.front(); E; E = E->next()) {
+	for (OrderedHashMap<StringName, Ref<GDScript> >::Element E = p_sc->subclasses.front(); E; E = E.next()) {
 
-		_set_subclass_path(E->get(), p_path);
+		_set_subclass_path(E.get(), p_path);
 	}
 }
 
@@ -609,9 +609,9 @@ Error GDScript::reload(bool p_keep_state) {
 
 	valid = true;
 
-	for (Map<StringName, Ref<GDScript> >::Element *E = subclasses.front(); E; E = E->next()) {
+	for (OrderedHashMap<StringName, Ref<GDScript> >::Element E = subclasses.front(); E; E = E.next()) {
 
-		_set_subclass_path(E->get(), path);
+		_set_subclass_path(E.get(), path);
 	}
 
 	return OK;
@@ -625,8 +625,8 @@ ScriptLanguage *GDScript::get_language() const {
 void GDScript::get_constants(Map<StringName, Variant> *p_constants) {
 
 	if (p_constants) {
-		for (Map<StringName, Variant>::Element *E = constants.front(); E; E = E->next()) {
-			(*p_constants)[E->key()] = E->value();
+		for (OrderedHashMap<StringName, Variant>::Element E = constants.front(); E; E = E.next()) {
+			(*p_constants)[E.key()] = E.value();
 		}
 	}
 }
@@ -644,15 +644,15 @@ Variant GDScript::call(const StringName &p_method, const Variant **p_args, int p
 	GDScript *top = this;
 	while (top) {
 
-		Map<StringName, GDScriptFunction *>::Element *E = top->member_functions.find(p_method);
+		OrderedHashMap<StringName, GDScriptFunction *>::Element E = top->member_functions.find(p_method);
 		if (E) {
 
-			if (!E->get()->is_static()) {
+			if (!E.get()->is_static()) {
 				ERR_EXPLAIN("Can't call non-static function: '" + String(p_method) + "' in script.");
 				ERR_FAIL_V(Variant());
 			}
 
-			return E->get()->call(NULL, p_args, p_argcount, r_error);
+			return E.get()->call(NULL, p_args, p_argcount, r_error);
 		}
 		top = top->_base;
 	}
@@ -670,19 +670,19 @@ bool GDScript::_get(const StringName &p_name, Variant &r_ret) const {
 		while (top) {
 
 			{
-				const Map<StringName, Variant>::Element *E = top->constants.find(p_name);
+				OrderedHashMap<StringName, Variant>::ConstElement E = top->constants.find(p_name);
 				if (E) {
 
-					r_ret = E->get();
+					r_ret = E.get();
 					return true;
 				}
 			}
 
 			{
-				const Map<StringName, Ref<GDScript> >::Element *E = subclasses.find(p_name);
+				OrderedHashMap<StringName, Ref<GDScript> >::ConstElement E = subclasses.find(p_name);
 				if (E) {
 
-					r_ret = E->get();
+					r_ret = E.get();
 					return true;
 				}
 			}
@@ -795,9 +795,9 @@ Error GDScript::load_byte_code(const String &p_path) {
 
 	valid = true;
 
-	for (Map<StringName, Ref<GDScript> >::Element *E = subclasses.front(); E; E = E->next()) {
+	for (OrderedHashMap<StringName, Ref<GDScript> >::Element E = subclasses.front(); E; E = E.next()) {
 
-		_set_subclass_path(E->get(), path);
+		_set_subclass_path(E.get(), path);
 	}
 
 	return OK;
@@ -837,7 +837,7 @@ Error GDScript::load_source_code(const String &p_path) {
 	return OK;
 }
 
-const Map<StringName, GDScriptFunction *> &GDScript::debug_get_member_functions() const {
+const OrderedHashMap<StringName, GDScriptFunction *> &GDScript::debug_get_member_functions() const {
 
 	return member_functions;
 }
@@ -873,13 +873,13 @@ bool GDScript::has_script_signal(const StringName &p_signal) const {
 }
 void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
 
-	for (const Map<StringName, Vector<StringName> >::Element *E = _signals.front(); E; E = E->next()) {
+	for (OrderedHashMap<StringName, Vector<StringName> >::ConstElement E = _signals.front(); E; E = E.next()) {
 
 		MethodInfo mi;
-		mi.name = E->key();
-		for (int i = 0; i < E->get().size(); i++) {
+		mi.name = E.key();
+		for (int i = 0; i < E.get().size(); i++) {
 			PropertyInfo arg;
-			arg.name = E->get()[i];
+			arg.name = E.get()[i];
 			mi.arguments.push_back(arg);
 		}
 		r_signals->push_back(mi);
@@ -924,12 +924,12 @@ GDScript::GDScript() :
 }
 
 GDScript::~GDScript() {
-	for (Map<StringName, GDScriptFunction *>::Element *E = member_functions.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (OrderedHashMap<StringName, GDScriptFunction *>::Element E = member_functions.front(); E; E = E.next()) {
+		memdelete(E.get());
 	}
 
-	for (Map<StringName, Ref<GDScript> >::Element *E = subclasses.front(); E; E = E->next()) {
-		E->get()->_owner = NULL; //bye, you are no longer owned cause I died
+	for (OrderedHashMap<StringName, Ref<GDScript> >::Element E = subclasses.front(); E; E = E.next()) {
+		E.get()->_owner = NULL; //bye, you are no longer owned cause I died
 	}
 
 #ifdef DEBUG_ENABLED
@@ -974,14 +974,14 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 	GDScript *sptr = script.ptr();
 	while (sptr) {
 
-		Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._set);
+		OrderedHashMap<StringName, GDScriptFunction *>::Element E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._set);
 		if (E) {
 
 			Variant name = p_name;
 			const Variant *args[2] = { &name, &p_value };
 
 			Variant::CallError err;
-			Variant ret = E->get()->call(this, (const Variant **)args, 2, err);
+			Variant ret = E.get()->call(this, (const Variant **)args, 2, err);
 			if (err.error == Variant::CallError::CALL_OK && ret.get_type() == Variant::BOOL && ret.operator bool())
 				return true;
 		}
@@ -1015,9 +1015,9 @@ bool GDScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 
 			const GDScript *sl = sptr;
 			while (sl) {
-				const Map<StringName, Variant>::Element *E = sl->constants.find(p_name);
+				OrderedHashMap<StringName, Variant>::ConstElement E = sl->constants.find(p_name);
 				if (E) {
-					r_ret = E->get();
+					r_ret = E.get();
 					return true; //index found
 				}
 				sl = sl->_base;
@@ -1025,14 +1025,14 @@ bool GDScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 		}
 
 		{
-			const Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._get);
+			OrderedHashMap<StringName, GDScriptFunction *>::ConstElement E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._get);
 			if (E) {
 
 				Variant name = p_name;
 				const Variant *args[1] = { &name };
 
 				Variant::CallError err;
-				Variant ret = const_cast<GDScriptFunction *>(E->get())->call(const_cast<GDScriptInstance *>(this), (const Variant **)args, 1, err);
+				Variant ret = const_cast<GDScriptFunction *>(E.get())->call(const_cast<GDScriptInstance *>(this), (const Variant **)args, 1, err);
 				if (err.error == Variant::CallError::CALL_OK && ret.get_type() != Variant::NIL) {
 					r_ret = ret;
 					return true;
@@ -1071,11 +1071,11 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 
 	while (sptr) {
 
-		const Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._get_property_list);
+		OrderedHashMap<StringName, GDScriptFunction *>::ConstElement E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._get_property_list);
 		if (E) {
 
 			Variant::CallError err;
-			Variant ret = const_cast<GDScriptFunction *>(E->get())->call(const_cast<GDScriptInstance *>(this), NULL, 0, err);
+			Variant ret = const_cast<GDScriptFunction *>(E.get())->call(const_cast<GDScriptInstance *>(this), NULL, 0, err);
 			if (err.error == Variant::CallError::CALL_OK) {
 
 				if (ret.get_type() != Variant::ARRAY) {
@@ -1109,12 +1109,12 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 		//instance a fake script for editing the values
 
 		Vector<_GDScriptMemberSort> msort;
-		for (Map<StringName, PropertyInfo>::Element *F = sptr->member_info.front(); F; F = F->next()) {
+		for (OrderedHashMap<StringName, PropertyInfo>::ConstElement F = sptr->member_info.front(); F; F = F.next()) {
 
 			_GDScriptMemberSort ms;
-			ERR_CONTINUE(!sptr->member_indices.has(F->key()));
-			ms.index = sptr->member_indices[F->key()].index;
-			ms.name = F->key();
+			ERR_CONTINUE(!sptr->member_indices.has(F.key()));
+			ms.index = sptr->member_indices[F.key()].index;
+			ms.name = F.key();
 			msort.push_back(ms);
 		}
 
@@ -1139,12 +1139,12 @@ void GDScriptInstance::get_method_list(List<MethodInfo> *p_list) const {
 	const GDScript *sptr = script.ptr();
 	while (sptr) {
 
-		for (Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.front(); E; E = E->next()) {
+		for (OrderedHashMap<StringName, GDScriptFunction *>::ConstElement E = sptr->member_functions.front(); E; E = E.next()) {
 
 			MethodInfo mi;
-			mi.name = E->key();
+			mi.name = E.key();
 			mi.flags |= METHOD_FLAG_FROM_SCRIPT;
-			for (int i = 0; i < E->get()->get_argument_count(); i++)
+			for (int i = 0; i < E.get()->get_argument_count(); i++)
 				mi.arguments.push_back(PropertyInfo(Variant::NIL, "arg" + itos(i)));
 			p_list->push_back(mi);
 		}
@@ -1156,7 +1156,7 @@ bool GDScriptInstance::has_method(const StringName &p_method) const {
 
 	const GDScript *sptr = script.ptr();
 	while (sptr) {
-		const Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.find(p_method);
+		const OrderedHashMap<StringName, GDScriptFunction *>::ConstElement E = sptr->member_functions.find(p_method);
 		if (E)
 			return true;
 		sptr = sptr->_base;
@@ -1170,9 +1170,9 @@ Variant GDScriptInstance::call(const StringName &p_method, const Variant **p_arg
 
 	GDScript *sptr = script.ptr();
 	while (sptr) {
-		Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.find(p_method);
+		OrderedHashMap<StringName, GDScriptFunction *>::Element E = sptr->member_functions.find(p_method);
 		if (E) {
-			return E->get()->call(this, p_args, p_argcount, r_error);
+			return E.get()->call(this, p_args, p_argcount, r_error);
 		}
 		sptr = sptr->_base;
 	}
@@ -1186,9 +1186,9 @@ void GDScriptInstance::call_multilevel(const StringName &p_method, const Variant
 	Variant::CallError ce;
 
 	while (sptr) {
-		Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.find(p_method);
+		OrderedHashMap<StringName, GDScriptFunction *>::Element E = sptr->member_functions.find(p_method);
 		if (E) {
-			E->get()->call(this, p_args, p_argcount, ce);
+			E.get()->call(this, p_args, p_argcount, ce);
 		}
 		sptr = sptr->_base;
 	}
@@ -1201,9 +1201,9 @@ void GDScriptInstance::_ml_call_reversed(GDScript *sptr, const StringName &p_met
 
 	Variant::CallError ce;
 
-	Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.find(p_method);
+	OrderedHashMap<StringName, GDScriptFunction *>::Element E = sptr->member_functions.find(p_method);
 	if (E) {
-		E->get()->call(this, p_args, p_argcount, ce);
+		E.get()->call(this, p_args, p_argcount, ce);
 	}
 }
 
@@ -1222,10 +1222,10 @@ void GDScriptInstance::notification(int p_notification) {
 
 	GDScript *sptr = script.ptr();
 	while (sptr) {
-		Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._notification);
+		OrderedHashMap<StringName, GDScriptFunction *>::Element E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._notification);
 		if (E) {
 			Variant::CallError err;
-			E->get()->call(this, args, 1, err);
+			E.get()->call(this, args, 1, err);
 			if (err.error != Variant::CallError::CALL_OK) {
 				//print error about notification call
 			}
@@ -1249,11 +1249,11 @@ MultiplayerAPI::RPCMode GDScriptInstance::get_rpc_mode(const StringName &p_metho
 	const GDScript *cscript = script.ptr();
 
 	while (cscript) {
-		const Map<StringName, GDScriptFunction *>::Element *E = cscript->member_functions.find(p_method);
+		OrderedHashMap<StringName, GDScriptFunction *>::ConstElement E = cscript->member_functions.find(p_method);
 		if (E) {
 
-			if (E->get()->get_rpc_mode() != MultiplayerAPI::RPC_MODE_DISABLED) {
-				return E->get()->get_rpc_mode();
+			if (E.get()->get_rpc_mode() != MultiplayerAPI::RPC_MODE_DISABLED) {
+				return E.get()->get_rpc_mode();
 			}
 		}
 		cscript = cscript->_base;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -80,11 +80,11 @@ class GDScript : public Script {
 	GDScript *_owner; //for subclasses
 
 	Set<StringName> members; //members are just indices to the instanced script.
-	Map<StringName, Variant> constants;
-	Map<StringName, GDScriptFunction *> member_functions;
+	OrderedHashMap<StringName, Variant> constants;
+	OrderedHashMap<StringName, GDScriptFunction *> member_functions;
 	OrderedHashMap<StringName, MemberInfo> member_indices; //members are just indices to the instanced script.
-	Map<StringName, Ref<GDScript> > subclasses;
-	Map<StringName, Vector<StringName> > _signals;
+	OrderedHashMap<StringName, Ref<GDScript> > subclasses;
+	OrderedHashMap<StringName, Vector<StringName> > _signals;
 
 #ifdef TOOLS_ENABLED
 
@@ -101,7 +101,7 @@ class GDScript : public Script {
 	void _update_exports_values(Map<StringName, Variant> &values, List<PropertyInfo> &propnames);
 
 #endif
-	Map<StringName, PropertyInfo> member_info;
+	OrderedHashMap<StringName, PropertyInfo> member_info;
 
 	GDScriptFunction *initializer; //direct pointer to _init , faster to locate
 
@@ -144,14 +144,14 @@ protected:
 public:
 	virtual bool is_valid() const { return valid; }
 
-	const Map<StringName, Ref<GDScript> > &get_subclasses() const { return subclasses; }
-	const Map<StringName, Variant> &get_constants() const { return constants; }
+	const OrderedHashMap<StringName, Ref<GDScript> > &get_subclasses() const { return subclasses; }
+	const OrderedHashMap<StringName, Variant> &get_constants() const { return constants; }
 	const Set<StringName> &get_members() const { return members; }
 	const GDScriptDataType &get_member_type(const StringName &p_member) const {
 		CRASH_COND(!member_indices.has(p_member));
 		return member_indices[p_member].data_type;
 	}
-	const Map<StringName, GDScriptFunction *> &get_member_functions() const { return member_functions; }
+	const OrderedHashMap<StringName, GDScriptFunction *> &get_member_functions() const { return member_functions; }
 	const Ref<GDScriptNativeClass> &get_native() const { return native; }
 	const String &get_script_class_name() const { return name; }
 
@@ -162,7 +162,7 @@ public:
 	Ref<GDScript> get_base() const;
 
 	const OrderedHashMap<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }
-	const Map<StringName, GDScriptFunction *> &debug_get_member_functions() const; //this is debug only
+	const OrderedHashMap<StringName, GDScriptFunction *> &debug_get_member_functions() const; //this is debug only
 	StringName debug_get_member_by_index(int p_idx) const;
 
 	Variant _new(const Variant **p_args, int p_argcount, Variant::CallError &r_error);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -33,9 +33,9 @@
 
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/ordered_hash_map.h"
 #include "core/script_language.h"
 #include "gdscript_function.h"
-
 class GDScriptNativeClass : public Reference {
 
 	GDCLASS(GDScriptNativeClass, Reference);
@@ -82,7 +82,7 @@ class GDScript : public Script {
 	Set<StringName> members; //members are just indices to the instanced script.
 	Map<StringName, Variant> constants;
 	Map<StringName, GDScriptFunction *> member_functions;
-	Map<StringName, MemberInfo> member_indices; //members are just indices to the instanced script.
+	OrderedHashMap<StringName, MemberInfo> member_indices; //members are just indices to the instanced script.
 	Map<StringName, Ref<GDScript> > subclasses;
 	Map<StringName, Vector<StringName> > _signals;
 
@@ -161,7 +161,7 @@ public:
 	bool is_tool() const { return tool; }
 	Ref<GDScript> get_base() const;
 
-	const Map<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }
+	const OrderedHashMap<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }
 	const Map<StringName, GDScriptFunction *> &debug_get_member_functions() const; //this is debug only
 	StringName debug_get_member_by_index(int p_idx) const;
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -715,19 +715,19 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 						if (on->arguments[0]->type == GDScriptParser::Node::TYPE_SELF && codegen.script && codegen.function_node && !codegen.function_node->_static) {
 
 							GDScriptParser::IdentifierNode *identifier = static_cast<GDScriptParser::IdentifierNode *>(on->arguments[1]);
-							const Map<StringName, GDScript::MemberInfo>::Element *MI = codegen.script->member_indices.find(identifier->name);
+							const OrderedHashMap<StringName, GDScript::MemberInfo>::Element MI = codegen.script->member_indices.find(identifier->name);
 
 #ifdef DEBUG_ENABLED
-							if (MI && MI->get().getter == codegen.function_node->name) {
+							if (MI && MI.get().getter == codegen.function_node->name) {
 								String n = static_cast<GDScriptParser::IdentifierNode *>(on->arguments[1])->name;
 								_set_error("Must use '" + n + "' instead of 'self." + n + "' in getter.", on);
 								return -1;
 							}
 #endif
 
-							if (MI && MI->get().getter == "") {
+							if (MI && MI.get().getter == "") {
 								// Faster than indexing self (as if no self. had been used)
-								return (MI->get().index) | (GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS);
+								return (MI.get().index) | (GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS);
 							}
 						}
 
@@ -957,8 +957,8 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 
 							if (inon->arguments[0]->type == GDScriptParser::Node::TYPE_SELF && codegen.script && codegen.function_node && !codegen.function_node->_static) {
 
-								const Map<StringName, GDScript::MemberInfo>::Element *MI = codegen.script->member_indices.find(static_cast<GDScriptParser::IdentifierNode *>(inon->arguments[1])->name);
-								if (MI && MI->get().setter == codegen.function_node->name) {
+								const OrderedHashMap<StringName, GDScript::MemberInfo>::Element MI = codegen.script->member_indices.find(static_cast<GDScriptParser::IdentifierNode *>(inon->arguments[1])->name);
+								if (MI && MI.get().setter == codegen.function_node->name) {
 									String n = static_cast<GDScriptParser::IdentifierNode *>(inon->arguments[1])->name;
 									_set_error("Must use '" + n + "' instead of 'self." + n + "' in setter.", inon);
 									return -1;
@@ -2111,8 +2111,8 @@ Error GDScriptCompiler::_parse_class_blocks(GDScript *p_script, const GDScriptPa
 					instance->owner = E->get();
 
 					//needed for hot reloading
-					for (Map<StringName, GDScript::MemberInfo>::Element *F = p_script->member_indices.front(); F; F = F->next()) {
-						instance->member_indices_cache[F->key()] = F->get().index;
+					for (OrderedHashMap<StringName, GDScript::MemberInfo>::Element F = p_script->member_indices.front(); F; F = F.next()) {
+						instance->member_indices_cache[F.key()] = F.get().index;
 					}
 					instance->owner->set_script_instance(instance);
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1869,8 +1869,8 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, GDScript *p_owner
 	p_script->_base = NULL;
 	p_script->members.clear();
 	p_script->constants.clear();
-	for (Map<StringName, GDScriptFunction *>::Element *E = p_script->member_functions.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (OrderedHashMap<StringName, GDScriptFunction *>::Element E = p_script->member_functions.front(); E; E = E.next()) {
+		memdelete(E.get());
 	}
 	p_script->member_functions.clear();
 	p_script->member_indices.clear();
@@ -2153,7 +2153,7 @@ Error GDScriptCompiler::_parse_class_blocks(GDScript *p_script, const GDScriptPa
 
 void GDScriptCompiler::_make_scripts(const GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state) {
 
-	Map<StringName, Ref<GDScript> > old_subclasses;
+	OrderedHashMap<StringName, Ref<GDScript> > old_subclasses;
 
 	if (p_keep_state) {
 		old_subclasses = p_script->subclasses;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -316,12 +316,12 @@ void GDScriptLanguage::debug_get_stack_level_members(int p_level, List<String> *
 	Ref<GDScript> script = instance->get_script();
 	ERR_FAIL_COND(script.is_null());
 
-	const Map<StringName, GDScript::MemberInfo> &mi = script->debug_get_member_indices();
+	const OrderedHashMap<StringName, GDScript::MemberInfo> &mi = script->debug_get_member_indices();
 
-	for (const Map<StringName, GDScript::MemberInfo>::Element *E = mi.front(); E; E = E->next()) {
+	for (OrderedHashMap<StringName, GDScript::MemberInfo>::ConstElement E = mi.front(); E; E = E.next()) {
 
-		p_members->push_back(E->key());
-		p_values->push_back(instance->debug_get_member_by_index(E->get().index));
+		p_members->push_back(E.key());
+		p_values->push_back(instance->debug_get_member_by_index(E.get().index));
 	}
 }
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1921,22 +1921,22 @@ static void _find_identifiers_in_base(const GDScriptCompletionContext &p_context
 						}
 					}
 					if (!p_only_functions) {
-						for (const Map<StringName, Variant>::Element *E = script->get_constants().front(); E; E = E->next()) {
-							r_result.insert(E->key().operator String());
+						for (OrderedHashMap<StringName, Variant>::ConstElement E = script->get_constants().front(); E; E = E.next()) {
+							r_result.insert(E.key().operator String());
 						}
 					}
-					for (const Map<StringName, GDScriptFunction *>::Element *E = script->get_member_functions().front(); E; E = E->next()) {
-						if (!_static || E->get()->is_static()) {
-							if (E->get()->get_argument_count()) {
-								r_result.insert(E->key().operator String() + "(");
+					for (OrderedHashMap<StringName, GDScriptFunction *>::ConstElement E = script->get_member_functions().front(); E; E = E.next()) {
+						if (!_static || E.get()->is_static()) {
+							if (E.get()->get_argument_count()) {
+								r_result.insert(E.key().operator String() + "(");
 							} else {
-								r_result.insert(E->key().operator String() + "()");
+								r_result.insert(E.key().operator String() + "()");
 							}
 						}
 					}
 					if (!p_only_functions) {
-						for (const Map<StringName, Ref<GDScript> >::Element *E = script->get_subclasses().front(); E; E = E->next()) {
-							r_result.insert(E->key().operator String());
+						for (OrderedHashMap<StringName, Ref<GDScript> >::ConstElement E = script->get_subclasses().front(); E; E = E.next()) {
+							r_result.insert(E.key().operator String());
 						}
 					}
 					base_type = GDScriptParser::DataType();

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -77,9 +77,9 @@ Variant *GDScriptFunction::_get_variant(int p_address, GDScriptInstance *p_insta
 				GDScript *s = o;
 				while (s) {
 
-					Map<StringName, Variant>::Element *E = s->constants.find(*sn);
+					OrderedHashMap<StringName, Variant>::Element E = s->constants.find(*sn);
 					if (E) {
-						return &E->get();
+						return &E.get();
 					}
 					s = s->_base;
 				}
@@ -1189,7 +1189,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				const GDScript *gds = _script;
 
-				const Map<StringName, GDScriptFunction *>::Element *E = NULL;
+				OrderedHashMap<StringName, GDScriptFunction *>::ConstElement E;
 				while (gds->base.ptr()) {
 					gds = gds->base.ptr();
 					E = gds->member_functions.find(*methodname);
@@ -1201,7 +1201,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				if (E) {
 
-					*dst = E->get()->call(p_instance, (const Variant **)argptrs, argc, err);
+					*dst = E.get()->call(p_instance, (const Variant **)argptrs, argc, err);
 				} else if (gds->native.ptr()) {
 
 					if (*methodname != GDScriptLanguage::get_singleton()->strings._init) {

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1158,9 +1158,9 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 			GDScriptInstance *ins = static_cast<GDScriptInstance *>(static_cast<Object *>(r_ret)->get_script_instance());
 			Ref<GDScript> gd_ref = ins->get_script();
 
-			for (Map<StringName, GDScript::MemberInfo>::Element *E = gd_ref->member_indices.front(); E; E = E->next()) {
-				if (d.has(E->key())) {
-					ins->members.write[E->get().index] = d[E->key()];
+			for (OrderedHashMap<StringName, GDScript::MemberInfo>::Element E = gd_ref->member_indices.front(); E; E = E.next()) {
+				if (d.has(E.key())) {
+					ins->members.write[E.get().index] = d[E.key()];
 				}
 			}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -6572,7 +6572,7 @@ bool GDScriptParser::_get_function_signature(DataType &p_base_type, const String
 	while (base_gdscript.is_valid()) {
 		native = base_gdscript->get_instance_base_type();
 
-		Map<StringName, GDScriptFunction *> funcs = base_gdscript->get_member_functions();
+		OrderedHashMap<StringName, GDScriptFunction *> funcs = base_gdscript->get_member_functions();
 
 		if (funcs.has(p_function)) {
 			GDScriptFunction *f = funcs[p_function];


### PR DESCRIPTION
Changed internal storage for
constants, member_functions, subclasses, member_indices, _signals from Map O (log n) to OrderedHashMap -> O(1) and also changed the default HashMap and OrderedHashMap RELATIONSHIP from 8 to 1 to reduce collisions.

My tests show an improvement of more than 10% in speed execution for a script that makes heavy use of external class variables (when that external class has 30 variables).

You will see no improvement if you test with classes that have few variables or a few functions and you test the speed referencing those but the difference in speed should increase for more complex classes.

Pull request is against 3.1 so tests can be done against the stable version but I don't think there is a problem to be ported to mainline.