### PR TITLE
Fix for running the export templates with newer emscripten versions.

### DIFF
--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -229,6 +229,7 @@ $GODOT_HEAD_INCLUDE
 
 		(function() {
 
+			const EXECUTABLE_NAME = '$GODOT_BASENAME';
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
 			const DEBUG_ENABLED = $GODOT_DEBUG_ENABLED;
 			const INDETERMINATE_STATUS_STEP_MS = 100;
@@ -380,7 +381,7 @@ $GODOT_HEAD_INCLUDE
 			} else {
 				setStatusMode('indeterminate');
 				engine.setCanvas(canvas);
-				engine.startGame(MAIN_PACK).then(() => {
+				engine.startGame(EXECUTABLE_NAME, MAIN_PACK).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -142,6 +142,7 @@ $GODOT_HEAD_INCLUDE
 
 		(function() {
 
+			const EXECUTABLE_NAME = '$GODOT_BASENAME';
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
@@ -254,7 +255,7 @@ $GODOT_HEAD_INCLUDE
 			} else {
 				setStatusMode('indeterminate');
 				engine.setCanvas(canvas);
-				engine.startGame(MAIN_PACK).then(() => {
+				engine.startGame(EXECUTABLE_NAME, MAIN_PACK).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -94,6 +94,7 @@
 			return new Promise(function(resolve, reject) {
 				rtenvProps.onRuntimeInitialized = resolve;
 				rtenvProps.onAbort = reject;
+				rtenvProps.thisProgram = executableName;
 				rtenvProps.engine.rtenv = Engine.RuntimeEnvironment(rtenvProps, LIBS);
 			});
 		}
@@ -130,13 +131,11 @@
 			);
 		};
 
-		this.startGame = function(mainPack) {
+		this.startGame = function(execName, mainPack) {
 
-			executableName = getBaseName(mainPack);
-			var mainArgs = [];
-			if (!getPathLeaf(mainPack).endsWith('.pck')) {
-				mainArgs = ['--main-pack', getPathLeaf(mainPack)];
-			}
+			executableName = execName;
+			var mainArgs = [ '--main-pack', mainPack ];
+
 			return Promise.all([
 				// Load from directory,
 				this.init(getBasePath(mainPack)),
@@ -186,8 +185,6 @@
 			}
 			this.rtenv.locale = this.rtenv.locale.split('.')[0];
 			this.rtenv.resizeCanvasOnStart = resizeCanvasOnStart;
-
-			this.rtenv.thisProgram = executableName || getBaseName(basePath);
 
 			preloadedFiles.forEach(function(file) {
 				var dir = LIBS.PATH.dirname(file.path);


### PR DESCRIPTION
The issue is pretty much that `argv[0]` gets set to `./this.program`, with the newer emscripten versions, and parameters are only added after this into the `argv` array.
(@fidli was talking about this in #32117.)

This is a really simple, no-refactor fix. I'm not familiar enough with emscripten yet to be able to make a more roboust solution, but at the very least it shows where the actual problem is.

By the way I found https://github.com/emscripten-core/emscripten/issues/2431.
This is exactly the same thing, maybe they reintroduced this?

I've tested this with both the `1.38.27`, and `master` emsdk.

fixes #32117
fixes #32422