### PR TITLE
Enable the script editor line length guideline by default

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -456,7 +456,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/appearance/show_info_gutter", true);
 	_initial_set("text_editor/appearance/code_folding", true);
 	_initial_set("text_editor/appearance/word_wrap", false);
-	_initial_set("text_editor/appearance/show_line_length_guideline", false);
+	_initial_set("text_editor/appearance/show_line_length_guideline", true);
 	_initial_set("text_editor/appearance/line_length_guideline_column", 80);
 	hints["text_editor/appearance/line_length_guideline_column"] = PropertyInfo(Variant::INT, "text_editor/appearance/line_length_guideline_column", PROPERTY_HINT_RANGE, "20, 160, 1");
 


### PR DESCRIPTION
[Now that the GDScript style guide has an official recommendation](https://github.com/godotengine/godot-docs/pull/2994), it makes sense to enable the line length guideline by default.