### PR TITLE
Prevents shader crash if name of variable overrides function name

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2914,6 +2914,16 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 
 				bool ok = _parse_function_arguments(p_block, p_builtin_types, func, &carg);
 
+				// Check if block has a variable with the same name as function to prevent shader crash.
+				ShaderLanguage::BlockNode *bnode = p_block;
+				while (bnode) {
+					if (bnode->variables.has(name)) {
+						_set_error("Expected function name");
+						return NULL;
+					}
+					bnode = bnode->parent_block;
+				}
+
 				//test if function was parsed first
 				for (int i = 0; i < shader->functions.size(); i++) {
 					if (shader->functions[i].name == name) {


### PR DESCRIPTION
This will prevent shader crash when user defines a variable with the same name as function and called it on next statement eg

```
shader_type spatial;

float b( in float b ) { return b / 6.0; }

void fragment() 
{ 
	float b = b(1.0);
	float a = b(1.0); // CRASH
		
	ALBEDO = vec3(b);
}
```