### PR TITLE
Fix import hints being ignored by glTF importer

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -156,7 +156,7 @@ static Transform _arr_to_xform(const Array &p_array) {
 }
 
 String EditorSceneImporterGLTF::_sanitize_scene_name(const String &name) {
-	RegEx regex("([^a-zA-Z0-9_ ]+)");
+	RegEx regex("([^a-zA-Z0-9_ -]+)");
 	String p_name = regex.sub(name, "", true);
 	return p_name;
 }


### PR DESCRIPTION
This fixes a regression introduced in commit 72d2468 (didn't find any associated PR) due to hyphens being removed from nodes names although they are required by [import hints](https://docs.godotengine.org/en/latest/getting_started/workflow/assets/importing_scenes.html#import-hints).

@marstaik may want to have a look at this to make sure it doesn't have unexpected side effects.

**Godot version:**

351c45a46

**OS:**

Ubuntu 19.10

**Steps to reproduce:**

* Import the following glb file [cube.zip](https://github.com/godotengine/godot/files/3653326/cube.zip) with _Godot v3.1.1 stable_ should give you the following node hierarchy:

 ![image](https://user-images.githubusercontent.com/1949583/65615216-4620a880-dfb9-11e9-8f7c-48f0c120d560.png)

* Importing the same file with revision 351c45a46 results in:

 ![image](https://user-images.githubusercontent.com/1949583/65615591-e8d92700-dfb9-11e9-81d8-6e48a7f32cdf.png)

(Scene root name certainly differ due to commit 6ee5f7c)

**Minimal reproduction project:**

[glTF import test.zip](https://github.com/godotengine/godot/files/3653438/glTF.import.test.zip)


This is my first contribution to Godot, so please be nice ;-) Opening an issue seemed a bit too much for such a simple change but let me know if I should do it.