### PR TITLE
Fix `String.is_valid_identifier()` to disallow single underscores

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3349,11 +3349,17 @@ bool String::is_valid_identifier() const {
 
 	const wchar_t *str = &operator[](0);
 
+	if (len == 1 && str[0] == '_') {
+		// Single underscores aren't valid identifiers in GDScript yet.
+		// Multiple underscores are valid identifiers though.
+		return false;
+	}
+
 	for (int i = 0; i < len; i++) {
 
 		if (i == 0) {
 			if (str[0] >= '0' && str[0] <= '9')
-				return false; // no start with number plz
+				return false; // Identifiers may not start with a number.
 		}
 
 		bool valid_char = (str[i] >= '0' && str[i] <= '9') || (str[i] >= 'a' && str[i] <= 'z') || (str[i] >= 'A' && str[i] <= 'Z') || str[i] == '_';

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -65,8 +65,14 @@ void EditorAutoloadSettings::_notification(int p_what) {
 bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, String *r_error) {
 
 	if (!p_name.is_valid_identifier()) {
-		if (r_error)
-			*r_error = TTR("Invalid name.") + "\n" + TTR("Valid characters:") + " a-z, A-Z, 0-9 or _";
+		if (r_error) {
+			if (p_name == "_") {
+				// Display a different error message to avoid confusion, as the other message below says `_` is allowed.
+				*r_error = TTR("Invalid name (it must not be a single underscore).");
+			} else {
+				*r_error = TTR("Invalid name.") + "\n" + TTR("Valid characters:") + " a-z, A-Z, 0-9 or _";
+			}
+		}
 
 		return false;
 	}


### PR DESCRIPTION
GDScript doesn't allow single underscores to be identifiers yet, but multiple underscores work fine. This changes `String.is_valid_identifier()` to reflect GDScript's behavior.

If supporting single underscores as GDScript identifiers is easy enough to do, it might be worth doing that instead. (cc @vnen)

This closes #33954.