### PR TITLE
Fix clang-format rule failing.

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -133,7 +133,6 @@ void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/camera_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need to use the camera"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/microphone_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need to use the microphone"), ""));
 
-
 #ifdef OSX_ENABLED
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/enable"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/identity", PROPERTY_HINT_PLACEHOLDER_TEXT, "Type: Name (ID)"), ""));


### PR DESCRIPTION
Fixes clang-format rule failing in Travis.

Following #34338, I'm getting a clang-format rule failing when touching this file elsewhere in #33391.

Although this was picked up by [Travis when testing #34338](https://travis-ci.org/godotengine/godot/jobs/624858603?utm_medium=notification&utm_source=github_status), it still passed, because it was merged between #34097 and 7f62ee69b.