### PR TITLE
Complete documentation of various classes

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -21,6 +21,7 @@
 			<return type="AudioStreamPlayback">
 			</return>
 			<description>
+				Returns the [AudioStreamPlayback] object associated with this [AudioStreamPlayer].
 			</description>
 		</method>
 		<method name="play">
@@ -69,6 +70,7 @@
 			The [AudioStream] object to be played.
 		</member>
 		<member name="stream_paused" type="bool" setter="set_stream_paused" getter="get_stream_paused" default="false">
+			If [code]true[/code], the playback is paused. You can resume it by setting [code]stream_paused[/code] to [code]false[/code].
 		</member>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
 			Volume of sound, in dB.

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -21,6 +21,7 @@
 			<return type="AudioStreamPlayback">
 			</return>
 			<description>
+				Returns the [AudioStreamPlayback] object associated with this [AudioStreamPlayer2D].
 			</description>
 		</method>
 		<method name="play">
@@ -75,6 +76,7 @@
 			The [AudioStream] object to be played.
 		</member>
 		<member name="stream_paused" type="bool" setter="set_stream_paused" getter="get_stream_paused" default="false">
+			If [code]true[/code], the playback is paused. You can resume it by setting [code]stream_paused[/code] to [code]false[/code].
 		</member>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
 			Base volume without dampening.

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -21,6 +21,7 @@
 			<return type="AudioStreamPlayback">
 			</return>
 			<description>
+				Returns the [AudioStreamPlayback] object associated with this [AudioStreamPlayer3D].
 			</description>
 		</method>
 		<method name="play">
@@ -99,6 +100,7 @@
 			The [AudioStream] object to be played.
 		</member>
 		<member name="stream_paused" type="bool" setter="set_stream_paused" getter="get_stream_paused" default="false">
+			If [code]true[/code], the playback is paused. You can resume it by setting [code]stream_paused[/code] to [code]false[/code].
 		</member>
 		<member name="unit_db" type="float" setter="set_unit_db" getter="get_unit_db" default="0.0">
 			Base sound level unaffected by dampening, in dB.

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -85,6 +85,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
+				Returns a global singleton with given [code]name[/code]. Often used for plugins, e.g. GodotPayments.
 			</description>
 		</method>
 		<method name="get_version_info" qualifiers="const">
@@ -116,6 +117,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
+				Returns [code]true[/code] if a singleton with given [code]name[/code] exists in global scope.
 			</description>
 		</method>
 		<method name="is_in_physics_frame" qualifiers="const">
@@ -134,6 +136,7 @@
 			The number of fixed iterations per second (for fixed process and physics).
 		</member>
 		<member name="physics_jitter_fix" type="float" setter="set_physics_jitter_fix" getter="get_physics_jitter_fix" default="0.5">
+			Controls how much physic ticks are synchronized  with real time. For 0 or less, the ticks are synchronized. Such values are recommended for network games, where clock synchronization matters. Higher values cause higher deviation of in-game clock and real clock, but allows to smooth out framerate jitters. The default value of 0.5 should be fine for most; values above 2 could cause the game to react to dropped frames with a noticeable delay and are not recommended.
 		</member>
 		<member name="target_fps" type="int" setter="set_target_fps" getter="get_target_fps" default="0">
 			The desired frames per second. If the hardware cannot keep up, this setting may not be respected. A value of 0 means no limit.

--- a/doc/classes/HScrollBar.xml
+++ b/doc/classes/HScrollBar.xml
@@ -4,7 +4,7 @@
 		Horizontal scroll bar.
 	</brief_description>
 	<description>
-		Horizontal scroll bar. See [ScrollBar]. This one goes from left (min) to right (max).
+		Horizontal version of [ScrollBar], which goes from left (min) to right (max).
 	</description>
 	<tutorials>
 	</tutorials>
@@ -14,22 +14,31 @@
 	</constants>
 	<theme_items>
 		<theme_item name="decrement" type="Texture">
+			Icon used as a button to scroll the [ScrollBar] left. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
 		<theme_item name="decrement_highlight" type="Texture">
+			Displayed when the mouse cursor hovers over the decrement button.
 		</theme_item>
 		<theme_item name="grabber" type="StyleBox">
+			Used as texture for the grabber, the draggable element representing current scroll.
 		</theme_item>
 		<theme_item name="grabber_highlight" type="StyleBox">
+			Used when the mouse hovers over the grabber.
 		</theme_item>
 		<theme_item name="grabber_pressed" type="StyleBox">
+			Used when the grabber is being dragged.
 		</theme_item>
 		<theme_item name="increment" type="Texture">
+			Icon used as a button to scroll the [ScrollBar] right. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
 		<theme_item name="increment_highlight" type="Texture">
+			Displayed when the mouse cursor hovers over the increment button.
 		</theme_item>
 		<theme_item name="scroll" type="StyleBox">
+			Used as background of this [ScrollBar].
 		</theme_item>
 		<theme_item name="scroll_focus" type="StyleBox">
+			Used as background when the [ScrollBar] has the GUI focus.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -96,7 +96,7 @@
 			The cursor's position inside the [LineEdit]. When set, the text may scroll to accommodate it.
 		</member>
 		<member name="clear_button_enabled" type="bool" setter="set_clear_button_enabled" getter="is_clear_button_enabled" default="false">
-			If [code]true[/code], the [LineEdit] will show a clear button if [code]text[/code] is not empty.
+			If [code]true[/code], the [LineEdit] will show a clear button if [code]text[/code] is not empty, which can be used to clear the text quickly.
 		</member>
 		<member name="context_menu_enabled" type="bool" setter="set_context_menu_enabled" getter="is_context_menu_enabled" default="true">
 			If [code]true[/code], the context menu will appear when right-clicked.
@@ -128,8 +128,10 @@
 			The character to use to mask secret input (defaults to "*"). Only a single character can be used as the secret character.
 		</member>
 		<member name="selecting_enabled" type="bool" setter="set_selecting_enabled" getter="is_selecting_enabled" default="true">
+			If [code]false[/code], it's impossible to select the text using mouse nor keyboard.
 		</member>
 		<member name="shortcut_keys_enabled" type="bool" setter="set_shortcut_keys_enabled" getter="is_shortcut_keys_enabled" default="true">
+			If [code]false[/code], using shortcuts will be disabled.
 		</member>
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
 			String value of the [LineEdit].
@@ -192,30 +194,43 @@
 	</constants>
 	<theme_items>
 		<theme_item name="clear" type="Texture">
+			Texture for the clear button. See [member clear_button_enabled].
 		</theme_item>
 		<theme_item name="clear_button_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+			Color used as default tint for the clear button.
 		</theme_item>
 		<theme_item name="clear_button_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+			Color used for the clear button when it's pressed.
 		</theme_item>
 		<theme_item name="cursor_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+			Color of the [LineEdit]'s visual cursor (caret).
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
+			Background used when [LineEdit] has GUI focus.
 		</theme_item>
 		<theme_item name="font" type="Font">
+			Font used for the text.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+			Default font color.
 		</theme_item>
 		<theme_item name="font_color_selected" type="Color" default="Color( 0, 0, 0, 1 )">
+			Font color for selected text (inside the selection rectangle).
 		</theme_item>
 		<theme_item name="font_color_uneditable" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
+			Font color when editing is disabled.
 		</theme_item>
 		<theme_item name="minimum_spaces" type="int" default="12">
+			Minimum horizontal space for the text (not counting the clear button and content margins).
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+			Default background for the [LineEdit].
 		</theme_item>
 		<theme_item name="read_only" type="StyleBox">
+			Background used when [LineEdit] is in read-only mode ([member editable] is set to [code]false[/code]).
 		</theme_item>
 		<theme_item name="selection_color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
+			Color of the selection rectangle.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -12,6 +12,7 @@
 	</methods>
 	<members>
 		<member name="custom_step" type="float" setter="set_custom_step" getter="get_custom_step" default="-1.0">
+			Overrides the step used when clicking increment and decrement buttons or when using arrow keys when the [ScrollBar] is focused.
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0" />
 		<member name="step" type="float" setter="set_step" getter="get_step" override="true" default="0.0" />

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VScrollBar" inherits="ScrollBar" category="Core" version="3.2">
 	<brief_description>
-		Vertical version of [ScrollBar], which goes from top (min) to bottom (max).
+		Vertical scroll bar.
 	</brief_description>
 	<description>
+		Vertical version of [ScrollBar], which goes from top (min) to bottom (max).
 	</description>
 	<tutorials>
 	</tutorials>
@@ -17,22 +18,31 @@
 	</constants>
 	<theme_items>
 		<theme_item name="decrement" type="Texture">
+			Icon used as a button to scroll the [ScrollBar] up. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
 		<theme_item name="decrement_highlight" type="Texture">
+			Displayed when the mouse cursor hovers over the decrement button.
 		</theme_item>
 		<theme_item name="grabber" type="StyleBox">
+			Used as texture for the grabber, the draggable element representing current scroll.
 		</theme_item>
 		<theme_item name="grabber_highlight" type="StyleBox">
+			Used when the mouse hovers over the grabber.
 		</theme_item>
 		<theme_item name="grabber_pressed" type="StyleBox">
+			Used when the grabber is being dragged.
 		</theme_item>
 		<theme_item name="increment" type="Texture">
+			Icon used as a button to scroll the [ScrollBar] down. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
 		<theme_item name="increment_highlight" type="Texture">
+			Displayed when the mouse cursor hovers over the increment button.
 		</theme_item>
 		<theme_item name="scroll" type="StyleBox">
+			Used as background of this [ScrollBar].
 		</theme_item>
 		<theme_item name="scroll_focus" type="StyleBox">
+			Used as background when the [ScrollBar] has the GUI focus.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/VisibilityEnabler.xml
+++ b/doc/classes/VisibilityEnabler.xml
@@ -15,6 +15,7 @@
 			<argument index="0" name="enabler" type="int" enum="VisibilityEnabler.Enabler">
 			</argument>
 			<description>
+				Returns whether the enabler identified by given [enum Enabler] constant is active. 
 			</description>
 		</method>
 		<method name="set_enabler">
@@ -25,6 +26,7 @@
 			<argument index="1" name="enabled" type="bool">
 			</argument>
 			<description>
+				Sets active state of the enabler identified by given [enum Enabler] constant.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/VisibilityEnabler2D.xml
+++ b/doc/classes/VisibilityEnabler2D.xml
@@ -15,6 +15,7 @@
 			<argument index="0" name="enabler" type="int" enum="VisibilityEnabler2D.Enabler">
 			</argument>
 			<description>
+				Returns whether the enabler identified by given [enum Enabler] constant is active. 
 			</description>
 		</method>
 		<method name="set_enabler">
@@ -25,6 +26,7 @@
 			<argument index="1" name="enabled" type="bool">
 			</argument>
 			<description>
+				Sets active state of the enabler identified by given [enum Enabler] constant.
 			</description>
 		</method>
 	</methods>
@@ -65,6 +67,7 @@
 			This enabler will stop the parent's _physics_process function.
 		</constant>
 		<constant name="ENABLER_PAUSE_ANIMATED_SPRITES" value="5" enum="Enabler">
+			This enabler will stop [AnimatedSprite] nodes animations.
 		</constant>
 		<constant name="ENABLER_MAX" value="6" enum="Enabler">
 			Represents the size of the [enum Enabler] enum.

--- a/modules/stb_vorbis/doc_classes/AudioStreamOGGVorbis.xml
+++ b/modules/stb_vorbis/doc_classes/AudioStreamOGGVorbis.xml
@@ -15,8 +15,10 @@
 			Contains the audio data in bytes.
 		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="false">
+			If [code]true[/code], the stream will automatically loop when it reaches the end.
 		</member>
 		<member name="loop_offset" type="float" setter="set_loop_offset" getter="get_loop_offset" default="0.0">
+			Time in seconds at which the stream starts after being looped.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
This PR completes documentation for some random classes that were close to completion according to the 3.2 Docs Sprint stats. However LineEdit and ScrollBars were a trap, because they had documentable `theme_items` that weren't counted for the sprint :/

There are more classes like this, so I might make few more batch PRs (unless it's better to make one, then consider this WIP).