### PR TITLE
Fix memory leak in NetworkedMultiplayerENet.

### DIFF
--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -440,6 +440,8 @@ void NetworkedMultiplayerENet::close_connection(uint32_t wait_usec) {
 	for (Map<int, ENetPeer *>::Element *E = peer_map.front(); E; E = E->next()) {
 		if (E->get()) {
 			enet_peer_disconnect_now(E->get(), unique_id);
+			int *id = (int *)(E->get()->data);
+			memdelete(id);
 			peers_disconnected = true;
 		}
 	}
@@ -455,6 +457,7 @@ void NetworkedMultiplayerENet::close_connection(uint32_t wait_usec) {
 	enet_host_destroy(host);
 	active = false;
 	incoming_packets.clear();
+	peer_map.clear();
 	unique_id = 1; // Server is 1
 	connection_status = CONNECTION_DISCONNECTED;
 }
@@ -471,16 +474,22 @@ void NetworkedMultiplayerENet::disconnect_peer(int p_peer, bool now) {
 		// enet_peer_disconnect_now doesn't generate ENET_EVENT_TYPE_DISCONNECT,
 		// notify everyone else, send disconnect signal & remove from peer_map like in poll()
 
+		int *id = NULL;
 		for (Map<int, ENetPeer *>::Element *E = peer_map.front(); E; E = E->next()) {
 
-			if (E->key() == p_peer)
+			if (E->key() == p_peer) {
+				id = (int *)(E->get()->data);
 				continue;
+			}
 
 			ENetPacket *packet = enet_packet_create(NULL, 8, ENET_PACKET_FLAG_RELIABLE);
 			encode_uint32(SYSMSG_REMOVE_PEER, &packet->data[0]);
 			encode_uint32(p_peer, &packet->data[4]);
 			enet_peer_send(E->get(), SYSCH_CONFIG, packet);
 		}
+
+		if (id)
+			memdelete(id);
 
 		emit_signal("peer_disconnected", p_peer);
 		peer_map.erase(p_peer);


### PR DESCRIPTION
Dynamically allocated ids of peers where not correctly freed when calling close_connection and disconnect_peer (with now=true).

Tested with this script:

```gdscript
extends SceneTree

func _init():
	var a = NetworkedMultiplayerENet.new()
	a.connect("peer_disconnected", self, "peer_disconnected")
	a.create_server(4343, 8)

	var cl = []
	for i in range(0,10):
		var p = NetworkedMultiplayerENet.new()
		p.connect("peer_disconnected", self, "peer_disconnected")
		p.connect("peer_connected", self, "peer_connected")
		p.connect("server_disconnected", self, "server_disconnected")
		p.create_client("127.0.0.1", 4343)
		cl.append(p)

	for i in range(0,10):
		_poll(cl + [a])

	# Forcibly disconnect peer 1
	a.disconnect_peer(cl[0].get_unique_id(), true)
	# Voluntarily close connection on peer 2
	cl[1].close_connection()
	# Gracefully disconnect peer 3
	a.disconnect_peer(cl[2].get_unique_id(), true)
	for i in range(0,10):
		_poll(cl + [a])
	a.close_connection()
	for i in range(0,10):
		_poll(cl + [a])
	quit()

func server_disconnected():
	print("Server Disconnected")

func peer_disconnected(id):
	print("Peer Disconnected %d" % id)

func peer_connected(id):
	print("Peer Connected %d" % id)

func _poll(peers):
	for p in peers:
		if p.get_connection_status() == NetworkedMultiplayerPeer.CONNECTION_DISCONNECTED:
			return
		p.poll()
```

Valgrind (without this patch)
--
```
==5269== 
==5269== HEAP SUMMARY:
==5269==     in use at exit: 93,705 bytes in 944 blocks
==5269==   total heap usage: 277,122 allocs, 276,178 frees, 862,595,341 bytes allocated
==5269== 
==5269== LEAK SUMMARY:
==5269==    definitely lost: 320 bytes in 16 blocks
==5269==    indirectly lost: 0 bytes in 0 blocks
==5269==      possibly lost: 104 bytes in 2 blocks
==5269==    still reachable: 93,281 bytes in 926 blocks
==5269==         suppressed: 0 bytes in 0 blocks
==5269== Rerun with --leak-check=full to see details of leaked memory
==5269== 
==5269== For counts of detected and suppressed errors, rerun with: -v
==5269== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Valgrind (with this patch)
--

```
==2625== 
==2625== HEAP SUMMARY:
==2625==     in use at exit: 93,201 bytes in 926 blocks
==2625==   total heap usage: 272,847 allocs, 271,921 frees, 862,203,805 bytes allocated
==2625== 
==2625== LEAK SUMMARY:
==2625==    definitely lost: 0 bytes in 0 blocks
==2625==    indirectly lost: 0 bytes in 0 blocks
==2625==      possibly lost: 104 bytes in 2 blocks
==2625==    still reachable: 93,097 bytes in 924 blocks
==2625==         suppressed: 0 bytes in 0 blocks
==2625== Rerun with --leak-check=full to see details of leaked memory
==2625== 
==2625== For counts of detected and suppressed errors, rerun with: -v
==2625== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```