### PR TITLE
Display a message if no results are found in the asset library

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1137,8 +1137,11 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 			initial_loading = false;
 
-			// The loading text only needs to be displayed before the first page is loaded
+			// The loading text only needs to be displayed before the first page is loaded.
+			// Therefore, we don't need to show it again.
 			library_loading->hide();
+
+			library_error->hide();
 
 			if (asset_items) {
 				memdelete(asset_items);
@@ -1186,6 +1189,11 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 			asset_bottom_page = _make_pages(page, pages, page_len, total_items, result.size());
 			library_vb->add_child(asset_bottom_page);
+
+			if (result.empty()) {
+				library_error->set_text(vformat(TTR("No results for \"%s\"."), filter->get_text()));
+				library_error->show();
+			}
 
 			for (int i = 0; i < result.size(); i++) {
 
@@ -1452,6 +1460,11 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	library_loading = memnew(Label(TTR("Loading...")));
 	library_loading->set_align(Label::ALIGN_CENTER);
 	library_vb->add_child(library_loading);
+
+	library_error = memnew(Label);
+	library_error->set_align(Label::ALIGN_CENTER);
+	library_error->hide();
+	library_vb->add_child(library_error);
 
 	asset_top_page = memnew(HBoxContainer);
 	library_vb->add_child(asset_top_page);

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -184,6 +184,7 @@ class EditorAssetLibrary : public PanelContainer {
 	ScrollContainer *library_scroll;
 	VBoxContainer *library_vb;
 	Label *library_loading;
+	Label *library_error;
 	LineEdit *filter;
 	OptionButton *categories;
 	OptionButton *repository;


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-proposals/issues/184.

## Preview

!["No results found" message](https://user-images.githubusercontent.com/180032/67609447-12d66280-f78d-11e9-99e0-cecf4fa69c46.png)