### PR TITLE
Clarify insert() returns a copy of the string.

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -459,7 +459,7 @@
 			<argument index="1" name="what" type="String">
 			</argument>
 			<description>
-				Inserts a substring at a given position.
+				Inserts a substring at a given position. Returns a copy of the string.
 			</description>
 		</method>
 		<method name="is_abs_path">


### PR DESCRIPTION
An alternate wording could be:

    Returns a copy of the string with the supplied substring inserted at the given position.

But I'm guessing this might be considered "passive voice" and arguably buries the description.

Related links:

 * https://github.com/godotengine/godot/issues/30429
 * https://godotengine.org/qa/47148/cant-get-string-insert-and-replace-to-work

As mentioned by https://github.com/godotengine/godot/issues/30429#issuecomment-509274404 this clarification is needed for some other methods also but I wanted to get buy-in on the wording first. (The wording is already present in some other methods.)

Also, given this behavior (i.e. methods return a copy of the string and do not operate in-place) is a key point on how most of the methods of `String` operate (and doesn't match the behavior in some other classes/languages) I think it might be good to also mention it in the class introduction.