### PR TITLE
Export: Add dedicated --export-pack option to export data pack

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -585,10 +585,7 @@ void EditorNode::_fs_changed() {
 				export_error = vformat("Export preset '%s' doesn't have a matching platform.", preset_name);
 			} else {
 				Error err = OK;
-				// FIXME: This way to export only resources .pck or .zip is pretty hacky
-				// and undocumented, and might be problematic for platforms where .zip is
-				// a valid project export format (e.g. macOS).
-				if (export_defer.path.ends_with(".pck") || export_defer.path.ends_with(".zip")) {
+				if (export_defer.pack_only) { // Only export .pck or .zip data pack.
 					if (export_defer.path.ends_with(".zip")) {
 						err = platform->export_zip(preset, export_defer.debug, export_defer.path);
 					} else if (export_defer.path.ends_with(".pck")) {
@@ -3942,11 +3939,12 @@ void EditorNode::_editor_file_dialog_unregister(EditorFileDialog *p_dialog) {
 
 Vector<EditorNodeInitCallback> EditorNode::_init_callbacks;
 
-Error EditorNode::export_preset(const String &p_preset, const String &p_path, bool p_debug) {
+Error EditorNode::export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only) {
 
 	export_defer.preset = p_preset;
 	export_defer.path = p_path;
 	export_defer.debug = p_debug;
+	export_defer.pack_only = p_pack_only;
 	disable_progress_dialog = true;
 	return OK;
 }

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -558,6 +558,7 @@ private:
 		String preset;
 		String path;
 		bool debug;
+		bool pack_only;
 	} export_defer;
 
 	bool disable_progress_dialog;
@@ -779,7 +780,7 @@ public:
 
 	void _copy_warning(const String &p_str);
 
-	Error export_preset(const String &p_preset, const String &p_path, bool p_debug);
+	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only);
 
 	static void register_editor_types();
 	static void unregister_editor_types();


### PR DESCRIPTION
The previous behavior relying on the provided extension was problematic
on macOS since .zip is the main extension used for the full project
export (binary + data pack).

We add a dedicated `--export-pack` command line option to define when
only the data pack should be exported. Its extension will still be
inferred from the path.

Fixes #23073.

---

Slightly breaks compat again, as it's no longer possible to export a data pack with `--export` or `--export-debug`, users will now have to use `--export-pack`. I think it's not a big breakage though and easy to adapt to, if anyone was actively using this hidden misfeature in the first place.

@Calinou Can you make sure to mention both this and the `s/custom_package/custom_template/` changes in the changelog?