### PR TITLE
Fixes spinbox not releasing focus on value change

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -108,21 +108,21 @@ void SpinBox::_gui_input(const Ref<InputEvent> &p_event) {
 
 			case BUTTON_LEFT: {
 
+				line_edit->grab_focus();
+
 				set_value(get_value() + (up ? get_step() : -get_step()));
 
 				range_click_timer->set_wait_time(0.6);
 				range_click_timer->set_one_shot(true);
 				range_click_timer->start();
 
-				line_edit->grab_focus();
-
 				drag.allowed = true;
 				drag.capture_pos = mb->get_position();
 			} break;
 			case BUTTON_RIGHT: {
 
-				set_value((up ? get_max() : get_min()));
 				line_edit->grab_focus();
+				set_value((up ? get_max() : get_min()));
 			} break;
 			case BUTTON_WHEEL_UP: {
 				if (line_edit->has_focus()) {


### PR DESCRIPTION
Trying to release focus of the spinbox's lineedit would not work when done in the "value_changed" callback. The reason is because the "value_change" signal is called first, then the "get_focus" method is called next. This causes the spinbox to get_focus after you try to release focus within the "value_changed" callback.

To resolve this, spinbox should get focus first and then emit "value_changed".

Closes: #31788