### PR TITLE
Improve cursor placement when clicking on text in LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1055,7 +1055,13 @@ void LineEdit::set_cursor_at_pixel_pos(int p_x) {
 		}
 		pixel_ofs += char_w;
 
-		if (pixel_ofs > p_x) { // Found what we look for.
+		if (pixel_ofs > p_x) {
+			// We found what we look for.
+			// If the click was done more than (roughly) halfway through the character, move the cursor to the next character like in TextEdit.
+			if (pixel_ofs - p_x < font->get_char_size(text[ofs]).width * 0.55) {
+				ofs++;
+			}
+
 			break;
 		}
 


### PR DESCRIPTION
This implements behavior similar to TextEdit when clicking on text.

This partially addresses https://github.com/godotengine/godot-proposals/issues/125.

This needs further testing with various fonts (in both LineEdit and TextEdit) :slightly_smiling_face: The selecting-by-holding behavior should also be tested.