### PR TITLE
ios: support get_model_name

### DIFF
--- a/platform/iphone/ios.h
+++ b/platform/iphone/ios.h
@@ -42,6 +42,7 @@ class iOS : public Object {
 public:
 	static void alert(const char *p_alert, const char *p_title);
 
+	String get_model() const;
 	String get_rate_url(int p_app_id) const;
 
 	iOS();

--- a/platform/iphone/ios.mm
+++ b/platform/iphone/ios.mm
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "ios.h"
+#include <sys/sysctl.h>
 
 #import <UIKit/UIKit.h>
 
@@ -40,6 +41,21 @@ void iOS::_bind_methods() {
 void iOS::alert(const char *p_alert, const char *p_title) {
 	UIAlertView *alert = [[[UIAlertView alloc] initWithTitle:[NSString stringWithUTF8String:p_title] message:[NSString stringWithUTF8String:p_alert] delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil, nil] autorelease];
 	[alert show];
+}
+
+String iOS::get_model() const {
+	// [[UIDevice currentDevice] model] only returns "iPad" or "iPhone".
+	size_t size;
+	sysctlbyname("hw.machine", NULL, &size, NULL, 0);
+	char *model = (char *)malloc(size);
+	if (model == NULL) {
+		return "";
+	}
+	sysctlbyname("hw.machine", model, &size, NULL, 0);
+	NSString *platform = [NSString stringWithCString:model encoding:NSUTF8StringEncoding];
+	free(model);
+	const char *str = [platform UTF8String];
+	return String(str != NULL ? str : "");
 }
 
 String iOS::get_rate_url(int p_app_id) const {

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -47,8 +47,6 @@
 
 #include "semaphore_iphone.h"
 
-#include "ios.h"
-
 #include <dlfcn.h>
 
 int OSIPhone::get_video_driver_count() const {
@@ -184,7 +182,8 @@ Error OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ICloud", icloud));
 	//icloud->connect();
 #endif
-	Engine::get_singleton()->add_singleton(Engine::Singleton("iOS", memnew(iOS)));
+	ios = memnew(iOS);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("iOS", ios));
 
 	return OK;
 };
@@ -506,6 +505,15 @@ String OSIPhone::get_name() const {
 
 	return "iOS";
 };
+
+String OSIPhone::get_model_name() const {
+
+	String model = ios->get_model();
+	if (model != "")
+		return model;
+
+	return OS_Unix::get_model_name();
+}
 
 Size2 OSIPhone::get_window_size() const {
 

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -41,6 +41,7 @@
 #include "game_center.h"
 #include "icloud.h"
 #include "in_app_store.h"
+#include "ios.h"
 #include "main/input_default.h"
 #include "servers/audio_server.h"
 #include "servers/visual/rasterizer.h"
@@ -72,6 +73,7 @@ private:
 #ifdef ICLOUD_ENABLED
 	ICloud *icloud;
 #endif
+	iOS *ios;
 
 	MainLoop *main_loop;
 
@@ -178,6 +180,7 @@ public:
 	void set_data_dir(String p_dir);
 
 	virtual String get_name() const;
+	virtual String get_model_name() const;
 
 	Error shell_open(String p_uri);
 


### PR DESCRIPTION
This implements iOS get_model_name. Fix #8476.