### PR TITLE
Animation Bezier Editor : fix double inserts on undo

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -929,13 +929,6 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, 1);
 			}
 
-			// 6-(undo) reinsert overlapped keys
-			for (List<AnimMoveRestore>::Element *E = to_restore.front(); E; E = E->next()) {
-
-				AnimMoveRestore &amr = E->get();
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, 1);
-			}
-
 			undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
 			undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
 


### PR DESCRIPTION
Removed duplicate step on undo that reinserts the same keys again.