### PR TITLE
Fixes crash after set_piece_texture with invalid texture

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1333,6 +1333,7 @@ void LargeTexture::set_piece_offset(int p_idx, const Point2 &p_offset) {
 void LargeTexture::set_piece_texture(int p_idx, const Ref<Texture> &p_texture) {
 
 	ERR_FAIL_COND(p_texture == this);
+	ERR_FAIL_COND(p_texture.is_null());
 	ERR_FAIL_INDEX(p_idx, pieces.size());
 	pieces.write[p_idx].texture = p_texture;
 };


### PR DESCRIPTION
This fixes #32982

* Validates the `p_texture` parameter in set_piece_texture
    * as `add_piece` validates the `p_texture` parameter this way

---

It's hard to reproduce the crash using the original worst-godot-test-project.

The following script can result in an immediate crash, with the same backtrace.

```gdscript
extends Node


func _process(_delta: float) -> void:
	var t: = LargeTexture.new()
	var texture: Texture = load("Icon.png")

	t.add_piece(Vector2.ZERO, texture)
	t.set_size(texture.get_size())

	t.set_piece_texture(0, null)

	t.draw(RID(), Vector2(100, 100))
```