### PR TITLE
Fix Visual Studio throwing C4996 warning in ustring.cpp.

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -142,9 +142,11 @@ void CharString::copy_from(const char *p_cstr) {
 		return;
 	}
 
-	resize(len + 1); // include terminating null char
+	Error err = resize(++len); // include terminating null char
 
-	strcpy(ptrw(), p_cstr);
+	ERR_FAIL_COND_MSG(err != OK, "Failed to copy C-string.");
+
+	memcpy(ptrw(), p_cstr, len);
 }
 
 void String::copy_from(const char *p_cstr) {


### PR DESCRIPTION
Fixes Visual Studio throwing a C4996 warning: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead at core\ustring.cpp(147).

Also ensures that resizing the storage was successful before trying to copy the data.

It doesn't address the fact that resize() takes an int and len is a size_t or unsigned long, or that len may wrap around when incrementing, but that's for another day.