### PR TITLE
Fix gridmap palette remaining invisible

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -40,11 +40,8 @@
 
 void GridMapEditor::_node_removed(Node *p_node) {
 
-	if (p_node == node) {
+	if (p_node == node)
 		node = NULL;
-		hide();
-		mesh_library_palette->hide();
-	}
 }
 
 void GridMapEditor::_configure() {


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/32925

The bug appeared in commit https://github.com/godotengine/godot/pull/32095 where the palette is now hidden when the node exit the tree but is also never shown again.
Correct me if I am wrong but there is no need to hide them anyway since another editor is displayed then (and there never was any displaying bug related to this before when the method was never called at all)
