### PR TITLE
Fix for #34258 and added get_zoom_hbox() documentation.

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -87,6 +87,8 @@
 			<return type="HBoxContainer">
 			</return>
 			<description>
+				Gets the [HBoxContainer] that contains the zooming and grid snap controls in the top left of the graph.
+				Warning: The intended usage of this function is to allow you to reposition or add your own custom controls to the container. This is an internal control and as such should not be freed. If you wish to hide this or any of it's children use their [member CanvasItem.visible] property instead. 
 			</description>
 		</method>
 		<method name="is_node_connected">


### PR DESCRIPTION
Fixes issue: https://github.com/godotengine/godot/issues/34258

Implements new GDScript exposed function ```GraphEdit.set_controls_visibility(visible)``` with documentation.

Clarifies that ```GraphEdit.get_zoom_hbox()``` returns an internal control and scripts should not free it and this function should instead be used for minor customisations.