### PR TITLE
GDScript: Validate object instance on `is` operation

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -803,6 +803,18 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			}
 		} break;
 		case Variant::OBJECT: {
+#ifdef DEBUG_ENABLED
+			// Test for potential wrong values sent by the debugger when it breaks.
+			Object *obj = p_variant;
+			if (!obj || !ObjectDB::instance_validate(obj)) {
+				// Object is invalid, send a NULL instead.
+				if (buf) {
+					encode_uint32(Variant::NIL, buf);
+				}
+				r_len += 4;
+				return OK;
+			}
+#endif // DEBUG_ENABLED
 			if (!p_full_objects) {
 				flags |= ENCODE_FLAG_OBJECT_AS_ID;
 			}

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -500,6 +500,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					Object *obj_A = *a;
 					Object *obj_B = *b;
 
+#ifdef DEBUG_ENABLED
+					if (!ObjectDB::instance_validate(obj_A)) {
+						err_text = "Left operand of 'is' was already freed.";
+						OPCODE_BREAK;
+					}
+#endif // DEBUG_ENABLED
+
 					GDScript *scr_B = Object::cast_to<GDScript>(obj_B);
 
 					if (scr_B) {


### PR DESCRIPTION
Avoids crashes on debug mode. Instead it now breaks the execution and show the error in-editor. Will still crash on release.

Also add a similar check to Marshalls to ensure the debugger doesn't crash when trying to serialize the invalid instance.

Fix #26356 (this is the fix (1) mentioned in https://github.com/godotengine/godot/issues/26356#issuecomment-572581098)