### PR TITLE
Android and iPhone location manager implementation

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -162,6 +162,18 @@ void OS::vibrate_handheld(int p_duration_ms) {
 	WARN_PRINTS("vibrate_handheld() only works with Android and iOS");
 }
 
+void OS::request_location(LocationParameter p_location_parameter) {
+	WARN_PRINTS("request_location(LocationParameter p_location_parameter) only works with Android and iOS");
+}
+
+void OS::stop_request_location() {
+	WARN_PRINTS("stop_request_location() only works with Android and iOS");
+}
+
+void OS::update_location(Location p_location) {
+	WARN_PRINTS("update_location(Location p_location) only works with Android and iOS");
+}
+
 bool OS::is_stdout_verbose() const {
 
 	return _verbose_stdout;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -1,5 +1,4 @@
 /*************************************************************************/
-/*************************************************************************/
 /*  os.h                                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
@@ -269,9 +268,8 @@ public:
 	struct LocationParameter {
 		uint64_t interval;
 		uint64_t max_wait_time;
-		uint32_t priority;
 	};
-	
+
 	struct Location {
 		float longitute;
 		float latitude;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -1,4 +1,5 @@
 /*************************************************************************/
+/*************************************************************************/
 /*  os.h                                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
@@ -264,6 +265,26 @@ public:
 	virtual Error kill(const ProcessID &p_pid) = 0;
 	virtual int get_process_id() const;
 	virtual void vibrate_handheld(int p_duration_ms = 500);
+
+	struct LocationParameter {
+		uint64_t interval;
+		uint64_t max_wait_time;
+		uint32_t priority;
+	};
+	
+	struct Location {
+		float longitute;
+		float latitude;
+		float horizontal_accuracy;
+		float vertical_accuracy;
+		float altitude;
+		float speed;
+		uint64_t time;
+	};
+
+	virtual void request_location(LocationParameter p_location_parameter);
+	virtual void stop_request_location();
+	virtual void update_location(Location p_location);
 
 	virtual Error shell_open(String p_uri);
 	virtual Error set_cwd(const String &p_cwd);

--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -36,6 +36,8 @@
 	<string>$camera_usage_description</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$photolibrary_usage_description</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>$location_when_in_usage_description</string>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UIStatusBarHidden</key>

--- a/modules/location/SCsub
+++ b/modules/location/SCsub
@@ -1,0 +1,6 @@
+# SCsub
+
+Import('env')
+
+module_env = env.Clone()
+module_env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/location/SCsub
+++ b/modules/location/SCsub
@@ -1,5 +1,7 @@
 # SCsub
 
+# @author Cagdas Caglak <cagdascaglak@gmail.com>
+
 Import('env')
 
 module_env = env.Clone()

--- a/modules/location/config.py
+++ b/modules/location/config.py
@@ -1,0 +1,12 @@
+# config.py
+
+def can_build(env, platform):
+    return True
+
+def configure(env):
+    if env['platform'] == "android":
+        env.android_add_dependency("implementation 'com.google.android.gms:play-services-location:17.0.0'") # Android location service dependency with androidx
+    if env['platform'] == "iphone":
+        env.Append(LINKFLAGS=['-ObjC', '-framework','CoreLocation'])
+
+    pass

--- a/modules/location/config.py
+++ b/modules/location/config.py
@@ -1,5 +1,7 @@
 # config.py
 
+# @author Cagdas Caglak <cagdascaglak@gmail.com>
+
 def can_build(env, platform):
     return True
 

--- a/modules/location/location_manager.cpp
+++ b/modules/location/location_manager.cpp
@@ -1,0 +1,54 @@
+/* location_manager.cpp */
+
+#include "location_manager.h"
+
+void LocationManager::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("request_location_updates", "location_parameters"), &LocationManager::request_location_updates);
+	ClassDB::bind_method(D_METHOD("stop_request_location"), &LocationManager::stop_request_location);
+
+	ADD_SIGNAL(MethodInfo("on_location_result", PropertyInfo(Variant::OBJECT, "location_result", PROPERTY_HINT_RESOURCE_TYPE, "LocationResult", 0)));
+
+}
+
+void LocationManager::request_location_updates(const Ref<LocationParam> &p_location_param) {
+	Ref<LocationParam> location_param = p_location_param;
+	OS::LocationParameter location_parameter;
+	location_parameter.interval = location_param->get_interval();
+	location_parameter.max_wait_time = location_param->get_max_wait_time();
+	location_parameter.priority = 100;
+
+	OS::get_singleton()->request_location(location_parameter);
+}
+
+void LocationManager::stop_request_location() {
+	OS::get_singleton()->stop_request_location();
+}
+
+void LocationManager::_send_location_data(OS::Location location) {
+	location_result->longitude = location.longitute;
+	location_result->latitude = location.latitude;
+	location_result->horizontal_accuracy = location.horizontal_accuracy;
+	location_result->vertical_accuracy = location.vertical_accuracy;
+	location_result->altitude = location.altitude;
+	location_result->speed = location.speed;
+	location_result->time = location.time;
+	emit_signal("on_location_result", location_result);
+}
+
+LocationManager *LocationManager::singleton = NULL;
+
+LocationManager *LocationManager::get_singleton() {
+
+	return singleton;
+}
+
+LocationManager::LocationManager() {
+	singleton = this;
+	
+	location_result = memnew(LocationResult);
+}
+
+LocationManager::~LocationManager() {
+	memdelete(location_result);
+}

--- a/modules/location/location_manager.cpp
+++ b/modules/location/location_manager.cpp
@@ -2,13 +2,16 @@
 
 #include "location_manager.h"
 
+/**
+	@author Cagdas Caglak <cagdascaglak@gmail.com>
+*/
+
 void LocationManager::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("request_location_updates", "location_parameters"), &LocationManager::request_location_updates);
 	ClassDB::bind_method(D_METHOD("stop_request_location"), &LocationManager::stop_request_location);
 
 	ADD_SIGNAL(MethodInfo("on_location_result", PropertyInfo(Variant::OBJECT, "location_result", PROPERTY_HINT_RESOURCE_TYPE, "LocationResult", 0)));
-
 }
 
 void LocationManager::request_location_updates(const Ref<LocationParam> &p_location_param) {
@@ -16,7 +19,6 @@ void LocationManager::request_location_updates(const Ref<LocationParam> &p_locat
 	OS::LocationParameter location_parameter;
 	location_parameter.interval = location_param->get_interval();
 	location_parameter.max_wait_time = location_param->get_max_wait_time();
-	location_parameter.priority = 100;
 
 	OS::get_singleton()->request_location(location_parameter);
 }
@@ -45,7 +47,7 @@ LocationManager *LocationManager::get_singleton() {
 
 LocationManager::LocationManager() {
 	singleton = this;
-	
+
 	location_result = memnew(LocationResult);
 }
 

--- a/modules/location/location_manager.h
+++ b/modules/location/location_manager.h
@@ -1,0 +1,32 @@
+/* location_manager.h */
+
+#ifndef LOCATION_MANAGER_H
+#define LOCATION_MANAGER_H
+
+#include "core/os/main_loop.h"
+#include "core/os/os.h"
+#include "core/os/thread_safe.h"
+#include "location_result.h"
+#include "location_param.h"
+
+class LocationManager : public Object {
+    GDCLASS(LocationManager, Object);
+
+    LocationResult *location_result;
+    static LocationManager *singleton;
+
+protected:
+    static void _bind_methods();
+
+public:
+    static LocationManager *get_singleton();
+
+    void _send_location_data(OS::Location location);
+    void request_location_updates(const Ref<LocationParam> &p_location_param);
+    void stop_request_location();
+    LocationManager();
+    ~LocationManager();
+
+};
+
+#endif // LOCATION_MANAGER_H

--- a/modules/location/location_manager.h
+++ b/modules/location/location_manager.h
@@ -6,27 +6,30 @@
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/os/thread_safe.h"
-#include "location_result.h"
 #include "location_param.h"
+#include "location_result.h"
+
+/**
+	@author Cagdas Caglak <cagdascaglak@gmail.com>
+*/
 
 class LocationManager : public Object {
-    GDCLASS(LocationManager, Object);
+	GDCLASS(LocationManager, Object);
 
-    LocationResult *location_result;
-    static LocationManager *singleton;
+	LocationResult *location_result;
+	static LocationManager *singleton;
 
 protected:
-    static void _bind_methods();
+	static void _bind_methods();
 
 public:
-    static LocationManager *get_singleton();
+	static LocationManager *get_singleton();
 
-    void _send_location_data(OS::Location location);
-    void request_location_updates(const Ref<LocationParam> &p_location_param);
-    void stop_request_location();
-    LocationManager();
-    ~LocationManager();
-
+	void _send_location_data(OS::Location location);
+	void request_location_updates(const Ref<LocationParam> &p_location_param);
+	void stop_request_location();
+	LocationManager();
+	~LocationManager();
 };
 
 #endif // LOCATION_MANAGER_H

--- a/modules/location/location_param.cpp
+++ b/modules/location/location_param.cpp
@@ -1,0 +1,37 @@
+/* location_param.cpp */
+
+#include "location_param.h"
+
+void LocationParam::_bind_methods() {
+
+    ClassDB::bind_method(D_METHOD("get_interval"), &LocationParam::get_interval);
+    ClassDB::bind_method(D_METHOD("get_max_wait_time"), &LocationParam::get_max_wait_time);
+    
+    ClassDB::bind_method(D_METHOD("set_interval"), &LocationParam::set_interval);
+    ClassDB::bind_method(D_METHOD("set_max_wait_time"), &LocationParam::set_max_wait_time);
+	
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "interval"), "set_interval", "get_interval");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "max_wait_time"), "set_max_wait_time", "get_max_wait_time");
+
+}
+
+void LocationParam::set_interval(int p_interval) {
+    interval = p_interval;
+}
+
+void LocationParam::set_max_wait_time(int p_max_wait_time) {
+    max_wait_time = p_max_wait_time;
+}
+
+int LocationParam::get_interval() {
+    return interval;
+}
+
+int LocationParam::get_max_wait_time() {
+    return max_wait_time;
+}
+
+
+LocationParam::LocationParam() {
+
+}

--- a/modules/location/location_param.cpp
+++ b/modules/location/location_param.cpp
@@ -2,36 +2,37 @@
 
 #include "location_param.h"
 
+/**
+	@author Cagdas Caglak <cagdascaglak@gmail.com>
+*/
+
 void LocationParam::_bind_methods() {
 
-    ClassDB::bind_method(D_METHOD("get_interval"), &LocationParam::get_interval);
-    ClassDB::bind_method(D_METHOD("get_max_wait_time"), &LocationParam::get_max_wait_time);
-    
-    ClassDB::bind_method(D_METHOD("set_interval"), &LocationParam::set_interval);
-    ClassDB::bind_method(D_METHOD("set_max_wait_time"), &LocationParam::set_max_wait_time);
-	
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "interval"), "set_interval", "get_interval");
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "max_wait_time"), "set_max_wait_time", "get_max_wait_time");
+	ClassDB::bind_method(D_METHOD("get_interval"), &LocationParam::get_interval);
+	ClassDB::bind_method(D_METHOD("get_max_wait_time"), &LocationParam::get_max_wait_time);
 
+	ClassDB::bind_method(D_METHOD("set_interval"), &LocationParam::set_interval);
+	ClassDB::bind_method(D_METHOD("set_max_wait_time"), &LocationParam::set_max_wait_time);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "interval"), "set_interval", "get_interval");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_wait_time"), "set_max_wait_time", "get_max_wait_time");
 }
 
 void LocationParam::set_interval(int p_interval) {
-    interval = p_interval;
+	interval = p_interval;
 }
 
 void LocationParam::set_max_wait_time(int p_max_wait_time) {
-    max_wait_time = p_max_wait_time;
+	max_wait_time = p_max_wait_time;
 }
 
 int LocationParam::get_interval() {
-    return interval;
+	return interval;
 }
 
 int LocationParam::get_max_wait_time() {
-    return max_wait_time;
+	return max_wait_time;
 }
 
-
 LocationParam::LocationParam() {
-
 }

--- a/modules/location/location_param.h
+++ b/modules/location/location_param.h
@@ -1,0 +1,30 @@
+/* location_param.h */
+
+#ifndef LOCATION_PARAM_H
+#define LOCATION_PARAM_H
+
+#include "core/os/main_loop.h"
+#include "core/os/os.h"
+#include "core/os/thread_safe.h"
+
+class LocationParam : public Resource {
+    GDCLASS(LocationParam, Resource);
+
+    int interval;
+    int max_wait_time;
+
+protected:
+    static void _bind_methods();
+
+public:
+    void set_interval(int p_interval);
+    void set_max_wait_time(int p_max_wait_time);
+
+    int get_interval();
+    int get_max_wait_time();
+
+    LocationParam();
+
+};
+
+#endif // LOCATION_PARAM_H

--- a/modules/location/location_param.h
+++ b/modules/location/location_param.h
@@ -7,24 +7,27 @@
 #include "core/os/os.h"
 #include "core/os/thread_safe.h"
 
-class LocationParam : public Resource {
-    GDCLASS(LocationParam, Resource);
+/**
+	@author Cagdas Caglak <cagdascaglak@gmail.com>
+*/
 
-    int interval;
-    int max_wait_time;
+class LocationParam : public Resource {
+	GDCLASS(LocationParam, Resource);
+
+	int interval;
+	int max_wait_time;
 
 protected:
-    static void _bind_methods();
+	static void _bind_methods();
 
 public:
-    void set_interval(int p_interval);
-    void set_max_wait_time(int p_max_wait_time);
+	void set_interval(int p_interval);
+	void set_max_wait_time(int p_max_wait_time);
 
-    int get_interval();
-    int get_max_wait_time();
+	int get_interval();
+	int get_max_wait_time();
 
-    LocationParam();
-
+	LocationParam();
 };
 
 #endif // LOCATION_PARAM_H

--- a/modules/location/location_result.cpp
+++ b/modules/location/location_result.cpp
@@ -1,0 +1,55 @@
+/* location_result.cpp */
+
+#include "location_result.h"
+
+void LocationResult::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("get_longitude"), &LocationResult::get_longitude);
+    ClassDB::bind_method(D_METHOD("get_latitude"), &LocationResult::get_latitude);
+    ClassDB::bind_method(D_METHOD("get_horizontal_accuracy"), &LocationResult::get_horizontal_accuracy);
+    ClassDB::bind_method(D_METHOD("get_vertical_accuracy"), &LocationResult::get_vertical_accuracy);
+    ClassDB::bind_method(D_METHOD("get_altitude"), &LocationResult::get_altitude);
+    ClassDB::bind_method(D_METHOD("get_speed"), &LocationResult::get_speed);
+    ClassDB::bind_method(D_METHOD("get_time"), &LocationResult::get_time);
+	
+
+    ADD_PROPERTY(PropertyInfo(Variant::REAL, "longitude"), "", "get_longitude");
+    ADD_PROPERTY(PropertyInfo(Variant::REAL, "latitude"), "", "get_latitude");
+    ADD_PROPERTY(PropertyInfo(Variant::REAL, "horizaontal_accuracy"), "", "get_horizontal_accuracy");
+    ADD_PROPERTY(PropertyInfo(Variant::REAL, "vertical_accuracy"), "", "get_vertical_accuracy");
+    ADD_PROPERTY(PropertyInfo(Variant::REAL, "altitude"), "", "get_altitude");
+    ADD_PROPERTY(PropertyInfo(Variant::REAL, "speed"), "", "get_speed");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "time"), "", "get_time");
+
+}
+
+real_t LocationResult::get_longitude() const {
+    return longitude;
+}
+
+real_t LocationResult::get_latitude() const {
+    return latitude;
+}
+
+real_t LocationResult::get_horizontal_accuracy() const {
+    return horizontal_accuracy;
+}
+
+real_t LocationResult::get_vertical_accuracy() const {
+    return vertical_accuracy;
+}
+
+real_t LocationResult::get_altitude() const {
+    return altitude;
+}
+
+real_t LocationResult::get_speed() const {
+    return speed;
+}
+
+uint64_t LocationResult::get_time() const {
+    return time;
+}
+
+LocationResult::LocationResult() {
+
+}

--- a/modules/location/location_result.cpp
+++ b/modules/location/location_result.cpp
@@ -2,54 +2,55 @@
 
 #include "location_result.h"
 
+/**
+	@author Cagdas Caglak <cagdascaglak@gmail.com>
+*/
+
 void LocationResult::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("get_longitude"), &LocationResult::get_longitude);
-    ClassDB::bind_method(D_METHOD("get_latitude"), &LocationResult::get_latitude);
-    ClassDB::bind_method(D_METHOD("get_horizontal_accuracy"), &LocationResult::get_horizontal_accuracy);
-    ClassDB::bind_method(D_METHOD("get_vertical_accuracy"), &LocationResult::get_vertical_accuracy);
-    ClassDB::bind_method(D_METHOD("get_altitude"), &LocationResult::get_altitude);
-    ClassDB::bind_method(D_METHOD("get_speed"), &LocationResult::get_speed);
-    ClassDB::bind_method(D_METHOD("get_time"), &LocationResult::get_time);
-	
+	ClassDB::bind_method(D_METHOD("get_longitude"), &LocationResult::get_longitude);
+	ClassDB::bind_method(D_METHOD("get_latitude"), &LocationResult::get_latitude);
+	ClassDB::bind_method(D_METHOD("get_horizontal_accuracy"), &LocationResult::get_horizontal_accuracy);
+	ClassDB::bind_method(D_METHOD("get_vertical_accuracy"), &LocationResult::get_vertical_accuracy);
+	ClassDB::bind_method(D_METHOD("get_altitude"), &LocationResult::get_altitude);
+	ClassDB::bind_method(D_METHOD("get_speed"), &LocationResult::get_speed);
+	ClassDB::bind_method(D_METHOD("get_time"), &LocationResult::get_time);
 
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "longitude"), "", "get_longitude");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "latitude"), "", "get_latitude");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "horizaontal_accuracy"), "", "get_horizontal_accuracy");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "vertical_accuracy"), "", "get_vertical_accuracy");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "altitude"), "", "get_altitude");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "speed"), "", "get_speed");
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "time"), "", "get_time");
-
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "longitude"), "", "get_longitude");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "latitude"), "", "get_latitude");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "horizaontal_accuracy"), "", "get_horizontal_accuracy");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "vertical_accuracy"), "", "get_vertical_accuracy");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "altitude"), "", "get_altitude");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "speed"), "", "get_speed");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "time"), "", "get_time");
 }
 
 real_t LocationResult::get_longitude() const {
-    return longitude;
+	return longitude;
 }
 
 real_t LocationResult::get_latitude() const {
-    return latitude;
+	return latitude;
 }
 
 real_t LocationResult::get_horizontal_accuracy() const {
-    return horizontal_accuracy;
+	return horizontal_accuracy;
 }
 
 real_t LocationResult::get_vertical_accuracy() const {
-    return vertical_accuracy;
+	return vertical_accuracy;
 }
 
 real_t LocationResult::get_altitude() const {
-    return altitude;
+	return altitude;
 }
 
 real_t LocationResult::get_speed() const {
-    return speed;
+	return speed;
 }
 
 uint64_t LocationResult::get_time() const {
-    return time;
+	return time;
 }
 
 LocationResult::LocationResult() {
-
 }

--- a/modules/location/location_result.h
+++ b/modules/location/location_result.h
@@ -7,39 +7,34 @@
 #include "core/os/os.h"
 #include "core/os/thread_safe.h"
 
+/**
+	@author Cagdas Caglak <cagdascaglak@gmail.com>
+*/
+
 class LocationResult : public Object {
-    GDCLASS(LocationResult, Object);
-
-    /**
-     *
-     * public Reference {
-
-	GDCLASS(LocationResult, Reference);
-	OBJ_CATEGORY("Resources");
-	RES_BASE_EXTENSION("res"); */
+	GDCLASS(LocationResult, Object);
 
 protected:
-    static void _bind_methods();
+	static void _bind_methods();
 
 public:
-    real_t longitude;
-    real_t latitude;
-    real_t horizontal_accuracy;
-    real_t vertical_accuracy;
-    real_t altitude;
-    real_t speed;
-    uint64_t time;
+	real_t longitude;
+	real_t latitude;
+	real_t horizontal_accuracy;
+	real_t vertical_accuracy;
+	real_t altitude;
+	real_t speed;
+	uint64_t time;
 
-    real_t get_longitude() const;
-    real_t get_latitude() const;
-    real_t get_horizontal_accuracy() const;
-    real_t get_vertical_accuracy() const;
-    real_t get_altitude() const;
-    real_t get_speed() const;
-    uint64_t get_time() const;
+	real_t get_longitude() const;
+	real_t get_latitude() const;
+	real_t get_horizontal_accuracy() const;
+	real_t get_vertical_accuracy() const;
+	real_t get_altitude() const;
+	real_t get_speed() const;
+	uint64_t get_time() const;
 
-    LocationResult();
-
+	LocationResult();
 };
 
 #endif // LOCATION_RESULT_H

--- a/modules/location/location_result.h
+++ b/modules/location/location_result.h
@@ -1,0 +1,45 @@
+/* location_result.h */
+
+#ifndef LOCATION_RESULT_H
+#define LOCATION_RESULT_H
+
+#include "core/os/main_loop.h"
+#include "core/os/os.h"
+#include "core/os/thread_safe.h"
+
+class LocationResult : public Object {
+    GDCLASS(LocationResult, Object);
+
+    /**
+     *
+     * public Reference {
+
+	GDCLASS(LocationResult, Reference);
+	OBJ_CATEGORY("Resources");
+	RES_BASE_EXTENSION("res"); */
+
+protected:
+    static void _bind_methods();
+
+public:
+    real_t longitude;
+    real_t latitude;
+    real_t horizontal_accuracy;
+    real_t vertical_accuracy;
+    real_t altitude;
+    real_t speed;
+    uint64_t time;
+
+    real_t get_longitude() const;
+    real_t get_latitude() const;
+    real_t get_horizontal_accuracy() const;
+    real_t get_vertical_accuracy() const;
+    real_t get_altitude() const;
+    real_t get_speed() const;
+    uint64_t get_time() const;
+
+    LocationResult();
+
+};
+
+#endif // LOCATION_RESULT_H

--- a/modules/location/register_types.cpp
+++ b/modules/location/register_types.cpp
@@ -1,0 +1,20 @@
+/* register_types.cpp */
+
+#include "register_types.h"
+
+#include "core/class_db.h"
+#include "location_manager.h"
+#include "location_result.h"
+#include "location_param.h"
+#include "core/engine.h"
+
+void register_location_types() {
+    ClassDB::register_class<LocationManager>();
+    ClassDB::register_class<LocationResult>();
+    ClassDB::register_class<LocationParam>();
+    Engine::get_singleton()->add_singleton(Engine::Singleton("LocationManager", LocationManager::get_singleton()));
+}
+
+void unregister_location_types() {
+   // Nothing to do here in this example.
+}

--- a/modules/location/register_types.cpp
+++ b/modules/location/register_types.cpp
@@ -3,18 +3,21 @@
 #include "register_types.h"
 
 #include "core/class_db.h"
-#include "location_manager.h"
-#include "location_result.h"
-#include "location_param.h"
 #include "core/engine.h"
+#include "location_manager.h"
+#include "location_param.h"
+#include "location_result.h"
+
+/**
+	@author Cagdas Caglak <cagdascaglak@gmail.com>
+*/
 
 void register_location_types() {
-    ClassDB::register_class<LocationManager>();
-    ClassDB::register_class<LocationResult>();
-    ClassDB::register_class<LocationParam>();
-    Engine::get_singleton()->add_singleton(Engine::Singleton("LocationManager", LocationManager::get_singleton()));
+	ClassDB::register_class<LocationManager>();
+	ClassDB::register_class<LocationResult>();
+	ClassDB::register_class<LocationParam>();
+	Engine::get_singleton()->add_singleton(Engine::Singleton("LocationManager", LocationManager::get_singleton()));
 }
 
 void unregister_location_types() {
-   // Nothing to do here in this example.
 }

--- a/modules/location/register_types.h
+++ b/modules/location/register_types.h
@@ -1,5 +1,8 @@
 /* register_types.h */
 
+/**
+	@author Cagdas Caglak <cagdascaglak@gmail.com>
+*/
+
 void register_location_types();
 void unregister_location_types();
-/* yes, the word in the middle must be the same as the module folder name */

--- a/modules/location/register_types.h
+++ b/modules/location/register_types.h
@@ -1,0 +1,5 @@
+/* register_types.h */
+
+void register_location_types();
+void unregister_location_types();
+/* yes, the word in the middle must be the same as the module folder name */

--- a/platform/android/java/gradle.properties
+++ b/platform/android/java/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/platform/android/java/src/com/google/android/vending/expansion/downloader/impl/DownloadNotification.java
+++ b/platform/android/java/src/com/google/android/vending/expansion/downloader/impl/DownloadNotification.java
@@ -25,9 +25,8 @@ import com.google.android.vending.expansion.downloader.IDownloaderClient;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
-import android.os.Build;
 import android.os.Messenger;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 
 /**
  * This class handles displaying the notification associated with the download

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -352,11 +352,11 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		}
 	}
 
-	public void startPeriodicLocationUpdate(final long interval, final long maxWaitTime, final int priority) {
+	public void startPeriodicLocationUpdate(final long interval, final long maxWaitTime) {
 		runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
-				locationManager.startLocationUpdates(interval, maxWaitTime, priority);
+				locationManager.startLocationUpdates(interval, maxWaitTime);
 			}
 		});
 	}

--- a/platform/android/java/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotLib.java
@@ -70,8 +70,7 @@ public class GodotLib {
 	public static native void callobject(int p_ID, String p_method, Object[] p_params);
 	public static native void calldeferred(int p_ID, String p_method, Object[] p_params);
 	public static native void requestPermissionResult(String p_permission, boolean p_result);
-	public static native void updateLocation(float p_longitude, float p_latitude, float p_h_accuracy,
-											 float p_v_accuracy, float p_altitude, float p_speed, long p_time);
+	public static native void updateLocation(float p_longitude, float p_latitude, float p_h_accuracy, float p_v_accuracy, float p_altitude, float p_speed, long p_time);
 
 	public static native void setVirtualKeyboardHeight(int p_height);
 }

--- a/platform/android/java/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotLib.java
@@ -70,6 +70,8 @@ public class GodotLib {
 	public static native void callobject(int p_ID, String p_method, Object[] p_params);
 	public static native void calldeferred(int p_ID, String p_method, Object[] p_params);
 	public static native void requestPermissionResult(String p_permission, boolean p_result);
+	public static native void updateLocation(float p_longitude, float p_latitude, float p_h_accuracy,
+											 float p_v_accuracy, float p_altitude, float p_speed, long p_time);
 
 	public static native void setVirtualKeyboardHeight(int p_height);
 }

--- a/platform/android/java/src/org/godotengine/godot/GodotLocationManager.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotLocationManager.java
@@ -69,7 +69,7 @@ public class GodotLocationManager {
 
     }
 
-    void startLocationUpdates(long interval, long maxWaitTime, int priority) {
+    void startLocationUpdates(long interval, long maxWaitTime) {
         if (locationUpdatesStart)
             return;
 
@@ -84,20 +84,7 @@ public class GodotLocationManager {
         LocationRequest request = new LocationRequest();
         request.setInterval(interval);
         request.setMaxWaitTime(maxWaitTime);
-
-        switch (priority) {
-            case LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY:
-                request.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
-                break;
-            case LocationRequest.PRIORITY_LOW_POWER:
-                request.setPriority(LocationRequest.PRIORITY_LOW_POWER);
-                break;
-            case LocationRequest.PRIORITY_NO_POWER:
-                request.setPriority(LocationRequest.PRIORITY_NO_POWER);
-                break;
-            default:
-                request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
-        }
+        request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
 
         mFusedLocationClient.requestLocationUpdates(request,
                 mLocationCallback, null);

--- a/platform/android/java/src/org/godotengine/godot/GodotLocationManager.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotLocationManager.java
@@ -1,0 +1,115 @@
+package org.godotengine.godot;
+
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.util.Log;
+
+import androidx.core.content.ContextCompat;
+
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
+
+public class GodotLocationManager {
+
+    public static final String ACCESS_COARSE_LOCATION_PERMISSION = "ACCESS_COARSE_LOCATION";
+    public static final String ACCESS_FINE_LOCATION_PERMISSION = "ACCESS_FINE_LOCATION";
+
+    private static GodotLocationManager singleton;
+    private Godot mActivity;
+    private LocationCallback mLocationCallback;
+    private FusedLocationProviderClient mFusedLocationClient;
+    private boolean locationUpdatesStart = false;
+
+    private GodotLocationManager(Godot activity) {
+        this.mActivity = activity;
+        mFusedLocationClient = LocationServices.getFusedLocationProviderClient(activity);
+    }
+
+    static GodotLocationManager getInstance(Godot activity) {
+        if (singleton == null)
+            singleton = new GodotLocationManager(activity);
+        return singleton;
+    }
+
+    private void initializeLocationCallback() {
+        if (mActivity == null)
+            return;
+
+        locationUpdatesStart = true;
+        mLocationCallback = new LocationCallback() {
+            @Override
+            public void onLocationResult(LocationResult locationResult) {
+                if (locationResult == null || locationResult.getLastLocation() == null) {
+                    Log.d("GODOT", "Location object is null.");
+                    return;
+                }
+
+                Location location = locationResult.getLastLocation();
+                double longitude = location.getLongitude();
+                double latitude = location.getLatitude();
+                float accuracy = location.getAccuracy();
+                float verticalAccuracyMeters = 0.0f;
+                double altitude = location.getAltitude();
+                float speed = location.getSpeed();
+                long time = location.getTime();
+
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                    verticalAccuracyMeters = location.getVerticalAccuracyMeters();
+                }
+
+                GodotLib.updateLocation((float) longitude, (float) latitude, accuracy, verticalAccuracyMeters,
+                        (float) altitude, speed, time);
+
+            }
+        };
+
+    }
+
+    void startLocationUpdates(long interval, long maxWaitTime, int priority) {
+        if (locationUpdatesStart)
+            return;
+
+        if (ContextCompat.checkSelfPermission(mActivity,
+                Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            Log.d("GODOT", "If you want to location requests, you need to give permission \"ACCESS_FINE_LOCATION\".");
+            return;
+        }
+
+        initializeLocationCallback();
+
+        LocationRequest request = new LocationRequest();
+        request.setInterval(interval);
+        request.setMaxWaitTime(maxWaitTime);
+
+        switch (priority) {
+            case LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY:
+                request.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+                break;
+            case LocationRequest.PRIORITY_LOW_POWER:
+                request.setPriority(LocationRequest.PRIORITY_LOW_POWER);
+                break;
+            case LocationRequest.PRIORITY_NO_POWER:
+                request.setPriority(LocationRequest.PRIORITY_NO_POWER);
+                break;
+            default:
+                request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+        }
+
+        mFusedLocationClient.requestLocationUpdates(request,
+                mLocationCallback, null);
+        Log.d("GODOT", "Location update started.");
+    }
+
+    void stopLocationUpdates() {
+        if (locationUpdatesStart && mLocationCallback != null) {
+            locationUpdatesStart = false;
+            mFusedLocationClient.removeLocationUpdates(mLocationCallback);
+            Log.d("GODOT", "Location update stopped.");
+        }
+    }
+
+}

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -761,9 +761,9 @@ static void _vibrate(int p_duration_ms) {
 	env->CallVoidMethod(_godot_instance, _vibrateDevice, p_duration_ms);
 }
 
-static void _start_periodic_location(uint64_t p_interval, uint64_t p_max_wait_time, uint32_t p_priority) {
+static void _start_periodic_location(uint64_t p_interval, uint64_t p_max_wait_time) {
 	JNIEnv *env = ThreadAndroid::get_env();
-	env->CallVoidMethod(_godot_instance, _start_periodic_location_update, p_interval, p_max_wait_time, p_priority);
+	env->CallVoidMethod(_godot_instance, _start_periodic_location_update, p_interval, p_max_wait_time);
 }
 
 static void _stop_periodic_location() {
@@ -817,7 +817,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *en
 		_setClipboard = env->GetMethodID(cls, "setClipboard", "(Ljava/lang/String;)V");
 		_requestPermission = env->GetMethodID(cls, "requestPermission", "(Ljava/lang/String;)Z");
 		_vibrateDevice = env->GetMethodID(cls, "vibrate", "(I)V");
-		_start_periodic_location_update = env->GetMethodID(cls, "startPeriodicLocationUpdate", "(JJI)V");
+		_start_periodic_location_update = env->GetMethodID(cls, "startPeriodicLocationUpdate", "(JJ)V");
 		_stop_periodic_location_update = env->GetMethodID(cls, "stopPeriodicLocationUpdate", "()V");
 		if (cls) {
 			jclass c = env->GetObjectClass(gob);
@@ -1608,7 +1608,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResu
 	}
 }
 
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_updateLocation(JNIEnv *env, jobject p_obj, jfloat p_longitude, jfloat p_latitude, jfloat p_h_accuracy,jfloat p_v_accuracy, jfloat p_altitude, jfloat p_speed, jlong p_time) {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_updateLocation(JNIEnv *env, jobject p_obj, jfloat p_longitude, jfloat p_latitude, jfloat p_h_accuracy, jfloat p_v_accuracy, jfloat p_altitude, jfloat p_speed, jlong p_time) {
 	OS::Location location;
 	location.longitute = p_longitude;
 	location.latitude = p_latitude;

--- a/platform/android/java_glue.h
+++ b/platform/android/java_glue.h
@@ -61,7 +61,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *en
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *env, jobject p_obj, jint ID, jstring method, jobjectArray params);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setVirtualKeyboardHeight(JNIEnv *env, jobject obj, jint p_height);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResult(JNIEnv *env, jobject p_obj, jstring p_permission, jboolean p_result);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_updateLocation(JNIEnv *env, jobject p_obj, jfloat p_longitude, jfloat p_latitude, jfloat p_h_accuracy,jfloat p_v_accuracy, jfloat p_altitude, jfloat p_speed, jlong p_time);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_updateLocation(JNIEnv *env, jobject p_obj, jfloat p_longitude, jfloat p_latitude, jfloat p_h_accuracy, jfloat p_v_accuracy, jfloat p_altitude, jfloat p_speed, jlong p_time);
 }
 
 #endif // JAVA_GLUE_H

--- a/platform/android/java_glue.h
+++ b/platform/android/java_glue.h
@@ -61,6 +61,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *en
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *env, jobject p_obj, jint ID, jstring method, jobjectArray params);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setVirtualKeyboardHeight(JNIEnv *env, jobject obj, jint p_height);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResult(JNIEnv *env, jobject p_obj, jstring p_permission, jboolean p_result);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_updateLocation(JNIEnv *env, jobject p_obj, jfloat p_longitude, jfloat p_latitude, jfloat p_h_accuracy,jfloat p_v_accuracy, jfloat p_altitude, jfloat p_speed, jlong p_time);
 }
 
 #endif // JAVA_GLUE_H

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -175,6 +175,7 @@ Error OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int
 	input = memnew(InputDefault);
 	input->set_fallback_mapping("Default Android Gamepad");
 
+	location_manager = memnew(LocationManager);
 	//power_manager = memnew(PowerAndroid);
 
 	return OK;
@@ -193,6 +194,7 @@ void OS_Android::delete_main_loop() {
 
 void OS_Android::finalize() {
 	memdelete(input);
+	memdelete(location_manager);
 }
 
 void OS_Android::alert(const String &p_alert, const String &p_title) {
@@ -703,6 +705,22 @@ void OS_Android::vibrate_handheld(int p_duration_ms) {
 		vibrate_func(p_duration_ms);
 }
 
+void OS_Android::request_location(LocationParameter p_location_parameter) {
+	if (start_periodic_location_func) {
+		start_periodic_location_func(p_location_parameter.interval, p_location_parameter.max_wait_time, p_location_parameter.priority);
+	}
+}
+
+void OS_Android::stop_request_location() {
+	if (stop_periodic_location_func) {
+		stop_periodic_location_func();
+	}
+}
+
+void OS_Android::update_location(Location p_location) {
+	LocationManager::get_singleton()->_send_location_data(p_location);
+}
+
 bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 	if (p_feature == "mobile") {
 		//TODO support etc2 only if GLES3 driver is selected
@@ -724,7 +742,7 @@ bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 	return false;
 }
 
-OS_Android::OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetUserDataDirFunc p_get_user_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, GetGLVersionCodeFunc p_get_gl_version_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, SetClipboardFunc p_set_clipboard_func, GetClipboardFunc p_get_clipboard_func, RequestPermissionFunc p_request_permission, VibrateFunc p_vibrate_func, bool p_use_apk_expansion) {
+OS_Android::OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetUserDataDirFunc p_get_user_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, GetGLVersionCodeFunc p_get_gl_version_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, SetClipboardFunc p_set_clipboard_func, GetClipboardFunc p_get_clipboard_func, RequestPermissionFunc p_request_permission, VibrateFunc p_vibrate_func, StartPeriodicLocationFunc p_start_periodic_location_func, StopPeriodicLocationFunc p_stop_periodic_location_func, bool p_use_apk_expansion) {
 
 	use_apk_expansion = p_use_apk_expansion;
 	default_videomode.width = 800;
@@ -765,6 +783,8 @@ OS_Android::OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURI
 	alert_func = p_alert_func;
 	request_permission_func = p_request_permission;
 	vibrate_func = p_vibrate_func;
+	start_periodic_location_func = p_start_periodic_location_func;
+	stop_periodic_location_func = p_stop_periodic_location_func;
 
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(AndroidLogger));

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -707,7 +707,7 @@ void OS_Android::vibrate_handheld(int p_duration_ms) {
 
 void OS_Android::request_location(LocationParameter p_location_parameter) {
 	if (start_periodic_location_func) {
-		start_periodic_location_func(p_location_parameter.interval, p_location_parameter.max_wait_time, p_location_parameter.priority);
+		start_periodic_location_func(p_location_parameter.interval, p_location_parameter.max_wait_time);
 	}
 }
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -40,6 +40,7 @@
 //#include "power_android.h"
 #include "servers/audio_server.h"
 #include "servers/visual/rasterizer.h"
+#include "modules/location/location_manager.h"
 
 typedef void (*GFXInitFunc)(void *ud, bool gl2);
 typedef int (*OpenURIFunc)(const String &);
@@ -65,6 +66,8 @@ typedef void (*AlertFunc)(const String &, const String &);
 typedef int (*VirtualKeyboardHeightFunc)();
 typedef bool (*RequestPermissionFunc)(const String &);
 typedef void (*VibrateFunc)(int);
+typedef void (*StartPeriodicLocationFunc)(uint64_t, uint64_t, uint32_t);
+typedef void (*StopPeriodicLocationFunc)();
 
 class OS_Android : public OS_Unix {
 public:
@@ -112,6 +115,7 @@ private:
 	InputDefault *input;
 	VideoMode default_videomode;
 	MainLoop *main_loop;
+	LocationManager *location_manager;
 
 	OpenURIFunc open_uri_func;
 	GetUserDataDirFunc get_user_data_dir_func;
@@ -136,6 +140,8 @@ private:
 	AlertFunc alert_func;
 	RequestPermissionFunc request_permission_func;
 	VibrateFunc vibrate_func;
+	StartPeriodicLocationFunc start_periodic_location_func;
+	StopPeriodicLocationFunc stop_periodic_location_func;
 
 	//PowerAndroid *power_manager;
 	int video_driver_index;
@@ -242,9 +248,12 @@ public:
 	virtual String get_joy_guid(int p_device) const;
 	void joy_connection_changed(int p_device, bool p_connected, String p_name);
 	void vibrate_handheld(int p_duration_ms = 500);
+	virtual void request_location(LocationParameter p_location_parameter);
+	virtual void stop_request_location();
+	virtual void update_location(Location p_location);
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
-	OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetUserDataDirFunc p_get_user_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, GetGLVersionCodeFunc p_get_gl_version_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, SetClipboardFunc p_set_clipboard, GetClipboardFunc p_get_clipboard, RequestPermissionFunc p_request_permission, VibrateFunc p_vibrate_func, bool p_use_apk_expansion);
+	OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetUserDataDirFunc p_get_user_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, GetGLVersionCodeFunc p_get_gl_version_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, SetClipboardFunc p_set_clipboard, GetClipboardFunc p_get_clipboard, RequestPermissionFunc p_request_permission, VibrateFunc p_vibrate_func, StartPeriodicLocationFunc p_start_periodic_location_func, StopPeriodicLocationFunc p_stop_periodic_location_func, bool p_use_apk_expansion);
 	~OS_Android();
 };
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -38,9 +38,9 @@
 #include "drivers/unix/os_unix.h"
 #include "main/input_default.h"
 //#include "power_android.h"
+#include "modules/location/location_manager.h"
 #include "servers/audio_server.h"
 #include "servers/visual/rasterizer.h"
-#include "modules/location/location_manager.h"
 
 typedef void (*GFXInitFunc)(void *ud, bool gl2);
 typedef int (*OpenURIFunc)(const String &);
@@ -66,7 +66,7 @@ typedef void (*AlertFunc)(const String &, const String &);
 typedef int (*VirtualKeyboardHeightFunc)();
 typedef bool (*RequestPermissionFunc)(const String &);
 typedef void (*VibrateFunc)(int);
-typedef void (*StartPeriodicLocationFunc)(uint64_t, uint64_t, uint32_t);
+typedef void (*StartPeriodicLocationFunc)(uint64_t, uint64_t);
 typedef void (*StopPeriodicLocationFunc)();
 
 class OS_Android : public OS_Unix {

--- a/platform/iphone/app_delegate.h
+++ b/platform/iphone/app_delegate.h
@@ -32,8 +32,8 @@
 #import "view_controller.h"
 #import <UIKit/UIKit.h>
 
-#import <CoreMotion/CoreMotion.h>
 #import <CoreLocation/CoreLocation.h>
+#import <CoreMotion/CoreMotion.h>
 
 @interface AppDelegate : NSObject <UIApplicationDelegate, GLViewDelegate, CLLocationManagerDelegate> {
 	//@property (strong, nonatomic) UIWindow *window;

--- a/platform/iphone/app_delegate.h
+++ b/platform/iphone/app_delegate.h
@@ -33,8 +33,9 @@
 #import <UIKit/UIKit.h>
 
 #import <CoreMotion/CoreMotion.h>
+#import <CoreLocation/CoreLocation.h>
 
-@interface AppDelegate : NSObject <UIApplicationDelegate, GLViewDelegate> {
+@interface AppDelegate : NSObject <UIApplicationDelegate, GLViewDelegate, CLLocationManagerDelegate> {
 	//@property (strong, nonatomic) UIWindow *window;
 	ViewController *view_controller;
 	bool is_focus_out;

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -106,7 +106,6 @@ void _start_location_update() {
 			NSLog(@"Location update started.");
 			break;
 	}
-	
 }
 
 void _stop_location_update() {
@@ -732,12 +731,12 @@ static int frame_count = 0;
 
 	// prevent to stop music in another background app
 	[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
-    
+
 	return TRUE;
 };
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
-    CLLocation *lastLoc = [locations lastObject];
+	CLLocation *lastLoc = [locations lastObject];
 
 	OS::Location location;
 	location.longitute = lastLoc.coordinate.latitude;
@@ -747,7 +746,7 @@ static int frame_count = 0;
 	location.altitude = lastLoc.altitude;
 	location.speed = lastLoc.speed;
 	location.time = [[NSNumber numberWithDouble:[lastLoc.timestamp timeIntervalSince1970]] unsignedLongLongValue];
-	
+
 	OSIPhone::get_singleton()->update_location(location);
 }
 

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -270,6 +270,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/camera_usage_description"), "Godot would like to use your camera"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/photolibrary_usage_description"), "Godot would like to use your photos"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/location_when_in_usage_description"), "Godot would like to use when in use your location"));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/portrait"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/landscape_left"), true));
@@ -401,6 +402,9 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].find("$photolibrary_usage_description") != -1) {
 			String description = p_preset->get("privacy/photolibrary_usage_description");
 			strnew += lines[i].replace("$photolibrary_usage_description", description) + "\n";
+		} else if (lines[i].find("$location_when_in_usage_description") != -1) {
+			String description = p_preset->get("privacy/location_when_in_usage_description");
+			strnew += lines[i].replace("$location_when_in_usage_description", description) + "\n";
 		} else {
 			strnew += lines[i] + "\n";
 		}

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -166,6 +166,7 @@ Error OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p
 	AudioDriverManager::initialize(p_audio_driver);
 
 	input = memnew(InputDefault);
+    location_manager = memnew(LocationManager);
 
 #ifdef GAME_CENTER_ENABLED
 	game_center = memnew(GameCenter);
@@ -366,6 +367,7 @@ void OSIPhone::finalize() {
 	//	memdelete(rasterizer);
 
 	memdelete(input);
+    memdelete(location_manager);
 };
 
 void OSIPhone::set_mouse_show(bool p_show){};
@@ -393,6 +395,12 @@ void OSIPhone::alert(const String &p_alert, const String &p_title) {
 	const CharString utf8_alert = p_alert.utf8();
 	const CharString utf8_title = p_title.utf8();
 	iOS::alert(utf8_alert.get_data(), utf8_title.get_data());
+}
+
+extern bool _request_permission(String p_name);
+
+bool OSIPhone::request_permission(const String &p_name) {
+	return _request_permission(p_name);
 }
 
 Error OSIPhone::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path) {
@@ -465,6 +473,8 @@ extern void _hide_keyboard();
 extern Error _shell_open(String p_uri);
 extern void _set_keep_screen_on(bool p_enabled);
 extern void _vibrate();
+extern void _start_location_update();
+extern void _stop_location_update();
 
 void OSIPhone::show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect) {
 	_show_keyboard(p_existing_text);
@@ -589,6 +599,18 @@ void OSIPhone::native_video_stop() {
 void OSIPhone::vibrate_handheld(int p_duration_ms) {
 	// iOS does not support duration for vibration
 	_vibrate();
+}
+
+void OSIPhone::request_location(LocationParameter p_location_parameter) {
+    _start_location_update();
+}
+
+void OSIPhone::stop_request_location() {
+    _stop_location_update();
+}
+
+void OSIPhone::update_location(Location p_location) {
+	LocationManager::get_singleton()->_send_location_data(p_location);
 }
 
 bool OSIPhone::_check_internal_feature_support(const String &p_feature) {

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -166,7 +166,7 @@ Error OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p
 	AudioDriverManager::initialize(p_audio_driver);
 
 	input = memnew(InputDefault);
-    location_manager = memnew(LocationManager);
+	location_manager = memnew(LocationManager);
 
 #ifdef GAME_CENTER_ENABLED
 	game_center = memnew(GameCenter);
@@ -367,7 +367,7 @@ void OSIPhone::finalize() {
 	//	memdelete(rasterizer);
 
 	memdelete(input);
-    memdelete(location_manager);
+	memdelete(location_manager);
 };
 
 void OSIPhone::set_mouse_show(bool p_show){};
@@ -602,11 +602,11 @@ void OSIPhone::vibrate_handheld(int p_duration_ms) {
 }
 
 void OSIPhone::request_location(LocationParameter p_location_parameter) {
-    _start_location_update();
+	_start_location_update();
 }
 
 void OSIPhone::stop_request_location() {
-    _stop_location_update();
+	_stop_location_update();
 }
 
 void OSIPhone::update_location(Location p_location) {

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -44,6 +44,7 @@
 #include "servers/audio_server.h"
 #include "servers/visual/rasterizer.h"
 #include "servers/visual_server.h"
+#include "modules/location/location_manager.h"
 
 class OSIPhone : public OS_Unix {
 
@@ -71,6 +72,7 @@ private:
 #endif
 
 	MainLoop *main_loop;
+    LocationManager *location_manager;
 
 	VideoMode video_mode;
 
@@ -149,6 +151,7 @@ public:
 	virtual void set_window_title(const String &p_title);
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
+	virtual bool request_permission(const String &p_name);
 
 	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
 	virtual Error close_dynamic_library(void *p_library_handle);
@@ -196,6 +199,9 @@ public:
 	virtual void native_video_focus_out();
 	virtual void native_video_stop();
 	virtual void vibrate_handheld(int p_duration_ms = 500);
+    virtual void request_location(LocationParameter p_location_parameter);
+	virtual void stop_request_location();
+	virtual void update_location(Location p_location);
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
 	OSIPhone(int width, int height, String p_data_dir);

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -41,10 +41,10 @@
 #include "icloud.h"
 #include "in_app_store.h"
 #include "main/input_default.h"
+#include "modules/location/location_manager.h"
 #include "servers/audio_server.h"
 #include "servers/visual/rasterizer.h"
 #include "servers/visual_server.h"
-#include "modules/location/location_manager.h"
 
 class OSIPhone : public OS_Unix {
 
@@ -72,7 +72,7 @@ private:
 #endif
 
 	MainLoop *main_loop;
-    LocationManager *location_manager;
+	LocationManager *location_manager;
 
 	VideoMode video_mode;
 
@@ -199,7 +199,7 @@ public:
 	virtual void native_video_focus_out();
 	virtual void native_video_stop();
 	virtual void vibrate_handheld(int p_duration_ms = 500);
-    virtual void request_location(LocationParameter p_location_parameter);
+	virtual void request_location(LocationParameter p_location_parameter);
 	virtual void stop_request_location();
 	virtual void update_location(Location p_location);
 


### PR DESCRIPTION
### Android 
I have implement **Fused Location Provider Client** for get user locations and make creative games like Pokemon. With this implementation I have to migrate Android project to AndroidX because of latest location library has androidx libraries and it gives errors while compiling java project. In additional I have implement **ACCESS_COARSE_LOCATION** and **ACCESS_FINE_LOCATION** permissions.

### iPhone
I have implement **CLLocationManager** for get user locations and make creative games like Pokemon. In iPhone you need to ask location usage permission to user so I have implement `request_permission(const String &p_name)` method to iPhone such as Android and add `NSLocationWhenInUseUsageDescription` check box to export options.

### Comments
This is basic implementation and I opened this PR to see missing things such as true implementation of `LocationManager`, `LocationParam`, `LocationResult`, memory usage(memnew and memdelete) and module definition and usage. After if review is okay, I will add documentation. I will push commits for master branch.

### Sample Project
You can test this branch with [this sample project](https://github.com/cagdasc/godot-samples)

Thank you.
Cagdas.

*Bugsquad edit:* This closes https://github.com/godotengine/godot-proposals/issues/57.