### PR TITLE
Display icon for "Set As Main Scene" in filesystem popup

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2147,7 +2147,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 			if (filenames.size() == 1) {
 				p_popup->add_icon_item(get_icon("Load", "EditorIcons"), TTR("Open Scene"), FILE_OPEN);
 				p_popup->add_icon_item(get_icon("CreateNewSceneFrom", "EditorIcons"), TTR("New Inherited Scene"), FILE_INHERIT);
-				p_popup->add_item(TTR("Set As Main Scene"), FILE_MAIN_SCENE);
+				p_popup->add_icon_item(get_icon("PlayScene", "EditorIcons"), TTR("Set As Main Scene"), FILE_MAIN_SCENE);
 			} else {
 				p_popup->add_icon_item(get_icon("Load", "EditorIcons"), TTR("Open Scenes"), FILE_OPEN);
 			}


### PR DESCRIPTION
Closes #33487.

`PlayScene` icon is used:

![fs-main-scene](https://user-images.githubusercontent.com/17108460/68582411-50243b00-0483-11ea-89fe-a43b27db9b51.png)

Seems like a good alternative according to https://github.com/godotengine/godot/issues/33487#issuecomment-552233143.