### PR TITLE
Fixed Show in file system should clear current search

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -477,6 +477,7 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 }
 
 void FileSystemDock::navigate_to_path(const String &p_path) {
+	file_list_search_box->clear();
 	_navigate_to_path(p_path);
 }
 


### PR DESCRIPTION
I add a new method for `FileSystemDock `class, that's `clear_file_list_search_box()`
it allow to clear the `file_list_search_box` inside `FileSystemDock`

Now when you right-click a resource in the inspector or scene tab etc. and select option to show it in the file system, then the search box will be clean then `FileSystemDock `will navigate for that resource

Fixes #32262 