### PR TITLE
Make the editor dimming smarter

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5171,12 +5171,18 @@ void EditorNode::_open_imported() {
 }
 
 void EditorNode::dim_editor(bool p_dimming, bool p_force_dim) {
-	// Dimming can be forced regardless of the editor setting, which is useful when quitting the editor
+	// Dimming can be forced regardless of the editor setting, which is useful when quitting the editor.
 	if ((p_force_dim || EditorSettings::get_singleton()->get("interface/editor/dim_editor_on_dialog_popup")) && p_dimming) {
+		dimmed = true;
 		gui_base->set_modulate(Color(0.5, 0.5, 0.5));
 	} else {
+		dimmed = false;
 		gui_base->set_modulate(Color(1, 1, 1));
 	}
+}
+
+bool EditorNode::is_editor_dimmed() const {
+	return dimmed;
 }
 
 void EditorNode::open_export_template_manager() {
@@ -5487,6 +5493,7 @@ EditorNode::EditorNode() {
 
 	singleton = this;
 	exiting = false;
+	dimmed = false;
 	last_checked_version = 0;
 	changing_scene = false;
 	_initializing_addons = false;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -260,6 +260,7 @@ private:
 	int tab_closing;
 
 	bool exiting;
+	bool dimmed;
 
 	int old_split_ofs;
 	VSplitContainer *top_split;
@@ -850,6 +851,7 @@ public:
 	void restart_editor();
 
 	void dim_editor(bool p_dimming, bool p_force_dim = false);
+	bool is_editor_dimmed() const;
 
 	void edit_current() { _edit_current(); };
 

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -239,13 +239,15 @@ void WindowDialog::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_POST_POPUP: {
-			if (get_tree() && Engine::get_singleton()->is_editor_hint() && EditorNode::get_singleton())
+			if (get_tree() && Engine::get_singleton()->is_editor_hint() && EditorNode::get_singleton()) {
+				was_editor_dimmed = EditorNode::get_singleton()->is_editor_dimmed();
 				EditorNode::get_singleton()->dim_editor(true);
+			}
 		} break;
 
 		case NOTIFICATION_POPUP_HIDE: {
-			if (get_tree() && Engine::get_singleton()->is_editor_hint() && EditorNode::get_singleton() && !get_viewport()->gui_has_modal_stack())
-				EditorNode::get_singleton()->dim_editor(false);
+			if (get_tree() && Engine::get_singleton()->is_editor_hint() && EditorNode::get_singleton())
+				EditorNode::get_singleton()->dim_editor(was_editor_dimmed);
 		} break;
 #endif
 	}
@@ -345,6 +347,10 @@ WindowDialog::WindowDialog() {
 	close_button = memnew(TextureButton);
 	add_child(close_button);
 	close_button->connect("pressed", this, "_closed");
+
+#ifdef TOOLS_ENABLED
+	was_editor_dimmed = false;
+#endif
 }
 
 WindowDialog::~WindowDialog() {

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -59,6 +59,10 @@ class WindowDialog : public Popup {
 	Point2 drag_offset_far;
 	bool resizable;
 
+#ifdef TOOLS_ENABLED
+	bool was_editor_dimmed;
+#endif
+
 	void _gui_input(const Ref<InputEvent> &p_event);
 	void _closed();
 	int _drag_hit_test(const Point2 &pos) const;
@@ -106,7 +110,6 @@ class AcceptDialog : public WindowDialog {
 	HBoxContainer *hbc;
 	Label *label;
 	Button *ok;
-	//Button *cancel; no more cancel (there is X on that titlebar)
 	bool hide_on_ok;
 
 	void _custom_action(const String &p_action);


### PR DESCRIPTION
Now when a `WindowDialog` is closed, it will only remove the dim if the editor was not dimmed before, instead of checking for other modals open.

Fixes #33213.
Fixes #32690.