### PR TITLE
Make text in the "About" dialog reset its position when changed

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -58,6 +58,7 @@ void EditorAbout::_notification(int p_what) {
 void EditorAbout::_license_tree_selected() {
 
 	TreeItem *selected = _tpl_tree->get_selected();
+	_tpl_text->scroll_to_line(0);
 	_tpl_text->set_text(selected->get_metadata(0));
 }
 


### PR DESCRIPTION
So the line position is always set at the beginning when switching between licenses.