### PR TITLE
SCons: Add 'split_libmodules' option to workaround linker issue

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -68,8 +68,6 @@ env_base.AppendENVPath('PATH', os.getenv('PATH'))
 env_base.AppendENVPath('PKG_CONFIG_PATH', os.getenv('PKG_CONFIG_PATH'))
 env_base.disabled_modules = []
 env_base.use_ptrcall = False
-env_base.split_drivers = False
-env_base.split_modules = False
 env_base.module_version_string = ""
 env_base.msvc = False
 
@@ -129,6 +127,7 @@ opts.Add(BoolVariable('dev', "If yes, alias for verbose=yes warnings=extra werro
 opts.Add('extra_suffix', "Custom extra suffix added to the base filename of all generated binary files", '')
 opts.Add(BoolVariable('vsproj', "Generate a Visual Studio solution", False))
 opts.Add(EnumVariable('macports_clang', "Build using Clang from MacPorts", 'no', ('no', '5.0', 'devel')))
+opts.Add(BoolVariable('split_libmodules', "Split intermediate libmodules.a in smaller chunks to prevent exceeding linker command line size (forced to True when using MinGW)", False))
 opts.Add(BoolVariable('disable_3d', "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable('disable_advanced_gui', "Disable advanced GUI nodes and behaviors", False))
 opts.Add(BoolVariable('no_editor_splash', "Don't use the custom splash screen for the editor", False))

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -46,9 +46,7 @@ if env['vsproj']:
     env.AddToVSProject(env.drivers_sources)
     os.chdir(path)
 
-if env.split_drivers:
-    env.split_lib("drivers")
-else:
-    env.add_source_files(env.drivers_sources, "*.cpp")
-    lib = env.add_library("drivers", env.drivers_sources)
-    env.Prepend(LIBS=[lib])
+env.add_source_files(env.drivers_sources, "*.cpp")
+
+lib = env.add_library("drivers", env.drivers_sources)
+env.Prepend(LIBS=[lib])

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -16,7 +16,7 @@ for x in env.module_list:
     env_modules.Append(CPPDEFINES=["MODULE_" + x.upper() + "_ENABLED"])
     SConscript(x + "/SCsub")
 
-if env.split_modules:
+if env['split_libmodules']:
     env.split_lib("modules", env_lib = env_modules)
 else:
     lib = env_modules.add_library("modules", env.modules_sources)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -151,14 +151,14 @@ def setup_msvc_auto(env):
         env['bits'] = '64'
     else:
         env['bits'] = '32'
-    print(" Found MSVC version %s, arch %s, bits=%s" % (env['MSVC_VERSION'], env['TARGET_ARCH'], env['bits']))
+    print("Found MSVC version %s, arch %s, bits=%s" % (env['MSVC_VERSION'], env['TARGET_ARCH'], env['bits']))
     if env['TARGET_ARCH'] in ('amd64', 'x86_64'):
         env["x86_libtheora_opt_vc"] = False
 
 def setup_mingw(env):
     """Set up env for use with mingw"""
     # Nothing to do here
-    print("Using Mingw")
+    print("Using MinGW")
     pass
 
 def configure_msvc(env, manual_msvc_config):
@@ -294,7 +294,10 @@ def configure_mingw(env):
     ## Compiler configuration
 
     if (os.name == "nt"):
-        env['ENV']['TMP'] = os.environ['TMP']  # way to go scons, you can be so stupid sometimes
+        # Force splitting libmodules.a in multiple chunks to work around
+        # issues reaching the linker command line size limit, which also
+        # seem to induce huge slowdown for 'ar' (GH-30892).
+        env['split_libmodules'] = True
     else:
         env["PROGSUFFIX"] = env["PROGSUFFIX"] + ".exe"  # for linux cross-compilation
 


### PR DESCRIPTION
The new 'split_libmodules=yes' option is useful to work around linker
command line size limitations when linking a huge number of objects.
We're currently over 64k chars when linking libmodules.a on Windows
with MinGW, which triggers issues as seen in #30892.

Even on Linux, we can also reach linker command line size limitations
by adding more custom modules.

We force this option to True for MinGW on Windows, which fixes #30892.

Additional changes:

Additional changes to lib splitting:

- Fix linking of the split module libs with interdependent symbols,
  hacking our way into LINKCOM and SHLINKCOM to set the `--start-group`
  and `--end-group` flags.
- Fix Python 3 compatibility in `methods.split_lib()`.
- Drop seemingly obsolete condition for 'msys' on 'posix'.
- Drop the unnecessary 'split_drivers' as the drivers lib is no longer
  too big since we moved all thirdparty builds to modules.

Co-authored-by: @hpvb