### PR TITLE
Travis: Force installing OpenJDK8 for Android SDK compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,10 @@ matrix:
       env: PLATFORM=android TOOLS=no TARGET=release_debug CACHE_NAME=${PLATFORM}-clang EXTRA_ARGS="warnings=extra werror=yes"
       os: linux
       compiler: clang
+      addons:
+        apt:
+          packages:
+            - openjdk-8-jdk
 
     - name: macOS editor (debug, Clang)
       stage: build
@@ -116,13 +120,13 @@ before_install:
 install:
   - pip install --user scons;
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PLATFORM" = "android" ]; then
+      export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64;
+      export PATH=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin:${PATH};
+      java -version;
       misc/travis/android-tools-linux.sh;
     fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       export PATH=${PATH}:/Users/travis/Library/Python/2.7/bin;
-    fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$PLATFORM" = "android" ]; then
-      misc/travis/android-tools-osx.sh;
     fi
 
 before_script:

--- a/misc/travis/android-tools-linux.sh
+++ b/misc/travis/android-tools-linux.sh
@@ -70,9 +70,10 @@ if [ ! -d $ANDROID_NDK_DIR ]; then
   echo
 fi
 
-echo "Installing: Android Tools ..."
 mkdir -p ~/.android && echo "count=0" > ~/.android/repositories.cfg
+echo "Installing: Accepting Licenses ..."
 yes | $ANDROID_SDK_DIR/tools/bin/sdkmanager --licenses > /dev/null
+echo "Installing: Android Build and Platform Tools ..."
 yes | $ANDROID_SDK_DIR/tools/bin/sdkmanager 'tools' > /dev/null
 yes | $ANDROID_SDK_DIR/tools/bin/sdkmanager 'platform-tools' > /dev/null
 yes | $ANDROID_SDK_DIR/tools/bin/sdkmanager 'build-tools;28.0.3' > /dev/null


### PR DESCRIPTION
Travis CI upgraded their Xenial VMs to default to openjdk11, which
is not working properly for sdkmanager, so we can no longer accept
licenses for the SDK.

They don't really seem to care about providing a good alternative
for us from the few threads I read, so let's just force openjdk8
back.

---

Somehow we weren't affected by the issue yet, probably because our SDK setup is cached, but it started failing in #26221 which adds some additional gradle dependencies. This PR should fix CI for #26221 (at least it does in my local tests).

@hpvb I *can't wait* to get rid of Travis and move to our own CI builders... Took me 2 hours of trial and error to come to this solution, the Travis documentation is outdated and all solutions to switch JDK are only for `language: java` builds (which break for us as we need a C++ compile, not just Java).