### PR TITLE
Fixes crash after remove_line in RichTextLabel

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1701,6 +1701,9 @@ bool RichTextLabel::remove_line(const int p_line) {
 
 	if (!was_newline) {
 		current_frame->lines.remove(p_line);
+		if (current_frame->lines.size() == 0) {
+			current_frame->lines.resize(1);
+		}
 	}
 
 	if (p_line == 0 && current->subitems.size() > 0)


### PR DESCRIPTION
This fixes #32736

* Keeps `lines.size() > 0`
    * `ItemFrame` should always have at least one line, even when it's empty.
        * This is what the constructor and `clear` function of `RichTextLabel` keeps.
    * Other codes assume this is true, using `lines[lines.size() - 1]` without check.

---

To reproduce the crash, you can either use the reproduction project in the original issue, or use the following script:

```gdscript
extends RichTextLabel

func _process(_delta: float) -> void:
	remove_line(0)
	push_list(RichTextLabel.LIST_DOTS)
```
