### PR TITLE
Fix shadow color in GLES2 by making sRGB

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -1954,8 +1954,7 @@ void RasterizerSceneGLES2::_setup_light(LightInstance *light, ShadowAtlas *shado
 	Color color = light_ptr->color * sign * energy * Math_PI;
 	state.scene_shader.set_uniform(SceneShaderGLES2::LIGHT_COLOR, color);
 
-	Color shadow_color = light_ptr->shadow_color.to_linear();
-	state.scene_shader.set_uniform(SceneShaderGLES2::SHADOW_COLOR, shadow_color);
+	state.scene_shader.set_uniform(SceneShaderGLES2::SHADOW_COLOR, light_ptr->shadow_color);
 
 	//specific parameters
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/27290

GLES2 renders in sRGB space, so the color should have been sRGB. 