### PR TITLE
GDScript: properly set type of local variable initialization

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8047,6 +8047,7 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 
 				last_var_assign = lv->assign;
 				if (lv->assign) {
+					lv->assign_op->arguments[0]->set_datatype(lv->datatype);
 					DataType assign_type = _reduce_node_type(lv->assign);
 #ifdef DEBUG_ENABLED
 					if (assign_type.has_type && assign_type.kind == DataType::BUILTIN && assign_type.builtin_type == Variant::NIL) {


### PR DESCRIPTION
Properly sets the type of the identifier for the local variable that is stored in the assignment operation. This makes sure that the compiler is aware of typing for local variables when they are initialized with the declaration.

Fix #32905
Fix #34791