### PR TITLE
Fixed cases where labels with autowrap can overflow the editor ui

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5818,6 +5818,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	info_message->set_valign(Label::VALIGN_CENTER);
 	info_message->set_align(Label::ALIGN_CENTER);
 	info_message->set_autowrap(true);
+	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	main_panel->add_child(info_message);
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -529,6 +529,7 @@ GroupDialog::GroupDialog() {
 	group_empty->set_valign(Label::VALIGN_CENTER);
 	group_empty->set_align(Label::ALIGN_CENTER);
 	group_empty->set_autowrap(true);
+	group_empty->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	nodes_to_remove->add_child(group_empty);
 	group_empty->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -1996,6 +1996,7 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	info_message->set_valign(Label::VALIGN_CENTER);
 	info_message->set_align(Label::ALIGN_CENTER);
 	info_message->set_autowrap(true);
+	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	palette->add_child(info_message);
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -584,6 +584,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	empty_message->set_valign(Label::VALIGN_CENTER);
 	empty_message->set_align(Label::ALIGN_CENTER);
 	empty_message->set_autowrap(true);
+	empty_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	empty_message->set_v_size_flags(SIZE_EXPAND_FILL);
 	main_vb->add_child(empty_message);
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -2424,6 +2424,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		info_message->set_valign(Label::VALIGN_CENTER);
 		info_message->set_align(Label::ALIGN_CENTER);
 		info_message->set_autowrap(true);
+		info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 		info_message->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 		perf_draw->add_child(info_message);
 	}

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1330,6 +1330,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	info_message->set_valign(Label::VALIGN_CENTER);
 	info_message->set_align(Label::ALIGN_CENTER);
 	info_message->set_autowrap(true);
+	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	mesh_library_palette->add_child(info_message);
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -296,8 +296,9 @@ Size2 Label::get_minimum_size() const {
 	Size2 min_style = get_stylebox("normal")->get_minimum_size();
 
 	// don't want to mutable everything
-	if (word_cache_dirty)
+	if (word_cache_dirty) {
 		const_cast<Label *>(this)->regenerate_word_cache();
+	}
 
 	if (autowrap)
 		return Size2(1, clip ? 1 : minsize.height) + min_style;
@@ -377,8 +378,14 @@ void Label::regenerate_word_cache() {
 		memdelete(current);
 	}
 
-	Ref<StyleBox> style = get_stylebox("normal");
-	int width = autowrap ? (get_size().width - style->get_minimum_size().width) : get_longest_line_width();
+	int width;
+	if (autowrap) {
+		Ref<StyleBox> style = get_stylebox("normal");
+		width = MAX(get_size().width, get_custom_minimum_size().width) - style->get_minimum_size().width;
+	} else {
+		width = get_longest_line_width();
+	}
+
 	Ref<Font> font = get_font("font");
 
 	int current_word_size = 0;


### PR DESCRIPTION
On top of adding a minimum size to some labels with autowrap, this change also makes `Label::regenerate_word_cache()` take into account the custom minimum size directly, because it can be called before the control has a chance to update its size according to the minimum size, like in this case:
```
Label::regenerate_word_cache() Line 383	C++
Label::get_minimum_size() Line 303	C++
Control::set_margins_preset(Control::LayoutPreset p_preset, Control::LayoutPresetMode p_resize_mode, int p_margin) Line 1585	C++
Control::set_anchors_and_margins_preset(Control::LayoutPreset p_preset, Control::LayoutPresetMode p_resize_mode, int p_margin) Line 1713	C++
GroupDialog::GroupDialog() Line 536	C++
GroupsEditor::GroupsEditor() Line 683	C++
```

Fixes #33155