### PR TITLE
Fixed an issue with recording audio.

### DIFF
--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -192,10 +192,11 @@ void AudioEffectRecord::set_recording_active(bool p_record) {
 		}
 
 		ensure_thread_stopped();
+		recording_active = true;
 		current_instance->init();
+	} else {
+		recording_active = false;
 	}
-
-	recording_active = p_record;
 }
 
 bool AudioEffectRecord::is_recording_active() const {


### PR DESCRIPTION
Prior to this fix, AudioEffectRecordInstance::init() was called before recording_active is set to true in AudioEffectRecord::set_recording_active(). This was setting is_recording to false in AudioEffectRecordInstance, because is_recording updates to the value of recording_active in AudioEffectRecordInstance::_io_thread_process(). To fix this issue, AudioEffectRecordInstance::init() is now called after recording_active is set to true.

