### PR TITLE
Highlight control flow keywords with a different color

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -303,6 +303,7 @@ public:
 
 	void get_core_type_words(List<String> *p_core_type_words) const;
 	virtual void get_reserved_words(List<String> *p_words) const = 0;
+	virtual bool is_control_flow_keyword(String p_string) const = 0;
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const = 0;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const = 0;
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const = 0;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -787,6 +787,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 
 	_initial_set("text_editor/highlighting/symbol_color", Color(0.73, 0.87, 1.0));
 	_initial_set("text_editor/highlighting/keyword_color", Color(1.0, 1.0, 0.7));
+	_initial_set("text_editor/highlighting/control_flow_keyword_color", Color(1.0, 0.85, 0.7));
 	_initial_set("text_editor/highlighting/base_type_color", Color(0.64, 1.0, 0.83));
 	_initial_set("text_editor/highlighting/engine_type_color", Color(0.51, 0.83, 1.0));
 	_initial_set("text_editor/highlighting/user_type_color", Color(0.42, 0.67, 0.93));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1306,6 +1306,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	const Color symbol_color = Color(0.34, 0.57, 1.0).lerp(mono_color, dark_theme ? 0.5 : 0.3);
 	const Color keyword_color = Color(1.0, 0.44, 0.52);
+	const Color control_flow_keyword_color = dark_theme ? Color(1.0, 0.55, 0.8) : Color(0.8, 0.4, 0.6);
 	const Color basetype_color = dark_theme ? Color(0.26, 1.0, 0.76) : Color(0.0, 0.76, 0.38);
 	const Color type_color = basetype_color.lerp(mono_color, dark_theme ? 0.4 : 0.3);
 	const Color usertype_color = basetype_color.lerp(mono_color, dark_theme ? 0.7 : 0.5);
@@ -1344,6 +1345,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	if (text_editor_color_theme == "Adaptive") {
 		setting->set_initial_value("text_editor/highlighting/symbol_color", symbol_color, true);
 		setting->set_initial_value("text_editor/highlighting/keyword_color", keyword_color, true);
+		setting->set_initial_value("text_editor/highlighting/control_flow_keyword_color", control_flow_keyword_color, true);
 		setting->set_initial_value("text_editor/highlighting/base_type_color", basetype_color, true);
 		setting->set_initial_value("text_editor/highlighting/engine_type_color", type_color, true);
 		setting->set_initial_value("text_editor/highlighting/user_type_color", usertype_color, true);

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -487,10 +487,15 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 	List<String> kwors;
 	scr->get_language()->get_reserved_words(&kwors);
 
+	Set<String> control_flow_keywords;
 	Set<String> keywords;
 
 	for (List<String>::Element *E = kwors.front(); E; E = E->next()) {
-		keywords.insert(E->get());
+		if (scr->get_language()->is_control_flow_keyword(E->get())) {
+			control_flow_keywords.insert(E->get());
+		} else {
+			keywords.insert(E->get());
+		}
 	}
 
 	int line = 0;
@@ -502,6 +507,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 
 	Color bg_color = EditorSettings::get_singleton()->get("text_editor/highlighting/background_color");
 	Color keyword_color = EditorSettings::get_singleton()->get("text_editor/highlighting/keyword_color");
+	Color control_flow_keyword_color = EditorSettings::get_singleton()->get("text_editor/highlighting/control_flow_keyword_color");
 	Color text_color = EditorSettings::get_singleton()->get("text_editor/highlighting/text_color");
 	Color symbol_color = EditorSettings::get_singleton()->get("text_editor/highlighting/symbol_color");
 	Color comment_color = EditorSettings::get_singleton()->get("text_editor/highlighting/comment_color");
@@ -523,6 +529,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 	col = x0;
 
 	bool prev_is_text = false;
+	bool in_control_flow_keyword = false;
 	bool in_keyword = false;
 	bool in_comment = false;
 	for (int i = 0; i < code.length(); i++) {
@@ -541,6 +548,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 					if (c != '_' && ((c >= '!' && c <= '/') || (c >= ':' && c <= '@') || (c >= '[' && c <= '`') || (c >= '{' && c <= '~') || c == '\t')) {
 						//make symbol a little visible
 						color = symbol_color;
+						in_control_flow_keyword = false;
 						in_keyword = false;
 					} else if (!prev_is_text && _is_text_char(c)) {
 						int pos = i;
@@ -549,7 +557,9 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 							pos++;
 						}
 						String word = code.substr(i, pos - i);
-						if (keywords.has(word)) {
+						if (control_flow_keywords.has(word)) {
+							in_control_flow_keyword = true;
+						} else if (keywords.has(word)) {
 							in_keyword = true;
 						}
 
@@ -557,11 +567,12 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 						in_keyword = false;
 					}
 
-					if (in_keyword) {
+					if (in_control_flow_keyword) {
+						color = control_flow_keyword_color;
+					} else if (in_keyword) {
 						color = keyword_color;
 					}
 				}
-
 				Color ul = color;
 				ul.a *= 0.5;
 				img->set_pixel(col, y0 + line * 2, bg_color.blend(ul));
@@ -572,6 +583,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 			col++;
 		} else {
 			prev_is_text = false;
+			in_control_flow_keyword = false;
 			in_keyword = false;
 
 			if (c == '\n') {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -140,10 +140,15 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 
 		/* Reserved words. */
 		const Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
+		const Color control_flow_keyword_color = EDITOR_GET("text_editor/highlighting/control_flow_keyword_color");
 		List<String> keywords;
 		script->get_language()->get_reserved_words(&keywords);
 		for (List<String>::Element *E = keywords.front(); E; E = E->next()) {
-			highlighter->add_keyword_color(E->get(), keyword_color);
+			if (script->get_language()->is_control_flow_keyword(E->get())) {
+				highlighter->add_keyword_color(E->get(), control_flow_keyword_color);
+			} else {
+				highlighter->add_keyword_color(E->get(), keyword_color);
+			}
 		}
 
 		/* Member types. */

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -141,9 +141,14 @@ void ShaderTextEditor::_load_theme_settings() {
 	List<String> keywords;
 	ShaderLanguage::get_keyword_list(&keywords);
 	const Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
+	const Color control_flow_keyword_color = EDITOR_GET("text_editor/highlighting/control_flow_keyword_color");
 
 	for (List<String>::Element *E = keywords.front(); E; E = E->next()) {
-		syntax_highlighter->add_keyword_color(E->get(), keyword_color);
+		if (ShaderLanguage::is_control_flow_keyword(E->get())) {
+			syntax_highlighter->add_keyword_color(E->get(), control_flow_keyword_color);
+		} else {
+			syntax_highlighter->add_keyword_color(E->get(), keyword_color);
+		}
 	}
 
 	// Colorize built-ins like `COLOR` differently to make them easier

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -736,6 +736,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		Color background_color = EDITOR_GET("text_editor/highlighting/background_color");
 		Color text_color = EDITOR_GET("text_editor/highlighting/text_color");
 		Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
+		Color control_flow_keyword_color = EDITOR_GET("text_editor/highlighting/control_flow_keyword_color");
 		Color comment_color = EDITOR_GET("text_editor/highlighting/comment_color");
 		Color symbol_color = EDITOR_GET("text_editor/highlighting/symbol_color");
 		Color function_color = EDITOR_GET("text_editor/highlighting/function_color");
@@ -746,7 +747,11 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		expression_box->add_theme_color_override("background_color", background_color);
 
 		for (List<String>::Element *E = VisualShaderEditor::get_singleton()->keyword_list.front(); E; E = E->next()) {
-			expression_syntax_highlighter->add_keyword_color(E->get(), keyword_color);
+			if (ShaderLanguage::is_control_flow_keyword(E->get())) {
+				expression_syntax_highlighter->add_keyword_color(E->get(), control_flow_keyword_color);
+			} else {
+				expression_syntax_highlighter->add_keyword_color(E->get(), keyword_color);
+			}
 		}
 
 		expression_box->add_theme_font_override("font", VisualShaderEditor::get_singleton()->get_theme_font("expression", "EditorFonts"));
@@ -2803,6 +2808,7 @@ void VisualShaderEditor::_notification(int p_what) {
 			Color background_color = EDITOR_GET("text_editor/highlighting/background_color");
 			Color text_color = EDITOR_GET("text_editor/highlighting/text_color");
 			Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
+			Color control_flow_keyword_color = EDITOR_GET("text_editor/highlighting/control_flow_keyword_color");
 			Color comment_color = EDITOR_GET("text_editor/highlighting/comment_color");
 			Color symbol_color = EDITOR_GET("text_editor/highlighting/symbol_color");
 			Color function_color = EDITOR_GET("text_editor/highlighting/function_color");
@@ -2812,7 +2818,11 @@ void VisualShaderEditor::_notification(int p_what) {
 			preview_text->add_theme_color_override("background_color", background_color);
 
 			for (List<String>::Element *E = keyword_list.front(); E; E = E->next()) {
-				syntax_highlighter->add_keyword_color(E->get(), keyword_color);
+				if (ShaderLanguage::is_control_flow_keyword(E->get())) {
+					syntax_highlighter->add_keyword_color(E->get(), control_flow_keyword_color);
+				} else {
+					syntax_highlighter->add_keyword_color(E->get(), keyword_color);
+				}
 			}
 
 			preview_text->add_theme_font_override("font", get_theme_font("expression", "EditorFonts"));

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1289,6 +1289,10 @@ void NativeScriptLanguage::finish() {
 void NativeScriptLanguage::get_reserved_words(List<String> *p_words) const {
 }
 
+bool NativeScriptLanguage::is_control_flow_keyword(String p_keyword) const {
+	return false;
+}
+
 void NativeScriptLanguage::get_comment_delimiters(List<String> *p_delimiters) const {
 }
 

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -336,6 +336,7 @@ public:
 	virtual Error execute_file(const String &p_path);
 	virtual void finish();
 	virtual void get_reserved_words(List<String> *p_words) const;
+	virtual bool is_control_flow_keyword(String p_keyword) const;
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const;
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -77,6 +77,10 @@ void PluginScriptLanguage::get_reserved_words(List<String> *p_words) const {
 	}
 }
 
+bool PluginScriptLanguage::is_control_flow_keyword(String p_keyword) const {
+	return false;
+}
+
 void PluginScriptLanguage::get_comment_delimiters(List<String> *p_delimiters) const {
 	if (_desc.comment_delimiters) {
 		const char **w = _desc.comment_delimiters;

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -71,6 +71,7 @@ public:
 
 	/* EDITOR FUNCTIONS */
 	virtual void get_reserved_words(List<String> *p_words) const;
+	virtual bool is_control_flow_keyword(String p_keyword) const;
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const;
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -485,10 +485,15 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 
 	/* Reserved words. */
 	const Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
+	const Color control_flow_keyword_color = EDITOR_GET("text_editor/highlighting/control_flow_keyword_color");
 	List<String> keyword_list;
 	gdscript->get_reserved_words(&keyword_list);
 	for (List<String>::Element *E = keyword_list.front(); E; E = E->next()) {
-		keywords[E->get()] = keyword_color;
+		if (gdscript->is_control_flow_keyword(E->get())) {
+			keywords[E->get()] = control_flow_keyword_color;
+		} else {
+			keywords[E->get()] = keyword_color;
+		}
 	}
 
 	/* Comments */

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2135,6 +2135,19 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 	}
 }
 
+bool GDScriptLanguage::is_control_flow_keyword(String p_keyword) const {
+	return p_keyword == "break" ||
+		   p_keyword == "continue" ||
+		   p_keyword == "elif" ||
+		   p_keyword == "else" ||
+		   p_keyword == "if" ||
+		   p_keyword == "for" ||
+		   p_keyword == "match" ||
+		   p_keyword == "pass" ||
+		   p_keyword == "return" ||
+		   p_keyword == "while";
+}
+
 bool GDScriptLanguage::handles_global_class_type(const String &p_type) const {
 	return p_type == "GDScript";
 }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -461,6 +461,7 @@ public:
 
 	/* EDITOR FUNCTIONS */
 	virtual void get_reserved_words(List<String> *p_words) const;
+	virtual bool is_control_flow_keyword(String p_keywords) const;
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const;
 	virtual String _get_processed_template(const String &p_template, const String &p_base_class_name) const;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -304,6 +304,26 @@ void CSharpLanguage::get_reserved_words(List<String> *p_words) const {
 	}
 }
 
+bool CSharpLanguage::is_control_flow_keyword(String p_keyword) const {
+	return p_keyword == "break" ||
+		   p_keyword == "case" ||
+		   p_keyword == "catch" ||
+		   p_keyword == "continue" ||
+		   p_keyword == "default" ||
+		   p_keyword == "do" ||
+		   p_keyword == "else" ||
+		   p_keyword == "finally" ||
+		   p_keyword == "for" ||
+		   p_keyword == "foreach" ||
+		   p_keyword == "goto" ||
+		   p_keyword == "if" ||
+		   p_keyword == "return" ||
+		   p_keyword == "switch" ||
+		   p_keyword == "throw" ||
+		   p_keyword == "try" ||
+		   p_keyword == "while";
+}
+
 void CSharpLanguage::get_comment_delimiters(List<String> *p_delimiters) const {
 	p_delimiters->push_back("//"); // single-line comment
 	p_delimiters->push_back("/* */"); // delimited comment

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -470,6 +470,7 @@ public:
 
 	/* EDITOR FUNCTIONS */
 	void get_reserved_words(List<String> *p_words) const override;
+	bool is_control_flow_keyword(String p_keyword) const;
 	void get_comment_delimiters(List<String> *p_delimiters) const override;
 	void get_string_delimiters(List<String> *p_delimiters) const override;
 	Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const override;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2336,6 +2336,10 @@ void VisualScriptLanguage::finish() {
 void VisualScriptLanguage::get_reserved_words(List<String> *p_words) const {
 }
 
+bool VisualScriptLanguage::is_control_flow_keyword(String p_keyword) const {
+	return false;
+}
+
 void VisualScriptLanguage::get_comment_delimiters(List<String> *p_delimiters) const {
 }
 

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -586,6 +586,7 @@ public:
 
 	/* EDITOR FUNCTIONS */
 	virtual void get_reserved_words(List<String> *p_words) const;
+	virtual bool is_control_flow_keyword(String p_keyword) const;
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const;
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -2969,6 +2969,20 @@ void ShaderLanguage::get_keyword_list(List<String> *r_keywords) {
 	}
 }
 
+bool ShaderLanguage::is_control_flow_keyword(String p_keyword) {
+	return p_keyword == "break" ||
+		   p_keyword == "case" ||
+		   p_keyword == "continue" ||
+		   p_keyword == "default" ||
+		   p_keyword == "do" ||
+		   p_keyword == "else" ||
+		   p_keyword == "for" ||
+		   p_keyword == "if" ||
+		   p_keyword == "return" ||
+		   p_keyword == "switch" ||
+		   p_keyword == "while";
+}
+
 void ShaderLanguage::get_builtin_funcs(List<String> *r_keywords) {
 	Set<String> kws;
 

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -748,6 +748,7 @@ public:
 	static uint32_t get_type_size(DataType p_type);
 
 	static void get_keyword_list(List<String> *r_keywords);
+	static bool is_control_flow_keyword(String p_keyword);
 	static void get_builtin_funcs(List<String> *r_keywords);
 
 	struct BuiltInInfo {


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/47751.

This makes them easier to distinguish from other keywords. This works in all languages supported by the Godot script editor.

**See [this comment](https://github.com/godotengine/godot/pull/33577#issuecomment-583898393) for alternative color choices.**

Related to #33548. This partially addresses #31054.

## Preview

![image](https://user-images.githubusercontent.com/180032/68699187-d3788600-0582-11ea-8a29-065d33a2915f.png)