### PR TITLE
Fix OptionButton's arrow margin in editor theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -587,11 +587,24 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_color_pressed", "Button", icon_color_pressed);
 
 	// OptionButton
-	theme->set_stylebox("normal", "OptionButton", style_widget);
-	theme->set_stylebox("hover", "OptionButton", style_widget_hover);
-	theme->set_stylebox("pressed", "OptionButton", style_widget_pressed);
-	theme->set_stylebox("focus", "OptionButton", style_widget_focus);
-	theme->set_stylebox("disabled", "OptionButton", style_widget_disabled);
+	Ref<StyleBoxFlat> style_option_button_normal = style_widget->duplicate();
+	Ref<StyleBoxFlat> style_option_button_hover = style_widget_hover->duplicate();
+	Ref<StyleBoxFlat> style_option_button_pressed = style_widget_pressed->duplicate();
+	Ref<StyleBoxFlat> style_option_button_focus = style_widget_focus->duplicate();
+	Ref<StyleBoxFlat> style_option_button_disabled = style_widget_disabled->duplicate();
+
+	int option_button_arrow_margin = theme->get_icon("GuiOptionArrow", "EditorIcons")->get_size().width + (default_margin_size + 4) * EDSCALE;
+	style_option_button_normal->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
+	style_option_button_hover->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
+	style_option_button_pressed->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
+	style_option_button_focus->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
+	style_option_button_disabled->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
+
+	theme->set_stylebox("normal", "OptionButton", style_option_button_normal);
+	theme->set_stylebox("hover", "OptionButton", style_option_button_hover);
+	theme->set_stylebox("pressed", "OptionButton", style_option_button_pressed);
+	theme->set_stylebox("focus", "OptionButton", style_option_button_focus);
+	theme->set_stylebox("disabled", "OptionButton", style_option_button_disabled);
 
 	theme->set_color("font_color", "OptionButton", font_color);
 	theme->set_color("font_color_hover", "OptionButton", font_color_hl);


### PR DESCRIPTION
Together with #34314, fully fixes #23806.