### PR TITLE
Add rotation widget to 3D viewport

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -256,6 +256,10 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	MAKE_DEFAULT_FONT(df_rulers, 8 * EDSCALE);
 	p_theme->set_font("rulers", "EditorFonts", df_rulers);
 
+	// Rotation widget font
+	MAKE_DEFAULT_FONT(df_rotation_control, 14 * EDSCALE);
+	p_theme->set_font("rotation_control", "EditorFonts", df_rotation_control);
+
 	// Code font
 	MAKE_SOURCE_FONT(df_code, int(EDITOR_GET("interface/editor/code_font_size")) * EDSCALE);
 	p_theme->set_font("source", "EditorFonts", df_code);


### PR DESCRIPTION
Video demo: https://streamable.com/p4sw4

I think this is feature complete now so I removed the draft status. It now handles the overlap with the FPS label properly, there is an option to enable/disable the "auto orthogonal" behavior and an editor setting to hide/show the viewport rotation gizmo.

Any feedback can go in the godot-proposals repo: https://github.com/godotengine/godot-proposals/issues/185

*Bugsquad edit:* This closes #11094.
Now fixes #26728 too.