### PR TITLE
fix move_and_slide_with_snap cause artifact

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1324,12 +1324,9 @@ Vector2 KinematicBody2D::move_and_slide_with_snap(const Vector2 &p_linear_veloci
 				on_floor = true;
 				on_floor_body = col.collider_rid;
 				floor_velocity = col.collider_vel;
-				if (p_stop_on_slope) {
-					// move and collide may stray the object a bit because of pre un-stucking,
-					// so only ensure that motion happens on floor direction in this case.
-					col.travel = p_floor_direction * p_floor_direction.dot(col.travel);
+				if (p_stop_on_slope && p_floor_direction.cross(col.travel) != 0) {
+					apply = false;
 				}
-
 			} else {
 				apply = false;
 			}

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1262,10 +1262,8 @@ Vector3 KinematicBody::move_and_slide_with_snap(const Vector3 &p_linear_velocity
 				on_floor = true;
 				on_floor_body = col.collider_rid;
 				floor_velocity = col.collider_vel;
-				if (p_stop_on_slope) {
-					// move and collide may stray the object a bit because of pre un-stucking,
-					// so only ensure that motion happens on floor direction in this case.
-					col.travel = p_floor_direction * p_floor_direction.dot(col.travel);
+				if (p_stop_on_slope && col.travel.cross(p_floor_direction) == Vector3(0, 0, 0)) {
+					apply = false;
 				}
 			} else {
 				apply = false; //snapped with floor direction, but did not snap to a floor, do not snap.


### PR DESCRIPTION
close #31097
![Screen Shot 2019-09-24 at 2 03 19 PM](https://user-images.githubusercontent.com/8491351/65485299-177cd200-ded4-11e9-8f8c-d781e26521e9.png)

When near the slope, applying snap may cause object intersect with the slope, so just cancel it in this case.