### PR TITLE
Normalize GDScript resource path extension while (de)serializing

### DIFF
--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1123,9 +1123,13 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 
 					NodePath cp(sname, Vector<StringName>(), false);
 
+					// Normalize script extension (gdc, gde)
+					String ext = GDScriptLanguage::get_singleton()->get_extension();
+					String path = p->path.get_basename() + "." + ext;
+
 					Dictionary d;
 					d["@subpath"] = cp;
-					d["@path"] = p->path;
+					d["@path"] = path;
 
 					p = base.ptr();
 
@@ -1176,21 +1180,12 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 
 				return;
 			}
+			// Normalize script extension (gdc, gde)
+			String ext = GDScriptLanguage::get_singleton()->get_extension();
+			String path = String(d["@path"]).get_basename() + "." + ext;
 
-			Ref<Script> scr = ResourceLoader::load(d["@path"]);
-			if (!scr.is_valid()) {
-
-				r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
-				r_error.argument = 0;
-				r_error.expected = Variant::OBJECT;
-				r_ret = RTR("Invalid instance dictionary format (can't load script at @path)");
-				return;
-			}
-
-			Ref<GDScript> gdscr = scr;
-
+			Ref<GDScript> gdscr = ResourceLoader::load(path);
 			if (!gdscr.is_valid()) {
-
 				r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.argument = 0;
 				r_error.expected = Variant::OBJECT;


### PR DESCRIPTION
Fixes #26188.
Fixes #31045 (if not, feel free to reopen).

When serializing (using `inst2dict`) from within exported project, script path keys has either `gdc` or `gde` extension, which can't be loaded / not present in editor.

When scripts are exported, the resource paths are remapped from `gd` to `gdc`/`gde`, so data saved using the editor is still compatible with exported game. Yet this PR fixes the opposite use case: reusing data generated with exported project to be loaded within editor.

This should make it easier for developers to test the save data sent by players to be tested within editor without having to write custom tools to manually convert `@path` properties to replace `gdc` to `gd` (json or whatever other format).

## Test project
[gdscript-inst2dict-path.zip](https://github.com/godotengine/godot/files/3776221/gdscript-inst2dict-path.zip)
