### PR TITLE
Changes the name of all parameters referring to track indices within Animation, to `track_idx`

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -34,7 +34,7 @@
 		<method name="animation_track_get_key_animation" qualifiers="const">
 			<return type="String">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -44,7 +44,7 @@
 		<method name="animation_track_insert_key">
 			<return type="int">
 			</return>
-			<argument index="0" name="track" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time" type="float">
 			</argument>
@@ -56,7 +56,7 @@
 		<method name="animation_track_set_key_animation">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -68,7 +68,7 @@
 		<method name="audio_track_get_key_end_offset" qualifiers="const">
 			<return type="float">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -78,7 +78,7 @@
 		<method name="audio_track_get_key_start_offset" qualifiers="const">
 			<return type="float">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -88,7 +88,7 @@
 		<method name="audio_track_get_key_stream" qualifiers="const">
 			<return type="Resource">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -98,7 +98,7 @@
 		<method name="audio_track_insert_key">
 			<return type="int">
 			</return>
-			<argument index="0" name="track" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time" type="float">
 			</argument>
@@ -114,7 +114,7 @@
 		<method name="audio_track_set_key_end_offset">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -126,7 +126,7 @@
 		<method name="audio_track_set_key_start_offset">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -138,7 +138,7 @@
 		<method name="audio_track_set_key_stream">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -150,7 +150,7 @@
 		<method name="bezier_track_get_key_in_handle" qualifiers="const">
 			<return type="Vector2">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -160,7 +160,7 @@
 		<method name="bezier_track_get_key_out_handle" qualifiers="const">
 			<return type="Vector2">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -170,7 +170,7 @@
 		<method name="bezier_track_get_key_value" qualifiers="const">
 			<return type="float">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -180,7 +180,7 @@
 		<method name="bezier_track_insert_key">
 			<return type="int">
 			</return>
-			<argument index="0" name="track" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time" type="float">
 			</argument>
@@ -196,7 +196,7 @@
 		<method name="bezier_track_interpolate" qualifiers="const">
 			<return type="float">
 			</return>
-			<argument index="0" name="track" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time" type="float">
 			</argument>
@@ -206,7 +206,7 @@
 		<method name="bezier_track_set_key_in_handle">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -218,7 +218,7 @@
 		<method name="bezier_track_set_key_out_handle">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -230,7 +230,7 @@
 		<method name="bezier_track_set_key_value">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -249,7 +249,7 @@
 		<method name="copy_track">
 			<return type="void">
 			</return>
-			<argument index="0" name="track" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="to_animation" type="Animation">
 			</argument>
@@ -276,7 +276,7 @@
 		<method name="method_track_get_key_indices" qualifiers="const">
 			<return type="PoolIntArray">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time_sec" type="float">
 			</argument>
@@ -289,7 +289,7 @@
 		<method name="method_track_get_name" qualifiers="const">
 			<return type="String">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -300,7 +300,7 @@
 		<method name="method_track_get_params" qualifiers="const">
 			<return type="Array">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -311,7 +311,7 @@
 		<method name="remove_track">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Removes a track by specifying the track index.
@@ -320,7 +320,7 @@
 		<method name="track_find_key" qualifiers="const">
 			<return type="int">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time" type="float">
 			</argument>
@@ -333,7 +333,7 @@
 		<method name="track_get_interpolation_loop_wrap" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Returns [code]true[/code] if the track at [code]idx[/code] wraps the interpolation loop. New tracks wrap the interpolation loop by default.
@@ -342,7 +342,7 @@
 		<method name="track_get_interpolation_type" qualifiers="const">
 			<return type="int" enum="Animation.InterpolationType">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Returns the interpolation type of a given track.
@@ -351,7 +351,7 @@
 		<method name="track_get_key_count" qualifiers="const">
 			<return type="int">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Returns the amount of keys in a given track.
@@ -360,7 +360,7 @@
 		<method name="track_get_key_time" qualifiers="const">
 			<return type="float">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -371,7 +371,7 @@
 		<method name="track_get_key_transition" qualifiers="const">
 			<return type="float">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -382,7 +382,7 @@
 		<method name="track_get_key_value" qualifiers="const">
 			<return type="Variant">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -393,7 +393,7 @@
 		<method name="track_get_path" qualifiers="const">
 			<return type="NodePath">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Gets the path of a track. For more information on the path format, see [method track_set_path].
@@ -402,7 +402,7 @@
 		<method name="track_get_type" qualifiers="const">
 			<return type="int" enum="Animation.TrackType">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Gets the type of a track.
@@ -411,7 +411,7 @@
 		<method name="track_insert_key">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time" type="float">
 			</argument>
@@ -426,7 +426,7 @@
 		<method name="track_is_enabled" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Returns [code]true[/code] if the track at index [code]idx[/code] is enabled.
@@ -435,7 +435,7 @@
 		<method name="track_is_imported" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Returns [code]true[/code] if the given track is imported. Else, return [code]false[/code].
@@ -444,7 +444,7 @@
 		<method name="track_move_down">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Moves a track down.
@@ -453,7 +453,7 @@
 		<method name="track_move_to">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="to_idx" type="int">
 			</argument>
@@ -464,7 +464,7 @@
 		<method name="track_move_up">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Moves a track up.
@@ -473,7 +473,7 @@
 		<method name="track_remove_key">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -484,7 +484,7 @@
 		<method name="track_remove_key_at_position">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="position" type="float">
 			</argument>
@@ -495,7 +495,7 @@
 		<method name="track_set_enabled">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="enabled" type="bool">
 			</argument>
@@ -506,7 +506,7 @@
 		<method name="track_set_imported">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="imported" type="bool">
 			</argument>
@@ -517,7 +517,7 @@
 		<method name="track_set_interpolation_loop_wrap">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="interpolation" type="bool">
 			</argument>
@@ -528,7 +528,7 @@
 		<method name="track_set_interpolation_type">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="interpolation" type="int" enum="Animation.InterpolationType">
 			</argument>
@@ -539,7 +539,7 @@
 		<method name="track_set_key_time">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -552,7 +552,7 @@
 		<method name="track_set_key_transition">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key_idx" type="int">
 			</argument>
@@ -565,7 +565,7 @@
 		<method name="track_set_key_value">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="key" type="int">
 			</argument>
@@ -578,7 +578,7 @@
 		<method name="track_set_path">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="path" type="NodePath">
 			</argument>
@@ -590,7 +590,7 @@
 		<method name="track_swap">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="with_idx" type="int">
 			</argument>
@@ -601,7 +601,7 @@
 		<method name="transform_track_insert_key">
 			<return type="int">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time" type="float">
 			</argument>
@@ -618,7 +618,7 @@
 		<method name="transform_track_interpolate" qualifiers="const">
 			<return type="Array">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time_sec" type="float">
 			</argument>
@@ -629,7 +629,7 @@
 		<method name="value_track_get_key_indices" qualifiers="const">
 			<return type="PoolIntArray">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="time_sec" type="float">
 			</argument>
@@ -642,7 +642,7 @@
 		<method name="value_track_get_update_mode" qualifiers="const">
 			<return type="int" enum="Animation.UpdateMode">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<description>
 				Returns the update mode of a value track.
@@ -651,7 +651,7 @@
 		<method name="value_track_set_update_mode">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="track_idx" type="int">
 			</argument>
 			<argument index="1" name="mode" type="int" enum="Animation.UpdateMode">
 			</argument>

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2741,77 +2741,77 @@ void Animation::copy_track(int p_track, Ref<Animation> p_to_animation) {
 void Animation::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_track", "type", "at_position"), &Animation::add_track, DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("remove_track", "idx"), &Animation::remove_track);
+	ClassDB::bind_method(D_METHOD("remove_track", "track_idx"), &Animation::remove_track);
 	ClassDB::bind_method(D_METHOD("get_track_count"), &Animation::get_track_count);
-	ClassDB::bind_method(D_METHOD("track_get_type", "idx"), &Animation::track_get_type);
-	ClassDB::bind_method(D_METHOD("track_get_path", "idx"), &Animation::track_get_path);
-	ClassDB::bind_method(D_METHOD("track_set_path", "idx", "path"), &Animation::track_set_path);
+	ClassDB::bind_method(D_METHOD("track_get_type", "track_idx"), &Animation::track_get_type);
+	ClassDB::bind_method(D_METHOD("track_get_path", "track_idx"), &Animation::track_get_path);
+	ClassDB::bind_method(D_METHOD("track_set_path", "track_idx", "path"), &Animation::track_set_path);
 	ClassDB::bind_method(D_METHOD("find_track", "path"), &Animation::find_track);
 
-	ClassDB::bind_method(D_METHOD("track_move_up", "idx"), &Animation::track_move_up);
-	ClassDB::bind_method(D_METHOD("track_move_down", "idx"), &Animation::track_move_down);
-	ClassDB::bind_method(D_METHOD("track_move_to", "idx", "to_idx"), &Animation::track_move_to);
-	ClassDB::bind_method(D_METHOD("track_swap", "idx", "with_idx"), &Animation::track_swap);
+	ClassDB::bind_method(D_METHOD("track_move_up", "track_idx"), &Animation::track_move_up);
+	ClassDB::bind_method(D_METHOD("track_move_down", "track_idx"), &Animation::track_move_down);
+	ClassDB::bind_method(D_METHOD("track_move_to", "track_idx", "to_idx"), &Animation::track_move_to);
+	ClassDB::bind_method(D_METHOD("track_swap", "track_idx", "with_idx"), &Animation::track_swap);
 
-	ClassDB::bind_method(D_METHOD("track_set_imported", "idx", "imported"), &Animation::track_set_imported);
-	ClassDB::bind_method(D_METHOD("track_is_imported", "idx"), &Animation::track_is_imported);
+	ClassDB::bind_method(D_METHOD("track_set_imported", "track_idx", "imported"), &Animation::track_set_imported);
+	ClassDB::bind_method(D_METHOD("track_is_imported", "track_idx"), &Animation::track_is_imported);
 
-	ClassDB::bind_method(D_METHOD("track_set_enabled", "idx", "enabled"), &Animation::track_set_enabled);
-	ClassDB::bind_method(D_METHOD("track_is_enabled", "idx"), &Animation::track_is_enabled);
+	ClassDB::bind_method(D_METHOD("track_set_enabled", "track_idx", "enabled"), &Animation::track_set_enabled);
+	ClassDB::bind_method(D_METHOD("track_is_enabled", "track_idx"), &Animation::track_is_enabled);
 
-	ClassDB::bind_method(D_METHOD("transform_track_insert_key", "idx", "time", "location", "rotation", "scale"), &Animation::transform_track_insert_key);
-	ClassDB::bind_method(D_METHOD("track_insert_key", "idx", "time", "key", "transition"), &Animation::track_insert_key, DEFVAL(1));
-	ClassDB::bind_method(D_METHOD("track_remove_key", "idx", "key_idx"), &Animation::track_remove_key);
-	ClassDB::bind_method(D_METHOD("track_remove_key_at_position", "idx", "position"), &Animation::track_remove_key_at_position);
-	ClassDB::bind_method(D_METHOD("track_set_key_value", "idx", "key", "value"), &Animation::track_set_key_value);
-	ClassDB::bind_method(D_METHOD("track_set_key_transition", "idx", "key_idx", "transition"), &Animation::track_set_key_transition);
-	ClassDB::bind_method(D_METHOD("track_set_key_time", "idx", "key_idx", "time"), &Animation::track_set_key_time);
-	ClassDB::bind_method(D_METHOD("track_get_key_transition", "idx", "key_idx"), &Animation::track_get_key_transition);
+	ClassDB::bind_method(D_METHOD("transform_track_insert_key", "track_idx", "time", "location", "rotation", "scale"), &Animation::transform_track_insert_key);
+	ClassDB::bind_method(D_METHOD("track_insert_key", "track_idx", "time", "key", "transition"), &Animation::track_insert_key, DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("track_remove_key", "track_idx", "key_idx"), &Animation::track_remove_key);
+	ClassDB::bind_method(D_METHOD("track_remove_key_at_position", "track_idx", "position"), &Animation::track_remove_key_at_position);
+	ClassDB::bind_method(D_METHOD("track_set_key_value", "track_idx", "key", "value"), &Animation::track_set_key_value);
+	ClassDB::bind_method(D_METHOD("track_set_key_transition", "track_idx", "key_idx", "transition"), &Animation::track_set_key_transition);
+	ClassDB::bind_method(D_METHOD("track_set_key_time", "track_idx", "key_idx", "time"), &Animation::track_set_key_time);
+	ClassDB::bind_method(D_METHOD("track_get_key_transition", "track_idx", "key_idx"), &Animation::track_get_key_transition);
 
-	ClassDB::bind_method(D_METHOD("track_get_key_count", "idx"), &Animation::track_get_key_count);
-	ClassDB::bind_method(D_METHOD("track_get_key_value", "idx", "key_idx"), &Animation::track_get_key_value);
-	ClassDB::bind_method(D_METHOD("track_get_key_time", "idx", "key_idx"), &Animation::track_get_key_time);
-	ClassDB::bind_method(D_METHOD("track_find_key", "idx", "time", "exact"), &Animation::track_find_key, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("track_get_key_count", "track_idx"), &Animation::track_get_key_count);
+	ClassDB::bind_method(D_METHOD("track_get_key_value", "track_idx", "key_idx"), &Animation::track_get_key_value);
+	ClassDB::bind_method(D_METHOD("track_get_key_time", "track_idx", "key_idx"), &Animation::track_get_key_time);
+	ClassDB::bind_method(D_METHOD("track_find_key", "track_idx", "time", "exact"), &Animation::track_find_key, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("track_set_interpolation_type", "idx", "interpolation"), &Animation::track_set_interpolation_type);
-	ClassDB::bind_method(D_METHOD("track_get_interpolation_type", "idx"), &Animation::track_get_interpolation_type);
+	ClassDB::bind_method(D_METHOD("track_set_interpolation_type", "track_idx", "interpolation"), &Animation::track_set_interpolation_type);
+	ClassDB::bind_method(D_METHOD("track_get_interpolation_type", "track_idx"), &Animation::track_get_interpolation_type);
 
-	ClassDB::bind_method(D_METHOD("track_set_interpolation_loop_wrap", "idx", "interpolation"), &Animation::track_set_interpolation_loop_wrap);
-	ClassDB::bind_method(D_METHOD("track_get_interpolation_loop_wrap", "idx"), &Animation::track_get_interpolation_loop_wrap);
+	ClassDB::bind_method(D_METHOD("track_set_interpolation_loop_wrap", "track_idx", "interpolation"), &Animation::track_set_interpolation_loop_wrap);
+	ClassDB::bind_method(D_METHOD("track_get_interpolation_loop_wrap", "track_idx"), &Animation::track_get_interpolation_loop_wrap);
 
-	ClassDB::bind_method(D_METHOD("transform_track_interpolate", "idx", "time_sec"), &Animation::_transform_track_interpolate);
-	ClassDB::bind_method(D_METHOD("value_track_set_update_mode", "idx", "mode"), &Animation::value_track_set_update_mode);
-	ClassDB::bind_method(D_METHOD("value_track_get_update_mode", "idx"), &Animation::value_track_get_update_mode);
+	ClassDB::bind_method(D_METHOD("transform_track_interpolate", "track_idx", "time_sec"), &Animation::_transform_track_interpolate);
+	ClassDB::bind_method(D_METHOD("value_track_set_update_mode", "track_idx", "mode"), &Animation::value_track_set_update_mode);
+	ClassDB::bind_method(D_METHOD("value_track_get_update_mode", "track_idx"), &Animation::value_track_get_update_mode);
 
-	ClassDB::bind_method(D_METHOD("value_track_get_key_indices", "idx", "time_sec", "delta"), &Animation::_value_track_get_key_indices);
+	ClassDB::bind_method(D_METHOD("value_track_get_key_indices", "track_idx", "time_sec", "delta"), &Animation::_value_track_get_key_indices);
 
-	ClassDB::bind_method(D_METHOD("method_track_get_key_indices", "idx", "time_sec", "delta"), &Animation::_method_track_get_key_indices);
-	ClassDB::bind_method(D_METHOD("method_track_get_name", "idx", "key_idx"), &Animation::method_track_get_name);
-	ClassDB::bind_method(D_METHOD("method_track_get_params", "idx", "key_idx"), &Animation::method_track_get_params);
+	ClassDB::bind_method(D_METHOD("method_track_get_key_indices", "track_idx", "time_sec", "delta"), &Animation::_method_track_get_key_indices);
+	ClassDB::bind_method(D_METHOD("method_track_get_name", "track_idx", "key_idx"), &Animation::method_track_get_name);
+	ClassDB::bind_method(D_METHOD("method_track_get_params", "track_idx", "key_idx"), &Animation::method_track_get_params);
 
-	ClassDB::bind_method(D_METHOD("bezier_track_insert_key", "track", "time", "value", "in_handle", "out_handle"), &Animation::bezier_track_insert_key, DEFVAL(Vector2()), DEFVAL(Vector2()));
+	ClassDB::bind_method(D_METHOD("bezier_track_insert_key", "track_idx", "time", "value", "in_handle", "out_handle"), &Animation::bezier_track_insert_key, DEFVAL(Vector2()), DEFVAL(Vector2()));
 
-	ClassDB::bind_method(D_METHOD("bezier_track_set_key_value", "idx", "key_idx", "value"), &Animation::bezier_track_set_key_value);
-	ClassDB::bind_method(D_METHOD("bezier_track_set_key_in_handle", "idx", "key_idx", "in_handle"), &Animation::bezier_track_set_key_in_handle);
-	ClassDB::bind_method(D_METHOD("bezier_track_set_key_out_handle", "idx", "key_idx", "out_handle"), &Animation::bezier_track_set_key_out_handle);
+	ClassDB::bind_method(D_METHOD("bezier_track_set_key_value", "track_idx", "key_idx", "value"), &Animation::bezier_track_set_key_value);
+	ClassDB::bind_method(D_METHOD("bezier_track_set_key_in_handle", "track_idx", "key_idx", "in_handle"), &Animation::bezier_track_set_key_in_handle);
+	ClassDB::bind_method(D_METHOD("bezier_track_set_key_out_handle", "track_idx", "key_idx", "out_handle"), &Animation::bezier_track_set_key_out_handle);
 
-	ClassDB::bind_method(D_METHOD("bezier_track_get_key_value", "idx", "key_idx"), &Animation::bezier_track_get_key_value);
-	ClassDB::bind_method(D_METHOD("bezier_track_get_key_in_handle", "idx", "key_idx"), &Animation::bezier_track_get_key_in_handle);
-	ClassDB::bind_method(D_METHOD("bezier_track_get_key_out_handle", "idx", "key_idx"), &Animation::bezier_track_get_key_out_handle);
+	ClassDB::bind_method(D_METHOD("bezier_track_get_key_value", "track_idx", "key_idx"), &Animation::bezier_track_get_key_value);
+	ClassDB::bind_method(D_METHOD("bezier_track_get_key_in_handle", "track_idx", "key_idx"), &Animation::bezier_track_get_key_in_handle);
+	ClassDB::bind_method(D_METHOD("bezier_track_get_key_out_handle", "track_idx", "key_idx"), &Animation::bezier_track_get_key_out_handle);
 
-	ClassDB::bind_method(D_METHOD("bezier_track_interpolate", "track", "time"), &Animation::bezier_track_interpolate);
+	ClassDB::bind_method(D_METHOD("bezier_track_interpolate", "track_idx", "time"), &Animation::bezier_track_interpolate);
 
-	ClassDB::bind_method(D_METHOD("audio_track_insert_key", "track", "time", "stream", "start_offset", "end_offset"), &Animation::audio_track_insert_key, DEFVAL(0), DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("audio_track_set_key_stream", "idx", "key_idx", "stream"), &Animation::audio_track_set_key_stream);
-	ClassDB::bind_method(D_METHOD("audio_track_set_key_start_offset", "idx", "key_idx", "offset"), &Animation::audio_track_set_key_start_offset);
-	ClassDB::bind_method(D_METHOD("audio_track_set_key_end_offset", "idx", "key_idx", "offset"), &Animation::audio_track_set_key_end_offset);
-	ClassDB::bind_method(D_METHOD("audio_track_get_key_stream", "idx", "key_idx"), &Animation::audio_track_get_key_stream);
-	ClassDB::bind_method(D_METHOD("audio_track_get_key_start_offset", "idx", "key_idx"), &Animation::audio_track_get_key_start_offset);
-	ClassDB::bind_method(D_METHOD("audio_track_get_key_end_offset", "idx", "key_idx"), &Animation::audio_track_get_key_end_offset);
+	ClassDB::bind_method(D_METHOD("audio_track_insert_key", "track_idx", "time", "stream", "start_offset", "end_offset"), &Animation::audio_track_insert_key, DEFVAL(0), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("audio_track_set_key_stream", "track_idx", "key_idx", "stream"), &Animation::audio_track_set_key_stream);
+	ClassDB::bind_method(D_METHOD("audio_track_set_key_start_offset", "track_idx", "key_idx", "offset"), &Animation::audio_track_set_key_start_offset);
+	ClassDB::bind_method(D_METHOD("audio_track_set_key_end_offset", "track_idx", "key_idx", "offset"), &Animation::audio_track_set_key_end_offset);
+	ClassDB::bind_method(D_METHOD("audio_track_get_key_stream", "track_idx", "key_idx"), &Animation::audio_track_get_key_stream);
+	ClassDB::bind_method(D_METHOD("audio_track_get_key_start_offset", "track_idx", "key_idx"), &Animation::audio_track_get_key_start_offset);
+	ClassDB::bind_method(D_METHOD("audio_track_get_key_end_offset", "track_idx", "key_idx"), &Animation::audio_track_get_key_end_offset);
 
-	ClassDB::bind_method(D_METHOD("animation_track_insert_key", "track", "time", "animation"), &Animation::animation_track_insert_key);
-	ClassDB::bind_method(D_METHOD("animation_track_set_key_animation", "idx", "key_idx", "animation"), &Animation::animation_track_set_key_animation);
-	ClassDB::bind_method(D_METHOD("animation_track_get_key_animation", "idx", "key_idx"), &Animation::animation_track_get_key_animation);
+	ClassDB::bind_method(D_METHOD("animation_track_insert_key", "track_idx", "time", "animation"), &Animation::animation_track_insert_key);
+	ClassDB::bind_method(D_METHOD("animation_track_set_key_animation", "track_idx", "key_idx", "animation"), &Animation::animation_track_set_key_animation);
+	ClassDB::bind_method(D_METHOD("animation_track_get_key_animation", "track_idx", "key_idx"), &Animation::animation_track_get_key_animation);
 
 	ClassDB::bind_method(D_METHOD("set_length", "time_sec"), &Animation::set_length);
 	ClassDB::bind_method(D_METHOD("get_length"), &Animation::get_length);
@@ -2823,7 +2823,7 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_step"), &Animation::get_step);
 
 	ClassDB::bind_method(D_METHOD("clear"), &Animation::clear);
-	ClassDB::bind_method(D_METHOD("copy_track", "track", "to_animation"), &Animation::copy_track);
+	ClassDB::bind_method(D_METHOD("copy_track", "track_idx", "to_animation"), &Animation::copy_track);
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "length", PROPERTY_HINT_RANGE, "0.001,99999,0.001"), "set_length", "get_length");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");


### PR DESCRIPTION
Closes godotengine/godot-docs#2856

This should help make it clearer that the parameters in question all refer to a track index, hopefully avoiding confusion like there was at https://github.com/godotengine/godot-proposals/issues/158#issuecomment-541937015.