### PR TITLE
Increase the size of the About dialog

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -141,7 +141,7 @@ EditorAbout::EditorAbout() {
 	hbc->add_child(about_text);
 
 	TabContainer *tc = memnew(TabContainer);
-	tc->set_custom_minimum_size(Size2(630, 240) * EDSCALE);
+	tc->set_custom_minimum_size(Size2(950, 400) * EDSCALE);
 	tc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vbc->add_child(tc);
 


### PR DESCRIPTION
This makes third-party license texts display without any soft wrapping.

The About dialog still fits in the editor when using the smallest window size permitted (1024x600).

## Preview

![New About dialog size](https://user-images.githubusercontent.com/180032/66257005-4d536d80-e794-11e9-81a0-3ea86dec380c.png)