### PR TITLE
Show complete file path of active scene in window title bar

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -206,7 +206,7 @@ void EditorNode::_update_title() {
 	String title = appname.empty() ? String(VERSION_FULL_NAME) : String(VERSION_NAME + String(" - ") + appname);
 	String edited = editor_data.get_edited_scene_root() ? editor_data.get_edited_scene_root()->get_filename() : String();
 	if (!edited.empty())
-		title += " - " + String(edited.get_file());
+		title += " - " + edited.replace_first("res://", "");
 	if (unsaved_cache)
 		title += " (*)";
 


### PR DESCRIPTION
Hello,
i added a small suggestion by @wyattbiker in issue #22911 to add the complete file path to the window title. Not sure if this is the right / best way to do it so please let me know if i can make it better :)
regards
Thomas

![godot_pathInToolbar](https://user-images.githubusercontent.com/1237975/67160197-84a64a80-f34e-11e9-8cf6-c1b9c84efa36.jpg)
