### PR TITLE
Fixed `move_and_slide` `stop_on_slope`

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1211,6 +1211,8 @@ bool KinematicBody2D::move_and_collide(const Vector2 &p_motion, bool p_infinite_
 
 //so, if you pass 45 as limit, avoid numerical precision errors when angle is 45.
 #define FLOOR_ANGLE_THRESHOLD 0.01
+// -cos(10 deg)
+#define COS_DOWN_DIRECTION_THRESHOLD -0.98480774002
 
 Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_up_direction, bool p_stop_on_slope, int p_max_slides, float p_floor_max_angle, bool p_infinite_inertia) {
 
@@ -1275,7 +1277,8 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 						floor_velocity = collision.collider_vel;
 
 						if (p_stop_on_slope) {
-							if ((body_velocity_normal + p_up_direction).length() < 0.01 && collision.travel.length() < 1) {
+							// We are on slope, if the body velocity is quite toward the down, stop sliding.
+							if (body_velocity_normal.dot(p_up_direction) < COS_DOWN_DIRECTION_THRESHOLD && collision.travel.length() < 1) {
 								Transform2D gt = get_global_transform();
 								gt.elements[2] -= collision.travel.slide(p_up_direction);
 								set_global_transform(gt);

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1139,6 +1139,8 @@ bool KinematicBody::move_and_collide(const Vector3 &p_motion, bool p_infinite_in
 
 //so, if you pass 45 as limit, avoid numerical precision errors when angle is 45.
 #define FLOOR_ANGLE_THRESHOLD 0.01
+// -cos(10 deg)
+#define COS_DOWN_DIRECTION_THRESHOLD -0.98480774002
 
 Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Vector3 &p_up_direction, bool p_stop_on_slope, int p_max_slides, float p_floor_max_angle, bool p_infinite_inertia) {
 
@@ -1200,7 +1202,8 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 						floor_velocity = collision.collider_vel;
 
 						if (p_stop_on_slope) {
-							if ((body_velocity_normal + p_up_direction).length() < 0.01 && collision.travel.length() < 1) {
+							// We are on slope, if the body velocity is quite toward the down, stop sliding.
+							if (body_velocity_normal.dot(p_up_direction) < COS_DOWN_DIRECTION_THRESHOLD && collision.travel.length() < 1) {
 								Transform gt = get_global_transform();
 								gt.origin -= collision.travel.slide(p_up_direction);
 								set_global_transform(gt);


### PR DESCRIPTION
After the `move_and_slide` behaviour reversion (in #33864) the old stop on slope check is not more valid making the `stop_on_slope` not working. This PR fix it for both 2d and 3d.

This work has been kindly sponsored by IMVU.