### PR TITLE
makerst: Escape default values using reST markup

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -213,9 +213,6 @@
 		<member name="mesh_library" type="MeshLibrary" setter="set_mesh_library" getter="get_mesh_library">
 			The assigned [MeshLibrary].
 		</member>
-		<member name="theme" type="MeshLibrary" setter="set_theme" getter="get_theme">
-			Deprecated, use [member mesh_library] instead.
-		</member>
 	</members>
 	<signals>
 		<signal name="cell_size_changed">


### PR DESCRIPTION
Otherwise the docs would complain about values like "godot_"
which reST tries to interpret as an identifier.

That let me solve those warnings:
```
/home/akien/Projects/godot/godot-docs/classes/class_gdnativelibrary.rst:33: WARNING: Unknown target name: "godot".
/home/akien/Projects/godot/godot-docs/classes/class_gdnativelibrary.rst:133: WARNING: Unknown target name: "godot".
```

Cf. godotengine/godot-docs@b6f0e1d5a0e1a1d8be48870b0ac2794812ae4928

There might be other fields that might need this basic escaping, and there's possibly more stuff in `rstize_text` that we may need for escaping normal text without BBCode, but this should be a good start.