### PR TITLE
Fix crash on Android devices supporting S3TC

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -6184,6 +6184,13 @@ void RasterizerStorageGLES2::initialize() {
 	config.pvrtc_supported = config.extensions.has("GL_IMG_texture_compression_pvrtc") || config.extensions.has("WEBGL_compressed_texture_pvrtc");
 	config.support_npot_repeat_mipmap = config.extensions.has("GL_OES_texture_npot");
 
+	// If the desktop build is using S3TC, and you export / run from the IDE for android, if the device supports
+	// S3TC it will crash trying to load these textures, as they are not exported in the APK. This is a simple way
+	// to prevent Android devices trying to load S3TC, by faking lack of hardware support.
+#if defined(ANDROID_ENABLED) || defined(IPHONE_ENABLED)
+	config.s3tc_supported = false;
+#endif
+
 #ifdef JAVASCRIPT_ENABLED
 	// RenderBuffer internal format must be 16 bits in WebGL,
 	// but depth_texture should default to 32 always


### PR DESCRIPTION
Fixes #28308

Android devices that support S3TC will currently crash if you export / run from the IDE a project that has S3TC textures imported. This is because these are not exported in the APK (android exporter, exporter.cpp, get_preset_features()), but the .import file still contains a reference to the S3TC files, and the app will attempt to load the resource and fail.

This PR fixes this by simply faking lack of hardware support for S3TC on android devices.

An alternative method maybe to remove the reference to the s3tc in the .import file.