### PR TITLE
Implemented 'Auto width' behaviour to the ItemList to complement the existing 'Auto height'

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -405,6 +405,9 @@
 		<member name="allow_rmb_select" type="bool" setter="set_allow_rmb_select" getter="get_allow_rmb_select" default="false">
 			If [code]true[/code], right mouse button click can select items.
 		</member>
+		<member name="auto_width" type="bool" setter="set_auto_width" getter="has_auto_width" default="false">
+			If [code]true[/code], the control will automatically resize the width to fit its content.
+		</member>
 		<member name="auto_height" type="bool" setter="set_auto_height" getter="has_auto_height" default="false">
 			If [code]true[/code], the control will automatically resize the height to fit its content.
 		</member>

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -95,6 +95,7 @@ ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<St
 			ItemList *il = memnew(ItemList);
 			il->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 			il->set_same_column_width(true);
+			il->set_auto_width(false);
 			il->set_auto_height(true);
 			il->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 			il->add_constant_override("hseparation", 16 * EDSCALE);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -892,7 +892,6 @@ void ItemList::_notification(int p_what) {
 				if (items[i].text != "") {
 
 					Size2 s = font->get_string_size(items[i].text);
-					//s.width=MIN(s.width,fixed_column_width);
 
 					if (icon_mode == ICON_MODE_TOP) {
 						minsize.x = MAX(minsize.x, s.width);
@@ -931,6 +930,7 @@ void ItemList::_notification(int p_what) {
 				bool all_fit = true;
 				Vector2 ofs;
 				int col = 0;
+				int max_w = 0;
 				int max_h = 0;
 				separators.clear();
 				for (int i = 0; i < items.size(); i++) {
@@ -945,6 +945,7 @@ void ItemList::_notification(int p_what) {
 					if (same_column_width)
 						items.write[i].rect_cache.size.x = max_column_width;
 					items.write[i].rect_cache.position = ofs;
+					max_w = MAX(max_w, items[i].rect_cache.size.x);
 					max_h = MAX(max_h, items[i].rect_cache.size.y);
 					ofs.x += items[i].rect_cache.size.x + hseparation;
 					col++;
@@ -971,6 +972,8 @@ void ItemList::_notification(int p_what) {
 				if (all_fit) {
 					float page = size.height - bg->get_minimum_size().height;
 					float max = MAX(page, ofs.y + max_h);
+					if (auto_width)
+						auto_width_value = ofs.x + max_w + bg->get_minimum_size().width;
 					if (auto_height)
 						auto_height_value = ofs.y + max_h + bg->get_minimum_size().height;
 					scroll_bar->set_max(max);
@@ -1422,8 +1425,8 @@ Array ItemList::_get_items() const {
 
 Size2 ItemList::get_minimum_size() const {
 
-	if (auto_height) {
-		return Size2(0, auto_height_value);
+	if (auto_width || auto_height) {
+		return Size2(auto_width_value, auto_height_value);
 	}
 	return Size2();
 }
@@ -1431,6 +1434,18 @@ Size2 ItemList::get_minimum_size() const {
 void ItemList::set_autoscroll_to_bottom(const bool p_enable) {
 
 	do_autoscroll_to_bottom = p_enable;
+}
+
+void ItemList::set_auto_width(bool p_enable) {
+
+	auto_width = p_enable;
+	shape_changed = true;
+	update();
+}
+
+bool ItemList::has_auto_width() const {
+
+	return auto_width;
 }
 
 void ItemList::set_auto_height(bool p_enable) {
@@ -1531,6 +1546,9 @@ void ItemList::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_allow_reselect", "allow"), &ItemList::set_allow_reselect);
 	ClassDB::bind_method(D_METHOD("get_allow_reselect"), &ItemList::get_allow_reselect);
 
+	ClassDB::bind_method(D_METHOD("set_auto_width", "enable"), &ItemList::set_auto_width);
+	ClassDB::bind_method(D_METHOD("has_auto_width"), &ItemList::has_auto_width);
+
 	ClassDB::bind_method(D_METHOD("set_auto_height", "enable"), &ItemList::set_auto_height);
 	ClassDB::bind_method(D_METHOD("has_auto_height"), &ItemList::has_auto_height);
 
@@ -1554,6 +1572,7 @@ void ItemList::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_rmb_select"), "set_allow_rmb_select", "get_allow_rmb_select");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_text_lines"), "set_max_text_lines", "get_max_text_lines");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_width"), "set_auto_width", "has_auto_width");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_height"), "set_auto_height", "has_auto_height");
 	ADD_GROUP("Columns", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_columns"), "set_max_columns", "get_max_columns");
@@ -1592,6 +1611,8 @@ ItemList::ItemList() {
 	same_column_width = false;
 	max_text_lines = 1;
 	max_columns = 1;
+	auto_width = false;
+	auto_width_value = 0.0f;
 	auto_height = false;
 	auto_height_value = 0.0f;
 

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -955,7 +955,7 @@ void ItemList::_notification(int p_what) {
 							separators.push_back(ofs.y + max_h + vseparation / 2);
 
 						for (int j = i; j >= 0 && col > 0; j--, col--) {
-							items.write[j].rect_cache.size.y = max_h; 
+							items.write[j].rect_cache.size.y = max_h;
 						}
 
 						ofs.x = 0;
@@ -966,7 +966,7 @@ void ItemList::_notification(int p_what) {
 				}
 
 				for (int j = items.size() - 1; j >= 0 && col > 0; j--, col--) {
-					items.write[j].rect_cache.size.y = max_h; 
+					items.write[j].rect_cache.size.y = max_h;
 				}
 
 				if (all_fit) {

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -82,6 +82,9 @@ private:
 	bool ensure_selected_visible;
 	bool same_column_width;
 
+	bool auto_width;
+	float auto_width_value;
+
 	bool auto_height;
 	float auto_height_value;
 
@@ -222,6 +225,9 @@ public:
 
 	void set_icon_scale(real_t p_scale);
 	real_t get_icon_scale() const;
+
+	void set_auto_width(bool p_enable);
+	bool has_auto_width() const;
 
 	void set_auto_height(bool p_enable);
 	bool has_auto_height() const;


### PR DESCRIPTION
I have implemented the 'Auto width' in ItemList. This is also in response to https://github.com/godotengine/godot/issues/31504 

The behaviour in this pull request should be identical to the existing 'Auto height', i.e. : expands the container & parent containers with the content but **does not shrink** the container or any parent container.

This change is a minimal change that serves to complement the existing 'Auto height' but perhaps both options should be updated to both shrink & expand with the contents?