### PR TITLE
Mention how to handle cancel in ConfirmationDialog

### DIFF
--- a/doc/classes/ConfirmationDialog.xml
+++ b/doc/classes/ConfirmationDialog.xml
@@ -5,6 +5,10 @@
 	</brief_description>
 	<description>
 		Dialog for confirmation of actions. This dialog inherits from [AcceptDialog], but has by default an OK and Cancel button (in host OS order).
+		To get cancel action, you can use:
+		[codeblock]
+		get_cancel().connect("pressed", self, "cancelled")
+		[/codeblock].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Resolves #17460

Although not sure what about the `modal_closed` mentioned in the issue. The `get_cancel()` is the proper way to use cancel, but you can do also do
```
connect("modal_closed", self, "cancelled") #This is emitted when user clicks outside dialog.
get_close_button().connect("pressed", self, "cancelled") #This is emitted when user clicks X.
```
which are more like "neutral actions" and aren't immanent to ConfirmationDialog.