### PR TITLE
Distinguish editor-originating messages in the editor log

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -113,6 +113,10 @@ void EditorLog::add_message(const String &p_msg, MessageType p_type) {
 			log->add_text(" ");
 			tool_button->set_icon(icon);
 		} break;
+		case MSG_TYPE_EDITOR: {
+			// Distinguish editor messages from messages printed by the project
+			log->push_color(get_color("font_color", "Editor") * Color(1, 1, 1, 0.6));
+		} break;
 	}
 
 	log->add_text(p_msg);
@@ -128,7 +132,7 @@ void EditorLog::set_tool_button(ToolButton *p_tool_button) {
 void EditorLog::_undo_redo_cbk(void *p_self, const String &p_name) {
 
 	EditorLog *self = (EditorLog *)p_self;
-	self->add_message(p_name);
+	self->add_message(p_name, EditorLog::MSG_TYPE_EDITOR);
 }
 
 void EditorLog::_bind_methods() {

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -74,7 +74,8 @@ public:
 	enum MessageType {
 		MSG_TYPE_STD,
 		MSG_TYPE_ERROR,
-		MSG_TYPE_WARNING
+		MSG_TYPE_WARNING,
+		MSG_TYPE_EDITOR
 	};
 
 	void add_message(const String &p_msg, MessageType p_type = MSG_TYPE_STD);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2212,27 +2212,27 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case EDIT_UNDO: {
 
 			if (Input::get_singleton()->get_mouse_button_mask() & 0x7) {
-				log->add_message("Can't UNDO while mouse buttons are pressed.");
+				log->add_message("Can't undo while mouse buttons are pressed.", EditorLog::MSG_TYPE_EDITOR);
 			} else {
 				String action = editor_data.get_undo_redo().get_current_action_name();
 
 				if (!editor_data.get_undo_redo().undo()) {
-					log->add_message("There is nothing to UNDO.");
+					log->add_message("Nothing to undo.", EditorLog::MSG_TYPE_EDITOR);
 				} else if (action != "") {
-					log->add_message("UNDO: " + action);
+					log->add_message("Undo: " + action, EditorLog::MSG_TYPE_EDITOR);
 				}
 			}
 		} break;
 		case EDIT_REDO: {
 
 			if (Input::get_singleton()->get_mouse_button_mask() & 0x7) {
-				log->add_message("Can't REDO while mouse buttons are pressed.");
+				log->add_message("Can't redo while mouse buttons are pressed.", EditorLog::MSG_TYPE_EDITOR);
 			} else {
 				if (!editor_data.get_undo_redo().redo()) {
-					log->add_message("There is nothing to REDO.");
+					log->add_message("Nothing to redo.", EditorLog::MSG_TYPE_EDITOR);
 				} else {
 					String action = editor_data.get_undo_redo().get_current_action_name();
-					log->add_message("REDO: " + action);
+					log->add_message("Redo: " + action, EditorLog::MSG_TYPE_EDITOR);
 				}
 			}
 		} break;

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1190,7 +1190,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					if (connection.is_null())
 						break;
 
-					EditorNode::get_log()->add_message("** Debug Process Started **");
+					EditorNode::get_log()->add_message("--- Debugging process started ---", EditorLog::MSG_TYPE_EDITOR);
 
 					ppeer->set_stream_peer(connection);
 
@@ -1200,7 +1200,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					dobreak->set_disabled(false);
 					tabs->set_current_tab(0);
 
-					_set_reason_text(TTR("Child Process Connected"), MESSAGE_SUCCESS);
+					_set_reason_text(TTR("Child process connected."), MESSAGE_SUCCESS);
 					profiler->clear();
 
 					inspect_scene_tree->clear();
@@ -1388,7 +1388,7 @@ void ScriptEditorDebugger::stop() {
 	ppeer->set_stream_peer(Ref<StreamPeer>());
 
 	if (connection.is_valid()) {
-		EditorNode::get_log()->add_message("** Debug Process Stopped **");
+		EditorNode::get_log()->add_message("--- Debugging process stopped ---", EditorLog::MSG_TYPE_EDITOR);
 		connection.unref();
 
 		reason->set_text("");

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -110,7 +110,7 @@ void EditorSettingsDialog::_filter_shortcuts(const String &p_filter) {
 }
 
 void EditorSettingsDialog::_undo_redo_callback(void *p_self, const String &p_name) {
-	EditorNode::get_log()->add_message(p_name);
+	EditorNode::get_log()->add_message(p_name, EditorLog::MSG_TYPE_EDITOR);
 }
 
 void EditorSettingsDialog::_notification(int p_what) {
@@ -151,7 +151,7 @@ void EditorSettingsDialog::_unhandled_input(const Ref<InputEvent> &p_event) {
 			if (ED_IS_SHORTCUT("editor/undo", p_event)) {
 				String action = undo_redo->get_current_action_name();
 				if (action != "")
-					EditorNode::get_log()->add_message("UNDO: " + action);
+					EditorNode::get_log()->add_message("Undo: " + action, EditorLog::MSG_TYPE_EDITOR);
 				undo_redo->undo();
 				handled = true;
 			}
@@ -159,7 +159,7 @@ void EditorSettingsDialog::_unhandled_input(const Ref<InputEvent> &p_event) {
 				undo_redo->redo();
 				String action = undo_redo->get_current_action_name();
 				if (action != "")
-					EditorNode::get_log()->add_message("REDO: " + action);
+					EditorNode::get_log()->add_message("Redo: " + action, EditorLog::MSG_TYPE_EDITOR);
 				handled = true;
 			}
 

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -64,7 +64,7 @@ void GDScriptLanguageServer::thread_main(void *p_userdata) {
 void GDScriptLanguageServer::start() {
 	int port = (int)_EDITOR_GET("network/language_server/remote_port");
 	if (protocol.start(port) == OK) {
-		EditorNode::get_log()->add_message("** GDScript Language Server Started **");
+		EditorNode::get_log()->add_message("--- GDScript language server started ---", EditorLog::MSG_TYPE_EDITOR);
 		ERR_FAIL_COND(thread != NULL || thread_exit);
 		thread_exit = false;
 		thread = Thread::create(GDScriptLanguageServer::thread_main, this);
@@ -78,7 +78,7 @@ void GDScriptLanguageServer::stop() {
 	memdelete(thread);
 	thread = NULL;
 	protocol.stop();
-	EditorNode::get_log()->add_message("** GDScript Language Server Stopped **");
+	EditorNode::get_log()->add_message("--- GDScript language server stopped ---", EditorLog::MSG_TYPE_EDITOR);
 }
 
 void register_lsp_types() {

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1474,8 +1474,8 @@ public:
 		if (use_remote) {
 			if (use_reverse) {
 
-				static const char *const msg = "** Device API >= 21; debugging over USB **";
-				EditorNode::get_singleton()->get_log()->add_message(msg);
+				static const char *const msg = "--- Device API >= 21; debugging over USB ---";
+				EditorNode::get_singleton()->get_log()->add_message(msg, EditorLog::MSG_TYPE_EDITOR);
 				print_line(String(msg).to_upper());
 
 				args.clear();
@@ -1515,8 +1515,8 @@ public:
 				}
 			} else {
 
-				static const char *const msg = "** Device API < 21; debugging over Wi-Fi **";
-				EditorNode::get_singleton()->get_log()->add_message(msg);
+				static const char *const msg = "--- Device API < 21; debugging over Wi-Fi ---";
+				EditorNode::get_singleton()->get_log()->add_message(msg, EditorLog::MSG_TYPE_EDITOR);
 				print_line(String(msg).to_upper());
 			}
 		}


### PR DESCRIPTION
This fades out messages originating from the editor to make messages printed by the project stand out more.

This also tweaks wording in some editor messages for consistency.

## Preview

![Editor log messages](https://user-images.githubusercontent.com/180032/65289270-4bf63400-db4a-11e9-83b2-62c3e4b95056.png)