### PR TITLE
Fix issue with disconnecting events when font changes

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2286,7 +2286,7 @@ void Control::set_theme(const Ref<Theme> &p_theme) {
 	}
 
 	if (data.theme.is_valid()) {
-		data.theme->connect("changed", this, "_theme_changed");
+		data.theme->connect("changed", this, "_theme_changed", varray(), CONNECT_DEFERRED);
 	}
 }
 


### PR DESCRIPTION
When the editor changes the font (e.g. zooming) the theme changes and try to disconnect signals in a signal emission (`add_font_override`). 

Fixes #34548 