### PR TITLE
Fix error log when selecting child of Containers

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4076,10 +4076,9 @@ void CanvasItemEditor::_popup_warning_depop(Control *p_control) {
 	ERR_FAIL_COND(!popup_temporarily_timers.has(p_control));
 
 	Timer *timer = popup_temporarily_timers[p_control];
+	timer->queue_delete();
 	p_control->hide();
-	remove_child(timer);
 	popup_temporarily_timers.erase(p_control);
-	memdelete(timer);
 	info_overlay->set_margin(MARGIN_LEFT, (show_rulers ? RULER_WIDTH : 0) + 10);
 }
 


### PR DESCRIPTION
> * core/object.cpp:1955 - Object was freed or unreferenced while signal 'timeout' is being emitted from it. Try connecting to the signal using 'CONNECT_DEFERRED' flag, or use queue_free() to free the object (if this object is a Node) to avoid this error and potential crashes.

![error_log_container](https://user-images.githubusercontent.com/8281454/71096599-f3d6d880-21f1-11ea-8744-7fb7d5fd3a63.gif)
