### PR TITLE
Fix SceneState instancing crash with NULL root node

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -292,6 +292,8 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 				if (owner)
 					node->_set_owner_nocheck(owner);
 			}
+		} else if (i == 0) {
+			ERR_FAIL_COND_V(!node, NULL);
 		}
 
 		ret_nodes[i] = node;


### PR DESCRIPTION
Fixed:
- `SceneState::instance()` no longer crashes on `NULL` pointer dereference when instanced scene is completely invalid.

Fixes one of the crashes from #26394 (https://github.com/godotengine/godot/issues/26394#issuecomment-470525673). This patch just prevents the crash, but there is still alert rises in editor, so it doesn't actually closes the issue.