### PR TITLE
[Docs] Description updates for Node2D & Object

### DIFF
--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Node2D" inherits="CanvasItem" category="Core" version="3.2">
 	<brief_description>
-		A 2D game object, parent of all 2D-related nodes. Has a position, rotation, scale and Z index.
+		A 2D game object, inherited by all 2D-related nodes. Has a position, rotation, scale, and Z index.
 	</brief_description>
 	<description>
-		A 2D game object, with a position, rotation and scale. All 2D physics nodes and sprites inherit from Node2D. Use Node2D as a parent node to move, scale and rotate children in a 2D project. Also gives control on the node's render order.
+		A 2D game object, with a transform (position, rotation, and scale). All 2D nodes, including physics objects and sprites, inherit from Node2D. Use Node2D as a parent node to move, scale and rotate children in a 2D project. Also gives control of the node's render order.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/2d/custom_drawing_in_2d.html</link>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -9,6 +9,12 @@
 		Objects do not manage memory. If a class inherits from Object, you will have to delete instances of it manually. To do so, call the [method free] method from your script or delete the instance from C++.
 		Some classes that extend Object add memory management. This is the case of [Reference], which counts references and deletes itself automatically when no longer referenced. [Node], another fundamental type, deletes all its children when freed from memory.
 		Objects export properties, which are mainly useful for storage and editing, but not really so much in programming. Properties are exported in [method _get_property_list] and handled in [method _get] and [method _set]. However, scripting languages and C++ have simpler means to export them.
+		Property membership can be tested directly in GDScript using [code]in[/code]:
+		[codeblock]
+		var n = Node2D.new()
+		print("position" in n)  # Prints "True".
+		print("other_property" in n)  # Prints "False".
+		[/codeblock]
 		Objects also receive notifications. Notifications are a simple way to notify the object about different events, so they can all be handled together. See [method _notification].
 	</description>
 	<tutorials>


### PR DESCRIPTION
A couple of minor docs updates:

- Node2D description - the use of "parent" here was leading to a bit of confusion regarding whether a Node2D was needed as a parent *node* In the tree.

- Object - since Object doesn't have a `has_property()` method, it's not immediately clear how to test for a property.