### PR TITLE
Custom property for Godot generated project

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -2,6 +2,7 @@ using GodotTools.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using Microsoft.Build.Construction;
 
 namespace GodotTools.ProjectEditor
@@ -155,6 +156,7 @@ namespace GodotTools.ProjectEditor
             mainGroup.AddProperty("RootNamespace", IdentifierUtils.SanitizeQualifiedIdentifier(name, allowEmptyIdentifiers: true));
             mainGroup.AddProperty("AssemblyName", name);
             mainGroup.AddProperty("TargetFrameworkVersion", "v4.5");
+            mainGroup.AddProperty("GodotProjectGeneratorVersion", Assembly.GetExecutingAssembly().GetName().Version.ToString());
 
             var debugGroup = root.AddPropertyGroup();
             debugGroup.Condition = " '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ";


### PR DESCRIPTION
custom property in csproj `GodotProjectGeneratorVersion` allows an IDE to relatively easy identify that project was generated by Godot.