### PR TITLE
Remember the editor window position and size across restarts

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -313,6 +313,8 @@ private:
 	PopupMenu *editor_layouts;
 	EditorLayoutsDialog *layout_dialog;
 
+	Ref<ConfigFile> window_config;
+
 	ConfirmationDialog *custom_build_manage_templates;
 	ConfirmationDialog *install_android_build_template;
 	ConfirmationDialog *remove_android_build_template;
@@ -596,6 +598,9 @@ private:
 	void _load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section);
 	void _update_dock_slots_visibility();
 	void _dock_tab_changed(int p_tab);
+
+	void _save_window_config();
+	void _load_window_config();
 
 	bool restoring_scenes;
 	void _save_open_scenes_to_config(Ref<ConfigFile> p_layout, const String &p_section);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1465,6 +1465,11 @@ String EditorSettings::get_editor_layouts_config() const {
 	return get_settings_dir().plus_file("editor_layouts.cfg");
 }
 
+String EditorSettings::get_window_config() const {
+
+	return get_cache_dir().plus_file("window.cfg");
+}
+
 // Shortcuts
 
 void EditorSettings::add_shortcut(const String &p_name, Ref<ShortCut> &p_shortcut) {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -190,6 +190,7 @@ public:
 
 	Vector<String> get_script_templates(const String &p_extension, const String &p_custom_path = String());
 	String get_editor_layouts_config() const;
+	String get_window_config() const;
 
 	void add_shortcut(const String &p_name, Ref<ShortCut> &p_shortcut);
 	bool is_shortcut(const String &p_name, const Ref<InputEvent> &p_event) const;


### PR DESCRIPTION
Some notes:

- For the purposes of configuration saving, exiting while the editor is fullscreen will be saved as maximized.
- ~~The configuration accounts for multiple monitors and will save the window position relative to the current monitor. When reopening the editor, it will open on the monitor that's currently active.~~
  - **TODO:** Remove this and just use absolute coordinates, as most other applications seem to use absolute coordinates.
- If the editor isn't maximized, the window will be resized while the splash screen is displayed. This could be solved by moving the configuration loading code to `main.cpp`, but I don't know how this could be done since it needs to be done early enough while getting the file path from the EditorSettings singleton.

This closes #5114.