### PR TITLE
Use GDScript resource path over script path for `inst2dict`

### DIFF
--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1126,7 +1126,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 
 					Dictionary d;
 					d["@subpath"] = cp;
-					d["@path"] = p->path;
+					d["@path"] = p->get_path();
 
 					p = base.ptr();
 


### PR DESCRIPTION
Supersedes #33115.

Fixes #26188.
Fixes #31045 (if not, feel free to reopen).

The resource path holds the original path which can be used to convert a dictionary to instance consistently both within editor and exported projects as the original path is automatically remapped from `gd` to `gdc` or `gde` in exported projects.

The fix is more simple compared to #33115 but there's one difference: the previously serialized data made in exported projects *cannot* be loaded before this PR *within editor* as there's no straightforward mechanism to remap `gdc` path back to `gd` (versus `gd` → `gdc`). That's why I made #33115 because it can provide some backward compatibility, but it might be negligible actually.

[gdscript-inst2dict-path.zip](https://github.com/godotengine/godot/files/3800504/gdscript-inst2dict-path.zip)
