### PR TITLE
Improved project creation UX

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -253,6 +253,12 @@ void EditorFileDialog::_post_popup() {
 	else
 		item_list->grab_focus();
 
+	if (mode == MODE_OPEN_DIR) {
+		file_box->set_visible(false);
+	} else {
+		file_box->set_visible(true);
+	}
+
 	if (is_visible_in_tree() && get_current_file() != "")
 		_request_single_thumbnail(get_current_dir().plus_file(get_current_file()));
 
@@ -1658,19 +1664,19 @@ EditorFileDialog::EditorFileDialog() {
 	prev_cc->add_child(preview);
 	preview_vb->hide();
 
-	HBoxContainer *filename_hbc = memnew(HBoxContainer);
-	filename_hbc->add_child(memnew(Label(TTR("File:"))));
+	file_box = memnew(HBoxContainer);
+	file_box->add_child(memnew(Label(TTR("File:"))));
 	file = memnew(LineEdit);
 	file->set_stretch_ratio(4);
 	file->set_h_size_flags(SIZE_EXPAND_FILL);
-	filename_hbc->add_child(file);
+	file_box->add_child(file);
 	filter = memnew(OptionButton);
 	filter->set_stretch_ratio(3);
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->set_clip_text(true); // Too many extensions overflow it.
-	filename_hbc->add_child(filter);
-	filename_hbc->set_h_size_flags(SIZE_EXPAND_FILL);
-	item_vb->add_child(filename_hbc);
+	file_box->add_child(filter);
+	file_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	item_vb->add_child(file_box);
 
 	dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	access = ACCESS_RESOURCES;

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -106,10 +106,11 @@ private:
 	TextureRect *preview;
 	VBoxContainer *preview_vb;
 	HSplitContainer *list_hb;
+	HBoxContainer *file_box;
 	LineEdit *file;
+	OptionButton *filter;
 	AcceptDialog *mkdirerr;
 	AcceptDialog *exterr;
-	OptionButton *filter;
 	DirAccess *dir_access;
 	ConfirmationDialog *confirm_save;
 	DependencyRemoveDialog *remove_dialog;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -178,8 +178,12 @@ void FileDialog::_post_popup() {
 	set_process_unhandled_input(true);
 
 	// For open dir mode, deselect all items on file dialog open.
-	if (mode == MODE_OPEN_DIR)
+	if (mode == MODE_OPEN_DIR) {
 		deselect_items();
+		file_box->set_visible(false);
+	} else {
+		file_box->set_visible(true);
+	}
 }
 
 void FileDialog::_action_pressed() {
@@ -894,6 +898,10 @@ FileDialog::FileDialog() {
 	hbc->add_child(dir_up);
 	dir_up->connect("pressed", this, "_go_up");
 
+	drives = memnew(OptionButton);
+	hbc->add_child(drives);
+	drives->connect("item_selected", this, "_select_drive");
+
 	hbc->add_child(memnew(Label(RTR("Path:"))));
 	dir = memnew(LineEdit);
 	hbc->add_child(dir);
@@ -911,10 +919,6 @@ FileDialog::FileDialog() {
 	show_hidden->connect("toggled", this, "set_show_hidden_files");
 	hbc->add_child(show_hidden);
 
-	drives = memnew(OptionButton);
-	hbc->add_child(drives);
-	drives->connect("item_selected", this, "_select_drive");
-
 	makedir = memnew(Button);
 	makedir->set_text(RTR("Create Folder"));
 	makedir->connect("pressed", this, "_make_dir");
@@ -925,18 +929,18 @@ FileDialog::FileDialog() {
 	tree->set_hide_root(true);
 	vbc->add_margin_child(RTR("Directories & Files:"), tree, true);
 
-	hbc = memnew(HBoxContainer);
-	hbc->add_child(memnew(Label(RTR("File:"))));
+	file_box = memnew(HBoxContainer);
+	file_box->add_child(memnew(Label(RTR("File:"))));
 	file = memnew(LineEdit);
 	file->set_stretch_ratio(4);
 	file->set_h_size_flags(SIZE_EXPAND_FILL);
-	hbc->add_child(file);
+	file_box->add_child(file);
 	filter = memnew(OptionButton);
 	filter->set_stretch_ratio(3);
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->set_clip_text(true); // too many extensions overflows it
-	hbc->add_child(filter);
-	vbc->add_child(hbc);
+	file_box->add_child(filter);
+	vbc->add_child(file_box);
 
 	dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	access = ACCESS_RESOURCES;

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -78,10 +78,11 @@ private:
 	LineEdit *dir;
 	OptionButton *drives;
 	Tree *tree;
+	HBoxContainer *file_box;
 	LineEdit *file;
+	OptionButton *filter;
 	AcceptDialog *mkdirerr;
 	AcceptDialog *exterr;
-	OptionButton *filter;
 	DirAccess *dir_access;
 	ConfirmationDialog *confirm_save;
 


### PR DESCRIPTION
Fixed #10567 
UX to project creation:
- Moved drive select to left side as it's more logical that way
- Hidden file field when selecting directories (it was previously unused)