### PR TITLE
Fixes Groups Editor batch add/remove nodes

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -121,7 +121,7 @@ bool GroupDialog::_can_edit(Node *p_node, String p_group) {
 }
 
 void GroupDialog::_add_pressed() {
-	TreeItem *selected = nodes_to_add->get_selected();
+	TreeItem *selected = nodes_to_add->get_next_selected(NULL);
 
 	if (!selected) {
 		return;
@@ -150,7 +150,7 @@ void GroupDialog::_add_pressed() {
 }
 
 void GroupDialog::_removed_pressed() {
-	TreeItem *selected = nodes_to_remove->get_selected();
+	TreeItem *selected = nodes_to_remove->get_next_selected(NULL);
 
 	if (!selected) {
 		return;


### PR DESCRIPTION
* Uses `get_next_selected(NULL)` to get first selected item

Before this fix, batch add/remove will only affect the first selected item if you select nodes from bottom to top:

![demo](https://user-images.githubusercontent.com/372476/71608295-23ef8580-2bbb-11ea-9952-e3bb6ab9b37a.gif)
