### PR TITLE
Exposed billboard_keep_scale to Sprite3D

### DIFF
--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -48,6 +48,8 @@
 		</member>
 		<member name="billboard" type="int" setter="set_billboard_mode" getter="get_billboard_mode" enum="SpatialMaterial.BillboardMode" default="0">
 		</member>
+		<member name="billboard_keep_scale" type="bool" setter="set_billboard_keep_scale" getter="is_billboard_keep_scale" default="false">
+		</member>
 		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">
 			If [code]true[/code], texture will be centered.
 		</member>

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -298,6 +298,17 @@ SpatialMaterial::BillboardMode SpriteBase3D::get_billboard_mode() const {
 	return billboard_mode;
 }
 
+void SpriteBase3D::set_billboard_keep_scale(bool p_enable) {
+
+	billboard_keep_scale = p_enable;
+	_queue_update();
+}
+
+bool SpriteBase3D::is_billboard_keep_scale() const {
+
+	return billboard_keep_scale;
+}
+
 void SpriteBase3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_centered", "centered"), &SpriteBase3D::set_centered);
@@ -333,6 +344,9 @@ void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_billboard_mode", "mode"), &SpriteBase3D::set_billboard_mode);
 	ClassDB::bind_method(D_METHOD("get_billboard_mode"), &SpriteBase3D::get_billboard_mode);
 
+	ClassDB::bind_method(D_METHOD("set_billboard_keep_scale", "enabled"), &SpriteBase3D::set_billboard_keep_scale);
+	ClassDB::bind_method(D_METHOD("is_billboard_keep_scale"), &SpriteBase3D::is_billboard_keep_scale);
+
 	ClassDB::bind_method(D_METHOD("get_item_rect"), &SpriteBase3D::get_item_rect);
 	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &SpriteBase3D::generate_triangle_mesh);
 
@@ -349,6 +363,7 @@ void SpriteBase3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis", PROPERTY_HINT_ENUM, "X-Axis,Y-Axis,Z-Axis"), "set_axis", "get_axis");
 	ADD_GROUP("Flags", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "billboard", PROPERTY_HINT_ENUM, "Disabled,Enabled,Y-Billboard"), "set_billboard_mode", "get_billboard_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "billboard_keep_scale"), "set_billboard_keep_scale", "is_billboard_keep_scale");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "transparent"), "set_draw_flag", "get_draw_flag", FLAG_TRANSPARENT);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "shaded"), "set_draw_flag", "get_draw_flag", FLAG_SHADED);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "double_sided"), "set_draw_flag", "get_draw_flag", FLAG_DOUBLE_SIDED);
@@ -378,6 +393,7 @@ SpriteBase3D::SpriteBase3D() {
 
 	alpha_cut = ALPHA_CUT_DISABLED;
 	billboard_mode = SpatialMaterial::BILLBOARD_DISABLED;
+	billboard_keep_scale = false;
 	axis = Vector3::AXIS_Z;
 	pixel_size = 0.01;
 	modulate = Color(1, 1, 1, 1);
@@ -480,7 +496,7 @@ void Sprite3D::_draw() {
 		tangent = Plane(1, 0, 0, 1);
 	}
 
-	RID mat = SpatialMaterial::get_material_rid_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == SpatialMaterial::BILLBOARD_ENABLED, get_billboard_mode() == SpatialMaterial::BILLBOARD_FIXED_Y);
+	RID mat = SpatialMaterial::get_material_rid_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == SpatialMaterial::BILLBOARD_ENABLED, get_billboard_mode() == SpatialMaterial::BILLBOARD_FIXED_Y, is_billboard_keep_scale());
 	VS::get_singleton()->immediate_set_material(immediate, mat);
 
 	VS::get_singleton()->immediate_begin(immediate, VS::PRIMITIVE_TRIANGLE_FAN, texture->get_rid());
@@ -808,7 +824,7 @@ void AnimatedSprite3D::_draw() {
 		tangent = Plane(1, 0, 0, -1);
 	}
 
-	RID mat = SpatialMaterial::get_material_rid_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == SpatialMaterial::BILLBOARD_ENABLED, get_billboard_mode() == SpatialMaterial::BILLBOARD_FIXED_Y);
+	RID mat = SpatialMaterial::get_material_rid_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == SpatialMaterial::BILLBOARD_ENABLED, get_billboard_mode() == SpatialMaterial::BILLBOARD_FIXED_Y, is_billboard_keep_scale());
 
 	VS::get_singleton()->immediate_set_material(immediate, mat);
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -81,6 +81,7 @@ private:
 	bool flags[FLAG_MAX];
 	AlphaCutMode alpha_cut;
 	SpatialMaterial::BillboardMode billboard_mode;
+	bool billboard_keep_scale;
 	bool pending_update;
 	void _im_update();
 
@@ -133,6 +134,8 @@ public:
 	AlphaCutMode get_alpha_cut_mode() const;
 	void set_billboard_mode(SpatialMaterial::BillboardMode p_mode);
 	SpatialMaterial::BillboardMode get_billboard_mode() const;
+	void set_billboard_keep_scale(bool p_enable);
+	bool is_billboard_keep_scale() const;
 
 	virtual Rect2 get_item_rect() const = 0;
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1772,7 +1772,7 @@ SpatialMaterial::TextureChannel SpatialMaterial::get_refraction_texture_channel(
 	return refraction_texture_channel;
 }
 
-RID SpatialMaterial::get_material_rid_for_2d(bool p_shaded, bool p_transparent, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass, bool p_billboard, bool p_billboard_y) {
+RID SpatialMaterial::get_material_rid_for_2d(bool p_shaded, bool p_transparent, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass, bool p_billboard, bool p_billboard_y, bool p_billboard_keep_scale) {
 
 	int version = 0;
 	if (p_shaded)
@@ -1789,6 +1789,8 @@ RID SpatialMaterial::get_material_rid_for_2d(bool p_shaded, bool p_transparent, 
 		version |= 32;
 	if (p_billboard_y)
 		version |= 64;
+	if (p_billboard_keep_scale)
+		version |= 128;
 
 	if (materials_for_2d[version].is_valid()) {
 		return materials_for_2d[version]->get_rid();
@@ -1809,6 +1811,7 @@ RID SpatialMaterial::get_material_rid_for_2d(bool p_shaded, bool p_transparent, 
 	} else if (p_billboard_y) {
 		material->set_billboard_mode(BILLBOARD_FIXED_Y);
 	}
+	material->set_flag(FLAG_BILLBOARD_KEEP_SCALE, p_billboard_keep_scale);
 
 	materials_for_2d[version] = material;
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -437,7 +437,7 @@ private:
 
 	_FORCE_INLINE_ void _validate_feature(const String &text, Feature feature, PropertyInfo &property) const;
 
-	static const int MAX_MATERIALS_FOR_2D = 128;
+	static const int MAX_MATERIALS_FOR_2D = 256;
 
 	static Ref<SpatialMaterial> materials_for_2d[MAX_MATERIALS_FOR_2D]; //used by Sprite3D and other stuff
 
@@ -624,7 +624,7 @@ public:
 	static void finish_shaders();
 	static void flush_changes();
 
-	static RID get_material_rid_for_2d(bool p_shaded, bool p_transparent, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass, bool p_billboard = false, bool p_billboard_y = false);
+	static RID get_material_rid_for_2d(bool p_shaded, bool p_transparent, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass, bool p_billboard = false, bool p_billboard_y = false, bool p_billboard_keep_scale = false);
 
 	RID get_shader_rid() const;
 


### PR DESCRIPTION
I think this is a good change which makes possible to easily resize billboards when needed.

![test](https://user-images.githubusercontent.com/3036176/67375869-eb647780-f58b-11e9-9214-4aa4aba15983.gif)
