### PR TITLE
[Vulkan] Adds repeat flag to texture preview checkerboard background

### DIFF
--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -132,6 +132,7 @@ void TextureEditor::_bind_methods() {
 
 TextureEditor::TextureEditor() {
 
+	set_texture_repeat(TextureRepeat::TEXTURE_REPEAT_ENABLED);
 	set_custom_minimum_size(Size2(1, 150));
 }
 


### PR DESCRIPTION
Fix incorrect drawing of the checkerboard background in the inspector for textures.

![bug](https://user-images.githubusercontent.com/3036176/68294624-abc88000-00a1-11ea-9a9e-812577e10d35.png)

to

![image](https://user-images.githubusercontent.com/3036176/68294732-edf1c180-00a1-11ea-9dd6-96a1ec2f824f.png)
