### PR TITLE
Fix control node transform animation jitter with pivot offset

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -461,11 +461,6 @@ void Control::_update_canvas_item_transform() {
 	Transform2D xform = _get_internal_transform();
 	xform[2] += get_position();
 
-	// We use a little workaround to avoid flickering when moving the pivot with _edit_set_pivot()
-	if (is_inside_tree() && Math::abs(Math::sin(data.rotation * 4.0f)) < 0.00001f && get_viewport()->is_snap_controls_to_pixels_enabled()) {
-		xform[2] = xform[2].round();
-	}
-
 	VisualServer::get_singleton()->canvas_item_set_transform(get_canvas_item(), xform);
 }
 


### PR DESCRIPTION
The workaround for moving the pivot is not needed anymore, in fact it causes all transforms applied to control nodes to jitter while animating (if a pivot offset is set).

This can be observed via AnimationPlayer and Tween.

The fix is to remove the obsolete workaround that causes this bug.

Fixes #28804