### PR TITLE
Fix misc. source comment typos

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -73,7 +73,7 @@
 			<argument index="6" name="optimize" type="bool" default="true">
 			</argument>
 			<description>
-				Blend another animaiton node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
+				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
 			</description>
 		</method>
 		<method name="get_caption" qualifiers="virtual">

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -154,7 +154,7 @@
 		</member>
 		<member name="offset_h" type="float" setter="set_h_offset" getter="get_h_offset" default="0.0">
 			The horizontal offset of the camera, relative to the drag margins.
-			[b]Note:[/b] Offset H is used only to force offset relative to margins. It's not updated in any way if drag margins are enabled and can be used to set inital offset.
+			[b]Note:[/b] Offset H is used only to force offset relative to margins. It's not updated in any way if drag margins are enabled and can be used to set initial offset.
 		</member>
 		<member name="offset_v" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
 			The vertical offset of the camera, relative to the drag margins.

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -22,7 +22,7 @@
 			</return>
 			<description>
 				Virtual method to be implemented by the user. Returns whether [method _gui_input] should not be called for children controls outside this control's rectangle. Input will be clipped to the Rect of this [Control]. Similar to [member rect_clip_content], but doesn't affect visibility.
-				If not overriden, defaults to [code]false[/code].
+				If not overridden, defaults to [code]false[/code].
 			</description>
 		</method>
 		<method name="_get_minimum_size" qualifiers="virtual">
@@ -30,7 +30,7 @@
 			</return>
 			<description>
 				Virtual method to be implemented by the user. Returns the minimum size for this control. Alternative to [member rect_min_size] for controlling minimum size via code. The actual minimum size will be the max value of these two (in each axis separately).
-				If not overriden, defaults to [constant Vector2.ZERO].
+				If not overridden, defaults to [constant Vector2.ZERO].
 			</description>
 		</method>
 		<method name="_gui_input" qualifiers="virtual">
@@ -395,7 +395,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Creates an [InputEventMouseButton] that attempts to click the control. If the event is received, the control aquires focus.
+				Creates an [InputEventMouseButton] that attempts to click the control. If the event is received, the control acquires focus.
 				[codeblock]
 				func _process(delta):
 				    grab_click_focus() #when clicking another Control node, this node will be clicked instead
@@ -503,7 +503,7 @@
 			</argument>
 			<description>
 				Virtual method to be implemented by the user. Returns whether the given [code]point[/code] is inside this control.
-				If not overriden, default behavior is checking if the point is within control's Rect.
+				If not overridden, default behavior is checking if the point is within control's Rect.
 				[b]Node:[/b] If you want to check if a point is inside the control, you can use [code]get_rect().has_point(point)[/code].
 			</description>
 		</method>
@@ -564,7 +564,7 @@
 			<description>
 				Sets the anchor identified by [code]margin[/code] constant from [enum Margin] enum to value [code]anchor[/code]. A setter method for [member anchor_bottom], [member anchor_left], [member anchor_right] and [member anchor_top].
 				If [code]keep_margin[/code] is [code]true[/code], margins aren't updated after this operation.
-				If [code]push_opposite_anchor[/code] is [code]true[/code] and the opposite anchor overlaps this anchor, the opposite one will have its value overriden. For example, when setting left anchor to 1 and the right anchor has value of 0.5, the right anchor will also get value of 1. If [code]push_opposite_anchor[/code] was [code]false[/code], the left anchor would get value 0.5.
+				If [code]push_opposite_anchor[/code] is [code]true[/code] and the opposite anchor overlaps this anchor, the opposite one will have its value overridden. For example, when setting left anchor to 1 and the right anchor has value of 0.5, the right anchor will also get value of 1. If [code]push_opposite_anchor[/code] was [code]false[/code], the left anchor would get value 0.5.
 			</description>
 		</method>
 		<method name="set_anchor_and_margin">

--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -38,7 +38,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the VCS addon has been intialized, else returns [code]false[/code].
+				Returns [code]true[/code] if the VCS addon has been initialized, else returns [code]false[/code].
 			</description>
 		</method>
 		<method name="get_modified_files_data">
@@ -65,7 +65,7 @@
 			<return type="String">
 			</return>
 			<description>
-				Return the name of the VCS if the VCS has been intialized, else return an empty string.
+				Return the name of the VCS if the VCS has been initialized, else return an empty string.
 			</description>
 		</method>
 		<method name="initialize">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -414,7 +414,7 @@
 			<argument index="1" name="grayscale" type="bool" default="false">
 			</argument>
 			<description>
-				Saves the image as an EXR file to [code]path[/code]. If grayscale is true and the image has only one channel, it will be saved explicitely as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE]  if Godot was compiled without the TinyEXR module.
+				Saves the image as an EXR file to [code]path[/code]. If grayscale is true and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE]  if Godot was compiled without the TinyEXR module.
 			</description>
 		</method>
 		<method name="save_png" qualifiers="const">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -223,7 +223,7 @@
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if you are pressing the action event. Note that if an action has multiple buttons asigned and more than one of them is pressed, releasing one button will release the action, even if some other button assigned to this action is still pressed.
+				Returns [code]true[/code] if you are pressing the action event. Note that if an action has multiple buttons assigned and more than one of them is pressed, releasing one button will release the action, even if some other button assigned to this action is still pressed.
 			</description>
 		</method>
 		<method name="is_joy_button_pressed" qualifiers="const">

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -233,7 +233,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Returns the index of the item containing the specified [code]id[/code]. Index is automatically assigned to each item by the engine. Index can not be set manualy.
+				Returns the index of the item containing the specified [code]id[/code]. Index is automatically assigned to each item by the engine. Index can not be set manually.
 			</description>
 		</method>
 		<method name="get_item_metadata" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -722,7 +722,7 @@
 			Fix to improve physics jitter, specially on monitors where refresh rate is different than the physics FPS.
 		</member>
 		<member name="rendering/environment/default_clear_color" type="Color" setter="" getter="" default="Color( 0.3, 0.3, 0.3, 1 )">
-			Default background clear color. Overriddable per [Viewport] using its [Environment]. See [member Environment.background_mode] and [member Environment.background_color] in particular. To change this default color programmatically, use [method VisualServer.set_default_clear_color].
+			Default background clear color. Overridable per [Viewport] using its [Environment]. See [member Environment.background_mode] and [member Environment.background_color] in particular. To change this default color programmatically, use [method VisualServer.set_default_clear_color].
 		</member>
 		<member name="rendering/limits/buffers/blend_shape_max_buffer_size_kb" type="int" setter="" getter="" default="4096">
 			Max buffer size for blend shapes. Any blend shape bigger than this will not work.

--- a/editor/collada/collada.cpp
+++ b/editor/collada/collada.cpp
@@ -616,7 +616,7 @@ void Collada::_parse_effect_material(XMLParser &parser, Effect &effect, String &
 
 										if (colorarr.size() >= 3) {
 
-											// alpha strangely not allright? maybe it needs to be multiplied by value as a channel intensity
+											// alpha strangely not alright? maybe it needs to be multiplied by value as a channel intensity
 											Color color(colorarr[0], colorarr[1], colorarr[2], 1.0);
 											if (what == "diffuse")
 												effect.diffuse.color = color;
@@ -854,7 +854,7 @@ void Collada::_parse_light(XMLParser &parser) {
 				COLLADA_PRINT("colorarr size: " + rtos(colorarr.size()));
 
 				if (colorarr.size() >= 4) {
-					// alpha strangely not allright? maybe it needs to be multiplied by value as a channel intensity
+					// alpha strangely not alright? maybe it needs to be multiplied by value as a channel intensity
 					Color color(colorarr[0], colorarr[1], colorarr[2], 1.0);
 					light.color = color;
 				}
@@ -2297,7 +2297,7 @@ bool Collada::_optimize_skeletons(VisualScene *p_vscene, Node *p_node) {
 		//replace parent by this...
 		Node *parent = node->parent;
 
-		//i wonder if this is allright.. i think it is since created skeleton (first joint) is already animated by bone..
+		//i wonder if this is alright.. i think it is since created skeleton (first joint) is already animated by bone..
 		node->id = parent->id;
 		node->name = parent->name;
 		node->xform_list = parent->xform_list;

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5186,7 +5186,7 @@ void SpatialEditor::snap_selected_nodes_to_floor() {
 	// The maximum height an object can travel to be snapped
 	const float max_snap_height = 20.0;
 
-	// Will be set to `true` if at least one node from the selection was sucessfully snapped
+	// Will be set to `true` if at least one node from the selection was successfully snapped
 	bool snapped_to_floor = false;
 
 	if (keys.size()) {

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -564,7 +564,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	diff_heading = memnew(Label);
 	diff_heading->set_text(TTR("Status"));
-	diff_heading->set_tooltip(TTR("View file diffs before commiting them to the latest version"));
+	diff_heading->set_tooltip(TTR("View file diffs before committing them to the latest version"));
 	diff_hbc->add_child(diff_heading);
 
 	diff_file_name = memnew(Label);

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -529,7 +529,7 @@ void EditorSceneImporterAssimp::_import_animation(ImportState &state, int p_anim
 }
 
 //
-// Mesh Generation from indicies ? why do we need so much mesh code
+// Mesh Generation from indices ? why do we need so much mesh code
 // [debt needs looked into]
 Ref<Mesh> EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(
 		ImportState &state,

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -114,7 +114,7 @@ void CSGBrush::_regen_face_aabbs() {
 		faces.write[i].aabb.position = faces[i].vertices[0];
 		faces.write[i].aabb.expand_to(faces[i].vertices[1]);
 		faces.write[i].aabb.expand_to(faces[i].vertices[2]);
-		faces.write[i].aabb.grow_by(faces[i].aabb.get_longest_axis_size() * 0.001); //make it a tad bigger to avoid num precision erros
+		faces.write[i].aabb.grow_by(faces[i].aabb.get_longest_axis_size() * 0.001); //make it a tad bigger to avoid num precision errors
 	}
 }
 

--- a/modules/gdnative/include/nativescript/godot_nativescript.h
+++ b/modules/gdnative/include/nativescript/godot_nativescript.h
@@ -64,9 +64,9 @@ typedef enum {
 	GODOT_PROPERTY_HINT_LAYERS_3D_RENDER,
 	GODOT_PROPERTY_HINT_LAYERS_3D_PHYSICS,
 	GODOT_PROPERTY_HINT_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,"
-	GODOT_PROPERTY_HINT_DIR, ///< a directort path must be passed
+	GODOT_PROPERTY_HINT_DIR, ///< a directory path must be passed
 	GODOT_PROPERTY_HINT_GLOBAL_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,"
-	GODOT_PROPERTY_HINT_GLOBAL_DIR, ///< a directort path must be passed
+	GODOT_PROPERTY_HINT_GLOBAL_DIR, ///< a directory path must be passed
 	GODOT_PROPERTY_HINT_RESOURCE_TYPE, ///< a resource object type
 	GODOT_PROPERTY_HINT_MULTILINE_TEXT, ///< used for string properties that can contain multiple lines
 	GODOT_PROPERTY_HINT_PLACEHOLDER_TEXT, ///< used to set a placeholder text for string properties

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -200,7 +200,7 @@ void PluginScriptLanguage::get_recognized_extensions(List<String> *p_extensions)
 }
 
 void PluginScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const {
-	// TODO: provid this statically in `godot_pluginscript_language_desc` ?
+	// TODO: provide this statically in `godot_pluginscript_language_desc` ?
 	if (_desc.get_public_functions) {
 		Array functions;
 		_desc.get_public_functions(_data, (godot_array *)&functions);
@@ -212,7 +212,7 @@ void PluginScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) c
 }
 
 void PluginScriptLanguage::get_public_constants(List<Pair<String, Variant> > *p_constants) const {
-	// TODO: provid this statically in `godot_pluginscript_language_desc` ?
+	// TODO: provide this statically in `godot_pluginscript_language_desc` ?
 	if (_desc.get_public_constants) {
 		Dictionary constants;
 		_desc.get_public_constants(_data, (godot_dictionary *)&constants);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -99,7 +99,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 #endif
 	instance->owner->set_script_instance(instance);
 
-	/* STEP 2, INITIALIZE AND CONSRTUCT */
+	/* STEP 2, INITIALIZE AND CONSTRUCT */
 
 #ifndef NO_THREADS
 	GDScriptLanguage::singleton->lock->lock();

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2064,7 +2064,7 @@ Error GDScriptCompiler::_parse_class_blocks(GDScript *p_script, const GDScriptPa
 					}
 					instance->owner->set_script_instance(instance);
 
-					/* STEP 2, INITIALIZE AND CONSRTUCT */
+					/* STEP 2, INITIALIZE AND CONSTRUCT */
 
 					Variant::CallError ce;
 					p_script->initializer->call(instance, NULL, 0, ce);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1207,7 +1207,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 					if (_get_completable_identifier(COMPLETION_INDEX, identifier)) {
 
 						if (identifier == StringName()) {
-							identifier = "@temp"; //so it parses allright
+							identifier = "@temp"; //so it parses alright
 						}
 						completion_node = op;
 

--- a/platform/windows/camera_win.cpp
+++ b/platform/windows/camera_win.cpp
@@ -30,9 +30,12 @@
 
 #include "camera_win.h"
 
-///@TODO sorry guys, I got about 80% through implementing this using DirectShow only to find out Microsoft deprecated half the API and its replacement is as confusing as they could make it
-// Joey suggested looking into libuvc which offers a more direct route to webcams over USB and this is very promissing but it wouldn't compile on windows for me...
-// I've gutted the classes I implemented DirectShow in just to have a skeleton for someone to work on, mail me for more details or if you want a copy....
+///@TODO sorry guys, I got about 80% through implementing this using DirectShow only
+// to find out Microsoft deprecated half the API and its replacement is as confusing
+// as they could make it. Joey suggested looking into libuvc which offers a more direct
+// route to webcams over USB and this is very promising but it wouldn't compile on
+// windows for me...I've gutted the classes I implemented DirectShow in just to have
+// a skeleton for someone to work on, mail me for more details or if you want a copy....
 
 //////////////////////////////////////////////////////////////////////////
 // CameraFeedWindows - Subclass for our camera feed on windows
@@ -69,7 +72,8 @@ bool CameraFeedWindows::activate_feed() {
 	return true;
 };
 
-///@TODO we should probably have a callback method here that is being called by the camera API which provides frames and call back into the CameraServer to update our texture
+///@TODO we should probably have a callback method here that is being called by the
+// camera API which provides frames and call back into the CameraServer to update our texture
 
 void CameraFeedWindows::deactivate_feed(){
 	///@TODO this should deactivate our camera and stop the process of capturing frames

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -155,7 +155,7 @@ void LineBuilder::build() {
 							 texture_mode == Line2D::LINE_TEXTURE_STRETCH;
 	if (distance_required) {
 		total_distance = calculate_total_distance(points);
-		//Ajust totalDistance.
+		//Adjust totalDistance.
 		// The line's outer length will be a little higher due to begin and end caps
 		if (begin_cap_mode == Line2D::LINE_CAP_BOX || begin_cap_mode == Line2D::LINE_CAP_ROUND) {
 			if (retrieve_curve)

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1209,7 +1209,7 @@ bool KinematicBody2D::move_and_collide(const Vector2 &p_motion, bool p_infinite_
 	return colliding;
 }
 
-//so, if you pass 45 as limit, avoid numerical precision erros when angle is 45.
+//so, if you pass 45 as limit, avoid numerical precision errors when angle is 45.
 #define FLOOR_ANGLE_THRESHOLD 0.01
 
 Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_floor_direction, bool p_stop_on_slope, int p_max_slides, float p_floor_max_angle, bool p_infinite_inertia) {

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1137,7 +1137,7 @@ bool KinematicBody::move_and_collide(const Vector3 &p_motion, bool p_infinite_in
 	return colliding;
 }
 
-//so, if you pass 45 as limit, avoid numerical precision erros when angle is 45.
+//so, if you pass 45 as limit, avoid numerical precision errors when angle is 45.
 #define FLOOR_ANGLE_THRESHOLD 0.01
 
 Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Vector3 &p_floor_direction, bool p_stop_on_slope, int p_max_slides, float p_floor_max_angle, bool p_infinite_inertia) {

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -191,7 +191,7 @@ void Tween::_notification(int p_what) {
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			// Are we processing during 'regular' time?
 			if (tween_process_mode == TWEEN_PROCESS_IDLE)
-				// Do nothing since we whould only process during idle time
+				// Do nothing since we would only process during idle time
 				break;
 
 			// Should we update?

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -647,7 +647,7 @@ void TextEdit::_notification(int p_what) {
 			if (scrolling && get_v_scroll() != target_v_scroll) {
 				double target_y = target_v_scroll - get_v_scroll();
 				double dist = sqrt(target_y * target_y);
-				// To ensure minimap is responsive overide the speed setting.
+				// To ensure minimap is responsive override the speed setting.
 				double vel = ((target_y / dist) * ((minimap_clicked) ? 3000 : v_scroll_speed)) * get_physics_process_delta_time();
 
 				if (Math::abs(vel) >= dist) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -328,7 +328,7 @@ void TreeItem::set_collapsed(bool p_collapsed) {
 
 			ci = ci->parent;
 		}
-		if (ci) { // collapsing cursor/selectd, move it!
+		if (ci) { // collapsing cursor/selected, move it!
 
 			if (tree->select_mode == Tree::SELECT_MULTI) {
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -461,7 +461,7 @@ void VisualServerViewport::viewport_set_render_direct_to_screen(RID p_viewport, 
 	VSG::storage->render_target_set_flag(viewport->render_target, RasterizerStorage::RENDER_TARGET_DIRECT_TO_SCREEN, p_enable);
 	viewport->viewport_render_direct_to_screen = p_enable;
 
-	// if attached to screen already, setup screen size and position, this needs to happen after setting flag to avoid an unneccesary buffer allocation
+	// if attached to screen already, setup screen size and position, this needs to happen after setting flag to avoid an unnecessary buffer allocation
 	if (VSG::rasterizer->is_low_end() && viewport->viewport_to_screen_rect != Rect2() && p_enable) {
 
 		VSG::storage->render_target_set_size(viewport->render_target, viewport->viewport_to_screen_rect.size.x, viewport->viewport_to_screen_rect.size.y);


### PR DESCRIPTION
Found using `codespell -q 3 -S ./thirdparty,*.po -L ang,ba,cas,dof,doubleclick,fave,hist,leapyear,lod,nd,numer,ois,paket,seeked,sinc,switchs,te,uint -D ~/Projects/codespell/codespell_lib/data/dictionary.txt `