### PR TITLE
Fix base 16 hex literal parsing

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -937,8 +937,10 @@ void GDScriptTokenizerText::_advance() {
 								return;
 							}
 							hexa_found = true;
-						} else if (GETCHAR(i) == 'b') {
-							if (hexa_found || bin_found || str.length() != 1 || !((i == 1 && str[0] == '0') || (i == 2 && str[1] == '0' && str[0] == '-'))) {
+						} else if (hexa_found && _is_hex(GETCHAR(i))) {
+
+						} else if (!hexa_found && GETCHAR(i) == 'b') {
+							if (bin_found || str.length() != 1 || !((i == 1 && str[0] == '0') || (i == 2 && str[1] == '0' && str[0] == '-'))) {
 								_make_error("Invalid numeric constant at 'b'");
 								return;
 							}
@@ -951,7 +953,6 @@ void GDScriptTokenizerText::_advance() {
 							exponent_found = true;
 						} else if (_is_number(GETCHAR(i))) {
 							//all ok
-						} else if (hexa_found && _is_hex(GETCHAR(i))) {
 
 						} else if (bin_found && _is_bin(GETCHAR(i))) {
 


### PR DESCRIPTION
Fixes #32963

The change to support binary literals resulted in lower case b's in hex literals throwing a parse error.