### PR TITLE
[Vulkan] Restore parts of #33783 and #32809 missing after rebase.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ matrix:
 
     - name: macOS editor (debug, Clang)
       stage: build
-      env: PLATFORM=osx TOOLS=yes TARGET=debug CACHE_NAME=${PLATFORM}-tools-clang EXTRA_ARGS="warnings=extra werror=yes"
+      env: PLATFORM=osx TOOLS=yes TARGET=debug CACHE_NAME=${PLATFORM}-tools-clang EXTRA_ARGS="warnings=extra" # werror=yes
       os: osx
       compiler: clang
 

--- a/platform/osx/context_gl_osx.h
+++ b/platform/osx/context_gl_osx.h
@@ -51,10 +51,6 @@ class ContextGL_OSX {
 	NSOpenGLContext *context;
 
 public:
-	bool waiting_for_vsync;
-	NSCondition *vsync_condition;
-	CVDisplayLinkRef displayLink;
-
 	void release_current();
 
 	void make_current();

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1524,7 +1524,11 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 #endif
 		[window_object setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
 	} else {
-		[window_view setWantsBestResolutionOpenGLSurface:NO];
+#if defined(OPENGL_ENABLED)
+		if (video_driver_index == VIDEO_DRIVER_GLES2) {
+			[window_view setWantsBestResolutionOpenGLSurface:NO];
+		}
+#endif
 	}
 
 	[window_object setContentView:window_view];
@@ -2957,14 +2961,6 @@ Error OS_OSX::move_to_trash(const String &p_path) {
 }
 
 void OS_OSX::_set_use_vsync(bool p_enable) {
-	// FIXME: Commented out during rebase of vulkan branch on master.
-	/*
-	CGLContextObj ctx = CGLGetCurrentContext();
-	if (ctx) {
-		GLint swapInterval = p_enable ? 1 : 0;
-		CGLSetParameter(ctx, kCGLCPSwapInterval, &swapInterval);
-	}
-	*/
 #if defined(OPENGL_ENABLED)
 	if (video_driver_index == VIDEO_DRIVER_GLES2) {
 		if (context_gles2)


### PR DESCRIPTION
#33783, OpenGL vsync changes were not rebased (OpenGL code was moved to the separate file before).
#32809, OpenGL specific call was left without driver check ifs.

Also, removes "werror=yes" from macOS Travis build, there are still Vulkan specific warnings.