### PR TITLE
Document TabContainer's "use_hidden_tabs_for_min_size"

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -150,6 +150,7 @@
 			If [code]true[/code], tabs are visible. If [code]false[/code], tabs' content and titles are hidden.
 		</member>
 		<member name="use_hidden_tabs_for_min_size" type="bool" setter="set_use_hidden_tabs_for_min_size" getter="get_use_hidden_tabs_for_min_size" default="false">
+			If [code]true[/code], children [Control] nodes that are hidden have their minimum size take into account in the total, instead of only the currently visible one.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="float" category="Built-In Types" version="3.2">
 	<brief_description>
-		Float built-in type
+		Float built-in type.
 	</brief_description>
 	<description>
 		Float built-in type.


### PR DESCRIPTION
This completes `TabContainer`'s documentation.