### PR TITLE
Added null check to prevent segfaults on disconnects while using websockets

### DIFF
--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -283,9 +283,10 @@ int WSLServer::get_peer_port(int p_peer_id) const {
 }
 
 void WSLServer::disconnect_peer(int p_peer_id, int p_code, String p_reason) {
-	ERR_FAIL_COND(!has_peer(p_peer_id));
+	Ref<WebSocketPeer> peer = get_peer(p_peer_id);
+	ERR_FAIL_COND(peer.is_null());
 
-	get_peer(p_peer_id)->close(p_code, p_reason);
+	peer->close(p_code, p_reason);
 }
 
 Error WSLServer::set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) {


### PR DESCRIPTION
While testing a websocket enabled server I started to experience some random crashes when players disconnected similar to what was reported on issue #33279. Looking over the logs the best I could tell is that the `_peer_map` was being modified between the `ERR_FAIL_COND(!has_peer(p_peer_id))` check in `disconnect_peer` and the `ERR_FAIL_COND_V(!has_peer(p_id), NULL)` check in `get_peer` causing it to return a NULL causing the segfault. 

To fix this I replaced the `ERR_FAIL_COND(!has_peer(p_peer_id));` check in `disconnect_peer` with a null check similar to the change made on PR #31482. This does not fix the underlying race condition with `_peer_map` but the server now only logs the issue instead of out right crashing. 

It should be noted that there where two areas in `websocket_multiplayer_peer` that also needed null checks but these where added on PR #31482 and #31483. This issue also occurs in 3.1 so cherry-picking this commit would help solve it there since it looks like PR #31482 and #31483 have already been moved to 3.1 as well.

