### PR TITLE
Fix severe performance drop while deflating polylines

### DIFF
--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -1158,7 +1158,7 @@ Vector<Vector<Point2> > Geometry::_polypath_offset(const Vector<Point2> &p_polyp
 		case END_SQUARE: et = etOpenSquare; break;
 		case END_ROUND: et = etOpenRound; break;
 	}
-	ClipperOffset co;
+	ClipperOffset co(2.0, 0.25 * SCALE_FACTOR); // Defaults from ClipperOffset.
 	Path path;
 
 	// Need to scale points (Clipper's requirement for robust computation).


### PR DESCRIPTION
The fix is extracted from #29758.

Underscaled arc tolerance produced very small values so that changes to this parameter were negligible when scaled internally, hence significant performance drop (lots of intermediate points inserted in an arc). Now the performance is mostly the same compared to other types of offsetting (SQUARE, MITER).

The performance drop might not be as noticible when using the methods per se but when drawing with `draw_polygon` or similar:

```gdscript
var polygons = Geometry.offset_polyline_2d(points, 20.0, Geometry.JOIN_ROUND, Geometry.END_ROUND)
for poly in polygons:
	draw_colored_polygon(poly, Color(1, 1, 0))
```

The use case is when I attempted to draw a fat bezier curve every frame (or whenever points are moved):

JohnMeadow1/GodotGeometryElements#2

![godot_bezier_grow](https://user-images.githubusercontent.com/17108460/70056454-2d99c380-15e4-11ea-8758-e143f30e9672.png)


