### PR TITLE
Remove outdated information from skeleton class reference

### DIFF
--- a/doc/classes/Skeleton.xml
+++ b/doc/classes/Skeleton.xml
@@ -4,7 +4,7 @@
 		Skeleton for characters and animated objects.
 	</brief_description>
 	<description>
-		Skeleton provides a hierarchical interface for managing bones, including pose, rest and animation (see [Animation]). Skeleton will support rag doll dynamics in the future.
+		Skeleton provides a hierarchical interface for managing bones, including pose, rest and animation (see [Animation]). It can also use ragdoll physics.
 		The overall transform of a bone with respect to the skeleton is determined by the following hierarchical order: rest pose, custom pose and pose.
 		Note that "global pose" below refers to the overall transform of the bone with respect to skeleton, so it not the actual global/world transform of the bone.
 	</description>


### PR DESCRIPTION
Ragdoll physics were added in Godot 3.1 so I updated the description.