### PR TITLE
Drag&drop custom nodes from filesystem to visual shader

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -149,13 +149,14 @@ class VisualShaderEditor : public VBoxContainer {
 
 	Vector<AddOption> add_options;
 	int texture_node_option_idx;
+	int custom_node_option_idx;
 	List<String> keyword_list;
 
 	void _draw_color_over_button(Object *obj, Color p_color);
 
+	void _add_custom_node(const String &p_path);
 	void _add_texture_node(const String &p_path);
 	VisualShaderNode *_add_node(int p_idx, int p_op_idx = -1);
-	void _update_custom_nodes();
 	void _update_options_menu();
 
 	void _show_preview_text();
@@ -255,6 +256,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	void update_custom_nodes();
 	void add_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
 	void remove_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
 


### PR DESCRIPTION
And better loading of custom nodes - no need to restart the editor to add them to graph tree - scene must be reloaded to apply tool scripts - after next focus of visual shader graph the changes will be applied

Drag and drop is simple:

![dragdrop](https://user-images.githubusercontent.com/3036176/66079273-67ab0280-e56c-11e9-8762-ac2248229fb4.gif)
