### PR TITLE
Improved search in settings dialogs

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1595,7 +1595,7 @@ void EditorInspector::update_tree() {
 			if (capitalize_paths)
 				cat = cat.capitalize();
 
-			if (!filter.is_subsequence_ofi(cat) && !filter.is_subsequence_ofi(name))
+			if (!filter.is_subsequence_ofi(cat) && !filter.is_subsequence_ofi(name) && property_prefix.to_lower().find(filter.to_lower()) == -1)
 				continue;
 		}
 

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -245,15 +245,15 @@ void SectionedInspector::update_category_list() {
 		if (pi.name.find(":") != -1 || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script"))
 			continue;
 
+		if (!filter.empty() && !filter.is_subsequence_ofi(pi.name) && !filter.is_subsequence_ofi(pi.name.replace("/", " ").capitalize()))
+			continue;
+
 		int sp = pi.name.find("/");
 		if (sp == -1)
 			pi.name = "global/" + pi.name;
 
 		Vector<String> sectionarr = pi.name.split("/");
 		String metasection;
-
-		if (!filter.empty() && !filter.is_subsequence_ofi(sectionarr[sectionarr.size() - 1].capitalize()))
-			continue;
 
 		int sc = MIN(2, sectionarr.size() - 1);
 


### PR DESCRIPTION
Settings search used to work only on properties, so if a searchbox text
was a substring of a category but not of a property the whole category
would be filtered out and no property would be shown.

Now the behaviour is changed so that when the searchbox text is a
substring of a category all its properties are shown too.

The previous behaviour is still present so that in case the searchbox
text is both a substring of a category and a property of another
category, all properties of the first category are shown and only the
property of the second category is shown.

Fixes #33005

![settings-search](https://user-images.githubusercontent.com/3314350/67521388-4be1da80-f69a-11e9-864e-c66f260a53b2.gif)

