### PR TITLE
Add a link to the code of conduct in the repository

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Code of Conduct
+
+By participating in this repository, you agree to abide by the
+[Godot Engine Code of Conduct](https://godotengine.org/code-of-conduct).


### PR DESCRIPTION
This makes it display when opening an issue for the first time in the repository.

(The code of conduct was already in effect before, this just makes it clearer.)