### PR TITLE
Fix Open Project Data Folder does not work

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2571,6 +2571,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			save_all_scenes();
 			restart_editor();
 		} break;
+		case RUN_PROJECT_DATA_FOLDER: {
+			OS::get_singleton()->shell_open(String("file://") + OS::get_singleton()->get_user_data_dir());
+		} break;
 		default: {
 		}
 	}


### PR DESCRIPTION
in the switch into  EditorNode::_menu_option_confirm
I noticed that the RUN_PROJECT_DATA_FOLDER case was missing, I added it with the related code. 