### PR TITLE
Fixes deselection not working when merging scene

### DIFF
--- a/editor/editor_sub_scene.cpp
+++ b/editor/editor_sub_scene.cpp
@@ -97,8 +97,14 @@ void EditorSubScene::_fill_tree(Node *p_node, TreeItem *p_parent) {
 }
 
 void EditorSubScene::_selected_changed() {
-	selection.clear();
-	is_root = false;
+	TreeItem *item = tree->get_selected();
+	ERR_FAIL_COND(!item);
+	Node *n = item->get_metadata(0);
+
+	if (!n || !selection.find(n)) {
+		selection.clear();
+		is_root = false;
+	}
 }
 
 void EditorSubScene::_item_multi_selected(Object *p_object, int p_cell, bool p_selected) {
@@ -116,6 +122,11 @@ void EditorSubScene::_item_multi_selected(Object *p_object, int p_cell, bool p_s
 				selection.clear();
 			}
 			selection.push_back(n);
+		} else {
+			List<Node *>::Element *E = selection.find(n);
+
+			if (E)
+				selection.erase(E);
 		}
 	}
 }


### PR DESCRIPTION
Fixes the issue of multiselection retaining its selection when deselecting in the merge scene dialog.

Closes: #32445

`EditorSubScene::_selected_changed()` is modified because of a related issue regarding single selection on a multiselection. For example, if you select 3 items and then select a single item within that selection, the selection is cleared and nothing happens when you press OK. This is because of the way that `Tree::select_single_item()` works: https://github.com/godotengine/godot/blob/41aac7c2df920fe5c5c272b30ccd623875a36a91/scene/gui/tree.cpp#L1611-L1621
Doing so only calls `cell_selected()` and doesn't call `multi_selected`