### PR TITLE
Add VisualServer methods to get the video adapter name and vendor

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -1397,6 +1397,22 @@
 				Returns the id of the test texture. Creates one if none exists.
 			</description>
 		</method>
+		<method name="get_video_adapter_name" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the name of the video adapter (e.g. "GeForce GTX 1080/PCIe/SSE2").
+				[b]Note:[/b] When running a headless or server binary, this function returns an empty string.
+			</description>
+		</method>
+		<method name="get_video_adapter_vendor" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the vendor of the video adapter (e.g. "NVIDIA Corporation").
+				[b]Note:[/b] When running a headless or server binary, this function returns an empty string.
+			</description>
+		</method>
 		<method name="get_white_texture">
 			<return type="RID">
 			</return>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -742,6 +742,8 @@ public:
 	int get_captured_render_info(VS::RenderInfo p_info) { return 0; }
 
 	int get_render_info(VS::RenderInfo p_info) { return 0; }
+	String get_video_adapter_name() const { return String(); }
+	String get_video_adapter_vendor() const { return String(); }
 
 	static RasterizerStorage *base_singleton;
 

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -263,8 +263,7 @@ void RasterizerGLES2::initialize() {
 #endif // GLES_OVER_GL
 #endif // CAN_DEBUG
 
-	const GLubyte *renderer = glGetString(GL_RENDERER);
-	print_line("OpenGL ES 2.0 Renderer: " + String((const char *)renderer));
+	print_line("OpenGL ES 2.0 Renderer: " + VisualServer::get_singleton()->get_video_adapter_name());
 	storage->initialize();
 	canvas->initialize();
 	scene->initialize();

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5766,6 +5766,16 @@ int RasterizerStorageGLES2::get_render_info(VS::RenderInfo p_info) {
 	}
 }
 
+String RasterizerStorageGLES2::get_video_adapter_name() const {
+
+	return (const char *)glGetString(GL_RENDERER);
+}
+
+String RasterizerStorageGLES2::get_video_adapter_vendor() const {
+
+	return (const char *)glGetString(GL_VENDOR);
+}
+
 void RasterizerStorageGLES2::initialize() {
 	RasterizerStorageGLES2::system_fbo = 0;
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1307,6 +1307,8 @@ public:
 	virtual int get_captured_render_info(VS::RenderInfo p_info);
 
 	virtual int get_render_info(VS::RenderInfo p_info);
+	virtual String get_video_adapter_name() const;
+	virtual String get_video_adapter_vendor() const;
 
 	RasterizerStorageGLES2();
 };

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -186,8 +186,7 @@ void RasterizerGLES3::initialize() {
 	}
 	*/
 
-	const GLubyte *renderer = glGetString(GL_RENDERER);
-	print_line("OpenGL ES 3.0 Renderer: " + String((const char *)renderer));
+	print_line("OpenGL ES 3.0 Renderer: " + VisualServer::get_singleton()->get_video_adapter_name());
 	storage->initialize();
 	canvas->initialize();
 	scene->initialize();

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8095,6 +8095,16 @@ int RasterizerStorageGLES3::get_render_info(VS::RenderInfo p_info) {
 	}
 }
 
+String RasterizerStorageGLES3::get_video_adapter_name() const {
+
+	return (const char *)glGetString(GL_RENDERER);
+}
+
+String RasterizerStorageGLES3::get_video_adapter_vendor() const {
+
+	return (const char *)glGetString(GL_VENDOR);
+}
+
 void RasterizerStorageGLES3::initialize() {
 
 	RasterizerStorageGLES3::system_fbo = 0;

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1467,6 +1467,8 @@ public:
 	virtual int get_captured_render_info(VS::RenderInfo p_info);
 
 	virtual int get_render_info(VS::RenderInfo p_info);
+	virtual String get_video_adapter_name() const;
+	virtual String get_video_adapter_vendor() const;
 
 	RasterizerStorageGLES3();
 };

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -588,6 +588,8 @@ public:
 	virtual int get_captured_render_info(VS::RenderInfo p_info) = 0;
 
 	virtual int get_render_info(VS::RenderInfo p_info) = 0;
+	virtual String get_video_adapter_name() const = 0;
+	virtual String get_video_adapter_vendor() const = 0;
 
 	static RasterizerStorage *base_singleton;
 	RasterizerStorage();

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -153,6 +153,16 @@ int VisualServerRaster::get_render_info(RenderInfo p_info) {
 	return VSG::storage->get_render_info(p_info);
 }
 
+String VisualServerRaster::get_video_adapter_name() const {
+
+	return VSG::storage->get_video_adapter_name();
+}
+
+String VisualServerRaster::get_video_adapter_vendor() const {
+
+	return VSG::storage->get_video_adapter_vendor();
+}
+
 /* TESTING */
 
 void VisualServerRaster::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -680,6 +680,8 @@ public:
 	/* STATUS INFORMATION */
 
 	virtual int get_render_info(RenderInfo p_info);
+	virtual String get_video_adapter_name() const;
+	virtual String get_video_adapter_vendor() const;
 
 	virtual RID get_test_cube();
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -602,6 +602,14 @@ public:
 		return visual_server->get_render_info(p_info);
 	}
 
+	virtual String get_video_adapter_name() const {
+		return visual_server->get_video_adapter_name();
+	}
+
+	virtual String get_video_adapter_vendor() const {
+		return visual_server->get_video_adapter_vendor();
+	}
+
 	FUNC4(set_boot_image, const Ref<Image> &, const Color &, bool, bool)
 	FUNC1(set_default_clear_color, const Color &)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2032,6 +2032,8 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("init"), &VisualServer::init);
 	ClassDB::bind_method(D_METHOD("finish"), &VisualServer::finish);
 	ClassDB::bind_method(D_METHOD("get_render_info", "info"), &VisualServer::get_render_info);
+	ClassDB::bind_method(D_METHOD("get_video_adapter_name"), &VisualServer::get_video_adapter_name);
+	ClassDB::bind_method(D_METHOD("get_video_adapter_vendor"), &VisualServer::get_video_adapter_vendor);
 #ifndef _3D_DISABLED
 
 	ClassDB::bind_method(D_METHOD("make_sphere_mesh", "latitudes", "longitudes", "radius"), &VisualServer::make_sphere_mesh);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1017,6 +1017,8 @@ public:
 	};
 
 	virtual int get_render_info(RenderInfo p_info) = 0;
+	virtual String get_video_adapter_name() const = 0;
+	virtual String get_video_adapter_vendor() const = 0;
 
 	/* Materials for 2D on 3D */
 


### PR DESCRIPTION
These methods can be used in scripts to retrieve the OpenGL `GL_RENDERER` and `GL_VENDOR` strings (respectively).

This closes #28404.

Demo project: [test_video_adapter.zip](https://github.com/godotengine/godot/files/3611311/test_video_adapter.zip)