### PR TITLE
Fix argument type in set_follow_focus()

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -514,7 +514,7 @@ bool ScrollContainer::is_following_focus() const {
 	return follow_focus;
 }
 
-void ScrollContainer::set_follow_focus(int p_follow) {
+void ScrollContainer::set_follow_focus(bool p_follow) {
 	follow_focus = p_follow;
 }
 

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -95,7 +95,7 @@ public:
 	void set_deadzone(int p_deadzone);
 
 	bool is_following_focus() const;
-	void set_follow_focus(int p_follow);
+	void set_follow_focus(bool p_follow);
 
 	HScrollBar *get_h_scrollbar();
 	VScrollBar *get_v_scrollbar();


### PR DESCRIPTION
Somehow I used wrong argument type in this method and the compiler nor Travis didn't complain.
Resolves https://github.com/godotengine/godot/pull/34572#discussion_r362112911