### PR TITLE
Fix HTTPClient::poll crash when connection set to null

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -98,6 +98,8 @@ Error HTTPClient::connect_to_host(const String &p_host, int p_port, bool p_ssl, 
 
 void HTTPClient::set_connection(const Ref<StreamPeer> &p_connection) {
 
+	ERR_FAIL_COND_MSG(p_connection.is_null(), "Connection is not a reference to a valid StreamPeer object.");
+
 	close();
 	connection = p_connection;
 	status = STATUS_CONNECTED;


### PR DESCRIPTION
Fixes #32703

Creating http client with ssl and setting it's connection to null was resulting in crash

Test case:
```gdscript
var client = HTTPClient.new()
client.connect_to_host('godotengine.org', -1, true)
client.set_connection(null)
client.poll()
```
This PR sets http client status to `STATUS_CANT_CONNECT` if null is passed to `HTTPClient::set_connection`
