### PR TITLE
Improve editor property capitalization

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1780,11 +1780,11 @@ void EditorInspector::update_tree() {
 			if (dot != -1) {
 				String ov = name.right(dot);
 				name = name.substr(0, dot);
-				name = name.capitalize();
+				name = EditorNode::get_singleton()->capitalize_string(name);
 				name += ov;
 
 			} else {
-				name = name.capitalize();
+				name = EditorNode::get_singleton()->capitalize_string(name);
 			}
 		}
 
@@ -1794,7 +1794,7 @@ void EditorInspector::update_tree() {
 			String cat = path;
 
 			if (capitalize_paths) {
-				cat = cat.capitalize();
+				cat = EditorNode::get_singleton()->capitalize_string(cat);
 			}
 
 			if (!filter.is_subsequence_ofi(cat) && !filter.is_subsequence_ofi(name) && property_prefix.to_lower().find(filter.to_lower()) == -1) {
@@ -1824,7 +1824,7 @@ void EditorInspector::update_tree() {
 					sections.push_back(section);
 
 					if (capitalize_paths) {
-						path_name = path_name.capitalize();
+						path_name = EditorNode::get_singleton()->capitalize_string(path_name);
 					}
 
 					Color c = sscolor;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4824,6 +4824,17 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 	editor_data.get_undo_redo().commit_action();
 }
 
+String EditorNode::capitalize_string(const String &p_string) const {
+	String capitalized_string = p_string.capitalize();
+
+	// Fix the casing of a few strings commonly found in editor property/setting names
+	for (Map<String, String>::Element *E = capitalize_string_remaps.front(); E; E = E->next()) {
+		capitalized_string = capitalized_string.replace(E->key(), E->value());
+	}
+
+	return capitalized_string;
+}
+
 Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item) {
 	Button *tb = memnew(Button);
 	tb->set_flat(true);
@@ -5637,6 +5648,46 @@ EditorNode::EditorNode() {
 	EditorFileDialog::set_default_display_mode((EditorFileDialog::DisplayMode)EditorSettings::get_singleton()->get("filesystem/file_dialog/display_mode").operator int());
 	ResourceLoader::set_error_notify_func(this, _load_error_notify);
 	ResourceLoader::set_dependency_error_notify_func(this, _dependency_error_report);
+
+	// The map is initialized here to avoid initializing it every time a string is replaced.
+	capitalize_string_remaps["2d"] = "2D";
+	capitalize_string_remaps["3d"] = "3D";
+	capitalize_string_remaps["Adb"] = "ADB";
+	capitalize_string_remaps["Bptc"] = "BPTC";
+	capitalize_string_remaps["Csg"] = "CSG";
+	capitalize_string_remaps["Db"] = "dB";
+	capitalize_string_remaps["Dof"] = "DoF";
+	capitalize_string_remaps["Dpi"] = "DPI";
+	capitalize_string_remaps["Etc"] = "ETC";
+	capitalize_string_remaps["Fbx"] = "FBX";
+	capitalize_string_remaps["Fps"] = "FPS";
+	capitalize_string_remaps["Fov"] = "FOV";
+	capitalize_string_remaps["Fs"] = "FS";
+	capitalize_string_remaps["Fxaa"] = "FXAA";
+	capitalize_string_remaps["Ggx"] = "GGX";
+	capitalize_string_remaps["Gdscript"] = "GDScript";
+	capitalize_string_remaps["Gles 2"] = "GLES2";
+	capitalize_string_remaps["Gles 3"] = "GLES3";
+	capitalize_string_remaps["Hdr"] = "HDR";
+	capitalize_string_remaps["Hidpi"] = "hiDPI";
+	capitalize_string_remaps["Ios"] = "iOS";
+	capitalize_string_remaps["Kb"] = "KB";
+	capitalize_string_remaps["Msaa"] = "MSAA";
+	capitalize_string_remaps["Macos"] = "macOS";
+	capitalize_string_remaps["Opentype"] = "OpenType";
+	capitalize_string_remaps["Pvrtc"] = "PVRTC";
+	capitalize_string_remaps["S 3 Tc"] = "S3TC";
+	capitalize_string_remaps["Sdfgi"] = "SDFGI";
+	capitalize_string_remaps["Srgb"] = "sRGB";
+	capitalize_string_remaps["Ssao"] = "SSAO";
+	capitalize_string_remaps["Ssl"] = "SSL";
+	capitalize_string_remaps["Tcp"] = "TCP";
+	capitalize_string_remaps["Uv 1"] = "UV1";
+	capitalize_string_remaps["Uv 2"] = "UV2";
+	capitalize_string_remaps["Vram"] = "VRAM";
+	capitalize_string_remaps["Vsync"] = "V-Sync";
+	capitalize_string_remaps["Webrtc"] = "WebRTC";
+	capitalize_string_remaps["Websocket"] = "WebSocket";
 
 	{ //register importers at the beginning, so dialogs are created with the right extensions
 		Ref<ResourceImporterTexture> import_texture;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -421,6 +421,7 @@ private:
 	VBoxContainer *bottom_panel_vb;
 	Label *version_label;
 	Button *bottom_panel_raise;
+	Map<String, String> capitalize_string_remaps;
 
 	void _bottom_panel_raise_toggled(bool);
 
@@ -822,6 +823,8 @@ public:
 	bool is_exiting() const { return exiting; }
 
 	Button *get_pause_button() { return pause_button; }
+
+	String capitalize_string(const String &p_string) const;
 
 	Button *add_bottom_panel_item(String p_text, Control *p_item);
 	void make_bottom_panel_item_visible(Control *p_item);

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_sectioned_inspector.h"
 
+#include "editor_node.h"
 #include "editor_scale.h"
 
 class SectionedInspectorFilter : public Object {
@@ -261,7 +262,7 @@ void SectionedInspector::update_category_list() {
 			if (!section_map.has(metasection)) {
 				TreeItem *ms = sections->create_item(parent);
 				section_map[metasection] = ms;
-				ms->set_text(0, sectionarr[i].capitalize());
+				ms->set_text(0, EditorNode::get_singleton()->capitalize_string(sectionarr[i]));
 				ms->set_metadata(0, metasection);
 				ms->set_selectable(0, false);
 			}

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -218,7 +218,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 		} else {
 			section = shortcuts->create_item(root);
 
-			String item_name = section_name.capitalize();
+			String item_name = EditorNode::get_singleton()->capitalize_string(section_name);
 			section->set_text(0, item_name);
 
 			if (collapsed.has(item_name)) {


### PR DESCRIPTION
An hardcoded list of exceptions is now used to make property name capitalization more natural.

I'm not too happy with this implementation – maybe we should add an optional "friendly name" property hint in the end. Also, it takes more time to run the string replacements (30 µs on average for each string in a debug build, compared to 10 µs with the old method). Still, it's not run every frame so it *should* be fine performance-wise.

There are other improvements we can do, such as not capitalizing stop words like `at`, `in` and `to`. We could do this for the general-purpose `String::capitalize()` function in 4.0.

## Preview

*Look at the section and property names.*

![Project Settings](https://user-images.githubusercontent.com/180032/66614780-90657480-ebca-11e9-83ec-ec182e5ea94a.png)

This closes https://github.com/godotengine/godot-proposals/issues/1399.