### PR TITLE
Fixed initial title in audio buses editor

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1329,7 +1329,8 @@ EditorAudioBuses::EditorAudioBuses() {
 	add_child(top_hb);
 
 	file = memnew(Label);
-	file->set_text(String(TTR("Layout")) + ": " + "default_bus_layout.tres");
+	String layout_path = ProjectSettings::get_singleton()->get("audio/default_bus_layout");
+	file->set_text(String(TTR("Layout")) + ": " + layout_path.get_file());
 	file->set_clip_text(true);
 	file->set_h_size_flags(SIZE_EXPAND_FILL);
 	top_hb->add_child(file);


### PR DESCRIPTION
Previously, 'default_bus_layout.tres' was always displayed at startup,
even if 'audio/default_bus_layout' was changed in Project Settings.