### PR TITLE
Fix shadow mapping with RGBA textures on html

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -131,7 +131,7 @@ void RasterizerSceneGLES2::shadow_atlas_set_size(RID p_atlas, int p_size) {
 
 			//maximum compatibility, renderbuffer and RGBA shadow
 			glGenRenderbuffers(1, &shadow_atlas->depth);
-			glBindRenderbuffer(GL_RENDERBUFFER, directional_shadow.depth);
+			glBindRenderbuffer(GL_RENDERBUFFER, shadow_atlas->depth);
 			glRenderbufferStorage(GL_RENDERBUFFER, storage->config.depth_internalformat, shadow_atlas->size, shadow_atlas->size);
 			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, shadow_atlas->depth);
 
@@ -3769,6 +3769,10 @@ void RasterizerSceneGLES2::render_shadow(RID p_light, RID p_shadow_atlas, int p_
 	glEnable(GL_SCISSOR_TEST);
 	glClearDepth(1.0f);
 	glClear(GL_DEPTH_BUFFER_BIT);
+	if (storage->config.use_rgba_3d_shadows) {
+		glClearColor(1.0, 1.0, 1.0, 1.0);
+		glClear(GL_COLOR_BUFFER_BIT);
+	}
 	glDisable(GL_SCISSOR_TEST);
 
 	if (light->reverse_cull) {

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5771,7 +5771,7 @@ void RasterizerStorageGLES2::initialize() {
 	config.support_depth_cubemaps = true;
 #else
 	config.use_rgba_2d_shadows = !(config.float_texture_supported && config.extensions.has("GL_EXT_texture_rg"));
-	config.support_depth_texture = config.extensions.has("GL_OES_depth_texture");
+	config.support_depth_texture = config.extensions.has("GL_OES_depth_texture") || config.extensions.has("WEBGL_depth_texture");
 	config.use_rgba_3d_shadows = !config.support_depth_texture;
 	config.support_depth_cubemaps = config.extensions.has("GL_OES_depth_texture_cube_map");
 #endif


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/28444

@Toshiwoz This doesn't address the GLES3 issue you were facing in that thread. If you can still reproduce that issue with orthogonal directional lights, please open another issue. 

This fix has two pieces. 

1) On WebGL [91%](https://webglstats.com/webgl/extension/WEBGL_depth_texture) of devices support depth textures with an extension. However, we were only polling for the GL ES 2.0 extension so it was never used on Web export. Accordingly HTML fell back on RGBA shadows. For most devices it was enough to just enable the extension. 

2) RGBA shadows were completely broken in 3D in GLES2. The color buffer was never cleared. Additionally, all lights were using the directional light shadow atlas to store shadow maps, which likely lead to some pretty odd results. We never caught this earlier because all desktop and the overwhelming majority of mobile devices supported and used depth textures. 

Code graciously donated by Gamblify. :)

CC: @jesperkondrup