### PR TITLE
Profiling with JetBrains Rider and JetBrains dotTrace

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -102,6 +102,18 @@ void gd_mono_profiler_init() {
 	bool profiler_enabled = GLOBAL_DEF("mono/profiler/enabled", false);
 	if (profiler_enabled) {
 		mono_profiler_load(profiler_args.utf8());
+		return;
+	}
+
+	const String env_var_name = "MONO_ENV_OPTIONS";
+	if (OS::get_singleton()->has_environment(env_var_name)) {
+		const auto mono_env_ops = OS::get_singleton()->get_environment(env_var_name);
+		// Usually MONO_ENV_OPTIONS looks like:   --profile=jb:prof=timeline,ctl=remote,host=127.0.0.1:55467
+		const String prefix = "--profile=";
+		if (mono_env_ops.begins_with(prefix)) {
+			const auto ops = mono_env_ops.substr(prefix.length(), mono_env_ops.length());
+			mono_profiler_load(ops.utf8());
+		}
 	}
 }
 


### PR DESCRIPTION
### Godot 4.x

Works on all OS.
How-to for JetBrains Rider 2023.2+:
1. Start Rider
2. Open your project, follow Notification suggestion to install Godot support plugin, if you don't have it.
3. Run-configurations .NET Executable "Player" and "Editor" are automatically generated
4. Try different profiling modes for both "Player" or "Editor"
![image](https://github.com/godotengine/godot/assets/1482681/a097c1ae-4728-4005-8ae8-737f46e7a1e2)
5. You may mark Godot Engine assemblies as System to simplify analysis, such nodes would be greyed out and folded
![image](https://github.com/godotengine/godot/assets/1482681/95fe1a92-da98-4518-942f-eabbaf3ef577)


### Godot 3.x.

It works out of the box on Mac and Linux, but on Windows only with locally compiled Godot from sources. Official windows builds are cross-compiled with mingw and they statically link mono (passing mono_static=yes). On official build Rider shows error "Unsupported Mono version". [Issue added](https://github.com/mono/mono/issues/18961)

How-to for JetBrains Rider 2020.2+:
1. Start Rider
2. Open your project, follow Notification suggestion to install Godot support plugin, if you don't have it.
3. Run-configurations "Player" and "Editor" are automatically generated
4. Start "Player" or "Editor" with Profiling (use Profile button)
![70929363-4a49e880-2033-11ea-9a9a-188affb56112](https://user-images.githubusercontent.com/1482681/73358961-0b4cbb00-42a0-11ea-8212-97db5160c243.jpg)

Note that:
1. It is worth enabling child processes profiling
![image](https://user-images.githubusercontent.com/1482681/71449358-f59d2080-274a-11ea-9219-10cae699a57e.png)
![image](https://user-images.githubusercontent.com/1482681/71449362-02217900-274b-11ea-9051-44cc4e3f4012.png)
2. For Windows, given that you compile Godot locally, there would be another interesting possibility "Enable Native profiling", which would profile both native code and Mono.
![image](https://user-images.githubusercontent.com/1482681/118648421-ab568c80-b7e2-11eb-9e99-8c192f85dec8.png)
3. Make sure that `Project Settings` -> `Profiler` in Godot Editor is disabled.