### PR TITLE
Fix int overflow in EditorResourcePreview::_preview_ready

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -116,7 +116,7 @@ void EditorResourcePreview::_preview_ready(const String &p_str, const Ref<Textur
 	uint64_t modified_time = 0;
 
 	if (p_str.begins_with("ID:")) {
-		hash = p_str.get_slicec(':', 2).to_int();
+		hash = uint32_t(p_str.get_slicec(':', 2).to_int64());
 		path = "ID:" + p_str.get_slicec(':', 1);
 	} else {
 		modified_time = FileAccess::get_modified_time(path);


### PR DESCRIPTION
Fixes #31232

to_int() function cannot be used for uint32_t because they have different scope of values
int32  -2,147,483,648 <-> 2,147,483,647
uint32_t 0 <-> 4,294,967,295