### PR TITLE
Implement zooming using Ctrl + Mouse wheel in the GridMap editor

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -839,12 +839,30 @@ void GridMapEditor::_text_changed(const String &p_text) {
 
 void GridMapEditor::_sbox_input(const Ref<InputEvent> &p_ie) {
 
-	Ref<InputEventKey> k = p_ie;
+	const Ref<InputEventKey> k = p_ie;
 
 	if (k.is_valid() && (k->get_scancode() == KEY_UP || k->get_scancode() == KEY_DOWN || k->get_scancode() == KEY_PAGEUP || k->get_scancode() == KEY_PAGEDOWN)) {
 
+		// Forward the key input to the ItemList so it can be scrolled
 		mesh_library_palette->call("_gui_input", k);
 		search_box->accept_event();
+	}
+}
+
+void GridMapEditor::_mesh_library_palette_input(const Ref<InputEvent> &p_ie) {
+
+	const Ref<InputEventMouseButton> mb = p_ie;
+
+	// Zoom in/out using Ctrl + mouse wheel
+	if (mb.is_valid() && mb->is_pressed() && mb->get_command()) {
+
+		if (mb->is_pressed() && mb->get_button_index() == BUTTON_WHEEL_UP) {
+			size_slider->set_value(size_slider->get_value() + 0.2);
+		}
+
+		if (mb->is_pressed() && mb->get_button_index() == BUTTON_WHEEL_DOWN) {
+			size_slider->set_value(size_slider->get_value() - 0.2);
+		}
 	}
 }
 
@@ -1182,6 +1200,7 @@ void GridMapEditor::_bind_methods() {
 
 	ClassDB::bind_method("_text_changed", &GridMapEditor::_text_changed);
 	ClassDB::bind_method("_sbox_input", &GridMapEditor::_sbox_input);
+	ClassDB::bind_method("_mesh_library_palette_input", &GridMapEditor::_mesh_library_palette_input);
 	ClassDB::bind_method("_icon_size_changed", &GridMapEditor::_icon_size_changed);
 	ClassDB::bind_method("_menu_option", &GridMapEditor::_menu_option);
 	ClassDB::bind_method("_configure", &GridMapEditor::_configure);
@@ -1310,7 +1329,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 
 	size_slider = memnew(HSlider);
 	size_slider->set_h_size_flags(SIZE_EXPAND_FILL);
-	size_slider->set_min(0.1f);
+	size_slider->set_min(0.2f);
 	size_slider->set_max(4.0f);
 	size_slider->set_step(0.1f);
 	size_slider->set_value(1.0f);
@@ -1324,6 +1343,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	mesh_library_palette = memnew(ItemList);
 	add_child(mesh_library_palette);
 	mesh_library_palette->set_v_size_flags(SIZE_EXPAND_FILL);
+	mesh_library_palette->connect("gui_input", this, "_mesh_library_palette_input");
 
 	info_message = memnew(Label);
 	info_message->set_text(TTR("Give a MeshLibrary resource to this GridMap to use its meshes."));

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -214,6 +214,7 @@ class GridMapEditor : public VBoxContainer {
 
 	void _text_changed(const String &p_text);
 	void _sbox_input(const Ref<InputEvent> &p_ie);
+	void _mesh_library_palette_input(const Ref<InputEvent> &p_ie);
 
 	void _icon_size_changed(float p_value);
 


### PR DESCRIPTION
The minimum value of the slider was changed to 0.2 as zooming works in increments of 0.2. This way, the value can go back to 1 after you've reached the slider's minimum value.