### PR TITLE
Initialise VMap and HashMap values to the default when they are created.

### DIFF
--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -210,6 +210,7 @@ private:
 		e->next = hash_table[index];
 		e->hash = hash;
 		e->pair.key = p_key;
+		e->pair.data = TData();
 
 		hash_table[index] = e;
 		elements++;

--- a/core/vmap.h
+++ b/core/vmap.h
@@ -196,8 +196,7 @@ public:
 
 		int pos = _find_exact(p_key);
 		if (pos < 0) {
-			V val;
-			pos = insert(p_key, val);
+			pos = insert(p_key, V());
 		}
 
 		return _cowdata.get_m(pos).value;


### PR DESCRIPTION
Assigns a default value to the VMap non const version of the array operator overload when the key does not exist.

Part part 7 of issue #27638 identified that VMap uses an uninitialized variable. In PR #32887 @RandomShaper suggested making a separate PR to just just address the uninitialised variable in the non const version of the array operator overload of VMap; so that it can be applied to 3.2. This is that PR.