### PR TITLE
Added support for adding header files to Scons (VS Projects)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -76,6 +76,7 @@ env_base.__class__.disable_module = methods.disable_module
 env_base.__class__.add_module_version_string = methods.add_module_version_string
 
 env_base.__class__.add_source_files = methods.add_source_files
+env_base.__class__.add_header_files = methods.add_header_files
 env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
 env_base.__class__.split_lib = methods.split_lib
 
@@ -262,7 +263,7 @@ if selected_platform in platform_list:
         env.vs_incs = []
         env.vs_srcs = []
 
-        def AddToVSProject(sources):
+        def AddSourcesToVSProject(sources):
             for x in sources:
                 if type(x) == type(""):
                     fname = env.File(x).path
@@ -280,7 +281,19 @@ if selected_platform in platform_list:
                         env.vs_srcs = env.vs_srcs + [basename + ".c"]
                     elif os.path.isfile(basename + ".cpp"):
                         env.vs_srcs = env.vs_srcs + [basename + ".cpp"]
-        env.AddToVSProject = AddToVSProject
+
+        def AddHeadersToVSProject(headers):
+            for x in headers:
+                fname = env.File(x).path
+                pieces = fname.split(".")
+                if len(pieces) > 0:
+                    basename = pieces[0]
+                    basename = basename.replace('\\\\', '/')
+                    if os.path.isfile(basename + ".h"):
+                        env.vs_incs = env.vs_incs + [basename + ".h"]
+
+        env.AddSourcesToVSProject = AddSourcesToVSProject
+        env.AddHeadersToVSProject = AddHeadersToVSProject
 
     env.extra_suffix = ""
 

--- a/core/SCsub
+++ b/core/SCsub
@@ -7,6 +7,7 @@ import make_binders
 from platform_methods import run_in_subprocess
 
 env.core_sources = []
+env.core_headers = []
 
 
 # Generate AES256 script encryption key
@@ -140,6 +141,7 @@ if env['builtin_zstd']:
 
 # Godot's own sources
 env.add_source_files(env.core_sources, "*.cpp")
+env.add_header_files(env.core_headers, "*.h")
 
 # Certificates
 env.Depends("#core/io/certs_compressed.gen.h", ["#thirdparty/certs/ca-certificates.crt", env.Value(env['builtin_certs']), env.Value(env['system_certs_path'])])

--- a/core/bind/SCsub
+++ b/core/bind/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.core_sources, "*.cpp")
+env.add_header_files(env.core_headers, "*.h")

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -36,3 +36,4 @@ if not has_module:
     env_thirdparty.add_source_files(env.core_sources, thirdparty_mbedtls_sources)
 
 env_crypto.add_source_files(env.core_sources, "*.cpp")
+env_crypto.add_header_files(env.core_headers, "*.h")

--- a/core/io/SCsub
+++ b/core/io/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.core_sources, "*.cpp")
+env.add_header_files(env.core_headers, "*.h")

--- a/core/math/SCsub
+++ b/core/math/SCsub
@@ -5,3 +5,5 @@ Import('env')
 env_math = env.Clone()
 
 env_math.add_source_files(env.core_sources, "*.cpp")
+env_math.add_header_files(env.core_headers, "*.h")
+

--- a/core/os/SCsub
+++ b/core/os/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.core_sources, "*.cpp")
+env.add_header_files(env.core_headers, "*.h")

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -3,6 +3,7 @@
 Import('env')
 
 env.drivers_sources = []
+env.drivers_headers = []
 
 # OS drivers
 SConscript('unix/SCsub')
@@ -38,10 +39,12 @@ if env['vsproj']:
     path = os.getcwd()
     # Change directory so the path resolves correctly in the function call.
     os.chdir("..")
-    env.AddToVSProject(env.drivers_sources)
+    env.AddSourcesToVSProject(env.drivers_sources)
+    env.AddHeadersToVSProject(env.drivers_headers)
     os.chdir(path)
 
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")
 
 lib = env.add_library("drivers", env.drivers_sources)
 env.Prepend(LIBS=[lib])

--- a/drivers/alsa/SCsub
+++ b/drivers/alsa/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/alsamidi/SCsub
+++ b/drivers/alsamidi/SCsub
@@ -4,3 +4,4 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/coreaudio/SCsub
+++ b/drivers/coreaudio/SCsub
@@ -4,3 +4,4 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/coremidi/SCsub
+++ b/drivers/coremidi/SCsub
@@ -4,3 +4,4 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/dummy/SCsub
+++ b/drivers/dummy/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -21,3 +21,4 @@ if (env["platform"] in ["haiku", "osx", "windows", "x11"]):
 
 # Godot source files
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/gles2/SCsub
+++ b/drivers/gles2/SCsub
@@ -3,5 +3,6 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")
 
 SConscript("shaders/SCsub")

--- a/drivers/gles3/SCsub
+++ b/drivers/gles3/SCsub
@@ -3,5 +3,6 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources,"*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")
 
 SConscript("shaders/SCsub")

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -55,5 +55,6 @@ if env['builtin_libpng']:
 
 # Godot source files
 env_png.add_source_files(env.drivers_sources, "*.cpp")
+env_png.add_header_files(env.drivers_headers, "*.h")
 
 Export('env')

--- a/drivers/pulseaudio/SCsub
+++ b/drivers/pulseaudio/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -3,5 +3,6 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")
 
 env["check_c_headers"] = [ [ "mntent.h", "HAVE_MNTENT" ] ]

--- a/drivers/wasapi/SCsub
+++ b/drivers/wasapi/SCsub
@@ -4,3 +4,4 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/windows/SCsub
+++ b/drivers/windows/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/winmidi/SCsub
+++ b/drivers/winmidi/SCsub
@@ -4,3 +4,4 @@ Import('env')
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")

--- a/drivers/xaudio2/SCsub
+++ b/drivers/xaudio2/SCsub
@@ -3,5 +3,7 @@
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_header_files(env.drivers_headers, "*.h")
+
 env.Append(CPPDEFINES=['XAUDIO2_ENABLED'])
 env.Append(LINKFLAGS=['xaudio2_8.lib'])

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -3,6 +3,7 @@
 Import('env')
 
 env.editor_sources = []
+env.editor_headers = []
 
 import os
 import os.path
@@ -79,6 +80,7 @@ if env['tools']:
     env.CommandNoCache('#editor/builtin_fonts.gen.h', flist, run_in_subprocess(editor_builders.make_fonts_header))
 
     env.add_source_files(env.editor_sources, "*.cpp")
+    env.add_header_files(env.editor_headers, "*.h")
 
     SConscript('collada/SCsub')
     SConscript('doc/SCsub')

--- a/editor/collada/SCsub
+++ b/editor/collada/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.editor_sources, "*.cpp")
+env.add_header_files(env.editor_headers, "*.h")

--- a/editor/doc/SCsub
+++ b/editor/doc/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.editor_sources, "*.cpp")
+env.add_header_files(env.editor_headers, "*.h")

--- a/editor/fileserver/SCsub
+++ b/editor/fileserver/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.editor_sources, "*.cpp")
+env.add_header_files(env.editor_headers, "*.h")

--- a/editor/import/SCsub
+++ b/editor/import/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.editor_sources, "*.cpp")
+env.add_header_files(env.editor_headers, "*.h")

--- a/editor/plugins/SCsub
+++ b/editor/plugins/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.editor_sources, "*.cpp")
+env.add_header_files(env.editor_headers, "*.h")

--- a/main/SCsub
+++ b/main/SCsub
@@ -6,8 +6,10 @@ from platform_methods import run_in_subprocess
 import main_builders
 
 env.main_sources = []
+env.main_headers = []
 
 env.add_source_files(env.main_sources, "*.cpp")
+env.add_header_files(env.main_headers, "*.h")
 
 # order matters here.  higher index controller database files write on top of lower index database files
 controller_databases = ["#main/gamecontrollerdb.txt", "#main/gamecontrollerdb_205.txt", "#main/gamecontrollerdb_204.txt", "#main/godotcontrollerdb.txt"]

--- a/main/tests/SCsub
+++ b/main/tests/SCsub
@@ -3,7 +3,9 @@
 Import('env')
 
 env.tests_sources = []
+env.tests_headers = []
 env.add_source_files(env.tests_sources, "*.cpp")
+env.add_header_files(env.tests_headers, "*.h")
 
 lib = env.add_library("tests", env.tests_sources)
 env.Prepend(LIBS=[lib])

--- a/methods.py
+++ b/methods.py
@@ -31,6 +31,28 @@ def add_source_files(self, sources, files, warn_duplicates=True):
                 continue
         sources.append(obj)
 
+def add_header_files(self, headers, files, warn_duplicates=True):
+    # Convert string to list of absolute paths (including expanding wildcard)
+    if isbasestring(files):
+        # Keep SCons project-absolute path as they are (no wildcard support)
+        if files.startswith('#'):
+            if '*' in files:
+                print("ERROR: Wildcards can't be expanded in SCons project-absolute path: '{}'".format(files))
+                return
+            files = [files]
+        else:
+            dir_path = self.Dir('.').abspath
+            files = sorted(glob.glob(dir_path + "/" + files))
+
+    # Add each header path
+    for path in files:
+        if path in headers:
+            if warn_duplicates:
+                print("WARNING: Header \"{}\" already included in environment headers.".format(path))
+            else:
+                continue
+        headers.append(path)
+
 
 def disable_warnings(self):
     # 'self' is the environment
@@ -540,12 +562,20 @@ def generate_vs_project(env, num_jobs):
             result = " ^& ".join(common_build_prefix + [commands])
             return result
 
-        env.AddToVSProject(env.core_sources)
-        env.AddToVSProject(env.main_sources)
-        env.AddToVSProject(env.modules_sources)
-        env.AddToVSProject(env.scene_sources)
-        env.AddToVSProject(env.servers_sources)
-        env.AddToVSProject(env.editor_sources)
+        env.AddSourcesToVSProject(env.core_sources)
+        env.AddHeadersToVSProject(env.core_headers)
+        env.AddSourcesToVSProject(env.main_sources)
+        env.AddHeadersToVSProject(env.main_headers)
+        env.AddSourcesToVSProject(env.tests_sources)
+        env.AddHeadersToVSProject(env.tests_headers)
+        env.AddSourcesToVSProject(env.modules_sources)
+        env.AddHeadersToVSProject(env.modules_headers)
+        env.AddSourcesToVSProject(env.scene_sources)
+        env.AddHeadersToVSProject(env.scene_headers)
+        env.AddSourcesToVSProject(env.servers_sources)
+        env.AddHeadersToVSProject(env.servers_headers)
+        env.AddSourcesToVSProject(env.editor_sources)
+        env.AddHeadersToVSProject(env.editor_headers)
 
         # windows allows us to have spaces in paths, so we need
         # to double quote off the directory. However, the path ends

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -7,8 +7,10 @@ env_modules = env.Clone()
 Export('env_modules')
 
 env.modules_sources = []
+env.modules_headers = []
 
 env_modules.add_source_files(env.modules_sources, "register_module_types.gen.cpp")
+env_modules.add_header_files(env.modules_headers, "register_module_types.h")
 
 for x in env.module_list:
     if (x in env.disabled_modules):

--- a/modules/arkit/SCsub
+++ b/modules/arkit/SCsub
@@ -7,6 +7,8 @@ env_arkit = env_modules.Clone()
 
 # (iOS) Build as separate static library
 modules_sources = []
+modules_headers = []
 env_arkit.add_source_files(modules_sources, "*.cpp")
 env_arkit.add_source_files(modules_sources, "*.mm")
+env_arkit.add_header_files(modules_headers, "*.h")
 mod_lib = env_modules.add_library('#bin/libgodot_arkit_module' + env['LIBSUFFIX'], modules_sources)

--- a/modules/assimp/SCsub
+++ b/modules/assimp/SCsub
@@ -98,3 +98,4 @@ env_thirdparty.add_source_files(env.modules_sources, Glob('#thirdparty/assimp/co
 
 # Godot's own source files
 env_assimp.add_source_files(env.modules_sources, "*.cpp")
+env_assimp.add_header_files(env.modules_headers, "*.h")

--- a/modules/bmp/SCsub
+++ b/modules/bmp/SCsub
@@ -7,3 +7,4 @@ env_bmp = env_modules.Clone()
 
 # Godot's own source files
 env_bmp.add_source_files(env.modules_sources, "*.cpp")
+env_bmp.add_header_files(env.modules_headers, "*.h")

--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -201,3 +201,4 @@ if env['builtin_bullet']:
 
 # Godot source files
 env_bullet.add_source_files(env.modules_sources, "*.cpp")
+env_bullet.add_header_files(env.modules_headers, "*.h")

--- a/modules/camera/SCsub
+++ b/modules/camera/SCsub
@@ -20,3 +20,4 @@ elif env["platform"] == "osx":
     env_camera.add_source_files(env.modules_sources, "register_types.cpp")
     env_camera.add_source_files(env.modules_sources, "camera_osx.mm")
 
+env_camera.add_header_files(env.modules_headers, "*.h")

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -7,3 +7,4 @@ env_csg = env_modules.Clone()
 
 # Godot's own source files
 env_csg.add_source_files(env.modules_sources, "*.cpp")
+env_csg.add_header_files(env.modules_headers, "*.h")

--- a/modules/cvtt/SCsub
+++ b/modules/cvtt/SCsub
@@ -21,3 +21,5 @@ env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_cvtt.add_source_files(env.modules_sources, "*.cpp")
+env_cvtt.add_header_files(env.modules_headers, "*.h")
+

--- a/modules/dds/SCsub
+++ b/modules/dds/SCsub
@@ -6,3 +6,4 @@ Import('env_modules')
 env_dds = env_modules.Clone()
 
 env_dds.add_source_files(env.modules_sources, "*.cpp")
+env_dds.add_header_files(env.modules_headers, "*.h")

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -29,3 +29,4 @@ if env['builtin_enet']:
     env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 env_enet.add_source_files(env.modules_sources, "*.cpp")
+env_enet.add_header_files(env.modules_headers, "*.h")

--- a/modules/etc/SCsub
+++ b/modules/etc/SCsub
@@ -35,3 +35,4 @@ env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_etc.add_source_files(env.modules_sources, "*.cpp")
+env_etc.add_header_files(env.modules_headers, "*.h")

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -102,5 +102,6 @@ if env['builtin_freetype']:
 
 # Godot source files
 env_freetype.add_source_files(env.modules_sources, "*.cpp")
+env_freetype.add_header_files(env.modules_headers, "*.h")
 # Used in scene/, needs to be in main env
 env.Append(CPPDEFINES=['FREETYPE_ENABLED'])

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -12,6 +12,14 @@ env_gdnative.add_source_files(env.modules_sources, "nativescript/*.cpp")
 env_gdnative.add_source_files(env.modules_sources, "gdnative_library_singleton_editor.cpp")
 env_gdnative.add_source_files(env.modules_sources, "gdnative_library_editor_plugin.cpp")
 
+env_gdnative.add_header_files(env.modules_headers, "gdnative.h")
+env_gdnative.add_header_files(env.modules_headers, "register_types.h")
+env_gdnative.add_header_files(env.modules_headers, "android/*.h")
+env_gdnative.add_header_files(env.modules_headers, "gdnative/*.h")
+env_gdnative.add_header_files(env.modules_headers, "nativescript/*.h")
+env_gdnative.add_header_files(env.modules_headers, "gdnative_library_singleton_editor.h")
+env_gdnative.add_header_files(env.modules_headers, "gdnative_library_editor_plugin.h")
+
 env_gdnative.Prepend(CPPPATH=['#modules/gdnative/include/'])
 
 Export('env_gdnative')

--- a/modules/gdnative/arvr/SCsub
+++ b/modules/gdnative/arvr/SCsub
@@ -4,3 +4,4 @@ Import('env')
 Import('env_gdnative')
 
 env_gdnative.add_source_files(env.modules_sources, '*.cpp')
+env_gdnative.add_header_files(env.modules_headers, "*.h")

--- a/modules/gdnative/nativescript/SCsub
+++ b/modules/gdnative/nativescript/SCsub
@@ -4,6 +4,7 @@ Import('env')
 Import('env_gdnative')
 
 env_gdnative.add_source_files(env.modules_sources, '*.cpp')
+env_gdnative.add_header_files(env.modules_headers, "*.h")
 
 if "platform" in env and env["platform"] in ["x11", "iphone"]:
     env.Append(LINKFLAGS=["-rdynamic"])

--- a/modules/gdnative/net/SCsub
+++ b/modules/gdnative/net/SCsub
@@ -10,4 +10,4 @@ if has_webrtc:
     env_net.Append(CPPDEFINES=['WEBRTC_GDNATIVE_ENABLED'])
 
 env_net.add_source_files(env.modules_sources, '*.cpp')
-
+env_net.add_header_files(env.modules_headers, "*.h")

--- a/modules/gdnative/pluginscript/SCsub
+++ b/modules/gdnative/pluginscript/SCsub
@@ -4,3 +4,4 @@ Import('env')
 Import('env_gdnative')
 
 env_gdnative.add_source_files(env.modules_sources, '*.cpp')
+env_gdnative.add_header_files(env.modules_headers, "*.h")

--- a/modules/gdnative/videodecoder/SCsub
+++ b/modules/gdnative/videodecoder/SCsub
@@ -7,3 +7,4 @@ env_vsdecoder_gdnative = env_modules.Clone()
 
 env_vsdecoder_gdnative.Prepend(CPPPATH=['#modules/gdnative/include/'])
 env_vsdecoder_gdnative.add_source_files(env.modules_sources, '*.cpp')
+env_vsdecoder_gdnative.add_header_files(env.modules_headers, "*.h")

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -6,13 +6,16 @@ Import('env_modules')
 env_gdscript = env_modules.Clone()
 
 env_gdscript.add_source_files(env.modules_sources, "*.cpp")
+env_gdscript.add_header_files(env.modules_headers, "*.h")
 
 if env['tools']:
     env_gdscript.add_source_files(env.modules_sources, "./editor/*.cpp")
+    env_gdscript.add_header_files(env.modules_headers, "./editor/*.h")
 
     # Those two modules are required for the language server protocol
     if env['module_jsonrpc_enabled'] and env['module_websocket_enabled']:
         env_gdscript.add_source_files(env.modules_sources, "./language_server/*.cpp")
+        env_gdscript.add_header_files(env.modules_headers, "./language_server/*.h")
     else:
         # Using a define in the disabled case, to avoid having an extra define
         # in regular builds where all modules are enabled.

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -6,3 +6,4 @@ Import('env_modules')
 env_gridmap = env_modules.Clone()
 
 env_gridmap.add_source_files(env.modules_sources, "*.cpp")
+env_gridmap.add_header_files(env.modules_headers, "*.h")

--- a/modules/hdr/SCsub
+++ b/modules/hdr/SCsub
@@ -7,3 +7,4 @@ env_hdr = env_modules.Clone()
 
 # Godot's own source files
 env_hdr.add_source_files(env.modules_sources, "*.cpp")
+env_hdr.add_header_files(env.modules_headers, "*.h")

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -21,3 +21,4 @@ env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot's own source files
 env_jpg.add_source_files(env.modules_sources, "*.cpp")
+env_jpg.add_header_files(env.modules_headers, "*.h")

--- a/modules/jsonrpc/SCsub
+++ b/modules/jsonrpc/SCsub
@@ -5,3 +5,4 @@ Import('env_modules')
 
 env_jsonrpc = env_modules.Clone()
 env_jsonrpc.add_source_files(env.modules_sources, "*.cpp")
+env_jsonrpc.add_header_files(env.modules_headers, "*.h")

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -100,3 +100,4 @@ if env['builtin_mbedtls']:
 
 # Module sources
 env_mbed_tls.add_source_files(env.modules_sources, "*.cpp")
+env_mbed_tls.add_header_files(env.modules_headers, "*.h")

--- a/modules/mobile_vr/SCsub
+++ b/modules/mobile_vr/SCsub
@@ -6,3 +6,4 @@ Import('env_modules')
 env_mobile_vr = env_modules.Clone()
 
 env_mobile_vr.add_source_files(env.modules_sources, '*.cpp')
+env_mobile_vr.add_header_files(env.modules_headers, "*.h")

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -64,5 +64,11 @@ env_mono.add_source_files(env.modules_sources, 'glue/*.cpp')
 env_mono.add_source_files(env.modules_sources, 'mono_gd/*.cpp')
 env_mono.add_source_files(env.modules_sources, 'utils/*.cpp')
 
+env_mono.add_header_files(env.modules_headers, '*.h')
+env_mono.add_header_files(env.modules_headers, 'glue/*.h')
+env_mono.add_header_files(env.modules_headers, 'mono_gd/*.h')
+env_mono.add_header_files(env.modules_headers, 'utils/*.h')
+
 if env['tools']:
     env_mono.add_source_files(env.modules_sources, 'editor/*.cpp')
+    env_mono.add_header_files(env.modules_headers, 'editor/*.h')

--- a/modules/ogg/SCsub
+++ b/modules/ogg/SCsub
@@ -22,3 +22,4 @@ if env['builtin_libogg']:
 
 # Godot source files
 env_ogg.add_source_files(env.modules_sources, "*.cpp")
+env_ogg.add_header_files(env.modules_headers, "*.h")

--- a/modules/opensimplex/SCsub
+++ b/modules/opensimplex/SCsub
@@ -20,3 +20,4 @@ env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot's own source files
 env_opensimplex.add_source_files(env.modules_sources, "*.cpp")
+env_opensimplex.add_header_files(env.modules_headers, "*.h")

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -238,6 +238,10 @@ if env['builtin_opus']:
 if not stub:
     # Module files
     env_opus.add_source_files(env.modules_sources, "*.cpp")
+    env_opus.add_header_files(env.modules_headers, "*.h")
 else:
     # Module files
     env_opus.add_source_files(env.modules_sources, "stub/register_types.cpp")
+    env_opus.add_header_files(env.modules_headers, "stub/register_types.h")
+
+

--- a/modules/recast/SCsub
+++ b/modules/recast/SCsub
@@ -31,3 +31,4 @@ if env['builtin_recast']:
 
 # Godot source files
 env_recast.add_source_files(env.modules_sources, "*.cpp")
+env_recast.add_header_files(env.modules_headers, "*.h")

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -60,3 +60,4 @@ if env['builtin_pcre2']:
 
 env_regex.Append(CPPDEFINES=[("PCRE2_CODE_UNIT_WIDTH", 0)])
 env_regex.add_source_files(env.modules_sources, "*.cpp")
+env_regex.add_header_files(env.modules_headers, "*.h")

--- a/modules/squish/SCsub
+++ b/modules/squish/SCsub
@@ -30,3 +30,4 @@ if env['builtin_squish']:
 
 # Godot source files
 env_squish.add_source_files(env.modules_sources, "*.cpp")
+env_squish.add_header_files(env.modules_headers, "*.h")

--- a/modules/stb_vorbis/SCsub
+++ b/modules/stb_vorbis/SCsub
@@ -14,3 +14,4 @@ env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot's own source files
 env_stb_vorbis.add_source_files(env.modules_sources, "*.cpp")
+env_stb_vorbis.add_header_files(env.modules_headers, "*.h")

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -24,3 +24,4 @@ env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot's own source files
 env_svg.add_source_files(env.modules_sources, "*.cpp")
+env_svg.add_header_files(env.modules_headers, "*.h")

--- a/modules/tga/SCsub
+++ b/modules/tga/SCsub
@@ -7,3 +7,4 @@ env_tga = env_modules.Clone()
 
 # Godot's own source files
 env_tga.add_source_files(env.modules_sources, "*.cpp")
+env_tga.add_header_files(env.modules_headers, "*.h")

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -84,3 +84,4 @@ if env['builtin_libtheora']:
 
 # Godot source files
 env_theora.add_source_files(env.modules_sources, "*.cpp")
+env_theora.add_header_files(env.modules_headers, "*.h")

--- a/modules/tinyexr/SCsub
+++ b/modules/tinyexr/SCsub
@@ -21,3 +21,4 @@ env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot's own source files
 env_tinyexr.add_source_files(env.modules_sources, "*.cpp")
+env_tinyexr.add_header_files(env.modules_headers, "*.h")

--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -35,3 +35,4 @@ if env['builtin_miniupnpc']:
 
 # Godot source files
 env_upnp.add_source_files(env.modules_sources, "*.cpp")
+env_upnp.add_header_files(env.modules_headers, "*.h")

--- a/modules/vhacd/SCsub
+++ b/modules/vhacd/SCsub
@@ -31,3 +31,4 @@ env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 env_vhacd.add_source_files(env.modules_sources, "*.cpp")
+env_vhacd.add_header_files(env.modules_headers, "*.h")

--- a/modules/visual_script/SCsub
+++ b/modules/visual_script/SCsub
@@ -6,3 +6,4 @@ Import('env_modules')
 env_vs = env_modules.Clone()
 
 env_vs.add_source_files(env.modules_sources, "*.cpp")
+env_vs.add_header_files(env.modules_headers, "*.h")

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -56,3 +56,5 @@ if not stub:
 else:
     # Module files
     env_vorbis.add_source_files(env.modules_sources, "stub/register_types.cpp")
+
+env_vorbis.add_header_files(env.modules_headers, "*.h")

--- a/modules/webm/SCsub
+++ b/modules/webm/SCsub
@@ -35,3 +35,4 @@ env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 # Godot source files
 env_webm.add_source_files(env.modules_sources, "*.cpp")
+env_webm.add_header_files(env.modules_headers, "*.h")

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -134,3 +134,4 @@ if env['builtin_libwebp']:
 
 # Godot source files
 env_webp.add_source_files(env.modules_sources, "*.cpp")
+env_webp.add_header_files(env.modules_headers, "*.h")

--- a/modules/webrtc/SCsub
+++ b/modules/webrtc/SCsub
@@ -13,3 +13,4 @@ if use_gdnative: # GDNative is retained in Javascript for export compatibility
     env_webrtc.Prepend(CPPPATH=["#modules/gdnative/include/"])
 
 env_webrtc.add_source_files(env.modules_sources, "*.cpp")
+env_webrtc.add_header_files(env.modules_headers, "*.h")

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -28,3 +28,4 @@ if env['builtin_wslay'] and not env["platform"] == "javascript": # already built
     env_wslay.add_source_files(env.modules_sources, wslay_sources)
 
 env_ws.add_source_files(env.modules_sources, "*.cpp")
+env_ws.add_header_files(env.modules_headers, "*.h")

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -21,3 +21,4 @@ if env['builtin_xatlas']:
 
 # Godot source files
 env_xatlas_unwrap.add_source_files(env.modules_sources, "*.cpp")
+env_xatlas_unwrap.add_header_files(env.modules_headers, "*.h")

--- a/scene/2d/SCsub
+++ b/scene/2d/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
+env.add_header_files(env.scene_headers, "*.h")

--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -8,5 +8,11 @@ if env['disable_3d']:
     env.add_source_files(env.scene_sources, "particles.cpp")
     env.add_source_files(env.scene_sources, "visual_instance.cpp")
     env.add_source_files(env.scene_sources, "world_environment.cpp")
+    env.add_header_files(env.scene_headers, "spatial.h")
+    env.add_header_files(env.scene_headers, "skeleton.h")
+    env.add_header_files(env.scene_headers, "particles.h")
+    env.add_header_files(env.scene_headers, "visual_instance.h")
+    env.add_header_files(env.scene_headers, "world_environment.h")
 else:
     env.add_source_files(env.scene_sources, "*.cpp")
+    env.add_header_files(env.scene_headers, "*.h")

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -3,6 +3,7 @@
 Import('env')
 
 env.scene_sources = []
+env.scene_headers = []
 
 # Thirdparty code
 thirdparty_dir = "#thirdparty/misc/"
@@ -20,6 +21,7 @@ env_thirdparty.add_source_files(env.scene_sources, thirdparty_sources)
 
 # Godot's own sources
 env.add_source_files(env.scene_sources, "*.cpp")
+env.add_header_files(env.scene_headers, "*.h")
 
 
 # Chain load SCsubs

--- a/scene/animation/SCsub
+++ b/scene/animation/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
+env.add_header_files(env.scene_headers, "*.h")

--- a/scene/audio/SCsub
+++ b/scene/audio/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
+env.add_header_files(env.scene_headers, "*.h")

--- a/scene/debugger/SCsub
+++ b/scene/debugger/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
+env.add_header_files(env.scene_headers, "*.h")

--- a/scene/gui/SCsub
+++ b/scene/gui/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
+env.add_header_files(env.scene_headers, "*.h")

--- a/scene/main/SCsub
+++ b/scene/main/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
+env.add_header_files(env.scene_headers, "*.h")

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -3,5 +3,6 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
+env.add_header_files(env.scene_headers, "*.h")
 
 SConscript("default_theme/SCsub")

--- a/scene/resources/default_theme/SCsub
+++ b/scene/resources/default_theme/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.scene_sources, "*.cpp")
+env.add_header_files(env.scene_headers, "*.h")

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -3,7 +3,10 @@
 Import('env')
 
 env.servers_sources = []
+env.servers_headers = []
+
 env.add_source_files(env.servers_sources, "*.cpp")
+env.add_header_files(env.servers_headers, "*.h")
 
 SConscript('arvr/SCsub')
 SConscript('camera/SCsub')

--- a/servers/arvr/SCsub
+++ b/servers/arvr/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
+env.add_header_files(env.servers_headers, "*.h")

--- a/servers/audio/SCsub
+++ b/servers/audio/SCsub
@@ -3,5 +3,6 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
+env.add_header_files(env.servers_headers, "*.h")
 
 SConscript("effects/SCsub")

--- a/servers/audio/effects/SCsub
+++ b/servers/audio/effects/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
+env.add_header_files(env.servers_headers, "*.h")

--- a/servers/camera/SCsub
+++ b/servers/camera/SCsub
@@ -3,5 +3,6 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
+env.add_header_files(env.servers_headers, "*.h")
 
 Export('env')

--- a/servers/physics/SCsub
+++ b/servers/physics/SCsub
@@ -3,5 +3,6 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
+env.add_header_files(env.servers_headers, "*.h")
 
 SConscript("joints/SCsub")

--- a/servers/physics/joints/SCsub
+++ b/servers/physics/joints/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
+env.add_header_files(env.servers_headers, "*.h")

--- a/servers/physics_2d/SCsub
+++ b/servers/physics_2d/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
+env.add_header_files(env.servers_headers, "*.h")

--- a/servers/visual/SCsub
+++ b/servers/visual/SCsub
@@ -3,3 +3,4 @@
 Import('env')
 
 env.add_source_files(env.servers_sources, "*.cpp")
+env.add_header_files(env.servers_headers, "*.h")


### PR DESCRIPTION
Ive added a way to add headers into a file list for Scons, which can be used to populate the Visual Studio project files correctly, to solve https://github.com/godotengine/godot/issues/34371. It can probably be used for other things as well.

It basically adds a `env.add_header_files(env.****_headers, "*.h")` that Scons subs can use to make sure their headers get included.

I don't know if this is the best way, but it works well. After diffing the .vcxproj file it includes 61 missing header files (excluding `/drivers`, as those are separate projects to be generated it seems). It took a few hours of manual work to add the command correctly everywhere it was needed.