### PR TITLE
Fix "matches" label color in light theme

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -328,7 +328,7 @@ void FindReplaceBar::_update_matches_label() {
 	} else {
 		matches_label->show();
 
-		matches_label->add_color_override("font_color", results_count > 0 ? Color(1, 1, 1) : EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
+		matches_label->add_color_override("font_color", results_count > 0 ? get_color("font_color", "Label") : get_color("error_color", "Editor"));
 		matches_label->set_text(vformat(results_count == 1 ? TTR("%d match.") : TTR("%d matches."), results_count));
 	}
 }

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1802,7 +1802,7 @@ void FindBar::_update_matches_label() {
 	} else {
 		matches_label->show();
 
-		matches_label->add_color_override("font_color", results_count > 0 ? Color(1, 1, 1) : EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
+		matches_label->add_color_override("font_color", results_count > 0 ? get_color("font_color", "Label") : get_color("error_color", "Editor"));
 		matches_label->set_text(vformat(results_count == 1 ? TTR("%d match.") : TTR("%d matches."), results_count));
 	}
 }


### PR DESCRIPTION
From

![image](https://user-images.githubusercontent.com/3036176/68832713-bba81b80-06c2-11ea-8a5f-b39c1d1e3f78.png)

To

![image](https://user-images.githubusercontent.com/3036176/68832719-bea30c00-06c2-11ea-9e78-11187243b061.png)
