### PR TITLE
Add flag to control the replacement of files by ProjectSettings.load_resource_pack

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -36,11 +36,11 @@
 
 #define PACK_VERSION 1
 
-Error PackedData::add_pack(const String &p_path) {
+Error PackedData::add_pack(const String &p_path, bool p_replace_files) {
 
 	for (int i = 0; i < sources.size(); i++) {
 
-		if (sources[i]->try_open_pack(p_path)) {
+		if (sources[i]->try_open_pack(p_path, p_replace_files)) {
 
 			return OK;
 		};
@@ -49,7 +49,7 @@ Error PackedData::add_pack(const String &p_path) {
 	return ERR_FILE_UNRECOGNIZED;
 };
 
-void PackedData::add_path(const String &pkg_path, const String &path, uint64_t ofs, uint64_t size, const uint8_t *p_md5, PackSource *p_src) {
+void PackedData::add_path(const String &pkg_path, const String &path, uint64_t ofs, uint64_t size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files) {
 
 	PathMD5 pmd5(path.md5_buffer());
 	//printf("adding path %ls, %lli, %lli\n", path.c_str(), pmd5.a, pmd5.b);
@@ -64,7 +64,8 @@ void PackedData::add_path(const String &pkg_path, const String &path, uint64_t o
 		pf.md5[i] = p_md5[i];
 	pf.src = p_src;
 
-	files[pmd5] = pf;
+	if (!exists || p_replace_files)
+		files[pmd5] = pf;
 
 	if (!exists) {
 		//search for dir
@@ -133,7 +134,7 @@ PackedData::~PackedData() {
 
 //////////////////////////////////////////////////////////////////
 
-bool PackedSourcePCK::try_open_pack(const String &p_path) {
+bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files) {
 
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f)
@@ -196,7 +197,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path) {
 		uint64_t size = f->get_64();
 		uint8_t md5[16];
 		f->get_buffer(md5, 16);
-		PackedData::get_singleton()->add_path(p_path, path, ofs, size, md5, this);
+		PackedData::get_singleton()->add_path(p_path, path, ofs, size, md5, this, p_replace_files);
 	};
 
 	return true;

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -102,13 +102,13 @@ private:
 
 public:
 	void add_pack_source(PackSource *p_source);
-	void add_path(const String &pkg_path, const String &path, uint64_t ofs, uint64_t size, const uint8_t *p_md5, PackSource *p_src); // for PackSource
+	void add_path(const String &pkg_path, const String &path, uint64_t ofs, uint64_t size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files); // for PackSource
 
 	void set_disabled(bool p_disabled) { disabled = p_disabled; }
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
 
 	static PackedData *get_singleton() { return singleton; }
-	Error add_pack(const String &p_path);
+	Error add_pack(const String &p_path, bool p_replace_files);
 
 	_FORCE_INLINE_ FileAccess *try_open_path(const String &p_path);
 	_FORCE_INLINE_ bool has_path(const String &p_path);
@@ -120,7 +120,7 @@ public:
 class PackSource {
 
 public:
-	virtual bool try_open_pack(const String &p_path) = 0;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files) = 0;
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file) = 0;
 	virtual ~PackSource() {}
 };
@@ -128,7 +128,7 @@ public:
 class PackedSourcePCK : public PackSource {
 
 public:
-	virtual bool try_open_pack(const String &p_path);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files);
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 };
 

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -160,7 +160,7 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 	return pkg;
 }
 
-bool ZipArchive::try_open_pack(const String &p_path) {
+bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files) {
 
 	//printf("opening zip pack %ls, %i, %i\n", p_name.c_str(), p_name.extension().nocasecmp_to("zip"), p_name.extension().nocasecmp_to("pcz"));
 	if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0)
@@ -210,7 +210,7 @@ bool ZipArchive::try_open_pack(const String &p_path) {
 		files[fname] = f;
 
 		uint8_t md5[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-		PackedData::get_singleton()->add_path(p_path, fname, 1, 0, md5, this);
+		PackedData::get_singleton()->add_path(p_path, fname, 1, 0, md5, this, p_replace_files);
 		//printf("packed data add path %ls, %ls\n", p_name.c_str(), fname.c_str());
 
 		if ((i + 1) < gi.number_entry) {

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -74,7 +74,7 @@ public:
 
 	bool file_exists(String p_name) const;
 
-	virtual bool try_open_pack(const String &p_path);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files);
 	FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 
 	static ZipArchive *get_singleton();

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -264,12 +264,12 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-bool ProjectSettings::_load_resource_pack(const String &p_pack) {
+bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files) {
 
 	if (PackedData::get_singleton()->is_disabled())
 		return false;
 
-	bool ok = PackedData::get_singleton()->add_pack(p_pack) == OK;
+	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files) == OK;
 
 	if (!ok)
 		return false;
@@ -979,7 +979,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
-	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack"), &ProjectSettings::_load_resource_pack);
+	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files"), &ProjectSettings::_load_resource_pack, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &ProjectSettings::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &ProjectSettings::property_get_revert);
 

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -104,7 +104,7 @@ protected:
 
 	void _convert_to_last_version(int p_from_version);
 
-	bool _load_resource_pack(const String &p_pack);
+	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true);
 
 	void _add_property_info_bind(const Dictionary &p_info);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -80,9 +80,11 @@
 			</return>
 			<argument index="0" name="pack" type="String">
 			</argument>
+			<argument index="1" name="replace_files" type="bool" default="true">
+			</argument>
 			<description>
 				Loads the contents of the .pck or .zip file specified by [code]pack[/code] into the resource filesystem ([code]res://[/code]). Returns [code]true[/code] on success.
-				[b]Note:[/b] If a file from [code]pack[/code] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [code]pack[/code].
+				[b]Note:[/b] If a file from [code]pack[/code] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [code]pack[/code] unless [code]replace_files[/code] is set to [code]false[/code].
 			</description>
 		</method>
 		<method name="localize_path" qualifiers="const">


### PR DESCRIPTION
When loading a mod via ProjectSettings.load_resource_pack(), the ability to overwrite existing files may not be wanted, as it can break the entire game, if the mod is poorly crafted.

This pull request introduces an additional parameter to ProjectSettings.load_resource_pack(). If overwrite_current is set to false, then existing files will be retained. (The default is set to true, in order to not break compability)