### PR TITLE
Auto-increment frame_coords when keying

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -644,7 +644,19 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 			emit_signal("property_keyed", property, use_keying_next());
 
 			if (use_keying_next()) {
-				call_deferred("emit_changed", property, object->get(property).operator int64_t() + 1, "", false);
+				if (property == "frame_coords" && (object->is_class("Sprite") || object->is_class("Sprite3D"))) {
+					Vector2 new_coords = object->get(property);
+					new_coords.x++;
+					if (new_coords.x >= object->get("hframes").operator int64_t()) {
+						new_coords.x = 0;
+						new_coords.y++;
+					}
+
+					call_deferred("emit_changed", property, new_coords, "", false);
+				} else {
+					call_deferred("emit_changed", property, object->get(property).operator int64_t() + 1, "", false);
+				}
+
 				call_deferred("update_property");
 			}
 		}

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -387,6 +387,10 @@ void Sprite::_validate_property(PropertyInfo &property) const {
 		property.hint_string = "0," + itos(vframes * hframes - 1) + ",1";
 		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
+
+	if (property.name == "frame_coords") {
+		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
+	}
 }
 
 void Sprite::_texture_changed() {

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -662,6 +662,10 @@ void Sprite3D::_validate_property(PropertyInfo &property) const {
 		property.hint_string = "0," + itos(vframes * hframes - 1) + ",1";
 		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
+
+	if (property.name == "frame_coords") {
+		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
+	}
 }
 
 void Sprite3D::_bind_methods() {


### PR DESCRIPTION
Follow-up to #32973

This might look like a hack, but I wasn't sure where to put this code. `PROPERTY_USAGE_KEYING_INCREMENTS` is rarely used.

![image](https://i.imgur.com/QSdtFUp.gif)