### PR TITLE
Fix Hide Console Window stores opposite value

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2519,7 +2519,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 			bool was_visible = OS::get_singleton()->is_console_visible();
 			OS::get_singleton()->set_console_visible(!was_visible);
-			EditorSettings::get_singleton()->set_setting("interface/editor/hide_console_window", !was_visible);
+			EditorSettings::get_singleton()->set_setting("interface/editor/hide_console_window", was_visible);
 		} break;
 		case EDITOR_SCREENSHOT: {
 


### PR DESCRIPTION
Now when 

Press Editor -> Toggle System Console  
THEN Console hides 
THEN Editor settings ->Hide Console Window is TRUE

successively

Press Editor -> Toggle System Console  
THEN Console appears
THEN Editor settings ->Hide Console Window is FALSE

Fixes #32263 