### PR TITLE
Cyclic BlendSpaces [1D/2D] for Animation

### DIFF
--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -32,6 +32,7 @@
 
 #include "core/os/keyboard.h"
 #include "editor/editor_scale.h"
+#include "scene/animation/animation_blend_space_cyclic_1d.h"
 #include "scene/animation/animation_blend_tree.h"
 
 StringName AnimationNodeBlendSpace1DEditor::get_blend_position_path() const {
@@ -57,7 +58,14 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 		animations_to_add.clear();
 
 		List<StringName> classes;
-		ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
+
+		// BlendSpaceCyclic1d can only use pure animation nodes (for now)
+		if (Object::cast_to<AnimationNodeBlendSpaceCyclic1D>(blend_space.ptr())) {
+			ClassDB::get_inheriters_from_class("AnimationNodeAnimation", &classes);
+		} else {
+			ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
+		}
+
 		classes.sort_custom<StringName::AlphCompare>();
 
 		menu->add_submenu_item(TTR("Add Animation"), "animations");

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -36,6 +36,7 @@
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
 #include "editor/editor_scale.h"
+#include "scene/animation/animation_blend_space_cyclic_2d.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
 #include "scene/gui/menu_button.h"
@@ -84,9 +85,16 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 		animations_menu->clear();
 		animations_to_add.clear();
 		List<StringName> classes;
+
+		// BlendSpaceCyclic2d can only use pure animation nodes (for now)
+		if (Object::cast_to<AnimationNodeBlendSpaceCyclic2D>(blend_space.ptr())) {
+			ClassDB::get_inheriters_from_class("AnimationNodeAnimation", &classes);
+		} else {
+			ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
+		}
+
 		classes.sort_custom<StringName::AlphCompare>();
 
-		ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
 		menu->add_submenu_item(TTR("Add Animation"), "animations");
 
 		AnimationTree *gp = AnimationTreeEditor::get_singleton()->get_tree();

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -912,6 +912,8 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_options.push_back(AddOption("BlendTree", "AnimationNodeBlendTree"));
 	add_options.push_back(AddOption("BlendSpace1D", "AnimationNodeBlendSpace1D"));
 	add_options.push_back(AddOption("BlendSpace2D", "AnimationNodeBlendSpace2D"));
+	add_options.push_back(AddOption("BlendSpaceCyclic1D", "AnimationNodeBlendSpaceCyclic1D"));
+	add_options.push_back(AddOption("BlendSpaceCyclic2D", "AnimationNodeBlendSpaceCyclic2D"));
 	add_options.push_back(AddOption("StateMachine", "AnimationNodeStateMachine"));
 	_update_options_menu();
 

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -87,6 +87,16 @@ protected:
 
 	void _tree_changed();
 
+	struct TriangleWeights {
+		int triangle = -1;
+		float weights[3] = { 0 };
+		int points[3] = { -1, -1, -1 };
+	};
+
+	TriangleWeights get_triangle_blends(const Vector2 &p_blend_pos);
+
+	void clamp_points(const Vector2 &min_space, const Vector2 &max_space);
+
 protected:
 	virtual void _validate_property(PropertyInfo &property) const override;
 	static void _bind_methods();
@@ -97,9 +107,10 @@ public:
 
 	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
 
-	void add_blend_point(const Ref<AnimationRootNode> &p_node, const Vector2 &p_position, int p_at_index = -1);
+	virtual void add_blend_point(const Ref<AnimationRootNode> &p_node, const Vector2 &p_position, int p_at_index = -1);
+	virtual void set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node);
+
 	void set_blend_point_position(int p_point, const Vector2 &p_position);
-	void set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node);
 	Vector2 get_blend_point_position(int p_point) const;
 	Ref<AnimationRootNode> get_blend_point_node(int p_point) const;
 	void remove_blend_point(int p_point);

--- a/scene/animation/animation_blend_space_cyclic_1d.cpp
+++ b/scene/animation/animation_blend_space_cyclic_1d.cpp
@@ -5,8 +5,8 @@
 /*                           GODOT ENGINE                                */
 /*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/scene/animation/animation_blend_space_cyclic_1d.cpp
+++ b/scene/animation/animation_blend_space_cyclic_1d.cpp
@@ -1,0 +1,133 @@
+/*************************************************************************/
+/*  animation_blend_space_cyclic_1d.cpp                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "animation_blend_space_cyclic_1d.h"
+#include "scene/animation/animation_blend_tree.h"
+
+/**
+	@author Marios Staikopoulos <marios@staik.net>
+*/
+
+const Ref<Animation> AnimationNodeBlendSpaceCyclic1D::get_animation_for_point(const int p_point) {
+	AnimationPlayer *ap = state->player;
+	ERR_FAIL_COND_V(!ap, nullptr);
+
+	AnimationNodeAnimation *anim_node = Object::cast_to<AnimationNodeAnimation>(blend_points[p_point].node.ptr());
+
+	const StringName anim_name = anim_node->get_animation();
+	ERR_FAIL_COND_V(!ap->has_animation(anim_name), nullptr);
+
+	return ap->get_animation(anim_name);
+}
+
+void AnimationNodeBlendSpaceCyclic1D::get_parameter_list(List<PropertyInfo> *r_list) const {
+	r_list->push_back(PropertyInfo(Variant::FLOAT, cycle, PROPERTY_HINT_NONE, "", 0));
+
+	AnimationNodeBlendSpace1D::get_parameter_list(r_list);
+}
+
+Variant AnimationNodeBlendSpaceCyclic1D::get_parameter_default_value(const StringName &p_parameter) const {
+	if (p_parameter == cycle) {
+		return 0.0;
+	}
+
+	return AnimationNodeBlendSpace1D::get_parameter_default_value(p_parameter);
+}
+
+void AnimationNodeBlendSpaceCyclic1D::add_blend_point(const Ref<AnimationRootNode> &p_node, float p_position, int p_at_index) {
+	ERR_FAIL_COND(Object::cast_to<AnimationNodeAnimation>(p_node.ptr()) == nullptr);
+	AnimationNodeBlendSpace1D::add_blend_point(p_node, p_position, p_at_index);
+}
+
+void AnimationNodeBlendSpaceCyclic1D::set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node) {
+	ERR_FAIL_COND(Object::cast_to<AnimationNodeAnimation>(p_node.ptr()) == nullptr);
+	AnimationNodeBlendSpace1D::set_blend_point_node(p_point, p_node);
+}
+
+float AnimationNodeBlendSpaceCyclic1D::process(float p_time, bool p_seek) {
+	if (blend_points_used == 0) {
+		return 0.0;
+	}
+
+	float cycle = get_parameter(this->cycle);
+
+	if (blend_points_used == 1) {
+		Ref<Animation> anim = get_animation_for_point(0);
+		const float length = anim->get_length();
+
+		if (p_seek) {
+			cycle = Math::fposmod(p_time, length) / length;
+		} else {
+			cycle = Math::fposmod(cycle * length + p_time, length) / length;
+		}
+
+		// Only one point available, just play that animation
+		blend_node(blend_points[0].name, blend_points[0].node, cycle * length, true, 1.0, FILTER_IGNORE, false);
+	}
+
+	// We have points to blend!
+	else {
+		const float blend_pos = get_parameter(blend_position);
+
+		const BlendWeights b_values = get_blend_values(blend_pos);
+
+		float total_runtime = 0;
+		float runtimes[2] = { 0 };
+
+		for (int i = 0; i < 2; ++i) {
+			// Having a weight means the animation definitely exists...
+			if (b_values.weights[i] > 0.0) {
+				Ref<Animation> anim = get_animation_for_point(b_values.points[i]);
+				runtimes[i] = anim->get_length();
+				total_runtime += b_values.weights[i] * runtimes[i];
+			}
+		}
+
+		if (p_seek) {
+			cycle = Math::fposmod(p_time, total_runtime) / total_runtime;
+		} else {
+			cycle = Math::fposmod(cycle * total_runtime + p_time, total_runtime) / total_runtime;
+		}
+
+		for (int i = 0; i < 2; i++) {
+			if (b_values.weights[i] > 0.0) {
+				const BlendPoint &blend_point = blend_points[b_values.points[i]];
+				blend_node(blend_point.name, blend_point.node, cycle * runtimes[i], true, b_values.weights[i], FILTER_IGNORE, false);
+			}
+		}
+	}
+
+	set_parameter(this->cycle, cycle);
+	return 1 - cycle;
+}
+
+String AnimationNodeBlendSpaceCyclic1D::get_caption() const {
+	return "BlendSpaceCyclic1D";
+}

--- a/scene/animation/animation_blend_space_cyclic_1d.h
+++ b/scene/animation/animation_blend_space_cyclic_1d.h
@@ -5,8 +5,8 @@
 /*                           GODOT ENGINE                                */
 /*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/scene/animation/animation_blend_space_cyclic_1d.h
+++ b/scene/animation/animation_blend_space_cyclic_1d.h
@@ -1,12 +1,12 @@
 /*************************************************************************/
-/*  animation_blend_space_1d.h                                           */
+/*  animation_blend_space_cyclic_1d.h                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
 /*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */
@@ -28,87 +28,36 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef ANIMATION_BLEND_SPACE_1D_H
-#define ANIMATION_BLEND_SPACE_1D_H
+#ifndef ANIMATION_BLEND_SPACE_CYCLIC_1D_H
+#define ANIMATION_BLEND_SPACE_CYCLIC_1D_H
 
-#include "scene/animation/animation_tree.h"
+#include "scene/animation/animation_blend_space_1d.h"
 
-class AnimationNodeBlendSpace1D : public AnimationRootNode {
-	GDCLASS(AnimationNodeBlendSpace1D, AnimationRootNode);
+/**
+	@author Marios Staikopoulos <marios@staik.net>
+*/
 
-protected:
-	enum {
-		MAX_BLEND_POINTS = 64
-	};
+class AnimationNodeBlendSpaceCyclic1D : public AnimationNodeBlendSpace1D {
+	GDCLASS(AnimationNodeBlendSpaceCyclic1D, AnimationNodeBlendSpace1D);
 
-	struct BlendPoint {
-		StringName name;
-		Ref<AnimationRootNode> node;
-		float position;
-	};
-
-	BlendPoint blend_points[MAX_BLEND_POINTS];
-	int blend_points_used;
-
-	float max_space;
-	float min_space;
-
-	float snap;
-
-	String value_label;
-
-	void _add_blend_point(int p_index, const Ref<AnimationRootNode> &p_node);
-
-	void _tree_changed();
-
-	StringName blend_position;
-
-	struct BlendWeights {
-		int points[2] = { -1, -1 };
-		float weights[2] = { 0 };
-	};
-
-	BlendWeights get_blend_values(const float p_blend_pos) const;
+private:
+	const Ref<Animation> get_animation_for_point(const int p_point);
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
-	static void _bind_methods();
+	StringName cycle;
 
 public:
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
-
-	virtual void add_blend_point(const Ref<AnimationRootNode> &p_node, float p_position, int p_at_index = -1);
-	virtual void set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node);
-
-	void set_blend_point_position(int p_point, float p_position);
-
-	float get_blend_point_position(int p_point) const;
-	Ref<AnimationRootNode> get_blend_point_node(int p_point) const;
-	void remove_blend_point(int p_point);
-	int get_blend_point_count() const;
-
-	void set_min_space(float p_min);
-	float get_min_space() const;
-
-	void set_max_space(float p_max);
-	float get_max_space() const;
-
-	void set_snap(float p_snap);
-	float get_snap() const;
-
-	void set_value_label(const String &p_label);
-	String get_value_label() const;
+	virtual void add_blend_point(const Ref<AnimationRootNode> &p_node, float p_position, int p_at_index = -1) override;
+	virtual void set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node) override;
 
 	virtual float process(float p_time, bool p_seek) override;
 	virtual String get_caption() const override;
 
-	Ref<AnimationNode> get_child_by_name(const StringName &p_name) override;
-
-	AnimationNodeBlendSpace1D();
-	~AnimationNodeBlendSpace1D();
+	AnimationNodeBlendSpaceCyclic1D(){};
+	~AnimationNodeBlendSpaceCyclic1D(){};
 };
 
-#endif // ANIMATION_BLEND_SPACE_1D_H
+#endif // ANIMATION_BLEND_SPACE_CYCLIC_1D_H

--- a/scene/animation/animation_blend_space_cyclic_2d.cpp
+++ b/scene/animation/animation_blend_space_cyclic_2d.cpp
@@ -5,8 +5,8 @@
 /*                           GODOT ENGINE                                */
 /*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/scene/animation/animation_blend_space_cyclic_2d.cpp
+++ b/scene/animation/animation_blend_space_cyclic_2d.cpp
@@ -1,0 +1,149 @@
+/*************************************************************************/
+/*  animation_blend_space_cyclic_2d.cpp                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "animation_blend_space_cyclic_2d.h"
+#include "scene/animation/animation_blend_tree.h"
+
+/**
+	@author Marios Staikopoulos <marios@staik.net>
+*/
+
+const Ref<Animation> AnimationNodeBlendSpaceCyclic2D::get_animation_for_point(const int p_point) {
+	AnimationPlayer *ap = state->player;
+	ERR_FAIL_COND_V(!ap, nullptr);
+
+	AnimationNodeAnimation *anim_node = Object::cast_to<AnimationNodeAnimation>(blend_points[p_point].node.ptr());
+
+	const StringName anim_name = anim_node->get_animation();
+	ERR_FAIL_COND_V(!ap->has_animation(anim_name), nullptr);
+
+	return ap->get_animation(anim_name);
+}
+
+void AnimationNodeBlendSpaceCyclic2D::get_parameter_list(List<PropertyInfo> *r_list) const {
+	r_list->push_back(PropertyInfo(Variant::FLOAT, cycle, PROPERTY_HINT_NONE, "", 0));
+
+	AnimationNodeBlendSpace2D::get_parameter_list(r_list);
+}
+
+Variant AnimationNodeBlendSpaceCyclic2D::get_parameter_default_value(const StringName &p_parameter) const {
+	if (p_parameter == cycle) {
+		return 0.0;
+	}
+
+	return AnimationNodeBlendSpace2D::get_parameter_default_value(p_parameter);
+}
+
+void AnimationNodeBlendSpaceCyclic2D::add_blend_point(const Ref<AnimationRootNode> &p_node, const Vector2 &p_position, int p_at_index) {
+	ERR_FAIL_COND(Object::cast_to<AnimationNodeAnimation>(p_node.ptr()) == nullptr);
+	AnimationNodeBlendSpace2D::add_blend_point(p_node, p_position, p_at_index);
+}
+
+void AnimationNodeBlendSpaceCyclic2D::set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node) {
+	ERR_FAIL_COND(Object::cast_to<AnimationNodeAnimation>(p_node.ptr()) == nullptr);
+	AnimationNodeBlendSpace2D::set_blend_point_node(p_point, p_node);
+}
+
+float AnimationNodeBlendSpaceCyclic2D::process(float p_time, bool p_seek) {
+	_update_triangles();
+
+	Vector2 blend_pos = get_parameter(blend_position);
+
+	float cycle = get_parameter(this->cycle);
+	float length_internal = get_parameter(this->length_internal);
+	int closest = get_parameter(this->closest);
+
+	if (blend_mode == BLEND_MODE_INTERPOLATED) {
+		if (triangles.size() == 0)
+			return 0;
+
+		TriangleWeights t_weights = get_triangle_blends(blend_pos);
+
+		length_internal = 0;
+		float runtimes[3] = { 0 };
+
+		for (int i = 0; i < 3; ++i) {
+			Ref<Animation> anim = get_animation_for_point(t_weights.points[i]);
+			runtimes[i] = anim->get_length();
+			length_internal += t_weights.weights[i] * runtimes[i];
+		}
+
+		if (p_seek) {
+			cycle = Math::fposmod(p_time, length_internal) / length_internal;
+		} else {
+			cycle = Math::fposmod(cycle * length_internal + p_time, length_internal) / length_internal;
+		}
+
+		float largest_weight = -1;
+		for (int i = 0; i < 3; ++i) {
+			const BlendPoint &blend_point = blend_points[t_weights.points[i]];
+			blend_node(blend_point.name, blend_point.node, cycle * runtimes[i], true, t_weights.weights[i], FILTER_IGNORE, false);
+
+			if (t_weights.weights[i] > largest_weight) {
+				largest_weight = t_weights.weights[i];
+				closest = t_weights.points[i];
+			}
+		}
+	}
+
+	// In a cyclic BlendSpace, Discrete and Discrete-Carry are the same thing
+	else {
+		float closest_dist = 1e20;
+
+		for (int i = 0; i < blend_points_used; i++) {
+			float d = blend_points[i].position.distance_squared_to(blend_pos);
+			if (d < closest_dist) {
+				closest = i;
+				closest_dist = d;
+			}
+		}
+
+		Ref<Animation> anim = get_animation_for_point(closest);
+		length_internal = anim->get_length();
+
+		if (p_seek) {
+			cycle = Math::fposmod(p_time, length_internal) / length_internal;
+		} else {
+			cycle = Math::fposmod(cycle * length_internal + p_time, length_internal) / length_internal;
+		}
+
+		blend_node(blend_points[closest].name, blend_points[closest].node, cycle * length_internal, true, 1.0, FILTER_IGNORE, false);
+	}
+
+	set_parameter(this->cycle, cycle);
+	set_parameter(this->closest, closest);
+	set_parameter(this->length_internal, length_internal);
+
+	return 1 - cycle;
+}
+
+String AnimationNodeBlendSpaceCyclic2D::get_caption() const {
+	return "BlendSpaceCyclic2D";
+}

--- a/scene/animation/animation_blend_space_cyclic_2d.h
+++ b/scene/animation/animation_blend_space_cyclic_2d.h
@@ -5,8 +5,8 @@
 /*                           GODOT ENGINE                                */
 /*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */

--- a/scene/animation/animation_blend_space_cyclic_2d.h
+++ b/scene/animation/animation_blend_space_cyclic_2d.h
@@ -1,12 +1,12 @@
 /*************************************************************************/
-/*  animation_blend_space_1d.h                                           */
+/*  animation_blend_space_cyclic_2d.h                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
 /*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
 /*                                                                       */
 /* Permission is hereby granted, free of charge, to any person obtaining */
 /* a copy of this software and associated documentation files (the       */
@@ -28,87 +28,36 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef ANIMATION_BLEND_SPACE_1D_H
-#define ANIMATION_BLEND_SPACE_1D_H
+#ifndef ANIMATION_BLEND_SPACE_CYCLIC_2D_H
+#define ANIMATION_BLEND_SPACE_CYCLIC_2D_H
 
-#include "scene/animation/animation_tree.h"
+#include "scene/animation/animation_blend_space_2d.h"
 
-class AnimationNodeBlendSpace1D : public AnimationRootNode {
-	GDCLASS(AnimationNodeBlendSpace1D, AnimationRootNode);
+/**
+	@author Marios Staikopoulos <marios@staik.net>
+*/
 
-protected:
-	enum {
-		MAX_BLEND_POINTS = 64
-	};
+class AnimationNodeBlendSpaceCyclic2D : public AnimationNodeBlendSpace2D {
+	GDCLASS(AnimationNodeBlendSpaceCyclic2D, AnimationNodeBlendSpace2D);
 
-	struct BlendPoint {
-		StringName name;
-		Ref<AnimationRootNode> node;
-		float position;
-	};
-
-	BlendPoint blend_points[MAX_BLEND_POINTS];
-	int blend_points_used;
-
-	float max_space;
-	float min_space;
-
-	float snap;
-
-	String value_label;
-
-	void _add_blend_point(int p_index, const Ref<AnimationRootNode> &p_node);
-
-	void _tree_changed();
-
-	StringName blend_position;
-
-	struct BlendWeights {
-		int points[2] = { -1, -1 };
-		float weights[2] = { 0 };
-	};
-
-	BlendWeights get_blend_values(const float p_blend_pos) const;
+private:
+	const Ref<Animation> get_animation_for_point(const int p_point);
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
-	static void _bind_methods();
+	StringName cycle;
 
 public:
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
-
-	virtual void add_blend_point(const Ref<AnimationRootNode> &p_node, float p_position, int p_at_index = -1);
-	virtual void set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node);
-
-	void set_blend_point_position(int p_point, float p_position);
-
-	float get_blend_point_position(int p_point) const;
-	Ref<AnimationRootNode> get_blend_point_node(int p_point) const;
-	void remove_blend_point(int p_point);
-	int get_blend_point_count() const;
-
-	void set_min_space(float p_min);
-	float get_min_space() const;
-
-	void set_max_space(float p_max);
-	float get_max_space() const;
-
-	void set_snap(float p_snap);
-	float get_snap() const;
-
-	void set_value_label(const String &p_label);
-	String get_value_label() const;
+	virtual void add_blend_point(const Ref<AnimationRootNode> &p_node, const Vector2 &p_position, int p_at_index = -1) override;
+	virtual void set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node) override;
 
 	virtual float process(float p_time, bool p_seek) override;
 	virtual String get_caption() const override;
 
-	Ref<AnimationNode> get_child_by_name(const StringName &p_name) override;
-
-	AnimationNodeBlendSpace1D();
-	~AnimationNodeBlendSpace1D();
+	AnimationNodeBlendSpaceCyclic2D() {}
+	~AnimationNodeBlendSpaceCyclic2D() {}
 };
 
-#endif // ANIMATION_BLEND_SPACE_1D_H
+#endif // ANIMATION_BLEND_SPACE_CYCLIC_2D_H

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -855,7 +855,6 @@ void AnimationTree::_process_graph(float p_delta) {
 								t->process_pass = process_pass;
 								t->loc = Vector3();
 								t->rot = Quat();
-								t->rot_blend_accum = 0;
 								t->scale = Vector3(1, 1, 1);
 							}
 
@@ -912,26 +911,18 @@ void AnimationTree::_process_graph(float p_delta) {
 
 							if (t->process_pass != process_pass) {
 								t->process_pass = process_pass;
-								t->loc = loc;
-								t->rot = rot;
-								t->rot_blend_accum = 0;
-								t->scale = scale;
+								t->loc = Vector3();
+								t->rot = Quat();
+								t->scale = Vector3();
 							}
 
 							if (err != OK) {
 								continue;
 							}
 
-							t->loc = t->loc.lerp(loc, blend);
-							if (t->rot_blend_accum == 0) {
-								t->rot = rot;
-								t->rot_blend_accum = blend;
-							} else {
-								float rot_total = t->rot_blend_accum + blend;
-								t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
-								t->rot_blend_accum = rot_total;
-							}
-							t->scale = t->scale.lerp(scale, blend);
+							t->loc += loc * blend;
+							t->rot = (t->rot * Quat().slerp(rot, blend)).normalized();
+							t->scale += scale * blend;
 						}
 
 					} break;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -193,7 +193,6 @@ private:
 		int bone_idx;
 		Vector3 loc;
 		Quat rot;
-		float rot_blend_accum;
 		Vector3 scale;
 
 		TrackCacheTransform() {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -68,6 +68,8 @@
 #include "scene/2d/y_sort.h"
 #include "scene/animation/animation_blend_space_1d.h"
 #include "scene/animation/animation_blend_space_2d.h"
+#include "scene/animation/animation_blend_space_cyclic_1d.h"
+#include "scene/animation/animation_blend_space_cyclic_2d.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_node_state_machine.h"
 #include "scene/animation/animation_player.h"
@@ -393,6 +395,8 @@ void register_scene_types() {
 	ClassDB::register_class<AnimationNodeBlendTree>();
 	ClassDB::register_class<AnimationNodeBlendSpace1D>();
 	ClassDB::register_class<AnimationNodeBlendSpace2D>();
+	ClassDB::register_class<AnimationNodeBlendSpaceCyclic1D>();
+	ClassDB::register_class<AnimationNodeBlendSpaceCyclic2D>();
 	ClassDB::register_class<AnimationNodeStateMachine>();
 	ClassDB::register_class<AnimationNodeStateMachinePlayback>();
 


### PR DESCRIPTION
*Note*: Depends on https://github.com/godotengine/godot/pull/34134, as the blends are even more broken without it.

This PR aims to do some bugfixing for blendspaces as well as introduce the concept of *Cyclic* BlendSpaces.

There was some previous discussion of this here: https://github.com/godotengine/godot/issues/23414

Coming from other game engines, this is really a crucial and useful component for animation.

These cyclic BlendSpaces are very important for blending in animations whose timescale is supposed to match, such as movement animations, look-at animations, breathing animations, etc...

Currently they only support AnimationNodeAnimation's, since its currently the only way to reliably obtain an AnimationNodes runtime length, which is a hard requirement.

If AnimationNode's had a common interface where each node could return its computed runtime length, then any node could be used in the future, but that is a ton of work and maybe not as crucial for Cyclic BlendSpaces anyways.

Here is a Demo:
https://f.staik.net/f/2de.mp4