### PR TITLE
Fixed Node's editor description not showing up after saving

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1225,6 +1225,8 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	}
 	memdelete(dummy_scene);
 
+	scene_tree_dock->get_tree_editor()->update_tree();
+
 	int flg = 0;
 	if (EditorSettings::get_singleton()->get("filesystem/on_save/compress_binary_resources"))
 		flg |= ResourceSaver::FLAG_COMPRESS;


### PR DESCRIPTION
The description was only updating during "Switch Scene Tab"

Before:

![Before](https://user-images.githubusercontent.com/37383316/67164804-bd492280-f354-11e9-955d-760d36208a6c.gif)

-----------------------------------------------------------------------------------------

After:

![After](https://user-images.githubusercontent.com/37383316/67164812-cc2fd500-f354-11e9-8be6-575b12c435cd.gif)
