### PR TITLE
Fixed issues with using a relative path in the export window.

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3792,7 +3792,8 @@ bool String::is_valid_float() const {
 
 String String::path_to_file(const String &p_path) const {
 
-	String src = this->replace("\\", "/").get_base_dir();
+	// Don't get base dir for src, this is expected to be a dir already.
+	String src = this->replace("\\", "/");
 	String dst = p_path.replace("\\", "/").get_base_dir();
 	String rel = src.path_to(dst);
 	if (rel == dst) // failed

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -958,6 +958,8 @@ String EditorFileDialog::get_current_path() const {
 }
 void EditorFileDialog::set_current_dir(const String &p_dir) {
 
+	if (p_dir.is_rel_path())
+		dir_access->change_dir(OS::get_singleton()->get_resource_dir());
 	dir_access->change_dir(p_dir);
 	update_dir();
 	invalidate();


### PR DESCRIPTION
This fix addresses issue #33567. Before this fix, opening relative export paths inside of an EditorFileDialog was broken. This fix improves how relative paths are saved in EditorExportPreset and how relative paths are opened in EditorFileDialog.

*Bugsquad edit:*
Fixes #33567.
Fixes #31427.