### PR TITLE
Make the replaced results appear in the matches counter

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -277,7 +277,8 @@ void FindReplaceBar::_replace_all() {
 	}
 
 	text_edit->set_v_scroll(vsval);
-	set_error(vformat(TTR("Replaced %d occurrence(s)."), rc));
+	matches_label->add_color_override("font_color", rc > 0 ? get_color("font_color", "Label") : get_color("error_color", "Editor"));
+	matches_label->set_text(vformat(TTR("%d replaced."), rc));
 
 	text_edit->call_deferred("connect", "text_changed", this, "_editor_text_changed");
 	results_count = -1;


### PR DESCRIPTION
Once again, a tight fit, but now the error section is completely free to do only what's supposed to be doing: Showing errors.
![Screenshot_20191115_095019](https://user-images.githubusercontent.com/30739239/68944743-837a0900-07a6-11ea-8c34-0f896b1f0fb3.png)

As this changes a translatable string, I pushed this one to 4.0.