### PR TITLE
Add "Open in External Editor" function

### DIFF
--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -141,6 +141,7 @@ class ScriptEditor : public PanelContainer {
 		FILE_OPEN,
 		FILE_REOPEN_CLOSED,
 		FILE_OPEN_RECENT,
+		FILE_OPEN_EXTERNAL,
 		FILE_SAVE,
 		FILE_SAVE_AS,
 		FILE_SAVE_ALL,
@@ -428,8 +429,8 @@ public:
 	void ensure_select_current();
 
 	_FORCE_INLINE_ bool edit(const RES &p_resource, bool p_grab_focus = true) { return edit(p_resource, -1, 0, p_grab_focus); }
+	bool open_script_in_external_editor(const RES &p_resource, int p_line, int p_col);
 	bool edit(const RES &p_resource, int p_line, int p_col, bool p_grab_focus = true);
-
 	void get_breakpoints(List<String> *p_breakpoints);
 
 	void save_all_scripts();


### PR DESCRIPTION
Add the option to open a specific file in the external editor.
It's found in the script editor's File menu.

Had to extend ScriptTextEditor to provide line and
column as a Vector2i to preserve cursor position.

(The shortcut in the picture is not there by default, I assigned it locally to test it.)

![Screenshot_2019-10-08_17-53-45](https://user-images.githubusercontent.com/6402237/66432570-c4873c80-e9f4-11e9-9702-e7b244efbe97.png)
