### PR TITLE
Allow to change the home indicator behaviour on iOS

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -437,6 +437,9 @@
 		<member name="display/window/vsync/vsync_via_compositor" type="bool" setter="" getter="" default="false">
 			If [code]Use Vsync[/code] is enabled and this setting is [code]true[/code], enables vertical synchronization via the operating system's window compositor when in windowed mode and the compositor is enabled. This will prevent stutter in certain situations. (Windows only.)
 		</member>
+		<member name="display/window/ios/hide_home_indicator" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the home indicator is hidden automatically. This only affects iOS devices without a physical home button.
+		</member>
 		<member name="editor/script_templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
 		</member>
 		<member name="editor/search_in_file_extensions" type="PoolStringArray" setter="" getter="" default="PoolStringArray( &quot;gd&quot;, &quot;shader&quot; )">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1126,6 +1126,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(GLOBAL_DEF("application/run/low_processor_mode_sleep_usec", 6900)); // Roughly 144 FPS
 	ProjectSettings::get_singleton()->set_custom_property_info("application/run/low_processor_mode_sleep_usec", PropertyInfo(Variant::INT, "application/run/low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "0,33200,1,or_greater")); // No negative numbers
 
+	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
+
 	Engine::get_singleton()->set_frame_delay(frame_delay);
 
 	message_queue = memnew(MessageQueue);

--- a/platform/iphone/view_controller.h
+++ b/platform/iphone/view_controller.h
@@ -45,4 +45,6 @@
 
 - (BOOL)prefersStatusBarHidden;
 
+- (BOOL)prefersHomeIndicatorAutoHidden;
+
 @end

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -32,6 +32,8 @@
 
 #include "os_iphone.h"
 
+#include "core/project_settings.h"
+
 extern "C" {
 
 int add_path(int, char **);
@@ -127,6 +129,14 @@ int add_cmdline(int p_argc, char **p_args) {
 
 - (BOOL)prefersStatusBarHidden {
 	return YES;
+}
+
+- (BOOL)prefersHomeIndicatorAutoHidden {
+	if (GLOBAL_GET("display/window/ios/hide_home_indicator")) {
+		return YES;
+	} else {
+		return NO;
+	}
 }
 
 #ifdef GAME_CENTER_ENABLED


### PR DESCRIPTION
On iOS devices without a physical home button iOS
shows a home indicator instead. This is often in the
way of the UI or the game.
Added a project setting to disable hidden home indicator.
The default value is to hide the home indicator

Fixes #34223 