### PR TITLE
Use the CanvasItemEditor info overlay to display TileMap coordinates

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -109,7 +109,6 @@ class TileMapEditor : public VBoxContainer {
 
 	bool selection_active;
 	bool mouse_over;
-	bool show_tile_info;
 
 	bool flip_h;
 	bool flip_v;
@@ -218,6 +217,7 @@ protected:
 public:
 	HBoxContainer *get_toolbar() const { return toolbar; }
 	HBoxContainer *get_toolbar_right() const { return toolbar_right; }
+	Label *get_tile_info() const { return tile_info; }
 
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
 	void forward_canvas_draw_over_viewport(Control *p_overlay);


### PR DESCRIPTION
This also removes the editor setting that toggles coordinate display, as it no longer solves an existing bug.

This closes #28135.

## Preview

![Editor with new position for the tilemap coordinates](https://user-images.githubusercontent.com/180032/69465943-f70dae80-0d82-11ea-8a66-3c89699d90e8.png)
