### PR TITLE
Fixes infinite loop when switching editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -630,7 +630,7 @@ void EditorNode::_editor_select_next() {
 		} else {
 			editor++;
 		}
-	} while (main_editor_buttons[editor]->is_visible());
+	} while (!main_editor_buttons[editor]->is_visible());
 
 	_editor_select(editor);
 }
@@ -645,7 +645,7 @@ void EditorNode::_editor_select_prev() {
 		} else {
 			editor--;
 		}
-	} while (main_editor_buttons[editor]->is_visible());
+	} while (!main_editor_buttons[editor]->is_visible());
 
 	_editor_select(editor);
 }


### PR DESCRIPTION
This fixes #34255 

* The loop condition is inverted
    * FYI: 3D / Script / AssetLib can be hidden, but the 2D Editor is always visible