### PR TITLE
Type match on assignment only if operators have type

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8210,12 +8210,10 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 							_add_warning(GDScriptWarning::FUNCTION_MAY_YIELD, op->line, _find_function_name(static_cast<OperatorNode *>(op->arguments[1])));
 						}
 
-						bool type_match = check_types;
 #endif // DEBUG_ENABLED
+						bool type_match = lh_type.has_type && rh_type.has_type;
 						if (check_types && !_is_type_compatible(lh_type, rh_type)) {
-#ifdef DEBUG_ENABLED
 							type_match = false;
-#endif // DEBUG_ENABLED
 
 							// Try supertype test
 							if (_is_type_compatible(rh_type, lh_type)) {
@@ -8247,9 +8245,7 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 
 									op->arguments.write[1] = convert_call;
 
-#ifdef DEBUG_ENABLED
 									type_match = true; // Since we are converting, the type is matching
-#endif // DEBUG_ENABLED
 								}
 #ifdef DEBUG_ENABLED
 								if (lh_type.builtin_type == Variant::INT && rh_type.builtin_type == Variant::REAL) {
@@ -8262,10 +8258,8 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 						if (!rh_type.has_type && (op->op != OperatorNode::OP_ASSIGN || lh_type.has_type || op->arguments[0]->type == Node::TYPE_OPERATOR)) {
 							_mark_line_as_unsafe(op->line);
 						}
-						op->datatype.has_type = type_match;
-#else
-						op->datatype.has_type = false;
 #endif // DEBUG_ENABLED
+						op->datatype.has_type = type_match;
 					} break;
 					case OperatorNode::OP_CALL:
 					case OperatorNode::OP_PARENT_CALL: {


### PR DESCRIPTION
This ensures that a value without type won't be wrongly assigned to a typed variable when the types mismatch.

Follow up of #34333.
Fix #35031