### PR TITLE
StyleBoxFlat doesn't draw content when width or height is zero

### DIFF
--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -694,6 +694,11 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 		return;
 	}
 
+	Rect2 style_rect = p_rect.grow_individual(expand_margin[MARGIN_LEFT], expand_margin[MARGIN_TOP], expand_margin[MARGIN_RIGHT], expand_margin[MARGIN_BOTTOM]);
+	if (Math::is_zero_approx(style_rect.size.width) || Math::is_zero_approx(style_rect.size.height)) {
+		return;
+	}
+
 	bool rounded_corners = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0);
 	bool aa_on = rounded_corners && anti_aliased;
 
@@ -701,7 +706,6 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 	bool blend_on = blend_border && draw_border;
 
-	Rect2 style_rect = p_rect.grow_individual(expand_margin[MARGIN_LEFT], expand_margin[MARGIN_TOP], expand_margin[MARGIN_RIGHT], expand_margin[MARGIN_BOTTOM]);
 	Rect2 border_style_rect = style_rect;
 	if (aa_on && !blend_on) {
 		float aa_size_grow = 0.5 * ((aa_size + 1) / 2);


### PR DESCRIPTION
Causes unnecessary computations and drawing, and a division by zero when calculating uv coordinates.

This case happened with `ScriptEditor`'s member overview (`ItemList`), initialized with a minimum width of 0.

Fixes #33634