### PR TITLE
godot exit code improvement for --script --check-only, fixes #33895

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1517,6 +1517,9 @@ bool Main::start() {
 		ERR_FAIL_COND_V_MSG(script_res.is_null(), false, "Can't load script: " + script);
 
 		if (check_only) {
+			if (!script_res->is_valid()) {
+				OS::get_singleton()->set_exit_code(1);
+			}
 			return false;
 		}
 


### PR DESCRIPTION
this commit causes godot executable to return non-zero exit code
once invalid script is passed via `--script` during `--check-only`

```
$ ./bin/godot.x11.tools.64 --check-only -s samples/fine.gd &>/dev/null; echo $?
0
$ ./bin/godot.x11.tools.64 --check-only -s samples/non_compiling.gd &>/dev/null; echo $?
1
```

*Bugsquad edit:* Fixes #33895.