### PR TITLE
HTML5: Fix support for Emscripten 1.39.1+

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -82,10 +82,7 @@ def configure(env):
     env['CXX'] = 'em++'
     env['LINK'] = 'emcc'
 
-    # Emscripten's ar has issues with duplicate file names, so use cc.
-    env['AR'] = 'emcc'
-    env['ARFLAGS'] = '-o'
-    # emranlib is a noop, so it's safe to use with AR=emcc.
+    env['AR'] = 'emar'
     env['RANLIB'] = 'emranlib'
 
     # Use TempFileMunge since some AR invocations are too long for cmd.exe.


### PR DESCRIPTION
A change in upstream Emscripten 1.39.1+ made our buildsystem error
out where it was previously only issuing a warning:
```
[  5%] Linking Static Library ==> main/libmain.javascript.opt.bc
shared:WARNING: Assuming object file output in the absence of `-c`, based on output filename. Please add with `-c` or `-r` to avoid this warning
Ranlib Library         ==> main/libmain.javascript.opt.bc
/opt/emsdk/upstream/bin/llvm-ranlib: error: unable to load 'main/libmain.javascript.opt.bc': file too small to be an archive
```

As advised on emscripten-core/emscripten#9806, we should be using
`emar` here to create the static library and not `emcc`.
This was apparently done to workaround Emscripten issues in the past,
but evidently this is no longer necessary.

The rest of the `env` redefinitions should probably be re-assessed
against the current state of Emscripten.

Fixes #33374.