### PR TITLE
Fix Android Launcher Activity

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1537,7 +1537,7 @@ public:
 		args.push_back("-a");
 		args.push_back("android.intent.action.MAIN");
 		args.push_back("-n");
-		args.push_back(get_package_name(package_name) + "/org.godotengine.godot.Godot");
+		args.push_back(get_package_name(package_name) + "/com.godot.game.GodotApp");
 
 		err = OS::get_singleton()->execute(adb, args, true, NULL, NULL, &rv);
 		if (err || rv != 0) {


### PR DESCRIPTION
With PR #31919 Android file hierarchy was changed and when you want to run project from editor, game can not start automatically for Android because `adb` want to start different activity which does not launcher.