### PR TITLE
vhacd: Patch to fix UWP ARM build

### DIFF
--- a/thirdparty/vhacd/0004-fix-uwp-arm-build.patch
+++ b/thirdparty/vhacd/0004-fix-uwp-arm-build.patch
@@ -1,0 +1,16 @@
+diff --git a/thirdparty/vhacd/inc/btScalar.h b/thirdparty/vhacd/inc/btScalar.h
+index 3999a71521..4c9e0cf7ab 100644
+--- a/thirdparty/vhacd/inc/btScalar.h
++++ b/thirdparty/vhacd/inc/btScalar.h
+@@ -72,7 +72,10 @@ inline int32_t btGetVersion()
+ #define btFsel(a, b, c) __fsel((a), (b), (c))
+ #else
+ 
+-#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION))
++// -- GODOT start --
++//#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION))
++#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION)) && (!defined(_M_ARM))
++// -- GODOT end --
+ #define BT_USE_SSE
+ #include <emmintrin.h>
+ #endif

--- a/thirdparty/vhacd/inc/btScalar.h
+++ b/thirdparty/vhacd/inc/btScalar.h
@@ -72,7 +72,10 @@ inline int32_t btGetVersion()
 #define btFsel(a, b, c) __fsel((a), (b), (c))
 #else
 
-#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION))
+// -- GODOT start --
+//#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION))
+#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION)) && (!defined(_M_ARM))
+// -- GODOT end --
 #define BT_USE_SSE
 #include <emmintrin.h>
 #endif


### PR DESCRIPTION
This is a very outdated copy of Bullet's btScalar.h,
we're probably only discovering the tip of the bad
cross-platform compatibility of the unmaintained vhacd.

Upstream PR: kmammou/v-hacd#75