### PR TITLE
Fix the editor path icon when switching from dark to light theme

### DIFF
--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -132,6 +132,15 @@ void EditorPath::_id_pressed(int p_idx) {
 	EditorNode::get_singleton()->push_item(obj);
 }
 
+void EditorPath::_notification(int p_what) {
+
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			update_path();
+		} break;
+	}
+}
+
 void EditorPath::_bind_methods() {
 
 	ClassDB::bind_method("_about_to_show", &EditorPath::_about_to_show);

--- a/editor/editor_path.h
+++ b/editor/editor_path.h
@@ -48,6 +48,7 @@ class EditorPath : public MenuButton {
 	void _add_children_to_popup(Object *p_obj, int p_depth = 0);
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
The icon now switches themes correctly when going from a dark theme to a light theme (or vice versa).

By "editor path icon", I mean the icon at the bottom of this screenshot:

![Inspector](https://user-images.githubusercontent.com/180032/66808468-955c5800-ef2b-11e9-8a4e-0a5d3be99c50.png)