### PR TITLE
Fix KinematicCollision docs mislabeling an ObjectID as an RID.

### DIFF
--- a/doc/classes/KinematicCollision.xml
+++ b/doc/classes/KinematicCollision.xml
@@ -16,7 +16,7 @@
 			The colliding body.
 		</member>
 		<member name="collider_id" type="int" setter="" getter="get_collider_id" default="0">
-			The colliding body's unique [RID].
+			The colliding body's unique instance ID. See [method Object.get_instance_id].
 		</member>
 		<member name="collider_metadata" type="Variant" setter="" getter="get_collider_metadata">
 			The colliding body's metadata. See [Object].

--- a/doc/classes/KinematicCollision2D.xml
+++ b/doc/classes/KinematicCollision2D.xml
@@ -16,7 +16,7 @@
 			The colliding body.
 		</member>
 		<member name="collider_id" type="int" setter="" getter="get_collider_id" default="0">
-			The colliding body's unique [RID].
+			The colliding body's unique instance ID. See [method Object.get_instance_id].
 		</member>
 		<member name="collider_metadata" type="Variant" setter="" getter="get_collider_metadata">
 			The colliding body's metadata. See [Object].


### PR DESCRIPTION
I checked the source code to confirm that this was actually an ObjectID and not an RID. Furthermore, an RID doesn't make sense since the method call doesn't mention a Shape at all.