### PR TITLE
Stop Shader Language allowing negation of unsigned DataTypes.

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -1020,7 +1020,7 @@ bool ShaderLanguage::_validate_operator(OperatorNode *p_op, DataType *r_ret_type
 		case OP_POST_DECREMENT:
 		case OP_NEGATE: {
 			DataType na = p_op->arguments[0]->get_datatype();
-			valid = na > TYPE_BOOL && na < TYPE_MAT2;
+			valid = (na > TYPE_BOOL && na < TYPE_UINT) || (na > TYPE_UVEC4 && na < TYPE_MAT2);
 			ret_type = na;
 		} break;
 		case OP_ADD:
@@ -3769,9 +3769,9 @@ ShaderLanguage::Node *ShaderLanguage::_reduce_expression(BlockNode *p_block, Sha
 						nv.sint = -cn->values[i].sint;
 					} break;
 					case TYPE_UINT: {
-						// FIXME: This can't work on uint
-						nv.uint = -cn->values[i].uint;
-					} break;
+						ERR_PRINT("Failed to reduce expression, cannot negate an unsigned integer.");
+						return p_node;
+					}
 					case TYPE_FLOAT: {
 						nv.real = -cn->values[i].real;
 					} break;


### PR DESCRIPTION
Visual Studio is throwing a C4146 warning: unary minus operator applied to unsigned type, result still unsigned at servers\visual\shader_language.cpp(3773).

This patch acknowledges the inability to do so prints an error message and returns the unmodified p_node, the same as in done elsewhere in the function e.g.:
https://github.com/godotengine/godot/blob/3c831377712ec7b37d8f22739538e6abb3c7741f/servers/visual/shader_language.cpp#L3741-L3743