### PR TITLE
set_script() detailing what happens to variables

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -460,6 +460,7 @@
 			</argument>
 			<description>
 				Assigns a script to the object. Each object can have a single script assigned to it, which are used to extend its functionality.
+				If the object already had a script, the previous script instance will be freed and its variables and state will be lost. The new script's [method _init] method will be called.
 			</description>
 		</method>
 		<method name="to_string">


### PR DESCRIPTION
Makes it clear to the reader that this is a clean replacement; no old variables will remain. I didn't know what would happen until I tested it.

It also seems somewhat significant to write this down because I think this is the only other way (other than writing ``var``) to initialize new variables on an existing node. Please correct me if I'm wrong, I've been looking for another way to initialize a new variable.