### PR TITLE
[DOCS] Class reference typos and fixes.

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -204,7 +204,7 @@
 	</methods>
 	<members>
 		<member name="filter_enabled" type="bool" setter="set_filter_enabled" getter="is_filter_enabled">
-			Returns whether filtering is enabled.
+			If [code]true[/code], filtering is enabled.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/DynamicFontData.xml
+++ b/doc/classes/DynamicFontData.xml
@@ -12,13 +12,13 @@
 	</methods>
 	<members>
 		<member name="antialiased" type="bool" setter="set_antialiased" getter="is_antialiased" default="true">
-			Controls whether the font should be rendered with anti-aliasing.
+			If [code]true[/code], the font is rendered with anti-aliasing.
 		</member>
 		<member name="font_path" type="String" setter="set_font_path" getter="get_font_path" default="&quot;&quot;">
 			The path to the vector font file.
 		</member>
 		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="DynamicFontData.Hinting" default="2">
-			The font hinting mode used by FreeType.
+			The font hinting mode used by FreeType. See [enum Hinting] for options.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -334,7 +334,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns whether the popup will be hidden when the window loses focus or not.
+				Returns [code]true[/code] if the popup will be hidden when the window loses focus or not.
 			</description>
 		</method>
 		<method name="is_item_checkable" qualifiers="const">
@@ -391,7 +391,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns whether the shortcut of the specified item [code]idx[/code] is disabled or not.
+				Returns [code]true[/code] if the specified item's shortcut is disabled.
 			</description>
 		</method>
 		<method name="remove_item">
@@ -477,7 +477,7 @@
 			<argument index="1" name="disabled" type="bool">
 			</argument>
 			<description>
-				Sets whether the item at index [code]idx[/code] is disabled or not. When it is disabled, it can't be selected and its action can't be invoked.
+				Enables/disables the item at index [code]idx[/code]. When it is disabled, it can't be selected and its action can't be invoked.
 			</description>
 		</method>
 		<method name="set_item_icon">

--- a/doc/classes/SphereMesh.xml
+++ b/doc/classes/SphereMesh.xml
@@ -15,7 +15,7 @@
 			Full height of the sphere.
 		</member>
 		<member name="is_hemisphere" type="bool" setter="set_is_hemisphere" getter="get_is_hemisphere" default="false">
-			Determines whether a full sphere or a hemisphere is created.
+			If [code]true[/code], a hemisphere is created rather than a full sphere.
 			[b]Note:[/b] To get a regular hemisphere, the height and radius of the sphere must be equal.
 		</member>
 		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="64">

--- a/doc/classes/SplitContainer.xml
+++ b/doc/classes/SplitContainer.xml
@@ -20,7 +20,7 @@
 		<member name="collapsed" type="bool" setter="set_collapsed" getter="is_collapsed" default="false">
 		</member>
 		<member name="dragger_visibility" type="int" setter="set_dragger_visibility" getter="get_dragger_visibility" enum="SplitContainer.DraggerVisibility" default="0">
-			Determines whether the dragger is visible.
+			Determines the dragger's visibility. See [enum DraggerVisibility] for options.
 		</member>
 		<member name="split_offset" type="int" setter="set_split_offset" getter="get_split_offset" default="0">
 		</member>

--- a/doc/classes/TextureProgress.xml
+++ b/doc/classes/TextureProgress.xml
@@ -86,7 +86,7 @@
 			The [member texture_progress] fills from right to left.
 		</constant>
 		<constant name="FILL_TOP_TO_BOTTOM" value="2" enum="FillMode">
-			The [member texture_progress] fills from top to bototm.
+			The [member texture_progress] fills from top to bottom.
 		</constant>
 		<constant name="FILL_BOTTOM_TO_TOP" value="3" enum="FillMode">
 			The [member texture_progress] fills from bottom to top.

--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -49,7 +49,7 @@
 		</member>
 		<member name="time_left" type="float" setter="" getter="get_time_left">
 			The timer's remaining time in seconds. Returns 0 if the timer is inactive.
-			[b]Note:[/b] You cannot set this value. To change the timer's remaining time, use [member wait_time].
+			[b]Note:[/b] You cannot set this value. To change the timer's remaining time, use [method start].
 		</member>
 		<member name="wait_time" type="float" setter="set_wait_time" getter="get_wait_time" default="1.0">
 			Wait time in seconds.


### PR DESCRIPTION
Fixed description wording on several member variables.

Also corrected a reference in Timer - setting `wait_time` isn't a valid solution when you wish to set `time_left`.