### PR TITLE
Fixes wrong minimum size of Group Editor

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -404,7 +404,7 @@ void GroupDialog::_bind_methods() {
 }
 
 GroupDialog::GroupDialog() {
-	set_custom_minimum_size(Size2(600, 400));
+	set_custom_minimum_size(Size2(600, 400) * EDSCALE);
 
 	scene_tree = SceneTree::get_singleton();
 


### PR DESCRIPTION
* Takes current editor scale into account when setting the minimum size.

---

Before this fix, the default size of Group Editor frame is too small on high DPI monitors (e.g. retina display).

<img width="526" alt="screenshot" src="https://user-images.githubusercontent.com/372476/70858308-bf85c280-1f3a-11ea-9f4c-310b5976c1fe.png">

To reproduce on a non high DPI monitor, change Display Scale to 200% in editor settings.