### PR TITLE
Added check if field name in the shader is equal to builtin

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -4754,6 +4754,11 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 					return ERR_PARSE_ERROR;
 				}
 
+				if (has_builtin(p_functions, name)) {
+					_set_error("Redefinition of '" + String(name) + "'");
+					return ERR_PARSE_ERROR;
+				}
+
 				if (uniform) {
 
 					ShaderNode::Uniform uniform2;
@@ -5002,6 +5007,11 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 					return ERR_PARSE_ERROR;
 				}
 
+				if (has_builtin(p_functions, name)) {
+					_set_error("Redefinition of '" + String(name) + "'");
+					return ERR_PARSE_ERROR;
+				}
+
 				tk = _get_token();
 				if (tk.type != TK_PARENTHESIS_OPEN) {
 					if (type == TYPE_VOID) {
@@ -5056,6 +5066,11 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 
 							name = tk.text;
 							if (_find_identifier(NULL, Map<StringName, BuiltInInfo>(), name)) {
+								_set_error("Redefinition of '" + String(name) + "'");
+								return ERR_PARSE_ERROR;
+							}
+
+							if (has_builtin(p_functions, name)) {
 								_set_error("Redefinition of '" + String(name) + "'");
 								return ERR_PARSE_ERROR;
 							}
@@ -5161,6 +5176,12 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 							return ERR_PARSE_ERROR;
 						}
 					}
+
+					if (has_builtin(p_functions, pname)) {
+						_set_error("Redefinition of '" + String(pname) + "'");
+						return ERR_PARSE_ERROR;
+					}
+
 					FunctionNode::Argument arg;
 					arg.type = ptype;
 					arg.name = pname;
@@ -5225,6 +5246,26 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 	}
 
 	return OK;
+}
+
+bool ShaderLanguage::has_builtin(const Map<StringName, ShaderLanguage::FunctionInfo> &p_functions, const StringName &p_name) {
+
+	if (p_functions.has("vertex")) {
+		if (p_functions["vertex"].built_ins.has(p_name)) {
+			return true;
+		}
+	}
+	if (p_functions.has("fragment")) {
+		if (p_functions["fragment"].built_ins.has(p_name)) {
+			return true;
+		}
+	}
+	if (p_functions.has("light")) {
+		if (p_functions["light"].built_ins.has(p_name)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 Error ShaderLanguage::_find_last_flow_op_in_op(ControlFlowNode *p_flow, FlowOperation p_op) {

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -645,6 +645,7 @@ public:
 		Map<StringName, BuiltInInfo> built_ins;
 		bool can_discard;
 	};
+	static bool has_builtin(const Map<StringName, ShaderLanguage::FunctionInfo> &p_functions, const StringName &p_name);
 
 private:
 	struct KeyWord {


### PR DESCRIPTION
Closes #32978, the name of functions and parameters should not be equal to the built-in to prevent crashes or logic errors.