### PR TITLE
HTML5: Explicitly link idbfs.js for IDBFS support

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -124,6 +124,10 @@ def configure(env):
 
     ## Link flags
 
+    # We use IDBFS in javascript_main.cpp. Since Emscripten 1.39.1 it needs to
+    # be linked explicitly.
+    env.Append(LIBS=['idbfs.js'])
+
     env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
 
     # Allow increasing memory buffer size during runtime. This is efficient


### PR DESCRIPTION
Upstream Emscripten changed this in 1.39.1+, so IDBFS is no longer
included by default and has to be linked manually.

The explicit linking doesn't seem to be problematic on earlier
versions (tested `1.38.47-upstream`).

Fixes #33724.