### PR TITLE
Fixes LineEdit emitting text_change with max chars

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -558,7 +558,6 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 						selection_delete();
 						CharType ucodestr[2] = { (CharType)k->get_unicode(), 0 };
 						append_at_cursor(ucodestr);
-						_text_changed();
 						accept_event();
 					}
 
@@ -948,13 +947,6 @@ void LineEdit::paste_text() {
 
 		if (selection.enabled) selection_delete();
 		append_at_cursor(paste_buffer);
-
-		if (!text_changed_dirty) {
-			if (is_inside_tree()) {
-				MessageQueue::get_singleton()->push_call(this, "_text_changed");
-			}
-			text_changed_dirty = true;
-		}
 	}
 }
 
@@ -1335,6 +1327,9 @@ void LineEdit::append_at_cursor(String p_text) {
 		String post = text.substr(cursor_pos, text.length() - cursor_pos);
 		text = pre + p_text + post;
 		set_cursor_position(cursor_pos + p_text.length());
+		_text_changed();
+	} else {
+		_text_change_rejected(p_text);
 	}
 }
 
@@ -1641,6 +1636,10 @@ void LineEdit::_emit_text_change() {
 	text_changed_dirty = false;
 }
 
+void LineEdit::_text_change_rejected(String p_text) {
+	emit_signal("text_change_rejected", p_text);
+}
+
 void LineEdit::update_placeholder_width() {
 	if ((max_length <= 0) || (placeholder_translated.length() <= max_length)) {
 		Ref<Font> font = get_font("font");
@@ -1753,6 +1752,7 @@ void LineEdit::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("text_changed", PropertyInfo(Variant::STRING, "new_text")));
 	ADD_SIGNAL(MethodInfo("text_entered", PropertyInfo(Variant::STRING, "new_text")));
+	ADD_SIGNAL(MethodInfo("text_change_rejected", PropertyInfo(Variant::STRING, "rejected_text")));
 
 	BIND_ENUM_CONSTANT(ALIGN_LEFT);
 	BIND_ENUM_CONSTANT(ALIGN_CENTER);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -128,6 +128,7 @@ private:
 
 	void _text_changed();
 	void _emit_text_change();
+	void _text_change_rejected(String p_text);
 	bool expand_to_text_length;
 
 	void update_placeholder_width();


### PR DESCRIPTION
When LineEdit reached the maximum characters, it stopped appending text but would still emit `LineEdit::_text_changed()`.

This PR also resolves the issue of `LineEdit::_text_changed()` not being emitted on certain situations when `LineEdit::append_at_cursor()` is called but no `LineEdit::_text_changed()` is called afterwards (e.g. LineEdit::set_text()).

Also adds a new signal: "text_change_rejected" which is emitted when trying to add text to the field is unsuccessful due to reaching the maximum character limit.

Closes: #33318