### PR TITLE
Fix Android keyboard crash with left cursor

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
@@ -96,7 +96,6 @@ public class GodotInputHandler implements InputDeviceListener {
 						GodotLib.joybutton(device_id, button, false);
 					}
 				});
-				return true;
 			}
 		} else {
 			final int chr = event.getUnicodeChar(0);
@@ -108,7 +107,7 @@ public class GodotInputHandler implements InputDeviceListener {
 			});
 		};
 
-		return false;
+		return true;
 	}
 
 	public boolean onKeyDown(final int keyCode, KeyEvent event) {
@@ -142,7 +141,6 @@ public class GodotInputHandler implements InputDeviceListener {
 						GodotLib.joybutton(device_id, button, true);
 					}
 				});
-				return true;
 			}
 		} else {
 			final int chr = event.getUnicodeChar(0);
@@ -154,7 +152,7 @@ public class GodotInputHandler implements InputDeviceListener {
 			});
 		};
 
-		return false;
+		return true;
 	}
 
 	public boolean onGenericMotionEvent(MotionEvent event) {


### PR DESCRIPTION
Fixes #32168.
Previously we were returning all key up and key down messages as unhandled to the OS. This was resulting in crashes on certain keypresses (left cursor), for undetermined reason.

This PR defaults all key up and keydown messages to be returned as handled by Godot, except those explicitly coded as exceptions (currently volume keys only).