### PR TITLE
Fixes tab height in Batch Rename dialog

### DIFF
--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -32,6 +32,7 @@
 
 #include "core/print_string.h"
 #include "editor_node.h"
+#include "editor_scale.h"
 #include "editor_settings.h"
 #include "editor_themes.h"
 #include "modules/regex/regex.h"
@@ -106,7 +107,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	// -- Feature Tabs
 
-	const int feature_min_height = 160;
+	const int feature_min_height = 160 * EDSCALE;
 
 	Ref<Theme> collapse_theme = create_editor_theme();
 	collapse_theme->set_icon("checked", "CheckBox", collapse_theme->get_icon("GuiTreeArrowDown", "EditorIcons"));


### PR DESCRIPTION
* Applies editor scale to minimum container height

Before this fix, tabs in Batch Rename dialog have different heights on a HiDPI monitor, which is different from the behavior on a normal DPI monitor.

Also, on a HiDPI monitor, the "Preview" section will be pushed outside the dialog if you:
1. Switch to the second tab
2. Click "Advanced Options" to close the tab area
3. Click "Advanced Options" again to open the tab area
4. Switch to the first tab

![demo](https://user-images.githubusercontent.com/372476/71429688-dc708180-2702-11ea-8687-360680b3e590.gif)