### PR TITLE
Mono/C#: Fix GD.PrintErr now showing in the Output panel

### DIFF
--- a/modules/mono/glue/gd_glue.cpp
+++ b/modules/mono/glue/gd_glue.cpp
@@ -83,7 +83,7 @@ void godot_icall_GD_printerr(MonoArray *p_what) {
 	String str;
 	for (int i = 0; i < what.size(); i++)
 		str += what[i].operator String();
-	OS::get_singleton()->printerr("%s\n", str.utf8().get_data());
+	print_error(str);
 }
 
 void godot_icall_GD_printraw(MonoArray *p_what) {


### PR DESCRIPTION
Fixes #34744
