### PR TITLE
Make some arguments in PCKPacker methods optional

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -55,9 +55,9 @@ static void _pad(FileAccess *p_file, int p_bytes) {
 
 void PCKPacker::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("pck_start", "pck_name", "alignment"), &PCKPacker::pck_start);
+	ClassDB::bind_method(D_METHOD("pck_start", "pck_name", "alignment"), &PCKPacker::pck_start, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("add_file", "pck_path", "source_path"), &PCKPacker::add_file);
-	ClassDB::bind_method(D_METHOD("flush", "verbose"), &PCKPacker::flush);
+	ClassDB::bind_method(D_METHOD("flush", "verbose"), &PCKPacker::flush, DEFVAL(false));
 };
 
 Error PCKPacker::pck_start(const String &p_file, int p_alignment) {

--- a/core/io/pck_packer.h
+++ b/core/io/pck_packer.h
@@ -54,7 +54,7 @@ class PCKPacker : public Reference {
 	Vector<File> files;
 
 public:
-	Error pck_start(const String &p_file, int p_alignment);
+	Error pck_start(const String &p_file, int p_alignment = 0);
 	Error add_file(const String &p_file, const String &p_src);
 	Error flush(bool p_verbose = false);
 

--- a/doc/classes/PCKPacker.xml
+++ b/doc/classes/PCKPacker.xml
@@ -6,9 +6,9 @@
 		The [PCKPacker] is used to create packages in application runtime.
 		[codeblock]
 		var packer = PCKPacker.new()
-		packer.pck_start("test.pck", 0)
+		packer.pck_start("test.pck")
 		packer.add_file("res://text.txt", "text.txt")
-		packer.flush(false)
+		packer.flush()
 		[/codeblock]
 		The above [PCKPacker] creates package [b]test.pck[/b], then adds a file named [b]text.txt[/b] in the root of the package.
 	</description>
@@ -29,7 +29,7 @@
 		<method name="flush">
 			<return type="int" enum="Error">
 			</return>
-			<argument index="0" name="verbose" type="bool">
+			<argument index="0" name="verbose" type="bool" default="false">
 			</argument>
 			<description>
 			</description>
@@ -39,7 +39,7 @@
 			</return>
 			<argument index="0" name="pck_name" type="String">
 			</argument>
-			<argument index="1" name="alignment" type="int">
+			<argument index="1" name="alignment" type="int" default="0">
 			</argument>
 			<description>
 			</description>


### PR DESCRIPTION
Those arguments aren't required for most common use cases, so making them optional should help with code readability.

See also #34163.