### PR TITLE
Fixed errors when saving scene with a shrunk viewport

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1065,7 +1065,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			img->crop_from_point(x, y, vp_size, vp_size);
 		} else {
 			int ratio = vp_size / preview_size;
-			int size = preview_size * (ratio / 2);
+			int size = preview_size * MAX(1, ratio / 2);
 
 			x = (img->get_width() - size) / 2;
 			y = (img->get_height() - size) / 2;


### PR DESCRIPTION
Handle viewport size larger than preview size but very close, when the ratio was 1 the size ended up being 0.

Fixes #33497