### PR TITLE
Call activate function when setting RigidBodyBullet activation state.

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -473,7 +473,7 @@ void RigidBodyBullet::assert_no_constraints() {
 
 void RigidBodyBullet::set_activation_state(bool p_active) {
 	if (p_active) {
-		btBody->setActivationState(ACTIVE_TAG);
+		btBody->activate();
 	} else {
 		btBody->setActivationState(WANTS_DEACTIVATION);
 	}


### PR DESCRIPTION
This patch enables a sleeping RigidBody to wake up when setting its sleeping state to false.
Fixes #16396 (together with #27730)
Fixes #28075

When setting a RigidBody's sleeping state to false, the deactivation time should be reset to prevent the RigidBody from immediately going back to sleep again. To enable this, RigidBodyBullet's set_activation_state(bool) function should call btCollissionObject's activate() function instead of setActivationState(ACTIVE_TAG).

The activate() function calls setActivationState(ACTIVE_TAG) and resets the deactivation time, after also checking that the CF_STATIC_OBJECT AND CF_KINEMATIC_OBJECT collisions flags are not set.

RigidBodyBullet's set_activation_state(bool) function is called by:
- BulletPhysicsDirectBodyState's set_sleep_state(bool)
- RigidBodyBullet::on_collision_filters_change()
- RigidBodyBullet::set_state(BODY_STATE_SLEEPING)

I think this is the desired behaviour for all these functions; so there should be no negative side-effects.