### PR TITLE
Update connection info on script validation rather then saved copy

### DIFF
--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -59,6 +59,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 	RichTextLabel *warnings_panel;
 
 	Ref<Script> script;
+	bool script_is_valid;
 
 	Vector<String> functions;
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3928,7 +3928,9 @@ void TextEdit::_base_insert_text(int p_line, int p_char, const String &p_text, i
 	if (shift_first_line) {
 		text.set_breakpoint(p_line + 1, text.is_breakpoint(p_line));
 		text.set_hidden(p_line + 1, text.is_hidden(p_line));
-		text.set_info_icon(p_line + 1, text.get_info_icon(p_line), text.get_info(p_line));
+		if (text.has_info_icon(p_line)) {
+			text.set_info_icon(p_line + 1, text.get_info_icon(p_line), text.get_info(p_line));
+		}
 
 		text.set_breakpoint(p_line, false);
 		text.set_hidden(p_line, false);


### PR DESCRIPTION
Updated connection info to use the results of a successful script validation, rather then the last saved copy. 

Fixed the connection info appearing when creating a new line under one that had it hidden.

closes #33128