### PR TITLE
Set proper icon for LineEdit in editor theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -861,6 +861,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("normal", "LineEdit", style_widget);
 	theme->set_stylebox("focus", "LineEdit", style_widget_focus);
 	theme->set_stylebox("read_only", "LineEdit", style_widget_disabled);
+	theme->set_icon("clear", "LineEdit", theme->get_icon("GuiClose", "EditorIcons"));
 	theme->set_color("read_only", "LineEdit", font_color_disabled);
 	theme->set_color("font_color", "LineEdit", font_color);
 	theme->set_color("font_color_selected", "LineEdit", mono_color);


### PR DESCRIPTION
Before this fix, the clear button of LineEdit is small on a HiDPI monitor.

The default icon is a cross icon: [line_edit_clear.png](https://github.com/godotengine/godot/blob/e21872f4b9798c14b2840f205eff7aa931f02c0d/scene/resources/default_theme/line_edit_clear.png). Although there is a similarly named [icon_clear.svg](https://github.com/godotengine/godot/blob/e21872f4b9798c14b2840f205eff7aa931f02c0d/editor/icons/icon_clear.svg) in editor icons, it's a broom icon instead. So I picked the visually similar [icon_gui_close.svg](https://github.com/godotengine/godot/blob/master/editor/icons/icon_gui_close.svg).