### PR TITLE
Set ShellExecuteW's verb to NULL - fixes #33388

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2988,7 +2988,7 @@ void OS_Windows::move_window_to_foreground() {
 
 Error OS_Windows::shell_open(String p_uri) {
 
-	ShellExecuteW(NULL, L"open", p_uri.c_str(), NULL, NULL, SW_SHOWNORMAL);
+	ShellExecuteW(NULL, NULL, p_uri.c_str(), NULL, NULL, SW_SHOWNORMAL);
 	return OK;
 }
 


### PR DESCRIPTION
from https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutew

> **NULL**
>The default verb is used, if available. If not, the "open" verb is used. If neither verb is available, the system uses the first verb listed in the registry.

so "open" is redundant at best

*Bugsquad edit:* Fixes #33388.