### PR TITLE
Fixed remote inspector for tool scripts

### DIFF
--- a/core/ref_ptr.cpp
+++ b/core/ref_ptr.cpp
@@ -49,6 +49,14 @@ bool RefPtr::operator==(const RefPtr &p_other) const {
 	return *ref == *ref_other;
 }
 
+bool RefPtr::operator!=(const RefPtr &p_other) const {
+
+	Ref<Reference> *ref = reinterpret_cast<Ref<Reference> *>(&data[0]);
+	Ref<Reference> *ref_other = reinterpret_cast<Ref<Reference> *>(const_cast<char *>(&p_other.data[0]));
+
+	return *ref != *ref_other;
+}
+
 RefPtr::RefPtr(const RefPtr &p_other) {
 
 	memnew_placement(&data[0], Ref<Reference>);

--- a/core/ref_ptr.h
+++ b/core/ref_ptr.h
@@ -50,6 +50,7 @@ public:
 	bool is_null() const;
 	void operator=(const RefPtr &p_other);
 	bool operator==(const RefPtr &p_other) const;
+	bool operator!=(const RefPtr &p_other) const;
 	RID get_rid() const;
 	void unref();
 	_FORCE_INLINE_ void *get_data() const { return data; }

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -611,8 +611,16 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 					}
 					var = ResourceLoader::load(path);
 
-					if (pinfo.hint_string == "Script")
-						debugObj->set_script(var);
+					if (pinfo.hint_string == "Script") {
+						if (debugObj->get_script() != var) {
+							debugObj->set_script(RefPtr());
+							Ref<Script> script(var);
+							if (!script.is_null()) {
+								ScriptInstance *script_instance = script->placeholder_instance_create(debugObj);
+								debugObj->set_script_and_instance(var, script_instance);
+							}
+						}
+					}
 				} else if (var.get_type() == Variant::OBJECT) {
 					if (((Object *)var)->is_class("EncodedObjectAsID")) {
 						var = Object::cast_to<EncodedObjectAsID>(var)->get_object_id();


### PR DESCRIPTION
Based on feedback from PR #32778 I'm proposing a fix for errors when inspecting a tool script which doesn't involve a change in core (except for adding `!=` operator for `RefPtr`, but I can do without it if needed).

`ScriptEditorDebugger` will just directly create a placeholder script instance for `ScriptEditorDebuggerInspectedObject`.

Fixes #29506