### PR TITLE
Ensure object metadata is unique

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -436,7 +436,7 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 
 	} else if (p_name == CoreStringNames::get_singleton()->_meta) {
 		//set_meta(p_name,p_value);
-		metadata = p_value;
+		metadata = p_value.duplicate();
 		if (r_valid)
 			*r_valid = true;
 		return;


### PR DESCRIPTION
Closes #32415.
*Bugsquad edit:* Fixes #20648, fixes #29189.

Not sure if this is the best fix. An alternative one would be to have a boolean which is true if the metadata might be shared, and having `set_meta` duplicate the dictionary when needed.