### PR TITLE
Increase the size of the item list editor popup

### DIFF
--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -302,7 +302,7 @@ void ItemListEditor::_delete_pressed() {
 
 void ItemListEditor::_edit_items() {
 
-	dialog->popup_centered(Vector2(300, 400) * EDSCALE);
+	dialog->popup_centered_clamped(Vector2(425, 1200) * EDSCALE, 0.8);
 }
 
 void ItemListEditor::edit(Node *p_item_list) {


### PR DESCRIPTION
This makes it easier to edit large amounts of items.

This partially addresses https://github.com/godotengine/godot-proposals/issues/368.

## Preview

![ItemList editor on 2560×1440 display](https://user-images.githubusercontent.com/180032/72222708-32994d80-3568-11ea-88a3-cb72a583285e.png)