### PR TITLE
Fix casting to uint64_t when returning unix system time

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -187,7 +187,7 @@ uint64_t OS_Unix::get_system_time_secs() const {
 uint64_t OS_Unix::get_system_time_msecs() const {
 	struct timeval tv_now;
 	gettimeofday(&tv_now, NULL);
-	return uint64_t(tv_now.tv_sec * 1000 + tv_now.tv_usec / 1000);
+	return uint64_t(tv_now.tv_sec) * 1000 + uint64_t(tv_now.tv_usec) / 1000;
 }
 
 OS::Date OS_Unix::get_date(bool utc) const {


### PR DESCRIPTION
Closes #32376.

When compiling with emscripten the time is defined as 32bit long, causing an overflow with the previous cast leading to an invalid value for system time when exporting to html5.

Tested with Firefox using the test script from #32376:
Before:
![2019-10-01-115722_147x92_scrot](https://user-images.githubusercontent.com/18357657/65952847-0cc9bc00-e443-11e9-8f21-818540246351.png)

After:
![2019-10-01-114637_154x98_scrot](https://user-images.githubusercontent.com/18357657/65952843-0afff880-e443-11e9-8499-5087773dc10e.png)