### PR TITLE
Sprite to polygon conversion improvements

### DIFF
--- a/editor/plugins/sprite_editor_plugin.h
+++ b/editor/plugins/sprite_editor_plugin.h
@@ -67,7 +67,8 @@ class SpriteEditor : public Control {
 	Vector<int> computed_indices;
 
 	SpinBox *simplification;
-	SpinBox *island_merging;
+	SpinBox *grow_pixels;
+	SpinBox *shrink_pixels;
 	Button *update_preview;
 
 	void _menu_option(int p_option);

--- a/scene/resources/bit_map.h
+++ b/scene/resources/bit_map.h
@@ -67,6 +67,7 @@ public:
 	void resize(const Size2 &p_new_size);
 
 	void grow_mask(int p_pixels, const Rect2 &p_rect);
+	void shrink_mask(int p_pixels, const Rect2 &p_rect);
 
 	void blit(const Vector2 &p_pos, const Ref<BitMap> &p_bitmap);
 	Ref<Image> convert_to_image() const;


### PR DESCRIPTION
I've mostly made some changes around the march square algorithm to fix errors and crashes when converting sprites to polygons, and added a few extra changes to make the tool easier to use.

List of changes:
- No reduced Rect in march square algorithm, it was causing inconsistent cases near the borders and made the outline less accurate
- Ignore invalid generated polygons (under 3 points) to avoid unnecessary errors and crashes
- Error popup only when no polygon could be generated at all
- Added option to shrink pixels (to get rid of small separate islands)
- Fixed polygon preview (lines were sometimes not showing along the borders)

Fixes #32564, fixes #29267