### PR TITLE
Makes adding port in Visual Script nodes deferred

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -575,7 +575,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					Button *btn = memnew(Button);
 					btn->set_text(TTR("Add Input Port"));
 					hbnc->add_child(btn);
-					btn->connect("pressed", this, "_add_input_port", varray(E->get()));
+					btn->connect("pressed", this, "_add_input_port", varray(E->get()), CONNECT_DEFERRED);
 				}
 				if (nd_list->is_output_port_editable()) {
 					if (nd_list->is_input_port_editable())
@@ -584,7 +584,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					Button *btn = memnew(Button);
 					btn->set_text(TTR("Add Output Port"));
 					hbnc->add_child(btn);
-					btn->connect("pressed", this, "_add_output_port", varray(E->get()));
+					btn->connect("pressed", this, "_add_output_port", varray(E->get()), CONNECT_DEFERRED);
 				}
 				gnode->add_child(hbnc);
 			} else if (Object::cast_to<VisualScriptExpression>(node.ptr())) {


### PR DESCRIPTION
This fixes #34458

Adding/removing a port will cause the graph to be updated, recreating all the nodes.

So before this fix, the add port button will be destroyed during the handling of its own action event. Although signal emission is safe from destroyed objects, the button's remaining action event handling code still needs to access the button itself, resulting in the crash.

The remove port button's signal was already connected with the `CONNECT_DEFERRED` flag, so clicking that won't crash.