### PR TITLE
Android Remote Debug & Scene Sync not working: Update editor_export.cpp

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -265,8 +265,6 @@ void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags)
 	String host = EditorSettings::get_singleton()->get("network/debug/remote_host");
 	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
-	if (p_flags & DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST)
-		host = "localhost";
 
 	if (p_flags & DEBUG_FLAG_DUMB_CLIENT) {
 		int port = EditorSettings::get_singleton()->get("filesystem/file_server/port");


### PR DESCRIPTION
**Godot version:**
3.1.1
**OS/device including version:**
Ubuntu 18.04 Laptop(development)
Android 7.0 Huawei GR5 (running the app)
**Issue description:**
Remote debug  and scene sync do not work. The service tries to connect to 'localhost' (which is the phone itself when it should connect to my laptop instead). 
I have set Editor Settings -> Network -> Debug -> Remote Host to 192.168.8.115 which is my laptop IP. But when deploying for android over [Wifi Adb](https://stackoverflow.com/questions/42364380/how-can-i-use-adb-over-wifi) the debug & sync service chooses "localhost" as Remote Host instead of 192.168.8.115. Since this service runs on the app the localhost becomes the phone instead of the laptop.

I installed a TCP listener app on my phone and listened to localhost:{Remote Port}. I got requests from the app to phone itself's remote port.



**Reason:**
editor/editor_export.cpp:EditorExportPlatform::gen_export_flags() method contains this line.


if (p_flags & DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST)
		host = "localhost";

This makes the method return "localhost" instead of the IP I chose ("192.168.8.115") as the Remote Host.
This PR deletes the buggy line.
Someone who knows the purpose of this line just delete it or handle it properly.