### PR TITLE
Prevent crash when scene has path, but no file

### DIFF
--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -135,6 +135,10 @@ void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p
 }
 void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path) {
 
+	FileAccessRef file_check = FileAccess::create(FileAccess::ACCESS_RESOURCES);
+	if (!file_check->file_exists(p_path)) //This can happen when creating scene from FilesystemDock. It has path, but no file.
+		return;
+
 	Ref<ConfigFile> config;
 	config.instance();
 


### PR DESCRIPTION
Fixes #33556