### PR TITLE
Improve the primary line setting display in the Configure Snap dialog

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -133,8 +133,12 @@ public:
 		grid_step_y->set_h_size_flags(SIZE_EXPAND_FILL);
 		child_container->add_child(grid_step_y);
 
+		child_container = memnew(GridContainer);
+		child_container->set_columns(2);
+		container->add_child(child_container);
+
 		label = memnew(Label);
-		label->set_text(TTR("Primary Line Every"));
+		label->set_text(TTR("Primary Line Every:"));
 		label->set_h_size_flags(SIZE_EXPAND_FILL);
 		child_container->add_child(label);
 
@@ -143,16 +147,14 @@ public:
 		primary_grid_steps->set_step(1);
 		primary_grid_steps->set_max(100);
 		primary_grid_steps->set_allow_greater(true);
+		primary_grid_steps->set_suffix(TTR("steps"));
 		primary_grid_steps->set_h_size_flags(SIZE_EXPAND_FILL);
 		child_container->add_child(primary_grid_steps);
 
-		label = memnew(Label);
-		label->set_text(TTR("steps"));
-		label->set_h_size_flags(SIZE_EXPAND_FILL);
-		child_container->add_child(label);
-
 		container->add_child(memnew(HSeparator));
 
+		// We need to create another GridContainer with the same column count,
+		// so we can put an HSeparator above
 		child_container = memnew(GridContainer);
 		child_container->set_columns(2);
 		container->add_child(child_container);


### PR DESCRIPTION
Follow-up to #32928.

This merges the "steps" suffix into the SpinBox using its `suffix` property.

## Preview

![Configure Snap dialog](https://user-images.githubusercontent.com/180032/67899835-6c5ed880-fb63-11e9-850d-e989407b5695.png)