### PR TITLE
Add an editor window color project setting

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1001,6 +1001,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/config/name", "");
 	GLOBAL_DEF("application/config/description", "");
 	custom_prop_info["application/config/description"] = PropertyInfo(Variant::STRING, "application/config/description", PROPERTY_HINT_MULTILINE_TEXT);
+	GLOBAL_DEF("application/config/color", Color(0, 0, 0));
+	custom_prop_info["application/config/color"] = PropertyInfo(Variant::COLOR, "application/config/color", PROPERTY_HINT_COLOR_NO_ALPHA, "");
 	GLOBAL_DEF("application/run/main_scene", "");
 	custom_prop_info["application/run/main_scene"] = PropertyInfo(Variant::STRING, "application/run/main_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res");
 	GLOBAL_DEF("application/run/disable_stdout", false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -194,6 +194,10 @@
 		<member name="application/boot_splash/use_filter" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], applies linear filtering when scaling the image (recommended for high resolution artwork). If [code]false[/code], uses nearest-neighbor interpolation (recommended for pixel art).
 		</member>
+		<member name="application/config/color" type="Color" setter="" getter="" default="Color( 0, 0, 0, 1 )">
+			If this color is changed from the default black color, it will be used to color the editor window's borders. This can be used to distinguish multiple projects at a quick glance.
+			[b]Note:[/b] The editor must be restarted for the change to be visible.
+		</member>
 		<member name="application/config/custom_user_dir_name" type="String" setter="" getter="" default="&quot;&quot;">
 			This user directory is used for storing persistent data ([code]user://[/code] filesystem). If left empty, [code]user://[/code] resolves to a project-specific folder in Godot's own configuration folder (see [method OS.get_user_data_dir]). If a custom directory name is defined, this name will be used instead and appended to the system-specific user data directory (same parent folder as the Godot configuration folder documented in [method OS.get_user_data_dir]).
 			The [member application/config/use_custom_user_dir] setting must be enabled for this to take effect.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -189,6 +189,21 @@ void EditorNode::_update_scene_tabs() {
 	}
 }
 
+void EditorNode::_update_gui_base_stylebox() {
+	// Updates the stylebox to use the project-defined editor color.
+	// This can be used to distinguish projects more easily, especially when working on
+	// several projects at once.
+	Ref<StyleBoxFlat> style_box = gui_base->get_stylebox("Background", "EditorStyles");
+
+	if (GLOBAL_GET("application/config/color") != Color(0, 0, 0)) {
+		// Only set borders if the value is different from the default setting
+		style_box->set_border_width_all(Math::round(4 * EDSCALE));
+		style_box->set_border_color(GLOBAL_GET("application/config/color"));
+	}
+
+	gui_base->add_style_override("panel", style_box);
+}
+
 void EditorNode::_version_control_menu_option(int p_idx) {
 
 	switch (vcs_actions_menu->get_item_id(p_idx)) {
@@ -378,7 +393,8 @@ void EditorNode::_notification(int p_what) {
 			theme_base->set_theme(theme);
 			gui_base->set_theme(theme);
 
-			gui_base->add_style_override("panel", gui_base->get_stylebox("Background", "EditorStyles"));
+			_update_gui_base_stylebox();
+
 			scene_root_parent->add_style_override("panel", gui_base->get_stylebox("Content", "EditorStyles"));
 			bottom_panel->add_style_override("panel", gui_base->get_stylebox("panel", "TabContainer"));
 			scene_tabs->add_style_override("tab_fg", gui_base->get_stylebox("SceneTabFG", "EditorStyles"));
@@ -5728,7 +5744,7 @@ EditorNode::EditorNode() {
 
 	theme_base->set_theme(theme);
 	gui_base->set_theme(theme);
-	gui_base->add_style_override("panel", gui_base->get_stylebox("Background", "EditorStyles"));
+	_update_gui_base_stylebox();
 
 	resource_preview = memnew(EditorResourcePreview);
 	add_child(resource_preview);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -483,6 +483,7 @@ private:
 	void _get_scene_metadata(const String &p_file);
 	void _update_title();
 	void _update_scene_tabs();
+	void _update_gui_base_stylebox();
 	void _version_control_menu_option(int p_idx);
 	void _close_messages();
 	void _show_messages();


### PR DESCRIPTION
This can be used to distinguish projects more easily, which is especially helpful when working on multiple projects at the same time.

The current coloring is a proof of concept. It does the job, but it's not that pretty. It'd be ideal if we could change the window border colors, but this requires us to implement client-side decorations first. (In other words, disabling the system-provided window borders and adding our own.)

This feature is inspired by the Visual Studio Code add-on [Peacock](https://github.com/johnpapa/vscode-peacock).

## Preview

![Editor colors](https://user-images.githubusercontent.com/180032/71314735-0ea58900-244e-11ea-8954-0caad2e02fb5.png)