### PR TITLE
Sort custom vshader nodes+prevents them from divide to different folders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -264,7 +264,7 @@ public:
 	static VisualShaderEditor *get_singleton() { return singleton; }
 
 	void clear_custom_types();
-	void add_custom_type(const String &p_name, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, const String &p_sub_category);
+	void add_custom_type(const String &p_name, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, const String &p_subcategory);
 
 	virtual Size2 get_minimum_size() const;
 	void edit(VisualShader *p_visual_shader);


### PR DESCRIPTION
Prevent custom visual shader nodes to divide to different folders like

![folding_bug](https://user-images.githubusercontent.com/3036176/68068601-7a7d4680-fd67-11e9-8fb5-5aae0ef0668c.png)

And makes them sorted alphabetically inside their category. Custom categories also will be sorted alphabetically (after Special).

![image](https://user-images.githubusercontent.com/3036176/68068613-a698c780-fd67-11e9-9ec9-a1486013624f.png)

