### PR TITLE
Remove extra quote from OS.execute()

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2674,14 +2674,12 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 	if (p_blocking && r_pipe) {
 
 		String argss;
-		argss = "\"\"" + p_path + "\"";
+		argss = p_path;
 
 		for (const List<String>::Element *E = p_arguments.front(); E; E = E->next()) {
 
-			argss += " \"" + E->get() + "\"";
+			argss += " " + E->get();
 		}
-
-		argss += "\"";
 
 		if (read_stderr) {
 			argss += " 2>&1"; // Read stderr too


### PR DESCRIPTION
I'm not sure why this quote was added (possibly for executables with spaces in them?) but i'v had issue with it so far. For example `OS.execute("CMD.exe", ["/C", "cd %TEMP% && dir"], true, output)` (taken from the docs) is parsed in cmd as `"cd %temp% && dir"` with the quotes which makes cmd think that the whole command is a string.

Looks like it was addded at 9e465c9. So @SubSage could elaborate.