### PR TITLE
Remove duplicate displayed node update call

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1217,7 +1217,6 @@ void SceneTreeDock::_node_selected() {
 	Node *node = scene_tree->get_selected();
 
 	if (!node) {
-		editor->push_item(nullptr);
 		return;
 	}
 
@@ -1902,11 +1901,10 @@ void SceneTreeDock::_selection_changed() {
 	if (selection_size > 1) {
 		//automatically turn on multi-edit
 		_tool_selected(TOOL_MULTI_EDIT);
-	} else if (selection_size == 1) {
-		editor->push_item(EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list()[0]);
-	} else {
+	} else if (selection_size == 0) {
 		editor->push_item(nullptr);
 	}
+
 	_update_script_button();
 }
 


### PR DESCRIPTION
Each time a new node is selected in the scene tree dock, both `_node_selected()` and `_selection_changed()` are called.
They are then both calling `editor->push_item()`, resulting in potentially lots of duplicate calls downstream (eg a Gridmap node is loaded twice)
This fixes this.

Ideally I think that _node_selected() and _selection_changed() should be merged, they are redundant.