### PR TITLE
Expose Node::update_configuration_warning() to scripts

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -40,8 +40,9 @@
 			<return type="String">
 			</return>
 			<description>
-				The string returned from this method is displayed as a warning in the "Scene Dock" if the script that overrides it is a [code]tool[/code] script.
+				The string returned from this method is displayed as a warning in the Scene Dock if the script that overrides it is a [code]tool[/code] script.
 				Returning an empty string produces no warning.
+				Call [method update_configuration_warning] when the warning needs to be updated for this node.
 			</description>
 		</method>
 		<method name="_input" qualifiers="virtual">
@@ -816,6 +817,14 @@
 			</argument>
 			<description>
 				Sets whether this is an instance load placeholder. See [InstancePlaceholder].
+			</description>
+		</method>
+		<method name="update_configuration_warning">
+			<return type="void">
+			</return>
+			<description>
+				Updates the warning displayed for this node in the Scene Dock.
+				Use [method _get_configuration_warning] to setup the warning message to display.
 			</description>
 		</method>
 	</methods>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2832,6 +2832,8 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rset_unreliable", "property", "value"), &Node::rset_unreliable);
 	ClassDB::bind_method(D_METHOD("rset_unreliable_id", "peer_id", "property", "value"), &Node::rset_unreliable_id);
 
+	ClassDB::bind_method(D_METHOD("update_configuration_warning"), &Node::update_configuration_warning);
+
 	BIND_CONSTANT(NOTIFICATION_ENTER_TREE);
 	BIND_CONSTANT(NOTIFICATION_EXIT_TREE);
 	BIND_CONSTANT(NOTIFICATION_MOVED_IN_PARENT);


### PR DESCRIPTION
This method can be used to generate custom node warnings by script.

Node::_get_configuration_warning() was already exposed to generate custom warnings, but it wasn't fully usable without being able to notify the scene tree when the warning needs to appear or change.