### PR TITLE
Fix WindowDialog moving when resized from the left/top edge

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -161,7 +161,7 @@ void WindowDialog::_gui_input(const Ref<InputEvent> &p_event) {
 			global_pos.y = MAX(global_pos.y, 0); // Ensure title bar stays visible.
 
 			Rect2 rect = get_rect();
-			Size2 min_size = get_minimum_size();
+			Size2 min_size = get_combined_minimum_size();
 
 			if (drag_type == DRAG_MOVE) {
 				rect.position = global_pos - drag_offset;


### PR DESCRIPTION
`get_combined_minimum_size()` must be used in order to consider the min size specified by the user when determining how far the left/top edge is allowed to move. Otherwise the dialog may think it can shrink further than it should, causing the right/bottom edge to move when the rect size is fixed in `set_size()`.

Fixes #23831