### PR TITLE
Range: Fix cases where max was set to or below min value

### DIFF
--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -702,13 +702,13 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 		bottom_hb->set_h_size_flags(SIZE_EXPAND_FILL);
 
 		min_value = memnew(SpinBox);
-		min_value->set_max(0);
 		min_value->set_min(-10000);
+		min_value->set_max(0);
 		min_value->set_step(0.01);
 
 		max_value = memnew(SpinBox);
-		max_value->set_max(10000);
 		max_value->set_min(0.01);
+		max_value->set_max(10000);
 		max_value->set_step(0.01);
 
 		label_value = memnew(LineEdit);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -969,16 +969,16 @@ void ItemList::_notification(int p_what) {
 				}
 
 				if (all_fit) {
-					float page = size.height - bg->get_minimum_size().height;
+					float page = MAX(0, size.height - bg->get_minimum_size().height);
 					float max = MAX(page, ofs.y + max_h);
 					if (auto_height)
 						auto_height_value = ofs.y + max_h + bg->get_minimum_size().height;
-					scroll_bar->set_max(max);
-					scroll_bar->set_page(page);
 					if (max <= page) {
 						scroll_bar->set_value(0);
 						scroll_bar->hide();
 					} else {
+						scroll_bar->set_max(max);
+						scroll_bar->set_page(page);
 						scroll_bar->show();
 
 						if (do_autoscroll_to_bottom)

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -100,6 +100,7 @@ void Range::set_value(double p_val) {
 	shared->emit_value_changed();
 }
 void Range::set_min(double p_min) {
+	ERR_FAIL_COND_MSG(p_min >= shared->max, "Range cannot have min value higher or equal to its max value.");
 
 	shared->min = p_min;
 	set_value(shared->val);
@@ -109,6 +110,7 @@ void Range::set_min(double p_min) {
 	update_configuration_warning();
 }
 void Range::set_max(double p_max) {
+	ERR_FAIL_COND_MSG(p_max <= shared->min, "Range cannot have max value lower or equal to its min value.");
 
 	shared->max = p_max;
 	set_value(shared->val);

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -388,7 +388,6 @@ void ScrollContainer::update_scrollbars() {
 	if (hide_scroll_v) {
 
 		v_scroll->hide();
-		v_scroll->set_max(0);
 		scroll.y = 0;
 	} else {
 
@@ -406,7 +405,6 @@ void ScrollContainer::update_scrollbars() {
 	if (hide_scroll_h) {
 
 		h_scroll->hide();
-		h_scroll->set_max(0);
 		scroll.x = 0;
 	} else {
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -417,7 +417,6 @@ void TextEdit::_update_scrollbars() {
 		cursor.line_ofs = 0;
 		cursor.wrap_ofs = 0;
 		v_scroll->set_value(0);
-		v_scroll->set_max(0);
 		v_scroll->hide();
 	}
 
@@ -436,7 +435,6 @@ void TextEdit::_update_scrollbars() {
 
 		cursor.x_ofs = 0;
 		h_scroll->set_value(0);
-		h_scroll->set_max(0);
 		h_scroll->hide();
 	}
 


### PR DESCRIPTION
It will now raise an error whenever this happens so that we can fix
these situations. `max == min` is not allowed as it could lead to
divisions by zero in ratios, and `max < min` doesn't make much sense.

Fixes #33907.