### PR TITLE
Remove extra spaces from parenthesis in *FileDialog's filter menu

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -916,16 +916,16 @@ void EditorFileDialog::update_filters() {
 		if (max_filters < filters.size())
 			all_filters += ", ...";
 
-		filter->add_item(TTR("All Recognized") + " ( " + all_filters + " )");
+		filter->add_item(TTR("All Recognized") + " (" + all_filters + ")");
 	}
 	for (int i = 0; i < filters.size(); i++) {
 
 		String flt = filters[i].get_slice(";", 0).strip_edges();
 		String desc = filters[i].get_slice(";", 1).strip_edges();
 		if (desc.length())
-			filter->add_item(desc + " ( " + flt + " )");
+			filter->add_item(desc + " (" + flt + ")");
 		else
-			filter->add_item("( " + flt + " )");
+			filter->add_item("(" + flt + ")");
 	}
 
 	filter->add_item(TTR("All Files (*)"));

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -567,16 +567,16 @@ void FileDialog::update_filters() {
 		if (max_filters < filters.size())
 			all_filters += ", ...";
 
-		filter->add_item(RTR("All Recognized") + " ( " + all_filters + " )");
+		filter->add_item(RTR("All Recognized") + " (" + all_filters + ")");
 	}
 	for (int i = 0; i < filters.size(); i++) {
 
 		String flt = filters[i].get_slice(";", 0).strip_edges();
 		String desc = filters[i].get_slice(";", 1).strip_edges();
 		if (desc.length())
-			filter->add_item(String(tr(desc)) + " ( " + flt + " )");
+			filter->add_item(String(tr(desc)) + " (" + flt + ")");
 		else
-			filter->add_item("( " + flt + " )");
+			filter->add_item("(" + flt + ")");
 	}
 
 	filter->add_item(RTR("All Files (*)"));


### PR DESCRIPTION
This a completely cosmetic change, not breaking compatibility.