### PR TITLE
Add option to paste animation as duplicate

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -60,6 +60,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 		TOOL_REMOVE_ANIM,
 		TOOL_COPY_ANIM,
 		TOOL_PASTE_ANIM,
+		TOOL_PASTE_ANIM_REF,
 		TOOL_EDIT_RESOURCE
 	};
 
@@ -183,6 +184,8 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _animation_blend();
 	void _animation_edit();
 	void _animation_duplicate();
+	Ref<Animation> _animation_clone(const Ref<Animation> p_anim);
+	void _animation_paste(const Ref<Animation> p_anim);
 	void _animation_resource_edit();
 	void _scale_changed(const String &p_scale);
 	void _save_animation(String p_file);


### PR DESCRIPTION
Might resolve #24950
![image](https://user-images.githubusercontent.com/2223172/68063729-a969cd00-fd13-11e9-8524-84efe2ad536a.png)
(this image is outdated, see below for new one)

@avencherus 
@golddotasksquestions

EDIT:
Added another commit that alternatively makes Paste duplicate by default and adds "Paste As Reference" option for current behavior.
![image](https://user-images.githubusercontent.com/2223172/68071639-81fb1a80-fd7c-11e9-9c23-df75b5ca7493.png)
