### PR TITLE
PoolByteArray decompress() compression mode is made required.

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1819,7 +1819,7 @@ void register_variant_methods() {
 	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, get_string_from_utf8, varray());
 	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, hex_encode, varray());
 	ADDFUNC1R(POOL_BYTE_ARRAY, POOL_BYTE_ARRAY, PoolByteArray, compress, INT, "compression_mode", varray(0));
-	ADDFUNC2R(POOL_BYTE_ARRAY, POOL_BYTE_ARRAY, PoolByteArray, decompress, INT, "buffer_size", INT, "compression_mode", varray(0));
+	ADDFUNC2R(POOL_BYTE_ARRAY, POOL_BYTE_ARRAY, PoolByteArray, decompress, INT, "buffer_size", INT, "compression_mode", varray());
 
 	ADDFUNC0R(POOL_INT_ARRAY, INT, PoolIntArray, size, varray());
 	ADDFUNC0R(POOL_INT_ARRAY, BOOL, PoolIntArray, empty, varray());

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -47,7 +47,7 @@
 			</return>
 			<argument index="0" name="buffer_size" type="int">
 			</argument>
-			<argument index="1" name="compression_mode" type="int" default="0">
+			<argument index="1" name="compression_mode" type="int">
 			</argument>
 			<description>
 				Returns a new [PoolByteArray] with the data decompressed. Set [code]buffer_size[/code] to the size of the uncompressed data. Set the compression mode using one of [enum File.CompressionMode]'s constants.


### PR DESCRIPTION
Fixes #24861

Removes default argument = 0.
Updates the docs for PoolByteArray::decompress.

Note: compress() still provides default = 0 for this argument, but this seems reasonable since there is only room for user error in the decompress case where two arguments are both castable to int.