### PR TITLE
Fixes inspector not displaying AnimationPlayer's subresource

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -165,7 +165,7 @@ void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	for (Map<StringName, AnimationData>::Element *E = animation_set.front(); E; E = E->next()) {
 
-		anim_names.push_back(PropertyInfo(Variant::OBJECT, "anims/" + String(E->key()), PROPERTY_HINT_RESOURCE_TYPE, "Animation", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE));
+		anim_names.push_back(PropertyInfo(Variant::OBJECT, "anims/" + String(E->key()), PROPERTY_HINT_RESOURCE_TYPE, "Animation", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE));
 		if (E->get().next != StringName())
 			anim_names.push_back(PropertyInfo(Variant::STRING, "next/" + String(E->key()), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 	}


### PR DESCRIPTION
Closes: #32839

When inspecting an AnimationPlayer, the inspector does not show its animations as a subresource when clicking on the name in the inspector.
<br><br>
The issue is because the subresource list will not be populated in the inspector if the **PROPERTY_USAGE_EDITOR** flag is not set:
https://github.com/godotengine/godot/blob/119bf237209414a49879fba40459f22315ab1467/editor/editor_path.cpp#L45-L48
