### PR TITLE
Exit the editor export process with a non-zero exit code on error

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -133,6 +133,7 @@
 #include "editor/script_editor_debugger.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
 EditorNode *EditorNode::singleton = NULL;
 
@@ -535,11 +536,13 @@ void EditorNode::_fs_changed() {
 		if (preset.is_null()) {
 			String errstr = "Unknown export preset: " + export_defer.preset;
 			ERR_PRINTS(errstr);
+			OS::get_singleton()->set_exit_code(EXIT_FAILURE);
 		} else {
 			Ref<EditorExportPlatform> platform = preset->get_platform();
 			if (platform.is_null()) {
 				String errstr = "Preset \"" + export_defer.preset + "\" doesn't have a platform.";
 				ERR_PRINTS(errstr);
+				OS::get_singleton()->set_exit_code(EXIT_FAILURE);
 			} else {
 				// ensures export_project does not loop infinitely, because notifications may
 				// come during the export
@@ -556,6 +559,7 @@ void EditorNode::_fs_changed() {
 				}
 				if (err != OK) {
 					ERR_PRINTS(vformat(TTR("Project export failed with error code %d."), (int)err));
+					OS::get_singleton()->set_exit_code(EXIT_FAILURE);
 				}
 			}
 		}


### PR DESCRIPTION
This will make it easier to detect errors in continuous integration. ([`EXIT_FAILURE` is equal to `1`](https://stackoverflow.com/questions/13667364/exit-failure-vs-exit1).)

This closes #34672.