### PR TITLE
Refactor VideoPlayer and VideoStream

### DIFF
--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -279,7 +279,7 @@ void VideoStreamPlaybackGDNative::set_paused(bool p_paused) {
 	paused = p_paused;
 }
 
-Ref<Texture> VideoStreamPlaybackGDNative::get_texture() {
+Ref<Texture> VideoStreamPlaybackGDNative::get_texture() const {
 	return texture;
 }
 

--- a/modules/gdnative/videodecoder/video_stream_gdnative.h
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.h
@@ -168,7 +168,7 @@ public:
 
 	//virtual int mix(int16_t* p_buffer,int p_frames)=0;
 
-	virtual Ref<Texture> get_texture();
+	virtual Ref<Texture> get_texture() const;
 	virtual void update(float p_delta);
 
 	virtual void set_mix_callback(AudioMixCallback p_callback, void *p_userdata);

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -368,7 +368,7 @@ float VideoStreamPlaybackTheora::get_time() const {
 	return time - AudioServer::get_singleton()->get_output_latency() - delay_compensation; //-((get_total())/(float)vi.rate);
 };
 
-Ref<Texture> VideoStreamPlaybackTheora::get_texture() {
+Ref<Texture> VideoStreamPlaybackTheora::get_texture() const {
 
 	return texture;
 }

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -147,7 +147,7 @@ public:
 
 	void set_file(const String &p_file);
 
-	virtual Ref<Texture> get_texture();
+	virtual Ref<Texture> get_texture() const;
 	virtual void update(float p_delta);
 
 	virtual void set_mix_callback(AudioMixCallback p_callback, void *p_userdata);

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -230,7 +230,7 @@ void VideoStreamPlaybackWebm::set_audio_track(int p_idx) {
 	audio_track = p_idx;
 }
 
-Ref<Texture> VideoStreamPlaybackWebm::get_texture() {
+Ref<Texture> VideoStreamPlaybackWebm::get_texture() const {
 
 	return texture;
 }

--- a/modules/webm/video_stream_webm.h
+++ b/modules/webm/video_stream_webm.h
@@ -90,7 +90,7 @@ public:
 
 	virtual void set_audio_track(int p_idx);
 
-	virtual Ref<Texture> get_texture();
+	virtual Ref<Texture> get_texture() const;
 	virtual void update(float p_delta);
 
 	virtual void set_mix_callback(AudioMixCallback p_callback, void *p_userdata);

--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -36,6 +36,10 @@
 
 int VideoPlayer::sp_get_channel_count() const {
 
+	if (playback.is_null()) {
+		return 0;
+	}
+
 	return playback->get_channels();
 }
 
@@ -56,6 +60,9 @@ bool VideoPlayer::mix(AudioFrame *p_buffer, int p_frames) {
 // Called from main thread (eg VideoStreamPlaybackWebm::update)
 int VideoPlayer::_audio_mix_callback(void *p_udata, const float *p_data, int p_frames) {
 
+	ERR_FAIL_NULL_V(p_udata, 0);
+	ERR_FAIL_NULL_V(p_data, 0);
+
 	VideoPlayer *vp = (VideoPlayer *)p_udata;
 
 	int todo = MIN(vp->resampler.get_writer_space(), p_frames);
@@ -69,6 +76,12 @@ int VideoPlayer::_audio_mix_callback(void *p_udata, const float *p_data, int p_f
 	vp->resampler.write(todo);
 
 	return todo;
+}
+
+void VideoPlayer::_mix_audios(void *p_self) {
+
+	ERR_FAIL_NULL(p_self);
+	reinterpret_cast<VideoPlayer *>(p_self)->_mix_audio();
 }
 
 // Called from audio thread
@@ -143,7 +156,7 @@ void VideoPlayer::_notification(int p_notification) {
 
 			bus_index = AudioServer::get_singleton()->thread_find_bus_index(bus);
 
-			if (stream.is_null() || paused || !playback->is_playing())
+			if (stream.is_null() || paused || playback.is_null() || !playback->is_playing())
 				return;
 
 			double audio_time = USEC_TO_SEC(OS::get_singleton()->get_ticks_usec());
@@ -358,7 +371,7 @@ void VideoPlayer::set_stream_position(float p_position) {
 		playback->seek(p_position);
 }
 
-Ref<Texture> VideoPlayer::get_video_texture() {
+Ref<Texture> VideoPlayer::get_video_texture() const {
 
 	if (playback.is_valid())
 		return playback->get_texture();
@@ -394,9 +407,9 @@ StringName VideoPlayer::get_bus() const {
 	return "Master";
 }
 
-void VideoPlayer::_validate_property(PropertyInfo &property) const {
+void VideoPlayer::_validate_property(PropertyInfo &p_property) const {
 
-	if (property.name == "bus") {
+	if (p_property.name == "bus") {
 
 		String options;
 		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
@@ -406,7 +419,7 @@ void VideoPlayer::_validate_property(PropertyInfo &property) const {
 			options += name;
 		}
 
-		property.hint_string = options;
+		p_property.hint_string = options;
 	}
 }
 

--- a/scene/gui/video_player.h
+++ b/scene/gui/video_player.h
@@ -55,7 +55,6 @@ class VideoPlayer : public Control {
 	RID stream_rid;
 
 	Ref<ImageTexture> texture;
-	Ref<Image> last_frame;
 
 	AudioRBResampler resampler;
 	Vector<AudioFrame> mix_buffer;
@@ -75,19 +74,19 @@ class VideoPlayer : public Control {
 
 	void _mix_audio();
 	static int _audio_mix_callback(void *p_udata, const float *p_data, int p_frames);
-	static void _mix_audios(void *self) { reinterpret_cast<VideoPlayer *>(self)->_mix_audio(); }
+	static void _mix_audios(void *p_self);
 
 protected:
 	static void _bind_methods();
 	void _notification(int p_notification);
-	void _validate_property(PropertyInfo &property) const;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	Size2 get_minimum_size() const;
 	void set_expand(bool p_expand);
 	bool has_expand() const;
 
-	Ref<Texture> get_video_texture();
+	Ref<Texture> get_video_texture() const;
 
 	void set_stream(const Ref<VideoStream> &p_stream);
 	Ref<VideoStream> get_stream() const;

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -63,7 +63,7 @@ public:
 
 	//virtual int mix(int16_t* p_buffer,int p_frames)=0;
 
-	virtual Ref<Texture> get_texture() = 0;
+	virtual Ref<Texture> get_texture() const = 0;
 	virtual void update(float p_delta) = 0;
 
 	virtual void set_mix_callback(AudioMixCallback p_callback, void *p_userdata) = 0;


### PR DESCRIPTION
VideoStream:
- Fix const correctenss

VideoPlayer:
- Remove unused member variable last_frame
- Move _mix_audios function definition to source file
- Fix function parameter naming to match p_ convention
- Fix const correctness
- Add null checking

Fix #32987