### PR TITLE
Fixes improper undo state for pivot setting

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1291,6 +1291,7 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 
 			// Start dragging if we still have nodes
 			if (drag_selection.size() > 0) {
+				_save_canvas_item_state(drag_selection);
 				drag_from = transform.affine_inverse().xform((b.is_valid()) ? b->get_position() : viewport->get_local_mouse_position());
 				Vector2 new_pos;
 				if (drag_selection.size() == 1) {
@@ -1304,7 +1305,6 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 				}
 
 				drag_type = DRAG_PIVOT;
-				_save_canvas_item_state(drag_selection);
 			}
 			return true;
 		}


### PR DESCRIPTION
After setting the pivot of a node, if you undo.... it will not revert the pivot to the previous state.

Closes: #33325