### PR TITLE
ItemList's add_(icon_)item method returns id of added item

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -12,18 +12,18 @@
 	</tutorials>
 	<methods>
 		<method name="add_icon_item">
-			<return type="void">
+			<return type="int">
 			</return>
 			<argument index="0" name="icon" type="Texture2D">
 			</argument>
 			<argument index="1" name="selectable" type="bool" default="true">
 			</argument>
 			<description>
-				Adds an item to the item list with no text, only an icon.
+				Adds an item to the item list with no text, only an icon. Returns the index of an added item.
 			</description>
 		</method>
 		<method name="add_item">
-			<return type="void">
+			<return type="int">
 			</return>
 			<argument index="0" name="text" type="String">
 			</argument>
@@ -32,7 +32,8 @@
 			<argument index="2" name="selectable" type="bool" default="true">
 			</argument>
 			<description>
-				Adds an item to the item list with specified text. Specify an [code]icon[/code], or use [code]null[/code] as the [code]icon[/code] for a list item with no icon.
+				Adds an item to the item list with specified text. Returns the index of an added item.
+				Specify an [code]icon[/code], or use [code]null[/code] as the [code]icon[/code] for a list item with no icon.
 				If selectable is [code]true[/code], the list item will be selectable.
 			</description>
 		</method>

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -32,7 +32,7 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 
-void ItemList::add_item(const String &p_item, const Ref<Texture2D> &p_texture, bool p_selectable) {
+int ItemList::add_item(const String &p_item, const Ref<Texture2D> &p_texture, bool p_selectable) {
 	Item item;
 	item.icon = p_texture;
 	item.icon_transposed = false;
@@ -45,12 +45,14 @@ void ItemList::add_item(const String &p_item, const Ref<Texture2D> &p_texture, b
 	item.tooltip_enabled = true;
 	item.custom_bg = Color(0, 0, 0, 0);
 	items.push_back(item);
+	int item_id = items.size() - 1;
 
 	update();
 	shape_changed = true;
+	return item_id;
 }
 
-void ItemList::add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable) {
+int ItemList::add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable) {
 	Item item;
 	item.icon = p_item;
 	item.icon_transposed = false;
@@ -63,9 +65,11 @@ void ItemList::add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable) {
 	item.tooltip_enabled = true;
 	item.custom_bg = Color(0, 0, 0, 0);
 	items.push_back(item);
+	int item_id = items.size() - 1;
 
 	update();
 	shape_changed = true;
+	return item_id;
 }
 
 void ItemList::set_item_text(int p_idx, const String &p_text) {

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -123,8 +123,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_item(const String &p_item, const Ref<Texture2D> &p_texture = Ref<Texture2D>(), bool p_selectable = true);
-	void add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable = true);
+	int add_item(const String &p_item, const Ref<Texture2D> &p_texture = Ref<Texture2D>(), bool p_selectable = true);
+	int add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable = true);
 
 	void set_item_text(int p_idx, const String &p_text);
 	String get_item_text(int p_idx) const;


### PR DESCRIPTION
 Normally, when using `ItemList` node, one must calculate id of the newly added item separately:

```
onready var _item_list = $ItemList
# (...)
_item_list.add_item('item')
var item_id = _item_list.get_item_count() - 1
_item_list.set_item_metadata(item_id, {})
```

It not only forces one to rely upon implementation details but also obfuscates the code.

This PR enables the possibility of:
```
onready var _item_list = $ItemList
# (...)
var item_id = _item_list.add_item('item')
_item_list.set_item_metadata(item_id, {})
```