### PR TITLE
Optimised vector and quaternion normalisations adding fast inverse square root

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -43,14 +43,14 @@ void Basis::from_z(const Vector3 &p_z) {
 
 		// choose p in y-z plane
 		real_t a = p_z[1] * p_z[1] + p_z[2] * p_z[2];
-		real_t k = 1.0 / Math::sqrt(a);
+		real_t k = Math::fast_inv_sqrt(a);
 		elements[0] = Vector3(0, -p_z[2] * k, p_z[1] * k);
 		elements[1] = Vector3(a * k, -p_z[0] * elements[0][2], p_z[0] * elements[0][1]);
 	} else {
 
 		// choose p in x-y plane
 		real_t a = p_z.x * p_z.x + p_z.y * p_z.y;
-		real_t k = 1.0 / Math::sqrt(a);
+		real_t k = Math::fast_inv_sqrt(a);
 		elements[0] = Vector3(-p_z.y * k, p_z.x * k, 0);
 		elements[1] = Vector3(-p_z.z * elements[0].y, p_z.z * elements[0].x, a * k);
 	}

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -39,6 +39,7 @@
 
 #include <float.h>
 #include <math.h>
+#include <string.h>
 
 class Math {
 
@@ -487,10 +488,13 @@ public:
 
 	// fast inverse square root, see https://en.wikipedia.org/wiki/Fast_inverse_square_root
 	static _ALWAYS_INLINE_ float fast_inv_sqrt(float x) {
-		int i = *(int *)&x;
+
+		float x2 = x * 0.5F, y = x;
+		int i;
+		memcpy(&i, &y, sizeof(float));
 		i = 0x5f3759df - (i >> 1);
-		float y = *(float *)&i;
-		return y * (1.5F - 0.5F * x * y * y);
+		memcpy(&y, &i, sizeof(float));
+		return y * (1.5F - (x2 * y * y));
 	}
 };
 

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -484,6 +484,14 @@ public:
 		}
 		return p_target;
 	}
+
+	// fast inverse square root, see https://en.wikipedia.org/wiki/Fast_inverse_square_root
+	static _ALWAYS_INLINE_ float fast_inv_sqrt(float x) {
+		int i = *(int *)&x;
+		i = 0x5f3759df - (i >> 1);
+		float y = *(float *)&i;
+		return y * (1.5F - 0.5F * x * y * y);
+	}
 };
 
 #endif // MATH_FUNCS_H

--- a/core/math/quat.cpp
+++ b/core/math/quat.cpp
@@ -127,7 +127,7 @@ real_t Quat::length() const {
 }
 
 void Quat::normalize() {
-	*this /= length();
+	*this *= Math::fast_inv_sqrt(length_squared());
 }
 
 Quat Quat::normalized() const {

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -50,9 +50,9 @@ void Vector2::normalize() {
 	real_t l = x * x + y * y;
 	if (l != 0) {
 
-		l = Math::sqrt(l);
-		x /= l;
-		y /= l;
+		l = Math::fast_inv_sqrt(l);
+		x *= l;
+		y *= l;
 	}
 }
 

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -437,10 +437,10 @@ void Vector3::normalize() {
 	if (lengthsq == 0) {
 		x = y = z = 0;
 	} else {
-		real_t length = Math::sqrt(lengthsq);
-		x /= length;
-		y /= length;
-		z /= length;
+		real_t inv_length = Math::fast_inv_sqrt(lengthsq);
+		x *= inv_length;
+		y *= inv_length;
+		z *= inv_length;
 	}
 }
 


### PR DESCRIPTION
I've added Math::fast_inv_sqrt that computes 1/sqrt(x) almost 5 times faster and modified the Vector2, Vector3 and Quat classes to make use of it for normalization. Normalizations should be now A LOT faster.
See https://en.wikipedia.org/wiki/Fast_inverse_square_root
