### PR TITLE
ClassDB: Exclude method binds starting with '_' from API hash

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -389,6 +389,13 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 
 			while ((k = t->method_map.next(k))) {
 
+				String name = k->operator String();
+
+				ERR_CONTINUE(name.empty());
+
+				if (name[0] == '_')
+					continue; // Ignore non-virtual methods that start with an underscore
+
 				snames.push_back(*k);
 			}
 


### PR DESCRIPTION
As discussed in #32967.

These methods are not meant to be part of the scripting API.
These are not the same as virtual methods starting with '_', e.g.: '_process'.
