### PR TITLE
Make stylebox preview not to expand Inspector panel

### DIFF
--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -64,21 +64,24 @@ void StyleBoxPreview::edit(const Ref<StyleBox> &p_stylebox) {
 void StyleBoxPreview::_sb_changed() {
 
 	preview->update();
+}
+
+void StyleBoxPreview::_redraw() {
 	if (stylebox.is_valid()) {
-		Size2 ms = stylebox->get_minimum_size() * 4 / 3;
-		ms.height = MAX(ms.height, 150 * EDSCALE);
-		preview->set_custom_minimum_size(ms);
+		preview->draw_style_box(stylebox, preview->get_rect());
 	}
 }
 
 void StyleBoxPreview::_bind_methods() {
 
 	ClassDB::bind_method("_sb_changed", &StyleBoxPreview::_sb_changed);
+	ClassDB::bind_method("_redraw", &StyleBoxPreview::_redraw);
 }
 
 StyleBoxPreview::StyleBoxPreview() {
-
-	preview = memnew(Panel);
+	preview = memnew(Control);
+	preview->set_custom_minimum_size(Size2(0, 150 * EDSCALE));
+	preview->connect("draw", this, "_redraw");
 	add_margin_child(TTR("Preview:"), preview);
 }
 

--- a/editor/plugins/style_box_editor_plugin.h
+++ b/editor/plugins/style_box_editor_plugin.h
@@ -41,10 +41,11 @@ class StyleBoxPreview : public VBoxContainer {
 
 	GDCLASS(StyleBoxPreview, VBoxContainer);
 
-	Panel *preview;
+	Control *preview;
 	Ref<StyleBox> stylebox;
 
 	void _sb_changed();
+	void _redraw();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Fix #30639

![Screenshot from 2019-10-25 06-23-05](https://user-images.githubusercontent.com/8281454/67526778-73fc2880-f6f0-11e9-91a4-ff56c09a6e36.png)
