### PR TITLE
Memory leaks and crash fixes

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -207,6 +207,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 			f->store_line(itos(has_small_texture));
 			f->store_line(itos(FileAccess::get_modified_time(p_item.path)));
 			f->store_line(FileAccess::get_md5(p_item.path));
+			f->close();
 			memdelete(f);
 		}
 	}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5215,6 +5215,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	snap_other_nodes = true;
 	snap_guides = true;
 	snap_rotation = false;
+	snap_scale = false;
 	snap_relative = false;
 	snap_pixel = false;
 	snap_target[0] = SNAP_TARGET_NONE;

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -103,9 +103,11 @@ Ref<Texture> EditorTexturePreviewPlugin::generate(const RES &p_from, const Size2
 		img = ltex->to_image();
 	} else {
 		Ref<Texture> tex = p_from;
-		img = tex->get_data();
-		if (img.is_valid()) {
-			img = img->duplicate();
+		if (tex.is_valid()) {
+			img = tex->get_data();
+			if (img.is_valid()) {
+				img = img->duplicate();
+			}
 		}
 	}
 

--- a/modules/etc/texture_loader_pkm.cpp
+++ b/modules/etc/texture_loader_pkm.cpp
@@ -91,6 +91,8 @@ RES ResourceFormatPKM::load(const String &p_path, const String &p_original_path,
 	if (r_error)
 		*r_error = OK;
 
+	f->close();
+	memdelete(f);
 	return texture;
 }
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -741,6 +741,8 @@ RES ResourceFormatLoaderTheora::load(const String &p_path, const String &p_origi
 		*r_error = OK;
 	}
 
+	f->close();
+	memdelete(f);
 	return ogv_stream;
 }
 

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -484,6 +484,8 @@ RES ResourceFormatLoaderWebm::load(const String &p_path, const String &p_origina
 		*r_error = OK;
 	}
 
+	f->close();
+	memdelete(f);
 	return webm_stream;
 }
 

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -213,6 +213,7 @@ void Range::unshare() {
 	nshared->val = shared->val;
 	nshared->step = shared->step;
 	nshared->page = shared->page;
+	nshared->exp_ratio = shared->exp_ratio;
 	nshared->allow_greater = shared->allow_greater;
 	nshared->allow_lesser = shared->allow_lesser;
 	_unref_shared();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4050,6 +4050,7 @@ Tree::Tree() {
 	drop_mode_section = 0;
 	single_select_defer = NULL;
 
+	scrolling = false;
 	allow_rmb_select = false;
 	force_edit_checkbox_only_on_checkbox = false;
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2369,16 +2369,20 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 
 	if (header[0] == 'G' && header[1] == 'D' && header[2] == '3' && header[3] == 'T') {
 		if (tex3d.is_null()) {
+			f->close();
 			memdelete(f);
 			ERR_FAIL_COND_V(tex3d.is_null(), RES())
 		}
 	} else if (header[0] == 'G' && header[1] == 'D' && header[2] == 'A' && header[3] == 'T') {
 		if (texarr.is_null()) {
+			f->close();
 			memdelete(f);
 			ERR_FAIL_COND_V(texarr.is_null(), RES())
 		}
 	} else {
 
+		f->close();
+		memdelete(f);
 		ERR_FAIL_V_MSG(RES(), "Unrecognized layered texture file format '" + String((const char *)header) + "'.");
 	}
 
@@ -2418,6 +2422,7 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 					if (r_error) {
 						*r_error = ERR_FILE_CORRUPT;
 					}
+					f->close();
 					memdelete(f);
 					ERR_FAIL_V(RES());
 				}
@@ -2453,6 +2458,7 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 					if (r_error) {
 						*r_error = ERR_FILE_CORRUPT;
 					}
+					f->close();
 					memdelete(f);
 					ERR_FAIL_V(RES());
 				}
@@ -2473,8 +2479,9 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 				if (bytes != total_size) {
 					if (r_error) {
 						*r_error = ERR_FILE_CORRUPT;
-						memdelete(f);
 					}
+					f->close();
+					memdelete(f);
 					ERR_FAIL_V(RES());
 				}
 			}

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -297,4 +297,5 @@ void AudioEffectRecord::_bind_methods() {
 
 AudioEffectRecord::AudioEffectRecord() {
 	format = AudioStreamSample::FORMAT_16_BITS;
+	recording_active = false;
 }


### PR DESCRIPTION
Fixes #33454

Also added value to 4 variables, which sanitizer shows that are used without initialization.

Also fixes some leaks when importing  resources/images like:
```
    #0 0x7f3037150ae8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dae8)
    #1 0x70ffd21 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:85
    #2 0x70ffc38 in operator new(unsigned long, char const*) core/os/memory.cpp:42
    #3 0x2eab0c6 in FileAccess* FileAccess::_create_builtin<FileAccessUnix>() core/os/file_access.h:77
    #4 0x7091608 in FileAccess::create(FileAccess::AccessType) core/os/file_access.cpp:49
    #5 0x709178c in FileAccess::create_for_path(String const&) core/os/file_access.cpp:76
    #6 0x709191f in FileAccess::open(String const&, int, Error*) core/os/file_access.cpp:108
    #7 0x1c82f74 in ResourceFormatLoaderWebm::load(String const&, String const&, Error*) modules/webm/video_stream_webm.cpp:470
    #8 0x731d038 in ResourceLoader::_load(String const&, String const&, String const&, bool, Error*) core/io/resource_loader.cpp:270
    #9 0x731ebf9 in ResourceLoader::load(String const&, String const&, bool, Error*) core/io/resource_loader.cpp:396
    #10 0x5e94da0 in ResourceInteractiveLoaderText::poll() scene/resources/resource_format_text.cpp:433
    #11 0x7318dde in ResourceFormatLoader::load(String const&, String const&, Error*) core/io/resource_loader.cpp:197
    #12 0x731d038 in ResourceLoader::_load(String const&, String const&, String const&, bool, Error*) core/io/resource_loader.cpp:270
    #13 0x731ebf9 in ResourceLoader::load(String const&, String const&, bool, Error*) core/io/resource_loader.cpp:396
    #14 0x342956a in EditorNode::load_scene(String const&, bool, bool, bool, bool) editor/editor_node.cpp:3252
    #15 0x343f080 in EditorNode::_load_open_scenes_from_config(Ref<ConfigFile>, String const&) editor/editor_node.cpp:4369
    #16 0x343b3f5 in EditorNode::_load_docks() editor/editor_node.cpp:4164
    #17 0x33f0f1b in EditorNode::_sources_changed(bool) editor/editor_node.cpp:603
    #18 0x18d171a in MethodBind1<bool>::call(Object*, Variant const**, int, Variant::CallError&) core/method_bind.gen.inc:775
    #19 0x6e0b795 in Object::call(StringName const&, Variant const**, int, Variant::CallError&) core/object.cpp:921
    #20 0x6e10468 in Object::emit_signal(StringName const&, Variant const**, int) core/object.cpp:1218
    #21 0x6e1150a in Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) core/object.cpp:1274
    #22 0x3300fd0 in EditorFileSystem::_notification(int) editor/editor_file_system.cpp:1146
    #23 0x331fbdb in EditorFileSystem::_notificationv(int, bool) editor/editor_file_system.h:108
    #24 0x6e0ba8f in Object::notification(int, bool) core/object.cpp:931
    #25 0x4aea490 in SceneTree::_notify_group_pause(StringName const&, int) scene/main/scene_tree.cpp:981
    #26 0x4ae5268 in SceneTree::idle(float) scene/main/scene_tree.cpp:527
    #27 0x14a2697 in Main::iteration() main/main.cpp:1980
    #28 0x1425e1b in OS_X11::run() platform/x11/os_x11.cpp:3259
    #29 0x13f7f65 in main platform/x11/godot_x11.cpp:56
```