### PR TITLE
Fixed not being able to scroll ending wrapped line

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4585,7 +4585,7 @@ void TextEdit::_scroll_moved(double p_to_val) {
 		int v_scroll_i = floor(get_v_scroll());
 		int sc = 0;
 		int n_line;
-		for (n_line = 0; n_line < text.size() - 1; n_line++) {
+		for (n_line = 0; n_line < text.size(); n_line++) {
 			if (!is_line_hidden(n_line)) {
 				sc++;
 				sc += times_line_wraps(n_line);


### PR DESCRIPTION
Fixed not being able to scroll the through the final line when its wrapped height was larger then the control height.

closes #32229