### PR TITLE
Properly update texture when roughness/metallic set

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1405,8 +1405,8 @@ void SpatialMaterial::set_texture(TextureParam p_param, const Ref<Texture> &p_te
 	textures[p_param] = p_texture;
 	RID rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 	VS::get_singleton()->material_set_param(_get_material(), shader_names->texture_names[p_param], rid);
-	_queue_shader_change();
 	_change_notify();
+	_queue_shader_change();
 }
 
 Ref<Texture> SpatialMaterial::get_texture(TextureParam p_param) const {

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -260,6 +260,8 @@ private:
 			uint64_t proximity_fade : 1;
 			uint64_t distance_fade : 2;
 			uint64_t emission_op : 1;
+			uint64_t texture_metallic : 1;
+			uint64_t texture_roughness : 1;
 		};
 
 		uint64_t key;
@@ -305,6 +307,8 @@ private:
 		mk.proximity_fade = proximity_fade_enabled;
 		mk.distance_fade = distance_fade;
 		mk.emission_op = emission_op;
+		mk.texture_metallic = textures[TEXTURE_METALLIC].is_valid() ? 1 : 0;
+		mk.texture_roughness = textures[TEXTURE_ROUGHNESS].is_valid() ? 1 : 0;
 
 		return mk;
 	}


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/33277

Turns out I didn't fully fix the issue because I forgot about Godot's shader caching. When textures were set and unset it wasn't registering as a different version, so the shader was not updating. 