### PR TITLE
Prevent GDScript language server from listening to external hosts by default

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -156,7 +156,7 @@ void GDScriptLanguageProtocol::poll() {
 	server->poll();
 }
 
-Error GDScriptLanguageProtocol::start(int p_port) {
+Error GDScriptLanguageProtocol::start(int p_port, const IP_Address &p_bind_ip) {
 	if (server == NULL) {
 		server = dynamic_cast<WebSocketServer *>(ClassDB::instance("WebSocketServer"));
 		ERR_FAIL_COND_V(!server, FAILED);
@@ -165,6 +165,7 @@ Error GDScriptLanguageProtocol::start(int p_port) {
 		server->connect("client_connected", this, "on_client_connected");
 		server->connect("client_disconnected", this, "on_client_disconnected");
 	}
+	server->set_bind_ip(p_bind_ip);
 	return server->listen(p_port);
 }
 

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -77,7 +77,7 @@ public:
 	_FORCE_INLINE_ bool is_initialized() const { return _initialized; }
 
 	void poll();
-	Error start(int p_port);
+	Error start(int p_port, const IP_Address &p_bind_ip);
 	void stop();
 
 	void notify_all_clients(const String &p_method, const Variant &p_params = Variant());

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -84,7 +84,7 @@ void GDScriptLanguageServer::thread_main(void *p_userdata) {
 void GDScriptLanguageServer::start() {
 	port = (int)_EDITOR_GET("network/language_server/remote_port");
 	use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
-	if (protocol.start(port) == OK) {
+	if (protocol.start(port, IP_Address("127.0.0.1")) == OK) {
 		EditorNode::get_log()->add_message("--- GDScript language server started ---", EditorLog::MSG_TYPE_EDITOR);
 		if (use_thread) {
 			ERR_FAIL_COND(thread != NULL);

--- a/modules/websocket/doc_classes/WebSocketServer.xml
+++ b/modules/websocket/doc_classes/WebSocketServer.xml
@@ -83,6 +83,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="bind_ip" type="String" setter="set_bind_ip" getter="get_bind_ip">
+			When not set to [code]*[/code] will restrict incoming connections to the specified IP address. Setting [code]bind_ip[/code] to [code]127.0.0.1[/code] will cause the server to listen only to the local host.
+		</member>
 		<member name="ca_chain" type="X509Certificate" setter="set_ca_chain" getter="get_ca_chain">
 			When using SSL (see [member private_key] and [member ssl_certificate]), you can set this to a valid [X509Certificate] to be provided as additional CA chain information during the SSL handshake.
 		</member>

--- a/modules/websocket/websocket_server.cpp
+++ b/modules/websocket/websocket_server.cpp
@@ -34,6 +34,7 @@ GDCINULL(WebSocketServer);
 
 WebSocketServer::WebSocketServer() {
 	_peer_id = 1;
+	bind_ip = IP_Address("*");
 }
 
 WebSocketServer::~WebSocketServer() {
@@ -48,6 +49,10 @@ void WebSocketServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_peer_address", "id"), &WebSocketServer::get_peer_address);
 	ClassDB::bind_method(D_METHOD("get_peer_port", "id"), &WebSocketServer::get_peer_port);
 	ClassDB::bind_method(D_METHOD("disconnect_peer", "id", "code", "reason"), &WebSocketServer::disconnect_peer, DEFVAL(1000), DEFVAL(""));
+
+	ClassDB::bind_method(D_METHOD("get_bind_ip"), &WebSocketServer::get_bind_ip);
+	ClassDB::bind_method(D_METHOD("set_bind_ip"), &WebSocketServer::set_bind_ip);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "bind_ip"), "set_bind_ip", "get_bind_ip");
 
 	ClassDB::bind_method(D_METHOD("get_private_key"), &WebSocketServer::get_private_key);
 	ClassDB::bind_method(D_METHOD("set_private_key"), &WebSocketServer::set_private_key);
@@ -65,6 +70,16 @@ void WebSocketServer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("client_disconnected", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::BOOL, "was_clean_close")));
 	ADD_SIGNAL(MethodInfo("client_connected", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "protocol")));
 	ADD_SIGNAL(MethodInfo("data_received", PropertyInfo(Variant::INT, "id")));
+}
+
+IP_Address WebSocketServer::get_bind_ip() const {
+	return bind_ip;
+}
+
+void WebSocketServer::set_bind_ip(const IP_Address &p_bind_ip) {
+	ERR_FAIL_COND(is_listening());
+	ERR_FAIL_COND(!p_bind_ip.is_valid() && !p_bind_ip.is_wildcard());
+	bind_ip = p_bind_ip;
 }
 
 Ref<CryptoKey> WebSocketServer::get_private_key() const {

--- a/modules/websocket/websocket_server.h
+++ b/modules/websocket/websocket_server.h
@@ -41,6 +41,8 @@ class WebSocketServer : public WebSocketMultiplayerPeer {
 	GDCLASS(WebSocketServer, WebSocketMultiplayerPeer);
 	GDCICLASS(WebSocketServer);
 
+	IP_Address bind_ip;
+
 protected:
 	static void _bind_methods();
 
@@ -66,6 +68,9 @@ public:
 	void _on_connect(int32_t p_peer_id, String p_protocol);
 	void _on_disconnect(int32_t p_peer_id, bool p_was_clean);
 	void _on_close_request(int32_t p_peer_id, int p_code, String p_reason);
+
+	IP_Address get_bind_ip() const;
+	void set_bind_ip(const IP_Address &p_bind_ip);
 
 	Ref<CryptoKey> get_private_key() const;
 	void set_private_key(Ref<CryptoKey> p_key);

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -165,7 +165,7 @@ Error WSLServer::listen(int p_port, const Vector<String> p_protocols, bool gd_mp
 	for (int i = 0; i < p_protocols.size(); i++) {
 		pw[i] = p_protocols[i].strip_edges();
 	}
-	_server->listen(p_port);
+	_server->listen(p_port, bind_ip);
 
 	return OK;
 }


### PR DESCRIPTION
* Add "bind_ip" property to WebSocketServer class which defaults to "*" (for compatibility with current users)
    * _WebSocketServer is the class that GDScript language server relies on_
* Add an editor option to set the bind_ip for the GDScript language server
* Set GDscript language server to listen only to localhost by default
_______________________

### Problem

Currently GDScript language server is enabled at startup and exposes an open port (6008 by default) to the net accessible by any host unless filtered.

I feel uncomfortable about it considering that 

* I don't even use the language server function.
* It cannot be turned off and/or bound to localhost from editor settings.

### Language server at startup by default?

The most straightforward solution would be to have the Language Server simply turned off at startup by default.
However at preliminary discussion @Faless at IRC stated that C# users are unlikely to appreciate if it will be turned off by default.
So a solution then to have it on by default, but listen only to localhost, which most likely covers 99% of intended usage anyway.

### Why not just make an off switch, so you, Houkime, turn this off, and others have it on by default?

I consider adding an off switch in a separate PR since it is an independent change.  
This PR however considers the security of those Godot users who are not likely to look at network settings or scan open ports (which is probably a majority) so it is a bit more important to make early.

### Why a property and not an argument for the listen() function?

It was recommended by @Faless for compatibility reasons and because bind_ip is unlikely to change often.

However, in places specific to GDscript Language server (where interfaces are not accessible from GDScript) it is an argument in the line with the underlying TCP_server listen() function. This can be changed however if considered clumsy (though i somehow think that making it a property of a gdscript ptotocol for example is even more odd).

### Why touching WSLServer?

WebSocketServer class is more of a virtual thing, which exact implementation depends on whether we're in browser or running natively (in browser it is a dummy). 
It doesn't implement a listen() function.

ClassDB::instance() when asked for WebSocketServer returns either WSL (native) server or EMWS server.
See https://github.com/godotengine/godot/blob/master/modules/websocket/websocket_server.cpp