### PR TITLE
Improve the AutoLoad editor UX

### DIFF
--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -76,6 +76,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 	Tree *tree;
 	EditorLineEditFileChooser *autoload_add_path;
 	LineEdit *autoload_add_name;
+	Button *add_autoload;
 
 	bool _autoload_name_is_valid(const String &p_name, String *r_error = NULL);
 
@@ -84,7 +85,9 @@ class EditorAutoloadSettings : public VBoxContainer {
 	void _autoload_edited();
 	void _autoload_button_pressed(Object *p_item, int p_column, int p_button);
 	void _autoload_activated();
-	void _autoload_text_entered(String) { _autoload_add(); }
+	void _autoload_path_text_changed(const String p_path);
+	void _autoload_text_entered(const String p_name);
+	void _autoload_text_changed(const String p_name);
 	void _autoload_open(const String &fpath);
 	void _autoload_file_callback(const String &p_path);
 	Node *_create_autoload(const String &p_path);


### PR DESCRIPTION
- Convert the default AutoLoad name to PascalCase when selecting a file.
- Disable the "Add" button if the path is empty or the name is invalid.
- Prefix the automatically-chosen name with "Global" if it would conflict with a built-in class.
- Replace the FileList icon with the Load icon as it better represents the action.