### PR TITLE
TCP is_connected_to_host comparison error

### DIFF
--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -253,7 +253,7 @@ bool StreamPeerTCP::is_connected_to_host() const {
 		return false;
 	}
 
-	if (status != STATUS_CONNECTED) {
+	if (status == STATUS_CONNECTED) {
 		return true;
 	}
 

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -248,16 +248,7 @@ void StreamPeerTCP::set_no_delay(bool p_enabled) {
 
 bool StreamPeerTCP::is_connected_to_host() const {
 
-	if (status == STATUS_NONE || status == STATUS_ERROR) {
-
-		return false;
-	}
-
-	if (status == STATUS_CONNECTED) {
-		return true;
-	}
-
-	return _sock.is_valid() && _sock->is_open();
+	return _sock.is_valid() && _sock->is_open() && (status == STATUS_CONNECTED || status == STATUS_CONNECTING);
 }
 
 StreamPeerTCP::Status StreamPeerTCP::get_status() {


### PR DESCRIPTION
We was returning true when the state was not connected, so we would never return true when the state was connected.