### PR TITLE
Make editor inspector easing lines use the accent color when dragged

### DIFF
--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -311,6 +311,7 @@ class EditorPropertyEasing : public EditorProperty {
 	EditorSpinSlider *spin;
 	bool setting;
 
+	bool dragging;
 	bool full;
 	bool flip;
 


### PR DESCRIPTION
This makes their visual feedback more consistent with other controls.

This also makes easing lines slightly more subtle by decreasing their opacity by 10%.