### PR TITLE
doc: Fix parsing of self-closing XML tags

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -67,7 +67,7 @@
 		<member name="dialog_text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
 			The text displayed by the dialog.
 		</member>
-		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Alert!&quot;"/>
+		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Alert!&quot;" />
 	</members>
 	<signals>
 		<signal name="confirmed">

--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -61,7 +61,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0" />
 		<member name="fps" type="float" setter="set_fps" getter="get_fps" default="4.0">
 			Animation speed in frames per second. This value defines the default time interval between two frames of the animation, and thus the overall duration of the animation loop based on the [member frames] property. A value of 0 means no predefined number of frames per second, the animation will play according to each frame's frame delay (see [method set_frame_delay]).
 			For example, an animation with 8 frames, no frame delay and a [code]fps[/code] value of 2 will run for 4 seconds, with each frame lasting 0.5 seconds.

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -61,7 +61,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" override="true" default="true"/>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" override="true" default="true" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -17,7 +17,7 @@
 		<member name="filter_clip" type="bool" setter="set_filter_clip" getter="has_filter_clip" default="false">
 			If [code]true[/code], clips the area outside of the region to avoid bleeding of the surrounding texture pixels.
 		</member>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0" />
 		<member name="margin" type="Rect2" setter="set_margin" getter="get_margin" default="Rect2( 0, 0, 0, 0 )">
 			The margin around the region. The [Rect2]'s [member Rect2.size] parameter ("w" and "h" in the editor) resizes the texture so it fits within the margin.
 		</member>

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -54,7 +54,7 @@
 		<member name="enabled_focus_mode" type="int" setter="set_enabled_focus_mode" getter="get_enabled_focus_mode" enum="Control.FocusMode" default="2">
 			Focus access mode to use when switching between enabled/disabled (see [member Control.focus_mode] and [member disabled]).
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2"/>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="group" type="ButtonGroup" setter="set_button_group" getter="get_button_group">
 			[ButtonGroup] associated to the button.
 		</member>

--- a/doc/classes/BoxContainer.xml
+++ b/doc/classes/BoxContainer.xml
@@ -23,7 +23,7 @@
 		<member name="alignment" type="int" setter="set_alignment" getter="get_alignment" enum="BoxContainer.AlignMode" default="0">
 			The alignment of the container's children (must be one of [constant ALIGN_BEGIN], [constant ALIGN_CENTER] or [constant ALIGN_END]).
 		</member>
-		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1"/>
+		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1" />
 	</members>
 	<constants>
 		<constant name="ALIGN_BEGIN" value="0" enum="AlignMode">

--- a/doc/classes/ButtonGroup.xml
+++ b/doc/classes/ButtonGroup.xml
@@ -26,7 +26,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" override="true" default="true"/>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" override="true" default="true" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/CameraTexture.xml
+++ b/doc/classes/CameraTexture.xml
@@ -17,7 +17,7 @@
 		<member name="camera_is_active" type="bool" setter="set_camera_active" getter="get_camera_active" default="false">
 			Convenience property that gives access to the active property of the [CameraFeed].
 		</member>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0" />
 		<member name="which_feed" type="int" setter="set_which_feed" getter="get_which_feed" enum="CameraServer.FeedImage" default="0">
 			Which image within the [CameraFeed] we want access to, important if the camera image is split in a Y and CbCr component.
 		</member>

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -11,8 +11,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="align" type="int" setter="set_text_align" getter="get_text_align" override="true" enum="Button.TextAlign" default="0"/>
-		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true"/>
+		<member name="align" type="int" setter="set_text_align" getter="get_text_align" override="true" enum="Button.TextAlign" default="0" />
+		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -11,8 +11,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="align" type="int" setter="set_text_align" getter="get_text_align" override="true" enum="Button.TextAlign" default="0"/>
-		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true"/>
+		<member name="align" type="int" setter="set_text_align" getter="get_text_align" override="true" enum="Button.TextAlign" default="0" />
+		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -31,7 +31,7 @@
 		<member name="edit_alpha" type="bool" setter="set_edit_alpha" getter="is_editing_alpha" default="true">
 			If [code]true[/code], the alpha channel in the displayed [ColorPicker] will be visible.
 		</member>
-		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true"/>
+		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true" />
 	</members>
 	<signals>
 		<signal name="color_changed">

--- a/doc/classes/ConfirmationDialog.xml
+++ b/doc/classes/ConfirmationDialog.xml
@@ -18,8 +18,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="rect_min_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" override="true" default="Vector2( 200, 70 )"/>
-		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Please Confirm...&quot;"/>
+		<member name="rect_min_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" override="true" default="Vector2( 200, 70 )" />
+		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Please Confirm...&quot;" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/DirectionalLight.xml
+++ b/doc/classes/DirectionalLight.xml
@@ -39,7 +39,7 @@
 		<member name="directional_shadow_split_3" type="float" setter="set_param" getter="get_param" default="0.5">
 			The distance from shadow split 2 to split 3. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [code]SHADOW_PARALLEL_4_SPLITS[/code].
 		</member>
-		<member name="shadow_bias" type="float" setter="set_param" getter="get_param" override="true" default="0.1"/>
+		<member name="shadow_bias" type="float" setter="set_param" getter="get_param" override="true" default="0.1" />
 	</members>
 	<constants>
 		<constant name="SHADOW_ORTHOGONAL" value="0" enum="ShadowMode">

--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -52,7 +52,7 @@
 		<member name="current_path" type="String" setter="set_current_path" getter="get_current_path" default="&quot;res://&quot;">
 			The file system path in the address bar.
 		</member>
-		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" override="true" default="false"/>
+		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" override="true" default="false" />
 		<member name="disable_overwrite_warning" type="bool" setter="set_disable_overwrite_warning" getter="is_overwrite_warning_disabled" default="false">
 			If [code]true[/code], the [EditorFileDialog] will not warn the user before overwriting files.
 		</member>
@@ -62,11 +62,11 @@
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="EditorFileDialog.Mode" default="4">
 			The purpose of the [EditorFileDialog], which defines the allowed behaviors.
 		</member>
-		<member name="resizable" type="bool" setter="set_resizable" getter="get_resizable" override="true" default="true"/>
+		<member name="resizable" type="bool" setter="set_resizable" getter="get_resizable" override="true" default="true" />
 		<member name="show_hidden_files" type="bool" setter="set_show_hidden_files" getter="is_showing_hidden_files" default="false">
 			If [code]true[/code], hidden files and directories will be visible in the [EditorFileDialog].
 		</member>
-		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Save a File&quot;"/>
+		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Save a File&quot;" />
 	</members>
 	<signals>
 		<signal name="dir_selected">

--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -15,7 +15,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="scroll_horizontal_enabled" type="bool" setter="set_enable_h_scroll" getter="is_h_scroll_enabled" override="true" default="false"/>
+		<member name="scroll_horizontal_enabled" type="bool" setter="set_enable_h_scroll" getter="is_h_scroll_enabled" override="true" default="false" />
 	</members>
 	<signals>
 		<signal name="object_id_selected">

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -67,7 +67,7 @@
 		<member name="current_path" type="String" setter="set_current_path" getter="get_current_path" default="&quot;res://&quot;">
 			The currently selected file path of the file dialog.
 		</member>
-		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" override="true" default="false"/>
+		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" override="true" default="false" />
 		<member name="filters" type="PoolStringArray" setter="set_filters" getter="get_filters" default="PoolStringArray(  )">
 			The available file type filters. For example, this shows only [code].png[/code] and [code].gd[/code] files: [code]set_filters(PoolStringArray(["*.png ; PNG Images","*.gd ; GDScript Files"]))[/code].
 		</member>
@@ -80,7 +80,7 @@
 		<member name="show_hidden_files" type="bool" setter="set_show_hidden_files" getter="is_showing_hidden_files" default="false">
 			If [code]true[/code], the dialog will show hidden files.
 		</member>
-		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Save a File&quot;"/>
+		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Save a File&quot;" />
 	</members>
 	<signals>
 		<signal name="dir_selected">

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -171,8 +171,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2"/>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true"/>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
+		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
 		<member name="right_disconnects" type="bool" setter="set_right_disconnects" getter="is_right_disconnects_enabled" default="false">
 			If [code]true[/code], enables disconnection of existing connections in the GraphEdit by dragging the right end.
 		</member>

--- a/doc/classes/GridContainer.xml
+++ b/doc/classes/GridContainer.xml
@@ -14,7 +14,7 @@
 		<member name="columns" type="int" setter="set_columns" getter="get_columns" default="1">
 			The number of columns in the [GridContainer]. If modified, [GridContainer] reorders its children to accommodate the new layout.
 		</member>
-		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1"/>
+		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -72,7 +72,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="7"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="7" />
 		<member name="lossy_quality" type="float" setter="set_lossy_storage_quality" getter="get_lossy_storage_quality" default="0.7">
 			The storage quality for [constant STORAGE_COMPRESS_LOSSY].
 		</member>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -414,7 +414,7 @@
 		<member name="fixed_icon_size" type="Vector2" setter="set_fixed_icon_size" getter="get_fixed_icon_size" default="Vector2( 0, 0 )">
 			Sets the default icon size in pixels.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2"/>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="icon_mode" type="int" setter="set_icon_mode" getter="get_icon_mode" enum="ItemList.IconMode" default="1">
 			Sets the default position of the icon to either [constant ICON_MODE_LEFT] or [constant ICON_MODE_TOP].
 		</member>
@@ -426,7 +426,7 @@
 		</member>
 		<member name="max_text_lines" type="int" setter="set_max_text_lines" getter="get_max_text_lines" default="1">
 		</member>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true"/>
+		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
 		<member name="same_column_width" type="bool" setter="set_same_column_width" getter="is_same_column_width" default="false">
 			If set to [code]true[/code], all columns will have the same width specified by [member fixed_column_width].
 		</member>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -55,11 +55,11 @@
 		<member name="max_lines_visible" type="int" setter="set_max_lines_visible" getter="get_max_lines_visible" default="-1">
 			Limits the lines of text the node shows on screen.
 		</member>
-		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="2"/>
+		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="2" />
 		<member name="percent_visible" type="float" setter="set_percent_visible" getter="get_percent_visible" default="1.0">
 			Limits the count of visible characters. If you set [code]percent_visible[/code] to 50, only up to half of the text's characters will display on screen. Useful to animate the text in a dialog box.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="4"/>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="4" />
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
 			The text to display on screen.
 		</member>

--- a/doc/classes/LargeTexture.xml
+++ b/doc/classes/LargeTexture.xml
@@ -86,7 +86,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -107,11 +107,11 @@
 		<member name="expand_to_text_length" type="bool" setter="set_expand_to_text_length" getter="get_expand_to_text_length" default="false">
 			If [code]true[/code], the [LineEdit] width will increase to stay longer than the [member text]. It will [b]not[/b] compress if the [member text] is shortened.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2"/>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length" default="0">
 			Maximum amount of characters that can be entered inside the [LineEdit]. If [code]0[/code], there is no limit.
 		</member>
-		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1"/>
+		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
 		<member name="placeholder_alpha" type="float" setter="set_placeholder_alpha" getter="get_placeholder_alpha" default="0.6">
 			Opacity of the [member placeholder_text]. From [code]0[/code] to [code]1[/code].
 		</member>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -11,9 +11,9 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="enabled_focus_mode" type="int" setter="set_enabled_focus_mode" getter="get_enabled_focus_mode" override="true" enum="Control.FocusMode" default="0"/>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="0"/>
-		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="2"/>
+		<member name="enabled_focus_mode" type="int" setter="set_enabled_focus_mode" getter="get_enabled_focus_mode" override="true" enum="Control.FocusMode" default="0" />
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="0" />
+		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="2" />
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
 		</member>
 		<member name="underline" type="int" setter="set_underline_mode" getter="get_underline_mode" enum="LinkButton.UnderlineMode" default="0">

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -26,14 +26,14 @@
 		</method>
 	</methods>
 	<members>
-		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" override="true" enum="BaseButton.ActionMode" default="0"/>
-		<member name="enabled_focus_mode" type="int" setter="set_enabled_focus_mode" getter="get_enabled_focus_mode" override="true" enum="Control.FocusMode" default="0"/>
-		<member name="flat" type="bool" setter="set_flat" getter="is_flat" override="true" default="true"/>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="0"/>
+		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" override="true" enum="BaseButton.ActionMode" default="0" />
+		<member name="enabled_focus_mode" type="int" setter="set_enabled_focus_mode" getter="get_enabled_focus_mode" override="true" enum="Control.FocusMode" default="0" />
+		<member name="flat" type="bool" setter="set_flat" getter="is_flat" override="true" default="true" />
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="0" />
 		<member name="switch_on_hover" type="bool" setter="set_switch_on_hover" getter="is_switch_on_hover" default="false">
 			If [code]true[/code], when the cursor hovers above another MenuButton within the same parent which also has [code]switch_on_hover[/code] enabled, it will close the current MenuButton and open the other one.
 		</member>
-		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true"/>
+		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true" />
 	</members>
 	<signals>
 		<signal name="about_to_show">

--- a/doc/classes/MeshTexture.xml
+++ b/doc/classes/MeshTexture.xml
@@ -14,7 +14,7 @@
 		<member name="base_texture" type="Texture" setter="set_base_texture" getter="get_base_texture">
 			Sets the base texture that the Mesh will use to draw.
 		</member>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0" />
 		<member name="image_size" type="Vector2" setter="set_image_size" getter="get_image_size" default="Vector2( 0, 0 )">
 			Sets the size of the image, needed for reference.
 		</member>

--- a/doc/classes/NinePatchRect.xml
+++ b/doc/classes/NinePatchRect.xml
@@ -38,7 +38,7 @@
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			If [code]true[/code], draw the panel's center. Else, only draw the 9-slice's borders.
 		</member>
-		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="2"/>
+		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="2" />
 		<member name="patch_margin_bottom" type="int" setter="set_patch_margin" getter="get_patch_margin" default="0">
 			The height of the 9-slice's bottom row. A margin of 16 means the 9-slice's bottom corners and side will have a height of 16 pixels. You can set all 4 margin values individually to create panels with non-uniform borders.
 		</member>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -197,11 +197,11 @@
 		</method>
 	</methods>
 	<members>
-		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" override="true" enum="BaseButton.ActionMode" default="0"/>
-		<member name="align" type="int" setter="set_text_align" getter="get_text_align" override="true" enum="Button.TextAlign" default="0"/>
+		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" override="true" enum="BaseButton.ActionMode" default="0" />
+		<member name="align" type="int" setter="set_text_align" getter="get_text_align" override="true" enum="Button.TextAlign" default="0" />
 		<member name="selected" type="int" setter="_select_int" getter="get_selected" default="-1">
 		</member>
-		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true"/>
+		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true" />
 	</members>
 	<signals>
 		<signal name="item_focused">

--- a/doc/classes/ParallaxBackground.xml
+++ b/doc/classes/ParallaxBackground.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="layer" type="int" setter="set_layer" getter="get_layer" override="true" default="-100"/>
+		<member name="layer" type="int" setter="set_layer" getter="get_layer" override="true" default="-100" />
 		<member name="scroll_base_offset" type="Vector2" setter="set_scroll_base_offset" getter="get_scroll_base_offset" default="Vector2( 0, 0 )">
 			The base position offset for all [ParallaxLayer] children.
 		</member>

--- a/doc/classes/Path2D.xml
+++ b/doc/classes/Path2D.xml
@@ -15,7 +15,7 @@
 		<member name="curve" type="Curve2D" setter="set_curve" getter="get_curve">
 			A [Curve2D] describing the path.
 		</member>
-		<member name="self_modulate" type="Color" setter="set_self_modulate" getter="get_self_modulate" override="true" default="Color( 0.5, 0.6, 1, 0.7 )"/>
+		<member name="self_modulate" type="Color" setter="set_self_modulate" getter="get_self_modulate" override="true" default="Color( 0.5, 0.6, 1, 0.7 )" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -85,7 +85,7 @@
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
 			The physics layers this area scans for collisions.
 		</member>
-		<member name="input_pickable" type="bool" setter="set_pickable" getter="is_pickable" override="true" default="false"/>
+		<member name="input_pickable" type="bool" setter="set_pickable" getter="is_pickable" override="true" default="false" />
 		<member name="layers" type="int" setter="_set_layers" getter="_get_layers">
 			Both [member collision_layer] and [member collision_mask]. Returns [member collision_layer] when accessed. Updates [member collision_layer] and [member collision_mask] when modified.
 		</member>

--- a/doc/classes/Popup.xml
+++ b/doc/classes/Popup.xml
@@ -68,7 +68,7 @@
 		<member name="popup_exclusive" type="bool" setter="set_exclusive" getter="is_exclusive" default="false">
 			If [code]true[/code], the popup will not be hidden when a click event occurs outside of it, or when it receives the [code]ui_cancel[/code] action event.
 		</member>
-		<member name="visible" type="bool" setter="set_visible" getter="is_visible" override="true" default="false"/>
+		<member name="visible" type="bool" setter="set_visible" getter="is_visible" override="true" default="false" />
 	</members>
 	<signals>
 		<signal name="about_to_show">

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -553,7 +553,7 @@
 		<member name="allow_search" type="bool" setter="set_allow_search" getter="get_allow_search" default="false">
 			If [code]true[/code], allows to navigate [PopupMenu] with letter keys.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2"/>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="hide_on_checkable_item_selection" type="bool" setter="set_hide_on_checkable_item_selection" getter="is_hide_on_checkable_item_selection" default="true">
 			If [code]true[/code], hides the [PopupMenu] when a checkbox or radio button is selected.
 		</member>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -14,8 +14,8 @@
 		<member name="percent_visible" type="bool" setter="set_percent_visible" getter="is_percent_visible" default="true">
 			If [code]true[/code], the fill percentage is displayed on the bar.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0"/>
-		<member name="step" type="float" setter="set_step" getter="get_step" override="true" default="0.01"/>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0" />
+		<member name="step" type="float" setter="set_step" getter="get_step" override="true" default="0.01" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/ProxyTexture.xml
+++ b/doc/classes/ProxyTexture.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="base" type="Texture" setter="set_base" getter="get_base">
 		</member>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -255,7 +255,7 @@
 		<member name="percent_visible" type="float" setter="set_percent_visible" getter="get_percent_visible" default="1.0">
 			The text's visibility, as a [float] between 0.0 and 1.0.
 		</member>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true"/>
+		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
 		<member name="scroll_active" type="bool" setter="set_scroll_active" getter="is_scroll_active" default="true">
 			If [code]true[/code], the scrollbar is visible. Does not block scrolling completely. See [method scroll_to_line].
 		</member>

--- a/doc/classes/ScriptCreateDialog.xml
+++ b/doc/classes/ScriptCreateDialog.xml
@@ -30,11 +30,11 @@
 		</method>
 	</methods>
 	<members>
-		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" override="true" default="false"/>
-		<member name="margin_bottom" type="float" setter="set_margin" getter="get_margin" override="true" default="76.0"/>
-		<member name="margin_right" type="float" setter="set_margin" getter="get_margin" override="true" default="200.0"/>
-		<member name="rect_size" type="Vector2" setter="_set_size" getter="get_size" override="true" default="Vector2( 200, 76 )"/>
-		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Attach Node Script&quot;"/>
+		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" override="true" default="false" />
+		<member name="margin_bottom" type="float" setter="set_margin" getter="get_margin" override="true" default="76.0" />
+		<member name="margin_right" type="float" setter="set_margin" getter="get_margin" override="true" default="200.0" />
+		<member name="rect_size" type="Vector2" setter="_set_size" getter="get_size" override="true" default="Vector2( 200, 76 )" />
+		<member name="window_title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Attach Node Script&quot;" />
 	</members>
 	<signals>
 		<signal name="script_created">

--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -13,8 +13,8 @@
 	<members>
 		<member name="custom_step" type="float" setter="set_custom_step" getter="get_custom_step" default="-1.0">
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0"/>
-		<member name="step" type="float" setter="set_step" getter="get_step" override="true" default="0.0"/>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0" />
+		<member name="step" type="float" setter="set_step" getter="get_step" override="true" default="0.0" />
 	</members>
 	<signals>
 		<signal name="scrolling">

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -23,7 +23,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true"/>
+		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
 		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -14,11 +14,11 @@
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
 			If [code]true[/code], the slider can be interacted with. If [code]false[/code], the value can be changed only by code.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2"/>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="scrollable" type="bool" setter="set_scrollable" getter="is_scrollable" default="true">
 			If [code]true[/code], the value can be changed using the mouse wheel.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0"/>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0" />
 		<member name="tick_count" type="int" setter="set_ticks" getter="get_ticks" default="0">
 			Number of ticks displayed on the slider, including border ticks. Ticks are uniformly-distributed value markers.
 		</member>

--- a/doc/classes/StreamTexture.xml
+++ b/doc/classes/StreamTexture.xml
@@ -19,7 +19,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0" />
 		<member name="load_path" type="String" setter="load" getter="get_load_path" default="&quot;&quot;">
 			The StreamTexture's file path to a [code].stex[/code] file.
 		</member>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -655,6 +655,15 @@
 				If the string is a path, this concatenates [code]file[/code] at the end of the string as a subpath. E.g. [code]"this/is".plus_file("path") == "this/is/path"[/code].
 			</description>
 		</method>
+		<method name="repeat">
+			<return type="String">
+			</return>
+			<argument index="0" name="count" type="int">
+			</argument>
+			<description>
+				Returns original string repeated a number of times. The number of repetitions is given by the argument.
+			</description>
+		</method>
 		<method name="replace">
 			<return type="String">
 			</return>
@@ -675,15 +684,6 @@
 			</argument>
 			<description>
 				Replaces occurrences of a case-insensitive substring with the given one inside the string.
-			</description>
-		</method>
-		<method name="repeat">
-			<return type="String">
-			</return>
-			<argument index="0" name="count" type="int">
-			</argument>
-			<description>
-				Returns original string repeated a number of times. The number of repetitions is given by the argument.
 			</description>
 		</method>
 		<method name="rfind">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -406,7 +406,7 @@
 		<member name="draw_tabs" type="bool" setter="set_draw_tabs" getter="is_drawing_tabs" default="false">
 			If [code]true[/code], the "tab" character will have a visible representation.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2"/>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="fold_gutter" type="bool" setter="set_draw_fold_gutter" getter="is_drawing_fold_gutter" default="false">
 			If [code]true[/code], the fold gutter is visible. This enables folding groups of indented lines.
 		</member>
@@ -423,7 +423,7 @@
 		</member>
 		<member name="minimap_width" type="int" setter="set_minimap_width" getter="get_minimap_width" default="80">
 		</member>
-		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1"/>
+		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
 		<member name="override_selected_font_color" type="bool" setter="set_override_selected_font_color" getter="is_overriding_selected_font_color" default="false">
 		</member>
 		<member name="readonly" type="bool" setter="set_readonly" getter="is_readonly" default="false">

--- a/doc/classes/Texture3D.xml
+++ b/doc/classes/Texture3D.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" override="true" default="{&quot;depth&quot;: 0,&quot;flags&quot;: 4,&quot;format&quot;: 37,&quot;height&quot;: 0,&quot;layers&quot;: [  ],&quot;width&quot;: 0}"/>
+		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" override="true" default="{&quot;depth&quot;: 0,&quot;flags&quot;: 4,&quot;format&quot;: 37,&quot;height&quot;: 0,&quot;layers&quot;: [  ],&quot;width&quot;: 0}" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/TextureProgress.xml
+++ b/doc/classes/TextureProgress.xml
@@ -32,7 +32,7 @@
 		<member name="fill_mode" type="int" setter="set_fill_mode" getter="get_fill_mode" default="0">
 			The fill direction. See [enum FillMode] for possible values.
 		</member>
-		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1"/>
+		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1" />
 		<member name="nine_patch_stretch" type="bool" setter="set_nine_patch_stretch" getter="get_nine_patch_stretch" default="false">
 			If [code]true[/code], Godot treats the bar's textures like in [NinePatchRect]. Use the [code]stretch_margin_*[/code] properties like [member stretch_margin_bottom] to set up the nine patch's 3×3 grid.
 		</member>

--- a/doc/classes/TextureRect.xml
+++ b/doc/classes/TextureRect.xml
@@ -20,7 +20,7 @@
 		<member name="flip_v" type="bool" setter="set_flip_v" getter="is_flipped_v" default="false">
 			If [code]true[/code], texture is flipped vertically.
 		</member>
-		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1"/>
+		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1" />
 		<member name="stretch_mode" type="int" setter="set_stretch_mode" getter="get_stretch_mode" enum="TextureRect.StretchMode" default="0">
 			Controls the texture's behavior when resizing the node's bounding rectangle. See [enum StretchMode].
 		</member>

--- a/doc/classes/ToolButton.xml
+++ b/doc/classes/ToolButton.xml
@@ -15,7 +15,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="flat" type="bool" setter="set_flat" getter="is_flat" override="true" default="true"/>
+		<member name="flat" type="bool" setter="set_flat" getter="is_flat" override="true" default="true" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -231,14 +231,14 @@
 		<member name="drop_mode_flags" type="int" setter="set_drop_mode_flags" getter="get_drop_mode_flags" default="0">
 			The drop mode as an OR combination of flags. See [code]DROP_MODE_*[/code] constants. Once dropping is done, reverts to [constant DROP_MODE_DISABLED]. Setting this during [method Control.can_drop_data] is recommended.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2"/>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="hide_folding" type="bool" setter="set_hide_folding" getter="is_folding_hidden" default="false">
 			If [code]true[/code], the folding arrow is hidden.
 		</member>
 		<member name="hide_root" type="bool" setter="set_hide_root" getter="is_root_hidden" default="false">
 			If [code]true[/code], the tree's root is hidden.
 		</member>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true"/>
+		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
 		<member name="select_mode" type="int" setter="set_select_mode" getter="get_select_mode" enum="Tree.SelectMode" default="0">
 			Allows single or multiple selection. See the [code]SELECT_*[/code] constants.
 		</member>

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -10,8 +10,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags" override="true" default="0"/>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="1"/>
+		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags" override="true" default="0" />
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="1" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VSlider.xml
+++ b/doc/classes/VSlider.xml
@@ -11,8 +11,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags" override="true" default="0"/>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="1"/>
+		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags" override="true" default="0" />
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="1" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VehicleBody.xml
+++ b/doc/classes/VehicleBody.xml
@@ -20,11 +20,11 @@
 			[b]Note:[/b] The simulation does not take the effect of gears into account, you will need to add logic for this if you wish to simulate gears.
 			A negative value will result in the vehicle reversing.
 		</member>
-		<member name="mass" type="float" setter="set_mass" getter="get_mass" override="true" default="40.0"/>
+		<member name="mass" type="float" setter="set_mass" getter="get_mass" override="true" default="40.0" />
 		<member name="steering" type="float" setter="set_steering" getter="get_steering" default="0.0">
 			The steering angle for the vehicle. Setting this to a non-zero value will result in the vehicle turning when it's moving. Wheels that have [member VehicleWheel.use_as_steering] set to [code]true[/code] will automatically be rotated.
 		</member>
-		<member name="weight" type="float" setter="set_weight" getter="get_weight" override="true" default="392.0"/>
+		<member name="weight" type="float" setter="set_weight" getter="get_weight" override="true" default="392.0" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -12,8 +12,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0"/>
-		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" override="true" default="true"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="0" />
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" override="true" default="true" />
 		<member name="viewport_path" type="NodePath" setter="set_viewport_path_in_scene" getter="get_viewport_path_in_scene" default="NodePath(&quot;&quot;)">
 			The path to the [Viewport] node to display. This is relative to the scene root, not to the node which uses the texture.
 		</member>

--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -183,7 +183,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="code" type="String" setter="set_code" getter="get_code" override="true" default="&quot;shader_type spatial;void vertex() {// Output:0}void fragment() {// Output:0}void light() {// Output:0}&quot;"/>
+		<member name="code" type="String" setter="set_code" getter="get_code" override="true" default="&quot;shader_type spatial;void vertex() {// Output:0}void fragment() {// Output:0}void light() {// Output:0}&quot;" />
 		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2( 0, 0 )">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeBooleanConstant.xml
+++ b/doc/classes/VisualShaderNodeBooleanConstant.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="constant" type="bool" setter="set_constant" getter="get_constant" default="false">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeColorConstant.xml
+++ b/doc/classes/VisualShaderNodeColorConstant.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="constant" type="Color" setter="set_constant" getter="get_constant" default="Color( 1, 1, 1, 1 )">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeColorOp.xml
+++ b/doc/classes/VisualShaderNodeColorOp.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeColorOp.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeCompare.xml
+++ b/doc/classes/VisualShaderNodeCompare.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="condition" type="int" setter="set_condition" getter="get_condition" enum="VisualShaderNodeCompare.Condition" default="0">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 1e-05 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 1e-05 ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeCompare.Function" default="0">
 		</member>
 		<member name="type" type="int" setter="set_comparsion_type" getter="get_comparsion_type" enum="VisualShaderNodeCompare.ComparsionType" default="0">

--- a/doc/classes/VisualShaderNodeCubeMap.xml
+++ b/doc/classes/VisualShaderNodeCubeMap.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="cube_map" type="CubeMap" setter="set_cube_map" getter="get_cube_map">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="texture_type" type="int" setter="set_texture_type" getter="get_texture_type" enum="VisualShaderNodeCubeMap.TextureType" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeCubeMapUniform.xml
+++ b/doc/classes/VisualShaderNodeCubeMapUniform.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -145,7 +145,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeDeterminant.xml
+++ b/doc/classes/VisualShaderNodeDeterminant.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeDotProduct.xml
+++ b/doc/classes/VisualShaderNodeDotProduct.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeExpression.xml
+++ b/doc/classes/VisualShaderNodeExpression.xml
@@ -15,7 +15,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="editable" type="bool" setter="set_editable" getter="is_editable" override="true" default="true"/>
+		<member name="editable" type="bool" setter="set_editable" getter="is_editable" override="true" default="true" />
 		<member name="expression" type="String" setter="set_expression" getter="get_expression" default="&quot;&quot;">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeFaceForward.xml
+++ b/doc/classes/VisualShaderNodeFaceForward.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeFresnel.xml
+++ b/doc/classes/VisualShaderNodeFresnel.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, false, 3, 1.0 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, false, 3, 1.0 ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeGlobalExpression.xml
+++ b/doc/classes/VisualShaderNodeGlobalExpression.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="editable" type="bool" setter="set_editable" getter="is_editable" override="true" default="false"/>
+		<member name="editable" type="bool" setter="set_editable" getter="is_editable" override="true" default="false" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeGroupBase.xml
+++ b/doc/classes/VisualShaderNodeGroupBase.xml
@@ -209,7 +209,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="false">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeIf.xml
+++ b/doc/classes/VisualShaderNodeIf.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 1e-05, 3, Vector3( 0, 0, 0 ), 4, Vector3( 0, 0, 0 ), 5, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 1e-05, 3, Vector3( 0, 0, 0 ), 4, Vector3( 0, 0, 0 ), 5, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeInput.xml
+++ b/doc/classes/VisualShaderNodeInput.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="input_name" type="String" setter="set_input_name" getter="get_input_name" default="&quot;[None]&quot;">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeIs.xml
+++ b/doc/classes/VisualShaderNodeIs.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0 ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeIs.Function" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeOuterProduct.xml
+++ b/doc/classes/VisualShaderNodeOuterProduct.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeScalarClamp.xml
+++ b/doc/classes/VisualShaderNodeScalarClamp.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 1.0 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 1.0 ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeScalarConstant.xml
+++ b/doc/classes/VisualShaderNodeScalarConstant.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="constant" type="float" setter="set_constant" getter="get_constant" default="0.0">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeScalarDerivativeFunc.xml
+++ b/doc/classes/VisualShaderNodeScalarDerivativeFunc.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0 ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeScalarDerivativeFunc.Function" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeScalarFunc.xml
+++ b/doc/classes/VisualShaderNodeScalarFunc.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0 ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeScalarFunc.Function" default="13">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeScalarInterp.xml
+++ b/doc/classes/VisualShaderNodeScalarInterp.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 1.0, 2, 0.5 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 1.0, 2, 0.5 ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeScalarOp.xml
+++ b/doc/classes/VisualShaderNodeScalarOp.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0 ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeScalarOp.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeScalarSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeScalarSmoothStep.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 0.0 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 0.0 ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeScalarSwitch.xml
+++ b/doc/classes/VisualShaderNodeScalarSwitch.xml
@@ -8,6 +8,9 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, false, 1, 1.0, 2, 0.0 ]" />
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeSwitch.xml
+++ b/doc/classes/VisualShaderNodeSwitch.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, false, 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, false, 1, Vector3( 1, 1, 1 ), 2, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeTexture.xml
+++ b/doc/classes/VisualShaderNodeTexture.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="source" type="int" setter="set_source" getter="get_source" enum="VisualShaderNodeTexture.Source" default="0">
 		</member>
 		<member name="texture" type="Texture" setter="set_texture" getter="get_texture">

--- a/doc/classes/VisualShaderNodeTransformCompose.xml
+++ b/doc/classes/VisualShaderNodeTransformCompose.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ), 3, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ), 3, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeTransformConstant.xml
+++ b/doc/classes/VisualShaderNodeTransformConstant.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="constant" type="Transform" setter="set_constant" getter="get_constant" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeTransformDecompose.xml
+++ b/doc/classes/VisualShaderNodeTransformDecompose.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeTransformFunc.xml
+++ b/doc/classes/VisualShaderNodeTransformFunc.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeTransformFunc.Function" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeTransformMult.xml
+++ b/doc/classes/VisualShaderNodeTransformMult.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ), 1, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ), 1, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeTransformMult.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeTransformVecMult.xml
+++ b/doc/classes/VisualShaderNodeTransformVecMult.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeTransformVecMult.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeUniform.xml
+++ b/doc/classes/VisualShaderNodeUniform.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="uniform_name" type="String" setter="set_uniform_name" getter="get_uniform_name" default="&quot;&quot;">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeVec3Constant.xml
+++ b/doc/classes/VisualShaderNodeVec3Constant.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="constant" type="Vector3" setter="set_constant" getter="get_constant" default="Vector3( 0, 0, 0 )">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorClamp.xml
+++ b/doc/classes/VisualShaderNodeVectorClamp.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 1, 1, 1 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 1, 1, 1 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorCompose.xml
+++ b/doc/classes/VisualShaderNodeVectorCompose.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 0.0 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 0.0 ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorDistance.xml
+++ b/doc/classes/VisualShaderNodeVectorDistance.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorInterp.xml
+++ b/doc/classes/VisualShaderNodeVectorInterp.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 1, 1, 1 ), 2, Vector3( 0.5, 0.5, 0.5 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 1, 1, 1 ), 2, Vector3( 0.5, 0.5, 0.5 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorOp.xml
+++ b/doc/classes/VisualShaderNodeVectorOp.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeVectorOp.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeVectorRefract.xml
+++ b/doc/classes/VisualShaderNodeVectorRefract.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, 0.0 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, 0.0 ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorScalarMix.xml
+++ b/doc/classes/VisualShaderNodeVectorScalarMix.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 1, 1, 1 ), 2, 0.5 ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 1, 1, 1 ), 2, 0.5 ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorScalarSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeVectorScalarSmoothStep.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorScalarStep.xml
+++ b/doc/classes/VisualShaderNodeVectorScalarStep.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeVectorSmoothStep.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ) ]"/>
+		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ) ]" />
 	</members>
 	<constants>
 	</constants>

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -872,7 +872,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 								ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name3 + ".");
 							}
 						} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "tutorials")
-							break; //end of <tutorials>
+							break; // End of <tutorials>.
 					}
 				} else if (name2 == "methods") {
 
@@ -905,16 +905,18 @@ Error DocData::_load(Ref<XMLParser> parser) {
 									prop2.getter = parser->get_attribute_value("getter");
 								if (parser->has_attribute("enum"))
 									prop2.enumeration = parser->get_attribute_value("enum");
-								parser->read();
-								if (parser->get_node_type() == XMLParser::NODE_TEXT)
-									prop2.description = parser->get_node_data();
+								if (!parser->is_empty()) {
+									parser->read();
+									if (parser->get_node_type() == XMLParser::NODE_TEXT)
+										prop2.description = parser->get_node_data();
+								}
 								c.properties.push_back(prop2);
 							} else {
 								ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name3 + ".");
 							}
 
 						} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "members")
-							break; //end of <constants>
+							break; // End of <members>.
 					}
 
 				} else if (name2 == "theme_items") {
@@ -933,16 +935,18 @@ Error DocData::_load(Ref<XMLParser> parser) {
 								prop2.name = parser->get_attribute_value("name");
 								ERR_FAIL_COND_V(!parser->has_attribute("type"), ERR_FILE_CORRUPT);
 								prop2.type = parser->get_attribute_value("type");
-								parser->read();
-								if (parser->get_node_type() == XMLParser::NODE_TEXT)
-									prop2.description = parser->get_node_data();
+								if (!parser->is_empty()) {
+									parser->read();
+									if (parser->get_node_type() == XMLParser::NODE_TEXT)
+										prop2.description = parser->get_node_data();
+								}
 								c.theme_properties.push_back(prop2);
 							} else {
 								ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name3 + ".");
 							}
 
 						} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "theme_items")
-							break; //end of <constants>
+							break; // End of <theme_items>.
 					}
 
 				} else if (name2 == "constants") {
@@ -963,16 +967,18 @@ Error DocData::_load(Ref<XMLParser> parser) {
 								if (parser->has_attribute("enum")) {
 									constant2.enumeration = parser->get_attribute_value("enum");
 								}
-								parser->read();
-								if (parser->get_node_type() == XMLParser::NODE_TEXT)
-									constant2.description = parser->get_node_data();
+								if (!parser->is_empty()) {
+									parser->read();
+									if (parser->get_node_type() == XMLParser::NODE_TEXT)
+										constant2.description = parser->get_node_data();
+								}
 								c.constants.push_back(constant2);
 							} else {
 								ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name3 + ".");
 							}
 
 						} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "constants")
-							break; //end of <constants>
+							break; // End of <constants>.
 					}
 
 				} else {
@@ -981,7 +987,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 				}
 
 			} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "class")
-				break; //end of <asset>
+				break; // End of <class>.
 		}
 	}
 
@@ -1109,7 +1115,7 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 				const PropertyDoc &p = c.properties[i];
 
 				if (c.properties[i].overridden) {
-					_write_string(f, 2, "<member name=\"" + p.name + "\" type=\"" + p.type + "\" setter=\"" + p.setter + "\" getter=\"" + p.getter + "\" override=\"true\"" + additional_attributes + "/>");
+					_write_string(f, 2, "<member name=\"" + p.name + "\" type=\"" + p.type + "\" setter=\"" + p.setter + "\" getter=\"" + p.getter + "\" override=\"true\"" + additional_attributes + " />");
 				} else {
 					_write_string(f, 2, "<member name=\"" + p.name + "\" type=\"" + p.type + "\" setter=\"" + p.setter + "\" getter=\"" + p.getter + "\"" + additional_attributes + ">");
 					_write_string(f, 3, p.description.strip_edges().xml_escape());

--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -115,11 +115,11 @@
 		<member name="compression_mode" type="int" setter="set_compression_mode" getter="get_compression_mode" enum="NetworkedMultiplayerENet.CompressionMode" default="0">
 			The compression method used for network packets. These have different tradeoffs of compression speed versus bandwidth, you may need to test which one works best for your use case if you use compression at all.
 		</member>
-		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" override="true" default="false"/>
+		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" override="true" default="false" />
 		<member name="transfer_channel" type="int" setter="set_transfer_channel" getter="get_transfer_channel" default="-1">
 			Set the default channel to be used to transfer data. By default, this value is [code]-1[/code] which means that ENet will only use 2 channels, one for reliable and one for unreliable packets. Channel [code]0[/code] is reserved, and cannot be used. Setting this member to any value between [code]0[/code] and [member channel_count] (excluded) will force ENet to use that channel for sending data.
 		</member>
-		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" override="true" enum="NetworkedMultiplayerPeer.TransferMode" default="2"/>
+		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" override="true" enum="NetworkedMultiplayerPeer.TransferMode" default="2" />
 	</members>
 	<constants>
 		<constant name="COMPRESS_NONE" value="0" enum="CompressionMode">

--- a/modules/opensimplex/doc_classes/NoiseTexture.xml
+++ b/modules/opensimplex/doc_classes/NoiseTexture.xml
@@ -17,7 +17,7 @@
 		</member>
 		<member name="bump_strength" type="float" setter="set_bump_strength" getter="get_bump_strength" default="8.0">
 		</member>
-		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="7"/>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" override="true" default="7" />
 		<member name="height" type="int" setter="set_height" getter="get_height" default="512">
 			Height of the generated texture.
 		</member>

--- a/modules/webrtc/doc_classes/WebRTCMultiplayer.xml
+++ b/modules/webrtc/doc_classes/WebRTCMultiplayer.xml
@@ -81,8 +81,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" override="true" default="false"/>
-		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" override="true" enum="NetworkedMultiplayerPeer.TransferMode" default="2"/>
+		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" override="true" default="false" />
+		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" override="true" enum="NetworkedMultiplayerPeer.TransferMode" default="2" />
 	</members>
 	<constants>
 	</constants>

--- a/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
+++ b/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
@@ -38,8 +38,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" override="true" default="false"/>
-		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" override="true" enum="NetworkedMultiplayerPeer.TransferMode" default="2"/>
+		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" override="true" default="false" />
+		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" override="true" enum="NetworkedMultiplayerPeer.TransferMode" default="2" />
 	</members>
 	<signals>
 		<signal name="peer_packet">


### PR DESCRIPTION
Follow-up to #31925, `<member />` tags just before `</members>` would cause
a parsing issue, and we'd never notice that we're no longer parsing members.

Also added space before closing `/>`.