### PR TITLE
SCons: do not build tests with tools=no

### DIFF
--- a/main/SCsub
+++ b/main/SCsub
@@ -28,7 +28,8 @@ env.CommandNoCache("#main/splash_editor.gen.h", "#main/splash_editor.png", run_i
 env.Depends("#main/app_icon.gen.h", "#main/app_icon.png")
 env.CommandNoCache("#main/app_icon.gen.h", "#main/app_icon.png", run_in_subprocess(main_builders.make_app_icon))
 
-SConscript('tests/SCsub')
+if env["tools"]:
+    SConscript('tests/SCsub')
 
 lib = env.add_library("main", env.main_sources)
 env.Prepend(LIBS=[lib])

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1457,12 +1457,11 @@ bool Main::start() {
 	};
 
 	if (test != "") {
-#ifdef DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 		main_loop = test_main(test, args);
 
 		if (!main_loop)
 			return false;
-
 #endif
 
 	} else if (script != "") {


### PR DESCRIPTION
This doesn't affect the resulting binary size much, but allows to save a phew seconds during compilation if building export templates.

Test related code is conditionally compiled with `TOOLS_ENABLED` in `main`, yet some parts were compiled with `DEBUG_ENABLED` instead, so this inconsistency is resolved as well.
