### PR TITLE
Remove deprecated theme property from GridMap

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -193,22 +193,6 @@ bool GridMap::get_collision_layer_bit(int p_bit) const {
 	return get_collision_layer() & (1 << p_bit);
 }
 
-#ifndef DISABLE_DEPRECATED
-void GridMap::set_theme(const Ref<MeshLibrary> &p_theme) {
-
-	WARN_DEPRECATED_MSG("GridMap.theme/set_theme() is deprecated and will be removed in a future version. Use GridMap.mesh_library/set_mesh_library() instead.");
-
-	set_mesh_library(p_theme);
-}
-
-Ref<MeshLibrary> GridMap::get_theme() const {
-
-	WARN_DEPRECATED_MSG("GridMap.theme/get_theme() is deprecated and will be removed in a future version. Use GridMap.mesh_library/get_mesh_library() instead.");
-
-	return get_mesh_library();
-}
-#endif // DISABLE_DEPRECATED
-
 void GridMap::set_mesh_library(const Ref<MeshLibrary> &p_mesh_library) {
 
 	if (!mesh_library.is_null())
@@ -838,11 +822,6 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_layer_bit", "bit", "value"), &GridMap::set_collision_layer_bit);
 	ClassDB::bind_method(D_METHOD("get_collision_layer_bit", "bit"), &GridMap::get_collision_layer_bit);
 
-#ifndef DISABLE_DEPRECATED
-	ClassDB::bind_method(D_METHOD("set_theme", "theme"), &GridMap::set_theme);
-	ClassDB::bind_method(D_METHOD("get_theme"), &GridMap::get_theme);
-#endif // DISABLE_DEPRECATED
-
 	ClassDB::bind_method(D_METHOD("set_mesh_library", "mesh_library"), &GridMap::set_mesh_library);
 	ClassDB::bind_method(D_METHOD("get_mesh_library"), &GridMap::get_mesh_library);
 
@@ -884,10 +863,6 @@ void GridMap::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("clear_baked_meshes"), &GridMap::clear_baked_meshes);
 	ClassDB::bind_method(D_METHOD("make_baked_meshes", "gen_lightmap_uv", "lightmap_uv_texel_size"), &GridMap::make_baked_meshes, DEFVAL(false), DEFVAL(0.1));
-
-#ifndef DISABLE_DEPRECATED
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, "MeshLibrary", 0), "set_theme", "get_theme");
-#endif // DISABLE_DEPRECATED
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh_library", PROPERTY_HINT_RESOURCE_TYPE, "MeshLibrary"), "set_mesh_library", "get_mesh_library");
 	ADD_GROUP("Cell", "cell_");

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -227,11 +227,6 @@ public:
 	void set_collision_mask_bit(int p_bit, bool p_value);
 	bool get_collision_mask_bit(int p_bit) const;
 
-#ifndef DISABLE_DEPRECATED
-	void set_theme(const Ref<MeshLibrary> &p_theme);
-	Ref<MeshLibrary> get_theme() const;
-#endif // DISABLE_DEPRECATED
-
 	void set_mesh_library(const Ref<MeshLibrary> &p_mesh_library);
 	Ref<MeshLibrary> get_mesh_library() const;
 


### PR DESCRIPTION
Closes #27405
The issue is there since 3.1, so it's probably ok to finally remove this.