### PR TITLE
GDScript LSP: Implement signatureHelp

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -522,6 +522,51 @@ const lsp::DocumentSymbol *ExtendGDScriptParser::search_symbol_defined_at_line(i
 	return ret;
 }
 
+Error ExtendGDScriptParser::get_left_function_call(const lsp::Position &p_position, lsp::Position &r_func_pos, int &r_arg_index) const {
+
+	ERR_FAIL_INDEX_V(p_position.line, lines.size(), ERR_INVALID_PARAMETER);
+
+	int bracket_stack = 0;
+	int index = 0;
+
+	bool found = false;
+	for (int l = p_position.line; l >= 0; --l) {
+		String line = lines[l];
+		int c = line.length() - 1;
+		if (l == p_position.line) {
+			c = MIN(c, p_position.character - 1);
+		}
+
+		while (c >= 0) {
+			const CharType &charactor = line[c];
+			if (charactor == ')') {
+				++bracket_stack;
+			} else if (charactor == '(') {
+				--bracket_stack;
+				if (bracket_stack < 0) {
+					found = true;
+				}
+			}
+			if (bracket_stack <= 0 && charactor == ',') {
+				++index;
+			}
+			--c;
+			if (found) {
+				r_func_pos.character = c;
+				break;
+			}
+		}
+
+		if (found) {
+			r_func_pos.line = l;
+			r_arg_index = index;
+			return OK;
+		}
+	}
+
+	return ERR_METHOD_NOT_FOUND;
+}
+
 const lsp::DocumentSymbol *ExtendGDScriptParser::get_symbol_defined_at_line(int p_line) const {
 	if (p_line <= 0) {
 		return &class_symbol;

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -83,6 +83,8 @@ public:
 	_FORCE_INLINE_ const ClassMembers &get_members() const { return members; }
 	_FORCE_INLINE_ const HashMap<String, ClassMembers> &get_inner_classes() const { return inner_classes; }
 
+	Error get_left_function_call(const lsp::Position &p_position, lsp::Position &r_func_pos, int &r_arg_index) const;
+
 	String get_text_for_completion(const lsp::Position &p_cursor) const;
 	String get_text_for_lookup_symbol(const lsp::Position &p_cursor, const String &p_symbol = "", bool p_func_requred = false) const;
 	String get_identifier_under_position(const lsp::Position &p_position, Vector2i &p_offset) const;

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -38,7 +38,7 @@ GDScriptLanguageServer::GDScriptLanguageServer() {
 	thread = NULL;
 	thread_exit = false;
 	_EDITOR_DEF("network/language_server/remote_port", 6008);
-	_EDITOR_DEF("network/language_server/enable_smart_resolve", false);
+	_EDITOR_DEF("network/language_server/enable_smart_resolve", true);
 	_EDITOR_DEF("network/language_server/show_native_symbols_in_editor", false);
 }
 

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -50,6 +50,7 @@ void GDScriptTextDocument::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("hover"), &GDScriptTextDocument::hover);
 	ClassDB::bind_method(D_METHOD("definition"), &GDScriptTextDocument::definition);
 	ClassDB::bind_method(D_METHOD("declaration"), &GDScriptTextDocument::declaration);
+	ClassDB::bind_method(D_METHOD("signatureHelp"), &GDScriptTextDocument::signatureHelp);
 	ClassDB::bind_method(D_METHOD("show_native_symbol_in_editor"), &GDScriptTextDocument::show_native_symbol_in_editor);
 }
 
@@ -385,6 +386,20 @@ Variant GDScriptTextDocument::declaration(const Dictionary &p_params) {
 		}
 	}
 	return arr;
+}
+
+Variant GDScriptTextDocument::signatureHelp(const Dictionary &p_params) {
+	Variant ret;
+
+	lsp::TextDocumentPositionParams params;
+	params.load(p_params);
+
+	lsp::SignatureHelp s;
+	if (OK == GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_signature(params, s)) {
+		ret = s.to_json();
+	}
+
+	return ret;
 }
 
 GDScriptTextDocument::GDScriptTextDocument() {

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -67,6 +67,7 @@ public:
 	Variant hover(const Dictionary &p_params);
 	Array definition(const Dictionary &p_params);
 	Variant declaration(const Dictionary &p_params);
+	Variant signatureHelp(const Dictionary &p_params);
 
 	void initialize();
 

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -83,6 +83,7 @@ public:
 	const lsp::DocumentSymbol *resolve_native_symbol(const lsp::NativeSymbolInspectParams &p_params);
 	void resolve_document_links(const String &p_uri, List<lsp::DocumentLink> &r_list);
 	Dictionary generate_script_api(const String &p_path);
+	Error resolve_signature(const lsp::TextDocumentPositionParams &p_doc_pos, lsp::SignatureHelp &r_signature);
 
 	GDScriptWorkspace();
 	~GDScriptWorkspace();


### PR DESCRIPTION
GDScript LSP: Implement signatureHelp
Enable smart resolve default to true as it is required for script symbol lookup

Fix https://github.com/godotengine/godot-vscode-plugin/issues/132