### PR TITLE
Fixes button flashing when releasing mousebutton outside

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -171,9 +171,17 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		}
 	}
 
-	if (!p_event->is_pressed()) { // pressed state should be correct with button_up signal
+	if (!p_event->is_pressed()) {
+		Ref<InputEventMouseButton> mouse_button = p_event;
+		if (mouse_button.is_valid()) {
+			if (!has_point(mouse_button->get_position())) {
+				status.hovering = false;
+			}
+		}
+		// pressed state should be correct with button_up signal
 		emit_signal("button_up");
 		status.press_attempt = false;
+		status.pressing_inside = false;
 	}
 
 	update();


### PR DESCRIPTION
Fixes #33553

Buttons had status.hovering kept as true for two frames, after releasing mouse button outside of the button node. Because it takes a couple of frames for NOTIFICATION_MOUSE_EXIT to get sent after releasing mousebutton outside button.

Edit 3: Sorry, did a couple of edits to improve the commit. Squashed a commit too many. Think i fixed it now! 🤣 
