### PR TITLE
Remove duplicate valid value check in gdscript_tokenizer.cpp.

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -849,12 +849,8 @@ void GDScriptTokenizerText::_advance() {
 										_make_error("Unterminated String");
 										return;
 									}
-									if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
 
-										_make_error("Malformed hex constant in string");
-										return;
-									}
-									CharType v;
+									CharType v = 0;
 									if (c >= '0' && c <= '9') {
 										v = c - '0';
 									} else if (c >= 'a' && c <= 'f') {
@@ -864,8 +860,8 @@ void GDScriptTokenizerText::_advance() {
 										v = c - 'A';
 										v += 10;
 									} else {
-										ERR_PRINT("BUG");
-										v = 0;
+										_make_error("Malformed hex constant in string");
+										return;
 									}
 
 									res <<= 4;


### PR DESCRIPTION
Fixes part 9 of #27649:
godot/modules/gdscript/gdscript_tokenizer.cpp:823(also 825, 828, 899 ): ostrzeżenie: V560 A part of conditional expression is always true: c >= '0'.
![55502770-9e4fa100-564d-11e9-9e40-966df596d341](https://user-images.githubusercontent.com/9253928/67085927-09069b00-f1a0-11e9-9953-d603dfd07a80.png)
![55502772-9f80ce00-564d-11e9-9f8c-9f3546352361](https://user-images.githubusercontent.com/9253928/67085965-22a7e280-f1a0-11e9-8abf-b8c4e58f2c1d.png)
