### PR TITLE
Fix HTTP HEAD requests

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -171,6 +171,7 @@ Error HTTPClient::request_raw(Method p_method, const String &p_url, const Vector
 	}
 
 	status = STATUS_REQUESTING;
+	head_request = p_method == METHOD_HEAD;
 
 	return OK;
 }
@@ -226,6 +227,7 @@ Error HTTPClient::request(Method p_method, const String &p_url, const Vector<Str
 	}
 
 	status = STATUS_REQUESTING;
+	head_request = p_method == METHOD_HEAD;
 
 	return OK;
 }
@@ -267,6 +269,7 @@ void HTTPClient::close() {
 
 	connection.unref();
 	status = STATUS_DISCONNECTED;
+	head_request = false;
 	if (resolving != IP::RESOLVER_INVALID_ID) {
 
 		IP::get_singleton()->erase_resolve_item(resolving);
@@ -466,6 +469,12 @@ Error HTTPClient::poll() {
 
 							response_headers.push_back(header);
 						}
+					}
+
+					// This is a HEAD request, we wont receive anything.
+					if (head_request) {
+						body_size = 0;
+						body_left = 0;
 					}
 
 					if (body_size != -1 || chunked) {
@@ -718,6 +727,7 @@ HTTPClient::HTTPClient() {
 	tcp_connection.instance();
 	resolving = IP::RESOLVER_INVALID_ID;
 	status = STATUS_DISCONNECTED;
+	head_request = false;
 	conn_port = -1;
 	body_size = -1;
 	chunked = false;

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -166,6 +166,7 @@ private:
 	bool ssl_verify_host;
 	bool blocking;
 	bool handshaking;
+	bool head_request;
 
 	Vector<uint8_t> response_str;
 


### PR DESCRIPTION
The current implementation of the HTTP client unconditionally waits for the response body to be sent. Therefore when sending a HEAD request, the client always freezes/times out when waiting for the response.
I added a few lines to fix this and make HEAD requests possible.