### PR TITLE
Don't cast item to Spatial when checking if it's locked

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -521,7 +521,7 @@ void SpatialEditorViewport::_select_region() {
 
 		if (selected.find(item) != -1) continue;
 
-		if (_is_node_locked(Object::cast_to<Spatial>(item))) continue;
+		if (_is_node_locked(item)) continue;
 
 		Ref<EditorSpatialGizmo> seg = sp->get_gizmo();
 


### PR DESCRIPTION
Not a necessary cast, and causes a crash any time it's not a Spatial. Fixes #33901
