### PR TITLE
doc: Add note about sending strings without size in StreamPeer

### DIFF
--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -211,6 +211,10 @@
 			</argument>
 			<description>
 				Puts a zero-terminated ASCII string into the stream prepended by a 32-bit unsigned integer representing its size.
+				Note: To put an ASCII string without prepending its size, you can use [method put_data]:
+				[codeblock]
+				put_data("Hello world".to_ascii())
+				[/codeblock]
 			</description>
 		</method>
 		<method name="put_u16">
@@ -256,6 +260,10 @@
 			</argument>
 			<description>
 				Puts a zero-terminated UTF-8 string into the stream prepended by a 32 bits unsigned integer representing its size.
+				Note: To put an UTF-8 string without prepending its size, you can use [method put_data]:
+				[codeblock]
+				put_data("Hello world".to_utf8())
+				[/codeblock]
 			</description>
 		</method>
 		<method name="put_var">


### PR DESCRIPTION
Follow-up to #29150, #29153, #32531.