### PR TITLE
Fix wrong project opening in some situations

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1409,9 +1409,7 @@ void ProjectList::sort_projects() {
 
 	for (int i = 0; i < _projects.size(); ++i) {
 		Item &item = _projects.write[i];
-		if (item.control->is_visible()) {
-			item.control->get_parent()->move_child(item.control, i);
-		}
+		item.control->get_parent()->move_child(item.control, i);
 	}
 
 	// Rewind the coroutine because order of projects changed


### PR DESCRIPTION
Hidden nodes were not reordered, causing the indices of visible nodes to not always match the array of project items in some situations.

Fixes https://github.com/godotengine/godot/issues/34645

So far I could not find a repro to test this with my local projects, @aaronfranke can you check if it fixes yours?