### PR TITLE
Fixes BaseButton not triggering the pressed signal on "Button Press"…

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -165,7 +165,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 				_pressed();
 			}
 		} else {
-			if (!p_event->is_pressed()) {
+			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
 				_pressed();
 			}
 		}


### PR DESCRIPTION
…" Action Mode

This should fix #34935

This is my first ever PR, and I'm a little inexperienced with Godot's source code and C++ in general, so please double check it before merging in case I broke anything by accident! It does seem to be working (and the issue fixed) on my end when I compiled it, though.