### PR TITLE
Fix negative light flickering

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2342,9 +2342,7 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 
 			if (accum_pass) { //accum pass force pass
 				blend_mode = RasterizerStorageGLES2::Shader::Spatial::BLEND_MODE_ADD;
-				if (rebind_light && light && light->light_ptr->negative) {
-					glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
-					glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+				if (light && light->light_ptr->negative) {
 					blend_mode = RasterizerStorageGLES2::Shader::Spatial::BLEND_MODE_SUB;
 				}
 			}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/33538

When there is only one light light == prev_light, so the blend mode was not updated to SUB, however it was still changing to ADD because accum pass was true. 

Also I got rid of the gl calls because they were unnecessary and on web export unnecessary gl calls still take up a lot of cpu time. 