### PR TITLE
Implement #32347 - (RichTextLabel's Item's should be structs)

### DIFF
--- a/scene/gui/rich_text_effect.cpp
+++ b/scene/gui/rich_text_effect.cpp
@@ -120,3 +120,7 @@ CharFXTransform::CharFXTransform() {
 	color = Color();
 	character = 0;
 }
+
+CharFXTransform::~CharFXTransform() {
+	environment.clear();
+}

--- a/scene/gui/rich_text_effect.h
+++ b/scene/gui/rich_text_effect.h
@@ -64,6 +64,8 @@ public:
 	Dictionary environment;
 
 	CharFXTransform();
+	~CharFXTransform();
+
 	uint64_t get_relative_index() { return relative_index; }
 	void set_relative_index(uint64_t p_index) { relative_index = p_index; }
 	uint64_t get_absolute_index() { return absolute_index; }


### PR DESCRIPTION
To be honest I'm kind of shocked how fast this came together. (I expected I'll need at least 3-ish really hard days.)

Also I found a few smaller things I fixed those as well.

I'll continue trying to break it for a few days.

Please tell if you like this solution or not, I'll change the implementation accordingly.

**Complete list of changes:**

I kept the inheritance tree unchanged, the ItemFX struct isn't in the enum. I replaced the query that gathers every ItemFX struct to just check for the relevant types. I don't think it worths it to add any new variable to check for this at the moment, however if the number of classes start to grow it might worth to add something.

CharFXTransforms now store a ref to the relevant RichTextEffect (as per @reduz), and since it doesn't need that string identifier anymore, I removed that. (I kept the lookup function, as it's useful when setting up the classes.)

The original code constantly allocated CharFXTransforms, now these are only created once, and stored in ItemCustomFX. This way ItemCustomFX doesn't need the environment dictionary, since it was only there so the code can give it to CharFXTransform on creation.

I found an emty for loop, I removed it.

I made _get_custom_effect_by_code return early, as there shouldn't be more than one bbcode per type.

Implements #32347

*Bugsquad edit:* Closes #32347.