### PR TITLE
Changed some code found by Clang Tidy and Coverity

### DIFF
--- a/core/crypto/hashing_context.cpp
+++ b/core/crypto/hashing_context.cpp
@@ -103,7 +103,7 @@ void HashingContext::_create_ctx(HashType p_type) {
 }
 
 void HashingContext::_delete_ctx() {
-	return;
+
 	switch (type) {
 		case HASH_MD5:
 			memdelete((CryptoCore::MD5Context *)ctx);

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -194,7 +194,7 @@ bool ZipArchive::try_open_pack(const String &p_path) {
 	packages.push_back(pkg);
 	int pkg_num = packages.size() - 1;
 
-	for (unsigned int i = 0; i < gi.number_entry; i++) {
+	for (uint64_t i = 0; i < gi.number_entry; i++) {
 
 		char filename_inzip[256];
 

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -715,7 +715,7 @@ Vector<Vector<Vector2> > Geometry::decompose_polygon_in_convex(Vector<Point2> po
 
 		decomp.write[idx].resize(tp.GetNumPoints());
 
-		for (int i = 0; i < tp.GetNumPoints(); i++) {
+		for (int64_t i = 0; i < tp.GetNumPoints(); i++) {
 			decomp.write[idx].write[i] = tp.GetPoint(i);
 		}
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2147,13 +2147,13 @@ int64_t String::to_int(const CharType *p_str, int p_len) {
 
 				if (c >= '0' && c <= '9') {
 
-					if (integer > INT32_MAX / 10) {
+					if (integer > INT64_MAX / 10) {
 						String number("");
 						str = p_str;
 						while (*str && str != limit) {
 							number += *(str++);
 						}
-						ERR_FAIL_V_MSG(sign == 1 ? INT32_MAX : INT32_MIN, "Cannot represent " + number + " as integer, provided value is " + (sign == 1 ? "too big." : "too small."));
+						ERR_FAIL_V_MSG(sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + number + " as integer, provided value is " + (sign == 1 ? "too big." : "too small."));
 					}
 					integer *= 10;
 					integer += c - '0';

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1522,7 +1522,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 					return err;
 				if (tk.type != TK_STRING) {
 					r_err_str = "Error reading quoted string";
-					return err;
+					return ERR_INVALID_DATA;
 				}
 
 				what = tk.value;

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -171,14 +171,14 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 		ad->start_counting_ticks();
 
 		if (!ad->active) {
-			for (unsigned int i = 0; i < ad->period_size * ad->channels; i++) {
+			for (uint64_t i = 0; i < ad->period_size * ad->channels; i++) {
 				ad->samples_out.write[i] = 0;
 			}
 
 		} else {
 			ad->audio_server_process(ad->period_size, ad->samples_in.ptrw());
 
-			for (unsigned int i = 0; i < ad->period_size * ad->channels; i++) {
+			for (uint64_t i = 0; i < ad->period_size * ad->channels; i++) {
 				ad->samples_out.write[i] = ad->samples_in[i] >> 16;
 			}
 		}

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1439,7 +1439,7 @@ Size2 EditorAudioMeterNotches::get_minimum_size() const {
 	float width = 0;
 	float height = top_padding + btm_padding;
 
-	for (uint8_t i = 0; i < notches.size(); i++) {
+	for (int i = 0; i < notches.size(); i++) {
 		if (notches[i].render_db_value) {
 			width = MAX(width, font->get_string_size(String::num(Math::abs(notches[i].db_value)) + "dB").x);
 			height += font_height;
@@ -1473,7 +1473,7 @@ void EditorAudioMeterNotches::_draw_audio_notches() {
 	Ref<Font> font = get_font("font", "Label");
 	float font_height = font->get_height();
 
-	for (uint8_t i = 0; i < notches.size(); i++) {
+	for (int i = 0; i < notches.size(); i++) {
 		AudioNotch n = notches[i];
 		draw_line(Vector2(0, (1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + top_padding),
 				Vector2(line_length, (1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + top_padding),

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -78,18 +78,12 @@ Dictionary EditorVCSInterface::_get_modified_files_data() {
 }
 
 void EditorVCSInterface::_stage_file(String p_file_path) {
-
-	return;
 }
 
 void EditorVCSInterface::_unstage_file(String p_file_path) {
-
-	return;
 }
 
 void EditorVCSInterface::_commit(String p_msg) {
-
-	return;
 }
 
 Array EditorVCSInterface::_get_file_diff(String p_file_path) {
@@ -134,7 +128,6 @@ void EditorVCSInterface::stage_file(String p_file_path) {
 
 		call("_stage_file", p_file_path);
 	}
-	return;
 }
 
 void EditorVCSInterface::unstage_file(String p_file_path) {
@@ -143,7 +136,6 @@ void EditorVCSInterface::unstage_file(String p_file_path) {
 
 		call("_unstage_file", p_file_path);
 	}
-	return;
 }
 
 bool EditorVCSInterface::is_addon_ready() {
@@ -157,7 +149,6 @@ void EditorVCSInterface::commit(String p_msg) {
 
 		call("_commit", p_msg);
 	}
-	return;
 }
 
 Array EditorVCSInterface::get_file_diff(String p_file_path) {

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1178,7 +1178,7 @@ void ResourceImporterScene::get_import_options(List<ImportOption> *r_options, in
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/import", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "animation/fps", PROPERTY_HINT_RANGE, "1,120,1"), 15));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "animation/filter_script", PROPERTY_HINT_MULTILINE_TEXT), ""));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "animation/storage", PROPERTY_HINT_ENUM, "Built-In,Files (.anim),Files (.tres)"), animations_out ? true : false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "animation/storage", PROPERTY_HINT_ENUM, "Built-In,Files (.anim),Files (.tres)"), animations_out));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/keep_custom_tracks"), animations_out));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/optimizer/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "animation/optimizer/max_linear_error"), 0.05));

--- a/editor/plugins/sprite_editor_plugin.cpp
+++ b/editor/plugins/sprite_editor_plugin.cpp
@@ -102,7 +102,7 @@ Vector<Vector2> expand(const Vector<Vector2> &points, const Rect2i &rect, float 
 
 	int lasti = p2->Contour.size() - 1;
 	Vector2 prev = Vector2(p2->Contour[lasti].X / PRECISION, p2->Contour[lasti].Y / PRECISION);
-	for (unsigned int i = 0; i < p2->Contour.size(); i++) {
+	for (uint64_t i = 0; i < p2->Contour.size(); i++) {
 
 		Vector2 cur = Vector2(p2->Contour[i].X / PRECISION, p2->Contour[i].Y / PRECISION);
 		if (cur.distance_to(prev) > 0.5) {

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -1280,7 +1280,6 @@ void EditorSceneImporterAssimp::create_bone(ImportState &state, RecursiveState &
 	// this transform is a bone
 	recursive_state.skeleton->add_bone(recursive_state.node_name);
 
-	ERR_FAIL_COND(recursive_state.skeleton == NULL); // serious bug we must now exit.
 	//ERR_FAIL_COND(recursive_state.skeleton->get_name() == "");
 	print_verbose("Bone added to lookup: " + AssimpUtils::get_assimp_string(recursive_state.bone->mName));
 	print_verbose("Skeleton attached to: " + recursive_state.skeleton->get_name());

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -63,139 +63,137 @@ Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 
 			ERR_FAIL_V(ERR_UNAVAILABLE);
 		}
-		if (err == OK) {
 
-			// Image data (might be indexed)
-			PoolVector<uint8_t> data;
-			int data_len = 0;
+		// Image data (might be indexed)
+		PoolVector<uint8_t> data;
+		int data_len = 0;
 
-			if (bits_per_pixel <= 8) { // indexed
-				data_len = width * height;
-			} else { // color
-				data_len = width * height * 4;
-			}
-			ERR_FAIL_COND_V(data_len == 0, ERR_BUG);
-			err = data.resize(data_len);
+		if (bits_per_pixel <= 8) { // indexed
+			data_len = width * height;
+		} else { // color
+			data_len = width * height * 4;
+		}
+		ERR_FAIL_COND_V(data_len == 0, ERR_BUG);
+		err = data.resize(data_len);
 
-			PoolVector<uint8_t>::Write data_w = data.write();
-			uint8_t *write_buffer = data_w.ptr();
+		PoolVector<uint8_t>::Write data_w = data.write();
+		uint8_t *write_buffer = data_w.ptr();
 
-			const uint32_t width_bytes = width * bits_per_pixel / 8;
-			const uint32_t line_width = (width_bytes + 3) & ~3;
+		const uint32_t width_bytes = width * bits_per_pixel / 8;
+		const uint32_t line_width = (width_bytes + 3) & ~3;
 
-			// The actual data traversal is determined by
-			// the data width in case of 8/4/1 bit images
-			const uint32_t w = bits_per_pixel >= 24 ? width : width_bytes;
-			const uint8_t *line = p_buffer + (line_width * (height - 1));
+		// The actual data traversal is determined by
+		// the data width in case of 8/4/1 bit images
+		const uint32_t w = bits_per_pixel >= 24 ? width : width_bytes;
+		const uint8_t *line = p_buffer + (line_width * (height - 1));
 
-			for (unsigned int i = 0; i < height; i++) {
-				const uint8_t *line_ptr = line;
+		for (uint64_t i = 0; i < height; i++) {
+			const uint8_t *line_ptr = line;
 
-				for (unsigned int j = 0; j < w; j++) {
-					switch (bits_per_pixel) {
-						case 1: {
-							uint8_t color_index = *line_ptr;
+			for (unsigned int j = 0; j < w; j++) {
+				switch (bits_per_pixel) {
+					case 1: {
+						uint8_t color_index = *line_ptr;
 
-							write_buffer[index + 0] = (color_index >> 7) & 1;
-							write_buffer[index + 1] = (color_index >> 6) & 1;
-							write_buffer[index + 2] = (color_index >> 5) & 1;
-							write_buffer[index + 3] = (color_index >> 4) & 1;
-							write_buffer[index + 4] = (color_index >> 3) & 1;
-							write_buffer[index + 5] = (color_index >> 2) & 1;
-							write_buffer[index + 6] = (color_index >> 1) & 1;
-							write_buffer[index + 7] = (color_index >> 0) & 1;
+						write_buffer[index + 0] = (color_index >> 7) & 1;
+						write_buffer[index + 1] = (color_index >> 6) & 1;
+						write_buffer[index + 2] = (color_index >> 5) & 1;
+						write_buffer[index + 3] = (color_index >> 4) & 1;
+						write_buffer[index + 4] = (color_index >> 3) & 1;
+						write_buffer[index + 5] = (color_index >> 2) & 1;
+						write_buffer[index + 6] = (color_index >> 1) & 1;
+						write_buffer[index + 7] = (color_index >> 0) & 1;
 
-							index += 8;
-							line_ptr += 1;
-						} break;
-						case 4: {
-							uint8_t color_index = *line_ptr;
+						index += 8;
+						line_ptr += 1;
+					} break;
+					case 4: {
+						uint8_t color_index = *line_ptr;
 
-							write_buffer[index + 0] = (color_index >> 4) & 0x0f;
-							write_buffer[index + 1] = color_index & 0x0f;
+						write_buffer[index + 0] = (color_index >> 4) & 0x0f;
+						write_buffer[index + 1] = color_index & 0x0f;
 
-							index += 2;
-							line_ptr += 1;
-						} break;
-						case 8: {
-							uint8_t color_index = *line_ptr;
+						index += 2;
+						line_ptr += 1;
+					} break;
+					case 8: {
+						uint8_t color_index = *line_ptr;
 
-							write_buffer[index] = color_index;
+						write_buffer[index] = color_index;
 
-							index += 1;
-							line_ptr += 1;
-						} break;
-						case 24: {
-							uint32_t color = *((uint32_t *)line_ptr);
+						index += 1;
+						line_ptr += 1;
+					} break;
+					case 24: {
+						uint32_t color = *((uint32_t *)line_ptr);
 
-							write_buffer[index + 2] = color & 0xff;
-							write_buffer[index + 1] = (color >> 8) & 0xff;
-							write_buffer[index + 0] = (color >> 16) & 0xff;
-							write_buffer[index + 3] = 0xff;
+						write_buffer[index + 2] = color & 0xff;
+						write_buffer[index + 1] = (color >> 8) & 0xff;
+						write_buffer[index + 0] = (color >> 16) & 0xff;
+						write_buffer[index + 3] = 0xff;
 
-							index += 4;
-							line_ptr += 3;
-						} break;
-						case 32: {
-							uint32_t color = *((uint32_t *)line_ptr);
+						index += 4;
+						line_ptr += 3;
+					} break;
+					case 32: {
+						uint32_t color = *((uint32_t *)line_ptr);
 
-							write_buffer[index + 2] = color & 0xff;
-							write_buffer[index + 1] = (color >> 8) & 0xff;
-							write_buffer[index + 0] = (color >> 16) & 0xff;
-							write_buffer[index + 3] = color >> 24;
+						write_buffer[index + 2] = color & 0xff;
+						write_buffer[index + 1] = (color >> 8) & 0xff;
+						write_buffer[index + 0] = (color >> 16) & 0xff;
+						write_buffer[index + 3] = color >> 24;
 
-							index += 4;
-							line_ptr += 4;
-						} break;
-					}
+						index += 4;
+						line_ptr += 4;
+					} break;
 				}
-				line -= line_width;
 			}
+			line -= line_width;
+		}
 
-			if (p_color_buffer == NULL || color_table_size == 0) { // regular pixels
+		if (p_color_buffer == NULL || color_table_size == 0) { // regular pixels
 
-				p_image->create(width, height, 0, Image::FORMAT_RGBA8, data);
+			p_image->create(width, height, 0, Image::FORMAT_RGBA8, data);
 
-			} else { // data is in indexed format, extend it
+		} else { // data is in indexed format, extend it
 
-				// Palette data
-				PoolVector<uint8_t> palette_data;
-				palette_data.resize(color_table_size * 4);
+			// Palette data
+			PoolVector<uint8_t> palette_data;
+			palette_data.resize(color_table_size * 4);
 
-				PoolVector<uint8_t>::Write palette_data_w = palette_data.write();
-				uint8_t *pal = palette_data_w.ptr();
+			PoolVector<uint8_t>::Write palette_data_w = palette_data.write();
+			uint8_t *pal = palette_data_w.ptr();
 
-				const uint8_t *cb = p_color_buffer;
+			const uint8_t *cb = p_color_buffer;
 
-				for (unsigned int i = 0; i < color_table_size; ++i) {
-					uint32_t color = *((uint32_t *)cb);
+			for (unsigned int i = 0; i < color_table_size; ++i) {
+				uint32_t color = *((uint32_t *)cb);
 
-					pal[i * 4 + 0] = (color >> 16) & 0xff;
-					pal[i * 4 + 1] = (color >> 8) & 0xff;
-					pal[i * 4 + 2] = (color)&0xff;
-					pal[i * 4 + 3] = 0xff;
+				pal[i * 4 + 0] = (color >> 16) & 0xff;
+				pal[i * 4 + 1] = (color >> 8) & 0xff;
+				pal[i * 4 + 2] = (color)&0xff;
+				pal[i * 4 + 3] = 0xff;
 
-					cb += 4;
-				}
-				// Extend palette to image
-				PoolVector<uint8_t> extended_data;
-				extended_data.resize(data.size() * 4);
-
-				PoolVector<uint8_t>::Write ex_w = extended_data.write();
-				uint8_t *dest = ex_w.ptr();
-
-				const int num_pixels = width * height;
-
-				for (int i = 0; i < num_pixels; i++) {
-					dest[0] = pal[write_buffer[i] * 4 + 0];
-					dest[1] = pal[write_buffer[i] * 4 + 1];
-					dest[2] = pal[write_buffer[i] * 4 + 2];
-					dest[3] = pal[write_buffer[i] * 4 + 3];
-
-					dest += 4;
-				}
-				p_image->create(width, height, 0, Image::FORMAT_RGBA8, extended_data);
+				cb += 4;
 			}
+			// Extend palette to image
+			PoolVector<uint8_t> extended_data;
+			extended_data.resize(data.size() * 4);
+
+			PoolVector<uint8_t>::Write ex_w = extended_data.write();
+			uint8_t *dest = ex_w.ptr();
+
+			const int num_pixels = width * height;
+
+			for (int i = 0; i < num_pixels; i++) {
+				dest[0] = pal[write_buffer[i] * 4 + 0];
+				dest[1] = pal[write_buffer[i] * 4 + 1];
+				dest[2] = pal[write_buffer[i] * 4 + 2];
+				dest[3] = pal[write_buffer[i] * 4 + 3];
+
+				dest += 4;
+			}
+			p_image->create(width, height, 0, Image::FORMAT_RGBA8, extended_data);
 		}
 	}
 	return err;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1399,9 +1399,6 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 					unary = true;
 					break;
 				case OperatorNode::OP_NEG:
-					priority = 1;
-					unary = true;
-					break;
 				case OperatorNode::OP_POS:
 					priority = 1;
 					unary = true;

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -189,6 +189,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 		lsp::DocumentSymbol symbol;
 		const GDScriptParser::ClassNode::Constant &c = E->value();
 		const GDScriptParser::ConstantNode *node = dynamic_cast<const GDScriptParser::ConstantNode *>(c.expression);
+		ERR_FAIL_COND(!node);
 		symbol.name = E->key();
 		symbol.kind = lsp::SymbolKind::Constant;
 		symbol.deprecated = false;
@@ -674,6 +675,7 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 
 		const GDScriptParser::ClassNode::Constant &c = E->value();
 		const GDScriptParser::ConstantNode *node = dynamic_cast<const GDScriptParser::ConstantNode *>(c.expression);
+		ERR_FAIL_COND_V(!node, class_api);
 
 		Dictionary api;
 		api["name"] = E->key();

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -100,9 +100,10 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 
 	String root_uri = p_params["rootUri"];
 	String root = p_params["rootPath"];
-	bool is_same_workspace = root == workspace->root;
+	bool is_same_workspace;
+#ifndef WINDOWS_ENABLED
 	is_same_workspace = root.to_lower() == workspace->root.to_lower();
-#ifdef WINDOWS_ENABLED
+#else
 	is_same_workspace = root.replace("\\", "/").to_lower() == workspace->root.to_lower();
 #endif
 
@@ -142,6 +143,7 @@ void GDScriptLanguageProtocol::poll() {
 Error GDScriptLanguageProtocol::start(int p_port) {
 	if (server == NULL) {
 		server = dynamic_cast<WebSocketServer *>(ClassDB::instance("WebSocketServer"));
+		ERR_FAIL_COND_V(!server, FAILED);
 		server->set_buffers(8192, 1024, 8192, 1024); // 8mb should be way more than enough
 		server->connect("data_received", this, "on_data_received");
 		server->connect("client_connected", this, "on_client_connected");

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -380,8 +380,8 @@ GDScriptTextDocument::~GDScriptTextDocument() {
 	memdelete(file_checker);
 }
 
-void GDScriptTextDocument::sync_script_content(const String &p_uri, const String &p_content) {
-	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(p_uri);
+void GDScriptTextDocument::sync_script_content(const String &p_path, const String &p_content) {
+	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(p_path);
 	GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_script(path, p_content);
 }
 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1308,7 +1308,7 @@ public:
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_xlarge"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/opengl_debug"), false));
 
-		for (unsigned int i = 0; i < sizeof(launcher_icons) / sizeof(launcher_icons[0]); ++i) {
+		for (uint64_t i = 0; i < sizeof(launcher_icons) / sizeof(launcher_icons[0]); ++i) {
 			r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_icons[i].option_id, PROPERTY_HINT_FILE, "*.png"), ""));
 		}
 
@@ -2100,7 +2100,7 @@ public:
 
 			if (file == "res/drawable-nodpi-v4/icon.png") {
 				bool found = false;
-				for (unsigned int i = 0; i < sizeof(launcher_icons) / sizeof(launcher_icons[0]); ++i) {
+				for (uint64_t i = 0; i < sizeof(launcher_icons) / sizeof(launcher_icons[0]); ++i) {
 					String icon_path = String(p_preset->get(launcher_icons[i].option_id)).strip_edges();
 					if (icon_path != "" && icon_path.ends_with(".png")) {
 						FileAccess *f = FileAccess::open(icon_path, FileAccess::READ);
@@ -2226,7 +2226,7 @@ public:
 			APKExportData ed;
 			ed.ep = &ep;
 			ed.apk = unaligned_apk;
-			for (unsigned int i = 0; i < sizeof(launcher_icons) / sizeof(launcher_icons[0]); ++i) {
+			for (uint64_t i = 0; i < sizeof(launcher_icons) / sizeof(launcher_icons[0]); ++i) {
 				String icon_path = String(p_preset->get(launcher_icons[i].option_id)).strip_edges();
 				if (icon_path != "" && icon_path.ends_with(".png") && FileAccess::exists(icon_path)) {
 					Vector<uint8_t> data = FileAccess::get_file_as_array(icon_path);

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -287,7 +287,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "optional_icons/spotlight_40x40", PROPERTY_HINT_FILE, "*.png"), "")); // Spotlight
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "optional_icons/spotlight_80x80", PROPERTY_HINT_FILE, "*.png"), "")); // Spotlight on devices with retina display
 
-	for (unsigned int i = 0; i < sizeof(loading_screen_infos) / sizeof(loading_screen_infos[0]); ++i) {
+	for (uint64_t i = 0; i < sizeof(loading_screen_infos) / sizeof(loading_screen_infos[0]); ++i) {
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, loading_screen_infos[i].preset_key, PROPERTY_HINT_FILE, "*.png"), ""));
 	}
 
@@ -489,7 +489,7 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 	DirAccess *da = DirAccess::open(p_iconset_dir);
 	ERR_FAIL_COND_V(!da, ERR_CANT_OPEN);
 
-	for (unsigned int i = 0; i < (sizeof(icon_infos) / sizeof(icon_infos[0])); ++i) {
+	for (uint64_t i = 0; i < (sizeof(icon_infos) / sizeof(icon_infos[0])); ++i) {
 		IconInfo info = icon_infos[i];
 		String icon_path = p_preset->get(info.preset_key);
 		if (icon_path.length() == 0) {
@@ -539,7 +539,7 @@ Error EditorExportPlatformIOS::_export_loading_screens(const Ref<EditorExportPre
 	DirAccess *da = DirAccess::open(p_dest_dir);
 	ERR_FAIL_COND_V(!da, ERR_CANT_OPEN);
 
-	for (unsigned int i = 0; i < sizeof(loading_screen_infos) / sizeof(loading_screen_infos[0]); ++i) {
+	for (uint64_t i = 0; i < sizeof(loading_screen_infos) / sizeof(loading_screen_infos[0]); ++i) {
 		LoadingScreenInfo info = loading_screen_infos[i];
 		String loading_screen_file = p_preset->get(info.preset_key);
 		if (loading_screen_file.size() > 0) {
@@ -626,7 +626,7 @@ private:
 	static String _hex_pad(uint32_t num) {
 		Vector<char> ret;
 		ret.resize(sizeof(num) * 2);
-		for (unsigned int i = 0; i < sizeof(num) * 2; ++i) {
+		for (uint64_t i = 0; i < sizeof(num) * 2; ++i) {
 			uint8_t four_bits = (num >> (sizeof(num) * 8 - (i + 1) * 4)) & 0xF;
 			ret.write[i] = _hex_char(four_bits);
 		}
@@ -1169,7 +1169,7 @@ bool EditorExportPlatformIOS::can_export(const Ref<EditorExportPreset> &p_preset
 		valid = false;
 	}
 
-	for (unsigned int i = 0; i < (sizeof(icon_infos) / sizeof(icon_infos[0])); ++i) {
+	for (uint64_t i = 0; i < (sizeof(icon_infos) / sizeof(icon_infos[0])); ++i) {
 		IconInfo info = icon_infos[i];
 		String icon_path = p_preset->get(info.preset_key);
 		if (icon_path.length() == 0) {

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -240,7 +240,7 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
 		{ "is32", "s8mk", false, 16 } //16x16 24-bit RLE + 8-bit uncompressed mask
 	};
 
-	for (unsigned int i = 0; i < (sizeof(icon_infos) / sizeof(icon_infos[0])); ++i) {
+	for (uint64_t i = 0; i < (sizeof(icon_infos) / sizeof(icon_infos[0])); ++i) {
 		Ref<Image> copy = p_icon; // does this make sense? doesn't this just increase the reference count instead of making a copy? Do we even need a copy?
 		copy->convert(Image::FORMAT_RGBA8);
 		copy->resize(icon_infos[i].size, icon_infos[i].size);

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -500,7 +500,7 @@ Error AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t
 
 		size_t block_size = (p_len - step) > BLOCK_SIZE ? (size_t)BLOCK_SIZE : (p_len - step);
 
-		for (uint32_t i = 0; i < block_size; i++) {
+		for (uint64_t i = 0; i < block_size; i++) {
 			strm_in.write[i] = p_buffer[step + i];
 		}
 
@@ -524,14 +524,14 @@ Error AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t
 			//package->store_buffer(strm_out.ptr(), strm.total_out - total_out_before);
 			int start = file_buffer.size();
 			file_buffer.resize(file_buffer.size() + bh.compressed_size);
-			for (uint32_t i = 0; i < bh.compressed_size; i++)
+			for (uint64_t i = 0; i < bh.compressed_size; i++)
 				file_buffer.write[start + i] = strm_out[i];
 		} else {
 			bh.compressed_size = block_size;
 			//package->store_buffer(strm_in.ptr(), block_size);
 			int start = file_buffer.size();
 			file_buffer.resize(file_buffer.size() + block_size);
-			for (uint32_t i = 0; i < bh.compressed_size; i++)
+			for (uint64_t i = 0; i < bh.compressed_size; i++)
 				file_buffer.write[start + i] = strm_in[i];
 		}
 
@@ -554,7 +554,7 @@ Error AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t
 		//package->store_buffer(strm_out.ptr(), strm.total_out - total_out_before);
 		int start = file_buffer.size();
 		file_buffer.resize(file_buffer.size() + (strm.total_out - total_out_before));
-		for (uint32_t i = 0; i < (strm.total_out - total_out_before); i++)
+		for (uint64_t i = 0; i < (strm.total_out - total_out_before); i++)
 			file_buffer.write[start + i] = strm_out[i];
 
 		deflateEnd(&strm);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1566,7 +1566,7 @@ bool OS_X11::is_window_maximize_allowed() {
 		bool found_wm_act_max_horz = false;
 		bool found_wm_act_max_vert = false;
 
-		for (unsigned int i = 0; i < len; i++) {
+		for (uint64_t i = 0; i < len; i++) {
 			if (atoms[i] == wm_act_max_horz)
 				found_wm_act_max_horz = true;
 			if (atoms[i] == wm_act_max_vert)
@@ -1612,7 +1612,7 @@ bool OS_X11::is_window_maximized() const {
 		bool found_wm_max_horz = false;
 		bool found_wm_max_vert = false;
 
-		for (unsigned int i = 0; i < len; i++) {
+		for (uint64_t i = 0; i < len; i++) {
 			if (atoms[i] == wm_max_horz)
 				found_wm_max_horz = true;
 			if (atoms[i] == wm_max_vert)
@@ -3028,7 +3028,7 @@ void OS_X11::alert(const String &p_alert, const String &p_title) {
 	String program;
 
 	for (int i = 0; i < path_elems.size(); i++) {
-		for (unsigned int k = 0; k < sizeof(message_programs) / sizeof(char *); k++) {
+		for (uint64_t k = 0; k < sizeof(message_programs) / sizeof(char *); k++) {
 			String tested_path = path_elems[i].plus_file(message_programs[k]);
 
 			if (FileAccess::exists(tested_path)) {

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -602,9 +602,7 @@ void CanvasItem::_notification(int p_what) {
 			}
 			global_invalid = true;
 		} break;
-		case NOTIFICATION_DRAW: {
-
-		} break;
+		case NOTIFICATION_DRAW:
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 
 		} break;

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -271,7 +271,7 @@ void NavigationPolygon::make_polygons_from_outlines() {
 
 		struct Polygon p;
 
-		for (int i = 0; i < tp.GetNumPoints(); i++) {
+		for (int64_t i = 0; i < tp.GetNumPoints(); i++) {
 
 			Map<Vector2, int>::Element *E = points.find(tp[i]);
 			if (!E) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -456,7 +456,7 @@ public:
 	void push_meta(const Variant &p_meta);
 	void push_table(int p_columns);
 	void push_fade(int p_start_index, int p_length);
-	void push_shake(int p_level, float p_rate);
+	void push_shake(int p_strength, float p_rate);
 	void push_wave(float p_frequency, float p_amplitude);
 	void push_tornado(float p_frequency, float p_radius);
 	void push_rainbow(float p_saturation, float p_value, float p_frequency);

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -81,7 +81,7 @@ public:
 	void remove_feed(const Ref<CameraFeed> &p_feed);
 
 	// get our feeds
-	Ref<CameraFeed> get_feed(int p_idx);
+	Ref<CameraFeed> get_feed(int p_index);
 	int get_feed_count();
 	Array get_feeds();
 


### PR DESCRIPTION
Changing type of variable in loops, prevent from overflow this variable - https://clang.llvm.org/extra/clang-tidy/checks/bugprone-too-small-loop-variable.html

also there is change from INT32 -> to INT64 in core/ustring.cpp because this function return 64 bit int.