### PR TITLE
Fix crash after clearing undo history

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3162,8 +3162,6 @@ void EditorNode::set_current_scene(int p_idx) {
 	if (editor_data.check_and_update_scene(p_idx)) {
 		if (editor_data.get_scene_path(p_idx) != "")
 			editor_folding.load_scene_folding(editor_data.get_edited_scene_root(p_idx), editor_data.get_scene_path(p_idx));
-
-		call_deferred("_clear_undo_history");
 	}
 
 	changing_scene = true;


### PR DESCRIPTION
From my fast tests, this fixes crash when opening twice same scene,  but I'm not sure why `call_deferred("_clear_undo_history");` was here.

Fixes #34532