### PR TITLE
Highlight singletons and class_names in GDScript

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -666,6 +666,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 	_initial_set("text_editor/highlighting/keyword_color", Color(1.0, 1.0, 0.7));
 	_initial_set("text_editor/highlighting/base_type_color", Color(0.64, 1.0, 0.83));
 	_initial_set("text_editor/highlighting/engine_type_color", Color(0.51, 0.83, 1.0));
+	_initial_set("text_editor/highlighting/user_type_color", Color(0.42, 0.67, 0.93));
 	_initial_set("text_editor/highlighting/comment_color", Color(0.4, 0.4, 0.4));
 	_initial_set("text_editor/highlighting/string_color", Color(0.94, 0.43, 0.75));
 	_initial_set("text_editor/highlighting/background_color", dark_theme ? Color(0.0, 0.0, 0.0, 0.23) : Color(0.2, 0.23, 0.31));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1130,7 +1130,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color symbol_color = Color(0.34, 0.57, 1.0).linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
 	const Color keyword_color = Color(1.0, 0.44, 0.52);
 	const Color basetype_color = dark_theme ? Color(0.26, 1.0, 0.76) : Color(0.0, 0.76, 0.38);
-	const Color type_color = basetype_color.linear_interpolate(mono_color, dark_theme ? 0.7 : 0.5);
+	const Color type_color = basetype_color.linear_interpolate(mono_color, dark_theme ? 0.4 : 0.3);
+	const Color usertype_color = basetype_color.linear_interpolate(mono_color, dark_theme ? 0.7 : 0.5);
 	const Color comment_color = dim_color;
 	const Color string_color = (dark_theme ? Color(1.0, 0.85, 0.26) : Color(1.0, 0.82, 0.09)).linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
 
@@ -1169,6 +1170,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		setting->set_initial_value("text_editor/highlighting/keyword_color", keyword_color, true);
 		setting->set_initial_value("text_editor/highlighting/base_type_color", basetype_color, true);
 		setting->set_initial_value("text_editor/highlighting/engine_type_color", type_color, true);
+		setting->set_initial_value("text_editor/highlighting/user_type_color", usertype_color, true);
 		setting->set_initial_value("text_editor/highlighting/comment_color", comment_color, true);
 		setting->set_initial_value("text_editor/highlighting/string_color", string_color, true);
 		setting->set_initial_value("text_editor/highlighting/background_color", te_background_color, true);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -224,6 +224,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
 	Color basetype_color = EDITOR_GET("text_editor/highlighting/base_type_color");
 	Color type_color = EDITOR_GET("text_editor/highlighting/engine_type_color");
+	Color usertype_color = EDITOR_GET("text_editor/highlighting/user_type_color");
 	Color comment_color = EDITOR_GET("text_editor/highlighting/comment_color");
 	Color string_color = EDITOR_GET("text_editor/highlighting/string_color");
 
@@ -262,6 +263,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	colors_cache.keyword_color = keyword_color;
 	colors_cache.basetype_color = basetype_color;
 	colors_cache.type_color = type_color;
+	colors_cache.usertype_color = usertype_color;
 	colors_cache.comment_color = comment_color;
 	colors_cache.string_color = string_color;
 
@@ -324,6 +326,29 @@ void ScriptTextEditor::_set_theme_for_script() {
 		text_edit->add_keyword_color(n, colors_cache.type_color);
 	}
 	_update_member_keywords();
+
+	//colorize user types
+	List<StringName> global_classes;
+	ScriptServer::get_global_class_list(&global_classes);
+
+	for (List<StringName>::Element *E = global_classes.front(); E; E = E->next()) {
+
+		text_edit->add_keyword_color(E->get(), colors_cache.usertype_color);
+	}
+
+	//colorize singleton autoloads (as types, just as engine singletons are)
+	List<PropertyInfo> props;
+	ProjectSettings::get_singleton()->get_property_list(&props);
+	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
+		String s = E->get().name;
+		if (!s.begins_with("autoload/")) {
+			continue;
+		}
+		String path = ProjectSettings::get_singleton()->get(s);
+		if (path.begins_with("*")) {
+			text_edit->add_keyword_color(s.get_slice("/", 1), colors_cache.usertype_color);
+		}
+	}
 
 	//colorize comments
 	List<String> comments;

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -91,6 +91,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 		Color keyword_color;
 		Color basetype_color;
 		Color type_color;
+		Color usertype_color;
 		Color comment_color;
 		Color string_color;
 	} colors_cache;

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -247,7 +247,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 				in_function_args = false;
 			}
 
-			if (expect_type && prev_is_char) {
+			if (expect_type && (prev_is_char || str[j] == '=')) {
 				expect_type = false;
 			}
 


### PR DESCRIPTION
Also, implement a small QoL change for auto-typed variables:

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/5276727/65815014-4d7ec680-e1f2-11e9-9e3f-71c29cb645ba.png) | ![image](https://user-images.githubusercontent.com/5276727/65815016-51aae400-e1f2-11e9-8a2c-065af07b6069.png) |

Preview:

| Adaptive highlighting theme with dark editor theme |
| - |
| ![image](https://user-images.githubusercontent.com/5276727/65814977-d5b09c00-e1f1-11e9-8f04-49d5ba7e7e68.png) |

| Adaptive highlighting theme with light editor theme |
| - |
| ![image](https://user-images.githubusercontent.com/5276727/65814979-da755000-e1f1-11e9-9816-13dd870bb582.png) |

| Default highlighting theme |
| - |
| ![image](https://user-images.githubusercontent.com/5276727/65814985-ebbe5c80-e1f1-11e9-99dc-678d421ae488.png) |


Closes #5739.
