### PR TITLE
Fixes crash for bad property of PackedScene

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1097,6 +1097,14 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 
 	ERR_FAIL_COND_MSG(version > PACK_VERSION, "Save format version too new.");
 
+	const int node_count = p_dictionary["node_count"];
+	const PoolVector<int> snodes = p_dictionary["nodes"];
+	ERR_FAIL_COND(snodes.size() != node_count);
+
+	const int conn_count = p_dictionary["conn_count"];
+	const PoolVector<int> sconns = p_dictionary["conns"];
+	ERR_FAIL_COND(sconns.size() != conn_count);
+
 	PoolVector<String> snames = p_dictionary["names"];
 	if (snames.size()) {
 
@@ -1121,13 +1129,11 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 		variants.clear();
 	}
 
-	nodes.resize(p_dictionary["node_count"]);
-	int nc = nodes.size();
-	if (nc) {
-		PoolVector<int> snodes = p_dictionary["nodes"];
+	nodes.resize(node_count);
+	if (node_count) {
 		PoolVector<int>::Read r = snodes.read();
 		int idx = 0;
-		for (int i = 0; i < nc; i++) {
+		for (int i = 0; i < node_count; i++) {
 			NodeData &nd = nodes.write[i];
 			nd.parent = r[idx++];
 			nd.owner = r[idx++];
@@ -1151,15 +1157,11 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 		}
 	}
 
-	connections.resize(p_dictionary["conn_count"]);
-	int cc = connections.size();
-
-	if (cc) {
-
-		PoolVector<int> sconns = p_dictionary["conns"];
+	connections.resize(conn_count);
+	if (conn_count) {
 		PoolVector<int>::Read r = sconns.read();
 		int idx = 0;
-		for (int i = 0; i < cc; i++) {
+		for (int i = 0; i < conn_count; i++) {
 			ConnectionData &cd = connections.write[i];
 			cd.from = r[idx++];
 			cd.to = r[idx++];


### PR DESCRIPTION
In the setter of `PackedScene`'s `bundled` property, adds a validation that `node_count` matches the size of `nodes`, and `conn_count` matches the size of `conns`.

Before this fix, the editor crashes when the recorded size is greater than the actual size of the array. To reproduce:

1. Open any scene
2. In the Inspector, click the "Create a new resource in memory and edit it" button, and create a new `PackedScene` resource
3. Edit the "Bundled" property
4. Set `node_count` or `conn_count` to 1

*Bugsquad edit:* Fixes #28398.