### PR TITLE
Fix crash when using `Node.get_as_property_path()`

### DIFF
--- a/core/node_path.cpp
+++ b/core/node_path.cpp
@@ -269,7 +269,7 @@ NodePath NodePath::rel_path_to(const NodePath &p_np) const {
 
 NodePath NodePath::get_as_property_path() const {
 
-	if (!data->path.size()) {
+	if (!data || !data->path.size()) {
 		return *this;
 	} else {
 		Vector<StringName> new_path = data->subpath;


### PR DESCRIPTION
This closes #32679.