### PR TITLE
seek theora in progress

### DIFF
--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -805,9 +805,10 @@ void VideoStreamPlaybackTheora::seek(float p_time) {
 			while (ogg_stream_packetout(&to, &op) > 0) {
 				ogg_int64_t videobuf_granulepos;
 				th_decode_packetin(td, &op, &videobuf_granulepos);
-				videobuf_time = th_granule_time(td, videobuf_granulepos);
-				if (op.granulepos > 0)
+				if (op.granulepos > 0) {
 					th_decode_ctl(td, TH_DECCTL_SET_GRANPOS, &op.granulepos, sizeof(op.granulepos));
+					videobuf_time = th_granule_time(td, videobuf_granulepos);
+				}
 				th_ycbcr_buffer yuv;
 				th_decode_ycbcr_out(td, yuv); //dump frames
 			}

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -823,9 +823,8 @@ void VideoStreamPlaybackTheora::seek(float p_time) {
 	}
 	//Update the audioframe time
 	audio_frames_wrote = videobuf_time * vi.rate;
-	
 	while(ogg_stream_packetout(&vo, &op) > 0) {
-		double current_audio_time = vorbis_granule_time(&vd, audio_granulepos + op.packetno - total_packets--);
+		double current_audio_time = vorbis_granule_time(&vd, audio_granulepos + total_packets--);
 		double diff = current_audio_time - videobuf_time;
 		if( diff > 0 ) {
 			int blank_frames = diff * vi.rate * vi.channels;

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -736,7 +736,7 @@ void VideoStreamPlaybackTheora::seek(float p_time) {
 		file->seek(current_block * buffer_size);
 		buffer_data();
 		bool seeked_file = false;
-		bool buffer_packet = false;
+		bool keyframe_found = false;
 		while (!seeked_file) {
 			int ogg_page_sync_state = ogg_sync_pageout(&oy, &og);
 			if (ogg_page_sync_state == -1) {
@@ -759,10 +759,10 @@ void VideoStreamPlaybackTheora::seek(float p_time) {
 							buffer_data();
 						}
 					}
-					buffer_packet = true;
 					if (th_packet_iskeyframe(&op)) {
 						videobuf_time = th_granule_time(td, op.granulepos);
 						if (videobuf_time < p_time) {
+							keyframe_found = true;
 							break;
 						}
 					} else
@@ -770,13 +770,8 @@ void VideoStreamPlaybackTheora::seek(float p_time) {
 				}
 			}
 		}
-		if(buffer_packet) {
-			if (th_packet_iskeyframe(&op)) {
-				videobuf_time = th_granule_time(td, op.granulepos);
-				if (videobuf_time < p_time) {
-					break;
-				}
-			}
+		if(keyframe_found) {
+			break;
 		}
 		current_block--;
 	}

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -50,6 +50,7 @@ class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 
 	enum {
 		MAX_FRAMES = 4,
+		BUFFERSIZE = 4096,
 	};
 
 	//Image frames[MAX_FRAMES];


### PR DESCRIPTION
First Ogg Theora Seek Attempt

Ogg Tidbits
Ogg lacks a seek table.
Timestamp exists on the ogg page with the closing packet stream.
Ogg_page_packets can discern which page has a timestamp.
Keyframes exist in pages with ogg_pages_packets(&og) == 1

Proposal
Split the file into BUFFERSIZE segments for binary searching and backtracking.

Algorithm
Binary Search Ogg Page Timestamps
Backtrack to Keyframe
Catch up to Seek

Section 1:
This section is implemented as nested loops. The inner loops finds an unprocessed buffer segment and retrieves the first ogg_page even if it spans across buffer segments.

The outer loop compares the ogg_page into an iterative binary search. Since ogg_page_packets can discern the granulepos or time stamp, no ogg_packet is inspected.

Section 2:
The section is implemented as a buffer sync step to combine all ogg_pages into one ogg_packet.

Section 3:
Submit the frames into the theora decoder and advance the video forward until the buffer catches up to the seek time.

Modified
Implemented Seek
Added BUFFERSIZE and remove the hard coded 4096

Known Bugs

- [x] ~~Seek cannot find subsequent ogg_pages in the buffer segment. When a buffer section has two ogg_pages and the keyframe is encoded in the latter ogg_page. Seek will not find it.~~

- [ ] VideoTheoraStreak is littered with time resets. Currently, seek only works during play mode.

- [x] ~~More audio frames needs to be dropped when videobuf_time > audio_time within the stream~~

- [x] ~~Seek 0 does not work~~

- [x] ~~Small artifacts at the beginning of the video~~

- [x] ~~Crashes godot when using a seeking near the end line: 771~~ https://github.com/godotengine/godot/pull/32539/commits/d4930c9600d266736c9d193f9619014798398edb

Links
https://www.theora.org/doc/libtheora-1.0/group__decfuncs.html
https://xiph.org/oggz/doc/group__basics.html

Issue #14430

Seek works somewhat. I need to fix these three bugs.
https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_stereo.ogg
I managed run big_buck_bunny.ogv
