### PR TITLE
Implement `TreeItem.get_button_tooltip(column, idx)`.

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -84,6 +84,15 @@
 				Returns the number of buttons in column [code]column[/code]. May be used to get the most recently added button's index, if no index was specified.
 			</description>
 		</method>
+		<method name="get_button_tooltip" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<description>
+				Returns the tooltip for the button in column [code]column[/code].
+			</description>
+		</method>
 		<method name="get_cell_mode" qualifiers="const">
 			<return type="int" enum="TreeItem.TreeCellMode">
 			</return>

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -547,6 +547,11 @@ Ref<Texture> TreeItem::get_button(int p_column, int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, cells[p_column].buttons.size(), Ref<Texture>());
 	return cells[p_column].buttons[p_idx].texture;
 }
+String TreeItem::get_button_tooltip(int p_column, int p_idx) const {
+	ERR_FAIL_INDEX_V(p_column, cells.size(), String());
+	ERR_FAIL_INDEX_V(p_idx, cells[p_column].buttons.size(), String());
+	return cells[p_column].buttons[p_idx].tooltip;
+}
 int TreeItem::get_button_id(int p_column, int p_idx) const {
 	ERR_FAIL_INDEX_V(p_column, cells.size(), -1);
 	ERR_FAIL_INDEX_V(p_idx, cells[p_column].buttons.size(), -1);
@@ -795,6 +800,7 @@ void TreeItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_button", "column", "button", "button_idx", "disabled", "tooltip"), &TreeItem::add_button, DEFVAL(-1), DEFVAL(false), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_button_count", "column"), &TreeItem::get_button_count);
+	ClassDB::bind_method(D_METHOD("get_button_tooltip", "column"), &TreeItem::get_button_tooltip);
 	ClassDB::bind_method(D_METHOD("get_button", "column", "button_idx"), &TreeItem::get_button);
 	ClassDB::bind_method(D_METHOD("set_button", "column", "button_idx", "button"), &TreeItem::set_button);
 	ClassDB::bind_method(D_METHOD("erase_button", "column", "button_idx"), &TreeItem::erase_button);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -201,6 +201,7 @@ public:
 
 	void add_button(int p_column, const Ref<Texture> &p_button, int p_id = -1, bool p_disabled = false, const String &p_tooltip = "");
 	int get_button_count(int p_column) const;
+	String get_button_tooltip(int p_column, int p_idx) const;
 	Ref<Texture> get_button(int p_column, int p_idx) const;
 	int get_button_id(int p_column, int p_idx) const;
 	void erase_button(int p_column, int p_idx);


### PR DESCRIPTION
When added to `TreeItem`, buttons are given tooltips. When returned via `get_button(...)`, however, the button is a `Texture` and the tooltip information isn't included.

For accessibility purposes, it is useful to have access to the tooltip text. As such, we can retrieve a button's tooltip to use as a button label.

My accessibility addon needs this to allow keyboard control over buttons in `Tree` columns. Specifically, without it, I can't add keys/buttons to actions.

Related to #14011.