### PR TITLE
Don't use in some functions empty PoolByteArrays

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -553,7 +553,7 @@ struct _VariantCall {
 
 		PoolByteArray *ba = reinterpret_cast<PoolByteArray *>(p_self._data._mem);
 		String s;
-		if (ba->size() >= 0) {
+		if (ba->size() > 0) {
 			PoolByteArray::Read r = ba->read();
 			CharString cs;
 			cs.resize(ba->size() + 1);
@@ -569,7 +569,7 @@ struct _VariantCall {
 
 		PoolByteArray *ba = reinterpret_cast<PoolByteArray *>(p_self._data._mem);
 		String s;
-		if (ba->size() >= 0) {
+		if (ba->size() > 0) {
 			PoolByteArray::Read r = ba->read();
 			s.parse_utf8((const char *)r.ptr(), ba->size());
 		}
@@ -580,14 +580,15 @@ struct _VariantCall {
 
 		PoolByteArray *ba = reinterpret_cast<PoolByteArray *>(p_self._data._mem);
 		PoolByteArray compressed;
-		Compression::Mode mode = (Compression::Mode)(int)(*p_args[0]);
+		if (ba->size() > 0) {
+			Compression::Mode mode = (Compression::Mode)(int)(*p_args[0]);
 
-		compressed.resize(Compression::get_max_compressed_buffer_size(ba->size(), mode));
-		int result = Compression::compress(compressed.write().ptr(), ba->read().ptr(), ba->size(), mode);
+			compressed.resize(Compression::get_max_compressed_buffer_size(ba->size(), mode));
+			int result = Compression::compress(compressed.write().ptr(), ba->read().ptr(), ba->size(), mode);
 
-		result = result >= 0 ? result : 0;
-		compressed.resize(result);
-
+			result = result >= 0 ? result : 0;
+			compressed.resize(result);
+		}
 		r_ret = compressed;
 	}
 
@@ -615,6 +616,10 @@ struct _VariantCall {
 
 	static void _call_PoolByteArray_hex_encode(Variant &r_ret, Variant &p_self, const Variant **p_args) {
 		PoolByteArray *ba = reinterpret_cast<PoolByteArray *>(p_self._data._mem);
+		if (ba->size() == 0) {
+			r_ret = String();
+			return;
+		}
 		PoolByteArray::Read r = ba->read();
 		String s = String::hex_encode_buffer(&r[0], ba->size());
 		r_ret = s;


### PR DESCRIPTION
Fixes #32738 and prevents from this errors:
```
core/variant_call.cpp:560:4: runtime error: null pointer passed as argument 2, which is declared to never be null
core/io/compression.cpp:50:5: runtime error: null pointer passed as argument 2, which is declared to never be null
core/pool_vector.h:307:75: runtime error: reference binding to null pointer of type 'const unsigned char'
```