### PR TITLE
Add option to disable loading scripts in ScriptCreateDialog

### DIFF
--- a/doc/classes/ScriptCreateDialog.xml
+++ b/doc/classes/ScriptCreateDialog.xml
@@ -24,6 +24,8 @@
 			</argument>
 			<argument index="2" name="built_in_enabled" type="bool" default="true">
 			</argument>
+			<argument index="3" name="load_enabled" type="bool" default="true">
+			</argument>
 			<description>
 				Prefills required fields to configure the ScriptCreateDialog for use.
 			</description>

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1761,7 +1761,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			if (!fpath.ends_with("/")) {
 				fpath = fpath.get_base_dir();
 			}
-			make_script_dialog->config("Node", fpath.plus_file("new_script.gd"), false);
+			make_script_dialog->config("Node", fpath.plus_file("new_script.gd"), false, false);
 			make_script_dialog->popup_centered();
 		} break;
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1004,7 +1004,7 @@ void ScriptEditor::_menu_option(int p_option) {
 	ScriptEditorBase *current = _get_current_editor();
 	switch (p_option) {
 		case FILE_NEW: {
-			script_create_dialog->config("Node", "new_script", false);
+			script_create_dialog->config("Node", "new_script", false, false);
 			script_create_dialog->popup_centered();
 		} break;
 		case FILE_NEW_TEXTFILE: {

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -74,6 +74,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool is_class_name_valid;
 	bool is_built_in;
 	bool built_in_enabled;
+	bool load_enabled;
 	int current_language;
 	int default_language;
 	bool re_check_path;
@@ -126,7 +127,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void config(const String &p_base_name, const String &p_base_path, bool p_built_in_enabled = true);
+	void config(const String &p_base_name, const String &p_base_path, bool p_built_in_enabled = true, bool p_load_enabled = true);
 	void set_inheritance_base_type(const String &p_base);
 	ScriptCreateDialog();
 };


### PR DESCRIPTION
This PR gives the option to disable the loading of existing scripts in places that such action doesn't make sense (e.g. everywhere but the "Scene" dock).