### PR TITLE
$ autocompletion keeps quotation

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6535,6 +6535,7 @@ void TextEdit::_update_completion_candidates() {
 		if (inquote && restore_quotes == 1 && !option.display.is_quoted()) {
 			String quote = single_quote ? "'" : "\"";
 			option.display = option.display.quote(quote);
+			option.insert_text = option.insert_text.quote(quote);
 		}
 
 		if (option.display.begins_with(s)) {


### PR DESCRIPTION
Using autocompletion with $ syntax sugar keeps `"` or `'`. $ without quotes works like before.

Fixes #32593.