### PR TITLE
Another scene tree dock menu cleanup

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1142,6 +1142,16 @@ List<Node *> &EditorSelection::get_selected_node_list() {
 	return selected_node_list;
 }
 
+List<Node *> EditorSelection::get_full_selected_node_list() {
+
+	List<Node *> node_list;
+	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
+		node_list.push_back(E->key());
+	}
+
+	return node_list;
+}
+
 void EditorSelection::clear() {
 
 	while (!selection.empty()) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -273,6 +273,7 @@ public:
 	void clear();
 
 	List<Node *> &get_selected_node_list();
+	List<Node *> get_full_selected_node_list();
 	Map<Node *, Object *> &get_selection() { return selection; }
 
 	EditorSelection();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2403,6 +2403,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	}
 
 	List<Node *> selection = editor_selection->get_selected_node_list();
+	List<Node *> full_selection = editor_selection->get_full_selected_node_list(); // Above method only returns nodes with common parent.
 
 	if (selection.size() == 0)
 		return;
@@ -2437,21 +2438,40 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	}
 
 	if (profile_allow_script_editing) {
+		bool add_separator = false;
 
-		if (selection.size() == 1) {
+		if (full_selection.size() == 1) {
+			add_separator = true;
 			menu->add_icon_shortcut(get_icon("ScriptCreate", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/attach_script"), TOOL_ATTACH_SCRIPT);
 			if (existing_script.is_valid()) {
 				menu->add_icon_shortcut(get_icon("ScriptExtend", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/extend_script"), TOOL_EXTEND_SCRIPT);
 			}
 		}
-		if (selection.size() > 1 || (existing_script.is_valid() && exisiting_script_removable)) {
+		if (existing_script.is_valid() && exisiting_script_removable) {
+			add_separator = true;
 			menu->add_icon_shortcut(get_icon("ScriptRemove", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/clear_script"), TOOL_CLEAR_SCRIPT);
+		} else if (full_selection.size() > 1) {
+			bool script_exists = false;
+			for (List<Node *>::Element *E = full_selection.front(); E; E = E->next()) {
+				if (!E->get()->get_script().is_null()) {
+					script_exists = true;
+					break;
+				}
+			}
+
+			if (script_exists) {
+				add_separator = true;
+				menu->add_icon_shortcut(get_icon("ScriptRemove", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/clear_script"), TOOL_CLEAR_SCRIPT);
+			}
 		}
-		menu->add_separator();
+
+		if (add_separator) {
+			menu->add_separator();
+		}
 	}
 
 	if (profile_allow_editing) {
-		if (selection.size() == 1) {
+		if (full_selection.size() == 1) {
 			menu->add_icon_shortcut(get_icon("Rename", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/rename"), TOOL_RENAME);
 		}
 		menu->add_icon_shortcut(get_icon("Reload", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/change_node_type"), TOOL_REPLACE);
@@ -2463,7 +2483,9 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->add_icon_shortcut(get_icon("Duplicate", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/duplicate"), TOOL_DUPLICATE);
 			menu->add_icon_shortcut(get_icon("Reparent", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/reparent"), TOOL_REPARENT);
 			menu->add_icon_shortcut(get_icon("ReparentToNewNode", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/reparent_to_new_node"), TOOL_REPARENT_TO_NEW_NODE);
-			menu->add_icon_shortcut(get_icon("NewRoot", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/make_root"), TOOL_MAKE_ROOT);
+			if (selection.size() == 1) {
+				menu->add_icon_shortcut(get_icon("NewRoot", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/make_root"), TOOL_MAKE_ROOT);
+			}
 		}
 	}
 	if (selection.size() == 1) {
@@ -2472,9 +2494,11 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->add_separator();
 			menu->add_icon_shortcut(get_icon("Blend", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/merge_from_scene"), TOOL_MERGE_FROM_SCENE);
 			menu->add_icon_shortcut(get_icon("CreateNewSceneFrom", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/save_branch_as_scene"), TOOL_NEW_SCENE_FROM);
-			menu->add_separator();
 		}
-		menu->add_icon_shortcut(get_icon("CopyNodePath", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/copy_node_path"), TOOL_COPY_NODE_PATH);
+		if (full_selection.size() == 1) {
+			menu->add_separator();
+			menu->add_icon_shortcut(get_icon("CopyNodePath", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/copy_node_path"), TOOL_COPY_NODE_PATH);
+		}
 
 		bool is_external = (selection[0]->get_filename() != "");
 		if (is_external) {


### PR DESCRIPTION
This is similar to #28011

SceneTreeDock used `get_selected_node_list()`, which only returned nodes with common parent, which caused some issues. The PR introduces a method that returns full node list and they are both used to make sure that only usable options appear in the context menu.

List of changes. To make listing easier, "node" is for single node and "family" is for single node with or without its children (what original `get_selected_node_list()` returns)
- "Make Scene Root" only appears if one family is selected
- "Rename" only appears if one node is selected
- "Clear Script" when multiple nodes are selected only appears if any of them has a script
- "Copy Node Path" only appears if one node is selected
- "Attach/Extend Script" only appears if one node is selected

Resolves #18787 (see my comment there)