### PR TITLE
Don't terminate search if begin_key doesn't fit (Fixes #33034)

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -161,57 +161,58 @@ void TextEdit::Text::_update_line_cache(int p_line) const {
 			/* BEGIN */
 
 			int lr = cr.begin_key.length();
-			if (lr == 0 || lr > left)
-				continue;
+			const CharType *kc;
+			bool match;
 
-			const CharType *kc = cr.begin_key.c_str();
+			if (lr != 0 && lr <= left) {
+				kc = cr.begin_key.c_str();
 
-			bool match = true;
+				match = true;
 
-			for (int k = 0; k < lr; k++) {
-				if (kc[k] != str[i + k]) {
-					match = false;
+				for (int k = 0; k < lr; k++) {
+					if (kc[k] != str[i + k]) {
+						match = false;
+						break;
+					}
+				}
+
+				if (match) {
+
+					ColorRegionInfo cri;
+					cri.end = false;
+					cri.region = j;
+					text.write[p_line].region_info[i] = cri;
+					i += lr - 1;
+
 					break;
 				}
-			}
-
-			if (match) {
-
-				ColorRegionInfo cri;
-				cri.end = false;
-				cri.region = j;
-				text.write[p_line].region_info[i] = cri;
-				i += lr - 1;
-
-				break;
 			}
 
 			/* END */
 
 			lr = cr.end_key.length();
-			if (lr == 0 || lr > left)
-				continue;
+			if (lr != 0 && lr <= left) {
+				kc = cr.end_key.c_str();
 
-			kc = cr.end_key.c_str();
+				match = true;
 
-			match = true;
+				for (int k = 0; k < lr; k++) {
+					if (kc[k] != str[i + k]) {
+						match = false;
+						break;
+					}
+				}
 
-			for (int k = 0; k < lr; k++) {
-				if (kc[k] != str[i + k]) {
-					match = false;
+				if (match) {
+
+					ColorRegionInfo cri;
+					cri.end = true;
+					cri.region = j;
+					text.write[p_line].region_info[i] = cri;
+					i += lr - 1;
+
 					break;
 				}
-			}
-
-			if (match) {
-
-				ColorRegionInfo cri;
-				cri.end = true;
-				cri.region = j;
-				text.write[p_line].region_info[i] = cri;
-				i += lr - 1;
-
-				break;
 			}
 		}
 	}


### PR DESCRIPTION
Previously this code would continue onto the next iteration of the loop if the line was smaller in size than begin_key, meaning that a situation where begin_key.length() > end_key.length() would cause weird behavior with newlines. Now both the checks for begin_key and end_key are in their own condition and do not skip the entire iteration if they can't be found.

Fixes #33034