### PR TITLE
Add basis rotation to gdscript.

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -999,6 +999,20 @@ struct _VariantCall {
 		r_ret = Basis(p_args[0]->operator Vector3(), p_args[1]->operator real_t());
 	}
 
+	static void Basis_init_euler_scale(Variant &r_ret, const Variant **p_args) {
+
+		Basis basis;
+		basis.set_euler_scale(p_args[0]->operator Vector3(), p_args[1]->operator Vector3());
+		r_ret = basis;
+	}
+
+	static void Basis_init_quat_scale(Variant &r_ret, const Variant **p_args) {
+
+		Basis basis;
+		basis.set_quat_scale(p_args[0]->operator Quat(), p_args[1]->operator Vector3());
+		r_ret = basis;
+	}
+
 	static void Transform_init1(Variant &r_ret, const Variant **p_args) {
 
 		Transform t;
@@ -1985,6 +1999,9 @@ void register_variant_methods() {
 
 	_VariantCall::add_constructor(_VariantCall::Basis_init1, Variant::BASIS, "x_axis", Variant::VECTOR3, "y_axis", Variant::VECTOR3, "z_axis", Variant::VECTOR3);
 	_VariantCall::add_constructor(_VariantCall::Basis_init2, Variant::BASIS, "axis", Variant::VECTOR3, "phi", Variant::REAL);
+
+	_VariantCall::add_constructor(_VariantCall::Basis_init_euler_scale, Variant::BASIS, "euler", Variant::VECTOR3, "scale", Variant::VECTOR3);
+	_VariantCall::add_constructor(_VariantCall::Basis_init_quat_scale, Variant::BASIS, "quat", Variant::QUAT, "scale", Variant::VECTOR3);
 
 	_VariantCall::add_constructor(_VariantCall::Transform_init1, Variant::TRANSFORM, "x_axis", Variant::VECTOR3, "y_axis", Variant::VECTOR3, "z_axis", Variant::VECTOR3, "origin", Variant::VECTOR3);
 	_VariantCall::add_constructor(_VariantCall::Transform_init2, Variant::TRANSFORM, "basis", Variant::BASIS, "origin", Variant::VECTOR3);


### PR DESCRIPTION
I noticed some useful functions from basis were not in gdscript.

Here's a way to create a basis from a rotation and scale without remembering what order the operations are.
