### PR TITLE
Disable file descriptor sharing with subprocs.

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -56,6 +56,12 @@
 #define S_ISREG(m) ((m)&S_IFREG)
 #endif
 
+#ifndef NO_FCNTL
+#include <fcntl.h>
+#else
+#include <sys/ioctl.h>
+#endif
+
 void FileAccessUnix::check_errors() const {
 
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
@@ -123,11 +129,24 @@ Error FileAccessUnix::_open(const String &p_path, int p_mode_flags) {
 			} break;
 		}
 		return last_error;
-	} else {
-		last_error = OK;
-		flags = p_mode_flags;
-		return OK;
 	}
+
+	// Set close on exec to avoid leaking it to subprocesses.
+	int fd = fileno(f);
+
+	if (fd != -1) {
+#if defined(NO_FCNTL)
+		unsigned long par = 0;
+		ioctl(fd, FIOCLEX, &par);
+#else
+		int opts = fcntl(fd, F_GETFD);
+		fcntl(fd, F_SETFD, opts | FD_CLOEXEC);
+#endif
+	}
+
+	last_error = OK;
+	flags = p_mode_flags;
+	return OK;
 }
 
 void FileAccessUnix::close() {


### PR DESCRIPTION
On Unix systems, file descriptors are usually shared among child processes.
This means, that if we spawn a subprocess (or we fork) like we do in the editor any open file descriptor will leak to the new process.
This PR sets the close-on-exec flag when opening a file, which causes the file descriptor to not be shared with the child process.

This PR is like #32616 but for files.
I've made this a separate PR and added the label `needs testing` because it might have a potentially bigger impact if something is wrong with it (although it seems to work in my tests).