### PR TITLE
Disable socket descriptor sharing with subprocs.

### DIFF
--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -280,6 +280,21 @@ void NetSocketPosix::_set_socket(SOCKET_TYPE p_sock, IP::Type p_ip_type, bool p_
 	_sock = p_sock;
 	_ip_type = p_ip_type;
 	_is_stream = p_is_stream;
+	// Disable descriptor sharing with subprocesses.
+	_set_close_exec_enabled(true);
+}
+
+void NetSocketPosix::_set_close_exec_enabled(bool p_enabled) {
+#ifndef WINDOWS_ENABLED
+	// Enable close on exec to avoid sharing with subprocesses. Off by default on Windows.
+#if defined(NO_FCNTL)
+	unsigned long par = p_enabled ? 1 : 0;
+	SOCK_IOCTL(_sock, FIOCLEX, &par);
+#else
+	int opts = fcntl(_sock, F_GETFD);
+	fcntl(_sock, F_SETFD, opts | FD_CLOEXEC);
+#endif
+#endif
 }
 
 Error NetSocketPosix::open(Type p_sock_type, IP::Type &ip_type) {
@@ -319,6 +334,9 @@ Error NetSocketPosix::open(Type p_sock_type, IP::Type &ip_type) {
 	}
 
 	_is_stream = p_sock_type == TYPE_TCP;
+
+	// Disable descriptor sharing with subprocesses.
+	_set_close_exec_enabled(true);
 
 #if defined(WINDOWS_ENABLED)
 	if (!_is_stream) {

--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -61,6 +61,7 @@ private:
 	NetError _get_socket_error();
 	void _set_socket(SOCKET_TYPE p_sock, IP::Type p_ip_type, bool p_is_stream);
 	_FORCE_INLINE_ Error _change_multicast_group(IP_Address p_ip, String p_if_name, bool p_add);
+	_FORCE_INLINE_ void _set_close_exec_enabled(bool p_enabled);
 
 protected:
 	static NetSocket *_create_func();


### PR DESCRIPTION
On Unix systems, sockets are like file descriptors, and file descriptors
are usually shared among child processes.
This means, that if we spawn a subprocess (or we fork) like we do in the
editor, open file descriptors will leak to the new process.
This causes issue with sockets as they might remain open and bound
(listening) when the original process closes.

Fixes #32533