### PR TITLE
Recent Nodes now respect Editor Profiles  #33420

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -59,7 +59,8 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 			String l = f->get_line().strip_edges();
 			String name = l.split(" ")[0];
 
-			if (ClassDB::class_exists(name) || ScriptServer::is_global_class(name)) {
+			if ((ClassDB::class_exists(name) || ScriptServer::is_global_class(name)) && !_is_class_disabled_by_feature_profile(name)) {
+
 				TreeItem *ti = recent->create_item(root);
 				ti->set_text(0, l);
 				ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(l, base_type));


### PR DESCRIPTION
Fixed the "Recent" tab ignoring the current editor profile, and showing ignored nodes.

*Bugsquad edit: This closes #33420.*