### PR TITLE
Make JSON properly write and parse dictionary keys

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -433,7 +433,6 @@ Error JSON::_parse_object(Dictionary &object, const CharType *p_str, int &index,
 
 			err = VariantParser::parse(&ss, key, r_err_str, line);
 			if (err != OK) {
-				ERR_FAIL_V_MSG(err, r_err_str);
 				return err;
 			}
 


### PR DESCRIPTION
Note: see #33241 which is more generalized enhancement.

Fixes #33161.
Allows to successfully serialize dictionary instances (as keys) in #33137.

This is certainly a hack currently, need more work. Ideally any json-incompatible type should be converted with `VariantWriter` as JSON strings and read with `VariantParser`s, see https://github.com/godotengine/godot/issues/33161#issuecomment-548053758.
