### PR TITLE
Reset hovered point in Curve when deleted to avoid errors on draw

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -456,6 +456,9 @@ void CurveEditor::remove_point(int index) {
 	if (index == _selected_point)
 		set_selected_point(-1);
 
+	if (index == _hover_point)
+		set_hover_point_index(-1);
+
 	ur.commit_action();
 }
 


### PR DESCRIPTION
Same logic as for the selected point now.

Fixes #32344