### PR TITLE
Node create dialog filtering optimization

### DIFF
--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -51,6 +51,7 @@ class CreateDialog : public ConfirmationDialog {
 	LineEdit *search_box;
 	Tree *search_options;
 	HashMap<String, TreeItem *> search_options_types;
+	HashMap<String, RES> search_loaded_scripts;
 	bool is_replace_mode;
 	String base_type;
 	String preferred_search_result_type;

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -870,7 +870,7 @@ bool EditorData::script_class_is_parent(const String &p_class, const String &p_i
 	if (!ScriptServer::is_global_class(p_class))
 		return false;
 	String base = script_class_get_base(p_class);
-	Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(p_class), "Script");
+	Ref<Script> script = script_class_load_script(p_class);
 	Ref<Script> base_script = script->get_base_script();
 
 	while (p_inherits != base) {
@@ -889,12 +889,7 @@ bool EditorData::script_class_is_parent(const String &p_class, const String &p_i
 
 StringName EditorData::script_class_get_base(const String &p_class) const {
 
-	if (!ScriptServer::is_global_class(p_class))
-		return StringName();
-
-	String path = ScriptServer::get_global_class_path(p_class);
-
-	Ref<Script> script = ResourceLoader::load(path, "Script");
+	Ref<Script> script = script_class_load_script(p_class);
 	if (script.is_null())
 		return StringName();
 
@@ -910,13 +905,22 @@ Object *EditorData::script_class_instance(const String &p_class) {
 	if (ScriptServer::is_global_class(p_class)) {
 		Object *obj = ClassDB::instance(ScriptServer::get_global_class_native_base(p_class));
 		if (obj) {
-			RES script = ResourceLoader::load(ScriptServer::get_global_class_path(p_class));
+			Ref<Script> script = script_class_load_script(p_class);
 			if (script.is_valid())
 				obj->set_script(script.get_ref_ptr());
 			return obj;
 		}
 	}
 	return NULL;
+}
+
+Ref<Script> EditorData::script_class_load_script(const String &p_class) const {
+
+	if (!ScriptServer::is_global_class(p_class))
+		return Ref<Script>();
+
+	String path = ScriptServer::get_global_class_path(p_class);
+	return ResourceLoader::load(path, "Script");
 }
 
 void EditorData::script_class_set_icon_path(const String &p_class, const String &p_icon_path) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -219,6 +219,8 @@ public:
 	StringName script_class_get_base(const String &p_class) const;
 	Object *script_class_instance(const String &p_class);
 
+	Ref<Script> script_class_load_script(const String &p_class) const;
+
 	StringName script_class_get_name(const String &p_path) const;
 	void script_class_set_name(const String &p_path, const StringName &p_class);
 


### PR DESCRIPTION
Avoid loading the same scripts several times to parse them in order to update the node type tree.

Improvement for #27333
(~2 times faster to update tree)