### PR TITLE
Hide LineEdit placeholder if IME composition string is not empty.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -704,7 +704,7 @@ void LineEdit::_notification(int p_what) {
 			}
 
 			int x_ofs = 0;
-			bool using_placeholder = text.empty();
+			bool using_placeholder = text.empty() && ime_text.empty();
 			int cached_text_width = using_placeholder ? cached_placeholder_width : cached_width;
 
 			switch (align) {


### PR DESCRIPTION
Fixes part one of #34192

The second part of the issue seems to be not directly controlled by the engine. In the IME input mode, keys are handled by OS, and it doesn't send back any events when IME window is closed to the engine.

We can override it, If we assume any that any backspace press that doesn't cause composition string change triggers window close, and cancel composition manually, but I have no idea whether this is correct assumption.