### PR TITLE
Fix buffers size calculation in PacketPeerStream.

### DIFF
--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -282,7 +282,7 @@ void PacketPeerStream::set_input_buffer_max_size(int p_max_size) {
 	ERR_FAIL_COND_MSG(p_max_size < 0, "Max size of input buffer size cannot be smaller than 0.");
 	//warning may lose packets
 	ERR_FAIL_COND_MSG(ring_buffer.data_left(), "Buffer in use, resizing would cause loss of data.");
-	ring_buffer.resize(nearest_shift(p_max_size + 4));
+	ring_buffer.resize(nearest_shift(next_power_of_2(p_max_size + 4)) - 1);
 	input_buffer.resize(next_power_of_2(p_max_size + 4));
 }
 


### PR DESCRIPTION
The calculation used to be wrong when exactly at a power of 2.
`nearest_shift` always return the "next" power of 2
`nearest_shift(4) == 3 # 2^3 = 8`.

On the other hand `next_power_of_2` returns the exact value if that
value is a power of 2 (i.e. `next_power_of_2(4) == 4`).

I.e. :
```
WARN_PRINT(itos(next_power_of_2(4)) + " " + itos(1 << nearest_shift(4)));
// WARNING: ... : 4 8
```

Is this by design? @reduz 

Follow up after #34516 which seems to causes errors when debugging now (not sure why it worked for me when I first tested it).