### PR TITLE
Fix `inst2dict` calling to getters to retrieve value

### DIFF
--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1127,25 +1127,11 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 					d["@subpath"] = cp;
 					d["@path"] = p->path;
 
-					p = base.ptr();
-
-					while (p) {
-
-						for (Set<StringName>::Element *E = p->members.front(); E; E = E->next()) {
-
-							Variant value;
-							if (ins->get(E->get(), value)) {
-
-								String k = E->get();
-								if (!d.has(k)) {
-									d[k] = value;
-								}
-							}
+					for (Map<StringName, GDScript::MemberInfo>::Element *E = base->member_indices.front(); E; E = E->next()) {
+						if (!d.has(E->key())) {
+							d[E->key()] = ins->members[E->get().index];
 						}
-
-						p = p->_base;
 					}
-
 					r_ret = d;
 				}
 			}


### PR DESCRIPTION
Fixes #33015.

Use `GDScriptInstance` to iterate through all members directly instead. This is similar to how `dict2inst` works currently:

https://github.com/godotengine/godot/blob/628f46760512a5bd4e318a86fa62e7d0cdf0e394/modules/gdscript/gdscript_functions.cpp#L1226-L1230

... so this makes the serialization behaviour more consistent.

Also note that it will also serialize `null` values, see reasoning in https://github.com/godotengine/godot/pull/33018#issuecomment-545603113.