### PR TITLE
Fix for collision polygon not working at all on exported builds.

### DIFF
--- a/scene/3d/collision_polygon.cpp
+++ b/scene/3d/collision_polygon.cpp
@@ -44,7 +44,7 @@ void CollisionPolygon::_build_polygon() {
 	if (polygon.size() == 0)
 		return;
 
-	Vector<Vector<Vector2> > decomp = Geometry::decompose_polygon(polygon);
+	Vector<Vector<Vector2> > decomp = Geometry::decompose_polygon_in_convex(polygon);
 	if (decomp.size() == 0)
 		return;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/30913.

The code to generate convex shapes in 3D (Geometry::decompose_polygon) was disabled in the non-tool builds, however, there was another function that does exactly the same thing (Geometry::decompose_polygon_in_convex), used for 2D collision polygons, which was NOT disabled.  I changed the 3D CollisionPolygon to use the same thing the 2D CollisionPolygon does.