### PR TITLE
Register Bullet-specific classes only when the module is enabled

### DIFF
--- a/modules/bullet/register_types.cpp
+++ b/modules/bullet/register_types.cpp
@@ -34,6 +34,10 @@
 #include "core/class_db.h"
 #include "core/project_settings.h"
 
+#include "scene/3d/soft_body.h"
+#include "scene/resources/cylinder_shape.h"
+#include "scene/resources/height_map_shape.h"
+
 /**
 	@author AndreaCatania
 */
@@ -51,6 +55,10 @@ void register_bullet_types() {
 
 	GLOBAL_DEF("physics/3d/active_soft_world", true);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/active_soft_world", PropertyInfo(Variant::BOOL, "physics/3d/active_soft_world"));
+
+	ClassDB::register_class<SoftBody>();
+	ClassDB::register_class<CylinderShape>();
+	ClassDB::register_class<HeightMapShape>();
 #endif
 }
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -136,12 +136,10 @@
 #include "scene/resources/concave_polygon_shape_2d.h"
 #include "scene/resources/convex_polygon_shape.h"
 #include "scene/resources/convex_polygon_shape_2d.h"
-#include "scene/resources/cylinder_shape.h"
 #include "scene/resources/default_theme/default_theme.h"
 #include "scene/resources/dynamic_font.h"
 #include "scene/resources/dynamic_font_stb.h"
 #include "scene/resources/gradient.h"
-#include "scene/resources/height_map_shape.h"
 #include "scene/resources/line_shape_2d.h"
 #include "scene/resources/material.h"
 #include "scene/resources/mesh.h"
@@ -203,7 +201,6 @@
 #include "scene/3d/remote_transform.h"
 #include "scene/3d/room_instance.h"
 #include "scene/3d/skeleton.h"
-#include "scene/3d/soft_body.h"
 #include "scene/3d/spring_arm.h"
 #include "scene/3d/sprite_3d.h"
 #include "scene/3d/vehicle_body.h"
@@ -440,8 +437,6 @@ void register_scene_types() {
 	ClassDB::register_class<SpringArm>();
 
 	ClassDB::register_class<PhysicalBone>();
-	ClassDB::register_class<SoftBody>();
-
 	ClassDB::register_class<SkeletonIK>();
 	ClassDB::register_class<BoneAttachment>();
 
@@ -629,8 +624,6 @@ void register_scene_types() {
 	ClassDB::register_class<SphereShape>();
 	ClassDB::register_class<BoxShape>();
 	ClassDB::register_class<CapsuleShape>();
-	ClassDB::register_class<CylinderShape>();
-	ClassDB::register_class<HeightMapShape>();
 	ClassDB::register_class<PlaneShape>();
 	ClassDB::register_class<ConvexPolygonShape>();
 	ClassDB::register_class<ConcavePolygonShape>();


### PR DESCRIPTION
Fixes #32216, Fixes #32217. 

The following classes are only implemented in Bullet for now, but these can be moved to `scene/register_scene_types.cpp` once implemented in GodotPhysics or when the support for GodotPhysics in 3D is deprecated in favor of Bullet:

* CylinderShape
* HeightMapShape
* SoftBody