### PR TITLE
Fix VideostreamGDNative seek

### DIFF
--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -168,8 +168,12 @@ void VideoStreamPlaybackGDNative::update(float p_delta) {
 		}
 	}
 
-	while (interface->get_playback_position(data_struct) < time && playing) {
+	if (seek_backward) {
+		update_texture();
+		seek_backward = false;
+	}
 
+	while (interface->get_playback_position(data_struct) < time && playing) {
 		update_texture();
 	}
 }
@@ -197,6 +201,7 @@ VideoStreamPlaybackGDNative::VideoStreamPlaybackGDNative() :
 		mix_callback(NULL),
 		num_channels(-1),
 		time(0),
+		seek_backward(false),
 		mix_rate(0),
 		delay_compensation(0),
 		pcm(NULL),
@@ -261,6 +266,13 @@ void VideoStreamPlaybackGDNative::stop() {
 void VideoStreamPlaybackGDNative::seek(float p_time) {
 	ERR_FAIL_COND(interface == NULL);
 	interface->seek(data_struct, p_time);
+	if (p_time < time)
+		seek_backward = true;
+	time = p_time;
+	// reset audio buffers
+	memset(pcm, 0, num_channels * AUX_BUFFER_SIZE * sizeof(float));
+	pcm_write_idx = -1;
+	samples_decoded = 0;
 }
 
 void VideoStreamPlaybackGDNative::set_paused(bool p_paused) {

--- a/modules/gdnative/videodecoder/video_stream_gdnative.h
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.h
@@ -121,6 +121,7 @@ class VideoStreamPlaybackGDNative : public VideoStreamPlayback {
 
 	int num_channels;
 	float time;
+	bool seek_backward;
 	int mix_rate;
 	double delay_compensation;
 


### PR DESCRIPTION
When implementing video seek function based on https://github.com/KidRigger/godot-videodecoder, we should also make sure audio buffers are reset and video time
is updated in video_stream_gdnative.cpp. 