### PR TITLE
Optimized variant reference function.

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -910,7 +910,15 @@ bool Variant::is_one() const {
 
 void Variant::reference(const Variant &p_variant) {
 
-	clear();
+	switch (type) {
+		case NIL:
+		case BOOL:
+		case INT:
+		case REAL:
+			break;
+		default:
+			clear();
+	}
 
 	type = p_variant.type;
 


### PR DESCRIPTION
Optimized critical execution path in Variant::reference by removing expensive and unnecessary call to clear() for atomic types.
Profiling shows that this function is executed at least for each variable assignment which can mean a lot in complex scripts that have lots of iterations (mine reached 98.7 millions calls to Variant::reference) .
Using this simple optimization my test script running time dropped consistently from 56 seconds to 51 seconds.

![Screenshot_2019-09-09_10-55-27](https://user-images.githubusercontent.com/38382/64521708-67627300-d2f0-11e9-8c11-16023b12113b.png)
