### PR TITLE
Independant spinbox arrow step precision

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -47,6 +47,9 @@
 		<member name="suffix" type="String" setter="set_suffix" getter="get_suffix" default="&quot;&quot;">
 			Adds the specified [code]suffix[/code] string after the numerical value of the [SpinBox].
 		</member>
+		<member name="arrow_step" type="float" setter="set_arrow_step" getter="get_arrow_step" default="0.0">
+			If greater than 0, [code]value[/code] will always be rounded to a multiple of [code]arrow_step[/code] when interacting with the arrow buttons of the [SpinBox].
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -48,6 +48,7 @@ class SpinBox : public Range {
 	virtual void _value_changed(double);
 	String prefix;
 	String suffix;
+	double arrow_step;
 
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 
@@ -88,6 +89,8 @@ public:
 	String get_prefix() const;
 
 	void apply();
+	void set_arrow_step(const double p_arrow_step);
+	double get_arrow_step() const;
 
 	SpinBox();
 };


### PR DESCRIPTION
The arrow buttons on Spinbox become relatively useless when one wants to have the ability to write numbers with high precision. For example setting step to 0.000001. In its current form the arrow buttons will become relatively useless.

This pull request fixes that by implementing an independent step value for the arrow buttons on spinboxes. Default value is 0 to avoid breaking compatibility, and if range class step value is higher it will use that step instead.
![spinbox](https://user-images.githubusercontent.com/2924543/69173144-12fd2000-0af7-11ea-832d-3ab0ab5627c5.gif)

This is related to my proposal https://github.com/godotengine/godot-proposals/issues/226

This work has been kindly sponsored by IMVU.