### PR TITLE
Make sure to include the path in the "Data template directory not found" error message

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -201,23 +201,25 @@ namespace GodotTools.Export
             string TemplateDirName() => $"data.mono.{platform}.{bits}.{target}";
 
             string templateDirPath = Path.Combine(Internal.FullTemplatesDir, TemplateDirName());
+            bool validTemplatePathFound = true;
 
             if (!Directory.Exists(templateDirPath))
             {
-                templateDirPath = null;
+                validTemplatePathFound = false;
 
                 if (isDebug)
                 {
                     target = "debug"; // Support both 'release_debug' and 'debug' for the template data directory name
                     templateDirPath = Path.Combine(Internal.FullTemplatesDir, TemplateDirName());
+                    validTemplatePathFound = true;
 
                     if (!Directory.Exists(templateDirPath))
-                        templateDirPath = null;
+                        validTemplatePathFound = false;
                 }
             }
 
-            if (templateDirPath == null)
-                throw new FileNotFoundException("Data template directory not found");
+            if (!validTemplatePathFound)
+                throw new FileNotFoundException("Data template directory not found", templateDirPath);
 
             string outputDataDir = Path.Combine(outputDir, DataDirName);
 


### PR DESCRIPTION
This changes the error message from
```
[...]
System.IO.FileNotFoundException: Data template directory not found
  at GodotTools.GodotSharpExport.ExportDataDirectory (System.Collections.Generic.IEnumerable`1[T] features, System.Boolean debug, System.String path) [0x000c1] in <ff90da86eed24c32a3b9a5a581689633>:0 
[...]
```
to
```
[...]
System.IO.FileNotFoundException: Data template directory not found
File name: '/home/myuser/.local/share/godot/templates/3.2.beta.mono/data.mono.x11.64.release'
  at GodotTools.Export.ExportPlugin.ExportDataDirectory (System.String[] features, System.String platform, System.Boolean isDebug, System.String outputDir) [0x0008a] in <925595f6ba474cddad0f26df764f7310>:0
[...]
```

The reason why this is relevant is because without looking at the engine's source code it's kinda hard to guess what exactly this path should be when doing a custom build.

Calling `--version` gives me `3.2.beta.mono.custom_build.cde6775e1` from which I would have to guess somehow that the correct path is `/templates/3.2.beta.mono/` rather than `/templates/3.2.beta.mono.custom_build.cde6775e1/`. So it's better if the engine just tells me explicitly.
