### PR TITLE
Remove glViewport call as it wasnt needed and caused crash GLES2

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4887,7 +4887,6 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 				}
 
 				glClearColor(1.0, 0.0, 1.0, 0.0);
-				glViewport(0, 0, rt->mip_maps[i].sizes[j].width, rt->mip_maps[i].sizes[j].height);
 				glClear(GL_COLOR_BUFFER_BIT);
 				if (used_depth) {
 					glClearDepth(1.0);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/32465

The editor appeared black because it wasnt able to render to needed parts of a texture used in the editor I guess. Still can't figure out what caused the crash, but it goes away with this PR soooo... thats good I guess.

This is a great wake up call that I need to go through all the GLES2 code and make sure that OpenGL state is being set properly and intentionally throughout. This glViewport call shouldn't have been an issue, but it was because at some point the renderer relies on glViewport not changing at any point. Every render operation should be responsible for making sure the OpenGL state is set properly beforehand. it shouldnt rely on the state having been set previously in some other operation. 

CC @Anutrix, @zaksnet Please try out this fix on your machines and let me know if the crash persists. 