### PR TITLE
Fixes custom styles for hover_pressed on CheckButton and CheckBox (v2.0)

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -93,14 +93,13 @@ void Button::_notification(int p_what) {
 				} break;
 				case DRAW_HOVER_PRESSED: {
 
-					if (has_stylebox("hover_pressed") && has_stylebox_override("hover_pressed")) {
+					// Edge case for CheckButton and CheckBox.
+					if (has_stylebox("hover_pressed")) {
 						style = get_stylebox("hover_pressed");
 						if (!flat)
 							style->draw(ci, Rect2(Point2(0, 0), size));
 						if (has_color("font_color_hover_pressed"))
 							color = get_color("font_color_hover_pressed");
-						else
-							color = get_color("font_color");
 						if (has_color("icon_color_hover_pressed"))
 							color_icon = get_color("icon_color_hover_pressed");
 


### PR DESCRIPTION
supersedes #34730
fixes #34727
Better and cleaner commit than last time, I hope. Should be less confusing for users.

Allows to use a theme and change text color for CheckButton and Checkbox, in the hover_pressed state.
Before, you had to add a custom stylebox to each CheckButton or CheckBox node, for the hover_pressed state. If not, the node would not use the hover_pressed stylebox from the theme, nor font_color_hover_pressed from the theme or node properties.

However, now you need to address the hover_pressed state for checkbox and checkbutton. It will not fall through to pressed state like before. 

