### PR TITLE
Calculate label size more accurately

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -103,8 +103,7 @@ void Label::_notification(int p_what) {
 
 		int lines_visible = (size.y + line_spacing) / font_h;
 
-		// ceiling to ensure autowrapping does not cut text
-		int space_w = Math::ceil(font->get_char_size(' ').width);
+		real_t space_w = font->get_char_size(' ').width;
 		int chars_total = 0;
 
 		int vbegin = 0, vsep = 0;
@@ -390,10 +389,9 @@ void Label::regenerate_word_cache() {
 
 	real_t current_word_size = 0;
 	int word_pos = 0;
-	int line_width = 0;
+	real_t line_width = 0;
 	int space_count = 0;
-	// ceiling to ensure autowrapping does not cut text
-	int space_width = Math::ceil(font->get_char_size(' ').width);
+	real_t space_width = font->get_char_size(' ').width;
 	int line_spacing = get_constant("line_spacing");
 	line_count = 1;
 	total_char_cache = 0;
@@ -454,10 +452,9 @@ void Label::regenerate_word_cache() {
 			if (current_word_size == 0) {
 				word_pos = i;
 			}
-			// ceiling to ensure autowrapping does not cut text
 			char_width = font->get_char_size(current, xl_text[i + 1]).width;
 			current_word_size += char_width;
-			line_width += Math::ceil(char_width);
+			line_width += char_width;
 			total_char_cache++;
 
 			// allow autowrap to cut words when they exceed line width


### PR DESCRIPTION
Fix #33584

![image](https://user-images.githubusercontent.com/8281454/71842946-28a9c180-3106-11ea-83bb-fafdc097976f.png)

![image](https://user-images.githubusercontent.com/8281454/71842974-34958380-3106-11ea-9f6d-37e0b57fecba.png)

used a custom flat stylebox to confirm easily.


it started from #15459.
it's fixed by #18862 but the pr caused #33584.

I also tested #15459 sample project and there's no more clipped character with oversampling feature with various resolution.