### PR TITLE
Don't open a project in the list if Ctrl is held while double-clicking

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1689,7 +1689,7 @@ void ProjectList::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 
 		emit_signal(SIGNAL_SELECTION_CHANGED);
 
-		if (mb->is_doubleclick()) {
+		if (!mb->get_control() && mb->is_doubleclick()) {
 			emit_signal(SIGNAL_PROJECT_ASK_OPEN);
 		}
 	}


### PR DESCRIPTION
This prevents accidentally editing a project while selecting many projects by holding <kbd>Ctrl</kbd>.