### PR TITLE
Disable gridmap selection actions when nothing is selected

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -354,6 +354,11 @@ void GridMapEditor::_set_selection(bool p_active, const Vector3 &p_begin, const 
 	selection.current = p_end;
 
 	_update_selection_transform();
+
+	options->get_popup()->set_item_disabled(options->get_popup()->get_item_index(MENU_OPTION_SELECTION_CLEAR), !selection.active);
+	options->get_popup()->set_item_disabled(options->get_popup()->get_item_index(MENU_OPTION_SELECTION_CUT), !selection.active);
+	options->get_popup()->set_item_disabled(options->get_popup()->get_item_index(MENU_OPTION_SELECTION_DUPLICATE), !selection.active);
+	options->get_popup()->set_item_disabled(options->get_popup()->get_item_index(MENU_OPTION_SELECTION_FILL), !selection.active);
 }
 
 bool GridMapEditor::do_input_action(Camera *p_camera, const Point2 &p_point, bool p_click) {
@@ -1465,7 +1470,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 		}
 	}
 
-	selection.active = false;
+	_set_selection(false);
 	updating = false;
 	accumulated_floor_delta = 0.0;
 }


### PR DESCRIPTION
Disable the gridmap actions related to the current selection (cut, clear, fill and duplicate) when nothing is selected.
Effectively gray out the actions in the gridmap menu and disable the shortcuts.

Also fixes #32852

On a side note there is now extraneous checks in the actions code to ensure there is something selected, it should not happen anymore in the editor but still can via code, don't know what is the consensus here for extra checking. I am tempted to remove them.

And it's my first PR! \o/