### PR TITLE
Changed `set_text` to place caret at start of the text.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6023,6 +6023,7 @@ void TextEdit::undo() {
 		}
 	}
 
+	_update_scrollbars();
 	if (undo_stack_pos->get().type == TextOperation::TYPE_REMOVE) {
 		cursor_set_line(undo_stack_pos->get().to_line);
 		cursor_set_column(undo_stack_pos->get().to_column);
@@ -6058,6 +6059,8 @@ void TextEdit::redo() {
 				break;
 		}
 	}
+
+	_update_scrollbars();
 	cursor_set_line(undo_stack_pos->get().to_line);
 	cursor_set_column(undo_stack_pos->get().to_column);
 	undo_stack_pos = undo_stack_pos->next();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4751,6 +4751,9 @@ void TextEdit::set_text(String p_text) {
 		selection.active = false;
 	}
 
+	cursor_set_line(0);
+	cursor_set_column(0);
+
 	update();
 	setting_text = false;
 };


### PR DESCRIPTION
Changed `set_text` to place caret at start of the text rather then the end.

I also noticed that undo / redo were not updating the scrollbar before adjusting the caret.

closes #32777