### PR TITLE
Fix Visual Studio throwing C4750 warning.

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_gles2.h
@@ -115,9 +115,9 @@ public:
 	virtual void canvas_end();
 
 	_FORCE_INLINE_ void _draw_gui_primitive(int p_points, const Vector2 *p_vertices, const Color *p_colors, const Vector2 *p_uvs);
-	_FORCE_INLINE_ void _draw_polygon(const int *p_indices, int p_index_count, int p_vertex_count, const Vector2 *p_vertices, const Vector2 *p_uvs, const Color *p_colors, bool p_singlecolor, const float *p_weights = nullptr, const int *p_bones = nullptr);
+	void _draw_polygon(const int *p_indices, int p_index_count, int p_vertex_count, const Vector2 *p_vertices, const Vector2 *p_uvs, const Color *p_colors, bool p_singlecolor, const float *p_weights = nullptr, const int *p_bones = nullptr);
 	_FORCE_INLINE_ void _draw_generic(GLuint p_primitive, int p_vertex_count, const Vector2 *p_vertices, const Vector2 *p_uvs, const Color *p_colors, bool p_singlecolor);
-	_FORCE_INLINE_ void _draw_generic_indices(GLuint p_primitive, const int *p_indices, int p_index_count, int p_vertex_count, const Vector2 *p_vertices, const Vector2 *p_uvs, const Color *p_colors, bool p_singlecolor);
+	void _draw_generic_indices(GLuint p_primitive, const int *p_indices, int p_index_count, int p_vertex_count, const Vector2 *p_vertices, const Vector2 *p_uvs, const Color *p_colors, bool p_singlecolor);
 
 	_FORCE_INLINE_ void _canvas_item_render_commands(Item *p_item, Item *current_clip, bool &reclip, RasterizerStorageGLES2::Material *p_material);
 	void _copy_screen(const Rect2 &p_rect);


### PR DESCRIPTION
Fixes Visual Studio throwing C4750 Level 1 warnings at:
- drivers\gles2\rasterizer_canvas_gles2.cpp(930)
- drivers\gles2\rasterizer_canvas_gles2.cpp(951)
- drivers\gles2\rasterizer_canvas_gles2.cpp(1592)
- drivers\gles2\rasterizer_canvas_gles2.cpp(1671)

The `alloca` call inside `_draw_polygon()` allows a variable sized array to be added to the stack:
https://github.com/godotengine/godot/blob/3c831377712ec7b37d8f22739538e6abb3c7741f/drivers/gles2/rasterizer_canvas_gles2.cpp#L346
By inlining `_draw_polygon()`, the `alloca` calls are added to the calling function's stack:
https://github.com/godotengine/godot/blob/3c831377712ec7b37d8f22739538e6abb3c7741f/drivers/gles2/rasterizer_canvas_gles2.h#L118
Therefore, the stack allocation is not released until the calling function returns instead of when `_draw_polygon()` returns.

`_canvas_item_render_commands()` calls the the inlined `_draw_polygon()` in a loop:
https://github.com/godotengine/godot/blob/3c831377712ec7b37d8f22739538e6abb3c7741f/drivers/gles2/rasterizer_canvas_gles2.cpp#L472
Therefore, the `alloca` calls are cumulative, and the compiler is worried that the limited stack size may be exhausted; especially since both the loop size `command_count` and the number of unsigned shorts `p_index_count` requested by `alloca` are variables.

This problem is aggravated, when the calling function `_canvas_item_render_commands()` is also inlined:
https://github.com/godotengine/godot/blob/3c831377712ec7b37d8f22739538e6abb3c7741f/drivers/gles2/rasterizer_canvas_gles2.h#L121
and also called from within a loop:
https://github.com/godotengine/godot/blob/3c831377712ec7b37d8f22739538e6abb3c7741f/drivers/gles2/rasterizer_canvas_gles2.cpp#L1364
and a loop within that loop:
https://github.com/godotengine/godot/blob/3c831377712ec7b37d8f22739538e6abb3c7741f/drivers/gles2/rasterizer_canvas_gles2.cpp#L1603

Note, we cannot simply catch a failed stack memory allocation by checking the value of the pointer returned is not 0 as with `malloc()`. When the stack is exhausted it will throw a stack overflow exception, which is not a C++ exception so it cannot be caught using C++ exception handling.

Therefore, this patch allocates these temporary arrays to the heap instead.