### PR TITLE
Mono: Fix PCK assembly paths when exporting from Windows

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpExport.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpExport.cs
@@ -16,7 +16,7 @@ namespace GodotTools
     {
         private void AddFile(string srcPath, string dstPath, bool remap = false)
         {
-            AddFile(dstPath, File.ReadAllBytes(srcPath), remap);
+            AddFile(dstPath.Replace("\\", "/"), File.ReadAllBytes(srcPath), remap);
         }
 
         public override void _ExportFile(string path, string type, string[] features)


### PR DESCRIPTION
Assembly paths were written to PCK files with backslash as path separator and PackedData only supports forward slash.
This would make exported games unable to find the assemblies.

Fixes #31869 and fixes #31581.
