### PR TITLE
Allow _integrate_forces() function to be called when defined in C++

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -456,8 +456,8 @@ void RigidBody2D::_direct_state_changed(Object *p_state) {
 		sleeping = state->is_sleeping();
 		emit_signal(SceneStringNames::get_singleton()->sleeping_state_changed);
 	}
-	if (get_script_instance())
-		get_script_instance()->call("_integrate_forces", state);
+	if (has_method("_integrate_forces"))
+		call("_integrate_forces", state);
 	set_block_transform_notify(false); // want it back
 
 	if (contact_monitor) {

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -457,8 +457,8 @@ void RigidBody::_direct_state_changed(Object *p_state) {
 		sleeping = state->is_sleeping();
 		emit_signal(SceneStringNames::get_singleton()->sleeping_state_changed);
 	}
-	if (get_script_instance())
-		get_script_instance()->call("_integrate_forces", state);
+	if (has_method("_integrate_forces"))
+		call("_integrate_forces", state);
 	set_ignore_transform_notification(false);
 
 	if (contact_monitor) {


### PR DESCRIPTION
At the current moment in Godot, _integrate_forces() can only be called if it is defined in a script.
It should be allowed to define this function in C++, in order to be able to customize the physics of a RigidBody-derivated class in custom modules.