### PR TITLE
Fixed a bug within sprite.cpp that caused a nan value to appear

### DIFF
--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -315,6 +315,9 @@ bool Sprite::is_pixel_opaque(const Point2 &p_point) const {
 	if (texture.is_null())
 		return false;
 
+	if (texture->get_size().width == 0 || texture->get_size().height == 0)
+		return false;
+
 	Rect2 src_rect, dst_rect;
 	bool filter_clip;
 	_get_rects(src_rect, dst_rect, filter_clip);


### PR DESCRIPTION
A nan value would be present and cause a project to crash if is_pixel_opaque was called on a sprite with a texture of area zero and still had the repeating flag set.

Since a texture is still valid even with zero area, the fix involves checking the length and width of the texture. If either are zero, is_pixel_opaque now immediately returns false instead of allowing nan to reach the return values.

Fixes #33716

[godot-test-project.zip](https://github.com/godotengine/godot/files/3947531/godot-test-project.zip)
Modified minimal reproduction project from #33716 (from user: qarmin) that now tests the behavior
