### PR TITLE
Add a tooltip to explain what marking a preset as "runnable" does

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1107,6 +1107,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	name->connect("text_changed", this, "_name_changed");
 	runnable = memnew(CheckButton);
 	runnable->set_text(TTR("Runnable"));
+	runnable->set_tooltip(TTR("If checked, the preset will be available for use in one-click deploy.\nOnly one preset per platform may be marked as runnable."));
 	runnable->connect("pressed", this, "_runnable_pressed");
 	settings_vb->add_child(runnable);
 


### PR DESCRIPTION
It may be confusing at first, so this helps clarify what "runnable" presets are for.