### PR TITLE
Emscripten: Re-add BINARYEN_TRAP_MODE='clamp' for fastcomp

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -131,6 +131,13 @@ def configure(env):
 
     env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
 
+    # This needs to be defined for Emscripten using 'fastcomp' (default pre-1.39.0)
+    # and undefined if using 'upstream'. And to make things simple, earlier
+    # Emscripten versions didn't include 'fastcomp' in their path, so we check
+    # against the presence of 'upstream' to conditionally add the flag.
+    if not "upstream" in em_config['EMSCRIPTEN_ROOT']:
+        env.Append(LINKFLAGS=['-s', 'BINARYEN_TRAP_MODE=\'clamp\''])
+
     # Allow increasing memory buffer size during runtime. This is efficient
     # when using WebAssembly (in comparison to asm.js) and works well for
     # us since we don't know requirements at compile-time.


### PR DESCRIPTION
The option is needed when using the 'fastcomp' backend (default before
1.39.0), and must not be defined when using 'upstream' (new default).
So we define it conditionally to support both backends.

Follow-up to #30751.

---

This must be cherry-picked in the `3.1` branch as we still build against Emscripten 1.38.31 with fastcomp there, and I cherry-picked #30751 in 3.1.2, thus introducing issues (it builds fine, but some projects cause errors, for example if they include `int(log(0))` in a script).
Thanks @ChronoDK for helping me debug this and narrow down what can reproduce the error.