### PR TITLE
Fix r1 (and r2) may be used uninitialized warning in eq.cpp.

### DIFF
--- a/servers/audio/effects/eq.cpp
+++ b/servers/audio/effects/eq.cpp
@@ -103,7 +103,9 @@ void EQ::recalculate_band_coefficients() {
 
 		//printf("band %i, precoefs = %f,%f,%f\n",i,c2a,c2b,c2c);
 
-		double r1, r2; //roots
+		// Default initializing to silence compiler warning about potential uninitialized use.
+		// Both variables are properly set in _solve_quadratic before use, or we continue if roots == 0.
+		double r1 = 0, r2 = 0; //roots
 		int roots = solve_quadratic(c2a, c2b, c2c, &r1, &r2);
 
 		ERR_CONTINUE(roots == 0);


### PR DESCRIPTION
While working on #33391, the [Travis, Linux headless editor build](https://travis-ci.org/godotengine/godot/jobs/608698612) identified that "'r1' may be used uninitialized". This may not have been picked up before, because this file hasn't be touched since b16c309f82c77d606472c3c721a1857e323a09e7 (Jan 1) and only since #26030 (Feb 18) are all warnings treated as errors.

Although the current implementation appears to ensure that they either will be initialised or the `ERR_CONTINUE` macro will skip their use, the warning should be addressed appropriately. This patch ensures that, irrespective of the implementation of the `solve_quadratic()` function, `r1` (and `r2`) will not be used uninitialised; irrespective of the implementation of `solve_quadratic()`.