### PR TITLE
Check that motion is not zero before doing a sweep test.

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -945,8 +945,8 @@ bool SpaceBullet::test_body_motion(RigidBodyBullet *p_body, const Transform &p_f
 
 	btVector3 motion;
 	G_TO_B(p_motion, motion);
-
-	{ /// phase two - sweep test, from a secure position without margin
+	if (!motion.fuzzyZero()) {
+		// Phase two - sweep test, from a secure position without margin
 
 		const int shape_count(p_body->get_shape_count());
 


### PR DESCRIPTION
Fixes #25476.

Bullet uses a normal of the motion to create a direction vector when doing a Broad Phase Convex Sweep Test during collision testing:
https://github.com/godotengine/godot/blob/8eb183aebb9c79ff92d6f566af7ad2f91696ce08/thirdparty/bullet/BulletCollision/CollisionDispatch/btCollisionWorld.cpp#L1040-L1041
As can be seen in the comment below the call, they acknowledge it may result in a division by zero, but they haven't addressed it; so we need to.

The check in `space_bullet.cpp` matches Bullet's fuzzyZero() check:
https://github.com/godotengine/godot/blob/8eb183aebb9c79ff92d6f566af7ad2f91696ce08/thirdparty/bullet/LinearMath/btVector3.h#L688-L691
Issue #25476 was caused by Bullet ensuring the length is not zero before dividing when a vector is normalized():
https://github.com/godotengine/godot/blob/8eb183aebb9c79ff92d6f566af7ad2f91696ce08/thirdparty/bullet/LinearMath/btVector3.h#L303-L305
