### PR TITLE
Expose Image's locking status as a property

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2379,6 +2379,19 @@ void Image::unlock() {
 	write_lock.release();
 }
 
+void Image::set_locked(bool p_locked) {
+
+	if (p_locked) {
+		lock();
+	} else {
+		unlock();
+	}
+}
+
+bool Image::is_locked() const {
+	return write_lock.ptr() != NULL;
+}
+
 Color Image::get_pixelv(const Point2 &p_src) const {
 	return get_pixel(p_src.x, p_src.y);
 }
@@ -2752,6 +2765,8 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("lock"), &Image::lock);
 	ClassDB::bind_method(D_METHOD("unlock"), &Image::unlock);
+	ClassDB::bind_method(D_METHOD("set_locked", "locked"), &Image::set_locked);
+	ClassDB::bind_method(D_METHOD("is_locked"), &Image::is_locked);
 	ClassDB::bind_method(D_METHOD("get_pixelv", "src"), &Image::get_pixelv);
 	ClassDB::bind_method(D_METHOD("get_pixel", "x", "y"), &Image::get_pixel);
 	ClassDB::bind_method(D_METHOD("set_pixelv", "dst", "color"), &Image::set_pixelv);
@@ -2762,6 +2777,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_webp_from_buffer", "buffer"), &Image::load_webp_from_buffer);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "_set_data", "_get_data");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "locked"), "set_locked", "is_locked");
 
 	BIND_CONSTANT(MAX_WIDTH);
 	BIND_CONSTANT(MAX_HEIGHT);

--- a/core/image.h
+++ b/core/image.h
@@ -336,6 +336,8 @@ public:
 
 	void lock();
 	void unlock();
+	void set_locked(bool p_locked);
+	bool is_locked() const;
 
 	//this is used for compression
 	enum DetectChannels {

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -362,7 +362,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Locks the data for reading and writing access. Sends an error to the console if the image is not locked when reading or writing a pixel.
+				Locks the data for reading and writing access. Sends an error to the console if the image is not locked when reading or writing a pixel. See also [member locked].
 			</description>
 		</method>
 		<method name="normalmap_to_xy">
@@ -485,13 +485,16 @@
 			<return type="void">
 			</return>
 			<description>
-				Unlocks the data and prevents changes.
+				Unlocks the data and prevents changes. See also [member locked].
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;data&quot;: PoolByteArray(  ),&quot;format&quot;: &quot;Lum8&quot;,&quot;height&quot;: 0,&quot;mipmaps&quot;: false,&quot;width&quot;: 0}">
 			Holds all of the image's color data in a given format. See [code]FORMAT_*[/code] constants.
+		</member>
+		<member name="locked" type="bool" setter="set_locked" getter="is_locked" default="false">
+			If [code]true[/code], the image's data can be read and written to using [method get_pixel], [method get_pixelv], [method set_pixel], and [method set_pixelv].
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
This makes it possible to read an Image's current locking status.

This closes https://github.com/godotengine/godot-proposals/issues/212.

## Snippet for testing

```gdscript
func _ready() -> void:
	var image := Image.new()
	image.create(256, 256, false, Image.FORMAT_RGB8)

	image.locked = true
	print(image.locked) # Should print `true`

	image.set_pixel(0, 2, Color(0, 1, 0))

	image.locked = false
	print(image.locked) # Should print `false`
```