### PR TITLE
Focus the project manager's search box automatically on startup

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1757,6 +1757,12 @@ void ProjectManager::_notification(int p_what) {
 
 			if (_project_list->get_project_count() == 0 && StreamPeerSSL::is_available())
 				open_templates->popup_centered_minsize();
+
+			if (_project_list->get_project_count() >= 1) {
+				// Focus on the search box immediately to allow the user
+				// to search without having to reach for their mouse
+				project_filter->search_box->grab_focus();
+			}
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 


### PR DESCRIPTION
This allows the user to search projects as soon as the project manager opens, without having to click on the search field first.