### PR TITLE
Fix 2D CollisionShape controls pointing the wrong way

### DIFF
--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -448,8 +448,8 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			float radius = shape->get_radius();
 			float height = shape->get_height() / 2;
 
-			handles.write[0] = Point2(radius, -height);
-			handles.write[1] = Point2(0, -(height + radius));
+			handles.write[0] = Point2(radius, height);
+			handles.write[1] = Point2(0, height + radius);
 
 			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
@@ -502,8 +502,8 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			handles.resize(3);
 			Vector2 ext = shape->get_extents();
 			handles.write[0] = Point2(ext.x, 0);
-			handles.write[1] = Point2(0, -ext.y);
-			handles.write[2] = Point2(ext.x, -ext.y);
+			handles.write[1] = Point2(0, ext.y);
+			handles.write[2] = Point2(ext.x, ext.y);
 
 			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);

--- a/scene/resources/line_shape_2d.cpp
+++ b/scene/resources/line_shape_2d.cpp
@@ -115,7 +115,7 @@ void LineShape2D::_bind_methods() {
 LineShape2D::LineShape2D() :
 		Shape2D(Physics2DServer::get_singleton()->line_shape_create()) {
 
-	normal = Vector2(0, -1);
+	normal = Vector2(0, 1);
 	d = 0;
 	_update_shape();
 }


### PR DESCRIPTION
They now point down, matching Godot's 2D coordinate system.

![f](https://user-images.githubusercontent.com/1646875/68829026-89bc9800-0675-11ea-927a-ff051c05e228.png)

Fixes the concerns raised in https://github.com/godotengine/godot/pull/21934#issuecomment-552877143. Might be worth cherry-picking to avoid users getting confused about Godot's 2D coordinate system.

Created in large part by picking out some of the code that @MCrafterzz placed in #33451