### PR TITLE
Improve Ctrl snapping in EditorSpinSlider

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -109,13 +109,8 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			if (grabbing_spinner) {
-				if (mm->get_control() || updown_offset != -1) {
-					set_value(Math::round(get_value()));
-					if (ABS(grabbing_spinner_dist_cache) > 6) {
-						set_value(get_value() + SGN(grabbing_spinner_dist_cache));
-						grabbing_spinner_dist_cache = 0;
-						pre_grab_value = get_value();
-					}
+				if (mm->get_control()) {
+					set_value(Math::round(pre_grab_value + get_step() * grabbing_spinner_dist_cache * 10));
 				} else {
 					set_value(pre_grab_value + get_step() * grabbing_spinner_dist_cache * 10);
 				}


### PR DESCRIPTION
- Remove FPS dependency by using a simpler implementation that just rounds the final number

The previous implementation could only increase the value as fast as the editor rendered, which made it difficult to use when adjusting large values. This is caused by input elements being accumulated.

- Make it possible to combine <kbd>Ctrl</kbd> and <kbd>Shift</kbd> together for slow, precise snapping

___

There might have been a reason as to why the old implementation was more complex. Please test for regressions :smiley: