### PR TITLE
Preserve folding when sub-scene is changed

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3133,7 +3133,14 @@ void EditorNode::_clear_undo_history() {
 
 void EditorNode::set_current_scene(int p_idx) {
 
+	//Save the folding in case the scene gets reloaded.
+	if (editor_data.get_scene_path(p_idx) != "")
+		editor_folding.save_scene_folding(editor_data.get_edited_scene_root(p_idx), editor_data.get_scene_path(p_idx));
+
 	if (editor_data.check_and_update_scene(p_idx)) {
+		if (editor_data.get_scene_path(p_idx) != "")
+			editor_folding.load_scene_folding(editor_data.get_edited_scene_root(p_idx), editor_data.get_scene_path(p_idx));
+
 		call_deferred("_clear_undo_history");
 	}
 


### PR DESCRIPTION
Fixes #29975

Turns out I was right in https://github.com/godotengine/godot/issues/29975#issuecomment-529269149. The folding is cleared in the constructors, because the scene is ninja-reloaded when the sub-scene is updated, bypassing any standard loading mechanisms. Trying to find this out was terrible process ;_;