### PR TITLE
pcre2: Use scons option to disable JIT on some platforms

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -150,6 +150,7 @@ opts.Add(BoolVariable('builtin_mbedtls', "Use the built-in mbedTLS library", Tru
 opts.Add(BoolVariable('builtin_miniupnpc', "Use the built-in miniupnpc library", True))
 opts.Add(BoolVariable('builtin_opus', "Use the built-in Opus library", True))
 opts.Add(BoolVariable('builtin_pcre2', "Use the built-in PCRE2 library", True))
+opts.Add(BoolVariable('builtin_pcre2_with_jit', "Use JIT compiler for the built-in PCRE2 library", True))
 opts.Add(BoolVariable('builtin_recast', "Use the built-in Recast library", True))
 opts.Add(BoolVariable('builtin_squish', "Use the built-in squish library", True))
 opts.Add(BoolVariable('builtin_xatlas', "Use the built-in xatlas library", True))

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -6,12 +6,10 @@ Import('env_modules')
 env_regex = env_modules.Clone()
 
 if env['builtin_pcre2']:
-    jit_blacklist = ['javascript', 'uwp']
-
     thirdparty_dir = '#thirdparty/pcre2/src/'
     thirdparty_flags = ['PCRE2_STATIC', 'HAVE_CONFIG_H']
 
-    if 'platform' in env and env['platform'] not in jit_blacklist:
+    if env['builtin_pcre2_with_jit']:
         thirdparty_flags.append('SUPPORT_JIT')
 
     thirdparty_sources = [

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -24,6 +24,7 @@ def get_opts():
 def get_flags():
     return [
         ('tools', False),
+        ('builtin_pcre2_with_jit', False),
         # Disabling the mbedtls module reduces file size.
         # The module has little use due to the limited networking functionality
         # in this platform. For the available networking methods, the browser

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -34,6 +34,7 @@ def get_flags():
     return [
         ('tools', False),
         ('xaudio2', True),
+        ('builtin_pcre2_with_jit', False),
     ]
 
 


### PR DESCRIPTION
Third-party platforms (e.g. console ports) need to be able to
disable JIT support in the regex module too, so it can't be
hardcoded in the module SCsub. This is cleaner this way anyway.

Fixes #19316.

---

Testing a javascript build right now to confirm that the override works as expected.
*Edit:* Seems OK, JIT is disabled for `p=javascript`.