### PR TITLE
Fixes crash when shader inputs/outputs is invalid string

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2259,6 +2259,8 @@ void VisualShaderNodeGroupBase::set_input_port_type(int p_id, int p_type) {
 	int index = 0;
 	for (int i = 0; i < inputs_strings.size(); i++) {
 		Vector<String> arr = inputs_strings[i].split(",");
+		ERR_FAIL_COND(arr.size() != 3);
+
 		if (arr[0].to_int() == p_id) {
 			index += arr[0].size();
 			count = arr[1].size() - 1;
@@ -2292,6 +2294,8 @@ void VisualShaderNodeGroupBase::set_input_port_name(int p_id, const String &p_na
 	int index = 0;
 	for (int i = 0; i < inputs_strings.size(); i++) {
 		Vector<String> arr = inputs_strings[i].split(",");
+		ERR_FAIL_COND(arr.size() != 3);
+
 		if (arr[0].to_int() == p_id) {
 			index += arr[0].size() + arr[1].size();
 			count = arr[2].size() - 1;
@@ -2325,6 +2329,8 @@ void VisualShaderNodeGroupBase::set_output_port_type(int p_id, int p_type) {
 	int index = 0;
 	for (int i = 0; i < output_strings.size(); i++) {
 		Vector<String> arr = output_strings[i].split(",");
+		ERR_FAIL_COND(arr.size() != 3);
+
 		if (arr[0].to_int() == p_id) {
 			index += arr[0].size();
 			count = arr[1].size() - 1;
@@ -2358,6 +2364,8 @@ void VisualShaderNodeGroupBase::set_output_port_name(int p_id, const String &p_n
 	int index = 0;
 	for (int i = 0; i < output_strings.size(); i++) {
 		Vector<String> arr = output_strings[i].split(",");
+		ERR_FAIL_COND(arr.size() != 3);
+
 		if (arr[0].to_int() == p_id) {
 			index += arr[0].size() + arr[1].size();
 			count = arr[2].size() - 1;
@@ -2405,6 +2413,8 @@ void VisualShaderNodeGroupBase::_apply_port_changes() {
 
 	for (int i = 0; i < inputs_strings.size(); i++) {
 		Vector<String> arr = inputs_strings[i].split(",");
+		ERR_FAIL_COND(arr.size() != 3);
+
 		Port port;
 		port.type = (PortType)arr[1].to_int();
 		port.name = arr[2];
@@ -2412,6 +2422,8 @@ void VisualShaderNodeGroupBase::_apply_port_changes() {
 	}
 	for (int i = 0; i < outputs_strings.size(); i++) {
 		Vector<String> arr = outputs_strings[i].split(",");
+		ERR_FAIL_COND(arr.size() != 3);
+
 		Port port;
 		port.type = (PortType)arr[1].to_int();
 		port.name = arr[2];


### PR DESCRIPTION
This fixes #29985

* More array size checks after spliting the inputs/outputs string