### PR TITLE
Fix build warning in ustring.cpp on Windows/MSVC platform

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -28,6 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS // to disable build-time warning which suggested to use strcpy_s instead strcpy
+#endif
+
 #include "ustring.h"
 
 #include "core/color.h"


### PR DESCRIPTION
Fixes this warning:
![image](https://user-images.githubusercontent.com/3036176/71069840-978c9e00-218a-11ea-9124-f94417928df6.png)
