### PR TITLE
Better format arguments in variant parser

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1423,47 +1423,47 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 		} break;
 		case Variant::VECTOR2: {
 			Vector2 v = p_variant;
-			p_store_string_func(p_store_string_ud, "Vector2( " + rtosfix(v.x) + ", " + rtosfix(v.y) + " )");
+			p_store_string_func(p_store_string_ud, "Vector2(" + rtosfix(v.x) + ", " + rtosfix(v.y) + ")");
 		} break;
 		case Variant::VECTOR2I: {
 			Vector2i v = p_variant;
-			p_store_string_func(p_store_string_ud, "Vector2i( " + itos(v.x) + ", " + itos(v.y) + " )");
+			p_store_string_func(p_store_string_ud, "Vector2i(" + itos(v.x) + ", " + itos(v.y) + ")");
 		} break;
 		case Variant::RECT2: {
 			Rect2 aabb = p_variant;
-			p_store_string_func(p_store_string_ud, "Rect2( " + rtosfix(aabb.position.x) + ", " + rtosfix(aabb.position.y) + ", " + rtosfix(aabb.size.x) + ", " + rtosfix(aabb.size.y) + " )");
+			p_store_string_func(p_store_string_ud, "Rect2(" + rtosfix(aabb.position.x) + ", " + rtosfix(aabb.position.y) + ", " + rtosfix(aabb.size.x) + ", " + rtosfix(aabb.size.y) + ")");
 
 		} break;
 		case Variant::RECT2I: {
 			Rect2i aabb = p_variant;
-			p_store_string_func(p_store_string_ud, "Rect2i( " + itos(aabb.position.x) + ", " + itos(aabb.position.y) + ", " + itos(aabb.size.x) + ", " + itos(aabb.size.y) + " )");
+			p_store_string_func(p_store_string_ud, "Rect2i(" + itos(aabb.position.x) + ", " + itos(aabb.position.y) + ", " + itos(aabb.size.x) + ", " + itos(aabb.size.y) + ")");
 
 		} break;
 		case Variant::VECTOR3: {
 			Vector3 v = p_variant;
-			p_store_string_func(p_store_string_ud, "Vector3( " + rtosfix(v.x) + ", " + rtosfix(v.y) + ", " + rtosfix(v.z) + " )");
+			p_store_string_func(p_store_string_ud, "Vector3(" + rtosfix(v.x) + ", " + rtosfix(v.y) + ", " + rtosfix(v.z) + ")");
 		} break;
 		case Variant::VECTOR3I: {
 			Vector3i v = p_variant;
-			p_store_string_func(p_store_string_ud, "Vector3i( " + itos(v.x) + ", " + itos(v.y) + ", " + itos(v.z) + " )");
+			p_store_string_func(p_store_string_ud, "Vector3i(" + itos(v.x) + ", " + itos(v.y) + ", " + itos(v.z) + ")");
 		} break;
 		case Variant::PLANE: {
 			Plane p = p_variant;
-			p_store_string_func(p_store_string_ud, "Plane( " + rtosfix(p.normal.x) + ", " + rtosfix(p.normal.y) + ", " + rtosfix(p.normal.z) + ", " + rtosfix(p.d) + " )");
+			p_store_string_func(p_store_string_ud, "Plane(" + rtosfix(p.normal.x) + ", " + rtosfix(p.normal.y) + ", " + rtosfix(p.normal.z) + ", " + rtosfix(p.d) + ")");
 
 		} break;
 		case Variant::AABB: {
 			AABB aabb = p_variant;
-			p_store_string_func(p_store_string_ud, "AABB( " + rtosfix(aabb.position.x) + ", " + rtosfix(aabb.position.y) + ", " + rtosfix(aabb.position.z) + ", " + rtosfix(aabb.size.x) + ", " + rtosfix(aabb.size.y) + ", " + rtosfix(aabb.size.z) + " )");
+			p_store_string_func(p_store_string_ud, "AABB(" + rtosfix(aabb.position.x) + ", " + rtosfix(aabb.position.y) + ", " + rtosfix(aabb.position.z) + ", " + rtosfix(aabb.size.x) + ", " + rtosfix(aabb.size.y) + ", " + rtosfix(aabb.size.z) + ")");
 
 		} break;
 		case Variant::QUATERNION: {
 			Quaternion quaternion = p_variant;
-			p_store_string_func(p_store_string_ud, "Quaternion( " + rtosfix(quaternion.x) + ", " + rtosfix(quaternion.y) + ", " + rtosfix(quaternion.z) + ", " + rtosfix(quaternion.w) + " )");
+			p_store_string_func(p_store_string_ud, "Quaternion(" + rtosfix(quaternion.x) + ", " + rtosfix(quaternion.y) + ", " + rtosfix(quaternion.z) + ", " + rtosfix(quaternion.w) + ")");
 
 		} break;
 		case Variant::TRANSFORM2D: {
-			String s = "Transform2D( ";
+			String s = "Transform2D(";
 			Transform2D m3 = p_variant;
 			for (int i = 0; i < 3; i++) {
 				for (int j = 0; j < 2; j++) {
@@ -1474,11 +1474,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				}
 			}
 
-			p_store_string_func(p_store_string_ud, s + " )");
+			p_store_string_func(p_store_string_ud, s + ")");
 
 		} break;
 		case Variant::BASIS: {
-			String s = "Basis( ";
+			String s = "Basis(";
 			Basis m3 = p_variant;
 			for (int i = 0; i < 3; i++) {
 				for (int j = 0; j < 3; j++) {
@@ -1489,11 +1489,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				}
 			}
 
-			p_store_string_func(p_store_string_ud, s + " )");
+			p_store_string_func(p_store_string_ud, s + ")");
 
 		} break;
 		case Variant::TRANSFORM3D: {
-			String s = "Transform3D( ";
+			String s = "Transform3D(";
 			Transform3D t = p_variant;
 			Basis &m3 = t.basis;
 			for (int i = 0; i < 3; i++) {
@@ -1507,13 +1507,13 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 
 			s = s + ", " + rtosfix(t.origin.x) + ", " + rtosfix(t.origin.y) + ", " + rtosfix(t.origin.z);
 
-			p_store_string_func(p_store_string_ud, s + " )");
+			p_store_string_func(p_store_string_ud, s + ")");
 		} break;
 
 		// misc types
 		case Variant::COLOR: {
 			Color c = p_variant;
-			p_store_string_func(p_store_string_ud, "Color( " + rtosfix(c.r) + ", " + rtosfix(c.g) + ", " + rtosfix(c.b) + ", " + rtosfix(c.a) + " )");
+			p_store_string_func(p_store_string_ud, "Color(" + rtosfix(c.r) + ", " + rtosfix(c.g) + ", " + rtosfix(c.b) + ", " + rtosfix(c.a) + ")");
 
 		} break;
 		case Variant::STRING_NAME: {
@@ -1553,7 +1553,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				if (res_text == String() && res->get_path().is_resource_file()) {
 					//external resource
 					String path = res->get_path();
-					res_text = "Resource( \"" + path + "\")";
+					res_text = "Resource(\"" + path + "\")";
 				}
 
 				//could come up with some sort of text
@@ -1616,7 +1616,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 
 		} break;
 		case Variant::ARRAY: {
-			p_store_string_func(p_store_string_ud, "[ ");
+			p_store_string_func(p_store_string_ud, "[");
 			Array array = p_variant;
 			int len = array.size();
 			for (int i = 0; i < len; i++) {
@@ -1625,12 +1625,12 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				}
 				write(array[i], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud);
 			}
-			p_store_string_func(p_store_string_ud, " ]");
+			p_store_string_func(p_store_string_ud, "]");
 
 		} break;
 
 		case Variant::PACKED_BYTE_ARRAY: {
-			p_store_string_func(p_store_string_ud, "PackedByteArray( ");
+			p_store_string_func(p_store_string_ud, "PackedByteArray(");
 			String s;
 			Vector<uint8_t> data = p_variant;
 			int len = data.size();
@@ -1644,11 +1644,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, itos(ptr[i]));
 			}
 
-			p_store_string_func(p_store_string_ud, " )");
+			p_store_string_func(p_store_string_ud, ")");
 
 		} break;
 		case Variant::PACKED_INT32_ARRAY: {
-			p_store_string_func(p_store_string_ud, "PackedInt32Array( ");
+			p_store_string_func(p_store_string_ud, "PackedInt32Array(");
 			Vector<int32_t> data = p_variant;
 			int32_t len = data.size();
 			const int32_t *ptr = data.ptr();
@@ -1661,11 +1661,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, itos(ptr[i]));
 			}
 
-			p_store_string_func(p_store_string_ud, " )");
+			p_store_string_func(p_store_string_ud, ")");
 
 		} break;
 		case Variant::PACKED_INT64_ARRAY: {
-			p_store_string_func(p_store_string_ud, "PackedInt64Array( ");
+			p_store_string_func(p_store_string_ud, "PackedInt64Array(");
 			Vector<int64_t> data = p_variant;
 			int64_t len = data.size();
 			const int64_t *ptr = data.ptr();
@@ -1678,11 +1678,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, itos(ptr[i]));
 			}
 
-			p_store_string_func(p_store_string_ud, " )");
+			p_store_string_func(p_store_string_ud, ")");
 
 		} break;
 		case Variant::PACKED_FLOAT32_ARRAY: {
-			p_store_string_func(p_store_string_ud, "PackedFloat32Array( ");
+			p_store_string_func(p_store_string_ud, "PackedFloat32Array(");
 			Vector<float> data = p_variant;
 			int len = data.size();
 			const float *ptr = data.ptr();
@@ -1694,11 +1694,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, rtosfix(ptr[i]));
 			}
 
-			p_store_string_func(p_store_string_ud, " )");
+			p_store_string_func(p_store_string_ud, ")");
 
 		} break;
 		case Variant::PACKED_FLOAT64_ARRAY: {
-			p_store_string_func(p_store_string_ud, "PackedFloat64Array( ");
+			p_store_string_func(p_store_string_ud, "PackedFloat64Array(");
 			Vector<double> data = p_variant;
 			int len = data.size();
 			const double *ptr = data.ptr();
@@ -1710,11 +1710,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, rtosfix(ptr[i]));
 			}
 
-			p_store_string_func(p_store_string_ud, " )");
+			p_store_string_func(p_store_string_ud, ")");
 
 		} break;
 		case Variant::PACKED_STRING_ARRAY: {
-			p_store_string_func(p_store_string_ud, "PackedStringArray( ");
+			p_store_string_func(p_store_string_ud, "PackedStringArray(");
 			Vector<String> data = p_variant;
 			int len = data.size();
 			const String *ptr = data.ptr();
@@ -1730,11 +1730,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, "\"" + str.c_escape() + "\"");
 			}
 
-			p_store_string_func(p_store_string_ud, " )");
+			p_store_string_func(p_store_string_ud, ")");
 
 		} break;
 		case Variant::PACKED_VECTOR2_ARRAY: {
-			p_store_string_func(p_store_string_ud, "PackedVector2Array( ");
+			p_store_string_func(p_store_string_ud, "PackedVector2Array(");
 			Vector<Vector2> data = p_variant;
 			int len = data.size();
 			const Vector2 *ptr = data.ptr();
@@ -1746,11 +1746,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, rtosfix(ptr[i].x) + ", " + rtosfix(ptr[i].y));
 			}
 
-			p_store_string_func(p_store_string_ud, " )");
+			p_store_string_func(p_store_string_ud, ")");
 
 		} break;
 		case Variant::PACKED_VECTOR3_ARRAY: {
-			p_store_string_func(p_store_string_ud, "PackedVector3Array( ");
+			p_store_string_func(p_store_string_ud, "PackedVector3Array(");
 			Vector<Vector3> data = p_variant;
 			int len = data.size();
 			const Vector3 *ptr = data.ptr();
@@ -1762,12 +1762,11 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, rtosfix(ptr[i].x) + ", " + rtosfix(ptr[i].y) + ", " + rtosfix(ptr[i].z));
 			}
 
-			p_store_string_func(p_store_string_ud, " )");
+			p_store_string_func(p_store_string_ud, ")");
 
 		} break;
 		case Variant::PACKED_COLOR_ARRAY: {
-			p_store_string_func(p_store_string_ud, "PackedColorArray( ");
-
+			p_store_string_func(p_store_string_ud, "PackedColorArray(");
 			Vector<Color> data = p_variant;
 			int len = data.size();
 			const Color *ptr = data.ptr();
@@ -1779,7 +1778,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 
 				p_store_string_func(p_store_string_ud, rtosfix(ptr[i].r) + ", " + rtosfix(ptr[i].g) + ", " + rtosfix(ptr[i].b) + ", " + rtosfix(ptr[i].a));
 			}
-			p_store_string_func(p_store_string_ud, " )");
+			p_store_string_func(p_store_string_ud, ")");
 
 		} break;
 		default: {

--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -257,13 +257,13 @@
 		</method>
 	</methods>
 	<members>
-		<member name="end" type="Vector3" setter="" getter="" default="Vector3( 0, 0, 0 )">
+		<member name="end" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
 			Ending corner. This is calculated as [code]position + size[/code]. Setting this value will change the size.
 		</member>
-		<member name="position" type="Vector3" setter="" getter="" default="Vector3( 0, 0, 0 )">
+		<member name="position" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
 			Beginning corner. Typically has values lower than [member end].
 		</member>
-		<member name="size" type="Vector3" setter="" getter="" default="Vector3( 0, 0, 0 )">
+		<member name="size" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
 			Size from [member position] to [member end]. Typically, all components are positive.
 			If the size is negative, you can use [method abs] to fix it.
 		</member>

--- a/doc/classes/AESContext.xml
+++ b/doc/classes/AESContext.xml
@@ -101,7 +101,7 @@
 			</argument>
 			<argument index="1" name="key" type="PackedByteArray">
 			</argument>
-			<argument index="2" name="iv" type="PackedByteArray" default="PackedByteArray(  )">
+			<argument index="2" name="iv" type="PackedByteArray" default="PackedByteArray()">
 			</argument>
 			<description>
 				Start the AES context in the given [code]mode[/code]. A [code]key[/code] of either 16 or 32 bytes must always be provided, while an [code]iv[/code] (initialization vector) of exactly 16 bytes, is only needed when [code]mode[/code] is either [constant MODE_CBC_ENCRYPT] or [constant MODE_CBC_DECRYPT].

--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -57,7 +57,7 @@
 		<member name="frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
 			The [SpriteFrames] resource containing the animation(s).
 		</member>
-		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
+		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
 		</member>
 		<member name="playing" type="bool" setter="_set_playing" getter="_is_playing" default="false">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -213,9 +213,9 @@
 			</argument>
 			<argument index="2" name="value" type="float">
 			</argument>
-			<argument index="3" name="in_handle" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="3" name="in_handle" type="Vector2" default="Vector2(0, 0)">
 			</argument>
-			<argument index="4" name="out_handle" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="4" name="out_handle" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Inserts a Bezier Track key at the given [code]time[/code] in seconds. The [code]track_idx[/code] must be the index of a Bezier Track.

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -132,13 +132,13 @@
 		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="AnimationNodeBlendSpace2D.BlendMode" default="0">
 			Controls the interpolation between animations. See [enum BlendMode] constants.
 		</member>
-		<member name="max_space" type="Vector2" setter="set_max_space" getter="get_max_space" default="Vector2( 1, 1 )">
+		<member name="max_space" type="Vector2" setter="set_max_space" getter="get_max_space" default="Vector2(1, 1)">
 			The blend space's X and Y axes' upper limit for the points' position. See [method add_blend_point].
 		</member>
-		<member name="min_space" type="Vector2" setter="set_min_space" getter="get_min_space" default="Vector2( -1, -1 )">
+		<member name="min_space" type="Vector2" setter="set_min_space" getter="get_min_space" default="Vector2(-1, -1)">
 			The blend space's X and Y axes' lower limit for the points' position. See [method add_blend_point].
 		</member>
-		<member name="snap" type="Vector2" setter="set_snap" getter="get_snap" default="Vector2( 0.1, 0.1 )">
+		<member name="snap" type="Vector2" setter="set_snap" getter="get_snap" default="Vector2(0.1, 0.1)">
 			Position increment to snap to when moving a point.
 		</member>
 		<member name="x_label" type="String" setter="set_x_label" getter="get_x_label" default="&quot;x&quot;">

--- a/doc/classes/AnimationNodeBlendTree.xml
+++ b/doc/classes/AnimationNodeBlendTree.xml
@@ -17,7 +17,7 @@
 			</argument>
 			<argument index="1" name="node" type="AnimationNode">
 			</argument>
-			<argument index="2" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Adds an [AnimationNode] at the given [code]position[/code]. The [code]name[/code] is used to identify the created sub-node later.
@@ -107,7 +107,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2( 0, 0 )">
+		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2(0, 0)">
 			The global offset of all sub-nodes.
 		</member>
 	</members>

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -28,7 +28,7 @@
 			</argument>
 			<argument index="1" name="node" type="AnimationNode">
 			</argument>
-			<argument index="2" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Adds a new node to the graph. The [code]position[/code] is used for display in the editor.

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -69,7 +69,7 @@
 		<member name="gravity_point" type="bool" setter="set_gravity_is_point" getter="is_gravity_a_point" default="false">
 			If [code]true[/code], gravity is calculated from a point (set via [member gravity_vec]). See also [member space_override].
 		</member>
-		<member name="gravity_vec" type="Vector2" setter="set_gravity_vector" getter="get_gravity_vector" default="Vector2( 0, 1 )">
+		<member name="gravity_vec" type="Vector2" setter="set_gravity_vector" getter="get_gravity_vector" default="Vector2(0, 1)">
 			The area's gravity vector (not normalized). If gravity is a point (see [member gravity_point]), this will be the point of attraction.
 		</member>
 		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.1">

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -67,7 +67,7 @@
 		<member name="gravity_point" type="bool" setter="set_gravity_is_point" getter="is_gravity_a_point" default="false">
 			If [code]true[/code], gravity is calculated from a point (set via [member gravity_vec]). See also [member space_override].
 		</member>
-		<member name="gravity_vec" type="Vector3" setter="set_gravity_vector" getter="get_gravity_vector" default="Vector3( 0, -1, 0 )">
+		<member name="gravity_vec" type="Vector3" setter="set_gravity_vector" getter="get_gravity_vector" default="Vector3(0, -1, 0)">
 			The area's gravity vector (not normalized). If gravity is a point (see [member gravity_point]), this will be the point of attraction.
 		</member>
 		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.1">

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -66,7 +66,7 @@
 			</argument>
 			<argument index="1" name="arrays" type="Array">
 			</argument>
-			<argument index="2" name="blend_shapes" type="Array" default="[  ]">
+			<argument index="2" name="blend_shapes" type="Array" default="[]">
 			</argument>
 			<argument index="3" name="lods" type="Dictionary" default="{
 }">
@@ -221,7 +221,7 @@
 		<member name="blend_shape_mode" type="int" setter="set_blend_shape_mode" getter="get_blend_shape_mode" enum="Mesh.BlendShapeMode" default="1">
 			Sets the blend shape mode to one of [enum Mesh.BlendShapeMode].
 		</member>
-		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB( 0, 0, 0, 0, 0, 0 )">
+		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
 		<member name="shadow_mesh" type="ArrayMesh" setter="set_shadow_mesh" getter="get_shadow_mesh">

--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -18,10 +18,10 @@
 		<member name="filter_clip" type="bool" setter="set_filter_clip" getter="has_filter_clip" default="false">
 			If [code]true[/code], clips the area outside of the region to avoid bleeding of the surrounding texture pixels.
 		</member>
-		<member name="margin" type="Rect2" setter="set_margin" getter="get_margin" default="Rect2( 0, 0, 0, 0 )">
+		<member name="margin" type="Rect2" setter="set_margin" getter="get_margin" default="Rect2(0, 0, 0, 0)">
 			The margin around the region. The [Rect2]'s [member Rect2.size] parameter ("w" and "h" in the editor) resizes the texture so it fits within the margin.
 		</member>
-		<member name="region" type="Rect2" setter="set_region" getter="get_region" default="Rect2( 0, 0, 0, 0 )">
+		<member name="region" type="Rect2" setter="set_region" getter="get_region" default="Rect2(0, 0, 0, 0)">
 			The AtlasTexture's used region.
 		</member>
 	</members>

--- a/doc/classes/AudioStreamSample.xml
+++ b/doc/classes/AudioStreamSample.xml
@@ -22,7 +22,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="data" type="PackedByteArray" setter="set_data" getter="get_data" default="PackedByteArray(  )">
+		<member name="data" type="PackedByteArray" setter="set_data" getter="get_data" default="PackedByteArray()">
 			Contains the audio data in bytes.
 			[b]Note:[/b] This property expects signed PCM8 data. To convert unsigned PCM8 to signed PCM8, subtract 128 from each byte.
 		</member>

--- a/doc/classes/BackBufferCopy.xml
+++ b/doc/classes/BackBufferCopy.xml
@@ -15,7 +15,7 @@
 		<member name="copy_mode" type="int" setter="set_copy_mode" getter="get_copy_mode" enum="BackBufferCopy.CopyMode" default="1">
 			Buffer mode. See [enum CopyMode] constants.
 		</member>
-		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect" default="Rect2( -100, -100, 200, 200 )">
+		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect" default="Rect2(-100, -100, 200, 200)">
 			The area covered by the BackBufferCopy. Only used if [member copy_mode] is [constant COPY_MODE_RECT].
 		</member>
 	</members>

--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -72,7 +72,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="albedo_color" type="Color" setter="set_albedo" getter="get_albedo" default="Color( 1, 1, 1, 1 )">
+		<member name="albedo_color" type="Color" setter="set_albedo" getter="get_albedo" default="Color(1, 1, 1, 1)">
 			The material's base color.
 		</member>
 		<member name="albedo_tex_force_srgb" type="bool" setter="set_flag" getter="get_flag" default="false">
@@ -117,7 +117,7 @@
 		<member name="ao_texture_channel" type="int" setter="set_ao_texture_channel" getter="get_ao_texture_channel" enum="BaseMaterial3D.TextureChannel" default="0">
 			Specifies the channel of the [member ao_texture] in which the ambient occlusion information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
-		<member name="backlight" type="Color" setter="set_backlight" getter="get_backlight" default="Color( 0, 0, 0, 1 )">
+		<member name="backlight" type="Color" setter="set_backlight" getter="get_backlight" default="Color(0, 0, 0, 1)">
 			The color used by the backlight effect. Represents the light passing through an object.
 		</member>
 		<member name="backlight_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
@@ -195,7 +195,7 @@
 		<member name="distance_fade_mode" type="int" setter="set_distance_fade" getter="get_distance_fade" enum="BaseMaterial3D.DistanceFadeMode" default="0">
 			Specifies which type of fade to use. Can be any of the [enum DistanceFadeMode]s.
 		</member>
-		<member name="emission" type="Color" setter="set_emission" getter="get_emission" default="Color( 0, 0, 0, 1 )">
+		<member name="emission" type="Color" setter="set_emission" getter="get_emission" default="Color(0, 0, 0, 1)">
 			The emitted light's color. See [member emission_enabled].
 		</member>
 		<member name="emission_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
@@ -345,7 +345,7 @@
 		</member>
 		<member name="subsurf_scatter_transmittance_boost" type="float" setter="set_transmittance_boost" getter="get_transmittance_boost" default="0.0">
 		</member>
-		<member name="subsurf_scatter_transmittance_color" type="Color" setter="set_transmittance_color" getter="get_transmittance_color" default="Color( 1, 1, 1, 1 )">
+		<member name="subsurf_scatter_transmittance_color" type="Color" setter="set_transmittance_color" getter="get_transmittance_color" default="Color(1, 1, 1, 1)">
 		</member>
 		<member name="subsurf_scatter_transmittance_curve" type="float" setter="set_transmittance_curve" getter="get_transmittance_curve" default="1.0">
 		</member>
@@ -370,10 +370,10 @@
 			If [code]true[/code], render point size can be changed.
 			[b]Note:[/b] this is only effective for objects whose geometry is point-based rather than triangle-based. See also [member point_size].
 		</member>
-		<member name="uv1_offset" type="Vector3" setter="set_uv1_offset" getter="get_uv1_offset" default="Vector3( 0, 0, 0 )">
+		<member name="uv1_offset" type="Vector3" setter="set_uv1_offset" getter="get_uv1_offset" default="Vector3(0, 0, 0)">
 			How much to offset the [code]UV[/code] coordinates. This amount will be added to [code]UV[/code] in the vertex function. This can be used to offset a texture.
 		</member>
-		<member name="uv1_scale" type="Vector3" setter="set_uv1_scale" getter="get_uv1_scale" default="Vector3( 1, 1, 1 )">
+		<member name="uv1_scale" type="Vector3" setter="set_uv1_scale" getter="get_uv1_scale" default="Vector3(1, 1, 1)">
 			How much to scale the [code]UV[/code] coordinates. This is multiplied by [code]UV[/code] in the vertex function.
 		</member>
 		<member name="uv1_triplanar" type="bool" setter="set_flag" getter="get_flag" default="false">
@@ -385,10 +385,10 @@
 		<member name="uv1_world_triplanar" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], triplanar mapping for [code]UV[/code] is calculated in world space rather than object local space. See also [member uv1_triplanar].
 		</member>
-		<member name="uv2_offset" type="Vector3" setter="set_uv2_offset" getter="get_uv2_offset" default="Vector3( 0, 0, 0 )">
+		<member name="uv2_offset" type="Vector3" setter="set_uv2_offset" getter="get_uv2_offset" default="Vector3(0, 0, 0)">
 			How much to offset the [code]UV2[/code] coordinates. This amount will be added to [code]UV2[/code] in the vertex function. This can be used to offset a texture.
 		</member>
-		<member name="uv2_scale" type="Vector3" setter="set_uv2_scale" getter="get_uv2_scale" default="Vector3( 1, 1, 1 )">
+		<member name="uv2_scale" type="Vector3" setter="set_uv2_scale" getter="get_uv2_scale" default="Vector3(1, 1, 1)">
 			How much to scale the [code]UV2[/code] coordinates. This is multiplied by [code]UV2[/code] in the vertex function.
 		</member>
 		<member name="uv2_triplanar" type="bool" setter="set_flag" getter="get_flag" default="false">

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -245,28 +245,28 @@
 		</method>
 	</methods>
 	<members>
-		<member name="x" type="Vector3" setter="" getter="" default="Vector3( 1, 0, 0 )">
+		<member name="x" type="Vector3" setter="" getter="" default="Vector3(1, 0, 0)">
 			The basis matrix's X vector (column 0). Equivalent to array index [code]0[/code].
 		</member>
-		<member name="y" type="Vector3" setter="" getter="" default="Vector3( 0, 1, 0 )">
+		<member name="y" type="Vector3" setter="" getter="" default="Vector3(0, 1, 0)">
 			The basis matrix's Y vector (column 1). Equivalent to array index [code]1[/code].
 		</member>
-		<member name="z" type="Vector3" setter="" getter="" default="Vector3( 0, 0, 1 )">
+		<member name="z" type="Vector3" setter="" getter="" default="Vector3(0, 0, 1)">
 			The basis matrix's Z vector (column 2). Equivalent to array index [code]2[/code].
 		</member>
 	</members>
 	<constants>
-		<constant name="IDENTITY" value="Basis( 1, 0, 0, 0, 1, 0, 0, 0, 1 )">
+		<constant name="IDENTITY" value="Basis(1, 0, 0, 0, 1, 0, 0, 0, 1)">
 			The identity basis, with no rotation or scaling applied.
 			This is identical to calling [code]Basis()[/code] without any parameters. This constant can be used to make your code clearer, and for consistency with C#.
 		</constant>
-		<constant name="FLIP_X" value="Basis( -1, 0, 0, 0, 1, 0, 0, 0, 1 )">
+		<constant name="FLIP_X" value="Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1)">
 			The basis that will flip something along the X axis when used in a transformation.
 		</constant>
-		<constant name="FLIP_Y" value="Basis( 1, 0, 0, 0, -1, 0, 0, 0, 1 )">
+		<constant name="FLIP_Y" value="Basis(1, 0, 0, 0, -1, 0, 0, 0, 1)">
 			The basis that will flip something along the Y axis when used in a transformation.
 		</constant>
-		<constant name="FLIP_Z" value="Basis( 1, 0, 0, 0, 1, 0, 0, 0, -1 )">
+		<constant name="FLIP_Z" value="Basis(1, 0, 0, 0, 1, 0, 0, 0, -1)">
 			The basis that will flip something along the Z axis when used in a transformation.
 		</constant>
 	</constants>

--- a/doc/classes/Bone2D.xml
+++ b/doc/classes/Bone2D.xml
@@ -101,7 +101,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="rest" type="Transform2D" setter="set_rest" getter="get_rest" default="Transform2D( 0, 0, 0, 0, 0, 0 )">
+		<member name="rest" type="Transform2D" setter="set_rest" getter="get_rest" default="Transform2D(0, 0, 0, 0, 0, 0)">
 			Rest transform of the bone. You can reset the node's transforms to this value using [method apply_rest].
 		</member>
 	</members>

--- a/doc/classes/BoxMesh.xml
+++ b/doc/classes/BoxMesh.xml
@@ -13,7 +13,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3( 2, 2, 2 )">
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(2, 2, 2)">
 			The box's width, height and depth.
 		</member>
 		<member name="subdivide_depth" type="int" setter="set_subdivide_depth" getter="get_subdivide_depth" default="0">

--- a/doc/classes/BoxShape3D.xml
+++ b/doc/classes/BoxShape3D.xml
@@ -14,7 +14,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3( 2, 2, 2 )">
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(2, 2, 2)">
 			The box's width, height and depth.
 		</member>
 	</members>

--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -116,22 +116,22 @@
 		<theme_item name="font" type="Font">
 			[Font] of the [Button]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [Button].
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Text [Color] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="font_hover_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_hover_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [Button] is being hovered and pressed.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [Button].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [Button] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">
@@ -143,19 +143,19 @@
 		<theme_item name="hseparation" type="int" default="2">
 			The horizontal space between [Button]'s icon and text.
 		</theme_item>
-		<theme_item name="icon_disabled_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="icon_disabled_color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="icon_hover_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="icon_hover_color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="icon_hover_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="icon_hover_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being hovered and pressed.
 		</theme_item>
-		<theme_item name="icon_normal_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="icon_normal_color" type="Color" default="Color(1, 1, 1, 1)">
 			Default icon modulate [Color] of the [Button].
 		</theme_item>
-		<theme_item name="icon_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="icon_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being pressed.
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -148,7 +148,7 @@
 		<member name="anim_speed_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
 			Animation speed randomness ratio.
 		</member>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			Each particle's initial color. If [member texture] is defined, it will be multiplied by this color.
 		</member>
 		<member name="color_ramp" type="Gradient" setter="set_color_ramp" getter="get_color_ramp">
@@ -163,7 +163,7 @@
 		<member name="damping_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
 			Damping randomness ratio.
 		</member>
-		<member name="direction" type="Vector2" setter="set_direction" getter="get_direction" default="Vector2( 1, 0 )">
+		<member name="direction" type="Vector2" setter="set_direction" getter="get_direction" default="Vector2(1, 0)">
 			Unit vector specifying the particles' emission direction.
 		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="CPUParticles2D.DrawOrder" default="0">
@@ -199,7 +199,7 @@
 		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
 		</member>
-		<member name="gravity" type="Vector2" setter="set_gravity" getter="get_gravity" default="Vector2( 0, 980 )">
+		<member name="gravity" type="Vector2" setter="set_gravity" getter="get_gravity" default="Vector2(0, 980)">
 			Gravity applied to every particle.
 		</member>
 		<member name="hue_variation" type="float" setter="set_param" getter="get_param" default="0.0">

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -147,7 +147,7 @@
 		<member name="anim_speed_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
 			Animation speed randomness ratio.
 		</member>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			Unused for 3D particles.
 		</member>
 		<member name="color_ramp" type="Gradient" setter="set_color_ramp" getter="get_color_ramp">
@@ -162,7 +162,7 @@
 		<member name="damping_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
 			Damping randomness ratio.
 		</member>
-		<member name="direction" type="Vector3" setter="set_direction" getter="get_direction" default="Vector3( 1, 0, 0 )">
+		<member name="direction" type="Vector3" setter="set_direction" getter="get_direction" default="Vector3(1, 0, 0)">
 			Unit vector specifying the particles' emission direction.
 		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="CPUParticles3D.DrawOrder" default="0">
@@ -171,13 +171,13 @@
 		<member name="emission_box_extents" type="Vector3" setter="set_emission_box_extents" getter="get_emission_box_extents">
 			The rectangle's extents if [member emission_shape] is set to [constant EMISSION_SHAPE_BOX].
 		</member>
-		<member name="emission_colors" type="PackedColorArray" setter="set_emission_colors" getter="get_emission_colors" default="PackedColorArray(  )">
+		<member name="emission_colors" type="PackedColorArray" setter="set_emission_colors" getter="get_emission_colors" default="PackedColorArray()">
 			Sets the [Color]s to modulate particles by when using [constant EMISSION_SHAPE_POINTS] or [constant EMISSION_SHAPE_DIRECTED_POINTS].
 		</member>
 		<member name="emission_normals" type="PackedVector3Array" setter="set_emission_normals" getter="get_emission_normals">
 			Sets the direction the particles will be emitted in when using [constant EMISSION_SHAPE_DIRECTED_POINTS].
 		</member>
-		<member name="emission_points" type="PackedVector3Array" setter="set_emission_points" getter="get_emission_points" default="PackedVector3Array(  )">
+		<member name="emission_points" type="PackedVector3Array" setter="set_emission_points" getter="get_emission_points" default="PackedVector3Array()">
 			Sets the initial positions to spawn particles when using [constant EMISSION_SHAPE_POINTS] or [constant EMISSION_SHAPE_DIRECTED_POINTS].
 		</member>
 		<member name="emission_shape" type="int" setter="set_emission_shape" getter="get_emission_shape" enum="CPUParticles3D.EmissionShape" default="0">
@@ -201,7 +201,7 @@
 		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
 		</member>
-		<member name="gravity" type="Vector3" setter="set_gravity" getter="get_gravity" default="Vector3( 0, -9.8, 0 )">
+		<member name="gravity" type="Vector3" setter="set_gravity" getter="get_gravity" default="Vector3(0, -9.8, 0)">
 			Gravity applied to every particle.
 		</member>
 		<member name="hue_variation" type="float" setter="set_param" getter="get_param" default="0.0">

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -165,7 +165,7 @@
 		<member name="limit_top" type="int" setter="set_limit" getter="get_limit" default="-10000000">
 			Top scroll limit in pixels. The camera stops moving when reaching this value.
 		</member>
-		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
+		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The camera's offset, useful for looking around or camera shake animations.
 		</member>
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="Camera2D.Camera2DProcessCallback" default="1">
@@ -180,7 +180,7 @@
 		<member name="smoothing_speed" type="float" setter="set_follow_smoothing" getter="get_follow_smoothing" default="5.0">
 			Speed in pixels per second of the camera's smoothing effect when [member smoothing_enabled] is [code]true[/code].
 		</member>
-		<member name="zoom" type="Vector2" setter="set_zoom" getter="get_zoom" default="Vector2( 1, 1 )">
+		<member name="zoom" type="Vector2" setter="set_zoom" getter="get_zoom" default="Vector2(1, 1)">
 			The camera's zoom relative to the viewport. Values larger than [code]Vector2(1, 1)[/code] zoom out and smaller values zoom in. For an example, use [code]Vector2(0.5, 0.5)[/code] for a 2× zoom-in, and [code]Vector2(4, 4)[/code] for a 4× zoom-out.
 		</member>
 	</members>

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -209,7 +209,7 @@
 			- ~107.51 degrees in a 16:9 viewport
 			- ~121.63 degrees in a 21:9 viewport
 		</member>
-		<member name="frustum_offset" type="Vector2" setter="set_frustum_offset" getter="get_frustum_offset" default="Vector2( 0, 0 )">
+		<member name="frustum_offset" type="Vector2" setter="set_frustum_offset" getter="get_frustum_offset" default="Vector2(0, 0)">
 			The camera's frustum offset. This can be changed from the default to create "tilted frustum" effects such as [url=https://zdoom.org/wiki/Y-shearing]Y-shearing[/url].
 		</member>
 		<member name="h_offset" type="float" setter="set_h_offset" getter="get_h_offset" default="0.0">

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -75,11 +75,11 @@
 			</argument>
 			<argument index="4" name="size" type="int" default="-1">
 			</argument>
-			<argument index="5" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="5" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="6" name="outline_size" type="int" default="0">
 			</argument>
-			<argument index="7" name="outline_modulate" type="Color" default="Color( 1, 1, 1, 0 )">
+			<argument index="7" name="outline_modulate" type="Color" default="Color(1, 1, 1, 0)">
 			</argument>
 			<description>
 				Draws a string character using a custom font. Returns the advance, depending on the character width and kerning with an optional next character.
@@ -105,7 +105,7 @@
 			</argument>
 			<argument index="1" name="color" type="Color">
 			</argument>
-			<argument index="2" name="uvs" type="PackedVector2Array" default="PackedVector2Array(  )">
+			<argument index="2" name="uvs" type="PackedVector2Array" default="PackedVector2Array()">
 			</argument>
 			<argument index="3" name="texture" type="Texture2D" default="null">
 			</argument>
@@ -142,9 +142,9 @@
 			</argument>
 			<argument index="1" name="texture" type="Texture2D">
 			</argument>
-			<argument index="2" name="transform" type="Transform2D" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
+			<argument index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			</argument>
-			<argument index="3" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draws a [Mesh] in 2D, using the provided texture. See [MeshInstance2D] for related documentation.
@@ -193,11 +193,11 @@
 			</argument>
 			<argument index="6" name="size" type="int" default="-1">
 			</argument>
-			<argument index="7" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="7" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="8" name="outline_size" type="int" default="0">
 			</argument>
-			<argument index="9" name="outline_modulate" type="Color" default="Color( 1, 1, 1, 0 )">
+			<argument index="9" name="outline_modulate" type="Color" default="Color(1, 1, 1, 0)">
 			</argument>
 			<argument index="10" name="flags" type="int" default="51">
 			</argument>
@@ -223,7 +223,7 @@
 			</argument>
 			<argument index="1" name="colors" type="PackedColorArray">
 			</argument>
-			<argument index="2" name="uvs" type="PackedVector2Array" default="PackedVector2Array(  )">
+			<argument index="2" name="uvs" type="PackedVector2Array" default="PackedVector2Array()">
 			</argument>
 			<argument index="3" name="texture" type="Texture2D" default="null">
 			</argument>
@@ -301,7 +301,7 @@
 			</argument>
 			<argument index="1" name="rotation" type="float" default="0.0">
 			</argument>
-			<argument index="2" name="scale" type="Vector2" default="Vector2( 1, 1 )">
+			<argument index="2" name="scale" type="Vector2" default="Vector2(1, 1)">
 			</argument>
 			<description>
 				Sets a custom transform for drawing via components. Anything drawn afterwards will be transformed by this.
@@ -331,11 +331,11 @@
 			</argument>
 			<argument index="5" name="size" type="int" default="-1">
 			</argument>
-			<argument index="6" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="6" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="7" name="outline_size" type="int" default="0">
 			</argument>
-			<argument index="8" name="outline_modulate" type="Color" default="Color( 1, 1, 1, 0 )">
+			<argument index="8" name="outline_modulate" type="Color" default="Color(1, 1, 1, 0)">
 			</argument>
 			<argument index="9" name="flags" type="int" default="3">
 			</argument>
@@ -381,7 +381,7 @@
 			</argument>
 			<argument index="1" name="position" type="Vector2">
 			</argument>
-			<argument index="2" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="2" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draws a texture at a given position.
@@ -396,7 +396,7 @@
 			</argument>
 			<argument index="2" name="tile" type="bool">
 			</argument>
-			<argument index="3" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="4" name="transpose" type="bool" default="false">
 			</argument>
@@ -413,7 +413,7 @@
 			</argument>
 			<argument index="2" name="src_rect" type="Rect2">
 			</argument>
-			<argument index="3" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="4" name="transpose" type="bool" default="false">
 			</argument>
@@ -595,10 +595,10 @@
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The material applied to textures on this [CanvasItem].
 		</member>
-		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color( 1, 1, 1, 1 )">
+		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
 			The color applied to textures on this [CanvasItem].
 		</member>
-		<member name="self_modulate" type="Color" setter="set_self_modulate" getter="get_self_modulate" default="Color( 1, 1, 1, 1 )">
+		<member name="self_modulate" type="Color" setter="set_self_modulate" getter="get_self_modulate" default="Color(1, 1, 1, 1)">
 			The color applied to textures on this [CanvasItem]. This is not inherited by children [CanvasItem]s.
 		</member>
 		<member name="show_behind_parent" type="bool" setter="set_draw_behind_parent" getter="is_draw_behind_parent_enabled" default="false">

--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -33,7 +33,7 @@
 		<member name="layer" type="int" setter="set_layer" getter="get_layer" default="1">
 			Layer index for draw order. Lower values are drawn first.
 		</member>
-		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
+		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The layer's base offset.
 		</member>
 		<member name="rotation" type="float" setter="set_rotation" getter="get_rotation" default="0.0">
@@ -42,10 +42,10 @@
 		<member name="rotation_degrees" type="float" setter="set_rotation_degrees" getter="get_rotation_degrees" default="0.0">
 			The layer's rotation in degrees.
 		</member>
-		<member name="scale" type="Vector2" setter="set_scale" getter="get_scale" default="Vector2( 1, 1 )">
+		<member name="scale" type="Vector2" setter="set_scale" getter="get_scale" default="Vector2(1, 1)">
 			The layer's scale.
 		</member>
-		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
+		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			The layer's transform.
 		</member>
 	</members>

--- a/doc/classes/CanvasModulate.xml
+++ b/doc/classes/CanvasModulate.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			The tint color to apply.
 		</member>
 	</members>

--- a/doc/classes/CanvasTexture.xml
+++ b/doc/classes/CanvasTexture.xml
@@ -13,7 +13,7 @@
 		</member>
 		<member name="normal_texture" type="Texture2D" setter="set_normal_texture" getter="get_normal_texture">
 		</member>
-		<member name="specular_color" type="Color" setter="set_specular_color" getter="get_specular_color" default="Color( 1, 1, 1, 1 )">
+		<member name="specular_color" type="Color" setter="set_specular_color" getter="get_specular_color" default="Color(1, 1, 1, 1)">
 		</member>
 		<member name="specular_shininess" type="float" setter="set_specular_shininess" getter="get_specular_shininess" default="1.0">
 		</member>

--- a/doc/classes/CharFXTransform.xml
+++ b/doc/classes/CharFXTransform.xml
@@ -13,7 +13,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 0, 0, 0, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(0, 0, 0, 1)">
 			The color the character will be drawn with.
 		</member>
 		<member name="elapsed_time" type="float" setter="set_elapsed_time" getter="get_elapsed_time" default="0.0">
@@ -33,13 +33,13 @@
 		<member name="glyph_index" type="int" setter="set_glyph_index" getter="get_glyph_index" default="0">
 			Font specific glyph index.
 		</member>
-		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
+		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The position offset the character will be drawn with (in pixels).
 		</member>
 		<member name="outline" type="bool" setter="set_outline" getter="is_outline" default="false">
 			If [code]true[/code], FX transform is called for outline drawing. Setting this property won't affect drawing.
 		</member>
-		<member name="range" type="Vector2i" setter="set_range" getter="get_range" default="Vector2i( 0, 0 )">
+		<member name="range" type="Vector2i" setter="set_range" getter="get_range" default="Vector2i(0, 0)">
 			Absolute character range in the string, corresponding to the glyph. Setting this property won't affect drawing.
 		</member>
 		<member name="visible" type="bool" setter="set_visibility" getter="is_visible" default="true">

--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -107,7 +107,7 @@
 		<member name="infinite_inertia" type="bool" setter="set_infinite_inertia_enabled" getter="is_infinite_inertia_enabled" default="true">
 			If [code]true[/code], the body will be able to push [RigidBody2D] nodes when calling [method move_and_slide], but it also won't detect any collisions with them. If [code]false[/code], it will interact with [RigidBody2D] nodes like with [StaticBody2D].
 		</member>
-		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2( 0, 0 )">
+		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2(0, 0)">
 			Current velocity vector in pixels per second, used and modified during calls to [method move_and_slide].
 		</member>
 		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="4">
@@ -116,14 +116,14 @@
 		<member name="motion/sync_to_physics" type="bool" setter="set_sync_to_physics" getter="is_sync_to_physics_enabled" default="false">
 			If [code]true[/code], the body's movement will be synchronized to the physics frame. This is useful when animating movement via [AnimationPlayer], for example on moving platforms. Do [b]not[/b] use together with [method move_and_slide] or [method PhysicsBody2D.move_and_collide] functions.
 		</member>
-		<member name="snap" type="Vector2" setter="set_snap" getter="get_snap" default="Vector2( 0, 0 )">
+		<member name="snap" type="Vector2" setter="set_snap" getter="get_snap" default="Vector2(0, 0)">
 			When set to a value different from [code]Vector2(0, 0)[/code], the body is kept attached to slopes when calling [method move_and_slide].
 			As long as the [code]snap[/code] vector is in contact with the ground, the body will remain attached to the surface. This means you must disable snap in order to jump, for example. You can do this by setting [code]snap[/code] to [code]Vector2(0, 0)[/code].
 		</member>
 		<member name="stop_on_slope" type="bool" setter="set_stop_on_slope_enabled" getter="is_stop_on_slope_enabled" default="false">
 			If [code]true[/code], the body will not slide on slopes when you include gravity in [code]linear_velocity[/code] when calling [method move_and_slide] and the body is standing still.
 		</member>
-		<member name="up_direction" type="Vector2" setter="set_up_direction" getter="get_up_direction" default="Vector2( 0, -1 )">
+		<member name="up_direction" type="Vector2" setter="set_up_direction" getter="get_up_direction" default="Vector2(0, -1)">
 			Direction vector used to determine what is a wall and what is a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. Defaults to [code]Vector2.UP[/code]. If set to [code]Vector2(0, 0)[/code], everything is considered a wall. This is useful for topdown games.
 		</member>
 	</members>

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -93,20 +93,20 @@
 		<member name="infinite_inertia" type="bool" setter="set_infinite_inertia_enabled" getter="is_infinite_inertia_enabled" default="true">
 			If [code]true[/code], the body will be able to push [RigidBody3D] nodes when calling [method move_and_slide], but it also won't detect any collisions with them. If [code]false[/code], it will interact with [RigidBody3D] nodes like with [StaticBody3D].
 		</member>
-		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3( 0, 0, 0 )">
+		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3(0, 0, 0)">
 			Current velocity vector (typically meters per second), used and modified during calls to [method move_and_slide].
 		</member>
 		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="4">
 			Maximum number of times the body can change direction before it stops when calling [method move_and_slide].
 		</member>
-		<member name="snap" type="Vector3" setter="set_snap" getter="get_snap" default="Vector3( 0, 0, 0 )">
+		<member name="snap" type="Vector3" setter="set_snap" getter="get_snap" default="Vector3(0, 0, 0)">
 			When set to a value different from [code]Vector3(0, 0, 0)[/code], the body is kept attached to slopes when calling [method move_and_slide].
 			As long as the [code]snap[/code] vector is in contact with the ground, the body will remain attached to the surface. This means you must disable snap in order to jump, for example. You can do this by setting [code]snap[/code] to [code]Vector3(0, 0, 0)[/code].
 		</member>
 		<member name="stop_on_slope" type="bool" setter="set_stop_on_slope_enabled" getter="is_stop_on_slope_enabled" default="false">
 			If [code]true[/code], the body will not slide on slopes when you include gravity in [code]linear_velocity[/code] when calling [method move_and_slide] and the body is standing still.
 		</member>
-		<member name="up_direction" type="Vector3" setter="set_up_direction" getter="get_up_direction" default="Vector3( 0, 1, 0 )">
+		<member name="up_direction" type="Vector3" setter="set_up_direction" getter="get_up_direction" default="Vector3(0, 1, 0)">
 			Direction vector used to determine what is a wall and what is a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. Defaults to [code]Vector3.UP[/code]. If set to [code]Vector3(0, 0, 0)[/code], everything is considered a wall. This is useful for topdown games.
 		</member>
 	</members>

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -35,22 +35,22 @@
 		<theme_item name="font" type="Font">
 			The [Font] to use for the [CheckBox] text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			The [CheckBox] text's font color.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			The [CheckBox] text's font color when it's disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			The [CheckBox] text's font color when it's hovered.
 		</theme_item>
-		<theme_item name="font_hover_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_hover_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckBox] text's font color when it's hovered and pressed.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [CheckBox].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckBox] text's font color when it's pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -30,22 +30,22 @@
 		<theme_item name="font" type="Font">
 			The [Font] to use for the [CheckButton] text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			The [CheckButton] text's font color.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			The [CheckButton] text's font color when it's disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			The [CheckButton] text's font color when it's hovered.
 		</theme_item>
-		<theme_item name="font_hover_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_hover_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckButton] text's font color when it's hovered and pressed.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [CheckButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckButton] text's font color when it's pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -45,7 +45,7 @@
 			</argument>
 			<argument index="2" name="insert_text" type="String">
 			</argument>
-			<argument index="3" name="text_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="text_color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="4" name="icon" type="Resource" default="null">
 			</argument>
@@ -456,13 +456,13 @@
 		<member name="code_completion_enabled" type="bool" setter="set_code_completion_enabled" getter="is_code_completion_enabled" default="false">
 			Sets whether code completion is allowed.
 		</member>
-		<member name="code_completion_prefixes" type="String[]" setter="set_code_completion_prefixes" getter="get_code_comletion_prefixes" default="[  ]">
+		<member name="code_completion_prefixes" type="String[]" setter="set_code_completion_prefixes" getter="get_code_comletion_prefixes" default="[]">
 			Sets prefixes that will trigger code completion.
 		</member>
-		<member name="delimiter_comments" type="String[]" setter="set_comment_delimiters" getter="get_comment_delimiters" default="[  ]">
+		<member name="delimiter_comments" type="String[]" setter="set_comment_delimiters" getter="get_comment_delimiters" default="[]">
 			Sets the comment delimiters. All existing comment delimiters will be removed.
 		</member>
-		<member name="delimiter_strings" type="String[]" setter="set_string_delimiters" getter="get_string_delimiters" default="[  ]">
+		<member name="delimiter_strings" type="String[]" setter="set_string_delimiters" getter="get_string_delimiters" default="[]">
 			Sets the string delimiters. All existing string delimiters will be removed.
 		</member>
 		<member name="draw_bookmarks" type="bool" setter="set_draw_bookmarks_gutter" getter="is_drawing_bookmarks_gutter" default="false">
@@ -479,7 +479,7 @@
 		<member name="line_folding" type="bool" setter="set_line_folding_enabled" getter="is_line_folding_enabled" default="true">
 			Sets whether line folding is allowed.
 		</member>
-		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" override="true" default="[  ]" />
+		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" override="true" default="[]" />
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" override="true" enum="Control.TextDirection" default="1" />
 		<member name="zero_pad_line_numbers" type="bool" setter="set_line_numbers_zero_padded" getter="is_line_numbers_zero_padded" default="false">
 		</member>
@@ -520,49 +520,49 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="background_color" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="background_color" type="Color" default="Color(0, 0, 0, 0)">
 		</theme_item>
 		<theme_item name="bookmark" type="Texture2D">
 		</theme_item>
-		<theme_item name="bookmark_color" type="Color" default="Color( 0.5, 0.64, 1, 0.8 )">
+		<theme_item name="bookmark_color" type="Color" default="Color(0.5, 0.64, 1, 0.8)">
 		</theme_item>
-		<theme_item name="brace_mismatch_color" type="Color" default="Color( 1, 0.2, 0.2, 1 )">
+		<theme_item name="brace_mismatch_color" type="Color" default="Color(1, 0.2, 0.2, 1)">
 		</theme_item>
 		<theme_item name="breakpoint" type="Texture2D">
 		</theme_item>
-		<theme_item name="breakpoint_color" type="Color" default="Color( 0.9, 0.29, 0.3, 1 )">
+		<theme_item name="breakpoint_color" type="Color" default="Color(0.9, 0.29, 0.3, 1)">
 		</theme_item>
 		<theme_item name="can_fold" type="Texture2D">
 		</theme_item>
-		<theme_item name="caret_background_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="caret_background_color" type="Color" default="Color(0, 0, 0, 1)">
 		</theme_item>
-		<theme_item name="caret_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="caret_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 		</theme_item>
-		<theme_item name="code_folding_color" type="Color" default="Color( 0.8, 0.8, 0.8, 0.8 )">
+		<theme_item name="code_folding_color" type="Color" default="Color(0.8, 0.8, 0.8, 0.8)">
 		</theme_item>
 		<theme_item name="completion" type="StyleBox">
 		</theme_item>
-		<theme_item name="completion_background_color" type="Color" default="Color( 0.17, 0.16, 0.2, 1 )">
+		<theme_item name="completion_background_color" type="Color" default="Color(0.17, 0.16, 0.2, 1)">
 		</theme_item>
-		<theme_item name="completion_existing_color" type="Color" default="Color( 0.87, 0.87, 0.87, 0.13 )">
+		<theme_item name="completion_existing_color" type="Color" default="Color(0.87, 0.87, 0.87, 0.13)">
 		</theme_item>
-		<theme_item name="completion_font_color" type="Color" default="Color( 0.67, 0.67, 0.67, 1 )">
+		<theme_item name="completion_font_color" type="Color" default="Color(0.67, 0.67, 0.67, 1)">
 		</theme_item>
 		<theme_item name="completion_lines" type="int" default="7">
 		</theme_item>
 		<theme_item name="completion_max_width" type="int" default="50">
 		</theme_item>
-		<theme_item name="completion_scroll_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="completion_scroll_color" type="Color" default="Color(1, 1, 1, 1)">
 		</theme_item>
 		<theme_item name="completion_scroll_width" type="int" default="3">
 		</theme_item>
-		<theme_item name="completion_selected_color" type="Color" default="Color( 0.26, 0.26, 0.27, 1 )">
+		<theme_item name="completion_selected_color" type="Color" default="Color(0.26, 0.26, 0.27, 1)">
 		</theme_item>
-		<theme_item name="current_line_color" type="Color" default="Color( 0.25, 0.25, 0.26, 0.8 )">
+		<theme_item name="current_line_color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">
 		</theme_item>
 		<theme_item name="executing_line" type="Texture2D">
 		</theme_item>
-		<theme_item name="executing_line_color" type="Color" default="Color( 0.98, 0.89, 0.27, 1 )">
+		<theme_item name="executing_line_color" type="Color" default="Color(0.98, 0.89, 0.27, 1)">
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
 		</theme_item>
@@ -572,19 +572,19 @@
 		</theme_item>
 		<theme_item name="font" type="Font">
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [CodeEdit].
 		</theme_item>
-		<theme_item name="font_readonly_color" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
+		<theme_item name="font_readonly_color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color(0, 0, 0, 1)">
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the [CodeEdit]'s text.
 		</theme_item>
-		<theme_item name="line_number_color" type="Color" default="Color( 0.67, 0.67, 0.67, 0.4 )">
+		<theme_item name="line_number_color" type="Color" default="Color(0.67, 0.67, 0.67, 0.4)">
 		</theme_item>
 		<theme_item name="line_spacing" type="int" default="4">
 		</theme_item>
@@ -595,15 +595,15 @@
 		</theme_item>
 		<theme_item name="read_only" type="StyleBox">
 		</theme_item>
-		<theme_item name="safe_line_number_color" type="Color" default="Color( 0.67, 0.78, 0.67, 0.6 )">
+		<theme_item name="safe_line_number_color" type="Color" default="Color(0.67, 0.78, 0.67, 0.6)">
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
+		<theme_item name="selection_color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 		</theme_item>
 		<theme_item name="space" type="Texture2D">
 		</theme_item>
 		<theme_item name="tab" type="Texture2D">
 		</theme_item>
-		<theme_item name="word_highlighted_color" type="Color" default="Color( 0.8, 0.9, 0.9, 0.15 )">
+		<theme_item name="word_highlighted_color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/CodeHighlighter.xml
+++ b/doc/classes/CodeHighlighter.xml
@@ -149,7 +149,7 @@
 		<member name="color_regions" type="Dictionary" setter="set_color_regions" getter="get_color_regions" default="{}">
 			Sets the color regions. All existing regions will be removed. The [Dictionary] key is the region start and end key, separated by a space. The value is the region color.
 		</member>
-		<member name="function_color" type="Color" setter="set_function_color" getter="get_function_color" default="Color( 0, 0, 0, 1 )">
+		<member name="function_color" type="Color" setter="set_function_color" getter="get_function_color" default="Color(0, 0, 0, 1)">
 			Sets color for functions. A function is a non-keyword string followed by a '('.
 		</member>
 		<member name="keyword_colors" type="Dictionary" setter="set_keyword_colors" getter="get_keyword_colors" default="{}">
@@ -158,13 +158,13 @@
 		<member name="member_keyword_colors" type="Dictionary" setter="set_member_keyword_colors" getter="get_member_keyword_colors" default="{}">
 			Sets the member keyword colors. All existing member keyword will be removed. The [Dictionary] key is the member keyword. The value is the member keyword color.
 		</member>
-		<member name="member_variable_color" type="Color" setter="set_member_variable_color" getter="get_member_variable_color" default="Color( 0, 0, 0, 1 )">
+		<member name="member_variable_color" type="Color" setter="set_member_variable_color" getter="get_member_variable_color" default="Color(0, 0, 0, 1)">
 			Sets color for member variables. A member variable is non-keyword, non-function string proceeded with a '.'.
 		</member>
-		<member name="number_color" type="Color" setter="set_number_color" getter="get_number_color" default="Color( 0, 0, 0, 1 )">
+		<member name="number_color" type="Color" setter="set_number_color" getter="get_number_color" default="Color(0, 0, 0, 1)">
 			Sets the color for numbers.
 		</member>
-		<member name="symbol_color" type="Color" setter="set_symbol_color" getter="get_symbol_color" default="Color( 0, 0, 0, 1 )">
+		<member name="symbol_color" type="Color" setter="set_symbol_color" getter="get_symbol_color" default="Color(0, 0, 0, 1)">
 			Sets the color for symbols.
 		</member>
 	</members>

--- a/doc/classes/CollisionPolygon2D.xml
+++ b/doc/classes/CollisionPolygon2D.xml
@@ -23,7 +23,7 @@
 		<member name="one_way_collision_margin" type="float" setter="set_one_way_collision_margin" getter="get_one_way_collision_margin" default="1.0">
 			The margin used for one-way collision (in pixels). Higher values will make the shape thicker, and work better for colliders that enter the polygon at a high velocity.
 		</member>
-		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array(  )">
+		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array()">
 			The polygon's list of vertices. The final point will be connected to the first. The returned value is a clone of the [PackedVector2Array], not a reference.
 		</member>
 	</members>

--- a/doc/classes/CollisionPolygon3D.xml
+++ b/doc/classes/CollisionPolygon3D.xml
@@ -20,7 +20,7 @@
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.04">
 			The collision margin for the generated [Shape3D]. See [member Shape3D.margin] for more details.
 		</member>
-		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array(  )">
+		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array()">
 			Array of vertices which define the polygon.
 			[b]Note:[/b] The returned value is a copy of the original. Methods which mutate the size or properties of the return value will not impact the original polygon. To change properties of the polygon, assign it to a temporary variable and make changes before reassigning the [code]polygon[/code] member.
 		</member>

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -139,9 +139,9 @@
 		<method name="clamp" qualifiers="const">
 			<return type="Color">
 			</return>
-			<argument index="0" name="min" type="Color" default="Color( 0, 0, 0, 0 )">
+			<argument index="0" name="min" type="Color" default="Color(0, 0, 0, 0)">
 			</argument>
-			<argument index="1" name="max" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="1" name="max" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Returns a new color with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
@@ -575,442 +575,442 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="ALICE_BLUE" value="Color( 0.94, 0.97, 1, 1 )">
+		<constant name="ALICE_BLUE" value="Color(0.94, 0.97, 1, 1)">
 			Alice blue color.
 		</constant>
-		<constant name="ANTIQUE_WHITE" value="Color( 0.98, 0.92, 0.84, 1 )">
+		<constant name="ANTIQUE_WHITE" value="Color(0.98, 0.92, 0.84, 1)">
 			Antique white color.
 		</constant>
-		<constant name="AQUA" value="Color( 0, 1, 1, 1 )">
+		<constant name="AQUA" value="Color(0, 1, 1, 1)">
 			Aqua color.
 		</constant>
-		<constant name="AQUAMARINE" value="Color( 0.5, 1, 0.83, 1 )">
+		<constant name="AQUAMARINE" value="Color(0.5, 1, 0.83, 1)">
 			Aquamarine color.
 		</constant>
-		<constant name="AZURE" value="Color( 0.94, 1, 1, 1 )">
+		<constant name="AZURE" value="Color(0.94, 1, 1, 1)">
 			Azure color.
 		</constant>
-		<constant name="BEIGE" value="Color( 0.96, 0.96, 0.86, 1 )">
+		<constant name="BEIGE" value="Color(0.96, 0.96, 0.86, 1)">
 			Beige color.
 		</constant>
-		<constant name="BISQUE" value="Color( 1, 0.89, 0.77, 1 )">
+		<constant name="BISQUE" value="Color(1, 0.89, 0.77, 1)">
 			Bisque color.
 		</constant>
-		<constant name="BLACK" value="Color( 0, 0, 0, 1 )">
+		<constant name="BLACK" value="Color(0, 0, 0, 1)">
 			Black color.
 		</constant>
-		<constant name="BLANCHED_ALMOND" value="Color( 1, 0.92, 0.8, 1 )">
+		<constant name="BLANCHED_ALMOND" value="Color(1, 0.92, 0.8, 1)">
 			Blanched almond color.
 		</constant>
-		<constant name="BLUE" value="Color( 0, 0, 1, 1 )">
+		<constant name="BLUE" value="Color(0, 0, 1, 1)">
 			Blue color.
 		</constant>
-		<constant name="BLUE_VIOLET" value="Color( 0.54, 0.17, 0.89, 1 )">
+		<constant name="BLUE_VIOLET" value="Color(0.54, 0.17, 0.89, 1)">
 			Blue violet color.
 		</constant>
-		<constant name="BROWN" value="Color( 0.65, 0.16, 0.16, 1 )">
+		<constant name="BROWN" value="Color(0.65, 0.16, 0.16, 1)">
 			Brown color.
 		</constant>
-		<constant name="BURLYWOOD" value="Color( 0.87, 0.72, 0.53, 1 )">
+		<constant name="BURLYWOOD" value="Color(0.87, 0.72, 0.53, 1)">
 			Burlywood color.
 		</constant>
-		<constant name="CADET_BLUE" value="Color( 0.37, 0.62, 0.63, 1 )">
+		<constant name="CADET_BLUE" value="Color(0.37, 0.62, 0.63, 1)">
 			Cadet blue color.
 		</constant>
-		<constant name="CHARTREUSE" value="Color( 0.5, 1, 0, 1 )">
+		<constant name="CHARTREUSE" value="Color(0.5, 1, 0, 1)">
 			Chartreuse color.
 		</constant>
-		<constant name="CHOCOLATE" value="Color( 0.82, 0.41, 0.12, 1 )">
+		<constant name="CHOCOLATE" value="Color(0.82, 0.41, 0.12, 1)">
 			Chocolate color.
 		</constant>
-		<constant name="CORAL" value="Color( 1, 0.5, 0.31, 1 )">
+		<constant name="CORAL" value="Color(1, 0.5, 0.31, 1)">
 			Coral color.
 		</constant>
-		<constant name="CORNFLOWER_BLUE" value="Color( 0.39, 0.58, 0.93, 1 )">
+		<constant name="CORNFLOWER_BLUE" value="Color(0.39, 0.58, 0.93, 1)">
 			Cornflower blue color.
 		</constant>
-		<constant name="CORNSILK" value="Color( 1, 0.97, 0.86, 1 )">
+		<constant name="CORNSILK" value="Color(1, 0.97, 0.86, 1)">
 			Cornsilk color.
 		</constant>
-		<constant name="CRIMSON" value="Color( 0.86, 0.08, 0.24, 1 )">
+		<constant name="CRIMSON" value="Color(0.86, 0.08, 0.24, 1)">
 			Crimson color.
 		</constant>
-		<constant name="CYAN" value="Color( 0, 1, 1, 1 )">
+		<constant name="CYAN" value="Color(0, 1, 1, 1)">
 			Cyan color.
 		</constant>
-		<constant name="DARK_BLUE" value="Color( 0, 0, 0.55, 1 )">
+		<constant name="DARK_BLUE" value="Color(0, 0, 0.55, 1)">
 			Dark blue color.
 		</constant>
-		<constant name="DARK_CYAN" value="Color( 0, 0.55, 0.55, 1 )">
+		<constant name="DARK_CYAN" value="Color(0, 0.55, 0.55, 1)">
 			Dark cyan color.
 		</constant>
-		<constant name="DARK_GOLDENROD" value="Color( 0.72, 0.53, 0.04, 1 )">
+		<constant name="DARK_GOLDENROD" value="Color(0.72, 0.53, 0.04, 1)">
 			Dark goldenrod color.
 		</constant>
-		<constant name="DARK_GRAY" value="Color( 0.66, 0.66, 0.66, 1 )">
+		<constant name="DARK_GRAY" value="Color(0.66, 0.66, 0.66, 1)">
 			Dark gray color.
 		</constant>
-		<constant name="DARK_GREEN" value="Color( 0, 0.39, 0, 1 )">
+		<constant name="DARK_GREEN" value="Color(0, 0.39, 0, 1)">
 			Dark green color.
 		</constant>
-		<constant name="DARK_KHAKI" value="Color( 0.74, 0.72, 0.42, 1 )">
+		<constant name="DARK_KHAKI" value="Color(0.74, 0.72, 0.42, 1)">
 			Dark khaki color.
 		</constant>
-		<constant name="DARK_MAGENTA" value="Color( 0.55, 0, 0.55, 1 )">
+		<constant name="DARK_MAGENTA" value="Color(0.55, 0, 0.55, 1)">
 			Dark magenta color.
 		</constant>
-		<constant name="DARK_OLIVE_GREEN" value="Color( 0.33, 0.42, 0.18, 1 )">
+		<constant name="DARK_OLIVE_GREEN" value="Color(0.33, 0.42, 0.18, 1)">
 			Dark olive green color.
 		</constant>
-		<constant name="DARK_ORANGE" value="Color( 1, 0.55, 0, 1 )">
+		<constant name="DARK_ORANGE" value="Color(1, 0.55, 0, 1)">
 			Dark orange color.
 		</constant>
-		<constant name="DARK_ORCHID" value="Color( 0.6, 0.2, 0.8, 1 )">
+		<constant name="DARK_ORCHID" value="Color(0.6, 0.2, 0.8, 1)">
 			Dark orchid color.
 		</constant>
-		<constant name="DARK_RED" value="Color( 0.55, 0, 0, 1 )">
+		<constant name="DARK_RED" value="Color(0.55, 0, 0, 1)">
 			Dark red color.
 		</constant>
-		<constant name="DARK_SALMON" value="Color( 0.91, 0.59, 0.48, 1 )">
+		<constant name="DARK_SALMON" value="Color(0.91, 0.59, 0.48, 1)">
 			Dark salmon color.
 		</constant>
-		<constant name="DARK_SEA_GREEN" value="Color( 0.56, 0.74, 0.56, 1 )">
+		<constant name="DARK_SEA_GREEN" value="Color(0.56, 0.74, 0.56, 1)">
 			Dark sea green color.
 		</constant>
-		<constant name="DARK_SLATE_BLUE" value="Color( 0.28, 0.24, 0.55, 1 )">
+		<constant name="DARK_SLATE_BLUE" value="Color(0.28, 0.24, 0.55, 1)">
 			Dark slate blue color.
 		</constant>
-		<constant name="DARK_SLATE_GRAY" value="Color( 0.18, 0.31, 0.31, 1 )">
+		<constant name="DARK_SLATE_GRAY" value="Color(0.18, 0.31, 0.31, 1)">
 			Dark slate gray color.
 		</constant>
-		<constant name="DARK_TURQUOISE" value="Color( 0, 0.81, 0.82, 1 )">
+		<constant name="DARK_TURQUOISE" value="Color(0, 0.81, 0.82, 1)">
 			Dark turquoise color.
 		</constant>
-		<constant name="DARK_VIOLET" value="Color( 0.58, 0, 0.83, 1 )">
+		<constant name="DARK_VIOLET" value="Color(0.58, 0, 0.83, 1)">
 			Dark violet color.
 		</constant>
-		<constant name="DEEP_PINK" value="Color( 1, 0.08, 0.58, 1 )">
+		<constant name="DEEP_PINK" value="Color(1, 0.08, 0.58, 1)">
 			Deep pink color.
 		</constant>
-		<constant name="DEEP_SKY_BLUE" value="Color( 0, 0.75, 1, 1 )">
+		<constant name="DEEP_SKY_BLUE" value="Color(0, 0.75, 1, 1)">
 			Deep sky blue color.
 		</constant>
-		<constant name="DIM_GRAY" value="Color( 0.41, 0.41, 0.41, 1 )">
+		<constant name="DIM_GRAY" value="Color(0.41, 0.41, 0.41, 1)">
 			Dim gray color.
 		</constant>
-		<constant name="DODGER_BLUE" value="Color( 0.12, 0.56, 1, 1 )">
+		<constant name="DODGER_BLUE" value="Color(0.12, 0.56, 1, 1)">
 			Dodger blue color.
 		</constant>
-		<constant name="FIREBRICK" value="Color( 0.7, 0.13, 0.13, 1 )">
+		<constant name="FIREBRICK" value="Color(0.7, 0.13, 0.13, 1)">
 			Firebrick color.
 		</constant>
-		<constant name="FLORAL_WHITE" value="Color( 1, 0.98, 0.94, 1 )">
+		<constant name="FLORAL_WHITE" value="Color(1, 0.98, 0.94, 1)">
 			Floral white color.
 		</constant>
-		<constant name="FOREST_GREEN" value="Color( 0.13, 0.55, 0.13, 1 )">
+		<constant name="FOREST_GREEN" value="Color(0.13, 0.55, 0.13, 1)">
 			Forest green color.
 		</constant>
-		<constant name="FUCHSIA" value="Color( 1, 0, 1, 1 )">
+		<constant name="FUCHSIA" value="Color(1, 0, 1, 1)">
 			Fuchsia color.
 		</constant>
-		<constant name="GAINSBORO" value="Color( 0.86, 0.86, 0.86, 1 )">
+		<constant name="GAINSBORO" value="Color(0.86, 0.86, 0.86, 1)">
 			Gainsboro color.
 		</constant>
-		<constant name="GHOST_WHITE" value="Color( 0.97, 0.97, 1, 1 )">
+		<constant name="GHOST_WHITE" value="Color(0.97, 0.97, 1, 1)">
 			Ghost white color.
 		</constant>
-		<constant name="GOLD" value="Color( 1, 0.84, 0, 1 )">
+		<constant name="GOLD" value="Color(1, 0.84, 0, 1)">
 			Gold color.
 		</constant>
-		<constant name="GOLDENROD" value="Color( 0.85, 0.65, 0.13, 1 )">
+		<constant name="GOLDENROD" value="Color(0.85, 0.65, 0.13, 1)">
 			Goldenrod color.
 		</constant>
-		<constant name="GRAY" value="Color( 0.75, 0.75, 0.75, 1 )">
+		<constant name="GRAY" value="Color(0.75, 0.75, 0.75, 1)">
 			Gray color.
 		</constant>
-		<constant name="GREEN" value="Color( 0, 1, 0, 1 )">
+		<constant name="GREEN" value="Color(0, 1, 0, 1)">
 			Green color.
 		</constant>
-		<constant name="GREEN_YELLOW" value="Color( 0.68, 1, 0.18, 1 )">
+		<constant name="GREEN_YELLOW" value="Color(0.68, 1, 0.18, 1)">
 			Green yellow color.
 		</constant>
-		<constant name="HONEYDEW" value="Color( 0.94, 1, 0.94, 1 )">
+		<constant name="HONEYDEW" value="Color(0.94, 1, 0.94, 1)">
 			Honeydew color.
 		</constant>
-		<constant name="HOT_PINK" value="Color( 1, 0.41, 0.71, 1 )">
+		<constant name="HOT_PINK" value="Color(1, 0.41, 0.71, 1)">
 			Hot pink color.
 		</constant>
-		<constant name="INDIAN_RED" value="Color( 0.8, 0.36, 0.36, 1 )">
+		<constant name="INDIAN_RED" value="Color(0.8, 0.36, 0.36, 1)">
 			Indian red color.
 		</constant>
-		<constant name="INDIGO" value="Color( 0.29, 0, 0.51, 1 )">
+		<constant name="INDIGO" value="Color(0.29, 0, 0.51, 1)">
 			Indigo color.
 		</constant>
-		<constant name="IVORY" value="Color( 1, 1, 0.94, 1 )">
+		<constant name="IVORY" value="Color(1, 1, 0.94, 1)">
 			Ivory color.
 		</constant>
-		<constant name="KHAKI" value="Color( 0.94, 0.9, 0.55, 1 )">
+		<constant name="KHAKI" value="Color(0.94, 0.9, 0.55, 1)">
 			Khaki color.
 		</constant>
-		<constant name="LAVENDER" value="Color( 0.9, 0.9, 0.98, 1 )">
+		<constant name="LAVENDER" value="Color(0.9, 0.9, 0.98, 1)">
 			Lavender color.
 		</constant>
-		<constant name="LAVENDER_BLUSH" value="Color( 1, 0.94, 0.96, 1 )">
+		<constant name="LAVENDER_BLUSH" value="Color(1, 0.94, 0.96, 1)">
 			Lavender blush color.
 		</constant>
-		<constant name="LAWN_GREEN" value="Color( 0.49, 0.99, 0, 1 )">
+		<constant name="LAWN_GREEN" value="Color(0.49, 0.99, 0, 1)">
 			Lawn green color.
 		</constant>
-		<constant name="LEMON_CHIFFON" value="Color( 1, 0.98, 0.8, 1 )">
+		<constant name="LEMON_CHIFFON" value="Color(1, 0.98, 0.8, 1)">
 			Lemon chiffon color.
 		</constant>
-		<constant name="LIGHT_BLUE" value="Color( 0.68, 0.85, 0.9, 1 )">
+		<constant name="LIGHT_BLUE" value="Color(0.68, 0.85, 0.9, 1)">
 			Light blue color.
 		</constant>
-		<constant name="LIGHT_CORAL" value="Color( 0.94, 0.5, 0.5, 1 )">
+		<constant name="LIGHT_CORAL" value="Color(0.94, 0.5, 0.5, 1)">
 			Light coral color.
 		</constant>
-		<constant name="LIGHT_CYAN" value="Color( 0.88, 1, 1, 1 )">
+		<constant name="LIGHT_CYAN" value="Color(0.88, 1, 1, 1)">
 			Light cyan color.
 		</constant>
-		<constant name="LIGHT_GOLDENROD" value="Color( 0.98, 0.98, 0.82, 1 )">
+		<constant name="LIGHT_GOLDENROD" value="Color(0.98, 0.98, 0.82, 1)">
 			Light goldenrod color.
 		</constant>
-		<constant name="LIGHT_GRAY" value="Color( 0.83, 0.83, 0.83, 1 )">
+		<constant name="LIGHT_GRAY" value="Color(0.83, 0.83, 0.83, 1)">
 			Light gray color.
 		</constant>
-		<constant name="LIGHT_GREEN" value="Color( 0.56, 0.93, 0.56, 1 )">
+		<constant name="LIGHT_GREEN" value="Color(0.56, 0.93, 0.56, 1)">
 			Light green color.
 		</constant>
-		<constant name="LIGHT_PINK" value="Color( 1, 0.71, 0.76, 1 )">
+		<constant name="LIGHT_PINK" value="Color(1, 0.71, 0.76, 1)">
 			Light pink color.
 		</constant>
-		<constant name="LIGHT_SALMON" value="Color( 1, 0.63, 0.48, 1 )">
+		<constant name="LIGHT_SALMON" value="Color(1, 0.63, 0.48, 1)">
 			Light salmon color.
 		</constant>
-		<constant name="LIGHT_SEA_GREEN" value="Color( 0.13, 0.7, 0.67, 1 )">
+		<constant name="LIGHT_SEA_GREEN" value="Color(0.13, 0.7, 0.67, 1)">
 			Light sea green color.
 		</constant>
-		<constant name="LIGHT_SKY_BLUE" value="Color( 0.53, 0.81, 0.98, 1 )">
+		<constant name="LIGHT_SKY_BLUE" value="Color(0.53, 0.81, 0.98, 1)">
 			Light sky blue color.
 		</constant>
-		<constant name="LIGHT_SLATE_GRAY" value="Color( 0.47, 0.53, 0.6, 1 )">
+		<constant name="LIGHT_SLATE_GRAY" value="Color(0.47, 0.53, 0.6, 1)">
 			Light slate gray color.
 		</constant>
-		<constant name="LIGHT_STEEL_BLUE" value="Color( 0.69, 0.77, 0.87, 1 )">
+		<constant name="LIGHT_STEEL_BLUE" value="Color(0.69, 0.77, 0.87, 1)">
 			Light steel blue color.
 		</constant>
-		<constant name="LIGHT_YELLOW" value="Color( 1, 1, 0.88, 1 )">
+		<constant name="LIGHT_YELLOW" value="Color(1, 1, 0.88, 1)">
 			Light yellow color.
 		</constant>
-		<constant name="LIME" value="Color( 0, 1, 0, 1 )">
+		<constant name="LIME" value="Color(0, 1, 0, 1)">
 			Lime color.
 		</constant>
-		<constant name="LIME_GREEN" value="Color( 0.2, 0.8, 0.2, 1 )">
+		<constant name="LIME_GREEN" value="Color(0.2, 0.8, 0.2, 1)">
 			Lime green color.
 		</constant>
-		<constant name="LINEN" value="Color( 0.98, 0.94, 0.9, 1 )">
+		<constant name="LINEN" value="Color(0.98, 0.94, 0.9, 1)">
 			Linen color.
 		</constant>
-		<constant name="MAGENTA" value="Color( 1, 0, 1, 1 )">
+		<constant name="MAGENTA" value="Color(1, 0, 1, 1)">
 			Magenta color.
 		</constant>
-		<constant name="MAROON" value="Color( 0.69, 0.19, 0.38, 1 )">
+		<constant name="MAROON" value="Color(0.69, 0.19, 0.38, 1)">
 			Maroon color.
 		</constant>
-		<constant name="MEDIUM_AQUAMARINE" value="Color( 0.4, 0.8, 0.67, 1 )">
+		<constant name="MEDIUM_AQUAMARINE" value="Color(0.4, 0.8, 0.67, 1)">
 			Medium aquamarine color.
 		</constant>
-		<constant name="MEDIUM_BLUE" value="Color( 0, 0, 0.8, 1 )">
+		<constant name="MEDIUM_BLUE" value="Color(0, 0, 0.8, 1)">
 			Medium blue color.
 		</constant>
-		<constant name="MEDIUM_ORCHID" value="Color( 0.73, 0.33, 0.83, 1 )">
+		<constant name="MEDIUM_ORCHID" value="Color(0.73, 0.33, 0.83, 1)">
 			Medium orchid color.
 		</constant>
-		<constant name="MEDIUM_PURPLE" value="Color( 0.58, 0.44, 0.86, 1 )">
+		<constant name="MEDIUM_PURPLE" value="Color(0.58, 0.44, 0.86, 1)">
 			Medium purple color.
 		</constant>
-		<constant name="MEDIUM_SEA_GREEN" value="Color( 0.24, 0.7, 0.44, 1 )">
+		<constant name="MEDIUM_SEA_GREEN" value="Color(0.24, 0.7, 0.44, 1)">
 			Medium sea green color.
 		</constant>
-		<constant name="MEDIUM_SLATE_BLUE" value="Color( 0.48, 0.41, 0.93, 1 )">
+		<constant name="MEDIUM_SLATE_BLUE" value="Color(0.48, 0.41, 0.93, 1)">
 			Medium slate blue color.
 		</constant>
-		<constant name="MEDIUM_SPRING_GREEN" value="Color( 0, 0.98, 0.6, 1 )">
+		<constant name="MEDIUM_SPRING_GREEN" value="Color(0, 0.98, 0.6, 1)">
 			Medium spring green color.
 		</constant>
-		<constant name="MEDIUM_TURQUOISE" value="Color( 0.28, 0.82, 0.8, 1 )">
+		<constant name="MEDIUM_TURQUOISE" value="Color(0.28, 0.82, 0.8, 1)">
 			Medium turquoise color.
 		</constant>
-		<constant name="MEDIUM_VIOLET_RED" value="Color( 0.78, 0.08, 0.52, 1 )">
+		<constant name="MEDIUM_VIOLET_RED" value="Color(0.78, 0.08, 0.52, 1)">
 			Medium violet red color.
 		</constant>
-		<constant name="MIDNIGHT_BLUE" value="Color( 0.1, 0.1, 0.44, 1 )">
+		<constant name="MIDNIGHT_BLUE" value="Color(0.1, 0.1, 0.44, 1)">
 			Midnight blue color.
 		</constant>
-		<constant name="MINT_CREAM" value="Color( 0.96, 1, 0.98, 1 )">
+		<constant name="MINT_CREAM" value="Color(0.96, 1, 0.98, 1)">
 			Mint cream color.
 		</constant>
-		<constant name="MISTY_ROSE" value="Color( 1, 0.89, 0.88, 1 )">
+		<constant name="MISTY_ROSE" value="Color(1, 0.89, 0.88, 1)">
 			Misty rose color.
 		</constant>
-		<constant name="MOCCASIN" value="Color( 1, 0.89, 0.71, 1 )">
+		<constant name="MOCCASIN" value="Color(1, 0.89, 0.71, 1)">
 			Moccasin color.
 		</constant>
-		<constant name="NAVAJO_WHITE" value="Color( 1, 0.87, 0.68, 1 )">
+		<constant name="NAVAJO_WHITE" value="Color(1, 0.87, 0.68, 1)">
 			Navajo white color.
 		</constant>
-		<constant name="NAVY_BLUE" value="Color( 0, 0, 0.5, 1 )">
+		<constant name="NAVY_BLUE" value="Color(0, 0, 0.5, 1)">
 			Navy blue color.
 		</constant>
-		<constant name="OLD_LACE" value="Color( 0.99, 0.96, 0.9, 1 )">
+		<constant name="OLD_LACE" value="Color(0.99, 0.96, 0.9, 1)">
 			Old lace color.
 		</constant>
-		<constant name="OLIVE" value="Color( 0.5, 0.5, 0, 1 )">
+		<constant name="OLIVE" value="Color(0.5, 0.5, 0, 1)">
 			Olive color.
 		</constant>
-		<constant name="OLIVE_DRAB" value="Color( 0.42, 0.56, 0.14, 1 )">
+		<constant name="OLIVE_DRAB" value="Color(0.42, 0.56, 0.14, 1)">
 			Olive drab color.
 		</constant>
-		<constant name="ORANGE" value="Color( 1, 0.65, 0, 1 )">
+		<constant name="ORANGE" value="Color(1, 0.65, 0, 1)">
 			Orange color.
 		</constant>
-		<constant name="ORANGE_RED" value="Color( 1, 0.27, 0, 1 )">
+		<constant name="ORANGE_RED" value="Color(1, 0.27, 0, 1)">
 			Orange red color.
 		</constant>
-		<constant name="ORCHID" value="Color( 0.85, 0.44, 0.84, 1 )">
+		<constant name="ORCHID" value="Color(0.85, 0.44, 0.84, 1)">
 			Orchid color.
 		</constant>
-		<constant name="PALE_GOLDENROD" value="Color( 0.93, 0.91, 0.67, 1 )">
+		<constant name="PALE_GOLDENROD" value="Color(0.93, 0.91, 0.67, 1)">
 			Pale goldenrod color.
 		</constant>
-		<constant name="PALE_GREEN" value="Color( 0.6, 0.98, 0.6, 1 )">
+		<constant name="PALE_GREEN" value="Color(0.6, 0.98, 0.6, 1)">
 			Pale green color.
 		</constant>
-		<constant name="PALE_TURQUOISE" value="Color( 0.69, 0.93, 0.93, 1 )">
+		<constant name="PALE_TURQUOISE" value="Color(0.69, 0.93, 0.93, 1)">
 			Pale turquoise color.
 		</constant>
-		<constant name="PALE_VIOLET_RED" value="Color( 0.86, 0.44, 0.58, 1 )">
+		<constant name="PALE_VIOLET_RED" value="Color(0.86, 0.44, 0.58, 1)">
 			Pale violet red color.
 		</constant>
-		<constant name="PAPAYA_WHIP" value="Color( 1, 0.94, 0.84, 1 )">
+		<constant name="PAPAYA_WHIP" value="Color(1, 0.94, 0.84, 1)">
 			Papaya whip color.
 		</constant>
-		<constant name="PEACH_PUFF" value="Color( 1, 0.85, 0.73, 1 )">
+		<constant name="PEACH_PUFF" value="Color(1, 0.85, 0.73, 1)">
 			Peach puff color.
 		</constant>
-		<constant name="PERU" value="Color( 0.8, 0.52, 0.25, 1 )">
+		<constant name="PERU" value="Color(0.8, 0.52, 0.25, 1)">
 			Peru color.
 		</constant>
-		<constant name="PINK" value="Color( 1, 0.75, 0.8, 1 )">
+		<constant name="PINK" value="Color(1, 0.75, 0.8, 1)">
 			Pink color.
 		</constant>
-		<constant name="PLUM" value="Color( 0.87, 0.63, 0.87, 1 )">
+		<constant name="PLUM" value="Color(0.87, 0.63, 0.87, 1)">
 			Plum color.
 		</constant>
-		<constant name="POWDER_BLUE" value="Color( 0.69, 0.88, 0.9, 1 )">
+		<constant name="POWDER_BLUE" value="Color(0.69, 0.88, 0.9, 1)">
 			Powder blue color.
 		</constant>
-		<constant name="PURPLE" value="Color( 0.63, 0.13, 0.94, 1 )">
+		<constant name="PURPLE" value="Color(0.63, 0.13, 0.94, 1)">
 			Purple color.
 		</constant>
-		<constant name="REBECCA_PURPLE" value="Color( 0.4, 0.2, 0.6, 1 )">
+		<constant name="REBECCA_PURPLE" value="Color(0.4, 0.2, 0.6, 1)">
 			Rebecca purple color.
 		</constant>
-		<constant name="RED" value="Color( 1, 0, 0, 1 )">
+		<constant name="RED" value="Color(1, 0, 0, 1)">
 			Red color.
 		</constant>
-		<constant name="ROSY_BROWN" value="Color( 0.74, 0.56, 0.56, 1 )">
+		<constant name="ROSY_BROWN" value="Color(0.74, 0.56, 0.56, 1)">
 			Rosy brown color.
 		</constant>
-		<constant name="ROYAL_BLUE" value="Color( 0.25, 0.41, 0.88, 1 )">
+		<constant name="ROYAL_BLUE" value="Color(0.25, 0.41, 0.88, 1)">
 			Royal blue color.
 		</constant>
-		<constant name="SADDLE_BROWN" value="Color( 0.55, 0.27, 0.07, 1 )">
+		<constant name="SADDLE_BROWN" value="Color(0.55, 0.27, 0.07, 1)">
 			Saddle brown color.
 		</constant>
-		<constant name="SALMON" value="Color( 0.98, 0.5, 0.45, 1 )">
+		<constant name="SALMON" value="Color(0.98, 0.5, 0.45, 1)">
 			Salmon color.
 		</constant>
-		<constant name="SANDY_BROWN" value="Color( 0.96, 0.64, 0.38, 1 )">
+		<constant name="SANDY_BROWN" value="Color(0.96, 0.64, 0.38, 1)">
 			Sandy brown color.
 		</constant>
-		<constant name="SEA_GREEN" value="Color( 0.18, 0.55, 0.34, 1 )">
+		<constant name="SEA_GREEN" value="Color(0.18, 0.55, 0.34, 1)">
 			Sea green color.
 		</constant>
-		<constant name="SEASHELL" value="Color( 1, 0.96, 0.93, 1 )">
+		<constant name="SEASHELL" value="Color(1, 0.96, 0.93, 1)">
 			Seashell color.
 		</constant>
-		<constant name="SIENNA" value="Color( 0.63, 0.32, 0.18, 1 )">
+		<constant name="SIENNA" value="Color(0.63, 0.32, 0.18, 1)">
 			Sienna color.
 		</constant>
-		<constant name="SILVER" value="Color( 0.75, 0.75, 0.75, 1 )">
+		<constant name="SILVER" value="Color(0.75, 0.75, 0.75, 1)">
 			Silver color.
 		</constant>
-		<constant name="SKY_BLUE" value="Color( 0.53, 0.81, 0.92, 1 )">
+		<constant name="SKY_BLUE" value="Color(0.53, 0.81, 0.92, 1)">
 			Sky blue color.
 		</constant>
-		<constant name="SLATE_BLUE" value="Color( 0.42, 0.35, 0.8, 1 )">
+		<constant name="SLATE_BLUE" value="Color(0.42, 0.35, 0.8, 1)">
 			Slate blue color.
 		</constant>
-		<constant name="SLATE_GRAY" value="Color( 0.44, 0.5, 0.56, 1 )">
+		<constant name="SLATE_GRAY" value="Color(0.44, 0.5, 0.56, 1)">
 			Slate gray color.
 		</constant>
-		<constant name="SNOW" value="Color( 1, 0.98, 0.98, 1 )">
+		<constant name="SNOW" value="Color(1, 0.98, 0.98, 1)">
 			Snow color.
 		</constant>
-		<constant name="SPRING_GREEN" value="Color( 0, 1, 0.5, 1 )">
+		<constant name="SPRING_GREEN" value="Color(0, 1, 0.5, 1)">
 			Spring green color.
 		</constant>
-		<constant name="STEEL_BLUE" value="Color( 0.27, 0.51, 0.71, 1 )">
+		<constant name="STEEL_BLUE" value="Color(0.27, 0.51, 0.71, 1)">
 			Steel blue color.
 		</constant>
-		<constant name="TAN" value="Color( 0.82, 0.71, 0.55, 1 )">
+		<constant name="TAN" value="Color(0.82, 0.71, 0.55, 1)">
 			Tan color.
 		</constant>
-		<constant name="TEAL" value="Color( 0, 0.5, 0.5, 1 )">
+		<constant name="TEAL" value="Color(0, 0.5, 0.5, 1)">
 			Teal color.
 		</constant>
-		<constant name="THISTLE" value="Color( 0.85, 0.75, 0.85, 1 )">
+		<constant name="THISTLE" value="Color(0.85, 0.75, 0.85, 1)">
 			Thistle color.
 		</constant>
-		<constant name="TOMATO" value="Color( 1, 0.39, 0.28, 1 )">
+		<constant name="TOMATO" value="Color(1, 0.39, 0.28, 1)">
 			Tomato color.
 		</constant>
-		<constant name="TRANSPARENT" value="Color( 1, 1, 1, 0 )">
+		<constant name="TRANSPARENT" value="Color(1, 1, 1, 0)">
 			Transparent color (white with zero alpha).
 		</constant>
-		<constant name="TURQUOISE" value="Color( 0.25, 0.88, 0.82, 1 )">
+		<constant name="TURQUOISE" value="Color(0.25, 0.88, 0.82, 1)">
 			Turquoise color.
 		</constant>
-		<constant name="VIOLET" value="Color( 0.93, 0.51, 0.93, 1 )">
+		<constant name="VIOLET" value="Color(0.93, 0.51, 0.93, 1)">
 			Violet color.
 		</constant>
-		<constant name="WEB_GRAY" value="Color( 0.5, 0.5, 0.5, 1 )">
+		<constant name="WEB_GRAY" value="Color(0.5, 0.5, 0.5, 1)">
 			Web gray color.
 		</constant>
-		<constant name="WEB_GREEN" value="Color( 0, 0.5, 0, 1 )">
+		<constant name="WEB_GREEN" value="Color(0, 0.5, 0, 1)">
 			Web green color.
 		</constant>
-		<constant name="WEB_MAROON" value="Color( 0.5, 0, 0, 1 )">
+		<constant name="WEB_MAROON" value="Color(0.5, 0, 0, 1)">
 			Web maroon color.
 		</constant>
-		<constant name="WEB_PURPLE" value="Color( 0.5, 0, 0.5, 1 )">
+		<constant name="WEB_PURPLE" value="Color(0.5, 0, 0.5, 1)">
 			Web purple color.
 		</constant>
-		<constant name="WHEAT" value="Color( 0.96, 0.87, 0.7, 1 )">
+		<constant name="WHEAT" value="Color(0.96, 0.87, 0.7, 1)">
 			Wheat color.
 		</constant>
-		<constant name="WHITE" value="Color( 1, 1, 1, 1 )">
+		<constant name="WHITE" value="Color(1, 1, 1, 1)">
 			White color.
 		</constant>
-		<constant name="WHITE_SMOKE" value="Color( 0.96, 0.96, 0.96, 1 )">
+		<constant name="WHITE_SMOKE" value="Color(0.96, 0.96, 0.96, 1)">
 			White smoke color.
 		</constant>
-		<constant name="YELLOW" value="Color( 1, 1, 0, 1 )">
+		<constant name="YELLOW" value="Color(1, 1, 0, 1)">
 			Yellow color.
 		</constant>
-		<constant name="YELLOW_GREEN" value="Color( 0.6, 0.8, 0.2, 1 )">
+		<constant name="YELLOW_GREEN" value="Color(0.6, 0.8, 0.2, 1)">
 			Yellow green color.
 		</constant>
 	</constants>

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -38,7 +38,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="set_pick_color" getter="get_pick_color" default="Color( 1, 1, 1, 1 )">
+		<member name="color" type="Color" setter="set_pick_color" getter="get_pick_color" default="Color(1, 1, 1, 1)">
 			The currently selected color.
 		</member>
 		<member name="deferred_mode" type="bool" setter="set_deferred_mode" getter="is_deferred_mode" default="false">

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -28,7 +28,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="set_pick_color" getter="get_pick_color" default="Color( 0, 0, 0, 1 )">
+		<member name="color" type="Color" setter="set_pick_color" getter="get_pick_color" default="Color(0, 0, 0, 1)">
 			The currently selected color.
 		</member>
 		<member name="edit_alpha" type="bool" setter="set_edit_alpha" getter="is_editing_alpha" default="true">
@@ -70,19 +70,19 @@
 		<theme_item name="font" type="Font">
 			[Font] of the [ColorPickerButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(1, 1, 1, 1)">
 			Default text [Color] of the [ColorPickerButton].
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.3 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.3)">
 			Text [Color] used when the [ColorPickerButton] is disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [ColorPickerButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color( 0.8, 0.8, 0.8, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color(0.8, 0.8, 0.8, 1)">
 			Text [Color] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/ColorRect.xml
+++ b/doc/classes/ColorRect.xml
@@ -12,7 +12,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			The fill color.
 			[codeblocks]
 			[gdscript]

--- a/doc/classes/ConcavePolygonShape2D.xml
+++ b/doc/classes/ConcavePolygonShape2D.xml
@@ -12,7 +12,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="segments" type="PackedVector2Array" setter="set_segments" getter="get_segments" default="PackedVector2Array(  )">
+		<member name="segments" type="PackedVector2Array" setter="set_segments" getter="get_segments" default="PackedVector2Array()">
 			The array of points that make up the [ConcavePolygonShape2D]'s line segments.
 		</member>
 	</members>

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -9,7 +9,7 @@
 		[section]
 		some_key=42
 		string_example="Hello World3D!"
-		a_vector=Vector3( 1, 0, 2 )
+		a_vector=Vector3(1, 0, 2)
 		[/codeblock]
 		The stored data can be saved to or parsed from a file, though ConfigFile objects can also be used directly without accessing the filesystem.
 		The following example shows how to parse an INI-style file from the system, read its contents and store new values in it:

--- a/doc/classes/ConfirmationDialog.xml
+++ b/doc/classes/ConfirmationDialog.xml
@@ -27,8 +27,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="min_size" type="Vector2i" setter="set_min_size" getter="get_min_size" override="true" default="Vector2i( 200, 70 )" />
-		<member name="size" type="Vector2i" setter="set_size" getter="get_size" override="true" default="Vector2i( 200, 100 )" />
+		<member name="min_size" type="Vector2i" setter="set_min_size" getter="get_min_size" override="true" default="Vector2i(200, 70)" />
+		<member name="size" type="Vector2i" setter="set_size" getter="get_size" override="true" default="Vector2i(200, 100)" />
 		<member name="title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Please Confirm...&quot;" />
 	</members>
 	<constants>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -395,7 +395,7 @@
 		<method name="get_cursor_shape" qualifiers="const">
 			<return type="int" enum="Control.CursorShape">
 			</return>
-			<argument index="0" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="0" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Returns the mouse cursor shape the control displays on mouse hover. See [enum CursorShape].
@@ -549,7 +549,7 @@
 		<method name="get_tooltip" qualifiers="const">
 			<return type="String">
 			</return>
-			<argument index="0" name="at_position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="0" name="at_position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Returns the tooltip, which will appear when the cursor is resting over this control. See [member hint_tooltip].
@@ -1140,13 +1140,13 @@
 		<member name="rect_global_position" type="Vector2" setter="_set_global_position" getter="get_global_position">
 			The node's global position, relative to the world (usually to the top-left corner of the window).
 		</member>
-		<member name="rect_min_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" default="Vector2( 0, 0 )">
+		<member name="rect_min_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" default="Vector2(0, 0)">
 			The minimum size of the node's bounding rectangle. If you set it to a value greater than (0, 0), the node's bounding rectangle will always have at least this size, even if its content is smaller. If it's set to (0, 0), the node sizes automatically to fit its content, be it a texture or child nodes.
 		</member>
-		<member name="rect_pivot_offset" type="Vector2" setter="set_pivot_offset" getter="get_pivot_offset" default="Vector2( 0, 0 )">
+		<member name="rect_pivot_offset" type="Vector2" setter="set_pivot_offset" getter="get_pivot_offset" default="Vector2(0, 0)">
 			By default, the node's pivot is its top-left corner. When you change its [member rect_scale], it will scale around this pivot. Set this property to [member rect_size] / 2 to center the pivot in the node's rectangle.
 		</member>
-		<member name="rect_position" type="Vector2" setter="_set_position" getter="get_position" default="Vector2( 0, 0 )">
+		<member name="rect_position" type="Vector2" setter="_set_position" getter="get_position" default="Vector2(0, 0)">
 			The node's position, relative to its parent. It corresponds to the rectangle's top-left corner. The property is not affected by [member rect_pivot_offset].
 		</member>
 		<member name="rect_rotation" type="float" setter="set_rotation" getter="get_rotation" default="0.0">
@@ -1155,12 +1155,12 @@
 		<member name="rect_rotation_degrees" type="float" setter="set_rotation_degrees" getter="get_rotation_degrees" default="0.0">
 			The node's rotation around its pivot, in degrees. See [member rect_pivot_offset] to change the pivot's position.
 		</member>
-		<member name="rect_scale" type="Vector2" setter="set_scale" getter="get_scale" default="Vector2( 1, 1 )">
+		<member name="rect_scale" type="Vector2" setter="set_scale" getter="get_scale" default="Vector2(1, 1)">
 			The node's scale, relative to its [member rect_size]. Change this property to scale the node around its [member rect_pivot_offset]. The Control's [member hint_tooltip] will also scale according to this value.
 			[b]Note:[/b] This property is mainly intended to be used for animation purposes. Text inside the Control will look pixelated or blurry when the Control is scaled. To support multiple resolutions in your project, use an appropriate viewport stretch mode as described in the [url=https://docs.godotengine.org/en/latest/tutorials/viewports/multiple_resolutions.html]documentation[/url] instead of scaling Controls individually.
 			[b]Note:[/b] If the Control node is a child of a [Container] node, the scale will be reset to [code]Vector2(1, 1)[/code] when the scene is instanced. To set the Control's scale when it's instanced, wait for one frame using [code]yield(get_tree(), "idle_frame")[/code] then set its [member rect_scale] property.
 		</member>
-		<member name="rect_size" type="Vector2" setter="_set_size" getter="get_size" default="Vector2( 0, 0 )">
+		<member name="rect_size" type="Vector2" setter="_set_size" getter="get_size" default="Vector2(0, 0)">
 			The size of the node's bounding rectangle, in pixels. [Container] nodes update this property automatically.
 		</member>
 		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags" default="1">

--- a/doc/classes/ConvexPolygonShape2D.xml
+++ b/doc/classes/ConvexPolygonShape2D.xml
@@ -21,7 +21,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="points" type="PackedVector2Array" setter="set_points" getter="get_points" default="PackedVector2Array(  )">
+		<member name="points" type="PackedVector2Array" setter="set_points" getter="get_points" default="PackedVector2Array()">
 			The polygon's list of vertices. Can be in either clockwise or counterclockwise order.
 		</member>
 	</members>

--- a/doc/classes/ConvexPolygonShape3D.xml
+++ b/doc/classes/ConvexPolygonShape3D.xml
@@ -12,7 +12,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="points" type="PackedVector3Array" setter="set_points" getter="get_points" default="PackedVector3Array(  )">
+		<member name="points" type="PackedVector3Array" setter="set_points" getter="get_points" default="PackedVector3Array()">
 			The list of 3D points forming the convex polygon shape.
 		</member>
 	</members>

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -15,9 +15,9 @@
 			</return>
 			<argument index="0" name="position" type="Vector2">
 			</argument>
-			<argument index="1" name="in" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="1" name="in" type="Vector2" default="Vector2(0, 0)">
 			</argument>
-			<argument index="2" name="out" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="out" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<argument index="3" name="at_position" type="int" default="-1">
 			</argument>

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -15,9 +15,9 @@
 			</return>
 			<argument index="0" name="position" type="Vector3">
 			</argument>
-			<argument index="1" name="in" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="1" name="in" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
-			<argument index="2" name="out" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="2" name="out" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<argument index="3" name="at_position" type="int" default="-1">
 			</argument>

--- a/doc/classes/Decal.xml
+++ b/doc/classes/Decal.xml
@@ -79,13 +79,13 @@
 		<member name="emission_energy" type="float" setter="set_emission_energy" getter="get_emission_energy" default="1.0">
 			Energy multiplier for the emission texture. This will make the decal emit light at a higher intensity.
 		</member>
-		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3( 1, 1, 1 )">
+		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(1, 1, 1)">
 			Sets the size of the [AABB] used by the decal. The AABB goes from [code]-extents[/code] to [code]extents[/code].
 		</member>
 		<member name="lower_fade" type="float" setter="set_lower_fade" getter="get_lower_fade" default="0.3">
 			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB].
 		</member>
-		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color( 1, 1, 1, 1 )">
+		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
 			Changes the [Color] of the Decal by multiplying it with this value.
 		</member>
 		<member name="normal_fade" type="float" setter="set_normal_fade" getter="get_normal_fade" default="0.0">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -46,7 +46,7 @@
 			</argument>
 			<argument index="1" name="flags" type="int">
 			</argument>
-			<argument index="2" name="rect" type="Rect2i" default="Rect2i( 0, 0, 0, 0 )">
+			<argument index="2" name="rect" type="Rect2i" default="Rect2i(0, 0, 0, 0)">
 			</argument>
 			<description>
 			</description>
@@ -64,7 +64,7 @@
 			</argument>
 			<argument index="1" name="shape" type="int" enum="DisplayServer.CursorShape" default="0">
 			</argument>
-			<argument index="2" name="hotspot" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="hotspot" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 			</description>
@@ -650,7 +650,7 @@
 			</return>
 			<argument index="0" name="existing_text" type="String">
 			</argument>
-			<argument index="1" name="position" type="Rect2" default="Rect2i( 0, 0, 0, 0 )">
+			<argument index="1" name="position" type="Rect2" default="Rect2i(0, 0, 0, 0)">
 			</argument>
 			<argument index="2" name="multiline" type="bool" default="false">
 			</argument>

--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -115,7 +115,7 @@
 			</argument>
 			<argument index="2" name="billboard" type="bool" default="false">
 			</argument>
-			<argument index="3" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Adds lines to the gizmo (as sets of 2 points), with a given material. The lines are used for visualizing the gizmo. Call this function during [method _redraw].
@@ -143,7 +143,7 @@
 			</argument>
 			<argument index="1" name="default_scale" type="float" default="1">
 			</argument>
-			<argument index="2" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="2" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Adds an unscaled billboard for visualization. Call this function during [method _redraw].

--- a/doc/classes/EditorNode3DGizmoPlugin.xml
+++ b/doc/classes/EditorNode3DGizmoPlugin.xml
@@ -163,7 +163,7 @@
 			</argument>
 			<argument index="2" name="on_top" type="bool" default="false">
 			</argument>
-			<argument index="3" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Creates an icon material with its variants (selected and/or editable) and adds them to the internal material list. They can then be accessed with [method get_material] and used in [method EditorNode3DGizmo.add_unscaled_billboard]. Should not be overridden.

--- a/doc/classes/EditorSceneImporterMesh.xml
+++ b/doc/classes/EditorSceneImporterMesh.xml
@@ -22,7 +22,7 @@
 			</argument>
 			<argument index="1" name="arrays" type="Array">
 			</argument>
-			<argument index="2" name="blend_shapes" type="Array" default="[  ]">
+			<argument index="2" name="blend_shapes" type="Array" default="[]">
 			</argument>
 			<argument index="3" name="lods" type="Dictionary" default="{
 }">
@@ -168,7 +168,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;surfaces&quot;: [  ]}">
+		<member name="_data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;surfaces&quot;: []}">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/EngineDebugger.xml
+++ b/doc/classes/EngineDebugger.xml
@@ -61,7 +61,7 @@
 			</argument>
 			<argument index="1" name="enable" type="bool">
 			</argument>
-			<argument index="2" name="arguments" type="Array" default="[  ]">
+			<argument index="2" name="arguments" type="Array" default="[]">
 			</argument>
 			<description>
 				Calls the [code]toggle[/code] callable of the profiler with given [code]name[/code] and [code]arguments[/code]. Enables/Disables the same profiler depending on [code]enable[/code] argument.

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -55,13 +55,13 @@
 		<member name="adjustment_saturation" type="float" setter="set_adjustment_saturation" getter="get_adjustment_saturation" default="1.0">
 			The global color saturation value of the rendered scene (default value is 1). Effective only if [code]adjustment_enabled[/code] is [code]true[/code].
 		</member>
-		<member name="ambient_light_color" type="Color" setter="set_ambient_light_color" getter="get_ambient_light_color" default="Color( 0, 0, 0, 1 )">
+		<member name="ambient_light_color" type="Color" setter="set_ambient_light_color" getter="get_ambient_light_color" default="Color(0, 0, 0, 1)">
 			The ambient light's [Color].
 		</member>
 		<member name="ambient_light_energy" type="float" setter="set_ambient_light_energy" getter="get_ambient_light_energy" default="1.0">
 			The ambient light's energy. The higher the value, the stronger the light.
 		</member>
-		<member name="ambient_light_occlusion_color" type="Color" setter="set_ao_color" getter="get_ao_color" default="Color( 0, 0, 0, 1 )">
+		<member name="ambient_light_occlusion_color" type="Color" setter="set_ao_color" getter="get_ao_color" default="Color(0, 0, 0, 1)">
 		</member>
 		<member name="ambient_light_sky_contribution" type="float" setter="set_ambient_light_sky_contribution" getter="get_ambient_light_sky_contribution" default="1.0">
 			Defines the amount of light that the sky brings on the scene. A value of 0 means that the sky's light emission has no effect on the scene illumination, thus all ambient illumination is provided by the ambient light. On the contrary, a value of 1 means that all the light that affects the scene is provided by the sky, thus the ambient light parameter has no effect on the scene.
@@ -89,7 +89,7 @@
 		<member name="background_canvas_max_layer" type="int" setter="set_canvas_max_layer" getter="get_canvas_max_layer" default="0">
 			The maximum layer ID to display. Only effective when using the [constant BG_CANVAS] background mode.
 		</member>
-		<member name="background_color" type="Color" setter="set_bg_color" getter="get_bg_color" default="Color( 0, 0, 0, 1 )">
+		<member name="background_color" type="Color" setter="set_bg_color" getter="get_bg_color" default="Color(0, 0, 0, 1)">
 			The [Color] displayed for clear areas of the scene. Only effective when using the [constant BG_COLOR] background mode.
 		</member>
 		<member name="background_energy" type="float" setter="set_bg_energy" getter="get_bg_energy" default="1.0">
@@ -111,7 +111,7 @@
 		</member>
 		<member name="fog_height_density" type="float" setter="set_fog_height_density" getter="get_fog_height_density" default="0.0">
 		</member>
-		<member name="fog_light_color" type="Color" setter="set_fog_light_color" getter="get_fog_light_color" default="Color( 0.5, 0.6, 0.7, 1 )">
+		<member name="fog_light_color" type="Color" setter="set_fog_light_color" getter="get_fog_light_color" default="Color(0.5, 0.6, 0.7, 1)">
 		</member>
 		<member name="fog_light_energy" type="float" setter="set_fog_light_energy" getter="get_fog_light_energy" default="1.0">
 		</member>
@@ -200,7 +200,7 @@
 		</member>
 		<member name="sky_custom_fov" type="float" setter="set_sky_custom_fov" getter="get_sky_custom_fov" default="0.0">
 		</member>
-		<member name="sky_rotation" type="Vector3" setter="set_sky_rotation" getter="get_sky_rotation" default="Vector3( 0, 0, 0 )">
+		<member name="sky_rotation" type="Vector3" setter="set_sky_rotation" getter="get_sky_rotation" default="Vector3(0, 0, 0)">
 		</member>
 		<member name="ss_reflections_depth_tolerance" type="float" setter="set_ssr_depth_tolerance" getter="get_ssr_depth_tolerance" default="0.2">
 			The depth tolerance for screen-space reflections.
@@ -263,7 +263,7 @@
 		</member>
 		<member name="volumetric_fog_length" type="float" setter="set_volumetric_fog_length" getter="get_volumetric_fog_length" default="64.0">
 		</member>
-		<member name="volumetric_fog_light" type="Color" setter="set_volumetric_fog_light" getter="get_volumetric_fog_light" default="Color( 0, 0, 0, 1 )">
+		<member name="volumetric_fog_light" type="Color" setter="set_volumetric_fog_light" getter="get_volumetric_fog_light" default="Color(0, 0, 0, 1)">
 		</member>
 		<member name="volumetric_fog_light_energy" type="float" setter="set_volumetric_fog_light_energy" getter="get_volumetric_fog_light_energy" default="1.0">
 		</member>

--- a/doc/classes/Expression.xml
+++ b/doc/classes/Expression.xml
@@ -54,7 +54,7 @@
 		<method name="execute">
 			<return type="Variant">
 			</return>
-			<argument index="0" name="inputs" type="Array" default="[  ]">
+			<argument index="0" name="inputs" type="Array" default="[]">
 			</argument>
 			<argument index="1" name="base_instance" type="Object" default="null">
 			</argument>
@@ -84,7 +84,7 @@
 			</return>
 			<argument index="0" name="expression" type="String">
 			</argument>
-			<argument index="1" name="input_names" type="PackedStringArray" default="PackedStringArray(  )">
+			<argument index="1" name="input_names" type="PackedStringArray" default="PackedStringArray()">
 			</argument>
 			<description>
 				Parses the expression and returns an [enum Error] code.

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -72,7 +72,7 @@
 		<member name="file_mode" type="int" setter="set_file_mode" getter="get_file_mode" enum="FileDialog.FileMode" default="4">
 			The dialog's open or save mode, which affects the selection behavior. See [enum FileMode].
 		</member>
-		<member name="filters" type="PackedStringArray" setter="set_filters" getter="get_filters" default="PackedStringArray(  )">
+		<member name="filters" type="PackedStringArray" setter="set_filters" getter="get_filters" default="PackedStringArray()">
 			The available file type filters. For example, this shows only [code].png[/code] and [code].gd[/code] files: [code]set_filters(PackedStringArray(["*.png ; PNG Images","*.gd ; GDScript Files"]))[/code].
 		</member>
 		<member name="mode_overrides_title" type="bool" setter="set_mode_overrides_title" getter="is_mode_overriding_title" default="true">
@@ -139,16 +139,16 @@
 		<theme_item name="file" type="Texture2D">
 			Custom icon for files.
 		</theme_item>
-		<theme_item name="file_icon_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="file_icon_modulate" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the file icon.
 		</theme_item>
-		<theme_item name="files_disabled" type="Color" default="Color( 0, 0, 0, 0.7 )">
+		<theme_item name="files_disabled" type="Color" default="Color(0, 0, 0, 0.7)">
 			The color tint for disabled files (when the [FileDialog] is used in open folder mode).
 		</theme_item>
 		<theme_item name="folder" type="Texture2D">
 			Custom icon for folders.
 		</theme_item>
-		<theme_item name="folder_icon_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="folder_icon_modulate" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the folder icon.
 		</theme_item>
 		<theme_item name="forward_folder" type="Texture2D">

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -85,11 +85,11 @@
 			</argument>
 			<argument index="4" name="size" type="int" default="-1">
 			</argument>
-			<argument index="5" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="5" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="6" name="outline_size" type="int" default="0">
 			</argument>
-			<argument index="7" name="outline_modulate" type="Color" default="Color( 1, 1, 1, 0 )">
+			<argument index="7" name="outline_modulate" type="Color" default="Color(1, 1, 1, 0)">
 			</argument>
 			<description>
 				Draw a single Unicode character [code]char[/code] into a canvas item using the font, at a given position, with [code]modulate[/code] color, and optionally kerning if [code]next[/code] is passed. [code]position[/code] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
@@ -113,11 +113,11 @@
 			</argument>
 			<argument index="6" name="size" type="int" default="-1">
 			</argument>
-			<argument index="7" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="7" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="8" name="outline_size" type="int" default="0">
 			</argument>
-			<argument index="9" name="outline_modulate" type="Color" default="Color( 1, 1, 1, 0 )">
+			<argument index="9" name="outline_modulate" type="Color" default="Color(1, 1, 1, 0)">
 			</argument>
 			<argument index="10" name="flags" type="int" default="51">
 			</argument>
@@ -141,11 +141,11 @@
 			</argument>
 			<argument index="5" name="size" type="int" default="-1">
 			</argument>
-			<argument index="6" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="6" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="7" name="outline_size" type="int" default="0">
 			</argument>
-			<argument index="8" name="outline_modulate" type="Color" default="Color( 1, 1, 1, 0 )">
+			<argument index="8" name="outline_modulate" type="Color" default="Color(1, 1, 1, 0)">
 			</argument>
 			<argument index="9" name="flags" type="int" default="3">
 			</argument>

--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -61,7 +61,7 @@
 			</argument>
 			<argument index="3" name="index" type="int">
 			</argument>
-			<argument index="4" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="4" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draws single glyph into a canvas item at the position, using [code]font[/code] at the size [code]size[/code].
@@ -82,7 +82,7 @@
 			</argument>
 			<argument index="4" name="index" type="int">
 			</argument>
-			<argument index="5" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="5" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draws single glyph outline of size [code]outline_size[/code] into a canvas item at the position, using [code]font[/code] at the size [code]size[/code]. If outline drawing is not supported, nothing is drawn.

--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -80,7 +80,7 @@
 		</member>
 		<member name="trail_sections" type="int" setter="set_trail_sections" getter="get_trail_sections" default="8">
 		</member>
-		<member name="visibility_rect" type="Rect2" setter="set_visibility_rect" getter="get_visibility_rect" default="Rect2( -100, -100, 200, 200 )">
+		<member name="visibility_rect" type="Rect2" setter="set_visibility_rect" getter="get_visibility_rect" default="Rect2(-100, -100, 200, 200)">
 			The [Rect2] that determines the node's region which needs to be visible on screen for the particle system to be active.
 			Grow the rect if particles suddenly appear/disappear when the node enters/exits the screen. The [Rect2] can be grown via code or with the [b]Particles → Generate Visibility Rect[/b] editor tool.
 		</member>

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -132,7 +132,7 @@
 		</member>
 		<member name="transform_align" type="int" setter="set_transform_align" getter="get_transform_align" enum="GPUParticles3D.TransformAlign" default="0">
 		</member>
-		<member name="visibility_aabb" type="AABB" setter="set_visibility_aabb" getter="get_visibility_aabb" default="AABB( -4, -4, -4, 8, 8, 8 )">
+		<member name="visibility_aabb" type="AABB" setter="set_visibility_aabb" getter="get_visibility_aabb" default="AABB(-4, -4, -4, 8, 8, 8)">
 			The [AABB] that determines the node's region which needs to be visible on screen for the particle system to be active.
 			Grow the box if particles suddenly appear/disappear when the node enters/exits the screen. The [AABB] can be grown via code or with the [b]Particles → Generate AABB[/b] editor tool.
 		</member>

--- a/doc/classes/GPUParticlesAttractorBox.xml
+++ b/doc/classes/GPUParticlesAttractorBox.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3( 1, 1, 1 )">
+		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(1, 1, 1)">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/GPUParticlesAttractorVectorField.xml
+++ b/doc/classes/GPUParticlesAttractorVectorField.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3( 1, 1, 1 )">
+		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(1, 1, 1)">
 		</member>
 		<member name="texture" type="Texture3D" setter="set_texture" getter="get_texture">
 		</member>

--- a/doc/classes/GPUParticlesCollisionBox.xml
+++ b/doc/classes/GPUParticlesCollisionBox.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3( 1, 1, 1 )">
+		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(1, 1, 1)">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/GPUParticlesCollisionHeightField.xml
+++ b/doc/classes/GPUParticlesCollisionHeightField.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3( 1, 1, 1 )">
+		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(1, 1, 1)">
 		</member>
 		<member name="follow_camera_enabled" type="bool" setter="set_follow_camera_mode" getter="is_follow_camera_mode_enabled" default="false">
 		</member>

--- a/doc/classes/GPUParticlesCollisionSDF.xml
+++ b/doc/classes/GPUParticlesCollisionSDF.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3( 1, 1, 1 )">
+		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(1, 1, 1)">
 		</member>
 		<member name="resolution" type="int" setter="set_resolution" getter="get_resolution" enum="GPUParticlesCollisionSDF.Resolution" default="2">
 		</member>

--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -87,10 +87,10 @@
 		</method>
 	</methods>
 	<members>
-		<member name="colors" type="PackedColorArray" setter="set_colors" getter="get_colors" default="PackedColorArray( 0, 0, 0, 1, 1, 1, 1, 1 )">
+		<member name="colors" type="PackedColorArray" setter="set_colors" getter="get_colors" default="PackedColorArray(0, 0, 0, 1, 1, 1, 1, 1)">
 			Gradient's colors returned as a [PackedColorArray].
 		</member>
-		<member name="offsets" type="PackedFloat32Array" setter="set_offsets" getter="get_offsets" default="PackedFloat32Array( 0, 1 )">
+		<member name="offsets" type="PackedFloat32Array" setter="set_offsets" getter="get_offsets" default="PackedFloat32Array(0, 1)">
 			Gradient's offsets returned as a [PackedFloat32Array].
 		</member>
 	</members>

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -187,14 +187,14 @@
 		<member name="minimap_opacity" type="float" setter="set_minimap_opacity" getter="get_minimap_opacity" default="0.65">
 			The opacity of the minimap rectangle.
 		</member>
-		<member name="minimap_size" type="Vector2" setter="set_minimap_size" getter="get_minimap_size" default="Vector2( 240, 160 )">
+		<member name="minimap_size" type="Vector2" setter="set_minimap_size" getter="get_minimap_size" default="Vector2(240, 160)">
 			The size of the minimap rectangle. The map itself is based on the size of the grid area and is scaled to fit this rectangle.
 		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
 		<member name="right_disconnects" type="bool" setter="set_right_disconnects" getter="is_right_disconnects_enabled" default="false">
 			If [code]true[/code], enables disconnection of existing connections in the GraphEdit by dragging the right end.
 		</member>
-		<member name="scroll_offset" type="Vector2" setter="set_scroll_ofs" getter="get_scroll_ofs" default="Vector2( 0, 0 )">
+		<member name="scroll_offset" type="Vector2" setter="set_scroll_ofs" getter="get_scroll_ofs" default="Vector2(0, 0)">
 			The scroll offset.
 		</member>
 		<member name="show_zoom_label" type="bool" setter="set_show_zoom_label" getter="is_showing_zoom_label" default="false">
@@ -329,7 +329,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="activity" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="activity" type="Color" default="Color(1, 1, 1, 1)">
 		</theme_item>
 		<theme_item name="bezier_len_neg" type="int" default="160">
 		</theme_item>
@@ -338,10 +338,10 @@
 		<theme_item name="bg" type="StyleBox">
 			The background drawn under the grid.
 		</theme_item>
-		<theme_item name="grid_major" type="Color" default="Color( 1, 1, 1, 0.2 )">
+		<theme_item name="grid_major" type="Color" default="Color(1, 1, 1, 0.2)">
 			Color of major grid lines.
 		</theme_item>
-		<theme_item name="grid_minor" type="Color" default="Color( 1, 1, 1, 0.05 )">
+		<theme_item name="grid_minor" type="Color" default="Color(1, 1, 1, 0.05)">
 			Color of minor grid lines.
 		</theme_item>
 		<theme_item name="minimap" type="Texture2D">
@@ -361,10 +361,10 @@
 		<theme_item name="reset" type="Texture2D">
 			The icon for the zoom reset button.
 		</theme_item>
-		<theme_item name="selection_fill" type="Color" default="Color( 1, 1, 1, 0.3 )">
+		<theme_item name="selection_fill" type="Color" default="Color(1, 1, 1, 0.3)">
 			The fill color of the selection rectangle.
 		</theme_item>
-		<theme_item name="selection_stroke" type="Color" default="Color( 1, 1, 1, 0.8 )">
+		<theme_item name="selection_stroke" type="Color" default="Color(1, 1, 1, 0.8)">
 			The outline color of the selection rectangle.
 		</theme_item>
 		<theme_item name="snap" type="Texture2D">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -285,7 +285,7 @@
 		<member name="overlay" type="int" setter="set_overlay" getter="get_overlay" enum="GraphNode.Overlay" default="0">
 			Sets the overlay shown above the GraphNode. See [enum Overlay].
 		</member>
-		<member name="position_offset" type="Vector2" setter="set_position_offset" getter="get_position_offset" default="Vector2( 0, 0 )">
+		<member name="position_offset" type="Vector2" setter="set_position_offset" getter="get_position_offset" default="Vector2(0, 0)">
 			The offset of the GraphNode, relative to the scroll offset of the [GraphEdit].
 			[b]Note:[/b] You cannot use position offset directly, as [GraphEdit] is a [Container].
 		</member>
@@ -365,7 +365,7 @@
 		<theme_item name="close" type="Texture2D">
 			The icon for the close button, visible when [member show_close] is enabled.
 		</theme_item>
-		<theme_item name="close_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="close_color" type="Color" default="Color(0, 0, 0, 1)">
 			The color modulation applied to the close button icon.
 		</theme_item>
 		<theme_item name="close_offset" type="int" default="18">
@@ -396,7 +396,7 @@
 		<theme_item name="resizer" type="Texture2D">
 			The icon used for resizer, visible when [member resizable] is enabled.
 		</theme_item>
-		<theme_item name="resizer_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="resizer_color" type="Color" default="Color(0, 0, 0, 1)">
 			The color modulation applied to the resizer icon.
 		</theme_item>
 		<theme_item name="selectedframe" type="StyleBox">
@@ -405,7 +405,7 @@
 		<theme_item name="separation" type="int" default="1">
 			The vertical distance between ports.
 		</theme_item>
-		<theme_item name="title_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="title_color" type="Color" default="Color(0, 0, 0, 1)">
 			Color of the title text.
 		</theme_item>
 		<theme_item name="title_font" type="Font">

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -192,7 +192,7 @@
 			</return>
 			<argument index="0" name="url" type="String">
 			</argument>
-			<argument index="1" name="custom_headers" type="PackedStringArray" default="PackedStringArray(  )">
+			<argument index="1" name="custom_headers" type="PackedStringArray" default="PackedStringArray()">
 			</argument>
 			<argument index="2" name="ssl_validate_domain" type="bool" default="true">
 			</argument>
@@ -211,13 +211,13 @@
 			</return>
 			<argument index="0" name="url" type="String">
 			</argument>
-			<argument index="1" name="custom_headers" type="PackedStringArray" default="PackedStringArray(  )">
+			<argument index="1" name="custom_headers" type="PackedStringArray" default="PackedStringArray()">
 			</argument>
 			<argument index="2" name="ssl_validate_domain" type="bool" default="true">
 			</argument>
 			<argument index="3" name="method" type="int" enum="HTTPClient.Method" default="0">
 			</argument>
-			<argument index="4" name="request_data_raw" type="PackedByteArray" default="PackedByteArray(  )">
+			<argument index="4" name="request_data_raw" type="PackedByteArray" default="PackedByteArray()">
 			</argument>
 			<description>
 				Creates request on the underlying [HTTPClient] using a raw array of bytes for the request body. If there is no configuration errors, it tries to connect using [method HTTPClient.connect_to_host] and passes parameters onto [method HTTPClient.request].

--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="map_data" type="PackedFloat32Array" setter="set_map_data" getter="get_map_data" default="PackedFloat32Array( 0, 0, 0, 0 )">
+		<member name="map_data" type="PackedFloat32Array" setter="set_map_data" getter="get_map_data" default="PackedFloat32Array(0, 0, 0, 0)">
 			Height map data, pool array must be of [member map_width] * [member map_depth] size.
 		</member>
 		<member name="map_depth" type="int" setter="set_map_depth" getter="get_map_depth" default="2">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -560,7 +560,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;data&quot;: PackedByteArray(  ),&quot;format&quot;: &quot;Lum8&quot;,&quot;height&quot;: 0,&quot;mipmaps&quot;: false,&quot;width&quot;: 0}">
+		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;data&quot;: PackedByteArray(),&quot;format&quot;: &quot;Lum8&quot;,&quot;height&quot;: 0,&quot;mipmaps&quot;: false,&quot;width&quot;: 0}">
 			Holds all the image's color data in a given format. See [enum Format] constants.
 		</member>
 	</members>

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -341,7 +341,7 @@
 			</argument>
 			<argument index="1" name="shape" type="int" enum="Input.CursorShape" default="0">
 			</argument>
-			<argument index="2" name="hotspot" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="hotspot" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Sets a custom mouse cursor image, which is only visible inside the game window. The hotspot can also be specified. Passing [code]null[/code] to the image parameter resets to the system cursor. See [enum CursorShape] for the list of shapes.

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -111,7 +111,7 @@
 			</return>
 			<argument index="0" name="xform" type="Transform2D">
 			</argument>
-			<argument index="1" name="local_ofs" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="1" name="local_ofs" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Returns a copy of the given input event which has been offset by [code]local_ofs[/code] and transformed by [code]xform[/code]. Relevant for events of type [InputEventMouseButton], [InputEventMouseMotion], [InputEventScreenTouch], [InputEventScreenDrag], [InputEventMagnifyGesture] and [InputEventPanGesture].

--- a/doc/classes/InputEventGesture.xml
+++ b/doc/classes/InputEventGesture.xml
@@ -10,7 +10,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2( 0, 0 )">
+		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The local gesture position relative to the [Viewport]. If used in [method Control._gui_input], the position is relative to the current [Control] that received this gesture.
 		</member>
 	</members>

--- a/doc/classes/InputEventMouse.xml
+++ b/doc/classes/InputEventMouse.xml
@@ -15,10 +15,10 @@
 		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" default="0">
 			The mouse button mask identifier, one of or a bitwise combination of the [enum MouseButton] button masks.
 		</member>
-		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position" default="Vector2( 0, 0 )">
+		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position" default="Vector2(0, 0)">
 			The global mouse position relative to the current [Viewport] when used in [method Control._gui_input], otherwise is at 0,0.
 		</member>
-		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2( 0, 0 )">
+		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The local mouse position relative to the [Viewport]. If used in [method Control._gui_input], the position is relative to the current [Control] which is under the mouse.
 		</member>
 	</members>

--- a/doc/classes/InputEventMouseMotion.xml
+++ b/doc/classes/InputEventMouseMotion.xml
@@ -17,14 +17,14 @@
 		<member name="pressure" type="float" setter="set_pressure" getter="get_pressure" default="0.0">
 			Represents the pressure the user puts on the pen. Ranges from [code]0.0[/code] to [code]1.0[/code].
 		</member>
-		<member name="relative" type="Vector2" setter="set_relative" getter="get_relative" default="Vector2( 0, 0 )">
+		<member name="relative" type="Vector2" setter="set_relative" getter="get_relative" default="Vector2(0, 0)">
 			The mouse position relative to the previous position (position at the last frame).
 			[b]Note:[/b] Since [InputEventMouseMotion] is only emitted when the mouse moves, the last event won't have a relative position of [code]Vector2(0, 0)[/code] when the user stops moving the mouse.
 		</member>
-		<member name="speed" type="Vector2" setter="set_speed" getter="get_speed" default="Vector2( 0, 0 )">
+		<member name="speed" type="Vector2" setter="set_speed" getter="get_speed" default="Vector2(0, 0)">
 			The mouse speed in pixels per second.
 		</member>
-		<member name="tilt" type="Vector2" setter="set_tilt" getter="get_tilt" default="Vector2( 0, 0 )">
+		<member name="tilt" type="Vector2" setter="set_tilt" getter="get_tilt" default="Vector2(0, 0)">
 			Represents the angles of tilt of the pen. Positive X-coordinate value indicates a tilt to the right. Positive Y-coordinate value indicates a tilt toward the user. Ranges from [code]-1.0[/code] to [code]1.0[/code] for both axes.
 		</member>
 	</members>

--- a/doc/classes/InputEventPanGesture.xml
+++ b/doc/classes/InputEventPanGesture.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="delta" type="Vector2" setter="set_delta" getter="get_delta" default="Vector2( 0, 0 )">
+		<member name="delta" type="Vector2" setter="set_delta" getter="get_delta" default="Vector2(0, 0)">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/InputEventScreenDrag.xml
+++ b/doc/classes/InputEventScreenDrag.xml
@@ -15,13 +15,13 @@
 		<member name="index" type="int" setter="set_index" getter="get_index" default="0">
 			The drag event index in the case of a multi-drag event.
 		</member>
-		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2( 0, 0 )">
+		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The drag position.
 		</member>
-		<member name="relative" type="Vector2" setter="set_relative" getter="get_relative" default="Vector2( 0, 0 )">
+		<member name="relative" type="Vector2" setter="set_relative" getter="get_relative" default="Vector2(0, 0)">
 			The drag position relative to its start position.
 		</member>
-		<member name="speed" type="Vector2" setter="set_speed" getter="get_speed" default="Vector2( 0, 0 )">
+		<member name="speed" type="Vector2" setter="set_speed" getter="get_speed" default="Vector2(0, 0)">
 			The drag speed.
 		</member>
 	</members>

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -16,7 +16,7 @@
 		<member name="index" type="int" setter="set_index" getter="get_index" default="0">
 			The touch index in the case of a multi-touch event. One index = one finger.
 		</member>
-		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2( 0, 0 )">
+		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The touch position.
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -484,7 +484,7 @@
 			The width all columns will be adjusted to.
 			A value of zero disables the adjustment, each item will have a width equal to the width of its content and the columns will have an uneven width.
 		</member>
-		<member name="fixed_icon_size" type="Vector2" setter="set_fixed_icon_size" getter="get_fixed_icon_size" default="Vector2( 0, 0 )">
+		<member name="fixed_icon_size" type="Vector2" setter="set_fixed_icon_size" getter="get_fixed_icon_size" default="Vector2(0, 0)">
 			The size all icons will be adjusted to.
 			If either X or Y component is not greater than zero, icon size won't be affected.
 		</member>
@@ -593,19 +593,19 @@
 		<theme_item name="font" type="Font">
 			[Font] of the item's text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.63, 0.63, 0.63, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.63, 0.63, 0.63, 1)">
 			Default text [Color] of the item.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the item.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the item is selected.
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the item's text.
 		</theme_item>
-		<theme_item name="guide_color" type="Color" default="Color( 0, 0, 0, 0.1 )">
+		<theme_item name="guide_color" type="Color" default="Color(0, 0, 0, 0.1)">
 			[Color] of the guideline. The guideline is a line drawn between each row of items.
 		</theme_item>
 		<theme_item name="hseparation" type="int" default="4">

--- a/doc/classes/KinematicCollision2D.xml
+++ b/doc/classes/KinematicCollision2D.xml
@@ -27,22 +27,22 @@
 		<member name="collider_shape_index" type="int" setter="" getter="get_collider_shape_index" default="0">
 			The colliding shape's index. See [CollisionObject2D].
 		</member>
-		<member name="collider_velocity" type="Vector2" setter="" getter="get_collider_velocity" default="Vector2( 0, 0 )">
+		<member name="collider_velocity" type="Vector2" setter="" getter="get_collider_velocity" default="Vector2(0, 0)">
 			The colliding object's velocity.
 		</member>
 		<member name="local_shape" type="Object" setter="" getter="get_local_shape">
 			The moving object's colliding shape.
 		</member>
-		<member name="normal" type="Vector2" setter="" getter="get_normal" default="Vector2( 0, 0 )">
+		<member name="normal" type="Vector2" setter="" getter="get_normal" default="Vector2(0, 0)">
 			The colliding body's shape's normal at the point of collision.
 		</member>
-		<member name="position" type="Vector2" setter="" getter="get_position" default="Vector2( 0, 0 )">
+		<member name="position" type="Vector2" setter="" getter="get_position" default="Vector2(0, 0)">
 			The point of collision, in global coordinates.
 		</member>
-		<member name="remainder" type="Vector2" setter="" getter="get_remainder" default="Vector2( 0, 0 )">
+		<member name="remainder" type="Vector2" setter="" getter="get_remainder" default="Vector2(0, 0)">
 			The moving object's remaining movement vector.
 		</member>
-		<member name="travel" type="Vector2" setter="" getter="get_travel" default="Vector2( 0, 0 )">
+		<member name="travel" type="Vector2" setter="" getter="get_travel" default="Vector2(0, 0)">
 			The distance the moving object traveled before collision.
 		</member>
 	</members>

--- a/doc/classes/KinematicCollision3D.xml
+++ b/doc/classes/KinematicCollision3D.xml
@@ -27,22 +27,22 @@
 		<member name="collider_shape_index" type="int" setter="" getter="get_collider_shape_index" default="0">
 			The colliding shape's index. See [CollisionObject3D].
 		</member>
-		<member name="collider_velocity" type="Vector3" setter="" getter="get_collider_velocity" default="Vector3( 0, 0, 0 )">
+		<member name="collider_velocity" type="Vector3" setter="" getter="get_collider_velocity" default="Vector3(0, 0, 0)">
 			The colliding object's velocity.
 		</member>
 		<member name="local_shape" type="Object" setter="" getter="get_local_shape">
 			The moving object's colliding shape.
 		</member>
-		<member name="normal" type="Vector3" setter="" getter="get_normal" default="Vector3( 0, 0, 0 )">
+		<member name="normal" type="Vector3" setter="" getter="get_normal" default="Vector3(0, 0, 0)">
 			The colliding body's shape's normal at the point of collision.
 		</member>
-		<member name="position" type="Vector3" setter="" getter="get_position" default="Vector3( 0, 0, 0 )">
+		<member name="position" type="Vector3" setter="" getter="get_position" default="Vector3(0, 0, 0)">
 			The point of collision, in global coordinates.
 		</member>
-		<member name="remainder" type="Vector3" setter="" getter="get_remainder" default="Vector3( 0, 0, 0 )">
+		<member name="remainder" type="Vector3" setter="" getter="get_remainder" default="Vector3(0, 0, 0)">
 			The moving object's remaining movement vector.
 		</member>
-		<member name="travel" type="Vector3" setter="" getter="get_travel" default="Vector3( 0, 0, 0 )">
+		<member name="travel" type="Vector3" setter="" getter="get_travel" default="Vector3(0, 0, 0)">
 			The distance the moving object traveled before collision.
 		</member>
 	</members>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -98,7 +98,7 @@
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="Control.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
 		</member>
-		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[  ]">
+		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[]">
 			Set additional options for BiDi override.
 		</member>
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
@@ -147,13 +147,13 @@
 		<theme_item name="font" type="Font">
 			[Font] used for the [Label]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(1, 1, 1, 1)">
 			Default text [Color] of the [Label].
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of [Font]'s outline.
 		</theme_item>
-		<theme_item name="font_shadow_color" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="font_shadow_color" type="Color" default="Color(0, 0, 0, 0)">
 			[Color] of the text's shadow effect.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/Light2D.xml
+++ b/doc/classes/Light2D.xml
@@ -30,7 +30,7 @@
 		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="Light2D.BlendMode" default="0">
 			The Light2D's blend mode. See [enum BlendMode] constants for values.
 		</member>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			The Light2D's [Color].
 		</member>
 		<member name="editor_only" type="bool" setter="set_editor_only" getter="is_editor_only" default="false">
@@ -57,7 +57,7 @@
 		<member name="range_z_min" type="int" setter="set_z_range_min" getter="get_z_range_min" default="-1024">
 			Minimum [code]z[/code] value of objects that are affected by the Light2D.
 		</member>
-		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color( 0, 0, 0, 0 )">
+		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color(0, 0, 0, 0)">
 			[Color] of shadows cast by the Light2D.
 		</member>
 		<member name="shadow_enabled" type="bool" setter="set_shadow_enabled" getter="is_shadow_enabled" default="false">

--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -42,7 +42,7 @@
 		<member name="light_bake_mode" type="int" setter="set_bake_mode" getter="get_bake_mode" enum="Light3D.BakeMode" default="1">
 			The light's bake mode. See [enum BakeMode].
 		</member>
-		<member name="light_color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+		<member name="light_color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			The light's color. An [i]overbright[/i] color can be used to achieve a result equivalent to increasing the light's [member light_energy].
 		</member>
 		<member name="light_cull_mask" type="int" setter="set_cull_mask" getter="get_cull_mask" default="4294967295">
@@ -72,7 +72,7 @@
 		<member name="shadow_blur" type="float" setter="set_param" getter="get_param" default="1.0">
 			Blurs the edges of the shadow. Can be used to hide pixel artifacts in low-resolution shadow maps. A high value can impact performance, make shadows appear grainy and can cause other unwanted artifacts. Try to keep as near default as possible.
 		</member>
-		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color( 0, 0, 0, 1 )">
+		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color(0, 0, 0, 1)">
 			The color of shadows cast by this light.
 		</member>
 		<member name="shadow_enabled" type="bool" setter="set_shadow" getter="has_shadow" default="false">

--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -74,7 +74,7 @@
 		<member name="begin_cap_mode" type="int" setter="set_begin_cap_mode" getter="get_begin_cap_mode" enum="Line2D.LineCapMode" default="0">
 			Controls the style of the line's first point. Use [enum LineCapMode] constants.
 		</member>
-		<member name="default_color" type="Color" setter="set_default_color" getter="get_default_color" default="Color( 1, 1, 1, 1 )">
+		<member name="default_color" type="Color" setter="set_default_color" getter="get_default_color" default="Color(1, 1, 1, 1)">
 			The line's color. Will not be used if a gradient is set.
 		</member>
 		<member name="end_cap_mode" type="int" setter="set_end_cap_mode" getter="get_end_cap_mode" enum="Line2D.LineCapMode" default="0">
@@ -86,7 +86,7 @@
 		<member name="joint_mode" type="int" setter="set_joint_mode" getter="get_joint_mode" enum="Line2D.LineJointMode" default="0">
 			The style for the points between the start and the end.
 		</member>
-		<member name="points" type="PackedVector2Array" setter="set_points" getter="get_points" default="PackedVector2Array(  )">
+		<member name="points" type="PackedVector2Array" setter="set_points" getter="get_points" default="PackedVector2Array()">
 			The points that form the lines. The line is drawn between every point set in this array. Points are interpreted as local vectors.
 		</member>
 		<member name="round_precision" type="int" setter="set_round_precision" getter="get_round_precision" default="8">

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -221,7 +221,7 @@
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="Control.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
 		</member>
-		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[  ]">
+		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[]">
 			Set additional options for BiDi override.
 		</member>
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
@@ -359,16 +359,16 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="caret_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="caret_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Color of the [LineEdit]'s caret (text cursor).
 		</theme_item>
 		<theme_item name="clear" type="Texture2D">
 			Texture for the clear button. See [member clear_button_enabled].
 		</theme_item>
-		<theme_item name="clear_button_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="clear_button_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Color used as default tint for the clear button.
 		</theme_item>
-		<theme_item name="clear_button_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="clear_button_color_pressed" type="Color" default="Color(1, 1, 1, 1)">
 			Color used for the clear button when it's pressed.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
@@ -377,19 +377,19 @@
 		<theme_item name="font" type="Font">
 			Font used for the text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default font color.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [LineEdit].
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color(0, 0, 0, 1)">
 			Font color for selected text (inside the selection rectangle).
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the [LineEdit]'s text.
 		</theme_item>
-		<theme_item name="font_uneditable_color" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
+		<theme_item name="font_uneditable_color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
 			Font color when editing is disabled.
 		</theme_item>
 		<theme_item name="minimum_character_width" type="int" default="4">
@@ -404,7 +404,7 @@
 		<theme_item name="read_only" type="StyleBox">
 			Background used when [LineEdit] is in read-only mode ([member editable] is set to [code]false[/code]).
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
+		<theme_item name="selection_color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 			Color of the selection rectangle.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/LineShape2D.xml
+++ b/doc/classes/LineShape2D.xml
@@ -14,7 +14,7 @@
 		<member name="distance" type="float" setter="set_distance" getter="get_distance" default="0.0">
 			The line's distance from the origin.
 		</member>
-		<member name="normal" type="Vector2" setter="set_normal" getter="get_normal" default="Vector2( 0, 1 )">
+		<member name="normal" type="Vector2" setter="set_normal" getter="get_normal" default="Vector2(0, 1)">
 			The line's normal.
 		</member>
 	</members>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -47,7 +47,7 @@
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="Control.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
 		</member>
-		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[  ]">
+		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[]">
 			Set additional options for BiDi override.
 		</member>
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
@@ -78,16 +78,16 @@
 		<theme_item name="font" type="Font">
 			[Font] of the [LinkButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [LinkButton].
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] used when the [LinkButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [LinkButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [LinkButton] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -56,19 +56,19 @@
 		<theme_item name="font" type="Font">
 			[Font] of the [MenuButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [MenuButton].
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color( 1, 1, 1, 0.3 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color(1, 1, 1, 0.3)">
 			Text [Color] used when the [MenuButton] is disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] used when the [MenuButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [MenuButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -106,7 +106,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="lightmap_size_hint" type="Vector2i" setter="set_lightmap_size_hint" getter="get_lightmap_size_hint" default="Vector2i( 0, 0 )">
+		<member name="lightmap_size_hint" type="Vector2i" setter="set_lightmap_size_hint" getter="get_lightmap_size_hint" default="Vector2i(0, 0)">
 			Sets a hint to be used for lightmap resolution.
 		</member>
 	</members>

--- a/doc/classes/MeshTexture.xml
+++ b/doc/classes/MeshTexture.xml
@@ -14,7 +14,7 @@
 		<member name="base_texture" type="Texture2D" setter="set_base_texture" getter="get_base_texture">
 			Sets the base texture that the Mesh will use to draw.
 		</member>
-		<member name="image_size" type="Vector2" setter="set_image_size" getter="get_image_size" default="Vector2( 0, 0 )">
+		<member name="image_size" type="Vector2" setter="set_image_size" getter="get_image_size" default="Vector2(0, 0)">
 			Sets the size of the image, needed for reference.
 		</member>
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -105,7 +105,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="buffer" type="PackedFloat32Array" setter="set_buffer" getter="get_buffer" default="PackedFloat32Array(  )">
+		<member name="buffer" type="PackedFloat32Array" setter="set_buffer" getter="get_buffer" default="PackedFloat32Array()">
 		</member>
 		<member name="color_array" type="PackedColorArray" setter="_set_color_array" getter="_get_color_array">
 		</member>

--- a/doc/classes/NinePatchRect.xml
+++ b/doc/classes/NinePatchRect.xml
@@ -53,7 +53,7 @@
 		<member name="patch_margin_top" type="int" setter="set_patch_margin" getter="get_patch_margin" default="0">
 			The height of the 9-slice's top row. A margin of 16 means the 9-slice's top corners and side will have a height of 16 pixels. You can set all 4 margin values individually to create panels with non-uniform borders.
 		</member>
-		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2( 0, 0, 0, 0 )">
+		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2(0, 0, 0, 0)">
 			Rectangular region of the texture to sample from. If you're working with an atlas, use this property to define the area the 9-slice should use. All other properties are relative to this one. If the rect is empty, NinePatchRect will use the whole texture.
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -568,7 +568,7 @@
 			</return>
 			<argument index="0" name="method" type="StringName">
 			</argument>
-			<argument index="1" name="args" type="Array" default="[  ]">
+			<argument index="1" name="args" type="Array" default="[]">
 			</argument>
 			<argument index="2" name="parent_first" type="bool" default="false">
 			</argument>

--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -131,7 +131,7 @@
 		<member name="global_transform" type="Transform2D" setter="set_global_transform" getter="get_global_transform">
 			Global [Transform2D].
 		</member>
-		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2( 0, 0 )">
+		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			Position, relative to the node's parent.
 		</member>
 		<member name="rotation" type="float" setter="set_rotation" getter="get_rotation" default="0.0">
@@ -140,7 +140,7 @@
 		<member name="rotation_degrees" type="float" setter="set_rotation_degrees" getter="get_rotation_degrees" default="0.0">
 			Rotation in degrees, relative to the node's parent.
 		</member>
-		<member name="scale" type="Vector2" setter="set_scale" getter="get_scale" default="Vector2( 1, 1 )">
+		<member name="scale" type="Vector2" setter="set_scale" getter="get_scale" default="Vector2(1, 1)">
 			The node's scale. Unscaled value: [code](1, 1)[/code].
 		</member>
 		<member name="skew" type="float" setter="set_skew" getter="get_skew" default="0.0">

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -103,7 +103,7 @@
 			</return>
 			<argument index="0" name="target" type="Vector3">
 			</argument>
-			<argument index="1" name="up" type="Vector3" default="Vector3( 0, 1, 0 )">
+			<argument index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)">
 			</argument>
 			<description>
 				Rotates itself so that the local -Z axis points towards the [code]target[/code] position.
@@ -118,7 +118,7 @@
 			</argument>
 			<argument index="1" name="target" type="Vector3">
 			</argument>
-			<argument index="2" name="up" type="Vector3" default="Vector3( 0, 1, 0 )">
+			<argument index="2" name="up" type="Vector3" default="Vector3(0, 1, 0)">
 			</argument>
 			<description>
 				Moves the node to the specified [code]position[/code], and then rotates itself to point toward the [code]target[/code] as per [method look_at]. Operations take place in global space.
@@ -291,23 +291,23 @@
 		<member name="global_transform" type="Transform3D" setter="set_global_transform" getter="get_global_transform">
 			World3D space (global) [Transform3D] of this node.
 		</member>
-		<member name="position" type="Vector3" setter="set_position" getter="get_position" default="Vector3( 0, 0, 0 )">
+		<member name="position" type="Vector3" setter="set_position" getter="get_position" default="Vector3(0, 0, 0)">
 			Local position or translation of this node relative to the parent. This is equivalent to [code]transform.origin[/code].
 		</member>
 		<member name="rotation" type="Vector3" setter="set_rotation" getter="get_rotation">
 			Rotation part of the local transformation in radians, specified in terms of YXZ-Euler angles in the format (X angle, Y angle, Z angle).
 			[b]Note:[/b] In the mathematical sense, rotation is a matrix and not a vector. The three Euler angles, which are the three independent parameters of the Euler-angle parametrization of the rotation matrix, are stored in a [Vector3] data structure not because the rotation is a vector, but only because [Vector3] exists as a convenient data-structure to store 3 floating-point numbers. Therefore, applying affine operations on the rotation "vector" is not meaningful.
 		</member>
-		<member name="rotation_degrees" type="Vector3" setter="set_rotation_degrees" getter="get_rotation_degrees" default="Vector3( 0, 0, 0 )">
+		<member name="rotation_degrees" type="Vector3" setter="set_rotation_degrees" getter="get_rotation_degrees" default="Vector3(0, 0, 0)">
 			Rotation part of the local transformation in degrees, specified in terms of YXZ-Euler angles in the format (X angle, Y angle, Z angle).
 		</member>
-		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale" default="Vector3( 1, 1, 1 )">
+		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale" default="Vector3(1, 1, 1)">
 			Scale part of the local transformation.
 		</member>
 		<member name="top_level" type="bool" setter="set_as_top_level" getter="is_set_as_top_level" default="false">
 			If [code]true[/code], the node will not inherit its transformations from its parent. Node transformations are only in global space.
 		</member>
-		<member name="transform" type="Transform3D" setter="set_transform" getter="get_transform" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<member name="transform" type="Transform3D" setter="set_transform" getter="get_transform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			Local space [Transform3D] of this node, with respect to the parent node.
 		</member>
 		<member name="visibility_parent" type="NodePath" setter="set_visibility_parent" getter="get_visibility_parent" default="NodePath(&quot;&quot;)">

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -94,7 +94,7 @@
 			</argument>
 			<argument index="1" name="arguments" type="PackedStringArray">
 			</argument>
-			<argument index="2" name="output" type="Array" default="[  ]">
+			<argument index="2" name="output" type="Array" default="[]">
 			</argument>
 			<argument index="3" name="read_stderr" type="bool" default="false">
 			</argument>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -92,7 +92,7 @@
 			</return>
 			<argument index="0" name="signal" type="String">
 			</argument>
-			<argument index="1" name="arguments" type="Array" default="[  ]">
+			<argument index="1" name="arguments" type="Array" default="[]">
 			</argument>
 			<description>
 				Adds a user-defined [code]signal[/code]. Arguments are optional, but can be added as an [Array] of dictionaries, each containing [code]name: String[/code] and [code]type: int[/code] (see [enum Variant.Type]) entries.
@@ -173,7 +173,7 @@
 			</argument>
 			<argument index="1" name="callable" type="Callable">
 			</argument>
-			<argument index="2" name="binds" type="Array" default="[  ]">
+			<argument index="2" name="binds" type="Array" default="[]">
 			</argument>
 			<argument index="3" name="flags" type="int" default="0">
 			</argument>

--- a/doc/classes/Occluder3D.xml
+++ b/doc/classes/Occluder3D.xml
@@ -9,9 +9,9 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="indices" type="PackedInt32Array" setter="set_indices" getter="get_indices" default="PackedInt32Array(  )">
+		<member name="indices" type="PackedInt32Array" setter="set_indices" getter="get_indices" default="PackedInt32Array()">
 		</member>
-		<member name="vertices" type="PackedVector3Array" setter="set_vertices" getter="get_vertices" default="PackedVector3Array(  )">
+		<member name="vertices" type="PackedVector3Array" setter="set_vertices" getter="get_vertices" default="PackedVector3Array()">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/OccluderPolygon2D.xml
+++ b/doc/classes/OccluderPolygon2D.xml
@@ -17,7 +17,7 @@
 		<member name="cull_mode" type="int" setter="set_cull_mode" getter="get_cull_mode" enum="OccluderPolygon2D.CullMode" default="0">
 			The culling mode to use.
 		</member>
-		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array(  )">
+		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array()">
 			A [Vector2] array with the index for polygon's vertices positions.
 			[b]Note:[/b] The returned value is a copy of the underlying array, rather than a reference.
 		</member>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -250,19 +250,19 @@
 		<theme_item name="font" type="Font">
 			[Font] of the [OptionButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [OptionButton].
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Text [Color] used when the [OptionButton] is disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] used when the [OptionButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [OptionButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [OptionButton] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/PackedDataContainer.xml
+++ b/doc/classes/PackedDataContainer.xml
@@ -23,7 +23,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="__data__" type="PackedByteArray" setter="_set_data" getter="_get_data" default="PackedByteArray(  )">
+		<member name="__data__" type="PackedByteArray" setter="_set_data" getter="_get_data" default="PackedByteArray()">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -110,7 +110,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" default="{&quot;conn_count&quot;: 0,&quot;conns&quot;: PackedInt32Array(  ),&quot;editable_instances&quot;: [  ],&quot;names&quot;: PackedStringArray(  ),&quot;node_count&quot;: 0,&quot;node_paths&quot;: [  ],&quot;nodes&quot;: PackedInt32Array(  ),&quot;variants&quot;: [  ],&quot;version&quot;: 2}">
+		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" default="{&quot;conn_count&quot;: 0,&quot;conns&quot;: PackedInt32Array(),&quot;editable_instances&quot;: [],&quot;names&quot;: PackedStringArray(),&quot;node_count&quot;: 0,&quot;node_paths&quot;: [],&quot;nodes&quot;: PackedInt32Array(),&quot;variants&quot;: [],&quot;version&quot;: 2}">
 			A dictionary representation of the scene contents.
 			Available keys include "rnames" and "variants" for resources, "node_count", "nodes", "node_paths" for nodes, "editable_instances" for base scene children overrides, "conn_count" and "conns" for signal connections, and "version" for the format style of the PackedScene.
 		</member>

--- a/doc/classes/ParallaxBackground.xml
+++ b/doc/classes/ParallaxBackground.xml
@@ -12,22 +12,22 @@
 	</methods>
 	<members>
 		<member name="layer" type="int" setter="set_layer" getter="get_layer" override="true" default="-100" />
-		<member name="scroll_base_offset" type="Vector2" setter="set_scroll_base_offset" getter="get_scroll_base_offset" default="Vector2( 0, 0 )">
+		<member name="scroll_base_offset" type="Vector2" setter="set_scroll_base_offset" getter="get_scroll_base_offset" default="Vector2(0, 0)">
 			The base position offset for all [ParallaxLayer] children.
 		</member>
-		<member name="scroll_base_scale" type="Vector2" setter="set_scroll_base_scale" getter="get_scroll_base_scale" default="Vector2( 1, 1 )">
+		<member name="scroll_base_scale" type="Vector2" setter="set_scroll_base_scale" getter="get_scroll_base_scale" default="Vector2(1, 1)">
 			The base motion scale for all [ParallaxLayer] children.
 		</member>
 		<member name="scroll_ignore_camera_zoom" type="bool" setter="set_ignore_camera_zoom" getter="is_ignore_camera_zoom" default="false">
 			If [code]true[/code], elements in [ParallaxLayer] child aren't affected by the zoom level of the camera.
 		</member>
-		<member name="scroll_limit_begin" type="Vector2" setter="set_limit_begin" getter="get_limit_begin" default="Vector2( 0, 0 )">
+		<member name="scroll_limit_begin" type="Vector2" setter="set_limit_begin" getter="get_limit_begin" default="Vector2(0, 0)">
 			Top-left limits for scrolling to begin. If the camera is outside of this limit, the background will stop scrolling. Must be lower than [member scroll_limit_end] to work.
 		</member>
-		<member name="scroll_limit_end" type="Vector2" setter="set_limit_end" getter="get_limit_end" default="Vector2( 0, 0 )">
+		<member name="scroll_limit_end" type="Vector2" setter="set_limit_end" getter="get_limit_end" default="Vector2(0, 0)">
 			Bottom-right limits for scrolling to end. If the camera is outside of this limit, the background will stop scrolling. Must be higher than [member scroll_limit_begin] to work.
 		</member>
-		<member name="scroll_offset" type="Vector2" setter="set_scroll_offset" getter="get_scroll_offset" default="Vector2( 0, 0 )">
+		<member name="scroll_offset" type="Vector2" setter="set_scroll_offset" getter="get_scroll_offset" default="Vector2(0, 0)">
 			The ParallaxBackground's scroll value. Calculated automatically when using a [Camera2D], but can be used to manually manage scrolling when no camera is present.
 		</member>
 	</members>

--- a/doc/classes/ParallaxLayer.xml
+++ b/doc/classes/ParallaxLayer.xml
@@ -13,13 +13,13 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="motion_mirroring" type="Vector2" setter="set_mirroring" getter="get_mirroring" default="Vector2( 0, 0 )">
+		<member name="motion_mirroring" type="Vector2" setter="set_mirroring" getter="get_mirroring" default="Vector2(0, 0)">
 			The ParallaxLayer's [Texture2D] mirroring. Useful for creating an infinite scrolling background. If an axis is set to [code]0[/code], the [Texture2D] will not be mirrored.
 		</member>
-		<member name="motion_offset" type="Vector2" setter="set_motion_offset" getter="get_motion_offset" default="Vector2( 0, 0 )">
+		<member name="motion_offset" type="Vector2" setter="set_motion_offset" getter="get_motion_offset" default="Vector2(0, 0)">
 			The ParallaxLayer's offset relative to the parent ParallaxBackground's [member ParallaxBackground.scroll_offset].
 		</member>
-		<member name="motion_scale" type="Vector2" setter="set_motion_scale" getter="get_motion_scale" default="Vector2( 1, 1 )">
+		<member name="motion_scale" type="Vector2" setter="set_motion_scale" getter="get_motion_scale" default="Vector2(1, 1)">
 			Multiplies the ParallaxLayer's motion. If an axis is set to [code]0[/code], it will not scroll.
 		</member>
 	</members>

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -141,7 +141,7 @@
 		</member>
 		<member name="collision_use_scale" type="bool" setter="set_collision_use_scale" getter="is_collision_using_scale" default="false">
 		</member>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			Each particle's initial color. If the [GPUParticles2D]'s [code]texture[/code] is defined, it will be multiplied by this color. To have particle display color in a [BaseMaterial3D] make sure to set [member BaseMaterial3D.vertex_color_use_as_albedo] to [code]true[/code].
 		</member>
 		<member name="color_ramp" type="Texture2D" setter="set_color_ramp" getter="get_color_ramp">
@@ -156,7 +156,7 @@
 		<member name="damping_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
 			Damping randomness ratio.
 		</member>
-		<member name="direction" type="Vector3" setter="set_direction" getter="get_direction" default="Vector3( 1, 0, 0 )">
+		<member name="direction" type="Vector3" setter="set_direction" getter="get_direction" default="Vector3(1, 0, 0)">
 			Unit vector specifying the particles' emission direction.
 		</member>
 		<member name="emission_box_extents" type="Vector3" setter="set_emission_box_extents" getter="get_emission_box_extents">
@@ -183,7 +183,7 @@
 		<member name="flatness" type="float" setter="set_flatness" getter="get_flatness" default="0.0">
 			Amount of [member spread] along the Y axis.
 		</member>
-		<member name="gravity" type="Vector3" setter="set_gravity" getter="get_gravity" default="Vector3( 0, -9.8, 0 )">
+		<member name="gravity" type="Vector3" setter="set_gravity" getter="get_gravity" default="Vector3(0, -9.8, 0)">
 			Gravity applied to every particle.
 		</member>
 		<member name="hue_variation" type="float" setter="set_param" getter="get_param" default="0.0">

--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -20,7 +20,7 @@
 			</argument>
 			<argument index="1" name="callable" type="Callable">
 			</argument>
-			<argument index="2" name="arguments" type="Array" default="[  ]">
+			<argument index="2" name="arguments" type="Array" default="[]">
 			</argument>
 			<description>
 				Adds a custom monitor with name same as id. You can specify the category of monitor using '/' in id. If there are more than one '/' then default category is used. Default category is "Custom".

--- a/doc/classes/PhysicalBone3D.xml
+++ b/doc/classes/PhysicalBone3D.xml
@@ -20,7 +20,7 @@
 			</return>
 			<argument index="0" name="impulse" type="Vector3">
 			</argument>
-			<argument index="1" name="position" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<description>
 			</description>
@@ -48,7 +48,7 @@
 		<member name="angular_damp" type="float" setter="set_angular_damp" getter="get_angular_damp" default="-1.0">
 			Damps the body's rotation if greater than [code]0[/code].
 		</member>
-		<member name="body_offset" type="Transform3D" setter="set_body_offset" getter="get_body_offset" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<member name="body_offset" type="Transform3D" setter="set_body_offset" getter="get_body_offset" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			Sets the body's transform.
 		</member>
 		<member name="bounce" type="float" setter="set_bounce" getter="get_bounce" default="0.0">
@@ -63,13 +63,13 @@
 		<member name="gravity_scale" type="float" setter="set_gravity_scale" getter="get_gravity_scale" default="1.0">
 			This is multiplied by the global 3D gravity setting found in [b]Project &gt; Project Settings &gt; Physics &gt; 3d[/b] to produce the body's gravity. For example, a value of 1 will be normal gravity, 2 will apply double gravity, and 0.5 will apply half gravity to this object.
 		</member>
-		<member name="joint_offset" type="Transform3D" setter="set_joint_offset" getter="get_joint_offset" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<member name="joint_offset" type="Transform3D" setter="set_joint_offset" getter="get_joint_offset" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			Sets the joint's transform.
 		</member>
 		<member name="joint_rotation" type="Vector3" setter="set_joint_rotation" getter="get_joint_rotation">
 			Sets the joint's rotation in radians.
 		</member>
-		<member name="joint_rotation_degrees" type="Vector3" setter="set_joint_rotation_degrees" getter="get_joint_rotation_degrees" default="Vector3( 0, 0, 0 )">
+		<member name="joint_rotation_degrees" type="Vector3" setter="set_joint_rotation_degrees" getter="get_joint_rotation_degrees" default="Vector3(0, 0, 0)">
 			Sets the joint's rotation in degrees.
 		</member>
 		<member name="joint_type" type="int" setter="set_joint_type" getter="get_joint_type" enum="PhysicalBone3D.JointType" default="0">

--- a/doc/classes/PhysicalSkyMaterial.xml
+++ b/doc/classes/PhysicalSkyMaterial.xml
@@ -19,13 +19,13 @@
 		<member name="exposure" type="float" setter="set_exposure" getter="get_exposure" default="0.1">
 			Sets the exposure of the sky. Higher exposure values make the entire sky brighter.
 		</member>
-		<member name="ground_color" type="Color" setter="set_ground_color" getter="get_ground_color" default="Color( 1, 1, 1, 1 )">
+		<member name="ground_color" type="Color" setter="set_ground_color" getter="get_ground_color" default="Color(1, 1, 1, 1)">
 			Modulates the [Color] on the bottom half of the sky to represent the ground.
 		</member>
 		<member name="mie_coefficient" type="float" setter="set_mie_coefficient" getter="get_mie_coefficient" default="0.005">
 			Controls the strength of mie scattering for the sky. Mie scattering results from light colliding with larger particles (like water). On earth, mie scattering results in a whitish color around the sun and horizon.
 		</member>
-		<member name="mie_color" type="Color" setter="set_mie_color" getter="get_mie_color" default="Color( 0.36, 0.56, 0.82, 1 )">
+		<member name="mie_color" type="Color" setter="set_mie_color" getter="get_mie_color" default="Color(0.36, 0.56, 0.82, 1)">
 			Controls the [Color] of the mie scattering effect. While not physically accurate, this allows for the creation of alien looking planets.
 		</member>
 		<member name="mie_eccentricity" type="float" setter="set_mie_eccentricity" getter="get_mie_eccentricity" default="0.8">
@@ -37,7 +37,7 @@
 		<member name="rayleigh_coefficient" type="float" setter="set_rayleigh_coefficient" getter="get_rayleigh_coefficient" default="2.0">
 			Controls the strength of the Rayleigh scattering. Rayleigh scattering results from light colliding with small particles. It is responsible for the blue color of the sky.
 		</member>
-		<member name="rayleigh_color" type="Color" setter="set_rayleigh_color" getter="get_rayleigh_color" default="Color( 0.056, 0.14, 0.3, 1 )">
+		<member name="rayleigh_color" type="Color" setter="set_rayleigh_color" getter="get_rayleigh_color" default="Color(0.056, 0.14, 0.3, 1)">
 			Controls the [Color] of the Rayleigh scattering. While not physically accurate, this allows for the creation of alien looking planets. For example, setting this to a red [Color] results in a Mars looking atmosphere with a corresponding blue sunset.
 		</member>
 		<member name="sun_disk_scale" type="float" setter="set_sun_disk_scale" getter="get_sun_disk_scale" default="1.0">

--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -24,7 +24,7 @@
 			</return>
 			<argument index="0" name="force" type="Vector2">
 			</argument>
-			<argument index="1" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="1" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Adds a positioned force to the body. Both the force and the offset from the body origin are in global coordinates.
@@ -53,7 +53,7 @@
 			</return>
 			<argument index="0" name="impulse" type="Vector2">
 			</argument>
-			<argument index="1" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="1" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Applies a positioned impulse to the body. An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise). The offset uses the rotation of the global coordinate system, but is centered at the object's origin.

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -12,7 +12,7 @@
 		<method name="add_central_force">
 			<return type="void">
 			</return>
-			<argument index="0" name="force" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="0" name="force" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<description>
 				Adds a constant directional force without affecting rotation.
@@ -24,7 +24,7 @@
 			</return>
 			<argument index="0" name="force" type="Vector3">
 			</argument>
-			<argument index="1" name="position" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<description>
 				Adds a positioned force to the body. Both the force and the offset from the body origin are in global coordinates.
@@ -42,7 +42,7 @@
 		<method name="apply_central_impulse">
 			<return type="void">
 			</return>
-			<argument index="0" name="impulse" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="0" name="impulse" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<description>
 				Applies a single directional impulse without affecting rotation.
@@ -54,7 +54,7 @@
 			</return>
 			<argument index="0" name="impulse" type="Vector3">
 			</argument>
-			<argument index="1" name="position" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<description>
 				Applies a positioned impulse to the body. An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason it should only be used when simulating one-time impacts. The position uses the rotation of the global coordinate system, but is centered at the object's origin.

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -56,7 +56,7 @@
 			</argument>
 			<argument index="1" name="max_results" type="int" default="32">
 			</argument>
-			<argument index="2" name="exclude" type="Array" default="[  ]">
+			<argument index="2" name="exclude" type="Array" default="[]">
 			</argument>
 			<argument index="3" name="collision_layer" type="int" default="2147483647">
 			</argument>
@@ -84,7 +84,7 @@
 			</argument>
 			<argument index="2" name="max_results" type="int" default="32">
 			</argument>
-			<argument index="3" name="exclude" type="Array" default="[  ]">
+			<argument index="3" name="exclude" type="Array" default="[]">
 			</argument>
 			<argument index="4" name="collision_layer" type="int" default="2147483647">
 			</argument>
@@ -102,7 +102,7 @@
 			</argument>
 			<argument index="1" name="to" type="Vector2">
 			</argument>
-			<argument index="2" name="exclude" type="Array" default="[  ]">
+			<argument index="2" name="exclude" type="Array" default="[]">
 			</argument>
 			<argument index="3" name="collision_layer" type="int" default="2147483647">
 			</argument>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -57,7 +57,7 @@
 			</argument>
 			<argument index="1" name="to" type="Vector3">
 			</argument>
-			<argument index="2" name="exclude" type="Array" default="[  ]">
+			<argument index="2" name="exclude" type="Array" default="[]">
 			</argument>
 			<argument index="3" name="collision_mask" type="int" default="2147483647">
 			</argument>

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -16,7 +16,7 @@
 			</argument>
 			<argument index="1" name="shape" type="RID">
 			</argument>
-			<argument index="2" name="transform" type="Transform2D" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
+			<argument index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			</argument>
 			<argument index="3" name="disabled" type="bool" default="false">
 			</argument>
@@ -333,7 +333,7 @@
 			</argument>
 			<argument index="1" name="force" type="Vector2">
 			</argument>
-			<argument index="2" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Adds a positioned force to the applied force and torque. As with [method body_apply_impulse], both the force and the offset from the body origin are in global coordinates. A force differs from an impulse in that, while the two are forces, the impulse clears itself after being applied.
@@ -346,7 +346,7 @@
 			</argument>
 			<argument index="1" name="shape" type="RID">
 			</argument>
-			<argument index="2" name="transform" type="Transform2D" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
+			<argument index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			</argument>
 			<argument index="3" name="disabled" type="bool" default="false">
 			</argument>
@@ -381,7 +381,7 @@
 			</argument>
 			<argument index="1" name="impulse" type="Vector2">
 			</argument>
-			<argument index="2" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Adds a positioned impulse to the applied force and torque. Both the force and the offset from the body origin are in global coordinates.

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -16,7 +16,7 @@
 			</argument>
 			<argument index="1" name="shape" type="RID">
 			</argument>
-			<argument index="2" name="transform" type="Transform3D" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+			<argument index="2" name="transform" type="Transform3D" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			</argument>
 			<argument index="3" name="disabled" type="bool" default="false">
 			</argument>
@@ -325,7 +325,7 @@
 			</argument>
 			<argument index="1" name="force" type="Vector3">
 			</argument>
-			<argument index="2" name="position" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="2" name="position" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<description>
 			</description>
@@ -337,7 +337,7 @@
 			</argument>
 			<argument index="1" name="shape" type="RID">
 			</argument>
-			<argument index="2" name="transform" type="Transform3D" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+			<argument index="2" name="transform" type="Transform3D" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			</argument>
 			<argument index="3" name="disabled" type="bool" default="false">
 			</argument>
@@ -372,7 +372,7 @@
 			</argument>
 			<argument index="1" name="impulse" type="Vector3">
 			</argument>
-			<argument index="2" name="position" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="2" name="position" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<description>
 				Gives the body a push at a [code]position[/code] in the direction of the [code]impulse[/code].

--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -20,13 +20,13 @@
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="2147483647">
 			The physics layer(s) the query will take into account (as a bitmask). See [url=https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
-		<member name="exclude" type="Array" setter="set_exclude" getter="get_exclude" default="[  ]">
+		<member name="exclude" type="Array" setter="set_exclude" getter="get_exclude" default="[]">
 			The list of objects or object [RID]s that will be excluded from collisions.
 		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
 			The collision margin for the shape.
 		</member>
-		<member name="motion" type="Vector2" setter="set_motion" getter="get_motion" default="Vector2( 0, 0 )">
+		<member name="motion" type="Vector2" setter="set_motion" getter="get_motion" default="Vector2(0, 0)">
 			The motion of the shape being queried for.
 		</member>
 		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
@@ -63,7 +63,7 @@
 				[/csharp]
 				[/codeblocks]
 		</member>
-		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
+		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			The queried shape's transform matrix.
 		</member>
 	</members>

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -20,7 +20,7 @@
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="2147483647">
 			The physics layer(s) the query will take into account (as a bitmask). See [url=https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
-		<member name="exclude" type="Array" setter="set_exclude" getter="get_exclude" default="[  ]">
+		<member name="exclude" type="Array" setter="set_exclude" getter="get_exclude" default="[]">
 			The list of objects or object [RID]s that will be excluded from collisions.
 		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
@@ -60,7 +60,7 @@
 				[/csharp]
 				[/codeblocks]
 		</member>
-		<member name="transform" type="Transform3D" setter="set_transform" getter="get_transform" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<member name="transform" type="Transform3D" setter="set_transform" getter="get_transform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			The queried shape's transform matrix.
 		</member>
 	</members>

--- a/doc/classes/PhysicsTestMotionResult2D.xml
+++ b/doc/classes/PhysicsTestMotionResult2D.xml
@@ -17,15 +17,15 @@
 		</member>
 		<member name="collider_shape" type="int" setter="" getter="get_collider_shape" default="0">
 		</member>
-		<member name="collider_velocity" type="Vector2" setter="" getter="get_collider_velocity" default="Vector2( 0, 0 )">
+		<member name="collider_velocity" type="Vector2" setter="" getter="get_collider_velocity" default="Vector2(0, 0)">
 		</member>
-		<member name="collision_normal" type="Vector2" setter="" getter="get_collision_normal" default="Vector2( 0, 0 )">
+		<member name="collision_normal" type="Vector2" setter="" getter="get_collision_normal" default="Vector2(0, 0)">
 		</member>
-		<member name="collision_point" type="Vector2" setter="" getter="get_collision_point" default="Vector2( 0, 0 )">
+		<member name="collision_point" type="Vector2" setter="" getter="get_collision_point" default="Vector2(0, 0)">
 		</member>
-		<member name="motion" type="Vector2" setter="" getter="get_motion" default="Vector2( 0, 0 )">
+		<member name="motion" type="Vector2" setter="" getter="get_motion" default="Vector2(0, 0)">
 		</member>
-		<member name="motion_remainder" type="Vector2" setter="" getter="get_motion_remainder" default="Vector2( 0, 0 )">
+		<member name="motion_remainder" type="Vector2" setter="" getter="get_motion_remainder" default="Vector2(0, 0)">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -204,7 +204,7 @@
 			The distance from the origin to the plane, in the direction of [member normal]. This value is typically non-negative.
 			In the scalar equation of the plane [code]ax + by + cz = d[/code], this is [code]d[/code], while the [code](a, b, c)[/code] coordinates are represented by the [member normal] property.
 		</member>
-		<member name="normal" type="Vector3" setter="" getter="" default="Vector3( 0, 0, 0 )">
+		<member name="normal" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
 			The normal of the plane, which must be normalized.
 			In the scalar equation of the plane [code]ax + by + cz = d[/code], this is the vector [code](a, b, c)[/code], where [code]d[/code] is the [member d] property.
 		</member>
@@ -219,13 +219,13 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="PLANE_YZ" value="Plane( 1, 0, 0, 0 )">
+		<constant name="PLANE_YZ" value="Plane(1, 0, 0, 0)">
 			A plane that extends in the Y and Z axes (normal vector points +X).
 		</constant>
-		<constant name="PLANE_XZ" value="Plane( 0, 1, 0, 0 )">
+		<constant name="PLANE_XZ" value="Plane(0, 1, 0, 0)">
 			A plane that extends in the X and Z axes (normal vector points +Y).
 		</constant>
-		<constant name="PLANE_XY" value="Plane( 0, 0, 1, 0 )">
+		<constant name="PLANE_XY" value="Plane(0, 0, 1, 0)">
 			A plane that extends in the X and Y axes (normal vector points +Z).
 		</constant>
 	</constants>

--- a/doc/classes/PlaneMesh.xml
+++ b/doc/classes/PlaneMesh.xml
@@ -12,7 +12,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2( 2, 2 )">
+		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(2, 2)">
 			Size of the generated plane.
 		</member>
 		<member name="subdivide_depth" type="int" setter="set_subdivide_depth" getter="get_subdivide_depth" default="0">

--- a/doc/classes/PointLight2D.xml
+++ b/doc/classes/PointLight2D.xml
@@ -12,7 +12,7 @@
 		<member name="height" type="float" setter="set_height" getter="get_height" default="0.0">
 			The height of the light. Used with 2D normal mapping.
 		</member>
-		<member name="offset" type="Vector2" setter="set_texture_offset" getter="get_texture_offset" default="Vector2( 0, 0 )">
+		<member name="offset" type="Vector2" setter="set_texture_offset" getter="get_texture_offset" default="Vector2(0, 0)">
 			The offset of the light's [member texture].
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">

--- a/doc/classes/Polygon2D.xml
+++ b/doc/classes/Polygon2D.xml
@@ -88,9 +88,9 @@
 		<member name="antialiased" type="bool" setter="set_antialiased" getter="get_antialiased" default="false">
 			If [code]true[/code], polygon edges will be anti-aliased.
 		</member>
-		<member name="bones" type="Array" setter="_set_bones" getter="_get_bones" default="[  ]">
+		<member name="bones" type="Array" setter="_set_bones" getter="_get_bones" default="[]">
 		</member>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			The polygon's fill color. If [code]texture[/code] is defined, it will be multiplied by this color. It will also be the default color for vertices not set in [code]vertex_colors[/code].
 		</member>
 		<member name="internal_vertex_count" type="int" setter="set_internal_vertex_count" getter="get_internal_vertex_count" default="0">
@@ -101,21 +101,21 @@
 		<member name="invert_enable" type="bool" setter="set_invert" getter="get_invert" default="false">
 			If [code]true[/code], polygon will be inverted, containing the area outside the defined points and extending to the [code]invert_border[/code].
 		</member>
-		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
+		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The offset applied to each vertex.
 		</member>
-		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array(  )">
+		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array()">
 			The polygon's list of vertices. The final point will be connected to the first.
 			[b]Note:[/b] This returns a copy of the [PackedVector2Array] rather than a reference.
 		</member>
-		<member name="polygons" type="Array" setter="set_polygons" getter="get_polygons" default="[  ]">
+		<member name="polygons" type="Array" setter="set_polygons" getter="get_polygons" default="[]">
 		</member>
 		<member name="skeleton" type="NodePath" setter="set_skeleton" getter="get_skeleton" default="NodePath(&quot;&quot;)">
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The polygon's fill texture. Use [code]uv[/code] to set texture coordinates.
 		</member>
-		<member name="texture_offset" type="Vector2" setter="set_texture_offset" getter="get_texture_offset" default="Vector2( 0, 0 )">
+		<member name="texture_offset" type="Vector2" setter="set_texture_offset" getter="get_texture_offset" default="Vector2(0, 0)">
 			Amount to offset the polygon's [code]texture[/code]. If [code](0, 0)[/code] the texture's origin (its top-left corner) will be placed at the polygon's [code]position[/code].
 		</member>
 		<member name="texture_rotation" type="float" setter="set_texture_rotation" getter="get_texture_rotation">
@@ -124,13 +124,13 @@
 		<member name="texture_rotation_degrees" type="float" setter="set_texture_rotation_degrees" getter="get_texture_rotation_degrees" default="0.0">
 			The texture's rotation in degrees.
 		</member>
-		<member name="texture_scale" type="Vector2" setter="set_texture_scale" getter="get_texture_scale" default="Vector2( 1, 1 )">
+		<member name="texture_scale" type="Vector2" setter="set_texture_scale" getter="get_texture_scale" default="Vector2(1, 1)">
 			Amount to multiply the [code]uv[/code] coordinates when using a [code]texture[/code]. Larger values make the texture smaller, and vice versa.
 		</member>
-		<member name="uv" type="PackedVector2Array" setter="set_uv" getter="get_uv" default="PackedVector2Array(  )">
+		<member name="uv" type="PackedVector2Array" setter="set_uv" getter="get_uv" default="PackedVector2Array()">
 			Texture coordinates for each vertex of the polygon. There should be one [code]uv[/code] per polygon vertex. If there are fewer, undefined vertices will use [code](0, 0)[/code].
 		</member>
-		<member name="vertex_colors" type="PackedColorArray" setter="set_vertex_colors" getter="get_vertex_colors" default="PackedColorArray(  )">
+		<member name="vertex_colors" type="PackedColorArray" setter="set_vertex_colors" getter="get_vertex_colors" default="PackedColorArray()">
 			Color for each vertex. Colors are interpolated between vertices, resulting in smooth gradients. There should be one per polygon vertex. If there are fewer, undefined vertices will use [code]color[/code].
 		</member>
 	</members>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -717,22 +717,22 @@
 		<theme_item name="font" type="Font">
 			[Font] used for the menu items.
 		</theme_item>
-		<theme_item name="font_accelerator_color" type="Color" default="Color( 0.7, 0.7, 0.7, 0.8 )">
+		<theme_item name="font_accelerator_color" type="Color" default="Color(0.7, 0.7, 0.7, 0.8)">
 			The text [Color] used for shortcuts and accelerators that show next to the menu item name when defined. See [method get_item_accelerator] for more info on accelerators.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			The default text [Color] for menu items' names.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color( 0.4, 0.4, 0.4, 0.8 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color(0.4, 0.4, 0.4, 0.8)">
 			[Color] used for disabled menu items' text.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			[Color] used for the hovered text.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the menu item.
 		</theme_item>
-		<theme_item name="font_separator_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_separator_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			[Color] used for labeled separators' text. See [method add_separator].
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -30,7 +30,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB( 0, 0, 0, 0, 0, 0 )">
+		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
 		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">

--- a/doc/classes/PrismMesh.xml
+++ b/doc/classes/PrismMesh.xml
@@ -14,7 +14,7 @@
 		<member name="left_to_right" type="float" setter="set_left_to_right" getter="get_left_to_right" default="0.5">
 			Displacement of the upper edge along the X axis. 0.0 positions edge straight above the bottom-left edge.
 		</member>
-		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3( 2, 2, 2 )">
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(2, 2, 2)">
 			Size of the prism.
 		</member>
 		<member name="subdivide_depth" type="int" setter="set_subdivide_depth" getter="get_subdivide_depth" default="0">

--- a/doc/classes/ProceduralSkyMaterial.xml
+++ b/doc/classes/ProceduralSkyMaterial.xml
@@ -13,7 +13,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="ground_bottom_color" type="Color" setter="set_ground_bottom_color" getter="get_ground_bottom_color" default="Color( 0.12, 0.12, 0.13, 1 )">
+		<member name="ground_bottom_color" type="Color" setter="set_ground_bottom_color" getter="get_ground_bottom_color" default="Color(0.12, 0.12, 0.13, 1)">
 			Color of the ground at the bottom. Blends with [member ground_horizon_color].
 		</member>
 		<member name="ground_curve" type="float" setter="set_ground_curve" getter="get_ground_curve" default="0.02">
@@ -22,7 +22,7 @@
 		<member name="ground_energy" type="float" setter="set_ground_energy" getter="get_ground_energy" default="1.0">
 			Amount of energy contribution from the ground.
 		</member>
-		<member name="ground_horizon_color" type="Color" setter="set_ground_horizon_color" getter="get_ground_horizon_color" default="Color( 0.37, 0.33, 0.31, 1 )">
+		<member name="ground_horizon_color" type="Color" setter="set_ground_horizon_color" getter="get_ground_horizon_color" default="Color(0.37, 0.33, 0.31, 1)">
 			Color of the ground at the horizon. Blends with [member ground_bottom_color].
 		</member>
 		<member name="sky_curve" type="float" setter="set_sky_curve" getter="get_sky_curve" default="0.09">
@@ -31,10 +31,10 @@
 		<member name="sky_energy" type="float" setter="set_sky_energy" getter="get_sky_energy" default="1.0">
 			Amount of energy contribution from the sky.
 		</member>
-		<member name="sky_horizon_color" type="Color" setter="set_sky_horizon_color" getter="get_sky_horizon_color" default="Color( 0.55, 0.69, 0.81, 1 )">
+		<member name="sky_horizon_color" type="Color" setter="set_sky_horizon_color" getter="get_sky_horizon_color" default="Color(0.55, 0.69, 0.81, 1)">
 			Color of the sky at the horizon. Blends with [member sky_top_color].
 		</member>
-		<member name="sky_top_color" type="Color" setter="set_sky_top_color" getter="get_sky_top_color" default="Color( 0.35, 0.46, 0.71, 1 )">
+		<member name="sky_top_color" type="Color" setter="set_sky_top_color" getter="get_sky_top_color" default="Color(0.35, 0.46, 0.71, 1)">
 			Color of the sky at the top. Blends with [member sky_horizon_color].
 		</member>
 		<member name="sun_angle_max" type="float" setter="set_sun_angle_max" getter="get_sun_angle_max" default="100.0">

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -29,13 +29,13 @@
 		<theme_item name="font" type="Font">
 			Font used to draw the fill percentage if [member percent_visible] is [code]true[/code].
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			The color of the text.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [ProgressBar].
 		</theme_item>
-		<theme_item name="font_shadow_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_shadow_color" type="Color" default="Color(0, 0, 0, 1)">
 			The color of the text's shadow.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -226,7 +226,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color( 0.14, 0.14, 0.14, 1 )">
+		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color(0.14, 0.14, 0.14, 1)">
 			Background color for the boot splash.
 		</member>
 		<member name="application/boot_splash/fullsize" type="bool" setter="" getter="" default="true">
@@ -461,7 +461,7 @@
 		<member name="debug/settings/visual_script/max_call_stack" type="int" setter="" getter="" default="1024">
 			Maximum call stack in visual scripting, to avoid infinite recursion.
 		</member>
-		<member name="debug/shapes/collision/contact_color" type="Color" setter="" getter="" default="Color( 1, 0.2, 0.1, 0.8 )">
+		<member name="debug/shapes/collision/contact_color" type="Color" setter="" getter="" default="Color(1, 0.2, 0.1, 0.8)">
 			Color of the contact points between collision shapes, visible when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
 		<member name="debug/shapes/collision/draw_2d_outlines" type="bool" setter="" getter="" default="true">
@@ -470,22 +470,22 @@
 		<member name="debug/shapes/collision/max_contacts_displayed" type="int" setter="" getter="" default="10000">
 			Maximum number of contact points between collision shapes to display when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
-		<member name="debug/shapes/collision/shape_color" type="Color" setter="" getter="" default="Color( 0, 0.6, 0.7, 0.42 )">
+		<member name="debug/shapes/collision/shape_color" type="Color" setter="" getter="" default="Color(0, 0.6, 0.7, 0.42)">
 			Color of the collision shapes, visible when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
-		<member name="debug/shapes/navigation/disabled_geometry_color" type="Color" setter="" getter="" default="Color( 1, 0.7, 0.1, 0.4 )">
+		<member name="debug/shapes/navigation/disabled_geometry_color" type="Color" setter="" getter="" default="Color(1, 0.7, 0.1, 0.4)">
 			Color of the disabled navigation geometry, visible when "Visible Navigation" is enabled in the Debug menu.
 		</member>
-		<member name="debug/shapes/navigation/geometry_color" type="Color" setter="" getter="" default="Color( 0.1, 1, 0.7, 0.4 )">
+		<member name="debug/shapes/navigation/geometry_color" type="Color" setter="" getter="" default="Color(0.1, 1, 0.7, 0.4)">
 			Color of the navigation geometry, visible when "Visible Navigation" is enabled in the Debug menu.
 		</member>
 		<member name="display/mouse_cursor/custom_image" type="String" setter="" getter="" default="&quot;&quot;">
 			Custom image for the mouse cursor (limited to 256×256).
 		</member>
-		<member name="display/mouse_cursor/custom_image_hotspot" type="Vector2" setter="" getter="" default="Vector2( 0, 0 )">
+		<member name="display/mouse_cursor/custom_image_hotspot" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
 			Hotspot for the custom mouse cursor image.
 		</member>
-		<member name="display/mouse_cursor/tooltip_position_offset" type="Vector2" setter="" getter="" default="Vector2( 10, 10 )">
+		<member name="display/mouse_cursor/tooltip_position_offset" type="Vector2" setter="" getter="" default="Vector2(10, 10)">
 			Position offset for tooltips, relative to the mouse cursor's hotspot.
 		</member>
 		<member name="display/window/dpi/allow_hidpi" type="bool" setter="" getter="" default="false">
@@ -551,7 +551,7 @@
 			prime-run %command%
 			[/codeblock]
 		</member>
-		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray( &quot;gd&quot;, &quot;gdshader&quot; )">
+		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray(&quot;gd&quot;, &quot;gdshader&quot;)">
 			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.
 		</member>
 		<member name="editor/script/templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
@@ -1222,7 +1222,7 @@
 			[/csharp]
 			[/codeblocks]
 		</member>
-		<member name="physics/2d/default_gravity_vector" type="Vector2" setter="" getter="" default="Vector2( 0, 1 )">
+		<member name="physics/2d/default_gravity_vector" type="Vector2" setter="" getter="" default="Vector2(0, 1)">
 			The default gravity direction in 2D.
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity vector at runtime, use the following code sample:
 			[codeblocks]
@@ -1274,7 +1274,7 @@
 			[/csharp]
 			[/codeblocks]
 		</member>
-		<member name="physics/3d/default_gravity_vector" type="Vector3" setter="" getter="" default="Vector3( 0, -1, 0 )">
+		<member name="physics/3d/default_gravity_vector" type="Vector3" setter="" getter="" default="Vector3(0, -1, 0)">
 			The default gravity direction in 3D.
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity vector at runtime, use the following code sample:
 			[codeblocks]
@@ -1366,7 +1366,7 @@
 		<member name="rendering/driver/threads/thread_model" type="int" setter="" getter="" default="1">
 			Thread model for rendering. Rendering on a thread can vastly improve performance, but synchronizing to the main thread can cause a bit more jitter.
 		</member>
-		<member name="rendering/environment/defaults/default_clear_color" type="Color" setter="" getter="" default="Color( 0.3, 0.3, 0.3, 1 )">
+		<member name="rendering/environment/defaults/default_clear_color" type="Color" setter="" getter="" default="Color(0.3, 0.3, 0.3, 1)">
 			Default background clear color. Overridable per [Viewport] using its [Environment]. See [member Environment.background_mode] and [member Environment.background_color] in particular. To change this default color programmatically, use [method RenderingServer.set_default_clear_color].
 		</member>
 		<member name="rendering/environment/defaults/default_environment" type="String" setter="" getter="" default="&quot;&quot;">

--- a/doc/classes/ProximityGroup3D.xml
+++ b/doc/classes/ProximityGroup3D.xml
@@ -23,7 +23,7 @@
 	<members>
 		<member name="dispatch_mode" type="int" setter="set_dispatch_mode" getter="get_dispatch_mode" enum="ProximityGroup3D.DispatchMode" default="0">
 		</member>
-		<member name="grid_radius" type="Vector3" setter="set_grid_radius" getter="get_grid_radius" default="Vector3( 1, 1, 1 )">
+		<member name="grid_radius" type="Vector3" setter="set_grid_radius" getter="get_grid_radius" default="Vector3(1, 1, 1)">
 		</member>
 		<member name="group_name" type="String" setter="set_group_name" getter="get_group_name" default="&quot;&quot;">
 		</member>

--- a/doc/classes/QuadMesh.xml
+++ b/doc/classes/QuadMesh.xml
@@ -13,7 +13,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2( 1, 1 )">
+		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(1, 1)">
 			Size on the X and Y axes.
 		</member>
 	</members>

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -301,7 +301,7 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="IDENTITY" value="Quaternion( 0, 0, 0, 1 )">
+		<constant name="IDENTITY" value="Quaternion(0, 0, 0, 1)">
 			The identity quaternion, representing no rotation. Equivalent to an identity [Basis] matrix. If a vector is transformed by an identity quaternion, it will not change.
 		</constant>
 	</constants>

--- a/doc/classes/RDPipelineColorBlendState.xml
+++ b/doc/classes/RDPipelineColorBlendState.xml
@@ -9,9 +9,9 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="attachments" type="RDPipelineColorBlendStateAttachment[]" setter="set_attachments" getter="get_attachments" default="[  ]">
+		<member name="attachments" type="RDPipelineColorBlendStateAttachment[]" setter="set_attachments" getter="get_attachments" default="[]">
 		</member>
-		<member name="blend_constant" type="Color" setter="set_blend_constant" getter="get_blend_constant" default="Color( 0, 0, 0, 1 )">
+		<member name="blend_constant" type="Color" setter="set_blend_constant" getter="get_blend_constant" default="Color(0, 0, 0, 1)">
 		</member>
 		<member name="enable_logic_op" type="bool" setter="set_enable_logic_op" getter="get_enable_logic_op" default="false">
 		</member>

--- a/doc/classes/RDPipelineMultisampleState.xml
+++ b/doc/classes/RDPipelineMultisampleState.xml
@@ -19,7 +19,7 @@
 		</member>
 		<member name="sample_count" type="int" setter="set_sample_count" getter="get_sample_count" enum="RenderingDevice.TextureSamples" default="0">
 		</member>
-		<member name="sample_masks" type="int[]" setter="set_sample_masks" getter="get_sample_masks" default="[  ]">
+		<member name="sample_masks" type="int[]" setter="set_sample_masks" getter="get_sample_masks" default="[]">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/RDShaderBytecode.xml
+++ b/doc/classes/RDShaderBytecode.xml
@@ -45,15 +45,15 @@
 		</method>
 	</methods>
 	<members>
-		<member name="bytecode_compute" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray(  )">
+		<member name="bytecode_compute" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray()">
 		</member>
-		<member name="bytecode_fragment" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray(  )">
+		<member name="bytecode_fragment" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray()">
 		</member>
-		<member name="bytecode_tesselation_control" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray(  )">
+		<member name="bytecode_tesselation_control" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray()">
 		</member>
-		<member name="bytecode_tesselation_evaluation" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray(  )">
+		<member name="bytecode_tesselation_evaluation" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray()">
 		</member>
-		<member name="bytecode_vertex" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray(  )">
+		<member name="bytecode_vertex" type="PackedByteArray" setter="set_stage_bytecode" getter="get_stage_bytecode" default="PackedByteArray()">
 		</member>
 		<member name="compile_error_compute" type="String" setter="set_stage_compile_error" getter="get_stage_compile_error" default="&quot;&quot;">
 		</member>

--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -138,7 +138,7 @@
 		<member name="exclude_parent" type="bool" setter="set_exclude_parent_body" getter="get_exclude_parent_body" default="true">
 			If [code]true[/code], the parent node will be excluded from collision detection.
 		</member>
-		<member name="target_position" type="Vector2" setter="set_target_position" getter="get_target_position" default="Vector2( 0, 50 )">
+		<member name="target_position" type="Vector2" setter="set_target_position" getter="get_target_position" default="Vector2(0, 50)">
 			The ray's destination point, relative to the RayCast's [code]position[/code].
 		</member>
 	</members>

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -136,7 +136,7 @@
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
 			The ray's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See [url=https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
-		<member name="debug_shape_custom_color" type="Color" setter="set_debug_shape_custom_color" getter="get_debug_shape_custom_color" default="Color( 0, 0, 0, 1 )">
+		<member name="debug_shape_custom_color" type="Color" setter="set_debug_shape_custom_color" getter="get_debug_shape_custom_color" default="Color(0, 0, 0, 1)">
 			The custom color to use to draw the shape in the editor and at run-time if [b]Visible Collision Shapes[/b] is enabled in the [b]Debug[/b] menu. This color will be highlighted at run-time if the [RayCast3D] is colliding with something.
 			If set to [code]Color(0.0, 0.0, 0.0)[/code] (by default), the color set in [member ProjectSettings.debug/shapes/collision/shape_color] is used.
 		</member>
@@ -149,7 +149,7 @@
 		<member name="exclude_parent" type="bool" setter="set_exclude_parent_body" getter="get_exclude_parent_body" default="true">
 			If [code]true[/code], collisions will be ignored for this RayCast3D's immediate parent.
 		</member>
-		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3( 0, -1, 0 )">
+		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3(0, -1, 0)">
 			The ray's destination point, relative to the RayCast's [code]position[/code].
 		</member>
 	</members>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -214,13 +214,13 @@
 		</method>
 	</methods>
 	<members>
-		<member name="end" type="Vector2" setter="" getter="" default="Vector2( 0, 0 )">
+		<member name="end" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
 			Ending corner. This is calculated as [code]position + size[/code]. Setting this value will change the size.
 		</member>
-		<member name="position" type="Vector2" setter="" getter="" default="Vector2( 0, 0 )">
+		<member name="position" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
 			Beginning corner. Typically has values lower than [member end].
 		</member>
-		<member name="size" type="Vector2" setter="" getter="" default="Vector2( 0, 0 )">
+		<member name="size" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
 			Size from [member position] to [member end]. Typically, all components are positive.
 			If the size is negative, you can use [method abs] to fix it.
 		</member>

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -193,13 +193,13 @@
 		</method>
 	</methods>
 	<members>
-		<member name="end" type="Vector2i" setter="" getter="" default="Vector2i( 0, 0 )">
+		<member name="end" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)">
 			Ending corner. This is calculated as [code]position + size[/code]. Setting this value will change the size.
 		</member>
-		<member name="position" type="Vector2i" setter="" getter="" default="Vector2i( 0, 0 )">
+		<member name="position" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)">
 			Beginning corner. Typically has values lower than [member end].
 		</member>
-		<member name="size" type="Vector2i" setter="" getter="" default="Vector2i( 0, 0 )">
+		<member name="size" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)">
 			Size from [member position] to [member end]. Typically, all components are positive.
 			If the size is negative, you can use [method abs] to fix it.
 		</member>

--- a/doc/classes/RectangleShape2D.xml
+++ b/doc/classes/RectangleShape2D.xml
@@ -13,7 +13,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2( 20, 20 )">
+		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(20, 20)">
 			The rectangle's width and height.
 		</member>
 	</members>

--- a/doc/classes/ReferenceRect.xml
+++ b/doc/classes/ReferenceRect.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color" default="Color( 1, 0, 0, 1 )">
+		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color" default="Color(1, 0, 0, 1)">
 			Sets the border [Color] of the [ReferenceRect].
 		</member>
 		<member name="border_width" type="float" setter="set_border_width" getter="get_border_width" default="1.0">

--- a/doc/classes/ReflectionProbe.xml
+++ b/doc/classes/ReflectionProbe.xml
@@ -13,7 +13,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="ambient_color" type="Color" setter="set_ambient_color" getter="get_ambient_color" default="Color( 0, 0, 0, 1 )">
+		<member name="ambient_color" type="Color" setter="set_ambient_color" getter="get_ambient_color" default="Color(0, 0, 0, 1)">
 		</member>
 		<member name="ambient_color_energy" type="float" setter="set_ambient_color_energy" getter="get_ambient_color_energy" default="1.0">
 		</member>
@@ -28,7 +28,7 @@
 		<member name="enable_shadows" type="bool" setter="set_enable_shadows" getter="are_shadows_enabled" default="false">
 			If [code]true[/code], computes shadows in the reflection probe. This makes the reflection probe slower to render; you may want to disable this if using the [constant UPDATE_ALWAYS] [member update_mode].
 		</member>
-		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3( 1, 1, 1 )">
+		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(1, 1, 1)">
 			The size of the reflection probe. The larger the extents the more space covered by the probe which will lower the perceived resolution. It is best to keep the extents only as large as you need them.
 		</member>
 		<member name="intensity" type="float" setter="set_intensity" getter="get_intensity" default="1.0">
@@ -42,7 +42,7 @@
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="0.0">
 			Sets the max distance away from the probe an object can be before it is culled.
 		</member>
-		<member name="origin_offset" type="Vector3" setter="set_origin_offset" getter="get_origin_offset" default="Vector3( 0, 0, 0 )">
+		<member name="origin_offset" type="Vector3" setter="set_origin_offset" getter="get_origin_offset" default="Vector3(0, 0, 0)">
 			Sets the origin offset to be used when this reflection probe is in box project mode.
 		</member>
 		<member name="update_mode" type="int" setter="set_update_mode" getter="get_update_mode" enum="ReflectionProbe.UpdateMode" default="0">

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -196,15 +196,15 @@
 			</argument>
 			<argument index="4" name="final_depth_action" type="int" enum="RenderingDevice.FinalAction">
 			</argument>
-			<argument index="5" name="clear_color_values" type="PackedColorArray" default="PackedColorArray(  )">
+			<argument index="5" name="clear_color_values" type="PackedColorArray" default="PackedColorArray()">
 			</argument>
 			<argument index="6" name="clear_depth" type="float" default="1.0">
 			</argument>
 			<argument index="7" name="clear_stencil" type="int" default="0">
 			</argument>
-			<argument index="8" name="region" type="Rect2" default="Rect2i( 0, 0, 0, 0 )">
+			<argument index="8" name="region" type="Rect2" default="Rect2i(0, 0, 0, 0)">
 			</argument>
-			<argument index="9" name="storage_textures" type="Array" default="[  ]">
+			<argument index="9" name="storage_textures" type="Array" default="[]">
 			</argument>
 			<description>
 			</description>
@@ -214,7 +214,7 @@
 			</return>
 			<argument index="0" name="screen" type="int" default="0">
 			</argument>
-			<argument index="1" name="clear_color" type="Color" default="Color( 0, 0, 0, 1 )">
+			<argument index="1" name="clear_color" type="Color" default="Color(0, 0, 0, 1)">
 			</argument>
 			<description>
 			</description>
@@ -234,15 +234,15 @@
 			</argument>
 			<argument index="5" name="final_depth_action" type="int" enum="RenderingDevice.FinalAction">
 			</argument>
-			<argument index="6" name="clear_color_values" type="PackedColorArray" default="PackedColorArray(  )">
+			<argument index="6" name="clear_color_values" type="PackedColorArray" default="PackedColorArray()">
 			</argument>
 			<argument index="7" name="clear_depth" type="float" default="1.0">
 			</argument>
 			<argument index="8" name="clear_stencil" type="int" default="0">
 			</argument>
-			<argument index="9" name="region" type="Rect2" default="Rect2i( 0, 0, 0, 0 )">
+			<argument index="9" name="region" type="Rect2" default="Rect2i(0, 0, 0, 0)">
 			</argument>
-			<argument index="10" name="storage_textures" type="RID[]" default="[  ]">
+			<argument index="10" name="storage_textures" type="RID[]" default="[]">
 			</argument>
 			<description>
 			</description>
@@ -316,7 +316,7 @@
 			</return>
 			<argument index="0" name="draw_list" type="int">
 			</argument>
-			<argument index="1" name="rect" type="Rect2" default="Rect2i( 0, 0, 0, 0 )">
+			<argument index="1" name="rect" type="Rect2" default="Rect2i(0, 0, 0, 0)">
 			</argument>
 			<description>
 			</description>
@@ -488,7 +488,7 @@
 			</argument>
 			<argument index="1" name="format" type="int" enum="RenderingDevice.IndexBufferFormat">
 			</argument>
-			<argument index="2" name="data" type="PackedByteArray" default="PackedByteArray(  )">
+			<argument index="2" name="data" type="PackedByteArray" default="PackedByteArray()">
 			</argument>
 			<argument index="3" name="use_restart_indices" type="bool" default="false">
 			</argument>
@@ -606,7 +606,7 @@
 			</return>
 			<argument index="0" name="size_bytes" type="int">
 			</argument>
-			<argument index="1" name="data" type="PackedByteArray" default="PackedByteArray(  )">
+			<argument index="1" name="data" type="PackedByteArray" default="PackedByteArray()">
 			</argument>
 			<argument index="2" name="usage" type="int" default="0">
 			</argument>
@@ -632,7 +632,7 @@
 			</argument>
 			<argument index="1" name="format" type="int" enum="RenderingDevice.DataFormat">
 			</argument>
-			<argument index="2" name="data" type="PackedByteArray" default="PackedByteArray(  )">
+			<argument index="2" name="data" type="PackedByteArray" default="PackedByteArray()">
 			</argument>
 			<description>
 			</description>
@@ -690,7 +690,7 @@
 			</argument>
 			<argument index="1" name="view" type="RDTextureView">
 			</argument>
-			<argument index="2" name="data" type="PackedByteArray[]" default="[  ]">
+			<argument index="2" name="data" type="PackedByteArray[]" default="[]">
 			</argument>
 			<description>
 			</description>
@@ -788,7 +788,7 @@
 			</return>
 			<argument index="0" name="size_bytes" type="int">
 			</argument>
-			<argument index="1" name="data" type="PackedByteArray" default="PackedByteArray(  )">
+			<argument index="1" name="data" type="PackedByteArray" default="PackedByteArray()">
 			</argument>
 			<description>
 			</description>
@@ -818,7 +818,7 @@
 			</return>
 			<argument index="0" name="size_bytes" type="int">
 			</argument>
-			<argument index="1" name="data" type="PackedByteArray" default="PackedByteArray(  )">
+			<argument index="1" name="data" type="PackedByteArray" default="PackedByteArray()">
 			</argument>
 			<argument index="2" name="use_as_storage" type="bool" default="false">
 			</argument>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -620,7 +620,7 @@
 			</argument>
 			<argument index="5" name="reflection_source" type="int" enum="RenderingServer.EnvironmentReflectionSource" default="0">
 			</argument>
-			<argument index="6" name="ao_color" type="Color" default="Color( 0, 0, 0, 1 )">
+			<argument index="6" name="ao_color" type="Color" default="Color(0, 0, 0, 1)">
 			</argument>
 			<description>
 			</description>
@@ -2725,7 +2725,7 @@
 			</return>
 			<argument index="0" name="viewport" type="RID">
 			</argument>
-			<argument index="1" name="rect" type="Rect2" default="Rect2( 0, 0, 0, 0 )">
+			<argument index="1" name="rect" type="Rect2" default="Rect2(0, 0, 0, 0)">
 			</argument>
 			<argument index="2" name="screen" type="int" default="0">
 			</argument>

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -84,7 +84,7 @@
 			</return>
 			<argument index="0" name="path" type="String">
 			</argument>
-			<argument index="1" name="progress" type="Array" default="[  ]">
+			<argument index="1" name="progress" type="Array" default="[]">
 			</argument>
 			<description>
 				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [code]path[/code]. See [enum ThreadLoadStatus] for possible return values.

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -24,7 +24,7 @@
 			</argument>
 			<argument index="2" name="height" type="int" default="0">
 			</argument>
-			<argument index="3" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="4" name="inline_align" type="int" enum="VAlign" default="0">
 			</argument>
@@ -209,13 +209,13 @@
 			</argument>
 			<argument index="2" name="size" type="int">
 			</argument>
-			<argument index="3" name="dropcap_margins" type="Rect2" default="Rect2( 0, 0, 0, 0 )">
+			<argument index="3" name="dropcap_margins" type="Rect2" default="Rect2(0, 0, 0, 0)">
 			</argument>
-			<argument index="4" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="4" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="5" name="outline_size" type="int" default="0">
 			</argument>
-			<argument index="6" name="outline_color" type="Color" default="Color( 0, 0, 0, 0 )">
+			<argument index="6" name="outline_color" type="Color" default="Color(0, 0, 0, 0)">
 			</argument>
 			<description>
 				Adds a [code][dropcap][/code] tag to the tag stack. Drop cap (dropped capital) is a decorative element at the beginning of a paragraph that is larger than the rest of the text.
@@ -450,7 +450,7 @@
 			The label's text in BBCode format. Is not representative of manual modifications to the internal tag stack. Erases changes made by other methods when edited.
 			[b]Note:[/b] It is unadvised to use the [code]+=[/code] operator with [code]bbcode_text[/code] (e.g. [code]bbcode_text += "some string"[/code]) as it replaces the whole text and can cause slowdowns. Use [method append_bbcode] for adding text instead, unless you absolutely need to close a tag that was opened in an earlier method call.
 		</member>
-		<member name="custom_effects" type="Array" setter="set_effects" getter="get_effects" default="[  ]">
+		<member name="custom_effects" type="Array" setter="set_effects" getter="get_effects" default="[]">
 			The currently installed custom effects. This is an array of [RichTextEffect]s.
 			To add a custom effect, it's more convenient to use [method install_effect].
 		</member>
@@ -484,7 +484,7 @@
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="Control.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
 		</member>
-		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[  ]">
+		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[]">
 			Set additional options for BiDi override.
 		</member>
 		<member name="tab_size" type="int" setter="set_tab_size" getter="get_tab_size" default="4">
@@ -612,19 +612,19 @@
 		<theme_item name="bold_italics_font_size" type="int">
 			The font size used for bold italics text.
 		</theme_item>
-		<theme_item name="default_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="default_color" type="Color" default="Color(1, 1, 1, 1)">
 			The default text color.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
 			The background The background used when the [RichTextLabel] is focused.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The default tint of text outline.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color(0, 0, 0, 1)">
 			The color of selected text, used when [member selection_enabled] is [code]true[/code].
 		</theme_item>
-		<theme_item name="font_shadow_color" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="font_shadow_color" type="Color" default="Color(0, 0, 0, 0)">
 			The color of the font's shadow.
 		</theme_item>
 		<theme_item name="italics_font" type="Font">
@@ -654,7 +654,7 @@
 		<theme_item name="outline_size" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color( 0.1, 0.1, 1, 0.8 )">
+		<theme_item name="selection_color" type="Color" default="Color(0.1, 0.1, 1, 0.8)">
 			The color of the selection box.
 		</theme_item>
 		<theme_item name="shadow_as_outline" type="int" default="0">
@@ -666,16 +666,16 @@
 		<theme_item name="shadow_offset_y" type="int" default="1">
 			The vertical offset of the font's shadow.
 		</theme_item>
-		<theme_item name="table_border" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="table_border" type="Color" default="Color(0, 0, 0, 0)">
 			The default cell border color.
 		</theme_item>
-		<theme_item name="table_even_row_bg" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="table_even_row_bg" type="Color" default="Color(0, 0, 0, 0)">
 			The default background color for even rows.
 		</theme_item>
 		<theme_item name="table_hseparation" type="int" default="3">
 			The horizontal separation of elements in a table.
 		</theme_item>
-		<theme_item name="table_odd_row_bg" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="table_odd_row_bg" type="Color" default="Color(0, 0, 0, 0)">
 			The default background color for odd rows.
 		</theme_item>
 		<theme_item name="table_vseparation" type="int" default="3">

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -39,7 +39,7 @@
 			</return>
 			<argument index="0" name="force" type="Vector2">
 			</argument>
-			<argument index="1" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="1" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Adds a positioned force to the body. Both the force and the offset from the body origin are in global coordinates.
@@ -57,7 +57,7 @@
 		<method name="apply_central_impulse">
 			<return type="void">
 			</return>
-			<argument index="0" name="impulse" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="0" name="impulse" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Applies a directional impulse without affecting rotation.
@@ -68,7 +68,7 @@
 			</return>
 			<argument index="0" name="impulse" type="Vector2">
 			</argument>
-			<argument index="1" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="1" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Applies a positioned impulse to the body. An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason it should only be used when simulating one-time impacts (use the "_force" functions otherwise). The position uses the rotation of the global coordinate system, but is centered at the object's origin.
@@ -109,7 +109,7 @@
 		<member name="angular_velocity" type="float" setter="set_angular_velocity" getter="get_angular_velocity" default="0.0">
 			The body's rotational velocity.
 		</member>
-		<member name="applied_force" type="Vector2" setter="set_applied_force" getter="get_applied_force" default="Vector2( 0, 0 )">
+		<member name="applied_force" type="Vector2" setter="set_applied_force" getter="get_applied_force" default="Vector2(0, 0)">
 			The body's total applied force.
 		</member>
 		<member name="applied_torque" type="float" setter="set_applied_torque" getter="get_applied_torque" default="0.0">
@@ -142,7 +142,7 @@
 			Damps the body's [member linear_velocity]. If [code]-1[/code], the body will use the [b]Default Linear Damp[/b] in [b]Project &gt; Project Settings &gt; Physics &gt; 2d[/b].
 			See [member ProjectSettings.physics/2d/default_linear_damp] for more details about damping.
 		</member>
-		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2( 0, 0 )">
+		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2(0, 0)">
 			The body's linear velocity.
 		</member>
 		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="1.0">

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -40,7 +40,7 @@
 			</return>
 			<argument index="0" name="force" type="Vector3">
 			</argument>
-			<argument index="1" name="position" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<description>
 				Adds a constant directional force (i.e. acceleration).
@@ -71,7 +71,7 @@
 			</return>
 			<argument index="0" name="impulse" type="Vector3">
 			</argument>
-			<argument index="1" name="position" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)">
 			</argument>
 			<description>
 				Applies a positioned impulse to the body. An impulse is time independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason it should only be used when simulating one-time impacts. The position uses the rotation of the global coordinate system, but is centered at the object's origin.
@@ -116,7 +116,7 @@
 			Damps RigidBody3D's rotational forces.
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
-		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3( 0, 0, 0 )">
+		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3(0, 0, 0)">
 			RigidBody3D's rotational velocity.
 		</member>
 		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep" default="true">
@@ -143,7 +143,7 @@
 			The body's linear damp. Cannot be less than -1.0. If this value is different from -1.0, any linear damp derived from the world or areas will be overridden.
 			See [member ProjectSettings.physics/3d/default_linear_damp] for more details about damping.
 		</member>
-		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3( 0, 0, 0 )">
+		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3(0, 0, 0)">
 			The body's linear velocity. Can be used sporadically, but [b]don't set this every frame[/b], because physics may run in another thread and runs at a different granularity. Use [method _integrate_forces] as your process loop for precise control of the body state.
 		</member>
 		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="1.0">

--- a/doc/classes/SegmentShape2D.xml
+++ b/doc/classes/SegmentShape2D.xml
@@ -11,10 +11,10 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="a" type="Vector2" setter="set_a" getter="get_a" default="Vector2( 0, 0 )">
+		<member name="a" type="Vector2" setter="set_a" getter="get_a" default="Vector2(0, 0)">
 			The segment's first point position.
 		</member>
-		<member name="b" type="Vector2" setter="set_b" getter="get_b" default="Vector2( 0, 10 )">
+		<member name="b" type="Vector2" setter="set_b" getter="get_b" default="Vector2(0, 10)">
 			The segment's second point position.
 		</member>
 	</members>

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -40,7 +40,7 @@
 			</return>
 			<argument index="0" name="callable" type="Callable">
 			</argument>
-			<argument index="1" name="binds" type="Array" default="[  ]">
+			<argument index="1" name="binds" type="Array" default="[]">
 			</argument>
 			<argument index="2" name="flags" type="int" default="0">
 			</argument>

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -171,7 +171,7 @@
 		<method name="physical_bones_start_simulation">
 			<return type="void">
 			</return>
-			<argument index="0" name="bones" type="StringName[]" default="[  ]">
+			<argument index="0" name="bones" type="StringName[]" default="[]">
 			</argument>
 			<description>
 				Tells the [PhysicalBone3D] nodes in the Skeleton to start simulating and reacting to the physics world.

--- a/doc/classes/SkeletonIK3D.xml
+++ b/doc/classes/SkeletonIK3D.xml
@@ -38,7 +38,7 @@
 	<members>
 		<member name="interpolation" type="float" setter="set_interpolation" getter="get_interpolation" default="1.0">
 		</member>
-		<member name="magnet" type="Vector3" setter="set_magnet_position" getter="get_magnet_position" default="Vector3( 0, 0, 0 )">
+		<member name="magnet" type="Vector3" setter="set_magnet_position" getter="get_magnet_position" default="Vector3(0, 0, 0)">
 		</member>
 		<member name="max_iterations" type="int" setter="set_max_iterations" getter="get_max_iterations" default="10">
 		</member>
@@ -48,7 +48,7 @@
 		</member>
 		<member name="root_bone" type="StringName" setter="set_root_bone" getter="get_root_bone" default="&amp;&quot;&quot;">
 		</member>
-		<member name="target" type="Transform3D" setter="set_target_transform" getter="get_target_transform" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<member name="target" type="Transform3D" setter="set_target_transform" getter="get_target_transform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 		</member>
 		<member name="target_node" type="NodePath" setter="set_target_node" getter="get_target_node" default="NodePath(&quot;&quot;)">
 		</member>

--- a/doc/classes/SkeletonModification2DJiggle.xml
+++ b/doc/classes/SkeletonModification2DJiggle.xml
@@ -208,7 +208,7 @@
 		<member name="damping" type="float" setter="set_damping" getter="get_damping" default="0.75">
 			The default amount of dampening applied to the Jiggle joints, if they are not overriden. Higher values lead to more of the calculated velocity being applied.
 		</member>
-		<member name="gravity" type="Vector2" setter="set_gravity" getter="get_gravity" default="Vector2( 0, 6 )">
+		<member name="gravity" type="Vector2" setter="set_gravity" getter="get_gravity" default="Vector2(0, 6)">
 			The default amount of gravity applied to the Jiggle joints, if they are not overriden.
 		</member>
 		<member name="jiggle_data_chain_length" type="int" setter="set_jiggle_data_chain_length" getter="get_jiggle_data_chain_length" default="0">

--- a/doc/classes/SkeletonModification2DPhysicalBones.xml
+++ b/doc/classes/SkeletonModification2DPhysicalBones.xml
@@ -40,7 +40,7 @@
 		<method name="start_simulation">
 			<return type="void">
 			</return>
-			<argument index="0" name="bones" type="StringName[]" default="[  ]">
+			<argument index="0" name="bones" type="StringName[]" default="[]">
 			</argument>
 			<description>
 				Tell the [PhysicalBone2D] nodes to start simulating and interacting with the physics world.
@@ -50,7 +50,7 @@
 		<method name="stop_simulation">
 			<return type="void">
 			</return>
-			<argument index="0" name="bones" type="StringName[]" default="[  ]">
+			<argument index="0" name="bones" type="StringName[]" default="[]">
 			</argument>
 			<description>
 				Tell the [PhysicalBone2D] nodes to stop simulating and interacting with the physics world.

--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -64,13 +64,13 @@
 		<member name="frame" type="int" setter="set_frame" getter="get_frame" default="0">
 			Current frame to display from sprite sheet. [member hframes] or [member vframes] must be greater than 1.
 		</member>
-		<member name="frame_coords" type="Vector2i" setter="set_frame_coords" getter="get_frame_coords" default="Vector2i( 0, 0 )">
+		<member name="frame_coords" type="Vector2i" setter="set_frame_coords" getter="get_frame_coords" default="Vector2i(0, 0)">
 			Coordinates of the frame to display from sprite sheet. This is as an alias for the [member frame] property. [member hframes] or [member vframes] must be greater than 1.
 		</member>
 		<member name="hframes" type="int" setter="set_hframes" getter="get_hframes" default="1">
 			The number of columns in the sprite sheet.
 		</member>
-		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
+		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
 		</member>
 		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
@@ -79,7 +79,7 @@
 		<member name="region_filter_clip_enabled" type="bool" setter="set_region_filter_clip_enabled" getter="is_region_filter_clip_enabled" default="false">
 			If [code]true[/code], the outermost pixels get blurred out. [member region_enabled] must be [code]true[/code].
 		</member>
-		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2( 0, 0, 0, 0 )">
+		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2(0, 0, 0, 0)">
 			The region of the atlas texture to display. [member region_enabled] must be [code]true[/code].
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">

--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -14,7 +14,7 @@
 		<member name="frame" type="int" setter="set_frame" getter="get_frame" default="0">
 			Current frame to display from sprite sheet. [member hframes] or [member vframes] must be greater than 1.
 		</member>
-		<member name="frame_coords" type="Vector2i" setter="set_frame_coords" getter="get_frame_coords" default="Vector2i( 0, 0 )">
+		<member name="frame_coords" type="Vector2i" setter="set_frame_coords" getter="get_frame_coords" default="Vector2i(0, 0)">
 			Coordinates of the frame to display from sprite sheet. This is as an alias for the [member frame] property. [member hframes] or [member vframes] must be greater than 1.
 		</member>
 		<member name="hframes" type="int" setter="set_hframes" getter="get_hframes" default="1">
@@ -23,7 +23,7 @@
 		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 			If [code]true[/code], texture will be cut from a larger atlas texture. See [member region_rect].
 		</member>
-		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2( 0, 0, 0, 0 )">
+		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2(0, 0, 0, 0)">
 			The region of the atlas texture to display. [member region_enabled] must be [code]true[/code].
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -66,10 +66,10 @@
 		<member name="flip_v" type="bool" setter="set_flip_v" getter="is_flipped_v" default="false">
 			If [code]true[/code], texture is flipped vertically.
 		</member>
-		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color( 1, 1, 1, 1 )">
+		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
 			A color value that gets multiplied on, could be used for mood-coloring or to simulate the color of light.
 		</member>
-		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
+		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
 		</member>
 		<member name="opacity" type="float" setter="set_opacity" getter="get_opacity" default="1.0">

--- a/doc/classes/StaticBody2D.xml
+++ b/doc/classes/StaticBody2D.xml
@@ -18,7 +18,7 @@
 		<member name="constant_angular_velocity" type="float" setter="set_constant_angular_velocity" getter="get_constant_angular_velocity" default="0.0">
 			The body's constant angular velocity. This does not rotate the body (unless [member kinematic_motion] is enabled), but affects other bodies that touch it, as if it were rotating.
 		</member>
-		<member name="constant_linear_velocity" type="Vector2" setter="set_constant_linear_velocity" getter="get_constant_linear_velocity" default="Vector2( 0, 0 )">
+		<member name="constant_linear_velocity" type="Vector2" setter="set_constant_linear_velocity" getter="get_constant_linear_velocity" default="Vector2(0, 0)">
 			The body's constant linear velocity. This does not move the body (unless [member kinematic_motion] is enabled), but affects other bodies that touch it, as if it were moving.
 		</member>
 		<member name="kinematic_motion" type="bool" setter="set_kinematic_motion_enabled" getter="is_kinematic_motion_enabled" default="false">

--- a/doc/classes/StaticBody3D.xml
+++ b/doc/classes/StaticBody3D.xml
@@ -18,10 +18,10 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="constant_angular_velocity" type="Vector3" setter="set_constant_angular_velocity" getter="get_constant_angular_velocity" default="Vector3( 0, 0, 0 )">
+		<member name="constant_angular_velocity" type="Vector3" setter="set_constant_angular_velocity" getter="get_constant_angular_velocity" default="Vector3(0, 0, 0)">
 			The body's constant angular velocity. This does not rotate the body (unless [member kinematic_motion] is enabled), but affects other bodies that touch it, as if it were rotating.
 		</member>
-		<member name="constant_linear_velocity" type="Vector3" setter="set_constant_linear_velocity" getter="get_constant_linear_velocity" default="Vector3( 0, 0, 0 )">
+		<member name="constant_linear_velocity" type="Vector3" setter="set_constant_linear_velocity" getter="get_constant_linear_velocity" default="Vector3(0, 0, 0)">
 			The body's constant linear velocity. This does not move the body (unless [member kinematic_motion] is enabled), but affects other bodies that touch it, as if it were moving.
 		</member>
 		<member name="kinematic_motion" type="bool" setter="set_kinematic_motion_enabled" getter="is_kinematic_motion_enabled" default="false">

--- a/doc/classes/StreamPeerBuffer.xml
+++ b/doc/classes/StreamPeerBuffer.xml
@@ -49,7 +49,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="data_array" type="PackedByteArray" setter="set_data_array" getter="get_data_array" default="PackedByteArray(  )">
+		<member name="data_array" type="PackedByteArray" setter="set_data_array" getter="get_data_array" default="PackedByteArray()">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -156,13 +156,13 @@
 		<member name="anti_aliasing_size" type="int" setter="set_aa_size" getter="get_aa_size" default="1">
 			This changes the size of the faded ring. Higher values can be used to achieve a "blurry" effect.
 		</member>
-		<member name="bg_color" type="Color" setter="set_bg_color" getter="get_bg_color" default="Color( 0.6, 0.6, 0.6, 1 )">
+		<member name="bg_color" type="Color" setter="set_bg_color" getter="get_bg_color" default="Color(0.6, 0.6, 0.6, 1)">
 			The background color of the stylebox.
 		</member>
 		<member name="border_blend" type="bool" setter="set_border_blend" getter="get_border_blend" default="false">
 			If [code]true[/code], the border will fade into the background color.
 		</member>
-		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color" default="Color( 0.8, 0.8, 0.8, 1 )">
+		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color" default="Color(0.8, 0.8, 0.8, 1)">
 			Sets the color of the border.
 		</member>
 		<member name="border_width_bottom" type="int" setter="set_border_width" getter="get_border_width" default="0">
@@ -209,10 +209,10 @@
 		<member name="expand_margin_top" type="float" setter="set_expand_margin" getter="get_expand_margin" default="0.0">
 			Expands the stylebox outside of the control rect on the top edge. Useful in combination with [member border_width_top] to draw a border outside the control rect.
 		</member>
-		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color( 0, 0, 0, 0.6 )">
+		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color(0, 0, 0, 0.6)">
 			The color of the shadow. This has no effect if [member shadow_size] is lower than 1.
 		</member>
-		<member name="shadow_offset" type="Vector2" setter="set_shadow_offset" getter="get_shadow_offset" default="Vector2( 0, 0 )">
+		<member name="shadow_offset" type="Vector2" setter="set_shadow_offset" getter="get_shadow_offset" default="Vector2(0, 0)">
 			The shadow offset in pixels. Adjusts the position of the shadow relatively to the stylebox.
 		</member>
 		<member name="shadow_size" type="int" setter="set_shadow_size" getter="get_shadow_size" default="0">

--- a/doc/classes/StyleBoxLine.xml
+++ b/doc/classes/StyleBoxLine.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 0, 0, 0, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(0, 0, 0, 1)">
 			The line's color.
 		</member>
 		<member name="grow_begin" type="float" setter="set_grow_begin" getter="get_grow_begin" default="1.0">

--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -116,10 +116,10 @@
 			A higher value means more of the source texture is considered to be part of the top border of the 3×3 box.
 			This is also the value used as fallback for [member StyleBox.content_margin_top] if it is negative.
 		</member>
-		<member name="modulate_color" type="Color" setter="set_modulate" getter="get_modulate" default="Color( 1, 1, 1, 1 )">
+		<member name="modulate_color" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
 			Modulates the color of the texture when this style box is drawn.
 		</member>
-		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2( 0, 0, 0, 0 )">
+		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2(0, 0, 0, 0)">
 			Species a sub-region of the texture to use.
 			This is equivalent to first wrapping the texture in an [AtlasTexture] with the same region.
 		</member>

--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -25,10 +25,10 @@
 		<member name="render_target_update_mode" type="int" setter="set_update_mode" getter="get_update_mode" enum="SubViewport.UpdateMode" default="2">
 			The update mode when the sub-viewport is used as a render target.
 		</member>
-		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i( 512, 512 )">
+		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(512, 512)">
 			The width and height of the sub-viewport.
 		</member>
-		<member name="size_2d_override" type="Vector2i" setter="set_size_2d_override" getter="get_size_2d_override" default="Vector2i( 0, 0 )">
+		<member name="size_2d_override" type="Vector2i" setter="set_size_2d_override" getter="get_size_2d_override" default="Vector2i(0, 0)">
 			The 2D size override of the sub-viewport. If either the width or height is [code]0[/code], the override is disabled.
 		</member>
 		<member name="size_2d_override_stretch" type="bool" setter="set_size_2d_override_stretch" getter="is_size_2d_override_stretch_enabled" default="false">

--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -45,15 +45,15 @@
 			</return>
 			<argument index="0" name="vertices" type="PackedVector3Array">
 			</argument>
-			<argument index="1" name="uvs" type="PackedVector2Array" default="PackedVector2Array(  )">
+			<argument index="1" name="uvs" type="PackedVector2Array" default="PackedVector2Array()">
 			</argument>
-			<argument index="2" name="colors" type="PackedColorArray" default="PackedColorArray(  )">
+			<argument index="2" name="colors" type="PackedColorArray" default="PackedColorArray()">
 			</argument>
-			<argument index="3" name="uv2s" type="PackedVector2Array" default="PackedVector2Array(  )">
+			<argument index="3" name="uv2s" type="PackedVector2Array" default="PackedVector2Array()">
 			</argument>
-			<argument index="4" name="normals" type="PackedVector3Array" default="PackedVector3Array(  )">
+			<argument index="4" name="normals" type="PackedVector3Array" default="PackedVector3Array()">
 			</argument>
-			<argument index="5" name="tangents" type="Array" default="[  ]">
+			<argument index="5" name="tangents" type="Array" default="[]">
 			</argument>
 			<description>
 				Inserts a triangle fan made of array data into [Mesh] being constructed.

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -198,19 +198,19 @@
 		<theme_item name="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Font color of disabled tabs.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the tab name.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Font color of the currently selected tab.
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the tab names.
 		</theme_item>
-		<theme_item name="font_unselected_color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
+		<theme_item name="font_unselected_color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
 			Font color of the other, unselected tabs.
 		</theme_item>
 		<theme_item name="icon_separation" type="int" default="4">

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -362,19 +362,19 @@
 		<theme_item name="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Font color of disabled tabs.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the tab name.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Font color of the currently selected tab.
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the tab names.
 		</theme_item>
-		<theme_item name="font_unselected_color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
+		<theme_item name="font_unselected_color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
 			Font color of the other, unselected tabs.
 		</theme_item>
 		<theme_item name="hseparation" type="int" default="4">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -692,7 +692,7 @@
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="Control.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
 		</member>
-		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[  ]">
+		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" default="[]">
 			Set additional options for BiDi override.
 		</member>
 		<member name="syntax_highlighter" type="SyntaxHighlighter" setter="set_syntax_highlighter" getter="get_syntax_highlighter">
@@ -881,16 +881,16 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="background_color" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="background_color" type="Color" default="Color(0, 0, 0, 0)">
 			Sets the background [Color] of this [TextEdit].
 		</theme_item>
-		<theme_item name="brace_mismatch_color" type="Color" default="Color( 1, 0.2, 0.2, 1 )">
+		<theme_item name="brace_mismatch_color" type="Color" default="Color(1, 0.2, 0.2, 1)">
 		</theme_item>
-		<theme_item name="caret_background_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="caret_background_color" type="Color" default="Color(0, 0, 0, 1)">
 		</theme_item>
-		<theme_item name="caret_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="caret_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 		</theme_item>
-		<theme_item name="current_line_color" type="Color" default="Color( 0.25, 0.25, 0.26, 0.8 )">
+		<theme_item name="current_line_color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">
 			Sets the [Color] of the breakpoints. [member breakpoint_gutter] has to be enabled.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
@@ -898,15 +898,15 @@
 		<theme_item name="font" type="Font">
 			Sets the default [Font].
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Sets the font [Color].
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [TextEdit].
 		</theme_item>
-		<theme_item name="font_readonly_color" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
+		<theme_item name="font_readonly_color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color(0, 0, 0, 1)">
 			Sets the [Color] of the selected text. [member override_selected_font_color] has to be enabled.
 		</theme_item>
 		<theme_item name="font_size" type="int">
@@ -924,7 +924,7 @@
 		<theme_item name="read_only" type="StyleBox">
 			Sets the [StyleBox] of this [TextEdit] when [member readonly] is enabled.
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
+		<theme_item name="selection_color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 			Sets the highlight [Color] of text selections.
 		</theme_item>
 		<theme_item name="space" type="Texture2D">
@@ -933,7 +933,7 @@
 		<theme_item name="tab" type="Texture2D">
 			Sets a custom [Texture2D] for tab text characters.
 		</theme_item>
-		<theme_item name="word_highlighted_color" type="Color" default="Color( 0.8, 0.9, 0.9, 0.15 )">
+		<theme_item name="word_highlighted_color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
 			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/TextLine.xml
+++ b/doc/classes/TextLine.xml
@@ -56,7 +56,7 @@
 			</argument>
 			<argument index="1" name="pos" type="Vector2">
 			</argument>
-			<argument index="2" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="2" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
@@ -71,7 +71,7 @@
 			</argument>
 			<argument index="2" name="outline_size" type="int" default="1">
 			</argument>
-			<argument index="3" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -63,9 +63,9 @@
 			</argument>
 			<argument index="1" name="pos" type="Vector2">
 			</argument>
-			<argument index="2" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="2" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
-			<argument index="3" name="dc_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="dc_color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw all lines of the text and drop cap into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
@@ -78,7 +78,7 @@
 			</argument>
 			<argument index="1" name="pos" type="Vector2">
 			</argument>
-			<argument index="2" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="2" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw drop cap into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
@@ -93,7 +93,7 @@
 			</argument>
 			<argument index="2" name="outline_size" type="int" default="1">
 			</argument>
-			<argument index="3" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw drop cap outline into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
@@ -108,7 +108,7 @@
 			</argument>
 			<argument index="2" name="line" type="int">
 			</argument>
-			<argument index="3" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw single line of text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
@@ -125,7 +125,7 @@
 			</argument>
 			<argument index="3" name="outline_size" type="int" default="1">
 			</argument>
-			<argument index="4" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="4" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw outline of the single line of text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
@@ -140,9 +140,9 @@
 			</argument>
 			<argument index="2" name="outline_size" type="int" default="1">
 			</argument>
-			<argument index="3" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
-			<argument index="4" name="dc_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="4" name="dc_color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw outlines of all lines of the text and drop cap into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
@@ -344,7 +344,7 @@
 			</argument>
 			<argument index="2" name="size" type="int">
 			</argument>
-			<argument index="3" name="dropcap_margins" type="Rect2" default="Rect2( 0, 0, 0, 0 )">
+			<argument index="3" name="dropcap_margins" type="Rect2" default="Rect2(0, 0, 0, 0)">
 			</argument>
 			<argument index="4" name="opentype_features" type="Dictionary" default="{
 }">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -149,7 +149,7 @@
 			</argument>
 			<argument index="4" name="index" type="int">
 			</argument>
-			<argument index="5" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="5" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draws single glyph into a canvas item at the position, using [code]font[/code] at the size [code]size[/code].
@@ -171,7 +171,7 @@
 			</argument>
 			<argument index="5" name="index" type="int">
 			</argument>
-			<argument index="6" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="6" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draws single glyph outline of size [code]outline_size[/code] into a canvas item at the position, using [code]font[/code] at the size [code]size[/code].
@@ -788,7 +788,7 @@
 			</argument>
 			<argument index="4" name="clip_r" type="float" default="-1">
 			</argument>
-			<argument index="5" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="5" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw shaped text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
@@ -809,7 +809,7 @@
 			</argument>
 			<argument index="5" name="outline_size" type="int" default="1">
 			</argument>
-			<argument index="6" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="6" name="color" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
 				Draw the outline of the shaped text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -19,7 +19,7 @@
 			</argument>
 			<argument index="1" name="position" type="Vector2">
 			</argument>
-			<argument index="2" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="2" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="3" name="transpose" type="bool" default="false">
 			</argument>
@@ -36,7 +36,7 @@
 			</argument>
 			<argument index="2" name="tile" type="bool">
 			</argument>
-			<argument index="3" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="4" name="transpose" type="bool" default="false">
 			</argument>
@@ -53,7 +53,7 @@
 			</argument>
 			<argument index="2" name="src_rect" type="Rect2">
 			</argument>
-			<argument index="3" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<argument index="4" name="transpose" type="bool" default="false">
 			</argument>

--- a/doc/classes/TextureProgressBar.xml
+++ b/doc/classes/TextureProgressBar.xml
@@ -36,7 +36,7 @@
 		<member name="nine_patch_stretch" type="bool" setter="set_nine_patch_stretch" getter="get_nine_patch_stretch" default="false">
 			If [code]true[/code], Godot treats the bar's textures like in [NinePatchRect]. Use the [code]stretch_margin_*[/code] properties like [member stretch_margin_bottom] to set up the nine patch's 3×3 grid. When using a radial [member fill_mode], this setting will enable stretching.
 		</member>
-		<member name="radial_center_offset" type="Vector2" setter="set_radial_center_offset" getter="get_radial_center_offset" default="Vector2( 0, 0 )">
+		<member name="radial_center_offset" type="Vector2" setter="set_radial_center_offset" getter="get_radial_center_offset" default="Vector2(0, 0)">
 			Offsets [member texture_progress] if [member fill_mode] is [constant FILL_CLOCKWISE] or [constant FILL_COUNTER_CLOCKWISE].
 		</member>
 		<member name="radial_fill_degrees" type="float" setter="set_fill_degrees" getter="get_fill_degrees" default="360.0">
@@ -68,13 +68,13 @@
 		<member name="texture_under" type="Texture2D" setter="set_under_texture" getter="get_under_texture">
 			[Texture2D] that draws under the progress bar. The bar's background.
 		</member>
-		<member name="tint_over" type="Color" setter="set_tint_over" getter="get_tint_over" default="Color( 1, 1, 1, 1 )">
+		<member name="tint_over" type="Color" setter="set_tint_over" getter="get_tint_over" default="Color(1, 1, 1, 1)">
 			Multiplies the color of the bar's [code]texture_over[/code] texture. The effect is similar to [member CanvasItem.modulate], except it only affects this specific texture instead of the entire node.
 		</member>
-		<member name="tint_progress" type="Color" setter="set_tint_progress" getter="get_tint_progress" default="Color( 1, 1, 1, 1 )">
+		<member name="tint_progress" type="Color" setter="set_tint_progress" getter="get_tint_progress" default="Color(1, 1, 1, 1)">
 			Multiplies the color of the bar's [code]texture_progress[/code] texture.
 		</member>
-		<member name="tint_under" type="Color" setter="set_tint_under" getter="get_tint_under" default="Color( 1, 1, 1, 1 )">
+		<member name="tint_under" type="Color" setter="set_tint_under" getter="get_tint_under" default="Color(1, 1, 1, 1)">
 			Multiplies the color of the bar's [code]texture_under[/code] texture.
 		</member>
 	</members>

--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -219,13 +219,13 @@
 		</member>
 		<member name="flip_v" type="bool" setter="set_flip_v" getter="get_flip_v" default="false">
 		</member>
-		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color( 1, 1, 1, 1 )">
+		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
 		</member>
 		<member name="probability" type="float" setter="set_probability" getter="get_probability" default="1.0">
 		</member>
 		<member name="terrain_set" type="int" setter="set_terrain_set" getter="get_terrain_set" default="-1">
 		</member>
-		<member name="texture_offset" type="Vector2i" setter="set_texture_offset" getter="get_texture_offset" default="Vector2i( 0, 0 )">
+		<member name="texture_offset" type="Vector2i" setter="set_texture_offset" getter="get_texture_offset" default="Vector2i(0, 0)">
 		</member>
 		<member name="transpose" type="bool" setter="set_transpose" getter="get_transpose" default="false">
 		</member>

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -103,7 +103,7 @@
 			</argument>
 			<argument index="1" name="source_id" type="int" default="-1">
 			</argument>
-			<argument index="2" name="atlas_coords" type="Vector2i" default="Vector2i( -1, -1 )">
+			<argument index="2" name="atlas_coords" type="Vector2i" default="Vector2i(-1, -1)">
 			</argument>
 			<argument index="3" name="alternative_tile" type="int" default="-1">
 			</argument>

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -287,9 +287,9 @@
 		</member>
 		<member name="tile_shape" type="int" setter="set_tile_shape" getter="get_tile_shape" enum="TileSet.TileShape" default="0">
 		</member>
-		<member name="tile_size" type="Vector2i" setter="set_tile_size" getter="get_tile_size" default="Vector2i( 16, 16 )">
+		<member name="tile_size" type="Vector2i" setter="set_tile_size" getter="get_tile_size" default="Vector2i(16, 16)">
 		</member>
-		<member name="tile_skew" type="Vector2" setter="set_tile_skew" getter="get_tile_skew" default="Vector2( 0, 0 )">
+		<member name="tile_skew" type="Vector2" setter="set_tile_skew" getter="get_tile_skew" default="Vector2(0, 0)">
 		</member>
 		<member name="uv_clipping" type="bool" setter="set_uv_clipping" getter="is_uv_clipping" default="false">
 		</member>

--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -12,9 +12,9 @@
 			</return>
 			<argument index="0" name="atlas_coords" type="Vector2i">
 			</argument>
-			<argument index="1" name="new_atlas_coords" type="Vector2i" default="Vector2i( -1, -1 )">
+			<argument index="1" name="new_atlas_coords" type="Vector2i" default="Vector2i(-1, -1)">
 			</argument>
-			<argument index="2" name="new_size" type="Vector2i" default="Vector2i( -1, -1 )">
+			<argument index="2" name="new_size" type="Vector2i" default="Vector2i(-1, -1)">
 			</argument>
 			<description>
 			</description>
@@ -40,7 +40,7 @@
 			</return>
 			<argument index="0" name="atlas_coords" type="Vector2i">
 			</argument>
-			<argument index="1" name="size" type="Vector2i" default="Vector2i( 1, 1 )">
+			<argument index="1" name="size" type="Vector2i" default="Vector2i(1, 1)">
 			</argument>
 			<description>
 			</description>
@@ -154,9 +154,9 @@
 			</return>
 			<argument index="0" name="atlas_coords" type="Vector2i">
 			</argument>
-			<argument index="1" name="new_atlas_coords" type="Vector2i" default="Vector2i( -1, -1 )">
+			<argument index="1" name="new_atlas_coords" type="Vector2i" default="Vector2i(-1, -1)">
 			</argument>
-			<argument index="2" name="new_size" type="Vector2i" default="Vector2i( -1, -1 )">
+			<argument index="2" name="new_size" type="Vector2i" default="Vector2i(-1, -1)">
 			</argument>
 			<description>
 			</description>
@@ -193,13 +193,13 @@
 		</method>
 	</methods>
 	<members>
-		<member name="margins" type="Vector2i" setter="set_margins" getter="get_margins" default="Vector2i( 0, 0 )">
+		<member name="margins" type="Vector2i" setter="set_margins" getter="get_margins" default="Vector2i(0, 0)">
 		</member>
-		<member name="separation" type="Vector2i" setter="set_separation" getter="get_separation" default="Vector2i( 0, 0 )">
+		<member name="separation" type="Vector2i" setter="set_separation" getter="get_separation" default="Vector2i(0, 0)">
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 		</member>
-		<member name="tile_size" type="Vector2i" setter="set_texture_region_size" getter="get_texture_region_size" default="Vector2i( 16, 16 )">
+		<member name="tile_size" type="Vector2i" setter="set_texture_region_size" getter="get_texture_region_size" default="Vector2i(16, 16)">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -132,7 +132,7 @@
 		<method name="looking_at" qualifiers="const">
 			<return type="Transform2D">
 			</return>
-			<argument index="0" name="target" type="Vector2" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
+			<argument index="0" name="target" type="Vector2" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			</argument>
 			<description>
 				Returns a copy of the transform rotated such that it's rotation on the X-axis points towards the [code]target[/code] position.
@@ -241,24 +241,24 @@
 		</method>
 	</methods>
 	<members>
-		<member name="origin" type="Vector2" setter="" getter="" default="Vector2( 0, 0 )">
+		<member name="origin" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
 			The origin vector (column 2, the third column). Equivalent to array index [code]2[/code]. The origin vector represents translation.
 		</member>
-		<member name="x" type="Vector2" setter="" getter="" default="Vector2( 1, 0 )">
+		<member name="x" type="Vector2" setter="" getter="" default="Vector2(1, 0)">
 			The basis matrix's X vector (column 0). Equivalent to array index [code]0[/code].
 		</member>
-		<member name="y" type="Vector2" setter="" getter="" default="Vector2( 0, 1 )">
+		<member name="y" type="Vector2" setter="" getter="" default="Vector2(0, 1)">
 			The basis matrix's Y vector (column 1). Equivalent to array index [code]1[/code].
 		</member>
 	</members>
 	<constants>
-		<constant name="IDENTITY" value="Transform2D( 1, 0, 0, 1, 0, 0 )">
+		<constant name="IDENTITY" value="Transform2D(1, 0, 0, 1, 0, 0)">
 			The identity [Transform2D] with no translation, rotation or scaling applied. When applied to other data structures, [constant IDENTITY] performs no transformation.
 		</constant>
-		<constant name="FLIP_X" value="Transform2D( -1, 0, 0, 1, 0, 0 )">
+		<constant name="FLIP_X" value="Transform2D(-1, 0, 0, 1, 0, 0)">
 			The [Transform2D] that will flip something along the X axis.
 		</constant>
-		<constant name="FLIP_Y" value="Transform2D( 1, 0, 0, -1, 0, 0 )">
+		<constant name="FLIP_Y" value="Transform2D(1, 0, 0, -1, 0, 0)">
 			The [Transform2D] that will flip something along the Y axis.
 		</constant>
 	</constants>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -97,7 +97,7 @@
 			</return>
 			<argument index="0" name="target" type="Vector3">
 			</argument>
-			<argument index="1" name="up" type="Vector3" default="Vector3( 0, 1, 0 )">
+			<argument index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)">
 			</argument>
 			<description>
 				Returns a copy of the transform rotated such that its -Z axis points towards the [code]target[/code] position.
@@ -192,24 +192,24 @@
 		</method>
 	</methods>
 	<members>
-		<member name="basis" type="Basis" setter="" getter="" default="Basis( 1, 0, 0, 0, 1, 0, 0, 0, 1 )">
+		<member name="basis" type="Basis" setter="" getter="" default="Basis(1, 0, 0, 0, 1, 0, 0, 0, 1)">
 			The basis is a matrix containing 3 [Vector3] as its columns: X axis, Y axis, and Z axis. These vectors can be interpreted as the basis vectors of local coordinate system traveling with the object.
 		</member>
-		<member name="origin" type="Vector3" setter="" getter="" default="Vector3( 0, 0, 0 )">
+		<member name="origin" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
 			The translation offset of the transform (column 3, the fourth column). Equivalent to array index [code]3[/code].
 		</member>
 	</members>
 	<constants>
-		<constant name="IDENTITY" value="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<constant name="IDENTITY" value="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			[Transform3D] with no translation, rotation or scaling applied. When applied to other data structures, [constant IDENTITY] performs no transformation.
 		</constant>
-		<constant name="FLIP_X" value="Transform3D( -1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<constant name="FLIP_X" value="Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			[Transform3D] with mirroring applied perpendicular to the YZ plane.
 		</constant>
-		<constant name="FLIP_Y" value="Transform3D( 1, 0, 0, 0, -1, 0, 0, 0, 1, 0, 0, 0 )">
+		<constant name="FLIP_Y" value="Transform3D(1, 0, 0, 0, -1, 0, 0, 0, 1, 0, 0, 0)">
 			[Transform3D] with mirroring applied perpendicular to the XZ plane.
 		</constant>
-		<constant name="FLIP_Z" value="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0 )">
+		<constant name="FLIP_Z" value="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0)">
 			[Transform3D] with mirroring applied perpendicular to the XY plane.
 		</constant>
 	</constants>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -533,7 +533,7 @@
 		<theme_item name="checked" type="Texture2D">
 			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is checked.
 		</theme_item>
-		<theme_item name="children_hl_line_color" type="Color" default="Color( 0.27, 0.27, 0.27, 1 )">
+		<theme_item name="children_hl_line_color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
 			The [Color] of the relationship lines between the selected [TreeItem] and its children.
 		</theme_item>
 		<theme_item name="children_hl_line_width" type="int" default="1">
@@ -548,7 +548,7 @@
 		<theme_item name="custom_button" type="StyleBox">
 			Default [StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell.
 		</theme_item>
-		<theme_item name="custom_button_font_highlight" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="custom_button_font_highlight" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
 		</theme_item>
 		<theme_item name="custom_button_hover" type="StyleBox">
@@ -563,25 +563,25 @@
 		<theme_item name="draw_relationship_lines" type="int" default="0">
 			Draws the relationship lines if not zero, this acts as a boolean. Relationship lines are drawn at the start of child items to show hierarchy.
 		</theme_item>
-		<theme_item name="drop_position_color" type="Color" default="Color( 1, 0.3, 0.2, 1 )">
+		<theme_item name="drop_position_color" type="Color" default="Color(1, 0.3, 0.2, 1)">
 			[Color] used to draw possible drop locations. See [enum DropModeFlags] constants for further description of drop locations.
 		</theme_item>
 		<theme_item name="font" type="Font">
 			[Font] of the item's text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
+		<theme_item name="font_color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
 			Default text [Color] of the item.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the item.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the item is selected.
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the item's text.
 		</theme_item>
-		<theme_item name="guide_color" type="Color" default="Color( 0, 0, 0, 0.1 )">
+		<theme_item name="guide_color" type="Color" default="Color(0, 0, 0, 0.1)">
 			[Color] of the guideline.
 		</theme_item>
 		<theme_item name="hseparation" type="int" default="4">
@@ -593,7 +593,7 @@
 		<theme_item name="outline_size" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="parent_hl_line_color" type="Color" default="Color( 0.27, 0.27, 0.27, 1 )">
+		<theme_item name="parent_hl_line_color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
 			The [Color] of the relationship lines between the selected [TreeItem] and its parents.
 		</theme_item>
 		<theme_item name="parent_hl_line_margin" type="int" default="0">
@@ -602,7 +602,7 @@
 		<theme_item name="parent_hl_line_width" type="int" default="1">
 			The width of the relationship lines between the selected [TreeItem] and its parents.
 		</theme_item>
-		<theme_item name="relationship_line_color" type="Color" default="Color( 0.27, 0.27, 0.27, 1 )">
+		<theme_item name="relationship_line_color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
 			The default [Color] of the relationship lines.
 		</theme_item>
 		<theme_item name="relationship_line_width" type="int" default="1">
@@ -623,7 +623,7 @@
 		<theme_item name="selected_focus" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is being focused.
 		</theme_item>
-		<theme_item name="title_button_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="title_button_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the title button.
 		</theme_item>
 		<theme_item name="title_button_font" type="Font">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -513,25 +513,25 @@
 		<constant name="AXIS_Y" value="1">
 			Enumerated value for the Y axis.
 		</constant>
-		<constant name="ZERO" value="Vector2( 0, 0 )">
+		<constant name="ZERO" value="Vector2(0, 0)">
 			Zero vector, a vector with all components set to [code]0[/code].
 		</constant>
-		<constant name="ONE" value="Vector2( 1, 1 )">
+		<constant name="ONE" value="Vector2(1, 1)">
 			One vector, a vector with all components set to [code]1[/code].
 		</constant>
-		<constant name="INF" value="Vector2( inf, inf )">
+		<constant name="INF" value="Vector2(inf, inf)">
 			Infinity vector, a vector with all components set to [constant @GDScript.INF].
 		</constant>
-		<constant name="LEFT" value="Vector2( -1, 0 )">
+		<constant name="LEFT" value="Vector2(-1, 0)">
 			Left unit vector. Represents the direction of left.
 		</constant>
-		<constant name="RIGHT" value="Vector2( 1, 0 )">
+		<constant name="RIGHT" value="Vector2(1, 0)">
 			Right unit vector. Represents the direction of right.
 		</constant>
-		<constant name="UP" value="Vector2( 0, -1 )">
+		<constant name="UP" value="Vector2(0, -1)">
 			Up unit vector. Y is down in 2D, so this vector points -Y.
 		</constant>
-		<constant name="DOWN" value="Vector2( 0, 1 )">
+		<constant name="DOWN" value="Vector2(0, 1)">
 			Down unit vector. Y is down in 2D, so this vector points +Y.
 		</constant>
 	</constants>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -246,22 +246,22 @@
 		<constant name="AXIS_Y" value="1">
 			Enumerated value for the Y axis.
 		</constant>
-		<constant name="ZERO" value="Vector2i( 0, 0 )">
+		<constant name="ZERO" value="Vector2i(0, 0)">
 			Zero vector, a vector with all components set to [code]0[/code].
 		</constant>
-		<constant name="ONE" value="Vector2i( 1, 1 )">
+		<constant name="ONE" value="Vector2i(1, 1)">
 			One vector, a vector with all components set to [code]1[/code].
 		</constant>
-		<constant name="LEFT" value="Vector2i( -1, 0 )">
+		<constant name="LEFT" value="Vector2i(-1, 0)">
 			Left unit vector. Represents the direction of left.
 		</constant>
-		<constant name="RIGHT" value="Vector2i( 1, 0 )">
+		<constant name="RIGHT" value="Vector2i(1, 0)">
 			Right unit vector. Represents the direction of right.
 		</constant>
-		<constant name="UP" value="Vector2i( 0, -1 )">
+		<constant name="UP" value="Vector2i(0, -1)">
 			Up unit vector. Y is down in 2D, so this vector points -Y.
 		</constant>
-		<constant name="DOWN" value="Vector2i( 0, 1 )">
+		<constant name="DOWN" value="Vector2i(0, 1)">
 			Down unit vector. Y is down in 2D, so this vector points +Y.
 		</constant>
 	</constants>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -173,7 +173,7 @@
 			<return type="Vector3">
 			</return>
 			<description>
-				Returns the inverse of the vector. This is the same as [code]Vector3( 1.0 / v.x, 1.0 / v.y, 1.0 / v.z )[/code].
+				Returns the inverse of the vector. This is the same as [code]Vector3(1.0 / v.x, 1.0 / v.y, 1.0 / v.z)[/code].
 			</description>
 		</method>
 		<method name="is_equal_approx" qualifiers="const">
@@ -556,31 +556,31 @@
 		<constant name="AXIS_Z" value="2">
 			Enumerated value for the Z axis. Returned by [method max_axis] and [method min_axis].
 		</constant>
-		<constant name="ZERO" value="Vector3( 0, 0, 0 )">
+		<constant name="ZERO" value="Vector3(0, 0, 0)">
 			Zero vector, a vector with all components set to [code]0[/code].
 		</constant>
-		<constant name="ONE" value="Vector3( 1, 1, 1 )">
+		<constant name="ONE" value="Vector3(1, 1, 1)">
 			One vector, a vector with all components set to [code]1[/code].
 		</constant>
-		<constant name="INF" value="Vector3( inf, inf, inf )">
+		<constant name="INF" value="Vector3(inf, inf, inf)">
 			Infinity vector, a vector with all components set to [constant @GDScript.INF].
 		</constant>
-		<constant name="LEFT" value="Vector3( -1, 0, 0 )">
+		<constant name="LEFT" value="Vector3(-1, 0, 0)">
 			Left unit vector. Represents the local direction of left, and the global direction of west.
 		</constant>
-		<constant name="RIGHT" value="Vector3( 1, 0, 0 )">
+		<constant name="RIGHT" value="Vector3(1, 0, 0)">
 			Right unit vector. Represents the local direction of right, and the global direction of east.
 		</constant>
-		<constant name="UP" value="Vector3( 0, 1, 0 )">
+		<constant name="UP" value="Vector3(0, 1, 0)">
 			Up unit vector.
 		</constant>
-		<constant name="DOWN" value="Vector3( 0, -1, 0 )">
+		<constant name="DOWN" value="Vector3(0, -1, 0)">
 			Down unit vector.
 		</constant>
-		<constant name="FORWARD" value="Vector3( 0, 0, -1 )">
+		<constant name="FORWARD" value="Vector3(0, 0, -1)">
 			Forward unit vector. Represents the local direction of forward, and the global direction of north.
 		</constant>
-		<constant name="BACK" value="Vector3( 0, 0, 1 )">
+		<constant name="BACK" value="Vector3(0, 0, 1)">
 			Back unit vector. Represents the local direction of back, and the global direction of south.
 		</constant>
 	</constants>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -260,28 +260,28 @@
 		<constant name="AXIS_Z" value="2">
 			Enumerated value for the Z axis.
 		</constant>
-		<constant name="ZERO" value="Vector3i( 0, 0, 0 )">
+		<constant name="ZERO" value="Vector3i(0, 0, 0)">
 			Zero vector, a vector with all components set to [code]0[/code].
 		</constant>
-		<constant name="ONE" value="Vector3i( 1, 1, 1 )">
+		<constant name="ONE" value="Vector3i(1, 1, 1)">
 			One vector, a vector with all components set to [code]1[/code].
 		</constant>
-		<constant name="LEFT" value="Vector3i( -1, 0, 0 )">
+		<constant name="LEFT" value="Vector3i(-1, 0, 0)">
 			Left unit vector. Represents the local direction of left, and the global direction of west.
 		</constant>
-		<constant name="RIGHT" value="Vector3i( 1, 0, 0 )">
+		<constant name="RIGHT" value="Vector3i(1, 0, 0)">
 			Right unit vector. Represents the local direction of right, and the global direction of east.
 		</constant>
-		<constant name="UP" value="Vector3i( 0, 1, 0 )">
+		<constant name="UP" value="Vector3i(0, 1, 0)">
 			Up unit vector.
 		</constant>
-		<constant name="DOWN" value="Vector3i( 0, -1, 0 )">
+		<constant name="DOWN" value="Vector3i(0, -1, 0)">
 			Down unit vector.
 		</constant>
-		<constant name="FORWARD" value="Vector3i( 0, 0, -1 )">
+		<constant name="FORWARD" value="Vector3i(0, 0, -1)">
 			Forward unit vector. Represents the local direction of forward, and the global direction of north.
 		</constant>
-		<constant name="BACK" value="Vector3i( 0, 0, 1 )">
+		<constant name="BACK" value="Vector3i(0, 0, 1)">
 			Back unit vector. Represents the local direction of back, and the global direction of south.
 		</constant>
 	</constants>

--- a/doc/classes/VisibleOnScreenNotifier2D.xml
+++ b/doc/classes/VisibleOnScreenNotifier2D.xml
@@ -21,7 +21,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect" default="Rect2( -10, -10, 20, 20 )">
+		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect" default="Rect2(-10, -10, 20, 20)">
 			The VisibleOnScreenNotifier2D's bounding rectangle.
 		</member>
 	</members>

--- a/doc/classes/VisibleOnScreenNotifier3D.xml
+++ b/doc/classes/VisibleOnScreenNotifier3D.xml
@@ -21,7 +21,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="aabb" type="AABB" setter="set_aabb" getter="get_aabb" default="AABB( -1, -1, -1, 2, 2, 2 )">
+		<member name="aabb" type="AABB" setter="set_aabb" getter="get_aabb" default="AABB(-1, -1, -1, 2, 2, 2)">
 			The VisibleOnScreenNotifier3D's bounding box.
 		</member>
 	</members>

--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -206,7 +206,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2( 0, 0 )">
+		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2(0, 0)">
 			The offset vector of the whole graph.
 		</member>
 		<member name="version" type="String" setter="set_version" getter="get_version" default="&quot;&quot;">

--- a/doc/classes/VisualShaderNodeColorConstant.xml
+++ b/doc/classes/VisualShaderNodeColorConstant.xml
@@ -12,7 +12,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="constant" type="Color" setter="set_constant" getter="get_constant" default="Color( 1, 1, 1, 1 )">
+		<member name="constant" type="Color" setter="set_constant" getter="get_constant" default="Color(1, 1, 1, 1)">
 			A [Color] constant which represents a state of this node.
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeColorUniform.xml
+++ b/doc/classes/VisualShaderNodeColorUniform.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_value" type="Color" setter="set_default_value" getter="get_default_value" default="Color( 1, 1, 1, 1 )">
+		<member name="default_value" type="Color" setter="set_default_value" getter="get_default_value" default="Color(1, 1, 1, 1)">
 			A default value to be assigned within the shader.
 		</member>
 		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">

--- a/doc/classes/VisualShaderNodeResizableBase.xml
+++ b/doc/classes/VisualShaderNodeResizableBase.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2( 0, 0 )">
+		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(0, 0)">
 			The size of the node in the visual shader graph.
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeTransformConstant.xml
+++ b/doc/classes/VisualShaderNodeTransformConstant.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="constant" type="Transform3D" setter="set_constant" getter="get_constant" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<member name="constant" type="Transform3D" setter="set_constant" getter="get_constant" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			A [Transform3D] constant which represents the state of this node.
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeTransformUniform.xml
+++ b/doc/classes/VisualShaderNodeTransformUniform.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_value" type="Transform3D" setter="set_default_value" getter="get_default_value" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<member name="default_value" type="Transform3D" setter="set_default_value" getter="get_default_value" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			A default value to be assigned within the shader.
 		</member>
 		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">

--- a/doc/classes/VisualShaderNodeVec3Constant.xml
+++ b/doc/classes/VisualShaderNodeVec3Constant.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="constant" type="Vector3" setter="set_constant" getter="get_constant" default="Vector3( 0, 0, 0 )">
+		<member name="constant" type="Vector3" setter="set_constant" getter="get_constant" default="Vector3(0, 0, 0)">
 			A [Vector3] constant which represents the state of this node.
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeVec3Uniform.xml
+++ b/doc/classes/VisualShaderNodeVec3Uniform.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_value" type="Vector3" setter="set_default_value" getter="get_default_value" default="Vector3( 0, 0, 0 )">
+		<member name="default_value" type="Vector3" setter="set_default_value" getter="get_default_value" default="Vector3(0, 0, 0)">
 			A default value to be assigned within the shader.
 		</member>
 		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">

--- a/doc/classes/VoxelGI.xml
+++ b/doc/classes/VoxelGI.xml
@@ -36,7 +36,7 @@
 		<member name="data" type="VoxelGIData" setter="set_probe_data" getter="get_probe_data">
 			The [VoxelGIData] resource that holds the data for this [VoxelGI].
 		</member>
-		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3( 10, 10, 10 )">
+		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(10, 10, 10)">
 			The size of the area covered by the [VoxelGI]. If you make the extents larger without increasing the subdivisions with [member subdiv], the size of each cell will increase and result in lower detailed lighting.
 		</member>
 		<member name="subdiv" type="int" setter="set_subdiv" getter="get_subdiv" enum="VoxelGI.Subdiv" default="1">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -218,7 +218,7 @@
 		<method name="popup">
 			<return type="void">
 			</return>
-			<argument index="0" name="rect" type="Rect2i" default="Rect2i( 0, 0, 0, 0 )">
+			<argument index="0" name="rect" type="Rect2i" default="Rect2i(0, 0, 0, 0)">
 			</argument>
 			<description>
 			</description>
@@ -226,7 +226,7 @@
 		<method name="popup_centered">
 			<return type="void">
 			</return>
-			<argument index="0" name="minsize" type="Vector2i" default="Vector2i( 0, 0 )">
+			<argument index="0" name="minsize" type="Vector2i" default="Vector2i(0, 0)">
 			</argument>
 			<description>
 			</description>
@@ -234,7 +234,7 @@
 		<method name="popup_centered_clamped">
 			<return type="void">
 			</return>
-			<argument index="0" name="minsize" type="Vector2i" default="Vector2i( 0, 0 )">
+			<argument index="0" name="minsize" type="Vector2i" default="Vector2i(0, 0)">
 			</argument>
 			<argument index="1" name="fallback_ratio" type="float" default="0.75">
 			</argument>
@@ -322,21 +322,21 @@
 		</member>
 		<member name="content_scale_mode" type="int" setter="set_content_scale_mode" getter="get_content_scale_mode" enum="Window.ContentScaleMode" default="0">
 		</member>
-		<member name="content_scale_size" type="Vector2i" setter="set_content_scale_size" getter="get_content_scale_size" default="Vector2i( 0, 0 )">
+		<member name="content_scale_size" type="Vector2i" setter="set_content_scale_size" getter="get_content_scale_size" default="Vector2i(0, 0)">
 		</member>
 		<member name="current_screen" type="int" setter="set_current_screen" getter="get_current_screen" default="0">
 		</member>
 		<member name="exclusive" type="bool" setter="set_exclusive" getter="is_exclusive" default="false">
 		</member>
-		<member name="max_size" type="Vector2i" setter="set_max_size" getter="get_max_size" default="Vector2i( 0, 0 )">
+		<member name="max_size" type="Vector2i" setter="set_max_size" getter="get_max_size" default="Vector2i(0, 0)">
 		</member>
-		<member name="min_size" type="Vector2i" setter="set_min_size" getter="get_min_size" default="Vector2i( 0, 0 )">
+		<member name="min_size" type="Vector2i" setter="set_min_size" getter="get_min_size" default="Vector2i(0, 0)">
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="Window.Mode" default="0">
 		</member>
-		<member name="position" type="Vector2i" setter="set_position" getter="get_position" default="Vector2i( 0, 0 )">
+		<member name="position" type="Vector2i" setter="set_position" getter="get_position" default="Vector2i(0, 0)">
 		</member>
-		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i( 100, 100 )">
+		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(100, 100)">
 		</member>
 		<member name="theme" type="Theme" setter="set_theme" getter="get_theme">
 		</member>
@@ -472,7 +472,7 @@
 		</theme_item>
 		<theme_item name="scaleborder_size" type="int" default="4">
 		</theme_item>
-		<theme_item name="title_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="title_color" type="Color" default="Color(0, 0, 0, 1)">
 		</theme_item>
 		<theme_item name="title_font" type="Font">
 		</theme_item>
@@ -481,7 +481,7 @@
 		</theme_item>
 		<theme_item name="title_height" type="int" default="20">
 		</theme_item>
-		<theme_item name="title_outline_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="title_outline_modulate" type="Color" default="Color(1, 1, 1, 1)">
 			The color of the title outline.
 		</theme_item>
 		<theme_item name="title_outline_size" type="int" default="0">

--- a/doc/classes/WorldMarginShape3D.xml
+++ b/doc/classes/WorldMarginShape3D.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="plane" type="Plane" setter="set_plane" getter="get_plane" default="Plane( 0, 1, 0, 0 )">
+		<member name="plane" type="Plane" setter="set_plane" getter="get_plane" default="Plane(0, 1, 0, 0)">
 			The [Plane] used by the [WorldMarginShape3D] for collision.
 		</member>
 	</members>

--- a/modules/csg/doc_classes/CSGBox3D.xml
+++ b/modules/csg/doc_classes/CSGBox3D.xml
@@ -14,7 +14,7 @@
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The material used to render the box.
 		</member>
-		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3( 2, 2, 2 )">
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(2, 2, 2)">
 			The box's width, height and depth.
 		</member>
 	</members>

--- a/modules/csg/doc_classes/CSGPolygon3D.xml
+++ b/modules/csg/doc_classes/CSGPolygon3D.xml
@@ -38,7 +38,7 @@
 		<member name="path_rotation" type="int" setter="set_path_rotation" getter="get_path_rotation" enum="CSGPolygon3D.PathRotation">
 			The method by which each slice is rotated along the path when [member mode] is [constant MODE_PATH].
 		</member>
-		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array( 0, 0, 0, 1, 1, 1, 1, 0 )">
+		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array(0, 0, 0, 1, 1, 1, 1, 0)">
 			Point array that defines the shape that we'll extrude.
 		</member>
 		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces" default="false">

--- a/modules/gltf/doc_classes/GLTFAccessor.xml
+++ b/modules/gltf/doc_classes/GLTFAccessor.xml
@@ -17,9 +17,9 @@
 		</member>
 		<member name="count" type="int" setter="set_count" getter="get_count" default="0">
 		</member>
-		<member name="max" type="PackedFloat64Array" setter="set_max" getter="get_max" default="PackedFloat64Array(  )">
+		<member name="max" type="PackedFloat64Array" setter="set_max" getter="get_max" default="PackedFloat64Array()">
 		</member>
-		<member name="min" type="PackedFloat64Array" setter="set_min" getter="get_min" default="PackedFloat64Array(  )">
+		<member name="min" type="PackedFloat64Array" setter="set_min" getter="get_min" default="PackedFloat64Array()">
 		</member>
 		<member name="normalized" type="bool" setter="set_normalized" getter="get_normalized" default="false">
 		</member>

--- a/modules/gltf/doc_classes/GLTFLight.xml
+++ b/modules/gltf/doc_classes/GLTFLight.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 0, 0, 0, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(0, 0, 0, 1)">
 		</member>
 		<member name="inner_cone_angle" type="float" setter="set_inner_cone_angle" getter="get_inner_cone_angle" default="0.0">
 		</member>

--- a/modules/gltf/doc_classes/GLTFMesh.xml
+++ b/modules/gltf/doc_classes/GLTFMesh.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="blend_weights" type="PackedFloat32Array" setter="set_blend_weights" getter="get_blend_weights" default="PackedFloat32Array(  )">
+		<member name="blend_weights" type="PackedFloat32Array" setter="set_blend_weights" getter="get_blend_weights" default="PackedFloat32Array()">
 		</member>
 		<member name="mesh" type="EditorSceneImporterMesh" setter="set_mesh" getter="get_mesh">
 		</member>

--- a/modules/gltf/doc_classes/GLTFNode.xml
+++ b/modules/gltf/doc_classes/GLTFNode.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="camera" type="int" setter="set_camera" getter="get_camera" default="-1">
 		</member>
-		<member name="children" type="PackedInt32Array" setter="set_children" getter="get_children" default="PackedInt32Array(  )">
+		<member name="children" type="PackedInt32Array" setter="set_children" getter="get_children" default="PackedInt32Array()">
 		</member>
 		<member name="height" type="int" setter="set_height" getter="get_height" default="-1">
 		</member>
@@ -23,17 +23,17 @@
 		</member>
 		<member name="parent" type="int" setter="set_parent" getter="get_parent" default="-1">
 		</member>
-		<member name="rotation" type="Quaternion" setter="set_rotation" getter="get_rotation" default="Quaternion( 0, 0, 0, 1 )">
+		<member name="rotation" type="Quaternion" setter="set_rotation" getter="get_rotation" default="Quaternion(0, 0, 0, 1)">
 		</member>
-		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale" default="Vector3( 1, 1, 1 )">
+		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale" default="Vector3(1, 1, 1)">
 		</member>
 		<member name="skeleton" type="int" setter="set_skeleton" getter="get_skeleton" default="-1">
 		</member>
 		<member name="skin" type="int" setter="set_skin" getter="get_skin" default="-1">
 		</member>
-		<member name="translation" type="Vector3" setter="set_translation" getter="get_translation" default="Vector3( 0, 0, 0 )">
+		<member name="translation" type="Vector3" setter="set_translation" getter="get_translation" default="Vector3(0, 0, 0)">
 		</member>
-		<member name="xform" type="Transform3D" setter="set_xform" getter="get_xform" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+		<member name="xform" type="Transform3D" setter="set_xform" getter="get_xform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 		</member>
 	</members>
 	<constants>

--- a/modules/gltf/doc_classes/GLTFSkeleton.xml
+++ b/modules/gltf/doc_classes/GLTFSkeleton.xml
@@ -57,9 +57,9 @@
 		</method>
 	</methods>
 	<members>
-		<member name="joints" type="PackedInt32Array" setter="set_joints" getter="get_joints" default="PackedInt32Array(  )">
+		<member name="joints" type="PackedInt32Array" setter="set_joints" getter="get_joints" default="PackedInt32Array()">
 		</member>
-		<member name="roots" type="PackedInt32Array" setter="set_roots" getter="get_roots" default="PackedInt32Array(  )">
+		<member name="roots" type="PackedInt32Array" setter="set_roots" getter="get_roots" default="PackedInt32Array()">
 		</member>
 	</members>
 	<constants>

--- a/modules/gltf/doc_classes/GLTFSkin.xml
+++ b/modules/gltf/doc_classes/GLTFSkin.xml
@@ -53,13 +53,13 @@
 	<members>
 		<member name="godot_skin" type="Skin" setter="set_godot_skin" getter="get_godot_skin">
 		</member>
-		<member name="joints" type="PackedInt32Array" setter="set_joints" getter="get_joints" default="PackedInt32Array(  )">
+		<member name="joints" type="PackedInt32Array" setter="set_joints" getter="get_joints" default="PackedInt32Array()">
 		</member>
-		<member name="joints_original" type="PackedInt32Array" setter="set_joints_original" getter="get_joints_original" default="PackedInt32Array(  )">
+		<member name="joints_original" type="PackedInt32Array" setter="set_joints_original" getter="get_joints_original" default="PackedInt32Array()">
 		</member>
-		<member name="non_joints" type="PackedInt32Array" setter="set_non_joints" getter="get_non_joints" default="PackedInt32Array(  )">
+		<member name="non_joints" type="PackedInt32Array" setter="set_non_joints" getter="get_non_joints" default="PackedInt32Array()">
 		</member>
-		<member name="roots" type="PackedInt32Array" setter="set_roots" getter="get_roots" default="PackedInt32Array(  )">
+		<member name="roots" type="PackedInt32Array" setter="set_roots" getter="get_roots" default="PackedInt32Array()">
 		</member>
 		<member name="skeleton" type="int" setter="set_skeleton" getter="get_skeleton" default="-1">
 		</member>

--- a/modules/gltf/doc_classes/GLTFSpecGloss.xml
+++ b/modules/gltf/doc_classes/GLTFSpecGloss.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="diffuse_factor" type="Color" setter="set_diffuse_factor" getter="get_diffuse_factor" default="Color( 1, 1, 1, 1 )">
+		<member name="diffuse_factor" type="Color" setter="set_diffuse_factor" getter="get_diffuse_factor" default="Color(1, 1, 1, 1)">
 		</member>
 		<member name="diffuse_img" type="Image" setter="set_diffuse_img" getter="get_diffuse_img">
 		</member>
@@ -17,7 +17,7 @@
 		</member>
 		<member name="spec_gloss_img" type="Image" setter="set_spec_gloss_img" getter="get_spec_gloss_img">
 		</member>
-		<member name="specular_factor" type="Color" setter="set_specular_factor" getter="get_specular_factor" default="Color( 1, 1, 1, 1 )">
+		<member name="specular_factor" type="Color" setter="set_specular_factor" getter="get_specular_factor" default="Color(1, 1, 1, 1)">
 		</member>
 	</members>
 	<constants>

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -243,9 +243,9 @@
 		</method>
 	</methods>
 	<members>
-		<member name="buffers" type="Array" setter="set_buffers" getter="get_buffers" default="[  ]">
+		<member name="buffers" type="Array" setter="set_buffers" getter="get_buffers" default="[]">
 		</member>
-		<member name="glb_data" type="PackedByteArray" setter="set_glb_data" getter="get_glb_data" default="PackedByteArray(  )">
+		<member name="glb_data" type="PackedByteArray" setter="set_glb_data" getter="get_glb_data" default="PackedByteArray()">
 		</member>
 		<member name="json" type="Dictionary" setter="set_json" getter="get_json" default="{}">
 		</member>
@@ -253,7 +253,7 @@
 		</member>
 		<member name="minor_version" type="int" setter="set_minor_version" getter="get_minor_version" default="0">
 		</member>
-		<member name="root_nodes" type="Array" setter="set_root_nodes" getter="get_root_nodes" default="[  ]">
+		<member name="root_nodes" type="Array" setter="set_root_nodes" getter="get_root_nodes" default="[]">
 		</member>
 		<member name="scene_name" type="String" setter="set_scene_name" getter="get_scene_name" default="&quot;&quot;">
 		</member>

--- a/modules/gltf/doc_classes/PackedSceneGLTF.xml
+++ b/modules/gltf/doc_classes/PackedSceneGLTF.xml
@@ -51,7 +51,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" override="true" default="{&quot;conn_count&quot;: 0,&quot;conns&quot;: PackedInt32Array(  ),&quot;editable_instances&quot;: [  ],&quot;names&quot;: PackedStringArray(  ),&quot;node_count&quot;: 0,&quot;node_paths&quot;: [  ],&quot;nodes&quot;: PackedInt32Array(  ),&quot;variants&quot;: [  ],&quot;version&quot;: 2}" />
+		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" override="true" default="{&quot;conn_count&quot;: 0,&quot;conns&quot;: PackedInt32Array(),&quot;editable_instances&quot;: [],&quot;names&quot;: PackedStringArray(),&quot;node_count&quot;: 0,&quot;node_paths&quot;: [],&quot;nodes&quot;: PackedInt32Array(),&quot;variants&quot;: [],&quot;version&quot;: 2}" />
 	</members>
 	<constants>
 	</constants>

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -203,7 +203,7 @@
 			The scale of the cell items.
 			This does not affect the size of the grid cells themselves, only the items in them. This can be used to make cell items overlap their neighbors.
 		</member>
-		<member name="cell_size" type="Vector3" setter="set_cell_size" getter="get_cell_size" default="Vector3( 2, 2, 2 )">
+		<member name="cell_size" type="Vector3" setter="set_cell_size" getter="get_cell_size" default="Vector3(2, 2, 2)">
 			The dimensions of the grid's cells.
 			This does not affect the size of the meshes. See [member cell_scale].
 		</member>

--- a/modules/minimp3/doc_classes/AudioStreamMP3.xml
+++ b/modules/minimp3/doc_classes/AudioStreamMP3.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="data" type="PackedByteArray" setter="set_data" getter="get_data" default="PackedByteArray(  )">
+		<member name="data" type="PackedByteArray" setter="set_data" getter="get_data" default="PackedByteArray()">
 			Contains the audio data in bytes.
 		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="false">

--- a/modules/opensimplex/doc_classes/NoiseTexture.xml
+++ b/modules/opensimplex/doc_classes/NoiseTexture.xml
@@ -31,7 +31,7 @@
 		<member name="noise" type="OpenSimplexNoise" setter="set_noise" getter="get_noise">
 			The [OpenSimplexNoise] instance used to generate the noise.
 		</member>
-		<member name="noise_offset" type="Vector2" setter="set_noise_offset" getter="get_noise_offset" default="Vector2( 0, 0 )">
+		<member name="noise_offset" type="Vector2" setter="set_noise_offset" getter="get_noise_offset" default="Vector2(0, 0)">
 			An offset used to specify the noise space coordinate of the top left corner of the generated noise. This value is ignored if [member seamless] is enabled.
 		</member>
 		<member name="seamless" type="bool" setter="set_seamless" getter="get_seamless" default="false">

--- a/modules/opensimplex/doc_classes/OpenSimplexNoise.xml
+++ b/modules/opensimplex/doc_classes/OpenSimplexNoise.xml
@@ -31,7 +31,7 @@
 			</argument>
 			<argument index="1" name="height" type="int">
 			</argument>
-			<argument index="2" name="noise_offset" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="noise_offset" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Generate a noise image in [constant Image.FORMAT_L8] format with the requested [code]width[/code] and [code]height[/code], based on the current noise parameters. If [code]noise_offset[/code] is specified, then the offset value is used as the coordinates of the top-left corner of the generated noise.

--- a/modules/regex/doc_classes/RegExMatch.xml
+++ b/modules/regex/doc_classes/RegExMatch.xml
@@ -51,7 +51,7 @@
 		<member name="names" type="Dictionary" setter="" getter="get_names" default="{}">
 			A dictionary of named groups and its corresponding group number. Only groups that were matched are included. If multiple groups have the same name, that name would refer to the first matching one.
 		</member>
-		<member name="strings" type="Array" setter="" getter="get_strings" default="[  ]">
+		<member name="strings" type="Array" setter="" getter="get_strings" default="[]">
 			An [Array] of the match and its capturing groups.
 		</member>
 		<member name="subject" type="String" setter="" getter="get_subject" default="&quot;&quot;">

--- a/modules/stb_vorbis/doc_classes/AudioStreamOGGVorbis.xml
+++ b/modules/stb_vorbis/doc_classes/AudioStreamOGGVorbis.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="data" type="PackedByteArray" setter="set_data" getter="get_data" default="PackedByteArray(  )">
+		<member name="data" type="PackedByteArray" setter="set_data" getter="get_data" default="PackedByteArray()">
 			Contains the audio data in bytes.
 		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="false">

--- a/modules/visual_script/doc_classes/VisualScript.xml
+++ b/modules/visual_script/doc_classes/VisualScript.xml
@@ -39,7 +39,7 @@
 			</argument>
 			<argument index="1" name="node" type="VisualScriptNode">
 			</argument>
-			<argument index="2" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="position" type="Vector2" default="Vector2(0, 0)">
 			</argument>
 			<description>
 				Add a node to the VisualScript.

--- a/modules/visual_script/doc_classes/VisualScriptComment.xml
+++ b/modules/visual_script/doc_classes/VisualScriptComment.xml
@@ -15,7 +15,7 @@
 		<member name="description" type="String" setter="set_description" getter="get_description" default="&quot;&quot;">
 			The text inside the comment node.
 		</member>
-		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2( 150, 150 )">
+		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(150, 150)">
 			The comment node's size (in pixels).
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;Comment&quot;">

--- a/modules/visual_script/doc_classes/VisualScriptFunctionState.xml
+++ b/modules/visual_script/doc_classes/VisualScriptFunctionState.xml
@@ -28,7 +28,7 @@
 		<method name="resume">
 			<return type="Variant">
 			</return>
-			<argument index="0" name="args" type="Array" default="[  ]">
+			<argument index="0" name="args" type="Array" default="[]">
 			</argument>
 			<description>
 			</description>

--- a/modules/websocket/doc_classes/WebSocketClient.xml
+++ b/modules/websocket/doc_classes/WebSocketClient.xml
@@ -17,11 +17,11 @@
 			</return>
 			<argument index="0" name="url" type="String">
 			</argument>
-			<argument index="1" name="protocols" type="PackedStringArray" default="PackedStringArray(  )">
+			<argument index="1" name="protocols" type="PackedStringArray" default="PackedStringArray()">
 			</argument>
 			<argument index="2" name="gd_mp_api" type="bool" default="false">
 			</argument>
-			<argument index="3" name="custom_headers" type="PackedStringArray" default="PackedStringArray(  )">
+			<argument index="3" name="custom_headers" type="PackedStringArray" default="PackedStringArray()">
 			</argument>
 			<description>
 				Connects to the given URL requesting one of the given [code]protocols[/code] as sub-protocol. If the list empty (default), no sub-protocol will be requested.

--- a/modules/websocket/doc_classes/WebSocketServer.xml
+++ b/modules/websocket/doc_classes/WebSocketServer.xml
@@ -63,7 +63,7 @@
 			</return>
 			<argument index="0" name="port" type="int">
 			</argument>
-			<argument index="1" name="protocols" type="PackedStringArray" default="PackedStringArray(  )">
+			<argument index="1" name="protocols" type="PackedStringArray" default="PackedStringArray()">
 			</argument>
 			<argument index="2" name="gd_mp_api" type="bool" default="false">
 			</argument>

--- a/tests/test_config_file.h
+++ b/tests/test_config_file.h
@@ -138,8 +138,8 @@ name="Unnamed Player"
 tagline="Waiting
 for
 Godot"
-color=Color( 0, 0.5, 1, 1 )
-position=Vector2( 3, 4 )
+color=Color(0, 0.5, 1, 1)
+position=Vector2(3, 4)
 
 [graphics]
 


### PR DESCRIPTION
Removed extra spaces from the variant parser, which means that in the docs values will appear as `Vector2(0, 0)` instead of `Vector( 0, 0 )`.