### PR TITLE
Added sampler port to CubeMap, fixed parsing in expresssions

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1067,16 +1067,7 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 
 				VisualShaderNodeUniform *uniform = (VisualShaderNodeUniform *)graph[type].nodes[from_node].node.ptr();
 				if (uniform) {
-					inputs[i] = "";
-					switch (uniform->get_uniform_type()) {
-						case VisualShaderNodeUniform::UTYPE_CUBEMAP:
-							inputs[i] += "cube_";
-							break;
-						case VisualShaderNodeUniform::UTYPE_SAMPLER2D:
-							inputs[i] += "s2d_";
-							break;
-					}
-					inputs[i] += uniform->get_uniform_name();
+					inputs[i] = uniform->get_uniform_name();
 				} else {
 					inputs[i] = "";
 				}
@@ -1981,16 +1972,7 @@ void VisualShaderNodeUniform::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "uniform_name"), "set_uniform_name", "get_uniform_name");
 }
 
-int VisualShaderNodeUniform::get_uniform_type() const {
-	return (int)uniform_type;
-}
-
-void VisualShaderNodeUniform::set_uniform_type(int p_type) {
-	uniform_type = (UniformType)p_type;
-}
-
 VisualShaderNodeUniform::VisualShaderNodeUniform() {
-	uniform_type = UTYPE_NONE;
 }
 
 ////////////// GroupBase

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -353,16 +353,8 @@ public:
 class VisualShaderNodeUniform : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeUniform, VisualShaderNode);
 
-public:
-	enum UniformType {
-		UTYPE_NONE,
-		UTYPE_CUBEMAP,
-		UTYPE_SAMPLER2D,
-	};
-
 private:
 	String uniform_name;
-	UniformType uniform_type;
 
 protected:
 	static void _bind_methods();
@@ -370,9 +362,6 @@ protected:
 public:
 	void set_uniform_name(const String &p_name);
 	String get_uniform_name() const;
-
-	int get_uniform_type() const;
-	void set_uniform_type(int p_type);
 
 	VisualShaderNodeUniform();
 };

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -259,6 +259,11 @@ class VisualShaderNodeCubeMap : public VisualShaderNode {
 	Ref<CubeMap> cube_map;
 
 public:
+	enum Source {
+		SOURCE_TEXTURE,
+		SOURCE_PORT
+	};
+
 	enum TextureType {
 		TYPE_DATA,
 		TYPE_COLOR,
@@ -266,6 +271,7 @@ public:
 	};
 
 private:
+	Source source;
 	TextureType texture_type;
 
 protected:
@@ -287,6 +293,9 @@ public:
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
+	void set_source(Source p_source);
+	Source get_source() const;
+
 	void set_cube_map(Ref<CubeMap> p_value);
 	Ref<CubeMap> get_cube_map() const;
 
@@ -299,6 +308,7 @@ public:
 };
 
 VARIANT_ENUM_CAST(VisualShaderNodeCubeMap::TextureType)
+VARIANT_ENUM_CAST(VisualShaderNodeCubeMap::Source)
 
 ///////////////////////////////////////
 /// OPS


### PR DESCRIPTION
Added "samplerCube" port to CubeMap which should accept sampler from CubeMapUniform, maked Texture node only accepts sampler2D from TextureUniform, fixed Expression by removing invalid parsing.

![image](https://user-images.githubusercontent.com/3036176/66632914-40120500-ec12-11e9-80d9-58f234261120.png)

Fix #32739