### PR TITLE
Removed "rebuild" function from public interface of VisualShader

### DIFF
--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -145,12 +145,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="rebuild">
-			<return type="void">
-			</return>
-			<description>
-			</description>
-		</method>
 		<method name="remove_node">
 			<return type="void">
 			</return>

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1358,7 +1358,6 @@ void VisualShader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_valid_node_id", "type"), &VisualShader::get_valid_node_id);
 
 	ClassDB::bind_method(D_METHOD("remove_node", "type", "id"), &VisualShader::remove_node);
-	ClassDB::bind_method(D_METHOD("rebuild"), &VisualShader::rebuild);
 
 	ClassDB::bind_method(D_METHOD("is_node_connection", "type", "from_node", "from_port", "to_node", "to_port"), &VisualShader::is_node_connection);
 	ClassDB::bind_method(D_METHOD("can_connect_nodes", "type", "from_node", "from_port", "to_node", "to_port"), &VisualShader::is_node_connection);


### PR DESCRIPTION
This function is not intended to be public. The usage of VisualShader in code must be focused only to construct resource and use it within ResourceSaver or ShaderMaterial - and not to play god and try to rebuild the shader inside it - the editor will do that for you internally. Fix #32700