### PR TITLE
Expose SyntaxHighlighter to scripts

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1371,9 +1371,9 @@ Variant CodeTextEditor::get_edit_state() {
 	state["bookmarks"] = text_editor->get_bookmarks_array();
 
 	state["syntax_highlighter"] = TTR("Standard");
-	SyntaxHighlighter *syntax_highlighter = text_editor->_get_syntax_highlighting();
-	if (syntax_highlighter) {
-		state["syntax_highlighter"] = syntax_highlighter->get_name();
+	Ref<SyntaxHighlighter> syntax_highlighter = text_editor->get_syntax_highlighter();
+	if (syntax_highlighter.is_valid()) {
+		state["syntax_highlighter"] = syntax_highlighter->call("get_name");
 	}
 
 	return state;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2141,7 +2141,7 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 			se->add_syntax_highlighter(highlighter);
 
 			if (script != NULL && !highlighter_set) {
-				List<String> languages = highlighter->get_supported_languages();
+				Array languages = highlighter->call("_get_supported_languages");
 				if (languages.find(script->get_language()->get_name())) {
 					se->set_syntax_highlighter(highlighter);
 					highlighter_set = true;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -83,8 +83,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter) = 0;
-	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter) = 0;
+	virtual void add_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter) = 0;
+	virtual void set_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter) = 0;
 
 	virtual void apply_code() = 0;
 	virtual RES get_edited_resource() const = 0;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1368,22 +1368,22 @@ void ScriptTextEditor::_edit_option_toggle_inline_comment() {
 	code_editor->toggle_inline_comment(delimiter);
 }
 
-void ScriptTextEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
-	highlighters[p_highlighter->get_name()] = p_highlighter;
-	highlighter_menu->add_radio_check_item(p_highlighter->get_name());
+void ScriptTextEditor::add_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter) {
+	highlighters[p_highlighter->call("get_name")] = p_highlighter;
+	highlighter_menu->add_radio_check_item(p_highlighter->call("get_name"));
 }
 
-void ScriptTextEditor::set_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
+void ScriptTextEditor::set_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter) {
 	TextEdit *te = code_editor->get_text_edit();
-	te->_set_syntax_highlighting(p_highlighter);
+	te->set_syntax_highlighter(p_highlighter);
 	if (p_highlighter != NULL)
-		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text(p_highlighter->get_name()), true);
+		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text(p_highlighter->call("get_name")), true);
 	else
 		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text(TTR("Standard")), true);
 }
 
 void ScriptTextEditor::_change_syntax_highlighter(int p_idx) {
-	Map<String, SyntaxHighlighter *>::Element *el = highlighters.front();
+	Map<String, Ref<SyntaxHighlighter>>::Element *el = highlighters.front();
 	while (el != NULL) {
 		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text(el->key()), false);
 		el = el->next();
@@ -1832,7 +1832,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/capitalize", TTR("Capitalize"), KEY_MASK_SHIFT | KEY_F6), EDIT_CAPITALIZE);
 	convert_case->connect("id_pressed", this, "_edit_option");
 
-	highlighters[TTR("Standard")] = NULL;
+	highlighters[TTR("Standard")] = Ref<SyntaxHighlighter>(NULL);
 	highlighter_menu = memnew(PopupMenu);
 	highlighter_menu->set_name("highlighter_menu");
 	edit_menu->get_popup()->add_child(highlighter_menu);
@@ -1897,11 +1897,6 @@ ScriptTextEditor::ScriptTextEditor() {
 }
 
 ScriptTextEditor::~ScriptTextEditor() {
-	for (const Map<String, SyntaxHighlighter *>::Element *E = highlighters.front(); E; E = E->next()) {
-		if (E->get() != NULL) {
-			memdelete(E->get());
-		}
-	}
 	highlighters.clear();
 }
 

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -165,7 +165,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	Map<String, SyntaxHighlighter *> highlighters;
+	Map<String, Ref<SyntaxHighlighter>> highlighters;
 	void _change_syntax_highlighter(int p_idx);
 
 	void _edit_option(int p_op);
@@ -188,8 +188,8 @@ protected:
 public:
 	void _update_connected_methods();
 
-	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
-	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);
+	virtual void add_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter);
+	virtual void set_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter);
 
 	virtual void apply_code();
 	virtual RES get_edited_resource() const;

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -33,16 +33,16 @@
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
 
-void TextEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
-	highlighters[p_highlighter->get_name()] = p_highlighter;
-	highlighter_menu->add_radio_check_item(p_highlighter->get_name());
+void TextEditor::add_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter) {
+	highlighters[p_highlighter->call("get_name")] = p_highlighter;
+	highlighter_menu->add_radio_check_item(p_highlighter->call("get_name"));
 }
 
-void TextEditor::set_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
+void TextEditor::set_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter) {
 	TextEdit *te = code_editor->get_text_edit();
-	te->_set_syntax_highlighting(p_highlighter);
+	te->set_syntax_highlighter(p_highlighter);
 	if (p_highlighter != NULL) {
-		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text(p_highlighter->get_name()), true);
+		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text(p_highlighter->call("get_name")), true);
 	} else {
 		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text("Standard"), true);
 	}
@@ -61,7 +61,7 @@ void TextEditor::set_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
 }
 
 void TextEditor::_change_syntax_highlighter(int p_idx) {
-	Map<String, SyntaxHighlighter *>::Element *el = highlighters.front();
+	Map<String, Ref<SyntaxHighlighter>>::Element *el = highlighters.front();
 	while (el != NULL) {
 		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text(el->key()), false);
 		el = el->next();
@@ -695,7 +695,7 @@ TextEditor::TextEditor() {
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/capitalize", TTR("Capitalize")), EDIT_CAPITALIZE);
 	convert_case->connect("id_pressed", this, "_edit_option");
 
-	highlighters["Standard"] = NULL;
+	highlighters["Standard"] = Ref<SyntaxHighlighter>(NULL);
 	highlighter_menu = memnew(PopupMenu);
 	highlighter_menu->set_name("highlighter_menu");
 	edit_menu->get_popup()->add_child(highlighter_menu);
@@ -727,11 +727,6 @@ TextEditor::TextEditor() {
 }
 
 TextEditor::~TextEditor() {
-	for (const Map<String, SyntaxHighlighter *>::Element *E = highlighters.front(); E; E = E->next()) {
-		if (E->get() != NULL) {
-			memdelete(E->get());
-		}
-	}
 	highlighters.clear();
 }
 

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -104,7 +104,7 @@ protected:
 	void _make_context_menu(bool p_selection, bool p_can_fold, bool p_is_folded, Vector2 p_position);
 	void _text_edit_gui_input(const Ref<InputEvent> &ev);
 
-	Map<String, SyntaxHighlighter *> highlighters;
+	Map<String, Ref<SyntaxHighlighter>> highlighters;
 	void _change_syntax_highlighter(int p_idx);
 	void _load_theme_settings();
 
@@ -116,8 +116,8 @@ protected:
 	void _bookmark_item_pressed(int p_idx);
 
 public:
-	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
-	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);
+	virtual void add_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter);
+	virtual void set_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter);
 
 	virtual String get_name();
 	virtual Ref<Texture> get_icon();

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -60,8 +60,8 @@ static bool _is_bin_symbol(CharType c) {
 	return (c == '0' || c == '1');
 }
 
-Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_highlighting(int p_line) {
-	Map<int, TextEdit::HighlighterInfo> color_map;
+Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting(int p_line) {
+	Dictionary color_map;
 
 	Type next_type = NONE;
 	Type current_type = NONE;
@@ -85,15 +85,13 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 	Color keyword_color;
 	Color color;
 
-	int in_region = text_editor->_is_line_in_region(p_line);
+	int in_region = text_editor->is_line_in_region(p_line);
 	int deregion = 0;
 
 	const Map<int, TextEdit::Text::ColorRegionInfo> cri_map = text_editor->_get_line_color_region_info(p_line);
 	const String &str = text_editor->get_line(p_line);
 	Color prev_color;
 	for (int j = 0; j < str.length(); j++) {
-		TextEdit::HighlighterInfo highlighter_info;
-
 		if (deregion > 0) {
 			deregion--;
 			if (deregion == 0) {
@@ -104,8 +102,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 		if (deregion != 0) {
 			if (color != prev_color) {
 				prev_color = color;
-				highlighter_info.color = color;
-				color_map[j] = highlighter_info;
+				color_map[j] = color;
 			}
 			continue;
 		}
@@ -340,19 +337,14 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 
 		if (color != prev_color) {
 			prev_color = color;
-			highlighter_info.color = color;
-			color_map[j] = highlighter_info;
+			color_map[j] = color;
 		}
 	}
 	return color_map;
 }
 
-String GDScriptSyntaxHighlighter::get_name() const {
-	return "GDScript";
-}
-
-List<String> GDScriptSyntaxHighlighter::get_supported_languages() {
-	List<String> languages;
+Array GDScriptSyntaxHighlighter::get_supported_languages() {
+	Array languages;
 	languages.push_back("GDScript");
 	return languages;
 }
@@ -394,5 +386,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 }
 
 SyntaxHighlighter *GDScriptSyntaxHighlighter::create() {
-	return memnew(GDScriptSyntaxHighlighter);
+	SyntaxHighlighter* highlighter = memnew(GDScriptSyntaxHighlighter);
+	highlighter->set_name("GDScript");
+	return highlighter;
 }

--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -63,10 +63,9 @@ public:
 	static SyntaxHighlighter *create();
 
 	virtual void _update_cache();
-	virtual Map<int, TextEdit::HighlighterInfo> _get_line_syntax_highlighting(int p_line);
+	Dictionary _get_line_syntax_highlighting(int p_line);
 
-	virtual String get_name() const;
-	virtual List<String> get_supported_languages();
+	virtual Array get_supported_languages();
 };
 
 #endif // GDSCRIPT_HIGHLIGHTER_H

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -4587,10 +4587,10 @@ void VisualScriptEditor::_member_option(int p_option) {
 	}
 }
 
-void VisualScriptEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
+void VisualScriptEditor::add_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter) {
 }
 
-void VisualScriptEditor::set_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
+void VisualScriptEditor::set_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter) {
 }
 
 void VisualScriptEditor::_bind_methods() {

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -289,8 +289,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
-	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);
+	virtual void add_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter);
+	virtual void set_syntax_highlighter(Ref<SyntaxHighlighter> p_highlighter);
 
 	virtual void apply_code();
 	virtual RES get_edited_resource() const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -222,7 +222,7 @@ private:
 	} cache;
 
 	Map<int, int> color_region_cache;
-	Map<int, Map<int, HighlighterInfo> > syntax_highlighting_cache;
+	Map<int, Dictionary> syntax_highlighting_cache;
 
 	struct TextOperation {
 
@@ -254,11 +254,11 @@ private:
 	void _do_text_op(const TextOperation &p_op, bool p_reverse);
 
 	//syntax coloring
-	SyntaxHighlighter *syntax_highlighter;
+	Ref<SyntaxHighlighter> syntax_highlighter;
 	HashMap<String, Color> keywords;
 	HashMap<String, Color> member_keywords;
 
-	Map<int, HighlighterInfo> _get_line_syntax_highlighting(int p_line);
+	Dictionary _get_line_syntax_highlighting(int p_line);
 
 	Vector<ColorRegion> color_regions;
 
@@ -484,10 +484,10 @@ protected:
 	static void _bind_methods();
 
 public:
-	SyntaxHighlighter *_get_syntax_highlighting();
-	void _set_syntax_highlighting(SyntaxHighlighter *p_syntax_highlighter);
+	Ref<SyntaxHighlighter> get_syntax_highlighter();
+	void set_syntax_highlighter(Ref<SyntaxHighlighter> p_syntax_highlighter);
 
-	int _is_line_in_region(int p_line);
+	int is_line_in_region(int p_line);
 	ColorRegion _get_color_region(int p_region) const;
 	Map<int, Text::ColorRegionInfo> _get_line_color_region_info(int p_line) const;
 
@@ -769,20 +769,25 @@ public:
 VARIANT_ENUM_CAST(TextEdit::MenuItems);
 VARIANT_ENUM_CAST(TextEdit::SearchFlags);
 
-class SyntaxHighlighter {
+class SyntaxHighlighter : public Resource {
+	GDCLASS(SyntaxHighlighter, Resource);
+	OBJ_SAVE_TYPE(SyntaxHighlighter);
+
 protected:
+	static void _bind_methods();
 	TextEdit *text_editor;
 
 public:
 	virtual ~SyntaxHighlighter() {}
-	virtual void _update_cache() = 0;
-	virtual Map<int, TextEdit::HighlighterInfo> _get_line_syntax_highlighting(int p_line) = 0;
-
-	virtual String get_name() const = 0;
-	virtual List<String> get_supported_languages() = 0;
+	virtual void _update_cache();
+	virtual Dictionary _get_line_syntax_highlighting(int p_line);
+	virtual void _line_edited(int p_line);
+	virtual Array _get_supported_languages();
 
 	void set_text_editor(TextEdit *p_text_editor);
 	TextEdit *get_text_editor();
+
+	SyntaxHighlighter();
 };
 
 #endif // TEXT_EDIT_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -336,6 +336,7 @@ void register_scene_types() {
 	ClassDB::register_class<Tree>();
 
 	ClassDB::register_class<TextEdit>();
+	ClassDB::register_class<SyntaxHighlighter>();
 
 	ClassDB::register_virtual_class<TreeItem>();
 	ClassDB::register_class<OptionButton>();


### PR DESCRIPTION
Exposes SyntaxHighlighter as a `Resource`. Exposes a new `set_syntax_highlighter` method on TextEdit. Intended to be used for complex syntax highlighting support in TextEdit where `add_keyword_color`/`add_color_region` simply don't cut it. This PR does not remove those functions or change their functionality (no breaking changes).

Example usage (C#):
```cs
using System;
using Godot;
using Godot.Collections;

public class LuaHighlighter : SyntaxHighlighter {
    public override Godot.Collections.Array _GetSupportedLanguages() {
        return new Godot.Collections.Array { "Lua" };
    }

    public override Dictionary _GetLineSyntaxHighlighting(int pLine) {
        var dict = new Dictionary();
        dict[0] = new Color("#FF0000");

        dict[3] = new Color("#0000FF");
        return dict;
    }
}
```

```cs
TextEditNode.SetSyntaxHighlighter(new LuaHighlighter());
```