### PR TITLE
Document that translated does not behave like rotated or scaled

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1950,7 +1950,7 @@ void register_variant_methods() {
 	ADDFUNC0R(TRANSFORM, TRANSFORM, Transform, orthonormalized, varray());
 	ADDFUNC2R(TRANSFORM, TRANSFORM, Transform, rotated, VECTOR3, "axis", REAL, "phi", varray());
 	ADDFUNC1R(TRANSFORM, TRANSFORM, Transform, scaled, VECTOR3, "scale", varray());
-	ADDFUNC1R(TRANSFORM, TRANSFORM, Transform, translated, VECTOR3, "ofs", varray());
+	ADDFUNC1R(TRANSFORM, TRANSFORM, Transform, translated, VECTOR3, "offset", varray());
 	ADDFUNC2R(TRANSFORM, TRANSFORM, Transform, looking_at, VECTOR3, "target", VECTOR3, "up", varray());
 	ADDFUNC2R(TRANSFORM, TRANSFORM, Transform, interpolate_with, TRANSFORM, "transform", REAL, "weight", varray());
 	ADDFUNC1R(TRANSFORM, BOOL, Transform, is_equal_approx, TRANSFORM, "transform", varray());

--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -126,7 +126,7 @@
 			<argument index="1" name="phi" type="float">
 			</argument>
 			<description>
-				Rotates the transform around given axis by phi. The axis must be a normalized vector.
+				Rotates the transform around the given axis by the given angle (in radians), using matrix multiplication. The axis must be a normalized vector.
 			</description>
 		</method>
 		<method name="scaled">
@@ -135,16 +135,17 @@
 			<argument index="0" name="scale" type="Vector3">
 			</argument>
 			<description>
-				Scales the transform by the specified 3D scaling factors.
+				Scales the transform by the given scale factor, using matrix multiplication.
 			</description>
 		</method>
 		<method name="translated">
 			<return type="Transform">
 			</return>
-			<argument index="0" name="ofs" type="Vector3">
+			<argument index="0" name="offset" type="Vector3">
 			</argument>
 			<description>
-				Translates the transform by the specified offset.
+				Translates the transform by the given offset, relative to the transform's basis vectors.
+				Unlike [method rotated] and [method scaled], this does not use matrix multiplication.
 			</description>
 		</method>
 		<method name="xform">

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -128,7 +128,7 @@
 			<argument index="0" name="phi" type="float">
 			</argument>
 			<description>
-				Rotates the transform by the given angle (in radians).
+				Rotates the transform by the given angle (in radians), using matrix multiplication.
 			</description>
 		</method>
 		<method name="scaled">
@@ -137,7 +137,7 @@
 			<argument index="0" name="scale" type="Vector2">
 			</argument>
 			<description>
-				Scales the transform by the given factor.
+				Scales the transform by the given scale factor, using matrix multiplication.
 			</description>
 		</method>
 		<method name="translated">
@@ -146,7 +146,8 @@
 			<argument index="0" name="offset" type="Vector2">
 			</argument>
 			<description>
-				Translates the transform by the given offset.
+				Translates the transform by the given offset, relative to the transform's basis vectors.
+				Unlike [method rotated] and [method scaled], this does not use matrix multiplication.
 			</description>
 		</method>
 		<method name="xform">


### PR DESCRIPTION
Fixes #34329. I also made sure the docs for Transform and Transform2D are similar, the text for `scaled` and `translated` is exactly the same, but `rotated` is a bit different.

I changed the argument name in `variant_call.cpp` from "ofs" to "offset", no behavior change.