### PR TITLE
[macOS] Fix loading PCK from the .app bundle resources.

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -343,6 +343,12 @@ String OS::get_cache_path() const {
 	return ".";
 }
 
+// Path to macOS .app bundle resources
+String OS::get_bundle_resource_dir() const {
+
+	return ".";
+};
+
 // OS specific path for user://
 String OS::get_user_data_dir() const {
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -411,6 +411,7 @@ public:
 	virtual String get_data_path() const;
 	virtual String get_config_path() const;
 	virtual String get_cache_path() const;
+	virtual String get_bundle_resource_dir() const;
 
 	virtual String get_user_data_dir() const;
 	virtual String get_resource_dir() const;

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -383,8 +383,16 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 			}
 		}
 
-		// Attempt with PCK bundled into executable
+#ifdef OSX_ENABLED
+		// Attempt to load PCK from macOS .app bundle resources
+		if (!found) {
+			if (_load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().plus_file(exec_basename + ".pck"))) {
+				found = true;
+			}
+		}
+#endif
 
+		// Attempt with PCK bundled into executable
 		if (!found) {
 			if (_load_resource_pack(exec_path)) {
 				found = true;

--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -45,35 +45,6 @@ int main(int argc, char **argv) {
 		printf("%i: %s\n", i, argv[i]);
 	};
 
-	if (argc >= 1 && argv[0][0] == '/') {
-		//potentially launched from finder
-		int len = strlen(argv[0]);
-		while (len--) {
-			if (argv[0][len] == '/') break;
-		}
-		if (len >= 0) {
-			char *path = (char *)malloc(len + 1);
-			memcpy(path, argv[0], len);
-			path[len] = 0;
-
-			char *pathinfo = (char *)malloc(strlen(path) + strlen("/../Info.plist") + 1);
-			//in real code you would check for errors in malloc here
-			strcpy(pathinfo, path);
-			strcat(pathinfo, "/../Info.plist");
-
-			FILE *f = fopen(pathinfo, "rb");
-			if (f) {
-				//running from app bundle, as Info.plist was found
-				fclose(f);
-				chdir(path);
-				chdir("../Resources"); //data.pck, or just the files are here
-			}
-
-			free(path);
-			free(pathinfo);
-		}
-	}
-
 #ifdef DEBUG_ENABLED
 	// lets report the path we made current after all that
 	char cwd[4096];

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -223,6 +223,7 @@ public:
 	virtual String get_config_path() const;
 	virtual String get_data_path() const;
 	virtual String get_cache_path() const;
+	virtual String get_bundle_resource_dir() const;
 	virtual String get_godot_dir_name() const;
 
 	virtual String get_system_dir(SystemDir p_dir) const;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -2111,6 +2111,19 @@ String OS_OSX::get_cache_path() const {
 	}
 }
 
+String OS_OSX::get_bundle_resource_dir() const {
+
+	NSBundle *main = [NSBundle mainBundle];
+	NSString *resourcePath = [main resourcePath];
+
+	char *utfs = strdup([resourcePath UTF8String]);
+	String ret;
+	ret.parse_utf8(utfs);
+	free(utfs);
+
+	return ret;
+}
+
 // Get properly capitalized engine name for system paths
 String OS_OSX::get_godot_dir_name() const {
 


### PR DESCRIPTION
Uses `NSBundle` API to find bundle resources instead of hardcoded `../Resources` and changing working directory.

Fixes #15930, fixes #28406, partially fixes #34517.