### PR TITLE
GradientEdit: Fix index crashes

### DIFF
--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -277,12 +277,13 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 
 			if (points[i].offset == newofs && i != grabbed) {
 				valid = false;
+				break;
 			}
 		}
 
-		if (!valid)
+		if (!valid || grabbed == -1) {
 			return;
-
+		}
 		points.write[grabbed].offset = newofs;
 
 		points.sort();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/33691

I feel this method could be redesigned to be more resilient but that requires more time. This is a quick fix that solves the crash, feel free to review it. 