### PR TITLE
Fixed missing argument for clear_selection signal in Bezier Curve editor

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -546,7 +546,7 @@ void AnimationBezierTrackEdit::set_timeline(AnimationTimelineEdit *p_timeline) {
 }
 void AnimationBezierTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 	editor = p_editor;
-	connect("clear_selection", editor, "_clear_selection");
+	connect("clear_selection", editor, "_clear_selection", varray(false));
 }
 
 void AnimationBezierTrackEdit::_play_position_draw() {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3080,7 +3080,6 @@ void AnimationTrackEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("insert_key", PropertyInfo(Variant::REAL, "ofs")));
 	ADD_SIGNAL(MethodInfo("select_key", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::BOOL, "single")));
 	ADD_SIGNAL(MethodInfo("deselect_key", PropertyInfo(Variant::INT, "index")));
-	ADD_SIGNAL(MethodInfo("clear_selection"));
 	ADD_SIGNAL(MethodInfo("bezier_edit"));
 
 	ADD_SIGNAL(MethodInfo("move_selection_begin"));
@@ -4265,7 +4264,6 @@ void AnimationTrackEditor::_update_tracks() {
 		track_edit->connect("select_key", this, "_key_selected", varray(i), CONNECT_DEFERRED);
 		track_edit->connect("deselect_key", this, "_key_deselected", varray(i), CONNECT_DEFERRED);
 		track_edit->connect("bezier_edit", this, "_bezier_edit", varray(i), CONNECT_DEFERRED);
-		track_edit->connect("clear_selection", this, "_clear_selection");
 		track_edit->connect("move_selection_begin", this, "_move_selection_begin");
 		track_edit->connect("move_selection", this, "_move_selection");
 		track_edit->connect("move_selection_commit", this, "_move_selection_commit");


### PR DESCRIPTION
A new argument for `AnimationTrackEditor::_clear_selection` was introduced in 77ec3ec0a30e38af4cd573b98d3934c18b91a48f and was causing errors in AnimationBezierTrackEdit.

Also removed unused `clear_selection` signal in `AnimationTrackEditor` (never emitted).

Fixes #32348