### PR TITLE
Fixed leak in gdscript when creating empty WeakRef

### DIFF
--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -589,7 +589,8 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 					r_ret = wref;
 				}
 			} else if (p_args[0]->get_type() == Variant::NIL) {
-				r_ret = memnew(WeakRef);
+				Ref<WeakRef> wref = memnew(WeakRef);
+				r_ret = wref;
 			} else {
 				r_error.error = Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.argument = 0;


### PR DESCRIPTION
In this specific case a simple pointer was created instead of a ref counted one.

Fixes #33150