### PR TITLE
Fix some overflows and unitialized variables

### DIFF
--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -279,6 +279,7 @@ Ref<StreamPeer> PacketPeerStream::get_stream_peer() const {
 
 void PacketPeerStream::set_input_buffer_max_size(int p_max_size) {
 
+	ERR_FAIL_COND_MSG(p_max_size < 0, "Max size of input buffer size cannot be smaller than 0.");
 	//warning may lose packets
 	ERR_FAIL_COND_MSG(ring_buffer.data_left(), "Buffer in use, resizing would cause loss of data.");
 	ring_buffer.resize(nearest_shift(p_max_size + 4));

--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -183,6 +183,10 @@ void CameraMatrix::set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear
 
 void CameraMatrix::set_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far) {
 
+	ERR_FAIL_COND(p_right <= p_left);
+	ERR_FAIL_COND(p_top <= p_bottom);
+	ERR_FAIL_COND(p_far <= p_near);
+
 	real_t *te = &matrix[0][0];
 	real_t x = 2 * p_near / (p_right - p_left);
 	real_t y = 2 * p_near / (p_top - p_bottom);

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -525,6 +525,8 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 		set(key, value);
 	}
 
+	f->close();
+	memdelete(f);
 	return OK;
 }
 

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -174,6 +174,9 @@ inline void __swap_tmpl(T &x, T &y) {
 
 static _FORCE_INLINE_ unsigned int next_power_of_2(unsigned int x) {
 
+	if (x == 0)
+		return 0;
+
 	--x;
 	x |= x >> 1;
 	x |= x >> 2;

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1416,7 +1416,7 @@ bool String::parse_utf8(const char *p_utf8, int p_len) {
 
 			if (skip == 0) {
 
-				uint8_t c = *ptrtmp;
+				uint8_t c = *ptrtmp >= 0 ? *ptrtmp : uint8_t(256 + *ptrtmp);
 
 				/* Determine the number of characters in sequence */
 				if ((c & 0x80) == 0)

--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -749,6 +749,10 @@ void RasterizerCanvasGLES2::_canvas_item_render_commands(Item *p_item, Item *cur
 					WARN_PRINT("NinePatch without texture not supported yet in GLES2 backend, skipping.");
 					continue;
 				}
+				if (tex->width == 0 || tex->height == 0) {
+					WARN_PRINT("Cannot set empty texture to NinePatch.");
+					continue;
+				}
 
 				Size2 texpixel_size(1.0 / tex->width, 1.0 / tex->height);
 

--- a/drivers/gles2/shader_gles2.h
+++ b/drivers/gles2/shader_gles2.h
@@ -119,6 +119,7 @@ private:
 		bool ok;
 		Version() {
 			code_version = 0;
+			frag_id = 0;
 			ok = false;
 			uniform_location = NULL;
 		}

--- a/editor/doc/doc_data.h
+++ b/editor/doc/doc_data.h
@@ -78,6 +78,9 @@ public:
 		bool operator<(const PropertyDoc &p_prop) const {
 			return name < p_prop.name;
 		}
+		PropertyDoc() {
+			overridden = false;
+		}
 	};
 
 	struct ClassDoc {

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -177,7 +177,7 @@ String SectionedInspector::get_full_item_path(const String &p_item) {
 void SectionedInspector::edit(Object *p_object) {
 
 	if (!p_object) {
-		obj = -1;
+		obj = 0;
 		sections->clear();
 
 		filter->set_edited(NULL);
@@ -308,7 +308,7 @@ EditorInspector *SectionedInspector::get_inspector() {
 }
 
 SectionedInspector::SectionedInspector() :
-		obj(-1),
+		obj(0),
 		sections(memnew(Tree)),
 		filter(memnew(SectionedInspectorFilter)),
 		inspector(memnew(EditorInspector)),

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5262,6 +5262,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	drag_to = Vector2();
 	dragged_guide_pos = Point2();
 	dragged_guide_index = -1;
+	is_hovering_h_guide = false;
+	is_hovering_v_guide = false;
 	panning = false;
 	pan_pressed = false;
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -852,6 +852,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	hb->add_child(path_button);
 	gc->add_child(memnew(Label(TTR("Path:"))));
 	gc->add_child(hb);
+	re_check_path = false;
 
 	/* Dialog Setup */
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -2600,6 +2600,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	p_editor->get_undo_redo()->set_method_notify_callback(_method_changeds, this);
 	p_editor->get_undo_redo()->set_property_notify_callback(_property_changeds, this);
 	live_debug = true;
+	camera_override = OVERRIDE_NONE;
 	last_path_id = false;
 	error_count = 0;
 	warning_count = 0;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1233,8 +1233,8 @@ void TileMap::_set_tile_data(const PoolVector<int> &p_data) {
 		}
 #endif
 
-		int16_t x = decode_uint16(&local[0]);
-		int16_t y = decode_uint16(&local[2]);
+		uint16_t x = decode_uint16(&local[0]);
+		uint16_t y = decode_uint16(&local[2]);
 		uint32_t v = decode_uint32(&local[4]);
 		bool flip_h = v & (1 << 29);
 		bool flip_v = v & (1 << 30);

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -63,6 +63,8 @@ void Tween::_add_pending_command(StringName p_key, const Variant &p_arg1, const 
 		count = 2;
 	else if (p_arg1.get_type() != Variant::NIL)
 		count = 1;
+	else
+		count = 0;
 
 	// Add the specified arguments to the command
 	// TODO: Make this a switch statement?

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -173,6 +173,8 @@ void Range::set_as_ratio(double p_value) {
 }
 double Range::get_as_ratio() const {
 
+	ERR_FAIL_COND_V_MSG(Math::is_equal_approx(get_max(), get_min()), 0.0, "Cannot get ratio when minimum and maximum value are equal.");
+
 	if (shared->exp_ratio && get_min() >= 0) {
 
 		double exp_min = get_min() == 0 ? 0.0 : Math::log(get_min()) / Math::log((double)2);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -159,7 +159,7 @@ protected:
 	//bind helpers
 	Dictionary _get_range_config(int p_column) {
 		Dictionary d;
-		double min, max, step;
+		double min = 0.0, max = 0.0, step = 0.0;
 		get_range_config(p_column, min, max, step);
 		d["min"] = min;
 		d["max"] = max;

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -95,8 +95,8 @@ void AudioStreamPlaybackSample::do_resample(const Depth *p_src, AudioFrame *p_ds
 	// this function will be compiled branchless by any decent compiler
 
 	int32_t final, final_r, next, next_r;
-	while (amount--) {
-
+	while (amount) {
+		amount--;
 		int64_t pos = offset >> MIX_FRAC_BITS;
 		if (is_stereo && !is_ima_adpcm)
 			pos <<= 1;
@@ -444,6 +444,7 @@ int AudioStreamSample::get_loop_end() const {
 
 void AudioStreamSample::set_mix_rate(int p_hz) {
 
+	ERR_FAIL_COND(p_hz == 0);
 	mix_rate = p_hz;
 }
 int AudioStreamSample::get_mix_rate() const {


### PR DESCRIPTION
Fixes #33240

Fixes also warnings showed by undefined behavior sanitizer like division by zero, unitialized variables and loss value conversions
```
scene/gui/range.cpp:188:10: runtime error: division by zero
editor/script_editor_debugger.cpp:1933:9: runtime error: load of value 3200171710, which is not a valid value for type 'ScriptEditorDebugger::CameraOverride'
scene/resources/texture.cpp:2588:15: runtime error: load of value 100, which is not a valid value for type 'CameraServer::FeedImage'
editor/editor_sectioned_inspector.cpp:311:7: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'ObjectID' (aka 'unsigned long') changed the value to 18446744073709551615 (64-bit, unsigned)
core/ustring.cpp:1419:17: runtime error: implicit conversion from type 'char' of value -60 (8-bit, signed) to type 'uint8_t' (aka 'unsigned char') changed the value to 196 (8-bit, unsigned)
scene/2d/tile_map.cpp:1236:15: runtime error: implicit conversion from type 'uint16_t' (aka 'unsigned short') of value 65129 (16-bit, unsigned) to type 'int16_t' (aka 'short') changed the value to -407 (16-bit, signed)
core/variant.cpp:2690:11: runtime error: implicit conversion from type 'int64_t' (aka 'long') of value -1 (64-bit, signed) to type 'uint32_t' (aka 'unsigned int') changed the value to 4294967295 (32-bit, unsigned)
scene/resources/audio_stream_sample.cpp:98:15: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'uint32_t' (aka 'unsigned int')
scene/resources/audio_stream_sample.cpp:475:20: runtime error: division by zero
core/math/camera_matrix.cpp:187:24: runtime error: division by zero
core/math/camera_matrix.cpp:188:24: runtime error: division by zero
core/math/camera_matrix.cpp:190:32: runtime error: division by zero
core/math/camera_matrix.cpp:191:32: runtime error: division by zero
core/math/camera_matrix.cpp:192:31: runtime error: division by zero
core/math/camera_matrix.cpp:193:33: runtime error: division by zero
```
and this leak
```
Direct leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x7f7f9be78ae8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dae8)
    #1 0x9c332bd in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:85
    #2 0x9c331bc in operator new(unsigned long, char const*) core/os/memory.cpp:42
    #3 0x9eb5781 in PackedSourcePCK::get_file(String const&, PackedData::PackedFile*) core/io/file_access_pack.cpp:220
    #4 0x9b64ea9 in PackedData::try_open_path(String const&) core/io/file_access_pack.h:187
    #5 0x9b5768d in FileAccess::open(String const&, int, Error*) core/os/file_access.cpp:100
    #6 0x9764db3 in ProjectSettings::_load_settings_binary(String const&) core/project_settings.cpp:493
    #7 0x97691c1 in ProjectSettings::_load_settings_text_or_binary(String const&, String const&) core/project_settings.cpp:606
    #8 0x9760b60 in ProjectSettings::_setup(String const&, String const&, bool) core/project_settings.cpp:392
    #9 0x9764335 in ProjectSettings::setup(String const&, String const&, bool) core/project_settings.cpp:467
    #10 0x1098c89 in Main::setup(char const*, int, char**, bool) main/main.cpp:825
    #11 0xf3e2ee in main platform/x11/godot_x11.cpp:49
    #12 0x7f7f9a9541e2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x271e2)
```