### PR TITLE
Show selected directory in split mode when selecting a file

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -124,6 +124,11 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 			udata.push_back(file_item);
 			EditorResourcePreview::get_singleton()->queue_resource_preview(file_metadata, this, "_tree_thumbnail_done", udata);
 		}
+	} else if (display_mode == DISPLAY_MODE_SPLIT) {
+		if (lpath.get_base_dir() == path.get_base_dir()) {
+			subdirectory_item->select(0);
+			subdirectory_item->set_as_cursor(0);
+		}
 	}
 
 	if (searched_string.length() > 0) {


### PR DESCRIPTION
Directory tree unselects current directory when selecting a file with split mode
![selected_dir_bug](https://user-images.githubusercontent.com/8281454/71548407-040c6600-29f1-11ea-83a6-0c30b2262eaf.gif)

It keeps showing selected directory with this PR.
![selected_dir_fixed](https://user-images.githubusercontent.com/8281454/71548410-07075680-29f1-11ea-9175-692dfab9112a.gif)
