### PR TITLE
Remove circular dependency between Vector3 and Basis.

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -28,13 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-// Circular dependency between Vector3 and Basis :/
-#include "core/math/vector3.h"
-
 #ifndef BASIS_H
 #define BASIS_H
 
 #include "core/math/quat.h"
+#include "core/math/vector3.h"
 
 class Basis {
 public:

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -134,6 +134,21 @@ Vector3 Vector3::move_toward(const Vector3 &p_to, const real_t p_delta) const {
 	return len <= p_delta || len < CMP_EPSILON ? p_to : v + vd / len * p_delta;
 }
 
+Basis Vector3::outer(const Vector3 &p_b) const {
+
+	Vector3 row0(x * p_b.x, x * p_b.y, x * p_b.z);
+	Vector3 row1(y * p_b.x, y * p_b.y, y * p_b.z);
+	Vector3 row2(z * p_b.x, z * p_b.y, z * p_b.z);
+
+	return Basis(row0, row1, row2);
+}
+
+Basis Vector3::to_diagonal_matrix() const {
+	return Basis(x, 0, 0,
+			0, y, 0,
+			0, 0, z);
+}
+
 Vector3::operator String() const {
 
 	return (rtos(x) + ", " + rtos(y) + ", " + rtos(z));

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -96,8 +96,8 @@ struct Vector3 {
 
 	_FORCE_INLINE_ Vector3 cross(const Vector3 &p_b) const;
 	_FORCE_INLINE_ real_t dot(const Vector3 &p_b) const;
-	_FORCE_INLINE_ Basis outer(const Vector3 &p_b) const;
-	_FORCE_INLINE_ Basis to_diagonal_matrix() const;
+	Basis outer(const Vector3 &p_b) const;
+	Basis to_diagonal_matrix() const;
 
 	_FORCE_INLINE_ Vector3 abs() const;
 	_FORCE_INLINE_ Vector3 floor() const;
@@ -154,9 +154,6 @@ struct Vector3 {
 	_FORCE_INLINE_ Vector3() { x = y = z = 0; }
 };
 
-// Should be included after class definition, otherwise we get circular refs
-#include "core/math/basis.h"
-
 Vector3 Vector3::cross(const Vector3 &p_b) const {
 
 	Vector3 ret(
@@ -170,21 +167,6 @@ Vector3 Vector3::cross(const Vector3 &p_b) const {
 real_t Vector3::dot(const Vector3 &p_b) const {
 
 	return x * p_b.x + y * p_b.y + z * p_b.z;
-}
-
-Basis Vector3::outer(const Vector3 &p_b) const {
-
-	Vector3 row0(x * p_b.x, x * p_b.y, x * p_b.z);
-	Vector3 row1(y * p_b.x, y * p_b.y, y * p_b.z);
-	Vector3 row2(z * p_b.x, z * p_b.y, z * p_b.z);
-
-	return Basis(row0, row1, row2);
-}
-
-Basis Vector3::to_diagonal_matrix() const {
-	return Basis(x, 0, 0,
-			0, y, 0,
-			0, 0, z);
 }
 
 Vector3 Vector3::abs() const {


### PR DESCRIPTION
There is a circular dependency between core/math/basis.h and core/math/vector3.h. This patch removes that dependency. The side-effect is that the Vector3 member functions outer() and to_diagonal_matrix() can no longer be forced inline.