### PR TITLE
GDScript: enable type checks on release mode

### DIFF
--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -671,6 +671,30 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 2;
 
 				} break;
+				case GDScriptFunction::OPCODE_ASSIGN_TYPED_BUILTIN: {
+
+					txt += " assign typed builtin (";
+					txt += Variant::get_type_name((Variant::Type)code[ip + 1]);
+					txt += ") ";
+					txt += DADDR(2);
+					txt += " = ";
+					txt += DADDR(3);
+					incr += 4;
+
+				} break;
+				case GDScriptFunction::OPCODE_ASSIGN_TYPED_NATIVE: {
+					Variant className = func.get_constant(code[ip + 1]);
+					GDScriptNativeClass *nc = Object::cast_to<GDScriptNativeClass>(className.operator Object *());
+
+					txt += " assign typed native (";
+					txt += nc->get_name().operator String();
+					txt += ") ";
+					txt += DADDR(2);
+					txt += " = ";
+					txt += DADDR(3);
+					incr += 4;
+
+				} break;
 				case GDScriptFunction::OPCODE_CAST_TO_SCRIPT: {
 
 					txt += " cast ";

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -2057,12 +2057,13 @@ MethodInfo GDScriptFunctions::get_info(Function p_func) {
 			mi.return_val.type = Variant::BOOL;
 			return mi;
 		} break;
-		case FUNC_MAX: {
+		default: {
 
 			ERR_FAIL_V(MethodInfo());
 		} break;
 	}
 #endif
-
-	return MethodInfo();
+	MethodInfo mi;
+	mi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+	return mi;
 }

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8191,11 +8191,14 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 						if (lh_type.has_type && rh_type.may_yield && op->arguments[1]->type == Node::TYPE_OPERATOR) {
 							_add_warning(GDScriptWarning::FUNCTION_MAY_YIELD, op->line, _find_function_name(static_cast<OperatorNode *>(op->arguments[1])));
 						}
-#endif // DEBUG_ENABLED
 
 						bool type_match = check_types;
+#endif // DEBUG_ENABLED
 						if (check_types && !_is_type_compatible(lh_type, rh_type)) {
+#ifdef DEBUG_ENABLED
 							type_match = false;
+#endif // DEBUG_ENABLED
+
 							// Try supertype test
 							if (_is_type_compatible(rh_type, lh_type)) {
 								_mark_line_as_unsafe(op->line);
@@ -8226,7 +8229,9 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 
 									op->arguments.write[1] = convert_call;
 
+#ifdef DEBUG_ENABLED
 									type_match = true; // Since we are converting, the type is matching
+#endif // DEBUG_ENABLED
 								}
 #ifdef DEBUG_ENABLED
 								if (lh_type.builtin_type == Variant::INT && rh_type.builtin_type == Variant::REAL) {
@@ -8239,8 +8244,10 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 						if (!rh_type.has_type && (op->op != OperatorNode::OP_ASSIGN || lh_type.has_type || op->arguments[0]->type == Node::TYPE_OPERATOR)) {
 							_mark_line_as_unsafe(op->line);
 						}
-#endif // DEBUG_ENABLED
 						op->datatype.has_type = type_match;
+#else
+						op->datatype.has_type = false;
+#endif // DEBUG_ENABLED
 					} break;
 					case OperatorNode::OP_CALL:
 					case OperatorNode::OP_PARENT_CALL: {
@@ -8483,11 +8490,8 @@ Error GDScriptParser::_parse(const String &p_base_path) {
 	current_class = main_class;
 	current_function = NULL;
 	current_block = NULL;
-#ifdef DEBUG_ENABLED
+
 	if (for_completion) check_types = false;
-#else
-	check_types = false;
-#endif
 
 	// Resolve all class-level stuff before getting into function blocks
 	_check_class_level_types(main_class);


### PR DESCRIPTION
Also make builtin GDScript functions report return type as Variant in release so type is converted when needed.

This might have a small performance impact on release for loading times (since now it needs to type-check during parsing) and in some assignment cases (since it might need to convert values to the correct type).

I think this is safe but it would be good to do some heavy testing with release builds to make sure nothing breaks.

Fix #24035