### PR TITLE
Set tooltip to an empty string after removing texture/material

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2649,6 +2649,7 @@ void EditorPropertyResource::update_property() {
 	if (res == RES()) {
 		assign->set_icon(Ref<Texture>());
 		assign->set_text(TTR("[empty]"));
+		assign->set_tooltip("");
 	} else {
 
 		assign->set_icon(EditorNode::get_singleton()->get_object_icon(res.operator->(), "Node"));


### PR DESCRIPTION
Fixes #32570 