### PR TITLE
Implement safe area on android platform

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -538,6 +538,10 @@ public abstract class Godot extends Activity implements SensorEventListener, IDo
 		window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
 		mClipboard = (ClipboardManager)getSystemService(Context.CLIPBOARD_SERVICE);
 
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+			window.getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+		}
+
 		//check for apk expansion API
 		if (true) {
 			boolean md5mismatch = false;

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -33,12 +33,14 @@ import android.content.*;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.AssetManager;
+import android.graphics.Rect;
 import android.media.*;
 import android.net.Uri;
 import android.os.*;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.SparseArray;
+import android.view.DisplayCutout;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
@@ -627,5 +629,22 @@ public class GodotIO {
 	public String getUniqueID() {
 
 		return unique_id;
+	}
+
+	public int[] getWindowInset() {
+		// Unified api is only available with API level 28
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+			DisplayCutout cutout = activity.getWindow().getDecorView().getRootWindowInsets().getDisplayCutout();
+			if (cutout == null) {
+				// We have no cutout
+				return new int[] { 0, 0, 0, 0 };
+			}
+
+			return new int[] { cutout.getSafeInsetLeft(), cutout.getSafeInsetTop(), cutout.getSafeInsetRight(), cutout.getSafeInsetBottom() };
+		}
+
+		// We have no cutout api, this does NOT mean that we have no display cutout but we have no
+		// unique way to query that
+		return new int[] { 0, 0, 0, 0 };
 	}
 }

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -61,6 +61,7 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 		_is_video_playing = p_env->GetMethodID(cls, "isVideoPlaying", "()Z");
 		_pause_video = p_env->GetMethodID(cls, "pauseVideo", "()V");
 		_stop_video = p_env->GetMethodID(cls, "stopVideo", "()V");
+		_get_window_inset = p_env->GetMethodID(cls, "getWindowInset", "()[I");
 	}
 }
 
@@ -204,4 +205,17 @@ int GodotIOJavaWrapper::get_vk_height() {
 
 void GodotIOJavaWrapper::set_vk_height(int p_height) {
 	virtual_keyboard_height = p_height;
+}
+
+Rect2 GodotIOJavaWrapper::get_window_inset() {
+	if (_get_window_inset) {
+		JNIEnv *env = ThreadAndroid::get_env();
+		jintArray ret = (jintArray)env->CallObjectMethod(godot_io_instance, _get_window_inset);
+		jint *inset_arr = env->GetIntArrayElements(ret, JNI_FALSE);
+		Rect2 inset_rect(inset_arr[0], inset_arr[1], inset_arr[2], inset_arr[3]);
+		env->ReleaseIntArrayElements(ret, inset_arr, JNI_ABORT);
+		return inset_rect;
+	} else {
+		return Rect2();
+	}
 }

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -37,6 +37,7 @@
 #include <android/log.h>
 #include <jni.h>
 
+#include "core/math/rect2.h"
 #include "string_android.h"
 
 // Class that makes functions in java/src/org/godotengine/godot/GodotIO.java callable from C++
@@ -59,6 +60,7 @@ private:
 	jmethodID _is_video_playing = 0;
 	jmethodID _pause_video = 0;
 	jmethodID _stop_video = 0;
+	jmethodID _get_window_inset = 0;
 
 public:
 	GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instance);
@@ -83,6 +85,7 @@ public:
 	bool is_video_playing();
 	void pause_video();
 	void stop_video();
+	Rect2 get_window_inset();
 };
 
 #endif /* !JAVA_GODOT_IO_WRAPPER_H */

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -291,6 +291,16 @@ Size2 OS_Android::get_window_size() const {
 	return Vector2(default_videomode.width, default_videomode.height);
 }
 
+Rect2 OS_Android::get_window_safe_area() const {
+	Rect2 inset = godot_io_java->get_window_inset();
+	Size2 window_size = get_window_size();
+
+	return Rect2(
+			inset.position.x, inset.position.y,
+			window_size.width - inset.size.width - inset.position.x,
+			window_size.height - inset.size.height - inset.position.y);
+}
+
 String OS_Android::get_name() const {
 
 	return "Android";

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -141,6 +141,7 @@ public:
 	virtual void set_keep_screen_on(bool p_enabled);
 
 	virtual Size2 get_window_size() const;
+	virtual Rect2 get_window_safe_area() const;
 
 	virtual String get_name() const;
 	virtual MainLoop *get_main_loop() const;


### PR DESCRIPTION
Implementing the `OS.get_window_safe_area()` method on android platform having Android 9 or later.
Before Android 9 there is no official way to get the safe area.

**This changes the default behavior for Android 9 and later!**
Without this merge Godot applications in landscape mode would letterbox the display cutout. After this PR Godot uses fullscreen again and the developers have to change their UI to respect the window safe area.
I thought about adding an option to allow the user to specify the `layoutInDisplayCutoutMode` and default that to the default value instead of `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`. Please give me feedback about this.

---

Feature Proposal: https://github.com/godotengine/godot-proposals/issues/321
This also might fix #34466 depending on if the manufacture added this to the safe area.