### PR TITLE
Fix to make sure the capture buffers are deallocated at shutdown.

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1079,6 +1079,7 @@ void AudioServer::finish() {
 
 	for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
 		AudioDriverManager::get_driver(i)->finish();
+		AudioDriverManager::get_driver(i)->clear_capture_buffer();
 	}
 
 	for (int i = 0; i < buses.size(); i++) {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -115,6 +115,8 @@ public:
 	unsigned int get_capture_position() { return capture_position; }
 	unsigned int get_capture_size() { return capture_size; }
 
+	void clear_capture_buffer() { capture_buffer.resize(0); }
+
 #ifdef DEBUG_ENABLED
 	uint64_t get_profiling_time() const { return prof_time; }
 	void reset_profiling_time() { prof_time = 0; }


### PR DESCRIPTION
Silences warnings about MemoryPool allocs in use at exit when closing the application after calling the capture_start method on the AudioServer.