### PR TITLE
Camera: Don't set default value for project_position

### DIFF
--- a/doc/classes/Camera.xml
+++ b/doc/classes/Camera.xml
@@ -77,10 +77,10 @@
 			</return>
 			<argument index="0" name="screen_point" type="Vector2">
 			</argument>
-			<argument index="1" name="z_depth" type="float" default="0">
+			<argument index="1" name="z_depth" type="float">
 			</argument>
 			<description>
-				Returns the 3D point in worldspace that maps to the given 2D coordinate in the [Viewport] rectangle on a plane that is the given distance into the scene away from the camera.
+				Returns the 3D point in worldspace that maps to the given 2D coordinate in the [Viewport] rectangle on a plane that is the given [code]z_depth[/code] distance into the scene away from the camera.
 			</description>
 		</method>
 		<method name="project_ray_normal" qualifiers="const">

--- a/scene/3d/arvr_nodes.h
+++ b/scene/3d/arvr_nodes.h
@@ -55,7 +55,7 @@ public:
 
 	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const;
 	virtual Point2 unproject_position(const Vector3 &p_pos) const;
-	virtual Vector3 project_position(const Point2 &p_point, float p_z_depth = 0) const;
+	virtual Vector3 project_position(const Point2 &p_point, float p_z_depth) const;
 	virtual Vector<Plane> get_frustum() const;
 
 	ARVRCamera();

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -486,7 +486,7 @@ void Camera::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("project_ray_origin", "screen_point"), &Camera::project_ray_origin);
 	ClassDB::bind_method(D_METHOD("unproject_position", "world_point"), &Camera::unproject_position);
 	ClassDB::bind_method(D_METHOD("is_position_behind", "world_point"), &Camera::is_position_behind);
-	ClassDB::bind_method(D_METHOD("project_position", "screen_point", "z_depth"), &Camera::project_position, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("project_position", "screen_point", "z_depth"), &Camera::project_position);
 	ClassDB::bind_method(D_METHOD("set_perspective", "fov", "z_near", "z_far"), &Camera::set_perspective);
 	ClassDB::bind_method(D_METHOD("set_orthogonal", "size", "z_near", "z_far"), &Camera::set_orthogonal);
 	ClassDB::bind_method(D_METHOD("set_frustum", "size", "offset", "z_near", "z_far"), &Camera::set_frustum);

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -142,7 +142,7 @@ public:
 	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const;
 	virtual Point2 unproject_position(const Vector3 &p_pos) const;
 	bool is_position_behind(const Vector3 &p_pos) const;
-	virtual Vector3 project_position(const Point2 &p_point, float p_z_depth = 0) const;
+	virtual Vector3 project_position(const Point2 &p_point, float p_z_depth) const;
 
 	Vector<Vector3> get_near_plane_points() const;
 


### PR DESCRIPTION
A z_depth of 0 returns the camera position, which is not really useful.
This also makes the API breakage from 3.1 clearer as 3.1 code will now
fail to compile, so users will have to adapt and use the new parameter.

For the reference, in 3.1, the z_depth was hardcoded to the near plane.

Closes #33493.