### PR TITLE
Add selective generation for navigation mesh spans

### DIFF
--- a/editor/icons/icon_gizmo_navigation_walkable_marker.svg
+++ b/editor/icons/icon_gizmo_navigation_walkable_marker.svg
@@ -1,0 +1,28 @@
+<svg width="128" height="128" version="1.1" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 -924.36)">
+<g transform="translate(2.3875 -1.9542)" fill="#f7f5cf" stroke="#000" stroke-opacity=".29412" stroke-width="4.6">
+<g transform="matrix(.71838 0 0 .71838 -121.07 312.9)" style="paint-order:stroke markers fill">
+<path d="m237.69 1021.4c-4.4477 7.3236-17.12 0.9312-25.688 0.9312s-21.24 6.3924-25.688-0.9312c-4.5795-7.5399 6.9169-16.281 11.345-23.912 4.197-7.2321 5.9809-20.58 14.343-20.58s10.146 13.348 14.343 20.58c4.428 7.6308 15.924 16.372 11.345 23.912z" stroke-width="4.6" style="paint-order:stroke markers fill"/>
+<g transform="matrix(5.864 0 0 5.864 164.06 937.71)" stroke-width=".78445" style="paint-order:stroke markers fill">
+<ellipse cx="5.7961" cy="3.5861" rx="1.4552" ry="2.4739" style="paint-order:stroke markers fill"/>
+<ellipse cx="10.556" cy="3.5406" rx="1.4552" ry="2.4739" style="paint-order:stroke markers fill"/>
+</g>
+<g transform="matrix(5.864 0 0 5.864 163.8 937.71)" stroke-width=".78445" style="paint-order:stroke markers fill">
+<ellipse cx="2.854" cy="7.7244" rx="1.4552" ry="2.4739" style="paint-order:stroke markers fill"/>
+<ellipse cx="13.586" cy="7.7244" rx="1.4552" ry="2.4739" style="paint-order:stroke markers fill"/>
+</g>
+</g>
+<g transform="matrix(.71838 0 0 .71838 -60.297 253.3)" style="paint-order:stroke markers fill">
+<path d="m237.69 1021.4c-4.4477 7.3236-17.12 0.9312-25.688 0.9312s-21.24 6.3924-25.688-0.9312c-4.5795-7.5399 6.9169-16.281 11.345-23.912 4.197-7.2321 5.9809-20.58 14.343-20.58s10.146 13.348 14.343 20.58c4.428 7.6308 15.924 16.372 11.345 23.912z" stroke-width="4.6" style="paint-order:stroke markers fill"/>
+<g transform="matrix(5.864 0 0 5.864 164.06 937.71)" stroke-width=".78445" style="paint-order:stroke markers fill">
+<ellipse cx="5.7961" cy="3.5861" rx="1.4552" ry="2.4739" style="paint-order:stroke markers fill"/>
+<ellipse cx="10.556" cy="3.5406" rx="1.4552" ry="2.4739" style="paint-order:stroke markers fill"/>
+</g>
+<g transform="matrix(5.864 0 0 5.864 163.8 937.71)" stroke-width=".78445" style="paint-order:stroke markers fill">
+<ellipse cx="2.854" cy="7.7244" rx="1.4552" ry="2.4739" style="paint-order:stroke markers fill"/>
+<ellipse cx="13.586" cy="7.7244" rx="1.4552" ry="2.4739" style="paint-order:stroke markers fill"/>
+</g>
+</g>
+</g>
+</g>
+</svg>

--- a/editor/icons/icon_navigation_walkable_marker.svg
+++ b/editor/icons/icon_navigation_walkable_marker.svg
@@ -1,0 +1,11 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<path d="m12.381 14.278c-0.75847 1.2489-2.9194 0.15873-4.3806 0.15873s-3.6221 1.0901-4.3806-0.15873c-0.78095-1.2859 1.1796-2.7765 1.9347-4.0777 0.71573-1.2333 1.0199-3.5097 2.4459-3.5097s1.7302 2.2764 2.4459 3.5097c0.75512 1.3012 2.7156 2.7918 1.9347 4.0777z" fill="#fc9c9c" fill-opacity=".99608" style="paint-order:markers stroke fill"/>
+<g transform="translate(-.17592)" fill="#fc9c9c" fill-opacity=".99608">
+<ellipse cx="5.7961" cy="3.5861" rx="1.4552" ry="2.4739" style="paint-order:markers stroke fill"/>
+<ellipse cx="10.556" cy="3.5406" rx="1.4552" ry="2.4739" style="paint-order:markers stroke fill"/>
+</g>
+<g transform="translate(-.22012)" fill="#fc9c9c" fill-opacity=".99608">
+<ellipse cx="2.854" cy="7.7244" rx="1.4552" ry="2.4739" style="paint-order:markers stroke fill"/>
+<ellipse cx="13.586" cy="7.7244" rx="1.4552" ry="2.4739" style="paint-order:markers stroke fill"/>
+</g>
+</svg>

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5471,6 +5471,7 @@ void SpatialEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<CollisionShapeSpatialGizmoPlugin>(memnew(CollisionShapeSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<CollisionPolygonSpatialGizmoPlugin>(memnew(CollisionPolygonSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<NavigationMeshSpatialGizmoPlugin>(memnew(NavigationMeshSpatialGizmoPlugin)));
+	add_gizmo_plugin(Ref<NavigationWalkableMarkerSpatialGizmoPlugin>(memnew(NavigationWalkableMarkerSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<JointSpatialGizmoPlugin>(memnew(JointSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<PhysicalBoneSpatialGizmoPlugin>(memnew(PhysicalBoneSpatialGizmoPlugin)));
 }

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -3922,6 +3922,29 @@ void NavigationMeshSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 
 //////
 
+NavigationWalkableMarkerSpatialGizmoPlugin::NavigationWalkableMarkerSpatialGizmoPlugin() {
+	create_icon_material("source_point_icon", SpatialEditor::get_singleton()->get_icon("GizmoNavigationWalkableMarker", "EditorIcons"));
+}
+
+bool NavigationWalkableMarkerSpatialGizmoPlugin::has_gizmo(Spatial *p_spatial) {
+	return Object::cast_to<NavigationWalkableMarker>(p_spatial) != NULL;
+}
+
+String NavigationWalkableMarkerSpatialGizmoPlugin::get_name() const {
+	return "NavigationWalkableMarker";
+}
+
+int NavigationWalkableMarkerSpatialGizmoPlugin::get_priority() const {
+	return -1;
+}
+
+void NavigationWalkableMarkerSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
+	p_gizmo->clear();
+	p_gizmo->add_unscaled_billboard(get_material("source_point_icon", p_gizmo), 0.05);
+}
+
+//////
+
 #define BODY_A_RADIUS 0.25
 #define BODY_B_RADIUS 0.27
 

--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -384,6 +384,19 @@ public:
 	NavigationMeshSpatialGizmoPlugin();
 };
 
+class NavigationWalkableMarkerSpatialGizmoPlugin : public EditorSpatialGizmoPlugin {
+
+	GDCLASS(NavigationWalkableMarkerSpatialGizmoPlugin, EditorSpatialGizmoPlugin);
+
+public:
+	bool has_gizmo(Spatial *p_spatial);
+	String get_name() const;
+	int get_priority() const;
+	void redraw(EditorSpatialGizmo *p_gizmo);
+
+	NavigationWalkableMarkerSpatialGizmoPlugin();
+};
+
 class JointGizmosDrawer {
 public:
 	static Basis look_body(const Transform &p_joint_transform, const Transform &p_body_transform);

--- a/modules/recast/navigation_mesh_generator.h
+++ b/modules/recast/navigation_mesh_generator.h
@@ -47,7 +47,7 @@ protected:
 	static void _add_vertex(const Vector3 &p_vec3, Vector<float> &p_verticies);
 	static void _add_mesh(const Ref<Mesh> &p_mesh, const Transform &p_xform, Vector<float> &p_verticies, Vector<int> &p_indices);
 	static void _add_faces(const PoolVector3Array &p_faces, const Transform &p_xform, Vector<float> &p_verticies, Vector<int> &p_indices);
-	static void _parse_geometry(Transform p_accumulated_transform, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices, int p_generate_from, uint32_t p_collision_mask, bool p_recurse_children);
+	static void _parse_geometry(Transform p_accumulated_transform, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices, Vector<Vector3> &r_walkable_markers, int p_generate_from, uint32_t p_collision_mask, bool p_recurse_children);
 
 	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_nav_mesh);
 	static void _build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh, EditorProgress *ep,

--- a/scene/3d/navigation_mesh.h
+++ b/scene/3d/navigation_mesh.h
@@ -105,6 +105,7 @@ protected:
 
 	SourceGeometryMode source_geometry_mode;
 	StringName source_group_name;
+	bool use_walkable_markers;
 
 	bool filter_low_hanging_obstacles;
 	bool filter_ledge_spans;
@@ -129,6 +130,9 @@ public:
 
 	void set_source_group_name(StringName p_group_name);
 	StringName get_source_group_name() const;
+
+	void set_use_walkable_markers(bool p_use_markers);
+	bool get_use_walkable_markers() const;
 
 	void set_cell_size(float p_value);
 	float get_cell_size() const;
@@ -187,10 +191,15 @@ public:
 	int get_polygon_count() const;
 	Vector<int> get_polygon(int p_idx);
 	void clear_polygons();
+	void prune_unreachable_spans(const Vector<Vector3> &p_sources);
 
 	Ref<Mesh> get_debug_mesh();
 
 	NavigationMesh();
+};
+
+class NavigationWalkableMarker : public Spatial {
+	GDCLASS(NavigationWalkableMarker, Spatial);
 };
 
 class Navigation;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -405,6 +405,7 @@ void register_scene_types() {
 	ClassDB::register_class<Position3D>();
 	ClassDB::register_class<NavigationMeshInstance>();
 	ClassDB::register_class<NavigationMesh>();
+	ClassDB::register_class<NavigationWalkableMarker>();
 	ClassDB::register_class<Navigation>();
 
 	ClassDB::register_class<RootMotionView>();


### PR DESCRIPTION
This PR adds a way to discard unnecessary navigation mesh spans.
The new NavigationWalkableMarker node allows the user to set which points the navigation mesh should reach, then the generator can discard (optional and disabled by default) all parts of the navigation mesh that are not connected to any walkable marker.

This feature can be used to get rid of unwanted navigation mesh spans, for example on the roof of a room or on the tops of tables, which are flat surfaces in which the player is not supposed to walk.

Icons by @QbieShay

Example of behaviour:
![walkable_marks](https://user-images.githubusercontent.com/4402304/67873872-70273680-fb34-11e9-9291-f2ea75a0d531.png)


This work has been kindly sponsored by IMVU.