### PR TITLE
Show preview of frame_coords in AnimationPlayer

### DIFF
--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -81,6 +81,7 @@ class AnimationTrackEditSpriteFrame : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditSpriteFrame, AnimationTrackEdit);
 
 	ObjectID id;
+	bool is_coords;
 
 public:
 	virtual int get_key_height() const;
@@ -89,6 +90,9 @@ public:
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 
 	void set_node(Object *p_object);
+	void set_as_coords();
+
+	AnimationTrackEditSpriteFrame() { is_coords = false; }
 };
 
 class AnimationTrackEditSubAnim : public AnimationTrackEdit {


### PR DESCRIPTION
Partially addresses https://github.com/godotengine/godot-proposals/issues/151

![image](https://user-images.githubusercontent.com/2223172/67253259-042f3900-f477-11e9-94ce-9b21a63f5c0f.png)
![image](https://user-images.githubusercontent.com/2223172/67253184-bb778000-f476-11e9-862f-86aa552bbed6.png)
![image](https://user-images.githubusercontent.com/2223172/67253190-c3cfbb00-f476-11e9-9ffc-a7edd46c59a2.png)

The idea is to make `frame_coords` on par with `frame`, so there's no reason to rant that you are forced to use the coords. This will also need the auto-advance for coords, but right now only ints are supported for that feature, so I'm postponing it for another PR.