### PR TITLE
Ensures cursor visible for Tree with title

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3462,8 +3462,13 @@ void Tree::ensure_cursor_is_visible() {
 	int ofs = get_item_offset(selected);
 	if (ofs == -1)
 		return;
+
+	const int tbh = _get_title_button_height();
+	ofs -= tbh;
+
+	const int marginh = cache.bg->get_margin(MARGIN_TOP) + cache.bg->get_margin(MARGIN_BOTTOM);
 	int h = compute_item_height(selected) + cache.vseparation;
-	int screenh = get_size().height - h_scroll->get_combined_minimum_size().height;
+	int screenh = get_size().height - h_scroll->get_combined_minimum_size().height - marginh - tbh;
 
 	if (h > screenh) { //screen size is too small, maybe it was not resized yet.
 		v_scroll->set_value(ofs);


### PR DESCRIPTION
* Takes title height and  top/bottom margins into account when calculating desired scroll offset

Before this fix, there are two issues when scrolling a `Tree` by moving the cursor with arrow keys:
1. With or without title: scrolling to the last item still leaves a little gap in the scroll bar
    * Because top/bottom margins are not taken into account
2. With title: when scrolling up, the first item will be hidden by the column title
    * Because the title height is not taken into account

In this GIF, I'm pressing up and down arrows until it reaches the end:
![demo](https://user-images.githubusercontent.com/372476/71642518-88a7fe80-2ce7-11ea-9972-7d81502fe01e.gif)

The sample project used in the GIF: [TreeHScroll.zip](https://github.com/godotengine/godot/files/4014159/TreeHScroll.zip)
