### PR TITLE
Code format for true/false/null to make documentation consistent

### DIFF
--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -125,7 +125,7 @@
 	</methods>
 	<members>
 		<member name="auto_triangles" type="bool" setter="set_auto_triangles" getter="get_auto_triangles" default="true">
-			If true, the blend space is triangulated automatically. The mesh updates every time you add or remove points with [method add_blend_point] and [method remove_blend_point].
+			If [code]true[/code], the blend space is triangulated automatically. The mesh updates every time you add or remove points with [method add_blend_point] and [method remove_blend_point].
 		</member>
 		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="AnimationNodeBlendSpace2D.BlendMode" default="0">
 			Controls the interpolation between animations. See [enum BlendMode] constants.

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -316,7 +316,7 @@
 			<argument index="3" name="deep" type="bool" default="False">
 			</argument>
 			<description>
-				Duplicates the subset described in the function and returns it in an array, deeply copying the array if [code]deep[/code] is true. Lower and upper index are inclusive, with the [code]step[/code] describing the change between indices while slicing.
+				Duplicates the subset described in the function and returns it in an array, deeply copying the array if [code]deep[/code] is [code]true[/code]. Lower and upper index are inclusive, with the [code]step[/code] describing the change between indices while slicing.
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -62,7 +62,7 @@
 			</argument>
 			<description>
 				Virtual method to be implemented by the user. Returns a [Control] node that should be used as a tooltip instead of the default one. Use [code]for_text[/code] parameter to determine what text the tooltip should contain (likely the contents of [member hint_tooltip]).
-				The returned node must be of type [Control] or Control-derieved. It can have child nodes of any type. It is freed when the tooltip disappears, so make sure you always provide a new instance, not e.g. a node from scene. When null or non-Control node is returned, the default tooltip will be used instead.
+				The returned node must be of type [Control] or Control-derieved. It can have child nodes of any type. It is freed when the tooltip disappears, so make sure you always provide a new instance, not e.g. a node from scene. When [code]null[/code] or non-Control node is returned, the default tooltip will be used instead.
 				[b]Note:[/b] The tooltip is shrunk to minimal size. If you want to ensure it's fully visible, you might want to set its [member rect_min_size] to some non-zero value.
 				Example of usage with custom-constructed node:
 				[codeblock]

--- a/doc/classes/EditorInspectorPlugin.xml
+++ b/doc/classes/EditorInspectorPlugin.xml
@@ -6,7 +6,7 @@
 	<description>
 		This plugins allows adding custom property editors to [EditorInspector].
 		Plugins are registered via [method EditorPlugin.add_inspector_plugin].
-		When an object is edited, the [method can_handle] function is called and must return true if the object type is supported.
+		When an object is edited, the [method can_handle] function is called and must return [code]true[/code] if the object type is supported.
 		If supported, the function [method parse_begin] will be called, allowing to place custom controls at the beginning of the class.
 		Subsequently, the [method parse_category] and [method parse_property] are called for every category and property. They offer the ability to add custom controls to the inspector too.
 		Finally [method parse_end] will be called.
@@ -54,7 +54,7 @@
 			<argument index="0" name="object" type="Object">
 			</argument>
 			<description>
-				Returns true if this object can be handled by this plugin.
+				Returns [code]true[/code] if this object can be handled by this plugin.
 			</description>
 		</method>
 		<method name="parse_begin" qualifiers="virtual">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -415,7 +415,7 @@
 			<argument index="1" name="grayscale" type="bool" default="false">
 			</argument>
 			<description>
-				Saves the image as an EXR file to [code]path[/code]. If grayscale is true and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE]  if Godot was compiled without the TinyEXR module.
+				Saves the image as an EXR file to [code]path[/code]. If grayscale is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
 			</description>
 		</method>
 		<method name="save_png" qualifiers="const">

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -444,7 +444,7 @@
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
-				Sets the type of the item at the specified index [code]idx[/code] to radio button. If false, sets the type of the item to plain text.
+				Sets the type of the item at the specified index [code]idx[/code] to radio button. If [code]false[/code], sets the type of the item to plain text.
 			</description>
 		</method>
 		<method name="set_item_as_separator">

--- a/doc/classes/SoftBody.xml
+++ b/doc/classes/SoftBody.xml
@@ -78,7 +78,7 @@
 	</methods>
 	<members>
 		<member name="ray_pickable" type="bool" setter="set_ray_pickable" getter="is_ray_pickable" default="false">
-			If true, the [SoftBody] will respond to [RayCast]s.
+			If [code]true[/code], the [SoftBody] will respond to [RayCast]s.
 		</member>
 		<member name="areaAngular_stiffness" type="float" setter="set_areaAngular_stiffness" getter="get_areaAngular_stiffness" default="0.5">
 		</member>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -94,7 +94,7 @@
 			</argument>
 			<description>
 				Moves the cursor at the specified [code]column[/code] index.
-				If [code]adjust_viewport[/code] is set to true, the viewport will center at the cursor position after the move occurs.
+				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the cursor position after the move occurs.
 			</description>
 		</method>
 		<method name="cursor_set_line">
@@ -110,8 +110,8 @@
 			</argument>
 			<description>
 				Moves the cursor at the specified [code]line[/code] index.
-				If [code]adjust_viewport[/code] is set to true, the viewport will center at the cursor position after the move occurs.
-				If [code]can_be_hidden[/code] is set to true, the specified [code]line[/code] can be hidden using [method set_line_as_hidden].
+				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the cursor position after the move occurs.
+				If [code]can_be_hidden[/code] is set to [code]true[/code], the specified [code]line[/code] can be hidden using [method set_line_as_hidden].
 			</description>
 		</method>
 		<method name="cut">


### PR DESCRIPTION
Making class documentation consistent for `true`, `false`, `null` values.

Fixes #33263