### PR TITLE
Updates min size on CenterContainer::set_use_top_left

### DIFF
--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -54,7 +54,13 @@ Size2 CenterContainer::get_minimum_size() const {
 
 void CenterContainer::set_use_top_left(bool p_enable) {
 
+	if (use_top_left == p_enable) {
+		return;
+	}
+
 	use_top_left = p_enable;
+
+	minimum_size_changed();
 	queue_sort();
 }
 


### PR DESCRIPTION
The `use_top_left` property affects CenterContainer's minimum size. When `true`, the minimum size is zero. When `false`, the minimum size is the largest min size of all children.

Before this fix, the minimum size is not updated after toggling,  I have to trigger it manually. (e.g. In the editor, switch to another scene and switch back, similar to #34979)

![demo](https://user-images.githubusercontent.com/372476/72304581-ebb47080-36ab-11ea-9afa-b95b1399be59.gif)

Putting `minimum_size_changed` before `queue_sort` is how it's used here:
https://github.com/godotengine/godot/blob/34ad33d9e0b211b2de5855373f8626af4fc0ce11/scene/gui/container.cpp#L59-L68