### PR TITLE
Add primary grid lines to the 2D editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -255,6 +255,7 @@ private:
 
 	Point2 grid_offset;
 	Point2 grid_step;
+	int primary_grid_steps;
 	int grid_step_multiplier;
 
 	float snap_rotation_step;


### PR DESCRIPTION
A "primary" line is drawn every 8 steps, which makes it easier to measure distances for snapping. Let me know if the effect is too strong (or too subtle) :slightly_smiling_face:

This also refactors the method for better readability.

## Preview

### Before

![2D grid without primary steps](https://user-images.githubusercontent.com/180032/67151288-42d0c200-f2c4-11e9-8ec8-11d144b2a98a.png)

### After

![2D grid with primary steps](https://user-images.githubusercontent.com/180032/67151270-187f0480-f2c4-11e9-8cf4-c94f610326d0.png)

**Edit:** The primary grid step is now configurable in the Configure Snap dialog:

![Configure Snap dialog](https://user-images.githubusercontent.com/180032/67778601-b496d180-fa63-11e9-9529-b02fa78f3895.png)
