### PR TITLE
Added sampler port type for visual shaders

### DIFF
--- a/doc/classes/VisualShaderNode.xml
+++ b/doc/classes/VisualShaderNode.xml
@@ -51,8 +51,11 @@
 		<constant name="PORT_TYPE_TRANSFORM" value="3" enum="PortType">
 			Transform type. Translated to [code]mat4[/code] type in shader code.
 		</constant>
-		<constant name="PORT_TYPE_ICON_COLOR" value="4" enum="PortType">
-			Color type. Can be used for return icon type in members dialog (see [method VisualShaderNodeCustom._get_return_icon_type]) - do not use it in other cases!
+		<constant name="PORT_TYPE_SAMPLER" value="4" enum="PortType">
+			Sampler type. Translated to reference of sampler uniform in shader code. Can only be used for input ports in non-uniform nodes.
+		</constant>
+		<constant name="PORT_TYPE_MAX" value="5" enum="PortType">
+			Represents the size of the [enum PortType] enum.
 		</constant>
 	</constants>
 </class>

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -122,7 +122,8 @@ void VisualShaderNode::_bind_methods() {
 	BIND_ENUM_CONSTANT(PORT_TYPE_VECTOR);
 	BIND_ENUM_CONSTANT(PORT_TYPE_BOOLEAN);
 	BIND_ENUM_CONSTANT(PORT_TYPE_TRANSFORM);
-	BIND_ENUM_CONSTANT(PORT_TYPE_ICON_COLOR);
+	BIND_ENUM_CONSTANT(PORT_TYPE_SAMPLER);
+	BIND_ENUM_CONSTANT(PORT_TYPE_MAX);
 }
 
 VisualShaderNode::VisualShaderNode() {
@@ -1058,7 +1059,15 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 
 			String src_var = "n_out" + itos(from_node) + "p" + itos(from_port);
 
-			if (in_type == out_type) {
+			if (in_type == VisualShaderNode::PORT_TYPE_SAMPLER && out_type == VisualShaderNode::PORT_TYPE_SAMPLER) {
+
+				VisualShaderNodeUniform *uniform = (VisualShaderNodeUniform *)graph[type].nodes[from_node].node.ptr();
+				if (uniform) {
+					inputs[i] = uniform->get_uniform_name();
+				} else {
+					inputs[i] = "";
+				}
+			} else if (in_type == out_type) {
 				inputs[i] = src_var;
 			} else if (in_type == VisualShaderNode::PORT_TYPE_SCALAR && out_type == VisualShaderNode::PORT_TYPE_VECTOR) {
 				inputs[i] = "dot(" + src_var + ",vec3(0.333333,0.333333,0.333333))";
@@ -2207,7 +2216,7 @@ void VisualShaderNodeGroupBase::clear_output_ports() {
 void VisualShaderNodeGroupBase::set_input_port_type(int p_id, int p_type) {
 
 	ERR_FAIL_COND(!has_input_port(p_id));
-	ERR_FAIL_COND(p_type < 0 || p_type > PORT_TYPE_TRANSFORM);
+	ERR_FAIL_COND(p_type < 0 || p_type >= PORT_TYPE_MAX);
 
 	if (input_ports[p_id].type == p_type)
 		return;
@@ -2273,7 +2282,7 @@ String VisualShaderNodeGroupBase::get_input_port_name(int p_id) const {
 void VisualShaderNodeGroupBase::set_output_port_type(int p_id, int p_type) {
 
 	ERR_FAIL_COND(!has_output_port(p_id));
-	ERR_FAIL_COND(p_type < 0 || p_type > PORT_TYPE_TRANSFORM);
+	ERR_FAIL_COND(p_type < 0 || p_type >= PORT_TYPE_MAX);
 
 	if (output_ports[p_id].type == p_type)
 		return;

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -184,7 +184,8 @@ public:
 		PORT_TYPE_VECTOR,
 		PORT_TYPE_BOOLEAN,
 		PORT_TYPE_TRANSFORM,
-		PORT_TYPE_ICON_COLOR // just a hint for node tree icons, do not use it as actual port type !
+		PORT_TYPE_SAMPLER,
+		PORT_TYPE_MAX,
 	};
 
 	virtual String get_caption() const = 0;

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -361,15 +361,35 @@ String VisualShaderNodeTexture::get_caption() const {
 }
 
 int VisualShaderNodeTexture::get_input_port_count() const {
-	return 2;
+	return 3;
 }
 
 VisualShaderNodeTexture::PortType VisualShaderNodeTexture::get_input_port_type(int p_port) const {
-	return p_port == 0 ? PORT_TYPE_VECTOR : PORT_TYPE_SCALAR;
+
+	switch (p_port) {
+		case 0:
+			return PORT_TYPE_VECTOR;
+		case 1:
+			return PORT_TYPE_SCALAR;
+		case 2:
+			return PORT_TYPE_SAMPLER;
+		default:
+			return PORT_TYPE_SCALAR;
+	}
 }
 
 String VisualShaderNodeTexture::get_input_port_name(int p_port) const {
-	return p_port == 0 ? "uv" : "lod";
+
+	switch (p_port) {
+		case 0:
+			return "uv";
+		case 1:
+			return "lod";
+		case 2:
+			return "sampler";
+		default:
+			return "";
+	}
 }
 
 int VisualShaderNodeTexture::get_output_port_count() const {
@@ -437,6 +457,29 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 		code += "\t" + p_output_vars[0] + " = " + id + "_read.rgb;\n";
 		code += "\t" + p_output_vars[1] + " = " + id + "_read.a;\n";
+		return code;
+	}
+
+	if (source == SOURCE_PORT) {
+		String id = p_input_vars[2];
+		String code;
+		if (id == String()) {
+			code += "\tvec4 " + id + "_tex_read = vec4(0.0);\n";
+		} else {
+			if (p_input_vars[0] == String()) { //none bound, do nothing
+
+				code += "\tvec4 " + id + "_tex_read = vec4(0.0);\n";
+
+			} else if (p_input_vars[1] == String()) {
+				//no lod
+				code += "\tvec4 " + id + "_tex_read = texture( " + id + " , " + p_input_vars[0] + ".xy );\n";
+			} else {
+				code += "\tvec4 " + id + "_tex_read = textureLod( " + id + " , " + p_input_vars[0] + ".xy , " + p_input_vars[1] + " );\n";
+			}
+
+			code += "\t" + p_output_vars[0] + " = " + id + "_tex_read.rgb;\n";
+			code += "\t" + p_output_vars[1] + " = " + id + "_tex_read.a;\n";
+		}
 		return code;
 	}
 
@@ -588,6 +631,10 @@ String VisualShaderNodeTexture::get_warning(Shader::Mode p_mode, VisualShader::T
 		return String(); // all good
 	}
 
+	if (source == SOURCE_PORT) {
+		return String(); // all good
+	}
+
 	if (source == SOURCE_SCREEN && (p_mode == Shader::MODE_SPATIAL || p_mode == Shader::MODE_CANVAS_ITEM) && p_type == VisualShader::TYPE_FRAGMENT) {
 
 		return String(); // all good
@@ -625,7 +672,7 @@ void VisualShaderNodeTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_type", "value"), &VisualShaderNodeTexture::set_texture_type);
 	ClassDB::bind_method(D_METHOD("get_texture_type"), &VisualShaderNodeTexture::get_texture_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "source", PROPERTY_HINT_ENUM, "Texture,Screen,Texture2D,NormalMap2D,Depth"), "set_source", "get_source");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "source", PROPERTY_HINT_ENUM, "Texture,Screen,Texture2D,NormalMap2D,Depth,SamplerPort"), "set_source", "get_source");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_type", PROPERTY_HINT_ENUM, "Data,Color,Normalmap"), "set_texture_type", "get_texture_type");
 
@@ -3023,15 +3070,35 @@ String VisualShaderNodeTextureUniform::get_input_port_name(int p_port) const {
 }
 
 int VisualShaderNodeTextureUniform::get_output_port_count() const {
-	return 2;
+	return 3;
 }
 
 VisualShaderNodeTextureUniform::PortType VisualShaderNodeTextureUniform::get_output_port_type(int p_port) const {
-	return p_port == 0 ? PORT_TYPE_VECTOR : PORT_TYPE_SCALAR;
+
+	switch (p_port) {
+		case 0:
+			return PORT_TYPE_VECTOR;
+		case 1:
+			return PORT_TYPE_SCALAR;
+		case 2:
+			return PORT_TYPE_SAMPLER;
+		default:
+			return PORT_TYPE_SCALAR;
+	}
 }
 
 String VisualShaderNodeTextureUniform::get_output_port_name(int p_port) const {
-	return p_port == 0 ? "rgb" : "alpha";
+
+	switch (p_port) {
+		case 0:
+			return "rgb";
+		case 1:
+			return "alpha";
+		case 2:
+			return "sampler";
+		default:
+			return "";
+	}
 }
 
 String VisualShaderNodeTextureUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -199,7 +199,8 @@ public:
 		SOURCE_SCREEN,
 		SOURCE_2D_TEXTURE,
 		SOURCE_2D_NORMAL,
-		SOURCE_DEPTH
+		SOURCE_DEPTH,
+		SOURCE_PORT,
 	};
 
 	enum TextureType {


### PR DESCRIPTION
Attempt to fulfill feature proposal - https://github.com/godotengine/godot-proposals/issues/73

This added a sampler port type: PORT_TYPE_SAMPLER (this can only be connected to other samplers), added output port "sampler" to TextureUniform and input port "sampler" to Texture nodes. New texture source mode "SamplerPort" will be used to get the sampler reference from that port.

![image](https://user-images.githubusercontent.com/3036176/65948454-f885bf00-e442-11e9-8e21-bb794a40bbe5.png)

They can be used in expression nodes (as input port type only):

![image](https://user-images.githubusercontent.com/3036176/65948232-857c4880-e442-11e9-9ff7-2b626a00d787.png)

Should work with Custom Nodes

![image](https://user-images.githubusercontent.com/3036176/65956224-8e751600-e452-11e9-9d5b-c6bce5cf4f02.png)
