### PR TITLE
Print a warning message if `OS.exit_code` is set to a non-portable value

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -686,6 +686,10 @@ int _OS::get_exit_code() const {
 
 void _OS::set_exit_code(int p_code) {
 
+	if (p_code < 0 || p_code > 125) {
+		WARN_PRINT("For portability reasons, the exit code should be set between 0 and 125 (inclusive).");
+	}
+
 	OS::get_singleton()->set_exit_code(p_code);
 }
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -905,7 +905,7 @@
 			The current screen index (starting from 0).
 		</member>
 		<member name="exit_code" type="int" setter="set_exit_code" getter="get_exit_code" default="0">
-			The exit code passed to the OS when the main loop exits.
+			The exit code passed to the OS when the main loop exits. By convention, an exit code of [code]0[/code] indicates success whereas a non-zero exit code indicates an error. For portability reasons, the exit code should be set between 0 and 125 (inclusive).
 		</member>
 		<member name="keep_screen_on" type="bool" setter="set_keep_screen_on" getter="is_keep_screen_on" default="true">
 			If [code]true[/code], the engine tries to keep the screen on while the game is running. Useful on mobile.


### PR DESCRIPTION
This also improves the related documentation. [More information about exit code semantics.](https://en.wikipedia.org/wiki/Exit_status#Semantics)