### PR TITLE
Scroll back to the top after opening a directory in FileDialog

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -703,6 +703,9 @@ void EditorFileDialog::update_file_list() {
 
 	item_list->clear();
 
+	// Scroll back to the top after opening a directory
+	item_list->get_v_scroll()->set_value(0);
+
 	if (display_mode == DISPLAY_THUMBNAILS) {
 
 		item_list->set_max_columns(0);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -413,6 +413,10 @@ void FileDialog::update_file_name() {
 void FileDialog::update_file_list() {
 
 	tree->clear();
+
+	// Scroll back to the top after opening a directory
+	tree->get_vscroll_bar()->set_value(0);
+
 	dir_access->list_dir_begin();
 
 	TreeItem *root = tree->create_item();


### PR DESCRIPTION
This also changes the behavior in EditorFileDialog.

This closes #26041.