### PR TITLE
Fix some crashes and using null pointers

### DIFF
--- a/core/crypto/hashing_context.cpp
+++ b/core/crypto/hashing_context.cpp
@@ -50,6 +50,7 @@ Error HashingContext::start(HashType p_type) {
 Error HashingContext::update(PoolByteArray p_chunk) {
 	ERR_FAIL_COND_V(ctx == NULL, ERR_UNCONFIGURED);
 	size_t len = p_chunk.size();
+	ERR_FAIL_COND_V(len == 0, FAILED);
 	PoolByteArray::Read r = p_chunk.read();
 	switch (type) {
 		case HASH_MD5:

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -885,8 +885,8 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
 	bool mipmap_aware = p_interpolation == INTERPOLATE_TRILINEAR /* || p_interpolation == INTERPOLATE_TRICUBIC */;
 
-	ERR_FAIL_COND_MSG(p_width <= 0, "Image width cannot be greater than 0.");
-	ERR_FAIL_COND_MSG(p_height <= 0, "Image height cannot be greater than 0.");
+	ERR_FAIL_COND_MSG(p_width <= 0, "Image width must be greater than 0.");
+	ERR_FAIL_COND_MSG(p_height <= 0, "Image height must be greater than 0.");
 	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH, "Image width cannot be greater than " + itos(MAX_WIDTH) + ".");
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT, "Image height cannot be greater than " + itos(MAX_HEIGHT) + ".");
 
@@ -1321,6 +1321,8 @@ void Image::expand_x2_hq2x() {
 	{
 		PoolVector<uint8_t>::Read r = data.read();
 		PoolVector<uint8_t>::Write w = dest.write();
+
+		ERR_FAIL_COND(!r.ptr());
 
 		hq2x_resize((const uint32_t *)r.ptr(), width, height, (uint32_t *)w.ptr());
 	}
@@ -2894,6 +2896,8 @@ void Image::bumpmap_to_normalmap(float bump_scale) {
 	{
 		PoolVector<uint8_t>::Read rp = data.read();
 		PoolVector<uint8_t>::Write wp = result_image.write();
+
+		ERR_FAIL_COND(!rp.ptr());
 
 		unsigned char *write_ptr = wp.ptr();
 		float *read_ptr = (float *)rp.ptr();

--- a/core/packed_data_container.cpp
+++ b/core/packed_data_container.cpp
@@ -137,6 +137,7 @@ uint32_t PackedDataContainer::_type_at_ofs(uint32_t p_ofs) const {
 int PackedDataContainer::_size(uint32_t p_ofs) const {
 
 	PoolVector<uint8_t>::Read rd = data.read();
+	ERR_FAIL_COND_V(!rd.ptr(), 0);
 	const uint8_t *r = &rd[p_ofs];
 	uint32_t type = decode_uint32(r);
 

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -986,6 +986,7 @@ Array TranslationServer::get_loaded_locales() const {
 	for (const Set<Ref<Translation> >::Element *E = translations.front(); E; E = E->next()) {
 
 		const Ref<Translation> &t = E->get();
+		ERR_FAIL_COND_V(t.is_null(), Array());
 		String l = t->get_locale();
 
 		locales.push_back(l);
@@ -1057,6 +1058,7 @@ StringName TranslationServer::translate(const StringName &p_message) const {
 	for (const Set<Ref<Translation> >::Element *E = translations.front(); E; E = E->next()) {
 
 		const Ref<Translation> &t = E->get();
+		ERR_FAIL_COND_V(t.is_null(), StringName(""));
 		String l = t->get_locale();
 		if (lptr[0] != l[0] || lptr[1] != l[1])
 			continue; // Language code does not match.
@@ -1085,6 +1087,7 @@ StringName TranslationServer::translate(const StringName &p_message) const {
 		for (const Set<Ref<Translation> >::Element *E = translations.front(); E; E = E->next()) {
 
 			const Ref<Translation> &t = E->get();
+			ERR_FAIL_COND_V(t.is_null(), StringName(""));
 			String l = t->get_locale();
 			if (fptr[0] != l[0] || fptr[1] != l[1])
 				continue; // Language code does not match.

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -665,6 +665,7 @@ void RasterizerStorageGLES2::texture_set_data(RID p_texture, const Ref<Image> &p
 
 	texture->data_size = img->get_data().size();
 	PoolVector<uint8_t>::Read read = img->get_data().read();
+	ERR_FAIL_COND(!read.ptr());
 
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(texture->target, texture->tex_id);
@@ -3236,12 +3237,14 @@ Color RasterizerStorageGLES2::multimesh_instance_get_custom_data(RID p_multimesh
 void RasterizerStorageGLES2::multimesh_set_as_bulk_array(RID p_multimesh, const PoolVector<float> &p_array) {
 	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);
 	ERR_FAIL_COND(!multimesh);
+	ERR_FAIL_COND(!multimesh->data.ptr());
 
 	int dsize = multimesh->data.size();
 
 	ERR_FAIL_COND(dsize != p_array.size());
 
 	PoolVector<float>::Read r = p_array.read();
+	ERR_FAIL_COND(!r.ptr());
 	copymem(multimesh->data.ptrw(), r.ptr(), dsize * sizeof(float));
 
 	multimesh->dirty_data = true;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -795,6 +795,7 @@ void RasterizerStorageGLES3::texture_set_data(RID p_texture, const Ref<Image> &p
 
 	texture->data_size = img->get_data().size();
 	PoolVector<uint8_t>::Read read = img->get_data().read();
+	ERR_FAIL_COND(!read.ptr());
 
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(texture->target, texture->tex_id);
@@ -4718,6 +4719,7 @@ void RasterizerStorageGLES3::multimesh_set_as_bulk_array(RID p_multimesh, const 
 
 	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);
 	ERR_FAIL_COND(!multimesh);
+	ERR_FAIL_COND(!multimesh->data.ptr());
 
 	int dsize = multimesh->data.size();
 
@@ -4854,15 +4856,16 @@ RID RasterizerStorageGLES3::immediate_create() {
 	return immediate_owner.make_rid(im);
 }
 
-void RasterizerStorageGLES3::immediate_begin(RID p_immediate, VS::PrimitiveType p_rimitive, RID p_texture) {
+void RasterizerStorageGLES3::immediate_begin(RID p_immediate, VS::PrimitiveType p_primitive, RID p_texture) {
 
+	ERR_FAIL_INDEX(p_primitive, (int)VS::PRIMITIVE_MAX);
 	Immediate *im = immediate_owner.get(p_immediate);
 	ERR_FAIL_COND(!im);
 	ERR_FAIL_COND(im->building);
 
 	Immediate::Chunk ic;
 	ic.texture = p_texture;
-	ic.primitive = p_rimitive;
+	ic.primitive = p_primitive;
 	im->chunks.push_back(ic);
 	im->mask = 0;
 	im->building = true;

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -869,7 +869,7 @@ public:
 	mutable RID_Owner<Immediate> immediate_owner;
 
 	virtual RID immediate_create();
-	virtual void immediate_begin(RID p_immediate, VS::PrimitiveType p_rimitive, RID p_texture = RID());
+	virtual void immediate_begin(RID p_immediate, VS::PrimitiveType p_primitive, RID p_texture = RID());
 	virtual void immediate_vertex(RID p_immediate, const Vector3 &p_vertex);
 	virtual void immediate_normal(RID p_immediate, const Vector3 &p_normal);
 	virtual void immediate_tangent(RID p_immediate, const Plane &p_tangent);

--- a/modules/bullet/btRayShape.h
+++ b/modules/bullet/btRayShape.h
@@ -62,7 +62,7 @@ public:
 
 	virtual void setMargin(btScalar margin);
 
-	void setSlipsOnSlope(bool p_slipOnSlope);
+	void setSlipsOnSlope(bool p_slipsOnSlope);
 	bool getSlipsOnSlope() const { return slipsOnSlope; }
 
 	const btTransform &getSupportPoint() const { return m_cacheSupportPoint; }

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -126,16 +126,16 @@ void BulletPhysicsDirectBodyState::add_torque(const Vector3 &p_torque) {
 	body->apply_torque(p_torque);
 }
 
-void BulletPhysicsDirectBodyState::apply_central_impulse(const Vector3 &p_j) {
-	body->apply_central_impulse(p_j);
+void BulletPhysicsDirectBodyState::apply_central_impulse(const Vector3 &p_impulse) {
+	body->apply_central_impulse(p_impulse);
 }
 
-void BulletPhysicsDirectBodyState::apply_impulse(const Vector3 &p_pos, const Vector3 &p_j) {
-	body->apply_impulse(p_pos, p_j);
+void BulletPhysicsDirectBodyState::apply_impulse(const Vector3 &p_pos, const Vector3 &p_impulse) {
+	body->apply_impulse(p_pos, p_impulse);
 }
 
-void BulletPhysicsDirectBodyState::apply_torque_impulse(const Vector3 &p_j) {
-	body->apply_torque_impulse(p_j);
+void BulletPhysicsDirectBodyState::apply_torque_impulse(const Vector3 &p_impulse) {
+	body->apply_torque_impulse(p_impulse);
 }
 
 void BulletPhysicsDirectBodyState::set_sleep_state(bool p_enable) {
@@ -920,7 +920,7 @@ void RigidBodyBullet::reload_space_override_modificator() {
 
 		currentArea = areasWhereIam[i];
 
-		if (PhysicsServer::AREA_SPACE_OVERRIDE_DISABLED == currentArea->get_spOv_mode()) {
+		if (!currentArea || PhysicsServer::AREA_SPACE_OVERRIDE_DISABLED == currentArea->get_spOv_mode()) {
 			continue;
 		}
 

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -114,8 +114,8 @@ public:
 	virtual void add_force(const Vector3 &p_force, const Vector3 &p_pos);
 	virtual void add_torque(const Vector3 &p_torque);
 	virtual void apply_central_impulse(const Vector3 &p_impulse);
-	virtual void apply_impulse(const Vector3 &p_pos, const Vector3 &p_j);
-	virtual void apply_torque_impulse(const Vector3 &p_j);
+	virtual void apply_impulse(const Vector3 &p_pos, const Vector3 &p_impulse);
+	virtual void apply_torque_impulse(const Vector3 &p_impulse);
 
 	virtual void set_sleep_state(bool p_enable);
 	virtual bool is_sleeping() const;

--- a/modules/etc/image_etc.cpp
+++ b/modules/etc/image_etc.cpp
@@ -168,6 +168,7 @@ static void _compress_etc(Image *p_img, float p_lossy_quality, bool force_etc1_f
 	}
 
 	PoolVector<uint8_t>::Read r = img->get_data().read();
+	ERR_FAIL_COND(!r.ptr());
 
 	unsigned int target_size = Image::get_image_data_size(imgw, imgh, etc_format, p_img->has_mipmaps());
 	int mmc = 1 + (p_img->has_mipmaps() ? Image::get_image_required_mipmaps(imgw, imgh, etc_format) : 0);

--- a/modules/gdnative/include/gdnative/array.h
+++ b/modules/gdnative/include/gdnative/array.h
@@ -132,7 +132,7 @@ void GDAPI godot_array_destroy(godot_array *p_self);
 
 godot_array GDAPI godot_array_duplicate(const godot_array *p_self, const godot_bool p_deep);
 
-godot_array GDAPI godot_array_slice(const godot_array *p_self, const godot_int p_begin, const godot_int p_end, const godot_int p_delta, const godot_bool p_deep);
+godot_array GDAPI godot_array_slice(const godot_array *p_self, const godot_int p_begin, const godot_int p_end, const godot_int p_step, const godot_bool p_deep);
 
 godot_variant GDAPI godot_array_max(const godot_array *p_self);
 

--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -158,7 +158,7 @@ void GDNativeExportPlugin::_export_file(const String &p_path, const String &p_ty
 		String additional_code = "extern void register_dynamic_symbol(char *name, void *address);\n"
 								 "extern void add_ios_init_callback(void (*cb)());\n";
 		String linker_flags = "";
-		for (unsigned int i = 0; i < sizeof(expected_symbols) / sizeof(expected_symbols[0]); ++i) {
+		for (unsigned long i = 0; i < sizeof(expected_symbols) / sizeof(expected_symbols[0]); ++i) {
 			String full_name = lib->get_symbol_prefix() + expected_symbols[i].name;
 			String code = declare_pattern.replace("$name", full_name);
 			code = code.replace("$weak", expected_symbols[i].is_required ? "" : " __attribute__((weak))");
@@ -174,7 +174,7 @@ void GDNativeExportPlugin::_export_file(const String &p_path, const String &p_ty
 
 		additional_code += String("void $prefixinit() {\n").replace("$prefix", lib->get_symbol_prefix());
 		String register_pattern = "  if (&$name) register_dynamic_symbol((char *)\"$name\", (void *)$name);\n";
-		for (unsigned int i = 0; i < sizeof(expected_symbols) / sizeof(expected_symbols[0]); ++i) {
+		for (unsigned long i = 0; i < sizeof(expected_symbols) / sizeof(expected_symbols[0]); ++i) {
 			String full_name = lib->get_symbol_prefix() + expected_symbols[i].name;
 			additional_code += register_pattern.replace("$name", full_name);
 		}

--- a/scene/3d/navigation_mesh.h
+++ b/scene/3d/navigation_mesh.h
@@ -124,7 +124,7 @@ public:
 	void set_collision_mask_bit(int p_bit, bool p_value);
 	bool get_collision_mask_bit(int p_bit) const;
 
-	void set_source_geometry_mode(int p_source_mode);
+	void set_source_geometry_mode(int p_geometry_mode);
 	int get_source_geometry_mode() const;
 
 	void set_source_group_name(StringName p_group_name);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1754,6 +1754,7 @@ SpatialMaterial::TextureChannel SpatialMaterial::get_roughness_texture_channel()
 
 void SpatialMaterial::set_ao_texture_channel(TextureChannel p_channel) {
 
+	ERR_FAIL_INDEX(p_channel, 5);
 	ao_texture_channel = p_channel;
 	VS::get_singleton()->material_set_param(_get_material(), shader_names->ao_texture_channel, _get_texture_mask(p_channel));
 }
@@ -1764,6 +1765,7 @@ SpatialMaterial::TextureChannel SpatialMaterial::get_ao_texture_channel() const 
 
 void SpatialMaterial::set_refraction_texture_channel(TextureChannel p_channel) {
 
+	ERR_FAIL_INDEX(p_channel, 5);
 	refraction_texture_channel = p_channel;
 	VS::get_singleton()->material_set_param(_get_material(), shader_names->refraction_texture_channel, _get_texture_mask(p_channel));
 }


### PR DESCRIPTION
Fixes #30343 - I'm not sure about fix, but for now this is better than crash
Fixes #32877
Fixes #32658
Fixes #32754 
Fixes #32659

Enums used in set_refraction_texture_channel and set_ao_texture_channel must be checked to prevent Godot crash.

I changed name of `p_rimitive` parameter to `p_primitive` 

This fixes also this messages from ubsan
core/pool_vector.h:307:75: runtime error: reference binding to null pointer of type 'const unsigned char'
drivers/gles2/rasterizer_storage_gles2.cpp:3245:2: runtime error: null pointer passed as argument 1, which is declared to never be null
drivers/gles2/rasterizer_storage_gles2.cpp:3245:2: runtime error: null pointer passed as argument 2, which is declared to never be null
scene/resources/material.cpp:1731:24: runtime error: index -3 out of bounds for type 'Plane [5]'
