### PR TITLE
Fix Color8 GDScript documentation

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -21,7 +21,7 @@
 			<argument index="3" name="a8" type="int" default="255">
 			</argument>
 			<description>
-				Returns a 32 bit color with red, green, blue and alpha channels. Each channel has 8 bits of information ranging from 0 to 255.
+				Returns a color constructed from integer red, green, blue, and alpha channels. Each channel should have 8 bits of information ranging from 0 to 255.
 				[code]r8[/code] red channel
 				[code]g8[/code] green channel
 				[code]b8[/code] blue channel


### PR DESCRIPTION
* It doesn't actually return a 32-bit color. `Color` itself is 128 bits in total regardless of how you construct it, even if each channel is 32-bit. Best to only mention the size of the inputs.

* Changed "has" to "should have" because it's not a hard limitation. Godot's `Color` is HDR-capable due to using floats.