### PR TITLE
Implement backward shift deletion for OAHashMap

### DIFF
--- a/main/tests/test_oa_hash_map.cpp
+++ b/main/tests/test_oa_hash_map.cpp
@@ -140,6 +140,19 @@ MainLoop *test() {
 		OS::get_singleton()->print("test for issue #31402 passed.\n");
 	}
 
+	// test collision resolution, should not crash or run indefinitely
+	{
+		OAHashMap<int, int> map(4);
+		map.set(1, 1);
+		map.set(5, 1);
+		map.set(9, 1);
+		map.set(13, 1);
+		map.remove(5);
+		map.remove(9);
+		map.remove(13);
+		map.set(5, 1);
+	}
+
 	return NULL;
 }
 } // namespace TestOAHashMap


### PR DESCRIPTION
Previous implementation of OAHashMap fails (either crashes or loops indefinitely) in corner cases found in stress tests for A* in #30556. The reason is that deleted elements still occupy slots in the original method, and this may cause the map to not resize even if the map is full considering 'tombstone' elements (since `num_elements` is not large enough). While this might be fixed by deferring the decrement of `num_elements` to after 'tombstone' removal, this patch instead replaces the logic with the backward shift deletion method to avoid them.

I have done no specific benchmarks, but since the cost of a deletion is equivalent to an insertion, and a deletion decreases the average probe sequence length (psl), performance should not be negatively affected (at least).

This, combined with a few more changes ([here](https://github.com/godotengine/godot/pull/30556#issuecomment-530310742)), makes A* tests in #30556 pass. I will rebase the changes and request review from there once this is merged.

Reference: http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/  
CC @karroffel