### PR TITLE
Added a FULLRECT_UV keyword in canvas item

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -923,6 +923,7 @@ ShaderCompilerGLES2::ShaderCompilerGLES2() {
 	actions[VS::SHADER_CANVAS_ITEM].renames["SCREEN_PIXEL_SIZE"] = "screen_pixel_size";
 	actions[VS::SHADER_CANVAS_ITEM].renames["FRAGCOORD"] = "gl_FragCoord";
 	actions[VS::SHADER_CANVAS_ITEM].renames["POINT_COORD"] = "gl_PointCoord";
+	actions[VS::SHADER_CANVAS_ITEM].renames["SRC_VERTEX"] = "src_vertex";
 
 	actions[VS::SHADER_CANVAS_ITEM].renames["LIGHT_VEC"] = "light_vec";
 	actions[VS::SHADER_CANVAS_ITEM].renames["LIGHT_HEIGHT"] = "light_height";

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -133,6 +133,7 @@ void main() {
 
 	vec4 color = color_attrib;
 	vec2 uv;
+	vec2 src_vertex = vertex;
 
 #ifdef USE_INSTANCING
 	mat4 extra_matrix_instance = extra_matrix * transpose(mat4(instance_xform0, instance_xform1, instance_xform2, vec4(0.0, 0.0, 0.0, 1.0)));

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -903,6 +903,7 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 	actions[VS::SHADER_CANVAS_ITEM].renames["SCREEN_PIXEL_SIZE"] = "screen_pixel_size";
 	actions[VS::SHADER_CANVAS_ITEM].renames["FRAGCOORD"] = "gl_FragCoord";
 	actions[VS::SHADER_CANVAS_ITEM].renames["POINT_COORD"] = "gl_PointCoord";
+	actions[VS::SHADER_CANVAS_ITEM].renames["SRC_VERTEX"] = "src_vertex";
 
 	actions[VS::SHADER_CANVAS_ITEM].renames["LIGHT_VEC"] = "light_vec";
 	actions[VS::SHADER_CANVAS_ITEM].renames["LIGHT_HEIGHT"] = "light_height";

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -137,7 +137,6 @@ VERTEX_SHADER_GLOBALS
 void main() {
 
 	vec4 color = color_attrib;
-
 #ifdef USE_INSTANCING
 	mat4 extra_matrix_instance = extra_matrix * transpose(mat4(instance_xform0, instance_xform1, instance_xform2, vec4(0.0, 0.0, 0.0, 1.0)));
 	color *= instance_color;
@@ -172,6 +171,7 @@ void main() {
 	outvec.xy /= color_texpixel_size;
 #endif
 
+	vec2 src_vertex = vertex;
 #define extra_matrix extra_matrix_instance
 
 	float point_size = 1.0;
@@ -513,7 +513,6 @@ void main() {
 	if (draw_center == 0) {
 		color.a = 0.0;
 	}
-
 	uv = uv * src_rect.zw + src_rect.xy; //apply region if needed
 #endif
 

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -209,6 +209,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["INSTANCE_CUSTOM"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["AT_LIGHT_PASS"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["TEXTURE_PIXEL_SIZE"] = constt(ShaderLanguage::TYPE_VEC2);
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["SRC_VERTEX"] = constt(ShaderLanguage::TYPE_VEC2);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].can_discard = false;
 
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["fragment"].built_ins["FRAGCOORD"] = constt(ShaderLanguage::TYPE_VEC4);


### PR DESCRIPTION
There are some cases where having information on the position compared
to the full quad is useful, for example a vertical fade based on the
quad's y UV coordinate.

Currently, cases such as atlas and 9patch don't bring information regarding the quad uv.
example below, the big white robot is a regular sprite while the smaller block on the
 left is an atlas. note the different alpha.
with `COLOR.a = UV.y`
![Screenshot_2019-10-16_11-12-15](https://user-images.githubusercontent.com/7917475/66905367-053f1100-f006-11e9-9b6b-a3c7d3392371.png)
with `COLOR.a = FULLRECT_UV.y`
![Screenshot_2019-10-16_11-11-53](https://user-images.githubusercontent.com/7917475/66905402-15ef8700-f006-11e9-9ca5-a8c1ec08f393.png)


An alternative solution would be to pass unprocessed UV in the vertex shader, but it could break compat.

This does not work for GLES2's 9patch rect.

Artwork by Manuel Bustamante: https://www.artstation.com/artwork/3oa9lJ