### PR TITLE
Make sure no additional slash being added with localize_path

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -107,6 +107,10 @@ String ProjectSettings::localize_path(const String &p_path) const {
 		if (plocal == "") {
 			return "";
 		};
+		// Only strip the starting '/' from 'path' if its parent ('plocal') ends with '/'
+		if (plocal[plocal.length() - 1] == '/') {
+			sep += 1;
+		}
 		return plocal + path.substr(sep, path.size() - sep);
 	};
 }


### PR DESCRIPTION
I took what @neikeq suggest at https://github.com/godotengine/godot/pull/34279/files#r357744994
This fixes #33654

![image](https://user-images.githubusercontent.com/8281454/71233337-a9ac3f00-2338-11ea-8a4f-6a1f38225411.png)

`/new_script.gd` is open through File > Open.
`new_script.gd` is open through FileSystem dock.