### PR TITLE
Add download_chunk_size property to HTTPRequest.

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -713,6 +713,10 @@ void HTTPClient::set_read_chunk_size(int p_size) {
 	read_chunk_size = p_size;
 }
 
+int HTTPClient::get_read_chunk_size() const {
+	return read_chunk_size;
+}
+
 HTTPClient::HTTPClient() {
 
 	tcp_connection.instance();
@@ -816,6 +820,7 @@ void HTTPClient::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_response_body_length"), &HTTPClient::get_response_body_length);
 	ClassDB::bind_method(D_METHOD("read_response_body_chunk"), &HTTPClient::read_response_body_chunk);
 	ClassDB::bind_method(D_METHOD("set_read_chunk_size", "bytes"), &HTTPClient::set_read_chunk_size);
+	ClassDB::bind_method(D_METHOD("get_read_chunk_size"), &HTTPClient::get_read_chunk_size);
 
 	ClassDB::bind_method(D_METHOD("set_blocking_mode", "enabled"), &HTTPClient::set_blocking_mode);
 	ClassDB::bind_method(D_METHOD("is_blocking_mode_enabled"), &HTTPClient::is_blocking_mode_enabled);
@@ -827,6 +832,7 @@ void HTTPClient::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "blocking_mode_enabled"), "set_blocking_mode", "is_blocking_mode_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "connection", PROPERTY_HINT_RESOURCE_TYPE, "StreamPeer", 0), "set_connection", "get_connection");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "read_chunk_size", PROPERTY_HINT_RANGE, "256,16777216"), "set_read_chunk_size", "get_read_chunk_size");
 
 	BIND_ENUM_CONSTANT(METHOD_GET);
 	BIND_ENUM_CONSTANT(METHOD_HEAD);

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -220,6 +220,7 @@ public:
 	bool is_blocking_mode_enabled() const;
 
 	void set_read_chunk_size(int p_size);
+	int get_read_chunk_size() const;
 
 	Error poll();
 

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -170,15 +170,6 @@
 				Sends the body data raw, as a byte array and does not encode it in any way.
 			</description>
 		</method>
-		<method name="set_read_chunk_size">
-			<return type="void">
-			</return>
-			<argument index="0" name="bytes" type="int">
-			</argument>
-			<description>
-				Sets the size of the buffer used and maximum bytes to read per iteration. See [method read_response_body_chunk].
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="blocking_mode_enabled" type="bool" setter="set_blocking_mode" getter="is_blocking_mode_enabled" default="false">
@@ -186,6 +177,9 @@
 		</member>
 		<member name="connection" type="StreamPeer" setter="set_connection" getter="get_connection">
 			The connection to use for this client.
+		</member>
+		<member name="read_chunk_size" type="int" setter="set_read_chunk_size" getter="get_read_chunk_size" default="4096">
+			The size of the buffer used and maximum bytes to read per iteration. See [method read_response_body_chunk].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -93,6 +93,10 @@
 		<member name="body_size_limit" type="int" setter="set_body_size_limit" getter="get_body_size_limit" default="-1">
 			Maximum allowed size for response bodies.
 		</member>
+		<member name="download_chunk_size" type="int" setter="set_download_chunk_size" getter="get_download_chunk_size" default="4096">
+			The size of the buffer used and maximum bytes to read per iteration. See [member HTTPClient.read_chunk_size].
+			Set this to a higher value (e.g. 65536 for 64 KiB) when downloading large files to achieve better speeds at the cost of memory.
+		</member>
 		<member name="download_file" type="String" setter="set_download_file" getter="get_download_file" default="&quot;&quot;">
 			The file to download into. Will output any received file into it.
 		</member>

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -211,6 +211,10 @@ void HTTPClient::set_read_chunk_size(int p_size) {
 	read_limit = p_size;
 }
 
+int HTTPClient::get_read_chunk_size() const {
+	return read_limit;
+}
+
 Error HTTPClient::poll() {
 
 	switch (status) {

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -457,6 +457,18 @@ String HTTPRequest::get_download_file() const {
 
 	return download_to_file;
 }
+
+void HTTPRequest::set_download_chunk_size(int p_chunk_size) {
+
+	ERR_FAIL_COND(get_http_client_status() != HTTPClient::STATUS_DISCONNECTED);
+
+	client->set_read_chunk_size(p_chunk_size);
+}
+
+int HTTPRequest::get_download_chunk_size() const {
+	return client->get_read_chunk_size();
+}
+
 HTTPClient::Status HTTPRequest::get_http_client_status() const {
 	return client->get_status();
 }
@@ -524,9 +536,13 @@ void HTTPRequest::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_timeout", "timeout"), &HTTPRequest::set_timeout);
 	ClassDB::bind_method(D_METHOD("get_timeout"), &HTTPRequest::get_timeout);
 
+	ClassDB::bind_method(D_METHOD("set_download_chunk_size"), &HTTPRequest::set_download_chunk_size);
+	ClassDB::bind_method(D_METHOD("get_download_chunk_size"), &HTTPRequest::get_download_chunk_size);
+
 	ClassDB::bind_method(D_METHOD("_timeout"), &HTTPRequest::_timeout);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "download_file", PROPERTY_HINT_FILE), "set_download_file", "get_download_file");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "download_chunk_size", PROPERTY_HINT_RANGE, "256,16777216"), "set_download_chunk_size", "get_download_chunk_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_threads"), "set_use_threads", "is_using_threads");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "body_size_limit", PROPERTY_HINT_RANGE, "-1,2000000000"), "set_body_size_limit", "get_body_size_limit");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_redirects", PROPERTY_HINT_RANGE, "-1,64"), "set_max_redirects", "get_max_redirects");

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -126,6 +126,9 @@ public:
 	void set_download_file(const String &p_file);
 	String get_download_file() const;
 
+	void set_download_chunk_size(int p_chunk_size);
+	int get_download_chunk_size() const;
+
 	void set_body_size_limit(int p_bytes);
 	int get_body_size_limit() const;
 


### PR DESCRIPTION
This allows setting the `read_chunk_size` of the internal HTTPClient.
This is important to reduce the allocation overhead and number of file
writes when downloading large files, allowing for better download speed.

Fixes #32807 (the user will need to raise the `download_chunk_size` to a higher value. 64KiB is enough).

```gdscript
extends Control

var done := false
var last_bytes := 0
var time := 0.0 # timer that is restarted ~every second
var http

func _ready():
	http = HTTPRequest.new()
	# Sets a 64KiB chunk size
	http.download_chunk_size = pow(2,16)
	add_child(http)
	http.use_threads = true
	http.download_file = "100MB.bin"
	http.connect("request_completed", self, "_on_file_request_completed")

	# 100MB test file
	http.request("https://speed.hetzner.de/100MB.bin")

func _process(delta):
	if not done and time >= 1:
		var speed_in_bytes = http.get_downloaded_bytes() - last_bytes
		var speed_in_mega_bytes = speed_in_bytes / 1000000.0
		
		print(speed_in_mega_bytes, " MB/s")
		
		last_bytes = http.get_downloaded_bytes()
		time = 0
	time += delta

func _on_file_request_completed(result, response_code, headers, body):
	done = true
	print("File downloaded")

```

In general, and like in other cases in Godot networking, we are doing some extra buffering, which could be cleaned up in the future.