### PR TITLE
Fix Batch Rename not opening

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -340,8 +340,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (!profile_allow_editing) {
 				break;
 			}
-			Tree *tree = scene_tree->get_scene_tree();
-			if (tree->is_anything_selected()) {
+			if (editor_selection->get_selected_node_list().size() > 1) {
 				rename_dialog->popup_centered();
 			}
 		} break;


### PR DESCRIPTION
The old check (`tree->is_anything_selected()`) was returning false on multiple selection choice so nothing was opening.

Closes #33208 