### PR TITLE
Bugfix: Fix Anim Tree blending inconsistency

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -854,7 +854,6 @@ void AnimationTree::_process_graph(float p_delta) {
 								t->process_pass = process_pass;
 								t->loc = Vector3();
 								t->rot = Quat();
-								t->rot_blend_accum = 0;
 								t->scale = Vector3(1, 1, 1);
 							}
 
@@ -911,26 +910,18 @@ void AnimationTree::_process_graph(float p_delta) {
 
 							if (t->process_pass != process_pass) {
 								t->process_pass = process_pass;
-								t->loc = loc;
-								t->rot = rot;
-								t->rot_blend_accum = 0;
-								t->scale = scale;
+								t->loc = Vector3();
+								t->rot = Quat();
+								t->scale = Vector3();
 							}
 
 							if (err != OK) {
 								continue;
 							}
 
-							t->loc = t->loc.lerp(loc, blend);
-							if (t->rot_blend_accum == 0) {
-								t->rot = rot;
-								t->rot_blend_accum = blend;
-							} else {
-								float rot_total = t->rot_blend_accum + blend;
-								t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
-								t->rot_blend_accum = rot_total;
-							}
-							t->scale = t->scale.lerp(scale, blend);
+							t->loc += loc * blend;
+							t->rot = (t->rot * Quat().slerp(rot, blend)).normalized();
+							t->scale += scale * blend;
 						}
 
 					} break;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -193,7 +193,6 @@ private:
 		int bone_idx;
 		Vector3 loc;
 		Quat rot;
-		float rot_blend_accum;
 		Vector3 scale;
 
 		TrackCacheTransform() {


### PR DESCRIPTION
Reduz had done some work on this to make it a "nicer" blend, but the logic is non-linear and non-deterministic.

In the old blending method, there is a rot_blend_accum that gets increased for each blend, and then the blend percentage is divided over the maximum.

This leads to non-linear scaling that is non-deterministic, since the order of the blends makes the blend weights different.

IE:
Blend 1 : 0.4 percent
Blend 2: 0.5 percent
Blend 3: 0.1 percent
-> (0.4/0.4 * rotation) * (0.5 / 0.9 * rotation) * ( 0.1 / 1.0 * rotation)

If you change the order:
Blend 3: 0.1
Blend 1: 0.4
Blend 2: 0.5
-> (0.1/0.1 * rotation) * (0.4 / 0.5 * rotation) * (0.5 / 1.0 * rotation)
...Which is inconsistent for the reasons above

This change also causes the triangles in blend spaces to jump dramatically between two zones, as you would go from blending triangle A into triangle B (where Blend 2 & 3 are the common edge between the triangles):
Blend 1: 0.1
Blend 2: 0.5
Blend 3: 0.4
->
Blend 2: 0.5
Blend 3: 0.4
Blend 4: 0.1

Strangely enough, the root motion code above it actually calculates all of the transforms correctly.