### PR TITLE
Fix bug where SpecularMode DISABLED is not cached

### DIFF
--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -252,7 +252,7 @@ private:
 			uint64_t flags : 18;
 			uint64_t detail_blend_mode : 2;
 			uint64_t diffuse_mode : 3;
-			uint64_t specular_mode : 2;
+			uint64_t specular_mode : 3;
 			uint64_t invalid_key : 1;
 			uint64_t deep_parallax : 1;
 			uint64_t billboard_mode : 2;


### PR DESCRIPTION
Bug was unreported. But we have 5 SpecularModes, and we were caching them using only 2 bits...

CC @akien-mga 

_edit:_  introduced by https://github.com/godotengine/godot/commit/e577c5b0705168177943fcdf9a0b66c1f8f864f3 