### PR TITLE
Make CowData self-inserts safe

### DIFF
--- a/core/vector.h
+++ b/core/vector.h
@@ -149,9 +149,8 @@ void Vector<T>::append_array(const Vector<T> &p_other) {
 template <class T>
 bool Vector<T>::push_back(const T &p_elem) {
 
-	Error err = resize(size() + 1);
+	Error err = _cowdata.insert(size(), p_elem);
 	ERR_FAIL_COND_V(err, true);
-	set(size() - 1, p_elem);
 
 	return false;
 }


### PR DESCRIPTION
When inserting an element taking the original from the current data block so that it will be resized, potentially invalidating the reference to the original, a backup is made to base the copy on it instead.

Fixes #31736.

Other related items (fixed, superseded or plainly related): #16961, #29408, #31159, #31609, #31694.

P. S.: Haven't had time to test this thoroughly.