### PR TITLE
Don't allow to use too big or too small shift count

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -1118,6 +1118,8 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_SHIFT_LEFT, INT) {
 				if (p_b.type != INT)
 					_RETURN_FAIL;
+				if (p_b._data._int < 0 || p_b._data._int >= 64)
+					_RETURN_FAIL;
 				_RETURN(p_a._data._int << p_b._data._int);
 			}
 
@@ -1128,6 +1130,8 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 		SWITCH_OP(math, OP_SHIFT_RIGHT, p_a.type) {
 			CASE_TYPE(math, OP_SHIFT_RIGHT, INT) {
 				if (p_b.type != INT)
+					_RETURN_FAIL;
+				if (p_b._data._int < 0 || p_b._data._int >= 64)
 					_RETURN_FAIL;
 				_RETURN(p_a._data._int >> p_b._data._int);
 			}


### PR DESCRIPTION
Using too small or too big shift count is undefined behaviour in C++