### PR TITLE
Fix draw_rect

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -494,8 +494,10 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				if (line->width <= 1) {
 					Vector2 verts[2] = {
-						Vector2(line->from.x, line->from.y),
-						Vector2(line->to.x, line->to.y)
+						// Offset the line slightly to make sure we always draw the pixel at the from coordinate.
+						// Without this, corners of rectangles might be missing a pixel. (See diamond exit rule and #32657)
+						Vector2(Math::floor(line->from.x) + 0.5, Math::floor(line->from.y) + 0.5),
+						Vector2(Math::floor(line->to.x) + 0.5, Math::floor(line->to.y) + 0.5)
 					};
 
 #ifdef GLES_OVER_GL

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -548,8 +548,10 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				if (line->width <= 1) {
 					Vector2 verts[2] = {
-						Vector2(line->from.x, line->from.y),
-						Vector2(line->to.x, line->to.y)
+						// Offset the line slightly to make sure we always draw the pixel at the from coordinate.
+						// Without this, corners of rectangles might be missing a pixel. (See diamond exit rule and #32657)
+						Vector2(Math::floor(line->from.x) + 0.5, Math::floor(line->from.y) + 0.5),
+						Vector2(Math::floor(line->to.x) + 0.5, Math::floor(line->to.y) + 0.5)
 					};
 
 #ifdef GLES_OVER_GL

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -777,29 +777,29 @@ void CanvasItem::draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_fil
 
 		VisualServer::get_singleton()->canvas_item_add_line(
 				canvas_item,
-				p_rect.position + Point2(-offset, 0),
+				p_rect.position + Size2(-offset, 0),
 				p_rect.position + Size2(p_rect.size.width + offset, 0),
 				p_color,
 				p_width,
 				p_antialiased);
 		VisualServer::get_singleton()->canvas_item_add_line(
 				canvas_item,
-				p_rect.position + Point2(0, offset),
-				p_rect.position + Size2(0, p_rect.size.height - offset),
-				p_color,
-				p_width,
-				p_antialiased);
-		VisualServer::get_singleton()->canvas_item_add_line(
-				canvas_item,
-				p_rect.position + Point2(-offset, p_rect.size.height),
-				p_rect.position + Size2(p_rect.size.width + offset, p_rect.size.height),
-				p_color,
-				p_width,
-				p_antialiased);
-		VisualServer::get_singleton()->canvas_item_add_line(
-				canvas_item,
-				p_rect.position + Point2(p_rect.size.width, offset),
+				p_rect.position + Size2(p_rect.size.width, offset),
 				p_rect.position + Size2(p_rect.size.width, p_rect.size.height - offset),
+				p_color,
+				p_width,
+				p_antialiased);
+		VisualServer::get_singleton()->canvas_item_add_line(
+				canvas_item,
+				p_rect.position + Size2(p_rect.size.width + offset, p_rect.size.height),
+				p_rect.position + Size2(-offset, p_rect.size.height),
+				p_color,
+				p_width,
+				p_antialiased);
+		VisualServer::get_singleton()->canvas_item_add_line(
+				canvas_item,
+				p_rect.position + Size2(0, p_rect.size.height - offset),
+				p_rect.position + Size2(0, offset),
 				p_color,
 				p_width,
 				p_antialiased);


### PR DESCRIPTION
OpenGL uses the diamond exit rule to rasterize lines. If we don't shift
the points down and to the right by 0.5, the line can sometimes miss a
pixel when it shouldn't. The final fragment of a line isn't drawn. By
drawing the lines clockwise, we can avoid a missing pixel in the rectangle.
See section 3.4.1 in the OpenGL 1.5 specification.
Fixes #32279