### PR TITLE
Makes Texture and TextureUniform in visual shaders to use UV by default

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -665,6 +665,15 @@ void VisualShaderEditor::_update_graph() {
 						label->set_text(name_left);
 						label->add_style_override("normal", label_style); //more compact
 						hb->add_child(label);
+
+						if (vsnode->get_input_port_default_hint(i) != "" && !port_left_used) {
+
+							Label *hint_label = memnew(Label);
+							hint_label->set_text("[" + vsnode->get_input_port_default_hint(i) + "]");
+							hint_label->add_color_override("font_color", get_color("font_color_readonly", "TextEdit"));
+							hint_label->add_style_override("normal", label_style);
+							hb->add_child(hint_label);
+						}
 					}
 				}
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -103,6 +103,10 @@ String VisualShaderNode::get_warning(Shader::Mode p_mode, VisualShader::Type p_t
 	return String();
 }
 
+String VisualShaderNode::get_input_port_default_hint(int p_port) const {
+	return "";
+}
+
 void VisualShaderNode::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_output_port_for_preview", "port"), &VisualShaderNode::set_output_port_for_preview);

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -201,6 +201,8 @@ public:
 	virtual PortType get_output_port_type(int p_port) const = 0;
 	virtual String get_output_port_name(int p_port) const = 0;
 
+	virtual String get_input_port_default_hint(int p_port) const;
+
 	void set_output_port_for_preview(int p_index);
 	int get_output_port_for_preview() const;
 

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -408,6 +408,13 @@ String VisualShaderNodeTexture::get_output_port_name(int p_port) const {
 	return p_port == 0 ? "rgb" : "alpha";
 }
 
+String VisualShaderNodeTexture::get_input_port_default_hint(int p_port) const {
+	if (p_port == 0) {
+		return "UV.xy";
+	}
+	return "";
+}
+
 static String make_unique_id(VisualShader::Type p_type, int p_id, const String &p_name) {
 
 	static const char *typepf[VisualShader::TYPE_MAX] = { "vtx", "frg", "lgt" };
@@ -444,10 +451,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	if (source == SOURCE_TEXTURE) {
 		String id = make_unique_id(p_type, p_id, "tex");
 		String code;
-		if (p_input_vars[0] == String()) { //none bound, do nothing
+		if (p_input_vars[0] == String()) { // Use UV by default.
 
-			code += "\tvec4 " + id + "_read = vec4(0.0);\n";
-
+			code += "\tvec4 " + id + "_read = texture( " + id + " , UV.xy );\n";
 		} else if (p_input_vars[1] == String()) {
 			//no lod
 			code += "\tvec4 " + id + "_read = texture( " + id + " , " + p_input_vars[0] + ".xy );\n";
@@ -466,9 +472,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 		if (id == String()) {
 			code += "\tvec4 " + id + "_tex_read = vec4(0.0);\n";
 		} else {
-			if (p_input_vars[0] == String()) { //none bound, do nothing
+			if (p_input_vars[0] == String()) { // Use UV by default.
 
-				code += "\tvec4 " + id + "_tex_read = vec4(0.0);\n";
+				code += "\tvec4 " + id + "_tex_read = texture( " + id + " , UV.xy );\n";
 
 			} else if (p_input_vars[1] == String()) {
 				//no lod
@@ -486,9 +492,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	if (source == SOURCE_SCREEN && (p_mode == Shader::MODE_SPATIAL || p_mode == Shader::MODE_CANVAS_ITEM) && p_type == VisualShader::TYPE_FRAGMENT) {
 
 		String code = "\t{\n";
-		if (p_input_vars[0] == String() || p_for_preview) { //none bound, do nothing
+		if (p_input_vars[0] == String() || p_for_preview) { // Use UV by default.
 
-			code += "\t\tvec4 _tex_read = vec4(0.0);\n";
+			code += "\t\tvec4 _tex_read = textureLod( SCREEN_TEXTURE , UV.xy, 0.0 );\n";
 
 		} else if (p_input_vars[1] == String()) {
 			//no lod
@@ -506,9 +512,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	if (source == SOURCE_2D_TEXTURE && p_mode == Shader::MODE_CANVAS_ITEM && p_type == VisualShader::TYPE_FRAGMENT) {
 
 		String code = "\t{\n";
-		if (p_input_vars[0] == String()) { //none bound, do nothing
+		if (p_input_vars[0] == String()) { // Use UV by default.
 
-			code += "\t\tvec4 _tex_read = vec4(0.0);\n";
+			code += "\t\tvec4 _tex_read = texture( TEXTURE , UV.xy );\n";
 
 		} else if (p_input_vars[1] == String()) {
 			//no lod
@@ -526,9 +532,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	if (source == SOURCE_2D_NORMAL && p_mode == Shader::MODE_CANVAS_ITEM && p_type == VisualShader::TYPE_FRAGMENT) {
 
 		String code = "\t{\n";
-		if (p_input_vars[0] == String()) { //none bound, do nothing
+		if (p_input_vars[0] == String()) { // Use UV by default.
 
-			code += "\t\tvec4 _tex_read = vec4(0.0);\n";
+			code += "\t\tvec4 _tex_read = texture( NORMAL_TEXTURE , UV.xy );\n";
 
 		} else if (p_input_vars[1] == String()) {
 			//no lod
@@ -556,9 +562,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	if (source == SOURCE_DEPTH && p_mode == Shader::MODE_SPATIAL && p_type == VisualShader::TYPE_FRAGMENT) {
 
 		String code = "\t{\n";
-		if (p_input_vars[0] == String()) { //none bound, do nothing
+		if (p_input_vars[0] == String()) { // Use UV by default.
 
-			code += "\t\tfloat _depth = 0.0;\n";
+			code += "\t\tfloat _depth = texture( DEPTH_TEXTURE , UV.xy ).r;\n";
 
 		} else if (p_input_vars[1] == String()) {
 			//no lod
@@ -3128,9 +3134,9 @@ String VisualShaderNodeTextureUniform::generate_code(Shader::Mode p_mode, Visual
 
 	String id = get_uniform_name();
 	String code = "\t{\n";
-	if (p_input_vars[0] == String()) { //none bound, do nothing
+	if (p_input_vars[0] == String()) { // Use UV by default.
 
-		code += "\t\tvec4 n_tex_read = vec4(0.0);\n";
+		code += "\t\tvec4 n_tex_read = texture( " + id + " , UV.xy );\n";
 	} else if (p_input_vars[1] == String()) {
 		//no lod
 		code += "\t\tvec4 n_tex_read = texture( " + id + " , " + p_input_vars[0] + ".xy );\n";
@@ -3187,6 +3193,13 @@ void VisualShaderNodeTextureUniform::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(COLOR_DEFAULT_WHITE);
 	BIND_ENUM_CONSTANT(COLOR_DEFAULT_BLACK);
+}
+
+String VisualShaderNodeTextureUniform::get_input_port_default_hint(int p_port) const {
+	if (p_port == 0) {
+		return "UV.xy";
+	}
+	return "";
 }
 
 VisualShaderNodeTextureUniform::VisualShaderNodeTextureUniform() {
@@ -3281,6 +3294,15 @@ String VisualShaderNodeTextureUniformTriplanar::generate_code(Shader::Mode p_mod
 	code += "\t}\n";
 
 	return code;
+}
+
+String VisualShaderNodeTextureUniformTriplanar::get_input_port_default_hint(int p_port) const {
+	if (p_port == 0) {
+		return "default";
+	} else if (p_port == 1) {
+		return "default";
+	}
+	return "";
 }
 
 VisualShaderNodeTextureUniformTriplanar::VisualShaderNodeTextureUniformTriplanar() {

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -227,6 +227,8 @@ public:
 	virtual PortType get_output_port_type(int p_port) const;
 	virtual String get_output_port_name(int p_port) const;
 
+	virtual String get_input_port_default_hint(int p_port) const;
+
 	virtual Vector<VisualShader::DefaultTextureParam> get_default_texture_parameters(VisualShader::Type p_type, int p_id) const;
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
@@ -1423,6 +1425,7 @@ public:
 	virtual int get_input_port_count() const;
 	virtual PortType get_input_port_type(int p_port) const;
 	virtual String get_input_port_name(int p_port) const;
+	virtual String get_input_port_default_hint(int p_port) const;
 
 	virtual int get_output_port_count() const;
 	virtual PortType get_output_port_type(int p_port) const;
@@ -1456,6 +1459,8 @@ public:
 	virtual int get_input_port_count() const;
 	virtual PortType get_input_port_type(int p_port) const;
 	virtual String get_input_port_name(int p_port) const;
+
+	virtual String get_input_port_default_hint(int p_port) const;
 
 	virtual String generate_global_per_node(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
 	virtual String generate_global_per_func(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;


### PR DESCRIPTION
I suppose this will make the texture usage less frustrating - if by default UV coordinates will be used instead 0,0

![image](https://user-images.githubusercontent.com/3036176/66108185-b5565800-e5ca-11e9-8fd8-0cd06444530b.png)
