### PR TITLE
Fixes crash described in issue 7945 (Duplicated [self drawView] in iphone gl_view)

### DIFF
--- a/platform/iphone/gl_view.mm
+++ b/platform/iphone/gl_view.mm
@@ -337,12 +337,9 @@ static void clear_touches() {
 // the same size as our display area.
 
 - (void)layoutSubviews {
-	//printf("HERE\n");
 	[EAGLContext setCurrentContext:context];
 	[self destroyFramebuffer];
 	[self createFramebuffer];
-	[self drawView];
-	[self drawView];
 }
 
 - (BOOL)createFramebuffer {


### PR DESCRIPTION
This patch fixes https://github.com/godotengine/godot/issues/7945.

I have removed both `[self drawView]` calls in `layoutSubviews` method, because I was able to reproduce the crash if I eliminated only the second (duplicated) call.