### PR TITLE
Allow scale setters to work with negative scales and add to Basis

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -321,6 +321,19 @@ Vector3 Basis::get_scale() const {
 	return det_sign * get_scale_abs();
 }
 
+void Basis::set_scale(const Vector3 &p_scale) {
+	Vector3 delta_scale = p_scale / get_scale();
+	rows[0][0] *= delta_scale.x;
+	rows[1][0] *= delta_scale.x;
+	rows[2][0] *= delta_scale.x;
+	rows[0][1] *= delta_scale.y;
+	rows[1][1] *= delta_scale.y;
+	rows[2][1] *= delta_scale.y;
+	rows[0][2] *= delta_scale.z;
+	rows[1][2] *= delta_scale.z;
+	rows[2][2] *= delta_scale.z;
+}
+
 // Decomposes a Basis into a rotation-reflection matrix (an element of the group O(3)) and a positive scaling matrix as B = O.S.
 // Returns the rotation-reflection matrix via reference argument, and scaling information is returned as a Vector3.
 // This (internal) function is too specific and named too ugly to expose to users, and probably there's no need to do so.

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -117,6 +117,7 @@ struct _NO_DISCARD_ Basis {
 	Vector3 get_scale() const;
 	Vector3 get_scale_abs() const;
 	Vector3 get_scale_local() const;
+	void set_scale(const Vector3 &p_scale);
 
 	void set_axis_angle_scale(const Vector3 &p_axis, real_t p_angle, const Vector3 &p_scale);
 	void set_euler_scale(const Vector3 &p_euler, const Vector3 &p_scale, EulerOrder p_order = EULER_ORDER_YXZ);

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -118,10 +118,9 @@ Size2 Transform2D::get_scale() const {
 }
 
 void Transform2D::set_scale(const Size2 &p_scale) {
-	columns[0].normalize();
-	columns[1].normalize();
-	columns[0] *= p_scale.x;
-	columns[1] *= p_scale.y;
+	Size2 delta_scale = p_scale / get_scale();
+	columns[0] *= delta_scale.x;
+	columns[1] *= delta_scale.y;
 }
 
 void Transform2D::scale(const Size2 &p_scale) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1873,6 +1873,7 @@ static void _register_variant_builtin_methods() {
 	bind_methodv(Basis, rotated, static_cast<Basis (Basis::*)(const Vector3 &, real_t) const>(&Basis::rotated), sarray("axis", "angle"), varray());
 	bind_method(Basis, scaled, sarray("scale"), varray());
 	bind_method(Basis, get_scale, sarray(), varray());
+	bind_method(Basis, set_scale, sarray("scale"), varray());
 	bind_method(Basis, get_euler, sarray("order"), varray(Basis::EULER_ORDER_YXZ));
 	bind_method(Basis, tdotx, sarray("with"), varray());
 	bind_method(Basis, tdoty, sarray("with"), varray());

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -148,6 +148,13 @@
 				Introduce an additional scaling specified by the given 3D scaling factor.
 			</description>
 		</method>
+		<method name="set_scale">
+			<return type="void" />
+			<argument index="0" name="scale" type="Vector3" />
+			<description>
+				Sets the scale of this [Basis]. Each component of the scale becomes the length of each basis vector.
+			</description>
+		</method>
 		<method name="slerp" qualifiers="const">
 			<return type="Basis" />
 			<argument index="0" name="to" type="Basis" />


### PR DESCRIPTION
I wrote the Transform2D scale setters awhile back, but I forgot about making it work with negative scales. I've updated the code to work such that, for example, setting the same scale won't change the matrix. It works by finding the "delta" multiplier needed to change the scale to the desired scale. This PR also adds it to Basis.

Test code:

```gdscript
func _ready():
	var b = Basis()
	b.y = Vector3.DOWN
	print(b)
	print(b.get_scale())
	b.set_scale(b.get_scale())
	print(b)
	print(b.get_scale())

	var t2 = Transform2D()
	t2.y = Vector2.UP
	print(t2)
	print(t2.get_scale())
	t2.set_scale(t2.get_scale())
	print(t2)
	print(t2.get_scale())
```