### PR TITLE
Check for cyclic inheritance when adding a global script class

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -218,6 +218,7 @@ void ScriptServer::global_classes_clear() {
 }
 
 void ScriptServer::add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path) {
+	ERR_FAIL_COND_MSG(p_class == p_base || (global_classes.has(p_base) && get_global_class_native_base(p_base) == p_class), "Cyclic inheritance in script class.");
 	GlobalScriptClass g;
 	g.language = p_language;
 	g.path = p_path;


### PR DESCRIPTION
This makes add_global_class() fail if a cyclic inheritance is detected.

Fixes #25339 and #32113