### PR TITLE
Fixes scene instances not displaying bounds when selected

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2172,7 +2172,7 @@ void SpatialEditorViewport::_notification(int p_what) {
 
 			VisualInstance *vi = Object::cast_to<VisualInstance>(sp);
 
-			se->aabb = vi ? vi->get_aabb() : AABB(Vector3(-0.2, -0.2, -0.2), Vector3(0.4, 0.4, 0.4));
+			se->aabb = vi ? vi->get_aabb() : _calculate_spatial_bounds(sp, AABB(Vector3(-0.2, -0.2, -0.2), Vector3(0.4, 0.4, 0.4)));
 
 			Transform t = sp->get_global_gizmo_transform();
 			t.translate(se->aabb.position);


### PR DESCRIPTION
When selecting instances of a scene file, it doesn't display the bounding box which makes it difficult to visually see that it is selected.

Closes: #32400