### PR TITLE
fix kinematicBody2D jitters when sync_to_physics is turned on

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -46,8 +46,6 @@ void CollisionObject2D::_notification(int p_what) {
 			else
 				Physics2DServer::get_singleton()->body_set_state(rid, Physics2DServer::BODY_STATE_TRANSFORM, global_transform);
 
-			last_transform = global_transform;
-
 			RID space = get_world_2d()->get_space();
 			if (area) {
 				Physics2DServer::get_singleton()->area_set_space(rid, space);
@@ -73,18 +71,16 @@ void CollisionObject2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 
-			Transform2D global_transform = get_global_transform();
-
-			if (only_update_transform_changes && global_transform == last_transform) {
+			if (only_update_transform_changes) {
 				return;
 			}
+
+			Transform2D global_transform = get_global_transform();
 
 			if (area)
 				Physics2DServer::get_singleton()->area_set_transform(rid, global_transform);
 			else
 				Physics2DServer::get_singleton()->body_set_state(rid, Physics2DServer::BODY_STATE_TRANSFORM, global_transform);
-
-			last_transform = global_transform;
 
 		} break;
 		case NOTIFICATION_EXIT_TREE: {

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -67,7 +67,6 @@ class CollisionObject2D : public Node2D {
 	int total_subshapes;
 
 	Map<uint32_t, ShapeData> shapes;
-	Transform2D last_transform;
 	bool only_update_transform_changes; //this is used for sync physics in KinematicBody
 
 protected:


### PR DESCRIPTION
closes #28181
seems `last_transform` is useless and it cause sync happens per two frames