### PR TITLE
Enhancements and fixes for the animation editor's copy track dialog

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5727,16 +5727,24 @@ void AnimationTrackEditor::_show_imported_anim_warning() const {
 }
 
 void AnimationTrackEditor::_select_all_tracks_for_copy() {
+
 	TreeItem *track = track_copy_select->get_root()->get_children();
+	if (!track)
+		return;
+
+	bool all_selected = true;
 	while (track) {
-		track->set_checked(0, selected_all_tracks);
+		if (!track->is_checked(0))
+			all_selected = false;
+
 		track = track->get_next();
 	}
-	selected_all_tracks = !selected_all_tracks;
-	if (selected_all_tracks)
-		select_all_button->set_text(TTR("Select All"));
-	else
-		select_all_button->set_text(TTR("Select None"));
+
+	track = track_copy_select->get_root()->get_children();
+	while (track) {
+		track->set_checked(0, !all_selected);
+		track = track->get_next();
+	}
 }
 
 void AnimationTrackEditor::_bind_methods() {
@@ -6067,25 +6075,22 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	track_copy_dialog = memnew(ConfirmationDialog);
 	add_child(track_copy_dialog);
-	track_copy_dialog->set_title(TTR("Select tracks to copy:"));
+	track_copy_dialog->set_title(TTR("Select Tracks to Copy"));
 	track_copy_dialog->get_ok()->set_text(TTR("Copy"));
 
 	VBoxContainer *track_vbox = memnew(VBoxContainer);
 	track_copy_dialog->add_child(track_vbox);
 
-	selected_all_tracks = true;
+	Button *select_all_button = memnew(Button);
+	select_all_button->set_text(TTR("Select All/None"));
+	select_all_button->connect("pressed", this, "_select_all_tracks_for_copy");
+	track_vbox->add_child(select_all_button);
 
 	track_copy_select = memnew(Tree);
 	track_copy_select->set_h_size_flags(SIZE_EXPAND_FILL);
 	track_copy_select->set_v_size_flags(SIZE_EXPAND_FILL);
 	track_copy_select->set_hide_root(true);
 	track_vbox->add_child(track_copy_select);
-	track_copy_options = memnew(HBoxContainer);
-	track_vbox->add_child(track_copy_options);
-	select_all_button = memnew(Button);
-	select_all_button->set_text(TTR("Select All"));
-	select_all_button->connect("pressed", this, "_select_all_tracks_for_copy");
-	track_copy_options->add_child(select_all_button);
 	track_copy_dialog->connect("confirmed", this, "_edit_menu_pressed", varray(EDIT_COPY_TRACKS_CONFIRM));
 	animation_changing_awaiting_update = false;
 }

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -465,11 +465,8 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _selection_changed();
 
-	bool selected_all_tracks;
 	ConfirmationDialog *track_copy_dialog;
 	Tree *track_copy_select;
-	HBoxContainer *track_copy_options;
-	Button *select_all_button;
 
 	struct TrackClipboard {
 		NodePath full_path;


### PR DESCRIPTION
- Fixed all/none selection not working properly when manually (de)selecting items.
- Moved the "Select All" button from being tucked on the bottom left to the top and expanded.
- Removed unnecessary` Control`s.
- Small renaming of some parts.