### PR TITLE
[Core] Reformat structure string operators

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -392,5 +392,5 @@ Variant AABB::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) c
 }
 
 AABB::operator String() const {
-	return String() + position + " - " + size;
+	return "[P: " + position.operator String() + ", S: " + size + "]";
 }

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -756,18 +756,9 @@ bool Basis::operator!=(const Basis &p_matrix) const {
 }
 
 Basis::operator String() const {
-	String mtx;
-	for (int i = 0; i < 3; i++) {
-		for (int j = 0; j < 3; j++) {
-			if (i != 0 || j != 0) {
-				mtx += ", ";
-			}
-
-			mtx += rtos(elements[j][i]); //matrix is stored transposed for performance, so print it transposed
-		}
-	}
-
-	return mtx;
+	return "[X: " + get_axis(0).operator String() +
+		   ", Y: " + get_axis(1).operator String() +
+		   ", Z: " + get_axis(2).operator String() + "]";
 }
 
 Quaternion Basis::get_quaternion() const {

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -466,7 +466,7 @@ Color Color::from_hsv(float p_h, float p_s, float p_v, float p_a) const {
 }
 
 Color::operator String() const {
-	return rtos(r) + ", " + rtos(g) + ", " + rtos(b) + ", " + rtos(a);
+	return "(" + String::num(r, 4) + ", " + String::num(g, 4) + ", " + String::num(b, 4) + ", " + String::num(a, 4) + ")";
 }
 
 Color Color::operator+(const Color &p_color) const {

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -175,5 +175,5 @@ bool Plane::is_equal_approx(const Plane &p_plane) const {
 }
 
 Plane::operator String() const {
-	return normal.operator String() + ", " + rtos(d);
+	return "[N: " + normal.operator String() + ", D: " + String::num_real(d, false) + "]";
 }

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -181,7 +181,7 @@ Quaternion Quaternion::cubic_slerp(const Quaternion &p_b, const Quaternion &p_pr
 }
 
 Quaternion::operator String() const {
-	return String::num(x) + ", " + String::num(y) + ", " + String::num(z) + ", " + String::num(w);
+	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ", " + String::num_real(z, false) + ", " + String::num_real(w, false) + ")";
 }
 
 Quaternion::Quaternion(const Vector3 &p_axis, real_t p_angle) {

--- a/core/math/rect2.cpp
+++ b/core/math/rect2.cpp
@@ -263,3 +263,11 @@ next4:
 
 	return true;
 }
+
+Rect2::operator String() const {
+	return "[P: " + position.operator String() + ", S: " + size + "]";
+}
+
+Rect2i::operator String() const {
+	return "[P: " + position.operator String() + ", S: " + size + "]";
+}

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -320,7 +320,7 @@ struct Rect2 {
 		return position + size;
 	}
 
-	operator String() const { return String(position) + ", " + String(size); }
+	operator String() const;
 
 	Rect2() {}
 	Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :
@@ -498,7 +498,7 @@ struct Rect2i {
 		return position + size;
 	}
 
-	operator String() const { return String(position) + ", " + String(size); }
+	operator String() const;
 
 	operator Rect2() const { return Rect2(position, size); }
 

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -277,5 +277,7 @@ Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, real_t
 }
 
 Transform2D::operator String() const {
-	return String(String() + elements[0] + ", " + elements[1] + ", " + elements[2]);
+	return "[X: " + elements[0].operator String() +
+		   ", Y: " + elements[1].operator String() +
+		   ", O: " + elements[2].operator String() + "]";
 }

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -191,7 +191,10 @@ Transform3D Transform3D::operator*(const Transform3D &p_transform) const {
 }
 
 Transform3D::operator String() const {
-	return basis.operator String() + " - " + origin.operator String();
+	return "[X: " + basis.get_axis(0).operator String() +
+		   ", Y: " + basis.get_axis(1).operator String() +
+		   ", Z: " + basis.get_axis(2).operator String() +
+		   ", O: " + origin.operator String() + "]";
 }
 
 Transform3D::Transform3D(const Basis &p_basis, const Vector3 &p_origin) :

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -193,6 +193,10 @@ bool Vector2::is_equal_approx(const Vector2 &p_v) const {
 	return Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y);
 }
 
+Vector2::operator String() const {
+	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ")";
+}
+
 /* Vector2i */
 
 Vector2i Vector2i::clamp(const Vector2i &p_min, const Vector2i &p_max) const {
@@ -268,4 +272,8 @@ bool Vector2i::operator==(const Vector2i &p_vec2) const {
 
 bool Vector2i::operator!=(const Vector2i &p_vec2) const {
 	return x != p_vec2.x || y != p_vec2.y;
+}
+
+Vector2i::operator String() const {
+	return "(" + itos(x) + ", " + itos(y) + ")";
 }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -165,7 +165,7 @@ struct Vector2 {
 	Vector2 clamp(const Vector2 &p_min, const Vector2 &p_max) const;
 	real_t aspect() const { return width / height; }
 
-	operator String() const { return String::num(x) + ", " + String::num(y); }
+	operator String() const;
 
 	_FORCE_INLINE_ Vector2() {}
 	_FORCE_INLINE_ Vector2(real_t p_x, real_t p_y) {
@@ -340,7 +340,7 @@ struct Vector2i {
 	Vector2i abs() const { return Vector2i(ABS(x), ABS(y)); }
 	Vector2i clamp(const Vector2i &p_min, const Vector2i &p_max) const;
 
-	operator String() const { return String::num(x) + ", " + String::num(y); }
+	operator String() const;
 
 	operator Vector2() const { return Vector2(x, y); }
 

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -126,5 +126,5 @@ bool Vector3::is_equal_approx(const Vector3 &p_v) const {
 }
 
 Vector3::operator String() const {
-	return (rtos(x) + ", " + rtos(y) + ", " + rtos(z));
+	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ", " + String::num_real(z, false) + ")";
 }

--- a/core/math/vector3i.cpp
+++ b/core/math/vector3i.cpp
@@ -56,5 +56,5 @@ Vector3i Vector3i::clamp(const Vector3i &p_min, const Vector3i &p_max) const {
 }
 
 Vector3i::operator String() const {
-	return (itos(x) + ", " + itos(y) + ", " + itos(z));
+	return "(" + itos(x) + ", " + itos(y) + ", " + itos(z) + ")";
 }

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1594,7 +1594,7 @@ String String::num_uint64(uint64_t p_num, int base, bool capitalize_hex) {
 	return s;
 }
 
-String String::num_real(double p_num) {
+String String::num_real(double p_num, bool p_trailing) {
 	if (Math::is_nan(p_num)) {
 		return "nan";
 	}
@@ -1669,8 +1669,10 @@ String String::num_real(double p_num) {
 			dec_int /= 10;
 		}
 		sd = '.' + decimal;
-	} else {
+	} else if (p_trailing) {
 		sd = ".0";
+	} else {
+		sd = "";
 	}
 
 	if (intn == 0) {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -309,7 +309,7 @@ public:
 	String unquote() const;
 	static String num(double p_num, int p_decimals = -1);
 	static String num_scientific(double p_num);
-	static String num_real(double p_num);
+	static String num_real(double p_num, bool p_trailing = true);
 	static String num_int64(int64_t p_num, int base = 10, bool capitalize_hex = false);
 	static String num_uint64(uint64_t p_num, int base = 10, bool capitalize_hex = false);
 	static String chr(char32_t p_char);

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1636,51 +1636,27 @@ String Variant::stringify(List<const void *> &stack) const {
 		case STRING:
 			return *reinterpret_cast<const String *>(_data._mem);
 		case VECTOR2:
-			return "(" + operator Vector2() + ")";
+			return operator Vector2();
 		case VECTOR2I:
-			return "(" + operator Vector2i() + ")";
+			return operator Vector2i();
 		case RECT2:
-			return "(" + operator Rect2() + ")";
+			return operator Rect2();
 		case RECT2I:
-			return "(" + operator Rect2i() + ")";
-		case TRANSFORM2D: {
-			Transform2D mat32 = operator Transform2D();
-			return "(" + Variant(mat32.elements[0]).operator String() + ", " + Variant(mat32.elements[1]).operator String() + ", " + Variant(mat32.elements[2]).operator String() + ")";
-		} break;
+			return operator Rect2i();
+		case TRANSFORM2D:
+			return operator Transform2D();
 		case VECTOR3:
-			return "(" + operator Vector3() + ")";
+			return operator Vector3();
 		case VECTOR3I:
-			return "(" + operator Vector3i() + ")";
+			return operator Vector3i();
 		case PLANE:
 			return operator Plane();
 		case AABB:
 			return operator ::AABB();
 		case QUATERNION:
-			return "(" + operator Quaternion() + ")";
-		case BASIS: {
-			Basis mat3 = operator Basis();
-
-			String mtx("(");
-			for (int i = 0; i < 3; i++) {
-				if (i != 0) {
-					mtx += ", ";
-				}
-
-				mtx += "(";
-
-				for (int j = 0; j < 3; j++) {
-					if (j != 0) {
-						mtx += ", ";
-					}
-
-					mtx += Variant(mat3.elements[i][j]).operator String();
-				}
-
-				mtx += ")";
-			}
-
-			return mtx + ")";
-		} break;
+			return operator Quaternion();
+		case BASIS:
+			return operator Basis();
 		case TRANSFORM3D:
 			return operator Transform3D();
 		case STRING_NAME:
@@ -1688,7 +1664,7 @@ String Variant::stringify(List<const void *> &stack) const {
 		case NODE_PATH:
 			return operator NodePath();
 		case COLOR:
-			return String::num(operator Color().r) + "," + String::num(operator Color().g) + "," + String::num(operator Color().b) + "," + String::num(operator Color().a);
+			return operator Color();
 		case DICTIONARY: {
 			const Dictionary &d = *reinterpret_cast<const Dictionary *>(_data._mem);
 			if (stack.find(d.id())) {

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -3053,28 +3053,25 @@ bool BindingsGenerator::_arg_default_value_from_variant(const Variant &p_val, Ar
 			break;
 		case Variant::PLANE: {
 			Plane plane = p_val.operator Plane();
-			r_iarg.default_argument = "new Plane(new Vector3(" + plane.normal.operator String() + "), " + rtos(plane.d) + ")";
+			r_iarg.default_argument = "new Plane(new Vector3" + plane.normal.operator String() + ", " + rtos(plane.d) + ")";
 			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_VAL;
 		} break;
 		case Variant::AABB: {
 			AABB aabb = p_val.operator ::AABB();
-			r_iarg.default_argument = "new AABB(new Vector3(" + aabb.position.operator String() + "), new Vector3(" + aabb.position.operator String() + "))";
+			r_iarg.default_argument = "new AABB(new Vector3" + aabb.position.operator String() + ", new Vector3" + aabb.position.operator String() + ")";
 			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_VAL;
 		} break;
 		case Variant::RECT2: {
 			Rect2 rect = p_val.operator Rect2();
-			r_iarg.default_argument = "new Rect2(new Vector2(" + rect.position.operator String() + "), new Vector2(" + rect.position.operator String() + "))";
+			r_iarg.default_argument = "new Rect2(new Vector2" + rect.position.operator String() + ", new Vector2" + rect.position.operator String() + ")";
 			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_VAL;
 		} break;
 		case Variant::RECT2I: {
 			Rect2i rect = p_val.operator Rect2i();
-			r_iarg.default_argument = "new Rect2i(new Vector2i(" + rect.position.operator String() + "), new Vector2i(" + rect.position.operator String() + "))";
+			r_iarg.default_argument = "new Rect2i(new Vector2i" + rect.position.operator String() + ", new Vector2i" + rect.position.operator String() + ")";
 			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_VAL;
 		} break;
 		case Variant::COLOR:
-			r_iarg.default_argument = "new %s(" + r_iarg.default_argument + ")";
-			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_VAL;
-			break;
 		case Variant::VECTOR2:
 		case Variant::VECTOR2I:
 		case Variant::VECTOR3:

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -676,7 +676,7 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("{0} - {1}", new object[]
+            return String.Format("{0}, {1}", new object[]
                 {
                     _position.ToString(),
                     _size.ToString()
@@ -685,7 +685,7 @@ namespace Godot
 
         public string ToString(string format)
         {
-            return String.Format("{0} - {1}", new object[]
+            return String.Format("{0}, {1}", new object[]
                 {
                     _position.ToString(format),
                     _size.ToString(format)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -863,22 +863,16 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1}, {2})", new object[]
-            {
-                Row0.ToString(),
-                Row1.ToString(),
-                Row2.ToString()
-            });
+            return "[X: " + x.ToString() +
+                    ", Y: " + y.ToString() +
+                    ", Z: " + z.ToString() + "]";
         }
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1}, {2})", new object[]
-            {
-                Row0.ToString(format),
-                Row1.ToString(format),
-                Row2.ToString(format)
-            });
+            return "[X: " + x.ToString(format) +
+                    ", Y: " + y.ToString(format) +
+                    ", Z: " + z.ToString(format) + "]";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -1010,12 +1010,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("{0},{1},{2},{3}", r.ToString(), g.ToString(), b.ToString(), a.ToString());
+            return String.Format("({0}, {1}, {2}, {3})", r.ToString(), g.ToString(), b.ToString(), a.ToString());
         }
 
         public string ToString(string format)
         {
-            return String.Format("{0},{1},{2},{3}", r.ToString(format), g.ToString(format), b.ToString(format), a.ToString(format));
+            return String.Format("({0}, {1}, {2}, {3})", r.ToString(format), g.ToString(format), b.ToString(format), a.ToString(format));
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -355,7 +355,7 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1})", new object[]
+            return String.Format("{0}, {1}", new object[]
             {
                 _normal.ToString(),
                 D.ToString()
@@ -364,7 +364,7 @@ namespace Godot
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1})", new object[]
+            return String.Format("{0}, {1}", new object[]
             {
                 _normal.ToString(format),
                 D.ToString(format)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -405,7 +405,7 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1})", new object[]
+            return String.Format("{0}, {1}", new object[]
             {
                 _position.ToString(),
                 _size.ToString()
@@ -414,7 +414,7 @@ namespace Godot
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1})", new object[]
+            return String.Format("{0}, {1}", new object[]
             {
                 _position.ToString(format),
                 _size.ToString(format)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -492,22 +492,16 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1}, {2})", new object[]
-            {
-                x.ToString(),
-                y.ToString(),
-                origin.ToString()
-            });
+            return "[X: " + x.ToString() +
+                    ", Y: " + y.ToString() +
+                    ", O: " + origin.ToString() + "]";
         }
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1}, {2})", new object[]
-            {
-                x.ToString(format),
-                y.ToString(format),
-                origin.ToString(format)
-            });
+            return "[X: " + x.ToString(format) +
+                    ", Y: " + y.ToString(format) +
+                    ", O: " + origin.ToString(format) + "]";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -393,20 +393,18 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("{0} - {1}", new object[]
-            {
-                basis.ToString(),
-                origin.ToString()
-            });
+            return "[X: " + basis.x.ToString() +
+                    ", Y: " + basis.y.ToString() +
+                    ", Z: " + basis.z.ToString() +
+                    ", O: " + origin.ToString() + "]";
         }
 
         public string ToString(string format)
         {
-            return String.Format("{0} - {1}", new object[]
-            {
-                basis.ToString(format),
-                origin.ToString(format)
-            });
+            return "[X: " + basis.x.ToString(format) +
+                    ", Y: " + basis.y.ToString(format) +
+                    ", Z: " + basis.z.ToString(format) +
+                    ", O: " + origin.ToString(format) + "]";
         }
     }
 }

--- a/tests/test_aabb.h
+++ b/tests/test_aabb.h
@@ -50,8 +50,8 @@ TEST_CASE("[AABB] Constructor methods") {
 
 TEST_CASE("[AABB] String conversion") {
 	CHECK_MESSAGE(
-			String(AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6))) == "-1.5, 2, -2.5 - 4, 5, 6",
-			"The string representation shouild match the expected value.");
+			String(AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6))) == "[P: (-1.5, 2, -2.5), S: (4, 5, 6)]",
+			"The string representation should match the expected value.");
 }
 
 TEST_CASE("[AABB] Basic getters") {

--- a/tests/test_color.h
+++ b/tests/test_color.h
@@ -140,7 +140,7 @@ TEST_CASE("[Color] Conversion methods") {
 			cyan.to_rgba64() == 0x0000'ffff'ffff'ffff,
 			"The returned 64-bit BGR number should match the expected value.");
 	CHECK_MESSAGE(
-			String(cyan) == "0, 1, 1, 1",
+			String(cyan) == "(0, 1, 1, 1)",
 			"The string representation should match the expected value.");
 }
 

--- a/tests/test_rect2.h
+++ b/tests/test_rect2.h
@@ -61,7 +61,7 @@ TEST_CASE("[Rect2] Constructor methods") {
 TEST_CASE("[Rect2] String conversion") {
 	// Note: This also depends on the Vector2 string representation.
 	CHECK_MESSAGE(
-			String(Rect2(0, 100, 1280, 720)) == "0, 100, 1280, 720",
+			String(Rect2(0, 100, 1280, 720)) == "[P: (0, 100), S: (1280, 720)]",
 			"The string representation should match the expected value.");
 }
 
@@ -273,7 +273,7 @@ TEST_CASE("[Rect2i] Constructor methods") {
 TEST_CASE("[Rect2i] String conversion") {
 	// Note: This also depends on the Vector2 string representation.
 	CHECK_MESSAGE(
-			String(Rect2i(0, 100, 1280, 720)) == "0, 100, 1280, 720",
+			String(Rect2i(0, 100, 1280, 720)) == "[P: (0, 100), S: (1280, 720)]",
 			"The string representation should match the expected value.");
 }
 


### PR DESCRIPTION
Implements and closes https://github.com/godotengine/godot-proposals/issues/1819

Explanation in bullets below each set of outputs. Test code:

```gdscript
func _ready():
	print("Vector2")
	print(Vector2())
	print("Vector2i")
	print(Vector2i())
	print("Vector3")
	print(Vector3())
	print("Vector3i")
	print(Vector3i())
	print("Color")
	print(Color())
	print("Quaternion")
	print(Quaternion())
	print("Plane")
	print(Plane())
	print("AABB")
	print(AABB())
	print("Rect2")
	print(Rect2())
	print("Rect2i")
	print(Rect2i())
	var t = Transform2D()
	t.x = Vector2(1, 5)
	print("Transform2D")
	print(t)
	var b = Basis()
	b.x = Vector3(1, 5, 0)
	print("Basis")
	print(b)
	print("Transform3D")
	print(Transform(b))
```

Output with current master:

```
Vector2
(0, 0)
Vector2i
(0, 0)
Vector3
(0, 0, 0)
Vector3i
(0, 0, 0)
Color
0,0,0,1
Quaternion
(0, 0, 0, 1)
Plane
0, 0, 0, 0
AABB
0, 0, 0 - 0, 0, 0
Rect2
(0, 0, 0, 0)
Rect2i
(0, 0, 0, 0)
Transform2D
((1, 5), (0, 1), (0, 0))
Basis
((1, 0, 0), (5, 1, 0), (0, 0, 1))
Transform3D
1, 5, 0, 0, 1, 0, 0, 0, 1 - 0, 0, 0
```

The current output is a bit confusing and inconsistent:

* Color is lacking spaces after the commas.

* AABB and Transform both contain a dash, which can be mistaken for a minus sign.

* Some things have parenthesis, some don't, and Basis/Transform2D have nested parenthesis.

* Transform2D prints out column-major, while Basis prints out row-major, and Transform is row major except the origin is last.

* The current internal code is a bit strange, with some of the string logic being inside of Variant and some being in the class.

Output with this PR:

```
Vector2
(0, 0)
Vector2i
(0, 0)
Vector3
(0, 0, 0)
Vector3i
(0, 0, 0)
Color
(0, 0, 0, 1)
Quaternion
(0, 0, 0, 1)
Plane
[N: (0, 0, 0), D: 0]
AABB
[P: (0, 0, 0), S: (0, 0, 0)]
Rect2
[P: (0, 0), S: (0, 0)]
Rect2i
[P: (0, 0), S: (0, 0)]
Transform2D
[X: (1, 5), Y: (0, 1), O: (0, 0)]
Basis
[X: (1, 5, 0), Y: (0, 1, 0), Z: (0, 0, 1)]
Transform3D
[X: (1, 5, 0), Y: (0, 1, 0), Z: (0, 0, 1), O: (0, 0, 0)]
```

* I've moved all the code to the classes and out of Variant.

* No dashes anywhere, parenthesis used for grouping with commas for separation.

* Transforms and Basis are now printed consistently and with explicit labels to avoid any confusion.

* Since they store `real_t`, I decided to use `String::num_real`, but normally this adds a trailing `.0` to whole numbers, so I added a new bool to include it or not called `p_trailing`, which defaults to true so its current uses are the same.

* Color is an exception to the above, it uses `String::num` with a fixed amount of decimals (4 seems like a good value, but maybe 5, 3 or 2 would be better).