### PR TITLE
GDScript: Fix type resolution not being return in some cases

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -6700,7 +6700,8 @@ GDScriptParser::DataType GDScriptParser::_reduce_node_type(Node *p_node) {
 		}
 	}
 
-	p_node->set_datatype(_resolve_type(node_type, p_node->line));
+	node_type = _resolve_type(node_type, p_node->line);
+	p_node->set_datatype(node_type);
 	return node_type;
 }
 


### PR DESCRIPTION
Some situations caused the parser node type to not being update when trying to resolve the type, returning invalid data and breaking the parsing when it shouldn't. This patch fix the behavior.

Fix sponsored by @JavaryGames.