### PR TITLE
Store meta for instanced scenes

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -510,9 +510,8 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 			// only save what has been changed
 			// only save changed properties in instance
 
-			if ((E->get().usage & PROPERTY_USAGE_NO_INSTANCE_STATE) || E->get().name == "__meta__") {
+			if (E->get().usage & PROPERTY_USAGE_NO_INSTANCE_STATE) {
 				//property has requested that no instance state is saved, sorry
-				//also, meta won't be overridden or saved
 				continue;
 			}
 


### PR DESCRIPTION
I investigated #12990 and noticed that metadata is a hardcoded exception for instances. I was going to put a comment in the issue, but then decided to try my luck with making a PR right away :v (maybe it will be closed, but will raise more awareness for the issue)

Removing the exception makes the metadata correctly saved, but it also permanently overwrites the metadata from original scene. If you e.g. set root node as locked and instance it in another scene, then the lock will also be saved in the other scene. And when you remove it from the original scene, the lock in the new scene will stay.

Now, should this be expected behavior? The dictionaries are compared by reference and since metadata is now always unique, the metadata in the instanced scene will never be equal to the original one, thus every instance will serialize duplicate metadata of original scene. We could somehow force metadata to be compared by value, but still, any modification will make the dictionary unique and store all keys.

So uh, in case this is acceptable, the PR can be merged. If not, meta serialization needs some rework to fix the issue.

Resolves #12990
Fixes #12838
Helps #33790