### PR TITLE
Fix scrollwheel triggering focus change

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1742,6 +1742,12 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 							return; // no one gets the event if exclusive NO ONE
 						}
 
+						if (mb->get_button_index() == BUTTON_WHEEL_UP || mb->get_button_index() == BUTTON_WHEEL_DOWN || mb->get_button_index() == BUTTON_WHEEL_LEFT || mb->get_button_index() == BUTTON_WHEEL_RIGHT) {
+							//cancel scroll wheel events, only clicks should trigger focus changes.
+							set_input_as_handled();
+							return;
+						}
+
 						top->notification(Control::NOTIFICATION_MODAL_CLOSE);
 						top->_modal_stack_remove();
 						top->hide();


### PR DESCRIPTION
Clicking or using the scrollwheel outside of the focused control triggers a focus change. This makes sense for mouse clicks, but scrollwheeling outside the focused control does not. This PR ignores scrollwheeling outside of the focused control.

Closes: #6453