### PR TITLE
Improve performance of connection info in the script editor

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -967,12 +967,17 @@ void ScriptTextEditor::_update_connected_methods() {
 	text_edit->clear_info_icons();
 	missing_connections.clear();
 
+	if (!script->is_valid()) {
+		return;
+	}
+
 	Node *base = get_tree()->get_edited_scene_root();
 	if (!base) {
 		return;
 	}
 
 	Vector<Node *> nodes = _find_all_node_for_script(base, base, script);
+	Set<StringName> methods_found;
 	for (int i = 0; i < nodes.size(); i++) {
 		List<Connection> connections;
 		nodes[i]->get_signals_connected_to_this(&connections);
@@ -989,28 +994,33 @@ void ScriptTextEditor::_update_connected_methods() {
 				continue;
 			}
 
+			if (methods_found.has(connection.method)) {
+				continue;
+			}
+
 			if (!ClassDB::has_method(script->get_instance_base_type(), connection.method)) {
-
-				int line = script->get_language()->find_function(connection.method, text_edit->get_text());
-				if (line < 0) {
-					// There is a chance that the method is inherited from another script.
-					bool found_inherited_function = false;
-					Ref<Script> inherited_script = script->get_base_script();
-					while (!inherited_script.is_null()) {
-						line = inherited_script->get_language()->find_function(connection.method, inherited_script->get_source_code());
-						if (line != -1) {
-							found_inherited_function = true;
-							break;
-						}
-
-						inherited_script = inherited_script->get_base_script();
-					}
-
-					if (!found_inherited_function) {
-						missing_connections.push_back(connection);
-					}
-				} else {
+				int line = -1;
+				if (script->has_method(connection.method)) {
+					line = script->get_member_line(connection.method);
 					text_edit->set_line_info_icon(line - 1, get_parent_control()->get_icon("Slot", "EditorIcons"), connection.method);
+					methods_found.insert(connection.method);
+					continue;
+				}
+
+				// There is a chance that the method is inherited from another script.
+				bool found_inherited_function = false;
+				Ref<Script> inherited_script = script->get_base_script();
+				while (!inherited_script.is_null()) {
+					if (inherited_script->has_method(connection.method)) {
+						found_inherited_function = true;
+						break;
+					}
+
+					inherited_script = inherited_script->get_base_script();
+				}
+
+				if (!found_inherited_function) {
+					missing_connections.push_back(connection);
 				}
 			}
 		}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -269,6 +269,12 @@ void TextEdit::Text::clear_wrap_cache() {
 	}
 }
 
+void TextEdit::Text::clear_info_icons() {
+	for (int i = 0; i < text.size(); i++) {
+		text.write[i].has_info = false;
+	}
+}
+
 void TextEdit::Text::clear() {
 
 	text.clear();
@@ -303,6 +309,7 @@ void TextEdit::Text::insert(int p_at, const String &p_text) {
 	line.breakpoint = false;
 	line.bookmark = false;
 	line.hidden = false;
+	line.has_info = false;
 	line.width_cache = -1;
 	line.wrap_amount_cache = -1;
 	line.data = p_text;
@@ -5663,9 +5670,7 @@ void TextEdit::set_line_info_icon(int p_line, Ref<Texture> p_icon, String p_info
 }
 
 void TextEdit::clear_info_icons() {
-	for (int i = 0; i < text.size(); i++) {
-		text.set_info_icon(i, NULL, "");
-	}
+	text.clear_info_icons();
 	update();
 }
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -78,6 +78,7 @@ public:
 			bool bookmark : 1;
 			bool hidden : 1;
 			bool safe : 1;
+			bool has_info : 1;
 			int wrap_amount_cache : 24;
 			Map<int, ColorRegionInfo> region_info;
 			Ref<Texture> info_icon;
@@ -115,10 +116,15 @@ public:
 		void set_safe(int p_line, bool p_safe) { text.write[p_line].safe = p_safe; }
 		bool is_safe(int p_line) const { return text[p_line].safe; }
 		void set_info_icon(int p_line, Ref<Texture> p_icon, String p_info) {
+			if (p_icon.is_null()) {
+				text.write[p_line].has_info = false;
+				return;
+			}
 			text.write[p_line].info_icon = p_icon;
 			text.write[p_line].info = p_info;
+			text.write[p_line].has_info = true;
 		}
-		bool has_info_icon(int p_line) const { return text[p_line].info_icon.is_valid(); }
+		bool has_info_icon(int p_line) const { return text[p_line].has_info; }
 		const Ref<Texture> &get_info_icon(int p_line) const { return text[p_line].info_icon; }
 		const String &get_info(int p_line) const { return text[p_line].info; }
 		void insert(int p_at, const String &p_text);
@@ -127,6 +133,7 @@ public:
 		void clear();
 		void clear_width_cache();
 		void clear_wrap_cache();
+		void clear_info_icons();
 		_FORCE_INLINE_ const String &operator[](int p_line) const { return text[p_line].data; }
 		Text() { indent_size = 4; }
 	};


### PR DESCRIPTION
Hopefully resolved most of the performance issues with the connection info in the script editor.

The majority of the time was spent in `get_language()->find_function` as it parses the script line by line for the function. Changing this to `has_method / get_member_line` improves performance as it uses the preparsed script, however, it will now require a valid script for it to work.

It now keeps a `Set` of methods that already have a connection, saving having to search for it again.

Lastly, swapped checking for a valid texture resource and string for a plain bool.

should close #32236