### PR TITLE
Mono/C#: Fix Variant -> MonoString* when type is Variant:NIL

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -78,7 +78,13 @@ namespace GodotTools.Export
             catch (Exception e)
             {
                 maybeLastExportError = e.Message;
-                GD.PushError($"Failed to export project: {e.Message}");
+
+                // 'maybeLastExportError' cannot be null or empty if there was an error, so we
+                // must consider the possibility of exceptions being thrown without a message.
+                if (string.IsNullOrEmpty(maybeLastExportError))
+                    maybeLastExportError = $"Exception thrown: {e.GetType().Name}";
+
+                GD.PushError($"Failed to export project: {maybeLastExportError}");
                 Console.Error.WriteLine(e);
                 // TODO: Do something on error once _ExportBegin supports failing.
             }
@@ -513,7 +519,7 @@ namespace GodotTools.Export
                 case OS.Platforms.HTML5:
                     return "wasm-wasm32";
                 default:
-                    throw new NotSupportedException();
+                    throw new NotSupportedException($"Platform not supported: {platform}");
             }
         }
 
@@ -655,7 +661,7 @@ namespace GodotTools.Export
                 case OS.Platforms.HTML5:
                     return "wasm";
                 default:
-                    throw new NotSupportedException();
+                    throw new NotSupportedException($"Platform not supported: {platform}");
             }
         }
 

--- a/modules/mono/mono_gd/gd_mono_field.cpp
+++ b/modules/mono/mono_gd/gd_mono_field.cpp
@@ -110,8 +110,14 @@ void GDMonoField::set_value_from_variant(MonoObject *p_object, const Variant &p_
 		} break;
 
 		case MONO_TYPE_STRING: {
-			MonoString *mono_string = GDMonoMarshal::mono_string_from_godot(p_value);
-			mono_field_set_value(p_object, mono_field, mono_string);
+			if (p_value.get_type() == Variant::NIL) {
+				// Otherwise, Variant -> String would return the string "Null"
+				MonoString *mono_string = NULL;
+				mono_field_set_value(p_object, mono_field, mono_string);
+			} else {
+				MonoString *mono_string = GDMonoMarshal::mono_string_from_godot(p_value);
+				mono_field_set_value(p_object, mono_field, mono_string);
+			}
 		} break;
 
 		case MONO_TYPE_VALUETYPE: {

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -374,6 +374,8 @@ MonoObject *variant_to_mono_object(const Variant *p_var, const ManagedType &p_ty
 		}
 
 		case MONO_TYPE_STRING: {
+			if (p_var->get_type() == Variant::NIL)
+				return NULL; // Otherwise, Variant -> String would return the string "Null"
 			return (MonoObject *)mono_string_from_godot(p_var->operator String());
 		} break;
 


### PR DESCRIPTION
`Variant::operator String()` returns "Null" if the type is `Variant:NIL`.
We must consider that and return a null `MonoString*` instead when marshalling.
This was also causing a "Null" error to be displayed when exporting a game because null string members would be set to "Null" during hot-reload.
