### PR TITLE
Fix Remote Tree Navigate to Inspected

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -434,6 +434,15 @@ int ScriptEditorDebugger::_update_scene_tree(TreeItem *parent, const Array &node
 	}
 	item->set_metadata(0, id);
 
+	if (id == inspected_object_id) {
+		TreeItem *cti = item->get_parent();
+		while (cti) {
+			cti->set_collapsed(false);
+			cti = cti->get_parent();
+		}
+		item->select(0);
+	}
+
 	// Set current item as collapsed if necessary
 	if (parent) {
 		if (!unfold_cache.has(id)) {


### PR DESCRIPTION
Fixes the regression of remote tree not navigating to what is being inspected in the inspector. Also fixes regression of losing selection in the remote tree.

Closes: #31929