### PR TITLE
Add setting to override the canvas editor's viewport size

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -399,6 +399,14 @@
 		<member name="display/window/size/borderless" type="bool" setter="" getter="" default="false">
 			Force the window to be borderless.
 		</member>
+		<member name="display/window/size/canvas_editor_height" type="int" setter="" getter="" default="0">
+			Overrides the canvas editor's viewport height with this instead of the window height.
+			Useful when the game's resolution is bigger than the initial window size.
+		</member>
+		<member name="display/window/size/canvas_editor_width" type="int" setter="" getter="" default="0">
+			Overrides the canvas editor's viewport width with this instead of the window width.
+			Useful when the game's resolution is bigger than the initial window size.
+		</member>
 		<member name="display/window/size/fullscreen" type="bool" setter="" getter="" default="false">
 			Sets the window to full screen when it starts.
 		</member>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -298,7 +298,13 @@ void EditorNode::_notification(int p_what) {
 
 			editor_selection->update();
 
-			scene_root->set_size_override(true, Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height")));
+			Size2 override_rect;
+			if ((int)ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_width") > 0 && (int)ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_height") > 0) {
+				override_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_width"), ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_height"));
+			} else {
+				override_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+			}
+			scene_root->set_size_override(true, override_rect);
 
 			ResourceImporterTexture::get_singleton()->update_imports();
 		} break;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3191,7 +3191,12 @@ void CanvasItemEditor::_draw_axis() {
 
 		Color area_axis_color = EditorSettings::get_singleton()->get("editors/2d/viewport_border_color");
 
-		Size2 screen_size = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+		Size2 screen_size;
+		if ((int)ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_width") > 0 && (int)ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_height") > 0) {
+			screen_size = Size2(ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_width"), ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_height"));
+		} else {
+			screen_size = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+		}
 
 		Vector2 screen_endpoints[4] = {
 			transform.xform(Vector2(0, 0)),
@@ -3835,7 +3840,12 @@ void CanvasItemEditor::_update_scrollbars() {
 	h_scroll->set_end(Point2(size.width - vmin.width, size.height));
 
 	// Get the visible frame
-	Size2 screen_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+	Size2 screen_rect;
+	if ((int)ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_width") > 0 && (int)ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_height") > 0) {
+		screen_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_width"), ProjectSettings::get_singleton()->get("display/window/size/canvas_editor_height"));
+	} else {
+		screen_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+	}
 	Rect2 local_rect = Rect2(Point2(), viewport->get_size() - Size2(vmin.width, hmin.height));
 
 	_queue_update_bone_list();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -974,6 +974,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_width", PropertyInfo(Variant::INT, "display/window/size/test_width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
 	GLOBAL_DEF("display/window/size/test_height", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_height", PropertyInfo(Variant::INT, "display/window/size/test_height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/canvas_editor_width", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/canvas_editor_width", PropertyInfo(Variant::INT, "display/window/size/canvas_editor_width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/canvas_editor_height", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/canvas_editor_height", PropertyInfo(Variant::INT, "display/window/size/canvas_editor_height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
 
 	if (use_custom_res) {
 


### PR DESCRIPTION
This commit adds a setting that overrides the canvas editor's "viewport" size.

The canvas editor has the feature of having viewport guides, which are taken from the project settings' `window/*` values. It's indispensable when positioning your GUI elements, and even 2D elements as well, but there's one problem: It's always set to the window size.

If you're working with a in-game resolution that's bigger than the initial window size (e. g. working in game with 4K resolution sprites, but setting the window size smaller, so players with smaller resolutions don't have their whole screen taken all of the sudden), you'll have to resort to setting all of your assets' scale to a lower value to work within the guides, which becomes even more bothersome when working with animations that edit it.

The new settings are added below the `window/test_*` settings, and are called `canvas_editor_width` and `canvas_editor_height`. If anyone has a better suggestion as to where to put them or how they should be called, just say it.