### PR TITLE
Moves switch for show scripts panel from File menu to status bar

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1508,6 +1508,10 @@ void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
 	emit_signal("show_warnings_panel", p_show);
 }
 
+void CodeTextEditor::_toggle_scripts_pressed() {
+	toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_icon("Back", "EditorIcons") : get_icon("Forward", "EditorIcons"));
+}
+
 void CodeTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
@@ -1523,6 +1527,7 @@ void CodeTextEditor::_notification(int p_what) {
 			emit_signal("load_theme_settings");
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
+			toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_icon("Back", "EditorIcons") : get_icon("Forward", "EditorIcons"));
 			_update_font();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
@@ -1623,6 +1628,7 @@ void CodeTextEditor::_bind_methods() {
 	ClassDB::bind_method("_complete_request", &CodeTextEditor::_complete_request);
 	ClassDB::bind_method("_font_resize_timeout", &CodeTextEditor::_font_resize_timeout);
 	ClassDB::bind_method("_error_pressed", &CodeTextEditor::_error_pressed);
+	ClassDB::bind_method("_toggle_scripts_pressed", &CodeTextEditor::_toggle_scripts_pressed);
 	ClassDB::bind_method("_warning_button_pressed", &CodeTextEditor::_warning_button_pressed);
 	ClassDB::bind_method("_warning_label_gui_input", &CodeTextEditor::_warning_label_gui_input);
 
@@ -1677,6 +1683,11 @@ CodeTextEditor::CodeTextEditor() {
 
 	error_line = 0;
 	error_column = 0;
+
+	toggle_scripts_button = memnew(ToolButton);
+	toggle_scripts_button->connect("pressed", this, "_toggle_scripts_pressed");
+	status_bar->add_child(toggle_scripts_button);
+	toggle_scripts_button->set_shortcut(ED_SHORTCUT("script_editor/toggle_scripts_panel", TTR("Toggle Scripts Panel"), KEY_MASK_CMD | KEY_BACKSLASH));
 
 	// Error
 	ScrollContainer *scroll = memnew(ScrollContainer);

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -145,6 +145,7 @@ class CodeTextEditor : public VBoxContainer {
 	FindReplaceBar *find_replace_bar;
 	HBoxContainer *status_bar;
 
+	ToolButton *toggle_scripts_button;
 	ToolButton *warning_button;
 	Label *warning_count_label;
 
@@ -186,6 +187,7 @@ class CodeTextEditor : public VBoxContainer {
 	void _error_pressed(const Ref<InputEvent> &p_event);
 
 	void _delete_line(int p_line);
+	void _toggle_scripts_pressed();
 
 protected:
 	virtual void _load_theme_settings() {}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -987,6 +987,15 @@ Array ScriptEditor::_get_open_scripts() const {
 	return ret;
 }
 
+bool ScriptEditor::toggle_scripts_panel() {
+	list_split->set_visible(!list_split->is_visible());
+	return list_split->is_visible();
+}
+
+bool ScriptEditor::is_scripts_panel_toggled() {
+	return list_split->is_visible();
+}
+
 void ScriptEditor::_menu_option(int p_option) {
 
 	switch (p_option) {
@@ -1127,7 +1136,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(DEBUG_WITH_EXTERNAL_EDITOR), debug_with_external_editor);
 		} break;
 		case TOGGLE_SCRIPTS_PANEL: {
-			list_split->set_visible(!list_split->is_visible());
+			toggle_scripts_panel();
 		}
 	}
 
@@ -3306,9 +3315,6 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	file_menu->get_popup()->add_separator();
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/run_file", TTR("Run"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_X), FILE_RUN);
-
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/toggle_scripts_panel", TTR("Toggle Scripts Panel"), KEY_MASK_CMD | KEY_BACKSLASH), TOGGLE_SCRIPTS_PANEL);
 	file_menu->get_popup()->connect("id_pressed", this, "_menu_option");
 
 	script_search_menu = memnew(MenuButton);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -419,6 +419,8 @@ protected:
 public:
 	static ScriptEditor *get_singleton() { return script_editor; }
 
+	bool toggle_scripts_panel();
+	bool is_scripts_panel_toggled();
 	void ensure_focus_current();
 	void apply_scripts() const;
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);


### PR DESCRIPTION
This may be subjective but I think its a more comfortable position for this switch than in File menu. 

![panel](https://user-images.githubusercontent.com/3036176/70863720-07691180-1f5c-11ea-9ea5-523e1436632a.gif)
