### PR TITLE
Send *_MSG macros' explanations directly to the _err_print_error().

### DIFF
--- a/core/error_macros.cpp
+++ b/core/error_macros.cpp
@@ -34,24 +34,7 @@
 #include "core/ustring.h"
 #include "os/os.h"
 
-bool _err_error_exists = false;
-
 static ErrorHandlerList *error_handler_list = NULL;
-
-void _err_set_last_error(const char *p_err) {
-
-	OS::get_singleton()->set_last_error(p_err);
-}
-
-void _err_set_last_error(const String &p_err) {
-
-	_err_set_last_error(p_err.utf8().get_data());
-}
-
-void _err_clear_last_error() {
-
-	OS::get_singleton()->clear_last_error();
-}
 
 void add_error_handler(ErrorHandlerList *p_handler) {
 
@@ -86,27 +69,11 @@ void remove_error_handler(ErrorHandlerList *p_handler) {
 }
 
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, ErrorHandlerType p_type) {
-
-	OS::get_singleton()->print_error(p_function, p_file, p_line, p_error, _err_error_exists ? OS::get_singleton()->get_last_error() : "", (Logger::ErrorType)p_type);
-
-	_global_lock();
-	ErrorHandlerList *l = error_handler_list;
-	while (l) {
-
-		l->errfunc(l->userdata, p_function, p_file, p_line, p_error, _err_error_exists ? OS::get_singleton()->get_last_error() : "", p_type);
-		l = l->next;
-	}
-
-	_global_unlock();
-
-	if (_err_error_exists) {
-		OS::get_singleton()->clear_last_error();
-		_err_error_exists = false;
-	}
+	_err_print_error(p_function, p_file, p_line, p_error, "", p_type);
 }
 
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, ErrorHandlerType p_type) {
-	_err_print_error(p_function, p_file, p_line, p_error.utf8().get_data(), p_type);
+	_err_print_error(p_function, p_file, p_line, p_error.utf8().get_data(), "", p_type);
 }
 
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, ErrorHandlerType p_type) {

--- a/core/error_macros.cpp
+++ b/core/error_macros.cpp
@@ -109,9 +109,40 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 	_err_print_error(p_function, p_file, p_line, p_error.utf8().get_data(), p_type);
 }
 
-void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, bool fatal) {
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, ErrorHandlerType p_type) {
+
+	OS::get_singleton()->print_error(p_function, p_file, p_line, p_error, p_message, (Logger::ErrorType)p_type);
+
+	_global_lock();
+	ErrorHandlerList *l = error_handler_list;
+	while (l) {
+
+		l->errfunc(l->userdata, p_function, p_file, p_line, p_error, p_message, p_type);
+		l = l->next;
+	}
+
+	_global_unlock();
+}
+
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const char *p_message, ErrorHandlerType p_type) {
+	_err_print_error(p_function, p_file, p_line, p_error.utf8().get_data(), p_message, p_type);
+}
+
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const String &p_message, ErrorHandlerType p_type) {
+	_err_print_error(p_function, p_file, p_line, p_error, p_message.utf8().get_data(), p_type);
+}
+
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, ErrorHandlerType p_type) {
+	_err_print_error(p_function, p_file, p_line, p_error.utf8().get_data(), p_message.utf8().get_data(), p_type);
+}
+
+void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message, bool fatal) {
 
 	String fstr(fatal ? "FATAL: " : "");
 	String err(fstr + "Index " + p_index_str + "=" + itos(p_index) + " out of size (" + p_size_str + "=" + itos(p_size) + ")");
-	_err_print_error(p_function, p_file, p_line, err.utf8().get_data());
+	_err_print_error(p_function, p_file, p_line, err.utf8().get_data(), p_message);
+}
+
+void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool fatal) {
+	_err_print_index_error(p_function, p_file, p_line, p_index, p_size, p_index_str, p_size_str, p_message.utf8().get_data(), fatal);
 }

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -57,9 +57,6 @@ enum ErrorHandlerType {
 
 class String;
 typedef void (*ErrorHandlerFunc)(void *, const char *, const char *, int p_line, const char *, const char *, ErrorHandlerType p_type);
-void _err_set_last_error(const char *p_err);
-void _err_set_last_error(const String &p_err);
-void _err_clear_last_error();
 
 struct ErrorHandlerList {
 
@@ -96,29 +93,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 
 /** An index has failed if m_index<0 or m_index >=m_size, the function exits */
 
-extern bool _err_error_exists;
-
-#ifdef DEBUG_ENABLED
-/** Print a warning string.
- */
-#define ERR_EXPLAINC(m_reason)         \
-	{                                  \
-		_err_set_last_error(m_reason); \
-		_err_error_exists = true;      \
-	}
-#define ERR_EXPLAIN(m_string)          \
-	{                                  \
-		_err_set_last_error(m_string); \
-		_err_error_exists = true;      \
-	}
-
-#else
-
-#define ERR_EXPLAIN(m_text)
-#define ERR_EXPLAINC(m_text)
-
-#endif
-
 #ifdef __GNUC__
 //#define FUNCTION_STR __PRETTY_FUNCTION__ - too annoying
 #define FUNCTION_STR __FUNCTION__
@@ -145,7 +119,6 @@ extern bool _err_error_exists;
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return;                                                                                                 \
 		}                                                                                                           \
-		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
 #define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                         \
@@ -154,7 +127,6 @@ extern bool _err_error_exists;
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
 			return;                                                                                                        \
 		}                                                                                                                  \
-		_err_error_exists = false;                                                                                         \
 	} while (0); // (*)
 
 /** An index has failed if m_index<0 or m_index >=m_size, the function exits.
@@ -168,7 +140,6 @@ extern bool _err_error_exists;
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return m_retval;                                                                                        \
 		}                                                                                                           \
-		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
 #define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                             \
@@ -177,7 +148,6 @@ extern bool _err_error_exists;
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
 			return m_retval;                                                                                               \
 		}                                                                                                                  \
-		_err_error_exists = false;                                                                                         \
 	} while (0); // (*)
 
 /** An index has failed if m_index >=m_size, the function exits.
@@ -191,7 +161,6 @@ extern bool _err_error_exists;
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 			return m_retval;                                                                                        \
 		}                                                                                                           \
-		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
 #define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                    \
@@ -200,7 +169,6 @@ extern bool _err_error_exists;
 			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
 			return m_retval;                                                                                               \
 		}                                                                                                                  \
-		_err_error_exists = false;                                                                                         \
 	} while (0); // (*)
 
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
@@ -232,7 +200,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null."); \
 			return;                                                                                         \
 		}                                                                                                   \
-		_err_error_exists = false;                                                                          \
 	}
 
 #define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                          \
@@ -241,7 +208,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null.", m_msg); \
 			return;                                                                                                \
 		}                                                                                                          \
-		_err_error_exists = false;                                                                                 \
 	}
 
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                                  \
@@ -250,7 +216,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null."); \
 			return m_retval;                                                                                \
 		}                                                                                                   \
-		_err_error_exists = false;                                                                          \
 	}
 
 #define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                              \
@@ -259,7 +224,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null.", m_msg); \
 			return m_retval;                                                                                       \
 		}                                                                                                          \
-		_err_error_exists = false;                                                                                 \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -272,7 +236,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true."); \
 			return;                                                                                        \
 		}                                                                                                  \
-		_err_error_exists = false;                                                                         \
 	}
 
 #define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                          \
@@ -281,7 +244,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true.", m_msg); \
 			return;                                                                                               \
 		}                                                                                                         \
-		_err_error_exists = false;                                                                                \
 	}
 
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
@@ -315,7 +277,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. returned: " _STR(m_retval)); \
 			return m_retval;                                                                                                         \
 		}                                                                                                                            \
-		_err_error_exists = false;                                                                                                   \
 	}
 
 #define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                        \
@@ -324,7 +285,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. returned: " _STR(m_retval), m_msg); \
 			return m_retval;                                                                                                                \
 		}                                                                                                                                   \
-		_err_error_exists = false;                                                                                                          \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -337,7 +297,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Continuing..:"); \
 			continue;                                                                                                    \
 		}                                                                                                                \
-		_err_error_exists = false;                                                                                       \
 	}
 
 #define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                         \
@@ -346,7 +305,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Continuing..:", m_msg); \
 			continue;                                                                                                           \
 		}                                                                                                                       \
-		_err_error_exists = false;                                                                                              \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -359,7 +317,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:"); \
 			break;                                                                                                     \
 		}                                                                                                              \
-		_err_error_exists = false;                                                                                     \
 	}
 
 #define ERR_BREAK_MSG(m_cond, m_msg)                                                                                          \
@@ -368,7 +325,6 @@ extern bool _err_error_exists;
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:", m_msg); \
 			break;                                                                                                            \
 		}                                                                                                                     \
-		_err_error_exists = false;                                                                                            \
 	}
 
 /** Print an error string and return
@@ -377,14 +333,12 @@ extern bool _err_error_exists;
 #define ERR_FAIL()                                                                     \
 	{                                                                                  \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed."); \
-		_err_error_exists = false;                                                     \
 		return;                                                                        \
 	}
 
 #define ERR_FAIL_MSG(m_msg)                                                                   \
 	{                                                                                         \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed.", m_msg); \
-		_err_error_exists = false;                                                            \
 		return;                                                                               \
 	}
 
@@ -394,14 +348,12 @@ extern bool _err_error_exists;
 #define ERR_FAIL_V(m_value)                                                                                       \
 	{                                                                                                             \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed, returning: " __STR(m_value)); \
-		_err_error_exists = false;                                                                                \
 		return m_value;                                                                                           \
 	}
 
 #define ERR_FAIL_V_MSG(m_value, m_msg)                                                                                   \
 	{                                                                                                                    \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed, returning: " __STR(m_value), m_msg); \
-		_err_error_exists = false;                                                                                       \
 		return m_value;                                                                                                  \
 	}
 
@@ -426,13 +378,11 @@ extern bool _err_error_exists;
 #define ERR_PRINT(m_string)                                           \
 	{                                                                 \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string); \
-		_err_error_exists = false;                                    \
 	}
 
 #define ERR_PRINTS(m_string)                                          \
 	{                                                                 \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string); \
-		_err_error_exists = false;                                    \
 	}
 
 #define ERR_PRINT_ONCE(m_string)                                          \
@@ -440,7 +390,6 @@ extern bool _err_error_exists;
 		static bool first_print = true;                                   \
 		if (first_print) {                                                \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string); \
-			_err_error_exists = false;                                    \
 			first_print = false;                                          \
 		}                                                                 \
 	}
@@ -451,13 +400,11 @@ extern bool _err_error_exists;
 #define WARN_PRINT(m_string)                                                               \
 	{                                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string, ERR_HANDLER_WARNING); \
-		_err_error_exists = false;                                                         \
 	}
 
 #define WARN_PRINTS(m_string)                                                              \
 	{                                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string, ERR_HANDLER_WARNING); \
-		_err_error_exists = false;                                                         \
 	}
 
 #define WARN_PRINT_ONCE(m_string)                                                              \
@@ -465,7 +412,6 @@ extern bool _err_error_exists;
 		static bool first_print = true;                                                        \
 		if (first_print) {                                                                     \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string, ERR_HANDLER_WARNING); \
-			_err_error_exists = false;                                                         \
 			first_print = false;                                                               \
 		}                                                                                      \
 	}
@@ -475,7 +421,6 @@ extern bool _err_error_exists;
 		static volatile bool warning_shown = false;                                                                                                       \
 		if (!warning_shown) {                                                                                                                             \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future", ERR_HANDLER_WARNING); \
-			_err_error_exists = false;                                                                                                                    \
 			warning_shown = true;                                                                                                                         \
 		}                                                                                                                                                 \
 	}
@@ -485,7 +430,6 @@ extern bool _err_error_exists;
 		static volatile bool warning_shown = false;                                                                                                              \
 		if (!warning_shown) {                                                                                                                                    \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future", m_msg, ERR_HANDLER_WARNING); \
-			_err_error_exists = false;                                                                                                                           \
 			warning_shown = true;                                                                                                                                \
 		}                                                                                                                                                        \
 	}

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -80,7 +80,12 @@ void remove_error_handler(ErrorHandlerList *p_handler);
 
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
-void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, bool fatal = false);
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const char *p_message, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const String &p_message, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
+void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool fatal = false);
+void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool fatal = false);
 
 #ifndef _STR
 #define _STR(m_x) #m_x
@@ -143,14 +148,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                  \
-	do {                                                                                                            \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-			ERR_EXPLAIN(m_msg);                                                                                     \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return;                                                                                                 \
-		}                                                                                                           \
-		_err_error_exists = false;                                                                                  \
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                         \
+	do {                                                                                                                   \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+			return;                                                                                                        \
+		}                                                                                                                  \
+		_err_error_exists = false;                                                                                         \
 	} while (0); // (*)
 
 /** An index has failed if m_index<0 or m_index >=m_size, the function exits.
@@ -167,14 +171,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                      \
-	do {                                                                                                            \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-			ERR_EXPLAIN(m_msg);                                                                                     \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return m_retval;                                                                                        \
-		}                                                                                                           \
-		_err_error_exists = false;                                                                                  \
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                             \
+	do {                                                                                                                   \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+			return m_retval;                                                                                               \
+		}                                                                                                                  \
+		_err_error_exists = false;                                                                                         \
 	} while (0); // (*)
 
 /** An index has failed if m_index >=m_size, the function exits.
@@ -191,34 +194,32 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                  \
 	} while (0); // (*)
 
-#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                             \
-	do {                                                                                                            \
-		if (unlikely((m_index) >= (m_size))) {                                                                      \
-			ERR_EXPLAIN(m_msg);                                                                                     \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return m_retval;                                                                                        \
-		}                                                                                                           \
-		_err_error_exists = false;                                                                                  \
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                    \
+	do {                                                                                                                   \
+		if (unlikely((m_index) >= (m_size))) {                                                                             \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+			return m_retval;                                                                                               \
+		}                                                                                                                  \
+		_err_error_exists = false;                                                                                         \
 	} while (0); // (*)
 
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
 *   We'll return a null reference and try to keep running.
 */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                  \
-	do {                                                                                                                  \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                           \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), true); \
-			GENERATE_TRAP                                                                                                 \
-		}                                                                                                                 \
+#define CRASH_BAD_INDEX(m_index, m_size)                                                                                      \
+	do {                                                                                                                      \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                               \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
+			GENERATE_TRAP                                                                                                     \
+		}                                                                                                                     \
 	} while (0); // (*)
 
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                       \
-	do {                                                                                                                  \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                           \
-			ERR_EXPLAIN(m_msg);                                                                                           \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), true); \
-			GENERATE_TRAP                                                                                                 \
-		}                                                                                                                 \
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                              \
+	do {                                                                                                                         \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+			GENERATE_TRAP                                                                                                        \
+		}                                                                                                                        \
 	} while (0); // (*)
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -234,14 +235,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                          \
 	}
 
-#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                   \
-	{                                                                                                       \
-		if (unlikely(!m_param)) {                                                                           \
-			ERR_EXPLAIN(m_msg);                                                                             \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null."); \
-			return;                                                                                         \
-		}                                                                                                   \
-		_err_error_exists = false;                                                                          \
+#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                          \
+	{                                                                                                              \
+		if (unlikely(!m_param)) {                                                                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null.", m_msg); \
+			return;                                                                                                \
+		}                                                                                                          \
+		_err_error_exists = false;                                                                                 \
 	}
 
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                                  \
@@ -253,14 +253,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                          \
 	}
 
-#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                       \
-	{                                                                                                       \
-		if (unlikely(!m_param)) {                                                                           \
-			ERR_EXPLAIN(m_msg);                                                                             \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null."); \
-			return m_retval;                                                                                \
-		}                                                                                                   \
-		_err_error_exists = false;                                                                          \
+#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                              \
+	{                                                                                                              \
+		if (unlikely(!m_param)) {                                                                                  \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter ' " _STR(m_param) " ' is null.", m_msg); \
+			return m_retval;                                                                                       \
+		}                                                                                                          \
+		_err_error_exists = false;                                                                                 \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -276,14 +275,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                         \
 	}
 
-#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                   \
-	{                                                                                                      \
-		if (unlikely(m_cond)) {                                                                            \
-			ERR_EXPLAIN(m_msg);                                                                            \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true."); \
-			return;                                                                                        \
-		}                                                                                                  \
-		_err_error_exists = false;                                                                         \
+#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                          \
+	{                                                                                                             \
+		if (unlikely(m_cond)) {                                                                                   \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true.", m_msg); \
+			return;                                                                                               \
+		}                                                                                                         \
+		_err_error_exists = false;                                                                                \
 	}
 
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
@@ -297,13 +295,12 @@ extern bool _err_error_exists;
 		}                                                                                                         \
 	}
 
-#define CRASH_COND_MSG(m_cond, m_msg)                                                                             \
-	{                                                                                                             \
-		if (unlikely(m_cond)) {                                                                                   \
-			ERR_EXPLAIN(m_msg);                                                                                   \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition ' " _STR(m_cond) " ' is true."); \
-			GENERATE_TRAP                                                                                         \
-		}                                                                                                         \
+#define CRASH_COND_MSG(m_cond, m_msg)                                                                                    \
+	{                                                                                                                    \
+		if (unlikely(m_cond)) {                                                                                          \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition ' " _STR(m_cond) " ' is true.", m_msg); \
+			GENERATE_TRAP                                                                                                \
+		}                                                                                                                \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -321,14 +318,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                                   \
 	}
 
-#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                 \
-	{                                                                                                                                \
-		if (unlikely(m_cond)) {                                                                                                      \
-			ERR_EXPLAIN(m_msg);                                                                                                      \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. returned: " _STR(m_retval)); \
-			return m_retval;                                                                                                         \
-		}                                                                                                                            \
-		_err_error_exists = false;                                                                                                   \
+#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                        \
+	{                                                                                                                                       \
+		if (unlikely(m_cond)) {                                                                                                             \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. returned: " _STR(m_retval), m_msg); \
+			return m_retval;                                                                                                                \
+		}                                                                                                                                   \
+		_err_error_exists = false;                                                                                                          \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -344,14 +340,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                       \
 	}
 
-#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                  \
-	{                                                                                                                    \
-		if (unlikely(m_cond)) {                                                                                          \
-			ERR_EXPLAIN(m_msg);                                                                                          \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Continuing..:"); \
-			continue;                                                                                                    \
-		}                                                                                                                \
-		_err_error_exists = false;                                                                                       \
+#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                         \
+	{                                                                                                                           \
+		if (unlikely(m_cond)) {                                                                                                 \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Continuing..:", m_msg); \
+			continue;                                                                                                           \
+		}                                                                                                                       \
+		_err_error_exists = false;                                                                                              \
 	}
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().
@@ -367,14 +362,13 @@ extern bool _err_error_exists;
 		_err_error_exists = false;                                                                                     \
 	}
 
-#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                   \
-	{                                                                                                                  \
-		if (unlikely(m_cond)) {                                                                                        \
-			ERR_EXPLAIN(m_msg);                                                                                        \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:"); \
-			break;                                                                                                     \
-		}                                                                                                              \
-		_err_error_exists = false;                                                                                     \
+#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                          \
+	{                                                                                                                         \
+		if (unlikely(m_cond)) {                                                                                               \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:", m_msg); \
+			break;                                                                                                            \
+		}                                                                                                                     \
+		_err_error_exists = false;                                                                                            \
 	}
 
 /** Print an error string and return
@@ -387,10 +381,11 @@ extern bool _err_error_exists;
 		return;                                                                        \
 	}
 
-#define ERR_FAIL_MSG(m_msg) \
-	{                       \
-		ERR_EXPLAIN(m_msg); \
-		ERR_FAIL();         \
+#define ERR_FAIL_MSG(m_msg)                                                                   \
+	{                                                                                         \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed.", m_msg); \
+		_err_error_exists = false;                                                            \
+		return;                                                                               \
 	}
 
 /** Print an error string and return with value
@@ -403,10 +398,11 @@ extern bool _err_error_exists;
 		return m_value;                                                                                           \
 	}
 
-#define ERR_FAIL_V_MSG(m_value, m_msg) \
-	{                                  \
-		ERR_EXPLAIN(m_msg);            \
-		ERR_FAIL_V(m_value);           \
+#define ERR_FAIL_V_MSG(m_value, m_msg)                                                                                   \
+	{                                                                                                                    \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/Function Failed, returning: " __STR(m_value), m_msg); \
+		_err_error_exists = false;                                                                                       \
+		return m_value;                                                                                                  \
 	}
 
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
@@ -418,10 +414,10 @@ extern bool _err_error_exists;
 		GENERATE_TRAP                                                                         \
 	}
 
-#define CRASH_NOW_MSG(m_msg) \
-	{                        \
-		ERR_EXPLAIN(m_msg);  \
-		CRASH_NOW();         \
+#define CRASH_NOW_MSG(m_msg)                                                                         \
+	{                                                                                                \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/Function Failed.", m_msg); \
+		GENERATE_TRAP                                                                                \
 	}
 
 /** Print an error string.
@@ -484,15 +480,14 @@ extern bool _err_error_exists;
 		}                                                                                                                                                 \
 	}
 
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                        \
-	{                                                                                                                                                     \
-		static volatile bool warning_shown = false;                                                                                                       \
-		if (!warning_shown) {                                                                                                                             \
-			ERR_EXPLAIN(m_msg);                                                                                                                           \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future", ERR_HANDLER_WARNING); \
-			_err_error_exists = false;                                                                                                                    \
-			warning_shown = true;                                                                                                                         \
-		}                                                                                                                                                 \
+#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                               \
+	{                                                                                                                                                            \
+		static volatile bool warning_shown = false;                                                                                                              \
+		if (!warning_shown) {                                                                                                                                    \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future", m_msg, ERR_HANDLER_WARNING); \
+			_err_error_exists = false;                                                                                                                           \
+			warning_shown = true;                                                                                                                                \
+		}                                                                                                                                                        \
 	}
 
 #endif

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -50,20 +50,17 @@ void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)) {
 #ifdef _MSC_VER
 void operator delete(void *p_mem, const char *p_description) {
 
-	ERR_EXPLAINC("Call to placement delete should not happen.");
-	CRASH_NOW();
+	CRASH_NOW_MSG("Call to placement delete should not happen.");
 }
 
 void operator delete(void *p_mem, void *(*p_allocfunc)(size_t p_size)) {
 
-	ERR_EXPLAINC("Call to placement delete should not happen.");
-	CRASH_NOW();
+	CRASH_NOW_MSG("Call to placement delete should not happen.");
 }
 
 void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_description) {
 
-	ERR_EXPLAINC("Call to placement delete should not happen.");
-	CRASH_NOW();
+	CRASH_NOW_MSG("Call to placement delete should not happen.");
 }
 #endif
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -196,29 +196,6 @@ bool OS::is_stdout_verbose() const {
 	return _verbose_stdout;
 }
 
-void OS::set_last_error(const char *p_error) {
-
-	GLOBAL_LOCK_FUNCTION
-	if (p_error == NULL)
-		p_error = "Unknown Error";
-
-	if (last_error)
-		memfree(last_error);
-	last_error = NULL;
-	int len = 0;
-	while (p_error[len++])
-		;
-
-	last_error = (char *)memalloc(len);
-	for (int i = 0; i < len; i++)
-		last_error[i] = p_error[i];
-}
-
-const char *OS::get_last_error() const {
-	GLOBAL_LOCK_FUNCTION
-	return last_error ? last_error : "";
-}
-
 void OS::dump_memory_to_file(const char *p_file) {
 
 	//Memory::dump_static_mem_to_file(p_file);
@@ -295,14 +272,6 @@ void OS::print_resources_in_use(bool p_short) {
 void OS::dump_resources_to_file(const char *p_file) {
 
 	ResourceCache::dump(p_file);
-}
-
-void OS::clear_last_error() {
-
-	GLOBAL_LOCK_FUNCTION
-	if (last_error)
-		memfree(last_error);
-	last_error = NULL;
 }
 
 void OS::set_no_window_mode(bool p_enable) {
@@ -764,7 +733,6 @@ OS::OS() {
 	void *volatile stack_bottom;
 
 	restart_on_exit = false;
-	last_error = NULL;
 	singleton = this;
 	_keep_screen_on = true; // set default value to true, because this had been true before godot 2.0.
 	low_processor_usage_mode = false;
@@ -790,8 +758,6 @@ OS::OS() {
 }
 
 OS::~OS() {
-	if (last_error)
-		memfree(last_error);
 	memdelete(_logger);
 	singleton = NULL;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -61,8 +61,6 @@ class OS {
 	bool _allow_layered;
 	bool _use_vsync;
 
-	char *last_error;
-
 	void *_stack_bottom;
 
 	CompositeLogger *_logger;
@@ -154,10 +152,6 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") = 0;
 	virtual String get_stdin_string(bool p_block = true) = 0;
-
-	virtual void set_last_error(const char *p_error);
-	virtual const char *get_last_error() const;
-	virtual void clear_last_error();
 
 	enum MouseMode {
 		MOUSE_MODE_VISIBLE,

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -43,7 +43,6 @@ namespace PNGDriverCommon {
 static bool check_error(const png_image &image) {
 	const png_uint_32 failed = PNG_IMAGE_FAILED(image);
 	if (failed & PNG_IMAGE_ERROR) {
-		ERR_EXPLAINC(image.message);
 		return true;
 	} else if (failed) {
 #ifdef TOOLS_ENABLED
@@ -67,7 +66,7 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, Ref<Image> p_image) {
 
 	// fetch image properties
 	int success = png_image_begin_read_from_memory(&png_img, p_source, p_size);
-	ERR_FAIL_COND_V(check_error(png_img), ERR_FILE_CORRUPT);
+	ERR_FAIL_COND_V_MSG(check_error(png_img), ERR_FILE_CORRUPT, png_img.message);
 	ERR_FAIL_COND_V(!success, ERR_FILE_CORRUPT);
 
 	// flags to be masked out of input format to give target format
@@ -112,7 +111,7 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, Ref<Image> p_image) {
 
 	// read image data to buffer and release libpng resources
 	success = png_image_finish_read(&png_img, NULL, writer.ptr(), stride, NULL);
-	ERR_FAIL_COND_V(check_error(png_img), ERR_FILE_CORRUPT);
+	ERR_FAIL_COND_V_MSG(check_error(png_img), ERR_FILE_CORRUPT, png_img.message);
 	ERR_FAIL_COND_V(!success, ERR_FILE_CORRUPT);
 
 	p_image->create(png_img.width, png_img.height, 0, dest_format, buffer);
@@ -176,7 +175,7 @@ Error image_to_png(const Ref<Image> &p_image, PoolVector<uint8_t> &p_buffer) {
 		PoolVector<uint8_t>::Write writer = p_buffer.write();
 		success = png_image_write_to_memory(&png_img, &writer[buffer_offset],
 				&compressed_size, 0, reader.ptr(), 0, NULL);
-		ERR_FAIL_COND_V(check_error(png_img), FAILED);
+		ERR_FAIL_COND_V_MSG(check_error(png_img), FAILED, png_img.message);
 	}
 	if (!success) {
 
@@ -190,7 +189,7 @@ Error image_to_png(const Ref<Image> &p_image, PoolVector<uint8_t> &p_buffer) {
 		PoolVector<uint8_t>::Write writer = p_buffer.write();
 		success = png_image_write_to_memory(&png_img, &writer[buffer_offset],
 				&compressed_size, 0, reader.ptr(), 0, NULL);
-		ERR_FAIL_COND_V(check_error(png_img), FAILED);
+		ERR_FAIL_COND_V_MSG(check_error(png_img), FAILED, png_img.message);
 		ERR_FAIL_COND_V(!success, FAILED);
 	}
 

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -106,29 +106,20 @@ void VersionControlEditorPlugin::_initialize_vcs() {
 
 	register_editor();
 
-	if (EditorVCSInterface::get_singleton()) {
-
-		ERR_EXPLAIN(EditorVCSInterface::get_singleton()->get_vcs_name() + " is already active");
-		return;
-	}
+	ERR_FAIL_COND_MSG(EditorVCSInterface::get_singleton(), EditorVCSInterface::get_singleton()->get_vcs_name() + " is already active");
 
 	const int id = set_up_choice->get_selected_id();
 	String selected_addon = set_up_choice->get_item_text(id);
 
 	String path = ScriptServer::get_global_class_path(selected_addon);
 	Ref<Script> script = ResourceLoader::load(path);
-	if (!script.is_valid()) {
 
-		ERR_EXPLAIN("VCS Addon path is invalid");
-	}
+	ERR_FAIL_COND_MSG(!script.is_valid(), "VCS Addon path is invalid");
 
 	EditorVCSInterface *vcs_interface = memnew(EditorVCSInterface);
 	ScriptInstance *addon_script_instance = script->instance_create(vcs_interface);
-	if (!addon_script_instance) {
 
-		ERR_FAIL_NULL(addon_script_instance);
-		return;
-	}
+	ERR_FAIL_COND_MSG(!addon_script_instance, "Failed to create addon script instance.");
 
 	// The addon is attached as a script to the VCS interface as a proxy end-point
 	vcs_interface->set_script_and_instance(script.get_ref_ptr(), addon_script_instance);
@@ -137,10 +128,8 @@ void VersionControlEditorPlugin::_initialize_vcs() {
 	EditorFileSystem::get_singleton()->connect("filesystem_changed", this, "_refresh_stage_area");
 
 	String res_dir = OS::get_singleton()->get_resource_dir();
-	if (!EditorVCSInterface::get_singleton()->initialize(res_dir)) {
 
-		ERR_EXPLAIN("VCS was not initialized");
-	}
+	ERR_FAIL_COND_MSG(!EditorVCSInterface::get_singleton()->initialize(res_dir), "VCS was not initialized");
 
 	_refresh_stage_area();
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2164,6 +2164,5 @@ void Main::cleanup() {
 	unregister_core_driver_types();
 	unregister_core_types();
 
-	OS::get_singleton()->clear_last_error();
 	OS::get_singleton()->finalize_core();
 }

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -148,8 +148,9 @@ Node *EditorSceneImporterAssimp::import_scene(const String &p_path, uint32_t p_f
 								 //aiProcess_SplitByBoneCount |
 								 0;
 	aiScene *scene = (aiScene *)importer.ReadFile(s_path.c_str(), post_process_Steps);
-	ERR_EXPLAIN(String("Open Asset Import failed to open: ") + String(importer.GetErrorString()));
-	ERR_FAIL_COND_V(scene == NULL, NULL);
+
+	ERR_FAIL_COND_V_MSG(scene == NULL, NULL, String("Open Asset Import failed to open: ") + String(importer.GetErrorString()));
+
 	return _generate_scene(p_path, scene, p_flags, p_bake_fps, max_bone_weights);
 }
 

--- a/modules/assimp/import_utils.h
+++ b/modules/assimp/import_utils.h
@@ -369,8 +369,7 @@ public:
 					state.path_to_image_cache.insert(p_path, img);
 					return img;
 				} else if (tex->CheckFormat("dds")) {
-					ERR_EXPLAIN("Open Asset Import: Embedded dds not implemented");
-					ERR_FAIL_COND_V(true, Ref<Image>());
+					ERR_FAIL_COND_V_MSG(true, Ref<Image>(), "Open Asset Import: Embedded dds not implemented");
 				}
 			} else {
 				Ref<Image> img;

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -397,8 +397,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		if (unlikely(m_cond)) {                                                                                        \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:"); \
 			OPCODE_BREAK;                                                                                              \
-		} else                                                                                                         \
-			_err_error_exists = false;                                                                                 \
+		}                                                                                                              \
 	}
 
 #define CHECK_SPACE(m_space) \

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -117,8 +117,7 @@ void GDScriptWorkspace::reload_all_workspace_scripts() {
 			if (S) {
 				err_msg += "\n" + S->get()->get_error();
 			}
-			ERR_EXPLAIN(err_msg);
-			ERR_CONTINUE(err != OK);
+			ERR_CONTINUE_MSG(err != OK, err_msg);
 		}
 	}
 }

--- a/modules/xatlas_unwrap/register_types.cpp
+++ b/modules/xatlas_unwrap/register_types.cpp
@@ -65,8 +65,7 @@ bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_ver
 	xatlas::Atlas *atlas = xatlas::Create();
 	printf("Adding mesh..\n");
 	xatlas::AddMeshError::Enum err = xatlas::AddMesh(atlas, input_mesh, 1);
-	ERR_EXPLAINC(xatlas::StringForEnum(err));
-	ERR_FAIL_COND_V(err != xatlas::AddMeshError::Enum::Success, false);
+	ERR_FAIL_COND_V_MSG(err != xatlas::AddMeshError::Enum::Success, false, xatlas::StringForEnum(err));
 
 	printf("Generate..\n");
 	xatlas::Generate(atlas, chart_options, NULL, pack_options);


### PR DESCRIPTION
Should fix #32276.

Currently the m_msg explanations sent to the *_MSG macros are being sent to _err_print_error() function via the ERR_EXPLAIN macro. The ERR_EXPLAIN macros stores a copy of the message in the OS singleton. The _err_print_error() then retrieves a pointer to the copy stored in the OS singleton. Since it appears as if the only function using the message stored in the OS singleton is the _err_print_error() function, there is no reason to store it there, and the m_msg can be sent directly to _err_print_error().

I think the reason the m_msg is currently sometimes not printed, is that _err_print_error() also deletes the message stored in the OS singleton. Since the error handlers may be running in a separate thread, they may not have a chance to print the message before it is deleted. Sending them the original message and not a copy that is subsequently deleted, should solve the problem.