### PR TITLE
Increase the TileSet and polygon UV editor zoom limits to 16×

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1444,7 +1444,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_mode_hb->add_child(uv_icon_zoom);
 	uv_zoom = memnew(HSlider);
 	uv_zoom->set_min(0.01);
-	uv_zoom->set_max(4);
+	uv_zoom->set_max(16);
 	uv_zoom->set_value(1);
 	uv_zoom->set_step(0.01);
 	uv_zoom->set_v_size_flags(SIZE_SHRINK_CENTER);

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -637,8 +637,8 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tile_names_visible = false;
 
 	// Config scale.
-	max_scale = 10.0f;
-	min_scale = 0.1f;
+	max_scale = 16.0f;
+	min_scale = 0.01f;
 	scale_ratio = 1.2f;
 }
 


### PR DESCRIPTION
This also changes the TileSet editor's minimum zoom to match other 2D editors.

This closes #34346.