### PR TITLE
Doc: Mention that Directory pre-opens res:// by default

### DIFF
--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Directory type. It is used to manage directories and their content (not restricted to the project folder).
+		When creating a new [Directory], its default opened directory will be [code]res://[/code]. This may change in the future, so it is advised to always use [method open] to initialize your [Directory] where you want to operate, with explicit error checking.
 		Here is an example on how to iterate through the files of a directory:
 		[codeblock]
 		func dir_contents(path):


### PR DESCRIPTION
This may be considered a bug, so we might change that in the future.
See #24149.