### PR TITLE
Replace the android.defaultConfig.applicationId in build.gradle with the package/unique_name

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1984,10 +1984,13 @@ public:
 
 			build_command = build_path.plus_file(build_command);
 
+			String package_name = get_package_name(p_preset->get("package/unique_name"));
+
 			List<String> cmdline;
 			cmdline.push_back("build");
-			cmdline.push_back("-p");
-			cmdline.push_back(build_path);
+			cmdline.push_back("-Pexport_package_name=" + package_name); // argument to specify the package name.
+			cmdline.push_back("-p"); // argument to specify the start directory.
+			cmdline.push_back(build_path); // start directory.
 			/*{ used for debug
 				int ec;
 				String pipe;

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -51,7 +51,7 @@ android {
 
     defaultConfig {
         // Feel free to modify the application id to your own.
-        applicationId "com.godot.game"
+        applicationId getExportPackageName()
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
 //CHUNK_ANDROID_DEFAULTCONFIG_BEGIN

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -10,3 +10,13 @@ ext.versions = [
 ext.libraries = [
         androidGradlePlugin : "com.android.tools.build:gradle:$versions.androidGradlePlugin"
 ]
+
+ext.getExportPackageName = { ->
+	// Retrieve the app id from the project property set by the Godot build command.
+	String appId = project.hasProperty("export_package_name") ? project.property("export_package_name") : ""
+	// Check if the app id is valid, otherwise use the default.
+	if (appId == null || appId.isEmpty()) {
+		appId = "com.godot.game"
+	}
+	return appId
+}


### PR DESCRIPTION
Fix #33838.

This is done by passing the package/unique_name to the gradle build as a project property during build time. 