### PR TITLE
Added option to enable high precision float in GLES2

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1134,6 +1134,10 @@
 		<member name="rendering/quality/shading/force_lambert_over_burley.mobile" type="bool" setter="" getter="" default="true">
 			Lower-end override for [member rendering/quality/shading/force_lambert_over_burley] on mobile devices, due to performance concerns or driver support.
 		</member>
+		<member name="rendering/gles2/compatibility/enable_high_float.Android" type="bool" setter="" getter="" default="false">
+			If [code]true[/code] and available on the target device, enables high floating point precision for all shader computations in GLES2.
+			[b]Warning:[/b] High floating point precision can be extremely slow on older devices and is often not available at all. Use with caution.
+		</member>
 		<member name="rendering/quality/shading/force_vertex_shading" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], forces vertex shading for all rendering. This can increase performance a lot, but also reduces quality immensely. Can be used to optimize performance on low-end mobile devices.
 		</member>

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -32,6 +32,7 @@
 
 #include "core/os/memory.h"
 #include "core/print_string.h"
+#include "core/project_settings.h"
 #include "core/string_builder.h"
 #include "rasterizer_gles2.h"
 #include "rasterizer_storage_gles2.h"
@@ -179,6 +180,12 @@ ShaderGLES2::Version *ShaderGLES2::get_current_version() {
 #ifdef JAVASCRIPT_ENABLED
 	strings.push_back("#define USE_HIGHP_PRECISION\n");
 #endif
+
+	if (GLOBAL_GET("rendering/gles2/compatibility/enable_high_float.Android")) {
+		// enable USE_HIGHP_PRECISION but safeguarded by an availability check as highp support is optional in GLES2
+		// see Section 4.5.4 of the GLSL_ES_Specification_1.00
+		strings.push_back("#ifdef GL_FRAGMENT_PRECISION_HIGH\n  #define USE_HIGHP_PRECISION\n#endif\n");
+	}
 
 #endif
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2444,6 +2444,7 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/batching/debug/flash_batching", false);
 	GLOBAL_DEF("rendering/batching/debug/diagnose_frame", false);
 	GLOBAL_DEF("rendering/gles2/compatibility/disable_half_float", false);
+	GLOBAL_DEF("rendering/gles2/compatibility/enable_high_float.Android", false);
 	GLOBAL_DEF("rendering/batching/precision/uv_contract", false);
 	GLOBAL_DEF("rendering/batching/precision/uv_contract_amount", 100);
 


### PR DESCRIPTION
An additional project setting under rendering/shading with the name
gles2_high_float_precision.mobile is introduced that enables #define USE_HIGHP_PRECISION
in GLES2 shader on Android when it is supported by the shader compiler.
This fixes #33633 and #32813 and also https://github.com/GodotVR/godot_oculus_mobile/issues/60
and https://github.com/GodotVR/godot_oculus_mobile/issues/68 on devices that support the highp (high precision) modifier.

@clayjohn suggested on discord to introduce a project setting to solve this problem.

Two open questions from my side are
1. Is it possible to show project settings only if the GLES2 backend is selected? If it is possible would this be desired for this option?
2. At the moment it is only active for Android. I don't know if this is needed for iOS or if it would work there.
