### PR TITLE
Fix missing null checks in Mono Binding of GD

### DIFF
--- a/modules/mono/glue/Managed/Files/GD.cs
+++ b/modules/mono/glue/Managed/Files/GD.cs
@@ -93,22 +93,22 @@ namespace Godot
 
         public static void PrintErr(params object[] what)
         {
-            godot_icall_GD_printerr(Array.ConvertAll(what, x => x.ToString()));
+            godot_icall_GD_printerr(Array.ConvertAll(what, x => x?.ToString()));
         }
 
         public static void PrintRaw(params object[] what)
         {
-            godot_icall_GD_printraw(Array.ConvertAll(what, x => x.ToString()));
+            godot_icall_GD_printraw(Array.ConvertAll(what, x => x?.ToString()));
         }
 
         public static void PrintS(params object[] what)
         {
-            godot_icall_GD_prints(Array.ConvertAll(what, x => x.ToString()));
+            godot_icall_GD_prints(Array.ConvertAll(what, x => x?.ToString()));
         }
 
         public static void PrintT(params object[] what)
         {
-            godot_icall_GD_printt(Array.ConvertAll(what, x => x.ToString()));
+            godot_icall_GD_printt(Array.ConvertAll(what, x => x?.ToString()));
         }
 
         public static float Randf()


### PR DESCRIPTION
The print methods of mono binding was missing null checks for the params.
Fixes #34136 