### PR TITLE
[Mono] Color arithmetic operators

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -541,7 +541,7 @@ namespace Godot
             return true;
         }
 
-        public static Color Color8(byte r8, byte g8, byte b8, byte a8)
+        public static Color Color8(byte r8, byte g8, byte b8, byte a8 = 255)
         {
             return new Color(r8 / 255f, g8 / 255f, b8 / 255f, a8 / 255f);
         }
@@ -603,6 +603,74 @@ namespace Godot
 
             if (b < 0)
                 throw new ArgumentOutOfRangeException("Invalid color code. Blue part is not valid hexadecimal: " + rgba);
+        }
+
+        public static Color operator +(Color left, Color right)
+        {
+            left.r += right.r;
+            left.g += right.g;
+            left.b += right.b;
+            left.a += right.a;
+            return left;
+        }
+
+        public static Color operator -(Color left, Color right)
+        {
+            left.r -= right.r;
+            left.g -= right.g;
+            left.b -= right.b;
+            left.a -= right.a;
+            return left;
+        }
+
+        public static Color operator -(Color color)
+        {
+            return Colors.White - color;
+        }
+
+        public static Color operator *(Color color, float scale)
+        {
+            color.r *= scale;
+            color.g *= scale;
+            color.b *= scale;
+            color.a *= scale;
+            return color;
+        }
+
+        public static Color operator *(float scale, Color color)
+        {
+            color.r *= scale;
+            color.g *= scale;
+            color.b *= scale;
+            color.a *= scale;
+            return color;
+        }
+
+        public static Color operator *(Color left, Color right)
+        {
+            left.r *= right.r;
+            left.g *= right.g;
+            left.b *= right.b;
+            left.a *= right.a;
+            return left;
+        }
+
+        public static Color operator /(Color color, float scale)
+        {
+            color.r /= scale;
+            color.g /= scale;
+            color.b /= scale;
+            color.a /= scale;
+            return color;
+        }
+
+        public static Color operator /(Color left, Color right)
+        {
+            left.r /= right.r;
+            left.g /= right.g;
+            left.b /= right.b;
+            left.a /= right.a;
+            return left;
         }
 
         public static bool operator ==(Color left, Color right)


### PR DESCRIPTION
Fixes #34403, I also slipped in an `= 255` for `Color8` since I noticed it.

A few notes:

* [Core's `/= real_t` code](https://github.com/godotengine/godot/blob/master/core/color.cpp#L619) has a check for if the value is zero, but not for `/ real_t` (no `=`). This inconsistency should be fixed eventually, but which behavior should be kept?

* The above should also be changed to `float` because `Color` never has a need for more precision than `float`, perhaps these can be fixed at the same time.

* There is no `float * Color` in GDScript, only `Color * float`, but there is `float * Vector2` etc in GDScript and C#, so I added `float * Color` for C#.