### PR TITLE
Fix the dependency error dialog being too small on hiDPI displays

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -646,7 +646,7 @@ DependencyErrorDialog::DependencyErrorDialog() {
 	vb->add_margin_child(TTR("Load failed due to missing dependencies:"), files, true);
 	files->set_v_size_flags(SIZE_EXPAND_FILL);
 
-	set_custom_minimum_size(Size2(500, 220));
+	set_custom_minimum_size(Size2(500, 220) * EDSCALE);
 	get_ok()->set_text(TTR("Open Anyway"));
 	get_cancel()->set_text(TTR("Close"));
 


### PR DESCRIPTION
This closes #32770.

## Preview

![Dependency error dialog on hiDPI](https://user-images.githubusercontent.com/180032/66702584-6cf51380-ed09-11e9-9915-ac8ba568241c.png)