### PR TITLE
StyleBox preview adjusted to fit all drawn content

### DIFF
--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -68,7 +68,14 @@ void StyleBoxPreview::_sb_changed() {
 
 void StyleBoxPreview::_redraw() {
 	if (stylebox.is_valid()) {
-		preview->draw_style_box(stylebox, preview->get_rect());
+		Rect2 preview_rect = preview->get_rect();
+
+		// Re-adjust preview panel to fit all drawn content
+		Rect2 draw_rect = stylebox->get_draw_rect(preview_rect);
+		preview_rect.size -= draw_rect.size - preview_rect.size;
+		preview_rect.position -= draw_rect.position - preview_rect.position;
+
+		preview->draw_style_box(stylebox, preview_rect);
 	}
 }
 
@@ -81,6 +88,7 @@ void StyleBoxPreview::_bind_methods() {
 StyleBoxPreview::StyleBoxPreview() {
 	preview = memnew(Control);
 	preview->set_custom_minimum_size(Size2(0, 150 * EDSCALE));
+	preview->set_clip_contents(true);
 	preview->connect("draw", this, "_redraw");
 	add_margin_child(TTR("Preview:"), preview);
 }

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -81,6 +81,10 @@ Size2 StyleBox::get_center_size() const {
 	return Size2();
 }
 
+Rect2 StyleBox::get_draw_rect(const Rect2 &p_rect) const {
+	return p_rect;
+}
+
 void StyleBox::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("test_mask", "point", "rect"), &StyleBox::test_mask);
@@ -173,6 +177,10 @@ float StyleBoxTexture::get_style_margin(Margin p_margin) const {
 	ERR_FAIL_INDEX_V((int)p_margin, 4, 0.0);
 
 	return margin[p_margin];
+}
+
+Rect2 StyleBoxTexture::get_draw_rect(const Rect2 &p_rect) const {
+	return p_rect.grow_individual(expand_margin[MARGIN_LEFT], expand_margin[MARGIN_TOP], expand_margin[MARGIN_RIGHT], expand_margin[MARGIN_BOTTOM]);
 }
 
 void StyleBoxTexture::draw(RID p_canvas_item, const Rect2 &p_rect) const {
@@ -685,6 +693,19 @@ inline void adapt_values(int p_index_a, int p_index_b, int *adapted_values, cons
 	adapted_values[p_index_a] = MIN(p_max_a, adapted_values[p_index_a]);
 	adapted_values[p_index_b] = MIN(p_max_b, adapted_values[p_index_b]);
 }
+
+Rect2 StyleBoxFlat::get_draw_rect(const Rect2 &p_rect) const {
+	Rect2 draw_rect = p_rect.grow_individual(expand_margin[MARGIN_LEFT], expand_margin[MARGIN_TOP], expand_margin[MARGIN_RIGHT], expand_margin[MARGIN_BOTTOM]);
+
+	if (shadow_size > 0) {
+		Rect2 shadow_rect = draw_rect.grow(shadow_size);
+		shadow_rect.position += shadow_offset;
+		draw_rect = draw_rect.merge(shadow_rect);
+	}
+
+	return draw_rect;
+}
+
 void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 	//PREPARATIONS

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -56,6 +56,7 @@ public:
 	float get_margin(Margin p_margin) const;
 	virtual Size2 get_center_size() const;
 
+	virtual Rect2 get_draw_rect(const Rect2 &p_rect) const;
 	virtual void draw(RID p_canvas_item, const Rect2 &p_rect) const = 0;
 
 	CanvasItem *get_current_item_drawn() const;
@@ -133,6 +134,7 @@ public:
 	void set_modulate(const Color &p_modulate);
 	Color get_modulate() const;
 
+	virtual Rect2 get_draw_rect(const Rect2 &p_rect) const;
 	virtual void draw(RID p_canvas_item, const Rect2 &p_rect) const;
 
 	StyleBoxTexture();
@@ -227,6 +229,7 @@ public:
 
 	virtual Size2 get_center_size() const;
 
+	virtual Rect2 get_draw_rect(const Rect2 &p_rect) const;
 	virtual void draw(RID p_canvas_item, const Rect2 &p_rect) const;
 
 	StyleBoxFlat();


### PR DESCRIPTION
This change allows StyleBox preview to take shadows and content margins into account to display how a whole panel would be rendered.

The preview control clips contents so that in any case it doesn't bleed on controls around.

Fixes #33801, fixes #32828

| Before  | After |
| ------------- | ------------- |
| ![stylebox_preview_old](https://user-images.githubusercontent.com/1075032/69496890-5a105a00-0ed7-11ea-9a4c-c56676a897ee.png)  | ![stylebox_preview_new](https://user-images.githubusercontent.com/1075032/69496895-6a283980-0ed7-11ea-822f-5d065011da57.png)  |