### PR TITLE
Color stacktraces printed by the crash handler when in a TTY

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -47,6 +47,7 @@
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <link.h>
+#include <unistd.h>
 #include <csignal>
 #include <cstdlib>
 
@@ -77,9 +78,13 @@ static void handle_crash(int sig) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
 	}
 
-	// Dump the backtrace to stderr with a message to the user
+	// Dump the backtrace to stderr with a message to the user.
 	print_error("\n================================================================");
-	print_error(vformat("%s: Program crashed with signal %d", __FUNCTION__, sig));
+	if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
+		print_error(vformat("\x1b[1;91m%s: Program crashed with signal %d.\x1b[0m", __FUNCTION__, sig));
+	} else {
+		print_error(vformat("%s: Program crashed with signal %d.", __FUNCTION__, sig));
+	}
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
 	if (String(GODOT_VERSION_HASH).is_empty()) {
@@ -138,8 +143,14 @@ static void handle_crash(int sig) {
 				}
 			}
 
-			// Simplify printed file paths to remove redundant `/./` sections (e.g. `/opt/godot/./core` -> `/opt/godot/core`).
-			print_error(vformat("[%d] %s (%s)", (int64_t)i, fname, err == OK ? addr2line_results[i].replace("/./", "/") : ""));
+			if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
+				// Print colors using ANSI escape codes for easier visual grepping.
+				// Simplify printed file paths to remove redundant `/./` sections (e.g. `/opt/godot/./core` -> `/opt/godot/core`).
+				print_error(vformat("\x1b[94m[%d] \x1b[96m%s \x1b[90m(%s)\x1b[0m", (int64_t)i, fname, err == OK ? addr2line_results[i].replace("/./", "/") : ""));
+			} else {
+				// Not a TTY (could be writing to a file). Don't use ANSI escape codes.
+				print_error(vformat("[%d] %s (%s)", (int64_t)i, fname, err == OK ? addr2line_results[i].replace("/./", "/") : ""));
+			}
 		}
 
 		free(strings);

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -201,10 +201,20 @@ static void handle_crash(int sig) {
 				// Simplify printed file paths to remove redundant `/./` sections (e.g. `/opt/godot/./core` -> `/opt/godot/core`).
 				if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
 					// Print colors using ANSI escape codes for easier visual grepping.
-					print_error(vformat("\x1b[94m[%d] \x1b[96m%x \x1b[90m(%s+%x) - %s\x1b[0m", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+					String color;
+					if (output.contains("::")) {
+						// Color function names and parameters.
+						output = output.replace(" at ", "\x1b[22;90m at ").replace("::", "\x1b[0m::\x1b[93m").replace("(", "\x1b[0m(");
+						// Godot function (green). This is generally what we're interested in, so highlight it.
+						color = "92";
+					} else {
+						// Not a Godot function (dark gray). Third-party library, or main process.
+						color = "90";
+					}
+					print_error(vformat("\x1b[94m%2d | \x1b[%sm%s - \x1b[22;90m%x (%s+%x)\x1b[0m", (int64_t)i, color, output, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off));
 				} else {
 					// Not a TTY (could be writing to a file). Don't use ANSI escape codes.
-					print_error(vformat("[%d] %x (%s+%x) - %s", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+					print_error(vformat("%2d | %s - %x (%s+%x)", (int64_t)i, output, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off));
 				}
 			}
 		} else {

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -48,6 +48,7 @@
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <link.h>
+#include <unistd.h>
 
 #include <csignal>
 #include <cstdio>
@@ -109,9 +110,13 @@ static void handle_crash(int sig) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
 	}
 
-	// Dump the backtrace to stderr with a message to the user
+	// Dump the backtrace to stderr with a message to the user.
 	print_error("\n================================================================");
-	print_error(vformat("%s: Program crashed with signal %d", __FUNCTION__, sig));
+	if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
+		print_error(vformat("\x1b[1;91m%s: Program crashed with signal %d.\x1b[0m", __FUNCTION__, sig));
+	} else {
+		print_error(vformat("%s: Program crashed with signal %d.", __FUNCTION__, sig));
+	}
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
 	if (String(GODOT_VERSION_HASH).is_empty()) {
@@ -194,7 +199,13 @@ static void handle_crash(int sig) {
 				}
 
 				// Simplify printed file paths to remove redundant `/./` sections (e.g. `/opt/godot/./core` -> `/opt/godot/core`).
-				print_error(vformat("[%d] %x (%s+%x) - %s", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+				if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
+					// Print colors using ANSI escape codes for easier visual grepping.
+					print_error(vformat("\x1b[94m[%d] \x1b[96m%x \x1b[90m(%s+%x) - %s\x1b[0m", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+				} else {
+					// Not a TTY (could be writing to a file). Don't use ANSI escape codes.
+					print_error(vformat("[%d] %x (%s+%x) - %s", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+				}
 			}
 		} else {
 			// Otherwise fall back to trace symbols.
@@ -226,7 +237,13 @@ static void handle_crash(int sig) {
 					mod_name = "<unknown module>";
 				}
 
-				print_error(vformat("[%d] %x (%s+%x) - %s", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+				if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
+					// Print colors using ANSI escape codes for easier visual grepping.
+					print_error(vformat("\x1b[94m[%d] \x1b[96m%x \x1b[90m(%s+%x) - %s\x1b[0m", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+				} else {
+					// Not a TTY (could be writing to a file). Don't use ANSI escape codes.
+					print_error(vformat("[%d] %x (%s+%x) - %s", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+				}
 			}
 		}
 

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -50,6 +50,7 @@
 #include <execinfo.h>
 #include <csignal>
 #include <cstdlib>
+#include <unistd>
 
 #import <mach-o/dyld.h>
 #import <mach-o/getsect.h>
@@ -100,7 +101,11 @@ static void handle_crash(int sig) {
 
 	// Dump the backtrace to stderr with a message to the user.
 	print_error("\n================================================================");
-	print_error(vformat("%s: Program crashed with signal %d", __FUNCTION__, sig));
+	if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
+		print_error(vformat("\x1b[1;91m%s: Program crashed with signal %d.\x1b[0m", __FUNCTION__, sig));
+	} else {
+		print_error(vformat("%s: Program crashed with signal %d.", __FUNCTION__, sig));
+	}
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
 	if (String(GODOT_VERSION_HASH).is_empty()) {
@@ -174,7 +179,13 @@ static void handle_crash(int sig) {
 				output = fname;
 			}
 
-			print_error(vformat("[%d] %s", (int64_t)i, output));
+			if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
+				// Print colors using ANSI escape codes for easier visual grepping.
+				print_error(vformat("\x1b[94m[%d] \x1b[96m%s\x1b[0m", uint64_t(i), output.utf8().ptr()));
+			} else {
+				// Not a TTY (could be writing to a file). Don't use ANSI escape codes.
+				print_error(vformat("[%d] %s", uint64_t(i), output.utf8().ptr()));
+			}
 		}
 
 		if (strings) {

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -82,7 +82,11 @@ static void handle_crash(int sig) {
 
 	// Dump the backtrace to stderr with a message to the user.
 	print_error("\n================================================================");
-	print_error(vformat("%s: Program crashed with signal %d", __FUNCTION__, sig));
+	if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
+		print_error(vformat("\x1b[1;91m%s: Program crashed with signal %d.\x1b[0m", __FUNCTION__, sig));
+	} else {
+		print_error(vformat("%s: Program crashed with signal %d.", __FUNCTION__, sig));
+	}
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
 	if (String(GODOT_VERSION_HASH).is_empty()) {
@@ -137,7 +141,13 @@ static void handle_crash(int sig) {
 				}
 			}
 
-			print_error(vformat("[%d] %x (%s+%x) - %s", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+			if (OS::get_singleton()->get_stderr_type() == OS::STD_HANDLE_CONSOLE) {
+				// Print colors using ANSI escape codes for easier visual grepping.
+				print_error(vformat("\x1b[94m[%d] \x1b[96m%x \x1b[90m(%s+%x) - %s\x1b[0m", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+			} else {
+				// Not a TTY (could be writing to a file). Don't use ANSI escape codes.
+				print_error(vformat("[%d] %x (%s+%x) - %s", (int64_t)i, (uint64_t)bt_buffer[i], mod_name, (uint64_t)bt_buffer[i] - mod_off, output));
+			}
 		}
 
 		if (strings) {

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -145,7 +145,7 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	}
 
 	print_error("\n================================================================");
-	print_error(vformat("%s: Program crashed", __FUNCTION__));
+	print_error(vformat("\x1b[1;91m%s: Program crashed.\x1b[0m", __FUNCTION__));
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
 	if (String(GODOT_VERSION_HASH).is_empty()) {
@@ -210,12 +210,12 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 				std::string fnName = symbol(process, frame.AddrPC.Offset).undecorated_name();
 
 				if (SymGetLineFromAddr64(process, frame.AddrPC.Offset, &offset_from_symbol, &line)) {
-					print_error(vformat("[%d] %s (%s:%d)", n, fnName.c_str(), (char *)line.FileName, (int)line.LineNumber));
+					print_error(vformat("\x1b[94m[%d] \x1b[96m%s \x1b[90m(%s:%d)\x1b[0m", n, fnName.c_str(), line.FileName, uint32_t(line.LineNumber)));
 				} else {
-					print_error(vformat("[%d] %s", n, fnName.c_str()));
+					print_error(vformat("\x1b[94m[%d] \x1b[96m%s\x1b[0m", n, fnName.c_str()));
 				}
 			} else {
-				print_error(vformat("[%d] ???", n));
+				print_error(vformat("\x1b[94m[%d] \x1b[96m???\x1b[0m", n));
 			}
 
 			n++;

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -142,7 +142,7 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	}
 
 	print_error("\n================================================================");
-	print_error(vformat("%s: Program crashed", __FUNCTION__));
+	print_error(vformat("\x1b[1;91m%s: Program crashed.\x1b[0m", __FUNCTION__));
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
 	if (String(GODOT_VERSION_HASH).is_empty()) {
@@ -226,11 +226,11 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 					}
 				}
 				if (SymGetLineFromAddr64(process, frame.AddrPC.Offset, &offset_from_symbol, &line)) {
-					print_error(vformat("[%d] %x (%s+%x) - %s (%s:%d)", n, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - offset, fnName.c_str(), (char *)line.FileName, (int)line.LineNumber));
+					print_error(vformat("\x1b[94m[%d] \x1b[96m%x \x1b[90m(%s+%x) - %s (%s:%d)\x1b[0m", n, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - offset, fnName.c_str(), (char *)line.FileName, (int)line.LineNumber));
 				} else if (!fnName.empty()) {
-					print_error(vformat("[%d] %x (%s+%x) - %s", n, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - offset, fnName.c_str()));
+					print_error(vformat("\x1b[94m[%d] \x1b[96m%x \x1b[90m(%s+%x) - %s\x1b[0m", n, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - offset, fnName.c_str()));
 				} else {
-					print_error(vformat("[%d] %x (%s+%x) - ???", n, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - offset));
+					print_error(vformat("\x1b[94m[%d] \x1b[96m%x \x1b[90m(%s+%x) - ???\x1b[0m", n, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - offset));
 				}
 			}
 

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -137,9 +137,9 @@ int symbol_callback(void *data, uintptr_t pc, const char *filename, int lineno, 
 				free(demangled);
 			}
 		}
-		print_error(vformat("[%d] %x (%s+%x) - %s (%s:%d)", ch_data->index++, ch_data->pc, mod_name, ch_data->pc - offset, String::utf8(fname), String::utf8(filename), lineno));
+		print_error(vformat("\x1b[96m[%d] \x1b[94m%x \x1b[90m(%s+%x) - %s (%s:%d)\x1b[0m", ch_data->index++, ch_data->pc, mod_name, ch_data->pc - offset, String::utf8(fname), String::utf8(filename), lineno));
 	} else if ((int64_t)ch_data->pc > 0) {
-		print_error(vformat("[%d] %x (%s+%x) - ???", ch_data->index++, ch_data->pc, mod_name, ch_data->pc - offset));
+		print_error(vformat("\x1b[96m[%d] \x1b[94m%x \x1b[90m(%s+%x) - ???\x1b[0m", ch_data->index++, ch_data->pc, mod_name, ch_data->pc - offset));
 	}
 	return 0;
 }
@@ -168,7 +168,7 @@ void error_callback(void *data, const char *msg, int errnum) {
 				}
 			}
 		}
-		print_error(vformat("[%d] %x (%s+%x) - %s", ch_data->index++, ch_data->pc, mod_name, ch_data->pc - offset, String::utf8(msg)));
+		print_error(vformat("\x1b[96m[%d] \x1b[94m%x \x1b[90m(%s+%x) - %s\x1b[0m", ch_data->index++, ch_data->pc, mod_name, ch_data->pc - offset, String::utf8(msg)));
 	}
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/44118.

This makes crash backtraces easier to read, which in turn improves the developer experience.

## Preview

### Windows 10 (MSVC)

![Windows 10 (MSVC)](https://user-images.githubusercontent.com/180032/189406525-9d330096-c21f-465b-b8b5-6c52c9863855.png)

### Linux

![Linux](https://user-images.githubusercontent.com/180032/189406534-0d59d362-6f3d-4488-aef0-0eaf6f7567cf.png)

PS: For testing purposes, you can call `CRASH_NOW();` anywhere to make Godot crash.