### PR TITLE
Makes more editor strings translatable

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -413,7 +413,7 @@ ConnectDialog::ConnectDialog() {
 	vbc_right->add_margin_child(TTR("Extra Call Arguments:"), bind_editor, true);
 
 	HBoxContainer *dstm_hb = memnew(HBoxContainer);
-	vbc_left->add_margin_child("Receiver Method:", dstm_hb);
+	vbc_left->add_margin_child(TTR("Receiver Method:"), dstm_hb);
 
 	dst_method = memnew(LineEdit);
 	dst_method->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -789,7 +789,7 @@ public:
 	Ref<Texture> get_class_icon(const String &p_class, const String &p_fallback = "Object") const;
 
 	void show_accept(const String &p_text, const String &p_title);
-	void show_warning(const String &p_text, const String &p_title = "Warning!");
+	void show_warning(const String &p_text, const String &p_title = TTR("Warning!"));
 
 	void _copy_warning(const String &p_str);
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -446,7 +446,7 @@ GroupDialog::GroupDialog() {
 	add_group_text->connect("text_entered", this, "_add_group_pressed");
 
 	Button *add_group_button = memnew(Button);
-	add_group_button->set_text("Add");
+	add_group_button->set_text(TTR("Add"));
 	chbc->add_child(add_group_button);
 	add_group_button->connect("pressed", this, "_add_group_pressed", varray(String()));
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1329,7 +1329,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	top_hb->add_spacer();
 
-	top_hb->add_child(memnew(Label("Play Mode:")));
+	top_hb->add_child(memnew(Label(TTR("Play Mode:"))));
 	play_mode = memnew(OptionButton);
 	top_hb->add_child(play_mode);
 

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -273,7 +273,7 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 	menu = memnew(MenuButton);
 	SpatialEditor::get_singleton()->add_control_to_menu_panel(menu);
 	menu->set_position(Point2(1, 1));
-	menu->set_text("Mesh Library");
+	menu->set_text(TTR("Mesh Library"));
 	menu->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("MeshLibrary", "EditorIcons"));
 	menu->get_popup()->add_item(TTR("Add Item"), MENU_OPTION_ADD_ITEM);
 	menu->get_popup()->add_item(TTR("Remove Selected Item"), MENU_OPTION_REMOVE_ITEM);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1225,7 +1225,7 @@ void ScriptEditor::_menu_option(int p_option) {
 
 				Ref<Script> scr = current->get_edited_resource();
 				if (scr == NULL || scr.is_null()) {
-					EditorNode::get_singleton()->show_warning("Can't obtain the script for running.");
+					EditorNode::get_singleton()->show_warning(TTR("Can't obtain the script for running."));
 					break;
 				}
 
@@ -1233,18 +1233,18 @@ void ScriptEditor::_menu_option(int p_option) {
 				Error err = scr->reload(false); //hard reload script before running always
 
 				if (err != OK) {
-					EditorNode::get_singleton()->show_warning("Script failed reloading, check console for errors.");
+					EditorNode::get_singleton()->show_warning(TTR("Script failed reloading, check console for errors."));
 					return;
 				}
 				if (!scr->is_tool()) {
 
-					EditorNode::get_singleton()->show_warning("Script is not in tool mode, will not be able to run.");
+					EditorNode::get_singleton()->show_warning(TTR("Script is not in tool mode, will not be able to run."));
 					return;
 				}
 
 				if (!ClassDB::is_parent_class(scr->get_instance_base_type(), "EditorScript")) {
 
-					EditorNode::get_singleton()->show_warning("To run this script, it must inherit EditorScript and be set to tool mode.");
+					EditorNode::get_singleton()->show_warning(TTR("To run this script, it must inherit EditorScript and be set to tool mode."));
 					return;
 				}
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -404,10 +404,15 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	HBoxContainer *tool_hb = memnew(HBoxContainer);
 	Ref<ButtonGroup> g(memnew(ButtonGroup));
 
-	String workspace_label[WORKSPACE_MODE_MAX] = { "Edit", "New Single Tile", "New Autotile", "New Atlas" };
+	String workspace_label[WORKSPACE_MODE_MAX] = {
+		TTR("Edit"),
+		TTR("New Single Tile"),
+		TTR("New Autotile"),
+		TTR("New Atlas")
+	};
 	for (int i = 0; i < (int)WORKSPACE_MODE_MAX; i++) {
 		tool_workspacemode[i] = memnew(Button);
-		tool_workspacemode[i]->set_text(TTR(workspace_label[i]));
+		tool_workspacemode[i]->set_text(workspace_label[i]);
 		tool_workspacemode[i]->set_toggle_mode(true);
 		tool_workspacemode[i]->set_button_group(g);
 		tool_workspacemode[i]->connect("pressed", this, "_on_workspace_mode_changed", varray(i));
@@ -445,7 +450,16 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tool_hb = memnew(HBoxContainer);
 
 	g = Ref<ButtonGroup>(memnew(ButtonGroup));
-	String label[EDITMODE_MAX] = { "Region", "Collision", "Occlusion", "Navigation", "Bitmask", "Priority", "Icon", "Z Index" };
+	String label[EDITMODE_MAX] = {
+		TTR("Region"),
+		TTR("Collision"),
+		TTR("Occlusion"),
+		TTR("Navigation"),
+		TTR("Bitmask"),
+		TTR("Priority"),
+		TTR("Icon"),
+		TTR("Z Index")
+	};
 	for (int i = 0; i < (int)EDITMODE_MAX; i++) {
 		tool_editmode[i] = memnew(Button);
 		tool_editmode[i]->set_text(label[i]);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -572,7 +572,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				if (nd_list->is_input_port_editable()) {
 					has_gnode_text = true;
 					Button *btn = memnew(Button);
-					btn->set_text("Add Input Port");
+					btn->set_text(TTR("Add Input Port"));
 					hbnc->add_child(btn);
 					btn->connect("pressed", this, "_add_input_port", varray(E->get()));
 				}
@@ -581,7 +581,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 						hbnc->add_spacer();
 					has_gnode_text = true;
 					Button *btn = memnew(Button);
-					btn->set_text("Add Output Port");
+					btn->set_text(TTR("Add Output Port"));
 					hbnc->add_child(btn);
 					btn->connect("pressed", this, "_add_output_port", varray(E->get()));
 				}


### PR DESCRIPTION
* "Add" button text in Groups Editor
* "Receiver Method" in Connect Signal Dialog
* "Play Mode" in Animation State Machine Editor
* "Mesh Library" button text in Mesh Library editor plugin
* Compose Array node button texts in Visual Script
* Various button texts in TileSet Editor
* Various Run Script errors