### PR TITLE
Fixes cursor position in multi-select mode Tree

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3176,6 +3176,7 @@ void Tree::item_selected(int p_column, TreeItem *p_item) {
 		p_item->cells.write[p_column].selected = true;
 		//emit_signal("multi_selected",p_item,p_column,true); - NO this is for TreeItem::select
 
+		selected_item = p_item;
 		selected_col = p_column;
 	} else {
 
@@ -3188,6 +3189,9 @@ void Tree::item_deselected(int p_column, TreeItem *p_item) {
 
 	if (select_mode == SELECT_MULTI || select_mode == SELECT_SINGLE) {
 		p_item->cells.write[p_column].selected = false;
+
+		selected_item = p_item;
+		selected_col = p_column;
 	}
 	update();
 }


### PR DESCRIPTION
Before this fix, CTRL-click a cell in a multi-select mode Tree:

* When adding to the selection, the cursor only moves in the same row
* When removing from the selection, the cursor does not move

In both cases, the common behavior is to move the cursor to the clicked cell.

![demo](https://user-images.githubusercontent.com/372476/71707303-26084d00-2e24-11ea-8ad9-d1df51835e84.gif)
