### PR TITLE
Fix Visual Studio throwing C4334 warning.

### DIFF
--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -213,7 +213,7 @@ void WSLPeer::make_context(PeerData *p_data, unsigned int p_in_buf_size, unsigne
 		wslay_event_context_server_init(&(_data->ctx), &wsl_callbacks, _data);
 	else
 		wslay_event_context_client_init(&(_data->ctx), &wsl_callbacks, _data);
-	wslay_event_config_set_max_recv_msg_length(_data->ctx, (1 << p_in_buf_size));
+	wslay_event_config_set_max_recv_msg_length(_data->ctx, (1ULL << p_in_buf_size));
 }
 
 void WSLPeer::set_write_mode(WriteMode p_mode) {


### PR DESCRIPTION
Fixes Visual Studio throwing a C4334 warning: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?) in modules\websocket\wsl_peer.cpp(216).

I assume this is intended, because `wslay_event_config_set_max_recv_msg_length()` is expecting an unsigned long:
https://github.com/godotengine/godot/blob/fea3890e1e994257a27cbf7480d8d4cdb037cfa6/thirdparty/wslay/includes/wslay/wslay.h#L446-L458
Therefore, this patch makes it explicit and stops the warning.