### PR TITLE
Fixes the edit rect in TreeItems

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1234,7 +1234,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				}
 			}
 
-			if (select_mode != SELECT_ROW && (p_item->cells[i].selected || selected_item == p_item)) {
+			if ((select_mode == SELECT_ROW && selected_item == p_item) || p_item->cells[i].selected) {
 				Rect2i r(cell_rect.position, cell_rect.size);
 
 				if (p_item->cells[i].text.size() > 0) {
@@ -2765,7 +2765,6 @@ bool Tree::edit_selected() {
 		return false;
 
 	Rect2 rect = s->get_meta("__focus_rect");
-
 	popup_edited_item = s;
 	popup_edited_item_col = col;
 


### PR DESCRIPTION
The way the edit rect was computed lead the Tree to always draw it on the top of the last item. Now the logic selects the right item's rect.

Fixes #33206
Supersedes: #33283 