### PR TITLE
Fix- using cut in first line of a script file does not remove the line

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5177,11 +5177,16 @@ void TextEdit::cut() {
 		OS::get_singleton()->set_clipboard(clipboard);
 		cursor_set_line(cursor.line);
 		cursor_set_column(0);
-		_remove_text(cursor.line, 0, cursor.line, text[cursor.line].length());
 
-		backspace_at_cursor();
+		if (cursor.line == 0 && get_line_count() > 1) {
+			_remove_text(cursor.line, 0, cursor.line + 1, 0);
+		} else {
+			_remove_text(cursor.line, 0, cursor.line, text[cursor.line].length());
+			backspace_at_cursor();
+			cursor_set_line(cursor.line + 1);
+		}
+
 		update();
-		cursor_set_line(cursor.line + 1);
 		cut_copy_line = clipboard;
 
 	} else {


### PR DESCRIPTION
Fix #34289 
**TextEdit::cut** needs to handle cuting first line of the file due to the fact that **TextEdit::backspace_at_cursor** does not perform it's functionality, when _cursor.line == 0_