### PR TITLE
Fix small memory leak in PackedSourcePCK::try_open_pack

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -151,6 +151,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files) 
 		magic = f->get_32();
 		if (magic != 0x43504447) {
 
+			f->close();
 			memdelete(f);
 			return false;
 		}
@@ -162,6 +163,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files) 
 		magic = f->get_32();
 		if (magic != 0x43504447) {
 
+			f->close();
 			memdelete(f);
 			return false;
 		}
@@ -172,8 +174,16 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files) 
 	uint32_t ver_minor = f->get_32();
 	f->get_32(); // ver_rev
 
-	ERR_FAIL_COND_V_MSG(version != PACK_VERSION, false, "Pack version unsupported: " + itos(version) + ".");
-	ERR_FAIL_COND_V_MSG(ver_major > VERSION_MAJOR || (ver_major == VERSION_MAJOR && ver_minor > VERSION_MINOR), false, "Pack created with a newer version of the engine: " + itos(ver_major) + "." + itos(ver_minor) + ".");
+	if (version != PACK_VERSION) {
+		f->close();
+		memdelete(f);
+		ERR_FAIL_V_MSG(false, "Pack version unsupported: " + itos(version) + ".");
+	}
+	if (ver_major > VERSION_MAJOR || (ver_major == VERSION_MAJOR && ver_minor > VERSION_MINOR)) {
+		f->close();
+		memdelete(f);
+		ERR_FAIL_V_MSG(false, "Pack created with a newer version of the engine: " + itos(ver_major) + "." + itos(ver_minor) + ".");
+	}
 
 	for (int i = 0; i < 16; i++) {
 		//reserved
@@ -200,6 +210,8 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files) 
 		PackedData::get_singleton()->add_path(p_path, path, ofs, size, md5, this, p_replace_files);
 	};
 
+	f->close();
+	memdelete(f);
 	return true;
 };
 


### PR DESCRIPTION
Leak info
```
Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f99f2814448 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10c448)
    #1 0xf7fee58 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:85
    #2 0xf7fee58 in operator new(unsigned long, char const*) core/os/memory.cpp:42
    #3 0xfdc5515 in PackedSourcePCK::try_open_pack(String const&, bool) core/io/file_access_pack.cpp:139
    #4 0xfd94122 in PackedData::add_pack(String const&, bool) core/io/file_access_pack.cpp:43
```