### PR TITLE
Make JSON write and parse incompatible values as Variant consistently

### DIFF
--- a/core/io/json.h
+++ b/core/io/json.h
@@ -49,23 +49,19 @@ class JSON {
 		TK_MAX
 	};
 
-	enum Expecting {
-
-		EXPECT_OBJECT,
-		EXPECT_OBJECT_KEY,
-		EXPECT_COLON,
-		EXPECT_OBJECT_VALUE,
-	};
-
 	struct Token {
-
 		TokenType type;
 		Variant value;
 	};
 
 	static const char *tk_name[TK_MAX];
 
-	static String _print_var(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys);
+	static bool _is_compatible_value(const Variant &p_var);
+
+	static String _print_var(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, bool p_at_key);
+	static String _print_value(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, bool p_at_key);
+	static String _print_array(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, bool p_at_key);
+	static String _print_object(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, bool p_at_key);
 
 	static Error _get_token(const CharType *p_str, int &index, int p_len, Token &r_token, int &line, String &r_err_str);
 	static Error _parse_value(Variant &value, Token &token, const CharType *p_str, int &index, int p_len, int &line, String &r_err_str);


### PR DESCRIPTION
Fixes #33161, Closes #11866.
Remake of #33163.
Helps #33137.

**TL;DR:** try to write compatible JSON with native types, but when it can't, just stuff vars into JSON strings. This should work as before but "the right way".

---

The JSON writer is rewritten to treat vars by JSON types. This is needed to better control the writing state. Namely, object keys determine whether a Variant can be written as another JSON compatible type, or whether it should be converted with `VariantWriter` (aka `var2str`) to be embedded into a JSON string which can be parsed later with `VariantParser` (aka `str2var`).

This effectively removes the need to manually convert incompatible types with `var2str` and `str2var` via scripting. JSON writer and parser use Variant serialization methods over its visual representation which makes the conversion behavior possible, see issues like #27529, godotengine/godot-proposals#1351, #48169.

## Example
Here's an example JSON serialized from dictionary with `to_json(dict)`:

<details>
 <summary>JSON</summary>

```json
{
    "10": "Color( 1, 1, 1, 1 )",
    "foo": "bar",
    "nested": {
        "{Basis( 1, 0, 0, 0, 1, 0, 0, 0, 1 ):Plane( 0, 0, 0, 0 )}": [
            "3D"
        ]
    },
    "{[3,2]:1}": {
        "[9,8]": 7
    },
    "{PoolStringArray( \"foo\", \"bar\", \"baz\" ):\"wow\"}": "PoolColorArray( 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1 )",
    "[1,2]": "Vector2( 10, -10.5 )",
    "[null,true,10,20.5,\"foobar\",Vector2( 10, 20 ),Rect2( 0, 0, 10, 20 ),Vector3( 1, 2, 3 ),Transform2D( 2, 0, 0, 2, 0, 0 ),Plane( 0, 0, 10, 10 ),Quat( 0, 0, 10, 10 ),AABB( 0, 0, 0, 1, 1, 1 ),Basis( 1, 0, 0, 0, 1, 0, 0, 0, 1 ),Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ),Color( 1, 0, 1, 1 ),NodePath(\"node\"),[9.0,8.0,7.0],PoolByteArray(  ),PoolIntArray( 1, 2, 3 ),PoolRealArray( 1.5, 2.5, 3.5 ),PoolStringArray( \"foo\", \"bar\", \"baz\" ),PoolVector2Array( 1, 0, 0, -1, -1, 0, 0, 1 ),PoolVector3Array( 0, 0, 0, 0, 0, 0, 0, 0, 0 ),PoolColorArray( 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1 )]": [
        null,
        true,
        10,
        20.5,
        "foobar",
        "Vector2( 10, 20 )",
        "Rect2( 0, 0, 10, 20 )",
        "Vector3( 1, 2, 3 )",
        "Transform2D( 2, 0, 0, 2, 0, 0 )",
        "Plane( 0, 0, 10, 10 )",
        "Quat( 0, 0, 10, 10 )",
        "AABB( 0, 0, 0, 1, 1, 1 )",
        "Basis( 1, 0, 0, 0, 1, 0, 0, 0, 1 )",
        "Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )",
        "Color( 1, 0, 1, 1 )",
        "NodePath(\"node\")",
        [
            9,
            8,
            7
        ],
        "PoolByteArray(  )",
        [
            1,
            2,
            3
        ],
        [
            1.5,
            2.5,
            3.5
        ],
        [
            "foo",
            "bar",
            "baz"
        ],
        "PoolVector2Array( 1, 0, 0, -1, -1, 0, 0, 1 )",
        "PoolVector3Array( 0, 0, 0, 0, 0, 0, 0, 0, 0 )",
        "PoolColorArray( 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1 )"
    ],
    "PoolIntArray( 1, 2, 3, 4 )": [
        "foo",
        "bar",
        "baz"
    ]
}
```
</details>

Original dictionary `parse_json(json)`:
<details>
<summary>Dictionary</summary>

```gdscript
var variants = [
	null,
	true,
	10, # 2
	20.5,
	"foobar",
	Vector2(10, 20),
	Rect2(0, 0, 10, 20),
	Vector3(1, 2, 3),
	Transform2D(Vector2(2, 0), Vector2(0, 2), Vector2(0, 0)),
	Plane(0, 0, 10, 10),
	Quat(0, 0, 10, 10),
	AABB(Vector3.ZERO, Vector3.ONE),
	Basis(),
	Transform(Basis(), Vector3.ZERO),
	Color(1, 0, 1),
	NodePath("node"),
	Array([9.0, 8.0, 7.0]),
	PoolByteArray(),
	PoolIntArray([1, 2, 3]), # 18
	PoolRealArray([1.5, 2.5, 3.5]), # 19
	PoolStringArray(["foo", "bar", "baz"]), # 20
	PoolVector2Array([Vector2.RIGHT, Vector2.UP, Vector2.LEFT, Vector2.DOWN]),
	PoolVector3Array([Vector3.AXIS_X, Vector3.AXIS_Y, Vector3.AXIS_Z]),
	PoolColorArray([Color.red, Color.green, Color.blue])
]

var dict_sample = {
	10: Color(1,1,1,1),
	"foo": "bar",
	{[3, 2] : 1}: {[9, 8] : 7},
	{PoolStringArray(["foo", "bar", "baz"]): "wow"} : PoolColorArray([Color.red, Color.green, Color.blue]),
	[1, 2]: Vector2(10, -10.5),
	PoolIntArray([1, 2, 3, 4]): PoolStringArray(["foo", "bar", "baz"]),
	variants: variants,
	"nested": {{Basis(): Plane()}: ["3D"]}
}
```
</details>

## Test project
I had to write some tests to keep regressions from occurring during development. See the script comments on what, how, and why.

[json-convert-incompatible.zip](https://github.com/godotengine/godot/files/3798524/json-convert-incompatible.zip)
