### PR TITLE
C#: Fix detection of outdated release Godot API assemblies

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
@@ -160,9 +160,16 @@ namespace GodotTools
             if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
                 return true; // No solution to build
 
-            // Make sure to update the API assemblies if they happen to be missing. Just in
-            // case the user decided to delete them at some point after they were loaded.
-            Internal.UpdateApiAssembliesFromPrebuilt();
+            // Make sure the API assemblies are up to date before building the project.
+            // We may not have had the chance to update the release API assemblies, and the debug ones
+            // may have been deleted by the user at some point after they were loaded by the Godot editor.
+            string apiAssembliesUpdateError = Internal.UpdateApiAssembliesFromPrebuilt(config == "Release" ? "Release" : "Debug");
+
+            if (!string.IsNullOrEmpty(apiAssembliesUpdateError))
+            {
+                ShowBuildErrorDialog("Failed to update the Godot API assemblies");
+                return false;
+            }
 
             var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
             var buildTool = (BuildTool) editorSettings.GetSetting("mono/builds/build_tool");

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -34,7 +34,7 @@ namespace GodotTools
 
         private bool CreateProjectSolution()
         {
-            using (var pr = new EditorProgress("create_csharp_solution", "Generating solution...".TTR(), 2))
+            using (var pr = new EditorProgress("create_csharp_solution", "Generating solution...".TTR(), 3))
             {
                 pr.Step("Generating C# project...".TTR());
 
@@ -73,9 +73,23 @@ namespace GodotTools
                         return false;
                     }
 
-                    // Make sure to update the API assemblies if they happen to be missing. Just in
-                    // case the user decided to delete them at some point after they were loaded.
-                    Internal.UpdateApiAssembliesFromPrebuilt();
+                    pr.Step("Updating Godot API assemblies...".TTR());
+
+                    string debugApiAssembliesError = Internal.UpdateApiAssembliesFromPrebuilt("Debug");
+
+                    if (!string.IsNullOrEmpty(debugApiAssembliesError))
+                    {
+                        ShowErrorDialog("Failed to update the Godot API assemblies: " + debugApiAssembliesError);
+                        return false;
+                    }
+
+                    string releaseApiAssembliesError = Internal.UpdateApiAssembliesFromPrebuilt("Release");
+
+                    if (!string.IsNullOrEmpty(releaseApiAssembliesError))
+                    {
+                        ShowErrorDialog("Failed to update the Godot API assemblies: " + releaseApiAssembliesError);
+                        return false;
+                    }
 
                     pr.Step("Done".TTR());
 

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -40,8 +40,7 @@ namespace GodotTools.Ides
 
         protected ILogger Logger
         {
-            get => logger ?? (logger = new ConsoleLogger());
-            set => logger = value;
+            get => logger ?? (logger = new GodotLogger());
         }
 
         private void StartServer()

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
@@ -10,8 +10,8 @@ namespace GodotTools.Internals
         public const string CSharpLanguageType = "CSharpScript";
         public const string CSharpLanguageExtension = "cs";
 
-        public static string UpdateApiAssembliesFromPrebuilt() =>
-            internal_UpdateApiAssembliesFromPrebuilt();
+        public static string UpdateApiAssembliesFromPrebuilt(string config) =>
+            internal_UpdateApiAssembliesFromPrebuilt(config);
 
         public static string FullTemplatesDir =>
             internal_FullTemplatesDir();
@@ -55,7 +55,7 @@ namespace GodotTools.Internals
         // Internal Calls
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern string internal_UpdateApiAssembliesFromPrebuilt();
+        private static extern string internal_UpdateApiAssembliesFromPrebuilt(string config);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_FullTemplatesDir();

--- a/modules/mono/editor/csharp_project.cpp
+++ b/modules/mono/editor/csharp_project.cpp
@@ -75,7 +75,7 @@ bool generate_api_solution(const String &p_solution_dir, const String &p_core_pr
 				p_editor_proj_dir, p_editor_compile_items,
 				GDMono::get_singleton()->get_tools_project_editor_assembly());
 	} else {
-		MonoDomain *temp_domain = GDMonoUtils::create_domain("GodotEngine.ApiSolutionGenerationDomain");
+		MonoDomain *temp_domain = GDMonoUtils::create_domain("GodotEngine.Domain.ApiSolutionGeneration");
 		CRASH_COND(temp_domain == NULL);
 		_GDMONO_SCOPE_EXIT_DOMAIN_UNLOAD_(temp_domain);
 

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -230,31 +230,9 @@ uint32_t godot_icall_GodotSharpExport_GetExportedAssemblyDependencies(MonoString
 	return GodotSharpExport::get_exported_assembly_dependencies(project_dll_name, project_dll_src_path, build_config, custom_lib_dir, dependencies);
 }
 
-float godot_icall_Globals_EditorScale() {
-	return EDSCALE;
-}
-
-MonoObject *godot_icall_Globals_GlobalDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
-	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
-	Variant default_value = GDMonoMarshal::mono_object_to_variant(p_default_value);
-	Variant result = _GLOBAL_DEF(setting, default_value, (bool)p_restart_if_changed);
-	return GDMonoMarshal::variant_to_mono_object(result);
-}
-
-MonoObject *godot_icall_Globals_EditorDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
-	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
-	Variant default_value = GDMonoMarshal::mono_object_to_variant(p_default_value);
-	Variant result = _EDITOR_DEF(setting, default_value, (bool)p_restart_if_changed);
-	return GDMonoMarshal::variant_to_mono_object(result);
-}
-
-MonoString *godot_icall_Globals_TTR(MonoString *p_text) {
-	String text = GDMonoMarshal::mono_string_to_godot(p_text);
-	return GDMonoMarshal::mono_string_from_godot(TTR(text));
-}
-
-MonoString *godot_icall_Internal_UpdateApiAssembliesFromPrebuilt() {
-	String error_str = GDMono::get_singleton()->update_api_assemblies_from_prebuilt();
+MonoString *godot_icall_Internal_UpdateApiAssembliesFromPrebuilt(MonoString *p_config) {
+	String config = GDMonoMarshal::mono_string_to_godot(p_config);
+	String error_str = GDMono::get_singleton()->update_api_assemblies_from_prebuilt(config);
 	return GDMonoMarshal::mono_string_from_godot(error_str);
 }
 
@@ -363,6 +341,29 @@ void godot_icall_Internal_ScriptEditorDebugger_ReloadScripts() {
 	if (sed) {
 		sed->reload_scripts();
 	}
+}
+
+float godot_icall_Globals_EditorScale() {
+	return EDSCALE;
+}
+
+MonoObject *godot_icall_Globals_GlobalDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
+	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
+	Variant default_value = GDMonoMarshal::mono_object_to_variant(p_default_value);
+	Variant result = _GLOBAL_DEF(setting, default_value, (bool)p_restart_if_changed);
+	return GDMonoMarshal::variant_to_mono_object(result);
+}
+
+MonoObject *godot_icall_Globals_EditorDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
+	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
+	Variant default_value = GDMonoMarshal::mono_object_to_variant(p_default_value);
+	Variant result = _EDITOR_DEF(setting, default_value, (bool)p_restart_if_changed);
+	return GDMonoMarshal::variant_to_mono_object(result);
+}
+
+MonoString *godot_icall_Globals_TTR(MonoString *p_text) {
+	String text = GDMonoMarshal::mono_string_to_godot(p_text);
+	return GDMonoMarshal::mono_string_from_godot(TTR(text));
 }
 
 MonoString *godot_icall_Utils_OS_GetPlatformName() {

--- a/modules/mono/editor/godotsharp_export.h
+++ b/modules/mono/editor/godotsharp_export.h
@@ -39,10 +39,11 @@
 
 namespace GodotSharpExport {
 
+Error get_assembly_dependencies(GDMonoAssembly *p_assembly, const Vector<String> &p_search_dirs, Dictionary &r_dependencies);
+
 Error get_exported_assembly_dependencies(const String &p_project_dll_name,
 		const String &p_project_dll_src_path, const String &p_build_config,
 		const String &p_custom_lib_dir, Dictionary &r_dependencies);
-Error get_assembly_dependencies(GDMonoAssembly *p_assembly, const Vector<String> &p_search_dirs, Dictionary &r_dependencies);
 
 } // namespace GodotSharpExport
 

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -43,25 +43,13 @@
 #include "utils/android_utils.h"
 #endif
 
+#include "mono_gd/gd_mono.h"
+
 namespace GodotSharpDirs {
 
 String _get_expected_build_config() {
 #ifdef TOOLS_ENABLED
 	return "Tools";
-#else
-
-#ifdef DEBUG_ENABLED
-	return "Debug";
-#else
-	return "Release";
-#endif
-
-#endif
-}
-
-String _get_expected_api_build_config() {
-#ifdef TOOLS_ENABLED
-	return "Debug";
 #else
 
 #ifdef DEBUG_ENABLED
@@ -134,7 +122,7 @@ private:
 		res_data_dir = "res://.mono";
 		res_metadata_dir = res_data_dir.plus_file("metadata");
 		res_assemblies_base_dir = res_data_dir.plus_file("assemblies");
-		res_assemblies_dir = res_assemblies_base_dir.plus_file(_get_expected_api_build_config());
+		res_assemblies_dir = res_assemblies_base_dir.plus_file(GDMono::get_expected_api_build_config());
 		res_config_dir = res_data_dir.plus_file("etc").plus_file("mono");
 
 		// TODO use paths from csproj

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -550,6 +550,8 @@ MonoObject *create_managed_from(const Dictionary &p_from, GDMonoClass *p_class) 
 }
 
 MonoDomain *create_domain(const String &p_friendly_name) {
+	print_verbose("Mono: Creating domain '" + p_friendly_name + "'...");
+
 	MonoDomain *domain = mono_domain_create_appdomain((char *)p_friendly_name.utf8().get_data(), NULL);
 
 	if (domain) {


### PR DESCRIPTION
Should fix the issue @akien-mga reported to me, and it may also fix some of the other release template issues reported the last month.
