### PR TITLE
Fixed TouchScreenButton::shape_centered having no effect

### DIFF
--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -325,8 +325,12 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 }
 
 Rect2 TouchScreenButton::_edit_get_rect() const {
-	if (texture.is_null())
-		return CanvasItem::_edit_get_rect();
+	if (texture.is_null()) {
+		if (shape.is_valid())
+			return shape->get_rect();
+		else
+			return CanvasItem::_edit_get_rect();
+	}
 
 	return Rect2(Size2(), texture->get_size());
 }


### PR DESCRIPTION
The problem was that the shape_centered depended on TouchScreenButton::texture having a Texture

Fixes #32725

![ShapeCenteredFix](https://user-images.githubusercontent.com/37383316/67151066-c2e03300-f296-11e9-9c95-527de4f59e6f.gif)