### PR TITLE
Provide and print error messages for JSON parsing

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -3165,6 +3165,9 @@ Ref<JSONParseResult> _JSON::parse(const String &p_json) {
 
 	result->error = JSON::parse(p_json, result->result, result->error_string, result->error_line);
 
+	if (result->error != OK) {
+		ERR_PRINTS(vformat("Error parsing JSON at line %s: %s", result->error_line, result->error_string));
+	}
 	return result;
 }
 

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1274,6 +1274,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 
 			if (err != OK) {
 				r_ret = Variant();
+				ERR_PRINTS(vformat("Error parsing JSON at line %s: %s", errl, errs));
 			}
 
 		} break;


### PR DESCRIPTION
Closes #33169.

Core is not touched, only for binding and scripting.

```json
{
"Name": "Bill",
"Height": "123"
"Weight": "456"
}
```

```gdscript
var result = JSON.parse(json)
var dict = parse_json(json)
```

![json-print-err](https://user-images.githubusercontent.com/17108460/67942774-48da7300-fbe1-11e9-967b-49d6299c215e.png)
