### PR TITLE
Add Thread `completed` signal

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2693,7 +2693,9 @@ void _Thread::_start_func(void *ud) {
 
 		ERR_FAIL_MSG("Could not call function '" + t->target_method.operator String() + "' to start thread " + t->get_id() + ": " + reason + ".");
 	}
-	t->emit_signal("completed", t->ret);
+	// Ensure signal emission is deferred so that
+	// the thread can be safely joined later with `wait_to_finish`.
+	t->call_deferred("emit_signal", "completed", t->ret);
 }
 
 Error _Thread::start(Object *p_instance, const StringName &p_method, const Variant &p_userdata, Priority p_priority) {

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2693,6 +2693,7 @@ void _Thread::_start_func(void *ud) {
 
 		ERR_FAIL_MSG("Could not call function '" + t->target_method.operator String() + "' to start thread " + t->get_id() + ": " + reason + ".");
 	}
+	t->emit_signal("completed", t->ret);
 }
 
 Error _Thread::start(Object *p_instance, const StringName &p_method, const Variant &p_userdata, Priority p_priority) {
@@ -2759,6 +2760,8 @@ void _Thread::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_id"), &_Thread::get_id);
 	ClassDB::bind_method(D_METHOD("is_active"), &_Thread::is_active);
 	ClassDB::bind_method(D_METHOD("wait_to_finish"), &_Thread::wait_to_finish);
+
+	ADD_SIGNAL(MethodInfo("completed", PropertyInfo(Variant::NIL, "result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
 
 	BIND_ENUM_CONSTANT(PRIORITY_LOW);
 	BIND_ENUM_CONSTANT(PRIORITY_NORMAL);


### PR DESCRIPTION
Closes #9339.

## Usage

```gdscript
var thread = Thread.new()

func _ready():
	thread.connect("completed", self, "_on_thread_completed", [thread])

func _on_thread_pressed():
	thread.start(self, "_image_process", "res://mona.png")

func _on_thread_completed(p_result, p_thread):
	# The thread must still be collected and finalized even if already finished.
	p_thread.wait_to_finish()
	$sprite.texture = p_result
```

The only caveat is that signal emission should happen deferred (see `CONNECT_DEFERRED`), but I noticed that it does return the result within the signal callback even without it, but `wait_to_finish` just hangs the thread in that case (which suggests that perhaps it should finalize it automatically in these cases https://github.com/godotengine/godot/issues/7235#issuecomment-437601392:

> The only way to make it go false is to call wait_to_finish(), but it will potentially hang the application if the function was actually still running.

Note: deferring issue is also fixed with https://github.com/godotengine/godot/pull/34862#issuecomment-571744578.

I intentionally named the signal as `completed` because you still have to "formally" finalize the thread with `wait_to_finish` method (which I think does more than what it says on the tin). As you may have noticed, it resembles `GDScriptFunctionState`'s `completed` signal (aka `yield` stuff).

## Test project
[threads.zip](https://github.com/godotengine/godot/files/4032798/threads.zip)

