### PR TITLE
Fix gridmap error spam at startup

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -353,7 +353,9 @@ void GridMapEditor::_set_selection(bool p_active, const Vector3 &p_begin, const 
 	selection.click = p_begin;
 	selection.current = p_end;
 
-	_update_selection_transform();
+	if (is_visible_in_tree()) {
+		_update_selection_transform();
+	}
 
 	options->get_popup()->set_item_disabled(options->get_popup()->get_item_index(MENU_OPTION_SELECTION_CLEAR), !selection.active);
 	options->get_popup()->set_item_disabled(options->get_popup()->get_item_index(MENU_OPTION_SELECTION_CUT), !selection.active);


### PR DESCRIPTION
Fix #32986, it seems to work with this fix. At least

![image](https://user-images.githubusercontent.com/3036176/67301499-261cd000-f4f8-11e9-8e79-f80206001d21.png)

these icons are disabled as described in #32893