### PR TITLE
Fixed errors in AnimationPlayerEditor when switching current_animation in the inspector

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -85,6 +85,9 @@ void AnimationPlayerEditor::_notification(int p_what) {
 				track_editor->set_anim_pos(player->get_current_animation_position());
 				EditorNode::get_singleton()->get_inspector()->refresh();
 
+			} else if (!player->is_valid()) {
+				// Reset timeline when the player has been stopped externally
+				frame->set_value(0);
 			} else if (last_active) {
 				// Need the last frame after it stopped.
 				frame->set_value(player->get_current_animation_position());


### PR DESCRIPTION
This change handle cases where the current animation has been changed in the inspector property itself, and the player can't retrieve the last played animation and its position.

Case 1: start and stop an animation in the inspector
Case 2: start an animation in the inspector, then stop and start again in the track editor

Fixes #34021