### PR TITLE
Remove circular include between core/typedefs.h and core/error_macros.h

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -33,6 +33,7 @@
 
 #include <string.h>
 
+#include "core/error_macros.h"
 #include "core/os/memory.h"
 #include "core/safe_refcount.h"
 

--- a/core/list.h
+++ b/core/list.h
@@ -31,6 +31,7 @@
 #ifndef GLOBALS_LIST_H
 #define GLOBALS_LIST_H
 
+#include "core/error_macros.h"
 #include "core/os/memory.h"
 #include "core/sort_array.h"
 

--- a/core/map.h
+++ b/core/map.h
@@ -31,6 +31,7 @@
 #ifndef MAP_H
 #define MAP_H
 
+#include "core/error_macros.h"
 #include "core/set.h"
 
 // based on the very nice implementation of rb-trees by:

--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -30,6 +30,8 @@
 
 #include "math_funcs.h"
 
+#include "core/error_macros.h"
+
 RandomPCG Math::default_rand(RandomPCG::DEFAULT_SEED, RandomPCG::DEFAULT_INC);
 
 #define PHI 0x9e3779b9

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -31,6 +31,7 @@
 #ifndef MEMORY_H
 #define MEMORY_H
 
+#include "core/error_macros.h"
 #include "core/safe_refcount.h"
 
 #include <stddef.h>

--- a/core/self_list.h
+++ b/core/self_list.h
@@ -31,6 +31,7 @@
 #ifndef SELF_LIST_H
 #define SELF_LIST_H
 
+#include "core/error_macros.h"
 #include "core/typedefs.h"
 
 template <class T>

--- a/core/sort_array.h
+++ b/core/sort_array.h
@@ -31,6 +31,7 @@
 #ifndef SORT_ARRAY_H
 #define SORT_ARRAY_H
 
+#include "core/error_macros.h"
 #include "core/typedefs.h"
 
 #define ERR_BAD_COMPARE(cond)                                         \

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -108,7 +108,6 @@ T *_nullptr() {
 #include "core/int_types.h"
 
 #include "core/error_list.h"
-#include "core/error_macros.h"
 
 /** Generic ABS function, for math uses please use Math::abs */
 


### PR DESCRIPTION
There is a circular dependency between core/typedefs.h and core/error_macros.h. This patch removes that dependency. I've also included core/error_macros.h in those files that needed it.