### PR TITLE
macOS export/code signing improvements.

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -133,7 +133,9 @@ void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) 
 
 #ifdef OSX_ENABLED
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/identity"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/entitlements"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/timestamp"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/hardened_runtime"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/entitlements", PROPERTY_HINT_GLOBAL_FILE, "*.plist"), ""));
 #endif
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/s3tc"), true));
@@ -360,9 +362,17 @@ void EditorExportPlatformOSX::_fix_plist(const Ref<EditorExportPreset> &p_preset
 Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path) {
 	List<String> args;
 
+	if (p_preset->get("codesign/timestamp")) {
+		args.push_back("--timestamp");
+	}
+	if (p_preset->get("codesign/hardened_runtime")) {
+		args.push_back("--options");
+		args.push_back("runtime");
+	}
+
 	if (p_preset->get("codesign/entitlements") != "") {
 		/* this should point to our entitlements.plist file that sandboxes our application, I don't know if this should also be placed in our app bundle */
-		args.push_back("-entitlements");
+		args.push_back("--entitlements");
 		args.push_back(p_preset->get("codesign/entitlements"));
 	}
 	args.push_back("-s");
@@ -379,6 +389,10 @@ Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_prese
 		EditorNode::add_io_error("codesign: no identity found");
 		return FAILED;
 	}
+	if ((str.find("unrecognized blob type") != -1) || (str.find("cannot read entitlement data") != -1)) {
+		EditorNode::add_io_error("codesign: invalid entitlements file");
+		return FAILED;
+	}
 
 	return OK;
 }
@@ -386,7 +400,9 @@ Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_prese
 Error EditorExportPlatformOSX::_create_dmg(const String &p_dmg_path, const String &p_pkg_name, const String &p_app_path_name) {
 	List<String> args;
 
-	OS::get_singleton()->move_to_trash(p_dmg_path);
+	if (FileAccess::exists(p_dmg_path)) {
+		OS::get_singleton()->move_to_trash(p_dmg_path);
+	}
 
 	args.push_back("create");
 	args.push_back(p_dmg_path);
@@ -671,19 +687,6 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 				err = _code_sign(p_preset, tmp_app_path_name + "/Contents/MacOS/" + pkg_name);
 
 				///@TODO we should check the contents of /Contents/Frameworks for frameworks to sign
-			}
-
-			if (err == OK && identity != "") {
-				// we should probably loop through all resources and sign them?
-				err = _code_sign(p_preset, tmp_app_path_name + "/Contents/Resources/icon.icns");
-			}
-
-			if (err == OK && identity != "") {
-				err = _code_sign(p_preset, pack_path);
-			}
-
-			if (err == OK && identity != "") {
-				err = _code_sign(p_preset, tmp_app_path_name + "/Contents/Info.plist");
 			}
 
 			// and finally create a DMG


### PR DESCRIPTION
Some macOS export/code signing improvements:

* Added `timestamp` and `hardened runtime` options (these options will be required for App Store distribution / [Notarization](https://developer.apple.com/documentation/xcode/notarizing_your_app_before_distribution) on macOS 10.15).
* Added `PROPERTY_HINT_GLOBAL_FILE` property hint for `entitlements.plist` file selection.
* Removed excessive `codesign` calls (we need to sign only frameworks (gdnative libs) and executable, associated resources are signed automatically).
* Suppressed "file not found" error on first export (exporter was trying to delete old `*.dmg` file, even if it doesn't exist).