### PR TITLE
Add Arrange functionality

### DIFF
--- a/editor/icons/icon_arrange_align_bottom.svg
+++ b/editor/icons/icon_arrange_align_bottom.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_align_bottom.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="7.1605588"
+     inkscape:cy="10.867932"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="1"
+     y="14" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.15470052"
+     id="rect122"
+     width="4"
+     height="11"
+     x="9"
+     y="2" />
+  <rect
+     style="fill:#808080;stroke-width:1.15470052"
+     id="rect124"
+     width="4"
+     height="7"
+     x="3"
+     y="6" />
+</svg>

--- a/editor/icons/icon_arrange_align_center_horizontal.svg
+++ b/editor/icons/icon_arrange_align_center_horizontal.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_align_center_horizontal.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="7.1605588"
+     inkscape:cy="10.867932"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="1"
+     y="7" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.25529182"
+     id="rect122"
+     width="4"
+     height="13"
+     x="9"
+     y="1" />
+  <rect
+     style="fill:#808080;stroke-width:1.30930722"
+     id="rect124"
+     width="4"
+     height="9"
+     x="3"
+     y="3" />
+</svg>

--- a/editor/icons/icon_arrange_align_center_vertical.svg
+++ b/editor/icons/icon_arrange_align_center_vertical.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_align_center_vertical.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="7.1605588"
+     inkscape:cy="10.867932"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="-15"
+     y="7"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.25529182"
+     id="rect122"
+     width="4"
+     height="13"
+     x="-13"
+     y="1"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;stroke-width:1.30930722"
+     id="rect124"
+     width="4"
+     height="9"
+     x="-7"
+     y="3"
+     transform="rotate(-90)" />
+</svg>

--- a/editor/icons/icon_arrange_align_left.svg
+++ b/editor/icons/icon_arrange_align_left.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_align_left.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="7.1605588"
+     inkscape:cy="10.867932"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="-15"
+     y="1"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.15470052"
+     id="rect122"
+     width="4"
+     height="11"
+     x="-13"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;stroke-width:1.15470052"
+     id="rect124"
+     width="4"
+     height="7"
+     x="-7"
+     y="3"
+     transform="rotate(-90)" />
+</svg>

--- a/editor/icons/icon_arrange_align_right.svg
+++ b/editor/icons/icon_arrange_align_right.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_align_right.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="7.1605588"
+     inkscape:cy="10.867932"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="-15"
+     y="14"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.15470052"
+     id="rect122"
+     width="4"
+     height="11"
+     x="-13"
+     y="2"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;stroke-width:1.15470052"
+     id="rect124"
+     width="4"
+     height="7"
+     x="-7"
+     y="6"
+     transform="rotate(-90)" />
+</svg>

--- a/editor/icons/icon_arrange_align_top.svg
+++ b/editor/icons/icon_arrange_align_top.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_top.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="7.1605588"
+     inkscape:cy="10.867932"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1415"
+     inkscape:window-x="2560"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="1"
+     y="1" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.15470052"
+     id="rect122"
+     width="4"
+     height="11"
+     x="9"
+     y="3" />
+  <rect
+     style="fill:#808080;stroke-width:1.15470052"
+     id="rect124"
+     width="4"
+     height="7"
+     x="3"
+     y="3" />
+</svg>

--- a/editor/icons/icon_arrange_dist_bottom.svg
+++ b/editor/icons/icon_arrange_dist_bottom.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_dist_bottom.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4578"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254831"
+     inkscape:cx="5.2188422"
+     inkscape:cy="6.9033146"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="1"
+     y="6" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.0298574"
+     id="rect122"
+     width="5"
+     height="7"
+     x="-14"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;stroke-width:1.19522858"
+     id="rect124"
+     width="5"
+     height="6"
+     x="-6"
+     y="4"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118-3"
+     width="14"
+     height="1"
+     x="1"
+     y="14" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="m 13,7 -2,3 h 4 z"
+     id="path2"
+     sodipodi:nodetypes="cccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="m 13,14 -2,-3 h 4 z"
+     id="path2-5"
+     sodipodi:nodetypes="cccc" />
+</svg>

--- a/editor/icons/icon_arrange_dist_center_horizontal.svg
+++ b/editor/icons/icon_arrange_dist_center_horizontal.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_dist_center_horizontal.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4578"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254831"
+     inkscape:cx="3.3242657"
+     inkscape:cy="6.5267306"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="-15"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;stroke-width:1.19522858"
+     id="rect124"
+     width="6"
+     height="5"
+     x="-12"
+     y="1"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118-3"
+     width="14"
+     height="1"
+     x="-15"
+     y="12"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.02985728"
+     id="rect122"
+     width="7"
+     height="5"
+     x="-13"
+     y="10"
+     transform="rotate(-90)" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="M 4,3 7,5 V 1 Z"
+     id="path2"
+     sodipodi:nodetypes="cccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="M 12,3 9,5 V 1 Z"
+     id="path2-5"
+     sodipodi:nodetypes="cccc" />
+</svg>

--- a/editor/icons/icon_arrange_dist_center_vertical.svg
+++ b/editor/icons/icon_arrange_dist_center_vertical.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_dist_center_vertical.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4578"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254831"
+     inkscape:cx="5.2188422"
+     inkscape:cy="6.9033146"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="1"
+     y="3" />
+  <rect
+     style="fill:#808080;stroke-width:1.19522858"
+     id="rect124"
+     width="5"
+     height="6"
+     x="-6"
+     y="4"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118-3"
+     width="14"
+     height="1"
+     x="1"
+     y="12" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.0298574"
+     id="rect122"
+     width="5"
+     height="7"
+     x="-15"
+     y="3"
+     transform="rotate(-90)" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="m 13,4 -2,3 h 4 z"
+     id="path2"
+     sodipodi:nodetypes="cccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="M 13,12 11,9 h 4 z"
+     id="path2-5"
+     sodipodi:nodetypes="cccc" />
+</svg>

--- a/editor/icons/icon_arrange_dist_gap_horizontal.svg
+++ b/editor/icons/icon_arrange_dist_gap_horizontal.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_dist_gap_horizontal.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4578"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254831"
+     inkscape:cx="3.3242657"
+     inkscape:cy="6.5267306"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#808080;stroke-width:1.23442674"
+     id="rect124"
+     width="8"
+     height="4"
+     x="-12"
+     y="1"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.10096371"
+     id="rect122"
+     width="10"
+     height="4"
+     x="-13"
+     y="11"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#ffffff"
+     id="rect20"
+     width="1"
+     height="6"
+     x="6"
+     y="5" />
+  <rect
+     style="fill:#ffffff"
+     id="rect22"
+     width="1"
+     height="6"
+     x="9"
+     y="5" />
+  <rect
+     style="fill:#ffffff"
+     id="rect24"
+     width="2"
+     height="2"
+     x="7"
+     y="7" />
+</svg>

--- a/editor/icons/icon_arrange_dist_gap_vertical.svg
+++ b/editor/icons/icon_arrange_dist_gap_vertical.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_dist_gap_vertical.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4578"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254831"
+     inkscape:cx="3.0363847"
+     inkscape:cy="7.0021344"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#808080;stroke-width:1.23442674"
+     id="rect124"
+     width="4"
+     height="8"
+     x="-5"
+     y="4"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.10096395"
+     id="rect122"
+     width="4"
+     height="10"
+     x="-15"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#ffffff"
+     id="rect20"
+     width="6"
+     height="1"
+     x="5"
+     y="6" />
+  <rect
+     style="fill:#ffffff"
+     id="rect22"
+     width="6"
+     height="1"
+     x="5"
+     y="9" />
+  <rect
+     style="fill:#ffffff"
+     id="rect24"
+     width="2"
+     height="2"
+     x="7"
+     y="7" />
+</svg>

--- a/editor/icons/icon_arrange_dist_left.svg
+++ b/editor/icons/icon_arrange_dist_left.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_dist_left.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4578"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254831"
+     inkscape:cx="3.3242657"
+     inkscape:cy="6.5267306"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="-15"
+     y="1"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.02985728"
+     id="rect122"
+     width="7"
+     height="5"
+     x="-13"
+     y="10"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;stroke-width:1.19522858"
+     id="rect124"
+     width="6"
+     height="5"
+     x="-12"
+     y="2"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118-3"
+     width="14"
+     height="1"
+     x="-15"
+     y="9"
+     transform="rotate(-90)" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="M 2,3 5,5 V 1 Z"
+     id="path2"
+     sodipodi:nodetypes="cccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="M 9,3 6,5 V 1 Z"
+     id="path2-5"
+     sodipodi:nodetypes="cccc" />
+</svg>

--- a/editor/icons/icon_arrange_dist_right.svg
+++ b/editor/icons/icon_arrange_dist_right.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_dist_right.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4578"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254831"
+     inkscape:cx="3.3194158"
+     inkscape:cy="6.5252989"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="-15"
+     y="6"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.02985728"
+     id="rect122"
+     width="7"
+     height="5"
+     x="-13"
+     y="9"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;stroke-width:1.19522858"
+     id="rect124"
+     width="6"
+     height="5"
+     x="-12"
+     y="1"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118-3"
+     width="14"
+     height="1"
+     x="-15"
+     y="14"
+     transform="rotate(-90)" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="m 7,3 3,2 V 1 Z"
+     id="path2"
+     sodipodi:nodetypes="cccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="M 14,3 11,5 V 1 Z"
+     id="path2-5"
+     sodipodi:nodetypes="cccc" />
+</svg>

--- a/editor/icons/icon_arrange_dist_top.svg
+++ b/editor/icons/icon_arrange_dist_top.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (unknown)"
+   inkscape:export-filename="/home/djrm/Projects/godot/tools/editor/icons/icon_control.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="icon_arrange_dist_top.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4578"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254831"
+     inkscape:cx="5.2188422"
+     inkscape:cy="6.9033146"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4" />
+    <sodipodi:guide
+       position="13,15"
+       orientation="0,1"
+       id="guide4135"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1,10"
+       orientation="1,0"
+       id="guide4137"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="9,1"
+       orientation="0,1"
+       id="guide4139"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15,8"
+       orientation="1,0"
+       id="guide4141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118"
+     width="14"
+     height="1"
+     x="1"
+     y="1" />
+  <rect
+     style="fill:#b3b3b3;stroke-width:1.0298574"
+     id="rect122"
+     width="5"
+     height="7"
+     x="-15"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;stroke-width:1.19522858"
+     id="rect124"
+     width="5"
+     height="6"
+     x="-7"
+     y="4"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#ffffff;stroke-width:1.08012342"
+     id="rect118-3"
+     width="14"
+     height="1"
+     x="1"
+     y="9" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="m 13,2 -2,3 h 4 z"
+     id="path2"
+     sodipodi:nodetypes="cccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff"
+     d="M 13,9 11,6 h 4 z"
+     id="path2-5"
+     sodipodi:nodetypes="cccc" />
+</svg>

--- a/editor/plugins/canvas_item_arrange_panel.cpp
+++ b/editor/plugins/canvas_item_arrange_panel.cpp
@@ -1,0 +1,628 @@
+/*************************************************************************/
+/*  canvas_item_arrange_plugin.cpp                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor/plugins/canvas_item_arrange_panel.h"
+
+List<CanvasItem *> ArrangePanel::get_selected_nodes() {
+	List<CanvasItem *> selected;
+	List<Node *> selection = EditorNode::get_singleton()->get_editor_selection()->get_full_selected_node_list();
+	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
+		CanvasItem *node = Object::cast_to<CanvasItem>(E->get());
+		if (node && !node->has_meta("_edit_lock_")) {
+			selected.push_back(node);
+		}
+	}
+	return selected;
+}
+
+void ArrangePanel::arrange_nodes(int p_action) {
+	List<CanvasItem *> selected = get_selected_nodes();
+
+	if (selected.size() < 2) {
+		return;
+	}
+
+	undo_redo->create_action(TTR("Arrange CanvasItem nodes."), UndoRedo::MERGE_DISABLE);
+	switch (p_action) {
+		case ALIGN_LEFT: {
+			selected.sort_custom<SortLeft>();
+
+			CanvasItem *target_node = selected.front()->get();
+			Rect2 rect_node = target_node->_edit_get_rect();
+			Point2 pos_local = rect_node.position;
+			Point2 pos_global = target_node->get_global_transform().xform(pos_local);
+			real_t target_x = pos_global.x;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.x = target_x;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.x -= to.x - prev.position.x;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.x = to.x;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+			}
+		} break;
+		case ALIGN_RIGHT: {
+			selected.sort_custom<SortRight>();
+
+			CanvasItem *target_node = selected.back()->get();
+			Rect2 rect_node = target_node->_edit_get_rect();
+			Point2 pos_local = rect_node.position + rect_node.size;
+			Point2 pos_global = target_node->get_global_transform().xform(pos_local);
+			real_t target_x = pos_global.x;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.x = target_x;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.x -= to.x - prev.size.x - prev.position.x;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.x = to.x - rect.size.x;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+			}
+		} break;
+		case ALIGN_CENTER_VERTICAL: {
+			selected.sort_custom<SortLeft>();
+
+			CanvasItem *left_node = selected.front()->get();
+			Rect2 rect_node = left_node->_edit_get_rect();
+			Point2 pos_local = left_node->_edit_get_rect().position;
+			Point2 pos_global = left_node->get_global_transform().xform(pos_local);
+			real_t target_x = pos_global.x;
+
+			selected.sort_custom<SortRight>();
+
+			CanvasItem *right_node = selected.back()->get();
+			rect_node = right_node->_edit_get_rect();
+			pos_local = right_node->_edit_get_rect().position + right_node->_edit_get_rect().size;
+			pos_global = right_node->get_global_transform().xform(pos_local);
+			target_x = (target_x + pos_global.x) / 2;
+
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.x = target_x;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.x -= to.x - prev.size.x / 2 - prev.position.x;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.x = to.x - rect.size.x / 2;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+			}
+		} break;
+		case DISTRIBUTE_LEFT: {
+			selected.sort_custom<SortLeft>();
+
+			CanvasItem *first_node = selected.front()->get();
+			Rect2 first_rect = first_node->_edit_get_rect();
+			Point2 first_local = first_rect.position;
+			Point2 first_global = first_node->get_global_transform().xform(first_local);
+			real_t first_x = first_global.x;
+
+			CanvasItem *last_node = selected.back()->get();
+			Rect2 last_rect = last_node->_edit_get_rect();
+			Point2 last_local = last_rect.position;
+			Point2 last_global = last_node->get_global_transform().xform(last_local);
+			real_t last_x = last_global.x;
+
+			real_t gap_x = (last_x - first_x) / (selected.size() - 1);
+			int index = 0;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.x = first_x + gap_x * index;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.x -= to.x - prev.position.x;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.x = to.x;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+
+				index++;
+			}
+		} break;
+		case DISTRIBUTE_RIGHT: {
+			selected.sort_custom<SortRight>();
+
+			CanvasItem *first_node = selected.front()->get();
+			Rect2 first_rect = first_node->_edit_get_rect();
+			Point2 first_local = first_rect.position + first_rect.size;
+			Point2 first_global = first_node->get_global_transform().xform(first_local);
+			real_t first_x = first_global.x;
+
+			CanvasItem *last_node = selected.back()->get();
+			Rect2 last_rect = last_node->_edit_get_rect();
+			Point2 last_local = last_rect.position + last_rect.size;
+			Point2 last_global = last_node->get_global_transform().xform(last_local);
+			real_t last_x = last_global.x;
+
+			real_t gap_x = (last_x - first_x) / (selected.size() - 1);
+			int index = 0;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.x = first_x + gap_x * index;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.x -= to.x - prev.size.x - prev.position.x;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.x = to.x - rect.size.x;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+
+				index++;
+			}
+		} break;
+		case DISTRIBUTE_CENTER_HORIZONTAL: {
+			selected.sort_custom<SortLeft>();
+
+			CanvasItem *first_node = selected.front()->get();
+			Rect2 first_rect = first_node->_edit_get_rect();
+			Point2 first_local = first_rect.position;
+			first_local.x += first_rect.size.x / 2;
+			Point2 first_global = first_node->get_global_transform().xform(first_local);
+			real_t first_x = first_global.x;
+
+			selected.sort_custom<SortRight>();
+
+			CanvasItem *last_node = selected.back()->get();
+			Rect2 last_rect = last_node->_edit_get_rect();
+			Point2 last_local = last_rect.position;
+			last_local.x += last_rect.size.x / 2;
+			Point2 last_global = last_node->get_global_transform().xform(last_local);
+			real_t last_x = last_global.x;
+
+			real_t gap_x = (last_x - first_x) / (selected.size() - 1);
+			int index = 0;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.x = first_x + gap_x * index;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.x -= to.x - prev.size.x / 2 - prev.position.x;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.x = to.x - rect.size.x / 2;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+
+				index++;
+			}
+		} break;
+		case DISTRIBUTE_GAP_HORIZONTAL: {
+			selected.sort_custom<SortLeft>();
+
+			CanvasItem *first_node = selected.front()->get();
+			Rect2 first_rect = first_node->_edit_get_rect();
+			Point2 first_local = first_rect.position;
+			Point2 first_global = first_node->get_global_transform().xform(first_local);
+			real_t first_x = first_global.x;
+
+			selected.sort_custom<SortRight>();
+
+			CanvasItem *last_node = selected.back()->get();
+			Rect2 last_rect = last_node->_edit_get_rect();
+			Point2 last_local = last_rect.position + last_rect.size;
+			Point2 last_global = last_node->get_global_transform().xform(last_local);
+			real_t last_x = last_global.x;
+
+			real_t max_x = last_x - first_x;
+			real_t total_x = 0;
+
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 size = node->get_global_transform().xform(node->_edit_get_rect().position + node->_edit_get_rect().size) - node->get_global_transform().xform(node->_edit_get_rect().position);
+				total_x += size.x;
+			}
+
+			real_t gap_x = (max_x - total_x) / (selected.size() - 1);
+			first_node = selected.front()->get();
+			Vector2 to = first_node->get_global_transform().xform(first_node->_edit_get_rect().position + first_node->_edit_get_rect().size);
+
+			for (List<CanvasItem *>::Element *E = selected.front()->next(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+
+				to.x += gap_x;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.x -= to.x - prev.position.x;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.x = to.x;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+
+				to = node->get_global_transform().xform(to + node->_edit_get_rect().size);
+			}
+		} break;
+		case ALIGN_TOP: {
+			selected.sort_custom<SortTop>();
+
+			CanvasItem *target_node = selected.front()->get();
+			Rect2 rect_node = target_node->_edit_get_rect();
+			Point2 pos_local = rect_node.position;
+			Point2 pos_global = target_node->get_global_transform().xform(pos_local);
+			real_t target_y = pos_global.y;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.y = target_y;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.y -= to.y - prev.position.y;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.y = to.y;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+			}
+		} break;
+		case ALIGN_BOTTOM: {
+			selected.sort_custom<SortBottom>();
+
+			CanvasItem *target_node = selected.back()->get();
+			Rect2 rect_node = target_node->_edit_get_rect();
+			Point2 pos_local = rect_node.position + rect_node.size;
+			Point2 pos_global = target_node->get_global_transform().xform(pos_local);
+			real_t target_y = pos_global.y;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.y = target_y;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.y -= to.y - prev.size.y - prev.position.y;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.y = to.y - rect.size.y;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+			}
+		} break;
+		case ALIGN_CENTER_HORIZONTAL: {
+			selected.sort_custom<SortTop>();
+
+			CanvasItem *top_node = selected.front()->get();
+			Rect2 rect_node = top_node->_edit_get_rect();
+			Point2 pos_local = top_node->_edit_get_rect().position;
+			Point2 pos_global = top_node->get_global_transform().xform(pos_local);
+			real_t target_y = pos_global.y;
+
+			selected.sort_custom<SortBottom>();
+
+			CanvasItem *bottom_node = selected.back()->get();
+			rect_node = bottom_node->_edit_get_rect();
+			pos_local = bottom_node->_edit_get_rect().position + bottom_node->_edit_get_rect().size;
+			pos_global = bottom_node->get_global_transform().xform(pos_local);
+			target_y = (target_y + pos_global.y) / 2;
+
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.y = target_y;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.y -= to.y - prev.size.y / 2 - prev.position.y;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.y = to.y - rect.size.y / 2;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+			}
+		} break;
+		case DISTRIBUTE_TOP: {
+			selected.sort_custom<SortTop>();
+
+			CanvasItem *first_node = selected.front()->get();
+			Rect2 first_rect = first_node->_edit_get_rect();
+			Point2 first_local = first_rect.position;
+			Point2 first_global = first_node->get_global_transform().xform(first_local);
+			real_t first_y = first_global.y;
+
+			CanvasItem *last_node = selected.back()->get();
+			Rect2 last_rect = last_node->_edit_get_rect();
+			Point2 last_local = last_rect.position;
+			Point2 last_global = last_node->get_global_transform().xform(last_local);
+			real_t last_y = last_global.y;
+
+			real_t gap_y = (last_y - first_y) / (selected.size() - 1);
+			int index = 0;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.y = first_y + gap_y * index;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.y -= to.y - prev.position.y;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.y = to.y;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+
+				index++;
+			}
+		} break;
+		case DISTRIBUTE_BOTTOM: {
+			selected.sort_custom<SortBottom>();
+
+			CanvasItem *first_node = selected.front()->get();
+			Rect2 first_rect = first_node->_edit_get_rect();
+			Point2 first_local = first_rect.position + first_rect.size;
+			Point2 first_global = first_node->get_global_transform().xform(first_local);
+			real_t first_y = first_global.y;
+
+			CanvasItem *last_node = selected.back()->get();
+			Rect2 last_rect = last_node->_edit_get_rect();
+			Point2 last_local = last_rect.position + last_rect.size;
+			Point2 last_global = last_node->get_global_transform().xform(last_local);
+			real_t last_y = last_global.y;
+
+			real_t gap_y = (last_y - first_y) / (selected.size() - 1);
+			int index = 0;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.y = first_y + gap_y * index;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.y -= to.y - prev.size.y - prev.position.y;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.y = to.y - rect.size.y;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+
+				index++;
+			}
+		} break;
+		case DISTRIBUTE_CENTER_VERTICAL: {
+			selected.sort_custom<SortTop>();
+
+			CanvasItem *first_node = selected.front()->get();
+			Rect2 first_rect = first_node->_edit_get_rect();
+			Point2 first_local = first_rect.position;
+			first_local.y += first_rect.size.y / 2;
+			Point2 first_global = first_node->get_global_transform().xform(first_local);
+			real_t first_y = first_global.y;
+
+			selected.sort_custom<SortBottom>();
+
+			CanvasItem *last_node = selected.back()->get();
+			Rect2 last_rect = last_node->_edit_get_rect();
+			Point2 last_local = last_rect.position;
+			last_local.y += last_rect.size.y / 2;
+			Point2 last_global = last_node->get_global_transform().xform(last_local);
+			real_t last_y = last_global.y;
+
+			real_t gap_y = (last_y - first_y) / (selected.size() - 1);
+			int index = 0;
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 to = node->get_global_transform().get_origin();
+				to.y = first_y + gap_y * index;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.y -= to.y - prev.size.y / 2 - prev.position.y;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.y = to.y - rect.size.y / 2;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+
+				index++;
+			}
+		} break;
+		case DISTRIBUTE_GAP_VERTICAL: {
+			selected.sort_custom<SortTop>();
+
+			CanvasItem *first_node = selected.front()->get();
+			Rect2 first_rect = first_node->_edit_get_rect();
+			Point2 first_local = first_rect.position;
+			Point2 first_global = first_node->get_global_transform().xform(first_local);
+			real_t first_y = first_global.y;
+
+			selected.sort_custom<SortBottom>();
+
+			CanvasItem *last_node = selected.back()->get();
+			Rect2 last_rect = last_node->_edit_get_rect();
+			Point2 last_local = last_rect.position + last_rect.size;
+			Point2 last_global = last_node->get_global_transform().xform(last_local);
+			real_t last_y = last_global.y;
+
+			real_t max_y = last_y - first_y;
+			real_t total_y = 0;
+
+			for (List<CanvasItem *>::Element *E = selected.front(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+				Vector2 size = node->get_global_transform().xform(node->_edit_get_rect().position + node->_edit_get_rect().size) - node->get_global_transform().xform(node->_edit_get_rect().position);
+				total_y += size.y;
+			}
+
+			real_t gap_y = (max_y - total_y) / (selected.size() - 1);
+			first_node = selected.front()->get();
+			Vector2 to = first_node->get_global_transform().xform(first_node->_edit_get_rect().position + first_node->_edit_get_rect().size);
+
+			for (List<CanvasItem *>::Element *E = selected.front()->next(); E; E = E->next()) {
+				CanvasItem *node = E->get();
+
+				to.y += gap_y;
+				to = node->make_canvas_position_local(to);
+
+				Rect2 prev = node->_edit_get_rect();
+				prev.position.y -= to.y - prev.position.y;
+				Rect2 rect = node->_edit_get_rect();
+				rect.position.y = to.y;
+
+				undo_redo->add_do_method(node, "_edit_set_rect", rect);
+				undo_redo->add_undo_method(node, "_edit_set_rect", prev);
+
+				to = node->get_global_transform().xform(to + node->_edit_get_rect().size);
+			}
+		} break;
+	}
+
+	undo_redo->commit_action();
+}
+
+Button *ArrangePanel::create_button(String p_tooltip, Action p_action) {
+	Vector2 button_size(32 * EDSCALE, 32 * EDSCALE);
+	Button *btn = memnew(Button);
+	btn->set_tooltip(TTR(p_tooltip));
+	btn->connect("pressed", this, "arrange_nodes", varray(p_action));
+	return btn;
+}
+
+void ArrangePanel::_gui_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseButton> b = p_event;
+	if (b.is_valid() && b->is_pressed()) {
+		if (!Rect2(Point2(), get_size()).has_point(b->get_position())) {
+			queue_delete();
+		}
+	}
+}
+
+bool ArrangePanel::has_point(const Point2 &p_point) const {
+	return true;
+}
+
+void ArrangePanel::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_gui_input"), &ArrangePanel::_gui_input);
+	ClassDB::bind_method(D_METHOD("arrange_nodes"), &ArrangePanel::arrange_nodes);
+}
+
+void ArrangePanel::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
+		btn_align_left->set_icon(get_icon("ArrangeAlignLeft", "EditorIcons"));
+		btn_align_center_vertical->set_icon(get_icon("ArrangeAlignCenterVertical", "EditorIcons"));
+		btn_align_right->set_icon(get_icon("ArrangeAlignRight", "EditorIcons"));
+		btn_align_top->set_icon(get_icon("ArrangeAlignTop", "EditorIcons"));
+		btn_align_center_horizontal->set_icon(get_icon("ArrangeAlignCenterHorizontal", "EditorIcons"));
+		btn_align_bottom->set_icon(get_icon("ArrangeAlignBottom", "EditorIcons"));
+
+		btn_dist_left->set_icon(get_icon("ArrangeDistLeft", "EditorIcons"));
+		btn_dist_center_horizon->set_icon(get_icon("ArrangeDistCenterHorizontal", "EditorIcons"));
+		btn_dist_right->set_icon(get_icon("ArrangeDistRight", "EditorIcons"));
+		btn_dist_gap_horizontal->set_icon(get_icon("ArrangeDistGapHorizontal", "EditorIcons"));
+		btn_dist_top->set_icon(get_icon("ArrangeDistTop", "EditorIcons"));
+		btn_dist_center_vertical->set_icon(get_icon("ArrangeDistCenterVertical", "EditorIcons"));
+		btn_dist_bottom->set_icon(get_icon("ArrangeDistBottom", "EditorIcons"));
+		btn_dist_gap_vertical->set_icon(get_icon("ArrangeDistGapVertical", "EditorIcons"));
+
+	} else if (p_what == NOTIFICATION_DRAW) {
+		draw_style_box(get_stylebox("panel", "PopupMenu"), Rect2(Vector2(), get_size()));
+	}
+}
+
+ArrangePanel::ArrangePanel() {
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
+
+	VBoxContainer *vbox = memnew(VBoxContainer);
+	add_child(vbox);
+
+	GridContainer *grid_align = memnew(GridContainer);
+	grid_align->set_columns(3);
+	vbox->add_child(grid_align);
+
+	btn_align_left = create_button("Align left", ALIGN_LEFT);
+	grid_align->add_child(btn_align_left);
+
+	btn_align_center_vertical = create_button("Align center vertically", ALIGN_CENTER_VERTICAL);
+	grid_align->add_child(btn_align_center_vertical);
+
+	btn_align_right = create_button("Align right", ALIGN_RIGHT);
+	grid_align->add_child(btn_align_right);
+
+	btn_align_top = create_button("Align top", ALIGN_TOP);
+	grid_align->add_child(btn_align_top);
+
+	btn_align_center_horizontal = create_button("Align center horizontally", ALIGN_CENTER_HORIZONTAL);
+	grid_align->add_child(btn_align_center_horizontal);
+
+	btn_align_bottom = create_button("Align bottom", ALIGN_BOTTOM);
+	grid_align->add_child(btn_align_bottom);
+
+	HSeparator *split = memnew(HSeparator);
+	vbox->add_child(split);
+
+	GridContainer *grid_distribute = memnew(GridContainer);
+	grid_distribute->set_columns(4);
+	vbox->add_child(grid_distribute);
+
+	btn_dist_left = create_button("Distribute left edges", DISTRIBUTE_LEFT);
+	grid_distribute->add_child(btn_dist_left);
+
+	btn_dist_center_horizon = create_button("Distribute center horizontally", DISTRIBUTE_CENTER_HORIZONTAL);
+	grid_distribute->add_child(btn_dist_center_horizon);
+
+	btn_dist_right = create_button("Distribute right edges", DISTRIBUTE_RIGHT);
+	grid_distribute->add_child(btn_dist_right);
+
+	btn_dist_gap_horizontal = create_button("Distribute gap horizontally", DISTRIBUTE_GAP_HORIZONTAL);
+	grid_distribute->add_child(btn_dist_gap_horizontal);
+
+	btn_dist_top = create_button("Distribute top edges", DISTRIBUTE_TOP);
+	grid_distribute->add_child(btn_dist_top);
+
+	btn_dist_center_vertical = create_button("Distribute center vertically", DISTRIBUTE_CENTER_VERTICAL);
+	grid_distribute->add_child(btn_dist_center_vertical);
+
+	btn_dist_bottom = create_button("Distribute bottom edges", DISTRIBUTE_BOTTOM);
+	grid_distribute->add_child(btn_dist_bottom);
+
+	btn_dist_gap_vertical = create_button("Distribute gap vertically", DISTRIBUTE_GAP_VERTICAL);
+	grid_distribute->add_child(btn_dist_gap_vertical);
+}

--- a/editor/plugins/canvas_item_arrange_panel.h
+++ b/editor/plugins/canvas_item_arrange_panel.h
@@ -1,0 +1,120 @@
+/*************************************************************************/
+/*  canvas_item_arrange_plugin.h                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef CANVASITEM_ARRANGE_PLUGIN_H
+#define CANVASITEM_ARRANGE_PLUGIN_H
+
+#include "editor/editor_node.h"
+#include "editor/editor_plugin.h"
+
+class ArrangePanel : public PanelContainer {
+	GDCLASS(ArrangePanel, PanelContainer);
+
+	enum Action {
+		ALIGN_LEFT,
+		ALIGN_RIGHT,
+		ALIGN_TOP,
+		ALIGN_BOTTOM,
+		ALIGN_CENTER_HORIZONTAL,
+		ALIGN_CENTER_VERTICAL,
+		DISTRIBUTE_LEFT,
+		DISTRIBUTE_RIGHT,
+		DISTRIBUTE_TOP,
+		DISTRIBUTE_BOTTOM,
+		DISTRIBUTE_CENTER_HORIZONTAL,
+		DISTRIBUTE_CENTER_VERTICAL,
+		DISTRIBUTE_GAP_HORIZONTAL,
+		DISTRIBUTE_GAP_VERTICAL
+	};
+
+	struct SortLeft {
+		bool operator()(const CanvasItem *p_a, const CanvasItem *p_b) const {
+			Vector2 pos_a = p_a->get_global_transform().xform(p_a->_edit_get_rect().position);
+			Vector2 pos_b = p_b->get_global_transform().xform(p_b->_edit_get_rect().position);
+			return pos_a.x < pos_b.x;
+		}
+	};
+
+	struct SortRight {
+		bool operator()(const CanvasItem *p_a, const CanvasItem *p_b) const {
+			Vector2 pos_a = p_a->get_global_transform().xform(p_a->_edit_get_rect().position + p_a->_edit_get_rect().size);
+			Vector2 pos_b = p_b->get_global_transform().xform(p_b->_edit_get_rect().position + p_b->_edit_get_rect().size);
+			return pos_a.x < pos_b.x;
+		}
+	};
+
+	struct SortTop {
+		bool operator()(const CanvasItem *p_a, const CanvasItem *p_b) const {
+			Vector2 pos_a = p_a->get_global_transform().xform(p_a->_edit_get_rect().position);
+			Vector2 pos_b = p_b->get_global_transform().xform(p_b->_edit_get_rect().position);
+			return pos_a.y < pos_b.y;
+		}
+	};
+
+	struct SortBottom {
+		bool operator()(const CanvasItem *p_a, const CanvasItem *p_b) const {
+			Vector2 pos_a = p_a->get_global_transform().xform(p_a->_edit_get_rect().position + p_a->_edit_get_rect().size);
+			Vector2 pos_b = p_b->get_global_transform().xform(p_b->_edit_get_rect().position + p_b->_edit_get_rect().size);
+			return pos_a.y < pos_b.y;
+		}
+	};
+
+	UndoRedo *undo_redo;
+
+	Button *btn_align_left;
+	Button *btn_align_right;
+	Button *btn_align_center_horizontal;
+	Button *btn_align_top;
+	Button *btn_align_bottom;
+	Button *btn_align_center_vertical;
+	Button *btn_dist_left;
+	Button *btn_dist_right;
+	Button *btn_dist_top;
+	Button *btn_dist_center_vertical;
+	Button *btn_dist_bottom;
+	Button *btn_dist_center_horizon;
+	Button *btn_dist_gap_horizontal;
+	Button *btn_dist_gap_vertical;
+
+	void arrange_nodes(int p_action);
+	Button *create_button(String p_tooltip, Action p_action);
+	void _gui_input(const Ref<InputEvent> &p_event);
+
+protected:
+	virtual bool has_point(const Point2 &p_point) const;
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	List<CanvasItem *> get_selected_nodes();
+	ArrangePanel();
+};
+
+#endif // CANVASITEM_ARRANGE_PLUGIN_H

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
+#include "editor/plugins/canvas_item_arrange_panel.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/script_editor_debugger.h"
 #include "scene/2d/light_2d.h"
@@ -3747,6 +3748,10 @@ void CanvasItemEditor::_notification(int p_what) {
 			anchor_mode_button->set_visible(false);
 		}
 
+		// Show / Hide the arrange tool button
+		List<CanvasItem *> selection_without_lock = _get_edited_canvas_items(false, false);
+		arrange_button->set_visible(selection_without_lock.size() > 1);
+
 		// Update the viewport if bones changes
 		for (Map<BoneKey, BoneList>::Element *E = bone_list.front(); E; E = E->next()) {
 
@@ -3881,6 +3886,7 @@ void CanvasItemEditor::_notification(int p_what) {
 		anchors_popup->add_icon_item(get_icon("ControlAlignWide", "EditorIcons"), "Full Rect", ANCHORS_PRESET_WIDE);
 
 		anchor_mode_button->set_icon(get_icon("Anchor", "EditorIcons"));
+		arrange_button->set_icon(get_icon("ArrangeAlignLeft", "EditorIcons"));
 	}
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
@@ -4341,6 +4347,16 @@ void CanvasItemEditor::_button_toggle_anchor_mode(bool p_status) {
 
 	anchors_mode = p_status;
 	viewport->update();
+}
+
+void CanvasItemEditor::_button_arrange() {
+	Vector2 pos = arrange_button->get_global_position();
+	pos.y += arrange_button->get_rect().size.y;
+
+	ArrangePanel *arrange_panel = memnew(ArrangePanel);
+	arrange_panel->set_position(pos);
+	arrange_panel->set_as_toplevel(true);
+	arrange_button->add_child(arrange_panel);
 }
 
 void CanvasItemEditor::_update_override_camera_button(bool p_game_running) {
@@ -4954,6 +4970,7 @@ void CanvasItemEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_button_override_camera", "pressed"), &CanvasItemEditor::_button_override_camera);
 	ClassDB::bind_method(D_METHOD("_update_override_camera_button", "game_running"), &CanvasItemEditor::_update_override_camera_button);
 	ClassDB::bind_method("_button_toggle_anchor_mode", &CanvasItemEditor::_button_toggle_anchor_mode);
+	ClassDB::bind_method("_button_arrange", &CanvasItemEditor::_button_arrange);
 	ClassDB::bind_method("_update_scroll", &CanvasItemEditor::_update_scroll);
 	ClassDB::bind_method("_update_scrollbars", &CanvasItemEditor::_update_scrollbars);
 	ClassDB::bind_method("_popup_callback", &CanvasItemEditor::_popup_callback);
@@ -5591,6 +5608,11 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	anchor_mode_button->set_toggle_mode(true);
 	anchor_mode_button->hide();
 	anchor_mode_button->connect("toggled", this, "_button_toggle_anchor_mode");
+
+	arrange_button = memnew(ToolButton);
+	hb->add_child(arrange_button);
+	arrange_button->hide();
+	arrange_button->connect("pressed", this, "_button_arrange");
 
 	animation_hb = memnew(HBoxContainer);
 	hb->add_child(animation_hb);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -375,6 +375,7 @@ private:
 	PopupMenu *anchors_popup;
 
 	ToolButton *anchor_mode_button;
+	ToolButton *arrange_button;
 
 	Button *key_loc_button;
 	Button *key_rot_button;
@@ -530,6 +531,7 @@ private:
 	void _set_anchors_and_margins_to_keep_ratio();
 
 	void _button_toggle_anchor_mode(bool p_status);
+	void _button_arrange();
 
 	VBoxContainer *controls_vb;
 	HBoxContainer *zoom_hb;


### PR DESCRIPTION
![arrange](https://user-images.githubusercontent.com/8281454/69822524-ec9f5900-1249-11ea-8a2d-676771c7323a.gif)

Arrange panel is visible when selecting 2 or more `CanvasItem` nodes.
too late for 3.2? :smile: 

_Edit : Arrange tool was moved to Toolbar from Inspector._