### PR TITLE
Animation editor: Set resource name when duplicating

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -997,9 +997,9 @@ void AnimationPlayerEditor::_animation_duplicate() {
 
 	String new_name = current;
 	while (player->has_animation(new_name)) {
-
 		new_name = new_name + " (copy)";
 	}
+	new_anim->set_name(new_name);
 
 	undo_redo->create_action(TTR("Duplicate Animation"));
 	undo_redo->add_do_method(player, "add_animation", new_name, new_anim);


### PR DESCRIPTION
Fixes #25156.