### PR TITLE
Update file list in split view when setting main scene

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1589,6 +1589,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				ProjectSettings::get_singleton()->set("application/run/main_scene", p_selected[0]);
 				ProjectSettings::get_singleton()->save();
 				_update_tree(_compute_uncollapsed_paths());
+				_update_file_list(true);
 			}
 		} break;
 


### PR DESCRIPTION
currently, file list is not updated when setting a new main scene with context menu.