### PR TITLE
Don't use constant reference in Vector push_back, insert and append_array

### DIFF
--- a/core/vector.h
+++ b/core/vector.h
@@ -63,7 +63,7 @@ private:
 	CowData<T> _cowdata;
 
 public:
-	bool push_back(const T &p_elem);
+	bool push_back(T p_elem);
 
 	void remove(int p_index) { _cowdata.remove(p_index); }
 	void erase(const T &p_val) {
@@ -83,10 +83,10 @@ public:
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
 	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }
-	Error insert(int p_pos, const T &p_val) { return _cowdata.insert(p_pos, p_val); }
+	Error insert(int p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }
 	int find(const T &p_val, int p_from = 0) const { return _cowdata.find(p_val, p_from); }
 
-	void append_array(const Vector<T> &p_other);
+	void append_array(Vector<T> p_other);
 
 	template <class C>
 	void sort_custom() {
@@ -136,7 +136,7 @@ void Vector<T>::invert() {
 }
 
 template <class T>
-void Vector<T>::append_array(const Vector<T> &p_other) {
+void Vector<T>::append_array(Vector<T> p_other) {
 	const int ds = p_other.size();
 	if (ds == 0)
 		return;
@@ -147,7 +147,7 @@ void Vector<T>::append_array(const Vector<T> &p_other) {
 }
 
 template <class T>
-bool Vector<T>::push_back(const T &p_elem) {
+bool Vector<T>::push_back(T p_elem) {
 
 	Error err = resize(size() + 1);
 	ERR_FAIL_COND_V(err, true);

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -172,7 +172,10 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 			min = 0;
 			max = 0;
 			sparse_count = 0;
+			sparse_indices_buffer_view = 0;
 			sparse_indices_byte_offset = 0;
+			sparse_indices_component_type = 0;
+			sparse_values_buffer_view = 0;
 			sparse_values_byte_offset = 0;
 		}
 	};


### PR DESCRIPTION
Fixes #31159 and similar

Test project - [Line.zip](https://github.com/godotengine/godot/files/4002901/Line.zip) - To see errors Valgrind or Address Sanitizer should be used

Reduz explanation from https://github.com/godotengine/godot/pull/31609#issuecomment-565617751
> Sorry, this should have been fixed long ago, we even discussed it at the beginning of the year.
> 
> I suggest just make a PR that changes this:
> 
> ```
> bool Vector<T>::push_back(const T &p_elem) 
> to this
> bool Vector<T>::push_back(T p_elem) 
> ```
> 
> It should be fine performance wise, the rational is that in far most cases (Specially where performance is required), Godot uses types that are 8 bytes or less, which is just the same as a pointer. This is fast because it will fit on a CPU register or cache. For larger datatypes, this is not really something critically performant anyway because a good amount of bytes has to be copied or a copy constructor needs to be run, so it should not matter much if it does a copy.

