### PR TITLE
Set "convert_text_resources_to_binary_on_export" default value to TRUE

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1733,5 +1733,5 @@ void EditorExportTextSceneToBinaryPlugin::_export_file(const String &p_path, con
 
 EditorExportTextSceneToBinaryPlugin::EditorExportTextSceneToBinaryPlugin() {
 
-	GLOBAL_DEF("editor/convert_text_resources_to_binary_on_export", false);
+	GLOBAL_DEF("editor/convert_text_resources_to_binary_on_export", true);
 }


### PR DESCRIPTION
To prevent resources from being exported in plain text by accident