### PR TITLE
Add script class categories to EditorInspector.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1504,9 +1504,9 @@ void EditorInspector::update_tree() {
 	String subgroup_base;
 	VBoxContainer *category_vbox = nullptr;
 
-	List<PropertyInfo>
-			plist;
+	List<PropertyInfo> plist;
 	object->get_property_list(&plist, true);
+	_update_script_class_properties(*object, plist);
 
 	HashMap<String, VBoxContainer *> item_path;
 	Map<VBoxContainer *, EditorInspectorSection *> section_map;
@@ -1572,7 +1572,28 @@ void EditorInspector::update_tree() {
 			category_vbox = nullptr; //reset
 
 			String type = p.name;
-			category->icon = EditorNode::get_singleton()->get_class_icon(type, "Object");
+			if (!ClassDB::class_exists(type) && !ScriptServer::is_global_class(type) && p.hint_string.length() && FileAccess::exists(p.hint_string)) {
+				Ref<Script> s = ResourceLoader::load(p.hint_string, "Script");
+				String base_type;
+				if (s.is_valid()) {
+					base_type = s->get_instance_base_type();
+				}
+				while (s.is_valid()) {
+					StringName name = EditorNode::get_editor_data().script_class_get_name(s->get_path());
+					String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
+					if (name != StringName() && icon_path.length()) {
+						category->icon = ResourceLoader::load(icon_path, "Texture");
+						break;
+					}
+					s = s->get_base_script();
+				}
+				if (category->icon.is_null() && has_theme_icon(base_type, "EditorIcons")) {
+					category->icon = get_theme_icon(base_type, "EditorIcons");
+				}
+			}
+			if (category->icon.is_null()) {
+				category->icon = EditorNode::get_singleton()->get_class_icon(type, "Object");
+			}
 			category->label = type;
 
 			category->bg_color = get_theme_color("prop_category", "Editor");
@@ -2368,6 +2389,83 @@ String EditorInspector::get_object_class() const {
 
 void EditorInspector::_feature_profile_changed() {
 	update_tree();
+}
+
+void EditorInspector::_update_script_class_properties(const Object &p_object, List<PropertyInfo> &r_list) const {
+	Ref<Script> script = p_object.get_script();
+	if (script.is_null()) {
+		return;
+	}
+
+	List<StringName> classes;
+	Map<StringName, String> paths;
+
+	// NodeC -> NodeB -> NodeA
+	while (script.is_valid()) {
+		String n = EditorNode::get_editor_data().script_class_get_name(script->get_path());
+		if (n.length()) {
+			classes.push_front(n);
+		} else {
+			n = script->get_path().get_file();
+			classes.push_front(n);
+		}
+		paths[n] = script->get_path();
+		script = script->get_base_script();
+	}
+
+	if (classes.empty()) {
+		return;
+	}
+
+	// Script Variables -> to insert: NodeC..B..A -> bottom (insert_here)
+	List<PropertyInfo>::Element *script_variables = NULL;
+	List<PropertyInfo>::Element *bottom = NULL;
+	List<PropertyInfo>::Element *insert_here = NULL;
+	for (List<PropertyInfo>::Element *E = r_list.front(); E; E = E->next()) {
+		PropertyInfo &pi = E->get();
+		if (pi.name != "Script Variables") {
+			continue;
+		}
+		script_variables = E;
+		bottom = r_list.insert_after(script_variables, PropertyInfo());
+		insert_here = bottom;
+		break;
+	}
+
+	Set<StringName> added;
+	for (List<StringName>::Element *E = classes.front(); E; E = E->next()) {
+		StringName name = E->get();
+		String path = paths[name];
+		Ref<Script> s = ResourceLoader::load(path, "Script");
+		List<PropertyInfo> props;
+		s->get_script_property_list(&props);
+
+		// Script Variables -> NodeA -> bottom (insert_here)
+		List<PropertyInfo>::Element *category = r_list.insert_before(insert_here, PropertyInfo(Variant::NIL, name, PROPERTY_HINT_NONE, path, PROPERTY_USAGE_CATEGORY));
+
+		// Script Variables -> NodeA -> A props... -> bottom (insert_here)
+		for (List<PropertyInfo>::Element *P = props.front(); P; P = P->next()) {
+			PropertyInfo &pi = P->get();
+			if (added.has(pi.name)) {
+				continue;
+			}
+			added.insert(pi.name);
+
+			r_list.insert_before(insert_here, pi);
+		}
+
+		// Script Variables -> NodeA (insert_here) -> A props... -> bottom
+		insert_here = category;
+	}
+
+	// NodeC -> C props... -> NodeB..C..
+	r_list.erase(script_variables);
+	List<PropertyInfo>::Element *to_delete = bottom->next();
+	while (to_delete && !(to_delete->get().usage & PROPERTY_USAGE_CATEGORY)) {
+		r_list.erase(to_delete);
+		to_delete = bottom->next();
+	}
+	r_list.erase(bottom);
 }
 
 void EditorInspector::_bind_methods() {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -332,6 +332,7 @@ class EditorInspector : public ScrollContainer {
 	void _vscroll_changed(double);
 
 	void _feature_profile_changed();
+	void _update_script_class_properties(const Object &p_object, List<PropertyInfo> &r_list) const;
 
 	bool _is_property_disabled_by_feature_profile(const StringName &p_property);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3661,8 +3661,6 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 		if (icon.is_null()) {
 			icon = gui_base->get_theme_icon(ScriptServer::get_global_class_base(name), "EditorIcons");
 		}
-
-		return icon;
 	}
 
 	const Map<String, Vector<EditorData::CustomType>> &p_map = EditorNode::get_editor_data().get_custom_types();


### PR DESCRIPTION
Closes godotengine/godot-proposals#109.

There isn't an icon showing beside DerivedB, but that is a bug that is unrelated to the mentioned Issue.

![inspector_script_class_hierarchy](https://user-images.githubusercontent.com/16217563/65826891-c2cdb400-e251-11e9-9759-16cab1054510.png)

    extends Node
    class_name DerivedA
    export var health := 0
    export var can_heal := true

    extends DerivedA
    class_name DerivedB
    export var power := 0
    export var duration := 0.0
    export var superpower := @""

---

Here is an updated version that does away with the "Script Variables" section entirely and which *always* uses the script class name (if it's available) or the file name (capitalized, without spaces) so that they usually appear as a valid identifier (unless it's a filename that starts with a number or something).

In the example below, I have a  non-script-class script in between two script classes:

![inspector_script_class_hierarchy_with_files](https://user-images.githubusercontent.com/16217563/65828070-6c19a780-e25c-11e9-8a7a-da12744ef828.png)

    extends Node
    class_name DerivedA
    export var health := 0
    export var can_heal := true

    extends DerivedA
    export var power := 0
    export var duration := 0.0
    export var superpower := @""

    extends "res://derived_b.gd"
    class_name DerivedC
    export var experience := 0
    export var level := 0

---

Okay, here is the same code, but now I've changed it to show the file name and I went ahead and updated the icon rendering code so that it will fetch the most recent script class icon / base type icon PER individual script in the hierarchy.

Note that the code now anticipates that if it is a category, and the category's name does not match an existing ClassDB or ScriptServer record, AND the `hint_string` contains a valid file path, then it will attempt to load that file path as a script so that it can load the script and fetch the appropriate icon from its information.

![inspector_script_class_hierarchy_with_files_and_icons](https://user-images.githubusercontent.com/16217563/65838856-f863b300-e2cc-11e9-8b02-fb5181e262fc.png)
