### PR TITLE
Mono/C#: Remove GodotTools dependency on the Mono.Posix assembly

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -34,7 +34,6 @@
       <HintPath>..\packages\JetBrains.Annotations.2019.1.3\lib\net20\JetBrains.Annotations.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Posix" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -99,9 +98,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Ides\Rider\.editorconfig" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using Mono.Unix.Native;
 
 namespace GodotTools.Utils
 {
@@ -14,6 +13,9 @@ namespace GodotTools.Utils
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
         static extern string GetPlatformName();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        static extern bool UnixFileHasExecutableAccess(string filePath);
 
         public static class Names
         {
@@ -131,7 +133,7 @@ namespace GodotTools.Utils
             searchDirs.Add(System.IO.Directory.GetCurrentDirectory()); // last in the list
 
             return searchDirs.Select(dir => Path.Combine(dir, name))
-                .FirstOrDefault(path => File.Exists(path) && Syscall.access(path, AccessModes.X_OK) == 0);
+                .FirstOrDefault(path => File.Exists(path) && UnixFileHasExecutableAccess(path));
         }
 
         public static void RunProcess(string command, IEnumerable<string> arguments)

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -30,6 +30,10 @@
 
 #include "editor_internal_calls.h"
 
+#ifdef UNIX_ENABLED
+#include <unistd.h> // access
+#endif
+
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
@@ -370,6 +374,15 @@ MonoString *godot_icall_Utils_OS_GetPlatformName() {
 	return GDMonoMarshal::mono_string_from_godot(os_name);
 }
 
+MonoBoolean godot_icall_Utils_OS_UnixFileHasExecutableAccess(MonoString *p_file_path) {
+#ifdef UNIX_ENABLED
+	String file_path = GDMonoMarshal::mono_string_to_godot(p_file_path);
+	return access(file_path.utf8().get_data(), X_OK) == 0;
+#else
+	ERR_FAIL_V(false);
+#endif
+}
+
 void register_editor_internal_calls() {
 
 	// GodotSharpDirs
@@ -442,4 +455,5 @@ void register_editor_internal_calls() {
 
 	// Utils.OS
 	mono_add_internal_call("GodotTools.Utils.OS::GetPlatformName", (void *)godot_icall_Utils_OS_GetPlatformName);
+	mono_add_internal_call("GodotTools.Utils.OS::UnixFileHasExecutableAccess", (void *)godot_icall_Utils_OS_UnixFileHasExecutableAccess);
 }


### PR DESCRIPTION
MSBuild on Windows uses the system .NET Framework BCL instead of Mono's. Because of this, it may not be able to find the Mono.Posix assembly, so it's better not to depend on it.
We needed Mono.Posix to call Syscall.access, so we can replace this with an internal call that does the same in C++.
