### PR TITLE
Fix crash in #32473. (Automatically seek timeline in selected animation)

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1077,10 +1077,14 @@ void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag)
 
 	if (!is_visible_in_tree())
 		return;
+
 	if (!player)
 		return;
 
 	if (player->is_playing())
+		return;
+
+	if (!player->has_animation(player->get_assigned_animation()))
 		return;
 
 	Ref<Animation> anim = player->get_animation(player->get_assigned_animation());


### PR DESCRIPTION
After #32473 the editor will crash, if you select an empty animation player. 
E.g. if you add an animation player into the scene via the add node menu, or when you delete all animations.

This pr fixes that crash.

Edit: 
For reference (I'm sorry i shoud've added this when creating the pr).
in `void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag)`
execution will get here `frame->set_value(Math::stepify(p_pos, _get_editor_step()));` 

it will go into ` _get_editor_step()`, and it willl crash at this line:
`return Input::get_singleton()->is_key_pressed(KEY_SHIFT) ? anim->get_step() * 0.25 : anim->get_step();` 
at the first `anim->get_step()`, because anim here will be an invalid reference. (If no anim is selected.)

(Also it will trip an `ERR_FAIL_COND` earlier. twice.)