### PR TITLE
Fixed remote inspector for tool scripts

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -979,7 +979,7 @@ void Object::set_script_and_instance(const RefPtr &p_script, ScriptInstance *p_i
 	script_instance = p_instance;
 }
 
-void Object::set_script(const RefPtr &p_script) {
+void Object::set_script(const RefPtr &p_script, bool p_instantiate) {
 
 	if (script == p_script)
 		return;
@@ -993,7 +993,7 @@ void Object::set_script(const RefPtr &p_script) {
 	Ref<Script> s(script);
 
 	if (!s.is_null()) {
-		if (s->can_instance()) {
+		if (p_instantiate && s->can_instance()) {
 			OBJ_DEBUG_LOCK
 			script_instance = s->instance_create(this);
 		} else if (Engine::get_singleton()->is_editor_hint()) {
@@ -1667,7 +1667,7 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("to_string"), &Object::to_string);
 	ClassDB::bind_method(D_METHOD("get_instance_id"), &Object::get_instance_id);
 
-	ClassDB::bind_method(D_METHOD("set_script", "script"), &Object::set_script);
+	ClassDB::bind_method(D_METHOD("set_script", "script", "instantiate"), &Object::set_script, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_script"), &Object::get_script);
 
 	ClassDB::bind_method(D_METHOD("set_meta", "name", "value"), &Object::set_meta);

--- a/core/object.h
+++ b/core/object.h
@@ -679,7 +679,7 @@ public:
 
 	/* SCRIPT */
 
-	void set_script(const RefPtr &p_script);
+	void set_script(const RefPtr &p_script, bool p_instantiate = true);
 	RefPtr get_script() const;
 
 	/* SCRIPT */

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -600,7 +600,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 					var = ResourceLoader::load(var);
 
 					if (pinfo.hint_string == "Script")
-						debugObj->set_script(var);
+						debugObj->set_script(var, false);
 				} else if (var.get_type() == Variant::OBJECT) {
 					if (((Object *)var)->is_class("EncodedObjectAsID")) {
 						var = Object::cast_to<EncodedObjectAsID>(var)->get_object_id();


### PR DESCRIPTION
`Object::set_script` was trying to create an active instance of the script instead of a placeholder when tool was on, even for the debugger. Instead `ScriptEditorDebugger` now forces the script to instantiate a placeholder for any `ScriptEditorDebuggerInspectedObject`.

I'm not sure it's a good idea to expose the new `set_script` parameter to scripts since it's not really needed. So if it's a problem, instead I can make a different method like `set_and_instantiate_script` to expose it (still as `set_script` on the script side) without the extra parameter.

Fixes #29506