### PR TITLE
Clean up error_macros.h

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -110,7 +110,7 @@ PoolStringArray _ResourceLoader::get_dependencies(const String &p_path) {
 
 #ifndef DISABLE_DEPRECATED
 bool _ResourceLoader::has(const String &p_path) {
-	WARN_PRINTS("ResourceLoader.has() is deprecated, please replace it with the equivalent has_cached() or the new exists().");
+	WARN_PRINT("ResourceLoader.has() is deprecated, please replace it with the equivalent has_cached() or the new exists().");
 	return has_cached(p_path);
 }
 #endif // DISABLE_DEPRECATED

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -3217,7 +3217,7 @@ Ref<JSONParseResult> _JSON::parse(const String &p_json) {
 	result->error = JSON::parse(p_json, result->result, result->error_string, result->error_line);
 
 	if (result->error != OK) {
-		ERR_PRINTS(vformat("Error parsing JSON at line %s: %s", result->error_line, result->error_string));
+		ERR_PRINT(vformat("Error parsing JSON at line %s: %s", result->error_line, result->error_string));
 	}
 	return result;
 }

--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -541,7 +541,7 @@ Object *ClassDB::instance(const StringName &p_class) {
 	}
 #ifdef TOOLS_ENABLED
 	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {
-		ERR_PRINTS("Class '" + String(p_class) + "' can only be instantiated by editor.");
+		ERR_PRINT("Class '" + String(p_class) + "' can only be instantiated by editor.");
 		return NULL;
 	}
 #endif

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -121,7 +121,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return;                                                                                                 \
 		}                                                                                                           \
-	} while (0);
+	} while (0)
 
 #define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                    \
 	do {                                                                                                                              \
@@ -129,7 +129,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
 			return;                                                                                                                   \
 		}                                                                                                                             \
-	} while (0);
+	} while (0)
 
 // The current function returns m_retval.
 
@@ -139,7 +139,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return m_retval;                                                                                        \
 		}                                                                                                           \
-	} while (0);
+	} while (0)
 
 #define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                        \
 	do {                                                                                                                              \
@@ -147,7 +147,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
 			return m_retval;                                                                                                          \
 		}                                                                                                                             \
-	} while (0);
+	} while (0)
 
 // Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
 
@@ -157,7 +157,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
 			GENERATE_TRAP();                                                                                                  \
 		}                                                                                                                     \
-	} while (0);
+	} while (0)
 
 #define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                         \
 	do {                                                                                                                                    \
@@ -165,7 +165,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
 			GENERATE_TRAP();                                                                                                                \
 		}                                                                                                                                   \
-	} while (0);
+	} while (0)
 
 // Unsigned integer index out of bounds error macros.
 // Ensures an unsigned integer index `m_index` is less than `m_size`
@@ -178,7 +178,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return;                                                                                                 \
 		}                                                                                                           \
-	} while (0);
+	} while (0)
 
 #define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                           \
 	do {                                                                                                                              \
@@ -186,7 +186,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
 			return;                                                                                                                   \
 		}                                                                                                                             \
-	} while (0);
+	} while (0)
 
 // The current function returns m_retval.
 
@@ -196,7 +196,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return m_retval;                                                                                        \
 		}                                                                                                           \
-	} while (0);
+	} while (0)
 
 #define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                               \
 	do {                                                                                                                              \
@@ -204,7 +204,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
 			return m_retval;                                                                                                          \
 		}                                                                                                                             \
-	} while (0);
+	} while (0)
 
 // Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
 
@@ -214,7 +214,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
 			GENERATE_TRAP();                                                                                                  \
 		}                                                                                                                     \
-	} while (0);
+	} while (0)
 
 #define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                \
 	do {                                                                                                                                    \
@@ -222,7 +222,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
 			GENERATE_TRAP();                                                                                                                \
 		}                                                                                                                                   \
-	} while (0);
+	} while (0)
 
 // Null reference error macros.
 // Ensures a pointer `m_param` is not null.

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -80,10 +80,15 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 #define FUNCTION_STR __FUNCTION__
 #endif
 
-// Don't use this directly; instead, use any of the CRASH_* macros
 #ifdef _MSC_VER
+/**
+ * Don't use GENERATE_TRAP() directly, should only be used be the macros below.
+ */
 #define GENERATE_TRAP() __debugbreak()
 #else
+/**
+ * Don't use GENERATE_TRAP() directly, should only be used be the macros below.
+ */
 #define GENERATE_TRAP() __builtin_trap()
 #endif
 
@@ -111,10 +116,14 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 // These macros should be used instead of `ERR_FAIL_COND` for bounds checking.
 
 // Integer index out of bounds error macros.
-// Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
 
-// The current function returns.
-
+/**
+ * Try using `ERR_FAIL_INDEX_MSG`.
+ * Only use this macro if there is no sensible error message.
+ *
+ * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
+ * If not, the current function returns.
+ */
 #define ERR_FAIL_INDEX(m_index, m_size)                                                                             \
 	do {                                                                                                            \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
@@ -123,6 +132,10 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                           \
 	} while (0)
 
+/**
+ * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
+ * If not, prints `m_msg` and the current function returns.
+ */
 #define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                    \
 	do {                                                                                                                              \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
@@ -131,8 +144,13 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                             \
 	} while (0)
 
-// The current function returns m_retval.
-
+/**
+ * Try using `ERR_FAIL_INDEX_V_MSG`.
+ * Only use this macro if there is no sensible error message.
+ *
+ * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
+ * If not, the current function returns `m_retval`.
+ */
 #define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                 \
 	do {                                                                                                            \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
@@ -141,6 +159,10 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                           \
 	} while (0)
 
+/**
+ * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
+ * If not, prints `m_msg` and the current function returns `m_retval`.
+ */
 #define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                        \
 	do {                                                                                                                              \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
@@ -149,8 +171,14 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                             \
 	} while (0)
 
-// Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
-
+/**
+ * Try using `ERR_FAIL_INDEX_MSG` or `ERR_FAIL_INDEX_V_MSG`.
+ * Only use this macro if there is no sensible fallback i.e. the error is unrecoverable, and
+ * there is no sensible error message.
+ *
+ * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
+ * If not, the application crashes.
+ */
 #define CRASH_BAD_INDEX(m_index, m_size)                                                                                      \
 	do {                                                                                                                      \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                               \
@@ -159,6 +187,13 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                     \
 	} while (0)
 
+/**
+ * Try using `ERR_FAIL_INDEX_MSG` or `ERR_FAIL_INDEX_V_MSG`.
+ * Only use this macro if there is no sensible fallback i.e. the error is unrecoverable.
+ *
+ * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
+ * If not, prints `m_msg` and the application crashes.
+ */
 #define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                         \
 	do {                                                                                                                                    \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                             \
@@ -168,10 +203,14 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 	} while (0)
 
 // Unsigned integer index out of bounds error macros.
-// Ensures an unsigned integer index `m_index` is less than `m_size`
 
-// The current function returns.
-
+/**
+ * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG`.
+ * Only use this macro if there is no sensible error message.
+ *
+ * Ensures an unsigned integer index `m_index` is less than `m_size`.
+ * If not, the current function returns.
+ */
 #define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                    \
 	do {                                                                                                            \
 		if (unlikely((m_index) >= (m_size))) {                                                                      \
@@ -180,6 +219,10 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                           \
 	} while (0)
 
+/**
+ * Ensures an unsigned integer index `m_index` is less than `m_size`.
+ * If not, prints `m_msg` and the current function returns.
+ */
 #define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                           \
 	do {                                                                                                                              \
 		if (unlikely((m_index) >= (m_size))) {                                                                                        \
@@ -188,8 +231,13 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                             \
 	} while (0)
 
-// The current function returns m_retval.
-
+/**
+ * Try using `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
+ * Only use this macro if there is no sensible error message.
+ *
+ * Ensures an unsigned integer index `m_index` is less than `m_size`.
+ * If not, the current function returns `m_retval`.
+ */
 #define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                        \
 	do {                                                                                                            \
 		if (unlikely((m_index) >= (m_size))) {                                                                      \
@@ -198,6 +246,10 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                           \
 	} while (0)
 
+/**
+ * Ensures an unsigned integer index `m_index` is less than `m_size`.
+ * If not, prints `m_msg` and the current function returns `m_retval`.
+ */
 #define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                               \
 	do {                                                                                                                              \
 		if (unlikely((m_index) >= (m_size))) {                                                                                        \
@@ -206,8 +258,14 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                             \
 	} while (0)
 
-// Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
-
+/**
+ * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG` or `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
+ * Only use this macro if there is no sensible fallback i.e. the error is unrecoverable, and
+ * there is no sensible error message.
+ *
+ * Ensures an unsigned integer index `m_index` is less than `m_size`.
+ * If not, the application crashes.
+ */
 #define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                             \
 	do {                                                                                                                      \
 		if (unlikely((m_index) >= (m_size))) {                                                                                \
@@ -216,6 +274,13 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                     \
 	} while (0)
 
+/**
+ * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG` or `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
+ * Only use this macro if there is no sensible fallback i.e. the error is unrecoverable.
+ *
+ * Ensures an unsigned integer index `m_index` is less than `m_size`.
+ * If not, prints `m_msg` and the application crashes.
+ */
 #define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                \
 	do {                                                                                                                                    \
 		if (unlikely((m_index) >= (m_size))) {                                                                                              \
@@ -225,10 +290,14 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 	} while (0)
 
 // Null reference error macros.
-// Ensures a pointer `m_param` is not null.
 
-// The current function returns.
-
+/**
+ * Try using `ERR_FAIL_NULL_MSG`.
+ * Only use this macro if there is no sensible error message.
+ *
+ * Ensures a pointer `m_param` is not null.
+ * If it is null, the current function returns.
+ */
 #define ERR_FAIL_NULL(m_param)                                                                              \
 	do {                                                                                                    \
 		if (unlikely(!m_param)) {                                                                           \
@@ -237,6 +306,10 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                   \
 	} while (0)
 
+/**
+ * Ensures a pointer `m_param` is not null.
+ * If it is null, prints `m_msg` and the current function returns.
+ */
 #define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                                     \
 	do {                                                                                                                      \
 		if (unlikely(!m_param)) {                                                                                             \
@@ -245,8 +318,13 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                     \
 	} while (0)
 
-// The current function returns m_retval.
-
+/**
+ * Try using `ERR_FAIL_NULL_V_MSG`.
+ * Only use this macro if there is no sensible error message.
+ *
+ * Ensures a pointer `m_param` is not null.
+ * If it is null, the current function returns `m_retval`.
+ */
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                                  \
 	do {                                                                                                    \
 		if (unlikely(!m_param)) {                                                                           \
@@ -255,6 +333,10 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                   \
 	} while (0)
 
+/**
+ * Ensures a pointer `m_param` is not null.
+ * If it is null, prints `m_msg` and the current function returns `m_retval`.
+ */
 #define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                                         \
 	do {                                                                                                                      \
 		if (unlikely(!m_param)) {                                                                                             \
@@ -263,11 +345,15 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                     \
 	} while (0)
 
-// Error condition macros.
-// Ensures that `m_cond` is not true.
-
-// The current function returns.
-
+/**
+ * Try using `ERR_FAIL_COND_MSG`.
+ * Only use this macro if there is no sensible error message.
+ * If checking for null use ERR_FAIL_NULL_MSG instead.
+ * If checking index bounds use ERR_FAIL_INDEX_MSG instead.
+ *
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, the current function returns.
+ */
 #define ERR_FAIL_COND(m_cond)                                                                              \
 	do {                                                                                                   \
 		if (unlikely(m_cond)) {                                                                            \
@@ -276,6 +362,13 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                  \
 	} while (0)
 
+/**
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, prints `m_msg` and the current function returns.
+ *
+ * If checking for null use ERR_FAIL_NULL_MSG instead.
+ * If checking index bounds use ERR_FAIL_INDEX_MSG instead.
+ */
 #define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                                     \
 	do {                                                                                                                     \
 		if (unlikely(m_cond)) {                                                                                              \
@@ -284,8 +377,15 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                    \
 	} while (0)
 
-// The current function returns m_retval.
-
+/**
+ * Try using `ERR_FAIL_COND_V_MSG`.
+ * Only use this macro if there is no sensible error message.
+ * If checking for null use ERR_FAIL_NULL_V_MSG instead.
+ * If checking index bounds use ERR_FAIL_INDEX_V_MSG instead.
+ *
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, the current function returns `m_retval`.
+ */
 #define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                            \
 	do {                                                                                                                             \
 		if (unlikely(m_cond)) {                                                                                                      \
@@ -294,6 +394,13 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                            \
 	} while (0)
 
+/**
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, prints `m_msg` and the current function returns `m_retval`.
+ *
+ * If checking for null use ERR_FAIL_NULL_V_MSG instead.
+ * If checking index bounds use ERR_FAIL_INDEX_V_MSG instead.
+ */
 #define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                                   \
 	do {                                                                                                                                               \
 		if (unlikely(m_cond)) {                                                                                                                        \
@@ -302,44 +409,68 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                                              \
 	} while (0)
 
-// The current loop continues.
-
-#define ERR_CONTINUE(m_cond)                                                                                             \
-	do {                                                                                                                 \
-		if (unlikely(m_cond)) {                                                                                          \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
-			continue;                                                                                                    \
-		}                                                                                                                \
-	} while (0)
-
-#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                                    \
-	do {                                                                                                                                   \
-		if (unlikely(m_cond)) {                                                                                                            \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", DEBUG_STR(m_msg)); \
-			continue;                                                                                                                      \
-		}                                                                                                                                  \
-	} while (0)
-
-// The current loop breaks.
-
-#define ERR_BREAK(m_cond)                                                                                              \
+/**
+ * Try using `ERR_CONTINUE_MSG`.
+ * Only use this macro if there is no sensible error message.
+ *
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, the current loop continues.
+ */
+#define ERR_CONTINUE(m_cond)                                                                                           \
 	do {                                                                                                               \
 		if (unlikely(m_cond)) {                                                                                        \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
-			break;                                                                                                     \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
+			continue;                                                                                                  \
 		}                                                                                                              \
 	} while (0)
 
-#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                                     \
+/**
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, prints `m_msg` and the current loop continues.
+ */
+#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                                  \
 	do {                                                                                                                                 \
 		if (unlikely(m_cond)) {                                                                                                          \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", DEBUG_STR(m_msg)); \
-			break;                                                                                                                       \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", DEBUG_STR(m_msg)); \
+			continue;                                                                                                                    \
 		}                                                                                                                                \
 	} while (0)
 
-// Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
+/**
+ * Try using `ERR_BREAK_MSG`.
+ * Only use this macro if there is no sensible error message.
+ *
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, the current loop breaks.
+ */
+#define ERR_BREAK(m_cond)                                                                                            \
+	do {                                                                                                             \
+		if (unlikely(m_cond)) {                                                                                      \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
+			break;                                                                                                   \
+		}                                                                                                            \
+	} while (0)
 
+/**
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, prints `m_msg` and the current loop breaks.
+ */
+#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                                   \
+	do {                                                                                                                               \
+		if (unlikely(m_cond)) {                                                                                                        \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", DEBUG_STR(m_msg)); \
+			break;                                                                                                                     \
+		}                                                                                                                              \
+	} while (0)
+
+/**
+ * Try using `ERR_FAIL_COND_MSG` or `ERR_FAIL_COND_V_MSG`.
+ * Only use this macro if there is no sensible fallback i.e. the error is unrecoverable, and
+ * there is no sensible error message.
+ *
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, the application crashes.
+ */
 #define CRASH_COND(m_cond)                                                                                        \
 	do {                                                                                                          \
 		if (unlikely(m_cond)) {                                                                                   \
@@ -348,6 +479,13 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                         \
 	} while (0)
 
+/**
+ * Try using `ERR_FAIL_COND_MSG` or `ERR_FAIL_COND_V_MSG`.
+ * Only use this macro if there is no sensible fallback i.e. the error is unrecoverable.
+ *
+ * Ensures `m_cond` is false.
+ * If `m_cond` is true, prints `m_msg` and the application crashes.
+ */
 #define CRASH_COND_MSG(m_cond, m_msg)                                                                                               \
 	do {                                                                                                                            \
 		if (unlikely(m_cond)) {                                                                                                     \
@@ -358,43 +496,71 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 
 // Generic error macros.
 
-// The current function returns.
-
+/**
+ * Try using `ERR_FAIL_COND_MSG` or `ERR_FAIL_MSG`.
+ * Only use this macro if more complex error detection or recovery is required, and
+ * there is no sensible error message.
+ *
+ * The current function returns.
+ */
 #define ERR_FAIL()                                                                     \
 	do {                                                                               \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed."); \
 		return;                                                                        \
 	} while (0)
 
+/**
+ * Try using `ERR_FAIL_COND_MSG`.
+ * Only use this macro if more complex error detection or recovery is required.
+ *
+ * Prints `m_msg`, and the current function returns.
+ */
 #define ERR_FAIL_MSG(m_msg)                                                                              \
 	do {                                                                                                 \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed.", DEBUG_STR(m_msg)); \
 		return;                                                                                          \
 	} while (0)
 
-// The current function returns m_retval.
-
+/**
+ * Try using `ERR_FAIL_COND_V_MSG` or `ERR_FAIL_V_MSG`.
+ * Only use this macro if more complex error detection or recovery is required, and
+ * there is no sensible error message.
+ *
+ * The current function returns `m_retval`.
+ */
 #define ERR_FAIL_V(m_retval)                                                                                      \
 	do {                                                                                                          \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed, returning: " __STR(m_value)); \
 		return m_retval;                                                                                          \
 	} while (0)
 
-#define ERR_FAIL_V_MSG(m_value, m_msg)                                                                                              \
+/**
+ * Try using `ERR_FAIL_COND_V_MSG`.
+ * Only use this macro if more complex error detection or recovery is required.
+ *
+ * Prints `m_msg`, and the current function returns `m_retval`.
+ */
+#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                             \
 	do {                                                                                                                            \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed, returning: " __STR(m_value), DEBUG_STR(m_msg)); \
-		return m_value;                                                                                                             \
+		return m_retval;                                                                                                            \
 	} while (0)
 
-// Print error message macros.
-
+/**
+ * Try using `ERR_FAIL_COND_MSG`, `ERR_FAIL_COND_V_MSG`, `ERR_CONTINUE_MSG` or ERR_BREAK_MSG.
+ * Only use this macro at the start of a function that has not been implemented yet, or
+ * if more complex error detection or recovery is required.
+ *
+ * Prints `m_msg`.
+ */
 #define ERR_PRINT(m_msg)                                                      \
 	do {                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg)); \
 	} while (0)
 
-// Only prints the error message once.
-
+/**
+ * Prints `m_msg` once during the application lifetime.
+ */
 #define ERR_PRINT_ONCE(m_msg)                                                     \
 	do {                                                                          \
 		static bool first_print = true;                                           \
@@ -405,15 +571,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 	} while (0)
 
 // Print warning message macros.
-// To warn about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
 
+/**
+ * Prints `m_msg`.
+ *
+ * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
+ */
 #define WARN_PRINT(m_msg)                                                                          \
 	do {                                                                                           \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
 	} while (0)
 
-// Only prints the warning message once.
-
+/**
+ * Prints `m_msg` once during the application lifetime.
+ *
+ * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
+ */
 #define WARN_PRINT_ONCE(m_msg)                                                                         \
 	do {                                                                                               \
 		static bool first_print = true;                                                                \
@@ -424,34 +597,48 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 	} while (0)
 
 // Print deprecated warning message macros.
-// Only prints the warning message once.
 
-#define WARN_DEPRECATED                                                                                                                                   \
-	do {                                                                                                                                                  \
-		static volatile bool warning_shown = false;                                                                                                       \
-		if (!warning_shown) {                                                                                                                             \
+/**
+ * Warns that the current function is deprecated.
+ */
+#define WARN_DEPRECATED                                                                                                                                    \
+	do {                                                                                                                                                   \
+		static volatile bool warning_shown = false;                                                                                                        \
+		if (!warning_shown) {                                                                                                                              \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", ERR_HANDLER_WARNING); \
-			warning_shown = true;                                                                                                                         \
-		}                                                                                                                                                 \
+			warning_shown = true;                                                                                                                          \
+		}                                                                                                                                                  \
 	} while (0)
 
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                          \
-	do {                                                                                                                                                                    \
-		static volatile bool warning_shown = false;                                                                                                                         \
-		if (!warning_shown) {                                                                                                                                               \
+/**
+ * Warns that the current function is deprecated and prints `m_msg`.
+ */
+#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                           \
+	do {                                                                                                                                                                     \
+		static volatile bool warning_shown = false;                                                                                                                          \
+		if (!warning_shown) {                                                                                                                                                \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
-			warning_shown = true;                                                                                                                                           \
-		}                                                                                                                                                                   \
+			warning_shown = true;                                                                                                                                            \
+		}                                                                                                                                                                    \
 	} while (0)
 
-// Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
-
+/**
+ * Do not use.
+ * If the application should never reach this point use CRASH_NOW_MSG(m_msg) to explain why.
+ *
+ * The application crashes.
+ */
 #define CRASH_NOW()                                                                           \
 	do {                                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/Function Failed."); \
 		GENERATE_TRAP();                                                                      \
 	} while (0)
 
+/**
+ * Only use if the application should never reach this point.
+ *
+ * Prints `m_msg`, and then the application crashes.
+ */
 #define CRASH_NOW_MSG(m_msg)                                                                                    \
 	do {                                                                                                        \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/Function Failed.", DEBUG_STR(m_msg)); \

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -32,21 +32,8 @@
 #define ERROR_MACROS_H
 
 #include "core/typedefs.h"
-/**
- * Error macros. Unlike exceptions and asserts, these macros try to maintain consistency and stability
- * inside the code. It is recommended to always return processable data, so in case of an error,
- * the engine can keep working well.
- * In most cases, bugs and/or invalid data are not fatal and should never allow a perfectly running application
- * to fail or crash.
- */
 
-/**
- * Pointer to the error macro printing function. Reassign to any function to have errors printed
- */
-
-/** Function used by the error macros */
-
-// function, file, line, error, explanation
+class String;
 
 enum ErrorHandlerType {
 	ERR_HANDLER_ERROR,
@@ -55,7 +42,8 @@ enum ErrorHandlerType {
 	ERR_HANDLER_SHADER,
 };
 
-class String;
+// Pointer to the error handler printing function. Reassign to any function to have errors printed.
+// Parameters: userdata, function, file, line, error, explanation, type.
 typedef void (*ErrorHandlerFunc)(void *, const char *, const char *, int p_line, const char *, const char *, ErrorHandlerType p_type);
 
 struct ErrorHandlerList {
@@ -75,6 +63,7 @@ struct ErrorHandlerList {
 void add_error_handler(ErrorHandlerList *p_handler);
 void remove_error_handler(ErrorHandlerList *p_handler);
 
+// Functions used by the error macros.
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
@@ -83,15 +72,6 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool fatal = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool fatal = false);
-
-#ifndef _STR
-#define _STR(m_x) #m_x
-#define _MKSTR(m_x) _STR(m_x)
-#endif
-
-#define _FNL __FILE__ ":"
-
-/** An index has failed if m_index<0 or m_index >=m_size, the function exits */
 
 #ifdef __GNUC__
 //#define FUNCTION_STR __PRETTY_FUNCTION__ - too annoying
@@ -102,13 +82,9 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 
 // Don't use this directly; instead, use any of the CRASH_* macros
 #ifdef _MSC_VER
-#define GENERATE_TRAP                       \
-	__debugbreak();                         \
-	/* Avoid warning about control paths */ \
-	for (;;) {                              \
-	}
+#define GENERATE_TRAP() __debugbreak()
 #else
-#define GENERATE_TRAP __builtin_trap();
+#define GENERATE_TRAP() __builtin_trap()
 #endif
 
 // Used to strip debug messages in release mode
@@ -118,117 +94,141 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 #define DEBUG_STR(m_msg) ""
 #endif
 
-// (*): See https://stackoverflow.com/questions/257418/do-while-0-what-is-it-good-for
-
 /**
- * If `m_index` is less than 0 or greater than or equal to `m_size`, prints a generic
- * error message and returns from the function. This macro should be preferred to
- * `ERR_FAIL_COND` for bounds checking.
+ * Error macros.
+ * WARNING: These macros work in the opposite way to assert().
+ *
+ * Unlike exceptions and asserts, these macros try to maintain consistency and stability.
+ * In most cases, bugs and/or invalid data are not fatal. They should never allow a perfectly
+ * running application to fail or crash.
+ * Always try to return processable data, so the engine can keep running well.
+ * Use the _MSG versions to print a meaningful message to help with debugging.
+ *
+ * Note: See https://stackoverflow.com/questions/257418/do-while-0-what-is-it-good-for
  */
+
+// Index out of bounds error macros.
+// These macros should be used instead of `ERR_FAIL_COND` for bounds checking.
+
+// Integer index out of bounds error macros.
+// Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
+
+// The current function returns.
+
 #define ERR_FAIL_INDEX(m_index, m_size)                                                                             \
 	do {                                                                                                            \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return;                                                                                                 \
 		}                                                                                                           \
-	} while (0); // (*)
+	} while (0);
 
-/**
- * If `m_index` is less than 0 or greater than or equal to `m_size`, prints a custom
- * error message and returns from the function. This macro should be preferred to
- * `ERR_FAIL_COND_MSG` for bounds checking.
- */
 #define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                    \
 	do {                                                                                                                              \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
 			return;                                                                                                                   \
 		}                                                                                                                             \
-	} while (0); // (*)
+	} while (0);
 
-/**
- * If `m_index` is less than 0 or greater than or equal to `m_size`,
- * prints a generic error message and returns the value specified in `m_retval`.
- * This macro should be preferred to `ERR_FAIL_COND_V` for bounds checking.
- */
+// The current function returns m_retval.
+
 #define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                 \
 	do {                                                                                                            \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return m_retval;                                                                                        \
 		}                                                                                                           \
-	} while (0); // (*)
+	} while (0);
 
-/**
- * If `m_index` is less than 0 or greater than or equal to `m_size`,
- * prints a custom error message and returns the value specified in `m_retval`.
- * This macro should be preferred to `ERR_FAIL_COND_V_MSG` for bounds checking.
- */
 #define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                        \
 	do {                                                                                                                              \
 		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
 			return m_retval;                                                                                                          \
 		}                                                                                                                             \
-	} while (0); // (*)
+	} while (0);
 
-/**
- * If `m_index` is greater than or equal to `m_size`,
- * prints a generic error message and returns the value specified in `m_retval`.
- * This macro should be preferred to `ERR_FAIL_COND_V` for unsigned bounds checking.
- */
+// Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
+
+#define CRASH_BAD_INDEX(m_index, m_size)                                                                                      \
+	do {                                                                                                                      \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                               \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
+			GENERATE_TRAP();                                                                                                  \
+		}                                                                                                                     \
+	} while (0);
+
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                         \
+	do {                                                                                                                                    \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                             \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
+			GENERATE_TRAP();                                                                                                                \
+		}                                                                                                                                   \
+	} while (0);
+
+// Unsigned integer index out of bounds error macros.
+// Ensures an unsigned integer index `m_index` is less than `m_size`
+
+// The current function returns.
+
+#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                    \
+	do {                                                                                                            \
+		if (unlikely((m_index) >= (m_size))) {                                                                      \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return;                                                                                                 \
+		}                                                                                                           \
+	} while (0);
+
+#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                           \
+	do {                                                                                                                              \
+		if (unlikely((m_index) >= (m_size))) {                                                                                        \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+			return;                                                                                                                   \
+		}                                                                                                                             \
+	} while (0);
+
+// The current function returns m_retval.
+
 #define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                        \
 	do {                                                                                                            \
 		if (unlikely((m_index) >= (m_size))) {                                                                      \
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return m_retval;                                                                                        \
 		}                                                                                                           \
-	} while (0); // (*)
+	} while (0);
 
-/**
- * If `m_index` is greater than or equal to `m_size`,
- * prints a custom error message and returns the value specified in `m_retval`.
- * This macro should be preferred to `ERR_FAIL_COND_V_MSG` for unsigned bounds checking.
- */
 #define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                               \
 	do {                                                                                                                              \
 		if (unlikely((m_index) >= (m_size))) {                                                                                        \
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
 			return m_retval;                                                                                                          \
 		}                                                                                                                             \
-	} while (0); // (*)
+	} while (0);
 
-/**
- * If `m_index` is less than 0 or greater than or equal to `m_size`,
- * crashes the engine immediately with a generic error message.
- * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
- * This macro should be preferred to `CRASH_COND` for bounds checking.
- */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                      \
+// Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
+
+#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                             \
 	do {                                                                                                                      \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                               \
+		if (unlikely((m_index) >= (m_size))) {                                                                                \
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
-			GENERATE_TRAP                                                                                                     \
+			GENERATE_TRAP();                                                                                                  \
 		}                                                                                                                     \
-	} while (0); // (*)
+	} while (0);
 
-/**
- * If `m_index` is less than 0 or greater than or equal to `m_size`,
- * crashes the engine immediately with a custom error message.
- * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
- * This macro should be preferred to `CRASH_COND` for bounds checking.
- */
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                              \
-	do {                                                                                                                         \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-			GENERATE_TRAP                                                                                                        \
-		}                                                                                                                        \
-	} while (0); // (*)
+#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                \
+	do {                                                                                                                                    \
+		if (unlikely((m_index) >= (m_size))) {                                                                                              \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
+			GENERATE_TRAP();                                                                                                                \
+		}                                                                                                                                   \
+	} while (0);
 
-/**
- * If `m_param` is `null`, prints a generic error message and returns from the function.
- */
+// Null reference error macros.
+// Ensures a pointer `m_param` is not null.
+
+// The current function returns.
+
 #define ERR_FAIL_NULL(m_param)                                                                              \
 	{                                                                                                       \
 		if (unlikely(!m_param)) {                                                                           \
@@ -237,9 +237,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                   \
 	}
 
-/**
- * If `m_param` is `null`, prints a custom error message and returns from the function.
- */
 #define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                                     \
 	{                                                                                                                         \
 		if (unlikely(!m_param)) {                                                                                             \
@@ -248,9 +245,8 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                     \
 	}
 
-/**
- * If `m_param` is `null`, prints a generic error message and returns the value specified in `m_retval`.
- */
+// The current function returns m_retval.
+
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                                  \
 	{                                                                                                       \
 		if (unlikely(!m_param)) {                                                                           \
@@ -259,9 +255,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                   \
 	}
 
-/**
- * If `m_param` is `null`, prints a custom error message and returns the value specified in `m_retval`.
- */
 #define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                                         \
 	{                                                                                                                         \
 		if (unlikely(!m_param)) {                                                                                             \
@@ -270,9 +263,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                     \
 	}
 
-/**
- * If `m_cond` evaluates to `true`, prints a generic error message and returns from the function.
- */
+// Error condition macros.
+// Ensures that `m_cond` is not true.
+
+// The current function returns.
+
 #define ERR_FAIL_COND(m_cond)                                                                              \
 	{                                                                                                      \
 		if (unlikely(m_cond)) {                                                                            \
@@ -281,9 +276,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                  \
 	}
 
-/**
- * If `m_cond` evaluates to `true`, prints a custom error message and returns from the function.
- */
 #define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                                     \
 	{                                                                                                                        \
 		if (unlikely(m_cond)) {                                                                                              \
@@ -292,55 +284,26 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                    \
 	}
 
-/**
- * If `m_cond` evaluates to `true`, crashes the engine immediately with a generic error message.
- * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
- */
-#define CRASH_COND(m_cond)                                                                                        \
-	{                                                                                                             \
-		if (unlikely(m_cond)) {                                                                                   \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
-			GENERATE_TRAP                                                                                         \
-		}                                                                                                         \
-	}
+// The current function returns m_retval.
 
-/**
- * If `m_cond` evaluates to `true`, crashes the engine immediately with a custom error message.
- * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
- */
-#define CRASH_COND_MSG(m_cond, m_msg)                                                                                               \
-	{                                                                                                                               \
-		if (unlikely(m_cond)) {                                                                                                     \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
-			GENERATE_TRAP                                                                                                           \
-		}                                                                                                                           \
-	}
-
-/**
- * If `m_cond` evaluates to `true`, prints a generic error message and returns the value specified in `m_retval`.
- */
 #define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                            \
 	{                                                                                                                                \
 		if (unlikely(m_cond)) {                                                                                                      \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returned: " _STR(m_retval)); \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. returned: " _STR(m_retval)); \
 			return m_retval;                                                                                                         \
 		}                                                                                                                            \
 	}
 
-/**
- * If `m_cond` evaluates to `true`, prints a custom error message and returns the value specified in `m_retval`.
- */
 #define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                                   \
 	{                                                                                                                                                  \
 		if (unlikely(m_cond)) {                                                                                                                        \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returned: " _STR(m_retval), DEBUG_STR(m_msg)); \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. returned: " _STR(m_retval), DEBUG_STR(m_msg)); \
 			return m_retval;                                                                                                                           \
 		}                                                                                                                                              \
 	}
 
-/**
- * If `m_cond` evaluates to `true`, prints a custom error message and continues the loop the macro is located in.
- */
+// The current loop continues.
+
 #define ERR_CONTINUE(m_cond)                                                                                           \
 	{                                                                                                                  \
 		if (unlikely(m_cond)) {                                                                                        \
@@ -349,9 +312,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                              \
 	}
 
-/**
- * If `m_cond` evaluates to `true`, prints a custom error message and continues the loop the macro is located in.
- */
 #define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                                  \
 	{                                                                                                                                    \
 		if (unlikely(m_cond)) {                                                                                                          \
@@ -360,9 +320,8 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                                \
 	}
 
-/**
- * If `m_cond` evaluates to `true`, prints a generic error message and breaks from the loop the macro is located in.
- */
+// The current loop breaks.
+
 #define ERR_BREAK(m_cond)                                                                                            \
 	{                                                                                                                \
 		if (unlikely(m_cond)) {                                                                                      \
@@ -371,9 +330,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                            \
 	}
 
-/**
- * If `m_cond` evaluates to `true`, prints a custom error message and breaks from the loop the macro is located in.
- */
 #define ERR_BREAK_MSG(m_cond, m_msg)                                                                                                   \
 	{                                                                                                                                  \
 		if (unlikely(m_cond)) {                                                                                                        \
@@ -382,127 +338,104 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                              \
 	}
 
-/**
- * Prints a generic error message and returns from the function.
- */
-#define ERR_FAIL()                                                            \
+// Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
+
+#define CRASH_COND(m_cond)                                                                                        \
+	{                                                                                                             \
+		if (unlikely(m_cond)) {                                                                                   \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
+			GENERATE_TRAP();                                                                                      \
+		}                                                                                                         \
+	}
+
+#define CRASH_COND_MSG(m_cond, m_msg)                                                                                               \
+	{                                                                                                                               \
+		if (unlikely(m_cond)) {                                                                                                     \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
+			GENERATE_TRAP();                                                                                                        \
+		}                                                                                                                           \
+	}
+
+// Generic error macros.
+
+// The current function returns.
+
+#define ERR_FAIL()                                                                     \
+	{                                                                                  \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed."); \
+		return;                                                                        \
+	}
+
+#define ERR_FAIL_MSG(m_msg)                                                                              \
+	{                                                                                                    \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed.", DEBUG_STR(m_msg)); \
+		return;                                                                                          \
+	}
+
+// The current function returns m_retval.
+
+#define ERR_FAIL_V(m_retval)                                                                                      \
+	{                                                                                                             \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed, returning: " __STR(m_value)); \
+		return m_retval;                                                                                          \
+	}
+
+#define ERR_FAIL_V_MSG(m_value, m_msg)                                                                                              \
+	{                                                                                                                               \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed, returning: " __STR(m_value), DEBUG_STR(m_msg)); \
+		return m_value;                                                                                                             \
+	}
+
+// Print error message macros.
+
+#define ERR_PRINT(m_msg)                                                      \
 	{                                                                         \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method failed."); \
-		return;                                                               \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg)); \
 	}
 
-/**
- * Prints a custom error message and returns from the function.
- */
-#define ERR_FAIL_MSG(m_msg)                                                                     \
-	{                                                                                           \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method failed.", DEBUG_STR(m_msg)); \
-		return;                                                                                 \
+#define ERR_PRINTS(m_msg)                                                     \
+	{                                                                         \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg)); \
 	}
 
-/**
- * Prints a generic error message and returns the value specified in `m_retval`.
- */
-#define ERR_FAIL_V(m_retval)                                                                              \
-	{                                                                                                     \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method failed. Returning: " __STR(m_retval)); \
-		return m_retval;                                                                                  \
+// Only prints the error message once.
+
+#define ERR_PRINT_ONCE(m_msg)                                                     \
+	{                                                                             \
+		static bool first_print = true;                                           \
+		if (first_print) {                                                        \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg)); \
+			first_print = false;                                                  \
+		}                                                                         \
 	}
 
-/**
- * Prints a custom error message and returns the value specified in `m_retval`.
- */
-#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                     \
-	{                                                                                                                       \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method failed. Returning: " __STR(m_retval), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                    \
+// Print warning message macros.
+// To warn about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
+
+#define WARN_PRINT(m_msg)                                                                          \
+	{                                                                                              \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
 	}
 
-/**
- * Crashes the engine immediately with a generic error message.
- * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
- */
-#define CRASH_NOW()                                                                  \
-	{                                                                                \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method failed."); \
-		GENERATE_TRAP                                                                \
+#define WARN_PRINTS(m_msg)                                                                         \
+	{                                                                                              \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
 	}
 
-/**
- * Crashes the engine immediately with a custom error message.
- * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
- */
-#define CRASH_NOW_MSG(m_msg)                                                                           \
+// Only prints the warning message once.
+
+#define WARN_PRINT_ONCE(m_msg)                                                                         \
 	{                                                                                                  \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method failed.", DEBUG_STR(m_msg)); \
-		GENERATE_TRAP                                                                                  \
+		static bool first_print = true;                                                                \
+		if (first_print) {                                                                             \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
+			first_print = false;                                                                       \
+		}                                                                                              \
 	}
 
-/**
- * Prints an error message without returning.
- */
-#define ERR_PRINT(m_string)                                           \
-	{                                                                 \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string); \
-	}
+// Print deprecated warning message macros.
+// Only prints the warning message once.
 
-/**
- * Prints an error message without returning.
- * FIXME: Remove this macro and replace all uses with `ERR_PRINT` as it's identical.
- */
-#define ERR_PRINTS(m_string)                                          \
-	{                                                                 \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string); \
-	}
-
-/**
- * Prints an error message without returning, but only do so once in the application lifecycle.
- * This can be used to avoid spamming the console with error messages.
- */
-#define ERR_PRINT_ONCE(m_string)                                          \
-	{                                                                     \
-		static bool first_print = true;                                   \
-		if (first_print) {                                                \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string); \
-			first_print = false;                                          \
-		}                                                                 \
-	}
-
-/**
- * Prints a warning message without returning. To warn about deprecated usage,
- * use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
- */
-#define WARN_PRINT(m_string)                                                               \
-	{                                                                                      \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string, ERR_HANDLER_WARNING); \
-	}
-
-/**
- * Prints a warning message without returning.
- * FIXME: Remove this macro and replace all uses with `WARN_PRINT` as it's identical.
- */
-#define WARN_PRINTS(m_string)                                                              \
-	{                                                                                      \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string, ERR_HANDLER_WARNING); \
-	}
-
-/**
- * Prints a warning message without returning, but only do so once in the application lifecycle.
- * This can be used to avoid spamming the console with warning messages.
- */
-#define WARN_PRINT_ONCE(m_string)                                                              \
-	{                                                                                          \
-		static bool first_print = true;                                                        \
-		if (first_print) {                                                                     \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string, ERR_HANDLER_WARNING); \
-			first_print = false;                                                               \
-		}                                                                                      \
-	}
-
-/**
- * Prints a generic deprecation warning message without returning.
- * This should be preferred to `WARN_PRINT` for deprecation warnings.
- */
 #define WARN_DEPRECATED                                                                                                                                    \
 	{                                                                                                                                                      \
 		static volatile bool warning_shown = false;                                                                                                        \
@@ -512,17 +445,27 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		}                                                                                                                                                  \
 	}
 
-/**
- * Prints a custom deprecation warning message without returning.
- * This should be preferred to `WARN_PRINT` for deprecation warnings.
- */
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                \
-	{                                                                                                                                                             \
-		static volatile bool warning_shown = false;                                                                                                               \
-		if (!warning_shown) {                                                                                                                                     \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, ERR_HANDLER_WARNING); \
-			warning_shown = true;                                                                                                                                 \
-		}                                                                                                                                                         \
+#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                           \
+	{                                                                                                                                                                        \
+		static volatile bool warning_shown = false;                                                                                                                          \
+		if (!warning_shown) {                                                                                                                                                \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
+			warning_shown = true;                                                                                                                                            \
+		}                                                                                                                                                                    \
+	}
+
+// Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
+
+#define CRASH_NOW()                                                                           \
+	{                                                                                         \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/Function Failed."); \
+		GENERATE_TRAP();                                                                      \
+	}
+
+#define CRASH_NOW_MSG(m_msg)                                                                                    \
+	{                                                                                                           \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/Function Failed.", DEBUG_STR(m_msg)); \
+		GENERATE_TRAP();                                                                                        \
 	}
 
 #endif

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -393,11 +393,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg)); \
 	}
 
-#define ERR_PRINTS(m_msg)                                                     \
-	{                                                                         \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg)); \
-	}
-
 // Only prints the error message once.
 
 #define ERR_PRINT_ONCE(m_msg)                                                     \

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -230,38 +230,38 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 // The current function returns.
 
 #define ERR_FAIL_NULL(m_param)                                                                              \
-	{                                                                                                       \
+	do {                                                                                                    \
 		if (unlikely(!m_param)) {                                                                           \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
 			return;                                                                                         \
 		}                                                                                                   \
-	}
+	} while (0)
 
 #define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                                     \
-	{                                                                                                                         \
+	do {                                                                                                                      \
 		if (unlikely(!m_param)) {                                                                                             \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
 			return;                                                                                                           \
 		}                                                                                                                     \
-	}
+	} while (0)
 
 // The current function returns m_retval.
 
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                                  \
-	{                                                                                                       \
+	do {                                                                                                    \
 		if (unlikely(!m_param)) {                                                                           \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
 			return m_retval;                                                                                \
 		}                                                                                                   \
-	}
+	} while (0)
 
 #define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                                         \
-	{                                                                                                                         \
+	do {                                                                                                                      \
 		if (unlikely(!m_param)) {                                                                                             \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
 			return m_retval;                                                                                                  \
 		}                                                                                                                     \
-	}
+	} while (0)
 
 // Error condition macros.
 // Ensures that `m_cond` is not true.
@@ -269,193 +269,193 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 // The current function returns.
 
 #define ERR_FAIL_COND(m_cond)                                                                              \
-	{                                                                                                      \
+	do {                                                                                                   \
 		if (unlikely(m_cond)) {                                                                            \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
 			return;                                                                                        \
 		}                                                                                                  \
-	}
+	} while (0)
 
 #define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                                     \
-	{                                                                                                                        \
+	do {                                                                                                                     \
 		if (unlikely(m_cond)) {                                                                                              \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
 			return;                                                                                                          \
 		}                                                                                                                    \
-	}
+	} while (0)
 
 // The current function returns m_retval.
 
 #define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                            \
-	{                                                                                                                                \
+	do {                                                                                                                             \
 		if (unlikely(m_cond)) {                                                                                                      \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. returned: " _STR(m_retval)); \
 			return m_retval;                                                                                                         \
 		}                                                                                                                            \
-	}
+	} while (0)
 
 #define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                                   \
-	{                                                                                                                                                  \
+	do {                                                                                                                                               \
 		if (unlikely(m_cond)) {                                                                                                                        \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. returned: " _STR(m_retval), DEBUG_STR(m_msg)); \
 			return m_retval;                                                                                                                           \
 		}                                                                                                                                              \
-	}
+	} while (0)
 
 // The current loop continues.
 
-#define ERR_CONTINUE(m_cond)                                                                                           \
-	{                                                                                                                  \
-		if (unlikely(m_cond)) {                                                                                        \
+#define ERR_CONTINUE(m_cond)                                                                                             \
+	do {                                                                                                                 \
+		if (unlikely(m_cond)) {                                                                                          \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
-			continue;                                                                                                  \
-		}                                                                                                              \
-	}
+			continue;                                                                                                    \
+		}                                                                                                                \
+	} while (0)
 
-#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                                  \
-	{                                                                                                                                    \
-		if (unlikely(m_cond)) {                                                                                                          \
+#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                                    \
+	do {                                                                                                                                   \
+		if (unlikely(m_cond)) {                                                                                                            \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", DEBUG_STR(m_msg)); \
-			continue;                                                                                                                    \
-		}                                                                                                                                \
-	}
+			continue;                                                                                                                      \
+		}                                                                                                                                  \
+	} while (0)
 
 // The current loop breaks.
 
-#define ERR_BREAK(m_cond)                                                                                            \
-	{                                                                                                                \
-		if (unlikely(m_cond)) {                                                                                      \
+#define ERR_BREAK(m_cond)                                                                                              \
+	do {                                                                                                               \
+		if (unlikely(m_cond)) {                                                                                        \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
-			break;                                                                                                   \
-		}                                                                                                            \
-	}
+			break;                                                                                                     \
+		}                                                                                                              \
+	} while (0)
 
-#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                                   \
-	{                                                                                                                                  \
-		if (unlikely(m_cond)) {                                                                                                        \
+#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                                     \
+	do {                                                                                                                                 \
+		if (unlikely(m_cond)) {                                                                                                          \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", DEBUG_STR(m_msg)); \
-			break;                                                                                                                     \
-		}                                                                                                                              \
-	}
+			break;                                                                                                                       \
+		}                                                                                                                                \
+	} while (0)
 
 // Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
 
 #define CRASH_COND(m_cond)                                                                                        \
-	{                                                                                                             \
+	do {                                                                                                          \
 		if (unlikely(m_cond)) {                                                                                   \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
 			GENERATE_TRAP();                                                                                      \
 		}                                                                                                         \
-	}
+	} while (0)
 
 #define CRASH_COND_MSG(m_cond, m_msg)                                                                                               \
-	{                                                                                                                               \
+	do {                                                                                                                            \
 		if (unlikely(m_cond)) {                                                                                                     \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
 			GENERATE_TRAP();                                                                                                        \
 		}                                                                                                                           \
-	}
+	} while (0)
 
 // Generic error macros.
 
 // The current function returns.
 
 #define ERR_FAIL()                                                                     \
-	{                                                                                  \
+	do {                                                                               \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed."); \
 		return;                                                                        \
-	}
+	} while (0)
 
 #define ERR_FAIL_MSG(m_msg)                                                                              \
-	{                                                                                                    \
+	do {                                                                                                 \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed.", DEBUG_STR(m_msg)); \
 		return;                                                                                          \
-	}
+	} while (0)
 
 // The current function returns m_retval.
 
 #define ERR_FAIL_V(m_retval)                                                                                      \
-	{                                                                                                             \
+	do {                                                                                                          \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed, returning: " __STR(m_value)); \
 		return m_retval;                                                                                          \
-	}
+	} while (0)
 
 #define ERR_FAIL_V_MSG(m_value, m_msg)                                                                                              \
-	{                                                                                                                               \
+	do {                                                                                                                            \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed, returning: " __STR(m_value), DEBUG_STR(m_msg)); \
 		return m_value;                                                                                                             \
-	}
+	} while (0)
 
 // Print error message macros.
 
 #define ERR_PRINT(m_msg)                                                      \
-	{                                                                         \
+	do {                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg)); \
-	}
+	} while (0)
 
 // Only prints the error message once.
 
 #define ERR_PRINT_ONCE(m_msg)                                                     \
-	{                                                                             \
+	do {                                                                          \
 		static bool first_print = true;                                           \
 		if (first_print) {                                                        \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg)); \
 			first_print = false;                                                  \
 		}                                                                         \
-	}
+	} while (0)
 
 // Print warning message macros.
 // To warn about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
 
 #define WARN_PRINT(m_msg)                                                                          \
-	{                                                                                              \
+	do {                                                                                           \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
-	}
+	} while (0)
 
 // Only prints the warning message once.
 
 #define WARN_PRINT_ONCE(m_msg)                                                                         \
-	{                                                                                                  \
+	do {                                                                                               \
 		static bool first_print = true;                                                                \
 		if (first_print) {                                                                             \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
 			first_print = false;                                                                       \
 		}                                                                                              \
-	}
+	} while (0)
 
 // Print deprecated warning message macros.
 // Only prints the warning message once.
 
-#define WARN_DEPRECATED                                                                                                                                    \
-	{                                                                                                                                                      \
-		static volatile bool warning_shown = false;                                                                                                        \
-		if (!warning_shown) {                                                                                                                              \
+#define WARN_DEPRECATED                                                                                                                                   \
+	do {                                                                                                                                                  \
+		static volatile bool warning_shown = false;                                                                                                       \
+		if (!warning_shown) {                                                                                                                             \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", ERR_HANDLER_WARNING); \
-			warning_shown = true;                                                                                                                          \
-		}                                                                                                                                                  \
-	}
+			warning_shown = true;                                                                                                                         \
+		}                                                                                                                                                 \
+	} while (0)
 
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                           \
-	{                                                                                                                                                                        \
-		static volatile bool warning_shown = false;                                                                                                                          \
-		if (!warning_shown) {                                                                                                                                                \
+#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                          \
+	do {                                                                                                                                                                    \
+		static volatile bool warning_shown = false;                                                                                                                         \
+		if (!warning_shown) {                                                                                                                                               \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
-			warning_shown = true;                                                                                                                                            \
-		}                                                                                                                                                                    \
-	}
+			warning_shown = true;                                                                                                                                           \
+		}                                                                                                                                                                   \
+	} while (0)
 
 // Only use CRASH macros if there is no sensible fallback, that is, the error is unrecoverable.
 
 #define CRASH_NOW()                                                                           \
-	{                                                                                         \
+	do {                                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/Function Failed."); \
 		GENERATE_TRAP();                                                                      \
-	}
+	} while (0)
 
 #define CRASH_NOW_MSG(m_msg)                                                                                    \
-	{                                                                                                           \
+	do {                                                                                                        \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/Function Failed.", DEBUG_STR(m_msg)); \
 		GENERATE_TRAP();                                                                                        \
-	}
+	} while (0)
 
 #endif

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -412,11 +412,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
 	}
 
-#define WARN_PRINTS(m_msg)                                                                         \
-	{                                                                                              \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
-	}
-
 // Only prints the warning message once.
 
 #define WARN_PRINT_ONCE(m_msg)                                                                         \

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1879,7 +1879,7 @@ Image::AlphaMode Image::detect_alpha() const {
 Error Image::load(const String &p_path) {
 #ifdef DEBUG_ENABLED
 	if (p_path.begins_with("res://") && ResourceLoader::exists(p_path)) {
-		WARN_PRINTS("Loaded resource as image file, this will not work on export: '" + p_path + "'. Instead, import the image file as an Image resource and load it normally as a resource.");
+		WARN_PRINT("Loaded resource as image file, this will not work on export: '" + p_path + "'. Instead, import the image file as an Image resource and load it normally as a resource.");
 	}
 #endif
 	return ImageLoader::load_image(p_path, this);

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -275,7 +275,7 @@ Error ConfigFile::_internal_load(const String &p_path, FileAccess *f) {
 			memdelete(f);
 			return OK;
 		} else if (err != OK) {
-			ERR_PRINTS("ConfgFile::load - " + p_path + ":" + itos(lines) + " error: " + error_text + ".");
+			ERR_PRINT("ConfgFile::load - " + p_path + ":" + itos(lines) + " error: " + error_text + ".");
 			memdelete(f);
 			return err;
 		}

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -53,7 +53,7 @@ Error ImageLoader::load_image(String p_file, Ref<Image> p_image, FileAccess *p_c
 		Error err;
 		f = FileAccess::open(p_file, FileAccess::READ, &err);
 		if (!f) {
-			ERR_PRINTS("Error opening file '" + p_file + "'.");
+			ERR_PRINT("Error opening file '" + p_file + "'.");
 			return err;
 		}
 	}
@@ -66,7 +66,7 @@ Error ImageLoader::load_image(String p_file, Ref<Image> p_image, FileAccess *p_c
 			continue;
 		Error err = loader[i]->load_image(p_image, f, p_force_linear, p_scale);
 		if (err != OK) {
-			ERR_PRINTS("Error loading image: " + p_file);
+			ERR_PRINT("Error loading image: " + p_file);
 		}
 
 		if (err != ERR_FILE_UNRECOGNIZED) {

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -184,7 +184,7 @@ IP_Address IP::get_resolve_item_address(ResolverID p_id) const {
 	resolver->mutex->lock();
 
 	if (resolver->queue[p_id].status != IP::RESOLVER_STATUS_DONE) {
-		ERR_PRINTS("Resolve of '" + resolver->queue[p_id].hostname + "'' didn't complete yet.");
+		ERR_PRINT("Resolve of '" + resolver->queue[p_id].hostname + "'' didn't complete yet.");
 		resolver->mutex->unlock();
 		return IP_Address();
 	}

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -253,7 +253,7 @@ Node *MultiplayerAPI::_process_get_node(int p_from, const uint8_t *p_packet, int
 		node = root_node->get_node(np);
 
 		if (!node)
-			ERR_PRINTS("Failed to get path from RPC: " + String(np) + ".");
+			ERR_PRINT("Failed to get path from RPC: " + String(np) + ".");
 	} else {
 		// Use cached path.
 		int id = target;
@@ -269,7 +269,7 @@ Node *MultiplayerAPI::_process_get_node(int p_from, const uint8_t *p_packet, int
 
 		node = root_node->get_node(ni->path);
 		if (!node)
-			ERR_PRINTS("Failed to get cached path from RPC: " + String(ni->path) + ".");
+			ERR_PRINT("Failed to get cached path from RPC: " + String(ni->path) + ".");
 	}
 	return node;
 }
@@ -324,7 +324,7 @@ void MultiplayerAPI::_process_rpc(Node *p_node, const StringName &p_name, int p_
 	if (ce.error != Variant::CallError::CALL_OK) {
 		String error = Variant::get_call_error_text(p_node, p_name, (const Variant **)argp.ptr(), argc, ce);
 		error = "RPC - " + error;
-		ERR_PRINTS(error);
+		ERR_PRINT(error);
 	}
 }
 
@@ -362,7 +362,7 @@ void MultiplayerAPI::_process_rset(Node *p_node, const StringName &p_name, int p
 	p_node->set(p_name, value, &valid);
 	if (!valid) {
 		String error = "Error setting remote property '" + String(p_name) + "', not found in object of type " + p_node->get_class() + ".";
-		ERR_PRINTS(error);
+		ERR_PRINT(error);
 	}
 }
 
@@ -683,7 +683,7 @@ void MultiplayerAPI::rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const 
 		if (ce.error != Variant::CallError::CALL_OK) {
 			String error = Variant::get_call_error_text(p_node, p_method, p_arg, p_argcount, ce);
 			error = "rpc() aborted in local call:  - " + error + ".";
-			ERR_PRINTS(error);
+			ERR_PRINT(error);
 			return;
 		}
 	}
@@ -698,7 +698,7 @@ void MultiplayerAPI::rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const 
 		if (ce.error != Variant::CallError::CALL_OK) {
 			String error = Variant::get_call_error_text(p_node, p_method, p_arg, p_argcount, ce);
 			error = "rpc() aborted in script local call:  - " + error + ".";
-			ERR_PRINTS(error);
+			ERR_PRINT(error);
 			return;
 		}
 	}
@@ -735,7 +735,7 @@ void MultiplayerAPI::rsetp(Node *p_node, int p_peer_id, bool p_unreliable, const
 
 			if (!valid) {
 				String error = "rset() aborted in local set, property not found:  - " + String(p_property) + ".";
-				ERR_PRINTS(error);
+				ERR_PRINT(error);
 				return;
 			}
 		} else if (p_node->get_script_instance()) {
@@ -753,7 +753,7 @@ void MultiplayerAPI::rsetp(Node *p_node, int p_peer_id, bool p_unreliable, const
 
 				if (!valid) {
 					String error = "rset() aborted in local script set, property not found:  - " + String(p_property) + ".";
-					ERR_PRINTS(error);
+					ERR_PRINT(error);
 					return;
 				}
 			}

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -222,7 +222,7 @@ Error PacketPeerUDP::_poll() {
 
 		if (rb.space_left() < read + 24) {
 #ifdef TOOLS_ENABLED
-			WARN_PRINTS("Buffer full, dropping packets!");
+			WARN_PRINT("Buffer full, dropping packets!");
 #endif
 			continue;
 		}

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1113,7 +1113,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		memdelete(da);
 		//use the old approach
 
-		WARN_PRINTS("This file is old, so it can't refactor dependencies, opening and resaving '" + p_path + "'.");
+		WARN_PRINT("This file is old, so it can't refactor dependencies, opening and resaving '" + p_path + "'.");
 
 		Error err;
 		f = FileAccess::open(p_path, FileAccess::READ, &err);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1635,7 +1635,7 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 
 			if (!p_main && (!bundle_resources) && res->get_path().length() && res->get_path().find("::") == -1) {
 				if (res->get_path() == path) {
-					ERR_PRINTS("Circular reference to resource being saved found: '" + local_path + "' will be null next time it's loaded.");
+					ERR_PRINT("Circular reference to resource being saved found: '" + local_path + "' will be null next time it's loaded.");
 					return;
 				}
 				int idx = external_resources.size();

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -74,7 +74,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 			memdelete(f);
 			return OK;
 		} else if (err != OK) {
-			ERR_PRINTS("ResourceFormatImporter::load - " + p_path + ".import:" + itos(lines) + " error: " + error_text);
+			ERR_PRINT("ResourceFormatImporter::load - " + p_path + ".import:" + itos(lines) + " error: " + error_text);
 			memdelete(f);
 			return err;
 		}
@@ -279,7 +279,7 @@ void ResourceFormatImporter::get_internal_resource_path_list(const String &p_pat
 			memdelete(f);
 			return;
 		} else if (err != OK) {
-			ERR_PRINTS("ResourceFormatImporter::get_internal_resource_path_list - " + p_path + ".import:" + itos(lines) + " error: " + error_text);
+			ERR_PRINT("ResourceFormatImporter::get_internal_resource_path_list - " + p_path + ".import:" + itos(lines) + " error: " + error_text);
 			memdelete(f);
 			return;
 		}

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -815,7 +815,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 				if (err == ERR_FILE_EOF) {
 					break;
 				} else if (err != OK) {
-					ERR_PRINTS("Parse error: " + p_path + ".remap:" + itos(lines) + " error: " + error_text + ".");
+					ERR_PRINT("Parse error: " + p_path + ".remap:" + itos(lines) + " error: " + error_text + ".");
 					break;
 				}
 
@@ -1013,7 +1013,7 @@ void ResourceLoader::finalize() {
 #ifndef NO_THREADS
 	const LoadingMapKey *K = NULL;
 	while ((K = loading_map.next(K))) {
-		ERR_PRINTS("Exited while resource is being loaded: " + K->path);
+		ERR_PRINT("Exited while resource is being loaded: " + K->path);
 	}
 	loading_map.clear();
 	memdelete(loading_map_mutex);

--- a/core/math/bsp_tree.cpp
+++ b/core/math/bsp_tree.cpp
@@ -341,7 +341,7 @@ static int _bsp_create_node(const Face3 *p_faces, const Vector<int> &p_indices, 
 	ERR_FAIL_COND_V(p_nodes.size() == BSP_Tree::MAX_NODES, -1);
 
 	// should not reach here
-	ERR_FAIL_COND_V(p_indices.size() == 0, -1)
+	ERR_FAIL_COND_V(p_indices.size() == 0, -1);
 
 	int ic = p_indices.size();
 	const int *indices = p_indices.ptr();

--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -250,7 +250,7 @@ void MessageQueue::_call_function(Object *p_target, const StringName &p_func, co
 	p_target->call(p_func, argptrs, p_argcount, ce);
 	if (p_show_error && ce.error != Variant::CallError::CALL_OK) {
 
-		ERR_PRINTS("Error calling deferred method: " + Variant::get_call_error_text(p_target, p_func, argptrs, p_argcount, ce) + ".");
+		ERR_PRINT("Error calling deferred method: " + Variant::get_call_error_text(p_target, p_func, argptrs, p_argcount, ce) + ".");
 	}
 }
 

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1225,7 +1225,7 @@ Error Object::emit_signal(const StringName &p_name, const Variant **p_args, int 
 				if (ce.error == Variant::CallError::CALL_ERROR_INVALID_METHOD && !ClassDB::class_exists(target->get_class_name())) {
 					//most likely object is not initialized yet, do not throw error.
 				} else {
-					ERR_PRINTS("Error calling method from signal '" + String(p_name) + "': " + Variant::get_call_error_text(target, c.method, args, argc, ce) + ".");
+					ERR_PRINT("Error calling method from signal '" + String(p_name) + "': " + Variant::get_call_error_text(target, c.method, args, argc, ce) + ".");
 					err = ERR_METHOD_NOT_FOUND;
 				}
 			}
@@ -1945,7 +1945,7 @@ Object::~Object() {
 
 	if (_emitting) {
 		//@todo this may need to actually reach the debugger prioritarily somehow because it may crash before
-		ERR_PRINTS("Object " + to_string() + " was freed or unreferenced while a signal is being emitted from it. Try connecting to the signal using 'CONNECT_DEFERRED' flag, or use queue_free() to free the object (if this object is a Node) to avoid this error and potential crashes.");
+		ERR_PRINT("Object " + to_string() + " was freed or unreferenced while a signal is being emitted from it. Try connecting to the signal using 'CONNECT_DEFERRED' flag, or use queue_free() to free the object (if this object is a Node) to avoid this error and potential crashes.");
 	}
 
 	while ((S = signal_map.next(NULL))) {

--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -285,7 +285,7 @@ Error DirAccess::copy(String p_from, String p_to, int p_chmod_flags) {
 	FileAccess *fsrc = FileAccess::open(p_from, FileAccess::READ, &err);
 
 	if (err) {
-		ERR_PRINTS("Failed to open " + p_from);
+		ERR_PRINT("Failed to open " + p_from);
 		return err;
 	}
 
@@ -294,7 +294,7 @@ Error DirAccess::copy(String p_from, String p_to, int p_chmod_flags) {
 
 		fsrc->close();
 		memdelete(fsrc);
-		ERR_PRINTS("Failed to open " + p_to);
+		ERR_PRINT("Failed to open " + p_to);
 		return err;
 	}
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -188,7 +188,7 @@ int OS::get_process_id() const {
 
 void OS::vibrate_handheld(int p_duration_ms) {
 
-	WARN_PRINTS("vibrate_handheld() only works with Android and iOS");
+	WARN_PRINT("vibrate_handheld() only works with Android and iOS");
 }
 
 bool OS::is_stdout_verbose() const {

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -206,7 +206,7 @@ bool ProjectSettings::_get(const StringName &p_name, Variant &r_ret) const {
 		name = feature_overrides[name];
 	}
 	if (!props.has(name)) {
-		WARN_PRINTS("Property not found: " + String(name));
+		WARN_PRINT("Property not found: " + String(name));
 		return false;
 	}
 	r_ret = props[name].variant;

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -579,7 +579,7 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 			_convert_to_last_version(config_version);
 			return OK;
 		} else if (err != OK) {
-			ERR_PRINTS("Error parsing " + p_path + " at line " + itos(lines) + ": " + error_text + " File might be corrupted.");
+			ERR_PRINT("Error parsing " + p_path + " at line " + itos(lines) + ": " + error_text + " File might be corrupted.");
 			memdelete(f);
 			return err;
 		}
@@ -612,7 +612,7 @@ Error ProjectSettings::_load_settings_text_or_binary(const String &p_text_path, 
 		return OK;
 	} else if (err_text != ERR_FILE_NOT_FOUND) {
 		// If the text-based file exists but can't be loaded, we want to know it
-		ERR_PRINTS("Couldn't load file '" + p_text_path + "', error code " + itos(err_text) + ".");
+		ERR_PRINT("Couldn't load file '" + p_text_path + "', error code " + itos(err_text) + ".");
 		return err_text;
 	}
 

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -966,7 +966,7 @@ void TranslationServer::set_locale(const String &p_locale) {
 		print_verbose(vformat("Unsupported locale '%s', falling back to '%s'.", p_locale, trimmed_locale));
 
 		if (!is_locale_valid(trimmed_locale)) {
-			ERR_PRINTS(vformat("Unsupported locale '%s', falling back to 'en'.", trimmed_locale));
+			ERR_PRINT(vformat("Unsupported locale '%s', falling back to 'en'.", trimmed_locale));
 			locale = "en";
 		} else {
 			locale = trimmed_locale;

--- a/core/type_info.h
+++ b/core/type_info.h
@@ -277,7 +277,7 @@ struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>:
 template <typename T>
 inline StringName __constant_get_enum_name(T param, const String &p_constant) {
 	if (GetTypeInfo<T>::VARIANT_TYPE == Variant::NIL)
-		ERR_PRINTS("Missing VARIANT_ENUM_CAST for constant's enum: " + p_constant);
+		ERR_PRINT("Missing VARIANT_ENUM_CAST for constant's enum: " + p_constant);
 	return GetTypeInfo<T>::get_class_info().class_name;
 }
 

--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -293,7 +293,7 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
 				Variant::CallError ce;
 				obj->call(op.name, (const Variant **)argptrs.ptr(), argc, ce);
 				if (ce.error != Variant::CallError::CALL_OK) {
-					ERR_PRINTS("Error calling method from signal '" + String(op.name) + "': " + Variant::get_call_error_text(obj, op.name, (const Variant **)argptrs.ptr(), argc, ce));
+					ERR_PRINT("Error calling method from signal '" + String(op.name) + "': " + Variant::get_call_error_text(obj, op.name, (const Variant **)argptrs.ptr(), argc, ce));
 				}
 #ifdef TOOLS_ENABLED
 				Resource *res = Object::cast_to<Resource>(obj);

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -204,7 +204,7 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 			} else {
 				wrote = snd_pcm_recover(ad->pcm_handle, wrote, 0);
 				if (wrote < 0) {
-					ERR_PRINTS("ALSA: Failed and can't recover: " + String(snd_strerror(wrote)));
+					ERR_PRINT("ALSA: Failed and can't recover: " + String(snd_strerror(wrote)));
 					ad->active = false;
 					ad->exit_thread = true;
 				}

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -91,7 +91,7 @@ void MIDIDriverALSAMidi::thread_func(void *p_udata) {
 				ret = snd_rawmidi_read(midi_in, &byte, 1);
 				if (ret < 0) {
 					if (ret != -EAGAIN) {
-						ERR_PRINTS("snd_rawmidi_read error: " + String(snd_strerror(ret)));
+						ERR_PRINT("snd_rawmidi_read error: " + String(snd_strerror(ret)));
 					}
 				} else {
 					if (byte & 0x80) {

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -241,7 +241,7 @@ OSStatus AudioDriverCoreAudio::input_callback(void *inRefCon,
 			}
 		}
 	} else {
-		ERR_PRINTS("AudioUnitRender failed, code: " + itos(result));
+		ERR_PRINT("AudioUnitRender failed, code: " + itos(result));
 	}
 
 	ad->unlock();
@@ -253,7 +253,7 @@ void AudioDriverCoreAudio::start() {
 	if (!active) {
 		OSStatus result = AudioOutputUnitStart(audio_unit);
 		if (result != noErr) {
-			ERR_PRINTS("AudioOutputUnitStart failed, code: " + itos(result));
+			ERR_PRINT("AudioOutputUnitStart failed, code: " + itos(result));
 		} else {
 			active = true;
 		}
@@ -264,7 +264,7 @@ void AudioDriverCoreAudio::stop() {
 	if (active) {
 		OSStatus result = AudioOutputUnitStop(audio_unit);
 		if (result != noErr) {
-			ERR_PRINTS("AudioOutputUnitStop failed, code: " + itos(result));
+			ERR_PRINT("AudioOutputUnitStop failed, code: " + itos(result));
 		} else {
 			active = false;
 		}
@@ -491,7 +491,7 @@ Error AudioDriverCoreAudio::capture_start() {
 
 	OSStatus result = AudioOutputUnitStart(input_unit);
 	if (result != noErr) {
-		ERR_PRINTS("AudioOutputUnitStart failed, code: " + itos(result));
+		ERR_PRINT("AudioOutputUnitStart failed, code: " + itos(result));
 	}
 
 	return OK;
@@ -502,7 +502,7 @@ Error AudioDriverCoreAudio::capture_stop() {
 	if (input_unit) {
 		OSStatus result = AudioOutputUnitStop(input_unit);
 		if (result != noErr) {
-			ERR_PRINTS("AudioOutputUnitStop failed, code: " + itos(result));
+			ERR_PRINT("AudioOutputUnitStop failed, code: " + itos(result));
 		}
 	}
 

--- a/drivers/coremidi/midi_driver_coremidi.cpp
+++ b/drivers/coremidi/midi_driver_coremidi.cpp
@@ -51,13 +51,13 @@ Error MIDIDriverCoreMidi::open() {
 	OSStatus result = MIDIClientCreate(name, NULL, NULL, &client);
 	CFRelease(name);
 	if (result != noErr) {
-		ERR_PRINTS("MIDIClientCreate failed, code: " + itos(result));
+		ERR_PRINT("MIDIClientCreate failed, code: " + itos(result));
 		return ERR_CANT_OPEN;
 	}
 
 	result = MIDIInputPortCreate(client, CFSTR("Godot Input"), MIDIDriverCoreMidi::read, (void *)this, &port_in);
 	if (result != noErr) {
-		ERR_PRINTS("MIDIInputPortCreate failed, code: " + itos(result));
+		ERR_PRINT("MIDIInputPortCreate failed, code: " + itos(result));
 		return ERR_CANT_OPEN;
 	}
 

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -130,7 +130,7 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 
 	String output = String() + "GL ERROR: Source: " + debSource + "\tType: " + debType + "\tID: " + itos(id) + "\tSeverity: " + debSev + "\tMessage: " + message;
 
-	ERR_PRINTS(output);
+	ERR_PRINT(output);
 }
 #endif // CAN_DEBUG
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4709,7 +4709,7 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 		int max_samples = 0;
 		glGetIntegerv(GL_MAX_SAMPLES, &max_samples);
 		if (msaa > max_samples) {
-			WARN_PRINTS("MSAA must be <= GL_MAX_SAMPLES, falling-back to GL_MAX_SAMPLES = " + itos(max_samples));
+			WARN_PRINT("MSAA must be <= GL_MAX_SAMPLES, falling-back to GL_MAX_SAMPLES = " + itos(max_samples));
 			msaa = max_samples;
 		}
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -591,7 +591,7 @@ void RasterizerStorageGLES2::texture_allocate(RID p_texture, int p_width, int p_
 
 			if (p_flags & VS::TEXTURE_FLAG_USED_FOR_STREAMING) {
 				//not supported
-				ERR_PRINTS("Streaming texture for non power of 2 or has mipmaps on this hardware: " + texture->path + "'. Mipmaps and repeat disabled.");
+				ERR_PRINT("Streaming texture for non power of 2 or has mipmaps on this hardware: " + texture->path + "'. Mipmaps and repeat disabled.");
 				texture->flags &= ~(VS::TEXTURE_FLAG_REPEAT | VS::TEXTURE_FLAG_MIPMAPS);
 			} else {
 				texture->alloc_height = po2_height;
@@ -650,7 +650,7 @@ void RasterizerStorageGLES2::texture_set_data(RID p_texture, const Ref<Image> &p
 
 	if (texture->resize_to_po2) {
 		if (p_image->is_compressed()) {
-			ERR_PRINTS("Texture '" + texture->path + "' is required to be a power of 2 because it uses either mipmaps or repeat, so it was decompressed. This will hurt performance and memory usage.");
+			ERR_PRINT("Texture '" + texture->path + "' is required to be a power of 2 because it uses either mipmaps or repeat, so it was decompressed. This will hurt performance and memory usage.");
 		}
 
 		if (img == p_image) {

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -126,7 +126,7 @@ static void _display_error_with_code(const String &p_error, const Vector<const c
 		line++;
 	}
 
-	ERR_PRINTS(p_error);
+	ERR_PRINT(p_error);
 }
 
 static String _mkid(const String &p_id) {

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -120,7 +120,7 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 
 	String output = String() + "GL ERROR: Source: " + debSource + "\tType: " + debType + "\tID: " + itos(id) + "\tSeverity: " + debSev + "\tMessage: " + message;
 
-	ERR_PRINTS(output);
+	ERR_PRINT(output);
 }
 #endif // GLAD_ENABLED
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -7144,7 +7144,7 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 		int max_samples = 0;
 		glGetIntegerv(GL_MAX_SAMPLES, &max_samples);
 		if (msaa > max_samples) {
-			WARN_PRINTS("MSAA must be <= GL_MAX_SAMPLES, falling-back to GL_MAX_SAMPLES = " + itos(max_samples));
+			WARN_PRINT("MSAA must be <= GL_MAX_SAMPLES, falling-back to GL_MAX_SAMPLES = " + itos(max_samples));
 			msaa = max_samples;
 		}
 

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -161,7 +161,7 @@ static void _display_error_with_code(const String &p_error, const Vector<const c
 		line++;
 	}
 
-	ERR_PRINTS(p_error);
+	ERR_PRINT(p_error);
 }
 
 ShaderGLES3::Version *ShaderGLES3::get_current_version() {

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -176,7 +176,7 @@ Error AudioDriverPulseAudio::init_device() {
 			break;
 
 		default:
-			WARN_PRINTS("PulseAudio: Unsupported number of channels: " + itos(pa_map.channels));
+			WARN_PRINT("PulseAudio: Unsupported number of channels: " + itos(pa_map.channels));
 			pa_channel_map_init_stereo(&pa_map);
 			channels = 2;
 			break;
@@ -666,7 +666,7 @@ Error AudioDriverPulseAudio::capture_init_device() {
 			break;
 
 		default:
-			WARN_PRINTS("PulseAudio: Unsupported number of input channels: " + itos(pa_rec_map.channels));
+			WARN_PRINT("PulseAudio: Unsupported number of input channels: " + itos(pa_rec_map.channels));
 			pa_channel_map_init_stereo(&pa_rec_map);
 			break;
 	}

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -204,7 +204,7 @@ Error AudioDriverPulseAudio::init_device() {
 
 	pa_str = pa_stream_new(pa_ctx, "Sound", &spec, &pa_map);
 	if (pa_str == NULL) {
-		ERR_PRINTS("PulseAudio: pa_stream_new error: " + String(pa_strerror(pa_context_errno(pa_ctx))));
+		ERR_PRINT("PulseAudio: pa_stream_new error: " + String(pa_strerror(pa_context_errno(pa_ctx))));
 		ERR_FAIL_V(ERR_CANT_OPEN);
 	}
 
@@ -388,7 +388,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 				const void *ptr = ad->samples_out.ptr();
 				ret = pa_stream_write(ad->pa_str, (char *)ptr + write_ofs, bytes_to_write, NULL, 0LL, PA_SEEK_RELATIVE);
 				if (ret != 0) {
-					ERR_PRINTS("PulseAudio: pa_stream_write error: " + String(pa_strerror(ret)));
+					ERR_PRINT("PulseAudio: pa_stream_write error: " + String(pa_strerror(ret)));
 				} else {
 					avail_bytes -= bytes_to_write;
 					write_ofs += bytes_to_write;
@@ -686,7 +686,7 @@ Error AudioDriverPulseAudio::capture_init_device() {
 
 	pa_rec_str = pa_stream_new(pa_ctx, "Record", &spec, &pa_rec_map);
 	if (pa_rec_str == NULL) {
-		ERR_PRINTS("PulseAudio: pa_stream_new error: " + String(pa_strerror(pa_context_errno(pa_ctx))));
+		ERR_PRINT("PulseAudio: pa_stream_new error: " + String(pa_strerror(pa_context_errno(pa_ctx))));
 		ERR_FAIL_V(ERR_CANT_OPEN);
 	}
 
@@ -694,7 +694,7 @@ Error AudioDriverPulseAudio::capture_init_device() {
 	pa_stream_flags flags = pa_stream_flags(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_ADJUST_LATENCY | PA_STREAM_AUTO_TIMING_UPDATE);
 	int error_code = pa_stream_connect_record(pa_rec_str, dev, &attr, flags);
 	if (error_code < 0) {
-		ERR_PRINTS("PulseAudio: pa_stream_connect_record error: " + String(pa_strerror(error_code)));
+		ERR_PRINT("PulseAudio: pa_stream_connect_record error: " + String(pa_strerror(error_code)));
 		ERR_FAIL_V(ERR_CANT_OPEN);
 	}
 
@@ -711,7 +711,7 @@ void AudioDriverPulseAudio::capture_finish_device() {
 	if (pa_rec_str) {
 		int ret = pa_stream_disconnect(pa_rec_str);
 		if (ret != 0) {
-			ERR_PRINTS("PulseAudio: pa_stream_disconnect error: " + String(pa_strerror(ret)));
+			ERR_PRINT("PulseAudio: pa_stream_disconnect error: " + String(pa_strerror(ret)));
 		}
 		pa_stream_unref(pa_rec_str);
 		pa_rec_str = NULL;

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -327,7 +327,7 @@ Error AudioDriverWASAPI::init_render_device(bool reinit) {
 			break;
 
 		default:
-			WARN_PRINTS("WASAPI: Unsupported number of channels: " + itos(audio_output.channels));
+			WARN_PRINT("WASAPI: Unsupported number of channels: " + itos(audio_output.channels));
 			channels = 2;
 			break;
 	}

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -102,7 +102,7 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 
 				String base_file = path.get_file();
 				if (base_file != fname && base_file.findn(fname) == 0) {
-					WARN_PRINTS("Case mismatch opening requested file '" + base_file + "', stored as '" + fname + "' in the filesystem. This file will not open when exported to other case-sensitive platforms.");
+					WARN_PRINT("Case mismatch opening requested file '" + base_file + "', stored as '" + fname + "' in the filesystem. This file will not open when exported to other case-sensitive platforms.");
 				}
 			}
 			FindClose(f);

--- a/drivers/winmidi/midi_driver_winmidi.cpp
+++ b/drivers/winmidi/midi_driver_winmidi.cpp
@@ -53,12 +53,12 @@ Error MIDIDriverWinMidi::open() {
 		} else {
 			char err[256];
 			midiInGetErrorText(res, err, 256);
-			ERR_PRINTS("midiInOpen error: " + String(err));
+			ERR_PRINT("midiInOpen error: " + String(err));
 
 			MIDIINCAPS caps;
 			res = midiInGetDevCaps(i, &caps, sizeof(MIDIINCAPS));
 			if (res == MMSYSERR_NOERROR) {
-				ERR_PRINTS("Can't open MIDI device \"" + String(caps.szPname) + "\", is it being used by another application?");
+				ERR_PRINT("Can't open MIDI device \"" + String(caps.szPname) + "\", is it being used by another application?");
 			}
 		}
 	}

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -748,7 +748,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			config.instance();
 			Error err = config->load(path + ".import");
 			if (err != OK) {
-				ERR_PRINTS("Could not parse: '" + path + "', not exported.");
+				ERR_PRINT("Could not parse: '" + path + "', not exported.");
 				continue;
 			}
 

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -192,14 +192,14 @@ Error EditorFeatureProfile::load_from_file(const String &p_path) {
 	Variant v;
 	err = JSON::parse(text, v, err_str, err_line);
 	if (err != OK) {
-		ERR_PRINTS("Error parsing '" + p_path + "' on line " + itos(err_line) + ": " + err_str);
+		ERR_PRINT("Error parsing '" + p_path + "' on line " + itos(err_line) + ": " + err_str);
 		return ERR_PARSE_ERROR;
 	}
 
 	Dictionary json = v;
 
 	if (!json.has("type") || String(json["type"]) != "feature_profile") {
-		ERR_PRINTS("Error parsing '" + p_path + "', it's not a feature profile.");
+		ERR_PRINT("Error parsing '" + p_path + "', it's not a feature profile.");
 		return ERR_PARSE_ERROR;
 	}
 
@@ -298,7 +298,7 @@ void EditorFeatureProfileManager::_notification(int p_what) {
 			current.instance();
 			Error err = current->load_from_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(current_profile + ".profile"));
 			if (err != OK) {
-				ERR_PRINTS("Error loading default feature profile: " + current_profile);
+				ERR_PRINT("Error loading default feature profile: " + current_profile);
 				current_profile = String();
 				current.unref();
 			}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -387,7 +387,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 		if (err == ERR_FILE_EOF) {
 			break;
 		} else if (err != OK) {
-			ERR_PRINTS("ResourceFormatImporter::load - '" + p_path + ".import:" + itos(lines) + "' error '" + error_text + "'.");
+			ERR_PRINT("ResourceFormatImporter::load - '" + p_path + ".import:" + itos(lines) + "' error '" + error_text + "'.");
 			memdelete(f);
 			return false; //parse error, try reimport manually (Avoid reimport loop on broken file)
 		}
@@ -435,7 +435,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 		if (err == ERR_FILE_EOF) {
 			break;
 		} else if (err != OK) {
-			ERR_PRINTS("ResourceFormatImporter::load - '" + p_path + ".import.md5:" + itos(lines) + "' error '" + error_text + "'.");
+			ERR_PRINT("ResourceFormatImporter::load - '" + p_path + ".import.md5:" + itos(lines) + "' error '" + error_text + "'.");
 			memdelete(md5s);
 			return false; // parse error
 		}
@@ -734,7 +734,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, DirAccess
 				da->change_dir("..");
 			}
 		} else {
-			ERR_PRINTS("Cannot go into subdir '" + E->get() + "'.");
+			ERR_PRINT("Cannot go into subdir '" + E->get() + "'.");
 		}
 
 		p_progress.update(idx, total);
@@ -1780,7 +1780,7 @@ void EditorFileSystem::_reimport_file(const String &p_file) {
 	Error err = importer->import(p_file, base_path, params, &import_variants, &gen_files, &metadata);
 
 	if (err != OK) {
-		ERR_PRINTS("Error importing '" + p_file + "'.");
+		ERR_PRINT("Error importing '" + p_file + "'.");
 	}
 
 	//as import is complete, save the .import file

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1114,7 +1114,7 @@ void EditorFileSystem::_notification(int p_what) {
 				Thread::wait_to_finish(thread);
 				memdelete(thread);
 				thread = NULL;
-				WARN_PRINTS("Scan thread aborted...");
+				WARN_PRINT("Scan thread aborted...");
 				set_process(false);
 			}
 

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -307,7 +307,7 @@ bool EditorHelpSearch::Runner::_slice() {
 		case PHASE_MAX:
 			return true;
 		default:
-			WARN_PRINTS("Invalid or unhandled phase in EditorHelpSearch::Runner, aborting search.");
+			WARN_PRINT("Invalid or unhandled phase in EditorHelpSearch::Runner, aborting search.");
 			return true;
 	};
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2732,7 +2732,7 @@ void EditorNode::_tool_menu_option(int p_idx) {
 				handler->call(callback, (const Variant **)&ud, 1, ce);
 				if (ce.error != Variant::CallError::CALL_OK) {
 					String err = Variant::get_call_error_text(handler, callback, (const Variant **)&ud, 1, ce);
-					ERR_PRINTS("Error calling function from tool menu: " + err);
+					ERR_PRINT("Error calling function from tool menu: " + err);
 				}
 			} // else it's a submenu so don't do anything.
 		} break;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3042,7 +3042,7 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 		}
 		ps->set("editor_plugins/enabled", enabled_plugins);
 		ps->save();
-		WARN_PRINTS("Addon '" + p_addon + "' failed to load. No directory found. Removing from enabled plugins.");
+		WARN_PRINT("Addon '" + p_addon + "' failed to load. No directory found. Removing from enabled plugins.");
 		return;
 	}
 	Error err = cf->load(addon_path);
@@ -3988,7 +3988,7 @@ void EditorNode::show_warning(const String &p_text, const String &p_title) {
 		warning->set_title(p_title);
 		warning->popup_centered_minsize();
 	} else {
-		WARN_PRINTS(p_title + " " + p_text);
+		WARN_PRINT(p_title + " " + p_text);
 	}
 }
 

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -96,28 +96,28 @@ void EditorPluginSettings::update_plugins() {
 		Error err2 = cf->load(path);
 
 		if (err2 != OK) {
-			WARN_PRINTS("Can't load plugin config: " + path);
+			WARN_PRINT("Can't load plugin config: " + path);
 		} else {
 			bool key_missing = false;
 
 			if (!cf->has_section_key("plugin", "name")) {
-				WARN_PRINTS("Plugin config misses \"plugin/name\" key: " + path);
+				WARN_PRINT("Plugin config misses \"plugin/name\" key: " + path);
 				key_missing = true;
 			}
 			if (!cf->has_section_key("plugin", "author")) {
-				WARN_PRINTS("Plugin config misses \"plugin/author\" key: " + path);
+				WARN_PRINT("Plugin config misses \"plugin/author\" key: " + path);
 				key_missing = true;
 			}
 			if (!cf->has_section_key("plugin", "version")) {
-				WARN_PRINTS("Plugin config misses \"plugin/version\" key: " + path);
+				WARN_PRINT("Plugin config misses \"plugin/version\" key: " + path);
 				key_missing = true;
 			}
 			if (!cf->has_section_key("plugin", "description")) {
-				WARN_PRINTS("Plugin config misses \"plugin/description\" key: " + path);
+				WARN_PRINT("Plugin config misses \"plugin/description\" key: " + path);
 				key_missing = true;
 			}
 			if (!cf->has_section_key("plugin", "script")) {
-				WARN_PRINTS("Plugin config misses \"plugin/script\" key: " + path);
+				WARN_PRINT("Plugin config misses \"plugin/script\" key: " + path);
 				key_missing = true;
 			}
 

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -297,7 +297,7 @@ void EditorResourcePreview::_thread() {
 								if (!f) {
 									// Not returning as this would leave the thread hanging and would require
 									// some proper cleanup/disabling of resource preview generation.
-									ERR_PRINTS("Cannot create file '" + file + "'. Check user write permissions.");
+									ERR_PRINT("Cannot create file '" + file + "'. Check user write permissions.");
 								} else {
 									f->store_line(itos(thumbnail_size));
 									f->store_line(itos(has_small_texture));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -794,13 +794,13 @@ void EditorSettings::create() {
 		self_contained = true;
 		Error err = extra_config->load(exe_path + "/._sc_");
 		if (err != OK) {
-			ERR_PRINTS("Can't load config from path '" + exe_path + "/._sc_'.");
+			ERR_PRINT("Can't load config from path '" + exe_path + "/._sc_'.");
 		}
 	} else if (d->file_exists(exe_path + "/_sc_")) {
 		self_contained = true;
 		Error err = extra_config->load(exe_path + "/_sc_");
 		if (err != OK) {
-			ERR_PRINTS("Can't load config from path '" + exe_path + "/_sc_'.");
+			ERR_PRINT("Can't load config from path '" + exe_path + "/_sc_'.");
 		}
 	}
 	memdelete(d);
@@ -1056,7 +1056,7 @@ void EditorSettings::save() {
 	Error err = ResourceSaver::save(singleton->config_file_path, singleton);
 
 	if (err != OK) {
-		ERR_PRINTS("Error saving editor settings to " + singleton->config_file_path);
+		ERR_PRINT("Error saving editor settings to " + singleton->config_file_path);
 	} else {
 		print_verbose("EditorSettings: Save OK!");
 	}

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -148,7 +148,7 @@ bool EditorSettings::_get(const StringName &p_name, Variant &r_ret) const {
 
 	const VariantContainer *v = props.getptr(p_name);
 	if (!v) {
-		WARN_PRINTS("EditorSettings::_get - Property not found: " + String(p_name));
+		WARN_PRINT("EditorSettings::_get - Property not found: " + String(p_name));
 		return false;
 	}
 	r_ret = v->variant;

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -63,7 +63,7 @@ void EditorVCSInterface::_bind_methods() {
 
 bool EditorVCSInterface::_initialize(String p_project_root_path) {
 
-	WARN_PRINT("Selected VCS addon does not implement an initialization function. This warning will be suppressed.")
+	WARN_PRINT("Selected VCS addon does not implement an initialization function. This warning will be suppressed.");
 	return true;
 }
 

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -638,7 +638,7 @@ Error ExportTemplateManager::install_android_template() {
 				FileAccess::set_unix_permissions(to_write, (info.external_fa >> 16) & 0x01FF);
 #endif
 			} else {
-				ERR_PRINTS("Can't uncompress file: " + to_write);
+				ERR_PRINT("Can't uncompress file: " + to_write);
 			}
 		}
 

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -892,7 +892,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 						material = material_cache[target];
 
 				} else if (p.material != "") {
-					WARN_PRINTS("Collada: Unreferenced material in geometry instance: " + p.material);
+					WARN_PRINT("Collada: Unreferenced material in geometry instance: " + p.material);
 				}
 			}
 
@@ -1210,7 +1210,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 					mesh_cache[meshid] = mesh;
 				} else {
 
-					WARN_PRINTS("Collada: Will not import geometry: " + meshid);
+					WARN_PRINT("Collada: Will not import geometry: " + meshid);
 				}
 			}
 
@@ -1237,7 +1237,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 
 							mi->set_surface_material(i, material);
 						} else if (matname != "") {
-							WARN_PRINTS("Collada: Unreferenced material in geometry instance: " + matname);
+							WARN_PRINT("Collada: Unreferenced material in geometry instance: " + matname);
 						}
 					}
 				}
@@ -1408,7 +1408,7 @@ void ColladaImport::create_animations(bool p_make_tracks_in_all_bones, bool p_im
 
 				node = node_name_map[at.target];
 			} else {
-				WARN_PRINTS("Collada: Couldn't find node: " + at.target);
+				WARN_PRINT("Collada: Couldn't find node: " + at.target);
 				continue;
 			}
 		} else {
@@ -1588,7 +1588,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 				}
 
 				if (xform_idx == -1) {
-					WARN_PRINTS("Collada: Couldn't find matching node " + at.target + " xform for track " + at.param + ".");
+					WARN_PRINT("Collada: Couldn't find matching node " + at.target + " xform for track " + at.param + ".");
 					continue;
 				}
 
@@ -1666,7 +1666,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 
 			Collada::Node *cn = collada.state.scene_map[E->key()];
 			if (cn->ignore_anim) {
-				WARN_PRINTS("Collada: Ignoring animation on node: " + path);
+				WARN_PRINT("Collada: Ignoring animation on node: " + path);
 				continue;
 			}
 
@@ -1735,7 +1735,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 					//matrix
 					WARN_PRINT("Collada: Value keys for matrices not supported.");
 				} else {
-					WARN_PRINTS("Collada: Unexpected amount of value keys: " + itos(data.size()));
+					WARN_PRINT("Collada: Unexpected amount of value keys: " + itos(data.size()));
 				}
 
 				animation->track_insert_key(track, time, value);

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -2438,7 +2438,7 @@ Error EditorSceneImporterGLTF::_parse_animations(GLTFState &state) {
 					track->weight_tracks.write[k] = cf;
 				}
 			} else {
-				WARN_PRINTS("Invalid path '" + path + "'.");
+				WARN_PRINT("Invalid path '" + path + "'.");
 			}
 		}
 

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -233,7 +233,7 @@ Error EditorSceneImporterGLTF::_parse_scenes(GLTFState &state) {
 	if (state.json.has("scene")) {
 		loaded_scene = state.json["scene"];
 	} else {
-		WARN_PRINT("The load-time scene is not defined in the glTF2 file. Picking the first scene.")
+		WARN_PRINT("The load-time scene is not defined in the glTF2 file. Picking the first scene.");
 	}
 
 	if (scenes.size()) {

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -63,7 +63,7 @@ static Error _parse_material_library(const String &p_path, Map<String, Ref<Spati
 			material_map[current_name] = current;
 		} else if (l.begins_with("Ka ")) {
 			//uv
-			WARN_PRINTS("OBJ: Ambient light for material '" + current_name + "' is ignored in PBR");
+			WARN_PRINT("OBJ: Ambient light for material '" + current_name + "' is ignored in PBR");
 
 		} else if (l.begins_with("Kd ")) {
 			//normal
@@ -119,7 +119,7 @@ static Error _parse_material_library(const String &p_path, Map<String, Ref<Spati
 
 		} else if (l.begins_with("map_Ka ")) {
 			//uv
-			WARN_PRINTS("OBJ: Ambient light texture for material '" + current_name + "' is ignored in PBR");
+			WARN_PRINT("OBJ: Ambient light texture for material '" + current_name + "' is ignored in PBR");
 
 		} else if (l.begins_with("map_Kd ")) {
 			//normal

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -812,7 +812,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 		_image_update(p_code == HTTPClient::RESPONSE_NOT_MODIFIED, true, p_data, p_queue_id);
 
 	} else {
-		WARN_PRINTS("Error getting image file from URL: " + image_queue[p_queue_id].image_url);
+		WARN_PRINT("Error getting image file from URL: " + image_queue[p_queue_id].image_url);
 		Object *obj = ObjectDB::get_instance(image_queue[p_queue_id].target);
 		if (obj) {
 			obj->call("set_image", image_queue[p_queue_id].image_type, image_queue[p_queue_id].image_index, get_icon("FileBrokenBigThumb", "EditorIcons"));

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -203,7 +203,7 @@ void VersionControlEditorPlugin::_refresh_stage_area() {
 		}
 	} else {
 
-		WARN_PRINT("No VCS addon is initialized. Select a Version Control Addon from Project menu.")
+		WARN_PRINT("No VCS addon is initialized. Select a Version Control Addon from Project menu.");
 	}
 }
 

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -974,7 +974,7 @@ void ProjectExportDialog::_export_project_to_path(const String &p_path) {
 			error_dialog->set_text(vformat(TTR("Failed to export the project for platform '%s'.\nThis might be due to a configuration issue in the export preset or your export settings."), platform->get_name()));
 		}
 
-		ERR_PRINTS(vformat("Failed to export the project for platform '%s'.", platform->get_name()));
+		ERR_PRINT(vformat("Failed to export the project for platform '%s'.", platform->get_name()));
 		error_dialog->show();
 		error_dialog->popup_centered_minsize(Size2(300, 80));
 	}

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -612,7 +612,7 @@ void RenameDialog::rename() {
 			const String &new_name = to_rename[i].second;
 
 			if (!n) {
-				ERR_PRINTS("Skipping missing node: " + to_rename[i].first.get_concatenated_subnames());
+				ERR_PRINT("Skipping missing node: " + to_rename[i].first.get_concatenated_subnames());
 				continue;
 			}
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -981,7 +981,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				if (!new_node) {
 					new_node = memnew(Node);
-					ERR_PRINTS("Creating root from favorite '" + selected_favorite_root + "' failed. Creating 'Node' instead.");
+					ERR_PRINT("Creating root from favorite '" + selected_favorite_root + "' failed. Creating 'Node' instead.");
 				}
 			} else {
 				switch (p_tool) {

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -338,7 +338,7 @@ void ScriptEditorDebugger::_file_selected(const String &p_file) {
 			FileAccessRef file = FileAccess::open(p_file, FileAccess::WRITE, &err);
 
 			if (err != OK) {
-				ERR_PRINTS("Failed to open " + p_file);
+				ERR_PRINT("Failed to open " + p_file);
 				return;
 			}
 			Vector<String> line;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1266,7 +1266,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 			boot_logo.instance();
 			Error load_err = ImageLoader::load_image(boot_logo_path, boot_logo);
 			if (load_err)
-				ERR_PRINTS("Non-existing or invalid boot splash at '" + boot_logo_path + "'. Loading default splash.");
+				ERR_PRINT("Non-existing or invalid boot splash at '" + boot_logo_path + "'. Loading default splash.");
 		}
 
 		Color boot_bg_color = GLOBAL_DEF("application/boot_splash/bg_color", boot_splash_bg_color);

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -389,7 +389,7 @@ EditorSceneImporterAssimp::_generate_scene(const String &p_path, aiScene *scene,
 				Spatial *parent_node = parent_lookup->value();
 
 				ERR_FAIL_COND_V_MSG(parent_node == NULL, state.root,
-						"Parent node invalid even though lookup successful, out of ram?")
+						"Parent node invalid even though lookup successful, out of ram?");
 
 				if (spatial != state.root) {
 					parent_node->add_child(spatial);

--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -167,7 +167,7 @@ bool AreaBullet::is_monitoring() const {
 }
 
 void AreaBullet::main_shape_changed() {
-	CRASH_COND(!get_main_shape())
+	CRASH_COND(!get_main_shape());
 	btGhost->setCollisionShape(get_main_shape());
 }
 

--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -245,7 +245,7 @@ void AreaBullet::set_param(PhysicsServer::AreaParameter p_param, const Variant &
 			set_spOv_gravityPointAttenuation(p_value);
 			break;
 		default:
-			WARN_PRINTS("Area doesn't support this parameter in the Bullet backend: " + itos(p_param));
+			WARN_PRINT("Area doesn't support this parameter in the Bullet backend: " + itos(p_param));
 	}
 }
 
@@ -268,7 +268,7 @@ Variant AreaBullet::get_param(PhysicsServer::AreaParameter p_param) const {
 		case PhysicsServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION:
 			return spOv_gravityPointAttenuation;
 		default:
-			WARN_PRINTS("Area doesn't support this parameter in the Bullet backend: " + itos(p_param));
+			WARN_PRINT("Area doesn't support this parameter in the Bullet backend: " + itos(p_param));
 			return Variant();
 	}
 }

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -57,10 +57,10 @@
 
 // <--------------- Joint creation asserts
 /// Assert the body is assigned to a space
-#define JointAssertSpace(body, bIndex, ret)                                                           \
-	if (!body->get_space()) {                                                                         \
-		ERR_PRINTS("Before create a joint the Body" + String(bIndex) + " must be added to a space!"); \
-		return ret;                                                                                   \
+#define JointAssertSpace(body, bIndex, ret)                                                          \
+	if (!body->get_space()) {                                                                        \
+		ERR_PRINT("Before create a joint the Body" + String(bIndex) + " must be added to a space!"); \
+		return ret;                                                                                  \
 	}
 
 /// Assert the two bodies of joint are in the same space

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -320,7 +320,7 @@ void RigidBodyBullet::destroy_kinematic_utilities() {
 }
 
 void RigidBodyBullet::main_shape_changed() {
-	CRASH_COND(!get_main_shape())
+	CRASH_COND(!get_main_shape());
 	btBody->setCollisionShape(get_main_shape());
 	set_continuous_collision_detection(is_continuous_collision_detection_enabled()); // Reset
 }

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -515,7 +515,7 @@ void RigidBodyBullet::set_param(PhysicsServer::BodyParameter p_param, real_t p_v
 			scratch_space_override_modificator();
 			break;
 		default:
-			WARN_PRINTS("Parameter " + itos(p_param) + " not supported by bullet. Value: " + itos(p_value));
+			WARN_PRINT("Parameter " + itos(p_param) + " not supported by bullet. Value: " + itos(p_value));
 	}
 }
 
@@ -536,7 +536,7 @@ real_t RigidBodyBullet::get_param(PhysicsServer::BodyParameter p_param) const {
 		case PhysicsServer::BODY_PARAM_GRAVITY_SCALE:
 			return gravity_scale;
 		default:
-			WARN_PRINTS("Parameter " + itos(p_param) + " not supported by bullet");
+			WARN_PRINT("Parameter " + itos(p_param) + " not supported by bullet");
 			return 0;
 	}
 }
@@ -619,7 +619,7 @@ Variant RigidBodyBullet::get_state(PhysicsServer::BodyState p_state) const {
 		case PhysicsServer::BODY_STATE_CAN_SLEEP:
 			return can_sleep;
 		default:
-			WARN_PRINTS("This state " + itos(p_state) + " is not supported by Bullet");
+			WARN_PRINT("This state " + itos(p_state) + " is not supported by Bullet");
 			return Variant();
 	}
 }

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -110,7 +110,7 @@ bool BulletPhysicsDirectSpaceState::intersect_ray(const Vector3 &p_from, const V
 			r_result.collider_id = gObj->get_instance_id();
 			r_result.collider = 0 == r_result.collider_id ? NULL : ObjectDB::get_instance(r_result.collider_id);
 		} else {
-			WARN_PRINTS("The raycast performed has hit a collision object that is not part of Godot scene, please check it.");
+			WARN_PRINT("The raycast performed has hit a collision object that is not part of Godot scene, please check it.");
 		}
 		return true;
 	} else {
@@ -389,7 +389,7 @@ void SpaceBullet::set_param(PhysicsServer::AreaParameter p_param, const Variant 
 		case PhysicsServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION:
 			break;
 		default:
-			WARN_PRINTS("This set parameter (" + itos(p_param) + ") is ignored, the SpaceBullet doesn't support it.");
+			WARN_PRINT("This set parameter (" + itos(p_param) + ") is ignored, the SpaceBullet doesn't support it.");
 			break;
 	}
 }
@@ -412,7 +412,7 @@ Variant SpaceBullet::get_param(PhysicsServer::AreaParameter p_param) {
 		case PhysicsServer::AREA_PARAM_GRAVITY_POINT_ATTENUATION:
 			return 0;
 		default:
-			WARN_PRINTS("This get parameter (" + itos(p_param) + ") is ignored, the SpaceBullet doesn't support it.");
+			WARN_PRINT("This get parameter (" + itos(p_param) + ") is ignored, the SpaceBullet doesn't support it.");
 			return Variant();
 	}
 }
@@ -428,7 +428,7 @@ void SpaceBullet::set_param(PhysicsServer::SpaceParameter p_param, real_t p_valu
 		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_DAMP_RATIO:
 		case PhysicsServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS:
 		default:
-			WARN_PRINTS("This set parameter (" + itos(p_param) + ") is ignored, the SpaceBullet doesn't support it.");
+			WARN_PRINT("This set parameter (" + itos(p_param) + ") is ignored, the SpaceBullet doesn't support it.");
 			break;
 	}
 }
@@ -444,7 +444,7 @@ real_t SpaceBullet::get_param(PhysicsServer::SpaceParameter p_param) {
 		case PhysicsServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_DAMP_RATIO:
 		case PhysicsServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS:
 		default:
-			WARN_PRINTS("The SpaceBullet  doesn't support this get parameter (" + itos(p_param) + "), 0 is returned.");
+			WARN_PRINT("The SpaceBullet  doesn't support this get parameter (" + itos(p_param) + "), 0 is returned.");
 			return 0.f;
 	}
 }

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -127,7 +127,7 @@ int BulletPhysicsDirectSpaceState::intersect_shape(const RID &p_shape, const Tra
 	btCollisionShape *btShape = shape->create_bt_shape(p_xform.basis.get_scale_abs(), p_margin);
 	if (!btShape->isConvex()) {
 		bulletdelete(btShape);
-		ERR_PRINTS("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
+		ERR_PRINT("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
 		return 0;
 	}
 	btConvexShape *btConvex = static_cast<btConvexShape *>(btShape);
@@ -157,7 +157,7 @@ bool BulletPhysicsDirectSpaceState::cast_motion(const RID &p_shape, const Transf
 	btCollisionShape *btShape = shape->create_bt_shape(p_xform.basis.get_scale(), p_margin);
 	if (!btShape->isConvex()) {
 		bulletdelete(btShape);
-		ERR_PRINTS("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
+		ERR_PRINT("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
 		return false;
 	}
 	btConvexShape *bt_convex_shape = static_cast<btConvexShape *>(btShape);
@@ -212,7 +212,7 @@ bool BulletPhysicsDirectSpaceState::collide_shape(RID p_shape, const Transform &
 	btCollisionShape *btShape = shape->create_bt_shape(p_shape_xform.basis.get_scale_abs(), p_margin);
 	if (!btShape->isConvex()) {
 		bulletdelete(btShape);
-		ERR_PRINTS("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
+		ERR_PRINT("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
 		return 0;
 	}
 	btConvexShape *btConvex = static_cast<btConvexShape *>(btShape);
@@ -244,7 +244,7 @@ bool BulletPhysicsDirectSpaceState::rest_info(RID p_shape, const Transform &p_sh
 	btCollisionShape *btShape = shape->create_bt_shape(p_shape_xform.basis.get_scale_abs(), p_margin);
 	if (!btShape->isConvex()) {
 		bulletdelete(btShape);
-		ERR_PRINTS("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
+		ERR_PRINT("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
 		return 0;
 	}
 	btConvexShape *btConvex = static_cast<btConvexShape *>(btShape);

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -339,7 +339,7 @@ bool GDNative::initialize() {
 	if (err || !library_init) {
 		OS::get_singleton()->close_dynamic_library(native_handle);
 		native_handle = NULL;
-		ERR_PRINTS("Failed to obtain " + library->get_symbol_prefix() + "gdnative_init symbol");
+		ERR_PRINT("Failed to obtain " + library->get_symbol_prefix() + "gdnative_init symbol");
 		return false;
 	}
 

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -746,7 +746,7 @@ void NativeScriptInstance::notification(int p_notification) {
 #ifdef DEBUG_ENABLED
 	if (p_notification == MainLoop::NOTIFICATION_CRASH) {
 		if (current_method_call != StringName("")) {
-			ERR_PRINTS("NativeScriptInstance detected crash on method: " + current_method_call);
+			ERR_PRINT("NativeScriptInstance detected crash on method: " + current_method_call);
 			current_method_call = "";
 		}
 	}

--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -278,7 +278,7 @@ void register_gdnative_types() {
 				proc_ptr);
 
 		if (err != OK) {
-			ERR_PRINTS("No " + lib->get_symbol_prefix() + "gdnative_singleton in \"" + singleton->get_library()->get_current_library_path() + "\" found");
+			ERR_PRINT("No " + lib->get_symbol_prefix() + "gdnative_singleton in \"" + singleton->get_library()->get_current_library_path() + "\" found");
 		} else {
 			singleton_gdnatives.push_back(singleton);
 			((void (*)())proc_ptr)();

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -800,7 +800,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 			}
 
 			String message = *p_args[0];
-			ERR_PRINTS(message);
+			ERR_PRINT(message);
 			r_ret = Variant();
 		} break;
 		case PUSH_WARNING: {
@@ -1260,7 +1260,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 
 			if (err != OK) {
 				r_ret = Variant();
-				ERR_PRINTS(vformat("Error parsing JSON at line %s: %s", errl, errs));
+				ERR_PRINT(vformat("Error parsing JSON at line %s: %s", errl, errs));
 			}
 
 		} break;

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -814,7 +814,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 			}
 
 			String message = *p_args[0];
-			WARN_PRINTS(message);
+			WARN_PRINT(message);
 			r_ret = Variant();
 		} break;
 		case VAR_TO_STR: {

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -47,7 +47,7 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 		if (line.begins_with("FORMAT=")) { // leave option to implement other commands
 			ERR_FAIL_COND_V_MSG(line != "FORMAT=32-bit_rle_rgbe", ERR_FILE_UNRECOGNIZED, "Only 32-bit_rle_rgbe is supported for HDR files.");
 		} else if (!line.begins_with("#")) { // not comment
-			WARN_PRINTS("Ignoring unsupported header information in HDR: " + line + ".");
+			WARN_PRINT("Ignoring unsupported header information in HDR: " + line + ".");
 		}
 	}
 

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -182,7 +182,7 @@ CryptoMbedTLS::CryptoMbedTLS() {
 	mbedtls_entropy_init(&entropy);
 	int ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, NULL, 0);
 	if (ret != 0) {
-		ERR_PRINTS(" failed\n  ! mbedtls_ctr_drbg_seed returned an error" + itos(ret));
+		ERR_PRINT(" failed\n  ! mbedtls_ctr_drbg_seed returned an error" + itos(ret));
 	}
 }
 
@@ -267,7 +267,7 @@ Ref<X509Certificate> CryptoMbedTLS::generate_self_signed_certificate(Ref<CryptoK
 	if (err != 0) {
 		mbedtls_mpi_free(&serial);
 		mbedtls_x509write_crt_free(&crt);
-		ERR_PRINTS("Generated invalid certificate: " + itos(err));
+		ERR_PRINT("Generated invalid certificate: " + itos(err));
 		return NULL;
 	}
 

--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -88,7 +88,7 @@ Error StreamPeerMbedTLS::_do_handshake() {
 	while ((ret = mbedtls_ssl_handshake(ssl_ctx->get_context())) != 0) {
 		if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
 			// An error occurred.
-			ERR_PRINTS("TLS handshake error: " + itos(ret));
+			ERR_PRINT("TLS handshake error: " + itos(ret));
 			_print_error(ret);
 			disconnect_from_stream();
 			status = STATUS_ERROR;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -165,9 +165,9 @@ void CSharpLanguage::finish() {
 		Object *obj = ObjectDB::get_instance(id);
 
 		if (obj) {
-			ERR_PRINTS("Leaked unsafe reference to object: " + obj->get_class() + ":" + itos(id));
+			ERR_PRINT("Leaked unsafe reference to object: " + obj->get_class() + ":" + itos(id));
 		} else {
-			ERR_PRINTS("Leaked unsafe reference to deleted object: " + itos(id));
+			ERR_PRINT("Leaked unsafe reference to deleted object: " + itos(id));
 		}
 	}
 #endif
@@ -1080,7 +1080,7 @@ void CSharpLanguage::_load_scripts_metadata() {
 		int err_line;
 		Error json_err = JSON::parse(old_json, old_dict_var, err_str, err_line);
 		if (json_err != OK) {
-			ERR_PRINTS("Failed to parse metadata file: '" + err_str + "' (" + String::num_int64(err_line) + ").");
+			ERR_PRINT("Failed to parse metadata file: '" + err_str + "' (" + String::num_int64(err_line) + ").");
 			return;
 		}
 
@@ -2444,7 +2444,7 @@ bool CSharpScript::_update_exports() {
 		if (tmp_native && !base_ref) {
 			Node *node = Object::cast_to<Node>(tmp_native);
 			if (node && node->is_inside_tree()) {
-				ERR_PRINTS("Temporary instance was added to the scene tree.");
+				ERR_PRINT("Temporary instance was added to the scene tree.");
 			} else {
 				memdelete(tmp_native);
 			}
@@ -2522,7 +2522,7 @@ bool CSharpScript::_get_signal(GDMonoClass *p_class, GDMonoClass *p_delegate, Ve
 					arg.type = GDMonoMarshal::managed_to_variant_type(types[i]);
 
 					if (arg.type == Variant::NIL) {
-						ERR_PRINTS("Unknown type of signal parameter: '" + arg.name + "' in '" + p_class->get_full_name() + "'.");
+						ERR_PRINT("Unknown type of signal parameter: '" + arg.name + "' in '" + p_class->get_full_name() + "'.");
 						return false;
 					}
 
@@ -2552,7 +2552,7 @@ bool CSharpScript::_get_member_export(IMonoClassMember *p_member, bool p_inspect
 
 	if (p_member->is_static()) {
 		if (p_member->has_attribute(CACHED_CLASS(ExportAttribute)))
-			ERR_PRINTS("Cannot export member because it is static: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
+			ERR_PRINT("Cannot export member because it is static: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
 		return false;
 	}
 
@@ -2575,12 +2575,12 @@ bool CSharpScript::_get_member_export(IMonoClassMember *p_member, bool p_inspect
 		GDMonoProperty *property = static_cast<GDMonoProperty *>(p_member);
 		if (!property->has_getter()) {
 			if (exported)
-				ERR_PRINTS("Read-only property cannot be exported: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
+				ERR_PRINT("Read-only property cannot be exported: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
 			return false;
 		}
 		if (!property->has_setter()) {
 			if (exported)
-				ERR_PRINTS("Write-only property (without getter) cannot be exported: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
+				ERR_PRINT("Write-only property (without getter) cannot be exported: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
 			return false;
 		}
 	}
@@ -2599,7 +2599,7 @@ bool CSharpScript::_get_member_export(IMonoClassMember *p_member, bool p_inspect
 	String hint_string;
 
 	if (variant_type == Variant::NIL) {
-		ERR_PRINTS("Unknown exported member type: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
+		ERR_PRINT("Unknown exported member type: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
 		return false;
 	}
 
@@ -2891,7 +2891,7 @@ bool CSharpScript::can_instance() const {
 						"Compile",
 						ProjectSettings::get_singleton()->globalize_path(get_path()));
 			} else {
-				ERR_PRINTS("C# project could not be created; cannot add file: '" + get_path() + "'.");
+				ERR_PRINT("C# project could not be created; cannot add file: '" + get_path() + "'.");
 			}
 		}
 	}
@@ -3437,7 +3437,7 @@ Error ResourceFormatSaverCSharpScript::save(const String &p_path, const RES &p_r
 					"Compile",
 					ProjectSettings::get_singleton()->globalize_path(p_path));
 		} else {
-			ERR_PRINTS("C# project could not be created; cannot add file: '" + p_path + "'.");
+			ERR_PRINT("C# project could not be created; cannot add file: '" + p_path + "'.");
 		}
 	}
 #endif

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -278,7 +278,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			Vector<String> link_target_parts = link_target.split(".");
 
 			if (link_target_parts.size() <= 0 || link_target_parts.size() > 2) {
-				ERR_PRINTS("Invalid reference format: '" + tag + "'.");
+				ERR_PRINT("Invalid reference format: '" + tag + "'.");
 
 				xml_output.append("<c>");
 				xml_output.append(tag);
@@ -374,7 +374,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 					xml_output.append(target_enum_itype.proxy_name); // Includes nesting class if any
 					xml_output.append("\"/>");
 				} else {
-					ERR_PRINTS("Cannot resolve enum reference in documentation: '" + link_target + "'.");
+					ERR_PRINT("Cannot resolve enum reference in documentation: '" + link_target + "'.");
 
 					xml_output.append("<c>");
 					xml_output.append(link_target);
@@ -423,7 +423,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 							xml_output.append(target_iconst->proxy_name);
 							xml_output.append("\"/>");
 						} else {
-							ERR_PRINTS("Cannot resolve global constant reference in documentation: '" + link_target + "'.");
+							ERR_PRINT("Cannot resolve global constant reference in documentation: '" + link_target + "'.");
 
 							xml_output.append("<c>");
 							xml_output.append(link_target);
@@ -463,7 +463,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 							xml_output.append(target_iconst->proxy_name);
 							xml_output.append("\"/>");
 						} else {
-							ERR_PRINTS("Cannot resolve constant reference in documentation: '" + link_target + "'.");
+							ERR_PRINT("Cannot resolve constant reference in documentation: '" + link_target + "'.");
 
 							xml_output.append("<c>");
 							xml_output.append(link_target);
@@ -533,7 +533,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 					xml_output.append(target_itype->proxy_name);
 					xml_output.append("\"/>");
 				} else {
-					ERR_PRINTS("Cannot resolve type reference in documentation: '" + tag + "'.");
+					ERR_PRINT("Cannot resolve type reference in documentation: '" + tag + "'.");
 
 					xml_output.append("<c>");
 					xml_output.append(tag);
@@ -1207,7 +1207,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 			output.append(obj_types[itype.base_name].proxy_name);
 			output.append("\n");
 		} else {
-			ERR_PRINTS("Base type '" + itype.base_name.operator String() + "' does not exist, for class '" + itype.name + "'.");
+			ERR_PRINT("Base type '" + itype.base_name.operator String() + "' does not exist, for class '" + itype.name + "'.");
 			return ERR_INVALID_DATA;
 		}
 	}
@@ -2134,7 +2134,7 @@ const BindingsGenerator::TypeInterface *BindingsGenerator::_get_type_or_placehol
 	if (found)
 		return found;
 
-	ERR_PRINTS(String() + "Type not found. Creating placeholder: '" + p_typeref.cname.operator String() + "'.");
+	ERR_PRINT(String() + "Type not found. Creating placeholder: '" + p_typeref.cname.operator String() + "'.");
 
 	const Map<StringName, TypeInterface>::Element *match = placeholder_types.find(p_typeref.cname);
 
@@ -2369,7 +2369,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				imethod.return_type.cname = return_info.class_name;
 				if (!imethod.is_virtual && ClassDB::is_parent_class(return_info.class_name, name_cache.type_Reference) && return_info.hint != PROPERTY_HINT_RESOURCE_TYPE) {
 					/* clang-format off */
-					ERR_PRINTS("Return type is reference but hint is not '" _STR(PROPERTY_HINT_RESOURCE_TYPE) "'."
+					ERR_PRINT("Return type is reference but hint is not '" _STR(PROPERTY_HINT_RESOURCE_TYPE) "'."
 							" Are you returning a reference type by pointer? Method: '" + itype.name + "." + imethod.name + "'.");
 					/* clang-format on */
 					ERR_FAIL_V(false);
@@ -3038,7 +3038,7 @@ void BindingsGenerator::_populate_global_constants() {
 			// HARDCODED: The Error enum have the prefix 'ERR_' for everything except 'OK' and 'FAILED'.
 			if (ienum.cname == name_cache.enum_Error) {
 				if (prefix_length > 0) { // Just in case it ever changes
-					ERR_PRINTS("Prefix for enum '" _STR(Error) "' is not empty.");
+					ERR_PRINT("Prefix for enum '" _STR(Error) "' is not empty.");
 				}
 
 				prefix_length = 1; // 'ERR_'
@@ -3133,7 +3133,7 @@ void BindingsGenerator::handle_cmdline_args(const List<String> &p_cmdline_args) 
 				glue_dir_path = path_elem->get();
 				elem = elem->next();
 			} else {
-				ERR_PRINTS(generate_all_glue_option + ": No output directory specified (expected path to '{GODOT_ROOT}/modules/mono/glue').");
+				ERR_PRINT(generate_all_glue_option + ": No output directory specified (expected path to '{GODOT_ROOT}/modules/mono/glue').");
 			}
 
 			--options_left;
@@ -3144,7 +3144,7 @@ void BindingsGenerator::handle_cmdline_args(const List<String> &p_cmdline_args) 
 				cs_dir_path = path_elem->get();
 				elem = elem->next();
 			} else {
-				ERR_PRINTS(generate_cs_glue_option + ": No output directory specified.");
+				ERR_PRINT(generate_cs_glue_option + ": No output directory specified.");
 			}
 
 			--options_left;
@@ -3155,7 +3155,7 @@ void BindingsGenerator::handle_cmdline_args(const List<String> &p_cmdline_args) 
 				cpp_dir_path = path_elem->get();
 				elem = elem->next();
 			} else {
-				ERR_PRINTS(generate_cpp_glue_option + ": No output directory specified.");
+				ERR_PRINT(generate_cpp_glue_option + ": No output directory specified.");
 			}
 
 			--options_left;
@@ -3169,26 +3169,26 @@ void BindingsGenerator::handle_cmdline_args(const List<String> &p_cmdline_args) 
 		bindings_generator.set_log_print_enabled(true);
 
 		if (!bindings_generator.initialized) {
-			ERR_PRINTS("Failed to initialize the bindings generator");
+			ERR_PRINT("Failed to initialize the bindings generator");
 			::exit(0);
 		}
 
 		if (glue_dir_path.length()) {
 			if (bindings_generator.generate_glue(glue_dir_path) != OK)
-				ERR_PRINTS(generate_all_glue_option + ": Failed to generate the C++ glue.");
+				ERR_PRINT(generate_all_glue_option + ": Failed to generate the C++ glue.");
 
 			if (bindings_generator.generate_cs_api(glue_dir_path.plus_file(API_SOLUTION_NAME)) != OK)
-				ERR_PRINTS(generate_all_glue_option + ": Failed to generate the C# API.");
+				ERR_PRINT(generate_all_glue_option + ": Failed to generate the C# API.");
 		}
 
 		if (cs_dir_path.length()) {
 			if (bindings_generator.generate_cs_api(cs_dir_path) != OK)
-				ERR_PRINTS(generate_cs_glue_option + ": Failed to generate the C# API.");
+				ERR_PRINT(generate_cs_glue_option + ": Failed to generate the C# API.");
 		}
 
 		if (cpp_dir_path.length()) {
 			if (bindings_generator.generate_glue(cpp_dir_path) != OK)
-				ERR_PRINTS(generate_cpp_glue_option + ": Failed to generate the C++ glue.");
+				ERR_PRINT(generate_cpp_glue_option + ": Failed to generate the C++ glue.");
 		}
 
 		// Exit once done

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1646,7 +1646,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 		if (p_imethod.is_deprecated) {
 			if (p_imethod.deprecation_message.empty())
-				WARN_PRINTS("An empty deprecation message is discouraged. Method: '" + p_imethod.proxy_name + "'.");
+				WARN_PRINT("An empty deprecation message is discouraged. Method: '" + p_imethod.proxy_name + "'.");
 
 			p_output.append(MEMBER_BEGIN "[Obsolete(\"");
 			p_output.append(p_imethod.deprecation_message);
@@ -2358,9 +2358,9 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				// which could actually will return something different.
 				// Let's put this to notify us if that ever happens.
 				if (itype.cname != name_cache.type_Object || imethod.name != "free") {
-					WARN_PRINTS("Notification: New unexpected virtual non-overridable method found."
-								" We only expected Object.free, but found '" +
-								itype.name + "." + imethod.name + "'.");
+					WARN_PRINT("Notification: New unexpected virtual non-overridable method found."
+							   " We only expected Object.free, but found '" +
+							   itype.name + "." + imethod.name + "'.");
 				}
 			} else if (return_info.type == Variant::INT && return_info.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
 				imethod.return_type.cname = return_info.class_name;

--- a/modules/mono/glue/gd_glue.cpp
+++ b/modules/mono/glue/gd_glue.cpp
@@ -251,7 +251,7 @@ void godot_icall_GD_pusherror(MonoString *p_str) {
 }
 
 void godot_icall_GD_pushwarning(MonoString *p_str) {
-	WARN_PRINTS(GDMonoMarshal::mono_string_to_godot(p_str));
+	WARN_PRINT(GDMonoMarshal::mono_string_to_godot(p_str));
 }
 
 MonoArray *godot_icall_GD_var2bytes(MonoObject *p_var, MonoBoolean p_full_objects) {

--- a/modules/mono/glue/gd_glue.cpp
+++ b/modules/mono/glue/gd_glue.cpp
@@ -235,7 +235,7 @@ MonoObject *godot_icall_GD_str2var(MonoString *p_str) {
 	Error err = VariantParser::parse(&ss, ret, errs, line);
 	if (err != OK) {
 		String err_str = "Parse error at line " + itos(line) + ": " + errs + ".";
-		ERR_PRINTS(err_str);
+		ERR_PRINT(err_str);
 		ret = err_str;
 	}
 
@@ -247,7 +247,7 @@ MonoBoolean godot_icall_GD_type_exists(MonoString *p_type) {
 }
 
 void godot_icall_GD_pusherror(MonoString *p_str) {
-	ERR_PRINTS(GDMonoMarshal::mono_string_to_godot(p_str));
+	ERR_PRINT(GDMonoMarshal::mono_string_to_godot(p_str));
 }
 
 void godot_icall_GD_pushwarning(MonoString *p_str) {

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -621,7 +621,7 @@ bool GDMono::copy_prebuilt_api_assembly(ApiAssemblyInfo::Type p_api_type, const 
 		memdelete(da);
 
 		if (err != OK) {
-			ERR_PRINTS("Failed to create destination directory for the API assemblies. Error: " + itos(err) + ".");
+			ERR_PRINT("Failed to create destination directory for the API assemblies. Error: " + itos(err) + ".");
 			return false;
 		}
 	}
@@ -638,7 +638,7 @@ bool GDMono::copy_prebuilt_api_assembly(ApiAssemblyInfo::Type p_api_type, const 
 
 	String assembly_file = assembly_name + ".dll";
 	if (da->copy(src_dir.plus_file(assembly_file), dst_dir.plus_file(assembly_file)) != OK) {
-		ERR_PRINTS("Failed to copy '" + assembly_file + "'.");
+		ERR_PRINT("Failed to copy '" + assembly_file + "'.");
 		return false;
 	}
 
@@ -1115,7 +1115,7 @@ Error GDMono::finalize_and_unload_domain(MonoDomain *p_domain) {
 	mono_domain_try_unload(p_domain, (MonoObject **)&exc);
 
 	if (exc) {
-		ERR_PRINTS("Exception thrown when unloading domain '" + domain_name + "'.");
+		ERR_PRINT("Exception thrown when unloading domain '" + domain_name + "'.");
 		GDMonoUtils::debug_print_unhandled_exception(exc);
 		return FAILED;
 	}

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -630,11 +630,11 @@ bool GDMono::copy_prebuilt_api_assembly(ApiAssemblyInfo::Type p_api_type, const 
 
 	String xml_file = assembly_name + ".xml";
 	if (da->copy(src_dir.plus_file(xml_file), dst_dir.plus_file(xml_file)) != OK)
-		WARN_PRINTS("Failed to copy '" + xml_file + "'.");
+		WARN_PRINT("Failed to copy '" + xml_file + "'.");
 
 	String pdb_file = assembly_name + ".pdb";
 	if (da->copy(src_dir.plus_file(pdb_file), dst_dir.plus_file(pdb_file)) != OK)
-		WARN_PRINTS("Failed to copy '" + pdb_file + "'.");
+		WARN_PRINT("Failed to copy '" + pdb_file + "'.");
 
 	String assembly_file = assembly_name + ".dll";
 	if (da->copy(src_dir.plus_file(assembly_file), dst_dir.plus_file(assembly_file)) != OK) {

--- a/modules/mono/mono_gd/gd_mono_class.cpp
+++ b/modules/mono/mono_gd/gd_mono_class.cpp
@@ -166,8 +166,8 @@ void GDMonoClass::fetch_methods_with_godot_api_checks(GDMonoClass *p_native_base
 
 #ifdef DEBUG_ENABLED
 			String fullname = method->get_ret_type_full_name() + " " + name + "(" + method->get_signature_desc(true) + ")";
-			WARN_PRINTS("Method '" + fullname + "' is hidden by Godot API method. Should be '" +
-						method->get_full_name_no_class() + "'. In class '" + namespace_name + "." + class_name + "'.");
+			WARN_PRINT("Method '" + fullname + "' is hidden by Godot API method. Should be '" +
+					   method->get_full_name_no_class() + "'. In class '" + namespace_name + "." + class_name + "'.");
 #endif
 			continue;
 		}
@@ -185,8 +185,8 @@ void GDMonoClass::fetch_methods_with_godot_api_checks(GDMonoClass *p_native_base
 				if (m && m->get_name() != name) {
 					// found
 					String fullname = m->get_ret_type_full_name() + " " + name + "(" + m->get_signature_desc(true) + ")";
-					WARN_PRINTS("Method '" + fullname + "' should be '" + m->get_full_name_no_class() +
-								"'. In class '" + namespace_name + "." + class_name + "'.");
+					WARN_PRINT("Method '" + fullname + "' should be '" + m->get_full_name_no_class() +
+							   "'. In class '" + namespace_name + "." + class_name + "'.");
 					break;
 				}
 

--- a/modules/mono/mono_gd/gd_mono_field.cpp
+++ b/modules/mono/mono_gd/gd_mono_field.cpp
@@ -512,7 +512,7 @@ void GDMonoField::set_value_from_variant(MonoObject *p_object, const Variant &p_
 		} break;
 
 		default: {
-			ERR_PRINTS("Attempted to set the value of a field of unexpected type encoding: " + itos(type.type_encoding) + ".");
+			ERR_PRINT("Attempted to set the value of a field of unexpected type encoding: " + itos(type.type_encoding) + ".");
 		} break;
 	}
 

--- a/modules/mono/mono_gd/gd_mono_log.cpp
+++ b/modules/mono/mono_gd/gd_mono_log.cpp
@@ -83,7 +83,7 @@ void GDMonoLog::mono_log_callback(const char *log_domain, const char *log_level,
 	}
 
 	if (fatal) {
-		ERR_PRINTS("Mono: FATAL ERROR, ABORTING! Logfile: '" + GDMonoLog::get_singleton()->log_file_path + "'.");
+		ERR_PRINT("Mono: FATAL ERROR, ABORTING! Logfile: '" + GDMonoLog::get_singleton()->log_file_path + "'.");
 		// Make sure to flush before aborting
 		f->flush();
 		f->close();
@@ -139,7 +139,7 @@ void GDMonoLog::initialize() {
 	CharString log_level = OS::get_singleton()->get_environment("GODOT_MONO_LOG_LEVEL").utf8();
 
 	if (log_level.length() != 0 && get_log_level_id(log_level.get_data()) == -1) {
-		ERR_PRINTS(String() + "Mono: Ignoring invalid log level (GODOT_MONO_LOG_LEVEL): '" + log_level.get_data() + "'.");
+		ERR_PRINT(String() + "Mono: Ignoring invalid log level (GODOT_MONO_LOG_LEVEL): '" + log_level.get_data() + "'.");
 		log_level = CharString();
 	}
 
@@ -167,7 +167,7 @@ void GDMonoLog::initialize() {
 
 		log_file = FileAccess::open(log_file_path, FileAccess::WRITE);
 		if (!log_file) {
-			ERR_PRINTS("Mono: Cannot create log file at: " + log_file_path);
+			ERR_PRINT("Mono: Cannot create log file at: " + log_file_path);
 		}
 	}
 

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -277,7 +277,7 @@ String mono_to_utf8_string(MonoString *p_mono_string) {
 	char *utf8 = mono_string_to_utf8_checked(p_mono_string, &error);
 
 	if (!mono_error_ok(&error)) {
-		ERR_PRINTS(String() + "Failed to convert MonoString* to UTF-8: '" + mono_error_get_message(&error) + "'.");
+		ERR_PRINT(String() + "Failed to convert MonoString* to UTF-8: '" + mono_error_get_message(&error) + "'.");
 		mono_error_cleanup(&error);
 		return String();
 	}

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -354,7 +354,7 @@ void debug_send_unhandled_exception_error(MonoException *p_exc) {
 	if (!ScriptDebugger::get_singleton()) {
 #ifdef TOOLS_ENABLED
 		if (Engine::get_singleton()->is_editor_hint()) {
-			ERR_PRINTS(GDMonoUtils::get_exception_name_and_message(p_exc));
+			ERR_PRINT(GDMonoUtils::get_exception_name_and_message(p_exc));
 		}
 #endif
 		return;
@@ -431,7 +431,7 @@ void set_pending_exception(MonoException *p_exc) {
 	}
 
 	if (!mono_runtime_set_pending_exception(p_exc, false)) {
-		ERR_PRINTS("Exception thrown from managed code, but it could not be set as pending:");
+		ERR_PRINT("Exception thrown from managed code, but it could not be set as pending:");
 		GDMonoUtils::debug_print_unhandled_exception(p_exc);
 	}
 #endif

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -69,7 +69,7 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 	ret = ParseEXRHeaderFromMemory(&exr_header, &exr_version, w.ptr(), src_image_len, &err);
 	if (ret != TINYEXR_SUCCESS) {
 		if (err) {
-			ERR_PRINTS(String(err));
+			ERR_PRINT(String(err));
 		}
 		return ERR_FILE_CORRUPT;
 	}
@@ -85,7 +85,7 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 	ret = LoadEXRImageFromMemory(&exr_image, &exr_header, w.ptr(), src_image_len, &err);
 	if (ret != TINYEXR_SUCCESS) {
 		if (err) {
-			ERR_PRINTS(String(err));
+			ERR_PRINT(String(err));
 		}
 		return ERR_FILE_CORRUPT;
 	}

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -610,7 +610,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 	static Error save_apk_so(void *p_userdata, const SharedObject &p_so) {
 		if (!p_so.path.get_file().begins_with("lib")) {
 			String err = "Android .so file names must start with \"lib\", but got: " + p_so.path;
-			ERR_PRINTS(err);
+			ERR_PRINT(err);
 			return FAILED;
 		}
 		APKExportData *ed = (APKExportData *)p_userdata;
@@ -631,7 +631,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		if (!exported) {
 			String abis_string = String(" ").join(abis);
 			String err = "Cannot determine ABI for library \"" + p_so.path + "\". One of the supported ABIs must be used as a tag: " + abis_string;
-			ERR_PRINTS(err);
+			ERR_PRINT(err);
 			return FAILED;
 		}
 		return OK;
@@ -1878,7 +1878,7 @@ public:
 								new_file += "//CHUNK_" + text + "_BEGIN\n";
 
 								if (!found) {
-									ERR_PRINTS("No end marker found in build.gradle for chunk: " + text);
+									ERR_PRINT("No end marker found in build.gradle for chunk: " + text);
 									f->seek(pos);
 								} else {
 
@@ -1914,7 +1914,7 @@ public:
 								new_file += "//DIR_" + text + "_BEGIN\n";
 
 								if (!found) {
-									ERR_PRINTS("No end marker found in build.gradle for dir: " + text);
+									ERR_PRINT("No end marker found in build.gradle for dir: " + text);
 									f->seek(pos);
 								} else {
 									//add chunk lines
@@ -1973,7 +1973,7 @@ public:
 								new_file += "<!--CHUNK_" + text + "_BEGIN-->\n";
 
 								if (!found) {
-									ERR_PRINTS("No end marker found in AndroidManifest.xml for chunk: " + text);
+									ERR_PRINT("No end marker found in AndroidManifest.xml for chunk: " + text);
 									f->seek(pos);
 								} else {
 									//add chunk lines
@@ -1992,7 +1992,7 @@ public:
 							String last_tag = "android:icon=\"@mipmap/icon\"";
 							int last_tag_pos = l.find(last_tag);
 							if (last_tag_pos == -1) {
-								ERR_PRINTS("Not adding application attributes as the expected tag was not found in '<application': " + last_tag);
+								ERR_PRINT("Not adding application attributes as the expected tag was not found in '<application': " + last_tag);
 								new_file += l + "\n";
 							} else {
 								String base = l.substr(0, last_tag_pos + last_tag.length());

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -1030,7 +1030,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 				print_line("Creating " + dir_name);
 				Error dir_err = tmp_app_path->make_dir_recursive(dir_name);
 				if (dir_err) {
-					ERR_PRINTS("Can't create '" + dir_name + "'.");
+					ERR_PRINT("Can't create '" + dir_name + "'.");
 					unzClose(src_pkg_zip);
 					memdelete(tmp_app_path);
 					return ERR_CANT_CREATE;
@@ -1040,7 +1040,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 			/* write the file */
 			FileAccess *f = FileAccess::open(file, FileAccess::WRITE);
 			if (!f) {
-				ERR_PRINTS("Can't write '" + file + "'.");
+				ERR_PRINT("Can't write '" + file + "'.");
 				unzClose(src_pkg_zip);
 				memdelete(tmp_app_path);
 				return ERR_CANT_CREATE;
@@ -1064,7 +1064,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	unzClose(src_pkg_zip);
 
 	if (!found_library) {
-		ERR_PRINTS("Requested template library '" + library_to_use + "' not found. It might be missing from your template archive.");
+		ERR_PRINT("Requested template library '" + library_to_use + "' not found. It might be missing from your template archive.");
 		memdelete(tmp_app_path);
 		return ERR_FILE_NOT_FOUND;
 	}
@@ -1093,7 +1093,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	String project_file_name = dest_dir + binary_name + ".xcodeproj/project.pbxproj";
 	FileAccess *f = FileAccess::open(project_file_name, FileAccess::WRITE);
 	if (!f) {
-		ERR_PRINTS("Can't write '" + project_file_name + "'.");
+		ERR_PRINT("Can't write '" + project_file_name + "'.");
 		return ERR_CANT_CREATE;
 	};
 	f->store_buffer(project_file_data.ptr(), project_file_data.size());

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -980,7 +980,7 @@ Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, 
 	EMSCRIPTEN_RESULT result;
 #define EM_CHECK(ev)                         \
 	if (result != EMSCRIPTEN_RESULT_SUCCESS) \
-	ERR_PRINTS("Error while setting " #ev " callback: Code " + itos(result))
+	ERR_PRINT("Error while setting " #ev " callback: Code " + itos(result))
 #define SET_EM_CALLBACK(target, ev, cb)                               \
 	result = emscripten_set_##ev##_callback(target, NULL, true, &cb); \
 	EM_CHECK(ev)

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -692,7 +692,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 	unzClose(src_pkg_zip);
 
 	if (!found_binary) {
-		ERR_PRINTS("Requested template binary '" + binary_to_use + "' not found. It might be missing from your template archive.");
+		ERR_PRINT("Requested template binary '" + binary_to_use + "' not found. It might be missing from your template archive.");
 		err = ERR_FILE_NOT_FOUND;
 	}
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -2931,7 +2931,7 @@ void OS_OSX::run() {
 				quit = true;
 			}
 		} @catch (NSException *exception) {
-			ERR_PRINTS("NSException: " + String([exception reason].UTF8String));
+			ERR_PRINT("NSException: " + String([exception reason].UTF8String));
 		}
 	};
 
@@ -2987,7 +2987,7 @@ Error OS_OSX::move_to_trash(const String &p_path) {
 	NSError *err;
 
 	if (![fm trashItemAtURL:url resultingItemURL:nil error:&err]) {
-		ERR_PRINTS("trashItemAtURL error: " + String(err.localizedDescription.UTF8String));
+		ERR_PRINT("trashItemAtURL error: " + String(err.localizedDescription.UTF8String));
 		return FAILED;
 	}
 

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1397,7 +1397,7 @@ public:
 		}
 
 		if (!FileAccess::exists(signtool_path)) {
-			ERR_PRINTS("Could not find signtool executable at " + signtool_path + ", aborting.");
+			ERR_PRINT("Could not find signtool executable at " + signtool_path + ", aborting.");
 			return ERR_FILE_NOT_FOUND;
 		}
 
@@ -1418,12 +1418,12 @@ public:
 		}
 
 		if (!FileAccess::exists(cert_path)) {
-			ERR_PRINTS("Could not find certificate file at " + cert_path + ", aborting.");
+			ERR_PRINT("Could not find certificate file at " + cert_path + ", aborting.");
 			return ERR_FILE_NOT_FOUND;
 		}
 
 		if (cert_alg < 0 || cert_alg > 2) {
-			ERR_PRINTS("Invalid certificate algorithm " + itos(cert_alg) + ", aborting.");
+			ERR_PRINT("Invalid certificate algorithm " + itos(cert_alg) + ", aborting.");
 			return ERR_INVALID_DATA;
 		}
 

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -105,7 +105,7 @@ void EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset>
 	}
 
 	if (!FileAccess::exists(rcedit_path)) {
-		ERR_PRINTS("Could not find rcedit executable at " + rcedit_path + ", no icon or app information data will be included.");
+		ERR_PRINT("Could not find rcedit executable at " + rcedit_path + ", no icon or app information data will be included.");
 		return;
 	}
 
@@ -114,7 +114,7 @@ void EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset>
 	String wine_path = EditorSettings::get_singleton()->get("export/windows/wine");
 
 	if (wine_path != String() && !FileAccess::exists(wine_path)) {
-		ERR_PRINTS("Could not find wine executable at " + wine_path + ", no icon or app information data will be included.");
+		ERR_PRINT("Could not find wine executable at " + wine_path + ", no icon or app information data will be included.");
 		return;
 	}
 
@@ -188,7 +188,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 #ifdef WINDOWS_ENABLED
 	String signtool_path = EditorSettings::get_singleton()->get("export/windows/signtool");
 	if (signtool_path != String() && !FileAccess::exists(signtool_path)) {
-		ERR_PRINTS("Could not find signtool executable at " + signtool_path + ", aborting.");
+		ERR_PRINT("Could not find signtool executable at " + signtool_path + ", aborting.");
 		return ERR_FILE_NOT_FOUND;
 	}
 	if (signtool_path == String()) {
@@ -197,7 +197,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 #else
 	String signtool_path = EditorSettings::get_singleton()->get("export/windows/osslsigncode");
 	if (signtool_path != String() && !FileAccess::exists(signtool_path)) {
-		ERR_PRINTS("Could not find osslsigncode executable at " + signtool_path + ", aborting.");
+		ERR_PRINT("Could not find osslsigncode executable at " + signtool_path + ", aborting.");
 		return ERR_FILE_NOT_FOUND;
 	}
 	if (signtool_path == String()) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2854,7 +2854,7 @@ void OS_Windows::set_native_icon(const String &p_filename) {
 	ERR_FAIL_COND_MSG(big_icon_index == -1, "No valid icons found!");
 
 	if (small_icon_index == -1) {
-		WARN_PRINTS("No small icon found, reusing " + itos(big_icon_width) + "x" + itos(big_icon_width) + " @" + itos(big_icon_cc) + " icon!");
+		WARN_PRINT("No small icon found, reusing " + itos(big_icon_width) + "x" + itos(big_icon_width) + " @" + itos(big_icon_cc) + " icon!");
 		small_icon_index = big_icon_index;
 		small_icon_cc = big_icon_cc;
 	}

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -3363,7 +3363,7 @@ Error OS_Windows::move_to_trash(const String &p_path) {
 	delete[] from;
 
 	if (ret) {
-		ERR_PRINTS("SHFileOperation error: " + itos(ret));
+		ERR_PRINT("SHFileOperation error: " + itos(ret));
 		return FAILED;
 	}
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -3406,7 +3406,7 @@ Error OS_X11::move_to_trash(const String &p_path) {
 
 	// Issue an error if none of the previous locations is appropriate for the trash can.
 	if (trash_can == "") {
-		ERR_PRINTS("move_to_trash: Could not determine the trash can location");
+		ERR_PRINT("move_to_trash: Could not determine the trash can location");
 		return FAILED;
 	}
 
@@ -3417,7 +3417,7 @@ Error OS_X11::move_to_trash(const String &p_path) {
 
 	// Issue an error if trash can is not created proprely.
 	if (err != OK) {
-		ERR_PRINTS("move_to_trash: Could not create the trash can \"" + trash_can + "\"");
+		ERR_PRINT("move_to_trash: Could not create the trash can \"" + trash_can + "\"");
 		return err;
 	}
 
@@ -3431,7 +3431,7 @@ Error OS_X11::move_to_trash(const String &p_path) {
 
 	// Issue an error if "mv" failed to move the given resource to the trash can.
 	if (err != OK || retval != 0) {
-		ERR_PRINTS("move_to_trash: Could not move the resource \"" + p_path + "\" to the trash can \"" + trash_can + "\"");
+		ERR_PRINT("move_to_trash: Could not move the resource \"" + p_path + "\" to the trash can \"" + trash_can + "\"");
 		return FAILED;
 	}
 

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -259,7 +259,7 @@ void NavigationPolygon::make_polygons_from_outlines() {
 
 	TriangulatorPartition tpart;
 	if (tpart.ConvexPartition_HM(&in_poly, &out_poly) == 0) { //failed!
-		ERR_PRINTS("NavigationPolygon: Convex partition failed!");
+		ERR_PRINT("NavigationPolygon: Convex partition failed!");
 		return;
 	}
 

--- a/scene/3d/baked_lightmap.cpp
+++ b/scene/3d/baked_lightmap.cpp
@@ -360,7 +360,7 @@ BakedLightmap::BakeError BakedLightmap::bake(Node *p_from_node, bool p_create_vi
 		//check for valid save path
 		DirAccessRef d = DirAccess::open(save_path);
 		if (!d) {
-			ERR_PRINTS("Invalid Save Path '" + save_path + "'.");
+			ERR_PRINT("Invalid Save Path '" + save_path + "'.");
 			return BAKE_ERROR_NO_SAVE_PATH;
 		}
 	}

--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -181,7 +181,7 @@ void Skeleton::_update_process_order() {
 
 		if (bonesptr[i].parent >= len) {
 			//validate this just in case
-			ERR_PRINTS("Bone " + itos(i) + " has invalid parent: " + itos(bonesptr[i].parent));
+			ERR_PRINT("Bone " + itos(i) + " has invalid parent: " + itos(bonesptr[i].parent));
 			bonesptr[i].parent = -1;
 		}
 		order[i] = i;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -493,7 +493,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 								pa->object->set_indexed(pa->subpath, value, &valid); //you are not speshul
 #ifdef DEBUG_ENABLED
 								if (!valid) {
-									ERR_PRINTS("Failed setting track value '" + String(pa->owner->path) + "'. Check if property exists or the type of key is valid. Animation '" + a->get_name() + "' at node '" + get_path() + "'.");
+									ERR_PRINT("Failed setting track value '" + String(pa->owner->path) + "'. Check if property exists or the type of key is valid. Animation '" + a->get_name() + "' at node '" + get_path() + "'.");
 								}
 #endif
 
@@ -501,7 +501,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 							case SP_NODE2D_POS: {
 #ifdef DEBUG_ENABLED
 								if (value.get_type() != Variant::VECTOR2) {
-									ERR_PRINTS("Position key at time " + rtos(p_time) + " in Animation Track '" + String(pa->owner->path) + "' not of type Vector2(). Animation '" + a->get_name() + "' at node '" + get_path() + "'.");
+									ERR_PRINT("Position key at time " + rtos(p_time) + " in Animation Track '" + String(pa->owner->path) + "' not of type Vector2(). Animation '" + a->get_name() + "' at node '" + get_path() + "'.");
 								}
 #endif
 								static_cast<Node2D *>(pa->object)->set_position(value);
@@ -509,7 +509,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 							case SP_NODE2D_ROT: {
 #ifdef DEBUG_ENABLED
 								if (value.is_num()) {
-									ERR_PRINTS("Rotation key at time " + rtos(p_time) + " in Animation Track '" + String(pa->owner->path) + "' not numerical. Animation '" + a->get_name() + "' at node '" + get_path() + "'.");
+									ERR_PRINT("Rotation key at time " + rtos(p_time) + " in Animation Track '" + String(pa->owner->path) + "' not numerical. Animation '" + a->get_name() + "' at node '" + get_path() + "'.");
 								}
 #endif
 
@@ -518,7 +518,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 							case SP_NODE2D_SCALE: {
 #ifdef DEBUG_ENABLED
 								if (value.get_type() != Variant::VECTOR2) {
-									ERR_PRINTS("Scale key at time " + rtos(p_time) + " in Animation Track '" + String(pa->owner->path) + "' not of type Vector2()." + a->get_name() + "' at node '" + get_path() + "'.");
+									ERR_PRINT("Scale key at time " + rtos(p_time) + " in Animation Track '" + String(pa->owner->path) + "' not of type Vector2()." + a->get_name() + "' at node '" + get_path() + "'.");
 								}
 #endif
 
@@ -553,7 +553,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 					ERR_CONTINUE(s > VARIANT_ARG_MAX);
 #ifdef DEBUG_ENABLED
 					if (!nc->node->has_method(method)) {
-						ERR_PRINTS("Invalid method call '" + method + "'. '" + a->get_name() + "' at node '" + get_path() + "'.");
+						ERR_PRINT("Invalid method call '" + method + "'. '" + a->get_name() + "' at node '" + get_path() + "'.");
 					}
 #endif
 
@@ -884,7 +884,7 @@ void AnimationPlayer::_animation_update_transforms() {
 				pa->object->set_indexed(pa->subpath, pa->value_accum, &valid); //you are not speshul
 #ifdef DEBUG_ENABLED
 				if (!valid) {
-					ERR_PRINTS("Failed setting key at time " + rtos(playback.current.pos) + " in Animation '" + get_current_animation() + "' at Node '" + get_path() + "', Track '" + String(pa->owner->path) + "'. Check if property exists or the type of key is right for the property");
+					ERR_PRINT("Failed setting key at time " + rtos(playback.current.pos) + " in Animation '" + get_current_animation() + "' at Node '" + get_path() + "', Track '" + String(pa->owner->path) + "'. Check if property exists or the type of key is right for the property");
 				}
 #endif
 
@@ -892,7 +892,7 @@ void AnimationPlayer::_animation_update_transforms() {
 			case SP_NODE2D_POS: {
 #ifdef DEBUG_ENABLED
 				if (pa->value_accum.get_type() != Variant::VECTOR2) {
-					ERR_PRINTS("Position key at time " + rtos(playback.current.pos) + " in Animation '" + get_current_animation() + "' at Node '" + get_path() + "', Track '" + String(pa->owner->path) + "' not of type Vector2()");
+					ERR_PRINT("Position key at time " + rtos(playback.current.pos) + " in Animation '" + get_current_animation() + "' at Node '" + get_path() + "', Track '" + String(pa->owner->path) + "' not of type Vector2()");
 				}
 #endif
 				static_cast<Node2D *>(pa->object)->set_position(pa->value_accum);
@@ -900,7 +900,7 @@ void AnimationPlayer::_animation_update_transforms() {
 			case SP_NODE2D_ROT: {
 #ifdef DEBUG_ENABLED
 				if (pa->value_accum.is_num()) {
-					ERR_PRINTS("Rotation key at time " + rtos(playback.current.pos) + " in Animation '" + get_current_animation() + "' at Node '" + get_path() + "', Track '" + String(pa->owner->path) + "' not numerical");
+					ERR_PRINT("Rotation key at time " + rtos(playback.current.pos) + " in Animation '" + get_current_animation() + "' at Node '" + get_path() + "', Track '" + String(pa->owner->path) + "' not numerical");
 				}
 #endif
 
@@ -909,7 +909,7 @@ void AnimationPlayer::_animation_update_transforms() {
 			case SP_NODE2D_SCALE: {
 #ifdef DEBUG_ENABLED
 				if (pa->value_accum.get_type() != Variant::VECTOR2) {
-					ERR_PRINTS("Scale key at time " + rtos(playback.current.pos) + " in Animation '" + get_current_animation() + "' at Node '" + get_path() + "', Track '" + String(pa->owner->path) + "' not of type Vector2()");
+					ERR_PRINT("Scale key at time " + rtos(playback.current.pos) + " in Animation '" + get_current_animation() + "' at Node '" + get_path() + "', Track '" + String(pa->owner->path) + "' not of type Vector2()");
 				}
 #endif
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -578,7 +578,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 				Node *child = parent->get_node_and_resource(path, resource, leftover_path);
 
 				if (!child) {
-					ERR_PRINTS("AnimationTree: '" + String(E->get()) + "', couldn't resolve track:  '" + String(path) + "'");
+					ERR_PRINT("AnimationTree: '" + String(E->get()) + "', couldn't resolve track:  '" + String(path) + "'");
 					continue;
 				}
 
@@ -608,7 +608,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 						Spatial *spatial = Object::cast_to<Spatial>(child);
 
 						if (!spatial) {
-							ERR_PRINTS("AnimationTree: '" + String(E->get()) + "', transform track does not point to spatial:  '" + String(path) + "'");
+							ERR_PRINT("AnimationTree: '" + String(E->get()) + "', transform track does not point to spatial:  '" + String(path) + "'");
 							continue;
 						}
 

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -92,7 +92,7 @@ Error ScriptDebuggerRemote::connect_to_host(const String &p_host, uint16_t p_por
 
 	if (tcp_client->get_status() != StreamPeerTCP::STATUS_CONNECTED) {
 
-		ERR_PRINTS("Remote Debugger: Unable to connect. Status: " + String::num(tcp_client->get_status()) + ".");
+		ERR_PRINT("Remote Debugger: Unable to connect. Status: " + String::num(tcp_client->get_status()) + ".");
 		return FAILED;
 	};
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4480,7 +4480,7 @@ void TextEdit::cursor_set_line(int p_row, bool p_adjust_viewport, bool p_can_be_
 				if (p_row - move_up > 0 && !is_line_hidden(p_row - move_up)) {
 					p_row -= move_up;
 				} else {
-					WARN_PRINTS(("Cursor set to hidden line " + itos(p_row) + " and there are no nonhidden lines."));
+					WARN_PRINT(("Cursor set to hidden line " + itos(p_row) + " and there are no nonhidden lines."));
 				}
 			}
 		}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1192,7 +1192,7 @@ void Node::add_child_below_node(Node *p_node, Node *p_child, bool p_legible_uniq
 	if (is_a_parent_of(p_node)) {
 		move_child(p_child, p_node->get_position_in_parent() + 1);
 	} else {
-		WARN_PRINTS("Cannot move under node " + p_node->get_name() + " as " + p_child->get_name() + " does not share a parent.");
+		WARN_PRINT("Cannot move under node " + p_node->get_name() + " as " + p_child->get_name() + " does not share a parent.");
 	}
 }
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2112,7 +2112,7 @@ SceneTree::SceneTree() {
 					ProjectSettings::get_singleton()->set("rendering/environment/default_environment", "");
 				} else {
 					//file was erased, notify user.
-					ERR_PRINTS(RTR("Default Environment as specified in Project Settings (Rendering -> Environment -> Default Environment) could not be loaded."));
+					ERR_PRINT(RTR("Default Environment as specified in Project Settings (Rendering -> Environment -> Default Environment) could not be loaded."));
 				}
 			}
 		}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1845,7 +1845,7 @@ bool Viewport::_gui_drop(Control *p_at_control, Point2 p_at_pos, bool p_just_che
 
 void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
-	ERR_FAIL_COND(p_event.is_null())
+	ERR_FAIL_COND(p_event.is_null());
 
 	//?
 	/*

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -749,7 +749,7 @@ void register_scene_types() {
 	if (font_path != String()) {
 		font = ResourceLoader::load(font_path);
 		if (!font.is_valid()) {
-			ERR_PRINTS("Error loading custom font '" + font_path + "'");
+			ERR_PRINT("Error loading custom font '" + font_path + "'");
 		}
 	}
 
@@ -764,7 +764,7 @@ void register_scene_types() {
 				Theme::set_default_font(font);
 			}
 		} else {
-			ERR_PRINTS("Error loading custom theme '" + theme_path + "'");
+			ERR_PRINT("Error loading custom theme '" + theme_path + "'");
 		}
 	}
 }

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -519,7 +519,7 @@ PoolVector<uint8_t> AudioStreamSample::get_data() const {
 
 Error AudioStreamSample::save_to_wav(const String &p_path) {
 	if (format == AudioStreamSample::FORMAT_IMA_ADPCM) {
-		WARN_PRINTS("Saving IMA_ADPC samples are not supported yet");
+		WARN_PRINT("Saving IMA_ADPC samples are not supported yet");
 		return ERR_UNAVAILABLE;
 	}
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1384,7 +1384,7 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 
 			if (!p_main && (!bundle_resources) && res->get_path().length() && res->get_path().find("::") == -1) {
 				if (res->get_path() == local_path) {
-					ERR_PRINTS("Circular reference to resource being saved found: '" + local_path + "' will be null next time it's loaded.");
+					ERR_PRINT("Circular reference to resource being saved found: '" + local_path + "' will be null next time it's loaded.");
 					return;
 				}
 				int index = external_resources.size();

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2374,13 +2374,13 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 		if (tex3d.is_null()) {
 			f->close();
 			memdelete(f);
-			ERR_FAIL_COND_V(tex3d.is_null(), RES())
+			ERR_FAIL_COND_V(tex3d.is_null(), RES());
 		}
 	} else if (header[0] == 'G' && header[1] == 'D' && header[2] == 'A' && header[3] == 'T') {
 		if (texarr.is_null()) {
 			f->close();
 			memdelete(f);
-			ERR_FAIL_COND_V(texarr.is_null(), RES())
+			ERR_FAIL_COND_V(texarr.is_null(), RES());
 		}
 	} else {
 

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -193,7 +193,7 @@ void AudioStreamPlaybackMicrophone::start(float p_from_pos) {
 	}
 
 	if (!GLOBAL_GET("audio/enable_audio_input")) {
-		WARN_PRINTS("Need to enable Project settings > Audio > Enable Audio Input option to use capturing.");
+		WARN_PRINT("Need to enable Project settings > Audio > Enable Audio Input option to use capturing.");
 		return;
 	}
 

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -186,7 +186,7 @@ void AudioEffectRecord::ensure_thread_stopped() {
 void AudioEffectRecord::set_recording_active(bool p_record) {
 	if (p_record) {
 		if (current_instance == 0) {
-			WARN_PRINTS("Recording should not be set as active before Godot has initialized.");
+			WARN_PRINT("Recording should not be set as active before Godot has initialized.");
 			recording_active = false;
 			return;
 		}

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -104,7 +104,7 @@ void AudioDriver::input_buffer_write(int32_t sample) {
 			input_size++;
 		}
 	} else {
-		WARN_PRINTS("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
+		WARN_PRINT("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
 	}
 }
 

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -119,7 +119,7 @@ void VisualServerRaster::draw(bool p_swap_buffers, double frame_step) {
 			obj->call(frame_drawn_callbacks.front()->get().method, &v, 1, ce);
 			if (ce.error != Variant::CallError::CALL_OK) {
 				String err = Variant::get_call_error_text(obj, frame_drawn_callbacks.front()->get().method, &v, 1, ce);
-				ERR_PRINTS("Error calling frame drawn function: " + err);
+				ERR_PRINT("Error calling frame drawn function: " + err);
 			}
 		}
 


### PR DESCRIPTION
This pull request aims to achieve a number of things:

- [x] Provide a consistent, readable layout to the error_macros.h file.
- [x] Remove redundant, duplicate macros following #33382.
- [x] Add missing 'do' ... 'while(0)' wrappers to macros without them.
- [x] Remove the trailing semicolons ';' after 'while(0)'
- [x] Add semicolons to all code segments that were relying on a trailing ';' or '{}' with missing 'do' ... 'while' wrappers.

To make it easier to review and rebase when necessary, the changes are added as separate commits. They can be squashed before merging.

Note: Although the initial commit makes significant changes to error_macros.h, these are limited to code ordering and comments to make it consistent and more readable. It has no impact on any code that uses error_macros.h. This initial commit makes it easier to review the following commits.