### PR TITLE
Fix ambiguous method description regarding `body_test_motion` in 2D

### DIFF
--- a/doc/classes/Physics2DServer.xml
+++ b/doc/classes/Physics2DServer.xml
@@ -822,7 +822,7 @@
 			<argument index="5" name="result" type="Physics2DTestMotionResult" default="null">
 			</argument>
 			<description>
-				Returns whether a body can move from a given point in a given direction. Apart from the boolean return value, a [Physics2DTestMotionResult] can be passed to return additional information in.
+				Returns [code]true[/code] if a collision would result from moving in the given direction from a given point in space. Margin increases the size of the shapes involved in the collision detection. [Physics2DTestMotionResult] can be passed to return additional information in.
 			</description>
 		</method>
 		<method name="capsule_shape_create">


### PR DESCRIPTION
According to description, a user can conclude that if a body can move, then it would return `true`, which is misleading because `true` is returned in case a collision occurs (stuck). Description adapted from `RigidBody2D`'s `test_motion` method.