### PR TITLE
Fix color of FileDialog icons

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -46,14 +46,31 @@ VBoxContainer *FileDialog::get_vbox() {
 
 void FileDialog::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
+	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
 
-		dir_up->set_icon(get_icon("parent_folder"));
-		refresh->set_icon(get_icon("reload"));
-		show_hidden->set_icon(get_icon("toggle_hidden"));
-	}
+		if (p_what == NOTIFICATION_ENTER_TREE) {
+			dir_up->set_icon(get_icon("parent_folder"));
+			refresh->set_icon(get_icon("reload"));
+			show_hidden->set_icon(get_icon("toggle_hidden"));
+		}
 
-	if (p_what == NOTIFICATION_POPUP_HIDE) {
+		Color font_color = get_color("font_color", "ToolButton");
+		Color font_color_hover = get_color("font_color_hover", "ToolButton");
+		Color font_color_pressed = get_color("font_color_pressed", "ToolButton");
+
+		dir_up->add_color_override("icon_color_normal", font_color);
+		dir_up->add_color_override("icon_color_hover", font_color_hover);
+		dir_up->add_color_override("icon_color_pressed", font_color_pressed);
+
+		refresh->add_color_override("icon_color_normal", font_color);
+		refresh->add_color_override("icon_color_hover", font_color_hover);
+		refresh->add_color_override("icon_color_pressed", font_color_pressed);
+
+		show_hidden->add_color_override("icon_color_normal", font_color);
+		show_hidden->add_color_override("icon_color_hover", font_color_hover);
+		show_hidden->add_color_override("icon_color_pressed", font_color_pressed);
+
+	} else if (p_what == NOTIFICATION_POPUP_HIDE) {
 
 		set_process_unhandled_input(false);
 	}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3036176/66746659-1c0d2880-ee8b-11e9-8c2d-ba781eba0faa.png)

~~Fixed incorrect coloring of these tool buttons by adding three new color font theme items to FileDialog. Users may override them too for own purposes.~~