### PR TITLE
Fix generation of irradiance map

### DIFF
--- a/drivers/gles3/shaders/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/cubemap_filter.glsl
@@ -309,7 +309,7 @@ void main() {
 			}
 			st /= vec2(M_PI * 2.0, M_PI);
 
-			irradiance += texture(source_panorama, st, source_mip_level).rgb * cos(theta) * sin(theta);
+			irradiance += textureLod(source_panorama, st, source_mip_level).rgb * cos(theta) * sin(theta);
 			num_samples++;
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/34483

Using mip maps was causing the texture read to read from the top of the sky when sampling the very bottom of the sky. This resulted in a single off-colored pixel at the very bottom of the irradiance map. This caused issues when sampling at exactly (0, -1, 0).

**Before**
_Scene_
![broken_scene](https://user-images.githubusercontent.com/16521339/72226902-42566900-354b-11ea-95cb-a87e3ef39e11.png)
_Irradiance map_
![broken_irradiance_map](https://user-images.githubusercontent.com/16521339/72226906-484c4a00-354b-11ea-82b1-f9a3290e740b.png)

**After**

_Scene_
![fixed_scene](https://user-images.githubusercontent.com/16521339/72226907-4b473a80-354b-11ea-9f36-8c3a28fcbf6a.png)

_Irradiance map_
![fixes_irradiance_map](https://user-images.githubusercontent.com/16521339/72226910-500bee80-354b-11ea-84f3-b061195bc4c0.png)

@akien-mga I have labelled this as high priority as it will actually affect a lot of projects, I'm guessing the reason it was so hard to spot is the combination of driver quirks and the fact that not many people look at their scenes from directly underneath.