### PR TITLE
[W.I.P] Made 3d raycast gizmo more visible

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -2084,10 +2084,9 @@ void RayCastSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 	lines.push_back(Vector3());
 	lines.push_back(raycast->get_cast_to());
 
-	const Ref<SpatialMaterial> material =
+	Ref<Material> material =
 			get_material(raycast->is_enabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
-
-	p_gizmo->add_lines(lines, material);
+	p_gizmo->add_solid_box(material, Vector3(0.01f, raycast->get_cast_to().y, 0.01f), Vector3(raycast->get_cast_to().x, raycast->get_cast_to().y / 2, raycast->get_cast_to().z));
 	p_gizmo->add_collision_segments(lines);
 }
 


### PR DESCRIPTION
Fixed #19793 
As @Calinou suggested I made it draw a box instead of a line. Possible improvements (Let me know if I should implement and give a hint on how to approach it :P):
- Make size depend on zoom so it still looks small when zoomed in (Probably some easy to get zoom level or something that can be used)
- Render above the axis (Feel like this is defined somewhere totally else, have not found any setZOrder or renderOnTop methouds or similar in the gizmo class)

Also I just found out that the size of the gizmo scales with the node scale :C
If anyone wants to help out then feel free to!