### PR TITLE
Fixed an issue with capturing audio from microphones in macOS.

### DIFF
--- a/misc/dist/osx_template.app/Contents/Info.plist
+++ b/misc/dist/osx_template.app/Contents/Info.plist
@@ -24,6 +24,10 @@
 	<string>$signature</string>
 	<key>CFBundleVersion</key>
 	<string>$version</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>$microphone_usage_description</string>
+	<key>NSCameraUsageDescription</key>
+	<string>$camera_usage_description</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>$copyright</string>
 	<key>LSMinimumSystemVersion</key>

--- a/misc/dist/osx_tools.app/Contents/Info.plist
+++ b/misc/dist/osx_tools.app/Contents/Info.plist
@@ -24,6 +24,10 @@
 	<string>godot</string>
 	<key>CFBundleVersion</key>
 	<string>3.2</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone access is required to capture audio.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera access is required to capture video.</string>
 	<key>NSRequiresAquaSystemAppearance</key>
     	<false />
 	<key>NSHumanReadableCopyright</key>

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -130,6 +130,9 @@ void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version"), "1.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "display/high_res"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/camera_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need to use the camera"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/microphone_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need to use the microphone"), ""));
+
 
 #ifdef OSX_ENABLED
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/enable"), false));
@@ -342,6 +345,12 @@ void EditorExportPlatformOSX::_fix_plist(const Ref<EditorExportPreset> &p_preset
 			strnew += lines[i].replace("$copyright", p_preset->get("application/copyright")) + "\n";
 		} else if (lines[i].find("$highres") != -1) {
 			strnew += lines[i].replace("$highres", p_preset->get("display/high_res") ? "<true/>" : "<false/>") + "\n";
+		} else if (lines[i].find("$camera_usage_description") != -1) {
+			String description = p_preset->get("privacy/camera_usage_description");
+			strnew += lines[i].replace("$camera_usage_description", description) + "\n";
+		} else if (lines[i].find("$microphone_usage_description") != -1) {
+			String description = p_preset->get("privacy/microphone_usage_description");
+			strnew += lines[i].replace("$microphone_usage_description", description) + "\n";
 		} else {
 			strnew += lines[i] + "\n";
 		}


### PR DESCRIPTION
Before this change, macOS failed to prompt the user for microphone access when recording was enabled and an AudioStreamMicrophone was in use. This blocked the application from capturing audio from the system's microphones. This issue was fixed by adding an NSMicrophoneUsageDescription to the Info.plist file for the macOS build of the Godot editor and the macOS export template.