### PR TITLE
Update the Godot gradle build tasks to provide additional flexibility

### DIFF
--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -20,14 +20,33 @@ allprojects {
     }
 }
 
-def binDir = "../../../bin/"
+ext {
+    sconsExt = org.gradle.internal.os.OperatingSystem.current().isWindows() ? ".bat" : ""
+
+    supportedAbis = ["armv7", "arm64v8", "x86", "x86_64"]
+    supportedTargets = ['release':"release", 'debug':"release_debug"]
+
+    // Used by gradle to specify which architecture to build for by default when running `./gradlew build`.
+    // This command is usually used by Android Studio.
+    // If building manually on the command line, it's recommended to use the
+    // `./gradlew generateGodotTemplates` build command instead after running the `scons` command.
+    // The defaultAbi must be one of the {supportedAbis} values.
+    defaultAbi = "arm64v8"
+}
+
+def rootDir = "../../.."
+def binDir = "$rootDir/bin/"
+
+def getSconsTaskName(String buildType) {
+    return "compileGodotNativeLibs" + buildType.capitalize()
+}
 
 /**
  * Copy the generated 'android_debug.apk' binary template into the Godot bin directory.
  * Depends on the app build task to ensure the binary is generated prior to copying.
  */
 task copyDebugBinaryToBin(type: Copy) {
-    dependsOn ':app:build'
+    dependsOn ':app:assembleDebug'
     from('app/build/outputs/apk/debug')
     into(binDir)
     include('android_debug.apk')
@@ -38,7 +57,7 @@ task copyDebugBinaryToBin(type: Copy) {
  * Depends on the app build task to ensure the binary is generated prior to copying.
  */
 task copyReleaseBinaryToBin(type: Copy) {
-    dependsOn ':app:build'
+    dependsOn ':app:assembleRelease'
     from('app/build/outputs/apk/release')
     into(binDir)
     include('android_release.apk')
@@ -49,7 +68,7 @@ task copyReleaseBinaryToBin(type: Copy) {
  * Depends on the library build task to ensure the AAR file is generated prior to copying.
  */
 task copyDebugAAR(type: Copy) {
-    dependsOn ':lib:build'
+    dependsOn ':lib:assembleDebug'
     from('lib/build/outputs/aar')
     into('app/libs/debug')
     include('godot-lib.debug.aar')
@@ -60,7 +79,7 @@ task copyDebugAAR(type: Copy) {
  * Depends on the library build task to ensure the AAR file is generated prior to copying.
  */
 task copyReleaseAAR(type: Copy) {
-    dependsOn ':lib:build'
+    dependsOn ':lib:assembleRelease'
     from('lib/build/outputs/aar')
     into('app/libs/release')
     include('godot-lib.release.aar')
@@ -72,8 +91,10 @@ task copyReleaseAAR(type: Copy) {
  * The zip file also includes some gradle tools to allow building of the custom build.
  */
 task zipCustomBuild(type: Zip) {
-    dependsOn 'copyDebugAAR'
-    dependsOn 'copyReleaseAAR'
+    dependsOn ':generateGodotTemplates'
+    doFirst {
+        logger.lifecycle("Generating Godot custom build template")
+    }
     from(fileTree(dir: 'app', excludes: ['**/build/**', '**/.gradle/**', '**/*.iml']), fileTree(dir: '.', includes: ['gradle.properties','gradlew', 'gradlew.bat', 'gradle/**']))
     include '**/*'
     archiveName 'android_source.zip'
@@ -84,12 +105,48 @@ task zipCustomBuild(type: Zip) {
  * Master task used to coordinate the tasks defined above to generate the set of Godot templates.
  */
 task generateGodotTemplates(type: GradleBuild) {
-    tasks = [
-            // Copy the generated aar library files to the custom build directory.
-            'copyDebugAAR', 'copyReleaseAAR',
-            // Zip the custom build directory.
-            'zipCustomBuild',
-            // Copy the prebuilt binary templates to the bin directory.
-            'copyDebugBinaryToBin', 'copyReleaseBinaryToBin',
-    ]
+    // We exclude these gradle tasks so we can run the scons command manually.
+    for (String buildType : supportedTargets.keySet()) {
+        startParameter.excludedTaskNames += ":lib:" + getSconsTaskName(buildType)
+    }
+
+    tasks = []
+
+    // Only build the apks and aar files for which we have native shared libraries.
+    for (String target : supportedTargets.keySet()) {
+        File targetLibs = new File("lib/libs/" + target)
+        if (targetLibs != null && targetLibs.isDirectory()) {
+            File[] targetLibsContents = targetLibs.listFiles()
+            if (targetLibsContents != null && targetLibsContents.length > 0) {
+                // Copy the generated aar library files to the custom build directory.
+                tasks += "copy" + target.capitalize() + "AAR"
+                // Copy the prebuilt binary templates to the bin directory.
+                tasks += "copy" + target.capitalize() + "BinaryToBin"
+            }
+        }
+    }
+
+    finalizedBy 'zipCustomBuild'
+}
+
+/**
+ * Clean the generated artifacts.
+ */
+task cleanGodotTemplates(type: Delete) {
+	// Delete the generated native libs
+	delete("lib/libs")
+
+	// Delete the library generated AAR files
+	delete("lib/build/outputs/aar")
+
+	// Delete the app libs directory contents
+	delete("app/libs")
+
+	// Delete the generated binary apks
+	delete("app/build/outputs/apk")
+
+	// Delete the Godot templates in the Godot bin directory
+	delete("$binDir/android_debug.apk")
+	delete("$binDir/android_release.apk")
+	delete("$binDir/android_source.zip")
 }

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -5,8 +5,6 @@ dependencies {
 }
 
 def pathToRootDir = "../../../../"
-// Note: Only keep the abis you support to speed up the gradle 'assemble' task.
-def supportedAbis = ["armv7", "arm64v8", "x86", "x86_64"]
 
 android {
     compileSdkVersion versions.compileSdk
@@ -56,27 +54,20 @@ android {
         // files is only setup for editing support.
         gradle.startParameter.excludedTaskNames += taskPrefix + "externalNativeBuild" + buildType
 
-        // Create tasks to generate the Godot native libraries.
-        def taskName = "compileGodotNativeLibs" + buildType
-        def releaseTarget = "release"
-        if (buildType == "Debug") {
-            releaseTarget += "_debug"
+        def releaseTarget = supportedTargets[buildType.toLowerCase()]
+        if (releaseTarget == null || releaseTarget == "") {
+            throw new GradleException("Invalid build type: " + buildType)
         }
 
-        def abiTaskNames = []
-        // Creating gradle tasks to generate the native libraries for the supported abis.
-        supportedAbis.each { abi ->
-            def abiTaskName = taskName + abi.capitalize()
-            abiTaskNames += abiTaskName
-            tasks.create(name: abiTaskName, type: Exec) {
-                executable "scons"
-                args "--directory=${pathToRootDir}", "platform=android", "target=${releaseTarget}", "android_arch=${abi}"
-            }
+        if (!supportedAbis.contains(defaultAbi)) {
+            throw new GradleException("Invalid default abi: " + defaultAbi)
         }
 
-        // Creating gradle task to run all of the previously generated tasks.
-        tasks.create(name: taskName, type: GradleBuild) {
-            tasks = abiTaskNames
+        // Creating gradle task to generate the native libraries for the default abi.
+        def taskName = getSconsTaskName(buildType)
+        tasks.create(name: taskName, type: Exec) {
+            executable "scons" + sconsExt
+            args "--directory=${pathToRootDir}", "platform=android", "target=${releaseTarget}", "android_arch=${defaultAbi}", "-j" + Runtime.runtime.availableProcessors()
         }
 
         // Schedule the tasks so the generated libs are present before the aar file is packaged.


### PR DESCRIPTION
Updates the Godot gradle tasks to enable manual runs of the `scons` command.

Example: To generate for the `release` build target and for the `armv7`, `arm64v8` and `x86` architectures, run the commands:
```
cd godot
scons -j4 platform=android target=release android_arch=armv7
scons -j4 platform=android target=release android_arch=arm64v8
scons -j4 platform=android target=release android_arch=x86
cd platform/android/java
./gradlew generateGodotTemplates
```

Notes:
- The generated build templates will be located in the `godot/bin` directory (i.e: `android_debug.apk`, `android_release.apk`, `android_source.zip`).
- The gradle command will only generate templates for the target(s) with available native shared libraries. For example, running the commands above will only generate the `android_release.apk` and `android_source.zip` files.


To delete the generated artifacts, the following commands can be used:
```
cd platform/android/java
./gradlew cleanGodotTemplates
```

Fixes #32215
Fixes #32270