### PR TITLE
TextureProgress: nine_patch_stretch property -> enable stretching for radial fills.

### DIFF
--- a/doc/classes/TextureProgress.xml
+++ b/doc/classes/TextureProgress.xml
@@ -34,7 +34,7 @@
 		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1" />
 		<member name="nine_patch_stretch" type="bool" setter="set_nine_patch_stretch" getter="get_nine_patch_stretch" default="false">
-			If [code]true[/code], Godot treats the bar's textures like in [NinePatchRect]. Use the [code]stretch_margin_*[/code] properties like [member stretch_margin_bottom] to set up the nine patch's 3×3 grid.
+			If [code]true[/code], Godot treats the bar's textures like in [NinePatchRect]. Use the [code]stretch_margin_*[/code] properties like [member stretch_margin_bottom] to set up the nine patch's 3×3 grid. When using a radial [member fill_mode], this setting will enable stretching.
 		</member>
 		<member name="radial_center_offset" type="Vector2" setter="set_radial_center_offset" getter="get_radial_center_offset" default="Vector2( 0, 0 )">
 			Offsets [member texture_progress] if [member fill_mode] is [constant FILL_CLOCKWISE] or [constant FILL_COUNTER_CLOCKWISE].

--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -344,6 +344,9 @@ void TextureProgress::_notification(int p_what) {
 						case FILL_CLOCKWISE:
 						case FILL_COUNTER_CLOCKWISE:
 						case FILL_CLOCKWISE_AND_COUNTER_CLOCKWISE: {
+							if (nine_patch_stretch)
+								s = get_size();
+
 							float val = get_as_ratio() * rad_max_degrees / 360;
 							if (val == 1) {
 								Rect2 region = Rect2(Point2(), s);
@@ -384,7 +387,13 @@ void TextureProgress::_notification(int p_what) {
 								draw_polygon(points, colors, uvs, progress);
 							}
 							if (Engine::get_singleton()->is_editor_hint()) {
-								Point2 p = progress->get_size();
+								Point2 p;
+
+								if (nine_patch_stretch)
+									p = get_size();
+								else
+									p = progress->get_size();
+
 								p.x *= get_relative_center().x;
 								p.y *= get_relative_center().y;
 								p = p.floor();


### PR DESCRIPTION
Having this capability is useful for resizable overlays.

This way you can have a 1px overlay texture, set TextureProgress to one of the radial modes, and you can just make it scale with a parent container. Useful for spell cooldowns for example.

I decided to use the nine_patch_stretch property, this way it shouldn't break most existing things. (Since it's off by default, and currently it does nothing for radial fills.). Also I feel like it's kind of wants to be there.

I also added this fact to the nine_patch_stretch property's documentation.