### PR TITLE
Restore GDNative compatibility after #33210

### DIFF
--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -91,6 +91,55 @@
               ["const godot_int", "p_step"],
               ["const godot_bool", "p_deep"]
             ]
+          },
+          {
+            "name": "godot_pool_byte_array_empty",
+            "return_type": "godot_bool",
+            "arguments": [
+              ["const godot_pool_byte_array *", "p_self"]
+            ]
+          },
+          {
+            "name": "godot_pool_int_array_empty",
+            "return_type": "godot_bool",
+            "arguments": [
+              ["const godot_pool_int_array *", "p_self"]
+            ]
+          },
+          {
+            "name": "godot_pool_real_array_empty",
+            "return_type": "godot_bool",
+            "arguments": [
+              ["const godot_pool_real_array *", "p_self"]
+            ]
+          },
+          {
+            "name": "godot_pool_string_array_empty",
+            "return_type": "godot_bool",
+            "arguments": [
+              ["const godot_pool_string_array *", "p_self"]
+            ]
+          },
+          {
+            "name": "godot_pool_vector2_array_empty",
+            "return_type": "godot_bool",
+            "arguments": [
+              ["const godot_pool_vector2_array *", "p_self"]
+            ]
+          },
+          {
+            "name": "godot_pool_vector3_array_empty",
+            "return_type": "godot_bool",
+            "arguments": [
+              ["const godot_pool_vector3_array *", "p_self"]
+            ]
+          },
+          {
+            "name": "godot_pool_color_array_empty",
+            "return_type": "godot_bool",
+            "arguments": [
+              ["const godot_pool_color_array *", "p_self"]
+            ]
           }
         ]
       },
@@ -1717,13 +1766,6 @@
         ]
       },
       {
-        "name": "godot_pool_byte_array_empty",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_pool_byte_array *", "p_self"]
-        ]
-      },
-      {
         "name": "godot_pool_byte_array_destroy",
         "return_type": "void",
         "arguments": [
@@ -1843,13 +1885,6 @@
       {
         "name": "godot_pool_int_array_size",
         "return_type": "godot_int",
-        "arguments": [
-          ["const godot_pool_int_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_pool_int_array_empty",
-        "return_type": "godot_bool",
         "arguments": [
           ["const godot_pool_int_array *", "p_self"]
         ]
@@ -1979,13 +2014,6 @@
         ]
       },
       {
-        "name": "godot_pool_real_array_empty",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_pool_real_array *", "p_self"]
-        ]
-      },
-      {
         "name": "godot_pool_real_array_destroy",
         "return_type": "void",
         "arguments": [
@@ -2105,13 +2133,6 @@
       {
         "name": "godot_pool_string_array_size",
         "return_type": "godot_int",
-        "arguments": [
-          ["const godot_pool_string_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_pool_string_array_empty",
-        "return_type": "godot_bool",
         "arguments": [
           ["const godot_pool_string_array *", "p_self"]
         ]
@@ -2241,13 +2262,6 @@
         ]
       },
       {
-        "name": "godot_pool_vector2_array_empty",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_pool_vector2_array *", "p_self"]
-        ]
-      },
-      {
         "name": "godot_pool_vector2_array_destroy",
         "return_type": "void",
         "arguments": [
@@ -2372,13 +2386,6 @@
         ]
       },
       {
-        "name": "godot_pool_vector3_array_empty",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_pool_vector3_array *", "p_self"]
-        ]
-      },
-      {
         "name": "godot_pool_vector3_array_destroy",
         "return_type": "void",
         "arguments": [
@@ -2498,13 +2505,6 @@
       {
         "name": "godot_pool_color_array_size",
         "return_type": "godot_int",
-        "arguments": [
-          ["const godot_pool_color_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_pool_color_array_empty",
-        "return_type": "godot_bool",
         "arguments": [
           ["const godot_pool_color_array *", "p_self"]
         ]


### PR DESCRIPTION
#33210 introduced new pool array functions and break GDNative compatibility by added them into the middle of existing core API structure.

This PR moves new definitions to the core API 1.2 extension, which contains all other post 3.1 changes to GDNative API

Fixes https://github.com/GodotNativeTools/godot-cpp/issues/342
