### PR TITLE
Prevent crash when we can't write to editor cache or config path

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -325,14 +325,12 @@ void EditorFileSystem::_save_filesystem_cache() {
 	String fscache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(CACHE_FILE_NAME);
 
 	FileAccess *f = FileAccess::open(fscache, FileAccess::WRITE);
-	if (f == NULL) {
-		ERR_PRINTS("Error writing fscache '" + fscache + "'.");
-	} else {
-		f->store_line(filesystem_settings_version_for_import);
-		_save_filesystem_cache(filesystem, f);
-		f->close();
-		memdelete(f);
-	}
+	ERR_FAIL_COND_MSG(!f, "Cannot create file '" + fscache + "'. Check user write permissions.");
+
+	f->store_line(filesystem_settings_version_for_import);
+	_save_filesystem_cache(filesystem, f);
+	f->close();
+	memdelete(f);
 }
 
 void EditorFileSystem::_thread_func(void *_userdata) {
@@ -1373,6 +1371,7 @@ void EditorFileSystem::_save_late_updated_files() {
 	//files that already existed, and were modified, need re-scanning for dependencies upon project restart. This is done via saving this special file
 	String fscache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file("filesystem_update4");
 	FileAccessRef f = FileAccess::open(fscache, FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(!f, "Cannot create file '" + fscache + "'. Check user write permissions.");
 	for (Set<String>::Element *E = late_update_files.front(); E; E = E->next()) {
 		f->store_line(E->get());
 	}

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -201,9 +201,8 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 			if (has_small_texture) {
 				ResourceSaver::save(cache_base + "_small.png", r_small_texture);
 			}
-			Error err;
-			FileAccess *f = FileAccess::open(cache_base + ".txt", FileAccess::WRITE, &err);
-			ERR_FAIL_COND_MSG(err != OK, "Cannot create file '" + cache_base + ".txt'.");
+			FileAccess *f = FileAccess::open(cache_base + ".txt", FileAccess::WRITE);
+			ERR_FAIL_COND_MSG(!f, "Cannot create file '" + cache_base + ".txt'. Check user write permissions.");
 			f->store_line(itos(thumbnail_size));
 			f->store_line(itos(has_small_texture));
 			f->store_line(itos(FileAccess::get_modified_time(p_item.path)));
@@ -295,11 +294,17 @@ void EditorResourcePreview::_thread() {
 								//update modified time
 
 								f = FileAccess::open(file, FileAccess::WRITE);
-								f->store_line(itos(thumbnail_size));
-								f->store_line(itos(has_small_texture));
-								f->store_line(itos(modtime));
-								f->store_line(md5);
-								memdelete(f);
+								if (!f) {
+									// Not returning as this would leave the thread hanging and would require
+									// some proper cleanup/disabling of resource preview generation.
+									ERR_PRINTS("Cannot create file '" + file + "'. Check user write permissions.");
+								} else {
+									f->store_line(itos(thumbnail_size));
+									f->store_line(itos(has_small_texture));
+									f->store_line(itos(modtime));
+									f->store_line(md5);
+									memdelete(f);
+								}
 							}
 						} else {
 							memdelete(f);


### PR DESCRIPTION
This can happen if users somehow got wrong user permissions assigned to
their Godot cache, config or data paths (e.g. `~/.config/godot`).

The error messages should give them a hint as to what the issue may be.

Fixes #33199.

There may be other situations that still lead to a crash, we need to
review all uses of `FileAccess::open` with `FileAccess::WRITE` mode to
ensure that proper pointer validation is done.