### PR TITLE
Fixed Particles restart after visibility has been set to off and on again

### DIFF
--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -331,6 +331,13 @@ void Particles::_notification(int p_what) {
 			set_process_internal(false);
 		}
 	}
+
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+		// make sure particles are updated before rendering occurs if they were active before
+		if (is_visible_in_tree() && !VS::get_singleton()->particles_is_inactive(particles)) {
+			VS::get_singleton()->particles_request_process(particles);
+		}
+	}
 }
 
 void Particles::_bind_methods() {

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -409,6 +409,8 @@ public:
 	BIND2(particles_set_process_material, RID, RID)
 	BIND2(particles_set_fixed_fps, RID, int)
 	BIND2(particles_set_fractional_delta, RID, bool)
+	BIND1R(bool, particles_is_inactive, RID)
+	BIND1(particles_request_process, RID)
 	BIND1(particles_restart, RID)
 
 	BIND2(particles_set_draw_order, RID, VS::ParticlesDrawOrder)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -343,6 +343,8 @@ public:
 	FUNC2(particles_set_process_material, RID, RID)
 	FUNC2(particles_set_fixed_fps, RID, int)
 	FUNC2(particles_set_fractional_delta, RID, bool)
+	FUNC1R(bool, particles_is_inactive, RID)
+	FUNC1(particles_request_process, RID)
 	FUNC1(particles_restart, RID)
 
 	FUNC2(particles_set_draw_order, RID, VS::ParticlesDrawOrder)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1844,6 +1844,8 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("particles_set_process_material", "particles", "material"), &VisualServer::particles_set_process_material);
 	ClassDB::bind_method(D_METHOD("particles_set_fixed_fps", "particles", "fps"), &VisualServer::particles_set_fixed_fps);
 	ClassDB::bind_method(D_METHOD("particles_set_fractional_delta", "particles", "enable"), &VisualServer::particles_set_fractional_delta);
+	ClassDB::bind_method(D_METHOD("particles_is_inactive", "particles"), &VisualServer::particles_is_inactive);
+	ClassDB::bind_method(D_METHOD("particles_request_process", "particles"), &VisualServer::particles_request_process);
 	ClassDB::bind_method(D_METHOD("particles_restart", "particles"), &VisualServer::particles_restart);
 	ClassDB::bind_method(D_METHOD("particles_set_draw_order", "particles", "order"), &VisualServer::particles_set_draw_order);
 	ClassDB::bind_method(D_METHOD("particles_set_draw_passes", "particles", "count"), &VisualServer::particles_set_draw_passes);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -560,6 +560,8 @@ public:
 	virtual void particles_set_process_material(RID p_particles, RID p_material) = 0;
 	virtual void particles_set_fixed_fps(RID p_particles, int p_fps) = 0;
 	virtual void particles_set_fractional_delta(RID p_particles, bool p_enable) = 0;
+	virtual bool particles_is_inactive(RID p_particles) = 0;
+	virtual void particles_request_process(RID p_particles) = 0;
 	virtual void particles_restart(RID p_particles) = 0;
 
 	enum ParticlesDrawOrder {


### PR DESCRIPTION
Make sure particles are processed during the same frame when visibility is set to on, in case they are still active from before and need to be restarted.

Fixed #33476