### PR TITLE
Remove wrong usage of `volatile` (3.2)

### DIFF
--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -41,6 +41,8 @@
 #include "core/os/semaphore.h"
 #include "core/os/thread.h"
 
+#include <atomic>
+
 class _ResourceLoader : public Object {
 	GDCLASS(_ResourceLoader, Object);
 
@@ -652,7 +654,7 @@ class _Thread : public Reference {
 protected:
 	Variant ret;
 	Variant userdata;
-	volatile bool active;
+	std::atomic<bool> active;
 	Object *target_instance;
 	StringName target_method;
 	Thread *thread;

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -32,6 +32,9 @@
 #define ERROR_MACROS_H
 
 #include "core/typedefs.h"
+
+#include <atomic>
+
 /**
  * Error macros. Unlike exceptions and asserts, these macros try to maintain consistency and stability
  * inside the code. It is recommended to always return processable data, so in case of an error, the
@@ -473,22 +476,20 @@ extern bool _err_error_exists;
 
 #define WARN_DEPRECATED                                                                                                                                   \
 	{                                                                                                                                                     \
-		static volatile bool warning_shown = false;                                                                                                       \
-		if (!warning_shown) {                                                                                                                             \
+		static std::atomic_flag warning_shown = ATOMIC_FLAG_INIT;                                                                                         \
+		if (!warning_shown.test_and_set()) {                                                                                                              \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future", ERR_HANDLER_WARNING); \
 			_err_error_exists = false;                                                                                                                    \
-			warning_shown = true;                                                                                                                         \
 		}                                                                                                                                                 \
 	}
 
 #define WARN_DEPRECATED_MSG(m_msg)                                                                                                                        \
 	{                                                                                                                                                     \
-		static volatile bool warning_shown = false;                                                                                                       \
-		if (!warning_shown) {                                                                                                                             \
+		static std::atomic_flag warning_shown = ATOMIC_FLAG_INIT;                                                                                         \
+		if (!warning_shown.test_and_set()) {                                                                                                              \
 			ERR_EXPLAIN(m_msg);                                                                                                                           \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future", ERR_HANDLER_WARNING); \
 			_err_error_exists = false;                                                                                                                    \
-			warning_shown = true;                                                                                                                         \
 		}                                                                                                                                                 \
 	}
 

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -42,7 +42,7 @@ struct _IP_ResolverPrivate {
 
 	struct QueueItem {
 
-		volatile IP::ResolverStatus status;
+		std::atomic<IP::ResolverStatus> status;
 		IP_Address response;
 		String hostname;
 		IP::Type type;

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -230,7 +230,7 @@ class EditorFileSystem : public Node {
 	};
 
 	void _scan_script_classes(EditorFileSystemDirectory *p_dir);
-	volatile bool update_script_classes_queued;
+	bool update_script_classes_queued;
 	void _queue_update_script_classes();
 
 	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -86,6 +86,8 @@
 #include "scene/gui/tree.h"
 #include "scene/gui/viewport_container.h"
 
+#include <atomic>
+
 typedef void (*EditorNodeInitCallback)();
 typedef void (*EditorPluginInitializeCallback)();
 typedef bool (*EditorBuildCallback)();
@@ -116,7 +118,7 @@ public:
 		Thread *execute_output_thread;
 		Mutex *execute_output_mutex;
 		int exitcode;
-		volatile bool done;
+		std::atomic<bool> done;
 	};
 
 private:

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -36,6 +36,8 @@
 #include "scene/main/node.h"
 #include "scene/resources/texture.h"
 
+#include <atomic>
+
 class EditorResourcePreviewGenerator : public Reference {
 
 	GDCLASS(EditorResourcePreviewGenerator, Reference);
@@ -73,8 +75,8 @@ class EditorResourcePreview : public Node {
 	Mutex *preview_mutex;
 	Semaphore *preview_sem;
 	Thread *thread;
-	volatile bool exit;
-	volatile bool exited;
+	std::atomic<bool> exit;
+	std::atomic<bool> exited;
 
 	struct Item {
 		Ref<Texture> preview;

--- a/editor/plugins/editor_preview_plugins.h
+++ b/editor/plugins/editor_preview_plugins.h
@@ -33,6 +33,8 @@
 
 #include "editor/editor_resource_preview.h"
 
+#include <atomic>
+
 void post_process_preview(Ref<Image> p_image);
 
 class EditorTexturePreviewPlugin : public EditorResourcePreviewGenerator {
@@ -92,7 +94,7 @@ class EditorMaterialPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID light2;
 	RID light_instance2;
 	RID camera;
-	mutable volatile bool preview_done;
+	mutable std::atomic<bool> preview_done;
 
 	void _preview_done(const Variant &p_udata);
 
@@ -137,7 +139,7 @@ class EditorMeshPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID light2;
 	RID light_instance2;
 	RID camera;
-	mutable volatile bool preview_done;
+	mutable std::atomic<bool> preview_done;
 
 	void _preview_done(const Variant &p_udata);
 
@@ -160,7 +162,7 @@ class EditorFontPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID viewport_texture;
 	RID canvas;
 	RID canvas_item;
-	mutable volatile bool preview_done;
+	mutable std::atomic<bool> preview_done;
 
 	void _preview_done(const Variant &p_udata);
 

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -48,6 +48,8 @@
 #include "core/os/mutex.h"
 #endif
 
+#include <atomic>
+
 struct NativeScriptDesc {
 
 	struct Method {
@@ -242,7 +244,7 @@ private:
 
 	Set<Ref<GDNativeLibrary> > libs_to_init;
 	Set<NativeScript *> scripts_to_register;
-	volatile bool has_objects_to_register; // so that we don't lock mutex every frame - it's rarely needed
+	std::atomic<bool> has_objects_to_register; // so that we don't lock mutex every frame - it's rarely needed
 	void defer_init_library(Ref<GDNativeLibrary> lib, NativeScript *script);
 #endif
 

--- a/modules/opus/audio_stream_opus.h
+++ b/modules/opus/audio_stream_opus.h
@@ -37,6 +37,8 @@
 
 #include <opus/opusfile.h>
 
+#include <atomic>
+
 /**
 	@author George Marques <george@gmarqu.es>
 */
@@ -63,7 +65,7 @@ class AudioStreamPlaybackOpus : public AudioStreamPlayback {
 	int64_t frames_mixed;
 
 	bool stream_loaded;
-	volatile bool playing;
+	std::atomic<bool> playing;
 	OggOpusFile *opus_file;
 	int stream_channels;
 	int current_section;

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -44,6 +44,10 @@
 
 //#define THEORA_USE_THREAD_STREAMING
 
+#ifdef THEORA_USE_THREAD_STREAMING
+#include <atomic>
+#endif
+
 class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 
 	GDCLASS(VideoStreamPlaybackTheora, VideoStreamPlayback);
@@ -114,7 +118,7 @@ class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 	bool thread_eof;
 	Semaphore *thread_sem;
 	Thread *thread;
-	volatile bool thread_exit;
+	std::atomic<bool> thread_exit;
 
 	static void _streaming_thread(void *ud);
 

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -38,6 +38,8 @@
 
 #include <vorbis/vorbisfile.h>
 
+#include <atomic>
+
 class AudioStreamPlaybackOGGVorbis : public AudioStreamPlayback {
 
 	GDCLASS(AudioStreamPlaybackOGGVorbis, AudioStreamPlayback);
@@ -59,7 +61,7 @@ class AudioStreamPlaybackOGGVorbis : public AudioStreamPlayback {
 	int64_t frames_mixed;
 
 	bool stream_loaded;
-	volatile bool playing;
+	std::atomic<bool> playing;
 	OggVorbis_File vf;
 	int stream_channels;
 	int stream_srate;

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -44,6 +44,7 @@
 #include "platform/android/run_icon.gen.h"
 
 #include <string.h>
+#include <atomic>
 
 static const char *android_perms[] = {
 	"ACCESS_CHECKIN_PROPERTIES",
@@ -229,10 +230,10 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 	};
 
 	Vector<Device> devices;
-	volatile bool devices_changed;
+	std::atomic<bool> devices_changed;
 	Mutex *device_lock;
 	Thread *device_thread;
-	volatile bool quit_request;
+	std::atomic<bool> quit_request;
 
 	static void _device_poll_thread(void *ud) {
 

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -31,6 +31,8 @@
 #include "java_godot_io_wrapper.h"
 #include "core/error_list.h"
 
+#include <atomic>
+
 // JNIEnv is only valid within the thread it belongs to, in a multi threading environment
 // we can't cache it.
 // For GodotIO we call all access methods from our thread and we thus get a valid JNIEnv
@@ -194,9 +196,9 @@ void GodotIOJavaWrapper::stop_video() {
 	}
 }
 
-// volatile because it can be changed from non-main thread and we need to
+// atomic because it can be changed from non-main thread and we need to
 // ensure the change is immediately visible to other threads.
-static volatile int virtual_keyboard_height;
+static std::atomic<int> virtual_keyboard_height;
 
 int GodotIOJavaWrapper::get_vk_height() {
 	return virtual_keyboard_height;

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -251,7 +251,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 
 		//start playing if requested
 		if (setplay >= 0.0) {
-			setseek = setplay;
+			setseek.store(setplay);
 			active = true;
 			setplay = -1;
 			//do not update, this makes it easier to animate (will shut off otherwise)

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -35,6 +35,8 @@
 #include "servers/audio/audio_stream.h"
 #include "servers/audio_server.h"
 
+#include <atomic>
+
 class AudioStreamPlayer2D : public Node2D {
 
 	GDCLASS(AudioStreamPlayer2D, Node2D);
@@ -54,8 +56,8 @@ private:
 	};
 
 	Output outputs[MAX_OUTPUTS];
-	volatile int output_count;
-	volatile bool output_ready;
+	std::atomic<int> output_count;
+	std::atomic<bool> output_ready;
 
 	//these are used by audio thread to have a reference of previous volumes (for ramping volume and avoiding clicks)
 	Output prev_outputs[MAX_OUTPUTS];
@@ -65,9 +67,9 @@ private:
 	Ref<AudioStream> stream;
 	Vector<AudioFrame> mix_buffer;
 
-	volatile float setseek;
-	volatile bool active;
-	volatile float setplay;
+	std::atomic<float> setseek;
+	std::atomic<bool> active;
+	std::atomic<float> setplay;
 
 	float volume_db;
 	float pitch_scale;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -617,7 +617,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 
 		//start playing if requested
 		if (setplay >= 0.0) {
-			setseek = setplay;
+			setseek.store(setplay);
 			active = true;
 			setplay = -1;
 			//do not update, this makes it easier to animate (will shut off otherwise)

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -37,6 +37,8 @@
 #include "servers/audio/audio_stream.h"
 #include "servers/audio_server.h"
 
+#include <atomic>
+
 class Camera;
 class AudioStreamPlayer3D : public Spatial {
 
@@ -89,8 +91,8 @@ private:
 	};
 
 	Output outputs[MAX_OUTPUTS];
-	volatile int output_count;
-	volatile bool output_ready;
+	std::atomic<int> output_count;
+	std::atomic<bool> output_ready;
 
 	//these are used by audio thread to have a reference of previous volumes (for ramping volume and avoiding clicks)
 	Output prev_outputs[MAX_OUTPUTS];
@@ -100,9 +102,9 @@ private:
 	Ref<AudioStream> stream;
 	Vector<AudioFrame> mix_buffer;
 
-	volatile float setseek;
-	volatile bool active;
-	volatile float setplay;
+	std::atomic<float> setseek;
+	std::atomic<bool> active;
+	std::atomic<float> setplay;
 
 	AttenuationModel attenuation_model;
 	float unit_db;

--- a/scene/3d/cpu_particles.h
+++ b/scene/3d/cpu_particles.h
@@ -34,6 +34,8 @@
 #include "core/rid.h"
 #include "scene/3d/visual_instance.h"
 
+#include <atomic>
+
 class CPUParticles : public GeometryInstance {
 private:
 	GDCLASS(CPUParticles, GeometryInstance);
@@ -142,7 +144,7 @@ private:
 
 	Transform inv_emission_transform;
 
-	volatile bool can_update;
+	std::atomic<bool> can_update;
 
 	DrawOrder draw_order;
 

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -1914,7 +1914,7 @@ Error VoxelLightBaker::make_lightmap(const Transform &p_xform, Ref<Mesh> &p_mesh
 	{
 		LightMap *lightmap_ptr = lightmap.ptrw();
 		uint64_t begin_time = OS::get_singleton()->get_ticks_usec();
-		volatile int lines = 0;
+		int lines = 0;
 
 		// make sure our OS-level rng is seeded
 

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -34,6 +34,8 @@
 #include "scene/main/node.h"
 #include "servers/audio/audio_stream.h"
 
+#include <atomic>
+
 class AudioStreamPlayer : public Node {
 
 	GDCLASS(AudioStreamPlayer, Node);
@@ -52,10 +54,10 @@ private:
 	Vector<AudioFrame> fadeout_buffer;
 	bool use_fadeout;
 
-	volatile float setseek;
-	volatile bool active;
-	volatile bool setstop;
-	volatile bool stop_has_priority;
+	std::atomic<float> setseek;
+	std::atomic<bool> active;
+	std::atomic<bool> setstop;
+	std::atomic<bool> stop_has_priority;
 
 	float mix_volume_db;
 	float pitch_scale;

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -37,6 +37,8 @@
 #include "node.h"
 #include "scene/main/timer.h"
 
+#include <atomic>
+
 class HTTPRequest : public Node {
 
 	GDCLASS(HTTPRequest, Node);
@@ -74,7 +76,7 @@ private:
 	bool request_sent;
 	Ref<HTTPClient> client;
 	PoolByteArray body;
-	volatile bool use_threads;
+	bool use_threads;
 
 	bool got_response;
 	int response_code;
@@ -85,7 +87,7 @@ private:
 	FileAccess *file;
 
 	int body_len;
-	volatile int downloaded;
+	std::atomic<int> downloaded;
 	int body_size_limit;
 
 	int redirections;
@@ -103,8 +105,8 @@ private:
 	Error _parse_url(const String &p_url);
 	Error _request();
 
-	volatile bool thread_done;
-	volatile bool thread_request_quit;
+	std::atomic<bool> thread_done;
+	std::atomic<bool> thread_request_quit;
 
 	Thread *thread;
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -89,7 +89,7 @@ private:
 
 	static RenderModeEnums render_mode_enums[];
 
-	volatile mutable bool dirty;
+	mutable std::atomic<bool> dirty;
 	void _queue_update();
 
 	union ConnectionKey {

--- a/servers/audio/audio_rb_resampler.h
+++ b/servers/audio/audio_rb_resampler.h
@@ -45,8 +45,8 @@ struct AudioRBResampler {
 	uint32_t src_mix_rate;
 	uint32_t target_mix_rate;
 
-	volatile int rb_read_pos;
-	volatile int rb_write_pos;
+	std::atomic<int> rb_read_pos;
+	std::atomic<int> rb_write_pos;
 
 	int32_t offset; //contains the fractional remainder of the resampler
 	enum {

--- a/servers/audio/voice_rb_sw.h
+++ b/servers/audio/voice_rb_sw.h
@@ -108,8 +108,8 @@ public:
 
 private:
 	Command voice_cmd_rb[VOICE_RB_SIZE];
-	volatile int read_pos;
-	volatile int write_pos;
+	std::atomic<int> read_pos;
+	std::atomic<int> write_pos;
 
 public:
 	_FORCE_INLINE_ bool commands_left() const { return read_pos != write_pos; }

--- a/servers/physics_2d/physics_2d_server_wrap_mt.h
+++ b/servers/physics_2d/physics_2d_server_wrap_mt.h
@@ -36,6 +36,8 @@
 #include "core/project_settings.h"
 #include "servers/physics_2d_server.h"
 
+#include <atomic>
+
 #ifdef DEBUG_SYNC
 #define SYNC_DEBUG print_line("sync on: " + String(__FUNCTION__));
 #else
@@ -53,9 +55,9 @@ class Physics2DServerWrapMT : public Physics2DServer {
 
 	Thread::ID server_thread;
 	Thread::ID main_thread;
-	volatile bool exit;
+	std::atomic<bool> exit;
 	Thread *thread;
-	volatile bool step_thread_up;
+	std::atomic<bool> step_thread_up;
 	bool create_thread;
 
 	Semaphore *step_sem;

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -40,6 +40,8 @@
 #include "core/self_list.h"
 #include "servers/arvr/arvr_interface.h"
 
+#include <atomic>
+
 class VisualServerScene {
 public:
 	enum {
@@ -527,7 +529,7 @@ public:
 	void _gi_probe_bake_thread();
 	static void _gi_probe_bake_threads(void *);
 
-	volatile bool probe_bake_thread_exit;
+	std::atomic<bool> probe_bake_thread_exit;
 	Thread *probe_bake_thread;
 	Semaphore *probe_bake_sem;
 	Mutex *probe_bake_mutex;

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -35,6 +35,8 @@
 #include "core/os/thread.h"
 #include "servers/visual_server.h"
 
+#include <atomic>
+
 class VisualServerWrapMT : public VisualServer {
 
 	// the real visual server
@@ -46,9 +48,9 @@ class VisualServerWrapMT : public VisualServer {
 	void thread_loop();
 
 	Thread::ID server_thread;
-	volatile bool exit;
+	std::atomic<bool> exit;
 	Thread *thread;
-	volatile bool draw_thread_up;
+	std::atomic<bool> draw_thread_up;
 	bool create_thread;
 
 	uint64_t draw_pending;


### PR DESCRIPTION
Since `volatile` is an incorrect way of ensuring thread-safe access to a variable, this is replacing it by `std::atomic` types.
Furthermore, a helper class called `CopyableAtomic` is introduced. See its corresponding file for details.
Also in a few cases where multi-threaded access doesn't happen, `volatile` is just removed.

This can potentially fix some bugs or even improve performance in some cases.

**This is the version of this change for 3.2. The great migration to C++ atomics will happen in 4.0, but these are needed for correct behavior right now and since we are already using C++11, it should be OK.**