### PR TITLE
Print errors when tab indent found in [codeblock]

### DIFF
--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -69,7 +69,7 @@
 				[codeblock]
 				{
 				    "content-length": 12,
-					"Content-Type": "application/json; charset=UTF-8",
+				    "Content-Type": "application/json; charset=UTF-8",
 				}
 				[/codeblock]
 			</description>

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -69,9 +69,9 @@
 				Commonly used to create a one-shot delay timer as in the following example:
 				[codeblock]
 				func some_function():
-					print("start")
-					yield(get_tree().create_timer(1.0), "timeout")
-					print("end")
+				    print("start")
+				    yield(get_tree().create_timer(1.0), "timeout")
+				    print("end")
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -608,8 +608,10 @@ def rstize_text(text, state):  # type: (str, State) -> str
             break
 
         pre_text = text[:pos]
+        indent_level = 0
         while text[pos + 1] == '\t':
             pos += 1
+            indent_level += 1
         post_text = text[pos + 1:]
 
         # Handle codeblocks
@@ -632,6 +634,9 @@ def rstize_text(text, state):  # type: (str, State) -> str
                 to_skip = 0
                 while code_pos + to_skip + 1 < len(code_text) and code_text[code_pos + to_skip + 1] == '\t':
                     to_skip += 1
+
+                if to_skip > indent_level:
+                    print_error("Four spaces should be used for indentation within [codeblock], file: {}".format(state.current_class), state)
 
                 if len(code_text[code_pos + to_skip + 1:]) == 0:
                     code_text = code_text[:code_pos] + "\n"

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -590,10 +590,10 @@
 				extends Sprite
 				var elapsed = 0.0
 				func _process(delta):
-					var min_angle = deg2rad(0.0)
-					var max_angle = deg2rad(90.0)
-					rotation = lerp_angle(min_angle, max_angle, elapsed)
-					elapsed += delta
+				    var min_angle = deg2rad(0.0)
+				    var max_angle = deg2rad(90.0)
+				    rotation = lerp_angle(min_angle, max_angle, elapsed)
+				    elapsed += delta
 				[/codeblock]
 			</description>
 		</method>


### PR DESCRIPTION
While I was reading [MainLoop](https://docs.godotengine.org/en/3.1/classes/class_mainloop.html), I found the indentation of codeblock in the page messed up.

Even though we states that we need to use 4 spaces in `[codeblock]`in [Improve formatting with BBcode style tags](https://docs.godotengine.org/en/3.1/community/contributing/updating_the_class_reference.html#improve-formatting-with-bbcode-style-tags), considering that Godot's default indentation character is `\t` and alternating between two ways of indentation in a file is quite cumbersome, it's prone to make mistakes like this.

Instead of manually fixing this one page, after reading `doc/tools/makerst.py`, I figured out we can enforce this by making a small change.

Here is the diff of "Before and After" of the output files of `make rst`:
https://github.com/yeonghoey/godot/commit/816c20144c7d97ed1e5ee0df83f29dfd57e6a3d3