### PR TITLE
Fix analog input in sliders

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -49,11 +49,11 @@ bool InputEvent::is_action(const StringName &p_action) const {
 	return InputMap::get_singleton()->event_is_action(Ref<InputEvent>((InputEvent *)this), p_action);
 }
 
-bool InputEvent::is_action_pressed(const StringName &p_action) const {
+bool InputEvent::is_action_pressed(const StringName &p_action, bool p_allow_echo) const {
 
 	bool pressed;
 	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed);
-	return valid && pressed && !is_echo();
+	return valid && pressed && (p_allow_echo || !is_echo());
 }
 
 bool InputEvent::is_action_released(const StringName &p_action) const {
@@ -112,7 +112,7 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_device"), &InputEvent::get_device);
 
 	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action);
-	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed);
+	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("is_action_released", "action"), &InputEvent::is_action_released);
 	ClassDB::bind_method(D_METHOD("get_action_strength", "action"), &InputEvent::get_action_strength);
 

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -184,7 +184,7 @@ public:
 	int get_device() const;
 
 	bool is_action(const StringName &p_action) const;
-	bool is_action_pressed(const StringName &p_action) const;
+	bool is_action_pressed(const StringName &p_action, bool p_allow_echo = false) const;
 	bool is_action_released(const StringName &p_action) const;
 	float get_action_strength(const StringName &p_action) const;
 

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -101,26 +101,26 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 
 	if (!mm.is_valid() && !mb.is_valid()) {
 
-		if (p_event->is_action("ui_left") && p_event->is_pressed()) {
+		if (p_event->is_action_pressed("ui_left", true)) {
 
 			if (orientation != HORIZONTAL)
 				return;
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
-		} else if (p_event->is_action("ui_right") && p_event->is_pressed()) {
+		} else if (p_event->is_action_pressed("ui_right", true)) {
 
 			if (orientation != HORIZONTAL)
 				return;
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
-		} else if (p_event->is_action("ui_up") && p_event->is_pressed()) {
+		} else if (p_event->is_action_pressed("ui_up", true)) {
 
 			if (orientation != VERTICAL)
 				return;
 
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
-		} else if (p_event->is_action("ui_down") && p_event->is_pressed()) {
+		} else if (p_event->is_action_pressed("ui_down", true)) {
 
 			if (orientation != VERTICAL)
 				return;


### PR DESCRIPTION
Fixes #30402

The problem was that `is_action` returns true for both `ui_left` and `ui_right` on horizontal axis input (and analogously with vertical). Not sure if this is intended, so my fix just works around that.