### PR TITLE
Fix related editor panel not opening after creating resource

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2569,6 +2569,8 @@ void EditorPropertyResource::_menu_option(int p_which) {
 
 			res = Ref<Resource>(resp);
 			emit_changed(get_edited_property(), res);
+			bool unfold = !get_edited_object()->editor_is_section_unfolded(get_edited_property());
+			get_edited_object()->editor_set_section_unfold(get_edited_property(), unfold);
 			update_property();
 
 		} break;


### PR DESCRIPTION
When creating a new resource inside an editor node, its related editor panel
should open automatically but it was opening only after selecting the resource.
Just like in **_resource_selected** method from `editor_properties` class,
adding a section unfold call in **_menu_option** method fixes this issue.

Fix #32895