### PR TITLE
Issue #34161: Keep loaded global classes reference in GDScriptLanguage

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1945,6 +1945,10 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 	return String();
 }
 
+void GDScriptLanguage::add_loaded_global_class(Ref<GDScript> global_class) {
+	loaded_global_classes.push_back(global_class);
+}
+
 #ifdef DEBUG_ENABLED
 String GDScriptWarning::get_message() const {
 
@@ -2166,6 +2170,8 @@ GDScriptLanguage::GDScriptLanguage() {
 
 GDScriptLanguage::~GDScriptLanguage() {
 
+	// Loaded global classes depend on GDScriptLanguage for their destruction
+	loaded_global_classes.clear();
 	if (lock) {
 		memdelete(lock);
 		lock = NULL;
@@ -2206,6 +2212,9 @@ RES ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_ori
 	if (r_error)
 		*r_error = OK;
 
+	if (ScriptServer::is_global_class(scriptres->get_script_class_name())) {
+		GDScriptLanguage::get_singleton()->add_loaded_global_class(scriptres);
+	}
 	return scriptres;
 }
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1945,8 +1945,8 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 	return String();
 }
 
-void GDScriptLanguage::add_loaded_global_class(Ref<GDScript> global_class) {
-	loaded_global_classes.push_back(global_class);
+void GDScriptLanguage::add_loaded_global_class(Ref<GDScript> p_global_class) {
+	loaded_global_classes.push_back(p_global_class);
 }
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -354,6 +354,8 @@ class GDScriptLanguage : public ScriptLanguage {
 	bool profiling;
 	uint64_t script_frame_time;
 
+	Vector<Ref<GDScript> > loaded_global_classes;
+
 public:
 	int calls;
 
@@ -504,6 +506,7 @@ public:
 
 	virtual bool handles_global_class_type(const String &p_type) const;
 	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL, String *r_icon_path = NULL) const;
+	void add_loaded_global_class(Ref<GDScript> global_class);
 
 	GDScriptLanguage();
 	~GDScriptLanguage();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -506,7 +506,7 @@ public:
 
 	virtual bool handles_global_class_type(const String &p_type) const;
 	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL, String *r_icon_path = NULL) const;
-	void add_loaded_global_class(Ref<GDScript> global_class);
+	void add_loaded_global_class(Ref<GDScript> p_global_class);
 
 	GDScriptLanguage();
 	~GDScriptLanguage();


### PR DESCRIPTION
This change adds a reference to any global class as soon as its loaded.
This removes a case where a global class was loaded more than once.
Specifically fixes an issue where referencing a subclass of a global class does not reference the global class, causing it to be released.
Then, any new reference to the same subclass is different from the original reference, causing problems like #34161.

To be considered:
There might need to be a case where the loaded global classes should be cleared.