### PR TITLE
Remove .exr saver debug print

### DIFF
--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -262,10 +262,6 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 	header.channels = channel_infos;
 	header.pixel_types = pixel_types;
 	header.requested_pixel_types = requested_pixel_types;
-	// TODO DEBUG REMOVE
-	for (int i = 0; i < 4; ++i) {
-		print_line(String("requested_pixel_types{0}: {1}").format(varray(i, requested_pixel_types[i])));
-	}
 
 	CharString utf8_filename = p_path.utf8();
 	const char *err;


### PR DESCRIPTION
In a plugin that I'm working on (https://github.com/NeoSpark314/seurat-godot-plugin) I need to save a lot of .exr (cubemap) images. In this case the leftover debug output fills the console with a lot of unneeded information. This PR removes the debug print_line.