### PR TITLE
Fix wrong cursor shape in empty space when meta link wraps in RichTextLabel

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1063,10 +1063,10 @@ Control::CursorShape RichTextLabel::get_cursor_shape(const Point2 &p_pos) const 
 
 	int line = 0;
 	Item *item = NULL;
+	bool outside;
+	((RichTextLabel *)(this))->_find_click(main, p_pos, &item, &line, &outside);
 
-	((RichTextLabel *)(this))->_find_click(main, p_pos, &item, &line);
-
-	if (item && ((RichTextLabel *)(this))->_find_meta(item, NULL))
+	if (item && !outside && ((RichTextLabel *)(this))->_find_meta(item, NULL))
 		return CURSOR_POINTING_HAND;
 
 	return CURSOR_ARROW;


### PR DESCRIPTION
Closes #34889.
Check that the cursor is not outside the meta link when setting the cursor shape.

Before:
![before](https://user-images.githubusercontent.com/18357657/71904586-b2897700-3166-11ea-8cd1-f5e40dd38e03.png)

After:
![after](https://user-images.githubusercontent.com/18357657/71904568-aa313c00-3166-11ea-8e14-1cf23ddccd74.png)