### PR TITLE
Fix double trailing forward slash being added to localize_path function

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -86,6 +86,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 		// DirAccess::get_current_dir() is not guaranteed to return a path that with a trailing '/',
 		// so we must make sure we have it as well in order to compare with 'res_path'.
 		cwd = cwd.plus_file("");
+		cwd = cwd.substr(0, cwd.length() - 1);
 
 		if (!cwd.begins_with(res_path)) {
 			return p_path;


### PR DESCRIPTION
Alternative fix to a bug described in this PR (https://github.com/godotengine/godot/pull/33380) where a double forward slash would under certain circumstances appear when calling the localise_path function, which had to be reverted to a regression described here (https://github.com/godotengine/godot/issues/33913)

To be more specific, the double forward slash would be added to the last forward slash when calling localise_path of an absoloute path which points to the working godot directory, for example, calling it on 'c:/my_godot_project/assets/my_scripts/my_script.gd' would result in res://assets/my_scripts//my_script.gd, which would frequently cause issues with saving or loading uncached scripts in the script editor.

This is an alternative fix which addresses the issue in my original PR without causing the regression, by simply replacing any double forward slashes with single ones.