### PR TITLE
Revert faulty stripping of / in ProjectSettings::localize_path

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -107,7 +107,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 		if (plocal == "") {
 			return "";
 		};
-		return plocal + path.substr((sep + 1), path.size() - (sep + 1));
+		return plocal + path.substr(sep, path.size() - sep);
 	};
 }
 


### PR DESCRIPTION
Fix #33913 by reverting commit from #33380

Issue #33380 doesn't contain steps to reproduce the bug so I couldn't find out how to reproduce it:'(

