### PR TITLE
Don't automatically trim trailing whitespace on the current line

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -918,15 +918,23 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_auto_brace_completion(EditorSettings::get_singleton()->get("text_editor/completion/auto_brace_complete"));
 }
 
-void CodeTextEditor::trim_trailing_whitespace() {
-	bool trimed_whitespace = false;
+void CodeTextEditor::trim_trailing_whitespace(bool p_exclude_current_line) {
+	bool trimmed_whitespace = false;
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
-		String line = text_editor->get_line(i);
+		// If enabled, ignore the line the cursor is currently on.
+		// This prevents the cursor from moving when saving a file if it's on an empty line with trailing whitespace.
+		// Methods that trim trailing whitespace automatically on save should always enable this.
+		if (p_exclude_current_line && i == text_editor->cursor_get_line()) {
+			continue;
+		}
+
+		const String line = text_editor->get_line(i);
+
 		if (line.ends_with(" ") || line.ends_with("\t")) {
 
-			if (!trimed_whitespace) {
+			if (!trimmed_whitespace) {
 				text_editor->begin_complex_operation();
-				trimed_whitespace = true;
+				trimmed_whitespace = true;
 			}
 
 			int end = 0;
@@ -940,7 +948,7 @@ void CodeTextEditor::trim_trailing_whitespace() {
 		}
 	}
 
-	if (trimed_whitespace) {
+	if (trimmed_whitespace) {
 		text_editor->end_complex_operation();
 		text_editor->update();
 	}

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -204,7 +204,7 @@ protected:
 	bool is_warnings_panel_opened;
 
 public:
-	void trim_trailing_whitespace();
+	void trim_trailing_whitespace(bool p_exclude_current_line = false);
 	void insert_final_newline();
 
 	void convert_indent_to_spaces();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -463,7 +463,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/script_list/show_members_overview", true);
 
 	// Files
-	_initial_set("text_editor/files/trim_trailing_whitespace_on_save", false);
+	_initial_set("text_editor/files/trim_trailing_whitespace_on_save", true);
 	_initial_set("text_editor/files/autosave_interval_secs", 0);
 	_initial_set("text_editor/files/restore_scripts_on_load", true);
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -732,7 +732,7 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 			continue; //internal script, who cares
 
 		if (trim_trailing_whitespace_on_save) {
-			se->trim_trailing_whitespace();
+			se->trim_trailing_whitespace(true);
 		}
 
 		se->insert_final_newline();
@@ -1158,7 +1158,7 @@ void ScriptEditor::_menu_option(int p_option) {
 					return;
 
 				if (trim_trailing_whitespace_on_save)
-					current->trim_trailing_whitespace();
+					current->trim_trailing_whitespace(true);
 
 				current->insert_final_newline();
 
@@ -1182,7 +1182,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			case FILE_SAVE_AS: {
 
 				if (trim_trailing_whitespace_on_save)
-					current->trim_trailing_whitespace();
+					current->trim_trailing_whitespace(true);
 
 				current->insert_final_newline();
 
@@ -2222,7 +2222,7 @@ void ScriptEditor::save_all_scripts() {
 		}
 
 		if (trim_trailing_whitespace_on_save) {
-			se->trim_trailing_whitespace();
+			se->trim_trailing_whitespace(true);
 		}
 
 		se->insert_final_newline();

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -99,7 +99,7 @@ public:
 	virtual void goto_line(int p_line, bool p_with_error = false) = 0;
 	virtual void set_executing_line(int p_line) = 0;
 	virtual void clear_executing_line() = 0;
-	virtual void trim_trailing_whitespace() = 0;
+	virtual void trim_trailing_whitespace(bool p_exclude_current_line = false) = 0;
 	virtual void insert_final_newline() = 0;
 	virtual void convert_indent_to_spaces() = 0;
 	virtual void convert_indent_to_tabs() = 0;
@@ -326,8 +326,6 @@ class ScriptEditor : public PanelContainer {
 	bool trim_trailing_whitespace_on_save;
 	bool use_space_indentation;
 	bool convert_indent_on_save;
-
-	void _trim_trailing_whitespace(TextEdit *tx);
 
 	void _goto_script_line2(int p_line);
 	void _goto_script_line(REF p_script, int p_line);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -478,9 +478,9 @@ void ScriptTextEditor::_convert_case(CodeTextEditor::CaseStyle p_case) {
 	code_editor->convert_case(p_case);
 }
 
-void ScriptTextEditor::trim_trailing_whitespace() {
+void ScriptTextEditor::trim_trailing_whitespace(bool p_exclude_current_line) {
 
-	code_editor->trim_trailing_whitespace();
+	code_editor->trim_trailing_whitespace(p_exclude_current_line);
 }
 
 void ScriptTextEditor::insert_final_newline() {

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -204,7 +204,7 @@ public:
 	virtual Variant get_edit_state();
 	virtual void set_edit_state(const Variant &p_state);
 	virtual void ensure_focus();
-	virtual void trim_trailing_whitespace();
+	virtual void trim_trailing_whitespace(bool p_exclude_current_line = false);
 	virtual void insert_final_newline();
 	virtual void convert_indent_to_spaces();
 	virtual void convert_indent_to_tabs();

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -284,9 +284,9 @@ void TextEditor::set_edit_state(const Variant &p_state) {
 	}
 }
 
-void TextEditor::trim_trailing_whitespace() {
+void TextEditor::trim_trailing_whitespace(bool p_exclude_current_line) {
 
-	code_editor->trim_trailing_whitespace();
+	code_editor->trim_trailing_whitespace(p_exclude_current_line);
 }
 
 void TextEditor::insert_final_newline() {

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -135,7 +135,7 @@ public:
 	void goto_line_selection(int p_line, int p_begin, int p_end);
 	virtual void set_executing_line(int p_line);
 	virtual void clear_executing_line();
-	virtual void trim_trailing_whitespace();
+	virtual void trim_trailing_whitespace(bool p_exclude_current_line = false);
 	virtual void insert_final_newline();
 	virtual void convert_indent_to_spaces();
 	virtual void convert_indent_to_tabs();

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2542,7 +2542,7 @@ void VisualScriptEditor::clear_executing_line() {
 	// todo: add a way to show which node is executing right now.
 }
 
-void VisualScriptEditor::trim_trailing_whitespace() {
+void VisualScriptEditor::trim_trailing_whitespace(bool p_exclude_current_line) {
 }
 
 void VisualScriptEditor::insert_final_newline() {

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -305,7 +305,7 @@ public:
 	virtual void goto_line(int p_line, bool p_with_error = false);
 	virtual void set_executing_line(int p_line);
 	virtual void clear_executing_line();
-	virtual void trim_trailing_whitespace();
+	virtual void trim_trailing_whitespace(bool p_exclude_current_line = false);
 	virtual void insert_final_newline();
 	virtual void convert_indent_to_spaces();
 	virtual void convert_indent_to_tabs();


### PR DESCRIPTION
This prevents the cursor from moving unexpectedly when saving a file.

"Trim Trailing Whitespace On Save" is now enabled by default, as this change makes it much more convenient to use.

Manual whitespace trimming operations (such as using the menu option) will still trim trailing whitespace on the current line.