### PR TITLE
Fixed leak on exit when using yield with SceneTreeTimer

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -78,6 +78,17 @@ bool SceneTreeTimer::is_pause_mode_process() {
 	return process_pause;
 }
 
+void SceneTreeTimer::release_connections() {
+
+	List<Connection> connections;
+	get_all_signal_connections(&connections);
+
+	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
+		Connection const &connection = E->get();
+		disconnect(connection.signal, connection.target, connection.method);
+	}
+}
+
 SceneTreeTimer::SceneTreeTimer() {
 	time_left = 0;
 	process_pause = true;
@@ -611,6 +622,12 @@ void SceneTree::finish() {
 		memdelete(root); //delete root
 		root = NULL;
 	}
+
+	// cleanup timers
+	for (List<Ref<SceneTreeTimer> >::Element *E = timers.front(); E; E = E->next()) {
+		E->get()->release_connections();
+	}
+	timers.clear();
 }
 
 void SceneTree::quit() {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -61,6 +61,8 @@ public:
 	void set_pause_mode_process(bool p_pause_mode_process);
 	bool is_pause_mode_process();
 
+	void release_connections();
+
 	SceneTreeTimer();
 };
 


### PR DESCRIPTION
Use case:
`yield(get_tree().create_timer(2), "timeout")`

Some resources were never released because the `SceneTreeTimer` was keeping a reference to `GDScriptFunctionState` in its signal connections, while `GDScriptFunctionState` was holding a reference to the `SceneTreeTimer` object. Cleaning all signal connections on game exit fixes the issue.

Fixes #29946