### PR TITLE
Fixes concaveshape not selecting in viewport

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -3730,6 +3730,7 @@ void CollisionShapeSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 		Ref<ConcavePolygonShape> cs2 = s;
 		Ref<ArrayMesh> mesh = cs2->get_debug_mesh();
 		p_gizmo->add_mesh(mesh, false, Ref<SkinReference>(), material);
+		p_gizmo->add_collision_segments(cs2->get_debug_mesh_lines());
 	}
 
 	if (Object::cast_to<RayShape>(*s)) {

--- a/scene/resources/box_shape.cpp
+++ b/scene/resources/box_shape.cpp
@@ -31,7 +31,7 @@
 #include "box_shape.h"
 #include "servers/physics_server.h"
 
-Vector<Vector3> BoxShape::_gen_debug_mesh_lines() {
+Vector<Vector3> BoxShape::get_debug_mesh_lines() {
 
 	Vector<Vector3> lines;
 	AABB aabb;

--- a/scene/resources/box_shape.h
+++ b/scene/resources/box_shape.h
@@ -42,11 +42,12 @@ protected:
 	static void _bind_methods();
 
 	virtual void _update_shape();
-	virtual Vector<Vector3> _gen_debug_mesh_lines();
 
 public:
 	void set_extents(const Vector3 &p_extents);
 	Vector3 get_extents() const;
+
+	virtual Vector<Vector3> get_debug_mesh_lines();
 
 	BoxShape();
 };

--- a/scene/resources/capsule_shape.cpp
+++ b/scene/resources/capsule_shape.cpp
@@ -31,7 +31,7 @@
 #include "capsule_shape.h"
 #include "servers/physics_server.h"
 
-Vector<Vector3> CapsuleShape::_gen_debug_mesh_lines() {
+Vector<Vector3> CapsuleShape::get_debug_mesh_lines() {
 
 	float radius = get_radius();
 	float height = get_height();

--- a/scene/resources/capsule_shape.h
+++ b/scene/resources/capsule_shape.h
@@ -44,13 +44,13 @@ protected:
 
 	virtual void _update_shape();
 
-	virtual Vector<Vector3> _gen_debug_mesh_lines();
-
 public:
 	void set_radius(float p_radius);
 	float get_radius() const;
 	void set_height(float p_height);
 	float get_height() const;
+
+	virtual Vector<Vector3> get_debug_mesh_lines();
 
 	CapsuleShape();
 };

--- a/scene/resources/concave_polygon_shape.cpp
+++ b/scene/resources/concave_polygon_shape.cpp
@@ -32,7 +32,7 @@
 
 #include "servers/physics_server.h"
 
-Vector<Vector3> ConcavePolygonShape::_gen_debug_mesh_lines() {
+Vector<Vector3> ConcavePolygonShape::get_debug_mesh_lines() {
 
 	Set<DrawEdge> edges;
 

--- a/scene/resources/concave_polygon_shape.h
+++ b/scene/resources/concave_polygon_shape.h
@@ -61,11 +61,12 @@ protected:
 	static void _bind_methods();
 
 	virtual void _update_shape();
-	virtual Vector<Vector3> _gen_debug_mesh_lines();
 
 public:
 	void set_faces(const PoolVector<Vector3> &p_faces);
 	PoolVector<Vector3> get_faces() const;
+
+	Vector<Vector3> get_debug_mesh_lines();
 
 	ConcavePolygonShape();
 };

--- a/scene/resources/convex_polygon_shape.cpp
+++ b/scene/resources/convex_polygon_shape.cpp
@@ -32,7 +32,7 @@
 #include "core/math/quick_hull.h"
 #include "servers/physics_server.h"
 
-Vector<Vector3> ConvexPolygonShape::_gen_debug_mesh_lines() {
+Vector<Vector3> ConvexPolygonShape::get_debug_mesh_lines() {
 
 	PoolVector<Vector3> points = get_points();
 

--- a/scene/resources/convex_polygon_shape.h
+++ b/scene/resources/convex_polygon_shape.h
@@ -43,11 +43,11 @@ protected:
 
 	virtual void _update_shape();
 
-	virtual Vector<Vector3> _gen_debug_mesh_lines();
-
 public:
 	void set_points(const PoolVector<Vector3> &p_points);
 	PoolVector<Vector3> get_points() const;
+
+	virtual Vector<Vector3> get_debug_mesh_lines();
 
 	ConvexPolygonShape();
 };

--- a/scene/resources/cylinder_shape.cpp
+++ b/scene/resources/cylinder_shape.cpp
@@ -31,7 +31,7 @@
 #include "cylinder_shape.h"
 #include "servers/physics_server.h"
 
-Vector<Vector3> CylinderShape::_gen_debug_mesh_lines() {
+Vector<Vector3> CylinderShape::get_debug_mesh_lines() {
 
 	float radius = get_radius();
 	float height = get_height();

--- a/scene/resources/cylinder_shape.h
+++ b/scene/resources/cylinder_shape.h
@@ -43,13 +43,13 @@ protected:
 	static void _bind_methods();
 	virtual void _update_shape();
 
-	virtual Vector<Vector3> _gen_debug_mesh_lines();
-
 public:
 	void set_radius(float p_radius);
 	float get_radius() const;
 	void set_height(float p_height);
 	float get_height() const;
+
+	virtual Vector<Vector3> get_debug_mesh_lines();
 
 	CylinderShape();
 };

--- a/scene/resources/height_map_shape.cpp
+++ b/scene/resources/height_map_shape.cpp
@@ -31,7 +31,7 @@
 #include "height_map_shape.h"
 #include "servers/physics_server.h"
 
-Vector<Vector3> HeightMapShape::_gen_debug_mesh_lines() {
+Vector<Vector3> HeightMapShape::get_debug_mesh_lines() {
 	Vector<Vector3> points;
 
 	if ((map_width != 0) && (map_depth != 0)) {

--- a/scene/resources/height_map_shape.h
+++ b/scene/resources/height_map_shape.h
@@ -46,8 +46,6 @@ protected:
 	static void _bind_methods();
 	virtual void _update_shape();
 
-	virtual Vector<Vector3> _gen_debug_mesh_lines();
-
 public:
 	void set_map_width(int p_new);
 	int get_map_width() const;
@@ -55,6 +53,8 @@ public:
 	int get_map_depth() const;
 	void set_map_data(PoolRealArray p_new);
 	PoolRealArray get_map_data() const;
+
+	virtual Vector<Vector3> get_debug_mesh_lines();
 
 	HeightMapShape();
 };

--- a/scene/resources/plane_shape.cpp
+++ b/scene/resources/plane_shape.cpp
@@ -32,7 +32,7 @@
 
 #include "servers/physics_server.h"
 
-Vector<Vector3> PlaneShape::_gen_debug_mesh_lines() {
+Vector<Vector3> PlaneShape::get_debug_mesh_lines() {
 
 	Plane p = get_plane();
 	Vector<Vector3> points;

--- a/scene/resources/plane_shape.h
+++ b/scene/resources/plane_shape.h
@@ -42,11 +42,11 @@ protected:
 	static void _bind_methods();
 	virtual void _update_shape();
 
-	virtual Vector<Vector3> _gen_debug_mesh_lines();
-
 public:
 	void set_plane(Plane p_plane);
 	Plane get_plane() const;
+
+	virtual Vector<Vector3> get_debug_mesh_lines();
 
 	PlaneShape();
 };

--- a/scene/resources/ray_shape.cpp
+++ b/scene/resources/ray_shape.cpp
@@ -32,7 +32,7 @@
 
 #include "servers/physics_server.h"
 
-Vector<Vector3> RayShape::_gen_debug_mesh_lines() {
+Vector<Vector3> RayShape::get_debug_mesh_lines() {
 
 	Vector<Vector3> points;
 	points.push_back(Vector3());

--- a/scene/resources/ray_shape.h
+++ b/scene/resources/ray_shape.h
@@ -41,7 +41,6 @@ class RayShape : public Shape {
 protected:
 	static void _bind_methods();
 	virtual void _update_shape();
-	virtual Vector<Vector3> _gen_debug_mesh_lines();
 
 public:
 	void set_length(float p_length);
@@ -49,6 +48,8 @@ public:
 
 	void set_slips_on_slope(bool p_active);
 	bool get_slips_on_slope() const;
+
+	virtual Vector<Vector3> get_debug_mesh_lines();
 
 	RayShape();
 };

--- a/scene/resources/shape.cpp
+++ b/scene/resources/shape.cpp
@@ -37,7 +37,7 @@
 
 void Shape::add_vertices_to_array(PoolVector<Vector3> &array, const Transform &p_xform) {
 
-	Vector<Vector3> toadd = _gen_debug_mesh_lines();
+	Vector<Vector3> toadd = get_debug_mesh_lines();
 
 	if (toadd.size()) {
 
@@ -64,7 +64,7 @@ Ref<ArrayMesh> Shape::get_debug_mesh() {
 	if (debug_mesh_cache.is_valid())
 		return debug_mesh_cache;
 
-	Vector<Vector3> lines = _gen_debug_mesh_lines();
+	Vector<Vector3> lines = get_debug_mesh_lines();
 
 	debug_mesh_cache = Ref<ArrayMesh>(memnew(ArrayMesh));
 

--- a/scene/resources/shape.h
+++ b/scene/resources/shape.h
@@ -50,13 +50,13 @@ protected:
 	_FORCE_INLINE_ RID get_shape() const { return shape; }
 	Shape(RID p_shape);
 
-	virtual Vector<Vector3> _gen_debug_mesh_lines() = 0; // { return Vector<Vector3>(); }
 	virtual void _update_shape();
 
 public:
 	virtual RID get_rid() const { return shape; }
 
 	Ref<ArrayMesh> get_debug_mesh();
+	virtual Vector<Vector3> get_debug_mesh_lines() = 0; // { return Vector<Vector3>(); }
 
 	void add_vertices_to_array(PoolVector<Vector3> &array, const Transform &p_xform);
 

--- a/scene/resources/sphere_shape.cpp
+++ b/scene/resources/sphere_shape.cpp
@@ -31,7 +31,7 @@
 #include "sphere_shape.h"
 #include "servers/physics_server.h"
 
-Vector<Vector3> SphereShape::_gen_debug_mesh_lines() {
+Vector<Vector3> SphereShape::get_debug_mesh_lines() {
 
 	float r = get_radius();
 

--- a/scene/resources/sphere_shape.h
+++ b/scene/resources/sphere_shape.h
@@ -42,11 +42,12 @@ protected:
 	static void _bind_methods();
 
 	virtual void _update_shape();
-	virtual Vector<Vector3> _gen_debug_mesh_lines();
 
 public:
 	void set_radius(float p_radius);
 	float get_radius() const;
+
+	virtual Vector<Vector3> get_debug_mesh_lines();
 
 	SphereShape();
 };


### PR DESCRIPTION
This PR resolves the issue of ConcaveShapes not being selectable in the Viewport.

Partially addresses: #32177