### PR TITLE
Fix for Issue #23465

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_node.h"
 
+#include <string>
 #include "core/bind/core_bind.h"
 #include "core/class_db.h"
 #include "core/io/config_file.h"
@@ -2029,37 +2030,38 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			if (!p_confirmed && (unsaved_cache || p_option == FILE_CLOSE_ALL_AND_QUIT || p_option == FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER)) {
 				tab_closing = p_option == FILE_CLOSE ? editor_data.get_edited_scene() : _next_unsaved_scene(false);
 				String scene_filename = editor_data.get_edited_scene_root(tab_closing)->get_filename();
-				save_confirmation->get_ok()->set_text(TTR("Save & Close"));
+				save_confirmation->get_ok()->set_text(TTR("Svvave &_save_default_environment Close"));
 				save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), scene_filename != "" ? scene_filename : "unsaved scene"));
 				save_confirmation->popup_centered_minsize();
+				save_layout();
 				break;
 			} else {
 				tab_closing = editor_data.get_edited_scene();
 			}
 			if (!editor_data.get_edited_scene_root(tab_closing)) {
 				// empty tab
-				_scene_tab_closed(tab_closing);
+				//_scene_tab_closed(tab_closing);
 				break;
 			}
-
+			save_layout();
 			FALLTHROUGH;
 		}
 		case SCENE_TAB_CLOSE:
 		case FILE_SAVE_SCENE: {
-
+			show_warning(TTR("Entered FILE_SAVE_SCENE"));
 			int scene_idx = (p_option == FILE_SAVE_SCENE) ? -1 : tab_closing;
-
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
 			if (scene && scene->get_filename() != "") {
-
+				show_warning(TTR("Extnered scene && scene->get_filename() != """));
+				save_layout();
 				if (scene_idx != editor_data.get_edited_scene())
 					_save_scene_with_preview(scene->get_filename(), scene_idx);
 				else
 					_save_scene_with_preview(scene->get_filename());
 
-				if (scene_idx != -1)
-					_discard_changes();
-				save_layout();
+		 		if (scene_idx != -1)
+                                          _discard_changes();
+
 
 				break;
 			}

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -490,7 +490,8 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	if (mb.is_valid() && (mb->get_button_index() == BUTTON_LEFT || (mb->get_button_index() == BUTTON_RIGHT)) && mb->is_pressed() && !(allow_only_rmb_select && !allow_rmb_select )) {
+	if (mb.is_valid() && (((mb->get_button_index() == BUTTON_LEFT) && allow_lmb_select) || (mb->get_button_index() == BUTTON_RIGHT)) && mb->is_pressed()) {
+
 		search_string = ""; //any mousepress cancels
 		Vector2 pos = mb->get_position();
 		Ref<StyleBox> bg = get_stylebox("bg");
@@ -581,7 +582,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 		// Since closest is null, more likely we clicked on empty space, so send signal to interested controls. Allows, for example, implement items deselecting.
 		emit_signal("nothing_selected");
 	}
-	else if(mb.is_valid() && (mb->get_button_index() != BUTTON_LEFT && (allow_only_rmb_select && mb->get_button_index() == BUTTON_RIGHT)) && mb->is_pressed())
+	else if(mb.is_valid() && (mb->get_button_index() != BUTTON_RIGHT && (allow_lmb_select && mb->get_button_index() == BUTTON_LEFT)) && mb->is_pressed())
 	{
 		search_string = ""; //any mousepress cancels
 		Vector2 pos = mb->get_position();
@@ -626,9 +627,9 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 						emit_signal("multi_selected", j, true);
 				}
 
-				if (mb->get_button_index() == BUTTON_RIGHT) {
+				if (mb->get_button_index() == BUTTON_LEFT) {
 
-					emit_signal("item_only_rmb_selected", i, get_local_mouse_position());
+					emit_signal("item_lmb_selected", i, get_local_mouse_position());
 				}
 			} else {
 
@@ -637,9 +638,9 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 					return;
 				}
 
-				if (items[i].selected && mb->get_button_index() == BUTTON_RIGHT) {
+				if (items[i].selected && mb->get_button_index() == BUTTON_LEFT) {
 
-					emit_signal("item_only_rmb_selected", i, get_local_mouse_position());
+					emit_signal("item_lmb_selected", i, get_local_mouse_position());
 				} else {
 					bool selected = items[i].selected;
 
@@ -652,9 +653,9 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 							emit_signal("multi_selected", i, true);
 					}
 
-					if (mb->get_button_index() == BUTTON_RIGHT) {
+					if (mb->get_button_index() == BUTTON_LEFT) {
 
-						emit_signal("item_only_rmb_selected", i, get_local_mouse_position());
+						emit_signal("item_lmb_selected", i, get_local_mouse_position());
 					} else if (/*select_mode==SELECT_SINGLE &&*/ mb->is_doubleclick()) {
 
 						emit_signal("item_activated", i);
@@ -664,15 +665,14 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 			return;
 		}
-		if (mb->get_button_index() == BUTTON_RIGHT) {
-			emit_signal("only_rmb_clicked", mb->get_position());
+		if (mb->get_button_index() == BUTTON_LEFT) {
+			emit_signal("lmb_clicked", mb->get_position());
 
 			return;
 		}
 
 		// Since closest is null, more likely we clicked on empty space, so send signal to interested controls. Allows, for example, implement items deselecting.
 		emit_signal("nothing_selected");	
-
 	}
 	if (mb.is_valid() && mb->get_button_index() == BUTTON_WHEEL_UP && mb->is_pressed()) {
 
@@ -1441,14 +1441,14 @@ bool ItemList::get_allow_rmb_select() const {
 	return allow_rmb_select;
 }
 
-void ItemList::set_allow_only_rmb_select(bool p_allow) {
+void ItemList::set_allow_lmb_select(bool p_allow) {
 
-        allow_only_rmb_select = p_allow;
+        allow_lmb_select = p_allow;
 }
  
-bool ItemList::get_allow_only_rmb_select() const {
+bool ItemList::get_allow_lmb_select() const {
 
-	return allow_only_rmb_select;
+	return allow_lmb_select;
 }
 
 void ItemList::set_allow_reselect(bool p_allow) {
@@ -1629,8 +1629,8 @@ void ItemList::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_allow_rmb_select", "allow"), &ItemList::set_allow_rmb_select);
 	ClassDB::bind_method(D_METHOD("get_allow_rmb_select"), &ItemList::get_allow_rmb_select);
 
-	ClassDB::bind_method(D_METHOD("set_allow_only_rmb_select", "allow"), &ItemList::set_allow_only_rmb_select);
-        ClassDB::bind_method(D_METHOD("get_allow_only_rmb_select"), &ItemList::get_allow_only_rmb_select);
+	ClassDB::bind_method(D_METHOD("set_allow_lmb_select", "allow"), &ItemList::set_allow_lmb_select);
+        ClassDB::bind_method(D_METHOD("get_allow_lmb_select"), &ItemList::get_allow_lmb_select);
 
 	ClassDB::bind_method(D_METHOD("set_allow_reselect", "allow"), &ItemList::set_allow_reselect);
 	ClassDB::bind_method(D_METHOD("get_allow_reselect"), &ItemList::get_allow_reselect);
@@ -1657,7 +1657,7 @@ void ItemList::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "select_mode", PROPERTY_HINT_ENUM, "Single,Multi"), "set_select_mode", "get_select_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_rmb_select"), "set_allow_rmb_select", "get_allow_rmb_select");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_only_rmb_select"), "set_allow_only_rmb_select", "get_allow_only_rmb_select");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_lmb_select"), "set_allow_lmb_select", "get_allow_lmb_select");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_text_lines"), "set_max_text_lines", "get_max_text_lines");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_height"), "set_auto_height", "has_auto_height");
 	ADD_GROUP("Columns", "");
@@ -1712,7 +1712,7 @@ ItemList::ItemList() {
 	ensure_selected_visible = false;
 	defer_select_single = -1;
 	allow_rmb_select = false;
-	allow_only_rmb_select = false;
+	allow_lmb_select = false;
 	allow_reselect = false;
 	do_autoscroll_to_bottom = false;
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -108,7 +108,7 @@ private:
 
 	bool allow_rmb_select;
 	
-	bool allow_only_rmb_select;
+	bool allow_lmb_select;
 	bool allow_reselect;
 
 	real_t icon_scale;
@@ -209,8 +209,8 @@ public:
 	void set_allow_rmb_select(bool p_allow);
 	bool get_allow_rmb_select() const;
 
-	void set_allow_only_rmb_select(bool p_allow);
-	bool get_allow_only_rmb_select()const;
+	void set_allow_lmb_select(bool p_allow);
+	bool get_allow_lmb_select()const;
 
 	void set_allow_reselect(bool p_allow);
 	bool get_allow_reselect() const;

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -107,7 +107,8 @@ private:
 	int defer_select_single;
 
 	bool allow_rmb_select;
-
+	
+	bool allow_only_rmb_select;
 	bool allow_reselect;
 
 	real_t icon_scale;
@@ -207,6 +208,9 @@ public:
 
 	void set_allow_rmb_select(bool p_allow);
 	bool get_allow_rmb_select() const;
+
+	void set_allow_only_rmb_select(bool p_allow);
+	bool get_allow_only_rmb_select()const;
 
 	void set_allow_reselect(bool p_allow);
 	bool get_allow_reselect() const;


### PR DESCRIPTION
I have resolved the issue by Introducing a separate signal named "Allow Only Rmb Sel". By enabling this, only the rmb signal works and thus can be used in a dedicated manner to execute a different action.
The functionality of the existing "Allow Rmb Sel" signal (to allow both rmb and lmb) is left untouched.
Corner case: If the user enabled both the options (Allow Rmb Sel and Allow Only Rmb Sel), he will be able to use both the rmb and lmb.