### PR TITLE
Fix `line` being assigned to twice in the GDScript language server

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -345,15 +345,13 @@ String ExtendGDScriptParser::marked_documentation(const String &p_bbcode) {
 		if (block_start != -1) {
 			code_block_indent = block_start;
 			in_code_block = true;
-			line = "'''gdscript";
-			line = "\n";
+			line = "'''gdscript\n";
 		} else if (in_code_block) {
 			line = "\t" + line.substr(code_block_indent, line.length());
 		}
 
 		if (in_code_block && line.find("[/codeblock]") != -1) {
-			line = "'''\n";
-			line = "\n";
+			line = "'''\n\n";
 			in_code_block = false;
 		}
 


### PR DESCRIPTION
This closes #32090.