### PR TITLE
33714 Crash fixes for GLTF2 and FBX

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -229,6 +229,7 @@ Error EditorSceneImporterGLTF::_parse_scenes(GLTFState &state) {
 
 	ERR_FAIL_COND_V(!state.json.has("scenes"), ERR_FILE_CORRUPT);
 	const Array &scenes = state.json["scenes"];
+	ERR_FAIL_COND_V(!scenes.size(), ERR_FILE_CORRUPT);
 	for (int i = 0; i < 1; i++) { //only first scene is imported
 		const Dictionary &s = scenes[i];
 		ERR_FAIL_COND_V(!s.has("nodes"), ERR_UNAVAILABLE);

--- a/modules/assimp/import_utils.h
+++ b/modules/assimp/import_utils.h
@@ -394,7 +394,9 @@ public:
 			return Ref<Image>();
 		} else {
 			Ref<Texture> texture = ResourceLoader::load(p_path);
+			ERR_FAIL_COND_V(texture.is_null(), Ref<Image>());
 			Ref<Image> image = texture->get_data();
+			ERR_FAIL_COND_V(image.is_null(), Ref<Image>());
 			state.path_to_image_cache.insert(p_path, image);
 			return image;
 		}


### PR DESCRIPTION
A bugfix for https://github.com/godotengine/godot/issues/33714. Not sure if it fixes all the bugs though.