### PR TITLE
Properly remove joint when a physical bone is removed from the scene

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -2161,6 +2161,9 @@ void PhysicalBone::_notification(int p_what) {
 			update_bone_id();
 			reset_to_rest_position();
 			_reset_physics_simulation_state();
+			if (!joint.is_valid() && joint_data) {
+				_reload_joint();
+			}
 			break;
 		case NOTIFICATION_EXIT_TREE:
 			if (parent_skeleton) {
@@ -2169,7 +2172,10 @@ void PhysicalBone::_notification(int p_what) {
 				}
 			}
 			parent_skeleton = NULL;
-			update_bone_id();
+			if (joint.is_valid()) {
+				PhysicsServer::get_singleton()->free(joint);
+				joint = RID();
+			}
 			break;
 		case NOTIFICATION_TRANSFORM_CHANGED:
 			if (Engine::get_singleton()->is_editor_hint()) {


### PR DESCRIPTION
It was triggering a warning in bullet followed with a crash in some cases.
```
WARNING: assert_no_constraints: A body with a joints is destroyed. Please check the implementation in order to destroy the joint before the body.
     At: modules/bullet/rigid_body_bullet.cpp:465
```

Extra change: removing `update_bone_id()` after setting `parent_skeleton = NULL` because it does nothing in this case.

Fixes #22823
Fixes #24968
Fixes #28495