### PR TITLE
Small fixes to redundand code, copy paste bugs

### DIFF
--- a/core/compressed_translation.cpp
+++ b/core/compressed_translation.cpp
@@ -136,6 +136,8 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 		bucket_table_size += 2 + b.size() * 4;
 	}
 
+	ERR_FAIL_COND(bucket_table_size == 0);
+
 	hash_table.resize(size);
 	bucket_table.resize(bucket_table_size);
 

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1973,7 +1973,7 @@ Error EditorSceneImporterGLTF::_reparent_to_fake_joint(GLTFState &state, GLTFSke
 	state.nodes.push_back(fake_joint);
 
 	// We better not be a joint, or we messed up in our logic
-	if (node->joint == true)
+	if (node->joint)
 		return FAILED;
 
 	fake_joint->translation = node->translation;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1197,7 +1197,7 @@ bool CanvasItemEditor::_gui_input_zoom_or_pan(const Ref<InputEvent> &p_event, bo
 					//Pan the viewport
 					panning = true;
 				}
-			} else if (panning) {
+			} else {
 				if (!k->is_pressed()) {
 					// Stop panning the viewport (for any mouse button press)
 					panning = false;
@@ -4894,7 +4894,7 @@ void CanvasItemEditor::set_state(const Dictionary &p_state) {
 
 	if (state.has("grid_snap_active")) {
 		grid_snap_active = state["grid_snap_active"];
-		grid_snap_button->set_pressed(smart_snap_active);
+		grid_snap_button->set_pressed(grid_snap_active);
 	}
 
 	if (state.has("snap_node_parent")) {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1109,6 +1109,8 @@ void ProjectSettingsEditor::drop_data_fw(const Point2 &p_point, const Variant &p
 
 	TreeItem *selected = input_editor->get_selected();
 	TreeItem *item = input_editor->get_item_at_position(p_point);
+	if (!item)
+		return;
 	TreeItem *target = item->get_parent() == input_editor->get_root() ? item : item->get_parent();
 
 	String selected_name = "input/" + selected->get_text(0);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1856,9 +1856,7 @@ bool Main::start() {
 			// Hide console window if requested (Windows-only).
 			bool hide_console = EditorSettings::get_singleton()->get_setting("interface/editor/hide_console_window");
 			OS::get_singleton()->set_console_visible(!hide_console);
-		}
 
-		if (project_manager || editor) {
 			// Load SSL Certificates from Editor Settings (or builtin)
 			Crypto::load_default_certificates(EditorSettings::get_singleton()->get_setting("network/ssl/editor_ssl_certificates").operator String());
 		}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2232,9 +2232,7 @@ void GDScriptParser::_parse_pattern_block(BlockNode *p_block, Vector<PatternBran
 			break; // go back a level
 		}
 
-		if (pending_newline != -1) {
-			pending_newline = -1;
-		}
+		pending_newline = -1;
 
 		PatternBranchNode *branch = alloc_node<PatternBranchNode>();
 		branch->body = alloc_node<BlockNode>();

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -496,7 +496,7 @@ struct TextDocumentSyncOptions {
 		dict["willSave"] = willSave;
 		dict["openClose"] = openClose;
 		dict["change"] = change;
-		dict["change"] = save.to_json();
+		dict["save"] = save.to_json();
 		return dict;
 	}
 };

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -228,7 +228,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 	void _update_node_size(int p_id);
 	void _port_name_focus_out(const Node *p_name_box, int p_id, int p_port, bool is_input);
 
-	Vector2 _get_available_pos(bool centered = true, Vector2 pos = Vector2()) const;
+	Vector2 _get_available_pos(bool centered = true, Vector2 ofs = Vector2()) const;
 	StringName _get_function_of_node(int p_id) const;
 
 	void _move_nodes_with_rescan(const StringName &p_func_from, const StringName &p_func_to, int p_id);

--- a/modules/visual_script/visual_script_property_selector.h
+++ b/modules/visual_script/visual_script_property_selector.h
@@ -45,7 +45,7 @@ class VisualScriptPropertySelector : public ConfirmationDialog {
 
 	void create_visualscript_item(const String &name, TreeItem *const root, const String &search_input, const String &text);
 
-	void get_visual_node_names(const String &root_filter, const Set<String> &filter, bool &found, TreeItem *const root, LineEdit *const search_box);
+	void get_visual_node_names(const String &root_filter, const Set<String> &p_modifiers, bool &found, TreeItem *const root, LineEdit *const search_box);
 
 	void _sbox_input(const Ref<InputEvent> &p_ie);
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -577,9 +577,8 @@ void Sprite3D::set_frame(int p_frame) {
 
 	ERR_FAIL_INDEX(p_frame, int64_t(vframes) * hframes);
 
-	if (frame != p_frame)
+	frame = p_frame;
 
-		frame = p_frame;
 	_queue_update();
 
 	_change_notify("frame");

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5915,7 +5915,7 @@ void TextEdit::unfold_line(int p_line) {
 
 	if (!is_folded(p_line) && !is_line_hidden(p_line))
 		return;
-	int fold_start = p_line;
+	int fold_start;
 	for (fold_start = p_line; fold_start > 0; fold_start--) {
 		if (is_folded(fold_start))
 			break;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -70,9 +70,8 @@ float SceneTreeTimer::get_time_left() const {
 }
 
 void SceneTreeTimer::set_pause_mode_process(bool p_pause_mode_process) {
-	if (process_pause != p_pause_mode_process) {
-		process_pause = p_pause_mode_process;
-	}
+
+	process_pause = p_pause_mode_process;
 }
 
 bool SceneTreeTimer::is_pause_mode_process() {

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -534,7 +534,7 @@ void BitMap::grow_mask(int p_pixels, const Rect2 &p_rect) {
 		return;
 	}
 
-	bool bit_value = (p_pixels > 0) ? true : false;
+	bool bit_value = p_pixels > 0;
 	p_pixels = Math::abs(p_pixels);
 
 	Rect2i r = Rect2i(0, 0, width, height).clip(p_rect);


### PR DESCRIPTION
Fixes #31117

I'm not sure which name should be used here(copy paste bug)
```
		dict["change"] = change;
		dict["change"] = save.to_json();
```
so for now i choose `dict["save"] = save.to_json();`
CC @Geequlim 