### PR TITLE
Properly orphan polygon index buffer after binding

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -327,9 +327,8 @@ void RasterizerCanvasGLES3::_draw_polygon(const int *p_indices, int p_index_coun
 	glBindBuffer(GL_ARRAY_BUFFER, data.polygon_buffer);
 
 #ifndef GLES_OVER_GL
-	// Orphan the buffers to avoid CPU/GPU sync points caused by glBufferSubData
+	// Orphan the buffer to avoid CPU/GPU sync points caused by glBufferSubData
 	glBufferData(GL_ARRAY_BUFFER, data.polygon_buffer_size, NULL, GL_DYNAMIC_DRAW);
-	glBufferData(GL_ELEMENT_ARRAY_BUFFER, data.polygon_index_buffer_size, NULL, GL_DYNAMIC_DRAW);
 #endif
 
 	uint32_t buffer_ofs = 0;
@@ -402,6 +401,10 @@ void RasterizerCanvasGLES3::_draw_polygon(const int *p_indices, int p_index_coun
 
 	//bind the indices buffer.
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, data.polygon_index_buffer);
+#ifndef GLES_OVER_GL
+	// Orphan the buffer to avoid CPU/GPU sync points caused by glBufferSubData
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, data.polygon_index_buffer_size, NULL, GL_DYNAMIC_DRAW);
+#endif
 	glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, sizeof(int) * p_index_count, p_indices);
 
 	//draw the triangles.
@@ -424,9 +427,8 @@ void RasterizerCanvasGLES3::_draw_generic(GLuint p_primitive, int p_vertex_count
 	glBindBuffer(GL_ARRAY_BUFFER, data.polygon_buffer);
 
 #ifndef GLES_OVER_GL
-	// Orphan the buffers to avoid CPU/GPU sync points caused by glBufferSubData
+	// Orphan the buffer to avoid CPU/GPU sync points caused by glBufferSubData
 	glBufferData(GL_ARRAY_BUFFER, data.polygon_buffer_size, NULL, GL_DYNAMIC_DRAW);
-	glBufferData(GL_ELEMENT_ARRAY_BUFFER, data.polygon_index_buffer_size, NULL, GL_DYNAMIC_DRAW);
 #endif
 
 	uint32_t buffer_ofs = 0;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/34065

Implements @oeleo1's patch from this comment https://github.com/godotengine/godot/issues/34065#issuecomment-561029328

See comment for explanation.