### PR TITLE
Fixed variables with built-in resource in remote inspector

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -597,7 +597,19 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				if (var.is_zero()) {
 					var = RES();
 				} else if (var.get_type() == Variant::STRING) {
-					var = ResourceLoader::load(var);
+					String path = var;
+					if (path.find("::") != -1) {
+						// built-in resource
+						String base_path = path.get_slice("::", 0);
+						if (ResourceLoader::get_resource_type(base_path) == "PackedScene") {
+							if (!EditorNode::get_singleton()->is_scene_open(base_path)) {
+								EditorNode::get_singleton()->load_scene(base_path);
+							}
+						} else {
+							EditorNode::get_singleton()->load_resource(base_path);
+						}
+					}
+					var = ResourceLoader::load(path);
 
 					if (pinfo.hint_string == "Script")
 						debugObj->set_script(var);


### PR DESCRIPTION
Now loading the base resource first in `ScriptEditorDebugger`, the same way it's done in `ScriptEditorPlugin`.

Fixes #33013