### PR TITLE
Fixed crashes when renaming a state in AnimationNodeStateMachineEditor

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2221,9 +2221,11 @@ void Control::_modal_stack_remove() {
 	if (!data.MI)
 		return;
 
-	get_viewport()->_gui_remove_from_modal_stack(data.MI, data.modal_prev_focus_owner);
-
+	List<Control *>::Element *element = data.MI;
 	data.MI = NULL;
+
+	get_viewport()->_gui_remove_from_modal_stack(element, data.modal_prev_focus_owner);
+
 	data.modal_prev_focus_owner = 0;
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2374,7 +2374,6 @@ void Viewport::_gui_remove_from_modal_stack(List<Control *>::Element *MI, Object
 	List<Control *>::Element *next = MI->next();
 
 	gui.modal_stack.erase(MI);
-	MI = NULL;
 
 	if (p_prev_focus_owner) {
 


### PR DESCRIPTION
Recursive calls to `Control::_modal_stack_remove` could cause a crash because of the list element not being invalidated while being erased from the list.

It happens in the state machine case by hiding a line edit control when it loses focus.

Fixes #23808