### PR TITLE
Fix GL error by properly using float uniform

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1853,7 +1853,7 @@ void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 
 		// Very large Panoramas require way too much effort to compute irradiance so use a mipmap
 		// level that corresponds to a panorama of 1024x512
-		shaders.cubemap_filter.set_uniform(CubemapFilterShaderGLES3::SOURCE_MIP_LEVEL, MAX(Math::log(float(texture->width)) / Math::log(2.0f) - 10.0f, 0.0f));
+		shaders.cubemap_filter.set_uniform(CubemapFilterShaderGLES3::SOURCE_MIP_LEVEL, MAX(Math::floor(Math::log(float(texture->width)) / Math::log(2.0f)) - 10.0f, 0.0f));
 
 		for (int i = 0; i < 2; i++) {
 			glViewport(0, i * size, size, size);

--- a/drivers/gles3/shaders/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/cubemap_filter.glsl
@@ -35,7 +35,7 @@ uniform sampler2D source_dual_paraboloid; //texunit:0
 #endif
 
 #if defined(USE_SOURCE_DUAL_PARABOLOID) || defined(COMPUTE_IRRADIANCE)
-uniform int source_mip_level;
+uniform float source_mip_level;
 #endif
 
 #if !defined(USE_SOURCE_DUAL_PARABOLOID_ARRAY) && !defined(USE_SOURCE_PANORAMA) && !defined(USE_SOURCE_DUAL_PARABOLOID)
@@ -236,7 +236,7 @@ vec4 textureDualParaboloid(vec3 normal) {
 	if (norm.z < 0.0) {
 		norm.y = 0.5 - norm.y + 0.5;
 	}
-	return textureLod(source_dual_paraboloid, norm.xy, float(source_mip_level));
+	return textureLod(source_dual_paraboloid, norm.xy, source_mip_level);
 }
 
 #endif


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/33787

In my previous fix I thought I was already using floats in the shader. Turns out I wasn't...

For some off reason I am not getting any error output, not even when running verbose. It could be because NVidia drivers just don't care, or it could be the same reason why I no longer get backtraces.

