### PR TITLE
Add `new_child` method to add child nodes from scenes

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -381,18 +381,6 @@
 				Returns [code]true[/code] if the [NodePath] points to a valid node and its subname points to a valid resource, e.g. [code]Area2D/CollisionShape2D:shape[/code]. Properties with a non-[Resource] type (e.g. nodes or primitive math types) are not considered resources.
 			</description>
 		</method>
-		<method name="instance_child">
-			<return type="Node">
-			</return>
-			<argument index="0" name="scene" type="PackedScene">
-			</argument>
-			<argument index="1" name="legible_unique_name" type="bool" default="false">
-			</argument>
-			<description>
-				Instantiates a node from the [code]scene[/code] as in [method PackedScene.instance] and adds the node as a child.
-				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have an human-readable name based on the name of the node being instanced instead of its type.
-			</description>
-		</method>
 		<method name="is_a_parent_of" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -499,6 +487,18 @@
 			</argument>
 			<description>
 				Moves a child node to a different position (order) among the other children. Since calls, signals, etc are performed by tree order, changing the order of children nodes may be useful.
+			</description>
+		</method>
+		<method name="new_child">
+			<return type="Node">
+			</return>
+			<argument index="0" name="scene" type="PackedScene" default="0">
+			</argument>
+			<argument index="1" name="legible_unique_name" type="bool" default="false">
+			</argument>
+			<description>
+				Instantiates and returns a new node from the [code]scene[/code] as in [method PackedScene.instance] and adds the node as a child. If the [code]scene[/code] is not valid, creates an empty node.
+				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have an human-readable name based on the name of the node being instanced instead of its type.
 			</description>
 		</method>
 		<method name="print_stray_nodes">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -492,7 +492,7 @@
 		<method name="new_child">
 			<return type="Node">
 			</return>
-			<argument index="0" name="scene" type="PackedScene" default="0">
+			<argument index="0" name="scene" type="PackedScene" default="null">
 			</argument>
 			<argument index="1" name="legible_unique_name" type="bool" default="false">
 			</argument>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -381,6 +381,18 @@
 				Returns [code]true[/code] if the [NodePath] points to a valid node and its subname points to a valid resource, e.g. [code]Area2D/CollisionShape2D:shape[/code]. Properties with a non-[Resource] type (e.g. nodes or primitive math types) are not considered resources.
 			</description>
 		</method>
+		<method name="instance_child">
+			<return type="Node">
+			</return>
+			<argument index="0" name="scene" type="PackedScene">
+			</argument>
+			<argument index="1" name="legible_unique_name" type="bool" default="false">
+			</argument>
+			<description>
+				Instantiates a node from the [code]scene[/code] as in [method PackedScene.instance] and adds the node as a child.
+				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have an human-readable name based on the name of the node being instanced instead of its type.
+			</description>
+		</method>
 		<method name="is_a_parent_of" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1196,6 +1196,15 @@ void Node::add_child_below_node(Node *p_node, Node *p_child, bool p_legible_uniq
 	}
 }
 
+Node *Node::instance_child(const Ref<PackedScene> &p_scene, bool p_legible_unique_name) {
+	ERR_FAIL_COND_V_MSG(p_scene.is_null(), NULL, "Can't instance a child node from an invalid scene.");
+
+	Node *new_node = p_scene->instance();
+	add_child(new_node, p_legible_unique_name);
+
+	return new_node;
+}
+
 void Node::_propagate_validate_owner() {
 
 	if (data.owner) {
@@ -2721,11 +2730,11 @@ void Node::_bind_methods() {
 	GLOBAL_DEF("node/name_casing", NAME_CASING_PASCAL_CASE);
 	ProjectSettings::get_singleton()->set_custom_property_info("node/name_casing", PropertyInfo(Variant::INT, "node/name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case"));
 
-	ClassDB::bind_method(D_METHOD("add_child_below_node", "node", "child_node", "legible_unique_name"), &Node::add_child_below_node, DEFVAL(false));
-
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Node::set_name);
 	ClassDB::bind_method(D_METHOD("get_name"), &Node::get_name);
 	ClassDB::bind_method(D_METHOD("add_child", "node", "legible_unique_name"), &Node::add_child, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("add_child_below_node", "node", "child_node", "legible_unique_name"), &Node::add_child_below_node, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("instance_child", "scene", "legible_unique_name"), &Node::instance_child, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_child", "node"), &Node::remove_child);
 	ClassDB::bind_method(D_METHOD("get_child_count"), &Node::get_child_count);
 	ClassDB::bind_method(D_METHOD("get_children"), &Node::_get_children);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1196,10 +1196,14 @@ void Node::add_child_below_node(Node *p_node, Node *p_child, bool p_legible_uniq
 	}
 }
 
-Node *Node::instance_child(const Ref<PackedScene> &p_scene, bool p_legible_unique_name) {
-	ERR_FAIL_COND_V_MSG(p_scene.is_null(), NULL, "Can't instance a child node from an invalid scene.");
+Node *Node::new_child(const Ref<PackedScene> &p_scene, bool p_legible_unique_name) {
+	Node *new_node;
 
-	Node *new_node = p_scene->instance();
+	if (p_scene.is_valid()) {
+		new_node = p_scene->instance();
+	} else {
+		new_node = memnew(Node);
+	}
 	add_child(new_node, p_legible_unique_name);
 
 	return new_node;
@@ -2734,7 +2738,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_name"), &Node::get_name);
 	ClassDB::bind_method(D_METHOD("add_child", "node", "legible_unique_name"), &Node::add_child, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("add_child_below_node", "node", "child_node", "legible_unique_name"), &Node::add_child_below_node, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("instance_child", "scene", "legible_unique_name"), &Node::instance_child, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("new_child", "scene", "legible_unique_name"), &Node::new_child, DEFVAL(NULL), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_child", "node"), &Node::remove_child);
 	ClassDB::bind_method(D_METHOD("get_child_count"), &Node::get_child_count);
 	ClassDB::bind_method(D_METHOD("get_children"), &Node::_get_children);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2738,7 +2738,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_name"), &Node::get_name);
 	ClassDB::bind_method(D_METHOD("add_child", "node", "legible_unique_name"), &Node::add_child, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("add_child_below_node", "node", "child_node", "legible_unique_name"), &Node::add_child_below_node, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("new_child", "scene", "legible_unique_name"), &Node::new_child, DEFVAL(NULL), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("new_child", "scene", "legible_unique_name"), &Node::new_child, DEFVAL(Variant()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_child", "node"), &Node::remove_child);
 	ClassDB::bind_method(D_METHOD("get_child_count"), &Node::get_child_count);
 	ClassDB::bind_method(D_METHOD("get_children"), &Node::_get_children);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -263,6 +263,7 @@ public:
 
 	void add_child(Node *p_child, bool p_legible_unique_name = false);
 	void add_child_below_node(Node *p_node, Node *p_child, bool p_legible_unique_name = false);
+	Node *instance_child(const Ref<PackedScene> &p_from_scene, bool p_legible_unique_name = false);
 	void remove_child(Node *p_child);
 
 	int get_child_count() const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -263,7 +263,7 @@ public:
 
 	void add_child(Node *p_child, bool p_legible_unique_name = false);
 	void add_child_below_node(Node *p_node, Node *p_child, bool p_legible_unique_name = false);
-	Node *instance_child(const Ref<PackedScene> &p_from_scene, bool p_legible_unique_name = false);
+	Node *new_child(const Ref<PackedScene> &p_from_scene = NULL, bool p_legible_unique_name = false);
 	void remove_child(Node *p_child);
 
 	int get_child_count() const;


### PR DESCRIPTION
Closes godotengine/godot-proposals#260.
Helps #6521, also see https://github.com/godotengine/godot/issues/6521#issuecomment-559032334.

*Ducks*.