### PR TITLE
Prevent showing toggle scripts panel switch in shader editor

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1527,7 +1527,9 @@ void CodeTextEditor::_notification(int p_what) {
 			emit_signal("load_theme_settings");
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_icon("Back", "EditorIcons") : get_icon("Forward", "EditorIcons"));
+			if (toggle_scripts_button->is_visible()) {
+				toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_icon("Back", "EditorIcons") : get_icon("Forward", "EditorIcons"));
+			}
 			_update_font();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
@@ -1643,6 +1645,10 @@ void CodeTextEditor::set_code_complete_func(CodeTextEditorCodeCompleteFunc p_cod
 	code_complete_ud = p_ud;
 }
 
+void CodeTextEditor::show_toggle_scripts_button() {
+	toggle_scripts_button->show();
+}
+
 CodeTextEditor::CodeTextEditor() {
 
 	code_complete_func = NULL;
@@ -1688,6 +1694,7 @@ CodeTextEditor::CodeTextEditor() {
 	toggle_scripts_button->connect("pressed", this, "_toggle_scripts_pressed");
 	status_bar->add_child(toggle_scripts_button);
 	toggle_scripts_button->set_shortcut(ED_SHORTCUT("script_editor/toggle_scripts_panel", TTR("Toggle Scripts Panel"), KEY_MASK_CMD | KEY_BACKSLASH));
+	toggle_scripts_button->hide();
 
 	// Error
 	ScrollContainer *scroll = memnew(ScrollContainer);

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -255,6 +255,8 @@ public:
 
 	void validate_script();
 
+	void show_toggle_scripts_button();
+
 	CodeTextEditor();
 };
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1760,6 +1760,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor->get_text_edit()->connect("symbol_lookup", this, "_lookup_symbol");
 	code_editor->get_text_edit()->connect("info_clicked", this, "_lookup_connections");
 	code_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	code_editor->show_toggle_scripts_button();
 
 	warnings_panel = memnew(RichTextLabel);
 	editor_box->add_child(warnings_panel);


### PR DESCRIPTION
Small bug fix for #34364, to prevent this button from show within shader editor