### PR TITLE
 StreamPeer::get_data now returns received size. 

### DIFF
--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -71,14 +71,18 @@ void FileAccessNetworkClient::put_64(int64_t p_64) {
 int FileAccessNetworkClient::get_32() {
 
 	uint8_t buf[4];
-	client->get_data(buf, 4);
+	int received;
+	Error err = client->get_data(buf, 4, received);
+	ERR_FAIL_COND_V(err != OK || received != 4, 0);
 	return decode_uint32(buf);
 }
 
 int64_t FileAccessNetworkClient::get_64() {
 
 	uint8_t buf[8];
-	client->get_data(buf, 8);
+	int received;
+	Error err = client->get_data(buf, 8, received);
+	ERR_FAIL_COND_V(err != OK || received != 8, 0);
 	return decode_uint64(buf);
 }
 
@@ -145,12 +149,16 @@ void FileAccessNetworkClient::_thread_func() {
 			} break;
 			case FileAccessNetwork::RESPONSE_DATA: {
 
+				int received;
 				int64_t offset = get_64();
 				uint32_t len = get_32();
 
 				Vector<uint8_t> block;
 				block.resize(len);
-				client->get_data(block.ptrw(), len);
+				err = client->get_data(block.ptrw(), len, received);
+
+				if (err != OK || (uint32_t)received != len)
+					ERR_PRINT("Invalid response packet");
 
 				if (fa) //may have been queued
 					fa->_set_block(offset, block);

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -683,26 +683,7 @@ bool HTTPClient::is_blocking_mode_enabled() const {
 Error HTTPClient::_get_http_data(uint8_t *p_buffer, int p_bytes, int &r_received) {
 
 	if (blocking) {
-
-		// We can't use StreamPeer.get_data, since when reaching EOF we will get an
-		// error without knowing how many bytes we received.
-		Error err = ERR_FILE_EOF;
-		int read = 0;
-		int left = p_bytes;
-		r_received = 0;
-		while (left > 0) {
-			err = connection->get_partial_data(p_buffer + r_received, left, read);
-			if (err == OK) {
-				r_received += read;
-			} else if (err == ERR_FILE_EOF) {
-				r_received += read;
-				return err;
-			} else {
-				return err;
-			}
-			left -= read;
-		}
-		return err;
+		return connection->get_data(p_buffer, p_bytes, r_received);
 	} else {
 		return connection->get_partial_data(p_buffer, p_bytes, r_received);
 	}

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -53,7 +53,7 @@ public:
 	virtual Error put_data(const uint8_t *p_data, int p_bytes) = 0; ///< put a whole chunk of data, blocking until it sent
 	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) = 0; ///< put as much data as possible, without blocking.
 
-	virtual Error get_data(uint8_t *p_buffer, int p_bytes) = 0; ///< read p_bytes of data, if p_bytes > available, it will block
+	virtual Error get_data(uint8_t *p_buffer, int p_bytes, int &r_read) = 0; ///< read p_bytes of data, if p_bytes > available, it will block
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) = 0; ///< read as much data as p_bytes into buffer, if less was read, return in r_received
 
 	virtual int get_available_bytes() const = 0;
@@ -106,7 +106,7 @@ public:
 	Error put_data(const uint8_t *p_data, int p_bytes);
 	Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent);
 
-	Error get_data(uint8_t *p_buffer, int p_bytes);
+	Error get_data(uint8_t *p_buffer, int p_bytes, int &r_read);
 	Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 
 	virtual int get_available_bytes() const;

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -299,10 +299,9 @@ Error StreamPeerTCP::put_partial_data(const uint8_t *p_data, int p_bytes, int &r
 	return write(p_data, p_bytes, r_sent, false);
 }
 
-Error StreamPeerTCP::get_data(uint8_t *p_buffer, int p_bytes) {
+Error StreamPeerTCP::get_data(uint8_t *p_buffer, int p_bytes, int &r_received) {
 
-	int total;
-	return read(p_buffer, p_bytes, total, true);
+	return read(p_buffer, p_bytes, r_received, true);
 }
 
 Error StreamPeerTCP::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) {

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -81,7 +81,7 @@ public:
 	// Read/Write from StreamPeer
 	Error put_data(const uint8_t *p_data, int p_bytes);
 	Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent);
-	Error get_data(uint8_t *p_buffer, int p_bytes);
+	Error get_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 	Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 
 	StreamPeerTCP();

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -58,8 +58,9 @@ void EditorFileServer::_subthread_start(void *s) {
 
 	cd->connection->set_no_delay(true);
 	uint8_t buf4[8];
-	Error err = cd->connection->get_data(buf4, 4);
-	if (err != OK) {
+	int received;
+	Error err = cd->connection->get_data(buf4, 4, received);
+	if (err != OK || received != 4) {
 		_close_client(cd);
 		ERR_FAIL_COND(err != OK);
 	}
@@ -74,8 +75,8 @@ void EditorFileServer::_subthread_start(void *s) {
 
 		Vector<char> passutf8;
 		passutf8.resize(passlen + 1);
-		err = cd->connection->get_data((uint8_t *)passutf8.ptr(), passlen);
-		if (err != OK) {
+		err = cd->connection->get_data((uint8_t *)passutf8.ptr(), passlen, received);
+		if (err != OK || received != passlen) {
 			_close_client(cd);
 			ERR_FAIL_COND(err != OK);
 		}
@@ -107,18 +108,18 @@ void EditorFileServer::_subthread_start(void *s) {
 	while (!cd->quit) {
 
 		//wait for ID
-		err = cd->connection->get_data(buf4, 4);
+		err = cd->connection->get_data(buf4, 4, received);
 		DEBUG_TIME("get_data")
 
-		if (err != OK) {
+		if (err != OK || received != 4) {
 			_close_client(cd);
 			ERR_FAIL_COND(err != OK);
 		}
 		int id = decode_uint32(buf4);
 
 		//wait for command
-		err = cd->connection->get_data(buf4, 4);
-		if (err != OK) {
+		err = cd->connection->get_data(buf4, 4, received);
+		if (err != OK || received != 4) {
 			_close_client(cd);
 			ERR_FAIL_COND(err != OK);
 		}
@@ -131,8 +132,8 @@ void EditorFileServer::_subthread_start(void *s) {
 			case FileAccessNetwork::COMMAND_OPEN_FILE: {
 
 				DEBUG_TIME("open_file")
-				err = cd->connection->get_data(buf4, 4);
-				if (err != OK) {
+				err = cd->connection->get_data(buf4, 4, received);
+				if (err != OK || received != 4) {
 					_close_client(cd);
 					ERR_FAIL_COND(err != OK);
 				}
@@ -140,8 +141,8 @@ void EditorFileServer::_subthread_start(void *s) {
 				int namelen = decode_uint32(buf4);
 				Vector<char> fileutf8;
 				fileutf8.resize(namelen + 1);
-				err = cd->connection->get_data((uint8_t *)fileutf8.ptr(), namelen);
-				if (err != OK) {
+				err = cd->connection->get_data((uint8_t *)fileutf8.ptr(), namelen, received);
+				if (err != OK || received != namelen) {
 					_close_client(cd);
 					ERR_FAIL_COND(err != OK);
 				}
@@ -218,8 +219,8 @@ void EditorFileServer::_subthread_start(void *s) {
 			} break;
 			case FileAccessNetwork::COMMAND_READ_BLOCK: {
 
-				err = cd->connection->get_data(buf4, 8);
-				if (err != OK) {
+				err = cd->connection->get_data(buf4, 8, received);
+				if (err != OK || received != 8) {
 					_close_client(cd);
 					ERR_FAIL_COND(err != OK);
 				}
@@ -228,8 +229,8 @@ void EditorFileServer::_subthread_start(void *s) {
 
 				uint64_t offset = decode_uint64(buf4);
 
-				err = cd->connection->get_data(buf4, 4);
-				if (err != OK) {
+				err = cd->connection->get_data(buf4, 4, received);
+				if (err != OK || received != 4) {
 					_close_client(cd);
 					ERR_FAIL_COND(err != OK);
 				}

--- a/modules/gdnative/include/net/godot_net.h
+++ b/modules/gdnative/include/net/godot_net.h
@@ -50,7 +50,7 @@ typedef struct {
 	godot_object *data; /* User reference */
 
 	/* This is StreamPeer */
-	godot_error (*get_data)(void *user, uint8_t *p_buffer, int p_bytes);
+	godot_error (*get_data)(void *user, uint8_t *p_buffer, int p_bytes, int *r_received);
 	godot_error (*get_partial_data)(void *user, uint8_t *p_buffer, int p_bytes, int *r_received);
 	godot_error (*put_data)(void *user, const uint8_t *p_data, int p_bytes);
 	godot_error (*put_partial_data)(void *user, const uint8_t *p_data, int p_bytes, int *r_sent);

--- a/modules/gdnative/net/stream_peer_gdnative.cpp
+++ b/modules/gdnative/net/stream_peer_gdnative.cpp
@@ -54,9 +54,9 @@ Error StreamPeerGDNative::put_partial_data(const uint8_t *p_data, int p_bytes, i
 	return (Error)(interface->put_partial_data(interface->data, p_data, p_bytes, &r_sent));
 }
 
-Error StreamPeerGDNative::get_data(uint8_t *p_buffer, int p_bytes) {
+Error StreamPeerGDNative::get_data(uint8_t *p_buffer, int p_bytes, int &r_received) {
 	ERR_FAIL_COND_V(interface == NULL, ERR_UNCONFIGURED);
-	return (Error)(interface->get_data(interface->data, p_buffer, p_bytes));
+	return (Error)(interface->get_data(interface->data, p_buffer, p_bytes, &r_received));
 }
 
 Error StreamPeerGDNative::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) {

--- a/modules/gdnative/net/stream_peer_gdnative.h
+++ b/modules/gdnative/net/stream_peer_gdnative.h
@@ -53,7 +53,7 @@ public:
 	/* Specific to StreamPeer */
 	Error put_data(const uint8_t *p_data, int p_bytes);
 	Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent);
-	Error get_data(uint8_t *p_buffer, int p_bytes);
+	Error get_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 	Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 	int get_available_bytes() const;
 };

--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -198,23 +198,23 @@ Error StreamPeerMbedTLS::put_partial_data(const uint8_t *p_data, int p_bytes, in
 	return OK;
 }
 
-Error StreamPeerMbedTLS::get_data(uint8_t *p_buffer, int p_bytes) {
+Error StreamPeerMbedTLS::get_data(uint8_t *p_buffer, int p_bytes, int &r_received) {
 
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_UNCONFIGURED);
 
 	Error err;
 
-	int got = 0;
+	int got;
 	while (p_bytes > 0) {
 
 		err = get_partial_data(p_buffer, p_bytes, got);
+		r_received += got;
+		p_buffer += got;
+		p_bytes -= got;
 
 		if (err != OK) {
 			return err;
 		}
-
-		p_buffer += got;
-		p_bytes -= got;
 	}
 
 	return OK;

--- a/modules/mbedtls/stream_peer_mbedtls.h
+++ b/modules/mbedtls/stream_peer_mbedtls.h
@@ -65,7 +65,7 @@ public:
 	virtual Error put_data(const uint8_t *p_data, int p_bytes);
 	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent);
 
-	virtual Error get_data(uint8_t *p_buffer, int p_bytes);
+	virtual Error get_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 
 	virtual int get_available_bytes() const;


### PR DESCRIPTION
Must still return `ERR_*` when `received != p_bytes`.

HTTPClient uses blocking TCP read in thread mode.

Potential fix for #33479 .

**This breaks GDNative compat with 3.1**.

`FileAccessNetworkClient` needs more testing.

Probably too late to merge for `3.2` pushing to `4.0`.