### PR TITLE
Fix ERR_MSG macros to make their behaviour consistent with normal ERR macros.

### DIFF
--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -140,14 +140,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                  \
-	do {                                                                                                            \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-			ERR_EXPLAIN(m_msg);                                                                                     \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return;                                                                                                 \
-		}                                                                                                           \
-		_err_error_exists = false;                                                                                  \
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                               \
+	do {                                                                                         \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			return;                                                                              \
+		}                                                                                        \
+		_err_error_exists = false;                                                               \
 	} while (0); // (*)
 
 /** An index has failed if m_index<0 or m_index >=m_size, the function exits.
@@ -164,14 +163,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                      \
-	do {                                                                                                            \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-			ERR_EXPLAIN(m_msg);                                                                                     \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return m_retval;                                                                                        \
-		}                                                                                                           \
-		_err_error_exists = false;                                                                                  \
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                   \
+	do {                                                                                         \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			return m_retval;                                                                     \
+		}                                                                                        \
+		_err_error_exists = false;                                                               \
 	} while (0); // (*)
 
 /** An index has failed if m_index >=m_size, the function exits.
@@ -188,14 +186,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
-#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                             \
-	do {                                                                                                            \
-		if (unlikely((m_index) >= (m_size))) {                                                                      \
-			ERR_EXPLAIN(m_msg);                                                                                     \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return m_retval;                                                                                        \
-		}                                                                                                           \
-		_err_error_exists = false;                                                                                  \
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                          \
+	do {                                                                                         \
+		if (unlikely((m_index) >= (m_size))) {                                                   \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			return m_retval;                                                                     \
+		}                                                                                        \
+		_err_error_exists = false;                                                               \
 	} while (0); // (*)
 
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
@@ -209,13 +206,12 @@ extern bool _err_error_exists;
 		}                                                                                                                 \
 	} while (0); // (*)
 
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                       \
-	do {                                                                                                                  \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                           \
-			ERR_EXPLAIN(m_msg);                                                                                           \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), true); \
-			GENERATE_TRAP                                                                                                 \
-		}                                                                                                                 \
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                              \
+	do {                                                                                         \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			GENERATE_TRAP                                                                        \
+		}                                                                                        \
 	} while (0); // (*)
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -231,14 +227,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                          \
 	}
 
-#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                   \
-	{                                                                                                       \
-		if (unlikely(!m_param)) {                                                                           \
-			ERR_EXPLAIN(m_msg);                                                                             \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null."); \
-			return;                                                                                         \
-		}                                                                                                   \
-		_err_error_exists = false;                                                                          \
+#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                        \
+	{                                                                                            \
+		if (unlikely(!m_param)) {                                                                \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			return;                                                                              \
+		}                                                                                        \
+		_err_error_exists = false;                                                               \
 	}
 
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                                  \
@@ -250,14 +245,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                          \
 	}
 
-#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                       \
-	{                                                                                                       \
-		if (unlikely(!m_param)) {                                                                           \
-			ERR_EXPLAIN(m_msg);                                                                             \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null."); \
-			return m_retval;                                                                                \
-		}                                                                                                   \
-		_err_error_exists = false;                                                                          \
+#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                            \
+	{                                                                                            \
+		if (unlikely(!m_param)) {                                                                \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			return m_retval;                                                                     \
+		}                                                                                        \
+		_err_error_exists = false;                                                               \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -273,14 +267,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                         \
 	}
 
-#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                   \
-	{                                                                                                      \
-		if (unlikely(m_cond)) {                                                                            \
-			ERR_EXPLAIN(m_msg);                                                                            \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true."); \
-			return;                                                                                        \
-		}                                                                                                  \
-		_err_error_exists = false;                                                                         \
+#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                         \
+	{                                                                                            \
+		if (unlikely(m_cond)) {                                                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			return;                                                                              \
+		}                                                                                        \
+		_err_error_exists = false;                                                               \
 	}
 
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
@@ -294,13 +287,12 @@ extern bool _err_error_exists;
 		}                                                                                                         \
 	}
 
-#define CRASH_COND_MSG(m_cond, m_msg)                                                                             \
-	{                                                                                                             \
-		if (unlikely(m_cond)) {                                                                                   \
-			ERR_EXPLAIN(m_msg);                                                                                   \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition ' " _STR(m_cond) " ' is true."); \
-			GENERATE_TRAP                                                                                         \
-		}                                                                                                         \
+#define CRASH_COND_MSG(m_cond, m_msg)                                                            \
+	{                                                                                            \
+		if (unlikely(m_cond)) {                                                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			GENERATE_TRAP                                                                        \
+		}                                                                                        \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -318,14 +310,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                                   \
 	}
 
-#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                 \
-	{                                                                                                                                \
-		if (unlikely(m_cond)) {                                                                                                      \
-			ERR_EXPLAIN(m_msg);                                                                                                      \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. returned: " _STR(m_retval)); \
-			return m_retval;                                                                                                         \
-		}                                                                                                                            \
-		_err_error_exists = false;                                                                                                   \
+#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                             \
+	{                                                                                            \
+		if (unlikely(m_cond)) {                                                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			return m_retval;                                                                     \
+		}                                                                                        \
+		_err_error_exists = false;                                                               \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -341,14 +332,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                       \
 	}
 
-#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                  \
-	{                                                                                                                    \
-		if (unlikely(m_cond)) {                                                                                          \
-			ERR_EXPLAIN(m_msg);                                                                                          \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Continuing..:"); \
-			continue;                                                                                                    \
-		}                                                                                                                \
-		_err_error_exists = false;                                                                                       \
+#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                          \
+	{                                                                                            \
+		if (unlikely(m_cond)) {                                                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			continue;                                                                            \
+		}                                                                                        \
+		_err_error_exists = false;                                                               \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -364,14 +354,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                     \
 	}
 
-#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                   \
-	{                                                                                                                  \
-		if (unlikely(m_cond)) {                                                                                        \
-			ERR_EXPLAIN(m_msg);                                                                                        \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:"); \
-			break;                                                                                                     \
-		}                                                                                                              \
-		_err_error_exists = false;                                                                                     \
+#define ERR_BREAK_MSG(m_cond, m_msg)                                                             \
+	{                                                                                            \
+		if (unlikely(m_cond)) {                                                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+			break;                                                                               \
+		}                                                                                        \
+		_err_error_exists = false;                                                               \
 	}
 
 /** Print an error string and return
@@ -384,10 +373,11 @@ extern bool _err_error_exists;
 		return;                                                                        \
 	}
 
-#define ERR_FAIL_MSG(m_msg) \
-	{                       \
-		ERR_EXPLAIN(m_msg); \
-		ERR_FAIL();         \
+#define ERR_FAIL_MSG(m_msg)                                                                  \
+	{                                                                                        \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+		_err_error_exists = false;                                                           \
+		return;                                                                              \
 	}
 
 /** Print an error string and return with value
@@ -400,10 +390,11 @@ extern bool _err_error_exists;
 		return m_value;                                                                                           \
 	}
 
-#define ERR_FAIL_V_MSG(m_value, m_msg) \
-	{                                  \
-		ERR_EXPLAIN(m_msg);            \
-		ERR_FAIL_V(m_value);           \
+#define ERR_FAIL_V_MSG(m_value, m_msg)                                                       \
+	{                                                                                        \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+		_err_error_exists = false;                                                           \
+		return m_value;                                                                      \
 	}
 
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
@@ -415,10 +406,10 @@ extern bool _err_error_exists;
 		GENERATE_TRAP                                                                         \
 	}
 
-#define CRASH_NOW_MSG(m_msg) \
-	{                        \
-		ERR_EXPLAIN(m_msg);  \
-		CRASH_NOW();         \
+#define CRASH_NOW_MSG(m_msg)                                                                 \
+	{                                                                                        \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data()); \
+		GENERATE_TRAP                                                                        \
 	}
 
 /** Print an error string.
@@ -481,15 +472,14 @@ extern bool _err_error_exists;
 		}                                                                                                                                                 \
 	}
 
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                        \
-	{                                                                                                                                                     \
-		static volatile bool warning_shown = false;                                                                                                       \
-		if (!warning_shown) {                                                                                                                             \
-			ERR_EXPLAIN(m_msg);                                                                                                                           \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future", ERR_HANDLER_WARNING); \
-			_err_error_exists = false;                                                                                                                    \
-			warning_shown = true;                                                                                                                         \
-		}                                                                                                                                                 \
+#define WARN_DEPRECATED_MSG(m_msg)                                                                                    \
+	{                                                                                                                 \
+		static volatile bool warning_shown = false;                                                                   \
+		if (!warning_shown) {                                                                                         \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, String(m_msg).utf8().get_data(), ERR_HANDLER_WARNING); \
+			_err_error_exists = false;                                                                                \
+			warning_shown = true;                                                                                     \
+		}                                                                                                             \
 	}
 
 #endif


### PR DESCRIPTION
As seen in #32276, #31832, #32143, the current `ERR_MSG` macros sometimes seem to produce the error message provided and sometimes just the assert condition, apparently like in #32143 it also seems to differ between editor and the terminal..

This is a bandaid fix (as something else seems to cause the discrepancy, so if the error list system is used in another place, it'll still behave erratically in those cases), but this should at least make the behaviour consistent for error macro usage with and without a message.

Testing needed, CC @Xrayez @KoBeWi @qarmin mind helping out? :D