### PR TITLE
Fixes crash when using Mesh::create_outline and Mesh::create_convex_shape

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -75,6 +75,7 @@ Ref<TriangleMesh> Mesh::generate_triangle_mesh() const {
 			continue;
 
 		Array a = surface_get_arrays(i);
+		ERR_FAIL_COND_V(a.empty(), Ref<TriangleMesh>());
 
 		int vc = surface_get_array_len(i);
 		PoolVector<Vector3> vertices = a[ARRAY_VERTEX];
@@ -234,6 +235,7 @@ Ref<Shape> Mesh::create_convex_shape() const {
 	for (int i = 0; i < get_surface_count(); i++) {
 
 		Array a = surface_get_arrays(i);
+		ERR_FAIL_COND_V(a.empty(), Ref<ConvexPolygonShape>());
 		PoolVector<Vector3> v = a[ARRAY_VERTEX];
 		vertices.append_array(v);
 	}
@@ -273,6 +275,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 			continue;
 
 		Array a = surface_get_arrays(i);
+		ERR_FAIL_COND_V(a.empty(), Ref<ArrayMesh>());
 
 		if (i == 0) {
 			arrays = a;
@@ -378,6 +381,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 		PoolVector<Vector3>::Write r = vertices.write();
 
 		if (indices.size()) {
+			ERR_FAIL_COND_V(indices.size() % 3 != 0, Ref<ArrayMesh>());
 			vc = indices.size();
 			ir = indices.write();
 			has_indices = true;


### PR DESCRIPTION
This fixes #32988

* ~~All paths in `surface_get_arrays` should return a `VS::ARRAY_MAX` sized array even on
error.~~
    * ~~There are four error paths in this function call. Three of them return an empty array before this fix, causing the index error crash.~~
    * ~~Currently, `Array` does not have a constructor for creating a non-zero sized array. To only create the array on error, I have to use `ERR_FAIL_V_MSG` instead of `ERR_FAIL_INDEX_V` or `ERR_FAIL_COND_V`. This can be fixed after #18328 is resolved.~~

Update:
* Adds a size check to the array returned by `surface_get_arrays` in these related functions.
* When `create_outline` uses indices to form a triangle, adds a check to make sure the `indices` array size is a multiple of three.