### PR TITLE
Fixed ScriptEditor autosave timer causing errors on start

### DIFF
--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -343,6 +343,7 @@ class ScriptEditor : public PanelContainer {
 	void _save_layout();
 	void _editor_settings_changed();
 	void _autosave_scripts();
+	void _update_autosave_timer();
 
 	void _update_members_overview_visibility();
 	void _update_members_overview();


### PR DESCRIPTION
Now waiting for the timer to enter the tree to start it. Also cleaned some duplicated code.

Fixes #32685