### PR TITLE
Updates docs of AABB and Plane

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -43,7 +43,7 @@
 			<return type="float">
 			</return>
 			<description>
-				Gets the area of the [AABB].
+				Returns the volume of the [AABB].
 			</description>
 		</method>
 		<method name="get_endpoint">
@@ -182,7 +182,7 @@
 			<argument index="0" name="aabb" type="AABB">
 			</argument>
 			<description>
-				Returns [code]true[/code] if this [AABB] and [code]aabb[/code] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
+				Returns [code]true[/code] if this [AABB] and [code]aabb[/code] are approximately equal, by calling [method @GDScript.is_equal_approx] on each component.
 			</description>
 		</method>
 		<method name="merge">
@@ -197,7 +197,7 @@
 	</methods>
 	<members>
 		<member name="end" type="Vector3" setter="" getter="" default="Vector3( 0, 0, 0 )">
-			Ending corner.
+			Ending corner. This is calculated as [code]position + size[/code]. Changing this property changes [member size] accordingly.
 		</member>
 		<member name="position" type="Vector3" setter="" getter="" default="Vector3( 0, 0, 0 )">
 			Beginning corner.

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -22,7 +22,7 @@
 			<argument index="3" name="d" type="float">
 			</argument>
 			<description>
-				Creates a plane from the four parameters [code]a[/code], [code]b[/code], [code]c[/code] and [code]d[/code].
+				Creates a plane from the four parameters. The three components of the resulting plane's [member normal] are [code]a[/code], [code]b[/code] and [code]c[/code], and the plane has a distance of [code]d[/code] from the origin.
 			</description>
 		</method>
 		<method name="Plane">
@@ -35,7 +35,7 @@
 			<argument index="2" name="v3" type="Vector3">
 			</argument>
 			<description>
-				Creates a plane from three points.
+				Creates a plane from the three points, given in clockwise order.
 			</description>
 		</method>
 		<method name="Plane">
@@ -153,14 +153,19 @@
 	</methods>
 	<members>
 		<member name="d" type="float" setter="" getter="" default="0.0">
+			Distance from the origin to the plane, in the direction of [member normal].
 		</member>
 		<member name="normal" type="Vector3" setter="" getter="" default="Vector3( 0, 0, 0 )">
+			The normal of the plane. "Over" or "Above" the plane is considered the side of the plane towards where the normal is pointing.
 		</member>
 		<member name="x" type="float" setter="" getter="" default="0.0">
+			The [member normal]'s X component.
 		</member>
 		<member name="y" type="float" setter="" getter="" default="0.0">
+			The [member normal]'s Y component.
 		</member>
 		<member name="z" type="float" setter="" getter="" default="0.0">
+			The [member normal]'s Z component.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
* AABB
    * Describes `get_area()` as returning the volume instead of area.
    * Adds description of relationship between `end` and the other two properties.
    * Makes the `is_equal_approx()` function reference clickable.
* Plane
    * Adds parameter description of `Plane(a, b, c, d)`.
    * Metions how the three points of `Plane(v1, v2, v3)` should be ordered.
    * Adds description for the five properties.