### PR TITLE
Emits meta_hover_ended when mouse exit RichTextLabel

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -935,6 +935,14 @@ void RichTextLabel::_notification(int p_what) {
 
 	switch (p_what) {
 
+		case NOTIFICATION_MOUSE_EXIT: {
+			if (meta_hovering) {
+				meta_hovering = NULL;
+				emit_signal("meta_hover_ended", current_meta);
+				current_meta = false;
+				update();
+			}
+		} break;
 		case NOTIFICATION_RESIZED: {
 
 			main->first_invalid_line = 0; //invalidate ALL


### PR DESCRIPTION
This fixes #31199

For the reference, this is how the normal hover ended signal gets emitted:
https://github.com/godotengine/godot/blob/ae21664655a16526b1a8e3e30f4e03d9a7c9c67c/scene/gui/rich_text_label.cpp#L1294-L1298