### PR TITLE
Fixes Tree item offset when root is hidden

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3426,7 +3426,10 @@ int Tree::get_item_offset(TreeItem *p_item) const {
 		if (it == p_item)
 			return ofs;
 
-		ofs += compute_item_height(it) + cache.vseparation;
+		ofs += compute_item_height(it);
+		if (it != root || !hide_root) {
+			ofs += cache.vseparation;
+		}
 
 		if (it->children && !it->collapsed) {
 


### PR DESCRIPTION
* Don't count vseparation for a hidden root item

Before this fix, in a Tree with hidden root, the rect returned by `get_item_area_rect` is y offset by one vseparation.