### PR TITLE
[Mono] Make Sign methods consistent with GDScript and System.Math

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -266,12 +266,14 @@ namespace Godot
 
         public static int Sign(int s)
         {
+            if (s == 0) return 0;
             return s < 0 ? -1 : 1;
         }
 
-        public static real_t Sign(real_t s)
+        public static int Sign(real_t s)
         {
-            return s < 0f ? -1f : 1f;
+            if (s == 0) return 0;
+            return s < 0 ? -1 : 1;
         }
 
         public static real_t Sin(real_t s)


### PR DESCRIPTION
Fixes an issue reported by Fabián\#7304 on `#csharp` on Discord.

I don't really know if we need the version that takes in an `int`, but @Chaosus added it and it might be better for performance, so I'll leave it unless someone says otherwise I guess.