### PR TITLE
Fix crash when guessing type of variable declared to itself - Godot 2.1

### DIFF
--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -960,7 +960,7 @@ static bool _guess_identifier_type_in_block(GDCompletionContext &context, int p_
 	}
 
 	//use the last assignment, (then backwards?)
-	if (last_assign) {
+	if (last_assign && last_assign_line != p_line) {
 
 		return _guess_expression_type(context, last_assign, last_assign_line, r_type);
 	}
@@ -1094,6 +1094,8 @@ static bool _guess_identifier_type(GDCompletionContext &context, int p_line, con
 					r_type = _get_type_from_pinfo(context._class->variables[i]._export);
 					return true;
 				} else if (context._class->variables[i].expression) {
+					if (p_line <= context._class->variables[i].line)
+						return false;
 
 					bool rtype = _guess_expression_type(context, context._class->variables[i].expression, context._class->variables[i].line, r_type);
 					if (rtype && r_type.type != Variant::NIL)


### PR DESCRIPTION
PR #12752 was made for Godot 3 to fix issue #10972, however Godot 2.1 was neglected. This PR is identical to the aforementioned PR.