### PR TITLE
Remove editor dependency

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -189,7 +189,7 @@ Help(opts.GenerateHelpText(env_base))  # generate help
 
 # add default include paths
 
-env_base.Prepend(CPPPATH=['#', '#editor'])
+env_base.Prepend(CPPPATH=['#'])
 
 # configure ENV for platform
 env_base.platform_exporters = platform_exporters

--- a/editor/import/resource_importer_obj.h
+++ b/editor/import/resource_importer_obj.h
@@ -31,7 +31,7 @@
 #ifndef RESOURCEIMPORTEROBJ_H
 #define RESOURCEIMPORTEROBJ_H
 
-#include "import/resource_importer_scene.h"
+#include "resource_importer_scene.h"
 
 class EditorOBJImporter : public EditorSceneImporter {
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -32,8 +32,8 @@
 
 #include "core/io/json.h"
 #include "core/version.h"
-#include "editor_node.h"
-#include "editor_settings.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
 
 void EditorAssetLibraryItem::configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, const String &p_cost) {
 

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -31,24 +31,22 @@
 #ifndef ASSET_LIBRARY_EDITOR_PLUGIN_H
 #define ASSET_LIBRARY_EDITOR_PLUGIN_H
 
-#include "editor_plugin.h"
+#include "editor/editor_asset_installer.h"
+#include "editor/editor_plugin.h"
+#include "editor/editor_plugin_settings.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/grid_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/link_button.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/progress_bar.h"
-#include "scene/gui/separator.h"
-#include "scene/gui/tab_container.h"
-
-#include "editor_plugin_settings.h"
-#include "scene/gui/grid_container.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
+#include "scene/gui/separator.h"
+#include "scene/gui/tab_container.h"
 #include "scene/gui/texture_button.h"
-
-#include "editor_asset_installer.h"
 #include "scene/main/http_request.h"
 
 class EditorAssetLibraryItem : public PanelContainer {

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -31,7 +31,7 @@
 #include "text_editor.h"
 
 #include "core/os/keyboard.h"
-#include "editor_node.h"
+#include "editor/editor_node.h"
 
 void TextEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
 	highlighters[p_highlighter->get_name()] = p_highlighter;

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -29,11 +29,12 @@
 /*************************************************************************/
 
 #include "editor_scene_importer_assimp.h"
+
 #include "core/bind/core_bind.h"
 #include "core/io/image_loader.h"
 #include "editor/editor_file_system.h"
+#include "editor/editor_settings.h"
 #include "editor/import/resource_importer_scene.h"
-#include "editor_settings.h"
 #include "import_utils.h"
 #include "scene/3d/camera.h"
 #include "scene/3d/light.h"

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -32,7 +32,7 @@
 
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
-#include "editor_scale.h"
+#include "editor/editor_scale.h"
 #include "modules/visual_script/visual_script.h"
 #include "modules/visual_script/visual_script_builtin_funcs.h"
 #include "modules/visual_script/visual_script_flow_control.h"

--- a/modules/visual_script/visual_script_property_selector.h
+++ b/modules/visual_script/visual_script_property_selector.h
@@ -31,8 +31,8 @@
 #ifndef VISUALSCRIPT_PROPERTYSELECTOR_H
 #define VISUALSCRIPT_PROPERTYSELECTOR_H
 
+#include "editor/editor_help.h"
 #include "editor/property_editor.h"
-#include "editor_help.h"
 #include "scene/gui/rich_text_label.h"
 
 class VisualScriptPropertySelector : public ConfirmationDialog {

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -29,8 +29,8 @@
 /*************************************************************************/
 
 #include "core/io/zip_io.h"
+#include "editor/editor_export.h"
 #include "editor/editor_node.h"
-#include "editor_export.h"
 #include "main/splash.gen.h"
 #include "platform/javascript/logo.gen.h"
 #include "platform/javascript/run_icon.gen.h"

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -35,8 +35,8 @@
 #include "core/os/os.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor_scale.h"
-#include "editor_settings.h"
+#include "editor/editor_scale.h"
+#include "editor/editor_settings.h"
 #endif
 #include "scene/main/viewport.h"
 


### PR DESCRIPTION
Building on #21978. This patch removes the dependency on the editor directory being in the build's include path. The first commit updates the files that were dependent on the editor directory being in the include path. The second commit removes editor from the SConstruct CPPATH.

