### PR TITLE
Fixes crash when using DynamicFont::set_font_data

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -657,6 +657,7 @@ void DynamicFont::_reload_cache() {
 	if (!data.is_valid()) {
 		data_at_size.unref();
 		outline_data_at_size.unref();
+		fallbacks.resize(0);
 		fallback_data_at_size.resize(0);
 		fallback_outline_data_at_size.resize(0);
 		return;


### PR DESCRIPTION
This fixes #32701

* Adds the missing resize of `fallbacks` 
    * `fallbacks` size and `fallback_data_at_size` size are always in sync until `set_font_data` is called with with an invalid reference