### PR TITLE
Document GDNativeLibrary

### DIFF
--- a/modules/gdnative/doc_classes/GDNativeLibrary.xml
+++ b/modules/gdnative/doc_classes/GDNativeLibrary.xml
@@ -1,35 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GDNativeLibrary" inherits="Resource" category="Core" version="3.2">
 	<brief_description>
+		An external library containing functions or script classes to use in Godot.
 	</brief_description>
 	<description>
+		A GDNative library can implement [NativeScript]s, global functions to call with the [GDNative] class, or low-level engine extensions through interfaces such as [ARVRInterfaceGDNative]. The library must be compiled for each platform and architecture that the project will run on.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/plugins/gdnative/gdnative-c-example.html</link>
+		<link>https://docs.godotengine.org/en/latest/tutorials/plugins/gdnative/gdnative-cpp-example.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_current_dependencies" qualifiers="const">
 			<return type="PoolStringArray">
 			</return>
 			<description>
+				Returns paths to all dependency libraries for the current platform and architecture.
 			</description>
 		</method>
 		<method name="get_current_library_path" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
+				Returns the path to the dynamic library file for the current platform and architecture.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="config_file" type="ConfigFile" setter="set_config_file" getter="get_config_file">
+			This resource in INI-style [ConfigFile] format, as in [code].gdnlib[/code] files.
 		</member>
 		<member name="load_once" type="bool" setter="set_load_once" getter="should_load_once" default="true">
+			If [code]true[/code], Godot loads only one copy of the library and each script that references the library will share static data like static or global variables.
+			If [code]false[/code], Godot loads a separate copy of the library into memory for each script that references it.
 		</member>
 		<member name="reloadable" type="bool" setter="set_reloadable" getter="is_reloadable" default="true">
+			If [code]true[/code], the editor will temporarily unload the library whenever the user switches away from the editor window, allowing the user to recompile the library without restarting Godot.
+			[b]Note:[/b] If the library defines tool scripts that run inside the editor, [code]reloadable[/code] must be [code]false[/code]. Otherwise, the editor will attempt to unload the tool scripts while they're in use and crash.
 		</member>
 		<member name="singleton" type="bool" setter="set_singleton" getter="is_singleton" default="false">
+			If [code]true[/code], Godot loads the library at startup rather than the first time a script uses the library, calling [code]gdnative_singleton[/code] after initializing the library. The library remains loaded as long as Godot is running.
+			[b]Note:[/b] A singleton library cannot be [member reloadable].
 		</member>
 		<member name="symbol_prefix" type="String" setter="set_symbol_prefix" getter="get_symbol_prefix" default="&quot;godot_&quot;">
+			The prefix this library's entry point functions begin with. For example, a GDNativeLibrary would declare its [code]gdnative_init[/code] function as [code]godot_gdnative_init[/code] by default.
+			On platforms that require statically linking libraries (currently only iOS), each library must have a different [code]symbol_prefix[/code].
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Some of the configuration options for this resource were previously documented in the C tutorial. This adds documentation to the class itself.

Also documents the fact that `reloadable` can't be used with tool NativeScripts in the editor (see #19686).