### PR TITLE
[3.x] GUI: Support for multi touch in _gui_input

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -286,6 +286,11 @@ private:
 	Ref<ViewportTexture> default_texture;
 	Set<ViewportTexture *> viewport_textures;
 
+	struct TouchFocus {
+		int index;
+		Control *control;
+	};
+
 	struct GUI {
 		// info used when this is a window
 
@@ -318,6 +323,8 @@ private:
 		int canvas_sort_index; //for sorting items with canvas as root
 		bool dragging;
 
+		Vector<TouchFocus> touch_focuses;
+
 		GUI();
 	} gui;
 
@@ -332,6 +339,11 @@ private:
 	void _gui_sort_modal_stack();
 	Control *_gui_find_control(const Point2 &p_global);
 	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform, Transform2D &r_inv_xform);
+
+	void _gui_set_touch_focus(int p_index, Control *p_control);
+	void _gui_clear_touch_focus(int p_index);
+	Control *_gui_get_touch_focus(int p_index);
+	int _gui_has_touch_focus(Control *p_control);
 
 	void _gui_input_event(Ref<InputEvent> p_event);
 


### PR DESCRIPTION
Fixes #29525 

---

Sends the released and drag touch events to the expected control.
Drag events now goes to the underlying control or if a touch press before happened to that control.
Released events now goes to the control which received the pressed event before.

Before the released event only reached _gui_input if it was from the first finger. 
And the drag events always reached the control with the first touch.

I also attached the small test project with which I tested the pressed & released events.
[TestMultiTouch.zip](https://github.com/godotengine/godot/files/3969434/TestMultiTouch.zip)