### PR TITLE
Ignore the classes in the recent and favorite panels of the create dialog if they are disabled

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -58,9 +58,7 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 		while (!f->eof_reached()) {
 			String l = f->get_line().strip_edges();
 			String name = l.split(" ")[0];
-
 			if ((ClassDB::class_exists(name) || ScriptServer::is_global_class(name)) && !_is_class_disabled_by_feature_profile(name)) {
-
 				TreeItem *ti = recent->create_item(root);
 				ti->set_text(0, l);
 				ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(l, base_type));
@@ -275,17 +273,7 @@ bool CreateDialog::_is_class_disabled_by_feature_profile(const StringName &p_cla
 		return false;
 	}
 
-	StringName class_name = p_class;
-
-	while (class_name != StringName()) {
-
-		if (profile->is_class_disabled(class_name)) {
-			return true;
-		}
-		class_name = ClassDB::get_parent_class_nocheck(class_name);
-	}
-
-	return false;
+	return profile->is_class_disabled(p_class);
 }
 
 void CreateDialog::select_type(const String &p_type) {
@@ -616,7 +604,7 @@ void CreateDialog::_update_favorite_list() {
 	for (int i = 0; i < favorite_list.size(); i++) {
 		String l = favorite_list[i];
 		String name = l.split(" ")[0];
-		if (!(ClassDB::class_exists(name) || ScriptServer::is_global_class(name)))
+		if (!((ClassDB::class_exists(name) || ScriptServer::is_global_class(name)) && !_is_class_disabled_by_feature_profile(name)))
 			continue;
 		TreeItem *ti = favorites->create_item(root);
 		ti->set_text(0, l);

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -64,7 +64,10 @@ void EditorFeatureProfile::set_disable_class(const StringName &p_class, bool p_d
 }
 
 bool EditorFeatureProfile::is_class_disabled(const StringName &p_class) const {
-	return disabled_classes.has(p_class);
+	if (p_class == StringName()) {
+		return false;
+	}
+	return disabled_classes.has(p_class) || is_class_disabled(ClassDB::get_parent_class_nocheck(p_class));
 }
 
 void EditorFeatureProfile::set_disable_class_editor(const StringName &p_class, bool p_disabled) {
@@ -76,7 +79,10 @@ void EditorFeatureProfile::set_disable_class_editor(const StringName &p_class, b
 }
 
 bool EditorFeatureProfile::is_class_editor_disabled(const StringName &p_class) const {
-	return disabled_editors.has(p_class);
+	if (p_class == StringName()) {
+		return false;
+	}
+	return disabled_editors.has(p_class) || is_class_editor_disabled(ClassDB::get_parent_class_nocheck(p_class));
 }
 
 void EditorFeatureProfile::set_disable_class_property(const StringName &p_class, const StringName &p_property, bool p_disabled) {


### PR DESCRIPTION
Fixes #33420

Now when opening a create node dialog the classes that will potentially added to the recent panel get checked whether they are disabled through the editor manage features dialog.

Also it seems that when checking if a class is disabled. The classes parents weren't checked. This means that you could disable Spatial, but if you call is_class_disabled on Camera, it would still return false.