### PR TITLE
Fixed -1 minimap index when smooth scrolling is enabled

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -935,7 +935,7 @@ void TextEdit::_notification(int p_what) {
 				int minimap_line = (v_scroll->get_max() <= minimap_visible_lines) ? -1 : first_visible_line;
 				if (minimap_line >= 0) {
 					minimap_line -= num_lines_from_rows(first_visible_line, 0, -num_lines_before, wi);
-					minimap_line -= (smooth_scroll_enabled ? 1 : 0);
+					minimap_line -= (minimap_line > 0 && smooth_scroll_enabled ? 1 : 0);
 				}
 				int minimap_draw_amount = minimap_visible_lines + times_line_wraps(minimap_line + 1);
 
@@ -2146,7 +2146,7 @@ void TextEdit::_get_minimap_mouse_row(const Point2i &p_mouse, int &r_row) const 
 	int minimap_line = (v_scroll->get_max() <= minimap_visible_lines) ? -1 : first_visible_line;
 	if (first_visible_line > 0 && minimap_line >= 0) {
 		minimap_line -= num_lines_from_rows(first_visible_line, 0, -num_lines_before, wi);
-		minimap_line -= (smooth_scroll_enabled ? 1 : 0);
+		minimap_line -= (minimap_line > 0 && smooth_scroll_enabled ? 1 : 0);
 	} else {
 		minimap_line = 0;
 	}


### PR DESCRIPTION
When smooth scroll is enabled, and the amount of text to draw is the same size as the minimap draw size, the number of lines is 0, so we don't need to account for smooth scrolling.

should close #32785