### PR TITLE
X11: Fix memory leak in handle_key_event

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1866,6 +1866,7 @@ void OS_X11::handle_key_event(XKeyEvent *p_event, bool p_echo) {
 
 				input->accumulate_input_event(k);
 			}
+			memfree(utf8string);
 			return;
 		}
 		memfree(utf8string);


### PR DESCRIPTION
Extracted from #27189.