### PR TITLE
Improvements for GDScript LSP server

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -36,10 +36,15 @@
 
 GDScriptLanguageServer::GDScriptLanguageServer() {
 	thread = NULL;
-	thread_exit = false;
-	_EDITOR_DEF("network/language_server/remote_port", 6008);
+	thread_running = false;
+	started = false;
+
+	use_thread = false;
+	port = 6008;
+	_EDITOR_DEF("network/language_server/remote_port", port);
 	_EDITOR_DEF("network/language_server/enable_smart_resolve", true);
 	_EDITOR_DEF("network/language_server/show_native_symbols_in_editor", false);
+	_EDITOR_DEF("network/language_server/use_thread", use_thread);
 }
 
 void GDScriptLanguageServer::_notification(int p_what) {
@@ -51,12 +56,25 @@ void GDScriptLanguageServer::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE:
 			stop();
 			break;
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			if (started && !use_thread) {
+				protocol.poll();
+			}
+		} break;
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			int port = (int)_EDITOR_GET("network/language_server/remote_port");
+			bool use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
+			if (port != this->port || use_thread != this->use_thread) {
+				this->stop();
+				this->start();
+			}
+		} break;
 	}
 }
 
 void GDScriptLanguageServer::thread_main(void *p_userdata) {
 	GDScriptLanguageServer *self = static_cast<GDScriptLanguageServer *>(p_userdata);
-	while (!self->thread_exit) {
+	while (self->thread_running) {
 		// Poll 20 times per second
 		self->protocol.poll();
 		OS::get_singleton()->delay_usec(50000);
@@ -64,22 +82,30 @@ void GDScriptLanguageServer::thread_main(void *p_userdata) {
 }
 
 void GDScriptLanguageServer::start() {
-	int port = (int)_EDITOR_GET("network/language_server/remote_port");
+	port = (int)_EDITOR_GET("network/language_server/remote_port");
+	use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
 	if (protocol.start(port) == OK) {
 		EditorNode::get_log()->add_message("--- GDScript language server started ---", EditorLog::MSG_TYPE_EDITOR);
-		ERR_FAIL_COND(thread != NULL || thread_exit);
-		thread_exit = false;
-		thread = Thread::create(GDScriptLanguageServer::thread_main, this);
+		if (use_thread) {
+			ERR_FAIL_COND(thread != NULL);
+			thread_running = true;
+			thread = Thread::create(GDScriptLanguageServer::thread_main, this);
+		}
+		set_process_internal(!use_thread);
+		started = true;
 	}
 }
 
 void GDScriptLanguageServer::stop() {
-	ERR_FAIL_COND(NULL == thread || thread_exit);
-	thread_exit = true;
-	Thread::wait_to_finish(thread);
-	memdelete(thread);
-	thread = NULL;
+	if (use_thread) {
+		ERR_FAIL_COND(NULL == thread);
+		thread_running = false;
+		Thread::wait_to_finish(thread);
+		memdelete(thread);
+		thread = NULL;
+	}
 	protocol.stop();
+	started = false;
 	EditorNode::get_log()->add_message("--- GDScript language server stopped ---", EditorLog::MSG_TYPE_EDITOR);
 }
 

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -41,7 +41,10 @@ class GDScriptLanguageServer : public EditorPlugin {
 	GDScriptLanguageProtocol protocol;
 
 	Thread *thread;
-	bool thread_exit;
+	bool thread_running;
+	bool started;
+	bool use_thread;
+	int port;
 	static void thread_main(void *p_userdata);
 
 private:

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -330,8 +330,6 @@ struct CompletionOptions {
 		triggerCharacters.push_back("$");
 		triggerCharacters.push_back("'");
 		triggerCharacters.push_back("\"");
-		triggerCharacters.push_back("(");
-		triggerCharacters.push_back(",");
 	}
 
 	Dictionary to_json() const {


### PR DESCRIPTION
Allow enable/disable threading for LSP server.
Restart LSP server when configurations change without restart the editor.
Remove completion triggers for ',' and '(' which may conflict with sinature helper.