### PR TITLE
Fix wrong return type in canvas.glsl

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -419,7 +419,7 @@ float map_ninepatch_axis(float pixel, float draw_size, float tex_pixel_size, flo
 			// Scale to source texture.
 			return (margin_begin + ratio * dst_area) * tex_pixel_size;
 		} else { // Shouldn't happen, but silences compiler warning.
-			return 0;
+			return 0.0;
 		}
 	}
 }


### PR DESCRIPTION
``ERROR: _display_error_with_code: CanvasShaderGLES3: Fragment Program Compilation Failed:
0:166(2): error: `return' with wrong type int, in function `map_ninepatch_axis' returning float
``
caused by e4907e50feab1af05f514a66adc0086d1c141885

and 6546735f23b8b6bd7e2a7679168edc9d9fb9ae51