### PR TITLE
[3.0] [Mono] Backport fix to Quat Equals

### DIFF
--- a/modules/mono/glue/cs_files/Quat.cs
+++ b/modules/mono/glue/cs_files/Quat.cs
@@ -192,7 +192,7 @@ namespace Godot
             return new Vector3(q.x, q.y, q.z);
         }
 
-        // Constructors 
+        // Constructors
         public Quat(real_t x, real_t y, real_t z, real_t w)
         {
             this.x = x;
@@ -306,9 +306,9 @@ namespace Godot
 
         public override bool Equals(object obj)
         {
-            if (obj is Vector2)
+            if (obj is Quat)
             {
-                return Equals((Vector2)obj);
+                return Equals((Quat)obj);
             }
 
             return false;


### PR DESCRIPTION
Not that I actually recommend any C# users use 3.0, but I realized this fix wasn't backported and it probably should be. It's a simple enough fix. #26023 @akien-mga 

Co-authored-by: RomanAkberov <r.k.akberov@gmail.com>