### PR TITLE
Don't show conf warning if script is not tool

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2680,7 +2680,8 @@ void Node::clear_internal_tree_resource_paths() {
 
 String Node::get_configuration_warning() const {
 
-	if (get_script_instance() && get_script_instance()->has_method("_get_configuration_warning")) {
+	if (get_script_instance() && get_script_instance()->get_script().is_valid() &&
+			get_script_instance()->get_script()->is_tool() && get_script_instance()->has_method("_get_configuration_warning")) {
 		return get_script_instance()->call("_get_configuration_warning");
 	}
 	return String();


### PR DESCRIPTION
Fixes #26201
(this is correct according to [documentation](https://docs.godotengine.org/en/latest/classes/class_node.html#class-node-method-get-configuration-warning))