### PR TITLE
Force duplication of sub-resource to fix make sub-resources unique on MeshInstance

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -99,7 +99,7 @@ void InspectorDock::_menu_option(int p_option) {
 							if (res.is_valid()) {
 
 								if (!duplicates.has(res)) {
-									duplicates[res] = res->duplicate();
+									duplicates[res] = res->duplicate(true);
 								}
 								res = duplicates[res];
 


### PR DESCRIPTION
Force duplication of sub-resources on "make sub-resources unique".  This fixes #33823 

Attached GIF showing this fix works:

![](https://user-images.githubusercontent.com/4380009/69456717-2fc86c00-0d20-11ea-8cd8-4713991296b9.gif)
