### PR TITLE
Changed variable name in shader because it was too generic

### DIFF
--- a/servers/visual/rasterizer_rd/shaders/canvas.glsl
+++ b/servers/visual/rasterizer_rd/shaders/canvas.glsl
@@ -439,7 +439,7 @@ FRAGMENT_SHADER_CODE
 		light_base >>= (i & 3) * 8;
 		light_base &= 0xFF;
 
-		vec2 tex_uv = (vec4(vertex, 0.0, 1.0) * mat4(light_array.data[light_base].matrix[0], light_array.data[light_base].matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.
+		vec2 tex_uv = (vec4(vertex, 0.0, 1.0) * mat4(light_array.data[light_base].texture_matrix[0], light_array.data[light_base].texture_matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.
 		vec4 light_color = texture(sampler2D(light_textures[i], texture_sampler), tex_uv);
 		vec4 light_base_color = light_array.data[light_base].color;
 

--- a/servers/visual/rasterizer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/visual/rasterizer_rd/shaders/canvas_uniforms_inc.glsl
@@ -104,7 +104,7 @@ layout(set = 2, binding = 2, std140) uniform SkeletonData {
 #define LIGHT_FLAGS_SHADOW_PCF13 (2 << 22)
 
 struct Light {
-	mat2x4 matrix; //light to texture coordinate matrix (transposed)
+	mat2x4 texture_matrix; //light to texture coordinate matrix (transposed)
 	mat2x4 shadow_matrix; //light to shadow coordinate matrix (transposed)
 	vec4 color;
 	vec4 shadow_color;


### PR DESCRIPTION
`matrix` as a variable name is too generic, and most importantly, it conflicts when trying to transpile the shader to HLSL