### PR TITLE
Added more details in Timer.start() error message.

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -108,7 +108,7 @@ bool Timer::has_autostart() const {
 
 void Timer::start(float p_time) {
 
-	ERR_FAIL_COND_MSG(!is_inside_tree(), "Timer was not added to the SceneTree!");
+	ERR_FAIL_COND_MSG(!is_inside_tree(), "Timer was not added to the SceneTree. Either add it or set autostart to true.");
 
 	if (p_time > 0) {
 		set_wait_time(p_time);


### PR DESCRIPTION
Added "(To fix: add to SceneTree before or set autostart to true instead.)" to the original short error string "Timer was not added to the SceneTree!".

Fixes #33929