### PR TITLE
Fix a constant name typo for GridContainer when creating an editor theme.

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1089,7 +1089,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("port", "GraphNode", theme->get_icon("GuiGraphNodePort", "EditorIcons"));
 
 	// GridContainer
-	theme->set_constant("vseperation", "GridContainer", (extra_spacing + default_margin_size) * EDSCALE);
+	theme->set_constant("vseparation", "GridContainer", (extra_spacing + default_margin_size) * EDSCALE);
 
 	// FileDialog
 	theme->set_icon("folder", "FileDialog", theme->get_icon("Folder", "EditorIcons"));


### PR DESCRIPTION
When creating an editor theme, a new constant for GridContainer called `Vseperation` is created due to a typo.

![vseperation](https://user-images.githubusercontent.com/7572446/67929525-c4550980-fb7a-11e9-91dc-2a7a82acb4f9.png)

This simply fixes that typo so no new constant is created and the correct constant `Vseparation` is set.