### PR TITLE
Fixes long popup menu scroll behavior

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -191,16 +191,20 @@ void PopupMenu::_submenu_timeout() {
 
 void PopupMenu::_scroll(float p_factor, const Point2 &p_over) {
 
-	const float global_y = get_global_position().y;
-
 	int vseparation = get_constant("vseparation");
 	Ref<Font> font = get_font("font");
 
 	float dy = (vseparation + font->get_height()) * 3 * p_factor * get_global_transform().get_scale().y;
-	if (dy > 0 && global_y < 0)
-		dy = MIN(dy, -global_y - 1);
-	else if (dy < 0 && global_y + get_size().y * get_global_transform().get_scale().y > get_viewport_rect().size.y)
-		dy = -MIN(-dy, global_y + get_size().y * get_global_transform().get_scale().y - get_viewport_rect().size.y - 1);
+	if (dy > 0) {
+		const float global_top = get_global_position().y;
+		const float limit = global_top < 0 ? -global_top : 0;
+		dy = MIN(dy, limit);
+	} else if (dy < 0) {
+		const float global_bottom = get_global_position().y + get_size().y * get_global_transform().get_scale().y;
+		const float viewport_height = get_viewport_rect().size.y;
+		const float limit = global_bottom > viewport_height ? global_bottom - viewport_height: 0;
+		dy = -MIN(-dy, limit);
+	}
 	set_position(get_position() + Vector2(0, dy));
 
 	Ref<InputEventMouseMotion> ie;


### PR DESCRIPTION
Before this fix, popup menus longer than the viewport can be scrolled further than the top of the screen.

To reproduce:

1. Open the language menu in project manager
2. Scroll down (i.e. move the menu down)
    * The menu will move down until it gets out of the mouse focus.
    * The menu can be scrolled out of the viewport if you wish.
3. Scroll up, so the top of the menu is above the viewport
4. Scroll down again
    * The menu will not scroll further once the top of it is inside the viewport (as expected)
        * But the menu actually have one pixel outside the viewport (It has a two pixel border, but only one pixel is inside the viewport). If you scroll all the way up, the bottom of the menu is kept one pixel off the viewport too.

![demo](https://user-images.githubusercontent.com/372476/70492587-e198d280-1b3f-11ea-86a7-fea7abb929d4.gif)