### PR TITLE
Make Label node consider spaces for visible_characters property

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -225,6 +225,7 @@ void Label::_notification(int p_what) {
 					return;
 				}
 				if (from->space_count) {
+					chars_total += from->space_count;
 					/* spacing */
 					x_ofs += space_w * from->space_count;
 					if (can_fill && align == ALIGN_FILL && spaces) {


### PR DESCRIPTION
Make Label node consider spaces for `visible_characters` property.

RichTextLabel node considers spaces for its `visible_characters` property, so the two nodes are now consistent.

Fixes #34775.

Thanks to @thebluefish for providing the solution. 😃