### PR TITLE
Centers label text in Dock Select popup panel

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5828,6 +5828,7 @@ EditorNode::EditorNode() {
 	Label *dock_label = memnew(Label);
 	dock_label->set_text(TTR("Dock Position"));
 	dock_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	dock_label->set_align(Label::ALIGN_CENTER);
 	dock_hb->add_child(dock_label);
 
 	dock_tab_move_right = memnew(ToolButton);


### PR DESCRIPTION
* Centers the "Dock Position" text in Dock Select popup panel.

The text is left aligned before this PR, which looks strange when the translated text is short.

![Screenshot of the panel in zh_CN and ko](https://user-images.githubusercontent.com/372476/71331648-11979b00-256e-11ea-8584-2e719f1c1cca.gif)
