### PR TITLE
Added apply_impulse methods to PhysicalBone for ragdolls

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1554,6 +1554,14 @@ bool PhysicalBone::JointData::_get(const StringName &p_name, Variant &r_ret) con
 void PhysicalBone::JointData::_get_property_list(List<PropertyInfo> *p_list) const {
 }
 
+void PhysicalBone::apply_central_impulse(const Vector3 &p_impulse) {
+	PhysicsServer::get_singleton()->body_apply_central_impulse(get_rid(), p_impulse);
+}
+
+void PhysicalBone::apply_impulse(const Vector3 &p_pos, const Vector3 &p_impulse) {
+	PhysicsServer::get_singleton()->body_apply_impulse(get_rid(), p_pos, p_impulse);
+}
+
 bool PhysicalBone::PinJointData::_set(const StringName &p_name, const Variant &p_value, RID j) {
 	if (JointData::_set(p_name, p_value, j)) {
 		return true;
@@ -2216,6 +2224,9 @@ void PhysicalBone::_direct_state_changed(Object *p_state) {
 }
 
 void PhysicalBone::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &PhysicalBone::apply_central_impulse);
+	ClassDB::bind_method(D_METHOD("apply_impulse", "position", "impulse"), &PhysicalBone::apply_impulse);
+
 	ClassDB::bind_method(D_METHOD("_direct_state_changed"), &PhysicalBone::_direct_state_changed);
 
 	ClassDB::bind_method(D_METHOD("set_joint_type", "joint_type"), &PhysicalBone::set_joint_type);

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -636,6 +636,9 @@ public:
 	void set_gravity_scale(real_t p_gravity_scale);
 	real_t get_gravity_scale() const;
 
+	void apply_central_impulse(const Vector3 &p_impulse);
+	void apply_impulse(const Vector3 &p_pos, const Vector3 &p_impulse);
+	
 	PhysicalBone();
 	~PhysicalBone();
 


### PR DESCRIPTION
The new ragdalls in Godot are cool, but lacks a way to apply the impulse. As the classes PhysicalBone and RigidBody are both based on PhysicsBody, I simply copied the methods 'apply_central_impulse' and 'apply_impulse' to the PhysicalBone class. 

The result:
 https://youtu.be/GcEj7Zkoxu8 