### PR TITLE
Change the 2D editor's snap to 8x8 by default

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5250,7 +5250,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	view_offset = Point2(-150 - RULER_WIDTH, -95 - RULER_WIDTH);
 	previous_update_view_offset = view_offset; // Moves the view a little bit to the left so that (0,0) is visible. The values a relative to a 16/10 screen
 	grid_offset = Point2();
-	grid_step = Point2(10, 10);
+	grid_step = Point2(8, 8); // A power-of-two value works better as a default
 	primary_grid_steps = 8; // A power-of-two value works better as a default
 	grid_step_multiplier = 0;
 	snap_rotation_offset = 0;


### PR DESCRIPTION
10x10 doesn't really make sense for 2D when most textures/tiles/sprites/anything is generally going to be made as a power of two. While tilesets have a grid of their own it's common to insert other objects into a scene, and having to reset it back to 8x8 every time you open/switch to a scene is incredibly tedious.

Being able to set a global project grid snap setting in the project settings (and/or editor settings) (and/or stored in the scene) would be ideal but until someone bothers to deal with that this is a simple fix.