### PR TITLE
Fix graphic tablet input coordinates on Windows.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -556,8 +556,14 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 
 			mm->set_button_mask(last_button_state);
 
-			mm->set_position(Vector2(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
-			mm->set_global_position(Vector2(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
+			POINT coords; //client coords
+			coords.x = GET_X_LPARAM(lParam);
+			coords.y = GET_Y_LPARAM(lParam);
+
+			ScreenToClient(hWnd, &coords);
+
+			mm->set_position(Vector2(coords.x, coords.y));
+			mm->set_global_position(Vector2(coords.x, coords.y));
 
 			if (mouse_mode == MOUSE_MODE_CAPTURED) {
 


### PR DESCRIPTION
[WM_POINTERUPDATE](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/inputmsg/wm-pointerupdate) returns point in the screen coordinates. (Issue was not noticed in #24329, because testing was done with a full screen window).