### PR TITLE
Fixes import of models as PackedScene

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1099,11 +1099,11 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 
 	const int node_count = p_dictionary["node_count"];
 	const PoolVector<int> snodes = p_dictionary["nodes"];
-	ERR_FAIL_COND(snodes.size() != node_count);
+	ERR_FAIL_COND(snodes.size() < node_count);
 
 	const int conn_count = p_dictionary["conn_count"];
 	const PoolVector<int> sconns = p_dictionary["conns"];
-	ERR_FAIL_COND(sconns.size() != conn_count);
+	ERR_FAIL_COND(sconns.size() < conn_count);
 
 	PoolVector<String> snames = p_dictionary["names"];
 	if (snames.size()) {


### PR DESCRIPTION
This fixes #34866

The check in #34829 is too aggressive, not considering imported scenes. It's `snodes.size() < node_count` that will crash the engine. Sorry for the regression.