### PR TITLE
Fix GDScript autocompletion with "as" or typed variables

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -744,6 +744,14 @@ static bool _guess_expression_type(GDScriptCompletionContext &p_context, const G
 			r_type.type.kind = GDScriptParser::DataType::BUILTIN;
 			r_type.type.builtin_type = Variant::ARRAY;
 		} break;
+		case GDScriptParser::Node::TYPE_CAST: {
+			const GDScriptParser::CastNode *cn = static_cast<const GDScriptParser::CastNode *>(p_expression);
+			GDScriptCompletionIdentifier value;
+			if (_guess_expression_type(p_context, cn->source_node, r_type)) {
+				r_type.type = cn->get_datatype();
+				found = true;
+			}
+		} break;
 		case GDScriptParser::Node::TYPE_OPERATOR: {
 			const GDScriptParser::OperatorNode *op = static_cast<const GDScriptParser::OperatorNode *>(p_expression);
 			switch (op->op) {
@@ -1232,6 +1240,9 @@ static bool _guess_identifier_type(GDScriptCompletionContext &p_context, const S
 		c.line = last_assign_line;
 		r_type.assigned_expression = last_assigned_expression;
 		if (_guess_expression_type(c, last_assigned_expression, r_type)) {
+			if (var_type.has_type) {
+				r_type.type = var_type;
+			}
 			return true;
 		}
 	}


### PR DESCRIPTION
Fixes #31818, fixes #33434.