### PR TITLE
Fix IBL specular persisting when specular disabled

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1560,12 +1560,14 @@ FRAGMENT_SHADER_CODE
 
 #ifdef USE_RADIANCE_MAP
 
+#if !defined(SPECULAR_DISABLED)
 	vec3 ref_vec = reflect(-eye_position, N);
 	ref_vec = normalize((radiance_inverse_xform * vec4(ref_vec, 0.0)).xyz);
 
 	ref_vec.z *= -1.0;
 
 	specular_light = textureCubeLod(radiance_map, ref_vec, roughness * RADIANCE_MAX_LOD).xyz * bg_energy;
+#endif
 #ifndef USE_LIGHTMAP
 	{
 		vec3 ambient_dir = normalize((radiance_inverse_xform * vec4(normal, 0.0)).xyz);

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1798,6 +1798,7 @@ FRAGMENT_SHADER_CODE
 #ifdef AMBIENT_LIGHT_DISABLED
 	ambient_light = vec3(0.0, 0.0, 0.0);
 #else
+#if !defined(SPECULAR_DISABLED)
 	{
 
 		{ //read radiance from dual paraboloid
@@ -1808,6 +1809,7 @@ FRAGMENT_SHADER_CODE
 			env_reflection_light = radiance;
 		}
 	}
+#endif
 #ifndef USE_LIGHTMAP
 	{
 


### PR DESCRIPTION
Fixes: #33616 

``SPECULAR_DISABLED`` wasn't affecting IBL specular. So in PBR scenes, there were still specular highlights even when specular was disabled.