### PR TITLE
Always use 16 bit renderbuffer depth on WebGL

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5812,10 +5812,11 @@ void RasterizerStorageGLES2::initialize() {
 	config.support_npot_repeat_mipmap = config.extensions.has("GL_OES_texture_npot");
 
 #ifdef JAVASCRIPT_ENABLED
-	// no way of detecting 32 or 16 bit support for renderbuffer, so default to 32
+	// RenderBuffer internal format must be 16 bits in WebGL,
+	// but depth_texture should default to 32 always
 	// if the implementation doesn't support 32, it should just quietly use 16 instead
 	// https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/
-	config.depth_buffer_internalformat = GL_DEPTH_COMPONENT;
+	config.depth_buffer_internalformat = GL_DEPTH_COMPONENT16;
 	config.depth_type = GL_UNSIGNED_INT;
 #else
 	// on mobile check for 24 bit depth support for RenderBufferStorage


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/34459

Looks like in the previous PR I mixed up depth textures and renderbuffers and thought I could have a 32 bit renderbuffer. In fact, what we needed was a 32 bit depth texture (which we got with ``config.depth_type = GL_UNSIGNED_INT``) as 32 bit renderbuffers don't exist for WebGL.

Now renderbuffer is properly 16 bit while depth texture defaults properly to 32 bit (or whatever the highest the platform supports is).