### PR TITLE
Added Missing Binding for `multimesh_create` to VisualServer

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -2604,6 +2604,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="multimesh_create">
+			<return type="RID">
+			</return>
+			<description>
+				Creates a new multimesh on the VisualServer and returns an [RID] handle.
+				Once finished with your RID, you will want to free the RID using the VisualServer's [method free_rid] static method.
+			</description>
+		</method>
 		<method name="multimesh_get_aabb" qualifiers="const">
 			<return type="AABB">
 			</return>

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1717,6 +1717,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("mesh_get_custom_aabb", "mesh"), &VisualServer::mesh_get_custom_aabb);
 	ClassDB::bind_method(D_METHOD("mesh_clear", "mesh"), &VisualServer::mesh_clear);
 
+	ClassDB::bind_method(D_METHOD("multimesh_create"), &VisualServer::multimesh_create);
 	ClassDB::bind_method(D_METHOD("multimesh_allocate", "multimesh", "instances", "transform_format", "color_format", "custom_data_format"), &VisualServer::multimesh_allocate, DEFVAL(MULTIMESH_CUSTOM_DATA_NONE));
 	ClassDB::bind_method(D_METHOD("multimesh_get_instance_count", "multimesh"), &VisualServer::multimesh_get_instance_count);
 	ClassDB::bind_method(D_METHOD("multimesh_set_mesh", "multimesh", "mesh"), &VisualServer::multimesh_set_mesh);


### PR DESCRIPTION
This is a minor correction to the VisualServer class which adds a `bind_method` call for `multimesh_create` so that you can now create multimesh RIDs via GDScript.

### Why?

I was making an RTS-style map editor and needed to have the ability to create my own version of a MultiMeshInstance without inheritance. A problem arose by the time I was trying to actually render an instanced mesh because I couldn't create the RIDs similarly to how the C++ code operates -- by calling `multimesh_create`.

With this patch, you can now make multimeshs RIDs with GDscript. It also brings `multimesh_create` to the same standard as other `create` methods (`material_create`, `mesh_create` and `shader_create` to name a few.) Here's a (probably slightly broken) example:

```
if len(map_multimeshes) > 0:
	for id in map_multimeshes:
		VisualServer.free_rid(id)
	map_multimeshes.clear()
	
if len(map_multimeshes) == 0:
	var instance = VisualServer.instance_create()
	var mm : RID = VisualServer.multimesh_create()
	VisualServer.multimesh_allocate(mm, columns * rows, VisualServer.MULTIMESH_TRANSFORM_3D, VisualServer.MULTIMESH_CUSTOM_DATA_NONE)
	VisualServer.multimesh_set_mesh(mm, cube.get_rid())
	for row in range(0, rows):
		for column in range(0, columns):
			var jpos = get_junction_transform(column, row)
			VisualServer.multimesh_instance_set_transform( mm, column + row * columns, Transform(Basis.IDENTITY.scaled(Vector3(0.1,0.1,0.1)), jpos))
				
		
	VisualServer.multimesh_set_visible_instances(mm, columns * rows)
	VisualServer.instance_attach_object_instance_id(instance, get_instance_id())
	VisualServer.instance_set_base(instance, mm)
	VisualServer.instance_set_scenario(instance, get_world().get_scenario())
	#set_notify_transform(true)
	map_multimeshes.append(instance)
```


This is my first foray into Godot's VisualServer code, so if there's actually an alternate way of doing what I'm doing, let me know and I'll close this.  It could very well be that there's a good explanation for why this method isn't exposed to GDScript that may explain its original absence. Otherwise, I've tested this and it seems to work as intended. 

