### PR TITLE
Fixes prompt closes the wrong scene on quit

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2049,14 +2049,17 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER:
 		case FILE_CLOSE: {
 
-			if (!p_confirmed && (unsaved_cache || p_option == FILE_CLOSE_ALL_AND_QUIT || p_option == FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER)) {
+			if (!p_confirmed) {
 				tab_closing = p_option == FILE_CLOSE ? editor_data.get_edited_scene() : _next_unsaved_scene(false);
-				String scene_filename = editor_data.get_edited_scene_root(tab_closing)->get_filename();
-				save_confirmation->get_ok()->set_text(TTR("Save & Close"));
-				save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), scene_filename != "" ? scene_filename : "unsaved scene"));
-				save_confirmation->popup_centered_minsize();
-				break;
-			} else {
+
+				if (unsaved_cache || p_option == FILE_CLOSE_ALL_AND_QUIT || p_option == FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER) {
+					String scene_filename = editor_data.get_edited_scene_root(tab_closing)->get_filename();
+					save_confirmation->get_ok()->set_text(TTR("Save & Close"));
+					save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), scene_filename != "" ? scene_filename : "unsaved scene"));
+					save_confirmation->popup_centered_minsize();
+					break;
+				}
+			} else if (p_option == FILE_CLOSE) {
 				tab_closing = editor_data.get_edited_scene();
 			}
 			if (!editor_data.get_edited_scene_root(tab_closing)) {


### PR DESCRIPTION
When quitting the editor with unsaved changes present, there will be a save prompt for each unsaved scene. If confirmed, it's always the active tab that's closed, not the prompted one.

To reproduce:
1. Open a project with two saved scenes (it's hard to tell the difference between two unsaved scenes, as they are all named 'unsaved scene');
2. Open the two scenes, and make random changes to them;
3. DON'T save the changes;
4. Now you have two tabs open (scene A and B from left to right), select the second one (scene B);
5. Try to close the editor (menu Scene -> Quit or Project -> Quit to Project List);
6. You'll be prompted to save scene A, click Save & Exit;
7. Scene B got saved and closed instead of scene A.