### PR TITLE
Display error messages in console when vformat is called

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -3299,7 +3299,7 @@ String vformat(const String &p_text, const Variant &p1, const Variant &p2, const
 	bool error = false;
 	String fmt = p_text.sprintf(args, &error);
 
-	ERR_FAIL_COND_V(error, String());
+	ERR_FAIL_COND_V_MSG(error, String(), fmt);
 
 	return fmt;
 }


### PR DESCRIPTION
Contributes to #31849.

The text returned by `sprintf` is the error text (in case of error!), so use that to display the actual error.

I found this useful for C++ debugging purposes alone, the editor does show these messages currently, but to note: they are not constructed as `Sentence case.`. In GDScript these are made of several parts:

https://github.com/godotengine/godot/blob/79dae3a87e1c8a66897fc1816059f39c8f25cde4/modules/gdscript/gdscript_function.cpp#L468-L474