### PR TITLE
Fixes wrong position when adding node in VS editor

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3464,6 +3464,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		ofs = ofs.snapped(Vector2(snap, snap));
 	}
 	ofs /= EDSCALE;
+	ofs /= graph->get_zoom();
 
 	Set<int> vn;
 


### PR DESCRIPTION
When adding a node in the visual script editor while zoomed in, the position of the newly added node would be wrong.

Related issue: #33935