### PR TITLE
Increase the default Camera Zfar to 4000

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -189,7 +189,7 @@
 		<member name="environment" type="Environment" setter="set_environment" getter="get_environment">
 			The [Environment] to use for this camera.
 		</member>
-		<member name="far" type="float" setter="set_zfar" getter="get_zfar" default="100.0">
+		<member name="far" type="float" setter="set_zfar" getter="get_zfar" default="4000.0">
 			The distance to the far culling boundary for this camera relative to its local Z axis.
 		</member>
 		<member name="fov" type="float" setter="set_fov" getter="get_fov" default="75.0">

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -549,9 +549,15 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/3d/grid_xy_plane", false);
 	_initial_set("editors/3d/grid_yz_plane", false);
 
+	// Use a lower default FOV for the 3D camera compared to the
+	// Camera3D node as the 3D viewport doesn't span the whole screen.
+	// This means it's technically viewed from a further distance, which warrants a narrower FOV.
 	_initial_set("editors/3d/default_fov", 70.0);
+	hints["editors/3d/default_fov"] = PropertyInfo(Variant::FLOAT, "editors/3d/default_fov", PROPERTY_HINT_RANGE, "1,179,0.1");
 	_initial_set("editors/3d/default_z_near", 0.05);
-	_initial_set("editors/3d/default_z_far", 500.0);
+	hints["editors/3d/default_z_near"] = PropertyInfo(Variant::FLOAT, "editors/3d/default_z_near", PROPERTY_HINT_RANGE, "0.01,10,0.01,or_greater");
+	_initial_set("editors/3d/default_z_far", 4000.0);
+	hints["editors/3d/default_z_far"] = PropertyInfo(Variant::FLOAT, "editors/3d/default_z_far", PROPERTY_HINT_RANGE, "0.1,4000,0.1,or_greater");
 
 	// 3D: Navigation
 	_initial_set("editors/3d/navigation/navigation_scheme", 0);

--- a/editor/import/collada.h
+++ b/editor/import/collada.h
@@ -96,8 +96,8 @@ public:
 		};
 
 		float aspect = 1;
-		float z_near = 0.1;
-		float z_far = 100;
+		float z_near = 0.05;
+		float z_far = 4000;
 
 		CameraData() {}
 	};

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -205,9 +205,9 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 	struct GLTFCamera {
 		bool perspective = true;
-		float fov_size = 64;
-		float zfar = 500;
-		float znear = 0.1;
+		float fov_size = 75;
+		float zfar = 4000;
+		float znear = 0.05;
 	};
 
 	struct GLTFLight {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6181,9 +6181,9 @@ void Node3DEditor::_bind_methods() {
 }
 
 void Node3DEditor::clear() {
-	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 70.0));
-	settings_znear->set_value(EDITOR_DEF("editors/3d/default_z_near", 0.05));
-	settings_zfar->set_value(EDITOR_DEF("editors/3d/default_z_far", 1500.0));
+	settings_fov->set_value(EDITOR_GET("editors/3d/default_fov"));
+	settings_znear->set_value(EDITOR_GET("editors/3d/default_z_near"));
+	settings_zfar->set_value(EDITOR_GET("editors/3d/default_z_far"));
 
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
 		viewports[i]->reset();
@@ -6475,22 +6475,22 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	settings_fov = memnew(SpinBox);
 	settings_fov->set_max(MAX_FOV);
 	settings_fov->set_min(MIN_FOV);
-	settings_fov->set_step(0.01);
-	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 70.0));
+	settings_fov->set_step(0.1);
+	settings_fov->set_value(EDITOR_GET("editors/3d/default_fov"));
 	settings_vbc->add_margin_child(TTR("Perspective FOV (deg.):"), settings_fov);
 
 	settings_znear = memnew(SpinBox);
 	settings_znear->set_max(MAX_Z);
 	settings_znear->set_min(MIN_Z);
 	settings_znear->set_step(0.01);
-	settings_znear->set_value(EDITOR_DEF("editors/3d/default_z_near", 0.05));
+	settings_znear->set_value(EDITOR_GET("editors/3d/default_z_near"));
 	settings_vbc->add_margin_child(TTR("View Z-Near:"), settings_znear);
 
 	settings_zfar = memnew(SpinBox);
 	settings_zfar->set_max(MAX_Z);
 	settings_zfar->set_min(MIN_Z);
-	settings_zfar->set_step(0.01);
-	settings_zfar->set_value(EDITOR_DEF("editors/3d/default_z_far", 1500));
+	settings_zfar->set_step(0.1);
+	settings_zfar->set_value(EDITOR_GET("editors/3d/default_z_far"));
 	settings_vbc->add_margin_child(TTR("View Z-Far:"), settings_zfar);
 
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; ++i) {

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -519,8 +519,8 @@ void Camera3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fov", PROPERTY_HINT_RANGE, "1,179,0.1"), "set_fov", "get_fov");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "size", PROPERTY_HINT_RANGE, "0.1,16384,0.01"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "frustum_offset"), "set_frustum_offset", "get_frustum_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "near", PROPERTY_HINT_EXP_RANGE, "0.001,8192,0.001,or_greater"), "set_znear", "get_znear");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "far", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01,or_greater"), "set_zfar", "get_zfar");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "near", PROPERTY_HINT_EXP_RANGE, "0.001,10,0.001,or_greater"), "set_znear", "get_znear");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "far", PROPERTY_HINT_EXP_RANGE, "0.01,4000,0.01,or_greater"), "set_zfar", "get_zfar");
 
 	BIND_ENUM_CONSTANT(PROJECTION_PERSPECTIVE);
 	BIND_ENUM_CONSTANT(PROJECTION_ORTHOGONAL);
@@ -662,7 +662,7 @@ Camera3D::Camera3D() {
 	viewport = nullptr;
 	force_change = false;
 	mode = PROJECTION_PERSPECTIVE;
-	set_perspective(75.0, 0.05, 100.0);
+	set_perspective(75.0, 0.05, 4000.0);
 	keep_aspect = KEEP_HEIGHT;
 	layers = 0xfffff;
 	v_offset = 0;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -89,7 +89,7 @@ public:
 			fov = 75;
 			type = PERSPECTIVE;
 			znear = 0.05;
-			zfar = 100;
+			zfar = 4000;
 			size = 1.0;
 			offset = Vector2();
 			vaspect = false;


### PR DESCRIPTION
This makes it possible to view far away objects without having to tweak any settings. This results in a more usable editor when working on large-scale levels.

This change should have no impact on performance, but note that Z-fighting will be visible at a distance. This can be made less visible by increasing the Znear value (however, doing so will cause nearby surfaces to disappear).
This change was also applied to the editor, but it will only apply to newly created scenes.

This also changes the default camera settings in the glTF importer to match the Camera node's defaults.

cc @lawnjelly, as he inspired me to do this in #32764. I also considered increasing the default Znear value back to 0.1 for better depth buffer precision, but this may not be a good idea as many games may be putting the camera close to walls/floors.

This closes https://github.com/godotengine/godot-proposals/issues/853.