### PR TITLE
Checks script path before show in filesystem

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1267,12 +1267,15 @@ void ScriptEditor::_menu_option(int p_option) {
 				_copy_script_path();
 			} break;
 			case SHOW_IN_FILE_SYSTEM: {
-				RES script = current->get_edited_resource();
-				FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
-				file_system_dock->navigate_to_path(script->get_path());
-				// Ensure that the FileSystem dock is visible.
-				TabContainer *tab_container = (TabContainer *)file_system_dock->get_parent_control();
-				tab_container->set_current_tab(file_system_dock->get_position_in_parent());
+				const RES script = current->get_edited_resource();
+				const String path = script->get_path();
+				if (!path.empty()) {
+					FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
+					file_system_dock->navigate_to_path(path);
+					// Ensure that the FileSystem dock is visible.
+					TabContainer *tab_container = (TabContainer *)file_system_dock->get_parent_control();
+					tab_container->set_current_tab(file_system_dock->get_position_in_parent());
+				}
 			} break;
 			case CLOSE_DOCS: {
 				_close_docs_tab();


### PR DESCRIPTION
* Makes "Show in Filesystem" do nothing for in-memory script files

Before this fix, "Show in Filesystem" for in-memory script file will navigate the FileSystem dock to the path `/`. (To reproduce, you can open an in-memory script file by clicking the New Resource button in the Inspector and choose GDScript.)

This matches the behavior of choosing "Show in Filesystem" on the right click menu of  an empty scene's tab.