### PR TITLE
Moved OS::set_cmdline

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -822,6 +822,22 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		FileAccess::make_default<FileAccessNetwork>(FileAccess::ACCESS_RESOURCES);
 	}
 
+#ifdef TOOLS_ENABLED
+	if (editor) {
+		Engine::get_singleton()->set_editor_hint(true);
+		main_args.push_back("--editor");
+		if (!init_windowed) {
+			init_maximized = true;
+			video_mode.maximized = true;
+		}
+	}
+
+	if (!project_manager) {
+		// Determine if the project manager should be requested
+		project_manager = main_args.size() == 0 && !found_project;
+	}
+#endif
+
 	OS::get_singleton()->set_cmdline(execpath, main_args);
 
 	if (globals->setup(project_path, main_pack, upwards) == OK) {
@@ -905,22 +921,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		int max_files = GLOBAL_GET("logging/file_logging/max_log_files");
 		OS::get_singleton()->add_logger(memnew(RotatedFileLogger(base_path, max_files)));
 	}
-
-#ifdef TOOLS_ENABLED
-	if (editor) {
-		Engine::get_singleton()->set_editor_hint(true);
-		main_args.push_back("--editor");
-		if (!init_windowed) {
-			init_maximized = true;
-			video_mode.maximized = true;
-		}
-	}
-
-	if (!project_manager) {
-		// Determine if the project manager should be requested
-		project_manager = main_args.size() == 0 && !found_project;
-	}
-#endif
 
 	if (main_args.size() == 0 && String(GLOBAL_DEF("application/run/main_scene", "")) == "") {
 #ifdef TOOLS_ENABLED

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -822,6 +822,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		FileAccess::make_default<FileAccessNetwork>(FileAccess::ACCESS_RESOURCES);
 	}
 
+	OS::get_singleton()->set_cmdline(execpath, main_args);
+
 	if (globals->setup(project_path, main_pack, upwards) == OK) {
 #ifdef TOOLS_ENABLED
 		found_project = true;
@@ -948,8 +950,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (quiet_stdout)
 		_print_line_enabled = false;
-
-	OS::get_singleton()->set_cmdline(execpath, main_args);
 
 	GLOBAL_DEF("rendering/quality/driver/driver_name", "GLES3");
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/driver/driver_name", PropertyInfo(Variant::STRING, "rendering/quality/driver/driver_name", PROPERTY_HINT_ENUM, "GLES2,GLES3"));


### PR DESCRIPTION
OS::set_cmdline sets executable path, which is then used in ProjectSettings::_setup (which is called by ProjectSettings::setup)

in project_settings.cpp:350
`String exec_path = OS::get_singleton()->get_executable_path();`
In such case get_executable_path() always returns ""