### PR TITLE
iOS: Disable armv7 as target arch by default

### DIFF
--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -219,7 +219,7 @@ void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> 
 
 Vector<EditorExportPlatformIOS::ExportArchitecture> EditorExportPlatformIOS::_get_supported_architectures() {
 	Vector<ExportArchitecture> archs;
-	archs.push_back(ExportArchitecture("armv7", true));
+	archs.push_back(ExportArchitecture("armv7", false)); // Disabled by default, not included in official templates.
 	archs.push_back(ExportArchitecture("arm64", true));
 	return archs;
 }


### PR DESCRIPTION
We no longer compile for armv7 and x86 in the official export templates,
as those architectures are no longer relevant for iOS.

If users really want to support armv7 (used on devices from before
September 2013, e.g. iPhone 5), they can still build their own templates
and toggle the option.

We might remove the option altogether in a later release to avoid the
confusion for users that might tick the checkbox without having compiled
their own templates.

Fixes #34135.