### PR TITLE
Mention that `Dictionary.hash()` can be used for equality comparisons

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -83,7 +83,13 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns a hashed integer value representing the dictionary contents.
+				Returns a hashed integer value representing the dictionary contents. This can be used to compare dictionaries by value:
+				[codeblock]
+				var dict1 = {0: 10}
+				var dict2 = {0: 10}
+				# The line below prints `true`, whereas it would have printed `false` if both variables were compared directly.
+				print(dict1.hash() == dict2.hash())
+				[/codeblock]
 			</description>
 		</method>
 		<method name="keys">


### PR DESCRIPTION
See #27615.

I don't know if there are plans to change how dictionaries are compared in 4.0, but I figure this is worth adding for now.