### PR TITLE
Add "vulkan_enabled" environment variable

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -120,6 +120,7 @@ opts.Add(BoolVariable('deprecated', "Enable deprecated features", True))
 opts.Add(BoolVariable('gdscript', "Enable GDScript support", True))
 opts.Add(BoolVariable('minizip', "Enable ZIP archive support using minizip", True))
 opts.Add(BoolVariable('xaudio2', "Enable the XAudio2 audio driver", False))
+opts.Add(BoolVariable('vulkan_enabled', "Enable vulkan", True))
 
 # Advanced options
 opts.Add(BoolVariable('verbose', "Enable verbose output for the compilation", False))

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -23,7 +23,7 @@ SConscript('coremidi/SCsub')
 SConscript('winmidi/SCsub')
 
 # Graphics drivers
-if (env["platform"] != "server"):
+if (env["vulkan_enabled"]):
 #    SConscript('gles3/SCsub')
 #    SConscript('gles2/SCsub')
     SConscript('vulkan/SCsub')


### PR DESCRIPTION
I thought this environment variable would be nice to have in the case that some platforms don't need any Vulkan code. This way, there is no need to mention any platforms on `drivers/SCsub`.

So, if a platform doesn't need any Vulkan code, it could be disabled like this, say on `platform/[platform]/detect.py` on `configure(env):`:

```        env['vulkan_enabled'] = False```
