### PR TITLE
Fix AudioStreamPlayer emitting finished signal on stopping

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -79,7 +79,12 @@
 	<signals>
 		<signal name="finished">
 			<description>
-				Emitted when the audio stops playing.
+				Emitted when the playback reaches the end of the audio stream. The signal is [b]not[/b] emitted when the playback is abruptly interrupted with the [method stop] method or other reason.
+			</description>
+		</signal>
+		<signal name="stopped">
+			<description>
+				Emitted when the audio stops playing with the [method stop] method or other reason. The signal is [b]not[/b] emitted when the playback reaches the end of the audio stream normally, without interruption.
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
Stopping and finishing a track are treated separately, ensure to reset `setstop` flag to `false` on playing again.

This breaks compat for people who expect/rely on `$audio.stop()` to emit `finished` signal as well. The signal is only emitted when the track reaches the end now.

Due to this, I've added `stopped` signal which is emitted only when the playback is abruptly stopped (same as before, but now it won't emit when the playback finishes normally, which closes #33579).

## Test project

[audio-stream-player-stop-finished.zip](https://github.com/godotengine/godot/files/4864744/audio-stream-player-stop-finished.zip) (Intro.ogg taken from demo projects).
