### PR TITLE
Android singleton, support taking MulticastLock manually

### DIFF
--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -37,6 +37,12 @@ void PacketPeerUDP::set_blocking_mode(bool p_enable) {
 	blocking = p_enable;
 }
 
+void PacketPeerUDP::set_broadcast_enabled(bool p_enabled) {
+	broadcast = p_enabled;
+	if (_sock.is_valid() && _sock->is_open())
+		_sock->set_broadcasting_enabled(p_enabled);
+}
+
 Error PacketPeerUDP::join_multicast_group(IP_Address p_multi_address, String p_if_name) {
 
 	ERR_FAIL_COND_V(!_sock.is_valid(), ERR_UNAVAILABLE);
@@ -47,6 +53,7 @@ Error PacketPeerUDP::join_multicast_group(IP_Address p_multi_address, String p_i
 		Error err = _sock->open(NetSocket::TYPE_UDP, ip_type);
 		ERR_FAIL_COND_V(err != OK, err);
 		_sock->set_blocking_enabled(false);
+		_sock->set_broadcasting_enabled(broadcast);
 	}
 	return _sock->join_multicast_group(p_multi_address, p_if_name);
 }
@@ -122,6 +129,7 @@ Error PacketPeerUDP::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 		err = _sock->open(NetSocket::TYPE_UDP, ip_type);
 		ERR_FAIL_COND_V(err != OK, err);
 		_sock->set_blocking_enabled(false);
+		_sock->set_broadcasting_enabled(broadcast);
 	}
 
 	do {
@@ -165,6 +173,7 @@ Error PacketPeerUDP::listen(int p_port, const IP_Address &p_bind_address, int p_
 
 	_sock->set_blocking_enabled(false);
 	_sock->set_reuse_address_enabled(true);
+	_sock->set_broadcasting_enabled(broadcast);
 	err = _sock->bind(p_bind_address, p_port);
 
 	if (err != OK) {
@@ -258,6 +267,7 @@ void PacketPeerUDP::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_packet_ip"), &PacketPeerUDP::_get_packet_ip);
 	ClassDB::bind_method(D_METHOD("get_packet_port"), &PacketPeerUDP::get_packet_port);
 	ClassDB::bind_method(D_METHOD("set_dest_address", "host", "port"), &PacketPeerUDP::_set_dest_address);
+	ClassDB::bind_method(D_METHOD("set_broadcast_enabled", "enabled"), &PacketPeerUDP::set_broadcast_enabled);
 	ClassDB::bind_method(D_METHOD("join_multicast_group", "multicast_address", "interface_name"), &PacketPeerUDP::join_multicast_group);
 	ClassDB::bind_method(D_METHOD("leave_multicast_group", "multicast_address", "interface_name"), &PacketPeerUDP::leave_multicast_group);
 }
@@ -267,6 +277,7 @@ PacketPeerUDP::PacketPeerUDP() :
 		queue_count(0),
 		peer_port(0),
 		blocking(true),
+		broadcast(false),
 		_sock(Ref<NetSocket>(NetSocket::create())) {
 	rb.resize(16);
 }

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -53,6 +53,7 @@ protected:
 	IP_Address peer_addr;
 	int peer_port;
 	bool blocking;
+	bool broadcast;
 	Ref<NetSocket> _sock;
 
 	static void _bind_methods();
@@ -77,6 +78,7 @@ public:
 	Error get_packet(const uint8_t **r_buffer, int &r_buffer_size);
 	int get_available_packet_count() const;
 	int get_max_packet_size() const;
+	void set_broadcast_enabled(bool p_enabled);
 	Error join_multicast_group(IP_Address p_multi_address, String p_if_name);
 	Error leave_multicast_group(IP_Address p_multi_address, String p_if_name);
 

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -76,6 +76,15 @@
 				If [code]bind_address[/code] is set to any valid address (e.g. [code]"192.168.1.101"[/code], [code]"::1"[/code], etc), the peer will only listen on the interface with that addresses (or fail if no interface with the given address exists).
 			</description>
 		</method>
+		<method name="set_broadcast_enabled">
+			<return type="void">
+			</return>
+			<argument index="0" name="enabled" type="bool">
+			</argument>
+			<description>
+				Enable or disable sending of broadcast packets (e.g. [code]set_dest_address("255.255.255.255", 4343)[/code]. This option is disabled by default.
+			</description>
+		</method>
 		<method name="set_dest_address">
 			<return type="int" enum="Error">
 			</return>
@@ -85,6 +94,7 @@
 			</argument>
 			<description>
 				Sets the destination address and port for sending packets and variables. A hostname will be resolved using DNS if needed.
+				Note: [method set_broadcast_enabled] must be enabled before sending packets to a broadcast address (e.g. [code]255.255.255.255[/code]).
 			</description>
 		</method>
 		<method name="wait">

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -333,9 +333,10 @@ Error NetSocketPosix::open(Type p_sock_type, IP::Type &ip_type) {
 		set_ipv6_only_enabled(ip_type != IP::TYPE_ANY);
 	}
 
-	if (protocol == IPPROTO_UDP && ip_type != IP::TYPE_IPV6) {
-		// Enable broadcasting for UDP sockets if it's not IPv6 only (IPv6 has no broadcast option).
-		set_broadcasting_enabled(true);
+	if (protocol == IPPROTO_UDP) {
+		// Make sure to disable broadcasting for UDP sockets.
+		// Depending on the OS, this option might or might not be enabled by default. Let's normilize it.
+		set_broadcasting_enabled(false);
 	}
 
 	_is_stream = p_sock_type == TYPE_TCP;
@@ -606,7 +607,8 @@ Error NetSocketPosix::sendto(const uint8_t *p_buffer, int p_len, int &r_sent, IP
 void NetSocketPosix::set_broadcasting_enabled(bool p_enabled) {
 	ERR_FAIL_COND(!is_open());
 	// IPv6 has no broadcast support.
-	ERR_FAIL_COND(_ip_type == IP::TYPE_IPV6);
+	if (_ip_type == IP::TYPE_IPV6)
+		return;
 
 	int par = p_enabled ? 1 : 0;
 	if (setsockopt(_sock, SOL_SOCKET, SO_BROADCAST, SOCK_CBUF(&par), sizeof(int)) != 0) {

--- a/platform/android/api/api.cpp
+++ b/platform/android/api/api.cpp
@@ -1,0 +1,103 @@
+/*************************************************************************/
+/*  api.cpp                                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "api.h"
+#include "core/engine.h"
+#ifdef ANDROID_ENABLED
+#include "platform/android/java_godot_io_wrapper.h"
+#include "platform/android/os_android.h"
+#endif
+
+#include "core/object.h"
+
+class Android : public Object {
+private:
+	GDCLASS(Android, Object);
+
+	static Android *singleton;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void multicast_lock_acquire();
+	void multicast_lock_release();
+
+	static Android *get_singleton();
+	Android();
+	~Android();
+};
+
+static Android *android_api;
+
+void register_android_api() {
+
+	ClassDB::register_virtual_class<Android>();
+	android_api = memnew(Android);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Android", android_api));
+}
+
+void unregister_android_api() {
+
+	memdelete(android_api);
+}
+
+Android *Android::singleton = NULL;
+
+Android *Android::get_singleton() {
+
+	return singleton;
+}
+
+Android::Android() {
+
+	ERR_FAIL_COND_MSG(singleton != NULL, "Android singleton already exist.");
+	singleton = this;
+}
+
+Android::~Android() {}
+
+void Android::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("multicast_lock_acquire"), &Android::multicast_lock_acquire);
+	ClassDB::bind_method(D_METHOD("multicast_lock_release"), &Android::multicast_lock_release);
+}
+
+void Android::multicast_lock_acquire() {
+#ifdef ANDROID_ENABLED
+	((OS_Android *)OS::get_singleton())->get_godot_io_java()->multicast_lock_acquire();
+#endif
+}
+
+void Android::multicast_lock_release() {
+#ifdef ANDROID_ENABLED
+	((OS_Android *)OS::get_singleton())->get_godot_io_java()->multicast_lock_release();
+#endif
+}

--- a/platform/android/api/api.h
+++ b/platform/android/api/api.h
@@ -1,0 +1,32 @@
+/*************************************************************************/
+/*  api.h                                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+void register_android_api();
+void unregister_android_api();

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -35,6 +35,7 @@ import android.content.pm.ActivityInfo;
 import android.content.res.AssetManager;
 import android.media.*;
 import android.net.Uri;
+import android.net.wifi.WifiManager;
 import android.os.*;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -54,6 +55,9 @@ public class GodotIO {
 	GodotEditText edit;
 
 	MediaPlayer mediaPlayer;
+
+	WifiManager.MulticastLock multicastLock;
+	boolean hasMulticastLock;
 
 	final int SCREEN_LANDSCAPE = 0;
 	final int SCREEN_PORTRAIT = 1;
@@ -345,6 +349,10 @@ public class GodotIO {
 		//streams = new HashMap<Integer, AssetData>();
 		streams = new SparseArray<AssetData>();
 		dirs = new SparseArray<AssetDir>();
+		hasMulticastLock = false;
+		WifiManager wifi = (WifiManager)activity.getSystemService(Context.WIFI_SERVICE);
+		multicastLock = wifi.createMulticastLock("GodotMulticastLock");
+		multicastLock.setReferenceCounted(false);
 	}
 
 	/////////////////////////
@@ -440,6 +448,22 @@ public class GodotIO {
 	/////////////////////////
 	// MISCELLANEOUS OS IO
 	/////////////////////////
+
+	public void multicastLockAcquire() {
+		try {
+			multicastLock.acquire();
+		} catch (RuntimeException e) {
+			Log.e("Godot", "Exception during multicast lock acquire: " + e);
+		}
+	}
+
+	public void multicastLockRelease() {
+		try {
+			multicastLock.release();
+		} catch (RuntimeException e) {
+			Log.e("Godot", "Exception during multicast lock release: " + e);
+		}
+	}
 
 	public int openURI(String p_uri) {
 

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -47,6 +47,8 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 			return;
 		}
 
+		_multicast_lock_acquire = p_env->GetMethodID(cls, "multicastLockAcquire", "()V");
+		_multicast_lock_release = p_env->GetMethodID(cls, "multicastLockRelease", "()V");
 		_open_URI = p_env->GetMethodID(cls, "openURI", "(Ljava/lang/String;)I");
 		_get_data_dir = p_env->GetMethodID(cls, "getDataDir", "()Ljava/lang/String;");
 		_get_locale = p_env->GetMethodID(cls, "getLocale", "()Ljava/lang/String;");
@@ -70,6 +72,20 @@ GodotIOJavaWrapper::~GodotIOJavaWrapper() {
 
 jobject GodotIOJavaWrapper::get_instance() {
 	return godot_io_instance;
+}
+
+void GodotIOJavaWrapper::multicast_lock_acquire() {
+	if (_multicast_lock_acquire) {
+		JNIEnv *env = ThreadAndroid::get_env();
+		env->CallVoidMethod(godot_io_instance, _multicast_lock_acquire);
+	}
+}
+
+void GodotIOJavaWrapper::multicast_lock_release() {
+	if (_multicast_lock_release) {
+		JNIEnv *env = ThreadAndroid::get_env();
+		env->CallVoidMethod(godot_io_instance, _multicast_lock_release);
+	}
 }
 
 Error GodotIOJavaWrapper::open_uri(const String &p_uri) {

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -45,6 +45,8 @@ private:
 	jobject godot_io_instance;
 	jclass cls;
 
+	jmethodID _multicast_lock_acquire = 0;
+	jmethodID _multicast_lock_release = 0;
 	jmethodID _open_URI = 0;
 	jmethodID _get_data_dir = 0;
 	jmethodID _get_locale = 0;
@@ -66,6 +68,8 @@ public:
 
 	jobject get_instance();
 
+	void multicast_lock_acquire();
+	void multicast_lock_release();
 	Error open_uri(const String &p_uri);
 	String get_user_data_dir();
 	String get_locale();


### PR DESCRIPTION
This PR is an alternative to #33910 .
Instead of using complex logic to try and automatically take the MulticastLock, this PR exposes a new `"Android"` engine singleton.
That singleton can `acquire` or `release` the lock.
Permission `CHANGE_WIFI_MULTICAST_STATE` is required to acquire the lock.
Like in #33910 UDP broadcast is now off by default.

```gdscript
func _ready():
	Engine.get_singleton("Android").multicast_lock_acquire()
	Engine.get_singleton("Android").multicast_lock_release()
```

Closes #33910
Fixes #24666