### PR TITLE
Display the current zoom percentage in the 2D editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3678,7 +3678,6 @@ void CanvasItemEditor::_notification(int p_what) {
 		key_auto_insert_button->set_icon(get_icon("AutoKey", "EditorIcons"));
 
 		zoom_minus->set_icon(get_icon("ZoomLess", "EditorIcons"));
-		zoom_reset->set_icon(get_icon("ZoomReset", "EditorIcons"));
 		zoom_plus->set_icon(get_icon("ZoomMore", "EditorIcons"));
 
 		presets_menu->set_icon(get_icon("ControlLayout", "EditorIcons"));
@@ -4036,7 +4035,20 @@ void CanvasItemEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
 	view_offset.x = Math::round(view_offset.x + ofs.x);
 	view_offset.y = Math::round(view_offset.y + ofs.y);
 
+	_update_zoom_label();
 	update_viewport();
+}
+
+void CanvasItemEditor::_update_zoom_label() {
+	String zoom_text;
+	if (zoom >= 10) {
+		// Don't show a decimal when the zoom level is higher than 1000 %
+		zoom_text = rtos(Math::round(zoom * 100)) + " %";
+	} else {
+		zoom_text = rtos(Math::stepify(zoom * 100, 0.1)) + " %";
+	}
+
+	zoom_reset->set_text(zoom_text);
 }
 
 void CanvasItemEditor::_button_zoom_minus() {
@@ -4811,6 +4823,7 @@ void CanvasItemEditor::set_state(const Dictionary &p_state) {
 	Dictionary state = p_state;
 	if (state.has("zoom")) {
 		zoom = p_state["zoom"];
+		_update_zoom_label();
 	}
 
 	if (state.has("ofs")) {
@@ -5128,6 +5141,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	zoom_hb = memnew(HBoxContainer);
 	viewport->add_child(zoom_hb);
 	zoom_hb->set_begin(Point2(5, 5));
+	// Bring the zoom percentage closer to the zoom buttons
+	zoom_hb->add_constant_override("separation", Math::round(-8 * EDSCALE));
 
 	zoom_minus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_minus);
@@ -5140,6 +5155,9 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	zoom_reset->connect("pressed", this, "_button_zoom_reset");
 	zoom_reset->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_reset", TTR("Zoom Reset"), KEY_MASK_CMD | KEY_0));
 	zoom_reset->set_focus_mode(FOCUS_NONE);
+	zoom_reset->set_text_align(Button::TextAlign::ALIGN_CENTER);
+	// Prevent the button's size from changing when the text size changes
+	zoom_reset->set_custom_minimum_size(Size2(75 * EDSCALE, 0));
 
 	zoom_plus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_plus);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -525,6 +525,7 @@ private:
 
 	HBoxContainer *zoom_hb;
 	void _zoom_on_position(float p_zoom, Point2 p_position = Point2());
+	void _update_zoom_label();
 	void _button_zoom_minus();
 	void _button_zoom_reset();
 	void _button_zoom_plus();


### PR DESCRIPTION
This makes it possible for the user to know precisely the current zoom level. The zoom percentage can be clicked to reset it to 100% (similar to Firefox). This can be useful when working on projects that require frequent zooming, such as games using a pixel art style.

## Preview

### New version with reduced spacing

![image](https://user-images.githubusercontent.com/180032/65069387-e0199d00-d98a-11e9-8b99-cd399b5d1e24.png)

<details>
<summary>Old version</summary>

![image](https://user-images.githubusercontent.com/180032/65012487-cee37880-d917-11e9-98ed-2618f2d890f0.png)
</details>

