### PR TITLE
Remove cursor from cache when set to default

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1974,6 +1974,7 @@ void OS_OSX::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 	} else {
 		// Reset to default system cursor
 		cursors[p_shape] = NULL;
+		cursors_cache.erase(p_shape);
 
 		CursorShape c = cursor_shape;
 		cursor_shape = CURSOR_MAX;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2486,6 +2486,7 @@ void OS_Windows::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shap
 	} else {
 		// Reset to default system cursor
 		cursors[p_shape] = NULL;
+		cursors_cache.erase(p_shape);
 
 		CursorShape c = cursor_shape;
 		cursor_shape = CURSOR_MAX;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2992,6 +2992,7 @@ void OS_X11::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 		if (img[p_shape]) {
 			cursors[p_shape] = XcursorImageLoadCursor(x11_display, img[p_shape]);
 		}
+		cursors_cache.erase(p_shape);
 
 		CursorShape c = current_cursor;
 		current_cursor = CURSOR_MAX;


### PR DESCRIPTION
Fixes #32486

The cache doesn't seem to hold information necessary to set the cursor, so removing it makes sense in this case.