### PR TITLE
macOS add signing of DMG and ZIPed export

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -57,6 +57,7 @@ class EditorExportPlatformOSX : public EditorExportPlatform {
 
 	Error _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path);
 	Error _create_dmg(const String &p_dmg_path, const String &p_pkg_name, const String &p_app_path_name);
+	void _zip_folder_recursive(zipFile &p_zip, const String &p_root_path, const String &p_folder, const String &p_pkg_name);
 
 #ifdef OSX_ENABLED
 	bool use_codesign() const { return true; }
@@ -363,6 +364,7 @@ void EditorExportPlatformOSX::_fix_plist(const Ref<EditorExportPreset> &p_preset
 **/
 
 Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path) {
+#ifdef OSX_ENABLED
 	List<String> args;
 
 	if (p_preset->get("codesign/timestamp")) {
@@ -373,8 +375,7 @@ Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_prese
 		args.push_back("runtime");
 	}
 
-	if (p_preset->get("codesign/entitlements") != "") {
-		/* this should point to our entitlements.plist file that sandboxes our application, I don't know if this should also be placed in our app bundle */
+	if ((p_preset->get("codesign/entitlements") != "") && (p_path.get_extension() != "dmg")) {
 		args.push_back("--entitlements");
 		args.push_back(p_preset->get("codesign/entitlements"));
 	}
@@ -407,6 +408,7 @@ Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_prese
 		EditorNode::add_io_error("codesign: invalid entitlements file");
 		return FAILED;
 	}
+#endif
 
 	return OK;
 }
@@ -500,53 +502,42 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 	Error err = OK;
 	String tmp_app_path_name = "";
-	zlib_filefunc_def io2 = io;
-	FileAccess *dst_f = nullptr;
-	io2.opaque = &dst_f;
-	zipFile dst_pkg_zip = nullptr;
 
 	DirAccess *tmp_app_path = nullptr;
 	String export_format = use_dmg() && p_path.ends_with("dmg") ? "dmg" : "zip";
-	if (export_format == "dmg") {
-		// We're on OSX so we can export to DMG, but first we create our application bundle
-		tmp_app_path_name = EditorSettings::get_singleton()->get_cache_dir().plus_file(pkg_name + ".app");
-		print_line("Exporting to " + tmp_app_path_name);
-		tmp_app_path = DirAccess::create_for_path(tmp_app_path_name);
-		if (!tmp_app_path) {
-			err = ERR_CANT_CREATE;
-		}
 
-		// Create our folder structure or rely on unzip?
-		if (err == OK) {
-			print_line("Creating " + tmp_app_path_name + "/Contents/MacOS");
-			err = tmp_app_path->make_dir_recursive(tmp_app_path_name + "/Contents/MacOS");
-		}
-
-		if (err == OK) {
-			print_line("Creating " + tmp_app_path_name + "/Contents/Frameworks");
-			err = tmp_app_path->make_dir_recursive(tmp_app_path_name + "/Contents/Frameworks");
-		}
-
-		if (err == OK) {
-			print_line("Creating " + tmp_app_path_name + "/Contents/Resources");
-			err = tmp_app_path->make_dir_recursive(tmp_app_path_name + "/Contents/Resources");
-		}
-	} else {
-		// Open our destination zip file
-		dst_pkg_zip = zipOpen2(p_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io2);
-		if (!dst_pkg_zip) {
-			err = ERR_CANT_CREATE;
-		}
+	// Create our application bundle.
+	tmp_app_path_name = EditorSettings::get_singleton()->get_cache_dir().plus_file(pkg_name + ".app");
+	print_line("Exporting to " + tmp_app_path_name);
+	tmp_app_path = DirAccess::create_for_path(tmp_app_path_name);
+	if (!tmp_app_path) {
+		err = ERR_CANT_CREATE;
 	}
 
-	// Now process our template
+	// Create our folder structure.
+	if (err == OK) {
+		print_line("Creating " + tmp_app_path_name + "/Contents/MacOS");
+		err = tmp_app_path->make_dir_recursive(tmp_app_path_name + "/Contents/MacOS");
+	}
+
+	if (err == OK) {
+		print_line("Creating " + tmp_app_path_name + "/Contents/Frameworks");
+		err = tmp_app_path->make_dir_recursive(tmp_app_path_name + "/Contents/Frameworks");
+	}
+
+	if (err == OK) {
+		print_line("Creating " + tmp_app_path_name + "/Contents/Resources");
+		err = tmp_app_path->make_dir_recursive(tmp_app_path_name + "/Contents/Resources");
+	}
+
+	// Now process our template.
 	bool found_binary = false;
 	int total_size = 0;
 
 	while (ret == UNZ_OK && err == OK) {
 		bool is_execute = false;
 
-		//get filename
+		// Get filename.
 		unz_file_info info;
 		char fname[16384];
 		ret = unzGetCurrentFileInfo(src_pkg_zip, &info, fname, 16384, nullptr, 0, nullptr, 0);
@@ -556,13 +547,12 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		Vector<uint8_t> data;
 		data.resize(info.uncompressed_size);
 
-		//read
+		// Read.
 		unzOpenCurrentFile(src_pkg_zip);
 		unzReadCurrentFile(src_pkg_zip, data.ptrw(), data.size());
 		unzCloseCurrentFile(src_pkg_zip);
 
-		//write
-
+		// Write.
 		file = file.replace_first("osx_template.app/", "");
 
 		if (file == "Contents/Info.plist") {
@@ -572,7 +562,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		if (file.begins_with("Contents/MacOS/godot_")) {
 			if (file != "Contents/MacOS/" + binary_to_use) {
 				ret = unzGoToNextFile(src_pkg_zip);
-				continue; //ignore!
+				continue; // skip
 			}
 			found_binary = true;
 			is_execute = true;
@@ -580,7 +570,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		}
 
 		if (file == "Contents/Resources/icon.icns") {
-			//see if there is an icon
+			// See if there is an icon.
 			String iconpath;
 			if (p_preset->get("application/icon") != "") {
 				iconpath = p_preset->get("application/icon");
@@ -612,14 +602,14 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			if (file.find("/data.mono.osx.64.release_debug/") != -1) {
 				if (!p_debug) {
 					ret = unzGoToNextFile(src_pkg_zip);
-					continue; //skip
+					continue; // skip
 				}
 				file = file.replace("/data.mono.osx.64.release_debug/", "/data_" + pkg_name_safe + "/");
 			}
 			if (file.find("/data.mono.osx.64.release/") != -1) {
 				if (p_debug) {
 					ret = unzGoToNextFile(src_pkg_zip);
-					continue; //skip
+					continue; // skip
 				}
 				file = file.replace("/data.mono.osx.64.release/", "/data_" + pkg_name_safe + "/");
 			}
@@ -627,62 +617,31 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			print_line("ADDING: " + file + " size: " + itos(data.size()));
 			total_size += data.size();
 
-			if (export_format == "dmg") {
-				// write it into our application bundle
-				file = tmp_app_path_name.plus_file(file);
-				if (err == OK) {
-					err = tmp_app_path->make_dir_recursive(file.get_base_dir());
-				}
-				if (err == OK) {
-					// write the file, need to add chmod
-					FileAccess *f = FileAccess::open(file, FileAccess::WRITE);
-					if (f) {
-						f->store_buffer(data.ptr(), data.size());
-						f->close();
-						if (is_execute) {
-							// Chmod with 0755 if the file is executable
-							FileAccess::set_unix_permissions(file, 0755);
-						}
-						memdelete(f);
-					} else {
-						err = ERR_CANT_CREATE;
+			// Write it into our application bundle.
+			file = tmp_app_path_name.plus_file(file);
+			if (err == OK) {
+				err = tmp_app_path->make_dir_recursive(file.get_base_dir());
+			}
+			if (err == OK) {
+				FileAccess *f = FileAccess::open(file, FileAccess::WRITE);
+				if (f) {
+					f->store_buffer(data.ptr(), data.size());
+					f->close();
+					if (is_execute) {
+						// chmod with 0755 if the file is executable.
+						FileAccess::set_unix_permissions(file, 0755);
 					}
+					memdelete(f);
+				} else {
+					err = ERR_CANT_CREATE;
 				}
-			} else {
-				// add it to our zip file
-				file = pkg_name + ".app/" + file;
-
-				zip_fileinfo fi;
-				fi.tmz_date.tm_hour = info.tmu_date.tm_hour;
-				fi.tmz_date.tm_min = info.tmu_date.tm_min;
-				fi.tmz_date.tm_sec = info.tmu_date.tm_sec;
-				fi.tmz_date.tm_mon = info.tmu_date.tm_mon;
-				fi.tmz_date.tm_mday = info.tmu_date.tm_mday;
-				fi.tmz_date.tm_year = info.tmu_date.tm_year;
-				fi.dosDate = info.dosDate;
-				fi.internal_fa = info.internal_fa;
-				fi.external_fa = info.external_fa;
-
-				zipOpenNewFileInZip(dst_pkg_zip,
-						file.utf8().get_data(),
-						&fi,
-						nullptr,
-						0,
-						nullptr,
-						0,
-						nullptr,
-						Z_DEFLATED,
-						Z_DEFAULT_COMPRESSION);
-
-				zipWriteInFileInZip(dst_pkg_zip, data.ptr(), data.size());
-				zipCloseFileInZip(dst_pkg_zip);
 			}
 		}
 
 		ret = unzGoToNextFile(src_pkg_zip);
 	}
 
-	// we're done with our source zip
+	// We're done with our source zip.
 	unzClose(src_pkg_zip);
 
 	if (!found_binary) {
@@ -695,120 +654,128 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			return ERR_SKIP;
 		}
 
+		String pack_path = tmp_app_path_name + "/Contents/Resources/" + pkg_name + ".pck";
+		Vector<SharedObject> shared_objects;
+		err = save_pack(p_preset, pack_path, &shared_objects);
+
+		// See if we can code sign our new package.
+		bool sign_enabled = p_preset->get("codesign/enable");
+
+		if (err == OK) {
+			DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			for (int i = 0; i < shared_objects.size(); i++) {
+				err = da->copy(shared_objects[i].path, tmp_app_path_name + "/Contents/Frameworks/" + shared_objects[i].path.get_file());
+				if (err == OK && sign_enabled) {
+					err = _code_sign(p_preset, tmp_app_path_name + "/Contents/Frameworks/" + shared_objects[i].path.get_file());
+				}
+			}
+			memdelete(da);
+		}
+
+		if (err == OK && sign_enabled) {
+			if (ep.step("Code signing bundle", 2)) {
+				return ERR_SKIP;
+			}
+			err = _code_sign(p_preset, tmp_app_path_name + "/Contents/MacOS/" + pkg_name);
+		}
+
 		if (export_format == "dmg") {
-			String pack_path = tmp_app_path_name + "/Contents/Resources/" + pkg_name + ".pck";
-			Vector<SharedObject> shared_objects;
-			err = save_pack(p_preset, pack_path, &shared_objects);
-
-			// see if we can code sign our new package
-			bool sign_enabled = p_preset->get("codesign/enable");
-
-			if (err == OK) {
-				DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-				for (int i = 0; i < shared_objects.size(); i++) {
-					err = da->copy(shared_objects[i].path, tmp_app_path_name + "/Contents/Frameworks/" + shared_objects[i].path.get_file());
-					if (err == OK && sign_enabled) {
-						err = _code_sign(p_preset, tmp_app_path_name + "/Contents/Frameworks/" + shared_objects[i].path.get_file());
-					}
-				}
-				memdelete(da);
-			}
-
-			if (err == OK && sign_enabled) {
-				if (ep.step("Code signing bundle", 2)) {
-					return ERR_SKIP;
-				}
-
-				// the order in which we code sign is important, this is a bit of a shame or we could do this in our loop that extracts the files from our ZIP
-
-				// start with our application
-				err = _code_sign(p_preset, tmp_app_path_name + "/Contents/MacOS/" + pkg_name);
-
-				///@TODO we should check the contents of /Contents/Frameworks for frameworks to sign
-			}
-
-			// and finally create a DMG
+			// Create a DMG.
 			if (err == OK) {
 				if (ep.step("Making DMG", 3)) {
 					return ERR_SKIP;
 				}
 				err = _create_dmg(p_path, pkg_name, tmp_app_path_name);
 			}
-
-			// Clean up temporary .app dir
-			OS::get_singleton()->move_to_trash(tmp_app_path_name);
-
-		} else { // pck
-
-			String pack_path = EditorSettings::get_singleton()->get_cache_dir().plus_file(pkg_name + ".pck");
-
-			Vector<SharedObject> shared_objects;
-			err = save_pack(p_preset, pack_path, &shared_objects);
-
-			if (err == OK) {
-				zipOpenNewFileInZip(dst_pkg_zip,
-						(pkg_name + ".app/Contents/Resources/" + pkg_name + ".pck").utf8().get_data(),
-						nullptr,
-						nullptr,
-						0,
-						nullptr,
-						0,
-						nullptr,
-						Z_DEFLATED,
-						Z_DEFAULT_COMPRESSION);
-
-				FileAccess *pf = FileAccess::open(pack_path, FileAccess::READ);
-				if (pf) {
-					const int BSIZE = 16384;
-					uint8_t buf[BSIZE];
-
-					while (true) {
-						int r = pf->get_buffer(buf, BSIZE);
-						if (r <= 0) {
-							break;
-						}
-						zipWriteInFileInZip(dst_pkg_zip, buf, r);
-					}
-
-					zipCloseFileInZip(dst_pkg_zip);
-					memdelete(pf);
-				} else {
-					err = ERR_CANT_OPEN;
+			// Sign DMG.
+			if (err == OK && sign_enabled) {
+				if (ep.step("Code signing DMG", 3)) {
+					return ERR_SKIP;
 				}
+				err = _code_sign(p_preset, p_path);
 			}
-
+		} else {
+			// Create ZIP.
 			if (err == OK) {
-				//add shared objects
-				for (int i = 0; i < shared_objects.size(); i++) {
-					Vector<uint8_t> file = FileAccess::get_file_as_array(shared_objects[i].path);
-					ERR_CONTINUE(file.empty());
-
-					zipOpenNewFileInZip(dst_pkg_zip,
-							(pkg_name + ".app/Contents/Frameworks/").plus_file(shared_objects[i].path.get_file()).utf8().get_data(),
-							nullptr,
-							nullptr,
-							0,
-							nullptr,
-							0,
-							nullptr,
-							Z_DEFLATED,
-							Z_DEFAULT_COMPRESSION);
-
-					zipWriteInFileInZip(dst_pkg_zip, file.ptr(), file.size());
-					zipCloseFileInZip(dst_pkg_zip);
+				if (ep.step("Making ZIP", 3)) {
+					return ERR_SKIP;
 				}
-			}
+				if (FileAccess::exists(p_path)) {
+					OS::get_singleton()->move_to_trash(p_path);
+				}
 
-			// Clean up generated file.
-			DirAccess::remove_file_or_error(pack_path);
+				FileAccess *dst_f = nullptr;
+				zlib_filefunc_def io_dst = zipio_create_io_from_file(&dst_f);
+				zipFile zip = zipOpen2(p_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io_dst);
+
+				_zip_folder_recursive(zip, EditorSettings::get_singleton()->get_cache_dir(), pkg_name + ".app", pkg_name);
+
+				zipClose(zip, nullptr);
+			}
 		}
-	}
 
-	if (dst_pkg_zip) {
-		zipClose(dst_pkg_zip, nullptr);
+		// Clean up temporary .app dir.
+		OS::get_singleton()->move_to_trash(tmp_app_path_name);
 	}
 
 	return err;
+}
+
+void EditorExportPlatformOSX::_zip_folder_recursive(zipFile &p_zip, const String &p_root_path, const String &p_folder, const String &p_pkg_name) {
+	String dir = p_root_path.plus_file(p_folder);
+
+	DirAccess *da = DirAccess::open(dir);
+	da->list_dir_begin();
+	String f;
+	while ((f = da->get_next()) != "") {
+		if (f == "." || f == "..") {
+			continue;
+		}
+		if (da->current_is_dir()) {
+			_zip_folder_recursive(p_zip, p_root_path, p_folder.plus_file(f), p_pkg_name);
+		} else {
+			bool is_executable = (p_folder.ends_with("MacOS") && (f == p_pkg_name));
+
+			OS::Time time = OS::get_singleton()->get_time();
+			OS::Date date = OS::get_singleton()->get_date();
+
+			zip_fileinfo zipfi;
+			zipfi.tmz_date.tm_hour = time.hour;
+			zipfi.tmz_date.tm_mday = date.day;
+			zipfi.tmz_date.tm_min = time.min;
+			zipfi.tmz_date.tm_mon = date.month;
+			zipfi.tmz_date.tm_sec = time.sec;
+			zipfi.tmz_date.tm_year = date.year;
+			zipfi.dosDate = 0;
+			zipfi.external_fa = (is_executable ? 0755 : 0644) << 16L;
+			zipfi.internal_fa = 0;
+
+			zipOpenNewFileInZip4(p_zip,
+					p_folder.plus_file(f).utf8().get_data(),
+					&zipfi,
+					nullptr,
+					0,
+					nullptr,
+					0,
+					nullptr,
+					Z_DEFLATED,
+					Z_DEFAULT_COMPRESSION,
+					0,
+					-MAX_WBITS,
+					DEF_MEM_LEVEL,
+					Z_DEFAULT_STRATEGY,
+					nullptr,
+					0,
+					0x0314, // "version made by", 0x03 - Unix, 0x14 - ZIP specification version 2.0, required to store Unix file permissions
+					0);
+
+			Vector<uint8_t> array = FileAccess::get_file_as_array(dir.plus_file(f));
+			zipWriteInFileInZip(p_zip, array.ptr(), array.size());
+			zipCloseFileInZip(p_zip);
+		}
+	}
+	da->list_dir_end();
+	memdelete(da);
 }
 
 bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {


### PR DESCRIPTION
1. Sign `DMG` after exporting (required for notarizing).
2. Sign `.app` bundle when exporting as `ZIP` on macOS.

Instead of separate export code that was modifying copy of export template `ZIP`, it now reuses same export procedure for both `ZIP` and `DMG` - extracting export template, signing and creating new archive.