### PR TITLE
Fix potential crash in AnimationPlayer

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -484,6 +484,8 @@ double AnimationPlayerEditor::_get_editor_step() const {
 	if (track_editor->is_snap_enabled()) {
 		const String current = player->get_assigned_animation();
 		const Ref<Animation> anim = player->get_animation(current);
+		ERR_FAIL_COND_V(!anim.is_valid(), 0.0);
+
 		// Use more precise snapping when holding Shift
 		return Input::get_singleton()->is_key_pressed(KEY_SHIFT) ? anim->get_step() * 0.25 : anim->get_step();
 	}


### PR DESCRIPTION
As per @akien-mga in #32504:

> It sounds like _get_editor_step() should also be fixed to avoid crashing in such situation.


I used an `ERR_FAIL_COND`, because that seems to be more inline with how these functions are designed.

For example `player->get_animation(current)` also uses an `ERR_FAIL_COND`.