### PR TITLE
Store VERSION_PATCH in pack header if available

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -72,7 +72,12 @@ Error PCKPacker::pck_start(const String &p_file, int p_alignment) {
 	file->store_32(1); // # version
 	file->store_32(VERSION_MAJOR); // # major
 	file->store_32(VERSION_MINOR); // # minor
-	file->store_32(0); // # revision
+#ifdef VERSION_PATCH
+	f->store_32(VERSION_PATCH); // # revision
+#else
+	// Patch version is always 0 for initial minor release versions (e.g. 3.2 is considered to be 3.2.0).
+	f->store_32(0);
+#endif
 
 	for (int i = 0; i < 16; i++) {
 

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -73,10 +73,10 @@ Error PCKPacker::pck_start(const String &p_file, int p_alignment) {
 	file->store_32(VERSION_MAJOR); // # major
 	file->store_32(VERSION_MINOR); // # minor
 #ifdef VERSION_PATCH
-	f->store_32(VERSION_PATCH); // # revision
+	file->store_32(VERSION_PATCH); // # revision
 #else
 	// Patch version is always 0 for initial minor release versions (e.g. 3.2 is considered to be 3.2.0).
-	f->store_32(0);
+	file->store_32(0);
 #endif
 
 	for (int i = 0; i < 16; i++) {

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -974,7 +974,11 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 	f->store_32(1); //pack version
 	f->store_32(VERSION_MAJOR);
 	f->store_32(VERSION_MINOR);
+#ifdef VERSION_PATCH
+	f->store_32(VERSION_PATCH);
+#else
 	f->store_32(0); //hmph
+#endif
 	for (int i = 0; i < 16; i++) {
 		//reserved
 		f->store_32(0);

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -977,7 +977,8 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 #ifdef VERSION_PATCH
 	f->store_32(VERSION_PATCH);
 #else
-	f->store_32(0); //hmph
+	// Patch version is always 0 for initial minor release versions (e.g. 3.2 is considered to be 3.2.0).
+ 	f->store_32(0);
 #endif
 	for (int i = 0; i < 16; i++) {
 		//reserved

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -978,7 +978,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 	f->store_32(VERSION_PATCH);
 #else
 	// Patch version is always 0 for initial minor release versions (e.g. 3.2 is considered to be 3.2.0).
- 	f->store_32(0);
+	f->store_32(0);
 #endif
 	for (int i = 0; i < 16; i++) {
 		//reserved


### PR DESCRIPTION
# What
Store VERSION_PATCH in PCK header's version revision field instead of always storing a zero.

# Why
We are working on a [public tool](https://gotm.io/web-player) that needs to recognize a PCK-file's version (i.e. which version of Godot that was used to export it) by reading the PCK's header. 

However, the header has a 32-bit field reserved for version revision that is unused, which means that we can't discern a 3.1.0 PCK from a 3.1.1 PCK.

Currently we have to ask the user to specify the version of their PCK file. With this change, the user experience of the tool would improve.