### PR TITLE
Fix GridContainer children visibility check for min size evaluation

### DIFF
--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -210,7 +210,7 @@ Size2 GridContainer::get_minimum_size() const {
 	for (int i = 0; i < get_child_count(); i++) {
 
 		Control *c = Object::cast_to<Control>(get_child(i));
-		if (!c || !c->is_visible_in_tree())
+		if (!c || !c->is_visible())
 			continue;
 		int row = valid_controls_index / columns;
 		int col = valid_controls_index % columns;


### PR DESCRIPTION
Fixed:
- `GridContainer` children visibility check for evaluation of minimum size changed from `is_visible_inside_tree()` to `is_visible()`

Makes check for visibility consistent with `BoxContainer`. Also allows `TabsContainer`'s new feature `use_hidden_tabs_for_min_size` to work properly with `GridContainer`.
Without this patch `TabsContainer` can't get `GridContainer`'s minimum size while tab is hidden.

Closes #32466