### PR TITLE
Fix mono on windows path ext error

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -107,7 +107,7 @@ namespace GodotTools.Utils
                 searchDirs.AddRange(pathDirs);
 
             string nameExt = Path.GetExtension(name);
-            bool hasPathExt = string.IsNullOrEmpty(nameExt) || windowsExts.Contains(nameExt, StringComparer.OrdinalIgnoreCase);
+            bool hasPathExt = !string.IsNullOrEmpty(nameExt) && windowsExts.Contains(nameExt, StringComparer.OrdinalIgnoreCase);
 
             searchDirs.Add(System.IO.Directory.GetCurrentDirectory()); // last in the list
 


### PR DESCRIPTION
Fixes #34434 (Error and unable to open Visual Studio Code from Godot editor) using @neikeq 's suggestion. 

Tested on Windows 10 with VS code