### PR TITLE
Fix 2D lighting when using skeleton.

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1413,7 +1413,7 @@ void RasterizerCanvasGLES3::canvas_render_items(Item *p_item_list, int p_z, cons
 			}
 
 			if (skeleton) {
-				glActiveTexture(GL_TEXTURE0 + storage->config.max_texture_image_units - 1);
+				glActiveTexture(GL_TEXTURE0 + storage->config.max_texture_image_units - 4);
 				glBindTexture(GL_TEXTURE_2D, skeleton->texture);
 				state.using_skeleton = true;
 				state.canvas_shader.set_uniform(CanvasShaderGLES3::SKELETON_TRANSFORM, state.skeleton_transform);
@@ -1674,7 +1674,6 @@ void RasterizerCanvasGLES3::canvas_render_items(Item *p_item_list, int p_z, cons
 					bool light_rebind = state.canvas_shader.bind();
 
 					if (light_rebind) {
-
 						state.canvas_shader.set_uniform(CanvasShaderGLES3::FINAL_MODULATE, state.canvas_item_modulate);
 						state.canvas_shader.set_uniform(CanvasShaderGLES3::MODELVIEW_MATRIX, state.final_transform);
 						state.canvas_shader.set_uniform(CanvasShaderGLES3::EXTRA_MATRIX, Transform2D());
@@ -1682,6 +1681,10 @@ void RasterizerCanvasGLES3::canvas_render_items(Item *p_item_list, int p_z, cons
 							state.canvas_shader.set_uniform(CanvasShaderGLES3::SCREEN_PIXEL_SIZE, Vector2(1.0 / storage->frame.current_rt->width, 1.0 / storage->frame.current_rt->height));
 						} else {
 							state.canvas_shader.set_uniform(CanvasShaderGLES3::SCREEN_PIXEL_SIZE, Vector2(1.0, 1.0));
+						}
+						if (state.using_skeleton) {
+							state.canvas_shader.set_uniform(CanvasShaderGLES3::SKELETON_TRANSFORM, state.skeleton_transform);
+							state.canvas_shader.set_uniform(CanvasShaderGLES3::SKELETON_TRANSFORM_INVERSE, state.skeleton_transform_inverse);
 						}
 					}
 

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -55,7 +55,7 @@ out highp vec2 pixel_size_interp;
 #endif
 
 #ifdef USE_SKELETON
-uniform mediump sampler2D skeleton_texture; // texunit:-1
+uniform mediump sampler2D skeleton_texture; // texunit:-4
 uniform highp mat4 skeleton_transform;
 uniform highp mat4 skeleton_transform_inverse;
 #endif


### PR DESCRIPTION
Fixes #32212.

Two problems on the light pass when using skeletons, leading to the wrong transform being applied to geometry:

- The texture unit used to bind the bone weights was the same as the light texture.
- The skeleton transform matrices were not being set after binding the lighting shader.