### PR TITLE
Use the filmic tonemapper by default

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -241,10 +241,10 @@
 		<member name="tonemap_exposure" type="float" setter="set_tonemap_exposure" getter="get_tonemap_exposure" default="1.0">
 			The default exposure used for tonemapping.
 		</member>
-		<member name="tonemap_mode" type="int" setter="set_tonemapper" getter="get_tonemapper" enum="Environment.ToneMapper" default="0">
+		<member name="tonemap_mode" type="int" setter="set_tonemapper" getter="get_tonemapper" enum="Environment.ToneMapper" default="2">
 			The tonemapping mode to use. Tonemapping is the process that "converts" HDR values to be suitable for rendering on a LDR display. (Godot doesn't support rendering on HDR displays yet.)
 		</member>
-		<member name="tonemap_white" type="float" setter="set_tonemap_white" getter="get_tonemap_white" default="1.0">
+		<member name="tonemap_white" type="float" setter="set_tonemap_white" getter="get_tonemap_white" default="6.0">
 			The white reference value for tonemapping. Only effective if the [member tonemap_mode] isn't set to [constant TONE_MAPPER_LINEAR].
 		</member>
 	</members>

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1165,9 +1165,9 @@ Environment::Environment() :
 	set_ambient_light_sky_contribution(1.0);
 	set_camera_feed_id(1);
 
-	tone_mapper = TONE_MAPPER_LINEAR;
+	tone_mapper = TONE_MAPPER_FILMIC;
 	tonemap_exposure = 1.0;
-	tonemap_white = 1.0;
+	tonemap_white = 6.0;
 	tonemap_auto_exposure = false;
 	tonemap_auto_exposure_max = 8;
 	tonemap_auto_exposure_min = 0.05;


### PR DESCRIPTION
See discussion in https://github.com/godotengine/godot-proposals/issues/348 for rationale.

## Preview

### Before (linear)

![material_tester_linear](https://user-images.githubusercontent.com/180032/71755473-0ce6b700-2e8b-11ea-8e72-4131c6a30a95.png)

### After (filmic, whitepoint set to 6)

![material_tester_filmic](https://user-images.githubusercontent.com/180032/71755481-1839e280-2e8b-11ea-9d19-1b8602f477d6.png)

### Before (linear)

![sponza_linear](https://user-images.githubusercontent.com/180032/71755457-f0e31580-2e8a-11ea-96b5-fae58105f878.png)

### After (filmic, whitepoint set to 6)

![sponza_filmic](https://user-images.githubusercontent.com/180032/71755458-f2acd900-2e8a-11ea-9247-d3ba3c52f6fb.png)