### PR TITLE
Fixed typo in docs for Script and GDScript classes

### DIFF
--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -4,7 +4,7 @@
 		A class stored as a resource.
 	</brief_description>
 	<description>
-		A class stored as a resource. A script exends the functionality of all objects that instance it.
+		A class stored as a resource. A script extends the functionality of all objects that instance it.
 		The [code]new[/code] method of a script subclass creates a new instance. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
 	</description>
 	<tutorials>

--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -4,7 +4,7 @@
 		A script implemented in the GDScript programming language.
 	</brief_description>
 	<description>
-		A script implemented in the GDScript programming language. The script exends the functionality of all objects that instance it.
+		A script implemented in the GDScript programming language. The script extends the functionality of all objects that instance it.
 		[method new] creates a new instance of the script. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
 	</description>
 	<tutorials>


### PR DESCRIPTION
"exends" -> "extends"