### PR TITLE
Allow Label autowrap to cut words when they exceed line width

### DIFF
--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -129,6 +129,7 @@ NodeDock::NodeDock() {
 
 	select_a_node = memnew(Label);
 	select_a_node->set_text(TTR("Select a single node to edit its signals and groups."));
+	select_a_node->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	select_a_node->set_v_size_flags(SIZE_EXPAND_FILL);
 	select_a_node->set_valign(Label::VALIGN_CENTER);
 	select_a_node->set_align(Label::ALIGN_CENTER);

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -452,6 +452,11 @@ void Label::regenerate_word_cache() {
 			current_word_size += char_width;
 			line_width += char_width;
 			total_char_cache++;
+
+			// allow autowrap to cut words when they exceed line width
+			if (autowrap && (current_word_size > width)) {
+				separatable = true;
+			}
 		}
 
 		if ((autowrap && (line_width >= width) && ((last && last->char_pos >= 0) || separatable)) || insert_newline) {


### PR DESCRIPTION
Prevents long words to overflow the label's rect when autowrap is on.

Fixes #30832