### PR TITLE
Spinbox apply input method

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -26,6 +26,13 @@
 				Returns the [LineEdit] instance from this [SpinBox]. You can use it to access properties and methods of [LineEdit].
 			</description>
 		</method>
+		<method name="apply">
+			<return type="void">
+			</return>
+			<description>
+				Applies the current value of this [SpinBox].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="align" type="int" setter="set_align" getter="get_align" enum="LineEdit.Align" default="0">

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -259,6 +259,10 @@ bool SpinBox::is_editable() const {
 	return line_edit->is_editable();
 }
 
+void SpinBox::apply() {
+	_text_entered(line_edit->get_text());
+}
+
 void SpinBox::_bind_methods() {
 
 	//ClassDB::bind_method(D_METHOD("_value_changed"),&SpinBox::_value_changed);
@@ -272,6 +276,7 @@ void SpinBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_prefix"), &SpinBox::get_prefix);
 	ClassDB::bind_method(D_METHOD("set_editable", "editable"), &SpinBox::set_editable);
 	ClassDB::bind_method(D_METHOD("is_editable"), &SpinBox::is_editable);
+	ClassDB::bind_method(D_METHOD("apply"), &SpinBox::apply);
 	ClassDB::bind_method(D_METHOD("_line_edit_focus_exit"), &SpinBox::_line_edit_focus_exit);
 	ClassDB::bind_method(D_METHOD("get_line_edit"), &SpinBox::get_line_edit);
 	ClassDB::bind_method(D_METHOD("_line_edit_input"), &SpinBox::_line_edit_input);

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -88,6 +88,8 @@ public:
 	void set_prefix(const String &p_prefix);
 	String get_prefix() const;
 
+	void apply();
+
 	SpinBox();
 };
 


### PR DESCRIPTION
When entering numbers into a spinbox via keyboard the number doesn't get applied unless spinbox loses focus or the user presses return. But in some cases it would be preferable for the input to be applied without the need for any extra action by the user. This pull request solves that by adding an "apply()" method to spinbox, when called will apply the number written.

An example usecase is from an editor plugin project for a client I am working on where users need to enter a lot of numbers into spinboxes. We've had cases of confusion from users where values would get lost after saving because a person forgot to press enter or  click outside the spinbox.

This work has been kindly sponsored by IMVU.