### PR TITLE
Use MOUSE_FILTER_PASS for all containers

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -856,7 +856,6 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	HBoxContainer *audioprev_hbc = memnew(HBoxContainer);
 	audioprev_hbc->set_v_size_flags(SIZE_EXPAND_FILL);
 	audioprev_hbc->set_h_size_flags(SIZE_EXPAND_FILL);
-	audioprev_hbc->set_mouse_filter(MOUSE_FILTER_PASS);
 	audio_value_preview_box->add_child(audioprev_hbc);
 
 	audio_value_preview_label = memnew(Label);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -139,8 +139,6 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 
 	set_custom_minimum_size(Size2(250, 100) * EDSCALE);
 	set_h_size_flags(SIZE_EXPAND_FILL);
-
-	set_mouse_filter(MOUSE_FILTER_PASS);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1452,7 +1450,6 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	library_scroll->add_child(library_vb_border);
 	library_vb_border->add_style_override("panel", border2);
 	library_vb_border->set_h_size_flags(SIZE_EXPAND_FILL);
-	library_vb_border->set_mouse_filter(MOUSE_FILTER_PASS);
 
 	library_vb = memnew(VBoxContainer);
 	library_vb->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -289,8 +289,6 @@ BoxContainer::BoxContainer(bool p_vertical) {
 
 	vertical = p_vertical;
 	align = ALIGN_BEGIN;
-	//set_ignore_mouse(true);
-	set_mouse_filter(MOUSE_FILTER_PASS);
 }
 
 void BoxContainer::_bind_methods() {

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -197,4 +197,6 @@ void Container::_bind_methods() {
 Container::Container() {
 
 	pending_sort = false;
+	// All containers should let mouse events pass by default.
+	set_mouse_filter(MOUSE_FILTER_PASS);
 }

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -254,7 +254,6 @@ void GraphEdit::add_child_notify(Node *p_child) {
 		gn->connect("raise_request", this, "_graph_node_raised", varray(gn));
 		gn->connect("item_rect_changed", connections_layer, "update");
 		_graph_node_moved(gn);
-		gn->set_mouse_filter(MOUSE_FILTER_PASS);
 	}
 }
 
@@ -1335,7 +1334,6 @@ GraphEdit::GraphEdit() {
 	top_layer->set_mouse_filter(MOUSE_FILTER_PASS);
 	top_layer->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	top_layer->connect("draw", this, "_top_layer_draw");
-	top_layer->set_mouse_filter(MOUSE_FILTER_PASS);
 	top_layer->connect("gui_input", this, "_top_layer_input");
 
 	connections_layer = memnew(Control);

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -247,7 +247,5 @@ Size2 GridContainer::get_minimum_size() const {
 }
 
 GridContainer::GridContainer() {
-
-	set_mouse_filter(MOUSE_FILTER_PASS);
 	columns = 1;
 }

--- a/scene/gui/panel.cpp
+++ b/scene/gui/panel.cpp
@@ -42,7 +42,7 @@ void Panel::_notification(int p_what) {
 }
 
 Panel::Panel() {
-
+	// Has visible stylebox, so stop by default.
 	set_mouse_filter(MOUSE_FILTER_STOP);
 }
 

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -103,4 +103,6 @@ void PanelContainer::_notification(int p_what) {
 }
 
 PanelContainer::PanelContainer() {
+	// Has visible stylebox, so stop by default.
+	set_mouse_filter(MOUSE_FILTER_STOP);
 }


### PR DESCRIPTION
Containers are meant to forward mouse input to their the Controls
they contain.

Fixes #34933.

---

Putting this up for discussion, I haven't thoroughly tested yet.

Apart from `GridContainer` and `BoxContainer`-derived classes which already defaulted to `PASS`, this changes the behavior for `CenterContainer`, `MarginContainer`, `PanelContainer`, `ScrollContainer`, `SplitContainer`, `TabContainer`, `ViewportContainer` and the base `Container`. Might have unforeseen consequences if nobody noticed this discrepancy in 6 years.