### PR TITLE
Enable Bullet DEBUG on debug builds.

### DIFF
--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -200,8 +200,8 @@ if env["builtin_bullet"]:
         env_bullet.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
     else:
         env_bullet.Prepend(CPPPATH=[thirdparty_dir])
-    # if env['target'] == "debug" or env['target'] == "release_debug":
-    #     env_bullet.Append(CPPDEFINES=['BT_DEBUG'])
+    if env["target"] == "debug" or env["target"] == "release_debug":
+        env_bullet.Append(CPPDEFINES=["DEBUG"])
 
     env_thirdparty = env_bullet.Clone()
     env_thirdparty.disable_warnings()


### PR DESCRIPTION
Fixes #25301.

Now that #25476 has been fixed, we can try re-enabling Bullet DEBUG in debug mode.

Note 1: This may reveal a bunch of new bugs that will cause `assert` crashes that will need to be resolved. A previous attempt to define Bullet's BT_DEBUG in debug mode (#25367) was reversed (#25500), because it  caused issues #25431 and #25476, and it was too close to the release of 3.1: https://github.com/godotengine/godot/issues/25301#issuecomment-461754836. Since we're already so close to releasing 3.2, we should probably not add it to 3.2 now either.

Note 2: While working on #34210 I noticed that (on Linux) Bullet requires DEBUG to be defined not BT_DEBUG:
https://github.com/godotengine/godot/blob/2ebc783e9c7c257bb122f8a19e2426193a481aa4/thirdparty/bullet/LinearMath/btScalar.h#L272-L276
Bullet defines BT_DEBUG when required if DEBUG is enabled:
https://github.com/godotengine/godot/blob/2ebc783e9c7c257bb122f8a19e2426193a481aa4/thirdparty/bullet/LinearMath/btScalar.h#L61-L63
