### PR TITLE
Removed errors when List::erase() can't find the value

### DIFF
--- a/core/list.h
+++ b/core/list.h
@@ -348,7 +348,7 @@ public:
 	 * erase an element in the list, by iterator pointing to it. Return true if it was found/erased.
 	 */
 	bool erase(const Element *p_I) {
-		if (_data) {
+		if (_data && p_I) {
 			bool ret = _data->erase(p_I);
 
 			if (_data->size_cache == 0) {


### PR DESCRIPTION
This change makes the behavior consistent when the value is not found between erasing from an empty list (no error, just returning false) and erasing from a non-empty list (previously triggering an error and returning false).

Error message previously triggered:
```
ERROR: erase: Condition ' !p_I ' is true. returned: false
   At: ./core/list.h:157.
```