### PR TITLE
Fix leak in Physics2DServerSW

### DIFF
--- a/servers/physics_2d/physics_2d_server_wrap_mt.cpp
+++ b/servers/physics_2d/physics_2d_server_wrap_mt.cpp
@@ -139,6 +139,7 @@ void Physics2DServerWrapMT::finish() {
 	segment_shape_free_cached_ids();
 	circle_shape_free_cached_ids();
 	rectangle_shape_free_cached_ids();
+	capsule_shape_free_cached_ids();
 	convex_polygon_shape_free_cached_ids();
 	concave_polygon_shape_free_cached_ids();
 


### PR DESCRIPTION
Leak info
```
    #0 0x7f10563a4ae8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dae8)
    #1 0xeb93101 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:85
    #2 0xeb93000 in operator new(unsigned long, char const*) core/os/memory.cpp:42
    #3 0xd2a873c in Physics2DServerSW::_shape_create(Physics2DServer::ShapeType) servers/physics_2d/physics_2d_server_sw.cpp:69
    #4 0xd2a92d3 in Physics2DServerSW::capsule_shape_create() servers/physics_2d/physics_2d_server_sw.cpp:115
    #5 0xd3198c0 in Physics2DServerWrapMT::capsule_shapeallocn() servers/physics_2d/physics_2d_server_wrap_mt.h:85
    #6 0xd40ffde in CommandQueueMT::CommandRet0<Physics2DServerWrapMT, int (Physics2DServerWrapMT::*)(), int>::call() core/command_queue_mt.h:304
    #7 0xd30c64a in CommandQueueMT::flush_one(bool) core/command_queue_mt.h:426
    #8 0xd30cffc in CommandQueueMT::flush_all() core/command_queue_mt.h:466
    #9 0xd304388 in Physics2DServerWrapMT::step(float) servers/physics_2d/physics_2d_server_wrap_mt.cpp:80
    #10 0x15a0078 in Main::iteration() main/main.cpp:1963
    #11 0x149d78c in OS_X11::run() platform/x11/os_x11.cpp:3192
    #12 0x141a337 in main platform/x11/godot_x11.cpp:56
    #13 0x7f1054e801e2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x271e2)
```