### PR TITLE
Bullet: Fix detection of concave shape in Area

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -726,9 +726,6 @@ void SpaceBullet::check_ghost_overlaps() {
 
 					other_body_shape = static_cast<btCollisionShape *>(otherObject->get_bt_shape(z));
 
-					if (other_body_shape->isConcave())
-						continue;
-
 					btTransform other_shape_transform(otherObject->get_bt_shape_transform(z));
 					other_shape_transform.getOrigin() *= other_body_scale;
 


### PR DESCRIPTION
Added a new property to the Area class that can make Areas perceive concave shapes. It is useful for jumping/crouching systems.

*Bugsquad edit:* Fixes #35854.