### PR TITLE
Folders in FileSystem are not expanded on project save anymore

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -71,11 +71,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 		subdirectory_item->select(0);
 	}
 
-	if ((path.begins_with(lpath) && path != lpath)) {
-		subdirectory_item->set_collapsed(false);
-	} else {
-		subdirectory_item->set_collapsed(uncollapsed_paths.find(lpath) < 0);
-	}
+	subdirectory_item->set_collapsed(uncollapsed_paths.find(lpath) < 0);
 	if (searched_string.length() > 0 && dname.to_lower().find(searched_string) >= 0) {
 		parent_should_expand = true;
 	}


### PR DESCRIPTION
If an item was selected in the FileSystem dock and its parent
was collapsed the folder would be expanded when saving the project.

Fixes #27525