### PR TITLE
Center error icon vertically in AssetLib

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1494,6 +1494,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	error_label->add_color_override("color", get_color("error_color", "Editor"));
 	error_hb->add_child(error_label);
 	error_tr = memnew(TextureRect);
+	error_tr->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	error_hb->add_child(error_tr);
 
 	description = NULL;


### PR DESCRIPTION
This centers the error icon (red dot) vertically in AssetLib.

Before this fix, it looked like this:

<img width="426" alt="screenshot" src="https://user-images.githubusercontent.com/372476/70872944-30ce7f80-1fe6-11ea-8d35-dfd325eb14a0.png">

To reproduce this, switch to the "Templates" tab in Project Manager (or "AssetLib" in the main editor), and change the "site" dropdown to "localhost".