### PR TITLE
Fix crash when exiting Godot 

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1381,6 +1381,9 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 		return; //just invalid, but no error
 	}
 
+	if (!ShaderTypes::get_singleton()) // It can happens when Godot cleaned singleton to prepare program to exit
+		return;
+
 	ShaderCompilerGLES2::GeneratedCode gen_code;
 	ShaderCompilerGLES2::IdentifierActions *actions = NULL;
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2081,6 +2081,9 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 		return; //just invalid, but no error
 	}
 
+	if (!ShaderTypes::get_singleton()) // It can happens when Godot cleaned singleton to prepare program to exit
+		return;
+
 	ShaderCompilerGLES3::GeneratedCode gen_code;
 	ShaderCompilerGLES3::IdentifierActions *actions = NULL;
 

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -283,3 +283,7 @@ ShaderTypes::ShaderTypes() {
 	shader_types.insert("canvas_item");
 	shader_types.insert("particles");
 }
+
+ShaderTypes::~ShaderTypes() {
+	singleton = NULL;
+}

--- a/servers/visual/shader_types.h
+++ b/servers/visual/shader_types.h
@@ -57,6 +57,7 @@ public:
 	const Set<String> &get_types();
 
 	ShaderTypes();
+	~ShaderTypes();
 };
 
 #endif // SHADERTYPES_H


### PR DESCRIPTION
Fixes #29686

I'm not sure if this is the best solution.
Maybe better will be to clear all shaders at exit instead compiling it?

Also changing execution of  `unregister_server_types()` after `OS::get_singleton()->finalize()` seems to work fine, but I suspect that this isn't correct solution 
```
diff --git a/main/main.cpp b/main/main.cpp
index c34d3da618..1bc7afdda7 100644
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2127,7 +2127,6 @@ void Main::cleanup() {
        unregister_module_types();
        unregister_platform_apis();
        unregister_scene_types();
-       unregister_server_types();
 
        if (audio_server) {
                audio_server->finish();
@@ -2135,6 +2134,7 @@ void Main::cleanup() {
        }
 
        OS::get_singleton()->finalize();
+       unregister_server_types();
        finalize_physics();
 
        if (packed_data)
```