### PR TITLE
Update configuration warnings for Particles, CPUParticles, Particles2D & CPUParticles2D

### DIFF
--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -186,10 +186,18 @@ private:
 
 	void _set_redraw(bool p_redraw);
 
+#ifdef TOOLS_ENABLED
+	Ref<Material> checked_material;
+#endif
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &property) const;
+
+#ifdef TOOLS_ENABLED
+	void _changed_callback(Object *p_changed, const char *p_prop);
+#endif
 
 public:
 	void set_emitting(bool p_emitting);

--- a/scene/2d/particles_2d.h
+++ b/scene/2d/particles_2d.h
@@ -69,10 +69,18 @@ private:
 
 	void _update_particle_emission_transform();
 
+#ifdef TOOLS_ENABLED
+	Ref<Material> checked_material;
+#endif
+
 protected:
 	static void _bind_methods();
 	virtual void _validate_property(PropertyInfo &property) const;
 	void _notification(int p_what);
+
+#ifdef TOOLS_ENABLED
+	void _changed_callback(Object *p_changed, const char *p_prop);
+#endif
 
 public:
 	void set_emitting(bool p_emitting);

--- a/scene/3d/cpu_particles.h
+++ b/scene/3d/cpu_particles.h
@@ -183,10 +183,19 @@ private:
 
 	void _set_redraw(bool p_redraw);
 
+#ifdef TOOLS_ENABLED
+	Set<Ref<Material> > checked_materials;
+	void _update_checked_materials();
+#endif
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &property) const;
+
+#ifdef TOOLS_ENABLED
+	void _changed_callback(Object *p_changed, const char *p_prop);
+#endif
 
 public:
 	AABB get_aabb() const;

--- a/scene/3d/particles.h
+++ b/scene/3d/particles.h
@@ -71,10 +71,19 @@ private:
 
 	Vector<Ref<Mesh> > draw_passes;
 
+#ifdef TOOLS_ENABLED
+	Set<Ref<Material> > checked_materials;
+	void _update_checked_materials();
+#endif
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &property) const;
+
+#ifdef TOOLS_ENABLED
+	void _changed_callback(Object *p_changed, const char *p_prop);
+#endif
 
 public:
 	AABB get_aabb() const;

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -163,6 +163,8 @@ void GeometryInstance::set_material_override(const Ref<Material> &p_material) {
 
 	material_override = p_material;
 	VS::get_singleton()->instance_geometry_set_material_override(get_instance(), p_material.is_valid() ? p_material->get_rid() : RID());
+
+	_change_notify("material_override");
 }
 
 Ref<Material> GeometryInstance::get_material_override() const {

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -720,6 +720,8 @@ void ParticlesMaterial::set_param(Parameter p_param, float p_value) {
 		} break;
 		case PARAM_MAX: break; // Can't happen, but silences warning
 	}
+
+	_change_notify();
 }
 float ParticlesMaterial::get_param(Parameter p_param) const {
 


### PR DESCRIPTION
Particle systems track changes in meshes, materials & parameters in the editor in order to update warnings properly.

Fixes #33488