### PR TITLE
Export: Improve usability of command line interface

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -325,18 +325,13 @@ private:
 	ExportTemplateManager *export_template_manager;
 	EditorFeatureProfileManager *feature_profile_manager;
 	EditorFileDialog *file_templates;
-	EditorFileDialog *file_export;
 	EditorFileDialog *file_export_lib;
 	EditorFileDialog *file_script;
 	CheckBox *file_export_lib_merge;
-	LineEdit *file_export_password;
 	String current_path;
 	MenuButton *update_spinner;
 
 	String defer_load_scene;
-	String defer_export;
-	String defer_export_platform;
-	bool defer_export_debug;
 	Node *_last_instanced_scene;
 
 	EditorLog *log;
@@ -563,8 +558,6 @@ private:
 		String preset;
 		String path;
 		bool debug;
-		String password;
-
 	} export_defer;
 
 	bool disable_progress_dialog;
@@ -786,7 +779,7 @@ public:
 
 	void _copy_warning(const String &p_str);
 
-	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, const String &p_password, bool p_quit_after = false);
+	Error export_preset(const String &p_preset, const String &p_path, bool p_debug);
 
 	static void register_editor_types();
 	static void unregister_editor_types();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -286,8 +286,10 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -s, --script <script>            Run a script.\n");
 	OS::get_singleton()->print("  --check-only                     Only parse for errors and quit (use with --script).\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  --export <target> <path>         Export the project using the given export target. Export only main pack if path ends with .pck or .zip. <path> is relative to the project directory.\n");
-	OS::get_singleton()->print("  --export-debug <target> <path>   Like --export, but use debug template.\n");
+	OS::get_singleton()->print("  --export <preset> <path>         Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.cfg.\n");
+	OS::get_singleton()->print("                                   <path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe').\n");
+	OS::get_singleton()->print("                                   The target directory should exist. Only the data pack is exported if <path> ends with .pck or .zip.\n");
+	OS::get_singleton()->print("  --export-debug <preset> <path>   Same as --export, but using the debug template.\n");
 	OS::get_singleton()->print("  --doctool <path>                 Dump the engine API reference to the given <path> in XML format, merging if existing files are found.\n");
 	OS::get_singleton()->print("  --no-docbase                     Disallow dumping the base types (used with --doctool).\n");
 	OS::get_singleton()->print("  --build-solutions                Build the scripting solutions (e.g. for C# projects).\n");
@@ -1513,11 +1515,11 @@ bool Main::start() {
 
 	if (_export_preset != "") {
 		if (game_path == "") {
-			String err = "Command line param ";
+			String err = "Command line parameter ";
 			err += export_debug ? "--export-debug" : "--export";
 			err += " passed but no destination path given.\n";
 			err += "Please specify the binary's file path to export to. Aborting export.";
-			ERR_PRINT(err.utf8().get_data());
+			ERR_PRINT(err);
 			return false;
 		}
 	}
@@ -1698,20 +1700,14 @@ bool Main::start() {
 		}
 
 #ifdef TOOLS_ENABLED
-
 		EditorNode *editor_node = NULL;
 		if (editor) {
-
 			editor_node = memnew(EditorNode);
 			sml->get_root()->add_child(editor_node);
 
-			//root_node->set_editor(editor);
-			//startup editor
-
 			if (_export_preset != "") {
-
-				editor_node->export_preset(_export_preset, game_path, export_debug, "", true);
-				game_path = ""; //no load anything
+				editor_node->export_preset(_export_preset, game_path, export_debug);
+				game_path = ""; // Do not load anything.
 			}
 		}
 #endif

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -288,31 +288,31 @@ Ref<Texture> EditorExportPlatformJavaScript::get_logo() const {
 
 bool EditorExportPlatformJavaScript::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {
 
-	bool valid = false;
 	String err;
+	bool valid = false;
 
-	if (find_export_template(EXPORT_TEMPLATE_WEBASSEMBLY_RELEASE) != "")
-		valid = true;
-	else if (find_export_template(EXPORT_TEMPLATE_WEBASSEMBLY_DEBUG) != "")
-		valid = true;
+	// Look for export templates (first official, and if defined custom templates).
+
+	bool dvalid = exists_export_template(EXPORT_TEMPLATE_WEBASSEMBLY_DEBUG, &err);
+	bool rvalid = exists_export_template(EXPORT_TEMPLATE_WEBASSEMBLY_RELEASE, &err);
 
 	if (p_preset->get("custom_template/debug") != "") {
-		if (FileAccess::exists(p_preset->get("custom_template/debug"))) {
-			valid = true;
-		} else {
+		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
+		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-
 	if (p_preset->get("custom_template/release") != "") {
-		if (FileAccess::exists(p_preset->get("custom_template/release"))) {
-			valid = true;
-		} else {
+		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
+		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";
 		}
 	}
 
+	valid = dvalid || rvalid;
 	r_missing_templates = !valid;
+
+	// Validate the rest of the configuration.
 
 	if (p_preset->get("vram_texture_compression/for_mobile")) {
 		String etc_error = test_etc2();


### PR DESCRIPTION
I'm barely scratching the surface of the changes needed to make the
--export command line interface easy to use, but this should already
improve things somewhat.

- Streamline `can_export()` templates check in all platforms, checking
  first for the presence of official templates, then of any defined
  custom template, and reporting on the absence of any.
  Shouldn't change the actual return value much which is still true if
  either release or debug is usable - we might want to change that
  eventually and better validate against the requested target.

- Fix discrepancy between platforms using `custom_package/debug` and
  `custom_template/debug` (resp. `release`).
  All now use `custom_template`, which will break compatibility for
  `export_presets.cfg` with earlier projects (but is easy to fix).

- Use `can_export()` when attempting a command line export and report
  the same errors that would be shown in the editor.

- Improve error reporting after a failed export attempt, handling
  missing template and invalid path more gracefully.

- Cleanup of unused stuff in EditorNode around the export workflow.

- Improve --export documentation in --help a bit.

Fixes #16949 (at least many of the misunderstandings listed there).
Fixes #18470.