### PR TITLE
Mono: Don't compare API hashes on release builds

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -30,7 +30,7 @@
 
 #include "bindings_generator.h"
 
-#ifdef DEBUG_METHODS_ENABLED
+#if defined(DEBUG_METHODS_ENABLED) && defined(TOOLS_ENABLED)
 
 #include "core/engine.h"
 #include "core/global_constants.h"

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -36,7 +36,7 @@
 #include "editor/doc/doc_data.h"
 #include "editor/editor_help.h"
 
-#ifdef DEBUG_METHODS_ENABLED
+#if defined(DEBUG_METHODS_ENABLED) && defined(TOOLS_ENABLED)
 
 #include "core/ustring.h"
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -427,8 +427,8 @@ void GDMono::_register_internal_calls() {
 }
 
 void GDMono::_initialize_and_check_api_hashes() {
-
 #ifdef MONO_GLUE_ENABLED
+#ifdef DEBUG_METHODS_ENABLED
 	if (get_api_core_hash() != GodotSharpBindings::get_core_api_hash()) {
 		ERR_PRINT("Mono: Core API hash mismatch.");
 	}
@@ -438,6 +438,7 @@ void GDMono::_initialize_and_check_api_hashes() {
 		ERR_PRINT("Mono: Editor API hash mismatch.");
 	}
 #endif // TOOLS_ENABLED
+#endif // DEBUG_METHODS_ENABLED
 #endif // MONO_GLUE_ENABLED
 }
 

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -151,6 +151,7 @@ protected:
 	static GDMono *singleton;
 
 public:
+#ifdef DEBUG_METHODS_ENABLED
 	uint64_t get_api_core_hash() {
 		if (api_core_hash == 0)
 			api_core_hash = ClassDB::get_api_hash(ClassDB::API_CORE);
@@ -162,7 +163,8 @@ public:
 			api_editor_hash = ClassDB::get_api_hash(ClassDB::API_EDITOR);
 		return api_editor_hash;
 	}
-#endif
+#endif // TOOLS_ENABLED
+#endif // DEBUG_METHODS_ENABLED
 
 #ifdef TOOLS_ENABLED
 	bool copy_prebuilt_api_assembly(APIAssembly::Type p_api_type, const String &p_config);


### PR DESCRIPTION
API hashes cannot be calculated on release builds, as bindings information is lacking. Therefore, we should not be comparing it with the generated glue hash as they will never match.
