### PR TITLE
Gamepad: Fix parsing order for SDL2 controller databases

### DIFF
--- a/main/SCsub
+++ b/main/SCsub
@@ -9,8 +9,8 @@ env.main_sources = []
 
 env.add_source_files(env.main_sources, "*.cpp")
 
-# order matters here.  higher index controller database files write on top of lower index database files
-controller_databases = ["#main/gamecontrollerdb.txt", "#main/gamecontrollerdb_205.txt", "#main/gamecontrollerdb_204.txt", "#main/godotcontrollerdb.txt"]
+# Order matters here. Higher index controller database files write on top of lower index database files.
+controller_databases = ["#main/gamecontrollerdb_204.txt", "#main/gamecontrollerdb_205.txt", "#main/gamecontrollerdb.txt", "#main/godotcontrollerdb.txt"]
 
 env.Depends("#main/default_controller_mappings.gen.cpp", controller_databases)
 env.CommandNoCache("#main/default_controller_mappings.gen.cpp", controller_databases, run_in_subprocess(main_builders.make_default_controller_mappings))


### PR DESCRIPTION
We were overriding values from `gamecontrollerdb.txt` (current, updated
upstream) with `gamecontrollerdb_205.txt` (legacy, SDL 2.0.5) and then
`gamecontrollerdb_204.txt` (legacy, SDL 2.0.4).

There was a comment to warn about this but it seems it did not prevent
using the wrong order for all this time...

Now `gamecontrollerdb.txt` mappings will properly override outdated
ones present in the `204` and `205` variants.