### PR TITLE
[Mono] Change Plane intersect methods to return nullable Vector3

### DIFF
--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -91,7 +91,7 @@ bool Plane::intersect_3(const Plane &p_plane1, const Plane &p_plane2, Vector3 *r
 
 	real_t denom = vec3_cross(normal0, normal1).dot(normal2);
 
-	if (ABS(denom) <= CMP_EPSILON)
+	if (Math::is_zero_approx(denom))
 		return false;
 
 	if (r_result) {

--- a/modules/mono/glue/Managed/Files/Plane.cs
+++ b/modules/mono/glue/Managed/Files/Plane.cs
@@ -82,12 +82,12 @@ namespace Godot
             return Mathf.Abs(dist) <= epsilon;
         }
 
-        public Vector3 Intersect3(Plane b, Plane c)
+        public Vector3? Intersect3(Plane b, Plane c)
         {
             real_t denom = _normal.Cross(b._normal).Dot(c._normal);
 
-            if (Mathf.Abs(denom) <= Mathf.Epsilon)
-                return new Vector3();
+            if (Mathf.IsZeroApprox(denom))
+                return null;
 
             Vector3 result = b._normal.Cross(c._normal) * D +
                                 c._normal.Cross(_normal) * b.D +
@@ -96,34 +96,35 @@ namespace Godot
             return result / denom;
         }
 
-        public Vector3 IntersectRay(Vector3 from, Vector3 dir)
+        public Vector3? IntersectRay(Vector3 from, Vector3 dir)
         {
             real_t den = _normal.Dot(dir);
 
-            if (Mathf.Abs(den) <= Mathf.Epsilon)
-                return new Vector3();
+            if (Mathf.IsZeroApprox(den))
+                return null;
 
             real_t dist = (_normal.Dot(from) - D) / den;
 
             // This is a ray, before the emitting pos (from) does not exist
             if (dist > Mathf.Epsilon)
-                return new Vector3();
+                return null;
 
             return from + dir * -dist;
         }
 
-        public Vector3 IntersectSegment(Vector3 begin, Vector3 end)
+        public Vector3? IntersectSegment(Vector3 begin, Vector3 end)
         {
             Vector3 segment = begin - end;
             real_t den = _normal.Dot(segment);
 
-            if (Mathf.Abs(den) <= Mathf.Epsilon)
-                return new Vector3();
+            if (Mathf.IsZeroApprox(den))
+                return null;
 
             real_t dist = (_normal.Dot(begin) - D) / den;
 
+            // Only allow dist to be in the range of 0 to 1, with tolerance.
             if (dist < -Mathf.Epsilon || dist > 1.0f + Mathf.Epsilon)
-                return new Vector3();
+                return null;
 
             return begin + segment * -dist;
         }


### PR DESCRIPTION
Null is returned whenever the methods do not find an intersection, matching the behavior of GDScript. The method return type has been changed to `Vector3?`, which breaks compatibility. Might be best to put this on the 4.0 milestone. Closes #32614 

Also there's minor semantic changes to use `IsZeroApprox()`.