### PR TITLE
[2.1] Fallback to the dummy audio driver if no other audio driver works

### DIFF
--- a/drivers/rtaudio/audio_driver_rtaudio.cpp
+++ b/drivers/rtaudio/audio_driver_rtaudio.cpp
@@ -181,7 +181,7 @@ Error AudioDriverRtAudio::init() {
 		}
 	}
 
-	return OK;
+	return active ? OK : ERR_UNAVAILABLE;
 }
 
 int AudioDriverRtAudio::get_mix_rate() const {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -143,12 +143,7 @@ void OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int 
 	};
 	visual_server->init();
 
-	AudioDriverManagerSW::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManagerSW::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManagerSW::initialize(p_audio_driver);
 
 	sample_manager = memnew(SampleManagerMallocSW);
 	audio_server = memnew(AudioServerSW(sample_manager));

--- a/platform/haiku/os_haiku.cpp
+++ b/platform/haiku/os_haiku.cpp
@@ -136,11 +136,7 @@ void OS_Haiku::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 	//physics_2d_server = Physics2DServerWrapMT::init_server<Physics2DServerSW>();
 	physics_2d_server->init();
 
-	AudioDriverManagerSW::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManagerSW::get_driver(p_audio_driver)->init() != OK) {
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManagerSW::initialize(p_audio_driver);
 
 	sample_manager = memnew(SampleManagerMallocSW);
 	audio_server = memnew(AudioServerSW(sample_manager));

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -440,12 +440,7 @@ void OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, i
 	visual_server = memnew(VisualServerRaster(rasterizer));
 	visual_server->init();
 
-	/*AudioDriverManagerSW::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManagerSW::get_driver(p_audio_driver)->init()!=OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}*/
+	// AudioDriverManagerSW::initialize(p_audio_driver);
 
 	print_line("Init SM");
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1029,12 +1029,7 @@ void OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 
 	visual_server->init();
 
-	AudioDriverManagerSW::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManagerSW::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManagerSW::initialize(p_audio_driver);
 
 	sample_manager = memnew(SampleManagerMallocSW);
 	audio_server = memnew(AudioServerSW(sample_manager));

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -62,12 +62,7 @@ void OS_Server::initialize(const VideoMode &p_desired, int p_video_driver, int p
 
 	visual_server = memnew(VisualServerRaster(rasterizer));
 
-	AudioDriverManagerSW::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManagerSW::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManagerSW::initialize(p_audio_driver);
 
 	sample_manager = memnew(SampleManagerMallocSW);
 	audio_server = memnew(AudioServerSW(sample_manager));
@@ -221,7 +216,6 @@ void OS_Server::run() {
 
 OS_Server::OS_Server() {
 
-	AudioDriverManagerSW::add_driver(&driver_dummy);
 	//adriver here
 	grab = false;
 };

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -33,7 +33,6 @@
 #include "drivers/rtaudio/audio_driver_rtaudio.h"
 #include "drivers/unix/os_unix.h"
 #include "main/input_default.h"
-#include "servers/audio/audio_driver_dummy.h"
 #include "servers/audio/audio_server_sw.h"
 #include "servers/audio/sample_manager_sw.h"
 #include "servers/physics_2d/physics_2d_server_sw.h"
@@ -57,7 +56,6 @@ class OS_Server : public OS_Unix {
 	List<String> args;
 	MainLoop *main_loop;
 
-	AudioDriverDummy driver_dummy;
 	bool grab;
 
 	PhysicsServer *physics_server;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1126,12 +1126,7 @@ void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int 
 	input = memnew(InputDefault);
 	joystick = memnew(joystick_windows(input, &hWnd));
 
-	AudioDriverManagerSW::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManagerSW::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManagerSW::initialize(p_audio_driver);
 
 	sample_manager = memnew(SampleManagerMallocSW);
 	audio_server = memnew(AudioServerSW(sample_manager));

--- a/platform/winrt/os_winrt.cpp
+++ b/platform/winrt/os_winrt.cpp
@@ -284,12 +284,7 @@ void OSWinrt::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	joystick = ref new JoystickWinrt(input);
 	joystick->register_events();
 
-	AudioDriverManagerSW::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManagerSW::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManagerSW::initialize(p_audio_driver);
 
 	sample_manager = memnew(SampleManagerMallocSW);
 	audio_server = memnew(AudioServerSW(sample_manager));

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -293,29 +293,7 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 		XFree(xsh);
 	}
 
-	AudioDriverManagerSW::get_driver(p_audio_driver)->set_singleton();
-
-	audio_driver_index = p_audio_driver;
-	if (AudioDriverManagerSW::get_driver(p_audio_driver)->init() != OK) {
-
-		bool success = false;
-		audio_driver_index = -1;
-		for (int i = 0; i < AudioDriverManagerSW::get_driver_count(); i++) {
-			if (i == p_audio_driver)
-				continue;
-			AudioDriverManagerSW::get_driver(i)->set_singleton();
-			if (AudioDriverManagerSW::get_driver(i)->init() == OK) {
-				success = true;
-				print_line("Audio Driver Failed: " + String(AudioDriverManagerSW::get_driver(p_audio_driver)->get_name()));
-				print_line("Using alternate audio driver: " + String(AudioDriverManagerSW::get_driver(i)->get_name()));
-				audio_driver_index = i;
-				break;
-			}
-		}
-		if (!success) {
-			ERR_PRINT("Initializing audio failed.");
-		}
-	}
+	AudioDriverManagerSW::initialize(p_audio_driver);
 
 	sample_manager = memnew(SampleManagerMallocSW);
 	audio_server = memnew(AudioServerSW(sample_manager));
@@ -2389,10 +2367,6 @@ OS::LatinKeyboardVariant OS_X11::get_latin_keyboard_variant() const {
 
 OS_X11::OS_X11() {
 
-#ifdef RTAUDIO_ENABLED
-	AudioDriverManagerSW::add_driver(&driver_rtaudio);
-#endif
-
 #ifdef PULSEAUDIO_ENABLED
 	AudioDriverManagerSW::add_driver(&driver_pulseaudio);
 #endif
@@ -2400,11 +2374,6 @@ OS_X11::OS_X11() {
 #ifdef ALSA_ENABLED
 	AudioDriverManagerSW::add_driver(&driver_alsa);
 #endif
-
-	if (AudioDriverManagerSW::get_driver_count() == 0) {
-		WARN_PRINT("No sound driver found... Defaulting to dummy driver");
-		AudioDriverManagerSW::add_driver(&driver_dummy);
-	}
 
 	minimized = false;
 	xim_style = 0L;

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -34,7 +34,6 @@
 #include "crash_handler_x11.h"
 #include "drivers/alsa/audio_driver_alsa.h"
 #include "drivers/pulseaudio/audio_driver_pulseaudio.h"
-#include "drivers/rtaudio/audio_driver_rtaudio.h"
 #include "drivers/unix/os_unix.h"
 #include "joystick_linux.h"
 #include "main/input_default.h"
@@ -173,10 +172,6 @@ class OS_X11 : public OS_Unix {
 	joystick_linux *joystick;
 #endif
 
-#ifdef RTAUDIO_ENABLED
-	AudioDriverRtAudio driver_rtaudio;
-#endif
-
 #ifdef ALSA_ENABLED
 	AudioDriverALSA driver_alsa;
 #endif
@@ -184,7 +179,6 @@ class OS_X11 : public OS_Unix {
 #ifdef PULSEAUDIO_ENABLED
 	AudioDriverPulseAudio driver_pulseaudio;
 #endif
-	AudioDriverDummy driver_dummy;
 
 	Atom net_wm_icon;
 

--- a/servers/audio/audio_server_sw.h
+++ b/servers/audio/audio_server_sw.h
@@ -36,6 +36,9 @@
 #include "servers/audio/audio_mixer_sw.h"
 #include "servers/audio/voice_rb_sw.h"
 #include "servers/audio_server.h"
+
+class AudioDriverDummy;
+
 class AudioServerSW : public AudioServer {
 
 	OBJ_TYPE(AudioServerSW, AudioServer);
@@ -265,9 +268,11 @@ class AudioDriverManagerSW {
 
 	static AudioDriverSW *drivers[MAX_DRIVERS];
 	static int driver_count;
+	static AudioDriverDummy dummy_driver;
 
 public:
 	static void add_driver(AudioDriverSW *p_driver);
+	static void initialize(int p_driver);
 	static int get_driver_count();
 	static AudioDriverSW *get_driver(int p_driver);
 };


### PR DESCRIPTION
Fix this issue https://github.com/godotengine/godot/issues/1684
Cannot cherry-pick those [changes](https://github.com/godotengine/godot/pull/11252), had to make the fix manually