### PR TITLE
Added some functions to harmonize Vector2/Vector3

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -31,25 +31,28 @@
 #include "vector2.h"
 
 real_t Vector2::angle() const {
-
 	return Math::atan2(y, x);
 }
 
 real_t Vector2::length() const {
-
 	return Math::sqrt(x * x + y * y);
 }
 
 real_t Vector2::length_squared() const {
-
 	return x * x + y * y;
 }
 
-void Vector2::normalize() {
+int Vector2::min_axis() const {
+	return x < y ? AXIS_X : AXIS_Y;
+}
 
+int Vector2::max_axis() const {
+	return x < y ? AXIS_Y : AXIS_X;
+}
+
+void Vector2::normalize() {
 	real_t l = x * x + y * y;
 	if (l != 0) {
-
 		l = Math::sqrt(l);
 		x /= l;
 		y /= l;
@@ -57,7 +60,6 @@ void Vector2::normalize() {
 }
 
 Vector2 Vector2::normalized() const {
-
 	Vector2 v = *this;
 	v.normalize();
 	return v;
@@ -68,58 +70,51 @@ bool Vector2::is_normalized() const {
 	return Math::is_equal_approx(length_squared(), 1.0, UNIT_EPSILON);
 }
 
-real_t Vector2::distance_to(const Vector2 &p_vector2) const {
+Vector2 Vector2::inverse() const {
+	return Vector2(1.0 / x, 1.0 / y);
+}
 
+real_t Vector2::distance_to(const Vector2 &p_vector2) const {
 	return Math::sqrt((x - p_vector2.x) * (x - p_vector2.x) + (y - p_vector2.y) * (y - p_vector2.y));
 }
 
 real_t Vector2::distance_squared_to(const Vector2 &p_vector2) const {
-
 	return (x - p_vector2.x) * (x - p_vector2.x) + (y - p_vector2.y) * (y - p_vector2.y);
 }
 
 real_t Vector2::angle_to(const Vector2 &p_vector2) const {
-
 	return Math::atan2(cross(p_vector2), dot(p_vector2));
 }
 
 real_t Vector2::angle_to_point(const Vector2 &p_vector2) const {
-
 	return Math::atan2(y - p_vector2.y, x - p_vector2.x);
 }
 
 real_t Vector2::dot(const Vector2 &p_other) const {
-
 	return x * p_other.x + y * p_other.y;
 }
 
 real_t Vector2::cross(const Vector2 &p_other) const {
-
 	return x * p_other.y - y * p_other.x;
 }
 
 Vector2 Vector2::sign() const {
-
 	return Vector2(SGN(x), SGN(y));
 }
 
 Vector2 Vector2::floor() const {
-
 	return Vector2(Math::floor(x), Math::floor(y));
 }
 
 Vector2 Vector2::ceil() const {
-
 	return Vector2(Math::ceil(x), Math::ceil(y));
 }
 
 Vector2 Vector2::round() const {
-
 	return Vector2(Math::round(x), Math::round(y));
 }
 
 Vector2 Vector2::rotated(real_t p_by) const {
-
 	Vector2 v;
 	v.set_rotation(angle() + p_by);
 	v *= length();
@@ -139,27 +134,24 @@ Vector2 Vector2::project(const Vector2 &p_b) const {
 }
 
 Vector2 Vector2::snapped(const Vector2 &p_by) const {
-
 	return Vector2(
 			Math::stepify(x, p_by.x),
 			Math::stepify(y, p_by.y));
 }
 
 Vector2 Vector2::clamped(real_t p_len) const {
-
-	real_t l = length();
 	Vector2 v = *this;
-	if (l > 0 && p_len < l) {
-
-		v /= l;
-		v *= p_len;
+	real_t len_squared = length_squared();
+	if (len_squared > 0) {
+		if (len_squared > p_len * p_len) {
+			real_t len = Math::sqrt(len_squared);
+			v *= (p_len / len);
+		}
 	}
-
 	return v;
 }
 
 Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_t) const {
-
 	Vector2 p0 = p_pre_a;
 	Vector2 p1 = *this;
 	Vector2 p2 = p_b;
@@ -206,65 +198,57 @@ Vector2 Vector2::reflect(const Vector2 &p_normal) const {
 /* Vector2i */
 
 Vector2i Vector2i::operator+(const Vector2i &p_v) const {
-
 	return Vector2i(x + p_v.x, y + p_v.y);
 }
-void Vector2i::operator+=(const Vector2i &p_v) {
 
+void Vector2i::operator+=(const Vector2i &p_v) {
 	x += p_v.x;
 	y += p_v.y;
 }
-Vector2i Vector2i::operator-(const Vector2i &p_v) const {
 
+Vector2i Vector2i::operator-(const Vector2i &p_v) const {
 	return Vector2i(x - p_v.x, y - p_v.y);
 }
-void Vector2i::operator-=(const Vector2i &p_v) {
 
+void Vector2i::operator-=(const Vector2i &p_v) {
 	x -= p_v.x;
 	y -= p_v.y;
 }
 
 Vector2i Vector2i::operator*(const Vector2i &p_v1) const {
-
 	return Vector2i(x * p_v1.x, y * p_v1.y);
-};
+}
 
 Vector2i Vector2i::operator*(const int &rvalue) const {
-
 	return Vector2i(x * rvalue, y * rvalue);
-};
-void Vector2i::operator*=(const int &rvalue) {
+}
 
+void Vector2i::operator*=(const int &rvalue) {
 	x *= rvalue;
 	y *= rvalue;
-};
+}
 
 Vector2i Vector2i::operator/(const Vector2i &p_v1) const {
-
 	return Vector2i(x / p_v1.x, y / p_v1.y);
-};
+}
 
 Vector2i Vector2i::operator/(const int &rvalue) const {
-
 	return Vector2i(x / rvalue, y / rvalue);
-};
+}
 
 void Vector2i::operator/=(const int &rvalue) {
-
 	x /= rvalue;
 	y /= rvalue;
-};
+}
 
 Vector2i Vector2i::operator-() const {
-
 	return Vector2i(-x, -y);
 }
 
 bool Vector2i::operator==(const Vector2i &p_vec2) const {
-
 	return x == p_vec2.x && y == p_vec2.y;
 }
-bool Vector2i::operator!=(const Vector2i &p_vec2) const {
 
+bool Vector2i::operator!=(const Vector2i &p_vec2) const {
 	return x != p_vec2.x || y != p_vec2.y;
 }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -63,8 +63,13 @@ struct Vector2 {
 	Vector2 normalized() const;
 	bool is_normalized() const;
 
+	Vector2 inverse() const;
+
 	real_t length() const;
 	real_t length_squared() const;
+
+	int min_axis() const;
+	int max_axis() const;
 
 	real_t distance_to(const Vector2 &p_vector2) const;
 	real_t distance_squared_to(const Vector2 &p_vector2) const;
@@ -122,19 +127,16 @@ struct Vector2 {
 	real_t angle() const;
 
 	void set_rotation(real_t p_radians) {
-
 		x = Math::cos(p_radians);
 		y = Math::sin(p_radians);
 	}
 
 	_FORCE_INLINE_ Vector2 abs() const {
-
 		return Vector2(Math::abs(x), Math::abs(y));
 	}
 
 	Vector2 rotated(real_t p_by) const;
 	Vector2 tangent() const {
-
 		return Vector2(y, -x);
 	}
 
@@ -155,81 +157,70 @@ struct Vector2 {
 };
 
 _FORCE_INLINE_ Vector2 Vector2::plane_project(real_t p_d, const Vector2 &p_vec) const {
-
 	return p_vec - *this * (dot(p_vec) - p_d);
 }
 
 _FORCE_INLINE_ Vector2 operator*(real_t p_scalar, const Vector2 &p_vec) {
-
 	return p_vec * p_scalar;
 }
 
 _FORCE_INLINE_ Vector2 Vector2::operator+(const Vector2 &p_v) const {
-
 	return Vector2(x + p_v.x, y + p_v.y);
 }
-_FORCE_INLINE_ void Vector2::operator+=(const Vector2 &p_v) {
 
+_FORCE_INLINE_ void Vector2::operator+=(const Vector2 &p_v) {
 	x += p_v.x;
 	y += p_v.y;
 }
-_FORCE_INLINE_ Vector2 Vector2::operator-(const Vector2 &p_v) const {
 
+_FORCE_INLINE_ Vector2 Vector2::operator-(const Vector2 &p_v) const {
 	return Vector2(x - p_v.x, y - p_v.y);
 }
-_FORCE_INLINE_ void Vector2::operator-=(const Vector2 &p_v) {
 
+_FORCE_INLINE_ void Vector2::operator-=(const Vector2 &p_v) {
 	x -= p_v.x;
 	y -= p_v.y;
 }
 
 _FORCE_INLINE_ Vector2 Vector2::operator*(const Vector2 &p_v1) const {
-
 	return Vector2(x * p_v1.x, y * p_v1.y);
-};
+}
 
 _FORCE_INLINE_ Vector2 Vector2::operator*(const real_t &rvalue) const {
-
 	return Vector2(x * rvalue, y * rvalue);
-};
-_FORCE_INLINE_ void Vector2::operator*=(const real_t &rvalue) {
+}
 
+_FORCE_INLINE_ void Vector2::operator*=(const real_t &rvalue) {
 	x *= rvalue;
 	y *= rvalue;
-};
+}
 
 _FORCE_INLINE_ Vector2 Vector2::operator/(const Vector2 &p_v1) const {
-
 	return Vector2(x / p_v1.x, y / p_v1.y);
-};
+}
 
 _FORCE_INLINE_ Vector2 Vector2::operator/(const real_t &rvalue) const {
-
 	return Vector2(x / rvalue, y / rvalue);
-};
+}
 
 _FORCE_INLINE_ void Vector2::operator/=(const real_t &rvalue) {
-
 	x /= rvalue;
 	y /= rvalue;
-};
+}
 
 _FORCE_INLINE_ Vector2 Vector2::operator-() const {
-
 	return Vector2(-x, -y);
 }
 
 _FORCE_INLINE_ bool Vector2::operator==(const Vector2 &p_vec2) const {
-
 	return Math::is_equal_approx(x, p_vec2.x) && Math::is_equal_approx(y, p_vec2.y);
 }
-_FORCE_INLINE_ bool Vector2::operator!=(const Vector2 &p_vec2) const {
 
+_FORCE_INLINE_ bool Vector2::operator!=(const Vector2 &p_vec2) const {
 	return !Math::is_equal_approx(x, p_vec2.x) || !Math::is_equal_approx(y, p_vec2.y);
 }
 
 Vector2 Vector2::linear_interpolate(const Vector2 &p_b, real_t p_t) const {
-
 	Vector2 res = *this;
 
 	res.x += (p_t * (p_b.x - x));
@@ -253,7 +244,6 @@ Vector2 Vector2::direction_to(const Vector2 &p_b) const {
 }
 
 Vector2 Vector2::linear_interpolate(const Vector2 &p_a, const Vector2 &p_b, real_t p_t) {
-
 	Vector2 res = p_a;
 
 	res.x += (p_t * (p_b.x - p_a.x));

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -33,12 +33,10 @@
 #include "core/math/basis.h"
 
 void Vector3::rotate(const Vector3 &p_axis, real_t p_phi) {
-
 	*this = Basis(p_axis, p_phi).xform(*this);
 }
 
 Vector3 Vector3::rotated(const Vector3 &p_axis, real_t p_phi) const {
-
 	Vector3 r = *this;
 	r.rotate(p_axis, p_phi);
 	return r;
@@ -48,36 +46,33 @@ void Vector3::set_axis(int p_axis, real_t p_value) {
 	ERR_FAIL_INDEX(p_axis, 3);
 	coord[p_axis] = p_value;
 }
-real_t Vector3::get_axis(int p_axis) const {
 
+real_t Vector3::get_axis(int p_axis) const {
 	ERR_FAIL_INDEX_V(p_axis, 3, 0);
 	return operator[](p_axis);
 }
 
 int Vector3::min_axis() const {
-
-	return x < y ? (x < z ? 0 : 2) : (y < z ? 1 : 2);
+	return x < y ? (x < z ? AXIS_X : AXIS_Z) : (y < z ? AXIS_Y : AXIS_Z);
 }
-int Vector3::max_axis() const {
 
-	return x < y ? (y < z ? 2 : 1) : (x < z ? 2 : 0);
+int Vector3::max_axis() const {
+	return x < y ? (y < z ? AXIS_Z : AXIS_Y) : (x < z ? AXIS_Z : AXIS_X);
 }
 
 void Vector3::snap(Vector3 p_val) {
-
 	x = Math::stepify(x, p_val.x);
 	y = Math::stepify(y, p_val.y);
 	z = Math::stepify(z, p_val.z);
 }
-Vector3 Vector3::snapped(Vector3 p_val) const {
 
+Vector3 Vector3::snapped(Vector3 p_val) const {
 	Vector3 v = *this;
 	v.snap(p_val);
 	return v;
 }
 
 Vector3 Vector3::cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_t) const {
-
 	Vector3 p0 = p_pre_a;
 	Vector3 p1 = *this;
 	Vector3 p2 = p_b;
@@ -90,10 +85,13 @@ Vector3 Vector3::cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, 
 		real_t bc = p1.distance_to(p2);
 		real_t cd = p2.distance_to(p3);
 
-		if (ab > 0)
+		if (ab > 0) {
 			p0 = p1 + (p0 - p1) * (bc / ab);
-		if (cd > 0)
+		}
+
+		if (cd > 0) {
 			p3 = p2 + (p3 - p2) * (bc / cd);
+		}
 	}
 
 	real_t t = p_t;
@@ -109,7 +107,6 @@ Vector3 Vector3::cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, 
 }
 
 Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_t) const {
-
 	Vector3 p0 = p_pre_a;
 	Vector3 p1 = *this;
 	Vector3 p2 = p_b;
@@ -135,7 +132,6 @@ Vector3 Vector3::move_toward(const Vector3 &p_to, const real_t p_delta) const {
 }
 
 Basis Vector3::outer(const Vector3 &p_b) const {
-
 	Vector3 row0(x * p_b.x, x * p_b.y, x * p_b.z);
 	Vector3 row1(y * p_b.x, y * p_b.y, y * p_b.z);
 	Vector3 row2(z * p_b.x, z * p_b.y, z * p_b.z);
@@ -149,7 +145,18 @@ Basis Vector3::to_diagonal_matrix() const {
 			0, 0, z);
 }
 
-Vector3::operator String() const {
+Vector3 Vector3::clamped(real_t p_len) const {
+	Vector3 v = *this;
+	real_t len_squared = length_squared();
+	if (len_squared > 0) {
+		if (len_squared > p_len * p_len) {
+			real_t len = Math::sqrt(len_squared);
+			v *= (p_len / len);
+		}
+	}
+	return v;
+}
 
+Vector3::operator String() const {
 	return (rtos(x) + ", " + rtos(y) + ", " + rtos(z));
 }

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -55,12 +55,10 @@ struct Vector3 {
 	};
 
 	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
-
 		return coord[p_axis];
 	}
 
 	_FORCE_INLINE_ real_t &operator[](int p_axis) {
-
 		return coord[p_axis];
 	}
 
@@ -98,6 +96,8 @@ struct Vector3 {
 	_FORCE_INLINE_ real_t dot(const Vector3 &p_b) const;
 	Basis outer(const Vector3 &p_b) const;
 	Basis to_diagonal_matrix() const;
+
+	Vector3 clamped(real_t p_len) const;
 
 	_FORCE_INLINE_ Vector3 abs() const;
 	_FORCE_INLINE_ Vector3 floor() const;
@@ -155,7 +155,6 @@ struct Vector3 {
 };
 
 Vector3 Vector3::cross(const Vector3 &p_b) const {
-
 	Vector3 ret(
 			(y * p_b.z) - (z * p_b.y),
 			(z * p_b.x) - (x * p_b.z),
@@ -165,37 +164,30 @@ Vector3 Vector3::cross(const Vector3 &p_b) const {
 }
 
 real_t Vector3::dot(const Vector3 &p_b) const {
-
 	return x * p_b.x + y * p_b.y + z * p_b.z;
 }
 
 Vector3 Vector3::abs() const {
-
 	return Vector3(Math::abs(x), Math::abs(y), Math::abs(z));
 }
 
 Vector3 Vector3::sign() const {
-
 	return Vector3(SGN(x), SGN(y), SGN(z));
 }
 
 Vector3 Vector3::floor() const {
-
 	return Vector3(Math::floor(x), Math::floor(y), Math::floor(z));
 }
 
 Vector3 Vector3::ceil() const {
-
 	return Vector3(Math::ceil(x), Math::ceil(y), Math::ceil(z));
 }
 
 Vector3 Vector3::round() const {
-
 	return Vector3(Math::round(x), Math::round(y), Math::round(z));
 }
 
 Vector3 Vector3::linear_interpolate(const Vector3 &p_b, real_t p_t) const {
-
 	return Vector3(
 			x + (p_t * (p_b.x - x)),
 			y + (p_t * (p_b.y - y)),
@@ -208,12 +200,10 @@ Vector3 Vector3::slerp(const Vector3 &p_b, real_t p_t) const {
 }
 
 real_t Vector3::distance_to(const Vector3 &p_b) const {
-
 	return (p_b - *this).length();
 }
 
 real_t Vector3::distance_squared_to(const Vector3 &p_b) const {
-
 	return (p_b - *this).length_squared();
 }
 
@@ -230,7 +220,6 @@ Vector3 Vector3::project(const Vector3 &p_b) const {
 }
 
 real_t Vector3::angle_to(const Vector3 &p_b) const {
-
 	return Math::atan2(cross(p_b).length(), dot(p_b));
 }
 
@@ -243,7 +232,6 @@ Vector3 Vector3::direction_to(const Vector3 &p_b) const {
 /* Operators */
 
 Vector3 &Vector3::operator+=(const Vector3 &p_v) {
-
 	x += p_v.x;
 	y += p_v.y;
 	z += p_v.z;
@@ -251,36 +239,32 @@ Vector3 &Vector3::operator+=(const Vector3 &p_v) {
 }
 
 Vector3 Vector3::operator+(const Vector3 &p_v) const {
-
 	return Vector3(x + p_v.x, y + p_v.y, z + p_v.z);
 }
 
 Vector3 &Vector3::operator-=(const Vector3 &p_v) {
-
 	x -= p_v.x;
 	y -= p_v.y;
 	z -= p_v.z;
 	return *this;
 }
-Vector3 Vector3::operator-(const Vector3 &p_v) const {
 
+Vector3 Vector3::operator-(const Vector3 &p_v) const {
 	return Vector3(x - p_v.x, y - p_v.y, z - p_v.z);
 }
 
 Vector3 &Vector3::operator*=(const Vector3 &p_v) {
-
 	x *= p_v.x;
 	y *= p_v.y;
 	z *= p_v.z;
 	return *this;
 }
-Vector3 Vector3::operator*(const Vector3 &p_v) const {
 
+Vector3 Vector3::operator*(const Vector3 &p_v) const {
 	return Vector3(x * p_v.x, y * p_v.y, z * p_v.z);
 }
 
 Vector3 &Vector3::operator/=(const Vector3 &p_v) {
-
 	x /= p_v.x;
 	y /= p_v.y;
 	z /= p_v.z;
@@ -288,12 +272,10 @@ Vector3 &Vector3::operator/=(const Vector3 &p_v) {
 }
 
 Vector3 Vector3::operator/(const Vector3 &p_v) const {
-
 	return Vector3(x / p_v.x, y / p_v.y, z / p_v.z);
 }
 
 Vector3 &Vector3::operator*=(real_t p_scalar) {
-
 	x *= p_scalar;
 	y *= p_scalar;
 	z *= p_scalar;
@@ -301,17 +283,14 @@ Vector3 &Vector3::operator*=(real_t p_scalar) {
 }
 
 _FORCE_INLINE_ Vector3 operator*(real_t p_scalar, const Vector3 &p_vec) {
-
 	return p_vec * p_scalar;
 }
 
 Vector3 Vector3::operator*(real_t p_scalar) const {
-
 	return Vector3(x * p_scalar, y * p_scalar, z * p_scalar);
 }
 
 Vector3 &Vector3::operator/=(real_t p_scalar) {
-
 	x /= p_scalar;
 	y /= p_scalar;
 	z /= p_scalar;
@@ -319,17 +298,14 @@ Vector3 &Vector3::operator/=(real_t p_scalar) {
 }
 
 Vector3 Vector3::operator/(real_t p_scalar) const {
-
 	return Vector3(x / p_scalar, y / p_scalar, z / p_scalar);
 }
 
 Vector3 Vector3::operator-() const {
-
 	return Vector3(-x, -y, -z);
 }
 
 bool Vector3::operator==(const Vector3 &p_v) const {
-
 	return (Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y) && Math::is_equal_approx(z, p_v.z));
 }
 
@@ -338,65 +314,62 @@ bool Vector3::operator!=(const Vector3 &p_v) const {
 }
 
 bool Vector3::operator<(const Vector3 &p_v) const {
-
 	if (Math::is_equal_approx(x, p_v.x)) {
-		if (Math::is_equal_approx(y, p_v.y))
+		if (Math::is_equal_approx(y, p_v.y)) {
 			return z < p_v.z;
-		else
+		} else {
 			return y < p_v.y;
+		}
 	} else {
 		return x < p_v.x;
 	}
 }
 
 bool Vector3::operator>(const Vector3 &p_v) const {
-
 	if (Math::is_equal_approx(x, p_v.x)) {
-		if (Math::is_equal_approx(y, p_v.y))
+		if (Math::is_equal_approx(y, p_v.y)) {
 			return z > p_v.z;
-		else
+		} else {
 			return y > p_v.y;
+		}
 	} else {
 		return x > p_v.x;
 	}
 }
 
 bool Vector3::operator<=(const Vector3 &p_v) const {
-
 	if (Math::is_equal_approx(x, p_v.x)) {
-		if (Math::is_equal_approx(y, p_v.y))
+		if (Math::is_equal_approx(y, p_v.y)) {
 			return z <= p_v.z;
-		else
+		} else {
 			return y < p_v.y;
+		}
 	} else {
 		return x < p_v.x;
 	}
 }
 
 bool Vector3::operator>=(const Vector3 &p_v) const {
-
 	if (Math::is_equal_approx(x, p_v.x)) {
-		if (Math::is_equal_approx(y, p_v.y))
+		if (Math::is_equal_approx(y, p_v.y)) {
 			return z >= p_v.z;
-		else
+		} else {
 			return y > p_v.y;
+		}
 	} else {
 		return x > p_v.x;
 	}
 }
 
 _FORCE_INLINE_ Vector3 vec3_cross(const Vector3 &p_a, const Vector3 &p_b) {
-
 	return p_a.cross(p_b);
 }
 
 _FORCE_INLINE_ real_t vec3_dot(const Vector3 &p_a, const Vector3 &p_b) {
-
 	return p_a.dot(p_b);
 }
 
 real_t Vector3::length() const {
-
 	real_t x2 = x * x;
 	real_t y2 = y * y;
 	real_t z2 = z * z;
@@ -405,7 +378,6 @@ real_t Vector3::length() const {
 }
 
 real_t Vector3::length_squared() const {
-
 	real_t x2 = x * x;
 	real_t y2 = y * y;
 	real_t z2 = z * z;
@@ -414,7 +386,6 @@ real_t Vector3::length_squared() const {
 }
 
 void Vector3::normalize() {
-
 	real_t lengthsq = length_squared();
 	if (lengthsq == 0) {
 		x = y = z = 0;
@@ -427,7 +398,6 @@ void Vector3::normalize() {
 }
 
 Vector3 Vector3::normalized() const {
-
 	Vector3 v = *this;
 	v.normalize();
 	return v;
@@ -439,12 +409,10 @@ bool Vector3::is_normalized() const {
 }
 
 Vector3 Vector3::inverse() const {
-
 	return Vector3(1.0 / x, 1.0 / y, 1.0 / z);
 }
 
 void Vector3::zero() {
-
 	x = y = z = 0;
 }
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -354,7 +354,10 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(Vector2, normalized);
 	VCALL_LOCALMEM0R(Vector2, length);
 	VCALL_LOCALMEM0R(Vector2, length_squared);
+	VCALL_LOCALMEM0R(Vector2, min_axis);
+	VCALL_LOCALMEM0R(Vector2, max_axis);
 	VCALL_LOCALMEM0R(Vector2, is_normalized);
+	VCALL_LOCALMEM0R(Vector2, inverse);
 	VCALL_LOCALMEM1R(Vector2, distance_to);
 	VCALL_LOCALMEM1R(Vector2, distance_squared_to);
 	VCALL_LOCALMEM1R(Vector2, posmod);
@@ -414,6 +417,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1R(Vector3, cross);
 	VCALL_LOCALMEM1R(Vector3, outer);
 	VCALL_LOCALMEM0R(Vector3, to_diagonal_matrix);
+	VCALL_LOCALMEM1R(Vector3, clamped);
 	VCALL_LOCALMEM0R(Vector3, abs);
 	VCALL_LOCALMEM0R(Vector3, floor);
 	VCALL_LOCALMEM0R(Vector3, ceil);
@@ -1611,7 +1615,10 @@ void register_variant_methods() {
 	ADDFUNC0R(VECTOR2, REAL, Vector2, length, varray());
 	ADDFUNC0R(VECTOR2, REAL, Vector2, angle, varray());
 	ADDFUNC0R(VECTOR2, REAL, Vector2, length_squared, varray());
+	ADDFUNC0R(VECTOR2, INT, Vector2, min_axis, varray());
+	ADDFUNC0R(VECTOR2, INT, Vector2, max_axis, varray());
 	ADDFUNC0R(VECTOR2, BOOL, Vector2, is_normalized, varray());
+	ADDFUNC0R(VECTOR2, VECTOR2, Vector2, inverse, varray());
 	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, direction_to, VECTOR2, "b", varray());
 	ADDFUNC1R(VECTOR2, REAL, Vector2, distance_to, VECTOR2, "to", varray());
 	ADDFUNC1R(VECTOR2, REAL, Vector2, distance_squared_to, VECTOR2, "to", varray());
@@ -1671,6 +1678,7 @@ void register_variant_methods() {
 	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, cross, VECTOR3, "b", varray());
 	ADDFUNC1R(VECTOR3, BASIS, Vector3, outer, VECTOR3, "b", varray());
 	ADDFUNC0R(VECTOR3, BASIS, Vector3, to_diagonal_matrix, varray());
+	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, clamped, REAL, "length", varray());
 	ADDFUNC0R(VECTOR3, VECTOR3, Vector3, abs, varray());
 	ADDFUNC0R(VECTOR3, VECTOR3, Vector3, floor, varray());
 	ADDFUNC0R(VECTOR3, VECTOR3, Vector3, ceil, varray());

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -153,6 +153,13 @@
 				Returns the vector with all components rounded down.
 			</description>
 		</method>
+		<method name="inverse">
+			<return type="Vector2">
+			</return>
+			<description>
+				Returns the inverse of the vector. This is the same as [code]Vector2( 1.0 / v.x, 1.0 / v.y )[/code].
+			</description>
+		</method>
 		<method name="is_normalized">
 			<return type="bool">
 			</return>
@@ -183,6 +190,20 @@
 			</argument>
 			<description>
 				Returns the result of the linear interpolation between this vector and [code]b[/code] by amount [code]t[/code]. [code]t[/code] is in the range of [code]0.0 - 1.0[/code], representing the amount of interpolation.
+			</description>
+		</method>
+		<method name="max_axis">
+			<return type="int">
+			</return>
+			<description>
+				Returns the axis of the vector's largest value. See [code]AXIS_*[/code] constants.
+			</description>
+		</method>
+		<method name="min_axis">
+			<return type="int">
+			</return>
+			<description>
+				Returns the axis of the vector's smallest value. See [code]AXIS_*[/code] constants.
 			</description>
 		</method>
 		<method name="move_toward">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -55,6 +55,15 @@
 				Returns a new vector with all components rounded up.
 			</description>
 		</method>
+		<method name="clamped">
+			<return type="Vector3">
+			</return>
+			<argument index="0" name="length" type="float">
+			</argument>
+			<description>
+				Returns the vector with a maximum length.
+			</description>
+		</method>
 		<method name="cross">
 			<return type="Vector3">
 			</return>

--- a/modules/gdnative/gdnative/vector2.cpp
+++ b/modules/gdnative/gdnative/vector2.cpp
@@ -77,6 +77,23 @@ godot_bool GDAPI godot_vector2_is_normalized(const godot_vector2 *p_self) {
 	return self->is_normalized();
 }
 
+godot_vector2 GDAPI godot_vector2_inverse(const godot_vector2 *p_self) {
+	godot_vector2 dest;
+	const Vector2 *self = (const Vector2 *)p_self;
+	*((Vector2 *)&dest) = self->inverse();
+	return dest;
+}
+
+godot_int GDAPI godot_vector2_min_axis(const godot_vector2 *p_self) {
+	const Vector2 *self = (const Vector2 *)p_self;
+	return self->min_axis();
+}
+
+godot_int GDAPI godot_vector2_max_axis(const godot_vector2 *p_self) {
+	const Vector2 *self = (const Vector2 *)p_self;
+	return self->max_axis();
+}
+
 godot_vector2 GDAPI godot_vector2_direction_to(const godot_vector2 *p_self, const godot_vector2 *p_to) {
 	godot_vector2 dest;
 	const Vector2 *self = (const Vector2 *)p_self;

--- a/modules/gdnative/gdnative/vector3.cpp
+++ b/modules/gdnative/gdnative/vector3.cpp
@@ -89,6 +89,14 @@ godot_vector3 GDAPI godot_vector3_inverse(const godot_vector3 *p_self) {
 	return dest;
 }
 
+godot_vector3 GDAPI godot_vector3_clamped(const godot_vector3 *p_self, const godot_real p_length) {
+	godot_vector3 dest;
+	const Vector3 *self = (const Vector3 *)p_self;
+
+	*((Vector3 *)&dest) = self->clamped(p_length);
+	return dest;
+}
+
 godot_vector3 GDAPI godot_vector3_snapped(const godot_vector3 *p_self, const godot_vector3 *p_by) {
 	godot_vector3 dest;
 	const Vector3 *self = (const Vector3 *)p_self;

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -621,6 +621,27 @@
         ]
       },
       {
+        "name": "godot_vector2_inverse",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_min_axis",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_max_axis",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_vector2_distance_to",
         "return_type": "godot_real",
         "arguments": [
@@ -1372,6 +1393,14 @@
         "return_type": "godot_vector3",
         "arguments": [
           ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_clamped",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_real", "p_length"]
         ]
       },
       {

--- a/modules/gdnative/include/gdnative/vector2.h
+++ b/modules/gdnative/include/gdnative/vector2.h
@@ -71,6 +71,12 @@ godot_real GDAPI godot_vector2_length_squared(const godot_vector2 *p_self);
 
 godot_bool GDAPI godot_vector2_is_normalized(const godot_vector2 *p_self);
 
+godot_vector2 GDAPI godot_vector2_inverse(const godot_vector2 *p_self);
+
+godot_int GDAPI godot_vector2_min_axis(const godot_vector2 *p_self);
+
+godot_int GDAPI godot_vector2_max_axis(const godot_vector2 *p_self);
+
 godot_vector2 GDAPI godot_vector2_direction_to(const godot_vector2 *p_self, const godot_vector2 *p_b);
 
 godot_real GDAPI godot_vector2_distance_to(const godot_vector2 *p_self, const godot_vector2 *p_to);

--- a/modules/gdnative/include/gdnative/vector3.h
+++ b/modules/gdnative/include/gdnative/vector3.h
@@ -82,6 +82,8 @@ godot_vector3 GDAPI godot_vector3_normalized(const godot_vector3 *p_self);
 
 godot_vector3 GDAPI godot_vector3_inverse(const godot_vector3 *p_self);
 
+godot_vector3 GDAPI godot_vector3_clamped(const godot_vector3 *p_self, const godot_real p_length);
+
 godot_vector3 GDAPI godot_vector3_snapped(const godot_vector3 *p_self, const godot_vector3 *p_by);
 
 godot_vector3 GDAPI godot_vector3_rotated(const godot_vector3 *p_self, const godot_vector3 *p_axis, const godot_real p_phi);

--- a/modules/mono/glue/Managed/Files/Vector2.cs
+++ b/modules/mono/glue/Managed/Files/Vector2.cs
@@ -119,14 +119,15 @@ namespace Godot
         public Vector2 Clamped(real_t length)
         {
             var v = this;
-            real_t l = Length();
-
-            if (l > 0 && length < l)
+            real_t len_squared = LengthSquared();
+            if (len_squared > 0)
             {
-                v /= l;
-                v *= length;
+                if (len_squared > length * length)
+                {
+                    real_t len = Mathf.Sqrt(len_squared);
+                    v *= (length / len);
+                }
             }
-
             return v;
         }
 
@@ -171,6 +172,11 @@ namespace Godot
             return new Vector2(Mathf.Floor(x), Mathf.Floor(y));
         }
 
+        public Vector2 Inverse()
+        {
+            return new Vector2(1.0 / x, 1.0 / y);
+        }
+
         public bool IsNormalized()
         {
             return Mathf.Abs(LengthSquared() - 1.0f) < Mathf.Epsilon;
@@ -184,6 +190,16 @@ namespace Godot
         public real_t LengthSquared()
         {
             return x * x + y * y;
+        }
+
+        public Axis MaxAxis()
+        {
+            return x < y ? Axis.Y : Axis.X;
+        }
+
+        public Axis MinAxis()
+        {
+            return x < y ? Axis.X : Axis.Y;
         }
 
         public Vector2 LinearInterpolate(Vector2 b, real_t t)

--- a/modules/mono/glue/Managed/Files/Vector3.cs
+++ b/modules/mono/glue/Managed/Files/Vector3.cs
@@ -104,6 +104,21 @@ namespace Godot
             return new Vector3(Mathf.Ceil(x), Mathf.Ceil(y), Mathf.Ceil(z));
         }
 
+        public Vector3 Clamped(real_t length)
+        {
+            var v = this;
+            real_t len_squared = LengthSquared();
+            if (len_squared > 0)
+            {
+                if (len_squared > length * length)
+                {
+                    real_t len = Mathf.Sqrt(len_squared);
+                    v *= (length / len);
+                }
+            }
+            return v;
+        }
+
         public Vector3 Cross(Vector3 b)
         {
             return new Vector3


### PR DESCRIPTION
This change adds a few missing functions to `Vector2` and `Vector3` to make their functionalities similar. The code has been also cleaned to follow the new coding rules.

New methods in Vector2 (from Vector3):
`Vector2 Vector2::inverse()`
`int Vector2::min_axis()`
`int Vector2::max_axis()`

New method in Vector3 (from Vector2):
`Vector3 Vector3::clamped(float length)`

These new methods are exposed to gdscript/gdnative and the doc is updated.