### PR TITLE
modifier actions will shadow simple actions if flag=false (fix #18793)

### DIFF
--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -225,6 +225,7 @@ class InputEventWithModifiers : public InputEvent {
 	bool meta; //< windows/mac key
 
 #endif
+	bool action_pressed_on_modifier;
 
 protected:
 	static void _bind_methods();
@@ -244,6 +245,12 @@ public:
 
 	void set_command(bool p_enabled);
 	bool get_command() const;
+
+	void set_action_pressed_on_modifier(bool p_enabled);
+	bool is_action_pressed_on_modifier() const;
+
+	bool has_modifiers() const;
+	virtual String as_text() const;
 
 	void set_modifiers_from_event(const InputEventWithModifiers *event);
 


### PR DESCRIPTION
It will keep the current input behavior, if needed `is_action_pressed_on_modifier=false` can be set.
(also improved `as_text()` for modifiers)

Test script:
```
extends Control

const is_action_pressed_on_modifier = 0

func _ready():
	add_key("Save", get_combo([KEY_CONTROL], KEY_S))
	add_key("Select S", get_keyboard_event(KEY_S), is_action_pressed_on_modifier)
	
	add_key("Run", get_keyboard_event(KEY_SHIFT))
	add_key("Jump", get_keyboard_event(KEY_SPACE), is_action_pressed_on_modifier)
	add_key("Super Jump", get_combo([KEY_SHIFT], KEY_SPACE))

func get_combo(modifiers, key):
	var new_event = InputEventKey.new()
	new_event.scancode = key
	
	for m in modifiers:
		if typeof(m)==TYPE_INT:
			if m==KEY_ALT:
				new_event.set_alt(true)
			if m==KEY_SHIFT:
				new_event.set_shift(true)
			if m==KEY_CONTROL:
				new_event.set_control(true)
			if m==KEY_META:
				new_event.set_meta(true)
			if m==KEY_MASK_CMD:
				new_event.set_command(true)
	
	return new_event

func get_keyboard_event(key):
	var new_event = InputEventKey.new()
	new_event.scancode = key
	return new_event

func add_key(action, key_event, _is_action_pressed_on_modifier=true):
	key_event.set_action_pressed_on_modifier(_is_action_pressed_on_modifier)
	
	if !InputMap.has_action(action):
		InputMap.add_action(action)
		
	InputMap.action_add_event(action, key_event)

func _input(event):
	if(Input.is_action_just_pressed("Save")):
		print("Save")
	if(Input.is_action_just_pressed("Select S")):
		print("Select S")
	
	if(Input.is_action_just_pressed("Run")):
		print("Run")
	if(Input.is_action_just_pressed("Jump")):
		print("Jump")
	if(Input.is_action_just_pressed("Super Jump")):
		print("Super Jump")

```

*Bugsquad edit:* Fixes #18793.