### PR TITLE
Improved TextEdit search usability & documentation

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -310,7 +310,15 @@
 			<argument index="3" name="from_column" type="int">
 			</argument>
 			<description>
-				Perform a search inside the text. Search flags can be specified in the[code]SEARCH_*[/code] enum.
+				Perform a search inside the text. Search flags can be specified in the [code]SEARCH_*[/code] enum.
+				Returns an empty [code]PoolIntArray[/code] if no result was found. Otherwise, the result line and column can be accessed at indices specified in the [code]SEARCH_RESULT_*[/code] enum, e.g:
+				[codeblock]
+				var result = search(key, flags, line, column)
+				if result.size() > 0:
+				    # result found
+				    var res_line = result[TextEdit.SEARCH_RESULT_LINE]
+				    var res_column = result[TextEdit.SEARCH_RESULT_COLUMN]
+				[/codeblock]
 			</description>
 		</method>
 		<method name="select">
@@ -503,6 +511,12 @@
 		</constant>
 		<constant name="SEARCH_BACKWARDS" value="4" enum="SearchFlags">
 			Search from end to beginning.
+		</constant>
+		<constant name="SEARCH_RESULT_COLUMN" value="0" enum="SearchResult">
+			Used to access the result column from [member search].
+		</constant>
+		<constant name="SEARCH_RESULT_LINE" value="1" enum="SearchResult">
+			Used to access the result line from [member search].
 		</constant>
 		<constant name="MENU_CUT" value="0" enum="MenuItems">
 			Cuts (Copies and clears) the selected text.

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5443,11 +5443,11 @@ int TextEdit::_get_column_pos_of_word(const String &p_key, const String &p_searc
 PoolVector<int> TextEdit::_search_bind(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column) const {
 
 	int col, line;
-	if (search(p_key, p_search_flags, p_from_line, p_from_column, col, line)) {
+	if (search(p_key, p_search_flags, p_from_line, p_from_column, line, col)) {
 		PoolVector<int> result;
 		result.resize(2);
-		result.set(0, line);
-		result.set(1, col);
+		result.set(SEARCH_RESULT_COLUMN, col);
+		result.set(SEARCH_RESULT_LINE, line);
 		return result;
 
 	} else {
@@ -6959,6 +6959,9 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(SEARCH_MATCH_CASE);
 	BIND_ENUM_CONSTANT(SEARCH_WHOLE_WORDS);
 	BIND_ENUM_CONSTANT(SEARCH_BACKWARDS);
+
+	BIND_ENUM_CONSTANT(SEARCH_RESULT_COLUMN);
+	BIND_ENUM_CONSTANT(SEARCH_RESULT_LINE);
 
 	/*
 	ClassDB::bind_method(D_METHOD("delete_char"),&TextEdit::delete_char);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -504,10 +504,14 @@ public:
 	};
 
 	enum SearchFlags {
-
 		SEARCH_MATCH_CASE = 1,
 		SEARCH_WHOLE_WORDS = 2,
 		SEARCH_BACKWARDS = 4
+	};
+
+	enum SearchResult {
+		SEARCH_RESULT_COLUMN,
+		SEARCH_RESULT_LINE,
 	};
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const;
@@ -768,6 +772,7 @@ public:
 
 VARIANT_ENUM_CAST(TextEdit::MenuItems);
 VARIANT_ENUM_CAST(TextEdit::SearchFlags);
+VARIANT_ENUM_CAST(TextEdit::SearchResult);
 
 class SyntaxHighlighter {
 protected:


### PR DESCRIPTION
These changes make `search()` functionality usable in scripts by defining how to get the line and column numbers from the returned `PoolIntArray`.