### PR TITLE
Fix mismatch between RigidBody2D and Body2DSW can_sleep defaults.

### DIFF
--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -794,7 +794,7 @@ BodySW::BodySW() :
 
 	still_time = 0;
 	continuous_cd = false;
-	can_sleep = false;
+	can_sleep = true;
 	fi_callback = NULL;
 }
 

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -694,7 +694,7 @@ Body2DSW::Body2DSW() :
 
 	still_time = 0;
 	continuous_cd_mode = Physics2DServer::CCD_MODE_DISABLED;
-	can_sleep = false;
+	can_sleep = true;
 	fi_callback = NULL;
 }
 


### PR DESCRIPTION
Fixes #25099
This patch fixes the mismatch between the default can_sleep variables of RigidBody2D in scene/2d/physics_body_2d and Body2DSW in servers/physics2d/body_2d_sw. The expected behaviour is that RigidBody2D can_sleep is true; so the change is made to Body2DSW.

This issue was exposed during the change from 3.0 and 3.1 when saving and loading scenes was changed to only include nodes' non-default values. In 3.0 the default can_sleep value was set in Body2DSW when the scene was loaded, because it was specified in the RigidBody2D node's properties. In 3.1 the default can_sleep value is not set when the scene is loaded; so RigidBody2Ds do not sleep until the can_sleep property is set to true in a script.