### PR TITLE
Control/Light2D: Preventing setting 0 as scale as for Node2D

### DIFF
--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -189,6 +189,10 @@ float Light2D::get_energy() const {
 void Light2D::set_texture_scale(float p_scale) {
 
 	_scale = p_scale;
+	// Avoid having 0 scale values, can lead to errors in physics and rendering.
+	if (_scale == 0) {
+		_scale = CMP_EPSILON;
+	}
 	VS::get_singleton()->canvas_light_set_scale(canvas_light, _scale);
 	item_rect_changed();
 }

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -173,6 +173,7 @@ void Node2D::set_scale(const Size2 &p_scale) {
 	if (_xform_dirty)
 		((Node2D *)this)->_update_xform_values();
 	_scale = p_scale;
+	// Avoid having 0 scale values, can lead to errors in physics and rendering.
 	if (_scale.x == 0)
 		_scale.x = CMP_EPSILON;
 	if (_scale.y == 0)

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2682,6 +2682,11 @@ Vector2 Control::get_pivot_offset() const {
 void Control::set_scale(const Vector2 &p_scale) {
 
 	data.scale = p_scale;
+	// Avoid having 0 scale values, can lead to errors in physics and rendering.
+	if (data.scale.x == 0)
+		data.scale.x = CMP_EPSILON;
+	if (data.scale.y == 0)
+		data.scale.y = CMP_EPSILON;
 	update();
 	_notify_transform();
 }


### PR DESCRIPTION
Triggers errors in `Transform2D::affine_invert()`.

Fixes #26510.
Fixes https://github.com/godotengine/godot/issues/24997#issuecomment-457951639.