### PR TITLE
Fix region editor for NinePatchRect

### DIFF
--- a/doc/classes/NinePatchRect.xml
+++ b/doc/classes/NinePatchRect.xml
@@ -51,7 +51,7 @@
 			The height of the 9-slice's top row.
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2( 0, 0, 0, 0 )">
-			Rectangular region of the texture to sample from. If you're working with an atlas, use this property to define the area the 9-slice should use. All other properties are relative to this one.
+			Rectangular region of the texture to sample from. If you're working with an atlas, use this property to define the area the 9-slice should use. All other properties are relative to this one. If the rect is empty, NinePatchRect will use the whole texture.
 		</member>
 		<member name="texture" type="Texture" setter="set_texture" getter="get_texture">
 			The node's texture resource.

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -625,9 +625,12 @@ void TextureRegionEditor::_update_rect() {
 		rect = node_sprite->get_region_rect();
 	else if (node_sprite_3d)
 		rect = node_sprite_3d->get_region_rect();
-	else if (node_ninepatch)
+	else if (node_ninepatch) {
 		rect = node_ninepatch->get_region_rect();
-	else if (obj_styleBox.is_valid())
+		if (rect == Rect2()) {
+			rect = Rect2(Vector2(), node_ninepatch->get_texture()->get_size());
+		}
+	} else if (obj_styleBox.is_valid())
 		rect = obj_styleBox->get_region_rect();
 	else if (atlas_tex.is_valid())
 		rect = atlas_tex->get_region();


### PR DESCRIPTION
Fixes #28871

The bug was caused by editor using the `region_rect` of NinePatch, which is (0, 0, 0, 0) by default. With empty region NinePatch uses full texture (I also added a doc mention for this behavior).