### PR TITLE
Update minimum size on Label::set_autowrap

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -35,9 +35,17 @@
 
 void Label::set_autowrap(bool p_autowrap) {
 
+	if (autowrap == p_autowrap) {
+		return;
+	}
+
 	autowrap = p_autowrap;
 	word_cache_dirty = true;
 	update();
+
+	if (clip) {
+		minimum_size_changed();
+	}
 }
 bool Label::has_autowrap() const {
 


### PR DESCRIPTION
When `clip_text` is true, the minimum height is one line if `autowrap` is true, or one pixel otherwise.

Before this fix, checking "Autowrap" in the Inspector may not update the minimum size. I have to switch the scene to force the update.
![demo](https://user-images.githubusercontent.com/372476/72132787-cdecc000-33ba-11ea-8c65-1a3d8744aee1.gif)

p.s. As shown in the GIF, unchecking "Autowrap" updates the minimum size correctly. This is because it's in the `regenerate_word_cache` function: the update is explicit ignored when both `clip_text` and `autowrap` is true.
https://github.com/godotengine/godot/blob/0d2993659b1a6b4eaafcae55dde116e297170f3a/scene/gui/label.cpp#L513-L516

---

It may be better to replace the `changed` variable with a return-on-not-changed. But I'm not sure if anyone relies on this behavior to make the word cache dirty.