### PR TITLE
Fixes crash when using Resource::_take_over_path

### DIFF
--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -68,7 +68,10 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 		if (p_take_over) {
 
 			ResourceCache::lock->write_lock();
-			ResourceCache::resources.get(p_path)->set_name("");
+			Resource **res = ResourceCache::resources.getptr(p_path);
+			if (res) {
+				(*res)->set_name("");
+			}
 			ResourceCache::lock->write_unlock();
 		} else {
 			ResourceCache::lock->read_lock();


### PR DESCRIPTION
This fixes #33072

* Adds an additional null check
    * The previous null check is in a separate read lock area. It still has a chance of becoming null between line 65 and 70, thus causing the crash. https://github.com/godotengine/godot/blob/371de5132ce6315e0b60cc74ebd47c134c275361/core/resource.cpp#L63-L72