### PR TITLE
Fixed AttributeError bug on doc_status.py

### DIFF
--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -259,7 +259,8 @@ class ClassStatus:
                     status.progresses[tag.tag].increment(len(descr.text.strip()) > 0)
             elif tag.tag in ['constants', 'members']:
                 for sub_tag in list(tag):
-                    status.progresses[tag.tag].increment(len(sub_tag.text.strip()) > 0)
+                    if not sub_tag.text is None:
+                        status.progresses[tag.tag].increment(len(sub_tag.text.strip()) > 0)
 
             elif tag.tag in ['tutorials']:
                 pass  # Ignore those tags for now


### PR DESCRIPTION
```
Traceback (most recent call last):
    File "tools/doc_status.py", line 394, in <module>
      status = ClassStatus.generate_for_class(c)
      File "tools/doc_status.py", line 263, in generate_for_class
      status.progresses[tag.tag].increment(len(sub_tag.text.strip()) > 0)
    AttributeError: 'NoneType' object has no attribute 'strip'
```

The `sub_tag.text` as None in some cases. Added a check before calling the `sub_tag.text.strip()` function.

OS: Manjaro 18.1.0 Testing branch