### PR TITLE
Add `instance_as_child` method for PackedScene

### DIFF
--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -56,6 +56,26 @@
 				Instantiates the scene's node hierarchy. Triggers child scene instantiation(s). Triggers a [constant Node.NOTIFICATION_INSTANCED] notification on the root node.
 			</description>
 		</method>
+		<method name="instance_as_child" qualifiers="const">
+			<return type="Node">
+			</return>
+			<argument index="0" name="parent" type="Node">
+			</argument>
+			<argument index="1" name="legible_unique_name" type="bool" default="false">
+			</argument>
+			<argument index="2" name="edit_state" type="int" enum="PackedScene.GenEditState" default="0">
+			</argument>
+			<description>
+				Same as [method instance], but adds the scene's root node as a child of any existing [code]parent[/code] node after the instantiation immediately with [method Node.add_child]. This ensures that any [code]onready[/code]-dependent members will get initialized so they can be referenced via code and allows for any operations to be performed that rely on a node being part of the [SceneTree] safely, such as retrieving the [member Node2D.global_transform] and the [member Node3D.global_transform].
+				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have an human-readable name based on the name of the node being instantiated instead of its type.
+				Example usage with shooting a bullet:
+				[codeblock]
+				func shoot():
+				    var bullet = preload("bullet.tscn").instance_as_child(self)
+				    bullet.global_position = self.global_position
+				[/codeblock]
+			</description>
+		</method>
 		<method name="pack">
 			<return type="int" enum="Error">
 			</return>

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1708,6 +1708,15 @@ Node *PackedScene::instance(GenEditState p_edit_state) const {
 	return s;
 }
 
+Node *PackedScene::instance_as_child(Node *p_parent, bool p_legible_unique_name, GenEditState p_edit_state) const {
+	ERR_FAIL_COND_V_MSG(!p_parent, nullptr, "Can't instance a scene to a non-existing node.");
+
+	Node *s = instance(p_edit_state);
+	p_parent->add_child(s, p_legible_unique_name);
+
+	return s;
+}
+
 void PackedScene::replace_state(Ref<SceneState> p_by) {
 
 	state = p_by;
@@ -1741,6 +1750,7 @@ void PackedScene::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("pack", "path"), &PackedScene::pack);
 	ClassDB::bind_method(D_METHOD("instance", "edit_state"), &PackedScene::instance, DEFVAL(GEN_EDIT_STATE_DISABLED));
+	ClassDB::bind_method(D_METHOD("instance_as_child", "parent", "legible_unique_name", "edit_state"), &PackedScene::instance_as_child, DEFVAL(false), DEFVAL(GEN_EDIT_STATE_DISABLED));
 	ClassDB::bind_method(D_METHOD("can_instance"), &PackedScene::can_instance);
 	ClassDB::bind_method(D_METHOD("_set_bundled_scene"), &PackedScene::_set_bundled_scene);
 	ClassDB::bind_method(D_METHOD("_get_bundled_scene"), &PackedScene::_get_bundled_scene);

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -221,6 +221,7 @@ public:
 
 	bool can_instance() const;
 	Node *instance(GenEditState p_edit_state = GEN_EDIT_STATE_DISABLED) const;
+	Node *instance_as_child(Node *p_parent, bool p_legible_unique_name = false, GenEditState p_edit_state = GEN_EDIT_STATE_DISABLED) const;
 
 	void recreate_state();
 	void replace_state(Ref<SceneState> p_by);


### PR DESCRIPTION
Closes godotengine/godot-proposals#260.

As suggested by @bojidar-bg in https://github.com/godotengine/godot-proposals/issues/260#issuecomment-559285521.