### PR TITLE
Exposed physics frame count and idle frame count

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -3024,6 +3024,16 @@ float _Engine::get_frames_per_second() const {
 	return Engine::get_singleton()->get_frames_per_second();
 }
 
+uint64_t _Engine::get_physics_frames() const {
+
+	return Engine::get_singleton()->get_physics_frames();
+}
+
+uint64_t _Engine::get_idle_frames() const {
+
+	return Engine::get_singleton()->get_idle_frames();
+}
+
 void _Engine::set_time_scale(float p_scale) {
 	Engine::get_singleton()->set_time_scale(p_scale);
 }
@@ -3108,6 +3118,8 @@ void _Engine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_frames_drawn"), &_Engine::get_frames_drawn);
 	ClassDB::bind_method(D_METHOD("get_frames_per_second"), &_Engine::get_frames_per_second);
+	ClassDB::bind_method(D_METHOD("get_physics_frames"), &_Engine::get_physics_frames);
+	ClassDB::bind_method(D_METHOD("get_idle_frames"), &_Engine::get_idle_frames);
 
 	ClassDB::bind_method(D_METHOD("get_main_loop"), &_Engine::get_main_loop);
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -747,6 +747,8 @@ public:
 	int get_target_fps() const;
 
 	float get_frames_per_second() const;
+	uint64_t get_physics_frames() const;
+	uint64_t get_idle_frames() const;
 
 	int get_frames_drawn();
 


### PR DESCRIPTION
Exposed:
```cpp
uint64_t get_physics_frames() const;
uint64_t get_idle_frames() const;
```