### PR TITLE
[macOS] Various volume list fixes

### DIFF
--- a/platform/osx/dir_access_osx.mm
+++ b/platform/osx/dir_access_osx.mm
@@ -48,18 +48,25 @@ String DirAccessOSX::fix_unicode_name(const char *p_name) const {
 }
 
 int DirAccessOSX::get_drive_count() {
-	NSArray *vols = [[NSWorkspace sharedWorkspace] mountedLocalVolumePaths];
+	NSArray *res_keys = [NSArray arrayWithObjects:NSURLVolumeURLKey, NSURLIsSystemImmutableKey, nil];
+	NSArray *vols = [[NSFileManager defaultManager] mountedVolumeURLsIncludingResourceValuesForKeys:res_keys options:NSVolumeEnumerationSkipHiddenVolumes];
+
 	return [vols count];
 }
 
 String DirAccessOSX::get_drive(int p_drive) {
-	NSArray *vols = [[NSWorkspace sharedWorkspace] mountedLocalVolumePaths];
+	NSArray *res_keys = [NSArray arrayWithObjects:NSURLVolumeURLKey, NSURLIsSystemImmutableKey, nil];
+	NSArray *vols = [[NSFileManager defaultManager] mountedVolumeURLsIncludingResourceValuesForKeys:res_keys options:NSVolumeEnumerationSkipHiddenVolumes];
 	int count = [vols count];
 
 	ERR_FAIL_INDEX_V(p_drive, count, "");
 
-	NSString *path = vols[p_drive];
-	return String([path UTF8String]);
+	String volname;
+	NSString *path = [vols[p_drive] path];
+
+	volname.parse_utf8([path UTF8String]);
+
+	return volname;
 }
 
 #endif //posix_enabled


### PR DESCRIPTION
* Fix non-ASCII volume names (UTF8 string was parsed as ASCII).
* Replace deprecated `mountedLocalVolumePaths` (10.0-10.11) API with `mountedVolumeURLsIncludingResourceValuesForKeys` (10.6+).
* Remove hidden mount points (Sandboxes, Time Machine snapshots, system recovery, etc.) from the volume list.

*Before:*
![Screenshot 2019-10-18 at 15 32 24](https://user-images.githubusercontent.com/7645683/67095004-9a383a80-f1bd-11e9-95a1-3766bab71d08.png)

*After:*
![Screenshot 2019-10-18 at 15 34 21](https://user-images.githubusercontent.com/7645683/67095021-a2907580-f1bd-11e9-88cf-28ba1bc3abfb.png)

