### PR TITLE
Move the ColorPicker preview under the picker area

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -737,20 +737,6 @@ ColorPicker::ColorPicker() :
 	presets_visible = true;
 	screen = NULL;
 
-	HBoxContainer *hb_smpl = memnew(HBoxContainer);
-	add_child(hb_smpl);
-
-	sample = memnew(TextureRect);
-	hb_smpl->add_child(sample);
-	sample->set_h_size_flags(SIZE_EXPAND_FILL);
-	sample->connect("draw", this, "_sample_draw");
-
-	btn_pick = memnew(ToolButton);
-	hb_smpl->add_child(btn_pick);
-	btn_pick->set_toggle_mode(true);
-	btn_pick->set_tooltip(TTR("Pick a color from the screen."));
-	btn_pick->connect("pressed", this, "_screen_pick_pressed");
-
 	HBoxContainer *hb_edit = memnew(HBoxContainer);
 	add_child(hb_edit);
 	hb_edit->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -771,6 +757,20 @@ ColorPicker::ColorPicker() :
 	w_edit->set_v_size_flags(SIZE_EXPAND_FILL);
 	w_edit->connect("gui_input", this, "_w_input");
 	w_edit->connect("draw", this, "_hsv_draw", make_binds(1, w_edit));
+
+	HBoxContainer *hb_smpl = memnew(HBoxContainer);
+	add_child(hb_smpl);
+
+	sample = memnew(TextureRect);
+	hb_smpl->add_child(sample);
+	sample->set_h_size_flags(SIZE_EXPAND_FILL);
+	sample->connect("draw", this, "_sample_draw");
+
+	btn_pick = memnew(ToolButton);
+	hb_smpl->add_child(btn_pick);
+	btn_pick->set_toggle_mode(true);
+	btn_pick->set_tooltip(TTR("Pick a color from the editor window."));
+	btn_pick->connect("pressed", this, "_screen_pick_pressed");
 
 	VBoxContainer *vbl = memnew(VBoxContainer);
 	add_child(vbl);


### PR DESCRIPTION
This moves it to be closer to the sliders, which in turn makes it easier for the user to preview the color.

This also makes it clearer that the Pick button can only pick colors in the editor window, not outside.

See https://github.com/Orama-Interactive/Pixelorama/issues/53 for more information.

## Preview

![image](https://user-images.githubusercontent.com/180032/71547315-e1e9f800-299e-11ea-9de2-818822252008.png)