### PR TITLE
Fixed error when creating physical skeleton

### DIFF
--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -65,13 +65,14 @@ void SkeletonEditor::create_physical_skeleton() {
 	for (int bone_id = 0; bc > bone_id; ++bone_id) {
 
 		const int parent = skeleton->get_bone_parent(bone_id);
-		const int parent_parent = skeleton->get_bone_parent(parent);
 
 		if (parent < 0) {
 
 			bones_infos.write[bone_id].relative_rest = skeleton->get_bone_rest(bone_id);
 
 		} else {
+
+			const int parent_parent = skeleton->get_bone_parent(parent);
 
 			bones_infos.write[bone_id].relative_rest = bones_infos[parent].relative_rest * skeleton->get_bone_rest(bone_id);
 


### PR DESCRIPTION
An error was systematically triggered on the root bone, when trying to access its parent (the return value wasn't used in this case anyway).

Fixes #23920