### PR TITLE
Fix theme in visual script dialogs (at startup)

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3915,6 +3915,8 @@ void VisualScriptEditor::_notification(int p_what) {
 				return;
 			}
 
+			edit_variable_edit->add_style_override("bg", get_stylebox("bg", "Tree"));
+			edit_signal_edit->add_style_override("bg", get_stylebox("bg", "Tree"));
 			func_input_scroll->add_style_override("bg", get_stylebox("bg", "Tree"));
 
 			Ref<Theme> tm = EditorNode::get_singleton()->get_theme_base()->get_theme();


### PR DESCRIPTION
At startup the Edit Variable and Edit Signals dialogs in Visual Scripts looked like this (Light theme):

![image](https://user-images.githubusercontent.com/3036176/65858631-1f72c100-e36f-11e9-93ec-f1cc060efa52.png)

now it will corrected to:

![image](https://user-images.githubusercontent.com/3036176/65858673-3a453580-e36f-11e9-92aa-37c28b8de846.png)
