### PR TITLE
Make new ScrollContainer focus behavior optional

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -24,6 +24,9 @@
 	</methods>
 	<members>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
+		<member name="follow_focus" type="bool" setter="set_follow_focus" getter="is_following_focus" default="false">
+			If [code]true[/code], the ScrollContainer will automatically scroll to focused children (including indirect children) to make sure they are fully visible.
+		</member>
 		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -235,6 +235,10 @@ void ScrollContainer::_update_scrollbar_position() {
 
 void ScrollContainer::_ensure_focused_visible(Control *p_control) {
 
+	if (!follow_focus) {
+		return;
+	}
+
 	if (is_a_parent_of(p_control)) {
 		Rect2 global_rect = get_global_rect();
 		Rect2 other_rect = p_control->get_global_rect();
@@ -506,6 +510,14 @@ void ScrollContainer::set_deadzone(int p_deadzone) {
 	deadzone = p_deadzone;
 }
 
+bool ScrollContainer::is_following_focus() const {
+	return follow_focus;
+}
+
+void ScrollContainer::set_follow_focus(int p_follow) {
+	follow_focus = p_follow;
+}
+
 String ScrollContainer::get_configuration_warning() const {
 
 	int found = 0;
@@ -555,12 +567,16 @@ void ScrollContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_v_scroll"), &ScrollContainer::get_v_scroll);
 	ClassDB::bind_method(D_METHOD("set_deadzone", "deadzone"), &ScrollContainer::set_deadzone);
 	ClassDB::bind_method(D_METHOD("get_deadzone"), &ScrollContainer::get_deadzone);
+	ClassDB::bind_method(D_METHOD("set_follow_focus", "enabled"), &ScrollContainer::set_follow_focus);
+	ClassDB::bind_method(D_METHOD("is_following_focus"), &ScrollContainer::is_following_focus);
 
 	ClassDB::bind_method(D_METHOD("get_h_scrollbar"), &ScrollContainer::get_h_scrollbar);
 	ClassDB::bind_method(D_METHOD("get_v_scrollbar"), &ScrollContainer::get_v_scrollbar);
 
 	ADD_SIGNAL(MethodInfo("scroll_started"));
 	ADD_SIGNAL(MethodInfo("scroll_ended"));
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "follow_focus"), "set_follow_focus", "is_following_focus");
 
 	ADD_GROUP("Scroll", "scroll_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_horizontal_enabled"), "set_enable_h_scroll", "is_h_scroll_enabled");
@@ -593,6 +609,7 @@ ScrollContainer::ScrollContainer() {
 	scroll_v = true;
 
 	deadzone = GLOBAL_GET("gui/common/default_scroll_deadzone");
+	follow_focus = false;
 
 	set_clip_contents(true);
 };

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -62,6 +62,7 @@ class ScrollContainer : public Container {
 	bool scroll_v;
 
 	int deadzone;
+	bool follow_focus;
 
 	void _cancel_drag();
 
@@ -92,6 +93,9 @@ public:
 
 	int get_deadzone() const;
 	void set_deadzone(int p_deadzone);
+
+	bool is_following_focus() const;
+	void set_follow_focus(int p_follow);
 
 	HScrollBar *get_h_scrollbar();
 	VScrollBar *get_v_scrollbar();


### PR DESCRIPTION
As title says, this PR makes the new behavior introduced in #34269 optional. It caused some unexpected issues with the inspector and I'm not really sure how to fix them, so here's alternate fix that avoids the problem while keeping the functionality. I made it just in case no one makes a proper fix, to not potentially block the release (reverting #34269 and #34389 could be a meh option too).

Resolves #34486
Resolves #34560
Resolves #34639