### PR TITLE
Flush remaining messages before quitting the game when loading fails

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2090,6 +2090,11 @@ void Main::cleanup() {
 
 	ERR_FAIL_COND(!_start_success);
 
+	if (script_debugger) {
+		// Flush any remaining messages
+		script_debugger->idle_poll();
+	}
+
 	ResourceLoader::remove_custom_loaders();
 	ResourceSaver::remove_custom_savers();
 


### PR DESCRIPTION
This change allows error messages to be printed in the editor debugger when the game fails on load, instead of displaying them in the console terminal only.

Example from #33881:
![image](https://user-images.githubusercontent.com/1075032/69870662-f14b2800-12b0-11ea-8b11-6993398ec0b4.png)