### PR TITLE
[3.2] Format remote printerr properly in script debugger output

### DIFF
--- a/scene/debugger/script_debugger_remote.h
+++ b/scene/debugger/script_debugger_remote.h
@@ -92,7 +92,12 @@ class ScriptDebuggerRemote : public ScriptDebugger {
 		Array callstack;
 	};
 
-	List<String> output_strings;
+	struct OutputString {
+		String message;
+		int type;
+	};
+
+	List<OutputString> output_strings;
 	List<Message> messages;
 	int max_messages_per_frame;
 	int n_messages_dropped;
@@ -151,6 +156,11 @@ class ScriptDebuggerRemote : public ScriptDebugger {
 	bool skip_breakpoints;
 
 public:
+	enum MessageType {
+		MESSAGE_TYPE_LOG,
+		MESSAGE_TYPE_ERROR,
+	};
+
 	struct ResourceUsage {
 
 		String path;


### PR DESCRIPTION
The information about an output message being an error or simple log is now sent over the remote debugging session.

Fixes #33324