### PR TITLE
Fixes variable naming in FileSystemDock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1746,8 +1746,8 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			if (!fpath.ends_with("/")) {
 				fpath = fpath.get_base_dir();
 			}
-			make_script_dialog_text->config("Node", fpath.plus_file("new_script.gd"), false);
-			make_script_dialog_text->popup_centered(Size2(300, 300) * EDSCALE);
+			make_script_dialog->config("Node", fpath.plus_file("new_script.gd"), false);
+			make_script_dialog->popup_centered(Size2(300, 300) * EDSCALE);
 		} break;
 
 		case FILE_COPY_PATH: {
@@ -2682,9 +2682,9 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	make_scene_dialog->register_text_enter(make_scene_dialog_text);
 	make_scene_dialog->connect("confirmed", this, "_make_scene_confirm");
 
-	make_script_dialog_text = memnew(ScriptCreateDialog);
-	make_script_dialog_text->set_title(TTR("Create Script"));
-	add_child(make_script_dialog_text);
+	make_script_dialog = memnew(ScriptCreateDialog);
+	make_script_dialog->set_title(TTR("Create Script"));
+	add_child(make_script_dialog);
 
 	new_resource_dialog = memnew(CreateDialog);
 	add_child(new_resource_dialog);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -140,7 +140,7 @@ private:
 	ConfirmationDialog *make_scene_dialog;
 	LineEdit *make_scene_dialog_text;
 	ConfirmationDialog *overwrite_dialog;
-	ScriptCreateDialog *make_script_dialog_text;
+	ScriptCreateDialog *make_script_dialog;
 	CreateDialog *new_resource_dialog;
 
 	bool always_show_folders;


### PR DESCRIPTION
In `editor/filesystem_dock.{h,cpp}`, the `ScriptCreateDialog` pointer variable's name doesn't match the convention used by nearby variables:

https://github.com/godotengine/godot/blob/d711c57d767734887fbf0955a7b9902c54498a0d/editor/filesystem_dock.h#L133-L144

`_text` is a postfix used by `LineEdits`, and a `_dialog` postfix denotes various dialogs here. The `make_script_dialog_text` variable on Line 143 breaks this rule.