### PR TITLE
Fix Show in file system should clear current search

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2213,6 +2213,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 			RES res = get_edited_object()->get(get_edited_property());
 
 			FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
+			file_system_dock->clear_file_list_search_box();
 			file_system_dock->navigate_to_path(res->get_path());
 			// Ensure that the FileSystem dock is visible.
 			TabContainer *tab_container = (TabContainer *)file_system_dock->get_parent_control();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2463,8 +2463,7 @@ void FileSystemDock::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("display_mode_changed"));
 }
 
-void FileSystemDock::clear_file_list_search_box()
-{
+void FileSystemDock::clear_file_list_search_box() {
 	file_list_search_box->clear();
 }
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2463,6 +2463,11 @@ void FileSystemDock::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("display_mode_changed"));
 }
 
+void FileSystemDock::clear_file_list_search_box()
+{
+	file_list_search_box->clear();
+}
+
 FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	set_name("FileSystem");
 	editor = p_editor;

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -303,6 +303,8 @@ public:
 	void set_file_list_display_mode(FileListDisplayMode p_mode);
 	FileListDisplayMode get_file_list_display_mode() { return file_list_display_mode; };
 
+	void clear_file_list_search_box();
+
 	FileSystemDock(EditorNode *p_editor);
 	~FileSystemDock();
 };


### PR DESCRIPTION
I add a new method for `FileSystemDock `class, that's `clear_file_list_search_box()`
it allow to clear the `file_list_search_box `inside `FileSystemDock `

Now when you right-click a resource in the inspector or scene tab etc. and select option to show it in the file system, then the search box will be clean then `FileSystemDock ` will navigate for that resource

Fixes #32262 