### PR TITLE
Decrease the default editor font sizes

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -47,9 +47,9 @@ void EditorAbout::_notification(int p_what) {
 			Control *base = EditorNode::get_singleton()->get_gui_base();
 			Ref<Font> font = base->get_font("source", "EditorFonts");
 			_tpl_text->add_font_override("normal_font", font);
-			_tpl_text->add_constant_override("line_separation", 6 * EDSCALE);
+			_tpl_text->add_constant_override("line_separation", Math::round((int)EDITOR_GET("text_editor/theme/line_spacing") * EDSCALE));
 			_license_text->add_font_override("normal_font", font);
-			_license_text->add_constant_override("line_separation", 6 * EDSCALE);
+			_license_text->add_constant_override("line_separation", Math::round((int)EDITOR_GET("text_editor/theme/line_spacing") * EDSCALE));
 			_logo->set_texture(base->get_icon("Logo", "EditorIcons"));
 		} break;
 	}

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -58,17 +58,18 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 
 void EditorLog::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
 
-		//button->set_icon(get_icon("Console","EditorIcons"));
-		log->add_font_override("normal_font", get_font("output_source", "EditorFonts"));
-	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		Ref<DynamicFont> df_output_code = get_font("output_source", "EditorFonts");
-		if (df_output_code.is_valid()) {
-			if (log != NULL) {
-				log->add_font_override("normal_font", get_font("output_source", "EditorFonts"));
+			const Ref<DynamicFont> df_output_code = get_font("output_source", "EditorFonts");
+			if (df_output_code.is_valid()) {
+				if (log != NULL) {
+					log->add_font_override("normal_font", get_font("output_source", "EditorFonts"));
+					log->add_constant_override("line_separation", Math::round((int)EDITOR_GET("text_editor/theme/line_spacing") * EDSCALE));
+				}
 			}
-		}
+		} break;
 	}
 }
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -319,9 +319,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/editor/display_scale"] = PropertyInfo(Variant::INT, "interface/editor/display_scale", PROPERTY_HINT_ENUM, "Auto,75%,100%,125%,150%,175%,200%,Custom", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/custom_display_scale", 1.0f);
 	hints["interface/editor/custom_display_scale"] = PropertyInfo(Variant::REAL, "interface/editor/custom_display_scale", PROPERTY_HINT_RANGE, "0.5,3,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
-	_initial_set("interface/editor/main_font_size", 14);
+	_initial_set("interface/editor/main_font_size", 13);
 	hints["interface/editor/main_font_size"] = PropertyInfo(Variant::INT, "interface/editor/main_font_size", PROPERTY_HINT_RANGE, "8,48,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
-	_initial_set("interface/editor/code_font_size", 14);
+	_initial_set("interface/editor/code_font_size", 12);
 	hints["interface/editor/code_font_size"] = PropertyInfo(Variant::INT, "interface/editor/code_font_size", PROPERTY_HINT_RANGE, "8,48,1", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/editor/font_antialiased", true);
 	_initial_set("interface/editor/font_hinting", 0);
@@ -419,7 +419,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Theme
 	_initial_set("text_editor/theme/color_theme", "Adaptive");
 	hints["text_editor/theme/color_theme"] = PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, "Adaptive,Default,Custom");
-	_initial_set("text_editor/theme/line_spacing", 6);
+	_initial_set("text_editor/theme/line_spacing", 7);
 	hints["text_editor/theme/line_spacing"] = PropertyInfo(Variant::INT, "text_editor/theme/line_spacing", PROPERTY_HINT_RANGE, "0,50,1");
 
 	_load_default_text_editor_theme();
@@ -493,11 +493,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Help
 	_initial_set("text_editor/help/show_help_index", true);
-	_initial_set("text_editor/help/help_font_size", 15);
+	_initial_set("text_editor/help/help_font_size", 14);
 	hints["text_editor/help/help_font_size"] = PropertyInfo(Variant::INT, "text_editor/help/help_font_size", PROPERTY_HINT_RANGE, "8,48,1");
 	_initial_set("text_editor/help/help_source_font_size", 14);
 	hints["text_editor/help/help_source_font_size"] = PropertyInfo(Variant::INT, "text_editor/help/help_source_font_size", PROPERTY_HINT_RANGE, "8,48,1");
-	_initial_set("text_editor/help/help_title_font_size", 23);
+	_initial_set("text_editor/help/help_title_font_size", 22);
 	hints["text_editor/help/help_title_font_size"] = PropertyInfo(Variant::INT, "text_editor/help/help_title_font_size", PROPERTY_HINT_RANGE, "8,48,1");
 
 	/* Editors */
@@ -608,7 +608,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("run/auto_save/save_before_running", true);
 
 	// Output
-	_initial_set("run/output/font_size", 13);
+	_initial_set("run/output/font_size", 12);
 	hints["run/output/font_size"] = PropertyInfo(Variant::INT, "run/output/font_size", PROPERTY_HINT_RANGE, "8,48,1");
 	_initial_set("run/output/always_clear_output_on_play", true);
 	_initial_set("run/output/always_open_output_on_play", true);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -419,6 +419,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	const int default_margin_size = 4;
 	const int margin_size_extra = default_margin_size + CLAMP(border_size, 0, 3);
+	// Dynamic margin based on the font size. On lower font sizes, one additional pixel will be added.
+	// This value should be used for separating list items, so they remain easy to click.
+	const int dynamic_margin_size = ((int)EDITOR_GET("interface/editor/main_font_size") <= 13) ? 1 : 0;
 
 	// styleboxes
 	// this is the most commonly used stylebox, variations should be made as duplicate of this
@@ -662,7 +665,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("visibility_hidden", "PopupMenu", theme->get_icon("GuiVisibilityHidden", "EditorIcons"));
 	theme->set_icon("visibility_visible", "PopupMenu", theme->get_icon("GuiVisibilityVisible", "EditorIcons"));
 	theme->set_icon("visibility_xray", "PopupMenu", theme->get_icon("GuiVisibilityXray", "EditorIcons"));
-	theme->set_constant("vseparation", "PopupMenu", (extra_spacing + default_margin_size + 1) * EDSCALE);
+	theme->set_constant("vseparation", "PopupMenu", (extra_spacing + default_margin_size + dynamic_margin_size + 2) * EDSCALE);
 
 	Ref<StyleBoxFlat> sub_inspector_bg = make_flat_stylebox(dark_color_1.linear_interpolate(accent_color, 0.08), 2, 0, 2, 2);
 	sub_inspector_bg->set_border_width(MARGIN_LEFT, 2);
@@ -702,7 +705,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("guide_color", "Tree", guide_color);
 	theme->set_color("relationship_line_color", "Tree", relationship_line_color);
 	theme->set_color("drop_position_color", "Tree", accent_color);
-	theme->set_constant("vseparation", "Tree", (extra_spacing + default_margin_size) * EDSCALE);
+	theme->set_constant("vseparation", "Tree", (extra_spacing + default_margin_size + dynamic_margin_size) * EDSCALE);
 	theme->set_constant("hseparation", "Tree", (extra_spacing + default_margin_size) * EDSCALE);
 	theme->set_constant("guide_width", "Tree", border_width);
 	theme->set_constant("item_margin", "Tree", 3 * default_margin_size * EDSCALE);
@@ -766,7 +769,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_color", "ItemList", font_color);
 	theme->set_color("font_color_selected", "ItemList", mono_color);
 	theme->set_color("guide_color", "ItemList", guide_color);
-	theme->set_constant("vseparation", "ItemList", 3 * EDSCALE);
+	theme->set_constant("vseparation", "ItemList", (3 + dynamic_margin_size) * EDSCALE);
 	theme->set_constant("hseparation", "ItemList", 3 * EDSCALE);
 	theme->set_constant("icon_margin", "ItemList", default_margin_size * EDSCALE);
 	theme->set_constant("line_separation", "ItemList", 3 * EDSCALE);
@@ -879,7 +882,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("margin_right", "MarginContainer", 0);
 	theme->set_constant("margin_bottom", "MarginContainer", 0);
 	theme->set_constant("hseparation", "GridContainer", default_margin_size * EDSCALE);
-	theme->set_constant("vseparation", "GridContainer", default_margin_size * EDSCALE);
+	theme->set_constant("vseparation", "GridContainer", (default_margin_size + dynamic_margin_size) * EDSCALE);
 
 	// WindowDialog
 	Ref<StyleBoxFlat> style_window = style_popup->duplicate();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -256,7 +256,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	text_edit->add_color_override("search_result_border_color", search_result_border_color);
 	text_edit->add_color_override("symbol_color", symbol_color);
 
-	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 6));
+	text_edit->add_constant_override("line_spacing", EDITOR_GET("text_editor/theme/line_spacing"));
 
 	colors_cache.symbol_color = symbol_color;
 	colors_cache.keyword_color = keyword_color;

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -134,7 +134,7 @@ void TextEditor::_load_theme_settings() {
 	text_edit->add_color_override("search_result_border_color", search_result_border_color);
 	text_edit->add_color_override("symbol_color", symbol_color);
 
-	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 6));
+	text_edit->add_constant_override("line_spacing", EDITOR_GET("text_editor/theme/line_spacing"));
 
 	colors_cache.font_color = text_color;
 	colors_cache.symbol_color = symbol_color;


### PR DESCRIPTION
This makes the editor feel less cramped on smaller displays. The default code font's line spacing was slightly increased to account for its lower size.

Some margins are now slightly increased when using a smaller font size to make list items easier to select.

The output log and About dialog now use the line spacing defined in the script editor settings.

See the discussion in https://github.com/godotengine/godot-proposals/issues/9.

## Preview

### Editor at 1920×1080 (old font sizes)

![editor_font_size_old](https://user-images.githubusercontent.com/180032/64552005-a1eefe80-d336-11e9-98d3-19668913c782.png)

### Editor at 1920×1080 (new font sizes + spacing compensation)

![editor_font_size_new](https://user-images.githubusercontent.com/180032/64552009-a4e9ef00-d336-11e9-987a-e2c94f8d4e88.png)

### New default font size and line spacing in the script editor


![editor_script_editor_font_size_new](https://user-images.githubusercontent.com/180032/64552030-ae735700-d336-11e9-8fa8-b96d87cac33f.png)