### PR TITLE
Document how to distinguish emulated mouse events from physical ones

### DIFF
--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -111,6 +111,7 @@
 	<members>
 		<member name="device" type="int" setter="set_device" getter="get_device" default="0">
 			The event's device ID.
+			[b]Note:[/b] This device ID will always be [code]-1[/code] for emulated mouse input from a touchscreen. This can be used to distinguish emulated mouse input from physical mouse input.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Mouse events emulated from a touchscreen will always have a device ID of -1.

Kudos to @ndarilek for finding this out :slightly_smiling_face: