### PR TITLE
Implemented get_path() & get_path_absolute() for FileAccessEncrypted

### DIFF
--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -176,6 +176,22 @@ bool FileAccessEncrypted::is_open() const {
 	return file != NULL;
 }
 
+String FileAccessEncrypted::get_path() const {
+
+	if (file)
+		return file->get_path();
+	else
+		return "";
+}
+
+String FileAccessEncrypted::get_path_absolute() const {
+
+	if (file)
+		return file->get_path_absolute();
+	else
+		return "";
+}
+
 void FileAccessEncrypted::seek(size_t p_position) {
 
 	if (p_position > (size_t)data.size())

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -60,6 +60,9 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
+	virtual String get_path() const; /// returns the path for the current open file
+	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
+
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
 	virtual size_t get_position() const; ///< get position in the file


### PR DESCRIPTION
This change makes encrypted files retrieve the path from their internal file, instead of returning a blank string.

Example script usage:
```
var f = File.new()
var err = f.open_encrypted_with_pass("user://savedata.bin", File.WRITE, OS.get_unique_id())
print("saving data file '%s'" % f.get_path_absolute())
f.store_var(game_state)
f.close()
```