### PR TITLE
Re-architecture of the Godot Android plugin.

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1215,9 +1215,6 @@ ProjectSettings::ProjectSettings() {
 	Compression::gzip_level = GLOBAL_DEF("compression/formats/gzip/compression_level", Z_DEFAULT_COMPRESSION);
 	custom_prop_info["compression/formats/gzip/compression_level"] = PropertyInfo(Variant::INT, "compression/formats/gzip/compression_level", PROPERTY_HINT_RANGE, "-1,9,1");
 
-	// Would ideally be defined in an Android-specific file, but then it doesn't appear in the docs
-	GLOBAL_DEF("android/modules", "");
-
 	using_datapack = false;
 }
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -179,9 +179,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="android/modules" type="String" setter="" getter="" default="&quot;&quot;">
-			Comma-separated list of custom Android modules (which must have been built in the Android export templates) using their Java package path, e.g. [code]org/godotengine/org/GodotPaymentV3,org/godotengine/godot/MyCustomSingleton"[/code].
-		</member>
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color( 0.14, 0.14, 0.14, 1 )">
 			Background color for the boot splash.
 		</member>

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -561,13 +561,6 @@ Error ExportTemplateManager::install_android_template() {
 	// Make res://android dir (if it does not exist).
 	da->make_dir("android");
 	{
-		// Add an empty .gdignore file to avoid scan.
-		FileAccessRef f = FileAccess::open("res://android/.gdignore", FileAccess::WRITE);
-		ERR_FAIL_COND_V(!f, ERR_CANT_CREATE);
-		f->store_line("");
-		f->close();
-	}
-	{
 		// Add version, to ensure building won't work if template and Godot version don't match.
 		FileAccessRef f = FileAccess::open("res://android/.build_version", FileAccess::WRITE);
 		ERR_FAIL_COND_V(!f, ERR_CANT_CREATE);
@@ -575,8 +568,19 @@ Error ExportTemplateManager::install_android_template() {
 		f->close();
 	}
 
-	Error err = da->make_dir_recursive("android/build");
+	// Create the android plugins directory.
+	Error err = da->make_dir_recursive("android/plugins");
 	ERR_FAIL_COND_V(err != OK, err);
+
+	err = da->make_dir_recursive("android/build");
+	ERR_FAIL_COND_V(err != OK, err);
+	{
+		// Add an empty .gdignore file to avoid scan.
+		FileAccessRef f = FileAccess::open("res://android/build/.gdignore", FileAccess::WRITE);
+		ERR_FAIL_COND_V(!f, ERR_CANT_CREATE);
+		f->store_line("");
+		f->close();
+	}
 
 	// Uncompress source template.
 

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -20,7 +20,8 @@ android_files = [
     'java_godot_io_wrapper.cpp',
     'jni_utils.cpp',
     'android_keys_utils.cpp',
-    'vulkan/vk_renderer_jni.cpp'
+    'vulkan/vk_renderer_jni.cpp',
+    'plugin/godot_plugin_jni.cpp'
 ]
 
 env_android = env.Clone()

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -6,9 +6,6 @@
     android:versionName="1.0"
     android:installLocation="auto" >
 
-    <!-- Adding custom text to the manifest is fine, but do it outside the custom USER and APPLICATION BEGIN/END comments, -->
-    <!-- as that gets rewritten. -->
-
     <supports-screens
         android:smallScreens="true"
         android:normalScreens="true"
@@ -19,14 +16,11 @@
         android:glEsVersion="0x00020000"
         android:required="true" />
 
-<!-- Custom user permissions XML added by add-ons. It's recommended to add them from the export preset, though. -->
-<!--CHUNK_USER_PERMISSIONS_BEGIN-->
-<!--CHUNK_USER_PERMISSIONS_END-->
-
-    <!-- Any tag in this line after android:icon will be erased when doing custom builds. -->
-    <!-- If you want to add tags manually, do before it. -->
-    <!-- WARNING: This should stay on a single line until the parsing code is improved. See GH-32414. -->
-    <application android:label="@string/godot_project_name_string" android:allowBackup="false" tools:ignore="GoogleAppIndexingWarning" android:icon="@mipmap/icon" >
+    <application
+        android:label="@string/godot_project_name_string"
+        android:allowBackup="false"
+        tools:ignore="GoogleAppIndexingWarning"
+        android:icon="@mipmap/icon" >
 
         <!-- The following metadata values are replaced when Godot exports, modifying them here has no effect. -->
         <!-- Do these changes in the export preset. Adding new ones is fine. -->
@@ -35,6 +29,11 @@
         <meta-data
             android:name="xr_mode_metadata_name"
             android:value="xr_mode_metadata_value" />
+
+        <!-- Metadata populated at export time and used by Godot to figure out which plugins must be enabled. -->
+        <meta-data
+            android:name="custom_template_plugins"
+            android:value="custom_template_plugins_value"/>
 
         <activity
             android:name=".GodotApp"
@@ -51,10 +50,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-<!-- Custom application XML added by add-ons. -->
-<!--CHUNK_APPLICATION_BEGIN-->
-<!--CHUNK_APPLICATION_END-->
 
     </application>
 

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -1,7 +1,4 @@
 // Gradle build config for Godot Engine's Android port.
-//
-// Do not remove/modify comments ending with BEGIN/END, they are used to inject
-// addon-specific configuration.
 apply from: 'config.gradle'
 
 buildscript {
@@ -10,14 +7,10 @@ buildscript {
     repositories {
         google()
         jcenter()
-//CHUNK_BUILDSCRIPT_REPOSITORIES_BEGIN
-//CHUNK_BUILDSCRIPT_REPOSITORIES_END
     }
     dependencies {
         classpath libraries.androidGradlePlugin
         classpath libraries.kotlinGradlePlugin
-//CHUNK_BUILDSCRIPT_DEPENDENCIES_BEGIN
-//CHUNK_BUILDSCRIPT_DEPENDENCIES_END
     }
 }
 
@@ -28,25 +21,35 @@ allprojects {
         mavenCentral()
         google()
         jcenter()
-//CHUNK_ALLPROJECTS_REPOSITORIES_BEGIN
-//CHUNK_ALLPROJECTS_REPOSITORIES_END
     }
 }
 
 dependencies {
     implementation libraries.supportCoreUtils
     implementation libraries.kotlinStdLib
+    implementation libraries.v4Support
 
     if (rootProject.findProject(":lib")) {
         implementation project(":lib")
+    } else if (rootProject.findProject(":godot:lib")) {
+        implementation project(":godot:lib")
     } else {
         // Custom build mode. In this scenario this project is the only one around and the Godot
         // library is available through the pre-generated godot-lib.*.aar android archive files.
         debugImplementation fileTree(dir: 'libs/debug', include: ['*.jar', '*.aar'])
         releaseImplementation fileTree(dir: 'libs/release', include: ['*.jar', '*.aar'])
     }
-//CHUNK_DEPENDENCIES_BEGIN
-//CHUNK_DEPENDENCIES_END
+
+    // Godot prebuilt plugins
+    implementation fileTree(dir: 'libs/plugins', include: ["GodotPayment*.aar"])
+
+    // Godot user plugins dependencies
+    String pluginsDir = getGodotPluginsDirectory()
+    String[] pluginsBinaries = getGodotPluginsBinaries()
+    if (pluginsDir != null && !pluginsDir.isEmpty() &&
+        pluginsBinaries != null && pluginsBinaries.size() > 0) {
+        implementation fileTree(dir: pluginsDir, include: pluginsBinaries)
+    }
 }
 
 android {
@@ -58,8 +61,6 @@ android {
         applicationId getExportPackageName()
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
-//CHUNK_ANDROID_DEFAULTCONFIG_BEGIN
-//CHUNK_ANDROID_DEFAULTCONFIG_END
     }
 
     lintOptions {
@@ -81,37 +82,13 @@ android {
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
-            java.srcDirs = [
-                'src'
-//DIR_SRC_BEGIN
-//DIR_SRC_END
-            ]
-            res.srcDirs = [
-                'res'
-//DIR_RES_BEGIN
-//DIR_RES_END
-            ]
-            aidl.srcDirs = [
-                'aidl'
-//DIR_AIDL_BEGIN
-//DIR_AIDL_END
-            ]
-            assets.srcDirs = [
-                'assets'
-//DIR_ASSETS_BEGIN
-//DIR_ASSETS_END
-            ]
+            java.srcDirs = ['src']
+            res.srcDirs = ['res']
+            aidl.srcDirs = ['aidl']
+            assets.srcDirs = ['assets']
         }
-        debug.jniLibs.srcDirs = [
-            'libs/debug'
-//DIR_JNI_DEBUG_BEGIN
-//DIR_JNI_DEBUG_END
-        ]
-        release.jniLibs.srcDirs = [
-            'libs/release'
-//DIR_JNI_RELEASE_BEGIN
-//DIR_JNI_RELEASE_END
-        ]
+        debug.jniLibs.srcDirs = ['libs/debug']
+        release.jniLibs.srcDirs = ['libs/release']
     }
 
     applicationVariants.all { variant ->
@@ -120,6 +97,3 @@ android {
         }
     }
 }
-
-//CHUNK_GLOBAL_BEGIN
-//CHUNK_GLOBAL_END

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -5,7 +5,8 @@ ext.versions = [
     targetSdk          : 29,
     buildTools         : '29.0.1',
     supportCoreUtils   : '28.0.0',
-    kotlinVersion      : '1.3.61'
+    kotlinVersion      : '1.3.61',
+    v4Support          : '28.0.0'
 
 ]
 
@@ -13,7 +14,8 @@ ext.libraries = [
     androidGradlePlugin: "com.android.tools.build:gradle:$versions.androidGradlePlugin",
     supportCoreUtils   : "com.android.support:support-core-utils:$versions.supportCoreUtils",
     kotlinGradlePlugin : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinVersion",
-    kotlinStdLib       : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlinVersion"
+    kotlinStdLib       : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlinVersion",
+    v4Support          : "com.android.support:support-v4:$versions.v4Support"
 ]
 
 ext.getExportPackageName = { ->
@@ -24,4 +26,41 @@ ext.getExportPackageName = { ->
         appId = "com.godot.game"
     }
     return appId
+}
+
+/**
+ * Parse the project properties for the 'custom_template_plugins' property and return
+ * their binaries for inclusion in the build dependencies.
+ *
+ * The listed plugins must have their binaries in the project plugins directory.
+ */
+ext.getGodotPluginsBinaries = { ->
+    String[] binDeps = []
+
+    // Retrieve the list of enabled plugins.
+    if (project.hasProperty("custom_template_plugins")) {
+        String pluginsList = project.property("custom_template_plugins")
+        if (pluginsList != null && !pluginsList.trim().isEmpty()) {
+            for (String plugin : pluginsList.split(",")) {
+                binDeps += plugin + "*.aar"
+            }
+        }
+    }
+
+    return binDeps
+}
+
+/**
+ * Parse the project properties for the 'custom_template_plugins_dir' property and return
+ * its value.
+ *
+ * The returned value is the directory containing user plugins.
+ */
+ext.getGodotPluginsDirectory = { ->
+    // The plugins directory is provided by the 'custom_template_plugins_dir' property.
+    String pluginsDir = project.hasProperty("custom_template_plugins_dir")
+        ? project.property("custom_template_plugins_dir")
+        : ""
+
+    return pluginsDir
 }

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -65,10 +65,10 @@ task copyReleaseBinaryToBin(type: Copy) {
 }
 
 /**
- * Copy the Godot android library archive debug file into the app debug libs directory.
+ * Copy the Godot android library archive debug file into the app module debug libs directory.
  * Depends on the library build task to ensure the AAR file is generated prior to copying.
  */
-task copyDebugAAR(type: Copy) {
+task copyDebugAARToAppModule(type: Copy) {
     dependsOn ':lib:assembleDebug'
     from('lib/build/outputs/aar')
     into('app/libs/debug')
@@ -76,13 +76,42 @@ task copyDebugAAR(type: Copy) {
 }
 
 /**
- * Copy the Godot android library archive release file into the app release libs directory.
+ * Copy the Godot android library archive debug file into the root bin directory.
  * Depends on the library build task to ensure the AAR file is generated prior to copying.
  */
-task copyReleaseAAR(type: Copy) {
+task copyDebugAARToBin(type: Copy) {
+    dependsOn ':lib:assembleDebug'
+    from('lib/build/outputs/aar')
+    into(binDir)
+    include('godot-lib.debug.aar')
+}
+
+/**
+ * Copy the Godot android library archive release file into the app module release libs directory.
+ * Depends on the library build task to ensure the AAR file is generated prior to copying.
+ */
+task copyReleaseAARToAppModule(type: Copy) {
     dependsOn ':lib:assembleRelease'
     from('lib/build/outputs/aar')
     into('app/libs/release')
+    include('godot-lib.release.aar')
+}
+
+task copyGodotPaymentPluginToAppModule(type: Copy) {
+    dependsOn ':plugins:godotpayment:assembleRelease'
+    from('plugins/godotpayment/build/outputs/aar')
+    into('app/libs/plugins')
+    include('GodotPayment.release.aar')
+}
+
+/**
+ * Copy the Godot android library archive release file into the root bin directory.
+ * Depends on the library build task to ensure the AAR file is generated prior to copying.
+ */
+task copyReleaseAARToBin(type: Copy) {
+    dependsOn ':lib:assembleRelease'
+    from('lib/build/outputs/aar')
+    into(binDir)
     include('godot-lib.release.aar')
 }
 
@@ -111,19 +140,24 @@ task generateGodotTemplates(type: GradleBuild) {
         startParameter.excludedTaskNames += ":lib:" + getSconsTaskName(buildType)
     }
 
-    tasks = []
+    tasks = ["copyGodotPaymentPluginToAppModule"]
 
     // Only build the apks and aar files for which we have native shared libraries.
     for (String target : supportedTargets.keySet()) {
         File targetLibs = new File("lib/libs/" + target)
-        if (targetLibs != null && targetLibs.isDirectory()) {
-            File[] targetLibsContents = targetLibs.listFiles()
-            if (targetLibsContents != null && targetLibsContents.length > 0) {
-                // Copy the generated aar library files to the custom build directory.
-                tasks += "copy" + target.capitalize() + "AAR"
-                // Copy the prebuilt binary templates to the bin directory.
-                tasks += "copy" + target.capitalize() + "BinaryToBin"
-            }
+        if (targetLibs != null
+            && targetLibs.isDirectory()
+            && targetLibs.listFiles() != null
+            && targetLibs.listFiles().length > 0) {
+            String capitalizedTarget = target.capitalize()
+            // Copy the generated aar library files to the custom build directory.
+            tasks += "copy" + capitalizedTarget + "AARToAppModule"
+            // Copy the generated aar library files to the bin directory.
+            tasks += "copy" + capitalizedTarget + "AARToBin"
+            // Copy the prebuilt binary templates to the bin directory.
+            tasks += "copy" + capitalizedTarget + "BinaryToBin"
+        } else {
+            logger.lifecycle("No native shared libs for target $target. Skipping build.")
         }
     }
 
@@ -140,6 +174,12 @@ task cleanGodotTemplates(type: Delete) {
     // Delete the library generated AAR files
     delete("lib/build/outputs/aar")
 
+    // Delete the godotpayment libs directory contents
+    delete("plugins/godotpayment/libs")
+
+    // Delete the generated godotpayment aar
+    delete("plugins/godotpayment/build/outputs/aar")
+
     // Delete the app libs directory contents
     delete("app/libs")
 
@@ -150,4 +190,6 @@ task cleanGodotTemplates(type: Delete) {
     delete("$binDir/android_debug.apk")
     delete("$binDir/android_release.apk")
     delete("$binDir/android_source.zip")
+    delete("$binDir/godot-lib.debug.aar")
+    delete("$binDir/godot-lib.release.aar")
 }

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation libraries.supportCoreUtils
     implementation libraries.kotlinStdLib
+    implementation libraries.v4Support
 }
 
 def pathToRootDir = "../../../../"

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
@@ -176,22 +176,6 @@ public class GodotLib {
 	public static native void audio();
 
 	/**
-	 * Used to setup a {@link org.godotengine.godot.Godot.SingletonBase} instance.
-	 * @param p_name Name of the instance.
-	 * @param p_object Reference to the singleton instance.
-	 */
-	public static native void singleton(String p_name, Object p_object);
-
-	/**
-	 * Used to complete registration of the {@link org.godotengine.godot.Godot.SingletonBase} instance's methods.
-	 * @param p_sname Name of the instance
-	 * @param p_name Name of the method to register
-	 * @param p_ret Return type of the registered method
-	 * @param p_params Method parameters types
-	 */
-	public static native void method(String p_sname, String p_name, String p_ret, String[] p_params);
-
-	/**
 	 * Used to access Godot global properties.
 	 * @param p_key Property key
 	 * @return String value of the property

--- a/platform/android/java/lib/src/org/godotengine/godot/payments/GodotPaymentInterface.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/payments/GodotPaymentInterface.java
@@ -1,12 +1,12 @@
 /*************************************************************************/
-/*  GodotRenderer.java                                                   */
+/*  GodotPaymentInterface.java                                           */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
 /*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */
@@ -28,61 +28,70 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-package org.godotengine.godot;
+package org.godotengine.godot.payments;
 
-import android.content.Context;
-import android.opengl.GLSurfaceView;
-import javax.microedition.khronos.egl.EGLConfig;
-import javax.microedition.khronos.opengles.GL10;
-import org.godotengine.godot.plugin.GodotPlugin;
-import org.godotengine.godot.plugin.GodotPluginRegistry;
-import org.godotengine.godot.utils.GLUtils;
+public interface GodotPaymentInterface {
+	void purchase(String sku, String transactionId);
 
-/**
- * Godot's renderer implementation.
- */
-class GodotRenderer implements GLSurfaceView.Renderer {
+	void consumeUnconsumedPurchases();
 
-	private final GodotPluginRegistry pluginRegistry;
-	private boolean activityJustResumed = false;
+	String getSignature();
 
-	GodotRenderer() {
-		this.pluginRegistry = GodotPluginRegistry.getPluginRegistry();
-	}
+	void callbackSuccess(String ticket, String signature, String sku);
 
-	public void onDrawFrame(GL10 gl) {
-		if (activityJustResumed) {
-			GodotLib.onRendererResumed();
-			activityJustResumed = false;
-		}
+	void callbackSuccessProductMassConsumed(String ticket, String signature, String sku);
 
-		GodotLib.step();
-		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
-			plugin.onGLDrawFrame(gl);
-		}
-	}
+	void callbackSuccessNoUnconsumedPurchases();
 
-	public void onSurfaceChanged(GL10 gl, int width, int height) {
-		GodotLib.resize(width, height);
-		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
-			plugin.onGLSurfaceChanged(gl, width, height);
-		}
-	}
+	void callbackFailConsume(String message);
 
-	public void onSurfaceCreated(GL10 gl, EGLConfig config) {
-		GodotLib.newcontext(GLUtils.use_32);
-		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
-			plugin.onGLSurfaceCreated(gl, config);
-		}
-	}
+	void callbackFail(String message);
 
-	void onActivityResumed() {
-		// We defer invoking GodotLib.onRendererResumed() until the first draw frame call.
-		// This ensures we have a valid GL context and surface when we do so.
-		activityJustResumed = true;
-	}
+	void callbackCancel();
 
-	void onActivityPaused() {
-		GodotLib.onRendererPaused();
-	}
+	void callbackAlreadyOwned(String sku);
+
+	int getPurchaseCallbackId();
+
+	void setPurchaseCallbackId(int purchaseCallbackId);
+
+	String getPurchaseValidationUrlPrefix();
+
+	void setPurchaseValidationUrlPrefix(String url);
+
+	String getAccessToken();
+
+	void setAccessToken(String accessToken);
+
+	void setTransactionId(String transactionId);
+
+	String getTransactionId();
+
+	// request purchased items are not consumed
+	void requestPurchased();
+
+	// callback for requestPurchased()
+	void callbackPurchased(String receipt, String signature, String sku);
+
+	void callbackDisconnected();
+
+	void callbackConnected();
+
+	// true if connected, false otherwise
+	boolean isConnected();
+
+	// consume item automatically after purchase. default is true.
+	void setAutoConsume(boolean autoConsume);
+
+	// consume a specific item
+	void consume(String sku);
+
+	// query in app item detail info
+	void querySkuDetails(String[] list);
+
+	void addSkuDetail(String itemJson);
+
+	void completeSkuDetail();
+
+	void errorSkuDetail(String errorMessage);
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/payments/PaymentsManager.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/payments/PaymentsManager.java
@@ -43,7 +43,6 @@ import android.util.Log;
 import com.android.vending.billing.IInAppBillingService;
 import java.util.ArrayList;
 import java.util.Arrays;
-import org.godotengine.godot.GodotPaymentV3;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -90,9 +89,9 @@ public class PaymentsManager {
 		public void onServiceDisconnected(ComponentName name) {
 			mService = null;
 
-			// At this stage, godotPaymentV3 might not have been initialized yet.
-			if (godotPaymentV3 != null) {
-				godotPaymentV3.callbackDisconnected();
+			// At this stage, godotPayment might not have been initialized yet.
+			if (godotPayment != null) {
+				godotPayment.callbackDisconnected();
 			}
 		}
 
@@ -100,9 +99,9 @@ public class PaymentsManager {
 		public void onServiceConnected(ComponentName name, IBinder service) {
 			mService = IInAppBillingService.Stub.asInterface(service);
 
-			// At this stage, godotPaymentV3 might not have been initialized yet.
-			if (godotPaymentV3 != null) {
-				godotPaymentV3.callbackConnected();
+			// At this stage, godotPayment might not have been initialized yet.
+			if (godotPayment != null) {
+				godotPayment.callbackConnected();
 			}
 		}
 	};
@@ -111,17 +110,17 @@ public class PaymentsManager {
 		new PurchaseTask(mService, activity) {
 			@Override
 			protected void error(String message) {
-				godotPaymentV3.callbackFail(message);
+				godotPayment.callbackFail(message);
 			}
 
 			@Override
 			protected void canceled() {
-				godotPaymentV3.callbackCancel();
+				godotPayment.callbackCancel();
 			}
 
 			@Override
 			protected void alreadyOwned() {
-				godotPaymentV3.callbackAlreadyOwned(sku);
+				godotPayment.callbackAlreadyOwned(sku);
 			}
 		}
 				.purchase(sku, transactionId);
@@ -135,19 +134,19 @@ public class PaymentsManager {
 		new ReleaseAllConsumablesTask(mService, activity) {
 			@Override
 			protected void success(String sku, String receipt, String signature, String token) {
-				godotPaymentV3.callbackSuccessProductMassConsumed(receipt, signature, sku);
+				godotPayment.callbackSuccessProductMassConsumed(receipt, signature, sku);
 			}
 
 			@Override
 			protected void error(String message) {
 				Log.d("godot", "consumeUnconsumedPurchases :" + message);
-				godotPaymentV3.callbackFailConsume(message);
+				godotPayment.callbackFailConsume(message);
 			}
 
 			@Override
 			protected void notRequired() {
 				Log.d("godot", "callbackSuccessNoUnconsumedPurchases :");
-				godotPaymentV3.callbackSuccessNoUnconsumedPurchases();
+				godotPayment.callbackSuccessNoUnconsumedPurchases();
 			}
 		}
 				.consumeItAll();
@@ -168,7 +167,7 @@ public class PaymentsManager {
 					final ArrayList<String> mySignatures = bundle.getStringArrayList("INAPP_DATA_SIGNATURE_LIST");
 
 					if (myPurchases == null || myPurchases.size() == 0) {
-						godotPaymentV3.callbackPurchased("", "", "");
+						godotPayment.callbackPurchased("", "", "");
 						return;
 					}
 
@@ -186,7 +185,7 @@ public class PaymentsManager {
 							pc.setConsumableFlag("block", sku, true);
 							pc.setConsumableValue("token", sku, token);
 
-							godotPaymentV3.callbackPurchased(receipt, signature, sku);
+							godotPayment.callbackPurchased(receipt, signature, sku);
 						} catch (JSONException e) {
 						}
 					}
@@ -203,7 +202,7 @@ public class PaymentsManager {
 		new HandlePurchaseTask(activity) {
 			@Override
 			protected void success(final String sku, final String signature, final String ticket) {
-				godotPaymentV3.callbackSuccess(ticket, signature, sku);
+				godotPayment.callbackSuccess(ticket, signature, sku);
 
 				if (auto_consume) {
 					new ConsumeTask(mService, activity) {
@@ -213,7 +212,7 @@ public class PaymentsManager {
 
 						@Override
 						protected void error(String message) {
-							godotPaymentV3.callbackFail(message);
+							godotPayment.callbackFail(message);
 						}
 					}
 							.consume(sku);
@@ -222,12 +221,12 @@ public class PaymentsManager {
 
 			@Override
 			protected void error(String message) {
-				godotPaymentV3.callbackFail(message);
+				godotPayment.callbackFail(message);
 			}
 
 			@Override
 			protected void canceled() {
-				godotPaymentV3.callbackCancel();
+				godotPayment.callbackCancel();
 			}
 		}
 				.handlePurchaseRequest(resultCode, data);
@@ -235,19 +234,19 @@ public class PaymentsManager {
 
 	public void validatePurchase(String purchaseToken, final String sku) {
 
-		new ValidateTask(activity, godotPaymentV3) {
+		new ValidateTask(activity, godotPayment) {
 			@Override
 			protected void success() {
 
 				new ConsumeTask(mService, activity) {
 					@Override
 					protected void success(String ticket) {
-						godotPaymentV3.callbackSuccess(ticket, null, sku);
+						godotPayment.callbackSuccess(ticket, null, sku);
 					}
 
 					@Override
 					protected void error(String message) {
-						godotPaymentV3.callbackFail(message);
+						godotPayment.callbackFail(message);
 					}
 				}
 						.consume(sku);
@@ -255,12 +254,12 @@ public class PaymentsManager {
 
 			@Override
 			protected void error(String message) {
-				godotPaymentV3.callbackFail(message);
+				godotPayment.callbackFail(message);
 			}
 
 			@Override
 			protected void canceled() {
-				godotPaymentV3.callbackCancel();
+				godotPayment.callbackCancel();
 			}
 		}
 				.validatePurchase(sku);
@@ -274,12 +273,12 @@ public class PaymentsManager {
 		new ConsumeTask(mService, activity) {
 			@Override
 			protected void success(String ticket) {
-				godotPaymentV3.callbackSuccessProductMassConsumed(ticket, "", sku);
+				godotPayment.callbackSuccessProductMassConsumed(ticket, "", sku);
 			}
 
 			@Override
 			protected void error(String message) {
-				godotPaymentV3.callbackFailConsume(message);
+				godotPayment.callbackFailConsume(message);
 			}
 		}
 				.consume(sku);
@@ -387,9 +386,9 @@ public class PaymentsManager {
 						if (!skuDetails.containsKey("DETAILS_LIST")) {
 							int response = getResponseCodeFromBundle(skuDetails);
 							if (response != BILLING_RESPONSE_RESULT_OK) {
-								godotPaymentV3.errorSkuDetail(getResponseDesc(response));
+								godotPayment.errorSkuDetail(getResponseDesc(response));
 							} else {
-								godotPaymentV3.errorSkuDetail("No error but no detail list.");
+								godotPayment.errorSkuDetail("No error but no detail list.");
 							}
 							return;
 						}
@@ -398,22 +397,22 @@ public class PaymentsManager {
 
 						for (String thisResponse : responseList) {
 							Log.d("godot", "response = " + thisResponse);
-							godotPaymentV3.addSkuDetail(thisResponse);
+							godotPayment.addSkuDetail(thisResponse);
 						}
 					} catch (RemoteException e) {
 						e.printStackTrace();
-						godotPaymentV3.errorSkuDetail("RemoteException error!");
+						godotPayment.errorSkuDetail("RemoteException error!");
 					}
 				}
-				godotPaymentV3.completeSkuDetail();
+				godotPayment.completeSkuDetail();
 			}
 		}))
 				.start();
 	}
 
-	private GodotPaymentV3 godotPaymentV3;
+	private GodotPaymentInterface godotPayment;
 
-	public void setBaseSingleton(GodotPaymentV3 godotPaymentV3) {
-		this.godotPaymentV3 = godotPaymentV3;
+	public void setBaseSingleton(GodotPaymentInterface godotPaymentInterface) {
+		this.godotPayment = godotPaymentInterface;
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/payments/ValidateTask.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/payments/ValidateTask.java
@@ -34,7 +34,6 @@ import android.app.Activity;
 import android.app.ProgressDialog;
 import android.os.AsyncTask;
 import java.lang.ref.WeakReference;
-import org.godotengine.godot.GodotPaymentV3;
 import org.godotengine.godot.utils.HttpRequester;
 import org.godotengine.godot.utils.RequestParams;
 import org.json.JSONException;
@@ -43,7 +42,7 @@ import org.json.JSONObject;
 abstract public class ValidateTask {
 
 	private Activity context;
-	private GodotPaymentV3 godotPaymentsV3;
+	private GodotPaymentInterface godotPayments;
 	private ProgressDialog dialog;
 	private String mSku;
 
@@ -80,9 +79,9 @@ abstract public class ValidateTask {
 		}
 	}
 
-	public ValidateTask(Activity context, GodotPaymentV3 godotPaymentsV3) {
+	public ValidateTask(Activity context, GodotPaymentInterface godotPayments) {
 		this.context = context;
-		this.godotPaymentsV3 = godotPaymentsV3;
+		this.godotPayments = godotPayments;
 	}
 
 	public void validatePurchase(final String sku) {
@@ -96,7 +95,7 @@ abstract public class ValidateTask {
 
 	private String doInBackground(String... params) {
 		PaymentsCache pc = new PaymentsCache(context);
-		String url = godotPaymentsV3.getPurchaseValidationUrlPrefix();
+		String url = godotPayments.getPurchaseValidationUrlPrefix();
 		RequestParams param = new RequestParams();
 		param.setUrl(url);
 		param.put("ticket", pc.getConsumableValue("ticket", mSku));

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
@@ -1,0 +1,256 @@
+/*************************************************************************/
+/*  GodotPlugin.java                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+package org.godotengine.godot.plugin;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.View;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
+import org.godotengine.godot.Godot;
+
+/**
+ * Base class for the Godot Android plugins.
+ * <p>
+ * A Godot Android plugin is a regular Android library packaged as an aar archive file with the following caveats:
+ * <p>
+ * - The library must have a dependency on the Godot Android library (godot-lib.aar).
+ * A stable version is available for each release.
+ * <p>
+ * - The library must include a <meta-data> tag in its manifest file setup as follow:
+ * <meta-data android:name="org.godotengine.plugin.v1.[PluginName]" android:value="[plugin.init.ClassFullName]" />
+ * Where:
+ * - 'PluginName' is the name of the plugin.
+ * - 'plugin.init.ClassFullName' is the full name (package + class name) of the plugin class
+ * extending {@link GodotPlugin}.
+ *
+ * A plugin can also define and provide c/c++ gdnative libraries and nativescripts for the target
+ * app/game to leverage.
+ * The shared library for the gdnative library will be automatically bundled by the aar build
+ * system.
+ * Godot '*.gdnlib' and '*.gdns' resource files must however be manually defined in the project
+ * 'assets' directory. The recommended path for these resources in the 'assets' directory should be:
+ * 'godot/plugin/v1/[PluginName]/'
+ */
+public abstract class GodotPlugin {
+
+	private final Godot godot;
+
+	public GodotPlugin(Godot godot) {
+		this.godot = godot;
+	}
+
+	/**
+	 * Provides access to the Godot engine.
+	 */
+	protected Godot getGodot() {
+		return godot;
+	}
+
+	/**
+	 * Register the plugin with Godot native code.
+	 */
+	public final void onGLRegisterPluginWithGodotNative() {
+		nativeRegisterSingleton(getPluginName());
+
+		Class clazz = getClass();
+		Method[] methods = clazz.getDeclaredMethods();
+		for (Method method : methods) {
+			boolean found = false;
+
+			for (String s : getPluginMethods()) {
+				if (s.equals(method.getName())) {
+					found = true;
+					break;
+				}
+			}
+			if (!found)
+				continue;
+
+			List<String> ptr = new ArrayList<String>();
+
+			Class[] paramTypes = method.getParameterTypes();
+			for (Class c : paramTypes) {
+				ptr.add(c.getName());
+			}
+
+			String[] pt = new String[ptr.size()];
+			ptr.toArray(pt);
+
+			nativeRegisterMethod(getPluginName(), method.getName(), method.getReturnType().getName(), pt);
+		}
+
+		// Get the list of gdnative libraries to register.
+		Set<String> gdnativeLibrariesPaths = getPluginGDNativeLibrariesPaths();
+		if (!gdnativeLibrariesPaths.isEmpty()) {
+			nativeRegisterGDNativeLibraries(gdnativeLibrariesPaths.toArray(new String[0]));
+		}
+	}
+
+	/**
+	 * Invoked once during the Godot Android initialization process after creation of the
+	 * {@link org.godotengine.godot.GodotView} view.
+	 * <p>
+	 * This method should be overridden by descendants of this class that would like to add
+	 * their view/layout to the Godot view hierarchy.
+	 *
+	 * @return the view to be included; null if no views should be included.
+	 */
+	@Nullable
+	public View onMainCreateView(Activity activity) {
+		return null;
+	}
+
+	/**
+	 * @see Activity#onActivityResult(int, int, Intent)
+	 */
+	public void onMainActivityResult(int requestCode, int resultCode, Intent data) {
+	}
+
+	/**
+	 * @see Activity#onRequestPermissionsResult(int, String[], int[])
+	 */
+	public void onMainRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+	}
+
+	/**
+	 * @see Activity#onPause()
+	 */
+	public void onMainPause() {}
+
+	/**
+	 * @see Activity#onResume()
+	 */
+	public void onMainResume() {}
+
+	/**
+	 * @see Activity#onDestroy()
+	 */
+	public void onMainDestroy() {}
+
+	/**
+	 * @see Activity#onBackPressed()
+	 */
+	public boolean onMainBackPressed() { return false; }
+
+	/**
+	 * Invoked on the GL thread when the Godot main loop has started.
+	 */
+	public void onGLGodotMainLoopStarted() {}
+
+	/**
+	 * Invoked once per frame on the GL thread after the frame is drawn.
+	 */
+	public void onGLDrawFrame(GL10 gl) {}
+
+	/**
+	 * Called on the GL thread after the surface is created and whenever the OpenGL ES surface size
+	 * changes.
+	 */
+	public void onGLSurfaceChanged(GL10 gl, int width, int height) {}
+
+	/**
+	 * Called on the GL thread when the surface is created or recreated.
+	 */
+	public void onGLSurfaceCreated(GL10 gl, EGLConfig config) {}
+
+	/**
+	 * Returns the name of the plugin.
+	 * <p>
+	 * This value must match the one listed in the plugin '<meta-data>' manifest entry.
+	 */
+	@NonNull
+	public abstract String getPluginName();
+
+	/**
+	 * Returns the list of methods to be exposed to Godot.
+	 */
+	@NonNull
+	public abstract List<String> getPluginMethods();
+
+	/**
+	 * Returns the paths for the plugin's gdnative libraries.
+	 *
+	 * The paths must be relative to the 'assets' directory and point to a '*.gdnlib' file.
+	 */
+	@NonNull
+	protected Set<String> getPluginGDNativeLibrariesPaths() {
+		return Collections.emptySet();
+	}
+
+	/**
+	 * Runs the specified action on the UI thread. If the current thread is the UI
+	 * thread, then the action is executed immediately. If the current thread is
+	 * not the UI thread, the action is posted to the event queue of the UI thread.
+	 *
+	 * @param action the action to run on the UI thread
+	 */
+	protected void runOnUiThread(Runnable action) {
+		godot.runOnUiThread(action);
+	}
+
+	/**
+	 * Queue the specified action to be run on the GL thread.
+	 *
+	 * @param action the action to run on the GL thread
+	 */
+	protected void runOnGLThread(Runnable action) {
+		godot.runOnGLThread(action);
+	}
+
+	/**
+	 * Used to setup a {@link GodotPlugin} instance.
+	 * @param p_name Name of the instance.
+	 */
+	private native void nativeRegisterSingleton(String p_name);
+
+	/**
+	 * Used to complete registration of the {@link GodotPlugin} instance's methods.
+	 * @param p_sname Name of the instance
+	 * @param p_name Name of the method to register
+	 * @param p_ret Return type of the registered method
+	 * @param p_params Method parameters types
+	 */
+	private native void nativeRegisterMethod(String p_sname, String p_name, String p_ret, String[] p_params);
+
+	/**
+	 * Used to register gdnative libraries bundled by the plugin.
+	 * @param gdnlibPaths Paths to the libraries relative to the 'assets' directory.
+	 */
+	private native void nativeRegisterGDNativeLibraries(String[] gdnlibPaths);
+}

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPluginRegistry.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPluginRegistry.java
@@ -1,0 +1,196 @@
+/*************************************************************************/
+/*  GodotPluginRegistry.java                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+package org.godotengine.godot.plugin;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+import android.util.Log;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.godotengine.godot.Godot;
+
+/**
+ * Registry used to load and access the registered Godot Android plugins.
+ */
+public final class GodotPluginRegistry {
+
+	private static final String TAG = GodotPluginRegistry.class.getSimpleName();
+
+	private static final String GODOT_PLUGIN_V1_NAME_PREFIX = "org.godotengine.plugin.v1.";
+
+	/**
+	 * Name for the metadata containing the list of Godot plugins to enable.
+	 */
+	private static final String GODOT_ENABLED_PLUGINS_LABEL = "custom_template_plugins";
+
+	private static GodotPluginRegistry instance;
+	private final ConcurrentHashMap<String, GodotPlugin> registry;
+
+	private GodotPluginRegistry(Godot godot) {
+		registry = new ConcurrentHashMap<>();
+		loadPlugins(godot);
+	}
+
+	/**
+	 * Retrieve the plugin tied to the given plugin name.
+	 * @param pluginName Name of the plugin
+	 * @return {@link GodotPlugin} handle if it exists, null otherwise.
+	 */
+	@Nullable
+	public GodotPlugin getPlugin(String pluginName) {
+		return registry.get(pluginName);
+	}
+
+	/**
+	 * Retrieve the full set of loaded plugins.
+	 */
+	public Collection<GodotPlugin> getAllPlugins() {
+		return registry.values();
+	}
+
+	/**
+	 * Parse the manifest file and load all included Godot Android plugins.
+	 * <p>
+	 * A plugin manifest entry is a '<meta-data>' tag setup as described in the {@link GodotPlugin}
+	 * documentation.
+	 *
+	 * @param godot Godot instance
+	 * @return A singleton instance of {@link GodotPluginRegistry}. This ensures that only one instance
+	 * of each Godot Android plugins is available at runtime.
+	 */
+	public static GodotPluginRegistry initializePluginRegistry(Godot godot) {
+		if (instance == null) {
+			instance = new GodotPluginRegistry(godot);
+		}
+
+		return instance;
+	}
+
+	/**
+	 * Return the plugin registry if it's initialized.
+	 * Throws a {@link IllegalStateException} exception if not.
+	 *
+	 * @throws IllegalStateException if {@link GodotPluginRegistry#initializePluginRegistry(Godot)} has not been called prior to calling this method.
+	 */
+	public static GodotPluginRegistry getPluginRegistry() throws IllegalStateException {
+		if (instance == null) {
+			throw new IllegalStateException("Plugin registry hasn't been initialized.");
+		}
+
+		return instance;
+	}
+
+	private void loadPlugins(Godot godot) {
+		try {
+			ApplicationInfo appInfo = godot
+											  .getPackageManager()
+											  .getApplicationInfo(godot.getPackageName(), PackageManager.GET_META_DATA);
+			Bundle metaData = appInfo.metaData;
+			if (metaData == null || metaData.isEmpty()) {
+				return;
+			}
+
+			// When using the Godot editor for building and exporting the apk, this is used to check
+			// which plugins to enable since the custom build template may contain prebuilt plugins.
+			// When using a custom process to generate the apk, the metadata is not needed since
+			// it's assumed that the developer is aware of the dependencies included in the apk.
+			final Set<String> enabledPluginsSet;
+			if (metaData.containsKey(GODOT_ENABLED_PLUGINS_LABEL)) {
+				String enabledPlugins = metaData.getString(GODOT_ENABLED_PLUGINS_LABEL, "");
+				String[] enabledPluginsList = enabledPlugins.split(",");
+				if (enabledPluginsList.length == 0) {
+					// No plugins to enable. Aborting early.
+					return;
+				}
+
+				enabledPluginsSet = new HashSet<>(Arrays.asList(enabledPluginsList));
+			} else {
+				enabledPluginsSet = null;
+			}
+
+			int godotPluginV1NamePrefixLength = GODOT_PLUGIN_V1_NAME_PREFIX.length();
+			for (String metaDataName : metaData.keySet()) {
+				// Parse the meta-data looking for entry with the Godot plugin name prefix.
+				if (metaDataName.startsWith(GODOT_PLUGIN_V1_NAME_PREFIX)) {
+					String pluginName = metaDataName.substring(godotPluginV1NamePrefixLength);
+					if (enabledPluginsSet != null && !enabledPluginsSet.contains(pluginName)) {
+						Log.w(TAG, "Plugin " + pluginName + " is listed in the dependencies but is not enabled.");
+						continue;
+					}
+
+					// Retrieve the plugin class full name.
+					String pluginHandleClassFullName = metaData.getString(metaDataName);
+					if (!TextUtils.isEmpty(pluginHandleClassFullName)) {
+						try {
+							// Attempt to create the plugin init class via reflection.
+							@SuppressWarnings("unchecked")
+							Class<GodotPlugin> pluginClass = (Class<GodotPlugin>)Class
+																	 .forName(pluginHandleClassFullName);
+							Constructor<GodotPlugin> pluginConstructor = pluginClass
+																				 .getConstructor(Godot.class);
+							GodotPlugin pluginHandle = pluginConstructor.newInstance(godot);
+
+							// Load the plugin initializer into the registry using the plugin name
+							// as key.
+							if (!pluginName.equals(pluginHandle.getPluginName())) {
+								Log.w(TAG,
+										"Meta-data plugin name does not match the value returned by the plugin handle: " + pluginName + " =/= " + pluginHandle.getPluginName());
+							}
+							registry.put(pluginName, pluginHandle);
+						} catch (ClassNotFoundException e) {
+							Log.w(TAG, "Unable to load Godot plugin " + pluginName, e);
+						} catch (IllegalAccessException e) {
+							Log.w(TAG, "Unable to load Godot plugin " + pluginName, e);
+						} catch (InstantiationException e) {
+							Log.w(TAG, "Unable to load Godot plugin " + pluginName, e);
+						} catch (NoSuchMethodException e) {
+							Log.w(TAG, "Unable to load Godot plugin " + pluginName, e);
+						} catch (InvocationTargetException e) {
+							Log.w(TAG, "Unable to load Godot plugin " + pluginName, e);
+						}
+					} else {
+						Log.w(TAG, "Invalid plugin loader class for " + pluginName);
+					}
+				}
+			}
+		} catch (PackageManager.NameNotFoundException e) {
+			Log.e(TAG, "Unable load Godot Android plugins from the manifest file.", e);
+		}
+	}
+}

--- a/platform/android/java/plugins/godotpayment/build.gradle
+++ b/platform/android/java/plugins/godotpayment/build.gradle
@@ -1,0 +1,31 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
+
+    defaultConfig {
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
+    }
+
+    libraryVariants.all { variant ->
+        variant.outputs.all { output ->
+            output.outputFileName = "GodotPayment.${variant.name}.aar"
+        }
+    }
+
+}
+
+dependencies {
+    implementation libraries.supportCoreUtils
+    implementation libraries.v4Support
+
+    if (rootProject.findProject(":lib")) {
+        compileOnly project(":lib")
+    } else if (rootProject.findProject(":godot:lib")) {
+        compileOnly project(":godot:lib")
+    } else {
+        compileOnly fileTree(dir: 'libs', include: ['godot-lib*.aar'])
+    }
+}

--- a/platform/android/java/plugins/godotpayment/src/main/AndroidManifest.xml
+++ b/platform/android/java/plugins/godotpayment/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.godotengine.godot.plugin.payment">
+
+    <application>
+
+        <meta-data
+            android:name="org.godotengine.plugin.v1.GodotPayment"
+            android:value="org.godotengine.godot.plugin.payment.GodotPayment" />
+
+    </application>
+</manifest>

--- a/platform/android/java/plugins/godotpayment/src/main/java/org/godotengine/godot/plugin/payment/GodotPayment.java
+++ b/platform/android/java/plugins/godotpayment/src/main/java/org/godotengine/godot/plugin/payment/GodotPayment.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  GodotPaymentV3.java                                                  */
+/*  GodotPayment.java                                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,20 +28,24 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-package org.godotengine.godot;
+package org.godotengine.godot.plugin.payment;
 
-import android.app.Activity;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.godotengine.godot.Dictionary;
+import org.godotengine.godot.Godot;
+import org.godotengine.godot.GodotLib;
+import org.godotengine.godot.payments.GodotPaymentInterface;
 import org.godotengine.godot.payments.PaymentsManager;
+import org.godotengine.godot.plugin.GodotPlugin;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class GodotPaymentV3 extends Godot.SingletonBase {
+public class GodotPayment extends GodotPlugin implements GodotPaymentInterface {
 
-	private Godot activity;
 	private Integer purchaseCallbackId = 0;
 	private String accessToken;
 	private String purchaseValidationUrlPrefix;
@@ -49,8 +53,16 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 	private PaymentsManager mPaymentManager;
 	private Dictionary mSkuDetails = new Dictionary();
 
+	public GodotPayment(Godot godot) {
+		super(godot);
+		onGLRegisterPluginWithGodotNative();
+		mPaymentManager = godot.getPaymentsManager();
+		mPaymentManager.setBaseSingleton(this);
+	}
+
+	@Override
 	public void purchase(final String sku, final String transactionId) {
-		activity.runOnUiThread(new Runnable() {
+		runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				mPaymentManager.requestPurchase(sku, transactionId);
@@ -58,21 +70,9 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 		});
 	}
 
-	static public Godot.SingletonBase initialize(Activity p_activity) {
-
-		return new GodotPaymentV3(p_activity);
-	}
-
-	public GodotPaymentV3(Activity p_activity) {
-
-		registerClass("GodotPayments", new String[] { "purchase", "setPurchaseCallbackId", "setPurchaseValidationUrlPrefix", "setTransactionId", "getSignature", "consumeUnconsumedPurchases", "requestPurchased", "setAutoConsume", "consume", "querySkuDetails", "isConnected" });
-		activity = (Godot)p_activity;
-		mPaymentManager = activity.getPaymentsManager();
-		mPaymentManager.setBaseSingleton(this);
-	}
-
+	@Override
 	public void consumeUnconsumedPurchases() {
-		activity.runOnUiThread(new Runnable() {
+		runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				mPaymentManager.consumeUnconsumedPurchases();
@@ -82,74 +82,91 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 
 	private String signature;
 
+	@Override
 	public String getSignature() {
 		return this.signature;
 	}
 
+	@Override
 	public void callbackSuccess(String ticket, String signature, String sku) {
 		GodotLib.calldeferred(purchaseCallbackId, "purchase_success", new Object[] { ticket, signature, sku });
 	}
 
+	@Override
 	public void callbackSuccessProductMassConsumed(String ticket, String signature, String sku) {
 		Log.d(this.getClass().getName(), "callbackSuccessProductMassConsumed > " + ticket + "," + signature + "," + sku);
 		GodotLib.calldeferred(purchaseCallbackId, "consume_success", new Object[] { ticket, signature, sku });
 	}
 
+	@Override
 	public void callbackSuccessNoUnconsumedPurchases() {
 		GodotLib.calldeferred(purchaseCallbackId, "consume_not_required", new Object[] {});
 	}
 
+	@Override
 	public void callbackFailConsume(String message) {
 		GodotLib.calldeferred(purchaseCallbackId, "consume_fail", new Object[] { message });
 	}
 
+	@Override
 	public void callbackFail(String message) {
 		GodotLib.calldeferred(purchaseCallbackId, "purchase_fail", new Object[] { message });
 	}
 
+	@Override
 	public void callbackCancel() {
 		GodotLib.calldeferred(purchaseCallbackId, "purchase_cancel", new Object[] {});
 	}
 
+	@Override
 	public void callbackAlreadyOwned(String sku) {
 		GodotLib.calldeferred(purchaseCallbackId, "purchase_owned", new Object[] { sku });
 	}
 
+	@Override
 	public int getPurchaseCallbackId() {
 		return purchaseCallbackId;
 	}
 
+	@Override
 	public void setPurchaseCallbackId(int purchaseCallbackId) {
 		this.purchaseCallbackId = purchaseCallbackId;
 	}
 
+	@Override
 	public String getPurchaseValidationUrlPrefix() {
 		return this.purchaseValidationUrlPrefix;
 	}
 
+	@Override
 	public void setPurchaseValidationUrlPrefix(String url) {
 		this.purchaseValidationUrlPrefix = url;
 	}
 
+	@Override
 	public String getAccessToken() {
 		return accessToken;
 	}
 
+	@Override
 	public void setAccessToken(String accessToken) {
 		this.accessToken = accessToken;
 	}
 
+	@Override
 	public void setTransactionId(String transactionId) {
 		this.transactionId = transactionId;
 	}
 
+	@Override
 	public String getTransactionId() {
 		return this.transactionId;
 	}
 
 	// request purchased items are not consumed
+	@Override
 	public void requestPurchased() {
-		activity.runOnUiThread(new Runnable() {
+		runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				mPaymentManager.requestPurchased();
@@ -158,34 +175,41 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 	}
 
 	// callback for requestPurchased()
+	@Override
 	public void callbackPurchased(String receipt, String signature, String sku) {
 		GodotLib.calldeferred(purchaseCallbackId, "has_purchased", new Object[] { receipt, signature, sku });
 	}
 
+	@Override
 	public void callbackDisconnected() {
 		GodotLib.calldeferred(purchaseCallbackId, "iap_disconnected", new Object[] {});
 	}
 
+	@Override
 	public void callbackConnected() {
 		GodotLib.calldeferred(purchaseCallbackId, "iap_connected", new Object[] {});
 	}
 
 	// true if connected, false otherwise
+	@Override
 	public boolean isConnected() {
 		return mPaymentManager.isConnected();
 	}
 
 	// consume item automatically after purchase. default is true.
+	@Override
 	public void setAutoConsume(boolean autoConsume) {
 		mPaymentManager.setAutoConsume(autoConsume);
 	}
 
 	// consume a specific item
+	@Override
 	public void consume(String sku) {
 		mPaymentManager.consume(sku);
 	}
 
 	// query in app item detail info
+	@Override
 	public void querySkuDetails(String[] list) {
 		List<String> nKeys = Arrays.asList(list);
 		List<String> cKeys = Arrays.asList(mSkuDetails.get_keys());
@@ -202,6 +226,7 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 		}
 	}
 
+	@Override
 	public void addSkuDetail(String itemJson) {
 		JSONObject o = null;
 		try {
@@ -220,11 +245,25 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 		}
 	}
 
+	@Override
 	public void completeSkuDetail() {
 		GodotLib.calldeferred(purchaseCallbackId, "sku_details_complete", new Object[] { mSkuDetails });
 	}
 
+	@Override
 	public void errorSkuDetail(String errorMessage) {
 		GodotLib.calldeferred(purchaseCallbackId, "sku_details_error", new Object[] { errorMessage });
+	}
+
+	@NonNull
+	@Override
+	public String getPluginName() {
+		return "GodotPayment";
+	}
+
+	@NonNull
+	@Override
+	public List<String> getPluginMethods() {
+		return Arrays.asList("purchase", "setPurchaseCallbackId", "setPurchaseValidationUrlPrefix", "setTransactionId", "getSignature", "consumeUnconsumedPurchases", "requestPurchased", "setAutoConsume", "consume", "querySkuDetails", "isConnected");
 	}
 }

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -3,3 +3,4 @@ rootProject.name = "Godot"
 
 include ':app'
 include ':lib'
+include ':plugins:godotpayment'

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -60,8 +60,6 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnetometer(JNIEnv *
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gyroscope(JNIEnv *env, jclass clazz, jfloat x, jfloat y, jfloat z);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusin(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusout(JNIEnv *env, jclass clazz);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_singleton(JNIEnv *env, jclass clazz, jstring name, jobject p_object);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_method(JNIEnv *env, jclass clazz, jstring sname, jstring name, jstring ret, jobjectArray args);
 JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getGlobal(JNIEnv *env, jclass clazz, jstring path);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *env, jclass clazz, jint ID, jstring method, jobjectArray params);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *env, jclass clazz, jint ID, jstring method, jobjectArray params);

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -66,6 +66,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance) {
 	_is_activity_resumed = p_env->GetMethodID(cls, "isActivityResumed", "()Z");
 	_vibrate = p_env->GetMethodID(cls, "vibrate", "(I)V");
 	_get_input_fallback_mapping = p_env->GetMethodID(cls, "getInputFallbackMapping", "()Ljava/lang/String;");
+	_on_gl_godot_main_loop_started = p_env->GetMethodID(cls, "onGLGodotMainLoopStarted", "()V");
 }
 
 GodotJavaWrapper::~GodotJavaWrapper() {
@@ -105,6 +106,15 @@ void GodotJavaWrapper::on_video_init(JNIEnv *p_env) {
 			p_env = ThreadAndroid::get_env();
 
 	p_env->CallVoidMethod(godot_instance, _on_video_init);
+}
+
+void GodotJavaWrapper::on_gl_godot_main_loop_started(JNIEnv *p_env) {
+	if (_on_gl_godot_main_loop_started) {
+		if (p_env == NULL) {
+			p_env = ThreadAndroid::get_env();
+		}
+	}
+	p_env->CallVoidMethod(godot_instance, _on_gl_godot_main_loop_started);
 }
 
 void GodotJavaWrapper::restart(JNIEnv *p_env) {

--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -1,0 +1,115 @@
+/*************************************************************************/
+/*  godot_plugin_jni.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "godot_plugin_jni.h"
+
+#include <core/engine.h>
+#include <core/error_macros.h>
+#include <core/project_settings.h>
+#include <platform/android/jni_utils.h>
+#include <platform/android/string_android.h>
+
+static HashMap<String, JNISingleton *> jni_singletons;
+
+extern "C" {
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeRegisterSingleton(JNIEnv *env, jobject obj, jstring name) {
+
+	String singname = jstring_to_string(name, env);
+	JNISingleton *s = memnew(JNISingleton);
+	s->set_instance(env->NewGlobalRef(obj));
+	jni_singletons[singname] = s;
+
+	Engine::get_singleton()->add_singleton(Engine::Singleton(singname, s));
+	ProjectSettings::get_singleton()->set(singname, s);
+}
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeRegisterMethod(JNIEnv *env, jobject obj, jstring sname, jstring name, jstring ret, jobjectArray args) {
+
+	String singname = jstring_to_string(sname, env);
+
+	ERR_FAIL_COND(!jni_singletons.has(singname));
+
+	JNISingleton *s = jni_singletons.get(singname);
+
+	String mname = jstring_to_string(name, env);
+	String retval = jstring_to_string(ret, env);
+	Vector<Variant::Type> types;
+	String cs = "(";
+
+	int stringCount = env->GetArrayLength(args);
+
+	for (int i = 0; i < stringCount; i++) {
+
+		jstring string = (jstring)env->GetObjectArrayElement(args, i);
+		const String rawString = jstring_to_string(string, env);
+		types.push_back(get_jni_type(rawString));
+		cs += get_jni_sig(rawString);
+	}
+
+	cs += ")";
+	cs += get_jni_sig(retval);
+	jclass cls = env->GetObjectClass(s->get_instance());
+	jmethodID mid = env->GetMethodID(cls, mname.ascii().get_data(), cs.ascii().get_data());
+	if (!mid) {
+
+		print_line("Failed getting method ID " + mname);
+	}
+
+	s->add_method(mname, mid, types, get_jni_type(retval));
+}
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeRegisterGDNativeLibraries(JNIEnv *env, jobject obj, jobjectArray gdnlib_paths) {
+	int gdnlib_count = env->GetArrayLength(gdnlib_paths);
+	if (gdnlib_count == 0) {
+		return;
+	}
+
+	// Retrieve the current list of gdnative libraries.
+	Array singletons = Array();
+	if (ProjectSettings::get_singleton()->has_setting("gdnative/singletons")) {
+		singletons = ProjectSettings::get_singleton()->get("gdnative/singletons");
+	}
+
+	// Insert the libraries provided by the plugin
+	for (int i = 0; i < gdnlib_count; i++) {
+		jstring relative_path = (jstring)env->GetObjectArrayElement(gdnlib_paths, i);
+
+		String path = "res://" + jstring_to_string(relative_path, env);
+		if (!singletons.has(path)) {
+			singletons.push_back(path);
+		}
+		env->DeleteLocalRef(relative_path);
+	}
+
+	// Insert the updated list back into project settings.
+	ProjectSettings::get_singleton()->set("gdnative/singletons", singletons);
+}
+}

--- a/platform/android/plugin/godot_plugin_jni.h
+++ b/platform/android/plugin/godot_plugin_jni.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  java_godot_wrapper.h                                                 */
+/*  godot_plugin_jni.h                                                   */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,69 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-// note, swapped java and godot around in the file name so all the java
-// wrappers are together
-
-#ifndef JAVA_GODOT_WRAPPER_H
-#define JAVA_GODOT_WRAPPER_H
+#ifndef GODOT_PLUGIN_JNI_H
+#define GODOT_PLUGIN_JNI_H
 
 #include <android/log.h>
 #include <jni.h>
 
-#include "string_android.h"
+extern "C" {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeRegisterSingleton(JNIEnv *env, jobject obj, jstring name);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeRegisterMethod(JNIEnv *env, jobject obj, jstring sname, jstring name, jstring ret, jobjectArray args);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeRegisterGDNativeLibraries(JNIEnv *env, jobject obj, jobjectArray gdnlib_paths);
+}
 
-// Class that makes functions in java/src/org/godotengine/godot/Godot.java callable from C++
-class GodotJavaWrapper {
-private:
-	jobject godot_instance;
-	jclass cls;
-
-	jmethodID _on_video_init = 0;
-	jmethodID _restart = 0;
-	jmethodID _finish = 0;
-	jmethodID _set_keep_screen_on = 0;
-	jmethodID _alert = 0;
-	jmethodID _get_GLES_version_code = 0;
-	jmethodID _get_clipboard = 0;
-	jmethodID _set_clipboard = 0;
-	jmethodID _request_permission = 0;
-	jmethodID _request_permissions = 0;
-	jmethodID _get_granted_permissions = 0;
-	jmethodID _init_input_devices = 0;
-	jmethodID _get_surface = 0;
-	jmethodID _is_activity_resumed = 0;
-	jmethodID _vibrate = 0;
-	jmethodID _get_input_fallback_mapping = 0;
-	jmethodID _on_gl_godot_main_loop_started = 0;
-
-public:
-	GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance);
-	~GodotJavaWrapper();
-
-	jobject get_activity();
-	jobject get_member_object(const char *p_name, const char *p_class, JNIEnv *p_env = NULL);
-
-	jobject get_class_loader();
-
-	void on_video_init(JNIEnv *p_env = NULL);
-	void on_gl_godot_main_loop_started(JNIEnv *p_env = NULL);
-	void restart(JNIEnv *p_env = NULL);
-	void force_quit(JNIEnv *p_env = NULL);
-	void set_keep_screen_on(bool p_enabled);
-	void alert(const String &p_message, const String &p_title);
-	int get_gles_version_code();
-	bool has_get_clipboard();
-	String get_clipboard();
-	bool has_set_clipboard();
-	void set_clipboard(const String &p_text);
-	bool request_permission(const String &p_name);
-	bool request_permissions();
-	Vector<String> get_granted_permissions() const;
-	void init_input_devices();
-	jobject get_surface();
-	bool is_activity_resumed();
-	void vibrate(int p_duration_ms);
-	String get_input_fallback_mapping();
-};
-
-#endif /* !JAVA_GODOT_WRAPPER_H */
+#endif // GODOT_PLUGIN_JNI_H


### PR DESCRIPTION
This PR revisits the Godot Android plugins' architecture.
This is done by leveraging the [Android library file format](https://developer.android.com/studio/projects/android-library#aar-contents). A Godot Android plugin is now defined as follow:

>  A Godot Android plugin is a regular Android library packaged as an aar archive file with the following caveats:
>  - The library must have a dependency on the Godot Android library (`godot-lib.aar`). A stable version is made available for each release.
>  - The library must include a `<meta-data>` tag in its manifest file setup as follow:
>  `<meta-data android:name="org.godotengine.plugin.v1.[PluginName]" android:value="[plugin.init.ClassFullName]" />`
>  Where:
>  
> 
> - `PluginName` is the name of the plugin.
> 
> - `plugin.init.ClassFullName` is the full name (package + class name) of the plugin class extending `GodotPlugin`.

At runtime, Godot (via `GodotPluginRegistry`) will parse the Android manifest, and retrieve all components with the specified `<meta-data>` tag. It'll then use reflection to instantiate and load the plugin class defined by `plugin.init.ClassFullName`. From there, the plugins follow the same lifecycle as with the previous architecture.

A nice side-effect of this new architecture is that we can remove all the gradle build and android manifest custom update logic, since we can just rely on the [Android library build and manifest merge mechanism](https://developer.android.com/studio/build/manifest-merge.html).

**Documentation update**: https://github.com/godotengine/godot-docs/pull/2979

**Note**: 
- This is a breaking / non-backward compatible change with the previous Godot Android plugin architecture.
- Just like the previous architecture, this requires the use of custom builds.
- This new architecture may be helpful for PR #26221, as the ARCore build dependencies no longer need to be included in Godot `core`. This would however limit ARCore to custom builds only.
- The updated architecture simplifies the process of bundling Android gdnative libraries with Android java libraries. See the updated documentation for details.

Example implementation: 
- Hello World reference plugin: https://github.com/m4gr3d/Godot-Android-Plugins/tree/master/hello_world
- Custom branch of the Godot Oculus mobile plugin: https://github.com/m4gr3d/godot_oculus_mobile/tree/2.0/plugin