### PR TITLE
Added flip_h and flip_v properties in TextureButton

### DIFF
--- a/doc/classes/TextureButton.xml
+++ b/doc/classes/TextureButton.xml
@@ -15,6 +15,12 @@
 		<member name="expand" type="bool" setter="set_expand" getter="get_expand" default="false">
 			If [code]true[/code], the texture stretches to the edges of the node's bounding rectangle using the [member stretch_mode]. If [code]false[/code], the texture will not scale with the node.
 		</member>
+		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" default="false">
+			If [code]true[/code], texture is flipped horizontally.
+		</member>
+		<member name="flip_v" type="bool" setter="set_flip_v" getter="is_flipped_v" default="false">
+			If [code]true[/code], texture is flipped vertically.
+		</member>
 		<member name="stretch_mode" type="int" setter="set_stretch_mode" getter="get_stretch_mode" enum="TextureButton.StretchMode" default="0">
 			Controls the texture's behavior when you resize the node's bounding rectangle, [b]only if[/b] [member expand] is [code]true[/code]. Set it to one of the [enum StretchMode] constants. See the constants to learn more.
 		</member>

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -166,9 +166,11 @@ void TextureButton::_notification(int p_what) {
 				} break;
 			}
 
+			Point2 ofs;
+			Size2 size;
+
 			if (texdraw.is_valid()) {
-				Point2 ofs;
-				Size2 size = texdraw->get_size();
+				size = texdraw->get_size();
 				_texture_region = Rect2(Point2(), texdraw->get_size());
 				_tile = false;
 				if (expand) {
@@ -218,17 +220,21 @@ void TextureButton::_notification(int p_what) {
 				}
 
 				_position_rect = Rect2(ofs, size);
+
+				size.width *= hflip ? -1.0f : 1.0f;
+				size.height *= vflip ? -1.0f : 1.0f;
+
 				if (_tile) {
-					draw_texture_rect(texdraw, _position_rect, _tile);
+					draw_texture_rect(texdraw, Rect2(ofs, size), _tile);
 				} else {
-					draw_texture_rect_region(texdraw, _position_rect, _texture_region);
+					draw_texture_rect_region(texdraw, Rect2(ofs, size), _texture_region);
 				}
 			} else {
 				_position_rect = Rect2();
 			}
 
 			if (has_focus() && focused.is_valid()) {
-				draw_texture_rect(focused, _position_rect, false);
+				draw_texture_rect(focused, Rect2(ofs, size), false);
 			};
 		} break;
 	}
@@ -243,6 +249,10 @@ void TextureButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_click_mask", "mask"), &TextureButton::set_click_mask);
 	ClassDB::bind_method(D_METHOD("set_expand", "p_expand"), &TextureButton::set_expand);
 	ClassDB::bind_method(D_METHOD("set_stretch_mode", "p_mode"), &TextureButton::set_stretch_mode);
+	ClassDB::bind_method(D_METHOD("set_flip_h", "enable"), &TextureButton::set_flip_h);
+	ClassDB::bind_method(D_METHOD("is_flipped_h"), &TextureButton::is_flipped_h);
+	ClassDB::bind_method(D_METHOD("set_flip_v", "enable"), &TextureButton::set_flip_v);
+	ClassDB::bind_method(D_METHOD("is_flipped_v"), &TextureButton::is_flipped_v);
 
 	ClassDB::bind_method(D_METHOD("get_normal_texture"), &TextureButton::get_normal_texture);
 	ClassDB::bind_method(D_METHOD("get_pressed_texture"), &TextureButton::get_pressed_texture);
@@ -262,6 +272,8 @@ void TextureButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture_click_mask", PROPERTY_HINT_RESOURCE_TYPE, "BitMap"), "set_click_mask", "get_click_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand", PROPERTY_HINT_RESOURCE_TYPE, "bool"), "set_expand", "get_expand");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_mode", PROPERTY_HINT_ENUM, "Scale,Tile,Keep,Keep Centered,Keep Aspect,Keep Aspect Centered,Keep Aspect Covered"), "set_stretch_mode", "get_stretch_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h", PROPERTY_HINT_RESOURCE_TYPE, "bool"), "set_flip_h", "is_flipped_h");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v", PROPERTY_HINT_RESOURCE_TYPE, "bool"), "set_flip_v", "is_flipped_v");
 
 	BIND_ENUM_CONSTANT(STRETCH_SCALE);
 	BIND_ENUM_CONSTANT(STRETCH_TILE);
@@ -345,9 +357,29 @@ TextureButton::StretchMode TextureButton::get_stretch_mode() const {
 	return stretch_mode;
 }
 
+void TextureButton::set_flip_h(bool p_flip) {
+	hflip = p_flip;
+	update();
+}
+
+bool TextureButton::is_flipped_h() const {
+	return hflip;
+}
+
+void TextureButton::set_flip_v(bool p_flip) {
+	vflip = p_flip;
+	update();
+}
+
+bool TextureButton::is_flipped_v() const {
+	return vflip;
+}
+
 TextureButton::TextureButton() {
 	expand = false;
 	stretch_mode = STRETCH_SCALE;
+	hflip = false;
+	vflip = false;
 
 	_texture_region = Rect2();
 	_position_rect = Rect2();

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -61,6 +61,9 @@ private:
 	Rect2 _position_rect;
 	bool _tile;
 
+	bool hflip;
+	bool vflip;
+
 protected:
 	virtual Size2 get_minimum_size() const;
 	virtual bool has_point(const Point2 &p_point) const;
@@ -87,6 +90,12 @@ public:
 
 	void set_stretch_mode(StretchMode p_stretch_mode);
 	StretchMode get_stretch_mode() const;
+
+	void set_flip_h(bool p_flip);
+	bool is_flipped_h() const;
+
+	void set_flip_v(bool p_flip);
+	bool is_flipped_v() const;
 
 	TextureButton();
 };


### PR DESCRIPTION
Same functionality as `flip_h` and `flip_v` in `Sprite` and `TextureRect`.

It's useful to be able to use the same texture for buttons with left and right arrows, for instance.