### PR TITLE
Add some TileSet editor keyboard shortcuts.

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -479,6 +479,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[TOOL_SELECT]->set_button_group(tg);
 	tools[TOOL_SELECT]->set_pressed(true);
 	tools[TOOL_SELECT]->connect("pressed", this, "_on_tool_clicked", varray(TOOL_SELECT));
+	tools[TOOL_SELECT]->set_shortcut(ED_SHORTCUT("tileset_editor/select", TTR("Select"), KEY_MASK_CTRL | KEY_1));
 
 	separator_bitmask = memnew(VSeparator);
 	toolbar->add_child(separator_bitmask);
@@ -500,12 +501,14 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[SHAPE_NEW_RECTANGLE]->set_toggle_mode(true);
 	tools[SHAPE_NEW_RECTANGLE]->set_button_group(tg);
 	tools[SHAPE_NEW_RECTANGLE]->set_tooltip(TTR("Create a new rectangle."));
+	tools[SHAPE_NEW_RECTANGLE]->set_shortcut(ED_SHORTCUT("tileset_editor/new_rectangle", TTR("Create New Rectangle"), KEY_MASK_CTRL | KEY_2));
 
 	tools[SHAPE_NEW_POLYGON] = memnew(ToolButton);
 	toolbar->add_child(tools[SHAPE_NEW_POLYGON]);
 	tools[SHAPE_NEW_POLYGON]->set_toggle_mode(true);
 	tools[SHAPE_NEW_POLYGON]->set_button_group(tg);
 	tools[SHAPE_NEW_POLYGON]->set_tooltip(TTR("Create a new polygon."));
+	tools[SHAPE_NEW_POLYGON]->set_shortcut(ED_SHORTCUT("tileset_editor/new_polygon", TTR("Create New Polygon"), KEY_MASK_CTRL | KEY_3));
 
 	separator_shape_toggle = memnew(VSeparator);
 	toolbar->add_child(separator_shape_toggle);


### PR DESCRIPTION
simply adds much needed keyboard shortcuts for "Select", "New Rectangle", and "New Polygon" buttons in the TileSet editor. For me this significantly reduces wrist strain when editing large or complex tile sets, since it removes the need to repeatedly navigate the cursor up to the toolbar and back down again.

Defaults I chose are:
CTRL-1: Select
CTRL-2: New Rectangle
CTRL-3: New Polygon