### PR TITLE
WSLPeer now prevents receiving data after close.

### DIFF
--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -142,7 +142,7 @@ int wsl_genmask_callback(wslay_event_context_ptr ctx, uint8_t *buf, size_t len, 
 
 void wsl_msg_recv_callback(wslay_event_context_ptr ctx, const struct wslay_event_on_msg_recv_arg *arg, void *user_data) {
 	struct WSLPeer::PeerData *peer_data = (struct WSLPeer::PeerData *)user_data;
-	if (!peer_data->valid) {
+	if (!peer_data->valid || peer_data->closing) {
 		return;
 	}
 	WSLPeer *peer = (WSLPeer *)peer_data->peer;
@@ -293,6 +293,7 @@ void WSLPeer::close(int p_code, String p_reason) {
 		CharString cs = p_reason.utf8();
 		wslay_event_queue_close(_data->ctx, p_code, (uint8_t *)cs.ptr(), cs.size());
 		wslay_event_send(_data->ctx);
+		_data->closing = true;
 	}
 
 	_in_buffer.clear();

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -53,6 +53,7 @@ public:
 		bool destroy;
 		bool valid;
 		bool is_server;
+		bool closing;
 		void *obj;
 		void *peer;
 		Ref<StreamPeer> conn;
@@ -68,6 +69,7 @@ public:
 			id = 1;
 			ctx = NULL;
 			obj = NULL;
+			closing = false;
 			peer = NULL;
 		}
 	};


### PR DESCRIPTION
Used to spit error and report empty packets when connection was still half-closed (waiting for confirmation from other end).