### PR TITLE
Mono: Fix detection of MsBuild from Visual Studio

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
@@ -34,7 +34,7 @@ namespace GodotTools.Build
 
                             if (_msbuildToolsPath.Empty())
                             {
-                                throw new FileNotFoundException($"Cannot find executable for '{BuildManager.PropNameMsbuildVs}'. Tried with path: {_msbuildToolsPath}");
+                                throw new FileNotFoundException($"Cannot find executable for '{BuildManager.PropNameMsbuildVs}'.");
                             }
                         }
 
@@ -142,7 +142,7 @@ namespace GodotTools.Build
             int exitCode = Godot.OS.Execute(vsWherePath, vsWhereArgs,
                 blocking: true, output: (Godot.Collections.Array) outputArray);
 
-            if (exitCode == 0)
+            if (exitCode != 0)
                 return string.Empty;
 
             if (outputArray.Count == 0)


### PR DESCRIPTION
This was a wrong check as an exit code of 0 means success,
not failure. It used to be fine as blocking mode always returned
-2, but this was changed in #32033 to return the exit code.

Fixes #32424.