### PR TITLE
Editor: fix typo in VCS plugin method names

### DIFF
--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -34,7 +34,7 @@
 				- [code]"offset"[/code] to store the offset of the line change since the first contextual line content.
 			</description>
 		</method>
-		<method name="get_is_vcs_intialized">
+		<method name="is_vcs_initialized">
 			<return type="bool">
 			</return>
 			<description>

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -36,7 +36,7 @@ void EditorVCSInterface::_bind_methods() {
 
 	// Proxy end points that act as fallbacks to unavailability of a function in the VCS addon
 	ClassDB::bind_method(D_METHOD("_initialize", "project_root_path"), &EditorVCSInterface::_initialize);
-	ClassDB::bind_method(D_METHOD("_get_is_vcs_intialized"), &EditorVCSInterface::_get_is_vcs_intialized);
+	ClassDB::bind_method(D_METHOD("_is_vcs_initialized"), &EditorVCSInterface::_is_vcs_initialized);
 	ClassDB::bind_method(D_METHOD("_get_vcs_name"), &EditorVCSInterface::_get_vcs_name);
 	ClassDB::bind_method(D_METHOD("_shut_down"), &EditorVCSInterface::_shut_down);
 	ClassDB::bind_method(D_METHOD("_get_project_name"), &EditorVCSInterface::_get_project_name);
@@ -50,7 +50,7 @@ void EditorVCSInterface::_bind_methods() {
 
 	// API methods that redirect calls to the proxy end points
 	ClassDB::bind_method(D_METHOD("initialize", "project_root_path"), &EditorVCSInterface::initialize);
-	ClassDB::bind_method(D_METHOD("get_is_vcs_intialized"), &EditorVCSInterface::get_is_vcs_intialized);
+	ClassDB::bind_method(D_METHOD("is_vcs_initialized"), &EditorVCSInterface::is_vcs_initialized);
 	ClassDB::bind_method(D_METHOD("get_modified_files_data"), &EditorVCSInterface::get_modified_files_data);
 	ClassDB::bind_method(D_METHOD("stage_file", "file_path"), &EditorVCSInterface::stage_file);
 	ClassDB::bind_method(D_METHOD("unstage_file", "file_path"), &EditorVCSInterface::unstage_file);
@@ -67,7 +67,7 @@ bool EditorVCSInterface::_initialize(String p_project_root_path) {
 	return true;
 }
 
-bool EditorVCSInterface::_get_is_vcs_intialized() {
+bool EditorVCSInterface::_is_vcs_initialized() {
 
 	return false;
 }
@@ -112,9 +112,9 @@ bool EditorVCSInterface::initialize(String p_project_root_path) {
 	return is_initialized;
 }
 
-bool EditorVCSInterface::get_is_vcs_intialized() {
+bool EditorVCSInterface::is_vcs_initialized() {
 
-	return call("_get_is_vcs_intialized");
+	return call("_is_vcs_initialized");
 }
 
 Dictionary EditorVCSInterface::get_modified_files_data() {

--- a/editor/editor_vcs_interface.h
+++ b/editor/editor_vcs_interface.h
@@ -48,7 +48,7 @@ protected:
 
 	// Implemented by addons as end points for the proxy functions
 	bool _initialize(String p_project_root_path);
-	bool _get_is_vcs_intialized();
+	bool _is_vcs_initialized();
 	Dictionary _get_modified_files_data();
 	void _stage_file(String p_file_path);
 	void _unstage_file(String p_file_path);
@@ -66,7 +66,7 @@ public:
 
 	// Proxy functions to the editor for use
 	bool initialize(String p_project_root_path);
-	bool get_is_vcs_intialized();
+	bool is_vcs_initialized();
 	Dictionary get_modified_files_data();
 	void stage_file(String p_file_path);
 	void unstage_file(String p_file_path);

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "version_control_editor_plugin.h"
+
 #include "core/script_language.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
@@ -398,9 +399,9 @@ void VersionControlEditorPlugin::shut_down() {
 	}
 }
 
-bool VersionControlEditorPlugin::get_is_vcs_intialized() const {
+bool VersionControlEditorPlugin::is_vcs_initialized() const {
 
-	return EditorVCSInterface::get_singleton() ? EditorVCSInterface::get_singleton()->get_is_vcs_intialized() : false;
+	return EditorVCSInterface::get_singleton() ? EditorVCSInterface::get_singleton()->is_vcs_initialized() : false;
 }
 
 const String VersionControlEditorPlugin::get_vcs_name() const {

--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -129,7 +129,7 @@ public:
 	PanelContainer *get_version_control_dock() const { return version_control_dock; }
 
 	List<StringName> get_available_vcs_names() const { return available_addons; }
-	bool get_is_vcs_intialized() const;
+	bool is_vcs_initialized() const;
 	const String get_vcs_name() const;
 
 	void register_editor();


### PR DESCRIPTION
intialized -> initialized.
The `get` prefix was also removed to be more consistent with the rest of the codebase.