### PR TITLE
Fallback to RGBA4444 for textures with alpha set to ETC compression

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2432,19 +2432,19 @@ Color Image::get_pixel(int p_x, int p_y) const {
 		}
 		case FORMAT_RGBA4444: {
 			uint16_t u = ((uint16_t *)ptr)[ofs];
-			float r = (u & 0xF) / 15.0;
-			float g = ((u >> 4) & 0xF) / 15.0;
-			float b = ((u >> 8) & 0xF) / 15.0;
-			float a = ((u >> 12) & 0xF) / 15.0;
+			float r = ((u >> 12) & 0xF) / 15.0;
+			float g = ((u >> 8) & 0xF) / 15.0;
+			float b = ((u >> 4) & 0xF) / 15.0;
+			float a = (u & 0xF) / 15.0;
 			return Color(r, g, b, a);
 		}
 		case FORMAT_RGBA5551: {
 
 			uint16_t u = ((uint16_t *)ptr)[ofs];
-			float r = (u & 0x1F) / 15.0;
-			float g = ((u >> 5) & 0x1F) / 15.0;
-			float b = ((u >> 10) & 0x1F) / 15.0;
-			float a = ((u >> 15) & 0x1) / 1.0;
+			float r = ((u >> 11) & 0x1F) / 15.0;
+			float g = ((u >> 6) & 0x1F) / 15.0;
+			float b = ((u >> 1) & 0x1F) / 15.0;
+			float a = (u & 0x1) / 1.0;
 			return Color(r, g, b, a);
 		}
 		case FORMAT_RF: {
@@ -2558,10 +2558,10 @@ void Image::set_pixel(int p_x, int p_y, const Color &p_color) {
 
 			uint16_t rgba = 0;
 
-			rgba = uint16_t(CLAMP(p_color.r * 15.0, 0, 15));
-			rgba |= uint16_t(CLAMP(p_color.g * 15.0, 0, 15)) << 4;
-			rgba |= uint16_t(CLAMP(p_color.b * 15.0, 0, 15)) << 8;
-			rgba |= uint16_t(CLAMP(p_color.a * 15.0, 0, 15)) << 12;
+			rgba = uint16_t(CLAMP(p_color.r * 15.0, 0, 15)) << 12;
+			rgba |= uint16_t(CLAMP(p_color.g * 15.0, 0, 15)) << 8;
+			rgba |= uint16_t(CLAMP(p_color.b * 15.0, 0, 15)) << 4;
+			rgba |= uint16_t(CLAMP(p_color.a * 15.0, 0, 15));
 
 			((uint16_t *)ptr)[ofs] = rgba;
 
@@ -2570,10 +2570,10 @@ void Image::set_pixel(int p_x, int p_y, const Color &p_color) {
 
 			uint16_t rgba = 0;
 
-			rgba = uint16_t(CLAMP(p_color.r * 31.0, 0, 31));
-			rgba |= uint16_t(CLAMP(p_color.g * 31.0, 0, 31)) << 5;
-			rgba |= uint16_t(CLAMP(p_color.b * 31.0, 0, 31)) << 10;
-			rgba |= uint16_t(p_color.a > 0.5 ? 1 : 0) << 15;
+			rgba = uint16_t(CLAMP(p_color.r * 31.0, 0, 31)) << 11;
+			rgba |= uint16_t(CLAMP(p_color.g * 31.0, 0, 31)) << 6;
+			rgba |= uint16_t(CLAMP(p_color.b * 31.0, 0, 31)) << 1;
+			rgba |= uint16_t(p_color.a > 0.5 ? 1 : 0);
 
 			((uint16_t *)ptr)[ofs] = rgba;
 

--- a/modules/etc/image_etc.cpp
+++ b/modules/etc/image_etc.cpp
@@ -139,6 +139,13 @@ static void _compress_etc(Image *p_img, float p_lossy_quality, bool force_etc1_f
 		return;
 	}
 
+	if (img_format >= Image::FORMAT_RGBA8 && force_etc1_format) {
+		// If VRAM compression is using ETC, but image has alpha, convert to RGBA4444
+		// This saves space while maintaining the alpha channel
+		p_img->convert(Image::FORMAT_RGBA4444);
+		return;
+	}
+
 	uint32_t imgw = p_img->get_width(), imgh = p_img->get_height();
 
 	Image::Format etc_format = force_etc1_format ? Image::FORMAT_ETC : _get_etc2_mode(detected_channels);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/33178

**The Primary Bugfix**
When creating the etc texture previously it would just ignore the alpha channel. Now, if an alpha channel is detected, it converts to ``RGBA4444`` and exits early. This cuts the size of the texture in half, maintains the alpha channel, but reduces precision dramatically. If users want full precision they should select "uncompressed". Reduz and I discussed this over IRC, this solution was selected as it respects the users choice of compression format while maintaining the alpha channel. Additionally, this change minimally impacts the codebase and so should be suitable to merge for 3.2.

**The Uncovered Bug**
In making this fix, I also noticed that ``Image::FORMAT_RGBA4444`` and  ``Image::FORMAT_RGBA5551`` were broken. The image below should be a solid gradient from white to clear however, it was appearing as a gradient from white to blue. 
![Screenshot (33)](https://user-images.githubusercontent.com/16521339/71708835-c02aaf80-2da8-11ea-8102-e9a08708be87.png)

**Fixing the Uncovered Bug**
This is because ``FORMAT_RGBA4444`` and ``FORMAT_RGBA5551`` were encoded backwards. The code appears to be from when Godot was open sourced and it appears it has been unused. The behaviour in master is to encode ``RGBA4444`` as ``AAAABBBBGGGGRRRR``, when instead it should be ``RRRRGGGGBBBBAAAA`` as we are instructing OpenGL to treat them as an RGBA color. A similar fix to ``RGBA5551`` was necessary, now both image formats can be used. 

**Note To Maintainers**
While the original bug fix has been discussed with reduz, the changes to image.cpp have not. As a result, his review is necessary before merging this PR.

This code is graciously donated by Gamblify.