### PR TITLE
Remove translation change notification when setting the locale of a Translation resource

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -835,7 +835,7 @@ void Translation::set_locale(const String &p_locale) {
 		locale = univ_locale;
 	}
 
-	if (OS::get_singleton()->get_main_loop()) {
+	if (OS::get_singleton()->get_main_loop() && TranslationServer::get_singleton()->get_loaded_locales().has(this)) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 	}
 }


### PR DESCRIPTION
I've spend a hour trying to find the source of a bug in my code as to why `NOTIFICATION_TRANSLATION_CHANGED` was being triggered when I was not changing the game's locale. The cause? Apparently loading a `Translation` resource via code triggers the `set_locale()` method in it, triggering the notification.

While I get it why it triggers it when changing the locale of the whole game (via `TranslationServer`), triggering the notification by changing the locale of a resource doesn't make much sense to me.