### PR TITLE
Use renderbuffer depth for post-process buffers when appropriate

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4914,7 +4914,11 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 
 				bool used_depth = false;
 				if (j == 0 && i == 0) { //use always
-					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
+					if (config.support_depth_texture) {
+						glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
+					} else {
+						glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth);
+					}
 					used_depth = true;
 				}
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/34055

``rt->depth`` is sometimes a renderbuffer on older hardware, so make sure that it is being properly attached using ``glFramebufferRenderBuffer()`` when that is the case.