### PR TITLE
Handle missing file properly when checking for case mismatch

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -96,7 +96,7 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 	if (p_mode_flags == READ) {
 		WIN32_FIND_DATAW d;
 		HANDLE f = FindFirstFileW(path.c_str(), &d);
-		if (f) {
+		if (f != INVALID_HANDLE_VALUE) {
 			String fname = d.cFileName;
 			if (fname != String()) {
 


### PR DESCRIPTION
This was causing false alarms to be randomly reported on Windows for files that didn't exist.