### PR TITLE
Add new file in libogg readme

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -162,7 +162,7 @@ Files extracted from upstream source:
 
 Files extracted from upstream source:
 
-- `src/*.c`
+- `src/*.{c,h}`
 - `include/ogg/*.h` in ogg/
 - COPYING
 


### PR DESCRIPTION
In #33192 a new file was added named `crctable.h`, but I forgot to include this in the README, so this is a quick PR to document that. Sorry for the hassle!