### PR TITLE
Fix calculating label size

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -313,8 +313,8 @@ Size2 Label::get_minimum_size() const {
 int Label::get_longest_line_width() const {
 
 	Ref<Font> font = get_font("font");
-	int max_line_width = 0;
-	int line_width = 0;
+	real_t max_line_width = 0;
+	real_t line_width = 0;
 
 	for (int i = 0; i < xl_text.size(); i++) {
 
@@ -332,8 +332,7 @@ int Label::get_longest_line_width() const {
 			}
 		} else {
 
-			// ceiling to ensure autowrapping does not cut text
-			int char_width = Math::ceil(font->get_char_size(current, xl_text[i + 1]).width);
+			real_t char_width = font->get_char_size(current, xl_text[i + 1]).width;
 			line_width += char_width;
 		}
 	}
@@ -341,7 +340,8 @@ int Label::get_longest_line_width() const {
 	if (line_width > max_line_width)
 		max_line_width = line_width;
 
-	return max_line_width;
+	// ceiling to ensure autowrapping does not cut text
+	return Math::ceil(max_line_width);
 }
 
 int Label::get_line_count() const {
@@ -388,7 +388,7 @@ void Label::regenerate_word_cache() {
 
 	Ref<Font> font = get_font("font");
 
-	int current_word_size = 0;
+	real_t current_word_size = 0;
 	int word_pos = 0;
 	int line_width = 0;
 	int space_count = 0;
@@ -413,7 +413,7 @@ void Label::regenerate_word_cache() {
 		bool separatable = (current >= 0x2E08 && current <= 0xFAFF) || (current >= 0xFE30 && current <= 0xFE4F);
 		//current>=33 && (current < 65||current >90) && (current<97||current>122) && (current<48||current>57);
 		bool insert_newline = false;
-		int char_width = 0;
+		real_t char_width = 0;
 
 		if (current < 33) {
 
@@ -455,9 +455,9 @@ void Label::regenerate_word_cache() {
 				word_pos = i;
 			}
 			// ceiling to ensure autowrapping does not cut text
-			char_width = Math::ceil(font->get_char_size(current, xl_text[i + 1]).width);
+			char_width = font->get_char_size(current, xl_text[i + 1]).width;
 			current_word_size += char_width;
-			line_width += char_width;
+			line_width += Math::ceil(char_width);
 			total_char_cache++;
 
 			// allow autowrap to cut words when they exceed line width


### PR DESCRIPTION
Fix #34799
it caused by accumulated precision lost.

![Screenshot from 2020-01-06 01-02-34](https://user-images.githubusercontent.com/8281454/71782751-025e2600-3021-11ea-8fa3-dc0e89eaf36f.png)
Initial run

![Screenshot from 2020-01-06 01-02-48](https://user-images.githubusercontent.com/8281454/71782752-04c08000-3021-11ea-988a-f58bc7ce2916.png)
Testing autowrap

![Screenshot from 2020-01-06 01-02-55](https://user-images.githubusercontent.com/8281454/71782754-068a4380-3021-11ea-8693-c276a2c5bfa5.png)
Testing oversampling works as intended