### PR TITLE
GLTF2 Import Fixes - Skin(s) to Skeleton - Skin Support

### DIFF
--- a/core/math/disjoint_set.cpp
+++ b/core/math/disjoint_set.cpp
@@ -1,0 +1,31 @@
+/*************************************************************************/
+/*  disjoint_set.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "disjoint_set.h"

--- a/core/math/disjoint_set.h
+++ b/core/math/disjoint_set.h
@@ -1,0 +1,155 @@
+/*************************************************************************/
+/*  disjoint_set.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef DISJOINT_SET_H
+#define DISJOINT_SET_H
+
+#include "core/map.h"
+#include "core/vector.h"
+
+/**
+	@author Marios Staikopoulos <marios@staik.net>
+*/
+
+/* This DisjointSet class uses Find with path compression and Union by rank */
+template <typename T, class C = Comparator<T>, class AL = DefaultAllocator>
+class DisjointSet {
+
+	struct Element {
+		T object;
+		Element *parent = nullptr;
+		int rank = 0;
+	};
+
+	typedef Map<T, Element *, C, AL> MapT;
+
+	MapT elements;
+
+	Element *get_parent(Element *element);
+
+	_FORCE_INLINE_ Element *insert_or_get(T object);
+
+public:
+	~DisjointSet();
+
+	_FORCE_INLINE_ void insert(T object) { (void)insert_or_get(object); }
+
+	void create_union(T a, T b);
+
+	void get_representatives(Vector<T> &out_roots);
+
+	void get_members(Vector<T> &out_members, T representative);
+};
+
+/* FUNCTIONS */
+
+template <typename T, class C, class AL>
+DisjointSet<T, C, AL>::~DisjointSet() {
+	for (typename MapT::Element *itr = elements.front(); itr != nullptr; itr = itr->next()) {
+		memdelete_allocator<Element, AL>(itr->value());
+	}
+}
+
+template <typename T, class C, class AL>
+typename DisjointSet<T, C, AL>::Element *DisjointSet<T, C, AL>::get_parent(Element *element) {
+	if (element->parent != element) {
+		element->parent = get_parent(element->parent);
+	}
+
+	return element->parent;
+}
+
+template <typename T, class C, class AL>
+typename DisjointSet<T, C, AL>::Element *DisjointSet<T, C, AL>::insert_or_get(T object) {
+	typename MapT::Element *itr = elements.find(object);
+	if (itr != nullptr) {
+		return itr->value();
+	}
+
+	Element *new_element = memnew_allocator(Element, AL);
+	new_element->object = object;
+	new_element->parent = new_element;
+	elements.insert(object, new_element);
+
+	return new_element;
+}
+
+template <typename T, class C, class AL>
+void DisjointSet<T, C, AL>::create_union(T a, T b) {
+
+	Element *x = insert_or_get(a);
+	Element *y = insert_or_get(b);
+
+	Element *x_root = get_parent(x);
+	Element *y_root = get_parent(y);
+
+	// Already in the same set
+	if (x_root == y_root)
+		return;
+
+	// Not in the same set, merge
+	if (x_root->rank < y_root->rank) {
+		SWAP(x_root, y_root);
+	}
+
+	// Merge y_root into x_root
+	y_root->parent = x_root;
+	if (x_root->rank == y_root->rank) {
+		++x_root->rank;
+	}
+}
+
+template <typename T, class C, class AL>
+void DisjointSet<T, C, AL>::get_representatives(Vector<T> &out_representatives) {
+	for (typename MapT::Element *itr = elements.front(); itr != nullptr; itr = itr->next()) {
+		Element *element = itr->value();
+		if (element->parent == element) {
+			out_representatives.push_back(element->object);
+		}
+	}
+}
+
+template <typename T, class C, class AL>
+void DisjointSet<T, C, AL>::get_members(Vector<T> &out_members, T representative) {
+	typename MapT::Element *rep_itr = elements.find(representative);
+	ERR_FAIL_COND(rep_itr == nullptr);
+
+	Element *rep_element = rep_itr->value();
+	ERR_FAIL_COND(rep_element->parent != rep_element);
+
+	for (typename MapT::Element *itr = elements.front(); itr != nullptr; itr = itr->next()) {
+		Element *parent = get_parent(itr->value());
+		if (parent == rep_element) {
+			out_members.push_back(itr->key());
+		}
+	}
+}
+
+#endif

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -179,11 +179,11 @@ String EditorSceneImporterGLTF::_gen_unique_name(GLTFState &state, const String 
 Error EditorSceneImporterGLTF::_parse_scenes(GLTFState &state) {
 
 	ERR_FAIL_COND_V(!state.json.has("scenes"), ERR_FILE_CORRUPT);
-	Array scenes = state.json["scenes"];
+	const Array &scenes = state.json["scenes"];
 	for (int i = 0; i < 1; i++) { //only first scene is imported
-		Dictionary s = scenes[i];
+		const Dictionary &s = scenes[i];
 		ERR_FAIL_COND_V(!s.has("nodes"), ERR_UNAVAILABLE);
-		Array nodes = s["nodes"];
+		const Array &nodes = s["nodes"];
 		for (int j = 0; j < nodes.size(); j++) {
 			state.root_nodes.push_back(nodes[j]);
 		}
@@ -201,11 +201,11 @@ Error EditorSceneImporterGLTF::_parse_scenes(GLTFState &state) {
 Error EditorSceneImporterGLTF::_parse_nodes(GLTFState &state) {
 
 	ERR_FAIL_COND_V(!state.json.has("nodes"), ERR_FILE_CORRUPT);
-	Array nodes = state.json["nodes"];
+	const Array &nodes = state.json["nodes"];
 	for (int i = 0; i < nodes.size(); i++) {
 
 		GLTFNode *node = memnew(GLTFNode);
-		Dictionary n = nodes[i];
+		const Dictionary &n = nodes[i];
 
 		if (n.has("name")) {
 			node->name = n["name"];
@@ -239,7 +239,7 @@ Error EditorSceneImporterGLTF::_parse_nodes(GLTFState &state) {
 		}
 
 		if (n.has("children")) {
-			Array children = n["children"];
+			const Array &children = n["children"];
 			for (int j = 0; j < children.size(); j++) {
 				node->children.push_back(children[j]);
 			}
@@ -249,15 +249,15 @@ Error EditorSceneImporterGLTF::_parse_nodes(GLTFState &state) {
 	}
 
 	// build the hierarchy
-	for (GLTFNodeIndex i = 0; i < state.nodes.size(); i++) {
+	for (GLTFNodeIndex node_i = 0; node_i < state.nodes.size(); node_i++) {
 
-		for (int j = 0; j < state.nodes[i]->children.size(); j++) {
-			GLTFNodeIndex child = state.nodes[i]->children[j];
+		for (int j = 0; j < state.nodes[node_i]->children.size(); j++) {
+			GLTFNodeIndex child_i = state.nodes[node_i]->children[j];
 
-			ERR_FAIL_INDEX_V(child, state.nodes.size(), ERR_FILE_CORRUPT);
-			ERR_CONTINUE(state.nodes[child]->parent != -1); //node already has a parent, wtf.
+			ERR_FAIL_INDEX_V(child_i, state.nodes.size(), ERR_FILE_CORRUPT);
+			ERR_CONTINUE(state.nodes[child_i]->parent != -1); //node already has a parent, wtf.
 
-			state.nodes[child]->parent = i;
+			state.nodes[child_i]->parent = node_i;
 		}
 	}
 
@@ -273,14 +273,15 @@ void EditorSceneImporterGLTF::_compute_node_heights(GLTFState &state) {
 		GLTFNode *node = state.nodes[node_i];
 		node->height = 0;
 
-		GLTFNodeIndex current = node_i;
-		while (current >= 0) {
-			GLTFNodeIndex parent = state.nodes[current]->parent;
-			if (parent >= 0) {
+		GLTFNodeIndex current_i = node_i;
+		while (current_i >= 0) {
+			const GLTFNodeIndex parent_i = state.nodes[current_i]->parent;
+			if (parent_i >= 0) {
 				++node->height;
 			}
-			current = parent;
+			current_i = parent_i;
 		}
+
 		if (node->height == 0) {
 			state.root_nodes.push_back(node_i);
 		}
@@ -312,14 +313,14 @@ Error EditorSceneImporterGLTF::_parse_buffers(GLTFState &state, const String &p_
 	if (!state.json.has("buffers"))
 		return OK;
 
-	Array buffers = state.json["buffers"];
-	for (int i = 0; i < buffers.size(); i++) {
+	const Array &buffers = state.json["buffers"];
+	for (GLTFBufferIndex i = 0; i < buffers.size(); i++) {
 
 		if (i == 0 && state.glb_data.size()) {
 			state.buffers.push_back(state.glb_data);
 
 		} else {
-			Dictionary buffer = buffers[i];
+			const Dictionary &buffer = buffers[i];
 			if (buffer.has("uri")) {
 
 				Vector<uint8_t> buffer_data;
@@ -351,10 +352,10 @@ Error EditorSceneImporterGLTF::_parse_buffers(GLTFState &state, const String &p_
 Error EditorSceneImporterGLTF::_parse_buffer_views(GLTFState &state) {
 
 	ERR_FAIL_COND_V(!state.json.has("bufferViews"), ERR_FILE_CORRUPT);
-	Array buffers = state.json["bufferViews"];
-	for (int i = 0; i < buffers.size(); i++) {
+	const Array &buffers = state.json["bufferViews"];
+	for (GLTFBufferViewIndex i = 0; i < buffers.size(); i++) {
 
-		Dictionary d = buffers[i];
+		const Dictionary &d = buffers[i];
 
 		GLTFBufferView buffer_view;
 
@@ -372,7 +373,7 @@ Error EditorSceneImporterGLTF::_parse_buffer_views(GLTFState &state) {
 		}
 
 		if (d.has("target")) {
-			int target = d["target"];
+			const int target = d["target"];
 			buffer_view.indices = target == ELEMENT_ARRAY_BUFFER;
 		}
 
@@ -409,10 +410,10 @@ EditorSceneImporterGLTF::GLTFType EditorSceneImporterGLTF::_get_type_from_str(co
 Error EditorSceneImporterGLTF::_parse_accessors(GLTFState &state) {
 
 	ERR_FAIL_COND_V(!state.json.has("accessors"), ERR_FILE_CORRUPT);
-	Array accessors = state.json["accessors"];
-	for (int i = 0; i < accessors.size(); i++) {
+	const Array &accessors = state.json["accessors"];
+	for (GLTFAccessorIndex i = 0; i < accessors.size(); i++) {
 
-		Dictionary d = accessors[i];
+		const Dictionary &d = accessors[i];
 
 		GLTFAccessor accessor;
 
@@ -442,12 +443,12 @@ Error EditorSceneImporterGLTF::_parse_accessors(GLTFState &state) {
 		if (d.has("sparse")) {
 			//eeh..
 
-			Dictionary s = d["sparse"];
+			const Dictionary &s = d["sparse"];
 
 			ERR_FAIL_COND_V(!d.has("count"), ERR_PARSE_ERROR);
 			accessor.sparse_count = d["count"];
 			ERR_FAIL_COND_V(!d.has("indices"), ERR_PARSE_ERROR);
-			Dictionary si = d["indices"];
+			const Dictionary &si = d["indices"];
 
 			ERR_FAIL_COND_V(!si.has("bufferView"), ERR_PARSE_ERROR);
 			accessor.sparse_indices_buffer_view = si["bufferView"];
@@ -459,7 +460,7 @@ Error EditorSceneImporterGLTF::_parse_accessors(GLTFState &state) {
 			}
 
 			ERR_FAIL_COND_V(!d.has("values"), ERR_PARSE_ERROR);
-			Dictionary sv = d["values"];
+			const Dictionary &sv = d["values"];
 
 			ERR_FAIL_COND_V(!sv.has("bufferView"), ERR_PARSE_ERROR);
 			accessor.sparse_values_buffer_view = sv["bufferView"];
@@ -476,7 +477,7 @@ Error EditorSceneImporterGLTF::_parse_accessors(GLTFState &state) {
 	return OK;
 }
 
-String EditorSceneImporterGLTF::_get_component_type_name(uint32_t p_component) {
+String EditorSceneImporterGLTF::_get_component_type_name(const uint32_t p_component) {
 
 	switch (p_component) {
 		case COMPONENT_TYPE_BYTE: return "Byte";
@@ -490,7 +491,7 @@ String EditorSceneImporterGLTF::_get_component_type_name(uint32_t p_component) {
 	return "<Error>";
 }
 
-String EditorSceneImporterGLTF::_get_type_name(GLTFType p_component) {
+String EditorSceneImporterGLTF::_get_type_name(const GLTFType p_component) {
 
 	static const char *names[] = {
 		"float",
@@ -505,7 +506,7 @@ String EditorSceneImporterGLTF::_get_type_name(GLTFType p_component) {
 	return names[p_component];
 }
 
-Error EditorSceneImporterGLTF::_decode_buffer_view(GLTFState &state, int p_buffer_view, double *dst, int skip_every, int skip_bytes, int element_size, int count, GLTFType type, int component_count, int component_type, int component_size, bool normalized, int byte_offset, bool for_vertex) {
+Error EditorSceneImporterGLTF::_decode_buffer_view(GLTFState &state, double *dst, const GLTFBufferViewIndex p_buffer_view, const int skip_every, const int skip_bytes, const int element_size, const int count, const GLTFType type, const int component_count, const int component_type, const int component_size, const bool normalized, const int byte_offset, const bool for_vertex) {
 
 	const GLTFBufferView &bv = state.buffer_views[p_buffer_view];
 
@@ -516,7 +517,7 @@ Error EditorSceneImporterGLTF::_decode_buffer_view(GLTFState &state, int p_buffe
 
 	ERR_FAIL_INDEX_V(bv.buffer, state.buffers.size(), ERR_PARSE_ERROR);
 
-	uint32_t offset = bv.byte_offset + byte_offset;
+	const uint32_t offset = bv.byte_offset + byte_offset;
 	Vector<uint8_t> buffer = state.buffers[bv.buffer]; //copy on write, so no performance hit
 	const uint8_t *bufptr = buffer.ptr();
 
@@ -524,7 +525,7 @@ Error EditorSceneImporterGLTF::_decode_buffer_view(GLTFState &state, int p_buffe
 	print_verbose("glTF: type " + _get_type_name(type) + " component type: " + _get_component_type_name(component_type) + " stride: " + itos(stride) + " amount " + itos(count));
 	print_verbose("glTF: accessor offset" + itos(byte_offset) + " view offset: " + itos(bv.byte_offset) + " total buffer len: " + itos(buffer.size()) + " view len " + itos(bv.byte_length));
 
-	int buffer_end = (stride * (count - 1)) + element_size;
+	const int buffer_end = (stride * (count - 1)) + element_size;
 	ERR_FAIL_COND_V(buffer_end > bv.byte_length, ERR_PARSE_ERROR);
 
 	ERR_FAIL_COND_V((int)(offset + buffer_end) > buffer.size(), ERR_PARSE_ERROR);
@@ -593,7 +594,7 @@ Error EditorSceneImporterGLTF::_decode_buffer_view(GLTFState &state, int p_buffe
 	return OK;
 }
 
-int EditorSceneImporterGLTF::_get_component_type_size(int component_type) {
+int EditorSceneImporterGLTF::_get_component_type_size(const int component_type) {
 
 	switch (component_type) {
 		case COMPONENT_TYPE_BYTE: return 1; break;
@@ -609,7 +610,7 @@ int EditorSceneImporterGLTF::_get_component_type_size(int component_type) {
 	return 0;
 }
 
-Vector<double> EditorSceneImporterGLTF::_decode_accessor(GLTFState &state, int p_accessor, bool p_for_vertex) {
+Vector<double> EditorSceneImporterGLTF::_decode_accessor(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex) {
 
 	//spec, for reference:
 	//https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#data-alignment
@@ -618,12 +619,12 @@ Vector<double> EditorSceneImporterGLTF::_decode_accessor(GLTFState &state, int p
 
 	const GLTFAccessor &a = state.accessors[p_accessor];
 
-	int component_count_for_type[7] = {
+	const int component_count_for_type[7] = {
 		1, 2, 3, 4, 4, 9, 16
 	};
 
-	int component_count = component_count_for_type[a.type];
-	int component_size = _get_component_type_size(a.component_type);
+	const int component_count = component_count_for_type[a.type];
+	const int component_size = _get_component_type_size(a.component_type);
 	ERR_FAIL_COND_V(component_size == 0, Vector<double>());
 	int element_size = component_count * component_size;
 
@@ -666,7 +667,7 @@ Vector<double> EditorSceneImporterGLTF::_decode_accessor(GLTFState &state, int p
 
 		ERR_FAIL_INDEX_V(a.buffer_view, state.buffer_views.size(), Vector<double>());
 
-		Error err = _decode_buffer_view(state, a.buffer_view, dst, skip_every, skip_bytes, element_size, a.count, a.type, component_count, a.component_type, component_size, a.normalized, a.byte_offset, p_for_vertex);
+		const Error err = _decode_buffer_view(state, dst, a.buffer_view, skip_every, skip_bytes, element_size, a.count, a.type, component_count, a.component_type, component_size, a.normalized, a.byte_offset, p_for_vertex);
 		if (err != OK)
 			return Vector<double>();
 
@@ -681,20 +682,20 @@ Vector<double> EditorSceneImporterGLTF::_decode_accessor(GLTFState &state, int p
 		// I could not find any file using this, so this code is so far untested
 		Vector<double> indices;
 		indices.resize(a.sparse_count);
-		int indices_component_size = _get_component_type_size(a.sparse_indices_component_type);
+		const int indices_component_size = _get_component_type_size(a.sparse_indices_component_type);
 
-		Error err = _decode_buffer_view(state, a.sparse_indices_buffer_view, indices.ptrw(), 0, 0, indices_component_size, a.sparse_count, TYPE_SCALAR, 1, a.sparse_indices_component_type, indices_component_size, false, a.sparse_indices_byte_offset, false);
+		Error err = _decode_buffer_view(state, indices.ptrw(), a.sparse_indices_buffer_view, 0, 0, indices_component_size, a.sparse_count, TYPE_SCALAR, 1, a.sparse_indices_component_type, indices_component_size, false, a.sparse_indices_byte_offset, false);
 		if (err != OK)
 			return Vector<double>();
 
 		Vector<double> data;
 		data.resize(component_count * a.sparse_count);
-		err = _decode_buffer_view(state, a.sparse_values_buffer_view, data.ptrw(), skip_every, skip_bytes, element_size, a.sparse_count, a.type, component_count, a.component_type, component_size, a.normalized, a.sparse_values_byte_offset, p_for_vertex);
+		err = _decode_buffer_view(state, data.ptrw(), a.sparse_values_buffer_view, skip_every, skip_bytes, element_size, a.sparse_count, a.type, component_count, a.component_type, component_size, a.normalized, a.sparse_values_byte_offset, p_for_vertex);
 		if (err != OK)
 			return Vector<double>();
 
 		for (int i = 0; i < indices.size(); i++) {
-			int write_offset = int(indices[i]) * component_count;
+			const int write_offset = int(indices[i]) * component_count;
 
 			for (int j = 0; j < component_count; j++) {
 				dst[write_offset + j] = data[i * component_count + j];
@@ -705,14 +706,16 @@ Vector<double> EditorSceneImporterGLTF::_decode_accessor(GLTFState &state, int p
 	return dst_buffer;
 }
 
-PoolVector<int> EditorSceneImporterGLTF::_decode_accessor_as_ints(GLTFState &state, int p_accessor, bool p_for_vertex) {
+PoolVector<int> EditorSceneImporterGLTF::_decode_accessor_as_ints(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex) {
 
-	Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
+	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	PoolVector<int> ret;
+
 	if (attribs.size() == 0)
 		return ret;
+
 	const double *attribs_ptr = attribs.ptr();
-	int ret_size = attribs.size();
+	const int ret_size = attribs.size();
 	ret.resize(ret_size);
 	{
 		PoolVector<int>::Write w = ret.write();
@@ -723,14 +726,16 @@ PoolVector<int> EditorSceneImporterGLTF::_decode_accessor_as_ints(GLTFState &sta
 	return ret;
 }
 
-PoolVector<float> EditorSceneImporterGLTF::_decode_accessor_as_floats(GLTFState &state, int p_accessor, bool p_for_vertex) {
+PoolVector<float> EditorSceneImporterGLTF::_decode_accessor_as_floats(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex) {
 
-	Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
+	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	PoolVector<float> ret;
+
 	if (attribs.size() == 0)
 		return ret;
+
 	const double *attribs_ptr = attribs.ptr();
-	int ret_size = attribs.size();
+	const int ret_size = attribs.size();
 	ret.resize(ret_size);
 	{
 		PoolVector<float>::Write w = ret.write();
@@ -741,15 +746,17 @@ PoolVector<float> EditorSceneImporterGLTF::_decode_accessor_as_floats(GLTFState 
 	return ret;
 }
 
-PoolVector<Vector2> EditorSceneImporterGLTF::_decode_accessor_as_vec2(GLTFState &state, int p_accessor, bool p_for_vertex) {
+PoolVector<Vector2> EditorSceneImporterGLTF::_decode_accessor_as_vec2(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex) {
 
-	Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
+	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	PoolVector<Vector2> ret;
+
 	if (attribs.size() == 0)
 		return ret;
+
 	ERR_FAIL_COND_V(attribs.size() % 2 != 0, ret);
 	const double *attribs_ptr = attribs.ptr();
-	int ret_size = attribs.size() / 2;
+	const int ret_size = attribs.size() / 2;
 	ret.resize(ret_size);
 	{
 		PoolVector<Vector2>::Write w = ret.write();
@@ -760,15 +767,17 @@ PoolVector<Vector2> EditorSceneImporterGLTF::_decode_accessor_as_vec2(GLTFState 
 	return ret;
 }
 
-PoolVector<Vector3> EditorSceneImporterGLTF::_decode_accessor_as_vec3(GLTFState &state, int p_accessor, bool p_for_vertex) {
+PoolVector<Vector3> EditorSceneImporterGLTF::_decode_accessor_as_vec3(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex) {
 
-	Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
+	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	PoolVector<Vector3> ret;
+
 	if (attribs.size() == 0)
 		return ret;
+
 	ERR_FAIL_COND_V(attribs.size() % 3 != 0, ret);
 	const double *attribs_ptr = attribs.ptr();
-	int ret_size = attribs.size() / 3;
+	const int ret_size = attribs.size() / 3;
 	ret.resize(ret_size);
 	{
 		PoolVector<Vector3>::Write w = ret.write();
@@ -778,13 +787,16 @@ PoolVector<Vector3> EditorSceneImporterGLTF::_decode_accessor_as_vec3(GLTFState 
 	}
 	return ret;
 }
-PoolVector<Color> EditorSceneImporterGLTF::_decode_accessor_as_color(GLTFState &state, int p_accessor, bool p_for_vertex) {
 
-	Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
+PoolVector<Color> EditorSceneImporterGLTF::_decode_accessor_as_color(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex) {
+
+	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	PoolVector<Color> ret;
+
 	if (attribs.size() == 0)
 		return ret;
-	int type = state.accessors[p_accessor].type;
+
+	const int type = state.accessors[p_accessor].type;
 	ERR_FAIL_COND_V(!(type == TYPE_VEC3 || type == TYPE_VEC4), ret);
 	int components;
 	if (type == TYPE_VEC3) {
@@ -792,9 +804,10 @@ PoolVector<Color> EditorSceneImporterGLTF::_decode_accessor_as_color(GLTFState &
 	} else { // TYPE_VEC4
 		components = 4;
 	}
+
 	ERR_FAIL_COND_V(attribs.size() % components != 0, ret);
 	const double *attribs_ptr = attribs.ptr();
-	int ret_size = attribs.size() / components;
+	const int ret_size = attribs.size() / components;
 	ret.resize(ret_size);
 	{
 		PoolVector<Color>::Write w = ret.write();
@@ -804,15 +817,17 @@ PoolVector<Color> EditorSceneImporterGLTF::_decode_accessor_as_color(GLTFState &
 	}
 	return ret;
 }
-Vector<Quat> EditorSceneImporterGLTF::_decode_accessor_as_quat(GLTFState &state, int p_accessor, bool p_for_vertex) {
+Vector<Quat> EditorSceneImporterGLTF::_decode_accessor_as_quat(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex) {
 
-	Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
+	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Quat> ret;
+
 	if (attribs.size() == 0)
 		return ret;
+
 	ERR_FAIL_COND_V(attribs.size() % 4 != 0, ret);
 	const double *attribs_ptr = attribs.ptr();
-	int ret_size = attribs.size() / 4;
+	const int ret_size = attribs.size() / 4;
 	ret.resize(ret_size);
 	{
 		for (int i = 0; i < ret_size; i++) {
@@ -821,12 +836,14 @@ Vector<Quat> EditorSceneImporterGLTF::_decode_accessor_as_quat(GLTFState &state,
 	}
 	return ret;
 }
-Vector<Transform2D> EditorSceneImporterGLTF::_decode_accessor_as_xform2d(GLTFState &state, int p_accessor, bool p_for_vertex) {
+Vector<Transform2D> EditorSceneImporterGLTF::_decode_accessor_as_xform2d(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex) {
 
-	Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
+	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Transform2D> ret;
+
 	if (attribs.size() == 0)
 		return ret;
+
 	ERR_FAIL_COND_V(attribs.size() % 4 != 0, ret);
 	ret.resize(attribs.size() / 4);
 	for (int i = 0; i < ret.size(); i++) {
@@ -836,12 +853,14 @@ Vector<Transform2D> EditorSceneImporterGLTF::_decode_accessor_as_xform2d(GLTFSta
 	return ret;
 }
 
-Vector<Basis> EditorSceneImporterGLTF::_decode_accessor_as_basis(GLTFState &state, int p_accessor, bool p_for_vertex) {
+Vector<Basis> EditorSceneImporterGLTF::_decode_accessor_as_basis(GLTFState &state, const GLTFAccessorIndex p_accessor, bool p_for_vertex) {
 
-	Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
+	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Basis> ret;
+
 	if (attribs.size() == 0)
 		return ret;
+
 	ERR_FAIL_COND_V(attribs.size() % 9 != 0, ret);
 	ret.resize(attribs.size() / 9);
 	for (int i = 0; i < ret.size(); i++) {
@@ -851,12 +870,15 @@ Vector<Basis> EditorSceneImporterGLTF::_decode_accessor_as_basis(GLTFState &stat
 	}
 	return ret;
 }
-Vector<Transform> EditorSceneImporterGLTF::_decode_accessor_as_xform(GLTFState &state, int p_accessor, bool p_for_vertex) {
 
-	Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
+Vector<Transform> EditorSceneImporterGLTF::_decode_accessor_as_xform(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex) {
+
+	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Transform> ret;
+
 	if (attribs.size() == 0)
 		return ret;
+
 	ERR_FAIL_COND_V(attribs.size() % 16 != 0, ret);
 	ret.resize(attribs.size() / 16);
 	for (int i = 0; i < ret.size(); i++) {
@@ -885,7 +907,7 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 		ERR_FAIL_COND_V(!d.has("primitives"), ERR_PARSE_ERROR);
 
 		Array primitives = d["primitives"];
-		Dictionary extras = d.has("extras") ? (Dictionary)d["extras"] : Dictionary();
+		const Dictionary &extras = d.has("extras") ? (Dictionary)d["extras"] : Dictionary();
 
 		for (int j = 0; j < primitives.size(); j++) {
 
@@ -900,7 +922,7 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 
 			Mesh::PrimitiveType primitive = Mesh::PRIMITIVE_TRIANGLES;
 			if (p.has("mode")) {
-				int mode = p["mode"];
+				const int mode = p["mode"];
 				ERR_FAIL_INDEX_V(mode, 7, ERR_FILE_CORRUPT);
 				static const Mesh::PrimitiveType primitives2[7] = {
 					Mesh::PRIMITIVE_POINTS,
@@ -919,7 +941,6 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 			if (a.has("POSITION")) {
 				array[Mesh::ARRAY_VERTEX] = _decode_accessor_as_vec3(state, a["POSITION"], true);
 			}
-
 			if (a.has("NORMAL")) {
 				array[Mesh::ARRAY_NORMAL] = _decode_accessor_as_vec3(state, a["NORMAL"], true);
 			}
@@ -944,9 +965,6 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 					int wc = weights.size();
 					PoolVector<float>::Write w = weights.write();
 
-					//PoolVector<int> v = array[Mesh::ARRAY_BONES];
-					//PoolVector<int>::Read r = v.read();
-
 					for (int k = 0; k < wc; k += 4) {
 						float total = 0.0;
 						total += w[k + 0];
@@ -959,36 +977,34 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 							w[k + 2] /= total;
 							w[k + 3] /= total;
 						}
-
-						//print_verbose(itos(j / 4) + ": " + itos(r[j + 0]) + ":" + rtos(w[j + 0]) + ", " + itos(r[j + 1]) + ":" + rtos(w[j + 1]) + ", " + itos(r[j + 2]) + ":" + rtos(w[j + 2]) + ", " + itos(r[j + 3]) + ":" + rtos(w[j + 3]));
 					}
 				}
 				array[Mesh::ARRAY_WEIGHTS] = weights;
 			}
 
 			if (p.has("indices")) {
-
 				PoolVector<int> indices = _decode_accessor_as_ints(state, p["indices"], false);
 
 				if (primitive == Mesh::PRIMITIVE_TRIANGLES) {
 					//swap around indices, convert ccw to cw for front face
 
-					int is = indices.size();
-					PoolVector<int>::Write w = indices.write();
+					const int is = indices.size();
+					const PoolVector<int>::Write w = indices.write();
 					for (int k = 0; k < is; k += 3) {
 						SWAP(w[k + 1], w[k + 2]);
 					}
 				}
 				array[Mesh::ARRAY_INDEX] = indices;
+
 			} else if (primitive == Mesh::PRIMITIVE_TRIANGLES) {
 				//generate indices because they need to be swapped for CW/CCW
-				PoolVector<Vector3> vertices = array[Mesh::ARRAY_VERTEX];
+				const PoolVector<Vector3> &vertices = array[Mesh::ARRAY_VERTEX];
 				ERR_FAIL_COND_V(vertices.size() == 0, ERR_PARSE_ERROR);
 				PoolVector<int> indices;
-				int vs = vertices.size();
+				const int vs = vertices.size();
 				indices.resize(vs);
 				{
-					PoolVector<int>::Write w = indices.write();
+					const PoolVector<int>::Write w = indices.write();
 					for (int k = 0; k < vs; k += 3) {
 						w[k] = k;
 						w[k + 1] = k + 2;
@@ -1022,23 +1038,23 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 			//blend shapes
 			if (p.has("targets")) {
 				print_verbose("glTF: Mesh has targets");
-				Array targets = p["targets"];
+				const Array &targets = p["targets"];
 
 				//ideally BLEND_SHAPE_MODE_RELATIVE since gltf2 stores in displacement
 				//but it could require a larger refactor?
 				mesh.mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
 
 				if (j == 0) {
-					Array target_names = extras.has("targetNames") ? (Array)extras["targetNames"] : Array();
+					const Array &target_names = extras.has("targetNames") ? (Array)extras["targetNames"] : Array();
 					for (int k = 0; k < targets.size(); k++) {
-						String name = k < target_names.size() ? (String)target_names[k] : String("morph_") + itos(k);
+						const String name = k < target_names.size() ? (String)target_names[k] : String("morph_") + itos(k);
 						mesh.mesh->add_blend_shape(name);
 					}
 				}
 
 				for (int k = 0; k < targets.size(); k++) {
 
-					Dictionary t = targets[k];
+					const Dictionary &t = targets[k];
 
 					Array array_copy;
 					array_copy.resize(Mesh::ARRAY_MAX);
@@ -1051,17 +1067,17 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 
 					if (t.has("POSITION")) {
 						PoolVector<Vector3> varr = _decode_accessor_as_vec3(state, t["POSITION"], true);
-						PoolVector<Vector3> src_varr = array[Mesh::ARRAY_VERTEX];
-						int size = src_varr.size();
+						const PoolVector<Vector3> src_varr = array[Mesh::ARRAY_VERTEX];
+						const int size = src_varr.size();
 						ERR_FAIL_COND_V(size == 0, ERR_PARSE_ERROR);
 						{
 
-							int max_idx = varr.size();
+							const int max_idx = varr.size();
 							varr.resize(size);
 
-							PoolVector<Vector3>::Write w_varr = varr.write();
-							PoolVector<Vector3>::Read r_varr = varr.read();
-							PoolVector<Vector3>::Read r_src_varr = src_varr.read();
+							const PoolVector<Vector3>::Write w_varr = varr.write();
+							const PoolVector<Vector3>::Read r_varr = varr.read();
+							const PoolVector<Vector3>::Read r_src_varr = src_varr.read();
 							for (int l = 0; l < size; l++) {
 								if (l < max_idx) {
 									w_varr[l] = r_varr[l] + r_src_varr[l];
@@ -1074,16 +1090,16 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 					}
 					if (t.has("NORMAL")) {
 						PoolVector<Vector3> narr = _decode_accessor_as_vec3(state, t["NORMAL"], true);
-						PoolVector<Vector3> src_narr = array[Mesh::ARRAY_NORMAL];
+						const PoolVector<Vector3> src_narr = array[Mesh::ARRAY_NORMAL];
 						int size = src_narr.size();
 						ERR_FAIL_COND_V(size == 0, ERR_PARSE_ERROR);
 						{
 							int max_idx = narr.size();
 							narr.resize(size);
 
-							PoolVector<Vector3>::Write w_narr = narr.write();
-							PoolVector<Vector3>::Read r_narr = narr.read();
-							PoolVector<Vector3>::Read r_src_narr = src_narr.read();
+							const PoolVector<Vector3>::Write w_narr = narr.write();
+							const PoolVector<Vector3>::Read r_narr = narr.read();
+							const PoolVector<Vector3>::Read r_src_narr = src_narr.read();
 							for (int l = 0; l < size; l++) {
 								if (l < max_idx) {
 									w_narr[l] = r_narr[l] + r_src_narr[l];
@@ -1095,10 +1111,11 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 						array_copy[Mesh::ARRAY_NORMAL] = narr;
 					}
 					if (t.has("TANGENT")) {
-						PoolVector<Vector3> tangents_v3 = _decode_accessor_as_vec3(state, t["TANGENT"], true);
-						PoolVector<float> tangents_v4;
-						PoolVector<float> src_tangents = array[Mesh::ARRAY_TANGENT];
+						const PoolVector<Vector3> tangents_v3 = _decode_accessor_as_vec3(state, t["TANGENT"], true);
+						const PoolVector<float> src_tangents = array[Mesh::ARRAY_TANGENT];
 						ERR_FAIL_COND_V(src_tangents.size() == 0, ERR_PARSE_ERROR);
+
+						PoolVector<float> tangents_v4;
 
 						{
 
@@ -1106,10 +1123,10 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 
 							int size4 = src_tangents.size();
 							tangents_v4.resize(size4);
-							PoolVector<float>::Write w4 = tangents_v4.write();
+							const PoolVector<float>::Write w4 = tangents_v4.write();
 
-							PoolVector<Vector3>::Read r3 = tangents_v3.read();
-							PoolVector<float>::Read r4 = src_tangents.read();
+							const PoolVector<Vector3>::Read r3 = tangents_v3.read();
+							const PoolVector<float>::Read r4 = src_tangents.read();
 
 							for (int l = 0; l < size4 / 4; l++) {
 
@@ -1147,16 +1164,16 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 			mesh.mesh->add_surface_from_arrays(primitive, array, morphs);
 
 			if (p.has("material")) {
-				int material = p["material"];
+				const int material = p["material"];
 				ERR_FAIL_INDEX_V(material, state.materials.size(), ERR_FILE_CORRUPT);
-				Ref<Material> mat = state.materials[material];
+				const Ref<Material> &mat = state.materials[material];
 
 				mesh.mesh->surface_set_material(mesh.mesh->get_surface_count() - 1, mat);
 			}
 		}
 
 		if (d.has("weights")) {
-			Array weights = d["weights"];
+			const Array &weights = d["weights"];
 			ERR_FAIL_COND_V(mesh.mesh->get_blend_shape_count() != weights.size(), ERR_PARSE_ERROR);
 			mesh.blend_weights.resize(weights.size());
 			for (int j = 0; j < weights.size(); j++) {
@@ -1177,10 +1194,10 @@ Error EditorSceneImporterGLTF::_parse_images(GLTFState &state, const String &p_b
 	if (!state.json.has("images"))
 		return OK;
 
-	Array images = state.json["images"];
+	const Array &images = state.json["images"];
 	for (int i = 0; i < images.size(); i++) {
 
-		Dictionary d = images[i];
+		const Dictionary &d = images[i];
 
 		String mimetype;
 		if (d.has("mimeType")) {
@@ -1210,13 +1227,13 @@ Error EditorSceneImporterGLTF::_parse_images(GLTFState &state, const String &p_b
 		}
 
 		if (d.has("bufferView")) {
-			int bvi = d["bufferView"];
+			const GLTFBufferViewIndex bvi = d["bufferView"];
 
 			ERR_FAIL_INDEX_V(bvi, state.buffer_views.size(), ERR_PARAMETER_RANGE_ERROR);
 
 			const GLTFBufferView &bv = state.buffer_views[bvi];
 
-			int bi = bv.buffer;
+			const GLTFBufferIndex bi = bv.buffer;
 			ERR_FAIL_INDEX_V(bi, state.buffers.size(), ERR_PARAMETER_RANGE_ERROR);
 
 			ERR_FAIL_COND_V(bv.byte_offset + bv.byte_length > state.buffers[bi].size(), ERR_FILE_CORRUPT);
@@ -1229,7 +1246,7 @@ Error EditorSceneImporterGLTF::_parse_images(GLTFState &state, const String &p_b
 
 		if (mimetype.findn("png") != -1) {
 			//is a png
-			Ref<Image> img = Image::_png_mem_loader_func(data_ptr, data_size);
+			const Ref<Image> img = Image::_png_mem_loader_func(data_ptr, data_size);
 
 			ERR_FAIL_COND_V(img.is_null(), ERR_FILE_CORRUPT);
 
@@ -1243,7 +1260,7 @@ Error EditorSceneImporterGLTF::_parse_images(GLTFState &state, const String &p_b
 
 		if (mimetype.findn("jpeg") != -1) {
 			//is a jpg
-			Ref<Image> img = Image::_jpg_mem_loader_func(data_ptr, data_size);
+			const Ref<Image> img = Image::_jpg_mem_loader_func(data_ptr, data_size);
 
 			ERR_FAIL_COND_V(img.is_null(), ERR_FILE_CORRUPT);
 
@@ -1269,10 +1286,10 @@ Error EditorSceneImporterGLTF::_parse_textures(GLTFState &state) {
 	if (!state.json.has("textures"))
 		return OK;
 
-	Array textures = state.json["textures"];
-	for (int i = 0; i < textures.size(); i++) {
+	const Array &textures = state.json["textures"];
+	for (GLTFTextureIndex i = 0; i < textures.size(); i++) {
 
-		Dictionary d = textures[i];
+		const Dictionary &d = textures[i];
 
 		ERR_FAIL_COND_V(!d.has("source"), ERR_PARSE_ERROR);
 
@@ -1284,9 +1301,9 @@ Error EditorSceneImporterGLTF::_parse_textures(GLTFState &state) {
 	return OK;
 }
 
-Ref<Texture> EditorSceneImporterGLTF::_get_texture(GLTFState &state, int p_texture) {
+Ref<Texture> EditorSceneImporterGLTF::_get_texture(GLTFState &state, const GLTFTextureIndex p_texture) {
 	ERR_FAIL_INDEX_V(p_texture, state.textures.size(), Ref<Texture>());
-	int image = state.textures[p_texture].src_image;
+	const GLTFImageIndex image = state.textures[p_texture].src_image;
 
 	ERR_FAIL_INDEX_V(image, state.images.size(), Ref<Texture>());
 
@@ -1298,10 +1315,10 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 	if (!state.json.has("materials"))
 		return OK;
 
-	Array materials = state.json["materials"];
-	for (int i = 0; i < materials.size(); i++) {
+	const Array &materials = state.json["materials"];
+	for (GLTFMaterialIndex i = 0; i < materials.size(); i++) {
 
-		Dictionary d = materials[i];
+		const Dictionary &d = materials[i];
 
 		Ref<SpatialMaterial> material;
 		material.instance();
@@ -1311,17 +1328,17 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 
 		if (d.has("pbrMetallicRoughness")) {
 
-			Dictionary mr = d["pbrMetallicRoughness"];
+			const Dictionary &mr = d["pbrMetallicRoughness"];
 			if (mr.has("baseColorFactor")) {
-				Array arr = mr["baseColorFactor"];
+				const Array &arr = mr["baseColorFactor"];
 				ERR_FAIL_COND_V(arr.size() != 4, ERR_PARSE_ERROR);
-				Color c = Color(arr[0], arr[1], arr[2], arr[3]).to_srgb();
+				const Color c = Color(arr[0], arr[1], arr[2], arr[3]).to_srgb();
 
 				material->set_albedo(c);
 			}
 
 			if (mr.has("baseColorTexture")) {
-				Dictionary bct = mr["baseColorTexture"];
+				const Dictionary &bct = mr["baseColorTexture"];
 				if (bct.has("index")) {
 					material->set_texture(SpatialMaterial::TEXTURE_ALBEDO, _get_texture(state, bct["index"]));
 				}
@@ -1343,9 +1360,9 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 			}
 
 			if (mr.has("metallicRoughnessTexture")) {
-				Dictionary bct = mr["metallicRoughnessTexture"];
+				const Dictionary &bct = mr["metallicRoughnessTexture"];
 				if (bct.has("index")) {
-					Ref<Texture> t = _get_texture(state, bct["index"]);
+					const Ref<Texture> t = _get_texture(state, bct["index"]);
 					material->set_texture(SpatialMaterial::TEXTURE_METALLIC, t);
 					material->set_metallic_texture_channel(SpatialMaterial::TEXTURE_CHANNEL_BLUE);
 					material->set_texture(SpatialMaterial::TEXTURE_ROUGHNESS, t);
@@ -1361,7 +1378,7 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 		}
 
 		if (d.has("normalTexture")) {
-			Dictionary bct = d["normalTexture"];
+			const Dictionary &bct = d["normalTexture"];
 			if (bct.has("index")) {
 				material->set_texture(SpatialMaterial::TEXTURE_NORMAL, _get_texture(state, bct["index"]));
 				material->set_feature(SpatialMaterial::FEATURE_NORMAL_MAPPING, true);
@@ -1371,7 +1388,7 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 			}
 		}
 		if (d.has("occlusionTexture")) {
-			Dictionary bct = d["occlusionTexture"];
+			const Dictionary &bct = d["occlusionTexture"];
 			if (bct.has("index")) {
 				material->set_texture(SpatialMaterial::TEXTURE_AMBIENT_OCCLUSION, _get_texture(state, bct["index"]));
 				material->set_ao_texture_channel(SpatialMaterial::TEXTURE_CHANNEL_RED);
@@ -1380,16 +1397,16 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 		}
 
 		if (d.has("emissiveFactor")) {
-			Array arr = d["emissiveFactor"];
+			const Array &arr = d["emissiveFactor"];
 			ERR_FAIL_COND_V(arr.size() != 3, ERR_PARSE_ERROR);
-			Color c = Color(arr[0], arr[1], arr[2]).to_srgb();
+			const Color c = Color(arr[0], arr[1], arr[2]).to_srgb();
 			material->set_feature(SpatialMaterial::FEATURE_EMISSION, true);
 
 			material->set_emission(c);
 		}
 
 		if (d.has("emissiveTexture")) {
-			Dictionary bct = d["emissiveTexture"];
+			const Dictionary &bct = d["emissiveTexture"];
 			if (bct.has("index")) {
 				material->set_texture(SpatialMaterial::TEXTURE_EMISSION, _get_texture(state, bct["index"]));
 				material->set_feature(SpatialMaterial::FEATURE_EMISSION, true);
@@ -1398,14 +1415,14 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 		}
 
 		if (d.has("doubleSided")) {
-			bool ds = d["doubleSided"];
+			const bool ds = d["doubleSided"];
 			if (ds) {
 				material->set_cull_mode(SpatialMaterial::CULL_DISABLED);
 			}
 		}
 
 		if (d.has("alphaMode")) {
-			String am = d["alphaMode"];
+			const String &am = d["alphaMode"];
 			if (am != "OPAQUE") {
 				material->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, true);
 			}
@@ -1436,7 +1453,7 @@ EditorSceneImporterGLTF::GLTFNodeIndex EditorSceneImporterGLTF::_find_highest_no
 	return best_node;
 }
 
-bool EditorSceneImporterGLTF::_capture_nodes_in_skin(GLTFState &state, GLTFSkin &skin, GLTFNodeIndex node_index) {
+bool EditorSceneImporterGLTF::_capture_nodes_in_skin(GLTFState &state, GLTFSkin &skin, const GLTFNodeIndex node_index) {
 
 	bool found_joint = false;
 
@@ -1465,8 +1482,8 @@ void EditorSceneImporterGLTF::_capture_nodes_for_multirooted_skin(GLTFState &sta
 	DisjointSet<GLTFNodeIndex> disjoint_set;
 
 	for (int i = 0; i < skin.joints.size(); ++i) {
-		GLTFNodeIndex node_index = skin.joints[i];
-		GLTFNodeIndex parent = state.nodes[node_index]->parent;
+		const GLTFNodeIndex node_index = skin.joints[i];
+		const GLTFNodeIndex parent = state.nodes[node_index]->parent;
 		disjoint_set.insert(node_index);
 
 		if (skin.joints.find(parent) >= 0) {
@@ -1485,7 +1502,7 @@ void EditorSceneImporterGLTF::_capture_nodes_for_multirooted_skin(GLTFState &sta
 
 	// Determine the max height rooted tree
 	for (int i = 0; i < roots.size(); ++i) {
-		GLTFNodeIndex root = roots[i];
+		const GLTFNodeIndex root = roots[i];
 
 		if (maxHeight == -1 || state.nodes[root]->height < maxHeight) {
 			maxHeight = state.nodes[root]->height;
@@ -1495,8 +1512,8 @@ void EditorSceneImporterGLTF::_capture_nodes_for_multirooted_skin(GLTFState &sta
 	// Go up the tree till all of the multiple roots of the skin are at the same hierarchy level.
 	// This sucks, but 99% of all game engines (not just Godot) would have this same issue.
 	for (int i = 0; i < roots.size(); ++i) {
-		GLTFNodeIndex current_node = roots[i];
 
+		GLTFNodeIndex current_node = roots[i];
 		while (state.nodes[current_node]->height > maxHeight) {
 			GLTFNodeIndex parent = state.nodes[current_node]->parent;
 
@@ -1526,8 +1543,8 @@ void EditorSceneImporterGLTF::_capture_nodes_for_multirooted_skin(GLTFState &sta
 
 		if (!all_same) {
 			for (int i = 0; i < roots.size(); ++i) {
-				GLTFNodeIndex current_node = roots[i];
-				GLTFNodeIndex parent = state.nodes[current_node]->parent;
+				const GLTFNodeIndex current_node = roots[i];
+				const GLTFNodeIndex parent = state.nodes[current_node]->parent;
 
 				if (state.nodes[parent]->joint && skin.joints.find(parent) < 0) {
 					skin.joints.push_back(parent);
@@ -1554,8 +1571,8 @@ Error EditorSceneImporterGLTF::_expand_skin(GLTFState &state, GLTFSkin &skin) {
 	all_skin_nodes.append_array(skin.non_joints);
 
 	for (int i = 0; i < all_skin_nodes.size(); ++i) {
-		GLTFNodeIndex node_index = all_skin_nodes[i];
-		GLTFNodeIndex parent = state.nodes[node_index]->parent;
+		const GLTFNodeIndex node_index = all_skin_nodes[i];
+		const GLTFNodeIndex parent = state.nodes[node_index]->parent;
 		disjoint_set.insert(node_index);
 
 		if (all_skin_nodes.find(parent) >= 0) {
@@ -1571,7 +1588,8 @@ Error EditorSceneImporterGLTF::_expand_skin(GLTFState &state, GLTFSkin &skin) {
 	for (int i = 0; i < out_owners.size(); ++i) {
 		Vector<GLTFNodeIndex> set;
 		disjoint_set.get_members(set, out_owners[i]);
-		GLTFNodeIndex root = _find_highest_node(state, set);
+
+		const GLTFNodeIndex root = _find_highest_node(state, set);
 		ERR_FAIL_COND_V(root < 0, FAILED);
 		out_roots.push_back(root);
 	}
@@ -1596,8 +1614,8 @@ Error EditorSceneImporterGLTF::_verify_skin(GLTFState &state, GLTFSkin &skin) {
 	all_skin_nodes.append_array(skin.non_joints);
 
 	for (int i = 0; i < all_skin_nodes.size(); ++i) {
-		GLTFNodeIndex node_index = all_skin_nodes[i];
-		GLTFNodeIndex parent = state.nodes[node_index]->parent;
+		const GLTFNodeIndex node_index = all_skin_nodes[i];
+		const GLTFNodeIndex parent = state.nodes[node_index]->parent;
 		disjoint_set.insert(node_index);
 
 		if (all_skin_nodes.find(parent) >= 0) {
@@ -1622,7 +1640,7 @@ Error EditorSceneImporterGLTF::_verify_skin(GLTFState &state, GLTFSkin &skin) {
 	}
 
 	// Make sure all parents of a multi-rooted skin are the SAME
-	GLTFNodeIndex parent = state.nodes[out_roots[0]]->parent;
+	const GLTFNodeIndex parent = state.nodes[out_roots[0]]->parent;
 	for (int i = 1; i < out_roots.size(); ++i) {
 		if (state.nodes[out_roots[i]]->parent != parent) {
 			return FAILED;
@@ -1637,7 +1655,7 @@ Error EditorSceneImporterGLTF::_parse_skins(GLTFState &state) {
 	if (!state.json.has("skins"))
 		return OK;
 
-	Array skins = state.json["skins"];
+	const Array &skins = state.json["skins"];
 
 	// Create the base skins, and mark nodes that are joints
 	for (int i = 0; i < skins.size(); i++) {
@@ -1648,7 +1666,7 @@ Error EditorSceneImporterGLTF::_parse_skins(GLTFState &state) {
 
 		ERR_FAIL_COND_V(!d.has("joints"), ERR_PARSE_ERROR);
 
-		Array joints = d["joints"];
+		const Array &joints = d["joints"];
 
 		if (d.has("inverseBindMatrices")) {
 			skin.inverse_binds = _decode_accessor_as_xform(state, d["inverseBindMatrices"], false);
@@ -1656,7 +1674,7 @@ Error EditorSceneImporterGLTF::_parse_skins(GLTFState &state) {
 		}
 
 		for (int j = 0; j < joints.size(); j++) {
-			int node = joints[j];
+			const GLTFNodeIndex node = joints[j];
 			ERR_FAIL_INDEX_V(node, state.nodes.size(), ERR_PARSE_ERROR);
 
 			skin.joints.push_back(node);
@@ -1706,8 +1724,8 @@ Error EditorSceneImporterGLTF::_determine_skeletons(GLTFState &state) {
 		all_skin_nodes.append_array(skin.non_joints);
 
 		for (int i = 0; i < all_skin_nodes.size(); ++i) {
-			GLTFNodeIndex node_index = all_skin_nodes[i];
-			GLTFNodeIndex parent = state.nodes[node_index]->parent;
+			const GLTFNodeIndex node_index = all_skin_nodes[i];
+			const GLTFNodeIndex parent = state.nodes[node_index]->parent;
 			skeleton_sets.insert(node_index);
 
 			if (all_skin_nodes.find(parent) >= 0) {
@@ -1728,7 +1746,7 @@ Error EditorSceneImporterGLTF::_determine_skeletons(GLTFState &state) {
 	// Mark all the skins actual skeletons, after we have merged them
 	for (GLTFSkeletonIndex skel_i = 0; skel_i < skeleton_owners.size(); ++skel_i) {
 
-		GLTFNodeIndex skeleton_owner = skeleton_owners[skel_i];
+		const GLTFNodeIndex skeleton_owner = skeleton_owners[skel_i];
 		GLTFSkeleton skeleton;
 
 		for (GLTFSkinIndex skin_i = 0; skin_i < state.skins.size(); ++skin_i) {
@@ -1744,7 +1762,7 @@ Error EditorSceneImporterGLTF::_determine_skeletons(GLTFState &state) {
 
 		Vector<GLTFNodeIndex> non_joints;
 		for (int i = 0; i < skeleton_nodes.size(); ++i) {
-			GLTFNodeIndex node_i = skeleton_nodes[i];
+			const GLTFNodeIndex node_i = skeleton_nodes[i];
 
 			if (state.nodes[node_i]->joint) {
 				skeleton.joints.push_back(node_i);
@@ -1762,7 +1780,7 @@ Error EditorSceneImporterGLTF::_determine_skeletons(GLTFState &state) {
 		GLTFSkeleton &skeleton = state.skeletons.write[skel_i];
 
 		for (int i = 0; i < skeleton.joints.size(); ++i) {
-			GLTFNodeIndex node_i = skeleton.joints[i];
+			const GLTFNodeIndex node_i = skeleton.joints[i];
 			GLTFNode *node = state.nodes[node_i];
 
 			ERR_FAIL_COND_V(!node->joint, ERR_PARSE_ERROR);
@@ -1833,7 +1851,7 @@ Error EditorSceneImporterGLTF::_reparent_to_fake_joint(GLTFState &state, GLTFSke
 	}
 
 	GLTFNode *fake_joint = memnew(GLTFNode);
-	GLTFNodeIndex fake_joint_index = state.nodes.size();
+	const GLTFNodeIndex fake_joint_index = state.nodes.size();
 	state.nodes.push_back(fake_joint);
 
 	// We better not be a joint, or we messed up in our logic
@@ -1891,7 +1909,7 @@ Error EditorSceneImporterGLTF::_reparent_to_fake_joint(GLTFState &state, GLTFSke
 	return OK;
 }
 
-Error EditorSceneImporterGLTF::_determine_skeleton_roots(GLTFState &state, GLTFSkeletonIndex &skel_i) {
+Error EditorSceneImporterGLTF::_determine_skeleton_roots(GLTFState &state, const GLTFSkeletonIndex skel_i) {
 
 	DisjointSet<GLTFNodeIndex> disjoint_set;
 
@@ -1919,7 +1937,7 @@ Error EditorSceneImporterGLTF::_determine_skeleton_roots(GLTFState &state, GLTFS
 	for (int i = 0; i < owners.size(); ++i) {
 		Vector<GLTFNodeIndex> set;
 		disjoint_set.get_members(set, owners[i]);
-		GLTFNodeIndex root = _find_highest_node(state, set);
+		const GLTFNodeIndex root = _find_highest_node(state, set);
 		ERR_FAIL_COND_V(root < 0, FAILED);
 		roots.push_back(root);
 	}
@@ -1963,7 +1981,7 @@ Error EditorSceneImporterGLTF::_create_skeletons(GLTFState &state) {
 		}
 
 		while (!bones.empty()) {
-			GLTFNodeIndex node_i = bones.front()->get();
+			const GLTFNodeIndex node_i = bones.front()->get();
 			bones.pop_front();
 
 			GLTFNode *node = state.nodes[node_i];
@@ -1987,7 +2005,7 @@ Error EditorSceneImporterGLTF::_create_skeletons(GLTFState &state) {
 			skeleton->set_bone_pose(bone_index, node->xform);
 
 			if (node->parent >= 0 && state.nodes[node->parent]->skeleton == skel_i) {
-				int bone_parent = skeleton->find_bone(state.nodes[node->parent]->name);
+				const int bone_parent = skeleton->find_bone(state.nodes[node->parent]->name);
 				ERR_FAIL_COND_V(bone_parent < 0, FAILED);
 				skeleton->set_bone_parent(bone_index, skeleton->find_bone(state.nodes[node->parent]->name));
 			}
@@ -2008,10 +2026,10 @@ Error EditorSceneImporterGLTF::_map_skin_joints_indices_to_skeleton_bone_indices
 		const GLTFSkeleton &skeleton = state.skeletons[skin.skeleton];
 
 		for (int joint_index = 0; joint_index < skin.joints_original.size(); ++joint_index) {
-			GLTFNodeIndex node_i = skin.joints_original[joint_index];
+			const GLTFNodeIndex node_i = skin.joints_original[joint_index];
 			const GLTFNode *node = state.nodes[node_i];
 
-			int bone_index = skeleton.godot_skeleton->find_bone(node->name);
+			const int bone_index = skeleton.godot_skeleton->find_bone(node->name);
 			ERR_FAIL_COND_V(bone_index < 0, FAILED);
 
 			skin.joint_i_to_bone_i.insert(joint_index, bone_index);
@@ -2036,8 +2054,8 @@ Transform EditorSceneImporterGLTF::_get_scene_transform_for_node(const GLTFState
 }
 
 Transform EditorSceneImporterGLTF::_compute_skin_to_skeleton_transform(const GLTFState &state, const GLTFNodeIndex skin_parent, const GLTFNodeIndex skeleton_parent) {
-	Transform xform_skin = _get_scene_transform_for_node(state, skin_parent);
-	Transform xform_skel = _get_scene_transform_for_node(state, skeleton_parent);
+	const Transform xform_skin = _get_scene_transform_for_node(state, skin_parent);
+	const Transform xform_skel = _get_scene_transform_for_node(state, skeleton_parent);
 
 	return xform_skin.affine_inverse() * xform_skel;
 }
@@ -2066,7 +2084,9 @@ Error EditorSceneImporterGLTF::_create_skins(GLTFState &state) {
 
 		GLTFSkin &gltf_skin = state.skins.write[skin_i];
 
-		Ref<Skin> skin = Ref<Skin>(memnew(Skin));
+		Ref<Skin> skin;
+		skin.instance();
+
 		skin->set_name(_gen_unique_name(state, "Skin"));
 
 		for (int joint_i = 0; joint_i < gltf_skin.joints_original.size(); ++joint_i) {
@@ -2086,20 +2106,20 @@ Error EditorSceneImporterGLTF::_parse_cameras(GLTFState &state) {
 	if (!state.json.has("cameras"))
 		return OK;
 
-	Array cameras = state.json["cameras"];
+	const Array &cameras = state.json["cameras"];
 
-	for (int i = 0; i < cameras.size(); i++) {
+	for (GLTFCameraIndex i = 0; i < cameras.size(); i++) {
 
-		Dictionary d = cameras[i];
+		const Dictionary &d = cameras[i];
 
 		GLTFCamera camera;
 		ERR_FAIL_COND_V(!d.has("type"), ERR_PARSE_ERROR);
-		String type = d["type"];
+		const String &type = d["type"];
 		if (type == "orthographic") {
 
 			camera.perspective = false;
 			if (d.has("orthographic")) {
-				Dictionary og = d["orthographic"];
+				const Dictionary &og = d["orthographic"];
 				camera.fov_size = og["ymag"];
 				camera.zfar = og["zfar"];
 				camera.znear = og["znear"];
@@ -2111,7 +2131,7 @@ Error EditorSceneImporterGLTF::_parse_cameras(GLTFState &state) {
 
 			camera.perspective = true;
 			if (d.has("perspective")) {
-				Dictionary ppt = d["perspective"];
+				const Dictionary &ppt = d["perspective"];
 				// GLTF spec is in radians, Godot's camera is in degrees.
 				camera.fov_size = (double)ppt["yfov"] * 180.0 / Math_PI;
 				camera.zfar = ppt["zfar"];
@@ -2136,11 +2156,11 @@ Error EditorSceneImporterGLTF::_parse_animations(GLTFState &state) {
 	if (!state.json.has("animations"))
 		return OK;
 
-	Array animations = state.json["animations"];
+	const Array &animations = state.json["animations"];
 
-	for (int i = 0; i < animations.size(); i++) {
+	for (GLTFAnimationIndex i = 0; i < animations.size(); i++) {
 
-		Dictionary d = animations[i];
+		const Dictionary &d = animations[i];
 
 		GLTFAnimation animation;
 
@@ -2156,25 +2176,25 @@ Error EditorSceneImporterGLTF::_parse_animations(GLTFState &state) {
 
 		for (int j = 0; j < channels.size(); j++) {
 
-			Dictionary c = channels[j];
+			const Dictionary &c = channels[j];
 			if (!c.has("target"))
 				continue;
 
-			Dictionary t = c["target"];
+			const Dictionary &t = c["target"];
 			if (!t.has("node") || !t.has("path")) {
 				continue;
 			}
 
 			ERR_FAIL_COND_V(!c.has("sampler"), ERR_PARSE_ERROR);
-			int sampler = c["sampler"];
+			const int sampler = c["sampler"];
 			ERR_FAIL_INDEX_V(sampler, samplers.size(), ERR_PARSE_ERROR);
 
-			int node = t["node"];
+			GLTFNodeIndex node = t["node"];
 			String path = t["path"];
 
 			ERR_FAIL_INDEX_V(node, state.nodes.size(), ERR_PARSE_ERROR);
 
-			GLTFAnimation::Track *track = NULL;
+			GLTFAnimation::Track *track = nullptr;
 
 			if (!animation.tracks.has(node)) {
 				animation.tracks[node] = GLTFAnimation::Track();
@@ -2182,17 +2202,17 @@ Error EditorSceneImporterGLTF::_parse_animations(GLTFState &state) {
 
 			track = &animation.tracks[node];
 
-			Dictionary s = samplers[sampler];
+			const Dictionary &s = samplers[sampler];
 
 			ERR_FAIL_COND_V(!s.has("input"), ERR_PARSE_ERROR);
 			ERR_FAIL_COND_V(!s.has("output"), ERR_PARSE_ERROR);
 
-			int input = s["input"];
-			int output = s["output"];
+			const int input = s["input"];
+			const int output = s["output"];
 
 			GLTFAnimation::Interpolation interp = GLTFAnimation::INTERP_LINEAR;
 			if (s.has("interpolation")) {
-				String in = s["interpolation"];
+				const String &in = s["interpolation"];
 				if (in == "STEP") {
 					interp = GLTFAnimation::INTERP_STEP;
 				} else if (in == "LINEAR") {
@@ -2204,33 +2224,33 @@ Error EditorSceneImporterGLTF::_parse_animations(GLTFState &state) {
 				}
 			}
 
-			PoolVector<float> times = _decode_accessor_as_floats(state, input, false);
+			const PoolVector<float> times = _decode_accessor_as_floats(state, input, false);
 			if (path == "translation") {
-				PoolVector<Vector3> translations = _decode_accessor_as_vec3(state, output, false);
+				const PoolVector<Vector3> translations = _decode_accessor_as_vec3(state, output, false);
 				track->translation_track.interpolation = interp;
 				track->translation_track.times = Variant(times); //convert via variant
 				track->translation_track.values = Variant(translations); //convert via variant
 			} else if (path == "rotation") {
-				Vector<Quat> rotations = _decode_accessor_as_quat(state, output, false);
+				const Vector<Quat> rotations = _decode_accessor_as_quat(state, output, false);
 				track->rotation_track.interpolation = interp;
 				track->rotation_track.times = Variant(times); //convert via variant
 				track->rotation_track.values = rotations; //convert via variant
 			} else if (path == "scale") {
-				PoolVector<Vector3> scales = _decode_accessor_as_vec3(state, output, false);
+				const PoolVector<Vector3> scales = _decode_accessor_as_vec3(state, output, false);
 				track->scale_track.interpolation = interp;
 				track->scale_track.times = Variant(times); //convert via variant
 				track->scale_track.values = Variant(scales); //convert via variant
 			} else if (path == "weights") {
-				PoolVector<float> weights = _decode_accessor_as_floats(state, output, false);
+				const PoolVector<float> weights = _decode_accessor_as_floats(state, output, false);
 
 				ERR_FAIL_INDEX_V(state.nodes[node]->mesh, state.meshes.size(), ERR_PARSE_ERROR);
 				const GLTFMesh *mesh = &state.meshes[state.nodes[node]->mesh];
 				ERR_FAIL_COND_V(mesh->blend_weights.size() == 0, ERR_PARSE_ERROR);
-				int wc = mesh->blend_weights.size();
+				const int wc = mesh->blend_weights.size();
 
 				track->weight_tracks.resize(wc);
 
-				int wlen = weights.size() / wc;
+				const int wlen = weights.size() / wc;
 				PoolVector<float>::Read r = weights.read();
 				for (int k = 0; k < wc; k++) { //separate tracks, having them together is not such a good idea
 					GLTFAnimation::Channel<float> cf;
@@ -2405,43 +2425,43 @@ struct EditorSceneImporterGLTFInterpolate {
 
 	T catmull_rom(const T &p0, const T &p1, const T &p2, const T &p3, float t) {
 
-		float t2 = t * t;
-		float t3 = t2 * t;
+		const float t2 = t * t;
+		const float t3 = t2 * t;
 
 		return 0.5f * ((2.0f * p1) + (-p0 + p2) * t + (2.0f * p0 - 5.0f * p1 + 4 * p2 - p3) * t2 + (-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3);
 	}
 
 	T bezier(T start, T control_1, T control_2, T end, float t) {
 		/* Formula from Wikipedia article on Bezier curves. */
-		real_t omt = (1.0 - t);
-		real_t omt2 = omt * omt;
-		real_t omt3 = omt2 * omt;
-		real_t t2 = t * t;
-		real_t t3 = t2 * t;
+		const real_t omt = (1.0 - t);
+		const real_t omt2 = omt * omt;
+		const real_t omt3 = omt2 * omt;
+		const real_t t2 = t * t;
+		const real_t t3 = t2 * t;
 
 		return start * omt3 + control_1 * omt2 * t * 3.0 + control_2 * omt * t2 * 3.0 + end * t3;
 	}
 };
 
-//thank you for existing, partial specialization
+// thank you for existing, partial specialization
 template <>
 struct EditorSceneImporterGLTFInterpolate<Quat> {
 
-	Quat lerp(const Quat &a, const Quat &b, float c) const {
+	Quat lerp(const Quat &a, const Quat &b, const float c) const {
 		ERR_FAIL_COND_V(!a.is_normalized(), Quat());
 		ERR_FAIL_COND_V(!b.is_normalized(), Quat());
 
 		return a.slerp(b, c).normalized();
 	}
 
-	Quat catmull_rom(const Quat &p0, const Quat &p1, const Quat &p2, const Quat &p3, float c) {
+	Quat catmull_rom(const Quat &p0, const Quat &p1, const Quat &p2, const Quat &p3, const float c) {
 		ERR_FAIL_COND_V(!p1.is_normalized(), Quat());
 		ERR_FAIL_COND_V(!p2.is_normalized(), Quat());
 
 		return p1.slerp(p2, c).normalized();
 	}
 
-	Quat bezier(Quat start, Quat control_1, Quat control_2, Quat end, float t) {
+	Quat bezier(const Quat start, const Quat control_1, const Quat control_2, const Quat end, const float t) {
 		ERR_FAIL_COND_V(!start.is_normalized(), Quat());
 		ERR_FAIL_COND_V(!end.is_normalized(), Quat());
 
@@ -2450,7 +2470,7 @@ struct EditorSceneImporterGLTFInterpolate<Quat> {
 };
 
 template <class T>
-T EditorSceneImporterGLTF::_interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, float p_time, GLTFAnimation::Interpolation p_interp) {
+T EditorSceneImporterGLTF::_interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, const float p_time, const GLTFAnimation::Interpolation p_interp) {
 
 	//could use binary search, worth it?
 	int idx = -1;
@@ -2471,7 +2491,7 @@ T EditorSceneImporterGLTF::_interpolate_track(const Vector<float> &p_times, cons
 				return p_values[p_times.size() - 1];
 			}
 
-			float c = (p_time - p_times[idx]) / (p_times[idx + 1] - p_times[idx]);
+			const float c = (p_time - p_times[idx]) / (p_times[idx + 1] - p_times[idx]);
 
 			return interp.lerp(p_values[idx], p_values[idx + 1], c);
 
@@ -2495,7 +2515,7 @@ T EditorSceneImporterGLTF::_interpolate_track(const Vector<float> &p_times, cons
 				return p_values[1 + p_times.size() - 1];
 			}
 
-			float c = (p_time - p_times[idx]) / (p_times[idx + 1] - p_times[idx]);
+			const float c = (p_time - p_times[idx]) / (p_times[idx + 1] - p_times[idx]);
 
 			return interp.catmull_rom(p_values[idx - 1], p_values[idx], p_values[idx + 1], p_values[idx + 3], c);
 
@@ -2508,12 +2528,12 @@ T EditorSceneImporterGLTF::_interpolate_track(const Vector<float> &p_times, cons
 				return p_values[(p_times.size() - 1) * 3 + 1];
 			}
 
-			float c = (p_time - p_times[idx]) / (p_times[idx + 1] - p_times[idx]);
+			const float c = (p_time - p_times[idx]) / (p_times[idx + 1] - p_times[idx]);
 
-			T from = p_values[idx * 3 + 1];
-			T c1 = from + p_values[idx * 3 + 2];
-			T to = p_values[idx * 3 + 4];
-			T c2 = to + p_values[idx * 3 + 3];
+			const T from = p_values[idx * 3 + 1];
+			const T c1 = from + p_values[idx * 3 + 2];
+			const T to = p_values[idx * 3 + 4];
+			const T c2 = to + p_values[idx * 3 + 3];
 
 			return interp.bezier(from, c1, c2, to, c);
 
@@ -2523,12 +2543,12 @@ T EditorSceneImporterGLTF::_interpolate_track(const Vector<float> &p_times, cons
 	ERR_FAIL_V(p_values[0]);
 }
 
-void EditorSceneImporterGLTF::_import_animation(GLTFState &state, AnimationPlayer *ap, int index, int bake_fps) {
+void EditorSceneImporterGLTF::_import_animation(GLTFState &state, AnimationPlayer *ap, const GLTFAnimationIndex index, const int bake_fps) {
 
 	const GLTFAnimation &anim = state.animations[index];
 
 	String name = anim.name;
-	if (name == "") {
+	if (name.empty()) {
 		name = _gen_unique_name(state, "Animation");
 	}
 
@@ -2550,14 +2570,14 @@ void EditorSceneImporterGLTF::_import_animation(GLTFState &state, AnimationPlaye
 			node_index = state.nodes[node_index]->fake_joint_parent;
 		}
 
-		GLTFNode *node = state.nodes[E->key()];
+		const GLTFNode *node = state.nodes[E->key()];
 
 		if (node->skeleton >= 0) {
-			Skeleton *sk = Object::cast_to<Skeleton>(state.scene_nodes.find(node_index)->get());
+			const Skeleton *sk = Object::cast_to<Skeleton>(state.scene_nodes.find(node_index)->get());
 			ERR_FAIL_COND(sk == nullptr);
 
-			String path = ap->get_parent()->get_path_to(sk);
-			String bone = node->name;
+			const String path = ap->get_parent()->get_path_to(sk);
+			const String bone = node->name;
 			node_path = path + ":" + bone;
 		} else {
 			node_path = ap->get_parent()->get_path_to(state.scene_nodes.find(node_index)->get());
@@ -2586,7 +2606,7 @@ void EditorSceneImporterGLTF::_import_animation(GLTFState &state, AnimationPlaye
 			animation->track_set_path(track_idx, node_path);
 			//first determine animation length
 
-			float increment = 1.0 / float(bake_fps);
+			const float increment = 1.0 / float(bake_fps);
 			float time = 0.0;
 
 			Vector3 base_pos;
@@ -2613,17 +2633,14 @@ void EditorSceneImporterGLTF::_import_animation(GLTFState &state, AnimationPlaye
 				Vector3 scale = base_scale;
 
 				if (track.translation_track.times.size()) {
-
 					pos = _interpolate_track<Vector3>(track.translation_track.times, track.translation_track.values, time, track.translation_track.interpolation);
 				}
 
 				if (track.rotation_track.times.size()) {
-
 					rot = _interpolate_track<Quat>(track.rotation_track.times, track.rotation_track.values, time, track.rotation_track.interpolation);
 				}
 
 				if (track.scale_track.times.size()) {
-
 					scale = _interpolate_track<Vector3>(track.scale_track.times, track.scale_track.values, time, track.scale_track.interpolation);
 				}
 
@@ -2633,9 +2650,9 @@ void EditorSceneImporterGLTF::_import_animation(GLTFState &state, AnimationPlaye
 					xform.basis.set_quat_scale(rot, scale);
 					xform.origin = pos;
 
-					Skeleton *skeleton = state.skeletons[node->skeleton].godot_skeleton;
-					int bone = skeleton->find_bone(node->name);
-					xform = skeleton->get_bone_rest(bone).affine_inverse() * xform;
+					const Skeleton *skeleton = state.skeletons[node->skeleton].godot_skeleton;
+					const int bone_idx = skeleton->find_bone(node->name);
+					xform = skeleton->get_bone_rest(bone_idx).affine_inverse() * xform;
 
 					rot = xform.basis.get_rotation_quat();
 					rot.normalize();
@@ -2659,10 +2676,10 @@ void EditorSceneImporterGLTF::_import_animation(GLTFState &state, AnimationPlaye
 		for (int i = 0; i < track.weight_tracks.size(); i++) {
 			ERR_CONTINUE(node->mesh < 0 || node->mesh >= state.meshes.size());
 			const GLTFMesh &mesh = state.meshes[node->mesh];
-			String prop = "blend_shapes/" + mesh.mesh->get_blend_shape_name(i);
+			const String prop = "blend_shapes/" + mesh.mesh->get_blend_shape_name(i);
 			node_path = String(node_path) + ":" + prop;
 
-			int track_idx = animation->get_track_count();
+			const int track_idx = animation->get_track_count();
 			animation->add_track(Animation::TYPE_VALUE);
 			animation->track_set_path(track_idx, node_path);
 
@@ -2672,13 +2689,13 @@ void EditorSceneImporterGLTF::_import_animation(GLTFState &state, AnimationPlaye
 			if (gltf_interp == GLTFAnimation::INTERP_LINEAR || gltf_interp == GLTFAnimation::INTERP_STEP) {
 				animation->track_set_interpolation_type(track_idx, gltf_interp == GLTFAnimation::INTERP_STEP ? Animation::INTERPOLATION_NEAREST : Animation::INTERPOLATION_LINEAR);
 				for (int j = 0; j < track.weight_tracks[i].times.size(); j++) {
-					float t = track.weight_tracks[i].times[j];
-					float w = track.weight_tracks[i].values[j];
+					const float t = track.weight_tracks[i].times[j];
+					const float w = track.weight_tracks[i].values[j];
 					animation->track_insert_key(track_idx, t, w);
 				}
 			} else {
 				// CATMULLROMSPLINE or CUBIC_SPLINE have to be baked, apologies.
-				float increment = 1.0 / float(bake_fps);
+				const float increment = 1.0 / float(bake_fps);
 				float time = 0.0;
 				bool last = false;
 				while (true) {
@@ -2712,7 +2729,7 @@ void EditorSceneImporterGLTF::_process_mesh_instances(GLTFState &state, Spatial 
 			MeshInstance *mi = Object::cast_to<MeshInstance>(mi_element->get());
 			ERR_FAIL_COND(mi == nullptr);
 
-			GLTFSkeletonIndex skel_i = state.skins[node->skin].skeleton;
+			const GLTFSkeletonIndex skel_i = state.skins[node->skin].skeleton;
 			const GLTFSkeleton &gltf_skeleton = state.skeletons[skel_i];
 			Skeleton *skeleton = gltf_skeleton.godot_skeleton;
 			ERR_FAIL_COND(skeleton == nullptr);
@@ -2728,7 +2745,7 @@ void EditorSceneImporterGLTF::_process_mesh_instances(GLTFState &state, Spatial 
 	}
 }
 
-Spatial *EditorSceneImporterGLTF::_generate_scene(GLTFState &state, int p_bake_fps) {
+Spatial *EditorSceneImporterGLTF::_generate_scene(GLTFState &state, const int p_bake_fps) {
 
 	Spatial *root = memnew(Spatial);
 	root->set_name(state.scene_name);

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -43,10 +43,18 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 	GDCLASS(EditorSceneImporterGLTF, EditorSceneImporter);
 
-	typedef int GLTFNodeIndex;
-	typedef int GLTFSkinIndex;
-	typedef int GLTFSkeletonIndex;
+	typedef int GLTFAccessorIndex;
+	typedef int GLTFAnimationIndex;
+	typedef int GLTFBufferIndex;
+	typedef int GLTFBufferViewIndex;
+	typedef int GLTFCameraIndex;
+	typedef int GLTFImageIndex;
+	typedef int GLTFMaterialIndex;
 	typedef int GLTFMeshIndex;
+	typedef int GLTFNodeIndex;
+	typedef int GLTFSkeletonIndex;
+	typedef int GLTFSkinIndex;
+	typedef int GLTFTextureIndex;
 
 	enum {
 		ARRAY_BUFFER = 34962,
@@ -68,8 +76,8 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 	};
 
-	String _get_component_type_name(uint32_t p_component);
-	int _get_component_type_size(int component_type);
+	String _get_component_type_name(const uint32_t p_component);
+	int _get_component_type_size(const int component_type);
 
 	enum GLTFType {
 		TYPE_SCALAR,
@@ -81,7 +89,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		TYPE_MAT4,
 	};
 
-	String _get_type_name(GLTFType p_component);
+	String _get_type_name(const GLTFType p_component);
 
 	struct GLTFNode {
 
@@ -92,13 +100,12 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		Transform xform;
 		String name;
 
-		int mesh;
-		int camera;
-		int skin;
+		GLTFMeshIndex mesh;
+		GLTFCameraIndex camera;
+		GLTFSkinIndex skin;
 
 		GLTFSkeletonIndex skeleton;
 		bool joint;
-
 
 		Vector3 translation;
 		Quat rotation;
@@ -123,7 +130,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 	struct GLTFBufferView {
 
-		int buffer;
+		GLTFBufferIndex buffer;
 		int byte_offset;
 		int byte_length;
 		int byte_stride;
@@ -131,7 +138,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		//matrices need to be transformed to this
 
 		GLTFBufferView() :
-				buffer(0),
+				buffer(-1),
 				byte_offset(0),
 				byte_length(0),
 				byte_stride(0),
@@ -141,7 +148,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 	struct GLTFAccessor {
 
-		int buffer_view;
+		GLTFBufferViewIndex buffer_view;
 		int byte_offset;
 		int component_type;
 		bool normalized;
@@ -170,7 +177,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		}
 	};
 	struct GLTFTexture {
-		int src_image;
+		GLTFImageIndex src_image;
 	};
 
 	struct GLTFSkeleton {
@@ -321,7 +328,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 	String _gen_unique_name(GLTFState &state, const String &p_name);
 
-	Ref<Texture> _get_texture(GLTFState &state, int p_texture);
+	Ref<Texture> _get_texture(GLTFState &state, const GLTFTextureIndex p_texture);
 
 	Error _parse_json(const String &p_path, GLTFState &state);
 	Error _parse_glb(const String &p_path, GLTFState &state);
@@ -335,17 +342,18 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 	Error _parse_buffer_views(GLTFState &state);
 	GLTFType _get_type_from_str(const String &p_string);
 	Error _parse_accessors(GLTFState &state);
-	Error _decode_buffer_view(GLTFState &state, int p_buffer_view, double *dst, int skip_every, int skip_bytes, int element_size, int count, GLTFType type, int component_count, int component_type, int component_size, bool normalized, int byte_offset, bool for_vertex);
-	Vector<double> _decode_accessor(GLTFState &state, int p_accessor, bool p_for_vertex);
-	PoolVector<float> _decode_accessor_as_floats(GLTFState &state, int p_accessor, bool p_for_vertex);
-	PoolVector<int> _decode_accessor_as_ints(GLTFState &state, int p_accessor, bool p_for_vertex);
-	PoolVector<Vector2> _decode_accessor_as_vec2(GLTFState &state, int p_accessor, bool p_for_vertex);
-	PoolVector<Vector3> _decode_accessor_as_vec3(GLTFState &state, int p_accessor, bool p_for_vertex);
-	PoolVector<Color> _decode_accessor_as_color(GLTFState &state, int p_accessor, bool p_for_vertex);
-	Vector<Quat> _decode_accessor_as_quat(GLTFState &state, int p_accessor, bool p_for_vertex);
-	Vector<Transform2D> _decode_accessor_as_xform2d(GLTFState &state, int p_accessor, bool p_for_vertex);
-	Vector<Basis> _decode_accessor_as_basis(GLTFState &state, int p_accessor, bool p_for_vertex);
-	Vector<Transform> _decode_accessor_as_xform(GLTFState &state, int p_accessor, bool p_for_vertex);
+	Error _decode_buffer_view(GLTFState &state, double *dst, const GLTFBufferViewIndex p_buffer_view, const int skip_every, const int skip_bytes, const int element_size, const int count, const GLTFType type, const int component_count, const int component_type, const int component_size, const bool normalized, const int byte_offset, const bool for_vertex);
+
+	Vector<double> _decode_accessor(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
+	PoolVector<float> _decode_accessor_as_floats(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
+	PoolVector<int> _decode_accessor_as_ints(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
+	PoolVector<Vector2> _decode_accessor_as_vec2(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
+	PoolVector<Vector3> _decode_accessor_as_vec3(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
+	PoolVector<Color> _decode_accessor_as_color(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
+	Vector<Quat> _decode_accessor_as_quat(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
+	Vector<Transform2D> _decode_accessor_as_xform2d(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
+	Vector<Basis> _decode_accessor_as_basis(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
+	Vector<Transform> _decode_accessor_as_xform(GLTFState &state, const GLTFAccessorIndex p_accessor, const bool p_for_vertex);
 
 	Error _parse_meshes(GLTFState &state);
 	Error _parse_images(GLTFState &state, const String &p_base_path);
@@ -355,7 +363,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 	GLTFNodeIndex _find_highest_node(GLTFState &state, const Vector<GLTFNodeIndex> &subtree);
 
-	bool _capture_nodes_in_skin(GLTFState &state, GLTFSkin &skin, GLTFNodeIndex node_index);
+	bool _capture_nodes_in_skin(GLTFState &state, GLTFSkin &skin, const GLTFNodeIndex node_index);
 	void _capture_nodes_for_multirooted_skin(GLTFState &state, GLTFSkin &skin);
 	Error _expand_skin(GLTFState &state, GLTFSkin &skin);
 	Error _verify_skin(GLTFState &state, GLTFSkin &skin);
@@ -364,7 +372,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 	Error _determine_skeletons(GLTFState &state);
 	Error _reparent_non_joint_skeleton_subtrees(GLTFState &state, GLTFSkeleton &skeleton, const Vector<GLTFNodeIndex> &non_joints);
 	Error _reparent_to_fake_joint(GLTFState &state, GLTFSkeleton &skeleton, const GLTFNodeIndex node_index);
-	Error _determine_skeleton_roots(GLTFState &state, GLTFSkeletonIndex &skel_i);
+	Error _determine_skeleton_roots(GLTFState &state, const GLTFSkeletonIndex skel_i);
 
 	Error _create_skeletons(GLTFState &state);
 	Error _map_skin_joints_indices_to_skeleton_bone_indices(GLTFState &state);
@@ -384,16 +392,16 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 	Spatial *_generate_spatial(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);
 
 	void _generate_scene_node(GLTFState &state, Node *scene_parent, Spatial *scene_root, const GLTFNodeIndex node_index);
-	Spatial *_generate_scene(GLTFState &state, int p_bake_fps);
+	Spatial *_generate_scene(GLTFState &state, const int p_bake_fps);
 
 	void _process_mesh_instances(GLTFState &state, Spatial *scene_root);
 
 	void _assign_scene_names(GLTFState &state);
 
 	template <class T>
-	T _interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, float p_time, GLTFAnimation::Interpolation p_interp);
+	T _interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, const float p_time, const GLTFAnimation::Interpolation p_interp);
 
-	void _import_animation(GLTFState &state, AnimationPlayer *ap, int index, int bake_fps);
+	void _import_animation(GLTFState &state, AnimationPlayer *ap, const GLTFAnimationIndex index, const int bake_fps);
 
 public:
 	virtual uint32_t get_import_flags() const;

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -191,6 +191,9 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		// The created Skeleton for the scene
 		Skeleton *godot_skeleton;
 
+		// Set of unique bone names for the skeleton
+		Set<String> unique_names;
+
 		GLTFSkeleton() :
 				godot_skeleton(nullptr) {
 		}
@@ -326,7 +329,11 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		}
 	};
 
+	String _sanitize_scene_name(const String &name);
 	String _gen_unique_name(GLTFState &state, const String &p_name);
+
+	String _sanitize_bone_name(const String &name);
+	String _gen_unique_bone_name(GLTFState &state, const GLTFSkeletonIndex skel_i, const String &p_name);
 
 	Ref<Texture> _get_texture(GLTFState &state, const GLTFTextureIndex p_texture);
 
@@ -381,6 +388,8 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 	Transform _compute_skin_to_skeleton_transform(const GLTFState &state, const GLTFNodeIndex skin_parent, const GLTFNodeIndex skeleton_parent);
 	void _compute_skeleton_rooted_skin_inverse_binds(GLTFState &state, const GLTFSkinIndex skin_i);
 	Error _create_skins(GLTFState &state);
+	bool _skins_are_same(const Ref<Skin>& skin_a, const Ref<Skin>& skin_b);
+	void _remove_duplicate_skins(GLTFState& state);
 
 	Error _parse_cameras(GLTFState &state);
 

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -229,10 +229,6 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		// Godot Skeleton's bone_indices
 		Map<int, int> joint_i_to_bone_i;
 
-		// The same inverse-binds as above, but they have been re-rooted to the
-		// skeletons parent node
-		Vector<Transform> skeleton_inverse_binds;
-
 		// The Actual Skin that will be created as a mapping between the IBM's of this skin
 		// to the generated skeleton for the mesh instances.
 		Ref<Skin> godot_skin;
@@ -368,7 +364,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 	Error _parse_materials(GLTFState &state);
 
-	GLTFNodeIndex _find_highest_node(GLTFState &state, const Vector<GLTFNodeIndex> &subtree);
+	GLTFNodeIndex _find_highest_node(GLTFState &state, const Vector<GLTFNodeIndex> &subset);
 
 	bool _capture_nodes_in_skin(GLTFState &state, GLTFSkin &skin, const GLTFNodeIndex node_index);
 	void _capture_nodes_for_multirooted_skin(GLTFState &state, GLTFSkin &skin);
@@ -384,12 +380,9 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 	Error _create_skeletons(GLTFState &state);
 	Error _map_skin_joints_indices_to_skeleton_bone_indices(GLTFState &state);
 
-	Transform _get_scene_transform_for_node(const GLTFState &state, const GLTFNodeIndex node_i);
-	Transform _compute_skin_to_skeleton_transform(const GLTFState &state, const GLTFNodeIndex skin_parent, const GLTFNodeIndex skeleton_parent);
-	void _compute_skeleton_rooted_skin_inverse_binds(GLTFState &state, const GLTFSkinIndex skin_i);
 	Error _create_skins(GLTFState &state);
-	bool _skins_are_same(const Ref<Skin>& skin_a, const Ref<Skin>& skin_b);
-	void _remove_duplicate_skins(GLTFState& state);
+	bool _skins_are_same(const Ref<Skin> &skin_a, const Ref<Skin> &skin_b);
+	void _remove_duplicate_skins(GLTFState &state);
 
 	Error _parse_cameras(GLTFState &state);
 


### PR DESCRIPTION
Initial Commit doing quite a bit of work:

- Expanding skins to capture non-joints
- Creating fake joints/stealing nodes for non-joints when they lie in between joints
- Merging overlapping Skins into a Skeleton
- Recomputing Skin IBM's to new Skeleton
- Making MeshInstances use new Skins + Skeletons
- ....and more stuff I don't remember

There needs to be quite a bit of code cleanup still, but functionality wise I think its in a good state and would like additional testing.

Tested GLTF2 files:
[godot-test-proj.zip](https://github.com/godotengine/godot/files/3634256/godot-test-proj.zip)

Preview:
https://f.staik.net/f/2bf.mp4
