### PR TITLE
Makes cubemaps to be works in visual shaders

### DIFF
--- a/doc/classes/VisualShaderNodeCubeMapUniform.xml
+++ b/doc/classes/VisualShaderNodeCubeMapUniform.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeCubeMapUniform" inherits="VisualShaderNode" category="Core" version="3.2">
+<class name="VisualShaderNodeCubeMapUniform" inherits="VisualShaderNodeTextureUniform" category="Core" version="3.2">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1067,7 +1067,16 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 
 				VisualShaderNodeUniform *uniform = (VisualShaderNodeUniform *)graph[type].nodes[from_node].node.ptr();
 				if (uniform) {
-					inputs[i] = uniform->get_uniform_name();
+					inputs[i] = "";
+					switch (uniform->get_uniform_type()) {
+						case VisualShaderNodeUniform::UTYPE_CUBEMAP:
+							inputs[i] += "cube_";
+							break;
+						case VisualShaderNodeUniform::UTYPE_SAMPLER2D:
+							inputs[i] += "s2d_";
+							break;
+					}
+					inputs[i] += uniform->get_uniform_name();
 				} else {
 					inputs[i] = "";
 				}
@@ -1973,7 +1982,16 @@ void VisualShaderNodeUniform::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "uniform_name"), "set_uniform_name", "get_uniform_name");
 }
 
+int VisualShaderNodeUniform::get_uniform_type() const {
+	return (int)uniform_type;
+}
+
+void VisualShaderNodeUniform::set_uniform_type(int p_type) {
+	uniform_type = (UniformType)p_type;
+}
+
 VisualShaderNodeUniform::VisualShaderNodeUniform() {
+	uniform_type = UTYPE_NONE;
 }
 
 ////////////// GroupBase

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -353,7 +353,16 @@ public:
 class VisualShaderNodeUniform : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeUniform, VisualShaderNode);
 
+public:
+	enum UniformType {
+		UTYPE_NONE,
+		UTYPE_CUBEMAP,
+		UTYPE_SAMPLER2D,
+	};
+
+private:
 	String uniform_name;
+	UniformType uniform_type;
 
 protected:
 	static void _bind_methods();
@@ -361,6 +370,9 @@ protected:
 public:
 	void set_uniform_name(const String &p_name);
 	String get_uniform_name() const;
+
+	int get_uniform_type() const;
+	void set_uniform_type(int p_type);
 
 	VisualShaderNodeUniform();
 };

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -277,6 +277,7 @@ public:
 	virtual int get_input_port_count() const;
 	virtual PortType get_input_port_type(int p_port) const;
 	virtual String get_input_port_name(int p_port) const;
+	virtual String get_input_port_default_hint(int p_port) const;
 
 	virtual int get_output_port_count() const;
 	virtual PortType get_output_port_type(int p_port) const;
@@ -1412,7 +1413,7 @@ public:
 		COLOR_DEFAULT_BLACK
 	};
 
-private:
+protected:
 	TextureType texture_type;
 	ColorDefault color_default;
 
@@ -1471,8 +1472,8 @@ public:
 
 ///////////////////////////////////////
 
-class VisualShaderNodeCubeMapUniform : public VisualShaderNode {
-	GDCLASS(VisualShaderNodeCubeMapUniform, VisualShaderNode);
+class VisualShaderNodeCubeMapUniform : public VisualShaderNodeTextureUniform {
+	GDCLASS(VisualShaderNodeCubeMapUniform, VisualShaderNodeTextureUniform);
 
 public:
 	virtual String get_caption() const;
@@ -1485,6 +1486,8 @@ public:
 	virtual PortType get_output_port_type(int p_port) const;
 	virtual String get_output_port_name(int p_port) const;
 
+	virtual String get_input_port_default_hint(int p_port) const;
+	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
 	VisualShaderNodeCubeMapUniform();


### PR DESCRIPTION
In current version CubeMaps in Visual Shaders are not working at all - CubeMapUniform seems empty and CubeMap contains incorrect code inside itself. So I've fixed it by making CubeMapUniform to be derived from TextureUniform and returns only reference to sampler which then can be handled by Texture node - I think its more correct for TextureUniform's - in 4.0 I want to make this also for TextureUniform (2d) (but not now cuz it will break compatibility).

![image](https://user-images.githubusercontent.com/3036176/66464914-8fc4c500-ea88-11e9-91d3-ef60c28ef6cf.png)

I've added internal type hint for samplers so the code above will correctly handled by texture. The generated code will look like this:

```
shader_type spatial;
uniform samplerCube CubeMapUniform : hint_albedo;



void vertex() {
// Output:0

}

void fragment() {
// CubeMapUniform:2

// Texture:3
	vec3 n_out3p0;
	float n_out3p1;
	vec4 CubeMapUniform_tex_read = texture( CubeMapUniform , vec3(UV, 0.0) );
	n_out3p0 = CubeMapUniform_tex_read.rgb;
	n_out3p1 = CubeMapUniform_tex_read.a;

// Output:0
	ALBEDO = n_out3p0;

}

void light() {
// Output:0

}
```
