### PR TITLE
Removed unused variables, add some constants numbers

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -739,8 +739,8 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 		if ((xx > yy) && (xx > zz)) { // elements[0][0] is the largest diagonal term
 			if (xx < epsilon) {
 				x = 0;
-				y = 0.7071;
-				z = 0.7071;
+				y = Math_SQRT12;
+				z = Math_SQRT12;
 			} else {
 				x = Math::sqrt(xx);
 				y = xy / x;
@@ -748,9 +748,9 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 			}
 		} else if (yy > zz) { // elements[1][1] is the largest diagonal term
 			if (yy < epsilon) {
-				x = 0.7071;
+				x = Math_SQRT12;
 				y = 0;
-				z = 0.7071;
+				z = Math_SQRT12;
 			} else {
 				y = Math::sqrt(yy);
 				x = xy / y;
@@ -758,8 +758,8 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 			}
 		} else { // elements[2][2] is the largest diagonal term so base result on this
 			if (zz < epsilon) {
-				x = 0.7071;
-				y = 0.7071;
+				x = Math_SQRT12;
+				y = Math_SQRT12;
 				z = 0;
 			} else {
 				z = Math::sqrt(zz);

--- a/core/math/bsp_tree.cpp
+++ b/core/math/bsp_tree.cpp
@@ -192,14 +192,14 @@ int BSP_Tree::get_points_inside(const Vector3 *p_points, int p_point_count) cons
 #ifdef DEBUG_ENABLED
 			int plane_count = planes.size();
 			uint16_t plane = nodesptr[idx].plane;
-			ERR_FAIL_UNSIGNED_INDEX_V(plane, plane_count, false);
+			ERR_FAIL_UNSIGNED_INDEX_V(plane, plane_count, 0);
 #endif
 
 			idx = planesptr[nodesptr[idx].plane].is_point_over(point) ? nodes[idx].over : nodes[idx].under;
 
 #ifdef DEBUG_ENABLED
 
-			ERR_FAIL_COND_V(idx < MAX_NODES && idx >= node_count, false);
+			ERR_FAIL_COND_V(idx < MAX_NODES && idx >= node_count, 0);
 #endif
 		}
 

--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -129,9 +129,6 @@ Error MessageQueue::push_notification(ObjectID p_id, int p_notification) {
 	uint8_t room_needed = sizeof(Message);
 
 	if ((buffer_end + room_needed) >= buffer_size) {
-		String type;
-		if (ObjectDB::get_instance(p_id))
-			type = ObjectDB::get_instance(p_id)->get_class();
 		print_line("Failed notification: " + itos(p_notification) + " target ID: " + itos(p_id));
 		statistics();
 		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'message_queue_size_kb' in project settings.");

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1917,7 +1917,7 @@ static double built_in_strtod(const C *string, /* A decimal ASCII floating-point
 		1.0e256
 	};
 
-	int sign, expSign = false;
+	bool sign, expSign = false;
 	double fraction, dblExp;
 	const double *d;
 	const C *p;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -266,7 +266,6 @@ public:
 				else
 					undo_redo->create_action(TTR("Anim Change Call"));
 
-				Variant prev = animation->track_get_key_value(track, key);
 				setting = true;
 				undo_redo->add_do_method(animation.ptr(), "track_set_key_value", track, key, d_new);
 				undo_redo->add_undo_method(animation.ptr(), "track_set_key_value", track, key, d_old);

--- a/editor/collada/collada.cpp
+++ b/editor/collada/collada.cpp
@@ -1488,7 +1488,6 @@ Collada::Node *Collada::_parse_visual_instance_geometry(XMLParser &parser) {
 
 Collada::Node *Collada::_parse_visual_instance_camera(XMLParser &parser) {
 
-	String type = parser.get_node_name();
 	NodeCamera *cam = memnew(NodeCamera);
 	cam->camera = _uri_to_id(parser.get_attribute_value_safe("url"));
 
@@ -1509,7 +1508,6 @@ Collada::Node *Collada::_parse_visual_instance_camera(XMLParser &parser) {
 
 Collada::Node *Collada::_parse_visual_instance_light(XMLParser &parser) {
 
-	String type = parser.get_node_name();
 	NodeLight *cam = memnew(NodeLight);
 	cam->light = _uri_to_id(parser.get_attribute_value_safe("url"));
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -49,7 +49,6 @@ void DependencyEditor::_searched(const String &p_path) {
 void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button) {
 
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
-	String fname = ti->get_text(0);
 	replacing = ti->get_text(1);
 
 	search->set_title(TTR("Search Replacement For:") + " " + replacing.get_file());

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -727,7 +727,7 @@ uint64_t EditorData::get_edited_scene_version() const {
 	return edited_scene[current_edited_scene].version;
 }
 uint64_t EditorData::get_scene_version(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), false);
+	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), 0);
 	return edited_scene[p_idx].version;
 }
 

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -55,7 +55,6 @@ void EditorFolding::save_resource_folding(const RES &p_resource, const String &p
 	PoolVector<String> unfolds = _get_unfolds(p_resource.ptr());
 	config->set_value("folding", "sections_unfolded", unfolds);
 
-	String path = EditorSettings::get_singleton()->get_project_settings_dir();
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
 	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
 	config->save(file);
@@ -76,7 +75,6 @@ void EditorFolding::load_resource_folding(RES p_resource, const String &p_path) 
 	Ref<ConfigFile> config;
 	config.instance();
 
-	String path = EditorSettings::get_singleton()->get_project_settings_dir();
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
 	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
 
@@ -151,7 +149,6 @@ void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path
 	config->set_value("folding", "resource_unfolds", res_unfolds);
 	config->set_value("folding", "nodes_folded", nodes_folded);
 
-	String path = EditorSettings::get_singleton()->get_project_settings_dir();
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
 	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
 	config->save(file);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -963,7 +963,7 @@ bool EditorNode::_find_and_save_edited_subresources(Object *obj, Map<RES, bool> 
 				int len = varray.size();
 				for (int i = 0; i < len; i++) {
 
-					Variant v = varray.get(i);
+					const Variant &v = varray.get(i);
 					RES res = v;
 					if (_find_and_save_resource(res, processed, flags))
 						ret_changed = true;
@@ -1027,13 +1027,10 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 	int c3d = 0;
 	_find_node_types(editor_data.get_edited_scene_root(), c2d, c3d);
 
-	RID viewport;
 	bool is2d;
 	if (c3d < c2d) {
-		viewport = scene_root->get_viewport_rid();
 		is2d = true;
 	} else {
-		viewport = SpatialEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_viewport_rid();
 		is2d = false;
 	}
 	save.step(TTR("Creating Thumbnail"), 1);
@@ -1282,7 +1279,6 @@ void EditorNode::restart_editor() {
 	}
 
 	_exit_editor();
-	String exec = OS::get_singleton()->get_executable_path();
 
 	List<String> args;
 	args.push_back("--path");

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -979,8 +979,6 @@ void EditorPropertyEasing::_draw_easing() {
 	RID ci = easing_draw->get_canvas_item();
 
 	Size2 s = easing_draw->get_size();
-	Rect2 r(Point2(), s);
-	r = r.grow(3);
 
 	const int points = 48;
 

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -172,7 +172,7 @@ void ExportTemplateManager::_uninstall_template_confirm() {
 	ERR_FAIL_COND_MSG(err != OK, "Could not remove all templates in '" + templates_dir.plus_file(to_remove) + "'.");
 
 	da->change_dir("..");
-	da->remove(to_remove);
+	err = da->remove(to_remove);
 	ERR_FAIL_COND_MSG(err != OK, "Could not remove templates directory at '" + templates_dir.plus_file(to_remove) + "'.");
 
 	_update_template_list();

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -889,7 +889,6 @@ String FindInFilesPanel::get_replace_text() {
 
 void FindInFilesPanel::update_replace_buttons() {
 
-	String text = get_replace_text();
 	bool disabled = _finder->is_searching();
 
 	_replace_all_button->set_disabled(disabled);

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1015,8 +1015,6 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 
 			Path *path = Object::cast_to<Path>(node);
 
-			String curve = ng->source;
-
 			if (curve_cache.has(ng->source)) {
 
 				path->set_curve(curve_cache[ng->source]);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1089,8 +1089,6 @@ void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag)
 	if (!player->has_animation(player->get_assigned_animation()))
 		return;
 
-	Ref<Animation> anim = player->get_animation(player->get_assigned_animation());
-
 	updating = true;
 	frame->set_value(Math::stepify(p_pos, _get_editor_step()));
 	updating = false;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -54,7 +54,7 @@
 #define MIN_ZOOM 0.01
 #define MAX_ZOOM 100
 
-#define RULER_WIDTH 15 * EDSCALE
+#define RULER_WIDTH (15 * EDSCALE)
 #define SCALE_HANDLE_DISTANCE 25
 
 class SnapDialog : public ConfirmationDialog {
@@ -3202,7 +3202,7 @@ void CanvasItemEditor::_draw_selection() {
 					int next = (i + 1) % 4;
 
 					Vector2 ofs = ((endpoints[i] - endpoints[prev]).normalized() + ((endpoints[i] - endpoints[next]).normalized())).normalized();
-					ofs *= 1.4144 * (select_handle->get_size().width / 2);
+					ofs *= Math_SQRT2 * (select_handle->get_size().width / 2);
 
 					select_handle->draw(ci, (endpoints[i] + ofs - (select_handle->get_size() / 2)).floor());
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -403,7 +403,6 @@ void SpriteFramesEditor::_up_pressed() {
 	sel = to_move;
 	sel -= 1;
 
-	Ref<Texture> r = frames->get_frame(edited_anim, to_move);
 	undo_redo->create_action(TTR("Delete Resource"));
 	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move - 1));
 	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move - 1, frames->get_frame(edited_anim, to_move));
@@ -428,7 +427,6 @@ void SpriteFramesEditor::_down_pressed() {
 	sel = to_move;
 	sel += 1;
 
-	Ref<Texture> r = frames->get_frame(edited_anim, to_move);
 	undo_redo->create_action(TTR("Delete Resource"));
 	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move + 1));
 	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move + 1, frames->get_frame(edited_anim, to_move));

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -150,7 +150,7 @@ void TextureRegionEditor::_region_draw() {
 		int next = (i + 1) % 4;
 
 		Vector2 ofs = ((endpoints[i] - endpoints[prev]).normalized() + ((endpoints[i] - endpoints[next]).normalized())).normalized();
-		ofs *= 1.4144 * (select_handle->get_size().width / 2);
+		ofs *= Math_SQRT2 * (select_handle->get_size().width / 2);
 
 		edit_draw->draw_line(endpoints[i] - draw_ofs * draw_zoom, endpoints[next] - draw_ofs * draw_zoom, color, 2);
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -349,16 +349,15 @@ private:
 
 	void _path_selected(const String &p_path) {
 
-		String p = p_path;
-		String sp = p.simplify_path();
+		String sp = p_path.simplify_path();
 		project_path->set_text(sp);
 		_path_text_changed(sp);
 		get_ok()->call_deferred("grab_focus");
 	}
 
 	void _install_path_selected(const String &p_path) {
-		String p = p_path;
-		String sp = p.simplify_path();
+
+		String sp = p_path.simplify_path();
 		install_path->set_text(sp);
 		_path_text_changed(sp);
 		get_ok()->call_deferred("grab_focus");

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -364,8 +364,6 @@ EditorSceneImporterAssimp::_generate_scene(const String &p_path, aiScene *scene,
 				}
 			} else if (bone != NULL) {
 				continue;
-			} else if (element_assimp_node->mNumMeshes > 0) {
-				spatial = memnew(Spatial);
 			} else {
 				spatial = memnew(Spatial);
 			}
@@ -393,16 +391,11 @@ EditorSceneImporterAssimp::_generate_scene(const String &p_path, aiScene *scene,
 				ERR_FAIL_COND_V_MSG(parent_node == NULL, state.root,
 						"Parent node invalid even though lookup successful, out of ram?")
 
-				if (parent_node && spatial != state.root) {
+				if (spatial != state.root) {
 					parent_node->add_child(spatial);
 					spatial->set_owner(state.root);
-				} else if (spatial == state.root) {
+				} else {
 					// required - think about it root never has a parent yet is valid, anything else without a parent is not valid.
-				} else // Safety for instances
-				{
-					WARN_PRINT(
-							"Failed to find parent node instance after lookup, serious warning report to godot with model");
-					memdelete(spatial); // this node is broken
 				}
 			} else if (spatial != state.root) {
 				// if the ainode is not in the tree
@@ -477,10 +470,11 @@ EditorSceneImporterAssimp::_generate_scene(const String &p_path, aiScene *scene,
 		for (Map<const aiNode *, Spatial *>::Element *key_value_pair = state.flat_node_map.front(); key_value_pair; key_value_pair = key_value_pair->next()) {
 			const aiNode *assimp_node = key_value_pair->key();
 			Spatial *mesh_template = key_value_pair->value();
-			Node *parent_node = mesh_template->get_parent();
 
 			ERR_CONTINUE(assimp_node == NULL);
 			ERR_CONTINUE(mesh_template == NULL);
+
+			Node *parent_node = mesh_template->get_parent();
 
 			if (mesh_template == state.root) {
 				continue;
@@ -1009,7 +1003,6 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 			}
 		}
 
-		const String mesh_name = AssimpUtils::get_assimp_string(ai_mesh->mName);
 		aiString mat_name;
 		if (AI_SUCCESS == ai_material->Get(AI_MATKEY_NAME, mat_name)) {
 			mat->set_name(AssimpUtils::get_assimp_string(mat_name));
@@ -1495,7 +1488,6 @@ void EditorSceneImporterAssimp::_generate_node(
 
 	ERR_FAIL_COND(assimp_node == NULL);
 	state.nodes.push_back(assimp_node);
-	String node_name = AssimpUtils::get_assimp_string(assimp_node->mName);
 	String parent_name = AssimpUtils::get_assimp_string(assimp_node->mParent->mName);
 
 	// please note

--- a/modules/assimp/import_utils.h
+++ b/modules/assimp/import_utils.h
@@ -309,9 +309,7 @@ public:
 			if (r_found) {
 				return;
 			}
-			if (r_found == false) {
-				find_texture_path(r_p_path, dir, r_path, r_found, "." + exts[i]);
-			}
+			find_texture_path(r_p_path, dir, r_path, r_found, "." + exts[i]);
 		}
 	}
 
@@ -322,9 +320,7 @@ public:
 	static void set_texture_mapping_mode(aiTextureMapMode *map_mode, Ref<ImageTexture> texture) {
 		ERR_FAIL_COND(texture.is_null());
 		ERR_FAIL_COND(map_mode == NULL);
-		aiTextureMapMode tex_mode = aiTextureMapMode::aiTextureMapMode_Wrap;
-
-		tex_mode = map_mode[0];
+		aiTextureMapMode tex_mode = map_mode[0];
 
 		int32_t flags = Texture::FLAGS_DEFAULT;
 		if (tex_mode == aiTextureMapMode_Wrap) {

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -224,7 +224,6 @@ void GDNativeLibraryEditor::_erase_entry(const String &platform, const String &e
 		if (List<String>::Element *E = platforms[platform].entries.find(entry)) {
 
 			String target = platform + "." + entry;
-			Ref<ConfigFile> config = library->get_config_file();
 
 			platforms[platform].entries.erase(E);
 			_set_target_value("entry", target, "");

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -115,7 +115,7 @@ void ExtendGDScriptParser::update_document_links(const String &p_code) {
 		if (tokenizer.get_token() == GDScriptTokenizer::TK_EOF) {
 			break;
 		} else if (tokenizer.get_token() == GDScriptTokenizer::TK_CONSTANT) {
-			Variant const_val = tokenizer.get_token_constant();
+			const Variant &const_val = tokenizer.get_token_constant();
 			if (const_val.get_type() == Variant::STRING) {
 				String path = const_val;
 				bool exists = fs->file_exists(path);

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -281,8 +281,6 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 }
 
 Array GDScriptTextDocument::foldingRange(const Dictionary &p_params) {
-	Dictionary params = p_params["textDocument"];
-	String path = params["uri"];
 	Array arr;
 	return arr;
 }

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -203,8 +203,6 @@ void CryptoMbedTLS::load_default_certificates(String p_path) {
 	default_certs = memnew(X509CertificateMbedTLS);
 	ERR_FAIL_COND(default_certs == NULL);
 
-	String certs_path = GLOBAL_DEF("network/ssl/certificates", "");
-
 	if (p_path != "") {
 		// Use certs defined in project settings.
 		default_certs->load(p_path);

--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -111,7 +111,6 @@ Error StreamPeerMbedTLS::connect_to_stream(Ref<StreamPeer> p_base, bool p_valida
 	ERR_FAIL_COND_V(p_base.is_null(), ERR_INVALID_PARAMETER);
 
 	base = p_base;
-	int ret = 0;
 	int authmode = p_validate_certs ? MBEDTLS_SSL_VERIFY_REQUIRED : MBEDTLS_SSL_VERIFY_NONE;
 
 	Error err = ssl_ctx->init_client(MBEDTLS_SSL_TRANSPORT_STREAM, authmode, p_ca_certs);
@@ -122,7 +121,7 @@ Error StreamPeerMbedTLS::connect_to_stream(Ref<StreamPeer> p_base, bool p_valida
 
 	status = STATUS_HANDSHAKING;
 
-	if ((ret = _do_handshake()) != OK) {
+	if (_do_handshake() != OK) {
 		status = STATUS_ERROR_HOSTNAME_MISMATCH;
 		return FAILED;
 	}
@@ -143,7 +142,7 @@ Error StreamPeerMbedTLS::accept_stream(Ref<StreamPeer> p_base, Ref<CryptoKey> p_
 
 	status = STATUS_HANDSHAKING;
 
-	if ((err = _do_handshake()) != OK) {
+	if (_do_handshake() != OK) {
 		return FAILED;
 	}
 

--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -62,7 +62,7 @@ void EditorNavigationMeshGenerator::_add_vertex(const Vector3 &p_vec3, Vector<fl
 }
 
 void EditorNavigationMeshGenerator::_add_mesh(const Ref<Mesh> &p_mesh, const Transform &p_xform, Vector<float> &p_verticies, Vector<int> &p_indices) {
-	int current_vertex_count = 0;
+	int current_vertex_count;
 
 	for (int i = 0; i < p_mesh->get_surface_count(); i++) {
 		current_vertex_count = p_verticies.size() / 3;

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1290,7 +1290,7 @@ public:
 		if (!instance->get_variable(variable, p_outputs[0])) {
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 			r_error_str = RTR("VariableGet not found in script: ") + "'" + String(variable) + "'";
-			return false;
+			return 0;
 		}
 		return 0;
 	}

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -169,8 +169,8 @@ void CollisionPolygon2D::_notification(int p_what) {
 				Vector<Vector2> pts;
 				float tsize = 8;
 				pts.push_back(line_to + (Vector2(0, tsize)));
-				pts.push_back(line_to + (Vector2(0.707 * tsize, 0)));
-				pts.push_back(line_to + (Vector2(-0.707 * tsize, 0)));
+				pts.push_back(line_to + (Vector2(Math_SQRT12 * tsize, 0)));
+				pts.push_back(line_to + (Vector2(-Math_SQRT12 * tsize, 0)));
 				Vector<Color> cols;
 				for (int i = 0; i < 3; i++)
 					cols.push_back(dcol);

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -134,8 +134,8 @@ void CollisionShape2D::_notification(int p_what) {
 				Vector<Vector2> pts;
 				float tsize = 8;
 				pts.push_back(line_to + (Vector2(0, tsize)));
-				pts.push_back(line_to + (Vector2(0.707 * tsize, 0)));
-				pts.push_back(line_to + (Vector2(-0.707 * tsize, 0)));
+				pts.push_back(line_to + (Vector2(Math_SQRT12 * tsize, 0)));
+				pts.push_back(line_to + (Vector2(-Math_SQRT12 * tsize, 0)));
 				Vector<Color> cols;
 				for (int i = 0; i < 3; i++)
 					cols.push_back(draw_col);

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -180,8 +180,8 @@ void RayCast2D::_notification(int p_what) {
 			Vector<Vector2> pts;
 			float tsize = 8;
 			pts.push_back(xf.xform(Vector2(tsize, 0)));
-			pts.push_back(xf.xform(Vector2(0, 0.707 * tsize)));
-			pts.push_back(xf.xform(Vector2(0, -0.707 * tsize)));
+			pts.push_back(xf.xform(Vector2(0, Math_SQRT12 * tsize)));
+			pts.push_back(xf.xform(Vector2(0, -Math_SQRT12 * tsize)));
 			Vector<Color> cols;
 			for (int i = 0; i < 3; i++)
 				cols.push_back(draw_col);

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -1594,10 +1594,10 @@ Vector3 VoxelLightBaker::_compute_pixel_light_at_pos(const Vector3 &p_pos, const
 		case BAKE_QUALITY_LOW: {
 			//default quality
 			static const Vector3 dirs[4] = {
-				Vector3(0.707107, 0, 0.707107),
-				Vector3(0, 0.707107, 0.707107),
-				Vector3(-0.707107, 0, 0.707107),
-				Vector3(0, -0.707107, 0.707107)
+				Vector3(Math_SQRT12, 0, Math_SQRT12),
+				Vector3(0, Math_SQRT12, Math_SQRT12),
+				Vector3(-Math_SQRT12, 0, Math_SQRT12),
+				Vector3(0, -Math_SQRT12, Math_SQRT12)
 			};
 
 			static const float weights[4] = { 0.25, 0.25, 0.25, 0.25 };

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -101,6 +101,12 @@ private:
 		int args;
 		Variant arg[5];
 		int uid;
+		InterpolateData() {
+			active = false;
+			finish = false;
+			call_deferred = false;
+			uid = 0;
+		}
 	};
 
 	String autoplay;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4438,7 +4438,6 @@ int TextEdit::get_line_wrap_index_at_col(int p_line, int p_column) const {
 }
 
 void TextEdit::cursor_set_column(int p_col, bool p_adjust_viewport) {
-
 	if (p_col < 0)
 		p_col = 0;
 
@@ -7141,6 +7140,7 @@ TextEdit::TextEdit() {
 	max_chars = 0;
 	clear();
 	wrap_enabled = false;
+	wrap_at = 0;
 	wrap_right_offset = 10;
 	set_focus_mode(FOCUS_ALL);
 	syntax_highlighter = NULL;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -69,6 +69,10 @@ public:
 
 			int region;
 			bool end;
+			ColorRegionInfo() {
+				region = 0;
+				end = false;
+			}
 		};
 
 		struct Line {
@@ -84,6 +88,16 @@ public:
 			Ref<Texture> info_icon;
 			String info;
 			String data;
+			Line() {
+				width_cache = 0;
+				marked = false;
+				breakpoint = false;
+				bookmark = false;
+				hidden = false;
+				safe = false;
+				has_info = false;
+				wrap_amount_cache = 0;
+			}
 		};
 
 	private:
@@ -143,6 +157,14 @@ private:
 		int last_fit_x;
 		int line, column; ///< cursor
 		int x_ofs, line_ofs, wrap_ofs;
+		Cursor() {
+			last_fit_x = 0;
+			line = 0;
+			column = 0; ///< cursor
+			x_ofs = 0;
+			line_ofs = 0;
+			wrap_ofs = 0;
+		}
 	} cursor;
 
 	struct Selection {
@@ -167,7 +189,21 @@ private:
 		int to_line, to_column;
 
 		bool shiftclick_left;
-
+		Selection() {
+			selecting_mode = MODE_NONE;
+			selecting_line = 0;
+			selecting_column = 0;
+			selected_word_beg = 0;
+			selected_word_end = 0;
+			selected_word_origin = 0;
+			selecting_text = false;
+			active = false;
+			from_line = 0;
+			from_column = 0;
+			to_line = 0;
+			to_column = 0;
+			shiftclick_left = false;
+		}
 	} selection;
 
 	struct Cache {
@@ -219,6 +255,16 @@ private:
 		int fold_gutter_width;
 		int info_gutter_width;
 		int minimap_width;
+		Cache() {
+
+			row_height = 0;
+			line_spacing = 0;
+			line_number_w = 0;
+			breakpoint_gutter_width = 0;
+			fold_gutter_width = 0;
+			info_gutter_width = 0;
+			minimap_width = 0;
+		}
 	} cache;
 
 	Map<int, int> color_region_cache;
@@ -240,6 +286,17 @@ private:
 		uint32_t version;
 		bool chain_forward;
 		bool chain_backward;
+		TextOperation() {
+			type = TYPE_NONE;
+			from_line = 0;
+			from_column = 0;
+			to_line = 0;
+			to_column = 0;
+			prev_version = 0;
+			version = 0;
+			chain_forward = false;
+			chain_backward = false;
+		}
 	};
 
 	String ime_text;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -423,7 +423,7 @@ void SceneTree::input_event(const Ref<InputEvent> &p_event) {
 
 	input_handled = false;
 
-	Ref<InputEvent> ev = p_event;
+	const Ref<InputEvent> &ev = p_event;
 
 	MainLoop::input_event(ev);
 

--- a/scene/resources/segment_shape_2d.cpp
+++ b/scene/resources/segment_shape_2d.cpp
@@ -120,8 +120,8 @@ void RayShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Vector2> pts;
 	float tsize = 4;
 	pts.push_back(tip + Vector2(0, tsize));
-	pts.push_back(tip + Vector2(0.707 * tsize, 0));
-	pts.push_back(tip + Vector2(-0.707 * tsize, 0));
+	pts.push_back(tip + Vector2(Math_SQRT12 * tsize, 0));
+	pts.push_back(tip + Vector2(-Math_SQRT12 * tsize, 0));
 	Vector<Color> cols;
 	for (int i = 0; i < 3; i++)
 		cols.push_back(p_color);
@@ -134,7 +134,7 @@ Rect2 RayShape2D::get_rect() const {
 	Rect2 rect;
 	rect.position = Vector2();
 	rect.expand_to(Vector2(0, length));
-	rect = rect.grow(0.707 * 4);
+	rect = rect.grow(Math_SQRT12 * 4);
 	return rect;
 }
 

--- a/servers/physics/joints/cone_twist_joint_sw.cpp
+++ b/servers/physics/joints/cone_twist_joint_sw.cpp
@@ -53,7 +53,7 @@ Written by: Marcus Hennix
 
 static void plane_space(const Vector3 &n, Vector3 &p, Vector3 &q) {
 
-	if (Math::abs(n.z) > 0.707106781186547524400844362) {
+	if (Math::abs(n.z) > Math_SQRT12) {
 		// choose p in y-z plane
 		real_t a = n[1] * n[1] + n[2] * n[2];
 		real_t k = 1.0 / Math::sqrt(a);

--- a/servers/physics/joints/hinge_joint_sw.cpp
+++ b/servers/physics/joints/hinge_joint_sw.cpp
@@ -51,7 +51,7 @@ subject to the following restrictions:
 
 static void plane_space(const Vector3 &n, Vector3 &p, Vector3 &q) {
 
-	if (Math::abs(n.z) > 0.707106781186547524400844362) {
+	if (Math::abs(n.z) > Math_SQRT12) {
 		// choose p in y-z plane
 		real_t a = n[1] * n[1] + n[2] * n[2];
 		real_t k = 1.0 / Math::sqrt(a);

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -174,7 +174,7 @@ void Physics2DServerSW::_shape_col_cbk(const Vector2 &p_point_A, const Vector2 &
 		}
 		Vector2 rel_dir = (p_point_A - p_point_B).normalized();
 
-		if (cbk->valid_dir.dot(rel_dir) < 0.7071) { //sqrt(2)/2.0 - 45 degrees
+		if (cbk->valid_dir.dot(rel_dir) < Math_SQRT12) { //sqrt(2)/2.0 - 45 degrees
 			cbk->invalid_by_dir++;
 
 			/*

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2912,7 +2912,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 			tk = _get_token();
 			if (tk.type == TK_PARENTHESIS_OPEN) {
 				//a function
-				StringName name = identifier;
+				const StringName &name = identifier;
 
 				OperatorNode *func = alloc_node<OperatorNode>();
 				func->op = OP_CALL;


### PR DESCRIPTION
I added check `storage->frame.current_rt` in rasterizer_scene_gles2.cpp, because this variable was checked later in code e.g. line 3319 or 3335

Also there are also new return checked from function unzGoToNextFile

0.7071 was changed to Math_SQRT12

Changes in text_edit are caused because in Valgrind I got more than hundred reports about using uninitialised variables
```

==18375== Conditional jump or move depends on uninitialised value(s)
==18375==    at 0x2D38FBB: TextEdit::times_line_wraps(int) const (text_edit.cpp:4327)
==18375==    by 0x2D39EDE: TextEdit::cursor_set_line(int, bool, bool, int) (text_edit.cpp:4491)
==18375==    by 0x2D3B6CA: TextEdit::set_text(String) (text_edit.cpp:4801)
==18375==    by 0x27D61DC: VersionControlEditorPlugin::VersionControlEditorPlugin() (version_control_editor_plugin.cpp:534)
==18375==    by 0x27D194A: VersionControlEditorPlugin::get_singleton() (version_control_editor_plugin.cpp:83)
==18375==    by 0x217B00D: EditorNode::EditorNode() (editor_node.cpp:6074)
==18375==    by 0x14251D3: Main::start() (main.cpp:1677)
==18375==    by 0x13E4957: main (godot_x11.cpp:55)
==18375== 
==18375== Conditional jump or move depends on uninitialised value(s)
==18375==    at 0x2D3AA0B: TextEdit::get_column_x_offset_for_line(int, int) const (text_edit.cpp:4645)
==18375==    by 0x2D39937: TextEdit::cursor_set_column(int, bool) (text_edit.cpp:4449)
==18375==    by 0x2D3B6E0: TextEdit::set_text(String) (text_edit.cpp:4802)
==18375==    by 0x27D61DC: VersionControlEditorPlugin::VersionControlEditorPlugin() (version_control_editor_plugin.cpp:534)
==18375==    by 0x27D194A: VersionControlEditorPlugin::get_singleton() (version_control_editor_plugin.cpp:83)
==18375==    by 0x217B00D: EditorNode::EditorNode() (editor_node.cpp:6074)
==18375==    by 0x14251D3: Main::start() (main.cpp:1677)
==18375==    by 0x13E4957: main (godot_x11.cpp:55)
```
