### PR TITLE
Correct `add_callback` for Signal Connection to Prevent Incorrect Number of New Lines

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -325,13 +325,14 @@ void ScriptTextEditor::add_callback(const String &p_function, PackedStringArray 
 	int pos = script->get_language()->find_function(p_function, code);
 	if (pos == -1) {
 		//does not exist
+		const int last_line_with_content = code_editor->get_text_editor()->get_last_line_with_content();
 		code_editor->get_text_editor()->deselect();
-		pos = code_editor->get_text_editor()->get_line_count() + 2;
 		String func = script->get_language()->make_function("", p_function, p_args);
 		//code=code+func;
-		code_editor->get_text_editor()->cursor_set_line(pos + 1);
+		code_editor->get_text_editor()->cursor_set_line(last_line_with_content + 1);
 		code_editor->get_text_editor()->cursor_set_column(1000000); //none shall be that big
 		code_editor->get_text_editor()->insert_text_at_cursor("\n\n" + func);
+		pos = last_line_with_content + 2;
 	}
 	code_editor->get_text_editor()->cursor_set_line(pos);
 	code_editor->get_text_editor()->cursor_set_column(1);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5711,6 +5711,24 @@ bool TextEdit::is_line_comment(int p_line) const {
 	return false;
 }
 
+int TextEdit::get_last_line_with_content() const {
+	const int last_index = get_line_count() - 1;
+
+	// Timeout index used as basic sanity test to prevent unnecessary iteration
+	// for white space at the end of a document. If there's over 50 spaces of
+	// whitespace at the end of the document, we'll stop 50 lines in.
+	const int line_timeout = get_line_count() > 50 ? 50 : get_line_count() - 1;
+	const int last_to_check = last_index - line_timeout;
+
+	for (int i = last_index; i > last_to_check; i--) {
+		if (text[i].length() > 0) {
+			return i;
+		}
+	}
+
+	return last_to_check;
+}
+
 bool TextEdit::can_fold(int p_line) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), false);
 	if (!is_hiding_enabled()) {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -673,6 +673,8 @@ public:
 	int get_indent_level(int p_line) const;
 	bool is_line_comment(int p_line) const;
 
+	int get_last_line_with_content() const;
+
 	inline void set_scroll_pass_end_of_file(bool p_enabled) {
 		scroll_past_end_of_file_enabled = p_enabled;
 		update();


### PR DESCRIPTION
As originally reported by KoBeWi #33287 -- With code end-line behavior added in #29262, it's sometimes possible for the wrong number of new lines to be created depending on the number of new lines at the end of the document. 

Now, it will try to find the last line with valid content and add the appropriate number of spaces according to the GDScript standard (2 new lines between each function.) This should bring more consistency to the user experience. For files with ridiculous amount of whitespace at the end of the document, there's a cutoff of 50 lines. 