### PR TITLE
Fixed index out of size error in TextEdit when opening scripts

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4593,6 +4593,7 @@ void TextEdit::_scroll_moved(double p_to_val) {
 					break;
 			}
 		}
+		n_line = MIN(n_line, text.size() - 1);
 		int line_wrap_amount = times_line_wraps(n_line);
 		int wi = line_wrap_amount - (sc - v_scroll_i - 1);
 		wi = CLAMP(wi, 0, line_wrap_amount);


### PR DESCRIPTION
Fixes #33853

In some cases, the scroll value can be high enough for `n_line` to be equal to `text.size()` after going through this loop without a break:
https://github.com/godotengine/godot/blob/636bc5c32f07050fb387a7f8f5f78f7dc9aef7be/scene/gui/text_edit.cpp#L4588-L4596