### PR TITLE
Fix toggle scripts panel to allow using shortcut in other areas

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1509,7 +1509,7 @@ void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
 }
 
 void CodeTextEditor::_toggle_scripts_pressed() {
-	toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_icon("Back", "EditorIcons") : get_icon("Forward", "EditorIcons"));
+	toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel(this) ? get_icon("Back", "EditorIcons") : get_icon("Forward", "EditorIcons"));
 }
 
 void CodeTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
@@ -1528,7 +1528,7 @@ void CodeTextEditor::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			if (toggle_scripts_button->is_visible()) {
-				toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_icon("Back", "EditorIcons") : get_icon("Forward", "EditorIcons"));
+				update_toggle_scripts_button();
 			}
 			_update_font();
 		} break;
@@ -1537,6 +1537,9 @@ void CodeTextEditor::_notification(int p_what) {
 			add_constant_override("separation", 4 * EDSCALE);
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (toggle_scripts_button->is_visible()) {
+				update_toggle_scripts_button();
+			}
 			set_process_input(is_visible_in_tree());
 		} break;
 		default:
@@ -1649,6 +1652,10 @@ void CodeTextEditor::show_toggle_scripts_button() {
 	toggle_scripts_button->show();
 }
 
+void CodeTextEditor::update_toggle_scripts_button() {
+	toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_icon("Back", "EditorIcons") : get_icon("Forward", "EditorIcons"));
+}
+
 CodeTextEditor::CodeTextEditor() {
 
 	code_complete_func = NULL;
@@ -1693,7 +1700,7 @@ CodeTextEditor::CodeTextEditor() {
 	toggle_scripts_button = memnew(ToolButton);
 	toggle_scripts_button->connect("pressed", this, "_toggle_scripts_pressed");
 	status_bar->add_child(toggle_scripts_button);
-	toggle_scripts_button->set_shortcut(ED_SHORTCUT("script_editor/toggle_scripts_panel", TTR("Toggle Scripts Panel"), KEY_MASK_CMD | KEY_BACKSLASH));
+	toggle_scripts_button->set_tooltip(TTR("Toggle Scripts Panel") + " (" + ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text() + ")");
 	toggle_scripts_button->hide();
 
 	// Error

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -256,6 +256,7 @@ public:
 	void validate_script();
 
 	void show_toggle_scripts_button();
+	void update_toggle_scripts_button();
 
 	CodeTextEditor();
 };

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -987,8 +987,11 @@ Array ScriptEditor::_get_open_scripts() const {
 	return ret;
 }
 
-bool ScriptEditor::toggle_scripts_panel() {
+bool ScriptEditor::toggle_scripts_panel(CodeTextEditor *p_editor) {
 	list_split->set_visible(!list_split->is_visible());
+	if (p_editor) {
+		p_editor->update_toggle_scripts_button();
+	}
 	return list_split->is_visible();
 }
 
@@ -998,6 +1001,7 @@ bool ScriptEditor::is_scripts_panel_toggled() {
 
 void ScriptEditor::_menu_option(int p_option) {
 
+	ScriptEditorBase *current = _get_current_editor();
 	switch (p_option) {
 		case FILE_NEW: {
 			script_create_dialog->config("Node", "new_script");
@@ -1136,11 +1140,19 @@ void ScriptEditor::_menu_option(int p_option) {
 			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(DEBUG_WITH_EXTERNAL_EDITOR), debug_with_external_editor);
 		} break;
 		case TOGGLE_SCRIPTS_PANEL: {
-			toggle_scripts_panel();
+			if (current) {
+				CodeTextEditor *code_editor = NULL;
+				ScriptTextEditor *editor = dynamic_cast<ScriptTextEditor *>(current);
+				if (editor) {
+					code_editor = editor->code_editor;
+				}
+				toggle_scripts_panel(code_editor);
+			} else {
+				toggle_scripts_panel(NULL);
+			}
 		}
 	}
 
-	ScriptEditorBase *current = _get_current_editor();
 	if (current) {
 
 		switch (p_option) {
@@ -3315,6 +3327,9 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	file_menu->get_popup()->add_separator();
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/run_file", TTR("Run"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_X), FILE_RUN);
+
+	file_menu->get_popup()->add_separator();
+	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/toggle_scripts_panel", TTR("Toggle Scripts Panel"), KEY_MASK_CMD | KEY_BACKSLASH), TOGGLE_SCRIPTS_PANEL);
 	file_menu->get_popup()->connect("id_pressed", this, "_menu_option");
 
 	script_search_menu = memnew(MenuButton);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -419,7 +419,7 @@ protected:
 public:
 	static ScriptEditor *get_singleton() { return script_editor; }
 
-	bool toggle_scripts_panel();
+	bool toggle_scripts_panel(CodeTextEditor *p_editor);
 	bool is_scripts_panel_toggled();
 	void ensure_focus_current();
 	void apply_scripts() const;

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -55,7 +55,6 @@ class ScriptTextEditor : public ScriptEditorBase {
 
 	GDCLASS(ScriptTextEditor, ScriptEditorBase);
 
-	CodeTextEditor *code_editor;
 	RichTextLabel *warnings_panel;
 
 	Ref<Script> script;
@@ -187,6 +186,8 @@ protected:
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 public:
+	CodeTextEditor *code_editor;
+
 	void _update_connected_methods();
 
 	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);


### PR DESCRIPTION
Fixing https://github.com/godotengine/godot/pull/34364#issuecomment-566457159, I've returned this option to File menu while keeping the new switch alive.
I think I'm inelegant in the provided code fix so please leave ideas to enhance that.