### PR TITLE
Fix #24137 Different number of leading zeros on MINGW printf("%lg")

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1337,7 +1337,17 @@ String String::num_scientific(double p_num) {
 	char buf[256];
 
 #if defined(__GNUC__) || defined(_MSC_VER)
+
+#if (defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900)) && defined(_TWO_DIGIT_EXPONENT)
+	// MinGW and old MSC require _set_output_format() to conform to C99 output for printf
+	unsigned int old_exponent_format = _set_output_format(_TWO_DIGIT_EXPONENT);
+#endif
 	snprintf(buf, 256, "%lg", p_num);
+
+#if (defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900)) && defined(_TWO_DIGIT_EXPONENT)
+	_set_output_format(old_exponent_format);
+#endif
+
 #else
 	sprintf(buf, "%.16lg", p_num);
 #endif


### PR DESCRIPTION
Use _set_output_format() on MINGW platform to force _snprintf_s() to
conform to the C99 standard and match the other platforms.

*Bugsquad edit:* Fixes #24137.