### PR TITLE
Mono/C#: Optimize the way we store GC handles for scripts

### DIFF
--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -240,7 +240,7 @@ class CSharpInstance : public ScriptInstance {
 	bool destructing_script_instance = false;
 
 	Ref<CSharpScript> script;
-	Ref<MonoGCHandle> gchandle;
+	MonoGCHandleData gchandle;
 
 	Vector<Callable> event_signal_callables;
 
@@ -258,7 +258,7 @@ class CSharpInstance : public ScriptInstance {
 
 	// Do not use unless you know what you are doing
 	friend void GDMonoInternals::tie_managed_to_unmanaged(MonoObject *, Object *);
-	static CSharpInstance *create_for_managed_type(Object *p_owner, CSharpScript *p_script, const Ref<MonoGCHandle> &p_gchandle);
+	static CSharpInstance *create_for_managed_type(Object *p_owner, CSharpScript *p_script, const MonoGCHandleData &p_gchandle);
 
 	void _call_multilevel(MonoObject *p_mono_object, const StringName &p_method, const Variant **p_args, int p_argcount);
 
@@ -326,8 +326,14 @@ struct CSharpScriptBinding {
 	bool inited;
 	StringName type_name;
 	GDMonoClass *wrapper_class;
-	Ref<MonoGCHandle> gchandle;
+	MonoGCHandleData gchandle;
 	Object *owner;
+
+	CSharpScriptBinding() :
+			inited(false),
+			wrapper_class(NULL),
+			owner(NULL) {
+	}
 };
 
 class ManagedCallableMiddleman : public Object {
@@ -414,8 +420,8 @@ public:
 	_FORCE_INLINE_ EditorPlugin *get_godotsharp_editor() const { return godotsharp_editor; }
 #endif
 
-	static void release_script_gchandle(Ref<MonoGCHandle> &p_gchandle);
-	static void release_script_gchandle(MonoObject *p_expected_obj, Ref<MonoGCHandle> &p_gchandle);
+	static void release_script_gchandle(MonoGCHandleData &p_gchandle);
+	static void release_script_gchandle(MonoObject *p_expected_obj, MonoGCHandleData &p_gchandle);
 
 	bool debug_break(const String &p_error, bool p_allow_continue = true);
 	bool debug_break_parse(const String &p_file, int p_line, const String &p_error);

--- a/modules/mono/glue/base_object_glue.cpp
+++ b/modules/mono/glue/base_object_glue.cpp
@@ -70,8 +70,8 @@ void godot_icall_Object_Disposed(MonoObject *p_obj, Object *p_ptr) {
 	if (data) {
 		CSharpScriptBinding &script_binding = ((Map<Object *, CSharpScriptBinding>::Element *)data)->get();
 		if (script_binding.inited) {
-			Ref<MonoGCHandle> &gchandle = script_binding.gchandle;
-			if (gchandle.is_valid()) {
+			MonoGCHandleData &gchandle = script_binding.gchandle;
+			if (!gchandle.is_released()) {
 				CSharpLanguage::release_script_gchandle(p_obj, gchandle);
 			}
 		}
@@ -117,8 +117,8 @@ void godot_icall_Reference_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoolea
 		if (data) {
 			CSharpScriptBinding &script_binding = ((Map<Object *, CSharpScriptBinding>::Element *)data)->get();
 			if (script_binding.inited) {
-				Ref<MonoGCHandle> &gchandle = script_binding.gchandle;
-				if (gchandle.is_valid()) {
+				MonoGCHandleData &gchandle = script_binding.gchandle;
+				if (!gchandle.is_released()) {
 					CSharpLanguage::release_script_gchandle(p_obj, gchandle);
 				}
 			}

--- a/modules/mono/managed_callable.h
+++ b/modules/mono/managed_callable.h
@@ -42,7 +42,7 @@
 
 class ManagedCallable : public CallableCustom {
 	friend class CSharpLanguage;
-	Ref<MonoGCHandle> delegate_handle;
+	MonoGCHandleData delegate_handle;
 	GDMonoMethod *delegate_invoke;
 
 #ifdef GD_MONO_HOT_RELOAD
@@ -60,7 +60,7 @@ public:
 	ObjectID get_object() const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
-	_FORCE_INLINE_ MonoDelegate *get_delegate() { return (MonoDelegate *)delegate_handle->get_target(); }
+	_FORCE_INLINE_ MonoDelegate *get_delegate() { return (MonoDelegate *)delegate_handle.get_target(); }
 
 	void set_delegate(MonoDelegate *p_delegate);
 
@@ -71,9 +71,7 @@ public:
 	static constexpr CompareEqualFunc compare_less_func_ptr = &ManagedCallable::compare_less;
 
 	ManagedCallable(MonoDelegate *p_delegate);
-#ifdef GD_MONO_HOT_RELOAD
 	~ManagedCallable();
-#endif
 };
 
 #endif // MANAGED_CALLABLE_H

--- a/modules/mono/mono_gc_handle.cpp
+++ b/modules/mono/mono_gc_handle.cpp
@@ -32,56 +32,35 @@
 
 #include "mono_gd/gd_mono.h"
 
-uint32_t MonoGCHandle::new_strong_handle(MonoObject *p_object) {
-
-	return mono_gchandle_new(p_object, /* pinned: */ false);
-}
-
-uint32_t MonoGCHandle::new_strong_handle_pinned(MonoObject *p_object) {
-
-	return mono_gchandle_new(p_object, /* pinned: */ true);
-}
-
-uint32_t MonoGCHandle::new_weak_handle(MonoObject *p_object) {
-
-	return mono_gchandle_new_weakref(p_object, /* track_resurrection: */ false);
-}
-
-void MonoGCHandle::free_handle(uint32_t p_gchandle) {
-
-	mono_gchandle_free(p_gchandle);
-}
-
-Ref<MonoGCHandle> MonoGCHandle::create_strong(MonoObject *p_object) {
-
-	return memnew(MonoGCHandle(new_strong_handle(p_object), STRONG_HANDLE));
-}
-
-Ref<MonoGCHandle> MonoGCHandle::create_weak(MonoObject *p_object) {
-
-	return memnew(MonoGCHandle(new_weak_handle(p_object), WEAK_HANDLE));
-}
-
-void MonoGCHandle::release() {
-
+void MonoGCHandleData::release() {
 #ifdef DEBUG_ENABLED
-	CRASH_COND(!released && GDMono::get_singleton() == NULL);
+	CRASH_COND(handle && GDMono::get_singleton() == NULL);
 #endif
 
-	if (!released && GDMono::get_singleton()->is_runtime_initialized()) {
-		free_handle(handle);
-		released = true;
+	if (handle && GDMono::get_singleton()->is_runtime_initialized()) {
+		GDMonoUtils::free_gchandle(handle);
+		handle = 0;
 	}
 }
 
-MonoGCHandle::MonoGCHandle(uint32_t p_handle, HandleType p_handle_type) {
-
-	released = false;
-	weak = p_handle_type == WEAK_HANDLE;
-	handle = p_handle;
+MonoGCHandleData MonoGCHandleData::new_strong_handle(MonoObject *p_object) {
+	return MonoGCHandleData(GDMonoUtils::new_strong_gchandle(p_object), gdmono::GCHandleType::STRONG_HANDLE);
 }
 
-MonoGCHandle::~MonoGCHandle() {
+MonoGCHandleData MonoGCHandleData::new_strong_handle_pinned(MonoObject *p_object) {
+	return MonoGCHandleData(GDMonoUtils::new_strong_gchandle_pinned(p_object), gdmono::GCHandleType::STRONG_HANDLE);
+}
 
-	release();
+MonoGCHandleData MonoGCHandleData::new_weak_handle(MonoObject *p_object) {
+	return MonoGCHandleData(GDMonoUtils::new_weak_gchandle(p_object), gdmono::GCHandleType::WEAK_HANDLE);
+}
+
+Ref<MonoGCHandleRef> MonoGCHandleRef::create_strong(MonoObject *p_object) {
+
+	return memnew(MonoGCHandleRef(MonoGCHandleData::new_strong_handle(p_object)));
+}
+
+Ref<MonoGCHandleRef> MonoGCHandleRef::create_weak(MonoObject *p_object) {
+
+	return memnew(MonoGCHandleRef(MonoGCHandleData::new_weak_handle(p_object)));
 }

--- a/modules/mono/mono_gc_handle.h
+++ b/modules/mono/mono_gc_handle.h
@@ -35,44 +35,79 @@
 
 #include "core/reference.h"
 
-class MonoGCHandle : public Reference {
+namespace gdmono {
 
-	GDCLASS(MonoGCHandle, Reference);
+enum class GCHandleType : char {
+	NIL,
+	STRONG_HANDLE,
+	WEAK_HANDLE
+};
 
-	bool released;
-	bool weak;
+}
 
-	friend class ManagedCallable;
+// Manual release of the GC handle must be done when using this struct
+struct MonoGCHandleData {
 	uint32_t handle;
+	gdmono::GCHandleType type;
 
-public:
-	enum HandleType {
-		STRONG_HANDLE,
-		WEAK_HANDLE
-	};
+	_FORCE_INLINE_ bool is_released() const { return !handle; }
+	_FORCE_INLINE_ bool is_weak() const { return type == gdmono::GCHandleType::WEAK_HANDLE; }
 
-	static uint32_t new_strong_handle(MonoObject *p_object);
-	static uint32_t new_strong_handle_pinned(MonoObject *p_object);
-	static uint32_t new_weak_handle(MonoObject *p_object);
-	static void free_handle(uint32_t p_gchandle);
+	_FORCE_INLINE_ MonoObject *get_target() const { return handle ? mono_gchandle_get_target(handle) : NULL; }
 
-	static Ref<MonoGCHandle> create_strong(MonoObject *p_object);
-	static Ref<MonoGCHandle> create_weak(MonoObject *p_object);
-
-	_FORCE_INLINE_ bool is_released() { return released; }
-	_FORCE_INLINE_ bool is_weak() { return weak; }
-
-	_FORCE_INLINE_ MonoObject *get_target() const { return released ? NULL : mono_gchandle_get_target(handle); }
-
-	_FORCE_INLINE_ void set_handle(uint32_t p_handle, HandleType p_handle_type) {
-		released = false;
-		weak = p_handle_type == WEAK_HANDLE;
-		handle = p_handle;
-	}
 	void release();
 
-	MonoGCHandle(uint32_t p_handle, HandleType p_handle_type);
-	~MonoGCHandle();
+	MonoGCHandleData &operator=(const MonoGCHandleData &p_other) {
+#ifdef DEBUG_ENABLED
+		CRASH_COND(!is_released());
+#endif
+		handle = p_other.handle;
+		type = p_other.type;
+		return *this;
+	}
+
+	MonoGCHandleData(const MonoGCHandleData &) = default;
+
+	MonoGCHandleData() :
+			handle(0),
+			type(gdmono::GCHandleType::NIL) {
+	}
+
+	MonoGCHandleData(uint32_t p_handle, gdmono::GCHandleType p_type) :
+			handle(p_handle),
+			type(p_type) {
+	}
+
+	static MonoGCHandleData new_strong_handle(MonoObject *p_object);
+	static MonoGCHandleData new_strong_handle_pinned(MonoObject *p_object);
+	static MonoGCHandleData new_weak_handle(MonoObject *p_object);
+};
+
+class MonoGCHandleRef : public Reference {
+
+	GDCLASS(MonoGCHandleRef, Reference);
+
+	MonoGCHandleData data;
+
+public:
+	static Ref<MonoGCHandleRef> create_strong(MonoObject *p_object);
+	static Ref<MonoGCHandleRef> create_weak(MonoObject *p_object);
+
+	_FORCE_INLINE_ bool is_released() const { return data.is_released(); }
+	_FORCE_INLINE_ bool is_weak() const { return data.is_weak(); }
+
+	_FORCE_INLINE_ MonoObject *get_target() const { return data.get_target(); }
+
+	void release() { data.release(); }
+
+	_FORCE_INLINE_ void set_handle(uint32_t p_handle, gdmono::GCHandleType p_handle_type) {
+		data = MonoGCHandleData(p_handle, p_handle_type);
+	}
+
+	MonoGCHandleRef(const MonoGCHandleData &p_gc_handle_data) :
+			data(p_gc_handle_data) {
+	}
+	~MonoGCHandleRef() { release(); }
 };
 
 #endif // CSHARP_GC_HANDLE_H

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -186,7 +186,7 @@ void CachedData::clear_godot_api_cache() {
 
 	// End of MarshalUtils methods
 
-	task_scheduler_handle = Ref<MonoGCHandle>();
+	task_scheduler_handle = Ref<MonoGCHandleRef>();
 }
 
 #define GODOT_API_CLASS(m_class) (GDMono::get_singleton()->get_core_api_assembly()->get_class(BINDINGS_NAMESPACE, #m_class))
@@ -316,7 +316,7 @@ void update_godot_api_cache() {
 	// TODO Move to CSharpLanguage::init() and do handle disposal
 	MonoObject *task_scheduler = mono_object_new(mono_domain_get(), GODOT_API_CLASS(GodotTaskScheduler)->get_mono_ptr());
 	GDMonoUtils::runtime_object_init(task_scheduler, GODOT_API_CLASS(GodotTaskScheduler));
-	cached_data.task_scheduler_handle = MonoGCHandle::create_strong(task_scheduler);
+	cached_data.task_scheduler_handle = MonoGCHandleRef::create_strong(task_scheduler);
 
 	cached_data.godot_api_cache_updated = true;
 }

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -156,7 +156,7 @@ struct CachedData {
 
 	// End of MarshalUtils methods
 
-	Ref<MonoGCHandle> task_scheduler_handle;
+	Ref<MonoGCHandleRef> task_scheduler_handle;
 
 	bool corlib_cache_updated;
 	bool godot_api_cache_updated;

--- a/modules/mono/mono_gd/gd_mono_internals.cpp
+++ b/modules/mono/mono_gd/gd_mono_internals.cpp
@@ -75,7 +75,7 @@ void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 		script_binding.inited = true;
 		script_binding.type_name = NATIVE_GDMONOCLASS_NAME(klass);
 		script_binding.wrapper_class = klass;
-		script_binding.gchandle = ref ? MonoGCHandle::create_weak(managed) : MonoGCHandle::create_strong(managed);
+		script_binding.gchandle = ref ? MonoGCHandleData::new_weak_handle(managed) : MonoGCHandleData::new_strong_handle(managed);
 		script_binding.owner = unmanaged;
 
 		if (ref) {
@@ -101,7 +101,7 @@ void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 		return;
 	}
 
-	Ref<MonoGCHandle> gchandle = ref ? MonoGCHandle::create_weak(managed) : MonoGCHandle::create_strong(managed);
+	MonoGCHandleData gchandle = ref ? MonoGCHandleData::new_weak_handle(managed) : MonoGCHandleData::new_strong_handle(managed);
 
 	Ref<CSharpScript> script = CSharpScript::create_for_managed_type(klass, native);
 

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -92,6 +92,11 @@ _FORCE_INLINE_ bool is_main_thread() {
 	return mono_domain_get() != NULL && mono_thread_get_main() == mono_thread_current();
 }
 
+uint32_t new_strong_gchandle(MonoObject *p_object);
+uint32_t new_strong_gchandle_pinned(MonoObject *p_object);
+uint32_t new_weak_gchandle(MonoObject *p_object);
+void free_gchandle(uint32_t p_gchandle);
+
 void runtime_object_init(MonoObject *p_this_obj, GDMonoClass *p_class, MonoException **r_exc = NULL);
 
 bool mono_delegate_equal(MonoDelegate *p_a, MonoDelegate *p_b);

--- a/modules/mono/signal_awaiter_utils.h
+++ b/modules/mono/signal_awaiter_utils.h
@@ -40,7 +40,7 @@ Error gd_mono_connect_signal_awaiter(Object *p_source, const StringName &p_signa
 
 class SignalAwaiterCallable : public CallableCustom {
 	ObjectID target_id;
-	Ref<MonoGCHandle> awaiter_handle;
+	MonoGCHandleData awaiter_handle;
 	StringName signal;
 
 public:
@@ -64,6 +64,7 @@ public:
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	SignalAwaiterCallable(Object *p_target, MonoObject *p_awaiter, const StringName &p_signal);
+	~SignalAwaiterCallable();
 };
 
 class EventSignalCallable : public CallableCustom {


### PR DESCRIPTION
Don't store GC handles for C# script instances and instance bindings as `Ref<MonoGCHandle>`; store the raw data instead. Initially this was not possible as we needed to store a `Variant`, but this has not been the case for a looong time yet the stored type was never updated.

~~We're still using `Ref<MonoGCHandle>` to store GC handles for `SignalAwaiter`. We need the awaiter to stay alive as long as the signal is connected to our slot, so we keep a strong reference and add it as a "bind" argument to the connection. The strong reference must be released once the signal is disconnected from our slot. As "bind" arguments are `Variant` the only way to do this is by using `Ref<>`.~~ This one has been addressed now, thanks to Callable.

We also plan to make it possible to pass any managed object as argument where Variant is expected (specially useful for user signals). Right now, this would mean wrapping them in `Ref<MonoGCHandle>` as well.

These last two wouldn't be a problem if we could extend `Variant` on mono builds to support GC handles as an additional type, but last time I proposed this it was rejected.
Alternatively, the signal awaiter one could be avoided if the target object could get a callback when the signal is disconnected from its slot. But that still leaves us with the second problem.
