### PR TITLE
Fixed #21527 (Show hint to right click when curve editor is empty)

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -736,6 +736,9 @@ void CurveEditor::_draw() {
 	if (_selected_point > 0 && _selected_point + 1 < curve.get_point_count()) {
 		text_color.a *= 0.4;
 		draw_string(font, Vector2(50, font_height), TTR("Hold Shift to edit tangents individually"), text_color);
+	} else if (curve.get_point_count() == 0) {
+		text_color.a *= 0.4;
+		draw_string(font, Vector2(50, font_height), TTR("Right click to add point"), text_color);
 	}
 }
 


### PR DESCRIPTION
Fixed #21527

When the curve editor is empty a "Right click to add point" hint is showed to inprove the ux and make it more clear what to do.

This is my first pull request/commit so let me know if it's all correct!