### PR TITLE
Make inst2dict and dict2inst work recursively

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -443,8 +443,11 @@
 			</return>
 			<argument index="0" name="inst" type="Object">
 			</argument>
+			<argument index="1" name="deep" type="bool" default="false">
+			</argument>
 			<description>
 				Returns the passed instance converted to a dictionary (useful for serializing).
+				If [code]deep[/code] is [code]true[/code], the method converts any inner instances recursively, including nested arrays and dictionaries with both keys and values as instances. Use this option only if you're sure that instances have no circular references to each other as it can lead to an endless conversion loop.
 				[codeblock]
 				var foo = "bar"
 				func _ready():

--- a/modules/gdscript/gdscript_functions.h
+++ b/modules/gdscript/gdscript_functions.h
@@ -31,6 +31,8 @@
 #ifndef GDSCRIPT_FUNCTIONS_H
 #define GDSCRIPT_FUNCTIONS_H
 
+#include "core/map.h"
+#include "core/object.h"
 #include "core/variant.h"
 
 class GDScriptFunctions {
@@ -132,6 +134,15 @@ public:
 	static void call(Function p_func, const Variant **p_args, int p_arg_count, Variant &r_ret, Callable::CallError &r_error);
 	static bool is_deterministic(Function p_func);
 	static MethodInfo get_info(Function p_func);
+
+private:
+	static void _instance_to_dictionary(Object *obj, Variant &r_ret, Callable::CallError &r_error, Map<ObjectID, Dictionary> *r_instances = NULL);
+	static void _dictionary_to_instance(const Dictionary &d, Variant &r_ret, Callable::CallError &r_error);
+
+	static Variant _inst_to_dict_or_var(const Variant &v, Callable::CallError &r_error, Map<ObjectID, Dictionary> *r_instances = NULL);
+	static Variant _dict_to_inst_or_var(const Variant &v, Callable::CallError &r_error);
+
+	_FORCE_INLINE_ static bool is_dict_instance(const Dictionary &d) { return d.has("@path"); }
 };
 
 #endif // GDSCRIPT_FUNCTIONS_H


### PR DESCRIPTION
Closes #6533.

This makes `inst2dict` GDScript method to turn inner instances present as properties to be converted to a dictionary recursively, including instances with nested arrays and dictionaries with key/value pair.

Added a `deep` paramater to `inst2dict` so that the default behavior remains the same. Recursive conversion is disabled by default because instances may have circular references as described in https://github.com/godotengine/godot/issues/31229#issuecomment-519955042, hence must be used with caution on case-to-case basis. Updated documentation accordingly.

## Features
- [x] Convert properties with instances (inner classes) recursively using `inst2dict`.
- [x] Convert nested arrays with classes recursively using `inst2dict`.
- [x] Convert nested dictionaries with classes recursively.
- [x] Convert all back using `dict2inst` (all above).
- [x] Add `recursive/deep` option for `inst2dict` method.

## Test project
Extensive test project demonstrating all of the added features, and showing how having circular references fail, which is handled in debug builds by checking that only unique objects are converted.

[inst2dict-recursive.zip](https://github.com/godotengine/godot/files/3783637/inst2dict-recursive.zip)