### PR TITLE
Don't handle Gridmap input when have no effect

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -664,14 +664,15 @@ bool GridMapEditor::forward_spatial_input_event(Camera *p_camera, const Ref<Inpu
 				input_action = INPUT_NONE;
 			} else if (mb->get_button_index() == BUTTON_LEFT) {
 
+				bool can_edit = (node && node->get_mesh_library().is_valid());
 				if (input_action == INPUT_PASTE) {
 					_do_paste();
 					input_action = INPUT_NONE;
 					_update_paste_indicator();
-				} else if (mb->get_shift()) {
+				} else if (mb->get_shift() && can_edit) {
 					input_action = INPUT_SELECT;
 					last_selection = selection;
-				} else if (mb->get_command()) {
+				} else if (mb->get_command() && can_edit) {
 					input_action = INPUT_PICK;
 				} else {
 					input_action = INPUT_PAINT;


### PR DESCRIPTION
Resolves #19861 which was caused by GridMap hijacking an input event, even though it had no effect. Not sure about the shift part or if the `can_edit` shouldn't be used in more cases.