### PR TITLE
IP: Fix build error on UWP

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -152,7 +152,7 @@ void IP_Unix::get_local_interfaces(Map<String, Interface_Info> *r_interfaces) co
 			Interface_Info info;
 			info.name = name;
 			info.name_friendly = hostname->DisplayName->Data();
-			info.index = 0;
+			info.index = String::num_uint64(0);
 			E = r_interfaces->insert(name, info);
 			ERR_CONTINUE(!E);
 		}


### PR DESCRIPTION
Fixes this error:
```
drivers\unix\ip_unix.cpp(155): error C2593: 'operator =' is ambiguous
.\core/ustring.h(177): note: could be 'void String::operator =(const CharType *)'
.\core/ustring.h(176): note: or       'void String::operator =(const char *)'
drivers\unix\ip_unix.cpp(155): note: while trying to match the argument list '(String, int)'
```

I guess I could have used `"0"` directly, but I just used the same method as in other `index` assignments.