### PR TITLE
Fix validating editor bold font

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -64,7 +64,7 @@
 	Ref<DynamicFont> m_name;                                    \
 	m_name.instance();                                          \
 	m_name->set_size(m_size);                                   \
-	if (CustomFont.is_valid()) {                                \
+	if (CustomFontBold.is_valid()) {                            \
 		m_name->set_font_data(CustomFontBold);                  \
 		m_name->add_fallback(DefaultFontBold);                  \
 	} else {                                                    \


### PR DESCRIPTION
when setting custom font without custom bold font,
texts with bold is not shown.
![image](https://user-images.githubusercontent.com/8281454/67211070-1dbf8900-f455-11e9-887f-cd60144fc46f.png)

after fixing it.
![image](https://user-images.githubusercontent.com/8281454/67211119-2fa12c00-f455-11e9-80ac-34c7676f2c4a.png)

confirmed 3.1 has the same issue.