### PR TITLE
Set "restore_scenes_on_load" default value to TRUE

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5704,7 +5704,7 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("interface/editor/quit_confirmation", true);
 	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_continuously", false);
-	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", false);
+	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", true);
 	EDITOR_DEF_RST("interface/scene_tabs/show_thumbnail_on_hover", true);
 	EDITOR_DEF_RST("interface/inspector/capitalize_properties", true);
 	EDITOR_DEF_RST("interface/inspector/default_float_step", 0.001);


### PR DESCRIPTION
As the way Godot is designed, a concept can be fragmented into several scenes that, depending on what's being developed, may take days to finish. Without this option checked one must note the names of scenes being edited somewhere to continue the next day. So it'd be a good idea to leave this option checked by default as it's quite useful and a little hard to find in the editor...