### PR TITLE
Expose EditorQuickOpen

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -129,6 +129,7 @@
 #include "editor/plugins/version_control_editor_plugin.h"
 #include "editor/plugins/visual_shader_editor_plugin.h"
 #include "editor/pvrtc_compress.h"
+#include "editor/quick_open.h"
 #include "editor/register_exporters.h"
 #include "editor/script_editor_debugger.h"
 
@@ -3559,6 +3560,7 @@ void EditorNode::register_editor_types() {
 	ResourceSaver::set_timestamp_on_save(true);
 
 	ClassDB::register_class<EditorPlugin>();
+	ClassDB::register_class<EditorQuickOpen>();
 	ClassDB::register_class<EditorImportPlugin>();
 	ClassDB::register_class<EditorScript>();
 	ClassDB::register_class<EditorSelection>();

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -281,6 +281,8 @@ void EditorQuickOpen::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_text_changed"), &EditorQuickOpen::_text_changed);
 	ClassDB::bind_method(D_METHOD("_confirmed"), &EditorQuickOpen::_confirmed);
 	ClassDB::bind_method(D_METHOD("_sbox_input"), &EditorQuickOpen::_sbox_input);
+	ClassDB::bind_method(D_METHOD("popup_dialog", "base", "enable_multi", "add_dirs", "dontclear"), &EditorQuickOpen::popup_dialog);
+	ClassDB::bind_method(D_METHOD("selected"), &EditorQuickOpen::get_selected);
 
 	ADD_SIGNAL(MethodInfo("quick_open"));
 }


### PR DESCRIPTION
For my game, I wanted to make a Binding of Issac style map with rooms being linked to one another.
I am going to use the GraphNode/Editor in an editor plugin to connect the different cardinal directions to other rooms. I wanted the ability to create nodes and link a scene to them. This was my hacking to expose the EditorQuickOpen to GDScript (because I saw it used in the instance scene action).

I'm not sure if this is a remotely common use case, but I needed it and thought someone else might too.

(within a EditorPlugin context)
```gdscript
var qo = EditorQuickOpen.new()
add_child(qo)
qo.popup_dialog("PackedScene", false, false, false)
yield(qo, "quick_open")
print(qo.selected())
remove_child(qo)
```
Setting the dialog's name does not work and it does not have the right editor theme.
![image](https://user-images.githubusercontent.com/6750326/70680838-63cfe680-1c67-11ea-9e84-a9a8425d9dd7.png)
