### PR TITLE
Setting the node process priority should not trigger an error

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -835,19 +835,26 @@ bool Node::is_processing_internal() const {
 void Node::set_process_priority(int p_priority) {
 	data.process_priority = p_priority;
 
-	ERR_FAIL_COND(!data.tree);
+	// Make sure we are in SceneTree.
+	if (data.tree == NULL) {
+		return;
+	}
 
-	if (is_processing())
+	if (is_processing()) {
 		data.tree->make_group_changed("idle_process");
+	}
 
-	if (is_processing_internal())
+	if (is_processing_internal()) {
 		data.tree->make_group_changed("idle_process_internal");
+	}
 
-	if (is_physics_processing())
+	if (is_physics_processing()) {
 		data.tree->make_group_changed("physics_process");
+	}
 
-	if (is_physics_processing_internal())
+	if (is_physics_processing_internal()) {
 		data.tree->make_group_changed("physics_process_internal");
+	}
 }
 
 int Node::get_process_priority() const {


### PR DESCRIPTION
Fixes #33749
This function can be called outside the scene tree.