### PR TITLE
lsp: Send godot class tree to clients

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -134,6 +134,22 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 }
 
 void GDScriptLanguageProtocol::initialized(const Variant &p_params) {
+
+	lsp::GodotCapabilities capabilities;
+
+	DocData *doc = EditorHelp::get_doc_data();
+	for (Map<String, DocData::ClassDoc>::Element *E = doc->class_list.front(); E; E = E->next()) {
+
+		lsp::GodotNativeClassInfo gdclass;
+		gdclass.name = E->get().name;
+		gdclass.class_doc = &(E->get());
+		if (ClassDB::ClassInfo *ptr = ClassDB::classes.getptr(StringName(E->get().name))) {
+			gdclass.class_info = ptr;
+		}
+		capabilities.native_classes.push_back(gdclass);
+	}
+
+	notify_client("gdscript/capabilities", capabilities.to_json());
 }
 
 void GDScriptLanguageProtocol::poll() {

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -31,7 +31,9 @@
 #ifndef GODOT_LSP_H
 #define GODOT_LSP_H
 
-#include "core/variant.h"
+#include "core/class_db.h"
+#include "core/list.h"
+#include "editor/doc/doc_data.h"
 
 namespace lsp {
 
@@ -1563,6 +1565,39 @@ struct InitializeResult {
 	_FORCE_INLINE_ Dictionary to_json() {
 		Dictionary dict;
 		dict["capabilities"] = capabilities.to_json();
+		return dict;
+	}
+};
+
+struct GodotNativeClassInfo {
+
+	String name;
+	const DocData::ClassDoc *class_doc = NULL;
+	const ClassDB::ClassInfo *class_info = NULL;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		dict["name"] = name;
+		dict["inherits"] = class_doc->inherits;
+		return dict;
+	}
+};
+
+/** Features not included in the standart lsp specifications */
+struct GodotCapabilities {
+
+	/**
+	 * Native class list
+	*/
+	List<GodotNativeClassInfo> native_classes;
+
+	Dictionary to_json() {
+		Dictionary dict;
+		Array classes;
+		for (List<GodotNativeClassInfo>::Element *E = native_classes.front(); E; E = E->next()) {
+			classes.push_back(E->get().to_json());
+		}
+		dict["native_classes"] = classes;
 		return dict;
 	}
 };


### PR DESCRIPTION
With class inherit tree infomation clients can make more useful things as possible.

* VSCode client can display inherit  relationships now.
![image](https://user-images.githubusercontent.com/6964556/66454142-72e4bd80-ea99-11e9-8741-ed3bdf33d3b2.png)
* VSCode client now allow search class documentations now.
![image](https://user-images.githubusercontent.com/6964556/66454172-96a80380-ea99-11e9-92db-c7c57419e418.png)
