### PR TITLE
Fix some crashes, overflows and using variables without  values

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1284,8 +1284,8 @@ static void _generate_po2_mipmap(const Component *p_src, Component *p_dst, uint3
 		Component *dst_ptr = &p_dst[i * dst_w * CC];
 		uint32_t count = dst_w;
 
-		while (count--) {
-
+		while (count) {
+			count--;
 			for (int j = 0; j < CC; j++) {
 				average_func(dst_ptr[j], rup_ptr[j], rup_ptr[j + right_step], rdown_ptr[j], rdown_ptr[j + right_step]);
 			}
@@ -1375,6 +1375,7 @@ void Image::shrink_x2() {
 		int ps = get_format_pixel_size(format);
 		new_img.resize((width / 2) * (height / 2) * ps);
 		ERR_FAIL_COND(new_img.size() == 0);
+		ERR_FAIL_COND(data.size() == 0);
 
 		{
 			PoolVector<uint8_t>::Write w = new_img.write();

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -4058,6 +4058,11 @@ String itos(int64_t p_val) {
 	return String::num_int64(p_val);
 }
 
+String uitos(uint64_t p_val) {
+
+	return String::num_uint64(p_val);
+}
+
 String rtos(double p_val) {
 
 	return String::num(p_val);

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -369,6 +369,7 @@ String operator+(const char *p_chr, const String &p_str);
 String operator+(CharType p_chr, const String &p_str);
 
 String itos(int64_t p_val);
+String uitos(uint64_t p_val);
 String rtos(double p_val);
 String rtoss(double p_val); //scientific version
 

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -275,6 +275,7 @@ void FileAccessUnix::store_8(uint8_t p_dest) {
 void FileAccessUnix::store_buffer(const uint8_t *p_src, int p_length) {
 
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
+	ERR_FAIL_COND(!p_src);
 	ERR_FAIL_COND((int)fwrite(p_src, 1, p_length, f) != p_length);
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1348,8 +1348,8 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	ClassDB::set_current_api(ClassDB::API_NONE); //no more api is registered at this point
 
-	print_verbose("CORE API HASH: " + itos(ClassDB::get_api_hash(ClassDB::API_CORE)));
-	print_verbose("EDITOR API HASH: " + itos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
+	print_verbose("CORE API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_CORE)));
+	print_verbose("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
 	MAIN_PRINT("Main: Done");
 
 	return OK;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1361,6 +1361,7 @@ void VisualScript::_bind_methods() {
 VisualScript::VisualScript() {
 
 	base_type = "Object";
+	is_tool_script = false;
 }
 
 StringName VisualScript::get_default_func() const {

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -157,6 +157,7 @@ Ref<AnimationRootNode> AnimationNodeBlendSpace1D::get_blend_point_node(int p_poi
 void AnimationNodeBlendSpace1D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
+	ERR_FAIL_COND(blend_points[p_point].node.is_null());
 	blend_points[p_point].node->disconnect("tree_changed", this, "_tree_changed");
 
 	for (int i = p_point; i < blend_points_used - 1; i++) {

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -113,6 +113,7 @@ Ref<AnimationRootNode> AnimationNodeBlendSpace2D::get_blend_point_node(int p_poi
 void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
+	ERR_FAIL_COND(blend_points[p_point].node.is_null());
 	blend_points[p_point].node->disconnect("tree_changed", this, "_tree_changed");
 
 	for (int i = 0; i < triangles.size(); i++) {

--- a/scene/resources/ray_shape.cpp
+++ b/scene/resources/ray_shape.cpp
@@ -90,6 +90,12 @@ void RayShape::_bind_methods() {
 RayShape::RayShape() :
 		Shape(PhysicsServer::get_singleton()->shape_create(PhysicsServer::SHAPE_RAY)) {
 
-	set_length(1.0);
-	set_slips_on_slope(false);
+	length = 1.0;
+	slips_on_slope = false;
+
+	/* Code copied from setters to prevent the use of uninitialized variables */
+	_update_shape();
+	notify_change_to_owners();
+	_change_notify("length");
+	_change_notify("slips_on_slope");
 }

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -905,6 +905,7 @@ void VisualShaderNodeCubeMap::_bind_methods() {
 
 VisualShaderNodeCubeMap::VisualShaderNodeCubeMap() {
 	texture_type = TYPE_DATA;
+	source = SOURCE_TEXTURE;
 }
 
 ////////////// Scalar Op

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -508,12 +508,11 @@ Error VisualServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint32_
 				if (p_format & ARRAY_COMPRESS_TANGENT) {
 
 					for (int i = 0; i < p_vertex_array_len; i++) {
-
-						uint8_t xyzw[4] = {
-							(uint8_t)CLAMP(src[i * 4 + 0] * 127, -128, 127),
-							(uint8_t)CLAMP(src[i * 4 + 1] * 127, -128, 127),
-							(uint8_t)CLAMP(src[i * 4 + 2] * 127, -128, 127),
-							(uint8_t)CLAMP(src[i * 4 + 3] * 127, -128, 127)
+						int8_t xyzw[4] = {
+							(int8_t)CLAMP(src[i * 4 + 0] * 127, -128, 127),
+							(int8_t)CLAMP(src[i * 4 + 1] * 127, -128, 127),
+							(int8_t)CLAMP(src[i * 4 + 2] * 127, -128, 127),
+							(int8_t)CLAMP(src[i * 4 + 3] * 127, -128, 127)
 						};
 
 						copymem(&vw[p_offsets[ai] + i * p_stride], xyzw, 4);


### PR DESCRIPTION
Fixes #32723
Fixes #31140 - I checked and seems that src[i]. always(or almost) return value (-1;1) and uint_t was a typo


Added function uitos to String, to prevent overflow Core and Editor API

Added to VisualShaderNodeCubeMap, RayShape and VisualScript value to some variables to prevent spam every time I open editor(I usually open it with sanitizer support which show error when using variables without values)

In Image::shrink_x2 and FileAccessUnix::store_buffer checks  should prevent using null pointers