### PR TITLE
Show selected main scene in FileSystem split view

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -90,6 +90,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 
 	// Create all items for the files in the subdirectory.
 	if (display_mode == DISPLAY_MODE_TREE_ONLY) {
+		String main_scene = ProjectSettings::get_singleton()->get("application/run/main_scene");
 		for (int i = 0; i < p_dir->get_file_count(); i++) {
 
 			String file_type = p_dir->get_file_type(i);
@@ -119,7 +120,6 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 				file_item->select(0);
 				file_item->set_as_cursor(0);
 			}
-			String main_scene = ProjectSettings::get_singleton()->get("application/run/main_scene");
 			if (main_scene == file_metadata) {
 				file_item->set_custom_color(0, get_color("accent_color", "Editor"));
 			}
@@ -750,6 +750,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	}
 
 	// Fills the ItemList control node from the FileInfos.
+	String main_scene = ProjectSettings::get_singleton()->get("application/run/main_scene");
 	String oi = "Object";
 	for (List<FileInfo>::Element *E = filelist.front(); E; E = E->next()) {
 		FileInfo *finfo = &(E->get());
@@ -784,6 +785,10 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			files->add_item(fname, type_icon, true);
 			item_index = files->get_item_count() - 1;
 			files->set_item_metadata(item_index, fpath);
+		}
+
+		if (fpath == main_scene) {
+			files->set_item_custom_fg_color(item_index, get_color("accent_color", "Editor"));
 		}
 
 		// Generate the preview.


### PR DESCRIPTION
Currently, selected main scene is highlighted in FileSystem tree view.
![Screenshot from 2020-01-08 02-11-18](https://user-images.githubusercontent.com/8281454/71914177-6832e500-31bc-11ea-873d-918107fcc558.png)

But not in split view.
![Screenshot from 2020-01-08 02-11-33](https://user-images.githubusercontent.com/8281454/71914215-7b45b500-31bc-11ea-9e04-babdf71d0106.png)

Now show it also in split view.
![Screenshot from 2020-01-08 02-18-45](https://user-images.githubusercontent.com/8281454/71914606-47b75a80-31bd-11ea-8519-08b2b421d0db.png)
