### PR TITLE
Mention `MeshLibrary.get_item_preview()` not working in running project

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -4,7 +4,7 @@
 		Library of meshes.
 	</brief_description>
 	<description>
-		Library of meshes. Contains a list of [Mesh] resources, each with name and ID. This resource is used in [GridMap].
+		A library of meshes. Contains a list of [Mesh] resources, each with a name and ID. This resource is used in [GridMap].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,7 +13,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Clear the library.
+				Clears the library.
 			</description>
 		</method>
 		<method name="create_item">
@@ -22,7 +22,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Create a new item in the library, supplied an id.
+				Create a new item in the library, supplied as an ID.
 			</description>
 		</method>
 		<method name="find_item_by_name" qualifiers="const">
@@ -80,6 +80,8 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
+				Returns a generated item preview (a 3D rendering in isometric perspective).
+				[b]Note:[/b] Since item previews are only generated in an editor context, this function will return an empty [Texture] in a running project.
 			</description>
 		</method>
 		<method name="get_item_shapes" qualifiers="const">
@@ -94,7 +96,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Gets an unused id for a new item.
+				Gets an unused ID for a new item.
 			</description>
 		</method>
 		<method name="remove_item">
@@ -114,7 +116,7 @@
 			<argument index="1" name="mesh" type="Mesh">
 			</argument>
 			<description>
-				Sets the mesh of the item.
+				Sets the item's mesh.
 			</description>
 		</method>
 		<method name="set_item_name">
@@ -125,7 +127,7 @@
 			<argument index="1" name="name" type="String">
 			</argument>
 			<description>
-				Sets the name of the item.
+				Sets the item's name.
 			</description>
 		</method>
 		<method name="set_item_navmesh">

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "mesh_library.h"
+#include "core/engine.h"
 
 bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 
@@ -200,6 +201,11 @@ Transform MeshLibrary::get_item_navmesh_transform(int p_item) const {
 }
 
 Ref<Texture> MeshLibrary::get_item_preview(int p_item) const {
+
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		ERR_PRINT("MeshLibrary item previews are only generated in an editor context, which means they aren't available in a running project.");
+		return Ref<Texture>();
+	}
 
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<Texture>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].preview;


### PR DESCRIPTION
See discussion here: https://godotforums.org/discussion/21263/how-to-get-3d-model-preview-image

Technically, it's possible for someone to generate and set item previews manually, but I don't know how this could be detected as the editor-generated mesh library previews seem to be available when you run the project from the editor. (We need to be able to distinguish those to display the error message only when relevant.) I don't know if anyone is currently doing this anyway :slightly_smiling_face:

To test this, add a script to a GridMap with at least one tile with the following contents:

```gdscript
extends GridMap

func _ready() -> void:
    print(mesh_library.get_item_preview(0))
```