### PR TITLE
Make MSAA in GLES2 work with external textures for VR

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5156,26 +5156,14 @@ void RasterizerStorageGLES2::render_target_set_external_texture(RID p_render_tar
 
 		// is there a point to setting the internal formats? we don't know them..
 
-		// check if MSAA is active to set the correct depth buffer and target texture for android
-		if (rt->multisample_active) {
-#if defined(GLES_OVER_GL) || defined(IPHONE_ENABLED)
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, p_texture_id);
-#elif ANDROID_ENABLED
-			static const int msaa_value[] = { 0, 2, 4, 8, 16 };
-			int msaa = msaa_value[rt->msaa];
-			glFramebufferTexture2DMultisample(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_texture_id, 0, msaa);
-#endif
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->multisample_depth);
-		} else {
-			// set our texture as the destination for our framebuffer
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_texture_id, 0);
+		// set our texture as the destination for our framebuffer
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_texture_id, 0);
 
-			// seeing we're rendering into this directly, better also use our depth buffer, just use our existing one :)
-			if (config.support_depth_texture) {
-				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
-			} else {
-				glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth);
-			}
+		// seeing we're rendering into this directly, better also use our depth buffer, just use our existing one :)
+		if (config.support_depth_texture) {
+			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
+		} else {
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth);
 		}
 
 		// check status and unbind


### PR DESCRIPTION
This PR undoes @NeoSpark314 s change and changes the MSAA logic so the scene gets rendered into Godots properly setup MSAA buffers and then does the MSAA resolve into the external texture instead of the normal forward buffer. This means MSAA now works on all platforms including desktop.

This is not all sunshine and daisies though. While this does correctly implement the MSAA logic as intended by Godot it removes an important optimisation for the Quest.

The ideal situation for the Quest is for the external texture to be a properly set up MSAA render target and for the _post_process to be skipped completely. The MSAA resolve will happen when the Oculus SDK applies the lens distortion shader to render the final output.

It is my opinion that should be a project in its own right and instead of using Godots MSAA logic, to turn off MSAA in Godot and instead have the plugin drive this fully. This does mean that the plugin needs to be aware whether the GLES2, GLES3 or Vulkan driver is active and some how inform Godot of the fact that a MSAA capable depth buffer is needed for the external fbo. Alternatively one options that was suggested is to have the plugin setup the FBO completely and just provide an FBO to Godot instead of a texture id (or a struct with all info as the texture id may still be needed).

*Bugsquad edit:* Reverts and supersedes #33291, fixes #33188.