### PR TITLE
GDScript: Check script path/name when evaluating compatibility

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -858,6 +858,15 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 							valid = true;
 							break;
 						}
+						GDScript *src_gdscript = Object::cast_to<GDScript>(src_type);
+						GDScript *base_gdscript = Object::cast_to<GDScript>(base_type);
+						if (src_gdscript != NULL && base_gdscript != NULL) {
+							if (src_gdscript->path == base_gdscript->path && src_gdscript->name == base_gdscript->name) {
+								valid = true;
+								break;
+							}
+						}
+
 						src_type = src_type->get_base_script().ptr();
 					}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -6185,6 +6185,16 @@ bool GDScriptParser::_is_type_compatible(const DataType &p_container, const Data
 				if (expr_script == p_container.script_type) {
 					return true;
 				}
+				// Since pointers can change because loading and unloading cycles, also check path/name (for inner classes) too
+				Ref<GDScript> expr_gdscript = expr_script;
+				Ref<GDScript> container_gdscript = p_container.script_type;
+				if (expr_gdscript.is_valid() && container_gdscript.is_valid()) {
+					if (expr_gdscript->get_path() == container_gdscript->get_path() &&
+							expr_gdscript->get_script_class_name() == container_gdscript->get_script_class_name()) {
+						return true;
+					}
+				}
+
 				expr_script = expr_script->get_base_script();
 			}
 			return false;


### PR DESCRIPTION
Since scripts can be unloaded and reloaded during the process, pointer comparison is not always safe.

This might not be 100% safe, since it is technically possible to have multiple classes with the same name in the same file (by nesting inner classes). However I assume that this pattern isn't common so this fix should cover the vast majority of actual issues.

Maybe we can also forbid same name classes in a file, even in different scopes, to avoid any confusion.

Fix #34161