### PR TITLE
Add a crosshair to the 3D viewport

### DIFF
--- a/editor/icons/icon_crosshair.svg
+++ b/editor/icons/icon_crosshair.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m6 1v5h-5v1 3h5v5h4v-5h5v-4h-5v-5z" fill-opacity=".627451"/><path d="m2 7v2l5.0000803.0000197-.0000803 4.9999803h2l-.0000803-4.9999803 5.0000803-.0000197v-2l-5.0000803.0001803.0000803-5.0001803h-2l.0000803 5.0001803z" fill="#fefefe" fill-opacity=".862745"/></svg>

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2135,6 +2135,13 @@ void SpatialEditorViewport::_notification(int p_what) {
 		call_deferred("update_transform_gizmo_view");
 	}
 
+	if (p_what == NOTIFICATION_READY) {
+		// The crosshair icon doesn't depend on the editor theme.
+		crosshair->set_texture(get_icon("Crosshair", "EditorIcons"));
+		// Set the anchors and margins after changing the icon to ensure it's centered correctly.
+		crosshair->set_anchors_and_margins_preset(PRESET_CENTER);
+	}
+
 	if (p_what == NOTIFICATION_PROCESS) {
 
 		real_t delta = get_process_delta_time();
@@ -2254,6 +2261,10 @@ void SpatialEditorViewport::_notification(int p_what) {
 		} else {
 			current_camera = camera;
 		}
+
+		// Display the crosshair only while freelooking. Hide it otherwise,
+		// as the crosshair can be distracting.
+		crosshair->set_visible(freelook_active);
 
 		if (show_info) {
 			String text;
@@ -3545,6 +3556,10 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	viewport->add_child(camera);
 	camera->make_current();
 	surface->set_focus_mode(FOCUS_ALL);
+
+	crosshair = memnew(TextureRect);
+	crosshair->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	surface->add_child(crosshair);
 
 	VBoxContainer *vbox = memnew(VBoxContainer);
 	surface->add_child(vbox);

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -217,6 +217,7 @@ private:
 	bool freelook_active;
 	real_t freelook_speed;
 
+	TextureRect *crosshair;
 	Label *info_label;
 	Label *fps_label;
 	Label *cinema_label;


### PR DESCRIPTION
The crosshair makes freelook navigation a bit easier, while making it clearer that it's possible to select nodes by clicking while in freelook mode.

The crosshair is only displayed while in freelook mode. It uses an icon designed to be visible on any background.

## Preview

![Crosshair on cube](https://user-images.githubusercontent.com/180032/71757873-8be2ec00-2e99-11ea-815f-e00bcb42f434.png)