### PR TITLE
Fix points being classified outside navmesh2d at edges

### DIFF
--- a/scene/2d/navigation_2d.h
+++ b/scene/2d/navigation_2d.h
@@ -151,6 +151,13 @@ class Navigation2D : public Node2D {
 	void _navpoly_link(int p_id);
 	void _navpoly_unlink(int p_id);
 
+	const real_t _point_in_tri_bb_epsilon = 1.0f;
+	const real_t _point_in_tri_edge_epsilon = 1.0f;
+	const real_t _point_in_tri_large_dist = 1e20;
+
+	real_t _is_point_within_poly(const Vector2 &p_point, const Navigation2D::Polygon &p_poly, int p_tri) const;
+	void _find_closest_polys(const Vector2 &p_pointA, const Vector2 &p_pointB, Navigation2D::Polygon **r_polyA, Navigation2D::Polygon **r_polyB) const;
+
 	float cell_size;
 	Map<int, NavMesh> navpoly_map;
 	int last_id;


### PR DESCRIPTION
Fixes #34449.

The old method of finding which navmesh triangle start and end points are within could fail due to floating point error if a point was on an edge, between 2 triangles. This new method uses a different test with an epsilon, and allows finding the closest triangle even if the point was just outside.

**Notes**
* I'm using _real_t_ type here going with the whole idea of enabling compiling with real_t as double. However I don't know how necessary this would be in practice even with a large 2d map, so can easily change these to float.
* I'm not sure how efficient the whole process of going through the nav polys is, I'm assuming it's using a linked list, I just copied that bit from the original. I'd personally probably pre-create a linear list, or use a spatial partitioning scheme (even a grid) however in the interests of changing as little as possible I've left as is. This is all getting changed in 4.0 anyway so this is more a bug fix.
* There are other ways of doing point in triangle tests (e.g. barycentric) but I wanted some kind of measure of closeness in world space so the triangles would be comparable.
* The test itself is not that optimized, but it does a cheaper bounding box test first so it shouldn't matter in practice. Bounding boxes could also be precalculated but again, I'm doing minimal changes.

This could do with some more testing, I've only tested it with the godot demo project for 2d navigation. I've never actually used the godot 2d / 3d navmeshes! :smile: 