### PR TITLE
Add property to make the number of columns in GridContainer dynamic

### DIFF
--- a/doc/classes/GridContainer.xml
+++ b/doc/classes/GridContainer.xml
@@ -15,6 +15,9 @@
 		<member name="columns" type="int" setter="set_columns" getter="get_columns" default="1">
 			The number of columns in the [GridContainer]. If modified, [GridContainer] reorders its children to accommodate the new layout.
 		</member>
+		<member name="dynamic_column_width" type="int" setter="set_dynamic_column_width" getter="get_dynamic_column_width" default="0">
+			If set to any value greater than 0, it will make the number of [member columns] be changed dynamically to the number of times the value fits horizontally (e.g. If the value is set to 100 in a [GridContainer] with a width of 250, the number of [member columns] will be changed to 2).
+		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1" />
 	</members>
 	<constants>

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -43,6 +43,16 @@ void GridContainer::_notification(int p_what) {
 
 			int hsep = get_constant("hseparation");
 			int vsep = get_constant("vseparation");
+
+			if (dynamic_column_width > 0) {
+				// Compute how many columns fit the container horizontally.
+				columns = MAX(1, (get_size().x - hsep) / dynamic_column_width);
+				if (columns > 1) {
+					// Repeat the above, but this time take into account the space between the columns.
+					columns = MAX(1, (get_size().x - columns * hsep) / dynamic_column_width);
+				}
+				_change_notify("columns");
+			}
 			int max_col = MIN(get_child_count(), columns);
 			int max_row = ceil((float)get_child_count() / (float)columns);
 
@@ -177,6 +187,10 @@ void GridContainer::_notification(int p_what) {
 void GridContainer::set_columns(int p_columns) {
 
 	ERR_FAIL_COND(p_columns < 1);
+	if (dynamic_column_width > 0) {
+		return;
+	}
+
 	columns = p_columns;
 	queue_sort();
 	minimum_size_changed();
@@ -187,12 +201,28 @@ int GridContainer::get_columns() const {
 	return columns;
 }
 
+void GridContainer::set_dynamic_column_width(int p_width) {
+
+	ERR_FAIL_COND(p_width < 0);
+	dynamic_column_width = p_width;
+	queue_sort();
+	minimum_size_changed();
+}
+
+int GridContainer::get_dynamic_column_width() {
+
+	return dynamic_column_width;
+}
+
 void GridContainer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_columns", "columns"), &GridContainer::set_columns);
 	ClassDB::bind_method(D_METHOD("get_columns"), &GridContainer::get_columns);
+	ClassDB::bind_method(D_METHOD("set_dynamic_column_width", "dynamic_column_width"), &GridContainer::set_dynamic_column_width);
+	ClassDB::bind_method(D_METHOD("get_dynamic_column_width"), &GridContainer::get_dynamic_column_width);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "columns", PROPERTY_HINT_RANGE, "1,1024,1"), "set_columns", "get_columns");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "dynamic_column_width", PROPERTY_HINT_RANGE, "0,0,1,or_greater"), "set_dynamic_column_width", "get_dynamic_column_width");
 }
 
 Size2 GridContainer::get_minimum_size() const {
@@ -250,4 +280,5 @@ GridContainer::GridContainer() {
 
 	set_mouse_filter(MOUSE_FILTER_PASS);
 	columns = 1;
+	dynamic_column_width = 0;
 }

--- a/scene/gui/grid_container.h
+++ b/scene/gui/grid_container.h
@@ -38,6 +38,7 @@ class GridContainer : public Container {
 	GDCLASS(GridContainer, Container);
 
 	int columns;
+	int dynamic_column_width;
 
 protected:
 	void _notification(int p_what);
@@ -46,6 +47,10 @@ protected:
 public:
 	void set_columns(int p_columns);
 	int get_columns() const;
+
+	void set_dynamic_column_width(int p_width);
+	int get_dynamic_column_width();
+
 	virtual Size2 get_minimum_size() const;
 
 	GridContainer();


### PR DESCRIPTION
This adds a new property to `GridContainer` called `dynamic_column_width`. Setting it to any value bigger than 0 will result in it changing the number of columns to how many times it fits in horizontally in the container:
![Peek 2019-11-04 18-42](https://user-images.githubusercontent.com/30739239/68160562-05b73180-ff4c-11e9-8121-5344ce6e5094.gif)

Closes #30173.