### PR TITLE
Fixes the New Window option in macOS dock menu

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5079,6 +5079,7 @@ void EditorNode::_global_menu_action(const Variant &p_id, const Variant &p_meta)
 	if (id == GLOBAL_NEW_WINDOW) {
 		if (OS::get_singleton()->get_main_loop()) {
 			List<String> args;
+			args.push_back("-e");
 			String exec = OS::get_singleton()->get_executable_path();
 
 			OS::ProcessID pid = 0;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1981,6 +1981,7 @@ void ProjectManager::_global_menu_action(const Variant &p_id, const Variant &p_m
 	int id = (int)p_id;
 	if (id == ProjectList::GLOBAL_NEW_WINDOW) {
 		List<String> args;
+		args.push_back("-p");
 		String exec = OS::get_singleton()->get_executable_path();
 
 		OS::ProcessID pid = 0;


### PR DESCRIPTION
Specifies the corresponding command line option when opening the new window.

Before this fix, choosing dock menu's "New Window"...

* in the editor:
    * Expected: Opens a new editor instance
    * Actual: Runs the current project
* in the project manager:
    * Expected: Opens a new project manager instance
    * Actual: Runs the project if the current working directory is a project directory (e.g. `/path/to/godot -p --path /path/to/project`)