### PR TITLE
Fixed UndoRedo "Set property" flood when using ColorPicker

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_properties.h"
 
+#include "core/os/input.h"
 #include "editor/editor_resource_preview.h"
 #include "editor_node.h"
 #include "editor_properties_array_dict.h"
@@ -1856,13 +1857,10 @@ EditorPropertyTransform::EditorPropertyTransform() {
 ////////////// COLOR PICKER //////////////////////
 
 void EditorPropertyColor::_color_changed(const Color &p_color) {
-
-	emit_changed(get_edited_property(), p_color, "", true);
-}
-
-void EditorPropertyColor::_popup_closed() {
-
-	emit_changed(get_edited_property(), picker->get_pick_color(), "", false);
+	if (!Input::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT))
+		emit_changed(get_edited_property(), p_color, "", true);
+	else
+		get_edited_object()->set(get_edited_property(), p_color);
 }
 
 void EditorPropertyColor::_picker_created() {
@@ -1877,7 +1875,6 @@ void EditorPropertyColor::_picker_created() {
 void EditorPropertyColor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_color_changed"), &EditorPropertyColor::_color_changed);
-	ClassDB::bind_method(D_METHOD("_popup_closed"), &EditorPropertyColor::_popup_closed);
 	ClassDB::bind_method(D_METHOD("_picker_created"), &EditorPropertyColor::_picker_created);
 }
 
@@ -1896,7 +1893,6 @@ EditorPropertyColor::EditorPropertyColor() {
 	add_child(picker);
 	picker->set_flat(true);
 	picker->connect("color_changed", this, "_color_changed");
-	picker->connect("popup_closed", this, "_popup_closed");
 	picker->connect("picker_created", this, "_picker_created");
 }
 

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -493,7 +493,6 @@ class EditorPropertyColor : public EditorProperty {
 	GDCLASS(EditorPropertyColor, EditorProperty);
 	ColorPickerButton *picker;
 	void _color_changed(const Color &p_color);
-	void _popup_closed();
 	void _picker_created();
 
 protected:

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -469,13 +469,12 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event) {
 			last_hsv = color;
 			set_pick_color(color);
 			_update_color();
-			if (!deferred_mode_enabled)
-				emit_signal("color_changed", color);
-		} else if (deferred_mode_enabled && !bev->is_pressed() && bev->get_button_index() == BUTTON_LEFT) {
-			emit_signal("color_changed", color);
-			changing_color = false;
-		} else {
-			changing_color = false;
+		} else if (!bev->is_pressed() && bev->get_button_index() == BUTTON_LEFT) {
+			if (changing_color) {
+				changing_color = false;
+				if (!deferred_mode_enabled)
+					emit_signal("color_changed", color);
+			}
 		}
 	}
 
@@ -507,17 +506,17 @@ void ColorPicker::_w_input(const Ref<InputEvent> &p_event) {
 			changing_color = true;
 			float y = CLAMP((float)bev->get_position().y, 0, w_edit->get_size().height);
 			h = y / w_edit->get_size().height;
-		} else {
-			changing_color = false;
+			color.set_hsv(h, s, v, color.a);
+			last_hsv = color;
+			set_pick_color(color);
+			_update_color();
+		} else if (!bev->is_pressed() && bev->get_button_index() == BUTTON_LEFT) {
+			if (changing_color) {
+				changing_color = false;
+				if (!deferred_mode_enabled)
+					emit_signal("color_changed", color);
+			}
 		}
-		color.set_hsv(h, s, v, color.a);
-		last_hsv = color;
-		set_pick_color(color);
-		_update_color();
-		if (!deferred_mode_enabled)
-			emit_signal("color_changed", color);
-		else if (!bev->is_pressed() && bev->get_button_index() == BUTTON_LEFT)
-			emit_signal("color_changed", color);
 	}
 
 	Ref<InputEventMouseMotion> mev = p_event;


### PR DESCRIPTION
That annoying message pollutes the entire Output tab by any slight color change in the color picker even with the LMB pressed. Or when you close the color picker (in this case, it automatically outputs twice).
This can be bad when you are using the message trail to know what you changed in the project while testing color variations on a CanvasItem node.

Before:

![Before](https://user-images.githubusercontent.com/37383316/67246966-5d2aad00-f436-11e9-9c8f-62a167d8b36c.gif)

------------------------------------------------------------------------------------------

After:

![After](https://user-images.githubusercontent.com/37383316/67247404-9d3e5f80-f437-11e9-82db-f49bd45c3c95.gif)

Please let me know if the commit has broken any functionality or raised bugs