### PR TITLE
Fix missing `z_verbose` and `z_error` symbols in the debug iOS build.

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -80,6 +80,8 @@ if env['builtin_zlib']:
 	env_thirdparty.Prepend(CPPPATH=[thirdparty_zlib_dir])
 	# Needs to be available in main env too
 	env.Prepend(CPPPATH=[thirdparty_zlib_dir])
+	if (env['target'] == 'debug'):
+		env_thirdparty.Append(CPPDEFINES=['ZLIB_DEBUG'])
 
 	env_thirdparty.add_source_files(env.core_sources, thirdparty_zlib_sources)
 

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -66,7 +66,7 @@ if env['builtin_freetype']:
     env.Prepend(CPPPATH=[thirdparty_dir + "/include"])
 
     env_freetype.Append(CPPDEFINES=['FT2_BUILD_LIBRARY', 'FT_CONFIG_OPTION_USE_PNG'])
-    if (env['target'] != 'release'):
+    if (env['target'] == 'debug'):
         env_freetype.Append(CPPDEFINES=['ZLIB_DEBUG'])
 
     # Also requires libpng headers


### PR DESCRIPTION
Fixes #24287, which was reintroduced by the subsequent `freetype` update in #27554.