### PR TITLE
Provide `draw_set_transform` defaults for rotation and scale

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -285,9 +285,9 @@
 			</return>
 			<argument index="0" name="position" type="Vector2">
 			</argument>
-			<argument index="1" name="rotation" type="float">
+			<argument index="1" name="rotation" type="float" default="0.0">
 			</argument>
-			<argument index="2" name="scale" type="Vector2">
+			<argument index="2" name="scale" type="Vector2" default="Vector2( 1, 1 )">
 			</argument>
 			<description>
 				Sets a custom transform for drawing via components. Anything drawn afterwards will be transformed by this.

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1174,7 +1174,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_mesh", "mesh", "texture", "normal_map", "specular_map", "specular_shininess", "transform", "modulate", "texture_filter", "texture_repeat"), &CanvasItem::draw_mesh, DEFVAL(Ref<Texture2D>()), DEFVAL(Ref<Texture2D>()), DEFVAL(Color(1, 1, 1, 1)), DEFVAL(Transform2D()), DEFVAL(Color(1, 1, 1, 1)), DEFVAL(TEXTURE_FILTER_PARENT_NODE), DEFVAL(TEXTURE_REPEAT_PARENT_NODE));
 	ClassDB::bind_method(D_METHOD("draw_multimesh", "multimesh", "texture", "normal_map", "specular_map", "specular_shininess", "texture_filter", "texture_repeat"), &CanvasItem::draw_multimesh, DEFVAL(Ref<Texture2D>()), DEFVAL(Ref<Texture2D>()), DEFVAL(Color(1, 1, 1, 1)), DEFVAL(TEXTURE_FILTER_PARENT_NODE), DEFVAL(TEXTURE_REPEAT_PARENT_NODE));
 
-	ClassDB::bind_method(D_METHOD("draw_set_transform", "position", "rotation", "scale"), &CanvasItem::draw_set_transform);
+	ClassDB::bind_method(D_METHOD("draw_set_transform", "position", "rotation", "scale"), &CanvasItem::draw_set_transform, DEFVAL(0.0), DEFVAL(Size2(1.0, 1.0)));
 	ClassDB::bind_method(D_METHOD("draw_set_transform_matrix", "xform"), &CanvasItem::draw_set_transform_matrix);
 	ClassDB::bind_method(D_METHOD("get_transform"), &CanvasItem::get_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &CanvasItem::get_global_transform);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -348,7 +348,7 @@ public:
 	void draw_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, const Color &p_modulate = Color(1, 1, 1), int p_clip_w = -1);
 	float draw_char(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, const String &p_next = "", const Color &p_modulate = Color(1, 1, 1));
 
-	void draw_set_transform(const Point2 &p_offset, float p_rot, const Size2 &p_scale);
+	void draw_set_transform(const Point2 &p_offset, float p_rot = 0.0, const Size2 &p_scale = Size2(1.0, 1.0));
 	void draw_set_transform_matrix(const Transform2D &p_matrix);
 
 	static CanvasItem *get_current_item_drawn();


### PR DESCRIPTION
I typically find myself not needing to set rotation nor scale while I simply need to offset the drawing. When I look throughout the engine internals, most use `draw_set_transform_matrix` instead.

The other alternative would be adding something akin to `draw_set_offset` but then you might be missing out the ability to set rotation etc.

One of the use cases I'm talking about:
```gdscript
func _draw():
    # Offset the drawing so as to simulate top-left margins
    draw_set_transform(Vector2(16, 16)) # rotation = 0.0, scale = Vector2(1,1)
    draw_polyline(points, Color.green) # now it's visible!
```

I believe this could mostly speed-up prototyping if not used for real.

One could use an hierarchy of `Node2D`s with each having it's own transform set via editor instead, but it's not the case for `Control` (or not as user-friendly), and you still need to assign a separate script to each of them for drawing regardless.