### PR TITLE
Rename External MSAA to AndroidVR MSAA

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -4255,10 +4255,10 @@
 			Multisample antialiasing is set to 16×.
 		</constant>
 		<constant name="VIEWPORT_MSAA_EXT_2X" value="5" enum="ViewportMSAA">
-			Multisample antialiasing is set to 2× on external texture. Special mode for GLES2 VR for the Oculus Quest.
+			Multisample antialiasing is set to 2× on external texture. Special mode for GLES2 Android VR (Oculus Quest and Go).
 		</constant>
 		<constant name="VIEWPORT_MSAA_EXT_4X" value="6" enum="ViewportMSAA">
-			Multisample antialiasing is set to 4× on external texture. Special mode for GLES2 VR for the Oculus Quest.
+			Multisample antialiasing is set to 4× on external texture. Special mode for GLES2 Android VR (Oculus Quest and Go).
 		</constant>
 		<constant name="VIEWPORT_USAGE_2D" value="0" enum="ViewportUsage">
 			The Viewport does not render 3D but samples.

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2066,7 +2066,7 @@ SceneTree::SceneTree() {
 	int ref_atlas_subdiv = GLOBAL_DEF("rendering/quality/reflections/atlas_subdiv", 8);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/reflections/atlas_subdiv", PropertyInfo(Variant::INT, "rendering/quality/reflections/atlas_subdiv", PROPERTY_HINT_RANGE, "0,32,or_greater")); //next_power_of_2 will return a 0 as min value
 	int msaa_mode = GLOBAL_DEF("rendering/quality/filters/msaa", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/filters/msaa", PropertyInfo(Variant::INT, "rendering/quality/filters/msaa", PROPERTY_HINT_ENUM, "Disabled,2x,4x,8x,16x,External 2x,External 4x"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/filters/msaa", PropertyInfo(Variant::INT, "rendering/quality/filters/msaa", PROPERTY_HINT_ENUM, "Disabled,2x,4x,8x,16x,AndroidVR 2x,AndroidVR 4x"));
 	root->set_msaa(Viewport::MSAA(msaa_mode));
 
 	GLOBAL_DEF("rendering/quality/depth/hdr", true);


### PR DESCRIPTION
A new external MSAA setting was introduced in https://github.com/godotengine/godot/pull/33518
that fixed issues on GLES2 and Oculus Mobile VR. To avoid misunderstanding it was suggested
by @BastiaanOlij and discussed on discord to rename it to AndroidVR.

@BastiaanOlij let me know if I missed sth.