### PR TITLE
Fix autocompletion undo

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6247,7 +6247,7 @@ void TextEdit::_confirm_completion() {
 	CharType last_completion_char = completion_current.insert_text[completion_current.insert_text.length() - 1];
 
 	if ((last_completion_char == '"' || last_completion_char == '\'') && last_completion_char == next_char) {
-		_base_remove_text(cursor.line, cursor.column, cursor.line, cursor.column + 1);
+		_remove_text(cursor.line, cursor.column, cursor.line, cursor.column + 1);
 	}
 
 	if (last_completion_char == '(') {


### PR DESCRIPTION
Fixes #21068

It has the problem mentioned in https://github.com/godotengine/godot/issues/21068#issuecomment-413520144, but it's rather acceptable (happens only on double undo + redo and doesn't break everything like the original behavior).