### PR TITLE
Fixes size of Create Function dialog

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -4776,6 +4776,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	// Add Function Dialog.
 	VBoxContainer *function_vb = memnew(VBoxContainer);
 	function_vb->set_v_size_flags(SIZE_EXPAND_FILL);
+	function_vb->set_custom_minimum_size(Size2(450, 300) * EDSCALE);
 
 	HBoxContainer *func_name_hbox = memnew(HBoxContainer);
 	function_vb->add_child(func_name_hbox);
@@ -4810,7 +4811,6 @@ VisualScriptEditor::VisualScriptEditor() {
 	func_input_scroll->add_child(func_input_vbox);
 
 	function_create_dialog = memnew(ConfirmationDialog);
-	function_create_dialog->set_custom_minimum_size(Size2(450, 300) * EDSCALE);
 	function_create_dialog->set_v_size_flags(SIZE_EXPAND_FILL);
 	function_create_dialog->set_title(TTR("Create Function"));
 	function_create_dialog->add_child(function_vb);


### PR DESCRIPTION
* Sets the minimum size of root element instead of the dialog itself.

Before this fix, the height of Create Function dialog in Visual Script editor is a bit short, especially on HiDPI monitors.

![before-normal](https://user-images.githubusercontent.com/372476/70957811-4610e000-20b2-11ea-8362-e1fbaf1f86f5.png)
![before-retina](https://user-images.githubusercontent.com/372476/70957812-47daa380-20b2-11ea-8cda-6ad7cb12e7c3.png)
