### PR TITLE
Remove type hint from the @GDScript class documentation

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -1365,17 +1365,17 @@
 				If passed an object and a signal, the execution is resumed when the object emits the given signal. In this case, [code]yield()[/code] returns the argument passed to [code]emit_signal()[/code] if the signal takes only one argument, or an array containing all the arguments passed to [code]emit_signal()[/code] if the signal takes multiple arguments.
 				You can also use [code]yield[/code] to wait for a function to finish:
 				[codeblock]
-				func _ready -> void:
+				func _ready():
 				    yield(do_something(), "completed")
 				    yield(do_something_else(), "completed")
 				    print("All functions are done!")
 
 				func do_something():
 				    print("Something is done!")
-				
+
 				func do_something_else():
 				    print("Something else is done!")
-				
+
 				# prints:
 				# Something is done!
 				# Something else is done!


### PR DESCRIPTION
The current consensus in the Godot documentation is to avoid using type hints unless they're relevant to the behavior explained. The previous syntax was also incorrect and used an unescaped `>` character (which should have been written as `&gt;`).