### PR TITLE
Use the Unicode "multiply" sign for the "A x B" visual script node

### DIFF
--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -949,7 +949,7 @@ String VisualScriptOperator::get_caption() const {
 		//mathematic
 		L"A + B", //OP_ADD,
 		L"A - B", //OP_SUBTRACT,
-		L"A x B", //OP_MULTIPLY,
+		L"A \u00D7 B", //OP_MULTIPLY,
 		L"A \u00F7 B", //OP_DIVIDE,
 		L"\u00AC A", //OP_NEGATE,
 		L"+ A", //OP_POSITIVE,


### PR DESCRIPTION
Based on feedback from Twitter. Note that this doesn't fully clear out possible confusion with the cross product, but `.` isn't ideal either in that regard. That one could be confusing to beginners who don't know what the cross product is :slightly_smiling_face:

## Preview

![A times B](https://user-images.githubusercontent.com/180032/68965289-b5f22900-07db-11ea-8705-73b38e9f5a76.png)