### PR TITLE
Clamps fov/size for Camera gizmo

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -1275,7 +1275,7 @@ void CameraSpatialGizmoPlugin::set_handle(EditorSpatialGizmo *p_gizmo, int p_idx
 	if (camera->get_projection() == Camera::PROJECTION_PERSPECTIVE) {
 		Transform gt2 = camera->get_global_transform();
 		float a = _find_closest_angle_to_half_pi_arc(s[0], s[1], 1.0, gt2);
-		camera->set("fov", a * 2.0);
+		camera->set("fov", CLAMP(a * 2.0, 1, 179));
 	} else {
 
 		Vector3 ra, rb;
@@ -1285,8 +1285,7 @@ void CameraSpatialGizmoPlugin::set_handle(EditorSpatialGizmo *p_gizmo, int p_idx
 			d = Math::stepify(d, SpatialEditor::get_singleton()->get_translate_snap());
 		}
 
-		if (d < 0)
-			d = 0;
+		d = CLAMP(d, 0.1, 16384);
 
 		camera->set("size", d);
 	}

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -583,12 +583,14 @@ Camera::Projection Camera::get_projection() const {
 }
 
 void Camera::set_fov(float p_fov) {
+	ERR_FAIL_COND(p_fov < 1 || p_fov > 179);
 	fov = p_fov;
 	_update_camera_mode();
 	_change_notify("fov");
 }
 
 void Camera::set_size(float p_size) {
+	ERR_FAIL_COND(p_size < 0.1 || p_size > 16384);
 	size = p_size;
 	_update_camera_mode();
 	_change_notify("size");


### PR DESCRIPTION
* Adds a validation in `set_fov` and `set_size`
* Clamps the FOV/Size value set by Camera gizmo

Before this PR, FOV/Size value of Camera can be adjusted out of range by using the gizmo handle, unsyncing the actual property value from the Inspector value shown.

e.g. By dragging the handle, the FOV of Camera can be set to a minimum value of -0.000005, which is outside the Inspector range [1, 127]. The inspector will show the current FOV as 1, but the actual value stored is -5.00896e-06.

The range applied is the property's hint range.