### PR TITLE
Make Rect2.encloses return true on same size

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -99,8 +99,8 @@ struct Rect2 {
 	inline bool encloses(const Rect2 &p_rect) const {
 
 		return (p_rect.position.x >= position.x) && (p_rect.position.y >= position.y) &&
-			   ((p_rect.position.x + p_rect.size.x) < (position.x + size.x)) &&
-			   ((p_rect.position.y + p_rect.size.y) < (position.y + size.y));
+			   ((p_rect.position.x + p_rect.size.x) <= (position.x + size.x)) &&
+			   ((p_rect.position.y + p_rect.size.y) <= (position.y + size.y));
 	}
 
 	_FORCE_INLINE_ bool has_no_area() const {


### PR DESCRIPTION
fix #26615

```
func _ready():
	assert(Rect2(0,0,0,0).encloses(Rect2(0,0,0,0)))
	assert(Rect2(0,0,2,2).encloses(Rect2(0,0,2,2)))
	assert(Rect2(0,0,2,2).encloses(Rect2(1,1,1,1)))
	assert(Rect2(0,0,2,2).encloses(Rect2(1,1,0.9,0.9)))
```