### PR TITLE
Clears initial button mask before activating menu item

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -309,6 +309,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 
 					bool was_during_grabbed_click = during_grabbed_click;
 					during_grabbed_click = false;
+					initial_button_mask = 0;
 
 					int over = _get_mouse_over(b->get_position());
 


### PR DESCRIPTION
This fixes #29521 (and probably #33572)

Syncs `during_grabbed_click` and `initial_button_mask` to prevent the potential double popup issue.

---

I think this is why the editor freezed (with dimming still on) after dismissing a dialog:

When left mouse button is released, there is a `drop_mouse_focus` call in `Viewport::_gui_show_modal`
https://github.com/godotengine/godot/blob/71d372a8ab1ee972326f8bd333f510330b7b7204/scene/main/viewport.cpp#L2703-L2706

which will send a mouse button release event for each mouse button that is still pressed.
https://github.com/godotengine/godot/blob/71d372a8ab1ee972326f8bd333f510330b7b7204/scene/main/viewport.cpp#L2656-L2667

The `PopupMenu` allows activating item by releasing any button that was down when the popup appeared
https://github.com/godotengine/godot/blob/71d372a8ab1ee972326f8bd333f510330b7b7204/scene/gui/popup_menu.cpp#L307-L308

so if the RMB is down at popup, a LMB click will activate the item twice, pushing the same popup dialog instance to the modal stack twice.

The double popup check in `Control::show_modal` failed because the second popup happens inside `get_viewport()->_gui_show_modal(this)`, just before assigning `data.MI`.
https://github.com/godotengine/godot/blob/71d372a8ab1ee972326f8bd333f510330b7b7204/scene/gui/control.cpp#L2207-L2211

During dialog dismiss, `Control::_modal_stack_remove` will fail if the current frame has a null `data.MI`
https://github.com/godotengine/godot/blob/71d372a8ab1ee972326f8bd333f510330b7b7204/scene/gui/control.cpp#L2223-L2227

So dismissing the first layer nulls its `data.MI`, and dismissing the second layer always fails, leaving an unremovable entry in the modal stack. And the while loop continues infinitely:

https://github.com/godotengine/godot/blob/71d372a8ab1ee972326f8bd333f510330b7b7204/scene/main/viewport.cpp#L1841