### PR TITLE
Add bbcode support for printing output (colored debug messages, better logging)

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -280,7 +280,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		log->pop();
 	}
 
-	log->add_text(p_message.text);
+	log->append_text(p_message.text);
 
 	// Need to use pop() to exit out of the RichTextLabels current "push" stack.
 	// We only "push" in the above switch when message type != STD, so only pop when that is the case.
@@ -342,6 +342,7 @@ EditorLog::EditorLog() {
 	log->set_focus_mode(FOCUS_CLICK);
 	log->set_v_size_flags(SIZE_EXPAND_FILL);
 	log->set_h_size_flags(SIZE_EXPAND_FILL);
+	log->set_use_bbcode(true);
 	vb_left->add_child(log);
 
 	// Search box


### PR DESCRIPTION
In reference to better logging #19122 and  #10870, this simple change enables styling of print messages.
The editor output log already uses a RichTextLabel, so why not use the bbcode functionality?

If performance is a concern (`add_text` vs `append_bbcode`) perhaps we could make it an editor setting?

If used, the bbcode will of course show up in the log files, I believe the same is true for coloring output in Unity. I don't think this is an issue if you want colored output for debugging, though. 

This is how it looks:
![print_color](https://user-images.githubusercontent.com/13589801/68591498-2d008800-0491-11ea-877a-4f95c95b48d0.PNG)

```
print("normal print")
print("[rainbow]normal print[/rainbow]")
print_debug("[color=aqua]Debug: [/color]", "[color=lime]Object 02[/color]")
```
