### PR TITLE
Make OptionButton itself take into account the arrow margin instead of relying on the theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -587,24 +587,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_color_pressed", "Button", icon_color_pressed);
 
 	// OptionButton
-	Ref<StyleBoxFlat> style_option_button_normal = style_widget->duplicate();
-	Ref<StyleBoxFlat> style_option_button_hover = style_widget_hover->duplicate();
-	Ref<StyleBoxFlat> style_option_button_pressed = style_widget_pressed->duplicate();
-	Ref<StyleBoxFlat> style_option_button_focus = style_widget_focus->duplicate();
-	Ref<StyleBoxFlat> style_option_button_disabled = style_widget_disabled->duplicate();
-
-	int option_button_arrow_margin = theme->get_icon("GuiOptionArrow", "EditorIcons")->get_size().width + (default_margin_size + 4) * EDSCALE;
-	style_option_button_normal->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
-	style_option_button_hover->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
-	style_option_button_pressed->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
-	style_option_button_focus->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
-	style_option_button_disabled->set_default_margin(MARGIN_RIGHT, option_button_arrow_margin);
-
-	theme->set_stylebox("normal", "OptionButton", style_option_button_normal);
-	theme->set_stylebox("hover", "OptionButton", style_option_button_hover);
-	theme->set_stylebox("pressed", "OptionButton", style_option_button_pressed);
-	theme->set_stylebox("focus", "OptionButton", style_option_button_focus);
-	theme->set_stylebox("disabled", "OptionButton", style_option_button_disabled);
+	theme->set_stylebox("normal", "OptionButton", style_widget);
+	theme->set_stylebox("hover", "OptionButton", style_widget_hover);
+	theme->set_stylebox("pressed", "OptionButton", style_widget_pressed);
+	theme->set_stylebox("focus", "OptionButton", style_widget_focus);
+	theme->set_stylebox("disabled", "OptionButton", style_widget_disabled);
 
 	theme->set_color("font_color", "OptionButton", font_color);
 	theme->set_color("font_color_hover", "OptionButton", font_color_hl);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -35,8 +35,9 @@ Size2 OptionButton::get_minimum_size() const {
 
 	Size2 minsize = Button::get_minimum_size();
 
-	if (has_icon("arrow"))
+	if (has_icon("arrow")) {
 		minsize.width += Control::get_icon("arrow")->get_width() + get_constant("hseparation");
+	}
 
 	return minsize;
 }
@@ -72,6 +73,12 @@ void OptionButton::_notification(int p_what) {
 
 			Point2 ofs(size.width - arrow->get_width() - get_constant("arrow_margin"), int(Math::abs((size.height - arrow->get_height()) / 2)));
 			arrow->draw(ci, ofs, clr);
+		} break;
+		case NOTIFICATION_THEME_CHANGED: {
+
+			if (has_icon("arrow")) {
+				_set_internal_margin(MARGIN_RIGHT, Control::get_icon("arrow")->get_width());
+			}
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 
@@ -327,7 +334,7 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_get_items"), &OptionButton::_get_items);
 
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "items", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_items", "_get_items");
-	// "selected" property must come after "items", otherwise GH-10213 occurs
+	// "selected" property must come after "items", otherwise GH-10213 occurs.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "selected"), "_select_int", "get_selected");
 	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("item_focused", PropertyInfo(Variant::INT, "id")));
@@ -339,6 +346,9 @@ OptionButton::OptionButton() {
 	set_toggle_mode(true);
 	set_text_align(ALIGN_LEFT);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
+	if (has_icon("arrow")) {
+		_set_internal_margin(MARGIN_RIGHT, Control::get_icon("arrow")->get_width());
+	}
 
 	popup = memnew(PopupMenu);
 	popup->hide();

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -266,10 +266,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// OptionButton
 
-	Ref<StyleBox> sb_optbutton_normal = sb_expand(make_stylebox(option_button_normal_png, 4, 4, 21, 4, 6, 3, 21, 3), 2, 2, 2, 2);
-	Ref<StyleBox> sb_optbutton_pressed = sb_expand(make_stylebox(option_button_pressed_png, 4, 4, 21, 4, 6, 3, 21, 3), 2, 2, 2, 2);
-	Ref<StyleBox> sb_optbutton_hover = sb_expand(make_stylebox(option_button_hover_png, 4, 4, 21, 4, 6, 2, 21, 2), 2, 2, 2, 2);
-	Ref<StyleBox> sb_optbutton_disabled = sb_expand(make_stylebox(option_button_disabled_png, 4, 4, 21, 4, 6, 2, 21, 2), 2, 2, 2, 2);
+	Ref<StyleBox> sb_optbutton_normal = sb_expand(make_stylebox(option_button_normal_png, 4, 4, 21, 4, 6, 3, 9, 3), 2, 2, 2, 2);
+	Ref<StyleBox> sb_optbutton_pressed = sb_expand(make_stylebox(option_button_pressed_png, 4, 4, 21, 4, 6, 3, 9, 3), 2, 2, 2, 2);
+	Ref<StyleBox> sb_optbutton_hover = sb_expand(make_stylebox(option_button_hover_png, 4, 4, 21, 4, 6, 2, 9, 2), 2, 2, 2, 2);
+	Ref<StyleBox> sb_optbutton_disabled = sb_expand(make_stylebox(option_button_disabled_png, 4, 4, 21, 4, 6, 2, 9, 2), 2, 2, 2, 2);
 	Ref<StyleBox> sb_optbutton_focus = sb_expand(make_stylebox(button_focus_png, 4, 4, 4, 4, 6, 2, 6, 2), 2, 2, 2, 2);
 
 	theme->set_stylebox("normal", "OptionButton", sb_optbutton_normal);


### PR DESCRIPTION
This commit reverts #34315 in favour of having the `OptionButton` itself setting its margin instead of relying on the theme.