### PR TITLE
Draw an outline for 2D debug collision shapes

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1327,7 +1327,7 @@ SceneTree::SceneTree() {
 	if (singleton == nullptr) {
 		singleton = this;
 	}
-	debug_collisions_color = GLOBAL_DEF("debug/shapes/collision/shape_color", Color(0.0, 0.6, 0.7, 0.5));
+	debug_collisions_color = GLOBAL_DEF("debug/shapes/collision/shape_color", Color(0.0, 0.6, 0.7, 0.42));
 	debug_collision_contact_color = GLOBAL_DEF("debug/shapes/collision/contact_color", Color(1.0, 0.2, 0.1, 0.8));
 	debug_navigation_color = GLOBAL_DEF("debug/shapes/navigation/geometry_color", Color(0.1, 1.0, 0.7, 0.4));
 	debug_navigation_disabled_color = GLOBAL_DEF("debug/shapes/navigation/disabled_geometry_color", Color(1.0, 0.7, 0.1, 0.4));

--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -85,6 +85,9 @@ void CapsuleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
+	RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
+	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+	RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
 }
 
 Rect2 CapsuleShape2D::get_rect() const {

--- a/scene/resources/circle_shape_2d.cpp
+++ b/scene/resources/circle_shape_2d.cpp
@@ -79,6 +79,9 @@ void CircleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
+	RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
+	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+	RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
 }
 
 CircleShape2D::CircleShape2D() :

--- a/scene/resources/convex_polygon_shape_2d.cpp
+++ b/scene/resources/convex_polygon_shape_2d.cpp
@@ -75,6 +75,9 @@ void ConvexPolygonShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
+	RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
+	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+	RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
 }
 
 Rect2 ConvexPolygonShape2D::get_rect() const {

--- a/scene/resources/rectangle_shape_2d.cpp
+++ b/scene/resources/rectangle_shape_2d.cpp
@@ -33,7 +33,7 @@
 #include "servers/physics_server_2d.h"
 #include "servers/rendering_server.h"
 void RectangleShape2D::_update_shape() {
-	PhysicsServer2D::get_singleton()->shape_set_data(get_rid(), size / 2);
+	PhysicsServer2D::get_singleton()->shape_set_data(get_rid(), size * 0.5);
 	emit_changed();
 }
 
@@ -47,11 +47,27 @@ Vector2 RectangleShape2D::get_size() const {
 }
 
 void RectangleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
-	RenderingServer::get_singleton()->canvas_item_add_rect(p_to_rid, Rect2(-size / 2, size), p_color);
+	// Draw an outlined rectangle to make individual shapes easier to distinguish.
+	Vector<Vector2> stroke_points;
+	stroke_points.resize(5);
+	stroke_points.write[0] = -size * 0.5;
+	stroke_points.write[1] = Vector2(size.x, -size.y) * 0.5;
+	stroke_points.write[2] = size * 0.5;
+	stroke_points.write[3] = Vector2(-size.x, size.y) * 0.5;
+	stroke_points.write[4] = -size * 0.5;
+
+	Vector<Color> stroke_colors;
+	stroke_colors.resize(5);
+	for (int i = 0; i < 5; i++) {
+		stroke_colors.write[i] = (p_color);
+	}
+
+	RenderingServer::get_singleton()->canvas_item_add_rect(p_to_rid, Rect2(-size * 0.5, size), p_color);
+	RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, stroke_points, stroke_colors);
 }
 
 Rect2 RectangleShape2D::get_rect() const {
-	return Rect2(-size / 2, size);
+	return Rect2(-size * 0.5, size);
 }
 
 real_t RectangleShape2D::get_enclosing_radius() const {


### PR DESCRIPTION
This makes them easier to distinguish, especially when used in a TileMap or when they're placed next to each other.

The default color's opacity has been slightly decreased to account for the new outline.

## Preview

### Before

![visible_collision_shapes_before](https://user-images.githubusercontent.com/180032/72000959-ad9af500-3244-11ea-8782-dac486cacdee.png)

### After

![visible_collision_shapes_after](https://user-images.githubusercontent.com/180032/72000957-ac69c800-3244-11ea-8b8c-e6b9682e60ca.png)