### PR TITLE
Fixes behavior of right arrow key in Tree

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2162,9 +2162,8 @@ void Tree::_go_right() {
 		if (selected_item->get_children() != NULL && selected_item->is_collapsed()) {
 			selected_item->set_collapsed(false);
 		} else if (selected_item->get_next_visible()) {
-			selected_item->select(0);
+			selected_col = 0;
 			_go_down();
-			return;
 		}
 	} else {
 		if (select_mode == SELECT_MULTI) {


### PR DESCRIPTION
* When wrapping the cursor, matches right arrow behavior with left arrow:
    https://github.com/godotengine/godot/blob/7fddf5eb7c6b6e58f891aaaa5b396f2b0cf616f8/scene/gui/tree.cpp#L2141-L2144

Before this fix, in a multi-select mode `Tree`, the first column of current row will be automatically selected when pressing right arrow at the last column of a row.

![demo](https://user-images.githubusercontent.com/372476/71640276-1113a880-2cc2-11ea-8548-1624b8191681.gif)
Only pressing left and right arrow in the above GIF.