### PR TITLE
Added empty() function to pool array types

### DIFF
--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -385,6 +385,7 @@ public:
 	}
 
 	inline int size() const;
+	inline bool empty() const;
 	T get(int p_index) const;
 	void set(int p_index, const T &p_val);
 	void push_back(const T &p_val);
@@ -472,6 +473,12 @@ template <class T>
 int PoolVector<T>::size() const {
 
 	return alloc ? alloc->size / sizeof(T) : 0;
+}
+
+template <class T>
+bool PoolVector<T>::empty() const {
+
+	return alloc ? alloc->size == 0 : true;
 }
 
 template <class T>

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -626,6 +626,7 @@ struct _VariantCall {
 	}
 
 	VCALL_LOCALMEM0R(PoolByteArray, size);
+	VCALL_LOCALMEM0R(PoolByteArray, empty);
 	VCALL_LOCALMEM2(PoolByteArray, set);
 	VCALL_LOCALMEM1R(PoolByteArray, get);
 	VCALL_LOCALMEM1(PoolByteArray, push_back);
@@ -638,6 +639,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM2R(PoolByteArray, subarray);
 
 	VCALL_LOCALMEM0R(PoolIntArray, size);
+	VCALL_LOCALMEM0R(PoolIntArray, empty);
 	VCALL_LOCALMEM2(PoolIntArray, set);
 	VCALL_LOCALMEM1R(PoolIntArray, get);
 	VCALL_LOCALMEM1(PoolIntArray, push_back);
@@ -649,6 +651,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0(PoolIntArray, invert);
 
 	VCALL_LOCALMEM0R(PoolRealArray, size);
+	VCALL_LOCALMEM0R(PoolRealArray, empty);
 	VCALL_LOCALMEM2(PoolRealArray, set);
 	VCALL_LOCALMEM1R(PoolRealArray, get);
 	VCALL_LOCALMEM1(PoolRealArray, push_back);
@@ -660,6 +663,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0(PoolRealArray, invert);
 
 	VCALL_LOCALMEM0R(PoolStringArray, size);
+	VCALL_LOCALMEM0R(PoolStringArray, empty);
 	VCALL_LOCALMEM2(PoolStringArray, set);
 	VCALL_LOCALMEM1R(PoolStringArray, get);
 	VCALL_LOCALMEM1(PoolStringArray, push_back);
@@ -672,6 +676,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1R(PoolStringArray, join);
 
 	VCALL_LOCALMEM0R(PoolVector2Array, size);
+	VCALL_LOCALMEM0R(PoolVector2Array, empty);
 	VCALL_LOCALMEM2(PoolVector2Array, set);
 	VCALL_LOCALMEM1R(PoolVector2Array, get);
 	VCALL_LOCALMEM1(PoolVector2Array, push_back);
@@ -683,6 +688,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0(PoolVector2Array, invert);
 
 	VCALL_LOCALMEM0R(PoolVector3Array, size);
+	VCALL_LOCALMEM0R(PoolVector3Array, empty);
 	VCALL_LOCALMEM2(PoolVector3Array, set);
 	VCALL_LOCALMEM1R(PoolVector3Array, get);
 	VCALL_LOCALMEM1(PoolVector3Array, push_back);
@@ -694,6 +700,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0(PoolVector3Array, invert);
 
 	VCALL_LOCALMEM0R(PoolColorArray, size);
+	VCALL_LOCALMEM0R(PoolColorArray, empty);
 	VCALL_LOCALMEM2(PoolColorArray, set);
 	VCALL_LOCALMEM1R(PoolColorArray, get);
 	VCALL_LOCALMEM1(PoolColorArray, push_back);
@@ -1782,6 +1789,7 @@ void register_variant_methods() {
 	ADDFUNC0R(ARRAY, NIL, Array, min, varray());
 
 	ADDFUNC0R(POOL_BYTE_ARRAY, INT, PoolByteArray, size, varray());
+	ADDFUNC0R(POOL_BYTE_ARRAY, BOOL, PoolByteArray, empty, varray());
 	ADDFUNC2(POOL_BYTE_ARRAY, NIL, PoolByteArray, set, INT, "idx", INT, "byte", varray());
 	ADDFUNC1(POOL_BYTE_ARRAY, NIL, PoolByteArray, push_back, INT, "byte", varray());
 	ADDFUNC1(POOL_BYTE_ARRAY, NIL, PoolByteArray, append, INT, "byte", varray());
@@ -1799,6 +1807,7 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_BYTE_ARRAY, POOL_BYTE_ARRAY, PoolByteArray, decompress, INT, "buffer_size", INT, "compression_mode", varray(0));
 
 	ADDFUNC0R(POOL_INT_ARRAY, INT, PoolIntArray, size, varray());
+	ADDFUNC0R(POOL_INT_ARRAY, BOOL, PoolIntArray, empty, varray());
 	ADDFUNC2(POOL_INT_ARRAY, NIL, PoolIntArray, set, INT, "idx", INT, "integer", varray());
 	ADDFUNC1(POOL_INT_ARRAY, NIL, PoolIntArray, push_back, INT, "integer", varray());
 	ADDFUNC1(POOL_INT_ARRAY, NIL, PoolIntArray, append, INT, "integer", varray());
@@ -1809,6 +1818,7 @@ void register_variant_methods() {
 	ADDFUNC0(POOL_INT_ARRAY, NIL, PoolIntArray, invert, varray());
 
 	ADDFUNC0R(POOL_REAL_ARRAY, INT, PoolRealArray, size, varray());
+	ADDFUNC0R(POOL_REAL_ARRAY, BOOL, PoolRealArray, empty, varray());
 	ADDFUNC2(POOL_REAL_ARRAY, NIL, PoolRealArray, set, INT, "idx", REAL, "value", varray());
 	ADDFUNC1(POOL_REAL_ARRAY, NIL, PoolRealArray, push_back, REAL, "value", varray());
 	ADDFUNC1(POOL_REAL_ARRAY, NIL, PoolRealArray, append, REAL, "value", varray());
@@ -1819,6 +1829,7 @@ void register_variant_methods() {
 	ADDFUNC0(POOL_REAL_ARRAY, NIL, PoolRealArray, invert, varray());
 
 	ADDFUNC0R(POOL_STRING_ARRAY, INT, PoolStringArray, size, varray());
+	ADDFUNC0R(POOL_STRING_ARRAY, BOOL, PoolStringArray, empty, varray());
 	ADDFUNC2(POOL_STRING_ARRAY, NIL, PoolStringArray, set, INT, "idx", STRING, "string", varray());
 	ADDFUNC1(POOL_STRING_ARRAY, NIL, PoolStringArray, push_back, STRING, "string", varray());
 	ADDFUNC1(POOL_STRING_ARRAY, NIL, PoolStringArray, append, STRING, "string", varray());
@@ -1830,6 +1841,7 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_STRING_ARRAY, STRING, PoolStringArray, join, STRING, "delimiter", varray());
 
 	ADDFUNC0R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, size, varray());
+	ADDFUNC0R(POOL_VECTOR2_ARRAY, BOOL, PoolVector2Array, empty, varray());
 	ADDFUNC2(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, set, INT, "idx", VECTOR2, "vector2", varray());
 	ADDFUNC1(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, push_back, VECTOR2, "vector2", varray());
 	ADDFUNC1(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, append, VECTOR2, "vector2", varray());
@@ -1840,6 +1852,7 @@ void register_variant_methods() {
 	ADDFUNC0(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, invert, varray());
 
 	ADDFUNC0R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, size, varray());
+	ADDFUNC0R(POOL_VECTOR3_ARRAY, BOOL, PoolVector3Array, empty, varray());
 	ADDFUNC2(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, set, INT, "idx", VECTOR3, "vector3", varray());
 	ADDFUNC1(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, push_back, VECTOR3, "vector3", varray());
 	ADDFUNC1(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, append, VECTOR3, "vector3", varray());
@@ -1850,6 +1863,7 @@ void register_variant_methods() {
 	ADDFUNC0(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, invert, varray());
 
 	ADDFUNC0R(POOL_COLOR_ARRAY, INT, PoolColorArray, size, varray());
+	ADDFUNC0R(POOL_COLOR_ARRAY, BOOL, PoolColorArray, empty, varray());
 	ADDFUNC2(POOL_COLOR_ARRAY, NIL, PoolColorArray, set, INT, "idx", COLOR, "color", varray());
 	ADDFUNC1(POOL_COLOR_ARRAY, NIL, PoolColorArray, push_back, COLOR, "color", varray());
 	ADDFUNC1(POOL_COLOR_ARRAY, NIL, PoolColorArray, append, COLOR, "color", varray());

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -53,6 +53,13 @@
 				Returns a new [PoolByteArray] with the data decompressed. Set [code]buffer_size[/code] to the size of the uncompressed data. Set the compression mode using one of [enum File.CompressionMode]'s constants.
 			</description>
 		</method>
+		<method name="empty">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the array is empty.
+			</description>
+		</method>
 		<method name="get_string_from_ascii">
 			<return type="String">
 			</return>

--- a/doc/classes/PoolColorArray.xml
+++ b/doc/classes/PoolColorArray.xml
@@ -33,6 +33,13 @@
 				Appends a [PoolColorArray] at the end of this array.
 			</description>
 		</method>
+		<method name="empty">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the array is empty.
+			</description>
+		</method>
 		<method name="insert">
 			<return type="int">
 			</return>

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -34,6 +34,13 @@
 				Appends a [PoolIntArray] at the end of this array.
 			</description>
 		</method>
+		<method name="empty">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the array is empty.
+			</description>
+		</method>
 		<method name="insert">
 			<return type="int">
 			</return>

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -33,6 +33,13 @@
 				Appends a [PoolRealArray] at the end of this array.
 			</description>
 		</method>
+		<method name="empty">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the array is empty.
+			</description>
+		</method>
 		<method name="insert">
 			<return type="int">
 			</return>

--- a/doc/classes/PoolStringArray.xml
+++ b/doc/classes/PoolStringArray.xml
@@ -33,6 +33,13 @@
 				Appends a [PoolStringArray] at the end of this array.
 			</description>
 		</method>
+		<method name="empty">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the array is empty.
+			</description>
+		</method>
 		<method name="insert">
 			<return type="int">
 			</return>

--- a/doc/classes/PoolVector2Array.xml
+++ b/doc/classes/PoolVector2Array.xml
@@ -33,6 +33,13 @@
 				Appends a [PoolVector2Array] at the end of this array.
 			</description>
 		</method>
+		<method name="empty">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the array is empty.
+			</description>
+		</method>
 		<method name="insert">
 			<return type="int">
 			</return>

--- a/doc/classes/PoolVector3Array.xml
+++ b/doc/classes/PoolVector3Array.xml
@@ -33,6 +33,13 @@
 				Appends a [PoolVector3Array] at the end of this array.
 			</description>
 		</method>
+		<method name="empty">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the array is empty.
+			</description>
+		</method>
 		<method name="insert">
 			<return type="int">
 			</return>

--- a/modules/gdnative/gdnative/pool_arrays.cpp
+++ b/modules/gdnative/gdnative/pool_arrays.cpp
@@ -129,6 +129,11 @@ godot_int GDAPI godot_pool_byte_array_size(const godot_pool_byte_array *p_self) 
 	return self->size();
 }
 
+godot_bool GDAPI godot_pool_byte_array_empty(const godot_pool_byte_array *p_self) {
+	const PoolVector<uint8_t> *self = (const PoolVector<uint8_t> *)p_self;
+	return self->empty();
+}
+
 void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_self) {
 	((PoolVector<uint8_t> *)p_self)->~PoolVector();
 }
@@ -218,6 +223,11 @@ godot_int GDAPI godot_pool_int_array_size(const godot_pool_int_array *p_self) {
 	return self->size();
 }
 
+godot_bool GDAPI godot_pool_int_array_empty(const godot_pool_int_array *p_self) {
+	const PoolVector<godot_int> *self = (const PoolVector<godot_int> *)p_self;
+	return self->empty();
+}
+
 void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_self) {
 	((PoolVector<godot_int> *)p_self)->~PoolVector();
 }
@@ -305,6 +315,11 @@ godot_real GDAPI godot_pool_real_array_get(const godot_pool_real_array *p_self, 
 godot_int GDAPI godot_pool_real_array_size(const godot_pool_real_array *p_self) {
 	const PoolVector<godot_real> *self = (const PoolVector<godot_real> *)p_self;
 	return self->size();
+}
+
+godot_bool GDAPI godot_pool_real_array_empty(const godot_pool_real_array *p_self) {
+	const PoolVector<godot_real> *self = (const PoolVector<godot_real> *)p_self;
+	return self->empty();
 }
 
 void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_self) {
@@ -404,6 +419,11 @@ godot_int GDAPI godot_pool_string_array_size(const godot_pool_string_array *p_se
 	return self->size();
 }
 
+godot_bool GDAPI godot_pool_string_array_empty(const godot_pool_string_array *p_self) {
+	const PoolVector<String> *self = (const PoolVector<String> *)p_self;
+	return self->empty();
+}
+
 void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_self) {
 	((PoolVector<String> *)p_self)->~PoolVector();
 }
@@ -498,6 +518,11 @@ godot_vector2 GDAPI godot_pool_vector2_array_get(const godot_pool_vector2_array 
 godot_int GDAPI godot_pool_vector2_array_size(const godot_pool_vector2_array *p_self) {
 	const PoolVector<Vector2> *self = (const PoolVector<Vector2> *)p_self;
 	return self->size();
+}
+
+godot_bool GDAPI godot_pool_vector2_array_empty(const godot_pool_vector2_array *p_self) {
+	const PoolVector<Vector2> *self = (const PoolVector<Vector2> *)p_self;
+	return self->empty();
 }
 
 void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_self) {
@@ -596,6 +621,11 @@ godot_int GDAPI godot_pool_vector3_array_size(const godot_pool_vector3_array *p_
 	return self->size();
 }
 
+godot_bool GDAPI godot_pool_vector3_array_empty(const godot_pool_vector3_array *p_self) {
+	const PoolVector<Vector3> *self = (const PoolVector<Vector3> *)p_self;
+	return self->empty();
+}
+
 void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_self) {
 	((PoolVector<Vector3> *)p_self)->~PoolVector();
 }
@@ -690,6 +720,11 @@ godot_color GDAPI godot_pool_color_array_get(const godot_pool_color_array *p_sel
 godot_int GDAPI godot_pool_color_array_size(const godot_pool_color_array *p_self) {
 	const PoolVector<Color> *self = (const PoolVector<Color> *)p_self;
 	return self->size();
+}
+
+godot_bool GDAPI godot_pool_color_array_empty(const godot_pool_color_array *p_self) {
+	const PoolVector<Color> *self = (const PoolVector<Color> *)p_self;
+	return self->empty();
 }
 
 void GDAPI godot_pool_color_array_destroy(godot_pool_color_array *p_self) {

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -1717,6 +1717,13 @@
         ]
       },
       {
+        "name": "godot_pool_byte_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_pool_byte_array *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_pool_byte_array_destroy",
         "return_type": "void",
         "arguments": [
@@ -1836,6 +1843,13 @@
       {
         "name": "godot_pool_int_array_size",
         "return_type": "godot_int",
+        "arguments": [
+          ["const godot_pool_int_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_pool_int_array_empty",
+        "return_type": "godot_bool",
         "arguments": [
           ["const godot_pool_int_array *", "p_self"]
         ]
@@ -1965,6 +1979,13 @@
         ]
       },
       {
+        "name": "godot_pool_real_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_pool_real_array *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_pool_real_array_destroy",
         "return_type": "void",
         "arguments": [
@@ -2084,6 +2105,13 @@
       {
         "name": "godot_pool_string_array_size",
         "return_type": "godot_int",
+        "arguments": [
+          ["const godot_pool_string_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_pool_string_array_empty",
+        "return_type": "godot_bool",
         "arguments": [
           ["const godot_pool_string_array *", "p_self"]
         ]
@@ -2213,6 +2241,13 @@
         ]
       },
       {
+        "name": "godot_pool_vector2_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_pool_vector2_array *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_pool_vector2_array_destroy",
         "return_type": "void",
         "arguments": [
@@ -2337,6 +2372,13 @@
         ]
       },
       {
+        "name": "godot_pool_vector3_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_pool_vector3_array *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_pool_vector3_array_destroy",
         "return_type": "void",
         "arguments": [
@@ -2456,6 +2498,13 @@
       {
         "name": "godot_pool_color_array_size",
         "return_type": "godot_int",
+        "arguments": [
+          ["const godot_pool_color_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_pool_color_array_empty",
+        "return_type": "godot_bool",
         "arguments": [
           ["const godot_pool_color_array *", "p_self"]
         ]

--- a/modules/gdnative/include/gdnative/pool_arrays.h
+++ b/modules/gdnative/include/gdnative/pool_arrays.h
@@ -191,6 +191,8 @@ uint8_t GDAPI godot_pool_byte_array_get(const godot_pool_byte_array *p_self, con
 
 godot_int GDAPI godot_pool_byte_array_size(const godot_pool_byte_array *p_self);
 
+godot_bool GDAPI godot_pool_byte_array_empty(const godot_pool_byte_array *p_self);
+
 void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_self);
 
 // int
@@ -221,6 +223,8 @@ void GDAPI godot_pool_int_array_set(godot_pool_int_array *p_self, const godot_in
 godot_int GDAPI godot_pool_int_array_get(const godot_pool_int_array *p_self, const godot_int p_idx);
 
 godot_int GDAPI godot_pool_int_array_size(const godot_pool_int_array *p_self);
+
+godot_bool GDAPI godot_pool_int_array_empty(const godot_pool_int_array *p_self);
 
 void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_self);
 
@@ -253,6 +257,8 @@ godot_real GDAPI godot_pool_real_array_get(const godot_pool_real_array *p_self, 
 
 godot_int GDAPI godot_pool_real_array_size(const godot_pool_real_array *p_self);
 
+godot_bool GDAPI godot_pool_real_array_empty(const godot_pool_real_array *p_self);
+
 void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_self);
 
 // string
@@ -283,6 +289,8 @@ void GDAPI godot_pool_string_array_set(godot_pool_string_array *p_self, const go
 godot_string GDAPI godot_pool_string_array_get(const godot_pool_string_array *p_self, const godot_int p_idx);
 
 godot_int GDAPI godot_pool_string_array_size(const godot_pool_string_array *p_self);
+
+godot_bool GDAPI godot_pool_string_array_empty(const godot_pool_string_array *p_self);
 
 void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_self);
 
@@ -315,6 +323,8 @@ godot_vector2 GDAPI godot_pool_vector2_array_get(const godot_pool_vector2_array 
 
 godot_int GDAPI godot_pool_vector2_array_size(const godot_pool_vector2_array *p_self);
 
+godot_bool GDAPI godot_pool_vector2_array_empty(const godot_pool_vector2_array *p_self);
+
 void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_self);
 
 // vector3
@@ -346,6 +356,8 @@ godot_vector3 GDAPI godot_pool_vector3_array_get(const godot_pool_vector3_array 
 
 godot_int GDAPI godot_pool_vector3_array_size(const godot_pool_vector3_array *p_self);
 
+godot_bool GDAPI godot_pool_vector3_array_empty(const godot_pool_vector3_array *p_self);
+
 void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_self);
 
 // color
@@ -376,6 +388,8 @@ void GDAPI godot_pool_color_array_set(godot_pool_color_array *p_self, const godo
 godot_color GDAPI godot_pool_color_array_get(const godot_pool_color_array *p_self, const godot_int p_idx);
 
 godot_int GDAPI godot_pool_color_array_size(const godot_pool_color_array *p_self);
+
+godot_bool GDAPI godot_pool_color_array_empty(const godot_pool_color_array *p_self);
 
 void GDAPI godot_pool_color_array_destroy(godot_pool_color_array *p_self);
 


### PR DESCRIPTION
This change adds `empty()` method to `PoolByteArray`, `PoolIntArray`, `PoolRealArray`, `PoolColorArray`, `PoolStringArray`, `PoolVector2Array` and `PoolVector3Array` to make their interface similar to other containers: `Array` and `Dictionary`.