### PR TITLE
Scroll ScrollContainer to focused children

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -310,6 +310,13 @@
 				Emitted when the size of the viewport is changed, whether by [method set_size_override], resize of window, or some other means.
 			</description>
 		</signal>
+		<signal name="gui_focus_changed">
+			<argument index="0" name="control" type="Control">
+			</argument>
+			<description>
+				Emitted when a Control node grabs keyboard focus.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="UPDATE_DISABLED" value="0" enum="UpdateMode">

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -30,6 +30,7 @@
 
 #include "scroll_container.h"
 #include "core/os/os.h"
+#include "scene/main/viewport.h"
 
 bool ScrollContainer::clips_input() const {
 
@@ -232,12 +233,34 @@ void ScrollContainer::_update_scrollbar_position() {
 	v_scroll->raise();
 }
 
+void ScrollContainer::_ensure_focused_visible(Control *p_control) {
+
+	if (is_a_parent_of(p_control)) {
+		float right_margin = 0;
+		if (v_scroll->is_visible()) {
+			right_margin += v_scroll->get_size().x;
+		}
+		float bottom_margin = 0;
+		if (h_scroll->is_visible()) {
+			bottom_margin += h_scroll->get_size().y;
+		}
+
+		set_v_scroll(MAX(MIN(p_control->get_begin().y, get_v_scroll()), p_control->get_end().y - get_size().y + bottom_margin));
+		set_h_scroll(MAX(MIN(p_control->get_begin().x, get_h_scroll()), p_control->get_end().x - get_size().x + right_margin));
+	}
+}
+
 void ScrollContainer::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
 
 		call_deferred("_update_scrollbar_position");
 	};
+
+	if (p_what == NOTIFICATION_READY) {
+
+		get_viewport()->connect("gui_focus_changed", this, "_ensure_focused_visible");
+	}
 
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
 
@@ -521,6 +544,7 @@ void ScrollContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_enable_v_scroll", "enable"), &ScrollContainer::set_enable_v_scroll);
 	ClassDB::bind_method(D_METHOD("is_v_scroll_enabled"), &ScrollContainer::is_v_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("_update_scrollbar_position"), &ScrollContainer::_update_scrollbar_position);
+	ClassDB::bind_method(D_METHOD("_ensure_focused_visible"), &ScrollContainer::_ensure_focused_visible);
 	ClassDB::bind_method(D_METHOD("set_h_scroll", "value"), &ScrollContainer::set_h_scroll);
 	ClassDB::bind_method(D_METHOD("get_h_scroll"), &ScrollContainer::get_h_scroll);
 	ClassDB::bind_method(D_METHOD("set_v_scroll", "value"), &ScrollContainer::set_v_scroll);

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -75,6 +75,7 @@ protected:
 	static void _bind_methods();
 
 	void _update_scrollbar_position();
+	void _ensure_focused_visible(Control *p_node);
 
 public:
 	int get_v_scroll() const;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2634,6 +2634,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 		return;
 	get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, "_viewports", "_gui_remove_focus");
 	gui.key_focus = p_control;
+	emit_signal("gui_focus_changed", p_control);
 	p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
 	p_control->update();
 }
@@ -3216,6 +3217,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "global_canvas_transform", PROPERTY_HINT_NONE, "", 0), "set_global_canvas_transform", "get_global_canvas_transform");
 
 	ADD_SIGNAL(MethodInfo("size_changed"));
+	ADD_SIGNAL(MethodInfo("gui_focus_changed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
 
 	BIND_ENUM_CONSTANT(UPDATE_DISABLED);
 	BIND_ENUM_CONSTANT(UPDATE_ONCE);


### PR DESCRIPTION
I had to add a new signal to Viewport called `gui_focus_changed`, but it works.
![0B0R1STGXB](https://user-images.githubusercontent.com/2223172/70625545-e5e9ec00-1c22-11ea-8ce1-53cf73b4eb9c.gif)
![bq2KDdEYm7](https://user-images.githubusercontent.com/2223172/70625550-e6828280-1c22-11ea-9056-9dd2da8d32b2.gif)

Fixes #5637