### PR TITLE
Sync pending VisualServer commands after ScriptServer finalization

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2169,6 +2169,9 @@ void Main::cleanup() {
 
 	ScriptServer::finish_languages();
 
+	// Sync pending commands that may have been queued from a different thread during ScriptServer finalization
+	VisualServer::get_singleton()->sync();
+
 #ifdef TOOLS_ENABLED
 	EditorNode::unregister_editor_types();
 #endif


### PR DESCRIPTION
This is needed as C# may free resources from the finalizer thread during
`CSharpLanguage::finish()`. Previously this would result in RIDs not being freed.

This fixes the Image leak mentioned in #34954.
