### PR TITLE
Add a tooltip to Color properties in the editor inspector

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1884,6 +1884,23 @@ void EditorPropertyColor::_bind_methods() {
 void EditorPropertyColor::update_property() {
 
 	picker->set_pick_color(get_edited_object()->get(get_edited_property()));
+	const Color color = picker->get_pick_color();
+
+	// Add a tooltip to display each channel's values without having to click the ColorPickerButton
+	if (picker->is_editing_alpha()) {
+		picker->set_tooltip(vformat(
+				"R: %s\nG: %s\nB: %s\nA: %s",
+				rtos(color.r).pad_decimals(2),
+				rtos(color.g).pad_decimals(2),
+				rtos(color.b).pad_decimals(2),
+				rtos(color.a).pad_decimals(2)));
+	} else {
+		picker->set_tooltip(vformat(
+				"R: %s\nG: %s\nB: %s",
+				rtos(color.r).pad_decimals(2),
+				rtos(color.g).pad_decimals(2),
+				rtos(color.b).pad_decimals(2)));
+	}
 }
 
 void EditorPropertyColor::setup(bool p_show_alpha) {


### PR DESCRIPTION
Inspired by https://github.com/godotengine/godot-proposals/issues/178.

This makes it possible to view a color's raw R/G/B/A values without clicking the ColorPickerButton. The main idea is to make it possible to discern values that are close to 1, but not equal to 1. This can be especially important with the alpha channel.

I'm looking for feedback on this, let me know if there's a better way to display this information (without using too much space).

## Preview

![ColorPickerButton tooltip](https://user-images.githubusercontent.com/180032/67334826-149ced80-f523-11e9-822d-f43b6472a1d9.png)