### PR TITLE
GLES3: Allow repeat flag in viewport textures

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1350,8 +1350,8 @@ void RasterizerStorageGLES3::texture_set_flags(RID p_texture, uint32_t p_flags) 
 	Texture *texture = texture_owner.get(p_texture);
 	ERR_FAIL_COND(!texture);
 	if (texture->render_target) {
-
-		p_flags &= VS::TEXTURE_FLAG_FILTER; //can change only filter
+		// only allow filter and repeat flags for render target (ie. viewport) textures
+		p_flags &= (VS::TEXTURE_FLAG_FILTER | VS::TEXTURE_FLAG_REPEAT);
 	}
 
 	bool had_mipmaps = texture->flags & VS::TEXTURE_FLAG_MIPMAPS;


### PR DESCRIPTION
This patch changes the `texture_set_flags` function in the GLES3 renderer to allow the use of the "Repeat" flag for render targets, which can fix visible seams when using viewports to generate procedural textures.

My setup for this is to generate a tiled noise texture around a sphere via the tutorial outlined [here](https://docs.godotengine.org/en/latest/tutorials/viewports/using_viewport_as_texture.html), reducing the viewport resolution to make the effect more visible, and enabling the filter and repeat flags in the texture. Notably, the repeat flag doesn't have any effect for viewport textures as of Godot 3.2.beta2.

Before applying the patch, enabling texture filtering creates a visible seam at the edges of the texture, where it wraps around the object:

![editor_screenshot_2019-11-29T183148-0300](https://user-images.githubusercontent.com/6194377/69891133-f58b3b80-12d8-11ea-8047-91d613b788f5.png)

But with the patch, the repeat flag works as it should and gets rid of the seam:

![editor_screenshot_2019-11-29T183226-0300](https://user-images.githubusercontent.com/6194377/69891134-f8862c00-12d8-11ea-9e50-2033a36581d2.png)

I believe there could be a reason for the flags to be set up as they were originally, however, I'm not very knowledgeable on OpenGL or Godot's rendering internals (it took me changing texture flags in many places and several compiles to nail the issue down!).