### PR TITLE
Fix Mac OS X 10.9 build issue due to CGLContextObj return type.

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1579,7 +1579,7 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	// setup our display link, this will inform us when a refresh is needed
 	CVDisplayLinkCreateWithActiveCGDisplays(&displayLink);
 	CVDisplayLinkSetOutputCallback(displayLink, &DisplayLinkCallback, this);
-	CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(displayLink, context.CGLContextObj, pixelFormat.CGLPixelFormatObj);
+	CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(displayLink, static_cast<CGLContextObj>(context.CGLContextObj), static_cast<CGLPixelFormatObj>(pixelFormat.CGLPixelFormatObj));
 	CVDisplayLinkStart(displayLink);
 
 	// initialise a conditional lock object


### PR DESCRIPTION
Prevents this compilation error on Mac OS X 10.9:

    candidate function not viable: cannot convert argument of incomplete type 'void *' to
      'CGLContextObj' (aka '_CGLContextObject *')

The issue occurs because pre-Mac OS X 10.10 the `CGLContextObj` property had a return type of `void *` but in 10.10 it changed to a return type of `struct _CGLContextObject *`.

Also prevents a similar error with `CGLPixelFormatObj` property.

The issue appeared due to the recent addition of the call to `CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext()` to work around a macOS 10.14 v-sync issue in https://github.com/godotengine/godot/commit/b53f2d1d598193ab1d1c02345fc321be254364ca. 

Note:

 * I've only tested this change by building on Mac OS X 10.9--I don't know if the addition of the `static_cast` will cause any issues on OS versions that don't require it.
 * An alternative approach would be to use the implementation that appears to come from Apple-supplied examples (e.g. [`GLEssentials/GLEssentials/Source/Classes/OSX/GLEssentialsGLView.m`](https://github.com/lmdsp/samples_apple_gl/blob/6ef05b5ee3f3b07194e4f7dfa67569baaeba60b0/GLEssentials/GLEssentials/Source/Classes/OSX/GLEssentialsGLView.m#L102-L105)) which would avoid the cast by explicitly storing the parameters into variables before making the function call:
```objc
CGLContextObj cglContext = [[self openGLContext] CGLContextObj];
CGLPixelFormatObj cglPixelFormat = [[self pixelFormat] CGLPixelFormatObj];
CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(displayLink, cglContext, cglPixelFormat);
```

### Additional context

Initial `CGLContextObj`-related build error:

```
platform/osx/os_osx.mm:1582:2: error: no matching function for call to 'CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext'
        CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(displayLink, context.CGLContextObj, pixelFormat.CGLPixelFormatObj);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/CoreVideo.framework/Headers/CVDisplayLink.h:100:20: note: candidate function not viable: cannot convert argument of incomplete type 'void *' to
      'CGLContextObj' (aka '_CGLContextObject *')
CV_EXPORT CVReturn CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(CVDisplayLinkRef displayLink, 
```

Subsequent `CGLPixelFormatObj`-related build error:
```
platform/osx/os_osx.mm:1582:2: error: no matching function for call to 'CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext'
        CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(displayLink, static_cast<CGLContextObj>(context.CGLContextObj), pixelFormat.CGLPixelFormatObj);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/CoreVideo.framework/Headers/CVDisplayLink.h:100:20: note: candidate function not viable: cannot convert argument of incomplete type 'void *' to
      'CGLPixelFormatObj' (aka '_CGLPixelFormatObject *')
CV_EXPORT CVReturn CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(CVDisplayLinkRef displayLink, 
                   ^
```

Mac OS X 10.9 header with `CGLContextObj` property in `NSOpenGL.h` in `AppKit` framework: [`AppKit.framework/Versions/C/Headers/NSOpenGL.h`](https://github.com/alexey-lysiuk/macos-sdk/blob/352a0070583ecdde139db5c36a6e0734b86438d3/MacOSX10.9.sdk/System/Library/Frameworks/AppKit.framework/Versions/C/Headers/NSOpenGL.h#L242)

Mac OS X 10.10 header with `CGLContextObj` property in `NSOpenGL.h` in `AppKit` framework: [`AppKit.framework/Versions/C/Headers/NSOpenGL.h`](https://github.com/alexey-lysiuk/macos-sdk/blob/352a0070583ecdde139db5c36a6e0734b86438d3/MacOSX10.10.sdk/System/Library/Frameworks/AppKit.framework/Versions/C/Headers/NSOpenGL.h#L241)

Current Godot code: https://github.com/godotengine/godot/blob/816341af25749e3c2ee1fad370c0c5785293f5b6/platform/osx/os_osx.mm#L1582

Mac OS X 10.9 header with `CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext()` function in `CVDisplayLink.h` in `CoreVideo` framework: [`CoreVideo.framework/Versions/A/Headers/CVDisplayLink.h`](https://github.com/alexey-lysiuk/macos-sdk/blob/352a0070583ecdde139db5c36a6e0734b86438d3/MacOSX10.9.sdk/System/Library/Frameworks/CoreVideo.framework/Versions/A/Headers/CVDisplayLink.h#L92-L102)

Equivalent Mac OS X 10.11 (the version the declaration next changed) header with `CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext()` function in `CVDisplayLink.h` in `CoreVideo` framework: [`CoreVideo.framework/Versions/A/Headers/CVDisplayLink.h`](https://github.com/alexey-lysiuk/macos-sdk/blob/352a0070583ecdde139db5c36a6e0734b86438d3/MacOSX10.11.sdk/System/Library/Frameworks/CoreVideo.framework/Versions/A/Headers/CVDisplayLink.h#L111-L122)