### PR TITLE
Silenced ubsan errors

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -458,7 +458,7 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
 
 				hash = hash_djb2_one_64(F->get().hash(), hash);
-				hash = hash_djb2_one_64(t->constant_map[F->get()], hash);
+				hash = hash_djb2_one_64((unsigned int)(t->constant_map[F->get()]), hash);
 			}
 		}
 

--- a/core/command_queue_mt.h
+++ b/core/command_queue_mt.h
@@ -348,7 +348,7 @@ class CommandQueueMT {
 	T *allocate() {
 
 		// alloc size is size+T+safeguard
-		uint32_t alloc_size = ((sizeof(T) + 8 - 1) & ~(8 - 1)) + 8;
+		uint32_t alloc_size = ((sizeof(T) + 8 - 1) & ~(8u - 1u)) + 8;
 
 	tryagain:
 
@@ -390,7 +390,7 @@ class CommandQueueMT {
 		// Allocate the size and the 'in use' bit.
 		// First bit used to mark if command is still in use (1)
 		// or if it has been destroyed and can be deallocated (0).
-		uint32_t size = (sizeof(T) + 8 - 1) & ~(8 - 1);
+		uint32_t size = (sizeof(T) + 8 - 1) & ~(8u - 1u);
 		uint32_t *p = (uint32_t *)&command_mem[write_ptr];
 		*p = (size << 1) | 1;
 		write_ptr += 8;
@@ -448,7 +448,7 @@ class CommandQueueMT {
 
 		cmd->post();
 		cmd->~CommandBase();
-		*(uint32_t *)&command_mem[size_ptr] &= ~1;
+		*(uint32_t *)&command_mem[size_ptr] &= ~1u;
 
 		if (p_lock) unlock();
 		return true;

--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -232,7 +232,7 @@ private:
 		hash_table_power = p_t.hash_table_power;
 		elements = p_t.elements;
 
-		for (int i = 0; i < (1 << p_t.hash_table_power); i++) {
+		for (unsigned int i = 0; i < (1u << p_t.hash_table_power); i++) {
 
 			hash_table[i] = nullptr;
 

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -958,7 +958,7 @@ public:
 			else
 				ret |= (1 << (p_idx + 1));
 
-			int mask = ret | (1 << p_idx);
+			int mask = ret | (1u << p_idx);
 			if (p_idx < 8)
 				ret |= 24;
 			else

--- a/core/ring_buffer.h
+++ b/core/ring_buffer.h
@@ -197,9 +197,9 @@ public:
 
 	void resize(int p_power) {
 		int old_size = size();
-		int new_size = 1 << p_power;
+		int new_size = 1u << p_power;
 		int mask = new_size - 1;
-		data.resize(1 << p_power);
+		data.resize(1u << p_power);
 		if (old_size < new_size && read_pos > write_pos) {
 			for (int i = 0; i < write_pos; i++) {
 				data.write[(old_size + i) & mask] = data[i];

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -557,7 +557,7 @@ void RasterizerStorageGLES2::texture_allocate(RID p_texture, int p_width, int p_
 	bool compressed = false;
 
 	if (p_flags & RS::TEXTURE_FLAG_USED_FOR_STREAMING) {
-		p_flags &= ~RS::TEXTURE_FLAG_MIPMAPS; // no mipies for video
+		p_flags &= ~((unsigned int)RS::TEXTURE_FLAG_MIPMAPS); // no mipies for video
 	}
 
 	Texture *texture = texture_owner.getornull(p_texture);
@@ -616,7 +616,7 @@ void RasterizerStorageGLES2::texture_allocate(RID p_texture, int p_width, int p_
 			if (p_flags & RS::TEXTURE_FLAG_USED_FOR_STREAMING) {
 				//not supported
 				ERR_PRINT("Streaming texture for non power of 2 or has mipmaps on this hardware: " + texture->path + "'. Mipmaps and repeat disabled.");
-				texture->flags &= ~(RS::TEXTURE_FLAG_REPEAT | RS::TEXTURE_FLAG_MIPMAPS);
+				texture->flags &= ~(unsigned int)(RS::TEXTURE_FLAG_REPEAT | RS::TEXTURE_FLAG_MIPMAPS);
 			} else {
 				texture->alloc_height = po2_height;
 				texture->alloc_width = po2_width;
@@ -852,7 +852,7 @@ void RasterizerStorageGLES2::texture_set_data(RID p_texture, const Ref<Image> &p
 
 	// printf("texture: %i x %i - size: %i - total: %i\n", texture->width, texture->height, tsize, info.texture_mem);
 
-	texture->stored_cube_sides |= (1 << p_layer);
+	texture->stored_cube_sides |= (1u << p_layer);
 
 	if ((texture->flags & RS::TEXTURE_FLAG_MIPMAPS) && mipmaps == 1 && !texture->ignore_mipmaps && (texture->type != RS::TEXTURE_TYPE_CUBEMAP || texture->stored_cube_sides == (1 << 6) - 1)) {
 		//generate mipmaps if they were requested and the image does not contain them
@@ -2119,7 +2119,7 @@ static Vector<uint8_t> _unpack_half_floats(const Vector<uint8_t> &array, uint32_
 						to_convert[i] = 3;
 					}
 
-					format &= ~RS::ARRAY_COMPRESS_VERTEX;
+					format &= ~(unsigned int)RS::ARRAY_COMPRESS_VERTEX;
 				} else {
 
 					if (p_format & RS::ARRAY_FLAG_USE_2D_VERTICES) {
@@ -2170,7 +2170,7 @@ static Vector<uint8_t> _unpack_half_floats(const Vector<uint8_t> &array, uint32_
 				if (p_format & RS::ARRAY_COMPRESS_TEX_UV) {
 					src_size[i] = 4;
 					to_convert[i] = 2;
-					format &= ~RS::ARRAY_COMPRESS_TEX_UV;
+					format &= ~(unsigned int)RS::ARRAY_COMPRESS_TEX_UV;
 				} else {
 					src_size[i] = 8;
 				}
@@ -2183,7 +2183,7 @@ static Vector<uint8_t> _unpack_half_floats(const Vector<uint8_t> &array, uint32_
 				if (p_format & RS::ARRAY_COMPRESS_TEX_UV2) {
 					src_size[i] = 4;
 					to_convert[i] = 2;
-					format &= ~RS::ARRAY_COMPRESS_TEX_UV2;
+					format &= ~(unsigned int)RS::ARRAY_COMPRESS_TEX_UV2;
 				} else {
 					src_size[i] = 8;
 				}

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -183,7 +183,7 @@ ShaderGLES2::Version *ShaderGLES2::get_current_version() {
 #endif
 
 	for (int j = 0; j < conditional_count; j++) {
-		bool enable = (conditional_version.version & (1 << j)) > 0;
+		bool enable = (conditional_version.version & (1u << j)) > 0;
 
 		if (enable) {
 			strings.push_back(conditional_defines[j]);

--- a/drivers/gles2/shader_gles2.h
+++ b/drivers/gles2/shader_gles2.h
@@ -262,9 +262,9 @@ void ShaderGLES2::_set_conditional(int p_which, bool p_value) {
 
 	ERR_FAIL_INDEX(p_which, conditional_count);
 	if (p_value)
-		new_conditional_version.version |= (1 << p_which);
+		new_conditional_version.version |= (1u << p_which);
 	else
-		new_conditional_version.version &= ~(1 << p_which);
+		new_conditional_version.version &= ~(1u << p_which);
 }
 
 #endif

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -3540,7 +3540,7 @@ bool RenderingDeviceVulkan::_uniform_add_binding(Vector<Vector<VkDescriptorSetLa
 
 				//just append stage mask and return
 				bindings.write[set].write[i].stageFlags |= shader_stage_masks[p_stage];
-				uniform_infos.write[set].write[i].stages |= 1 << p_stage;
+				uniform_infos.write[set].write[i].stages |= 1u << p_stage;
 				return true;
 			}
 		}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -757,10 +757,10 @@ void EditorPropertyLayers::_button_pressed() {
 }
 
 void EditorPropertyLayers::_menu_pressed(int p_menu) {
-	if (grid->value & (1 << p_menu)) {
-		grid->value &= ~(1 << p_menu);
+	if (grid->value & (1u << p_menu)) {
+		grid->value &= ~(1u << p_menu);
 	} else {
-		grid->value |= (1 << p_menu);
+		grid->value |= (1u << p_menu);
 	}
 	grid->update();
 	layers->set_item_checked(layers->get_item_index(p_menu), grid->value & (1 << p_menu));

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -1445,14 +1445,14 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 								uint32_t old_mask = tileset->autotile_get_bitmask(get_current_tile(), coord);
 								uint32_t new_mask = old_mask;
 								if (alternative) {
-									new_mask &= ~bit;
+									new_mask &= ~(unsigned int)bit;
 									new_mask |= (bit << 16);
 								} else if (erasing) {
-									new_mask &= ~bit;
-									new_mask &= ~(bit << 16);
+									new_mask &= ~(unsigned int)bit;
+									new_mask &= ~(unsigned int)(bit << 16);
 								} else {
 									new_mask |= bit;
-									new_mask &= ~(bit << 16);
+									new_mask &= ~(unsigned int)(bit << 16);
 								}
 
 								if (old_mask != new_mask) {
@@ -1523,14 +1523,14 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 							uint32_t old_mask = tileset->autotile_get_bitmask(get_current_tile(), coord);
 							uint32_t new_mask = old_mask;
 							if (alternative) {
-								new_mask &= ~bit;
+								new_mask &= ~(unsigned int)bit;
 								new_mask |= (bit << 16);
 							} else if (erasing) {
-								new_mask &= ~bit;
-								new_mask &= ~(bit << 16);
+								new_mask &= ~(unsigned int)bit;
+								new_mask &= ~(unsigned int)(bit << 16);
 							} else {
 								new_mask |= bit;
-								new_mask &= ~(bit << 16);
+								new_mask &= ~(unsigned int)(bit << 16);
 							}
 							if (old_mask != new_mask) {
 								undo_redo->create_action(TTR("Edit Tile Bitmask"));

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -1236,9 +1236,9 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 				uint32_t f = v;
 				if (checks20[p_which]->is_pressed())
-					f |= (1 << p_which);
+					f |= (1u << p_which);
 				else
-					f &= ~(1 << p_which);
+					f &= ~(1u << p_which);
 
 				v = f;
 				emit_signal("variant_changed");

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -80,7 +80,7 @@ Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 		uint8_t *write_buffer = data_w;
 
 		const uint32_t width_bytes = width * bits_per_pixel / 8;
-		const uint32_t line_width = (width_bytes + 3) & ~3;
+		const uint32_t line_width = (width_bytes + 3) & ~3u;
 
 		// The actual data traversal is determined by
 		// the data width in case of 8/4/1 bit images

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -92,30 +92,30 @@ void CSGShape3D::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool CSGShape3D::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void CSGShape3D::set_collision_layer_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_layer();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_layer(mask);
 }
 
 bool CSGShape3D::get_collision_layer_bit(int p_bit) const {
 
-	return get_collision_layer() & (1 << p_bit);
+	return get_collision_layer() & (1u << p_bit);
 }
 
 bool CSGShape3D::is_root_shape() const {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -168,30 +168,30 @@ void GridMap::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool GridMap::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void GridMap::set_collision_layer_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_layer();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_layer(mask);
 }
 
 bool GridMap::get_collision_layer_bit(int p_bit) const {
 
-	return get_collision_layer() & (1 << p_bit);
+	return get_collision_layer() & (1u << p_bit);
 }
 
 void GridMap::set_mesh_library(const Ref<MeshLibrary> &p_mesh_library) {

--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -37,7 +37,7 @@ void EMWSPeer::set_sock(int p_sock, unsigned int p_in_buf_size, unsigned int p_i
 
 	peer_sock = p_sock;
 	_in_buffer.resize(p_in_pkt_size, p_in_buf_size);
-	_packet_buffer.resize((1 << p_in_buf_size));
+	_packet_buffer.resize((1u << p_in_buf_size));
 }
 
 void EMWSPeer::set_write_mode(WriteMode p_mode) {

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -515,30 +515,30 @@ void Area2D::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool Area2D::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void Area2D::set_collision_layer_bit(int p_bit, bool p_value) {
 
 	uint32_t layer = get_collision_layer();
 	if (p_value)
-		layer |= 1 << p_bit;
+		layer |= 1u << p_bit;
 	else
-		layer &= ~(1 << p_bit);
+		layer &= ~(1u << p_bit);
 	set_collision_layer(layer);
 }
 
 bool Area2D::get_collision_layer_bit(int p_bit) const {
 
-	return get_collision_layer() & (1 << p_bit);
+	return get_collision_layer() & (1u << p_bit);
 }
 
 void Area2D::set_audio_bus_override(bool p_override) {

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -105,29 +105,29 @@ void PhysicsBody2D::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 bool PhysicsBody2D::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void PhysicsBody2D::set_collision_layer_bit(int p_bit, bool p_value) {
 
 	uint32_t collision_layer = get_collision_layer();
 	if (p_value)
-		collision_layer |= 1 << p_bit;
+		collision_layer |= 1u << p_bit;
 	else
-		collision_layer &= ~(1 << p_bit);
+		collision_layer &= ~(1u << p_bit);
 	set_collision_layer(collision_layer);
 }
 
 bool PhysicsBody2D::get_collision_layer_bit(int p_bit) const {
 
-	return get_collision_layer() & (1 << p_bit);
+	return get_collision_layer() & (1u << p_bit);
 }
 
 PhysicsBody2D::PhysicsBody2D(PhysicsServer2D::BodyMode p_mode) :

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -61,15 +61,15 @@ void RayCast2D::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool RayCast2D::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 bool RayCast2D::is_colliding() const {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1323,9 +1323,9 @@ void TileMap::set_collision_layer_bit(int p_bit, bool p_value) {
 
 	uint32_t layer = get_collision_layer();
 	if (p_value)
-		layer |= 1 << p_bit;
+		layer |= 1u << p_bit;
 	else
-		layer &= ~(1 << p_bit);
+		layer &= ~(1u << p_bit);
 	set_collision_layer(layer);
 }
 
@@ -1333,9 +1333,9 @@ void TileMap::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
@@ -1421,12 +1421,12 @@ uint32_t TileMap::get_collision_mask() const {
 
 bool TileMap::get_collision_layer_bit(int p_bit) const {
 
-	return get_collision_layer() & (1 << p_bit);
+	return get_collision_layer() & (1u << p_bit);
 }
 
 bool TileMap::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void TileMap::set_mode(Mode p_mode) {

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -511,30 +511,30 @@ void Area3D::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool Area3D::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void Area3D::set_collision_layer_bit(int p_bit, bool p_value) {
 
 	uint32_t layer = get_collision_layer();
 	if (p_value)
-		layer |= 1 << p_bit;
+		layer |= 1u << p_bit;
 	else
-		layer &= ~(1 << p_bit);
+		layer &= ~(1u << p_bit);
 	set_collision_layer(layer);
 }
 
 bool Area3D::get_collision_layer_bit(int p_bit) const {
 
-	return get_collision_layer() & (1 << p_bit);
+	return get_collision_layer() & (1u << p_bit);
 }
 
 void Area3D::set_audio_bus_override(bool p_override) {

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -623,15 +623,15 @@ uint32_t Camera3D::get_cull_mask() const {
 void Camera3D::set_cull_mask_bit(int p_layer, bool p_enable) {
 	ERR_FAIL_INDEX(p_layer, 32);
 	if (p_enable) {
-		set_cull_mask(layers | (1 << p_layer));
+		set_cull_mask(layers | (1u << p_layer));
 	} else {
-		set_cull_mask(layers & (~(1 << p_layer)));
+		set_cull_mask(layers & (~(1u << p_layer)));
 	}
 }
 
 bool Camera3D::get_cull_mask_bit(int p_layer) const {
 	ERR_FAIL_INDEX_V(p_layer, 32, false);
-	return (layers & (1 << p_layer));
+	return (layers & (1u << p_layer));
 }
 
 Vector<Plane> Camera3D::get_frustum() const {
@@ -810,15 +810,15 @@ void ClippedCamera3D::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool ClippedCamera3D::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void ClippedCamera3D::add_exception_rid(const RID &p_rid) {

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -84,30 +84,30 @@ void PhysicsBody3D::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool PhysicsBody3D::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void PhysicsBody3D::set_collision_layer_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_layer();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_layer(mask);
 }
 
 bool PhysicsBody3D::get_collision_layer_bit(int p_bit) const {
 
-	return get_collision_layer() & (1 << p_bit);
+	return get_collision_layer() & (1u << p_bit);
 }
 
 Array PhysicsBody3D::get_collision_exceptions() {

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -63,15 +63,15 @@ void RayCast3D::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool RayCast3D::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 bool RayCast3D::is_colliding() const {

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -527,27 +527,27 @@ uint32_t SoftBody3D::get_collision_layer() const {
 void SoftBody3D::set_collision_mask_bit(int p_bit, bool p_value) {
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool SoftBody3D::get_collision_mask_bit(int p_bit) const {
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void SoftBody3D::set_collision_layer_bit(int p_bit, bool p_value) {
 	uint32_t layer = get_collision_layer();
 	if (p_value)
-		layer |= 1 << p_bit;
+		layer |= 1u << p_bit;
 	else
-		layer &= ~(1 << p_bit);
+		layer &= ~(1u << p_bit);
 	set_collision_layer(layer);
 }
 
 bool SoftBody3D::get_collision_layer_bit(int p_bit) const {
-	return get_collision_layer() & (1 << p_bit);
+	return get_collision_layer() & (1u << p_bit);
 }
 
 void SoftBody3D::set_parent_collision_ignore(const NodePath &p_parent_collision_ignore) {

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -108,15 +108,15 @@ uint32_t VisualInstance3D::get_layer_mask() const {
 void VisualInstance3D::set_layer_mask_bit(int p_layer, bool p_enable) {
 	ERR_FAIL_INDEX(p_layer, 32);
 	if (p_enable) {
-		set_layer_mask(layers | (1 << p_layer));
+		set_layer_mask(layers | (1u << p_layer));
 	} else {
-		set_layer_mask(layers & (~(1 << p_layer)));
+		set_layer_mask(layers & (~(1u << p_layer)));
 	}
 }
 
 bool VisualInstance3D::get_layer_mask_bit(int p_layer) const {
 	ERR_FAIL_INDEX_V(p_layer, 32, false);
-	return (layers & (1 << p_layer));
+	return (layers & (1u << p_layer));
 }
 
 void VisualInstance3D::_bind_methods() {

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -550,9 +550,9 @@ void Environment::set_glow_level(int p_level, bool p_enabled) {
 	ERR_FAIL_INDEX(p_level, RS::MAX_GLOW_LEVELS);
 
 	if (p_enabled)
-		glow_levels |= (1 << p_level);
+		glow_levels |= (1u << p_level);
 	else
-		glow_levels &= ~(1 << p_level);
+		glow_levels &= ~(1u << p_level);
 
 	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
 }
@@ -560,7 +560,7 @@ bool Environment::is_glow_level_enabled(int p_level) const {
 
 	ERR_FAIL_INDEX_V(p_level, RS::MAX_GLOW_LEVELS, false);
 
-	return glow_levels & (1 << p_level);
+	return glow_levels & (1u << p_level);
 }
 
 void Environment::set_glow_intensity(float p_intensity) {

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -95,15 +95,15 @@ void NavigationMesh::set_collision_mask_bit(int p_bit, bool p_value) {
 
 	uint32_t mask = get_collision_mask();
 	if (p_value)
-		mask |= 1 << p_bit;
+		mask |= 1u << p_bit;
 	else
-		mask &= ~(1 << p_bit);
+		mask &= ~(1u << p_bit);
 	set_collision_mask(mask);
 }
 
 bool NavigationMesh::get_collision_mask_bit(int p_bit) const {
 
-	return get_collision_mask() & (1 << p_bit);
+	return get_collision_mask() & (1u << p_bit);
 }
 
 void NavigationMesh::set_source_geometry_mode(int p_geometry_mode) {

--- a/servers/rendering/rendering_server_scene.cpp
+++ b/servers/rendering/rendering_server_scene.cpp
@@ -996,7 +996,7 @@ void RenderingServerScene::_update_instance(Instance *p_instance) {
 
 	if (p_instance->octree_id == 0) {
 
-		uint32_t base_type = 1 << p_instance->base_type;
+		uint32_t base_type = 1u << p_instance->base_type;
 		uint32_t pairable_mask = 0;
 		bool pairable = false;
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -910,9 +910,9 @@ Error RenderingServer::mesh_create_surface_data_from_arrays(SurfaceData *r_surfa
 				Variant arr = p_arrays[0];
 				if (arr.get_type() == Variant::PACKED_VECTOR2_ARRAY) {
 					elem_size = 2;
-					p_compress_format |= ARRAY_FLAG_USE_2D_VERTICES;
+					p_compress_format |= (unsigned int)ARRAY_FLAG_USE_2D_VERTICES;
 				} else if (arr.get_type() == Variant::PACKED_VECTOR3_ARRAY) {
-					p_compress_format &= ~ARRAY_FLAG_USE_2D_VERTICES;
+					p_compress_format &= ~(unsigned int)ARRAY_FLAG_USE_2D_VERTICES;
 					elem_size = 3;
 				} else {
 					elem_size = (p_compress_format & ARRAY_FLAG_USE_2D_VERTICES) ? 2 : 3;


### PR DESCRIPTION
This commit silence messages from Ubsan Sanitizer like
```
core/command_queue_mt.h:431:42: runtime error: implicit conversion from type 'int' of value -2 (32-bit, signed) to type 'unsigned int' changed the value to 4294967294 (32-bit, unsigned)
```
and this fixes #33773

EDIT: This commit grows too much, so I created another one