### PR TITLE
Check for motion in cast_motion() before doing Bullet convexSweepTest().

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -152,6 +152,15 @@ int BulletPhysicsDirectSpaceState::intersect_shape(const RID &p_shape, const Tra
 }
 
 bool BulletPhysicsDirectSpaceState::cast_motion(const RID &p_shape, const Transform &p_xform, const Vector3 &p_motion, float p_margin, float &r_closest_safe, float &r_closest_unsafe, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas, ShapeRestInfo *r_info) {
+	r_closest_safe = 0.0f;
+	r_closest_unsafe = 0.0f;
+	btVector3 bt_motion;
+	G_TO_B(p_motion, bt_motion);
+
+	if (bt_motion.fuzzyZero()) {
+		return false;
+	}
+
 	ShapeBullet *shape = space->get_physics_server()->get_shape_owner()->getornull(p_shape);
 
 	btCollisionShape *btShape = shape->create_bt_shape(p_xform.basis.get_scale(), p_margin);
@@ -161,9 +170,6 @@ bool BulletPhysicsDirectSpaceState::cast_motion(const RID &p_shape, const Transf
 		return false;
 	}
 	btConvexShape *bt_convex_shape = static_cast<btConvexShape *>(btShape);
-
-	btVector3 bt_motion;
-	G_TO_B(p_motion, bt_motion);
 
 	btTransform bt_xform_from;
 	G_TO_B(p_xform, bt_xform_from);
@@ -177,9 +183,6 @@ bool BulletPhysicsDirectSpaceState::cast_motion(const RID &p_shape, const Transf
 	btResult.m_collisionFilterMask = p_collision_mask;
 
 	space->dynamicsWorld->convexSweepTest(bt_convex_shape, bt_xform_from, bt_xform_to, btResult, space->dynamicsWorld->getDispatchInfo().m_allowedCcdPenetration);
-
-	r_closest_unsafe = 1.0;
-	r_closest_safe = 1.0;
 
 	if (btResult.hasHit()) {
 		const btScalar l = bt_motion.length();
@@ -196,6 +199,9 @@ bool BulletPhysicsDirectSpaceState::cast_motion(const RID &p_shape, const Transf
 			r_info->collider_id = collision_object->get_instance_id();
 			r_info->shape = btResult.m_shapeId;
 		}
+	} else {
+		r_closest_safe = 1.0f;
+		r_closest_unsafe = 1.0f;
 	}
 
 	bulletdelete(bt_convex_shape);

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -754,9 +754,9 @@ void ClippedCamera3D::_notification(int p_what) {
 		xf.origin = ray_from;
 		xf.orthonormalize();
 
-		float csafe, cunsafe;
-		if (dspace->cast_motion(pyramid_shape, xf, cam_pos - ray_from, margin, csafe, cunsafe, exclude, collision_mask, clip_to_bodies, clip_to_areas)) {
-			clip_offset = cam_pos.distance_to(ray_from + (cam_pos - ray_from) * csafe);
+		float closest_safe = 1.0f, closest_unsafe = 1.0f;
+		if (dspace->cast_motion(pyramid_shape, xf, cam_pos - ray_from, margin, closest_safe, closest_unsafe, exclude, collision_mask, clip_to_bodies, clip_to_areas)) {
+			clip_offset = cam_pos.distance_to(ray_from + (cam_pos - ray_from) * closest_safe);
 		}
 
 		_update_camera();

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -295,7 +295,7 @@ Array PhysicsDirectSpaceState3D::_intersect_shape(const Ref<PhysicsShapeQueryPar
 Array PhysicsDirectSpaceState3D::_cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, const Vector3 &p_motion) {
 	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Array());
 
-	float closest_safe, closest_unsafe;
+	float closest_safe = 1.0f, closest_unsafe = 1.0f;
 	bool res = cast_motion(p_shape_query->shape, p_shape_query->transform, p_motion, p_shape_query->margin, closest_safe, closest_unsafe, p_shape_query->exclude, p_shape_query->collision_mask, p_shape_query->collide_with_bodies, p_shape_query->collide_with_areas);
 	if (!res) {
 		return Array();


### PR DESCRIPTION
Addresses: https://github.com/godotengine/godot/pull/34210#issuecomment-563134988

Also ensures that default `closest_safe` and `closest_unsafe` values are
defined both in `cast_motion()` and before `cast_motion()` is called in camera.cpp and physics_server.cpp.

Note: The other use of `cast_motion()` (in spring_arm.cpp) defines default values for the variables used for `closest_safe` and `closest_unsafe`:
https://github.com/godotengine/godot/blob/2ebc783e9c7c257bb122f8a19e2426193a481aa4/scene/3d/spring_arm.cpp#L141-L142
before calling `cast_motion()`:
https://github.com/godotengine/godot/blob/2ebc783e9c7c257bb122f8a19e2426193a481aa4/scene/3d/spring_arm.cpp#L158
