### PR TITLE
Bind the `String::humanize_size` method

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3298,7 +3298,7 @@ static int _humanize_digits(int p_num) {
 		return 0;
 }
 
-String String::humanize_size(size_t p_size) {
+String String::humanize_size(uint64_t p_size) {
 
 	uint64_t _div = 1;
 	Vector<String> prefixes;

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -322,7 +322,7 @@ public:
 	String path_to_file(const String &p_path) const;
 	String get_base_dir() const;
 	String get_file() const;
-	static String humanize_size(size_t p_size);
+	static String humanize_size(uint64_t p_size);
 	String simplify_path() const;
 
 	String xml_escape(bool p_escape_quotes = false) const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -284,6 +284,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(String, sha1_buffer);
 	VCALL_LOCALMEM0R(String, sha256_buffer);
 	VCALL_LOCALMEM0R(String, empty);
+	VCALL_LOCALMEM1R(String, humanize_size);
 	VCALL_LOCALMEM0R(String, is_abs_path);
 	VCALL_LOCALMEM0R(String, is_rel_path);
 	VCALL_LOCALMEM0R(String, get_base_dir);
@@ -1561,6 +1562,7 @@ void register_variant_methods() {
 	ADDFUNC0R(STRING, POOL_BYTE_ARRAY, String, sha1_buffer, varray());
 	ADDFUNC0R(STRING, POOL_BYTE_ARRAY, String, sha256_buffer, varray());
 	ADDFUNC0R(STRING, BOOL, String, empty, varray());
+	ADDFUNC1R(STRING, STRING, String, humanize_size, INT, "size", varray());
 	ADDFUNC0R(STRING, BOOL, String, is_abs_path, varray());
 	ADDFUNC0R(STRING, BOOL, String, is_rel_path, varray());
 	ADDFUNC0R(STRING, STRING, String, get_base_dir, varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -437,6 +437,20 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="humanize_size">
+			<return type="String">
+			</return>
+			<argument index="0" name="size" type="int">
+			</argument>
+			<description>
+				Converts [code]size[/code] represented as number of bytes to human-readable format using internationalized set of data size units, namely: B, KiB, MiB, GiB, TiB, PiB, EiB. Note that the next smallest unit is picked automatically to hold at most 1024 units.
+				[codeblock]
+				var bytes = 133790307
+				var size = String.humanize_size(bytes)
+				print(size) # prints "127.5 MiB"
+				[/codeblock]
+			</description>
+		</method>
 		<method name="insert">
 			<return type="String">
 			</return>


### PR DESCRIPTION
As suggested in #31993:

> We could also consider exposing this method to scripts, so that projects that need to display file sizes can use it directly.

Exactly my use case. I want to compare different compression methods more easily.

The method signature is also changed to use `uint64_t` instead of `size_t` for it to be Variant-compatible: https://github.com/godotengine/godot/pull/32546#issuecomment-538374553.