### PR TITLE
Activate Body(2D)SW when switching to rigid or character mode.

### DIFF
--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -260,12 +260,14 @@ void BodySW::set_mode(PhysicsServer::BodyMode p_mode) {
 
 			_inv_mass = mass > 0 ? (1.0 / mass) : 0;
 			_set_static(false);
+			set_active(true);
 
 		} break;
 		case PhysicsServer::BODY_MODE_CHARACTER: {
 
 			_inv_mass = mass > 0 ? (1.0 / mass) : 0;
 			_set_static(false);
+			set_active(true);
 			angular_velocity = Vector3();
 		} break;
 	}

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -238,6 +238,7 @@ void Body2DSW::set_mode(Physics2DServer::BodyMode p_mode) {
 			_inv_mass = mass > 0 ? (1.0 / mass) : 0;
 			_inv_inertia = inertia > 0 ? (1.0 / inertia) : 0;
 			_set_static(false);
+			set_active(true);
 
 		} break;
 		case Physics2DServer::BODY_MODE_CHARACTER: {
@@ -245,6 +246,7 @@ void Body2DSW::set_mode(Physics2DServer::BodyMode p_mode) {
 			_inv_mass = mass > 0 ? (1.0 / mass) : 0;
 			_inv_inertia = 0;
 			_set_static(false);
+			set_active(true);
 			angular_velocity = 0;
 		} break;
 	}


### PR DESCRIPTION
This patch calls activate(true) in BodySW and Body2DSW when the mode is set to BODY_MODE_RIGID or BODY_MODE_CHARACTER.

When setting the mode of a RigidBody2D or RigidBody with GodotPhysics to MODE_RIGID or MODE_CHARACTER, the RigidBody(2D) should stop sleeping; especially if the RigidBody(2D)'s "Can Sleep" is disabled.

Fixes #25738
 