### PR TITLE
Improve the `OS.shell_open()` documentation

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -828,9 +828,10 @@
 			<argument index="0" name="uri" type="String">
 			</argument>
 			<description>
-				Requests the OS to open a resource with the most appropriate program. For example.
-					[code]OS.shell_open("C:\\Users\name\Downloads")[/code] on Windows opens the file explorer at the downloads folders of the user.
-					[code]OS.shell_open("https://godotengine.org")[/code] opens the default web browser on the official Godot website.
+				Requests the OS to open a resource with the most appropriate program. For example:
+				- [code]OS.shell_open("C:\\Users\name\Downloads")[/code] on Windows opens the file explorer at the user's Downloads folder.
+				- [code]OS.shell_open("https://godotengine.org")[/code] opens the default web browser on the official Godot website.
+				- [code]OS.shell_open("mailto:example@example.com")[/code] opens the default email client with the "To" field set to [code]example@example.com[/code]. See [url=https://blog.escapecreative.com/customizing-mailto-links/]Customizing [code]mailto:[/code] Links[/url] for a list of fields that can be added.
 			</description>
 		</method>
 		<method name="show_virtual_keyboard">


### PR DESCRIPTION
This adds a `mailto:` example to `OS.shell_open()`.

I've seen a few people ask about this on the Godot Q&A and Reddit, so it makes sense to document it :slightly_smiling_face: