### PR TITLE
Add signal for when contents of cell are changed

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -336,7 +336,6 @@ void GridMap::set_cell_item(int p_x, int p_y, int p_z, int p_item, int p_rot) {
 	c.rot = p_rot;
 
 	cell_map[key] = c;
-	
 	emit_signal("cell_contents_changed", Vector3(p_x, p_y, p_z));
 }
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -336,6 +336,8 @@ void GridMap::set_cell_item(int p_x, int p_y, int p_z, int p_item, int p_rot) {
 	c.rot = p_rot;
 
 	cell_map[key] = c;
+	
+	emit_signal("cell_contents_changed", Vector3(p_x, p_y, p_z));
 }
 
 int GridMap::get_cell_item(int p_x, int p_y, int p_z) const {
@@ -878,6 +880,7 @@ void GridMap::_bind_methods() {
 
 	BIND_CONSTANT(INVALID_CELL_ITEM);
 
+	ADD_SIGNAL(MethodInfo("cell_contents_changed", PropertyInfo(Variant::VECTOR3, "cell_location")));
 	ADD_SIGNAL(MethodInfo("cell_size_changed", PropertyInfo(Variant::VECTOR3, "cell_size")));
 }
 


### PR DESCRIPTION
Enhancement suggested by issue #11855. Creates a new signal for GridMap of "cell_contents_changed"
This signal passes info on the location of the cell updated as a Vector3