### PR TITLE
Notify user when trying to free locked references.

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -510,6 +510,12 @@ private:
 	void *_script_instance_bindings[MAX_SCRIPT_INSTANCE_BINDINGS];
 
 protected:
+#ifdef DEBUG_ENABLED
+	_FORCE_INLINE_ bool _is_locked() { return _lock_index.get() > 1; }
+#else
+	_FORCE_INLINE_ bool _is_locked() { return false; }
+#endif
+
 	virtual void _initialize_classv() { initialize_class(); }
 	virtual bool _setv(const StringName &p_name, const Variant &p_property) { return false; };
 	virtual bool _getv(const StringName &p_name, Variant &r_property) const { return false; };

--- a/core/reference.cpp
+++ b/core/reference.cpp
@@ -97,6 +97,7 @@ bool Reference::unreference() {
 				}
 			}
 		}
+		ERR_FAIL_COND_V_MSG(_is_locked() && die, false, "Reference is locked and can't be freed. You are leaking memory! This will likely cause crashes in release builds.");
 	}
 
 	return die;


### PR DESCRIPTION
This explains #33279 , #33290 . Demos will need to be fixed too if this is confirmed to be the desired approach.

The reference will not be freed when debug is enabled, causing a memory leak as explained by the message.

**Needs review from @reduz** : I hope I understood well what you suggested.