### PR TITLE
Python pickle version fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ logs/
 
 # for projects that use SCons for building: http://http://www.scons.org/
 .sconf_temp
-.sconsign.dblite
+.sconsign*.dblite
 *.pyc
 
 # https://github.com/github/gitignore/blob/master/VisualStudio.gitignore

--- a/SConstruct
+++ b/SConstruct
@@ -5,6 +5,7 @@ EnsureSConsVersion(0, 98, 1)
 # System
 import glob
 import os
+import pickle
 import sys
 
 # Local
@@ -87,6 +88,9 @@ env_base.__class__.disable_warnings = methods.disable_warnings
 
 env_base["x86_libtheora_opt_gcc"] = False
 env_base["x86_libtheora_opt_vc"] = False
+
+# avoid issues when building with different versions of python out of the same directory
+env_base.SConsignFile(".sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL))
 
 # Build options
 


### PR DESCRIPTION
Added support to allow to compile Godot from the same directory while using different versions of python.

More info:
I compile Godot using different a combinations of dockers and just straight off my main system out of the same directory.
My main system uses bleeding edge version of python - 3.8
while my docker uses an old version of python for stability - 3.5

scons uses the pickle library to persist what files have been built, but it saves it using pickle.HIGHEST_PROTOCOL

this means if I build using my main system, the generate .sconsign.dblite is in pickle format 5 (which was changed in python 3.8 I believe).
then if I went to build on my docker it would fail with a pickle error.

the previous solution was to delete the .sconsign.dblite file to allow the build to run, but the whole project would be recompiled from scratch!

this patch resolves the problem by adding in the pickle version into the filename.