### PR TITLE
Mono/C#: Fix project export and fix FindLast/GetFile regression

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -39,7 +39,7 @@ namespace GodotTools.Export
 
         private void AddFile(string srcPath, string dstPath, bool remap = false)
         {
-            AddFile(dstPath, File.ReadAllBytes(srcPath), remap);
+            AddFile(dstPath.Replace("\\", "/"), File.ReadAllBytes(srcPath), remap);
         }
 
         public override void _ExportFile(string path, string type, string[] features)

--- a/modules/mono/glue/Managed/Files/StringExtensions.cs
+++ b/modules/mono/glue/Managed/Files/StringExtensions.cs
@@ -18,7 +18,7 @@ namespace Godot
             int pos = 0;
             int slices = 1;
 
-            while ((pos = instance.Find(splitter, true, pos)) >= 0)
+            while ((pos = instance.Find(splitter, pos, caseSensitive: true)) >= 0)
             {
                 slices++;
                 pos += splitter.Length;
@@ -229,7 +229,7 @@ namespace Godot
         // </summary>
         public static int CasecmpTo(this string instance, string to)
         {
-            return instance.CompareTo(to, true);
+            return instance.CompareTo(to, caseSensitive: true);
         }
 
         // <summary>
@@ -322,25 +322,29 @@ namespace Godot
             return instance.Substring(pos + 1);
         }
 
-        // <summary>
-        // Find the first occurrence of a substring, return the starting position of the substring or -1 if not found. Optionally, the initial search index can be passed.
-        // </summary>
-        public static int Find(this string instance, string what, bool caseSensitive = true, int from = 0)
+        /// <summary>Find the first occurrence of a substring. Optionally, the search starting position can be passed.</summary>
+        /// <returns>The starting position of the substring, or -1 if not found.</returns>
+        public static int Find(this string instance, string what, int from = 0, bool caseSensitive = true)
         {
             return instance.IndexOf(what, from, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
         }
 
-        // <summary>
-        // Find the last occurrence of a substring, return the starting position of the substring or -1 if not found. Optionally, the initial search index can be passed.
-        // </summary>
-        public static int FindLast(this string instance, string what, bool caseSensitive = true, int from = 0)
+        /// <summary>Find the last occurrence of a substring.</summary>
+        /// <returns>The starting position of the substring, or -1 if not found.</returns>
+        public static int FindLast(this string instance, string what, bool caseSensitive = true)
+        {
+            return instance.FindLast(what, instance.Length - 1, caseSensitive);
+        }
+
+        /// <summary>Find the last occurrence of a substring specifying the search starting position.</summary>
+        /// <returns>The starting position of the substring, or -1 if not found.</returns>
+        public static int FindLast(this string instance, string what, int from, bool caseSensitive = true)
         {
             return instance.LastIndexOf(what, from, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
         }
 
-        // <summary>
-        // Find the first occurrence of a substring but search as case-insensitive, return the starting position of the substring or -1 if not found. Optionally, the initial search index can be passed.
-        // </summary>
+        /// <summary>Find the first occurrence of a substring but search as case-insensitive. Optionally, the search starting position can be passed.</summary>
+        /// <returns>The starting position of the substring, or -1 if not found.</returns>
         public static int FindN(this string instance, string what, int from = 0)
         {
             return instance.IndexOf(what, from, StringComparison.OrdinalIgnoreCase);
@@ -502,7 +506,7 @@ namespace Godot
         // </summary>
         public static bool IsSubsequenceOfI(this string instance, string text)
         {
-            return instance.IsSubsequenceOf(text, false);
+            return instance.IsSubsequenceOf(text, caseSensitive: false);
         }
 
         // <summary>
@@ -662,7 +666,7 @@ namespace Godot
         // </summary>
         public static bool MatchN(this string instance, string expr)
         {
-            return instance.ExprMatch(expr, false);
+            return instance.ExprMatch(expr, caseSensitive: false);
         }
 
         // <summary>
@@ -692,7 +696,7 @@ namespace Godot
         // </summary>
         public static int NocasecmpTo(this string instance, string to)
         {
-            return instance.CompareTo(to, false);
+            return instance.CompareTo(to, caseSensitive: false);
         }
 
         // <summary>
@@ -928,7 +932,7 @@ namespace Godot
 
             while (true)
             {
-                int end = instance.Find(divisor, true, from);
+                int end = instance.Find(divisor, from, caseSensitive: true);
                 if (end < 0)
                     end = len;
                 if (allowEmpty || end > from)


### PR DESCRIPTION
d09193b08ae8fdb082bee6ffd3828eb19fd45ce6 introduced a regression in StringExtensions.FindLast. StringExtensions.GetFile was also affected as it relies on FindLast. This in turn broke the project exporter as it uses GetFile.
The cause of the regression is that now FindLast is calling LastIndexOf
with 'startIndex: 0'. This should be 'startIndex: str.Length - 1' instead.

Also fixed another regression in the project exporter: de7c2ad21b4cc2d889a5aeda64ead962036d2aa4 moved 'GodotTools/GodotSharpExport.cs' to 'GodotTools/Export/ExportPlugin.cs' and in doing so accidently reverted the changes from commit e439581198de92e63661c4fe71108cb59cc2d999.
