### PR TITLE
Fixed disconnecting not connected signal

### DIFF
--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -95,7 +95,9 @@ void EditorDirDialog::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
-		EditorFileSystem::get_singleton()->disconnect("filesystem_changed", this, "reload");
+		if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", this, "reload")) {
+			EditorFileSystem::get_singleton()->disconnect("filesystem_changed", this, "reload");
+		}
 	}
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -397,8 +397,9 @@ void VersionControlEditorPlugin::clear_stage_area() {
 void VersionControlEditorPlugin::shut_down() {
 
 	if (EditorVCSInterface::get_singleton()) {
-
-		EditorFileSystem::get_singleton()->disconnect("filesystem_changed", this, "_refresh_stage_area");
+		if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", this, "_refresh_stage_area")) {
+			EditorFileSystem::get_singleton()->disconnect("filesystem_changed", this, "_refresh_stage_area");
+		}
 		EditorVCSInterface::get_singleton()->shut_down();
 		memdelete(EditorVCSInterface::get_singleton());
 		EditorVCSInterface::set_singleton(NULL);

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1037,7 +1037,9 @@ void CPUParticles2D::_set_redraw(bool p_redraw) {
 
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, -1);
 	} else {
-		VS::get_singleton()->disconnect("frame_pre_draw", this, "_update_render_thread");
+		if (VS::get_singleton()->is_connected("frame_pre_draw", this, "_update_render_thread")) {
+			VS::get_singleton()->disconnect("frame_pre_draw", this, "_update_render_thread");
+		}
 		VS::get_singleton()->canvas_item_set_update_when_visible(get_canvas_item(), false);
 
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, 0);

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -1124,7 +1124,9 @@ void CPUParticles::_set_redraw(bool p_redraw) {
 		VS::get_singleton()->instance_geometry_set_flag(get_instance(), VS::INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE, true);
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, -1);
 	} else {
-		VS::get_singleton()->disconnect("frame_pre_draw", this, "_update_render_thread");
+		if (VS::get_singleton()->is_connected("frame_pre_draw", this, "_update_render_thread")) {
+			VS::get_singleton()->disconnect("frame_pre_draw", this, "_update_render_thread");
+		}
 		VS::get_singleton()->instance_geometry_set_flag(get_instance(), VS::INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE, false);
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, 0);
 	}

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -460,7 +460,9 @@ void SoftBody::update_physics_server() {
 	} else {
 
 		PhysicsServer::get_singleton()->soft_body_set_mesh(physics_rid, NULL);
-		VS::get_singleton()->disconnect("frame_pre_draw", this, "_draw_soft_mesh");
+		if (VS::get_singleton()->is_connected("frame_pre_draw", this, "_draw_soft_mesh")) {
+			VS::get_singleton()->disconnect("frame_pre_draw", this, "_draw_soft_mesh");
+		}
 	}
 }
 


### PR DESCRIPTION
As described in #33135, disconnecting not connected (not initialized in this case) signal prints redundant error message, which in case of not initialized object can be misleading. 
Added checks in few places to avoid such behaviour. 