### PR TITLE
Correct size for PacketPeerStream in Debugger.

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -2247,7 +2247,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	add_constant_override("margin_right", -EditorNode::get_singleton()->get_gui_base()->get_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(MARGIN_RIGHT));
 
 	ppeer = Ref<PacketPeerStream>(memnew(PacketPeerStream));
-	ppeer->set_input_buffer_max_size(1024 * 1024 * 8); //8mb should be enough
+	ppeer->set_input_buffer_max_size((1024 * 1024 * 8) - 4); // 8 MiB should be enough, minus 4 bytes for separator.
 	editor = p_editor;
 	editor->get_inspector()->connect("object_id_selected", this, "_scene_tree_property_select_object");
 

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -1257,7 +1257,7 @@ ScriptDebuggerRemote::ScriptDebuggerRemote() :
 		scene_tree(NULL) {
 
 	packet_peer_stream->set_stream_peer(tcp_client);
-	packet_peer_stream->set_output_buffer_max_size(1024 * 1024 * 8); //8mb should be way more than enough
+	packet_peer_stream->set_output_buffer_max_size((1024 * 1024 * 8) - 4); // 8 MiB should be way more than enough, minus 4 bytes for separator.
 
 	phl.printfunc = _print_handler;
 	phl.userdata = this;


### PR DESCRIPTION
We wanted 8 MiB but we were getting 16 MiB (minus 4 bytes for the separator). We are now getting 8 MiB minus 4 bytes for encoding.