### PR TITLE
Show full enum name when not on the same doc page

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -798,7 +798,7 @@ void EditorHelp::_update_doc() {
 				class_desc->pop();
 				class_desc->push_font(doc_code_font);
 				String e = E->key();
-				if (e.get_slice_count(".")) {
+				if ((e.get_slice_count(".") > 1) && (e.get_slice(".", 0) == edited_class)) {
 					e = e.get_slice(".", 1);
 				}
 


### PR DESCRIPTION
* Removes the prefix only when it's the same as the current class name
    * The original `e.get_slice_count(".")` condition is only false when `e` is empty, but `"".get_slice(".", 1)` returns `""` anyway.
    * The slice count is still checked to avoid lots of string comparison, as most enum names don't have a `.` separator.

---

Rationale:

`Variant.Type` and `Variant.Operator` enums are documented on the `@GlobalScope` page.

In the online [API Reference](https://docs.godotengine.org/en/latest/classes/class_@globalscope.html), they are correctly listed by their full name. But in editor's built-in help, they are listed as `Type` and `Operator`, leaving no clue of `Variant`.

The `Variant.` prefix should only be omitted if listed on the `Variant` page.