### PR TITLE
Only render depth with alpha prepass on prepass

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1093,7 +1093,7 @@ void RasterizerSceneGLES3::gi_probe_instance_set_bounds(RID p_probe, const Vecto
 ////////////////////////////
 ////////////////////////////
 
-bool RasterizerSceneGLES3::_setup_material(RasterizerStorageGLES3::Material *p_material, bool p_alpha_pass) {
+bool RasterizerSceneGLES3::_setup_material(RasterizerStorageGLES3::Material *p_material, bool p_depth_pass, bool p_alpha_pass) {
 
 	/* this is handled outside
 	if (p_material->shader->spatial.cull_mode == RasterizerStorageGLES3::Shader::Spatial::CULL_MODE_DISABLED) {
@@ -1121,7 +1121,7 @@ bool RasterizerSceneGLES3::_setup_material(RasterizerStorageGLES3::Material *p_m
 	if (state.current_depth_draw != p_material->shader->spatial.depth_draw_mode) {
 		switch (p_material->shader->spatial.depth_draw_mode) {
 			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS: {
-				glDepthMask(GL_TRUE);
+				glDepthMask(p_depth_pass);
 				// If some transparent objects write to depth, we need to re-copy depth texture when we need it
 				if (p_alpha_pass && !state.used_depth_prepass) {
 					state.prepared_depth_texture = false;
@@ -2241,7 +2241,7 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 
 			storage->info.render.material_switch_count++;
 
-			rebind = _setup_material(material, p_alpha_pass);
+			rebind = _setup_material(material, use_opaque_prepass, p_alpha_pass);
 
 			if (rebind) {
 				storage->info.render.shader_rebind_count++;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -832,7 +832,7 @@ public:
 
 	_FORCE_INLINE_ void _set_cull(bool p_front, bool p_disabled, bool p_reverse_cull);
 
-	_FORCE_INLINE_ bool _setup_material(RasterizerStorageGLES3::Material *p_material, bool p_alpha_pass);
+	_FORCE_INLINE_ bool _setup_material(RasterizerStorageGLES3::Material *p_material, bool p_depth_pass, bool p_alpha_pass);
 	_FORCE_INLINE_ void _setup_geometry(RenderList::Element *e, const Transform &p_view_transform);
 	_FORCE_INLINE_ void _render_geometry(RenderList::Element *e);
 	_FORCE_INLINE_ void _setup_light(RenderList::Element *e, const Transform &p_view_transform);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/32016

This makes it so that the only time alpha_prepass materials render to depth is during the prepass. 

Bug was introduced by https://github.com/godotengine/godot/pull/31309 which never actually fully solved https://github.com/godotengine/godot/issues/28240. In the future, we need to figure out a better way of handling alpha and depth so that transparent objects can be blurred accurately. 