### PR TITLE
Fixed RigidBody stuttering when changing collision layer/mask

### DIFF
--- a/modules/bullet/collision_object_bullet.h
+++ b/modules/bullet/collision_object_bullet.h
@@ -167,14 +167,18 @@ public:
 	_FORCE_INLINE_ const VSet<RID> &get_exceptions() const { return exceptions; }
 
 	_FORCE_INLINE_ void set_collision_layer(uint32_t p_layer) {
-		collisionLayer = p_layer;
-		on_collision_filters_change();
+		if (collisionLayer != p_layer) {
+			collisionLayer = p_layer;
+			on_collision_filters_change();
+		}
 	}
 	_FORCE_INLINE_ uint32_t get_collision_layer() const { return collisionLayer; }
 
 	_FORCE_INLINE_ void set_collision_mask(uint32_t p_mask) {
-		collisionMask = p_mask;
-		on_collision_filters_change();
+		if (collisionMask != p_mask) {
+			collisionMask = p_mask;
+			on_collision_filters_change();
+		}
 	}
 	_FORCE_INLINE_ uint32_t get_collision_mask() const { return collisionMask; }
 

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -411,6 +411,8 @@ void RigidBodyBullet::on_collision_filters_change() {
 	if (space) {
 		space->reload_collision_filters(this);
 	}
+
+	set_activation_state(true);
 }
 
 void RigidBodyBullet::on_collision_checker_start() {


### PR DESCRIPTION
- Changing collision layer/mask now only updates the broadphase proxy to avoid the velocity to be reset each time (also avoids unnecessary computations)
- No rigid body update at all when the collision layer/mask stays the same
- Same changes for Area for optimization purpose

Fixes #32577