### PR TITLE
Report explicit error when shadowing reserved keyword

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2785,8 +2785,7 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 				int var_line = tokenizer->get_token_line();
 				StringName n = tokenizer->get_token_literal();
 				if (!tokenizer->is_token_literal(0, true)) {
-
-					_set_error("Invalid variable identifier \"" + String(n) + "\".");
+					_set_error("Cannot use reserved keyword \"" + String(n) + "\" for the local variable name.");
 					return;
 				}
 				tokenizer->advance();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2783,12 +2783,12 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 
 				tokenizer->advance();
 				int var_line = tokenizer->get_token_line();
+				StringName n = tokenizer->get_token_literal();
 				if (!tokenizer->is_token_literal(0, true)) {
 
-					_set_error("Expected an identifier for the local variable name.");
+					_set_error("Invalid variable identifier \"" + String(n) + "\".");
 					return;
 				}
-				StringName n = tokenizer->get_token_literal();
 				tokenizer->advance();
 				if (current_function) {
 					for (int i = 0; i < current_function->arguments.size(); i++) {


### PR DESCRIPTION
Created as to fix  #32372 by producing an error which explicitly reports why the script isn't valid (attempt to use reserved term) and which term is the problem.

I'm not 100% certain about the wording, I don't know if there's standards to follow in this regard.