### PR TITLE
WebSocket profiler for HTML5 platform.

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -42,6 +42,7 @@
 #include "core/version.h"
 #include "editor/editor_file_system.h"
 #include "editor/plugins/script_editor_plugin.h"
+#include "editor/script_editor_debugger.h"
 #include "editor_node.h"
 #include "editor_settings.h"
 #include "scene/resources/resource_format_text.h"
@@ -1146,6 +1147,11 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 		r_flags.push_back("--debug-navigation");
 	}
 }
+
+ScriptEditorDebuggerServer *EditorExportPlatform::create_debugger_server() {
+	return memnew(ScriptEditorDebuggerTCP);
+}
+
 EditorExportPlatform::EditorExportPlatform() {
 }
 

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -40,6 +40,7 @@
 class FileAccess;
 class EditorExportPlatform;
 class EditorFileSystemDirectory;
+class ScriptEditorDebuggerServer;
 struct EditorProgress;
 
 class EditorExportPreset : public Reference {
@@ -216,6 +217,8 @@ protected:
 	void gen_export_flags(Vector<String> &r_flags, int p_flags);
 
 public:
+	virtual ScriptEditorDebuggerServer *create_debugger_server();
+
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) = 0;
 
 	struct ExportOption {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -166,7 +166,6 @@ private:
 
 		RUN_STOP,
 		RUN_PLAY_SCENE,
-		RUN_PLAY_NATIVE,
 		RUN_PLAY_CUSTOM_SCENE,
 		RUN_SCENE_SETTINGS,
 		RUN_SETTINGS,
@@ -507,6 +506,7 @@ private:
 	void _quick_run();
 
 	void _run(bool p_current = false, const String &p_custom = "");
+	void _native_run(Ref<EditorExportPreset> p_platform);
 
 	void _save_optimized();
 	void _import_action(const String &p_action);

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -133,7 +133,7 @@ void EditorRunNative::_run_native(int p_idx, int p_platform) {
 		return;
 	}
 
-	emit_signal("native_run");
+	emit_signal("native_run", preset);
 
 	int flags = 0;
 	if (deploy_debug_remote)
@@ -156,7 +156,7 @@ void EditorRunNative::_bind_methods() {
 
 	ClassDB::bind_method("_run_native", &EditorRunNative::_run_native);
 
-	ADD_SIGNAL(MethodInfo("native_run"));
+	ADD_SIGNAL(MethodInfo("native_run", PropertyInfo(Variant::OBJECT, "platform")));
 }
 
 void EditorRunNative::set_deploy_dumb(bool p_enabled) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1411,7 +1411,7 @@ void ScriptEditor::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
-			editor->connect("play_pressed", this, "_editor_play");
+			editor->connect("start_debugger", this, "_editor_play");
 			editor->connect("pause_pressed", this, "_editor_pause");
 			editor->connect("stop_pressed", this, "_editor_stop");
 			editor->connect("script_add_function_request", this, "_add_callback");
@@ -1453,7 +1453,7 @@ void ScriptEditor::_notification(int p_what) {
 
 		case NOTIFICATION_EXIT_TREE: {
 
-			editor->disconnect("play_pressed", this, "_editor_play");
+			editor->disconnect("start_debugger", this, "_editor_play");
 			editor->disconnect("pause_pressed", this, "_editor_pause");
 			editor->disconnect("stop_pressed", this, "_editor_stop");
 		} break;
@@ -2248,9 +2248,12 @@ void ScriptEditor::open_script_create_dialog(const String &p_base_name, const St
 	script_create_dialog->config(p_base_name, p_base_path);
 }
 
-void ScriptEditor::_editor_play() {
+void ScriptEditor::_editor_play(Ref<EditorExportPreset> p_preset) {
 
-	debugger->start(memnew(ScriptEditorDebuggerTCP));
+	if (p_preset.is_null())
+		debugger->start(memnew(ScriptEditorDebuggerTCP));
+	else
+		debugger->start(p_preset->get_platform()->create_debugger_server());
 	debug_menu->get_popup()->grab_focus();
 	debug_menu->get_popup()->set_item_disabled(debug_menu->get_popup()->get_item_index(DEBUG_NEXT), true);
 	debug_menu->get_popup()->set_item_disabled(debug_menu->get_popup()->get_item_index(DEBUG_STEP), true);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2250,7 +2250,7 @@ void ScriptEditor::open_script_create_dialog(const String &p_base_name, const St
 
 void ScriptEditor::_editor_play() {
 
-	debugger->start();
+	debugger->start(memnew(ScriptEditorDebuggerTCP));
 	debug_menu->get_popup()->grab_focus();
 	debug_menu->get_popup()->set_item_disabled(debug_menu->get_popup()->get_item_index(DEBUG_NEXT), true);
 	debug_menu->get_popup()->set_item_disabled(debug_menu->get_popup()->get_item_index(DEBUG_STEP), true);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "core/script_language.h"
 #include "editor/code_editor.h"
+#include "editor/editor_export.h"
 #include "editor/editor_help.h"
 #include "editor/editor_help_search.h"
 #include "editor/editor_plugin.h"
@@ -314,7 +315,7 @@ class ScriptEditor : public PanelContainer {
 
 	EditorScriptCodeCompletionCache *completion_cache;
 
-	void _editor_play();
+	void _editor_play(Ref<EditorExportPreset> p_preset);
 	void _editor_pause();
 	void _editor_stop();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -852,7 +852,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (debug_mode == "remote") {
 
-		ScriptDebuggerRemote *sdr = memnew(ScriptDebuggerRemote);
+		ScriptDebuggerRemote *sdr = memnew(ScriptDebuggerRemote(ScriptDebuggerConnection::create()));
 		uint16_t debug_port = 6007;
 		if (debug_host.find(":") != -1) {
 			int sep_pos = debug_host.find_last(":");

--- a/methods.py
+++ b/methods.py
@@ -235,6 +235,14 @@ def win32_spawn(sh, escape, cmd, args, spawnenv):
 def disable_module(self):
     self.disabled_modules.append(self.current_module)
 
+def generate_modules_enabled(target = None, source = None, env = None):
+    with open(target[0].path, 'w') as f:
+        for x in env.module_list:
+            if (x in env.disabled_modules):
+                continue
+
+            f.write('#define %s\n' % ("MODULE_" + x.upper() + "_ENABLED"))
+
 def use_windows_spawn_fix(self, platform=None):
 
     if (os.name != "nt"):

--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -231,6 +231,7 @@ $GODOT_HEAD_INCLUDE
 
 			const EXECUTABLE_NAME = '$GODOT_BASENAME';
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
+			const MAIN_FLAGS = JSON.parse('$GODOT_FLAGS');
 			const DEBUG_ENABLED = $GODOT_DEBUG_ENABLED;
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
@@ -381,7 +382,7 @@ $GODOT_HEAD_INCLUDE
 			} else {
 				setStatusMode('indeterminate');
 				engine.setCanvas(canvas);
-				engine.startGame(EXECUTABLE_NAME, MAIN_PACK).then(() => {
+				engine.startGame(EXECUTABLE_NAME, MAIN_PACK, MAIN_FLAGS).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -144,6 +144,7 @@ $GODOT_HEAD_INCLUDE
 
 			const EXECUTABLE_NAME = '$GODOT_BASENAME';
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
+			const MAIN_FLAGS = JSON.parse('$GODOT_FLAGS');
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
 			var canvas = document.getElementById('canvas');
@@ -255,7 +256,7 @@ $GODOT_HEAD_INCLUDE
 			} else {
 				setStatusMode('indeterminate');
 				engine.setCanvas(canvas);
-				engine.startGame(EXECUTABLE_NAME, MAIN_PACK).then(() => {
+				engine.startGame(EXECUTABLE_NAME, MAIN_PACK, MAIN_FLAGS).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from methods import generate_modules_enabled
+
 Import('env')
 
 env_modules = env.Clone()
@@ -15,6 +17,8 @@ for x in env.module_list:
         continue
     env_modules.Append(CPPDEFINES=["MODULE_" + x.upper() + "_ENABLED"])
     SConscript(x + "/SCsub")
+
+env.Command("modules_enabled.gen.h", Value([sorted(env.module_list), sorted(env.disabled_modules)]), generate_modules_enabled)
 
 if env.split_modules:
     env.split_lib("modules", env_lib = env_modules)

--- a/modules/websocket/script_debugger_websocket.cpp
+++ b/modules/websocket/script_debugger_websocket.cpp
@@ -97,6 +97,14 @@ Ref<PacketPeer> ScriptDebuggerWebSocket::get_peer() {
 	return ws_client->get_peer(1); // should not be cached.
 }
 
+bool ScriptDebuggerWebSocket::can_block() {
+#ifdef JAVASCRIPT_ENABLED
+	return false;
+#else
+	return true;
+#endif
+}
+
 ScriptDebuggerWebSocket::ScriptDebuggerWebSocket() {
 #define _SET_HINT(NAME, _VAL_, _MAX_) \
 	GLOBAL_DEF(NAME, _VAL_);          \

--- a/modules/websocket/script_debugger_websocket.cpp
+++ b/modules/websocket/script_debugger_websocket.cpp
@@ -1,0 +1,122 @@
+/*************************************************************************/
+/*  script_debugger_websocket.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "script_debugger_websocket.h"
+
+#include "core/project_settings.h"
+
+ScriptDebuggerConnection *ScriptDebuggerWebSocket::_create() {
+	return memnew(ScriptDebuggerWebSocket);
+}
+
+void ScriptDebuggerWebSocket::make_default() {
+	ScriptDebuggerConnection::_create = _create;
+}
+
+Error ScriptDebuggerWebSocket::connect_to_host(const String &p_host, uint16_t p_port) {
+
+	IP_Address ip;
+	if (p_host.is_valid_ip_address())
+		ip = p_host;
+	else
+		ip = IP::get_singleton()->resolve_hostname(p_host);
+
+	int port = p_port;
+	Vector<String> protocols;
+	protocols.push_back("binary"); // Compatibility for emscripten TCP-to-WebSocket.
+
+	const int tries = 6;
+	int waits[tries] = { 10, 10, 100, 1000, 1000, 1000 };
+
+	for (int i = 0; i < tries; i++) {
+
+		if (ws_client->get_connection_status() == WebSocketClient::CONNECTION_DISCONNECTED)
+			ws_client->connect_to_url("ws://" + p_host + ":" + itos(port), protocols);
+		ws_client->poll();
+
+		// Wait and poll
+		const int ms = waits[i];
+		for (int j = 0; j < ms; j++) {
+			ws_client->poll();
+			if (is_connected_to_host()) {
+				print_verbose("Remote Debugger: Connected!");
+				return OK;
+			}
+			OS::get_singleton()->delay_usec(1000);
+		}
+		print_verbose("Remote Debugger: Connection failed with status: '" + String::num(ws_client->get_connection_status()) + "', retrying in " + String::num(ms) + " msec.");
+	};
+
+	if (!is_connected_to_host()) {
+
+		ERR_PRINTS("Remote Debugger: Unable to connect. Status: " + String::num(ws_client->get_connection_status()) + ".");
+		return FAILED;
+	};
+
+	return FAILED;
+}
+
+void ScriptDebuggerWebSocket::poll() {
+	ws_client->poll();
+}
+
+bool ScriptDebuggerWebSocket::is_connected_to_host() {
+	return ws_client->get_connection_status() == WebSocketClient::CONNECTION_CONNECTED;
+}
+
+Ref<PacketPeer> ScriptDebuggerWebSocket::get_peer() {
+	if (!is_connected_to_host())
+		return memnew(PacketPeerStream); // avoid returning null.
+	return ws_client->get_peer(1); // should not be cached.
+}
+
+ScriptDebuggerWebSocket::ScriptDebuggerWebSocket() {
+#define _SET_HINT(NAME, _VAL_, _MAX_) \
+	GLOBAL_DEF(NAME, _VAL_);          \
+	ProjectSettings::get_singleton()->set_custom_property_info(NAME, PropertyInfo(Variant::INT, NAME, PROPERTY_HINT_RANGE, "2," #_MAX_ ",1,or_greater"));
+
+	// Client buffers project settings
+	_SET_HINT(WSC_IN_BUF, 64, 4096);
+	_SET_HINT(WSC_IN_PKT, 1024, 16384);
+	_SET_HINT(WSC_OUT_BUF, 64, 4096);
+	_SET_HINT(WSC_OUT_PKT, 1024, 16384);
+
+	// Server buffers project settings
+	_SET_HINT(WSS_IN_BUF, 64, 4096);
+	_SET_HINT(WSS_IN_PKT, 1024, 16384);
+	_SET_HINT(WSS_OUT_BUF, 64, 4096);
+	_SET_HINT(WSS_OUT_PKT, 1024, 16384);
+
+#ifdef JAVASCRIPT_ENABLED
+	ws_client = Ref<WebSocketClient>(memnew(EMWSClient));
+#else
+	ws_client = Ref<WebSocketClient>(memnew(WSLClient));
+#endif
+}

--- a/modules/websocket/script_debugger_websocket.h
+++ b/modules/websocket/script_debugger_websocket.h
@@ -52,6 +52,7 @@ public:
 
 	virtual Error connect_to_host(const String &p_host, uint16_t p_port);
 	virtual bool is_connected_to_host();
+	virtual bool can_block();
 	ScriptDebuggerWebSocket();
 };
 

--- a/modules/websocket/script_debugger_websocket.h
+++ b/modules/websocket/script_debugger_websocket.h
@@ -1,0 +1,58 @@
+/*************************************************************************/
+/*  script_debugger_websocket.h                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SCRIPT_DEBUGGER_WEBSOCKET_H
+#define SCRIPT_DEBUGGER_WEBSOCKET_H
+
+#ifdef JAVASCRIPT_ENABLED
+#include "modules/websocket/emws_client.h"
+#else
+#include "modules/websocket/wsl_client.h"
+#endif
+#include "scene/debugger/script_debugger_remote.h"
+
+class ScriptDebuggerWebSocket : public ScriptDebuggerConnection {
+
+	Ref<WebSocketClient> ws_client;
+
+	virtual void poll();
+	virtual Ref<PacketPeer> get_peer();
+
+	static ScriptDebuggerConnection *_create();
+
+public:
+	static void make_default();
+
+	virtual Error connect_to_host(const String &p_host, uint16_t p_port);
+	virtual bool is_connected_to_host();
+	ScriptDebuggerWebSocket();
+};
+
+#endif // SCRIPT_DEBUGGER_WEBSOCKET_H

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -131,11 +131,13 @@
 			);
 		};
 
-		this.startGame = function(execName, mainPack) {
+		this.startGame = function(execName, mainPack, flags) {
 
 			executableName = execName;
 			var mainArgs = [ '--main-pack', mainPack ];
-
+			if (flags) {
+				mainArgs = mainArgs.concat(flags);
+			}
 			return Promise.all([
 				// Load from directory,
 				this.init(getBasePath(mainPack)),

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -34,8 +34,13 @@
 #include "editor/editor_export.h"
 #include "editor/editor_node.h"
 #include "main/splash.gen.h"
+#include "modules/modules_enabled.gen.h"
 #include "platform/javascript/logo.gen.h"
 #include "platform/javascript/run_icon.gen.h"
+
+#if defined(MODULE_WEBSOCKET_ENABLED) && defined(TOOLS_ENABLED)
+#include "modules/websocket/script_editor_debugger_websocket.h"
+#endif
 
 #define EXPORT_TEMPLATE_WEBASSEMBLY_RELEASE "webassembly_release.zip"
 #define EXPORT_TEMPLATE_WEBASSEMBLY_DEBUG "webassembly_debug.zip"
@@ -188,6 +193,9 @@ private:
 	static void _server_thread_poll(void *data);
 
 public:
+#if defined(MODULE_WEBSOCKET_ENABLED) && defined(TOOLS_ENABLED)
+	virtual ScriptEditorDebuggerServer *create_debugger_server() { return memnew(ScriptEditorDebuggerWebSocket); };
+#endif
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features);
 
 	virtual void get_export_options(List<ExportOption> *r_options);

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -36,6 +36,7 @@
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #include "main/main.h"
+#include "modules/modules_enabled.gen.h"
 #include "servers/visual/visual_server_raster.h"
 
 #include <emscripten.h>
@@ -43,6 +44,10 @@
 #include <stdlib.h>
 
 #include "dom_keys.inc"
+
+#ifdef MODULE_WEBSOCKET_ENABLED
+#include "modules/websocket/script_debugger_websocket.h"
+#endif
 
 #define DOM_BUTTON_LEFT 0
 #define DOM_BUTTON_MIDDLE 1
@@ -873,6 +878,9 @@ void OS_JavaScript::initialize_core() {
 
 	OS_Unix::initialize_core();
 	FileAccess::make_default<FileAccessBufferedFA<FileAccessUnix> >(FileAccess::ACCESS_RESOURCES);
+#ifdef MODULE_WEBSOCKET_ENABLED
+	ScriptDebuggerWebSocket::make_default();
+#endif
 }
 
 Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -148,6 +148,10 @@ void ScriptDebuggerRemote::debug(ScriptLanguage *p_script, bool p_can_continue, 
 
 	ERR_FAIL_COND_MSG(!_connection_is_connected(), "Script Debugger failed to connect, but being used anyway.");
 
+	// Workaround for javascript platform which does not support IO when blocking the main thread.
+	if (!connection->can_block())
+		return;
+
 	_connection_put_var("debug_enter");
 	_connection_put_var(2);
 	_connection_put_var(p_can_continue);

--- a/scene/debugger/script_debugger_remote.h
+++ b/scene/debugger/script_debugger_remote.h
@@ -46,6 +46,7 @@ class ScriptDebuggerConnection : public Reference {
 	virtual Ref<PacketPeer> get_peer() = 0;
 	virtual Error connect_to_host(const String &p_host, uint16_t p_port) = 0;
 	virtual bool is_connected_to_host() = 0;
+	virtual bool can_block() { return true; }
 
 protected:
 	static ScriptDebuggerConnection *(*_create)();


### PR DESCRIPTION
This PR implements Editor debugger support for the HTML5 platform.

Highlights:

- Javascript can now be exported with flags (godot export flags).
- Separate most of the connection logic out of `ScriptRemoteDebugger`/`ScriptEditorDebugger` moving that to an appropriate interface.
- TCP (default) and WebSocket implementations for those interfaces.

Everything should work except for breakpoints/script errors as we cannot receive data while busy waiting in the HTML5 platform.
A potential improvement could be to send the stack frame and error info anyway and pin it somehow to the editor debugger.

A couple of things are hacky. Suggestions are very welcome.

![usage3](https://user-images.githubusercontent.com/1687918/69663075-d0eb5580-1085-11ea-9223-2e05658f7474.png)
![usage2](https://user-images.githubusercontent.com/1687918/69663076-d183ec00-1085-11ea-8024-2a0259cd455c.png)
![usage](https://user-images.githubusercontent.com/1687918/69663078-d183ec00-1085-11ea-9c85-59d430e17c7c.png)
