### PR TITLE
Docs: GridMap and MeshLibrary

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -4,7 +4,7 @@
 		Library of meshes.
 	</brief_description>
 	<description>
-		A library of meshes. Contains a list of [Mesh] resources, each with a name and ID. This resource is used in [GridMap].
+		A library of meshes. Contains a list of [Mesh] resources, each with a name and ID. Each item can also include collision and navigation shapes. This resource is used in [GridMap].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -22,7 +22,8 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Create a new item in the library, supplied as an ID.
+				Creates a new item in the library with the given ID.
+				You can get an unused ID from [method get_last_unused_item_id].
 			</description>
 		</method>
 		<method name="find_item_by_name" qualifiers="const">
@@ -31,13 +32,14 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
+				Returns the first item with the given name.
 			</description>
 		</method>
 		<method name="get_item_list" qualifiers="const">
 			<return type="PoolIntArray">
 			</return>
 			<description>
-				Returns the list of items.
+				Returns the list of item IDs in use.
 			</description>
 		</method>
 		<method name="get_item_mesh" qualifiers="const">
@@ -46,7 +48,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Returns the mesh of the item.
+				Returns the item's mesh.
 			</description>
 		</method>
 		<method name="get_item_name" qualifiers="const">
@@ -55,7 +57,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Returns the name of the item.
+				Returns the item's name.
 			</description>
 		</method>
 		<method name="get_item_navmesh" qualifiers="const">
@@ -64,6 +66,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
+				Returns the item's navigation mesh.
 			</description>
 		</method>
 		<method name="get_item_navmesh_transform" qualifiers="const">
@@ -72,6 +75,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
+				Returns the transform applied to the item's navigation mesh.
 			</description>
 		</method>
 		<method name="get_item_preview" qualifiers="const">
@@ -90,6 +94,8 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
+				Returns an item's collision shapes.
+				The array consists of each [Shape] followed by its [Transform].
 			</description>
 		</method>
 		<method name="get_last_unused_item_id" qualifiers="const">
@@ -128,6 +134,7 @@
 			</argument>
 			<description>
 				Sets the item's name.
+				This name is shown in the editor. It can also be used to look up the item later using [method find_item_by_name].
 			</description>
 		</method>
 		<method name="set_item_navmesh">
@@ -138,6 +145,7 @@
 			<argument index="1" name="navmesh" type="NavigationMesh">
 			</argument>
 			<description>
+				Sets the item's navigation mesh.
 			</description>
 		</method>
 		<method name="set_item_navmesh_transform">
@@ -148,6 +156,7 @@
 			<argument index="1" name="navmesh" type="Transform">
 			</argument>
 			<description>
+				Sets the transform to apply to the item's navigation mesh.
 			</description>
 		</method>
 		<method name="set_item_preview">
@@ -158,6 +167,7 @@
 			<argument index="1" name="texture" type="Texture">
 			</argument>
 			<description>
+				Sets a texture to use as the item's preview icon in the editor.
 			</description>
 		</method>
 		<method name="set_item_shapes">
@@ -168,6 +178,8 @@
 			<argument index="1" name="shapes" type="Array">
 			</argument>
 			<description>
+				Sets an item's collision shapes.
+				The array should consist of [Shape] objects, each followed by a [Transform] that will be applied to it. For shapes that should not have a transform, use [constant Transform.IDENTITY].
 			</description>
 		</method>
 	</methods>

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -4,10 +4,10 @@
 		Node for 3D tile-based maps.
 	</brief_description>
 	<description>
-		GridMap lets you place meshes on a grid interactively. It works both from the editor and can help you create in-game level editors.
-		GridMaps use a [MeshLibrary] which contain a list of tiles: meshes with materials plus optional collisions and extra elements.
-		A GridMap contains a collection of cells. Each grid cell refers to a [MeshLibrary] item. All cells in the map have the same dimensions.
-		A GridMap is split into a sparse collection of octants for efficient rendering and physics processing. Every octant has the same dimensions and can contain several cells.
+		GridMap lets you place meshes on a grid interactively. It works both from the editor and from scripts, which can help you create in-game level editors.
+		GridMaps use a [MeshLibrary] which contains a list of tiles. Each tile is a mesh with materials plus optional collision and navigation shapes.
+		A GridMap contains a collection of cells. Each grid cell refers to a tile in the [MeshLibrary]. All cells in the map have the same dimensions.
+		Internally, a GridMap is split into a sparse collection of octants for efficient rendering and physics processing. Every octant has the same dimensions and can contain several cells.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/3d/using_gridmaps.html</link>
@@ -72,6 +72,7 @@
 			<argument index="0" name="bit" type="int">
 			</argument>
 			<description>
+				Returns an individual bit on the [member collision_layer].
 			</description>
 		</method>
 		<method name="get_collision_mask_bit" qualifiers="const">
@@ -80,20 +81,21 @@
 			<argument index="0" name="bit" type="int">
 			</argument>
 			<description>
+				Returns an individual bit on the [member collision_mask].
 			</description>
 		</method>
 		<method name="get_meshes">
 			<return type="Array">
 			</return>
 			<description>
-				Array of [Transform] and [Mesh] references corresponding to the non-empty cells in the grid. The transforms are specified in world space.
+				Returns an array of [Transform] and [Mesh] references corresponding to the non-empty cells in the grid. The transforms are specified in world space.
 			</description>
 		</method>
 		<method name="get_used_cells" qualifiers="const">
 			<return type="Array">
 			</return>
 			<description>
-				Array of [Vector3] with the non-empty cell coordinates in the grid map.
+				Returns an array of [Vector3] with the non-empty cell coordinates in the grid map.
 			</description>
 		</method>
 		<method name="make_baked_meshes">
@@ -116,6 +118,7 @@
 			<argument index="2" name="z" type="int">
 			</argument>
 			<description>
+				Returns the position of a grid cell in the GridMap's local coordinate space.
 			</description>
 		</method>
 		<method name="resource_changed">
@@ -140,9 +143,9 @@
 			<argument index="4" name="orientation" type="int" default="0">
 			</argument>
 			<description>
-				Set the mesh index for the cell referenced by its grid-based X, Y and Z coordinates.
-				A negative item index will clear the cell.
-				Optionally, the item's orientation can be passed.
+				Sets the mesh index for the cell referenced by its grid-based X, Y and Z coordinates.
+				A negative item index such as [constant INVALID_CELL_ITEM] will clear the cell.
+				Optionally, the item's orientation can be passed. For valid orientation values, see [method Basis.get_orthogonal_index].
 			</description>
 		</method>
 		<method name="set_clip">
@@ -167,6 +170,7 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
+				Sets an individual bit on the [member collision_layer].
 			</description>
 		</method>
 		<method name="set_collision_mask_bit">
@@ -177,6 +181,7 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
+				Sets an individual bit on the [member collision_mask].
 			</description>
 		</method>
 		<method name="world_to_map" qualifiers="const">
@@ -185,6 +190,8 @@
 			<argument index="0" name="pos" type="Vector3">
 			</argument>
 			<description>
+				Returns the coordinates of the grid cell containing the given point.
+				[code]pos[/code] should be in the GridMap's local coordinate space.
 			</description>
 		</method>
 	</methods>
@@ -202,13 +209,19 @@
 			The size of each octant measured in number of cells. This applies to all three axis.
 		</member>
 		<member name="cell_scale" type="float" setter="set_cell_scale" getter="get_cell_scale" default="1.0">
+			The scale of the cell items.
+			This does not affect the size of the grid cells themselves, only the items in them. This can be used to make cell items overlap their neighbors.
 		</member>
 		<member name="cell_size" type="Vector3" setter="set_cell_size" getter="get_cell_size" default="Vector3( 2, 2, 2 )">
 			The dimensions of the grid's cells.
+			This does not affect the size of the meshes. See [member cell_scale].
 		</member>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="1">
+			The physics layers this GridMap is in.
+			GridMaps act as static bodies, meaning they aren't affected by gravity or other forces. They only affect other physics bodies that collide with them.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
+			The physics layers this GridMap detects collisions in.
 		</member>
 		<member name="mesh_library" type="MeshLibrary" setter="set_mesh_library" getter="get_mesh_library">
 			The assigned [MeshLibrary].
@@ -222,6 +235,7 @@
 			<argument index="0" name="cell_size" type="Vector3">
 			</argument>
 			<description>
+				Emitted when [member cell_size] changes.
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
Adds missing API documentation for GridMap and MeshLibrary, and edits some existing documentation to make it clearer.

resource_changed, set_clip, and the methods dealing with baked meshes are still empty.