### PR TITLE
Add option to consider disable points

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -257,14 +257,14 @@ void AStar::reserve_space(int p_num_nodes) {
 	points.reserve(p_num_nodes);
 }
 
-int AStar::get_closest_point(const Vector3 &p_point) const {
+int AStar::get_closest_point(const Vector3 &p_point, bool p_include_disabled) const {
 
 	int closest_id = -1;
 	real_t closest_dist = 1e20;
 
 	for (OAHashMap<int, Point *>::Iterator it = points.iter(); it.valid; it = points.next_iter(it)) {
 
-		if (!(*it.value)->enabled) continue; // Disabled points should not be considered.
+		if (!p_include_disabled && !(*it.value)->enabled) continue; // Disabled points should not be considered.
 
 		real_t d = p_point.distance_squared_to((*it.value)->pos);
 		if (closest_id < 0 || d < closest_dist) {
@@ -540,7 +540,7 @@ void AStar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reserve_space", "num_nodes"), &AStar::reserve_space);
 	ClassDB::bind_method(D_METHOD("clear"), &AStar::clear);
 
-	ClassDB::bind_method(D_METHOD("get_closest_point", "to_position"), &AStar::get_closest_point);
+	ClassDB::bind_method(D_METHOD("get_closest_point", "to_position", "include_disabled"), &AStar::get_closest_point, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_closest_position_in_segment", "to_position"), &AStar::get_closest_position_in_segment);
 
 	ClassDB::bind_method(D_METHOD("get_point_path", "from_id", "to_id"), &AStar::get_point_path);
@@ -638,8 +638,8 @@ void AStar2D::reserve_space(int p_num_nodes) {
 	astar.reserve_space(p_num_nodes);
 }
 
-int AStar2D::get_closest_point(const Vector2 &p_point) const {
-	return astar.get_closest_point(Vector3(p_point.x, p_point.y, 0));
+int AStar2D::get_closest_point(const Vector2 &p_point, bool p_include_disabled) const {
+	return astar.get_closest_point(Vector3(p_point.x, p_point.y, 0), p_include_disabled);
 }
 
 Vector2 AStar2D::get_closest_position_in_segment(const Vector2 &p_point) const {
@@ -693,7 +693,7 @@ void AStar2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reserve_space", "num_nodes"), &AStar2D::reserve_space);
 	ClassDB::bind_method(D_METHOD("clear"), &AStar2D::clear);
 
-	ClassDB::bind_method(D_METHOD("get_closest_point", "to_position"), &AStar2D::get_closest_point);
+	ClassDB::bind_method(D_METHOD("get_closest_point", "to_position", "include_disabled"), &AStar2D::get_closest_point, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_closest_position_in_segment", "to_position"), &AStar2D::get_closest_position_in_segment);
 
 	ClassDB::bind_method(D_METHOD("get_point_path", "from_id", "to_id"), &AStar2D::get_point_path);

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -141,7 +141,7 @@ public:
 	void reserve_space(int p_num_nodes);
 	void clear();
 
-	int get_closest_point(const Vector3 &p_point) const;
+	int get_closest_point(const Vector3 &p_point, bool p_include_disabled = false) const;
 	Vector3 get_closest_position_in_segment(const Vector3 &p_point) const;
 
 	PoolVector<Vector3> get_point_path(int p_from_id, int p_to_id);
@@ -183,7 +183,7 @@ public:
 	void reserve_space(int p_num_nodes);
 	void clear();
 
-	int get_closest_point(const Vector2 &p_point) const;
+	int get_closest_point(const Vector2 &p_point, bool p_include_disabled = false) const;
 	Vector2 get_closest_position_in_segment(const Vector2 &p_point) const;
 
 	PoolVector<Vector2> get_point_path(int p_from_id, int p_to_id);


### PR DESCRIPTION
Previously, there is no way to obtain the disabled points using `get_closest_point`. This commit changes that by introducing an additional flag for this behavior that will not skip disabled points.

Closes #31814.
Related file: [issue_31814.zip](https://github.com/godotengine/godot/files/3639711/issue_31814.zip)

```
extends Node
func _ready():
	var astar = AStar.new()
	astar.add_point(1, Vector3(1, 1, 1))
	astar.add_point(2, Vector3(2, 2, 2))
	astar.set_point_disabled(1)
	astar.connect_points(1, 2)
	print(astar.get_closest_point(Vector3(0,0,0)))
	print(astar.get_closest_point(Vector3(0,0,0), false))
	pass # Replace with function body.
```
will print
```
2
1
```