### PR TITLE
Create intermediate segments in ConcavePolygonShape2D.

### DIFF
--- a/scene/resources/concave_polygon_shape_2d.cpp
+++ b/scene/resources/concave_polygon_shape_2d.cpp
@@ -64,13 +64,9 @@ Vector<Vector2> ConcavePolygonShape2D::get_segments() const {
 void ConcavePolygonShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Vector2> s = get_segments();
 	int len = s.size();
-	if (len == 0 || (len % 2) == 1) {
-		return;
-	}
-
 	const Vector2 *r = s.ptr();
-	for (int i = 0; i < len; i += 2) {
-		RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, r[i], r[i + 1], p_color, 2);
+	for (int i = 0; i < len; i++) {
+		RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, r[i], r[(i + 1) % len], p_color, 2);
 	}
 }
 

--- a/servers/physics_2d/godot_shape_2d.cpp
+++ b/servers/physics_2d/godot_shape_2d.cpp
@@ -827,7 +827,6 @@ void GodotConcavePolygonShape2D::set_data(const Variant &p_data) {
 	if (p_data.get_type() == Variant::PACKED_VECTOR2_ARRAY) {
 		Vector<Vector2> p2arr = p_data;
 		int len = p2arr.size();
-		ERR_FAIL_COND(len % 2);
 
 		segments.clear();
 		points.clear();
@@ -842,17 +841,14 @@ void GodotConcavePolygonShape2D::set_data(const Variant &p_data) {
 		const Vector2 *arr = p2arr.ptr();
 
 		HashMap<Point2, int> pointmap;
-		for (int i = 0; i < len; i += 2) {
+		pointmap[arr[0]] = 0;
+
+		for (int i = 0; i < len; i++) {
 			Point2 p1 = arr[i];
-			Point2 p2 = arr[i + 1];
+			Point2 p2 = arr[(i + 1) % len];
 			int idx_p1, idx_p2;
 
-			if (pointmap.has(p1)) {
-				idx_p1 = pointmap[p1];
-			} else {
-				idx_p1 = pointmap.size();
-				pointmap[p1] = idx_p1;
-			}
+			idx_p1 = pointmap[p1];
 
 			if (pointmap.has(p2)) {
 				idx_p2 = pointmap[p2];
@@ -895,11 +891,10 @@ void GodotConcavePolygonShape2D::set_data(const Variant &p_data) {
 Variant GodotConcavePolygonShape2D::get_data() const {
 	Vector<Vector2> rsegments;
 	int len = segments.size();
-	rsegments.resize(len * 2);
+	rsegments.resize(len);
 	Vector2 *w = rsegments.ptrw();
 	for (int i = 0; i < len; i++) {
-		w[(i << 1) + 0] = points[segments[i].points[0]];
-		w[(i << 1) + 1] = points[segments[i].points[1]];
+		w[i] = points[segments[i].points[0]];
 	}
 
 	return rsegments;


### PR DESCRIPTION
Fixes #19353, fixes #29320.

A ConcavePolygonShape2D is expected to be similar to a ConvexPolygonShape2D. The [description for ConcavePolygonShape2D](https://docs.godotengine.org/en/3.1/classes/class_concavepolygonshape2d.html#description) states:
> The main difference between a ConvexPolygonShape2D and a ConcavePolygonShape2D is that a concave polygon assumes it is concave and uses a more complex method of collision detection, and a convex one forces itself to be convex in order to speed up collision detection.

This patch makes them similar by using the points in the PoolVector2Array associated with a ConcavePolygonShape2D to create a contiguous, closed-loop of segments instead of requiring and grouping them into pairs of discontiguous segments, which leaves unexpected holes between the pairs.