### PR TITLE
Make texture_debug_usage thread safe

### DIFF
--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -101,7 +101,7 @@ public:
 	FUNC2(texture_set_path, RID, const String &)
 	FUNC1RC(String, texture_get_path, RID)
 	FUNC1(texture_set_shrink_all_x2_on_set_data, bool)
-	FUNC1(texture_debug_usage, List<TextureInfo> *)
+	FUNC1S(texture_debug_usage, List<TextureInfo> *)
 
 	FUNC1(textures_keep_original, bool)
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/28533

I guess the "S" makes it thread safe. I'll be honest, I am just guessing that from reading https://github.com/godotengine/godot/blob/a7f49ac9a107820a62677ee3fb49d38982a25165/servers/server_wrap_mt_common.h