### PR TITLE
Display compatible custom resources when editing a Resource property in the inspector

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -461,6 +461,7 @@ void EditorData::add_custom_type(const String &p_type, const String &p_inherits,
 	ERR_FAIL_COND_MSG(p_script.is_null(), "It's not a reference to a valid Script object.");
 	CustomType ct;
 	ct.name = p_type;
+	ct.base = p_inherits;
 	ct.icon = p_icon;
 	ct.script = p_script;
 	if (!custom_types.has(p_inherits)) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -104,6 +104,7 @@ class EditorData {
 public:
 	struct CustomType {
 		String name;
+		String base;
 		Ref<Script> script;
 		Ref<Texture2D> icon;
 	};

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -36,6 +36,7 @@
 #include "scene/gui/button.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/texture_rect.h"
+#include "editor_data.h"
 
 class EditorResourcePicker : public HBoxContainer {
 	GDCLASS(EditorResourcePicker, HBoxContainer);
@@ -46,8 +47,12 @@ class EditorResourcePicker : public HBoxContainer {
 	bool editable = true;
 	bool dropping = false;
 
-	Vector<String> inheritors_array;
-
+	struct Inheritor {
+		String type;
+		const EditorData::CustomType *custom_resource = nullptr;
+	};
+	Vector<Inheritor> inheritors_array;
+	
 	Button *assign_button;
 	TextureRect *preview_rect;
 	Button *edit_button;
@@ -82,7 +87,8 @@ class EditorResourcePicker : public HBoxContainer {
 	void _button_draw();
 	void _button_input(const Ref<InputEvent> &p_event);
 
-	void _get_allowed_types(bool p_with_convert, Set<String> *p_vector) const;
+	void _get_custom_resources_from_allowed_types(Set<String> *p_allowed_types, Vector<EditorData::CustomType> *p_vector) const;
+	void _get_allowed_types(bool p_with_convert, Set<String> *p_set) const;
 	bool _is_drop_valid(const Dictionary &p_drag_data) const;
 	bool _is_type_valid(const String p_type_name, Set<String> p_allowed_types) const;
 


### PR DESCRIPTION
Fixes #31591 
When the user adds a custom resource via a GDScript plugin, their resource will now be displayed in the pop up menu when editing a compatible Resource property.

One limitation of my solution however is that it does not display children of custom resources. The solution I have in mind for that issue is a bit messy: find children of each custom type already found, and then find their children until no more children are found.

I'm actually not sure how to make a custom resource that derives from another custom resource through a GDScript plugin, so I can't set up a test project right now. If anyone knows how, I'd appreciate some guidance.