### PR TITLE
Make `dict2inst` to work with arbitrary `_init` parameters

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -103,15 +103,14 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	instance->owner->set_script_instance(instance);
 
 	/* STEP 2, INITIALIZE AND CONSTRUCT */
-
 	{
 		MutexLock lock(GDScriptLanguage::singleton->lock);
-
 		instances.insert(instance->owner);
 	}
-
+	if (p_argcount < 0) {
+		return instance;
+	}
 	initializer->call(instance, p_args, p_argcount, r_error);
-
 	if (r_error.error != Callable::CallError::CALL_OK) {
 		instance->script = Ref<GDScript>();
 		instance->owner->set_script_instance(nullptr);
@@ -119,10 +118,8 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 			MutexLock lock(GDScriptLanguage::singleton->lock);
 			instances.erase(p_owner);
 		}
-
-		ERR_FAIL_COND_V(r_error.error != Callable::CallError::CALL_OK, nullptr); //error constructing
+		ERR_FAIL_V_MSG(nullptr, "Error constructing a GDScriptInstance.");
 	}
-
 	//@TODO make thread safe
 	return instance;
 }

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1197,8 +1197,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 					return;
 				}
 			}
-
-			r_ret = gdscr->_new(nullptr, 0, r_error);
+			r_ret = gdscr->_new(nullptr, -1 /*skip initializer*/, r_error);
 
 			GDScriptInstance *ins = static_cast<GDScriptInstance *>(static_cast<Object *>(r_ret)->get_script_instance());
 			Ref<GDScript> gd_ref = ins->get_script();


### PR DESCRIPTION
Fixes #30572.

This is achieved by skipping initializer call while creating an instance of a GDScript. This is implemented by passing -1 as an argument count to `_new` and interpreting any value below 0 to mean that the initializer should not be called during instantiation, because internal members of an instance are going to be overridden afterwards (from a dictionary).

I'm not sure if the initializer should actually be called, but it doesn't make sense to me because this is mostly done for deserialization, so I think this should do it. In fact, I don't see a way to call the initializer without knowing what are the actual arguments for parameters, unless you somehow store the initial arguments beforehand when an instance is created normally with `script.new(vararg)` for them to be stored directly inside dictionary created with `inst2dict`.

I'd be more adventurous in making more thorough changes but I'd like to hear what you think of this, or whether you see a better fix. Namely, creation and construction would need to be refactored and treated separately.
