### PR TITLE
[macOS] Fix locale detection.

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -2224,7 +2224,7 @@ Error OS_OSX::shell_open(String p_uri) {
 }
 
 String OS_OSX::get_locale() const {
-	NSString *locale_code = [[NSLocale currentLocale] localeIdentifier];
+	NSString *locale_code = [[NSLocale preferredLanguages] objectAtIndex:0];
 	return [locale_code UTF8String];
 }
 


### PR DESCRIPTION
Fixes #31673
Fixes #33875

`[NSLocale currentLocale]` seems to work only in console, `[NSLocale preferredLanguages]` works for both console and bundled apps.