### PR TITLE
Allows to doc vararg method return type as void

### DIFF
--- a/core/class_db.h
+++ b/core/class_db.h
@@ -294,11 +294,11 @@ public:
 	}
 
 	template <class M>
-	static MethodBind *bind_vararg_method(uint32_t p_flags, StringName p_name, M p_method, const MethodInfo &p_info = MethodInfo(), const Vector<Variant> &p_default_args = Vector<Variant>()) {
+	static MethodBind *bind_vararg_method(uint32_t p_flags, StringName p_name, M p_method, const MethodInfo &p_info = MethodInfo(), const Vector<Variant> &p_default_args = Vector<Variant>(), bool p_return_nil_is_variant = true) {
 
 		GLOBAL_LOCK_FUNCTION;
 
-		MethodBind *bind = create_vararg_method_bind(p_method, p_info);
+		MethodBind *bind = create_vararg_method_bind(p_method, p_info, p_return_nil_is_variant);
 		ERR_FAIL_COND_V(!bind, NULL);
 
 		bind->set_name(p_name);

--- a/core/method_bind.h
+++ b/core/method_bind.h
@@ -344,7 +344,7 @@ public:
 		return (instance->*call_method)(p_args, p_arg_count, r_error);
 	}
 
-	void set_method_info(const MethodInfo &p_info) {
+	void set_method_info(const MethodInfo &p_info, bool p_return_nil_is_variant) {
 
 		set_argument_count(p_info.arguments.size());
 #ifdef DEBUG_METHODS_ENABLED
@@ -364,7 +364,9 @@ public:
 		}
 		argument_types = at;
 		arguments = p_info;
-		arguments.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+		if (p_return_nil_is_variant) {
+			arguments.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+		}
 #endif
 	}
 
@@ -387,11 +389,11 @@ public:
 };
 
 template <class T>
-MethodBind *create_vararg_method_bind(Variant (T::*p_method)(const Variant **, int, Variant::CallError &), const MethodInfo &p_info) {
+MethodBind *create_vararg_method_bind(Variant (T::*p_method)(const Variant **, int, Variant::CallError &), const MethodInfo &p_info, bool p_return_nil_is_variant) {
 
 	MethodBindVarArg<T> *a = memnew((MethodBindVarArg<T>));
 	a->set_method(p_method);
-	a->set_method_info(p_info);
+	a->set_method_info(p_info, p_return_nil_is_variant);
 	return a;
 }
 

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1686,7 +1686,7 @@ void Object::_bind_methods() {
 		mi.name = "emit_signal";
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "signal"));
 
-		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "emit_signal", &Object::_emit_signal, mi);
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "emit_signal", &Object::_emit_signal, mi, varray(), false);
 	}
 
 	{
@@ -1702,7 +1702,7 @@ void Object::_bind_methods() {
 		mi.name = "call_deferred";
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "method"));
 
-		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_deferred", &Object::_call_deferred_bind, mi);
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_deferred", &Object::_call_deferred_bind, mi, varray(), false);
 	}
 
 	ClassDB::bind_method(D_METHOD("set_deferred", "property", "value"), &Object::set_deferred);

--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -520,7 +520,7 @@ void UndoRedo::_bind_methods() {
 		mi.arguments.push_back(PropertyInfo(Variant::OBJECT, "object"));
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "method"));
 
-		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "add_do_method", &UndoRedo::_add_do_method, mi);
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "add_do_method", &UndoRedo::_add_do_method, mi, varray(), false);
 	}
 
 	{
@@ -529,7 +529,7 @@ void UndoRedo::_bind_methods() {
 		mi.arguments.push_back(PropertyInfo(Variant::OBJECT, "object"));
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "method"));
 
-		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "add_undo_method", &UndoRedo::_add_undo_method, mi);
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "add_undo_method", &UndoRedo::_add_undo_method, mi, varray(), false);
 	}
 
 	ClassDB::bind_method(D_METHOD("add_do_property", "object", "property", "value"), &UndoRedo::add_do_property);

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -99,12 +99,12 @@
 			</description>
 		</method>
 		<method name="call_deferred" qualifiers="vararg">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<argument index="0" name="method" type="String">
 			</argument>
 			<description>
-				Calls the [code]method[/code] on the object during idle time and returns the result. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
+				Calls the [code]method[/code] on the object during idle time. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
 				[codeblock]
 				call_deferred("set", "position", Vector2(42.0, 0.0))
 				[/codeblock]
@@ -178,7 +178,7 @@
 			</description>
 		</method>
 		<method name="emit_signal" qualifiers="vararg">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<argument index="0" name="signal" type="String">
 			</argument>

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -32,7 +32,7 @@
 	</tutorials>
 	<methods>
 		<method name="add_do_method" qualifiers="vararg">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<argument index="0" name="object" type="Object">
 			</argument>
@@ -65,7 +65,7 @@
 			</description>
 		</method>
 		<method name="add_undo_method" qualifiers="vararg">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<argument index="0" name="object" type="Object">
 			</argument>


### PR DESCRIPTION
This fixes #34743 

Parameter `p_return_nil_is_variant` is added to `bind_vararg_method` to opt-out the `PROPERTY_USAGE_NIL_IS_VARIANT` flag.

Before this fix, `MethodBindVarArg` always set `PROPERTY_USAGE_NIL_IS_VARIANT` for the return type.
https://github.com/godotengine/godot/blob/1788b22b118db02ed57487c62157f83ab73b4165/core/method_bind.h#L365-L367

---
Update: renamed `p_return_nil_as_variant` to `p_return_nil_is_variant`, to be consistent with the flag name.