### PR TITLE
[macOS] Remove CVDisplayLink v-sync hack.

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -113,9 +113,6 @@ public:
 	NSOpenGLContext *context;
 
 	bool layered_window;
-	bool waiting_for_vsync;
-	NSCondition *vsync_condition;
-	CVDisplayLinkRef displayLink;
 
 	CursorShape cursor_shape;
 	NSCursor *cursors[CURSOR_MAX];


### PR DESCRIPTION
Remove macOS v-sync hack introduced in #25443. OS bug was fixed and this hack doesn't work on newer macOS versions.

Fixes #33125, supersedes #33116.