### PR TITLE
Adds inner shadow option for stylebox

### DIFF
--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -149,11 +149,13 @@ class StyleBoxFlat : public StyleBox {
 
 	Color bg_color;
 	Color shadow_color;
+	Color inner_shadow_color;
 	Color border_color;
 
 	int border_width[4];
 	int expand_margin[4];
 	int corner_radius[4];
+	int inner_shadow_width[4];
 
 	bool draw_center;
 	bool blend_border;
@@ -162,6 +164,7 @@ class StyleBoxFlat : public StyleBox {
 	int corner_detail;
 	int shadow_size;
 	Point2 shadow_offset;
+	
 	int aa_size;
 
 protected:
@@ -219,6 +222,12 @@ public:
 
 	void set_shadow_offset(const Point2 &p_offset);
 	Point2 get_shadow_offset() const;
+
+	void set_inner_shadow_color(const Color &p_color);
+	Color get_inner_shadow_color() const;
+
+	void set_inner_shadow_width(Margin p_margin, int p_width);
+	int get_inner_shadow_width(Margin p_margin) const;
 
 	//ANTI_ALIASING
 	void set_anti_aliased(const bool &p_anti_aliased);


### PR DESCRIPTION
Adds an option to set inner shadow for styleboxes.

- This is a stlyebox option, which means that this can be used with all controls that can have a stylebox (Panels, RichTextLabel etc...).
- Inner shadow is a separate option from outer shadow. Only the Group name was changed for outer shadow so it should not break compatibility (?).
- Takes anti aliasing into account.

- [ ] Add documentation.

- [x] Add individual options for top,left,bottom,right (in case someone doesn't want to display an individual shadow).

- [ ] Add individual options for top,left,bottom,right for **outer** shadow also.

![image](https://user-images.githubusercontent.com/1850856/70776746-a9370580-1d86-11ea-92dc-5b31c7ae44ce.png)
![image](https://user-images.githubusercontent.com/1850856/70860137-5d22c700-1f26-11ea-98bc-ac44c3c1f77d.png)
