### PR TITLE
[WIP] Standardise the behaviour of the const and non const versions of the array operator within and between the Map classes

### DIFF
--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -437,27 +437,18 @@ public:
 		return false;
 	}
 
-	inline const TData &operator[](const TKey &p_key) const { //constref
+	inline const TData &operator[](const TKey &p_key) const {
 
-		return get(p_key);
+		const TData *res = getptr(p_key);
+		CRASH_COND_MSG(!res, "Map key not found.");
+		return *res;
 	}
-	inline TData &operator[](const TKey &p_key) { //assignment
 
-		Element *e = NULL;
-		if (!hash_table)
-			make_hash_table(); // if no table, make one
-		else
-			e = const_cast<Element *>(get_element(p_key));
+	inline TData &operator[](const TKey &p_key) {
 
-		/* if we made it up to here, the pair doesn't exist, create */
-		if (!e) {
-
-			e = create_element(p_key);
-			CRASH_COND(!e);
-			check_hash_table(); // perform mantenience routine
-		}
-
-		return e->pair.data;
+		TData *res = getptr(p_key);
+		CRASH_COND_MSG(!res, "Map key not found.");
+		return *res;
 	}
 
 	/**

--- a/core/map.h
+++ b/core/map.h
@@ -589,23 +589,17 @@ public:
 		return true;
 	}
 
-	const V &operator[](const K &p_key) const {
+	inline const V &operator[](const K &p_key) const {
 
-		CRASH_COND(!_data._root);
 		const Element *e = find(p_key);
-		CRASH_COND(!e);
+		CRASH_COND_MSG(!e, "Map key not found.");
 		return e->_value;
 	}
 
-	V &operator[](const K &p_key) {
-
-		if (!_data._root)
-			_data._create_root();
+	inline V &operator[](const K &p_key) {
 
 		Element *e = find(p_key);
-		if (!e)
-			e = insert(p_key, V());
-
+		CRASH_COND_MSG(!e, "Map key not found.");
 		return e->_value;
 	}
 

--- a/core/ordered_hash_map.h
+++ b/core/ordered_hash_map.h
@@ -240,18 +240,17 @@ public:
 		return map.has(p_key);
 	}
 
-	const V &operator[](const K &p_key) const {
+	inline const V &operator[](const K &p_key) const {
+
 		ConstElement e = find(p_key);
-		CRASH_COND(!e);
+		CRASH_COND_MSG(!e, "Map key not found.");
 		return e.value();
 	}
 
-	V &operator[](const K &p_key) {
+	inline V &operator[](const K &p_key) {
+
 		Element e = find(p_key);
-		if (!e) {
-			// consistent with Map behaviour
-			e = insert(p_key, V());
-		}
+		CRASH_COND_MSG(!e, "Map key not found.");
 		return e.value();
 	}
 

--- a/core/vmap.h
+++ b/core/vmap.h
@@ -186,20 +186,15 @@ public:
 	inline const V &operator[](const T &p_key) const {
 
 		int pos = _find_exact(p_key);
-
-		CRASH_COND(pos < 0);
-
-		return _cowdata.get(pos).value;
+		CRASH_COND_MSG(pos < 0, "Map key not found.");
+		return getv(pos);
 	}
 
 	inline V &operator[](const T &p_key) {
 
 		int pos = _find_exact(p_key);
-		if (pos < 0) {
-			pos = insert(p_key, V());
-		}
-
-		return _cowdata.get_m(pos).value;
+		CRASH_COND_MSG(pos < 0, "Map key not found.");
+		return getv(pos);
 	}
 
 	_FORCE_INLINE_ VMap(){};


### PR DESCRIPTION
Fixes part 7 of #27638, which was not addressed by #30716.

Part 7 of #27638 points out that in the non const version of the array subscript overloading of the VMap<T, V> template class an instance of V is used uninitialised:
![55487295-202fd200-562e-11e9-9230-26c7e63537e4](https://user-images.githubusercontent.com/9253928/66929159-d5f2c900-f032-11e9-9804-35c9d2e60fad.png)

The non const version of an array subscript overload can be used to both assign a value and give access to a writeable version of an underlying variable. The use of an uninitialised version of V is only a problem when the array subscript is used to access a writeable version of the underlying variable when the array index i.e. the T key is not found in the underlying CowData, but a potential problem nonetheless.

The const version of the VMap array subscript overload calls CRASH_COND when the T key is not found in the underlying CowData.
https://github.com/godotengine/godot/blob/119bf237209414a49879fba40459f22315ab1467/core/vmap.h#L186-L193
This patch mirrors the non const behaviour. Any attempt to use VMap's array subscript to access a value V, when the T key is not found will generate a CRASH_COND instead.

Unfortunately, this will also cause a CRASH_COND if the array subscript is used to assign a V value to a new T value. Since the code was simply calling the public insert function, code using VMap can use this function instead:
https://github.com/godotengine/godot/blob/119bf237209414a49879fba40459f22315ab1467/core/vmap.h#L116-L127
This will have the desired result of overwriting the existing V value if the T key value exists and creating a new pair if it doesn't.

VMap is currently used by Object for Signal, Slot pairs, VisualShader for connections and GDScriptTokenizerBuffer for storing bytes (uint32_t). It appears as if only Object is using VMap's non const version of the array subscript, and it only uses it once for assignment and twice for accessing writeable versions of the underlying Slots. Therefore this patch also makes the following changes:

- Object's use of the array subscript assignment is replaced with the insert function.
- The first use for accessing a writeable version of a Slot is also protected by an initial check to ensure the key exists:
https://github.com/godotengine/godot/blob/119bf237209414a49879fba40459f22315ab1467/core/object.cpp#L1459-L1466
Therefore, no change is required.
- The second use for accessing a writeable version also performs a ERR_FAIL_COND_MSG check, which also returns out of the function.
https://github.com/godotengine/godot/blob/119bf237209414a49879fba40459f22315ab1467/core/object.cpp#L1524-L1526
Therefore, no change is required.

