### PR TITLE
Object: Remove error on disconnect of locked signals

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1185,13 +1185,11 @@ Error Object::emit_signal(const StringName &p_name, const Variant **p_args, int 
 
 		const Connection &c = slot_map.getv(i).conn;
 
-		Object *target;
-#ifdef DEBUG_ENABLED
-		target = ObjectDB::get_instance(slot_map.getk(i)._id);
-		ERR_CONTINUE(!target);
-#else
-		target = c.target;
-#endif
+		Object *target = ObjectDB::get_instance(slot_map.getk(i)._id);
+		if (!target) {
+			// Target might have been deleted during signal callback, this is expected and OK.
+			continue;
+		}
 
 		const Variant **args = p_args;
 		int argc = p_argcount;

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1519,10 +1519,6 @@ void Object::_disconnect(const StringName &p_signal, Object *p_to_object, const 
 	Signal *s = signal_map.getptr(p_signal);
 	ERR_FAIL_COND_MSG(!s, vformat("Nonexistent signal '%s' in %s.", p_signal, to_string()));
 
-	ERR_FAIL_COND_MSG(s->lock > 0,
-			vformat("Attempt to disconnect %s signal '%s' while in emission callback '%s' (in target %s). Use CONNECT_DEFERRED (to be able to safely disconnect) or CONNECT_ONESHOT (for automatic disconnection) as connection flags.",
-					to_string(), p_signal, p_to_method, p_to_object->to_string()));
-
 	Signal::Target target(p_to_object->get_instance_id(), p_to_method);
 
 	ERR_FAIL_COND_MSG(!s->slot_map.has(target), "Disconnecting nonexistent signal '" + p_signal + "', slot: " + itos(target._id) + ":" + target.method + ".");


### PR DESCRIPTION
According to https://github.com/godotengine/godot/commit/22637beb2ed625c3e43ab75ab5865b57d7470948#commitcomment-36651823
and as confirmed by @reduz, this seems not to be necessary now that we
copy-on-write.

This triggered freeze scenarios in cases where a node would be deleted
while being used as a target in a signal emission.

Fixes #34650.
Fixes #34769.

Now those two errors go back to reporting:
```
ERROR: emit_signal: Condition ' !target ' is true. Continuing..:
   At: core/object.cpp:1191.
```

CC @timothyqiu 