### PR TITLE
Fix radiance map generation on mobile

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1794,13 +1794,21 @@ void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(texture->target, texture->tex_id);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 10);
-	// Need Mipmaps regardless of whether they are set in import by user
+	glTexParameteri(texture->target, GL_TEXTURE_BASE_LEVEL, 0);
+#ifdef GLES_OVER_GL
+	glTexParameteri(texture->target, GL_TEXTURE_MAX_LEVEL, int(Math::floor(Math::log(float(texture->width)) / Math::log(2.0f))));
 	glGenerateMipmap(texture->target);
+#else
+	glTexParameteri(texture->target, GL_TEXTURE_MAX_LEVEL, 0);
+#endif
+	// Need Mipmaps regardless of whether they are set in import by user
 	glTexParameterf(texture->target, GL_TEXTURE_WRAP_S, GL_REPEAT);
 	glTexParameterf(texture->target, GL_TEXTURE_WRAP_T, GL_REPEAT);
+#ifdef GLES_OVER_GL
 	glTexParameterf(texture->target, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+#else
+	glTexParameterf(texture->target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+#endif
 	glTexParameterf(texture->target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
 	if (config.srgb_decode_supported && texture->srgb && !texture->using_srgb) {
@@ -1925,7 +1933,11 @@ void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 
 			glBindFramebuffer(GL_FRAMEBUFFER, tmp_fb2);
 
+#ifdef GLES_OVER_GL
 			if (j < 3) {
+#else
+			if (j == 0) {
+#endif
 
 				shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::USE_DUAL_PARABOLOID, true);
 				shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::USE_SOURCE_PANORAMA, true);
@@ -2051,7 +2063,11 @@ void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 			glTexImage2D(GL_TEXTURE_2D, 0, internal_format, size, size * 2, 0, format, type, NULL);
 			glBindFramebuffer(GL_FRAMEBUFFER, tmp_fb2);
 			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tmp_tex, 0);
+#ifdef GLES_OVER_GL
 			if (lod < 3) {
+#else
+			if (lod == 0) {
+#endif
 
 				shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::USE_DUAL_PARABOLOID, true);
 				shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::USE_SOURCE_PANORAMA, true);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/33870

Looks like mobile was having issues with using mipmaps with the environment map. 

This PR disables the mipmap which results in slightly worse quality radiance and irradiance maps.  