### PR TITLE
Correct change made to joints_2d.cpp by 072e403.

### DIFF
--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -61,8 +61,6 @@ void Joint2D::_update_joint(bool p_only_free) {
 	if (!body_a || !body_b)
 		return;
 
-	SWAP(body_a, body_b);
-
 	joint = _configure_joint(body_a, body_b);
 
 	if (!joint.is_valid())


### PR DESCRIPTION
Fixes a change made by #29283.

Suggestion 27 of issue #27668 is:
"godot/scene/2d/joints_2d.cpp:64: ostrzeżenie: V547 Expression '!body_a' is always false.
![55543328-2030e000-56c9-11e9-9095-7bbab5fa878f](https://user-images.githubusercontent.com/9253928/66849161-b8602980-ef76-11e9-982c-1d2de6773d36.png)
This is not a double negative, therefore SWAP(body_a, body_b) will never run, not always run.

However part of 072e403 results in SWAP(body_a, body_b) always running through the following change:
```
diff --git a/scene/2d/joints_2d.cpp b/scene/2d/joints_2d.cpp
index 5b14b3e8e..d8156a0af 100644
--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -61,9 +61,7 @@ void Joint2D::_update_joint(bool p_only_free) {
        if (!body_a || !body_b)
                return;
 
-       if (!body_a) {
-               SWAP(body_a, body_b);
-       }
+       SWAP(body_a, body_b);
 
        joint = _configure_joint(body_a, body_b);
```
One of the negative consequences of swapping body_a and body_b is that the direction of the forces applied by DampedSpringJoint2D are inverted, because it uses a vector created by subtracting the location of the two bodies. This results in the attached objects being pushed/pulled in the wrong direction.