### PR TITLE
Fix build on musl-based systems

### DIFF
--- a/thirdparty/vhacd/0003-fix-musl-build.patch
+++ b/thirdparty/vhacd/0003-fix-musl-build.patch
@@ -1,0 +1,15 @@
+diff --git a/thirdparty/vhacd/inc/vhacdMutex.h b/thirdparty/vhacd/inc/vhacdMutex.h
+index 6b09259200..d587dd6387 100644
+--- a/thirdparty/vhacd/inc/vhacdMutex.h
++++ b/thirdparty/vhacd/inc/vhacdMutex.h
+@@ -71,7 +71,9 @@
+ #include <pthread.h>
+ #endif
+ 
+-#if defined(__APPLE__)
++// -- GODOT start --
++#if defined(__APPLE__) || !defined(__GLIBC__)
++// -- GODOT end --
+ #define PTHREAD_MUTEX_RECURSIVE_NP PTHREAD_MUTEX_RECURSIVE
+ #endif
+ 

--- a/thirdparty/vhacd/inc/vhacdMutex.h
+++ b/thirdparty/vhacd/inc/vhacdMutex.h
@@ -71,7 +71,9 @@
 #include <pthread.h>
 #endif
 
-#if defined(__APPLE__)
+// -- GODOT start --
+#if defined(__APPLE__) || !defined(__GLIBC__)
+// -- GODOT end --
 #define PTHREAD_MUTEX_RECURSIVE_NP PTHREAD_MUTEX_RECURSIVE
 #endif
 


### PR DESCRIPTION
On some systems, including Alpine Linux, musl is used instead of
glibc. This commit patches the third-party V-HACD module to provide
a macro not provided by musl.

Fixes #31555.