### PR TITLE
Do not remove ragdoll collision layers after simulation disabled

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -2729,8 +2729,6 @@ void PhysicalBone::_stop_physics_simulation() {
 		return;
 	}
 	PhysicsServer::get_singleton()->body_set_mode(get_rid(), PhysicsServer::BODY_MODE_STATIC);
-	PhysicsServer::get_singleton()->body_set_collision_layer(get_rid(), 0);
-	PhysicsServer::get_singleton()->body_set_collision_mask(get_rid(), 0);
 	PhysicsServer::get_singleton()->body_set_force_integration_callback(get_rid(), NULL, "");
 	parent_skeleton->set_bone_global_pose_override(bone_id, Transform(), 0.0, false);
 	_internal_simulate_physics = false;


### PR DESCRIPTION
Those two lines that I removed clear collision layers and masks for each bone, if simulation was disabled.
With that collision detection doesn't work any more.
Here is how it works right now:
https://youtu.be/H0wkiiwg4bI 

And here is how it has to work, and is without those lines:
https://youtu.be/m2KjrekxD0Y

*(in videos the act of shooting enable a simulation, and a keypress disable it and returns character to default position)*

If game developer want to clear collision layers, he/she can do that in the script.