### PR TITLE
Removed translation for bookmarks menu item name in TextEditor

### DIFF
--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -713,7 +713,7 @@ TextEditor::TextEditor() {
 	goto_menu->get_popup()->add_separator();
 
 	bookmarks_menu = memnew(PopupMenu);
-	bookmarks_menu->set_name(TTR("Bookmarks"));
+	bookmarks_menu->set_name("Bookmarks");
 	goto_menu->get_popup()->add_child(bookmarks_menu);
 	goto_menu->get_popup()->add_submenu_item(TTR("Bookmarks"), "Bookmarks");
 	_update_bookmark_list();


### PR DESCRIPTION
Only the label's text needs a translation, and it could cause issues when getting the node by name in a different language.

Now `TextEditor` bookmarks sub-menu is set up the same way as in `ScriptTextEditor` and `ShaderEditor`.