### PR TITLE
Fix plugin script classes defined even if inactive.

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1411,6 +1411,9 @@ String EditorFileSystem::_get_global_script_class(const String &p_type, const St
 }
 
 void EditorFileSystem::_scan_script_classes(EditorFileSystemDirectory *p_dir) {
+	if (p_dir->parent && p_dir->parent->name == "addons" && !EditorNode::get_singleton()->is_addon_plugin_enabled(p_dir->name)) {
+		return;
+	}
 	int filecount = p_dir->files.size();
 	const EditorFileSystemDirectory::FileInfo *const *files = p_dir->files.ptr();
 	for (int i = 0; i < filecount; i++) {


### PR DESCRIPTION
Currently, script classes will always be registered no matter where they are defined in a project. This change correctly filters out scripts from being registered if they are in a plugin's subdirectory and if that plugin is inactive.