### PR TITLE
MultiplayerAPI: Fix disconnect errors when passing invalid peer

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -139,6 +139,9 @@ void MultiplayerAPI::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_pee
 
 	if (p_peer == network_peer) return; // Nothing to do
 
+	ERR_FAIL_COND_MSG(p_peer.is_valid() && p_peer->get_connection_status() == NetworkedMultiplayerPeer::CONNECTION_DISCONNECTED,
+			"Supplied NetworkedMultiplayerPeer must be connecting or connected.");
+
 	if (network_peer.is_valid()) {
 		network_peer->disconnect("peer_connected", this, "_add_peer");
 		network_peer->disconnect("peer_disconnected", this, "_del_peer");
@@ -149,8 +152,6 @@ void MultiplayerAPI::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_pee
 	}
 
 	network_peer = p_peer;
-
-	ERR_FAIL_COND_MSG(p_peer.is_valid() && p_peer->get_connection_status() == NetworkedMultiplayerPeer::CONNECTION_DISCONNECTED, "Supplied NetworkedNetworkPeer must be connecting or connected.");
 
 	if (network_peer.is_valid()) {
 		network_peer->connect("peer_connected", this, "_add_peer");


### PR DESCRIPTION
Fixes #34634.

As mentioned in the issue, when I tried this fix on the "minimal" reproduction project, my system froze. Not sure what to make of it as I don't see why this code change would trigger a freeze when the previous code didn't. Might just have been bad luck.