### PR TITLE
Fix for #34186: "Center Selection" in 2D editor introduces graphic bias.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4938,8 +4938,8 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 
 		center = rect.position + rect.size / 2;
 		Vector2 offset = viewport->get_size() / 2 - editor->get_scene_root()->get_global_canvas_transform().xform(center);
-		view_offset.x -= offset.x / zoom;
-		view_offset.y -= offset.y / zoom;
+		view_offset.x -= Math::round(offset.x / zoom);
+		view_offset.y -= Math::round(offset.y / zoom);
 		update_viewport();
 
 	} else { // VIEW_FRAME_TO_SELECTION


### PR DESCRIPTION
*Bugsquad edit:* Fixes #34186.