### PR TITLE
Make ScriptCreateDialog's script valid message a bit more clearer

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -644,7 +644,7 @@ void ScriptCreateDialog::_update_dialog() {
 	}
 
 	if (script_ok) {
-		_msg_script_valid(true, TTR("Script is valid."));
+		_msg_script_valid(true, TTR("Script path/name is valid."));
 	}
 
 	// Does script have named classes?


### PR DESCRIPTION
And by that I mean specify that the path/name is valid. As it's possible for that message to appear even when something is wrong, which is a tad confusing.

I would've but this together with #34937, but since string changes this late in development are a no-no...