### PR TITLE
Fix animation key snapping at high zooms

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2026,7 +2026,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				float offset = animation->track_get_key_time(track, i) - timeline->get_value();
 				if (editor->is_key_selected(track, i) && editor->is_moving_selection()) {
-					offset = editor->snap_time(offset + editor->get_moving_selection_offset());
+					offset = editor->snap_time(offset + editor->get_moving_selection_offset(), true);
 				}
 				offset = offset * scale + limit;
 				if (i < animation->track_get_key_count(track) - 1) {
@@ -5703,7 +5703,7 @@ void AnimationTrackEditor::_selection_changed() {
 	}
 }
 
-float AnimationTrackEditor::snap_time(float p_value) {
+float AnimationTrackEditor::snap_time(float p_value, bool p_relative) {
 
 	if (is_snap_enabled()) {
 
@@ -5713,7 +5713,12 @@ float AnimationTrackEditor::snap_time(float p_value) {
 		else
 			snap_increment = step->get_value();
 
-		p_value = Math::stepify(p_value, snap_increment);
+		if (p_relative) {
+			double rel = Math::fmod(timeline->get_value(), snap_increment);
+			p_value = Math::stepify(p_value + rel, snap_increment) - rel;
+		} else {
+			p_value = Math::stepify(p_value, snap_increment);
+		}
 	}
 
 	return p_value;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -521,7 +521,7 @@ public:
 	bool is_moving_selection() const;
 	bool is_snap_enabled() const;
 	float get_moving_selection_offset() const;
-	float snap_time(float p_value);
+	float snap_time(float p_value, bool p_relative = false);
 	bool is_grouping_tracks();
 
 	MenuButton *get_edit_menu();


### PR DESCRIPTION
Fixes #28597

If anyone is interested in cause of this issue:
![image](https://user-images.githubusercontent.com/2223172/69015500-bd106700-0994-11ea-828d-599f24f5bb72.png)
