### PR TITLE
Keep focus on the top-most node for multi-selection in scene tree

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -71,6 +71,7 @@
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
 #include "editor/import/resource_importer_wav.h"
+#include "editor/multi_node_edit.h"
 #include "editor/plugins/animation_blend_space_1d_editor.h"
 #include "editor/plugins/animation_blend_space_2d_editor.h"
 #include "editor/plugins/animation_blend_tree_editor_plugin.h"
@@ -1742,15 +1743,37 @@ void EditorNode::_edit_current() {
 
 	} else {
 
+		Node *selected_node = NULL;
+
 		if (current_obj->is_class("ScriptEditorDebuggerInspectedObject")) {
 			editable_warning = TTR("This is a remote object, so changes to it won't be kept.\nPlease read the documentation relevant to debugging to better understand this workflow.");
 			capitalize = false;
 			disable_folding = true;
+		} else if (current_obj->is_class("MultiNodeEdit")) {
+			Node *scene = get_edited_scene();
+			if (scene) {
+				MultiNodeEdit *multi_node_edit = Object::cast_to<MultiNodeEdit>(current_obj);
+				int node_count = multi_node_edit->get_node_count();
+				if (node_count > 0) {
+					List<Node *> multi_nodes;
+					for (int node_index = 0; node_index < node_count; ++node_index) {
+						Node *node = scene->get_node(multi_node_edit->get_node(node_index));
+						if (node) {
+							multi_nodes.push_back(node);
+						}
+					}
+					if (!multi_nodes.empty()) {
+						// Pick the top-most node
+						multi_nodes.sort_custom<Node::Comparator>();
+						selected_node = multi_nodes.front()->get();
+					}
+				}
+			}
 		}
 
 		get_inspector()->edit(current_obj);
 		node_dock->set_node(NULL);
-		scene_tree_dock->set_selected(NULL);
+		scene_tree_dock->set_selected(selected_node);
 		inspector_dock->update(NULL);
 	}
 

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -34,12 +34,10 @@
 #include "editor_node.h"
 
 bool MultiNodeEdit::_set(const StringName &p_name, const Variant &p_value) {
-
 	return _set_impl(p_name, p_value, "");
 }
 
 bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, const String &p_field) {
-
 	Node *es = EditorNode::get_singleton()->get_edited_scene();
 	if (!es)
 		return false;
@@ -88,7 +86,6 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 }
 
 bool MultiNodeEdit::_get(const StringName &p_name, Variant &r_ret) const {
-
 	Node *es = EditorNode::get_singleton()->get_edited_scene();
 	if (!es)
 		return false;
@@ -117,7 +114,6 @@ bool MultiNodeEdit::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
-
 	HashMap<String, PLData> usage;
 
 	Node *es = EditorNode::get_singleton()->get_edited_scene();
@@ -171,17 +167,23 @@ void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 }
 
 void MultiNodeEdit::clear_nodes() {
-
 	nodes.clear();
 }
 
 void MultiNodeEdit::add_node(const NodePath &p_node) {
-
 	nodes.push_back(p_node);
 }
 
-void MultiNodeEdit::set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field) {
+int MultiNodeEdit::get_node_count() const {
+	return nodes.size();
+}
 
+NodePath MultiNodeEdit::get_node(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, nodes.size(), NodePath());
+	return nodes[p_index];
+}
+
+void MultiNodeEdit::set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field) {
 	_set_impl(p_property, p_value, p_field);
 }
 

--- a/editor/multi_node_edit.h
+++ b/editor/multi_node_edit.h
@@ -54,6 +54,9 @@ public:
 	void clear_nodes();
 	void add_node(const NodePath &p_node);
 
+	int get_node_count() const;
+	NodePath get_node(int p_index) const;
+
 	void set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field);
 
 	MultiNodeEdit();


### PR DESCRIPTION
Makes behavior consistent with selecting/deselecting single nodes and fixes a regression about the focused node being lost when multi-selecting.

<img src="https://user-images.githubusercontent.com/1075032/68541296-dcf4c900-039d-11ea-936f-22cfec58201d.gif" width="200" />

Fixes #33332