### PR TITLE
Fix VisualShaderInput (if compiled with MinGW) (correct, tested version)

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2053,7 +2053,7 @@ Variant VisualShaderEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 
 		Dictionary d;
 		d["id"] = id;
-		if (op.sub_func_str != "") {
+		if (op.sub_func == -1) {
 			d["sub_func"] = op.sub_func_str;
 		} else {
 			d["sub_func"] = op.sub_func;

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -137,6 +137,7 @@ class VisualShaderEditor : public VBoxContainer {
 			category = p_category;
 			sub_category = p_sub_category;
 			description = p_description;
+			sub_func = 0;
 			sub_func_str = p_sub_func;
 			return_type = p_return_type;
 			mode = p_mode;


### PR DESCRIPTION
Correct, (tested on Linux) version of previous bugfix

Revert : https://github.com/godotengine/godot/pull/32541
