### PR TITLE
Skeleton: Add functionality to get bone global_pose without the override

### DIFF
--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -144,6 +144,8 @@ private:
 
 	void _update_process_order();
 
+	_FORCE_INLINE_ Transform compute_global_pose(const Bone &p_bone, const Bone *p_bonesptr, bool p_ignore_override) const;
+
 protected:
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
@@ -177,6 +179,7 @@ public:
 	void set_bone_rest(int p_bone, const Transform &p_rest);
 	Transform get_bone_rest(int p_bone) const;
 	Transform get_bone_global_pose(int p_bone) const;
+	Transform get_bone_global_pose_without_override(int p_bone) const;
 
 	void clear_bones_global_pose_override();
 	void set_bone_global_pose_override(int p_bone, const Transform &p_pose, float p_amount, bool p_persistent = false);


### PR DESCRIPTION
The changes made to the skeleton class post-skin changed logic a bit for the global_pose, which caused the expected usage of get_bone_global_pose() to be different.

It is actually more correct now than it was before, but there was an expected usage by users that is now missing.

This PR adds the ability for users to obtain a bones global pose while ignoring the override pose of the bone they are requesting.

See: https://github.com/godotengine/godot/issues/33552