### PR TITLE
Update TextureRect when its Texture is modified directly

### DIFF
--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -135,12 +135,12 @@ void Sprite::set_texture(const Ref<Texture> &p_texture) {
 		return;
 
 	if (texture.is_valid())
-		texture->remove_change_receptor(this);
+		texture->disconnect(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
 
 	texture = p_texture;
 
 	if (texture.is_valid())
-		texture->add_change_receptor(this);
+		texture->connect(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
 
 	update();
 	emit_signal("texture_changed");
@@ -389,11 +389,11 @@ void Sprite::_validate_property(PropertyInfo &property) const {
 	}
 }
 
-void Sprite::_changed_callback(Object *p_changed, const char *p_prop) {
+void Sprite::_texture_changed() {
 
 	// Changes to the texture need to trigger an update to make
 	// the editor redraw the sprite with the updated texture.
-	if (texture.is_valid() && texture.ptr() == p_changed) {
+	if (texture.is_valid()) {
 		update();
 	}
 }
@@ -443,6 +443,8 @@ void Sprite::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_rect"), &Sprite::get_rect);
 
+	ClassDB::bind_method(D_METHOD("_texture_changed"), &Sprite::_texture_changed);
+
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 	ADD_SIGNAL(MethodInfo("texture_changed"));
 
@@ -480,6 +482,4 @@ Sprite::Sprite() {
 }
 
 Sprite::~Sprite() {
-	if (texture.is_valid())
-		texture->remove_change_receptor(this);
 }

--- a/scene/2d/sprite.h
+++ b/scene/2d/sprite.h
@@ -57,14 +57,14 @@ class Sprite : public Node2D {
 
 	void _get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_clip) const;
 
+	void _texture_changed();
+
 protected:
 	void _notification(int p_what);
 
 	static void _bind_methods();
 
 	virtual void _validate_property(PropertyInfo &property) const;
-
-	virtual void _changed_callback(Object *p_changed, const char *p_prop);
 
 public:
 	virtual Dictionary _edit_get_state() const;

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "texture_rect.h"
+#include "core/core_string_names.h"
 #include "servers/visual_server.h"
 
 void TextureRect::_notification(int p_what) {
@@ -123,6 +124,7 @@ void TextureRect::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_flipped_v"), &TextureRect::is_flipped_v);
 	ClassDB::bind_method(D_METHOD("set_stretch_mode", "stretch_mode"), &TextureRect::set_stretch_mode);
 	ClassDB::bind_method(D_METHOD("get_stretch_mode"), &TextureRect::get_stretch_mode);
+	ClassDB::bind_method(D_METHOD("_texture_changed"), &TextureRect::_texture_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand"), "set_expand", "has_expand");
@@ -140,9 +142,27 @@ void TextureRect::_bind_methods() {
 	BIND_ENUM_CONSTANT(STRETCH_KEEP_ASPECT_COVERED);
 }
 
+void TextureRect::_texture_changed() {
+
+	if (texture.is_valid()) {
+		update();
+		minimum_size_changed();
+	}
+}
+
 void TextureRect::set_texture(const Ref<Texture> &p_tex) {
 
+	if (p_tex == texture)
+		return;
+
+	if (texture.is_valid())
+		texture->disconnect(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+
 	texture = p_tex;
+
+	if (texture.is_valid())
+		texture->connect(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+
 	update();
 	/*
 	if (texture.is_valid())

--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -56,6 +56,8 @@ private:
 	Ref<Texture> texture;
 	StretchMode stretch_mode;
 
+	void _texture_changed();
+
 protected:
 	void _notification(int p_what);
 	virtual Size2 get_minimum_size() const;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -117,6 +117,7 @@ void ImageTexture::reload_from_file() {
 	} else {
 		Resource::reload_from_file();
 		_change_notify();
+		emit_changed();
 	}
 }
 
@@ -180,6 +181,7 @@ void ImageTexture::_reload_hook(const RID &p_hook) {
 	VisualServer::get_singleton()->texture_set_data(texture, img);
 
 	_change_notify();
+	emit_changed();
 }
 
 void ImageTexture::create(int p_width, int p_height, Image::Format p_format, uint32_t p_flags) {
@@ -190,6 +192,7 @@ void ImageTexture::create(int p_width, int p_height, Image::Format p_format, uin
 	w = p_width;
 	h = p_height;
 	_change_notify();
+	emit_changed();
 }
 void ImageTexture::create_from_image(const Ref<Image> &p_image, uint32_t p_flags) {
 
@@ -202,23 +205,23 @@ void ImageTexture::create_from_image(const Ref<Image> &p_image, uint32_t p_flags
 	VisualServer::get_singleton()->texture_allocate(texture, p_image->get_width(), p_image->get_height(), 0, p_image->get_format(), VS::TEXTURE_TYPE_2D, p_flags);
 	VisualServer::get_singleton()->texture_set_data(texture, p_image);
 	_change_notify();
+	emit_changed();
 
 	image_stored = true;
 }
 
 void ImageTexture::set_flags(uint32_t p_flags) {
 
-	/*	uint32_t cube = flags & FLAG_CUBEMAP;
-	if (flags == p_flags&cube)
+	if (flags == p_flags)
 		return;
 
-	flags=p_flags|cube;	*/
 	flags = p_flags;
 	if (w == 0 || h == 0) {
 		return; //uninitialized, do not set to texture
 	}
 	VisualServer::get_singleton()->texture_set_flags(texture, p_flags);
 	_change_notify("flags");
+	emit_changed();
 }
 
 uint32_t ImageTexture::get_flags() const {
@@ -250,6 +253,8 @@ void ImageTexture::set_data(const Ref<Image> &p_image) {
 	VisualServer::get_singleton()->texture_set_data(texture, p_image);
 
 	_change_notify();
+	emit_changed();
+
 	alpha_cache.unref();
 	image_stored = true;
 }
@@ -736,6 +741,7 @@ Error StreamTexture::load(const String &p_path) {
 	format = image->get_format();
 
 	_change_notify();
+	emit_changed();
 	return OK;
 }
 String StreamTexture::get_load_path() const {
@@ -827,6 +833,7 @@ void StreamTexture::set_flags(uint32_t p_flags) {
 	flags = p_flags;
 	VS::get_singleton()->texture_set_flags(texture, flags);
 	_change_notify("flags");
+	emit_changed();
 }
 
 void StreamTexture::reload_from_file() {


### PR DESCRIPTION
This change makes `TextureRect` properly react to `ImageTexture::_change_notify()`

Fixes #32349