### PR TITLE
Fix localise_path method

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -107,7 +107,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 		if (plocal == "") {
 			return "";
 		};
-		return plocal + path.substr(sep, path.size() - sep);
+		return plocal + path.substr((sep + 1), path.size() - (sep + 1));
 	};
 }
 


### PR DESCRIPTION
This fixes the localise_path method which was resulting in uncached scripts being loaded with two slashes '//' at the last directory of their path, resulting in names being mangled and scripts often being saved accidentally as duplicates by the script editor