### PR TITLE
Clarifying how float(String from) parses partially invalid strings

### DIFF
--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -33,7 +33,7 @@
 			<argument index="0" name="from" type="String">
 			</argument>
 			<description>
-				Cast a [String] value to a floating-point value. This method accepts float value strings like [code]"1.23"[/code] and exponential notation strings for its parameter so calling [code]float("1e3")[/code] will return 1000.0 and calling [code]float("1e-3")[/code] will return 0.001.
+				Cast a [String] value to a floating-point value. This method accepts float value strings like [code]"1.23"[/code] and exponential notation strings for its parameter so calling [code]float("1e3")[/code] will return 1000.0 and calling [code]float("1e-3")[/code] will return 0.001. Calling this method with an invalid float string will return 0. This method stops parsing at the first invalid character and will return the parsed result so far, so calling [code]float("1a3")[/code] will return 1 while calling [code]float("1e3a2")[/code] will return 1000.0.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Update the description of this method to be in line with [code]int int(String from)[/code] in regards to how it deals with a completely invalid parameter and a partially invalid parameter.