### PR TITLE
Add documentation for the Listener class

### DIFF
--- a/doc/classes/Listener.xml
+++ b/doc/classes/Listener.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Listener" inherits="Spatial" category="Core" version="3.2">
 	<brief_description>
+		Overrides the location sounds are heard from.
 	</brief_description>
 	<description>
+		Once added to the scene tree and enabled using [method make_current], this node will override the location sounds are heard from. This can be used to listen from a location different from the [member Camera].
+		[b]Note:[/b] There is no 2D equivalent for this node yet.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,24 +14,29 @@
 			<return type="void">
 			</return>
 			<description>
+				Disables the listener to use the current camera's listener instead.
 			</description>
 		</method>
 		<method name="get_listener_transform" qualifiers="const">
 			<return type="Transform">
 			</return>
 			<description>
+				Returns the listener's global orthonormalized [Transform].
 			</description>
 		</method>
 		<method name="is_current" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+				Returns [code]true[/code] if the listener was made current using [method]make_current[/method), [code]false[/code] otherwise.
+				[b]Note:[/b] There may be more than one Listener marked as "current" in the scene tree, but only the one that was made current last will be used.
 			</description>
 		</method>
 		<method name="make_current">
 			<return type="void">
 			</return>
 			<description>
+				Enables the listener. This will override the current camera's listener.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
PS: I noticed there's an undocumented `current` property defined using `_set` magic. We might want to make it a full-fledged property in 4.0, and remove `make_current` and `clear_current`.