### PR TITLE
Code formatting for the Mono module

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.BuildLogger/GodotBuildLogger.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.BuildLogger/GodotBuildLogger.cs
@@ -18,7 +18,7 @@ namespace GodotTools.BuildLogger
             if (null == Parameters)
                 throw new LoggerException("Log directory was not set.");
 
-            var parameters = Parameters.Split(new[] {';'});
+            var parameters = Parameters.Split(new[] { ';' });
 
             string logDir = parameters[0];
 

--- a/modules/mono/editor/GodotTools/GodotTools.BuildLogger/GodotTools.BuildLogger.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.BuildLogger/GodotTools.BuildLogger.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
@@ -26,7 +26,7 @@ namespace GodotTools.Core
 
             path = path.Replace('\\', '/');
 
-            string[] parts = path.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
+            string[] parts = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
             path = string.Join(Path.DirectorySeparatorChar.ToString(), parts).Trim();
 
@@ -44,7 +44,7 @@ namespace GodotTools.Core
 
         public static string CsvEscape(this string value, char delimiter = ',')
         {
-            bool hasSpecialChar = value.IndexOfAny(new char[] {'\"', '\n', '\r', delimiter}) != -1;
+            bool hasSpecialChar = value.IndexOfAny(new char[] { '\"', '\n', '\r', delimiter }) != -1;
 
             if (hasSpecialChar)
                 return "\"" + value.Replace("\"", "\"\"") + "\"";
@@ -54,8 +54,8 @@ namespace GodotTools.Core
 
         public static string ToSafeDirName(this string dirName, bool allowDirSeparator)
         {
-            var invalidChars = new List<string> {":", "*", "?", "\"", "<", ">", "|"};
-            
+            var invalidChars = new List<string> { ":", "*", "?", "\"", "<", ">", "|" };
+
             if (allowDirSeparator)
             {
                 // Directory separators are allowed, but disallow ".." to avoid going up the filesystem

--- a/modules/mono/editor/GodotTools/GodotTools.IdeConnection/GodotIdeClient.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeConnection/GodotIdeClient.cs
@@ -106,7 +106,7 @@ namespace GodotTools.IdeConnection
             try
             {
                 Logger.LogInfo("Connecting to Godot Ide Server");
-                
+
                 tcpClient.Connect(IPAddress.Loopback, GodotIdeMetadata.Port);
 
                 Logger.LogInfo("Connection open with Godot Ide Server");
@@ -130,7 +130,7 @@ namespace GodotTools.IdeConnection
         public void Start()
         {
             Logger.LogInfo("Starting Godot Ide Client");
-            
+
             fsWatcher.Changed += OnMetaFileChanged;
             fsWatcher.Deleted += OnMetaFileDeleted;
             fsWatcher.EnableRaisingEvents = true;

--- a/modules/mono/editor/GodotTools/GodotTools.IdeConnection/GodotIdeConnection.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeConnection/GodotIdeConnection.cs
@@ -149,7 +149,7 @@ namespace GodotTools.IdeConnection
         public bool WriteMessage(Message message)
         {
             Logger.LogDebug($"Sending message {message}");
-            
+
             var messageComposer = new MessageComposer();
 
             messageComposer.AddArgument(message.Id);
@@ -201,7 +201,7 @@ namespace GodotTools.IdeConnection
 
             clientReader?.Dispose();
             clientWriter?.Dispose();
-            ((IDisposable) tcpClient)?.Dispose();
+            ((IDisposable)tcpClient)?.Dispose();
         }
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.IdeConnection/GodotTools.IdeConnection.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeConnection/GodotTools.IdeConnection.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools.IdeConnection/MessageComposer.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeConnection/MessageComposer.cs
@@ -22,14 +22,14 @@ namespace GodotTools.IdeConnection
             if (quoted)
             {
                 stringBuilder.Append('"');
-                
+
                 foreach (char @char in argument)
                 {
                     if (CharsToEscape.Contains(@char))
                         stringBuilder.Append('\\');
                     stringBuilder.Append(@char);
                 }
-                
+
                 stringBuilder.Append('"');
             }
             else

--- a/modules/mono/editor/GodotTools/GodotTools.IdeConnection/MessageParser.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeConnection/MessageParser.cs
@@ -37,7 +37,7 @@ namespace GodotTools.IdeConnection
                 while (i < messageLine.Length)
                 {
                     @char = messageLine[i];
-                    
+
                     if (quoted && @char == '"')
                     {
                         i++;
@@ -60,10 +60,10 @@ namespace GodotTools.IdeConnection
                     {
                         stringBuilder.Append(@char);
                     }
-                    
+
                     i++;
                 }
-                
+
                 arguments.Add(stringBuilder.ToString());
                 stringBuilder.Clear();
 

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -26,8 +26,8 @@ namespace GodotTools.ProjectEditor
             mainGroup.SetProperty("BaseIntermediateOutputPath", "obj");
 
             GenAssemblyInfoFile(root, dir, CoreApiProjectName,
-                new[] {"[assembly: InternalsVisibleTo(\"" + EditorApiProjectName + "\")]"},
-                new[] {"System.Runtime.CompilerServices"});
+                new[] { "[assembly: InternalsVisibleTo(\"" + EditorApiProjectName + "\")]" },
+                new[] { "System.Runtime.CompilerServices" });
 
             foreach (var item in compileItems)
             {

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/packages.config
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DotNet.Glob" version="2.1.1" targetFramework="net45" />
 </packages>

--- a/modules/mono/editor/GodotTools/GodotTools/BottomPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/BottomPanel.cs
@@ -34,7 +34,7 @@ namespace GodotTools
 
             for (int i = 0; i < buildTabs.GetChildCount(); i++)
             {
-                var tab = (BuildTab) buildTabs.GetChild(i);
+                var tab = (BuildTab)buildTabs.GetChild(i);
 
                 if (tab == null)
                     continue;
@@ -120,7 +120,7 @@ namespace GodotTools
             if (currentTab < 0 || currentTab >= buildTabs.GetTabCount())
                 throw new InvalidOperationException("No tab selected");
 
-            var buildTab = (BuildTab) buildTabs.GetChild(currentTab);
+            var buildTab = (BuildTab)buildTabs.GetChild(currentTab);
             buildTab.WarningsVisible = pressed;
             buildTab.UpdateIssuesList();
         }
@@ -132,7 +132,7 @@ namespace GodotTools
             if (currentTab < 0 || currentTab >= buildTabs.GetTabCount())
                 throw new InvalidOperationException("No tab selected");
 
-            var buildTab = (BuildTab) buildTabs.GetChild(currentTab);
+            var buildTab = (BuildTab)buildTabs.GetChild(currentTab);
             buildTab.ErrorsVisible = pressed;
             buildTab.UpdateIssuesList();
         }
@@ -193,7 +193,7 @@ namespace GodotTools
 
             int selectedItem = selectedItems[0];
 
-            var buildTab = (BuildTab) buildTabs.GetTabControl(selectedItem);
+            var buildTab = (BuildTab)buildTabs.GetTabControl(selectedItem);
 
             OS.ShellOpen(Path.Combine(buildTab.BuildInfo.LogsDirPath, BuildManager.MsBuildLogFileName));
         }
@@ -249,14 +249,14 @@ namespace GodotTools
 
             var editorBaseControl = editorInterface.GetBaseControl();
 
-            SizeFlagsVertical = (int) SizeFlags.ExpandFill;
+            SizeFlagsVertical = (int)SizeFlags.ExpandFill;
             SetAnchorsAndMarginsPreset(LayoutPreset.Wide);
 
             panelTabs = new TabContainer
             {
                 TabAlign = TabContainer.TabAlignEnum.Left,
                 RectMinSize = new Vector2(0, 228) * EditorScale,
-                SizeFlagsVertical = (int) SizeFlags.ExpandFill
+                SizeFlagsVertical = (int)SizeFlags.ExpandFill
             };
             panelTabs.AddStyleboxOverride("panel", editorBaseControl.GetStylebox("DebuggerPanel", "EditorStyles"));
             panelTabs.AddStyleboxOverride("tab_fg", editorBaseControl.GetStylebox("DebuggerTabFG", "EditorStyles"));
@@ -268,11 +268,11 @@ namespace GodotTools
                 panelBuildsTab = new VBoxContainer
                 {
                     Name = "Builds".TTR(),
-                    SizeFlagsHorizontal = (int) SizeFlags.ExpandFill
+                    SizeFlagsHorizontal = (int)SizeFlags.ExpandFill
                 };
                 panelTabs.AddChild(panelBuildsTab);
 
-                var toolBarHBox = new HBoxContainer {SizeFlagsHorizontal = (int) SizeFlags.ExpandFill};
+                var toolBarHBox = new HBoxContainer { SizeFlagsHorizontal = (int)SizeFlags.ExpandFill };
                 panelBuildsTab.AddChild(toolBarHBox);
 
                 var buildProjectBtn = new Button
@@ -320,12 +320,12 @@ namespace GodotTools
 
                 var hsc = new HSplitContainer
                 {
-                    SizeFlagsHorizontal = (int) SizeFlags.ExpandFill,
-                    SizeFlagsVertical = (int) SizeFlags.ExpandFill
+                    SizeFlagsHorizontal = (int)SizeFlags.ExpandFill,
+                    SizeFlagsVertical = (int)SizeFlags.ExpandFill
                 };
                 panelBuildsTab.AddChild(hsc);
 
-                buildTabsList = new ItemList {SizeFlagsHorizontal = (int) SizeFlags.ExpandFill};
+                buildTabsList = new ItemList { SizeFlagsHorizontal = (int)SizeFlags.ExpandFill };
                 buildTabsList.Connect("item_selected", this, nameof(_BuildTabsItemSelected));
                 buildTabsList.Connect("nothing_selected", this, nameof(_BuildTabsNothingSelected));
                 hsc.AddChild(buildTabsList);
@@ -333,7 +333,7 @@ namespace GodotTools
                 buildTabs = new TabContainer
                 {
                     TabAlign = TabContainer.TabAlignEnum.Left,
-                    SizeFlagsHorizontal = (int) SizeFlags.ExpandFill,
+                    SizeFlagsHorizontal = (int)SizeFlags.ExpandFill,
                     TabsVisible = false
                 };
                 hsc.AddChild(buildTabs);

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -46,7 +46,7 @@ namespace GodotTools.Build
             {
                 if (OS.IsWindows)
                 {
-                    return (BuildManager.BuildTool) EditorSettings.GetSetting("mono/builds/build_tool")
+                    return (BuildManager.BuildTool)EditorSettings.GetSetting("mono/builds/build_tool")
                            == BuildManager.BuildTool.MsBuildMono;
                 }
 
@@ -55,7 +55,7 @@ namespace GodotTools.Build
         }
 
         private static bool PrintBuildOutput =>
-            (bool) EditorSettings.GetSetting("mono/builds/print_build_output");
+            (bool)EditorSettings.GetSetting("mono/builds/print_build_output");
 
         private static Process LaunchBuild(string solution, string config, string loggerOutputDir, IEnumerable<string> customProperties = null)
         {
@@ -90,7 +90,7 @@ namespace GodotTools.Build
             // Needed when running from Developer Command Prompt for VS
             RemovePlatformVariable(startInfo.EnvironmentVariables);
 
-            var process = new Process {StartInfo = startInfo};
+            var process = new Process { StartInfo = startInfo };
 
             process.Start();
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
@@ -19,7 +19,7 @@ namespace GodotTools.Build
         public static string FindMsBuild()
         {
             var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
-            var buildTool = (BuildManager.BuildTool) editorSettings.GetSetting("mono/builds/build_tool");
+            var buildTool = (BuildManager.BuildTool)editorSettings.GetSetting("mono/builds/build_tool");
 
             if (OS.IsWindows)
             {
@@ -136,11 +136,11 @@ namespace GodotTools.Build
             string vsWherePath = Environment.GetEnvironmentVariable(Internal.GodotIs32Bits() ? "ProgramFiles" : "ProgramFiles(x86)");
             vsWherePath += "\\Microsoft Visual Studio\\Installer\\vswhere.exe";
 
-            var vsWhereArgs = new[] {"-latest", "-products", "*", "-requires", "Microsoft.Component.MSBuild"};
+            var vsWhereArgs = new[] { "-latest", "-products", "*", "-requires", "Microsoft.Component.MSBuild" };
 
             var outputArray = new Godot.Collections.Array<string>();
             int exitCode = Godot.OS.Execute(vsWherePath, vsWhereArgs,
-                blocking: true, output: (Godot.Collections.Array) outputArray);
+                blocking: true, output: (Godot.Collections.Array)outputArray);
 
             if (exitCode != 0)
                 return string.Empty;

--- a/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
@@ -172,7 +172,7 @@ namespace GodotTools
             }
 
             var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
-            var buildTool = (BuildTool) editorSettings.GetSetting("mono/builds/build_tool");
+            var buildTool = (BuildTool)editorSettings.GetSetting("mono/builds/build_tool");
 
             using (var pr = new EditorProgress("mono_project_debug_build", "Building project solution...", 1))
             {

--- a/modules/mono/editor/GodotTools/GodotTools/BuildTab.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/BuildTab.cs
@@ -113,7 +113,7 @@ namespace GodotTools
                 throw new IndexOutOfRangeException("Item list index out of range");
 
             // Get correct issue idx from issue list
-            int issueIndex = (int) issuesList.GetItemMetadata(idx);
+            int issueIndex = (int)issuesList.GetItemMetadata(idx);
 
             if (idx < 0 || idx >= issues.Count)
                 throw new IndexOutOfRangeException("Issue index out of range");
@@ -134,7 +134,7 @@ namespace GodotTools
 
             if (file.StartsWith("res://"))
             {
-                var script = (Script) ResourceLoader.Load(file, typeHint: Internal.CSharpLanguageType);
+                var script = (Script)ResourceLoader.Load(file, typeHint: Internal.CSharpLanguageType);
 
                 if (script != null && Internal.ScriptEditorEdit(script, issue.Line, issue.Column))
                     Internal.EditorNodeShowScriptScreen();
@@ -220,7 +220,7 @@ namespace GodotTools
 
             issuesList.Clear();
 
-            var issue = new BuildIssue {Message = cause, Warning = false};
+            var issue = new BuildIssue { Message = cause, Warning = false };
 
             ErrorCount += 1;
             issues.Add(issue);
@@ -250,7 +250,7 @@ namespace GodotTools
         {
             base._Ready();
 
-            issuesList = new ItemList {SizeFlagsVertical = (int) SizeFlags.ExpandFill};
+            issuesList = new ItemList { SizeFlagsVertical = (int)SizeFlags.ExpandFill };
             issuesList.Connect("item_activated", this, nameof(_IssueActivated));
             AddChild(issuesList);
         }

--- a/modules/mono/editor/GodotTools/GodotTools/CsProjOperations.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/CsProjOperations.cs
@@ -26,7 +26,7 @@ namespace GodotTools
 
         public static void AddItem(string projectPath, string itemType, string include)
         {
-            if (!(bool) GlobalDef("mono/project/auto_update_project", true))
+            if (!(bool)GlobalDef("mono/project/auto_update_project", true))
                 return;
 
             ProjectUtils.AddItemToProjectChecked(projectPath, itemType, include);
@@ -49,7 +49,7 @@ namespace GodotTools
         private static ulong ConvertToTimestamp(this DateTime value)
         {
             TimeSpan elapsedTime = value - Epoch;
-            return (ulong) elapsedTime.TotalSeconds;
+            return (ulong)elapsedTime.TotalSeconds;
         }
 
         public static void GenerateScriptsMetadata(string projectPath, string outputPath)
@@ -68,7 +68,7 @@ namespace GodotTools
 
                 if (oldDict.TryGetValue(projectIncludeFile, out var oldFileVar))
                 {
-                    var oldFileDict = (Dictionary) oldFileVar;
+                    var oldFileDict = (Dictionary)oldFileVar;
 
                     if (ulong.TryParse(oldFileDict["modified_time"] as string, out ulong storedModifiedTime))
                     {
@@ -108,7 +108,7 @@ namespace GodotTools
                 if (classDict.Count == 0)
                     continue; // Not found
 
-                newDict[projectIncludeFile] = new Dictionary {["modified_time"] = $"{modifiedTime}", ["class"] = classDict};
+                newDict[projectIncludeFile] = new Dictionary { ["modified_time"] = $"{modifiedTime}", ["class"] = classDict };
             }
 
             if (newDict.Count > 0)

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -54,7 +54,7 @@ namespace GodotTools.Export
 
             // TODO What if the source file is not part of the game's C# project
 
-            bool includeScriptsContent = (bool) ProjectSettings.GetSetting("mono/export/include_scripts_content");
+            bool includeScriptsContent = (bool)ProjectSettings.GetSetting("mono/export/include_scripts_content");
 
             if (!includeScriptsContent)
             {
@@ -114,7 +114,7 @@ namespace GodotTools.Export
 
             var dependencies = new Godot.Collections.Dictionary<string, string>();
 
-            var projectDllName = (string) ProjectSettings.GetSetting("application/config/name");
+            var projectDllName = (string)ProjectSettings.GetSetting("application/config/name");
             if (projectDllName.Empty())
             {
                 projectDllName = "UnnamedProject";
@@ -147,7 +147,7 @@ namespace GodotTools.Export
             string apiConfig = isDebug ? "Debug" : "Release";
             string resAssembliesDir = Path.Combine(GodotSharpDirs.ResAssembliesBaseDir, apiConfig);
 
-            bool assembliesInsidePck = (bool) ProjectSettings.GetSetting("mono/export/export_assemblies_inside_pck") || outputDataDir == null;
+            bool assembliesInsidePck = (bool)ProjectSettings.GetSetting("mono/export/export_assemblies_inside_pck") || outputDataDir == null;
 
             if (!assembliesInsidePck)
             {
@@ -174,7 +174,7 @@ namespace GodotTools.Export
 
             // AOT
 
-            if ((bool) ProjectSettings.GetSetting("mono/export/aot/enabled"))
+            if ((bool)ProjectSettings.GetSetting("mono/export/aot/enabled"))
             {
                 AotCompileDependencies(features, platform, isDebug, outputDir, outputDataDir, dependencies);
             }
@@ -336,7 +336,7 @@ namespace GodotTools.Export
 
                         AotCompileAssembly(platform, isDebug, data, assemblyPath, outputFilePathForThisAbi);
 
-                        AddSharedObject(outputFilePathForThisAbi, tags: new[] {abi});
+                        AddSharedObject(outputFilePathForThisAbi, tags: new[] { abi });
                     }
                 }
                 else
@@ -377,7 +377,7 @@ namespace GodotTools.Export
 
             string compilerCommand = Path.Combine(monoCrossBin, $"{toolPrefix}{monoExeName}{exeExt}");
 
-            bool fullAot = (bool) ProjectSettings.GetSetting("mono/export/aot/full_aot");
+            bool fullAot = (bool)ProjectSettings.GetSetting("mono/export/aot/full_aot");
 
             string EscapeOption(string option) => option.Contains(',') ? $"\"{option}\"" : option;
             string OptionsToString(IEnumerable<string> options) => string.Join(",", options.Select(EscapeOption));
@@ -394,7 +394,7 @@ namespace GodotTools.Export
             {
                 string abi = data["abi"];
 
-                string androidToolchain = (string) ProjectSettings.GetSetting("mono/export/aot/android_toolchain_path");
+                string androidToolchain = (string)ProjectSettings.GetSetting("mono/export/aot/android_toolchain_path");
 
                 if (string.IsNullOrEmpty(androidToolchain))
                 {
@@ -419,13 +419,13 @@ namespace GodotTools.Export
                 aotOptions.Add("tool-prefix=" + Path.Combine(androidToolchain, "bin", androidToolPrefixes[abi]));
 
                 string triple = GetAndroidTriple(abi);
-                aotOptions.Add ($"mtriple={triple}");
+                aotOptions.Add($"mtriple={triple}");
             }
 
             aotOptions.Add($"outfile={outputFilePath}");
 
-            var extraAotOptions = (string[]) ProjectSettings.GetSetting("mono/export/aot/extra_aot_options");
-            var extraOptimizerOptions = (string[]) ProjectSettings.GetSetting("mono/export/aot/extra_optimizer_options");
+            var extraAotOptions = (string[])ProjectSettings.GetSetting("mono/export/aot/extra_aot_options");
+            var extraOptimizerOptions = (string[])ProjectSettings.GetSetting("mono/export/aot/extra_optimizer_options");
 
             if (extraAotOptions.Length > 0)
                 aotOptions.AddRange(extraAotOptions);
@@ -575,7 +575,7 @@ namespace GodotTools.Export
         private static bool PlatformHasTemplateDir(string platform)
         {
             // OSX export templates are contained in a zip, so we place our custom template inside it and let Godot do the rest.
-            return !new[] {OS.Platforms.OSX, OS.Platforms.Android, OS.Platforms.HTML5}.Contains(platform);
+            return !new[] { OS.Platforms.OSX, OS.Platforms.Android, OS.Platforms.HTML5 }.Contains(platform);
         }
 
         private static string DeterminePlatformFromFeatures(IEnumerable<string> features)
@@ -623,7 +623,7 @@ namespace GodotTools.Export
         /// </summary>
         private static bool PlatformRequiresCustomBcl(string platform)
         {
-            if (new[] {OS.Platforms.Android, OS.Platforms.HTML5}.Contains(platform))
+            if (new[] { OS.Platforms.Android, OS.Platforms.HTML5 }.Contains(platform))
                 return true;
 
             // The 'net_4_x' BCL is not compatible between Windows and the other platforms.
@@ -663,7 +663,7 @@ namespace GodotTools.Export
         {
             get
             {
-                var appName = (string) ProjectSettings.GetSetting("application/config/name");
+                var appName = (string)ProjectSettings.GetSetting("application/config/name");
                 string appNameSafe = appName.ToSafeDirName(allowDirSeparator: false);
                 return $"data_{appNameSafe}";
             }

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -44,7 +44,7 @@ namespace GodotTools
                 string resourceDir = ProjectSettings.GlobalizePath("res://");
 
                 string path = resourceDir;
-                string name = (string) ProjectSettings.GetSetting("application/config/name");
+                string name = (string)ProjectSettings.GetSetting("application/config/name");
                 if (name.Empty())
                     name = "UnnamedProject";
 
@@ -61,7 +61,7 @@ namespace GodotTools
                     {
                         Guid = guid,
                         PathRelativeToSolution = name + ".csproj",
-                        Configs = new List<string> {"Debug", "Release", "Tools"}
+                        Configs = new List<string> { "Debug", "Release", "Tools" }
                     };
 
                     solution.AddNewProject(name, projectInfo);
@@ -110,20 +110,20 @@ namespace GodotTools
 
         private void _RemoveCreateSlnMenuOption()
         {
-            menuPopup.RemoveItem(menuPopup.GetItemIndex((int) MenuOptions.CreateSln));
+            menuPopup.RemoveItem(menuPopup.GetItemIndex((int)MenuOptions.CreateSln));
             bottomPanelBtn.Show();
         }
 
         private void _ShowAboutDialog()
         {
-            bool showOnStart = (bool) editorSettings.GetSetting("mono/editor/show_info_on_start");
+            bool showOnStart = (bool)editorSettings.GetSetting("mono/editor/show_info_on_start");
             aboutDialogCheckBox.Pressed = showOnStart;
             aboutDialog.PopupCenteredMinsize();
         }
 
         private void _ToggleAboutDialogOnStart(bool enabled)
         {
-            bool showOnStart = (bool) editorSettings.GetSetting("mono/editor/show_info_on_start");
+            bool showOnStart = (bool)editorSettings.GetSetting("mono/editor/show_info_on_start");
             if (showOnStart != enabled)
                 editorSettings.SetSetting("mono/editor/show_info_on_start", enabled);
         }
@@ -160,7 +160,7 @@ namespace GodotTools
 
             if (what == NotificationReady)
             {
-                bool showInfoDialog = (bool) editorSettings.GetSetting("mono/editor/show_info_on_start");
+                bool showInfoDialog = (bool)editorSettings.GetSetting("mono/editor/show_info_on_start");
                 if (showInfoDialog)
                 {
                     aboutDialog.PopupExclusive = true;
@@ -194,7 +194,7 @@ namespace GodotTools
         [UsedImplicitly]
         public Error OpenInExternalEditor(Script script, int line, int col)
         {
-            var editor = (ExternalEditorId) editorSettings.GetSetting("mono/editor/external_editor");
+            var editor = (ExternalEditorId)editorSettings.GetSetting("mono/editor/external_editor");
 
             switch (editor)
             {
@@ -318,7 +318,7 @@ namespace GodotTools
         [UsedImplicitly]
         public bool OverridesExternalEditor()
         {
-            return (ExternalEditorId) editorSettings.GetSetting("mono/editor/external_editor") != ExternalEditorId.None;
+            return (ExternalEditorId)editorSettings.GetSetting("mono/editor/external_editor") != ExternalEditorId.None;
         }
 
         public override bool Build()
@@ -346,7 +346,7 @@ namespace GodotTools
 
             bottomPanelBtn = AddControlToBottomPanel(BottomPanel, "Mono".TTR());
 
-            AddChild(new HotReloadAssemblyWatcher {Name = "HotReloadAssemblyWatcher"});
+            AddChild(new HotReloadAssemblyWatcher { Name = "HotReloadAssemblyWatcher" });
 
             menuPopup = new PopupMenu();
             menuPopup.Hide();
@@ -356,7 +356,7 @@ namespace GodotTools
 
             // TODO: Remove or edit this info dialog once Mono support is no longer in alpha
             {
-                menuPopup.AddItem("About C# support".TTR(), (int) MenuOptions.AboutCSharp);
+                menuPopup.AddItem("About C# support".TTR(), (int)MenuOptions.AboutCSharp);
                 aboutDialog = new AcceptDialog();
                 editorBaseControl.AddChild(aboutDialog);
                 aboutDialog.WindowTitle = "Important: C# support is not feature-complete";
@@ -379,7 +379,7 @@ namespace GodotTools
                 var aboutLabel = new Label();
                 aboutHBox.AddChild(aboutLabel);
                 aboutLabel.RectMinSize = new Vector2(600, 150) * EditorScale;
-                aboutLabel.SizeFlagsVertical = (int) Control.SizeFlags.ExpandFill;
+                aboutLabel.SizeFlagsVertical = (int)Control.SizeFlags.ExpandFill;
                 aboutLabel.Autowrap = true;
                 aboutLabel.Text =
                     "C# support in Godot Engine is in late alpha stage and, while already usable, " +
@@ -394,7 +394,7 @@ namespace GodotTools
                 EditorDef("mono/editor/show_info_on_start", true);
 
                 // CheckBox in main container
-                aboutDialogCheckBox = new CheckBox {Text = "Show this warning when starting the editor"};
+                aboutDialogCheckBox = new CheckBox { Text = "Show this warning when starting the editor" };
                 aboutDialogCheckBox.Connect("toggled", this, nameof(_ToggleAboutDialogOnStart));
                 aboutVBox.AddChild(aboutDialogCheckBox);
             }
@@ -407,7 +407,7 @@ namespace GodotTools
             else
             {
                 bottomPanelBtn.Hide();
-                menuPopup.AddItem("Create C# solution".TTR(), (int) MenuOptions.CreateSln);
+                menuPopup.AddItem("Create C# solution".TTR(), (int)MenuOptions.CreateSln);
             }
 
             menuPopup.Connect("id_pressed", this, nameof(_MenuOptionPressed));
@@ -428,22 +428,22 @@ namespace GodotTools
 
             if (OS.IsWindows)
             {
-                settingsHintStr += $",MonoDevelop:{(int) ExternalEditorId.MonoDevelop}" +
-                                   $",Visual Studio Code:{(int) ExternalEditorId.VsCode}" +
-                                   $",JetBrains Rider:{(int) ExternalEditorId.Rider}";
+                settingsHintStr += $",MonoDevelop:{(int)ExternalEditorId.MonoDevelop}" +
+                                   $",Visual Studio Code:{(int)ExternalEditorId.VsCode}" +
+                                   $",JetBrains Rider:{(int)ExternalEditorId.Rider}";
             }
             else if (OS.IsOSX)
             {
-                settingsHintStr += $",Visual Studio:{(int) ExternalEditorId.VisualStudioForMac}" +
-                                   $",MonoDevelop:{(int) ExternalEditorId.MonoDevelop}" +
-                                   $",Visual Studio Code:{(int) ExternalEditorId.VsCode}" +
-                                   $",JetBrains Rider:{(int) ExternalEditorId.Rider}";
+                settingsHintStr += $",Visual Studio:{(int)ExternalEditorId.VisualStudioForMac}" +
+                                   $",MonoDevelop:{(int)ExternalEditorId.MonoDevelop}" +
+                                   $",Visual Studio Code:{(int)ExternalEditorId.VsCode}" +
+                                   $",JetBrains Rider:{(int)ExternalEditorId.Rider}";
             }
             else if (OS.IsUnixLike())
             {
-                settingsHintStr += $",MonoDevelop:{(int) ExternalEditorId.MonoDevelop}" +
-                                   $",Visual Studio Code:{(int) ExternalEditorId.VsCode}" +
-                                   $",JetBrains Rider:{(int) ExternalEditorId.Rider}";
+                settingsHintStr += $",MonoDevelop:{(int)ExternalEditorId.MonoDevelop}" +
+                                   $",Visual Studio Code:{(int)ExternalEditorId.VsCode}" +
+                                   $",JetBrains Rider:{(int)ExternalEditorId.Rider}";
             }
 
             editorSettings.AddPropertyInfo(new Godot.Collections.Dictionary

--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
@@ -38,7 +38,7 @@ namespace GodotTools
             watchTimer = new Timer
             {
                 OneShot = false,
-                WaitTime = (float) EditorDef("mono/assembly_watch_interval_sec", 0.5)
+                WaitTime = (float)EditorDef("mono/assembly_watch_interval_sec", 0.5)
             };
             watchTimer.Connect("timeout", this, nameof(TimerTimeout));
             AddChild(watchTimer);

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -64,7 +64,7 @@ namespace GodotTools.Ides
 
         private void LaunchIde()
         {
-            var editor = (ExternalEditorId) GodotSharpEditor.Instance.GetEditorInterface()
+            var editor = (ExternalEditorId)GodotSharpEditor.Instance.GetEditorInterface()
                 .GetEditorSettings().GetSetting("mono/editor/external_editor");
 
             switch (editor)

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeServer.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeServer.cs
@@ -45,7 +45,7 @@ namespace GodotTools.Ides
             listener = new TcpListener(new IPEndPoint(IPAddress.Loopback, port: 0));
             listener.Start();
 
-            int port = ((IPEndPoint) listener.Server.LocalEndPoint).Port;
+            int port = ((IPEndPoint)listener.Server.LocalEndPoint).Port;
             using (var metaFileWriter = new StreamWriter(metaFile, Encoding.UTF8))
             {
                 metaFileWriter.WriteLine(port);
@@ -57,7 +57,7 @@ namespace GodotTools.Ides
 
         public void StartServer()
         {
-            var serverThread = new Thread(RunServerThread) {Name = "Godot Ide Connection Server"};
+            var serverThread = new Thread(RunServerThread) { Name = "Godot Ide Connection Server" };
             serverThread.Start();
         }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/.editorconfig
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/.editorconfig
@@ -1,6 +1,0 @@
-root = true
-
-[*]
-indent_style = space
-indent_size = 2
-end_of_line = lf

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,403 +14,403 @@ using OS = GodotTools.Utils.OS;
 
 namespace GodotTools.Ides.Rider
 {
-  /// <summary>
-  /// This code is a modified version of the JetBrains resharper-unity plugin listed under Apache License 2.0 license:
-  /// https://github.com/JetBrains/resharper-unity/blob/master/unity/JetBrains.Rider.Unity.Editor/EditorPlugin/RiderPathLocator.cs
-  /// </summary>
-  public static class RiderPathLocator
-  {
-    public static RiderInfo[] GetAllRiderPaths()
+    /// <summary>
+    /// This code is a modified version of the JetBrains resharper-unity plugin listed under Apache License 2.0 license:
+    /// https://github.com/JetBrains/resharper-unity/blob/master/unity/JetBrains.Rider.Unity.Editor/EditorPlugin/RiderPathLocator.cs
+    /// </summary>
+    public static class RiderPathLocator
     {
-      try
-      {
-        if (OS.IsWindows)
+        public static RiderInfo[] GetAllRiderPaths()
         {
-          return CollectRiderInfosWindows();
-        }
-        if (OS.IsOSX)
-        {
-          return CollectRiderInfosMac();
-        }
-        if (OS.IsUnixLike())
-        {
-          return CollectAllRiderPathsLinux();
-        }
-        throw new Exception("Unexpected OS.");
-      }
-      catch (Exception e)
-      {
-        GD.PushWarning(e.Message);
-      }
-
-      return new RiderInfo[0];
-    }
-
-    private static RiderInfo[] CollectAllRiderPathsLinux()
-    {
-      var installInfos = new List<RiderInfo>();
-      var home = Environment.GetEnvironmentVariable("HOME");
-      if (!string.IsNullOrEmpty(home))
-      {
-        var toolboxRiderRootPath = GetToolboxBaseDir();
-        installInfos.AddRange(CollectPathsFromToolbox(toolboxRiderRootPath, "bin", "rider.sh", false)
-          .Select(a => new RiderInfo(a, true)).ToList());
-
-        //$Home/.local/share/applications/jetbrains-rider.desktop
-        var shortcut = new FileInfo(Path.Combine(home, @".local/share/applications/jetbrains-rider.desktop"));
-
-        if (shortcut.Exists)
-        {
-          var lines = File.ReadAllLines(shortcut.FullName);
-          foreach (var line in lines)
-          {
-            if (!line.StartsWith("Exec=\""))
-              continue;
-            var path = line.Split('"').Where((item, index) => index == 1).SingleOrDefault();
-            if (string.IsNullOrEmpty(path))
-              continue;
-
-            if (installInfos.Any(a => a.Path == path)) // avoid adding similar build as from toolbox
-              continue;
-            installInfos.Add(new RiderInfo(path, false));
-          }
-        }
-      }
-
-      // snap install
-      var snapInstallPath = "/snap/rider/current/bin/rider.sh";
-      if (new FileInfo(snapInstallPath).Exists)
-        installInfos.Add(new RiderInfo(snapInstallPath, false));
-      
-      return installInfos.ToArray();
-    }
-
-    private static RiderInfo[] CollectRiderInfosMac()
-    {
-      var installInfos = new List<RiderInfo>();
-      // "/Applications/*Rider*.app"
-      var folder = new DirectoryInfo("/Applications");
-      if (folder.Exists)
-      {
-        installInfos.AddRange(folder.GetDirectories("*Rider*.app")
-          .Select(a => new RiderInfo(a.FullName, false))
-          .ToList());
-      }
-
-      // /Users/user/Library/Application Support/JetBrains/Toolbox/apps/Rider/ch-1/181.3870.267/Rider EAP.app
-      var toolboxRiderRootPath = GetToolboxBaseDir();
-      var paths = CollectPathsFromToolbox(toolboxRiderRootPath, "", "Rider*.app", true)
-        .Select(a => new RiderInfo(a, true));
-      installInfos.AddRange(paths);
-
-      return installInfos.ToArray();
-    }
-
-    private static RiderInfo[] CollectRiderInfosWindows()
-    {
-      var installInfos = new List<RiderInfo>();
-      var toolboxRiderRootPath = GetToolboxBaseDir();
-      var installPathsToolbox = CollectPathsFromToolbox(toolboxRiderRootPath, "bin", "rider64.exe", false).ToList();
-      installInfos.AddRange(installPathsToolbox.Select(a => new RiderInfo(a, true)).ToList());
-      
-      var installPaths = new List<string>();
-      const string registryKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
-      CollectPathsFromRegistry(registryKey, installPaths);
-      const string wowRegistryKey = @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall";
-      CollectPathsFromRegistry(wowRegistryKey, installPaths);
-      
-      installInfos.AddRange(installPaths.Select(a => new RiderInfo(a, false)).ToList());
-
-      return installInfos.ToArray();
-    }
-
-    private static string GetToolboxBaseDir()
-    {   
-      if (OS.IsWindows)
-      {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(localAppData, @"JetBrains\Toolbox\apps\Rider");
-      }
-
-      if (OS.IsOSX)
-      {
-        var home = Environment.GetEnvironmentVariable("HOME");
-        if (!string.IsNullOrEmpty(home))
-        {
-          return Path.Combine(home, @"Library/Application Support/JetBrains/Toolbox/apps/Rider");
-        }
-      }
-
-      if (OS.IsUnixLike())
-      {
-        var home = Environment.GetEnvironmentVariable("HOME");
-        if (!string.IsNullOrEmpty(home))
-        {
-          return Path.Combine(home, @".local/share/JetBrains/Toolbox/apps/Rider");
-        }
-      }
-
-      throw new Exception("Unexpected OS.");
-    }
-    
-    internal static ProductInfo GetBuildVersion(string path)
-    {
-      var buildTxtFileInfo = new FileInfo(Path.Combine(path, GetRelativePathToBuildTxt()));
-      var dir = buildTxtFileInfo.DirectoryName;
-      if (!Directory.Exists(dir))
-        return null;
-      var buildVersionFile = new FileInfo(Path.Combine(dir, "product-info.json"));
-      if (!buildVersionFile.Exists) 
-        return null;
-      var json = File.ReadAllText(buildVersionFile.FullName);
-      return ProductInfo.GetProductInfo(json);
-    }
-    
-    internal static Version GetBuildNumber(string path)
-    {
-      var file = new FileInfo(Path.Combine(path, GetRelativePathToBuildTxt()));
-      if (!file.Exists) 
-        return null;
-      var text = File.ReadAllText(file.FullName);
-      if (text.Length <= 3) 
-        return null;
-      
-      var versionText = text.Substring(3);
-      return Version.TryParse(versionText, out var v) ? v : null;
-    }
-
-    internal static bool IsToolbox(string path)
-    {
-      return path.StartsWith(GetToolboxBaseDir());
-    }
-
-    private static string GetRelativePathToBuildTxt()
-    {
-      if (OS.IsWindows || OS.IsUnixLike())
-        return "../../build.txt";
-      if (OS.IsOSX)
-        return "Contents/Resources/build.txt";
-      throw new Exception("Unknown OS.");
-    }
-
-    private static void CollectPathsFromRegistry(string registryKey, List<string> installPaths)
-    {
-      using (var key = Registry.LocalMachine.OpenSubKey(registryKey))
-      {
-        if (key == null) return;
-        foreach (var subkeyName in key.GetSubKeyNames().Where(a => a.Contains("Rider")))
-        {
-          using (var subkey = key.OpenSubKey(subkeyName))
-          {
-            var folderObject = subkey?.GetValue("InstallLocation");
-            if (folderObject == null) continue;
-            var folder = folderObject.ToString();
-            var possiblePath = Path.Combine(folder, @"bin\rider64.exe");
-            if (File.Exists(possiblePath))
-              installPaths.Add(possiblePath);
-          }
-        }
-      }
-    }
-
-    private static string[] CollectPathsFromToolbox(string toolboxRiderRootPath, string dirName, string searchPattern,
-      bool isMac)
-    {
-      if (!Directory.Exists(toolboxRiderRootPath))
-        return new string[0];
-
-      var channelDirs = Directory.GetDirectories(toolboxRiderRootPath);
-      var paths = channelDirs.SelectMany(channelDir =>
-        {
-          try
-          {
-            // use history.json - last entry stands for the active build https://jetbrains.slack.com/archives/C07KNP99D/p1547807024066500?thread_ts=1547731708.057700&cid=C07KNP99D
-            var historyFile = Path.Combine(channelDir, ".history.json");
-            if (File.Exists(historyFile))
+            try
             {
-              var json = File.ReadAllText(historyFile);
-              var build = ToolboxHistory.GetLatestBuildFromJson(json);
-              if (build != null)
-              {
-                var buildDir = Path.Combine(channelDir, build);
-                var executablePaths = GetExecutablePaths(dirName, searchPattern, isMac, buildDir);
-                if (executablePaths.Any())
-                  return executablePaths;
-              }
+                if (OS.IsWindows)
+                {
+                    return CollectRiderInfosWindows();
+                }
+                if (OS.IsOSX)
+                {
+                    return CollectRiderInfosMac();
+                }
+                if (OS.IsUnixLike())
+                {
+                    return CollectAllRiderPathsLinux();
+                }
+                throw new Exception("Unexpected OS.");
+            }
+            catch (Exception e)
+            {
+                GD.PushWarning(e.Message);
             }
 
-            var channelFile = Path.Combine(channelDir, ".channel.settings.json");
-            if (File.Exists(channelFile))
+            return new RiderInfo[0];
+        }
+
+        private static RiderInfo[] CollectAllRiderPathsLinux()
+        {
+            var installInfos = new List<RiderInfo>();
+            var home = Environment.GetEnvironmentVariable("HOME");
+            if (!string.IsNullOrEmpty(home))
             {
-              var json = File.ReadAllText(channelFile).Replace("active-application", "active_application");
-              var build = ToolboxInstallData.GetLatestBuildFromJson(json);
-              if (build != null)
-              {
-                var buildDir = Path.Combine(channelDir, build);
-                var executablePaths = GetExecutablePaths(dirName, searchPattern, isMac, buildDir);
-                if (executablePaths.Any())
-                  return executablePaths;
-              }
+                var toolboxRiderRootPath = GetToolboxBaseDir();
+                installInfos.AddRange(CollectPathsFromToolbox(toolboxRiderRootPath, "bin", "rider.sh", false)
+                  .Select(a => new RiderInfo(a, true)).ToList());
+
+                //$Home/.local/share/applications/jetbrains-rider.desktop
+                var shortcut = new FileInfo(Path.Combine(home, @".local/share/applications/jetbrains-rider.desktop"));
+
+                if (shortcut.Exists)
+                {
+                    var lines = File.ReadAllLines(shortcut.FullName);
+                    foreach (var line in lines)
+                    {
+                        if (!line.StartsWith("Exec=\""))
+                            continue;
+                        var path = line.Split('"').Where((item, index) => index == 1).SingleOrDefault();
+                        if (string.IsNullOrEmpty(path))
+                            continue;
+
+                        if (installInfos.Any(a => a.Path == path)) // avoid adding similar build as from toolbox
+                            continue;
+                        installInfos.Add(new RiderInfo(path, false));
+                    }
+                }
             }
 
-            // changes in toolbox json files format may brake the logic above, so return all found Rider installations
-            return Directory.GetDirectories(channelDir)
-              .SelectMany(buildDir => GetExecutablePaths(dirName, searchPattern, isMac, buildDir));
-          }
-          catch (Exception e)
-          {
-            // do not write to Debug.Log, just log it.
-            Logger.Warn($"Failed to get RiderPath from {channelDir}", e);
-          }
+            // snap install
+            var snapInstallPath = "/snap/rider/current/bin/rider.sh";
+            if (new FileInfo(snapInstallPath).Exists)
+                installInfos.Add(new RiderInfo(snapInstallPath, false));
 
-          return new string[0];
-        })
-        .Where(c => !string.IsNullOrEmpty(c))
-        .ToArray();
-      return paths;
-    }
+            return installInfos.ToArray();
+        }
 
-    private static string[] GetExecutablePaths(string dirName, string searchPattern, bool isMac, string buildDir)
-    {
-      var folder = new DirectoryInfo(Path.Combine(buildDir, dirName));
-      if (!folder.Exists)
-        return new string[0];
+        private static RiderInfo[] CollectRiderInfosMac()
+        {
+            var installInfos = new List<RiderInfo>();
+            // "/Applications/*Rider*.app"
+            var folder = new DirectoryInfo("/Applications");
+            if (folder.Exists)
+            {
+                installInfos.AddRange(folder.GetDirectories("*Rider*.app")
+                  .Select(a => new RiderInfo(a.FullName, false))
+                  .ToList());
+            }
 
-      if (!isMac)
-        return new[] {Path.Combine(folder.FullName, searchPattern)}.Where(File.Exists).ToArray();
-      return folder.GetDirectories(searchPattern).Select(f => f.FullName)
-        .Where(Directory.Exists).ToArray();
-    }
+            // /Users/user/Library/Application Support/JetBrains/Toolbox/apps/Rider/ch-1/181.3870.267/Rider EAP.app
+            var toolboxRiderRootPath = GetToolboxBaseDir();
+            var paths = CollectPathsFromToolbox(toolboxRiderRootPath, "", "Rider*.app", true)
+              .Select(a => new RiderInfo(a, true));
+            installInfos.AddRange(paths);
 
-    // Disable the "field is never assigned" compiler warning. We never assign it, but Unity does.
-    // Note that Unity disable this warning in the generated C# projects
+            return installInfos.ToArray();
+        }
+
+        private static RiderInfo[] CollectRiderInfosWindows()
+        {
+            var installInfos = new List<RiderInfo>();
+            var toolboxRiderRootPath = GetToolboxBaseDir();
+            var installPathsToolbox = CollectPathsFromToolbox(toolboxRiderRootPath, "bin", "rider64.exe", false).ToList();
+            installInfos.AddRange(installPathsToolbox.Select(a => new RiderInfo(a, true)).ToList());
+
+            var installPaths = new List<string>();
+            const string registryKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
+            CollectPathsFromRegistry(registryKey, installPaths);
+            const string wowRegistryKey = @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall";
+            CollectPathsFromRegistry(wowRegistryKey, installPaths);
+
+            installInfos.AddRange(installPaths.Select(a => new RiderInfo(a, false)).ToList());
+
+            return installInfos.ToArray();
+        }
+
+        private static string GetToolboxBaseDir()
+        {
+            if (OS.IsWindows)
+            {
+                var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                return Path.Combine(localAppData, @"JetBrains\Toolbox\apps\Rider");
+            }
+
+            if (OS.IsOSX)
+            {
+                var home = Environment.GetEnvironmentVariable("HOME");
+                if (!string.IsNullOrEmpty(home))
+                {
+                    return Path.Combine(home, @"Library/Application Support/JetBrains/Toolbox/apps/Rider");
+                }
+            }
+
+            if (OS.IsUnixLike())
+            {
+                var home = Environment.GetEnvironmentVariable("HOME");
+                if (!string.IsNullOrEmpty(home))
+                {
+                    return Path.Combine(home, @".local/share/JetBrains/Toolbox/apps/Rider");
+                }
+            }
+
+            throw new Exception("Unexpected OS.");
+        }
+
+        internal static ProductInfo GetBuildVersion(string path)
+        {
+            var buildTxtFileInfo = new FileInfo(Path.Combine(path, GetRelativePathToBuildTxt()));
+            var dir = buildTxtFileInfo.DirectoryName;
+            if (!Directory.Exists(dir))
+                return null;
+            var buildVersionFile = new FileInfo(Path.Combine(dir, "product-info.json"));
+            if (!buildVersionFile.Exists)
+                return null;
+            var json = File.ReadAllText(buildVersionFile.FullName);
+            return ProductInfo.GetProductInfo(json);
+        }
+
+        internal static Version GetBuildNumber(string path)
+        {
+            var file = new FileInfo(Path.Combine(path, GetRelativePathToBuildTxt()));
+            if (!file.Exists)
+                return null;
+            var text = File.ReadAllText(file.FullName);
+            if (text.Length <= 3)
+                return null;
+
+            var versionText = text.Substring(3);
+            return Version.TryParse(versionText, out var v) ? v : null;
+        }
+
+        internal static bool IsToolbox(string path)
+        {
+            return path.StartsWith(GetToolboxBaseDir());
+        }
+
+        private static string GetRelativePathToBuildTxt()
+        {
+            if (OS.IsWindows || OS.IsUnixLike())
+                return "../../build.txt";
+            if (OS.IsOSX)
+                return "Contents/Resources/build.txt";
+            throw new Exception("Unknown OS.");
+        }
+
+        private static void CollectPathsFromRegistry(string registryKey, List<string> installPaths)
+        {
+            using (var key = Registry.LocalMachine.OpenSubKey(registryKey))
+            {
+                if (key == null) return;
+                foreach (var subkeyName in key.GetSubKeyNames().Where(a => a.Contains("Rider")))
+                {
+                    using (var subkey = key.OpenSubKey(subkeyName))
+                    {
+                        var folderObject = subkey?.GetValue("InstallLocation");
+                        if (folderObject == null) continue;
+                        var folder = folderObject.ToString();
+                        var possiblePath = Path.Combine(folder, @"bin\rider64.exe");
+                        if (File.Exists(possiblePath))
+                            installPaths.Add(possiblePath);
+                    }
+                }
+            }
+        }
+
+        private static string[] CollectPathsFromToolbox(string toolboxRiderRootPath, string dirName, string searchPattern,
+          bool isMac)
+        {
+            if (!Directory.Exists(toolboxRiderRootPath))
+                return new string[0];
+
+            var channelDirs = Directory.GetDirectories(toolboxRiderRootPath);
+            var paths = channelDirs.SelectMany(channelDir =>
+              {
+                  try
+                  {
+                // use history.json - last entry stands for the active build https://jetbrains.slack.com/archives/C07KNP99D/p1547807024066500?thread_ts=1547731708.057700&cid=C07KNP99D
+                var historyFile = Path.Combine(channelDir, ".history.json");
+                      if (File.Exists(historyFile))
+                      {
+                          var json = File.ReadAllText(historyFile);
+                          var build = ToolboxHistory.GetLatestBuildFromJson(json);
+                          if (build != null)
+                          {
+                              var buildDir = Path.Combine(channelDir, build);
+                              var executablePaths = GetExecutablePaths(dirName, searchPattern, isMac, buildDir);
+                              if (executablePaths.Any())
+                                  return executablePaths;
+                          }
+                      }
+
+                      var channelFile = Path.Combine(channelDir, ".channel.settings.json");
+                      if (File.Exists(channelFile))
+                      {
+                          var json = File.ReadAllText(channelFile).Replace("active-application", "active_application");
+                          var build = ToolboxInstallData.GetLatestBuildFromJson(json);
+                          if (build != null)
+                          {
+                              var buildDir = Path.Combine(channelDir, build);
+                              var executablePaths = GetExecutablePaths(dirName, searchPattern, isMac, buildDir);
+                              if (executablePaths.Any())
+                                  return executablePaths;
+                          }
+                      }
+
+                // changes in toolbox json files format may brake the logic above, so return all found Rider installations
+                return Directory.GetDirectories(channelDir)
+                  .SelectMany(buildDir => GetExecutablePaths(dirName, searchPattern, isMac, buildDir));
+                  }
+                  catch (Exception e)
+                  {
+                // do not write to Debug.Log, just log it.
+                Logger.Warn($"Failed to get RiderPath from {channelDir}", e);
+                  }
+
+                  return new string[0];
+              })
+              .Where(c => !string.IsNullOrEmpty(c))
+              .ToArray();
+            return paths;
+        }
+
+        private static string[] GetExecutablePaths(string dirName, string searchPattern, bool isMac, string buildDir)
+        {
+            var folder = new DirectoryInfo(Path.Combine(buildDir, dirName));
+            if (!folder.Exists)
+                return new string[0];
+
+            if (!isMac)
+                return new[] { Path.Combine(folder.FullName, searchPattern) }.Where(File.Exists).ToArray();
+            return folder.GetDirectories(searchPattern).Select(f => f.FullName)
+              .Where(Directory.Exists).ToArray();
+        }
+
+        // Disable the "field is never assigned" compiler warning. We never assign it, but Unity does.
+        // Note that Unity disable this warning in the generated C# projects
 #pragma warning disable 0649
 
-    [Serializable]
-    class ToolboxHistory
-    {
-      public List<ItemNode> history;
-
-      public static string GetLatestBuildFromJson(string json)
-      {
-        try
+        [Serializable]
+        class ToolboxHistory
         {
-          return JsonConvert.DeserializeObject<ToolboxHistory>(json).history.LastOrDefault()?.item.build;
-        }
-        catch (Exception)
-        {
-          Logger.Warn($"Failed to get latest build from json {json}");
-        }
+            public List<ItemNode> history;
 
-        return null;
-      }
-    }
+            public static string GetLatestBuildFromJson(string json)
+            {
+                try
+                {
+                    return JsonConvert.DeserializeObject<ToolboxHistory>(json).history.LastOrDefault()?.item.build;
+                }
+                catch (Exception)
+                {
+                    Logger.Warn($"Failed to get latest build from json {json}");
+                }
 
-    [Serializable]
-    class ItemNode
-    {
-      public BuildNode item;
-    }
-
-    [Serializable]
-    class BuildNode
-    {
-      public string build;
-    }
-
-    [Serializable]
-    public class ProductInfo
-    {
-      public string version;
-      public string versionSuffix;
-
-      [CanBeNull]
-      internal static ProductInfo GetProductInfo(string json)
-      {
-        try
-        {
-          var productInfo = JsonConvert.DeserializeObject<ProductInfo>(json);
-          return productInfo;
-        }
-        catch (Exception)
-        {
-          Logger.Warn($"Failed to get version from json {json}");
+                return null;
+            }
         }
 
-        return null;
-      }
-    }
-
-    // ReSharper disable once ClassNeverInstantiated.Global
-    [Serializable]
-    class ToolboxInstallData
-    {
-      // ReSharper disable once InconsistentNaming
-      public ActiveApplication active_application;
-
-      [CanBeNull]
-      public static string GetLatestBuildFromJson(string json)
-      {
-        try
+        [Serializable]
+        class ItemNode
         {
-          var toolbox = JsonConvert.DeserializeObject<ToolboxInstallData>(json);
-          var builds = toolbox.active_application.builds;
-          if (builds != null && builds.Any())
-            return builds.First();
-        }
-        catch (Exception)
-        {
-          Logger.Warn($"Failed to get latest build from json {json}");
+            public BuildNode item;
         }
 
-        return null;
-      }
-    }
+        [Serializable]
+        class BuildNode
+        {
+            public string build;
+        }
 
-    [Serializable]
-    class ActiveApplication
-    {
-      // ReSharper disable once InconsistentNaming
-      public List<string> builds;
-    }
+        [Serializable]
+        public class ProductInfo
+        {
+            public string version;
+            public string versionSuffix;
+
+            [CanBeNull]
+            internal static ProductInfo GetProductInfo(string json)
+            {
+                try
+                {
+                    var productInfo = JsonConvert.DeserializeObject<ProductInfo>(json);
+                    return productInfo;
+                }
+                catch (Exception)
+                {
+                    Logger.Warn($"Failed to get version from json {json}");
+                }
+
+                return null;
+            }
+        }
+
+        // ReSharper disable once ClassNeverInstantiated.Global
+        [Serializable]
+        class ToolboxInstallData
+        {
+            // ReSharper disable once InconsistentNaming
+            public ActiveApplication active_application;
+
+            [CanBeNull]
+            public static string GetLatestBuildFromJson(string json)
+            {
+                try
+                {
+                    var toolbox = JsonConvert.DeserializeObject<ToolboxInstallData>(json);
+                    var builds = toolbox.active_application.builds;
+                    if (builds != null && builds.Any())
+                        return builds.First();
+                }
+                catch (Exception)
+                {
+                    Logger.Warn($"Failed to get latest build from json {json}");
+                }
+
+                return null;
+            }
+        }
+
+        [Serializable]
+        class ActiveApplication
+        {
+            // ReSharper disable once InconsistentNaming
+            public List<string> builds;
+        }
 
 #pragma warning restore 0649
 
-    public struct RiderInfo
-    {
-      public bool IsToolbox;
-      public string Presentation;
-      public Version BuildNumber;
-      public ProductInfo ProductInfo;
-      public string Path;
-
-      public RiderInfo(string path, bool isToolbox)
-      {
-        BuildNumber = GetBuildNumber(path);
-        ProductInfo = GetBuildVersion(path);
-        Path = new FileInfo(path).FullName; // normalize separators
-        var presentation = $"Rider {BuildNumber}";
-
-        if (ProductInfo != null && !string.IsNullOrEmpty(ProductInfo.version))
+        public struct RiderInfo
         {
-          var suffix = string.IsNullOrEmpty(ProductInfo.versionSuffix) ? "" : $" {ProductInfo.versionSuffix}";
-          presentation = $"Rider {ProductInfo.version}{suffix}";
+            public bool IsToolbox;
+            public string Presentation;
+            public Version BuildNumber;
+            public ProductInfo ProductInfo;
+            public string Path;
+
+            public RiderInfo(string path, bool isToolbox)
+            {
+                BuildNumber = GetBuildNumber(path);
+                ProductInfo = GetBuildVersion(path);
+                Path = new FileInfo(path).FullName; // normalize separators
+                var presentation = $"Rider {BuildNumber}";
+
+                if (ProductInfo != null && !string.IsNullOrEmpty(ProductInfo.version))
+                {
+                    var suffix = string.IsNullOrEmpty(ProductInfo.versionSuffix) ? "" : $" {ProductInfo.versionSuffix}";
+                    presentation = $"Rider {ProductInfo.version}{suffix}";
+                }
+
+                if (isToolbox)
+                    presentation += " (JetBrains Toolbox)";
+
+                Presentation = presentation;
+                IsToolbox = isToolbox;
+            }
         }
 
-        if (isToolbox)
-          presentation += " (JetBrains Toolbox)";
-
-        Presentation = presentation;
-        IsToolbox = isToolbox;
-      }
+        private static class Logger
+        {
+            internal static void Warn(string message, Exception e = null)
+            {
+                throw new Exception(message, e);
+            }
+        }
     }
-
-    private static class Logger
-    {
-      internal static void Warn(string message, Exception e = null)
-      { 
-        throw new Exception(message, e);
-      }
-    }
-  }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -7,111 +7,111 @@ using GodotTools.Internals;
 
 namespace GodotTools.Ides.Rider
 {
-  public static class RiderPathManager
-  {
-    private static readonly string editorPathSettingName= "mono/editor/editor_path_optional";
+    public static class RiderPathManager
+    {
+        private static readonly string editorPathSettingName = "mono/editor/editor_path_optional";
 
-    private static string GetRiderPathFromSettings()
-    {
-      var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
-      if (editorSettings.HasSetting(editorPathSettingName)) 
-        return (string) editorSettings.GetSetting(editorPathSettingName);
-      return null;
-    }
-    
-    public static void Initialize()
-    {
-      var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
-      var editor = (ExternalEditorId) editorSettings.GetSetting("mono/editor/external_editor");
-      if (editor == ExternalEditorId.Rider)
-      {
-        if (!editorSettings.HasSetting(editorPathSettingName))
+        private static string GetRiderPathFromSettings()
         {
-          Globals.EditorDef(editorPathSettingName, "Optional");
-          editorSettings.AddPropertyInfo(new Godot.Collections.Dictionary
-          {
-            ["type"] = Variant.Type.String,
-            ["name"] = editorPathSettingName,
-            ["hint"] = PropertyHint.File,
-            ["hint_string"] = ""
-          });
+            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            if (editorSettings.HasSetting(editorPathSettingName))
+                return (string)editorSettings.GetSetting(editorPathSettingName);
+            return null;
         }
 
-        var riderPath = (string) editorSettings.GetSetting(editorPathSettingName);
-        if (IsRiderAndExists(riderPath))
+        public static void Initialize()
         {
-          Globals.EditorDef(editorPathSettingName, riderPath);
-          return;
+            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var editor = (ExternalEditorId)editorSettings.GetSetting("mono/editor/external_editor");
+            if (editor == ExternalEditorId.Rider)
+            {
+                if (!editorSettings.HasSetting(editorPathSettingName))
+                {
+                    Globals.EditorDef(editorPathSettingName, "Optional");
+                    editorSettings.AddPropertyInfo(new Godot.Collections.Dictionary
+                    {
+                        ["type"] = Variant.Type.String,
+                        ["name"] = editorPathSettingName,
+                        ["hint"] = PropertyHint.File,
+                        ["hint_string"] = ""
+                    });
+                }
+
+                var riderPath = (string)editorSettings.GetSetting(editorPathSettingName);
+                if (IsRiderAndExists(riderPath))
+                {
+                    Globals.EditorDef(editorPathSettingName, riderPath);
+                    return;
+                }
+
+                var paths = RiderPathLocator.GetAllRiderPaths();
+
+                if (!paths.Any())
+                    return;
+
+                var newPath = paths.Last().Path;
+                Globals.EditorDef(editorPathSettingName, newPath);
+                editorSettings.SetSetting(editorPathSettingName, newPath);
+            }
         }
 
-        var paths = RiderPathLocator.GetAllRiderPaths();
+        private static bool IsRider(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
 
-        if (!paths.Any())
-          return;
+            var fileInfo = new FileInfo(path);
+            var filename = fileInfo.Name.ToLowerInvariant();
+            return filename.StartsWith("rider", StringComparison.Ordinal);
+        }
 
-        var newPath = paths.Last().Path;
-        Globals.EditorDef(editorPathSettingName, newPath);
-        editorSettings.SetSetting(editorPathSettingName, newPath);
-      }
+        private static string CheckAndUpdatePath(string riderPath)
+        {
+            if (IsRiderAndExists(riderPath))
+            {
+                return riderPath;
+            }
+
+            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var paths = RiderPathLocator.GetAllRiderPaths();
+
+            if (!paths.Any())
+                return null;
+
+            var newPath = paths.Last().Path;
+            editorSettings.SetSetting(editorPathSettingName, newPath);
+            Globals.EditorDef(editorPathSettingName, newPath);
+            return newPath;
+        }
+
+        private static bool IsRiderAndExists(string riderPath)
+        {
+            return !string.IsNullOrEmpty(riderPath) && IsRider(riderPath) && new FileInfo(riderPath).Exists;
+        }
+
+        public static void OpenFile(string slnPath, string scriptPath, int line)
+        {
+            var pathFromSettings = GetRiderPathFromSettings();
+            var path = CheckAndUpdatePath(pathFromSettings);
+
+            var args = new List<string>();
+            args.Add(slnPath);
+            if (line >= 0)
+            {
+                args.Add("--line");
+                args.Add(line.ToString());
+            }
+            args.Add(scriptPath);
+            try
+            {
+                Utils.OS.RunProcess(path, args);
+            }
+            catch (Exception e)
+            {
+                GD.PushError($"Error when trying to run code editor: JetBrains Rider. Exception message: '{e.Message}'");
+            }
+        }
     }
-
-    private static bool IsRider(string path)
-    {
-      if (string.IsNullOrEmpty(path))
-      {
-        return false;
-      }
-
-      var fileInfo = new FileInfo(path);
-      var filename = fileInfo.Name.ToLowerInvariant();
-      return filename.StartsWith("rider", StringComparison.Ordinal);
-    }
-
-    private static string CheckAndUpdatePath(string riderPath)
-    {
-      if (IsRiderAndExists(riderPath))
-      {
-        return riderPath;
-      }
-
-      var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
-      var paths = RiderPathLocator.GetAllRiderPaths();
-
-      if (!paths.Any())
-        return null;
-        
-      var newPath = paths.Last().Path;
-      editorSettings.SetSetting(editorPathSettingName, newPath);
-      Globals.EditorDef(editorPathSettingName, newPath);
-      return newPath;
-    }
-
-    private static bool IsRiderAndExists(string riderPath)
-    {
-      return !string.IsNullOrEmpty(riderPath) && IsRider(riderPath) && new FileInfo(riderPath).Exists;
-    }
-
-    public static void OpenFile(string slnPath, string scriptPath, int line)
-    {
-      var pathFromSettings = GetRiderPathFromSettings();
-      var path = CheckAndUpdatePath(pathFromSettings);
-      
-      var args = new List<string>();
-      args.Add(slnPath);
-      if (line >= 0)
-      {
-        args.Add("--line");
-        args.Add(line.ToString());
-      }
-      args.Add(scriptPath);
-      try
-      {
-        Utils.OS.RunProcess(path, args);
-      }
-      catch (Exception e)
-      {
-        GD.PushError($"Error when trying to run code editor: JetBrains Rider. Exception message: '{e.Message}'");
-      }
-    }
-  }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -33,10 +33,10 @@ namespace GodotTools.Internals
         #region Windows-only
         public static string DataMonoBinDir => internal_DataMonoBinDir();
         #endregion
-        
-        
+
+
         #region Internal
-        
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ResDataDir();
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -85,7 +85,7 @@ namespace GodotTools.Internals
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_DataMonoBinDir();
         #endregion
-        
+
         #endregion
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/ScriptClassParser.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/ScriptClassParser.cs
@@ -39,10 +39,10 @@ namespace GodotTools.Internals
             foreach (var classDeclDict in classesArray)
             {
                 classesList.Add(new ClassDecl(
-                    (string) classDeclDict["name"],
-                    (string) classDeclDict["namespace"],
-                    (bool) classDeclDict["nested"],
-                    (int) classDeclDict["base_count"]
+                    (string)classDeclDict["name"],
+                    (string)classDeclDict["namespace"],
+                    (bool)classDeclDict["nested"],
+                    (int)classDeclDict["base_count"]
                 ));
             }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -75,7 +75,7 @@ namespace GodotTools.Utils
         public static bool IsHTML5 => _isHTML5.Value;
 
         private static bool? _isUnixCache;
-        private static readonly string[] UnixLikePlatforms = {Names.OSX, Names.X11, Names.Server, Names.Haiku, Names.Android};
+        private static readonly string[] UnixLikePlatforms = { Names.OSX, Names.X11, Names.Server, Names.Haiku, Names.Android };
 
         public static bool IsUnixLike()
         {
@@ -113,10 +113,10 @@ namespace GodotTools.Utils
                 return searchDirs.Select(dir => Path.Combine(dir, name)).FirstOrDefault(File.Exists);
 
             return (from dir in searchDirs
-                select Path.Combine(dir, name)
+                    select Path.Combine(dir, name)
                 into path
-                from ext in windowsExts
-                select path + ext).FirstOrDefault(File.Exists);
+                    from ext in windowsExts
+                    select path + ext).FirstOrDefault(File.Exists);
         }
 
         private static string PathWhichUnix(string name)
@@ -157,7 +157,7 @@ namespace GodotTools.Utils
 
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
-                if (IsWindows && process.Id>0) 
+                if (IsWindows && process.Id > 0)
                     User32Dll.AllowSetForegroundWindow(process.Id); // allows application to focus itself
             }
         }

--- a/modules/mono/editor/GodotTools/GodotTools/packages.config
+++ b/modules/mono/editor/GodotTools/GodotTools/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="JetBrains.Annotations" version="2019.1.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />

--- a/modules/mono/glue/Managed/Managed.csproj
+++ b/modules/mono/glue/Managed/Managed.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
Ran an autoformatter on the Mono folder (from VS Code). @neikeq Biggest changes are:

* No space for casting
* Add spaces inside braces
* 4 spaces for indentation (Rider files are all that changed here)
* Remove trailing indentation
* Remove BOM

The autoformatter also formatted Python files, but I discarded all such changes. 

The only files which don't end with newline characters are the `csproj` files because most IDEs don't include them when saving `csproj` files, and the new `csproj` format (which we aren't using yet) will solve this problem anyway as it recommends including newline characters at the end.