### PR TITLE
Add ENet option to disable server relaying.

### DIFF
--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -116,6 +116,9 @@
 			The compression method used for network packets. These have different tradeoffs of compression speed versus bandwidth, you may need to test which one works best for your use case if you use compression at all.
 		</member>
 		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" override="true" default="false" />
+		<member name="server_relay" type="bool" setter="set_server_relay_enabled" getter="is_server_relay_enabled" default="true">
+			Enable or disable the server feature that notifies clients of other peers' connection/disconnection, and relays messages between them. When this option is [code]false[/code], clients won't be automatically notified of other peers and won't be able to send them packets through the server.
+		</member>
 		<member name="transfer_channel" type="int" setter="set_transfer_channel" getter="get_transfer_channel" default="-1">
 			Set the default channel to be used to transfer data. By default, this value is [code]-1[/code] which means that ENet will only use 2 channels, one for reliable and one for unreliable packets. Channel [code]0[/code] is reserved, and cannot be used. Setting this member to any value between [code]0[/code] and [member channel_count] (excluded) will force ENet to use that channel for sending data.
 		</member>

--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -78,6 +78,7 @@ private:
 	ENetHost *host;
 
 	bool refuse_connections;
+	bool server_relay;
 
 	ConnectionStatus connection_status;
 
@@ -158,6 +159,8 @@ public:
 	int get_channel_count() const;
 	void set_always_ordered(bool p_ordered);
 	bool is_always_ordered() const;
+	void set_server_relay_enabled(bool p_enabled);
+	bool is_server_relay_enabled() const;
 
 	NetworkedMultiplayerENet();
 	~NetworkedMultiplayerENet();


### PR DESCRIPTION
It's useless when building fully authoritative servers, and prevents various kinds of abuse.

Fixes #27932