### PR TITLE
Prevent to create or choose file outside of scope

### DIFF
--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -83,6 +83,8 @@ public:
 	virtual Error make_dir_recursive(String p_dir);
 	virtual Error erase_contents_recursive(); //super dangerous, use with care!
 
+	virtual bool check_access_scope(String p_path);
+
 	virtual bool file_exists(String p_file) = 0;
 	virtual bool dir_exists(String p_dir) = 0;
 	static bool exists(String p_dir);

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -111,6 +111,7 @@ private:
 	OptionButton *filter;
 	AcceptDialog *mkdirerr;
 	AcceptDialog *exterr;
+	AcceptDialog *patherr;
 	DirAccess *dir_access;
 	ConfirmationDialog *confirm_save;
 	DependencyRemoveDialog *remove_dialog;


### PR DESCRIPTION
Fixes #34194 

---

Validate relative paths in file dialog to make sure that
the provided path doesn't escape the scope of the
file dialog. Before it was possible to create, save or open a
file outside of res:// for example.

---

We also could move the `check_access_scope` to the driver implementation to let the operating system resolves the relative path and then make sure that the resolved path still starts with the root path of `DirAccess`. Feedback wanted.