### PR TITLE
Add a shorthand for setting the exit code using `SceneTree::quit()`

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -906,6 +906,7 @@
 		</member>
 		<member name="exit_code" type="int" setter="set_exit_code" getter="get_exit_code" default="0">
 			The exit code passed to the OS when the main loop exits. By convention, an exit code of [code]0[/code] indicates success whereas a non-zero exit code indicates an error. For portability reasons, the exit code should be set between 0 and 125 (inclusive).
+			[b]Note:[/b] This value will be ignored if using [method SceneTree.quit] with an [code]exit_code[/code] argument passed.
 		</member>
 		<member name="keep_screen_on" type="bool" setter="set_keep_screen_on" getter="is_keep_screen_on" default="true">
 			If [code]true[/code], the engine tries to keep the screen on while the game is running. Useful on mobile.

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -185,8 +185,10 @@
 		<method name="quit">
 			<return type="void">
 			</return>
+			<argument index="0" name="exit_code" type="int" default="-1">
+			</argument>
 			<description>
-				Quits the application.
+				Quits the application. A process [code]exit_code[/code] can optionally be passed as an argument. If this argument is [code]0[/code] or greater, it will override the [member OS.exit_code] defined before quitting the application.
 			</description>
 		</method>
 		<method name="reload_current_scene">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -631,7 +631,13 @@ void SceneTree::finish() {
 	timers.clear();
 }
 
-void SceneTree::quit() {
+void SceneTree::quit(int p_exit_code) {
+
+	if (p_exit_code >= 0) {
+		// Override the exit code if a positive argument is given (the default is `-1`).
+		// This is a shorthand for calling `set_exit_code()` on the OS singleton then quitting.
+		OS::get_singleton()->set_exit_code(p_exit_code);
+	}
 
 	_quit = true;
 }
@@ -1812,8 +1818,6 @@ bool SceneTree::is_refusing_new_network_connections() const {
 
 void SceneTree::_bind_methods() {
 
-	//ClassDB::bind_method(D_METHOD("call_group","call_flags","group","method","arg1","arg2"),&SceneMainLoop::_call_group,DEFVAL(Variant()),DEFVAL(Variant()));
-
 	ClassDB::bind_method(D_METHOD("get_root"), &SceneTree::get_root);
 	ClassDB::bind_method(D_METHOD("has_group", "name"), &SceneTree::has_group);
 
@@ -1837,7 +1841,7 @@ void SceneTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_node_count"), &SceneTree::get_node_count);
 	ClassDB::bind_method(D_METHOD("get_frame"), &SceneTree::get_frame);
-	ClassDB::bind_method(D_METHOD("quit"), &SceneTree::quit);
+	ClassDB::bind_method(D_METHOD("quit", "exit_code"), &SceneTree::quit, DEFVAL(-1));
 
 	ClassDB::bind_method(D_METHOD("set_screen_stretch", "mode", "aspect", "minsize", "shrink"), &SceneTree::set_screen_stretch, DEFVAL(1));
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -303,7 +303,7 @@ public:
 	void set_auto_accept_quit(bool p_enable);
 	void set_quit_on_go_back(bool p_enable);
 
-	void quit();
+	void quit(int p_exit_code = -1);
 
 	void set_input_as_handled();
 	bool is_input_handled();


### PR DESCRIPTION
This reduces the amount of code required to exit a process with a non-zero exit code. This pattern is also found in most other programming languages (e.g. [Go](https://golang.org/pkg/os/#Exit)).

See also #34680.