### PR TITLE
Minor fixes for ScriptCreateDialog

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1761,7 +1761,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				fpath = fpath.get_base_dir();
 			}
 			make_script_dialog->config("Node", fpath.plus_file("new_script.gd"), false);
-			make_script_dialog->popup_centered(Size2(300, 300) * EDSCALE);
+			make_script_dialog->popup_centered();
 		} break;
 
 		case FILE_COPY_PATH: {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1004,8 +1004,8 @@ void ScriptEditor::_menu_option(int p_option) {
 	ScriptEditorBase *current = _get_current_editor();
 	switch (p_option) {
 		case FILE_NEW: {
-			script_create_dialog->config("Node", "new_script");
-			script_create_dialog->popup_centered(Size2(300, 300) * EDSCALE);
+			script_create_dialog->config("Node", "new_script", false);
+			script_create_dialog->popup_centered();
 		} break;
 		case FILE_NEW_TEXTFILE: {
 			file_dialog->set_mode(EditorFileDialog::MODE_SAVE_FILE);

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -678,6 +678,11 @@ void ScriptCreateDialog::_update_dialog() {
 		}
 	}
 
+	if (!_can_be_built_in()) {
+		internal->set_pressed(false);
+	}
+	internal->set_disabled(!_can_be_built_in());
+
 	/* Is Script created or loaded from existing file */
 
 	if (is_built_in) {
@@ -685,8 +690,6 @@ void ScriptCreateDialog::_update_dialog() {
 		parent_name->set_editable(true);
 		parent_search_button->set_disabled(false);
 		parent_browse_button->set_disabled(!can_inherit_from_file);
-		internal->set_visible(_can_be_built_in());
-		internal_label->set_visible(_can_be_built_in());
 		_msg_path_valid(true, TTR("Built-in script (into scene file)."));
 	} else if (is_new_script_created) {
 		// New Script Created
@@ -694,8 +697,6 @@ void ScriptCreateDialog::_update_dialog() {
 		parent_name->set_editable(true);
 		parent_search_button->set_disabled(false);
 		parent_browse_button->set_disabled(!can_inherit_from_file);
-		internal->set_visible(_can_be_built_in());
-		internal_label->set_visible(_can_be_built_in());
 		if (is_path_valid) {
 			_msg_path_valid(true, TTR("Will create a new script file."));
 		}
@@ -705,7 +706,6 @@ void ScriptCreateDialog::_update_dialog() {
 		parent_name->set_editable(false);
 		parent_search_button->set_disabled(true);
 		parent_browse_button->set_disabled(true);
-		internal->set_disabled(!_can_be_built_in());
 		if (is_path_valid) {
 			_msg_path_valid(true, TTR("Will load an existing script file."));
 		}
@@ -834,8 +834,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	internal = memnew(CheckBox);
 	internal->set_text(TTR("On"));
 	internal->connect("pressed", this, "_built_in_pressed");
-	internal_label = memnew(Label(TTR("Built-in Script:")));
-	gc->add_child(internal_label);
+	gc->add_child(memnew(Label(TTR("Built-in Script:"))));
 	gc->add_child(internal);
 
 	/* Path */

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -58,7 +58,6 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	Button *path_button;
 	EditorFileDialog *file_browse;
 	CheckBox *internal;
-	Label *internal_label;
 	VBoxContainer *path_vb;
 	AcceptDialog *alert;
 	CreateDialog *select_class;


### PR DESCRIPTION
Past year I made a modification to `ScriptCreateDialog` to hide the "built-in" section when not necessary, the main reason being is that `CheckButton` did not have a proper disabled theme.
But now that it's a `CheckBox` instead, and that decision has also caused some problems, I changed it back to just disabling it.

I also made the dialog itself the same size no matter who popped it, and disabled built-in functionality when creating from the script editor.

Fixes #34591.