### PR TITLE
Improve the Video RAM debugger UX

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -484,8 +484,10 @@ int ScriptEditorDebugger::_update_scene_tree(TreeItem *parent, const Array &node
 
 void ScriptEditorDebugger::_video_mem_request() {
 
-	ERR_FAIL_COND(connection.is_null());
-	ERR_FAIL_COND(!connection->is_connected_to_host());
+	if (connection.is_null() || !connection->is_connected_to_host()) {
+		// Video RAM usage is only available while a project is being debugged.
+		return;
+	}
 
 	Array msg;
 	msg.push_back("request_video_mem");
@@ -1323,6 +1325,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					inspect_scene_tree->clear();
 					le_set->set_disabled(true);
 					le_clear->set_disabled(false);
+					vmem_refresh->set_disabled(false);
 					error_tree->clear();
 					error_count = 0;
 					warning_count = 0;
@@ -1523,6 +1526,7 @@ void ScriptEditorDebugger::stop() {
 	le_clear->set_disabled(false);
 	le_set->set_disabled(true);
 	profiler->set_enabled(true);
+	vmem_refresh->set_disabled(true);
 
 	inspect_scene_tree->clear();
 	inspector->edit(NULL);
@@ -2187,6 +2191,13 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 	}
 }
 
+void ScriptEditorDebugger::_tab_changed(int p_tab) {
+	if (tabs->get_tab_title(p_tab) == TTR("Video RAM")) {
+		// "Video RAM" tab was clicked, refresh the data it's dislaying when entering the tab.
+		_video_mem_request();
+	}
+}
+
 void ScriptEditorDebugger::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_stack_dump_frame_selected"), &ScriptEditorDebugger::_stack_dump_frame_selected);
@@ -2218,6 +2229,7 @@ void ScriptEditorDebugger::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_error_tree_item_rmb_selected"), &ScriptEditorDebugger::_error_tree_item_rmb_selected);
 	ClassDB::bind_method(D_METHOD("_item_menu_id_pressed"), &ScriptEditorDebugger::_item_menu_id_pressed);
+	ClassDB::bind_method(D_METHOD("_tab_changed"), &ScriptEditorDebugger::_tab_changed);
 
 	ClassDB::bind_method(D_METHOD("_paused"), &ScriptEditorDebugger::_paused);
 
@@ -2258,13 +2270,13 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	tabs->add_style_override("panel", editor->get_gui_base()->get_stylebox("DebuggerPanel", "EditorStyles"));
 	tabs->add_style_override("tab_fg", editor->get_gui_base()->get_stylebox("DebuggerTabFG", "EditorStyles"));
 	tabs->add_style_override("tab_bg", editor->get_gui_base()->get_stylebox("DebuggerTabBG", "EditorStyles"));
+	tabs->connect("tab_changed", this, "_tab_changed");
 
 	add_child(tabs);
 
 	{ //debugger
 		VBoxContainer *vbc = memnew(VBoxContainer);
 		vbc->set_name(TTR("Debugger"));
-		//tabs->add_child(vbc);
 		Control *dbg = vbc;
 
 		HBoxContainer *hbc = memnew(HBoxContainer);
@@ -2522,6 +2534,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		vmem_total->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 		vmem_hb->add_child(vmem_total);
 		vmem_refresh = memnew(ToolButton);
+		vmem_refresh->set_disabled(true);
 		vmem_hb->add_child(vmem_refresh);
 		vmem_vb->add_child(vmem_hb);
 		vmem_refresh->connect("pressed", this, "_video_mem_request");
@@ -2534,20 +2547,20 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		vmmc->set_v_size_flags(SIZE_EXPAND_FILL);
 		vmem_vb->add_child(vmmc);
 
-		vmem_vb->set_name(TTR("Video Mem"));
+		vmem_vb->set_name(TTR("Video RAM"));
 		vmem_tree->set_columns(4);
 		vmem_tree->set_column_titles_visible(true);
 		vmem_tree->set_column_title(0, TTR("Resource Path"));
 		vmem_tree->set_column_expand(0, true);
 		vmem_tree->set_column_expand(1, false);
 		vmem_tree->set_column_title(1, TTR("Type"));
-		vmem_tree->set_column_min_width(1, 100);
+		vmem_tree->set_column_min_width(1, 100 * EDSCALE);
 		vmem_tree->set_column_expand(2, false);
 		vmem_tree->set_column_title(2, TTR("Format"));
-		vmem_tree->set_column_min_width(2, 150);
+		vmem_tree->set_column_min_width(2, 150 * EDSCALE);
 		vmem_tree->set_column_expand(3, false);
 		vmem_tree->set_column_title(3, TTR("Usage"));
-		vmem_tree->set_column_min_width(3, 80);
+		vmem_tree->set_column_min_width(3, 80 * EDSCALE);
 		vmem_tree->set_hide_root(true);
 
 		tabs->add_child(vmem_vb);

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -226,6 +226,7 @@ private:
 
 	void _error_tree_item_rmb_selected(const Vector2 &p_pos);
 	void _item_menu_id_pressed(int p_option);
+	void _tab_changed(int p_tab);
 
 	void _export_csv();
 


### PR DESCRIPTION
- Refresh the tab automatically when switching to it.
- Disable the Refresh button if no project is currently being debugged.
- Scale the column widths on hiDPI displays.
- Rename the tab from "Video Mem" to "Video RAM" for consistency.