### PR TITLE
Partial revert of #32657, undoing line shifting by 0.5

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -494,10 +494,8 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				if (line->width <= 1) {
 					Vector2 verts[2] = {
-						// Offset the line slightly to make sure we always draw the pixel at the from coordinate.
-						// Without this, corners of rectangles might be missing a pixel. (See diamond exit rule and #32657)
-						Vector2(Math::floor(line->from.x) + 0.5, Math::floor(line->from.y) + 0.5),
-						Vector2(Math::floor(line->to.x) + 0.5, Math::floor(line->to.y) + 0.5)
+						Vector2(line->from.x, line->from.y),
+						Vector2(line->to.x, line->to.y)
 					};
 
 #ifdef GLES_OVER_GL

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -548,10 +548,8 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				if (line->width <= 1) {
 					Vector2 verts[2] = {
-						// Offset the line slightly to make sure we always draw the pixel at the from coordinate.
-						// Without this, corners of rectangles might be missing a pixel. (See diamond exit rule and #32657)
-						Vector2(Math::floor(line->from.x) + 0.5, Math::floor(line->from.y) + 0.5),
-						Vector2(Math::floor(line->to.x) + 0.5, Math::floor(line->to.y) + 0.5)
+						Vector2(line->from.x, line->from.y),
+						Vector2(line->to.x, line->to.y)
 					};
 
 #ifdef GLES_OVER_GL


### PR DESCRIPTION
As discussed in #32657, this can't be done here as lines can be used
with a canvas scale, and this breaks them.
A suggestion is to do the pixel shifting at matrix level instead.

Fixes #33393.
Fixes #33421.