### PR TITLE
Fix current issues with post-processing

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2905,16 +2905,10 @@ void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p
 		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->depth);
 
 		glActiveTexture(GL_TEXTURE0);
-		if (!storage->frame.current_rt->used_dof_blur_near) {
-			if (storage->frame.current_rt->mip_maps[0].color) {
-				glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].color);
-			} else {
-				for (int i = 0; i < storage->frame.current_rt->mip_maps[i].sizes.size(); i++) {
-					glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[i].color);
-					glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, storage->frame.current_rt->mip_maps[0].sizes[i].width, storage->frame.current_rt->mip_maps[0].sizes[i].height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-				}
-				glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[0].color);
-			}
+		if (storage->frame.current_rt->mip_maps[0].color) {
+			glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].color);
+		} else {
+			glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[0].color);
 		}
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5757,7 +5757,8 @@ void RasterizerStorageGLES2::initialize() {
 	config.multisample_supported = config.extensions.has("GL_EXT_framebuffer_multisample") || config.extensions.has("GL_EXT_multisampled_render_to_texture") || config.extensions.has("GL_APPLE_framebuffer_multisample");
 
 #ifdef GLES_OVER_GL
-	config.render_to_mipmap_supported = true;
+	//TODO: causes huge problems with desktop video drivers. Making false for now, needs to be true to render SCREEN_TEXTURE mipmaps
+	config.render_to_mipmap_supported = false;
 #else
 	//check if mipmaps can be used for SCREEN_TEXTURE and Glow on Mobile and web platforms
 	config.render_to_mipmap_supported = config.extensions.has("GL_OES_fbo_render_mipmap") && config.extensions.has("GL_EXT_texture_lod");


### PR DESCRIPTION
Fixes an unreported bug with near_dof 

Also turns off mipmapped textures for post-processing effects. Something about the mipmapped texture was causing a driver bug to act up, thus causing https://github.com/godotengine/godot/issues/32574 and https://github.com/godotengine/godot/issues/32601

For now, turn off mipmapped textures (not needed for post-processing) and default to multi-texture approach. 

@akien-mga I likely won't have time to figure out how to get mip-mapping working correctly before 3.2, I suggest we leave this turned off until I have the time to properly figure out what is causing the driver bug. In the meantime I will implement https://github.com/godotengine/godot/issues/32458 without screen texture mipmaps