### PR TITLE
#33429, Fixes warnings adding up when saving while program is running.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1091,6 +1091,9 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 	save.step(TTR("Saving Scene"), 4);
 	_save_scene(p_file, p_idx);
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
+	if (editor_run.get_status() == EditorRun::STATUS_PLAY) {
+		_menu_option_confirm(RUN_STOP, true);
+	}
 }
 
 bool EditorNode::_validate_scene_recursive(const String &p_filename, Node *p_node) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1094,6 +1094,9 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 	save.step(TTR("Saving Scene"), 4);
 	_save_scene(p_file, p_idx);
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
+	if (editor_run.get_status() == EditorRun::STATUS_PLAY) {
+		_menu_option_confirm(RUN_STOP, true);
+	}
 }
 
 bool EditorNode::_validate_scene_recursive(const String &p_filename, Node *p_node) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1091,6 +1091,8 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 	save.step(TTR("Saving Scene"), 4);
 	_save_scene(p_file, p_idx);
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
+
+	// stops the game if it is running to fix warnings accumulating
 	if (editor_run.get_status() == EditorRun::STATUS_PLAY) {
 		_menu_option_confirm(RUN_STOP, true);
 	}


### PR DESCRIPTION
It does this by stopping the running program after saving if it is playing.