### PR TITLE
Make right align for calls number in Profiler

### DIFF
--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -397,6 +397,7 @@ void EditorProfiler::_update_frame() {
 			item->set_metadata(0, it.signature);
 			item->set_metadata(1, it.script);
 			item->set_metadata(2, it.line);
+			item->set_text_align(2, TreeItem::ALIGN_RIGHT);
 			item->set_tooltip(0, it.script + ":" + itos(it.line));
 
 			float time = dtime == DISPLAY_SELF_TIME ? it.self : it.total;


### PR DESCRIPTION
Before
![Screenshot from 2019-12-18 16-15-20](https://user-images.githubusercontent.com/8281454/71064228-f31e5200-21b1-11ea-8520-424a97d35451.png)

After
![Screenshot from 2019-12-18 16-14-10](https://user-images.githubusercontent.com/8281454/71064231-f580ac00-21b1-11ea-94a4-113be7d04386.png)
