### PR TITLE
Don't try to connect "text_entered" signal to nodes other than LineEdit

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -443,7 +443,9 @@ bool AcceptDialog::has_autowrap() {
 void AcceptDialog::register_text_enter(Node *p_line_edit) {
 
 	ERR_FAIL_NULL(p_line_edit);
-	p_line_edit->connect("text_entered", this, "_builtin_text_entered");
+	LineEdit *line_edit = Object::cast_to<LineEdit>(p_line_edit);
+	if (line_edit)
+		line_edit->connect("text_entered", this, "_builtin_text_entered");
 }
 
 void AcceptDialog::_update_child_rects() {


### PR DESCRIPTION
This prevents from this error, when to register_text_enter was passed not LineEdit node
```
ERROR: connect: In Object of type 'AcceptDialog': Attempt to connect nonexistent signal 'text_entered' to method 'AcceptDialog._builtin_text_entered'.
   At: core/object.cpp:1454.
```