### PR TITLE
Deconstruct node for Visualscript

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1353,6 +1353,8 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 		selected = ti->get_text(0);
 		function_name_edit->set_position(Input::get_singleton()->get_mouse_position() - Vector2(60, -10));
 		function_name_edit->popup();
+		function_name_box->set_text(selected);
+		function_name_box->select_all();
 	}
 }
 
@@ -1757,8 +1759,7 @@ void VisualScriptEditor::_members_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> btn = p_event;
 	if (btn.is_valid() && btn->is_doubleclick()) {
 		TreeItem *ti = members->get_selected();
-		ERR_FAIL_COND(!ti);
-		if (ti->get_parent() == members->get_root()->get_children()) // to check if it's a function
+		if (ti && ti->get_parent() == members->get_root()->get_children()) // to check if it's a function
 			_center_on_node(ti->get_metadata(0), script->get_function_node_id(ti->get_metadata(0)));
 	}
 }
@@ -4541,6 +4542,8 @@ void VisualScriptEditor::_member_option(int p_option) {
 			} else if (p_option == MEMBER_EDIT) {
 				selected = members->get_selected()->get_text(0);
 				function_name_edit->popup();
+				function_name_box->set_text(selected);
+				function_name_box->select_all();
 			}
 		} break;
 		case MEMBER_VARIABLE: {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -4075,6 +4075,14 @@ VisualScriptDeconstruct::VisualScriptDeconstruct() {
 	type = Variant::NIL;
 }
 
+template <Variant::Type T>
+static Ref<VisualScriptNode> create_node_deconst_typed(const String &p_name) {
+	Ref<VisualScriptDeconstruct> node;
+	node.instance();
+	node->set_deconstruct_type(T);
+	return node;
+}
+
 void register_visual_script_nodes() {
 
 	VisualScriptLanguage::singleton->add_register_func("data/set_variable", create_node_generic<VisualScriptVariableSet>);
@@ -4132,7 +4140,16 @@ void register_visual_script_nodes() {
 	VisualScriptLanguage::singleton->add_register_func("operators/logic/in", create_op_node<Variant::OP_IN>);
 	VisualScriptLanguage::singleton->add_register_func("operators/logic/select", create_node_generic<VisualScriptSelect>);
 
-	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct", create_node_generic<VisualScriptDeconstruct>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::VECTOR2), create_node_deconst_typed<Variant::Type::VECTOR2>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::VECTOR3), create_node_deconst_typed<Variant::Type::VECTOR3>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::COLOR), create_node_deconst_typed<Variant::Type::COLOR>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::RECT2), create_node_deconst_typed<Variant::Type::RECT2>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::TRANSFORM2D), create_node_deconst_typed<Variant::Type::TRANSFORM2D>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::PLANE), create_node_deconst_typed<Variant::Type::PLANE>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::QUAT), create_node_deconst_typed<Variant::Type::QUAT>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::AABB), create_node_deconst_typed<Variant::Type::AABB>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::BASIS), create_node_deconst_typed<Variant::Type::BASIS>);
+	VisualScriptLanguage::singleton->add_register_func("functions/deconstruct/" + Variant::get_type_name(Variant::Type::TRANSFORM), create_node_deconst_typed<Variant::Type::TRANSFORM>);
 	VisualScriptLanguage::singleton->add_register_func("functions/compose_array", create_node_generic<VisualScriptComposeArray>);
 
 	for (int i = 1; i < Variant::VARIANT_MAX; i++) {


### PR DESCRIPTION
Technically this a cosmetic patch as all the functionalities were already present just not properly exposed.
Fixes: https://github.com/godotengine/godot/issues/32420

![deconstruct](https://user-images.githubusercontent.com/19930870/65832325-9fe9e100-e2df-11e9-8c3e-3b18b18ee3b0.gif)

This works with all builtin types that can be deconstructed.

Also sneaks in the fix for the UX:https://github.com/godotengine/godot/issues/32396