### PR TITLE
Check for null pointer in PulseAudio server info callback.

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -78,6 +78,8 @@ void AudioDriverPulseAudio::pa_source_info_cb(pa_context *c, const pa_source_inf
 }
 
 void AudioDriverPulseAudio::pa_server_info_cb(pa_context *c, const pa_server_info *i, void *userdata) {
+
+	ERR_FAIL_COND_MSG(!i, "PulseAudio server info is null.");
 	AudioDriverPulseAudio *ad = (AudioDriverPulseAudio *)userdata;
 
 	ad->capture_default_device = i->default_source_name;


### PR DESCRIPTION
The pa_server_info_cb is sometimes passed a null pointer. I suspect this is when the server is not yet ready. This function is called asynchronously in an infinite loop:
https://github.com/godotengine/godot/blob/318c69351624f7794c51b5385d252af397c0404a/drivers/pulseaudio/audio_driver_pulseaudio.cpp#L96-L103
So it will simply be called again until the server is ready.

We can probably safely return without printing an error, but, since PulseAudio prints an error in their own volume control, we should probably copy them and do so too:
https://gitlab.freedesktop.org/pulseaudio/pavucontrol/blob/master/src/pavucontrol.cc#L206-216

