### PR TITLE
Fixes property names serialization in project.godot

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -769,10 +769,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 
 			String vstr;
 			VariantWriter::write_to_string(value, vstr);
-			if (F->get().find(" ") != -1)
-				file->store_string(F->get().quote() + "=" + vstr + "\n");
-			else
-				file->store_string(F->get() + "=" + vstr + "\n");
+			file->store_string(F->get().property_name_encode() + "=" + vstr + "\n");
 		}
 	}
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -4059,6 +4059,19 @@ String String::percent_decode() const {
 	return String::utf8(pe.ptr());
 }
 
+String String::property_name_encode() const {
+	// Escape and quote strings with extended ASCII or further Unicode characters
+	// as well as '"', '=' or ' ' (32)
+	const CharType *cstr = c_str();
+	for (int i = 0; cstr[i]; i++) {
+		if (cstr[i] == '=' || cstr[i] == '"' || cstr[i] < 33 || cstr[i] > 126) {
+			return "\"" + c_escape_multiline() + "\"";
+		}
+	}
+	// Keep as is
+	return *this;
+}
+
 String String::get_basename() const {
 
 	int pos = find_last(".");

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -338,6 +338,8 @@ public:
 	String percent_encode() const;
 	String percent_decode() const;
 
+	String property_name_encode() const;
+
 	bool is_valid_identifier() const;
 	bool is_valid_integer() const;
 	bool is_valid_float() const;

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1530,9 +1530,6 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 			} else if (c != '=') {
 				what += String::chr(c);
 			} else {
-				if (p_stream->is_utf8()) {
-					what.parse_utf8(what.ascii(true).get_data());
-				}
 				r_assign = what;
 				Token token;
 				get_token(p_stream, token, line, r_err_str);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1459,20 +1459,6 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 	}
 }
 
-static String _valprop(const String &p_name) {
-
-	// Escape and quote strings with extended ASCII or further Unicode characters
-	// as well as '"', '=' or ' ' (32)
-	const CharType *cstr = p_name.c_str();
-	for (int i = 0; cstr[i]; i++) {
-		if (cstr[i] == '=' || cstr[i] == '"' || cstr[i] < 33 || cstr[i] > 126) {
-			return "\"" + p_name.c_escape_multiline() + "\"";
-		}
-	}
-	// Keep as is
-	return p_name;
-}
-
 Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
 
 	if (p_path.ends_with(".tscn")) {
@@ -1675,7 +1661,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 
 				String vars;
 				VariantWriter::write_to_string(value, vars, _write_resources, this);
-				f->store_string(_valprop(name) + " = " + vars + "\n");
+				f->store_string(name.property_name_encode() + " = " + vars + "\n");
 			}
 		}
 
@@ -1747,7 +1733,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 				String vars;
 				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, _write_resources, this);
 
-				f->store_string(_valprop(String(state->get_node_property_name(i, j))) + " = " + vars + "\n");
+				f->store_string(String(state->get_node_property_name(i, j)).property_name_encode() + " = " + vars + "\n");
 			}
 
 			if (i < state->get_node_count() - 1)


### PR DESCRIPTION
* Fixes unicode error when project name contains Unicode characters
* Serializes property names in `project.godot` following the same rule as in `ResourceFormatSaverTextInstance `
    * The common rule is extracted as `String::property_name_encode()`
        * Why not `quote_*` or `escape_*`:
            * It's the combination of quote and escape.
            * It's more like `percent_encode`, where characters are escaped only if a certain criteria is met.

---

Before this fix, when the project name contains Unciode character (e.g. `测试`), a `Unicode error: no space left` error message will be printed during Godot startup.

This behavior was introduced by #26787 which I believe is a wrong fix to #26380.

https://github.com/godotengine/godot/blob/a7430a9d060614169dd00117adc00ffab2a245a7/core/variant_parser.cpp#L1545-L1547

`what` may be assigned by the `get_token` result string, which contains valid Unicode code points. Calling `.ascii(true)` truncates the `wchar_t` code points to `char`, causing `parse_utf8` to fail. (Anyway, it's a valid Unicode string, `parse_utf8` is not even necessary.)

The root cause of issue #26380 is that property names in `project.godot` are not properly serialized. It only quotes the name when a space is detected. The behavior is inconsistent with `ResourceFormatSaverTextInstance`.

https://github.com/godotengine/godot/blob/2a4c528d067826dd1af865c93c3dc945c9a0e196/core/project_settings.cpp#L772-L775

https://github.com/godotengine/godot/blob/2a4c528d067826dd1af865c93c3dc945c9a0e196/scene/resources/resource_format_text.cpp#L1464-L1473
