### PR TITLE
vhacd: Sync with upstream b07958e

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -481,7 +481,7 @@ Files extracted from upstream source:
 ## vhacd
 
 - Upstream: https://github.com/kmammou/v-hacd
-- Version: git (2297aa1, 2018)
+- Version: git (b07958e, 2019)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:

--- a/thirdparty/vhacd/src/FloatMath.inl
+++ b/thirdparty/vhacd/src/FloatMath.inl
@@ -7,6 +7,10 @@
 // a quaternion is a 'float *' to 4 floats representing a quaternion x,y,z,w
 //
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996)
+#endif
+
 namespace FLOAT_MATH
 {
 


### PR DESCRIPTION
Nothing to see here, it is just a cosmetic sync to confirm
that we have the latest upstream changes.