### PR TITLE
Prevents folding of member tree on drag&drop in visual shader

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -178,6 +178,9 @@ bool VisualShaderEditor::_is_available(int p_mode) {
 }
 
 void VisualShaderEditor::update_custom_nodes() {
+	if (members_dialog->is_visible()) {
+		return;
+	}
 	clear_custom_types();
 	List<StringName> class_list;
 	ScriptServer::get_global_class_list(&class_list);


### PR DESCRIPTION
Bugfix of
![dragdrop_bug](https://user-images.githubusercontent.com/3036176/66564766-7ba4c480-eb69-11e9-851b-b45c357517f7.gif)
