### PR TITLE
Add Input `is_anything_pressed` method

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -90,6 +90,7 @@ Input::MouseMode Input::get_mouse_mode() const {
 }
 
 void Input::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_anything_pressed"), &Input::is_anything_pressed);
 	ClassDB::bind_method(D_METHOD("is_key_pressed", "keycode"), &Input::is_key_pressed);
 	ClassDB::bind_method(D_METHOD("is_physical_key_pressed", "keycode"), &Input::is_physical_key_pressed);
 	ClassDB::bind_method(D_METHOD("is_mouse_button_pressed", "button"), &Input::is_mouse_button_pressed);
@@ -216,6 +217,19 @@ Input::VelocityTrack::VelocityTrack() {
 	min_ref_frame = 0.1;
 	max_ref_frame = 0.3;
 	reset();
+}
+
+bool Input::is_anything_pressed() const {
+	_THREAD_SAFE_METHOD_
+
+	for (Map<StringName, Input::Action>::Element *E = action_state.front(); E; E = E->next()) {
+		if (E->get().pressed) {
+			return true;
+		}
+	}
+	return !keys_pressed.is_empty() ||
+			!joy_buttons_pressed.is_empty() ||
+			mouse_button_mask > MouseButton::NONE;
 }
 
 bool Input::is_key_pressed(Key p_keycode) const {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -242,6 +242,7 @@ public:
 
 	static Input *get_singleton();
 
+	bool is_anything_pressed() const;
 	bool is_key_pressed(Key p_keycode) const;
 	bool is_physical_key_pressed(Key p_keycode) const;
 	bool is_mouse_button_pressed(MouseButton p_button) const;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -209,6 +209,12 @@
 				[b]Note:[/b] Due to keyboard ghosting, [method is_action_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
 			</description>
 		</method>
+		<method name="is_anything_pressed" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if any action, key, joypad button, or mouse button is being pressed. This will also return [code]true[/code] if any action is simulated via code by calling [method action_press].
+			</description>
+		</method>
 		<method name="is_joy_button_pressed" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="device" type="int" />


### PR DESCRIPTION
Your typical "Press any key" use case using the `Input` singleton, can also be used to conveniently detect and switch various `idle` states, such as character switching to `bored` state if you wish so. 🙂 

```gdscript
func _physics_process(_delta):
	if Input.is_anything_pressed():
		$message.text = "Thanks!"
```

There's another way for doing so using `_input`:
```gdscript
func _input(event):
	if event.is_pressed():
		$message.text = "Thanks!"
```

But it might not be possible to achieve in the future according to:

https://github.com/godotengine/godot/blob/02cd1442227127604549159d66b9bfc68a193dd3/core/os/input_event.h#L191-L194

In **any** case, I'm here to tell that it might be a good idea to leave `InputEvent.is_pressed()` as is.

### Test project
[press-any-key.zip](https://github.com/godotengine/godot/files/4049371/press-any-key.zip)
