### PR TITLE
Revert "Fixed TouchScreenButton::shape_centered having no effect"

### DIFF
--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -325,12 +325,8 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 }
 
 Rect2 TouchScreenButton::_edit_get_rect() const {
-	if (texture.is_null()) {
-		if (shape.is_valid())
-			return shape->get_rect();
-		else
-			return CanvasItem::_edit_get_rect();
-	}
+	if (texture.is_null())
+		return CanvasItem::_edit_get_rect();
 
 	return Rect2(Size2(), texture->get_size());
 }


### PR DESCRIPTION
This reverts commit 127c2d75ad109fe4a905f9061fcbc25d1e8b0ca9.

This was a misunderstanding as #32725 is not a bug but expected
behavior.

Reverts #32927.
Supersedes and closes #33436.

An addition to the documentation would be good to clarify things. CC @groud