### PR TITLE
Cleanup the "Attach Node Script" dialog

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -602,7 +602,7 @@ void ScriptCreateDialog::_path_entered(const String &p_path) {
 
 void ScriptCreateDialog::_msg_script_valid(bool valid, const String &p_msg) {
 
-	error_label->set_text(TTR(p_msg));
+	error_label->set_text("- " + TTR(p_msg));
 	if (valid) {
 		error_label->add_color_override("font_color", get_color("success_color", "Editor"));
 	} else {
@@ -612,7 +612,7 @@ void ScriptCreateDialog::_msg_script_valid(bool valid, const String &p_msg) {
 
 void ScriptCreateDialog::_msg_path_valid(bool valid, const String &p_msg) {
 
-	path_error_label->set_text(TTR(p_msg));
+	path_error_label->set_text("- " + TTR(p_msg));
 	if (valid) {
 		path_error_label->add_color_override("font_color", get_color("success_color", "Editor"));
 	} else {
@@ -744,25 +744,11 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 
-	HBoxContainer *hb = memnew(HBoxContainer);
-	Label *l = memnew(Label);
-	l->set_text(" - ");
-	hb->add_child(l);
 	error_label = memnew(Label);
-	error_label->set_text(TTR("Error!"));
-	error_label->set_align(Label::ALIGN_LEFT);
-	hb->add_child(error_label);
-	vb->add_child(hb);
+	vb->add_child(error_label);
 
-	hb = memnew(HBoxContainer);
-	l = memnew(Label);
-	l->set_text(" - ");
-	hb->add_child(l);
 	path_error_label = memnew(Label);
-	path_error_label->set_text(TTR("Error!"));
-	path_error_label->set_align(Label::ALIGN_LEFT);
-	hb->add_child(path_error_label);
-	vb->add_child(hb);
+	vb->add_child(path_error_label);
 
 	status_panel = memnew(PanelContainer);
 	status_panel->set_h_size_flags(Control::SIZE_FILL);
@@ -777,7 +763,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	vb->add_child(gc);
 	vb->add_child(spacing);
 	vb->add_child(status_panel);
-	hb = memnew(HBoxContainer);
+	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->add_child(vb);
 
 	add_child(hb);
@@ -787,9 +773,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	language_menu = memnew(OptionButton);
 	language_menu->set_custom_minimum_size(Size2(250, 0) * EDSCALE);
 	language_menu->set_h_size_flags(SIZE_EXPAND_FILL);
-	l = memnew(Label(TTR("Language")));
-	l->set_align(Label::ALIGN_RIGHT);
-	gc->add_child(l);
+	gc->add_child(memnew(Label(TTR("Language:"))));
 	gc->add_child(language_menu);
 
 	default_language = 0;
@@ -825,9 +809,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	parent_browse_button->set_flat(true);
 	parent_browse_button->connect("pressed", this, "_browse_path", varray(true, false));
 	hb->add_child(parent_browse_button);
-	l = memnew(Label(TTR("Inherits")));
-	l->set_align(Label::ALIGN_RIGHT);
-	gc->add_child(l);
+	gc->add_child(memnew(Label(TTR("Inherits:"))));
 	gc->add_child(hb);
 	is_browsing_parent = false;
 
@@ -836,17 +818,13 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	class_name = memnew(LineEdit);
 	class_name->connect("text_changed", this, "_class_name_changed");
 	class_name->set_h_size_flags(SIZE_EXPAND_FILL);
-	l = memnew(Label(TTR("Class Name")));
-	l->set_align(Label::ALIGN_RIGHT);
-	gc->add_child(l);
+	gc->add_child(memnew(Label(TTR("Class Name:"))));
 	gc->add_child(class_name);
 
 	/* Templates */
 
 	template_menu = memnew(OptionButton);
-	l = memnew(Label(TTR("Template")));
-	l->set_align(Label::ALIGN_RIGHT);
-	gc->add_child(l);
+	gc->add_child(memnew(Label(TTR("Template:"))));
 	gc->add_child(template_menu);
 	template_menu->connect("item_selected", this, "_template_changed");
 
@@ -855,8 +833,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	internal = memnew(CheckBox);
 	internal->set_text(TTR("On"));
 	internal->connect("pressed", this, "_built_in_pressed");
-	internal_label = memnew(Label(TTR("Built-in Script")));
-	internal_label->set_align(Label::ALIGN_RIGHT);
+	internal_label = memnew(Label(TTR("Built-in Script:")));
 	gc->add_child(internal_label);
 	gc->add_child(internal);
 
@@ -873,9 +850,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	path_button->set_flat(true);
 	path_button->connect("pressed", this, "_browse_path", varray(false, true));
 	hb->add_child(path_button);
-	l = memnew(Label(TTR("Path")));
-	l->set_align(Label::ALIGN_RIGHT);
-	gc->add_child(l);
+	gc->add_child(memnew(Label(TTR("Path:"))));
 	gc->add_child(hb);
 
 	/* Dialog Setup */


### PR DESCRIPTION
- Made section names be in the same style as other dialogs (starting from the left and ending with a ":").
- Cleanup unnecessary nodes and redundant calls.