### PR TITLE
Fix incorrect coloring of in-editor documentation when theme changed

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1467,6 +1467,10 @@ void EditorHelp::_notification(int p_what) {
 
 			_update_doc();
 		} break;
+		case NOTIFICATION_THEME_CHANGED: {
+
+			_class_desc_resized();
+		} break;
 		default: break;
 	}
 }


### PR DESCRIPTION
Fixed incorrect background color -
![doc_bug](https://user-images.githubusercontent.com/3036176/66807764-790fe980-ef32-11e9-925e-250eac23f953.gif)
