### PR TITLE
Call CRASH_COND_MSG if key not found in HashMap get(key) functions.

### DIFF
--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -280,13 +280,13 @@ public:
 
 	const TData &get(const TKey &p_key) const {
 		const TData *res = getptr(p_key);
-		ERR_FAIL_COND_V(!res, *res);
+		CRASH_COND_MSG(!res, "Map key not found.");
 		return *res;
 	}
 
 	TData &get(const TKey &p_key) {
 		TData *res = getptr(p_key);
-		ERR_FAIL_COND_V(!res, *res);
+		CRASH_COND_MSG(!res, "Map key not found.");
 		return *res;
 	}
 


### PR DESCRIPTION
`HashMap` is currently calling `ERR_FAIL_COND_V(!res, *res)` when calling `get(TKey)` and `TKey` isn't found in the `HashMap` table. This would result in a dereferenced null pointer being returned to the caller, which is what (I assume) the `ERR_FAIL_COND` was trying to prevent. If the key is not found in the `HashMap` then there is no safe `TData` to return. A `CRASH_COND_MSG` at least enables a message to be generated before crashing.