### PR TITLE
Enable script class resource exports.

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -249,7 +249,16 @@ StringName ScriptServer::get_global_class_native_base(const String &p_class) {
 	}
 	return base;
 }
-
+StringName ScriptServer::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) {
+	for (int i = 0; i < get_language_count(); i++) {
+		ScriptLanguage *lang = get_language(i);
+		StringName class_name = lang->get_global_class_name(p_path, r_base_type, r_icon_path);
+		if (class_name != StringName()) {
+			return class_name;
+		}
+	}
+	return StringName();
+}
 void ScriptServer::get_global_class_list(List<StringName> *r_global_classes) {
 	const StringName *K = nullptr;
 	List<StringName> classes;

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -99,6 +99,7 @@ public:
 	static String get_global_class_path(const String &p_class);
 	static StringName get_global_class_base(const String &p_class);
 	static StringName get_global_class_native_base(const String &p_class);
+	static StringName get_global_class_name(const String &p_path, String *r_base = NULL, String *r_icon_path = NULL);
 	static void get_global_class_list(List<StringName> *r_global_classes);
 	static void save_global_classes();
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -834,6 +834,14 @@ void EditorData::get_plugin_window_layout(Ref<ConfigFile> p_layout) {
 	}
 }
 
+bool EditorData::class_equals_or_inherits(const String &p_class, const String &p_inherits) {
+	if (p_class == p_inherits)
+		return true;
+	if (ScriptServer::is_global_class(p_class))
+		return script_class_is_parent(p_class, p_inherits);
+	return ClassDB::is_parent_class(p_class, p_inherits);
+}
+
 bool EditorData::script_class_is_parent(const String &p_class, const String &p_inherits) {
 	if (!ScriptServer::is_global_class(p_class)) {
 		return false;

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -208,6 +208,7 @@ public:
 	void notify_edited_scene_changed();
 	void notify_resource_saved(const Ref<Resource> &p_resource);
 
+	bool class_equals_or_inherits(const String &p_class, const String &p_inherits);
 	bool script_class_is_parent(const String &p_class, const String &p_inherits);
 	StringName script_class_get_base(const String &p_class) const;
 	Object *script_class_instance(const String &p_class);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2287,16 +2287,16 @@ void EditorPropertyResource::_file_selected(const String &p_path) {
 	if (!property_types.empty()) {
 		bool any_type_matches = false;
 		const Vector<String> split_property_types = property_types.split(",");
+		String res_class = _get_file_script_name_or_default(res);
 		for (int i = 0; i < split_property_types.size(); ++i) {
-			if (res->is_class(split_property_types[i])) {
+			if (EditorNode::get_editor_data().class_equals_or_inherits(res_class, split_property_types[i])) {
 				any_type_matches = true;
 				break;
 			}
 		}
 
-		if (!any_type_matches) {
-			EditorNode::get_singleton()->show_warning(vformat(TTR("The selected resource (%s) does not match any type expected for this property (%s)."), res->get_class(), property_types));
-		}
+		if (!any_type_matches)
+			EditorNode::get_singleton()->show_warning(vformat(TTR("The selected resource (%s) does not match any type expected for this property (%s)."), res_class, property_types));
 	}
 
 	emit_changed(get_edited_property(), res);
@@ -2314,6 +2314,9 @@ void EditorPropertyResource::_menu_option(int p_which) {
 			}
 			file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 			String type = base_type;
+			if (ScriptServer::is_global_class(type)) {
+				type = ScriptServer::get_global_class_native_base(type);
+			}
 
 			List<String> extensions;
 			for (int i = 0; i < type.get_slice_count(","); i++) {
@@ -2839,7 +2842,7 @@ void EditorPropertyResource::update_property() {
 			assign->set_text(res->get_path().get_file());
 			assign->set_tooltip(res->get_path());
 		} else {
-			assign->set_text(res->get_class());
+			assign->set_text(_get_file_script_name_or_default(res));
 		}
 
 		if (res->get_path().is_resource_file()) {
@@ -2962,9 +2965,12 @@ bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const
 			String ftype = EditorFileSystem::get_singleton()->get_file_type(file);
 
 			if (ftype != "") {
+				RES res = ResourceLoader::load(file);
+				ftype = _get_file_script_name_or_default(res);
+
 				for (int i = 0; i < allowed_type.get_slice_count(","); i++) {
 					String at = allowed_type.get_slice(",", i).strip_edges();
-					if (ClassDB::is_parent_class(ftype, at)) {
+					if (EditorNode::get_editor_data().class_equals_or_inherits(ftype, at)) {
 						return true;
 					}
 				}
@@ -3009,6 +3015,20 @@ void EditorPropertyResource::drop_data_fw(const Point2 &p_point, const Variant &
 
 void EditorPropertyResource::set_use_sub_inspector(bool p_enable) {
 	use_sub_inspector = p_enable;
+}
+
+String EditorPropertyResource::_get_file_script_name_or_default(const RES &p_resource) const {
+	Ref<Script> rscript = p_resource->get_script();
+	if (rscript.is_valid()) {
+		String rscript_path = rscript->get_path();
+		int script_index;
+		EditorFileSystemDirectory *fsdir = EditorFileSystem::get_singleton()->find_file(rscript_path, &script_index);
+		ERR_FAIL_COND_V(!fsdir, p_resource->get_class());
+		String file_script_name = fsdir->get_file_script_class_name(script_index);
+		if (!file_script_name.empty())
+			return file_script_name;
+	}
+	return p_resource->get_class();
 }
 
 void EditorPropertyResource::_bind_methods() {
@@ -3536,7 +3556,8 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 					String type = open_in_new.get_slicec(',', i).strip_edges();
 					for (int j = 0; j < p_hint_text.get_slice_count(","); j++) {
 						String inherits = p_hint_text.get_slicec(',', j);
-						if (ClassDB::is_parent_class(inherits, type)) {
+
+						if (!ScriptServer::is_global_class(inherits) && ClassDB::is_parent_class(inherits, type)) {
 							editor->set_use_sub_inspector(false);
 						}
 					}

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -647,6 +647,8 @@ class EditorPropertyResource : public EditorProperty {
 	void _open_editor_pressed();
 	void _fold_other_editors(Object *p_self);
 
+	String _get_file_script_name_or_default(const RES &p_resource) const;
+
 	bool opened_editor;
 
 protected:


### PR DESCRIPTION
Closes godotengine/godot-proposals#18 for GDScript. To add support for custom resource exports in other languages, all you would have to do is add script class support to those languages (godotengine/godot-proposals#22) and program their export code to correctly set the `class_name` and `hint_string` values for the PropertyInfo object.

**Credits:**

Much of this work derives from @vixelz's efforts from #26162, so some credit is due there. 

**Changes:**

I have fixed some of the concerns addressed by those who commented on that PR, namely...

- regular export hints getting messed up in the process (fixed, screenshot demonstration below)
- it operating from scanning an identifier rather than reducing a constant (it now reduces a constant and iterates through languages to check if any of them can find a script class name for the script).

**Caveats:**

As for using preloaded constants, I have decided to forego any implementation on purpose since...

1. Preloaded constants only have a name within the scope of the actual script they reside in. When the editor views the name, there is no globally recognizable location in which it can pull the name and convert it into a script instance to test if the assigned resource instance is type-constrained properly.
2. Non-integer constants are not a concept within the Object API so they cannot be language-agnostically accessed from editor code even if it *did* know the name of the constant. This point is pretty ironic too since most scripting languages implement their own support for read-only StringName->Variant maps to enable the use of constants anyway. Maybe if that feature became part of the Object API, we would be able to add better support for this as it would be "just another place to check" when examining where a valid inheritor comes from.

**Screenshots:**

Here are some images of the PR in action. It demonstrates...

1. Various export hints combined with type hints all working together.
1. Using a MyResource export hint and assigning to it a DerivedMyResource instance.
1. The resource dropdown displays the list of types that correctly extend the custom resource script class.
1. What it looks like when you preload a constant and attempt to export it (you get an error).

<img width="936" alt="example_node_script" src="https://user-images.githubusercontent.com/16217563/64453078-5f66c100-d0ad-11e9-8685-cd569350f7b8.png">

<img width="820" alt="example_export_derived_in_dropdown" src="https://user-images.githubusercontent.com/16217563/64453158-8c1ad880-d0ad-11e9-80f3-6a141cbdce22.png">

<img width="936" alt="bad_script_class_export" src="https://user-images.githubusercontent.com/16217563/64453164-8f15c900-d0ad-11e9-8425-d44fe91f78cb.png">

Edit: Fixed a bug where the custom resource icons were not displaying in the Inspector. The screenshots are outdated in this respect, so keep in mind that class icons will appear in the resource dropdown menu.