### PR TITLE
Don't compile editor-only functions when tools=no

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -35,6 +35,7 @@
 
 #define NORMAL_SUFFIX "_normal"
 
+#ifdef TOOLS_ENABLED
 Dictionary AnimatedSprite::_edit_get_state() const {
 	Dictionary state = Node2D::_edit_get_state();
 	state["offset"] = offset;
@@ -72,6 +73,7 @@ bool AnimatedSprite::_edit_use_rect() const {
 		t = frames->get_frame(animation, frame);
 	return t.is_valid();
 }
+#endif
 
 Rect2 AnimatedSprite::get_anchorable_rect() const {
 	return _get_rect();

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -156,6 +156,7 @@ protected:
 	virtual void _validate_property(PropertyInfo &property) const;
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Dictionary _edit_get_state() const;
 	virtual void _edit_set_state(const Dictionary &p_state);
 
@@ -164,6 +165,7 @@ public:
 	virtual bool _edit_use_pivot() const;
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
+#endif
 
 	virtual Rect2 get_anchorable_rect() const;
 

--- a/scene/2d/back_buffer_copy.cpp
+++ b/scene/2d/back_buffer_copy.cpp
@@ -50,6 +50,7 @@ void BackBufferCopy::_update_copy_mode() {
 	}
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 BackBufferCopy::_edit_get_rect() const {
 
 	return rect;
@@ -58,6 +59,7 @@ Rect2 BackBufferCopy::_edit_get_rect() const {
 bool BackBufferCopy::_edit_use_rect() const {
 	return true;
 }
+#endif
 
 Rect2 BackBufferCopy::get_anchorable_rect() const {
 

--- a/scene/2d/back_buffer_copy.h
+++ b/scene/2d/back_buffer_copy.h
@@ -53,8 +53,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
+#endif
 
 	void set_rect(const Rect2 &p_rect);
 	Rect2 get_rect() const;

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -351,7 +351,7 @@ CanvasItemMaterial::~CanvasItemMaterial() {
 }
 
 ///////////////////////////////////////////////////////////////////
-
+#ifdef TOOLS_ENABLED
 bool CanvasItem::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 	if (_edit_use_rect()) {
 		return _edit_get_rect().has_point(p_point);
@@ -363,6 +363,7 @@ bool CanvasItem::_edit_is_selected_on_click(const Point2 &p_point, double p_tole
 Transform2D CanvasItem::_edit_get_transform() const {
 	return Transform2D(_edit_get_rotation(), _edit_get_position() + _edit_get_pivot());
 }
+#endif
 
 bool CanvasItem::is_visible_in_tree() const {
 
@@ -1121,9 +1122,10 @@ void CanvasItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_toplevel_raise_self"), &CanvasItem::_toplevel_raise_self);
 	ClassDB::bind_method(D_METHOD("_update_callback"), &CanvasItem::_update_callback);
+
+#ifdef TOOLS_ENABLED
 	ClassDB::bind_method(D_METHOD("_edit_set_state", "state"), &CanvasItem::_edit_set_state);
 	ClassDB::bind_method(D_METHOD("_edit_get_state"), &CanvasItem::_edit_get_state);
-
 	ClassDB::bind_method(D_METHOD("_edit_set_position", "position"), &CanvasItem::_edit_set_position);
 	ClassDB::bind_method(D_METHOD("_edit_get_position"), &CanvasItem::_edit_get_position);
 	ClassDB::bind_method(D_METHOD("_edit_set_scale", "scale"), &CanvasItem::_edit_set_scale);
@@ -1138,6 +1140,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_edit_get_pivot"), &CanvasItem::_edit_get_pivot);
 	ClassDB::bind_method(D_METHOD("_edit_use_pivot"), &CanvasItem::_edit_use_pivot);
 	ClassDB::bind_method(D_METHOD("_edit_get_transform"), &CanvasItem::_edit_get_transform);
+#endif
 
 	ClassDB::bind_method(D_METHOD("get_canvas_item"), &CanvasItem::get_canvas_item);
 

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -249,7 +249,7 @@ public:
 	};
 
 	/* EDITOR */
-
+#ifdef TOOLS_ENABLED
 	// Select the node
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
@@ -282,6 +282,7 @@ public:
 	virtual Point2 _edit_get_pivot() const { return Point2(); };
 
 	virtual Transform2D _edit_get_transform() const;
+#endif
 
 	/* VISIBILITY */
 

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -227,6 +227,7 @@ CollisionPolygon2D::BuildMode CollisionPolygon2D::get_build_mode() const {
 	return build_mode;
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 CollisionPolygon2D::_edit_get_rect() const {
 
 	return aabb;
@@ -240,6 +241,7 @@ bool CollisionPolygon2D::_edit_is_selected_on_click(const Point2 &p_point, doubl
 
 	return Geometry::is_point_in_polygon(p_point, Variant(polygon));
 }
+#endif
 
 String CollisionPolygon2D::get_configuration_warning() const {
 

--- a/scene/2d/collision_polygon_2d.h
+++ b/scene/2d/collision_polygon_2d.h
@@ -67,15 +67,17 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
+	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
+	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+#endif
+
 	void set_build_mode(BuildMode p_mode);
 	BuildMode get_build_mode() const;
 
 	void set_polygon(const Vector<Point2> &p_polygon);
 	Vector<Point2> get_polygon() const;
-
-	virtual Rect2 _edit_get_rect() const;
-	virtual bool _edit_use_rect() const;
-	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
 	virtual String get_configuration_warning() const;
 

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -33,6 +33,7 @@
 #include "core/engine.h"
 #include "servers/visual_server.h"
 
+#ifdef TOOLS_ENABLED
 Dictionary Light2D::_edit_get_state() const {
 	Dictionary state = Node2D::_edit_get_state();
 	state["offset"] = get_texture_offset();
@@ -68,6 +69,7 @@ Rect2 Light2D::_edit_get_rect() const {
 bool Light2D::_edit_use_rect() const {
 	return !texture.is_null();
 }
+#endif
 
 Rect2 Light2D::get_anchorable_rect() const {
 	if (texture.is_null())

--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -85,6 +85,7 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Dictionary _edit_get_state() const;
 	virtual void _edit_set_state(const Dictionary &p_state);
 
@@ -93,6 +94,7 @@ public:
 	virtual bool _edit_use_pivot() const;
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
+#endif
 
 	virtual Rect2 get_anchorable_rect() const;
 

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -33,6 +33,8 @@
 #include "core/engine.h"
 
 #define LINE_GRAB_WIDTH 8
+
+#ifdef TOOLS_ENABLED
 Rect2 OccluderPolygon2D::_edit_get_rect() const {
 
 	if (rect_cache_dirty) {
@@ -80,6 +82,7 @@ bool OccluderPolygon2D::_edit_is_selected_on_click(const Point2 &p_point, double
 		return false;
 	}
 }
+#endif
 
 void OccluderPolygon2D::set_polygon(const PoolVector<Vector2> &p_polygon) {
 
@@ -215,6 +218,7 @@ void LightOccluder2D::_notification(int p_what) {
 	}
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 LightOccluder2D::_edit_get_rect() const {
 
 	return occluder_polygon.is_valid() ? occluder_polygon->_edit_get_rect() : Rect2();
@@ -224,6 +228,7 @@ bool LightOccluder2D::_edit_is_selected_on_click(const Point2 &p_point, double p
 
 	return occluder_polygon.is_valid() ? occluder_polygon->_edit_is_selected_on_click(p_point, p_tolerance) : false;
 }
+#endif
 
 void LightOccluder2D::set_occluder_polygon(const Ref<OccluderPolygon2D> &p_polygon) {
 

--- a/scene/2d/light_occluder_2d.h
+++ b/scene/2d/light_occluder_2d.h
@@ -57,8 +57,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+#endif
 
 	void set_polygon(const PoolVector<Vector2> &p_polygon);
 	PoolVector<Vector2> get_polygon() const;
@@ -91,8 +93,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+#endif
 
 	void set_occluder_polygon(const Ref<OccluderPolygon2D> &p_polygon);
 	Ref<OccluderPolygon2D> get_occluder_polygon() const;

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -50,6 +50,7 @@ Line2D::Line2D() {
 	_antialiased = false;
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 Line2D::_edit_get_rect() const {
 
 	if (_points.size() == 0)
@@ -79,6 +80,7 @@ bool Line2D::_edit_is_selected_on_click(const Point2 &p_point, double p_toleranc
 
 	return false;
 }
+#endif
 
 void Line2D::set_points(const PoolVector<Vector2> &p_points) {
 	_points = p_points;

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -56,11 +56,13 @@ public:
 		LINE_TEXTURE_STRETCH
 	};
 
-	Line2D();
-
+#ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+#endif
+
+	Line2D();
 
 	void set_points(const PoolVector<Vector2> &p_points);
 	PoolVector<Vector2> get_points() const;

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -94,6 +94,7 @@ Ref<Texture> MeshInstance2D::get_texture() const {
 	return texture;
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 MeshInstance2D::_edit_get_rect() const {
 
 	if (mesh.is_valid()) {
@@ -103,6 +104,7 @@ Rect2 MeshInstance2D::_edit_get_rect() const {
 
 	return Node2D::_edit_get_rect();
 }
+#endif
 
 MeshInstance2D::MeshInstance2D() {
 }

--- a/scene/2d/mesh_instance_2d.h
+++ b/scene/2d/mesh_instance_2d.h
@@ -46,6 +46,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
+	virtual Rect2 _edit_get_rect() const;
+#endif
+
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh() const;
 
@@ -54,8 +58,6 @@ public:
 
 	void set_normal_map(const Ref<Texture> &p_texture);
 	Ref<Texture> get_normal_map() const;
-
-	virtual Rect2 _edit_get_rect() const;
 
 	MeshInstance2D();
 };

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -94,6 +94,7 @@ Ref<Texture> MultiMeshInstance2D::get_normal_map() const {
 	return normal_map;
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 MultiMeshInstance2D::_edit_get_rect() const {
 
 	if (multimesh.is_valid()) {
@@ -103,6 +104,7 @@ Rect2 MultiMeshInstance2D::_edit_get_rect() const {
 
 	return Node2D::_edit_get_rect();
 }
+#endif
 
 MultiMeshInstance2D::MultiMeshInstance2D() {
 }

--- a/scene/2d/multimesh_instance_2d.h
+++ b/scene/2d/multimesh_instance_2d.h
@@ -47,6 +47,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
+	virtual Rect2 _edit_get_rect() const;
+#endif
+
 	void set_multimesh(const Ref<MultiMesh> &p_multimesh);
 	Ref<MultiMesh> get_multimesh() const;
 
@@ -55,8 +59,6 @@ public:
 
 	void set_normal_map(const Ref<Texture> &p_texture);
 	Ref<Texture> get_normal_map() const;
-
-	virtual Rect2 _edit_get_rect() const;
 
 	MultiMeshInstance2D();
 	~MultiMeshInstance2D();

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -36,6 +36,7 @@
 
 #include "thirdparty/misc/triangulator.h"
 
+#ifdef TOOLS_ENABLED
 Rect2 NavigationPolygon::_edit_get_rect() const {
 
 	if (rect_cache_dirty) {
@@ -75,6 +76,7 @@ bool NavigationPolygon::_edit_is_selected_on_click(const Point2 &p_point, double
 	}
 	return false;
 }
+#endif
 
 void NavigationPolygon::set_vertices(const PoolVector<Vector2> &p_vertices) {
 
@@ -357,7 +359,7 @@ bool NavigationPolygonInstance::is_enabled() const {
 }
 
 /////////////////////////////
-
+#ifdef TOOLS_ENABLED
 Rect2 NavigationPolygonInstance::_edit_get_rect() const {
 
 	return navpoly.is_valid() ? navpoly->_edit_get_rect() : Rect2();
@@ -367,6 +369,7 @@ bool NavigationPolygonInstance::_edit_is_selected_on_click(const Point2 &p_point
 
 	return navpoly.is_valid() ? navpoly->_edit_is_selected_on_click(p_point, p_tolerance) : false;
 }
+#endif
 
 void NavigationPolygonInstance::_notification(int p_what) {
 

--- a/scene/2d/navigation_polygon.h
+++ b/scene/2d/navigation_polygon.h
@@ -57,8 +57,10 @@ protected:
 	Array _get_outlines() const;
 
 public:
+#ifdef TOOLS_ENABLED
 	Rect2 _edit_get_rect() const;
 	bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+#endif
 
 	void set_vertices(const PoolVector<Vector2> &p_vertices);
 	PoolVector<Vector2> get_vertices() const;
@@ -100,8 +102,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+#endif
 
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -35,6 +35,7 @@
 #include "scene/main/viewport.h"
 #include "servers/visual_server.h"
 
+#ifdef TOOLS_ENABLED
 Dictionary Node2D::_edit_get_state() const {
 
 	Dictionary state;
@@ -44,6 +45,7 @@ Dictionary Node2D::_edit_get_state() const {
 
 	return state;
 }
+
 void Node2D::_edit_set_state(const Dictionary &p_state) {
 
 	pos = p_state["position"];
@@ -119,6 +121,7 @@ void Node2D::_edit_set_rect(const Rect2 &p_edit_rect) {
 	_change_notify("scale");
 	_change_notify("position");
 }
+#endif
 
 void Node2D::_update_xform_values() {
 

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -55,6 +55,7 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Dictionary _edit_get_state() const;
 	virtual void _edit_set_state(const Dictionary &p_state);
 
@@ -69,6 +70,7 @@ public:
 	virtual bool _edit_use_rotation() const;
 
 	virtual void _edit_set_rect(const Rect2 &p_edit_rect);
+#endif
 
 	void set_position(const Point2 &p_pos);
 	void set_rotation(float p_radians);

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_scale.h"
 #endif
 
+#ifdef TOOLS_ENABLED
 Rect2 Path2D::_edit_get_rect() const {
 
 	if (!curve.is_valid() || curve->get_point_count() == 0)
@@ -85,6 +86,7 @@ bool Path2D::_edit_is_selected_on_click(const Point2 &p_point, double p_toleranc
 
 	return false;
 }
+#endif
 
 void Path2D::_notification(int p_what) {
 

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -47,9 +47,11 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+#endif
 
 	void set_curve(const Ref<Curve2D> &p_curve);
 	Ref<Curve2D> get_curve() const;

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -33,6 +33,7 @@
 #include "core/math/geometry.h"
 #include "skeleton_2d.h"
 
+#ifdef TOOLS_ENABLED
 Dictionary Polygon2D::_edit_get_state() const {
 	Dictionary state = Node2D::_edit_get_state();
 	state["offset"] = offset;
@@ -87,6 +88,7 @@ bool Polygon2D::_edit_is_selected_on_click(const Point2 &p_point, double p_toler
 	}
 	return Geometry::is_point_in_polygon(p_point - get_offset(), polygon2d);
 }
+#endif
 
 void Polygon2D::_skeleton_bone_setup_changed() {
 	update();

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -77,6 +77,7 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Dictionary _edit_get_state() const;
 	virtual void _edit_set_state(const Dictionary &p_state);
 
@@ -87,6 +88,7 @@ public:
 	virtual bool _edit_use_rect() const;
 
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+#endif
 
 	void set_polygon(const PoolVector<Vector2> &p_polygon);
 	PoolVector<Vector2> get_polygon() const;

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -43,6 +43,7 @@ void Position2D::_draw_cross() {
 	draw_line(Point2(0, -extents), Point2(0, +extents), Color(0.53, 0.84, 0.01));
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 Position2D::_edit_get_rect() const {
 
 	float extents = get_gizmo_extents();
@@ -52,6 +53,7 @@ Rect2 Position2D::_edit_get_rect() const {
 bool Position2D::_edit_use_rect() const {
 	return false;
 }
+#endif
 
 void Position2D::_notification(int p_what) {
 

--- a/scene/2d/position_2d.h
+++ b/scene/2d/position_2d.h
@@ -44,8 +44,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
+#endif
 
 	void set_gizmo_extents(float p_extents);
 	float get_gizmo_extents() const;

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -34,6 +34,7 @@
 #include "scene/main/viewport.h"
 #include "scene/scene_string_names.h"
 
+#ifdef TOOLS_ENABLED
 Dictionary Sprite::_edit_get_state() const {
 	Dictionary state = Node2D::_edit_get_state();
 	state["offset"] = offset;
@@ -58,6 +59,11 @@ bool Sprite::_edit_use_pivot() const {
 	return true;
 }
 
+bool Sprite::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+
+	return is_pixel_opaque(p_point);
+}
+
 Rect2 Sprite::_edit_get_rect() const {
 	return get_rect();
 }
@@ -65,6 +71,7 @@ Rect2 Sprite::_edit_get_rect() const {
 bool Sprite::_edit_use_rect() const {
 	return texture.is_valid();
 }
+#endif
 
 Rect2 Sprite::get_anchorable_rect() const {
 	return get_rect();
@@ -303,11 +310,6 @@ void Sprite::set_hframes(int p_amount) {
 int Sprite::get_hframes() const {
 
 	return hframes;
-}
-
-bool Sprite::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
-
-	return is_pixel_opaque(p_point);
 }
 
 bool Sprite::is_pixel_opaque(const Point2 &p_point) const {

--- a/scene/2d/sprite.h
+++ b/scene/2d/sprite.h
@@ -67,6 +67,7 @@ protected:
 	virtual void _validate_property(PropertyInfo &property) const;
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Dictionary _edit_get_state() const;
 	virtual void _edit_set_state(const Dictionary &p_state);
 
@@ -75,10 +76,11 @@ public:
 	virtual bool _edit_use_pivot() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
-	bool is_pixel_opaque(const Point2 &p_point) const;
-
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
+#endif
+
+	bool is_pixel_opaque(const Point2 &p_point) const;
 
 	void set_texture(const Ref<Texture> &p_texture);
 	Ref<Texture> get_texture() const;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1282,6 +1282,7 @@ PoolVector<int> TileMap::_get_tile_data() const {
 	return data;
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 TileMap::_edit_get_rect() const {
 	if (pending_update) {
 		const_cast<TileMap *>(this)->update_dirty_quadrants();
@@ -1290,6 +1291,7 @@ Rect2 TileMap::_edit_get_rect() const {
 	}
 	return rect_cache;
 }
+#endif
 
 void TileMap::set_collision_layer(uint32_t p_layer) {
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -244,7 +244,9 @@ public:
 		INVALID_CELL = -1
 	};
 
+#ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const;
+#endif
 
 	void set_tileset(const Ref<TileSet> &p_tileset);
 	Ref<TileSet> get_tileset() const;

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -135,7 +135,9 @@ void TouchScreenButton::_notification(int p_what) {
 				return;
 			if (shape.is_valid()) {
 				Color draw_col = get_tree()->get_debug_collisions_color();
-				Vector2 pos = shape_centered ? _edit_get_rect().size * 0.5f : Vector2();
+
+				Vector2 size = texture.is_null() ? shape->get_rect().size : texture->get_size();
+				Vector2 pos = shape_centered ? size * 0.5f : Vector2();
 				draw_set_transform_matrix(get_canvas_transform().translated(pos));
 				shape->draw(get_canvas_item(), draw_col);
 			}
@@ -251,9 +253,7 @@ void TouchScreenButton::_input(const Ref<InputEvent> &p_event) {
 }
 
 bool TouchScreenButton::_is_point_inside(const Point2 &p_point) {
-
 	Point2 coord = (get_global_transform_with_canvas()).affine_inverse().xform(p_point);
-	Rect2 item_rect = _edit_get_rect();
 
 	bool touched = false;
 	bool check_rect = true;
@@ -261,7 +261,7 @@ bool TouchScreenButton::_is_point_inside(const Point2 &p_point) {
 	if (shape.is_valid()) {
 
 		check_rect = false;
-		Transform2D xform = shape_centered ? Transform2D().translated(item_rect.size * 0.5f) : Transform2D();
+		Transform2D xform = shape_centered ? Transform2D().translated(shape->get_rect().size * 0.5f) : Transform2D();
 		touched = shape->collide(xform, unit_rect, Transform2D(0, coord + Vector2(0.5, 0.5)));
 	}
 
@@ -277,7 +277,7 @@ bool TouchScreenButton::_is_point_inside(const Point2 &p_point) {
 
 	if (!touched && check_rect) {
 		if (texture.is_valid())
-			touched = item_rect.has_point(coord);
+			touched = Rect2(Size2(), texture->get_size()).has_point(coord);
 	}
 
 	return touched;
@@ -324,6 +324,7 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 	}
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 TouchScreenButton::_edit_get_rect() const {
 	if (texture.is_null())
 		return CanvasItem::_edit_get_rect();
@@ -334,6 +335,7 @@ Rect2 TouchScreenButton::_edit_get_rect() const {
 bool TouchScreenButton::_edit_use_rect() const {
 	return !texture.is_null();
 }
+#endif
 
 Rect2 TouchScreenButton::get_anchorable_rect() const {
 	if (texture.is_null())

--- a/scene/2d/touch_screen_button.h
+++ b/scene/2d/touch_screen_button.h
@@ -74,6 +74,11 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
+	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
+#endif
+
 	void set_texture(const Ref<Texture> &p_texture);
 	Ref<Texture> get_texture() const;
 
@@ -103,8 +108,6 @@ public:
 
 	bool is_pressed() const;
 
-	virtual Rect2 _edit_get_rect() const;
-	virtual bool _edit_use_rect() const;
 	virtual Rect2 get_anchorable_rect() const;
 
 	TouchScreenButton();

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -38,6 +38,16 @@
 #include "scene/main/viewport.h"
 #include "scene/scene_string_names.h"
 
+#ifdef TOOLS_ENABLED
+Rect2 VisibilityNotifier2D::_edit_get_rect() const {
+	return rect;
+}
+
+bool VisibilityNotifier2D::_edit_use_rect() const {
+	return true;
+}
+#endif
+
 void VisibilityNotifier2D::_enter_viewport(Viewport *p_viewport) {
 
 	ERR_FAIL_COND(viewports.has(p_viewport));
@@ -82,15 +92,6 @@ void VisibilityNotifier2D::set_rect(const Rect2 &p_rect) {
 	}
 
 	_change_notify("rect");
-}
-
-Rect2 VisibilityNotifier2D::_edit_get_rect() const {
-
-	return rect;
-}
-
-bool VisibilityNotifier2D::_edit_use_rect() const {
-	return true;
 }
 
 Rect2 VisibilityNotifier2D::get_rect() const {

--- a/scene/2d/visibility_notifier_2d.h
+++ b/scene/2d/visibility_notifier_2d.h
@@ -55,8 +55,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
+#endif
 
 	void set_rect(const Rect2 &p_rect);
 	Rect2 get_rect() const;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -47,6 +47,7 @@
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #endif
 
+#ifdef TOOLS_ENABLED
 Dictionary Control::_edit_get_state() const {
 
 	Dictionary s;
@@ -155,6 +156,11 @@ bool Control::_edit_use_pivot() const {
 	return true;
 }
 
+Size2 Control::_edit_get_minimum_size() const {
+	return get_combined_minimum_size();
+}
+#endif
+
 void Control::set_custom_minimum_size(const Size2 &p_custom) {
 
 	if (p_custom == data.custom_minimum_size)
@@ -191,11 +197,6 @@ Size2 Control::get_combined_minimum_size() const {
 		const_cast<Control *>(this)->_update_minimum_size_cache();
 	}
 	return data.minimum_size_cache;
-}
-
-Size2 Control::_edit_get_minimum_size() const {
-
-	return get_combined_minimum_size();
 }
 
 Transform2D Control::_get_internal_transform() const {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -279,6 +279,7 @@ public:
 	};
 
 	/* EDITOR */
+#ifdef TOOLS_ENABLED
 	virtual Dictionary _edit_get_state() const;
 	virtual void _edit_set_state(const Dictionary &p_state);
 
@@ -301,6 +302,7 @@ public:
 	virtual bool _edit_use_pivot() const;
 
 	virtual Size2 _edit_get_minimum_size() const;
+#endif
 
 	void accept_event();
 


### PR DESCRIPTION
Specifically for nodes extending canvas_item. I should have done that before, but, well...  :)