### PR TITLE
Don't update the floor_velocity with the current linear_velocity.

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1151,17 +1151,8 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 		}
 	}
 
-	Vector3 current_floor_velocity = floor_velocity;
-	if (on_floor && on_floor_body.is_valid()) {
-		//this approach makes sure there is less delay between the actual body velocity and the one we saved
-		PhysicsDirectBodyState *bs = PhysicsServer::get_singleton()->body_get_direct_state(on_floor_body);
-		if (bs) {
-			current_floor_velocity = bs->get_linear_velocity();
-		}
-	}
-
 	// Hack in order to work with calling from _process as well as from _physics_process; calling from thread is risky
-	Vector3 motion = (current_floor_velocity + body_velocity) * (Engine::get_singleton()->is_in_physics_frame() ? get_physics_process_delta_time() : get_process_delta_time());
+	Vector3 motion = (floor_velocity + body_velocity) * (Engine::get_singleton()->is_in_physics_frame() ? get_physics_process_delta_time() : get_process_delta_time());
 
 	on_floor = false;
 	on_floor_body = RID();


### PR DESCRIPTION
Updating the floor velocity with the body's current linear velocity discards the velocity component provided by the body's angular rotation. Without the current contact point there is no way to calculate the current velocity component provided by the body's angular rotation therefore we need to use the velocity calculated at the time of the collision.

Fixes #34807.