### PR TITLE
AppVeyor: Enable warnings as errors.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,10 +7,19 @@ environment:
   PYTHON: C:\Python38
   SCONS_CACHE_ROOT: "%HOME%\\scons_cache"
   SCONS_CACHE_LIMIT: 1024
+  OPTIONS: "debug_symbols=no verbose=yes progress=no"
+  EXTRA_ARGS: "warnings=all werror=yes"
   matrix:
-    - GD_PLATFORM: windows
-      TOOLS: yes
-      TARGET: release_debug
+  - GD_PLATFORM: windows
+    TARGET: release_debug
+    TOOLS: yes
+# Disabled for performance reasons until master is more stable.
+#  - GD_PLATFORM: windows
+#    TARGET: release
+#    TOOLS: no
+
+matrix:
+  fast_finish: true
 
 init:
   - ps: if ($env:APPVEYOR_REPO_BRANCH -ne "master") { $env:APPVEYOR_CACHE_SKIP_SAVE = "true" }
@@ -29,4 +38,4 @@ before_build:
   - set "SCONS_CACHE=%SCONS_CACHE_ROOT%\%APPVEYOR_REPO_BRANCH%"
 
 build_script:
-  - scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% debug_symbols=no verbose=yes progress=no gdnative_wrapper=yes
+  - scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% %OPTIONS% %EXTRA_ARGS%


### PR DESCRIPTION
The AppVeyor tests are currently sometimes passing when they should be failing. Two examples:
- PR #33517 caused issue #33600, which required PR #33595.
- PR #31227 passed when it should have failed, and therefore required PR #31234.

This patch will help AppVeyor to fail when it should by:
- Including a windows release build.
- Setting the options to be the same as Travis builds, except use warnings=all instead of warnings=extra, because VisualStudio throws too many warnings ¯\_(ツ)_/¯.
- Failing on warnings as per Travis builds.

Note 1: To keep AppVeyor consistent with Travis, this patch removes the SCons option `gdnative_wrapper=yes`, which was added by PR #15343, but removed in the Travis builds by PR #26058. A better option may be to update this PR to readd `gdnative_wrapper=yes` to the Travis build again instead, but I don't know why it was removed from the Travis build.

Note 2: The option `builtin_libpng=yes` was included, because the option was added to the Travis builds by PR #29874. However, this appears to be the default:
https://github.com/godotengine/godot/blob/fea3890e1e994257a27cbf7480d8d4cdb037cfa6/SConstruct#L143
So again, a better option may be to update this PR to remove `builtin_libpng=yes` from the Travis builds, but, again, I don't know if it still needs to be included.
**EDIT:** As per @akien-mga's [comment](https://github.com/godotengine/godot/pull/33736#discussion_r376997247), this PR removes `builtin_libpng=yes` from the Travis build.

Note 3: For the new AppVeyor tests to pass the following PRs need to be merged first:
- [x] #33637
- [ ] #33670
- [x] #33706
- [x] #33731
- [x] #36097